### PR TITLE
Deep copy modules in compiler

### DIFF
--- a/ast/compile.go
+++ b/ast/compile.go
@@ -162,8 +162,10 @@ func NewCompiler() *Compiler {
 // compiler. If the compilation process fails for any reason, the compiler will
 // contain a slice of errors.
 func (c *Compiler) Compile(modules map[string]*Module) {
-	// TODO(tsandall): should the modules be deep copied?
-	c.Modules = modules
+	c.Modules = make(map[string]*Module, len(modules))
+	for k, v := range modules {
+		c.Modules[k] = v.Copy()
+	}
 	c.compile()
 }
 

--- a/ast/compile_test.go
+++ b/ast/compile_test.go
@@ -808,20 +808,6 @@ func TestCompilerGetRulesWithPrefix(t *testing.T) {
 	}
 }
 
-func TestRecompile(t *testing.T) {
-	c := NewCompiler()
-
-	mod := MustParseModule(`
-	package abc
-	import xyz as foo
-	p = true :- foo.bar = true`)
-
-	c.Compile(map[string]*Module{"": mod})
-	assertNotFailed(t, c)
-	c.Compile(c.Modules)
-	assertNotFailed(t, c)
-}
-
 func assertNotFailed(t *testing.T, c *Compiler) {
 	if c.Failed() {
 		t.Errorf("Unexpected compilation error: %v", c.Errors)

--- a/ast/example_test.go
+++ b/ast/example_test.go
@@ -43,9 +43,9 @@ func ExampleCompiler_Compile() {
 		fmt.Println("Compile error:", c.Errors)
 	}
 
-	fmt.Println("Expr 1:", mod.Rules[0].Body[0])
-	fmt.Println("Expr 2:", mod.Rules[0].Body[1])
-	fmt.Println("Expr 3:", mod.Rules[0].Body[2])
+	fmt.Println("Expr 1:", c.Modules["my_module"].Rules[0].Body[0])
+	fmt.Println("Expr 2:", c.Modules["my_module"].Rules[0].Body[1])
+	fmt.Println("Expr 3:", c.Modules["my_module"].Rules[0].Body[2])
 
 	// Output:
 	//

--- a/ast/policy.go
+++ b/ast/policy.go
@@ -100,6 +100,21 @@ func (mod *Module) Compare(other *Module) int {
 	return rulesCompare(mod.Rules, other.Rules)
 }
 
+// Copy returns a deep copy of mod.
+func (mod *Module) Copy() *Module {
+	cpy := *mod
+	cpy.Rules = make([]*Rule, len(mod.Rules))
+	for i := range mod.Rules {
+		cpy.Rules[i] = mod.Rules[i].Copy()
+	}
+	cpy.Imports = make([]*Import, len(mod.Imports))
+	for i := range mod.Imports {
+		cpy.Imports[i] = mod.Imports[i].Copy()
+	}
+	cpy.Package = mod.Package.Copy()
+	return &cpy
+}
+
 // Equal returns true if mod equals other.
 func (mod *Module) Equal(other *Module) bool {
 	return mod.Compare(other) == 0
@@ -123,6 +138,13 @@ func (mod *Module) String() string {
 // or greater than other.
 func (pkg *Package) Compare(other *Package) int {
 	return Compare(pkg.Path, other.Path)
+}
+
+// Copy returns a deep copy of pkg.
+func (pkg *Package) Copy() *Package {
+	cpy := *pkg
+	cpy.Path = pkg.Path.Copy()
+	return &cpy
 }
 
 // Equal returns true if pkg is equal to other.
@@ -150,6 +172,13 @@ func (imp *Import) Compare(other *Import) int {
 		return cmp
 	}
 	return Compare(imp.Alias, other.Alias)
+}
+
+// Copy returns a deep copy of imp.
+func (imp *Import) Copy() *Import {
+	cpy := *imp
+	cpy.Path = imp.Path.Copy()
+	return &cpy
 }
 
 // Equal returns true if imp is equal to other.
@@ -183,6 +212,15 @@ func (rule *Rule) Compare(other *Rule) int {
 		return cmp
 	}
 	return rule.Body.Compare(other.Body)
+}
+
+// Copy returns a deep copy of rule.
+func (rule *Rule) Copy() *Rule {
+	cpy := *rule
+	cpy.Key = rule.Key.Copy()
+	cpy.Value = rule.Value.Copy()
+	cpy.Body = rule.Body.Copy()
+	return &cpy
 }
 
 // Equal returns true if rule is equal to other.
@@ -300,6 +338,15 @@ func (body Body) Compare(other Body) int {
 		return 1
 	}
 	return 0
+}
+
+// Copy returns a deep copy of body.
+func (body Body) Copy() Body {
+	cpy := make(Body, len(body))
+	for i := range body {
+		cpy[i] = body[i].Copy()
+	}
+	return cpy
 }
 
 // Contains returns true if this body contains the given expression.
@@ -423,6 +470,22 @@ func (expr *Expr) Compare(other *Expr) int {
 		return termSliceCompare(t, u)
 	}
 	panic(fmt.Sprintf("illegal value: %T", expr.Terms))
+}
+
+// Copy returns a deep copy of expr.
+func (expr *Expr) Copy() *Expr {
+	cpy := *expr
+	switch ts := expr.Terms.(type) {
+	case []*Term:
+		cpyTs := make([]*Term, len(ts))
+		for i := range ts {
+			cpyTs[i] = ts[i].Copy()
+		}
+		cpy.Terms = cpyTs
+	case *Term:
+		cpy.Terms = ts.Copy()
+	}
+	return &cpy
 }
 
 // Hash returns the hash code of the Expr.

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -294,8 +294,6 @@ func (r *REPL) cmdUnset(args []string) bool {
 		return false
 	}
 
-	policies := r.store.ListPolicies(r.txn)
-
 	mod := r.modules[r.currentModuleID]
 	rules := []*ast.Rule{}
 
@@ -310,9 +308,10 @@ func (r *REPL) cmdUnset(args []string) bool {
 		return false
 	}
 
-	cpy := &(*mod)
+	cpy := mod.Copy()
 	cpy.Rules = rules
 
+	policies := r.store.ListPolicies(r.txn)
 	policies[r.currentModuleID] = cpy
 
 	for id, mod := range r.modules {
@@ -360,7 +359,10 @@ func (r *REPL) compileBody(body ast.Body) (ast.Body, error) {
 		return nil, compiler.Errors
 	}
 
-	return mod.Rules[len(prev)].Body, nil
+	compiledMod := compiler.Modules[r.currentModuleID]
+	compiledBody := compiledMod.Rules[len(prev)].Body
+
+	return compiledBody, nil
 }
 
 func (r *REPL) compileRule(rule *ast.Rule) error {
@@ -437,7 +439,6 @@ func (r *REPL) evalBufferMulti() bool {
 func (r *REPL) loadCompiler() (*ast.Compiler, error) {
 
 	policies := r.store.ListPolicies(r.txn)
-
 	for id, mod := range r.modules {
 		policies[id] = mod
 	}

--- a/repl/repl_test.go
+++ b/repl/repl_test.go
@@ -560,6 +560,16 @@ func TestEvalImport(t *testing.T) {
 		t.Errorf("Expected expression to evaluate successfully but got: %v", result)
 		return
 	}
+
+	// https://github.com/open-policy-agent/opa/issues/158 - re-run query to
+	// make sure import is not lost
+	buffer.Reset()
+	repl.OneShot("a[0].b.c[0] = true")
+	result = buffer.String()
+	expected = "true\n"
+	if result != expected {
+		t.Fatalf("Expected expression to evaluate successfully but got: %v", result)
+	}
 }
 
 func TestEvalPackage(t *testing.T) {

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -220,6 +220,7 @@ func (rt *Runtime) getBanner() string {
 func compileAndStoreInputs(parsed map[string]*parsedModule, store *storage.Storage, txn storage.Transaction) error {
 
 	mods := store.ListPolicies(txn)
+
 	for _, p := range parsed {
 		mods[p.id] = p.mod
 	}
@@ -230,8 +231,7 @@ func compileAndStoreInputs(parsed map[string]*parsedModule, store *storage.Stora
 	}
 
 	for id := range parsed {
-		mod := c.Modules[id]
-		if err := store.InsertPolicy(txn, id, mod, parsed[id].raw, false); err != nil {
+		if err := store.InsertPolicy(txn, id, parsed[id].mod, parsed[id].raw, false); err != nil {
 			return err
 		}
 	}

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -21,6 +21,7 @@ func TestInit(t *testing.T) {
 		panic(err)
 	}
 	defer os.Remove(tmp1.Name())
+
 	doc1 := `{"foo": "bar", "x": {"y": {"z": [1]}}}`
 	if _, err := tmp1.Write([]byte(doc1)); err != nil {
 		panic(err)
@@ -82,6 +83,13 @@ func TestInit(t *testing.T) {
 	if util.Compare(node, "bar") != 0 || err != nil {
 		t.Errorf("Expected %v but got %v (err: %v)", "bar", node, err)
 		return
+	}
+
+	modules := rt.Store.ListPolicies(txn)
+	expected := ast.MustParseModule(mod1)
+
+	if !expected.Equal(modules[tmp2.Name()]) {
+		t.Fatalf("Expected %v but got: %v", expected, modules[tmp2.Name()])
 	}
 
 }

--- a/storage/example_test.go
+++ b/storage/example_test.go
@@ -186,6 +186,6 @@ func ExampleStorage_Open() {
 	fmt.Println("Expr:", mod.Rules[0].Body[0])
 
 	// Output:
-	// Expr: neq(data.opa.example.q.r, 0)
+	// Expr: neq(q.r, 0)
 
 }

--- a/storage/policystore.go
+++ b/storage/policystore.go
@@ -43,11 +43,11 @@ func loadPolicies(bufs map[string][]byte) (map[string]*ast.Module, error) {
 		return nil, c.Errors
 	}
 
-	return c.Modules, nil
+	return parsed, nil
 }
 
 // NewPolicyStore returns an empty PolicyStore.
-func newPolicyStore(store Store, policyDir string) *policyStore {
+func newPolicyStore(policyDir string) *policyStore {
 	return &policyStore{
 		policyDir: policyDir,
 		raw:       map[string][]byte{},
@@ -69,7 +69,7 @@ func (p *policyStore) List() map[string]*ast.Module {
 // This should be called on startup to load policies from persistent storage.
 // The callback function "f" will be invoked with the buffers representing the
 // persisted policies. The callback should return the compiled version of the
-// policies so that they can be installed into the data store.
+// policies so that they can be installed into the  store.
 func (p *policyStore) Open(txn Transaction, f func(map[string][]byte) (map[string]*ast.Module, error)) error {
 
 	if len(p.policyDir) == 0 {

--- a/storage/policystore_test.go
+++ b/storage/policystore_test.go
@@ -33,8 +33,7 @@ func TestPolicyStoreDefaultOpen(t *testing.T) {
 		panic(err)
 	}
 
-	dataStore := NewDataStore()
-	policyStore := newPolicyStore(dataStore, dir)
+	policyStore := newPolicyStore(dir)
 
 	err = policyStore.Open(invalidTXN, loadPolicies)
 	if err != nil {
@@ -54,9 +53,8 @@ func TestPolicyStoreDefaultOpen(t *testing.T) {
 		return
 	}
 
-	if !c.Modules["testMod1"].Equal(stored) {
-		t.Errorf("Expected %v from policy store but got: %v", c.Modules["testMod1"], stored)
-		return
+	if !mod.Equal(stored) {
+		t.Fatalf("Expected %v from policy store but got: %v", mod, stored)
 	}
 }
 
@@ -212,7 +210,7 @@ const (
 	testMod1 = `
     package a.b
 
-    p = true :- true
+    p = true :- q
     q = true :- true
     `
 
@@ -225,7 +223,6 @@ const (
 
 type fixture struct {
 	policyStore *policyStore
-	dataStore   *DataStore
 }
 
 func newFixture() *fixture {
@@ -235,8 +232,7 @@ func newFixture() *fixture {
 		panic(err)
 	}
 
-	dataStore := NewDataStore()
-	policyStore := newPolicyStore(dataStore, dir)
+	policyStore := newPolicyStore(dir)
 	err = policyStore.Open(invalidTXN, func(map[string][]byte) (map[string]*ast.Module, error) {
 		return nil, nil
 	})
@@ -246,7 +242,6 @@ func newFixture() *fixture {
 
 	f := &fixture{
 		policyStore: policyStore,
-		dataStore:   dataStore,
 	}
 
 	return f

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -66,7 +66,7 @@ func New(config Config) *Storage {
 	return &Storage{
 		builtin:     config.Builtin,
 		indices:     newIndices(),
-		policyStore: newPolicyStore(config.Builtin, config.PolicyDir),
+		policyStore: newPolicyStore(config.PolicyDir),
 		active:      map[string]struct{}{},
 	}
 }


### PR DESCRIPTION
Previously, the compiler would mutate the parsed modules and store them as
output. This made it difficult to reason about the state of modules
constructed programatically in places like the REPL.

This change adds a Copy() function to the AST types that are stored by
reference. This allows the compiler to deep copy the parsed modules before
operating on them. This removes the challenge of reasoning about how the
compiler will behave when compiling the same input multiple times.

Various callers had to be modified to deal with the new calling convention.
Unit tests have been added to verify the new behaviour.

Fixes #158