### PR TITLE
Fix panic in index.html error handling

### DIFF
--- a/ast/compile.go
+++ b/ast/compile.go
@@ -91,6 +91,42 @@ type stage struct {
 	name string
 }
 
+// CompileQuery is a helper function to compile a query represented as a string.
+func CompileQuery(q string) (Body, error) {
+
+	parsed, err := ParseBody(q)
+	if err != nil {
+		return nil, err
+	}
+
+	key := string(Wildcard.Value.(Var))
+
+	mod := &Module{
+		Package: &Package{
+			Path:     Ref{DefaultRootDocument},
+			Location: parsed.Loc(),
+		},
+		Rules: []*Rule{
+			&Rule{
+				Name:     Var(key),
+				Body:     parsed,
+				Location: parsed.Loc(),
+			},
+		},
+	}
+	mods := map[string]*Module{
+		key: mod,
+	}
+
+	c := NewCompiler()
+
+	if c.Compile(mods); c.Failed() {
+		return nil, c.Errors[0]
+	}
+
+	return c.Modules[key].Rules[0].Body, nil
+}
+
 // NewCompiler returns a new empty compiler.
 func NewCompiler() *Compiler {
 

--- a/runtime/server.go
+++ b/runtime/server.go
@@ -110,34 +110,12 @@ func (s *Server) Loop() error {
 
 func (s *Server) execQuery(qStr string) (resultSetV1, error) {
 
-	query, err := ast.ParseBody(qStr)
-
+	query, err := ast.CompileQuery(qStr)
 	if err != nil {
 		return nil, err
 	}
 
-	path := ast.Ref{ast.DefaultRootDocument}
-
-	rule := &ast.Rule{
-		Body: query,
-	}
-
-	mod := &ast.Module{
-		Package: &ast.Package{
-			Path: path,
-		},
-		Rules: []*ast.Rule{rule},
-	}
-
-	c := ast.NewCompiler()
-
-	if c.Compile(map[string]*ast.Module{"": mod}); c.Failed() {
-		return nil, c.Errors[0]
-	}
-
-	compiled := c.Modules[""].Rules[0].Body
-
-	ctx := topdown.NewContext(compiled, s.Runtime.DataStore)
+	ctx := topdown.NewContext(query, s.Runtime.DataStore)
 
 	results := resultSetV1{}
 

--- a/runtime/server_test.go
+++ b/runtime/server_test.go
@@ -148,6 +148,25 @@ func TestIndexGet(t *testing.T) {
 	}
 }
 
+func TestIndexGetCompileError(t *testing.T) {
+	f := newFixture(t)
+	// "foo" is not bound
+	get, err := http.NewRequest("GET", `/?q=foo`, strings.NewReader(""))
+	if err != nil {
+		panic(err)
+	}
+	f.server.Router.ServeHTTP(f.recorder, get)
+	if f.recorder.Code != 200 {
+		t.Errorf("Expected success but got: %v", f.recorder)
+		return
+	}
+	page := f.recorder.Body.String()
+	if !strings.Contains(page, "foo is unsafe") {
+		t.Errorf("Expected page to contain 'foo is unsafe' but got: %v", page)
+		return
+	}
+}
+
 func TestPoliciesPutV1(t *testing.T) {
 	f := newFixture(t)
 	req := newReqV1("PUT", "/policies/1", testMod)


### PR DESCRIPTION
If the query compile failed while rendering index.html, a panic would occur
because the dummy rule was not initialized with a location value.

Also, added a utility function to compile query strings. This may be useful in
other places.