### PR TITLE
Update QueryCompiler to report rewritten vars

### DIFF
--- a/rego/rego_test.go
+++ b/rego/rego_test.go
@@ -51,6 +51,25 @@ func TestRegoCaptureTermsRewrite(t *testing.T) {
 	}
 }
 
+func TestRegoRewrittenVarsCapture(t *testing.T) {
+
+	ctx := context.Background()
+
+	r := New(
+		Query("a := 1; a != 0; a"),
+	)
+
+	rs, err := r.Eval(ctx)
+	if err != nil || len(rs) != 1 {
+		t.Fatalf("Unexpected result: %v (err: %v)", rs, err)
+	}
+
+	if !reflect.DeepEqual(rs[0].Bindings["a"], json.Number("1")) {
+		t.Fatal("Expected a to be 1 but got:", rs[0].Bindings["a"])
+	}
+
+}
+
 func TestRegoCancellation(t *testing.T) {
 
 	ast.RegisterBuiltin(&ast.Builtin{


### PR DESCRIPTION
Since assigned vars are rewritten, we need to allow callers to lookup
whether a generated var corresponds to a var in the parsed query.
Previously, no generated vars needed to be reported to the callers of
the rego package (and so they are filtered out from the ResultSet). Now,
that generated vars correspond to vars the caller may care about, the
rego package has to map generated vars back to ones the user knows
about.