### PR TITLE
Update release patch script to cover YAML files

### DIFF
--- a/build/gen-release-patch.sh
+++ b/build/gen-release-patch.sh
@@ -57,7 +57,7 @@ EOF
 }
 
 update_docs() {
-    find ./docs/ -name "*.md" -exec sed -i='' s/${LAST_VERSION:1}/$VERSION/g {} \;
+    find ./docs/ \( -name "*.md" -o -name "*.yaml" \) -exec sed -i='' s/${LAST_VERSION:1}/$VERSION/g {} \;
 }
 
 main() {

--- a/docs/book/tutorials/kubernetes-admission-control-validation/admission-controller.yaml
+++ b/docs/book/tutorials/kubernetes-admission-control-validation/admission-controller.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
         - name: opa
-          image: openpolicyagent/opa:0.6.0
+          image: openpolicyagent/opa:0.7.1
           args:
             - "run"
             - "--server"


### PR DESCRIPTION
The script was not searching for version numbers in YAML files in the
docs. As a result the Kubernetes admission controller tutorial was out
of date.