### PR TITLE
Improve request parameter handling

### DIFF
--- a/ast/policy.go
+++ b/ast/policy.go
@@ -210,19 +210,19 @@ func IsValidImportPath(v Value) (err error) {
 	switch v := v.(type) {
 	case Var:
 		if !v.Equal(DefaultRootDocument.Value) && !v.Equal(RequestRootDocument.Value) {
-			return fmt.Errorf("path %v is not valid (must begin with known root)", v)
+			return fmt.Errorf("invalid path %v: path must begin with request or data", v)
 		}
 	case Ref:
 		if err := IsValidImportPath(v[0].Value); err != nil {
-			return fmt.Errorf("path %v is not valid (must begin with known root)", v)
+			return fmt.Errorf("invalid path %v: path must begin with request or data", v)
 		}
 		for _, e := range v[1:] {
 			if _, ok := e.Value.(String); !ok {
-				return fmt.Errorf("path elements must be string")
+				return fmt.Errorf("invalid path %v: path elements must be %vs", v, StringTypeName)
 			}
 		}
 	default:
-		return fmt.Errorf("path must be ref")
+		return fmt.Errorf("invalid path %v: path must be %v or %v", v, RefTypeName, VarTypeName)
 	}
 	return nil
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -183,12 +183,26 @@ func TestDataV1(t *testing.T) {
 		}},
 		{"get with request (root)", []tr{
 			tr{"PUT", "/policies/test", testMod1, 200, ""},
-			tr{"GET", `/data/testmod/gt1?request=:{"req1": 2}`, "", 200, `true`},
+			tr{"GET", `/data/testmod/gt1?request=:{"req1":2}`, "", 200, `true`},
+		}},
+		{"get with request (root-2)", []tr{
+			tr{"PUT", "/policies/test", testMod1, 200, ""},
+			tr{"GET", `/data/testmod/gt1?request={"req1":2}`, "", 200, `true`},
+		}},
+		{"get with request (root+non-ground)", []tr{
+			tr{"PUT", "/policies/test", testMod1, 200, ""},
+			tr{"GET", `/data/testmod/gt1?request={"req1":data.testmod.arr[i]}`, "", 200, `[[true, {"i": 1}], [true, {"i": 2}], [true, {"i": 3}]]`},
 		}},
 		{"get with request (bad format)", []tr{
-			tr{"GET", "/data/deadbeef?request=[1,2,3]", "", 400, `{
+			tr{"GET", `/data/deadbeef?request="foo`, "", 400, `{
 				"Code": 400,
-				"Message": "request format: <path>:<value> where <path> is either var or ref"
+				"Message": "request parameter format is [[<path>]:]<value> where <path> is either var or ref"
+			}`},
+		}},
+		{"get with request (path error)", []tr{
+			tr{"GET", `/data/deadbeef?request="foo:1`, "", 400, `{
+				"Code": 400,
+				"Message": "request parameter format is [[<path>]:]<value> where <path> is either var or ref"
 			}`},
 		}},
 		{"get undefined", []tr{

--- a/site/documentation/references/rest/index.md
+++ b/site/documentation/references/rest/index.md
@@ -1120,7 +1120,7 @@ Content-Type: application/json
 
 #### Query Parameters
 
-- **request** - Provide a request document. Format is `<path>:<value>` where `<path>` is the import path of the request document. The parameter may be specified multiple times but each instance should specify a unique `<path>`. The `<path>` may be empty (in which case, the entire request will be set to the `<value>`). The `<value>` may be a reference to a document in OPA. If `<value>` contains variables the response will contain a set of results instead of a single document.
+- **request** - Provide a request document. Format is `[[<path>]:]<value>` where `<path>` is the import path of the request document. The parameter may be specified multiple times but each instance should specify a unique `<path>`. The `<path>` may be empty (in which case, the entire request will be set to the `<value>`). The `<value>` may be a reference to a document in OPA. If `<value>` contains variables the response will contain a set of results instead of a single document.
 - **pretty** - If parameter is `true`, response will formatted for humans.
 - **explain** - Return query explanation instead of normal result. Values: **full**, **truth**. See [Explanations](#explanations) for how to interpret results.
 

--- a/topdown/request.go
+++ b/topdown/request.go
@@ -24,6 +24,10 @@ func MakeRequest(pairs [][2]*ast.Term) (ast.Value, error) {
 
 	for _, pair := range pairs {
 
+		if r, ok := pair[0].Value.(ast.Ref); ok && len(r) == 0 {
+			return nil, fmt.Errorf("conflicting request values: check request parameters")
+		}
+
 		if err := ast.IsValidImportPath(pair[0].Value); err != nil {
 			return nil, errors.Wrapf(err, "invalid request path")
 		}

--- a/topdown/request_test.go
+++ b/topdown/request_test.go
@@ -27,6 +27,9 @@ func TestMakeRequest(t *testing.T) {
 			[][2]string{{"foo.bar", "data.com.example.widgets[i]"}},
 			`{"foo": {"bar": data.com.example.widgets[i]}}`},
 		{"non-object", [][2]string{{"", "[1,2,3]"}}, "[1,2,3]"},
+		{"non-object conflict",
+			[][2]string{{"", "[1,2,3]"}, {"a.b", "true"}},
+			fmt.Errorf("conflicting request values: check request parameters")},
 		{"conflicting vars",
 			[][2]string{{`a.b`, `"c"`}, {`a.b.d`, `"d"`}},
 			fmt.Errorf("conflicting request value request.a.b.d: check request parameters")},
@@ -41,7 +44,7 @@ func TestMakeRequest(t *testing.T) {
 			fmt.Errorf("conflicting request value request.a: check request parameters")},
 		{"bad path",
 			[][2]string{{`a[1]`, `1`}},
-			fmt.Errorf("invalid request path: path elements must be string"),
+			fmt.Errorf("invalid request path: invalid path request.a[1]: path elements must be strings"),
 		},
 	}
 


### PR DESCRIPTION
Make the ":" in the request parameter value optional. Typical use case will
be for callers to supply the entire request value in one parameter.

Fixes #201