### PR TITLE
storage/inmem: support pointers to structs

### DIFF
--- a/rego/rego.go
+++ b/rego/rego.go
@@ -463,12 +463,13 @@ func (r *Rego) compileQuery(extras []extraStage, query ast.Body) (ast.QueryCompi
 	var input ast.Value
 
 	if r.rawInput != nil {
+		rawPtr := util.Reference(r.rawInput)
 		// roundtrip through json: this turns slices (e.g. []string, []bool) into
 		// []interface{}, the only array type ast.InterfaceToValue can work with
-		if err := util.RoundTrip(r.rawInput); err != nil {
+		if err := util.RoundTrip(rawPtr); err != nil {
 			return nil, nil, err
 		}
-		val, err := ast.InterfaceToValue(*r.rawInput)
+		val, err := ast.InterfaceToValue(*rawPtr)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/storage/inmem/inmem.go
+++ b/storage/inmem/inmem.go
@@ -160,10 +160,11 @@ func (db *store) Read(ctx context.Context, txn storage.Transaction, path storage
 
 func (db *store) Write(ctx context.Context, txn storage.Transaction, op storage.PatchOp, path storage.Path, value interface{}) error {
 	underlying := txn.(*transaction)
-	if err := util.RoundTrip(&value); err != nil {
+	val := util.Reference(value)
+	if err := util.RoundTrip(val); err != nil {
 		return err
 	}
-	return underlying.Write(op, path, value)
+	return underlying.Write(op, path, *val)
 }
 
 func (db *store) Build(ctx context.Context, txn storage.Transaction, ref ast.Ref) (storage.Index, error) {

--- a/util/json.go
+++ b/util/json.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
+	"reflect"
 
 	"github.com/ghodss/yaml"
 )
@@ -68,6 +69,24 @@ func RoundTrip(x *interface{}) error {
 		return err
 	}
 	return UnmarshalJSON(bs, x)
+}
+
+// Reference returns a pointer to its argument unless the argument already is
+// a pointer. If the argument is **t, or ***t, etc, it will return *t.
+//
+// Used for preparing Go types (including pointers to structs) into values to be
+// put through util.RoundTrip().
+func Reference(x interface{}) *interface{} {
+	var y interface{}
+	rv := reflect.ValueOf(x)
+	if rv.Kind() == reflect.Ptr {
+		return Reference(rv.Elem().Interface())
+	}
+	if rv.Kind() != reflect.Invalid {
+		y = rv.Interface()
+		return &y
+	}
+	return &x
 }
 
 // Unmarshal decodes a YAML or JSON value into the specified type.


### PR DESCRIPTION
This should fix #722. It's a slight variation of the code snippet provided
there:

I wasn't sure what the reflect.Interface part was for, so this is using
only reflect.Ptr. Also, there existing tests would fail without the added
check for reflect.Invalid.

Adds a test case for inmem -- in a new method, as I couldn't quite fit it
into the schema of TestInMemoryWrite.

Also, util.Reference() ensures that the returned value is a pointer to
something -- and not a pointer to a pointer to something. While this wasn't
part of the issue #722, it felt weird not to solve the general problem, but
only the edge case. :)
