### PR TITLE
Suppress match errors if closures contained errors

### DIFF
--- a/ast/check_test.go
+++ b/ast/check_test.go
@@ -473,6 +473,19 @@ func TestCheckErrorSuppression(t *testing.T) {
 	if !ok {
 		t.Fatalf("Expected ref error but got: %v", errs)
 	}
+
+	query = `_ = [true | count(1)]`
+
+	_, errs = newTypeChecker().CheckBody(newTypeChecker().checkLanguageBuiltins(), MustParseBody(query))
+	if len(errs) != 1 {
+		t.Fatalf("Expected exactly one error but got: %v", errs)
+	}
+
+	_, ok = errs[0].Details.(*ArgErrDetail)
+	if !ok {
+		t.Fatalf("Expected arg error but got: %v", errs)
+	}
+
 }
 
 func TestCheckBadCardinality(t *testing.T) {


### PR DESCRIPTION
These changes modify the type checker to run on closures contained in
the expression before the containing expression. This way the type
checker can suppress less specific/actionable match errors in the same
way it does for ref errors.

Fixes #438