### PR TITLE
Move versioning into Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@
 # Use of this source code is governed by an Apache2
 # license that can be found in the LICENSE file.
 
+VERSION := "0.1.1-dev"
+
 PACKAGES := \
 	github.com/open-policy-agent/opa/ast/.../ \
 	github.com/open-policy-agent/opa/cmd/.../ \
@@ -19,7 +21,8 @@ BUILD_COMMIT := $(shell ./build/get-build-commit.sh)
 BUILD_TIMESTAMP := $(shell ./build/get-build-timestamp.sh)
 BUILD_HOSTNAME := $(shell ./build/get-build-hostname.sh)
 
-LDFLAGS := "-X github.com/open-policy-agent/opa/version.Vcs=$(BUILD_COMMIT) \
+LDFLAGS := "-X github.com/open-policy-agent/opa/version.Version=$(VERSION) \
+	-X github.com/open-policy-agent/opa/version.Vcs=$(BUILD_COMMIT) \
 	-X github.com/open-policy-agent/opa/version.Timestamp=$(BUILD_TIMESTAMP) \
 	-X github.com/open-policy-agent/opa/version.Hostname=$(BUILD_HOSTNAME)"
 
@@ -30,7 +33,7 @@ CROSSCOMPILE ?=
 GO15VENDOREXPERIMENT := 1
 export GO15VENDOREXPERIMENT
 
-.PHONY: all deps generate build test cover check check-fmt check-vet check-lint fmt clean
+.PHONY: all deps generate build install test perf perf-regression cover check check-fmt check-vet check-lint fmt clean
 
 all: build test check
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -24,7 +24,7 @@ CHANGELOG.md snippet and uploading the packages from the build phase.
 
 1. Edit CHANGELOG.md to update the Unreleased header (e.g., s/Unreleased/0.12.8/) and add any missing items to prepare for release.
 
-1. Edit version/version.go to set Version variable to prepare for release (e.g., s/Version = “0.12.8-dev”/Version = "0.12.8”/).
+1. Edit Makefile to set VERSION variable to prepare for release (e.g., s/VERSION := “0.12.8-dev”/VERSION := "0.12.8”/).
 
 1. Commit the changes and push to remote repository.
 
@@ -42,7 +42,7 @@ CHANGELOG.md snippet and uploading the packages from the build phase.
 
 1. Edit CHANGELOG.md to add back the Unreleased header to prepare for development.
 
-1. Edit version/version.go to set Version variable to prepare for development (e.g., s/Version = “0.12.8”/Version = “0.12.9-dev”/).
+1. Edit Makefile to set VERSION variable to prepare for development (e.g., s/VERSION := “0.12.8”/VERSION = “0.12.9-dev”/).
 
 1. Commit the changes and push to remote repository.
 

--- a/version/version.go
+++ b/version/version.go
@@ -8,7 +8,7 @@ package version
 // Version information that is displayed by the "version" command and used to
 // identify the version of running instances of OPA.
 var (
-	Version   = "0.1.1-dev"
+	Version   = ""
 	Vcs       = ""
 	Timestamp = ""
 	Hostname  = ""


### PR DESCRIPTION
This will make it easier to version other artifacts (e.g., docker image,
documentation, etc.)

/cc @timothyhinrichs 