### PR TITLE
Remove redundant package alias "gintersect".

### DIFF
--- a/topdown/regex.go
+++ b/topdown/regex.go
@@ -8,7 +8,7 @@ import (
 	"regexp"
 	"sync"
 
-	gintersect "github.com/yashtewari/glob-intersection"
+	"github.com/yashtewari/glob-intersection"
 
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/topdown/builtins"


### PR DESCRIPTION
Alias is the same as the package name.