### PR TITLE
Fix safety check bug for call args

### DIFF
--- a/ast/compile.go
+++ b/ast/compile.go
@@ -1726,7 +1726,7 @@ func outputVarsForExprCall(expr *Expr, arity func(Ref) int, safe VarSet, terms [
 	numInputTerms := numArgs + 1
 
 	if numInputTerms >= len(terms) {
-		return VarSet{}
+		return output
 	}
 
 	vis := NewVarVisitor().WithParams(VarVisitorParams{

--- a/ast/compile_test.go
+++ b/ast/compile_test.go
@@ -277,6 +277,17 @@ func TestCompilerFunctions(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			note: "call argument ref output vars",
+			modules: []string{
+				`package x
+
+				f(x)
+
+				p { f(data.foo[i]) }`,
+			},
+			wantErr: false,
+		},
 	}
 	for _, tc := range tests {
 		test.Subtest(t, tc.note, func(t *testing.T) {
@@ -415,7 +426,7 @@ func TestCompilerCheckSafetyBodyReordering(t *testing.T) {
 			c.Modules = getCompilerTestModules()
 			c.Modules["reordering"] = MustParseModule(fmt.Sprintf(
 				`package test
-			 p { %s }`, tc.body))
+				p { %s }`, tc.body))
 
 			compileStages(c, c.checkSafetyRuleBodies)
 


### PR DESCRIPTION
This bug was introduced in 051157f. If not output value is specified in
a call expression, the ref outputs are still safe.

Fixes #625