### PR TITLE
Fix panic on unhashable key type

### DIFF
--- a/ast/term.go
+++ b/ast/term.go
@@ -35,22 +35,23 @@ func NewLocation(text []byte, file string, row int, col int) *Location {
 // Errorf returns a new error value with a message formatted to include the location
 // info (e.g., line, column, filename, etc.)
 func (loc *Location) Errorf(f string, a ...interface{}) error {
-	return fmt.Errorf(loc.format(f), a...)
+	return errors.New(loc.Format(f, a...))
 }
 
 // Wrapf returns a new error value that wraps an existing error with a message formatted
 // to include the location info (e.g., line, column, filename, etc.)
 func (loc *Location) Wrapf(err error, f string, a ...interface{}) error {
-	return errors.Wrapf(err, loc.format(f), a...)
+	return errors.Wrap(err, loc.Format(f, a...))
 }
 
-func (loc *Location) format(f string) string {
+// Format returns a formatted string prefixed with the location information.
+func (loc *Location) Format(f string, a ...interface{}) string {
 	if len(loc.File) > 0 {
 		f = fmt.Sprintf("%v:%v: %v", loc.File, loc.Row, f)
 	} else {
 		f = fmt.Sprintf("%v:%v: %v", loc.Row, loc.Col, f)
 	}
-	return f
+	return fmt.Sprintf(f, a...)
 }
 
 // Value declares the common interface for all Term values. Every kind of Term value
@@ -203,6 +204,21 @@ func (term *Term) Vars() VarSet {
 	vis := &varVisitor{vars: VarSet{}}
 	Walk(vis, term)
 	return vis.vars
+}
+
+// IsScalar returns true if the AST value is a scalar.
+func IsScalar(v Value) bool {
+	switch v.(type) {
+	case String:
+		return true
+	case Number:
+		return true
+	case Boolean:
+		return true
+	case Null:
+		return true
+	}
+	return false
 }
 
 // Null represents the null value defined by JSON.

--- a/ast/term_test.go
+++ b/ast/term_test.go
@@ -182,6 +182,28 @@ func TestTermIsGround(t *testing.T) {
 
 }
 
+func TestIsScalar(t *testing.T) {
+
+	tests := []struct {
+		term     string
+		expected bool
+	}{
+		{"null", true},
+		{`"string"`, true},
+		{"3.14", true},
+		{"false", true},
+		{"[1,2,3]", false},
+		{`{"a": 1}`, false},
+		{`[x | x = 0]`, false},
+	}
+	for _, tc := range tests {
+		term := MustParseTerm(tc.term)
+		if IsScalar(term.Value) != tc.expected {
+			t.Errorf("Expected IsScalar(%v) = %v", term, tc.expected)
+		}
+	}
+}
+
 func TestTermString(t *testing.T) {
 	assertToString(t, Null{}, "null")
 	assertToString(t, Boolean(true), "true")


### PR DESCRIPTION
The cache that was added to the topdown implementation assumed rules
producing objects would always yield hashable/scalar keys. If the key was not
hashable, the cache lookup would cause a panic.

This change updates the topdown implementation to check the type of the object
key that was produced and return an intelligible error message if necessary.