### PR TITLE
Add JSON output format to check command

### DIFF
--- a/cover/cover.go
+++ b/cover/cover.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by an Apache2
 // license that can be found in the LICENSE file.
 
+// Package cover reports coverage on modules.
 package cover
 
 import (


### PR DESCRIPTION
This allows tools to consume the output of the check command programmatically.