### PR TITLE
Update query compiler to deep copy parsed query

### DIFF
--- a/ast/compile.go
+++ b/ast/compile.go
@@ -903,6 +903,8 @@ func (qc *queryCompiler) RewrittenVars() map[Var]Var {
 
 func (qc *queryCompiler) Compile(query Body) (Body, error) {
 
+	query = query.Copy()
+
 	stages := []struct {
 		name string
 		f    func(*QueryContext, Body) (Body, error)

--- a/ast/compile_test.go
+++ b/ast/compile_test.go
@@ -2067,6 +2067,33 @@ func TestQueryCompilerRewrittenVars(t *testing.T) {
 	}
 }
 
+func TestQueryCompilerRecompile(t *testing.T) {
+
+	// Query which contains terms that will be rewritten.
+	parsed := MustParseBody(`a := [1]; data.bar == data.foo[a[0]]`)
+	parsed0 := parsed
+
+	qc := NewCompiler().QueryCompiler()
+	compiled, err := qc.Compile(parsed)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	compiled2, err := qc.Compile(parsed)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !compiled2.Equal(compiled) {
+		t.Fatalf("Expected same compiled query. Expected: %v, Got: %v", compiled, compiled2)
+	}
+
+	if !parsed0.Equal(parsed) {
+		t.Fatalf("Expected parsed query to be unmodified. Expected %v, Got: %v", parsed0, parsed)
+	}
+
+}
+
 func assertCompilerErrorStrings(t *testing.T, compiler *Compiler, expected []string) {
 	result := compilerErrsToStringSlice(compiler.Errors)
 	if len(result) != len(expected) {

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -744,7 +744,7 @@ func (r *REPL) evalStatement(ctx context.Context, stmt interface{}) error {
 			}
 		}
 
-		compiledBody, typeEnv, err := r.compileBody(ctx, s, input)
+		compiledBody, typeEnv, err := r.compileBody(ctx, parsedBody, input)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
The query compiler was not deep copying queries like the compiler does
for modules. As a result, the parsed query in the REPL was being
recompiled and the rewritten var mapping was not correct. E.g.,
rewritten vars were not be displayed properly.