### PR TITLE
Improve command-line JSON input handling

### DIFF
--- a/runtime/merge.go
+++ b/runtime/merge.go
@@ -1,0 +1,46 @@
+// Copyright 2016 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package runtime
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+)
+
+// mergeDocs returns the result of merging a and b. If a and b cannot be merged
+// because of conflicting key-value pairs, an error is returned.
+func mergeDocs(a map[string]interface{}, b map[string]interface{}) (map[string]interface{}, error) {
+
+	merged := map[string]interface{}{}
+	for k := range a {
+		merged[k] = a[k]
+	}
+
+	for k := range b {
+
+		add := b[k]
+		exist, ok := merged[k]
+		if !ok {
+			merged[k] = add
+			continue
+		}
+
+		existObj, existOk := exist.(map[string]interface{})
+		addObj, addOk := add.(map[string]interface{})
+		if !existOk || !addOk {
+			return nil, fmt.Errorf("%v: merge error: %T cannot merge into %T", k, add, exist)
+		}
+
+		mergedObj, err := mergeDocs(existObj, addObj)
+		if err != nil {
+			return nil, errors.Wrapf(err, k)
+		}
+
+		merged[k] = mergedObj
+	}
+
+	return merged, nil
+}

--- a/runtime/merge_test.go
+++ b/runtime/merge_test.go
@@ -1,0 +1,60 @@
+// Copyright 2016 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package runtime
+
+import "testing"
+import "encoding/json"
+import "reflect"
+import "fmt"
+
+func TestMergeDocs(t *testing.T) {
+
+	tests := []struct {
+		a string
+		b string
+		c interface{}
+	}{
+		{`{"x": 1, "y": 2}`, `{"z": 3}`, `{"x": 1, "y": 2, "z": 3}`},
+		{`{"x": {"y": 2}}`, `{"z": 3, "x": {"q": 4}}`, `{"x": {"y": 2, "q": 4}, "z": 3}`},
+		{`{"x": 1}`, `{"x": 1}`, fmt.Errorf("x: merge error: float64 cannot merge into float64")},
+		{`{"x": {"y": [{"z": 2}]}}`, `{"x": {"y": [{"z": 3}]}}`, fmt.Errorf("x: y: merge error: []interface {} cannot merge into []interface {}")},
+	}
+
+	for _, tc := range tests {
+		a := map[string]interface{}{}
+		if err := json.Unmarshal([]byte(tc.a), &a); err != nil {
+			panic(err)
+		}
+
+		b := map[string]interface{}{}
+		if err := json.Unmarshal([]byte(tc.b), &b); err != nil {
+			panic(err)
+		}
+
+		switch c := tc.c.(type) {
+		case error:
+			_, err := mergeDocs(a, b)
+			if !reflect.DeepEqual(err.Error(), c.Error()) {
+				t.Errorf("Expected error to be exactly %v but got: %v", c, err)
+			}
+
+		case string:
+			expected := map[string]interface{}{}
+			if err := json.Unmarshal([]byte(c), &expected); err != nil {
+				panic(err)
+			}
+
+			result, err := mergeDocs(a, b)
+			if err != nil {
+				t.Errorf("Unexpected error on merge(%v, %v): %v", a, b, err)
+				continue
+			}
+
+			if !reflect.DeepEqual(result, expected) {
+				t.Errorf("Expected merge(%v, %v) to be %v but got: %v", a, b, expected, result)
+			}
+		}
+	}
+}

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -304,7 +304,7 @@ func parseInputs(paths []string) (*parsedInput, error) {
 
 		switch filepath.Ext(file) {
 		case ".json":
-			return nil, jsonErr
+			return nil, errors.Wrapf(jsonErr, file)
 		case ".rego":
 			return nil, astErr
 		default:

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -106,10 +106,9 @@ func (rt *Runtime) init(params *Params) error {
 
 	defer store.Close(txn)
 
-	for _, doc := range parsed.docs {
-		if err := store.Write(txn, storage.AddOp, doc.ref, doc.value); err != nil {
-			return errors.Wrap(err, "unable to open data store")
-		}
+	ref := ast.Ref{ast.DefaultRootDocument}
+	if err := store.Write(txn, storage.AddOp, ref, parsed.baseDocs); err != nil {
+		return errors.Wrapf(err, "storage error")
 	}
 
 	// Load policies provided via input.
@@ -202,10 +201,9 @@ func (rt *Runtime) processWatcherUpdate(paths []string) error {
 
 	defer rt.Store.Close(txn)
 
-	for _, doc := range parsed.docs {
-		if err := rt.Store.Write(txn, storage.AddOp, doc.ref, doc.value); err != nil {
-			return err
-		}
+	ref := ast.Ref{ast.DefaultRootDocument}
+	if err := rt.Store.Write(txn, storage.AddOp, ref, parsed.baseDocs); err != nil {
+		return err
 	}
 
 	return compileAndStoreInputs(parsed.modules, rt.Store, txn)
@@ -247,19 +245,14 @@ type parsedModule struct {
 	raw []byte
 }
 
-type parsedDoc struct {
-	ref   ast.Ref
-	value interface{}
-}
-
 type parsedInput struct {
-	docs    []parsedDoc
-	modules map[string]*parsedModule
+	baseDocs map[string]interface{}
+	modules  map[string]*parsedModule
 }
 
 func parseInputs(paths []string) (*parsedInput, error) {
 
-	parsedDocs := []parsedDoc{}
+	baseDocs := map[string]interface{}{}
 	parsedModules := map[string]*parsedModule{}
 
 	for _, file := range paths {
@@ -290,14 +283,12 @@ func parseInputs(paths []string) (*parsedInput, error) {
 			continue
 		}
 
-		d, jsonErr := parseJSONObjectFile(file)
+		parsed, jsonErr := parseJSONObjectFile(file)
 
 		if jsonErr == nil {
-			for k, v := range d {
-				parsedDocs = append(parsedDocs, parsedDoc{
-					ref:   ast.Ref{ast.DefaultRootDocument, ast.StringTerm(k)},
-					value: v,
-				})
+			baseDocs, err = mergeDocs(baseDocs, parsed)
+			if err != nil {
+				return nil, errors.Wrapf(err, file)
 			}
 			continue
 		}
@@ -313,8 +304,8 @@ func parseInputs(paths []string) (*parsedInput, error) {
 	}
 
 	r := &parsedInput{
-		docs:    parsedDocs,
-		modules: parsedModules,
+		baseDocs: baseDocs,
+		modules:  parsedModules,
 	}
 
 	return r, nil


### PR DESCRIPTION
Commit messages contain more details. Basically, instead of simply overwriting top-level keys, recursively merge JSON inputs if possible. This makes it easier to deal with namespaced data. For example:

file1.json

```
{
  "com": {
    "example": {
      "servers": [...]
    }
  }
}
```

file2.json

```
{
  "com": {
    "example": {
      "networks": [...]
    }
  }
}
```

usage

```
opa run file1.json file2.sjon
OPA 0.1.1-dev (commit 77d0c86, built at 2016-11-04T15:25:58Z)

Run 'help' to see a list of commands.

> data.com.example[k] = _
+------------+
|     k      |
+------------+
| "networks" |
| "servers"  |
+------------+
```