### PR TITLE
Log server error and exit with non-zero status

### DIFF
--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -110,11 +110,14 @@ func (rt *Runtime) Start(params *Params) {
 }
 
 func (rt *Runtime) startServer(params *Params) {
-	glog.Warning("First line of log stream.")
+	glog.Infof("First line of log stream.")
 	glog.V(2).Infof("Server listening address: %v.", params.Addr)
 	persist := len(params.PolicyDir) > 0
 	server := NewServer(rt, params.Addr, persist)
-	server.Loop()
+	if err := server.Loop(); err != nil {
+		glog.Errorf("Server exiting: %v", err)
+		os.Exit(1)
+	}
 }
 
 func (rt *Runtime) startRepl(params *Params) {

--- a/runtime/server.go
+++ b/runtime/server.go
@@ -103,9 +103,9 @@ func NewServer(rt *Runtime, addr string, persist bool) *Server {
 }
 
 // Loop starts the server. This function does not return.
-func (s *Server) Loop() {
+func (s *Server) Loop() error {
 	wrapped := NewLoggingHandler(s.Router)
-	http.ListenAndServe(s.Addr, wrapped)
+	return http.ListenAndServe(s.Addr, wrapped)
 }
 
 func (s *Server) execQuery(qStr string) (resultSetV1, error) {


### PR DESCRIPTION
Previously there was no error message and the exit code was zero; this was
quite confusing.

/cc @timothyhinrichs 