### PR TITLE
Fix unix socket removal to take relative paths as well

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -328,11 +328,12 @@ func (s *Server) getListenerFromURL(u *url.URL) (func() error, func() error, err
 		return nil, nil, fmt.Errorf("invalid url scheme %q", u.Scheme)
 	}
 
+	socketPath := u.Host + u.Path
+
 	// Remove domain socket file in case it already exists.
-	os.Remove(u.Path)
+	os.Remove(socketPath)
 
 	domainSocketServer := http.Server{Handler: s.Handler}
-	socketPath := u.Host + u.Path
 	unixListener, err := net.Listen("unix", socketPath)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
The socket removal was using the URIs path, which is fine for absolute
paths, but doesn't work properly with relative ones.

The socket itself is listening on the Host + Path, which works for
relative paths, so we use that same path for the removal.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>