### PR TITLE
Add tutorial for doing API authorization with JWTs

### DIFF
--- a/site/tutorials/working-with-the-opa-repl/index.md
+++ b/site/tutorials/working-with-the-opa-repl/index.md
@@ -113,7 +113,7 @@ The rule above defines a set of values that are the indices of elements in the a
 
 When you enter expressions into the OPA REPL, you are effectively running *queries*. The REPL output shows the values of variables in the expression that make the query `true`. If there is no set of variables that would make the query `true`, the REPL prints `false`. If there are no variables in the query and the query evaluates successfully, then the REPL just prints `true`.
 
-Quit out of the REPL by pressing Control-C or typing `exit`:
+Quit out of the REPL by pressing Control-D or typing `exit`:
 
 ```ruby
 > exit


### PR DESCRIPTION
Depends on https://github.com/open-policy-agent/contrib/pull/19 having its docker image pushed. Also requires a release of OPA that has `io.jwt.decode`.