### PR TITLE
Fix virtual document cache invalidation

### DIFF
--- a/topdown/cache.go
+++ b/topdown/cache.go
@@ -28,7 +28,7 @@ func (c *virtualCache) Push() {
 }
 
 func (c *virtualCache) Pop() {
-	c.stack = c.stack[:len(c.stack)]
+	c.stack = c.stack[:len(c.stack)-1]
 }
 
 func (c *virtualCache) Get(ref ast.Ref) *ast.Term {

--- a/topdown/cache_test.go
+++ b/topdown/cache_test.go
@@ -1,0 +1,22 @@
+// Copyright 2018 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package topdown
+
+import (
+	"testing"
+
+	"github.com/open-policy-agent/opa/ast"
+)
+
+func TestVirtualCacheInvalidate(t *testing.T) {
+	cache := newVirtualCache()
+	cache.Push()
+	cache.Put(ast.MustParseRef("data.x.p"), ast.BooleanTerm(true))
+	cache.Pop()
+	result := cache.Get(ast.MustParseRef("data.x.p"))
+	if result != nil {
+		t.Fatal("Expected nil result but got:", result)
+	}
+}


### PR DESCRIPTION
The virtual document cache was not being invalidated. As a result, if
the same rule was evaluated twice where the first expression included a
with modifier, the result on the second evaluation may be incorrect.

Fixes #736

Signed-off-by: Torin Sandall <torinsandall@gmail.com>