### PR TITLE
Add Product to calculate the product of array or set

### DIFF
--- a/ast/builtins.go
+++ b/ast/builtins.go
@@ -40,7 +40,7 @@ var DefaultBuiltins = [...]*Builtin{
 	And, Or,
 
 	// Aggregates
-	Count, Sum, Max, Min,
+	Count, Sum, Product, Max, Min,
 
 	// Casting
 	ToNumber,
@@ -281,6 +281,19 @@ var Count = &Builtin{
 // Sum takes an array or set of numbers and sums them.
 var Sum = &Builtin{
 	Name: "sum",
+	Decl: types.NewFunction(
+		types.NewAny(
+			types.NewSet(types.N),
+			types.NewArray(nil, types.N),
+		),
+		types.N,
+	),
+	TargetPos: []int{1},
+}
+
+// Product takes an array or set of numbers and multiplies them.
+var Product = &Builtin{
+	Name: "product",
 	Decl: types.NewFunction(
 		types.NewAny(
 			types.NewSet(types.N),

--- a/docs/book/language-reference.md
+++ b/docs/book/language-reference.md
@@ -36,6 +36,7 @@ complex types.
 | ------- |--------|-------------|
 | <span class="opa-keep-it-together">``count(collection, output)``</span> | 1 | ``output`` is the length of the object, array, or set ``collection`` |
 | <span class="opa-keep-it-together">``sum(array_or_set, output)``</span> | 1 | ``output`` is the sum of the numbers in ``array_or_set`` |
+| <span class="opa-keep-it-together">``product(array_or_set, output)``</span> | 1 | ``output`` is the product of the numbers in ``array_or_set`` |
 | <span class="opa-keep-it-together">``max(array_or_set, output)``</span> | 1 | ``output`` is the maximum value in ``array_or_set`` |
 | <span class="opa-keep-it-together">``min(array_or_set, output)``</span> | 1 | ``output`` is the minimum value in ``array_or_set`` |
 

--- a/topdown/aggregates.go
+++ b/topdown/aggregates.go
@@ -51,6 +51,32 @@ func builtinSum(a ast.Value) (ast.Value, error) {
 	return nil, builtins.NewOperandTypeErr(1, a, ast.SetTypeName, ast.ArrayTypeName)
 }
 
+func builtinProduct(a ast.Value) (ast.Value, error) {
+	switch a := a.(type) {
+	case ast.Array:
+		product := big.NewFloat(1)
+		for _, x := range a {
+			n, ok := x.Value.(ast.Number)
+			if !ok {
+				return nil, builtins.NewOperandElementErr(1, a, x.Value, ast.NumberTypeName)
+			}
+			product = new(big.Float).Mul(product, builtins.NumberToFloat(n))
+		}
+		return builtins.FloatToNumber(product), nil
+	case *ast.Set:
+		product := big.NewFloat(1)
+		for _, x := range *a {
+			n, ok := x.Value.(ast.Number)
+			if !ok {
+				return nil, builtins.NewOperandElementErr(1, a, x.Value, ast.NumberTypeName)
+			}
+			product = new(big.Float).Mul(product, builtins.NumberToFloat(n))
+		}
+		return builtins.FloatToNumber(product), nil
+	}
+	return nil, builtins.NewOperandTypeErr(1, a, ast.SetTypeName, ast.ArrayTypeName)
+}
+
 func builtinMax(a ast.Value) (ast.Value, error) {
 	switch a := a.(type) {
 	case ast.Array:
@@ -119,6 +145,7 @@ func builtinMin(a ast.Value) (ast.Value, error) {
 func init() {
 	RegisterFunctionalBuiltin1(ast.Count.Name, builtinCount)
 	RegisterFunctionalBuiltin1(ast.Sum.Name, builtinSum)
+	RegisterFunctionalBuiltin1(ast.Product.Name, builtinProduct)
 	RegisterFunctionalBuiltin1(ast.Max.Name, builtinMax)
 	RegisterFunctionalBuiltin1(ast.Min.Name, builtinMin)
 }


### PR DESCRIPTION
While I agree with the comment on https://github.com/open-policy-agent/opa/issues/466, it would still be tedious to perform the product of members of an array without a function. Feel free to close if you disagree.