### PR TITLE
Refactor bundle configuration to be singleton

### DIFF
--- a/docs/book/bundles.md
+++ b/docs/book/bundles.md
@@ -29,12 +29,12 @@ services:
     credentials:
       bearer:
         token: "Bearer <base64 encoded string>"
-bundles:
-  - name: http/example/authz
-    service: acmecorp
-    polling:
-      min_delay_seconds: 60
-      max_delay_seconds: 120
+bundle:
+  name: http/example/authz
+  service: acmecorp
+  polling:
+    min_delay_seconds: 60
+    max_delay_seconds: 120
 ```
 
 With this configuration OPA will attempt to download a bundle named
@@ -52,12 +52,12 @@ services:
     credentials:
       bearer:
         token: string
-bundles:
-  - name: string
-    service: string
-    polling:
-      min_delay_seconds: number
-      max_delay_seconds: number
+bundle:
+  name: string
+  service: string
+  polling:
+    min_delay_seconds: number
+    max_delay_seconds: number
 ```
 
 Most fields in the configuration are optional, however, to enable bundle
@@ -67,8 +67,8 @@ downloading, you must set the following fields:
 | --- | --- |
 | `services[_].name` | Unique name for the service. Referred to by plugins. |
 | `services[_].url` | Base URL to contact the service with. |
-| `bundles[_].name` | Name of the bundle to download. |
-| `bundles[_].service` | Name of service to use to contact remote server. |
+| `bundle.name` | Name of the bundle to download. |
+| `bundle.service` | Name of service to use to contact remote server. |
 
 ## Bundle Service API
 

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -436,30 +436,29 @@ func initPlugins(store storage.Store, configFile string) (*plugins.Manager, erro
 		return nil, err
 	}
 
-	if err := initBundlePlugins(m, bs); err != nil {
+	if err := initBundlePlugin(m, bs); err != nil {
 		return nil, err
 	}
 
 	return m, nil
 }
 
-func initBundlePlugins(m *plugins.Manager, bs []byte) error {
+func initBundlePlugin(m *plugins.Manager, bs []byte) error {
 
 	var config struct {
-		Bundles []json.RawMessage `json:"bundles"`
+		Bundle json.RawMessage `json:"bundle"`
 	}
 
 	if err := util.Unmarshal(bs, &config); err != nil {
 		return err
 	}
 
-	for _, bs := range config.Bundles {
-		p, err := bundle.New(bs, m)
-		if err != nil {
-			return err
-		}
-		m.Register(p)
+	p, err := bundle.New(config.Bundle, m)
+	if err != nil {
+		return err
 	}
+
+	m.Register(p)
 
 	return nil
 }


### PR DESCRIPTION
The initial implementation allowed for N bundles to be configured. While
this is more flexible, it introduces unnecessary complexity around
management (e.g., how do you know which bundle a decision was comoputed
from?) and performance (e.g., you would expect OPA to dedup data between
bundles.)

Moving to a single bundle DOES NOT prevent admins from bundling
multiple policies and data sets together.

/cc @koponen-styra 