### PR TITLE
Remove lint errors detected during 'make check'

### DIFF
--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -293,10 +293,7 @@ func (rt *Runtime) processWatcherUpdate(ctx context.Context, paths []string, rem
 				}
 			}
 		}
-		if err := compileAndStoreInputs(ctx, rt.Store, txn, loaded.Modules, -1); err != nil {
-			return err
-		}
-		return nil
+		return compileAndStoreInputs(ctx, rt.Store, txn, loaded.Modules, -1)
 	})
 }
 

--- a/server/types/types.go
+++ b/server/types/types.go
@@ -325,11 +325,7 @@ func (te *TraceEventV1) UnmarshalJSON(bs []byte) error {
 		te.Node = &rule
 	}
 
-	if err := util.UnmarshalJSON(keys["locals"], &te.Locals); err != nil {
-		return err
-	}
-
-	return nil
+	return util.UnmarshalJSON(keys["locals"], &te.Locals)
 }
 
 // BindingsV1 represents a set of term bindings.


### PR DESCRIPTION
Removing redundant `err != nil` checks detected during `make check`