### PR TITLE
Nested References

### DIFF
--- a/ast/parser_test.go
+++ b/ast/parser_test.go
@@ -72,12 +72,19 @@ func TestRefTerms(t *testing.T) {
 	assertParseOneTerm(t, "constants 2", "foo.bar[0].baz", RefTerm(VarTerm("foo"), StringTerm("bar"), NumberTerm(0), StringTerm("baz")))
 	assertParseOneTerm(t, "variables", "foo.bar[0].baz[i]", RefTerm(VarTerm("foo"), StringTerm("bar"), NumberTerm(0), StringTerm("baz"), VarTerm("i")))
 	assertParseOneTerm(t, "spaces", "foo[\"white space\"].bar", RefTerm(VarTerm("foo"), StringTerm("white space"), StringTerm("bar")))
+	assertParseOneTerm(t, "nested", "foo[baz[1][borge[i]]].bar", RefTerm(
+		VarTerm("foo"),
+		RefTerm(
+			VarTerm("baz"), NumberTerm(float64(1)), RefTerm(
+				VarTerm("borge"), VarTerm("i"),
+			),
+		),
+		StringTerm("bar"),
+	))
 	assertParseError(t, "missing component 1", "foo.")
 	assertParseError(t, "missing component 2", "foo[].bar")
 	assertParseError(t, "composite operand 1", "foo[[1,2,3]].bar")
 	assertParseError(t, "composite operand 2", "foo[{1: 2}].bar")
-	// TODO(tsandall): this may be allowed some day
-	assertParseError(t, "nested refs", "foo[baz.qux].bar")
 }
 
 func TestObjectWithScalars(t *testing.T) {

--- a/ast/rego.peg
+++ b/ast/rego.peg
@@ -252,7 +252,7 @@ RefDot <- "." val:Var {
     return str, nil
 }
 
-RefBracket <- "[" val:(Scalar / Var) "]" {
+RefBracket <- "[" val:(Ref / Scalar / Var) "]" {
     return val, nil
 }
 

--- a/ast/term_test.go
+++ b/ast/term_test.go
@@ -12,6 +12,38 @@ import (
 	"testing"
 )
 
+func TestInterfaceToValue(t *testing.T) {
+	input := `
+	{
+		"x": [
+			1,
+			true,
+			false,
+			null,
+			"hello",
+			["goodbye", 1],
+			{"y": 3.1}
+		]
+	}
+	`
+	var x interface{}
+	if err := json.Unmarshal([]byte(input), &x); err != nil {
+		panic(err)
+	}
+
+	expected := MustParseTerm(input).Value
+
+	v, err := InterfaceToValue(x)
+	if err != nil {
+		t.Errorf("Unexpected error converting interface{} to ast.Value: %v", err)
+		return
+	}
+
+	if !v.Equal(expected) {
+		t.Errorf("Expected ast.Value to equal:\n%v\nBut got:\n%v", expected, v)
+	}
+}
+
 func TestObjectSetOperations(t *testing.T) {
 
 	a := MustParseTerm(`{"a": "b", "c": "d"}`).Value.(Object)

--- a/docs/docs/examples/repl.md
+++ b/docs/docs/examples/repl.md
@@ -157,6 +157,39 @@ Steps
         | {"id":"s4","name":"dev","ports":["p1","p2"],"protocols":["http"]}             |
         +-------------------------------------------------------------------------------+
 
+    One powerful thing about Rego and the REPL is that you can run queries using the same syntax that you would use to lookup values.
+
+    For example if `i` has value 0 then `data.servers[i]` returns the first value in the `data.servers` array:
+
+        > i = 0
+        > data.servers[i]
+        {
+        "id": "s1",
+        "name": "app",
+        "ports": [
+            "p1",
+            "p2",
+            "p3"
+        ],
+        "protocols": [
+            "https",
+            "ssh"
+        ]
+        }
+
+    That same expression `data.servers[i]` when `i` has no value defines a query that returns all the values of `i` and `data.servers[i]`:
+
+        > unset i
+        > data.servers[i]
+        +---+-------------------------------------------------------------------------------+
+        | i |                                data.servers[i]                                |
+        +---+-------------------------------------------------------------------------------+
+        | 0 | {"id":"s1","name":"app","ports":["p1","p2","p3"],"protocols":["https","ssh"]} |
+        | 1 | {"id":"s2","name":"db","ports":["p3"],"protocols":["mysql"]}                  |
+        | 2 | {"id":"s3","name":"cache","ports":["p3"],"protocols":["memcache"]}            |
+        | 3 | {"id":"s4","name":"dev","ports":["p1","p2"],"protocols":["http"]}             |
+        +---+-------------------------------------------------------------------------------+
+
 1. The REPL also understands the [Import and Package](/docs/lang.html#modules) directives.
 
         > import data.servers


### PR DESCRIPTION
These changes add support for nested references. See the first commit message for details.

Essentially, instead of writing...

```
q = 1
p :- x = q, data.a[x] = ...
```

You can now just write...

```
q = 1
p :- data.a[q] = ...
```