### PR TITLE
Initialize server compiler in New

### DIFF
--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -118,12 +118,17 @@ func (rt *Runtime) startServer(params *Params) {
 	glog.V(2).Infof("Server listening address: %v.", params.Addr)
 
 	persist := len(params.PolicyDir) > 0
-	s := server.New(rt.Store, params.Addr, persist)
+
+	s, err := server.New(rt.Store, params.Addr, persist)
+
+	if err != nil {
+		glog.Fatalf("Error creating server: %v", err)
+	}
+
 	s.Handler = NewLoggingHandler(s.Handler)
 
 	if err := s.Loop(); err != nil {
-		glog.Errorf("Server exiting: %v", err)
-		os.Exit(1)
+		glog.Fatalf("Server exiting: %v", err)
 	}
 }
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -548,7 +548,10 @@ type fixture struct {
 func newFixture(t *testing.T) *fixture {
 
 	store := storage.New(storage.InMemoryConfig().WithPolicyDir(policyDir))
-	server := New(store, ":8182", false)
+	server, err := New(store, ":8182", false)
+	if err != nil {
+		panic(err)
+	}
 	recorder := httptest.NewRecorder()
 
 	return &fixture{


### PR DESCRIPTION
Previously, the compiler was being created before calling into
http.ListenAndServe. This prevented users from obtaining the server's compiler
on startup.