### PR TITLE
topdown: introduce queryIDFactory for unique queryIDs

### DIFF
--- a/topdown/eval_test.go
+++ b/topdown/eval_test.go
@@ -1,0 +1,16 @@
+// Copyright 2018 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package topdown
+
+import "testing"
+
+func TestQueryIDFactory(t *testing.T) {
+	f := &queryIDFactory{}
+	for i := 0; i < 10; i++ {
+		if n := f.Next(); n != uint64(i) {
+			t.Errorf("expected %d, got %d", i, n)
+		}
+	}
+}

--- a/topdown/query.go
+++ b/topdown/query.go
@@ -120,10 +120,13 @@ func (q *Query) PartialRun(ctx context.Context) (partials []ast.Body, support []
 	if q.partialNamespace == "" {
 		q.partialNamespace = "partial" // lazily initialize partial namespace
 	}
+	f := &queryIDFactory{}
 	e := &eval{
 		ctx:           ctx,
 		cancel:        q.cancel,
 		query:         q.query,
+		queryIDFact:   f,
+		queryID:       f.Next(),
 		bindings:      newBindings(0, q.instr),
 		compiler:      q.compiler,
 		store:         q.store,
@@ -180,10 +183,13 @@ func (q *Query) Run(ctx context.Context) (QueryResultSet, error) {
 // Iter executes the query and invokes the iter function with query results
 // produced by evaluating the query.
 func (q *Query) Iter(ctx context.Context, iter func(QueryResult) error) error {
+	f := &queryIDFactory{}
 	e := &eval{
 		ctx:          ctx,
 		cancel:       q.cancel,
 		query:        q.query,
+		queryIDFact:  f,
+		queryID:      f.Next(),
 		bindings:     newBindings(0, q.instr),
 		compiler:     q.compiler,
 		store:        q.store,

--- a/topdown/topdown_partial_test.go
+++ b/topdown/topdown_partial_test.go
@@ -162,7 +162,7 @@ func TestTopDownPartialEval(t *testing.T) {
 			},
 			wantQueries: []string{
 				`input.x = x; y1 = x; y1 = "foo"; y1 = x_term_0_1; x_term_0_1 != false`,
-				`input.x = x; z1 = x; z1 = "bar"; z1 = x_term_0_1; x_term_0_1 != false`,
+				`input.x = x; z2 = x; z2 = "bar"; z2 = x_term_0_1; x_term_0_1 != false`,
 			},
 		},
 		{


### PR DESCRIPTION
This is for issue #707.

I didn't go all the way to adding the partial test including `not` -- but this should cover the other bits.

Fixes #707