### PR TITLE
Add Secret JWT signature verification built-in function

### DIFF
--- a/ast/builtins.go
+++ b/ast/builtins.go
@@ -104,6 +104,7 @@ var DefaultBuiltins = [...]*Builtin{
 	// Tokens
 	JWTDecode,
 	JWTVerifyRS256,
+	JWTVerifyHS256,
 
 	// Time
 	NowNanos,
@@ -758,6 +759,18 @@ var JWTDecode = &Builtin{
 // JWTVerifyRS256 verifies if a RS256 JWT signature is valid or not.
 var JWTVerifyRS256 = &Builtin{
 	Name: "io.jwt.verify_rs256",
+	Decl: types.NewFunction(
+		types.Args(
+			types.S,
+			types.S,
+		),
+		types.B,
+	),
+}
+
+// JWTVerifyHS256 verifies if a HS256 (secret) JWT signature is valid or not.
+var JWTVerifyHS256 = &Builtin{
+	Name: "io.jwt.verify_hs256",
 	Decl: types.NewFunction(
 		types.Args(
 			types.S,

--- a/docs/book/language-reference.md
+++ b/docs/book/language-reference.md
@@ -111,6 +111,7 @@ complex types.
 | Built-in | Inputs | Description |
 | ------- |--------|-------------|
 | <span class="opa-keep-it-together">``io.jwt.verify_rs256(string, certificate, output)``</span> | 1 | ``output`` is ``true`` if the RS256 signature of the input token is valid. ``certificate`` is the PEM encoded certificate used to verify the RS256 signature|
+| <span class="opa-keep-it-together">``io.jwt.verify_hs256(token, secret, output)``</span> | 1 | ``output`` is ``true`` if the Secret signature of the input token is valid. ``secret`` is a plain text secret used to verify the HS256 signature|
 | <span class="opa-keep-it-together">``io.jwt.decode(string, [header, payload, sig])``</span> | 1 | ``header`` and ``payload`` are ``object``. ``signature`` is the hexadecimal representation of the signature on the token. |
 
 The input `string` is a JSON Web Token encoded with JWS Compact Serialization. JWE and JWS JSON Serialization are not supported. If nested signing was used, the ``header``, ``payload`` and ``signature`` will represent the most deeply nested token.

--- a/docs/book/language-reference.md
+++ b/docs/book/language-reference.md
@@ -111,7 +111,7 @@ complex types.
 | Built-in | Inputs | Description |
 | ------- |--------|-------------|
 | <span class="opa-keep-it-together">``io.jwt.verify_rs256(string, certificate, output)``</span> | 1 | ``output`` is ``true`` if the RS256 signature of the input token is valid. ``certificate`` is the PEM encoded certificate used to verify the RS256 signature|
-| <span class="opa-keep-it-together">``io.jwt.verify_hs256(token, secret, output)``</span> | 1 | ``output`` is ``true`` if the Secret signature of the input token is valid. ``secret`` is a plain text secret used to verify the HS256 signature|
+| <span class="opa-keep-it-together">``io.jwt.verify_hs256(string, secret, output)``</span> | 1 | ``output`` is ``true`` if the Secret signature of the input token is valid. ``secret`` is a plain text secret used to verify the HS256 signature|
 | <span class="opa-keep-it-together">``io.jwt.decode(string, [header, payload, sig])``</span> | 1 | ``header`` and ``payload`` are ``object``. ``signature`` is the hexadecimal representation of the signature on the token. |
 
 The input `string` is a JSON Web Token encoded with JWS Compact Serialization. JWE and JWS JSON Serialization are not supported. If nested signing was used, the ``header``, ``payload`` and ``signature`` will represent the most deeply nested token.

--- a/topdown/tokens.go
+++ b/topdown/tokens.go
@@ -6,6 +6,7 @@ package topdown
 
 import (
 	"crypto"
+	"crypto/hmac"
 	"crypto/rsa"
 	"crypto/sha256"
 	"crypto/x509"
@@ -25,24 +26,26 @@ var (
 	jwtCtyKey = ast.StringTerm("cty")
 )
 
+// JSONWebToken represent the 3 parts (header, payload & signature) of
+//              a JWT in Base64.
+type JSONWebToken struct {
+	header    string
+	payload   string
+	signature string
+}
+
 // Implements JWT decoding/validation based on RFC 7519 Section 7.2:
 // https://tools.ietf.org/html/rfc7519#section-7.2
 // It does no data validation, it merely checks that the given string
 // represents a structurally valid JWT. It supports JWTs using JWS compact
 // serialization.
 func builtinJWTDecode(a ast.Value) (ast.Value, error) {
-	astEncode, err := builtins.StringOperand(a, 1)
-	encoding := string(astEncode)
-	if !strings.Contains(encoding, ".") {
-		return nil, errors.New("encoded JWT had no period separators")
+	token, err := decodeJWT(a)
+	if err != nil {
+		return nil, err
 	}
 
-	parts := strings.Split(encoding, ".")
-	if len(parts) != 3 {
-		return nil, fmt.Errorf("encoded JWT must have 3 sections, found %d", len(parts))
-	}
-
-	h, err := builtinBase64UrlDecode(ast.String(parts[0]))
+	h, err := builtinBase64UrlDecode(ast.String(token.header))
 	if err != nil {
 		return nil, fmt.Errorf("JWT header had invalid encoding: %v", err)
 	}
@@ -52,7 +55,7 @@ func builtinJWTDecode(a ast.Value) (ast.Value, error) {
 		return nil, err
 	}
 
-	p, err := builtinBase64UrlDecode(ast.String(parts[1]))
+	p, err := builtinBase64UrlDecode(ast.String(token.payload))
 	if err != nil {
 		return nil, fmt.Errorf("JWT payload had invalid encoding: %v", err)
 	}
@@ -81,7 +84,7 @@ func builtinJWTDecode(a ast.Value) (ast.Value, error) {
 		return nil, err
 	}
 
-	s, err := builtinBase64UrlDecode(ast.String(parts[2]))
+	s, err := builtinBase64UrlDecode(ast.String(token.signature))
 	if err != nil {
 		return nil, fmt.Errorf("JWT signature had invalid encoding: %v", err)
 	}
@@ -97,24 +100,11 @@ func builtinJWTDecode(a ast.Value) (ast.Value, error) {
 
 // Implements RS256 JWT signature verification
 func builtinJWTVerifyRS256(a ast.Value, b ast.Value) (ast.Value, error) {
-
-	// Process the token
-	astToken, err := builtins.StringOperand(a, 1)
+	// Decode the JSON Web Token
+	token, err := decodeJWT(a)
 	if err != nil {
 		return nil, err
 	}
-	token := string(astToken)
-	parts := strings.Split(token, ".")
-	if len(parts) != 3 {
-		return nil, fmt.Errorf("encoded JWT must have 3 sections, found %d", len(parts))
-	}
-
-	headerPayload := []byte(strings.Join(parts[:2], "."))
-	sign, err := builtinBase64UrlDecode(ast.String(parts[2]))
-	if err != nil {
-		return nil, err
-	}
-	signature := []byte(sign.(ast.String))
 
 	// Process PEM encoded certificate input
 	astCertificate, err := builtins.StringOperand(b, 2)
@@ -137,13 +127,84 @@ func builtinJWTVerifyRS256(a ast.Value, b ast.Value) (ast.Value, error) {
 	// Get public key
 	publicKey := cert.PublicKey.(*rsa.PublicKey)
 
+	signature, err := token.decodeSignature()
+	if err != nil {
+		return nil, err
+	}
+
 	// Validate the JWT signature
-	err = rsa.VerifyPKCS1v15(publicKey, crypto.SHA256, getInputSHA(headerPayload), signature)
+	err = rsa.VerifyPKCS1v15(
+		publicKey,
+		crypto.SHA256,
+		getInputSHA([]byte(token.header+"."+token.payload)),
+		[]byte(signature))
 
 	if err != nil {
 		return ast.Boolean(false), nil
 	}
 	return ast.Boolean(true), nil
+}
+
+// Implements HS256 (secret) JWT signature verification
+func builtinJWTVerifyHS256(a ast.Value, b ast.Value) (ast.Value, error) {
+	// Decode the JSON Web Token
+	token, err := decodeJWT(a)
+	if err != nil {
+		return nil, err
+	}
+
+	// Process Secret input
+	astSecret, err := builtins.StringOperand(b, 2)
+	if err != nil {
+		return nil, err
+	}
+	secret := string(astSecret)
+
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, err = mac.Write([]byte(token.header + "." + token.payload))
+	if err != nil {
+		return nil, err
+	}
+
+	signature, err := token.decodeSignature()
+	if err != nil {
+		return nil, err
+	}
+
+	return ast.Boolean(hmac.Equal([]byte(signature), mac.Sum(nil))), nil
+}
+
+func decodeJWT(a ast.Value) (*JSONWebToken, error) {
+	// Parse the JSON Web Token
+	astEncode, err := builtins.StringOperand(a, 1)
+	if err != nil {
+		return nil, err
+	}
+
+	encoding := string(astEncode)
+	if !strings.Contains(encoding, ".") {
+		return nil, errors.New("encoded JWT had no period separators")
+	}
+
+	parts := strings.Split(encoding, ".")
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("encoded JWT must have 3 sections, found %d", len(parts))
+	}
+
+	return &JSONWebToken{header: parts[0], payload: parts[1], signature: parts[2]}, nil
+}
+
+func (token *JSONWebToken) decodeSignature() (string, error) {
+	decodedSignature, err := builtinBase64UrlDecode(ast.String(token.signature))
+	if err != nil {
+		return "", err
+	}
+
+	signatureAst, err := builtins.StringOperand(decodedSignature, 1)
+	if err != nil {
+		return "", err
+	}
+	return string(signatureAst), err
 }
 
 // Extract, validate and return the JWT header as an ast.Object.
@@ -196,4 +257,5 @@ func getInputSHA(input []byte) (hash []byte) {
 func init() {
 	RegisterFunctionalBuiltin1(ast.JWTDecode.Name, builtinJWTDecode)
 	RegisterFunctionalBuiltin2(ast.JWTVerifyRS256.Name, builtinJWTVerifyRS256)
+	RegisterFunctionalBuiltin2(ast.JWTVerifyHS256.Name, builtinJWTVerifyHS256)
 }

--- a/topdown/topdown_test.go
+++ b/topdown/topdown_test.go
@@ -1614,6 +1614,65 @@ func TestTopDownJWTVerifyRS256(t *testing.T) {
 	}
 }
 
+func TestTopDownJWTVerifyHS256(t *testing.T) {
+	params := []struct {
+		note   string
+		input1 string
+		input2 string
+		result bool
+		err    string
+	}{
+		{
+			"success",
+			`eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyIjoiYWxpY2UiLCJhenAiOiJhbGljZSIsInN1Ym9yZGluYXRlcyI6W10sImhyIjpmYWxzZX0.rz3jTY033z-NrKfwrK89_dcLF7TN4gwCMj-fVBDyLoM`,
+			"secret",
+			true,
+			"",
+		},
+		{
+			"failure-bad token",
+			`eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyIjoiYWxpY2UiLCJhenAiOiJhbGljZSIsInN1Ym9yZGluYXRlcyI6W10sImhyIjpmYWxzZX0.R0NDxM1gHTucWQKwayMDre2PbMNR9K9efmOfygDZWcE`,
+			"secret",
+			false,
+			"",
+		},
+		{
+			"failure-invalid token",
+			`eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyIjoiYWxpY2UiLCJhenAiOiJhbGljZSIsInN1Ym9yZGluYXRlcyI6W10sImhyIjpmYWxzZX0`,
+			"secret",
+			false,
+			"encoded JWT must have 3 sections, found 2",
+		},
+	}
+
+	type test struct {
+		note     string
+		rules    []string
+		expected interface{}
+	}
+	tests := []test{}
+
+	for _, p := range params {
+		var exp interface{}
+		exp = fmt.Sprintf(`%t`, p.result)
+		if p.err != "" {
+			exp = errors.New(p.err)
+		}
+
+		tests = append(tests, test{
+			p.note,
+			[]string{fmt.Sprintf(`p = x { io.jwt.verify_hs256("%s", "%s", x) }`, p.input1, p.input2)},
+			exp,
+		})
+	}
+
+	data := loadSmallTestData()
+
+	for _, tc := range tests {
+		runTopDownTestCase(t, data, tc.note, tc.rules, tc.expected)
+	}
+}
+
 func TestTopDownTime(t *testing.T) {
 
 	data := loadSmallTestData()


### PR DESCRIPTION
Signed-off-by: Henri Bouvier <henribouvier@yahoo.com>

Thanks for the review, I appreciate it.

Pull request feedback:
[x] (@tsandall) verify_secret was renamed to verify_hs256 in builtins.go
[x] (@tsandall) language-reference.md correct the naming from rs256 to hs256
[x] (@srenatus) corrected the comment of the HS256 JWT verification function
[x] (@srenatus) refactored common code from builtinJWTDecode, builtinJWTVerifyRS256 and builtinJWTVerifyHS256 into decodeJWT() and decodeSignature()
[x] (@srenatus) verify and bubble up error from io.writer
[x] (@srenatus) simplify returning result (remove unnecessary if condition)

NOTES:
- I realize that re-creating the pull request was probably not the best way of doing this (e.g. we will lose the review comments/feedback). Therefore, I tried to keep track of them in the above list. I guess the proper way of addressing the feedback is to add commits to the pull request?

