### PR TITLE
Add partial evaluation support to Rego package

### DIFF
--- a/rego/example_test.go
+++ b/rego/example_test.go
@@ -393,3 +393,137 @@ q = {1, 2, 3} { true }`,
 	// row: 3
 	// filename: example_error.rego
 }
+
+func ExampleRego_Partial() {
+
+	ctx := context.Background()
+
+	// Define a role-based access control (RBAC) policy that decides whether to
+	// allow or deny requests. Requests are allowed if the user is bound to a
+	// role that grants permission to perform the operation on the resource.
+	module := `
+		package example
+
+		import data.bindings
+		import data.roles
+
+		default allow = false
+
+		allow {
+			user_has_role[role_name]
+			role_has_permission[role_name]
+		}
+
+		user_has_role[role_name] {
+			b = bindings[_]
+			b.role = role_name
+			b.user = input.subject.user
+		}
+
+		role_has_permission[role_name] {
+			r = roles[_]
+			r.name = role_name
+			match_with_wildcard(r.operations, input.operation)
+			match_with_wildcard(r.resources, input.resource)
+		}
+
+		match_with_wildcard(allowed, value) {
+			allowed[_] = "*"
+		}
+
+		match_with_wildcard(allowed, value) {
+			allowed[_] = value
+		}
+	`
+
+	// Define dummy roles and role bindings for the example. In real-world
+	// scenarios, this data would be pushed or pulled into the service
+	// embedding OPA either from an external API or configuration file.
+	store := inmem.NewFromReader(bytes.NewBufferString(`{
+		"roles": [
+			{
+				"resources": ["documentA", "documentB"],
+				"operations": ["read"],
+				"name": "analyst"
+			},
+			{
+				"resources": ["*"],
+				"operations": ["*"],
+				"name": "admin"
+			}
+		],
+		"bindings": [
+			{
+				"user": "bob",
+				"role": "admin"
+			},
+			{
+				"user": "alice",
+				"role": "analyst"
+			}
+		]
+	}`))
+
+	// Prepare and run partial evaluation on the query. The result of partial
+	// evaluation can be cached for performance. When the data or policy
+	// change, partial evaluation should be re-run.
+	r := rego.New(
+		rego.Query("data.example.allow"),
+		rego.Module("example.rego", module),
+		rego.Store(store),
+	)
+
+	pr, err := r.PartialEval(ctx)
+	if err != nil {
+		// Handle error.
+	}
+
+	// Define example inputs (representing requests) that will be used to test
+	// the policy.
+	examples := []map[string]interface{}{
+		{
+			"resource":  "documentA",
+			"operation": "write",
+			"subject": map[string]interface{}{
+				"user": "bob",
+			},
+		},
+		{
+			"resource":  "documentB",
+			"operation": "write",
+			"subject": map[string]interface{}{
+				"user": "alice",
+			},
+		},
+		{
+			"resource":  "documentB",
+			"operation": "read",
+			"subject": map[string]interface{}{
+				"user": "alice",
+			},
+		},
+	}
+
+	for i := range examples {
+
+		// Prepare and run normal evaluation from the result of partial
+		// evaluation.
+		r := pr.Rego(
+			rego.Input(examples[i]),
+		)
+
+		rs, err := r.Eval(ctx)
+
+		if err != nil || len(rs) != 1 || len(rs[0].Expressions) != 1 {
+			// Handle erorr.
+		} else {
+			fmt.Printf("input %d allowed: %v\n", i+1, rs[0].Expressions[0].Value)
+		}
+	}
+
+	// Output:
+	//
+	// input 1 allowed: true
+	// input 2 allowed: false
+	// input 3 allowed: true
+}

--- a/rego/rego.go
+++ b/rego/rego.go
@@ -222,7 +222,9 @@ func Metrics(m metrics.Metrics) func(r *Rego) {
 // Tracer returns an argument that sets the topdown Tracer.
 func Tracer(t topdown.Tracer) func(r *Rego) {
 	return func(r *Rego) {
-		r.tracer = t
+		if t != nil {
+			r.tracer = t
+		}
 	}
 }
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -888,21 +888,33 @@ func TestDataMetrics(t *testing.T) {
 	}
 
 	for _, key := range expected {
-		if result.Metrics[key] == 0 {
+		if result.Metrics[key] == nil {
 			t.Fatalf("Expected non-zero metric for %v but got: %v", key, result)
 		}
 	}
 
 	req = newReqV1(http.MethodPost, "/data?metrics&partial", "")
+
 	f.reset()
 	f.server.Handler.ServeHTTP(f.recorder, req)
+
+	result = types.DataResponseV1{}
 
 	if err := util.NewJSONDecoder(f.recorder.Body).Decode(&result); err != nil {
 		t.Fatalf("Unexpected JSON decode error: %v", err)
 	}
 
-	if result.Metrics["timer_rego_partial_eval_ns"] == 0 {
-		t.Fatalf("Expected partial evaluation latency but got: %v", result)
+	expected = []string{
+		"timer_rego_query_parse_ns",
+		"timer_rego_query_compile_ns",
+		"timer_rego_query_eval_ns",
+		"timer_rego_partial_eval_ns",
+	}
+
+	for _, key := range expected {
+		if result.Metrics[key] == nil {
+			t.Fatalf("Expected non-zero metric for %v but got: %v", key, result)
+		}
 	}
 
 }


### PR DESCRIPTION
These changes update the Rego package to provide convenient access to the partial evaluation feature added in v0.6.0. The Rego package implicitly treats the input document as unknown. This behaviour can be overridden by the caller explicitly setting the unknowns.

These changes also refactor the server to use the partial evaluation setup from the rego package instead of the initial ad-hoc setup that was implemented directly in the server.