### PR TITLE
Include location attribute on ast errors

### DIFF
--- a/ast/compile_test.go
+++ b/ast/compile_test.go
@@ -956,7 +956,7 @@ func getCompilerTestModules() map[string]*Module {
 	}
 }
 
-func compilerErrsToStringSlice(errors []error) []string {
+func compilerErrsToStringSlice(errors []*Error) []string {
 	result := []string{}
 	for _, e := range errors {
 		msg := strings.SplitN(e.Error(), ":", 3)[2]

--- a/ast/errors.go
+++ b/ast/errors.go
@@ -11,7 +11,7 @@ import (
 
 // Errors represents a series of errors encountered during parsing, compiling,
 // etc.
-type Errors []error
+type Errors []*Error
 
 func (e Errors) Error() string {
 
@@ -29,4 +29,51 @@ func (e Errors) Error() string {
 	}
 
 	return fmt.Sprintf("%d errors occurred:\n%s", len(e), strings.Join(s, "\n"))
+}
+
+// ErrCode defines the types of errors returned during parsing, compiling, etc.
+type ErrCode int
+
+const (
+	// ParseErr indicates an unclassified parse error occurred.
+	ParseErr = iota
+
+	// CompileErr indicates an unclassified compile error occurred.
+	CompileErr = iota
+
+	// UnsafeVarErr indicates an unsafe variable was found during compilation.
+	UnsafeVarErr = iota
+
+	// RecursionErr indicates recursion was found during compilation.
+	RecursionErr = iota
+)
+
+// Error represents a single error caught during parsing, compiling, etc.
+type Error struct {
+	Code     int
+	Location *Location
+	Message  string
+}
+
+func (e *Error) Error() string {
+	if e.Location == nil {
+		return e.Message
+	}
+
+	prefix := ""
+
+	if len(e.Location.File) > 0 {
+		prefix += e.Location.File + ":"
+	}
+
+	return fmt.Sprintf("%v%v:%v: %v", prefix, e.Location.Row, e.Location.Col, e.Message)
+}
+
+// NewError returns a new Error object.
+func NewError(code int, loc *Location, f string, a ...interface{}) *Error {
+	return &Error{
+		Code:     code,
+		Location: loc,
+		Message:  fmt.Sprintf(f, a...),
+	}
 }

--- a/ast/errors_test.go
+++ b/ast/errors_test.go
@@ -4,31 +4,28 @@
 
 package ast
 
-import (
-	"fmt"
-	"testing"
-)
+import "testing"
 
 func TestErrorsString(t *testing.T) {
 
 	err := Errors{
-		fmt.Errorf("test1"),
-		fmt.Errorf("test2"),
-		fmt.Errorf("test3"),
+		NewError(ParseErr, nil, "blah"),
+		NewError(ParseErr, NewLocation(nil, "", 100, 2), "bleh"),
+		NewError(ParseErr, NewLocation(nil, "foo.rego", 100, 2), "blarg"),
 	}
 
 	expected := `3 errors occurred:
-test1
-test2
-test3`
+blah
+100:2: bleh
+foo.rego:100:2: blarg`
 	result := err.Error()
 
 	if result != expected {
 		t.Errorf("Expected %v but got: %v", expected, result)
 	}
 
-	err = Errors{fmt.Errorf("testx")}
-	expected = `1 error occurred: testx`
+	err = Errors{NewError(ParseErr, nil, "blah")}
+	expected = `1 error occurred: blah`
 	result = err.Error()
 
 	if result != expected {

--- a/ast/term.go
+++ b/ast/term.go
@@ -21,7 +21,7 @@ import (
 
 // Location records a position in source code
 type Location struct {
-	Text []byte // The original text fragment from the source.
+	Text []byte `json:"-"` // The original text fragment from the source.
 	File string // The name of the source file (which may be empty).
 	Row  int    // The line in the source.
 	Col  int    // The column in the row.


### PR DESCRIPTION
Previously, errors returned by the parser and compiler would encode the
location information in the error string. Now, the location information is
structured and can be readily used by consumers.

/cc @timothyhinrichs @mikol 