### PR TITLE
Update docker 'latest' tagging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,6 @@ after_success:
 - if is_travis_push_env; then docker login -u $DOCKER_USER -p $DOCKER_PASSWORD; fi
 - if is_travis_push_env; then make image-quick; fi
 - if is_travis_push_env; then make push; fi
-- if is_travis_push_env; then make tag-latest; fi
-- if is_travis_push_env; then make push-latest; fi
+- if is_travis_release_env; then make tag-latest; fi
+- if is_travis_release_env; then make push-latest; fi
 - if is_travis_push_env; then make perf-regression; fi

--- a/Makefile
+++ b/Makefile
@@ -38,8 +38,10 @@ LDFLAGS := "-X github.com/open-policy-agent/opa/version.Version=$(VERSION) \
 GO15VENDOREXPERIMENT := 1
 export GO15VENDOREXPERIMENT
 
-.PHONY: all deps generate build install test perf perf-regression cover check check-fmt check-vet check-lint fmt clean \
-	release-builder push-release-builder release release-patch
+.PHONY: all build check check-fmt check-lint check-vet \
+	clean cover deps fmt generate install perf perf-regression \
+	push push-latest push-release-builder release release-builder \
+	release-patch tag-latest test version
 
 ######################################################
 #
@@ -48,6 +50,9 @@ export GO15VENDOREXPERIMENT
 ######################################################
 
 all: deps build test check
+
+version:
+	@echo $(VERSION)
 
 deps:
 	@./build/install-deps.sh

--- a/build/travis-utils.sh
+++ b/build/travis-utils.sh
@@ -6,3 +6,13 @@ function is_travis_push_env() {
     fi
     return 1
 }
+
+# Travis-CI sets TRAVIS_TAG=<tag> when the build is triggered for a tag.
+# If the tag matches the source version then we can assume this is build is
+# for a release.
+function is_travis_release_env() {
+  if [ "$TRAVIS_TAG" = "$(make version)" ]; then
+    return 0
+  fi
+  return 1
+}


### PR DESCRIPTION
Only re-tag on releases. Latest development build can still be gotten with the `:<version>-dev` tag.