### PR TITLE
Fix empty request parameter parsing

### DIFF
--- a/runtime/logging.go
+++ b/runtime/logging.go
@@ -91,7 +91,7 @@ func dropRequestParam(u *url.URL) string {
 func getRequestParam(u *url.URL) (r []string) {
 	for _, g := range u.Query()[server.ParamRequestV1] {
 		s, err := url.QueryUnescape(g)
-		if err == nil {
+		if len(s) > 0 && err == nil {
 			r = append(r, s)
 		}
 	}

--- a/runtime/logging_test.go
+++ b/runtime/logging_test.go
@@ -65,4 +65,24 @@ func TestGetRequestParam(t *testing.T) {
 	if !reflect.DeepEqual(result, expected) {
 		t.Errorf("Expected %v but got: %v", expected, result)
 	}
+
+	uri, err = url.ParseRequestURI(fmt.Sprintf(`http://localhost:8181/v1/data/foo?request`))
+	if err != nil {
+		panic(err)
+	}
+
+	result = getRequestParam(uri)
+	if len(result) != 0 {
+		t.Errorf("Expected empty result but got: %v", result)
+	}
+
+	uri, err = url.ParseRequestURI(fmt.Sprintf(`http://localhost:8181/v1/data/foo?request=`))
+	if err != nil {
+		panic(err)
+	}
+
+	result = getRequestParam(uri)
+	if len(result) != 0 {
+		t.Errorf("Expected empty result but got: %v", result)
+	}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -1071,6 +1071,10 @@ func parseRequest(s []string) (ast.Value, bool, error) {
 		var v *ast.Term
 		var err error
 
+		if len(s[i]) == 0 {
+			return nil, false, errRequestPathFormat
+		}
+
 		if s[i][0] == ':' {
 			k = ast.NewTerm(ast.EmptyRef())
 			v, err = ast.ParseTerm(s[i][1:])

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -194,6 +194,14 @@ func TestDataV1(t *testing.T) {
 			tr{"GET", `/data/testmod/gt1?request={"req1":data.testmod.arr[i]}`, "", 200, `[[true, {"i": 1}], [true, {"i": 2}], [true, {"i": 3}]]`},
 		}},
 		{"get with request (bad format)", []tr{
+			tr{"GET", "/data/deadbeef?request", "", 400, `{
+				"Code": 400,
+				"Message": "request parameter format is [[<path>]:]<value> where <path> is either var or ref"
+			}`},
+			tr{"GET", "/data/deadbeef?request=", "", 400, `{
+				"Code": 400,
+				"Message": "request parameter format is [[<path>]:]<value> where <path> is either var or ref"
+			}`},
 			tr{"GET", `/data/deadbeef?request="foo`, "", 400, `{
 				"Code": 400,
 				"Message": "request parameter format is [[<path>]:]<value> where <path> is either var or ref"


### PR DESCRIPTION
Return an error if the request parameter is empty. This indicates an error in
the caller.

Fixes #212