### PR TITLE
Only start plugins if config provided

### DIFF
--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -455,9 +455,11 @@ func initPlugins(id string, store storage.Store, configFile string) (*plugins.Ma
 		return nil, err
 	}
 
-	_, err = initStatusPlugin(m, bs, bundlePlugin)
-	if err != nil {
-		return nil, err
+	if bundlePlugin != nil {
+		_, err = initStatusPlugin(m, bs, bundlePlugin)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return m, nil
@@ -471,6 +473,10 @@ func initBundlePlugin(m *plugins.Manager, bs []byte) (*bundle.Plugin, error) {
 
 	if err := util.Unmarshal(bs, &config); err != nil {
 		return nil, err
+	}
+
+	if config.Bundle == nil {
+		return nil, nil
 	}
 
 	p, err := bundle.New(config.Bundle, m)
@@ -491,6 +497,10 @@ func initStatusPlugin(m *plugins.Manager, bs []byte, bundlePlugin *bundle.Plugin
 
 	if err := util.Unmarshal(bs, &config); err != nil {
 		return nil, err
+	}
+
+	if config.Status == nil {
+		return nil, nil
 	}
 
 	p, err := status.New(config.Status, m)


### PR DESCRIPTION
The runtime was starting the bundle and status plugins even if the
config was missing.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>