### PR TITLE
Add REST API documentation

### DIFF
--- a/site/_assets/stylesheets/style.scss
+++ b/site/_assets/stylesheets/style.scss
@@ -78,6 +78,14 @@ h3 {
   margin: 20px 0 12px;
 }
 
+h4 {
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 16px;
+  line-height: 24px;
+  font-weight: bold;
+  margin: 10px 0 6px;
+}
+
 ol,
 ul {
   margin: 12px auto;
@@ -107,7 +115,7 @@ p {
 }
 
 strong {
-  font-style: bold;
+  font-weight: bold;
 }
 
 .opa-nav-main {

--- a/site/_includes/nav-documentation.html
+++ b/site/_includes/nav-documentation.html
@@ -10,6 +10,8 @@
       {% assign doc_work = page %}
     {% when 'HOW_DO_I_WRITE_POLICIES' %}
       {% assign doc_rego = page %}
+    {% when 'REST_API_VERSION_1' %}
+      {% assign doc_rest = page %}
   {% endcase %}
 {% endfor %}
 
@@ -23,6 +25,9 @@
     </li>
     <li class="opa-header--abstract--nav-item{% if page.doc_id == doc_rego.doc_id %}--selected{% endif %}">
       {% if page.doc_id != doc_rego.doc_id %}<a class="opa-header--abstract--nav-link" href="{{doc_rego.url}}">{{ doc_rego.title }}</a>{% else %}{{ doc_rego.title }}{% endif %}
+    </li>
+    <li class="opa-header--abstract--nav-item{% if page.doc_id == doc_rest.doc_id %}--selected{% endif %}">
+      {% if page.doc_id != doc_rest.doc_id %}<a class="opa-header--abstract--nav-link" href="{{doc_rest.url}}">{{ doc_rest.title }}</a>{% else %}{{ doc_rest.title }}{% endif %}
     </li>
   </ul>
 </nav>

--- a/site/documentation/references/rest/README.md
+++ b/site/documentation/references/rest/README.md
@@ -1,0 +1,1 @@
+The JSON and Rego files in this directory are used by gen-examples.sh to generate the example output for the REST API reference. The output of gen-examples.sh can be copied into the index.md file manually for now.

--- a/site/documentation/references/rest/example-patch.json
+++ b/site/documentation/references/rest/example-patch.json
@@ -1,0 +1,10 @@
+[
+    {"op": "add",
+     "path": "-",
+     "value": {
+         "id": "s5",
+         "name": "job",
+         "protocols": ["amqp"],
+         "ports": ["p3"]
+     }}
+]

--- a/site/documentation/references/rest/example.json
+++ b/site/documentation/references/rest/example.json
@@ -1,0 +1,18 @@
+{
+    "servers": [
+        {"id": "s1", "name": "app", "protocols": ["https", "ssh"], "ports": ["p1", "p2", "p3"]},
+        {"id": "s2", "name": "db", "protocols": ["mysql"], "ports": ["p3"]},
+        {"id": "s3", "name": "cache", "protocols": ["memcache", "http"], "ports": ["p3"]},
+        {"id": "s4", "name": "dev", "protocols": ["http"], "ports": ["p1", "p2"]}
+    ],
+    "networks": [
+        {"id": "n1", "public": false},
+        {"id": "n2", "public": false},
+        {"id": "n3", "public": true}
+    ],
+    "ports": [
+        {"id": "p1", "networks": ["n1"]},
+        {"id": "p2", "networks": ["n3"]},
+        {"id": "p3", "networks": ["n2"]}
+    ]
+}

--- a/site/documentation/references/rest/example1.rego
+++ b/site/documentation/references/rest/example1.rego
@@ -1,0 +1,11 @@
+package opa.examples
+
+import data.servers
+import data.networks
+import data.ports
+
+public_servers[server] :-
+	server = servers[_],
+	server.ports[_] = ports[k].id,
+	ports[k].networks[_] = networks[m].id,
+	networks[m].public = true

--- a/site/documentation/references/rest/example2.rego
+++ b/site/documentation/references/rest/example2.rego
@@ -1,0 +1,8 @@
+package opa.examples
+
+import data.servers
+
+violations[server] :-
+	server = servers[_],
+	server.protocols[_] = "http",
+	public_servers[server]

--- a/site/documentation/references/rest/example3.rego
+++ b/site/documentation/references/rest/example3.rego
@@ -1,0 +1,5 @@
+package opa.examples
+
+import example.flag
+
+allow_request :- flag = true

--- a/site/documentation/references/rest/gen-examples.sh
+++ b/site/documentation/references/rest/gen-examples.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+
+set -e
+
+BASE_URL='http://localhost:8181/v1'
+
+function main() {
+
+    trap 'kill $(jobs -p)' EXIT
+
+    # setup for examples below
+    start_opa
+    load_policies
+
+    # execute each of the examples from the reference
+    list_policies
+    get_a_policy
+    create_or_update_a_policy
+    delete_a_policy
+    get_a_document
+    patch_a_document
+    execute_a_query
+}
+
+function list_policies() {
+    echo "### List Policies"
+    echo ""
+    curl $BASE_URL/policies -s -v
+    echo ""
+}
+
+function get_a_policy() {
+    echo "### Get a Policy"
+    echo ""
+    curl $BASE_URL/policies/example1 -s -v
+    echo ""
+}
+
+function create_or_update_a_policy() {
+    echo "### Create or Update a Policy"
+    echo ""
+    curl $BASE_URL/policies/example1 -X PUT -s -v --data-binary @example1.rego
+    echo ""
+}
+
+function delete_a_policy() {
+    echo "### Delete a Policy"
+    echo ""
+    curl $BASE_URL/policies/example2 -X DELETE -s -v
+    echo ""
+
+    # Re-create the policy module so that remaining reference document sections can be generated.
+    curl $BASE_URL/policies/example2 -X PUT -s -v --data-binary @example2.rego >/dev/null 2>&1
+}
+
+function get_a_document() {
+    # Create policy module for this example.
+    curl $BASE_URL/policies/example3 -X PUT -s -v --data-binary @example3.rego >/dev/null 2>&1
+    echo ""
+
+    echo "### Get a Document"
+    echo ""
+    curl $BASE_URL/data/opa/examples/public_servers?pretty=true -s -v
+    echo ""
+    curl $BASE_URL/data/opa/examples/allow_request?pretty=true -s -v -G --data-urlencode 'global=example.flag:false'
+    echo ""
+
+    # Delete policy module created above.
+    curl $BASE_URL/policies/example3 -X DELETE -s >/dev/null 2>&1
+}
+
+function patch_a_document() {
+    echo "### Patch a Document"
+    echo ""
+    curl $BASE_URL/data/servers -X PATCH -s -v --data-binary @example-patch.json
+    echo ""
+}
+
+function execute_a_query() {
+    echo "### Execute a Query"
+    echo ""
+    curl $BASE_URL/query?pretty=true -s -v -G --data-urlencode 'q=data.servers[i].ports[_] = "p2", data.servers[i].name = name'
+    echo ""
+}
+
+function start_opa() {
+    opa run -s example.json &
+    while [ 1 ]; do
+        rc=0
+        curl $BASE_URL/policies -s >/dev/null 2>&1 || rc=$?
+        if [ $rc -eq 0 ]; then
+            break
+        else
+            sleep 0.1
+        fi
+    done
+}
+
+function load_policies() {
+
+    curl $BASE_URL/policies/example1 \
+        -X PUT \
+        --data-binary @example1.rego -s >/dev/null 2>&1
+
+    curl $BASE_URL/policies/example2 \
+        -X PUT \
+        --data-binary @example2.rego -s >/dev/null 2>&1
+}
+
+main

--- a/site/documentation/references/rest/index.md
+++ b/site/documentation/references/rest/index.md
@@ -1,0 +1,1230 @@
+---
+nav_id: MAIN_DOCUMENTATION
+doc_id: REST_API_VERSION_1
+layout: documentation
+
+title: REST API
+---
+
+{% contentfor header %}
+
+# REST API
+
+This document is the authoritative specification of the OPA REST API (v1). These APIs are the foundation for integrating with OPA using languages other than Go.
+
+{% endcontentfor %}
+
+{% contentfor body %}
+
+## Policy API
+
+The Policy API exposes CRUD endpoints for managing policy modules. Policy modules can be added, removed, or updated at any time.
+
+The identifiers given to policy modules are only used for management purposes. They are not used outside of the Policy API.
+
+### List Policies
+
+```
+GET /v1/policies
+```
+
+List policy modules.
+
+#### Example Request
+
+```http
+GET /v1/policies HTTP/1.1
+```
+
+#### Example Response
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+```
+
+```json
+[
+  {
+    "ID": "example2",
+    "Module": {
+      "Package": {
+        "Path": [
+          {
+            "Type": "var",
+            "Value": "data"
+          },
+          {
+            "Type": "string",
+            "Value": "opa"
+          },
+          {
+            "Type": "string",
+            "Value": "examples"
+          }
+        ]
+      },
+      "Imports": [
+        {
+          "Path": {
+            "Type": "ref",
+            "Value": [
+              {
+                "Type": "var",
+                "Value": "data"
+              },
+              {
+                "Type": "string",
+                "Value": "servers"
+              }
+            ]
+          }
+        }
+      ],
+      "Rules": [
+        {
+          "Name": "violations",
+          "Key": {
+            "Type": "var",
+            "Value": "server"
+          },
+          "Body": [
+            {
+              "Terms": [
+                {
+                  "Type": "var",
+                  "Value": "="
+                },
+                {
+                  "Type": "var",
+                  "Value": "server"
+                },
+                {
+                  "Type": "ref",
+                  "Value": [
+                    {
+                      "Type": "var",
+                      "Value": "data"
+                    },
+                    {
+                      "Type": "string",
+                      "Value": "servers"
+                    },
+                    {
+                      "Type": "var",
+                      "Value": "$0"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "Terms": [
+                {
+                  "Type": "var",
+                  "Value": "="
+                },
+                {
+                  "Type": "ref",
+                  "Value": [
+                    {
+                      "Type": "var",
+                      "Value": "server"
+                    },
+                    {
+                      "Type": "string",
+                      "Value": "protocols"
+                    },
+                    {
+                      "Type": "var",
+                      "Value": "$1"
+                    }
+                  ]
+                },
+                {
+                  "Type": "string",
+                  "Value": "http"
+                }
+              ]
+            },
+            {
+              "Terms": {
+                "Type": "ref",
+                "Value": [
+                  {
+                    "Type": "var",
+                    "Value": "data"
+                  },
+                  {
+                    "Type": "string",
+                    "Value": "opa"
+                  },
+                  {
+                    "Type": "string",
+                    "Value": "examples"
+                  },
+                  {
+                    "Type": "string",
+                    "Value": "public_servers"
+                  },
+                  {
+                    "Type": "var",
+                    "Value": "server"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "ID": "example1",
+    "Module": {
+      "Package": {
+        "Path": [
+          {
+            "Type": "var",
+            "Value": "data"
+          },
+          {
+            "Type": "string",
+            "Value": "opa"
+          },
+          {
+            "Type": "string",
+            "Value": "examples"
+          }
+        ]
+      },
+      "Imports": [
+        {
+          "Path": {
+            "Type": "ref",
+            "Value": [
+              {
+                "Type": "var",
+                "Value": "data"
+              },
+              {
+                "Type": "string",
+                "Value": "servers"
+              }
+            ]
+          }
+        },
+        {
+          "Path": {
+            "Type": "ref",
+            "Value": [
+              {
+                "Type": "var",
+                "Value": "data"
+              },
+              {
+                "Type": "string",
+                "Value": "networks"
+              }
+            ]
+          }
+        },
+        {
+          "Path": {
+            "Type": "ref",
+            "Value": [
+              {
+                "Type": "var",
+                "Value": "data"
+              },
+              {
+                "Type": "string",
+                "Value": "ports"
+              }
+            ]
+          }
+        }
+      ],
+      "Rules": [
+        {
+          "Name": "public_servers",
+          "Key": {
+            "Type": "var",
+            "Value": "server"
+          },
+          "Body": [
+            {
+              "Terms": [
+                {
+                  "Type": "var",
+                  "Value": "="
+                },
+                {
+                  "Type": "var",
+                  "Value": "server"
+                },
+                {
+                  "Type": "ref",
+                  "Value": [
+                    {
+                      "Type": "var",
+                      "Value": "data"
+                    },
+                    {
+                      "Type": "string",
+                      "Value": "servers"
+                    },
+                    {
+                      "Type": "var",
+                      "Value": "$0"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "Terms": [
+                {
+                  "Type": "var",
+                  "Value": "="
+                },
+                {
+                  "Type": "ref",
+                  "Value": [
+                    {
+                      "Type": "var",
+                      "Value": "server"
+                    },
+                    {
+                      "Type": "string",
+                      "Value": "ports"
+                    },
+                    {
+                      "Type": "var",
+                      "Value": "$1"
+                    }
+                  ]
+                },
+                {
+                  "Type": "ref",
+                  "Value": [
+                    {
+                      "Type": "var",
+                      "Value": "data"
+                    },
+                    {
+                      "Type": "string",
+                      "Value": "ports"
+                    },
+                    {
+                      "Type": "var",
+                      "Value": "k"
+                    },
+                    {
+                      "Type": "string",
+                      "Value": "id"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "Terms": [
+                {
+                  "Type": "var",
+                  "Value": "="
+                },
+                {
+                  "Type": "ref",
+                  "Value": [
+                    {
+                      "Type": "var",
+                      "Value": "data"
+                    },
+                    {
+                      "Type": "string",
+                      "Value": "ports"
+                    },
+                    {
+                      "Type": "var",
+                      "Value": "k"
+                    },
+                    {
+                      "Type": "string",
+                      "Value": "networks"
+                    },
+                    {
+                      "Type": "var",
+                      "Value": "$2"
+                    }
+                  ]
+                },
+                {
+                  "Type": "ref",
+                  "Value": [
+                    {
+                      "Type": "var",
+                      "Value": "data"
+                    },
+                    {
+                      "Type": "string",
+                      "Value": "networks"
+                    },
+                    {
+                      "Type": "var",
+                      "Value": "m"
+                    },
+                    {
+                      "Type": "string",
+                      "Value": "id"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "Terms": [
+                {
+                  "Type": "var",
+                  "Value": "="
+                },
+                {
+                  "Type": "ref",
+                  "Value": [
+                    {
+                      "Type": "var",
+                      "Value": "data"
+                    },
+                    {
+                      "Type": "string",
+                      "Value": "networks"
+                    },
+                    {
+                      "Type": "var",
+                      "Value": "m"
+                    },
+                    {
+                      "Type": "string",
+                      "Value": "public"
+                    }
+                  ]
+                },
+                {
+                  "Type": "boolean",
+                  "Value": true
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  }
+]
+```
+
+#### Status Codes
+
+- **200** - no error
+- **500** - server error
+
+### Get a Policy
+
+```
+GET /v1/policies/<id>
+```
+
+Get a policy module.
+
+#### Example Request
+
+```http
+GET /v1/policies/example1 HTTP/1.1
+```
+
+#### Example Response
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+```
+
+```json
+{
+  "ID": "example1",
+  "Module": {
+    "Package": {
+      "Path": [
+        {
+          "Type": "var",
+          "Value": "data"
+        },
+        {
+          "Type": "string",
+          "Value": "opa"
+        },
+        {
+          "Type": "string",
+          "Value": "examples"
+        }
+      ]
+    },
+    "Imports": [
+      {
+        "Path": {
+          "Type": "ref",
+          "Value": [
+            {
+              "Type": "var",
+              "Value": "data"
+            },
+            {
+              "Type": "string",
+              "Value": "servers"
+            }
+          ]
+        }
+      },
+      {
+        "Path": {
+          "Type": "ref",
+          "Value": [
+            {
+              "Type": "var",
+              "Value": "data"
+            },
+            {
+              "Type": "string",
+              "Value": "networks"
+            }
+          ]
+        }
+      },
+      {
+        "Path": {
+          "Type": "ref",
+          "Value": [
+            {
+              "Type": "var",
+              "Value": "data"
+            },
+            {
+              "Type": "string",
+              "Value": "ports"
+            }
+          ]
+        }
+      }
+    ],
+    "Rules": [
+      {
+        "Name": "public_servers",
+        "Key": {
+          "Type": "var",
+          "Value": "server"
+        },
+        "Body": [
+          {
+            "Terms": [
+              {
+                "Type": "var",
+                "Value": "="
+              },
+              {
+                "Type": "var",
+                "Value": "server"
+              },
+              {
+                "Type": "ref",
+                "Value": [
+                  {
+                    "Type": "var",
+                    "Value": "data"
+                  },
+                  {
+                    "Type": "string",
+                    "Value": "servers"
+                  },
+                  {
+                    "Type": "var",
+                    "Value": "$0"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "Terms": [
+              {
+                "Type": "var",
+                "Value": "="
+              },
+              {
+                "Type": "ref",
+                "Value": [
+                  {
+                    "Type": "var",
+                    "Value": "server"
+                  },
+                  {
+                    "Type": "string",
+                    "Value": "ports"
+                  },
+                  {
+                    "Type": "var",
+                    "Value": "$1"
+                  }
+                ]
+              },
+              {
+                "Type": "ref",
+                "Value": [
+                  {
+                    "Type": "var",
+                    "Value": "data"
+                  },
+                  {
+                    "Type": "string",
+                    "Value": "ports"
+                  },
+                  {
+                    "Type": "var",
+                    "Value": "k"
+                  },
+                  {
+                    "Type": "string",
+                    "Value": "id"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "Terms": [
+              {
+                "Type": "var",
+                "Value": "="
+              },
+              {
+                "Type": "ref",
+                "Value": [
+                  {
+                    "Type": "var",
+                    "Value": "data"
+                  },
+                  {
+                    "Type": "string",
+                    "Value": "ports"
+                  },
+                  {
+                    "Type": "var",
+                    "Value": "k"
+                  },
+                  {
+                    "Type": "string",
+                    "Value": "networks"
+                  },
+                  {
+                    "Type": "var",
+                    "Value": "$2"
+                  }
+                ]
+              },
+              {
+                "Type": "ref",
+                "Value": [
+                  {
+                    "Type": "var",
+                    "Value": "data"
+                  },
+                  {
+                    "Type": "string",
+                    "Value": "networks"
+                  },
+                  {
+                    "Type": "var",
+                    "Value": "m"
+                  },
+                  {
+                    "Type": "string",
+                    "Value": "id"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "Terms": [
+              {
+                "Type": "var",
+                "Value": "="
+              },
+              {
+                "Type": "ref",
+                "Value": [
+                  {
+                    "Type": "var",
+                    "Value": "data"
+                  },
+                  {
+                    "Type": "string",
+                    "Value": "networks"
+                  },
+                  {
+                    "Type": "var",
+                    "Value": "m"
+                  },
+                  {
+                    "Type": "string",
+                    "Value": "public"
+                  }
+                ]
+              },
+              {
+                "Type": "boolean",
+                "Value": true
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+#### Status Codes
+
+- **200** - no error
+- **404** - not found
+- **500** - server error
+
+### Create or Update a Policy
+
+```
+PUT /v1/policies/<id>
+Content-Type: text/plain
+```
+
+Create or update a policy module.
+
+If the policy module does not exist, it is created. If the policy module already exists, it is replaced.
+
+#### Example Request
+
+```http
+PUT /v1/policies/example1 HTTP/1.1
+Content-Type: text/plain
+```
+
+```ruby
+package opa.examples
+
+import data.servers
+import data.networks
+import data.ports
+
+public_servers[server] :-
+	server = servers[_],
+	server.ports[_] = ports[k].id,
+	ports[k].networks[_] = networks[m].id,
+	networks[m].public = true
+```
+
+#### Example Response
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+```
+
+```json
+{
+  "ID": "example1",
+  "Module": {
+    "Package": {
+      "Path": [
+        {
+          "Type": "var",
+          "Value": "data"
+        },
+        {
+          "Type": "string",
+          "Value": "opa"
+        },
+        {
+          "Type": "string",
+          "Value": "examples"
+        }
+      ]
+    },
+    "Imports": [
+      {
+        "Path": {
+          "Type": "ref",
+          "Value": [
+            {
+              "Type": "var",
+              "Value": "data"
+            },
+            {
+              "Type": "string",
+              "Value": "servers"
+            }
+          ]
+        }
+      },
+      {
+        "Path": {
+          "Type": "ref",
+          "Value": [
+            {
+              "Type": "var",
+              "Value": "data"
+            },
+            {
+              "Type": "string",
+              "Value": "networks"
+            }
+          ]
+        }
+      },
+      {
+        "Path": {
+          "Type": "ref",
+          "Value": [
+            {
+              "Type": "var",
+              "Value": "data"
+            },
+            {
+              "Type": "string",
+              "Value": "ports"
+            }
+          ]
+        }
+      }
+    ],
+    "Rules": [
+      {
+        "Name": "public_servers",
+        "Key": {
+          "Type": "var",
+          "Value": "server"
+        },
+        "Body": [
+          {
+            "Terms": [
+              {
+                "Type": "var",
+                "Value": "="
+              },
+              {
+                "Type": "var",
+                "Value": "server"
+              },
+              {
+                "Type": "ref",
+                "Value": [
+                  {
+                    "Type": "var",
+                    "Value": "data"
+                  },
+                  {
+                    "Type": "string",
+                    "Value": "servers"
+                  },
+                  {
+                    "Type": "var",
+                    "Value": "$0"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "Terms": [
+              {
+                "Type": "var",
+                "Value": "="
+              },
+              {
+                "Type": "ref",
+                "Value": [
+                  {
+                    "Type": "var",
+                    "Value": "server"
+                  },
+                  {
+                    "Type": "string",
+                    "Value": "ports"
+                  },
+                  {
+                    "Type": "var",
+                    "Value": "$1"
+                  }
+                ]
+              },
+              {
+                "Type": "ref",
+                "Value": [
+                  {
+                    "Type": "var",
+                    "Value": "data"
+                  },
+                  {
+                    "Type": "string",
+                    "Value": "ports"
+                  },
+                  {
+                    "Type": "var",
+                    "Value": "k"
+                  },
+                  {
+                    "Type": "string",
+                    "Value": "id"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "Terms": [
+              {
+                "Type": "var",
+                "Value": "="
+              },
+              {
+                "Type": "ref",
+                "Value": [
+                  {
+                    "Type": "var",
+                    "Value": "data"
+                  },
+                  {
+                    "Type": "string",
+                    "Value": "ports"
+                  },
+                  {
+                    "Type": "var",
+                    "Value": "k"
+                  },
+                  {
+                    "Type": "string",
+                    "Value": "networks"
+                  },
+                  {
+                    "Type": "var",
+                    "Value": "$2"
+                  }
+                ]
+              },
+              {
+                "Type": "ref",
+                "Value": [
+                  {
+                    "Type": "var",
+                    "Value": "data"
+                  },
+                  {
+                    "Type": "string",
+                    "Value": "networks"
+                  },
+                  {
+                    "Type": "var",
+                    "Value": "m"
+                  },
+                  {
+                    "Type": "string",
+                    "Value": "id"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "Terms": [
+              {
+                "Type": "var",
+                "Value": "="
+              },
+              {
+                "Type": "ref",
+                "Value": [
+                  {
+                    "Type": "var",
+                    "Value": "data"
+                  },
+                  {
+                    "Type": "string",
+                    "Value": "networks"
+                  },
+                  {
+                    "Type": "var",
+                    "Value": "m"
+                  },
+                  {
+                    "Type": "string",
+                    "Value": "public"
+                  }
+                ]
+              },
+              {
+                "Type": "boolean",
+                "Value": true
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+#### Status Codes
+
+- **200** - no error
+- **400** - bad request
+- **500** - server error
+
+Before accepting the request, the server will parse, compile, and install the policy module. If any of these operations fail, all changes will be rolled back and the server will return 400. The error message that accompanies the response should indicate why the request failed.
+
+### Delete a Policy
+
+```
+DELETE /v1/policies/<id>
+```
+
+Delete a policy module.
+
+#### Example Request
+
+```http
+DELETE /v1/policies/example2 HTTP/1.1
+```
+
+#### Example Response
+
+```http
+HTTP/1.1 204 No Content
+```
+
+#### Status Codes
+
+- **204** - no content
+- **400** - bad request
+- **404** - not found
+- **500** - server error
+
+If other policy modules in the same package depend on rules in the module to be deleted, the server will return 400.
+
+## Data API
+
+The Data API exposes endpoints for reading and writing documents in OPA. For an introduction to the different types of documents in OPA see [How Does OPA Work?](../../how-does-opa-work/).
+
+### Get a Document
+
+```
+GET /v1/data/{path:.+}
+```
+
+Get a document.
+
+The path separator is used to access an object value by key or an array element by index. If the path accesses an array, OPA attempts to treat the path element as an integer.
+
+#### Example Request
+
+```http
+GET /v1/data/opa/examples/public_servers HTTP/1.1
+```
+
+#### Example Response
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+```
+
+```json
+[
+  {
+    "id": "s1",
+    "name": "app",
+    "ports": [
+      "p1",
+      "p2",
+      "p3"
+    ],
+    "protocols": [
+      "https",
+      "ssh"
+    ]
+  },
+  {
+    "id": "s4",
+    "name": "dev",
+    "ports": [
+      "p1",
+      "p2"
+    ],
+    "protocols": [
+      "http"
+    ]
+  }
+]
+```
+
+#### Query Parameters
+
+- **global** - Provide an input document to the query. Format is `<path>:<value>` where `<path>` is the import path of the input document and `<value>` is the JSON serialized input document. The parameter may be specified multiple times but each instance should contain a unique `<path>`.
+- **pretty** - Return data with indented, human-readable formatting.
+
+#### Status Codes
+
+- **200** - no error
+- **404** - not found
+- **500** - server error
+
+The server returns 404 in two cases:
+
+1. The path refers to a non-existent document.
+2. The path refers to a Virtual Document that is undefined at the time of the query.
+
+In the second case, the response body will contain an object indicating the document is undefined.
+
+#### Example Module
+
+```ruby
+package opa.examples
+
+import example.flag
+
+allow_request :- flag = true
+```
+
+#### Example Request with Global Parameter
+
+```http
+GET /v1/data/opa/examples/allow_request?global=example.flag:false HTTP/1.1
+```
+
+#### Example Response for Undefined Virtual Document
+
+```http
+HTTP/1.1 404 Not Found
+Content-Type: application/json
+```
+
+```json
+{
+  "IsUndefined": true
+}
+```
+
+### Patch a Document
+
+```
+PATCH /v1/data/{path:.+}
+Content-Type: application/json-patch+json
+```
+
+Update a document.
+
+The path separator is used to access an object value by key or an array element by index. If the path accesses an array, OPA attempts to treat the path element as an integer.
+
+OPA accepts updates encoded as JSON Patch operations. The message body of the request should contain a JSON encoded array containing one or more JSON Patch operations. Each operation specifies the operation type, path, and an optional value. For more information on JSON Patch, see [RFC 6902](https://tools.ietf.org/html/rfc6902).
+
+#### Example Request
+
+```http
+PATCH /v1/data/servers HTTP/1.1
+Content-Type: application/json-patch+json
+```
+
+```json
+[
+    {"op": "add",
+     "path": "-",
+     "value": {
+         "id": "s5",
+         "name": "job",
+         "protocols": ["amqp"],
+         "ports": ["p3"]
+     }}
+]
+```
+
+#### Example Response
+
+```http
+HTTP/1.1 204 No Content
+```
+
+#### Status Codes
+
+- **200** - no content
+- **404** - not found
+- **500** - server error
+
+The effective path of the JSON Patch operation is obtained by joining the path portion of the URL with the path value from the operation(s) contained in the message body. In all cases, the parent of the effective path MUST refer to an existing document, otherwise the server returns 404. In the case of **remove** and **replace** operations, the effective path MUST refer to an existing document, otherwise the server returns 404.
+
+## Query API
+
+### Execute a Query
+
+```
+GET /v1/query
+```
+
+Execute an ad-hoc query and returns bindings for variables found in the query.
+
+#### Example Request
+
+```
+GET /v1/query?q=data.servers[i].ports[_] = "p2", data.servers[i].name = name HTTP/1.1
+```
+
+#### Example Response
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+```
+
+```json
+[
+  {
+    "i": 3,
+    "name": "dev"
+  },
+  {
+    "i": 0,
+    "name": "app"
+  }
+]
+```
+
+#### Query Parameters
+
+- **q** - The ad-hoc query to execute. OPA will parse, compile, and execute the query represented by the parameter value. The value MUST be URL encoded.
+- **pretty** - Return data with indented, human-readable formatting.
+
+#### Status Codes
+
+- **200** - no error
+- **400** - bad request
+- **500** - server error
+
+## Errors
+
+All of the API endpoints use standard HTTP error codes to indicate success or failure of an API call. If an API call fails, the response will contain a JSON encoded object that provides more detail:
+
+```
+{
+  "Code": 404,
+  "Message": "storage error (code: 1): module not found: test"
+}
+```
+
+{% endcontentfor %}


### PR DESCRIPTION
The REST API has been manually documented in
site/documentation/references/rest/index.md.

Each of the API endpoints is listed with:

- HTTP method and path
- Query parameters
- Response status codes
- Example request/response transactions

In the future, we could consider modelling the REST APIs using a framework
like Swagger, however, at this point in time, the existing Go-based solutions
either (1) require implementing the entire API inside of another framework
(e.g., go-restful) or (2) lack sufficient support for comment-based
annotations (e.g., go-swagger).

For now, given the relatively small size of the API, it should be OK to
manually update the docs as the API evolves.