### PR TITLE
Properly remove temporary files when running `opa fmt -d`

### DIFF
--- a/cmd/fmt.go
+++ b/cmd/fmt.go
@@ -167,10 +167,15 @@ func doDiff(old, new []byte) (stdout, stderr bytes.Buffer, err error) {
 	if err != nil {
 		return stdout, stderr, err
 	}
+	defer os.Remove(o.Name())
+	defer o.Close()
+
 	n, err := ioutil.TempFile("", ".opafmt")
 	if err != nil {
 		return stdout, stderr, err
 	}
+	defer os.Remove(n.Name())
+	defer n.Close()
 
 	o.Write(old)
 	n.Write(new)


### PR DESCRIPTION
When computing diffs, `opa fmt` created temporary files in order to use
the diff utility. However, it did not properly clean up after itself,
leaving these temporary files behind.