### PR TITLE
Add command line flag to eval, print, and exit

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -28,7 +28,7 @@ var defaultAddr = ":8181"
 
 func init() {
 
-	params := &runtime.Params{}
+	params := runtime.NewParams()
 
 	runCommand := &cobra.Command{
 		Use:   "run",
@@ -39,13 +39,13 @@ To run the interactive shell:
 
 	$ opa run
 
-To run the server without saving policies:
+To run the server:
 
 	$ opa run -s
 
-To run the server and persist policies to a local directory:
+To evaluate a query from the command line:
 
-	$ opa run -s -p ./policies/
+	$ opa run -e 'data.repl.version[key] = value'
 
 The 'run' command starts an instance of the OPA runtime. The OPA
 runtime can be started as an interactive shell or a server.
@@ -70,6 +70,7 @@ In addition, API calls to delete policies will remove the definition file.
 	}
 
 	runCommand.Flags().BoolVarP(&params.Server, "server", "s", false, "start the runtime in server mode")
+	runCommand.Flags().StringVarP(&params.Eval, "eval", "e", "", "evaluate, print, exit")
 	runCommand.Flags().StringVarP(&params.HistoryPath, "history", "H", historyPath(), "set path of history file")
 	runCommand.Flags().StringVarP(&params.PolicyDir, "policy-dir", "p", "", "set directory to store policy definitions")
 	runCommand.Flags().StringVarP(&params.Addr, "addr", "a", defaultAddr, "set listening address of the server")

--- a/repl/errors.go
+++ b/repl/errors.go
@@ -1,0 +1,41 @@
+// Copyright 2016 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package repl
+
+import "fmt"
+
+// Error is the error type returned by the REPL.
+type Error struct {
+	Code    ErrCode
+	Message string
+}
+
+func (err *Error) Error() string {
+	return fmt.Sprintf("code %v: %v", err.Code, err.Message)
+}
+
+// ErrCode represents the collection of errors that may be returned by the REPL.
+type ErrCode int
+
+const (
+	// BadArgsErr indicates bad arguments were provided to a built-in REPL
+	// command.
+	BadArgsErr ErrCode = iota
+)
+
+func newBadArgsErr(f string, a ...interface{}) *Error {
+	return &Error{
+		Code:    BadArgsErr,
+		Message: fmt.Sprintf(f, a...),
+	}
+}
+
+// stop is returned by the 'exit' command to indicate to the REPL that it should
+// break and return.
+type stop struct{}
+
+func (stop) Error() string {
+	return "<stop>"
+}


### PR DESCRIPTION
Can now evaluate queries from the command line, for example:

```
$ opa run -f json -e 'data.repl.version[x] = y'
```

Fixes #152