### PR TITLE
Add walk built-in function

### DIFF
--- a/ast/builtins.go
+++ b/ast/builtins.go
@@ -58,6 +58,9 @@ var DefaultBuiltins = [...]*Builtin{
 
 	// Time
 	NowNanos, ParseNanos, ParseRFC3339Nanos,
+
+	// Graphs
+	WalkBuiltin,
 }
 
 // BuiltinMap provides a convenient mapping of built-in names to
@@ -586,6 +589,27 @@ var ParseRFC3339Nanos = &Builtin{
 	Args: []types.Type{
 		types.S,
 		types.N,
+	},
+	TargetPos: []int{1},
+}
+
+/**
+ * Graphs.
+ */
+
+// WalkBuiltin generates [path, value] tuples for all nested documents
+// (recursively).
+var WalkBuiltin = &Builtin{
+	Name: String("walk"),
+	Args: []types.Type{
+		types.A,
+		types.NewArray(
+			[]types.Type{
+				types.NewArray(nil, types.A),
+				types.A,
+			},
+			nil,
+		),
 	},
 	TargetPos: []int{1},
 }

--- a/docs/book/language-reference.md
+++ b/docs/book/language-reference.md
@@ -100,7 +100,13 @@ The input `string` is a JSON Web Token encoded with JWS Compact Serialization. J
 | <span class="opa-keep-it-together">``time.parse_rfc3339_ns(value, output)``</span> | 1 | ``output`` is ``number`` representing the time ``value`` in nanoseconds since epoch.`` |
 
 > Multiple calls to the `time.now_ns` built-in function within a single policy
-evaluation query will always the same value.
+evaluation query will always return the same value.
+
+### <a name="graphs"/>Graphs
+
+| Built-in | Inputs | Description |
+| --- | --- | --- |
+| <span class="opa-keep-it-together">``walk(x, [path, value])``</span> | 0 | ``path`` is ``array`` representing a pointer to ``value`` in ``x``.  Queries can use ``walk`` to traverse documents nested under ``x`` (recursively). |
 
 ## <a name="reserved-names"></a> Reserved Names
 

--- a/topdown/example_test.go
+++ b/topdown/example_test.go
@@ -204,13 +204,10 @@ func ExampleRegisterFunctionalBuiltin1() {
 		return nil
 	})
 
-	// If you are adding new built-in functions to upstream OPA, you must also
-	// update the [Language
-	// Reference](http://www.openpolicyagent.org/documentation/references/language/)
-	// and [How Do I Write
-	// Policies](http://www.openpolicyagent.org/documentation/how-do-i-write-policies/)
-	// documents. In addition, you must add tests for your new built-in. See the
-	// existing integration tests in the topdown package.
+	// If you add a new built-in function to OPA, you should:
+	//
+	// 1. Update the Language Reference: http://www.openpolicyagent.org/docs/language-reference.html.
+	// 2. Add an integration test to the topdown package.
 
 	// Output:
 	//

--- a/topdown/walk.go
+++ b/topdown/walk.go
@@ -1,0 +1,68 @@
+// Copyright 2017 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package topdown
+
+import "github.com/open-policy-agent/opa/ast"
+
+func evalWalk(t *Topdown, expr *ast.Expr, iter Iterator) error {
+
+	a, err := ResolveRefs(expr.Operand(0).Value, t)
+	if err != nil {
+		return err
+	}
+
+	b := expr.Operand(1)
+
+	return walkRec(t, b.Value, a, ast.Array{}, iter)
+}
+
+func walkRec(t *Topdown, output ast.Value, v ast.Value, path ast.Array, iter Iterator) error {
+
+	if err := unifyAndContinue(t, iter, ast.Array{ast.NewTerm(path), ast.NewTerm(v)}, output); err != nil {
+		return err
+	}
+
+	if ast.IsScalar(v) {
+		return nil
+	}
+
+	switch v := v.(type) {
+	case ast.Array:
+		for i := range v {
+			path = append(path, ast.IntNumberTerm(i))
+			if err := walkRec(t, output, v[i].Value, path, iter); err != nil {
+				return err
+			}
+			path = path[:len(path)-1]
+		}
+	case ast.Object:
+		for _, p := range v {
+			path = append(path, p[0])
+			if err := walkRec(t, output, p[1].Value, path, iter); err != nil {
+				return err
+			}
+			path = path[:len(path)-1]
+		}
+	case *ast.Set:
+		var err error
+		v.Iter(func(e *ast.Term) bool {
+			path = append(path, e)
+			if err = walkRec(t, output, e.Value, path, iter); err != nil {
+				return true
+			}
+			path = path[:len(path)-1]
+			return false
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func init() {
+	RegisterBuiltinFunc(ast.WalkBuiltin.Name, evalWalk)
+}


### PR DESCRIPTION
While working on Terraform policies we encountered JSON documents that
can be nested arbitrarily, e.g.:

```
foo:
  bar:
    baz:
     v: 1
    qux:
     v: 2
  corge:
    v: 3
```

In the Terraform case, we want to process objects at foo.bar.baz,
foo.bar.qux, and foo.corge, however, we don't know ahead of time what
these paths will be.

To handle this, we add a new built-in function 'walk' that traverses all
documents nested under the input.