### PR TITLE
Remove undefined response from API

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -53,11 +53,6 @@ func IsWriteConflict(err error) bool {
 	return ok
 }
 
-// undefinedV1 models the an undefined query result.
-type undefinedV1 struct {
-	IsUndefined bool
-}
-
 // patchV1 models a single patch operation against a document.
 type patchV1 struct {
 	Op    string      `json:"op"`
@@ -259,7 +254,7 @@ func (s *Server) v1DataGet(w http.ResponseWriter, r *http.Request) {
 	pretty := getPretty(r.URL.Query()["pretty"])
 
 	if _, ok := result.(topdown.Undefined); ok {
-		handleResponseJSON(w, 404, undefinedV1{true}, pretty)
+		handleResponse(w, 404, nil)
 		return
 	}
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -178,7 +178,8 @@ func TestDataV1(t *testing.T) {
 		}},
 		{"get undefined", []tr{
 			tr{"PUT", "/policies/test", testMod1, 200, ""},
-			tr{"GET", "/data/testmod/undef", "", 404, `{"IsUndefined": true}`},
+			tr{"GET", "/data/testmod/undef", "", 404, ""},
+			tr{"GET", "/data/does/not/exist", "", 404, ""},
 		}},
 		{"get root", []tr{
 			tr{"PUT", "/policies/test", testMod2, 200, ""},

--- a/site/documentation/references/rest/index.md
+++ b/site/documentation/references/rest/index.md
@@ -1126,15 +1126,16 @@ Content-Type: application/json
 #### Status Codes
 
 - **200** - no error
+- **400** - bad request
 - **404** - not found
 - **500** - server error
 
+The server returns 400 if a global variable required for the query was not supplied.
+
 The server returns 404 in two cases:
 
-1. The path refers to a non-existent document.
-2. The path refers to a Virtual Document that is undefined at the time of the query.
-
-In the second case, the response body will contain an object indicating the document is undefined.
+- The path refers to a non-existent base document.
+- The path refers to a Virtual Document that is undefined in the context of the query.
 
 #### Example Module
 
@@ -1152,17 +1153,10 @@ allow_request :- flag = true
 GET /v1/data/opa/examples/allow_request?global=example.flag:false HTTP/1.1
 ```
 
-#### Example Response For Undefined Virtual Document
+#### Example Response For Non-Existent Or Undefined Document
 
 ```http
 HTTP/1.1 404 Not Found
-Content-Type: application/json
-```
-
-```json
-{
-  "IsUndefined": true
-}
 ```
 
 ### Create or Overwrite a Document
@@ -1193,13 +1187,13 @@ If-None-Match: *
 #### Example Response If Document Already Exists
 
 ```http
-HTTP/1.1 Not Modified 304
+HTTP/1.1 304 Not Modified
 ```
 
 #### Example Response If Document Does Not Exist
 
 ```http
-HTTP/1.1 No Content 204
+HTTP/1.1 204 No Content
 ```
 
 #### Status Codes

--- a/site/examples/docker-authorization/index.md
+++ b/site/examples/docker-authorization/index.md
@@ -82,7 +82,7 @@ OPA will run until it receives a signal to stop. Open another terminal to contin
 ### 4. Download the [open-policy-agent/docker-authz-plugin](https://github.com/open-policy-agent/docker-authz-plugin) executable.
 
 ```shell
-$ curl -L https://github.com/open-policy-agent/docker-authz-plugin/releases/download/v0.1.0/docker-authz-plugin_linux_amd64 > docker-authz-plugin
+$ curl -L https://github.com/open-policy-agent/docker-authz-plugin/releases/download/v0.1.1/docker-authz-plugin_linux_amd64 > docker-authz-plugin
 $ chmod u+x docker-authz-plugin
 ```
 


### PR DESCRIPTION
The commit message has the details, but essentially, the {"IsUndefined": true} response included in 404s for GET /data/... is no longer required and is just cruft at this point.

The Docker Authorization Plugin has been made compatible.