### PR TITLE
Modify Language Reference in Docs

### DIFF
--- a/docs/book/language-reference.md
+++ b/docs/book/language-reference.md
@@ -58,7 +58,7 @@ complex types.
 | <span class="opa-keep-it-together">``format_int(number, base, output)``</span> | 2 | ``output`` is string representation of ``number`` in the given ``base`` |
 | <span class="opa-keep-it-together">``indexof(string, search, output)``</span> | 2 | ``output`` is the index inside ``string`` where ``search`` first occurs, or -1 if ``search`` does not exist |
 | <span class="opa-keep-it-together">``lower(string, output)``</span> | 1 | ``output`` is ``string`` after converting to lower case |
-| <span class="opa-keep-it-together">``re_match(pattern, value)``</span> | 2 | true if the value matches the pattern |
+| <span class="opa-keep-it-together">``re_match(pattern, value)``</span> | 2 | true if the value matches the regex pattern |
 | <span class="opa-keep-it-together">``replace(string, old, new, output)``</span> | 3 | ``output`` is a ``string`` representing ``string`` with all instances of ``old`` replaced by ``new`` |
 | <span class="opa-keep-it-together">``split(string, delimiter, output)``</span> | 2 | ``output`` is ``array[string]`` representing elements of ``string`` separated by ``delimiter`` |
 | <span class="opa-keep-it-together">``sprintf(string, values, output)``</span> | 2 | ``output`` is a ``string`` representing ``string`` formatted by the values in the ``array`` ``values``. |


### PR DESCRIPTION
Makes it easier to find the `re_match` builtin.