### PR TITLE
Remove GOPATH warning from build scripts

### DIFF
--- a/build/install-deps.sh
+++ b/build/install-deps.sh
@@ -2,11 +2,6 @@
 
 set -e
 
-if [ -z "$GOPATH" ]; then
-	echo '$GOPATH environment variable not set. Have you installed Go?'
-	exit 1
-fi
-
 which pigeon >/dev/null || {
 	echo "Installing pigeon from vendor"
 	go install ./vendor/github.com/mna/pigeon


### PR DESCRIPTION
Go now defaults to ~/go so this is no longer required.