### PR TITLE
fix #435: deduplicate paths in completion

### DIFF
--- a/repl/repl.go
+++ b/repl/repl.go
@@ -289,8 +289,9 @@ func (r *REPL) DisableUndefinedOutput(yes bool) *REPL {
 	return r
 }
 
-func (r *REPL) complete(line string) (c []string) {
-
+func (r *REPL) complete(line string) []string {
+	c := []string{}
+	set := map[string]struct{}{}
 	ctx := context.Background()
 	txn, err := r.store.NewTransaction(ctx)
 
@@ -306,7 +307,7 @@ func (r *REPL) complete(line string) (c []string) {
 		for _, imp := range mod.Imports {
 			path := imp.Name().String()
 			if strings.HasPrefix(path, line) {
-				c = append(c, path)
+				set[path] = struct{}{}
 			}
 		}
 	}
@@ -316,7 +317,7 @@ func (r *REPL) complete(line string) (c []string) {
 		for _, rule := range mod.Rules {
 			path := rule.Path().String()
 			if strings.HasPrefix(path, line) {
-				c = append(c, path)
+				set[path] = struct{}{}
 			}
 		}
 	}
@@ -332,11 +333,14 @@ func (r *REPL) complete(line string) (c []string) {
 		for _, rule := range mod.Rules {
 			path := rule.Path().String()
 			if strings.HasPrefix(path, line) {
-				c = append(c, path)
+				set[path] = struct{}{}
 			}
 		}
 	}
 
+	for path := range set {
+		c = append(c, path)
+	}
 	return c
 }
 

--- a/repl/repl_test.go
+++ b/repl/repl_test.go
@@ -110,7 +110,8 @@ func TestComplete(t *testing.T) {
 	mod1 := []byte(`package a.b.c
 
 p = 1 { true }
-q = 2 { true }`)
+q = 2 { true }
+q = 3 { false }`)
 
 	mod2 := []byte(`package a.b.d
 
@@ -164,7 +165,7 @@ r = 3 { true }`)
 	}
 
 	result = repl.complete("data.a.b.c.p[x]")
-	expected = nil
+	expected = []string{}
 
 	if !reflect.DeepEqual(result, expected) {
 		t.Fatalf("Expected %v but got: %v", expected, result)


### PR DESCRIPTION
I have not added a specific test case, but altered the existing one
slightly -- hope that's fine.

Fixes #435.