### PR TITLE
Handle local vars in composite head better

### DIFF
--- a/ast/compile_test.go
+++ b/ast/compile_test.go
@@ -1083,9 +1083,9 @@ func TestCompilerRewriteLocalAssignments(t *testing.T) {
 		{k: v1, "k2": v2} := {"foo": 1, "k2": 2}
 	}
 
-	head_array_comprehensions = [x | x := 1]
-	head_set_comprehensions = {x | x := 1}
-	head_object_comprehensions = {k: x | k := "foo"; x := 1}
+	head_array_comprehensions = [[x] | x := 1]
+	head_set_comprehensions = {[x] | x := 1}
+	head_object_comprehensions = {k: [x] | k := "foo"; x := 1}
 	`)
 
 	c.Modules["test2"] = MustParseModule(`package test
@@ -1140,9 +1140,9 @@ func TestCompilerRewriteLocalAssignments(t *testing.T) {
 		{k: __local19__, "k2": __local20__} = {"foo": 1, "k2": 2}
 	}
 
-	head_array_comprehensions = [__local21__ | __local21__ = 1]
-	head_set_comprehensions = {__local22__ | __local22__ = 1}
-	head_object_comprehensions = {__local23__: __local24__ | __local23__ = "foo"; __local24__ = 1}
+	head_array_comprehensions = [[__local21__] | __local21__ = 1]
+	head_set_comprehensions = {[__local22__] | __local22__ = 1}
+	head_object_comprehensions = {__local23__: [__local24__] | __local23__ = "foo"; __local24__ = 1}
 	`)
 
 	if len(module1.Rules) != len(expectedModule.Rules) {


### PR DESCRIPTION
Previously the rewriting step was not walking the comprehension head. As
a result, vars embedded inside composites were not rewritten. This
change updates the rewriting to use a visitor to resolve the issue.