### PR TITLE
Allow slash in policy id/path

### DIFF
--- a/server/server_test.go
+++ b/server/server_test.go
@@ -722,7 +722,7 @@ func TestPoliciesGetV1(t *testing.T) {
 	}
 }
 
-func TestPoliciesGetRawV1(t *testing.T) {
+func TestPoliciesGetSourceV1(t *testing.T) {
 	f := newFixture(t)
 	put := newReqV1("PUT", "/policies/1", testMod)
 	f.server.Handler.ServeHTTP(f.recorder, put)
@@ -732,7 +732,7 @@ func TestPoliciesGetRawV1(t *testing.T) {
 	}
 
 	f.reset()
-	get := newReqV1("GET", "/policies/1/raw", "")
+	get := newReqV1("GET", "/policies/1?source", "")
 
 	f.server.Handler.ServeHTTP(f.recorder, get)
 
@@ -770,6 +770,16 @@ func TestPoliciesDeleteV1(t *testing.T) {
 	f.server.Handler.ServeHTTP(f.recorder, get)
 	if f.recorder.Code != 404 {
 		t.Fatalf("Expected not found but got %v", f.recorder)
+	}
+}
+
+func TestPoliciesPathSlashes(t *testing.T) {
+	f := newFixture(t)
+	if err := f.v1("PUT", "/policies/a/b/c.rego", testMod, 200, ""); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if err := f.v1("GET", "/policies/a/b/c.rego", testMod, 200, ""); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
 	}
 }
 

--- a/server/types/types.go
+++ b/server/types/types.go
@@ -277,6 +277,14 @@ const (
 	// ParamInputV1 defines the name of the HTTP URL parameter that specifies
 	// values for the "input" document.
 	ParamInputV1 = "input"
+
+	// ParamSourceV1 defines the name of the HTTP URL parameter that indicates
+	// the client wants to receive the raw (uncompiled) version of the module.
+	ParamSourceV1 = "source"
+
+	// ParamPrettyV1 defines the name of the HTTP URL parameter that indicates
+	// the client wants to receive a pretty-printed version of the response.
+	ParamPrettyV1 = "pretty"
 )
 
 // WriteConflictErr represents an error condition raised if the caller attempts

--- a/site/_scripts/rest-examples/example1.rego
+++ b/site/_scripts/rest-examples/example1.rego
@@ -4,8 +4,9 @@ import data.servers
 import data.networks
 import data.ports
 
-public_servers[server] :-
-	server = servers[_],
-	server.ports[_] = ports[k].id,
-	ports[k].networks[_] = networks[m].id,
+public_servers[server] {
+	server = servers[_]
+	server.ports[_] = ports[k].id
+	ports[k].networks[_] = networks[m].id
 	networks[m].public = true
+}

--- a/site/_scripts/rest-examples/example2.rego
+++ b/site/_scripts/rest-examples/example2.rego
@@ -2,7 +2,8 @@ package opa.examples
 
 import data.servers
 
-violations[server] :-
-	server = servers[_],
-	server.protocols[_] = "http",
+violations[server] {
+	server = servers[_]
+	server.protocols[_] = "http"
 	public_servers[server]
+}

--- a/site/_scripts/rest-examples/example3.rego
+++ b/site/_scripts/rest-examples/example3.rego
@@ -2,4 +2,4 @@ package opa.examples
 
 import input.example.flag
 
-allow_request :- flag = true
+allow_request { flag = true }

--- a/site/_scripts/rest-examples/example4.rego
+++ b/site/_scripts/rest-examples/example4.rego
@@ -2,8 +2,10 @@ package opa.examples
 
 import input.container
 
-allow_container :-
+allow_container {
     not seccomp_unconfined
+}
 
-seccomp_unconfined :-
+seccomp_unconfined {
     container.HostConfig.SecurityOpt[_] = "seccomp:unconfined"
+}

--- a/site/_scripts/rest-examples/gen-examples.sh
+++ b/site/_scripts/rest-examples/gen-examples.sh
@@ -15,7 +15,7 @@ function main() {
     # execute each of the examples from the reference
     list_policies
     get_a_policy
-    get_a_raw_policy
+    get_a_policy_source
     create_or_update_a_policy
     delete_a_policy
     get_a_document
@@ -40,10 +40,10 @@ function get_a_policy() {
     echo ""
 }
 
-function get_a_raw_policy() {
-    echo "### Get a Raw Policy"
+function get_a_policy_source() {
+    echo "#### Example Request For Source"
     echo ""
-    curl $BASE_URL/policies/example1/raw -s -v
+    curl $BASE_URL/policies/example1?source=true -s -v
     echo ""
 }
 

--- a/site/documentation/references/deployments/index.md
+++ b/site/documentation/references/deployments/index.md
@@ -64,9 +64,10 @@ curl -i localhost:8181/
 #### Logging
 
 OPA focuses on providing debugging support through well-defined APIs and
-whenever possible, OPA returns detailed, structured error messages to clients.
-By default, OPA only emits log messages in response to critical internal events.
-When OPA is healthy, the log stream is quiet.
+detailed error messages in response to client requests.
+
+Log verbosity can be increased to provide debugging information about API
+requests and responses.
 
 The `--v=N` flag controls log verbosity:
 
@@ -78,7 +79,7 @@ The `--v=N` flag controls log verbosity:
 With response logging enabled, API response metadata is logged:
 
 ```
-I0308 20:20:16.107720       1 logging.go:43] 172.17.0.1:57000 GET /v1/policies 200 18 0.821549ms
+I0311 18:54:17.110689       1 logging.go:60] rid=1: 172.17.0.1:60944 PUT /v1/policies/test 200 3683 4.601334ms
 ```
 
 These log messages include:

--- a/site/documentation/references/rest/index.md
+++ b/site/documentation/references/rest/index.md
@@ -597,29 +597,13 @@ Content-Type: application/json
 }
 ```
 
-#### Status Codes
-
-- **200** - no error
-- **404** - not found
-- **500** - server error
-
-### Get a Raw Policy
-
-```
-GET /v1/policies/<id>/raw
-```
-
-Get a raw policy module.
-
-Returns the raw policy module content that was sent by the client when the policy was created or last updated.
-
-#### Example Request
+#### Example Request For Source
 
 ```http
-GET /v1/policies/example1/raw HTTP/1.1
+GET /v1/policies/example1?source=true HTTP/1.1
 ```
 
-#### Example Response
+#### Example Response For Source
 
 ```http
 HTTP/1.1 200 OK
@@ -640,6 +624,11 @@ public_servers[server] {
 	networks[m].public = true
 }
 ```
+
+#### Query Parameters
+
+- **source** - If `true` the response will contain the raw source instead of
+  the AST.
 
 #### Status Codes
 


### PR DESCRIPTION
As part of this change, the /policies/{id}/raw API has been removed in
favour of a "source" query parameter. When GET
/policies/{id}?source=true is received, the server returns the
raw/source of the policy.

Also, cleaned up handling of boolean query params.

Fixes #292