### PR TITLE
Refactor AST type name strings

### DIFF
--- a/ast/compile_test.go
+++ b/ast/compile_test.go
@@ -1235,7 +1235,7 @@ func TestRewriteLocalVarDeclarationErrors(t *testing.T) {
 		"var r1 assigned or referenced above",
 		"var r2 assigned or referenced above",
 		"var input assigned or referenced above",
-		"cannot assign vars inside negated expr",
+		"cannot assign vars inside negated expression",
 		"cannot assign to ref",
 		"cannot assign to arraycomprehension",
 		"cannot assign to setcomprehension",

--- a/ast/parser_internal.go
+++ b/ast/parser_internal.go
@@ -206,7 +206,7 @@ func makeRuleHead(loc *Location, name, args, key, value interface{}) (interface{
 	head.Name = name.(*Term).Value.(Var)
 
 	if args != nil && key != nil {
-		return nil, fmt.Errorf("partial %v/%v %vs cannot take arguments", SetTypeName, ObjectTypeName, RuleTypeName)
+		return nil, fmt.Errorf("partial rules cannot take arguments")
 	}
 
 	if args != nil {
@@ -234,7 +234,7 @@ func makeRuleHead(loc *Location, name, args, key, value interface{}) (interface{
 		switch head.Key.Value.(type) {
 		case Var, String, Ref: // nop
 		default:
-			return nil, fmt.Errorf("object key must be one of %v, %v, %v not %v", StringTypeName, VarTypeName, RefTypeName, TypeName(head.Key.Value))
+			return nil, fmt.Errorf("object key must be string, var, or ref, not %v", TypeName(head.Key.Value))
 		}
 	}
 

--- a/ast/parser_test.go
+++ b/ast/parser_test.go
@@ -847,7 +847,7 @@ func TestRule(t *testing.T) {
 	})
 
 	assertParseErrorEquals(t, "empty body", `f(_) = y {}`, "rego_parse_error: body must be non-empty")
-	assertParseErrorEquals(t, "object composite key", "p[[x,y]] = z { true }", "rego_parse_error: object key must be one of string, var, ref not array")
+	assertParseErrorEquals(t, "object composite key", "p[[x,y]] = z { true }", "rego_parse_error: object key must be string, var, or ref, not array")
 	assertParseErrorEquals(t, "default ref value", "default p = [data.foo]", "rego_parse_error: default rule value cannot contain ref")
 	assertParseErrorEquals(t, "default var value", "default p = [x]", "rego_parse_error: default rule value cannot contain var")
 	assertParseErrorEquals(t, "empty rule body", "p {}", "rego_parse_error: body must be non-empty")

--- a/ast/policy.go
+++ b/ast/policy.go
@@ -314,11 +314,11 @@ func IsValidImportPath(v Value) (err error) {
 		}
 		for _, e := range v[1:] {
 			if _, ok := e.Value.(String); !ok {
-				return fmt.Errorf("invalid path %v: path elements must be %vs", v, StringTypeName)
+				return fmt.Errorf("invalid path %v: path elements must be strings", v)
 			}
 		}
 	default:
-		return fmt.Errorf("invalid path %v: path must be %v or %v", v, RefTypeName, VarTypeName)
+		return fmt.Errorf("invalid path %v: path must be ref or var", v)
 	}
 	return nil
 }

--- a/ast/strings.go
+++ b/ast/strings.go
@@ -13,28 +13,3 @@ import (
 func TypeName(x interface{}) string {
 	return strings.ToLower(reflect.Indirect(reflect.ValueOf(x)).Type().Name())
 }
-
-// The type names provide consistent strings for types in error messages.
-const (
-	NullTypeName                = "null"
-	BooleanTypeName             = "boolean"
-	StringTypeName              = "string"
-	NumberTypeName              = "number"
-	VarTypeName                 = "var"
-	RefTypeName                 = "ref"
-	ArrayTypeName               = "array"
-	ObjectTypeName              = "object"
-	SetTypeName                 = "set"
-	ArrayComprehensionTypeName  = "arraycomprehension"
-	SetComprehensionTypeName    = "setcomprehension"
-	ObjectComprehensionTypeName = "objectcomprehension"
-	CallTypeName                = "call"
-	ExprTypeName                = "expr"
-	WithTypeName                = "with"
-	BodyTypeName                = "body"
-	HeadTypeName                = "head"
-	RuleTypeName                = "rule"
-	ArgsTypeName                = "args"
-	ImportTypeName              = "import"
-	PackageTypeName             = "package"
-)

--- a/ast/term.go
+++ b/ast/term.go
@@ -1994,7 +1994,7 @@ func unmarshalTermSliceValue(d map[string]interface{}) ([]*Term, error) {
 	if s, ok := d["value"].([]interface{}); ok {
 		return unmarshalTermSlice(s)
 	}
-	return nil, fmt.Errorf(`ast: unable to unmarshal term (expected {"value": [...], "type": ...} where type is one of: %v, %v, %v)`, ArrayTypeName, SetTypeName, RefTypeName)
+	return nil, fmt.Errorf(`ast: unable to unmarshal term (expected {"value": [...], "type": ...} where type is one of: ref, array, or set)`)
 }
 
 func unmarshalWith(i interface{}) (*With, error) {

--- a/rego/rego.go
+++ b/rego/rego.go
@@ -646,21 +646,21 @@ func waitForDone(ctx context.Context, exit chan struct{}, f func()) {
 
 func rewriteQueryForPartialEval(query ast.Body) (ast.Body, *ast.Term, error) {
 	if len(query) != 1 {
-		return nil, nil, fmt.Errorf("partial evaluation requires single %v (not multiple %v)", ast.RefTypeName, ast.ExprTypeName)
+		return nil, nil, fmt.Errorf("partial evaluation requires single ref (not multiple expressions)")
 	}
 
 	term, ok := query[0].Terms.(*ast.Term)
 	if !ok {
-		return nil, nil, fmt.Errorf("partial evaluation requires %v (not call %v)", ast.RefTypeName, ast.TypeName(query[0]))
+		return nil, nil, fmt.Errorf("partial evaluation requires ref (not expression)")
 	}
 
 	ref, ok := term.Value.(ast.Ref)
 	if !ok {
-		return nil, nil, fmt.Errorf("partial evaluation requires %v (not %v)", ast.RefTypeName, ast.TypeName(term))
+		return nil, nil, fmt.Errorf("partial evaluation requires ref (not %v)", ast.TypeName(term.Value))
 	}
 
 	if !ref.IsGround() {
-		return nil, nil, fmt.Errorf("partial evaluation requires ground %v", ast.RefTypeName)
+		return nil, nil, fmt.Errorf("partial evaluation requires ground ref")
 	}
 
 	return ast.NewBody(ast.Equality.Expr(ast.Wildcard, term)), ast.Wildcard, nil

--- a/server/types/types.go
+++ b/server/types/types.go
@@ -305,19 +305,19 @@ func (te *TraceEventV1) UnmarshalJSON(bs []byte) error {
 	}
 
 	switch te.Type {
-	case ast.BodyTypeName:
+	case "body":
 		var body ast.Body
 		if err := util.UnmarshalJSON(keys["node"], &body); err != nil {
 			return err
 		}
 		te.Node = body
-	case ast.ExprTypeName:
+	case "expr":
 		var expr ast.Expr
 		if err := util.UnmarshalJSON(keys["node"], &expr); err != nil {
 			return err
 		}
 		te.Node = &expr
-	case ast.RuleTypeName:
+	case "rule":
 		var rule ast.Rule
 		if err := util.UnmarshalJSON(keys["node"], &rule); err != nil {
 			return err

--- a/topdown/aggregates.go
+++ b/topdown/aggregates.go
@@ -22,7 +22,7 @@ func builtinCount(a ast.Value) (ast.Value, error) {
 	case ast.String:
 		return ast.IntNumberTerm(len(a)).Value, nil
 	}
-	return nil, builtins.NewOperandTypeErr(1, a, ast.ArrayTypeName, ast.ObjectTypeName, ast.SetTypeName)
+	return nil, builtins.NewOperandTypeErr(1, a, "array", "object", "set")
 }
 
 func builtinSum(a ast.Value) (ast.Value, error) {
@@ -32,7 +32,7 @@ func builtinSum(a ast.Value) (ast.Value, error) {
 		for _, x := range a {
 			n, ok := x.Value.(ast.Number)
 			if !ok {
-				return nil, builtins.NewOperandElementErr(1, a, x.Value, ast.NumberTypeName)
+				return nil, builtins.NewOperandElementErr(1, a, x.Value, "number")
 			}
 			sum = new(big.Float).Add(sum, builtins.NumberToFloat(n))
 		}
@@ -42,14 +42,14 @@ func builtinSum(a ast.Value) (ast.Value, error) {
 		err := a.Iter(func(x *ast.Term) error {
 			n, ok := x.Value.(ast.Number)
 			if !ok {
-				return builtins.NewOperandElementErr(1, a, x.Value, ast.NumberTypeName)
+				return builtins.NewOperandElementErr(1, a, x.Value, "number")
 			}
 			sum = new(big.Float).Add(sum, builtins.NumberToFloat(n))
 			return nil
 		})
 		return builtins.FloatToNumber(sum), err
 	}
-	return nil, builtins.NewOperandTypeErr(1, a, ast.SetTypeName, ast.ArrayTypeName)
+	return nil, builtins.NewOperandTypeErr(1, a, "set", "array")
 }
 
 func builtinProduct(a ast.Value) (ast.Value, error) {
@@ -59,7 +59,7 @@ func builtinProduct(a ast.Value) (ast.Value, error) {
 		for _, x := range a {
 			n, ok := x.Value.(ast.Number)
 			if !ok {
-				return nil, builtins.NewOperandElementErr(1, a, x.Value, ast.NumberTypeName)
+				return nil, builtins.NewOperandElementErr(1, a, x.Value, "number")
 			}
 			product = new(big.Float).Mul(product, builtins.NumberToFloat(n))
 		}
@@ -69,14 +69,14 @@ func builtinProduct(a ast.Value) (ast.Value, error) {
 		err := a.Iter(func(x *ast.Term) error {
 			n, ok := x.Value.(ast.Number)
 			if !ok {
-				return builtins.NewOperandElementErr(1, a, x.Value, ast.NumberTypeName)
+				return builtins.NewOperandElementErr(1, a, x.Value, "number")
 			}
 			product = new(big.Float).Mul(product, builtins.NumberToFloat(n))
 			return nil
 		})
 		return builtins.FloatToNumber(product), err
 	}
-	return nil, builtins.NewOperandTypeErr(1, a, ast.SetTypeName, ast.ArrayTypeName)
+	return nil, builtins.NewOperandTypeErr(1, a, "set", "array")
 }
 
 func builtinMax(a ast.Value) (ast.Value, error) {
@@ -105,7 +105,7 @@ func builtinMax(a ast.Value) (ast.Value, error) {
 		return max.Value, err
 	}
 
-	return nil, builtins.NewOperandTypeErr(1, a, ast.SetTypeName, ast.ArrayTypeName)
+	return nil, builtins.NewOperandTypeErr(1, a, "set", "array")
 }
 
 func builtinMin(a ast.Value) (ast.Value, error) {
@@ -141,7 +141,7 @@ func builtinMin(a ast.Value) (ast.Value, error) {
 		return min.Value, err
 	}
 
-	return nil, builtins.NewOperandTypeErr(1, a, ast.SetTypeName, ast.ArrayTypeName)
+	return nil, builtins.NewOperandTypeErr(1, a, "set", "array")
 }
 
 func builtinSort(a ast.Value) (ast.Value, error) {
@@ -151,7 +151,7 @@ func builtinSort(a ast.Value) (ast.Value, error) {
 	case ast.Set:
 		return a.Sorted(), nil
 	}
-	return nil, builtins.NewOperandTypeErr(1, a, ast.SetTypeName, ast.ArrayTypeName)
+	return nil, builtins.NewOperandTypeErr(1, a, "set", "array")
 }
 
 func init() {

--- a/topdown/arithmetic.go
+++ b/topdown/arithmetic.go
@@ -105,10 +105,10 @@ func builtinMinus(a, b ast.Value) (ast.Value, error) {
 	}
 
 	if !ok1 && !ok3 {
-		return nil, builtins.NewOperandTypeErr(1, a, ast.NumberTypeName, ast.SetTypeName)
+		return nil, builtins.NewOperandTypeErr(1, a, "number", "set")
 	}
 
-	return nil, builtins.NewOperandTypeErr(2, b, ast.NumberTypeName, ast.SetTypeName)
+	return nil, builtins.NewOperandTypeErr(2, b, "number", "set")
 }
 
 func init() {

--- a/topdown/builtins/builtins.go
+++ b/topdown/builtins/builtins.go
@@ -81,7 +81,7 @@ func NewOperandEnumErr(pos int, expected ...string) error {
 func IntOperand(x ast.Value, pos int) (int, error) {
 	n, ok := x.(ast.Number)
 	if !ok {
-		return 0, NewOperandTypeErr(pos, x, ast.NumberTypeName)
+		return 0, NewOperandTypeErr(pos, x, "number")
 	}
 
 	i, ok := n.Int()
@@ -97,7 +97,7 @@ func IntOperand(x ast.Value, pos int) (int, error) {
 func NumberOperand(x ast.Value, pos int) (ast.Number, error) {
 	n, ok := x.(ast.Number)
 	if !ok {
-		return ast.Number(""), NewOperandTypeErr(pos, x, ast.NumberTypeName)
+		return ast.Number(""), NewOperandTypeErr(pos, x, "number")
 	}
 	return n, nil
 }
@@ -107,7 +107,7 @@ func NumberOperand(x ast.Value, pos int) (ast.Number, error) {
 func SetOperand(x ast.Value, pos int) (ast.Set, error) {
 	s, ok := x.(ast.Set)
 	if !ok {
-		return nil, NewOperandTypeErr(pos, x, ast.SetTypeName)
+		return nil, NewOperandTypeErr(pos, x, "set")
 	}
 	return s, nil
 }
@@ -117,7 +117,7 @@ func SetOperand(x ast.Value, pos int) (ast.Set, error) {
 func StringOperand(x ast.Value, pos int) (ast.String, error) {
 	s, ok := x.(ast.String)
 	if !ok {
-		return ast.String(""), NewOperandTypeErr(pos, x, ast.StringTypeName)
+		return ast.String(""), NewOperandTypeErr(pos, x, "string")
 	}
 	return s, nil
 }
@@ -127,7 +127,7 @@ func StringOperand(x ast.Value, pos int) (ast.String, error) {
 func ObjectOperand(x ast.Value, pos int) (ast.Object, error) {
 	o, ok := x.(ast.Object)
 	if !ok {
-		return nil, NewOperandTypeErr(pos, x, ast.ObjectTypeName)
+		return nil, NewOperandTypeErr(pos, x, "object")
 	}
 	return o, nil
 }

--- a/topdown/casts.go
+++ b/topdown/casts.go
@@ -30,7 +30,7 @@ func builtinToNumber(a ast.Value) (ast.Value, error) {
 		}
 		return ast.Number(json.Number(a)), nil
 	}
-	return nil, builtins.NewOperandTypeErr(1, a, ast.NullTypeName, ast.BooleanTypeName, ast.NumberTypeName, ast.StringTypeName)
+	return nil, builtins.NewOperandTypeErr(1, a, "null", "boolean", "number", "string")
 }
 
 func init() {

--- a/topdown/strings.go
+++ b/topdown/strings.go
@@ -58,7 +58,7 @@ func builtinConcat(a, b ast.Value) (ast.Value, error) {
 		for i := range b {
 			s, ok := b[i].Value.(ast.String)
 			if !ok {
-				return nil, builtins.NewOperandElementErr(2, b, b[i].Value, ast.StringTypeName)
+				return nil, builtins.NewOperandElementErr(2, b, b[i].Value, "string")
 			}
 			strs = append(strs, string(s))
 		}
@@ -66,7 +66,7 @@ func builtinConcat(a, b ast.Value) (ast.Value, error) {
 		err := b.Iter(func(x *ast.Term) error {
 			s, ok := x.Value.(ast.String)
 			if !ok {
-				return builtins.NewOperandElementErr(2, b, x.Value, ast.StringTypeName)
+				return builtins.NewOperandElementErr(2, b, x.Value, "string")
 			}
 			strs = append(strs, string(s))
 			return nil
@@ -75,7 +75,7 @@ func builtinConcat(a, b ast.Value) (ast.Value, error) {
 			return nil, err
 		}
 	default:
-		return nil, builtins.NewOperandTypeErr(2, b, ast.SetTypeName, ast.ArrayTypeName)
+		return nil, builtins.NewOperandTypeErr(2, b, "set", "array")
 	}
 
 	return ast.String(strings.Join(strs, string(join))), nil
@@ -250,7 +250,7 @@ func builtinSprintf(a, b ast.Value) (ast.Value, error) {
 
 	astArr, ok := b.(ast.Array)
 	if !ok {
-		return nil, builtins.NewOperandTypeErr(2, b, ast.ArrayTypeName)
+		return nil, builtins.NewOperandTypeErr(2, b, "array")
 	}
 
 	strArr := []interface{}{}


### PR DESCRIPTION
Previously we had constants defined for AST type names. These were used
in error messages in various places. The original goal was to make error
messages consistent, however, this approach made it difficult to locate
the source of the error in code.