### PR TITLE
Add support for set literals

### DIFF
--- a/ast/compare.go
+++ b/ast/compare.go
@@ -1,0 +1,279 @@
+// Copyright 2016 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package ast
+
+import (
+	"fmt"
+	"sort"
+)
+
+// Compare returns an integer indicating whether two AST values are less than,
+// equal to, or greater than each other.
+//
+// If a is less than b, the return value is negative. If a is greater than b,
+// the return value is positive. If a is equal to b, the return value is zero.
+//
+// Different types are never equal to each other. For comparison purposes, types
+// are sorted as follows:
+//
+// nil < Null < Boolean < Number < String < Var < Ref < Array < Object < Set <
+// ArrayComprehension < Expr < Body < Rule < Import < Package < Module.
+//
+// Arrays and Refs are equal iff both a and b have the same length and all
+// corresponding elements are equal. If one element is not equal, the return
+// value is the same as for the first differing element. If all elements are
+// equal but a and b have different lengths, the shorter is considered less than
+// the other.
+//
+// Objects are considered equal iff both a and b have the same sorted (key,
+// value) pairs and are of the same length. Other comparisons are consistent but
+// not defined.
+//
+// Sets are considered equal iff the symmetric difference of a and b is empty.
+// Other comparisons are consistent but not defined.
+func Compare(a, b interface{}) int {
+
+	if t, ok := a.(*Term); ok {
+		if t == nil {
+			return Compare(nil, b)
+		}
+		return Compare(t.Value, b)
+	}
+
+	if t, ok := b.(*Term); ok {
+		if t == nil {
+			return Compare(a, nil)
+		}
+		return Compare(a, t.Value)
+	}
+
+	if a == nil {
+		if b == nil {
+			return 0
+		}
+		return -1
+	}
+	if b == nil {
+		return 1
+	}
+
+	sortA := sortOrder(a)
+	sortB := sortOrder(b)
+
+	if sortA < sortB {
+		return -1
+	} else if sortB < sortA {
+		return 1
+	}
+
+	switch a := a.(type) {
+	case Null:
+		return 0
+	case Boolean:
+		b := b.(Boolean)
+		if a.Equal(b) {
+			return 0
+		}
+		if !a {
+			return -1
+		}
+		return 1
+	case Number:
+		b := b.(Number)
+		if a.Equal(b) {
+			return 0
+		}
+		if a < b {
+			return -1
+		}
+		return 1
+	case String:
+		b := b.(String)
+		if a.Equal(b) {
+			return 0
+		}
+		if a < b {
+			return -1
+		}
+		return 1
+	case Var:
+		b := b.(Var)
+		if a.Equal(b) {
+			return 0
+		}
+		if a < b {
+			return -1
+		}
+		return 1
+	case Ref:
+		b := b.(Ref)
+		return termSliceCompare(a, b)
+	case Array:
+		b := b.(Array)
+		return termSliceCompare(a, b)
+	case Object:
+		b := b.(Object)
+		keysA := a.Keys()
+		keysB := b.Keys()
+		sort.Sort(termSlice(keysA))
+		sort.Sort(termSlice(keysB))
+		minLen := len(a)
+		if len(b) < len(a) {
+			minLen = len(b)
+		}
+		for i := 0; i < minLen; i++ {
+			keysCmp := Compare(keysA[i], keysB[i])
+			if keysCmp < 0 {
+				return -1
+			}
+			if keysCmp > 0 {
+				return 1
+			}
+			valA := a.Get(keysA[i])
+			valB := b.Get(keysB[i])
+			valCmp := Compare(valA, valB)
+			if valCmp != 0 {
+				return valCmp
+			}
+		}
+		if len(a) < len(b) {
+			return -1
+		}
+		if len(b) < len(a) {
+			return 1
+		}
+		return 0
+	case *Set:
+		b := b.(*Set)
+		sort.Sort(termSlice(*a))
+		sort.Sort(termSlice(*b))
+		return termSliceCompare(*a, *b)
+	case *ArrayComprehension:
+		b := b.(*ArrayComprehension)
+		if cmp := Compare(a.Term, b.Term); cmp != 0 {
+			return cmp
+		}
+		return Compare(a.Body, b.Body)
+	case *Expr:
+		b := b.(*Expr)
+		return a.Compare(b)
+	case Body:
+		b := b.(Body)
+		return a.Compare(b)
+	case *Rule:
+		b := b.(*Rule)
+		return a.Compare(b)
+	case *Import:
+		b := b.(*Import)
+		return a.Compare(b)
+	case *Package:
+		b := b.(*Package)
+		return a.Compare(b)
+	case *Module:
+		b := b.(*Module)
+		return a.Compare(b)
+	}
+	panic(fmt.Sprintf("illegal value: %T", a))
+}
+
+type termSlice []*Term
+
+func (s termSlice) Less(i, j int) bool { return Compare(s[i].Value, s[j].Value) < 0 }
+func (s termSlice) Swap(i, j int)      { x := s[i]; s[i] = s[j]; s[j] = x }
+func (s termSlice) Len() int           { return len(s) }
+
+func sortOrder(x interface{}) int {
+	switch x.(type) {
+	case Null:
+		return 0
+	case Boolean:
+		return 1
+	case Number:
+		return 2
+	case String:
+		return 3
+	case Var:
+		return 4
+	case Ref:
+		return 5
+	case Array:
+		return 6
+	case Object:
+		return 7
+	case *Set:
+		return 8
+	case *ArrayComprehension:
+		return 9
+	case *Expr:
+		return 100
+	case Body:
+		return 200
+	case *Rule:
+		return 1000
+	case *Import:
+		return 1001
+	case *Package:
+		return 1002
+	case *Module:
+		return 10000
+	}
+	panic(fmt.Sprintf("illegal value: %T", x))
+}
+
+func importsCompare(a, b []*Import) int {
+	minLen := len(a)
+	if len(b) < minLen {
+		minLen = len(b)
+	}
+	for i := 0; i < minLen; i++ {
+		if cmp := a[i].Compare(b[i]); cmp != 0 {
+			return cmp
+		}
+	}
+	if len(a) < len(b) {
+		return -1
+	}
+	if len(b) < len(a) {
+		return 1
+	}
+	return 0
+}
+
+func rulesCompare(a, b []*Rule) int {
+	minLen := len(a)
+	if len(b) < minLen {
+		minLen = len(b)
+	}
+	for i := 0; i < minLen; i++ {
+		if cmp := a[i].Compare(b[i]); cmp != 0 {
+			return cmp
+		}
+	}
+	if len(a) < len(b) {
+		return -1
+	}
+	if len(b) < len(a) {
+		return 1
+	}
+	return 0
+}
+
+func termSliceCompare(a, b []*Term) int {
+	minLen := len(a)
+	if len(b) < minLen {
+		minLen = len(b)
+	}
+	for i := 0; i < minLen; i++ {
+		if cmp := Compare(a[i], b[i]); cmp != 0 {
+			return cmp
+		}
+	}
+	if len(a) < len(b) {
+		return -1
+	} else if len(b) < len(a) {
+		return 1
+	}
+	return 0
+}

--- a/ast/compare_test.go
+++ b/ast/compare_test.go
@@ -1,0 +1,79 @@
+// Copyright 2016 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package ast
+
+import "testing"
+
+func TestCompare(t *testing.T) {
+
+	// Many of the comparison cases are covered by existing equality tests. Here
+	// we cover edge cases.
+	tests := []struct {
+		a        string
+		b        string
+		expected int
+	}{
+		// Comparisons to Go nil. Everything is greater than nil and nil is equal to nil
+		{"null", "", 1},
+		{"", "null", -1},
+		{"", "", 0},
+
+		// Booleans
+		{"false", "true", -1},
+		{"true", "false", 1},
+
+		// Object comparisons are consistent
+		{`{1: 2, 3: 4}`, `{4: 3, 1: 2}`, -1},
+		{`{1: 2, 3: 4}`, `{1: 2, 4: 3}`, -1},
+		{`{1: 2, 3: 4}`, `{1: 2, 3: 5}`, -1},
+		{`{1: 2, 3: 4}`, `{1: 2, 3: 4, 5: 6}`, -1},
+		{`{1: 2, 3: 4, 5: 6}`, `{1: 2, 3: 4}`, 1},
+
+		// Array comprehensions
+		{`[ null | true ]`, `[ false | null ]`, -1},
+
+		// Expressions
+		{`a = b`, `b = a`, -1},
+		{`b = a`, `not a = b`, -1},
+		{`a = b`, `x`, 1},
+
+		// Body
+		{`a = b`, `a = b, b = a`, -1},
+		{`a = b, b = a`, `a = b`, 1},
+	}
+	for _, tc := range tests {
+		var a, b interface{}
+		if len(tc.a) > 0 {
+			a = MustParseStatement(tc.a)
+		}
+		if len(tc.b) > 0 {
+			b = MustParseStatement(tc.b)
+		}
+		result := Compare(a, b)
+		if tc.expected != result {
+			t.Errorf("Expected %v.Compare(%v) == %v but got %v", a, b, tc.expected, result)
+		}
+	}
+}
+
+func TestCompareModule(t *testing.T) {
+	a := MustParseModule(`package a.b.c`)
+	b := MustParseModule(`package a.b.d`)
+	result := Compare(a, b)
+
+	if result != -1 {
+		t.Errorf("Expected %v to be less than %v but got: %v", a, b, result)
+	}
+
+	a = MustParseModule(`package a.b.c
+    import x.y`)
+	b = MustParseModule(`package a.b.c
+    import x.z`)
+	result = Compare(a, b)
+
+	if result != -1 {
+		t.Errorf("Expected %v to be less than %v but got: %v", a, b, result)
+	}
+}

--- a/ast/compile.go
+++ b/ast/compile.go
@@ -627,6 +627,15 @@ func (c *Compiler) resolveRefsInTerm(globals map[Var]Value, term *Term) *Term {
 		cpy := *term
 		cpy.Value = a
 		return &cpy
+	case *Set:
+		s := &Set{}
+		for _, e := range *v {
+			x := c.resolveRefsInTerm(globals, e)
+			s.Add(x)
+		}
+		cpy := *term
+		cpy.Value = s
+		return &cpy
 	case *ArrayComprehension:
 		ac := &ArrayComprehension{}
 		ac.Term = c.resolveRefsInTerm(globals, v.Term)

--- a/ast/compile_test.go
+++ b/ast/compile_test.go
@@ -410,7 +410,7 @@ func TestCompilerResolveAllRefs(t *testing.T) {
 	mod3 := c.Modules["mod3"]
 	expr4 := mod3.Rules[0].Body[0]
 	term = expr4.Terms.([]*Term)[2]
-	e = MustParseTerm("{x.secret: [x.keyid]}")
+	e = MustParseTerm("{x.secret: [{x.keyid}]}")
 	if !term.Equal(e) {
 		t.Errorf("Wrong term (nested refs): expected %v but got: %v", e, term)
 	}
@@ -833,7 +833,7 @@ func getCompilerTestModules() map[string]*Module {
 	package a.b.d
 	import req
 	import x as y
-	t = true :- req = {y.secret: [y.keyid]}
+	t = true :- req = {y.secret: [{y.keyid}]}
 	x = false :- true
 	`)
 

--- a/ast/parser.go
+++ b/ast/parser.go
@@ -585,63 +585,80 @@ var g = &grammar{
 		{
 			name: "PrefixExpr",
 			pos:  position{line: 194, col: 1, offset: 5955},
-			expr: &actionExpr{
+			expr: &choiceExpr{
 				pos: position{line: 194, col: 15, offset: 5969},
-				run: (*parser).callonPrefixExpr1,
+				alternatives: []interface{}{
+					&ruleRefExpr{
+						pos:  position{line: 194, col: 15, offset: 5969},
+						name: "SetEmpty",
+					},
+					&ruleRefExpr{
+						pos:  position{line: 194, col: 26, offset: 5980},
+						name: "Builtin",
+					},
+				},
+			},
+		},
+		{
+			name: "Builtin",
+			pos:  position{line: 196, col: 1, offset: 5989},
+			expr: &actionExpr{
+				pos: position{line: 196, col: 12, offset: 6000},
+				run: (*parser).callonBuiltin1,
 				expr: &seqExpr{
-					pos: position{line: 194, col: 15, offset: 5969},
+					pos: position{line: 196, col: 12, offset: 6000},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 194, col: 15, offset: 5969},
+							pos:   position{line: 196, col: 12, offset: 6000},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 194, col: 18, offset: 5972},
+								pos:  position{line: 196, col: 15, offset: 6003},
 								name: "Var",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 194, col: 22, offset: 5976},
+							pos:        position{line: 196, col: 19, offset: 6007},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 194, col: 26, offset: 5980},
+							pos:  position{line: 196, col: 23, offset: 6011},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 194, col: 28, offset: 5982},
+							pos:   position{line: 196, col: 25, offset: 6013},
 							label: "head",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 194, col: 33, offset: 5987},
+								pos: position{line: 196, col: 30, offset: 6018},
 								expr: &ruleRefExpr{
-									pos:  position{line: 194, col: 33, offset: 5987},
+									pos:  position{line: 196, col: 30, offset: 6018},
 									name: "Term",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 194, col: 39, offset: 5993},
+							pos:   position{line: 196, col: 36, offset: 6024},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 194, col: 44, offset: 5998},
+								pos: position{line: 196, col: 41, offset: 6029},
 								expr: &seqExpr{
-									pos: position{line: 194, col: 46, offset: 6000},
+									pos: position{line: 196, col: 43, offset: 6031},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 194, col: 46, offset: 6000},
+											pos:  position{line: 196, col: 43, offset: 6031},
 											name: "_",
 										},
 										&litMatcher{
-											pos:        position{line: 194, col: 48, offset: 6002},
+											pos:        position{line: 196, col: 45, offset: 6033},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 194, col: 52, offset: 6006},
+											pos:  position{line: 196, col: 49, offset: 6037},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 194, col: 54, offset: 6008},
+											pos:  position{line: 196, col: 51, offset: 6039},
 											name: "Term",
 										},
 									},
@@ -649,11 +666,11 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 194, col: 62, offset: 6016},
+							pos:  position{line: 196, col: 59, offset: 6047},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 194, col: 65, offset: 6019},
+							pos:        position{line: 196, col: 62, offset: 6050},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -663,34 +680,34 @@ var g = &grammar{
 		},
 		{
 			name: "Term",
-			pos:  position{line: 210, col: 1, offset: 6421},
+			pos:  position{line: 212, col: 1, offset: 6452},
 			expr: &actionExpr{
-				pos: position{line: 210, col: 9, offset: 6429},
+				pos: position{line: 212, col: 9, offset: 6460},
 				run: (*parser).callonTerm1,
 				expr: &labeledExpr{
-					pos:   position{line: 210, col: 9, offset: 6429},
+					pos:   position{line: 212, col: 9, offset: 6460},
 					label: "val",
 					expr: &choiceExpr{
-						pos: position{line: 210, col: 15, offset: 6435},
+						pos: position{line: 212, col: 15, offset: 6466},
 						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 210, col: 15, offset: 6435},
+								pos:  position{line: 212, col: 15, offset: 6466},
 								name: "Comprehension",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 210, col: 31, offset: 6451},
+								pos:  position{line: 212, col: 31, offset: 6482},
 								name: "Composite",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 210, col: 43, offset: 6463},
+								pos:  position{line: 212, col: 43, offset: 6494},
 								name: "Scalar",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 210, col: 52, offset: 6472},
+								pos:  position{line: 212, col: 52, offset: 6503},
 								name: "Ref",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 210, col: 58, offset: 6478},
+								pos:  position{line: 212, col: 58, offset: 6509},
 								name: "Var",
 							},
 						},
@@ -700,65 +717,65 @@ var g = &grammar{
 		},
 		{
 			name: "Comprehension",
-			pos:  position{line: 214, col: 1, offset: 6509},
+			pos:  position{line: 216, col: 1, offset: 6540},
 			expr: &ruleRefExpr{
-				pos:  position{line: 214, col: 18, offset: 6526},
+				pos:  position{line: 216, col: 18, offset: 6557},
 				name: "ArrayComprehension",
 			},
 		},
 		{
 			name: "ArrayComprehension",
-			pos:  position{line: 216, col: 1, offset: 6546},
+			pos:  position{line: 218, col: 1, offset: 6577},
 			expr: &actionExpr{
-				pos: position{line: 216, col: 23, offset: 6568},
+				pos: position{line: 218, col: 23, offset: 6599},
 				run: (*parser).callonArrayComprehension1,
 				expr: &seqExpr{
-					pos: position{line: 216, col: 23, offset: 6568},
+					pos: position{line: 218, col: 23, offset: 6599},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 216, col: 23, offset: 6568},
+							pos:        position{line: 218, col: 23, offset: 6599},
 							val:        "[",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 216, col: 27, offset: 6572},
+							pos:  position{line: 218, col: 27, offset: 6603},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 216, col: 29, offset: 6574},
+							pos:   position{line: 218, col: 29, offset: 6605},
 							label: "term",
 							expr: &ruleRefExpr{
-								pos:  position{line: 216, col: 34, offset: 6579},
+								pos:  position{line: 218, col: 34, offset: 6610},
 								name: "Term",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 216, col: 39, offset: 6584},
+							pos:  position{line: 218, col: 39, offset: 6615},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 216, col: 41, offset: 6586},
+							pos:        position{line: 218, col: 41, offset: 6617},
 							val:        "|",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 216, col: 45, offset: 6590},
+							pos:  position{line: 218, col: 45, offset: 6621},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 216, col: 47, offset: 6592},
+							pos:   position{line: 218, col: 47, offset: 6623},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 216, col: 52, offset: 6597},
+								pos:  position{line: 218, col: 52, offset: 6628},
 								name: "Body",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 216, col: 57, offset: 6602},
+							pos:  position{line: 218, col: 57, offset: 6633},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 216, col: 59, offset: 6604},
+							pos:        position{line: 218, col: 59, offset: 6635},
 							val:        "]",
 							ignoreCase: false,
 						},
@@ -768,41 +785,45 @@ var g = &grammar{
 		},
 		{
 			name: "Composite",
-			pos:  position{line: 222, col: 1, offset: 6729},
+			pos:  position{line: 224, col: 1, offset: 6760},
 			expr: &choiceExpr{
-				pos: position{line: 222, col: 14, offset: 6742},
+				pos: position{line: 224, col: 14, offset: 6773},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 222, col: 14, offset: 6742},
+						pos:  position{line: 224, col: 14, offset: 6773},
 						name: "Object",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 222, col: 23, offset: 6751},
+						pos:  position{line: 224, col: 23, offset: 6782},
 						name: "Array",
+					},
+					&ruleRefExpr{
+						pos:  position{line: 224, col: 31, offset: 6790},
+						name: "Set",
 					},
 				},
 			},
 		},
 		{
 			name: "Scalar",
-			pos:  position{line: 224, col: 1, offset: 6758},
+			pos:  position{line: 226, col: 1, offset: 6795},
 			expr: &choiceExpr{
-				pos: position{line: 224, col: 11, offset: 6768},
+				pos: position{line: 226, col: 11, offset: 6805},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 224, col: 11, offset: 6768},
+						pos:  position{line: 226, col: 11, offset: 6805},
 						name: "Number",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 224, col: 20, offset: 6777},
+						pos:  position{line: 226, col: 20, offset: 6814},
 						name: "String",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 224, col: 29, offset: 6786},
+						pos:  position{line: 226, col: 29, offset: 6823},
 						name: "Bool",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 224, col: 36, offset: 6793},
+						pos:  position{line: 226, col: 36, offset: 6830},
 						name: "Null",
 					},
 				},
@@ -810,20 +831,20 @@ var g = &grammar{
 		},
 		{
 			name: "Key",
-			pos:  position{line: 226, col: 1, offset: 6799},
+			pos:  position{line: 228, col: 1, offset: 6836},
 			expr: &choiceExpr{
-				pos: position{line: 226, col: 8, offset: 6806},
+				pos: position{line: 228, col: 8, offset: 6843},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 226, col: 8, offset: 6806},
+						pos:  position{line: 228, col: 8, offset: 6843},
 						name: "Scalar",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 226, col: 17, offset: 6815},
+						pos:  position{line: 228, col: 17, offset: 6852},
 						name: "Ref",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 226, col: 23, offset: 6821},
+						pos:  position{line: 228, col: 23, offset: 6858},
 						name: "Var",
 					},
 				},
@@ -831,49 +852,49 @@ var g = &grammar{
 		},
 		{
 			name: "Object",
-			pos:  position{line: 228, col: 1, offset: 6826},
+			pos:  position{line: 230, col: 1, offset: 6863},
 			expr: &actionExpr{
-				pos: position{line: 228, col: 11, offset: 6836},
+				pos: position{line: 230, col: 11, offset: 6873},
 				run: (*parser).callonObject1,
 				expr: &seqExpr{
-					pos: position{line: 228, col: 11, offset: 6836},
+					pos: position{line: 230, col: 11, offset: 6873},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 228, col: 11, offset: 6836},
+							pos:        position{line: 230, col: 11, offset: 6873},
 							val:        "{",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 228, col: 15, offset: 6840},
+							pos:  position{line: 230, col: 15, offset: 6877},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 228, col: 17, offset: 6842},
+							pos:   position{line: 230, col: 17, offset: 6879},
 							label: "head",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 228, col: 22, offset: 6847},
+								pos: position{line: 230, col: 22, offset: 6884},
 								expr: &seqExpr{
-									pos: position{line: 228, col: 23, offset: 6848},
+									pos: position{line: 230, col: 23, offset: 6885},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 228, col: 23, offset: 6848},
+											pos:  position{line: 230, col: 23, offset: 6885},
 											name: "Key",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 228, col: 27, offset: 6852},
+											pos:  position{line: 230, col: 27, offset: 6889},
 											name: "_",
 										},
 										&litMatcher{
-											pos:        position{line: 228, col: 29, offset: 6854},
+											pos:        position{line: 230, col: 29, offset: 6891},
 											val:        ":",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 228, col: 33, offset: 6858},
+											pos:  position{line: 230, col: 33, offset: 6895},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 228, col: 35, offset: 6860},
+											pos:  position{line: 230, col: 35, offset: 6897},
 											name: "Term",
 										},
 									},
@@ -881,45 +902,45 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 228, col: 42, offset: 6867},
+							pos:   position{line: 230, col: 42, offset: 6904},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 228, col: 47, offset: 6872},
+								pos: position{line: 230, col: 47, offset: 6909},
 								expr: &seqExpr{
-									pos: position{line: 228, col: 49, offset: 6874},
+									pos: position{line: 230, col: 49, offset: 6911},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 228, col: 49, offset: 6874},
+											pos:  position{line: 230, col: 49, offset: 6911},
 											name: "_",
 										},
 										&litMatcher{
-											pos:        position{line: 228, col: 51, offset: 6876},
+											pos:        position{line: 230, col: 51, offset: 6913},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 228, col: 55, offset: 6880},
+											pos:  position{line: 230, col: 55, offset: 6917},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 228, col: 57, offset: 6882},
+											pos:  position{line: 230, col: 57, offset: 6919},
 											name: "Key",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 228, col: 61, offset: 6886},
+											pos:  position{line: 230, col: 61, offset: 6923},
 											name: "_",
 										},
 										&litMatcher{
-											pos:        position{line: 228, col: 63, offset: 6888},
+											pos:        position{line: 230, col: 63, offset: 6925},
 											val:        ":",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 228, col: 67, offset: 6892},
+											pos:  position{line: 230, col: 67, offset: 6929},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 228, col: 69, offset: 6894},
+											pos:  position{line: 230, col: 69, offset: 6931},
 											name: "Term",
 										},
 									},
@@ -927,11 +948,11 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 228, col: 77, offset: 6902},
+							pos:  position{line: 230, col: 77, offset: 6939},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 228, col: 79, offset: 6904},
+							pos:        position{line: 230, col: 79, offset: 6941},
 							val:        "}",
 							ignoreCase: false,
 						},
@@ -941,56 +962,56 @@ var g = &grammar{
 		},
 		{
 			name: "Array",
-			pos:  position{line: 252, col: 1, offset: 7683},
+			pos:  position{line: 254, col: 1, offset: 7720},
 			expr: &actionExpr{
-				pos: position{line: 252, col: 10, offset: 7692},
+				pos: position{line: 254, col: 10, offset: 7729},
 				run: (*parser).callonArray1,
 				expr: &seqExpr{
-					pos: position{line: 252, col: 10, offset: 7692},
+					pos: position{line: 254, col: 10, offset: 7729},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 252, col: 10, offset: 7692},
+							pos:        position{line: 254, col: 10, offset: 7729},
 							val:        "[",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 252, col: 14, offset: 7696},
+							pos:  position{line: 254, col: 14, offset: 7733},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 252, col: 17, offset: 7699},
+							pos:   position{line: 254, col: 17, offset: 7736},
 							label: "head",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 252, col: 22, offset: 7704},
+								pos: position{line: 254, col: 22, offset: 7741},
 								expr: &ruleRefExpr{
-									pos:  position{line: 252, col: 22, offset: 7704},
+									pos:  position{line: 254, col: 22, offset: 7741},
 									name: "Term",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 252, col: 28, offset: 7710},
+							pos:   position{line: 254, col: 28, offset: 7747},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 252, col: 33, offset: 7715},
+								pos: position{line: 254, col: 33, offset: 7752},
 								expr: &seqExpr{
-									pos: position{line: 252, col: 34, offset: 7716},
+									pos: position{line: 254, col: 34, offset: 7753},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 252, col: 34, offset: 7716},
+											pos:  position{line: 254, col: 34, offset: 7753},
 											name: "_",
 										},
 										&litMatcher{
-											pos:        position{line: 252, col: 36, offset: 7718},
+											pos:        position{line: 254, col: 36, offset: 7755},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 252, col: 40, offset: 7722},
+											pos:  position{line: 254, col: 40, offset: 7759},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 252, col: 42, offset: 7724},
+											pos:  position{line: 254, col: 42, offset: 7761},
 											name: "Term",
 										},
 									},
@@ -998,11 +1019,11 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 252, col: 49, offset: 7731},
+							pos:  position{line: 254, col: 49, offset: 7768},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 252, col: 51, offset: 7733},
+							pos:        position{line: 254, col: 51, offset: 7770},
 							val:        "]",
 							ignoreCase: false,
 						},
@@ -1011,36 +1032,148 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "Ref",
-			pos:  position{line: 276, col: 1, offset: 8306},
+			name: "Set",
+			pos:  position{line: 278, col: 1, offset: 8343},
+			expr: &choiceExpr{
+				pos: position{line: 278, col: 8, offset: 8350},
+				alternatives: []interface{}{
+					&ruleRefExpr{
+						pos:  position{line: 278, col: 8, offset: 8350},
+						name: "SetEmpty",
+					},
+					&ruleRefExpr{
+						pos:  position{line: 278, col: 19, offset: 8361},
+						name: "SetNonEmpty",
+					},
+				},
+			},
+		},
+		{
+			name: "SetEmpty",
+			pos:  position{line: 280, col: 1, offset: 8374},
 			expr: &actionExpr{
-				pos: position{line: 276, col: 8, offset: 8313},
-				run: (*parser).callonRef1,
+				pos: position{line: 280, col: 13, offset: 8386},
+				run: (*parser).callonSetEmpty1,
 				expr: &seqExpr{
-					pos: position{line: 276, col: 8, offset: 8313},
+					pos: position{line: 280, col: 13, offset: 8386},
 					exprs: []interface{}{
+						&litMatcher{
+							pos:        position{line: 280, col: 13, offset: 8386},
+							val:        "set(",
+							ignoreCase: false,
+						},
+						&ruleRefExpr{
+							pos:  position{line: 280, col: 20, offset: 8393},
+							name: "_",
+						},
+						&litMatcher{
+							pos:        position{line: 280, col: 22, offset: 8395},
+							val:        ")",
+							ignoreCase: false,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "SetNonEmpty",
+			pos:  position{line: 286, col: 1, offset: 8483},
+			expr: &actionExpr{
+				pos: position{line: 286, col: 16, offset: 8498},
+				run: (*parser).callonSetNonEmpty1,
+				expr: &seqExpr{
+					pos: position{line: 286, col: 16, offset: 8498},
+					exprs: []interface{}{
+						&litMatcher{
+							pos:        position{line: 286, col: 16, offset: 8498},
+							val:        "{",
+							ignoreCase: false,
+						},
+						&ruleRefExpr{
+							pos:  position{line: 286, col: 20, offset: 8502},
+							name: "_",
+						},
 						&labeledExpr{
-							pos:   position{line: 276, col: 8, offset: 8313},
+							pos:   position{line: 286, col: 22, offset: 8504},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 276, col: 13, offset: 8318},
+								pos:  position{line: 286, col: 27, offset: 8509},
+								name: "Term",
+							},
+						},
+						&labeledExpr{
+							pos:   position{line: 286, col: 32, offset: 8514},
+							label: "tail",
+							expr: &zeroOrMoreExpr{
+								pos: position{line: 286, col: 37, offset: 8519},
+								expr: &seqExpr{
+									pos: position{line: 286, col: 38, offset: 8520},
+									exprs: []interface{}{
+										&ruleRefExpr{
+											pos:  position{line: 286, col: 38, offset: 8520},
+											name: "_",
+										},
+										&litMatcher{
+											pos:        position{line: 286, col: 40, offset: 8522},
+											val:        ",",
+											ignoreCase: false,
+										},
+										&ruleRefExpr{
+											pos:  position{line: 286, col: 44, offset: 8526},
+											name: "_",
+										},
+										&ruleRefExpr{
+											pos:  position{line: 286, col: 46, offset: 8528},
+											name: "Term",
+										},
+									},
+								},
+							},
+						},
+						&ruleRefExpr{
+							pos:  position{line: 286, col: 53, offset: 8535},
+							name: "_",
+						},
+						&litMatcher{
+							pos:        position{line: 286, col: 55, offset: 8537},
+							val:        "}",
+							ignoreCase: false,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Ref",
+			pos:  position{line: 303, col: 1, offset: 8942},
+			expr: &actionExpr{
+				pos: position{line: 303, col: 8, offset: 8949},
+				run: (*parser).callonRef1,
+				expr: &seqExpr{
+					pos: position{line: 303, col: 8, offset: 8949},
+					exprs: []interface{}{
+						&labeledExpr{
+							pos:   position{line: 303, col: 8, offset: 8949},
+							label: "head",
+							expr: &ruleRefExpr{
+								pos:  position{line: 303, col: 13, offset: 8954},
 								name: "Var",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 276, col: 17, offset: 8322},
+							pos:   position{line: 303, col: 17, offset: 8958},
 							label: "tail",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 276, col: 22, offset: 8327},
+								pos: position{line: 303, col: 22, offset: 8963},
 								expr: &choiceExpr{
-									pos: position{line: 276, col: 24, offset: 8329},
+									pos: position{line: 303, col: 24, offset: 8965},
 									alternatives: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 276, col: 24, offset: 8329},
+											pos:  position{line: 303, col: 24, offset: 8965},
 											name: "RefDot",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 276, col: 33, offset: 8338},
+											pos:  position{line: 303, col: 33, offset: 8974},
 											name: "RefBracket",
 										},
 									},
@@ -1053,23 +1186,23 @@ var g = &grammar{
 		},
 		{
 			name: "RefDot",
-			pos:  position{line: 289, col: 1, offset: 8577},
+			pos:  position{line: 316, col: 1, offset: 9213},
 			expr: &actionExpr{
-				pos: position{line: 289, col: 11, offset: 8587},
+				pos: position{line: 316, col: 11, offset: 9223},
 				run: (*parser).callonRefDot1,
 				expr: &seqExpr{
-					pos: position{line: 289, col: 11, offset: 8587},
+					pos: position{line: 316, col: 11, offset: 9223},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 289, col: 11, offset: 8587},
+							pos:        position{line: 316, col: 11, offset: 9223},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 289, col: 15, offset: 8591},
+							pos:   position{line: 316, col: 15, offset: 9227},
 							label: "val",
 							expr: &ruleRefExpr{
-								pos:  position{line: 289, col: 19, offset: 8595},
+								pos:  position{line: 316, col: 19, offset: 9231},
 								name: "Var",
 							},
 						},
@@ -1079,41 +1212,41 @@ var g = &grammar{
 		},
 		{
 			name: "RefBracket",
-			pos:  position{line: 296, col: 1, offset: 8814},
+			pos:  position{line: 323, col: 1, offset: 9450},
 			expr: &actionExpr{
-				pos: position{line: 296, col: 15, offset: 8828},
+				pos: position{line: 323, col: 15, offset: 9464},
 				run: (*parser).callonRefBracket1,
 				expr: &seqExpr{
-					pos: position{line: 296, col: 15, offset: 8828},
+					pos: position{line: 323, col: 15, offset: 9464},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 296, col: 15, offset: 8828},
+							pos:        position{line: 323, col: 15, offset: 9464},
 							val:        "[",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 296, col: 19, offset: 8832},
+							pos:   position{line: 323, col: 19, offset: 9468},
 							label: "val",
 							expr: &choiceExpr{
-								pos: position{line: 296, col: 24, offset: 8837},
+								pos: position{line: 323, col: 24, offset: 9473},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 296, col: 24, offset: 8837},
+										pos:  position{line: 323, col: 24, offset: 9473},
 										name: "Ref",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 296, col: 30, offset: 8843},
+										pos:  position{line: 323, col: 30, offset: 9479},
 										name: "Scalar",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 296, col: 39, offset: 8852},
+										pos:  position{line: 323, col: 39, offset: 9488},
 										name: "Var",
 									},
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 296, col: 44, offset: 8857},
+							pos:        position{line: 323, col: 44, offset: 9493},
 							val:        "]",
 							ignoreCase: false,
 						},
@@ -1123,35 +1256,35 @@ var g = &grammar{
 		},
 		{
 			name: "Var",
-			pos:  position{line: 300, col: 1, offset: 8886},
+			pos:  position{line: 327, col: 1, offset: 9522},
 			expr: &actionExpr{
-				pos: position{line: 300, col: 8, offset: 8893},
+				pos: position{line: 327, col: 8, offset: 9529},
 				run: (*parser).callonVar1,
 				expr: &seqExpr{
-					pos: position{line: 300, col: 8, offset: 8893},
+					pos: position{line: 327, col: 8, offset: 9529},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 300, col: 8, offset: 8893},
+							pos: position{line: 327, col: 8, offset: 9529},
 							expr: &ruleRefExpr{
-								pos:  position{line: 300, col: 9, offset: 8894},
+								pos:  position{line: 327, col: 9, offset: 9530},
 								name: "Reserved",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 300, col: 18, offset: 8903},
+							pos:  position{line: 327, col: 18, offset: 9539},
 							name: "AsciiLetter",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 300, col: 30, offset: 8915},
+							pos: position{line: 327, col: 30, offset: 9551},
 							expr: &choiceExpr{
-								pos: position{line: 300, col: 31, offset: 8916},
+								pos: position{line: 327, col: 31, offset: 9552},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 300, col: 31, offset: 8916},
+										pos:  position{line: 327, col: 31, offset: 9552},
 										name: "AsciiLetter",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 300, col: 45, offset: 8930},
+										pos:  position{line: 327, col: 45, offset: 9566},
 										name: "DecimalDigit",
 									},
 								},
@@ -1163,39 +1296,39 @@ var g = &grammar{
 		},
 		{
 			name: "Number",
-			pos:  position{line: 307, col: 1, offset: 9073},
+			pos:  position{line: 334, col: 1, offset: 9709},
 			expr: &actionExpr{
-				pos: position{line: 307, col: 11, offset: 9083},
+				pos: position{line: 334, col: 11, offset: 9719},
 				run: (*parser).callonNumber1,
 				expr: &seqExpr{
-					pos: position{line: 307, col: 11, offset: 9083},
+					pos: position{line: 334, col: 11, offset: 9719},
 					exprs: []interface{}{
 						&zeroOrOneExpr{
-							pos: position{line: 307, col: 11, offset: 9083},
+							pos: position{line: 334, col: 11, offset: 9719},
 							expr: &litMatcher{
-								pos:        position{line: 307, col: 11, offset: 9083},
+								pos:        position{line: 334, col: 11, offset: 9719},
 								val:        "-",
 								ignoreCase: false,
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 307, col: 16, offset: 9088},
+							pos:  position{line: 334, col: 16, offset: 9724},
 							name: "Integer",
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 307, col: 24, offset: 9096},
+							pos: position{line: 334, col: 24, offset: 9732},
 							expr: &seqExpr{
-								pos: position{line: 307, col: 26, offset: 9098},
+								pos: position{line: 334, col: 26, offset: 9734},
 								exprs: []interface{}{
 									&litMatcher{
-										pos:        position{line: 307, col: 26, offset: 9098},
+										pos:        position{line: 334, col: 26, offset: 9734},
 										val:        ".",
 										ignoreCase: false,
 									},
 									&oneOrMoreExpr{
-										pos: position{line: 307, col: 30, offset: 9102},
+										pos: position{line: 334, col: 30, offset: 9738},
 										expr: &ruleRefExpr{
-											pos:  position{line: 307, col: 30, offset: 9102},
+											pos:  position{line: 334, col: 30, offset: 9738},
 											name: "DecimalDigit",
 										},
 									},
@@ -1203,9 +1336,9 @@ var g = &grammar{
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 307, col: 47, offset: 9119},
+							pos: position{line: 334, col: 47, offset: 9755},
 							expr: &ruleRefExpr{
-								pos:  position{line: 307, col: 47, offset: 9119},
+								pos:  position{line: 334, col: 47, offset: 9755},
 								name: "Exponent",
 							},
 						},
@@ -1215,48 +1348,48 @@ var g = &grammar{
 		},
 		{
 			name: "String",
-			pos:  position{line: 316, col: 1, offset: 9360},
+			pos:  position{line: 343, col: 1, offset: 9996},
 			expr: &actionExpr{
-				pos: position{line: 316, col: 11, offset: 9370},
+				pos: position{line: 343, col: 11, offset: 10006},
 				run: (*parser).callonString1,
 				expr: &seqExpr{
-					pos: position{line: 316, col: 11, offset: 9370},
+					pos: position{line: 343, col: 11, offset: 10006},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 316, col: 11, offset: 9370},
+							pos:        position{line: 343, col: 11, offset: 10006},
 							val:        "\"",
 							ignoreCase: false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 316, col: 15, offset: 9374},
+							pos: position{line: 343, col: 15, offset: 10010},
 							expr: &choiceExpr{
-								pos: position{line: 316, col: 17, offset: 9376},
+								pos: position{line: 343, col: 17, offset: 10012},
 								alternatives: []interface{}{
 									&seqExpr{
-										pos: position{line: 316, col: 17, offset: 9376},
+										pos: position{line: 343, col: 17, offset: 10012},
 										exprs: []interface{}{
 											&notExpr{
-												pos: position{line: 316, col: 17, offset: 9376},
+												pos: position{line: 343, col: 17, offset: 10012},
 												expr: &ruleRefExpr{
-													pos:  position{line: 316, col: 18, offset: 9377},
+													pos:  position{line: 343, col: 18, offset: 10013},
 													name: "EscapedChar",
 												},
 											},
 											&anyMatcher{
-												line: 316, col: 30, offset: 9389,
+												line: 343, col: 30, offset: 10025,
 											},
 										},
 									},
 									&seqExpr{
-										pos: position{line: 316, col: 34, offset: 9393},
+										pos: position{line: 343, col: 34, offset: 10029},
 										exprs: []interface{}{
 											&litMatcher{
-												pos:        position{line: 316, col: 34, offset: 9393},
+												pos:        position{line: 343, col: 34, offset: 10029},
 												val:        "\\",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 316, col: 39, offset: 9398},
+												pos:  position{line: 343, col: 39, offset: 10034},
 												name: "EscapeSequence",
 											},
 										},
@@ -1265,7 +1398,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 316, col: 57, offset: 9416},
+							pos:        position{line: 343, col: 57, offset: 10052},
 							val:        "\"",
 							ignoreCase: false,
 						},
@@ -1275,24 +1408,24 @@ var g = &grammar{
 		},
 		{
 			name: "Bool",
-			pos:  position{line: 325, col: 1, offset: 9674},
+			pos:  position{line: 352, col: 1, offset: 10310},
 			expr: &choiceExpr{
-				pos: position{line: 325, col: 9, offset: 9682},
+				pos: position{line: 352, col: 9, offset: 10318},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 325, col: 9, offset: 9682},
+						pos: position{line: 352, col: 9, offset: 10318},
 						run: (*parser).callonBool2,
 						expr: &litMatcher{
-							pos:        position{line: 325, col: 9, offset: 9682},
+							pos:        position{line: 352, col: 9, offset: 10318},
 							val:        "true",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 329, col: 5, offset: 9782},
+						pos: position{line: 356, col: 5, offset: 10418},
 						run: (*parser).callonBool4,
 						expr: &litMatcher{
-							pos:        position{line: 329, col: 5, offset: 9782},
+							pos:        position{line: 356, col: 5, offset: 10418},
 							val:        "false",
 							ignoreCase: false,
 						},
@@ -1302,12 +1435,12 @@ var g = &grammar{
 		},
 		{
 			name: "Null",
-			pos:  position{line: 335, col: 1, offset: 9883},
+			pos:  position{line: 362, col: 1, offset: 10519},
 			expr: &actionExpr{
-				pos: position{line: 335, col: 9, offset: 9891},
+				pos: position{line: 362, col: 9, offset: 10527},
 				run: (*parser).callonNull1,
 				expr: &litMatcher{
-					pos:        position{line: 335, col: 9, offset: 9891},
+					pos:        position{line: 362, col: 9, offset: 10527},
 					val:        "null",
 					ignoreCase: false,
 				},
@@ -1315,37 +1448,37 @@ var g = &grammar{
 		},
 		{
 			name: "Reserved",
-			pos:  position{line: 341, col: 1, offset: 9986},
+			pos:  position{line: 368, col: 1, offset: 10622},
 			expr: &choiceExpr{
-				pos: position{line: 341, col: 14, offset: 9999},
+				pos: position{line: 368, col: 14, offset: 10635},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 341, col: 14, offset: 9999},
+						pos:        position{line: 368, col: 14, offset: 10635},
 						val:        "not",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 341, col: 22, offset: 10007},
+						pos:        position{line: 368, col: 22, offset: 10643},
 						val:        "package",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 341, col: 34, offset: 10019},
+						pos:        position{line: 368, col: 34, offset: 10655},
 						val:        "import",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 341, col: 45, offset: 10030},
+						pos:        position{line: 368, col: 45, offset: 10666},
 						val:        "null",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 341, col: 54, offset: 10039},
+						pos:        position{line: 368, col: 54, offset: 10675},
 						val:        "true",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 341, col: 63, offset: 10048},
+						pos:        position{line: 368, col: 63, offset: 10684},
 						val:        "false",
 						ignoreCase: false,
 					},
@@ -1354,26 +1487,26 @@ var g = &grammar{
 		},
 		{
 			name: "Integer",
-			pos:  position{line: 343, col: 1, offset: 10058},
+			pos:  position{line: 370, col: 1, offset: 10694},
 			expr: &choiceExpr{
-				pos: position{line: 343, col: 12, offset: 10069},
+				pos: position{line: 370, col: 12, offset: 10705},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 343, col: 12, offset: 10069},
+						pos:        position{line: 370, col: 12, offset: 10705},
 						val:        "0",
 						ignoreCase: false,
 					},
 					&seqExpr{
-						pos: position{line: 343, col: 18, offset: 10075},
+						pos: position{line: 370, col: 18, offset: 10711},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 343, col: 18, offset: 10075},
+								pos:  position{line: 370, col: 18, offset: 10711},
 								name: "NonZeroDecimalDigit",
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 343, col: 38, offset: 10095},
+								pos: position{line: 370, col: 38, offset: 10731},
 								expr: &ruleRefExpr{
-									pos:  position{line: 343, col: 38, offset: 10095},
+									pos:  position{line: 370, col: 38, offset: 10731},
 									name: "DecimalDigit",
 								},
 							},
@@ -1384,19 +1517,19 @@ var g = &grammar{
 		},
 		{
 			name: "Exponent",
-			pos:  position{line: 345, col: 1, offset: 10110},
+			pos:  position{line: 372, col: 1, offset: 10746},
 			expr: &seqExpr{
-				pos: position{line: 345, col: 13, offset: 10122},
+				pos: position{line: 372, col: 13, offset: 10758},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 345, col: 13, offset: 10122},
+						pos:        position{line: 372, col: 13, offset: 10758},
 						val:        "e",
 						ignoreCase: true,
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 345, col: 18, offset: 10127},
+						pos: position{line: 372, col: 18, offset: 10763},
 						expr: &charClassMatcher{
-							pos:        position{line: 345, col: 18, offset: 10127},
+							pos:        position{line: 372, col: 18, offset: 10763},
 							val:        "[+-]",
 							chars:      []rune{'+', '-'},
 							ignoreCase: false,
@@ -1404,9 +1537,9 @@ var g = &grammar{
 						},
 					},
 					&oneOrMoreExpr{
-						pos: position{line: 345, col: 24, offset: 10133},
+						pos: position{line: 372, col: 24, offset: 10769},
 						expr: &ruleRefExpr{
-							pos:  position{line: 345, col: 24, offset: 10133},
+							pos:  position{line: 372, col: 24, offset: 10769},
 							name: "DecimalDigit",
 						},
 					},
@@ -1415,9 +1548,9 @@ var g = &grammar{
 		},
 		{
 			name: "AsciiLetter",
-			pos:  position{line: 347, col: 1, offset: 10148},
+			pos:  position{line: 374, col: 1, offset: 10784},
 			expr: &charClassMatcher{
-				pos:        position{line: 347, col: 16, offset: 10163},
+				pos:        position{line: 374, col: 16, offset: 10799},
 				val:        "[A-Za-z_]",
 				chars:      []rune{'_'},
 				ranges:     []rune{'A', 'Z', 'a', 'z'},
@@ -1427,9 +1560,9 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedChar",
-			pos:  position{line: 349, col: 1, offset: 10174},
+			pos:  position{line: 376, col: 1, offset: 10810},
 			expr: &charClassMatcher{
-				pos:        position{line: 349, col: 16, offset: 10189},
+				pos:        position{line: 376, col: 16, offset: 10825},
 				val:        "[\\x00-\\x1f\"\\\\]",
 				chars:      []rune{'"', '\\'},
 				ranges:     []rune{'\x00', '\x1f'},
@@ -1439,16 +1572,16 @@ var g = &grammar{
 		},
 		{
 			name: "EscapeSequence",
-			pos:  position{line: 351, col: 1, offset: 10205},
+			pos:  position{line: 378, col: 1, offset: 10841},
 			expr: &choiceExpr{
-				pos: position{line: 351, col: 19, offset: 10223},
+				pos: position{line: 378, col: 19, offset: 10859},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 351, col: 19, offset: 10223},
+						pos:  position{line: 378, col: 19, offset: 10859},
 						name: "SingleCharEscape",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 351, col: 38, offset: 10242},
+						pos:  position{line: 378, col: 38, offset: 10878},
 						name: "UnicodeEscape",
 					},
 				},
@@ -1456,9 +1589,9 @@ var g = &grammar{
 		},
 		{
 			name: "SingleCharEscape",
-			pos:  position{line: 353, col: 1, offset: 10257},
+			pos:  position{line: 380, col: 1, offset: 10893},
 			expr: &charClassMatcher{
-				pos:        position{line: 353, col: 21, offset: 10277},
+				pos:        position{line: 380, col: 21, offset: 10913},
 				val:        "[\"\\\\/bfnrt]",
 				chars:      []rune{'"', '\\', '/', 'b', 'f', 'n', 'r', 't'},
 				ignoreCase: false,
@@ -1467,29 +1600,29 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeEscape",
-			pos:  position{line: 355, col: 1, offset: 10290},
+			pos:  position{line: 382, col: 1, offset: 10926},
 			expr: &seqExpr{
-				pos: position{line: 355, col: 18, offset: 10307},
+				pos: position{line: 382, col: 18, offset: 10943},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 355, col: 18, offset: 10307},
+						pos:        position{line: 382, col: 18, offset: 10943},
 						val:        "u",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 355, col: 22, offset: 10311},
+						pos:  position{line: 382, col: 22, offset: 10947},
 						name: "HexDigit",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 355, col: 31, offset: 10320},
+						pos:  position{line: 382, col: 31, offset: 10956},
 						name: "HexDigit",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 355, col: 40, offset: 10329},
+						pos:  position{line: 382, col: 40, offset: 10965},
 						name: "HexDigit",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 355, col: 49, offset: 10338},
+						pos:  position{line: 382, col: 49, offset: 10974},
 						name: "HexDigit",
 					},
 				},
@@ -1497,9 +1630,9 @@ var g = &grammar{
 		},
 		{
 			name: "DecimalDigit",
-			pos:  position{line: 357, col: 1, offset: 10348},
+			pos:  position{line: 384, col: 1, offset: 10984},
 			expr: &charClassMatcher{
-				pos:        position{line: 357, col: 17, offset: 10364},
+				pos:        position{line: 384, col: 17, offset: 11000},
 				val:        "[0-9]",
 				ranges:     []rune{'0', '9'},
 				ignoreCase: false,
@@ -1508,9 +1641,9 @@ var g = &grammar{
 		},
 		{
 			name: "NonZeroDecimalDigit",
-			pos:  position{line: 359, col: 1, offset: 10371},
+			pos:  position{line: 386, col: 1, offset: 11007},
 			expr: &charClassMatcher{
-				pos:        position{line: 359, col: 24, offset: 10394},
+				pos:        position{line: 386, col: 24, offset: 11030},
 				val:        "[1-9]",
 				ranges:     []rune{'1', '9'},
 				ignoreCase: false,
@@ -1519,9 +1652,9 @@ var g = &grammar{
 		},
 		{
 			name: "HexDigit",
-			pos:  position{line: 361, col: 1, offset: 10401},
+			pos:  position{line: 388, col: 1, offset: 11037},
 			expr: &charClassMatcher{
-				pos:        position{line: 361, col: 13, offset: 10413},
+				pos:        position{line: 388, col: 13, offset: 11049},
 				val:        "[0-9a-f]",
 				ranges:     []rune{'0', '9', 'a', 'f'},
 				ignoreCase: false,
@@ -1531,11 +1664,11 @@ var g = &grammar{
 		{
 			name:        "ws",
 			displayName: "\"whitespace\"",
-			pos:         position{line: 363, col: 1, offset: 10423},
+			pos:         position{line: 390, col: 1, offset: 11059},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 363, col: 20, offset: 10442},
+				pos: position{line: 390, col: 20, offset: 11078},
 				expr: &charClassMatcher{
-					pos:        position{line: 363, col: 20, offset: 10442},
+					pos:        position{line: 390, col: 20, offset: 11078},
 					val:        "[ \\t\\r\\n]",
 					chars:      []rune{' ', '\t', '\r', '\n'},
 					ignoreCase: false,
@@ -1546,21 +1679,21 @@ var g = &grammar{
 		{
 			name:        "_",
 			displayName: "\"whitespace\"",
-			pos:         position{line: 365, col: 1, offset: 10454},
+			pos:         position{line: 392, col: 1, offset: 11090},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 365, col: 19, offset: 10472},
+				pos: position{line: 392, col: 19, offset: 11108},
 				expr: &choiceExpr{
-					pos: position{line: 365, col: 21, offset: 10474},
+					pos: position{line: 392, col: 21, offset: 11110},
 					alternatives: []interface{}{
 						&charClassMatcher{
-							pos:        position{line: 365, col: 21, offset: 10474},
+							pos:        position{line: 392, col: 21, offset: 11110},
 							val:        "[ \\t\\r\\n]",
 							chars:      []rune{' ', '\t', '\r', '\n'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 365, col: 33, offset: 10486},
+							pos:  position{line: 392, col: 33, offset: 11122},
 							name: "Comment",
 						},
 					},
@@ -1569,14 +1702,14 @@ var g = &grammar{
 		},
 		{
 			name: "Comment",
-			pos:  position{line: 367, col: 1, offset: 10498},
+			pos:  position{line: 394, col: 1, offset: 11134},
 			expr: &seqExpr{
-				pos: position{line: 367, col: 12, offset: 10509},
+				pos: position{line: 394, col: 12, offset: 11145},
 				exprs: []interface{}{
 					&zeroOrMoreExpr{
-						pos: position{line: 367, col: 12, offset: 10509},
+						pos: position{line: 394, col: 12, offset: 11145},
 						expr: &charClassMatcher{
-							pos:        position{line: 367, col: 12, offset: 10509},
+							pos:        position{line: 394, col: 12, offset: 11145},
 							val:        "[ \\t]",
 							chars:      []rune{' ', '\t'},
 							ignoreCase: false,
@@ -1584,14 +1717,14 @@ var g = &grammar{
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 367, col: 19, offset: 10516},
+						pos:        position{line: 394, col: 19, offset: 11152},
 						val:        "#",
 						ignoreCase: false,
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 367, col: 23, offset: 10520},
+						pos: position{line: 394, col: 23, offset: 11156},
 						expr: &charClassMatcher{
-							pos:        position{line: 367, col: 23, offset: 10520},
+							pos:        position{line: 394, col: 23, offset: 11156},
 							val:        "[^\\r\\n]",
 							chars:      []rune{'\r', '\n'},
 							ignoreCase: false,
@@ -1603,11 +1736,11 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 369, col: 1, offset: 10530},
+			pos:  position{line: 396, col: 1, offset: 11166},
 			expr: &notExpr{
-				pos: position{line: 369, col: 8, offset: 10537},
+				pos: position{line: 396, col: 8, offset: 11173},
 				expr: &anyMatcher{
-					line: 369, col: 9, offset: 10538,
+					line: 396, col: 9, offset: 11174,
 				},
 			},
 		},
@@ -1847,7 +1980,7 @@ func (p *parser) callonInfixOp1() (interface{}, error) {
 	return p.cur.onInfixOp1(stack["val"])
 }
 
-func (c *current) onPrefixExpr1(op, head, tail interface{}) (interface{}, error) {
+func (c *current) onBuiltin1(op, head, tail interface{}) (interface{}, error) {
 	buf := []*Term{op.(*Term)}
 	if head == nil {
 		return buf, nil
@@ -1863,10 +1996,10 @@ func (c *current) onPrefixExpr1(op, head, tail interface{}) (interface{}, error)
 	return buf, nil
 }
 
-func (p *parser) callonPrefixExpr1() (interface{}, error) {
+func (p *parser) callonBuiltin1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onPrefixExpr1(stack["op"], stack["head"], stack["tail"])
+	return p.cur.onBuiltin1(stack["op"], stack["head"], stack["tail"])
 }
 
 func (c *current) onTerm1(val interface{}) (interface{}, error) {
@@ -1949,6 +2082,41 @@ func (p *parser) callonArray1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onArray1(stack["head"], stack["tail"])
+}
+
+func (c *current) onSetEmpty1() (interface{}, error) {
+	set := SetTerm()
+	set.Location = currentLocation(c)
+	return set, nil
+}
+
+func (p *parser) callonSetEmpty1() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onSetEmpty1()
+}
+
+func (c *current) onSetNonEmpty1(head, tail interface{}) (interface{}, error) {
+	set := SetTerm()
+	set.Location = currentLocation(c)
+
+	val := set.Value.(*Set)
+	val.Add(head.(*Term))
+
+	tailSlice := tail.([]interface{})
+	for _, v := range tailSlice {
+		s := v.([]interface{})
+		// SetNonEmpty definition above describes the "tail" structure. We only care about the "Term" elements.
+		val.Add(s[len(s)-1].(*Term))
+	}
+
+	return set, nil
+}
+
+func (p *parser) callonSetNonEmpty1() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onSetNonEmpty1(stack["head"], stack["tail"])
 }
 
 func (c *current) onRef1(head, tail interface{}) (interface{}, error) {

--- a/ast/parser_ext.go
+++ b/ast/parser_ext.go
@@ -340,6 +340,8 @@ func (vis *wildcardMangler) Visit(x interface{}) Visitor {
 		}
 	case Array:
 		vis.mangleSlice(x)
+	case *Set:
+		vis.mangleSlice(*x)
 	case Ref:
 		vis.mangleSlice(x)
 	case *Expr:

--- a/ast/policy_test.go
+++ b/ast/policy_test.go
@@ -20,6 +20,8 @@ func TestModuleJSONRoundTrip(t *testing.T) {
 	r[y] = v :- i[1] = y, v = i[2]
 	q[x] :- a=[true,false,null,{"x":[1,2,3]}], a[i] = x
 	t = true :- xs = [{"x": a[i].a} | a[i].n = "bob", b[x]]
+	s = {1,2,3} :- true
+	s = set() :- false
 	`)
 
 	bs, err := json.Marshal(mod)

--- a/ast/rego.peg
+++ b/ast/rego.peg
@@ -191,7 +191,9 @@ InfixOp <- val:("=" / "!=" / "<=" / ">=" / "<" / ">") {
 	return operator, nil
 }
 
-PrefixExpr <- op:Var "(" _ head:Term? tail:( _ "," _ Term )* _  ")" {
+PrefixExpr <- SetEmpty / Builtin
+
+Builtin <- op:Var "(" _ head:Term? tail:( _ "," _ Term )* _  ")" {
     buf := []*Term{op.(*Term)}
     if head == nil {
         return buf, nil
@@ -219,7 +221,7 @@ ArrayComprehension <- "[" _ term:Term _ "|" _ body:Body _ "]" {
     return ac, nil
 }
 
-Composite <- Object / Array
+Composite <- Object / Array / Set
 
 Scalar <- Number / String / Bool / Null
 
@@ -271,6 +273,31 @@ Array <- '[' _  head:Term? tail:(_ ',' _ Term)* _ ']' {
    }
 
    return arr, nil
+}
+
+Set <- SetEmpty / SetNonEmpty
+
+SetEmpty <- "set(" _ ")" {
+    set := SetTerm()
+    set.Location = currentLocation(c)
+    return set, nil
+}
+
+SetNonEmpty <- '{' _ head:Term tail:(_ ',' _ Term)* _ '}' {
+    set := SetTerm()
+    set.Location = currentLocation(c)
+
+    val := set.Value.(*Set)
+    val.Add(head.(*Term))
+
+    tailSlice := tail.([]interface{})
+    for _, v := range tailSlice {
+        s := v.([]interface{})
+        // SetNonEmpty definition above describes the "tail" structure. We only care about the "Term" elements.
+        val.Add(s[len(s) - 1].(*Term))
+    }
+
+    return set, nil
 }
 
 Ref <- head:Var tail:( RefDot / RefBracket )+ {

--- a/ast/term.go
+++ b/ast/term.go
@@ -62,7 +62,6 @@ func (loc *Location) Format(f string, a ...interface{}) string {
 // - Variables
 // - References
 // - Array Comprehensions
-//
 type Value interface {
 	// Equal returns true if this value equals the other value.
 	Equal(other Value) bool
@@ -423,14 +422,9 @@ func (ref Ref) Append(term *Term) Ref {
 	return dst
 }
 
-// Equal returns true if the other Value is a Ref and the elements of the
-// other Ref are equal to the this Ref.
+// Equal returns true if ref is equal to other.
 func (ref Ref) Equal(other Value) bool {
-	switch other := other.(type) {
-	case Ref:
-		return termSliceEqual(ref, other)
-	}
-	return false
+	return Compare(ref, other) == 0
 }
 
 // Hash returns the hash code for the Value.
@@ -587,15 +581,9 @@ func ArrayTerm(a ...*Term) *Term {
 	return &Term{Value: Array(a)}
 }
 
-// Equal returns true if the other Value is an Array and the elements of the
-// other Array are equal to the elements of this Array. The elements are
-// ordered.
+// Equal returns true if arr is equal to other.
 func (arr Array) Equal(other Value) bool {
-	switch other := other.(type) {
-	case Array:
-		return termSliceEqual(arr, other)
-	}
-	return false
+	return Compare(arr, other) == 0
 }
 
 // Hash returns the hash code for the Value.
@@ -619,6 +607,7 @@ func (arr Array) String() string {
 // Set represents a set as defined by the language.
 type Set []*Term
 
+// SetTerm returns a new Term representing a set containing terms t.
 func SetTerm(t ...*Term) *Term {
 	s := &Set{}
 	for i := range t {
@@ -629,10 +618,12 @@ func SetTerm(t ...*Term) *Term {
 	}
 }
 
+// IsGround returns true if all terms in s are ground.
 func (s *Set) IsGround() bool {
 	return termSliceIsGround(*s)
 }
 
+// Hash returns a hash code for s.
 func (s *Set) Hash() int {
 	return termSliceHash(*s)
 }
@@ -654,13 +645,12 @@ func (s *Set) String() string {
 	return "{" + strings.Join(buf, ", ") + "}"
 }
 
+// Equal returns true if s is equal to v.
 func (s *Set) Equal(v Value) bool {
-	if other, ok := v.(*Set); ok {
-		return len(*s.Diff(other)) == 0 && len(*other.Diff(s)) == 0
-	}
-	return false
+	return Compare(s, v) == 0
 }
 
+// Diff returns elements in s that are not in other.
 func (s *Set) Diff(other *Set) *Set {
 	r := &Set{}
 	for _, x := range *s {
@@ -671,6 +661,7 @@ func (s *Set) Diff(other *Set) *Set {
 	return r
 }
 
+// Add updates s to include t.
 func (s *Set) Add(t *Term) {
 	if s.Contains(t) {
 		return
@@ -678,6 +669,7 @@ func (s *Set) Add(t *Term) {
 	*s = append(*s, t)
 }
 
+// Map returns a new Set obtained by applying f to each value in s.
 func (s *Set) Map(f func(*Term) (*Term, error)) (*Set, error) {
 	sl := *s
 	set := &Set{}
@@ -691,6 +683,7 @@ func (s *Set) Map(f func(*Term) (*Term, error)) (*Set, error) {
 	return set, nil
 }
 
+// Contains returns true if t is in s.
 func (s Set) Contains(t *Term) bool {
 	for i := range s {
 		if s[i].Equal(t) {
@@ -711,25 +704,19 @@ func Item(key, value *Term) [2]*Term {
 	return [2]*Term{key, value}
 }
 
-// Equal returns true if the other Value is an Object and the key/value pairs
-// of the Other object are equal to the key/value pairs of this Object. The
-// key/value pairs are ordered.
+// Equal returns true if obj is equal to other.
 func (obj Object) Equal(other Value) bool {
-	switch other := other.(type) {
-	case Object:
-		if len(obj) == len(other) {
-			for i := range obj {
-				if !obj[i][0].Equal(other[i][0]) {
-					return false
-				}
-				if !obj[i][1].Equal(other[i][1]) {
-					return false
-				}
-			}
-			return true
+	return Compare(obj, other) == 0
+}
+
+// Get returns the value of k in obj if k exists, otherwise nil.
+func (obj Object) Get(k *Term) *Term {
+	for _, pair := range obj {
+		if pair[0].Equal(k) {
+			return pair[1]
 		}
 	}
-	return false
+	return nil
 }
 
 // Hash returns the hash code for the Value.
@@ -793,6 +780,15 @@ func (obj Object) Intersect(other Object) [][3]*Term {
 	return r
 }
 
+// Keys returns the keys of obj.
+func (obj Object) Keys() []*Term {
+	keys := make([]*Term, len(obj))
+	for i, pair := range obj {
+		keys[i] = pair[0]
+	}
+	return keys
+}
+
 // Merge returns a new Object containing the non-overlapping keys of obj and other. If there are
 // overlapping keys between obj and other, the values of associated with the keys are merged. Only
 // objects can be merged with other objects. If the values cannot be merged, the second turn value
@@ -846,16 +842,9 @@ func ArrayComprehensionTerm(term *Term, body Body) *Term {
 	}
 }
 
-// Equal returns true if this array comprehension is syntactically equal to another.
+// Equal returns true if ac is equal to other.
 func (ac *ArrayComprehension) Equal(other Value) bool {
-	if ac == other {
-		return true
-	}
-	o, ok := other.(*ArrayComprehension)
-	if !ok {
-		return false
-	}
-	return o.Term.Equal(ac.Term) && o.Body.Equal(ac.Body)
+	return Compare(ac, other) == 0
 }
 
 // Hash returns the hash code of the Value.

--- a/ast/transform.go
+++ b/ast/transform.go
@@ -1,0 +1,240 @@
+// Copyright 2016 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package ast
+
+import "fmt"
+
+// Transformer defines the interface for transforming AST elements. If the
+// transformer returns nil and does not indicate an error, the AST element will
+// be set to nil and no transformations will be applied to children of the
+// element.
+type Transformer interface {
+	Transform(v interface{}) (interface{}, error)
+}
+
+// Transform iterates the AST and calls the Transform function on the
+// Transformer t for x before recursing.
+func Transform(t Transformer, x interface{}) (interface{}, error) {
+
+	if term, ok := x.(*Term); ok {
+		return Transform(t, term.Value)
+	}
+
+	y, err := t.Transform(x)
+	if err != nil {
+		return x, err
+	}
+
+	if y == nil {
+		return nil, nil
+	}
+
+	var ok bool
+	switch y := y.(type) {
+	case *Module:
+		p, err := Transform(t, y.Package)
+		if err != nil {
+			return nil, err
+		}
+		if y.Package, ok = p.(*Package); !ok {
+			return nil, fmt.Errorf("illegal transform: %T != %T", y.Package, p)
+		}
+		for i := range y.Imports {
+			imp, err := Transform(t, y.Imports[i])
+			if err != nil {
+				return nil, err
+			}
+			if y.Imports[i], ok = imp.(*Import); !ok {
+				return nil, fmt.Errorf("illegal transform: %T != %T", y.Imports[i], imp)
+			}
+		}
+		for i := range y.Rules {
+			rule, err := Transform(t, y.Rules[i])
+			if err != nil {
+				return nil, err
+			}
+			if y.Rules[i], ok = rule.(*Rule); !ok {
+				return nil, fmt.Errorf("illegal transform: %T != %T", y.Rules[i], rule)
+			}
+		}
+		return y, nil
+	case *Package:
+		ref, err := Transform(t, y.Path)
+		if err != nil {
+			return nil, err
+		}
+		if y.Path, ok = ref.(Ref); !ok {
+			return nil, fmt.Errorf("illegal transform: %T != %T", y.Path, ref)
+		}
+		return y, nil
+	case *Import:
+		y.Path, err = transformTerm(t, y.Path)
+		if err != nil {
+			return nil, err
+		}
+		if y.Alias, err = transformVar(t, y.Alias); err != nil {
+			return nil, err
+		}
+		return y, nil
+	case *Rule:
+		if y.Name, err = transformVar(t, y.Name); err != nil {
+			return nil, err
+		}
+		if y.Key != nil {
+			if y.Key, err = transformTerm(t, y.Key); err != nil {
+				return nil, err
+			}
+		}
+		if y.Value != nil {
+			if y.Value, err = transformTerm(t, y.Value); err != nil {
+				return nil, err
+			}
+		}
+		if y.Body, err = transformBody(t, y.Body); err != nil {
+			return nil, err
+		}
+		return y, nil
+	case Body:
+		for i, e := range y {
+			e, err := Transform(t, e)
+			if err != nil {
+				return nil, err
+			}
+			if y[i], ok = e.(*Expr); !ok {
+				return nil, fmt.Errorf("illegal transform: %T != %T", y[i], e)
+			}
+		}
+		return y, nil
+	case *Expr:
+		switch ts := y.Terms.(type) {
+		case []*Term:
+			for i := range ts {
+				if ts[i], err = transformTerm(t, ts[i]); err != nil {
+					return nil, err
+				}
+			}
+		case *Term:
+			if y.Terms, err = transformTerm(t, ts); err != nil {
+				return nil, err
+			}
+		}
+		return y, nil
+	case Ref:
+		for i, term := range y {
+			if y[i], err = transformTerm(t, term); err != nil {
+				return nil, err
+			}
+		}
+		return y, nil
+	case Object:
+		for i, elem := range y {
+			k, err := transformTerm(t, elem[0])
+			if err != nil {
+				return nil, err
+			}
+			v, err := transformTerm(t, elem[1])
+			if err != nil {
+				return nil, err
+			}
+			y[i] = Item(k, v)
+		}
+		return y, nil
+	case Array:
+		for i := range y {
+			if y[i], err = transformTerm(t, y[i]); err != nil {
+				return nil, err
+			}
+		}
+		return y, nil
+	case *Set:
+		y, err = y.Map(func(term *Term) (*Term, error) {
+			return transformTerm(t, term)
+		})
+		if err != nil {
+			return nil, err
+		}
+		return y, nil
+	case *ArrayComprehension:
+		if y.Term, err = transformTerm(t, y.Term); err != nil {
+			return nil, err
+		}
+		if y.Body, err = transformBody(t, y.Body); err != nil {
+			return nil, err
+		}
+		return y, nil
+	default:
+		return y, nil
+	}
+}
+
+// TransformRefs calls the function f on all references under x.
+func TransformRefs(x interface{}, f func(Ref) (Value, error)) (interface{}, error) {
+	t := &GenericTransformer{func(x interface{}) (interface{}, error) {
+		if r, ok := x.(Ref); ok {
+			return f(r)
+		}
+		return x, nil
+	}}
+	return Transform(t, x)
+}
+
+// GenericTransformer implements the Transformer interface to provide a utility
+// to transform AST nodes using a closure.
+type GenericTransformer struct {
+	f func(x interface{}) (interface{}, error)
+}
+
+// Transform calls the function f on the GenericTransformer.
+func (t *GenericTransformer) Transform(x interface{}) (interface{}, error) {
+	return t.f(x)
+}
+
+func transformBody(t Transformer, body Body) (Body, error) {
+	y, err := Transform(t, body)
+	if err != nil {
+		return nil, err
+	}
+	r, ok := y.(Body)
+	if !ok {
+		return nil, fmt.Errorf("illegal transform: %T != %T", body, y)
+	}
+	return r, nil
+}
+
+func transformTerm(t Transformer, term *Term) (*Term, error) {
+	v, err := transformValue(t, term.Value)
+	if err != nil {
+		return nil, err
+	}
+	r := &Term{
+		Value:    v,
+		Location: term.Location,
+	}
+	return r, nil
+}
+
+func transformValue(t Transformer, v Value) (Value, error) {
+	v1, err := Transform(t, v)
+	if err != nil {
+		return nil, err
+	}
+	r, ok := v1.(Value)
+	if !ok {
+		return nil, fmt.Errorf("illegal transform: %T != %T", v, v1)
+	}
+	return r, nil
+}
+
+func transformVar(t Transformer, v Var) (Var, error) {
+	v1, err := Transform(t, v)
+	if err != nil {
+		return "", err
+	}
+	r, ok := v1.(Var)
+	if !ok {
+		return "", fmt.Errorf("illegal transform: %T != %T", v, v1)
+	}
+	return r, nil
+}

--- a/ast/transform_test.go
+++ b/ast/transform_test.go
@@ -1,0 +1,56 @@
+// Copyright 2016 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package ast
+
+import "testing"
+
+func TestTransform(t *testing.T) {
+	module := MustParseModule(`
+    package ex["this"]
+    import foo
+    import bar["this"] as qux
+    p :- "this" = "that"
+    p = "this" :- false
+    p["this"] :- false
+    p[y] = {"this": ["this"]} :- false
+    p :- ["this" | "this"]
+	p = n :- count({"this", "that"}, n)
+    `)
+
+	result, err := Transform(&GenericTransformer{
+		func(x interface{}) (interface{}, error) {
+			if s, ok := x.(String); ok && s == String("this") {
+				return String("that"), nil
+			}
+			return x, nil
+		},
+	}, module)
+
+	if err != nil {
+		t.Fatalf("Unexpected error during transfom: %v", err)
+	}
+
+	resultMod, ok := result.(*Module)
+	if !ok {
+		t.Fatalf("Expected module from transform but got: %v", result)
+	}
+
+	expected := MustParseModule(`
+    package ex["that"]
+    import foo
+    import bar["that"] as qux
+    p :- "that" = "that"
+    p = "that" :- false
+    p["that"] :- false
+    p[y] = {"that": ["that"]} :- false
+    p :- ["that" | "that"]
+	p = n :- count({"that"}, n)
+    `)
+
+	if !expected.Equal(resultMod) {
+		t.Fatalf("Expected module:\n%v\n\nGot:\n%v\n", expected, resultMod)
+	}
+
+}

--- a/ast/visit.go
+++ b/ast/visit.go
@@ -72,6 +72,10 @@ func Walk(v Visitor, x interface{}) {
 		for _, t := range x {
 			Walk(w, t.Value)
 		}
+	case *Set:
+		for _, t := range *x {
+			Walk(w, t.Value)
+		}
 	case *ArrayComprehension:
 		Walk(w, x.Term)
 		Walk(w, x.Body)

--- a/ast/visit_test.go
+++ b/ast/visit_test.go
@@ -23,7 +23,8 @@ func TestVisitor(t *testing.T) {
 	t[x] = y :-
 		p[x] = {"foo": [y,2,{"bar": 3}]},
 		not q[x],
-		y = [ [x,z] | x = "x", z = "z" ]
+		y = [ [x,z] | x = "x", z = "z" ],
+		count({1,2,3}, n)
 	`)
 	vis := &testVis{}
 	Walk(vis, rule)
@@ -78,9 +79,16 @@ func TestVisitor(t *testing.T) {
 									=
 									z
 									"z"
+					expr4
+						count
+						set
+							1
+							2
+							3
+						n
 	*/
-	if len(vis.elems) != 49 {
-		t.Errorf("Expected exactly 49 elements in AST but got %d: %v", len(vis.elems), vis.elems)
+	if len(vis.elems) != 56 {
+		t.Errorf("Expected exactly 56 elements in AST but got %d: %v", len(vis.elems), vis.elems)
 	}
 
 }

--- a/site/documentation/how-do-i-write-policies/index.md
+++ b/site/documentation/how-do-i-write-policies/index.md
@@ -241,6 +241,57 @@ Composite values can also be defined in terms of [Variables](#variables) or [Ref
 
 By defining composite values in terms of variables and references, rules can define abstractions over raw data and other rules.
 
+### Sets
+
+In addition to arrays and objects, Rego supports set values. Sets are unordered
+collections of unique values. Just like other composite values, sets can be
+defined in terms of scalars, variables, references, and other composite values.
+For example:
+
+```ruby
+> s = {cube.width, cube.height, cube.depth}, count(s, n)
++---+---------+
+| n |    s    |
++---+---------+
+| 3 | [5,4,3] |
++---+---------+
+```
+
+> Set documents are collections of values without keys. OPA represents set
+documents as arrays when serializing to JSON or other formats that do not
+support a set data type. The important distinction between sets and arrays or
+objects is that sets are unkeyed while arrays and objects are keyed, i.e., you
+cannot refer to the index of an element within a set.
+{: .opa-tip}
+
+When comparing sets, the order of elements does not matter:
+
+```
+> {1,2,3} = {3,1,2}
+true
+```
+
+Because sets are unordered, variables inside sets must be unified with a ground
+value outside of the set. If the variable is not unified with a ground value
+outside the set, OPA will complain:
+
+```ruby
+> {1,2,3} = {3,x,2}
+error: 1 error occurred: 1:1: repl0: x is unsafe (variable x must appear in the output position of at least one non-negated expression)
+```
+
+Because sets share curly-brace syntax with objects, and an empty object is
+defined with `{}`, an empty set has to be constructed with a different syntax:
+
+```ruby
+> count(set(), n)
++---+
+| n |
++---+
+| 0 |
++---+
+```
+
 ## <a name="variables"></a> Variables
 
 Variables are another kind of term in Rego. They appear in both the head and body of rules.
@@ -544,9 +595,6 @@ First, the rule defines a set document where the contents are defined by the var
 ```
 
 For a more formal definition of the rule syntax, see the [Language Reference](/documentation/references/language#grammar) document.
-
-> Set documents are collections of values without keys. OPA represents set documents as arrays when serializing to JSON or other formats which do not support a set data type. The important distinction between sets and arrays or objects is that sets are unkeyed while arrays and objects are keyed, i.e., you cannot refer to the index of an element within a set.
-{: .opa-tip}
 
 Second, the `sites[_].servers[_].hostname` fragment selects the `hostname` attribute from all of the objects in the `servers` collection. From reading the fragment in isolation we cannot tell whether the fragment refers to arrays or objects. We only know that it refers to a collections of values.
 

--- a/site/documentation/references/language/index.md
+++ b/site/documentation/references/language/index.md
@@ -8,7 +8,6 @@ title: Language Reference
 
 {% contentfor header %}
 
-
 # Language Reference
 
 This document is the authoritative specification of the Rego policy language
@@ -50,8 +49,8 @@ complex types.
 | Built-in | Inputs | Description |
 | ------- |--------|-------------|
 | ``count(collection, output)`` | 1 | output is the length of the object, array, or set |
-| ``sum(array, output)`` | 1 | output is the sum of the numbers in array |
-| ``max(array, output)`` | 1 | output is the maximum value in the array |
+| ``sum(array_or_set, output)`` | 1 | output is the sum of the numbers in array or set |
+| ``max(array_or_set, output)`` | 1 | output is the maximum value in the array or set |
 
 ### Types
 
@@ -64,7 +63,7 @@ complex types.
 | Built-in | Inputs | Description |
 | ------- |--------|-------------|
 | <span class="opa-keep-it-together">``format_int(number, base, output)``</span> | 2 | output is string representation of number in given base |
-| ``concat(join, array, output)`` | 2 | output is the result of concatenating the elements of array with the join string |
+| ``concat(join, array_or_set, output)`` | 2 | output is the result of concatenating the elements of array or set with the join string |
 |``re_match(pattern, value)`` | 2 | true if the value matches the pattern |
 
 ## <a name="grammar"></a> Grammar
@@ -83,7 +82,7 @@ literal        = expr | "not" expr
 expr           = term | expr-built-in | expr-infix
 expr-built-in  = var "(" [ term { , term } ] ")"
 expr-infix     = term bool-operator term
-term           = ref | var | scalar | array | object | array-compr
+term           = ref | var | scalar | array | object | set | array-compr
 array-compr    = "[" term "|" rule-body "]"
 bool-operator  = "=" | "!=" | "<" | ">" | ">=" | "<="
 ref            = var { ref-arg }
@@ -95,6 +94,9 @@ scalar         = STRING | NUMBER | TRUE | FALSE | NULL
 array          = "[" term { "," term } "]"
 object         = "{" object-item { "," object-item } "}"
 object-item    = ( scalar | ref | var ) ":" term
+set            = empty-set | non-empty-set
+non-empty-set  = "{" term { "," term } "}"
+empty-set      = "set(" ")"
 ```
 {: .opa-collapse--ignore}
 

--- a/topdown/eq.go
+++ b/topdown/eq.go
@@ -22,27 +22,17 @@ func evalEq(ctx *Context, expr *ast.Expr, iter Iterator) error {
 }
 
 func evalEqGround(ctx *Context, a ast.Value, b ast.Value, iter Iterator) error {
-
-	ai, err := ast.TransformRefs(a, func(x ast.Ref) (ast.Value, error) {
-		return lookupValue(ctx, x)
-	})
-
+	a, err := ResolveRefs(a, ctx)
 	if err != nil {
 		return err
 	}
-
-	a = ai.(ast.Value)
-
-	bi, err := ast.TransformRefs(b, func(x ast.Ref) (ast.Value, error) {
-		return lookupValue(ctx, x)
-	})
-
-	b = bi.(ast.Value)
-
-	if cmp := ast.Compare(a, b); cmp == 0 {
+	b, err = ResolveRefs(b, ctx)
+	if err != nil {
+		return err
+	}
+	if ast.Compare(a, b) == 0 {
 		return iter(ctx)
 	}
-
 	return nil
 }
 
@@ -76,6 +66,8 @@ func evalEqUnify(ctx *Context, a ast.Value, b ast.Value, prev *Undo, iter Iterat
 		return evalEqUnifyObject(ctx, a, b, prev, iter)
 	case ast.Array:
 		return evalEqUnifyArray(ctx, a, b, prev, iter)
+	case *ast.Set:
+		return evalEqUnifySet(ctx, a, b, prev, iter)
 	default:
 		switch b := b.(type) {
 		case ast.Var:
@@ -84,6 +76,8 @@ func evalEqUnify(ctx *Context, a ast.Value, b ast.Value, prev *Undo, iter Iterat
 			return evalEqUnifyArray(ctx, b, a, prev, iter)
 		case ast.Object:
 			return evalEqUnifyObject(ctx, b, a, prev, iter)
+		case *ast.Set:
+			return evalEqUnifySet(ctx, b, a, prev, iter)
 		default:
 			return prev, evalEqGround(ctx, a, b, iter)
 		}
@@ -279,6 +273,40 @@ func evalEqUnifyObjects(ctx *Context, a ast.Object, b ast.Object, prev *Undo, it
 	}
 
 	return prev, iter(ctx)
+}
+
+func evalEqUnifySet(ctx *Context, a *ast.Set, b ast.Value, prev *Undo, iter Iterator) (*Undo, error) {
+	switch b := b.(type) {
+	case *ast.Set:
+		return evalEqSets(ctx, a, b, prev, iter)
+	case ast.Var:
+		return evalEqUnifyVar(ctx, b, a, prev, iter)
+	default:
+		return prev, nil
+	}
+}
+
+func evalEqSets(ctx *Context, a *ast.Set, b *ast.Set, prev *Undo, iter Iterator) (*Undo, error) {
+
+	x, err := ResolveRefs(a, ctx)
+	if err != nil {
+		return prev, err
+	}
+
+	a = x.(*ast.Set)
+
+	y, err := ResolveRefs(b, ctx)
+	if err != nil {
+		return prev, err
+	}
+
+	b = y.(*ast.Set)
+
+	if a.Equal(b) {
+		return prev, iter(ctx)
+	}
+
+	return prev, nil
 }
 
 func evalEqUnifyVar(ctx *Context, a ast.Var, b ast.Value, prev *Undo, iter Iterator) (*Undo, error) {

--- a/topdown/ineq.go
+++ b/topdown/ineq.go
@@ -4,46 +4,42 @@
 
 package topdown
 
-import (
-	"github.com/open-policy-agent/opa/ast"
-	"github.com/open-policy-agent/opa/util"
-)
+import "github.com/open-policy-agent/opa/ast"
 
-type compareFunc func(a, b interface{}) bool
+type compareFunc func(a, b ast.Value) bool
 
-func compareGreaterThan(a, b interface{}) bool {
-	return util.Compare(a, b) > 0
+func compareGreaterThan(a, b ast.Value) bool {
+	return ast.Compare(a, b) > 0
 }
 
-func compareGreaterThanEq(a, b interface{}) bool {
-	return util.Compare(a, b) >= 0
+func compareGreaterThanEq(a, b ast.Value) bool {
+	return ast.Compare(a, b) >= 0
 }
 
-func compareLessThan(a, b interface{}) bool {
-	return util.Compare(a, b) < 0
+func compareLessThan(a, b ast.Value) bool {
+	return ast.Compare(a, b) < 0
 }
 
-func compareLessThanEq(a, b interface{}) bool {
-	return util.Compare(a, b) <= 0
+func compareLessThanEq(a, b ast.Value) bool {
+	return ast.Compare(a, b) <= 0
 }
 
-func compareNotEq(a, b interface{}) bool {
-	return util.Compare(a, b) != 0
+func compareNotEq(a, b ast.Value) bool {
+	return ast.Compare(a, b) != 0
 }
 
 func evalIneq(cmp compareFunc) BuiltinFunc {
 	return func(ctx *Context, expr *ast.Expr, iter Iterator) error {
 		ops := expr.Terms.([]*ast.Term)
-		a, b := ops[1].Value, ops[2].Value
-		av, err := ValueToInterface(a, ctx)
+		a, err := ResolveRefs(ops[1].Value, ctx)
 		if err != nil {
 			return err
 		}
-		bv, err := ValueToInterface(b, ctx)
+		b, err := ResolveRefs(ops[2].Value, ctx)
 		if err != nil {
 			return err
 		}
-		if cmp(av, bv) {
+		if cmp(a, b) {
 			return iter(ctx)
 		}
 		return nil


### PR DESCRIPTION
These changes add support for set literals. E.g., 

```
> {1,2,3}
[
  1,
  2,
  3
]
```

or 

```
> count(set(), 0)
true
```

The main motivation was to fix the "not implemented" error callers would receive when querying arbitrary locations in the global document that have sets embedded underneath them. For example, users can now simply query for /v1/data and get back *everything* (assuming there are no rules that depend on query inputs!)