### PR TITLE
Improve query evaluation support & misc. improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ install: generate
 	$(GO) install -ldflags $(LDFLAGS)
 
 test: generate
-	$(GO) test -v $(PACKAGES)
+	$(GO) test $(PACKAGES)
 
 COVER_PACKAGES=$(PACKAGES)
 $(COVER_PACKAGES):

--- a/ast/compile.go
+++ b/ast/compile.go
@@ -173,10 +173,12 @@ func CompileQuery(q string) (*Compiler, Body, error) {
 func NewCompiler() *Compiler {
 
 	c := &Compiler{
-		Modules:   map[string]*Module{},
-		Globals:   map[*Module]map[Var]Value{},
-		RuleGraph: map[*Rule]map[*Rule]struct{}{},
-		RuleTree:  NewRuleTree(nil),
+		Modules:    map[string]*Module{},
+		Exports:    newExports(),
+		Globals:    map[*Module]map[Var]Value{},
+		RuleGraph:  map[*Rule]map[*Rule]struct{}{},
+		ModuleTree: NewModuleTree(nil),
+		RuleTree:   NewRuleTree(nil),
 	}
 
 	c.stages = []stage{
@@ -525,13 +527,7 @@ func (c *Compiler) resolveRefsInTerm(globals map[Var]Value, term *Term) *Term {
 // See Compiler for a description of Exports.
 func (c *Compiler) setExports() {
 
-	c.Exports = util.NewHashMap(func(a, b util.T) bool {
-		r1 := a.(Ref)
-		r2 := a.(Ref)
-		return r1.Equal(r2)
-	}, func(v util.T) int {
-		return v.(Ref).Hash()
-	})
+	c.Exports = newExports()
 
 	for _, mod := range c.Modules {
 		for _, rule := range mod.Rules {
@@ -545,6 +541,17 @@ func (c *Compiler) setExports() {
 		}
 	}
 
+}
+
+func newExports() *util.HashMap {
+	// TODO(tsandall): replace with ValueMap
+	return util.NewHashMap(func(a, b util.T) bool {
+		r1 := a.(Ref)
+		r2 := a.(Ref)
+		return r1.Equal(r2)
+	}, func(v util.T) int {
+		return v.(Ref).Hash()
+	})
 }
 
 // setGlobals populates the Globals on the compiler.

--- a/ast/policy.go
+++ b/ast/policy.go
@@ -198,6 +198,11 @@ func (rule *Rule) Loc() *Location {
 	return rule.Location
 }
 
+// Path returns a reference that identifies the rule under ns.
+func (rule *Rule) Path(ns Ref) Ref {
+	return ns.Append(StringTerm(string(rule.Name)))
+}
+
 func (rule *Rule) String() string {
 	var buf []string
 	if rule.Key != nil {

--- a/ast/term.go
+++ b/ast/term.go
@@ -389,6 +389,15 @@ func RefTerm(r ...*Term) *Term {
 	return &Term{Value: Ref(r)}
 }
 
+// Append returns a copy of ref with the term appended to the end.
+func (ref Ref) Append(term *Term) Ref {
+	n := len(ref)
+	dst := make(Ref, n+1)
+	copy(dst, ref)
+	dst[n] = term
+	return dst
+}
+
 // Equal returns true if the other Value is a Ref and the elements of the
 // other Ref are equal to the this Ref.
 func (ref Ref) Equal(other Value) bool {

--- a/ast/term_test.go
+++ b/ast/term_test.go
@@ -234,6 +234,14 @@ func TestRefHasPrefix(t *testing.T) {
 	}
 }
 
+func TestRefAppend(t *testing.T) {
+	a := MustParseRef("foo.bar.baz")
+	b := a.Append(VarTerm("x"))
+	if !b.Equal(MustParseRef("foo.bar.baz[x]")) {
+		t.Error("Expected foo.bar.baz[x]")
+	}
+}
+
 func assertTermEqual(t *testing.T, x *Term, y *Term) {
 	if !x.Equal(y) {
 		t.Errorf("Failure on equality: \n%s and \n%s\n", x, y)

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -273,6 +273,7 @@ func (r *REPL) compileBody(body ast.Body) (ast.Body, error) {
 	rule := &ast.Rule{
 		Location: body[0].Location,
 		Name:     ast.Var(name),
+		Value:    ast.BooleanTerm(true),
 		Body:     body,
 	}
 

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -84,25 +84,4 @@ func TestInit(t *testing.T) {
 		return
 	}
 
-	node, err = rt.Store.Read(txn, ast.MustParseRef("data.a.b.c.p"))
-	rules, ok := node.([]*ast.Rule)
-	if !ok {
-		t.Errorf("Expected rules but got: %v", node)
-		return
-	}
-	if !rules[0].Name.Equal(ast.Var("p")) {
-		t.Errorf("Expected rule p but got: %v", rules[0])
-		return
-	}
-
-	node, err = rt.Store.Read(txn, ast.MustParseRef("data.a.b.c.q"))
-	rules, ok = node.([]*ast.Rule)
-	if !ok {
-		t.Errorf("Expected rules but got: %v", node)
-		return
-	}
-	if !rules[0].Name.Equal(ast.Var("q")) {
-		t.Errorf("Expected rule q but got: %v", rules[0])
-		return
-	}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -33,6 +34,22 @@ func (err *apiErrorV1) Bytes() []byte {
 		return bs
 	}
 	return nil
+}
+
+// WriteConflictError represents an error condition raised if the caller
+// attempts to modify a virtual document.
+type WriteConflictError struct {
+	path ast.Ref
+}
+
+func (err WriteConflictError) Error() string {
+	return fmt.Sprintf("write conflict: %v", err.path)
+}
+
+// IsWriteConflict returns true if the error indicates write conflict.
+func IsWriteConflict(err error) bool {
+	_, ok := err.(WriteConflictError)
+	return ok
 }
 
 // undefinedV1 models the an undefined query result.
@@ -67,8 +84,11 @@ type Server struct {
 	addr    string
 	persist bool
 
+	// access to the compiler is guarded by mtx
+	mtx      sync.RWMutex
 	compiler *ast.Compiler
-	store    *storage.Storage
+
+	store *storage.Storage
 }
 
 // New returns a new Server.
@@ -101,22 +121,40 @@ func New(store *storage.Storage, addr string, persist bool) *Server {
 
 // Loop starts the server. This function does not return.
 func (s *Server) Loop() error {
+
+	txn, err := s.store.NewTransaction()
+	if err != nil {
+		return err
+	}
+
+	mods := s.store.ListPolicies(txn)
+	s.store.Close(txn)
+
+	c := ast.NewCompiler()
+	if c.Compile(mods); c.Failed() {
+		return c.Errors[0]
+	}
+
+	s.setCompiler(c)
+
 	return http.ListenAndServe(s.addr, s.Handler)
 }
 
-func (s *Server) compileQuery(qStr string) (ast.Body, error) {
+func (s *Server) compileQuery(compiler *ast.Compiler, qStr string) (ast.Body, error) {
 
 	body, err := ast.ParseBody(qStr)
 	if err != nil {
 		return nil, errors.Wrapf(err, "parse error")
 	}
 
-	return s.compiler.CompileOne(body)
+	return compiler.CompileOne(body)
 }
 
 func (s *Server) execQuery(qStr string) (resultSetV1, error) {
 
-	query, err := s.compileQuery(qStr)
+	compiler := s.getCompiler()
+
+	query, err := s.compileQuery(compiler, qStr)
 	if err != nil {
 		return nil, err
 	}
@@ -128,7 +166,7 @@ func (s *Server) execQuery(qStr string) (resultSetV1, error) {
 
 	defer s.store.Close(txn)
 
-	ctx := topdown.NewContext(query, s.compiler, s.store, txn)
+	ctx := topdown.NewContext(query, compiler, s.store, txn)
 
 	results := resultSetV1{}
 
@@ -197,7 +235,7 @@ func (s *Server) v1DataGet(w http.ResponseWriter, r *http.Request) {
 		handleError(w, 400, err)
 		return
 	}
-	params := topdown.NewQueryParams(s.compiler, s.store, globals, path)
+	params := topdown.NewQueryParams(s.getCompiler(), s.store, globals, path)
 
 	result, err := topdown.Query(params)
 
@@ -256,6 +294,11 @@ func (s *Server) v1DataPatch(w http.ResponseWriter, r *http.Request) {
 		path := root
 		path = append(path, stringPathToRef(ops[i].Path)...)
 
+		if err := s.writeConflict(op, path); err != nil {
+			handleErrorAuto(w, err)
+			return
+		}
+
 		if err := s.store.Write(txn, op, path, ops[i].Value); err != nil {
 			handleErrorAuto(w, err)
 			return
@@ -263,6 +306,19 @@ func (s *Server) v1DataPatch(w http.ResponseWriter, r *http.Request) {
 	}
 
 	handleResponse(w, 204, nil)
+}
+
+func (s *Server) writeConflict(op storage.PatchOp, path ast.Ref) error {
+
+	if op == storage.AddOp && path[len(path)-1].Value.Equal(ast.String("-")) {
+		path = path[:len(path)-1]
+	}
+
+	if rs := s.getCompiler().GetRulesForVirtualDocument(path); rs != nil {
+		return WriteConflictError{path}
+	}
+
+	return nil
 }
 
 func (s *Server) v1PoliciesDelete(w http.ResponseWriter, r *http.Request) {
@@ -298,7 +354,7 @@ func (s *Server) v1PoliciesDelete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	s.compiler = c
+	s.setCompiler(c)
 
 	handleResponse(w, 204, nil)
 }
@@ -422,7 +478,7 @@ func (s *Server) v1PoliciesPut(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	s.compiler = c
+	s.setCompiler(c)
 
 	policy := &policyV1{
 		ID:     id,
@@ -451,6 +507,18 @@ func (s *Server) v1QueryGet(w http.ResponseWriter, r *http.Request) {
 	pretty := getPretty(r.URL.Query()["pretty"])
 
 	handleResponseJSON(w, 200, results, pretty)
+}
+
+func (s *Server) getCompiler() *ast.Compiler {
+	s.mtx.RLock()
+	defer s.mtx.RUnlock()
+	return s.compiler
+}
+
+func (s *Server) setCompiler(compiler *ast.Compiler) {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	s.compiler = compiler
 }
 
 func stringPathToRef(s string) ast.Ref {
@@ -497,6 +565,10 @@ func handleErrorAuto(w http.ResponseWriter, err error) {
 		}
 		if topdown.IsUnboundGlobal(curr) {
 			handleError(w, 400, err)
+			return
+		}
+		if IsWriteConflict(curr) {
+			handleError(w, 404, err)
 			return
 		}
 		prev = curr

--- a/storage/datastore.go
+++ b/storage/datastore.go
@@ -145,7 +145,14 @@ func (ds *DataStore) mustPatch(op PatchOp, path []interface{}, value interface{}
 func (ds *DataStore) patch(op PatchOp, path []interface{}, value interface{}) error {
 
 	if len(path) == 0 {
-		return notFoundError(path, nonEmptyMsg)
+		if op == AddOp || op == ReplaceOp {
+			if obj, ok := value.(map[string]interface{}); ok {
+				ds.data = obj
+				return nil
+			}
+			return invalidPatchErr(rootMustBeObjectMsg)
+		}
+		return invalidPatchErr(rootCannotBeRemovedMsg)
 	}
 
 	_, isString := path[0].(string)

--- a/storage/datastore_test.go
+++ b/storage/datastore_test.go
@@ -78,28 +78,31 @@ func TestStoragePatch(t *testing.T) {
 		getPath     interface{}
 		getExpected interface{}
 	}{
-		{"add root", "add", path("newroot"), `{"a": [[1]]}`, nil, path("newroot"), `{"a": [[1]]}`},
-		{"add root/arr", "add", path("a[1]"), `"x"`, nil, path("a"), `[1,"x",2,3,4]`},
+		{"add root", "add", path([]interface{}{}), `{"a": [1]}`, nil, path([]interface{}{}), `{"a": [1]}`},
+		{"add", "add", path("newroot"), `{"a": [[1]]}`, nil, path("newroot"), `{"a": [[1]]}`},
+		{"add arr", "add", path("a[1]"), `"x"`, nil, path("a"), `[1,"x",2,3,4]`},
 		{"add arr/arr", "add", path("h[1][2]"), `"x"`, nil, path("h"), `[[1,2,3], [2,3,"x",4]]`},
 		{"add obj/arr", "add", path("d.e[1]"), `"x"`, nil, path("d"), `{"e": ["bar", "x", "baz"]}`},
 		{"add obj", "add", path("b.vNew"), `"x"`, nil, path("b"), `{"v1": "hello", "v2": "goodbye", "vNew": "x"}`},
 		{"add obj (existing)", "add", path("b.v2"), `"x"`, nil, path("b"), `{"v1": "hello", "v2": "x"}`},
 
-		{"append root/arr", "add", path(`a["-"]`), `"x"`, nil, path("a"), `[1,2,3,4,"x"]`},
+		{"append arr", "add", path(`a["-"]`), `"x"`, nil, path("a"), `[1,2,3,4,"x"]`},
 		{"append obj/arr", "add", path(`c[0].x["-"]`), `"x"`, nil, path("c[0].x"), `[true,false,"foo","x"]`},
 		{"append arr/arr", "add", path(`h[0]["-"]`), `"x"`, nil, path(`h[0][3]`), `"x"`},
 
-		{"remove root", "remove", path("a"), "", nil, path("a"), notFoundError(path("a"), doesNotExistMsg)},
-		{"remove root/arr", "remove", path("a[1]"), "", nil, path("a"), "[1,3,4]"},
+		{"remove", "remove", path("a"), "", nil, path("a"), notFoundError(path("a"), doesNotExistMsg)},
+		{"remove arr", "remove", path("a[1]"), "", nil, path("a"), "[1,3,4]"},
 		{"remove obj/arr", "remove", path("c[0].x[1]"), "", nil, path("c[0].x"), `[true,"foo"]`},
 		{"remove arr/arr", "remove", path("h[0][1]"), "", nil, path("h[0]"), "[1,3]"},
 		{"remove obj", "remove", path("b.v2"), "", nil, path("b"), `{"v1": "hello"}`},
 
-		{"replace root", "replace", path("a"), "1", nil, path("a"), "1"},
+		{"replace root", "replace", path([]interface{}{}), `{"a": [1]}`, nil, path([]interface{}{}), `{"a": [1]}`},
+		{"replace", "replace", path("a"), "1", nil, path("a"), "1"},
 		{"replace obj", "replace", path("b.v1"), "1", nil, path("b"), `{"v1": 1, "v2": "goodbye"}`},
 		{"replace array", "replace", path("a[1]"), "999", nil, path("a"), "[1,999,3,4]"},
 
-		{"err: empty path", "add", []interface{}{}, "", notFoundError([]interface{}{}, nonEmptyMsg), nil, nil},
+		{"err: bad root type", "add", []interface{}{}, "[1,2,3]", invalidPatchErr(rootMustBeObjectMsg), nil, nil},
+		{"err: remove root", "remove", []interface{}{}, "", invalidPatchErr(rootCannotBeRemovedMsg), nil, nil},
 		{"err: non-string head", "add", []interface{}{float64(1)}, "", notFoundError([]interface{}{float64(1)}, stringHeadMsg), nil, nil},
 		{"err: add arr (non-integer)", "add", path("a.foo"), "1", notFoundError(path("a.foo"), arrayIndexTypeMsg("xxx")), nil, nil},
 		{"err: add arr (non-integer)", "add", path("a[3.14]"), "1", notFoundError(path("a[3.14]"), arrayIndexTypeMsg(3.14)), nil, nil},

--- a/storage/errors.go
+++ b/storage/errors.go
@@ -22,6 +22,10 @@ const (
 	// locate a document.
 	NotFoundErr = iota
 
+	// InvalidPatchErr indicates an invalid patch/write was issued. The patch
+	// was rejected.
+	InvalidPatchErr = iota
+
 	// MountConflictErr indicates a mount attempt was made on a path that is
 	// already used for a mount.
 	MountConflictErr = iota
@@ -62,9 +66,19 @@ func IsNotFound(err error) bool {
 	return false
 }
 
+// IsInvalidPatch returns true if this error is a InvalidPatchErr.
+func IsInvalidPatch(err error) bool {
+	switch err := err.(type) {
+	case *Error:
+		return err.Code == InvalidPatchErr
+	}
+	return false
+}
+
+var rootMustBeObjectMsg = "root must be object"
+var rootCannotBeRemovedMsg = "root cannot be removed"
 var doesNotExistMsg = "document does not exist"
 var outOfRangeMsg = "array index out of range"
-var nonEmptyMsg = "path must be non-empty"
 var stringHeadMsg = "path must begin with string"
 
 func arrayIndexTypeMsg(v interface{}) string {
@@ -101,6 +115,17 @@ func internalError(f string, a ...interface{}) *Error {
 	return &Error{
 		Code:    InternalErr,
 		Message: fmt.Sprintf(f, a...),
+	}
+}
+
+func invalidPatchErr(f string, a ...interface{}) *Error {
+	msg := fmt.Sprintf("bad patch")
+	if len(f) > 0 {
+		msg += ": " + fmt.Sprintf(f, a...)
+	}
+	return &Error{
+		Code:    InvalidPatchErr,
+		Message: msg,
 	}
 }
 

--- a/storage/policystore_test.go
+++ b/storage/policystore_test.go
@@ -133,22 +133,6 @@ func TestPolicyStoreAddIdempotent(t *testing.T) {
 		return
 	}
 
-	node, err := f.dataStore.get(path("a.b.p"))
-	if err != nil {
-		t.Errorf("Unexpected error on Get(): %v", err)
-		return
-	}
-
-	rules := node.([]*ast.Rule)
-	if len(rules) != 1 {
-		t.Errorf("Expected ruleset to exactly one rule: %v", rules)
-		return
-	}
-
-	if !rules[0].Equal(mod1.Rules[0]) {
-		t.Errorf("Expected rule to be %v but got: %v", mod1, rules[0])
-		return
-	}
 }
 
 func TestPolicyStoreRemove(t *testing.T) {
@@ -222,28 +206,6 @@ func TestPolicyStoreUpdate(t *testing.T) {
 		return
 	}
 
-	node, err := f.dataStore.get(path("a.b.p"))
-	if err != nil {
-		t.Errorf("Unexpected error on Get(): %v", err)
-		return
-	}
-
-	rules := node.([]*ast.Rule)
-	if len(rules) != 1 {
-		t.Errorf("Expected exactly one rule but got: %v", rules)
-		return
-	}
-
-	if !rules[0].Equal(mod2.Rules[0]) {
-		t.Errorf("Expected rule to equal %v but got: %v", mod2.Rules[0], rules[0])
-		return
-	}
-
-	node, err = f.dataStore.get(path("a.b.q"))
-	if !IsNotFound(err) {
-		t.Errorf("Expected storage not found error but got: %v (err: %v)", node, err)
-		return
-	}
 }
 
 const (

--- a/test/scheduler/scheduler_bench_test.go
+++ b/test/scheduler/scheduler_bench_test.go
@@ -69,7 +69,7 @@ func setupBenchmark(nodes int, pods int) *topdown.QueryParams {
 	req := ast.MustParseTerm(requestedPod).Value
 	globals.Put(ast.Var("requested_pod"), req)
 	path := []interface{}{"opa", "test", "scheduler", "fit"}
-	params := topdown.NewQueryParams(store, globals, path)
+	params := topdown.NewQueryParams(c, store, globals, path)
 
 	// data setup
 	txn := storage.NewTransactionOrDie(store)

--- a/test/scheduler/scheduler_bench_test.go
+++ b/test/scheduler/scheduler_bench_test.go
@@ -62,7 +62,6 @@ func setupBenchmark(nodes int, pods int) *topdown.QueryParams {
 
 	// storage setup
 	store := storage.New(storage.InMemoryConfig())
-	insertPolicies(store, c.Modules)
 
 	// parameter setup
 	globals := storage.NewBindings()

--- a/test/scheduler/scheduler_test.go
+++ b/test/scheduler/scheduler_test.go
@@ -56,7 +56,7 @@ func setup(t *testing.T, filename string) *topdown.QueryParams {
 	req := ast.MustParseTerm(requestedPod).Value
 	globals.Put(ast.Var("requested_pod"), req)
 	path := []interface{}{"opa", "test", "scheduler", "fit"}
-	params := topdown.NewQueryParams(store, globals, path)
+	params := topdown.NewQueryParams(c, store, globals, path)
 
 	return params
 }

--- a/test/scheduler/scheduler_test.go
+++ b/test/scheduler/scheduler_test.go
@@ -49,7 +49,6 @@ func setup(t *testing.T, filename string) *topdown.QueryParams {
 	store := storage.New(storage.Config{
 		Builtin: loadDataStore(filename),
 	})
-	insertPolicies(store, c.Modules)
 
 	// parameter setup
 	globals := storage.NewBindings()
@@ -68,14 +67,6 @@ func loadDataStore(filename string) *storage.DataStore {
 	}
 	defer f.Close()
 	return storage.NewDataStoreFromReader(f)
-}
-
-func insertPolicies(store *storage.Storage, modules map[string]*ast.Module) {
-	for id, mod := range modules {
-		if err := storage.InsertPolicy(store, id, mod, nil, false); err != nil {
-			panic(err)
-		}
-	}
 }
 
 func getFilename(filename string) string {

--- a/topdown/example_test.go
+++ b/topdown/example_test.go
@@ -16,7 +16,7 @@ import (
 func ExampleEval() {
 
 	// Define a dummy query and some data that the query will execute against.
-	query, err := ast.CompileQuery("data.a[_] = x, x >= 2")
+	compiler, query, err := ast.CompileQuery("data.a[_] = x, x >= 2")
 	if err != nil {
 		// Handle error.
 	}
@@ -43,7 +43,7 @@ func ExampleEval() {
 	// storage. In this case, we seed the storage with a single array of number. Other parameters
 	// such as globals, tracing configuration, etc. can be set on the context. See the Context
 	// documentation for more details.
-	ctx := topdown.NewContext(query, store, txn)
+	ctx := topdown.NewContext(query, compiler, store, txn)
 
 	result := []interface{}{}
 
@@ -75,7 +75,7 @@ func ExampleEval() {
 func ExampleQuery() {
 
 	// Define a dummy module with rules that produce documents that we will query below.
-	mod, err := ast.CompileModule(`
+	compiler, module, err := ast.CompileModule(`
 
 	    package opa.example
 
@@ -92,7 +92,7 @@ func ExampleQuery() {
 	// Instantiate the policy engine's storage layer.
 	store := storage.New(storage.InMemoryConfig())
 
-	if err := storage.InsertPolicy(store, "my_module", mod, nil, false); err != nil {
+	if err := storage.InsertPolicy(store, "my_module_id", module, nil, false); err != nil {
 		// Handle error.
 	}
 
@@ -100,7 +100,7 @@ func ExampleQuery() {
 	// accept additional documents (which are referred to as "globals"). In this case we have no
 	// additional documents.
 	globals := storage.NewBindings()
-	params := topdown.NewQueryParams(store, globals, []interface{}{"opa", "example", "p"})
+	params := topdown.NewQueryParams(compiler, store, globals, []interface{}{"opa", "example", "p"})
 
 	// Execute the query against "p".
 	v1, err1 := topdown.Query(params)

--- a/topdown/example_test.go
+++ b/topdown/example_test.go
@@ -75,7 +75,7 @@ func ExampleEval() {
 func ExampleQuery() {
 
 	// Define a dummy module with rules that produce documents that we will query below.
-	compiler, module, err := ast.CompileModule(`
+	compiler, _, err := ast.CompileModule(`
 
 	    package opa.example
 
@@ -91,10 +91,6 @@ func ExampleQuery() {
 
 	// Instantiate the policy engine's storage layer.
 	store := storage.New(storage.InMemoryConfig())
-
-	if err := storage.InsertPolicy(store, "my_module_id", module, nil, false); err != nil {
-		// Handle error.
-	}
 
 	// Prepare the query parameters. Queries execute against the policy engine's storage and can
 	// accept additional documents (which are referred to as "globals"). In this case we have no

--- a/topdown/topdown.go
+++ b/topdown/topdown.go
@@ -16,6 +16,7 @@ import (
 // Context contains the state of the evaluation process.
 type Context struct {
 	Query    ast.Body
+	Compiler *ast.Compiler
 	Globals  *storage.Bindings
 	Locals   *storage.Bindings
 	Index    int
@@ -28,14 +29,15 @@ type Context struct {
 }
 
 // NewContext creates a new Context with no bindings.
-func NewContext(query ast.Body, store *storage.Storage, txn storage.Transaction) *Context {
+func NewContext(query ast.Body, compiler *ast.Compiler, store *storage.Storage, txn storage.Transaction) *Context {
 	return &Context{
-		Query:   query,
-		Globals: storage.NewBindings(),
-		Locals:  storage.NewBindings(),
-		Store:   store,
-		txn:     txn,
-		cache:   newContextCache(),
+		Query:    query,
+		Compiler: compiler,
+		Globals:  storage.NewBindings(),
+		Locals:   storage.NewBindings(),
+		Store:    store,
+		txn:      txn,
+		cache:    newContextCache(),
 	}
 }
 
@@ -330,31 +332,34 @@ func PlugValue(v ast.Value, ctx *Context) ast.Value {
 
 // QueryParams defines input parameters for the query interface.
 type QueryParams struct {
-	Store   *storage.Storage
-	Globals *storage.Bindings
-	Tracer  Tracer
-	Path    []interface{}
+	Compiler *ast.Compiler
+	Store    *storage.Storage
+	Globals  *storage.Bindings
+	Tracer   Tracer
+	Path     []interface{}
 }
 
-// NewQueryParams returns a new QueryParams q.
-func NewQueryParams(store *storage.Storage, globals *storage.Bindings, path []interface{}) (q *QueryParams) {
+// NewQueryParams returns a new QueryParams.
+func NewQueryParams(compiler *ast.Compiler, store *storage.Storage, globals *storage.Bindings, path []interface{}) *QueryParams {
 	return &QueryParams{
-		Store:   store,
-		Globals: globals,
-		Path:    path,
+		Compiler: compiler,
+		Store:    store,
+		Globals:  globals,
+		Path:     path,
 	}
 }
 
 // NewContext returns a new Context that can be used to do evaluation.
 func (q *QueryParams) NewContext(body ast.Body, txn storage.Transaction) *Context {
 	ctx := &Context{
-		Query:   body,
-		Globals: q.Globals,
-		Locals:  storage.NewBindings(),
-		Store:   q.Store,
-		Tracer:  q.Tracer,
-		txn:     txn,
-		cache:   newContextCache(),
+		Query:    body,
+		Compiler: q.Compiler,
+		Globals:  q.Globals,
+		Locals:   storage.NewBindings(),
+		Store:    q.Store,
+		Tracer:   q.Tracer,
+		txn:      txn,
+		cache:    newContextCache(),
 	}
 	return ctx
 }

--- a/topdown/topdown.go
+++ b/topdown/topdown.go
@@ -24,7 +24,11 @@ type Context struct {
 	Store    *storage.Storage
 	Tracer   Tracer
 
-	txn   storage.Transaction
+	// TODO(tsandall): make the transaction public and lazily create one in
+	// Eval(). This way callers do not have to provide the transaction unless
+	// they want to run evaluation multiple times against the same snapshot.
+	txn storage.Transaction
+
 	cache *contextcache
 }
 
@@ -390,49 +394,31 @@ func Query(params *QueryParams) (interface{}, error) {
 
 	defer params.Store.Close(txn)
 
-	// TODO(tsandall): once set literals are supported this code path can be
-	// replaced with a call to Eval that assigns the path to a variable.
-	if node := params.Compiler.GetRulesExact(ref); node != nil {
-		if len(node) == 0 {
-			return Undefined{}, nil
-		}
-		// This assumes that all the rules identified by the path are of the same
-		// type.
-		// TODO(tsandall): enforce at compile time.
-		switch node[0].DocKind() {
-		case ast.CompleteDoc:
-			return queryCompleteDoc(params, txn, node)
-		case ast.PartialObjectDoc:
-			return queryPartialObjectDoc(params, txn, node)
+	// TODO(tsandall): set literals: once they are supported, this special case can
+	// be removed.
+	if rs := params.Compiler.GetRulesExact(ref); rs != nil {
+		switch rs[0].DocKind() {
 		case ast.PartialSetDoc:
-			return queryPartialSetDoc(params, txn, node)
-		default:
-			return nil, fmt.Errorf("illegal document type %T: %v", node[0].DocKind(), ref)
+			return queryPartialSetDoc(params, txn, rs)
 		}
 	}
 
-	query := ast.Body{
-		&ast.Expr{
-			Terms: &ast.Term{
-				Value: ref,
-			},
-		},
-	}
-
+	// Construct and execute a query to obtain the value for the reference.
+	query := ast.Body{ast.Equality.Expr(ast.RefTerm(ref...), ast.Wildcard)}
 	ctx := params.NewContext(query, txn)
-	var result interface{}
+	var result interface{} = Undefined{}
 
 	err = Eval(ctx, func(ctx *Context) error {
-		if ctx.Binding(ref) == nil {
-			result, err = ctx.Store.Read(txn, ref)
-			return err
-		}
-		val := PlugValue(ref, ctx)
+		val := PlugValue(ast.Wildcard.Value, ctx)
 		result, err = ValueToInterface(val, ctx)
 		return err
 	})
 
-	return result, err
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
 }
 
 // Undefined represents the absence of bindings that satisfy a completely defined rule.
@@ -646,10 +632,10 @@ func evalExpr(ctx *Context, iter Iterator) error {
 	}
 }
 
-// evalRef evaluates the ast.Ref ref and calls the Iterator iter once for each
-// instance of ref that would be defined. If an error occurs during the evaluation
-// process, the return value is non-nil. Also, if iter returns an error, the return
-// value is non-nil.
+// evalRef evaluates the reference and invokes the iterator for each instance of
+// the reference that is defined. The iterator is invoked with bindings for (1)
+// all variables found in the reference and (2) the reference itself if that
+// reference refers to a virtual document (ditto for nested references).
 func evalRef(ctx *Context, ref, path ast.Ref, iter Iterator) error {
 
 	if len(ref) == 0 {
@@ -662,7 +648,7 @@ func evalRef(ctx *Context, ref, path ast.Ref, iter Iterator) error {
 			}
 			return evalRefRuleResult(ctx, path, path[1:], v, iter)
 		}
-		return evalRefRec(ctx, ast.Ref{path[0]}, path[1:], iter)
+		return evalRefRec(ctx, path, iter)
 	}
 
 	head, tail := ref[0], ref[1:]
@@ -673,103 +659,279 @@ func evalRef(ctx *Context, ref, path ast.Ref, iter Iterator) error {
 	}
 
 	return evalRef(ctx, n, ast.Ref{}, func(ctx *Context) error {
+
 		var undo *Undo
+
+		// Add a binding for the nested reference 'n' if one does not exist. If
+		// 'n' referred to a virtual document the binding would already exist.
+		// We bind nested references so that when the overall expression is
+		// evaluated, it will not contain any nested references.
 		if b := ctx.Binding(n); b == nil {
-			p := PlugValue(n, ctx).(ast.Ref)
-			v, err := lookupValue(ctx, p)
-			if err != nil {
-				return err
+			var err error
+			var v ast.Value
+			switch p := PlugValue(n, ctx).(type) {
+			case ast.Ref:
+				v, err = lookupValue(ctx, p)
+				if err != nil {
+					return err
+				}
+			default:
+				v = p
 			}
 			undo = ctx.Bind(n, v, nil)
 		}
+
 		tmp := append(path, head)
 		err := evalRef(ctx, tail, tmp, iter)
+
 		if undo != nil {
 			ctx.Unbind(undo)
 		}
+
 		return err
 	})
 }
 
-func evalRefRec(ctx *Context, path, tail ast.Ref, iter Iterator) error {
+func evalRefRec(ctx *Context, ref ast.Ref, iter Iterator) error {
 
-	if len(tail) == 0 {
-		ok, err := lookupExists(ctx, path)
-		if err == nil && ok {
-			return iter(ctx)
-		}
-		return err
+	// Obtain ground prefix of the reference.
+	var plugged ast.Ref
+	var prefix ast.Ref
+	switch v := PlugValue(ref, ctx).(type) {
+	case ast.Ref:
+		plugged = v
+		prefix = plugged.GroundPrefix()
+	default:
+		// Fast-path? TODO test case.
+		return iter(ctx)
 	}
 
-	if tail[0].IsGround() {
-		// Check if the node exists. If the node does not exist, stop.
-		// If the node exists and is a rule, evaluate the rule to produce a virtual doc.
-		// Otherwise, process the rest of the reference.
-		path = append(path, PlugTerm(tail[0], ctx))
-		rules := ctx.Compiler.GetRulesExact(path)
-
-		if rules != nil {
-			ref := append(path, tail[1:]...)
+	// Check if the prefix refers to a virtual document.
+	var rules []*ast.Rule
+	path := prefix
+	for len(path) > 0 {
+		if rules = ctx.Compiler.GetRulesExact(path); rules != nil {
 			return evalRefRule(ctx, ref, path, rules, iter)
 		}
-
-		return evalRefRec(ctx, path, tail[1:], iter)
+		path = path[:len(path)-1]
 	}
 
-	// Check if the variable has a binding.
-	// If there is a binding, process the rest of the reference normally.
-	// If there is no binding, enumerate the collection referred to by the path.
-	plugged := PlugTerm(tail[0], ctx)
-
-	if plugged.IsGround() {
-		path = append(path, plugged)
-		return evalRefRec(ctx, path, tail[1:], iter)
+	if len(prefix) == len(ref) {
+		return evalRefRecGround(ctx, ref, prefix, iter)
 	}
 
-	return evalRefRecWalkColl(ctx, path, tail, iter)
+	return evalRefRecNonGround(ctx, ref, prefix, iter)
 }
 
-func evalRefRecWalkColl(ctx *Context, path, tail ast.Ref, iter Iterator) error {
+// evalRefRecGround evaluates the ground reference prefix. The reference is
+// processed to decide whether evaluation should continue. If the reference
+// refers to one or more virtual documents, then all of the referenced documents
+// (i.e., base and virtual documents) are merged and the ref is bound to the
+// result before continuing.
+func evalRefRecGround(ctx *Context, ref, prefix ast.Ref, iter Iterator) error {
 
-	node, err := ctx.Store.Read(ctx.txn, path)
-	if err != nil {
-		if storage.IsNotFound(err) {
+	doc, readErr := ctx.Store.Read(ctx.txn, prefix)
+	if readErr != nil {
+		if !storage.IsNotFound(readErr) {
+			return readErr
+		}
+	}
+
+	node := ctx.Compiler.RuleTree
+	for _, x := range prefix {
+		node = node.Children[x.Value]
+		if node == nil {
+			break
+		}
+	}
+
+	// If the reference does not refer to any virtual docs, evaluation continues
+	// or stops depending on whether the reference is defined for some base doc.
+	// The same logic is applied below after attempting to produce virtual
+	// documents referred to by the reference.
+	if node == nil || node.Size() == 0 {
+		if storage.IsNotFound(readErr) {
 			return nil
 		}
+		return iter(ctx)
+	}
+
+	vdoc, err := evalRefRecTree(ctx, prefix, node)
+	if err != nil {
 		return err
 	}
 
-	head := tail[0].Value.(ast.Var)
-	tail = tail[1:]
-
-	switch node := node.(type) {
-	case map[string]interface{}:
-		for key := range node {
-			undo := ctx.Bind(head, ast.String(key), nil)
-			path = append(path, ast.StringTerm(key))
-			err := evalRefRec(ctx, path, tail, iter)
-			ctx.Unbind(undo)
-			if err != nil {
-				return err
-			}
-			path = path[:len(path)-1]
+	if vdoc == nil {
+		if storage.IsNotFound(readErr) {
+			return nil
 		}
-		return nil
-	case []interface{}:
-		for i := range node {
-			undo := ctx.Bind(head, ast.Number(i), nil)
-			path = append(path, ast.NumberTerm(float64(i)))
-			err := evalRefRec(ctx, path, tail, iter)
-			ctx.Unbind(undo)
-			if err != nil {
-				return err
-			}
-			path = path[:len(path)-1]
-		}
-		return nil
-	default:
-		return fmt.Errorf("non-collection document: %v", path)
+		return iter(ctx)
 	}
+
+	// The reference is defined for one or more virtual documents. Now merge the
+	// virtual and base documents together (if they exist) and continue.
+	result := vdoc
+	if readErr == nil {
+
+		v, err := ast.InterfaceToValue(doc)
+		if err != nil {
+			return err
+		}
+
+		// It should not be possible for the cast or merge to fail. The cast
+		// cannot fail because by definition, the document must be an object, as
+		// there are rules that have been evaluated and rules cannot be defined
+		// inside arrays. The merge cannot fail either, because that would
+		// indicate a conflict between a base document and a virtual document.
+		//
+		// TODO(tsandall): confirm that we have guards to prevent base and
+		// virtual documents from conflicting with each other.
+		result, _ = v.(ast.Object).Merge(result)
+	}
+
+	return Continue(ctx, ref, result, iter)
+}
+
+// evalRefRecTree evaluates the rules found in the leaves of the tree. For each
+// non-leaf node in the tree, the results are merged together to form an object.
+// The final result is the object representing the virtual document rooted at
+// node.
+func evalRefRecTree(ctx *Context, path ast.Ref, node *ast.RuleTreeNode) (ast.Object, error) {
+	var v ast.Object
+
+	for _, c := range node.Children {
+		path = append(path, &ast.Term{Value: c.Key})
+		if len(c.Rules) > 0 {
+			var result ast.Value
+			err := evalRefRule(ctx, path, path, c.Rules, func(ctx *Context) error {
+				result = ctx.Binding(path)
+				return nil
+			})
+			if err != nil {
+				// TODO(tsandall): consider treating unbound globals as undefined.
+				return nil, err
+			}
+			if result == nil {
+				continue
+			}
+			key := path[len(path)-1]
+			val := &ast.Term{Value: result}
+			obj := ast.Object{ast.Item(key, val)}
+			if v == nil {
+				v = ast.Object{}
+			}
+			v, _ = v.Merge(obj)
+		} else {
+			result, err := evalRefRecTree(ctx, path, c)
+			if err != nil {
+				return nil, err
+			}
+			if result == nil {
+				continue
+			}
+			key := &ast.Term{Value: c.Key}
+			val := &ast.Term{Value: result}
+			obj := ast.Object{ast.Item(key, val)}
+			if v == nil {
+				v = ast.Object{}
+			}
+			v, _ = v.Merge(obj)
+		}
+		path = path[:len(path)-1]
+	}
+
+	return v, nil
+}
+
+// evalRefRecNonGround processes the non-ground reference ref. The reference
+// is processed by enumerating values that may be used as keys for the next
+// (variable) term in the reference and then recursing on the reference.
+func evalRefRecNonGround(ctx *Context, ref, prefix ast.Ref, iter Iterator) error {
+
+	// Keep track of keys visited. The reference may refer to both virtual and
+	// base documents or virtual documents produced by disjunctive rules. In
+	// either case, we only want to visit each unique key once.
+	visited := map[ast.Value]struct{}{}
+
+	variable := ref[len(prefix)].Value
+
+	doc, err := ctx.Store.Read(ctx.txn, prefix)
+	if err != nil {
+		if !storage.IsNotFound(err) {
+			return err
+		}
+	}
+
+	if err == nil {
+		switch doc := doc.(type) {
+		case map[string]interface{}:
+			for k := range doc {
+				key := ast.String(k)
+				if _, ok := visited[key]; ok {
+					continue
+				}
+				undo := ctx.Bind(variable, key, nil)
+				err := evalRefRec(ctx, ref, iter)
+				ctx.Unbind(undo)
+				if err != nil {
+					return err
+				}
+				visited[key] = struct{}{}
+			}
+		case []interface{}:
+			for idx := range doc {
+				undo := ctx.Bind(variable, ast.Number(idx), nil)
+				err := evalRefRec(ctx, ref, iter)
+				ctx.Unbind(undo)
+				if err != nil {
+					return err
+				}
+			}
+			return nil
+		default:
+			return nil
+		}
+	}
+
+	node := ctx.Compiler.ModuleTree
+	for _, x := range prefix {
+		node = node.Children[x.Value]
+		if node == nil {
+			return nil
+		}
+	}
+
+	for _, mod := range node.Modules {
+		for _, rule := range mod.Rules {
+			key := ast.String(rule.Name)
+			if _, ok := visited[key]; ok {
+				continue
+			}
+			undo := ctx.Bind(variable, key, nil)
+			err := evalRefRec(ctx, ref, iter)
+			ctx.Unbind(undo)
+			if err != nil {
+				return err
+			}
+			visited[key] = struct{}{}
+		}
+	}
+
+	for child := range node.Children {
+		key := child.(ast.String)
+		if _, ok := visited[key]; ok {
+			continue
+		}
+		undo := ctx.Bind(variable, key, nil)
+		err := evalRefRec(ctx, ref, iter)
+		ctx.Unbind(undo)
+		if err != nil {
+			return err
+		}
+		visited[key] = struct{}{}
+	}
+
+	return nil
 }
 
 func evalRefRule(ctx *Context, ref ast.Ref, path ast.Ref, rules []*ast.Rule, iter Iterator) error {
@@ -1123,7 +1285,7 @@ func evalRefRuleResultRecObject(ctx *Context, obj ast.Object, ref, path ast.Ref,
 
 func evalRefRuleResultRecRef(ctx *Context, v, ref, path ast.Ref, iter func(*Context, ast.Value) error) error {
 	b := append(v, ref...)
-	return evalRefRec(ctx, v, ref, func(ctx *Context) error {
+	return evalRefRec(ctx, b, func(ctx *Context) error {
 		return iter(ctx, PlugValue(b, ctx))
 	})
 }
@@ -1406,73 +1568,6 @@ func lookupValue(ctx *Context, ref ast.Ref) (ast.Value, error) {
 		return nil, err
 	}
 	return ast.InterfaceToValue(r)
-}
-
-func queryCompleteDoc(params *QueryParams, txn storage.Transaction, rules []*ast.Rule) (interface{}, error) {
-
-	var result ast.Value
-	var resultContext *Context
-
-	for _, rule := range rules {
-		ctx := params.NewContext(rule.Body, txn)
-
-		err := Eval(ctx, func(ctx *Context) error {
-			if result == nil {
-				result = PlugValue(rule.Value.Value, ctx)
-			} else {
-				r := PlugValue(rule.Value.Value, ctx)
-				if !result.Equal(r) {
-					return conflictErr(params.Path, "complete documents", rule)
-				}
-			}
-			return nil
-		})
-
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	if result == nil {
-		return Undefined{}, nil
-	}
-
-	return ValueToInterface(result, resultContext)
-}
-
-func queryPartialObjectDoc(params *QueryParams, txn storage.Transaction, rules []*ast.Rule) (interface{}, error) {
-
-	result := map[string]interface{}{}
-	keys := map[string]struct{}{}
-
-	for _, rule := range rules {
-		ctx := params.NewContext(rule.Body, txn)
-		err := Eval(ctx, func(ctx *Context) error {
-			k, err := ValueToInterface(rule.Key.Value, ctx)
-			if err != nil {
-				return err
-			}
-			key, ok := k.(string)
-			if !ok {
-				return fmt.Errorf("illegal object key: %v", k)
-			}
-			if _, ok := keys[key]; ok {
-				return conflictErr(params.Path, "object document keys", rule)
-			}
-			value, err := ValueToInterface(rule.Value.Value, ctx)
-			if err != nil {
-				return err
-			}
-			keys[key] = struct{}{}
-			result[key] = value
-			return nil
-		})
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	return result, nil
 }
 
 func queryPartialSetDoc(params *QueryParams, txn storage.Transaction, rules []*ast.Rule) (interface{}, error) {

--- a/topdown/tracer_test.go
+++ b/topdown/tracer_test.go
@@ -31,12 +31,6 @@ func TestTracer(t *testing.T) {
 
 	store := storage.New(storage.InMemoryWithJSONConfig(loadSmallTestData()))
 
-	for id, mod := range compiler.Modules {
-		if err := storage.InsertPolicy(store, id, mod, nil, false); err != nil {
-			panic(err)
-		}
-	}
-
 	tracer := &mockTracer{[]string{}}
 
 	params := &QueryParams{

--- a/topdown/tracer_test.go
+++ b/topdown/tracer_test.go
@@ -24,14 +24,14 @@ func (t *mockTracer) Trace(ctx *Context, f string, a ...interface{}) {
 
 func TestTracer(t *testing.T) {
 
-	mods := compileRules([]string{"data.a"}, []string{
+	compiler := compileRules([]string{"data.a"}, []string{
 		"p[x] :- q[x] = y",
 		"q[i] = j :- a[i] = j",
 	})
 
 	store := storage.New(storage.InMemoryWithJSONConfig(loadSmallTestData()))
 
-	for id, mod := range mods {
+	for id, mod := range compiler.Modules {
 		if err := storage.InsertPolicy(store, id, mod, nil, false); err != nil {
 			panic(err)
 		}
@@ -40,10 +40,11 @@ func TestTracer(t *testing.T) {
 	tracer := &mockTracer{[]string{}}
 
 	params := &QueryParams{
-		Store:   store,
-		Globals: storage.NewBindings(),
-		Tracer:  tracer,
-		Path:    []interface{}{"p"}}
+		Compiler: compiler,
+		Store:    store,
+		Globals:  storage.NewBindings(),
+		Tracer:   tracer,
+		Path:     []interface{}{"p"}}
 
 	result, err := Query(params)
 	if err != nil {

--- a/util/test/subtest.go
+++ b/util/test/subtest.go
@@ -1,0 +1,14 @@
+// Copyright 2016 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+// +build !go1.7
+
+package test
+
+import "testing"
+
+// Subtest provides pre-1.7 backwards compatibility for sub-tests.
+func Subtest(t *testing.T, name string, f func(*testing.T)) {
+	f(t)
+}

--- a/util/test/subtest17.go
+++ b/util/test/subtest17.go
@@ -1,0 +1,14 @@
+// Copyright 2016 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+// +build go1.7
+
+package test
+
+import "testing"
+
+// Subtest executes a sub-test f under test t.
+func Subtest(t *testing.T, name string, f func(*testing.T)) {
+	t.Run(name, f)
+}


### PR DESCRIPTION
...again, sorry for the size of this...

The main change is in 8646239a73ef9f7e53a663f25fec32962db84048. It is the improvement to query evaluation to better handle refs. Specifically:

- support iterating over virtual documents.
- support referring to base AND virtual documents with a single ref.
- avoid accessing storage eagerly while evaluating refs.

The other large-ish change here is the removal of rules from built-in store. Previously, topdown would only see rules if they were installed into the built-in store. Now, topdown obtains rules from the compiler. To assist this, there's a new tree data structure (RuleTree) exposed on the compiler. I made this change because (1) topdown will come to depend on compile/analysis-time data structures soon; at that point, rules will be available from two places (and I would rather not duplicate state) (2) it simplifies example code that shows how to use OPA as a library (3) if/when we eventually support other stores (e.g., etcd) the storage layer will not have to worry about handling rule objects (i.e., it will only have to deal with JSON docs).