### PR TITLE
Fix boolean expression in "Get Started" doc

### DIFF
--- a/docs/book/get-started.md
+++ b/docs/book/get-started.md
@@ -78,7 +78,7 @@ true
 You can also test simple boolean expressions:
 
 ```ruby
-> true = false
+> true == false
 false
 > 3.14 > 3
 true


### PR DESCRIPTION
The example was "true = false" which was doing an assignment which
couldn't be evaluated, this would return undefined, instead of "false"
which is what the docs indicate. This changes the doc to an appropriate
expression.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>