### PR TITLE
Correct ambiguous syntax around Body and Set Comprehensions

### DIFF
--- a/ast/parser.go
+++ b/ast/parser.go
@@ -832,11 +832,11 @@ var g = &grammar{
 				alternatives: []interface{}{
 					&ruleRefExpr{
 						pos:  position{line: 385, col: 9, offset: 10356},
-						name: "BraceEnclosedBody",
+						name: "NonWhitespaceBody",
 					},
 					&ruleRefExpr{
 						pos:  position{line: 385, col: 29, offset: 10376},
-						name: "NonWhitespaceBody",
+						name: "BraceEnclosedBody",
 					},
 				},
 			},

--- a/ast/parser_test.go
+++ b/ast/parser_test.go
@@ -353,6 +353,25 @@ func TestSetComprehensions(t *testing.T) {
 	assertParseOneTerm(t, "nested", input, expected)
 }
 
+func TestSetComprehensionsAlone(t *testing.T) {
+	input := `{k | a = [1,2,3]; a[k]}`
+
+	expected := SetComprehensionTerm(
+		VarTerm("k"),
+		NewBody(
+			Equality.Expr(
+				VarTerm("a"),
+				ArrayTerm(NumberTerm("1"), NumberTerm("2"), NumberTerm("3")),
+			),
+			&Expr{
+				Terms: RefTerm(VarTerm("a"), VarTerm("k")),
+			},
+		),
+	)
+
+	assertParseOneTerm(t, "alone", input, expected)
+}
+
 func TestInfixExpr(t *testing.T) {
 	assertParseOneExpr(t, "scalars 1", "true = false", Equality.Expr(BooleanTerm(true), BooleanTerm(false)))
 	assertParseOneExpr(t, "scalars 2", "3.14 = null", Equality.Expr(FloatNumberTerm(3.14), NullTerm()))

--- a/ast/rego.peg
+++ b/ast/rego.peg
@@ -382,7 +382,7 @@ RuleDup <- b:NonEmptyBraceEnclosedBody {
 
 RuleExt <- Else / RuleDup
 
-Body <- BraceEnclosedBody / NonWhitespaceBody
+Body <- NonWhitespaceBody / BraceEnclosedBody
 
 NonEmptyBraceEnclosedBody <- "{" _ val:WhitespaceBody? _ "}" {
     if val == nil {


### PR DESCRIPTION
The grammar definition was ambigious to whether a lone Set Comprehension
was a Set Comprehension at all, instead parsing it as a Body. An example
is:
    `{k | a = [1, 2, 3]; a[k]}`

The parser would interpret this as a Body with the expressions
`[1, 2, 3] = k | a` and `a[k]`, which is not the intended result. To
resolve this, the parser now prioritizes `NonWhitespaceBody`s over
`BraceEnclosedBody`s in order to parse Set Comprehensions passed to
the REPL or as queries properly.

Fixes #377

Co-Authored-By: Torin Sandall <torinsandall@gmail.com>