### PR TITLE
Catch unsafe vars with built-in operator names

### DIFF
--- a/ast/builtins.go
+++ b/ast/builtins.go
@@ -12,7 +12,6 @@ var Builtins []*Builtin
 func RegisterBuiltin(b *Builtin) {
 	Builtins = append(Builtins, b)
 	BuiltinMap[b.Name] = b
-	ReservedVars.Add(b.Name)
 }
 
 // DefaultBuiltins is the registry of built-in functions supported in OPA

--- a/ast/policy.go
+++ b/ast/policy.go
@@ -32,7 +32,7 @@ var DefaultRootRef = Ref{DefaultRootDocument}
 // All refs to query arguments are prefixed with this ref.
 var RequestRootRef = Ref{RequestRootDocument}
 
-// ReservedVars is the set of reserved variable names.
+// ReservedVars is the set of names that refer to implicitly ground vars.
 var ReservedVars = NewVarSet(DefaultRootDocument.Value.(Var), RequestRootDocument.Value.(Var))
 
 // Wildcard represents the wildcard variable as defined in the language.
@@ -687,10 +687,10 @@ func (expr *Expr) outputVarsBuiltins(b *Builtin, safe VarSet) VarSet {
 			continue
 		}
 		vis := NewVarVisitor().WithParams(VarVisitorParams{
-			SkipClosures:     true,
-			SkipObjectKeys:   true,
-			SkipRefHead:      true,
-			SkipBuiltinNames: true,
+			SkipClosures:         true,
+			SkipObjectKeys:       true,
+			SkipRefHead:          true,
+			SkipBuiltinOperators: true,
 		})
 		Walk(vis, t)
 		unsafe := vis.Vars().Diff(o).Diff(safe)

--- a/ast/unify.go
+++ b/ast/unify.go
@@ -156,9 +156,9 @@ func (u *unifier) unifyAll(a Var, b Value) {
 
 func (u *unifier) varVisitor() *VarVisitor {
 	return NewVarVisitor().WithParams(VarVisitorParams{
-		SkipRefHead:      true,
-		SkipObjectKeys:   true,
-		SkipClosures:     true,
-		SkipBuiltinNames: true,
+		SkipRefHead:          true,
+		SkipObjectKeys:       true,
+		SkipClosures:         true,
+		SkipBuiltinOperators: true,
 	})
 }

--- a/ast/visit.go
+++ b/ast/visit.go
@@ -156,10 +156,10 @@ type VarVisitor struct {
 
 // VarVisitorParams contains settings for a VarVisitor.
 type VarVisitorParams struct {
-	SkipRefHead      bool
-	SkipObjectKeys   bool
-	SkipClosures     bool
-	SkipBuiltinNames bool
+	SkipRefHead          bool
+	SkipObjectKeys       bool
+	SkipClosures         bool
+	SkipBuiltinOperators bool
 }
 
 // NewVarVisitor returns a new VarVisitor object.
@@ -204,7 +204,7 @@ func (vis *VarVisitor) Visit(v interface{}) Visitor {
 			return nil
 		}
 	}
-	if vis.params.SkipBuiltinNames {
+	if vis.params.SkipBuiltinOperators {
 		if v, ok := v.(*Expr); ok {
 			if ts, ok := v.Terms.([]*Term); ok {
 				for _, t := range ts[1:] {

--- a/site/documentation/references/language/index.md
+++ b/site/documentation/references/language/index.md
@@ -81,9 +81,11 @@ complex types.
 
 ## <a name="reserved"></a> Reserved Names
 
-In addition to built-in function names, the following words are reserved and cannot be used as variable names, rule names, or dot-access style reference arguments:
+The following words are reserved and cannot be used as variable names, rule
+names, or dot-access style reference arguments:
 
 ```
+as
 false
 import
 package


### PR DESCRIPTION
The built-in operator names should never have been added to the ReservedVars
set. These changes remove them from the ReservedVars set so they are not
considered global/safe when performing the safety checks.

Fixes #206