### PR TITLE
Fix bug in expression formatting

### DIFF
--- a/format/format.go
+++ b/format/format.go
@@ -334,18 +334,19 @@ func (w *writer) writeFunctionCall(expr *ast.Expr, comments []*ast.Comment) []*a
 	if expr.Infix {
 		name := terms[0].Value.String()
 		if bi, ok := ast.BuiltinMap[name]; ok {
-			// Handle relational operators (=, !=, >, etc.)
 			if types.Compare(bi.Decl.Result(), types.T) == 0 {
+				// Handle relational operators (=, !=, >, etc.)
+				comments = w.writeTerm(terms[1], comments)
+				w.write(" " + string(bi.Infix) + " ")
+				return w.writeTerm(terms[2], comments)
+			} else if bi.Infix != "" {
+				// Handle arithmetic operators (+, *, &, etc.)
+				comments = w.writeTerm(terms[3], comments)
+				w.write(" = ")
 				comments = w.writeTerm(terms[1], comments)
 				w.write(" " + string(bi.Infix) + " ")
 				return w.writeTerm(terms[2], comments)
 			}
-			// Handle arithmetic operators (+, *, &, etc.)
-			comments = w.writeTerm(terms[3], comments)
-			w.write(" = ")
-			comments = w.writeTerm(terms[1], comments)
-			w.write(" " + string(bi.Infix) + " ")
-			return w.writeTerm(terms[2], comments)
 		}
 		comments = w.writeTerm(terms[len(terms)-1], comments)
 		w.write(" = " + string(terms[0].String()) + "(")

--- a/format/testfiles/test.rego
+++ b/format/testfiles/test.rego
@@ -75,6 +75,8 @@ z], {"foo": a}) = b {
 split(x, y, c)
 trim(a, z, d) # function comment 1
 split(c[0], d, b)
+x = sprintf("hello %v",
+["world"])
 #function comment 2
 } # function comment 3
 

--- a/format/testfiles/test.rego.formatted
+++ b/format/testfiles/test.rego.formatted
@@ -84,6 +84,7 @@ fn2(
 	split(x, y, c)
 	trim(a, z, d) # function comment 1
 	split(c[0], d, b)
+	x = sprintf("hello %v", ["world"])
 	#function comment 2
 } # function comment 3
 


### PR DESCRIPTION
Call expressions written with infix notation were being incorrectly
formatted using the logic for arithmetic operations.