### PR TITLE
Add Language Reference document

### DIFF
--- a/site/README.md
+++ b/site/README.md
@@ -2,9 +2,8 @@
 
 We use GitHub pages to host the website that includes all of the OPA documentation. In order to update the website, you need to have write permission on the open-policy-agent/opa repository.
 
-You also need to have [Jekyll](http://jekyllrb.com) installed to build the site. If you are not sure how to install Jekyll, see the link for details.
-
-Assuming you have Ruby installed, all you should need to do is run:
+You also need to have [Jekyll](http://jekyllrb.com) installed to build the site. The instructions below install it
+for you. Assuming you have Ruby installed, all you should need to do is run:
 
 ```
 gem install --user-install jekyll
@@ -14,7 +13,32 @@ gem install --user-install jekyll-contentblocks
 gem install --user-install jekyll-minifier
 ```
 
-To update the website perform the following steps:
+Changing the documentation on the live site requires two separate merges:
+
+1. Changes to documentation source files must be merged into the master branch.
+
+1. Website artifacts must be re-built and merged into the gh-pages branch.
+
+## Write and View Documentation Locally
+
+1. Start webserver on your local machine:
+
+    ```
+    cd opa/site
+    jekyll serve .
+    ```
+
+1. View docs in the browser.  After you make local changes, you can just refresh your browser to the latest version.
+
+    ```
+    http://localhost:4000/
+    ```
+
+Once you are happy with the changes, commit them and open a Pull Request against master.
+
+## Update Website Artifacts
+
+To update the live website, perform the following steps:
 
 1. Obtain a fresh copy of the repository
 
@@ -48,6 +72,4 @@ To update the website perform the following steps:
 
 ## REST API Examples
 
-The REST API specification contains examples that are generated manually by running
-`./_scripts/rest-examples/gen-examples.sh`. This script will launch OPA and
-execute a series of API calls to produce output can be copied into the specification.
+The REST API specification contains examples that are generated manually by running `./_scripts/rest-examples/gen-examples.sh`. This script will launch OPA and execute a series of API calls to produce output can be copied into the specification.

--- a/site/_assets/stylesheets/style.scss
+++ b/site/_assets/stylesheets/style.scss
@@ -315,8 +315,9 @@ strong {
 
   &--nav {
     bottom: 0;
+    float: left;
     left: -10px;
-    position: absolute;
+    position: relative;
     top: 0;
     width: 224px;
 
@@ -653,5 +654,20 @@ strong {
         content: "▼";
       }
     }
+  }
+}
+
+table {
+  border-collapse: collapse;
+
+  & td, & th {
+    border: solid 1px #ddd;
+
+    padding: 0.5em;
+    text-align: left;
+  }
+
+  & th {
+    font-weight: bold;
   }
 }

--- a/site/_includes/nav-documentation.html
+++ b/site/_includes/nav-documentation.html
@@ -12,6 +12,8 @@
       {% assign doc_rego = page %}
     {% when 'REST_API_VERSION_1' %}
       {% assign doc_rest = page %}
+    {% when 'LANGUAGE_REFERENCE' %}
+      {% assign doc_refer = page %}
   {% endcase %}
 {% endfor %}
 
@@ -25,6 +27,9 @@
     </li>
     <li class="opa-header--abstract--nav-item{% if page.doc_id == doc_rego.doc_id %}--selected{% endif %}">
       {% if page.doc_id != doc_rego.doc_id %}<a class="opa-header--abstract--nav-link" href="{{doc_rego.url}}">{{ doc_rego.title }}</a>{% else %}{{ doc_rego.title }}{% endif %}
+    </li>
+    <li class="opa-header--abstract--nav-item{% if page.doc_id == doc_refer.doc_id %}--selected{% endif %}">
+      {% if page.doc_id != doc_refer.doc_id %}<a class="opa-header--abstract--nav-link" href="{{doc_refer.url}}">{{ doc_refer.title }}</a>{% else %}{{ doc_refer.title }}{% endif %}
     </li>
     <li class="opa-header--abstract--nav-item{% if page.doc_id == doc_rest.doc_id %}--selected{% endif %}">
       {% if page.doc_id != doc_rest.doc_id %}<a class="opa-header--abstract--nav-link" href="{{doc_rest.url}}">{{ doc_rest.title }}</a>{% else %}{{ doc_rest.title }}{% endif %}

--- a/site/documentation/how-do-i-write-policies/index.md
+++ b/site/documentation/how-do-i-write-policies/index.md
@@ -176,7 +176,13 @@ undefined
 true
 ```
 
-If you made it this far, congratulations. This section introduced the main aspects of Rego. The rest of this document describes the individual aspects of Rego in detail and is useful as a reference when reading and writing policy. Rego’s syntax is defined at the end of this document in the [Rego Grammar](#grammar) section.
+If you made it this far, congratulations!
+
+This section introduced the main aspects of Rego. The rest of this document
+walks through each part of the language in more detail.
+
+For a concise reference, see the [Language
+Reference](/documentation/references/language) document.
 
 ## <a name="scalar-values"></a> Scalar Values
 
@@ -537,7 +543,7 @@ First, the rule defines a set document where the contents are defined by the var
 <name> <key>? <value>? <body>?
 ```
 
-For a more formal definition of the rule syntax, see the [Rego Grammar](#grammar) section at the end of this document.
+For a more formal definition of the rule syntax, see the [Language Reference](/documentation/references/language#grammar) document.
 
 > Set documents are collections of values without keys. OPA represents set documents as arrays when serializing to JSON or other formats which do not support a set data type. The important distinction between sets and arrays or objects is that sets are unkeyed while arrays and objects are keyed, i.e., you cannot refer to the index of an element within a set.
 {: .opa-tip}
@@ -754,88 +760,57 @@ Unlike the equality operator, these operators do not bind variables contained in
 
 ## <a name="built-ins"></a> Built-in Functions
 
-In some cases, rules must perform simple arithmetic, aggregation, and so son. Rego provides a number of built-in functions (or “built-ins”) for performing these tasks.
+In some cases, rules must perform simple arithmetic, aggregation, and so on.
+Rego provides a number of built-in functions (or “built-ins”) for performing
+these tasks.
 
-Built-ins can be easily recognized by their syntax. All built-ins have the following form:
+Built-ins can be easily recognized by their syntax. All built-ins have the
+following form:
 
 ```
 <name>(<arg-1>, <arg-2>, ..., <arg-n>)
 ```
 
-Built-ins usually take one or more input values and produce at least one output value. Unless stated otherwise, all built-ins accept values or variables as output arguments.
+Built-ins usually take one or more input values and produce at least one output
+value. Unless stated otherwise, all built-ins accept values or variables as
+output arguments.
+
+See the [Language Reference](/documentation/references/language) document for
+details on each built-in function.
 
 ### Arithmetic
 
 ```ruby
-# plus(a, b, output)
-#
-# Adds two numbers.
-
 > plus(1, 2, x)
 +---+
 | x |
 +---+
 | 3 |
 +---+
-```
-
-```ruby
-# minus(a, b, output)
-#
-# Subtracts two numbers.
-
 > minus(13, 5, x)
 +---+
 | x |
 +---+
 | 8 |
 +---+
-```
-
-```ruby
-# mul(a, b, output)
-#
-# Multiplies two numbers.
-
 > mul(2, 4, x)
 +---+
 | x |
 +---+
 | 8 |
 +---+
-```
-
-```ruby
-# div(a, b, output)
-#
-# Divides two numbers.
-
 > div(16, 4, x)
 +---+
 | x |
 +---+
 | 4 |
 +---+
-```
-
-```ruby
-# round(number, output)
-#
-# Rounds the number to its nearest integer value.
-
 > round(3.5, x)
 +---+
 | x |
 +---+
 | 4 |
 +---+
-```
-
-```ruby
-# abs(number, output)
-#
-# Calculates the absolute value of a number.
-
 > abs(-1, x)
 +---+
 | x |
@@ -847,37 +822,18 @@ Built-ins usually take one or more input values and produce at least one output 
 ### Aggregation
 
 ```ruby
-# count(scalar, output)
-#
-# Counts the number of elements in the array or object or the number of
-# characters in a string.
-
 > count([1,2,3], x)
 +---+
 | x |
 +---+
 | 3 |
 +---+
-```
-
-```ruby
-# sum(array, output)
-#
-# Sums the numbers in an array.
-
 > sum([1,2,3], x)
 +---+
 | x |
 +---+
 | 6 |
 +---+
-```
-
-```ruby
-# max(array, output)
-#
-# Calculates the maximum value in an array.
-
 > max([1,2,3], x)
 +---+
 | x |
@@ -889,10 +845,6 @@ Built-ins usually take one or more input values and produce at least one output 
 ### Casting
 
 ```ruby
-# to_number(scalar, output)
-#
-# Converts a scalar value to a number.
-
 > to_number("3.14", x)
 +------+
 |  x   |
@@ -904,10 +856,6 @@ Built-ins usually take one or more input values and produce at least one output 
 ### Regular Expressions
 
 ```ruby
-# re_match(pattern, value)
-#
-# Evaluates to true if value matches regular expression defined by pattern string.
-
 > pattern = "^us-west-1.*$"
 > re_match(pattern, "us-west-1.production")
 true
@@ -918,22 +866,12 @@ false
 ### Strings
 
 ```ruby
-# format_int(number, base, output)
-#
-# Returns the string representation of the number in the given base after converting it to an integer value.
-
 > format_int(15.5, 16, x)
 +-----+
 |  x  |
 +-----+
 | "f" |
 +-----+
-```
-
-```ruby
-# concat(join, array, output)
-#
-# Returns the string produced by concatenating the elements in array with the join string.
 > concat("/", ["", "foo", "bar", "baz"], x)
 +----------------+
 |       x        |
@@ -1028,53 +966,5 @@ containers = [
     }
 ]
 ```
-
-## <a name="grammar"></a> Rego Grammar
-
-Rego’s syntax is defined by the following grammar:
-
-```
-module         = package { import } policy
-package        = "package" ref
-import         = "import" package [ "as" var ]
-policy         = { rule }
-rule           = rule-head [ ":-" rule-body ]
-rule-head      = var [ "[" var "]" ] [ = term ]
-rule-body      = [ literal { "," literal } ]
-literal        = expr | "not" expr
-expr           = term | expr-builtin | expr-infix
-expr-builtin   = var "(" [ term { , term } ] ")"
-expr-infix     = term bool-operator term
-term           = ref | var | scalar | array | object | array-compr
-array-compr    = "[" term "|" rule-body "]"
-bool-operator  = "=" | "!=" | "<" | ">" | ">=" | "<="
-ref            = var { ref-arg }
-ref-arg        = ref-arg-dot | ref-arg-brack
-ref-arg-brack  = "[" ( scalar | var | "_" ) "]"
-ref-arg-dot    = "." var
-var            = ALPHA { ALPHA | DIGIT | "_" }
-scalar         = STRING | NUMBER | TRUE | FALSE | NULL
-array          = "[" term { "," term } "]"
-object         = "{" object-item { "," object-item } "}"
-object-item    = ( scalar | ref | var ) ":" term
-```
-{: .opa-collapse--ignore}
-
-The grammar defined above makes use of the following syntax. See [the Wikipedia page on EBNF](https://en.wikipedia.org/wiki/Extended_Backus–Naur_Form) for more details:
-
-```
-[]     optional (zero or one instances)
-{}     repetition (zero or more instances)
-|      alteration (one of the instances)
-()     grouping (order of expansion)
-STRING JSON string
-NUMBER JSON number
-TRUE   JSON true
-FALSE  JSON false
-NULL   JSON null
-ALPHA  ASCII characters A-Z and a-z
-DIGIT  ASCII characters 0-9
-```
-{: .opa-collapse--ignore}
 
 {% endcontentfor %}

--- a/site/documentation/references/language/index.md
+++ b/site/documentation/references/language/index.md
@@ -1,0 +1,118 @@
+---
+nav_id: MAIN_DOCUMENTATION
+doc_id: LANGUAGE_REFERENCE
+layout: documentation
+
+title: Language Reference
+---
+
+{% contentfor header %}
+
+
+# Language Reference
+
+This document is the authoritative specification of the Rego policy language
+(V1). All policies in OPA are written in Rego.
+
+{% endcontentfor %}
+
+{% contentfor body %}
+
+## Built-in Functions
+
+The built-in functions for the language provide basic operations to manipulate
+scalar values (e.g. numbers and strings), and aggregate functions that summarize
+complex types.
+
+### Inequality
+
+| Built-in | Inputs | Description |
+| ------- |--------|-------------|
+| ``x != y``   |  2     | x is not equal to y |
+| ``x < y``   |  2     | x is less than y |
+| ``x <= y``   |  2     | x is less than or equal to y |
+| ``x > y``   |  2     | x is greater than y |
+| ``x >= y``   |  2     | x is greater than or equal to y |
+
+### Numbers
+
+| Built-in | Inputs | Description |
+| ------- |--------|-------------|
+| ``plus(x, y, output)``   |  2     | x + y = output |
+| ``minus(x, y, output)``  |  2     | x - y = output |
+| ``mul(x, y, output)``   |  2     | x * y = output |
+| ``div(x, y, output)``   |  2     | x / y = output |
+| ``round(x, output)``    |  1     | output is x rounded to the nearest integer |
+| ``abs(x, output)``    |  1     | output is the absolute value of x |
+
+### Aggregates
+
+| Built-in | Inputs | Description |
+| ------- |--------|-------------|
+| ``count(collection, output)`` | 1 | output is the length of the object, array, or set |
+| ``sum(array, output)`` | 1 | output is the sum of the numbers in array |
+| ``max(array, output)`` | 1 | output is the maximum value in the array |
+
+### Types
+
+| Built-in | Inputs | Description |
+| ------- |--------|-------------|
+| ``to_number(x, output)`` | 1 | output is x converted to a number |
+
+### Strings
+
+| Built-in | Inputs | Description |
+| ------- |--------|-------------|
+| <span class="opa-keep-it-together">``format_int(number, base, output)``</span> | 2 | output is string representation of number in given base |
+| ``concat(join, array, output)`` | 2 | output is the result of concatenating the elements of array with the join string |
+|``re_match(pattern, value)`` | 2 | true if the value matches the pattern |
+
+## <a name="grammar"></a> Grammar
+
+Rego’s syntax is defined by the following grammar:
+
+```
+module         = package { import } policy
+package        = "package" ref
+import         = "import" package [ "as" var ]
+policy         = { rule }
+rule           = rule-head [ ":-" rule-body ]
+rule-head      = var [ "[" term "]" ] [ = term ]
+rule-body      = [ literal { "," literal } ]
+literal        = expr | "not" expr
+expr           = term | expr-built-in | expr-infix
+expr-built-in  = var "(" [ term { , term } ] ")"
+expr-infix     = term bool-operator term
+term           = ref | var | scalar | array | object | array-compr
+array-compr    = "[" term "|" rule-body "]"
+bool-operator  = "=" | "!=" | "<" | ">" | ">=" | "<="
+ref            = var { ref-arg }
+ref-arg        = ref-arg-dot | ref-arg-brack
+ref-arg-brack  = "[" ( scalar | var | "_" ) "]"
+ref-arg-dot    = "." var
+var            = ( ALPHA | "_" ) { ALPHA | DIGIT | "_" }
+scalar         = STRING | NUMBER | TRUE | FALSE | NULL
+array          = "[" term { "," term } "]"
+object         = "{" object-item { "," object-item } "}"
+object-item    = ( scalar | ref | var ) ":" term
+```
+{: .opa-collapse--ignore}
+
+The grammar defined above makes use of the following syntax. See [the Wikipedia page on EBNF](https://en.wikipedia.org/wiki/Extended_Backus–Naur_Form) for more details:
+
+```
+[]     optional (zero or one instances)
+{}     repetition (zero or more instances)
+|      alteration (one of the instances)
+()     grouping (order of expansion)
+STRING JSON string
+NUMBER JSON number
+TRUE   JSON true
+FALSE  JSON false
+NULL   JSON null
+ALPHA  ASCII characters A-Z and a-z
+DIGIT  ASCII characters 0-9
+```
+{: .opa-collapse--ignore}
+
+{% endcontentfor %}


### PR DESCRIPTION
This is intended to be a concise reference for Rego. Details about built-in
functions and the grammar have been moved out of the How Do I Write Policies
document (into the Language Reference document).

Also, update site/README.md with local development steps.