### PR TITLE
Improve release infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 coverage
 opa_*
 .Dockerfile_*
+_release
 
 # runtime artifacts
 policies

--- a/Dockerfile_release-builder.in
+++ b/Dockerfile_release-builder.in
@@ -1,0 +1,20 @@
+FROM golang:GOVERSION
+
+RUN apt-get update -y \
+    && apt-get install -y -q --no-install-recommends \
+        ruby \
+        ruby-dev \
+        nodejs \
+        locales \
+    && gem update --system \
+    && gem install jekyll \
+        autoprefixer-rails \
+        jekyll-assets \
+        jekyll-contentblocks \
+        jekyll-minifier \
+    && rm -fr /var/lib/apt/lists/* /var/cache/*
+
+RUN echo en_US.UTF-8 UTF-8 > /etc/locale.gen && locale-gen
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8

--- a/build/build-release.sh
+++ b/build/build-release.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# This script will build an OPA release given (1) the release version and
+# (2) the output directory to write artifacts to. This script assumes it is
+# running under Docker.
+
+set -ex
+
+VERSION=$1
+RELEASE_DIR=$2
+
+git clone https://github.com/open-policy-agent/opa.git /go/src/github.com/open-policy-agent/opa
+cd /go/src/github.com/open-policy-agent/opa
+git checkout v$VERSION
+
+build_binaries() {
+    make deps
+    GOOS=darwin GOARCH=amd64 make build
+    GOOS=linux GOARCH=amd64 make build
+    mv opa_*_* $RELEASE_DIR
+}
+
+build_site() {
+    pushd site
+    jekyll build . && rm _site/assets/.sprockets-manifest-*.json
+    tar czvf $RELEASE_DIR/site.tar.gz -C _site .
+    popd
+}
+
+main() {
+    build_binaries
+    build_site
+    make test
+}
+
+main

--- a/build/gen-release-patch.sh
+++ b/build/gen-release-patch.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+set -e
+
+git clone --quiet https://github.com/open-policy-agent/opa.git /src >/dev/null
+cd /src
+
+LAST_VERSION=$(git describe --abbrev=0 --tags)
+VERSION=$1
+
+update_makefile() {
+    sed -i='' -e "s/^VERSION[ \t]*:=[ \t]*.\+$/VERSION := $VERSION/" Makefile
+}
+
+update_changelog() {
+    cat >_CHANGELOG.md <<EOF
+$(awk '1;/## Unreleased/{exit}' CHANGELOG.md | sed '$d')
+
+## $VERSION
+
+$(./build/changelog.py $LAST_VERSION HEAD)
+$(sed '1,/## Unreleased/d' CHANGELOG.md)
+EOF
+
+    mv _CHANGELOG.md CHANGELOG.md
+}
+
+update_docs() {
+    find ./site/ -name "*.md" -exec sed -i='' s/$LAST_VERSION/v$VERSION/g {} \;
+}
+
+main() {
+    update_makefile
+    update_docs
+    update_changelog
+    git --no-pager diff --no-color
+}
+
+main

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -11,29 +11,38 @@ Versioning involves maintaining the following files:
 - **Makefile** - the Makefile contains a VERSION variable that defines the version of the project.
 - **site/*** - there are a few files in the documentation that contain hardcoded versions.
 
-The steps below explain how to update these files. In addition, the repository should be tagged with the semantic version identifying the release.
+The steps below explain how to update these files. In addition, the repository
+should be tagged with the semantic version identifying the release.
 
-Building involves obtaining a copy of the repository, checking out the release tag, and building the binaries.
+Building involves obtaining a copy of the repository, checking out the release
+tag, and building the binaries.
 
-Publishing involves creating a new *Release* on GitHub with the relevant CHANGELOG.md snippet and uploading the binaries from the build phase.
+Publishing involves creating a new *Release* on GitHub with the relevant
+CHANGELOG.md snippet and uploading the binaries from the build phase.
 
 ## Versioning
 
-1. Obtain copy of remote repository.
+1. Obtain a copy of repository.
 
 	```
 	git clone git@github.com:open-policy-agent/opa.git
 	```
 
-1. Edit CHANGELOG.md to update the Unreleased header (e.g., s/Unreleased/0.12.8/) and add any missing items to prepare for release.
-
-1. Edit Makefile to set VERSION variable to prepare for release (e.g., s/VERSION := “0.12.8-dev”/VERSION := "0.12.8”/).
-
-1. Update documentation that refers to the latest release by semantic version. For example:
+1. Execute the release-patch target to generate boilerplate patch. Give the semantic version of the release:
 
 	```
-	find site/ -name "*.md" -exec sed -i "" 's/0.12.7/0.12.8/g' {} \;
+	make release-patch VERSION=0.12.8 > ~/release.patch
 	```
+
+1. Apply the release patch to the working copy:
+
+	```
+	patch -p1 < ~/release.patch
+	```
+
+	> Amend the changes as necessary, e.g., many of the Fixes and Miscellaneous
+	> changes may not be user facing (so remove them). Also, if there have been
+	> any significant API changes, call them out in their own sections.
 
 1. Commit the changes and push to remote repository.
 
@@ -68,17 +77,10 @@ Publishing involves creating a new *Release* on GitHub with the relevant CHANGEL
 	git clone git@github.com:open-policy-agent/opa.git
 	```
 
-1. Checkout release tag.
+1. Execute the release target. The results can be found under _release/VERSION:
 
 	```
-	git checkout v<semver>
-	```
-
-1. Build binaries for target platforms.
-
-	```
-	make build GOOS=linux GOARCH=amd64
-	make build GOOS=darwin GOARCH=amd64
+	make release VERSION=0.12.8
 	```
 
 ## Publishing
@@ -89,8 +91,11 @@ Publishing involves creating a new *Release* on GitHub with the relevant CHANGEL
 	- Copy the changelog content into the message.
 	- Upload the binaries.
 
-1. There may be documentation updates that should be released. See [site/README.md](../site/README.md) for steps to update the website.
+1. There may be documentation updates that should be released. See
+   [site/README.md](../site/README.md) for steps to update the website.
 
 ## Notes
 
-- The openpolicyagent/opa Docker image is automatically built and published to Docker Hub as part of the Travis-CI pipeline. There are no manual steps involved here.
+- The openpolicyagent/opa Docker image is automatically built and published to
+  Docker Hub as part of the Travis-CI pipeline. There are no manual steps
+  involved here.

--- a/site/README.md
+++ b/site/README.md
@@ -6,11 +6,8 @@ You also need to have [Jekyll](http://jekyllrb.com) installed to build the site.
 for you. Assuming you have Ruby installed, all you should need to do is run:
 
 ```
-gem install --user-install jekyll
-gem install --user-install autoprefixer-rails
-gem install --user-install jekyll-assets
-gem install --user-install jekyll-contentblocks
-gem install --user-install jekyll-minifier
+gem install --user-install jekyll \
+    autoprefixer-rails jekyll-assets jekyll-contentblocks jekyll-minifier
 ```
 
 Changing the documentation on the live site requires two separate merges:
@@ -40,28 +37,25 @@ Once you are happy with the changes, commit them and open a Pull Request against
 
 To update the live website, perform the following steps:
 
-1. Obtain a fresh copy of the repository
+1. Obtain a fresh copy of the repository and build the site.
 
     ```
-    git clone git@github.com:open-policy-agent/opa.git opa-site
-    ```
-
-    - Note: if you are preparing documentation for a specific release, checkout the release tag in this step as well.
-
-1. Build the site content and save the output:
-
-    ```
-    cd opa-site/site
+    git clone git@github.com:open-policy-agent/opa.git
+    cd opa/site
     jekyll build .
     tar czvf ~/site.tar.gz -C _site .
     ```
+
+    > If you are updating the website as part of a release, the site content
+    > will have been built by the `make release` command so this step can be
+    > skipped.
 
 1. Checkout the gh-pages branch and overlay the new site content:
 
     ```
     git checkout gh-pages
     tar zxvf ~/site.tar.gz
-    git commit -a -m "Updating site for release 0.12.8"
+    git commit -a
     ```
 
 1. Push the gh-pages branch back to GitHub:


### PR DESCRIPTION
- Add script to build release artifacts from inside a container. In the past,
release artifacts have been created from a clean checkout, but this should be
much more reliable.

- Add script to generate release patch from tip. In the past, the release
patch changes have been made manually.