### PR TITLE
Correct `opa fmt` panic on missing files

### DIFF
--- a/cmd/fmt.go
+++ b/cmd/fmt.go
@@ -67,6 +67,10 @@ func opaFmt(args []string) int {
 }
 
 func formatFile(filename string, info os.FileInfo, err error) error {
+	if err != nil {
+		return err
+	}
+
 	if info.IsDir() {
 		return nil
 	}


### PR DESCRIPTION
If the provided file name does not exist, `opa fmt` would panic
due to filepath.Walk passing in a nil `os.FileInfo`. The WalkFunc
now checks the incoming error properly to catch this case.