### PR TITLE
Update Terraform tutorial commands to v0.8

### DIFF
--- a/docs/book/terraform.md
+++ b/docs/book/terraform.md
@@ -254,14 +254,14 @@ To evaluate the policy against that plan, you hand OPA the policy, the Terraform
 ask it to evaluate `data.terraform.analysis.authz`.
 
 ```shell
-opa run terraform.rego repl.input:tfplan.json -e "data.terraform.analysis.authz"
+opa eval --data terraform.rego --input tfplan.json "data.terraform.analysis.authz"
 ```
 
 If you're curious, you can ask for the score that the policy used to make the authorization decision.
 In our example, it is 11 (10 for the creation of the auto-scaling group and 1 for the creation of the server).
 
 ```shell
-opa run terraform.rego repl.input:tfplan.json -e "data.terraform.analysis.score"
+opa eval --data terraform.rego --input tfplan.json "data.terraform.analysis.score"
 ```
 
 If as suggested in the previous step, you want to modify your policy to make an authorization decision
@@ -335,8 +335,8 @@ tfjson tfplan_large.binary > tfplan_large.json
 Evaluate the policy to see that it fails the policy tests and check the score.
 
 ```shell
-opa run terraform.rego repl.input:tfplan_large.json -e "data.terraform.analysis.authz"
-opa run terraform.rego repl.input:tfplan_large.json -e "data.terraform.analysis.score"
+opa eval --data terraform.rego --input tfplan_large.json "data.terraform.analysis.authz"
+opa eval --data terraform.rego --input tfplan_large.json "data.terraform.analysis.score"
 ```
 
 


### PR DESCRIPTION
Due to the deprecation of the `-e`/`--eval` flag of the run command in release 0.8, the Terraform tutorial is no longer accurate. This commit updates the tutorial to use the new `eval` command which replaces the old flag.

----

I've been investigating OPA at work for the past few days (specifically for usage with Terraform plans) and this was a pretty big head-scratch moment. It's not yet clear to me what the best practices are with the `eval` command when it comes to `--data` vs `--input`, so please let me know if I'm abusing the flags here.