### PR TITLE
Fix expression evaluation for refs to base docs

### DIFF
--- a/topdown/topdown.go
+++ b/topdown/topdown.go
@@ -596,6 +596,13 @@ func evalExpr(ctx *Context, iter Iterator) error {
 		})
 	case *ast.Term:
 		v := tt.Value
+		if r, ok := v.(ast.Ref); ok {
+			var err error
+			v, err = lookupValue(ctx.DataStore, r)
+			if err != nil {
+				return err
+			}
+		}
 		if !v.Equal(ast.Boolean(false)) {
 			if v.IsGround() {
 				ctx.traceSuccess(expr)

--- a/topdown/topdown_test.go
+++ b/topdown/topdown_test.go
@@ -326,6 +326,7 @@ func TestTopDownEvalTermExpr(t *testing.T) {
 		{"object empty", `p :- {}`, "true"},
 		{"ref", "p :- a[i]", "true"},
 		{"ref undefined", "p :- data.deadbeef[i]", ""},
+		{"ref false", "p :- data.c[0].x[1]", ""},
 		{"array comprehension", "p :- [x | x = 1]", "true"},
 		{"array comprehension empty", "p :- [x | x = 1, x = 2]", "true"},
 		{"arbitrary position", "p :- a[i] = x, x, i", "true"},


### PR DESCRIPTION
If the expression consists of a single ref to a base doc, the ref must be
looked up before the "truth check" to determine if evaluation continues.

In 34b1c86 we modified the evaluation behaviour to continue as long as
the term is not Boolean(false). In doing so, we forgot to handle the case
where a reference refers to a "false" value in storage.

This is confusing in cases where you have some reference to a flag on an
object, e.g., "..., data.servers[i].interfaces[j].enabled, ...".

This problem does not arise with references to virtual docs because the
reference would be bound in the context.

With this change, the REPL had to be updated, otherwise we would not display
"false" values when evaluating a non-ground reference. E.g., given data = {"x":
[false,true]}, data.x[i] should print 0/false, 1/true (not just 1/true).