### PR TITLE
Tweak urlquery.encode_object implementation

### DIFF
--- a/ast/builtins.go
+++ b/ast/builtins.go
@@ -722,11 +722,19 @@ var URLQueryEncode = &Builtin{
 	),
 }
 
-// URLQueryEncodeObject encodes the given JSON into a URL encoded query string
+// URLQueryEncodeObject encodes the given JSON into a URL encoded query string.
 var URLQueryEncodeObject = &Builtin{
 	Name: "urlquery.encode_object",
 	Decl: types.NewFunction(
-		types.Args(types.A),
+		types.Args(
+			types.NewObject(
+				nil,
+				types.NewDynamicProperty(
+					types.S,
+					types.NewAny(
+						types.S,
+						types.NewArray(nil, types.S),
+						types.NewSet(types.S))))),
 		types.S,
 	),
 }

--- a/topdown/encoding.go
+++ b/topdown/encoding.go
@@ -123,42 +123,39 @@ func builtinURLQueryDecode(a ast.Value) (ast.Value, error) {
 	return ast.String(s), nil
 }
 
+var encodeObjectErr = builtins.NewOperandErr(1, "values must be string, array[string], or set[string]")
+
 func builtinURLQueryEncodeObject(a ast.Value) (ast.Value, error) {
 	asJSON, err := ast.JSON(a)
 	if err != nil {
 		return nil, err
 	}
 
-	// type assert on underlying structure
 	inputs, ok := asJSON.(map[string]interface{})
 	if !ok {
-		return nil, fmt.Errorf("invalid JSON format")
+		return nil, builtins.NewOperandTypeErr(1, a, "object")
 	}
 
 	query := url.Values{}
 
-	// loop over the inner items of the map, understanding what type they are
 	for k, v := range inputs {
 		switch vv := v.(type) {
 		case string:
-			// single value for a key
 			query.Set(k, vv)
 		case []interface{}:
-			// multiple values for the key, add all of them
 			for _, val := range vv {
 				strVal, ok := val.(string)
 				if !ok {
-					return nil, fmt.Errorf("only arrays of strings are permitted as values")
+					return nil, encodeObjectErr
 				}
 				query.Add(k, strVal)
 			}
 		default:
+			return nil, encodeObjectErr
 		}
 	}
 
-	// encoded version of these values
-	str := fmt.Sprintf("%v", query.Encode())
-	return ast.String(str), nil
+	return ast.String(query.Encode()), nil
 }
 
 func builtinYAMLMarshal(a ast.Value) (ast.Value, error) {

--- a/topdown/topdown_test.go
+++ b/topdown/topdown_test.go
@@ -1390,7 +1390,13 @@ func TestTopDownURLBuiltins(t *testing.T) {
 		expected interface{}
 	}{
 		{"encode", []string{`p = x { urlquery.encode("a=b+1", x) }`}, `"a%3Db%2B1"`},
+		{"encode empty", []string{`p = x { urlquery.encode("", x) }`}, `""`},
 		{"decode", []string{`p = x { urlquery.decode("a%3Db%2B1", x) }`}, `"a=b+1"`},
+		{"encode_object empty", []string{`p = x { urlquery.encode_object({}, x) }`}, `""`},
+		{"encode_object strings", []string{`p = x { urlquery.encode_object({"a": "b", "c": "d"}, x) }`}, `"a=b&c=d"`},
+		{"encode_object escape", []string{`p = x { urlquery.encode_object({"a": "c=b+1"}, x) }`}, `"a=c%3Db%2B1"`},
+		{"encode_object array", []string{`p = x { urlquery.encode_object({"a": ["b+1","c+2"]}, x) }`}, `"a=b%2B1&a=c%2B2"`},
+		{"encode_object set", []string{`p = x { urlquery.encode_object({"a": {"b+1"}}, x) }`}, `"a=b%2B1"`},
 	}
 
 	data := loadSmallTestData()


### PR DESCRIPTION
These changes just update the built-in declaration to include types for
the call argument and refactor the errors returned by the built-in
implementation to use the helpers in topdown.builtins.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>