### PR TITLE
Handle escaped paths in data writes

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -835,7 +835,7 @@ func (s *Server) v1DataPut(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	path, ok := storage.ParsePath("/" + strings.Trim(vars["path"], "/"))
+	path, ok := storage.ParsePathEscaped("/" + strings.Trim(vars["path"], "/"))
 	if !ok {
 		writer.Error(w, http.StatusBadRequest, types.NewErrorV1(types.CodeInvalidParameter, "bad path: %v", vars["path"]))
 		return
@@ -880,7 +880,7 @@ func (s *Server) v1DataDelete(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	vars := mux.Vars(r)
 
-	path, ok := storage.ParsePath("/" + strings.Trim(vars["path"], "/"))
+	path, ok := storage.ParsePathEscaped("/" + strings.Trim(vars["path"], "/"))
 	if !ok {
 		writer.Error(w, http.StatusBadRequest, types.NewErrorV1(types.CodeInvalidParameter, "bad path: %v", vars["path"]))
 		return
@@ -1413,7 +1413,7 @@ func (s *Server) prepareV1PatchSlice(root string, ops []types.PatchV1) (result [
 		}
 
 		var ok bool
-		impl.path, ok = storage.ParsePath(path)
+		impl.path, ok = storage.ParsePathEscaped(path)
 		if !ok {
 			return nil, types.BadPatchPathErr(op.Path)
 		}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -434,6 +434,16 @@ p = true { false }`
 			tr{http.MethodGet, "/data/a", "", 200, `{"result": {}}`},
 			tr{http.MethodGet, "/data/a/b/c", "", 200, `{}`},
 		}},
+		{"escaped paths", []tr{
+			tr{http.MethodPut, "/data/a%2Fb", `{"c/d": 1}`, 204, ""},
+			tr{http.MethodGet, "/data", "", 200, `{"result": {"a/b": {"c/d": 1}}}`},
+			tr{http.MethodGet, "/data/a%2Fb/c%2Fd", "", 200, `{"result": 1}`},
+			tr{http.MethodGet, "/data/a/b", "", 200, `{}`},
+			tr{http.MethodPost, "/data/a%2Fb/c%2Fd", "", 200, `{"result": 1}`},
+			tr{http.MethodPost, "/data/a/b", "", 200, `{}`},
+			tr{http.MethodPatch, "/data/a%2Fb", `[{"op": "add", "path": "/e%2Ff", "value": 2}]`, 204, ""},
+			tr{http.MethodPost, "/data", "", 200, `{"result": {"a/b": {"c/d": 1, "e/f": 2}}}`},
+		}},
 	}
 
 	for _, tc := range tests {

--- a/storage/path.go
+++ b/storage/path.go
@@ -6,6 +6,7 @@ package storage
 
 import (
 	"fmt"
+	"net/url"
 	"strconv"
 	"strings"
 
@@ -28,6 +29,21 @@ func ParsePath(str string) (path Path, ok bool) {
 	}
 	parts := strings.Split(str[1:], "/")
 	return parts, true
+}
+
+// ParsePathEscaped returns a new path for the given escaped str.
+func ParsePathEscaped(str string) (path Path, ok bool) {
+	path, ok = ParsePath(str)
+	if !ok {
+		return
+	}
+	for i := range path {
+		segment, err := url.PathUnescape(path[i])
+		if err == nil {
+			path[i] = segment
+		}
+	}
+	return
 }
 
 // NewPathForRef returns a new path for the given ref.
@@ -118,7 +134,11 @@ func (p Path) Ref(head *ast.Term) (ref ast.Ref) {
 }
 
 func (p Path) String() string {
-	return "/" + strings.Join(p, "/")
+	buf := make([]string, len(p))
+	for i := range buf {
+		buf[i] = url.PathEscape(p[i])
+	}
+	return "/" + strings.Join(buf, "/")
 }
 
 // MustParsePath returns a new Path for s. If s cannot be parsed, this function

--- a/storage/path_test.go
+++ b/storage/path_test.go
@@ -68,6 +68,38 @@ func TestNewPathForRef(t *testing.T) {
 	}
 }
 
+func TestNewPathForStringEscaped(t *testing.T) {
+
+	tests := []struct {
+		input  string
+		result Path
+		ok     bool
+	}{
+		{
+			input:  "/foo/bar", // no escaping
+			result: Path{"foo", "bar"},
+			ok:     true,
+		},
+		{
+			input:  "/foo%2Fbar/baz", // single escape
+			result: Path{"foo/bar", "baz"},
+			ok:     true,
+		},
+		{
+			input:  "/foo%2F%2Fbar/baz", // double escape
+			result: Path{"foo//bar", "baz"},
+			ok:     true,
+		},
+	}
+
+	for _, tc := range tests {
+		result, ok := ParsePathEscaped(tc.input)
+		if (tc.ok != ok) || !tc.result.Equal(result) {
+			t.Errorf("For %v wanted (%v, %v) but got (%v, %v)", tc.input, tc.result, tc.ok, result, ok)
+		}
+	}
+}
+
 func TestPathCompare(t *testing.T) {
 	tests := []struct {
 		a      Path


### PR DESCRIPTION
These changes extend #702 to include writes. If the path segments are
escaped, the should be unescaped during parsing. This allows callers to
write keys like "foo/bar" into storage.

Fixes #695

Signed-off-by: Torin Sandall <torinsandall@gmail.com>