### PR TITLE
Update format package to support raw strings

### DIFF
--- a/format/format.go
+++ b/format/format.go
@@ -421,6 +421,10 @@ func (w *writer) writeTerm(term *ast.Term, comments []*ast.Comment) []*ast.Comme
 		comments = w.writeObjectComprehension(x, term.Location, comments)
 	case *ast.SetComprehension:
 		comments = w.writeSetComprehension(x, term.Location, comments)
+	case ast.String:
+		// To preserve raw strings, we need to output the original text,
+		// not what x.String() would give us.
+		w.write(string(term.Location.Text))
 	case fmt.Stringer:
 		w.write(x.String())
 	}

--- a/format/testfiles/test.rego
+++ b/format/testfiles/test.rego
@@ -50,6 +50,12 @@ long(x) = true {
     x = "bar"
     }
 
+raw_string = `hi\there`
+raw_multiline = `this
+string
+  is on
+multiple lines`
+
 foo([x, y,
 z], {"foo": a}) = b {
 split(x, y, c)

--- a/format/testfiles/test.rego.formatted
+++ b/format/testfiles/test.rego.formatted
@@ -55,6 +55,13 @@ short(x) {
 	x = "bar"
 }
 
+raw_string = `hi\there`
+
+raw_multiline = `this
+string
+  is on
+multiple lines`
+
 foo([
 	x, y,
 	z,


### PR DESCRIPTION
Currently format turns them into properly escaped quoted strings, which maintains correctness, but not desired.