### PR TITLE
added builtin for n-way set union and intersection

### DIFF
--- a/ast/builtins.go
+++ b/ast/builtins.go
@@ -50,6 +50,8 @@ var DefaultBuiltins = [...]*Builtin{
 
 	// Sets
 	SetDiff,
+	Intersection,
+	Union,
 
 	// Strings
 	Concat, FormatInt, IndexOf, Substring, Lower, Upper, Contains, StartsWith, EndsWith, Split, Replace, Trim, Sprintf,
@@ -797,6 +799,32 @@ var HTTPSend = &Builtin{
 			types.NewObject(nil, types.NewDynamicProperty(types.S, types.A)),
 		),
 		types.NewObject(nil, types.NewDynamicProperty(types.A, types.A)),
+	),
+}
+
+/**
+ * Set
+ */
+
+// Intersection returns the intersection of the given input sets
+var Intersection = &Builtin{
+	Name: "intersection",
+	Decl: types.NewFunction(
+		types.Args(
+			types.NewSet(types.NewSet(types.A)),
+		),
+		types.NewSet(types.A),
+	),
+}
+
+// Union returns the union of the given input sets
+var Union = &Builtin{
+	Name: "union",
+	Decl: types.NewFunction(
+		types.Args(
+			types.NewSet(types.NewSet(types.A)),
+		),
+		types.NewSet(types.A),
 	),
 }
 

--- a/docs/book/language-reference.md
+++ b/docs/book/language-reference.md
@@ -47,6 +47,8 @@ complex types.
 | <span class="opa-keep-it-together">``s3 = s1 & s2``</span> | 2 | ``s3`` is the intersection of ``s1`` and ``s2``. |
 | <span class="opa-keep-it-together"><code>s3 = s1 &#124; s2</code></span> | 2 | ``s3`` is the union of ``s1`` and ``s2``. |
 | <span class="opa-keep-it-together">``s3 = s1 - s2``</span> | 2 | ``s3`` is the difference between ``s1`` and ``s2``, i.e., the elements in ``s1`` that are not in ``s2`` |
+| <span class="opa-keep-it-together">``intersection(set[set], output)``</span> | 1 | ``output`` is the intersection of the sets in the input set  |
+| <span class="opa-keep-it-together">``union(set[set], output)``</span> | 1 | ``output`` is the union of the sets in the input set  |
 
 ### <a name="strings"/>Strings
 

--- a/topdown/sets.go
+++ b/topdown/sets.go
@@ -4,8 +4,10 @@
 
 package topdown
 
-import "github.com/open-policy-agent/opa/ast"
-import "github.com/open-policy-agent/opa/topdown/builtins"
+import (
+	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/topdown/builtins"
+)
 
 // Deprecated in v0.4.2 in favour of minus/infix "-" operation.
 func builtinSetDiff(a, b ast.Value) (ast.Value, error) {
@@ -23,6 +25,60 @@ func builtinSetDiff(a, b ast.Value) (ast.Value, error) {
 	return s1.Diff(s2), nil
 }
 
+// builtinSetIntersection returns the intersection of the given input sets
+func builtinSetIntersection(a ast.Value) (ast.Value, error) {
+
+	inputSet, err := builtins.SetOperand(a, 1)
+	if err != nil {
+		return nil, err
+	}
+
+	// empty input set
+	if inputSet.Len() == 0 {
+		return ast.NewSet(), nil
+	}
+
+	var result ast.Set
+
+	err = inputSet.Iter(func(x *ast.Term) error {
+		n, err := builtins.SetOperand(x.Value, 1)
+		if err != nil {
+			return err
+		}
+
+		if result == nil {
+			result = n
+		} else {
+			result = result.Intersect(n)
+		}
+		return nil
+	})
+	return result, err
+}
+
+// builtinSetUnion returns the union of the given input sets
+func builtinSetUnion(a ast.Value) (ast.Value, error) {
+
+	inputSet, err := builtins.SetOperand(a, 1)
+	if err != nil {
+		return nil, err
+	}
+
+	result := ast.NewSet()
+
+	err = inputSet.Iter(func(x *ast.Term) error {
+		n, err := builtins.SetOperand(x.Value, 1)
+		if err != nil {
+			return err
+		}
+		result = result.Union(n)
+		return nil
+	})
+	return result, err
+}
+
 func init() {
 	RegisterFunctionalBuiltin2(ast.SetDiff.Name, builtinSetDiff)
+	RegisterFunctionalBuiltin1(ast.Intersection.Name, builtinSetIntersection)
+	RegisterFunctionalBuiltin1(ast.Union.Name, builtinSetUnion)
 }

--- a/topdown/sets_test.go
+++ b/topdown/sets_test.go
@@ -1,0 +1,51 @@
+// Copyright 2018 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package topdown
+
+import (
+	"testing"
+)
+
+// TestIntersection tests intersection of the given input sets
+func TestIntersection(t *testing.T) {
+	tests := []struct {
+		note     string
+		rules    []string
+		expected interface{}
+	}{
+		{"intersection_0_sets", []string{`p = x { intersection(set(), x) }`}, "[]"},
+		{"intersection_2_sets", []string{`p = x { intersection({set(), {1, 2}}, x) }`}, "[]"},
+		{"intersection_2_sets", []string{`p = x { s1 = {1, 2, 3}; s2 = {2}; intersection({s1, s2}, x) }`}, "[2]"},
+		{"intersection_3_sets", []string{`p = x { s1 = {1, 2, 3}; s2 = {2, 3, 4}; s3 = {4, 5, 6}; intersection({s1, s2, s3}, x) }`}, "[]"},
+		{"intersection_4_sets", []string{`p = x { s1 = {"a", "b", "c", "d"}; s2 = {"b", "c", "d"}; s3 = {"c", "d"}; s4 = {"d"}; intersection({s1, s2, s3, s4}, x) }`}, "[\"d\"]"},
+	}
+
+	data := loadSmallTestData()
+
+	for _, tc := range tests {
+		runTopDownTestCase(t, data, tc.note, tc.rules, tc.expected)
+	}
+}
+
+// TestUnion tests union of the given input sets
+func TestUnion(t *testing.T) {
+	tests := []struct {
+		note     string
+		rules    []string
+		expected interface{}
+	}{
+		{"union_0_sets", []string{`p = x { union(set(), x) }`}, "[]"},
+		{"union_2_sets", []string{`p = x { union({set(), {1, 2}}, x) }`}, "[1, 2]"},
+		{"union_2_sets", []string{`p = x { s1 = {1, 2, 3}; s2 = {2}; union({s1, s2}, x) }`}, "[1, 2, 3]"},
+		{"union_3_sets", []string{`p = x { s1 = {1, 2, 3}; s2 = {2, 3, 4}; s3 = {4, 5, 6}; union({s1, s2, s3}, x) }`}, "[1, 2, 3, 4, 5, 6]"},
+		{"union_4_sets", []string{`p = x { s1 = {"a", "b", "c", "d"}; s2 = {"b", "c", "d"}; s3 = {"c", "d"}; s4 = {"d"}; union({s1, s2, s3, s4}, x) }`}, "[\"a\", \"b\", \"c\", \"d\"]"},
+	}
+
+	data := loadSmallTestData()
+
+	for _, tc := range tests {
+		runTopDownTestCase(t, data, tc.note, tc.rules, tc.expected)
+	}
+}


### PR DESCRIPTION
The builtin performs set union and intersection for the given input sets.

Ex1:  `x = {{1,2,3,4},{2,3,4}, {1,2,3}}`
`intersection(x, output)`
output => {2, 3}

Ex2: ` x = {{1,2,3,4},{2,3,4}, {1,2,3}}`
`union(x, output)`
output => {1, 2, 3, 4}