### PR TITLE
Initial support for pluggable storage backends

### DIFF
--- a/ast/term.go
+++ b/ast/term.go
@@ -404,6 +404,19 @@ func (ref Ref) Hash() int {
 	return termSliceHash(ref)
 }
 
+// HasPrefix returns true if the other ref is a prefix of this ref.
+func (ref Ref) HasPrefix(other Ref) bool {
+	if len(other) > len(ref) {
+		return false
+	}
+	for i := range other {
+		if !ref[i].Equal(other[i]) {
+			return false
+		}
+	}
+	return true
+}
+
 // IsGround returns true if all of the parts of the Ref are ground.
 func (ref Ref) IsGround() bool {
 	if len(ref) == 0 {

--- a/ast/term_test.go
+++ b/ast/term_test.go
@@ -215,6 +215,25 @@ func TestRefUnderlying(t *testing.T) {
 
 }
 
+func TestRefHasPrefix(t *testing.T) {
+
+	a := MustParseRef("foo.bar.baz")
+	b := MustParseRef("foo.bar")
+	c := MustParseRef("foo.bar[0][x]")
+
+	if !a.HasPrefix(b) {
+		t.Error("Expected a.HasPrefix(b)")
+	}
+
+	if b.HasPrefix(a) {
+		t.Error("Expected !b.HasPrefix(a)")
+	}
+
+	if !c.HasPrefix(b) {
+		t.Error("Expected c.HasPrefix(b)")
+	}
+}
+
 func assertTermEqual(t *testing.T, x *Term, y *Term) {
 	if !x.Equal(y) {
 		t.Errorf("Failure on equality: \n%s and \n%s\n", x, y)

--- a/repl/example_test.go
+++ b/repl/example_test.go
@@ -17,6 +17,10 @@ func ExampleREPL_OneShot() {
 	// Setup dummy storage for the policy engine.
 	ds := storage.NewDataStore()
 	ps := storage.NewPolicyStore(ds, "")
+	store := storage.New(storage.Config{
+		Builtin: ds,
+	})
+
 	if err := ps.Open(storage.LoadPolicies); err != nil {
 		fmt.Println("Open error:", err)
 	}
@@ -25,7 +29,7 @@ func ExampleREPL_OneShot() {
 	var buf bytes.Buffer
 
 	// Create a new REPL.
-	repl := repl.New(ds, ps, "", &buf, "json", "")
+	repl := repl.New(store, ds, ps, "", &buf, "json", "")
 
 	// Define a rule inside the REPL.
 	repl.OneShot("p :- a = [1, 2, 3, 4], a[_] > 3")

--- a/repl/repl_test.go
+++ b/repl/repl_test.go
@@ -516,8 +516,11 @@ func expectOutput(t *testing.T, output string, expected string) {
 }
 
 func newRepl(dataStore *storage.DataStore, buffer *bytes.Buffer) *REPL {
+	store := storage.New(storage.Config{
+		Builtin: dataStore,
+	})
 	policyStore := storage.NewPolicyStore(dataStore, "")
-	repl := New(dataStore, policyStore, "", buffer, "", "")
+	repl := New(store, dataStore, policyStore, "", buffer, "", "")
 	return repl
 }
 

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -118,7 +118,11 @@ func (rt *Runtime) startServer(params *Params) {
 
 	persist := len(params.PolicyDir) > 0
 
-	s := server.New(rt.DataStore, rt.PolicyStore, params.Addr, persist)
+	store := storage.New(storage.Config{
+		Builtin: rt.DataStore,
+	})
+
+	s := server.New(store, rt.DataStore, rt.PolicyStore, params.Addr, persist)
 
 	s.Handler = NewLoggingHandler(s.Handler)
 
@@ -130,7 +134,10 @@ func (rt *Runtime) startServer(params *Params) {
 
 func (rt *Runtime) startRepl(params *Params) {
 	banner := rt.getBanner()
-	repl := repl.New(rt.DataStore, rt.PolicyStore, params.HistoryPath, os.Stdout, params.OutputFormat, banner)
+	store := storage.New(storage.Config{
+		Builtin: rt.DataStore,
+	})
+	repl := repl.New(store, rt.DataStore, rt.PolicyStore, params.HistoryPath, os.Stdout, params.OutputFormat, banner)
 	repl.Loop()
 }
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -472,13 +472,16 @@ type fixture struct {
 func newFixture(t *testing.T) *fixture {
 
 	ds := storage.NewDataStore()
-
 	ps := storage.NewPolicyStore(ds, policyDir)
+	store := storage.New(storage.Config{
+		Builtin: ds,
+	})
+
 	if err := ps.Open(storage.LoadPolicies); err != nil {
 		t.Fatalf("Error opening storage: %v", err)
 	}
 
-	server := New(ds, ps, ":8182", false)
+	server := New(store, ds, ps, ":8182", false)
 	recorder := httptest.NewRecorder()
 
 	return &fixture{

--- a/storage/dump.go
+++ b/storage/dump.go
@@ -24,3 +24,13 @@ func Load(r io.Reader) (*DataStore, error) {
 	}
 	return NewDataStoreFromJSONObject(data), nil
 }
+
+// LoadOrDie reads the content of a serialized DataStore from the io.Reader r.
+// If the load fails for any reason, this function will panic.
+func LoadOrDie(r io.Reader) *DataStore {
+	ds, err := Load(r)
+	if err != nil {
+		panic(err)
+	}
+	return ds
+}

--- a/storage/index_test.go
+++ b/storage/index_test.go
@@ -50,7 +50,8 @@ func TestIndicesAdd(t *testing.T) {
 
 	ref := ast.MustParseRef("data.d[x][y]")
 
-	indices.Build(store, ref)
+	// TODO(tsandall):
+	indices.Build(store, invalidTXN, ref)
 	index := indices.Get(ref)
 
 	// new value to add
@@ -84,7 +85,8 @@ func runIndexBuildTestCase(t *testing.T, i int, note string, refStr string, expe
 		return
 	}
 
-	err := indices.Build(store, ref)
+	// TODO(tsandall):
+	err := indices.Build(store, invalidTXN, ref)
 	if err != nil {
 		t.Errorf("Test case %d (%v): Did not expect error from build: %v", i, note, err)
 		return
@@ -123,4 +125,28 @@ func assertBindingsEqual(t *testing.T, note string, index *Index, value interfac
 		t.Errorf("%v: Missing expected bindings: %v", note, expected)
 		return
 	}
+}
+
+func loadExpectedBindings(input string) []*Bindings {
+	var data []map[string]interface{}
+	if err := json.Unmarshal([]byte(input), &data); err != nil {
+		panic(err)
+	}
+	var expected []*Bindings
+	for _, bindings := range data {
+		buf := NewBindings()
+		for k, v := range bindings {
+			switch v := v.(type) {
+			case string:
+				buf.Put(ast.Var(k), ast.String(v))
+			case float64:
+				buf.Put(ast.Var(k), ast.Number(v))
+			default:
+				panic("unreachable")
+			}
+		}
+		expected = append(expected, buf)
+	}
+
+	return expected
 }

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -1,0 +1,33 @@
+// Copyright 2016 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package storage
+
+import "github.com/open-policy-agent/opa/ast"
+
+// Store defines the interface for plugging into the policy engine's storage
+// layer. Users can implement this interface to provide the policy engine access
+// to data stored outside the default, built-in store.
+type Store interface {
+	Trigger
+
+	// Returns a unique identifier for this store. The function should namespace
+	// the identifier to avoid potential conflicts, e.g.,
+	// com.example/foo-service.
+	ID() string
+
+	// Begin is called to indicate that a new transaction has started. The store
+	// can use the call to initialize any resources that may be required for the
+	// transaction. The caller will provide refs hinting the paths that may be
+	// read during the transaction.
+	Begin(txn Transaction, refs []ast.Ref) error
+
+	// Read is called to fetch a document referred to by path.
+	Read(txn Transaction, ref ast.Ref) (interface{}, error)
+
+	// Finished is called to indicate that a transaction has finished. The
+	// store can use the call to clean up any resources that may have been
+	// allocated for the transaction.
+	Finished(txn Transaction)
+}

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -1,0 +1,220 @@
+// Copyright 2016 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package storage
+
+import "github.com/open-policy-agent/opa/ast"
+
+// Config represents the configuration for the policy engine's storage layer.
+type Config struct {
+	Builtin Store
+}
+
+// Storage represents the policy engine's storage layer.
+type Storage struct {
+	builtin Store
+	indices *Indices
+	mounts  []*mount
+}
+
+type mount struct {
+	path    ast.Ref
+	strpath []string
+	backend Store
+}
+
+// New returns a new instance of the policy engine's storage layer.
+func New(config Config) *Storage {
+	return &Storage{
+		builtin: config.Builtin,
+		indices: NewIndices(),
+	}
+}
+
+// Mount adds a store into the storage layer at the given path. If the path
+// conflicts with an existing mount, an error is returned.
+func (s *Storage) Mount(backend Store, path ast.Ref) error {
+	for _, m := range s.mounts {
+		if path.HasPrefix(m.path) || m.path.HasPrefix(path) {
+			return mountConflictError()
+		}
+	}
+	spath := make([]string, len(path))
+	for i, x := range path {
+		switch v := x.Value.(type) {
+		case ast.String:
+			spath[i] = string(v)
+		case ast.Var:
+			spath[i] = string(v)
+		default:
+			return internalError("bad mount path: %v", path)
+		}
+	}
+	m := &mount{
+		path:    path,
+		strpath: spath,
+		backend: backend,
+	}
+	s.mounts = append(s.mounts, m)
+	return nil
+}
+
+// Unmount removes a store from the storage layer. If the path does not locate
+// an existing mount, an error is returned.
+func (s *Storage) Unmount(path ast.Ref) error {
+	for i := range s.mounts {
+		if s.mounts[i].path.Equal(path) {
+			s.mounts = append(s.mounts[:i], s.mounts[i+1:]...)
+			return nil
+		}
+	}
+	return notFoundRefError(path, "unmount")
+}
+
+type hole struct {
+	path []string
+	doc  interface{}
+}
+
+// Read fetches the value in storage referred to by path. The path may refer to
+// multiple stores in which case the storage layer will fetch the values from
+// each store and then stitch together the result.
+func (s *Storage) Read(txn Transaction, path ast.Ref) (interface{}, error) {
+
+	// TODO(tsandall): lazily call Begin() on backend if it has not been done so
+	// already for this transaction.
+
+	if !path.IsGround() {
+		return nil, internalError("non-ground reference:", path)
+	}
+
+	holes := []hole{}
+
+	for _, mount := range s.mounts {
+
+		// Check if read is against this mount (alone)
+		if path.HasPrefix(mount.path) {
+			return mount.backend.Read(txn, path)
+		}
+
+		// Check if read is over this mount (and possibly others)
+		if mount.path.HasPrefix(path) {
+			node, err := mount.backend.Read(txn, mount.path)
+			if err != nil {
+				return nil, err
+			}
+			prefix := mount.strpath[len(path):]
+			holes = append(holes, hole{prefix, node})
+		}
+	}
+
+	doc, err := s.builtin.Read(txn, path)
+	if err != nil {
+		return nil, err
+	}
+
+	// Fill holes in built-in document with any documents obtained from mounted
+	// stores. The mounts imply a hierarchy of objects, so traverse each mount
+	// path and create that hierarchy as necessary.
+	for _, hole := range holes {
+
+		p := hole.path
+		curr := doc.(map[string]interface{})
+
+		for _, s := range p[:len(p)-1] {
+			next, ok := curr[s]
+			if !ok {
+				next = map[string]interface{}{}
+				curr[s] = next
+			}
+			curr = next.(map[string]interface{})
+		}
+
+		curr[p[len(p)-1]] = hole.doc
+	}
+
+	return doc, nil
+}
+
+// NewTransaction returns a new transcation that can be used to perform reads
+// against a consistent snapshot of the storage layer. The caller can provide a
+// slice of references that may be read during the transaction.
+func (s *Storage) NewTransaction(refs []ast.Ref) (Transaction, error) {
+	// TODO(tsandall):
+	return invalidTXN, nil
+}
+
+// Close finishes a transaction.
+func (s *Storage) Close(txn Transaction) {
+	// TODO(tsandall):
+}
+
+// BuildIndex causes the storage layer to create an index for the given
+// reference over the snapshot identified by the transaction.
+func (s *Storage) BuildIndex(txn Transaction, ref ast.Ref) error {
+
+	// TODO(tsandall): for now we prevent indexing against stores other than the
+	// built-in. This will be revisited in the future. To determine the
+	// reference touches an external store, we collect the ground portion of
+	// the reference and see if it matches any mounts.
+	ground := ast.Ref{ref[0]}
+
+	for _, x := range ref[1:] {
+		if x.IsGround() {
+			ground = append(ground, x)
+		}
+	}
+
+	for _, mount := range s.mounts {
+		if ground.HasPrefix(mount.path) {
+			return indexingNotSupportedError()
+		}
+	}
+
+	return s.indices.Build(s.builtin, txn, ref)
+}
+
+// IndexExists returns true if an index has been built for reference.
+func (s *Storage) IndexExists(ref ast.Ref) bool {
+	return s.indices.Get(ref) != nil
+}
+
+// Index invokes the iterator with bindings for each variable in the reference
+// that if plugged into the reference, would locate a document with a matching
+// value.
+func (s *Storage) Index(txn Transaction, ref ast.Ref, value interface{}, iter func(*Bindings) error) error {
+
+	idx := s.indices.Get(ref)
+	if idx == nil {
+		return indexNotFoundError()
+	}
+
+	return idx.Iter(value, iter)
+}
+
+// ReadOrDie is a helper function to read the path from storage. If the read
+// fails for any reason, this function will panic. This function should only be
+// used for tests.
+func ReadOrDie(store *Storage, path ast.Ref) interface{} {
+	txn, err := store.NewTransaction(nil)
+	if err != nil {
+		panic(err)
+	}
+	node, err := store.Read(txn, path)
+	if err != nil {
+		panic(err)
+	}
+	return node
+}
+
+// NewTransactionOrDie is a helper function to create a new transaction. If the
+// storage layer cannot create a new transaction, this function will panic. This
+// function should only be used for tests.
+func NewTransactionOrDie(store *Storage, refs []ast.Ref) Transaction {
+	txn, err := store.NewTransaction(refs)
+	if err != nil {
+		panic(err)
+	}
+	return txn
+}

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -1,0 +1,107 @@
+// Copyright 2016 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package storage
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/open-policy-agent/opa/ast"
+)
+
+func TestStorageReadPlugin(t *testing.T) {
+
+	mem1 := LoadOrDie(strings.NewReader(`
+    {
+        "foo": {
+            "bar": {
+                "baz": [1,2,3,4]
+            }
+        }
+    }`))
+
+	mem2 := LoadOrDie(strings.NewReader(`
+	{
+		"corge": [5,6,7,8]
+	}
+	`))
+
+	mountPath := ast.MustParseRef("data.foo.bar.qux")
+	mem2.SetMountPath(mountPath)
+	store := New(Config{
+		Builtin: mem1,
+	})
+	if err := store.Mount(mem2, mountPath); err != nil {
+		t.Fatalf("Unexpected mount error: %v", err)
+	}
+
+	txn, err := store.NewTransaction(nil)
+	if err != nil {
+		panic(err)
+	}
+
+	tests := []struct {
+		note     string
+		path     string
+		expected string
+	}{
+		{"plugin", "data.foo.bar.qux.corge[1]", "6"},
+		{"multiple", "data.foo.bar", `{"baz": [1,2,3,4], "qux": {"corge": [5,6,7,8]}}`},
+	}
+
+	for i, tc := range tests {
+
+		result, err := store.Read(txn, ast.MustParseRef(tc.path))
+		if err != nil {
+			t.Errorf("Test #%d (%v): Unexpected read error: %v", i+1, tc.note, err)
+		}
+
+		expected := loadExpectedResult(tc.expected)
+
+		if !reflect.DeepEqual(result, expected) {
+			t.Fatalf("Test #%d (%v): Expected %v from built-in store but got: %v", i+1, tc.note, expected, result)
+		}
+
+	}
+
+}
+
+func TestStorageIndexingBasicUpdate(t *testing.T) {
+
+	refA := ast.MustParseRef("data.a[i]")
+	refB := ast.MustParseRef("data.b[x]")
+	store, ds := newStorageWithIndices(refA, refB)
+	ds.MustPatch(AddOp, path(`a["-"]`), float64(100))
+
+	if store.IndexExists(refA) {
+		t.Errorf("Expected index to be removed after patch")
+	}
+}
+
+func mustBuild(store *Storage, ref ast.Ref) {
+	err := store.BuildIndex(invalidTXN, ref)
+	if err != nil {
+		panic(err)
+	}
+	if !store.IndexExists(ref) {
+		panic(err)
+	}
+}
+
+func newStorageWithIndices(r ...ast.Ref) (*Storage, *DataStore) {
+
+	data := loadSmallTestData()
+	ds := NewDataStoreFromJSONObject(data)
+	store := New(Config{
+		Builtin: ds,
+	})
+
+	for _, x := range r {
+		mustBuild(store, x)
+	}
+
+	return store, ds
+}

--- a/storage/transaction.go
+++ b/storage/transaction.go
@@ -1,0 +1,23 @@
+// Copyright 2016 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package storage
+
+// Transaction defines the interface that identifies a consistent snapshot over
+// the policy engine's storage layer.
+type Transaction interface {
+
+	// ID returns a unique identifier for this transaction.
+	ID() uint64
+}
+
+type transaction uint64
+
+const (
+	invalidTXN = transaction(0)
+)
+
+func (t transaction) ID() uint64 {
+	return uint64(t)
+}

--- a/storage/trigger.go
+++ b/storage/trigger.go
@@ -1,0 +1,44 @@
+// Copyright 2016 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package storage
+
+// TriggerCallback defines the interface that callers can implement to handle
+// changes in the stores.
+type TriggerCallback func(txn Transaction, op PatchOp, path []interface{}, value interface{}) error
+
+// TriggerConfig contains the trigger registration configuration.
+type TriggerConfig struct {
+
+	// Before is called before the change is applied to the store.
+	Before TriggerCallback
+
+	// After is called after the change is applied to the store.
+	After TriggerCallback
+
+	// TODO(tsandall): include callbacks for aborted changes
+}
+
+// Trigger defines the interface that stores implement to register for change
+// notifications when data in the store changes.
+type Trigger interface {
+	Register(id string, config TriggerConfig) error
+
+	// Unregister instructs the trigger to remove the registration.
+	Unregister(id string)
+}
+
+// TriggersNotSupported provides default implementations of the Trigger
+// interface which may be used if the backend does not support triggers.
+type TriggersNotSupported struct{}
+
+// Register always returns an error indicating triggers are not supported.
+func (TriggersNotSupported) Register(string, TriggerConfig) error {
+	return triggersNotSupportedError()
+}
+
+// Unregister is a no-op.
+func (TriggersNotSupported) Unregister(string) {
+
+}

--- a/test/scheduler/scheduler_bench_test.go
+++ b/test/scheduler/scheduler_bench_test.go
@@ -63,13 +63,16 @@ func setupBenchmark(nodes int, pods int) *topdown.QueryParams {
 	// storage setup
 	ds := storage.NewDataStore()
 	loadPolicyStore(ds, c.Modules)
+	store := storage.New(storage.Config{
+		Builtin: ds,
+	})
 
 	// parameter setup
 	globals := storage.NewBindings()
 	req := ast.MustParseTerm(requestedPod).Value
 	globals.Put(ast.Var("requested_pod"), req)
 	path := []interface{}{"opa", "test", "scheduler", "fit"}
-	params := topdown.NewQueryParams(ds, globals, path)
+	params := topdown.NewQueryParams(store, globals, path)
 
 	// data setup
 	setupNodes(ds, nodes)

--- a/test/scheduler/scheduler_test.go
+++ b/test/scheduler/scheduler_test.go
@@ -48,13 +48,16 @@ func setup(t *testing.T, filename string) *topdown.QueryParams {
 	// storage setup
 	ds := loadDataStore(filename)
 	loadPolicyStore(ds, c.Modules)
+	store := storage.New(storage.Config{
+		Builtin: ds,
+	})
 
 	// parameter setup
 	globals := storage.NewBindings()
 	req := ast.MustParseTerm(requestedPod).Value
 	globals.Put(ast.Var("requested_pod"), req)
 	path := []interface{}{"opa", "test", "scheduler", "fit"}
-	params := topdown.NewQueryParams(ds, globals, path)
+	params := topdown.NewQueryParams(store, globals, path)
 
 	return params
 }

--- a/topdown/eq.go
+++ b/topdown/eq.go
@@ -97,7 +97,8 @@ func evalEqUnifyArray(ctx *Context, a ast.Array, b ast.Value, prev *Undo, iter I
 
 func evalEqUnifyArrayRef(ctx *Context, a ast.Array, b ast.Ref, prev *Undo, iter Iterator) (*Undo, error) {
 
-	r, err := ctx.DataStore.GetRef(b)
+	// TODO(tsandall): should not be accessing txn here?
+	r, err := ctx.Store.Read(ctx.txn, b)
 	if err != nil {
 		return prev, err
 	}
@@ -176,7 +177,8 @@ func evalEqUnifyObject(ctx *Context, a ast.Object, b ast.Value, prev *Undo, iter
 
 func evalEqUnifyObjectRef(ctx *Context, a ast.Object, b ast.Ref, prev *Undo, iter Iterator) (*Undo, error) {
 
-	r, err := ctx.DataStore.GetRef(b)
+	// TODO(tsandall): should not be accessing txn here?
+	r, err := ctx.Store.Read(ctx.txn, b)
 
 	if err != nil {
 		return prev, err

--- a/topdown/tracer_test.go
+++ b/topdown/tracer_test.go
@@ -33,6 +33,9 @@ func TestTracer(t *testing.T) {
 
 	ds := storage.NewDataStoreFromJSONObject(data)
 	ps := storage.NewPolicyStore(ds, "")
+	store := storage.New(storage.Config{
+		Builtin: ds,
+	})
 
 	for id, mod := range mods {
 		err := ps.Add(id, mod, []byte(""), false)
@@ -44,10 +47,10 @@ func TestTracer(t *testing.T) {
 	tracer := &mockTracer{[]string{}}
 
 	params := &QueryParams{
-		DataStore: ds,
-		Globals:   storage.NewBindings(),
-		Tracer:    tracer,
-		Path:      []interface{}{"p"}}
+		Store:   store,
+		Globals: storage.NewBindings(),
+		Tracer:  tracer,
+		Path:    []interface{}{"p"}}
 
 	result, err := Query(params)
 	if err != nil {


### PR DESCRIPTION
The commit message summarizes the changes. The main addition is the Storage object to represent the storage layer and integration of the Storage object with the topdown package.

There are still a few TODOs but this is a good place to review and I think it can be merged as is.

Still TODO:

1. Implement transaction management. This will just be done with simple locking for now. We can do something more sophisticated in the future if it's warranted.

1. Refactor reference evaluation to avoid unnecessary reads against mounted stores when attempting to determine if reference refers to a virtual document. 

1. Implement analysis to determine the documents in use for a given query. The result of the query analysis (i.e., document hints) can be provided to storage backends so they can prepare for transaction.

1. Remove references to DataStore and PolicyStore from REPL and Server. It should be sufficient to given them an instance of Storage.