### PR TITLE
 server: handle foo%2fbar in path (#695)

### DIFF
--- a/runtime/logging.go
+++ b/runtime/logging.go
@@ -49,7 +49,7 @@ func (h *LoggingHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			"client_addr": r.RemoteAddr,
 			"req_id":      requestID,
 			"req_method":  r.Method,
-			"req_path":    r.URL.Path,
+			"req_path":    r.URL.EscapedPath(),
 			"req_params":  r.URL.Query(),
 		}
 
@@ -88,7 +88,7 @@ func (h *LoggingHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			"client_addr":   r.RemoteAddr,
 			"req_id":        requestID,
 			"req_method":    r.Method,
-			"req_path":      r.URL.Path,
+			"req_path":      r.URL.EscapedPath(),
 			"resp_status":   statusCode,
 			"resp_bytes":    recorder.bytesWritten,
 			"resp_duration": float64(dt.Nanoseconds()) / 1e6,
@@ -157,7 +157,7 @@ func (r *recorder) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 		"client_addr": r.req.RemoteAddr,
 		"req_id":      r.id,
 		"req_method":  r.req.Method,
-		"req_path":    r.req.URL.Path,
+		"req_path":    r.req.URL.EscapedPath(),
 	}
 
 	queries := r.req.URL.Query()[types.ParamQueryV1]

--- a/server/server.go
+++ b/server/server.go
@@ -121,6 +121,7 @@ func New() *Server {
 
 	// Initialize HTTP handlers.
 	router := mux.NewRouter()
+	router.UseEncodedPath()
 	router.Handle("/metrics", promhttp.HandlerFor(promRegistry, promhttp.HandlerOpts{})).Methods(http.MethodGet)
 	s.registerHandler(router, 0, "/data/{path:.+}", http.MethodPost, promhttp.InstrumentHandlerDuration(v0DataDur, http.HandlerFunc(s.v0DataPost)))
 	s.registerHandler(router, 0, "/data", http.MethodPost, promhttp.InstrumentHandlerDuration(v0DataDur, http.HandlerFunc(s.v0DataPost)))
@@ -1453,6 +1454,9 @@ func stringPathToRef(s string) (r ast.Ref) {
 	for _, x := range p {
 		if x == "" {
 			continue
+		}
+		if y, err := url.PathUnescape(x); err == nil {
+			x = y
 		}
 		i, err := strconv.Atoi(x)
 		if err != nil {


### PR DESCRIPTION
Now, GET /v1/data/foo%2fbar will construct a query string of

    data["foo/bar"]

allowing to retrieve the key mentioned in issue #695.

However, I believe further work would be necessary, as the code path for
POST/PATCH/DELETE is different. (That has also blocked added a test for
this change, unfortunately.)

I also couldn't get this to work with POST /v0/data/foo%2fbar. (But I also
haven't tried very long, to be honest.)