### PR TITLE
Fix indexing usage for refs with intersecting vars

### DIFF
--- a/topdown/topdown_test.go
+++ b/topdown/topdown_test.go
@@ -431,6 +431,9 @@ func TestTopDownEqExpr(t *testing.T) {
 		{"pattern: object = var", `p[x] :- {"a": 1, "b": y} = x, y = 2`, `[{"a": 1, "b": 2}]`},
 		{"pattern: object/array nested", `p[ys] :- f[i] = {"xs": [2.0], "ys": ys}`, `[[3.0]]`},
 		{"pattern: object/array nested 2", `p[v] :- f[i] = {"xs": [x], "ys": [y]}, v = [x, y]`, `[[1.0, 2.0], [2.0, 3.0]]`},
+
+		// indexing
+		{"indexing: intersection", "p :- a[i] = g[i][j]", ""},
 	}
 
 	data := loadSmallTestData()


### PR DESCRIPTION
If refs have intersecting vars, the bindings produced by the index and the
evaluation of the non-indexed term may conflict. In this case, evaluation
should not continue as it means the variable did not unify.

Also, refactored check performed to determine if indexing can be used.

Fixes #153