### PR TITLE
Fix log message punctuation in runtime.go

### DIFF
--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -262,7 +262,7 @@ func (rt *Runtime) StartServer(ctx context.Context) {
 	for {
 		select {
 		case err := <-errc:
-			logrus.WithField("err", err).Fatal("Listener failed")
+			logrus.WithField("err", err).Fatal("Listener failed.")
 		}
 	}
 }


### PR DESCRIPTION
Signed-off-by: Torin Sandall <torinsandall@gmail.com>