### PR TITLE
Policy API refactoring

### DIFF
--- a/docs/book/rest-api.md
+++ b/docs/book/rest-api.md
@@ -33,206 +33,9 @@ Content-Type: application/json
 {
   "result": [
     {
-      "id": "example1",
-      "module": {
-        "package": {
-          "path": [
-            {
-              "type": "var",
-              "value": "data"
-            },
-            {
-              "type": "string",
-              "value": "opa"
-            },
-            {
-              "type": "string",
-              "value": "examples"
-            }
-          ]
-        },
-        "rules": [
-          {
-            "name": "public_servers",
-            "key": {
-              "type": "var",
-              "value": "server"
-            },
-            "body": [
-              {
-                "index": 0,
-                "terms": [
-                  {
-                    "type": "var",
-                    "value": "eq"
-                  },
-                  {
-                    "type": "var",
-                    "value": "server"
-                  },
-                  {
-                    "type": "ref",
-                    "value": [
-                      {
-                        "type": "var",
-                        "value": "data"
-                      },
-                      {
-                        "type": "string",
-                        "value": "servers"
-                      },
-                      {
-                        "type": "var",
-                        "value": "$0"
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "index": 1,
-                "terms": [
-                  {
-                    "type": "var",
-                    "value": "eq"
-                  },
-                  {
-                    "type": "ref",
-                    "value": [
-                      {
-                        "type": "var",
-                        "value": "server"
-                      },
-                      {
-                        "type": "string",
-                        "value": "ports"
-                      },
-                      {
-                        "type": "var",
-                        "value": "$1"
-                      }
-                    ]
-                  },
-                  {
-                    "type": "ref",
-                    "value": [
-                      {
-                        "type": "var",
-                        "value": "data"
-                      },
-                      {
-                        "type": "string",
-                        "value": "ports"
-                      },
-                      {
-                        "type": "var",
-                        "value": "k"
-                      },
-                      {
-                        "type": "string",
-                        "value": "id"
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "index": 2,
-                "terms": [
-                  {
-                    "type": "var",
-                    "value": "eq"
-                  },
-                  {
-                    "type": "ref",
-                    "value": [
-                      {
-                        "type": "var",
-                        "value": "data"
-                      },
-                      {
-                        "type": "string",
-                        "value": "ports"
-                      },
-                      {
-                        "type": "var",
-                        "value": "k"
-                      },
-                      {
-                        "type": "string",
-                        "value": "networks"
-                      },
-                      {
-                        "type": "var",
-                        "value": "$2"
-                      }
-                    ]
-                  },
-                  {
-                    "type": "ref",
-                    "value": [
-                      {
-                        "type": "var",
-                        "value": "data"
-                      },
-                      {
-                        "type": "string",
-                        "value": "networks"
-                      },
-                      {
-                        "type": "var",
-                        "value": "m"
-                      },
-                      {
-                        "type": "string",
-                        "value": "id"
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "index": 3,
-                "terms": [
-                  {
-                    "type": "var",
-                    "value": "eq"
-                  },
-                  {
-                    "type": "ref",
-                    "value": [
-                      {
-                        "type": "var",
-                        "value": "data"
-                      },
-                      {
-                        "type": "string",
-                        "value": "networks"
-                      },
-                      {
-                        "type": "var",
-                        "value": "m"
-                      },
-                      {
-                        "type": "string",
-                        "value": "public"
-                      }
-                    ]
-                  },
-                  {
-                    "type": "boolean",
-                    "value": true
-                  }
-                ]
-              }
-            ]
-          }
-        ]
-      }
-    },
-    {
       "id": "example2",
-      "module": {
+      "raw": "package opa.examples\n\nimport data.servers\n\nviolations[server] {\n\tserver = servers[_]\n\tserver.protocols[_] = \"http\"\n\tpublic_servers[server]\n}\n",
+      "ast": {
         "package": {
           "path": [
             {
@@ -251,17 +54,19 @@ Content-Type: application/json
         },
         "rules": [
           {
-            "name": "violations",
-            "key": {
-              "type": "var",
-              "value": "server"
+            "head": {
+              "name": "violations",
+              "key": {
+                "type": "var",
+                "value": "server"
+              }
             },
             "body": [
               {
                 "index": 0,
                 "terms": [
                   {
-                    "type": "var",
+                    "type": "string",
                     "value": "eq"
                   },
                   {
@@ -291,7 +96,7 @@ Content-Type: application/json
                 "index": 1,
                 "terms": [
                   {
-                    "type": "var",
+                    "type": "string",
                     "value": "eq"
                   },
                   {
@@ -349,9 +154,211 @@ Content-Type: application/json
           }
         ]
       }
+    },
+    {
+      "id": "example1",
+      "raw": "package opa.examples\n\nimport data.servers\nimport data.networks\nimport data.ports\n\npublic_servers[server] {\n\tserver = servers[_]\n\tserver.ports[_] = ports[k].id\n\tports[k].networks[_] = networks[m].id\n\tnetworks[m].public = true\n}\n",
+      "ast": {
+        "package": {
+          "path": [
+            {
+              "type": "var",
+              "value": "data"
+            },
+            {
+              "type": "string",
+              "value": "opa"
+            },
+            {
+              "type": "string",
+              "value": "examples"
+            }
+          ]
+        },
+        "rules": [
+          {
+            "head": {
+              "name": "public_servers",
+              "key": {
+                "type": "var",
+                "value": "server"
+              }
+            },
+            "body": [
+              {
+                "index": 0,
+                "terms": [
+                  {
+                    "type": "string",
+                    "value": "eq"
+                  },
+                  {
+                    "type": "var",
+                    "value": "server"
+                  },
+                  {
+                    "type": "ref",
+                    "value": [
+                      {
+                        "type": "var",
+                        "value": "data"
+                      },
+                      {
+                        "type": "string",
+                        "value": "servers"
+                      },
+                      {
+                        "type": "var",
+                        "value": "$0"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "index": 1,
+                "terms": [
+                  {
+                    "type": "string",
+                    "value": "eq"
+                  },
+                  {
+                    "type": "ref",
+                    "value": [
+                      {
+                        "type": "var",
+                        "value": "server"
+                      },
+                      {
+                        "type": "string",
+                        "value": "ports"
+                      },
+                      {
+                        "type": "var",
+                        "value": "$1"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "ref",
+                    "value": [
+                      {
+                        "type": "var",
+                        "value": "data"
+                      },
+                      {
+                        "type": "string",
+                        "value": "ports"
+                      },
+                      {
+                        "type": "var",
+                        "value": "k"
+                      },
+                      {
+                        "type": "string",
+                        "value": "id"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "index": 2,
+                "terms": [
+                  {
+                    "type": "string",
+                    "value": "eq"
+                  },
+                  {
+                    "type": "ref",
+                    "value": [
+                      {
+                        "type": "var",
+                        "value": "data"
+                      },
+                      {
+                        "type": "string",
+                        "value": "ports"
+                      },
+                      {
+                        "type": "var",
+                        "value": "k"
+                      },
+                      {
+                        "type": "string",
+                        "value": "networks"
+                      },
+                      {
+                        "type": "var",
+                        "value": "$2"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "ref",
+                    "value": [
+                      {
+                        "type": "var",
+                        "value": "data"
+                      },
+                      {
+                        "type": "string",
+                        "value": "networks"
+                      },
+                      {
+                        "type": "var",
+                        "value": "m"
+                      },
+                      {
+                        "type": "string",
+                        "value": "id"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "index": 3,
+                "terms": [
+                  {
+                    "type": "string",
+                    "value": "eq"
+                  },
+                  {
+                    "type": "ref",
+                    "value": [
+                      {
+                        "type": "var",
+                        "value": "data"
+                      },
+                      {
+                        "type": "string",
+                        "value": "networks"
+                      },
+                      {
+                        "type": "var",
+                        "value": "m"
+                      },
+                      {
+                        "type": "string",
+                        "value": "public"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "boolean",
+                    "value": true
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
     }
   ]
 }
+
 ```
 
 #### Status Codes
@@ -384,7 +391,8 @@ Content-Type: application/json
 {
   "result": {
     "id": "example1",
-    "module": {
+    "raw": "package opa.examples\n\nimport data.servers\nimport data.networks\nimport data.ports\n\npublic_servers[server] {\n\tserver = servers[_]\n\tserver.ports[_] = ports[k].id\n\tports[k].networks[_] = networks[m].id\n\tnetworks[m].public = true\n}\n",
+    "ast": {
       "package": {
         "path": [
           {
@@ -403,17 +411,19 @@ Content-Type: application/json
       },
       "rules": [
         {
-          "name": "public_servers",
-          "key": {
-            "type": "var",
-            "value": "server"
+          "head": {
+            "name": "public_servers",
+            "key": {
+              "type": "var",
+              "value": "server"
+            }
           },
           "body": [
             {
               "index": 0,
               "terms": [
                 {
-                  "type": "var",
+                  "type": "string",
                   "value": "eq"
                 },
                 {
@@ -443,7 +453,7 @@ Content-Type: application/json
               "index": 1,
               "terms": [
                 {
-                  "type": "var",
+                  "type": "string",
                   "value": "eq"
                 },
                 {
@@ -490,7 +500,7 @@ Content-Type: application/json
               "index": 2,
               "terms": [
                 {
-                  "type": "var",
+                  "type": "string",
                   "value": "eq"
                 },
                 {
@@ -545,7 +555,7 @@ Content-Type: application/json
               "index": 3,
               "terms": [
                 {
-                  "type": "var",
+                  "type": "string",
                   "value": "eq"
                 },
                 {
@@ -583,38 +593,9 @@ Content-Type: application/json
 }
 ```
 
-#### Example Request For Source
-
-```http
-GET /v1/policies/example1?source=true HTTP/1.1
-```
-
-#### Example Response For Source
-
-```http
-HTTP/1.1 200 OK
-Content-Type: text/plain; charset=utf-8
-```
-
-```ruby
-package opa.examples
-
-import data.servers
-import data.networks
-import data.ports
-
-public_servers[server] {
-	server = servers[_]
-	server.ports[_] = ports[k].id
-	ports[k].networks[_] = networks[m].id
-	networks[m].public = true
-}
-```
-
 #### Query Parameters
 
-- **source** - If `true` the response will contain the raw source instead of
-  the AST.
+- **pretty** - If parameter is `true`, response will formatted for humans.
 
 #### Status Codes
 
@@ -666,207 +647,13 @@ Content-Type: application/json
 ```
 
 ```json
-{
-  "result": {
-    "id": "example1",
-    "module": {
-      "package": {
-        "path": [
-          {
-            "type": "var",
-            "value": "data"
-          },
-          {
-            "type": "string",
-            "value": "opa"
-          },
-          {
-            "type": "string",
-            "value": "examples"
-          }
-        ]
-      },
-      "rules": [
-        {
-          "name": "public_servers",
-          "key": {
-            "type": "var",
-            "value": "server"
-          },
-          "body": [
-            {
-              "index": 0,
-              "terms": [
-                {
-                  "type": "var",
-                  "value": "eq"
-                },
-                {
-                  "type": "var",
-                  "value": "server"
-                },
-                {
-                  "type": "ref",
-                  "value": [
-                    {
-                      "type": "var",
-                      "value": "data"
-                    },
-                    {
-                      "type": "string",
-                      "value": "servers"
-                    },
-                    {
-                      "type": "var",
-                      "value": "$0"
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "index": 1,
-              "terms": [
-                {
-                  "type": "var",
-                  "value": "eq"
-                },
-                {
-                  "type": "ref",
-                  "value": [
-                    {
-                      "type": "var",
-                      "value": "server"
-                    },
-                    {
-                      "type": "string",
-                      "value": "ports"
-                    },
-                    {
-                      "type": "var",
-                      "value": "$1"
-                    }
-                  ]
-                },
-                {
-                  "type": "ref",
-                  "value": [
-                    {
-                      "type": "var",
-                      "value": "data"
-                    },
-                    {
-                      "type": "string",
-                      "value": "ports"
-                    },
-                    {
-                      "type": "var",
-                      "value": "k"
-                    },
-                    {
-                      "type": "string",
-                      "value": "id"
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "index": 2,
-              "terms": [
-                {
-                  "type": "var",
-                  "value": "eq"
-                },
-                {
-                  "type": "ref",
-                  "value": [
-                    {
-                      "type": "var",
-                      "value": "data"
-                    },
-                    {
-                      "type": "string",
-                      "value": "ports"
-                    },
-                    {
-                      "type": "var",
-                      "value": "k"
-                    },
-                    {
-                      "type": "string",
-                      "value": "networks"
-                    },
-                    {
-                      "type": "var",
-                      "value": "$2"
-                    }
-                  ]
-                },
-                {
-                  "type": "ref",
-                  "value": [
-                    {
-                      "type": "var",
-                      "value": "data"
-                    },
-                    {
-                      "type": "string",
-                      "value": "networks"
-                    },
-                    {
-                      "type": "var",
-                      "value": "m"
-                    },
-                    {
-                      "type": "string",
-                      "value": "id"
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "index": 3,
-              "terms": [
-                {
-                  "type": "var",
-                  "value": "eq"
-                },
-                {
-                  "type": "ref",
-                  "value": [
-                    {
-                      "type": "var",
-                      "value": "data"
-                    },
-                    {
-                      "type": "string",
-                      "value": "networks"
-                    },
-                    {
-                      "type": "var",
-                      "value": "m"
-                    },
-                    {
-                      "type": "string",
-                      "value": "public"
-                    }
-                  ]
-                },
-                {
-                  "type": "boolean",
-                  "value": true
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    }
-  }
-}
+{}
 ```
+
+### Query Parameters
+
+- **pretty** - If parameter is `true`, response will formatted for humans.
+- **metrics** - Return compiler performance metrics in addition to result. See [Performance Metrics](#performance-metrics) for more detail.
 
 #### Status Codes
 
@@ -893,8 +680,18 @@ DELETE /v1/policies/example2 HTTP/1.1
 #### Example Response
 
 ```http
-HTTP/1.1 204 No Content
+HTTP/1.1 200 OK
+Content-Type: application/json
 ```
+
+```json
+{}
+```
+
+#### Query Parameters
+
+- **pretty** - If parameter is `true`, response will formatted for humans.
+- **metrics** - Return compiler performance metrics in addition to result. See [Performance Metrics](#performance-metrics) for more detail.
 
 #### Status Codes
 
@@ -1773,6 +1570,8 @@ OPA currently supports the following query performance metrics:
 - **timer_rego_query_parse_ns**: time taken (in nanonseconds) to parse the query.
 - **timer_rego_query_compile_ns**: time taken (in nanonseconds) to compile the query.
 - **timer_rego_query_eval_ns**: time taken (in nanonseconds) to evaluate the query.
+- **timer_rego_module_parse_ns**: time taken (in nanoseconds) to parse the input policy module.
+- **timer_rego_module_compile_ns**: time taken (in nanoseconds) to compile the loaded policy modules.
 
 ## <a name="diagnostics"></a> Diagnostics
 

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -11,9 +11,11 @@ import (
 
 // Well-known metric names.
 const (
-	RegoQueryCompile = "rego_query_compile"
-	RegoQueryEval    = "rego_query_eval"
-	RegoQueryParse   = "rego_query_parse"
+	RegoQueryCompile  = "rego_query_compile"
+	RegoQueryEval     = "rego_query_eval"
+	RegoQueryParse    = "rego_query_parse"
+	RegoModuleParse   = "rego_module_parse"
+	RegoModuleCompile = "rego_module_compile"
 )
 
 // Metrics defines the interface for a collection of perfomrance metrics in the

--- a/server/types/types.go
+++ b/server/types/types.go
@@ -97,18 +97,24 @@ type PolicyGetResponseV1 struct {
 
 // PolicyPutResponseV1 models the response message for the Policy API put operation.
 type PolicyPutResponseV1 struct {
-	Result PolicyV1 `json:"result"`
+	Metrics MetricsV1 `json:"metrics,omitempty"`
+}
+
+// PolicyDeleteResponseV1 models the response message for the Policy API delete operation.
+type PolicyDeleteResponseV1 struct {
+	Metrics MetricsV1 `json:"metrics,omitempty"`
 }
 
 // PolicyV1 models a policy module in OPA.
 type PolicyV1 struct {
-	ID     string      `json:"id"`
-	Module *ast.Module `json:"module"`
+	ID  string      `json:"id"`
+	Raw string      `json:"raw"`
+	AST *ast.Module `json:"ast"`
 }
 
 // Equal returns true if p is equal to other.
 func (p PolicyV1) Equal(other PolicyV1) bool {
-	return p.ID == other.ID && p.Module.Equal(other.Module)
+	return p.ID == other.ID && p.Raw == other.Raw && p.AST.Equal(other.AST)
 }
 
 // DataRequestV1 models the request message for Data API POST operations.
@@ -376,10 +382,6 @@ const (
 	// ParamInputV1 defines the name of the HTTP URL parameter that specifies
 	// values for the "input" document.
 	ParamInputV1 = "input"
-
-	// ParamSourceV1 defines the name of the HTTP URL parameter that indicates
-	// the client wants to receive the raw (uncompiled) version of the module.
-	ParamSourceV1 = "source"
 
 	// ParamPrettyV1 defines the name of the HTTP URL parameter that indicates
 	// the client wants to receive a pretty-printed version of the response.


### PR DESCRIPTION
These changes update the Policy API responses to:

- Return empty objects for PUT/DELETE with optional support for ?metrics
- Return AST and raw/source for GET

Support for the ?source param has been removed as the raw/source version is now included by default.