### PR TITLE
Ignore some built-in calls during partial eval

### DIFF
--- a/ast/builtins.go
+++ b/ast/builtins.go
@@ -136,6 +136,14 @@ var DefaultBuiltins = [...]*Builtin{
 // built-in definitions.
 var BuiltinMap map[string]*Builtin
 
+// IgnoreDuringPartialEval is a set of built-in functions that should not be
+// evaluated during partial evaluation. These functions are not partially
+// evaluated because they are not pure.
+var IgnoreDuringPartialEval = []*Builtin{
+	NowNanos,
+	HTTPSend,
+}
+
 /**
  * Unification
  */

--- a/topdown/topdown_partial_test.go
+++ b/topdown/topdown_partial_test.go
@@ -411,6 +411,13 @@ func TestTopDownPartialEval(t *testing.T) {
 			},
 		},
 		{
+			note:  "save: ignore ast",
+			query: "time.now_ns(x)",
+			wantQueries: []string{
+				`time.now_ns(x)`,
+			},
+		},
+		{
 			note:  "support: default trivial",
 			query: "data.test.p = x",
 			modules: []string{


### PR DESCRIPTION
Some buillt-in functions should not be partially evaluated because they
are not pure functions (e.g., http.send and time.now_ns are two exampels
we currently have.)

In the future, we may need to add variants of these functions that can
be evaluated during partial evaluation.

Fixes #622