### PR TITLE
Add support for query cancellation

### DIFF
--- a/topdown/cancel.go
+++ b/topdown/cancel.go
@@ -1,0 +1,33 @@
+// Copyright 2017 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package topdown
+
+import (
+	"sync/atomic"
+)
+
+// Cancel defines the interface for cancelling topdown queries. Cancel
+// operations are thread-safe and idempotent.
+type Cancel interface {
+	Cancel()
+	Cancelled() bool
+}
+
+type cancel struct {
+	flag int32
+}
+
+// NewCancel returns a new Cancel object.
+func NewCancel() Cancel {
+	return &cancel{}
+}
+
+func (c *cancel) Cancel() {
+	atomic.StoreInt32(&c.flag, 1)
+}
+
+func (c *cancel) Cancelled() bool {
+	return atomic.LoadInt32(&c.flag) != 0
+}

--- a/topdown/errors.go
+++ b/topdown/errors.go
@@ -23,6 +23,9 @@ const (
 	// InternalErr represents an unknown evaluation error.
 	InternalErr string = "eval_internal_error"
 
+	// CancelErr indicates the evaluation process was cancelled.
+	CancelErr string = "eval_cancel_error"
+
 	// ConflictErr indicates a conflict was encountered during evaluation. For
 	// instance, a conflict occurs if a rule produces multiple, differing values
 	// for the same key in an object. Conflict errors indicate the policy does


### PR DESCRIPTION
These changes add a custom query cancellation mechanism to topdown which
allows callers to terminate in-progress queries that taking too long.