### PR TITLE
Improve error messages

### DIFF
--- a/ast/compile.go
+++ b/ast/compile.go
@@ -393,22 +393,14 @@ func (c *Compiler) setGlobals() {
 					globals[i.Alias] = p
 				case Var:
 					globals[i.Alias] = p
-				default:
-					c.err("unexpected %T: %v", p, i)
 				}
 			} else {
 				switch p := i.Path.Value.(type) {
 				case Ref:
-					switch v := p[len(p)-1].Value.(type) {
-					case String:
-						globals[Var(v)] = p
-					default:
-						c.err("unexpected %T: %v", v, i)
-					}
+					v := p[len(p)-1].Value.(String)
+					globals[Var(v)] = p
 				case Var:
 					globals[p] = p
-				default:
-					c.err("unexpected %T: %v", i.Path, i.Path)
 				}
 			}
 		}

--- a/ast/compile.go
+++ b/ast/compile.go
@@ -105,6 +105,7 @@ func NewCompiler() *Compiler {
 		stage{c.setModuleTree, "setModuleTree"},
 		stage{c.checkSafetyHead, "checkSafetyHead"},
 		stage{c.checkSafetyBody, "checkSafetyBody"},
+		stage{c.checkBuiltinArgs, "checkBuiltinArgs"},
 		stage{c.resolveAllRefs, "resolveAllRefs"},
 		stage{c.setRuleGraph, "setRuleGraph"},
 		stage{c.checkRecursion, "checkRecursion"},
@@ -160,6 +161,26 @@ func (c *Compiler) FlattenErrors() string {
 	return fmt.Sprintf("%d errors occurred:\n%s", len(c.Errors), strings.Join(b, "\n"))
 }
 
+// checkBuiltinArgs ensures that all built-ins are called with the correct number
+// of arguments.
+//
+// TODO(tsandall): in the future this should be replaced with schema checking.
+func (c *Compiler) checkBuiltinArgs() {
+	for _, m := range c.Modules {
+		for _, r := range m.Rules {
+			for _, expr := range r.Body {
+				if ts, ok := expr.Terms.([]*Term); ok {
+					if bi, ok := BuiltinMap[ts[0].Value.(Var)]; ok {
+						if bi.NumArgs != len(ts[1:]) {
+							c.err(expr.Location.Errorf("%v: wrong number of arguments (expression %s must specify %d arguments to built-in function %v)", r.Name, expr.Location.Text, bi.NumArgs, ts[0]))
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
 // checkRecursion ensures that there are no recursive rule definitions, i.e., there are
 // no cycles in the RuleGraph.
 func (c *Compiler) checkRecursion() {
@@ -173,7 +194,7 @@ func (c *Compiler) checkRecursion() {
 			for _, x := range p {
 				n = append(n, string(x.(*Rule).Name))
 			}
-			c.err("recursion found in %v: %v", r.Name, strings.Join(n, ", "))
+			c.err(r.Location.Errorf("%v: recursive reference: %v (recursion is not allowed)", r.Name, strings.Join(n, " -> ")))
 		}
 	}
 }
@@ -190,7 +211,9 @@ func (c *Compiler) checkSafetyBody() {
 		for _, r := range m.Rules {
 			reordered, unsafe := reorderBodyForSafety(globals, r.Body)
 			if len(unsafe) != 0 {
-				c.err("unsafe variables in %v: %v", r.Name, unsafe.Vars())
+				for v := range unsafe.Vars() {
+					c.err(r.Location.Errorf("%v: %v is unsafe (variable %v must appear in the output position of at least one non-negated expression)", r.Name, v, v))
+				}
 			} else {
 				r.Body = reordered
 			}
@@ -203,19 +226,15 @@ func (c *Compiler) checkSafetyBody() {
 func (c *Compiler) checkSafetyHead() {
 	for _, m := range c.Modules {
 		for _, r := range m.Rules {
-			headVars := r.HeadVars()
-			bodyVars := r.Body.Vars(true)
-			for headVar := range headVars {
-				if _, ok := bodyVars[headVar]; !ok {
-					c.err("unsafe variable from head of %v: %v", r.Name, headVar)
-				}
+			unsafe := r.HeadVars().Diff(r.Body.Vars(true))
+			for v := range unsafe {
+				c.err(r.Location.Errorf("%v: %v is unsafe (variable %v must appear in at least one expression within the body of %v)", r.Name, v, v, r.Name))
 			}
 		}
 	}
 }
 
-func (c *Compiler) err(f string, a ...interface{}) {
-	err := fmt.Errorf(f, a...)
+func (c *Compiler) err(err error) {
 	c.Errors = append(c.Errors, err)
 }
 

--- a/ast/compile_test.go
+++ b/ast/compile_test.go
@@ -75,10 +75,7 @@ func TestCompilerEmpty(t *testing.T) {
 
 func TestCompilerExample(t *testing.T) {
 	c := NewCompiler()
-	m, err := ParseModule(testModule)
-	if err != nil {
-		panic(err)
-	}
+	m := MustParseModule(testModule)
 	c.Compile(map[string]*Module{"testMod": m})
 	assertNotFailed(t, c)
 }

--- a/ast/parser_ext.go
+++ b/ast/parser_ext.go
@@ -227,7 +227,8 @@ func parseModule(stmts []interface{}) (*Module, error) {
 
 	_package, ok := stmts[0].(*Package)
 	if !ok {
-		return nil, fmt.Errorf("first statement must be package")
+		loc := stmts[0].(Statement).Loc()
+		return nil, loc.Errorf("expected package directive (%s must come after package directive)", stmts[0])
 	}
 
 	mod := &Module{
@@ -243,7 +244,7 @@ func parseModule(stmts []interface{}) (*Module, error) {
 		case Body:
 			rule := ParseConstantRule(stmt)
 			if rule == nil {
-				return nil, fmt.Errorf("body must be contained inside rule: %v", stmt)
+				return nil, stmt[0].Location.Errorf("expected rule (%s must be declared inside a rule)", stmt[0].Location.Text)
 			}
 			mod.Rules = append(mod.Rules, rule)
 		}

--- a/ast/parser_test.go
+++ b/ast/parser_test.go
@@ -256,6 +256,7 @@ func TestImport(t *testing.T) {
 	ref2 := RefTerm(VarTerm("foo"), StringTerm("bar"), StringTerm("white space"))
 	assertParseImport(t, "white space", "import foo.bar[\"white space\"]", &Import{Path: ref2})
 	assertParseError(t, "non-ground ref", "import foo[x]")
+	assertParseError(t, "non-string", "import foo[0]")
 }
 
 func TestRule(t *testing.T) {

--- a/ast/parser_test.go
+++ b/ast/parser_test.go
@@ -386,6 +386,24 @@ func TestExample(t *testing.T) {
 	})
 }
 
+func TestLocation(t *testing.T) {
+	mod, err := ParseModule("test", testModule)
+	if err != nil {
+		t.Errorf("Unexpected error while parsing test module: %v", err)
+		return
+	}
+	expr := mod.Rules[0].Body[0]
+	if expr.Location.Col != 5 {
+		t.Errorf("Expected column of %v to be 5 but got: %v", expr, expr.Location.Col)
+	}
+	if expr.Location.Row != 9 {
+		t.Errorf("Expected row of %v to be 9 but got: %v", expr, expr.Location.Row)
+	}
+	if expr.Location.File != "test" {
+		t.Errorf("Expected file of %v to be test but got: %v", expr, expr.Location.File)
+	}
+}
+
 func TestConstantRules(t *testing.T) {
 	testModule := `
     package a.b.c

--- a/ast/parser_test.go
+++ b/ast/parser_test.go
@@ -310,7 +310,7 @@ func TestRule(t *testing.T) {
 }
 
 func TestEmptyModule(t *testing.T) {
-	r, err := ParseModule("    ")
+	r, err := ParseModule("", "    ")
 	if err != nil {
 		t.Errorf("Expected nil for empty module: %s", err)
 		return
@@ -491,7 +491,7 @@ func TestWildcards(t *testing.T) {
 }
 
 func assertParse(t *testing.T, msg string, input string, correct func([]interface{})) {
-	p, err := ParseStatements(input)
+	p, err := ParseStatements("", input)
 	if err != nil {
 		t.Errorf("Error on test %s: parse error on %s: %s", msg, input, err)
 		return
@@ -519,7 +519,7 @@ func assertParseImport(t *testing.T, msg string, input string, correct *Import) 
 
 func assertParseModule(t *testing.T, msg string, input string, correct *Module) {
 
-	m, err := ParseModule(input)
+	m, err := ParseModule("", input)
 	if err != nil {
 		t.Errorf("Error on test %s: parse error on %s: %s", msg, input, err)
 		return

--- a/ast/policy.go
+++ b/ast/policy.go
@@ -32,6 +32,7 @@ var Wildcard = &Term{Value: Var("_")}
 var WildcardPrefix = "$"
 
 type (
+
 	// Module represents a collection of policies (defined by rules)
 	// within a namespace (defined by the package) and optional
 	// dependencies on external documents (defined by imports).
@@ -39,6 +40,11 @@ type (
 		Package *Package
 		Imports []*Import
 		Rules   []*Rule
+	}
+
+	// Statement represents a single statement within a module.
+	Statement interface {
+		Loc() *Location
 	}
 
 	// Package represents the namespace of the documents produced
@@ -108,6 +114,11 @@ func (pkg *Package) Equal(other *Package) bool {
 	return pkg.Path.Equal(other.Path)
 }
 
+// Loc returns the location of the Package in the definition.
+func (pkg *Package) Loc() *Location {
+	return pkg.Location
+}
+
 func (pkg *Package) String() string {
 	return fmt.Sprintf("package %v", pkg.Path)
 }
@@ -115,6 +126,11 @@ func (pkg *Package) String() string {
 // Equal returns true if this Import has the same path and alias as the other Import.
 func (imp *Import) Equal(other *Import) bool {
 	return imp.Alias.Equal(other.Alias) && imp.Path.Equal(other.Path)
+}
+
+// Loc returns the location of the Import in the definition.
+func (imp *Import) Loc() *Location {
+	return imp.Location
 }
 
 func (imp *Import) String() string {
@@ -177,6 +193,11 @@ func (rule *Rule) HeadVars() VarSet {
 	return vis.vars
 }
 
+// Loc returns the location of the Rule in the definition.
+func (rule *Rule) Loc() *Location {
+	return rule.Location
+}
+
 func (rule *Rule) String() string {
 	var buf []string
 	if rule.Key != nil {
@@ -236,6 +257,11 @@ func (body Body) IsGround() bool {
 		}
 	}
 	return true
+}
+
+// Loc returns the location of the Body in the definition.
+func (body Body) Loc() *Location {
+	return body[0].Location
 }
 
 // OutputVars returns a VarSet containing the variables that would be bound by evaluating

--- a/ast/rego.peg
+++ b/ast/rego.peg
@@ -77,8 +77,10 @@ Import <- "import" ws path:(Ref / Var) alias:(ws "as" ws Var)? {
     imp.Path = path.(*Term)
     switch p := imp.Path.Value.(type) {
     case Ref:
-        if !p.IsGround() {
-            return nil, fmt.Errorf("import cannot contain variables in tail: %v", p)
+        for _, x := range p[1:] {
+            if _, ok := x.Value.(String); !ok {
+                return nil, fmt.Errorf("import path cannot contain non-string values: %v", x)
+            }
         }
     }
     if alias == nil {

--- a/ast/term.go
+++ b/ast/term.go
@@ -11,6 +11,8 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/pkg/errors"
 )
 
 // Location records a position in source code
@@ -24,6 +26,27 @@ type Location struct {
 // NewLocation returns a new Location object.
 func NewLocation(text []byte, file string, row int, col int) *Location {
 	return &Location{Text: text, File: file, Row: row, Col: col}
+}
+
+// Errorf returns a new error value with a message formatted to include the location
+// info (e.g., line, column, filename, etc.)
+func (loc *Location) Errorf(f string, a ...interface{}) error {
+	return fmt.Errorf(loc.format(f), a...)
+}
+
+// Wrapf returns a new error value that wraps an existing error with a message formatted
+// to include the location info (e.g., line, column, filename, etc.)
+func (loc *Location) Wrapf(err error, f string, a ...interface{}) error {
+	return errors.Wrapf(err, loc.format(f), a...)
+}
+
+func (loc *Location) format(f string) string {
+	if len(loc.File) > 0 {
+		f = fmt.Sprintf("%v:%v: %v", loc.File, loc.Row, f)
+	} else {
+		f = fmt.Sprintf("%v:%v: %v", loc.Row, loc.Col, f)
+	}
+	return f
 }
 
 // Value declares the common interface for all Term values. Every kind of Term value

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -281,7 +281,7 @@ func (r *REPL) evalBufferOne() bool {
 	// The user may enter lines with comments on the end or
 	// multiple lines with comments interspersed. In these cases
 	// the parser will return multiple statements.
-	stmts, err := ast.ParseStatements(line)
+	stmts, err := ast.ParseStatements("", line)
 
 	if err != nil {
 		return false
@@ -305,7 +305,7 @@ func (r *REPL) evalBufferMulti() bool {
 		return false
 	}
 
-	stmts, err := ast.ParseStatements(line)
+	stmts, err := ast.ParseStatements("", line)
 
 	if err != nil {
 		fmt.Fprintln(r.output, "error:", err)

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -235,8 +235,9 @@ func (r *REPL) compileBody(body ast.Body) (ast.Body, error) {
 	r.nextID++
 
 	rule := &ast.Rule{
-		Name: ast.Var(name),
-		Body: body,
+		Location: body[0].Location,
+		Name:     ast.Var(name),
+		Body:     body,
 	}
 
 	modules := r.policyStore.List()

--- a/repl/repl_test.go
+++ b/repl/repl_test.go
@@ -39,7 +39,7 @@ func TestUnset(t *testing.T) {
 	repl.OneShot("unset p")
 	repl.OneShot("p")
 	result := buffer.String()
-	if result != "error: 1 error occurred: unsafe variables in repl2: [p]\n" {
+	if result != "error: 1 error occurred: 1:1: repl2: p is unsafe (variable p must appear in the output position of at least one non-negated expression)\n" {
 		t.Errorf("Expected p to be unsafe but got: %v", result)
 		return
 	}
@@ -50,7 +50,7 @@ func TestUnset(t *testing.T) {
 	repl.OneShot("unset p")
 	repl.OneShot("p")
 	result = buffer.String()
-	if result != "error: 1 error occurred: unsafe variables in repl4: [p]\n" {
+	if result != "error: 1 error occurred: 1:1: repl4: p is unsafe (variable p must appear in the output position of at least one non-negated expression)\n" {
 		t.Errorf("Expected p to be unsafe but got: %v", result)
 		return
 	}
@@ -344,7 +344,7 @@ func TestEvalRuleCompileError(t *testing.T) {
 	repl := newRepl(store, &buffer)
 	repl.OneShot("p[x] :- true")
 	result := buffer.String()
-	expected := "error: 1 error occurred: unsafe variable from head of p: x\n"
+	expected := "error: 1 error occurred: 1:1: p: x is unsafe (variable x must appear in at least one expression within the body of p)\n"
 	if result != expected {
 		t.Errorf("Expected error message in output but got: %v", result)
 		return
@@ -354,7 +354,6 @@ func TestEvalRuleCompileError(t *testing.T) {
 	result = buffer.String()
 	if result != "" {
 		t.Errorf("Expected valid rule to compile (because state should have been rolled back) but got: %v", result)
-		return
 	}
 }
 
@@ -365,9 +364,9 @@ func TestEvalBodyCompileError(t *testing.T) {
 	repl.outputFormat = "json"
 	repl.OneShot("x = 1, y > x")
 	result1 := buffer.String()
-	expected1 := "error: 1 error occurred: unsafe variables in repl0: [y]\n"
+	expected1 := "error: 1 error occurred: 1:1: repl0: y is unsafe (variable y must appear in the output position of at least one non-negated expression)\n"
 	if result1 != expected1 {
-		t.Errorf("Expected error message in output but got : %v", result1)
+		t.Errorf("Expected error message in output but got`: %v", result1)
 		return
 	}
 	buffer.Reset()
@@ -441,7 +440,7 @@ func TestEvalPackage(t *testing.T) {
 	repl.OneShot("package baz.qux")
 	buffer.Reset()
 	repl.OneShot("p")
-	if buffer.String() != "error: 1 error occurred: unsafe variables in repl0: [p]\n" {
+	if buffer.String() != "error: 1 error occurred: 1:1: repl0: p is unsafe (variable p must appear in the output position of at least one non-negated expression)\n" {
 		t.Errorf("Expected unsafe variable error but got: %v", buffer.String())
 		return
 	}

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -181,7 +181,7 @@ func parseInputs(paths []string) (*parsedInput, error) {
 			return nil, err
 		}
 
-		m, astErr := ast.ParseModuleFile(file)
+		m, astErr := ast.ParseModule(file, string(bs))
 
 		if astErr == nil {
 			parsedModules[file] = &parsedModule{

--- a/runtime/server.go
+++ b/runtime/server.go
@@ -377,7 +377,7 @@ func (s *Server) v1PoliciesPut(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	mod, err := ast.ParseModule(string(buf))
+	mod, err := ast.ParseModule(id, string(buf))
 	if err != nil {
 		handleError(w, 400, err)
 		return

--- a/storage/policystore.go
+++ b/storage/policystore.go
@@ -31,7 +31,7 @@ func LoadPolicies(bufs map[string][]byte) (map[string]*ast.Module, error) {
 	parsed := map[string]*ast.Module{}
 
 	for id, bs := range bufs {
-		mod, err := ast.ParseModule(string(bs))
+		mod, err := ast.ParseModule(id, string(bs))
 		if err != nil {
 			return nil, err
 		}

--- a/topdown/arithmetic.go
+++ b/topdown/arithmetic.go
@@ -9,7 +9,6 @@ import (
 	"math"
 
 	"github.com/open-policy-agent/opa/ast"
-	"github.com/pkg/errors"
 )
 
 type arithArity1 func(a float64) (ast.Number, error)
@@ -48,7 +47,7 @@ func evalArithArity1(f arithArity1) BuiltinFunc {
 		ops := expr.Terms.([]*ast.Term)
 		a, err := ValueToFloat64(ops[1].Value, ctx)
 		if err != nil {
-			return errors.Wrapf(err, "arithmetic")
+			return expr.Location.Wrapf(err, "expected number (operand %s is not a number)", ops[0].Location.Text)
 		}
 
 		r, err := f(a)
@@ -77,12 +76,12 @@ func evalArithArity2(f arithArity2) BuiltinFunc {
 
 		a, err := ValueToFloat64(ops[1].Value, ctx)
 		if err != nil {
-			return errors.Wrapf(err, "arithemtic")
+			return expr.Location.Wrapf(err, "expected number (first operand %s is not a number)", ops[0].Location.Text)
 		}
 
 		b, err := ValueToFloat64(ops[2].Value, ctx)
 		if err != nil {
-			return errors.Wrapf(err, "arithemtic")
+			return expr.Location.Wrapf(err, "expected number (second operand %s is not a number)", ops[2].Location.Text)
 		}
 
 		c, err := f(a, b)


### PR DESCRIPTION
This is a small set of changes that improve the error messages mostly reported by the compiler. Specifically, the error messages now include the line/column/file location in the Rego file where the error was encountered.

There are more improvements to be made in the topdown package. I'll get to those in a future PR.