### PR TITLE
Add simple rule indexing implementation

### DIFF
--- a/ast/compile_test.go
+++ b/ast/compile_test.go
@@ -1081,12 +1081,8 @@ func TestQueryCompiler(t *testing.T) {
 		{"unsafe vars", "z", "", nil, "", fmt.Errorf("1 error occurred: 1:1: rego_unsafe_var_error: var z is unsafe")},
 		{"safe vars", `data; abc`, `package ex`, []string{"import input.xyz as abc"}, `{}`, `data; input.xyz`},
 		{"reorder", `x != 1; x = 0`, "", nil, "", `x = 0; x != 1`},
-		// {"bad builtin", "deadbeef(1,2,3)", "", nil, "", fmt.Errorf("1 error occurred: 1:1: rego_type_error: undefined built-in function")},
 		{"bad with target", "x = 1 with data.p as null", "", nil, "", fmt.Errorf("1 error occurred: 1:7: rego_type_error: with keyword target must be input")},
-		// wrapping refs in extra terms to cover error handling
-		{"undefined input", `[[true | [data.a.b.d.t, true]], true]`, "", nil, "", fmt.Errorf("5:12: rego_input_error: input document not defined")},
-		{"conflicting input", `[true | data.a.b.d.t with input as 1]`, "", nil, "2", fmt.Errorf("1:9: rego_input_error: input document conflict")},
-		{"conflicting input-2", `sum([1 | data.a.b.d.t with input as 2], x) with input as 3`, "", nil, "", fmt.Errorf("1:10: rego_input_error: input document conflict")},
+		{"check types", "x = data.a.b.c.z; y = null; x = y", "", nil, "", fmt.Errorf("match error\n\tleft  : number\n\tright : null")},
 	}
 
 	for _, tc := range tests {
@@ -1259,7 +1255,7 @@ func runQueryCompilerTest(t *testing.T, note, q, pkg string, imports []string, i
 			if err == nil {
 				t.Fatalf("Expected error from %v but got: %v", query, result)
 			}
-			if err.Error() != expected.Error() {
+			if !strings.Contains(err.Error(), expected.Error()) {
 				t.Fatalf("Expected error %v but got: %v", expected, err)
 			}
 		}

--- a/ast/index.go
+++ b/ast/index.go
@@ -1,0 +1,422 @@
+// Copyright 2017 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package ast
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/open-policy-agent/opa/util"
+)
+
+// RuleIndex defines the interface for rule indices.
+type RuleIndex interface {
+
+	// Build tries to construct an index for the given rules. If the index was
+	// constructed, ok is true, otherwise false.
+	Build(rules []*Rule) (ok bool)
+
+	// Index returns a set of rules to evaluate and a default rule if one was
+	// present when the index was built.
+	Index(resolver ValueResolver) (rules []*Rule, defaultRule *Rule, err error)
+}
+
+type baseDocEqIndex struct {
+	isVirtual   func(Ref) bool
+	root        *trieNode
+	defaultRule *Rule
+}
+
+func newBaseDocEqIndex(isVirtual func(Ref) bool) *baseDocEqIndex {
+	return &baseDocEqIndex{
+		isVirtual: isVirtual,
+		root:      newTrieNodeImpl(),
+	}
+}
+
+func (i *baseDocEqIndex) Build(rules []*Rule) bool {
+
+	refs := make(refValueIndex, len(rules))
+
+	// freq is map[ref]int where the values represent the frequency of the
+	// ref/key.
+	freq := util.NewHashMap(func(a, b util.T) bool {
+		r1, r2 := a.(Ref), b.(Ref)
+		return r1.Equal(r2)
+	}, func(x util.T) int {
+		return x.(Ref).Hash()
+	})
+
+	// Build refs and freq maps
+	for _, rule := range rules {
+
+		if rule.Default {
+			// Compiler guarantees that only one default will be defined per path.
+			i.defaultRule = rule
+			continue
+		}
+
+		for _, expr := range rule.Body {
+			ref, value, ok := i.getRefAndValue(expr)
+			if ok {
+				refs.Insert(rule, ref, value)
+				count, ok := freq.Get(ref)
+				if !ok {
+					count = 0
+				}
+				count = count.(int) + 1
+				freq.Put(ref, count)
+			}
+		}
+	}
+
+	// Sort by frequency
+	type refCountPair struct {
+		ref   Ref
+		count int
+	}
+
+	sorted := make([]refCountPair, 0, freq.Len())
+	freq.Iter(func(k, v util.T) bool {
+		ref, count := k.(Ref), v.(int)
+		sorted = append(sorted, refCountPair{ref, count})
+		return false
+	})
+
+	sort.Slice(sorted, func(i, j int) bool {
+		if sorted[i].count > sorted[j].count {
+			return true
+		}
+		return false
+	})
+
+	// Build trie
+	for _, rule := range rules {
+
+		if rule.Default {
+			continue
+		}
+
+		node := i.root
+
+		if refs := refs[rule]; refs != nil {
+			for _, pair := range sorted {
+				value := refs.Get(pair.ref)
+				node = node.Insert(pair.ref, value)
+			}
+		}
+
+		node.rules = append(node.rules, rule)
+	}
+
+	return true
+}
+
+func (i *baseDocEqIndex) Index(resolver ValueResolver) ([]*Rule, *Rule, error) {
+	rules, err := i.traverse(i.root, resolver)
+	return rules, i.defaultRule, err
+}
+
+func (i *baseDocEqIndex) traverse(node *trieNode, resolver ValueResolver) ([]*Rule, error) {
+
+	if node == nil {
+		return nil, nil
+	}
+
+	result := make([]*Rule, len(node.rules))
+	copy(result, node.rules)
+	next := node.next
+
+	if next == nil {
+		return result, nil
+	}
+
+	children, err := next.Resolve(resolver)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, child := range children {
+		rules, err := i.traverse(child, resolver)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, rules...)
+	}
+
+	return result, nil
+}
+
+func (i *baseDocEqIndex) getRefAndValue(expr *Expr) (Ref, Value, bool) {
+
+	if !expr.IsEquality() || expr.Negated {
+		return nil, nil, false
+	}
+
+	a, b := expr.Operand(0), expr.Operand(1)
+
+	if ref, value, ok := i.getRefAndValueFromTerms(a, b); ok {
+		return ref, value, true
+	}
+
+	return i.getRefAndValueFromTerms(b, a)
+}
+
+func (i *baseDocEqIndex) getRefAndValueFromTerms(a, b *Term) (Ref, Value, bool) {
+
+	ref, ok := a.Value.(Ref)
+	if !ok {
+		return nil, nil, false
+	}
+
+	if !RootDocumentNames.Contains(ref[0]) {
+		return nil, nil, false
+	}
+
+	if i.isVirtual(ref) {
+		return nil, nil, false
+	}
+
+	if ref.IsNested() || !ref.IsGround() {
+		return nil, nil, false
+	}
+
+	switch b := b.Value.(type) {
+	case Null, Boolean, Number, String, Var:
+		return ref, b, true
+	case Array:
+		stop := false
+		first := true
+		vis := NewGenericVisitor(func(x interface{}) bool {
+			if first {
+				first = false
+				return false
+			}
+			switch x.(type) {
+			// No nested structures or values that require evaluation (other than var).
+			case Array, Object, *Set, *ArrayComprehension, Ref:
+				stop = true
+			}
+			return stop
+		})
+		Walk(vis, b)
+		if !stop {
+			return ref, b, true
+		}
+	}
+
+	return nil, nil, false
+}
+
+type refValueIndex map[*Rule]*ValueMap
+
+func (m refValueIndex) Insert(rule *Rule, ref Ref, value Value) {
+	vm, ok := m[rule]
+	if !ok {
+		vm = NewValueMap()
+		m[rule] = vm
+	}
+	vm.Put(ref, value)
+}
+
+type trieWalker interface {
+	Do(x interface{}) trieWalker
+}
+
+type trieNode struct {
+	ref       Ref
+	next      *trieNode
+	any       *trieNode
+	undefined *trieNode
+	scalars   map[Value]*trieNode
+	array     *trieNode
+	rules     []*Rule
+}
+
+func newTrieNodeImpl() *trieNode {
+	return &trieNode{
+		scalars: map[Value]*trieNode{},
+	}
+}
+
+func (node *trieNode) Do(walker trieWalker) {
+	next := walker.Do(node)
+	if next == nil {
+		return
+	}
+	if node.next != nil {
+		node.next.Do(next)
+		return
+	}
+	if node.any != nil {
+		node.any.Do(next)
+	}
+	if node.undefined != nil {
+		node.undefined.Do(next)
+	}
+	for _, child := range node.scalars {
+		child.Do(next)
+	}
+	if node.array != nil {
+		node.array.Do(next)
+	}
+}
+
+func (node *trieNode) Insert(ref Ref, value Value) *trieNode {
+
+	if node.next == nil {
+		node.next = newTrieNodeImpl()
+		node.next.ref = ref
+	}
+
+	return node.next.insertValue(value)
+}
+
+func (node *trieNode) Resolve(resolver ValueResolver) ([]*trieNode, error) {
+
+	v, err := resolver.Resolve(node.ref)
+	if err != nil {
+		return nil, err
+	}
+
+	result := []*trieNode{}
+
+	if node.undefined != nil {
+		result = append(result, node.undefined)
+	}
+
+	if v == nil {
+		return result, nil
+	}
+
+	if node.any != nil {
+		result = append(result, node.any)
+	}
+
+	result = append(result, node.resolveValue(v)...)
+	return result, nil
+}
+
+func (node *trieNode) insertValue(value Value) *trieNode {
+
+	switch value := value.(type) {
+	case nil:
+		if node.undefined == nil {
+			node.undefined = newTrieNodeImpl()
+		}
+		return node.undefined
+	case Var:
+		if node.any == nil {
+			node.any = newTrieNodeImpl()
+		}
+		return node.any
+	case Null, Boolean, Number, String:
+		child, ok := node.scalars[value]
+		if !ok {
+			child = newTrieNodeImpl()
+			node.scalars[value] = child
+		}
+		return child
+	case Array:
+		if node.array == nil {
+			node.array = newTrieNodeImpl()
+		}
+		return node.array.insertArray(value)
+	}
+
+	panic("illegal value")
+}
+
+func (node *trieNode) insertArray(arr Array) *trieNode {
+
+	if len(arr) == 0 {
+		return node
+	}
+
+	switch head := arr[0].Value.(type) {
+	case Var:
+		if node.any == nil {
+			node.any = newTrieNodeImpl()
+		}
+		return node.any.insertArray(arr[1:])
+	case Null, Boolean, Number, String:
+		child, ok := node.scalars[head]
+		if !ok {
+			child = newTrieNodeImpl()
+			node.scalars[head] = child
+		}
+		return child.insertArray(arr[1:])
+	}
+
+	panic("illegal value")
+}
+
+func (node *trieNode) resolveValue(value Value) []*trieNode {
+
+	switch value := value.(type) {
+	case Array:
+		if node.array == nil {
+			return nil
+		}
+		return node.array.resolveArray(value)
+
+	case Null, Boolean, Number, String:
+		child, ok := node.scalars[value]
+		if !ok {
+			return nil
+		}
+		return []*trieNode{child}
+	}
+
+	return nil
+}
+
+func (node *trieNode) resolveArray(arr Array) []*trieNode {
+
+	if len(arr) == 0 {
+		if node.next != nil || len(node.rules) > 0 {
+			return []*trieNode{node}
+		}
+		return nil
+	}
+
+	head := arr[0].Value
+
+	if !IsScalar(head) {
+		return nil
+	}
+
+	var result []*trieNode
+
+	if node.any != nil {
+		result = append(result, node.any.resolveArray(arr[1:])...)
+	}
+
+	child, ok := node.scalars[head]
+	if !ok {
+		return result
+	}
+
+	return append(result, child.resolveArray(arr[1:])...)
+}
+
+type triePrinter struct {
+	depth int
+	w     io.Writer
+}
+
+func (p triePrinter) Do(x interface{}) trieWalker {
+	padding := strings.Repeat(" ", p.depth)
+	fmt.Fprintf(p.w, "%v%v\n", padding, x)
+	p.depth++
+	return p
+}
+
+func printTrie(w io.Writer, trie *trieNode) {
+	pp := triePrinter{0, w}
+	trie.Do(pp)
+}

--- a/ast/index_test.go
+++ b/ast/index_test.go
@@ -1,0 +1,350 @@
+// Copyright 2017 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package ast
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/open-policy-agent/opa/util/test"
+)
+
+type testResolver struct {
+	input   *Term
+	failRef Ref
+}
+
+func (r testResolver) Resolve(ref Ref) (Value, error) {
+	if ref.Equal(r.failRef) {
+		return nil, fmt.Errorf("some error")
+	}
+	if ref.HasPrefix(InputRootRef) {
+		v, err := r.input.Value.Find(ref[1:])
+		if err != nil {
+			return nil, nil
+		}
+		return v, nil
+	}
+	panic("illegal value")
+}
+
+func TestBaseDocEqIndexing(t *testing.T) {
+
+	module := MustParseModule(`
+	package test
+
+	exact {
+		input.x = 1
+		input.y = 2
+	} {
+		input.x = 3
+		input.y = 4
+	}
+
+	scalars {
+		input.x = 0
+		input.y = 1
+	} {
+		1 = input.y  # exercise ordering
+		input.x = 0
+	} {
+		input.y = 2
+		input.z = 2
+	} {
+		input.x = 2
+	}
+
+	vars {
+		input.x = 1
+		input.y = 2
+	} {
+		input.x = x
+		input.y = 3
+	} {
+		input.x = 4
+		input.z = 5
+	}
+
+	composite_arr {
+		input.x = 1
+		input.y = [1,2,3]
+		input.z = 1
+	} {
+		input.x = 1
+		input.y = [1,2,4,x]
+	} {
+		input.y = [1,2,y,5]
+		input.z = 3
+	} {
+		input.y = []
+	} {
+		# Must be included in all results as nested composites are not indexed.
+		input.y = [1,[2,3],4]
+	}
+
+	composite_obj {
+		input.y = {"foo": "bar", "bar": x}
+	}
+
+	# filtering ruleset contains rules that cannot be indexed (for different reasons).
+	filtering {
+		count([], x)
+	} {
+		not input.x = 0
+	} {
+		x = [1,2,3]
+		x[0] = 1
+	} {
+		input.x[_] = 1
+	} {
+		input.x[input.y] = 1
+	} {
+		# include one rule that can be indexed to exercise merging of root non-indexable
+		# rules with other rules.
+		input.x = 1
+	}
+
+	# exercise default keyword
+	default allow = false
+	allow {
+		input.x = 1
+	} {
+		input.x = 0
+	}
+	`)
+
+	tests := []struct {
+		note       string
+		ruleset    string
+		input      string
+		expectedRS interface{}
+		expectedDR *Rule
+	}{
+		{
+			note:    "exact match",
+			ruleset: "exact",
+			input:   `{"x": 3, "y": 4}`,
+			expectedRS: []string{
+				`exact { input.x = 3; input.y = 4 }`,
+			},
+		},
+		{
+			note:    "undefined match",
+			ruleset: "scalars",
+			input:   `{"x": 2, "y": 2}`,
+			expectedRS: []string{
+				`scalars { input.x = 2 }`},
+		},
+		{
+			note:    "disjoint match",
+			ruleset: "scalars",
+			input:   `{"x": 2, "y": 2, "z": 2}`,
+			expectedRS: []string{
+				`scalars { input.x = 2 }`,
+				`scalars { input.y = 2; input.z = 2}`},
+		},
+		{
+			note:    "ordering match",
+			ruleset: "scalars",
+			input:   `{"x": 0, "y": 1}`,
+			expectedRS: []string{
+				`scalars { input.x = 0; input.y = 1 }`,
+				`scalars { 1 = input.y; input.x = 0 }`},
+		},
+		{
+			note:    "type no match",
+			ruleset: "vars",
+			input:   `{"y": 3, "x": {1,2,3}}`,
+			expectedRS: []string{
+				`vars { input.x = x; input.y = 3 }`,
+			},
+		},
+		{
+			note:    "var match",
+			ruleset: "vars",
+			input:   `{"x": 1, "y": 3}`,
+			expectedRS: []string{
+				`vars { input.x = x; input.y = 3 }`,
+			},
+		},
+		{
+			note:    "var match disjoint",
+			ruleset: "vars",
+			input:   `{"x": 4, "z": 5, "y": 3}`,
+			expectedRS: []string{
+				`vars { input.x = x; input.y = 3 }`,
+				`vars { input.x = 4; input.z = 5 }`,
+			},
+		},
+		{
+			note:    "array match",
+			ruleset: "composite_arr",
+			input: `{
+				"x": 1,
+				"y": [1,2,3],
+				"z": 1,
+			}`,
+			expectedRS: []string{
+				`composite_arr { input.x = 1; input.y = [1,2,3]; input.z = 1 }`,
+				`composite_arr { input.y = [1,[2,3],4] }`,
+			},
+		},
+		{
+			note:    "array var match",
+			ruleset: "composite_arr",
+			input: `{
+				"x": 1,
+				"y": [1,2,4,5],
+			}`,
+			expectedRS: []string{
+				`composite_arr { input.x = 1; input.y = [1,2,4,x] }`,
+				`composite_arr { input.y = [1,[2,3],4] }`,
+			},
+		},
+		{
+			note:    "array var multiple match",
+			ruleset: "composite_arr",
+			input: `{
+				"x": 1,
+				"y": [1,2,4,5],
+				"z": 3,
+			}`,
+			expectedRS: []string{
+				`composite_arr { input.x = 1; input.y = [1,2,4,x] }`,
+				`composite_arr { input.y = [1,2,y,5]; input.z = 3 }`,
+				`composite_arr { input.y = [1,[2,3],4] }`,
+			},
+		},
+		{
+			note:    "array nested match non-indexable rules",
+			ruleset: "composite_arr",
+			input: `{
+				"x": 1,
+				"y": [1,[2,3],4],
+			}`,
+			expectedRS: []string{
+				`composite_arr { input.y = [1,[2,3],4] }`,
+			},
+		},
+		{
+			note:    "array empty match",
+			ruleset: "composite_arr",
+			input:   `{"y": []}`,
+			expectedRS: []string{
+				`composite_arr { input.y = [] }`,
+				`composite_arr { input.y = [1,[2,3],4] }`,
+			},
+		},
+		{
+			note:    "object match non-indexable rule",
+			ruleset: "composite_obj",
+			input:   `{"y": {"foo": "bar", "bar": "baz"}}`,
+			expectedRS: []string{
+				`composite_obj { input.y = {"foo": "bar", "bar": x} }`,
+			},
+		},
+		{
+			note:       "default rule only",
+			ruleset:    "allow",
+			input:      `{"x": 2}`,
+			expectedRS: []string{},
+			expectedDR: MustParseRule(`default allow = false`),
+		},
+		{
+			note:       "match and default rule",
+			ruleset:    "allow",
+			input:      `{"x": 1}`,
+			expectedRS: []string{"allow { input.x = 1 }"},
+			expectedDR: MustParseRule(`default allow = false`),
+		},
+		{
+			note:       "match and non-indexable rules",
+			ruleset:    "filtering",
+			input:      `{"x": 1}`,
+			expectedRS: module.RuleSet(Var("filtering")),
+		},
+		{
+			note:       "non-indexable rules",
+			ruleset:    "filtering",
+			input:      `{}`,
+			expectedRS: module.RuleSet(Var("filtering")).Diff(NewRuleSet(MustParseRule(`filtering { input.x = 1 }`))),
+		},
+	}
+
+	for _, tc := range tests {
+		test.Subtest(t, tc.note, func(t *testing.T) {
+
+			rules := []*Rule{}
+			for _, rule := range module.Rules {
+				if rule.Head.Name == Var(tc.ruleset) {
+					rules = append(rules, rule)
+				}
+			}
+
+			input := MustParseTerm(tc.input)
+			var expectedRS RuleSet
+
+			switch e := tc.expectedRS.(type) {
+			case []string:
+				for _, r := range e {
+					expectedRS.Add(MustParseRule(r))
+				}
+			case RuleSet:
+				expectedRS = e
+			default:
+				panic("Unexpected test case expected value")
+			}
+
+			index := newBaseDocEqIndex(func(Ref) bool {
+				return false
+			})
+
+			if !index.Build(rules) {
+				t.Fatalf("Expected index build to succeed")
+			}
+
+			rs, dr, err := index.Index(testResolver{input, nil})
+			if err != nil {
+				t.Fatalf("Unexpected error during index lookup: %v", err)
+			}
+
+			result := NewRuleSet(rs...)
+
+			if !result.Equal(expectedRS) {
+				t.Fatalf("Expected ruleset %v but got: %v", expectedRS, rs)
+			}
+
+			if dr == nil && tc.expectedDR != nil {
+				t.Fatalf("Expected default rule but got nil")
+			} else if dr != nil && tc.expectedDR == nil {
+				t.Fatalf("Unexpected default rule %v", dr)
+			} else if dr != nil && tc.expectedDR != nil && !dr.Equal(tc.expectedDR) {
+				t.Fatalf("Expected default rule %v but got: %v", tc.expectedDR, dr)
+			}
+		})
+	}
+
+}
+
+func TestBaseDocEqIndexingErrors(t *testing.T) {
+	index := newBaseDocEqIndex(func(Ref) bool {
+		return false
+	})
+
+	module := MustParseModule(`
+	package ex
+
+	p { input.raise_error = 1 }`)
+
+	if !index.Build(module.Rules) {
+		t.Fatalf("Expected index to build")
+	}
+
+	_, _, err := index.Index(testResolver{MustParseTerm(`{}`), MustParseRef("input.raise_error")})
+
+	if err == nil || err.Error() != "some error" {
+		t.Fatalf("Expected error but got: %v", err)
+	}
+}

--- a/ast/term.go
+++ b/ast/term.go
@@ -125,6 +125,11 @@ type Resolver interface {
 	Resolve(ref Ref) (value interface{}, err error)
 }
 
+// ValueResolver defines the interface for resolving references to AST values.
+type ValueResolver interface {
+	Resolve(ref Ref) (value Value, err error)
+}
+
 type illegalResolver struct{}
 
 func (illegalResolver) Resolve(ref Ref) (interface{}, error) {
@@ -792,6 +797,25 @@ func (arr Array) Find(path Ref) (Value, error) {
 		return nil, fmt.Errorf("find: not found")
 	}
 	return arr[i].Value.Find(path[1:])
+}
+
+// Get returns the element at pos or nil if not possible.
+func (arr Array) Get(pos *Term) *Term {
+	num, ok := pos.Value.(Number)
+	if !ok {
+		return nil
+	}
+
+	i, ok := num.Int()
+	if !ok {
+		return nil
+	}
+
+	if i > 0 && i < len(arr) {
+		return arr[i]
+	}
+
+	return nil
 }
 
 // Hash returns the hash code for the Value.

--- a/ast/term_test.go
+++ b/ast/term_test.go
@@ -131,16 +131,16 @@ func TestFind(t *testing.T) {
 	term := MustParseTerm(`{"foo": [1,{"bar": {2,3,4}}], "baz": {"qux": ["hello", "world"]}}`)
 
 	tests := []struct {
-		path     string
+		path     *Term
 		expected interface{}
 	}{
-		{"foo/1/bar", MustParseTerm(`{2, 3, 4}`)},
-		{"foo/2", fmt.Errorf("not found")},
-		{"baz/qux/0", MustParseTerm(`"hello"`)},
+		{RefTerm(StringTerm("foo"), IntNumberTerm(1), StringTerm("bar")), MustParseTerm(`{2, 3, 4}`)},
+		{RefTerm(StringTerm("foo"), IntNumberTerm(2)), fmt.Errorf("not found")},
+		{RefTerm(StringTerm("baz"), StringTerm("qux"), IntNumberTerm(0)), MustParseTerm(`"hello"`)},
 	}
 
 	for _, tc := range tests {
-		result, err := term.Value.Find(strings.Split(tc.path, "/"))
+		result, err := term.Value.Find(tc.path.Value.(Ref))
 		switch expected := tc.expected.(type) {
 		case *Term:
 			if err != nil {

--- a/repl/repl_test.go
+++ b/repl/repl_test.go
@@ -321,11 +321,13 @@ func TestUnset(t *testing.T) {
 		t.Fatalf("Expected unset to succeed for input: %v", err)
 	}
 
-	err = repl.OneShot(ctx, `true = input`)
+	buffer.Reset()
+	repl.OneShot(ctx, `not input`)
 
-	if !strings.Contains(err.Error(), "input document not defined") {
-		t.Fatalf("Expected undefined error but got: %v", err)
+	if buffer.String() != "true\n" {
+		t.Fatalf("Expected unset input to remove input document: %v", buffer.String())
 	}
+
 }
 
 func TestOneShotEmptyBufferOneExpr(t *testing.T) {
@@ -827,11 +829,13 @@ func TestEvalBodyWith(t *testing.T) {
 	repl := newRepl(store, &buffer)
 
 	repl.OneShot(ctx, `p = true { input.foo = "bar" }`)
-	err := repl.OneShot(ctx, "p")
+	repl.OneShot(ctx, "p")
 
-	if err == nil || !strings.Contains(err.Error(), "input document not defined") {
-		t.Fatalf("Expected input document undefined error")
+	if buffer.String() != "undefined\n" {
+		t.Fatalf("Expected undefined but got: %v", buffer.String())
 	}
+
+	buffer.Reset()
 
 	repl.OneShot(ctx, `p with input.foo as "bar"`)
 

--- a/server/authorizer/authorizer_test.go
+++ b/server/authorizer/authorizer_test.go
@@ -175,14 +175,14 @@ func TestBasic(t *testing.T) {
 					t.Fatalf("Expected JSON response but got: %v", recorder)
 				}
 				response := ast.MustInterfaceToValue(x)
-				code, err := response.Find([]string{"code"})
+				code, err := response.Find(ast.RefTerm(ast.StringTerm("code")).Value.(ast.Ref))
 				if err != nil {
 					t.Fatalf("Missing code in response: %v", recorder)
 				} else if !code.Equal(ast.String(tc.expectedCode)) {
 					t.Fatalf("Expected code %v but got: %v", tc.expectedCode, recorder)
 				}
 
-				msg, err := response.Find([]string{"message"})
+				msg, err := response.Find(ast.RefTerm(ast.StringTerm("message")).Value.(ast.Ref))
 				if err != nil {
 					t.Fatalf("Missing message in response: %v", recorder)
 				} else if !strings.Contains(msg.String(), tc.expectedMsg) {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -593,7 +593,7 @@ func TestPoliciesPutV1ParseError(t *testing.T) {
 
 	v := ast.MustInterfaceToValue(response)
 
-	name, err := v.Find([]string{"errors", "0", "location", "file"})
+	name, err := v.Find(ast.MustParseRef("_.errors[0].location.file")[1:])
 	if err != nil {
 		t.Fatalf("Expecfted to find name in errors but: %v", err)
 	}
@@ -629,7 +629,7 @@ q[x] { p[x] }`,
 
 	v := ast.MustInterfaceToValue(response)
 
-	name, err := v.Find([]string{"errors", "0", "location", "file"})
+	name, err := v.Find(ast.MustParseRef("_.errors[0].location.file")[1:])
 	if err != nil {
 		t.Fatalf("Expecfted to find name in errors but: %v", err)
 	}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -54,11 +54,6 @@ undef = true { false }`
 p = [1, 2, 3, 4] { true }
 q = {"a": 1, "b": 2} { true }`
 
-	testMod3 := `package testmod
-
-p = true { loopback with input as true }
-loopback = input { true }`
-
 	testMod4 := `package testmod
 
 p = true { true }
@@ -168,24 +163,6 @@ p = true { false }`
 			tr{"PUT", "/policies/test", testMod1, 200, ""},
 			tr{"GET", "/data/testmod/g?input=req1%3A%7B%22a%22%3A%5B1%5D%7D&input=req2%3A%7B%22b%22%3A%5B0%2C1%5D%7D", "", 200, `{"result": true}`},
 		}},
-		{"get missing input", []tr{
-			tr{"PUT", "/policies/test", testMod1, 200, ""},
-			tr{"GET", "/data/testmod/g", "", 400, `{
-    		  "code": "invalid_parameter",
-    		  "errors": [
-    		    {
-    		      "code": "rego_input_error",
-    		      "location": {
-    		        "col": 12,
-    		        "file": "test",
-    		        "row": 10
-    		      },
-    		      "message": "input document not defined"
-    		    }
-    		  ],
-    		  "message": "input document is missing or conflicts with query"
-    		}`},
-		}},
 		{"get with input (missing input value)", []tr{
 			tr{"PUT", "/policies/test", testMod1, 200, ""},
 			tr{"GET", "/data/testmod/g?input=req1%3A%7B%22a%22%3A%5B1%5D%7D", "", 200, "{}"}, // req2 not specified
@@ -257,24 +234,6 @@ p = true { false }`
 			tr{"PUT", "/policies/test", testMod1, 200, ""},
 			tr{"POST", "/data/testmod/gt1", `{"input": {"req1": 2}}`, 200, `{"result": true}`},
 		}},
-		{"post missing input", []tr{
-			tr{"PUT", "/policies/test", testMod1, 200, ""},
-			tr{"POST", "/data/testmod/gt1", ``, 400, `{
-				"code": "invalid_parameter",
-				"message": "input document is missing or conflicts with query",
-				"errors": [
-					{
-						"code": "rego_input_error",
-						"location": {
-							"file": "test",
-							"row": 12,
-							"col": 14
-						},
-						"message": "input document not defined"
-					}
-				]
-			}`},
-		}},
 		{"post malformed input", []tr{
 			tr{"POST", "/data/deadbeef", `{"input": @}`, 400, `{
 				"code": "invalid_parameter",
@@ -297,24 +256,6 @@ p = true { false }`
     		    }
     		  ],
     		  "message": "error(s) occurred while evaluating query"
-    		}`},
-		}},
-		{"input conflict", []tr{
-			tr{"PUT", "/policies/test", testMod3, 200, ""},
-			tr{"POST", "/data/testmod/p", `{"input": false}`, 400, `{
-    		  "code": "invalid_parameter",
-    		  "errors": [
-    		    {
-    		      "code": "rego_input_error",
-    		      "location": {
-    		        "col": 12,
-    		        "file": "test",
-    		        "row": 3
-    		      },
-    		      "message": "input document conflict"
-    		    }
-    		  ],
-    		  "message": "input document is missing or conflicts with query"
     		}`},
 		}},
 		{"query wildcards omitted", []tr{

--- a/topdown/topdown_test.go
+++ b/topdown/topdown_test.go
@@ -1186,7 +1186,7 @@ loopback = input { true }`})
 
 	assertTopDown(t, compiler, store, "loopback", []string{"z", "loopback"}, `{"foo": 1}`, `{"foo": 1}`)
 
-	assertTopDown(t, compiler, store, "loopback undefined", []string{"z", "loopback"}, ``, fmt.Errorf("input document not defined"))
+	assertTopDown(t, compiler, store, "loopback undefined", []string{"z", "loopback"}, ``, ``)
 
 	assertTopDown(t, compiler, store, "simple", []string{"z", "p"}, `{
 		"req1": {"foo": 4},


### PR DESCRIPTION
These changes add a simple rule indexing implementation to OPA. In the future, we can add more sophisticated strategies and perform analysis on queries to determine which indices ought to be used.

The first indexing strategy supports expressions of form eq(ref, term) (or vice versa) where ref is a ground, non-nested reference to a base document (input or data) and term is scalar, non-nested array, or var. The implementation builds a trie from the expressions in rule sets that match this pattern. The trie shrinks the search space required at evaluation time.