### PR TITLE
Remove guards in deps installer

### DIFF
--- a/build/install-deps.sh
+++ b/build/install-deps.sh
@@ -2,18 +2,6 @@
 
 set -e
 
-which pigeon >/dev/null || {
-	echo "Installing pigeon from vendor"
-	go install ./vendor/github.com/mna/pigeon
-}
-
-
-which goimports >/dev/null || {
-	echo "Installing goimports from vendor"
-	go install ./vendor/golang.org/x/tools/cmd/goimports
-}
-
-which golint >/dev/null || {
-	echo "Installing golint from vendor"
-	go install ./vendor/github.com/golang/lint/golint
-}
+go install ./vendor/github.com/mna/pigeon
+go install ./vendor/golang.org/x/tools/cmd/goimports
+go install ./vendor/github.com/golang/lint/golint


### PR DESCRIPTION
If the pigeon dependency is updated, the parser is regenerated and
committed back to the repo. Other developers need to re-install pigeon
whenever this happens (otherwise they will regenerate a stale version of
the parser.)