### PR TITLE
Improve partial eval of negated expressions

### DIFF
--- a/topdown/save.go
+++ b/topdown/save.go
@@ -73,6 +73,21 @@ func (n *saveSet) Pop() {
 	n.s = n.s[:len(n.s)-1]
 }
 
+func (n *saveSet) Vars() ast.VarSet {
+	if n == nil {
+		return nil
+	}
+	result := ast.NewVarSet()
+	for i := 0; i < len(n.s); i++ {
+		for k := range n.s[i].children {
+			if v, ok := k.(ast.Var); ok {
+				result.Add(v)
+			}
+		}
+	}
+	return result
+}
+
 type saveSetElem struct {
 	children map[ast.Value]*saveSetElem
 }

--- a/topdown/topdown_partial_test.go
+++ b/topdown/topdown_partial_test.go
@@ -647,6 +647,25 @@ func TestTopDownPartialEval(t *testing.T) {
 				__not1_1__ { input.y = 2 }`,
 			},
 		},
+		{
+			note:  "support: negation with input",
+			query: "input.x = x; input.y = y; not data.test.p[[x,y]]",
+			modules: []string{
+				`package test
+
+				p[[0, 1]]
+				p[[2, 3]]`,
+			},
+			wantQueries: []string{
+				`input.x = x; input.y = y; not data.partial.__not0_2__(x, y)`,
+			},
+			wantSupport: []string{
+				`package partial
+
+				__not0_2__(x, y) { 0 = x; 1 = y }
+				__not0_2__(x, y) { 2 = x; 3 = y }`,
+			},
+		},
 	}
 
 	ctx := context.Background()


### PR DESCRIPTION
Previously, support rules generated for negated expressions did not
include arguments. Assuming the negated expression did not depend on
unknowns in the calling query this is fine. However, if that's not the
case, then the support rule must be able refer to the unknowns,
otherwise, the partial evaluation result will yield false positives.

The unknowns cannot be pushed down to the support rule via the binding
lists because the bindings do not support references, only vars and
values. To workaround this, we generate support rules that include
arguments which can be used to push the unknwons down.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>