### PR TITLE
Insert language builtins into the TypeEnv on compiler creation

### DIFF
--- a/ast/check.go
+++ b/ast/check.go
@@ -147,13 +147,8 @@ func (tc *typeChecker) checkFunc(env *TypeEnv, fn *Func) {
 	env.PutFunc(name, argTypes)
 }
 
-func (tc *typeChecker) checkLanguageBuiltins(env *TypeEnv) *TypeEnv {
-	if env == nil {
-		env = NewTypeEnv()
-	} else {
-		env = env.wrap()
-	}
-
+func (tc *typeChecker) checkLanguageBuiltins() *TypeEnv {
+	env := NewTypeEnv()
 	for _, bi := range Builtins {
 		env.PutFunc(bi.Name, bi.Args)
 	}

--- a/ast/check_test.go
+++ b/ast/check_test.go
@@ -225,8 +225,7 @@ func TestCheckInference(t *testing.T) {
 		test.Subtest(t, tc.note, func(t *testing.T) {
 			body := MustParseBody(tc.query)
 			checker := newTypeChecker()
-			env := NewTypeEnv()
-			env = checker.checkLanguageBuiltins(env)
+			env := checker.checkLanguageBuiltins()
 			env, err := checker.CheckBody(env, body)
 			if len(err) != 0 {
 				t.Fatalf("Unexpected error: %v", err)
@@ -487,9 +486,8 @@ func TestCheckBadCardinality(t *testing.T) {
 	}
 	for _, test := range tests {
 		body := MustParseBody(test.body)
-		env := NewTypeEnv()
 		tc := newTypeChecker()
-		env = tc.checkLanguageBuiltins(env)
+		env := tc.checkLanguageBuiltins()
 		_, err := tc.CheckBody(env, body)
 		if len(err) != 1 || err[0].Code != TypeErr {
 			t.Fatalf("Expected 1 type error from %v but got: %v", body, err)


### PR DESCRIPTION
Since language builtins never change, they can be inserted into the
TypeEnv before any compilation takes place.