### PR TITLE
Fix performance regression script

### DIFF
--- a/build/run-perf-regression.sh
+++ b/build/run-perf-regression.sh
@@ -7,15 +7,12 @@ DEFAULT_N=10
 # This is the number of commits to run the benchmark on.
 N=${1:-$DEFAULT_N}
 
-# This is the commit that performance benchmarks were first added.
-# This script runs the performance benchmarks on the last N commits
-# between HEAD and EPOCH.
-EPOCH=52b6684a8c03efe51cd4e166b8b60e5197cb747d
+HEAD=$(git rev-parse HEAD)
+EPOCH=$(git rev-list $HEAD | tail -n 1)
 
 echo "commit,subject,author,timestamp,benchmark,runs,latency(ns)"
 
-for rev in $(git rev-list HEAD...${EPOCH} | head -n ${N} | xargs); do
-
+for rev in $(git rev-list ${EPOCH}..${HEAD} | head -n $N | xargs); do
     # Check out next revision to run benchmarks on.
     git checkout $rev 1>&2 2>/dev/null
     metadata=$(git log --format="%h,%s,%ae,%at" -1 $rev)


### PR DESCRIPTION
The build on Travis CI was succeeding even though the performance regression
was not running due to a bad git command.