### PR TITLE
Make REPL banner configurable

### DIFF
--- a/repl/example_test.go
+++ b/repl/example_test.go
@@ -25,7 +25,7 @@ func ExampleREPL_OneShot() {
 	var buf bytes.Buffer
 
 	// Create a new REPL.
-	repl := repl.New(ds, ps, "", &buf, "json")
+	repl := repl.New(ds, ps, "", &buf, "json", "")
 
 	// Define a rule inside the REPL.
 	repl.OneShot("p :- a = [1, 2, 3, 4], a[_] > 3")

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -19,7 +19,6 @@ import (
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/storage"
 	"github.com/open-policy-agent/opa/topdown"
-	"github.com/open-policy-agent/opa/version"
 
 	"github.com/peterh/liner"
 )
@@ -42,10 +41,11 @@ type REPL struct {
 	historyPath  string
 	initPrompt   string
 	bufferPrompt string
+	banner       string
 }
 
 // New returns a new instance of the REPL.
-func New(dataStore *storage.DataStore, policyStore *storage.PolicyStore, historyPath string, output io.Writer, outputFormat string) *REPL {
+func New(dataStore *storage.DataStore, policyStore *storage.PolicyStore, historyPath string, output io.Writer, outputFormat string, banner string) *REPL {
 	return &REPL{
 		output:          output,
 		outputFormat:    outputFormat,
@@ -56,6 +56,7 @@ func New(dataStore *storage.DataStore, policyStore *storage.PolicyStore, history
 		historyPath:     historyPath,
 		initPrompt:      "> ",
 		bufferPrompt:    "| ",
+		banner:          banner,
 	}
 }
 
@@ -69,10 +70,9 @@ func (r *REPL) Loop() {
 	line.SetMultiLineMode(true)
 	r.loadHistory(line)
 
-	fmt.Fprintf(r.output, "OPA %v (commit %v, built at %v)\n", version.Version, version.Vcs, version.Timestamp)
-	fmt.Fprintf(r.output, "\n")
-	fmt.Fprintf(r.output, "Run 'help' to see a list of commands.\n")
-	fmt.Fprintf(r.output, "\n")
+	if len(r.banner) > 0 {
+		fmt.Fprintln(r.output, r.banner)
+	}
 
 	for true {
 

--- a/repl/repl_test.go
+++ b/repl/repl_test.go
@@ -517,7 +517,7 @@ func expectOutput(t *testing.T, output string, expected string) {
 
 func newRepl(dataStore *storage.DataStore, buffer *bytes.Buffer) *REPL {
 	policyStore := storage.NewPolicyStore(dataStore, "")
-	repl := New(dataStore, policyStore, "", buffer, "")
+	repl := New(dataStore, policyStore, "", buffer, "", "")
 	return repl
 }
 

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -5,6 +5,7 @@
 package runtime
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -16,6 +17,7 @@ import (
 	"github.com/open-policy-agent/opa/repl"
 	"github.com/open-policy-agent/opa/server"
 	"github.com/open-policy-agent/opa/storage"
+	"github.com/open-policy-agent/opa/version"
 	"github.com/pkg/errors"
 )
 
@@ -127,8 +129,17 @@ func (rt *Runtime) startServer(params *Params) {
 }
 
 func (rt *Runtime) startRepl(params *Params) {
-	repl := repl.New(rt.DataStore, rt.PolicyStore, params.HistoryPath, os.Stdout, params.OutputFormat)
+	banner := rt.getBanner()
+	repl := repl.New(rt.DataStore, rt.PolicyStore, params.HistoryPath, os.Stdout, params.OutputFormat, banner)
 	repl.Loop()
+}
+
+func (rt *Runtime) getBanner() string {
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "OPA %v (commit %v, built at %v)\n", version.Version, version.Vcs, version.Timestamp)
+	fmt.Fprintf(&buf, "\n")
+	fmt.Fprintf(&buf, "Run 'help' to see a list of commands.\n")
+	return buf.String()
 }
 
 func compileAndStoreInputs(parsed map[string]*parsedModule, policyStore *storage.PolicyStore) error {


### PR DESCRIPTION
Other projects that embed OPA and use the REPL will probably not set the OPA
build version, timestamp, etc.   Give projects embedding the REPL control over
what is printed.