### PR TITLE
Rewrite refs in rule args

### DIFF
--- a/ast/compile.go
+++ b/ast/compile.go
@@ -715,6 +715,13 @@ func (c *Compiler) rewriteRefsInHead() {
 				rule.Head.Value = expr.Operand(0)
 				rule.Body.Append(expr)
 			}
+			for i := 0; i < len(rule.Head.Args); i++ {
+				if requiresEval(rule.Head.Args[i]) {
+					expr := f.Generate(rule.Head.Args[i])
+					rule.Head.Args[i] = expr.Operand(0)
+					rule.Body.Append(expr)
+				}
+			}
 			return false
 		})
 		if vs, ok := c.generatedVars[mod]; !ok {

--- a/ast/compile_test.go
+++ b/ast/compile_test.go
@@ -805,6 +805,8 @@ elsekw {
 } else = baz {
 	true
 }
+
+f(0, [baz], 2) = true { true }
 `)
 
 	compileStages(c, c.rewriteRefsInHead)
@@ -829,6 +831,10 @@ elsekw {
 	rule5 := c.Modules["head"].Rules[4]
 	expected5 := MustParseRule(`elsekw { false } else = __local5__ { true; __local5__ = input.qux }`)
 	assertRulesEqual(t, rule5, expected5)
+
+	rule6 := c.Modules["head"].Rules[5]
+	expected6 := MustParseRule(`f(0, __local6__, 2) = true { true; __local6__ = [input.qux] }`)
+	assertRulesEqual(t, rule6, expected6)
 }
 
 func TestRewriteComprehensionTerm(t *testing.T) {


### PR DESCRIPTION
Rule args need to be rewritten just like the key/value terms in the rule
head.

Fixes #497