### PR TITLE
Refactor test runner to accept Store argument

### DIFF
--- a/cmd/test.go
+++ b/cmd/test.go
@@ -74,13 +74,23 @@ Example test run:
 }
 
 func opaTest(args []string) int {
-
-	compiler := ast.NewCompiler().SetErrorLimit(testParams.errLimit)
-
 	ctx, cancel := context.WithTimeout(context.Background(), testParams.timeout)
 	defer cancel()
 
-	ch, err := tester.NewRunner().SetCompiler(compiler).Paths(ctx, args...)
+	compiler := ast.NewCompiler().
+		SetErrorLimit(testParams.errLimit)
+
+	modules, store, err := tester.Load(args)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+
+	runner := tester.NewRunner().
+		SetCompiler(compiler).
+		SetStore(store)
+
+	ch, err := runner.Run(ctx, modules)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return 1

--- a/tester/runner.go
+++ b/tester/runner.go
@@ -12,19 +12,24 @@ import (
 	"strings"
 	"time"
 
-	"github.com/open-policy-agent/opa/topdown"
-
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/loader"
 	"github.com/open-policy-agent/opa/rego"
+	"github.com/open-policy-agent/opa/storage"
+	"github.com/open-policy-agent/opa/storage/inmem"
+	"github.com/open-policy-agent/opa/topdown"
 )
 
 // TestPrefix declares the prefix for all rules.
 const TestPrefix = "test_"
 
 // Run executes all test cases found under files in path.
-func Run(ctx context.Context, path ...string) ([]*Result, error) {
-	ch, err := NewRunner().Paths(ctx, path...)
+func Run(ctx context.Context, paths ...string) ([]*Result, error) {
+	modules, store, err := Load(paths)
+	if err != nil {
+		return nil, err
+	}
+	ch, err := NewRunner().SetStore(store).Run(ctx, modules)
 	if err != nil {
 		return nil, err
 	}
@@ -80,6 +85,7 @@ func (r *Result) setFail(fail interface{}) {
 // Runner implements simple test discovery and execution.
 type Runner struct {
 	compiler *ast.Compiler
+	store    storage.Store
 }
 
 // NewRunner returns a new runner.
@@ -93,28 +99,22 @@ func (r *Runner) SetCompiler(compiler *ast.Compiler) *Runner {
 	return r
 }
 
-// Paths executes all tests contained in policies under the specified paths.
-func (r *Runner) Paths(ctx context.Context, path ...string) (ch chan *Result, err error) {
+// SetStore sets the store to execute tests over.
+func (r *Runner) SetStore(store storage.Store) *Runner {
+	r.store = store
+	return r
+}
+
+// Run executes all tests contained in supplied modules.
+func (r *Runner) Run(ctx context.Context, modules map[string]*ast.Module) (ch chan *Result, err error) {
 
 	if r.compiler == nil {
 		r.compiler = ast.NewCompiler()
 	}
 
-	result, err := loader.AllRegos(path)
-	if err != nil {
-		return nil, err
+	if r.store == nil {
+		r.store = inmem.New()
 	}
-
-	modules := map[string]*ast.Module{}
-	for _, m := range result.Modules {
-		modules[m.Name] = m.Parsed
-	}
-
-	return r.Modules(ctx, modules)
-}
-
-// Modules executes all tests contained in the specified modules.
-func (r *Runner) Modules(ctx context.Context, modules map[string]*ast.Module) (ch chan *Result, err error) {
 
 	filenames := make([]string, 0, len(modules))
 	for name := range modules {
@@ -152,6 +152,7 @@ func (r *Runner) Modules(ctx context.Context, modules map[string]*ast.Module) (c
 func (r *Runner) runTest(ctx context.Context, mod *ast.Module, rule *ast.Rule) (*Result, bool) {
 
 	rego := rego.New(
+		rego.Store(r.store),
 		rego.Compiler(r.compiler),
 		rego.Query(rule.Path().String()),
 	)
@@ -175,4 +176,18 @@ func (r *Runner) runTest(ctx context.Context, mod *ast.Module, rule *ast.Rule) (
 	}
 
 	return tr, stop
+}
+
+// Load returns modules and an in-memory store for running tests.
+func Load(args []string) (map[string]*ast.Module, storage.Store, error) {
+	loaded, err := loader.All(args)
+	if err != nil {
+		return nil, nil, err
+	}
+	store := inmem.NewFromObject(loaded.Documents)
+	modules := map[string]*ast.Module{}
+	for _, loadedModule := range loaded.Modules {
+		modules[loadedModule.Name] = loadedModule.Parsed
+	}
+	return modules, store, nil
 }

--- a/tester/runner_test.go
+++ b/tester/runner_test.go
@@ -96,14 +96,12 @@ func TestRunnerCancel(t *testing.T) {
 	}
 
 	test.WithTempFS(files, func(d string) {
-		ch, err := NewRunner().Paths(ctx, d)
+		results, err := Run(ctx, d)
 		if err != nil {
 			t.Fatal(err)
 		}
-		<-ch
-		_, ok := <-ch
-		if ok {
-			t.Fatal("Expected channel to be closed after first test")
+		if results[0].Error.(*topdown.Error).Code != topdown.CancelErr {
+			t.Fatalf("Expected cancel error but got: %v", results[0].Error)
 		}
 	})
 


### PR DESCRIPTION
This allows testers to provide input data in raw JSON/YAML files as
opposed to copying them into Rego files.