### PR TITLE
Fix OPA home link alignment.

### DIFF
--- a/site/_assets/stylesheets/style.scss
+++ b/site/_assets/stylesheets/style.scss
@@ -132,6 +132,7 @@ strong {
     float: left;
     font-size: 16px;
     line-height: 24px;
+    margin: 0;
 
     &--selected {
       border-bottom: solid 2px #444;
@@ -139,6 +140,7 @@ strong {
       float: left;
       font-size: 16px;
       line-height: 24px;
+      margin: 0;
     }
   }
 


### PR DESCRIPTION
Changes to the generic `<ol>` and `<ul>` styling ended up pushing the “Open Policy Agent” link in the main navigation 60 pixels to the right. This change aligns it to the left edge of the rest of the content.