### PR TITLE
Update webhook registration in Kubernetes tutorial

### DIFF
--- a/docs/book/kubernetes-admission-control.md
+++ b/docs/book/kubernetes-admission-control.md
@@ -111,7 +111,7 @@ metadata:
 webhooks:
   - name: validating-webhook.openpolicyagent.org
     rules:
-      - operations: ["*"]
+      - operations: ["CREATE", "UPDATE"]
         apiGroups: ["*"]
         apiVersions: ["*"]
         resources: ["*"]
@@ -166,7 +166,7 @@ metadata:
   name: qa
 ```
 
-**production-namespace**:
+**production-namespace.yaml**:
 
 ```yaml
 apiVersion: v1


### PR DESCRIPTION
Due to https://github.com/kubernetes/kubernetes/issues/59759, we should
not recommend registering webhooks that match the CONNECT operation as
this can break exec/port-forward functionality.