### PR TITLE
Http built in

### DIFF
--- a/ast/builtins.go
+++ b/ast/builtins.go
@@ -78,8 +78,11 @@ var DefaultBuiltins = [...]*Builtin{
 	IsObject,
 	IsNull,
 
-	//Type Name
+	// Type Name
 	TypeNameBuiltin,
+
+	// HTTP Request
+	HTTPReqBuiltin,
 }
 
 // BuiltinMap provides a convenient mapping of built-in names to
@@ -781,6 +784,21 @@ var TypeNameBuiltin = &Builtin{
 			),
 		),
 		types.S,
+	),
+}
+
+/**
+ * HTTP Request
+ */
+
+// HTTPReqBuiltin returns a HTTP response to the given HTTP request
+var HTTPReqBuiltin = &Builtin{
+	Name: "http.send",
+	Decl: types.NewFunction(
+		types.Args(
+			types.NewObject(nil, types.NewDynamicProperty(types.S, types.A)),
+		),
+		types.NewObject(nil, types.NewDynamicProperty(types.A, types.A)),
 	),
 }
 

--- a/docs/book/language-reference.md
+++ b/docs/book/language-reference.md
@@ -118,6 +118,11 @@ evaluation query will always return the same value.
 | --- | --- | --- |
 | <span class="opa-keep-it-together">``walk(x, [path, value])``</span> | 0 | ``walk`` is a relation that produces ``path`` and ``value`` pairs for documents under ``x``. ``path`` is ``array`` representing a pointer to ``value`` in ``x``.  Queries can use ``walk`` to traverse documents nested under ``x`` (recursively). |
 
+### <a name="http"/>HTTP
+| Built-in | Inputs | Description |
+| ------- |--------|-------------|
+| <span class="opa-keep-it-together">``http.send(request, output)``</span> | 1 | ``http.send`` executes a HTTP request and returns the response.``request`` is an object containing keys ``method``, ``url`` and  optionally ``body``. For example, ``http.send({"method": "get", "url": "http://www.openpolicyagent.org/"}, output)``. ``output`` is an object containing keys ``status``, ``status_code`` and ``body`` which represent the HTTP status, status code and response body respectively. Sample output, ``{"status": "200 OK", "status_code": 200, "body": null``}|
+
 ## <a name="reserved-names"></a> Reserved Names
 
 The following words are reserved and cannot be used as variable names, rule

--- a/topdown/http.go
+++ b/topdown/http.go
@@ -1,0 +1,175 @@
+// Copyright 2018 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package topdown
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/topdown/builtins"
+)
+
+// DefaultHTTPRequestTimeoutSec Default timeout value for http client
+const defaultHTTPRequestTimeoutSec = 5
+
+var allowedKeys = ast.NewSet(ast.StringTerm("method"), ast.StringTerm("url"), ast.StringTerm("body"))
+var requiredKeys = ast.NewSet(ast.StringTerm("method"), ast.StringTerm("url"))
+
+var client *http.Client
+
+func builtinHTTPReq(bctx BuiltinContext, a ast.Value) (ast.Value, error) {
+	switch a.(type) {
+	case ast.Object:
+		obj, ok := a.(ast.Object)
+		if !ok {
+			return nil, fmt.Errorf("type assertion error")
+		}
+
+		return evaluateHTTPRequest(obj, bctx)
+	default:
+		return nil, builtins.NewOperandTypeErr(1, a, ast.ObjectTypeName)
+	}
+
+}
+
+func init() {
+	createHTTPClient()
+	RegisterFunctionalBuiltin1WithCtxt(ast.HTTPReqBuiltin.Name, builtinHTTPReq)
+}
+
+// createHTTPClient creates a HTTP client
+func createHTTPClient() {
+	var timeout time.Duration
+
+	timeoutDuration := os.Getenv("HTTP_SEND_TIMEOUT")
+
+	if timeoutDuration == "" {
+		timeout = time.Duration(defaultHTTPRequestTimeoutSec) * time.Second
+	} else {
+		timeout, _ = time.ParseDuration(timeoutDuration)
+	}
+
+	client = &http.Client{
+		Timeout: timeout,
+	}
+}
+
+// evaluateHTTPRequest executes the HTTP request and processes the response
+func evaluateHTTPRequest(obj ast.Object, bctx BuiltinContext) (ast.Value, error) {
+	var url string
+	var method string
+	var body *bytes.Buffer
+
+	requestKeys := ast.NewSet(obj.Keys()...)
+
+	// check invalid keys
+	invalidKeys := requestKeys.Diff(allowedKeys)
+	if invalidKeys.Len() != 0 {
+		return nil, fmt.Errorf("invalid key %s", invalidKeys)
+	}
+
+	// check missing keys
+	missingKeys := requiredKeys.Diff(requestKeys)
+	if missingKeys.Len() != 0 {
+		return nil, fmt.Errorf("missing keys %s", missingKeys)
+	}
+
+	for _, val := range obj.Keys() {
+		key, err := ast.JSON(val.Value)
+		if err != nil {
+			return nil, fmt.Errorf("error while converting value to json %v", err)
+		}
+		key = key.(string)
+
+		if key == "method" {
+			method = obj.Get(val).String()
+			method = strings.Trim(method, "\"")
+		} else if key == "url" {
+			url = obj.Get(val).String()
+			url = strings.Trim(url, "\"")
+		} else {
+			bodyVal := obj.Get(val).Value
+			bodyValInterface, err := ast.JSON(bodyVal)
+			if err != nil {
+				return nil, fmt.Errorf("error while converting value to json %v", err)
+			}
+
+			bodyValBytes, err := json.Marshal(bodyValInterface)
+			if err != nil {
+				return nil, fmt.Errorf("error while json marshalling %v", err)
+			}
+			body = bytes.NewBuffer(bodyValBytes)
+		}
+	}
+
+	if body == nil {
+		body = bytes.NewBufferString("")
+	}
+
+	// check if cache already has a response for this query
+	cachedResponse := checkCache(method, url, bctx)
+	if cachedResponse != nil {
+		return cachedResponse, nil
+	}
+
+	// create the http request
+	req, err := http.NewRequest(strings.ToUpper(method), url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// execute the http request
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	// format the http result
+	var resultBody interface{}
+	json.NewDecoder(resp.Body).Decode(&resultBody)
+
+	result := make(map[string]interface{})
+	result["status"] = resp.Status
+	result["status_code"] = resp.StatusCode
+	result["body"] = resultBody
+
+	resultObj, err := ast.InterfaceToValue(result)
+	if err != nil {
+		return nil, err
+	}
+
+	// add result to cache
+	key := getCtxKey(method, url)
+	bctx.Cache.Put(key, resultObj)
+
+	return resultObj, nil
+}
+
+// getCtxKey returns the cache key.
+// Key format: <METHOD>_<url>
+func getCtxKey(method string, url string) string {
+	keyTerms := []string{strings.ToUpper(method), url}
+	return strings.Join(keyTerms, "_")
+}
+
+// checkCache checks for the given key's value in the cache
+func checkCache(method string, url string, bctx BuiltinContext) ast.Value {
+	key := getCtxKey(method, url)
+
+	val, ok := bctx.Cache.Get(key)
+	if ok {
+		return val.(ast.Value)
+	}
+	return nil
+}

--- a/topdown/http_test.go
+++ b/topdown/http_test.go
@@ -1,0 +1,256 @@
+// Copyright 2018 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package topdown
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/open-policy-agent/opa/ast"
+)
+
+// The person Type
+type Person struct {
+	ID        string `json:"id,omitempty"`
+	Firstname string `json:"firstname,omitempty"`
+}
+
+// TestHTTPGetRequest returns the list of persons
+func TestHTTPGetRequest(t *testing.T) {
+
+	var people []Person
+
+	// test data
+	people = append(people, Person{ID: "1", Firstname: "John"})
+
+	// test server
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(people)
+	}))
+
+	defer ts.Close()
+
+	// expected result
+	expectedResult := make(map[string]interface{})
+	expectedResult["status"] = "200 OK"
+	expectedResult["status_code"] = http.StatusOK
+
+	var body []interface{}
+	bodyMap := map[string]string{"id": "1", "firstname": "John"}
+	body = append(body, bodyMap)
+	expectedResult["body"] = body
+
+	resultObj, err := ast.InterfaceToValue(expectedResult)
+	if err != nil {
+		panic(err)
+	}
+
+	// run the test
+	tests := []struct {
+		note     string
+		rules    []string
+		expected interface{}
+	}{
+		{"http.send", []string{fmt.Sprintf(
+			`p = x { http.send({"method": "get", "url": "%s"}, x) }`, ts.URL)}, resultObj.String()},
+	}
+
+	data := loadSmallTestData()
+
+	for _, tc := range tests {
+		runTopDownTestCase(t, data, tc.note, tc.rules, tc.expected)
+	}
+}
+
+// TestHTTPostRequest adds a new person
+func TestHTTPostRequest(t *testing.T) {
+
+	var people []Person
+
+	// test data
+	people = append(people, Person{ID: "1", Firstname: "John"})
+
+	// test server
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		var person Person
+		if r.Body == nil {
+			http.Error(w, "Please send a request body", 400)
+			return
+		}
+		err := json.NewDecoder(r.Body).Decode(&person)
+		if err != nil {
+			http.Error(w, err.Error(), 400)
+			return
+		}
+
+		// create new person
+		people = append(people, Person{ID: person.ID, Firstname: person.Firstname})
+
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(people)
+	}))
+
+	defer ts.Close()
+
+	// expected result
+	expectedResult := make(map[string]interface{})
+	expectedResult["status"] = "200 OK"
+	expectedResult["status_code"] = http.StatusOK
+
+	var body []interface{}
+	bodyMap1 := map[string]string{"id": "1", "firstname": "John"}
+	bodyMap2 := map[string]string{"id": "2", "firstname": "Joe"}
+	body = append(body, bodyMap1)
+	body = append(body, bodyMap2)
+	expectedResult["body"] = body
+
+	resultObj, err := ast.InterfaceToValue(expectedResult)
+	if err != nil {
+		panic(err)
+	}
+
+	// create a new person object
+	person2 := Person{ID: "2", Firstname: "Joe"}
+	b := new(bytes.Buffer)
+	json.NewEncoder(b).Encode(person2)
+
+	// run the test
+	tests := []struct {
+		note     string
+		rules    []string
+		expected interface{}
+	}{
+		{"http.send", []string{fmt.Sprintf(
+			`p = x { http.send({"method": "post", "url": "%s", "body": %s}, x) }`, ts.URL, b)}, resultObj.String()},
+	}
+
+	data := loadSmallTestData()
+
+	for _, tc := range tests {
+		runTopDownTestCase(t, data, tc.note, tc.rules, tc.expected)
+	}
+}
+
+// TestHTTDeleteRequest deletes a person
+func TestHTTDeleteRequest(t *testing.T) {
+
+	var people []Person
+
+	// test data
+	people = append(people, Person{ID: "1", Firstname: "John"})
+	people = append(people, Person{ID: "2", Firstname: "Joe"})
+
+	// test server
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		var person Person
+		if r.Body == nil {
+			http.Error(w, "Please send a request body", 400)
+			return
+		}
+		err := json.NewDecoder(r.Body).Decode(&person)
+		if err != nil {
+			http.Error(w, err.Error(), 400)
+			return
+		}
+
+		// delete person
+		for index, item := range people {
+			if item.ID == person.ID {
+				people = append(people[:index], people[index+1:]...)
+				break
+			}
+		}
+
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(people)
+	}))
+
+	defer ts.Close()
+
+	// expected result
+	expectedResult := make(map[string]interface{})
+	expectedResult["status"] = "200 OK"
+	expectedResult["status_code"] = http.StatusOK
+
+	var body []interface{}
+	bodyMap := map[string]string{"id": "1", "firstname": "John"}
+	body = append(body, bodyMap)
+	expectedResult["body"] = body
+
+	resultObj, err := ast.InterfaceToValue(expectedResult)
+	if err != nil {
+		panic(err)
+	}
+
+	// delete a new person
+	personToDelete := Person{ID: "2", Firstname: "Joe"}
+	b := new(bytes.Buffer)
+	json.NewEncoder(b).Encode(personToDelete)
+
+	// run the test
+	tests := []struct {
+		note     string
+		rules    []string
+		expected interface{}
+	}{
+		{"http.send", []string{fmt.Sprintf(
+			`p = x { http.send({"method": "delete", "url": "%s", "body": %s}, x) }`, ts.URL, b)}, resultObj.String()},
+	}
+
+	data := loadSmallTestData()
+
+	for _, tc := range tests {
+		runTopDownTestCase(t, data, tc.note, tc.rules, tc.expected)
+	}
+}
+
+// TestInvalidKeyError returns an error when an invalid key is passed in the
+// http.send builtin
+func TestInvalidKeyError(t *testing.T) {
+
+	// run the test
+	tests := []struct {
+		note     string
+		rules    []string
+		expected interface{}
+	}{
+		{"http.send", []string{
+			`p = x { http.send({"method": "get", "url": "http://127.0.0.1:51113", "bad_key": "bad_value"}, x) }`}, fmt.Errorf("invalid key {\"bad_key\"}")},
+	}
+
+	data := loadSmallTestData()
+
+	for _, tc := range tests {
+		runTopDownTestCase(t, data, tc.note, tc.rules, tc.expected)
+	}
+}
+
+// TestMissingKeyError returns an error when a required key is not passed
+// in the http.send builtin
+func TestMissingKeyError(t *testing.T) {
+
+	// run the test
+	tests := []struct {
+		note     string
+		rules    []string
+		expected interface{}
+	}{
+		{"http.send", []string{
+			`p = x { http.send({"method": "get"}, x) }`}, fmt.Errorf("missing keys {\"url\"}")},
+	}
+
+	data := loadSmallTestData()
+
+	for _, tc := range tests {
+		runTopDownTestCase(t, data, tc.note, tc.rules, tc.expected)
+	}
+}


### PR DESCRIPTION
Added a new builtin to execute HTTP requests.

The builtin **http.send** executes a HTTP request and returns the response. For example, http.send({"method": "get", "url": "http://www.openpolicyagent.org/"}, output). output is an object containing keys status, status_code and body which represent the HTTP status, status code and response body respectively. Sample output, {"status": "200 OK", "status_code": 200, "body": null}


Addresses  issue https://github.com/open-policy-agent/opa/issues/510