### PR TITLE
Improve partial evaluation testing

### DIFF
--- a/topdown/http_test.go
+++ b/topdown/http_test.go
@@ -72,11 +72,6 @@ func TestHTTPGetRequest(t *testing.T) {
 // TestHTTPostRequest adds a new person
 func TestHTTPostRequest(t *testing.T) {
 
-	var people []Person
-
-	// test data
-	people = append(people, Person{ID: "1", Firstname: "John"})
-
 	// test server
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 
@@ -91,26 +86,18 @@ func TestHTTPostRequest(t *testing.T) {
 			return
 		}
 
-		// create new person
-		people = append(people, Person{ID: person.ID, Firstname: person.Firstname})
-
 		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(people)
+		json.NewEncoder(w).Encode(person)
 	}))
 
 	defer ts.Close()
 
 	// expected result
-	expectedResult := make(map[string]interface{})
-	expectedResult["status"] = "200 OK"
-	expectedResult["status_code"] = http.StatusOK
-
-	var body []interface{}
-	bodyMap1 := map[string]string{"id": "1", "firstname": "John"}
-	bodyMap2 := map[string]string{"id": "2", "firstname": "Joe"}
-	body = append(body, bodyMap1)
-	body = append(body, bodyMap2)
-	expectedResult["body"] = body
+	expectedResult := map[string]interface{}{
+		"status":      "200 OK",
+		"status_code": http.StatusOK,
+		"body":        map[string]string{"id": "2", "firstname": "Joe"},
+	}
 
 	resultObj, err := ast.InterfaceToValue(expectedResult)
 	if err != nil {

--- a/topdown/save.go
+++ b/topdown/save.go
@@ -232,6 +232,9 @@ func (e saveStackElem) Plug(caller *bindings) *ast.Expr {
 	case *ast.Term:
 		expr.Terms = e.B1.PlugNamespaced(terms, caller)
 	}
+	for i := range expr.With {
+		expr.With[i].Value = e.B1.PlugNamespaced(expr.With[i].Value, caller)
+	}
 	return expr
 }
 

--- a/topdown/topdown_partial_test.go
+++ b/topdown/topdown_partial_test.go
@@ -286,6 +286,21 @@ func TestTopDownPartialEval(t *testing.T) {
 			},
 		},
 		{
+			note:  "namespace: reference head",
+			query: "data.test.p = x",
+			modules: []string{
+				`package test
+
+				p {
+					input = x
+					x[0] = true
+				}`,
+			},
+			wantQueries: []string{
+				`input = x1; x1[0] = true; true = x`,
+			},
+		},
+		{
 			note:  "ignore conflicts: complete",
 			query: "data.test.p = x",
 			modules: []string{


### PR DESCRIPTION
These changes update the topdown test suite to run tests using normal
evaluation and then again against the result of partial evaluation. In
the second pass, input is treated as unknown.

This additional coverage uncovered an issue in the namespacing applied
before partial evaluation results are returned to callers. Specifically,
reference heads and with values were not being namespaced.

The http.send POST test was also updated to avoid keeping track of
request bodies as this broke when the case was executed twice.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>