### PR TITLE
Add basic performance metric collection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ VERSION := 0.4.9-dev
 PACKAGES := \
 	github.com/open-policy-agent/opa/ast/.../ \
 	github.com/open-policy-agent/opa/cmd/.../ \
+	github.com/open-policy-agent/opa/metrics/.../ \
 	github.com/open-policy-agent/opa/rego/.../ \
 	github.com/open-policy-agent/opa/repl/.../ \
 	github.com/open-policy-agent/opa/runtime/.../ \

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -1,0 +1,91 @@
+// Copyright 2017 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+// Package metrics contains helpers for performance metric management inside the policy engine.
+package metrics
+
+import (
+	"time"
+)
+
+// Well-known metric names.
+const (
+	RegoQueryCompile = "rego_query_compile"
+	RegoQueryEval    = "rego_query_eval"
+	RegoQueryParse   = "rego_query_parse"
+)
+
+// Metrics defines the interface for a collection of perfomrance metrics in the
+// policy engine.
+type Metrics interface {
+	Timer(name string) Timer
+	All() map[string]interface{}
+}
+
+type metrics struct {
+	timers map[string]Timer
+}
+
+// Sample defines a common interface to obtain a single metric value.
+type Sample interface {
+	Value() interface{}
+}
+
+// New returns a new Metrics object.
+func New() Metrics {
+	return &metrics{
+		timers: map[string]Timer{},
+	}
+}
+
+func (m *metrics) Timer(name string) Timer {
+	t, ok := m.timers[name]
+	if !ok {
+		t = &timer{}
+		m.timers[name] = t
+	}
+	return t
+}
+
+func (m *metrics) All() map[string]interface{} {
+	result := map[string]interface{}{}
+	for name, timer := range m.timers {
+		result[m.formatKey(name, timer)] = timer.Value()
+	}
+	return result
+}
+
+func (m *metrics) formatKey(name string, sample Sample) string {
+	switch sample.(type) {
+	case Timer:
+		return "timer_" + name + "_ns"
+	default:
+		return name
+	}
+}
+
+// Timer defines the interface for a restartable timer that accumulates elapsed
+// time.
+type Timer interface {
+	Sample
+	Start()
+	Stop()
+}
+
+type timer struct {
+	start time.Time
+	value int64
+}
+
+func (t *timer) Start() {
+	t.start = time.Now()
+}
+
+func (t *timer) Stop() {
+	t.value += time.Now().Sub(t.start).Nanoseconds()
+}
+
+func (t timer) Value() interface{} {
+	return t.value
+}

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -1,0 +1,20 @@
+// Copyright 2017 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package metrics
+
+import (
+	"testing"
+	"time"
+)
+
+func TestMetricsTimer(t *testing.T) {
+	m := New()
+	m.Timer("foo").Start()
+	time.Sleep(time.Millisecond)
+	m.Timer("foo").Stop()
+	if m.All()["timer_foo_ns"] == 0 {
+		t.Fatalf("Expected foo timer to be non-zero: %v", m.All())
+	}
+}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -413,6 +413,35 @@ p = [1, 2, 3, 4] { true }`, 200, "")
 
 }
 
+func TestDataMetrics(t *testing.T) {
+
+	f := newFixture(t)
+
+	req := newReqV1("POST", "/data?metrics", "")
+	f.reset()
+	f.server.Handler.ServeHTTP(f.recorder, req)
+
+	var result types.DataResponseV1
+
+	if err := util.NewJSONDecoder(f.recorder.Body).Decode(&result); err != nil {
+		t.Fatalf("Unexpected JSON decode error: %v", err)
+	}
+
+	// Test some basic well-known metrics.
+	expected := []string{
+		"timer_rego_query_parse_ns",
+		"timer_rego_query_compile_ns",
+		"timer_rego_query_eval_ns",
+	}
+
+	for _, key := range expected {
+		if result.Metrics[key] == 0 {
+			t.Fatalf("Expected non-zero metric for %v but got: %v", key, result)
+		}
+	}
+
+}
+
 func TestV1Pretty(t *testing.T) {
 
 	f := newFixture(t)

--- a/server/types/types.go
+++ b/server/types/types.go
@@ -117,12 +117,17 @@ type DataRequestV1 struct {
 // DataResponseV1 models the response message for Data API read operations.
 type DataResponseV1 struct {
 	Explanation TraceV1      `json:"explanation,omitempty"`
+	Metrics     MetricsV1    `json:"metrics,omitempty"`
 	Result      *interface{} `json:"result,omitempty"`
 }
+
+// MetricsV1 models a collection of performance metrics.
+type MetricsV1 map[string]interface{}
 
 // QueryResponseV1 models the response message for Query API operations.
 type QueryResponseV1 struct {
 	Explanation TraceV1               `json:"explanation,omitempty"`
+	Metrics     MetricsV1             `json:"metrics,omitempty"`
 	Result      AdhocQueryResultSetV1 `json:"result"`
 }
 
@@ -285,6 +290,11 @@ const (
 	// ParamPrettyV1 defines the name of the HTTP URL parameter that indicates
 	// the client wants to receive a pretty-printed version of the response.
 	ParamPrettyV1 = "pretty"
+
+	// ParamMetricsV1 defines the name of the HTTP URL parameter that indicates
+	// the client wants to receive performance metrics in addition to the
+	// result.
+	ParamMetricsV1 = "metrics"
 )
 
 // WriteConflictErr represents an error condition raised if the caller attempts

--- a/site/documentation/references/rest/index.md
+++ b/site/documentation/references/rest/index.md
@@ -1380,6 +1380,7 @@ seccomp_unconfined {
 - **input** - Provide an input document. Format is `[[<path>]:]<value>` where `<path>` is the import path of the input document. The parameter may be specified multiple times but each instance should specify a unique `<path>`. The `<path>` may be empty (in which case, the entire input will be set to the `<value>`). The `<value>` may be a reference to a document in OPA. If `<value>` contains variables the response will contain a set of results instead of a single document. In most cases, input should be provided using the POST method, see [Get a Document With Input](#get-a-document-with-input).
 - **pretty** - If parameter is `true`, response will formatted for humans.
 - **explain** - Return query explanation in addition to result. Values: **full**, **truth**.
+- **metrics** - Return query performance metrics in addition to result. See [Performance Metrics](#performance-metrics) for more detail.
 
 #### Status Codes
 
@@ -1485,6 +1486,7 @@ HTTP/1.1 200 OK
 
 - **pretty** - If parameter is `true`, response will formatted for humans.
 - **explain** - Return query explanation in addition to result. Values: **full**, **truth**.
+- **metrics** - Return query performance metrics in addition to result. See [Performance Metrics](#performance-metrics) for more detail.
 
 #### Status Codes
 
@@ -1635,6 +1637,7 @@ Content-Type: application/json
 - **q** - The ad-hoc query to execute. OPA will parse, compile, and execute the query represented by the parameter value. The value MUST be URL encoded.
 - **pretty** - If parameter is `true`, response will formatted for humans.
 - **explain** - Return query explanation in addition to result. Values: **full**, **truth**.
+- **metrics** - Return query performance metrics in addition to result. See [Performance Metrics](#performance-metrics) for more detail.
 
 #### Status Codes
 
@@ -1791,5 +1794,49 @@ restarts, a **Redo** Trace Event is emitted.
 }
 ```
 
+## <a name="performance-metrics"></a> Performance Metrics
+
+OPA can report detailed performance metrics at runtime. Currently, performance metrics can be requested on individual API calls and are returned inline with the API response. To enable performance metric collection on an API call, specify the `metrics=true` query parameter when executing the API call. Performance metrics are currently supported for the following APIs:
+
+- Data API GET
+- Data API POST
+- Query API
+
+For example:
+
+```http
+POST /v1/data/example?metrics=true HTTP/1.1
+```
+
+Response:
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+```
+
+```json
+{
+  "metrics": {
+    "timer_rego_query_compile_ns": 69994,
+    "timer_rego_query_eval_ns": 48425,
+    "timer_rego_query_parse_ns": 4096
+  },
+  "result": {
+    "some_strings": [
+      "hello",
+      "world"
+    ]
+  }
+}
+```
+
+### <a name="query-performance-metrics"></a> Query Performance Metrics
+
+OPA currently supports the following query performance metrics:
+
+- **timer_rego_query_parse_ns**: time taken (in nanonseconds) to parse the query.
+- **timer_rego_query_compile_ns**: time taken (in nanonseconds) to compile the query.
+- **timer_rego_query_eval_ns**: time taken (in nanonseconds) to evaluate the query.
 
 {% endcontentfor %}


### PR DESCRIPTION
This is a relatively simple change that adds some basic performance metrics to OPA. The metrics can be requested when making an API call. The collected values are returned alongside the response result.

Eventually, we'll want to have metrics collection available out-of-band. We can add that later.

Closes #271