### PR TITLE
Fix body to rule conversion bug

### DIFF
--- a/ast/parser_ext.go
+++ b/ast/parser_ext.go
@@ -131,9 +131,19 @@ func ParseRuleFromBody(body Body) *Rule {
 	}
 
 	terms := expr.Terms.([]*Term)
-	name, ok := terms[1].Value.(Var)
 
-	if !ok {
+	var name Var
+
+	switch v := terms[1].Value.(type) {
+	case Var:
+		name = v
+	case Ref:
+		if v.Equal(RequestRootRef) || v.Equal(DefaultRootRef) {
+			name = Var(v.String())
+		} else {
+			return nil
+		}
+	default:
 		return nil
 	}
 

--- a/ast/parser_test.go
+++ b/ast/parser_test.go
@@ -516,6 +516,21 @@ func TestRuleFromBody(t *testing.T) {
 		},
 	})
 
+	mockModule := `
+	package ex
+
+	request = {"foo": 1}
+	data = {"bar": 2}
+	`
+
+	assertParseModule(t, "rule name: request/data", mockModule, &Module{
+		Package: MustParsePackage("package ex"),
+		Rules: []*Rule{
+			MustParseRule(`request = {"foo": 1} :- true`),
+			MustParseRule(`data = {"bar": 2} :- true`),
+		},
+	})
+
 	multipleExprs := `
     package a.b.c
 
@@ -534,9 +549,16 @@ func TestRuleFromBody(t *testing.T) {
     "pi" = 3
     `
 
+	refName := `
+	package a.b.c
+
+	request.x = true
+	`
+
 	assertParseModuleError(t, "multiple expressions", multipleExprs)
 	assertParseModuleError(t, "non-equality", nonEquality)
 	assertParseModuleError(t, "non-var name", nonVarName)
+	assertParseModuleError(t, "ref name", refName)
 }
 
 func TestWildcards(t *testing.T) {


### PR DESCRIPTION
With the request document changes, the "request" var in "request = <term>"
is transformed into a ref. As a result, the body to rule conversion was not
working (and returning an error).

Fixes #202