### PR TITLE
Update OPA "policy enable" tag line

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # OPA: Open Policy Agent
 
-The Open Policy Agent (OPA) is an open source project that helps policy-enable your application.
-By integrating with OPA, your application's operators will be empowered to manage the size,
+The Open Policy Agent (OPA) is an open source project that helps policy-enable your service.
+By integrating with OPA, your service's operators will be empowered to manage the size,
 complexity, and scale of modern deployments.
 
 To learn more and get started, visit [openpolicyagent.org](http://www.openpolicyagent.org).
@@ -12,4 +12,4 @@ To learn more and get started, visit [openpolicyagent.org](http://www.openpolicy
 - Bugs: [Github Issues](https://github.com/open-policy-agent/opa/issues)
 - Features: [Github Issues](https://github.com/open-policy-agent/opa/issues)
 - Discussions: [Google Groups](https://groups.google.com/forum/?hl=en#!forum/open-policy-agent)
-- Continuous Integration: [![Build Status](https://travis-ci.org/open-policy-agent/opa.svg?branch=master)](https://travis-ci.org/open-policy-agent/opa) [![Go Report Card](https://goreportcard.com/badge/open-policy-agent/opa)](https://goreportcard.com/report/open-policy-agent/opa) 
+- Continuous Integration: [![Build Status](https://travis-ci.org/open-policy-agent/opa.svg?branch=master)](https://travis-ci.org/open-policy-agent/opa) [![Go Report Card](https://goreportcard.com/badge/open-policy-agent/opa)](https://goreportcard.com/report/open-policy-agent/opa)

--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -12,5 +12,5 @@ import "os"
 var RootCommand = &cobra.Command{
 	Use:   path.Base(os.Args[0]),
 	Short: "Open Policy Agent (OPA)",
-	Long:  "An open source project to policy enable any application.",
+	Long:  "An open source project to policy-enable your service.",
 }

--- a/runtime/server.go
+++ b/runtime/server.go
@@ -551,7 +551,7 @@ func renderBanner(w http.ResponseWriter) {
    \ \_______\   \ \__\      \ \__\ \__\
     \|_______|    \|__|       \|__|\|__|
 	</pre>`)
-	fmt.Fprintln(w, "Open Policy Agent - An open source project to policy enable any application.<br>")
+	fmt.Fprintln(w, "Open Policy Agent - An open source project to policy-enable your service.<br>")
 	fmt.Fprintln(w, "<br>")
 }
 

--- a/site/_config.yml
+++ b/site/_config.yml
@@ -8,7 +8,7 @@
 # Site settings
 title: Open Policy Agent
 email:
-description: "OPA: An open source project to policy enable any application."
+description: "OPA: An open source project to policy-enable your service."
 baseurl: "" # the subpath of your site, e.g. /blog
 url: "http://openpolicyagent.org" # the base hostname & protocol for your site
 github_username:  open-policy-agent


### PR DESCRIPTION
With the site refresh, we have begun referring to services being policy
enabled instead of applications. These changes just update a few spots that
were not touched in the refresh.