### PR TITLE
Use standard base64 encoding for tokens

### DIFF
--- a/docs/book/language-reference.md
+++ b/docs/book/language-reference.md
@@ -107,7 +107,7 @@ complex types.
 
 | Built-in | Inputs | Description |
 | ------- |--------|-------------|
-| <span class="opa-keep-it-together">``io.jwt.verify_rs256(string, certificate, output)``</span> | 1 | ``output`` is a string which represents whether the RS256 signature of the input token is valid or not. An empty output string represents a valid signature. ``certificate`` is the PEM encoded certificate used to verify the RSA256 signature|
+| <span class="opa-keep-it-together">``io.jwt.verify_rs256(string, certificate, output)``</span> | 1 | ``output`` is ``true`` if the RS256 signature of the input token is valid. ``certificate`` is the PEM encoded certificate used to verify the RS256 signature|
 | <span class="opa-keep-it-together">``io.jwt.decode(string, [header, payload, sig])``</span> | 1 | ``header`` and ``payload`` are ``object``. ``signature`` is the hexadecimal representation of the signature on the token. |
 
 The input `string` is a JSON Web Token encoded with JWS Compact Serialization. JWE and JWS JSON Serialization are not supported. If nested signing was used, the ``header``, ``payload`` and ``signature`` will represent the most deeply nested token.


### PR DESCRIPTION
For encoding and decoding the different parts of the JWT use standard base64 encoding.