### PR TITLE
Fix go-fmt failures

### DIFF
--- a/tester/reporter.go
+++ b/tester/reporter.go
@@ -81,7 +81,7 @@ type JSONReporter struct {
 
 // Report prints the test report to the reporter's output.
 func (r JSONReporter) Report(ch chan *Result) error {
-	results := make([]*Result, 0)
+	var results []*Result
 	for tr := range ch {
 		results = append(results, tr)
 	}

--- a/topdown/aggregates.go
+++ b/topdown/aggregates.go
@@ -85,7 +85,7 @@ func builtinMax(a ast.Value) (ast.Value, error) {
 		if len(a) == 0 {
 			return nil, BuiltinEmpty{}
 		}
-		var max ast.Value = ast.Null{}
+		var max = ast.Value(ast.Null{})
 		for i := range a {
 			if ast.Compare(max, a[i].Value) <= 0 {
 				max = a[i].Value


### PR DESCRIPTION
The following failures were fixed:

tester/reporter.go:84:2: can probably use "var results []*Result" instead
topdown/aggregates.go:88:11: should omit type ast.Value from declaration of var max; it will be inferred from the right-hand side