### PR TITLE
Plug comprehensions in partial eval results

### DIFF
--- a/topdown/topdown_partial_test.go
+++ b/topdown/topdown_partial_test.go
@@ -317,6 +317,11 @@ func TestTopDownPartialEval(t *testing.T) {
 			wantQueries: []string{`x = [true | true]; y = {true | true}; z = {a: true | a = "foo"}`},
 		},
 		{
+			note:        "comprehensions: closure",
+			query:       `i = 1; xs = [x | x = data.foo[i]]`,
+			wantQueries: []string{`xs = [x | x = data.foo[1]]; i = 1`},
+		},
+		{
 			note:  "save: sub path",
 			query: "input.x = 1; input.y = 2; input.z.a = 3; input.z.b = x",
 			input: `{"x": 1, "z": {"b": 4}}`,


### PR DESCRIPTION
During partial evaluation, comprehensions were not being plugged before
being returned to callers. If the comprehension closed over a variable
that was not included in the result, the comprehension would become
unsafe.

With this change, comprehensions are plugged before being returned to
callers. This will prevent these variables from becoming unsafe.

In the future, when comprehensions are evaluated during partial
evaluation, this may be unnecessary.

Fixes #656

Signed-off-by: Torin Sandall <torinsandall@gmail.com>