### PR TITLE
Fix formatting of else statements with functions

### DIFF
--- a/format/testfiles/test.rego
+++ b/format/testfiles/test.rego
@@ -56,6 +56,20 @@ fn(x) = y {
 		y = x
 }
 
+fn_else(x) = 1 {
+    true
+} # foo
+else  =
+# bar
+2
+{
+    true
+} else = 3
+# baz
+{
+    false
+}
+
 long(x) = true {
     x = "foo %host"
     }

--- a/format/testfiles/test.rego.formatted
+++ b/format/testfiles/test.rego.formatted
@@ -59,6 +59,21 @@ fn(x) = y {
 	y = x
 }
 
+fn_else(x) = 1 {
+	true
+} # foo
+
+# bar
+else = 2 {
+	true
+}
+
+else = 3 {
+	# baz
+
+	false
+}
+
 long(x) {
 	x = "foo %host"
 }


### PR DESCRIPTION
The formatter was not handling else statements for functions properly.
The function args were being written after the else keyword which
resulted in rules that did not parse.