### PR TITLE
Add support for partial doc shorthand

### DIFF
--- a/ast/policy.go
+++ b/ast/policy.go
@@ -1095,6 +1095,12 @@ func (expr *Expr) OutputVars(safe VarSet) VarSet {
 	return VarSet{}
 }
 
+// SetLocation sets the expr's location and returns the expr itself.
+func (expr *Expr) SetLocation(loc *Location) *Expr {
+	expr.Location = loc
+	return expr
+}
+
 func (expr *Expr) String() string {
 	var buf []string
 	if expr.Negated {

--- a/format/format.go
+++ b/format/format.go
@@ -218,7 +218,8 @@ func (w *writer) writeRule(rule *ast.Rule, comments []*ast.Comment) []*ast.Comme
 	// `foo = {"a": "b"} { true }` in the AST. We want to preserve that notation
 	// in the formatted code instead of expanding the bodies into rules, so we
 	// pretend that the rule has no body in this case.
-	isExpandedConst := rule.Head.DocKind() == ast.CompleteDoc && rule.Body.Equal(ast.NewBody(ast.NewExpr(ast.BooleanTerm(true))))
+	isExpandedConst := rule.Body.Equal(ast.NewBody(ast.NewExpr(ast.BooleanTerm(true))))
+
 	if len(rule.Body) == 0 || isExpandedConst {
 		w.endLine()
 		return comments
@@ -409,7 +410,6 @@ func (w *writer) writeTerm(term *ast.Term, comments []*ast.Comment) []*ast.Comme
 	switch x := term.Value.(type) {
 	case ast.Ref:
 		w.write(x.String())
-		return comments
 	case ast.Object:
 		comments = w.writeObject(x, term.Location, comments)
 	case ast.Array:
@@ -423,9 +423,14 @@ func (w *writer) writeTerm(term *ast.Term, comments []*ast.Comment) []*ast.Comme
 	case *ast.SetComprehension:
 		comments = w.writeSetComprehension(x, term.Location, comments)
 	case ast.String:
-		// To preserve raw strings, we need to output the original text,
-		// not what x.String() would give us.
-		w.write(string(term.Location.Text))
+		if term.Location.Text[0] == '.' {
+			// This string was parsed from a ref, so preserve the value.
+			w.write(`"%s"`, string(x))
+		} else {
+			// To preserve raw strings, we need to output the original text,
+			// not what x.String() would give us.
+			w.write(string(term.Location.Text))
+		}
 	case fmt.Stringer:
 		w.write(x.String())
 	}

--- a/format/testfiles/test.rego
+++ b/format/testfiles/test.rego
@@ -19,6 +19,16 @@ not x = g
 globals = {"foo": "bar",
 "fizz": "buzz"}
 
+partial_obj["x"] = 1
+partial_obj.y = 2
+
+partial_obj["z"] = 3 {
+    true
+}
+
+partial_set["x"]
+partial_set.y
+
 # Latent comment.
 
 r = y {
@@ -84,8 +94,8 @@ a = {"a": "b", "c": "d"}
 b = [1, 2, 3, 4]
 c = [1, 2,
 # Comment inside array
-3, 4, 
-5, 6, 7, 
+3, 4,
+5, 6, 7,
 8,
 ] # Comment on closing array bracket.
 
@@ -115,7 +125,7 @@ m = {y:
 x | split("foo.bar", ".", x); y = x[_]}
 n = {y:  x | split("foo.bar", ".", x)
 y = x[_]}
-o = {y: x | 
+o = {y: x |
 split("foo.bar", ".", x) # comment in object comprehension
 y = x[_]
 

--- a/format/testfiles/test.rego.formatted
+++ b/format/testfiles/test.rego.formatted
@@ -22,6 +22,16 @@ globals = {
 	"fizz": "buzz",
 }
 
+partial_obj["x"] = 1
+
+partial_obj["y"] = 2
+
+partial_obj["z"] = 3
+
+partial_set["x"]
+
+partial_set["y"]
+
 # Latent comment.
 
 r = y {

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -762,6 +762,10 @@ func (r *REPL) evalStatement(ctx context.Context, stmt interface{}) error {
 			return err
 		}
 
+		// This will only parse rules from equality expressions that can be
+		// interpreted as rules defining complete docs because rules defining
+		// partial sets/objects would fail to compile above (due to the head of
+		// the ref being unsafe, e.g., p["foo"] = "bar".
 		rule, err3 := ast.ParseRuleFromBody(r.modules[r.currentModuleID], body)
 		if err3 == nil {
 			return r.compileRule(ctx, rule)

--- a/repl/repl_test.go
+++ b/repl/repl_test.go
@@ -298,13 +298,9 @@ import input.xyz` + "\n\n"
 import data.foo as bar
 import input.xyz
 
-p[1] {
-	true
-}
+p[1]
 
-p[2] {
-	true
-}` + "\n\n"
+p[2]` + "\n\n"
 	assertREPLText(t, buffer, expected)
 	buffer.Reset()
 


### PR DESCRIPTION
These changes allow partial docs to be defined without a body in Rego
source files. Before, the rules would have to include a `{true}` body
for the parser to allow them. Now, the body can be omitted.

Rules defined this way (inside modules) cannot be copy/pasted as-is into
the REPL. This could be addressed by creating a "paste mode" in the REPL
similar to ipython and other interactive shells.

These changes build on https://github.com/open-policy-agent/opa/pull/412
with a few differences:

- Dynamic values are allowed in the head.
- Partial sets are allowed.

Both of these changes are based on personal experience writing policy.
Dynamic values are fine to allow as the compiler will catch unsafe vars
and rewrite the head to handle refs and comprehensions.