### PR TITLE
Fix docker authorization example

### DIFF
--- a/site/examples/docker-authorization/index.md
+++ b/site/examples/docker-authorization/index.md
@@ -301,7 +301,7 @@ valid_user_role :-
 # only one instance evaluates successfully in a given query. If multiple
 # instances evaluated successfully, it indicates a conflict.
 valid_user_role :-
-    user_id = req.Headers["Authz-User"],
+    user_id = request.Headers["Authz-User"],
     user = users[user_id],
     request.Method = "GET",
     user.readOnly = true


### PR DESCRIPTION
The search-replace as part of the request changes did not catch "req.Headers"
in valid_user_role.