### PR TITLE
Fix query to path conversion in decision logger

### DIFF
--- a/plugins/logs/plugin.go
+++ b/plugins/logs/plugin.go
@@ -166,7 +166,7 @@ func (p *Plugin) Log(ctx context.Context, decision *server.Info) {
 
 	var buf bytes.Buffer
 
-	path := strings.Replace(strings.TrimLeft(decision.Query, "data."), ".", "/", -1)
+	path := strings.Replace(strings.TrimPrefix(decision.Query, "data."), ".", "/", -1)
 
 	event := EventV1{
 		Labels:      p.manager.Labels,

--- a/plugins/logs/plugin_test.go
+++ b/plugins/logs/plugin_test.go
@@ -38,7 +38,7 @@ func TestPluginStart(t *testing.T) {
 		fixture.plugin.Log(ctx, &server.Info{
 			Revision:   "a",
 			DecisionID: fmt.Sprint(i),
-			Query:      "data.foo.bar",
+			Query:      "data.tda.bar",
 			Input:      map[string]interface{}{"method": "GET"},
 			Results:    &result,
 			RemoteAddr: "test",
@@ -69,7 +69,7 @@ func TestPluginStart(t *testing.T) {
 		},
 		Revision:    "a",
 		DecisionID:  "153",
-		Path:        "foo/bar",
+		Path:        "tda/bar",
 		Input:       &expInput,
 		Result:      &result,
 		RequestedBy: "test",


### PR DESCRIPTION
The decision logger was using strings.TrimLeft when it should have been
using strings.TrimPrefix. As a result, the prefix was not being trimmed
correctly--leading characters in the cutset "data." were being removed.

Fixes #783