### PR TITLE
Remove dead code associated with input doc errors

### DIFF
--- a/ast/compile.go
+++ b/ast/compile.go
@@ -996,46 +996,6 @@ func (qc *queryCompiler) checkSafety(_ *QueryContext, body Body) (Body, error) {
 	return reordered, nil
 }
 
-// referencesInput returns true if expr refers to the input document. This
-// function will not visit closures.
-func referencesInput(expr *Expr) bool {
-
-	found := false
-
-	vis := NewGenericVisitor(func(x interface{}) bool {
-		if found {
-			return found
-		}
-		switch x := x.(type) {
-		case *ArrayComprehension, *ObjectComprehension, *SetComprehension: // skip closures
-			return true
-		case Ref:
-			if x.HasPrefix(InputRootRef) {
-				found = true
-				return found
-			}
-		}
-		return false
-	})
-
-	Walk(vis, expr)
-
-	return found
-}
-
-// definesInput returns true if expr defines the input document using the with
-// modifier.
-func definesInput(expr *Expr) bool {
-	for _, w := range expr.With {
-		if ref, ok := w.Target.Value.(Ref); ok {
-			if ref.HasPrefix(InputRootRef) {
-				return true
-			}
-		}
-	}
-	return false
-}
-
 func (qc *queryCompiler) checkTypes(qctx *QueryContext, body Body) (Body, error) {
 	var errs Errors
 	checker := newTypeChecker()

--- a/ast/errors.go
+++ b/ast/errors.go
@@ -46,10 +46,6 @@ const (
 
 	// RecursionErr indicates recursion was found during compilation.
 	RecursionErr = "rego_recursion_error"
-
-	// InputErr indicates the query depends on input but no input or conflicting
-	// input was provided.
-	InputErr = "rego_input_error"
 )
 
 // IsError returns true if err is an AST error with code.

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -744,21 +744,7 @@ func (r *REPL) evalStatement(ctx context.Context, stmt interface{}) error {
 		}
 
 		body, typeEnv, err := r.compileBody(ctx, s, input)
-
 		if err != nil {
-			// The compile step can fail if input is undefined. In that case,
-			// we still want to allow users to define an input document (e.g.,
-			// "input = { ... }") so try to parse a rule nonetheless.
-			if ast.IsError(ast.InputErr, err) {
-				rule, err2 := ast.ParseRuleFromBody(r.modules[r.currentModuleID], s)
-				if err2 != nil {
-					// The statement cannot be understood as a rule, so the original
-					// error returned from compiling the query should be given the
-					// caller.
-					return err
-				}
-				return r.compileRule(ctx, rule)
-			}
 			return err
 		}
 

--- a/server/server.go
+++ b/server/server.go
@@ -1463,8 +1463,6 @@ func getExplain(p []string, zero types.ExplainModeV1) types.ExplainModeV1 {
 	return zero
 }
 
-var errInputPathFormat = fmt.Errorf(`input parameter format is [[<path>]:]<value> where <path> is either var or ref`)
-
 func readInputV0(r io.ReadCloser) (ast.Value, error) {
 
 	bs, err := ioutil.ReadAll(r)
@@ -1513,7 +1511,7 @@ func readInputPostV1(r io.ReadCloser) (ast.Value, error) {
 		}
 
 		if request.Input == nil {
-			return nil, fmt.Errorf(types.MsgInputDocError)
+			return nil, nil
 		}
 
 		return ast.InterfaceToValue(*request.Input)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -285,6 +285,9 @@ p = true { false }`
 				"message": "body contains malformed input document: invalid character '@' looking for beginning of value"
 			}`},
 		}},
+		{"post empty object", []tr{
+			tr{http.MethodPost, "/data", `{}`, 200, `{"result": {}}`},
+		}},
 		{"evaluation conflict", []tr{
 			tr{http.MethodPut, "/policies/test", testMod4, 200, ""},
 			tr{http.MethodPost, "/data/testmod/p", "", 500, `{

--- a/server/types/types.go
+++ b/server/types/types.go
@@ -72,7 +72,6 @@ const (
 	MsgCompileModuleError         = "error(s) occurred while compiling module(s)"
 	MsgCompileQueryError          = "error(s) occurred while compiling query"
 	MsgEvaluationError            = "error(s) occurred while evaluating query"
-	MsgInputDocError              = "input document is missing or conflicts with query"
 	MsgUnauthorizedUndefinedError = "authorization policy missing or undefined"
 	MsgUnauthorizedError          = "request rejected by administrative policy"
 	MsgUndefinedError             = "document missing or undefined"

--- a/server/writer/writer.go
+++ b/server/writer/writer.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/server/types"
 	"github.com/open-policy-agent/opa/storage"
 	"github.com/open-policy-agent/opa/topdown"
@@ -30,11 +29,6 @@ func ErrorAuto(w http.ResponseWriter, err error) {
 
 	if topdown.IsError(err) {
 		Error(w, http.StatusInternalServerError, types.NewErrorV1(types.CodeInternal, types.MsgEvaluationError).WithError(err))
-		return
-	}
-
-	if ast.IsError(ast.InputErr, err) {
-		Error(w, http.StatusBadRequest, types.NewErrorV1(types.CodeInvalidParameter, types.MsgInputDocError).WithError(err))
 		return
 	}
 


### PR DESCRIPTION
In b23cb4e the compiler was changed to allow queries to refer to the
input document without the input document being defined. Those changes
did not remove all of the code associated with input errors.

These changes remove the remaining (dead) code associated with input
errors and also update the server to allow Data API POST requests that
do not specify an input document.