### PR TITLE
Improve support for decision logging in OPA

### DIFF
--- a/docs/book/decision_logs.md
+++ b/docs/book/decision_logs.md
@@ -1,0 +1,116 @@
+# Decision Logs
+
+OPA can periodically report decision logs to remote HTTP servers. The
+decision logs contain events that describe policy queries. Each event
+includes the policy that was queried, the input to the query, bundle
+metadata, and other information that enables auditing and offline debugging
+of policy decisions.
+
+## Decision Log Configuration
+
+You can configure OPA to periodically report decision logs by starting OPA
+with a configuration file (both YAML and JSON files are supported):
+
+```bash
+opa run --server --config-file config.yaml
+```
+
+**config.yaml**:
+
+```yaml
+services:
+  - name: acmecorp
+    url: https://example.com/
+    credentials:
+      bearer:
+        token: "Bearer <base64 encoded string>"
+bundle:
+  name: http/example/authz
+  service: acmecorp
+labels:
+  app: example
+decision_logs:
+  service: acmecorp
+  reporting:
+    min_delay_seconds: 300
+    max_delay_seconds: 600
+```
+
+With this configuration OPA will report decision logs to
+`https://example.com` every 5-10 minutes. The reporting delay is randomized
+(between min and max) to stagger upload requests when there are a large
+number of OPAs uploading decision logs.
+
+### Configuration File Format
+
+```yaml
+labels: object
+decision_logs:
+  service: string
+  partition_name: string
+  reporting:
+    upload_size_limit_bytes: number
+    min_delay_seconds: number
+    max_delay_seconds: number
+```
+
+| Field | Required | Description |
+| --- | --- | --- |
+| `labels` | No |  Set of key-value pairs that uniquely identify the OPA instance. |
+| `decision_logs.service` | Yes | Name of the service to use to contact remote server. |
+| `decision_logs.partition_name` | No | Path segment to include in status updates. |
+| `decision_logs.reporting.buffer_size_limit_bytes` | No | Decision log buffer size limit in bytes. OPA will drop old events from the log if this limit is exceeded. |
+| `decision_logs.reporting.upload_size_limit_bytes` | No | Decision log upload size limit in bytes. OPA will chunk uploads to cap message body to this limit. |
+| `decision_logs.reporting.min_delay_seconds` | No | Minimum amount of time to wait between uploads. |
+| `decision_logs.reporting.max_delay_seconds` | No | Maximum amount of time to wait between uploads. |
+
+### Decision Log Service API
+
+OPA expects the service to expose an API endpoint that will receive decision logs.
+
+```http
+POST /logs[/<partition_name>] HTTP/1.1
+Content-Encoding: gzip
+Content-Type: application/json
+```
+
+The partition name is an optional path segment that can be used to route logs
+to different backends. If the partition name is not configured on the agent,
+updates will be sent to `/logs`.
+
+The message body contains a gzip compressed JSON array. Each array element (event)
+represents a policy decision returned by OPA.
+
+```json
+[
+  {
+    "labels": {
+      "app": "my-example-app",
+      "id": "1780d507-aea2-45cc-ae50-fa153c8e4a5a"
+    },
+    "decision_id": "4ca636c1-55e4-417a-b1d8-4aceb67960d1",
+    "revision": "W3sibCI6InN5cy9jYXRhbG9nIiwicyI6NDA3MX1d",
+    "path": "http/example/authz/allow",
+    "input": {
+      "method": "GET",
+      "path": "/salary/bob"
+    },
+    "result": "true",
+    "requested_by": "[::1]:59943",
+    "timestamp": "2018-01-01T00:00:00.000000Z"
+  }
+]
+```
+
+Decision log updates contain the following fields:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `[_].labels` | `object` | Set of key-value pairs that uniquely identify the OPA instance. |
+| `[_].decision_id` | `string` | Unique identifier generated for each decision for traceability. |
+| `[_].revision` | `string` | Bundle revision that contained the policy used to produce the decision. |
+| `[_].path` | `string` | Hierarchical policy decision path, e.g., `/http/example/authz/allow`. |
+| `[_].input` | `any` | Input data provided in the policy query. |
+| `[_].result` | `any` | Policy decision returned to the client, e.g., `true` or `false`. |
+| `[_].requested_by` | `string` | Identifier for client that executed policy query, e.g., the client address. |
+| `[_].timestamp` | `string` | RFC3999 timestamp of policy decision. |

--- a/plugins/bundle/plugin_test.go
+++ b/plugins/bundle/plugin_test.go
@@ -159,7 +159,7 @@ func TestPluginStart(t *testing.T) {
 				t.Fatalf("Bad policy content. Exp:\n%v\n\nGot:\n\n%v", string(exp), string(bs))
 			}
 			data, err := fixture.store.Read(ctx, txn, storage.Path{})
-			expData := util.MustUnmarshalJSON([]byte(`{"foo": {"bar": 1, "baz": "qux"}}`))
+			expData := util.MustUnmarshalJSON([]byte(`{"foo": {"bar": 1, "baz": "qux"}, "system": {"bundle": {"manifest": {"revision": "quickbrownfaux"}}}}`))
 			if err != nil {
 				t.Fatal(err)
 			} else if !reflect.DeepEqual(data, expData) {
@@ -351,6 +351,8 @@ func TestPluginActivatationRemovesOld(t *testing.T) {
 			return fmt.Errorf("expected updated policy ids")
 		}
 		data, err := store.Read(ctx, txn, storage.Path{})
+		// remove system key to make comparison simpler
+		delete(data.(map[string]interface{}), "system")
 		if err != nil {
 			return err
 		} else if !reflect.DeepEqual(data, map[string]interface{}{"baz": "qux"}) {

--- a/plugins/logs/buffer.go
+++ b/plugins/logs/buffer.go
@@ -1,0 +1,59 @@
+// Copyright 2018 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package logs
+
+import (
+	"container/list"
+)
+
+// logBuffer implements a circular FIFO buffer for the plugin that caps memory
+// usage at the configured limit. If the buffer size is exceeded, events from
+// the front of the buffer are dropped.
+type logBuffer struct {
+	usage int64
+	limit int64
+	l     *list.List
+}
+
+type logBufferElem struct {
+	bs      []byte
+	isChunk bool
+}
+
+func newLogBuffer(limit int64) *logBuffer {
+	return &logBuffer{
+		limit: limit,
+		usage: 0,
+		l:     list.New(),
+	}
+}
+
+func (lb *logBuffer) Push(bs []byte, isChunk bool) (dropped int) {
+	size := int64(len(bs))
+
+	for elem := lb.l.Front(); elem != nil && (lb.usage+size > lb.limit); elem = elem.Next() {
+		drop := elem.Value.(logBufferElem).bs
+		lb.l.Remove(elem)
+		lb.usage -= int64(len(drop))
+		dropped++
+	}
+
+	elem := logBufferElem{bs, isChunk}
+
+	lb.l.PushBack(elem)
+	lb.usage += size
+	return dropped
+}
+
+func (lb *logBuffer) Pop() ([]byte, bool) {
+	elem := lb.l.Front()
+	if elem != nil {
+		e := elem.Value.(logBufferElem)
+		lb.usage -= int64(len(e.bs))
+		lb.l.Remove(elem)
+		return e.bs, e.isChunk
+	}
+	return nil, false
+}

--- a/plugins/logs/buffer_test.go
+++ b/plugins/logs/buffer_test.go
@@ -1,0 +1,60 @@
+// Copyright 2018 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package logs
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestLogBuffer(t *testing.T) {
+
+	buffer := newLogBuffer(int64(20)) // 20 byte limit for test purposes
+
+	dropped := buffer.Push(make([]byte, 20), false)
+	if dropped != 0 {
+		t.Fatal("Expected dropped to be zero")
+	}
+
+	bs, chunk := buffer.Pop()
+	if len(bs) != 20 {
+		t.Fatal("Expected buffer size to be 20")
+	} else if chunk {
+		t.Fatal("Expected !chunk")
+	}
+
+	bs, _ = buffer.Pop()
+	if bs != nil {
+		t.Fatal("Expected buffer to be nil")
+	}
+
+	dropped = buffer.Push(bytes.Repeat([]byte(`1`), 10), false)
+	if dropped != 0 {
+		t.Fatal("Expected dropped to be zero")
+	}
+
+	dropped = buffer.Push(bytes.Repeat([]byte(`2`), 10), true)
+	if dropped != 0 {
+		t.Fatal("Expected dropped to be zero")
+	}
+
+	dropped = buffer.Push(bytes.Repeat([]byte(`3`), 10), false)
+	if dropped != 1 {
+		t.Fatal("Expected dropped to be 1")
+	}
+
+	bs, chunk = buffer.Pop()
+	exp := bytes.Repeat([]byte(`2`), 10)
+	if !bytes.Equal(bs, exp) {
+		t.Fatalf("Expected %v but got %v", exp, bs)
+	} else if !chunk {
+		t.Fatal("Expected chunk to be true")
+	}
+
+	if buffer.usage != 10 {
+		t.Fatalf("Expected buffer usage to be 10 but got %v", buffer.usage)
+	}
+
+}

--- a/plugins/logs/encoder.go
+++ b/plugins/logs/encoder.go
@@ -1,0 +1,95 @@
+// Copyright 2018 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package logs
+
+import (
+	"bytes"
+	"compress/gzip"
+	"fmt"
+)
+
+// chunkEncoder implements log buffer chunking and compression. Log events are
+// written to the encoder and the encoder outputs chunks that are fit to the
+// configured limit.
+type chunkEncoder struct {
+	limit        int64
+	bytesWritten int
+	buf          *bytes.Buffer
+	w            *gzip.Writer
+}
+
+func newChunkEncoder(limit int64) *chunkEncoder {
+	enc := &chunkEncoder{
+		limit: limit,
+	}
+	enc.reset()
+	return enc
+}
+
+func (enc *chunkEncoder) Write(bs []byte) (result []byte, err error) {
+
+	if len(bs) == 0 {
+		return nil, nil
+	} else if int64(len(bs)+2) > enc.limit {
+		return nil, fmt.Errorf("upload chunk size too small")
+	}
+
+	if int64(len(bs)+enc.bytesWritten+1) > enc.limit {
+		if err := enc.writeClose(); err != nil {
+			return nil, err
+		}
+		result = enc.reset()
+	}
+
+	if enc.bytesWritten == 0 {
+		n, err := enc.w.Write([]byte(`[`))
+		if err != nil {
+			return nil, err
+		}
+		enc.bytesWritten += n
+	} else {
+		n, err := enc.w.Write([]byte(`,`))
+		if err != nil {
+			return nil, err
+		}
+		enc.bytesWritten += n
+	}
+
+	n, err := enc.w.Write(bs)
+	if err != nil {
+		return nil, err
+	}
+
+	enc.bytesWritten += n
+	return
+}
+
+func (enc *chunkEncoder) writeClose() error {
+	if _, err := enc.w.Write([]byte(`]`)); err != nil {
+		return err
+	}
+	return enc.w.Close()
+}
+
+func (enc *chunkEncoder) Flush() ([]byte, error) {
+	if enc.bytesWritten == 0 {
+		return nil, nil
+	}
+	if err := enc.writeClose(); err != nil {
+		return nil, err
+	}
+	return enc.reset(), nil
+}
+
+func (enc *chunkEncoder) reset() []byte {
+	buf := enc.buf
+	enc.buf = new(bytes.Buffer)
+	enc.bytesWritten = 0
+	enc.w = gzip.NewWriter(enc.buf)
+	if buf != nil {
+		return buf.Bytes()
+	}
+	return nil
+}

--- a/plugins/logs/encoder_test.go
+++ b/plugins/logs/encoder_test.go
@@ -1,0 +1,51 @@
+// Copyright 2018 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package logs
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestChunkEncoder(t *testing.T) {
+
+	enc := newChunkEncoder(1000)
+
+	bs, err := enc.Write(bytes.Repeat([]byte(`1`), 500))
+	if bs != nil || err != nil {
+		t.Fatalf("Unexpected error or chunk produced: err: %v", err)
+	}
+
+	bs, err = enc.Write(bytes.Repeat([]byte(`1`), 498))
+	if bs != nil || err != nil {
+		t.Fatalf("Unexpected error or chunk produced: err: %v", err)
+	}
+
+	bs, err = enc.Write(bytes.Repeat([]byte(`1`), 1))
+	if bs == nil || err != nil {
+		t.Fatalf("Unexpected error or NO chunk produced: err: %v", err)
+	}
+
+	bs, err = enc.Write(bytes.Repeat([]byte(`1`), 1))
+	if bs != nil || err != nil {
+		t.Fatalf("Unexpected error or chunk produced: err: %v", err)
+	}
+
+	bs, err = enc.Flush()
+	if bs == nil || err != nil {
+		t.Fatalf("Unexpected error or NO chunk produced: err: %v", err)
+	}
+
+	bs, err = enc.Flush()
+	if bs != nil || err != nil {
+		t.Fatalf("Unexpected error chunk produced: err: %v", err)
+	}
+
+	bs, err = enc.Write(nil)
+	if bs != nil || err != nil || enc.bytesWritten != 0 {
+		t.Fatalf("Unexpected error chunk produced or bytesWritten != 0: err: %v, bytesWritten: %v", err, enc.bytesWritten)
+	}
+
+}

--- a/plugins/logs/plugin.go
+++ b/plugins/logs/plugin.go
@@ -1,0 +1,349 @@
+// Copyright 2018 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+// Package logs implements decision log buffering and uploading.
+package logs
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/open-policy-agent/opa/plugins"
+	"github.com/open-policy-agent/opa/server"
+	"github.com/open-policy-agent/opa/util"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+// EventV1 represents a decision log event.
+type EventV1 struct {
+	Labels      map[string]string `json:"labels"`
+	DecisionID  string            `json:"decision_id"`
+	Revision    string            `json:"revision,omitempty"`
+	Path        string            `json:"path"`
+	Input       *interface{}      `json:"input,omitempty"`
+	Result      *interface{}      `json:"result,omitempty"`
+	RequestedBy string            `json:"requested_by"`
+	Timestamp   time.Time         `json:"timestamp"`
+}
+
+const (
+	// min amount of time to wait following a failure
+	minRetryDelay               = time.Millisecond * 100
+	defaultMinDelaySeconds      = int64(300)
+	defaultMaxDelaySeconds      = int64(600)
+	defaultUploadSizeLimitBytes = int64(32768)   // 32KB limit
+	defaultBufferSizeLimitBytes = int64(1048576) // 1MB limit
+)
+
+// ReportingConfig represents configuration for the plugin's reporting behaviour.
+type ReportingConfig struct {
+	BufferSizeLimitBytes *int64 `json:"buffer_size_limit_bytes,omitempty"` // max size of in-memory buffer
+	UploadSizeLimitBytes *int64 `json:"upload_size_limit_bytes,omitempty"` // max size of upload payload
+	MinDelaySeconds      *int64 `json:"min_delay_seconds,omitempty"`       // min amount of time to wait between successful poll attempts
+	MaxDelaySeconds      *int64 `json:"max_delay_seconds,omitempty"`       // max amount of time to wait between poll attempts
+}
+
+// Config represents the plugin configuration.
+type Config struct {
+	Service       string          `json:"service"`
+	PartitionName string          `json:"partition_name,omitempty"`
+	Reporting     ReportingConfig `json:"reporting"`
+}
+
+func (c *Config) validateAndInjectDefaults(services []string) error {
+
+	found := false
+
+	for _, svc := range services {
+		if svc == c.Service {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		return fmt.Errorf("invalid service name %q in decision_logs", c.Service)
+	}
+
+	min := defaultMinDelaySeconds
+	max := defaultMaxDelaySeconds
+
+	// reject bad min/max values
+	if c.Reporting.MaxDelaySeconds != nil && c.Reporting.MinDelaySeconds != nil {
+		if *c.Reporting.MaxDelaySeconds < *c.Reporting.MinDelaySeconds {
+			return fmt.Errorf("max reporting delay must be >= min reporting delay in decision_logs")
+		}
+		min = *c.Reporting.MinDelaySeconds
+		max = *c.Reporting.MaxDelaySeconds
+	} else if c.Reporting.MaxDelaySeconds == nil && c.Reporting.MinDelaySeconds != nil {
+		return fmt.Errorf("reporting configuration missing 'max_delay_seconds' in decision_logs")
+	} else if c.Reporting.MinDelaySeconds == nil && c.Reporting.MaxDelaySeconds != nil {
+		return fmt.Errorf("reporting configuration missing 'min_delay_seconds' in decision_logs")
+	}
+
+	// scale to seconds
+	minSeconds := int64(time.Duration(min) * time.Second)
+	c.Reporting.MinDelaySeconds = &minSeconds
+
+	maxSeconds := int64(time.Duration(max) * time.Second)
+	c.Reporting.MaxDelaySeconds = &maxSeconds
+
+	// default the upload size limit
+	uploadLimit := defaultUploadSizeLimitBytes
+	if c.Reporting.UploadSizeLimitBytes != nil {
+		uploadLimit = *c.Reporting.UploadSizeLimitBytes
+	}
+
+	c.Reporting.UploadSizeLimitBytes = &uploadLimit
+
+	// default the buffer size limit
+	bufferLimit := defaultBufferSizeLimitBytes
+	if c.Reporting.BufferSizeLimitBytes != nil {
+		bufferLimit = *c.Reporting.BufferSizeLimitBytes
+	}
+
+	c.Reporting.BufferSizeLimitBytes = &bufferLimit
+
+	return nil
+}
+
+// Plugin implements decision log buffering and uploading.
+type Plugin struct {
+	manager *plugins.Manager
+	config  Config
+	buffer  *logBuffer
+	mtx     sync.Mutex
+	stop    chan chan struct{}
+}
+
+// New returns a new Plugin with the given config.
+func New(config []byte, manager *plugins.Manager) (*Plugin, error) {
+
+	var parsedConfig Config
+
+	if err := util.Unmarshal(config, &parsedConfig); err != nil {
+		return nil, err
+	}
+
+	if err := parsedConfig.validateAndInjectDefaults(manager.Services()); err != nil {
+		return nil, err
+	}
+
+	plugin := &Plugin{
+		manager: manager,
+		config:  parsedConfig,
+		stop:    make(chan chan struct{}),
+		buffer:  newLogBuffer(*parsedConfig.Reporting.BufferSizeLimitBytes),
+	}
+
+	return plugin, nil
+}
+
+// Start starts the plugin.
+func (p *Plugin) Start(ctx context.Context) error {
+	go p.loop()
+	return nil
+}
+
+// Stop stops the plugin.
+func (p *Plugin) Stop(ctx context.Context) {
+	done := make(chan struct{})
+	p.stop <- done
+	_ = <-done
+}
+
+// Log appends a decision log event to the buffer for uploading.
+func (p *Plugin) Log(ctx context.Context, decision *server.Info) {
+
+	var buf bytes.Buffer
+
+	path := strings.Replace(strings.TrimLeft(decision.Query, "data."), ".", "/", -1)
+
+	event := EventV1{
+		Labels:      p.manager.Labels,
+		DecisionID:  decision.DecisionID,
+		Revision:    decision.Revision,
+		Path:        path,
+		Input:       &decision.Input,
+		Result:      decision.Results,
+		RequestedBy: decision.RemoteAddr,
+		Timestamp:   decision.Timestamp,
+	}
+
+	if err := json.NewEncoder(&buf).Encode(event); err != nil {
+		p.logError("Log serialization failed: %v.", err)
+		return
+	}
+
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+	dropped := p.buffer.Push(buf.Bytes(), false)
+	if dropped > 0 {
+		p.logInfo("Dropped %v events from buffer. Reduce reporting interval or increase buffer size.")
+	}
+}
+
+func (p *Plugin) loop() {
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var retry int
+
+	for {
+		uploaded, err := p.oneShot(ctx)
+
+		if err != nil {
+			p.logError("%v.", err)
+		} else if uploaded {
+			p.logInfo("Logs uploaded successfully.")
+		} else {
+			p.logInfo("Log upload skipped.")
+		}
+
+		var delay time.Duration
+
+		if err == nil {
+			min := float64(*p.config.Reporting.MinDelaySeconds)
+			max := float64(*p.config.Reporting.MaxDelaySeconds)
+			delay = time.Duration(((max - min) * rand.Float64()) + min)
+		} else {
+			delay = util.DefaultBackoff(float64(minRetryDelay), float64(*p.config.Reporting.MaxDelaySeconds), retry)
+		}
+
+		p.logDebug("Waiting %v before next upload/retry.", delay)
+		timer := time.NewTimer(delay)
+
+		select {
+		case <-timer.C:
+			if err != nil {
+				retry++
+			} else {
+				retry = 0
+			}
+		case done := <-p.stop:
+			cancel()
+			done <- struct{}{}
+			return
+		}
+	}
+}
+
+func (p *Plugin) oneShot(ctx context.Context) (ok bool, err error) {
+
+	chunks, err := p.chunkBuffer()
+	if err != nil {
+		return false, errors.Wrap(err, "Log processing failed")
+	}
+
+	var chunkIndex int
+
+	defer func() {
+		if err != nil {
+			p.requeueChunks(chunks, chunkIndex)
+		}
+	}()
+
+	for chunkIndex = range chunks {
+
+		resp, err := p.manager.Client(p.config.Service).
+			WithHeader("Content-Type", "application/json").
+			WithHeader("Content-Encoding", "gzip").
+			WithBytes(chunks[chunkIndex]).
+			Do(ctx, "POST", fmt.Sprintf("/logs/%v", p.config.PartitionName))
+
+		if err != nil {
+			return false, errors.Wrap(err, "Log upload failed")
+		}
+
+		defer util.Close(resp)
+
+		switch resp.StatusCode {
+		case http.StatusOK:
+			break
+		case http.StatusNotFound:
+			return false, fmt.Errorf("Log upload failed, server replied with not found")
+		case http.StatusUnauthorized:
+			return false, fmt.Errorf("Log upload failed, server replied with not authorized")
+		default:
+			return false, fmt.Errorf("Log upload failed, server replied with HTTP %v", resp.StatusCode)
+		}
+	}
+
+	return len(chunks) > 0, nil
+}
+
+func (p *Plugin) chunkBuffer() ([][]byte, error) {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+	return chunk(*p.config.Reporting.UploadSizeLimitBytes, p.buffer)
+}
+
+func (p *Plugin) requeueChunks(chunks [][]byte, idx int) {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+
+	var dropped int
+
+	for ; idx < len(chunks); idx++ {
+		dropped += p.buffer.Push(chunks[idx], true)
+	}
+
+	if dropped > 0 {
+		p.logInfo("Dropped %v events from buffer. Reduce reporting interval or increase buffer size.")
+	}
+}
+
+func (p *Plugin) logError(fmt string, a ...interface{}) {
+	logrus.WithFields(p.logrusFields()).Errorf(fmt, a...)
+}
+
+func (p *Plugin) logInfo(fmt string, a ...interface{}) {
+	logrus.WithFields(p.logrusFields()).Infof(fmt, a...)
+}
+
+func (p *Plugin) logDebug(fmt string, a ...interface{}) {
+	logrus.WithFields(p.logrusFields()).Debugf(fmt, a...)
+}
+
+func (p *Plugin) logrusFields() logrus.Fields {
+	return logrus.Fields{
+		"plugin": "decision_logs",
+	}
+}
+
+func chunk(limit int64, buffer *logBuffer) ([][]byte, error) {
+
+	enc := newChunkEncoder(limit)
+	chunks := [][]byte{}
+
+	for bs, isChunk := buffer.Pop(); bs != nil; bs, isChunk = buffer.Pop() {
+		if !isChunk {
+			chunk, err := enc.Write(bs)
+			if err != nil {
+				return nil, err
+			} else if chunk != nil {
+				chunks = append(chunks, chunk)
+			}
+		} else {
+			chunks = append(chunks, bs)
+		}
+	}
+
+	chunk, err := enc.Flush()
+	if err != nil {
+		return nil, err
+	} else if chunk != nil {
+		chunks = append(chunks, chunk)
+	}
+
+	return chunks, nil
+}

--- a/plugins/logs/plugin_test.go
+++ b/plugins/logs/plugin_test.go
@@ -1,0 +1,213 @@
+// Copyright 2018 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package logs
+
+import (
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/open-policy-agent/opa/plugins"
+	"github.com/open-policy-agent/opa/server"
+	"github.com/open-policy-agent/opa/storage/inmem"
+)
+
+func TestPluginStart(t *testing.T) {
+	ctx := context.Background()
+
+	fixture := newTestFixture(t)
+	defer fixture.server.stop()
+
+	fixture.server.ch = make(chan []EventV1, 2)
+	var result interface{} = false
+
+	ts, err := time.Parse(time.RFC3339Nano, "2018-01-01T12:00:00.123456Z")
+	if err != nil {
+		panic(err)
+	}
+
+	for i := 0; i < 154; i++ { // first chunk fits exactly n-1 events
+		fixture.plugin.Log(ctx, &server.Info{
+			Revision:   "a",
+			DecisionID: fmt.Sprint(i),
+			Query:      "data.foo.bar",
+			Input:      map[string]interface{}{"method": "GET"},
+			Results:    &result,
+			RemoteAddr: "test",
+			Timestamp:  ts,
+		})
+	}
+
+	_, err = fixture.plugin.oneShot(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	chunk1 := <-fixture.server.ch
+	chunk2 := <-fixture.server.ch
+	expLen1 := 153
+	expLen2 := 1
+
+	if len(chunk1) != expLen1 || len(chunk2) != expLen2 {
+		t.Fatalf("Expected chunk lens %v and %v but got: %v and %v", expLen1, expLen2, len(chunk1), len(chunk2))
+	}
+
+	var expInput interface{} = map[string]interface{}{"method": "GET"}
+
+	exp := EventV1{
+		Labels: map[string]string{
+			"id":  "test-instance-id",
+			"app": "example-app",
+		},
+		Revision:    "a",
+		DecisionID:  "153",
+		Path:        "foo/bar",
+		Input:       &expInput,
+		Result:      &result,
+		RequestedBy: "test",
+		Timestamp:   ts,
+	}
+
+	if !reflect.DeepEqual(chunk2[0], exp) {
+		t.Fatalf("Expected %v but got %v", exp, chunk2[0])
+	}
+}
+
+func TestPluginRequeue(t *testing.T) {
+	ctx := context.Background()
+
+	fixture := newTestFixture(t)
+	defer fixture.server.stop()
+
+	fixture.server.ch = make(chan []EventV1, 1)
+
+	var result1 interface{} = false
+
+	fixture.plugin.Log(ctx, &server.Info{
+		DecisionID: "abc",
+		Query:      "data.foo.bar",
+		Input:      map[string]interface{}{"method": "GET"},
+		Results:    &result1,
+		RemoteAddr: "test",
+		Timestamp:  time.Now().UTC(),
+	})
+
+	fixture.server.expCode = 500
+	_, err := fixture.plugin.oneShot(ctx)
+	if err == nil {
+		t.Fatal("Expected error")
+	}
+
+	events1 := <-fixture.server.ch
+
+	fixture.server.expCode = 200
+
+	_, err = fixture.plugin.oneShot(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	events2 := <-fixture.server.ch
+
+	if !reflect.DeepEqual(events1, events2) {
+		t.Fatalf("Expected %v but got: %v", events1, events2)
+	}
+
+	uploaded, err := fixture.plugin.oneShot(ctx)
+	if uploaded || err != nil {
+		t.Fatalf("Unexpected error or upload, err: %v", err)
+	}
+}
+
+type testFixture struct {
+	manager *plugins.Manager
+	plugin  *Plugin
+	server  *testServer
+}
+
+func newTestFixture(t *testing.T) testFixture {
+
+	ts := testServer{
+		t:       t,
+		expCode: 200,
+	}
+
+	ts.start()
+
+	managerConfig := []byte(fmt.Sprintf(`{
+			"labels": {
+				"app": "example-app"
+			},
+			"services": [
+				{
+					"name": "example",
+					"url": %q,
+					"credentials": {
+						"bearer": {
+							"scheme": "Bearer",
+							"token": "secret"
+						}
+					}
+				}
+			]}`, ts.server.URL))
+
+	manager, err := plugins.New(managerConfig, "test-instance-id", inmem.New())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pluginConfig := []byte(fmt.Sprintf(`{
+			"service": "example",
+		}`))
+
+	p, err := New(pluginConfig, manager)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return testFixture{
+		manager: manager,
+		plugin:  p,
+		server:  &ts,
+	}
+
+}
+
+type testServer struct {
+	t       *testing.T
+	expCode int
+	server  *httptest.Server
+	ch      chan []EventV1
+}
+
+func (t *testServer) handle(w http.ResponseWriter, r *http.Request) {
+	gr, err := gzip.NewReader(r.Body)
+	if err != nil {
+		t.t.Fatal(err)
+	}
+	var events []EventV1
+	if err := json.NewDecoder(gr).Decode(&events); err != nil {
+		t.t.Fatal(err)
+	}
+	if err := gr.Close(); err != nil {
+		t.t.Fatal(err)
+	}
+	t.ch <- events
+	w.WriteHeader(t.expCode)
+}
+
+func (t *testServer) start() {
+	t.server = httptest.NewServer(http.HandlerFunc(t.handle))
+}
+
+func (t *testServer) stop() {
+	t.server.Close()
+}

--- a/plugins/rest/rest.go
+++ b/plugins/rest/rest.go
@@ -47,6 +47,7 @@ func (c *Config) validateAndInjectDefaults() error {
 // services.
 type Client struct {
 	Client  http.Client
+	bytes   *[]byte
 	json    *interface{}
 	config  Config
 	headers map[string]string
@@ -90,6 +91,13 @@ func (c Client) WithJSON(body interface{}) Client {
 	return c
 }
 
+// WithBytes returns a shallow copy of the client with the bytes set as the
+// message body to include in the requests.
+func (c Client) WithBytes(body []byte) Client {
+	c.bytes = &body
+	return c
+}
+
 // Do executes a request using the client.
 func (c Client) Do(ctx context.Context, method, path string) (*http.Response, error) {
 
@@ -97,7 +105,10 @@ func (c Client) Do(ctx context.Context, method, path string) (*http.Response, er
 
 	var body io.Reader
 
-	if c.json != nil {
+	if c.bytes != nil {
+		buf := bytes.NewBuffer(*c.bytes)
+		body = buf
+	} else if c.json != nil {
 		var buf bytes.Buffer
 		if err := json.NewEncoder(&buf).Encode(*c.json); err != nil {
 			return nil, err

--- a/plugins/rest/rest.go
+++ b/plugins/rest/rest.go
@@ -151,5 +151,17 @@ func (c Client) Do(ctx context.Context, method, path string) (*http.Response, er
 		"headers": req.Header,
 	}).Debug("Sending request.")
 
-	return c.Client.Do(req)
+	resp, err := c.Client.Do(req)
+	if resp != nil {
+		// Only log for debug purposes. If an error occurred, the caller should handle
+		// that. In the non-error case, the caller may not do anything.
+		logrus.WithFields(logrus.Fields{
+			"method":  method,
+			"url":     url,
+			"status":  resp.Status,
+			"headers": resp.Header,
+		}).Debug("Received response.")
+	}
+
+	return resp, err
 }

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -116,6 +116,8 @@ type Runtime struct {
 	Params  Params
 	Store   storage.Store
 	Manager *plugins.Manager
+
+	decisionLogger func(context.Context, *server.Info)
 }
 
 // NewRuntime returns a new Runtime object initialized with params.
@@ -193,6 +195,7 @@ func (rt *Runtime) StartServer(ctx context.Context) {
 		WithAuthorization(rt.Params.Authorization).
 		WithDiagnosticsBuffer(rt.Params.DiagnosticsBuffer).
 		WithDecisionIDFactory(rt.Params.DecisionIDFactory).
+		WithDecisionLogger(rt.decisionLogger).
 		Init(ctx)
 
 	if err != nil {

--- a/server/buffer.go
+++ b/server/buffer.go
@@ -72,6 +72,7 @@ func (b *buffer) Iter(fn func(*Info)) {
 
 // Info contains information describing a policy decision.
 type Info struct {
+	Revision   string
 	DecisionID string
 	RemoteAddr string
 	Query      string

--- a/server/server.go
+++ b/server/server.go
@@ -1716,7 +1716,7 @@ func (l diagnosticsLogger) Log(ctx context.Context, decisionID, remoteAddr, quer
 
 	info := &Info{
 		Revision:   l.revision,
-		Timestamp:  time.Now(),
+		Timestamp:  time.Now().UTC(),
 		DecisionID: decisionID,
 		RemoteAddr: remoteAddr,
 		Query:      query,

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -308,7 +308,7 @@ p = true { false }`
 			tr{http.MethodPut, "/data/a/b", `[1,2,3,4]`, 204, ""},
 			tr{http.MethodPut, "/data/a/b/c/d", "0", 404, `{
 				"code": "resource_conflict",
-				"message": "write conflict: /a/b"
+				"message": "storage_write_conflict_error: /a/b"
 			}`},
 		}},
 		{"get virtual", []tr{

--- a/server/types/types.go
+++ b/server/types/types.go
@@ -137,6 +137,7 @@ type DiagnosticsResponseV1 struct {
 // DiagnosticsResponseElementV1 models an element in the response message for the
 // Diagnostics API.
 type DiagnosticsResponseElementV1 struct {
+	Revision    string       `json:"revision,omitempty"`
 	DecisionID  string       `json:"decision_id,omitempty"`
 	RemoteAddr  string       `json:"remote_addr"`
 	Query       string       `json:"query"`

--- a/server/types/types.go
+++ b/server/types/types.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 
 	"github.com/open-policy-agent/opa/ast"
-	"github.com/open-policy-agent/opa/storage"
 	"github.com/open-policy-agent/opa/topdown"
 	"github.com/open-policy-agent/opa/util"
 )
@@ -390,23 +389,6 @@ const (
 	// the client wants to set a watch on the current query or data reference.
 	ParamWatchV1 = "watch"
 )
-
-// WriteConflictErr represents an error condition raised if the caller attempts
-// to modify a virtual document or create a document at a path that conflicts
-// with an existing document.
-type WriteConflictErr struct {
-	Path storage.Path
-}
-
-func (err WriteConflictErr) Error() string {
-	return fmt.Sprintf("write conflict: %v", err.Path)
-}
-
-// IsWriteConflict returns true if err is a WriteConflictErr.
-func IsWriteConflict(err error) bool {
-	_, ok := err.(WriteConflictErr)
-	return ok
-}
 
 // BadRequestErr represents an error condition raised if the caller passes
 // invalid parameters.

--- a/server/writer/writer.go
+++ b/server/writer/writer.go
@@ -30,7 +30,7 @@ func ErrorAuto(w http.ResponseWriter, err error) {
 		return
 	}
 
-	if types.IsWriteConflict(err) {
+	if storage.IsWriteConflictError(err) {
 		ErrorString(w, http.StatusNotFound, types.CodeResourceConflict, err)
 		return
 	}

--- a/storage/errors.go
+++ b/storage/errors.go
@@ -16,6 +16,10 @@ const (
 	// locate a document.
 	NotFoundErr = "storage_not_found_error"
 
+	// WriteConflictErr indicates a write on the path enocuntered a conflicting
+	// value inside the transaction.
+	WriteConflictErr = "storage_write_conflict_error"
+
 	// InvalidPatchErr indicates an invalid patch/write was issued. The patch
 	// was rejected.
 	InvalidPatchErr = "storage_invalid_patch_error"
@@ -63,6 +67,15 @@ func IsNotFound(err error) bool {
 	return false
 }
 
+// IsWriteConflictError returns true if this error a WriteConflictErr.
+func IsWriteConflictError(err error) bool {
+	switch err := err.(type) {
+	case *Error:
+		return err.Code == WriteConflictErr
+	}
+	return false
+}
+
 // IsInvalidPatch returns true if this error is a InvalidPatchErr.
 func IsInvalidPatch(err error) bool {
 	switch err := err.(type) {
@@ -88,6 +101,13 @@ func IsIndexingNotSupported(err error) bool {
 		return err.Code == IndexingNotSupportedErr
 	}
 	return false
+}
+
+func writeConflictError(path Path) *Error {
+	return &Error{
+		Code:    WriteConflictErr,
+		Message: fmt.Sprint(path),
+	}
 }
 
 func triggersNotSupportedError() *Error {

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -49,6 +49,38 @@ func WriteOne(ctx context.Context, store Store, op PatchOp, path Path, value int
 	return store.Commit(ctx, txn)
 }
 
+// MakeDir inserts an empty object at path. If the parent path does not exist,
+// MakeDir will create it recursively.
+func MakeDir(ctx context.Context, store Store, txn Transaction, path Path) (err error) {
+
+	if len(path) == 0 {
+		return nil
+	}
+
+	node, err := store.Read(ctx, txn, path)
+
+	if err != nil {
+		if !IsNotFound(err) {
+			return err
+		}
+
+		if err := MakeDir(ctx, store, txn, path[:len(path)-1]); err != nil {
+			return err
+		} else if err := store.Write(ctx, txn, AddOp, path, map[string]interface{}{}); err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	if _, ok := node.(map[string]interface{}); ok {
+		return nil
+	}
+
+	return writeConflictError(path)
+
+}
+
 // Txn is a convenience function that executes f inside a new transaction
 // opened on the store. If the function returns an error, the transaction is
 // aborted and the error is returned. Otherwise, the transaction is committed


### PR DESCRIPTION
Previously, decisions were recorded in an in-memory buffer and could be queried via the REST API. While this is useful for debug purposes, it's not a reliable way to audit policy decisions or debug policy decisions at scale.

These changes extend the decision logging capability in OPA to upload batches of decision logs to remote HTTP servers.