### PR TITLE
Fix built-in output handling for base doc refs

### DIFF
--- a/topdown/aggregates.go
+++ b/topdown/aggregates.go
@@ -38,15 +38,9 @@ func evalReduce(f reduceFunc) BuiltinFunc {
 			return err
 		}
 
-		switch dst := dst.(type) {
-		case ast.Var:
-			return Continue(ctx, dst, y, iter)
-		default:
-			if dst.Equal(y) {
-				return iter(ctx)
-			}
-			return nil
-		}
+		undo, err := evalEqUnify(ctx, y, dst, nil, iter)
+		ctx.Unbind(undo)
+		return err
 	}
 }
 

--- a/topdown/arithmetic.go
+++ b/topdown/arithmetic.go
@@ -57,15 +57,9 @@ func evalArithArity1(f arithArity1) BuiltinFunc {
 
 		b := ops[2].Value
 
-		switch b := b.(type) {
-		case ast.Var:
-			return Continue(ctx, b, r, iter)
-		default:
-			if b.Equal(r) {
-				return iter(ctx)
-			}
-			return nil
-		}
+		undo, err := evalEqUnify(ctx, r, b, nil, iter)
+		ctx.Unbind(undo)
+		return err
 	}
 }
 
@@ -90,14 +84,8 @@ func evalArithArity2(f arithArity2) BuiltinFunc {
 
 		cv := ops[3].Value
 
-		switch cv := cv.(type) {
-		case ast.Var:
-			return Continue(ctx, cv, c, iter)
-		default:
-			if cv.Equal(c) {
-				return iter(ctx)
-			}
-			return nil
-		}
+		undo, err := evalEqUnify(ctx, c, cv, nil, iter)
+		ctx.Unbind(undo)
+		return err
 	}
 }

--- a/topdown/casts.go
+++ b/topdown/casts.go
@@ -42,13 +42,7 @@ func evalToNumber(ctx *Context, expr *ast.Expr, iter Iterator) error {
 		return fmt.Errorf("to_number: source must be a string, boolean, or number: %T", a)
 	}
 
-	switch b := b.(type) {
-	case ast.Var:
-		return Continue(ctx, b, n, iter)
-	default:
-		if n.Equal(b) {
-			return iter(ctx)
-		}
-		return nil
-	}
+	undo, err := evalEqUnify(ctx, n, b, nil, iter)
+	ctx.Unbind(undo)
+	return err
 }

--- a/topdown/strings.go
+++ b/topdown/strings.go
@@ -30,19 +30,9 @@ func evalFormatInt(ctx *Context, expr *ast.Expr, iter Iterator) error {
 	b := int(base)
 	s := ast.String(strconv.FormatInt(i, b))
 
-	// TODO(tsandall): revisit handling of output arguments. If a reference is given in an output
-	// position, the built-in should evaluate the referenced value. Several of the built-ins call
-	// the ast.Equal function on the output argument (which is not correct for references.)
-	switch r := ops[3].Value.(type) {
-	case ast.Var:
-		return Continue(ctx, r, s, iter)
-	case ast.String:
-		if r.Equal(s) {
-			return iter(ctx)
-		}
-	}
-
-	return nil
+	undo, err := evalEqUnify(ctx, s, ops[3].Value, nil, iter)
+	ctx.Unbind(undo)
+	return err
 }
 
 func evalConcat(ctx *Context, expr *ast.Expr, iter Iterator) error {
@@ -60,13 +50,7 @@ func evalConcat(ctx *Context, expr *ast.Expr, iter Iterator) error {
 
 	s := ast.String(strings.Join(sl, join))
 
-	switch r := ops[3].Value.(type) {
-	case ast.Var:
-		return Continue(ctx, r, s, iter)
-	case ast.String:
-		if r.Equal(s) {
-			return iter(ctx)
-		}
-	}
-	return nil
+	undo, err := evalEqUnify(ctx, s, ops[3].Value, nil, iter)
+	ctx.Unbind(undo)
+	return err
 }


### PR DESCRIPTION
Previously, built-ins were not hanlding references in output positions
properly. Specifically, they were just calling Equals() on the term in the
output position against the built-in function result. The Equals() call would
return false and evaluation would stop.

Now, the built-ins just call the unify function which handles references
correctly and will also work in cases where a composite value (potentially
containing variables and/or references) is given in the output position.