### PR TITLE
Fix error handling bug in Query API

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -348,7 +348,7 @@ func (s *Server) execQuery(compiler *ast.Compiler, txn storage.Transaction, quer
 				return false
 			}
 			vv, e := topdown.ValueToInterface(v, ctx)
-			if err != nil {
+			if e != nil {
 				err = e
 				return true
 			}


### PR DESCRIPTION
The server was not correctly checking the return code from the binding
conversion.

Fixes #183