### PR TITLE
Fix incorrect REPL interpretation of some exprs

### DIFF
--- a/ast/parser_test.go
+++ b/ast/parser_test.go
@@ -1040,6 +1040,8 @@ foo["9"] = "10"
 foo.buz = "bar"
 bar[1]
 bar[[{"foo":"baz"}]]
+input = 1
+data = 2
 `
 
 	assertParseModule(t, "rules from bodies", testModule, &Module{
@@ -1056,6 +1058,8 @@ bar[[{"foo":"baz"}]]
 			MustParseRule(`foo["buz"] = "bar" { true }`),
 			MustParseRule(`bar[1] { true }`),
 			MustParseRule(`bar[[{"foo":"baz"}]] { true }`),
+			MustParseRule(`input = 1 { true }`),
+			MustParseRule(`data = 2 { true }`),
 		},
 	})
 
@@ -1106,12 +1110,24 @@ data = {"bar": 2} { true }`
 
 	p["x"].y`
 
+	negated := `
+	package a.b.c
+
+	not p = 1`
+
+	nonRefTerm := `
+	package a.b.c
+
+	p`
+
 	assertParseModuleError(t, "multiple expressions", multipleExprs)
 	assertParseModuleError(t, "non-equality", nonEquality)
 	assertParseModuleError(t, "non-var name", nonVarName)
 	assertParseModuleError(t, "with expr", withExpr)
 	assertParseModuleError(t, "bad ref (too long)", badRefLen1)
 	assertParseModuleError(t, "bad ref (too long)", badRefLen2)
+	assertParseModuleError(t, "negated", negated)
+	assertParseModuleError(t, "non ref term", nonRefTerm)
 }
 
 func TestWildcards(t *testing.T) {

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -748,13 +748,12 @@ func (r *REPL) evalStatement(ctx context.Context, stmt interface{}) error {
 			return err
 		}
 
-		// This will only parse rules from equality expressions that can be
-		// interpreted as rules defining complete docs because rules defining
-		// partial sets/objects would fail to compile above (due to the head of
-		// the ref being unsafe, e.g., p["foo"] = "bar".
-		rule, err3 := ast.ParseRuleFromBody(r.modules[r.currentModuleID], body)
-		if err3 == nil {
-			return r.compileRule(ctx, rule)
+		if len(body) == 1 && body[0].IsEquality() {
+			expr := body[0]
+			rule, err := ast.ParseCompleteDocRuleFromEqExpr(r.modules[r.currentModuleID], expr.Operand(0), expr.Operand(1))
+			if err == nil {
+				return r.compileRule(ctx, rule)
+			}
 		}
 
 		compiler, err := r.loadCompiler(ctx)

--- a/repl/repl_test.go
+++ b/repl/repl_test.go
@@ -939,6 +939,23 @@ func TestEvalBodyInputComplete(t *testing.T) {
 		t.Fatalf("Expected 1 but got: %v", result)
 	}
 
+	// Test that deferencing undefined input results in undefined
+	buffer.Reset()
+
+	repl = newRepl(store, &buffer)
+	repl.OneShot(ctx, `input.p`)
+	result = buffer.String()
+	if result != "undefined\n" {
+		t.Fatalf("Expected undefined but got: %v", result)
+	}
+
+	buffer.Reset()
+	repl.OneShot(ctx, `input.p = false`)
+	result = buffer.String()
+	if result != "false\n" {
+		t.Fatalf("Expected false but got: %v", result)
+	}
+
 }
 
 func TestEvalBodyWith(t *testing.T) {


### PR DESCRIPTION
These changes refactor the parser extensions that convert bodies into
rules if they can interpreted as such. The cases that can be converted
are clearer now and the test coverage is improved.

Fixes #433