### PR TITLE
Fix syntax error in comprehension example

### DIFF
--- a/docs/book/how-do-i-write-policies.md
+++ b/docs/book/how-do-i-write-policies.md
@@ -563,7 +563,7 @@ Like [Rules](#rules), comprehensions consist of a head and a body. The body of a
 The body of a comprehension is able to refer to variables defined in the outer body. For example:
 
 ```ruby
-> region = "west", names = [name | sites[i].region = region, sites[i].name = name]
+> region = "west"; names = [name | sites[i].region = region; sites[i].name = name]
 +-----------------+--------+
 |      names      | region |
 +-----------------+--------+


### PR DESCRIPTION
Apparently we missed one instance of the hold comma-based syntax when we
moved over to semicolons.