### PR TITLE
Add support for server-side HTTPS

### DIFF
--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -7,6 +7,7 @@ package runtime
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"fmt"
 	"io"
 	"os"
@@ -30,6 +31,10 @@ type Params struct {
 
 	// Addr is the listening address that the OPA server will bind to.
 	Addr string
+
+	// Certificate is the certificate to use in server-mode. If the certificate
+	// is nil, the server will NOT use TLS.
+	Certificate *tls.Certificate
 
 	// Eval is a string to evaluate in the REPL.
 	Eval string
@@ -150,6 +155,7 @@ func (rt *Runtime) startServer(ctx context.Context, params *Params) {
 		WithStorage(rt.Store).
 		WithAddress(params.Addr).
 		WithPersist(persist).
+		WithCertificate(params.Certificate).
 		Init(ctx)
 
 	if err != nil {

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -146,7 +146,11 @@ func (rt *Runtime) startServer(ctx context.Context, params *Params) {
 
 	persist := len(params.PolicyDir) > 0
 
-	s, err := server.New(ctx, rt.Store, params.Addr, persist)
+	s, err := server.New().
+		WithStorage(rt.Store).
+		WithAddress(params.Addr).
+		WithPersist(persist).
+		Init(ctx)
 
 	if err != nil {
 		glog.Fatalf("Error creating server: %v", err)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -876,7 +876,7 @@ func TestQueryBindingIterationError(t *testing.T) {
 		panic(err)
 	}
 
-	server, err := New(ctx, store, ":8182", false)
+	server, err := New().WithStorage(store).WithAddress(":8182").Init(ctx)
 	if err != nil {
 		panic(err)
 	}
@@ -915,7 +915,10 @@ type fixture struct {
 func newFixture(t *testing.T) *fixture {
 	ctx := context.Background()
 	store := storage.New(storage.InMemoryConfig().WithPolicyDir(policyDir))
-	server, err := New(ctx, store, ":8182", false)
+	server, err := New().
+		WithAddress(":8182").
+		WithStorage(store).
+		Init(ctx)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
With this change, OPA will listen for HTTPS connections if the `--tls-private-key-file` and `--tls-cert-file` arguments are given.

This is related to #272 