### PR TITLE
Allow sets to be treated like objects/arrays

### DIFF
--- a/repl/repl_test.go
+++ b/repl/repl_test.go
@@ -619,7 +619,7 @@ func TestEvalSingleTermMultiValueSetRef(t *testing.T) {
 	// acceptable, as it should be an edge case.
 	buffer.Reset()
 	repl.OneShot(ctx, "r[_][x]")
-	expected = parseJSON(`[{"x": 5, "r[_][x]": true}, {"x": 6, "r[_][x]": true}, {"x": 0, "r[_][x]": 7}, {"x": 1, "r[_][x]": 8}]`)
+	expected = parseJSON(`[{"x": 5, "r[_][x]": 5}, {"x": 6, "r[_][x]": 6}, {"x": 0, "r[_][x]": 7}, {"x": 1, "r[_][x]": 8}]`)
 	result = parseJSON(buffer.String())
 	if !reflect.DeepEqual(result, expected) {
 		t.Fatalf("Expected %v but got: %v", expected, result)

--- a/site/examples/working-with-the-opa-repl/index.md
+++ b/site/examples/working-with-the-opa-repl/index.md
@@ -100,7 +100,7 @@ In addition to running queries, the REPL also lets you define rules:
 
 ```ruby
 > p[x] { a = [1,2,3,4], a[x] }
-> p[x], x > 1
+> p[x] > 1
 +---+
 | x |
 +---+
@@ -247,7 +247,7 @@ The REPL also understands the [Import and Package](/documentation/how-do-i-write
 
 ```ruby
 > package opa.example
-> public_servers[x], x.protocols[_] = "http"
+> public_servers[x].protocols[_] = "http"
 +-------------------------------------------------------------------+
 |                                 x                                 |
 +-------------------------------------------------------------------+

--- a/topdown/errors.go
+++ b/topdown/errors.go
@@ -76,11 +76,3 @@ func objectDocKeyTypeErr(loc *ast.Location) error {
 		Message:  "partial rule definitions must produce string values for object keys",
 	}
 }
-
-func setDereferenceTypeErr(loc *ast.Location) error {
-	return &Error{
-		Code:     TypeErr,
-		Location: loc,
-		Message:  "set documents cannot be dereferenced",
-	}
-}


### PR DESCRIPTION
In the past, topdown would bind set[x] to true. This resulted in
confusion when people attempted to write joins with set elements.

With this change, topdown treats sets like objects/arrays, except that
set[x] is bound to x. This allows users to write queries that
dereference sets just like objects and arrays.

Also, fix handling of self-joins where previously a recursive binding
could be added. The "self-join" test case was added to cover this.

Fixes #243