### PR TITLE
Replace some fmt.Sprintf("%d", i) by strconv.Itoa(i), remove some double type wrapping

### DIFF
--- a/ast/term.go
+++ b/ast/term.go
@@ -544,8 +544,7 @@ func NumberTerm(n json.Number) *Term {
 
 // IntNumberTerm creates a new Term with an integer Number value.
 func IntNumberTerm(i int) *Term {
-	num := Number(json.Number(fmt.Sprintf("%d", i)))
-	return &Term{Value: num}
+	return &Term{Value: Number(strconv.Itoa(i))}
 }
 
 // FloatNumberTerm creates a new Term with a floating point Number value.
@@ -613,11 +612,11 @@ func (num Number) String() string {
 }
 
 func intNumber(i int) Number {
-	return Number(json.Number(fmt.Sprintf("%d", i)))
+	return Number(strconv.Itoa(i))
 }
 
 func int64Number(i int64) Number {
-	return Number(json.Number(fmt.Sprintf("%d", i)))
+	return Number(strconv.FormatInt(i, 10))
 }
 
 func floatNumber(f float64) Number {

--- a/topdown/casts.go
+++ b/topdown/casts.go
@@ -5,7 +5,6 @@
 package topdown
 
 import (
-	"encoding/json"
 	"strconv"
 
 	"github.com/open-policy-agent/opa/ast"
@@ -28,7 +27,7 @@ func builtinToNumber(a ast.Value) (ast.Value, error) {
 		if err != nil {
 			return nil, err
 		}
-		return ast.Number(json.Number(a)), nil
+		return ast.Number(a), nil
 	}
 	return nil, builtins.NewOperandTypeErr(1, a, "null", "boolean", "number", "string")
 }


### PR DESCRIPTION
Apparently, the latter, `strconv.Itoa`, is a little cheaper. Also simplifying some type
re-wrapping in the process -- the outcome should be the same in any
case.