### PR TITLE
Update partial eval to check call args recursively

### DIFF
--- a/topdown/eval.go
+++ b/topdown/eval.go
@@ -178,7 +178,7 @@ func (e *eval) evalStep(index int, iter evalIterator) error {
 				e.traceRedo(expr)
 				return err
 			})
-		} else if e.saveSet.ContainsAny(terms[1:]) {
+		} else if e.saveSet.ContainsRecursiveAny(plugSlice(terms[1:], e.bindings)) {
 			return e.saveCall(terms[0], terms[1:len(terms)-1], terms[len(terms)-1], func() error {
 				return e.evalExpr(index+1, iter)
 			})
@@ -1633,4 +1633,12 @@ func plugKeys(a ast.Object, b *bindings) ast.Object {
 		return b.Plug(k), v, nil
 	})
 	return plugged
+}
+
+func plugSlice(xs []*ast.Term, b *bindings) []*ast.Term {
+	cpy := make([]*ast.Term, len(xs))
+	for i := range cpy {
+		cpy[i] = b.Plug(xs[i])
+	}
+	return cpy
 }

--- a/topdown/save.go
+++ b/topdown/save.go
@@ -42,9 +42,23 @@ func (n *saveSet) Contains(x *ast.Term) bool {
 	return false
 }
 
-func (n *saveSet) ContainsAny(xs []*ast.Term) bool {
+func (n *saveSet) ContainsRecursive(x *ast.Term) bool {
+	stop := false
+	ast.WalkTerms(x, func(t *ast.Term) bool {
+		if stop {
+			return true
+		}
+		if n.Contains(t) {
+			stop = true
+		}
+		return stop
+	})
+	return stop
+}
+
+func (n *saveSet) ContainsRecursiveAny(xs []*ast.Term) bool {
 	for i := range xs {
-		if n.Contains(xs[i]) {
+		if n.ContainsRecursive(xs[i]) {
 			return true
 		}
 	}

--- a/topdown/topdown_partial_test.go
+++ b/topdown/topdown_partial_test.go
@@ -368,6 +368,13 @@ func TestTopDownPartialEval(t *testing.T) {
 			},
 		},
 		{
+			note:  "save: call embedded",
+			query: "x = input; a = [x]; count([a], n)",
+			wantQueries: []string{
+				`x = input; count([[x]], n); a = [x]`,
+			},
+		},
+		{
 			note:  "save: negation",
 			query: "data.test.p = true",
 			modules: []string{


### PR DESCRIPTION
Previously, partial eval was not checking call args recursively for
terms in the save set. As a result, if a call expression passed a term
that had an unknown embedded, the call would be evaluated, which could
potentially result in an internal error.

Fixes #621