### PR TITLE
fix new go scorecard issues

### DIFF
--- a/ast/parser_internal.go
+++ b/ast/parser_internal.go
@@ -151,7 +151,7 @@ func makeRule(loc *Location, head, rest interface{}) (interface{}, error) {
 	sl := rest.([]interface{})
 
 	rules := []*Rule{
-		&Rule{
+		{
 			Location: loc,
 			Head:     head.(*Head),
 			Body:     sl[0].(Body),

--- a/cover/cover_test.go
+++ b/cover/cover_test.go
@@ -67,16 +67,16 @@ baz {     # expect no exit
 	}
 
 	expectedCovered := []Position{
-		Position{5},              // foo head
-		Position{6}, Position{7}, // foo body
-		Position{10},                             // bar head
-		Position{11}, Position{12}, Position{13}, // bar body
-		Position{17}, // baz body hits
+		{5},      // foo head
+		{6}, {7}, // foo body
+		{10},             // bar head
+		{11}, {12}, {13}, // bar body
+		{17}, // baz body hits
 	}
 
 	expectedNotCovered := []Position{
-		Position{16}, // baz head
-		Position{19}, // baz body miss
+		{16}, // baz head
+		{19}, // baz body miss
 	}
 
 	for _, exp := range expectedCovered {

--- a/server/server.go
+++ b/server/server.go
@@ -936,6 +936,10 @@ func (s *Server) v1DataDelete(w http.ResponseWriter, r *http.Request) {
 	}
 
 	_, err = s.store.Read(ctx, txn, path)
+	if err != nil {
+		s.abortAuto(ctx, txn, w, err)
+		return
+	}
 
 	if err := s.store.Write(ctx, txn, storage.RemoveOp, path, nil); err != nil {
 		s.abortAuto(ctx, txn, w, err)

--- a/topdown/save.go
+++ b/topdown/save.go
@@ -171,7 +171,7 @@ type saveStack struct {
 func newSaveStack() *saveStack {
 	return &saveStack{
 		Stack: []saveStackQuery{
-			saveStackQuery{},
+			{},
 		},
 	}
 }


### PR DESCRIPTION
Follow-up to #770. Hadn't realised I was fixing a 5-month-old view of the code when I did that. (goscorecard required manual refreshes, by clicking a button on the site.)

It really doesn't matter, but this PR should get us to 100% for all but go vet and gocyclo.