### PR TITLE
Fix release script to expect version not tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,7 @@ release:
 		-v $(PWD)/_release/$(VERSION):/_release/$(VERSION) \
 		-v $(PWD):/_src \
 		$(REPOSITORY)/release-builder:latest \
-		/_src/build/build-release.sh --tag=$(VERSION) --output-dir=/_release/$(VERSION) --source-url=/_src
+		/_src/build/build-release.sh --version=$(VERSION) --output-dir=/_release/$(VERSION) --source-url=/_src
 
 release-local:
 	docker run -it --rm \

--- a/build/build-release.sh
+++ b/build/build-release.sh
@@ -9,7 +9,7 @@ BUILD_DIR=$OPA_DIR/build
 usage() {
     echo "build-release.sh --output-dir=<path>"
     echo "                 --source-url=<git-url>"
-    echo "                 [--tag=<tag>]"
+    echo "                 [--version=<mj.mn.pt>]"
 }
 
 for i in "$@"; do
@@ -22,8 +22,8 @@ for i in "$@"; do
         OUTPUT_DIR="${i#*=}"
         shift
         ;;
-    --tag=*)
-        TAG="${i#*=}"
+    --version=*)
+        VERSION="${i#*=}"
         shift
         ;;
     *)
@@ -51,8 +51,8 @@ build_binaries() {
 clone_repo() {
     git clone $SOURCE_URL /go/src/github.com/open-policy-agent/opa
     cd /go/src/github.com/open-policy-agent/opa
-    if [ -n "$TAG" ]; then
-        git checkout $TAG
+    if [ -n "$VERSION" ]; then
+        git checkout v${VERSION}
     fi
 }
 


### PR DESCRIPTION
When release script was updated as part of the site refresh, the changes
broke the RELEASE.md steps.