### PR TITLE
Policy API changes

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -11,9 +11,11 @@ import (
 
 // Well-known metric names.
 const (
-	RegoQueryCompile = "rego_query_compile"
-	RegoQueryEval    = "rego_query_eval"
-	RegoQueryParse   = "rego_query_parse"
+	RegoQueryCompile  = "rego_query_compile"
+	RegoQueryEval     = "rego_query_eval"
+	RegoQueryParse    = "rego_query_parse"
+	RegoModuleParse   = "rego_module_parse"
+	RegoModuleCompile = "rego_module_compile"
 )
 
 // Metrics defines the interface for a collection of perfomrance metrics in the

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -757,8 +757,17 @@ func TestPoliciesDeleteV1(t *testing.T) {
 
 	f.server.Handler.ServeHTTP(f.recorder, del)
 
-	if f.recorder.Code != 204 {
+	if f.recorder.Code != 200 {
 		t.Fatalf("Expected success but got %v", f.recorder)
+	}
+
+	var response map[string]interface{}
+	if err := json.NewDecoder(f.recorder.Body).Decode(&response); err != nil {
+		t.Fatalf("Unexpected unmarshal error: %v", err)
+	}
+
+	if len(response) > 0 {
+		t.Fatalf("Expected empty response but got: %v", response)
 	}
 
 	f.reset()

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -718,31 +718,6 @@ func TestPoliciesGetV1(t *testing.T) {
 	}
 }
 
-func TestPoliciesGetSourceV1(t *testing.T) {
-	f := newFixture(t)
-	put := newReqV1("PUT", "/policies/1", testMod)
-	f.server.Handler.ServeHTTP(f.recorder, put)
-
-	if f.recorder.Code != 200 {
-		t.Fatalf("Expected success but got %v", f.recorder)
-	}
-
-	f.reset()
-	get := newReqV1("GET", "/policies/1?source", "")
-
-	f.server.Handler.ServeHTTP(f.recorder, get)
-
-	if f.recorder.Code != 200 {
-		t.Fatalf("Expected success but got %v", f.recorder)
-	}
-
-	raw := f.recorder.Body.String()
-	if raw != testMod {
-		t.Fatalf("Expected raw string to equal testMod:\n\nExpected:\n\n%v\n\nGot:\n\n%v\n", testMod, raw)
-	}
-
-}
-
 func TestPoliciesDeleteV1(t *testing.T) {
 	f := newFixture(t)
 	put := newReqV1("PUT", "/policies/1", testMod)
@@ -1116,7 +1091,7 @@ func newPolicy(id, s string) types.PolicyV1 {
 		panic(compiler.Errors)
 	}
 	mod := compiler.Modules[""]
-	return types.PolicyV1{ID: id, Module: mod}
+	return types.PolicyV1{ID: id, AST: mod, Raw: s}
 }
 
 func newReqV1(method string, path string, body string) *http.Request {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -558,16 +558,13 @@ func TestPoliciesPutV1(t *testing.T) {
 		t.Fatalf("Expected success but got %v", f.recorder)
 	}
 
-	var response types.PolicyPutResponseV1
-
-	if err := util.NewJSONDecoder(f.recorder.Body).Decode(&response); err != nil {
-		t.Fatalf("Unexpected error: %v", err)
+	var response map[string]interface{}
+	if err := json.NewDecoder(f.recorder.Body).Decode(&response); err != nil {
+		t.Fatalf("Unexpected error while unmarshalling response: %v", err)
 	}
 
-	expected := newPolicy("1", testMod)
-
-	if !expected.Equal(response.Result) {
-		t.Errorf("Expected policies to be equal. Expected:\n\n%v\n\nGot:\n\n%v\n", expected, response.Result)
+	if len(response) != 0 {
+		t.Fatalf("Expected empty wrapper object")
 	}
 }
 

--- a/server/types/types.go
+++ b/server/types/types.go
@@ -100,6 +100,11 @@ type PolicyPutResponseV1 struct {
 	Metrics MetricsV1 `json:"metrics,omitempty"`
 }
 
+// PolicyDeleteResponseV1 models the response message for the Policy API delete operation.
+type PolicyDeleteResponseV1 struct {
+	Metrics MetricsV1 `json:"metrics,omitempty"`
+}
+
 // PolicyV1 models a policy module in OPA.
 type PolicyV1 struct {
 	ID     string      `json:"id"`

--- a/server/types/types.go
+++ b/server/types/types.go
@@ -97,7 +97,7 @@ type PolicyGetResponseV1 struct {
 
 // PolicyPutResponseV1 models the response message for the Policy API put operation.
 type PolicyPutResponseV1 struct {
-	Result PolicyV1 `json:"result"`
+	Metrics MetricsV1 `json:"metrics,omitempty"`
 }
 
 // PolicyV1 models a policy module in OPA.

--- a/server/types/types.go
+++ b/server/types/types.go
@@ -107,13 +107,14 @@ type PolicyDeleteResponseV1 struct {
 
 // PolicyV1 models a policy module in OPA.
 type PolicyV1 struct {
-	ID     string      `json:"id"`
-	Module *ast.Module `json:"module"`
+	ID  string      `json:"id"`
+	Raw string      `json:"raw"`
+	AST *ast.Module `json:"ast"`
 }
 
 // Equal returns true if p is equal to other.
 func (p PolicyV1) Equal(other PolicyV1) bool {
-	return p.ID == other.ID && p.Module.Equal(other.Module)
+	return p.ID == other.ID && p.Raw == other.Raw && p.AST.Equal(other.AST)
 }
 
 // DataRequestV1 models the request message for Data API POST operations.
@@ -289,10 +290,6 @@ const (
 	// ParamInputV1 defines the name of the HTTP URL parameter that specifies
 	// values for the "input" document.
 	ParamInputV1 = "input"
-
-	// ParamSourceV1 defines the name of the HTTP URL parameter that indicates
-	// the client wants to receive the raw (uncompiled) version of the module.
-	ParamSourceV1 = "source"
 
 	// ParamPrettyV1 defines the name of the HTTP URL parameter that indicates
 	// the client wants to receive a pretty-printed version of the response.

--- a/site/documentation/references/rest-v1/index.md
+++ b/site/documentation/references/rest-v1/index.md
@@ -47,206 +47,9 @@ Content-Type: application/json
 {
   "result": [
     {
-      "id": "example1",
-      "module": {
-        "package": {
-          "path": [
-            {
-              "type": "var",
-              "value": "data"
-            },
-            {
-              "type": "string",
-              "value": "opa"
-            },
-            {
-              "type": "string",
-              "value": "examples"
-            }
-          ]
-        },
-        "rules": [
-          {
-            "name": "public_servers",
-            "key": {
-              "type": "var",
-              "value": "server"
-            },
-            "body": [
-              {
-                "index": 0,
-                "terms": [
-                  {
-                    "type": "var",
-                    "value": "eq"
-                  },
-                  {
-                    "type": "var",
-                    "value": "server"
-                  },
-                  {
-                    "type": "ref",
-                    "value": [
-                      {
-                        "type": "var",
-                        "value": "data"
-                      },
-                      {
-                        "type": "string",
-                        "value": "servers"
-                      },
-                      {
-                        "type": "var",
-                        "value": "$0"
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "index": 1,
-                "terms": [
-                  {
-                    "type": "var",
-                    "value": "eq"
-                  },
-                  {
-                    "type": "ref",
-                    "value": [
-                      {
-                        "type": "var",
-                        "value": "server"
-                      },
-                      {
-                        "type": "string",
-                        "value": "ports"
-                      },
-                      {
-                        "type": "var",
-                        "value": "$1"
-                      }
-                    ]
-                  },
-                  {
-                    "type": "ref",
-                    "value": [
-                      {
-                        "type": "var",
-                        "value": "data"
-                      },
-                      {
-                        "type": "string",
-                        "value": "ports"
-                      },
-                      {
-                        "type": "var",
-                        "value": "k"
-                      },
-                      {
-                        "type": "string",
-                        "value": "id"
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "index": 2,
-                "terms": [
-                  {
-                    "type": "var",
-                    "value": "eq"
-                  },
-                  {
-                    "type": "ref",
-                    "value": [
-                      {
-                        "type": "var",
-                        "value": "data"
-                      },
-                      {
-                        "type": "string",
-                        "value": "ports"
-                      },
-                      {
-                        "type": "var",
-                        "value": "k"
-                      },
-                      {
-                        "type": "string",
-                        "value": "networks"
-                      },
-                      {
-                        "type": "var",
-                        "value": "$2"
-                      }
-                    ]
-                  },
-                  {
-                    "type": "ref",
-                    "value": [
-                      {
-                        "type": "var",
-                        "value": "data"
-                      },
-                      {
-                        "type": "string",
-                        "value": "networks"
-                      },
-                      {
-                        "type": "var",
-                        "value": "m"
-                      },
-                      {
-                        "type": "string",
-                        "value": "id"
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "index": 3,
-                "terms": [
-                  {
-                    "type": "var",
-                    "value": "eq"
-                  },
-                  {
-                    "type": "ref",
-                    "value": [
-                      {
-                        "type": "var",
-                        "value": "data"
-                      },
-                      {
-                        "type": "string",
-                        "value": "networks"
-                      },
-                      {
-                        "type": "var",
-                        "value": "m"
-                      },
-                      {
-                        "type": "string",
-                        "value": "public"
-                      }
-                    ]
-                  },
-                  {
-                    "type": "boolean",
-                    "value": true
-                  }
-                ]
-              }
-            ]
-          }
-        ]
-      }
-    },
-    {
       "id": "example2",
-      "module": {
+      "raw": "package opa.examples\n\nimport data.servers\n\nviolations[server] {\n\tserver = servers[_]\n\tserver.protocols[_] = \"http\"\n\tpublic_servers[server]\n}\n",
+      "ast": {
         "package": {
           "path": [
             {
@@ -265,17 +68,19 @@ Content-Type: application/json
         },
         "rules": [
           {
-            "name": "violations",
-            "key": {
-              "type": "var",
-              "value": "server"
+            "head": {
+              "name": "violations",
+              "key": {
+                "type": "var",
+                "value": "server"
+              }
             },
             "body": [
               {
                 "index": 0,
                 "terms": [
                   {
-                    "type": "var",
+                    "type": "string",
                     "value": "eq"
                   },
                   {
@@ -305,7 +110,7 @@ Content-Type: application/json
                 "index": 1,
                 "terms": [
                   {
-                    "type": "var",
+                    "type": "string",
                     "value": "eq"
                   },
                   {
@@ -363,9 +168,211 @@ Content-Type: application/json
           }
         ]
       }
+    },
+    {
+      "id": "example1",
+      "raw": "package opa.examples\n\nimport data.servers\nimport data.networks\nimport data.ports\n\npublic_servers[server] {\n\tserver = servers[_]\n\tserver.ports[_] = ports[k].id\n\tports[k].networks[_] = networks[m].id\n\tnetworks[m].public = true\n}\n",
+      "ast": {
+        "package": {
+          "path": [
+            {
+              "type": "var",
+              "value": "data"
+            },
+            {
+              "type": "string",
+              "value": "opa"
+            },
+            {
+              "type": "string",
+              "value": "examples"
+            }
+          ]
+        },
+        "rules": [
+          {
+            "head": {
+              "name": "public_servers",
+              "key": {
+                "type": "var",
+                "value": "server"
+              }
+            },
+            "body": [
+              {
+                "index": 0,
+                "terms": [
+                  {
+                    "type": "string",
+                    "value": "eq"
+                  },
+                  {
+                    "type": "var",
+                    "value": "server"
+                  },
+                  {
+                    "type": "ref",
+                    "value": [
+                      {
+                        "type": "var",
+                        "value": "data"
+                      },
+                      {
+                        "type": "string",
+                        "value": "servers"
+                      },
+                      {
+                        "type": "var",
+                        "value": "$0"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "index": 1,
+                "terms": [
+                  {
+                    "type": "string",
+                    "value": "eq"
+                  },
+                  {
+                    "type": "ref",
+                    "value": [
+                      {
+                        "type": "var",
+                        "value": "server"
+                      },
+                      {
+                        "type": "string",
+                        "value": "ports"
+                      },
+                      {
+                        "type": "var",
+                        "value": "$1"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "ref",
+                    "value": [
+                      {
+                        "type": "var",
+                        "value": "data"
+                      },
+                      {
+                        "type": "string",
+                        "value": "ports"
+                      },
+                      {
+                        "type": "var",
+                        "value": "k"
+                      },
+                      {
+                        "type": "string",
+                        "value": "id"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "index": 2,
+                "terms": [
+                  {
+                    "type": "string",
+                    "value": "eq"
+                  },
+                  {
+                    "type": "ref",
+                    "value": [
+                      {
+                        "type": "var",
+                        "value": "data"
+                      },
+                      {
+                        "type": "string",
+                        "value": "ports"
+                      },
+                      {
+                        "type": "var",
+                        "value": "k"
+                      },
+                      {
+                        "type": "string",
+                        "value": "networks"
+                      },
+                      {
+                        "type": "var",
+                        "value": "$2"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "ref",
+                    "value": [
+                      {
+                        "type": "var",
+                        "value": "data"
+                      },
+                      {
+                        "type": "string",
+                        "value": "networks"
+                      },
+                      {
+                        "type": "var",
+                        "value": "m"
+                      },
+                      {
+                        "type": "string",
+                        "value": "id"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "index": 3,
+                "terms": [
+                  {
+                    "type": "string",
+                    "value": "eq"
+                  },
+                  {
+                    "type": "ref",
+                    "value": [
+                      {
+                        "type": "var",
+                        "value": "data"
+                      },
+                      {
+                        "type": "string",
+                        "value": "networks"
+                      },
+                      {
+                        "type": "var",
+                        "value": "m"
+                      },
+                      {
+                        "type": "string",
+                        "value": "public"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "boolean",
+                    "value": true
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
     }
   ]
 }
+
 ```
 
 #### Status Codes
@@ -398,7 +405,8 @@ Content-Type: application/json
 {
   "result": {
     "id": "example1",
-    "module": {
+    "raw": "package opa.examples\n\nimport data.servers\nimport data.networks\nimport data.ports\n\npublic_servers[server] {\n\tserver = servers[_]\n\tserver.ports[_] = ports[k].id\n\tports[k].networks[_] = networks[m].id\n\tnetworks[m].public = true\n}\n",
+    "ast": {
       "package": {
         "path": [
           {
@@ -417,17 +425,19 @@ Content-Type: application/json
       },
       "rules": [
         {
-          "name": "public_servers",
-          "key": {
-            "type": "var",
-            "value": "server"
+          "head": {
+            "name": "public_servers",
+            "key": {
+              "type": "var",
+              "value": "server"
+            }
           },
           "body": [
             {
               "index": 0,
               "terms": [
                 {
-                  "type": "var",
+                  "type": "string",
                   "value": "eq"
                 },
                 {
@@ -457,7 +467,7 @@ Content-Type: application/json
               "index": 1,
               "terms": [
                 {
-                  "type": "var",
+                  "type": "string",
                   "value": "eq"
                 },
                 {
@@ -504,7 +514,7 @@ Content-Type: application/json
               "index": 2,
               "terms": [
                 {
-                  "type": "var",
+                  "type": "string",
                   "value": "eq"
                 },
                 {
@@ -559,7 +569,7 @@ Content-Type: application/json
               "index": 3,
               "terms": [
                 {
-                  "type": "var",
+                  "type": "string",
                   "value": "eq"
                 },
                 {
@@ -597,38 +607,9 @@ Content-Type: application/json
 }
 ```
 
-#### Example Request For Source
-
-```http
-GET /v1/policies/example1?source=true HTTP/1.1
-```
-
-#### Example Response For Source
-
-```http
-HTTP/1.1 200 OK
-Content-Type: text/plain; charset=utf-8
-```
-
-```ruby
-package opa.examples
-
-import data.servers
-import data.networks
-import data.ports
-
-public_servers[server] {
-	server = servers[_]
-	server.ports[_] = ports[k].id
-	ports[k].networks[_] = networks[m].id
-	networks[m].public = true
-}
-```
-
 #### Query Parameters
 
-- **source** - If `true` the response will contain the raw source instead of
-  the AST.
+- **pretty** - If parameter is `true`, response will formatted for humans.
 
 #### Status Codes
 
@@ -680,207 +661,13 @@ Content-Type: application/json
 ```
 
 ```json
-{
-  "result": {
-    "id": "example1",
-    "module": {
-      "package": {
-        "path": [
-          {
-            "type": "var",
-            "value": "data"
-          },
-          {
-            "type": "string",
-            "value": "opa"
-          },
-          {
-            "type": "string",
-            "value": "examples"
-          }
-        ]
-      },
-      "rules": [
-        {
-          "name": "public_servers",
-          "key": {
-            "type": "var",
-            "value": "server"
-          },
-          "body": [
-            {
-              "index": 0,
-              "terms": [
-                {
-                  "type": "var",
-                  "value": "eq"
-                },
-                {
-                  "type": "var",
-                  "value": "server"
-                },
-                {
-                  "type": "ref",
-                  "value": [
-                    {
-                      "type": "var",
-                      "value": "data"
-                    },
-                    {
-                      "type": "string",
-                      "value": "servers"
-                    },
-                    {
-                      "type": "var",
-                      "value": "$0"
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "index": 1,
-              "terms": [
-                {
-                  "type": "var",
-                  "value": "eq"
-                },
-                {
-                  "type": "ref",
-                  "value": [
-                    {
-                      "type": "var",
-                      "value": "server"
-                    },
-                    {
-                      "type": "string",
-                      "value": "ports"
-                    },
-                    {
-                      "type": "var",
-                      "value": "$1"
-                    }
-                  ]
-                },
-                {
-                  "type": "ref",
-                  "value": [
-                    {
-                      "type": "var",
-                      "value": "data"
-                    },
-                    {
-                      "type": "string",
-                      "value": "ports"
-                    },
-                    {
-                      "type": "var",
-                      "value": "k"
-                    },
-                    {
-                      "type": "string",
-                      "value": "id"
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "index": 2,
-              "terms": [
-                {
-                  "type": "var",
-                  "value": "eq"
-                },
-                {
-                  "type": "ref",
-                  "value": [
-                    {
-                      "type": "var",
-                      "value": "data"
-                    },
-                    {
-                      "type": "string",
-                      "value": "ports"
-                    },
-                    {
-                      "type": "var",
-                      "value": "k"
-                    },
-                    {
-                      "type": "string",
-                      "value": "networks"
-                    },
-                    {
-                      "type": "var",
-                      "value": "$2"
-                    }
-                  ]
-                },
-                {
-                  "type": "ref",
-                  "value": [
-                    {
-                      "type": "var",
-                      "value": "data"
-                    },
-                    {
-                      "type": "string",
-                      "value": "networks"
-                    },
-                    {
-                      "type": "var",
-                      "value": "m"
-                    },
-                    {
-                      "type": "string",
-                      "value": "id"
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "index": 3,
-              "terms": [
-                {
-                  "type": "var",
-                  "value": "eq"
-                },
-                {
-                  "type": "ref",
-                  "value": [
-                    {
-                      "type": "var",
-                      "value": "data"
-                    },
-                    {
-                      "type": "string",
-                      "value": "networks"
-                    },
-                    {
-                      "type": "var",
-                      "value": "m"
-                    },
-                    {
-                      "type": "string",
-                      "value": "public"
-                    }
-                  ]
-                },
-                {
-                  "type": "boolean",
-                  "value": true
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    }
-  }
-}
+{}
 ```
+
+### Query Parameters
+
+- **pretty** - If parameter is `true`, response will formatted for humans.
+- **metrics** - Return compiler performance metrics in addition to result. See [Performance Metrics](#performance-metrics) for more detail.
 
 #### Status Codes
 
@@ -907,8 +694,18 @@ DELETE /v1/policies/example2 HTTP/1.1
 #### Example Response
 
 ```http
-HTTP/1.1 204 No Content
+HTTP/1.1 200 OK
+Content-Type: application/json
 ```
+
+```json
+{}
+```
+
+#### Query Parameters
+
+- **pretty** - If parameter is `true`, response will formatted for humans.
+- **metrics** - Return compiler performance metrics in addition to result. See [Performance Metrics](#performance-metrics) for more detail.
 
 #### Status Codes
 
@@ -1838,5 +1635,7 @@ OPA currently supports the following query performance metrics:
 - **timer_rego_query_parse_ns**: time taken (in nanonseconds) to parse the query.
 - **timer_rego_query_compile_ns**: time taken (in nanonseconds) to compile the query.
 - **timer_rego_query_eval_ns**: time taken (in nanonseconds) to evaluate the query.
+- **timer_rego_module_parse_ns**: time taken (in nanoseconds) to parse the input policy module.
+- **timer_rego_module_compile_ns**: time taken (in nanoseconds) to compile the loaded policy modules.
 
 {% endcontentfor %}


### PR DESCRIPTION
This is WIP so don't merge it yet.

These changes modify the policy management API based on my experience interacting with it. Specifically, it changes the format of the response messages. Old behaviour:

- PUT returned AST representation of compiled module (pretty printed)
- DELETE returned HTTP 204 / No Content
- GET returned AST representation of compiled module (or modules when listing)

New behaviour:

- PUT returns empty object by default. If ?metrics query parameter is provided than performance metrics on parsing, compiling, etc. are included.
- DELETE returns HTTP 200 empty object by default. Same ?metrics behaviour (as modules have to be recompiled.)
- GET returns objects that contain (i) policy module ID (ii) raw/string representation (w/ certain chars escaped for JSON) and (iii) AST representation. See docs for example.

All of the policy APIs now respect the ?pretty query parameter as well.