### PR TITLE
Update UNIX domain socket support

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -123,7 +123,7 @@ the data document with the following syntax:
 	runCommand.Flags().StringVarP(&params.ConfigFile, "config-file", "c", "", "set path of configuration file")
 	runCommand.Flags().BoolVarP(&serverMode, "server", "s", false, "start the runtime in server mode")
 	runCommand.Flags().StringVarP(&params.HistoryPath, "history", "H", historyPath(), "set path of history file")
-	runCommand.Flags().StringVarP(&params.Addr, "addr", "a", defaultAddr, "set listening address of the server. Takes either the <IP>:<Port> format, or a URL such as unix:///path/to/domain/socket for UNIX domain sockets")
+	runCommand.Flags().StringVarP(&params.Addr, "addr", "a", defaultAddr, "set listening address of the server (e.g., [ip]:<port> for TCP, unix://<path> for UNIX domain socket)")
 	runCommand.Flags().StringVarP(&params.InsecureAddr, "insecure-addr", "", "", "set insecure listening address of the server")
 	runCommand.Flags().StringVarP(&params.OutputFormat, "format", "f", "pretty", "set shell output format, i.e, pretty, json")
 	runCommand.Flags().BoolVarP(&params.Watch, "watch", "w", false, "watch command line files for changes")

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -247,7 +247,12 @@ func (rt *Runtime) StartServer(ctx context.Context) {
 
 	s.Handler = NewLoggingHandler(s.Handler)
 
-	loop1, loop2 := s.Listeners()
+	loop1, loop2, err := s.Listeners()
+	if err != nil {
+		fmt.Println(rt.Params.Output, "error creating listener:", err)
+		os.Exit(1)
+	}
+
 	if loop2 != nil {
 		go func() {
 			if err := loop2(); err != nil {


### PR DESCRIPTION
These changes tweak the UNIX domain socket to (1) return an error
instead of panicing (because the server may be embedded as a library)
and (2) to unlink the domain socket file before binding. The latter is
required so that OPA can be stopped and started without manually
removing the socket file.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>