### PR TITLE
Fix bug in ad-hoc query execution over HTTP

### DIFF
--- a/ast/compile.go
+++ b/ast/compile.go
@@ -207,35 +207,6 @@ func (c *Compiler) Compile(modules map[string]*Module) {
 	c.compile()
 }
 
-// CompileOne runs the compilation process on an input query.
-func (c *Compiler) CompileOne(query Body) (Body, error) {
-
-	key := string(Wildcard.Value.(Var))
-
-	mod := &Module{
-		Package: &Package{
-			Path:     Ref{DefaultRootDocument},
-			Location: query.Loc(),
-		},
-		Rules: []*Rule{
-			&Rule{
-				Name:     Var(key),
-				Body:     query,
-				Location: query.Loc(),
-			},
-		},
-	}
-
-	c.Modules[key] = mod
-	c.compile()
-
-	if c.Failed() {
-		return nil, c.Errors[0]
-	}
-
-	return c.Modules[key].Rules[0].Body, nil
-}
-
 // Failed returns true if a compilation error has been encountered.
 func (c *Compiler) Failed() bool {
 	return len(c.Errors) > 0

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -189,6 +189,11 @@ func TestDataV1(t *testing.T) {
 			tr{"PATCH", "/data/x", `[{"op": "add", "path": "/", "value": [1,2,3,4]}]`, 204, ""},
 			tr{"GET", "/query?q=data.x[_]%20=%20x", "", 200, `[{"x": 1}, {"x": 2}, {"x": 3}, {"x": 4}]`},
 		}},
+		{"query compiler error", []tr{
+			tr{"GET", "/query?q=x", "", 400, ""},
+			// Subsequent query should not fail.
+			tr{"GET", "/query?q=x=1", "", 200, `[{"x": 1}]`},
+		}},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
The server was using the cached compiler to compile ad-hoc queries. The
problem with this was that an invalid ad-hoc query would invalidate the
cached compiler (thus breaking subsequent use of it).

Since ad-hoc queries do not have to use the cached compiler, simply don't use
it. If ad-hoc queries need to make use of the cached compiler in the future,
we can change the compiler to not invalidate data structures, be immutable,
etc.