### PR TITLE
Fix output in REPL examples for getting started

### DIFF
--- a/docs/book/get-started.md
+++ b/docs/book/get-started.md
@@ -105,7 +105,7 @@ One thing to watch out for in the REPL is that `=` is used both for assigning va
 
 ```ruby
 > pi = 3
-false
+undefined
 > unset pi
 > pi = 3
 > pi


### PR DESCRIPTION
There is still a need to improve the output of references to set docs
that include variables. In those cases, the expression value AND the
variable bindings are displayed. Only the bindings should be displayed.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>