### PR TITLE
Fix check subcommand parse error printing

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -56,7 +56,7 @@ func checkModules(args []string) int {
 
 	result, err := loader.AllRegos(args)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
+		outputErrors(err)
 		return 1
 	}
 
@@ -74,10 +74,16 @@ func checkModules(args []string) int {
 		return 0
 	}
 
+	outputErrors(compiler.Errors)
+
+	return 1
+}
+
+func outputErrors(err error) {
 	switch checkParams.format.String() {
 	case checkFormatJSON:
 		result := map[string]error{
-			"errors": compiler.Errors,
+			"errors": err,
 		}
 		bs, err := json.MarshalIndent(result, "", "  ")
 		if err != nil {
@@ -86,10 +92,8 @@ func checkModules(args []string) int {
 			fmt.Fprintln(os.Stdout, string(bs))
 		}
 	default:
-		fmt.Fprintln(os.Stdout, compiler.Errors)
+		fmt.Fprintln(os.Stdout, err)
 	}
-
-	return 1
 }
 
 func init() {

--- a/loader/errors.go
+++ b/loader/errors.go
@@ -7,6 +7,8 @@ package loader
 import (
 	"fmt"
 	"strings"
+
+	"github.com/open-policy-agent/opa/ast"
 )
 
 type loaderErrors []error
@@ -26,7 +28,13 @@ func (e loaderErrors) Error() string {
 }
 
 func (e *loaderErrors) Add(err error) {
-	*e = append(*e, err)
+	if errs, ok := err.(ast.Errors); ok {
+		for i := range errs {
+			*e = append(*e, errs[i])
+		}
+	} else {
+		*e = append(*e, err)
+	}
 }
 
 func newResult() *Result {


### PR DESCRIPTION
The check subcommand was not formatting parse errors as JSON if
requested. Also, since the loader package returns a set of errors, parse
errors are unpacked to avoid double nesting.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>