### PR TITLE
Fix partial cache invalidation for data changes

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -484,9 +484,6 @@ func (s *Server) reload(ctx context.Context, txn storage.Transaction, event stor
 		}
 	}
 
-	if !event.PolicyChanged() {
-		return
-	}
 	s.partials = map[string]rego.PartialResult{}
 }
 


### PR DESCRIPTION
The partial cache was not be invalidated when data changed. As a result,
callers would receive stale results when data updated.

Fixes #589

Signed-off-by: Torin Sandall <torinsandall@gmail.com>