### PR TITLE
Fix handling of missing input document

### DIFF
--- a/ast/errors.go
+++ b/ast/errors.go
@@ -46,7 +46,19 @@ const (
 
 	// RecursionErr indicates recursion was found during compilation.
 	RecursionErr = iota
+
+	// MissingInputErr indicates the query depends on input but no input
+	// document was provided.
+	MissingInputErr = iota
 )
+
+// IsError returns true if err is an AST error with code.
+func IsError(code ErrCode, err error) bool {
+	if err, ok := err.(*Error); ok {
+		return err.Code == code
+	}
+	return false
+}
 
 // Error represents a single error caught during parsing, compiling, etc.
 type Error struct {

--- a/ast/example_test.go
+++ b/ast/example_test.go
@@ -89,20 +89,22 @@ func ExampleQueryCompiler_Compile() {
 
 	// Obtain the QueryCompiler from the compiler instance. Note, we will
 	// compile this query within the context of the opa.example package and
-	// declare that a query input named "queryinput" must be supplied.
+	// declare that a query input named "queryinput" must be supplied. The
+	// QueryContext will include the input value so.
 	qc := c.QueryCompiler().
 		WithContext(
-			ast.NewQueryContext(
-				// Note, the ast.MustParse<X> functions are meant for test
-				// purposes only. They will panic if an error occurs. Prefer the
-				// ast.Parse<X> functions that return meaningful error messages
-				// instead.
-				ast.MustParsePackage("package opa.example"),
-				ast.MustParseImports("import input.queryinput"),
-			))
+			// Note, the ast.MustParse<X> functions are meant for test
+			// purposes only. They will panic if an error occurs. Prefer the
+			// ast.Parse<X> functions that return meaningful error messages
+			// instead.
+			ast.NewQueryContext().
+				WithPackage(ast.MustParsePackage("package opa.example")).
+				WithImports(ast.MustParseImports("import input.query_arg")).
+				WithInput(ast.MustParseTerm(`{"query_arg": 1000, "bar": [1,2,3]}`).Value),
+		)
 
 	// Parse the input query to obtain the AST representation.
-	query, err := ast.ParseBody("p[x], x < queryinput")
+	query, err := ast.ParseBody("p[x], x < query_arg")
 	if err != nil {
 		fmt.Println("Parse error:", err)
 	}
@@ -116,5 +118,5 @@ func ExampleQueryCompiler_Compile() {
 
 	// Output:
 	//
-	// Compiled: data.opa.example.p[x], lt(x, input.queryinput)
+	// Compiled: data.opa.example.p[x], lt(x, input.query_arg)
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -169,9 +169,16 @@ func TestDataV1(t *testing.T) {
 			tr{"PUT", "/policies/test", testMod1, 200, ""},
 			tr{"GET", "/data/testmod/g?input=req1%3A%7B%22a%22%3A%5B1%5D%7D&input=req2%3A%7B%22b%22%3A%5B0%2C1%5D%7D", "", 200, `{"result": true}`},
 		}},
+		{"get missing input", []tr{
+			tr{"PUT", "/policies/test", testMod1, 200, ""},
+			tr{"GET", "/data/testmod/g", "", 400, `{
+				"code": 400,
+				"message": "query requires input document (hint: POST /data[/path] {\"input\": value})"
+			}`},
+		}},
 		{"get with input (missing input value)", []tr{
 			tr{"PUT", "/policies/test", testMod1, 200, ""},
-			tr{"GET", "/data/testmod/g?input=req1%3A%7B%22a%22%3A%5B1%5D%7D", "", 404, ""},
+			tr{"GET", "/data/testmod/g?input=req1%3A%7B%22a%22%3A%5B1%5D%7D", "", 404, ""}, // req2 not specified
 		}},
 		{"get with input (namespaced)", []tr{
 			tr{"PUT", "/policies/test", testMod1, 200, ""},
@@ -233,9 +240,10 @@ func TestDataV1(t *testing.T) {
 			tr{"POST", "/data/testmod/gt1", `{"input": {"req1": 2}}`, 200, `{"result": true}`},
 		}},
 		{"post missing input", []tr{
-			tr{"POST", "/data/deadbeef", `{"req1": 2}`, 400, `{
+			tr{"PUT", "/policies/test", testMod1, 200, ""},
+			tr{"POST", "/data/testmod/gt1", ``, 400, `{
 				"code": 400,
-				"message": "body must include input document {\"input\": ...}"
+				"message": "query requires input document (hint: POST /data[/path] {\"input\": value})"
 			}`},
 		}},
 		{"post malformed input", []tr{

--- a/topdown/input.go
+++ b/topdown/input.go
@@ -15,6 +15,11 @@ import (
 // keys are valid import paths.
 func MakeInput(pairs [][2]*ast.Term) (ast.Value, error) {
 
+	// Fast-path for empty case.
+	if len(pairs) == 0 {
+		return nil, nil
+	}
+
 	// Fast-path for the root case.
 	if len(pairs) == 1 && len(pairs[0][0].Value.(ast.Ref)) == 0 {
 		return pairs[0][1].Value, nil

--- a/topdown/topdown_test.go
+++ b/topdown/topdown_test.go
@@ -1148,7 +1148,7 @@ func TestTopDownInputValues(t *testing.T) {
 
 	assertTopDown(t, compiler, store, "loopback", []string{"z", "loopback"}, `{"foo": 1}`, `{"foo": 1}`)
 
-	assertTopDown(t, compiler, store, "loopback undefined", []string{"z", "loopback"}, ``, ``)
+	assertTopDown(t, compiler, store, "loopback undefined", []string{"z", "loopback"}, ``, fmt.Errorf("missing input document"))
 
 	assertTopDown(t, compiler, store, "simple", []string{"z", "p"}, `{
 		"req1": {"foo": 4},


### PR DESCRIPTION
These changes update OPA to analyze queries to determine if an input
document is required. In the future, more sophisticated checks could be
performed (e.g., JSON schema validation).

If an input document is required but not provided, OPA will return HTTP
400 (per the documentation). This was broken in #197.

Fixes #227