### PR TITLE
Compare strings in value map test

### DIFF
--- a/ast/map_test.go
+++ b/ast/map_test.go
@@ -90,10 +90,9 @@ func TestValueMapString(t *testing.T) {
 	a.Put(MustParseRef("a.b.c[x]"), String("foo"))
 	a.Put(Var("x"), Number(1))
 	result := a.String()
-	term := MustParseTerm(result)
-	obj := term.Value.(Object)
-	expected := `{a.b.c[x]: "foo", x: 1}`
-	if !obj.Equal(MustParseTerm(expected).Value) {
-		t.Fatalf("Expected string to equal %v but got: %v", expected, result)
+	o1 := `{a.b.c[x]: "foo", x: 1}`
+	o2 := `{x: 1, a.b.c[x]: "foo"}`
+	if result != o1 && result != o2 {
+		t.Fatalf("Expected string to equal either %v or %v but got: %v", o1, o2, result)
 	}
 }


### PR DESCRIPTION
ast.Object.Equal is sensitive to ordering, so just compare result to both
possibilities.