### PR TITLE
Improve module parsing errors

### DIFF
--- a/ast/parser.go
+++ b/ast/parser.go
@@ -25,60 +25,68 @@ func currentLocation(c *current) *Location {
 	return NewLocation(c.text, "", c.pos.line, c.pos.col)
 }
 
+func ifaceSliceToByteSlice(i interface{}) []byte {
+	var buf bytes.Buffer
+	for _, x := range i.([]interface{}) {
+		buf.Write(x.([]byte))
+	}
+	return buf.Bytes()
+}
+
 var g = &grammar{
 	rules: []*rule{
 		{
 			name: "Program",
-			pos:  position{line: 16, col: 1, offset: 367},
+			pos:  position{line: 24, col: 1, offset: 547},
 			expr: &actionExpr{
-				pos: position{line: 16, col: 12, offset: 378},
+				pos: position{line: 24, col: 12, offset: 558},
 				run: (*parser).callonProgram1,
 				expr: &seqExpr{
-					pos: position{line: 16, col: 12, offset: 378},
+					pos: position{line: 24, col: 12, offset: 558},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 16, col: 12, offset: 378},
+							pos:  position{line: 24, col: 12, offset: 558},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 16, col: 14, offset: 380},
+							pos:   position{line: 24, col: 14, offset: 560},
 							label: "vals",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 16, col: 19, offset: 385},
+								pos: position{line: 24, col: 19, offset: 565},
 								expr: &seqExpr{
-									pos: position{line: 16, col: 20, offset: 386},
+									pos: position{line: 24, col: 20, offset: 566},
 									exprs: []interface{}{
 										&labeledExpr{
-											pos:   position{line: 16, col: 20, offset: 386},
+											pos:   position{line: 24, col: 20, offset: 566},
 											label: "head",
 											expr: &ruleRefExpr{
-												pos:  position{line: 16, col: 25, offset: 391},
+												pos:  position{line: 24, col: 25, offset: 571},
 												name: "Stmt",
 											},
 										},
 										&labeledExpr{
-											pos:   position{line: 16, col: 30, offset: 396},
+											pos:   position{line: 24, col: 30, offset: 576},
 											label: "tail",
 											expr: &zeroOrMoreExpr{
-												pos: position{line: 16, col: 35, offset: 401},
+												pos: position{line: 24, col: 35, offset: 581},
 												expr: &seqExpr{
-													pos: position{line: 16, col: 36, offset: 402},
+													pos: position{line: 24, col: 36, offset: 582},
 													exprs: []interface{}{
 														&choiceExpr{
-															pos: position{line: 16, col: 37, offset: 403},
+															pos: position{line: 24, col: 37, offset: 583},
 															alternatives: []interface{}{
 																&ruleRefExpr{
-																	pos:  position{line: 16, col: 37, offset: 403},
+																	pos:  position{line: 24, col: 37, offset: 583},
 																	name: "ws",
 																},
 																&ruleRefExpr{
-																	pos:  position{line: 16, col: 42, offset: 408},
+																	pos:  position{line: 24, col: 42, offset: 588},
 																	name: "ParseError",
 																},
 															},
 														},
 														&ruleRefExpr{
-															pos:  position{line: 16, col: 54, offset: 420},
+															pos:  position{line: 24, col: 54, offset: 600},
 															name: "Stmt",
 														},
 													},
@@ -90,11 +98,11 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 16, col: 63, offset: 429},
+							pos:  position{line: 24, col: 63, offset: 609},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 16, col: 65, offset: 431},
+							pos:  position{line: 24, col: 65, offset: 611},
 							name: "EOF",
 						},
 					},
@@ -103,38 +111,38 @@ var g = &grammar{
 		},
 		{
 			name: "Stmt",
-			pos:  position{line: 34, col: 1, offset: 768},
+			pos:  position{line: 42, col: 1, offset: 948},
 			expr: &actionExpr{
-				pos: position{line: 34, col: 9, offset: 776},
+				pos: position{line: 42, col: 9, offset: 956},
 				run: (*parser).callonStmt1,
 				expr: &labeledExpr{
-					pos:   position{line: 34, col: 9, offset: 776},
+					pos:   position{line: 42, col: 9, offset: 956},
 					label: "val",
 					expr: &choiceExpr{
-						pos: position{line: 34, col: 14, offset: 781},
+						pos: position{line: 42, col: 14, offset: 961},
 						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 34, col: 14, offset: 781},
+								pos:  position{line: 42, col: 14, offset: 961},
 								name: "Package",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 34, col: 24, offset: 791},
+								pos:  position{line: 42, col: 24, offset: 971},
 								name: "Import",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 34, col: 33, offset: 800},
+								pos:  position{line: 42, col: 33, offset: 980},
 								name: "Rule",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 34, col: 40, offset: 807},
+								pos:  position{line: 42, col: 40, offset: 987},
 								name: "Body",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 34, col: 47, offset: 814},
+								pos:  position{line: 42, col: 47, offset: 994},
 								name: "Comment",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 34, col: 57, offset: 824},
+								pos:  position{line: 42, col: 57, offset: 1004},
 								name: "ParseError",
 							},
 						},
@@ -144,45 +152,45 @@ var g = &grammar{
 		},
 		{
 			name: "ParseError",
-			pos:  position{line: 43, col: 1, offset: 1188},
+			pos:  position{line: 51, col: 1, offset: 1368},
 			expr: &actionExpr{
-				pos: position{line: 43, col: 15, offset: 1202},
+				pos: position{line: 51, col: 15, offset: 1382},
 				run: (*parser).callonParseError1,
 				expr: &anyMatcher{
-					line: 43, col: 15, offset: 1202,
+					line: 51, col: 15, offset: 1382,
 				},
 			},
 		},
 		{
 			name: "Package",
-			pos:  position{line: 47, col: 1, offset: 1275},
+			pos:  position{line: 55, col: 1, offset: 1455},
 			expr: &actionExpr{
-				pos: position{line: 47, col: 12, offset: 1286},
+				pos: position{line: 55, col: 12, offset: 1466},
 				run: (*parser).callonPackage1,
 				expr: &seqExpr{
-					pos: position{line: 47, col: 12, offset: 1286},
+					pos: position{line: 55, col: 12, offset: 1466},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 47, col: 12, offset: 1286},
+							pos:        position{line: 55, col: 12, offset: 1466},
 							val:        "package",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 47, col: 22, offset: 1296},
+							pos:  position{line: 55, col: 22, offset: 1476},
 							name: "ws",
 						},
 						&labeledExpr{
-							pos:   position{line: 47, col: 25, offset: 1299},
+							pos:   position{line: 55, col: 25, offset: 1479},
 							label: "val",
 							expr: &choiceExpr{
-								pos: position{line: 47, col: 30, offset: 1304},
+								pos: position{line: 55, col: 30, offset: 1484},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 47, col: 30, offset: 1304},
+										pos:  position{line: 55, col: 30, offset: 1484},
 										name: "Ref",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 47, col: 36, offset: 1310},
+										pos:  position{line: 55, col: 36, offset: 1490},
 										name: "Var",
 									},
 								},
@@ -194,62 +202,62 @@ var g = &grammar{
 		},
 		{
 			name: "Import",
-			pos:  position{line: 83, col: 1, offset: 2691},
+			pos:  position{line: 91, col: 1, offset: 2871},
 			expr: &actionExpr{
-				pos: position{line: 83, col: 11, offset: 2701},
+				pos: position{line: 91, col: 11, offset: 2881},
 				run: (*parser).callonImport1,
 				expr: &seqExpr{
-					pos: position{line: 83, col: 11, offset: 2701},
+					pos: position{line: 91, col: 11, offset: 2881},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 83, col: 11, offset: 2701},
+							pos:        position{line: 91, col: 11, offset: 2881},
 							val:        "import",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 83, col: 20, offset: 2710},
+							pos:  position{line: 91, col: 20, offset: 2890},
 							name: "ws",
 						},
 						&labeledExpr{
-							pos:   position{line: 83, col: 23, offset: 2713},
+							pos:   position{line: 91, col: 23, offset: 2893},
 							label: "path",
 							expr: &choiceExpr{
-								pos: position{line: 83, col: 29, offset: 2719},
+								pos: position{line: 91, col: 29, offset: 2899},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 83, col: 29, offset: 2719},
+										pos:  position{line: 91, col: 29, offset: 2899},
 										name: "Ref",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 83, col: 35, offset: 2725},
+										pos:  position{line: 91, col: 35, offset: 2905},
 										name: "Var",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 83, col: 40, offset: 2730},
+							pos:   position{line: 91, col: 40, offset: 2910},
 							label: "alias",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 83, col: 46, offset: 2736},
+								pos: position{line: 91, col: 46, offset: 2916},
 								expr: &seqExpr{
-									pos: position{line: 83, col: 47, offset: 2737},
+									pos: position{line: 91, col: 47, offset: 2917},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 83, col: 47, offset: 2737},
+											pos:  position{line: 91, col: 47, offset: 2917},
 											name: "ws",
 										},
 										&litMatcher{
-											pos:        position{line: 83, col: 50, offset: 2740},
+											pos:        position{line: 91, col: 50, offset: 2920},
 											val:        "as",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 83, col: 55, offset: 2745},
+											pos:  position{line: 91, col: 55, offset: 2925},
 											name: "ws",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 83, col: 58, offset: 2748},
+											pos:  position{line: 91, col: 58, offset: 2928},
 											name: "Var",
 										},
 									},
@@ -262,57 +270,57 @@ var g = &grammar{
 		},
 		{
 			name: "Rule",
-			pos:  position{line: 99, col: 1, offset: 3198},
+			pos:  position{line: 107, col: 1, offset: 3378},
 			expr: &actionExpr{
-				pos: position{line: 99, col: 9, offset: 3206},
+				pos: position{line: 107, col: 9, offset: 3386},
 				run: (*parser).callonRule1,
 				expr: &seqExpr{
-					pos: position{line: 99, col: 9, offset: 3206},
+					pos: position{line: 107, col: 9, offset: 3386},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 99, col: 9, offset: 3206},
+							pos:   position{line: 107, col: 9, offset: 3386},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 99, col: 14, offset: 3211},
+								pos:  position{line: 107, col: 14, offset: 3391},
 								name: "Var",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 99, col: 18, offset: 3215},
+							pos:   position{line: 107, col: 18, offset: 3395},
 							label: "key",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 99, col: 22, offset: 3219},
+								pos: position{line: 107, col: 22, offset: 3399},
 								expr: &seqExpr{
-									pos: position{line: 99, col: 24, offset: 3221},
+									pos: position{line: 107, col: 24, offset: 3401},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 99, col: 24, offset: 3221},
+											pos:  position{line: 107, col: 24, offset: 3401},
 											name: "_",
 										},
 										&litMatcher{
-											pos:        position{line: 99, col: 26, offset: 3223},
+											pos:        position{line: 107, col: 26, offset: 3403},
 											val:        "[",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 99, col: 30, offset: 3227},
+											pos:  position{line: 107, col: 30, offset: 3407},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 99, col: 32, offset: 3229},
+											pos:  position{line: 107, col: 32, offset: 3409},
 											name: "Term",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 99, col: 37, offset: 3234},
+											pos:  position{line: 107, col: 37, offset: 3414},
 											name: "_",
 										},
 										&litMatcher{
-											pos:        position{line: 99, col: 39, offset: 3236},
+											pos:        position{line: 107, col: 39, offset: 3416},
 											val:        "]",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 99, col: 43, offset: 3240},
+											pos:  position{line: 107, col: 43, offset: 3420},
 											name: "_",
 										},
 									},
@@ -320,28 +328,28 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 99, col: 48, offset: 3245},
+							pos:   position{line: 107, col: 48, offset: 3425},
 							label: "value",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 99, col: 54, offset: 3251},
+								pos: position{line: 107, col: 54, offset: 3431},
 								expr: &seqExpr{
-									pos: position{line: 99, col: 56, offset: 3253},
+									pos: position{line: 107, col: 56, offset: 3433},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 99, col: 56, offset: 3253},
+											pos:  position{line: 107, col: 56, offset: 3433},
 											name: "_",
 										},
 										&litMatcher{
-											pos:        position{line: 99, col: 58, offset: 3255},
+											pos:        position{line: 107, col: 58, offset: 3435},
 											val:        "=",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 99, col: 62, offset: 3259},
+											pos:  position{line: 107, col: 62, offset: 3439},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 99, col: 64, offset: 3261},
+											pos:  position{line: 107, col: 64, offset: 3441},
 											name: "Term",
 										},
 									},
@@ -349,26 +357,26 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 99, col: 72, offset: 3269},
+							pos:   position{line: 107, col: 72, offset: 3449},
 							label: "body",
 							expr: &seqExpr{
-								pos: position{line: 99, col: 79, offset: 3276},
+								pos: position{line: 107, col: 79, offset: 3456},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 99, col: 79, offset: 3276},
+										pos:  position{line: 107, col: 79, offset: 3456},
 										name: "_",
 									},
 									&litMatcher{
-										pos:        position{line: 99, col: 81, offset: 3278},
+										pos:        position{line: 107, col: 81, offset: 3458},
 										val:        ":-",
 										ignoreCase: false,
 									},
 									&ruleRefExpr{
-										pos:  position{line: 99, col: 86, offset: 3283},
+										pos:  position{line: 107, col: 86, offset: 3463},
 										name: "_",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 99, col: 88, offset: 3285},
+										pos:  position{line: 107, col: 88, offset: 3465},
 										name: "Body",
 									},
 								},
@@ -380,51 +388,51 @@ var g = &grammar{
 		},
 		{
 			name: "Body",
-			pos:  position{line: 155, col: 1, offset: 4916},
+			pos:  position{line: 163, col: 1, offset: 5096},
 			expr: &actionExpr{
-				pos: position{line: 155, col: 9, offset: 4924},
+				pos: position{line: 163, col: 9, offset: 5104},
 				run: (*parser).callonBody1,
 				expr: &seqExpr{
-					pos: position{line: 155, col: 9, offset: 4924},
+					pos: position{line: 163, col: 9, offset: 5104},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 155, col: 9, offset: 4924},
+							pos:   position{line: 163, col: 9, offset: 5104},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 155, col: 14, offset: 4929},
+								pos:  position{line: 163, col: 14, offset: 5109},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 155, col: 19, offset: 4934},
+							pos:   position{line: 163, col: 19, offset: 5114},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 155, col: 24, offset: 4939},
+								pos: position{line: 163, col: 24, offset: 5119},
 								expr: &seqExpr{
-									pos: position{line: 155, col: 26, offset: 4941},
+									pos: position{line: 163, col: 26, offset: 5121},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 155, col: 26, offset: 4941},
+											pos:  position{line: 163, col: 26, offset: 5121},
 											name: "_",
 										},
 										&litMatcher{
-											pos:        position{line: 155, col: 28, offset: 4943},
+											pos:        position{line: 163, col: 28, offset: 5123},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 155, col: 32, offset: 4947},
+											pos:  position{line: 163, col: 32, offset: 5127},
 											name: "_",
 										},
 										&choiceExpr{
-											pos: position{line: 155, col: 35, offset: 4950},
+											pos: position{line: 163, col: 35, offset: 5130},
 											alternatives: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 155, col: 35, offset: 4950},
+													pos:  position{line: 163, col: 35, offset: 5130},
 													name: "Expr",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 155, col: 42, offset: 4957},
+													pos:  position{line: 163, col: 42, offset: 5137},
 													name: "ParseError",
 												},
 											},
@@ -439,28 +447,28 @@ var g = &grammar{
 		},
 		{
 			name: "Expr",
-			pos:  position{line: 165, col: 1, offset: 5177},
+			pos:  position{line: 173, col: 1, offset: 5357},
 			expr: &actionExpr{
-				pos: position{line: 165, col: 9, offset: 5185},
+				pos: position{line: 173, col: 9, offset: 5365},
 				run: (*parser).callonExpr1,
 				expr: &seqExpr{
-					pos: position{line: 165, col: 9, offset: 5185},
+					pos: position{line: 173, col: 9, offset: 5365},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 165, col: 9, offset: 5185},
+							pos:   position{line: 173, col: 9, offset: 5365},
 							label: "neg",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 165, col: 13, offset: 5189},
+								pos: position{line: 173, col: 13, offset: 5369},
 								expr: &seqExpr{
-									pos: position{line: 165, col: 15, offset: 5191},
+									pos: position{line: 173, col: 15, offset: 5371},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 165, col: 15, offset: 5191},
+											pos:        position{line: 173, col: 15, offset: 5371},
 											val:        "not",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 165, col: 21, offset: 5197},
+											pos:  position{line: 173, col: 21, offset: 5377},
 											name: "ws",
 										},
 									},
@@ -468,21 +476,21 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 165, col: 27, offset: 5203},
+							pos:   position{line: 173, col: 27, offset: 5383},
 							label: "val",
 							expr: &choiceExpr{
-								pos: position{line: 165, col: 32, offset: 5208},
+								pos: position{line: 173, col: 32, offset: 5388},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 165, col: 32, offset: 5208},
+										pos:  position{line: 173, col: 32, offset: 5388},
 										name: "InfixExpr",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 165, col: 44, offset: 5220},
+										pos:  position{line: 173, col: 44, offset: 5400},
 										name: "PrefixExpr",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 165, col: 57, offset: 5233},
+										pos:  position{line: 173, col: 57, offset: 5413},
 										name: "Term",
 									},
 								},
@@ -494,42 +502,42 @@ var g = &grammar{
 		},
 		{
 			name: "InfixExpr",
-			pos:  position{line: 173, col: 1, offset: 5375},
+			pos:  position{line: 181, col: 1, offset: 5555},
 			expr: &actionExpr{
-				pos: position{line: 173, col: 14, offset: 5388},
+				pos: position{line: 181, col: 14, offset: 5568},
 				run: (*parser).callonInfixExpr1,
 				expr: &seqExpr{
-					pos: position{line: 173, col: 14, offset: 5388},
+					pos: position{line: 181, col: 14, offset: 5568},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 173, col: 14, offset: 5388},
+							pos:   position{line: 181, col: 14, offset: 5568},
 							label: "left",
 							expr: &ruleRefExpr{
-								pos:  position{line: 173, col: 19, offset: 5393},
+								pos:  position{line: 181, col: 19, offset: 5573},
 								name: "Term",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 173, col: 24, offset: 5398},
+							pos:  position{line: 181, col: 24, offset: 5578},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 173, col: 26, offset: 5400},
+							pos:   position{line: 181, col: 26, offset: 5580},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 173, col: 29, offset: 5403},
+								pos:  position{line: 181, col: 29, offset: 5583},
 								name: "InfixOp",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 173, col: 37, offset: 5411},
+							pos:  position{line: 181, col: 37, offset: 5591},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 173, col: 39, offset: 5413},
+							pos:   position{line: 181, col: 39, offset: 5593},
 							label: "right",
 							expr: &ruleRefExpr{
-								pos:  position{line: 173, col: 45, offset: 5419},
+								pos:  position{line: 181, col: 45, offset: 5599},
 								name: "Term",
 							},
 						},
@@ -539,43 +547,43 @@ var g = &grammar{
 		},
 		{
 			name: "InfixOp",
-			pos:  position{line: 177, col: 1, offset: 5494},
+			pos:  position{line: 185, col: 1, offset: 5674},
 			expr: &actionExpr{
-				pos: position{line: 177, col: 12, offset: 5505},
+				pos: position{line: 185, col: 12, offset: 5685},
 				run: (*parser).callonInfixOp1,
 				expr: &labeledExpr{
-					pos:   position{line: 177, col: 12, offset: 5505},
+					pos:   position{line: 185, col: 12, offset: 5685},
 					label: "val",
 					expr: &choiceExpr{
-						pos: position{line: 177, col: 17, offset: 5510},
+						pos: position{line: 185, col: 17, offset: 5690},
 						alternatives: []interface{}{
 							&litMatcher{
-								pos:        position{line: 177, col: 17, offset: 5510},
+								pos:        position{line: 185, col: 17, offset: 5690},
 								val:        "=",
 								ignoreCase: false,
 							},
 							&litMatcher{
-								pos:        position{line: 177, col: 23, offset: 5516},
+								pos:        position{line: 185, col: 23, offset: 5696},
 								val:        "!=",
 								ignoreCase: false,
 							},
 							&litMatcher{
-								pos:        position{line: 177, col: 30, offset: 5523},
+								pos:        position{line: 185, col: 30, offset: 5703},
 								val:        "<=",
 								ignoreCase: false,
 							},
 							&litMatcher{
-								pos:        position{line: 177, col: 37, offset: 5530},
+								pos:        position{line: 185, col: 37, offset: 5710},
 								val:        ">=",
 								ignoreCase: false,
 							},
 							&litMatcher{
-								pos:        position{line: 177, col: 44, offset: 5537},
+								pos:        position{line: 185, col: 44, offset: 5717},
 								val:        "<",
 								ignoreCase: false,
 							},
 							&litMatcher{
-								pos:        position{line: 177, col: 50, offset: 5543},
+								pos:        position{line: 185, col: 50, offset: 5723},
 								val:        ">",
 								ignoreCase: false,
 							},
@@ -586,16 +594,16 @@ var g = &grammar{
 		},
 		{
 			name: "PrefixExpr",
-			pos:  position{line: 189, col: 1, offset: 5787},
+			pos:  position{line: 197, col: 1, offset: 5967},
 			expr: &choiceExpr{
-				pos: position{line: 189, col: 15, offset: 5801},
+				pos: position{line: 197, col: 15, offset: 5981},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 189, col: 15, offset: 5801},
+						pos:  position{line: 197, col: 15, offset: 5981},
 						name: "SetEmpty",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 189, col: 26, offset: 5812},
+						pos:  position{line: 197, col: 26, offset: 5992},
 						name: "Builtin",
 					},
 				},
@@ -603,64 +611,64 @@ var g = &grammar{
 		},
 		{
 			name: "Builtin",
-			pos:  position{line: 191, col: 1, offset: 5821},
+			pos:  position{line: 199, col: 1, offset: 6001},
 			expr: &actionExpr{
-				pos: position{line: 191, col: 12, offset: 5832},
+				pos: position{line: 199, col: 12, offset: 6012},
 				run: (*parser).callonBuiltin1,
 				expr: &seqExpr{
-					pos: position{line: 191, col: 12, offset: 5832},
+					pos: position{line: 199, col: 12, offset: 6012},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 191, col: 12, offset: 5832},
+							pos:   position{line: 199, col: 12, offset: 6012},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 191, col: 15, offset: 5835},
+								pos:  position{line: 199, col: 15, offset: 6015},
 								name: "Var",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 191, col: 19, offset: 5839},
+							pos:        position{line: 199, col: 19, offset: 6019},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 191, col: 23, offset: 5843},
+							pos:  position{line: 199, col: 23, offset: 6023},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 191, col: 25, offset: 5845},
+							pos:   position{line: 199, col: 25, offset: 6025},
 							label: "head",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 191, col: 30, offset: 5850},
+								pos: position{line: 199, col: 30, offset: 6030},
 								expr: &ruleRefExpr{
-									pos:  position{line: 191, col: 30, offset: 5850},
+									pos:  position{line: 199, col: 30, offset: 6030},
 									name: "Term",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 191, col: 36, offset: 5856},
+							pos:   position{line: 199, col: 36, offset: 6036},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 191, col: 41, offset: 5861},
+								pos: position{line: 199, col: 41, offset: 6041},
 								expr: &seqExpr{
-									pos: position{line: 191, col: 43, offset: 5863},
+									pos: position{line: 199, col: 43, offset: 6043},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 191, col: 43, offset: 5863},
+											pos:  position{line: 199, col: 43, offset: 6043},
 											name: "_",
 										},
 										&litMatcher{
-											pos:        position{line: 191, col: 45, offset: 5865},
+											pos:        position{line: 199, col: 45, offset: 6045},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 191, col: 49, offset: 5869},
+											pos:  position{line: 199, col: 49, offset: 6049},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 191, col: 51, offset: 5871},
+											pos:  position{line: 199, col: 51, offset: 6051},
 											name: "Term",
 										},
 									},
@@ -668,11 +676,11 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 191, col: 59, offset: 5879},
+							pos:  position{line: 199, col: 59, offset: 6059},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 191, col: 62, offset: 5882},
+							pos:        position{line: 199, col: 62, offset: 6062},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -682,34 +690,34 @@ var g = &grammar{
 		},
 		{
 			name: "Term",
-			pos:  position{line: 207, col: 1, offset: 6284},
+			pos:  position{line: 215, col: 1, offset: 6464},
 			expr: &actionExpr{
-				pos: position{line: 207, col: 9, offset: 6292},
+				pos: position{line: 215, col: 9, offset: 6472},
 				run: (*parser).callonTerm1,
 				expr: &labeledExpr{
-					pos:   position{line: 207, col: 9, offset: 6292},
+					pos:   position{line: 215, col: 9, offset: 6472},
 					label: "val",
 					expr: &choiceExpr{
-						pos: position{line: 207, col: 15, offset: 6298},
+						pos: position{line: 215, col: 15, offset: 6478},
 						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 207, col: 15, offset: 6298},
+								pos:  position{line: 215, col: 15, offset: 6478},
 								name: "Comprehension",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 207, col: 31, offset: 6314},
+								pos:  position{line: 215, col: 31, offset: 6494},
 								name: "Composite",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 207, col: 43, offset: 6326},
+								pos:  position{line: 215, col: 43, offset: 6506},
 								name: "Scalar",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 207, col: 52, offset: 6335},
+								pos:  position{line: 215, col: 52, offset: 6515},
 								name: "Ref",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 207, col: 58, offset: 6341},
+								pos:  position{line: 215, col: 58, offset: 6521},
 								name: "Var",
 							},
 						},
@@ -719,65 +727,65 @@ var g = &grammar{
 		},
 		{
 			name: "Comprehension",
-			pos:  position{line: 211, col: 1, offset: 6372},
+			pos:  position{line: 219, col: 1, offset: 6552},
 			expr: &ruleRefExpr{
-				pos:  position{line: 211, col: 18, offset: 6389},
+				pos:  position{line: 219, col: 18, offset: 6569},
 				name: "ArrayComprehension",
 			},
 		},
 		{
 			name: "ArrayComprehension",
-			pos:  position{line: 213, col: 1, offset: 6409},
+			pos:  position{line: 221, col: 1, offset: 6589},
 			expr: &actionExpr{
-				pos: position{line: 213, col: 23, offset: 6431},
+				pos: position{line: 221, col: 23, offset: 6611},
 				run: (*parser).callonArrayComprehension1,
 				expr: &seqExpr{
-					pos: position{line: 213, col: 23, offset: 6431},
+					pos: position{line: 221, col: 23, offset: 6611},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 213, col: 23, offset: 6431},
+							pos:        position{line: 221, col: 23, offset: 6611},
 							val:        "[",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 213, col: 27, offset: 6435},
+							pos:  position{line: 221, col: 27, offset: 6615},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 213, col: 29, offset: 6437},
+							pos:   position{line: 221, col: 29, offset: 6617},
 							label: "term",
 							expr: &ruleRefExpr{
-								pos:  position{line: 213, col: 34, offset: 6442},
+								pos:  position{line: 221, col: 34, offset: 6622},
 								name: "Term",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 213, col: 39, offset: 6447},
+							pos:  position{line: 221, col: 39, offset: 6627},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 213, col: 41, offset: 6449},
+							pos:        position{line: 221, col: 41, offset: 6629},
 							val:        "|",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 213, col: 45, offset: 6453},
+							pos:  position{line: 221, col: 45, offset: 6633},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 213, col: 47, offset: 6455},
+							pos:   position{line: 221, col: 47, offset: 6635},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 213, col: 52, offset: 6460},
+								pos:  position{line: 221, col: 52, offset: 6640},
 								name: "Body",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 213, col: 57, offset: 6465},
+							pos:  position{line: 221, col: 57, offset: 6645},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 213, col: 59, offset: 6467},
+							pos:        position{line: 221, col: 59, offset: 6647},
 							val:        "]",
 							ignoreCase: false,
 						},
@@ -787,20 +795,20 @@ var g = &grammar{
 		},
 		{
 			name: "Composite",
-			pos:  position{line: 219, col: 1, offset: 6592},
+			pos:  position{line: 227, col: 1, offset: 6772},
 			expr: &choiceExpr{
-				pos: position{line: 219, col: 14, offset: 6605},
+				pos: position{line: 227, col: 14, offset: 6785},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 219, col: 14, offset: 6605},
+						pos:  position{line: 227, col: 14, offset: 6785},
 						name: "Object",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 219, col: 23, offset: 6614},
+						pos:  position{line: 227, col: 23, offset: 6794},
 						name: "Array",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 219, col: 31, offset: 6622},
+						pos:  position{line: 227, col: 31, offset: 6802},
 						name: "Set",
 					},
 				},
@@ -808,24 +816,24 @@ var g = &grammar{
 		},
 		{
 			name: "Scalar",
-			pos:  position{line: 221, col: 1, offset: 6627},
+			pos:  position{line: 229, col: 1, offset: 6807},
 			expr: &choiceExpr{
-				pos: position{line: 221, col: 11, offset: 6637},
+				pos: position{line: 229, col: 11, offset: 6817},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 221, col: 11, offset: 6637},
+						pos:  position{line: 229, col: 11, offset: 6817},
 						name: "Number",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 221, col: 20, offset: 6646},
+						pos:  position{line: 229, col: 20, offset: 6826},
 						name: "String",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 221, col: 29, offset: 6655},
+						pos:  position{line: 229, col: 29, offset: 6835},
 						name: "Bool",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 221, col: 36, offset: 6662},
+						pos:  position{line: 229, col: 36, offset: 6842},
 						name: "Null",
 					},
 				},
@@ -833,20 +841,20 @@ var g = &grammar{
 		},
 		{
 			name: "Key",
-			pos:  position{line: 223, col: 1, offset: 6668},
+			pos:  position{line: 231, col: 1, offset: 6848},
 			expr: &choiceExpr{
-				pos: position{line: 223, col: 8, offset: 6675},
+				pos: position{line: 231, col: 8, offset: 6855},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 223, col: 8, offset: 6675},
+						pos:  position{line: 231, col: 8, offset: 6855},
 						name: "Scalar",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 223, col: 17, offset: 6684},
+						pos:  position{line: 231, col: 17, offset: 6864},
 						name: "Ref",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 223, col: 23, offset: 6690},
+						pos:  position{line: 231, col: 23, offset: 6870},
 						name: "Var",
 					},
 				},
@@ -854,49 +862,49 @@ var g = &grammar{
 		},
 		{
 			name: "Object",
-			pos:  position{line: 225, col: 1, offset: 6695},
+			pos:  position{line: 233, col: 1, offset: 6875},
 			expr: &actionExpr{
-				pos: position{line: 225, col: 11, offset: 6705},
+				pos: position{line: 233, col: 11, offset: 6885},
 				run: (*parser).callonObject1,
 				expr: &seqExpr{
-					pos: position{line: 225, col: 11, offset: 6705},
+					pos: position{line: 233, col: 11, offset: 6885},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 225, col: 11, offset: 6705},
+							pos:        position{line: 233, col: 11, offset: 6885},
 							val:        "{",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 225, col: 15, offset: 6709},
+							pos:  position{line: 233, col: 15, offset: 6889},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 225, col: 17, offset: 6711},
+							pos:   position{line: 233, col: 17, offset: 6891},
 							label: "head",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 225, col: 22, offset: 6716},
+								pos: position{line: 233, col: 22, offset: 6896},
 								expr: &seqExpr{
-									pos: position{line: 225, col: 23, offset: 6717},
+									pos: position{line: 233, col: 23, offset: 6897},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 225, col: 23, offset: 6717},
+											pos:  position{line: 233, col: 23, offset: 6897},
 											name: "Key",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 225, col: 27, offset: 6721},
+											pos:  position{line: 233, col: 27, offset: 6901},
 											name: "_",
 										},
 										&litMatcher{
-											pos:        position{line: 225, col: 29, offset: 6723},
+											pos:        position{line: 233, col: 29, offset: 6903},
 											val:        ":",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 225, col: 33, offset: 6727},
+											pos:  position{line: 233, col: 33, offset: 6907},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 225, col: 35, offset: 6729},
+											pos:  position{line: 233, col: 35, offset: 6909},
 											name: "Term",
 										},
 									},
@@ -904,45 +912,45 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 225, col: 42, offset: 6736},
+							pos:   position{line: 233, col: 42, offset: 6916},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 225, col: 47, offset: 6741},
+								pos: position{line: 233, col: 47, offset: 6921},
 								expr: &seqExpr{
-									pos: position{line: 225, col: 49, offset: 6743},
+									pos: position{line: 233, col: 49, offset: 6923},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 225, col: 49, offset: 6743},
+											pos:  position{line: 233, col: 49, offset: 6923},
 											name: "_",
 										},
 										&litMatcher{
-											pos:        position{line: 225, col: 51, offset: 6745},
+											pos:        position{line: 233, col: 51, offset: 6925},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 225, col: 55, offset: 6749},
+											pos:  position{line: 233, col: 55, offset: 6929},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 225, col: 57, offset: 6751},
+											pos:  position{line: 233, col: 57, offset: 6931},
 											name: "Key",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 225, col: 61, offset: 6755},
+											pos:  position{line: 233, col: 61, offset: 6935},
 											name: "_",
 										},
 										&litMatcher{
-											pos:        position{line: 225, col: 63, offset: 6757},
+											pos:        position{line: 233, col: 63, offset: 6937},
 											val:        ":",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 225, col: 67, offset: 6761},
+											pos:  position{line: 233, col: 67, offset: 6941},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 225, col: 69, offset: 6763},
+											pos:  position{line: 233, col: 69, offset: 6943},
 											name: "Term",
 										},
 									},
@@ -950,11 +958,11 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 225, col: 77, offset: 6771},
+							pos:  position{line: 233, col: 77, offset: 6951},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 225, col: 79, offset: 6773},
+							pos:        position{line: 233, col: 79, offset: 6953},
 							val:        "}",
 							ignoreCase: false,
 						},
@@ -964,56 +972,56 @@ var g = &grammar{
 		},
 		{
 			name: "Array",
-			pos:  position{line: 249, col: 1, offset: 7552},
+			pos:  position{line: 257, col: 1, offset: 7732},
 			expr: &actionExpr{
-				pos: position{line: 249, col: 10, offset: 7561},
+				pos: position{line: 257, col: 10, offset: 7741},
 				run: (*parser).callonArray1,
 				expr: &seqExpr{
-					pos: position{line: 249, col: 10, offset: 7561},
+					pos: position{line: 257, col: 10, offset: 7741},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 249, col: 10, offset: 7561},
+							pos:        position{line: 257, col: 10, offset: 7741},
 							val:        "[",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 249, col: 14, offset: 7565},
+							pos:  position{line: 257, col: 14, offset: 7745},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 249, col: 17, offset: 7568},
+							pos:   position{line: 257, col: 17, offset: 7748},
 							label: "head",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 249, col: 22, offset: 7573},
+								pos: position{line: 257, col: 22, offset: 7753},
 								expr: &ruleRefExpr{
-									pos:  position{line: 249, col: 22, offset: 7573},
+									pos:  position{line: 257, col: 22, offset: 7753},
 									name: "Term",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 249, col: 28, offset: 7579},
+							pos:   position{line: 257, col: 28, offset: 7759},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 249, col: 33, offset: 7584},
+								pos: position{line: 257, col: 33, offset: 7764},
 								expr: &seqExpr{
-									pos: position{line: 249, col: 34, offset: 7585},
+									pos: position{line: 257, col: 34, offset: 7765},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 249, col: 34, offset: 7585},
+											pos:  position{line: 257, col: 34, offset: 7765},
 											name: "_",
 										},
 										&litMatcher{
-											pos:        position{line: 249, col: 36, offset: 7587},
+											pos:        position{line: 257, col: 36, offset: 7767},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 249, col: 40, offset: 7591},
+											pos:  position{line: 257, col: 40, offset: 7771},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 249, col: 42, offset: 7593},
+											pos:  position{line: 257, col: 42, offset: 7773},
 											name: "Term",
 										},
 									},
@@ -1021,11 +1029,11 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 249, col: 49, offset: 7600},
+							pos:  position{line: 257, col: 49, offset: 7780},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 249, col: 51, offset: 7602},
+							pos:        position{line: 257, col: 51, offset: 7782},
 							val:        "]",
 							ignoreCase: false,
 						},
@@ -1035,16 +1043,16 @@ var g = &grammar{
 		},
 		{
 			name: "Set",
-			pos:  position{line: 273, col: 1, offset: 8175},
+			pos:  position{line: 281, col: 1, offset: 8355},
 			expr: &choiceExpr{
-				pos: position{line: 273, col: 8, offset: 8182},
+				pos: position{line: 281, col: 8, offset: 8362},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 273, col: 8, offset: 8182},
+						pos:  position{line: 281, col: 8, offset: 8362},
 						name: "SetEmpty",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 273, col: 19, offset: 8193},
+						pos:  position{line: 281, col: 19, offset: 8373},
 						name: "SetNonEmpty",
 					},
 				},
@@ -1052,24 +1060,24 @@ var g = &grammar{
 		},
 		{
 			name: "SetEmpty",
-			pos:  position{line: 275, col: 1, offset: 8206},
+			pos:  position{line: 283, col: 1, offset: 8386},
 			expr: &actionExpr{
-				pos: position{line: 275, col: 13, offset: 8218},
+				pos: position{line: 283, col: 13, offset: 8398},
 				run: (*parser).callonSetEmpty1,
 				expr: &seqExpr{
-					pos: position{line: 275, col: 13, offset: 8218},
+					pos: position{line: 283, col: 13, offset: 8398},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 275, col: 13, offset: 8218},
+							pos:        position{line: 283, col: 13, offset: 8398},
 							val:        "set(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 275, col: 20, offset: 8225},
+							pos:  position{line: 283, col: 20, offset: 8405},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 275, col: 22, offset: 8227},
+							pos:        position{line: 283, col: 22, offset: 8407},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -1079,53 +1087,53 @@ var g = &grammar{
 		},
 		{
 			name: "SetNonEmpty",
-			pos:  position{line: 281, col: 1, offset: 8315},
+			pos:  position{line: 289, col: 1, offset: 8495},
 			expr: &actionExpr{
-				pos: position{line: 281, col: 16, offset: 8330},
+				pos: position{line: 289, col: 16, offset: 8510},
 				run: (*parser).callonSetNonEmpty1,
 				expr: &seqExpr{
-					pos: position{line: 281, col: 16, offset: 8330},
+					pos: position{line: 289, col: 16, offset: 8510},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 281, col: 16, offset: 8330},
+							pos:        position{line: 289, col: 16, offset: 8510},
 							val:        "{",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 281, col: 20, offset: 8334},
+							pos:  position{line: 289, col: 20, offset: 8514},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 281, col: 22, offset: 8336},
+							pos:   position{line: 289, col: 22, offset: 8516},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 281, col: 27, offset: 8341},
+								pos:  position{line: 289, col: 27, offset: 8521},
 								name: "Term",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 281, col: 32, offset: 8346},
+							pos:   position{line: 289, col: 32, offset: 8526},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 281, col: 37, offset: 8351},
+								pos: position{line: 289, col: 37, offset: 8531},
 								expr: &seqExpr{
-									pos: position{line: 281, col: 38, offset: 8352},
+									pos: position{line: 289, col: 38, offset: 8532},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 281, col: 38, offset: 8352},
+											pos:  position{line: 289, col: 38, offset: 8532},
 											name: "_",
 										},
 										&litMatcher{
-											pos:        position{line: 281, col: 40, offset: 8354},
+											pos:        position{line: 289, col: 40, offset: 8534},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 281, col: 44, offset: 8358},
+											pos:  position{line: 289, col: 44, offset: 8538},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 281, col: 46, offset: 8360},
+											pos:  position{line: 289, col: 46, offset: 8540},
 											name: "Term",
 										},
 									},
@@ -1133,11 +1141,11 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 281, col: 53, offset: 8367},
+							pos:  position{line: 289, col: 53, offset: 8547},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 281, col: 55, offset: 8369},
+							pos:        position{line: 289, col: 55, offset: 8549},
 							val:        "}",
 							ignoreCase: false,
 						},
@@ -1147,35 +1155,35 @@ var g = &grammar{
 		},
 		{
 			name: "Ref",
-			pos:  position{line: 298, col: 1, offset: 8774},
+			pos:  position{line: 306, col: 1, offset: 8954},
 			expr: &actionExpr{
-				pos: position{line: 298, col: 8, offset: 8781},
+				pos: position{line: 306, col: 8, offset: 8961},
 				run: (*parser).callonRef1,
 				expr: &seqExpr{
-					pos: position{line: 298, col: 8, offset: 8781},
+					pos: position{line: 306, col: 8, offset: 8961},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 298, col: 8, offset: 8781},
+							pos:   position{line: 306, col: 8, offset: 8961},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 298, col: 13, offset: 8786},
+								pos:  position{line: 306, col: 13, offset: 8966},
 								name: "Var",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 298, col: 17, offset: 8790},
+							pos:   position{line: 306, col: 17, offset: 8970},
 							label: "tail",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 298, col: 22, offset: 8795},
+								pos: position{line: 306, col: 22, offset: 8975},
 								expr: &choiceExpr{
-									pos: position{line: 298, col: 24, offset: 8797},
+									pos: position{line: 306, col: 24, offset: 8977},
 									alternatives: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 298, col: 24, offset: 8797},
+											pos:  position{line: 306, col: 24, offset: 8977},
 											name: "RefDot",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 298, col: 33, offset: 8806},
+											pos:  position{line: 306, col: 33, offset: 8986},
 											name: "RefBracket",
 										},
 									},
@@ -1188,23 +1196,23 @@ var g = &grammar{
 		},
 		{
 			name: "RefDot",
-			pos:  position{line: 311, col: 1, offset: 9045},
+			pos:  position{line: 319, col: 1, offset: 9225},
 			expr: &actionExpr{
-				pos: position{line: 311, col: 11, offset: 9055},
+				pos: position{line: 319, col: 11, offset: 9235},
 				run: (*parser).callonRefDot1,
 				expr: &seqExpr{
-					pos: position{line: 311, col: 11, offset: 9055},
+					pos: position{line: 319, col: 11, offset: 9235},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 311, col: 11, offset: 9055},
+							pos:        position{line: 319, col: 11, offset: 9235},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 311, col: 15, offset: 9059},
+							pos:   position{line: 319, col: 15, offset: 9239},
 							label: "val",
 							expr: &ruleRefExpr{
-								pos:  position{line: 311, col: 19, offset: 9063},
+								pos:  position{line: 319, col: 19, offset: 9243},
 								name: "Var",
 							},
 						},
@@ -1214,41 +1222,41 @@ var g = &grammar{
 		},
 		{
 			name: "RefBracket",
-			pos:  position{line: 318, col: 1, offset: 9282},
+			pos:  position{line: 326, col: 1, offset: 9462},
 			expr: &actionExpr{
-				pos: position{line: 318, col: 15, offset: 9296},
+				pos: position{line: 326, col: 15, offset: 9476},
 				run: (*parser).callonRefBracket1,
 				expr: &seqExpr{
-					pos: position{line: 318, col: 15, offset: 9296},
+					pos: position{line: 326, col: 15, offset: 9476},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 318, col: 15, offset: 9296},
+							pos:        position{line: 326, col: 15, offset: 9476},
 							val:        "[",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 318, col: 19, offset: 9300},
+							pos:   position{line: 326, col: 19, offset: 9480},
 							label: "val",
 							expr: &choiceExpr{
-								pos: position{line: 318, col: 24, offset: 9305},
+								pos: position{line: 326, col: 24, offset: 9485},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 318, col: 24, offset: 9305},
+										pos:  position{line: 326, col: 24, offset: 9485},
 										name: "Ref",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 318, col: 30, offset: 9311},
+										pos:  position{line: 326, col: 30, offset: 9491},
 										name: "Scalar",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 318, col: 39, offset: 9320},
+										pos:  position{line: 326, col: 39, offset: 9500},
 										name: "Var",
 									},
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 318, col: 44, offset: 9325},
+							pos:        position{line: 326, col: 44, offset: 9505},
 							val:        "]",
 							ignoreCase: false,
 						},
@@ -1258,15 +1266,15 @@ var g = &grammar{
 		},
 		{
 			name: "Var",
-			pos:  position{line: 322, col: 1, offset: 9354},
+			pos:  position{line: 330, col: 1, offset: 9534},
 			expr: &actionExpr{
-				pos: position{line: 322, col: 8, offset: 9361},
+				pos: position{line: 330, col: 8, offset: 9541},
 				run: (*parser).callonVar1,
 				expr: &labeledExpr{
-					pos:   position{line: 322, col: 8, offset: 9361},
+					pos:   position{line: 330, col: 8, offset: 9541},
 					label: "val",
 					expr: &ruleRefExpr{
-						pos:  position{line: 322, col: 12, offset: 9365},
+						pos:  position{line: 330, col: 12, offset: 9545},
 						name: "VarChecked",
 					},
 				},
@@ -1274,20 +1282,20 @@ var g = &grammar{
 		},
 		{
 			name: "VarChecked",
-			pos:  position{line: 327, col: 1, offset: 9487},
+			pos:  position{line: 335, col: 1, offset: 9667},
 			expr: &seqExpr{
-				pos: position{line: 327, col: 15, offset: 9501},
+				pos: position{line: 335, col: 15, offset: 9681},
 				exprs: []interface{}{
 					&labeledExpr{
-						pos:   position{line: 327, col: 15, offset: 9501},
+						pos:   position{line: 335, col: 15, offset: 9681},
 						label: "val",
 						expr: &ruleRefExpr{
-							pos:  position{line: 327, col: 19, offset: 9505},
+							pos:  position{line: 335, col: 19, offset: 9685},
 							name: "VarUnchecked",
 						},
 					},
 					&notCodeExpr{
-						pos: position{line: 327, col: 32, offset: 9518},
+						pos: position{line: 335, col: 32, offset: 9698},
 						run: (*parser).callonVarChecked4,
 					},
 				},
@@ -1295,28 +1303,28 @@ var g = &grammar{
 		},
 		{
 			name: "VarUnchecked",
-			pos:  position{line: 331, col: 1, offset: 9583},
+			pos:  position{line: 339, col: 1, offset: 9763},
 			expr: &actionExpr{
-				pos: position{line: 331, col: 17, offset: 9599},
+				pos: position{line: 339, col: 17, offset: 9779},
 				run: (*parser).callonVarUnchecked1,
 				expr: &seqExpr{
-					pos: position{line: 331, col: 17, offset: 9599},
+					pos: position{line: 339, col: 17, offset: 9779},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 331, col: 17, offset: 9599},
+							pos:  position{line: 339, col: 17, offset: 9779},
 							name: "AsciiLetter",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 331, col: 29, offset: 9611},
+							pos: position{line: 339, col: 29, offset: 9791},
 							expr: &choiceExpr{
-								pos: position{line: 331, col: 30, offset: 9612},
+								pos: position{line: 339, col: 30, offset: 9792},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 331, col: 30, offset: 9612},
+										pos:  position{line: 339, col: 30, offset: 9792},
 										name: "AsciiLetter",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 331, col: 44, offset: 9626},
+										pos:  position{line: 339, col: 44, offset: 9806},
 										name: "DecimalDigit",
 									},
 								},
@@ -1328,30 +1336,30 @@ var g = &grammar{
 		},
 		{
 			name: "Number",
-			pos:  position{line: 338, col: 1, offset: 9769},
+			pos:  position{line: 346, col: 1, offset: 9949},
 			expr: &actionExpr{
-				pos: position{line: 338, col: 11, offset: 9779},
+				pos: position{line: 346, col: 11, offset: 9959},
 				run: (*parser).callonNumber1,
 				expr: &seqExpr{
-					pos: position{line: 338, col: 11, offset: 9779},
+					pos: position{line: 346, col: 11, offset: 9959},
 					exprs: []interface{}{
 						&zeroOrOneExpr{
-							pos: position{line: 338, col: 11, offset: 9779},
+							pos: position{line: 346, col: 11, offset: 9959},
 							expr: &litMatcher{
-								pos:        position{line: 338, col: 11, offset: 9779},
+								pos:        position{line: 346, col: 11, offset: 9959},
 								val:        "-",
 								ignoreCase: false,
 							},
 						},
 						&choiceExpr{
-							pos: position{line: 338, col: 18, offset: 9786},
+							pos: position{line: 346, col: 18, offset: 9966},
 							alternatives: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 338, col: 18, offset: 9786},
+									pos:  position{line: 346, col: 18, offset: 9966},
 									name: "Float",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 338, col: 26, offset: 9794},
+									pos:  position{line: 346, col: 26, offset: 9974},
 									name: "Integer",
 								},
 							},
@@ -1362,16 +1370,16 @@ var g = &grammar{
 		},
 		{
 			name: "Float",
-			pos:  position{line: 351, col: 1, offset: 10185},
+			pos:  position{line: 359, col: 1, offset: 10365},
 			expr: &choiceExpr{
-				pos: position{line: 351, col: 10, offset: 10194},
+				pos: position{line: 359, col: 10, offset: 10374},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 351, col: 10, offset: 10194},
+						pos:  position{line: 359, col: 10, offset: 10374},
 						name: "ExponentFloat",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 351, col: 26, offset: 10210},
+						pos:  position{line: 359, col: 26, offset: 10390},
 						name: "PointFloat",
 					},
 				},
@@ -1379,25 +1387,25 @@ var g = &grammar{
 		},
 		{
 			name: "ExponentFloat",
-			pos:  position{line: 353, col: 1, offset: 10222},
+			pos:  position{line: 361, col: 1, offset: 10402},
 			expr: &seqExpr{
-				pos: position{line: 353, col: 18, offset: 10239},
+				pos: position{line: 361, col: 18, offset: 10419},
 				exprs: []interface{}{
 					&choiceExpr{
-						pos: position{line: 353, col: 20, offset: 10241},
+						pos: position{line: 361, col: 20, offset: 10421},
 						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 353, col: 20, offset: 10241},
+								pos:  position{line: 361, col: 20, offset: 10421},
 								name: "PointFloat",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 353, col: 33, offset: 10254},
+								pos:  position{line: 361, col: 33, offset: 10434},
 								name: "Integer",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 353, col: 43, offset: 10264},
+						pos:  position{line: 361, col: 43, offset: 10444},
 						name: "Exponent",
 					},
 				},
@@ -1405,19 +1413,19 @@ var g = &grammar{
 		},
 		{
 			name: "PointFloat",
-			pos:  position{line: 355, col: 1, offset: 10274},
+			pos:  position{line: 363, col: 1, offset: 10454},
 			expr: &seqExpr{
-				pos: position{line: 355, col: 15, offset: 10288},
+				pos: position{line: 363, col: 15, offset: 10468},
 				exprs: []interface{}{
 					&zeroOrOneExpr{
-						pos: position{line: 355, col: 15, offset: 10288},
+						pos: position{line: 363, col: 15, offset: 10468},
 						expr: &ruleRefExpr{
-							pos:  position{line: 355, col: 15, offset: 10288},
+							pos:  position{line: 363, col: 15, offset: 10468},
 							name: "Integer",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 355, col: 24, offset: 10297},
+						pos:  position{line: 363, col: 24, offset: 10477},
 						name: "Fraction",
 					},
 				},
@@ -1425,19 +1433,19 @@ var g = &grammar{
 		},
 		{
 			name: "Fraction",
-			pos:  position{line: 357, col: 1, offset: 10307},
+			pos:  position{line: 365, col: 1, offset: 10487},
 			expr: &seqExpr{
-				pos: position{line: 357, col: 13, offset: 10319},
+				pos: position{line: 365, col: 13, offset: 10499},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 357, col: 13, offset: 10319},
+						pos:        position{line: 365, col: 13, offset: 10499},
 						val:        ".",
 						ignoreCase: false,
 					},
 					&oneOrMoreExpr{
-						pos: position{line: 357, col: 17, offset: 10323},
+						pos: position{line: 365, col: 17, offset: 10503},
 						expr: &ruleRefExpr{
-							pos:  position{line: 357, col: 17, offset: 10323},
+							pos:  position{line: 365, col: 17, offset: 10503},
 							name: "DecimalDigit",
 						},
 					},
@@ -1446,19 +1454,19 @@ var g = &grammar{
 		},
 		{
 			name: "Exponent",
-			pos:  position{line: 359, col: 1, offset: 10338},
+			pos:  position{line: 367, col: 1, offset: 10518},
 			expr: &seqExpr{
-				pos: position{line: 359, col: 13, offset: 10350},
+				pos: position{line: 367, col: 13, offset: 10530},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 359, col: 13, offset: 10350},
+						pos:        position{line: 367, col: 13, offset: 10530},
 						val:        "e",
 						ignoreCase: true,
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 359, col: 18, offset: 10355},
+						pos: position{line: 367, col: 18, offset: 10535},
 						expr: &charClassMatcher{
-							pos:        position{line: 359, col: 18, offset: 10355},
+							pos:        position{line: 367, col: 18, offset: 10535},
 							val:        "[+-]",
 							chars:      []rune{'+', '-'},
 							ignoreCase: false,
@@ -1466,9 +1474,9 @@ var g = &grammar{
 						},
 					},
 					&oneOrMoreExpr{
-						pos: position{line: 359, col: 24, offset: 10361},
+						pos: position{line: 367, col: 24, offset: 10541},
 						expr: &ruleRefExpr{
-							pos:  position{line: 359, col: 24, offset: 10361},
+							pos:  position{line: 367, col: 24, offset: 10541},
 							name: "DecimalDigit",
 						},
 					},
@@ -1477,26 +1485,26 @@ var g = &grammar{
 		},
 		{
 			name: "Integer",
-			pos:  position{line: 361, col: 1, offset: 10376},
+			pos:  position{line: 369, col: 1, offset: 10556},
 			expr: &choiceExpr{
-				pos: position{line: 361, col: 12, offset: 10387},
+				pos: position{line: 369, col: 12, offset: 10567},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 361, col: 12, offset: 10387},
+						pos:        position{line: 369, col: 12, offset: 10567},
 						val:        "0",
 						ignoreCase: false,
 					},
 					&seqExpr{
-						pos: position{line: 361, col: 20, offset: 10395},
+						pos: position{line: 369, col: 20, offset: 10575},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 361, col: 20, offset: 10395},
+								pos:  position{line: 369, col: 20, offset: 10575},
 								name: "NonZeroDecimalDigit",
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 361, col: 40, offset: 10415},
+								pos: position{line: 369, col: 40, offset: 10595},
 								expr: &ruleRefExpr{
-									pos:  position{line: 361, col: 40, offset: 10415},
+									pos:  position{line: 369, col: 40, offset: 10595},
 									name: "DecimalDigit",
 								},
 							},
@@ -1507,48 +1515,48 @@ var g = &grammar{
 		},
 		{
 			name: "String",
-			pos:  position{line: 363, col: 1, offset: 10432},
+			pos:  position{line: 371, col: 1, offset: 10612},
 			expr: &actionExpr{
-				pos: position{line: 363, col: 11, offset: 10442},
+				pos: position{line: 371, col: 11, offset: 10622},
 				run: (*parser).callonString1,
 				expr: &seqExpr{
-					pos: position{line: 363, col: 11, offset: 10442},
+					pos: position{line: 371, col: 11, offset: 10622},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 363, col: 11, offset: 10442},
+							pos:        position{line: 371, col: 11, offset: 10622},
 							val:        "\"",
 							ignoreCase: false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 363, col: 15, offset: 10446},
+							pos: position{line: 371, col: 15, offset: 10626},
 							expr: &choiceExpr{
-								pos: position{line: 363, col: 17, offset: 10448},
+								pos: position{line: 371, col: 17, offset: 10628},
 								alternatives: []interface{}{
 									&seqExpr{
-										pos: position{line: 363, col: 17, offset: 10448},
+										pos: position{line: 371, col: 17, offset: 10628},
 										exprs: []interface{}{
 											&notExpr{
-												pos: position{line: 363, col: 17, offset: 10448},
+												pos: position{line: 371, col: 17, offset: 10628},
 												expr: &ruleRefExpr{
-													pos:  position{line: 363, col: 18, offset: 10449},
+													pos:  position{line: 371, col: 18, offset: 10629},
 													name: "EscapedChar",
 												},
 											},
 											&anyMatcher{
-												line: 363, col: 30, offset: 10461,
+												line: 371, col: 30, offset: 10641,
 											},
 										},
 									},
 									&seqExpr{
-										pos: position{line: 363, col: 34, offset: 10465},
+										pos: position{line: 371, col: 34, offset: 10645},
 										exprs: []interface{}{
 											&litMatcher{
-												pos:        position{line: 363, col: 34, offset: 10465},
+												pos:        position{line: 371, col: 34, offset: 10645},
 												val:        "\\",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 363, col: 39, offset: 10470},
+												pos:  position{line: 371, col: 39, offset: 10650},
 												name: "EscapeSequence",
 											},
 										},
@@ -1557,7 +1565,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 363, col: 57, offset: 10488},
+							pos:        position{line: 371, col: 57, offset: 10668},
 							val:        "\"",
 							ignoreCase: false,
 						},
@@ -1567,24 +1575,24 @@ var g = &grammar{
 		},
 		{
 			name: "Bool",
-			pos:  position{line: 372, col: 1, offset: 10746},
+			pos:  position{line: 380, col: 1, offset: 10926},
 			expr: &choiceExpr{
-				pos: position{line: 372, col: 9, offset: 10754},
+				pos: position{line: 380, col: 9, offset: 10934},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 372, col: 9, offset: 10754},
+						pos: position{line: 380, col: 9, offset: 10934},
 						run: (*parser).callonBool2,
 						expr: &litMatcher{
-							pos:        position{line: 372, col: 9, offset: 10754},
+							pos:        position{line: 380, col: 9, offset: 10934},
 							val:        "true",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 376, col: 5, offset: 10854},
+						pos: position{line: 384, col: 5, offset: 11034},
 						run: (*parser).callonBool4,
 						expr: &litMatcher{
-							pos:        position{line: 376, col: 5, offset: 10854},
+							pos:        position{line: 384, col: 5, offset: 11034},
 							val:        "false",
 							ignoreCase: false,
 						},
@@ -1594,12 +1602,12 @@ var g = &grammar{
 		},
 		{
 			name: "Null",
-			pos:  position{line: 382, col: 1, offset: 10955},
+			pos:  position{line: 390, col: 1, offset: 11135},
 			expr: &actionExpr{
-				pos: position{line: 382, col: 9, offset: 10963},
+				pos: position{line: 390, col: 9, offset: 11143},
 				run: (*parser).callonNull1,
 				expr: &litMatcher{
-					pos:        position{line: 382, col: 9, offset: 10963},
+					pos:        position{line: 390, col: 9, offset: 11143},
 					val:        "null",
 					ignoreCase: false,
 				},
@@ -1607,9 +1615,9 @@ var g = &grammar{
 		},
 		{
 			name: "AsciiLetter",
-			pos:  position{line: 388, col: 1, offset: 11058},
+			pos:  position{line: 396, col: 1, offset: 11238},
 			expr: &charClassMatcher{
-				pos:        position{line: 388, col: 16, offset: 11073},
+				pos:        position{line: 396, col: 16, offset: 11253},
 				val:        "[A-Za-z_]",
 				chars:      []rune{'_'},
 				ranges:     []rune{'A', 'Z', 'a', 'z'},
@@ -1619,9 +1627,9 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedChar",
-			pos:  position{line: 390, col: 1, offset: 11084},
+			pos:  position{line: 398, col: 1, offset: 11264},
 			expr: &charClassMatcher{
-				pos:        position{line: 390, col: 16, offset: 11099},
+				pos:        position{line: 398, col: 16, offset: 11279},
 				val:        "[\\x00-\\x1f\"\\\\]",
 				chars:      []rune{'"', '\\'},
 				ranges:     []rune{'\x00', '\x1f'},
@@ -1631,16 +1639,16 @@ var g = &grammar{
 		},
 		{
 			name: "EscapeSequence",
-			pos:  position{line: 392, col: 1, offset: 11115},
+			pos:  position{line: 400, col: 1, offset: 11295},
 			expr: &choiceExpr{
-				pos: position{line: 392, col: 19, offset: 11133},
+				pos: position{line: 400, col: 19, offset: 11313},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 392, col: 19, offset: 11133},
+						pos:  position{line: 400, col: 19, offset: 11313},
 						name: "SingleCharEscape",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 392, col: 38, offset: 11152},
+						pos:  position{line: 400, col: 38, offset: 11332},
 						name: "UnicodeEscape",
 					},
 				},
@@ -1648,9 +1656,9 @@ var g = &grammar{
 		},
 		{
 			name: "SingleCharEscape",
-			pos:  position{line: 394, col: 1, offset: 11167},
+			pos:  position{line: 402, col: 1, offset: 11347},
 			expr: &charClassMatcher{
-				pos:        position{line: 394, col: 21, offset: 11187},
+				pos:        position{line: 402, col: 21, offset: 11367},
 				val:        "[\"\\\\/bfnrt]",
 				chars:      []rune{'"', '\\', '/', 'b', 'f', 'n', 'r', 't'},
 				ignoreCase: false,
@@ -1659,29 +1667,29 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeEscape",
-			pos:  position{line: 396, col: 1, offset: 11200},
+			pos:  position{line: 404, col: 1, offset: 11380},
 			expr: &seqExpr{
-				pos: position{line: 396, col: 18, offset: 11217},
+				pos: position{line: 404, col: 18, offset: 11397},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 396, col: 18, offset: 11217},
+						pos:        position{line: 404, col: 18, offset: 11397},
 						val:        "u",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 396, col: 22, offset: 11221},
+						pos:  position{line: 404, col: 22, offset: 11401},
 						name: "HexDigit",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 396, col: 31, offset: 11230},
+						pos:  position{line: 404, col: 31, offset: 11410},
 						name: "HexDigit",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 396, col: 40, offset: 11239},
+						pos:  position{line: 404, col: 40, offset: 11419},
 						name: "HexDigit",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 396, col: 49, offset: 11248},
+						pos:  position{line: 404, col: 49, offset: 11428},
 						name: "HexDigit",
 					},
 				},
@@ -1689,9 +1697,9 @@ var g = &grammar{
 		},
 		{
 			name: "DecimalDigit",
-			pos:  position{line: 398, col: 1, offset: 11258},
+			pos:  position{line: 406, col: 1, offset: 11438},
 			expr: &charClassMatcher{
-				pos:        position{line: 398, col: 17, offset: 11274},
+				pos:        position{line: 406, col: 17, offset: 11454},
 				val:        "[0-9]",
 				ranges:     []rune{'0', '9'},
 				ignoreCase: false,
@@ -1700,9 +1708,9 @@ var g = &grammar{
 		},
 		{
 			name: "NonZeroDecimalDigit",
-			pos:  position{line: 400, col: 1, offset: 11281},
+			pos:  position{line: 408, col: 1, offset: 11461},
 			expr: &charClassMatcher{
-				pos:        position{line: 400, col: 24, offset: 11304},
+				pos:        position{line: 408, col: 24, offset: 11484},
 				val:        "[1-9]",
 				ranges:     []rune{'1', '9'},
 				ignoreCase: false,
@@ -1711,9 +1719,9 @@ var g = &grammar{
 		},
 		{
 			name: "HexDigit",
-			pos:  position{line: 402, col: 1, offset: 11311},
+			pos:  position{line: 410, col: 1, offset: 11491},
 			expr: &charClassMatcher{
-				pos:        position{line: 402, col: 13, offset: 11323},
+				pos:        position{line: 410, col: 13, offset: 11503},
 				val:        "[0-9a-f]",
 				ranges:     []rune{'0', '9', 'a', 'f'},
 				ignoreCase: false,
@@ -1723,11 +1731,11 @@ var g = &grammar{
 		{
 			name:        "ws",
 			displayName: "\"whitespace\"",
-			pos:         position{line: 404, col: 1, offset: 11333},
+			pos:         position{line: 412, col: 1, offset: 11513},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 404, col: 20, offset: 11352},
+				pos: position{line: 412, col: 20, offset: 11532},
 				expr: &charClassMatcher{
-					pos:        position{line: 404, col: 20, offset: 11352},
+					pos:        position{line: 412, col: 20, offset: 11532},
 					val:        "[ \\t\\r\\n]",
 					chars:      []rune{' ', '\t', '\r', '\n'},
 					ignoreCase: false,
@@ -1738,21 +1746,21 @@ var g = &grammar{
 		{
 			name:        "_",
 			displayName: "\"whitespace\"",
-			pos:         position{line: 406, col: 1, offset: 11364},
+			pos:         position{line: 414, col: 1, offset: 11544},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 406, col: 19, offset: 11382},
+				pos: position{line: 414, col: 19, offset: 11562},
 				expr: &choiceExpr{
-					pos: position{line: 406, col: 21, offset: 11384},
+					pos: position{line: 414, col: 21, offset: 11564},
 					alternatives: []interface{}{
 						&charClassMatcher{
-							pos:        position{line: 406, col: 21, offset: 11384},
+							pos:        position{line: 414, col: 21, offset: 11564},
 							val:        "[ \\t\\r\\n]",
 							chars:      []rune{' ', '\t', '\r', '\n'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 406, col: 33, offset: 11396},
+							pos:  position{line: 414, col: 33, offset: 11576},
 							name: "Comment",
 						},
 					},
@@ -1761,33 +1769,41 @@ var g = &grammar{
 		},
 		{
 			name: "Comment",
-			pos:  position{line: 408, col: 1, offset: 11408},
-			expr: &seqExpr{
-				pos: position{line: 408, col: 12, offset: 11419},
-				exprs: []interface{}{
-					&zeroOrMoreExpr{
-						pos: position{line: 408, col: 12, offset: 11419},
-						expr: &charClassMatcher{
-							pos:        position{line: 408, col: 12, offset: 11419},
-							val:        "[ \\t]",
-							chars:      []rune{' ', '\t'},
-							ignoreCase: false,
-							inverted:   false,
+			pos:  position{line: 416, col: 1, offset: 11588},
+			expr: &actionExpr{
+				pos: position{line: 416, col: 12, offset: 11599},
+				run: (*parser).callonComment1,
+				expr: &seqExpr{
+					pos: position{line: 416, col: 12, offset: 11599},
+					exprs: []interface{}{
+						&zeroOrMoreExpr{
+							pos: position{line: 416, col: 12, offset: 11599},
+							expr: &charClassMatcher{
+								pos:        position{line: 416, col: 12, offset: 11599},
+								val:        "[ \\t]",
+								chars:      []rune{' ', '\t'},
+								ignoreCase: false,
+								inverted:   false,
+							},
 						},
-					},
-					&litMatcher{
-						pos:        position{line: 408, col: 19, offset: 11426},
-						val:        "#",
-						ignoreCase: false,
-					},
-					&zeroOrMoreExpr{
-						pos: position{line: 408, col: 23, offset: 11430},
-						expr: &charClassMatcher{
-							pos:        position{line: 408, col: 23, offset: 11430},
-							val:        "[^\\r\\n]",
-							chars:      []rune{'\r', '\n'},
+						&litMatcher{
+							pos:        position{line: 416, col: 19, offset: 11606},
+							val:        "#",
 							ignoreCase: false,
-							inverted:   true,
+						},
+						&labeledExpr{
+							pos:   position{line: 416, col: 23, offset: 11610},
+							label: "text",
+							expr: &zeroOrMoreExpr{
+								pos: position{line: 416, col: 28, offset: 11615},
+								expr: &charClassMatcher{
+									pos:        position{line: 416, col: 28, offset: 11615},
+									val:        "[^\\r\\n]",
+									chars:      []rune{'\r', '\n'},
+									ignoreCase: false,
+									inverted:   true,
+								},
+							},
 						},
 					},
 				},
@@ -1795,11 +1811,11 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 410, col: 1, offset: 11440},
+			pos:  position{line: 422, col: 1, offset: 11750},
 			expr: &notExpr{
-				pos: position{line: 410, col: 8, offset: 11447},
+				pos: position{line: 422, col: 8, offset: 11757},
 				expr: &anyMatcher{
-					line: 410, col: 9, offset: 11448,
+					line: 422, col: 9, offset: 11758,
 				},
 			},
 		},
@@ -2316,6 +2332,18 @@ func (p *parser) callonNull1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onNull1()
+}
+
+func (c *current) onComment1(text interface{}) (interface{}, error) {
+	comment := NewComment(ifaceSliceToByteSlice(text))
+	comment.Location = currentLocation(c)
+	return comment, nil
+}
+
+func (p *parser) callonComment1() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onComment1(stack["text"])
 }
 
 var (

--- a/ast/parser_test.go
+++ b/ast/parser_test.go
@@ -681,7 +681,7 @@ func TestNoMatchError(t *testing.T) {
 	}
 }
 
-func assertParse(t *testing.T, msg string, input string, correct func([]interface{})) {
+func assertParse(t *testing.T, msg string, input string, correct func([]Statement)) {
 	p, err := ParseStatements("", input)
 	if err != nil {
 		t.Errorf("Error on test %s: parse error on %s: %s", msg, input, err)

--- a/ast/parser_test.go
+++ b/ast/parser_test.go
@@ -527,6 +527,32 @@ func TestExample(t *testing.T) {
 	})
 }
 
+func TestModuleParseErrors(t *testing.T) {
+	input := `
+	x = 1			# expect package
+	package a  		# unexpected package
+	1 = 2			# non-var head
+	1 != 2			# non-equality expr
+	x = y, x = 1    # multiple exprs
+	`
+
+	mod, err := ParseModule("test.rego", input)
+	if err == nil {
+		t.Fatalf("Expected error but got: %v", mod)
+	}
+
+	errs, ok := err.(Errors)
+	if !ok {
+		panic("unexpected error value")
+	}
+
+	if len(errs) != 5 {
+		t.Fatalf("Expected exactly 5 errors but got: %v", err)
+	}
+
+	fmt.Println(errs)
+}
+
 func TestLocation(t *testing.T) {
 	mod, err := ParseModule("test", testModule)
 	if err != nil {

--- a/ast/policy.go
+++ b/ast/policy.go
@@ -80,7 +80,7 @@ type (
 		Rules   []*Rule
 	}
 
-	// Comment represents
+	// Comment contains the raw text from the comment in the definition.
 	Comment struct {
 		Text     []byte
 		Location *Location

--- a/ast/policy.go
+++ b/ast/policy.go
@@ -63,6 +63,13 @@ func IsKeyword(s string) bool {
 var WildcardPrefix = "$"
 
 type (
+	// Statement represents a single statement in a policy module.
+	Statement interface {
+		Loc() *Location
+	}
+)
+
+type (
 
 	// Module represents a collection of policies (defined by rules)
 	// within a namespace (defined by the package) and optional
@@ -73,9 +80,10 @@ type (
 		Rules   []*Rule
 	}
 
-	// Statement represents a single statement within a module.
-	Statement interface {
-		Loc() *Location
+	// Comment represents
+	Comment struct {
+		Text     []byte
+		Location *Location
 	}
 
 	// Package represents the namespace of the documents produced
@@ -171,6 +179,22 @@ func (mod *Module) String() string {
 		}
 	}
 	return strings.Join(buf, "\n")
+}
+
+// NewComment returns a new Comment object.
+func NewComment(text []byte) *Comment {
+	return &Comment{
+		Text: text,
+	}
+}
+
+// Loc returns the location of the comment in the definition.
+func (c *Comment) Loc() *Location {
+	return c.Location
+}
+
+func (c *Comment) String() string {
+	return "#" + string(c.Text)
 }
 
 // Compare returns an integer indicating whether pkg is less than, equal to,

--- a/ast/rego.peg
+++ b/ast/rego.peg
@@ -11,6 +11,14 @@ func currentLocation(c *current) *Location {
     return NewLocation(c.text, "", c.pos.line, c.pos.col)
 }
 
+func ifaceSliceToByteSlice(i interface{}) []byte {
+    var buf bytes.Buffer
+    for _, x := range i.([]interface{}) {
+        buf.Write(x.([]byte))
+    }
+    return buf.Bytes()
+}
+
 }
 
 Program <- _ vals:(head:Stmt tail:((ws / ParseError) Stmt)*)? _ EOF {
@@ -405,6 +413,10 @@ ws "whitespace" <- [ \t\r\n]+
 
 _ "whitespace" <- ( [ \t\r\n] / Comment )*
 
-Comment <- [ \t]* "#" [^\r\n]*
+Comment <- [ \t]* "#" text:[^\r\n]* {
+    comment := NewComment(ifaceSliceToByteSlice(text))
+    comment.Location = currentLocation(c)
+    return comment, nil
+}
 
 EOF <- !.

--- a/ast/strings.go
+++ b/ast/strings.go
@@ -26,4 +26,10 @@ const (
 	ObjectTypeName             = "object"
 	SetTypeName                = "set"
 	ArrayComprehensionTypeName = "arraycomprehension"
+	ExprTypeName               = "expr"
+	BodyTypeName               = "body"
+	HeadTypeName               = "head"
+	RuleTypeName               = "rule"
+	ImportTypeName             = "import"
+	PackageTypeName            = "package"
 )

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -574,7 +574,7 @@ func (r *REPL) evalStatement(ctx context.Context, stmt interface{}) error {
 		if err != nil {
 			return err
 		}
-		if rule := ast.ParseRuleFromBody(body); rule != nil {
+		if rule, err := ast.ParseRuleFromBody(body); err == nil {
 			if err := r.compileRule(rule); err != nil {
 				return err
 			}


### PR DESCRIPTION
These changes improve the details of the error messages, catch multiple package directives (which are invalid), and report all parse errors (instead of stopping on the first).