### PR TITLE
Update rule index to support ==

### DIFF
--- a/ast/index.go
+++ b/ast/index.go
@@ -190,9 +190,19 @@ func (i *baseDocEqIndex) Lookup(resolver ValueResolver) (*IndexResult, error) {
 	return result, nil
 }
 
+func indexedOperator(expr *Expr) bool {
+	if expr.IsEquality() {
+		return true
+	}
+	if expr.Operator().Compare(Equal.Ref()) == 0 {
+		return true
+	}
+	return false
+}
+
 func (i *baseDocEqIndex) getRefAndValue(expr *Expr) (Ref, Value, bool) {
 
-	if !expr.IsEquality() || expr.Negated {
+	if !indexedOperator(expr) || expr.Negated {
 		return nil, nil, false
 	}
 

--- a/ast/index_test.go
+++ b/ast/index_test.go
@@ -88,6 +88,14 @@ func TestBaseDocEqIndexing(t *testing.T) {
 		input.y = {"foo": "bar", "bar": x}
 	}
 
+	equal {
+		input.x == 1
+	} {
+		input.x == 2
+	} {
+		input.y == 3
+	}
+
 	# filtering ruleset contains rules that cannot be indexed (for different reasons).
 	filtering {
 		count([], x)
@@ -244,6 +252,21 @@ func TestBaseDocEqIndexing(t *testing.T) {
 			expectedRS: []string{
 				`composite_obj { input.y = {"foo": "bar", "bar": x} }`,
 			},
+		},
+		{
+			note:    "match ==",
+			ruleset: "equal",
+			input:   `{"x": 2, "y": 3}`,
+			expectedRS: []string{
+				"equal { input.y == 3 }",
+				"equal { input.x == 2 }",
+			},
+		},
+		{
+			note:       "miss ==",
+			ruleset:    "equal",
+			input:      `{"x": 1000, "y": 1000}`,
+			expectedRS: []string{},
 		},
 		{
 			note:       "default rule only",


### PR DESCRIPTION
This is a simple change that updates the rule index to support the == operator that was added in v0.7.