### PR TITLE
Fix "data" query in REPL and refactor query compilation

### DIFF
--- a/ast/compile.go
+++ b/ast/compile.go
@@ -117,64 +117,6 @@ type stage struct {
 	name string
 }
 
-// CompileModule is a helper function to compile a module represented as a string.
-func CompileModule(m string) (*Compiler, *Module, error) {
-
-	mod, err := ParseModule("", m)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	c := NewCompiler()
-
-	key := WildcardPrefix
-	mods := map[string]*Module{
-		key: mod,
-	}
-
-	if c.Compile(mods); c.Failed() {
-		return nil, nil, c.Errors
-	}
-
-	return c, c.Modules[key], nil
-}
-
-// CompileQuery is a helper function to compile a query represented as a string.
-func CompileQuery(q string) (*Compiler, Body, error) {
-
-	parsed, err := ParseBody(q)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	key := string(Wildcard.Value.(Var))
-
-	mod := &Module{
-		Package: &Package{
-			Path:     Ref{DefaultRootDocument},
-			Location: parsed.Loc(),
-		},
-		Rules: []*Rule{
-			&Rule{
-				Name:     Var(key),
-				Body:     parsed,
-				Location: parsed.Loc(),
-			},
-		},
-	}
-	mods := map[string]*Module{
-		key: mod,
-	}
-
-	c := NewCompiler()
-
-	if c.Compile(mods); c.Failed() {
-		return nil, nil, c.Errors
-	}
-
-	return c, c.Modules[key].Rules[0].Body, nil
-}
-
 // NewCompiler returns a new empty compiler.
 func NewCompiler() *Compiler {
 

--- a/ast/compile.go
+++ b/ast/compile.go
@@ -78,6 +78,20 @@ type QueryContext struct {
 	Imports []*Import
 }
 
+// NewQueryContext returns a new QueryContext object.
+func NewQueryContext(pkg *Package, imports []*Import) *QueryContext {
+	return &QueryContext{
+		Package: pkg,
+		Imports: imports,
+	}
+}
+
+// NewQueryContextForModule returns a new QueryContext object based on the
+// provided module.
+func NewQueryContextForModule(mod *Module) *QueryContext {
+	return NewQueryContext(mod.Package, mod.Imports)
+}
+
 // Copy returns a deep copy of qc.
 func (qc *QueryContext) Copy() *QueryContext {
 	if qc == nil {
@@ -90,14 +104,6 @@ func (qc *QueryContext) Copy() *QueryContext {
 		cpy.Imports[i] = qc.Imports[i].Copy()
 	}
 	return &cpy
-}
-
-// NewQueryContext returns a new QueryContext object.
-func NewQueryContext(pkg *Package, imports []*Import) *QueryContext {
-	return &QueryContext{
-		Package: pkg,
-		Imports: imports,
-	}
 }
 
 // QueryCompiler defines the interface for compiling ad-hoc queries.

--- a/ast/compile_test.go
+++ b/ast/compile_test.go
@@ -583,6 +583,10 @@ func TestCompilerCheckRecursion(t *testing.T) {
 						package rec7
 						prefix :- data.rec7
 						`),
+		"newMod9": MustParseModule(`
+						package rec8
+						dataref :- data
+						`),
 	}
 
 	compileStages(c, "", "checkRecursion")
@@ -605,6 +609,7 @@ func TestCompilerCheckRecursion(t *testing.T) {
 		makeErrMsg("np", "np", "nq", "np"),
 		makeErrMsg("nq", "nq", "np", "nq"),
 		makeErrMsg("prefix", "prefix", "prefix"),
+		makeErrMsg("dataref", "dataref", "dataref"),
 	}
 
 	result := compilerErrsToStringSlice(c.Errors)

--- a/ast/compile_test.go
+++ b/ast/compile_test.go
@@ -813,6 +813,27 @@ func TestCompilerGetRulesWithPrefix(t *testing.T) {
 	}
 }
 
+func TestQueryCompiler(t *testing.T) {
+	tests := []struct {
+		note     string
+		q        string
+		pkg      string
+		imports  []string
+		expected interface{}
+	}{
+		{"exports resolved", "z", "package a.b.c", nil, "data.a.b.c.z"},
+		{"imports resolved", "z", "package a.b.c.d", []string{"import data.a.b.c.z"}, "data.a.b.c.z"},
+		{"unsafe vars", "z", "", nil, fmt.Errorf("1 error occurred: 1:1: z is unsafe (variable z must appear in the output position of at least one non-negated expression)")},
+		{"safe vars", "data, abc", "package ex", []string{"import xyz as abc"}, "data, xyz"},
+		{"reorder", "x != 1, x = 0", "", nil, "x = 0, x != 1"},
+		{"bad builtin", "deadbeef(1,2,3)", "", nil, fmt.Errorf("1 error occurred: 1:1: deadbeef is unsafe (variable deadbeef must appear in the output position of at least one non-negated expression)")},
+	}
+
+	for _, tc := range tests {
+		runQueryCompilerTest(t, tc.note, tc.q, tc.pkg, tc.imports, tc.expected)
+	}
+}
+
 func assertNotFailed(t *testing.T, c *Compiler) {
 	if c.Failed() {
 		t.Errorf("Unexpected compilation error: %v", c.Errors)
@@ -919,4 +940,44 @@ func compilerErrsToStringSlice(errors []*Error) []string {
 	}
 	sort.Strings(result)
 	return result
+}
+
+func runQueryCompilerTest(t *testing.T, note, q, pkg string, imports []string, expected interface{}) {
+	test.Subtest(t, note, func(t *testing.T) {
+		c := NewCompiler()
+		c.Compile(getCompilerTestModules())
+		assertNotFailed(t, c)
+		qc := c.QueryCompiler()
+		query := MustParseBody(q)
+		var qctx *QueryContext
+		if pkg != "" {
+			pkg := MustParsePackage(pkg)
+			qctx = NewQueryContext(pkg, nil)
+			if len(imports) > 0 {
+				qctx.Imports = MustParseImports(strings.Join(imports, "\n"))
+			}
+		}
+		if qctx != nil {
+			qc.WithContext(qctx)
+		}
+		switch expected := expected.(type) {
+		case string:
+			expectedQuery := MustParseBody(expected)
+			result, err := qc.Compile(query)
+			if err != nil {
+				t.Fatalf("Unexpected error from %v: %v", query, err)
+			}
+			if !expectedQuery.Equal(result) {
+				t.Fatalf("Expected:\n%v\n\nGot:\n%v", expectedQuery, result)
+			}
+		case error:
+			result, err := qc.Compile(query)
+			if err == nil {
+				t.Fatalf("Expected error from %v but got: %v", query, result)
+			}
+			if err.Error() != expected.Error() {
+				t.Fatalf("Expected error %v but got: %v", expected, err)
+			}
+		}
+	})
 }

--- a/ast/errors.go
+++ b/ast/errors.go
@@ -50,7 +50,7 @@ const (
 
 // Error represents a single error caught during parsing, compiling, etc.
 type Error struct {
-	Code     int
+	Code     ErrCode
 	Location *Location
 	Message  string
 }
@@ -70,7 +70,7 @@ func (e *Error) Error() string {
 }
 
 // NewError returns a new Error object.
-func NewError(code int, loc *Location, f string, a ...interface{}) *Error {
+func NewError(code ErrCode, loc *Location, f string, a ...interface{}) *Error {
 	return &Error{
 		Code:     code,
 		Location: loc,

--- a/ast/example_test.go
+++ b/ast/example_test.go
@@ -20,7 +20,7 @@ func ExampleCompiler_Compile() {
 		import data.foo
 		import bar
 
-		p[x] :- foo[x], not bar[x], x < min_x
+		p[x] :- foo[x], not bar[x], x >= min_x
 
 		min_x = 100
 
@@ -51,5 +51,70 @@ func ExampleCompiler_Compile() {
 	//
 	// Expr 1: data.foo[x]
 	// Expr 2: not bar[x]
-	// Expr 3: lt(x, data.opa.example.min_x)
+	// Expr 3: gte(x, data.opa.example.min_x)
+}
+
+func ExampleQueryCompiler_Compile() {
+
+	// Define an input module that will be compiled.
+	exampleModule := `
+
+		package opa.example
+
+		import data.foo
+		import bar
+
+		p[x] :- foo[x], not bar[x], x >= min_x
+
+		min_x = 100
+
+	`
+
+	// Parse the input module to obtain the AST representation.
+	mod, err := ast.ParseModule("my_module", exampleModule)
+	if err != nil {
+		fmt.Println("Parse error:", err)
+	}
+
+	// Create a new compiler instance and compile the module.
+	c := ast.NewCompiler()
+
+	mods := map[string]*ast.Module{
+		"my_module": mod,
+	}
+
+	if c.Compile(mods); c.Failed() {
+		fmt.Println("Compile error:", c.Errors)
+	}
+
+	// Obtain the QueryCompiler from the compiler instance. Note, we will
+	// compile this query within the context of the opa.example package and
+	// declare that a query input named "queryinput" must be supplied.
+	qc := c.QueryCompiler().
+		WithContext(
+			ast.NewQueryContext(
+				// Note, the ast.MustParse<X> functions are meant for test
+				// purposes only. They will panic if an error occurs. Prefer the
+				// ast.Parse<X> functions that return meaningful error messages
+				// instead.
+				ast.MustParsePackage("package opa.example"),
+				ast.MustParseImports("import queryinput"),
+			))
+
+	// Parse the input query to obtain the AST representation.
+	query, err := ast.ParseBody("p[x], x < queryinput")
+	if err != nil {
+		fmt.Println("Parse error:", err)
+	}
+
+	compiled, err := qc.Compile(query)
+	if err != nil {
+		fmt.Println("Compile error:", err)
+	}
+
+	fmt.Println("Compiled:", compiled)
+
+	// Output:
+	//
+	// Compiled: data.opa.example.p[x], lt(x, queryinput)
 }

--- a/ast/parser_ext.go
+++ b/ast/parser_ext.go
@@ -36,10 +36,30 @@ func MustParseExpr(input string) *Expr {
 	return parsed
 }
 
+// MustParseImports returns a slice of imports.
+// If an error occurs during parsing, panic.
+func MustParseImports(input string) []*Import {
+	parsed, err := ParseImports(input)
+	if err != nil {
+		panic(err)
+	}
+	return parsed
+}
+
 // MustParseModule returns a parsed module.
 // If an error occurs during parsing, panic.
 func MustParseModule(input string) *Module {
 	parsed, err := ParseModule("", input)
+	if err != nil {
+		panic(err)
+	}
+	return parsed
+}
+
+// MustParsePackage returns a Package.
+// If an error occurs during parsing, panic.
+func MustParsePackage(input string) *Package {
+	parsed, err := ParsePackage(input)
 	if err != nil {
 		panic(err)
 	}
@@ -127,6 +147,23 @@ func ParseConstantRule(body Body) *Rule {
 	}
 }
 
+// ParseImports returns a slice of Import objects.
+func ParseImports(input string) ([]*Import, error) {
+	stmts, err := ParseStatements("", input)
+	if err != nil {
+		return nil, err
+	}
+	result := []*Import{}
+	for _, stmt := range stmts {
+		if imp, ok := stmt.(*Import); ok {
+			result = append(result, imp)
+		} else {
+			return nil, fmt.Errorf("expected import but got %T", stmt)
+		}
+	}
+	return result, nil
+}
+
 // ParseModule returns a parsed Module object.
 // For details on Module objects and their fields, see policy.go.
 // Empty input will return nil, nil.
@@ -166,6 +203,20 @@ func ParseExpr(input string) (*Expr, error) {
 		return nil, fmt.Errorf("expected exactly one expression but got: %v", body)
 	}
 	return body[0], nil
+}
+
+// ParsePackage returns exactly one Package.
+// If multiple statements are parsed, an error is returned.
+func ParsePackage(input string) (*Package, error) {
+	stmt, err := ParseStatement(input)
+	if err != nil {
+		return nil, err
+	}
+	pkg, ok := stmt.(*Package)
+	if !ok {
+		return nil, fmt.Errorf("expected package but got %T", stmt)
+	}
+	return pkg, nil
 }
 
 // ParseTerm returns exactly one term.

--- a/ast/policy.go
+++ b/ast/policy.go
@@ -13,9 +13,15 @@ import (
 )
 
 // DefaultRootDocument is the default root document.
-// All package directives inside source files are implicitly
-// prefixed with the DefaultRootDocument value.
+//
+// All package directives inside source files are implicitly prefixed with the
+// DefaultRootDocument value.
 var DefaultRootDocument = VarTerm("data")
+
+// DefaultRootRef is a reference to the root of the default document.
+//
+// All refs to data in the policy engine's storage layer are prefixed with this ref.
+var DefaultRootRef = Ref{DefaultRootDocument}
 
 // ReservedVars is the set of reserved variable names.
 var ReservedVars = NewVarSet(DefaultRootDocument.Value.(Var))

--- a/repl/repl_test.go
+++ b/repl/repl_test.go
@@ -144,7 +144,7 @@ func TestUnset(t *testing.T) {
 	repl.OneShot("unset p")
 	repl.OneShot("p")
 	result := buffer.String()
-	if result != "error: 1 error occurred: 1:1: repl2: p is unsafe (variable p must appear in the output position of at least one non-negated expression)\n" {
+	if result != "error: 1 error occurred: 1:1: p is unsafe (variable p must appear in the output position of at least one non-negated expression)\n" {
 		t.Errorf("Expected p to be unsafe but got: %v", result)
 		return
 	}
@@ -155,7 +155,7 @@ func TestUnset(t *testing.T) {
 	repl.OneShot("unset p")
 	repl.OneShot("p")
 	result = buffer.String()
-	if result != "error: 1 error occurred: 1:1: repl4: p is unsafe (variable p must appear in the output position of at least one non-negated expression)\n" {
+	if result != "error: 1 error occurred: 1:1: p is unsafe (variable p must appear in the output position of at least one non-negated expression)\n" {
 		t.Errorf("Expected p to be unsafe but got: %v", result)
 		return
 	}
@@ -298,6 +298,52 @@ func TestOneShotJSON(t *testing.T) {
 	}
 	if !reflect.DeepEqual(expected, result) {
 		t.Errorf("Expected %v but got: %v", expected, result)
+	}
+}
+
+func TestEvalData(t *testing.T) {
+	store := newTestStore()
+	var buffer bytes.Buffer
+	repl := newRepl(store, &buffer)
+	testmod := ast.MustParseModule(`package ex
+	p = [1,2,3]`)
+	if err := storage.InsertPolicy(store, "test", testmod, nil, false); err != nil {
+		panic(err)
+	}
+	repl.OneShot("data")
+	expected := parseJSON(`
+	{
+		"a": [
+			{
+			"b": {
+				"c": [
+				true,
+				2,
+				false
+				]
+			}
+			},
+			{
+			"b": {
+				"c": [
+				false,
+				true,
+				1
+				]
+			}
+			}
+		],
+		"ex": {
+			"p": [
+			1,
+			2,
+			3
+			]
+		}
+	}`)
+	result := parseJSON(buffer.String())
+	if !reflect.DeepEqual(result, expected) {
+		t.Fatalf("Expected:\n%v\n\nGot:\n%v", expected, result)
 	}
 }
 
@@ -497,7 +543,7 @@ func TestEvalRuleCompileError(t *testing.T) {
 	repl.OneShot("p = true :- true")
 	result = buffer.String()
 	if result != "" {
-		t.Errorf("Expected valid rule to compile (because state should have been rolled back) but got: %v", result)
+		t.Errorf("Expected valid rule to compile (because state should be unaffected) but got: %v", result)
 	}
 }
 
@@ -508,7 +554,7 @@ func TestEvalBodyCompileError(t *testing.T) {
 	repl.outputFormat = "json"
 	repl.OneShot("x = 1, y > x")
 	result1 := buffer.String()
-	expected1 := "error: 1 error occurred: 1:1: repl0: y is unsafe (variable y must appear in the output position of at least one non-negated expression)\n"
+	expected1 := "error: 1 error occurred: 1:1: y is unsafe (variable y must appear in the output position of at least one non-negated expression)\n"
 	if result1 != expected1 {
 		t.Errorf("Expected error message in output but got`: %v", result1)
 		return
@@ -615,7 +661,7 @@ func TestEvalPackage(t *testing.T) {
 	repl.OneShot("package baz.qux")
 	buffer.Reset()
 	repl.OneShot("p")
-	if buffer.String() != "error: 1 error occurred: 1:1: repl0: p is unsafe (variable p must appear in the output position of at least one non-negated expression)\n" {
+	if buffer.String() != "error: 1 error occurred: 1:1: p is unsafe (variable p must appear in the output position of at least one non-negated expression)\n" {
 		t.Errorf("Expected unsafe variable error but got: %v", buffer.String())
 		return
 	}

--- a/repl/repl_test.go
+++ b/repl/repl_test.go
@@ -22,18 +22,13 @@ import (
 
 func TestComplete(t *testing.T) {
 	store := newTestStore()
-	_, mod1, err := ast.CompileModule(`package a.b.c
+
+	mod1 := ast.MustParseModule(`package a.b.c
 	p = 1
 	q = 2`)
-	if err != nil {
-		panic(err)
-	}
 
-	_, mod2, err := ast.CompileModule(`package a.b.d
+	mod2 := ast.MustParseModule(`package a.b.d
 	r = 3`)
-	if err != nil {
-		panic(err)
-	}
 
 	if err := storage.InsertPolicy(store, "mod1", mod1, nil, false); err != nil {
 		panic(err)

--- a/topdown/example_test.go
+++ b/topdown/example_test.go
@@ -15,8 +15,10 @@ import (
 
 func ExampleEval() {
 
+	compiler := ast.NewCompiler()
+
 	// Define a dummy query and some data that the query will execute against.
-	compiler, query, err := ast.CompileQuery("data.a[_] = x, x >= 2")
+	query, err := compiler.QueryCompiler().Compile(ast.MustParseBody("data.a[_] = x, x >= 2"))
 	if err != nil {
 		// Handle error.
 	}
@@ -74,8 +76,10 @@ func ExampleEval() {
 
 func ExampleQuery() {
 
+	compiler := ast.NewCompiler()
+
 	// Define a dummy module with rules that produce documents that we will query below.
-	compiler, _, err := ast.CompileModule(`
+	module, err := ast.ParseModule("my_module.rego", `
 
 	    package opa.example
 
@@ -84,6 +88,14 @@ func ExampleQuery() {
 	    r[z] :- b = [2,4], z = b[_]
 
 	`)
+
+	mods := map[string]*ast.Module{
+		"my_module": module,
+	}
+
+	if compiler.Compile(mods); compiler.Failed() {
+		fmt.Println(compiler.Errors)
+	}
 
 	if err != nil {
 		// Handle error.

--- a/topdown/explain/explain_test.go
+++ b/topdown/explain/explain_test.go
@@ -210,9 +210,12 @@ func executeQuery(data string, compiler *ast.Compiler, tracer topdown.Tracer) {
 }
 
 func explainQuery(data string, module string) ([]*topdown.Event, []*topdown.Event, error) {
-	compiler, _, err := ast.CompileModule(module)
-	if err != nil {
-		panic(err)
+
+	compiler := ast.NewCompiler()
+	mods := map[string]*ast.Module{"": ast.MustParseModule(module)}
+
+	if compiler.Compile(mods); compiler.Failed() {
+		panic(compiler.Errors)
 	}
 
 	buf := topdown.NewBufferTracer()


### PR DESCRIPTION
These changes are mostly refactoring with the goal of fixing the "data" query in the REPL. The main change is the introduction of a separate interface (`ast.QueryCompiler`) to compile ad-hoc queries.

The `ast.QueryCompiler` can be obtained from an instance of an `ast.Compiler`.

This avoids the need to construct fake modules/rules in order to compile ad-hoc queries and also avoids the need to re-compile every module each time an ad-hoc query has to be compiled.

Fixes #150 