### PR TITLE
Fix bug in ast.ParseTerm

### DIFF
--- a/ast/parser_ext.go
+++ b/ast/parser_ext.go
@@ -253,8 +253,8 @@ func ParseTerm(input string) (*Term, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to parse term")
 	}
-	if len(body) > 1 {
-		return nil, fmt.Errorf("expected exactly one term but got %v", body)
+	if len(body) != 1 {
+		return nil, fmt.Errorf("expected exactly one term but got: %v", body)
 	}
 	term, ok := body[0].Terms.(*Term)
 	if !ok {


### PR DESCRIPTION
ParseTerm should have been checking if body was exactly size 1. This was
allowing the form in index.html to trigger a panic if the input field
was empty.