### PR TITLE
Update OPA to support context.Context

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: required
 language: go
 
 go:
-- 1.6
 - 1.7   # make sure to bump LATEST_GO_VERSION (below) when updating
 
 env:

--- a/repl/example_test.go
+++ b/repl/example_test.go
@@ -6,6 +6,7 @@ package repl_test
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 
 	"github.com/open-policy-agent/opa/repl"
@@ -13,6 +14,9 @@ import (
 )
 
 func ExampleREPL_OneShot() {
+	// Initialize context for the example. Normally the caller would obtain the
+	// context from an input parameter or instantiate their own.
+	ctx := context.Background()
 
 	// Instantiate the policy engine's storage layer.
 	store := storage.New(storage.InMemoryConfig())
@@ -24,10 +28,10 @@ func ExampleREPL_OneShot() {
 	repl := repl.New(store, "", &buf, "json", "")
 
 	// Define a rule inside the REPL.
-	repl.OneShot("p :- a = [1, 2, 3, 4], a[_] > 3")
+	repl.OneShot(ctx, "p :- a = [1, 2, 3, 4], a[_] > 3")
 
 	// Query the rule defined above.
-	repl.OneShot("p")
+	repl.OneShot(ctx, "p")
 
 	// Inspect the output. Defining rules does not produce output so we only expect
 	// output from the second line of input.

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -6,6 +6,7 @@ package runtime
 
 import (
 	"bytes"
+	"context"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -33,6 +34,8 @@ func TestEval(t *testing.T) {
 }
 
 func TestInit(t *testing.T) {
+	ctx := context.Background()
+
 	tmp1, err := ioutil.TempFile("", "docFile")
 	if err != nil {
 		panic(err)
@@ -84,7 +87,7 @@ func TestInit(t *testing.T) {
 
 	rt := Runtime{}
 
-	err = rt.init(&Params{
+	err = rt.init(ctx, &Params{
 		Paths:     []string{tmp1.Name(), tmp2.Name()},
 		PolicyDir: tmp3,
 	})
@@ -94,9 +97,9 @@ func TestInit(t *testing.T) {
 		return
 	}
 
-	txn := storage.NewTransactionOrDie(rt.Store)
+	txn := storage.NewTransactionOrDie(ctx, rt.Store)
 
-	node, err := rt.Store.Read(txn, storage.MustParsePath("/foo"))
+	node, err := rt.Store.Read(ctx, txn, storage.MustParsePath("/foo"))
 	if util.Compare(node, "bar") != 0 || err != nil {
 		t.Errorf("Expected %v but got %v (err: %v)", "bar", node, err)
 		return

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -5,6 +5,7 @@
 package server
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -665,7 +666,7 @@ func (queryBindingErrStore) ID() string {
 	return "mock"
 }
 
-func (s *queryBindingErrStore) Read(txn storage.Transaction, path storage.Path) (interface{}, error) {
+func (s *queryBindingErrStore) Read(ctx context.Context, txn storage.Transaction, path storage.Path) (interface{}, error) {
 	// At this time, the store will receive two reads:
 	// - The first during evaluation
 	// - The second when the server tries to accumulate the bindings
@@ -676,16 +677,17 @@ func (s *queryBindingErrStore) Read(txn storage.Transaction, path storage.Path) 
 	return "", nil
 }
 
-func (queryBindingErrStore) Begin(txn storage.Transaction, params storage.TransactionParams) error {
+func (queryBindingErrStore) Begin(ctx context.Context, txn storage.Transaction, params storage.TransactionParams) error {
 	return nil
 }
 
-func (queryBindingErrStore) Close(txn storage.Transaction) {
+func (queryBindingErrStore) Close(ctx context.Context, txn storage.Transaction) {
 
 }
 
 func TestQueryBindingIterationError(t *testing.T) {
 
+	ctx := context.Background()
 	store := storage.New(storage.InMemoryConfig())
 	mock := &queryBindingErrStore{}
 
@@ -693,7 +695,7 @@ func TestQueryBindingIterationError(t *testing.T) {
 		panic(err)
 	}
 
-	server, err := New(store, ":8182", false)
+	server, err := New(ctx, store, ":8182", false)
 	if err != nil {
 		panic(err)
 	}
@@ -729,9 +731,9 @@ type fixture struct {
 }
 
 func newFixture(t *testing.T) *fixture {
-
+	ctx := context.Background()
 	store := storage.New(storage.InMemoryConfig().WithPolicyDir(policyDir))
-	server, err := New(store, ":8182", false)
+	server, err := New(ctx, store, ":8182", false)
 	if err != nil {
 		panic(err)
 	}

--- a/storage/datastore_test.go
+++ b/storage/datastore_test.go
@@ -5,6 +5,7 @@
 package storage
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -42,7 +43,7 @@ func TestDataStoreGet(t *testing.T) {
 	ds := NewDataStoreFromJSONObject(data)
 
 	for idx, tc := range tests {
-		result, err := ds.Read(nil, MustParsePath(tc.path))
+		result, err := ds.Read(context.Background(), nil, MustParsePath(tc.path))
 		switch e := tc.expected.(type) {
 		case error:
 			if err == nil {
@@ -135,7 +136,7 @@ func TestDataStorePatch(t *testing.T) {
 			panic(fmt.Sprintf("illegal value: %v", tc.op))
 		}
 
-		err := ds.patch(op, MustParsePath(tc.path), value)
+		err := ds.patch(context.Background(), op, MustParsePath(tc.path), value)
 
 		if tc.expected == nil {
 			if err != nil {
@@ -158,7 +159,7 @@ func TestDataStorePatch(t *testing.T) {
 		}
 
 		// Perform get and verify result
-		result, err := ds.Read(nil, MustParsePath(tc.getPath))
+		result, err := ds.Read(context.Background(), nil, MustParsePath(tc.getPath))
 		switch expected := tc.getExpected.(type) {
 		case error:
 			if err == nil {

--- a/storage/example_test.go
+++ b/storage/example_test.go
@@ -6,6 +6,7 @@ package storage_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -16,6 +17,9 @@ import (
 )
 
 func ExampleStorage_Read() {
+	// Initialize context for the example. Normally the caller would obtain the
+	// context from an input parameter or instantiate their own.
+	ctx := context.Background()
 
 	// Define some dummy data to initialize the built-in store with.
 	exampleInput := `
@@ -49,16 +53,16 @@ func ExampleStorage_Read() {
 	// Instantiate the storage layer.
 	store := storage.New(storage.InMemoryWithJSONConfig(data))
 
-	txn, err := store.NewTransaction()
+	txn, err := store.NewTransaction(ctx)
 	if err != nil {
 		// Handle error.
 	}
 
-	defer store.Close(txn)
+	defer store.Close(ctx, txn)
 
 	// Read values out of storage.
-	v1, err1 := store.Read(txn, storage.MustParsePath("/users/1/likes/1"))
-	v2, err2 := store.Read(txn, storage.MustParsePath("/users/0/age"))
+	v1, err1 := store.Read(ctx, txn, storage.MustParsePath("/users/1/likes/1"))
+	v2, err2 := store.Read(ctx, txn, storage.MustParsePath("/users/0/age"))
 
 	// Inspect the return values.
 	fmt.Println("v1:", v1)
@@ -76,6 +80,9 @@ func ExampleStorage_Read() {
 }
 
 func ExampleStorage_Write() {
+	// Initialize context for the example. Normally the caller would obtain the
+	// context from an input parameter or instantiate their own.
+	ctx := context.Background()
 
 	// Define some dummy data to initialize the DataStore with.
 	exampleInput := `
@@ -125,17 +132,17 @@ func ExampleStorage_Write() {
 		// Handle error.
 	}
 
-	txn, err := store.NewTransaction()
+	txn, err := store.NewTransaction(ctx)
 	if err != nil {
 		// Handle error.
 	}
 
-	defer store.Close(txn)
+	defer store.Close(ctx, txn)
 
 	// Write values into storage and read result.
-	err0 := store.Write(txn, storage.AddOp, storage.MustParsePath("/users/0/location"), patch)
-	v1, err1 := store.Read(txn, storage.MustParsePath("/users/0/location/latitude"))
-	err2 := store.Write(txn, storage.ReplaceOp, storage.MustParsePath("/users/1/color"), "red")
+	err0 := store.Write(ctx, txn, storage.AddOp, storage.MustParsePath("/users/0/location"), patch)
+	v1, err1 := store.Read(ctx, txn, storage.MustParsePath("/users/0/location/latitude"))
+	err2 := store.Write(ctx, txn, storage.ReplaceOp, storage.MustParsePath("/users/1/color"), "red")
 
 	// Inspect the return values.
 	fmt.Println("err0:", err0)
@@ -154,6 +161,9 @@ func ExampleStorage_Write() {
 }
 
 func ExampleStorage_Open() {
+	// Initialize context for the example. Normally the caller would obtain the
+	// context from an input parameter or instantiate their own.
+	ctx := context.Background()
 
 	// Define two example modules and write them to disk in a temporary directory.
 	ex1 := `
@@ -190,12 +200,12 @@ func ExampleStorage_Open() {
 	// Instantiate storage layer and configure with a directory to persist policy modules.
 	store := storage.New(storage.InMemoryConfig().WithPolicyDir(path))
 
-	if err = store.Open(); err != nil {
+	if err = store.Open(ctx); err != nil {
 		// Handle error.
 	}
 
 	// Inspect one of the loaded policies.
-	mod, _, err := storage.GetPolicy(store, "ex1.rego")
+	mod, _, err := storage.GetPolicy(ctx, store, "ex1.rego")
 
 	if err != nil {
 		// Handle error.

--- a/storage/index_test.go
+++ b/storage/index_test.go
@@ -5,6 +5,7 @@
 package storage
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -52,7 +53,7 @@ func TestIndicesAdd(t *testing.T) {
 	ref := ast.MustParseRef("data.d[x][y]")
 
 	// TODO(tsandall):
-	indices.Build(store, invalidTXN, ref)
+	indices.Build(context.Background(), store, invalidTXN, ref)
 	index := indices.Get(ref)
 
 	// new value to add
@@ -87,7 +88,7 @@ func runIndexBuildTestCase(t *testing.T, i int, note string, refStr string, expe
 	}
 
 	// TODO(tsandall):
-	err := indices.Build(store, invalidTXN, ref)
+	err := indices.Build(context.Background(), store, invalidTXN, ref)
 	if err != nil {
 		t.Errorf("Test case %d (%v): Did not expect error from build: %v", i, note, err)
 		return

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -4,6 +4,8 @@
 
 package storage
 
+import "context"
+
 // Store defines the interface for the storage layer's backend. Users can
 // implement their own stores and mount them into the storage layer to provide
 // the policy engine access to external data sources.
@@ -18,17 +20,17 @@ type Store interface {
 	// Begin is called to indicate that a new transaction has started. The store
 	// can use the call to initialize any resources that may be required for the
 	// transaction.
-	Begin(txn Transaction, params TransactionParams) error
+	Begin(ctx context.Context, txn Transaction, params TransactionParams) error
 
 	// Read is called to fetch a document referred to by path.
-	Read(txn Transaction, path Path) (interface{}, error)
+	Read(ctx context.Context, txn Transaction, path Path) (interface{}, error)
 
 	// Write is called to modify a document referred to by path.
-	Write(txn Transaction, op PatchOp, path Path, value interface{}) error
+	Write(ctx context.Context, txn Transaction, op PatchOp, path Path, value interface{}) error
 
 	// Close indicates a transaction has finished. The store can use the call to
 	// release any resources temporarily allocated for the transaction.
-	Close(txn Transaction)
+	Close(ctx context.Context, txn Transaction)
 }
 
 // TransactionParams describes a new transaction.
@@ -65,6 +67,6 @@ const (
 // interface which may be used if the backend does not support writes.
 type WritesNotSupported struct{}
 
-func (WritesNotSupported) Write(txn Transaction, op PatchOp, path Path, value interface{}) error {
+func (WritesNotSupported) Write(ctx context.Context, txn Transaction, op PatchOp, path Path, value interface{}) error {
 	return writesNotSupportedError()
 }

--- a/storage/trigger.go
+++ b/storage/trigger.go
@@ -4,9 +4,11 @@
 
 package storage
 
+import "context"
+
 // TriggerCallback defines the interface that callers can implement to handle
 // changes in the stores.
-type TriggerCallback func(txn Transaction, op PatchOp, path Path, value interface{}) error
+type TriggerCallback func(ctx context.Context, txn Transaction, op PatchOp, path Path, value interface{}) error
 
 // TriggerConfig contains the trigger registration configuration.
 type TriggerConfig struct {

--- a/test/scheduler/scheduler_test.go
+++ b/test/scheduler/scheduler_test.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"testing"
 
+	"context"
+
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/storage"
 	"github.com/open-policy-agent/opa/topdown"
@@ -18,7 +20,7 @@ import (
 
 func TestScheduler(t *testing.T) {
 	params := setup(t, "data_10nodes_30pods.json")
-	defer params.Store.Close(params.Transaction)
+	defer params.Store.Close(params.Context, params.Transaction)
 
 	qrs, err := topdown.Query(params)
 
@@ -54,12 +56,13 @@ func setup(t *testing.T, filename string) *topdown.QueryParams {
 	})
 
 	// parameter setup
+	ctx := context.Background()
 	globals := ast.NewValueMap()
 	req := ast.MustParseTerm(requestedPod).Value
 	globals.Put(ast.Var("requested_pod"), req)
 	path := ast.MustParseRef("data.opa.test.scheduler.fit")
-	txn := storage.NewTransactionOrDie(store)
-	params := topdown.NewQueryParams(c, store, txn, globals, path)
+	txn := storage.NewTransactionOrDie(ctx, store)
+	params := topdown.NewQueryParams(ctx, c, store, txn, globals, path)
 
 	return params
 }

--- a/topdown/aggregates.go
+++ b/topdown/aggregates.go
@@ -23,10 +23,10 @@ func (e empty) Error() string {
 }
 
 func evalReduce(f reduceFunc) BuiltinFunc {
-	return func(ctx *Context, expr *ast.Expr, iter Iterator) error {
+	return func(t *Topdown, expr *ast.Expr, iter Iterator) error {
 		ops := expr.Terms.([]*ast.Term)
 		src, dst := ops[1].Value, ops[2].Value
-		x, err := ValueToInterface(src, ctx)
+		x, err := ValueToInterface(src, t)
 		if err != nil {
 			return errors.Wrapf(err, "aggregate")
 		}
@@ -40,8 +40,8 @@ func evalReduce(f reduceFunc) BuiltinFunc {
 			return err
 		}
 
-		undo, err := evalEqUnify(ctx, y, dst, nil, iter)
-		ctx.Unbind(undo)
+		undo, err := evalEqUnify(t, y, dst, nil, iter)
+		t.Unbind(undo)
 		return err
 	}
 }

--- a/topdown/arithmetic.go
+++ b/topdown/arithmetic.go
@@ -69,10 +69,10 @@ func arithDivide(a, b *big.Float) (*big.Float, error) {
 }
 
 func evalArithArity1(f arithArity1) BuiltinFunc {
-	return func(ctx *Context, expr *ast.Expr, iter Iterator) error {
+	return func(t *Topdown, expr *ast.Expr, iter Iterator) error {
 		ops := expr.Terms.([]*ast.Term)
 
-		a, err := ValueToJSONNumber(ops[1].Value, ctx)
+		a, err := ValueToJSONNumber(ops[1].Value, t)
 		if err != nil {
 			return expr.Location.Wrapf(err, "expected number (operand %s is not a number)", ops[0].Location.Text)
 		}
@@ -83,22 +83,22 @@ func evalArithArity1(f arithArity1) BuiltinFunc {
 		}
 
 		b := ops[2].Value
-		undo, err := evalEqUnify(ctx, floatToASTNumber(x), b, nil, iter)
-		ctx.Unbind(undo)
+		undo, err := evalEqUnify(t, floatToASTNumber(x), b, nil, iter)
+		t.Unbind(undo)
 		return err
 	}
 }
 
 func evalArithArity2(f arithArity2) BuiltinFunc {
-	return func(ctx *Context, expr *ast.Expr, iter Iterator) error {
+	return func(t *Topdown, expr *ast.Expr, iter Iterator) error {
 		ops := expr.Terms.([]*ast.Term)
 
-		a, err := ValueToJSONNumber(ops[1].Value, ctx)
+		a, err := ValueToJSONNumber(ops[1].Value, t)
 		if err != nil {
 			return expr.Location.Wrapf(err, "expected number (first operand %s is not a number)", ops[0].Location.Text)
 		}
 
-		b, err := ValueToJSONNumber(ops[2].Value, ctx)
+		b, err := ValueToJSONNumber(ops[2].Value, t)
 		if err != nil {
 			return expr.Location.Wrapf(err, "expected number (second operand %s is not a number)", ops[2].Location.Text)
 		}
@@ -110,8 +110,8 @@ func evalArithArity2(f arithArity2) BuiltinFunc {
 
 		cv := ops[3].Value
 
-		undo, err := evalEqUnify(ctx, floatToASTNumber(c), cv, nil, iter)
-		ctx.Unbind(undo)
+		undo, err := evalEqUnify(t, floatToASTNumber(c), cv, nil, iter)
+		t.Unbind(undo)
 		return err
 	}
 }

--- a/topdown/builtins.go
+++ b/topdown/builtins.go
@@ -10,12 +10,12 @@ import "github.com/open-policy-agent/opa/ast"
 // invoke built-in functions. Users can implement their own built-in functions
 // and register them with the evaluation engine.
 //
-// Callers are given the current evaluation Context ctx with the expression
+// Callers are given the current evaluation Context t with the expression
 // expr to be evaluated. Callers can assume that the expression has been plugged
 // with bindings from the current context. If the built-in function determines
 // that the expression has evaluated successfully it should bind any output variables
 // and invoke the iterator with the context produced by binding the output variables.
-type BuiltinFunc func(ctx *Context, expr *ast.Expr, iter Iterator) (err error)
+type BuiltinFunc func(t *Topdown, expr *ast.Expr, iter Iterator) (err error)
 
 // RegisterBuiltinFunc adds a new built-in function to the evaluation engine.
 func RegisterBuiltinFunc(name ast.Var, fun BuiltinFunc) {

--- a/topdown/casts.go
+++ b/topdown/casts.go
@@ -17,7 +17,7 @@ import (
 // values to numbers. For details on the signature, see builtins.go. This
 // function will only be called by evaluation enigne when the expression refers
 // to the "to_number" built-in.
-func evalToNumber(ctx *Context, expr *ast.Expr, iter Iterator) error {
+func evalToNumber(t *Topdown, expr *ast.Expr, iter Iterator) error {
 
 	// Step 1. unpack the expression to get access to the operands. The Terms
 	// contains the parsed expression: ["to_number", <value>, <output>]
@@ -30,7 +30,7 @@ func evalToNumber(ctx *Context, expr *ast.Expr, iter Iterator) error {
 	// your built-in function is specific to certain types (e.g., strings) see
 	// the other variants of the ValueToInterface function at
 	// https://godoc.org/github.com/open-policy-agent/opa/topdown.
-	x, err := ValueToInterface(a, ctx)
+	x, err := ValueToInterface(a, t)
 	if err != nil {
 		return errors.Wrapf(err, "to_number")
 	}
@@ -69,14 +69,14 @@ func evalToNumber(ctx *Context, expr *ast.Expr, iter Iterator) error {
 	//	success := <logic>
 	//
 	//  if success {
-	// 	  return iter(ctx)
+	// 	  return iter(t)
 	//  }
 	//
 	//  return nil
-	undo, err := evalEqUnify(ctx, n, b, nil, iter)
+	undo, err := evalEqUnify(t, n, b, nil, iter)
 
 	// Step 5. at this point, evaluation is backtracking so the bindings must be undone.
-	ctx.Unbind(undo)
+	t.Unbind(undo)
 
 	// Step 6. finished, return error (which may be nil).
 	return err

--- a/topdown/example_test.go
+++ b/topdown/example_test.go
@@ -48,22 +48,22 @@ func ExampleEval() {
 
 	defer store.Close(txn)
 
-	// Prepare the evaluation parameters. Evaluation executes against the policy engine's
-	// storage. In this case, we seed the storage with a single array of number. Other parameters
-	// such as globals, tracing configuration, etc. can be set on the context. See the Context
-	// documentation for more details.
-	ctx := topdown.NewContext(query, compiler, store, txn)
+	// Prepare the evaluation parameters. Evaluation executes against the policy
+	// engine's storage. In this case, we seed the storage with a single array
+	// of number. Other parameters such as globals, tracing configuration, etc.
+	// can be set on the Topdown object.
+	t := topdown.New(query, compiler, store, txn)
 
 	result := []interface{}{}
 
 	// Execute the query and provide a callbakc function to accumulate the results.
-	err = topdown.Eval(ctx, func(ctx *topdown.Context) error {
+	err = topdown.Eval(t, func(t *topdown.Topdown) error {
 
 		// Each variable in the query will have an associated "binding" in the context.
-		x := ctx.Binding(ast.Var("x"))
+		x := t.Binding(ast.Var("x"))
 
 		// The bindings are ast.Value types so we will convert to a native Go value here.
-		v, err := topdown.ValueToInterface(x, ctx)
+		v, err := topdown.ValueToInterface(x, t)
 		if err != nil {
 			return err
 		}

--- a/topdown/example_test.go
+++ b/topdown/example_test.go
@@ -6,6 +6,7 @@ package topdown_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -15,6 +16,9 @@ import (
 )
 
 func ExampleEval() {
+	// Initialize context for the example. Normally the caller would obtain the
+	// context from an input parameter or instantiate their own.
+	ctx := context.Background()
 
 	compiler := ast.NewCompiler()
 
@@ -41,18 +45,18 @@ func ExampleEval() {
 
 	// Create a new transaction. Transactions allow the policy engine to
 	// evaluate the query over a consistent snapshot fo the storage layer.
-	txn, err := store.NewTransaction()
+	txn, err := store.NewTransaction(ctx)
 	if err != nil {
 		// Handle error.
 	}
 
-	defer store.Close(txn)
+	defer store.Close(ctx, txn)
 
 	// Prepare the evaluation parameters. Evaluation executes against the policy
 	// engine's storage. In this case, we seed the storage with a single array
 	// of number. Other parameters such as globals, tracing configuration, etc.
 	// can be set on the Topdown object.
-	t := topdown.New(query, compiler, store, txn)
+	t := topdown.New(ctx, query, compiler, store, txn)
 
 	result := []interface{}{}
 
@@ -82,6 +86,9 @@ func ExampleEval() {
 }
 
 func ExampleQuery() {
+	// Initialize context for the example. Normally the caller would obtain the
+	// context from an input parameter or instantiate their own.
+	ctx := context.Background()
 
 	compiler := ast.NewCompiler()
 
@@ -113,18 +120,18 @@ func ExampleQuery() {
 
 	// Create a new transaction. Transactions allow the policy engine to
 	// evaluate the query over a consistent snapshot fo the storage layer.
-	txn, err := store.NewTransaction()
+	txn, err := store.NewTransaction(ctx)
 	if err != nil {
 		// Handle error.
 	}
 
-	defer store.Close(txn)
+	defer store.Close(ctx, txn)
 
 	// Prepare the query parameters. Queries execute against the policy engine's storage and can
 	// accept additional documents (which are referred to as "globals"). In this case we have no
 	// additional documents.
 	globals := ast.NewValueMap()
-	params := topdown.NewQueryParams(compiler, store, txn, globals, ast.MustParseRef("data.opa.example.p"))
+	params := topdown.NewQueryParams(ctx, compiler, store, txn, globals, ast.MustParseRef("data.opa.example.p"))
 
 	// Execute the query against "p".
 	v1, err1 := topdown.Query(params)

--- a/topdown/explain/explain_test.go
+++ b/topdown/explain/explain_test.go
@@ -7,6 +7,8 @@ package explain
 import (
 	"testing"
 
+	"context"
+
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/storage"
 	"github.com/open-policy-agent/opa/topdown"
@@ -195,12 +197,11 @@ func executeQuery(data string, compiler *ast.Compiler, tracer topdown.Tracer) {
 		}
 	}
 
+	ctx := context.Background()
 	store := storage.New(storage.InMemoryWithJSONConfig(d))
-
-	txn := storage.NewTransactionOrDie(store)
-	defer store.Close(txn)
-
-	params := topdown.NewQueryParams(compiler, store, txn, nil, ast.MustParseRef("data.test.p"))
+	txn := storage.NewTransactionOrDie(ctx, store)
+	defer store.Close(ctx, txn)
+	params := topdown.NewQueryParams(ctx, compiler, store, txn, nil, ast.MustParseRef("data.test.p"))
 	params.Tracer = tracer
 
 	_, err := topdown.Query(params)

--- a/topdown/ineq.go
+++ b/topdown/ineq.go
@@ -29,18 +29,18 @@ func compareNotEq(a, b ast.Value) bool {
 }
 
 func evalIneq(cmp compareFunc) BuiltinFunc {
-	return func(ctx *Context, expr *ast.Expr, iter Iterator) error {
+	return func(t *Topdown, expr *ast.Expr, iter Iterator) error {
 		ops := expr.Terms.([]*ast.Term)
-		a, err := ResolveRefs(ops[1].Value, ctx)
+		a, err := ResolveRefs(ops[1].Value, t)
 		if err != nil {
 			return err
 		}
-		b, err := ResolveRefs(ops[2].Value, ctx)
+		b, err := ResolveRefs(ops[2].Value, t)
 		if err != nil {
 			return err
 		}
 		if cmp(a, b) {
-			return iter(ctx)
+			return iter(t)
 		}
 		return nil
 	}

--- a/topdown/regex.go
+++ b/topdown/regex.go
@@ -15,13 +15,13 @@ import (
 var regexpCacheLock = sync.Mutex{}
 var regexpCache map[string]*regexp.Regexp
 
-func evalRegexMatch(ctx *Context, expr *ast.Expr, iter Iterator) error {
+func evalRegexMatch(t *Topdown, expr *ast.Expr, iter Iterator) error {
 	ops := expr.Terms.([]*ast.Term)
-	pat, err := ValueToString(ops[1].Value, ctx)
+	pat, err := ValueToString(ops[1].Value, t)
 	if err != nil {
 		return errors.Wrapf(err, "re_match: pattern value must be a string")
 	}
-	input, err := ValueToString(ops[2].Value, ctx)
+	input, err := ValueToString(ops[2].Value, t)
 	if err != nil {
 		return errors.Wrapf(err, "re_match: input value must be a string")
 	}
@@ -30,7 +30,7 @@ func evalRegexMatch(ctx *Context, expr *ast.Expr, iter Iterator) error {
 		return err
 	}
 	if re.Match([]byte(input)) {
-		return iter(ctx)
+		return iter(t)
 	}
 	return nil
 }

--- a/topdown/sets.go
+++ b/topdown/sets.go
@@ -11,9 +11,9 @@ import (
 	"github.com/pkg/errors"
 )
 
-func evalSetDiff(ctx *Context, expr *ast.Expr, iter Iterator) (err error) {
+func evalSetDiff(t *Topdown, expr *ast.Expr, iter Iterator) (err error) {
 	ops := expr.Terms.([]*ast.Term)
-	op1, err := ResolveRefs(ops[1].Value, ctx)
+	op1, err := ResolveRefs(ops[1].Value, t)
 	if err != nil {
 		return errors.Wrapf(err, "set_diff")
 	}
@@ -26,7 +26,7 @@ func evalSetDiff(ctx *Context, expr *ast.Expr, iter Iterator) (err error) {
 		}
 	}
 
-	op2, err := ResolveRefs(ops[2].Value, ctx)
+	op2, err := ResolveRefs(ops[2].Value, t)
 	if err != nil {
 		return errors.Wrapf(err, "set_diff")
 	}
@@ -40,7 +40,7 @@ func evalSetDiff(ctx *Context, expr *ast.Expr, iter Iterator) (err error) {
 	}
 
 	s3 := s1.Diff(s2)
-	undo, err := evalEqUnify(ctx, s3, ops[3].Value, nil, iter)
-	ctx.Unbind(undo)
+	undo, err := evalEqUnify(t, s3, ops[3].Value, nil, iter)
+	t.Unbind(undo)
 	return err
 }

--- a/topdown/strings.go
+++ b/topdown/strings.go
@@ -12,17 +12,17 @@ import (
 	"github.com/pkg/errors"
 )
 
-func evalFormatInt(ctx *Context, expr *ast.Expr, iter Iterator) error {
+func evalFormatInt(t *Topdown, expr *ast.Expr, iter Iterator) error {
 	ops := expr.Terms.([]*ast.Term)
 
-	input, err := ValueToJSONNumber(ops[1].Value, ctx)
+	input, err := ValueToJSONNumber(ops[1].Value, t)
 	if err != nil {
 		return errors.Wrapf(err, "%v: input must be a number", ast.FormatInt.Name)
 	}
 
 	i, _ := jsonNumberToFloat(input).Int(nil)
 
-	base, err := ValueToInt(ops[2].Value, ctx)
+	base, err := ValueToInt(ops[2].Value, t)
 	if err != nil {
 		return errors.Wrapf(err, "%v: base must be an integer", ast.FormatInt.Name)
 	}
@@ -43,65 +43,65 @@ func evalFormatInt(ctx *Context, expr *ast.Expr, iter Iterator) error {
 
 	s := ast.String(fmt.Sprintf(format, i))
 
-	undo, err := evalEqUnify(ctx, s, ops[3].Value, nil, iter)
-	ctx.Unbind(undo)
+	undo, err := evalEqUnify(t, s, ops[3].Value, nil, iter)
+	t.Unbind(undo)
 	return err
 }
 
-func evalConcat(ctx *Context, expr *ast.Expr, iter Iterator) error {
+func evalConcat(t *Topdown, expr *ast.Expr, iter Iterator) error {
 	ops := expr.Terms.([]*ast.Term)
 
-	join, err := ValueToString(ops[1].Value, ctx)
+	join, err := ValueToString(ops[1].Value, t)
 	if err != nil {
 		return errors.Wrapf(err, "%v: join value must be a string", ast.Concat.Name)
 	}
 
-	sl, err := ValueToStrings(ops[2].Value, ctx)
+	sl, err := ValueToStrings(ops[2].Value, t)
 	if err != nil {
 		return errors.Wrapf(err, "%v: input value must be array of strings", ast.Concat.Name)
 	}
 
 	s := ast.String(strings.Join(sl, join))
 
-	undo, err := evalEqUnify(ctx, s, ops[3].Value, nil, iter)
-	ctx.Unbind(undo)
+	undo, err := evalEqUnify(t, s, ops[3].Value, nil, iter)
+	t.Unbind(undo)
 	return err
 }
 
-func evalIndexOf(ctx *Context, expr *ast.Expr, iter Iterator) error {
+func evalIndexOf(t *Topdown, expr *ast.Expr, iter Iterator) error {
 	ops := expr.Terms.([]*ast.Term)
 
-	base, err := ValueToString(ops[1].Value, ctx)
+	base, err := ValueToString(ops[1].Value, t)
 	if err != nil {
 		return errors.Wrapf(err, "%v: base value must be a string", ast.IndexOf.Name)
 	}
 
-	search, err := ValueToString(ops[2].Value, ctx)
+	search, err := ValueToString(ops[2].Value, t)
 	if err != nil {
 		return errors.Wrapf(err, "%v: search value must be a string", ast.IndexOf.Name)
 	}
 
 	index := ast.IntNumberTerm(strings.Index(base, search))
 
-	undo, err := evalEqUnify(ctx, index.Value, ops[3].Value, nil, iter)
-	ctx.Unbind(undo)
+	undo, err := evalEqUnify(t, index.Value, ops[3].Value, nil, iter)
+	t.Unbind(undo)
 	return err
 }
 
-func evalSubstring(ctx *Context, expr *ast.Expr, iter Iterator) error {
+func evalSubstring(t *Topdown, expr *ast.Expr, iter Iterator) error {
 	ops := expr.Terms.([]*ast.Term)
 
-	base, err := ValueToString(ops[1].Value, ctx)
+	base, err := ValueToString(ops[1].Value, t)
 	if err != nil {
 		return errors.Wrapf(err, "%v: base value must be a string", ast.Substring.Name)
 	}
 
-	startIndex, err := ValueToInt(ops[2].Value, ctx)
+	startIndex, err := ValueToInt(ops[2].Value, t)
 	if err != nil {
 		return errors.Wrapf(err, "%v: start index must be a number", ast.Substring.Name)
 	}
 
-	l, err := ValueToInt(ops[3].Value, ctx)
+	l, err := ValueToInt(ops[3].Value, t)
 	if err != nil {
 		return errors.Wrapf(err, "%v: length must be a number", ast.Substring.Name)
 	}
@@ -113,94 +113,94 @@ func evalSubstring(ctx *Context, expr *ast.Expr, iter Iterator) error {
 		s = ast.String(base[startIndex : startIndex+l])
 	}
 
-	undo, err := evalEqUnify(ctx, s, ops[4].Value, nil, iter)
-	ctx.Unbind(undo)
+	undo, err := evalEqUnify(t, s, ops[4].Value, nil, iter)
+	t.Unbind(undo)
 	return err
 }
 
-func evalContains(ctx *Context, expr *ast.Expr, iter Iterator) error {
+func evalContains(t *Topdown, expr *ast.Expr, iter Iterator) error {
 	ops := expr.Terms.([]*ast.Term)
 
-	base, err := ValueToString(ops[1].Value, ctx)
+	base, err := ValueToString(ops[1].Value, t)
 	if err != nil {
 		return errors.Wrapf(err, "%v: base value must be a string", ast.Contains.Name)
 	}
 
-	search, err := ValueToString(ops[2].Value, ctx)
+	search, err := ValueToString(ops[2].Value, t)
 	if err != nil {
 		return errors.Wrapf(err, "%v: search must be a string", ast.Contains.Name)
 	}
 
 	if strings.Contains(base, search) {
-		return iter(ctx)
+		return iter(t)
 	}
 	return nil
 }
 
-func evalStartsWith(ctx *Context, expr *ast.Expr, iter Iterator) error {
+func evalStartsWith(t *Topdown, expr *ast.Expr, iter Iterator) error {
 	ops := expr.Terms.([]*ast.Term)
 
-	base, err := ValueToString(ops[1].Value, ctx)
+	base, err := ValueToString(ops[1].Value, t)
 	if err != nil {
 		return errors.Wrapf(err, "%v: base value must be a string", ast.StartsWith.Name)
 	}
 
-	search, err := ValueToString(ops[2].Value, ctx)
+	search, err := ValueToString(ops[2].Value, t)
 	if err != nil {
 		return errors.Wrapf(err, "%v: search must be a string", ast.StartsWith.Name)
 	}
 
 	if strings.HasPrefix(base, search) {
-		return iter(ctx)
+		return iter(t)
 	}
 	return nil
 }
 
-func evalEndsWith(ctx *Context, expr *ast.Expr, iter Iterator) error {
+func evalEndsWith(t *Topdown, expr *ast.Expr, iter Iterator) error {
 	ops := expr.Terms.([]*ast.Term)
 
-	base, err := ValueToString(ops[1].Value, ctx)
+	base, err := ValueToString(ops[1].Value, t)
 	if err != nil {
 		return errors.Wrapf(err, "%v: base value must be a string", ast.EndsWith.Name)
 	}
 
-	search, err := ValueToString(ops[2].Value, ctx)
+	search, err := ValueToString(ops[2].Value, t)
 	if err != nil {
 		return errors.Wrapf(err, "%v: search must be a string", ast.EndsWith.Name)
 	}
 
 	if strings.HasSuffix(base, search) {
-		return iter(ctx)
+		return iter(t)
 	}
 	return nil
 }
 
-func evalLower(ctx *Context, expr *ast.Expr, iter Iterator) error {
+func evalLower(t *Topdown, expr *ast.Expr, iter Iterator) error {
 	ops := expr.Terms.([]*ast.Term)
 
-	orig, err := ValueToString(ops[1].Value, ctx)
+	orig, err := ValueToString(ops[1].Value, t)
 	if err != nil {
 		return errors.Wrapf(err, "%v: original value must be a string", ast.Lower.Name)
 	}
 
 	s := ast.String(strings.ToLower(orig))
 
-	undo, err := evalEqUnify(ctx, s, ops[2].Value, nil, iter)
-	ctx.Unbind(undo)
+	undo, err := evalEqUnify(t, s, ops[2].Value, nil, iter)
+	t.Unbind(undo)
 	return err
 }
 
-func evalUpper(ctx *Context, expr *ast.Expr, iter Iterator) error {
+func evalUpper(t *Topdown, expr *ast.Expr, iter Iterator) error {
 	ops := expr.Terms.([]*ast.Term)
 
-	orig, err := ValueToString(ops[1].Value, ctx)
+	orig, err := ValueToString(ops[1].Value, t)
 	if err != nil {
 		return errors.Wrapf(err, "%v: original value must be a string", ast.Upper.Name)
 	}
 
 	s := ast.String(strings.ToUpper(orig))
 
-	undo, err := evalEqUnify(ctx, s, ops[2].Value, nil, iter)
-	ctx.Unbind(undo)
+	undo, err := evalEqUnify(t, s, ops[2].Value, nil, iter)
+	t.Unbind(undo)
 	return err
 }

--- a/topdown/topdown.go
+++ b/topdown/topdown.go
@@ -14,14 +14,15 @@ import (
 	"github.com/pkg/errors"
 )
 
-// Context contains the state of the evaluation process.
-type Context struct {
+// Topdown stores the state of the evaluation process and contains context
+// needed to evaluate queries.
+type Topdown struct {
 	Query    ast.Body
 	Compiler *ast.Compiler
 	Globals  *ast.ValueMap
 	Locals   *ast.ValueMap
 	Index    int
-	Previous *Context
+	Previous *Topdown
 	Store    *storage.Storage
 	Tracer   Tracer
 
@@ -64,13 +65,13 @@ type redoStack struct {
 }
 
 type redoStackElement struct {
-	ctx *Context
+	t   *Topdown
 	evt *Event
 }
 
-// NewContext creates a new Context with no bindings.
-func NewContext(query ast.Body, compiler *ast.Compiler, store *storage.Storage, txn storage.Transaction) *Context {
-	return &Context{
+// New returns a new Topdown object without any bindings.
+func New(query ast.Body, compiler *ast.Compiler, store *storage.Storage, txn storage.Transaction) *Topdown {
+	return &Topdown{
 		Query:    query,
 		Compiler: compiler,
 		Locals:   ast.NewValueMap(),
@@ -83,11 +84,11 @@ func NewContext(query ast.Body, compiler *ast.Compiler, store *storage.Storage, 
 }
 
 // Binding returns the value bound to the given key.
-func (ctx *Context) Binding(k ast.Value) ast.Value {
-	if v := ctx.Locals.Get(k); v != nil {
+func (t *Topdown) Binding(k ast.Value) ast.Value {
+	if v := t.Locals.Get(k); v != nil {
 		return v
 	}
-	if v := ctx.Globals.Get(k); v != nil {
+	if v := t.Globals.Get(k); v != nil {
 		return v
 	}
 	return nil
@@ -100,50 +101,51 @@ type Undo struct {
 	Prev  *Undo
 }
 
-// Bind updates the context to include a binding from the key to the value. The return
-// value is used to return the context to the state before the binding was added.
-func (ctx *Context) Bind(key ast.Value, value ast.Value, prev *Undo) *Undo {
-	o := ctx.Locals.Get(key)
-	ctx.Locals.Put(key, value)
+// Bind updates t to include a binding from the key to the value. The return
+// value is used to return t to the state before the binding was added.
+func (t *Topdown) Bind(key ast.Value, value ast.Value, prev *Undo) *Undo {
+	o := t.Locals.Get(key)
+	t.Locals.Put(key, value)
 	return &Undo{key, o, prev}
 }
 
-// Unbind updates the context by removing the binding represented by the undo.
-func (ctx *Context) Unbind(undo *Undo) {
+// Unbind updates t by removing the binding represented by the undo.
+func (t *Topdown) Unbind(undo *Undo) {
 	for u := undo; u != nil; u = u.Prev {
 		if u.Value != nil {
-			ctx.Locals.Put(u.Key, u.Value)
+			t.Locals.Put(u.Key, u.Value)
 		} else {
-			ctx.Locals.Delete(u.Key)
+			t.Locals.Delete(u.Key)
 		}
 	}
 }
 
-// Child returns a new context to evaluate a query that was referenced by this context.
-func (ctx *Context) Child(query ast.Body, locals *ast.ValueMap) *Context {
-	cpy := *ctx
+// Child returns a new Topdown object to evaluate a query that was referred to
+// by the query of t.
+func (t *Topdown) Child(query ast.Body, locals *ast.ValueMap) *Topdown {
+	cpy := *t
 	cpy.Query = query
 	cpy.Locals = locals
-	cpy.Previous = ctx
+	cpy.Previous = t
 	cpy.Index = 0
 	cpy.qid = qidFactory.Next()
 	return &cpy
 }
 
 // Current returns the current expression to evaluate.
-func (ctx *Context) Current() *ast.Expr {
-	return ctx.Query[ctx.Index]
+func (t *Topdown) Current() *ast.Expr {
+	return t.Query[t.Index]
 }
 
 // Resolve returns the native Go value referred to by the ref.
-func (ctx *Context) Resolve(ref ast.Ref) (interface{}, error) {
+func (t *Topdown) Resolve(ref ast.Ref) (interface{}, error) {
 
 	if ref.IsNested() {
 		cpy := make(ast.Ref, len(ref))
 		for i := range ref {
 			switch v := ref[i].Value.(type) {
 			case ast.Ref:
-				r, err := lookupValue(ctx, v)
+				r, err := lookupValue(t, v)
 				if err != nil {
 					return nil, err
 				}
@@ -160,70 +162,70 @@ func (ctx *Context) Resolve(ref ast.Ref) (interface{}, error) {
 		return nil, err
 	}
 
-	return ctx.Store.Read(ctx.txn, path)
+	return t.Store.Read(t.txn, path)
 }
 
-// Step returns a new context to evaluate the next expression.
-func (ctx *Context) Step() *Context {
-	cpy := *ctx
+// Step returns a new Topdown object to evaluate the next expression.
+func (t *Topdown) Step() *Topdown {
+	cpy := *t
 	cpy.Index++
 	return &cpy
 }
 
-func (ctx *Context) traceEnter(node interface{}) {
-	if ctx.tracingEnabled() {
-		evt := ctx.makeEvent(EnterOp, node)
-		ctx.flushRedos(evt)
-		ctx.Tracer.Trace(ctx, evt)
+func (t *Topdown) traceEnter(node interface{}) {
+	if t.tracingEnabled() {
+		evt := t.makeEvent(EnterOp, node)
+		t.flushRedos(evt)
+		t.Tracer.Trace(t, evt)
 	}
 }
 
-func (ctx *Context) traceExit(node interface{}) {
-	if ctx.tracingEnabled() {
-		evt := ctx.makeEvent(ExitOp, node)
-		ctx.flushRedos(evt)
-		ctx.Tracer.Trace(ctx, evt)
+func (t *Topdown) traceExit(node interface{}) {
+	if t.tracingEnabled() {
+		evt := t.makeEvent(ExitOp, node)
+		t.flushRedos(evt)
+		t.Tracer.Trace(t, evt)
 	}
 }
 
-func (ctx *Context) traceEval(node interface{}) {
-	if ctx.tracingEnabled() {
-		evt := ctx.makeEvent(EvalOp, node)
-		ctx.flushRedos(evt)
-		ctx.Tracer.Trace(ctx, evt)
+func (t *Topdown) traceEval(node interface{}) {
+	if t.tracingEnabled() {
+		evt := t.makeEvent(EvalOp, node)
+		t.flushRedos(evt)
+		t.Tracer.Trace(t, evt)
 	}
 }
 
-func (ctx *Context) traceRedo(node interface{}) {
-	if ctx.tracingEnabled() {
-		evt := ctx.makeEvent(RedoOp, node)
-		ctx.saveRedo(evt)
+func (t *Topdown) traceRedo(node interface{}) {
+	if t.tracingEnabled() {
+		evt := t.makeEvent(RedoOp, node)
+		t.saveRedo(evt)
 	}
 }
 
-func (ctx *Context) traceFail(node interface{}) {
-	if ctx.tracingEnabled() {
-		evt := ctx.makeEvent(FailOp, node)
-		ctx.flushRedos(evt)
-		ctx.Tracer.Trace(ctx, evt)
+func (t *Topdown) traceFail(node interface{}) {
+	if t.tracingEnabled() {
+		evt := t.makeEvent(FailOp, node)
+		t.flushRedos(evt)
+		t.Tracer.Trace(t, evt)
 	}
 }
 
-func (ctx *Context) tracingEnabled() bool {
-	return ctx.Tracer != nil && ctx.Tracer.Enabled()
+func (t *Topdown) tracingEnabled() bool {
+	return t.Tracer != nil && t.Tracer.Enabled()
 }
 
-func (ctx *Context) saveRedo(evt *Event) {
+func (t *Topdown) saveRedo(evt *Event) {
 
 	buf := &redoStackElement{
-		ctx: ctx,
+		t:   t,
 		evt: evt,
 	}
 
 	// Search stack for redo that this (redo) event should follow.
-	for len(ctx.redos.events) > 0 {
-		idx := len(ctx.redos.events) - 1
-		top := ctx.redos.events[idx]
+	for len(t.redos.events) > 0 {
+		idx := len(t.redos.events) - 1
+		top := t.redos.events[idx]
 
 		// Expression redo should follow rule/body redo from the same query.
 		if evt.HasExpr() {
@@ -241,39 +243,39 @@ func (ctx *Context) saveRedo(evt *Event) {
 
 		// Top of stack can be discarded. This indicates the search terminated
 		// without producing any more events.
-		ctx.redos.events = ctx.redos.events[:idx]
+		t.redos.events = t.redos.events[:idx]
 	}
 
-	ctx.redos.events = append(ctx.redos.events, buf)
+	t.redos.events = append(t.redos.events, buf)
 }
 
-func (ctx *Context) flushRedos(evt *Event) {
+func (t *Topdown) flushRedos(evt *Event) {
 
-	idx := len(ctx.redos.events) - 1
+	idx := len(t.redos.events) - 1
 
 	if idx != -1 {
-		top := ctx.redos.events[idx]
+		top := t.redos.events[idx]
 
 		if top.evt.QueryID == evt.QueryID {
-			for _, buf := range ctx.redos.events {
-				ctx.Tracer.Trace(buf.ctx, buf.evt)
+			for _, buf := range t.redos.events {
+				t.Tracer.Trace(buf.t, buf.evt)
 			}
 		}
 
-		ctx.redos.events = nil
+		t.redos.events = nil
 	}
 
 }
 
-func (ctx *Context) makeEvent(op Op, node interface{}) *Event {
+func (t *Topdown) makeEvent(op Op, node interface{}) *Event {
 	evt := Event{
 		Op:      op,
 		Node:    node,
-		QueryID: ctx.qid,
-		Locals:  ctx.Locals.Copy(),
+		QueryID: t.qid,
+		Locals:  t.Locals.Copy(),
 	}
-	if ctx.Previous != nil {
-		evt.ParentID = ctx.Previous.qid
+	if t.Previous != nil {
+		evt.ParentID = t.Previous.qid
 	}
 	return &evt
 }
@@ -368,43 +370,42 @@ func typeErrSetLookupDereference(rule *ast.Rule, ref ast.Ref, loc *ast.Location)
 	}
 }
 
-// Iterator is the interface for processing contexts.
-type Iterator func(*Context) error
+// Iterator is the interface for processing evaluation results.
+type Iterator func(*Topdown) error
 
-// Continue binds the key to the value in the current context and invokes the iterator.
-// This is a helper function for simple cases where a single value (e.g., a variable) needs
-// to be bound to a value in order for the evaluation the proceed.
-func Continue(ctx *Context, key, value ast.Value, iter Iterator) error {
-	undo := ctx.Bind(key, value, nil)
-	err := iter(ctx)
-	ctx.Unbind(undo)
+// Continue binds key to value in t and calls the iterator. This is a helper
+// function for simple cases where a single value (e.g., a variable) needs to be
+// bound to a value in order for the evaluation the proceed.
+func Continue(t *Topdown, key, value ast.Value, iter Iterator) error {
+	undo := t.Bind(key, value, nil)
+	err := iter(t)
+	t.Unbind(undo)
 	return err
 }
 
-// ContinueN binds N keys to N values. The key/value pairs are passed in as alternating pairs, e.g.,
-// key-1, value-1, key-2, value-2, ..., key-N, value-N.
-func ContinueN(ctx *Context, iter Iterator, x ...ast.Value) error {
+// ContinueN binds N keys to N values. The key/value pairs are passed in as
+// alternating pairs, e.g., key-1, value-1, key-2, value-2, ..., key-N, value-N.
+func ContinueN(t *Topdown, iter Iterator, x ...ast.Value) error {
 	var prev *Undo
 	for i := 0; i < len(x)/2; i++ {
 		offset := i * 2
-		prev = ctx.Bind(x[offset], x[offset+1], prev)
+		prev = t.Bind(x[offset], x[offset+1], prev)
 	}
-	err := iter(ctx)
-	ctx.Unbind(prev)
+	err := iter(t)
+	t.Unbind(prev)
 	return err
 }
 
-// Eval runs the evaluation algorithm on the context and calls the iterator
-// for each context that contains bindings that satisfy all of the expressions
-// inside the body.
-func Eval(ctx *Context, iter Iterator) error {
-	ctx.traceEnter(ctx.Query)
-	return evalContext(ctx, func(ctx *Context) error {
-		ctx.traceExit(ctx.Query)
-		if err := iter(ctx); err != nil {
+// Eval evaluates the query in t and calls iter once for each set of bindings
+// that satisfy all of the expressions in the query.
+func Eval(t *Topdown, iter Iterator) error {
+	t.traceEnter(t.Query)
+	return eval(t, func(t *Topdown) error {
+		t.traceExit(t.Query)
+		if err := iter(t); err != nil {
 			return err
 		}
-		ctx.traceRedo(ctx.Query)
+		t.traceRedo(t.Query)
 		return nil
 	})
 }
@@ -563,12 +564,12 @@ func NewQueryParams(compiler *ast.Compiler, store *storage.Storage, txn storage.
 	}
 }
 
-// NewContext returns a new Context that can be used to do evaluation.
-func (q *QueryParams) NewContext(body ast.Body) *Context {
-	ctx := NewContext(body, q.Compiler, q.Store, q.Transaction)
-	ctx.Globals = q.Globals
-	ctx.Tracer = q.Tracer
-	return ctx
+// NewTopdown returns a new Topdown object that can be used to do evaluation.
+func (q *QueryParams) NewTopdown(body ast.Body) *Topdown {
+	t := New(body, q.Compiler, q.Store, q.Transaction)
+	t.Globals = q.Globals
+	t.Tracer = q.Tracer
+	return t
 }
 
 // QueryResult represents a single query result.
@@ -612,13 +613,13 @@ func Query(params *QueryParams) (QueryResultSet, error) {
 func queryOne(params *QueryParams) (QueryResultSet, error) {
 
 	query := ast.NewBody(ast.Equality.Expr(ast.RefTerm(params.Path...), ast.Wildcard))
-	ctx := params.NewContext(query)
+	t := params.NewTopdown(query)
 	var result interface{} = struct{}{}
 	var err error
 
-	err = Eval(ctx, func(ctx *Context) error {
-		val := PlugValue(ast.Wildcard.Value, ctx.Binding)
-		result, err = ValueToInterface(val, ctx)
+	err = Eval(t, func(t *Topdown) error {
+		val := PlugValue(ast.Wildcard.Value, t.Binding)
+		result, err = ValueToInterface(val, t)
 		return err
 	})
 
@@ -655,7 +656,7 @@ func queryN(params *QueryParams) (QueryResultSet, error) {
 		return false
 	})
 
-	err := evalGlobals(params, func(globals *ast.ValueMap, root *Context) error {
+	err := evalGlobals(params, func(globals *ast.ValueMap, root *Topdown) error {
 		params.Globals = globals
 		result, err := queryOne(params)
 		if err != nil || result.Undefined() {
@@ -680,7 +681,7 @@ func queryN(params *QueryParams) (QueryResultSet, error) {
 
 // evalGlobals constructs query to find bindings for all variables in the params
 // Globals field.
-func evalGlobals(params *QueryParams, iter func(*ast.ValueMap, *Context) error) error {
+func evalGlobals(params *QueryParams, iter func(*ast.ValueMap, *Topdown) error) error {
 	exprs := []*ast.Expr{}
 	params.Globals.Iter(func(k, v ast.Value) bool {
 		exprs = append(exprs, ast.Equality.Expr(ast.NewTerm(k), ast.NewTerm(v)))
@@ -688,15 +689,15 @@ func evalGlobals(params *QueryParams, iter func(*ast.ValueMap, *Context) error) 
 	})
 
 	query := ast.NewBody(exprs...)
-	ctx := params.NewContext(query)
+	t := params.NewTopdown(query)
 
-	return Eval(ctx, func(ctx *Context) error {
+	return Eval(t, func(t *Topdown) error {
 		globals := ast.NewValueMap()
 		params.Globals.Iter(func(k, _ ast.Value) bool {
-			globals.Put(k, PlugValue(k, ctx.Binding))
+			globals.Put(k, PlugValue(k, t.Binding))
 			return false
 		})
-		return iter(globals, ctx)
+		return iter(globals, t)
 	})
 }
 
@@ -721,9 +722,9 @@ func (r resolver) Resolve(ref ast.Ref) (interface{}, error) {
 
 // ResolveRefs returns the AST value obtained by resolving references to base
 // documents.
-func ResolveRefs(v ast.Value, ctx *Context) (ast.Value, error) {
+func ResolveRefs(v ast.Value, t *Topdown) (ast.Value, error) {
 	result, err := ast.TransformRefs(v, func(r ast.Ref) (ast.Value, error) {
-		return lookupValue(ctx, r)
+		return lookupValue(t, r)
 	})
 	if err != nil {
 		return nil, err
@@ -868,34 +869,34 @@ func ValueToStrings(v ast.Value, resolver Resolver) ([]string, error) {
 	return r, nil
 }
 
-func evalContext(ctx *Context, iter Iterator) error {
+func eval(t *Topdown, iter Iterator) error {
 
-	if ctx.Index >= len(ctx.Query) {
-		return iter(ctx)
+	if t.Index >= len(t.Query) {
+		return iter(t)
 	}
 
-	if ctx.Current().Negated {
-		return evalContextNegated(ctx, iter)
+	if t.Current().Negated {
+		return evalNegated(t, iter)
 	}
 
-	ctx.traceEval(ctx.Current())
+	t.traceEval(t.Current())
 
 	// isRedo indicates if the expression's terms are defined at least once. If
 	// any of the terms are undefined, then the closure below will not run (but
 	// a Fail event still needs to be emitted).
 	isRedo := false
 
-	err := evalTerms(ctx, func(ctx *Context) error {
+	err := evalTerms(t, func(t *Topdown) error {
 		isRedo = true
 
 		// isTrue indicates if the expression is true and is used to determine
 		// if a Fail event should be emitted below.
 		isTrue := false
 
-		err := evalExpr(ctx, func(ctx *Context) error {
+		err := evalExpr(t, func(t *Topdown) error {
 			isTrue = true
-			ctx = ctx.Step()
-			return evalContext(ctx, iter)
+			t = t.Step()
+			return eval(t, iter)
 		})
 
 		if err != nil {
@@ -903,10 +904,10 @@ func evalContext(ctx *Context, iter Iterator) error {
 		}
 
 		if !isTrue {
-			ctx.traceFail(ctx.Current())
+			t.traceFail(t.Current())
 		}
 
-		ctx.traceRedo(ctx.Current())
+		t.traceRedo(t.Current())
 
 		return nil
 	})
@@ -916,22 +917,22 @@ func evalContext(ctx *Context, iter Iterator) error {
 	}
 
 	if !isRedo {
-		ctx.traceFail(ctx.Current())
+		t.traceFail(t.Current())
 	}
 
 	return nil
 }
 
-func evalContextNegated(ctx *Context, iter Iterator) error {
+func evalNegated(t *Topdown, iter Iterator) error {
 
-	negation := ast.NewBody(ctx.Current().Complement())
-	child := ctx.Child(negation, ctx.Locals)
+	negation := ast.NewBody(t.Current().Complement())
+	child := t.Child(negation, t.Locals)
 
-	ctx.traceEval(ctx.Current())
+	t.traceEval(t.Current())
 
 	isTrue := false
 
-	err := Eval(child, func(*Context) error {
+	err := Eval(child, func(*Topdown) error {
 		isTrue = true
 		return nil
 	})
@@ -941,35 +942,35 @@ func evalContextNegated(ctx *Context, iter Iterator) error {
 	}
 
 	if !isTrue {
-		return evalContext(ctx.Step(), iter)
+		return eval(t.Step(), iter)
 	}
 
-	ctx.traceFail(ctx.Current())
+	t.traceFail(t.Current())
 
 	return nil
 }
 
-func evalExpr(ctx *Context, iter Iterator) error {
-	expr := PlugExpr(ctx.Current(), ctx.Binding)
+func evalExpr(t *Topdown, iter Iterator) error {
+	expr := PlugExpr(t.Current(), t.Binding)
 	switch tt := expr.Terms.(type) {
 	case []*ast.Term:
 		builtin, ok := builtinFunctions[tt[0].Value.(ast.Var)]
 		if !ok {
 			return typeErrUnsupportedBuiltin(expr)
 		}
-		return builtin(ctx, expr, iter)
+		return builtin(t, expr, iter)
 	case *ast.Term:
 		v := tt.Value
 		if r, ok := v.(ast.Ref); ok {
 			var err error
-			v, err = lookupValue(ctx, r)
+			v, err = lookupValue(t, r)
 			if err != nil {
 				return err
 			}
 		}
 		if !v.Equal(ast.Boolean(false)) {
 			if v.IsGround() {
-				return iter(ctx)
+				return iter(t)
 			}
 		}
 		return nil
@@ -982,29 +983,29 @@ func evalExpr(ctx *Context, iter Iterator) error {
 // the reference that is defined. The iterator is invoked with bindings for (1)
 // all variables found in the reference and (2) the reference itself if that
 // reference refers to a virtual document (ditto for nested references).
-func evalRef(ctx *Context, ref, path ast.Ref, iter Iterator) error {
+func evalRef(t *Topdown, ref, path ast.Ref, iter Iterator) error {
 
 	if len(ref) == 0 {
 		// If this reference refers to a local variable, evaluate against the binding.
 		// Otherwise, evaluate against the database.
 		if !path[0].Equal(ast.DefaultRootDocument) {
-			v := ctx.Binding(path[0].Value)
+			v := t.Binding(path[0].Value)
 			if v == nil {
 				return unboundGlobalVarErr(path)
 			}
-			return evalRefRuleResult(ctx, path, path[1:], v, iter)
+			return evalRefRuleResult(t, path, path[1:], v, iter)
 		}
-		return evalRefRec(ctx, path, iter)
+		return evalRefRec(t, path, iter)
 	}
 
 	head, tail := ref[0], ref[1:]
 	n, ok := head.Value.(ast.Ref)
 	if !ok {
 		path = append(path, head)
-		return evalRef(ctx, tail, path, iter)
+		return evalRef(t, tail, path, iter)
 	}
 
-	return evalRef(ctx, n, ast.Ref{}, func(ctx *Context) error {
+	return evalRef(t, n, ast.Ref{}, func(t *Topdown) error {
 
 		var undo *Undo
 
@@ -1012,60 +1013,60 @@ func evalRef(ctx *Context, ref, path ast.Ref, iter Iterator) error {
 		// 'n' referred to a virtual document the binding would already exist.
 		// We bind nested references so that when the overall expression is
 		// evaluated, it will not contain any nested references.
-		if b := ctx.Binding(n); b == nil {
+		if b := t.Binding(n); b == nil {
 			var err error
 			var v ast.Value
-			switch p := PlugValue(n, ctx.Binding).(type) {
+			switch p := PlugValue(n, t.Binding).(type) {
 			case ast.Ref:
-				v, err = lookupValue(ctx, p)
+				v, err = lookupValue(t, p)
 				if err != nil {
 					return err
 				}
 			default:
 				v = p
 			}
-			undo = ctx.Bind(n, v, nil)
+			undo = t.Bind(n, v, nil)
 		}
 
 		tmp := append(path, head)
-		err := evalRef(ctx, tail, tmp, iter)
+		err := evalRef(t, tail, tmp, iter)
 
 		if undo != nil {
-			ctx.Unbind(undo)
+			t.Unbind(undo)
 		}
 
 		return err
 	})
 }
 
-func evalRefRec(ctx *Context, ref ast.Ref, iter Iterator) error {
+func evalRefRec(t *Topdown, ref ast.Ref, iter Iterator) error {
 
 	// Obtain ground prefix of the reference.
 	var prefix ast.Ref
 
-	switch v := PlugValue(ref, ctx.Binding).(type) {
+	switch v := PlugValue(ref, t.Binding).(type) {
 	case ast.Ref:
 		prefix = v.GroundPrefix()
 	default:
 		// Fast-path? TODO test case.
-		return iter(ctx)
+		return iter(t)
 	}
 
 	// Check if the prefix refers to a virtual document.
 	var rules []*ast.Rule
 	path := prefix
 	for len(path) > 0 {
-		if rules = ctx.Compiler.GetRulesExact(path); rules != nil {
-			return evalRefRule(ctx, ref, path, rules, iter)
+		if rules = t.Compiler.GetRulesExact(path); rules != nil {
+			return evalRefRule(t, ref, path, rules, iter)
 		}
 		path = path[:len(path)-1]
 	}
 
 	if len(prefix) == len(ref) {
-		return evalRefRecGround(ctx, ref, prefix, iter)
+		return evalRefRecGround(t, ref, prefix, iter)
 	}
 
-	return evalRefRecNonGround(ctx, ref, prefix, iter)
+	return evalRefRecNonGround(t, ref, prefix, iter)
 }
 
 // evalRefRecGround evaluates the ground reference prefix. The reference is
@@ -1073,16 +1074,16 @@ func evalRefRec(ctx *Context, ref ast.Ref, iter Iterator) error {
 // refers to one or more virtual documents, then all of the referenced documents
 // (i.e., base and virtual documents) are merged and the ref is bound to the
 // result before continuing.
-func evalRefRecGround(ctx *Context, ref, prefix ast.Ref, iter Iterator) error {
+func evalRefRecGround(t *Topdown, ref, prefix ast.Ref, iter Iterator) error {
 
-	doc, readErr := ctx.Resolve(prefix)
+	doc, readErr := t.Resolve(prefix)
 	if readErr != nil {
 		if !storage.IsNotFound(readErr) {
 			return readErr
 		}
 	}
 
-	node := ctx.Compiler.RuleTree
+	node := t.Compiler.RuleTree
 	for _, x := range prefix {
 		node = node.Children[x.Value]
 		if node == nil {
@@ -1098,10 +1099,10 @@ func evalRefRecGround(ctx *Context, ref, prefix ast.Ref, iter Iterator) error {
 		if storage.IsNotFound(readErr) {
 			return nil
 		}
-		return iter(ctx)
+		return iter(t)
 	}
 
-	vdoc, err := evalRefRecTree(ctx, prefix, node)
+	vdoc, err := evalRefRecTree(t, prefix, node)
 	if err != nil {
 		return err
 	}
@@ -1110,7 +1111,7 @@ func evalRefRecGround(ctx *Context, ref, prefix ast.Ref, iter Iterator) error {
 		if storage.IsNotFound(readErr) {
 			return nil
 		}
-		return iter(ctx)
+		return iter(t)
 	}
 
 	// The reference is defined for one or more virtual documents. Now merge the
@@ -1134,22 +1135,22 @@ func evalRefRecGround(ctx *Context, ref, prefix ast.Ref, iter Iterator) error {
 		result, _ = v.(ast.Object).Merge(result)
 	}
 
-	return Continue(ctx, ref, result, iter)
+	return Continue(t, ref, result, iter)
 }
 
 // evalRefRecTree evaluates the rules found in the leaves of the tree. For each
 // non-leaf node in the tree, the results are merged together to form an object.
 // The final result is the object representing the virtual document rooted at
 // node.
-func evalRefRecTree(ctx *Context, path ast.Ref, node *ast.RuleTreeNode) (ast.Object, error) {
+func evalRefRecTree(t *Topdown, path ast.Ref, node *ast.RuleTreeNode) (ast.Object, error) {
 	var v ast.Object
 
 	for _, c := range node.Children {
 		path = append(path, &ast.Term{Value: c.Key})
 		if len(c.Rules) > 0 {
 			var result ast.Value
-			err := evalRefRule(ctx, path, path, c.Rules, func(ctx *Context) error {
-				result = ctx.Binding(path)
+			err := evalRefRule(t, path, path, c.Rules, func(t *Topdown) error {
+				result = t.Binding(path)
 				return nil
 			})
 			if err != nil {
@@ -1167,7 +1168,7 @@ func evalRefRecTree(ctx *Context, path ast.Ref, node *ast.RuleTreeNode) (ast.Obj
 			}
 			v, _ = v.Merge(obj)
 		} else {
-			result, err := evalRefRecTree(ctx, path, c)
+			result, err := evalRefRecTree(t, path, c)
 			if err != nil {
 				return nil, err
 			}
@@ -1191,7 +1192,7 @@ func evalRefRecTree(ctx *Context, path ast.Ref, node *ast.RuleTreeNode) (ast.Obj
 // evalRefRecNonGround processes the non-ground reference ref. The reference
 // is processed by enumerating values that may be used as keys for the next
 // (variable) term in the reference and then recursing on the reference.
-func evalRefRecNonGround(ctx *Context, ref, prefix ast.Ref, iter Iterator) error {
+func evalRefRecNonGround(t *Topdown, ref, prefix ast.Ref, iter Iterator) error {
 
 	// Keep track of keys visited. The reference may refer to both virtual and
 	// base documents or virtual documents produced by disjunctive rules. In
@@ -1200,7 +1201,7 @@ func evalRefRecNonGround(ctx *Context, ref, prefix ast.Ref, iter Iterator) error
 
 	variable := ref[len(prefix)].Value
 
-	doc, err := ctx.Resolve(prefix)
+	doc, err := t.Resolve(prefix)
 	if err != nil {
 		if !storage.IsNotFound(err) {
 			return err
@@ -1215,9 +1216,9 @@ func evalRefRecNonGround(ctx *Context, ref, prefix ast.Ref, iter Iterator) error
 				if _, ok := visited[key]; ok {
 					continue
 				}
-				undo := ctx.Bind(variable, key, nil)
-				err := evalRefRec(ctx, ref, iter)
-				ctx.Unbind(undo)
+				undo := t.Bind(variable, key, nil)
+				err := evalRefRec(t, ref, iter)
+				t.Unbind(undo)
 				if err != nil {
 					return err
 				}
@@ -1225,9 +1226,9 @@ func evalRefRecNonGround(ctx *Context, ref, prefix ast.Ref, iter Iterator) error
 			}
 		case []interface{}:
 			for idx := range doc {
-				undo := ctx.Bind(variable, ast.IntNumberTerm(idx).Value, nil)
-				err := evalRefRec(ctx, ref, iter)
-				ctx.Unbind(undo)
+				undo := t.Bind(variable, ast.IntNumberTerm(idx).Value, nil)
+				err := evalRefRec(t, ref, iter)
+				t.Unbind(undo)
 				if err != nil {
 					return err
 				}
@@ -1238,7 +1239,7 @@ func evalRefRecNonGround(ctx *Context, ref, prefix ast.Ref, iter Iterator) error
 		}
 	}
 
-	node := ctx.Compiler.ModuleTree
+	node := t.Compiler.ModuleTree
 	for _, x := range prefix {
 		node = node.Children[x.Value]
 		if node == nil {
@@ -1252,9 +1253,9 @@ func evalRefRecNonGround(ctx *Context, ref, prefix ast.Ref, iter Iterator) error
 			if _, ok := visited[key]; ok {
 				continue
 			}
-			undo := ctx.Bind(variable, key, nil)
-			err := evalRefRec(ctx, ref, iter)
-			ctx.Unbind(undo)
+			undo := t.Bind(variable, key, nil)
+			err := evalRefRec(t, ref, iter)
+			t.Unbind(undo)
 			if err != nil {
 				return err
 			}
@@ -1267,9 +1268,9 @@ func evalRefRecNonGround(ctx *Context, ref, prefix ast.Ref, iter Iterator) error
 		if _, ok := visited[key]; ok {
 			continue
 		}
-		undo := ctx.Bind(variable, key, nil)
-		err := evalRefRec(ctx, ref, iter)
-		ctx.Unbind(undo)
+		undo := t.Bind(variable, key, nil)
+		err := evalRefRec(t, ref, iter)
+		t.Unbind(undo)
 		if err != nil {
 			return err
 		}
@@ -1279,21 +1280,21 @@ func evalRefRecNonGround(ctx *Context, ref, prefix ast.Ref, iter Iterator) error
 	return nil
 }
 
-func evalRefRule(ctx *Context, ref ast.Ref, path ast.Ref, rules []*ast.Rule, iter Iterator) error {
+func evalRefRule(t *Topdown, ref ast.Ref, path ast.Ref, rules []*ast.Rule, iter Iterator) error {
 
 	suffix := ref[len(path):]
 
 	switch rules[0].DocKind() {
 
 	case ast.CompleteDoc:
-		return evalRefRuleCompleteDoc(ctx, ref, suffix, rules, iter)
+		return evalRefRuleCompleteDoc(t, ref, suffix, rules, iter)
 
 	case ast.PartialObjectDoc:
 		if len(suffix) == 0 {
-			return evalRefRulePartialObjectDocFull(ctx, ref, rules, iter)
+			return evalRefRulePartialObjectDocFull(t, ref, rules, iter)
 		}
 		for i, rule := range rules {
-			err := evalRefRulePartialObjectDoc(ctx, ref, path, rule, i > 0, iter)
+			err := evalRefRulePartialObjectDoc(t, ref, path, rule, i > 0, iter)
 			if err != nil {
 				return err
 			}
@@ -1301,13 +1302,13 @@ func evalRefRule(ctx *Context, ref ast.Ref, path ast.Ref, rules []*ast.Rule, ite
 
 	case ast.PartialSetDoc:
 		if len(suffix) == 0 {
-			return evalRefRulePartialSetDocFull(ctx, ref, rules, iter)
+			return evalRefRulePartialSetDocFull(t, ref, rules, iter)
 		}
 		if len(suffix) != 1 {
-			return typeErrSetLookupDereference(rules[0], ref, ctx.Current().Location)
+			return typeErrSetLookupDereference(rules[0], ref, t.Current().Location)
 		}
 		for i, rule := range rules {
-			err := evalRefRulePartialSetDoc(ctx, ref, path, rule, i > 0, iter)
+			err := evalRefRulePartialSetDoc(t, ref, path, rule, i > 0, iter)
 			if err != nil {
 				return err
 			}
@@ -1317,28 +1318,28 @@ func evalRefRule(ctx *Context, ref ast.Ref, path ast.Ref, rules []*ast.Rule, ite
 	return nil
 }
 
-func evalRefRuleCompleteDoc(ctx *Context, ref ast.Ref, suffix ast.Ref, rules []*ast.Rule, iter Iterator) error {
+func evalRefRuleCompleteDoc(t *Topdown, ref ast.Ref, suffix ast.Ref, rules []*ast.Rule, iter Iterator) error {
 
 	var result ast.Value
 
 	// Check if we have cached the result of evaluating this rule set already.
 	for _, rule := range rules {
-		if doc, ok := ctx.cache.complete[rule]; ok {
-			return evalRefRuleResult(ctx, ref, suffix, doc, iter)
+		if doc, ok := t.cache.complete[rule]; ok {
+			return evalRefRuleResult(t, ref, suffix, doc, iter)
 		}
 	}
 
 	for i, rule := range rules {
 
 		bindings := ast.NewValueMap()
-		child := ctx.Child(rule.Body, bindings)
+		child := t.Child(rule.Body, bindings)
 		if i == 0 {
 			child.traceEnter(rule)
 		} else {
 			child.traceRedo(rule)
 		}
 
-		err := evalContext(child, func(child *Context) error {
+		err := eval(child, func(child *Topdown) error {
 			if result == nil {
 				result = PlugValue(rule.Value.Value, child.Binding)
 			} else {
@@ -1361,43 +1362,43 @@ func evalRefRuleCompleteDoc(ctx *Context, ref ast.Ref, suffix ast.Ref, rules []*
 		// Add the result to the cache. All of the rules have either produced the same value
 		// or only one of them has produced a value. As such, we can cache the result on any
 		// of them.
-		ctx.cache.complete[rules[0]] = result
-		return evalRefRuleResult(ctx, ref, suffix, result, iter)
+		t.cache.complete[rules[0]] = result
+		return evalRefRuleResult(t, ref, suffix, result, iter)
 	}
 
 	return nil
 }
 
-func evalRefRulePartialObjectDoc(ctx *Context, ref ast.Ref, path ast.Ref, rule *ast.Rule, redo bool, iter Iterator) error {
+func evalRefRulePartialObjectDoc(t *Topdown, ref ast.Ref, path ast.Ref, rule *ast.Rule, redo bool, iter Iterator) error {
 	suffix := ref[len(path):]
 
-	key := PlugValue(suffix[0].Value, ctx.Binding)
+	key := PlugValue(suffix[0].Value, t.Binding)
 
 	// There are two cases being handled below. The first deals with non-ground
 	// keys. If the key is not ground, we evaluate the child query and copy the
-	// key binding from the child context into this context. The second deals
-	// with ground keys. In that case, we initialize the child context with a key
-	// binding and evaluate the child query. This reduces the amount of processing
-	// the child query has to do.
+	// key binding from the child into t. The second deals with ground keys. In
+	// that case, we initialize the child with a key binding and evaluate the
+	// child query. This reduces the amount of processing the child query has to
+	// do.
 	//
-	// In the first case, we do not unify the keys because the unification does not
-	// namespace variables within their context. As a result, we could end up with
-	// a recursive binding if we unified "key" with "rule.Key.Value". If unification
-	// is improved to handle namespacing, this can be revisited.
+	// In the first case, we do not unify the keys because the unification does
+	// not namespace variables within their context. As a result, we could end
+	// up with a recursive binding if we unified "key" with "rule.Key.Value". If
+	// unification is improved to handle namespacing, this can be revisited.
 	if !key.IsGround() {
-		child := ctx.Child(rule.Body, ast.NewValueMap())
+		child := t.Child(rule.Body, ast.NewValueMap())
 		if redo {
 			child.traceRedo(rule)
 		} else {
 			child.traceEnter(rule)
 		}
-		return evalContext(child, func(child *Context) error {
+		return eval(child, func(child *Topdown) error {
 
 			key := PlugValue(rule.Key.Value, child.Binding)
 
 			if r, ok := key.(ast.Ref); ok {
 				var err error
-				key, err = lookupValue(ctx, r)
+				key, err = lookupValue(t, r)
 				if err != nil {
 					if storage.IsNotFound(err) {
 						return nil
@@ -1417,9 +1418,9 @@ func evalRefRulePartialObjectDoc(ctx *Context, ref ast.Ref, path ast.Ref, rule *
 
 			child.traceExit(rule)
 
-			undo := ctx.Bind(suffix[0].Value.(ast.Var), key, nil)
-			err := evalRefRuleResult(ctx, ref, ref[len(path)+1:], value, iter)
-			ctx.Unbind(undo)
+			undo := t.Bind(suffix[0].Value.(ast.Var), key, nil)
+			err := evalRefRuleResult(t, ref, ref[len(path)+1:], value, iter)
+			t.Unbind(undo)
 			child.traceRedo(rule)
 			return err
 		})
@@ -1428,10 +1429,10 @@ func evalRefRulePartialObjectDoc(ctx *Context, ref ast.Ref, path ast.Ref, rule *
 	// Check if the rule has already been evaluated with this key. If it has,
 	// proceed with the cached value. Otherwise, evaluate the rule and update
 	// the cache.
-	if docs, ok := ctx.cache.partialobjs[rule]; ok {
+	if docs, ok := t.cache.partialobjs[rule]; ok {
 		if r, ok := key.(ast.Ref); ok {
 			var err error
-			key, err = lookupValue(ctx, r)
+			key, err = lookupValue(t, r)
 			if err != nil {
 				if storage.IsNotFound(err) {
 					return nil
@@ -1443,13 +1444,13 @@ func evalRefRulePartialObjectDoc(ctx *Context, ref ast.Ref, path ast.Ref, rule *
 			return typeErrObjectKey(rule, key)
 		}
 		if doc, ok := docs[key]; ok {
-			return evalRefRuleResult(ctx, ref, ref[len(path)+1:], doc, iter)
+			return evalRefRuleResult(t, ref, ref[len(path)+1:], doc, iter)
 		}
 	}
 
-	child := ctx.Child(rule.Body, ast.NewValueMap())
+	child := t.Child(rule.Body, ast.NewValueMap())
 
-	_, err := evalEqUnify(child, key, rule.Key.Value, nil, func(child *Context) error {
+	_, err := evalEqUnify(child, key, rule.Key.Value, nil, func(child *Topdown) error {
 
 		if redo {
 			child.traceRedo(rule)
@@ -1457,22 +1458,22 @@ func evalRefRulePartialObjectDoc(ctx *Context, ref ast.Ref, path ast.Ref, rule *
 			child.traceEnter(rule)
 		}
 
-		return evalContext(child, func(child *Context) error {
+		return eval(child, func(child *Topdown) error {
 
 			value := PlugValue(rule.Value.Value, child.Binding)
 			if !value.IsGround() {
 				return fmt.Errorf("unbound variable: %v", value)
 			}
 
-			cache, ok := ctx.cache.partialobjs[rule]
+			cache, ok := t.cache.partialobjs[rule]
 			if !ok {
 				cache = map[ast.Value]ast.Value{}
-				ctx.cache.partialobjs[rule] = cache
+				t.cache.partialobjs[rule] = cache
 			}
 
 			if r, ok := key.(ast.Ref); ok {
 				var err error
-				key, err = lookupValue(ctx, r)
+				key, err = lookupValue(t, r)
 				if err != nil {
 					if storage.IsNotFound(err) {
 						return nil
@@ -1489,7 +1490,7 @@ func evalRefRulePartialObjectDoc(ctx *Context, ref ast.Ref, path ast.Ref, rule *
 
 			child.traceExit(rule)
 
-			err := evalRefRuleResult(ctx, ref, ref[len(path)+1:], value.(ast.Value), iter)
+			err := evalRefRuleResult(t, ref, ref[len(path)+1:], value.(ast.Value), iter)
 			if err != nil {
 				return err
 			}
@@ -1503,7 +1504,7 @@ func evalRefRulePartialObjectDoc(ctx *Context, ref ast.Ref, path ast.Ref, rule *
 
 }
 
-func evalRefRulePartialObjectDocFull(ctx *Context, ref ast.Ref, rules []*ast.Rule, iter Iterator) error {
+func evalRefRulePartialObjectDocFull(t *Topdown, ref ast.Ref, rules []*ast.Rule, iter Iterator) error {
 
 	var result ast.Object
 	keys := ast.NewValueMap()
@@ -1511,20 +1512,20 @@ func evalRefRulePartialObjectDocFull(ctx *Context, ref ast.Ref, rules []*ast.Rul
 	for i, rule := range rules {
 
 		bindings := ast.NewValueMap()
-		child := ctx.Child(rule.Body, bindings)
+		child := t.Child(rule.Body, bindings)
 		if i == 0 {
 			child.traceEnter(rule)
 		} else {
 			child.traceRedo(rule)
 		}
 
-		err := evalContext(child, func(child *Context) error {
+		err := eval(child, func(child *Topdown) error {
 
 			key := PlugValue(rule.Key.Value, child.Binding)
 
 			if r, ok := key.(ast.Ref); ok {
 				var err error
-				key, err = lookupValue(ctx, r)
+				key, err = lookupValue(t, r)
 				if err != nil {
 					if storage.IsNotFound(err) {
 						return nil
@@ -1560,17 +1561,17 @@ func evalRefRulePartialObjectDocFull(ctx *Context, ref ast.Ref, rules []*ast.Rul
 		}
 	}
 
-	return Continue(ctx, ref, result, iter)
+	return Continue(t, ref, result, iter)
 }
 
-func evalRefRulePartialSetDoc(ctx *Context, ref ast.Ref, path ast.Ref, rule *ast.Rule, redo bool, iter Iterator) error {
+func evalRefRulePartialSetDoc(t *Topdown, ref ast.Ref, path ast.Ref, rule *ast.Rule, redo bool, iter Iterator) error {
 
 	suffix := ref[len(path):]
-	key := PlugValue(suffix[0].Value, ctx.Binding)
+	key := PlugValue(suffix[0].Value, t.Binding)
 
 	// See comment in evalRefRulePartialObjectDoc about the two branches below.
 	if !key.IsGround() {
-		child := ctx.Child(rule.Body, ast.NewValueMap())
+		child := t.Child(rule.Body, ast.NewValueMap())
 
 		if redo {
 			child.traceRedo(rule)
@@ -1579,41 +1580,42 @@ func evalRefRulePartialSetDoc(ctx *Context, ref ast.Ref, path ast.Ref, rule *ast
 		}
 
 		// TODO(tsandall): Currently this evaluates the child query without any
-		// bindings from the current context. In cases where the key is partially
-		// ground this may be quite inefficient. An optimization would be to unify
-		// variables in the child query with ground values in the current context/query.
-		// To do this, the unification may need to be improved to namespace variables
-		// across contexts (otherwise we could end up with recursive bindings).
-		return evalContext(child, func(child *Context) error {
+		// bindings from t. In cases where the key is partially ground this may
+		// be quite inefficient. An optimization would be to unify variables in
+		// the child query with ground values in the current context/query. To
+		// do this, the unification may need to be improved to namespace
+		// variables across contexts (otherwise we could end up with recursive
+		// bindings).
+		return eval(child, func(child *Topdown) error {
 			value := PlugValue(rule.Key.Value, child.Binding)
 			if !value.IsGround() {
 				return fmt.Errorf("unbound variable: %v", rule.Value)
 			}
 			child.traceExit(rule)
-			undo, err := evalEqUnify(ctx, key, value, nil, func(child *Context) error {
-				return Continue(ctx, ref[:len(path)+1], ast.Boolean(true), iter)
+			undo, err := evalEqUnify(t, key, value, nil, func(child *Topdown) error {
+				return Continue(t, ref[:len(path)+1], ast.Boolean(true), iter)
 			})
 
 			if err != nil {
 				return err
 			}
-			ctx.Unbind(undo)
+			t.Unbind(undo)
 			child.traceRedo(rule)
 			return nil
 		})
 	}
 
-	child := ctx.Child(rule.Body, ast.NewValueMap())
+	child := t.Child(rule.Body, ast.NewValueMap())
 
-	_, err := evalEqUnify(child, key, rule.Key.Value, nil, func(child *Context) error {
+	_, err := evalEqUnify(child, key, rule.Key.Value, nil, func(child *Topdown) error {
 		if redo {
 			child.traceRedo(rule)
 		} else {
 			child.traceEnter(rule)
 		}
-		return evalContext(child, func(child *Context) error {
+		return eval(child, func(child *Topdown) error {
 			child.traceExit(rule)
-			err := Continue(ctx, ref[:len(path)+1], ast.Boolean(true), iter)
+			err := Continue(t, ref[:len(path)+1], ast.Boolean(true), iter)
 			if err != nil {
 				return err
 			}
@@ -1625,14 +1627,14 @@ func evalRefRulePartialSetDoc(ctx *Context, ref ast.Ref, path ast.Ref, rule *ast
 	return err
 }
 
-func evalRefRulePartialSetDocFull(ctx *Context, ref ast.Ref, rules []*ast.Rule, iter Iterator) error {
+func evalRefRulePartialSetDocFull(t *Topdown, ref ast.Ref, rules []*ast.Rule, iter Iterator) error {
 
 	result := &ast.Set{}
 
 	for i, rule := range rules {
 
 		bindings := ast.NewValueMap()
-		child := ctx.Child(rule.Body, bindings)
+		child := t.Child(rule.Body, bindings)
 
 		if i == 0 {
 			child.traceEnter(rule)
@@ -1640,7 +1642,7 @@ func evalRefRulePartialSetDocFull(ctx *Context, ref ast.Ref, rules []*ast.Rule, 
 			child.traceRedo(rule)
 		}
 
-		err := evalContext(child, func(child *Context) error {
+		err := eval(child, func(child *Topdown) error {
 			value := PlugValue(rule.Key.Value, child.Binding)
 			result.Add(&ast.Term{Value: value})
 			child.traceExit(rule)
@@ -1653,43 +1655,43 @@ func evalRefRulePartialSetDocFull(ctx *Context, ref ast.Ref, rules []*ast.Rule, 
 		}
 	}
 
-	return Continue(ctx, ref, result, iter)
+	return Continue(t, ref, result, iter)
 }
 
-func evalRefRuleResult(ctx *Context, ref ast.Ref, suffix ast.Ref, result ast.Value, iter Iterator) error {
+func evalRefRuleResult(t *Topdown, ref ast.Ref, suffix ast.Ref, result ast.Value, iter Iterator) error {
 
 	s := make(ast.Ref, len(suffix))
 
 	for i := range suffix {
-		s[i] = PlugTerm(suffix[i], ctx.Binding)
+		s[i] = PlugTerm(suffix[i], t.Binding)
 	}
 
-	return evalRefRuleResultRec(ctx, result, s, ast.Ref{}, func(ctx *Context, v ast.Value) error {
-		return Continue(ctx, ref, v, iter)
+	return evalRefRuleResultRec(t, result, s, ast.Ref{}, func(t *Topdown, v ast.Value) error {
+		return Continue(t, ref, v, iter)
 	})
 }
 
-func evalRefRuleResultRec(ctx *Context, v ast.Value, ref, path ast.Ref, iter func(*Context, ast.Value) error) error {
+func evalRefRuleResultRec(t *Topdown, v ast.Value, ref, path ast.Ref, iter func(*Topdown, ast.Value) error) error {
 
 	if len(ref) == 0 {
-		return iter(ctx, v)
+		return iter(t, v)
 	}
 
 	switch v := v.(type) {
 	case ast.Array:
-		return evalRefRuleResultRecArray(ctx, v, ref, path, iter)
+		return evalRefRuleResultRecArray(t, v, ref, path, iter)
 	case *ast.Set:
-		return evalRefRuleResultRecSet(ctx, v, ref, path, iter)
+		return evalRefRuleResultRecSet(t, v, ref, path, iter)
 	case ast.Object:
-		return evalRefRuleResultRecObject(ctx, v, ref, path, iter)
+		return evalRefRuleResultRecObject(t, v, ref, path, iter)
 	case ast.Ref:
-		return evalRefRuleResultRecRef(ctx, v, ref, path, iter)
+		return evalRefRuleResultRecRef(t, v, ref, path, iter)
 	}
 
 	return nil
 }
 
-func evalRefRuleResultRecArray(ctx *Context, arr ast.Array, ref, path ast.Ref, iter func(*Context, ast.Value) error) error {
+func evalRefRuleResultRecArray(t *Topdown, arr ast.Array, ref, path ast.Ref, iter func(*Topdown, ast.Value) error) error {
 	head, tail := ref[0], ref[1:]
 	switch n := head.Value.(type) {
 	case ast.Number:
@@ -1702,23 +1704,23 @@ func evalRefRuleResultRecArray(ctx *Context, arr ast.Array, ref, path ast.Ref, i
 		}
 		el := arr[idx]
 		path = append(path, head)
-		return evalRefRuleResultRec(ctx, el.Value, tail, path, iter)
+		return evalRefRuleResultRec(t, el.Value, tail, path, iter)
 	case ast.Var:
 		for i := range arr {
 			idx := ast.IntNumberTerm(i)
-			undo := ctx.Bind(n, idx.Value, nil)
+			undo := t.Bind(n, idx.Value, nil)
 			path = append(path, idx)
-			if err := evalRefRuleResultRec(ctx, arr[i].Value, tail, path, iter); err != nil {
+			if err := evalRefRuleResultRec(t, arr[i].Value, tail, path, iter); err != nil {
 				return err
 			}
-			ctx.Unbind(undo)
+			t.Unbind(undo)
 			path = path[:len(path)-1]
 		}
 	}
 	return nil
 }
 
-func evalRefRuleResultRecObject(ctx *Context, obj ast.Object, ref, path ast.Ref, iter func(*Context, ast.Value) error) error {
+func evalRefRuleResultRecObject(t *Topdown, obj ast.Object, ref, path ast.Ref, iter func(*Topdown, ast.Value) error) error {
 	head, tail := ref[0], ref[1:]
 	switch k := head.Value.(type) {
 	case ast.String:
@@ -1727,7 +1729,7 @@ func evalRefRuleResultRecObject(ctx *Context, obj ast.Object, ref, path ast.Ref,
 			x := i[0].Value
 			if r, ok := i[0].Value.(ast.Ref); ok {
 				var err error
-				if x, err = lookupValue(ctx, r); err != nil {
+				if x, err = lookupValue(t, r); err != nil {
 					if storage.IsNotFound(err) {
 						return nil
 					}
@@ -1743,31 +1745,31 @@ func evalRefRuleResultRecObject(ctx *Context, obj ast.Object, ref, path ast.Ref,
 			return nil
 		}
 		path = append(path, head)
-		return evalRefRuleResultRec(ctx, obj[match][1].Value, tail, path, iter)
+		return evalRefRuleResultRec(t, obj[match][1].Value, tail, path, iter)
 	case ast.Var:
 		for _, i := range obj {
-			undo := ctx.Bind(k, i[0].Value, nil)
+			undo := t.Bind(k, i[0].Value, nil)
 			path = append(path, i[0])
-			if err := evalRefRuleResultRec(ctx, i[1].Value, tail, path, iter); err != nil {
+			if err := evalRefRuleResultRec(t, i[1].Value, tail, path, iter); err != nil {
 				return err
 			}
-			ctx.Unbind(undo)
+			t.Unbind(undo)
 			path = path[:len(path)-1]
 		}
 	}
 	return nil
 }
 
-func evalRefRuleResultRecRef(ctx *Context, v, ref, path ast.Ref, iter func(*Context, ast.Value) error) error {
+func evalRefRuleResultRecRef(t *Topdown, v, ref, path ast.Ref, iter func(*Topdown, ast.Value) error) error {
 
 	b := append(v, ref...)
 
-	return evalRefRec(ctx, b, func(ctx *Context) error {
-		return iter(ctx, PlugValue(b, ctx.Binding))
+	return evalRefRec(t, b, func(t *Topdown) error {
+		return iter(t, PlugValue(b, t.Binding))
 	})
 }
 
-func evalRefRuleResultRecSet(ctx *Context, set *ast.Set, ref, suffix ast.Ref, iter func(*Context, ast.Value) error) error {
+func evalRefRuleResultRecSet(t *Topdown, set *ast.Set, ref, suffix ast.Ref, iter func(*Topdown, ast.Value) error) error {
 	head, tail := ref[0], ref[1:]
 	if len(tail) > 0 {
 		return nil
@@ -1775,39 +1777,39 @@ func evalRefRuleResultRecSet(ctx *Context, set *ast.Set, ref, suffix ast.Ref, it
 	switch k := head.Value.(type) {
 	case ast.Var:
 		for _, e := range *set {
-			undo := ctx.Bind(k, e.Value, nil)
-			err := iter(ctx, ast.Boolean(true))
+			undo := t.Bind(k, e.Value, nil)
+			err := iter(t, ast.Boolean(true))
 			if err != nil {
 				return err
 			}
-			ctx.Unbind(undo)
+			t.Unbind(undo)
 		}
 		return nil
 	default:
 		// Set lookup requires that nested references be resolved to their
 		// values. In some cases this will be expensive, so it may have to be
 		// revisited.
-		resolved, err := ResolveRefs(set, ctx)
+		resolved, err := ResolveRefs(set, t)
 		if err != nil {
 			return err
 		}
 
 		rset := resolved.(*ast.Set)
-		rval, err := ResolveRefs(k, ctx)
+		rval, err := ResolveRefs(k, t)
 		if err != nil {
 			return err
 		}
 
 		if rset.Contains(ast.NewTerm(rval)) {
-			return iter(ctx, ast.Boolean(true))
+			return iter(t, ast.Boolean(true))
 		}
 		return nil
 	}
 }
 
-func evalTerms(ctx *Context, iter Iterator) error {
+func evalTerms(t *Topdown, iter Iterator) error {
 
-	expr := ctx.Current()
+	expr := t.Current()
 
 	// Attempt to evaluate the terms using indexing. Indexing can be used
 	// if this is an equality expression where one side is a non-ground,
@@ -1819,28 +1821,28 @@ func evalTerms(ctx *Context, iter Iterator) error {
 		// The terms must be plugged otherwise the index may yield bindings
 		// that would result in false positives.
 		ts := expr.Terms.([]*ast.Term)
-		t1 := PlugTerm(ts[1], ctx.Binding)
-		t2 := PlugTerm(ts[2], ctx.Binding)
+		t1 := PlugTerm(ts[1], t.Binding)
+		t2 := PlugTerm(ts[2], t.Binding)
 		r1, _ := t1.Value.(ast.Ref)
 		r2, _ := t2.Value.(ast.Ref)
 
 		if indexingAllowed(r1, t2) {
-			ok, err := indexBuildLazy(ctx, r1)
+			ok, err := indexBuildLazy(t, r1)
 			if err != nil {
 				return errors.Wrapf(err, "index build failed on %v", r1)
 			}
 			if ok {
-				return evalTermsIndexed(ctx, iter, r1, t2)
+				return evalTermsIndexed(t, iter, r1, t2)
 			}
 		}
 
 		if indexingAllowed(r2, t1) {
-			ok, err := indexBuildLazy(ctx, r2)
+			ok, err := indexBuildLazy(t, r2)
 			if err != nil {
 				return errors.Wrapf(err, "index build failed on %v", r2)
 			}
 			if ok {
-				return evalTermsIndexed(ctx, iter, r2, t1)
+				return evalTermsIndexed(t, iter, r2, t1)
 			}
 		}
 	}
@@ -1855,197 +1857,197 @@ func evalTerms(ctx *Context, iter Iterator) error {
 		panic(fmt.Sprintf("illegal argument: %v", t))
 	}
 
-	return evalTermsRec(ctx, iter, ts)
+	return evalTermsRec(t, iter, ts)
 }
 
-func evalTermsComprehension(ctx *Context, comp ast.Value, iter Iterator) error {
+func evalTermsComprehension(t *Topdown, comp ast.Value, iter Iterator) error {
 	switch comp := comp.(type) {
 	case *ast.ArrayComprehension:
 		r := ast.Array{}
-		c := ctx.Child(comp.Body, ctx.Locals)
-		err := Eval(c, func(c *Context) error {
+		c := t.Child(comp.Body, t.Locals)
+		err := Eval(c, func(c *Topdown) error {
 			r = append(r, PlugTerm(comp.Term, c.Binding))
 			return nil
 		})
 		if err != nil {
 			return err
 		}
-		return Continue(ctx, comp, r, iter)
+		return Continue(t, comp, r, iter)
 	default:
-		panic(fmt.Sprintf("illegal argument: %v %v", ctx, comp))
+		panic(fmt.Sprintf("illegal argument: %v %v", t, comp))
 	}
 }
 
-func evalTermsIndexed(ctx *Context, iter Iterator, indexed ast.Ref, nonIndexed *ast.Term) error {
+func evalTermsIndexed(t *Topdown, iter Iterator, indexed ast.Ref, nonIndexed *ast.Term) error {
 
-	iterateIndex := func(ctx *Context) error {
+	iterateIndex := func(t *Topdown) error {
 
 		// Evaluate the non-indexed term.
-		value, err := ValueToInterface(PlugValue(nonIndexed.Value, ctx.Binding), ctx)
+		value, err := ValueToInterface(PlugValue(nonIndexed.Value, t.Binding), t)
 		if err != nil {
 			return err
 		}
 
 		// Iterate the bindings for the indexed term that when applied to the reference
 		// would locate the non-indexed value obtained above.
-		return ctx.Store.Index(ctx.txn, indexed, value, func(bindings *ast.ValueMap) error {
+		return t.Store.Index(t.txn, indexed, value, func(bindings *ast.ValueMap) error {
 			var prev *Undo
 
 			// We will skip these bindings if the non-indexed term contains a
 			// different binding for the same variable. This can arise if output
 			// variables in references on either side intersect (e.g., a[i] = g[i][j]).
 			skip := bindings.Iter(func(k, v ast.Value) bool {
-				if o := ctx.Binding(k); o != nil && !o.Equal(v) {
+				if o := t.Binding(k); o != nil && !o.Equal(v) {
 					return true
 				}
-				prev = ctx.Bind(k, v, prev)
+				prev = t.Bind(k, v, prev)
 				return false
 			})
 
 			var err error
 
 			if !skip {
-				err = iter(ctx)
+				err = iter(t)
 			}
 
-			ctx.Unbind(prev)
+			t.Unbind(prev)
 			return err
 		})
 
 	}
 
-	return evalTermsRec(ctx, iterateIndex, []*ast.Term{nonIndexed})
+	return evalTermsRec(t, iterateIndex, []*ast.Term{nonIndexed})
 }
 
-func evalTermsRec(ctx *Context, iter Iterator, ts []*ast.Term) error {
+func evalTermsRec(t *Topdown, iter Iterator, ts []*ast.Term) error {
 
 	if len(ts) == 0 {
-		return iter(ctx)
+		return iter(t)
 	}
 
 	head := ts[0]
 	tail := ts[1:]
 
-	rec := func(ctx *Context) error {
-		return evalTermsRec(ctx, iter, tail)
+	rec := func(t *Topdown) error {
+		return evalTermsRec(t, iter, tail)
 	}
 
 	switch head := head.Value.(type) {
 	case ast.Ref:
-		return evalRef(ctx, head, ast.Ref{}, rec)
+		return evalRef(t, head, ast.Ref{}, rec)
 	case ast.Array:
-		return evalTermsRecArray(ctx, head, 0, rec)
+		return evalTermsRecArray(t, head, 0, rec)
 	case ast.Object:
-		return evalTermsRecObject(ctx, head, 0, rec)
+		return evalTermsRecObject(t, head, 0, rec)
 	case *ast.Set:
-		return evalTermsRecSet(ctx, head, 0, rec)
+		return evalTermsRecSet(t, head, 0, rec)
 	case *ast.ArrayComprehension:
-		return evalTermsComprehension(ctx, head, rec)
+		return evalTermsComprehension(t, head, rec)
 	default:
-		return evalTermsRec(ctx, iter, tail)
+		return evalTermsRec(t, iter, tail)
 	}
 }
 
-func evalTermsRecArray(ctx *Context, arr ast.Array, idx int, iter Iterator) error {
+func evalTermsRecArray(t *Topdown, arr ast.Array, idx int, iter Iterator) error {
 	if idx >= len(arr) {
-		return iter(ctx)
+		return iter(t)
 	}
 
-	rec := func(ctx *Context) error {
-		return evalTermsRecArray(ctx, arr, idx+1, iter)
+	rec := func(t *Topdown) error {
+		return evalTermsRecArray(t, arr, idx+1, iter)
 	}
 
 	switch v := arr[idx].Value.(type) {
 	case ast.Ref:
-		return evalRef(ctx, v, ast.Ref{}, rec)
+		return evalRef(t, v, ast.Ref{}, rec)
 	case ast.Array:
-		return evalTermsRecArray(ctx, v, 0, rec)
+		return evalTermsRecArray(t, v, 0, rec)
 	case ast.Object:
-		return evalTermsRecObject(ctx, v, 0, rec)
+		return evalTermsRecObject(t, v, 0, rec)
 	case *ast.Set:
-		return evalTermsRecSet(ctx, v, 0, rec)
+		return evalTermsRecSet(t, v, 0, rec)
 	case *ast.ArrayComprehension:
-		return evalTermsComprehension(ctx, v, rec)
+		return evalTermsComprehension(t, v, rec)
 	default:
-		return evalTermsRecArray(ctx, arr, idx+1, iter)
+		return evalTermsRecArray(t, arr, idx+1, iter)
 	}
 }
 
-func evalTermsRecObject(ctx *Context, obj ast.Object, idx int, iter Iterator) error {
+func evalTermsRecObject(t *Topdown, obj ast.Object, idx int, iter Iterator) error {
 	if idx >= len(obj) {
-		return iter(ctx)
+		return iter(t)
 	}
 
-	rec := func(ctx *Context) error {
-		return evalTermsRecObject(ctx, obj, idx+1, iter)
+	rec := func(t *Topdown) error {
+		return evalTermsRecObject(t, obj, idx+1, iter)
 	}
 
 	switch k := obj[idx][0].Value.(type) {
 	case ast.Ref:
-		return evalRef(ctx, k, ast.Ref{}, func(ctx *Context) error {
+		return evalRef(t, k, ast.Ref{}, func(t *Topdown) error {
 			switch v := obj[idx][1].Value.(type) {
 			case ast.Ref:
-				return evalRef(ctx, v, ast.Ref{}, rec)
+				return evalRef(t, v, ast.Ref{}, rec)
 			case ast.Array:
-				return evalTermsRecArray(ctx, v, 0, rec)
+				return evalTermsRecArray(t, v, 0, rec)
 			case ast.Object:
-				return evalTermsRecObject(ctx, v, 0, rec)
+				return evalTermsRecObject(t, v, 0, rec)
 			case *ast.Set:
-				return evalTermsRecSet(ctx, v, 0, rec)
+				return evalTermsRecSet(t, v, 0, rec)
 			case *ast.ArrayComprehension:
-				return evalTermsComprehension(ctx, v, rec)
+				return evalTermsComprehension(t, v, rec)
 			default:
-				return evalTermsRecObject(ctx, obj, idx+1, iter)
+				return evalTermsRecObject(t, obj, idx+1, iter)
 			}
 		})
 	default:
 		switch v := obj[idx][1].Value.(type) {
 		case ast.Ref:
-			return evalRef(ctx, v, ast.Ref{}, rec)
+			return evalRef(t, v, ast.Ref{}, rec)
 		case ast.Array:
-			return evalTermsRecArray(ctx, v, 0, rec)
+			return evalTermsRecArray(t, v, 0, rec)
 		case ast.Object:
-			return evalTermsRecObject(ctx, v, 0, rec)
+			return evalTermsRecObject(t, v, 0, rec)
 		case *ast.Set:
-			return evalTermsRecSet(ctx, v, 0, rec)
+			return evalTermsRecSet(t, v, 0, rec)
 		case *ast.ArrayComprehension:
-			return evalTermsComprehension(ctx, v, rec)
+			return evalTermsComprehension(t, v, rec)
 		default:
-			return evalTermsRecObject(ctx, obj, idx+1, iter)
+			return evalTermsRecObject(t, obj, idx+1, iter)
 		}
 	}
 }
 
-func evalTermsRecSet(ctx *Context, set *ast.Set, idx int, iter Iterator) error {
+func evalTermsRecSet(t *Topdown, set *ast.Set, idx int, iter Iterator) error {
 	if idx >= len(*set) {
-		return iter(ctx)
+		return iter(t)
 	}
 
-	rec := func(ctx *Context) error {
-		return evalTermsRecSet(ctx, set, idx+1, iter)
+	rec := func(t *Topdown) error {
+		return evalTermsRecSet(t, set, idx+1, iter)
 	}
 
 	switch v := (*set)[idx].Value.(type) {
 	case ast.Ref:
-		return evalRef(ctx, v, ast.Ref{}, rec)
+		return evalRef(t, v, ast.Ref{}, rec)
 	case ast.Array:
-		return evalTermsRecArray(ctx, v, 0, rec)
+		return evalTermsRecArray(t, v, 0, rec)
 	case ast.Object:
-		return evalTermsRecObject(ctx, v, 0, rec)
+		return evalTermsRecObject(t, v, 0, rec)
 	case *ast.ArrayComprehension:
-		return evalTermsComprehension(ctx, v, rec)
+		return evalTermsComprehension(t, v, rec)
 	default:
-		return evalTermsRecSet(ctx, set, idx+1, iter)
+		return evalTermsRecSet(t, set, idx+1, iter)
 	}
 }
 
 // indexBuildLazy returns true if there is an index built for this term. If there is no index
 // currently built for the term, but the term is a candidate for indexing, ther index will be
 // built on the fly.
-func indexBuildLazy(ctx *Context, ref ast.Ref) (bool, error) {
+func indexBuildLazy(t *Topdown, ref ast.Ref) (bool, error) {
 
 	// Check if index was already built.
-	if ctx.Store.IndexExists(ref) {
+	if t.Store.IndexExists(ref) {
 		return true, nil
 	}
 
@@ -2056,7 +2058,7 @@ func indexBuildLazy(ctx *Context, ref ast.Ref) (bool, error) {
 
 	// Ignore refs against virtual docs.
 	tmp := ast.Ref{ref[0], ref[1]}
-	r := ctx.Compiler.GetRulesExact(tmp)
+	r := t.Compiler.GetRulesExact(tmp)
 	if r != nil {
 		return false, nil
 	}
@@ -2068,13 +2070,13 @@ func indexBuildLazy(ctx *Context, ref ast.Ref) (bool, error) {
 		}
 
 		tmp = append(tmp, p)
-		r := ctx.Compiler.GetRulesExact(tmp)
+		r := t.Compiler.GetRulesExact(tmp)
 		if r != nil {
 			return false, nil
 		}
 	}
 
-	if err := ctx.Store.BuildIndex(ctx.txn, ref); err != nil {
+	if err := t.Store.BuildIndex(t.txn, ref); err != nil {
 		switch err := err.(type) {
 		case *storage.Error:
 			if err.Code == storage.IndexingNotSupportedErr {
@@ -2109,8 +2111,8 @@ func indexingAllowed(ref ast.Ref, term *ast.Term) bool {
 	return true
 }
 
-func lookupValue(ctx *Context, ref ast.Ref) (ast.Value, error) {
-	r, err := ctx.Resolve(ref)
+func lookupValue(t *Topdown, ref ast.Ref) (ast.Value, error) {
+	r, err := t.Resolve(ref)
 	if err != nil {
 		return nil, err
 	}

--- a/topdown/topdown_test.go
+++ b/topdown/topdown_test.go
@@ -62,7 +62,7 @@ func TestEvalRef(t *testing.T) {
 	txn := storage.NewTransactionOrDie(store)
 	defer store.Close(txn)
 
-	ctx := NewContext(nil, compiler, store, txn)
+	top := New(nil, compiler, store, txn)
 
 	for _, tc := range tests {
 
@@ -70,9 +70,9 @@ func TestEvalRef(t *testing.T) {
 
 			switch e := tc.expected.(type) {
 			case nil:
-				var tmp *Context
-				err := evalRef(ctx, ast.MustParseRef(tc.ref), ast.Ref{}, func(ctx *Context) error {
-					tmp = ctx
+				var tmp *Topdown
+				err := evalRef(top, ast.MustParseRef(tc.ref), ast.Ref{}, func(t *Topdown) error {
+					tmp = t
 					return nil
 				})
 				if err != nil {
@@ -84,10 +84,10 @@ func TestEvalRef(t *testing.T) {
 				}
 			case string:
 				expected := loadExpectedBindings(e)
-				err := evalRef(ctx, ast.MustParseRef(tc.ref), ast.Ref{}, func(ctx *Context) error {
+				err := evalRef(top, ast.MustParseRef(tc.ref), ast.Ref{}, func(t *Topdown) error {
 					if len(expected) > 0 {
 						for j, exp := range expected {
-							if exp.Equal(ctx.Locals) {
+							if exp.Equal(t.Locals) {
 								tmp := expected[:j]
 								expected = append(tmp, expected[j+1:]...)
 								return nil
@@ -95,7 +95,7 @@ func TestEvalRef(t *testing.T) {
 						}
 					}
 					// If there was not a matching expected binding, treat this case as a failure.
-					return fmt.Errorf("unexpected bindings: %v", ctx.Locals)
+					return fmt.Errorf("unexpected bindings: %v", t.Locals)
 				})
 				if err != nil {
 					t.Errorf("Expected success but got error: %v", err)
@@ -158,14 +158,14 @@ func TestEvalTerms(t *testing.T) {
 
 		testutil.Subtest(t, tc.body, func(t *testing.T) {
 
-			ctx := NewContext(ast.MustParseBody(tc.body), compiler, store, txn)
+			top := New(ast.MustParseBody(tc.body), compiler, store, txn)
 
 			expected := loadExpectedBindings(tc.expected)
 
-			err := evalTerms(ctx, func(ctx *Context) error {
+			err := evalTerms(top, func(t *Topdown) error {
 				if len(expected) > 0 {
 					for j, exp := range expected {
-						if exp.Equal(ctx.Locals) {
+						if exp.Equal(t.Locals) {
 							tmp := expected[:j]
 							expected = append(tmp, expected[j+1:]...)
 							return nil
@@ -173,7 +173,7 @@ func TestEvalTerms(t *testing.T) {
 					}
 				}
 				// If there was not a matching expected binding, treat this case as a failure.
-				return fmt.Errorf("unexpected bindings: %v", ctx.Locals)
+				return fmt.Errorf("unexpected bindings: %v", t.Locals)
 			})
 
 			if err != nil {
@@ -202,28 +202,28 @@ func TestPlugValue(t *testing.T) {
 	hello := ast.String("hello")
 	world := ast.String("world")
 
-	ctx1 := NewContext(nil, nil, nil, nil)
-	ctx1.Bind(a, b, nil)
-	ctx1.Bind(b, cs, nil)
-	ctx1.Bind(c, ks, nil)
-	ctx1.Bind(k, hello, nil)
+	t1 := New(nil, nil, nil, nil)
+	t1.Bind(a, b, nil)
+	t1.Bind(b, cs, nil)
+	t1.Bind(c, ks, nil)
+	t1.Bind(k, hello, nil)
 
-	ctx2 := NewContext(nil, nil, nil, nil)
-	ctx2.Bind(a, b, nil)
-	ctx2.Bind(b, cs, nil)
-	ctx2.Bind(c, vs, nil)
-	ctx2.Bind(v, world, nil)
+	t2 := New(nil, nil, nil, nil)
+	t2.Bind(a, b, nil)
+	t2.Bind(b, cs, nil)
+	t2.Bind(c, vs, nil)
+	t2.Bind(v, world, nil)
 
 	expected := ast.MustParseTerm(`[{"hello": "world"}]`).Value
 
-	r1 := PlugValue(a, ctx1.Binding)
+	r1 := PlugValue(a, t1.Binding)
 
 	if !expected.Equal(r1) {
 		t.Errorf("Expected %v but got %v", expected, r1)
 		return
 	}
 
-	r2 := PlugValue(a, ctx2.Binding)
+	r2 := PlugValue(a, t2.Binding)
 
 	if !expected.Equal(r2) {
 		t.Errorf("Expected %v but got %v", expected, r2)
@@ -231,13 +231,13 @@ func TestPlugValue(t *testing.T) {
 
 	n := ast.MustParseTerm("a.b[x.y[i]]").Value
 
-	ctx3 := NewContext(nil, nil, nil, nil)
-	ctx3.Bind(ast.Var("i"), ast.IntNumberTerm(1).Value, nil)
-	ctx3.Bind(ast.MustParseTerm("x.y[i]").Value, ast.IntNumberTerm(1).Value, nil)
+	t3 := New(nil, nil, nil, nil)
+	t3.Bind(ast.Var("i"), ast.IntNumberTerm(1).Value, nil)
+	t3.Bind(ast.MustParseTerm("x.y[i]").Value, ast.IntNumberTerm(1).Value, nil)
 
 	expected = ast.MustParseTerm("a.b[1]").Value
 
-	r3 := PlugValue(n, ctx3.Binding)
+	r3 := PlugValue(n, t3.Binding)
 
 	if !expected.Equal(r3) {
 		t.Errorf("Expected %v but got: %v", expected, r3)
@@ -1345,9 +1345,9 @@ func TestTopDownUnsupportedBuiltin(t *testing.T) {
 	compiler := ast.NewCompiler()
 	store := storage.New(storage.InMemoryConfig())
 	txn := storage.NewTransactionOrDie(store)
-	ctx := NewContext(body, compiler, store, txn)
+	top := New(body, compiler, store, txn)
 
-	err := Eval(ctx, func(*Context) error {
+	err := Eval(top, func(*Topdown) error {
 		return nil
 	})
 

--- a/topdown/trace.go
+++ b/topdown/trace.go
@@ -103,7 +103,7 @@ func (evt *Event) equalNodes(other *Event) bool {
 // Tracer defines the interface for tracing in the top-down evaluation engine.
 type Tracer interface {
 	Enabled() bool
-	Trace(ctx *Context, evt *Event)
+	Trace(t *Topdown, evt *Event)
 }
 
 // BufferTracer implements the Tracer interface by simply buffering all events
@@ -121,7 +121,7 @@ func (b *BufferTracer) Enabled() bool {
 }
 
 // Trace adds the event to the buffer.
-func (b *BufferTracer) Trace(ctx *Context, evt *Event) {
+func (b *BufferTracer) Trace(t *Topdown, evt *Event) {
 	*b = append(*b, evt)
 }
 

--- a/topdown/trace_test.go
+++ b/topdown/trace_test.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"testing"
 
+	"context"
+
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/storage"
 )
@@ -56,12 +58,14 @@ func TestPrettyTrace(t *testing.T) {
 	q[x] :- x = data.a[_]
 	`
 
+	ctx := context.Background()
 	compiler := compileModules([]string{module})
 	data := loadSmallTestData()
 	store := storage.New(storage.InMemoryWithJSONConfig(data))
-	txn := storage.NewTransactionOrDie(store)
+	txn := storage.NewTransactionOrDie(ctx, store)
+	defer store.Close(ctx, txn)
 
-	params := NewQueryParams(compiler, store, txn, nil, ast.MustParseRef("data.test.p"))
+	params := NewQueryParams(ctx, compiler, store, txn, nil, ast.MustParseRef("data.test.p"))
 	tracer := NewBufferTracer()
 	params.Tracer = tracer
 


### PR DESCRIPTION
These changes are fairly self-explanatory. The storage interfaces have been changed to include the `context.Context` parameter and the rest of OPA has been updated to propagate `context.Context` values accordingly. These changes only include the addition of the param; no deadlines or cancellation support has been added.