### PR TITLE
Added URLGenerate and URLQueryFromJSON builtins for URL generation

### DIFF
--- a/ast/builtins.go
+++ b/ast/builtins.go
@@ -98,8 +98,7 @@ var DefaultBuiltins = [...]*Builtin{
 	Base64UrlDecode,
 	URLQueryDecode,
 	URLQueryEncode,
-	URLQueryFromJSON,
-	URLGenerate,
+	URLQueryEncodeObject,
 	YAMLMarshal,
 	YAMLUnmarshal,
 
@@ -722,24 +721,11 @@ var URLQueryEncode = &Builtin{
 	),
 }
 
-// URLQueryFromJSON encodes the given JSON into a URL encoded query string
-var URLQueryFromJSON = &Builtin{
-	Name: "urlquery.fromjson",
+// URLQueryEncodeObject encodes the given JSON into a URL encoded query string
+var URLQueryEncodeObject = &Builtin{
+	Name: "urlquery.encode_object",
 	Decl: types.NewFunction(
 		types.Args(types.A),
-		types.S,
-	),
-}
-
-// URLGenerate takes a host and a path and a list of query arguments in JSON format and encodes it into a string
-var URLGenerate = &Builtin{
-	Name: "url.generate",
-	Decl: types.NewFunction(
-		types.Args(
-			types.S,
-			types.S,
-			types.A,
-		),
 		types.S,
 	),
 }

--- a/ast/builtins.go
+++ b/ast/builtins.go
@@ -731,7 +731,7 @@ var URLQueryFromJSON = &Builtin{
 	),
 }
 
-// URLQueryFromJSON takes a host and a path and a list of query arguments in JSON format and encodes it into a string
+// URLGenerate takes a host and a path and a list of query arguments in JSON format and encodes it into a string
 var URLGenerate = &Builtin{
 	Name: "url.generate",
 	Decl: types.NewFunction(

--- a/ast/builtins.go
+++ b/ast/builtins.go
@@ -98,6 +98,8 @@ var DefaultBuiltins = [...]*Builtin{
 	Base64UrlDecode,
 	URLQueryDecode,
 	URLQueryEncode,
+	URLQueryFromJSON,
+	URLGenerate,
 	YAMLMarshal,
 	YAMLUnmarshal,
 
@@ -716,6 +718,28 @@ var URLQueryEncode = &Builtin{
 	Name: "urlquery.encode",
 	Decl: types.NewFunction(
 		types.Args(types.S),
+		types.S,
+	),
+}
+
+// URLQueryFromJSON encodes the given JSON into a URL encoded query string
+var URLQueryFromJSON = &Builtin{
+	Name: "urlquery.fromjson",
+	Decl: types.NewFunction(
+		types.Args(types.A),
+		types.S,
+	),
+}
+
+// URLQueryFromJSON takes a host and a path and a list of query arguments in JSON format and encodes it into a string
+var URLGenerate = &Builtin{
+	Name: "url.generate",
+	Decl: types.NewFunction(
+		types.Args(
+			types.S,
+			types.S,
+			types.A,
+		),
 		types.S,
 	),
 }

--- a/topdown/encoding.go
+++ b/topdown/encoding.go
@@ -123,8 +123,7 @@ func builtinURLQueryDecode(a ast.Value) (ast.Value, error) {
 	return ast.String(s), nil
 }
 
-// new builtin that generates query arguments from a JSON object
-func builtinURLQueryFromJSON(a ast.Value) (ast.Value, error) {
+func builtinURLQueryEncodeObject(a ast.Value) (ast.Value, error) {
 	asJSON, err := ast.JSON(a)
 	if err != nil {
 		return nil, err
@@ -160,37 +159,6 @@ func builtinURLQueryFromJSON(a ast.Value) (ast.Value, error) {
 	// encoded version of these values
 	str := fmt.Sprintf("%v", query.Encode())
 	return ast.String(str), nil
-}
-
-// Generates a url from host, path, and input query string
-func builtinURLGenerate(a, b, c ast.Value) (ast.Value, error) {
-	// convert host to ast.string
-	host, err := builtins.StringOperand(a, 1)
-	if err != nil {
-		return nil, err
-	}
-	// convert path to ast.string
-	path, err := builtins.StringOperand(b, 2)
-	if err != nil {
-		return nil, err
-	}
-	// call builtinURL function and convert the result to string
-	query, err := builtinURLQueryFromJSON(c)
-	if err != nil {
-		return nil, err
-	}
-	queryStr, err := builtins.StringOperand(query, 3)
-	if err != nil {
-		return nil, err
-	}
-
-	x := url.URL{}
-	x.Scheme = "http"
-	x.Host = string(host)
-	x.Path = string(path)
-	x.RawQuery = string(queryStr)
-
-	return ast.String(x.String()), nil
 }
 
 func builtinYAMLMarshal(a ast.Value) (ast.Value, error) {
@@ -246,8 +214,7 @@ func init() {
 	RegisterFunctionalBuiltin1(ast.Base64UrlDecode.Name, builtinBase64UrlDecode)
 	RegisterFunctionalBuiltin1(ast.URLQueryDecode.Name, builtinURLQueryDecode)
 	RegisterFunctionalBuiltin1(ast.URLQueryEncode.Name, builtinURLQueryEncode)
-	RegisterFunctionalBuiltin1(ast.URLQueryFromJSON.Name, builtinURLQueryFromJSON)
-	RegisterFunctionalBuiltin3(ast.URLGenerate.Name, builtinURLGenerate)
+	RegisterFunctionalBuiltin1(ast.URLQueryEncodeObject.Name, builtinURLQueryEncodeObject)
 	RegisterFunctionalBuiltin1(ast.YAMLMarshal.Name, builtinYAMLMarshal)
 	RegisterFunctionalBuiltin1(ast.YAMLUnmarshal.Name, builtinYAMLUnmarshal)
 }


### PR DESCRIPTION
Wrote two new builtins:

urlquery.fromjson takes as input a JSON map of key value pairs, where the values can either be single strings or array of strings, and produces a properly encoded query string (minus the ?). 

url.generate takes as input a host, a path and a JSON object (empty object for no query string) and produces a properly formatted http:// URL 

Signed-off-by: vrnmthr <varun.mathur@live.com>