### PR TITLE
Generate support rules for negated expressions

### DIFF
--- a/topdown/topdown_partial_test.go
+++ b/topdown/topdown_partial_test.go
@@ -375,18 +375,6 @@ func TestTopDownPartialEval(t *testing.T) {
 			},
 		},
 		{
-			note:  "save: negation",
-			query: "data.test.p = true",
-			modules: []string{
-				`package test
-				p { input.x = 1; not q }
-				q { input.y = 2 }`,
-			},
-			wantQueries: []string{
-				`input.x = 1; not data.test.q`,
-			},
-		},
-		{
 			note:  "save: with",
 			query: "data.test.p = true",
 			modules: []string{
@@ -566,9 +554,13 @@ func TestTopDownPartialEval(t *testing.T) {
 			wantSupport: []string{
 				`package partial.test
 
-				p = true { input.x = 1; not data.test.r[1] }
-				p = true { input.y = 2; not data.test.r[2] }
+				p = true { input.x = 1; not data.partial.__not1_1__ }
+				p = true { input.y = 2 }
 				default p = false
+				`,
+				`package partial
+
+				__not1_1__ { input.z = 3 }
 				`,
 			},
 		},
@@ -612,6 +604,24 @@ func TestTopDownPartialEval(t *testing.T) {
 
 				p = true { input.x = 1 }
 				default p = false`,
+			},
+		},
+		{
+			note:  "support: negation",
+			query: "data.test.p = true",
+			modules: []string{
+				`package test
+				p { input.x = 1; not q; not r }
+				q { input.y = 2 }
+				r { false }`,
+			},
+			wantQueries: []string{
+				`input.x = 1; not data.partial.__not1_1__`,
+			},
+			wantSupport: []string{
+				`package partial
+
+				__not1_1__ { input.y = 2 }`,
 			},
 		},
 	}

--- a/topdown/topdown_partial_test.go
+++ b/topdown/topdown_partial_test.go
@@ -130,6 +130,29 @@ func TestTopDownPartialEval(t *testing.T) {
 			},
 		},
 		{
+			note:  "iterate keys: sets",
+			query: `input = x; s = {1,2}; s[x] = y`,
+			wantQueries: []string{
+				`input = x; 1 = x; s = {1, 2}; y = 1`,
+				`input = x; 2 = x; s = {1, 2}; y = 2`,
+			},
+		},
+		{
+			note:  "iterate keys: objects",
+			query: `input = x; o = {"a": 1, "b": 2}; o[x] = y`,
+			wantQueries: []string{
+				`input = x; "a" = x; o = {"a": 1, "b": 2}; y = 1`,
+				`input = x; "b" = x; o = {"a": 1, "b": 2}; y = 2`,
+			},
+		},
+		{
+			note:  "iterate keys: saved",
+			query: `x = input; y = [x]; z = y[i][j] `,
+			wantQueries: []string{
+				`x = input; x[j] = z; i = 0; y = [x]`,
+			},
+		},
+		{
 			note:  "single term: save",
 			query: `input.x = x; data.test.p[x]`,
 			modules: []string{


### PR DESCRIPTION
Previously, partial evaluation would save negated expressions and not
perform any inlining. With these changes, partial evaluation inlines
negated expressions into support rules and rewrites the original
expression to refer to the support rule.

These changes will improve the coverage of partial evaluation which
improves the applicability of rule indexing and other optimizations.

Fixes #623 