### PR TITLE
Remove use of unsafe.Pointer for string hashing

### DIFF
--- a/ast/term_bench_test.go
+++ b/ast/term_bench_test.go
@@ -5,6 +5,7 @@ package ast
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 )
 
@@ -63,6 +64,19 @@ func BenchmarkSetMembership(b *testing.B) {
 				if !setA.Contains(key) {
 					b.Fatal("expected hit")
 				}
+			}
+		})
+	}
+}
+
+func BenchmarkTermHashing(b *testing.B) {
+	sizes := []int{10, 100, 1000}
+	for _, n := range sizes {
+		b.Run(fmt.Sprint(n), func(b *testing.B) {
+			s := String(strings.Repeat("a", n))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_ = s.Hash()
 			}
 		})
 	}


### PR DESCRIPTION
We recently encountered an issue where an old version of siphash
(v1.0.0) was vendored along with OPA. The combination of this version of
siphash and use of unsafe.Pointer to obtain a byte slices caused
back-to-back ast#Term.Hash calls to return different values! Ultimately
this lead to incorrect evaluation results.

Previously, we used unsafe.Pointer to improve performance in the
scheduler benchmark. At this point though, reverting to []byte conversion
during hashing does not introduce a noticeable performance regression.

If the extra allocation during hashing becomes a bottleneck in the
future, we can revisit this.