### PR TITLE
Fix expr term rewriting to include with modifiers

### DIFF
--- a/ast/compile.go
+++ b/ast/compile.go
@@ -1986,12 +1986,22 @@ func expandExpr(gen *localVarGenerator, expr *Expr) (result []*Expr) {
 	switch terms := expr.Terms.(type) {
 	case *Term:
 		extras, term := expandExprTerm(gen, terms)
+		if len(expr.With) > 0 {
+			for i := range extras {
+				extras[i].With = expr.With
+			}
+		}
 		result = append(result, extras...)
 		expr.Terms = term
 		result = append(result, expr)
 	case []*Term:
 		for i := 1; i < len(terms); i++ {
 			var extras []*Expr
+			if len(expr.With) > 0 {
+				for i := range extras {
+					extras[i].With = expr.With
+				}
+			}
 			extras, terms[i] = expandExprTerm(gen, terms[i])
 			result = append(result, extras...)
 		}

--- a/ast/compile_test.go
+++ b/ast/compile_test.go
@@ -770,7 +770,7 @@ func TestCompilerExprExpansion(t *testing.T) {
 			note:  "with",
 			input: "f[x+1] with input as q",
 			expected: []*Expr{
-				MustParseExpr("plus(x, 1, __local0__)"),
+				MustParseExpr("plus(x, 1, __local0__) with input as q"),
 				MustParseExpr("f[__local0__] with input as q"),
 			},
 		},


### PR DESCRIPTION
Expression term rewriting was not copying the with modifier to expanded
expressions which led to non-obvious evaluation results.