### PR TITLE
High level API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ VERSION := 0.4.2-dev
 PACKAGES := \
 	github.com/open-policy-agent/opa/ast/.../ \
 	github.com/open-policy-agent/opa/cmd/.../ \
+	github.com/open-policy-agent/opa/rego/.../ \
 	github.com/open-policy-agent/opa/repl/.../ \
 	github.com/open-policy-agent/opa/runtime/.../ \
 	github.com/open-policy-agent/opa/server/.../ \

--- a/rego/example_test.go
+++ b/rego/example_test.go
@@ -1,0 +1,212 @@
+// Copyright 2017 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package rego_test
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/rego"
+	"github.com/open-policy-agent/opa/storage"
+	"github.com/open-policy-agent/opa/util"
+)
+
+func ExampleRego_Eval_simple() {
+
+	ctx := context.Background()
+
+	// Create very simple query that binds a single variable.
+	rego := rego.New(rego.Query("x = 1"))
+
+	// Run evaluation.
+	rs, err := rego.Eval(ctx)
+
+	// Inspect results.
+	fmt.Println("len:", len(rs))
+	fmt.Println("bindings:", rs[0].Bindings)
+	fmt.Println("err:", err)
+
+	// Output:
+	//
+	// len: 1
+	// bindings: map[x:1]
+	// err: <nil>
+}
+
+func ExampleRego_Eval_multipleBindings() {
+
+	ctx := context.Background()
+
+	// Create query that produces multiple bindings for variable.
+	rego := rego.New(rego.Query(`a = ["ex", "am", "ple"], x = a[_]`))
+
+	// Run evaluation.
+	rs, err := rego.Eval(ctx)
+
+	// Inspect results.
+	fmt.Println("len:", len(rs))
+	fmt.Println("err:", err)
+	for i := range rs {
+		fmt.Printf("bindings[\"x\"]: %v (i=%d)\n", rs[i].Bindings["x"], i)
+	}
+
+	// Output:
+	//
+	// len: 3
+	// err: <nil>
+	// bindings["x"]: ex (i=0)
+	// bindings["x"]: am (i=1)
+	// bindings["x"]: ple (i=2)
+}
+
+func ExampleRego_Eval_singleDocument() {
+
+	ctx := context.Background()
+
+	// Create query that produces a single document.
+	rego := rego.New(
+		rego.Query("data.example.p"),
+		rego.Module("example.rego",
+			`
+                package example
+
+                p = ["hello", "world"]
+            `))
+
+	// Run evaluation.
+	rs, err := rego.Eval(ctx)
+
+	// Inspect result.
+	fmt.Println("value:", rs[0].Expressions[0].Value)
+	fmt.Println("err:", err)
+
+	// Output:
+	//
+	// value: [hello world]
+	// err: <nil>
+}
+
+func ExampleRego_Eval_multipleDocuments() {
+
+	ctx := context.Background()
+
+	// Create query that produces multiple documents.
+	rego := rego.New(
+		rego.Query("data.example.p[x]"),
+		rego.Module("example.rego",
+			`
+                package example
+
+                p = {"hello": "alice", "goodbye": "bob"}
+            `))
+
+	// Run evaluation.
+	rs, err := rego.Eval(ctx)
+
+	// Inspect results.
+	fmt.Println("len:", len(rs))
+	fmt.Println("err:", err)
+	for i := range rs {
+		fmt.Printf("bindings[\"x\"]: %v (i=%d)\n", rs[i].Bindings["x"], i)
+		fmt.Printf("value: %v (i=%d)\n", rs[i].Expressions[0].Value, i)
+	}
+
+	// Output:
+	//
+	// len: 2
+	// err: <nil>
+	// bindings["x"]: hello (i=0)
+	// value: alice (i=0)
+	// bindings["x"]: goodbye (i=1)
+	// value: bob (i=1)
+}
+
+func ExampleRego_Eval_storage() {
+
+	ctx := context.Background()
+
+	data := `{
+        "example": {
+            "users": [
+                {
+                    "name": "alice",
+                    "likes": ["dogs", "clouds"]
+                },
+                {
+                    "name": "bob",
+                    "likes": ["pizza", "cats"]
+                }
+            ]
+        }
+    }`
+
+	var json map[string]interface{}
+
+	err := util.UnmarshalJSON([]byte(data), &json)
+	if err != nil {
+		// Handle error.
+	}
+
+	// Manually create the storage layer. storage.InMemoryWithJSONConfig will
+	// return configure the storage layer to use an in-memory store with the
+	// specified json data. This is mostly for test purposes. See storage
+	// package for more information on custom storage backends.
+	store := storage.New(storage.InMemoryWithJSONConfig(json))
+
+	// Create new query that returns the value
+	rego := rego.New(
+		rego.Query("data.example.users[0].likes"),
+		rego.Storage(store))
+
+	// Run evaluation.
+	rs, err := rego.Eval(ctx)
+
+	// Inspect the result.
+	fmt.Println("value:", rs[0].Expressions[0].Value)
+
+	// Output:
+	//
+	// value: [dogs clouds]
+}
+
+func ExampleRego_Eval_errors() {
+
+	ctx := context.Background()
+
+	r := rego.New(
+		rego.Query("data.example.p"),
+		rego.Module("example_error.rego",
+			`
+                package example
+
+                # variable 'x' is unsafe. This will not compile.
+                p :- not q[x]
+
+                q = {1,2,3}
+            `))
+
+	_, err := r.Eval(ctx)
+
+	switch err := err.(type) {
+	case rego.Errors:
+		for i := range err {
+			switch e := err[i].(type) {
+			case *ast.Error:
+				fmt.Println("code:", e.Code)
+				fmt.Println("row:", e.Location.Row)
+				fmt.Println("filename:", e.Location.File)
+			}
+		}
+	default:
+		// Some other error occurred.
+	}
+
+	// Output:
+	//
+	// code: 2
+	// row: 5
+	// filename: example_error.rego
+}

--- a/rego/rego.go
+++ b/rego/rego.go
@@ -1,0 +1,345 @@
+// Copyright 2017 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+// Package rego exposes high level APIs for evaluating Rego policies.
+package rego
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/storage"
+	"github.com/open-policy-agent/opa/topdown"
+)
+
+// Result defines the output of Rego evaluation.
+type Result struct {
+	Expressions []*ExpressionValue `json:"expressions"`
+	Bindings    Vars               `json:"bindings,omitempty"`
+}
+
+func newResult() Result {
+	return Result{
+		Bindings: Vars{},
+	}
+}
+
+// Location defines a position in a Rego query or module.
+type Location struct {
+	Row int `json:"row"`
+	Col int `json:"col"`
+}
+
+// ExpressionValue defines the value of an expression in a Rego query.
+type ExpressionValue struct {
+	Value    interface{} `json:"value"`
+	Text     string      `json:"text"`
+	Location *Location   `json:"location"`
+}
+
+func newExpressionValue(expr *ast.Expr, value interface{}) *ExpressionValue {
+	return &ExpressionValue{
+		Value: value,
+		Text:  string(expr.Location.Text),
+		Location: &Location{
+			Row: expr.Location.Row,
+			Col: expr.Location.Col,
+		},
+	}
+}
+
+// ResultSet represents a collection of output from Rego evaluation. An empty
+// result set represents an undefined query.
+type ResultSet []Result
+
+// Vars represents a collection of variable bindings. The keys are the variable
+// names and the values are the binding values.
+type Vars map[string]interface{}
+
+// Errors represents a collection of errors returned when evaluating Rego.
+type Errors []error
+
+func (errs Errors) Error() string {
+	if len(errs) == 0 {
+		return "no error"
+	}
+	if len(errs) == 1 {
+		return fmt.Sprintf("1 error occurred: %v", errs[0].Error())
+	}
+	buf := []string{fmt.Sprintf("%v errors occurred", len(errs))}
+	for _, err := range errs {
+		buf = append(buf, err.Error())
+	}
+	return strings.Join(buf, "\n")
+}
+
+// Rego constructs a query and can be evaluated to obtain results.
+type Rego struct {
+	query     string
+	pkg       string
+	imports   []string
+	rawInput  *interface{}
+	input     ast.Value
+	modules   []rawModule
+	compiler  *ast.Compiler
+	storage   *storage.Storage
+	termVarID int
+}
+
+// Query returns an argument that sets the Rego query.
+func Query(q string) func(r *Rego) {
+	return func(r *Rego) {
+		r.query = q
+	}
+}
+
+// Package returns an argument that sets the Rego package on the query's
+// context.
+func Package(p string) func(r *Rego) {
+	return func(r *Rego) {
+		r.pkg = p
+	}
+}
+
+// Imports returns an argument that adds a Rego import to the query's context.
+func Imports(p []string) func(r *Rego) {
+	return func(r *Rego) {
+		r.imports = append(r.imports, p...)
+	}
+}
+
+// Input returns an argument that sets the Rego input document.
+func Input(x interface{}) func(r *Rego) {
+	return func(r *Rego) {
+		r.rawInput = &x
+	}
+}
+
+// Module returns an argument that adds a Rego module.
+func Module(filename, input string) func(r *Rego) {
+	return func(r *Rego) {
+		r.modules = append(r.modules, rawModule{
+			filename: filename,
+			module:   input,
+		})
+	}
+}
+
+// Compiler returns an argument that sets the Rego compiler.
+func Compiler(c *ast.Compiler) func(r *Rego) {
+	return func(r *Rego) {
+		r.compiler = c
+	}
+}
+
+// Storage returns an argument that sets the policy engine's data storage layer.
+func Storage(s *storage.Storage) func(r *Rego) {
+	return func(r *Rego) {
+		r.storage = s
+	}
+}
+
+// New returns a new Rego object.
+func New(options ...func(*Rego)) *Rego {
+	r := &Rego{}
+
+	for _, option := range options {
+		option(r)
+	}
+
+	if r.compiler == nil {
+		r.compiler = ast.NewCompiler()
+	}
+
+	if r.storage == nil {
+		r.storage = storage.New(storage.InMemoryConfig())
+	}
+
+	return r
+}
+
+// Eval evaluates this Rego object and returns a ResultSet.
+func (r *Rego) Eval(ctx context.Context) (ResultSet, error) {
+
+	if len(r.query) == 0 {
+		return nil, fmt.Errorf("cannot evaluate empty query")
+	}
+
+	// Parse inputs
+	parsed, query, err := r.parse()
+	if err != nil {
+		return nil, err
+	}
+
+	// If the query contains expressions that consist of a single term, rewrite
+	// those expressions so that we capture the value of the term in a variable
+	// that can be included in the result.
+	for i := range query {
+		if term, ok := query[i].Terms.(*ast.Term); ok {
+			query[i].Terms = ast.Equality.Expr(term, r.generateTermVar()).Terms
+		}
+	}
+
+	// Compile inputs
+	compiled, err := r.compile(parsed, query)
+	if err != nil {
+		return nil, err
+	}
+
+	// Prepare storage layer. Transaction could be an argument in the future.
+	txn, err := r.storage.NewTransaction(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Evaluate query
+	return r.eval(ctx, compiled, txn)
+}
+
+func (r *Rego) parse() (map[string]*ast.Module, ast.Body, error) {
+	var errs Errors
+	parsed := map[string]*ast.Module{}
+
+	for _, module := range r.modules {
+		p, err := module.Parse()
+		if err != nil {
+			errs = append(errs, err)
+		}
+		parsed[module.filename] = p
+	}
+
+	query, err := ast.ParseBody(r.query)
+	if err != nil {
+		errs = append(errs, err)
+	}
+
+	if len(errs) > 0 {
+		return nil, nil, errs
+	}
+
+	return parsed, query, nil
+}
+
+func (r *Rego) compile(modules map[string]*ast.Module, query ast.Body) (ast.Body, error) {
+
+	if len(modules) > 0 {
+		r.compiler.Compile(modules)
+
+		if r.compiler.Failed() {
+			var errs Errors
+			for _, err := range r.compiler.Errors {
+				errs = append(errs, err)
+			}
+			return nil, errs
+		}
+	}
+
+	var qctx *ast.QueryContext
+
+	if r.pkg != "" {
+		pkg, err := ast.ParsePackage(fmt.Sprintf("package %v", r.pkg))
+		if err != nil {
+			return nil, err
+		}
+		qctx = qctx.WithPackage(pkg)
+	}
+
+	if len(r.imports) > 0 {
+		s := make([]string, len(r.imports))
+		for i := range r.imports {
+			s[i] = fmt.Sprintf("import %v", r.imports[i])
+		}
+		imports, err := ast.ParseImports(strings.Join(s, "\n"))
+		if err != nil {
+			return nil, err
+		}
+		qctx = qctx.WithImports(imports)
+	}
+
+	if r.rawInput != nil {
+		val, err := ast.InterfaceToValue(*r.rawInput)
+		if err != nil {
+			return nil, err
+		}
+		qctx = qctx.WithInput(val)
+		r.input = val
+	}
+
+	return r.compiler.QueryCompiler().WithContext(qctx).Compile(query)
+}
+
+func (r *Rego) eval(ctx context.Context, compiled ast.Body, txn storage.Transaction) (rs ResultSet, err error) {
+
+	t := topdown.New(ctx, compiled, r.compiler, r.storage, txn)
+
+	if r.input != nil {
+		t.Input = r.input
+	}
+
+	exprs := map[*ast.Expr]struct{}{}
+
+	err = topdown.Eval(t, func(t *topdown.Topdown) error {
+		result := newResult()
+		for key, value := range t.Vars() {
+			val, err := topdown.ValueToInterface(value, t)
+			if err != nil {
+				return err
+			}
+			if !isTermVar(key) {
+				result.Bindings[string(key)] = val
+			} else if expr := findExprForTermVar(compiled, key); expr != nil {
+				result.Expressions = append(result.Expressions, newExpressionValue(expr, val))
+				exprs[expr] = struct{}{}
+			}
+		}
+		for _, expr := range compiled {
+			if _, ok := exprs[expr]; !ok {
+				result.Expressions = append(result.Expressions, newExpressionValue(expr, true))
+			}
+		}
+		rs = append(rs, result)
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	if len(rs) == 0 {
+		return nil, nil
+	}
+
+	return rs, nil
+}
+
+func (r *Rego) generateTermVar() *ast.Term {
+	r.termVarID++
+	return ast.VarTerm(ast.WildcardPrefix + fmt.Sprintf("term%v", r.termVarID))
+}
+
+func isTermVar(v ast.Var) bool {
+	return strings.HasPrefix(string(v), ast.WildcardPrefix+"term")
+}
+
+func findExprForTermVar(query ast.Body, v ast.Var) *ast.Expr {
+	for i := range query {
+		vis := ast.NewVarVisitor()
+		ast.Walk(vis, query[i])
+		if vis.Vars().Contains(v) {
+			return query[i]
+		}
+	}
+	return nil
+}
+
+type rawModule struct {
+	filename string
+	module   string
+}
+
+func (m rawModule) Parse() (*ast.Module, error) {
+	return ast.ParseModule(m.filename, m.module)
+}


### PR DESCRIPTION
This PR adds a new top-level package to OPA: "rego". The new package provides a high-level interface for performing query evaluation. The package tries to hide the underlying usage of the ast/storage/topdown packages as much as possible.

A couple open questions:

1) What's the right API for returning results? It would be nice if this interface was future proof for features like pagination. Perhaps chan[result] would work. Perhaps we can find a good example in another project.

2) All errors should include a location. Perhaps we need a top-level errors package that defines the location interface.