### PR TITLE
Initial type checking implementation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ PACKAGES := \
 	github.com/open-policy-agent/opa/server/.../ \
 	github.com/open-policy-agent/opa/storage/.../ \
 	github.com/open-policy-agent/opa/topdown/.../ \
+	github.com/open-policy-agent/opa/types/.../ \
 	github.com/open-policy-agent/opa/util/.../ \
 	github.com/open-policy-agent/opa/test/.../
 

--- a/ast/builtins.go
+++ b/ast/builtins.go
@@ -4,6 +4,8 @@
 
 package ast
 
+import "github.com/open-policy-agent/opa/types"
+
 // Builtins is the registry of built-in functions supported by OPA.
 // Call RegisterBuiltin to add a new built-in.
 var Builtins []*Builtin
@@ -62,9 +64,12 @@ var BuiltinMap map[Var]*Builtin
 
 // Equality represents the "=" operator.
 var Equality = &Builtin{
-	Name:      Var("eq"),
-	Infix:     Var("="),
-	NumArgs:   2,
+	Name:  Var("eq"),
+	Infix: Var("="),
+	Args: []types.Type{
+		types.A,
+		types.A,
+	},
 	TargetPos: []int{0, 1},
 }
 
@@ -74,37 +79,52 @@ var Equality = &Builtin{
 
 // GreaterThan represents the ">" comparison operator.
 var GreaterThan = &Builtin{
-	Name:    Var("gt"),
-	Infix:   Var(">"),
-	NumArgs: 2,
+	Name:  Var("gt"),
+	Infix: Var(">"),
+	Args: []types.Type{
+		types.A,
+		types.A,
+	},
 }
 
 // GreaterThanEq represents the ">=" comparison operator.
 var GreaterThanEq = &Builtin{
-	Name:    Var("gte"),
-	Infix:   Var(">="),
-	NumArgs: 2,
+	Name:  Var("gte"),
+	Infix: Var(">="),
+	Args: []types.Type{
+		types.A,
+		types.A,
+	},
 }
 
 // LessThan represents the "<" comparison operator.
 var LessThan = &Builtin{
-	Name:    Var("lt"),
-	Infix:   Var("<"),
-	NumArgs: 2,
+	Name:  Var("lt"),
+	Infix: Var("<"),
+	Args: []types.Type{
+		types.A,
+		types.A,
+	},
 }
 
 // LessThanEq represents the "<=" comparison operator.
 var LessThanEq = &Builtin{
-	Name:    Var("lte"),
-	Infix:   Var("<="),
-	NumArgs: 2,
+	Name:  Var("lte"),
+	Infix: Var("<="),
+	Args: []types.Type{
+		types.A,
+		types.A,
+	},
 }
 
 // NotEqual represents the "!=" comparison operator.
 var NotEqual = &Builtin{
-	Name:    Var("neq"),
-	Infix:   Var("!="),
-	NumArgs: 2,
+	Name:  Var("neq"),
+	Infix: Var("!="),
+	Args: []types.Type{
+		types.A,
+		types.A,
+	},
 }
 
 /**
@@ -113,48 +133,70 @@ var NotEqual = &Builtin{
 
 // Plus adds two numbers together.
 var Plus = &Builtin{
-	Name:      Var("plus"),
-	Infix:     Var("+"),
-	NumArgs:   3,
+	Name:  Var("plus"),
+	Infix: Var("+"),
+	Args: []types.Type{
+		types.N,
+		types.N,
+		types.N,
+	},
 	TargetPos: []int{2},
 }
 
 // Minus subtracts the second number from the first number or computes the diff
 // between two sets.
 var Minus = &Builtin{
-	Name:      Var("minus"),
-	Infix:     Var("-"),
-	NumArgs:   3,
+	Name:  Var("minus"),
+	Infix: Var("-"),
+	Args: []types.Type{
+		types.NewAny(types.N, types.NewSet(types.A)),
+		types.NewAny(types.N, types.NewSet(types.A)),
+		types.NewAny(types.N, types.NewSet(types.A)),
+	},
 	TargetPos: []int{2},
 }
 
 // Multiply multiplies two numbers together.
 var Multiply = &Builtin{
-	Name:      Var("mul"),
-	Infix:     Var("*"),
-	NumArgs:   3,
+	Name:  Var("mul"),
+	Infix: Var("*"),
+	Args: []types.Type{
+		types.N,
+		types.N,
+		types.N,
+	},
 	TargetPos: []int{2},
 }
 
 // Divide divides the first number by the second number.
 var Divide = &Builtin{
-	Name:      Var("div"),
-	Infix:     Var("/"),
-	NumArgs:   3,
+	Name:  Var("div"),
+	Infix: Var("/"),
+	Args: []types.Type{
+		types.N,
+		types.N,
+		types.N,
+	},
 	TargetPos: []int{2},
 }
 
 // Round rounds the number up to the nearest integer.
 var Round = &Builtin{
-	Name:      Var("round"),
-	NumArgs:   2,
+	Name: Var("round"),
+	Args: []types.Type{
+		types.N,
+		types.N,
+	},
 	TargetPos: []int{1},
 }
 
 // Abs returns the number without its sign.
 var Abs = &Builtin{
-	Name:      Var("abs"),
-	NumArgs:   2,
+	Name: Var("abs"),
+	Args: []types.Type{
+		types.N,
+		types.N,
+	},
 	TargetPos: []int{1},
 }
 
@@ -162,20 +204,29 @@ var Abs = &Builtin{
  * Binary
  */
 
-// And performs a binary AND operation on numbers and an intersection operation
-// on sets.
+// TODO(tsandall): update binary operators to support integers.
+
+// And performs an intersection operation on sets.
 var And = &Builtin{
-	Name:      Var("and"),
-	Infix:     Var("&"),
-	NumArgs:   3,
+	Name:  Var("and"),
+	Infix: Var("&"),
+	Args: []types.Type{
+		types.NewSet(types.A),
+		types.NewSet(types.A),
+		types.NewSet(types.A),
+	},
 	TargetPos: []int{2},
 }
 
-// Or performs a binary OR operation on numbers and a union operation on sets.
+// Or performs a union operation on sets.
 var Or = &Builtin{
-	Name:      Var("or"),
-	Infix:     Var("|"),
-	NumArgs:   3,
+	Name:  Var("or"),
+	Infix: Var("|"),
+	Args: []types.Type{
+		types.NewSet(types.A),
+		types.NewSet(types.A),
+		types.NewSet(types.A),
+	},
 	TargetPos: []int{2},
 }
 
@@ -183,24 +234,44 @@ var Or = &Builtin{
  * Aggregates
  */
 
-// Count takes a collection and counts the number of elements in it.
+// Count takes a collection or string and counts the number of elements in it.
 var Count = &Builtin{
-	Name:      Var("count"),
-	NumArgs:   2,
+	Name: Var("count"),
+	Args: []types.Type{
+		types.NewAny(
+			types.NewSet(types.A),
+			types.NewArray(nil, types.A),
+			types.NewObject(nil, types.A),
+			types.S,
+		),
+		types.N,
+	},
 	TargetPos: []int{1},
 }
 
-// Sum takes an array of numbers and sums them.
+// Sum takes an array or set of numbers and sums them.
 var Sum = &Builtin{
-	Name:      Var("sum"),
-	NumArgs:   2,
+	Name: Var("sum"),
+	Args: []types.Type{
+		types.NewAny(
+			types.NewSet(types.N),
+			types.NewArray(nil, types.N),
+		),
+		types.N,
+	},
 	TargetPos: []int{1},
 }
 
 // Max returns the maximum value in a collection.
 var Max = &Builtin{
-	Name:      Var("max"),
-	NumArgs:   2,
+	Name: Var("max"),
+	Args: []types.Type{
+		types.NewAny(
+			types.NewSet(types.A),
+			types.NewArray(nil, types.A),
+		),
+		types.A,
+	},
 	TargetPos: []int{1},
 }
 
@@ -212,8 +283,16 @@ var Max = &Builtin{
 // Strings are converted to numbers using strconv.Atoi.
 // Boolean false is converted to 0 and boolean true is converted to 1.
 var ToNumber = &Builtin{
-	Name:      Var("to_number"),
-	NumArgs:   2,
+	Name: Var("to_number"),
+	Args: []types.Type{
+		types.NewAny(
+			types.N,
+			types.S,
+			types.B,
+			types.NewNull(),
+		),
+		types.N,
+	},
 	TargetPos: []int{1},
 }
 
@@ -224,72 +303,110 @@ var ToNumber = &Builtin{
 // RegexMatch takes two strings and evaluates to true if the string in the second
 // position matches the pattern in the first position.
 var RegexMatch = &Builtin{
-	Name:    Var("re_match"),
-	NumArgs: 2,
+	Name: Var("re_match"),
+	Args: []types.Type{
+		types.S,
+		types.S,
+	},
 }
 
 /**
  * Strings
  */
 
-// Concat joins an array of strings to with an input string.
+// Concat joins an array of strings with an input string.
 var Concat = &Builtin{
-	Name:      Var("concat"),
-	NumArgs:   3,
+	Name: Var("concat"),
+	Args: []types.Type{
+		types.S,
+		types.NewAny(
+			types.NewSet(types.S),
+			types.NewArray(nil, types.S),
+		),
+		types.S,
+	},
 	TargetPos: []int{2},
 }
 
 // FormatInt returns the string representation of the number in the given base after converting it to an integer value.
 var FormatInt = &Builtin{
-	Name:      Var("format_int"),
-	NumArgs:   3,
+	Name: Var("format_int"),
+	Args: []types.Type{
+		types.N,
+		types.N,
+		types.S,
+	},
 	TargetPos: []int{2},
 }
 
 // IndexOf returns the index of a substring contained inside a string
 var IndexOf = &Builtin{
-	Name:      Var("indexof"),
-	NumArgs:   3,
+	Name: Var("indexof"),
+	Args: []types.Type{
+		types.S,
+		types.S,
+		types.N,
+	},
 	TargetPos: []int{2},
 }
 
 // Substring returns the portion of a string for a given start index and a length.
 //   If the length is less than zero, then substring returns the remainder of the string.
 var Substring = &Builtin{
-	Name:      Var("substring"),
-	NumArgs:   4,
+	Name: Var("substring"),
+	Args: []types.Type{
+		types.S,
+		types.N,
+		types.N,
+		types.S,
+	},
 	TargetPos: []int{3},
 }
 
 // Contains returns true if the search string is included in the base string
 var Contains = &Builtin{
-	Name:    Var("contains"),
-	NumArgs: 2,
+	Name: Var("contains"),
+	Args: []types.Type{
+		types.S,
+		types.S,
+	},
 }
 
 // StartsWith returns true if the search string begins with the base string
 var StartsWith = &Builtin{
-	Name:    Var("startswith"),
-	NumArgs: 2,
+	Name: Var("startswith"),
+	Args: []types.Type{
+		types.S,
+		types.S,
+	},
 }
 
 // EndsWith returns true if the search string begins with the base string
 var EndsWith = &Builtin{
-	Name:    Var("endswith"),
-	NumArgs: 2,
+	Name: Var("endswith"),
+	Args: []types.Type{
+		types.S,
+		types.S,
+	},
 }
 
 // Lower returns the input string but with all characters in lower-case
 var Lower = &Builtin{
-	Name:      Var("lower"),
-	NumArgs:   2,
+	Name: Var("lower"),
+	Args: []types.Type{
+		types.S,
+		types.S,
+	},
 	TargetPos: []int{1},
 }
 
 // Upper returns the input string but with all characters in upper-case
 var Upper = &Builtin{
-	Name:      Var("upper"),
-	NumArgs:   2,
+	Name: Var("upper"),
+	Args: []types.Type{
+		types.S,
+		types.S,
+	},
 	TargetPos: []int{1},
 }
 
@@ -299,15 +416,21 @@ var Upper = &Builtin{
 
 // JSONMarshal serializes the input term.
 var JSONMarshal = &Builtin{
-	Name:      Var("json_marshal"),
-	NumArgs:   2,
+	Name: Var("json_marshal"),
+	Args: []types.Type{
+		types.A,
+		types.S,
+	},
 	TargetPos: []int{1},
 }
 
 // JSONUnmarshal deserializes the input string.
 var JSONUnmarshal = &Builtin{
-	Name:      Var("json_unmarshal"),
-	NumArgs:   2,
+	Name: Var("json_unmarshal"),
+	Args: []types.Type{
+		types.S,
+		types.A,
+	},
 	TargetPos: []int{1},
 }
 
@@ -317,18 +440,22 @@ var JSONUnmarshal = &Builtin{
 
 // SetDiff has been replaced by the minus built-in.
 var SetDiff = &Builtin{
-	Name:      Var("set_diff"),
-	NumArgs:   3,
+	Name: Var("set_diff"),
+	Args: []types.Type{
+		types.NewSet(types.A),
+		types.NewSet(types.A),
+		types.NewSet(types.A),
+	},
 	TargetPos: []int{2},
 }
 
 // Builtin represents a built-in function supported by OPA. Every
 // built-in function is uniquely identified by a name.
 type Builtin struct {
-	Name      Var   // Unique name of built-in function, e.g., <Name>(term,term,...,term)
-	Infix     Var   // Unique name of infix operator. Default should be unset.
-	NumArgs   int   // Total number of args required by built-in.
-	TargetPos []int // Argument positions that bind outputs. Indexing is zero-based.
+	Name      Var          // Unique name of built-in function, e.g., <Name>(term,term,...,term)
+	Infix     Var          // Unique name of infix operator. Default should be unset.
+	Args      []types.Type // Built-in argument type declaration.
+	TargetPos []int        // Argument positions that bind outputs. Indexing is zero-based.
 }
 
 // Expr creates a new expression for the built-in with the given terms.

--- a/ast/builtins_test.go
+++ b/ast/builtins_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 )
 
-func TestUnifies(t *testing.T) {
-	b := &Builtin{Name: Var("dummy"), NumArgs: 4, TargetPos: []int{1, 3}}
+func TestIsTargetPos(t *testing.T) {
+	b := &Builtin{Name: Var("dummy"), TargetPos: []int{1, 3}}
 	expected := []int{1, 3}
 	result := []int{}
 	for i := 0; i < 4; i++ {

--- a/ast/check.go
+++ b/ast/check.go
@@ -1,0 +1,680 @@
+// Copyright 2017 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package ast
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/open-policy-agent/opa/types"
+)
+
+// exprChecker defines the interface for executing type checking on a single
+// expression. The exprChecker must update the provided TypeEnv with inferred
+// types of vars.
+type exprChecker func(*TypeEnv, *Expr) *Error
+
+// typeChecker implements type checking on queries and rules. Errors are
+// accumulated on the typeChecker so that a single run can report multiple
+// issues.
+type typeChecker struct {
+	errs         Errors
+	exprCheckers map[Var]exprChecker
+}
+
+// newTypeChecker returns a new typeChecker object that has no errors.
+func newTypeChecker() *typeChecker {
+	tc := &typeChecker{}
+	tc.exprCheckers = map[Var]exprChecker{
+		Equality.Name: tc.checkExprEq,
+	}
+	return tc
+}
+
+// CheckBody runs type checking on the body and returns a TypeEnv if no errors
+// are found. The resulting TypeEnv wraps the provided one. The resulting
+// TypeEnv will be able to resolve types of vars contained in the body.
+func (tc *typeChecker) CheckBody(env *TypeEnv, body Body) (*TypeEnv, Errors) {
+
+	if env == nil {
+		env = NewTypeEnv()
+	} else {
+		env = env.wrap()
+	}
+
+	WalkExprs(body, func(expr *Expr) bool {
+
+		vis := newRefChecker(env)
+		Walk(vis, expr)
+		for _, err := range vis.errs {
+			tc.err(err)
+		}
+
+		if err := tc.checkExpr(env, expr); err != nil {
+			tc.err(err)
+		}
+		return false
+	})
+
+	return env, tc.errs
+}
+
+// CheckRules runs type checking on the rules and returns a TypeEnv if no
+// errors are found. The resulting TypeEnv wraps the provided one. The
+// resulting TypeEnv will be able to resolve types of refs that refer to rules.
+func (tc *typeChecker) CheckRules(env *TypeEnv, rules []*Rule) (*TypeEnv, Errors) {
+
+	if env == nil {
+		env = NewTypeEnv()
+	} else {
+		env.wrap()
+	}
+
+	for _, rule := range rules {
+		cpy, err := tc.CheckBody(env, rule.Body)
+
+		if len(err) == 0 {
+
+			path := rule.Path()
+			var tpe types.Type
+
+			switch rule.Head.DocKind() {
+			case CompleteDoc:
+				typeV := cpy.Get(rule.Head.Value)
+				if typeV != nil {
+					exist := env.tree.Get(path)
+					tpe = types.Or(typeV, exist)
+				}
+			case PartialObjectDoc:
+				// TODO(tsandall): partial object keys require 'optional' support
+				// in types.Object. For now, treat partial objects as having
+				// dynamic keys where the value type is constrained.
+				typeV := cpy.Get(rule.Head.Value)
+				if typeV != nil {
+					exist := env.tree.Get(path)
+					typeV = types.Or(types.Values(exist), typeV)
+					tpe = types.NewObject(nil, typeV)
+				}
+			case PartialSetDoc:
+				typeK := cpy.Get(rule.Head.Key)
+				if typeK != nil {
+					exist := env.tree.Get(path)
+					typeK = types.Or(types.Keys(exist), typeK)
+					tpe = types.NewSet(typeK)
+				}
+			}
+			if tpe != nil {
+				env.tree.Put(path, tpe)
+			}
+		}
+	}
+
+	return env, tc.errs
+}
+
+func (tc *typeChecker) checkExpr(env *TypeEnv, expr *Expr) *Error {
+
+	if !expr.IsBuiltin() {
+		return nil
+	}
+
+	bi := expr.Builtin()
+	if bi == nil {
+		return NewError(TypeErr, expr.Location, "undefined built-in function")
+	}
+
+	checker := tc.exprCheckers[bi.Name]
+	if checker != nil {
+		return checker(env, expr)
+	}
+
+	return tc.checkExprBuiltin(env, bi, expr)
+}
+
+func (tc *typeChecker) checkExprEq(env *TypeEnv, expr *Expr) *Error {
+
+	a, b := expr.Operand(0), expr.Operand(1)
+	typeA, typeB := env.Get(a), env.Get(b)
+
+	if !tc.unify2(env, a, typeA, b, typeB) {
+		err := NewError(TypeErr, expr.Location, "match error")
+		err.Details = &UnificationErrDetail{
+			Left:  typeA,
+			Right: typeB,
+		}
+		return err
+	}
+
+	return nil
+}
+
+func (tc *typeChecker) checkExprBuiltin(env *TypeEnv, bi *Builtin, expr *Expr) *Error {
+
+	args := expr.Operands()
+
+	pre := make([]types.Type, len(args))
+	for i := range args {
+		pre[i] = env.Get(args[i])
+	}
+
+	if len(args) < len(bi.Args) {
+		return newArgError(expr.Location, bi.Name, "too few arguments", pre, bi.Args)
+	} else if len(args) > len(bi.Args) {
+		return newArgError(expr.Location, bi.Name, "too many arguments", pre, bi.Args)
+	}
+
+	for i := range args {
+		if !tc.unify1(env, args[i], bi.Args[i]) {
+			post := make([]types.Type, len(args))
+			for i := range args {
+				post[i] = env.Get(args[i])
+			}
+			return newArgError(expr.Location, bi.Name, "invalid argument(s)", post, bi.Args)
+		}
+	}
+
+	return nil
+}
+
+func (tc *typeChecker) unify2(env *TypeEnv, a *Term, typeA types.Type, b *Term, typeB types.Type) bool {
+
+	nilA := types.Nil(typeA)
+	nilB := types.Nil(typeB)
+
+	if nilA && !nilB {
+		return tc.unify1(env, a, typeB)
+	} else if nilB && !nilA {
+		return tc.unify1(env, b, typeA)
+	} else if !nilA && !nilB {
+		return unifies(typeA, typeB)
+	}
+
+	switch a := a.Value.(type) {
+	case Array:
+		switch b := b.Value.(type) {
+		case Array:
+			if len(a) == len(b) {
+				for i := range a {
+					if !tc.unify2(env, a[i], env.Get(a[i]), b[i], env.Get(b[i])) {
+						return false
+					}
+				}
+				return true
+			}
+		}
+	case Object:
+		switch b := b.Value.(type) {
+		case Object:
+			c := a.Intersect(b)
+			if len(a) == len(b) && len(b) == len(c) {
+				for i := range c {
+					if !tc.unify2(env, c[i][1], env.Get(c[i][1]), c[i][2], env.Get(c[i][2])) {
+						return false
+					}
+				}
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func (tc *typeChecker) unify1(env *TypeEnv, term *Term, tpe types.Type) bool {
+	switch v := term.Value.(type) {
+	case Array:
+		switch tpe := tpe.(type) {
+		case *types.Array:
+			return tc.unify1Array(env, v, tpe)
+		case types.Any:
+			if types.Compare(tpe, types.A) == 0 {
+				for i := range v {
+					tc.unify1(env, v[i], types.A)
+				}
+				return true
+			}
+			unifies := false
+			for i := range tpe {
+				unifies = tc.unify1(env, term, tpe[i]) || unifies
+			}
+			return unifies
+		}
+		return false
+	case Object:
+		switch tpe := tpe.(type) {
+		case *types.Object:
+			return tc.unify1Object(env, v, tpe)
+		case types.Any:
+			if types.Compare(tpe, types.A) == 0 {
+				for i := range v {
+					tc.unify1(env, v[i][1], types.A)
+				}
+				return true
+			}
+			unifies := false
+			for i := range tpe {
+				unifies = tc.unify1(env, term, tpe[i]) || unifies
+			}
+			return unifies
+		}
+		return false
+	case *Set:
+		switch tpe := tpe.(type) {
+		case *types.Set:
+			return tc.unify1Set(env, v, tpe)
+		case types.Any:
+			if types.Compare(tpe, types.A) == 0 {
+				v.Iter(func(elem *Term) bool {
+					tc.unify1(env, elem, types.A)
+					return true
+				})
+				return true
+			}
+			unifies := false
+			for i := range tpe {
+				unifies = tc.unify1(env, term, tpe[i]) || unifies
+			}
+			return unifies
+		}
+		return false
+	case *ArrayComprehension:
+		return unifies(env.Get(v), tpe)
+	case Ref:
+		return unifies(env.Get(v), tpe)
+	case Var:
+		if exist := env.Get(v); exist != nil {
+			return unifies(exist, tpe)
+		}
+		env.tree.PutOne(term.Value, tpe)
+		return true
+	default:
+		if !IsConstant(v) {
+			panic("unreachable")
+		}
+		return unifies(env.Get(term), tpe)
+	}
+}
+
+func (tc *typeChecker) unify1Array(env *TypeEnv, val Array, tpe *types.Array) bool {
+	if len(val) != tpe.Len() && tpe.Dynamic() == nil {
+		return false
+	}
+	for i := range val {
+		if !tc.unify1(env, val[i], tpe.Select(i)) {
+			return false
+		}
+	}
+	return true
+}
+
+func (tc *typeChecker) unify1Object(env *TypeEnv, val Object, tpe *types.Object) bool {
+	if len(val) != len(tpe.Keys()) && tpe.Dynamic() == nil {
+		return false
+	}
+	for i := range val {
+		if child := selectConstant(tpe, val[i][0]); child != nil {
+			if !tc.unify1(env, val[i][1], child) {
+				return false
+			}
+		} else {
+			return false
+		}
+	}
+	return true
+}
+
+func (tc *typeChecker) unify1Set(env *TypeEnv, val *Set, tpe *types.Set) bool {
+	of := types.Values(tpe)
+	return !val.Iter(func(elem *Term) bool {
+		return !tc.unify1(env, elem, of)
+	})
+}
+
+func (tc *typeChecker) err(err *Error) {
+	tc.errs = append(tc.errs, err)
+}
+
+type refChecker struct {
+	env  *TypeEnv
+	errs Errors
+}
+
+func newRefChecker(env *TypeEnv) *refChecker {
+	return &refChecker{
+		env:  env,
+		errs: nil,
+	}
+}
+
+func (rc *refChecker) Visit(x interface{}) Visitor {
+	switch x := x.(type) {
+	case *ArrayComprehension:
+		return nil
+	case Ref:
+		if err := rc.checkRef(rc.env, rc.env.tree, x, 0); err != nil {
+			rc.errs = append(rc.errs, err)
+		}
+	}
+	return rc
+}
+
+func (rc *refChecker) checkRef(curr *TypeEnv, node *typeTreeNode, ref Ref, idx int) *Error {
+
+	if idx == len(ref) {
+		return nil
+	}
+
+	head := ref[idx]
+
+	// Handle constant ref operands, i.e., strings or the ref head.
+	if _, ok := head.Value.(String); ok || idx == 0 {
+
+		child := node.Child(head.Value)
+		if child == nil {
+			return rc.checkRefNext(curr, ref)
+		}
+
+		if child.Leaf() {
+			return rc.checkRefLeaf(child.Value(), ref, idx+1)
+		}
+
+		return rc.checkRef(curr, child, ref, idx+1)
+	}
+
+	// Handle dynamic ref operands.
+	switch value := head.Value.(type) {
+
+	case Var:
+
+		if exist := rc.env.Get(value); exist != nil {
+			if !unifies(types.S, exist) {
+				return newRefError(ref[0].Location, ref, idx, nil, exist)
+			}
+		} else {
+			rc.env.tree.PutOne(value, types.S)
+		}
+
+	case Ref:
+
+		exist := rc.env.Get(value)
+		if exist == nil {
+			// If ref type is unknown, an error will already be reported so
+			// stop here.
+			return nil
+		}
+
+		if !unifies(types.S, exist) {
+			return newRefError(ref[0].Location, ref, idx, nil, exist)
+		}
+
+	// Catch other ref operand types here. Non-leaf nodes must be referred to
+	// with string values.
+	default:
+		return newRefError(ref[0].Location, ref, idx, nil, rc.env.Get(value))
+	}
+
+	// Run checking on remaining portion of the ref. Note, since the ref
+	// potentially refers to data for which no type information exists,
+	// checking should never fail.
+	for _, child := range node.Children() {
+		rc.checkRef(curr, child, ref, idx+1)
+	}
+
+	return nil
+}
+
+func (rc *refChecker) checkRefLeaf(tpe types.Type, ref Ref, idx int) *Error {
+
+	if idx == len(ref) {
+		return nil
+	}
+
+	head := ref[idx]
+
+	keys := types.Keys(tpe)
+	if keys == nil {
+		return newRefError(ref[0].Location, ref, idx, tpe, nil)
+	}
+
+	switch value := head.Value.(type) {
+
+	case Var:
+		if exist := rc.env.Get(value); exist != nil {
+			if !unifies(exist, keys) {
+				return newRefError(ref[0].Location, ref, idx, tpe, exist)
+			}
+		} else {
+			rc.env.tree.PutOne(value, types.Keys(tpe))
+		}
+
+	case Ref:
+		if exist := rc.env.Get(value); exist != nil {
+			if !unifies(exist, keys) {
+				return newRefError(ref[0].Location, ref, idx, tpe, exist)
+			}
+		}
+
+	default:
+		child := selectConstant(tpe, head)
+		if child == nil {
+			return newRefError(ref[0].Location, ref, idx, tpe, nil)
+		}
+		return rc.checkRefLeaf(child, ref, idx+1)
+	}
+
+	return rc.checkRefLeaf(types.Values(tpe), ref, idx+1)
+}
+
+func (rc *refChecker) checkRefNext(curr *TypeEnv, ref Ref) *Error {
+
+	if curr.next != nil {
+		next := curr.next
+		return rc.checkRef(next, next.tree, ref, 0)
+	}
+
+	if RootDocumentNames.Contains(ref[0]) {
+		return rc.checkRefLeaf(types.A, ref, 0)
+	}
+
+	panic("unreachable")
+}
+
+func unifies(a, b types.Type) bool {
+
+	if a == nil || b == nil {
+		return false
+	}
+
+	if anyA, ok := a.(types.Any); ok {
+		return unifiesAny(anyA, b)
+	}
+
+	if anyB, ok := b.(types.Any); ok {
+		return unifiesAny(anyB, a)
+	}
+
+	switch a := a.(type) {
+	case types.Null:
+		_, ok := b.(types.Null)
+		return ok
+	case types.Boolean:
+		_, ok := b.(types.Boolean)
+		return ok
+	case types.Number:
+		_, ok := b.(types.Number)
+		return ok
+	case types.String:
+		_, ok := b.(types.String)
+		return ok
+	case *types.Array:
+		b, ok := b.(*types.Array)
+		if !ok {
+			return false
+		}
+		return unifiesArrays(a, b)
+	case *types.Object:
+		b, ok := b.(*types.Object)
+		if !ok {
+			return false
+		}
+		return unifiesObjects(a, b)
+	case *types.Set:
+		b, ok := b.(*types.Set)
+		if !ok {
+			return false
+		}
+		return unifies(types.Values(a), types.Values(b))
+	default:
+		panic("unreachable")
+	}
+}
+
+func unifiesAny(a types.Any, b types.Type) bool {
+	if types.Compare(a, types.A) == 0 {
+		return true
+	}
+	for i := range a {
+		if unifies(a[i], b) {
+			return true
+		}
+	}
+	return false
+}
+
+func unifiesArrays(a, b *types.Array) bool {
+
+	if !unifiesArraysStatic(a, b) {
+		return false
+	}
+
+	if !unifiesArraysStatic(b, a) {
+		return false
+	}
+
+	return a.Dynamic() == nil || b.Dynamic() == nil || unifies(a.Dynamic(), b.Dynamic())
+}
+
+func unifiesArraysStatic(a, b *types.Array) bool {
+	if a.Len() != 0 {
+		for i := 0; i < a.Len(); i++ {
+			if !unifies(a.Select(i), b.Select(i)) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func unifiesObjects(a, b *types.Object) bool {
+	if !unifiesObjectsStatic(a, b) {
+		return false
+	}
+
+	if !unifiesObjectsStatic(b, a) {
+		return false
+	}
+
+	return a.Dynamic() == nil || b.Dynamic() == nil || unifies(a.Dynamic(), b.Dynamic())
+}
+
+func unifiesObjectsStatic(a, b *types.Object) bool {
+	for _, k := range a.Keys() {
+		if !unifies(a.Select(k), b.Select(k)) {
+			return false
+		}
+	}
+	return true
+}
+
+// ArgErrDetail represents a generic argument error.
+type ArgErrDetail struct {
+	Have []types.Type `json:"have"`
+	Want []types.Type `json:"want"`
+}
+
+// Lines returns the string representation of the detail.
+func (d *ArgErrDetail) Lines() []string {
+	lines := make([]string, 2)
+	lines[0] = fmt.Sprint("have : ", formatArgs(d.Have))
+	lines[1] = fmt.Sprint("want : ", formatArgs(d.Want))
+	return lines
+}
+
+// UnificationErrDetail represents a type mismatch error when two **values**
+// are unified (as in x = y).
+type UnificationErrDetail struct {
+	Left  types.Type `json:"a"`
+	Right types.Type `json:"b"`
+}
+
+// Lines returns the string representation of the detail.
+func (a *UnificationErrDetail) Lines() []string {
+	lines := make([]string, 2)
+	lines[0] = fmt.Sprint("left  : ", types.Sprint(a.Left))
+	lines[1] = fmt.Sprint("right : ", types.Sprint(a.Right))
+	return lines
+}
+
+// RefErrDetail represents an undefined ref.
+type RefErrDetail struct {
+	Ref      Ref        `json:"ref"`
+	Index    int        `json:"index"`
+	Refers   types.Type `json:"refers"`
+	Referrer types.Type `json:"referrer"`
+}
+
+// Lines returns the string representation of the detail.
+func (r *RefErrDetail) Lines() []string {
+	lines := []string{}
+	lines = append(lines, fmt.Sprintf("prefix    : %v (valid)", r.Ref[:r.Index]))
+	if r.Refers != nil {
+		lines = append(lines, fmt.Sprintf("refers to : %v", r.Refers))
+	}
+	tail := r.Ref[r.Index:]
+	var str string
+	if len(tail) == 1 {
+		switch v := tail[0].Value.(type) {
+		case String:
+			str = formatString(v)
+		default:
+			str = v.String()
+		}
+	} else {
+		str = tail.String()
+	}
+	lines = append(lines, fmt.Sprintf("suffix    : %v (invalid)", str))
+	if r.Referrer != nil {
+		lines = append(lines, fmt.Sprintf("refers to : %v", r.Referrer))
+	}
+	return lines
+}
+
+func formatArgs(args []types.Type) string {
+	buf := make([]string, len(args))
+	for i := range args {
+		buf[i] = types.Sprint(args[i])
+	}
+	return "(" + strings.Join(buf, ", ") + ")"
+}
+
+func newRefError(loc *Location, ref Ref, idx int, refers, referrer types.Type) *Error {
+	err := NewError(TypeErr, loc, "undefined ref: %v", ref)
+	err.Details = &RefErrDetail{
+		Ref:      ref,
+		Index:    idx,
+		Refers:   refers,
+		Referrer: referrer,
+	}
+	return err
+}
+
+func newArgError(loc *Location, builtinName Var, msg string, have []types.Type, want []types.Type) *Error {
+	err := NewError(TypeErr, loc, "%v: %v", builtinName, msg)
+	err.Details = &ArgErrDetail{
+		Have: have,
+		Want: want,
+	}
+	return err
+}

--- a/ast/check_test.go
+++ b/ast/check_test.go
@@ -1,0 +1,610 @@
+// Copyright 2017 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package ast
+
+import (
+	"testing"
+
+	"github.com/open-policy-agent/opa/types"
+	"github.com/open-policy-agent/opa/util/test"
+)
+
+func TestCheckInference(t *testing.T) {
+
+	// fake_builtin_1([str1,str2])
+	RegisterBuiltin(&Builtin{
+		Name: Var("fake_builtin_1"),
+		Args: []types.Type{
+			types.NewArray(
+				[]types.Type{types.S, types.S}, nil,
+			),
+		},
+		TargetPos: []int{0},
+	})
+
+	// fake_builtin_2({"a":str1,"b":str2})
+	RegisterBuiltin(&Builtin{
+		Name: Var("fake_builtin_2"),
+		Args: []types.Type{
+			types.NewObject(
+				[]*types.Property{
+					{"a", types.S},
+					{"b", types.S},
+				}, nil,
+			),
+		},
+		TargetPos: []int{0},
+	})
+
+	// fake_builtin_3({str1,str2,...})
+	RegisterBuiltin(&Builtin{
+		Name: Var("fake_builtin_3"),
+		Args: []types.Type{
+			types.NewSet(types.S),
+		},
+		TargetPos: []int{0},
+	})
+
+	tests := []struct {
+		note     string
+		query    string
+		expected map[Var]types.Type
+	}{
+		{"trivial", `x = 1`, map[Var]types.Type{
+			Var("x"): types.N,
+		}},
+		{"one-level", "y = 1; x = y", map[Var]types.Type{
+			Var("x"): types.N,
+			Var("y"): types.N,
+		}},
+		{"two-level", "z = 1; y = z; x = y", map[Var]types.Type{
+			Var("x"): types.N,
+			Var("y"): types.N,
+			Var("z"): types.N,
+		}},
+		{"array-nested", "[x, 1] = [true, y]", map[Var]types.Type{
+			Var("x"): types.B,
+			Var("y"): types.N,
+		}},
+		{"array-transitive", "y = [[2], 1]; [[x], 1] = y", map[Var]types.Type{
+			Var("x"): types.N,
+			Var("y"): types.NewArray(
+				[]types.Type{
+					types.NewArray([]types.Type{types.N}, nil),
+					types.N,
+				}, nil),
+		}},
+		{"array-embedded", `[1, "2", x] = data.foo`, map[Var]types.Type{
+			Var("x"): types.A,
+		}},
+		{"object-nested", `{"a": "foo", "b": {"c": x}} = {"a": y, "b": {"c": 2}}`, map[Var]types.Type{
+			Var("x"): types.N,
+			Var("y"): types.S,
+		}},
+		{"object-transitive", `y = {"a": "foo", "b": 2}; {"a": z, "b": x} = y`, map[Var]types.Type{
+			Var("x"): types.N,
+			Var("z"): types.S,
+		}},
+		{"object-embedded", `{"1": "2", "2": x} = data.foo`, map[Var]types.Type{
+			Var("x"): types.A,
+		}},
+		{"sets", `x = {1, 2}; y = {{"foo", 1}, x}`, map[Var]types.Type{
+			Var("x"): types.NewSet(types.N),
+			Var("y"): types.NewSet(
+				types.NewAny(
+					types.NewSet(
+						types.NewAny(types.N, types.S),
+					),
+					types.NewSet(
+						types.N,
+					),
+				),
+			),
+		}},
+		{"sets-nested", `{"a", 1, 2} = {1,2,3}`, nil},
+		{"empty-composites", `
+				obj = {};
+				arr = [];
+				set = set();
+				obj[i] = v1;
+				arr[j] = v2;
+				set[v3];
+				obj = {"foo": "bar"}
+				arr = [1];
+				set = {1,2,3}
+				`, map[Var]types.Type{
+			Var("obj"): types.NewObject(nil, types.A),
+			Var("i"):   types.S,
+			Var("v1"):  types.A,
+			Var("arr"): types.NewArray(nil, types.A),
+			Var("j"):   types.N,
+			Var("v2"):  types.A,
+			Var("set"): types.NewSet(types.A),
+			Var("v3"):  types.A,
+		}},
+		{"empty-composite-property", `
+			obj = {};
+			obj.foo = x;
+			obj[i].foo = y
+		`, map[Var]types.Type{
+			Var("x"): types.A,
+			Var("y"): types.A,
+		}},
+		{"local-reference", `
+			a = [
+				1,
+				{
+					"foo": [
+						{"bar": null},
+						-1,
+						{"bar": true}
+					]
+				},
+				3];
+
+			x = a[1].foo[_].bar`, map[Var]types.Type{
+			Var("x"): types.NewAny(types.NewNull(), types.B),
+		}},
+		{"local-reference-var", `
+
+			a = [
+				{
+					"a": null,
+					"b": {
+						"foo": {
+							"c": {1,},
+						},
+						"bar": {
+							"c": {"hello",},
+						},
+					},
+				},
+				{
+					"a": null,
+					"b": {
+						"foo": {
+							"c": {1,},
+						},
+						"bar": {
+							"c": {true,},
+						},
+					},
+				},
+			];
+			x = a[i].b[j].c[k]
+			`, map[Var]types.Type{
+			Var("i"): types.N,
+			Var("j"): types.S,
+			Var("k"): types.NewAny(types.S, types.N, types.B),
+			Var("x"): types.NewAny(types.S, types.N, types.B),
+		}},
+		{"local-reference-var-any", `
+			a = [[], {}];
+			a[_][i]
+		`, map[Var]types.Type{
+			Var("i"): types.NewAny(types.S, types.N),
+		}},
+		{"local-reference-nested", `
+			a = [["foo"], 0, {"bar": "baz"}, 2];
+			b = [0,1,2,3];
+			a[b[_]][k] = v
+			`, map[Var]types.Type{
+			Var("k"): types.NewAny(types.S, types.N),
+		}},
+		{"simple-built-in", "x = 1 + 2", map[Var]types.Type{
+			Var("x"): types.N,
+		}},
+		{"simple-built-in-exists", "x = 1 + 2; y = x + 2", map[Var]types.Type{
+			Var("x"): types.N,
+			Var("y"): types.N,
+		}},
+		{"array-builtin", `fake_builtin_1([x,"foo"])`, map[Var]types.Type{
+			Var("x"): types.S,
+		}},
+		{"object-builtin", `fake_builtin_2({"a": "foo", "b": x})`, map[Var]types.Type{
+			Var("x"): types.S,
+		}},
+		{"set-builtin", `fake_builtin_3({"foo", x})`, map[Var]types.Type{
+			Var("x"): types.S,
+		}},
+		{"array-comprehension-ref-closure", `a = [1,"foo",3]; x = [ i | a[_] = i ]`, map[Var]types.Type{
+			Var("x"): types.NewArray(nil, types.NewAny(types.N, types.S)),
+		}},
+		{"array-comprehension-var-closure", `x = 1; y = [ i | x = i ]`, map[Var]types.Type{
+			Var("y"): types.NewArray(nil, types.N),
+		}},
+	}
+
+	for _, tc := range tests {
+		test.Subtest(t, tc.note, func(t *testing.T) {
+			body := MustParseBody(tc.query)
+			checker := newTypeChecker()
+			env, err := checker.CheckBody(nil, body)
+			if len(err) != 0 {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			for k, tpe := range tc.expected {
+				result := env.Get(k)
+				if tpe == nil {
+					if result != nil {
+						t.Errorf("Expected %v type to be unset but got: %v", k, result)
+					}
+				} else {
+					if result == nil {
+						t.Errorf("Expected to infer %v => %v but got nil", k, tpe)
+					} else if types.Compare(tpe, result) != 0 {
+						t.Errorf("Expected to infer %v => %v but got %v", k, tpe, result)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestCheckInferenceRules(t *testing.T) {
+
+	// Rules must have refs resolved, safe ordering, etc. Each pair is a
+	// (package path, rule) tuple. The test constructs the Rule objects to
+	// run the inference on from these inputs.
+	ruleset1 := [][2]string{
+		{`a`, `trivial = true { true }`},
+		{`a`, `complete = [{"foo": x}] { x = 1 }`},
+		{`a`, `partialset[{"foo": x}] { y = "bar"; x = y }`},
+		{`a`, `partialobj[x] = {"foo": y} { y = "bar"; x = y }`},
+		{`b`, `trivial_ref = x { x = data.a.trivial }`},
+		{`b`, `transitive_ref = [x] { y = data.b.trivial_ref; x = y }`},
+		{`iteration`, `arr = [[1], ["two"], {"x": true}, ["four"]] { true }`},
+		{`iteration`, `values[x] { data.iteration.arr[_][_] = x } `},
+		{`iteration`, `keys[i] { data.iteration.arr[_][i] = _ } `},
+		{`disjunction`, `partialset[1] { true }`},
+		{`disjunction`, `partialset[x] { x = "foo" }`},
+		{`disjunction`, `partialset[3] { true }`},
+		{`disjunction`, `partialobj[x] = y { y = "bar"; x = "foo" }`},
+		{`disjunction`, `partialobj[x] = y { y = 100; x = "foo" }`},
+		{`disjunction`, `complete = 1 { true }`},
+		{`disjunction`, `complete = x { x = "foo" }`},
+		{`prefix.a.b.c`, `d = true { true }`},
+		{`prefix.i.j.k`, `p = 1 { true }`},
+		{`prefix.i.j.k`, `p = "foo" { true }`},
+		{`default_rule`, `default x = 1`},
+		{`default_rule`, `x = "foo" { true }`},
+		{`unknown_type`, `p = [x] { x = data.deadbeef }`},
+		{`nested_ref`, `inner = {"a": 0, "b": "1"} { true }`},
+		{`nested_ref`, `middle = [[1, true], ["foo", false]] { true }`},
+		{`nested_ref`, `p = x { data.nested_ref.middle[data.nested_ref.inner.a][0] = x }`},
+		{`number_key`, `q[x] = y { a = ["a", "b"]; y = a[x] }`},
+		{`non_leaf`, `p[x] { data.prefix.i[x][_] }`},
+	}
+
+	tests := []struct {
+		note     string
+		rules    [][2]string
+		ref      string
+		expected types.Type
+	}{
+		{"trivial", ruleset1, `data.a.trivial`, types.B},
+
+		{"complete-doc", ruleset1, `data.a.complete`, types.NewArray(
+			[]types.Type{types.NewObject(
+				[]*types.Property{{
+					"foo", types.N,
+				}},
+				nil,
+			)},
+			nil,
+		)},
+
+		{"complete-doc-suffix", ruleset1, `data.a.complete[0].foo`, types.N},
+
+		{"partial-set-doc", ruleset1, `data.a.partialset`, types.NewSet(
+			types.NewObject(
+				[]*types.Property{{
+					"foo", types.S,
+				}},
+				nil,
+			),
+		)},
+
+		{"partial-object-doc", ruleset1, "data.a.partialobj", types.NewObject(
+			nil,
+			types.NewObject(
+				[]*types.Property{{
+					"foo", types.S,
+				}},
+				nil,
+			),
+		)},
+
+		{"partial-object-doc-suffix", ruleset1, `data.a.partialobj.somekey.foo`, types.S},
+
+		{"partial-object-doc-number-suffix", ruleset1, "data.number_key.q[1]", types.S},
+
+		{"iteration", ruleset1, "data.iteration.values", types.NewSet(
+			types.NewAny(
+				types.S,
+				types.N,
+				types.B),
+		)},
+
+		{"iteration-keys", ruleset1, "data.iteration.keys", types.NewSet(
+			types.NewAny(
+				types.S,
+				types.N,
+			),
+		)},
+
+		{"disj-complete-doc", ruleset1, "data.disjunction.complete", types.NewAny(
+			types.S,
+			types.N,
+		)},
+
+		{"disj-partial-set-doc", ruleset1, "data.disjunction.partialset", types.NewSet(
+			types.NewAny(
+				types.S,
+				types.N),
+		)},
+
+		{"disj-partial-obj-doc", ruleset1, "data.disjunction.partialobj", types.NewObject(
+			nil,
+			types.NewAny(
+				types.S,
+				types.N),
+		)},
+
+		{"ref", ruleset1, "data.b.trivial_ref", types.B},
+
+		{"ref-transitive", ruleset1, "data.b.transitive_ref", types.NewArray(
+			[]types.Type{
+				types.B,
+			},
+			nil,
+		)},
+
+		{"prefix", ruleset1, `data.prefix.a.b`, types.NewObject(
+			[]*types.Property{{
+				"c", types.NewObject(
+					[]*types.Property{{
+						"d", types.B,
+					}},
+					types.A,
+				),
+			}},
+			types.A,
+		)},
+
+		// Check that prefixes that iterate fallback to any.
+		{"prefix-iter", ruleset1, `data.prefix.i.j[k]`, types.A},
+
+		// Check that iteration targetting a rule (but nonetheless prefixed) falls back to any.
+		{"prefix-iter-2", ruleset1, `data.prefix.i.j[k].p`, types.A},
+
+		{"default-rule", ruleset1, "data.default_rule.x", types.NewAny(
+			types.S,
+			types.N,
+		)},
+
+		{"unknown-type", ruleset1, "data.unknown_type.p", types.NewArray(
+			[]types.Type{
+				types.A,
+			},
+			nil,
+		)},
+
+		{"nested-ref", ruleset1, "data.nested_ref.p", types.NewAny(
+			types.S,
+			types.N,
+		)},
+
+		{"non-leaf", ruleset1, "data.non_leaf.p", types.NewSet(
+			types.S,
+		)},
+	}
+
+	for _, tc := range tests {
+		test.Subtest(t, tc.note, func(t *testing.T) {
+			rules := make([]*Rule, len(tc.rules))
+
+			// Convert test rules into rule slice for call.
+			for i := range tc.rules {
+				pkg := MustParsePackage(`package ` + tc.rules[i][0])
+				rule := MustParseRule(tc.rules[i][1])
+				module := &Module{
+					Package: pkg,
+					Rules:   []*Rule{rule},
+				}
+				rule.Module = module
+				rules[i] = rule
+			}
+
+			ref := MustParseRef(tc.ref)
+			checker := newTypeChecker()
+			env, err := checker.CheckRules(nil, rules)
+
+			if err != nil {
+				t.Fatalf("Unexpected error %v:", err)
+			}
+
+			result := env.Get(ref)
+			if tc.expected == nil {
+				if result != nil {
+					t.Errorf("Expected %v type to be unset but got: %v", ref, result)
+				}
+			} else {
+				if result == nil {
+					t.Errorf("Expected to infer %v => %v but got nil", ref, tc.expected)
+				} else if types.Compare(tc.expected, result) != 0 {
+					t.Errorf("Expected to infer %v => %v but got %v", ref, tc.expected, result)
+				}
+			}
+		})
+	}
+
+}
+
+func TestCheckBadBuiltin(t *testing.T) {
+	body := MustParseBody(`bad_builtin()`)
+	tc := newTypeChecker()
+	_, err := tc.CheckBody(nil, body)
+	if len(err) != 1 || err[0].Code != TypeErr {
+		t.Fatalf("Expected type error from %v but got: %v", body, err)
+	}
+}
+
+func TestCheckBadCardinality(t *testing.T) {
+	body := MustParseBody("plus(1,2); plus(1,2,3,4)")
+	tc := newTypeChecker()
+	_, err := tc.CheckBody(nil, body)
+	if len(err) != 2 || err[0].Code != TypeErr || err[1].Code != TypeErr {
+		t.Fatalf("Expected 2 type errors from %v but got: %v", body, err)
+	}
+	detail, ok := err[1].Details.(*ArgErrDetail)
+	if !ok {
+		t.Fatalf("Expected argument error details but got: %v", err)
+	}
+	expected := []types.Type{
+		types.N,
+		types.N,
+		types.N,
+		types.N,
+	}
+	if len(expected) != len(detail.Have) {
+		t.Fatalf("Expected arg types %v but got: %v", expected, detail.Have)
+	}
+	for i := range expected {
+		if types.Compare(expected[i], detail.Have[i]) != 0 {
+			t.Fatalf("Expected types for %v to be %v but got: %v", body[0], expected, detail.Have)
+		}
+	}
+}
+
+func TestCheckMatchErrors(t *testing.T) {
+	tests := []struct {
+		note  string
+		query string
+	}{
+		{"null", "{ null = true }"},
+		{"boolean", "{ true = null }"},
+		{"number", "{ 1 = null }"},
+		{"string", `{ "hello" = null }`},
+		{"array", "{[1,2,3] = null}"},
+		{"array-nested", `{[1,2,3] = [1,2,"3"]}`},
+		{"array-nested-2", `{[1,2] = [1,2,3]}`},
+		{"array-dynamic", `{ [ true | true ] = [x | a = [1, "foo"]; x = a[_]] }`},
+		{"object", `{{"a": 1, "b": 2} = null}`},
+		{"object-nested", `{ {"a": 1, "b": "2"} = {"a": 1, "b": 2} }`},
+		{"object-nested-2", `{ {"a": 1} = {"a": 1, "b": "2"} }`},
+		{"object-dynamic", `{ obj2 = obj1 }`},
+		{"set", "{{1,2,3} = null}"},
+	}
+
+	for _, tc := range tests {
+		test.Subtest(t, tc.note, func(t *testing.T) {
+			body := MustParseBody(tc.query)
+			checker := newTypeChecker()
+			_, err := checker.CheckBody(nil, body)
+			if len(err) != 1 {
+				t.Fatalf("Expected exactly one error from %v, but got:\n%v", body, err)
+			}
+		})
+	}
+
+}
+
+func TestCheckBuiltinErrors(t *testing.T) {
+
+	RegisterBuiltin(&Builtin{
+		Name: Var("fake_builtin_2"),
+		Args: []types.Type{
+			types.NewAny(types.NewObject(
+				[]*types.Property{
+					{"a", types.S},
+					{"b", types.S},
+				}, nil,
+			), types.NewObject(
+				[]*types.Property{
+					{"b", types.S},
+					{"c", types.S},
+				}, nil,
+			)),
+		},
+		TargetPos: []int{0},
+	})
+
+	tests := []struct {
+		note  string
+		query string
+	}{
+		{"trivial", "x = true + 1"},
+		{"refs", "x = [null]; y = x[0] + 1"},
+		{"array comprehensions", `sum([null | true], x)`},
+		{"arrays-any", `sum([1,2,"3",4], x)`},
+		{"arrays-bad-input", `contains([1,2,3], "x")`},
+		{"objects-any", `fake_builtin_2({"a": a, "c": c})`},
+		{"objects-bad-input", `sum({"a": 1, "b": 2}, x)`},
+		{"sets-any", `sum({1,2,"3",4}, x)`},
+	}
+
+	for _, tc := range tests {
+		test.Subtest(t, tc.note, func(t *testing.T) {
+			body := MustParseBody(tc.query)
+			checker := newTypeChecker()
+			_, err := checker.CheckBody(nil, body)
+			if len(err) != 1 {
+				t.Fatalf("Expected exactly one error from %v but got:\n%v", body, err)
+			}
+		})
+	}
+}
+
+func TestCheckRefErrors(t *testing.T) {
+
+	module := MustParseModule(`
+		package test
+	`)
+
+	rs := []string{
+		`scalar = 1 { true }`,
+		`obj = {"foo": 1, "bar": 2} { true }`,
+		`nested = {"foo": [1,2,3]} { true }`,
+		`set[1] { true }`,
+	}
+
+	rules := make([]*Rule, len(rs))
+	for i := range rules {
+		rules[i] = MustParseRule(rs[i])
+		rules[i].Module = module
+	}
+
+	env, err := newTypeChecker().CheckRules(nil, rules)
+	if len(err) > 0 {
+		t.Fatalf("Unexpected error in rules: %v", err)
+	}
+
+	tests := []struct {
+		note  string
+		input string
+	}{
+		{"trivial", "{ data.test.obj.deadbeef }"},
+		{"trivial-2", "{ data.test.obj.foo.deadbeef }"},
+		{"non-leaf-var", `{ x = null; data.test[x] }`},
+		{"non-leaf-ref", `{ x = [1]; data.test[x[0]] }`},
+		{"non-leaf-nested-ref", `{ x = ["a"]; data.test[x[1]] }`},
+		{"non-leaf-invalid", `{ data.test[100] }`},
+		{"leaf-ref", `{ x = {"foo": 1}; data.test.obj[x.foo] }`},
+		{"leaf-var", `{ x = 1; data.test.obj[x] }`},
+		{"repeat", `{ data.test.nested[x][x] }`},
+		{"scalar", `{ data.test.scalar[x] }`},
+	}
+
+	for _, tc := range tests {
+		test.Subtest(t, tc.note, func(t *testing.T) {
+			body := MustParseBody(tc.input)
+			_, err := newTypeChecker().CheckBody(env, body)
+			if len(err) != 1 {
+				t.Fatalf("Expected exactly one error but got: %v", err)
+			}
+		})
+	}
+}

--- a/ast/compile.go
+++ b/ast/compile.go
@@ -1009,9 +1009,9 @@ func (bc *builtinChecker) Visit(x interface{}) Visitor {
 	case *Expr:
 		if ts, ok := x.Terms.([]*Term); ok {
 			if bi, ok := BuiltinMap[ts[0].Value.(Var)]; ok {
-				if bi.NumArgs != len(ts[1:]) {
+				if len(bi.Args) != len(ts[1:]) {
 					msg := "built-in function %v takes exactly %v arguments but got %v"
-					bc.err(TypeErr, x.Location, msg, ts[0], bi.NumArgs, len(ts[1:]))
+					bc.err(TypeErr, x.Location, msg, ts[0], len(bi.Args), len(ts[1:]))
 				}
 			} else {
 				msg := "unknown built-in function %v"

--- a/ast/compile.go
+++ b/ast/compile.go
@@ -367,12 +367,15 @@ func (c *Compiler) checkBuiltins() {
 // checkRecursion ensures that there are no recursive rule definitions, i.e., there are
 // no cycles in the RuleGraph.
 func (c *Compiler) checkRecursion() {
+	eq := func(a, b util.T) bool {
+		return a.(*Rule) == b.(*Rule)
+	}
 	for r := range c.RuleGraph {
 		t := &ruleGraphTraveral{
 			graph:   c.RuleGraph,
 			visited: map[*Rule]struct{}{},
 		}
-		if p := util.DFS(t, r, r); len(p) > 0 {
+		if p := util.DFSPath(t, eq, r, r); len(p) > 0 {
 			n := []string{}
 			for _, x := range p {
 				n = append(n, string(x.(*Rule).Head.Name))
@@ -1141,10 +1144,6 @@ func (g *ruleGraphTraveral) Visited(x util.T) bool {
 	_, ok := g.visited[u]
 	g.visited[u] = struct{}{}
 	return ok
-}
-
-func (g *ruleGraphTraveral) Equals(a, b util.T) bool {
-	return a.(*Rule) == b.(*Rule)
 }
 
 type unsafeVars map[*Expr]VarSet

--- a/ast/env.go
+++ b/ast/env.go
@@ -1,0 +1,295 @@
+// Copyright 2017 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package ast
+
+import (
+	"encoding/json"
+
+	"github.com/open-policy-agent/opa/types"
+)
+
+// TypeEnv contains type info for static analysis such as type checking.
+type TypeEnv struct {
+	tree *typeTreeNode
+	next *TypeEnv
+}
+
+// NewTypeEnv returns an empty TypeEnv.
+func NewTypeEnv() *TypeEnv {
+	return &TypeEnv{
+		tree: newTypeTree(),
+	}
+}
+
+// Get returns the type of x.
+func (env *TypeEnv) Get(x interface{}) types.Type {
+
+	if term, ok := x.(*Term); ok {
+		x = term.Value
+	}
+
+	switch x := x.(type) {
+
+	// Scalars.
+	case Null:
+		return types.NewNull()
+	case Boolean:
+		return types.NewBoolean()
+	case Number:
+		return types.NewNumber()
+	case String:
+		return types.NewString()
+
+	// Composites.
+	case Array:
+		static := make([]types.Type, len(x))
+		for i := range static {
+			tpe := env.Get(x[i].Value)
+			static[i] = tpe
+		}
+
+		var dynamic types.Type
+		if len(static) == 0 {
+			dynamic = types.A
+		}
+
+		return types.NewArray(static, dynamic)
+
+	case Object:
+		static := []*types.Property{}
+		// TODO(tsandall): handle non-string keys?
+		for _, pair := range x {
+			if k, ok := pair[0].Value.(String); ok {
+				tpe := env.Get(pair[1].Value)
+				static = append(static, types.NewProperty(string(k), tpe))
+			}
+		}
+
+		var dynamic types.Type
+		if len(static) == 0 {
+			dynamic = types.A
+		}
+
+		return types.NewObject(static, dynamic)
+
+	case *Set:
+		var tpe types.Type
+		x.Iter(func(elem *Term) bool {
+			other := env.Get(elem.Value)
+			tpe = types.Or(tpe, other)
+			return false
+		})
+		if tpe == nil {
+			tpe = types.A
+		}
+		return types.NewSet(tpe)
+
+	// Comprehensions.
+	case *ArrayComprehension:
+
+		checker := newTypeChecker()
+		cpy, errs := checker.CheckBody(env, x.Body)
+		if len(errs) == 0 {
+			return types.NewArray(nil, cpy.Get(x.Term))
+		}
+
+		return nil
+
+	// Refs.
+	case Ref:
+		return env.getRef(x)
+
+	// Vars.
+	case Var:
+		if node := env.tree.Child(x); node != nil {
+			return node.Value()
+		}
+		if env.next != nil {
+			return env.next.Get(x)
+		}
+		return nil
+
+	default:
+		panic("unreachable")
+	}
+}
+
+func (env *TypeEnv) getRef(ref Ref) types.Type {
+
+	node := env.tree.Child(ref[0].Value)
+	if node == nil {
+		return env.getRefFallback(ref)
+	}
+
+	return env.getRefRec(node, ref, ref[1:])
+}
+
+func (env *TypeEnv) getRefFallback(ref Ref) types.Type {
+
+	if env.next != nil {
+		return env.next.Get(ref)
+	}
+
+	if RootDocumentNames.Contains(ref[0]) {
+		return types.A
+	}
+
+	return nil
+}
+
+func (env *TypeEnv) getRefRec(node *typeTreeNode, ref, tail Ref) types.Type {
+
+	if len(tail) == 0 {
+		return env.getRefRecExtent(node)
+	}
+
+	if node.Leaf() {
+		return selectRef(node.Value(), tail)
+	}
+
+	if !IsConstant(tail[0].Value) {
+		return selectRef(env.getRefRecExtent(node), tail)
+	}
+
+	child := node.Child(tail[0].Value)
+	if child == nil {
+		return env.getRefFallback(ref)
+	}
+
+	return env.getRefRec(child, ref, tail[1:])
+}
+
+func (env *TypeEnv) getRefRecExtent(node *typeTreeNode) types.Type {
+
+	if node.Leaf() {
+		return node.Value()
+	}
+
+	children := []*types.Property{}
+
+	for key, child := range node.Children() {
+		tpe := env.getRefRecExtent(child)
+		// TODO(tsandall): handle non-string keys?
+		if s, ok := key.(String); ok {
+			children = append(children, types.NewProperty(string(s), tpe))
+		}
+	}
+
+	// TODO(tsandall): for now, these objects can have any dynamic properties
+	// because we don't have schema for base docs. Once schemas are supported
+	// we can improve this.
+	return types.NewObject(children, types.A)
+}
+
+func (env *TypeEnv) wrap() *TypeEnv {
+	cpy := *env
+	cpy.next = env
+	cpy.tree = newTypeTree()
+	return &cpy
+}
+
+// typeTreeNode is used to store type information in a tree.
+type typeTreeNode struct {
+	key      Value
+	value    types.Type
+	children map[Value]*typeTreeNode
+}
+
+func newTypeTree() *typeTreeNode {
+	return &typeTreeNode{
+		key:      nil,
+		value:    nil,
+		children: map[Value]*typeTreeNode{},
+	}
+}
+
+func (n *typeTreeNode) Child(key Value) *typeTreeNode {
+	return n.children[key]
+}
+
+func (n *typeTreeNode) Children() map[Value]*typeTreeNode {
+	return n.children
+}
+
+func (n *typeTreeNode) Get(path Ref) types.Type {
+	curr := n
+	for _, term := range path {
+		child, ok := curr.children[term.Value]
+		if !ok {
+			return nil
+		}
+		curr = child
+	}
+	return curr.Value()
+}
+
+func (n *typeTreeNode) Leaf() bool {
+	return n.value != nil
+}
+
+func (n *typeTreeNode) PutOne(key Value, tpe types.Type) {
+	child, ok := n.children[key]
+	if !ok {
+		child = newTypeTree()
+		child.key = key
+		n.children[key] = child
+	}
+	child.value = tpe
+}
+
+func (n *typeTreeNode) Put(path Ref, tpe types.Type) {
+	curr := n
+	for _, term := range path {
+		child, ok := curr.children[term.Value]
+		if !ok {
+			child = newTypeTree()
+			child.key = term.Value
+			curr.children[child.key] = child
+		}
+		curr = child
+	}
+	curr.value = tpe
+}
+
+func (n *typeTreeNode) Value() types.Type {
+	return n.value
+}
+
+// selectConstant returns the attribute of the type referred to by the term. If
+// the attribute type cannot be determined, nil is returned.
+func selectConstant(tpe types.Type, term *Term) types.Type {
+	switch v := term.Value.(type) {
+	case String:
+		return types.Select(tpe, string(v))
+	case Number:
+		return types.Select(tpe, json.Number(v))
+	case Boolean:
+		return types.Select(tpe, bool(v))
+	case Null:
+		return types.Select(tpe, nil)
+	default:
+		return nil
+	}
+}
+
+// selectRef returns the type of the nested attribute referred to by ref. If
+// the attribute type cannot be determined, nil is returned. If the ref
+// contains vars or refs, then the returned type will be a union of the
+// possible types.
+func selectRef(tpe types.Type, ref Ref) types.Type {
+
+	if tpe == nil || len(ref) == 0 {
+		return tpe
+	}
+
+	head, tail := ref[0], ref[1:]
+
+	switch head.Value.(type) {
+	case Var, Ref:
+		return selectRef(types.Values(tpe), tail)
+	default:
+		return selectRef(selectConstant(tpe, head), tail)
+	}
+}

--- a/ast/errors.go
+++ b/ast/errors.go
@@ -60,11 +60,17 @@ func IsError(code string, err error) bool {
 	return false
 }
 
+// ErrorDetails defines the interface for detailed error messages.
+type ErrorDetails interface {
+	Lines() []string
+}
+
 // Error represents a single error caught during parsing, compiling, etc.
 type Error struct {
-	Code     string    `json:"code"`
-	Message  string    `json:"message"`
-	Location *Location `json:"location,omitempty"`
+	Code     string       `json:"code"`
+	Message  string       `json:"message"`
+	Location *Location    `json:"location,omitempty"`
+	Details  ErrorDetails `json:"details,omitempty"`
 }
 
 func (e *Error) Error() string {
@@ -84,6 +90,12 @@ func (e *Error) Error() string {
 
 	if len(prefix) > 0 {
 		msg = prefix + ": " + msg
+	}
+
+	if e.Details != nil {
+		for _, line := range e.Details.Lines() {
+			msg += "\n\t" + line
+		}
 	}
 
 	return msg

--- a/ast/parser_ext.go
+++ b/ast/parser_ext.go
@@ -119,7 +119,7 @@ func MustParseTerm(input string) *Term {
 // ParseRuleFromBody attempts to return a rule from a body. Equality expressions
 // of the form <var> = <term> can be converted into rules of the form <var> =
 // <term> { true }. This is a concise way of defining constants inside modules.
-func ParseRuleFromBody(body Body) (*Rule, error) {
+func ParseRuleFromBody(module *Module, body Body) (*Rule, error) {
 
 	if len(body) != 1 {
 		return nil, fmt.Errorf("multiple %vs cannot be used for %v", ExprTypeName, HeadTypeName)
@@ -159,6 +159,7 @@ func ParseRuleFromBody(body Body) (*Rule, error) {
 		Body: NewBody(
 			&Expr{Terms: BooleanTerm(true)},
 		),
+		Module: module,
 	}
 
 	return rule, nil
@@ -382,9 +383,10 @@ func parseModule(stmts []Statement) (*Module, error) {
 		case *Import:
 			mod.Imports = append(mod.Imports, stmt)
 		case *Rule:
+			stmt.Module = mod
 			mod.Rules = append(mod.Rules, stmt)
 		case Body:
-			rule, err := ParseRuleFromBody(stmt)
+			rule, err := ParseRuleFromBody(mod, stmt)
 			if err != nil {
 				errs = append(errs, NewError(ParseErr, stmt[0].Location, err.Error()))
 			} else {

--- a/ast/parser_test.go
+++ b/ast/parser_test.go
@@ -845,6 +845,28 @@ func TestWildcards(t *testing.T) {
 		)))
 }
 
+func TestRuleModulePtr(t *testing.T) {
+	mod := `package test
+
+	p { true }
+	p { true }
+	q { true }
+	r = 1
+	default s = 2
+	`
+
+	parsed, err := ParseModule("", mod)
+	if err != nil {
+		t.Fatalf("Unexpected parse error: %v", err)
+	}
+
+	for _, rule := range parsed.Rules {
+		if rule.Module != parsed {
+			t.Fatalf("Expected module ptr to be %p but got %p", parsed, rule.Module)
+		}
+	}
+}
+
 func TestNoMatchError(t *testing.T) {
 	mod := `package test
 

--- a/ast/policy.go
+++ b/ast/policy.go
@@ -781,7 +781,7 @@ func (expr *Expr) String() string {
 		bi := BuiltinMap[name]
 		var s string
 		if bi != nil && len(bi.Infix) > 0 {
-			switch bi.NumArgs {
+			switch len(bi.Args) {
 			case 2:
 				s = fmt.Sprintf("%v %v %v", t[1], bi.Infix, t[2])
 			case 3:

--- a/ast/policy.go
+++ b/ast/policy.go
@@ -129,6 +129,12 @@ type (
 		Default bool  `json:"default,omitempty"`
 		Head    *Head `json:"head"`
 		Body    Body  `json:"body"`
+
+		// Module is a pointer to the module containing this rule. If the rule
+		// was NOT created while parsing/constructing a module, this should be
+		// left unset. The pointer is not included in any standard operations
+		// on the rule (e.g., printing, comparison, visiting, etc.)
+		Module *Module `json:"-"`
 	}
 
 	// Head represents the head of a rule.
@@ -362,9 +368,13 @@ func (rule *Rule) Loc() *Location {
 	return rule.Head.Location
 }
 
-// Path returns a reference that identifies the rule under ns.
-func (rule *Rule) Path(ns Ref) Ref {
-	return ns.Append(StringTerm(string(rule.Head.Name)))
+// Path returns a ref referring to the document produced by this rule. If rule
+// is not contained in a module, this function panics.
+func (rule *Rule) Path() Ref {
+	if rule.Module == nil {
+		panic("assertion failed")
+	}
+	return rule.Module.Package.Path.Append(StringTerm(string(rule.Head.Name)))
 }
 
 func (rule *Rule) String() string {

--- a/ast/policy.go
+++ b/ast/policy.go
@@ -737,6 +737,46 @@ func (expr *Expr) IsEquality() bool {
 	return terms[0].Value.Equal(Equality.Name)
 }
 
+// IsBuiltin returns true if this expression refers to a built-in function.
+func (expr *Expr) IsBuiltin() bool {
+	_, ok := expr.Terms.([]*Term)
+	return ok
+}
+
+// Builtin returns the builtin object referred to by this expression. If the
+// expression does not refer to a built-in or the built-in is unknown, this
+// function returns nil.
+func (expr *Expr) Builtin() *Builtin {
+	terms, ok := expr.Terms.([]*Term)
+	if !ok {
+		return nil
+	}
+	return BuiltinMap[terms[0].Value.(Var)]
+}
+
+// Operand returns the term at the zero-based pos. If the expr does not include
+// at least pos+1 terms, this function returns nil.
+func (expr *Expr) Operand(pos int) *Term {
+	terms, ok := expr.Terms.([]*Term)
+	if !ok {
+		return nil
+	}
+	idx := pos + 1
+	if idx < len(terms) {
+		return terms[idx]
+	}
+	return nil
+}
+
+// Operands returns the built-in function operands.
+func (expr *Expr) Operands() []*Term {
+	terms, ok := expr.Terms.([]*Term)
+	if !ok {
+		return nil
+	}
+	return terms[1:]
+}
+
 // IsGround returns true if all of the expression terms are ground.
 func (expr *Expr) IsGround() bool {
 	switch ts := expr.Terms.(type) {

--- a/ast/term.go
+++ b/ast/term.go
@@ -1184,6 +1184,14 @@ func (ac *ArrayComprehension) String() string {
 	return "[" + ac.Term.String() + " | " + ac.Body.String() + "]"
 }
 
+func formatString(s String) string {
+	str := string(s)
+	if varRegexp.MatchString(str) {
+		return str
+	}
+	return s.String()
+}
+
 func termSliceCopy(a []*Term) []*Term {
 	cpy := make([]*Term, len(a))
 	for i := range a {

--- a/ast/term_test.go
+++ b/ast/term_test.go
@@ -215,6 +215,22 @@ func TestTermIsGround(t *testing.T) {
 
 }
 
+func TestIsConstant(t *testing.T) {
+	tests := []struct {
+		term     string
+		expected bool
+	}{
+		{`[{"foo": {true, false, [1, 2]}}]`, true},
+		{`[{"foo": {x}}]`, false},
+	}
+	for _, tc := range tests {
+		term := MustParseTerm(tc.term)
+		if IsConstant(term.Value) != tc.expected {
+			t.Fatalf("Expected IsConstant(%v) = %v", term, tc.expected)
+		}
+	}
+}
+
 func TestIsScalar(t *testing.T) {
 
 	tests := []struct {
@@ -283,6 +299,16 @@ func TestRefAppend(t *testing.T) {
 	b := a.Append(VarTerm("x"))
 	if !b.Equal(MustParseRef("foo.bar.baz[x]")) {
 		t.Error("Expected foo.bar.baz[x]")
+	}
+}
+
+func TestRefDynamic(t *testing.T) {
+	a := MustParseRef("foo.bar[baz.qux].corge")
+	if a.Dynamic() != 2 {
+		t.Fatalf("Expected dynamic offset to be baz.qux for foo.bar[baz.qux].corge")
+	}
+	if a[:a.Dynamic()].Dynamic() != -1 {
+		t.Fatalf("Expected dynamic offset to be -1 for foo.bar")
 	}
 }
 

--- a/ast/visit.go
+++ b/ast/visit.go
@@ -103,6 +103,18 @@ func WalkClosures(x interface{}, f func(interface{}) bool) {
 	Walk(vis, x)
 }
 
+// WalkExprs calls the function f on all expressions under x. If the function f
+// returns true, AST nodes under the last node will not be visited.
+func WalkExprs(x interface{}, f func(*Expr) bool) {
+	vis := &GenericVisitor{func(x interface{}) bool {
+		if r, ok := x.(*Expr); ok {
+			return f(r)
+		}
+		return false
+	}}
+	Walk(vis, x)
+}
+
 // WalkRefs calls the function f on all references under x. If the function f
 // returns true, AST nodes under the last node will not be visited.
 func WalkRefs(x interface{}, f func(Ref) bool) {

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -296,7 +296,7 @@ func (r *REPL) complete(line string) (c []string) {
 	// add virtual docs defined in repl
 	for _, mod := range r.modules {
 		for _, rule := range mod.Rules {
-			path := rule.Path(mod.Package.Path).String()
+			path := rule.Path().String()
 			if strings.HasPrefix(path, line) {
 				c = append(c, path)
 			}
@@ -308,7 +308,7 @@ func (r *REPL) complete(line string) (c []string) {
 	// add virtual docs defined by policies
 	for _, mod := range mods {
 		for _, rule := range mod.Rules {
-			path := rule.Path(mod.Package.Path).String()
+			path := rule.Path().String()
 			if strings.HasPrefix(path, line) {
 				c = append(c, path)
 			}
@@ -591,7 +591,7 @@ func (r *REPL) evalStatement(ctx context.Context, stmt interface{}) error {
 		body, err := r.compileBody(s, input)
 
 		if err != nil {
-			rule, err2 := ast.ParseRuleFromBody(s)
+			rule, err2 := ast.ParseRuleFromBody(r.modules[r.currentModuleID], s)
 			if err2 != nil {
 				// The statement cannot be understood as a rule, so the original
 				// error returned from compiling the query should be given the
@@ -601,7 +601,7 @@ func (r *REPL) evalStatement(ctx context.Context, stmt interface{}) error {
 			return r.compileRule(rule)
 		}
 
-		rule, err3 := ast.ParseRuleFromBody(body)
+		rule, err3 := ast.ParseRuleFromBody(r.modules[r.currentModuleID], body)
 		if err3 == nil {
 			return r.compileRule(rule)
 		}

--- a/topdown/example_test.go
+++ b/topdown/example_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/open-policy-agent/opa/storage"
 	"github.com/open-policy-agent/opa/topdown"
 	"github.com/open-policy-agent/opa/topdown/builtins"
+	"github.com/open-policy-agent/opa/types"
 )
 
 func ExampleEval() {
@@ -165,8 +166,11 @@ func ExampleRegisterFunctionalBuiltin1() {
 	// registry to include your built-in. Otherwise, the compiler will complain
 	// when it encounters your built-in.
 	builtin := &ast.Builtin{
-		Name:      ast.Var("selective_upper"),
-		NumArgs:   2,
+		Name: ast.Var("selective_upper"),
+		Args: []types.Type{
+			types.S,
+			types.S,
+		},
 		TargetPos: []int{1},
 	}
 

--- a/topdown/explain/explain.go
+++ b/topdown/explain/explain.go
@@ -105,7 +105,7 @@ func (t *truth) Answer() (result []*topdown.Event) {
 	}
 
 	traversal := newTruthTraversal(t)
-	nodes := util.DFS(traversal, t.source, sink)
+	nodes := util.DFSPath(traversal, traversal.Equals, t.source, sink)
 
 	for _, n := range nodes {
 		node := n.(*node)

--- a/types/types.go
+++ b/types/types.go
@@ -1,0 +1,601 @@
+// Copyright 2017 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+// Package types declares data types for Rego values and helper functions to
+// operate on these types.
+package types
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/open-policy-agent/opa/util"
+)
+
+// Sprint returns the string representation of the type.
+func Sprint(x Type) string {
+	if x == nil {
+		return "???"
+	}
+	return x.String()
+}
+
+// Type represents a type of a term in the language.
+type Type interface {
+	String() string
+}
+
+// Null represents the null type.
+type Null struct{}
+
+// NewNull returns a new Null type.
+func NewNull() Null {
+	return Null{}
+}
+
+func (t Null) String() string {
+	return "null"
+}
+
+// Boolean represents the boolean type.
+type Boolean struct{}
+
+// B represents an instance of the boolean type.
+var B = NewBoolean()
+
+// NewBoolean returns a new Boolean type.
+func NewBoolean() Boolean {
+	return Boolean{}
+}
+
+func (t Boolean) String() string {
+	return "boolean"
+}
+
+// String represents the string type.
+type String struct{}
+
+// S represents an instance of the string type.
+var S = NewString()
+
+// NewString returns a new String type.
+func NewString() String {
+	return String{}
+}
+
+func (t String) String() string {
+	return "string"
+}
+
+// Number represents the number type.
+type Number struct{}
+
+// N represents an instance of the number type.
+var N = NewNumber()
+
+// NewNumber returns a new Number type.
+func NewNumber() Number {
+	return Number{}
+}
+
+func (Number) String() string {
+	return "number"
+}
+
+// Array represents the array type.
+type Array struct {
+	static  []Type // static items
+	dynamic Type   // dynamic items
+}
+
+// NewArray returns a new Array type.
+func NewArray(static []Type, dynamic Type) *Array {
+	return &Array{
+		static:  static,
+		dynamic: dynamic,
+	}
+}
+
+func (t *Array) String() string {
+	prefix := "array"
+	buf := []string{}
+	for _, tpe := range t.static {
+		buf = append(buf, Sprint(tpe))
+	}
+	var repr = prefix
+	if len(buf) > 0 {
+		repr += "<" + strings.Join(buf, ", ") + ">"
+	}
+	if t.dynamic != nil {
+		repr += "[" + t.dynamic.String() + "]"
+	}
+	return repr
+}
+
+// Dynamic returns the type of the array's dynamic elements.
+func (t *Array) Dynamic() Type {
+	return t.dynamic
+}
+
+// Len returns the number of static array elements.
+func (t *Array) Len() int {
+	return len(t.static)
+}
+
+// Select returns the type of element at the zero-based pos.
+func (t *Array) Select(pos int) Type {
+	if len(t.static) > pos {
+		return t.static[pos]
+	}
+	if t.dynamic != nil {
+		return t.dynamic
+	}
+	return nil
+}
+
+// Set represents the set type.
+type Set struct {
+	of Type
+}
+
+// NewSet returns a new Set type.
+func NewSet(of Type) *Set {
+	return &Set{
+		of: of,
+	}
+}
+
+func (t *Set) String() string {
+	prefix := "set"
+	return prefix + "[" + Sprint(t.of) + "]"
+}
+
+// Property represents a static object property.
+type Property struct {
+	Key   interface{}
+	Value Type
+}
+
+// NewProperty returns a new Property object.
+func NewProperty(key interface{}, value Type) *Property {
+	return &Property{
+		Key:   key,
+		Value: value,
+	}
+}
+
+// Object represents the object type.
+type Object struct {
+	static  []*Property // constant properties
+	dynamic Type        // dynamic properties
+}
+
+// NewObject returns a new Object type.
+func NewObject(static []*Property, dynamic Type) *Object {
+	sort.Slice(static, func(i, j int) bool {
+		cmp := util.Compare(static[i].Key, static[j].Key)
+		return cmp == -1
+	})
+	return &Object{
+		static:  static,
+		dynamic: dynamic,
+	}
+}
+
+func (t *Object) String() string {
+	prefix := "object"
+	buf := make([]string, 0, len(t.static))
+	for _, p := range t.static {
+		buf = append(buf, fmt.Sprintf("%v: %v", p.Key, Sprint(p.Value)))
+	}
+	var repr = prefix
+	if len(buf) > 0 {
+		repr += "<" + strings.Join(buf, ", ") + ">"
+	}
+	if t.dynamic != nil {
+		repr += "[" + t.dynamic.String() + "]"
+	}
+	return repr
+}
+
+// Dynamic returns the type of the object's dynamic elements.
+func (t *Object) Dynamic() Type {
+	return t.dynamic
+}
+
+// Keys returns the keys of the object's static elements.
+func (t *Object) Keys() []interface{} {
+	sl := make([]interface{}, 0, len(t.static))
+	for _, p := range t.static {
+		sl = append(sl, p.Key)
+	}
+	return sl
+}
+
+// Select returns the type of the named property.
+func (t *Object) Select(name interface{}) Type {
+	for _, p := range t.static {
+		if util.Compare(p.Key, name) == 0 {
+			return p.Value
+		}
+	}
+	if t.dynamic != nil {
+		return t.dynamic
+	}
+	return nil
+}
+
+// Any represents a dynamic type.
+type Any []Type
+
+// A represents the superset of all types.
+var A = NewAny()
+
+// NewAny returns a new Any type.
+func NewAny(of ...Type) Any {
+	sl := make(Any, len(of))
+	for i := range sl {
+		sl[i] = of[i]
+	}
+	return sl
+}
+
+// Contains returns true if t is a superset of other.
+func (t Any) Contains(other Type) bool {
+	for i := range t {
+		if Compare(t[i], other) == 0 {
+			return true
+		}
+	}
+	return len(t) == 0
+}
+
+// Merge return a new Any type that is the superset of t and other.
+func (t Any) Merge(other Type) Any {
+	if otherAny, ok := other.(Any); ok {
+		return t.Union(otherAny)
+	}
+	if t.Contains(other) {
+		return t
+	}
+	return append(t, other)
+}
+
+// Union returns a new Any type that is the union of the two Any types.
+func (t Any) Union(other Any) Any {
+	if len(t) == 0 {
+		return t
+	}
+	if len(other) == 0 {
+		return other
+	}
+	cpy := make(Any, len(t))
+	for i := range cpy {
+		cpy[i] = t[i]
+	}
+	for i := range other {
+		if !cpy.Contains(other[i]) {
+			cpy = append(cpy, other[i])
+		}
+	}
+	return cpy
+}
+
+func (t Any) String() string {
+	prefix := "any"
+	if len(t) == 0 {
+		return prefix
+	}
+	buf := make([]string, len(t))
+	for i := range t {
+		buf[i] = Sprint(t[i])
+	}
+	return prefix + "<" + strings.Join(buf, ", ") + ">"
+}
+
+// Compare returns -1, 0, 1 based on comparison between a and b.
+func Compare(a, b Type) int {
+	x := typeOrder(a)
+	y := typeOrder(b)
+	if x > y {
+		return 1
+	} else if x < y {
+		return -1
+	}
+	switch a.(type) {
+	case nil:
+		return 0
+	case Null, Boolean, Number, String:
+		return 0
+	case *Array:
+		arrA := a.(*Array)
+		arrB := b.(*Array)
+		if arrA.dynamic != nil && arrB.dynamic == nil {
+			return 1
+		} else if arrB.dynamic != nil && arrA.dynamic == nil {
+			return -1
+		}
+		if arrB.dynamic != nil && arrA.dynamic != nil {
+			if cmp := Compare(arrA.dynamic, arrB.dynamic); cmp != 0 {
+				return cmp
+			}
+		}
+		return typeSliceCompare(arrA.static, arrB.static)
+	case *Object:
+		objA := a.(*Object)
+		objB := b.(*Object)
+		if objA.dynamic != nil && objB.dynamic == nil {
+			return 1
+		} else if objB.dynamic != nil && objA.dynamic == nil {
+			return -1
+		}
+		if objA.dynamic != nil && objB.dynamic != nil {
+			if cmp := Compare(objA.dynamic, objB.dynamic); cmp != 0 {
+				return cmp
+			}
+		}
+
+		lenStaticA := len(objA.static)
+		lenStaticB := len(objB.static)
+
+		minLen := lenStaticA
+		if lenStaticB < minLen {
+			minLen = lenStaticB
+		}
+
+		for i := 0; i < minLen; i++ {
+			if cmp := util.Compare(objA.static[i].Key, objB.static[i].Key); cmp != 0 {
+				return cmp
+			}
+			if cmp := Compare(objA.static[i].Value, objB.static[i].Value); cmp != 0 {
+				return cmp
+			}
+		}
+
+		if lenStaticA < lenStaticB {
+			return -1
+		} else if lenStaticB < lenStaticA {
+			return 1
+		}
+
+		return 0
+	case *Set:
+		setA := a.(*Set)
+		setB := b.(*Set)
+		if setA.of == nil && setB.of == nil {
+			return 0
+		} else if setA.of == nil {
+			return -1
+		} else if setB.of == nil {
+			return 1
+		}
+		return Compare(setA.of, setB.of)
+	case Any:
+		sl1 := typeSlice(a.(Any))
+		sl2 := typeSlice(b.(Any))
+		sort.Sort(sl1)
+		sort.Sort(sl2)
+		return typeSliceCompare(sl1, sl2)
+	default:
+		panic("unreachable")
+	}
+}
+
+// Or returns a type that represents the union of a and b. If one type is a
+// superset of the other, the superset is returned unchanged.
+func Or(a, b Type) Type {
+	if a == nil {
+		return b
+	} else if b == nil {
+		return a
+	}
+	anyA, ok1 := a.(Any)
+	anyB, ok2 := b.(Any)
+	if ok1 {
+		return anyA.Merge(b)
+	}
+	if ok2 {
+		return anyB.Merge(a)
+	}
+	if Compare(a, b) == 0 {
+		return a
+	}
+	return NewAny(a, b)
+}
+
+// Select returns a property or item of a.
+func Select(a Type, x interface{}) Type {
+	switch a := a.(type) {
+	case *Array:
+		n, ok := x.(json.Number)
+		if !ok {
+			return nil
+		}
+		pos, err := n.Int64()
+		if err != nil {
+			return nil
+		}
+		return a.Select(int(pos))
+	case *Object:
+		return a.Select(x)
+	case *Set:
+		tpe := TypeOf(x)
+		if Compare(a.of, tpe) == 0 {
+			return a.of
+		}
+		if any, ok := a.of.(Any); ok {
+			if any.Contains(tpe) {
+				return tpe
+			}
+		}
+		return nil
+	case Any:
+		if Compare(a, A) == 0 {
+			return A
+		}
+		var tpe Type
+		for i := range a {
+			// TODO(tsandall): test nil/nil
+			tpe = Or(Select(a[i], x), tpe)
+		}
+		return tpe
+	default:
+		return nil
+	}
+}
+
+// Keys returns the type of keys that can be enumerated for a. For arrays, the
+// keys are always number types, for objects the keys are always string types,
+// and for sets the keys are always the type of the set element.
+func Keys(a Type) Type {
+	switch a := a.(type) {
+	case *Array:
+		return N
+	case *Object:
+		return S
+	case *Set:
+		return a.of
+	case Any:
+		// TODO(tsandall): ditto test
+		if Compare(a, A) == 0 {
+			return A
+		}
+		var tpe Type
+		for i := range a {
+			tpe = Or(Keys(a[i]), tpe)
+		}
+		return tpe
+	}
+	return nil
+}
+
+// Values returns the type of values that can be enumerated for a.
+func Values(a Type) Type {
+	switch a := a.(type) {
+	case *Array:
+		var tpe Type
+		for i := range a.static {
+			tpe = Or(tpe, a.static[i])
+		}
+		return Or(tpe, a.dynamic)
+	case *Object:
+		var tpe Type
+		for _, v := range a.static {
+			tpe = Or(tpe, v.Value)
+		}
+		return Or(tpe, a.dynamic)
+	case *Set:
+		return a.of
+	case Any:
+		if Compare(a, A) == 0 {
+			return A
+		}
+		var tpe Type
+		for i := range a {
+			tpe = Or(Values(a[i]), tpe)
+		}
+		return tpe
+	}
+	return nil
+}
+
+// Nil returns true if a's type is unknown.
+func Nil(a Type) bool {
+	switch a := a.(type) {
+	case nil:
+		return true
+	case *Array:
+		for i := range a.static {
+			if Nil(a.static[i]) {
+				return true
+			}
+		}
+	case *Object:
+		for i := range a.static {
+			if Nil(a.static[i].Value) {
+				return true
+			}
+		}
+	case *Set:
+		return Nil(a.of)
+	}
+	return false
+}
+
+// TypeOf returns the type of the Golang native value.
+func TypeOf(x interface{}) Type {
+	switch x := x.(type) {
+	case nil:
+		return NewNull()
+	case bool:
+		return B
+	case string:
+		return S
+	case json.Number:
+		return N
+	case map[interface{}]interface{}:
+		static := make([]*Property, 0, len(x))
+		for k, v := range x {
+			static = append(static, NewProperty(k, TypeOf(v)))
+		}
+		return NewObject(static, nil)
+	case []interface{}:
+		static := make([]Type, len(x))
+		for i := range x {
+			static[i] = TypeOf(x[i])
+		}
+		return NewArray(static, nil)
+	}
+	panic("unreachable")
+}
+
+type typeSlice []Type
+
+func (s typeSlice) Less(i, j int) bool { return Compare(s[i], s[j]) < 0 }
+func (s typeSlice) Swap(i, j int)      { x := s[i]; s[i] = s[j]; s[j] = x }
+func (s typeSlice) Len() int           { return len(s) }
+
+func typeSliceCompare(a, b []Type) int {
+	minLen := len(a)
+	if len(b) < minLen {
+		minLen = len(b)
+	}
+	for i := 0; i < minLen; i++ {
+		if cmp := Compare(a[i], b[i]); cmp != 0 {
+			return cmp
+		}
+	}
+	if len(a) < len(b) {
+		return -1
+	} else if len(b) < len(a) {
+		return 1
+	}
+	return 0
+}
+
+func typeOrder(x Type) int {
+	switch x.(type) {
+	case Null:
+		return 0
+	case Boolean:
+		return 1
+	case Number:
+		return 2
+	case String:
+		return 3
+	case *Array:
+		return 4
+	case *Object:
+		return 5
+	case *Set:
+		return 6
+	case Any:
+		return 7
+	case nil:
+		return -1
+	}
+	panic("unreachable")
+}

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -1,0 +1,276 @@
+// Copyright 2017 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package types
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/open-policy-agent/opa/util/test"
+)
+
+func TestStrings(t *testing.T) {
+
+	tpe := NewObject([]*Property{
+		{"foo", NewNull()},
+		{"bar", NewBoolean()},
+		{"baz", NewNumber()},
+		{"qux", NewString()},
+		{"corge", NewArray(
+			[]Type{
+				NewAny(),
+				NewAny(NewNull(), NewString()),
+				NewSet(NewString()),
+			}, NewString(),
+		)},
+		{"nil", nil},
+	}, NewNumber())
+
+	expected := `object<bar: boolean, baz: number, corge: array<any, any<null, string>, set[string]>[string], foo: null, nil: ???, qux: string>[number]`
+
+	if tpe.String() != expected {
+		t.Fatalf("Expected %v but got: %v", expected, tpe)
+	}
+}
+
+func TestCompare(t *testing.T) {
+
+	tests := []struct {
+		a   Type
+		b   Type
+		cmp int
+	}{
+		{NewNull(), NewNull(), 0},
+		{NewNull(), NewBoolean(), -1},
+		{NewBoolean(), NewNull(), 1},
+		{NewBoolean(), NewBoolean(), 0},
+		{NewBoolean(), NewNumber(), -1},
+		{NewNumber(), NewNumber(), 0},
+		{NewNumber(), NewString(), -1},
+		{NewString(), NewString(), 0},
+		{NewString(), NewArray(NewAny(), nil), -1},
+		{NewArray(NewAny(), nil), NewArray(NewAny(), NewAny()), -1},
+		{NewArray(NewAny(), NewAny()), NewArray(NewAny(), NewAny()), 0},
+		{NewArray(NewAny(), NewAny()), NewArray(NewAny(), NewString()), 1},
+		{NewArray(NewAny(), NewAny()), NewArray(NewAny(), nil), 1},
+		{NewArray([]Type{NewString()}, nil), NewArray([]Type{NewNumber()}, nil), 1},
+		{NewObject(nil, nil), NewObject(nil, NewAny()), -1},
+		{NewObject(nil, NewAny()), NewObject(nil, nil), 1},
+		{NewObject(nil, NewAny()), NewObject(nil, NewAny()), 0},
+		{NewObject(nil, NewAny()), NewObject(nil, NewAny(NewString(), NewNull())), -1},
+		{NewSet(NewNull()), NewSet(NewAny()), -1},
+		{
+			NewObject(
+				[]*Property{{"foo", NewString()}},
+				nil),
+			NewObject(
+				[]*Property{{"foo", NewString()}, {"bar", NewNumber()}},
+				nil),
+			1,
+		},
+		{
+			NewObject(
+				[]*Property{{"foo", NewString()}, {"bar", NewNumber()}},
+				nil),
+			NewObject(
+				[]*Property{{"foo", NewString()}},
+				nil),
+			-1,
+		},
+		{
+			NewObject(
+				[]*Property{{"foo", NewString()}},
+				nil),
+			NewObject(
+				[]*Property{{"foo", NewNull()}},
+				nil),
+			1,
+		},
+		{
+			NewObject(
+				[]*Property{{"foo", NewString()}},
+				nil),
+			NewObject(
+				[]*Property{{"foo", NewString()}, {"foo-2", NewNumber()}},
+				nil),
+			-1,
+		},
+		{
+			NewObject(
+				[]*Property{{"foo", NewString()}, {"foo-2", NewNumber()}},
+				nil),
+			NewObject(
+				[]*Property{{"foo", NewString()}},
+				nil),
+			1,
+		},
+	}
+
+	for _, tc := range tests {
+		result := Compare(tc.a, tc.b)
+		if result != tc.cmp {
+			t.Fatalf("For Compare(%v, %v) expected %v but got: %v", tc.a, tc.b, tc.cmp, result)
+		}
+	}
+}
+
+func TestOr(t *testing.T) {
+	tests := []struct {
+		a        Type
+		b        Type
+		expected Type
+	}{
+		{nil, NewString(), NewString()},
+		{NewString(), nil, NewString()},
+		{NewNull(), NewNull(), NewNull()},
+		{NewString(), NewNumber(), NewAny(NewNumber(), NewString())},
+		{NewAny(), NewNull(), NewAny()},
+		{NewNull(), NewAny(), NewAny()},
+		{NewNull(), NewAny(NewString(), NewNumber()), NewAny(NewString(), NewNumber(), NewNull())},
+		{NewAny(), NewAny(), NewAny()},
+		{NewAny(NewNull(), NewNumber()), NewAny(), NewAny()},
+		{NewAny(NewNumber(), NewString()), NewAny(NewNull(), NewBoolean()), NewAny(NewNull(), NewBoolean(), NewString(), NewNumber())},
+		{NewAny(NewNull(), NewNumber()), NewNull(), NewAny(NewNull(), NewNumber())},
+	}
+
+	for _, tc := range tests {
+		c := Or(tc.a, tc.b)
+		if Compare(c, tc.expected) != 0 {
+			t.Fatalf("Expected Or(%v, %v) to be %v but got: %v", tc.a, tc.b, tc.expected, c)
+		}
+	}
+
+}
+
+func TestSelect(t *testing.T) {
+
+	tests := []struct {
+		note     string
+		a        Type
+		k        interface{}
+		expected Type
+	}{
+		{"static", NewArray([]Type{S}, nil), json.Number("0"), S},
+		{"dynamic", NewArray(nil, S), json.Number("100"), S},
+		{"out of range", NewArray([]Type{S, N, B}, nil), json.Number("4"), nil},
+		{"non int", NewArray([]Type{S, N, B}, nil), json.Number("1.5"), nil},
+		{"non int-2", NewArray([]Type{S, N, B}, nil), 1, nil},
+		{"static", NewObject([]*Property{NewProperty("hello", S)}, nil), "hello", S},
+		{"dynamic", NewObject([]*Property{NewProperty("hello", S)}, N), "goodbye", N},
+		{"non exist", NewObject([]*Property{NewProperty("hello", S)}, nil), "deadbeef", nil},
+		{"non string", NewObject([]*Property{NewProperty(json.Number("1"), S), NewProperty(json.Number("2"), N)}, nil), json.Number("2"), N},
+		{"member of", NewSet(N), json.Number("2"), N},
+		{"non exist", NewSet(N), "foo", nil},
+		{"superset", A, A, A},
+		{"union", NewAny(NewArray(nil, N), NewArray(nil, S)), json.Number("10"), NewAny(N, S)},
+		{"union set", NewSet(NewAny(S, N)), json.Number("1"), N},
+		{"scalar", N, "1", nil},
+		{"scalar-2", S, "1", nil},
+		{"scalar-3", B, "1", nil},
+		{"scalar-4", NewNull(), "1", nil},
+	}
+
+	for _, tc := range tests {
+		test.Subtest(t, tc.note, func(t *testing.T) {
+			result := Select(tc.a, tc.k)
+			if Compare(result, tc.expected) != 0 {
+				t.Fatalf("Expected Select(%v, %v) to be %v but got: %v", tc.a, tc.k, tc.expected, result)
+			}
+		})
+	}
+}
+
+func TestKeys(t *testing.T) {
+	tests := []struct {
+		note     string
+		tpe      Type
+		expected Type
+	}{
+		{"array", NewArray(nil, nil), N},
+		{"object", NewObject(nil, nil), S},
+		{"set", NewSet(N), N},
+		{"any", NewAny(NewArray(nil, nil), NewSet(S)), NewAny(S, N)},
+		{"any", NewAny(NewArray(nil, nil), S), N},
+		{"superset", A, A},
+		{"scalar-1", N, nil},
+		{"scalar-2", S, nil},
+		{"scalar-3", B, nil},
+		{"scalar-4", NewNull(), nil},
+	}
+
+	for _, tc := range tests {
+		test.Subtest(t, tc.note, func(t *testing.T) {
+			result := Keys(tc.tpe)
+			if Compare(result, tc.expected) != 0 {
+				t.Fatalf("Expected Keys(%v) to be %v but got: %v", tc.tpe, tc.expected, result)
+			}
+		})
+	}
+}
+
+func TestValues(t *testing.T) {
+	tests := []struct {
+		note     string
+		tpe      Type
+		expected Type
+	}{
+		{"array", NewArray([]Type{N}, nil), N},
+		{"array dynamic", NewArray([]Type{N, S}, B), NewAny(S, N, B)},
+		{"object", NewObject([]*Property{NewProperty("a", S), NewProperty("b", N)}, nil), NewAny(S, N)},
+		{"object dynamic", NewObject([]*Property{NewProperty("a", S), NewProperty("b", N)}, B), NewAny(S, N, B)},
+		{"set", NewSet(N), N},
+		{"superset", A, A},
+		{"any", NewAny(NewArray(nil, N), S), N},
+		{"scalar-1", N, nil},
+		{"scalar-2", S, nil},
+		{"scalar-3", B, nil},
+		{"scalar-4", NewNull(), nil},
+	}
+
+	for _, tc := range tests {
+		test.Subtest(t, tc.note, func(t *testing.T) {
+			result := Values(tc.tpe)
+			if Compare(result, tc.expected) != 0 {
+				t.Fatalf("Expected Keys(%v) to be %v but got: %v", tc.tpe, tc.expected, result)
+			}
+		})
+	}
+}
+
+func TestTypeOf(t *testing.T) {
+	tpe := TypeOf(map[interface{}]interface{}{
+		"foo": []interface{}{
+			json.Number("1"), true, nil, "hello",
+		},
+	})
+
+	exp := NewObject([]*Property{
+		NewProperty("foo", NewArray(
+			[]Type{
+				N, B, NewNull(), S,
+			}, nil,
+		)),
+	}, nil)
+
+	if Compare(exp, tpe) != 0 {
+		t.Fatalf("Expected %v but got: %v", exp, tpe)
+	}
+}
+
+func TestNil(t *testing.T) {
+
+	tpe := NewObject([]*Property{
+		NewProperty("foo", NewArray(
+			[]Type{
+				N, B, NewNull(), S, NewSet(nil),
+			}, nil,
+		)),
+	}, nil)
+
+	if !Nil(tpe) {
+		t.Fatalf("Expected %v type to be unknown", tpe)
+	}
+
+}

--- a/util/graph.go
+++ b/util/graph.go
@@ -4,15 +4,11 @@
 
 package util
 
-// DFSTraversal defines the basic interface required to perform a depth
-// first traveral.
-type DFSTraversal interface {
+// Traversal defines a basic interface to perform traversals.
+type Traversal interface {
 
 	// Edges should return the neighbours of node "u".
 	Edges(u T) []T
-
-	// Equals should return true if node "u" equals node "v".
-	Equals(u T, v T) bool
 
 	// Visited should return true if node "u" has already been visited in this
 	// traversal. If the same traversal is used multiple times, the state that
@@ -20,10 +16,54 @@ type DFSTraversal interface {
 	Visited(u T) bool
 }
 
-// DFS returns a path from node a to node z found by performing
+// Equals should return true if node "u" equals node "v".
+type Equals func(u T, v T) bool
+
+// Iter should return true to indicate stop.
+type Iter func(u T) bool
+
+// DFS performs a depth first traversal calling f for each node starting from u.
+// If f returns true, traversal stops and DFS returns true.
+func DFS(t Traversal, f Iter, u T) bool {
+	lifo := NewLIFO(u)
+	for lifo.Size() > 0 {
+		next, _ := lifo.Pop()
+		if t.Visited(next) {
+			continue
+		}
+		if f(next) {
+			return true
+		}
+		for _, v := range t.Edges(next) {
+			lifo.Push(v)
+		}
+	}
+	return false
+}
+
+// BFS performs a breadth first traversal calling f for each node starting from
+// u. If f returns true, traversal stops and BFS returns true.
+func BFS(t Traversal, f Iter, u T) bool {
+	fifo := NewFIFO(u)
+	for fifo.Size() > 0 {
+		next, _ := fifo.Pop()
+		if t.Visited(next) {
+			continue
+		}
+		if f(next) {
+			return true
+		}
+		for _, v := range t.Edges(next) {
+			fifo.Push(v)
+		}
+	}
+	return false
+}
+
+// DFSPath returns a path from node a to node z found by performing
 // a depth first traversal. If no path is found, an empty slice is returned.
-func DFS(t DFSTraversal, a, z T) []T {
-	p := dfsRecursive(t, a, z, []T{})
+func DFSPath(t Traversal, eq Equals, a, z T) []T {
+	p := dfsRecursive(t, eq, a, z, []T{})
 	for i := len(p)/2 - 1; i >= 0; i-- {
 		o := len(p) - i - 1
 		p[i], p[o] = p[o], p[i]
@@ -31,17 +71,17 @@ func DFS(t DFSTraversal, a, z T) []T {
 	return p
 }
 
-func dfsRecursive(t DFSTraversal, u, z T, path []T) []T {
+func dfsRecursive(t Traversal, eq Equals, u, z T, path []T) []T {
 	if t.Visited(u) {
 		return path
 	}
 	for _, v := range t.Edges(u) {
-		if t.Equals(v, z) {
+		if eq(v, z) {
 			path = append(path, z)
 			path = append(path, u)
 			return path
 		}
-		if p := dfsRecursive(t, v, z, path); len(p) > 0 {
+		if p := dfsRecursive(t, eq, v, z, path); len(p) > 0 {
 			path = append(p, u)
 			return path
 		}

--- a/util/queue.go
+++ b/util/queue.go
@@ -1,0 +1,113 @@
+// Copyright 2017 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package util
+
+// LIFO represents a simple LIFO queue.
+type LIFO struct {
+	top  *queueNode
+	size int
+}
+
+type queueNode struct {
+	v    T
+	next *queueNode
+}
+
+// NewLIFO returns a new LIFO queue containing elements ts starting with the
+// left-most argument at the bottom.
+func NewLIFO(ts ...T) *LIFO {
+	s := &LIFO{}
+	for i := range ts {
+		s.Push(ts[i])
+	}
+	return s
+}
+
+// Push adds a new element onto the LIFO.
+func (s *LIFO) Push(t T) {
+	node := &queueNode{v: t, next: s.top}
+	s.top = node
+	s.size++
+}
+
+// Peek returns the top of the LIFO. If LIFO is empty, returns nil, false.
+func (s *LIFO) Peek() (T, bool) {
+	if s.top == nil {
+		return nil, false
+	}
+	return s.top.v, true
+}
+
+// Pop returns the top of the LIFO and removes it. If LIFO is empty returns
+// nil, false.
+func (s *LIFO) Pop() (T, bool) {
+	if s.top == nil {
+		return nil, false
+	}
+	node := s.top
+	s.top = node.next
+	s.size--
+	return node.v, true
+}
+
+// Size returns the size of the LIFO.
+func (s *LIFO) Size() int {
+	return s.size
+}
+
+// FIFO represents a simple FIFO queue.
+type FIFO struct {
+	front *queueNode
+	back  *queueNode
+	size  int
+}
+
+// NewFIFO returns a new FIFO queue containing elements ts starting with the
+// left-most argument at the front.
+func NewFIFO(ts ...T) *FIFO {
+	s := &FIFO{}
+	for i := range ts {
+		s.Push(ts[i])
+	}
+	return s
+}
+
+// Push adds a new element onto the LIFO.
+func (s *FIFO) Push(t T) {
+	node := &queueNode{v: t, next: nil}
+	if s.front == nil {
+		s.front = node
+		s.back = node
+	} else {
+		s.back.next = node
+		s.back = node
+	}
+	s.size++
+}
+
+// Peek returns the top of the LIFO. If LIFO is empty, returns nil, false.
+func (s *FIFO) Peek() (T, bool) {
+	if s.front == nil {
+		return nil, false
+	}
+	return s.front.v, true
+}
+
+// Pop returns the top of the LIFO and removes it. If LIFO is empty returns
+// nil, false.
+func (s *FIFO) Pop() (T, bool) {
+	if s.front == nil {
+		return nil, false
+	}
+	node := s.front
+	s.front = node.next
+	s.size--
+	return node.v, true
+}
+
+// Size returns the size of the LIFO.
+func (s *FIFO) Size() int {
+	return s.size
+}

--- a/util/queue_test.go
+++ b/util/queue_test.go
@@ -1,0 +1,84 @@
+// Copyright 2017 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package util
+
+import "testing"
+
+func TestLIFO(t *testing.T) {
+
+	lifo := NewLIFO(1, 2, 3, 4)
+
+	if lifo.Size() != 4 {
+		t.Fatalf("Expected LIFO size == 4 but got: %v", lifo.Size())
+	}
+
+	for i := 4; i >= 1; i-- {
+		x, ok := lifo.Peek()
+		if !ok || x != i {
+			t.Fatalf("Expected peek() == %v but got: %v (ok=%v)", i, x, ok)
+		}
+		x, ok = lifo.Pop()
+		if !ok || x != i {
+			t.Fatalf("Expected pop() == %v but got: %v (ok=%v)", i, x, ok)
+		}
+	}
+
+	x, ok := lifo.Peek()
+	if ok || x != nil {
+		t.Fatalf("Expected peek() == nil, false but got: %v (ok=%v)", x, ok)
+	}
+
+	x, ok = lifo.Pop()
+	if ok || x != nil {
+		t.Fatalf("Expected pop() == nil, false but got: %v (ok=%v)", x, ok)
+	}
+
+	for i := 4; i >= 1; i-- {
+		lifo.Push(i)
+		x, ok = lifo.Peek()
+		if !ok || x != i {
+			t.Fatalf("Expected peek() == %v but got: %v (ok=%v)", i, x, ok)
+		}
+	}
+
+}
+
+func TestFIFO(t *testing.T) {
+	fifo := NewFIFO(1, 2, 3, 4)
+
+	if fifo.Size() != 4 {
+		t.Fatalf("Expected FIFO size == 1 but got: %v", fifo.Size())
+	}
+
+	for i := 1; i <= 4; i++ {
+		x, ok := fifo.Peek()
+		if !ok || x != i {
+			t.Fatalf("Expected peek() == %v but got: %v (ok=%v)", i, x, ok)
+		}
+		x, ok = fifo.Pop()
+		if !ok || x != i {
+			t.Fatalf("Expected pop() == %v but got: %v (ok=%v)", i, x, ok)
+		}
+	}
+
+	x, ok := fifo.Peek()
+	if ok || x != nil {
+		t.Fatalf("Expected peek() == nil, false but got: %v (ok=%v)", x, ok)
+	}
+
+	x, ok = fifo.Pop()
+	if ok || x != nil {
+		t.Fatalf("Expected pop() == nil, false but got: %v (ok=%v)", x, ok)
+	}
+
+	for i := 1; i <= 4; i++ {
+		fifo.Push(i)
+		x, ok = fifo.Peek()
+		if !ok || x != 1 {
+			t.Fatalf("Expected peek() == %v but got: %v (ok=%v)", 1, x, ok)
+		}
+	}
+
+}


### PR DESCRIPTION
These changes add basic support for type inference and type checking.

Type inference covers queries (i.e., terms/vars inside queries) as well as virtual docs. Type information for base docs is not available yet--and type checking treats base docs as having "any" type.

Type inference and checking are performed in one pass. The output of the type checking phase is a type environment that contains all relevant type information (for the query or rule set).

Type inference and checking for virtual docs is performed bottom-up after topologically sorting the rules. In the future, we could investigate relaxing this so that type errors/conflicts in base documents could be detected.

Currently, type checking handles the following:

1) Built-in arguments
2) Reference arguments
