### PR TITLE
Fix Makefile VERSION

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Use of this source code is governed by an Apache2
 # license that can be found in the LICENSE file.
 
-VERSION := 0.8.0-dev
+VERSION := 0.8.1-dev
 
 PACKAGES := $(shell go list ./.../ | grep -v 'vendor')
 


### PR DESCRIPTION
The VERSION value was not updated properly during the last release. As a
result, the -dev images were being cut under 0.8.0 instead of 0.8.1.

Whoops!

Signed-off-by: Torin Sandall <torinsandall@gmail.com>