### PR TITLE
Add expand/collapse to code blocks.

### DIFF
--- a/site/_assets/js/collapse.js
+++ b/site/_assets/js/collapse.js
@@ -1,0 +1,45 @@
+opa = typeof opa === 'undefined' ? {} : opa;
+
+opa.collapse = (function () {
+  'use strict';
+
+  var classNames =
+    OPA_COLLAPSE_CONFIG.baseClassName + ' ' +
+    OPA_COLLAPSE_CONFIG.collapsedClassName;
+  var collapsedClassName = OPA_COLLAPSE_CONFIG.collapsedClassName;
+  var elements = opa.dom.getElementsByClassName(OPA_COLLAPSE_CONFIG.classNames);
+  var ignoreClassName = OPA_COLLAPSE_CONFIG.ignoreClassName;
+
+  function makeToggleCollapseHandler(element) {
+    return function (event) {
+      if (event.type === 'click' || event.keyCode === /* enter */ 13) {
+        if (opa.dom.hasClassName(element, collapsedClassName)) {
+          opa.dom.removeClassName(element, collapsedClassName);
+        } else {
+          opa.dom.addClassName(element, collapsedClassName);
+        }
+      }
+    };
+  }
+
+  for (var i = elements.length; i--;) {
+    var element = elements[i]
+    var ignore =
+      opa.dom.hasClassName(element, ignoreClassName) ||
+      opa.dom.hasClassName(element.parentNode, ignoreClassName) ||
+      element.offsetHeight <= OPA_COLLAPSE_CONFIG.maxHeight;
+
+    if (ignore) {
+      continue;
+    }
+
+    var target = document.createElement('a');
+    target.setAttribute('tabindex', '0');
+    target.className = OPA_COLLAPSE_CONFIG.targetClassName;
+
+    element.appendChild(target);
+
+    opa.dom.addClassName(element, classNames);
+    opa.dom.on(target, 'click keydown', makeToggleCollapseHandler(element));
+  }
+}());

--- a/site/_assets/js/dom.js
+++ b/site/_assets/js/dom.js
@@ -1,0 +1,119 @@
+opa = typeof opa === 'undefined' ? {} : opa;
+
+opa.dom = (function () {
+  'use strict';
+
+  var addEventListener = 'addEventListener';
+  var eventTypePrefix = '';
+
+  if (!document.addEventListener) {
+    var addEventListener = 'attachEvent';
+    var eventTypePrefix = 'on';
+  }
+
+  /**
+   * Retrieves a collection of DOM elements from the descendents of `element`
+   * that include all `classNames`.
+   *
+   * @param {string} classNames - A space-separated list of class names.
+   * @param {Element=} [element=document] - The parent element whose
+   *     descendents will be inspected for matching class names.
+   *
+   * @return {Array<Element>} A list of descendents of `element` that include
+   *     all `classNames`.
+   */
+  function getElementsByClassName(classNames, element) {
+    var elements = (element || document).getElementsByTagName('*');
+    var output = [];
+
+    for (var i = elements.length; i--;) {
+      if (hasClassName(elements[i], classNames)) {
+        output.push(elements[i]);
+      }
+    }
+
+    return output;
+  }
+
+  /**
+   * Adds all `classNames` to `element`.
+   *
+   * @param {Element} element - The DOM element to modify.
+   * @param {string} classNames - A space-separated list of class names.
+   */
+  function addClassName(element, classNames) {
+    element.className += (element.className ? ' ' : '') + classNames;
+  }
+
+  /**
+   * Removes all `classNames` from `element`.
+   *
+   * @param {Element} element - The DOM element to modify.
+   * @param {string} classNames - A space-separated list of class names.
+   */
+  function removeClassName(element, classNames) {
+    var inputClassNames = classNames.split(/\s/);
+    var elementClassNames = element.className.split(/\s/);
+
+    for (var i = inputClassNames.length; i--;) {
+      for (var j = elementClassNames.length; j--;) {
+        if (inputClassNames[i] === elementClassNames[j]) {
+          elementClassNames.splice(j, 1);
+          break;
+        }
+      }
+    }
+
+    element.className = elementClassNames.join(' ');
+  }
+
+  /**
+   * Determines if `element` includes all `classNames`.
+   *
+   * @param {Element} element - The DOM element to examine.
+   * @param {string} classNames - A space-separated list of class names.
+   *
+   * @return {boolean} `true` if `element` includes all `classNames`.
+   */
+  function hasClassName(element, classNames) {
+    var count = 0;
+    var inputClassNames = classNames.split(/\s/);
+    var elementClassNames = element.className.split(/\s/);
+
+    for (var i = inputClassNames.length; i--;) {
+      for (var j = elementClassNames.length; j--;) {
+        if (inputClassNames[i] === elementClassNames[j]) {
+          count++;
+          break;
+        }
+      }
+    }
+
+    return count === inputClassNames.length;
+  }
+
+  /**
+   * Registers `callback` for events of `type` on `target`.
+   *
+   * @param {EventTarget|Array<EventTarget>} target - The object or that should
+   *     respond to events.
+   * @param {string} type - The event type (for example, 'click') to listen for.
+   * @param {function(Event)} callback - The function to call when an event of
+   *     the specified type occurs.
+   */
+  function on(target, type, callback) {
+    var types = type.split(/\s/);
+
+    for (var i = types.length; i--;) {
+      target[addEventListener](eventTypePrefix + types[i], callback);
+    }
+  }
+
+  return {
+    addClassName: addClassName,
+    getElementsByClassName: getElementsByClassName,
+    hasClassName: hasClassName,
+    on: on,
+    removeClassName: removeClassName
+  };
+}());

--- a/site/_assets/stylesheets/style.scss
+++ b/site/_assets/stylesheets/style.scss
@@ -49,6 +49,7 @@ div.highlighter-rouge {
   margin: 24px auto;
   max-width: 720px;
   padding: 24px;
+  position: relative;
 
   & > .highlight {
     overflow-x: auto;
@@ -582,4 +583,65 @@ strong {
 
 .opa-keep-it-together {
   white-space: nowrap;
+}
+
+.opa-collapse {
+  height: auto;
+
+  & > .opa-collapse--target {
+    cursor: pointer;
+    font-size: 12px;
+    padding: 2px 8px;
+    position: absolute;
+    right: 0;
+    top: 0;
+
+    &:hover {
+      &:before {
+        color: rgba(0, 0, 0, 1.00);
+      }
+
+      &:after {
+        color: rgba(0, 0, 0, 0.87);
+      }
+    }
+
+    &:before {
+      color: rgba(0, 0, 0, 0.80);
+      content: "show less";
+    }
+
+    &:after {
+      color: rgba(0, 0, 0, 0.67);
+      content: "▲";
+      display: inline;
+      margin: 0 0 0 8px;
+    }
+  }
+
+  &--collapsed {
+    height: 320px;
+    overflow: auto;
+
+    &:after {
+      background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAAgCAYAAADT5RIaAAAABGdBTUEAALGPC/xhBQAAAGBJREFUGFc1irkNwzAQBHfHFLgE3H9VrMSpQsF3CiyH82jvfaj78+Y8E8a4AtcIF98ABJtJVS2Gj4ld+WGVg+yJ3cH2E+wO8mtidVArtBUkhe7/rFbw4xYyE0kTdS1k5wbQbSZ9Np8UEAAAAABJRU5ErkJggg==);
+      background-repeat: repeat-x;
+      bottom: 24px;
+      content: "";
+      height: 32px;
+      left: 0;
+      position: absolute;
+      right: 0;
+    };
+
+    & > .opa-collapse--target {
+      &:before {
+        content: "show more";
+      }
+
+      &:after {
+        content: "▼";
+      }
+    }
+  }
 }

--- a/site/_config.yml
+++ b/site/_config.yml
@@ -23,6 +23,7 @@ gems:
 assets:
   compress:
     css: true
+    js: true
   assets:
     - "*.png"
     - "*.svg"

--- a/site/_includes/footer.html
+++ b/site/_includes/footer.html
@@ -12,3 +12,17 @@
     © 2016 Open Policy Agent contributors. Licensed under the <a class="opa-footer--link" href="http://www.apache.org/licenses/LICENSE-2.0">Apache License, Version 2.0</a>. For information about contributing, see <a class="opa-footer--link" href="https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md">CONTRIBUTING.md</a>.
   </p>
 </footer>
+
+<script>
+  var OPA_COLLAPSE_CONFIG = {
+    classNames: 'highlight',
+    baseClassName: 'opa-collapse',
+    collapsedClassName: 'opa-collapse--collapsed',
+    ignoreClassName: 'opa-collapse--ignore',
+    maxHeight: 320,
+    targetClassName: 'opa-collapse--target'
+  };
+</script>
+
+{% js dom.js %}
+{% js collapse.js %}

--- a/site/documentation/how-do-i-write-policies/index.md
+++ b/site/documentation/how-do-i-write-policies/index.md
@@ -1058,6 +1058,7 @@ array          = "[" term { "," term } "]"
 object         = "{" object-item { "," object-item } "}"
 object-item    = ( scalar | ref | var ) ":" term
 ```
+{: .opa-collapse--ignore}
 
 The grammar defined above makes use of the following syntax. See [the Wikipedia page on EBNF](https://en.wikipedia.org/wiki/Extended_Backus–Naur_Form) for more details:
 
@@ -1074,5 +1075,6 @@ NULL   JSON null
 ALPHA  ASCII characters A-Z and a-z
 DIGIT  ASCII characters 0-9
 ```
+{: .opa-collapse--ignore}
 
 {% endcontentfor %}


### PR DESCRIPTION
This change adds JS and CSS, which automatically collapses all code
blocks on a page above a specified height (currently 320px). The user
can selectively expand code blocks. Collapsed code blocks scroll
internally and independently of the page.

The parameters (for example, the maximum height of a code block
before it will be collapsed) are configurable via the
`OPA_COLLAPSE_CONFIG` object.