### PR TITLE
Add watch package to `make test` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,8 @@ PACKAGES := \
 	github.com/open-policy-agent/opa/topdown/.../ \
 	github.com/open-policy-agent/opa/types/.../ \
 	github.com/open-policy-agent/opa/util/.../ \
-	github.com/open-policy-agent/opa/test/.../
+	github.com/open-policy-agent/opa/test/.../ \
+	github.com/open-policy-agent/opa/watch/.../
 
 GO := go
 GOARCH := $(shell go env GOARCH)

--- a/watch/watch_test.go
+++ b/watch/watch_test.go
@@ -98,6 +98,18 @@ func TestWatchSimple(t *testing.T) {
 				t.Errorf("Expected result set length 1, got %d", len(e.Value))
 			}
 
+			for s, v := range e.Metrics.All() {
+				if d := v.(int64); d == 0 {
+					t.Errorf("Expected non-zero metrics, got %s:%d", s, d)
+				}
+			}
+			e.Metrics = nil
+
+			if len(e.Tracer) != 3 {
+				t.Errorf("Expected explanation to have length 3, got %d", len(e.Tracer))
+			}
+			e.Tracer = nil
+
 			e.Value[0].Expressions = nil
 			if !reflect.DeepEqual(exp[i], e) {
 				t.Errorf("Expected notification %v, got %v", exp[i], e)


### PR DESCRIPTION
Also correct a bug in the watch tests. They had not been updated to
expect metrics and evaluation traces.