### PR TITLE
Add regex and string built-ins

### DIFF
--- a/ast/builtins.go
+++ b/ast/builtins.go
@@ -24,6 +24,7 @@ var DefaultBuiltins = [...]*Builtin{
 	Plus, Minus, Multiply, Divide, Round, Abs,
 	Count, Sum, Max,
 	ToNumber,
+	RegexMatch,
 }
 
 // BuiltinMap provides a convenient mapping of built-in names to
@@ -163,6 +164,17 @@ var ToNumber = &Builtin{
 	Name:      Var("to_number"),
 	NumArgs:   2,
 	TargetPos: []int{1},
+}
+
+/**
+ * Regular Expressions
+ */
+
+// RegexMatch takes two strings and evaluates to true if the string in the second
+// position matches the pattern in the first position.
+var RegexMatch = &Builtin{
+	Name:    Var("re_match"),
+	NumArgs: 2,
 }
 
 // Builtin represents a built-in function supported by OPA. Every

--- a/ast/builtins.go
+++ b/ast/builtins.go
@@ -25,6 +25,7 @@ var DefaultBuiltins = [...]*Builtin{
 	Count, Sum, Max,
 	ToNumber,
 	RegexMatch,
+	Concat, FormatInt,
 }
 
 // BuiltinMap provides a convenient mapping of built-in names to
@@ -175,6 +176,24 @@ var ToNumber = &Builtin{
 var RegexMatch = &Builtin{
 	Name:    Var("re_match"),
 	NumArgs: 2,
+}
+
+/**
+ * Strings
+ */
+
+// Concat joins an array of strings to with an input string.
+var Concat = &Builtin{
+	Name:      Var("concat"),
+	NumArgs:   3,
+	TargetPos: []int{2},
+}
+
+// FormatInt returns the string representation of the number in the given base after converting it to an integer value.
+var FormatInt = &Builtin{
+	Name:      Var("format_int"),
+	NumArgs:   3,
+	TargetPos: []int{2},
 }
 
 // Builtin represents a built-in function supported by OPA. Every

--- a/site/documentation/how-do-i-write-policies/index.md
+++ b/site/documentation/how-do-i-write-policies/index.md
@@ -874,7 +874,7 @@ Built-ins usually take one or more input values and produce at least one output 
 ```
 
 ```ruby
-# max(array, x)
+# max(array, output)
 #
 # Calculates the maximum value in an array.
 
@@ -889,7 +889,7 @@ Built-ins usually take one or more input values and produce at least one output 
 ### Casting
 
 ```ruby
-# to_number(scalar, ouput)
+# to_number(scalar, output)
 #
 # Converts a scalar value to a number.
 
@@ -899,6 +899,47 @@ Built-ins usually take one or more input values and produce at least one output 
 +------+
 | 3.14 |
 +------+
+```
+
+### Regular Expressions
+
+```ruby
+# re_match(pattern, value)
+#
+# Evaluates to true if value matches regular expression defined by pattern string.
+
+> pattern = "^us-west-1.*$"
+> re_match(pattern, "us-west-1.production")
+true
+> re_match(pattern, "us-east-2.dev")
+false
+```
+
+### Strings
+
+```ruby
+# format_int(number, base, output)
+#
+# Returns the string representation of the number in the given base after converting it to an integer value.
+
+> format_int(15.5, 16, x)
++-----+
+|  x  |
++-----+
+| "f" |
++-----+
+```
+
+```ruby
+# concat(join, array, output)
+#
+# Returns the string produced by concatenating the elements in array with the join string.
+> concat("/", ["", "foo", "bar", "baz"], x)
++----------------+
+|       x        |
++----------------+
+| "/foo/bar/baz" |
++----------------+
 ```
 
 ## <a name="examples"></a> Examples

--- a/topdown/builtins.go
+++ b/topdown/builtins.go
@@ -41,6 +41,7 @@ var defaultBuiltinFuncs = map[ast.Var]BuiltinFunc{
 	ast.Sum.Name:           evalReduce(reduceSum),
 	ast.Max.Name:           evalReduce(reduceMax),
 	ast.ToNumber.Name:      evalToNumber,
+	ast.RegexMatch.Name:    evalRegexMatch,
 }
 
 func init() {

--- a/topdown/builtins.go
+++ b/topdown/builtins.go
@@ -42,6 +42,8 @@ var defaultBuiltinFuncs = map[ast.Var]BuiltinFunc{
 	ast.Max.Name:           evalReduce(reduceMax),
 	ast.ToNumber.Name:      evalToNumber,
 	ast.RegexMatch.Name:    evalRegexMatch,
+	ast.FormatInt.Name:     evalFormatInt,
+	ast.Concat.Name:        evalConcat,
 }
 
 func init() {

--- a/topdown/regex.go
+++ b/topdown/regex.go
@@ -1,0 +1,55 @@
+// Copyright 2016 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package topdown
+
+import (
+	"regexp"
+	"sync"
+
+	"github.com/open-policy-agent/opa/ast"
+	"github.com/pkg/errors"
+)
+
+var regexpCacheLock = sync.Mutex{}
+var regexpCache map[string]*regexp.Regexp
+
+func evalRegexMatch(ctx *Context, expr *ast.Expr, iter Iterator) error {
+	ops := expr.Terms.([]*ast.Term)
+	pat, err := ValueToString(ops[1].Value, ctx)
+	if err != nil {
+		return errors.Wrapf(err, "re_match: pattern value must be a string")
+	}
+	input, err := ValueToString(ops[2].Value, ctx)
+	if err != nil {
+		return errors.Wrapf(err, "re_match: input value must be a string")
+	}
+	re, err := getRegexp(pat)
+	if err != nil {
+		return err
+	}
+	if re.Match([]byte(input)) {
+		return iter(ctx)
+	}
+	return nil
+}
+
+func getRegexp(pat string) (*regexp.Regexp, error) {
+	regexpCacheLock.Lock()
+	defer regexpCacheLock.Unlock()
+	re, ok := regexpCache[pat]
+	if !ok {
+		var err error
+		re, err = regexp.Compile(string(pat))
+		if err != nil {
+			return nil, errors.Wrapf(err, "re_match")
+		}
+		regexpCache[pat] = re
+	}
+	return re, nil
+}
+
+func init() {
+	regexpCache = map[string]*regexp.Regexp{}
+}

--- a/topdown/strings.go
+++ b/topdown/strings.go
@@ -1,0 +1,72 @@
+// Copyright 2016 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package topdown
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/open-policy-agent/opa/ast"
+	"github.com/pkg/errors"
+)
+
+func evalFormatInt(ctx *Context, expr *ast.Expr, iter Iterator) error {
+	ops := expr.Terms.([]*ast.Term)
+
+	input, err := ValueToFloat64(ops[1].Value, ctx)
+	if err != nil {
+		return errors.Wrapf(err, "%v: input must be a number", ast.FormatInt.Name)
+	}
+
+	i := int64(input)
+
+	base, err := ValueToFloat64(ops[2].Value, ctx)
+	if err != nil {
+		return errors.Wrapf(err, "%v: base must be a number", ast.FormatInt.Name)
+	}
+
+	b := int(base)
+	s := ast.String(strconv.FormatInt(i, b))
+
+	// TODO(tsandall): revisit handling of output arguments. If a reference is given in an output
+	// position, the built-in should evaluate the referenced value. Several of the built-ins call
+	// the ast.Equal function on the output argument (which is not correct for references.)
+	switch r := ops[3].Value.(type) {
+	case ast.Var:
+		return Continue(ctx, r, s, iter)
+	case ast.String:
+		if r.Equal(s) {
+			return iter(ctx)
+		}
+	}
+
+	return nil
+}
+
+func evalConcat(ctx *Context, expr *ast.Expr, iter Iterator) error {
+	ops := expr.Terms.([]*ast.Term)
+
+	join, err := ValueToString(ops[1].Value, ctx)
+	if err != nil {
+		return errors.Wrapf(err, "%v: join value must be a string", ast.Concat.Name)
+	}
+
+	sl, err := ValueToStrings(ops[2].Value, ctx)
+	if err != nil {
+		return errors.Wrapf(err, "%v: input value must be array of strings", ast.Concat.Name)
+	}
+
+	s := ast.String(strings.Join(sl, join))
+
+	switch r := ops[3].Value.(type) {
+	case ast.Var:
+		return Continue(ctx, r, s, iter)
+	case ast.String:
+		if r.Equal(s) {
+			return iter(ctx)
+		}
+	}
+	return nil
+}

--- a/topdown/topdown.go
+++ b/topdown/topdown.go
@@ -516,6 +516,23 @@ func ValueToString(v ast.Value, ctx *Context) (string, error) {
 	return s, nil
 }
 
+// ValueToStrings returns a slice of strings associated with an AST value.
+func ValueToStrings(v ast.Value, ctx *Context) ([]string, error) {
+	sl, err := ValueToSlice(v, ctx)
+	if err != nil {
+		return nil, err
+	}
+	r := make([]string, len(sl))
+	for i, x := range sl {
+		var ok bool
+		r[i], ok = x.(string)
+		if !ok {
+			return nil, fmt.Errorf("illegal argument: %v", x)
+		}
+	}
+	return r, nil
+}
+
 func evalContext(ctx *Context, iter Iterator) error {
 
 	if ctx.Index >= len(ctx.Query) {

--- a/topdown/topdown_test.go
+++ b/topdown/topdown_test.go
@@ -859,6 +859,27 @@ func TestTopDownRegex(t *testing.T) {
 	}
 }
 
+func TestTopDownStrings(t *testing.T) {
+	tests := []struct {
+		note     string
+		rules    []string
+		expected interface{}
+	}{
+		{"format_int", []string{"p = x :- format_int(15.5, 16, x)"}, `"f"`},
+		{"format_int: undefined", []string{`p :- format_int(15.5, 16, "10000")`}, ""},
+		{"format_int: err", []string{"p :- format_int(null, 16, x)"}, fmt.Errorf("format_int: input must be a number: illegal argument: null")},
+		{"concat", []string{`p = x :- concat("/", ["", "foo", "bar", "0", "baz"], x)`}, `"/foo/bar/0/baz"`},
+		{"concat: undefined", []string{`p :- concat("/", ["a", "b"], "deadbeef")`}, ""},
+		{"concat: non-string err", []string{`p = x :- concat("/", ["", "foo", "bar", 0, "baz"], x)`}, fmt.Errorf("concat: input value must be array of strings: illegal argument: 0")},
+	}
+
+	data := loadSmallTestData()
+
+	for i, tc := range tests {
+		runTopDownTestCase(t, data, i, tc.note, tc.rules, tc.expected)
+	}
+}
+
 func TestTopDownEmbeddedVirtualDoc(t *testing.T) {
 
 	mods := compileModules([]string{

--- a/topdown/topdown_test.go
+++ b/topdown/topdown_test.go
@@ -840,6 +840,25 @@ func TestTopDownCasts(t *testing.T) {
 	}
 }
 
+func TestTopDownRegex(t *testing.T) {
+	tests := []struct {
+		note     string
+		rules    []string
+		expected interface{}
+	}{
+		{"re_match", []string{`p :- re_match("^[a-z]+\\[[0-9]+\\]$", "foo[1]")`}, "true"},
+		{"re_match: undefined", []string{`p :- re_match("^[a-z]+\\[[0-9]+\\]$", "foo[\"bar\"]")`}, ""},
+		{"re_match: bad pattern err", []string{`p :- re_match("][", "foo[\"bar\"]")`}, fmt.Errorf("re_match: error parsing regexp: missing closing ]: `[`")},
+		{"re_match: ref", []string{`p[x] :- re_match("^b.*$", d.e[x])`}, "[0,1]"},
+	}
+
+	data := loadSmallTestData()
+
+	for i, tc := range tests {
+		runTopDownTestCase(t, data, i, tc.note, tc.rules, tc.expected)
+	}
+}
+
 func TestTopDownEmbeddedVirtualDoc(t *testing.T) {
 
 	mods := compileModules([]string{


### PR DESCRIPTION
A couple built-ins to perform basic regex and string manipulation. Encountered the need for these while working on an admission controller prototype in Kubernetes.