### PR TITLE
Remove decision log buffer limit

### DIFF
--- a/docs/book/decision_logs.md
+++ b/docs/book/decision_logs.md
@@ -59,7 +59,7 @@ decision_logs:
 | `labels` | No |  Set of key-value pairs that uniquely identify the OPA instance. |
 | `decision_logs.service` | Yes | Name of the service to use to contact remote server. |
 | `decision_logs.partition_name` | No | Path segment to include in status updates. |
-| `decision_logs.reporting.buffer_size_limit_bytes` | No | Decision log buffer size limit in bytes. OPA will drop old events from the log if this limit is exceeded. |
+| `decision_logs.reporting.buffer_size_limit_bytes` | No | Decision log buffer size limit in bytes. OPA will drop old events from the log if this limit is exceeded. By default, no limit is set. |
 | `decision_logs.reporting.upload_size_limit_bytes` | No | Decision log upload size limit in bytes. OPA will chunk uploads to cap message body to this limit. |
 | `decision_logs.reporting.min_delay_seconds` | No | Minimum amount of time to wait between uploads. |
 | `decision_logs.reporting.max_delay_seconds` | No | Maximum amount of time to wait between uploads. |

--- a/plugins/logs/buffer.go
+++ b/plugins/logs/buffer.go
@@ -32,11 +32,13 @@ func newLogBuffer(limit int64) *logBuffer {
 func (lb *logBuffer) Push(bs []byte) (dropped int) {
 	size := int64(len(bs))
 
-	for elem := lb.l.Front(); elem != nil && (lb.usage+size > lb.limit); elem = elem.Next() {
-		drop := elem.Value.(logBufferElem).bs
-		lb.l.Remove(elem)
-		lb.usage -= int64(len(drop))
-		dropped++
+	if lb.limit > 0 {
+		for elem := lb.l.Front(); elem != nil && (lb.usage+size > lb.limit); elem = elem.Next() {
+			drop := elem.Value.(logBufferElem).bs
+			lb.l.Remove(elem)
+			lb.usage -= int64(len(drop))
+			dropped++
+		}
 	}
 
 	elem := logBufferElem{bs}

--- a/plugins/logs/plugin.go
+++ b/plugins/logs/plugin.go
@@ -39,8 +39,8 @@ const (
 	minRetryDelay               = time.Millisecond * 100
 	defaultMinDelaySeconds      = int64(300)
 	defaultMaxDelaySeconds      = int64(600)
-	defaultUploadSizeLimitBytes = int64(32768)     // 32KB limit
-	defaultBufferSizeLimitBytes = int64(104857600) // 100MB limit
+	defaultUploadSizeLimitBytes = int64(32768) // 32KB limit
+	defaultBufferSizeLimitBytes = int64(0)     // unlimited
 )
 
 // ReportingConfig represents configuration for the plugin's reporting behaviour.


### PR DESCRIPTION
This change removes the default decision log buffer limit to avoid
unintentionally dropping decision logs. If users are concerned about
memory usage they can set the limit, but by default they will not be
surprised by log discards.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>