### PR TITLE
Allow passing multiple addresses to the server

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -123,7 +123,7 @@ the data document with the following syntax:
 	runCommand.Flags().StringVarP(&params.ConfigFile, "config-file", "c", "", "set path of configuration file")
 	runCommand.Flags().BoolVarP(&serverMode, "server", "s", false, "start the runtime in server mode")
 	runCommand.Flags().StringVarP(&params.HistoryPath, "history", "H", historyPath(), "set path of history file")
-	runCommand.Flags().StringVarP(&params.Addr, "addr", "a", defaultAddr, "set listening address of the server (e.g., [ip]:<port> for TCP, unix://<path> for UNIX domain socket)")
+	params.Addrs = runCommand.Flags().StringSliceP("addr", "a", []string{defaultAddr}, "set listening address of the server (e.g., [ip]:<port> for TCP, unix://<path> for UNIX domain socket)")
 	runCommand.Flags().StringVarP(&params.InsecureAddr, "insecure-addr", "", "", "set insecure listening address of the server")
 	runCommand.Flags().StringVarP(&params.OutputFormat, "format", "f", "pretty", "set shell output format, i.e, pretty, json")
 	runCommand.Flags().BoolVarP(&params.Watch, "watch", "w", false, "watch command line files for changes")

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -64,8 +64,8 @@ type Params struct {
 	// the runtime will generate one.
 	ID string
 
-	// Addr is the listening address that the OPA server will bind to.
-	Addr string
+	// Addrs are the listening addresses that the OPA server will bind to.
+	Addrs *[]string
 
 	// InsecureAddr is the listening address that the OPA server will bind to
 	// in addition to Addr if TLS is enabled.
@@ -212,7 +212,7 @@ func (rt *Runtime) StartServer(ctx context.Context) {
 	setupLogging(rt.Params.Logging)
 
 	logrus.WithFields(logrus.Fields{
-		"addr":          rt.Params.Addr,
+		"addrs":         *rt.Params.Addrs,
 		"insecure_addr": rt.Params.InsecureAddr,
 	}).Infof("First line of log stream.")
 
@@ -224,7 +224,7 @@ func (rt *Runtime) StartServer(ctx context.Context) {
 		WithStore(rt.Store).
 		WithManager(rt.Manager).
 		WithCompilerErrorLimit(rt.Params.ErrorLimit).
-		WithAddress(rt.Params.Addr).
+		WithAddresses(*rt.Params.Addrs).
 		WithInsecureAddress(rt.Params.InsecureAddr).
 		WithCertificate(rt.Params.Certificate).
 		WithAuthentication(rt.Params.Authentication).

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1459,7 +1459,7 @@ func TestQueryWatchMigrateInvalidate(t *testing.T) {
 func TestDiagnostics(t *testing.T) {
 	f := newFixture(t)
 	f.server, _ = New().
-		WithAddress(":8182").
+		WithAddresses([]string{":8182"}).
 		WithStore(f.server.store).
 		WithManager(f.server.manager).
 		WithDiagnosticsBuffer(NewBoundedBuffer(8)).
@@ -2080,7 +2080,7 @@ func TestAuthorization(t *testing.T) {
 	}
 
 	server, err := New().
-		WithAddress(":8182").
+		WithAddresses([]string{":8182"}).
 		WithStore(store).
 		WithManager(m).
 		WithAuthorization(AuthorizationBasic).
@@ -2222,7 +2222,7 @@ func TestQueryBindingIterationError(t *testing.T) {
 		panic(err)
 	}
 
-	server, err := New().WithStore(mock).WithManager(m).WithAddress(":8182").Init(ctx)
+	server, err := New().WithStore(mock).WithManager(m).WithAddresses([]string{":8182"}).Init(ctx)
 	if err != nil {
 		panic(err)
 	}
@@ -2271,7 +2271,7 @@ func newFixture(t *testing.T) *fixture {
 	}
 
 	server, err := New().
-		WithAddress(":8182").
+		WithAddresses([]string{":8182"}).
 		WithStore(store).
 		WithManager(m).
 		Init(ctx)


### PR DESCRIPTION
This makes the --addr CLI parameter to be a slice and refactors the code
to allow several addresses to be passed. Hence we can listen on as many
HTTP and UNIX sockets as we want.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>