### PR TITLE
Add support for policy tests

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/loader"
-
 	"github.com/spf13/cobra"
 )
 
@@ -56,6 +55,6 @@ func checkModules(args []string) int {
 }
 
 func init() {
-	checkCommand.Flags().IntVarP(&errLimit, "max-errors", "m", ast.CompileErrorLimitDefault, "set the number of errors to allow before compilation fails early")
+	setMaxErrors(checkCommand.Flags(), &errLimit)
 	RootCommand.AddCommand(checkCommand)
 }

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -19,8 +19,8 @@ var errLimit int
 
 var checkCommand = &cobra.Command{
 	Use:   "check",
-	Short: "Check policies for errors",
-	Long: `Check that policy source files can be parsed and compiled.
+	Short: "Check Rego source files",
+	Long: `Check Rego source files for parse and compilation errors.
 
 If the 'check' command succeeds in parsing and compiling the source file(s), no output
 is produced. If the parsing or compiling fails, 'check' will output the errors

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -13,6 +13,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var checkParams = struct {
+	errLimit int
+}{}
+
 var errLimit int
 
 var checkCommand = &cobra.Command{
@@ -42,7 +46,7 @@ func checkModules(args []string) int {
 		modules[m.Name] = m.Parsed
 	}
 
-	compiler := ast.NewCompiler().SetErrorLimit(errLimit)
+	compiler := ast.NewCompiler().SetErrorLimit(checkParams.errLimit)
 
 	if compiler.Compile(modules); compiler.Failed() {
 		for _, err := range compiler.Errors {
@@ -55,6 +59,6 @@ func checkModules(args []string) int {
 }
 
 func init() {
-	setMaxErrors(checkCommand.Flags(), &errLimit)
+	setMaxErrors(checkCommand.Flags(), &checkParams.errLimit)
 	RootCommand.AddCommand(checkCommand)
 }

--- a/cmd/errors.go
+++ b/cmd/errors.go
@@ -1,0 +1,14 @@
+// Copyright 2017 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package cmd
+
+import (
+	"github.com/open-policy-agent/opa/ast"
+	"github.com/spf13/pflag"
+)
+
+func setMaxErrors(fs *pflag.FlagSet, errLimit *int) {
+	fs.IntVarP(errLimit, "max-errors", "m", ast.CompileErrorLimitDefault, "set the number of errors to allow before compilation fails early")
+}

--- a/cmd/fmt.go
+++ b/cmd/fmt.go
@@ -28,8 +28,8 @@ var (
 
 var formatCommand = &cobra.Command{
 	Use:   "fmt",
-	Short: "Format Rego source code",
-	Long: `Format Rego source code.
+	Short: "Format Rego source files",
+	Long: `Format Rego source files.
 
 The 'fmt' command takes a Rego source file and outputs a reformatted version.
 The format of the output is not defined specifically; whatever this tool outputs

--- a/cmd/fmt.go
+++ b/cmd/fmt.go
@@ -20,11 +20,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
+var fmtParams = struct {
 	overwrite bool
 	list      bool
 	diff      bool
-)
+}{}
 
 var formatCommand = &cobra.Command{
 	Use:   "fmt",
@@ -94,12 +94,12 @@ func formatFile(filename string, info os.FileInfo, err error) error {
 	}
 
 	var out io.Writer = os.Stdout
-	if list {
+	if fmtParams.list {
 		fmt.Fprintln(out, filename)
 		out = ioutil.Discard
 	}
 
-	if diff {
+	if fmtParams.diff {
 		stdout, stderr, err := doDiff(contents, formatted)
 		if err != nil && stdout.Len() == 0 {
 			fmt.Fprintln(os.Stderr, stderr.String())
@@ -112,7 +112,7 @@ func formatFile(filename string, info os.FileInfo, err error) error {
 		out = ioutil.Discard
 	}
 
-	if overwrite {
+	if fmtParams.overwrite {
 		backupName := filename + ".bak"
 		if _, err := os.Stat(backupName); err == nil || !os.IsNotExist(err) {
 			backupName, err = requestBackupName(backupName)
@@ -203,8 +203,8 @@ func newError(msg string, a ...interface{}) fmtError {
 }
 
 func init() {
-	formatCommand.Flags().BoolVarP(&overwrite, "write", "w", false, "overwrite the original source file")
-	formatCommand.Flags().BoolVarP(&list, "list", "l", false, "list all files who would change when formatted")
-	formatCommand.Flags().BoolVarP(&diff, "diff", "d", false, "only display a diff of the changes")
+	formatCommand.Flags().BoolVarP(&fmtParams.overwrite, "write", "w", false, "overwrite the original source file")
+	formatCommand.Flags().BoolVarP(&fmtParams.list, "list", "l", false, "list all files who would change when formatted")
+	formatCommand.Flags().BoolVarP(&fmtParams.diff, "diff", "d", false, "only display a diff of the changes")
 	RootCommand.AddCommand(formatCommand)
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"path"
 
-	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/runtime"
 	"github.com/open-policy-agent/opa/server"
 	"github.com/open-policy-agent/opa/util"
@@ -128,7 +127,7 @@ For example:
 	runCommand.Flags().StringVarP(&params.InsecureAddr, "insecure-addr", "", "", "set insecure listening address of the server")
 	runCommand.Flags().StringVarP(&params.OutputFormat, "format", "f", "pretty", "set shell output format, i.e, pretty, json")
 	runCommand.Flags().BoolVarP(&params.Watch, "watch", "w", false, "watch command line files for changes")
-	runCommand.Flags().IntVarP(&params.ErrorLimit, "max-errors", "m", ast.CompileErrorLimitDefault, "set the number of errors to allow before compilation fails early")
+	setMaxErrors(runCommand.Flags(), &params.ErrorLimit)
 	runCommand.Flags().IntVarP(&params.ServerDiagnosticsBufferSize, "server-diagnostics-buffer-size", "", server.DefaultDiagnosticsBufferSize, "set the size of the server's diagnostics buffer")
 	runCommand.Flags().StringVarP(&tlsCertFile, "tls-cert-file", "", "", "set path of TLS certificate file")
 	runCommand.Flags().StringVarP(&tlsPrivateKeyFile, "tls-private-key-file", "", "", "set path of TLS private key file")

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -1,0 +1,120 @@
+// Copyright 2017 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/tester"
+	"github.com/spf13/cobra"
+)
+
+var testParams = struct {
+	verbose  bool
+	errLimit int
+	timeout  time.Duration
+}{}
+
+var testCommand = &cobra.Command{
+	Use:   "test",
+	Short: "Execute Rego test cases",
+	Long: `Execute Rego test cases.
+
+The 'test' command takes a file or directory path as input and executes all
+test cases discovered in matching files. Test cases are rules whose names have the prefix "test_".
+
+Example policy (example/authz.rego):
+
+	package authz
+
+	allow {
+		input.path = ["users"]
+		input.method = "POST"
+	}
+
+	allow {
+		input.path = ["users", profile_id]
+		input.method = "GET"
+		profile_id = input.user_id
+	}
+
+Example test (example/authz_test.rego):
+
+	package authz
+
+	test_post_allowed {
+		allow with input as {"path": ["users"], "method": "POST"}
+	}
+
+	test_get_denied {
+		not allow with input as {"path": ["users"], "method": "GET"}
+	}
+
+	test_get_user_allowed {
+		allow with input as {"path": ["users", "bob"], "method": "GET", "user_id": "bob"}
+	}
+
+	test_get_another_user_denied {
+		not allow with input as {"path": ["users", "bob"], "method": "GET", "user_id": "alice"}
+	}
+
+Example test run:
+
+	$ opa test ./example/
+`,
+	Run: func(cmd *cobra.Command, args []string) {
+		os.Exit(opaTest(args))
+	},
+}
+
+func opaTest(args []string) int {
+
+	compiler := ast.NewCompiler().SetErrorLimit(testParams.errLimit)
+
+	ctx, cancel := context.WithTimeout(context.Background(), testParams.timeout)
+	defer cancel()
+
+	ch, err := tester.NewRunner().SetCompiler(compiler).Paths(ctx, args...)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+
+	reporter := tester.PrettyReporter{
+		Verbose: testParams.verbose,
+		Output:  os.Stdout,
+	}
+
+	exitCode := 0
+	dup := make(chan *tester.Result)
+
+	go func() {
+		defer close(dup)
+		for tr := range ch {
+			if !tr.Pass() {
+				exitCode = 1
+			}
+			dup <- tr
+		}
+	}()
+
+	if err := reporter.Report(dup); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+
+	return exitCode
+}
+
+func init() {
+	testCommand.Flags().BoolVarP(&testParams.verbose, "verbose", "v", false, "set verbose reporting mode")
+	testCommand.Flags().DurationVarP(&testParams.timeout, "timeout", "t", time.Second*5, "set test timeout")
+	setMaxErrors(testCommand.Flags(), &testParams.errLimit)
+	RootCommand.AddCommand(testCommand)
+}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -11,18 +11,19 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var versionCommand = &cobra.Command{
-	Use:   "version",
-	Short: "Print the version of OPA",
-	Long:  "Show version and build information for OPA.",
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("Version: " + version.Version)
-		fmt.Println("Build Commit: " + version.Vcs)
-		fmt.Println("Build Timestamp: " + version.Timestamp)
-		fmt.Println("Build Hostname: " + version.Hostname)
-	},
-}
-
 func init() {
+
+	var versionCommand = &cobra.Command{
+		Use:   "version",
+		Short: "Print the version of OPA",
+		Long:  "Show version and build information for OPA.",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println("Version: " + version.Version)
+			fmt.Println("Build Commit: " + version.Vcs)
+			fmt.Println("Build Timestamp: " + version.Timestamp)
+			fmt.Println("Build Hostname: " + version.Hostname)
+		},
+	}
+
 	RootCommand.AddCommand(versionCommand)
 }

--- a/loader/errors.go
+++ b/loader/errors.go
@@ -1,0 +1,66 @@
+// Copyright 2017 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package loader
+
+import (
+	"fmt"
+	"strings"
+)
+
+type loaderErrors []error
+
+func (e loaderErrors) Error() string {
+	if len(e) == 0 {
+		return "no error(s)"
+	}
+	if len(e) == 1 {
+		return "1 error occurred during loading: " + e[0].Error()
+	}
+	buf := make([]string, len(e))
+	for i := range buf {
+		buf[i] = e[i].Error()
+	}
+	return fmt.Sprintf("%v errors occured during loading:\n", len(e)) + strings.Join(buf, "\n")
+}
+
+func (e *loaderErrors) Add(err error) {
+	*e = append(*e, err)
+}
+
+func newResult() *Result {
+	return &Result{
+		Documents: map[string]interface{}{},
+		Modules:   map[string]*RegoFile{},
+	}
+}
+
+type unsupportedDocumentType string
+
+func (path unsupportedDocumentType) Error() string {
+	return string(path) + ": bad document type"
+}
+
+type unrecognizedFile string
+
+func (path unrecognizedFile) Error() string {
+	return string(path) + ": can't recognize file type"
+}
+
+func isUnrecognizedFile(err error) bool {
+	_, ok := err.(unrecognizedFile)
+	return ok
+}
+
+type mergeError string
+
+func (e mergeError) Error() string {
+	return string(e) + ": merge error"
+}
+
+type emptyModuleError string
+
+func (e emptyModuleError) Error() string {
+	return string(e) + ": empty policy"
+}

--- a/loader/merge.go
+++ b/loader/merge.go
@@ -1,8 +1,8 @@
-// Copyright 2016 The OPA Authors.  All rights reserved.
+// Copyright 2017 The OPA Authors.  All rights reserved.
 // Use of this source code is governed by an Apache2
 // license that can be found in the LICENSE file.
 
-package runtime
+package loader
 
 // mergeDocs returns the result of merging a and b. If a and b cannot be merged
 // because of conflicting key-value pairs, ok is false.

--- a/loader/merge_test.go
+++ b/loader/merge_test.go
@@ -1,8 +1,8 @@
-// Copyright 2016 The OPA Authors.  All rights reserved.
+// Copyright 2017 The OPA Authors.  All rights reserved.
 // Use of this source code is governed by an Apache2
 // license that can be found in the LICENSE file.
 
-package runtime
+package loader
 
 import (
 	"reflect"

--- a/tester/reporter.go
+++ b/tester/reporter.go
@@ -1,0 +1,63 @@
+// Copyright 2017 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package tester
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+// PrettyReporter reports test results in a simple human readable format.
+type PrettyReporter struct {
+	Output  io.Writer
+	Verbose bool
+}
+
+// Report prints the test report to the reporter's output.
+func (r PrettyReporter) Report(ch chan *Result) error {
+
+	dirty := false
+	var pass, fail, errs int
+
+	// Report individual tests.
+	for tr := range ch {
+		if tr.Pass() {
+			pass++
+		} else if tr.Error != nil {
+			errs++
+		} else if tr.Fail != nil {
+			fail++
+		}
+		if !tr.Pass() || r.Verbose {
+			fmt.Fprintln(r.Output, tr)
+			dirty = true
+		}
+		if tr.Error != nil {
+			fmt.Fprintf(r.Output, "  %v\n", tr.Error)
+		}
+	}
+
+	// Report summary of test.
+	if dirty {
+		fmt.Fprintln(r.Output, strings.Repeat("-", 80))
+	}
+
+	total := pass + fail + errs
+
+	if pass != 0 {
+		fmt.Fprintln(r.Output, "PASS:", fmt.Sprintf("%d/%d", pass, total))
+	}
+
+	if fail != 0 {
+		fmt.Fprintln(r.Output, "FAIL:", fmt.Sprintf("%d/%d", fail, total))
+	}
+
+	if errs != 0 {
+		fmt.Fprintln(r.Output, "ERROR:", fmt.Sprintf("%d/%d", errs, total))
+	}
+
+	return nil
+}

--- a/tester/reporter_test.go
+++ b/tester/reporter_test.go
@@ -1,0 +1,51 @@
+package tester
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+)
+
+func TestPrettyReporter(t *testing.T) {
+
+	var badResult interface{} = "fail"
+
+	ts := []*Result{
+		{nil, "data.foo.bar", "test_baz", nil, nil, 0},
+		{nil, "data.foo.bar", "test_qux", nil, fmt.Errorf("some err"), 0},
+		{nil, "data.foo.bar", "test_corge", &badResult, nil, 0},
+	}
+
+	var buf bytes.Buffer
+
+	r := PrettyReporter{
+		Output:  &buf,
+		Verbose: true,
+	}
+
+	ch := make(chan *Result)
+	go func() {
+		for _, tr := range ts {
+			ch <- tr
+		}
+		close(ch)
+	}()
+
+	if err := r.Report(ch); err != nil {
+		t.Fatal(err)
+	}
+
+	exp := `data.foo.bar.test_baz: PASS (0s)
+data.foo.bar.test_qux: ERROR (0s)
+  some err
+data.foo.bar.test_corge: FAIL (0s)
+--------------------------------------------------------------------------------
+PASS: 1/3
+FAIL: 1/3
+ERROR: 1/3
+`
+
+	if exp != buf.String() {
+		t.Fatalf("Expected:\n\n%v\n\nGot:\n\n%v", exp, buf.String())
+	}
+}

--- a/tester/runner.go
+++ b/tester/runner.go
@@ -1,0 +1,178 @@
+// Copyright 2017 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+// Package tester contains utilities for executing Rego tests.
+package tester
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/open-policy-agent/opa/topdown"
+
+	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/loader"
+	"github.com/open-policy-agent/opa/rego"
+)
+
+// TestPrefix declares the prefix for all rules.
+const TestPrefix = "test_"
+
+// Run executes all test cases found under files in path.
+func Run(ctx context.Context, path ...string) ([]*Result, error) {
+	ch, err := NewRunner().Paths(ctx, path...)
+	if err != nil {
+		return nil, err
+	}
+	result := []*Result{}
+	for r := range ch {
+		result = append(result, r)
+	}
+	return result, nil
+}
+
+// Result represents a single test case result.
+type Result struct {
+	Location *ast.Location `json:"location"`
+	Package  string        `json:"package"`
+	Name     string        `json:"name"`
+	Fail     *interface{}  `json:"fail,omitempty"`
+	Error    error         `json:"error,omitempty"`
+	Duration time.Duration `json:"duration"`
+}
+
+func newResult(loc *ast.Location, pkg, name string, duration time.Duration) *Result {
+	return &Result{
+		Location: loc,
+		Package:  pkg,
+		Name:     name,
+		Duration: duration,
+	}
+}
+
+// Pass returns true if the test case passed.
+func (r Result) Pass() bool {
+	return r.Fail == nil && r.Error == nil
+}
+
+func (r *Result) String() string {
+	return fmt.Sprintf("%v.%v: %v (%v)", r.Package, r.Name, r.outcome(), r.Duration/time.Microsecond)
+}
+
+func (r *Result) outcome() string {
+	if r.Pass() {
+		return "PASS"
+	}
+	if r.Fail != nil {
+		return "FAIL"
+	}
+	return "ERROR"
+}
+
+func (r *Result) setFail(fail interface{}) {
+	r.Fail = &fail
+}
+
+// Runner implements simple test discovery and execution.
+type Runner struct {
+	compiler *ast.Compiler
+}
+
+// NewRunner returns a new runner.
+func NewRunner() *Runner {
+	return &Runner{}
+}
+
+// SetCompiler sets the compiler used by the runner.
+func (r *Runner) SetCompiler(compiler *ast.Compiler) *Runner {
+	r.compiler = compiler
+	return r
+}
+
+// Paths executes all tests contained in policies under the specified paths.
+func (r *Runner) Paths(ctx context.Context, path ...string) (ch chan *Result, err error) {
+
+	if r.compiler == nil {
+		r.compiler = ast.NewCompiler()
+	}
+
+	result, err := loader.AllRegos(path)
+	if err != nil {
+		return nil, err
+	}
+
+	modules := map[string]*ast.Module{}
+	for _, m := range result.Modules {
+		modules[m.Name] = m.Parsed
+	}
+
+	return r.Modules(ctx, modules)
+}
+
+// Modules executes all tests contained in the specified modules.
+func (r *Runner) Modules(ctx context.Context, modules map[string]*ast.Module) (ch chan *Result, err error) {
+
+	filenames := make([]string, 0, len(modules))
+	for name := range modules {
+		filenames = append(filenames, name)
+	}
+
+	sort.Strings(filenames)
+
+	if r.compiler.Compile(modules); r.compiler.Failed() {
+		return nil, r.compiler.Errors
+	}
+
+	ch = make(chan *Result)
+
+	go func() {
+		defer close(ch)
+		for _, name := range filenames {
+			module := r.compiler.Modules[name]
+			for _, rule := range module.Rules {
+				if !strings.HasPrefix(string(rule.Head.Name), TestPrefix) {
+					continue
+				}
+				tr, stop := r.runTest(ctx, module, rule)
+				ch <- tr
+				if stop {
+					return
+				}
+			}
+		}
+	}()
+
+	return ch, nil
+}
+
+func (r *Runner) runTest(ctx context.Context, mod *ast.Module, rule *ast.Rule) (*Result, bool) {
+
+	rego := rego.New(
+		rego.Compiler(r.compiler),
+		rego.Query(rule.Path().String()),
+	)
+
+	t0 := time.Now()
+	rs, err := rego.Eval(ctx)
+	dt := time.Since(t0)
+
+	tr := newResult(rule.Loc(), mod.Package.Path.String(), string(rule.Head.Name), dt)
+	var stop bool
+
+	if err != nil {
+		tr.Error = err
+		if err, ok := err.(*topdown.Error); ok && err.Code == topdown.CancelErr {
+			stop = true
+		}
+	} else if len(rs) == 0 {
+		tr.setFail(false)
+	} else if b, ok := rs[0].Expressions[0].Value.(bool); !ok || !b {
+		tr.setFail(rs[0].Expressions[0].Value)
+	}
+
+	return tr, stop
+}

--- a/tester/runner_test.go
+++ b/tester/runner_test.go
@@ -1,0 +1,110 @@
+// Copyright 2017 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package tester
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/topdown"
+	"github.com/open-policy-agent/opa/types"
+	"github.com/open-policy-agent/opa/util/test"
+)
+
+func TestRun(t *testing.T) {
+
+	ctx := context.Background()
+
+	files := map[string]string{
+		"/a.rego": `package foo
+			allow { true }
+			`,
+		"/a_test.rego": `package foo
+			test_pass { allow }
+			non_test { true }
+			test_fail { not allow }
+			test_fail_non_bool = 100
+			test_err { conflict }
+			conflict = true
+			conflict = false
+			`,
+	}
+
+	tests := map[[2]string]struct {
+		wantErr  bool
+		wantFail bool
+	}{
+		{"data.foo", "test_pass"}:          {false, false},
+		{"data.foo", "test_fail"}:          {false, true},
+		{"data.foo", "test_fail_non_bool"}: {false, true},
+		{"data.foo", "test_err"}:           {true, false},
+	}
+
+	test.WithTempFS(files, func(d string) {
+		rs, err := Run(ctx, d)
+		if err != nil {
+			t.Fatal(err)
+		}
+		seen := map[[2]string]struct{}{}
+		for i := range rs {
+			k := [2]string{rs[i].Package, rs[i].Name}
+			seen[k] = struct{}{}
+			exp, ok := tests[k]
+			if !ok {
+				t.Errorf("Unexpected result for %v", k)
+			} else if exp.wantErr != (rs[i].Error != nil) || exp.wantFail != (rs[i].Fail != nil) {
+				t.Errorf("Expected %v for %v but got: %v", exp, k, rs[i])
+			}
+		}
+		for k := range tests {
+			if _, ok := seen[k]; !ok {
+				t.Errorf("Expected result for %v", k)
+			}
+		}
+	})
+}
+
+func TestRunnerCancel(t *testing.T) {
+
+	ast.RegisterBuiltin(&ast.Builtin{
+		Name: ast.String("test.sleep"),
+		Args: []types.Type{
+			types.S,
+		},
+	})
+
+	topdown.RegisterFunctionalBuiltinVoid1("test.sleep", func(a ast.Value) error {
+		d, _ := time.ParseDuration(string(a.(ast.String)))
+		time.Sleep(d)
+		return nil
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	module := `package foo
+
+	test_1 { test.sleep("100ms") }
+	test_2 { true }`
+
+	files := map[string]string{
+		"/a_test.rego": module,
+	}
+
+	test.WithTempFS(files, func(d string) {
+		ch, err := NewRunner().Paths(ctx, d)
+		if err != nil {
+			t.Fatal(err)
+		}
+		<-ch
+		_, ok := <-ch
+		if ok {
+			t.Fatal("Expected channel to be closed after first test")
+		}
+	})
+
+}

--- a/util/test/doc.go
+++ b/util/test/doc.go
@@ -1,0 +1,6 @@
+// Copyright 2017 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+// Package test contains utilities used in the policy engine's test suite.
+package test

--- a/util/test/tempfs.go
+++ b/util/test/tempfs.go
@@ -1,0 +1,68 @@
+// Copyright 2017 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package test
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+// WithTempFS creates a temporary directory structure and invokes f with the
+// root directory path.
+func WithTempFS(files map[string]string, f func(string)) {
+	rootDir, cleanup, err := MakeTempFS(files)
+	if err != nil {
+		panic(err)
+	}
+	defer cleanup()
+	f(rootDir)
+}
+
+// MakeTempFS creates a temporary directory structure for test purposes. If the
+// creation fails, cleanup is nil and the caller does not have to invoke it. If
+// creation succeeds, the caller should invoke cleanup when they are done.
+func MakeTempFS(files map[string]string) (rootDir string, cleanup func(), err error) {
+
+	rootDir, err = ioutil.TempDir("", "loader_test")
+
+	if err != nil {
+		return "", nil, err
+	}
+
+	cleanup = func() {
+		os.RemoveAll(rootDir)
+	}
+
+	skipCleanup := false
+
+	// Cleanup unless flag is unset. It will be unset if we succeed.
+	defer func() {
+		if !skipCleanup {
+			cleanup()
+		}
+	}()
+
+	for path, content := range files {
+		dirname, filename := filepath.Split(path)
+		dirPath := filepath.Join(rootDir, dirname)
+		if err := os.MkdirAll(dirPath, 0777); err != nil {
+			return "", nil, err
+		}
+
+		f, err := os.Create(filepath.Join(dirPath, filename))
+		if err != nil {
+			return "", nil, err
+		}
+
+		if _, err := f.WriteString(content); err != nil {
+			return "", nil, err
+		}
+	}
+
+	skipCleanup = true
+
+	return rootDir, cleanup, nil
+}


### PR DESCRIPTION
Most of these changes are refactoring. The actual `opa test` sub-command bits are in the last commit (82e22ba).