### PR TITLE
fix some go reportcard issues

### DIFF
--- a/ast/check_test.go
+++ b/ast/check_test.go
@@ -422,7 +422,7 @@ func TestCheckInferenceRules(t *testing.T) {
 		// Check that prefixes that iterate fallback to any.
 		{"prefix-iter", ruleset1, `data.prefix.i.j[k]`, types.A},
 
-		// Check that iteration targetting a rule (but nonetheless prefixed) falls back to any.
+		// Check that iteration targeting a rule (but nonetheless prefixed) falls back to any.
 		{"prefix-iter-2", ruleset1, `data.prefix.i.j[k].p`, types.A},
 
 		{"default-rule", ruleset1, "data.default_rule.x", types.NewAny(

--- a/ast/compile_test.go
+++ b/ast/compile_test.go
@@ -1441,8 +1441,8 @@ func TestCompilerSetGraph(t *testing.T) {
 	r := mod2.Rules[0]
 
 	edges := map[util.T]struct{}{
-		q: struct{}{},
-		r: struct{}{},
+		q: {},
+		r: {},
 	}
 
 	if !reflect.DeepEqual(edges, c.Graph.Dependencies(p)) {

--- a/ast/parser_test.go
+++ b/ast/parser_test.go
@@ -904,11 +904,11 @@ func TestRuleElseKeyword(t *testing.T) {
 	expected := &Module{
 		Package: MustParsePackage(`package test`),
 		Rules: []*Rule{
-			&Rule{
+			{
 				Head: head,
 				Body: MustParseBody(`"p0"`),
 			},
-			&Rule{
+			{
 				Head: head,
 				Body: MustParseBody(`"p1"`),
 				Else: &Rule{
@@ -930,11 +930,11 @@ func TestRuleElseKeyword(t *testing.T) {
 					},
 				},
 			},
-			&Rule{
+			{
 				Head: head,
 				Body: MustParseBody(`"p2"`),
 			},
-			&Rule{
+			{
 				Head: &Head{
 					Name:  Var("f"),
 					Args:  Args{VarTerm("x")},
@@ -968,11 +968,11 @@ func TestRuleElseKeyword(t *testing.T) {
 	notExpected := &Module{
 		Package: MustParsePackage(`package test`),
 		Rules: []*Rule{
-			&Rule{
+			{
 				Head: head,
 				Body: MustParseBody(`"p0"`),
 			},
-			&Rule{
+			{
 				Head: head,
 				Body: MustParseBody(`"p1"`),
 				Else: &Rule{
@@ -994,7 +994,7 @@ func TestRuleElseKeyword(t *testing.T) {
 					},
 				},
 			},
-			&Rule{
+			{
 				Head: head,
 				Body: MustParseBody(`"p2"`),
 			},

--- a/ast/parser_test.go
+++ b/ast/parser_test.go
@@ -236,8 +236,8 @@ func TestSetFail(t *testing.T) {
 
 func TestEmptyComposites(t *testing.T) {
 	assertParseOneTerm(t, "empty object", "{}", ObjectTerm())
-	assertParseOneTerm(t, "emtpy array", "[]", ArrayTerm())
-	assertParseOneTerm(t, "emtpy set", "set()", SetTerm())
+	assertParseOneTerm(t, "empty array", "[]", ArrayTerm())
+	assertParseOneTerm(t, "empty set", "set()", SetTerm())
 }
 
 func TestNestedComposites(t *testing.T) {

--- a/ast/policy_test.go
+++ b/ast/policy_test.go
@@ -179,7 +179,7 @@ func TestExprEquals(t *testing.T) {
 	expr30 := &Expr{
 		Terms: MustParseTerm("data.foo.bar"),
 		With: []*With{
-			&With{
+			{
 				Target: MustParseTerm("input"),
 				Value:  MustParseTerm("bar"),
 			},
@@ -189,7 +189,7 @@ func TestExprEquals(t *testing.T) {
 	expr31 := &Expr{
 		Terms: MustParseTerm("data.foo.bar"),
 		With: []*With{
-			&With{
+			{
 				Target: MustParseTerm("input"),
 				Value:  MustParseTerm("bar"),
 			},
@@ -199,7 +199,7 @@ func TestExprEquals(t *testing.T) {
 	expr32 := &Expr{
 		Terms: MustParseTerm("data.foo.bar"),
 		With: []*With{
-			&With{
+			{
 				Target: MustParseTerm("input.foo"),
 				Value:  MustParseTerm("baz"),
 			},

--- a/ast/transform_test.go
+++ b/ast/transform_test.go
@@ -32,7 +32,7 @@ foo(x) = y { split(x, "this", y) }
 	}, module)
 
 	if err != nil {
-		t.Fatalf("Unexpected error during transfom: %v", err)
+		t.Fatalf("Unexpected error during transform: %v", err)
 	}
 
 	resultMod, ok := result.(*Module)

--- a/dependencies/deps.go
+++ b/dependencies/deps.go
@@ -42,7 +42,7 @@ func All(x interface{}) (resolved []ast.Ref, err error) {
 			}
 
 			// The analysis will discard variables that are not used in
-			// direct comparisions or in the output. Since lone Bodies are
+			// direct comparisons or in the output. Since lone Bodies are
 			// often queries, we want all the variables to be in the output.
 			r := &ast.Rule{
 				Head: &ast.Head{Name: ast.Var("_"), Value: ast.NewTerm(arr)},

--- a/format/format.go
+++ b/format/format.go
@@ -24,7 +24,7 @@ func Bytes(src []byte) ([]byte, error) {
 	return Ast(astElem)
 }
 
-// Source formats a Rego source file. The bytes provided must decribe a complete
+// Source formats a Rego source file. The bytes provided must describe a complete
 // Rego module. If they don't, Source will return an error resulting from the attempt
 // to parse the bytes.
 func Source(filename string, src []byte) ([]byte, error) {

--- a/loader/errors.go
+++ b/loader/errors.go
@@ -24,7 +24,7 @@ func (e loaderErrors) Error() string {
 	for i := range buf {
 		buf[i] = e[i].Error()
 	}
-	return fmt.Sprintf("%v errors occured during loading:\n", len(e)) + strings.Join(buf, "\n")
+	return fmt.Sprintf("%v errors occurred during loading:\n", len(e)) + strings.Join(buf, "\n")
 }
 
 func (e *loaderErrors) Add(err error) {

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -21,7 +21,7 @@ const (
 	RegoPartialEval   = "rego_partial_eval"
 )
 
-// Metrics defines the interface for a collection of perfomrance metrics in the
+// Metrics defines the interface for a collection of performance metrics in the
 // policy engine.
 type Metrics interface {
 	Timer(name string) Timer

--- a/rego/example_test.go
+++ b/rego/example_test.go
@@ -275,6 +275,9 @@ func ExampleRego_Eval_storage() {
 
 	// Run evaluation.
 	rs, err := rego.Eval(ctx)
+	if err != nil {
+		// Handle error.
+	}
 
 	// Inspect the result.
 	fmt.Println("value:", rs[0].Expressions[0].Value)

--- a/repl/repl_test.go
+++ b/repl/repl_test.go
@@ -230,7 +230,7 @@ func TestDumpPath(t *testing.T) {
 
 	var result map[string]interface{}
 	if err := util.UnmarshalJSON(bs, &result); err != nil {
-		t.Fatalf("Expected json unmarhsal to suceed but got: %v", err)
+		t.Fatalf("Expected json unmarshal to succeed but got: %v", err)
 	}
 
 	if !reflect.DeepEqual(data, result) {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -68,7 +68,7 @@ func TestDataV0(t *testing.T) {
 	}
 
 	if err := f.v0(http.MethodPost, "/data/test/q/foo", `{"flag": true}`, 200, `[1,2,3,4]`); err != nil {
-		t.Fatalf("Exepcted response [1,2,3,4] but got: %v", err)
+		t.Fatalf("Expected response [1,2,3,4] but got: %v", err)
 	}
 
 	req := newReqV0(http.MethodPost, "/data/test/q", "")
@@ -1972,7 +1972,7 @@ func TestWatchParams(t *testing.T) {
 		}
 		explain := expl.([]interface{})
 		if len(explain) != exp.explainLength {
-			t.Fatalf("Expection %d explanations, got %d", exp.explainLength, len(explain))
+			t.Fatalf("Expected %d explanations, got %d", exp.explainLength, len(explain))
 		}
 
 		result, ok := m["result"].([]interface{})[0].(map[string]interface{})["bindings"]

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -96,54 +96,54 @@ func Test405StatusCodev1(t *testing.T) {
 		reqs []tr
 	}{
 		{"v1 data one level 405", []tr{
-			tr{http.MethodHead, "/data/lvl1", "", 405, ""},
-			tr{http.MethodConnect, "/data/lvl1", "", 405, ""},
-			tr{http.MethodOptions, "/data/lvl1", "", 405, ""},
-			tr{http.MethodTrace, "/data/lvl1", "", 405, ""},
+			{http.MethodHead, "/data/lvl1", "", 405, ""},
+			{http.MethodConnect, "/data/lvl1", "", 405, ""},
+			{http.MethodOptions, "/data/lvl1", "", 405, ""},
+			{http.MethodTrace, "/data/lvl1", "", 405, ""},
 		}},
 		{"v1 data 405", []tr{
-			tr{http.MethodHead, "/data", "", 405, ""},
-			tr{http.MethodConnect, "/data", "", 405, ""},
-			tr{http.MethodOptions, "/data", "", 405, ""},
-			tr{http.MethodTrace, "/data", "", 405, ""},
-			tr{http.MethodDelete, "/data", "", 405, ""},
+			{http.MethodHead, "/data", "", 405, ""},
+			{http.MethodConnect, "/data", "", 405, ""},
+			{http.MethodOptions, "/data", "", 405, ""},
+			{http.MethodTrace, "/data", "", 405, ""},
+			{http.MethodDelete, "/data", "", 405, ""},
 		}},
 		{"v1 policies 405", []tr{
-			tr{http.MethodHead, "/policies", "", 405, ""},
-			tr{http.MethodConnect, "/policies", "", 405, ""},
-			tr{http.MethodDelete, "/policies", "", 405, ""},
-			tr{http.MethodOptions, "/policies", "", 405, ""},
-			tr{http.MethodTrace, "/policies", "", 405, ""},
-			tr{http.MethodPost, "/policies", "", 405, ""},
-			tr{http.MethodPut, "/policies", "", 405, ""},
-			tr{http.MethodPatch, "/policies", "", 405, ""},
+			{http.MethodHead, "/policies", "", 405, ""},
+			{http.MethodConnect, "/policies", "", 405, ""},
+			{http.MethodDelete, "/policies", "", 405, ""},
+			{http.MethodOptions, "/policies", "", 405, ""},
+			{http.MethodTrace, "/policies", "", 405, ""},
+			{http.MethodPost, "/policies", "", 405, ""},
+			{http.MethodPut, "/policies", "", 405, ""},
+			{http.MethodPatch, "/policies", "", 405, ""},
 		}},
 		{"v1 policies one level 405", []tr{
-			tr{http.MethodHead, "/policies/lvl1", "", 405, ""},
-			tr{http.MethodConnect, "/policies/lvl1", "", 405, ""},
-			tr{http.MethodOptions, "/policies/lvl1", "", 405, ""},
-			tr{http.MethodTrace, "/policies/lvl1", "", 405, ""},
-			tr{http.MethodPost, "/policies/lvl1", "", 405, ""},
+			{http.MethodHead, "/policies/lvl1", "", 405, ""},
+			{http.MethodConnect, "/policies/lvl1", "", 405, ""},
+			{http.MethodOptions, "/policies/lvl1", "", 405, ""},
+			{http.MethodTrace, "/policies/lvl1", "", 405, ""},
+			{http.MethodPost, "/policies/lvl1", "", 405, ""},
 		}},
 		{"v1 query one level 405", []tr{
-			tr{http.MethodHead, "/query/lvl1", "", 405, ""},
-			tr{http.MethodConnect, "/query/lvl1", "", 405, ""},
-			tr{http.MethodDelete, "/query/lvl1", "", 405, ""},
-			tr{http.MethodOptions, "/query/lvl1", "", 405, ""},
-			tr{http.MethodTrace, "/query/lvl1", "", 405, ""},
-			tr{http.MethodPost, "/query/lvl1", "", 405, ""},
-			tr{http.MethodPut, "/query/lvl1", "", 405, ""},
-			tr{http.MethodPatch, "/query/lvl1", "", 405, ""},
+			{http.MethodHead, "/query/lvl1", "", 405, ""},
+			{http.MethodConnect, "/query/lvl1", "", 405, ""},
+			{http.MethodDelete, "/query/lvl1", "", 405, ""},
+			{http.MethodOptions, "/query/lvl1", "", 405, ""},
+			{http.MethodTrace, "/query/lvl1", "", 405, ""},
+			{http.MethodPost, "/query/lvl1", "", 405, ""},
+			{http.MethodPut, "/query/lvl1", "", 405, ""},
+			{http.MethodPatch, "/query/lvl1", "", 405, ""},
 		}},
 		{"v1 query 405", []tr{
-			tr{http.MethodHead, "/query", "", 405, ""},
-			tr{http.MethodConnect, "/query", "", 405, ""},
-			tr{http.MethodDelete, "/query", "", 405, ""},
-			tr{http.MethodOptions, "/query", "", 405, ""},
-			tr{http.MethodTrace, "/query", "", 405, ""},
-			tr{http.MethodPost, "/query", "", 405, ""},
-			tr{http.MethodPut, "/query", "", 405, ""},
-			tr{http.MethodPatch, "/query", "", 405, ""},
+			{http.MethodHead, "/query", "", 405, ""},
+			{http.MethodConnect, "/query", "", 405, ""},
+			{http.MethodDelete, "/query", "", 405, ""},
+			{http.MethodOptions, "/query", "", 405, ""},
+			{http.MethodTrace, "/query", "", 405, ""},
+			{http.MethodPost, "/query", "", 405, ""},
+			{http.MethodPut, "/query", "", 405, ""},
+			{http.MethodPatch, "/query", "", 405, ""},
 		}},
 	}
 	for _, tc := range tests {
@@ -160,24 +160,24 @@ func Test405StatusCodev0(t *testing.T) {
 		reqs []tr
 	}{
 		{"v0 data one levels 405", []tr{
-			tr{http.MethodHead, "/data/lvl2", "", 405, ""},
-			tr{http.MethodConnect, "/data/lvl2", "", 405, ""},
-			tr{http.MethodDelete, "/data/lvl2", "", 405, ""},
-			tr{http.MethodOptions, "/data/lvl2", "", 405, ""},
-			tr{http.MethodTrace, "/data/lvl2", "", 405, ""},
-			tr{http.MethodGet, "/data/lvl2", "", 405, ""},
-			tr{http.MethodPatch, "/data/lvl2", "", 405, ""},
-			tr{http.MethodPut, "/data/lvl2", "", 405, ""},
+			{http.MethodHead, "/data/lvl2", "", 405, ""},
+			{http.MethodConnect, "/data/lvl2", "", 405, ""},
+			{http.MethodDelete, "/data/lvl2", "", 405, ""},
+			{http.MethodOptions, "/data/lvl2", "", 405, ""},
+			{http.MethodTrace, "/data/lvl2", "", 405, ""},
+			{http.MethodGet, "/data/lvl2", "", 405, ""},
+			{http.MethodPatch, "/data/lvl2", "", 405, ""},
+			{http.MethodPut, "/data/lvl2", "", 405, ""},
 		}},
 		{"v0 data 405", []tr{
-			tr{http.MethodHead, "/data", "", 405, ""},
-			tr{http.MethodConnect, "/data", "", 405, ""},
-			tr{http.MethodDelete, "/data", "", 405, ""},
-			tr{http.MethodOptions, "/data", "", 405, ""},
-			tr{http.MethodTrace, "/data", "", 405, ""},
-			tr{http.MethodGet, "/data", "", 405, ""},
-			tr{http.MethodPatch, "/data", "", 405, ""},
-			tr{http.MethodPut, "/data", "", 405, ""},
+			{http.MethodHead, "/data", "", 405, ""},
+			{http.MethodConnect, "/data", "", 405, ""},
+			{http.MethodDelete, "/data", "", 405, ""},
+			{http.MethodOptions, "/data", "", 405, ""},
+			{http.MethodTrace, "/data", "", 405, ""},
+			{http.MethodGet, "/data", "", 405, ""},
+			{http.MethodPatch, "/data", "", 405, ""},
+			{http.MethodPut, "/data", "", 405, ""},
 		}},
 	}
 	for _, tc := range tests {
@@ -250,46 +250,46 @@ p = true { false }`
 		reqs []tr
 	}{
 		{"add root", []tr{
-			tr{http.MethodPatch, "/data/x", `[{"op": "add", "path": "/", "value": {"a": 1}}]`, 204, ""},
-			tr{http.MethodGet, "/data/x/a", "", 200, `{"result": 1}`},
+			{http.MethodPatch, "/data/x", `[{"op": "add", "path": "/", "value": {"a": 1}}]`, 204, ""},
+			{http.MethodGet, "/data/x/a", "", 200, `{"result": 1}`},
 		}},
 		{"append array", []tr{
-			tr{http.MethodPatch, "/data/x", `[{"op": "add", "path": "/", "value": []}]`, 204, ""},
-			tr{http.MethodPatch, "/data/x", `[{"op": "add", "path": "-", "value": {"a": 1}}]`, 204, ""},
-			tr{http.MethodPatch, "/data/x", `[{"op": "add", "path": "-", "value": {"a": 2}}]`, 204, ""},
-			tr{http.MethodGet, "/data/x/0/a", "", 200, `{"result": 1}`},
-			tr{http.MethodGet, "/data/x/1/a", "", 200, `{"result": 2}`},
+			{http.MethodPatch, "/data/x", `[{"op": "add", "path": "/", "value": []}]`, 204, ""},
+			{http.MethodPatch, "/data/x", `[{"op": "add", "path": "-", "value": {"a": 1}}]`, 204, ""},
+			{http.MethodPatch, "/data/x", `[{"op": "add", "path": "-", "value": {"a": 2}}]`, 204, ""},
+			{http.MethodGet, "/data/x/0/a", "", 200, `{"result": 1}`},
+			{http.MethodGet, "/data/x/1/a", "", 200, `{"result": 2}`},
 		}},
 		{"append array one-shot", []tr{
-			tr{http.MethodPatch, "/data/x", `[
+			{http.MethodPatch, "/data/x", `[
                 {"op": "add", "path": "/", "value": []},
                 {"op": "add", "path": "-", "value": {"a": 1}},
                 {"op": "add", "path": "-", "value": {"a": 2}}
             ]`, 204, ""},
-			tr{http.MethodGet, "/data/x/1/a", "", 200, `{"result": 2}`},
+			{http.MethodGet, "/data/x/1/a", "", 200, `{"result": 2}`},
 		}},
 		{"insert array", []tr{
-			tr{http.MethodPatch, "/data/x", `[{"op": "add", "path": "/", "value": {
+			{http.MethodPatch, "/data/x", `[{"op": "add", "path": "/", "value": {
                 "y": [
                     {"z": [1,2,3]},
                     {"z": [4,5,6]}
                 ]
             }}]`, 204, ""},
-			tr{http.MethodGet, "/data/x/y/1/z/2", "", 200, `{"result": 6}`},
-			tr{http.MethodPatch, "/data/x/y/1", `[{"op": "add", "path": "/z/1", "value": 100}]`, 204, ""},
-			tr{http.MethodGet, "/data/x/y/1/z", "", 200, `{"result": [4, 100, 5, 6]}`},
+			{http.MethodGet, "/data/x/y/1/z/2", "", 200, `{"result": 6}`},
+			{http.MethodPatch, "/data/x/y/1", `[{"op": "add", "path": "/z/1", "value": 100}]`, 204, ""},
+			{http.MethodGet, "/data/x/y/1/z", "", 200, `{"result": [4, 100, 5, 6]}`},
 		}},
 		{"patch root", []tr{
-			tr{http.MethodPatch, "/data", `[
+			{http.MethodPatch, "/data", `[
 				{"op": "add",
 				 "path": "/",
 				 "value": {"a": 1, "b": 2}
 				}
 			]`, 204, ""},
-			tr{http.MethodGet, "/data", "", 200, `{"result": {"a": 1, "b": 2}}`},
+			{http.MethodGet, "/data", "", 200, `{"result": {"a": 1, "b": 2}}`},
 		}},
 		{"patch invalid", []tr{
-			tr{http.MethodPatch, "/data", `[
+			{http.MethodPatch, "/data", `[
 				{
 					"op": "remove",
 					"path": "/"
@@ -297,137 +297,137 @@ p = true { false }`
 			]`, 400, ""},
 		}},
 		{"patch abort", []tr{
-			tr{http.MethodPatch, "/data", `[
+			{http.MethodPatch, "/data", `[
 				{"op": "add", "path": "/foo", "value": "hello"},
 				{"op": "add", "path": "/bar", "value": "world"},
 				{"op": "add", "path": "/foo/bad", "value": "deadbeef"}
 			]`, 404, ""},
-			tr{http.MethodGet, "/data", "", 200, `{"result": {}}`},
+			{http.MethodGet, "/data", "", 200, `{"result": {}}`},
 		}},
 		{"put root", []tr{
-			tr{http.MethodPut, "/data", `{"foo": [1,2,3]}`, 204, ""},
-			tr{http.MethodGet, "/data", "", 200, `{"result": {"foo": [1,2,3]}}`},
+			{http.MethodPut, "/data", `{"foo": [1,2,3]}`, 204, ""},
+			{http.MethodGet, "/data", "", 200, `{"result": {"foo": [1,2,3]}}`},
 		}},
 		{"put deep makedir", []tr{
-			tr{http.MethodPut, "/data/a/b/c/d", `1`, 204, ""},
-			tr{http.MethodGet, "/data/a/b/c", "", 200, `{"result": {"d": 1}}`},
+			{http.MethodPut, "/data/a/b/c/d", `1`, 204, ""},
+			{http.MethodGet, "/data/a/b/c", "", 200, `{"result": {"d": 1}}`},
 		}},
 		{"put deep makedir partial", []tr{
-			tr{http.MethodPut, "/data/a/b", `{}`, 204, ""},
-			tr{http.MethodPut, "/data/a/b/c/d", `0`, 204, ""},
-			tr{http.MethodGet, "/data/a/b/c", "", 200, `{"result": {"d": 0}}`},
+			{http.MethodPut, "/data/a/b", `{}`, 204, ""},
+			{http.MethodPut, "/data/a/b/c/d", `0`, 204, ""},
+			{http.MethodGet, "/data/a/b/c", "", 200, `{"result": {"d": 0}}`},
 		}},
 		{"put exists overwrite", []tr{
-			tr{http.MethodPut, "/data/a/b/c", `"hello"`, 204, ""},
-			tr{http.MethodPut, "/data/a/b", `"goodbye"`, 204, ""},
-			tr{http.MethodGet, "/data/a", "", 200, `{"result": {"b": "goodbye"}}`},
+			{http.MethodPut, "/data/a/b/c", `"hello"`, 204, ""},
+			{http.MethodPut, "/data/a/b", `"goodbye"`, 204, ""},
+			{http.MethodGet, "/data/a", "", 200, `{"result": {"b": "goodbye"}}`},
 		}},
 		{"put base write conflict", []tr{
-			tr{http.MethodPut, "/data/a/b", `[1,2,3,4]`, 204, ""},
-			tr{http.MethodPut, "/data/a/b/c/d", "0", 404, `{
+			{http.MethodPut, "/data/a/b", `[1,2,3,4]`, 204, ""},
+			{http.MethodPut, "/data/a/b/c/d", "0", 404, `{
 				"code": "resource_conflict",
 				"message": "storage_write_conflict_error: /a/b"
 			}`},
 		}},
 		{"get virtual", []tr{
-			tr{http.MethodPut, "/policies/test", testMod1, 200, ""},
-			tr{http.MethodPatch, "/data/x", `[{"op": "add", "path": "/", "value": {"y": [1,2,3,4], "z": [3,4,5,6]}}]`, 204, ""},
-			tr{http.MethodGet, "/data/testmod/p", "", 200, `{"result": [1,2]}`},
+			{http.MethodPut, "/policies/test", testMod1, 200, ""},
+			{http.MethodPatch, "/data/x", `[{"op": "add", "path": "/", "value": {"y": [1,2,3,4], "z": [3,4,5,6]}}]`, 204, ""},
+			{http.MethodGet, "/data/testmod/p", "", 200, `{"result": [1,2]}`},
 		}},
 		{"get with input", []tr{
-			tr{http.MethodPut, "/policies/test", testMod1, 200, ""},
-			tr{http.MethodGet, "/data/testmod/g?input=%7B%22req1%22%3A%7B%22a%22%3A%5B1%5D%7D%2C+%22req2%22%3A%7B%22b%22%3A%5B0%2C1%5D%7D%7D", "", 200, `{"result": true}`},
+			{http.MethodPut, "/policies/test", testMod1, 200, ""},
+			{http.MethodGet, "/data/testmod/g?input=%7B%22req1%22%3A%7B%22a%22%3A%5B1%5D%7D%2C+%22req2%22%3A%7B%22b%22%3A%5B0%2C1%5D%7D%7D", "", 200, `{"result": true}`},
 		}},
 		{"get with input (missing input value)", []tr{
-			tr{http.MethodPut, "/policies/test", testMod1, 200, ""},
-			tr{http.MethodGet, "/data/testmod/g?input=%7B%22req1%22%3A%7B%22a%22%3A%5B1%5D%7D%7D", "", 200, "{}"}, // req2 not specified
+			{http.MethodPut, "/policies/test", testMod1, 200, ""},
+			{http.MethodGet, "/data/testmod/g?input=%7B%22req1%22%3A%7B%22a%22%3A%5B1%5D%7D%7D", "", 200, "{}"}, // req2 not specified
 		}},
 		{"get with input (namespaced)", []tr{
-			tr{http.MethodPut, "/policies/test", testMod1, 200, ""},
-			tr{http.MethodGet, "/data/testmod/h?input=%7B%22req3%22%3A%7B%22attr1%22%3A%5B4%2C3%2C2%2C1%5D%7D%7D", "", 200, `{"result": true}`},
+			{http.MethodPut, "/policies/test", testMod1, 200, ""},
+			{http.MethodGet, "/data/testmod/h?input=%7B%22req3%22%3A%7B%22attr1%22%3A%5B4%2C3%2C2%2C1%5D%7D%7D", "", 200, `{"result": true}`},
 		}},
 		{"get with input (root)", []tr{
-			tr{http.MethodPut, "/policies/test", testMod1, 200, ""},
-			tr{http.MethodGet, `/data/testmod/gt1?input={"req1":2}`, "", 200, `{"result": true}`},
+			{http.MethodPut, "/policies/test", testMod1, 200, ""},
+			{http.MethodGet, `/data/testmod/gt1?input={"req1":2}`, "", 200, `{"result": true}`},
 		}},
 		{"get with input (bad format)", []tr{
-			tr{http.MethodGet, "/data/deadbeef?input", "", 400, `{
+			{http.MethodGet, "/data/deadbeef?input", "", 400, `{
 				"code": "invalid_parameter",
 				"message": "parameter contains malformed input document: EOF"
 			}`},
-			tr{http.MethodGet, "/data/deadbeef?input=", "", 400, `{
+			{http.MethodGet, "/data/deadbeef?input=", "", 400, `{
 				"code": "invalid_parameter",
 				"message": "parameter contains malformed input document: EOF"
 			}`},
-			tr{http.MethodGet, `/data/deadbeef?input="foo`, "", 400, `{
+			{http.MethodGet, `/data/deadbeef?input="foo`, "", 400, `{
 				"code": "invalid_parameter",
 				"message": "parameter contains malformed input document: unexpected EOF"
 			}`},
 		}},
 		{"get with input (path error)", []tr{
-			tr{http.MethodGet, `/data/deadbeef?input={"foo:1}`, "", 400, `{
+			{http.MethodGet, `/data/deadbeef?input={"foo:1}`, "", 400, `{
 				"code": "invalid_parameter",
 				"message": "parameter contains malformed input document: unexpected EOF"
 			}`},
 		}},
 		{"get empty and undefined", []tr{
-			tr{http.MethodPut, "/policies/test", testMod1, 200, ""},
-			tr{http.MethodPut, "/policies/test2", testMod5, 200, ""},
-			tr{http.MethodPut, "/policies/test3", testMod6, 200, ""},
-			tr{http.MethodGet, "/data/testmod/undef", "", 200, "{}"},
-			tr{http.MethodGet, "/data/doesnot/exist", "", 200, "{}"},
-			tr{http.MethodGet, "/data/testmod/empty/mod", "", 200, `{
+			{http.MethodPut, "/policies/test", testMod1, 200, ""},
+			{http.MethodPut, "/policies/test2", testMod5, 200, ""},
+			{http.MethodPut, "/policies/test3", testMod6, 200, ""},
+			{http.MethodGet, "/data/testmod/undef", "", 200, "{}"},
+			{http.MethodGet, "/data/doesnot/exist", "", 200, "{}"},
+			{http.MethodGet, "/data/testmod/empty/mod", "", 200, `{
 				"result": {}
 			}`},
-			tr{http.MethodGet, "/data/testmod/all/undefined", "", 200, `{
+			{http.MethodGet, "/data/testmod/all/undefined", "", 200, `{
 				"result": {}
 			}`},
 		}},
 		{"get root", []tr{
-			tr{http.MethodPut, "/policies/test", testMod2, 200, ""},
-			tr{http.MethodPatch, "/data/x", `[{"op": "add", "path": "/", "value": [1,2,3,4]}]`, 204, ""},
-			tr{http.MethodGet, "/data", "", 200, `{"result": {"testmod": {"p": [1,2,3,4], "q": {"a":1, "b": 2}}, "x": [1,2,3,4]}}`},
+			{http.MethodPut, "/policies/test", testMod2, 200, ""},
+			{http.MethodPatch, "/data/x", `[{"op": "add", "path": "/", "value": [1,2,3,4]}]`, 204, ""},
+			{http.MethodGet, "/data", "", 200, `{"result": {"testmod": {"p": [1,2,3,4], "q": {"a":1, "b": 2}}, "x": [1,2,3,4]}}`},
 		}},
 		{"post root", []tr{
-			tr{http.MethodPost, "/data", "", 200, `{"result": {}}`},
-			tr{http.MethodPut, "/policies/test", testMod2, 200, ""},
-			tr{http.MethodPost, "/data", "", 200, `{"result": {"testmod": {"p": [1,2,3,4], "q": {"b": 2, "a": 1}}}}`},
+			{http.MethodPost, "/data", "", 200, `{"result": {}}`},
+			{http.MethodPut, "/policies/test", testMod2, 200, ""},
+			{http.MethodPost, "/data", "", 200, `{"result": {"testmod": {"p": [1,2,3,4], "q": {"b": 2, "a": 1}}}}`},
 		}},
 		{"post input", []tr{
-			tr{http.MethodPut, "/policies/test", testMod1, 200, ""},
-			tr{http.MethodPost, "/data/testmod/gt1", `{"input": {"req1": 2}}`, 200, `{"result": true}`},
+			{http.MethodPut, "/policies/test", testMod1, 200, ""},
+			{http.MethodPost, "/data/testmod/gt1", `{"input": {"req1": 2}}`, 200, `{"result": true}`},
 		}},
 		{"post malformed input", []tr{
-			tr{http.MethodPost, "/data/deadbeef", `{"input": @}`, 400, `{
+			{http.MethodPost, "/data/deadbeef", `{"input": @}`, 400, `{
 				"code": "invalid_parameter",
 				"message": "body contains malformed input document: invalid character '@' looking for beginning of value"
 			}`},
 		}},
 		{"post empty object", []tr{
-			tr{http.MethodPost, "/data", `{}`, 200, `{"result": {}}`},
+			{http.MethodPost, "/data", `{}`, 200, `{"result": {}}`},
 		}},
 		{"post partial", []tr{
-			tr{http.MethodPut, "/policies/test", testMod7, 200, ""},
-			tr{http.MethodPost, "/data/testmod/p?partial", `{"input": {"x": 1, "y": 2, "z": 9999}}`, 200, `{"result": true}`},
-			tr{http.MethodPost, "/data/testmod/p?partial", `{"input": {"x": 1, "z": 3}}`, 200, `{"result": false}`},
-			tr{http.MethodPost, "/data/testmod/p", `{"input": {"x": 1, "y": 2, "z": 9999}}`, 200, `{"result": true}`},
-			tr{http.MethodPost, "/data/testmod/p", `{"input": {"x": 1, "z": 3}}`, 200, `{"result": false}`},
+			{http.MethodPut, "/policies/test", testMod7, 200, ""},
+			{http.MethodPost, "/data/testmod/p?partial", `{"input": {"x": 1, "y": 2, "z": 9999}}`, 200, `{"result": true}`},
+			{http.MethodPost, "/data/testmod/p?partial", `{"input": {"x": 1, "z": 3}}`, 200, `{"result": false}`},
+			{http.MethodPost, "/data/testmod/p", `{"input": {"x": 1, "y": 2, "z": 9999}}`, 200, `{"result": true}`},
+			{http.MethodPost, "/data/testmod/p", `{"input": {"x": 1, "z": 3}}`, 200, `{"result": false}`},
 		}},
 		{"partial invalidate policy", []tr{
-			tr{http.MethodPut, "/policies/test", testMod7, 200, ""},
-			tr{http.MethodPost, "/data/testmod/p?partial", `{"input": {"x": 1, "y": 2, "z": 3}}`, 200, `{"result": true}`},
-			tr{http.MethodPut, "/policies/test", testMod7Modified, 200, ""},
-			tr{http.MethodPost, "/data/testmod/p?partial", `{"input": {"x": 1, "y": 2, "z": 3}}`, 200, `{"result": false}`},
+			{http.MethodPut, "/policies/test", testMod7, 200, ""},
+			{http.MethodPost, "/data/testmod/p?partial", `{"input": {"x": 1, "y": 2, "z": 3}}`, 200, `{"result": true}`},
+			{http.MethodPut, "/policies/test", testMod7Modified, 200, ""},
+			{http.MethodPost, "/data/testmod/p?partial", `{"input": {"x": 1, "y": 2, "z": 3}}`, 200, `{"result": false}`},
 		}},
 		{"partial invalidate data", []tr{
-			tr{http.MethodPut, "/policies/test", testMod8, 200, ""},
-			tr{http.MethodPost, "/data/testmod/p?partial", "", 200, `{}`},
-			tr{http.MethodPut, "/data/x", `1`, 204, ""},
-			tr{http.MethodPost, "/data/testmod/p?partial", "", 200, `{"result": true}`},
+			{http.MethodPut, "/policies/test", testMod8, 200, ""},
+			{http.MethodPost, "/data/testmod/p?partial", "", 200, `{}`},
+			{http.MethodPut, "/data/x", `1`, 204, ""},
+			{http.MethodPost, "/data/testmod/p?partial", "", 200, `{"result": true}`},
 		}},
 		{"evaluation conflict", []tr{
-			tr{http.MethodPut, "/policies/test", testMod4, 200, ""},
-			tr{http.MethodPost, "/data/testmod/p", "", 500, `{
+			{http.MethodPut, "/policies/test", testMod4, 200, ""},
+			{http.MethodPost, "/data/testmod/p", "", 500, `{
     		  "code": "internal_error",
     		  "errors": [
     		    {
@@ -444,35 +444,35 @@ p = true { false }`
     		}`},
 		}},
 		{"query wildcards omitted", []tr{
-			tr{http.MethodPatch, "/data/x", `[{"op": "add", "path": "/", "value": [1,2,3,4]}]`, 204, ""},
-			tr{http.MethodGet, "/query?q=data.x[_]%20=%20x", "", 200, `{"result": [{"x": 1}, {"x": 2}, {"x": 3}, {"x": 4}]}`},
+			{http.MethodPatch, "/data/x", `[{"op": "add", "path": "/", "value": [1,2,3,4]}]`, 204, ""},
+			{http.MethodGet, "/query?q=data.x[_]%20=%20x", "", 200, `{"result": [{"x": 1}, {"x": 2}, {"x": 3}, {"x": 4}]}`},
 		}},
 		{"query undefined", []tr{
-			tr{http.MethodGet, "/query?q=a=1%3Bb=2%3Ba=b", "", 200, `{}`},
+			{http.MethodGet, "/query?q=a=1%3Bb=2%3Ba=b", "", 200, `{}`},
 		}},
 		{"query compiler error", []tr{
-			tr{http.MethodGet, "/query?q=x", "", 400, ""},
+			{http.MethodGet, "/query?q=x", "", 400, ""},
 			// Subsequent query should not fail.
-			tr{http.MethodGet, "/query?q=x=1", "", 200, `{"result": [{"x": 1}]}`},
+			{http.MethodGet, "/query?q=x=1", "", 200, `{"result": [{"x": 1}]}`},
 		}},
 		{"delete and check", []tr{
-			tr{http.MethodDelete, "/data/a/b", "", 404, ""},
-			tr{http.MethodPut, "/data/a/b/c/d", `1`, 204, ""},
-			tr{http.MethodGet, "/data/a/b/c", "", 200, `{"result": {"d": 1}}`},
-			tr{http.MethodDelete, "/data/a/b", "", 204, ""},
-			tr{http.MethodGet, "/data/a/b/c/d", "", 200, `{}`},
-			tr{http.MethodGet, "/data/a", "", 200, `{"result": {}}`},
-			tr{http.MethodGet, "/data/a/b/c", "", 200, `{}`},
+			{http.MethodDelete, "/data/a/b", "", 404, ""},
+			{http.MethodPut, "/data/a/b/c/d", `1`, 204, ""},
+			{http.MethodGet, "/data/a/b/c", "", 200, `{"result": {"d": 1}}`},
+			{http.MethodDelete, "/data/a/b", "", 204, ""},
+			{http.MethodGet, "/data/a/b/c/d", "", 200, `{}`},
+			{http.MethodGet, "/data/a", "", 200, `{"result": {}}`},
+			{http.MethodGet, "/data/a/b/c", "", 200, `{}`},
 		}},
 		{"escaped paths", []tr{
-			tr{http.MethodPut, "/data/a%2Fb", `{"c/d": 1}`, 204, ""},
-			tr{http.MethodGet, "/data", "", 200, `{"result": {"a/b": {"c/d": 1}}}`},
-			tr{http.MethodGet, "/data/a%2Fb/c%2Fd", "", 200, `{"result": 1}`},
-			tr{http.MethodGet, "/data/a/b", "", 200, `{}`},
-			tr{http.MethodPost, "/data/a%2Fb/c%2Fd", "", 200, `{"result": 1}`},
-			tr{http.MethodPost, "/data/a/b", "", 200, `{}`},
-			tr{http.MethodPatch, "/data/a%2Fb", `[{"op": "add", "path": "/e%2Ff", "value": 2}]`, 204, ""},
-			tr{http.MethodPost, "/data", "", 200, `{"result": {"a/b": {"c/d": 1, "e/f": 2}}}`},
+			{http.MethodPut, "/data/a%2Fb", `{"c/d": 1}`, 204, ""},
+			{http.MethodGet, "/data", "", 200, `{"result": {"a/b": {"c/d": 1}}}`},
+			{http.MethodGet, "/data/a%2Fb/c%2Fd", "", 200, `{"result": 1}`},
+			{http.MethodGet, "/data/a/b", "", 200, `{}`},
+			{http.MethodPost, "/data/a%2Fb/c%2Fd", "", 200, `{"result": 1}`},
+			{http.MethodPost, "/data/a/b", "", 200, `{}`},
+			{http.MethodPatch, "/data/a%2Fb", `[{"op": "add", "path": "/e%2Ff", "value": 2}]`, 204, ""},
+			{http.MethodPost, "/data", "", 200, `{"result": {"a/b": {"c/d": 1, "e/f": 2}}}`},
 		}},
 	}
 

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -140,7 +140,7 @@ func (e TriggerEvent) DataChanged() bool {
 // TriggerConfig contains the trigger registration configuration.
 type TriggerConfig struct {
 
-	// OnCommit is invoked when a transaction is succesfully committed. The
+	// OnCommit is invoked when a transaction is successfully committed. The
 	// callback is invoked with a handle to the write transaction that
 	// successfully committed before other clients see the changes.
 	OnCommit func(ctx context.Context, txn Transaction, event TriggerEvent)

--- a/topdown/strings.go
+++ b/topdown/strings.go
@@ -193,6 +193,9 @@ func builtinSplit(a, b ast.Value) (ast.Value, error) {
 		return nil, err
 	}
 	d, err := builtins.StringOperand(b, 2)
+	if err != nil {
+		return nil, err
+	}
 	elems := strings.Split(string(s), string(d))
 	arr := make(ast.Array, len(elems))
 	for i := range arr {

--- a/topdown/tokens.go
+++ b/topdown/tokens.go
@@ -171,7 +171,7 @@ func extractJSONObject(s string) (ast.Object, error) {
 	// Object. If duplicate keys are present in a JWT, the last must be
 	// used or the token rejected. Since detecting duplicates is tantamount
 	// to parsing it ourselves, we're relying on the Go implementation
-	// using the last occuring instance of the key, which is the behavior
+	// using the last occurring instance of the key, which is the behavior
 	// as of Go 1.8.1.
 	v, err := builtinJSONUnmarshal(ast.String(s))
 	if err != nil {

--- a/watch/watch.go
+++ b/watch/watch.go
@@ -18,7 +18,7 @@ import (
 	"github.com/open-policy-agent/opa/topdown"
 )
 
-// Watcher allows for watches to be registed on queries.
+// Watcher allows for watches to be registered on queries.
 type Watcher struct {
 	store    storage.Store
 	compiler *ast.Compiler
@@ -41,7 +41,7 @@ type Handle struct {
 	query      string // the original query, used for migration
 
 	out    chan Event // out is the same channel as C, but without directional constraints
-	notify signal     // channel to recieve new data change alerts on.
+	notify signal     // channel to receive new data change alerts on.
 
 	done signal // closed by the watcher to signal the sending goroutine to stop sending query results.
 	ack  signal // closed by the sending goroutine to tell the watcher it has stopped sending query results.

--- a/watch/watch_test.go
+++ b/watch/watch_test.go
@@ -420,7 +420,7 @@ func testWatchRandom(t *testing.T, watcher *Watcher, zero, one, two, three *Hand
 			// all the queries results are linearly dependent on the
 			// data they watch, the result should never increase. It
 			// may stay the same or skip values due to multiple store
-			// writes occuring after a notification is acted upon,
+			// writes occurring after a notification is acted upon,
 			// but while or before the new result is computed.
 			if i < last {
 				t.Errorf("query result decreased, last=%d, cur=%d", last, i)


### PR DESCRIPTION
This is all rather trivial. 😃 But should get `opa` to 100% in some of these: https://goreportcard.com/report/github.com/open-policy-agent/opa

Couldn't fix govet (that error just seems wrong, there's an upstream issue for it); ran out of time before looking at gocyclo. No idea about the golint one, either.