### PR TITLE
Updates to handle large integers

### DIFF
--- a/ast/compare.go
+++ b/ast/compare.go
@@ -5,8 +5,11 @@
 package ast
 
 import (
+	"encoding/json"
 	"fmt"
 	"sort"
+
+	"github.com/open-policy-agent/opa/util"
 )
 
 // Compare returns an integer indicating whether two AST values are less than,
@@ -81,14 +84,7 @@ func Compare(a, b interface{}) int {
 		}
 		return 1
 	case Number:
-		b := b.(Number)
-		if a.Equal(b) {
-			return 0
-		}
-		if a < b {
-			return -1
-		}
-		return 1
+		return util.Compare(json.Number(a), json.Number(b.(Number)))
 	case String:
 		b := b.(String)
 		if a.Equal(b) {

--- a/ast/map_test.go
+++ b/ast/map_test.go
@@ -78,7 +78,7 @@ func TestValueMapGetMissing(t *testing.T) {
 func TestValueMapString(t *testing.T) {
 	a := NewValueMap()
 	a.Put(MustParseRef("a.b.c[x]"), String("foo"))
-	a.Put(Var("x"), Number(1))
+	a.Put(Var("x"), Number("1"))
 	result := a.String()
 	o1 := `{a.b.c[x]: "foo", x: 1}`
 	o2 := `{x: 1, a.b.c[x]: "foo"}`

--- a/ast/parser.go
+++ b/ast/parser.go
@@ -2,6 +2,7 @@ package ast
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -1378,48 +1379,48 @@ var g = &grammar{
 		},
 		{
 			name: "String",
-			pos:  position{line: 352, col: 1, offset: 10224},
+			pos:  position{line: 352, col: 1, offset: 10242},
 			expr: &actionExpr{
-				pos: position{line: 352, col: 11, offset: 10234},
+				pos: position{line: 352, col: 11, offset: 10252},
 				run: (*parser).callonString1,
 				expr: &seqExpr{
-					pos: position{line: 352, col: 11, offset: 10234},
+					pos: position{line: 352, col: 11, offset: 10252},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 352, col: 11, offset: 10234},
+							pos:        position{line: 352, col: 11, offset: 10252},
 							val:        "\"",
 							ignoreCase: false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 352, col: 15, offset: 10238},
+							pos: position{line: 352, col: 15, offset: 10256},
 							expr: &choiceExpr{
-								pos: position{line: 352, col: 17, offset: 10240},
+								pos: position{line: 352, col: 17, offset: 10258},
 								alternatives: []interface{}{
 									&seqExpr{
-										pos: position{line: 352, col: 17, offset: 10240},
+										pos: position{line: 352, col: 17, offset: 10258},
 										exprs: []interface{}{
 											&notExpr{
-												pos: position{line: 352, col: 17, offset: 10240},
+												pos: position{line: 352, col: 17, offset: 10258},
 												expr: &ruleRefExpr{
-													pos:  position{line: 352, col: 18, offset: 10241},
+													pos:  position{line: 352, col: 18, offset: 10259},
 													name: "EscapedChar",
 												},
 											},
 											&anyMatcher{
-												line: 352, col: 30, offset: 10253,
+												line: 352, col: 30, offset: 10271,
 											},
 										},
 									},
 									&seqExpr{
-										pos: position{line: 352, col: 34, offset: 10257},
+										pos: position{line: 352, col: 34, offset: 10275},
 										exprs: []interface{}{
 											&litMatcher{
-												pos:        position{line: 352, col: 34, offset: 10257},
+												pos:        position{line: 352, col: 34, offset: 10275},
 												val:        "\\",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 352, col: 39, offset: 10262},
+												pos:  position{line: 352, col: 39, offset: 10280},
 												name: "EscapeSequence",
 											},
 										},
@@ -1428,7 +1429,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 352, col: 57, offset: 10280},
+							pos:        position{line: 352, col: 57, offset: 10298},
 							val:        "\"",
 							ignoreCase: false,
 						},
@@ -1438,24 +1439,24 @@ var g = &grammar{
 		},
 		{
 			name: "Bool",
-			pos:  position{line: 361, col: 1, offset: 10538},
+			pos:  position{line: 361, col: 1, offset: 10556},
 			expr: &choiceExpr{
-				pos: position{line: 361, col: 9, offset: 10546},
+				pos: position{line: 361, col: 9, offset: 10564},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 361, col: 9, offset: 10546},
+						pos: position{line: 361, col: 9, offset: 10564},
 						run: (*parser).callonBool2,
 						expr: &litMatcher{
-							pos:        position{line: 361, col: 9, offset: 10546},
+							pos:        position{line: 361, col: 9, offset: 10564},
 							val:        "true",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 365, col: 5, offset: 10646},
+						pos: position{line: 365, col: 5, offset: 10664},
 						run: (*parser).callonBool4,
 						expr: &litMatcher{
-							pos:        position{line: 365, col: 5, offset: 10646},
+							pos:        position{line: 365, col: 5, offset: 10664},
 							val:        "false",
 							ignoreCase: false,
 						},
@@ -1465,12 +1466,12 @@ var g = &grammar{
 		},
 		{
 			name: "Null",
-			pos:  position{line: 371, col: 1, offset: 10747},
+			pos:  position{line: 371, col: 1, offset: 10765},
 			expr: &actionExpr{
-				pos: position{line: 371, col: 9, offset: 10755},
+				pos: position{line: 371, col: 9, offset: 10773},
 				run: (*parser).callonNull1,
 				expr: &litMatcher{
-					pos:        position{line: 371, col: 9, offset: 10755},
+					pos:        position{line: 371, col: 9, offset: 10773},
 					val:        "null",
 					ignoreCase: false,
 				},
@@ -1478,26 +1479,26 @@ var g = &grammar{
 		},
 		{
 			name: "Integer",
-			pos:  position{line: 377, col: 1, offset: 10850},
+			pos:  position{line: 377, col: 1, offset: 10868},
 			expr: &choiceExpr{
-				pos: position{line: 377, col: 12, offset: 10861},
+				pos: position{line: 377, col: 12, offset: 10879},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 377, col: 12, offset: 10861},
+						pos:        position{line: 377, col: 12, offset: 10879},
 						val:        "0",
 						ignoreCase: false,
 					},
 					&seqExpr{
-						pos: position{line: 377, col: 18, offset: 10867},
+						pos: position{line: 377, col: 18, offset: 10885},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 377, col: 18, offset: 10867},
+								pos:  position{line: 377, col: 18, offset: 10885},
 								name: "NonZeroDecimalDigit",
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 377, col: 38, offset: 10887},
+								pos: position{line: 377, col: 38, offset: 10905},
 								expr: &ruleRefExpr{
-									pos:  position{line: 377, col: 38, offset: 10887},
+									pos:  position{line: 377, col: 38, offset: 10905},
 									name: "DecimalDigit",
 								},
 							},
@@ -1508,19 +1509,19 @@ var g = &grammar{
 		},
 		{
 			name: "Exponent",
-			pos:  position{line: 379, col: 1, offset: 10902},
+			pos:  position{line: 379, col: 1, offset: 10920},
 			expr: &seqExpr{
-				pos: position{line: 379, col: 13, offset: 10914},
+				pos: position{line: 379, col: 13, offset: 10932},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 379, col: 13, offset: 10914},
+						pos:        position{line: 379, col: 13, offset: 10932},
 						val:        "e",
 						ignoreCase: true,
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 379, col: 18, offset: 10919},
+						pos: position{line: 379, col: 18, offset: 10937},
 						expr: &charClassMatcher{
-							pos:        position{line: 379, col: 18, offset: 10919},
+							pos:        position{line: 379, col: 18, offset: 10937},
 							val:        "[+-]",
 							chars:      []rune{'+', '-'},
 							ignoreCase: false,
@@ -1528,9 +1529,9 @@ var g = &grammar{
 						},
 					},
 					&oneOrMoreExpr{
-						pos: position{line: 379, col: 24, offset: 10925},
+						pos: position{line: 379, col: 24, offset: 10943},
 						expr: &ruleRefExpr{
-							pos:  position{line: 379, col: 24, offset: 10925},
+							pos:  position{line: 379, col: 24, offset: 10943},
 							name: "DecimalDigit",
 						},
 					},
@@ -1539,9 +1540,9 @@ var g = &grammar{
 		},
 		{
 			name: "AsciiLetter",
-			pos:  position{line: 381, col: 1, offset: 10940},
+			pos:  position{line: 381, col: 1, offset: 10958},
 			expr: &charClassMatcher{
-				pos:        position{line: 381, col: 16, offset: 10955},
+				pos:        position{line: 381, col: 16, offset: 10973},
 				val:        "[A-Za-z_]",
 				chars:      []rune{'_'},
 				ranges:     []rune{'A', 'Z', 'a', 'z'},
@@ -1551,9 +1552,9 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedChar",
-			pos:  position{line: 383, col: 1, offset: 10966},
+			pos:  position{line: 383, col: 1, offset: 10984},
 			expr: &charClassMatcher{
-				pos:        position{line: 383, col: 16, offset: 10981},
+				pos:        position{line: 383, col: 16, offset: 10999},
 				val:        "[\\x00-\\x1f\"\\\\]",
 				chars:      []rune{'"', '\\'},
 				ranges:     []rune{'\x00', '\x1f'},
@@ -1563,16 +1564,16 @@ var g = &grammar{
 		},
 		{
 			name: "EscapeSequence",
-			pos:  position{line: 385, col: 1, offset: 10997},
+			pos:  position{line: 385, col: 1, offset: 11015},
 			expr: &choiceExpr{
-				pos: position{line: 385, col: 19, offset: 11015},
+				pos: position{line: 385, col: 19, offset: 11033},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 385, col: 19, offset: 11015},
+						pos:  position{line: 385, col: 19, offset: 11033},
 						name: "SingleCharEscape",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 385, col: 38, offset: 11034},
+						pos:  position{line: 385, col: 38, offset: 11052},
 						name: "UnicodeEscape",
 					},
 				},
@@ -1580,9 +1581,9 @@ var g = &grammar{
 		},
 		{
 			name: "SingleCharEscape",
-			pos:  position{line: 387, col: 1, offset: 11049},
+			pos:  position{line: 387, col: 1, offset: 11067},
 			expr: &charClassMatcher{
-				pos:        position{line: 387, col: 21, offset: 11069},
+				pos:        position{line: 387, col: 21, offset: 11087},
 				val:        "[\"\\\\/bfnrt]",
 				chars:      []rune{'"', '\\', '/', 'b', 'f', 'n', 'r', 't'},
 				ignoreCase: false,
@@ -1591,29 +1592,29 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeEscape",
-			pos:  position{line: 389, col: 1, offset: 11082},
+			pos:  position{line: 389, col: 1, offset: 11100},
 			expr: &seqExpr{
-				pos: position{line: 389, col: 18, offset: 11099},
+				pos: position{line: 389, col: 18, offset: 11117},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 389, col: 18, offset: 11099},
+						pos:        position{line: 389, col: 18, offset: 11117},
 						val:        "u",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 389, col: 22, offset: 11103},
+						pos:  position{line: 389, col: 22, offset: 11121},
 						name: "HexDigit",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 389, col: 31, offset: 11112},
+						pos:  position{line: 389, col: 31, offset: 11130},
 						name: "HexDigit",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 389, col: 40, offset: 11121},
+						pos:  position{line: 389, col: 40, offset: 11139},
 						name: "HexDigit",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 389, col: 49, offset: 11130},
+						pos:  position{line: 389, col: 49, offset: 11148},
 						name: "HexDigit",
 					},
 				},
@@ -1621,9 +1622,9 @@ var g = &grammar{
 		},
 		{
 			name: "DecimalDigit",
-			pos:  position{line: 391, col: 1, offset: 11140},
+			pos:  position{line: 391, col: 1, offset: 11158},
 			expr: &charClassMatcher{
-				pos:        position{line: 391, col: 17, offset: 11156},
+				pos:        position{line: 391, col: 17, offset: 11174},
 				val:        "[0-9]",
 				ranges:     []rune{'0', '9'},
 				ignoreCase: false,
@@ -1632,9 +1633,9 @@ var g = &grammar{
 		},
 		{
 			name: "NonZeroDecimalDigit",
-			pos:  position{line: 393, col: 1, offset: 11163},
+			pos:  position{line: 393, col: 1, offset: 11181},
 			expr: &charClassMatcher{
-				pos:        position{line: 393, col: 24, offset: 11186},
+				pos:        position{line: 393, col: 24, offset: 11204},
 				val:        "[1-9]",
 				ranges:     []rune{'1', '9'},
 				ignoreCase: false,
@@ -1643,9 +1644,9 @@ var g = &grammar{
 		},
 		{
 			name: "HexDigit",
-			pos:  position{line: 395, col: 1, offset: 11193},
+			pos:  position{line: 395, col: 1, offset: 11211},
 			expr: &charClassMatcher{
-				pos:        position{line: 395, col: 13, offset: 11205},
+				pos:        position{line: 395, col: 13, offset: 11223},
 				val:        "[0-9a-f]",
 				ranges:     []rune{'0', '9', 'a', 'f'},
 				ignoreCase: false,
@@ -1655,11 +1656,11 @@ var g = &grammar{
 		{
 			name:        "ws",
 			displayName: "\"whitespace\"",
-			pos:         position{line: 397, col: 1, offset: 11215},
+			pos:         position{line: 397, col: 1, offset: 11233},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 397, col: 20, offset: 11234},
+				pos: position{line: 397, col: 20, offset: 11252},
 				expr: &charClassMatcher{
-					pos:        position{line: 397, col: 20, offset: 11234},
+					pos:        position{line: 397, col: 20, offset: 11252},
 					val:        "[ \\t\\r\\n]",
 					chars:      []rune{' ', '\t', '\r', '\n'},
 					ignoreCase: false,
@@ -1670,21 +1671,21 @@ var g = &grammar{
 		{
 			name:        "_",
 			displayName: "\"whitespace\"",
-			pos:         position{line: 399, col: 1, offset: 11246},
+			pos:         position{line: 399, col: 1, offset: 11264},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 399, col: 19, offset: 11264},
+				pos: position{line: 399, col: 19, offset: 11282},
 				expr: &choiceExpr{
-					pos: position{line: 399, col: 21, offset: 11266},
+					pos: position{line: 399, col: 21, offset: 11284},
 					alternatives: []interface{}{
 						&charClassMatcher{
-							pos:        position{line: 399, col: 21, offset: 11266},
+							pos:        position{line: 399, col: 21, offset: 11284},
 							val:        "[ \\t\\r\\n]",
 							chars:      []rune{' ', '\t', '\r', '\n'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 399, col: 33, offset: 11278},
+							pos:  position{line: 399, col: 33, offset: 11296},
 							name: "Comment",
 						},
 					},
@@ -1693,14 +1694,14 @@ var g = &grammar{
 		},
 		{
 			name: "Comment",
-			pos:  position{line: 401, col: 1, offset: 11290},
+			pos:  position{line: 401, col: 1, offset: 11308},
 			expr: &seqExpr{
-				pos: position{line: 401, col: 12, offset: 11301},
+				pos: position{line: 401, col: 12, offset: 11319},
 				exprs: []interface{}{
 					&zeroOrMoreExpr{
-						pos: position{line: 401, col: 12, offset: 11301},
+						pos: position{line: 401, col: 12, offset: 11319},
 						expr: &charClassMatcher{
-							pos:        position{line: 401, col: 12, offset: 11301},
+							pos:        position{line: 401, col: 12, offset: 11319},
 							val:        "[ \\t]",
 							chars:      []rune{' ', '\t'},
 							ignoreCase: false,
@@ -1708,14 +1709,14 @@ var g = &grammar{
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 401, col: 19, offset: 11308},
+						pos:        position{line: 401, col: 19, offset: 11326},
 						val:        "#",
 						ignoreCase: false,
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 401, col: 23, offset: 11312},
+						pos: position{line: 401, col: 23, offset: 11330},
 						expr: &charClassMatcher{
-							pos:        position{line: 401, col: 23, offset: 11312},
+							pos:        position{line: 401, col: 23, offset: 11330},
 							val:        "[^\\r\\n]",
 							chars:      []rune{'\r', '\n'},
 							ignoreCase: false,
@@ -1727,11 +1728,11 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 403, col: 1, offset: 11322},
+			pos:  position{line: 403, col: 1, offset: 11340},
 			expr: &notExpr{
-				pos: position{line: 403, col: 8, offset: 11329},
+				pos: position{line: 403, col: 8, offset: 11347},
 				expr: &anyMatcher{
-					line: 403, col: 9, offset: 11330,
+					line: 403, col: 9, offset: 11348,
 				},
 			},
 		},
@@ -2188,8 +2189,8 @@ func (p *parser) callonVarUnchecked1() (interface{}, error) {
 func (c *current) onNumber1() (interface{}, error) {
 	// JSON numbers have the same syntax as Go's, and are parseable using
 	// strconv.
-	v, err := strconv.ParseFloat(string(c.text), 64)
-	num := NumberTerm(v)
+	_, err := strconv.ParseFloat(string(c.text), 64)
+	num := NumberTerm(json.Number(c.text))
 	num.Location = currentLocation(c)
 	return num, err
 }

--- a/ast/parser_test.go
+++ b/ast/parser_test.go
@@ -38,11 +38,11 @@ func TestScalarTerms(t *testing.T) {
 	assertParseOneTerm(t, "null", "null", NullTerm())
 	assertParseOneTerm(t, "true", "true", BooleanTerm(true))
 	assertParseOneTerm(t, "false", "false", BooleanTerm(false))
-	assertParseOneTerm(t, "integer", "53", NumberTerm(53))
-	assertParseOneTerm(t, "integer2", "-53", NumberTerm(-53))
-	assertParseOneTerm(t, "float", "16.7", NumberTerm(16.7))
-	assertParseOneTerm(t, "float2", "-16.7", NumberTerm(-16.7))
-	assertParseOneTerm(t, "exponent", "6e7", NumberTerm(6e7))
+	assertParseOneTerm(t, "integer", "53", IntNumberTerm(53))
+	assertParseOneTerm(t, "integer2", "-53", IntNumberTerm(-53))
+	assertParseOneTerm(t, "float", "16.7", FloatNumberTerm(16.7))
+	assertParseOneTerm(t, "float2", "-16.7", FloatNumberTerm(-16.7))
+	assertParseOneTerm(t, "exponent", "6e7", FloatNumberTerm(6e7))
 	assertParseOneTerm(t, "string", "\"a string\"", StringTerm("a string"))
 	assertParseOneTerm(t, "string", "\"a string u6abc7def8abc0def with unicode\"", StringTerm("a string u6abc7def8abc0def with unicode"))
 	assertParseError(t, "hex", "6abc")
@@ -74,13 +74,13 @@ func TestVarTerms(t *testing.T) {
 
 func TestRefTerms(t *testing.T) {
 	assertParseOneTerm(t, "constants", "foo.bar.baz", RefTerm(VarTerm("foo"), StringTerm("bar"), StringTerm("baz")))
-	assertParseOneTerm(t, "constants 2", "foo.bar[0].baz", RefTerm(VarTerm("foo"), StringTerm("bar"), NumberTerm(0), StringTerm("baz")))
-	assertParseOneTerm(t, "variables", "foo.bar[0].baz[i]", RefTerm(VarTerm("foo"), StringTerm("bar"), NumberTerm(0), StringTerm("baz"), VarTerm("i")))
+	assertParseOneTerm(t, "constants 2", "foo.bar[0].baz", RefTerm(VarTerm("foo"), StringTerm("bar"), IntNumberTerm(0), StringTerm("baz")))
+	assertParseOneTerm(t, "variables", "foo.bar[0].baz[i]", RefTerm(VarTerm("foo"), StringTerm("bar"), IntNumberTerm(0), StringTerm("baz"), VarTerm("i")))
 	assertParseOneTerm(t, "spaces", "foo[\"white space\"].bar", RefTerm(VarTerm("foo"), StringTerm("white space"), StringTerm("bar")))
 	assertParseOneTerm(t, "nested", "foo[baz[1][borge[i]]].bar", RefTerm(
 		VarTerm("foo"),
 		RefTerm(
-			VarTerm("baz"), NumberTerm(float64(1)), RefTerm(
+			VarTerm("baz"), IntNumberTerm(1), RefTerm(
 				VarTerm("borge"), VarTerm("i"),
 			),
 		),
@@ -93,17 +93,17 @@ func TestRefTerms(t *testing.T) {
 }
 
 func TestObjectWithScalars(t *testing.T) {
-	assertParseOneTerm(t, "number", "{\"abc\": 7, \"def\": 8}", ObjectTerm(Item(StringTerm("abc"), NumberTerm(7)), Item(StringTerm("def"), NumberTerm(8))))
+	assertParseOneTerm(t, "number", "{\"abc\": 7, \"def\": 8}", ObjectTerm(Item(StringTerm("abc"), IntNumberTerm(7)), Item(StringTerm("def"), IntNumberTerm(8))))
 	assertParseOneTerm(t, "bool", "{\"abc\": false, \"def\": true}", ObjectTerm(Item(StringTerm("abc"), BooleanTerm(false)), Item(StringTerm("def"), BooleanTerm(true))))
 	assertParseOneTerm(t, "string", "{\"abc\": \"foo\", \"def\": \"bar\"}", ObjectTerm(Item(StringTerm("abc"), StringTerm("foo")), Item(StringTerm("def"), StringTerm("bar"))))
-	assertParseOneTerm(t, "mixed", "{\"abc\": 7, \"def\": null}", ObjectTerm(Item(StringTerm("abc"), NumberTerm(7)), Item(StringTerm("def"), NullTerm())))
-	assertParseOneTerm(t, "number key", "{8: 7, \"def\": null}", ObjectTerm(Item(NumberTerm(8), NumberTerm(7)), Item(StringTerm("def"), NullTerm())))
-	assertParseOneTerm(t, "number key 2", "{8.5: 7, \"def\": null}", ObjectTerm(Item(NumberTerm(8.5), NumberTerm(7)), Item(StringTerm("def"), NullTerm())))
+	assertParseOneTerm(t, "mixed", "{\"abc\": 7, \"def\": null}", ObjectTerm(Item(StringTerm("abc"), IntNumberTerm(7)), Item(StringTerm("def"), NullTerm())))
+	assertParseOneTerm(t, "number key", "{8: 7, \"def\": null}", ObjectTerm(Item(IntNumberTerm(8), IntNumberTerm(7)), Item(StringTerm("def"), NullTerm())))
+	assertParseOneTerm(t, "number key 2", "{8.5: 7, \"def\": null}", ObjectTerm(Item(FloatNumberTerm(8.5), IntNumberTerm(7)), Item(StringTerm("def"), NullTerm())))
 	assertParseOneTerm(t, "bool key", "{true: false}", ObjectTerm(Item(BooleanTerm(true), BooleanTerm(false))))
 }
 
 func TestObjectWithVars(t *testing.T) {
-	assertParseOneTerm(t, "var keys", "{foo: \"bar\", bar: 64}", ObjectTerm(Item(VarTerm("foo"), StringTerm("bar")), Item(VarTerm("bar"), NumberTerm(64))))
+	assertParseOneTerm(t, "var keys", "{foo: \"bar\", bar: 64}", ObjectTerm(Item(VarTerm("foo"), StringTerm("bar")), Item(VarTerm("bar"), IntNumberTerm(64))))
 	assertParseOneTerm(t, "nested var keys", "{baz: {foo: \"bar\", bar: qux}}", ObjectTerm(Item(VarTerm("baz"), ObjectTerm(Item(VarTerm("foo"), StringTerm("bar")), Item(VarTerm("bar"), VarTerm("qux"))))))
 }
 
@@ -117,15 +117,15 @@ func TestObjectFail(t *testing.T) {
 }
 
 func TestArrayWithScalars(t *testing.T) {
-	assertParseOneTerm(t, "number", "[1,2,3,4.5]", ArrayTerm(NumberTerm(1), NumberTerm(2), NumberTerm(3), NumberTerm(4.5)))
+	assertParseOneTerm(t, "number", "[1,2,3,4.5]", ArrayTerm(IntNumberTerm(1), IntNumberTerm(2), IntNumberTerm(3), FloatNumberTerm(4.5)))
 	assertParseOneTerm(t, "bool", "[true, false, true]", ArrayTerm(BooleanTerm(true), BooleanTerm(false), BooleanTerm(true)))
 	assertParseOneTerm(t, "string", "[\"foo\", \"bar\"]", ArrayTerm(StringTerm("foo"), StringTerm("bar")))
-	assertParseOneTerm(t, "mixed", "[null, true, 42]", ArrayTerm(NullTerm(), BooleanTerm(true), NumberTerm(42)))
+	assertParseOneTerm(t, "mixed", "[null, true, 42]", ArrayTerm(NullTerm(), BooleanTerm(true), IntNumberTerm(42)))
 }
 
 func TestArrayWithVars(t *testing.T) {
-	assertParseOneTerm(t, "var elements", "[foo, bar, 42]", ArrayTerm(VarTerm("foo"), VarTerm("bar"), NumberTerm(42)))
-	assertParseOneTerm(t, "nested var elements", "[[foo, true], [null, bar], 42]", ArrayTerm(ArrayTerm(VarTerm("foo"), BooleanTerm(true)), ArrayTerm(NullTerm(), VarTerm("bar")), NumberTerm(42)))
+	assertParseOneTerm(t, "var elements", "[foo, bar, 42]", ArrayTerm(VarTerm("foo"), VarTerm("bar"), IntNumberTerm(42)))
+	assertParseOneTerm(t, "nested var elements", "[[foo, true], [null, bar], 42]", ArrayTerm(ArrayTerm(VarTerm("foo"), BooleanTerm(true)), ArrayTerm(NullTerm(), VarTerm("bar")), IntNumberTerm(42)))
 }
 
 func TestArrayFail(t *testing.T) {
@@ -137,14 +137,14 @@ func TestArrayFail(t *testing.T) {
 }
 
 func TestSetWithScalars(t *testing.T) {
-	assertParseOneTerm(t, "number", "{1,2,3,4.5}", SetTerm(NumberTerm(1), NumberTerm(2), NumberTerm(3), NumberTerm(4.5)))
+	assertParseOneTerm(t, "number", "{1,2,3,4.5}", SetTerm(IntNumberTerm(1), IntNumberTerm(2), IntNumberTerm(3), FloatNumberTerm(4.5)))
 	assertParseOneTerm(t, "bool", "{true, false, true}", SetTerm(BooleanTerm(true), BooleanTerm(false), BooleanTerm(true)))
 	assertParseOneTerm(t, "string", "{\"foo\", \"bar\"}", SetTerm(StringTerm("foo"), StringTerm("bar")))
-	assertParseOneTerm(t, "mixed", "{null, true, 42}", SetTerm(NullTerm(), BooleanTerm(true), NumberTerm(42)))
+	assertParseOneTerm(t, "mixed", "{null, true, 42}", SetTerm(NullTerm(), BooleanTerm(true), IntNumberTerm(42)))
 }
 
 func TestSetWithVars(t *testing.T) {
-	assertParseOneTerm(t, "var elements", "{foo, bar, 42}", SetTerm(VarTerm("foo"), VarTerm("bar"), NumberTerm(42)))
+	assertParseOneTerm(t, "var elements", "{foo, bar, 42}", SetTerm(VarTerm("foo"), VarTerm("bar"), IntNumberTerm(42)))
 	assertParseOneTerm(t, "nested var elements", "{[foo, true], {null, bar}, set()}", SetTerm(ArrayTerm(VarTerm("foo"), BooleanTerm(true)), SetTerm(NullTerm(), VarTerm("bar")), SetTerm()))
 }
 
@@ -169,9 +169,9 @@ func TestNestedComposites(t *testing.T) {
 
 func TestCompositesWithRefs(t *testing.T) {
 	ref1 := RefTerm(VarTerm("a"), VarTerm("i"), StringTerm("b"))
-	ref2 := RefTerm(VarTerm("c"), NumberTerm(0), StringTerm("d"), StringTerm("e"), VarTerm("j"))
-	assertParseOneTerm(t, "ref keys", "[{a[i].b: 8, c[0][\"d\"].e[j]: f}]", ArrayTerm(ObjectTerm(Item(ref1, NumberTerm(8)), Item(ref2, VarTerm("f")))))
-	assertParseOneTerm(t, "ref values", "[{8: a[i].b, f: c[0][\"d\"].e[j]}]", ArrayTerm(ObjectTerm(Item(NumberTerm(8), ref1), Item(VarTerm("f"), ref2))))
+	ref2 := RefTerm(VarTerm("c"), IntNumberTerm(0), StringTerm("d"), StringTerm("e"), VarTerm("j"))
+	assertParseOneTerm(t, "ref keys", "[{a[i].b: 8, c[0][\"d\"].e[j]: f}]", ArrayTerm(ObjectTerm(Item(ref1, IntNumberTerm(8)), Item(ref2, VarTerm("f")))))
+	assertParseOneTerm(t, "ref values", "[{8: a[i].b, f: c[0][\"d\"].e[j]}]", ArrayTerm(ObjectTerm(Item(IntNumberTerm(8), ref1), Item(VarTerm("f"), ref2))))
 	assertParseOneTerm(t, "ref values (sets)", `{a[i].b, {c[0]["d"].e[j]}}`, SetTerm(ref1, SetTerm(ref2)))
 }
 
@@ -216,27 +216,27 @@ func TestArrayComprehensions(t *testing.T) {
 
 func TestInfixExpr(t *testing.T) {
 	assertParseOneExpr(t, "scalars 1", "true = false", Equality.Expr(BooleanTerm(true), BooleanTerm(false)))
-	assertParseOneExpr(t, "scalars 2", "3.14 = null", Equality.Expr(NumberTerm(3.14), NullTerm()))
-	assertParseOneExpr(t, "scalars 3", "42 = \"hello world\"", Equality.Expr(NumberTerm(42), StringTerm("hello world")))
+	assertParseOneExpr(t, "scalars 2", "3.14 = null", Equality.Expr(FloatNumberTerm(3.14), NullTerm()))
+	assertParseOneExpr(t, "scalars 3", "42 = \"hello world\"", Equality.Expr(IntNumberTerm(42), StringTerm("hello world")))
 	assertParseOneExpr(t, "vars 1", "hello = world", Equality.Expr(VarTerm("hello"), VarTerm("world")))
-	assertParseOneExpr(t, "vars 2", "42 = hello", Equality.Expr(NumberTerm(42), VarTerm("hello")))
+	assertParseOneExpr(t, "vars 2", "42 = hello", Equality.Expr(IntNumberTerm(42), VarTerm("hello")))
 
-	ref1 := RefTerm(VarTerm("foo"), NumberTerm(0), StringTerm("bar"), VarTerm("x"))
+	ref1 := RefTerm(VarTerm("foo"), IntNumberTerm(0), StringTerm("bar"), VarTerm("x"))
 	ref2 := RefTerm(VarTerm("baz"), BooleanTerm(false), StringTerm("qux"), StringTerm("hello"))
 	assertParseOneExpr(t, "refs 1", "foo[0].bar[x] = baz[false].qux[\"hello\"]", Equality.Expr(ref1, ref2))
 
 	left1 := ObjectTerm(Item(VarTerm("a"), ArrayTerm(ref1)))
-	right1 := ArrayTerm(ObjectTerm(Item(NumberTerm(42), BooleanTerm(true))))
+	right1 := ArrayTerm(ObjectTerm(Item(IntNumberTerm(42), BooleanTerm(true))))
 	assertParseOneExpr(t, "composites", "{a: [foo[0].bar[x]]} = [{42: true}]", Equality.Expr(left1, right1))
 
-	assertParseOneExpr(t, "ne", "100 != 200", NotEqual.Expr(NumberTerm(100), NumberTerm(200)))
-	assertParseOneExpr(t, "gt", "17.4 > \"hello\"", GreaterThan.Expr(NumberTerm(17.4), StringTerm("hello")))
-	assertParseOneExpr(t, "lt", "17.4 < \"hello\"", LessThan.Expr(NumberTerm(17.4), StringTerm("hello")))
-	assertParseOneExpr(t, "gte", "17.4 >= \"hello\"", GreaterThanEq.Expr(NumberTerm(17.4), StringTerm("hello")))
-	assertParseOneExpr(t, "lte", "17.4 <= \"hello\"", LessThanEq.Expr(NumberTerm(17.4), StringTerm("hello")))
+	assertParseOneExpr(t, "ne", "100 != 200", NotEqual.Expr(IntNumberTerm(100), IntNumberTerm(200)))
+	assertParseOneExpr(t, "gt", "17.4 > \"hello\"", GreaterThan.Expr(FloatNumberTerm(17.4), StringTerm("hello")))
+	assertParseOneExpr(t, "lt", "17.4 < \"hello\"", LessThan.Expr(FloatNumberTerm(17.4), StringTerm("hello")))
+	assertParseOneExpr(t, "gte", "17.4 >= \"hello\"", GreaterThanEq.Expr(FloatNumberTerm(17.4), StringTerm("hello")))
+	assertParseOneExpr(t, "lte", "17.4 <= \"hello\"", LessThanEq.Expr(FloatNumberTerm(17.4), StringTerm("hello")))
 
-	left2 := ArrayTerm(ObjectTerm(Item(NumberTerm(14.2), BooleanTerm(true)), Item(StringTerm("a"), NullTerm())))
-	right2 := ObjectTerm(Item(VarTerm("foo"), ObjectTerm(Item(RefTerm(VarTerm("a"), StringTerm("b"), NumberTerm(0)), ArrayTerm(NumberTerm(10))))))
+	left2 := ArrayTerm(ObjectTerm(Item(FloatNumberTerm(14.2), BooleanTerm(true)), Item(StringTerm("a"), NullTerm())))
+	right2 := ObjectTerm(Item(VarTerm("foo"), ObjectTerm(Item(RefTerm(VarTerm("a"), StringTerm("b"), IntNumberTerm(0)), ArrayTerm(IntNumberTerm(10))))))
 	assertParseOneExpr(t, "composites", "[{14.2: true, \"a\": null}] != {foo: {a.b[0]: [10]}}", NotEqual.Expr(left2, right2))
 }
 
@@ -244,13 +244,13 @@ func TestMiscBuiltinExpr(t *testing.T) {
 	xyz := VarTerm("xyz")
 	assertParseOneExpr(t, "empty", "xyz()", NewBuiltinExpr(xyz))
 	assertParseOneExpr(t, "single", "xyz(abc)", NewBuiltinExpr(xyz, VarTerm("abc")))
-	assertParseOneExpr(t, "multiple", "xyz(abc, {\"one\": [1,2,3]})", NewBuiltinExpr(xyz, VarTerm("abc"), ObjectTerm(Item(StringTerm("one"), ArrayTerm(NumberTerm(1), NumberTerm(2), NumberTerm(3))))))
+	assertParseOneExpr(t, "multiple", "xyz(abc, {\"one\": [1,2,3]})", NewBuiltinExpr(xyz, VarTerm("abc"), ObjectTerm(Item(StringTerm("one"), ArrayTerm(IntNumberTerm(1), IntNumberTerm(2), IntNumberTerm(3))))))
 }
 
 func TestNegatedExpr(t *testing.T) {
 	assertParseOneTermNegated(t, "scalars 1", "not true", BooleanTerm(true))
 	assertParseOneTermNegated(t, "scalars 2", "not \"hello\"", StringTerm("hello"))
-	assertParseOneTermNegated(t, "scalars 3", "not 100", NumberTerm(100))
+	assertParseOneTermNegated(t, "scalars 3", "not 100", IntNumberTerm(100))
 	assertParseOneTermNegated(t, "scalars 4", "not null", NullTerm())
 	assertParseOneTermNegated(t, "var", "not x", VarTerm("x"))
 	assertParseOneTermNegated(t, "ref", "not x[y].z", RefTerm(VarTerm("x"), VarTerm("y"), StringTerm("z")))
@@ -299,7 +299,7 @@ func TestRule(t *testing.T) {
 		Name: Var("p"),
 		Key:  VarTerm("x"),
 		Body: NewBody(
-			Equality.Expr(VarTerm("x"), NumberTerm(42)),
+			Equality.Expr(VarTerm("x"), IntNumberTerm(42)),
 		),
 	})
 
@@ -308,7 +308,7 @@ func TestRule(t *testing.T) {
 		Key:   VarTerm("x"),
 		Value: VarTerm("y"),
 		Body: NewBody(
-			Equality.Expr(VarTerm("x"), NumberTerm(42)),
+			Equality.Expr(VarTerm("x"), IntNumberTerm(42)),
 			Equality.Expr(VarTerm("y"), StringTerm("hello")),
 		),
 	})
@@ -316,7 +316,7 @@ func TestRule(t *testing.T) {
 	assertParseRule(t, "constant composite", "p = [{\"foo\": [1,2,3,4]}] :- true", &Rule{
 		Name: Var("p"),
 		Value: ArrayTerm(
-			ObjectTerm(Item(StringTerm("foo"), ArrayTerm(NumberTerm(1), NumberTerm(2), NumberTerm(3), NumberTerm(4)))),
+			ObjectTerm(Item(StringTerm("foo"), ArrayTerm(IntNumberTerm(1), IntNumberTerm(2), IntNumberTerm(3), IntNumberTerm(4)))),
 		),
 		Body: NewBody(
 			&Expr{Terms: BooleanTerm(true)},
@@ -339,8 +339,8 @@ func TestRule(t *testing.T) {
 			),
 		),
 		Body: NewBody(
-			Equality.Expr(VarTerm("a"), NumberTerm(float64(1))),
-			Equality.Expr(VarTerm("b"), NumberTerm(float64(2))),
+			Equality.Expr(VarTerm("a"), IntNumberTerm(1)),
+			Equality.Expr(VarTerm("b"), IntNumberTerm(2)),
 		),
 	})
 

--- a/ast/rego.peg
+++ b/ast/rego.peg
@@ -343,8 +343,8 @@ VarUnchecked <- AsciiLetter (AsciiLetter / DecimalDigit)* {
 Number <- '-'? Integer ( '.' DecimalDigit+ )? Exponent? {
     // JSON numbers have the same syntax as Go's, and are parseable using
     // strconv.
-    v, err := strconv.ParseFloat(string(c.text), 64)
-    num := NumberTerm(v)
+    _, err := strconv.ParseFloat(string(c.text), 64)
+    num := NumberTerm(json.Number(c.text))
     num.Location = currentLocation(c)
     return num, err
 }

--- a/ast/term_test.go
+++ b/ast/term_test.go
@@ -5,11 +5,12 @@
 package ast
 
 import (
-	"encoding/json"
 	"fmt"
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/open-policy-agent/opa/util"
 )
 
 func TestInterfaceToValue(t *testing.T) {
@@ -27,7 +28,7 @@ func TestInterfaceToValue(t *testing.T) {
 	}
 	`
 	var x interface{}
-	if err := json.Unmarshal([]byte(input), &x); err != nil {
+	if err := util.UnmarshalJSON([]byte(input), &x); err != nil {
 		panic(err)
 	}
 
@@ -87,7 +88,7 @@ func TestTermBadJSON(t *testing.T) {
 	}`
 
 	term := Term{}
-	err := json.Unmarshal([]byte(input), &term)
+	err := util.UnmarshalJSON([]byte(input), &term)
 	expected := fmt.Errorf("ast: unable to unmarshal term")
 	if !reflect.DeepEqual(expected, err) {
 		t.Errorf("Expected %v but got: %v", expected, err)
@@ -98,28 +99,28 @@ func TestTermBadJSON(t *testing.T) {
 func TestTermEqual(t *testing.T) {
 	assertTermEqual(t, NullTerm(), NullTerm())
 	assertTermEqual(t, BooleanTerm(true), BooleanTerm(true))
-	assertTermEqual(t, NumberTerm(5), NumberTerm(5))
+	assertTermEqual(t, IntNumberTerm(5), IntNumberTerm(5))
 	assertTermEqual(t, StringTerm("a string"), StringTerm("a string"))
 	assertTermEqual(t, ObjectTerm(), ObjectTerm())
 	assertTermEqual(t, ArrayTerm(), ArrayTerm())
-	assertTermEqual(t, ObjectTerm(Item(NumberTerm(1), NumberTerm(2))), ObjectTerm(Item(NumberTerm(1), NumberTerm(2))))
-	assertTermEqual(t, ObjectTerm(Item(NumberTerm(1), NumberTerm(2)), Item(NumberTerm(3), NumberTerm(4))), ObjectTerm(Item(NumberTerm(1), NumberTerm(2)), Item(NumberTerm(3), NumberTerm(4))))
-	assertTermEqual(t, ArrayTerm(NumberTerm(1), NumberTerm(2), NumberTerm(3)), ArrayTerm(NumberTerm(1), NumberTerm(2), NumberTerm(3)))
+	assertTermEqual(t, ObjectTerm(Item(IntNumberTerm(1), IntNumberTerm(2))), ObjectTerm(Item(IntNumberTerm(1), IntNumberTerm(2))))
+	assertTermEqual(t, ObjectTerm(Item(IntNumberTerm(1), IntNumberTerm(2)), Item(IntNumberTerm(3), IntNumberTerm(4))), ObjectTerm(Item(IntNumberTerm(1), IntNumberTerm(2)), Item(IntNumberTerm(3), IntNumberTerm(4))))
+	assertTermEqual(t, ArrayTerm(IntNumberTerm(1), IntNumberTerm(2), IntNumberTerm(3)), ArrayTerm(IntNumberTerm(1), IntNumberTerm(2), IntNumberTerm(3)))
 	assertTermEqual(t, VarTerm("foo"), VarTerm("foo"))
-	assertTermEqual(t, RefTerm(VarTerm("foo"), VarTerm("i"), NumberTerm(2)), RefTerm(VarTerm("foo"), VarTerm("i"), NumberTerm(2)))
+	assertTermEqual(t, RefTerm(VarTerm("foo"), VarTerm("i"), IntNumberTerm(2)), RefTerm(VarTerm("foo"), VarTerm("i"), IntNumberTerm(2)))
 	assertTermEqual(t, ArrayComprehensionTerm(VarTerm("x"), NewBody(&Expr{Terms: RefTerm(VarTerm("a"), VarTerm("i"))})), ArrayComprehensionTerm(VarTerm("x"), NewBody(&Expr{Terms: RefTerm(VarTerm("a"), VarTerm("i"))})))
 	assertTermNotEqual(t, NullTerm(), BooleanTerm(true))
 	assertTermNotEqual(t, BooleanTerm(true), BooleanTerm(false))
-	assertTermNotEqual(t, NumberTerm(5), NumberTerm(7))
+	assertTermNotEqual(t, IntNumberTerm(5), IntNumberTerm(7))
 	assertTermNotEqual(t, StringTerm("a string"), StringTerm("abc"))
-	assertTermNotEqual(t, ObjectTerm(Item(NumberTerm(3), NumberTerm(2))), ObjectTerm(Item(NumberTerm(1), NumberTerm(2))))
-	assertTermNotEqual(t, ObjectTerm(Item(NumberTerm(1), NumberTerm(2)), Item(NumberTerm(3), NumberTerm(7))), ObjectTerm(Item(NumberTerm(1), NumberTerm(2)), Item(NumberTerm(3), NumberTerm(4))))
-	assertTermNotEqual(t, NumberTerm(5), StringTerm("a string"))
-	assertTermNotEqual(t, NumberTerm(1), BooleanTerm(true))
-	assertTermNotEqual(t, ObjectTerm(Item(NumberTerm(1), NumberTerm(2)), Item(NumberTerm(3), NumberTerm(7))), ArrayTerm(NumberTerm(1), NumberTerm(2), NumberTerm(7)))
-	assertTermNotEqual(t, ArrayTerm(NumberTerm(1), NumberTerm(2), NumberTerm(3)), ArrayTerm(NumberTerm(1), NumberTerm(2), NumberTerm(4)))
+	assertTermNotEqual(t, ObjectTerm(Item(IntNumberTerm(3), IntNumberTerm(2))), ObjectTerm(Item(IntNumberTerm(1), IntNumberTerm(2))))
+	assertTermNotEqual(t, ObjectTerm(Item(IntNumberTerm(1), IntNumberTerm(2)), Item(IntNumberTerm(3), IntNumberTerm(7))), ObjectTerm(Item(IntNumberTerm(1), IntNumberTerm(2)), Item(IntNumberTerm(3), IntNumberTerm(4))))
+	assertTermNotEqual(t, IntNumberTerm(5), StringTerm("a string"))
+	assertTermNotEqual(t, IntNumberTerm(1), BooleanTerm(true))
+	assertTermNotEqual(t, ObjectTerm(Item(IntNumberTerm(1), IntNumberTerm(2)), Item(IntNumberTerm(3), IntNumberTerm(7))), ArrayTerm(IntNumberTerm(1), IntNumberTerm(2), IntNumberTerm(7)))
+	assertTermNotEqual(t, ArrayTerm(IntNumberTerm(1), IntNumberTerm(2), IntNumberTerm(3)), ArrayTerm(IntNumberTerm(1), IntNumberTerm(2), IntNumberTerm(4)))
 	assertTermNotEqual(t, VarTerm("foo"), VarTerm("bar"))
-	assertTermNotEqual(t, RefTerm(VarTerm("foo"), VarTerm("i"), NumberTerm(2)), RefTerm(VarTerm("foo"), StringTerm("i"), NumberTerm(2)))
+	assertTermNotEqual(t, RefTerm(VarTerm("foo"), VarTerm("i"), IntNumberTerm(2)), RefTerm(VarTerm("foo"), StringTerm("i"), IntNumberTerm(2)))
 	assertTermNotEqual(t, ArrayComprehensionTerm(VarTerm("x"), NewBody(&Expr{Terms: RefTerm(VarTerm("a"), VarTerm("j"))})), ArrayComprehensionTerm(VarTerm("x"), NewBody(&Expr{Terms: RefTerm(VarTerm("a"), VarTerm("i"))})))
 }
 
@@ -214,20 +215,20 @@ func TestTermString(t *testing.T) {
 	assertToString(t, Null{}, "null")
 	assertToString(t, Boolean(true), "true")
 	assertToString(t, Boolean(false), "false")
-	assertToString(t, Number(4), "4")
-	assertToString(t, Number(42.1), "42.1")
-	assertToString(t, Number(6e7), "6E+07")
+	assertToString(t, Number("4"), "4")
+	assertToString(t, Number("42.1"), "42.1")
+	assertToString(t, Number("6e7"), "6e7")
 	assertToString(t, String("foo"), "\"foo\"")
 	assertToString(t, String("\"foo\""), "\"\\\"foo\\\"\"")
 	assertToString(t, String("foo bar"), "\"foo bar\"")
 	assertToString(t, Var("foo"), "foo")
 	assertToString(t, RefTerm(VarTerm("foo"), StringTerm("bar")).Value, "foo.bar")
-	assertToString(t, RefTerm(VarTerm("foo"), StringTerm("bar"), VarTerm("i"), NumberTerm(0), StringTerm("baz")).Value, "foo.bar[i][0].baz")
+	assertToString(t, RefTerm(VarTerm("foo"), StringTerm("bar"), VarTerm("i"), IntNumberTerm(0), StringTerm("baz")).Value, "foo.bar[i][0].baz")
 	assertToString(t, RefTerm(VarTerm("foo"), BooleanTerm(false), NullTerm(), StringTerm("bar")).Value, "foo[false][null].bar")
 	assertToString(t, ArrayTerm().Value, "[]")
 	assertToString(t, ObjectTerm().Value, "{}")
 	assertToString(t, SetTerm().Value, "set()")
-	assertToString(t, ArrayTerm(ObjectTerm(Item(VarTerm("foo"), ArrayTerm(RefTerm(VarTerm("bar"), VarTerm("i"))))), StringTerm("foo"), SetTerm(BooleanTerm(true), NullTerm()), NumberTerm(42.1)).Value, "[{foo: [bar[i]]}, \"foo\", {true, null}, 42.1]")
+	assertToString(t, ArrayTerm(ObjectTerm(Item(VarTerm("foo"), ArrayTerm(RefTerm(VarTerm("bar"), VarTerm("i"))))), StringTerm("foo"), SetTerm(BooleanTerm(true), NullTerm()), FloatNumberTerm(42.1)).Value, "[{foo: [bar[i]]}, \"foo\", {true, null}, 42.1]")
 	assertToString(t, ArrayComprehensionTerm(ArrayTerm(VarTerm("x")), NewBody(&Expr{Terms: RefTerm(VarTerm("a"), VarTerm("i"))})).Value, "[[x] | a[i]]")
 }
 

--- a/repl/repl_test.go
+++ b/repl/repl_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/storage"
+	"github.com/open-policy-agent/opa/util"
 )
 
 func TestComplete(t *testing.T) {
@@ -96,7 +97,7 @@ func TestComplete(t *testing.T) {
 func TestDump(t *testing.T) {
 	input := `{"a": [1,2,3,4]}`
 	var data map[string]interface{}
-	err := json.Unmarshal([]byte(input), &data)
+	err := util.UnmarshalJSON([]byte(input), &data)
 	if err != nil {
 		panic(err)
 	}
@@ -110,7 +111,7 @@ func TestDump(t *testing.T) {
 func TestDumpPath(t *testing.T) {
 	input := `{"a": [1,2,3,4]}`
 	var data map[string]interface{}
-	err := json.Unmarshal([]byte(input), &data)
+	err := util.UnmarshalJSON([]byte(input), &data)
 	if err != nil {
 		panic(err)
 	}
@@ -137,7 +138,7 @@ func TestDumpPath(t *testing.T) {
 	}
 
 	var result map[string]interface{}
-	if err := json.Unmarshal(bs, &result); err != nil {
+	if err := util.UnmarshalJSON(bs, &result); err != nil {
 		t.Fatalf("Expected json unmarhsal to suceed but got: %v", err)
 	}
 
@@ -340,13 +341,13 @@ func TestOneShotJSON(t *testing.T) {
 		}
 	]
 	`
-	if err := json.Unmarshal([]byte(input), &expected); err != nil {
+	if err := util.UnmarshalJSON([]byte(input), &expected); err != nil {
 		panic(err)
 	}
 
 	var result interface{}
 
-	if err := json.Unmarshal(buffer.Bytes(), &result); err != nil {
+	if err := util.UnmarshalJSON(buffer.Bytes(), &result); err != nil {
 		t.Errorf("Unexpected output format: %v", err)
 		return
 	}
@@ -486,13 +487,13 @@ func TestEvalSingleTermMultiValue(t *testing.T) {
 	]`
 
 	var expected interface{}
-	if err := json.Unmarshal([]byte(input), &expected); err != nil {
+	if err := util.UnmarshalJSON([]byte(input), &expected); err != nil {
 		panic(err)
 	}
 
 	repl.OneShot("data.a[i].b.c[_]")
 	var result interface{}
-	if err := json.Unmarshal(buffer.Bytes(), &result); err != nil {
+	if err := util.UnmarshalJSON(buffer.Bytes(), &result); err != nil {
 		t.Errorf("Expected valid JSON document: %v: %v", err, buffer.String())
 		return
 	}
@@ -534,11 +535,11 @@ func TestEvalSingleTermMultiValue(t *testing.T) {
 	]
 	`
 
-	if err := json.Unmarshal([]byte(input), &expected); err != nil {
+	if err := util.UnmarshalJSON([]byte(input), &expected); err != nil {
 		panic(err)
 	}
 
-	if err := json.Unmarshal(buffer.Bytes(), &result); err != nil {
+	if err := util.UnmarshalJSON(buffer.Bytes(), &result); err != nil {
 		t.Errorf("Expected valid JSON document: %v: %v", err, buffer.String())
 		return
 	}
@@ -618,15 +619,15 @@ func TestEvalBodyCompileError(t *testing.T) {
 	buffer.Reset()
 	repl.OneShot("x = 1, y = 2, y > x")
 	var result2 []interface{}
-	err = json.Unmarshal(buffer.Bytes(), &result2)
+	err = util.UnmarshalJSON(buffer.Bytes(), &result2)
 	if err != nil {
 		t.Errorf("Expected valid JSON output but got: %v", buffer.String())
 		return
 	}
 	expected2 := []interface{}{
 		map[string]interface{}{
-			"x": float64(1),
-			"y": float64(2),
+			"x": json.Number("1"),
+			"y": json.Number("2"),
 		},
 	}
 	if !reflect.DeepEqual(expected2, result2) {
@@ -844,7 +845,7 @@ func newTestStore() *storage.Storage {
     }
     `
 	var data map[string]interface{}
-	err := json.Unmarshal([]byte(input), &data)
+	err := util.UnmarshalJSON([]byte(input), &data)
 	if err != nil {
 		panic(err)
 	}
@@ -853,7 +854,7 @@ func newTestStore() *storage.Storage {
 
 func parseJSON(s string) interface{} {
 	var v interface{}
-	if err := json.Unmarshal([]byte(s), &v); err != nil {
+	if err := util.UnmarshalJSON([]byte(s), &v); err != nil {
 		panic(err)
 	}
 	return v

--- a/runtime/merge_test.go
+++ b/runtime/merge_test.go
@@ -4,10 +4,13 @@
 
 package runtime
 
-import "testing"
-import "encoding/json"
-import "reflect"
-import "fmt"
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/open-policy-agent/opa/util"
+)
 
 func TestMergeDocs(t *testing.T) {
 
@@ -18,18 +21,18 @@ func TestMergeDocs(t *testing.T) {
 	}{
 		{`{"x": 1, "y": 2}`, `{"z": 3}`, `{"x": 1, "y": 2, "z": 3}`},
 		{`{"x": {"y": 2}}`, `{"z": 3, "x": {"q": 4}}`, `{"x": {"y": 2, "q": 4}, "z": 3}`},
-		{`{"x": 1}`, `{"x": 1}`, fmt.Errorf("x: merge error: float64 cannot merge into float64")},
+		{`{"x": 1}`, `{"x": 1}`, fmt.Errorf("x: merge error: json.Number cannot merge into json.Number")},
 		{`{"x": {"y": [{"z": 2}]}}`, `{"x": {"y": [{"z": 3}]}}`, fmt.Errorf("x: y: merge error: []interface {} cannot merge into []interface {}")},
 	}
 
 	for _, tc := range tests {
 		a := map[string]interface{}{}
-		if err := json.Unmarshal([]byte(tc.a), &a); err != nil {
+		if err := util.UnmarshalJSON([]byte(tc.a), &a); err != nil {
 			panic(err)
 		}
 
 		b := map[string]interface{}{}
-		if err := json.Unmarshal([]byte(tc.b), &b); err != nil {
+		if err := util.UnmarshalJSON([]byte(tc.b), &b); err != nil {
 			panic(err)
 		}
 
@@ -42,7 +45,7 @@ func TestMergeDocs(t *testing.T) {
 
 		case string:
 			expected := map[string]interface{}{}
-			if err := json.Unmarshal([]byte(c), &expected); err != nil {
+			if err := util.UnmarshalJSON([]byte(c), &expected); err != nil {
 				panic(err)
 			}
 

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -6,7 +6,6 @@ package runtime
 
 import (
 	"bytes"
-	"encoding/json"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -114,7 +113,7 @@ func TestInit(t *testing.T) {
 
 func parseJSON(s string) interface{} {
 	var x interface{}
-	if err := json.Unmarshal([]byte(s), &x); err != nil {
+	if err := util.UnmarshalJSON([]byte(s), &x); err != nil {
 		panic(err)
 	}
 	return x

--- a/server/server.go
+++ b/server/server.go
@@ -20,6 +20,7 @@ import (
 	"github.com/open-policy-agent/opa/storage"
 	"github.com/open-policy-agent/opa/topdown"
 	"github.com/open-policy-agent/opa/topdown/explain"
+	"github.com/open-policy-agent/opa/util"
 	"github.com/open-policy-agent/opa/version"
 	"github.com/pkg/errors"
 )
@@ -197,48 +198,48 @@ func (te *traceEventV1) UnmarshalJSON(bs []byte) error {
 
 	keys := map[string]json.RawMessage{}
 
-	if err := json.Unmarshal(bs, &keys); err != nil {
+	if err := util.UnmarshalJSON(bs, &keys); err != nil {
 		return err
 	}
 
-	if err := json.Unmarshal(keys["Type"], &te.Type); err != nil {
+	if err := util.UnmarshalJSON(keys["Type"], &te.Type); err != nil {
 		return err
 	}
 
-	if err := json.Unmarshal(keys["Op"], &te.Op); err != nil {
+	if err := util.UnmarshalJSON(keys["Op"], &te.Op); err != nil {
 		return err
 	}
 
-	if err := json.Unmarshal(keys["QueryID"], &te.QueryID); err != nil {
+	if err := util.UnmarshalJSON(keys["QueryID"], &te.QueryID); err != nil {
 		return err
 	}
 
-	if err := json.Unmarshal(keys["ParentID"], &te.ParentID); err != nil {
+	if err := util.UnmarshalJSON(keys["ParentID"], &te.ParentID); err != nil {
 		return err
 	}
 
 	switch te.Type {
 	case nodeTypeBodyV1:
 		var body ast.Body
-		if err := json.Unmarshal(keys["Node"], &body); err != nil {
+		if err := util.UnmarshalJSON(keys["Node"], &body); err != nil {
 			return err
 		}
 		te.Node = body
 	case nodeTypeExprV1:
 		var expr ast.Expr
-		if err := json.Unmarshal(keys["Node"], &expr); err != nil {
+		if err := util.UnmarshalJSON(keys["Node"], &expr); err != nil {
 			return err
 		}
 		te.Node = &expr
 	case nodeTypeRuleV1:
 		var rule ast.Rule
-		if err := json.Unmarshal(keys["Node"], &rule); err != nil {
+		if err := util.UnmarshalJSON(keys["Node"], &rule); err != nil {
 			return err
 		}
 		te.Node = &rule
 	}
 
-	if err := json.Unmarshal(keys["Locals"], &te.Locals); err != nil {
+	if err := util.UnmarshalJSON(keys["Locals"], &te.Locals); err != nil {
 		return err
 	}
 
@@ -532,7 +533,7 @@ func (s *Server) v1DataPatch(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 
 	ops := []patchV1{}
-	if err := json.NewDecoder(r.Body).Decode(&ops); err != nil {
+	if err := util.NewJSONDecoder(r.Body).Decode(&ops); err != nil {
 		handleError(w, 400, err)
 		return
 	}
@@ -565,7 +566,7 @@ func (s *Server) v1DataPut(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 
 	var value interface{}
-	if err := json.NewDecoder(r.Body).Decode(&value); err != nil {
+	if err := util.NewJSONDecoder(r.Body).Decode(&value); err != nil {
 		handleError(w, 400, err)
 		return
 	}
@@ -938,7 +939,7 @@ func stringPathToRef(s string) (r ast.Ref) {
 		if err != nil {
 			r = append(r, ast.StringTerm(x))
 		} else {
-			r = append(r, ast.NumberTerm(float64(i)))
+			r = append(r, ast.IntNumberTerm(i))
 		}
 	}
 	return r

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -5,7 +5,6 @@
 package server
 
 import (
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -17,6 +16,7 @@ import (
 
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/storage"
+	"github.com/open-policy-agent/opa/util"
 	"github.com/open-policy-agent/opa/util/test"
 )
 
@@ -240,7 +240,7 @@ func TestDataGetExplainFull(t *testing.T) {
 
 	var result traceV1
 
-	if err := json.NewDecoder(f.recorder.Body).Decode(&result); err != nil {
+	if err := util.NewJSONDecoder(f.recorder.Body).Decode(&result); err != nil {
 		t.Fatalf("Unexpected JSON decode error: %v", err)
 	}
 
@@ -267,7 +267,7 @@ func TestDataGetExplainFull(t *testing.T) {
 		t.Fatalf("Expected status code to be 404 but got: %v", f.recorder.Code)
 	}
 
-	if err := json.NewDecoder(f.recorder.Body).Decode(&result); err != nil {
+	if err := util.NewJSONDecoder(f.recorder.Body).Decode(&result); err != nil {
 		t.Fatalf("Unexpected JSON decode error: %v", err)
 	}
 
@@ -294,7 +294,7 @@ func TestDataGetExplainTruth(t *testing.T) {
 
 	var result traceV1
 
-	if err := json.NewDecoder(f.recorder.Body).Decode(&result); err != nil {
+	if err := util.NewJSONDecoder(f.recorder.Body).Decode(&result); err != nil {
 		t.Fatalf("Unexpected JSON decode error: %v", err)
 	}
 
@@ -418,7 +418,7 @@ func TestPoliciesPutV1ParseError(t *testing.T) {
 	}
 
 	errs := astErrorV1{}
-	if err := json.NewDecoder(f.recorder.Body).Decode(&errs); err != nil {
+	if err := util.NewJSONDecoder(f.recorder.Body).Decode(&errs); err != nil {
 		t.Fatalf("Unexpected JSON decode error: %v", err)
 	}
 
@@ -444,7 +444,7 @@ func TestPoliciesPutV1CompileError(t *testing.T) {
 	}
 
 	errs := astErrorV1{}
-	if err := json.NewDecoder(f.recorder.Body).Decode(&errs); err != nil {
+	if err := util.NewJSONDecoder(f.recorder.Body).Decode(&errs); err != nil {
 		t.Fatalf("Unexpected JSON decode error: %v", err)
 	}
 
@@ -486,7 +486,7 @@ func TestPoliciesListV1(t *testing.T) {
 	}
 
 	var policies []*policyV1
-	err := json.NewDecoder(f.recorder.Body).Decode(&policies)
+	err := util.NewJSONDecoder(f.recorder.Body).Decode(&policies)
 	if err != nil {
 		t.Errorf("Expected policy list but got error: %v", err)
 		return
@@ -600,13 +600,13 @@ func TestQueryV1(t *testing.T) {
 	}
 
 	var expected adhocQueryResultSetV1
-	err := json.Unmarshal([]byte(`[{"a":[1,2,3],"i":0,"x":1},{"a":[1,2,3],"i":1,"x":2},{"a":[1,2,3],"i":2,"x":3}]`), &expected)
+	err := util.UnmarshalJSON([]byte(`[{"a":[1,2,3],"i":0,"x":1},{"a":[1,2,3],"i":1,"x":2},{"a":[1,2,3],"i":2,"x":3}]`), &expected)
 	if err != nil {
 		panic(err)
 	}
 
 	var result adhocQueryResultSetV1
-	err = json.Unmarshal(f.recorder.Body.Bytes(), &result)
+	err = util.UnmarshalJSON(f.recorder.Body.Bytes(), &result)
 	if err != nil {
 		t.Errorf("Unexpected error while unmarshalling result: %v", err)
 		return
@@ -628,7 +628,7 @@ func TestQueryV1Explain(t *testing.T) {
 
 	var result traceV1
 
-	if err := json.NewDecoder(f.recorder.Body).Decode(&result); err != nil {
+	if err := util.NewJSONDecoder(f.recorder.Body).Decode(&result); err != nil {
 		t.Fatalf("Unexpected JSON decode error: %v", err)
 	}
 
@@ -646,7 +646,7 @@ func TestQueryV1Explain(t *testing.T) {
 
 	result = traceV1{}
 
-	if err := json.NewDecoder(f.recorder.Body).Decode(&result); err != nil {
+	if err := util.NewJSONDecoder(f.recorder.Body).Decode(&result); err != nil {
 		t.Fatalf("Unexpected JSON decode error: %v", err)
 	}
 
@@ -746,7 +746,7 @@ func newFixture(t *testing.T) *fixture {
 
 func (f *fixture) loadPolicy() *policyV1 {
 	policy := &policyV1{}
-	err := json.NewDecoder(f.recorder.Body).Decode(policy)
+	err := util.NewJSONDecoder(f.recorder.Body).Decode(policy)
 	if err != nil {
 		panic(err)
 	}
@@ -755,7 +755,7 @@ func (f *fixture) loadPolicy() *policyV1 {
 
 func (f *fixture) loadResponse() interface{} {
 	var v interface{}
-	err := json.NewDecoder(f.recorder.Body).Decode(&v)
+	err := util.NewJSONDecoder(f.recorder.Body).Decode(&v)
 	if err != nil {
 		panic(err)
 	}
@@ -775,11 +775,11 @@ func (f *fixture) executeRequest(req *http.Request, code int, resp string) error
 	}
 	if resp != "" {
 		var result interface{}
-		if err := json.Unmarshal([]byte(f.recorder.Body.String()), &result); err != nil {
+		if err := util.UnmarshalJSON([]byte(f.recorder.Body.String()), &result); err != nil {
 			return fmt.Errorf("Expected JSON response from %v %v but got: %v", req.Method, req.URL, f.recorder)
 		}
 		var expected interface{}
-		if err := json.Unmarshal([]byte(resp), &expected); err != nil {
+		if err := util.UnmarshalJSON([]byte(resp), &expected); err != nil {
 			panic(err)
 		}
 		if !reflect.DeepEqual(result, expected) {

--- a/storage/datastore.go
+++ b/storage/datastore.go
@@ -5,9 +5,10 @@
 package storage
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
+
+	"github.com/open-policy-agent/opa/util"
 
 	"strconv"
 )
@@ -41,7 +42,7 @@ func NewDataStoreFromJSONObject(data map[string]interface{}) *DataStore {
 // NewDataStoreFromReader returns a new DataStore from a reader that produces a
 // JSON serialized object. This function is for test purposes.
 func NewDataStoreFromReader(r io.Reader) *DataStore {
-	d := json.NewDecoder(r)
+	d := util.NewJSONDecoder(r)
 	var data map[string]interface{}
 	if err := d.Decode(&data); err != nil {
 		panic(err)

--- a/storage/datastore_test.go
+++ b/storage/datastore_test.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+
+	"github.com/open-policy-agent/opa/util"
 )
 
 func TestDataStoreGet(t *testing.T) {
@@ -19,13 +21,13 @@ func TestDataStoreGet(t *testing.T) {
 		path     string
 		expected interface{}
 	}{
-		{"/a/0", float64(1)},
-		{"/a/3", float64(4)},
+		{"/a/0", json.Number("1")},
+		{"/a/3", json.Number("4")},
 		{"/b/v1", "hello"},
 		{"/b/v2", "goodbye"},
 		{"/c/0/x/1", false},
 		{"/c/0/y/0", nil},
-		{"/c/0/y/1", 3.14159},
+		{"/c/0/y/1", json.Number("3.14159")},
 		{"/d/e/1", "baz"},
 		{"/d/e", []interface{}{"bar", "baz"}},
 		{"/c/0/z", map[string]interface{}{"p": true, "q": false}},
@@ -189,7 +191,7 @@ func loadExpectedResult(input string) interface{} {
 		return nil
 	}
 	var data interface{}
-	if err := json.Unmarshal([]byte(input), &data); err != nil {
+	if err := util.UnmarshalJSON([]byte(input), &data); err != nil {
 		panic(err)
 	}
 	return data
@@ -207,7 +209,7 @@ func loadExpectedSortedResult(input string) interface{} {
 
 func loadSmallTestData() map[string]interface{} {
 	var data map[string]interface{}
-	err := json.Unmarshal([]byte(`{
+	err := util.UnmarshalJSON([]byte(`{
         "a": [1,2,3,4],
         "b": {
             "v1": "hello",

--- a/storage/example_test.go
+++ b/storage/example_test.go
@@ -5,6 +5,7 @@
 package storage_test
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -34,7 +35,14 @@ func ExampleStorage_Read() {
     `
 
 	var data map[string]interface{}
-	if err := json.Unmarshal([]byte(exampleInput), &data); err != nil {
+
+	// OPA uses Go's standard JSON library but assumes that numbers have been
+	// decoded as json.Number instead of float64. You MUST decode with UseNumber
+	// enabled.
+	decoder := json.NewDecoder(bytes.NewBufferString(exampleInput))
+	decoder.UseNumber()
+
+	if err := decoder.Decode(&data); err != nil {
 		// Handle error.
 	}
 
@@ -87,7 +95,14 @@ func ExampleStorage_Write() {
     `
 
 	var data map[string]interface{}
-	if err := json.Unmarshal([]byte(exampleInput), &data); err != nil {
+
+	// OPA uses Go's standard JSON library but assumes that numbers have been
+	// decoded as json.Number instead of float64. You MUST decode with UseNumber
+	// enabled.
+	decoder := json.NewDecoder(bytes.NewBufferString(exampleInput))
+	decoder.UseNumber()
+
+	if err := decoder.Decode(&data); err != nil {
 		// Handle error.
 	}
 
@@ -102,7 +117,11 @@ func ExampleStorage_Write() {
 
 	var patch interface{}
 
-	if err := json.Unmarshal([]byte(examplePatch), &patch); err != nil {
+	// See comment above regarding decoder usage.
+	decoder = json.NewDecoder(bytes.NewBufferString(examplePatch))
+	decoder.UseNumber()
+
+	if err := decoder.Decode(&patch); err != nil {
 		// Handle error.
 	}
 

--- a/storage/index_test.go
+++ b/storage/index_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/util"
 )
 
 func TestIndicesBuild(t *testing.T) {
@@ -20,10 +21,10 @@ func TestIndicesBuild(t *testing.T) {
 		value    interface{}
 		expected string
 	}{
-		{"single var", "data.a[i]", float64(2), `[{"i": 1}]`},
+		{"single var", "data.a[i]", json.Number("2"), `[{"i": 1}]`},
 		{"two var", "data.d[x][y]", "baz", `[{"x": "e", "y": 1}]`},
 		{"partial ground", `data.c[i]["y"][j]`, nil, `[{"i": 0, "j": 0}]`},
-		{"multiple bindings", "data.g[x][y]", float64(0), `[
+		{"multiple bindings", "data.g[x][y]", json.Number("0"), `[
 			{"x": "a", "y": 1},
 			{"x": "a", "y": 2},
 			{"x": "a", "y": 3},
@@ -56,7 +57,7 @@ func TestIndicesAdd(t *testing.T) {
 
 	// new value to add
 	var val1 interface{}
-	err := json.Unmarshal([]byte(`{"x":[1,true]}`), &val1)
+	err := util.UnmarshalJSON([]byte(`{"x":[1,true]}`), &val1)
 	if err != nil {
 		panic(err)
 	}
@@ -129,7 +130,7 @@ func assertBindingsEqual(t *testing.T, note string, index *bindingIndex, value i
 
 func loadExpectedBindings(input string) []*ast.ValueMap {
 	var data []map[string]interface{}
-	if err := json.Unmarshal([]byte(input), &data); err != nil {
+	if err := util.UnmarshalJSON([]byte(input), &data); err != nil {
 		panic(err)
 	}
 	var expected []*ast.ValueMap
@@ -139,7 +140,7 @@ func loadExpectedBindings(input string) []*ast.ValueMap {
 			switch v := v.(type) {
 			case string:
 				buf.Put(ast.Var(k), ast.String(v))
-			case float64:
+			case json.Number:
 				buf.Put(ast.Var(k), ast.Number(v))
 			default:
 				panic("unreachable")
@@ -147,6 +148,5 @@ func loadExpectedBindings(input string) []*ast.ValueMap {
 		}
 		expected = append(expected, buf)
 	}
-
 	return expected
 }

--- a/storage/path.go
+++ b/storage/path.go
@@ -104,7 +104,7 @@ func (p Path) Ref(head *ast.Term) (ref ast.Ref) {
 	for i := range p {
 		idx, err := strconv.ParseInt(p[i], 10, 64)
 		if err == nil {
-			ref[i+1] = ast.NumberTerm(float64(idx))
+			ref[i+1] = ast.IntNumberTerm(int(idx))
 		} else {
 			ref[i+1] = ast.StringTerm(p[i])
 		}

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -71,7 +71,7 @@ func TestStorageIndexingBasicUpdate(t *testing.T) {
 	refA := ast.MustParseRef("data.a[i]")
 	refB := ast.MustParseRef("data.b[x]")
 	store, ds := newStorageWithIndices(refA, refB)
-	ds.Write(nil, AddOp, MustParsePath("/a/-"), float64(100))
+	ds.Write(nil, AddOp, MustParsePath("/a/-"), nil)
 
 	if store.IndexExists(refA) {
 		t.Errorf("Expected index to be removed after patch")

--- a/test/scheduler/scheduler_bench_test.go
+++ b/test/scheduler/scheduler_bench_test.go
@@ -6,7 +6,6 @@ package scheduler
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"testing"
 	"text/template"
@@ -14,6 +13,7 @@ import (
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/storage"
 	"github.com/open-policy-agent/opa/topdown"
+	"github.com/open-policy-agent/opa/util"
 )
 
 func BenchmarkScheduler10x30(b *testing.B) {
@@ -42,7 +42,7 @@ func runSchedulerBenchmark(b *testing.B, nodes int, pods int) {
 			b.Fatal("unexpected query result:", qrs)
 		}
 		for n, w := range ws {
-			if fmt.Sprintf("%.3f", w) != "5.014" {
+			if fmt.Sprint(w) != "5.01388889" {
 				b.Fatalf("unexpected weight for: %v: %v\n\nDumping all weights:\n\n%v\n", n, w, qrs)
 			}
 		}
@@ -162,7 +162,7 @@ func runTemplate(tmpl *template.Template, input interface{}) interface{} {
 		panic(err)
 	}
 	var v interface{}
-	if err := json.Unmarshal(buf.Bytes(), &v); err != nil {
+	if err := util.UnmarshalJSON(buf.Bytes(), &v); err != nil {
 		panic(err)
 	}
 	return v

--- a/test/scheduler/scheduler_test.go
+++ b/test/scheduler/scheduler_test.go
@@ -30,7 +30,7 @@ func TestScheduler(t *testing.T) {
 		t.Fatal("unexpected query result:", qrs)
 	}
 	for n, w := range ws {
-		if fmt.Sprintf("%.3f", w) != "5.014" {
+		if fmt.Sprint(w) != "5.01388889" {
 			t.Fatalf("unexpected weight for: %v: %v\n\nDumping all weights:\n\n%v\n", n, w, qrs)
 		}
 	}

--- a/topdown/casts.go
+++ b/topdown/casts.go
@@ -5,6 +5,7 @@
 package topdown
 
 import (
+	"encoding/json"
 	"fmt"
 	"strconv"
 
@@ -39,18 +40,18 @@ func evalToNumber(ctx *Context, expr *ast.Expr, iter Iterator) error {
 
 	switch x := x.(type) {
 	case string:
-		f, err := strconv.ParseFloat(string(x), 64)
+		_, err := strconv.ParseFloat(string(x), 64)
 		if err != nil {
 			return errors.Wrapf(err, "to_number")
 		}
-		n = ast.Number(f)
-	case float64:
+		n = ast.Number(json.Number(x))
+	case json.Number:
 		n = ast.Number(x)
 	case bool:
 		if x {
-			n = ast.Number(1)
+			n = ast.Number("1")
 		} else {
-			n = ast.Number(0)
+			n = ast.Number("0")
 		}
 	default:
 		return fmt.Errorf("to_number: source must be a string, boolean, or number: %T", a)

--- a/topdown/eq.go
+++ b/topdown/eq.go
@@ -118,7 +118,7 @@ func evalEqUnifyArrayRef(ctx *Context, a ast.Array, b ast.Ref, prev *Undo, iter 
 		var tmp *Context
 		child := make(ast.Ref, len(b), len(b)+1)
 		copy(child, b)
-		child = append(child, ast.NumberTerm(float64(i)))
+		child = append(child, ast.IntNumberTerm(i))
 		p, err := evalEqUnify(ctx, a[i].Value, child, prev, func(ctx *Context) error {
 			tmp = ctx
 			return nil

--- a/topdown/example_test.go
+++ b/topdown/example_test.go
@@ -5,6 +5,7 @@
 package topdown_test
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 
@@ -25,7 +26,13 @@ func ExampleEval() {
 
 	var data map[string]interface{}
 
-	if err := json.Unmarshal([]byte(`{"a": [1,2,3,4]}`), &data); err != nil {
+	// OPA uses Go's standard JSON library but assumes that numbers have been
+	// decoded as json.Number instead of float64. You MUST decode with UseNumber
+	// enabled.
+	decoder := json.NewDecoder(bytes.NewBufferString(`{"a": [1,2,3,4]}`))
+	decoder.UseNumber()
+
+	if err := decoder.Decode(&data); err != nil {
 		// Handle error.
 	}
 

--- a/topdown/explain/explain_test.go
+++ b/topdown/explain/explain_test.go
@@ -5,12 +5,12 @@
 package explain
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/storage"
 	"github.com/open-policy-agent/opa/topdown"
+	"github.com/open-policy-agent/opa/util"
 )
 
 func TestTruth(t *testing.T) {
@@ -190,7 +190,7 @@ func executeQuery(data string, compiler *ast.Compiler, tracer topdown.Tracer) {
 	d := map[string]interface{}{}
 
 	if len(data) > 0 {
-		if err := json.Unmarshal([]byte(data), &d); err != nil {
+		if err := util.UnmarshalJSON([]byte(data), &d); err != nil {
 			panic(err)
 		}
 	}

--- a/topdown/trace_test.go
+++ b/topdown/trace_test.go
@@ -16,9 +16,9 @@ import (
 func TestEventEqual(t *testing.T) {
 
 	a := ast.NewValueMap()
-	a.Put(ast.String("foo"), ast.Number(1))
+	a.Put(ast.String("foo"), ast.Number("1"))
 	b := ast.NewValueMap()
-	b.Put(ast.String("foo"), ast.Number(2))
+	b.Put(ast.String("foo"), ast.Number("2"))
 
 	tests := []struct {
 		a     *Event

--- a/util/compare.go
+++ b/util/compare.go
@@ -5,7 +5,9 @@
 package util
 
 import (
+	"encoding/json"
 	"fmt"
+	"math/big"
 	"sort"
 )
 
@@ -38,15 +40,10 @@ func Compare(a, b interface{}) int {
 			}
 			return 1
 		}
-	case float64:
+	case json.Number:
 		switch b := b.(type) {
-		case float64:
-			if a == b {
-				return 0
-			} else if a < b {
-				return -1
-			}
-			return 1
+		case json.Number:
+			return compareJSONNumber(a, b)
 		}
 	case string:
 		switch b := b.(type) {
@@ -133,13 +130,25 @@ const (
 	objectSort = iota
 )
 
+func compareJSONNumber(a, b json.Number) int {
+	bigA, ok := new(big.Float).SetString(string(a))
+	if !ok {
+		panic("illegal value")
+	}
+	bigB, ok := new(big.Float).SetString(string(b))
+	if !ok {
+		panic("illegal value")
+	}
+	return bigA.Cmp(bigB)
+}
+
 func sortOrder(v interface{}) int {
 	switch v.(type) {
 	case nil:
 		return nilSort
 	case bool:
 		return boolSort
-	case float64:
+	case json.Number:
 		return numberSort
 	case string:
 		return stringSort

--- a/util/compare_test.go
+++ b/util/compare_test.go
@@ -4,10 +4,13 @@
 
 package util
 
-import "testing"
-import "math"
+import (
+	"encoding/json"
+	"testing"
+)
 
 func TestCompare(t *testing.T) {
+
 	tests := []struct {
 		a        interface{}
 		b        interface{}
@@ -20,12 +23,12 @@ func TestCompare(t *testing.T) {
 		{false, true, -1},
 		{true, true, 0},
 		{true, false, 1},
-		{true, float64(0), -1},
-		{float64(0), float64(0), 0},
-		{float64(0), float64(-1), 1},
-		{float64(-1), float64(0), -1},
-		{math.MaxFloat64, math.SmallestNonzeroFloat64, 1},
-		{float64(-1), "", -1},
+		{true, json.Number("0"), -1},
+		{json.Number("0"), json.Number("0"), 0},
+		{json.Number("0"), json.Number("-1"), 1},
+		{json.Number("-1"), json.Number("0"), -1},
+		{json.Number("1.797693134862315708145274237317043567981e+308"), json.Number("4.940656458412465441765687928682213723651e-324"), 1},
+		{json.Number("-1"), "", -1},
 		{"", "", 0},
 		{"hello", "", 1},
 		{"hello world", "hello worldz", -1},

--- a/util/json.go
+++ b/util/json.go
@@ -1,0 +1,32 @@
+// Copyright 2016 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package util
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+)
+
+// UnmarshalJSON parses the JSON encoded data and stores the result in the value
+// pointed to by x.
+//
+// This function is intended to be used in place of the standard json.Marshal
+// function when json.Number is required.
+func UnmarshalJSON(bs []byte, x interface{}) (err error) {
+	buf := bytes.NewBuffer(bs)
+	decoder := NewJSONDecoder(buf)
+	return decoder.Decode(x)
+}
+
+// NewJSONDecoder returns a new decoder that reads from r.
+//
+// This function is intended to be used in place of the standard json.NewDecoder
+// when json.Number is required.
+func NewJSONDecoder(r io.Reader) *json.Decoder {
+	decoder := json.NewDecoder(r)
+	decoder.UseNumber()
+	return decoder
+}


### PR DESCRIPTION
These changes fix #154 by updating OPA to use json.Number for representation of numbers (instead of float64) and `math/big` for comparisons on json.Number values and all numeric operations (add, mul, sum, etc.)