### PR TITLE
Fix examples in "Putting it all together" doc

### DIFF
--- a/docs/book/how-does-opa-work.md
+++ b/docs/book/how-does-opa-work.md
@@ -393,7 +393,7 @@ violations[server] {
     # ...and any of the server’s protocols is HTTP
     server.protocols[_] = "http"
     # ...and the server is public.
-    public_servers[server] = true
+    public_servers[server]
 }
 
 # A server exists in the public_servers set if...

--- a/docs/book/how-does-opa-work.md
+++ b/docs/book/how-does-opa-work.md
@@ -229,89 +229,87 @@ Let’s take a look at some documents representing the state of a hypothetical s
 
 ```json
 {
-  "data": {
-    "servers": [
-      {
-        "id": "s1",
-        "name": "app",
-        "protocols": [
-          "https",
-          "ssh"
-        ],
-        "ports": [
-          "p1",
-          "p2",
-          "p3"
-        ]
-      },
-      {
-        "id": "s2",
-        "name": "db",
-        "protocols": [
-          "mysql"
-        ],
-        "ports": [
-          "p3"
-        ]
-      },
-      {
-        "id": "s3",
-        "name": "cache",
-        "protocols": [
-          "memcache",
-          "http"
-        ],
-        "ports": [
-          "p3"
-        ]
-      },
-      {
-        "id": "s4",
-        "name": "dev",
-        "protocols": [
-          "http"
-        ],
-        "ports": [
-          "p1",
-          "p2"
-        ]
-      }
-    ],
-    "networks": [
-      {
-        "id": "n1",
-        "public": false
-      },
-      {
-        "id": "n2",
-        "public": false
-      },
-      {
-        "id": "n3",
-        "public": true
-      }
-    ],
-    "ports": [
-      {
-        "id": "p1",
-        "networks": [
-          "n1"
-        ]
-      },
-      {
-        "id": "p2",
-        "networks": [
-          "n3"
-        ]
-      },
-      {
-        "id": "p3",
-        "networks": [
-          "n2"
-        ]
-      }
-    ]
-  }
+  "servers": [
+    {
+      "id": "s1",
+      "name": "app",
+      "protocols": [
+        "https",
+        "ssh"
+      ],
+      "ports": [
+        "p1",
+        "p2",
+        "p3"
+      ]
+    },
+    {
+      "id": "s2",
+      "name": "db",
+      "protocols": [
+        "mysql"
+      ],
+      "ports": [
+        "p3"
+      ]
+    },
+    {
+      "id": "s3",
+      "name": "cache",
+      "protocols": [
+        "memcache",
+        "http"
+      ],
+      "ports": [
+        "p3"
+      ]
+    },
+    {
+      "id": "s4",
+      "name": "dev",
+      "protocols": [
+        "http"
+      ],
+      "ports": [
+        "p1",
+        "p2"
+      ]
+    }
+  ],
+  "networks": [
+    {
+      "id": "n1",
+      "public": false
+    },
+    {
+      "id": "n2",
+      "public": false
+    },
+    {
+      "id": "n3",
+      "public": true
+    }
+  ],
+  "ports": [
+    {
+      "id": "p1",
+      "networks": [
+        "n1"
+      ]
+    },
+    {
+      "id": "p2",
+      "networks": [
+        "n3"
+      ]
+    },
+    {
+      "id": "p3",
+      "networks": [
+        "n2"
+      ]
+    }
+  ]
 }
 ```
 


### PR DESCRIPTION
The example wrongly covered the servers, ports and networks keys under
the "data" key. It shouldn't have been that way (probably a typo?). So I
removed that.

Also fixed the policy definition example in the same document.