### PR TITLE
REPL improvements

### DIFF
--- a/ast/policy.go
+++ b/ast/policy.go
@@ -129,13 +129,17 @@ func (mod *Module) Equal(other *Module) bool {
 func (mod *Module) String() string {
 	buf := []string{}
 	buf = append(buf, mod.Package.String())
-	buf = append(buf, "")
-	for _, imp := range mod.Imports {
-		buf = append(buf, imp.String())
+	if len(mod.Imports) > 0 {
+		buf = append(buf, "")
+		for _, imp := range mod.Imports {
+			buf = append(buf, imp.String())
+		}
 	}
-	buf = append(buf, "")
-	for _, rule := range mod.Rules {
-		buf = append(buf, rule.String())
+	if len(mod.Rules) > 0 {
+		buf = append(buf, "")
+		for _, rule := range mod.Rules {
+			buf = append(buf, rule.String())
+		}
 	}
 	return strings.Join(buf, "\n")
 }

--- a/repl/repl_test.go
+++ b/repl/repl_test.go
@@ -49,6 +49,7 @@ func TestComplete(t *testing.T) {
 		"data.a.b.c.q",
 		"data.a.b.d.r",
 		"data.repl.s",
+		"data.repl.version",
 	}
 
 	sort.Strings(result)
@@ -139,14 +140,15 @@ func TestShow(t *testing.T) {
 	var buffer bytes.Buffer
 	repl := newRepl(store, &buffer)
 
+	repl.OneShot("package repl_test")
 	repl.OneShot("show")
-	assertREPLText(t, buffer, "package repl\n")
+	assertREPLText(t, buffer, "package repl_test\n")
 	buffer.Reset()
 
 	repl.OneShot("import xyz")
 	repl.OneShot("show")
 
-	expected := `package repl
+	expected := `package repl_test
 
 import xyz` + "\n"
 	assertREPLText(t, buffer, expected)
@@ -155,7 +157,7 @@ import xyz` + "\n"
 	repl.OneShot("import data.foo as bar")
 	repl.OneShot("show")
 
-	expected = `package repl
+	expected = `package repl_test
 
 import xyz
 import data.foo as bar` + "\n"
@@ -166,7 +168,7 @@ import data.foo as bar` + "\n"
 	repl.OneShot("p[2] :- true")
 	repl.OneShot("show")
 
-	expected = `package repl
+	expected = `package repl_test
 
 import xyz
 import data.foo as bar
@@ -182,7 +184,7 @@ p[2] :- true` + "\n"
 	assertREPLText(t, buffer, "package abc\n")
 	buffer.Reset()
 
-	repl.OneShot("package repl")
+	repl.OneShot("package repl_test")
 	repl.OneShot("show")
 
 	assertREPLText(t, buffer, expected)
@@ -397,6 +399,11 @@ func TestEvalData(t *testing.T) {
 		}
 	}`)
 	result := parseJSON(buffer.String())
+
+	// Strip REPL documents out as these change depending on build settings.
+	data := result.(map[string]interface{})
+	delete(data, "repl")
+
 	if !reflect.DeepEqual(result, expected) {
 		t.Fatalf("Expected:\n%v\n\nGot:\n%v", expected, result)
 	}


### PR DESCRIPTION
New REPL help output looks like this:

```
(dev)torin:~/go/src/github.com/open-policy-agent/opa$ ./opa_darwin_amd64 run
OPA 0.2.2-dev (commit e83a083, built at 2016-11-25T01:40:36Z)

Run 'help' to see a list of commands.

> help

Examples
========

> data               # show all documents
> data[x] = _        # show all top level keys
> data.repl.version  # drill into specific document

Commands
========

        <stmt> : evaluate the statement
package <term> : change active package
 import <term> : add import to active module
          show : show active module definition
   unset <var> : undefine rules in currently active module
          json : set output format to JSON
        pretty : set output format to pretty
         trace : toggle full trace
         truth : toggle truth explanation
   dump [path] : dump raw data in storage
          help : print this message
          exit : exit back to shell (or ctrl+c, ctrl+d)
        ctrl+l : clear the screen

>
>
> data.repl.version
{
  "BuildCommit": "e83a083",
  "BuildHostname": "excess.local",
  "BuildTimestamp": "2016-11-25T01:40:36Z",
  "Version": "0.2.2-dev"
}
>
>
```