### PR TITLE
Update resolving to skip function args

### DIFF
--- a/ast/visit.go
+++ b/ast/visit.go
@@ -264,7 +264,6 @@ type VarVisitorParams struct {
 	SkipClosures    bool
 	SkipWithTarget  bool
 	SkipSets        bool
-	SkipFuncVars    bool
 }
 
 // NewVarVisitor returns a new VarVisitor object.


### PR DESCRIPTION
Previously, vars in function args were resolved like other vars in the
head. In most cases though, authors expect function args to shadow
globals. As a result, the old behaviour lead to unexpected results when
functions with resolved args were called.