### PR TITLE
Update QueryParams to include Transaction

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -237,7 +237,16 @@ func (s *Server) v1DataGet(w http.ResponseWriter, r *http.Request) {
 		handleError(w, 400, err)
 		return
 	}
-	params := topdown.NewQueryParams(s.getCompiler(), s.store, globals, path)
+
+	txn, err := s.store.NewTransaction()
+	if err != nil {
+		handleErrorAuto(w, err)
+		return
+	}
+
+	defer s.store.Close(txn)
+
+	params := topdown.NewQueryParams(s.getCompiler(), s.store, txn, globals, path)
 
 	result, err := topdown.Query(params)
 

--- a/test/scheduler/scheduler_test.go
+++ b/test/scheduler/scheduler_test.go
@@ -18,7 +18,10 @@ import (
 
 func TestScheduler(t *testing.T) {
 	params := setup(t, "data_10nodes_30pods.json")
+	defer params.Store.Close(params.Transaction)
+
 	r, err := topdown.Query(params)
+
 	if err != nil {
 		t.Fatal("unexpected error:", err)
 	}
@@ -55,7 +58,8 @@ func setup(t *testing.T, filename string) *topdown.QueryParams {
 	req := ast.MustParseTerm(requestedPod).Value
 	globals.Put(ast.Var("requested_pod"), req)
 	path := []interface{}{"opa", "test", "scheduler", "fit"}
-	params := topdown.NewQueryParams(c, store, globals, path)
+	txn := storage.NewTransactionOrDie(store)
+	params := topdown.NewQueryParams(c, store, txn, globals, path)
 
 	return params
 }

--- a/topdown/example_test.go
+++ b/topdown/example_test.go
@@ -92,11 +92,20 @@ func ExampleQuery() {
 	// Instantiate the policy engine's storage layer.
 	store := storage.New(storage.InMemoryConfig())
 
+	// Create a new transaction. Transactions allow the policy engine to
+	// evaluate the query over a consistent snapshot fo the storage layer.
+	txn, err := store.NewTransaction()
+	if err != nil {
+		// Handle error.
+	}
+
+	defer store.Close(txn)
+
 	// Prepare the query parameters. Queries execute against the policy engine's storage and can
 	// accept additional documents (which are referred to as "globals"). In this case we have no
 	// additional documents.
 	globals := storage.NewBindings()
-	params := topdown.NewQueryParams(compiler, store, globals, []interface{}{"opa", "example", "p"})
+	params := topdown.NewQueryParams(compiler, store, txn, globals, []interface{}{"opa", "example", "p"})
 
 	// Execute the query against "p".
 	v1, err1 := topdown.Query(params)

--- a/topdown/topdown_test.go
+++ b/topdown/topdown_test.go
@@ -1383,10 +1383,13 @@ func assertTopDown(t *testing.T, compiler *ast.Compiler, store *storage.Storage,
 		p = append(p, x)
 	}
 
+	txn := storage.NewTransactionOrDie(store)
+	defer store.Close(txn)
+
 	testutil.Subtest(t, note, func(t *testing.T) {
 		switch e := expected.(type) {
 		case error:
-			result, err := Query(&QueryParams{Compiler: compiler, Store: store, Path: p, Globals: g})
+			result, err := Query(&QueryParams{Compiler: compiler, Store: store, Transaction: txn, Path: p, Globals: g})
 			if err == nil {
 				t.Errorf("Expected error but got: %v", result)
 				return
@@ -1396,7 +1399,7 @@ func assertTopDown(t *testing.T, compiler *ast.Compiler, store *storage.Storage,
 			}
 		case string:
 			expected := loadExpectedSortedResult(e)
-			result, err := Query(&QueryParams{Compiler: compiler, Store: store, Path: p, Globals: g})
+			result, err := Query(&QueryParams{Compiler: compiler, Store: store, Transaction: txn, Path: p, Globals: g})
 			if err != nil {
 				t.Errorf("Unexpected error: %v", err)
 				return

--- a/topdown/tracer_test.go
+++ b/topdown/tracer_test.go
@@ -30,15 +30,13 @@ func TestTracer(t *testing.T) {
 	})
 
 	store := storage.New(storage.InMemoryWithJSONConfig(loadSmallTestData()))
+	txn := storage.NewTransactionOrDie(store)
+	defer store.Close(txn)
 
 	tracer := &mockTracer{[]string{}}
 
-	params := &QueryParams{
-		Compiler: compiler,
-		Store:    store,
-		Globals:  storage.NewBindings(),
-		Tracer:   tracer,
-		Path:     []interface{}{"p"}}
+	params := NewQueryParams(compiler, store, txn, storage.NewBindings(), []interface{}{"p"})
+	params.Tracer = tracer
 
 	result, err := Query(params)
 	if err != nil {


### PR DESCRIPTION
Before, each topdown.Query call opened a new transaction. This was a bit too
simplistic. In some cases, callers may want to execute multiple topdown.Query
calls (without relying on topdown.Eval) or perform writes in the same
transaction. The scheduler POC expects the latter.