### PR TITLE
Fix server to exclude wildcard variable bindings

### DIFF
--- a/ast/term.go
+++ b/ast/term.go
@@ -347,28 +347,33 @@ func VarTerm(v string) *Term {
 
 // Equal returns true if the other Value is a Variable and has the same value
 // (name).
-func (variable Var) Equal(other Value) bool {
+func (v Var) Equal(other Value) bool {
 	switch other := other.(type) {
 	case Var:
-		return variable == other
+		return v == other
 	default:
 		return false
 	}
 }
 
 // Hash returns the hash code for the Value.
-func (variable Var) Hash() int {
-	h := siphash.Hash(hashSeed0, hashSeed1, *(*[]byte)(unsafe.Pointer(&variable)))
+func (v Var) Hash() int {
+	h := siphash.Hash(hashSeed0, hashSeed1, *(*[]byte)(unsafe.Pointer(&v)))
 	return int(h)
 }
 
 // IsGround always returns false.
-func (variable Var) IsGround() bool {
+func (v Var) IsGround() bool {
 	return false
 }
 
-func (variable Var) String() string {
-	return string(variable)
+// IsWildcard returns true if this is a wildcard variable.
+func (v Var) IsWildcard() bool {
+	return strings.HasPrefix(string(v), WildcardPrefix)
+}
+
+func (v Var) String() string {
+	return string(v)
 }
 
 // Ref represents a reference as defined by the language.

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -412,11 +412,11 @@ func (r *REPL) evalBody(body ast.Body) bool {
 		var err error
 		row := map[string]interface{}{}
 		ctx.Locals.Iter(func(k, v ast.Value) bool {
-			name, ok := k.(ast.Var)
+			kv, ok := k.(ast.Var)
 			if !ok {
 				return false
 			}
-			if strings.HasPrefix(string(name), ast.WildcardPrefix) {
+			if kv.IsWildcard() {
 				return false
 			}
 			r, e := topdown.ValueToInterface(v, ctx)
@@ -589,8 +589,7 @@ func (r *REPL) evalTermMultiValue(body ast.Body) bool {
 
 		ctx.Locals.Iter(func(k, v ast.Value) bool {
 			if k, ok := k.(ast.Var); ok {
-				name := string(k)
-				if strings.HasPrefix(name, ast.WildcardPrefix) {
+				if k.IsWildcard() {
 					return false
 				}
 				x, e := topdown.ValueToInterface(v, ctx)
@@ -598,8 +597,9 @@ func (r *REPL) evalTermMultiValue(body ast.Body) bool {
 					err = e
 					return true
 				}
-				result[name] = x
-				vars[name] = struct{}{}
+				s := string(k)
+				result[s] = x
+				vars[s] = struct{}{}
 			}
 			return false
 		})
@@ -818,8 +818,8 @@ func buildHeader(fields map[string]struct{}, term *ast.Term) {
 			buildHeader(fields, t)
 		}
 	case ast.Var:
-		s := string(v)
-		if !strings.HasPrefix(s, ast.WildcardPrefix) {
+		if !v.IsWildcard() {
+			s := string(v)
 			fields[s] = struct{}{}
 		}
 	case ast.Object:

--- a/runtime/server.go
+++ b/runtime/server.go
@@ -130,6 +130,9 @@ func (s *Server) execQuery(qStr string) (resultSetV1, error) {
 			if !ok {
 				return false
 			}
+			if kv.IsWildcard() {
+				return false
+			}
 			vv, e := topdown.ValueToInterface(v, ctx)
 			if err != nil {
 				err = e

--- a/runtime/server_test.go
+++ b/runtime/server_test.go
@@ -123,6 +123,10 @@ func TestDataV1(t *testing.T) {
 			tr{"PUT", "/policies/test", testMod, 200, ""},
 			tr{"GET", "/data/testmod/undef", "", 404, `{"IsUndefined": true}`},
 		}},
+		{"query wildcards omitted", []tr{
+			tr{"PATCH", "/data/x", `[{"op": "add", "path": "/", "value": [1,2,3,4]}]`, 204, ""},
+			tr{"GET", "/query?q=data.x[_]%20=%20x", "", 200, `[{"x": 1}, {"x": 2}, {"x": 3}, {"x": 4}]`},
+		}},
 	}
 
 	for i, tc := range tests {


### PR DESCRIPTION
Also, add helper function to check if a variable is a wildcard (instead of
relying on strings.HasPrefix everywhere).

Rename self reference on Var functions to "v" which is more idiomatic.