### PR TITLE
Refactor HTTP and HTTPS listener creation

### DIFF
--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -240,8 +240,7 @@ func (rt *Runtime) StartServer(ctx context.Context) {
 
 	if rt.Params.Watch {
 		if err := rt.startWatcher(ctx, rt.Params.Paths, onReloadLogger); err != nil {
-			fmt.Fprintln(rt.Params.Output, "error opening watch:", err)
-			os.Exit(1)
+			logrus.WithField("err", err).Fatalf("Unable to open watch.")
 		}
 	}
 
@@ -249,8 +248,7 @@ func (rt *Runtime) StartServer(ctx context.Context) {
 
 	loops, err := s.Listeners()
 	if err != nil {
-		fmt.Println(rt.Params.Output, "error creating listener:", err)
-		os.Exit(1)
+		logrus.WithField("err", err).Fatalf("Unable to create listeners.")
 	}
 
 	errc := make(chan error)


### PR DESCRIPTION
@JAORMX take a look at this.

I've basically just split the getListenerForHTTPServer function so that it only deals with HTTP. There's a new getListenerForHTTP**S**Server function for HTTPS. And then the --insecure-addr case is handled outside the loop (so it should be easier to rip out later.)

Signed-off-by: Torin Sandall <torinsandall@gmail.com>