### PR TITLE
Add dev-patch target to improve release process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,3 +149,9 @@ release-patch:
 		-v $(PWD):/_src \
 		python:2.7 \
 		/_src/build/gen-release-patch.sh --version=$(VERSION) --source-url=/_src
+
+dev-patch:
+	@docker run -it --rm \
+		-v $(PWD):/_src \
+		python:2.7 \
+		/_src/build/gen-dev-patch.sh --version=$(VERSION) --source-url=/_src

--- a/build/gen-dev-patch.sh
+++ b/build/gen-dev-patch.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+set -e
+
+OPA_DIR=/go/src/github.com/open-policy-agent/opa
+
+usage() {
+    echo "gen-dev-patch.sh --source-url=<git-url>"
+    echo "                 --version=<mj.mn.pt>"
+}
+
+for i in "$@"; do
+    case $i in
+    --source-url=*)
+        SOURCE_URL="${i#*=}"
+        shift
+        ;;
+    --version=*)
+        VERSION="${i#*=}"
+        shift
+        ;;
+    *)
+        usage
+        exit 1
+        ;;
+    esac
+done
+
+if [ -z "$SOURCE_URL" ]; then
+    usage
+    exit 1
+elif [ -z "$VERSION" ]; then
+    usage
+    exit 1
+fi
+
+git clone $SOURCE_URL $OPA_DIR
+cd $OPA_DIR
+
+LAST_VERSION=$(git describe --abbrev=0 --tags | cut -c 2-)
+
+update_makefile() {
+    sed -i='' -e "s/^VERSION[ \t]*:=[ \t]*.\+$/VERSION := $VERSION-dev/" Makefile
+}
+
+update_changelog() {
+    cat >_CHANGELOG.md <<EOF
+$(awk "1;/## $LAST_VERSION/{exit}" CHANGELOG.md | sed '$d')
+
+## Unreleased
+
+## $LAST_VERSION
+$(sed "1,/## $LAST_VERSION/d" CHANGELOG.md)
+EOF
+
+    mv _CHANGELOG.md CHANGELOG.md
+}
+
+main() {
+    update_makefile
+    update_changelog
+    git --no-pager diff --no-color
+}
+
+main

--- a/docs/devel/RELEASE.md
+++ b/docs/devel/RELEASE.md
@@ -34,10 +34,11 @@ CHANGELOG.md snippet and uploading the binaries from the build phase.
 	make release-patch VERSION=0.12.8 > ~/release.patch
 	```
 
-1. Apply the release patch to the working copy:
+1. Apply the release patch to the working copy and preview the changes:
 
 	```
 	patch -p1 < ~/release.patch
+	git diff
 	```
 
 	> Amend the changes as necessary, e.g., many of the Fixes and Miscellaneous
@@ -58,9 +59,20 @@ CHANGELOG.md snippet and uploading the binaries from the build phase.
 	git push origin --tags
 	```
 
-1. Edit CHANGELOG.md to add back the Unreleased header to prepare for development.
+1. Execute the dev-patch target to generate boilerplate patch. Give the semantic version of the next release:
 
-1. Edit Makefile to set VERSION variable to prepare for development (e.g., s/VERSION := “0.12.8”/VERSION = “0.12.9-dev”/).
+	```
+	make dev-patch VERSION=0.12.9 > ~/dev.patch
+	```
+
+	> The semantic version of the next release typically increments the point version by one.
+
+1. Apply the patch to the working copy and preview the changes:
+
+	```
+	patch -p1 < ~/dev.patch
+	git diff
+	```
 
 1. Commit the changes and push to remote repository.
 


### PR DESCRIPTION
This removes some of the manual labour of performing a release. Namely,
in the typical case, the Makefile and CHANGELOG don't have to edited by
hand.