### PR TITLE
Fix panic due to nil term value

### DIFF
--- a/server/server_test.go
+++ b/server/server_test.go
@@ -312,24 +312,10 @@ p = true { false }`
 				"message": "write conflict: /a/b"
 			}`},
 		}},
-		{"put virtual write conflict", []tr{
-			tr{http.MethodPut, "/policies/test", testMod2, 200, ""},
-			tr{http.MethodPut, "/data/testmod/q/x", "0", 404, `{
-				"code": "resource_conflict",
-				"message": "write conflict: /testmod/q"
-			}`},
-		}},
 		{"get virtual", []tr{
 			tr{http.MethodPut, "/policies/test", testMod1, 200, ""},
 			tr{http.MethodPatch, "/data/x", `[{"op": "add", "path": "/", "value": {"y": [1,2,3,4], "z": [3,4,5,6]}}]`, 204, ""},
 			tr{http.MethodGet, "/data/testmod/p", "", 200, `{"result": [1,2]}`},
-		}},
-		{"patch virtual error", []tr{
-			tr{http.MethodPut, "/policies/test", testMod1, 200, ""},
-			tr{http.MethodPatch, "/data/testmod/p", `[{"op": "add", "path": "-", "value": 1}]`, 404, `{
-                "code": "resource_conflict",
-                "message": "write conflict: /testmod/p"
-            }`},
 		}},
 		{"get with input", []tr{
 			tr{http.MethodPut, "/policies/test", testMod1, 200, ""},

--- a/topdown/errors.go
+++ b/topdown/errors.go
@@ -86,6 +86,14 @@ func objectDocKeyConflictErr(loc *ast.Location) error {
 	}
 }
 
+func documentConflictErr(loc *ast.Location) error {
+	return &Error{
+		Code:     ConflictErr,
+		Location: loc,
+		Message:  "base and virtual document keys must be disjoint",
+	}
+}
+
 func unsupportedBuiltinErr(loc *ast.Location) error {
 	return &Error{
 		Code:     InternalErr,

--- a/topdown/eval.go
+++ b/topdown/eval.go
@@ -62,7 +62,6 @@ func (e *eval) child(query ast.Body) *eval {
 	return &cpy
 }
 
-// partial returns true if the evaluator is performing partial evaluation.
 func (e *eval) partial() bool {
 	return e.saveSet != nil
 }
@@ -997,9 +996,15 @@ func (e evalTree) extent() (*ast.Term, error) {
 		}
 		return ast.NewTerm(base), nil
 	}
-
 	if base != nil {
-		merged, _ := base.(ast.Object).Merge(virtual)
+		merged, ok := base.(ast.Object).Merge(virtual)
+		if !ok {
+			// TODO(tsandall): the location used in this error could be
+			// improved to reference the containing expression. We should
+			// update the eval struct to keep track of the currently evaluation
+			// expression.
+			return nil, documentConflictErr(e.ref[0].Location)
+		}
 		return ast.NewTerm(merged), nil
 	}
 

--- a/topdown/topdown_test.go
+++ b/topdown/topdown_test.go
@@ -534,6 +534,9 @@ func TestTopDownBaseAndVirtualDocs(t *testing.T) {
 			},
 			"set": {
 				"u": [1,2,3,4]
+			},
+			"conflicts": {
+				"k": "foo"
 			}
 		}
 	}
@@ -603,6 +606,9 @@ w = data.topdown.set { true }
 
 iterate_ground[x] { data.topdown.virtual.constants[x] = 1 }
 `,
+		`package topdown.conflicts
+
+		k = "bar"`,
 	})
 
 	store := inmem.NewFromObject(data)
@@ -651,6 +657,7 @@ iterate_ground[x] { data.topdown.virtual.constants[x] = 1 }
 	assertTopDownWithPath(t, compiler, store, "base/virtual: undefined-2", []string{"topdown", "v"}, "{}", `{"h": {"k": [1,2,3]}}`)
 	assertTopDownWithPath(t, compiler, store, "base/virtual: missing input value", []string{"topdown", "u"}, "{}", "{}")
 	assertTopDownWithPath(t, compiler, store, "iterate ground", []string{"topdown", "iterate_ground"}, "{}", `["p", "r"]`)
+	assertTopDownWithPath(t, compiler, store, "base/virtual: conflicts", []string{"topdown.conflicts"}, "{}", fmt.Errorf("base and virtual document keys must be disjoint"))
 }
 
 func TestTopDownNestedReferences(t *testing.T) {


### PR DESCRIPTION
We were not catching merge failures when combining base and virtual
documents. As a result, a term with a nil value (which is invalid) was
being created and returned.

It's arguable that these kinds of conflicts should be caught when data
or policies are inserted. Alternatively, we should revisit whether
policy decisions should be obtained by querying the same root document
as raw data (e.g., decisions could be namespaced under a separate root
document.)

Fixes #601