### PR TITLE
Add alpine-based Docker image

### DIFF
--- a/Dockerfile_alpine.in
+++ b/Dockerfile_alpine.in
@@ -1,0 +1,13 @@
+# Copyright 2017 The OPA Authors.  All rights reserved.
+# Use of this source code is governed by an Apache2
+# license that can be found in the LICENSE file.
+
+FROM alpine
+
+MAINTAINER Torin Sandall <torinsandall@gmail.com>
+
+ADD opa_linux_GOARCH /opa
+
+ENTRYPOINT ["/opa"]
+
+CMD ["run"]

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,9 @@ image:
 
 image-quick:
 	sed -e 's/GOARCH/$(GOARCH)/g' Dockerfile.in > .Dockerfile_$(GOARCH)
+	sed -e 's/GOARCH/$(GOARCH)/g' Dockerfile_alpine.in > .Dockerfile_alpine_$(GOARCH)
 	docker build -t $(IMAGE):$(VERSION)	-f .Dockerfile_$(GOARCH) .
+	docker build -t $(IMAGE):$(VERSION)-alpine -f .Dockerfile_alpine_$(GOARCH) .
 
 push:
 	docker push $(IMAGE):$(VERSION)


### PR DESCRIPTION
In some cases, users will want to obtain a shell inside the container
running OPA. Currently, we need a way to run opa fmt --diff (which
relies on the diff program) as part of the open-policy-agent/library
build/CI process. This image makes that possible.