### PR TITLE
Improve request logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,6 @@ See [DEVELOPMENT.md](./docs/DEVELOPMENT.md) for development environment setup an
 - License: [Apache Version 2.0](https://raw.githubusercontent.com/open-policy-agent/opa/master/LICENSE)
 - Bugs: [Github Issues](https://github.com/open-policy-agent/opa/issues)
 - Features: [Github Issues](https://github.com/open-policy-agent/opa/issues)
-- Discussions: [![Slack Status](http://slack.openpolicyagent.org/badge.svg)](http://slack.openpolicyagent.org) [Google Groups](https://groups.google.com/forum/?hl=en#!forum/open-policy-agent)
+- Discussions: [Google Groups](https://groups.google.com/forum/?hl=en#!forum/open-policy-agent) [![Slack Status](http://slack.openpolicyagent.org/badge.svg)](http://slack.openpolicyagent.org)
 - Documentation: [Introduction](http://www.openpolicyagent.org/documentation/what-is-policy-enablement/), [Examples](http://www.openpolicyagent.org/examples/working-with-the-opa-repl/), [![GoDoc](https://godoc.org/github.com/open-policy-agent/opa?status.svg)](https://godoc.org/github.com/open-policy-agent/opa)
 - Continuous Integration: [![Build Status](https://travis-ci.org/open-policy-agent/opa.svg?branch=master)](https://travis-ci.org/open-policy-agent/opa) [![Go Report Card](https://goreportcard.com/badge/open-policy-agent/opa)](https://goreportcard.com/report/open-policy-agent/opa)

--- a/runtime/logging_test.go
+++ b/runtime/logging_test.go
@@ -7,7 +7,6 @@ package runtime
 import (
 	"fmt"
 	"net/url"
-	"reflect"
 	"testing"
 )
 
@@ -45,44 +44,4 @@ func TestDropInputParam(t *testing.T) {
 		t.Errorf("Expected %v but got: %v", expected, result)
 	}
 
-}
-
-func TestGetInputParam(t *testing.T) {
-
-	abc := `a.b.c:{"foo":[1,2,3,4]}`
-	def := `d.e.f:{"bar":{"baz":null}}`
-	abcEncoded := url.QueryEscape(abc)
-	defEncoded := url.QueryEscape(def)
-
-	uri, err := url.ParseRequestURI(fmt.Sprintf(`http://localhost:8181/v1/data/foo/bar?input=%v&pretty=true&input=%v`, abcEncoded, defEncoded))
-	if err != nil {
-		panic(err)
-	}
-
-	result := getInputParam(uri)
-	expected := []string{abc, def}
-
-	if !reflect.DeepEqual(result, expected) {
-		t.Errorf("Expected %v but got: %v", expected, result)
-	}
-
-	uri, err = url.ParseRequestURI(fmt.Sprintf(`http://localhost:8181/v1/data/foo?input`))
-	if err != nil {
-		panic(err)
-	}
-
-	result = getInputParam(uri)
-	if len(result) != 0 {
-		t.Errorf("Expected empty result but got: %v", result)
-	}
-
-	uri, err = url.ParseRequestURI(fmt.Sprintf(`http://localhost:8181/v1/data/foo?input=`))
-	if err != nil {
-		panic(err)
-	}
-
-	result = getInputParam(uri)
-	if len(result) != 0 {
-		t.Errorf("Expected empty result but got: %v", result)
-	}
 }


### PR DESCRIPTION
The new request logging uses httputil.DumpRequest which is much cleaner
than the old approach of trying to extract values from the request.
Also, the new approach adds a unique id on each line for correlation.

Also, move slack link around.

Fixes #281