### PR TITLE
Update a command in the Kubernetes Admission Control tutorial

### DIFF
--- a/docs/book/kubernetes-admission-control.md
+++ b/docs/book/kubernetes-admission-control.md
@@ -116,7 +116,7 @@ webhooks:
         apiVersions: ["*"]
         resources: ["*"]
     clientConfig:
-      caBundle: $(base64 ca.crt)
+      caBundle: $(cat ca.crt | base64 | tr -d '\n')
       service:
         namespace: opa
         name: opa


### PR DESCRIPTION
Add `--wrap=0` flag to the `base64` command to disable line wrapping.
Without the flag the `yaml` contains extra new lines and it is invalid:
```
Error from server (BadRequest): error when creating "webhook-configuration.yaml": ValidatingWebhookConfiguration in version "v1beta1" cannot be handled as a ValidatingWebhookConfiguration: v1beta1.ValidatingWebhookConfiguration: Webhooks: []v1beta1.Webhook: v1beta1.Webhook: ClientConfig: v1beta1.WebhookClientConfig: Service: CABundle: decode base64: illegal base64 data at input byte [...]
```