### PR TITLE
Do not elide rule head value of true in some cases

### DIFF
--- a/format/testfiles/test.rego
+++ b/format/testfiles/test.rego
@@ -168,6 +168,10 @@ nested_infix {
     y = q()
 }
 
+expanded_const = true
+
+partial_obj["why"] = true { false }
+
 # more comments!
 # more comments!
 # more comments!

--- a/format/testfiles/test.rego.formatted
+++ b/format/testfiles/test.rego.formatted
@@ -193,6 +193,12 @@ nested_infix {
 	y = q()
 }
 
+expanded_const = true
+
+partial_obj["why"] = true {
+	false
+}
+
 # more comments!
 # more comments!
 # more comments!


### PR DESCRIPTION
If the rule defines a constant value or is part of an incremental
definition, then the value must not be elided because that would result
in a syntax error or change the meaning of the rule.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>