### PR TITLE
Fix recursion check

### DIFF
--- a/ast/policy.go
+++ b/ast/policy.go
@@ -583,6 +583,12 @@ func NewBuiltinExpr(terms ...*Term) *Expr {
 	return &Expr{Terms: terms}
 }
 
+type ruleSlice []*Rule
+
+func (s ruleSlice) Less(i, j int) bool { return Compare(s[i], s[j]) < 0 }
+func (s ruleSlice) Swap(i, j int)      { x := s[i]; s[i] = s[j]; s[j] = x }
+func (s ruleSlice) Len() int           { return len(s) }
+
 type varVisitor struct {
 	skipRefHead      bool
 	skipObjectKeys   bool


### PR DESCRIPTION
The recursion check was not catching cases such as:

package ex

p :- data.ex

In this case, data.ex implicitly refers to data.ex.p.

The fix was to update the visitor that builds the rule graph.