### PR TITLE
Add basic copy propagation optimization

### DIFF
--- a/topdown/copy_propagator.go
+++ b/topdown/copy_propagator.go
@@ -1,0 +1,211 @@
+// Copyright 2018 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package topdown
+
+import (
+	"github.com/open-policy-agent/opa/ast"
+)
+
+// copyPropagator implements a simple copy propagation optimization to remove
+// intermediate variables in partial evaluation results.
+//
+// For example, given the query: input.x > 1 where 'input' is unknown, the
+// compiled query would become input.x = a; a > 1 which would remain in the
+// partial evaluation result. The copyPropagator implementation will remove the
+// variable assignment so that partial evaluation simply outputs input.x > 1.
+//
+// In many cases, copy propagation can remove all variables from the result of
+// partial evaluation which simplifies evaluation for non-OPA consumers.
+//
+// In some cases, copy propagation cannot remove all variables. If the output of
+// a built-in call is subsequently used as a ref head, the output variable must
+// be kept. For example. sort(input, x); x[0] == 1. In this case, copy
+// propagation cannot replace x[0] == 1 with sort(input, x)[0] == 1 as this is
+// not legal.
+type copyPropagator struct {
+	liveSet ast.VarSet // vars that cannot be removed.
+}
+
+func newCopyPropagator(callerQuery ast.Body) *copyPropagator {
+
+	liveSet := ast.NewVarSet()
+
+	ast.WalkVars(callerQuery, func(v ast.Var) bool {
+		if !v.IsGenerated() {
+			liveSet.Add(v)
+		}
+		return false
+	})
+
+	return &copyPropagator{
+		liveSet: liveSet,
+	}
+}
+
+func (p *copyPropagator) Apply(query ast.Body) (result ast.Body) {
+
+	headSet := newHeadSet(query)
+	killed := map[ast.Var]*ast.Term{} // vars to substitute with other values.
+
+	for _, expr := range query {
+		p.substitute(killed, expr)
+		if v, t, kill := p.check(headSet, expr); kill {
+			killed[v] = t
+		} else {
+			result.Append(expr)
+		}
+	}
+
+	return
+}
+
+func (p *copyPropagator) substitute(killed map[ast.Var]*ast.Term, x interface{}) {
+	ast.WalkTerms(x, func(t *ast.Term) bool {
+		switch v := t.Value.(type) {
+		case ast.Var:
+			if v2, ok := killed[v]; ok {
+				t.Value = v2.Value
+				return true
+			}
+		case ast.Ref:
+			// Refs require special handling. if the head var has been killed, the ref
+			// head has to be substituted by concatenating the corresponding term with
+			// the rest of the ref. For example, given:
+			//
+			// ref: ref(x, 0) and binding: x/ref(input, "foo")
+			//
+			// The result should be ref(input, "foo", 0) and not ref(ref(input, "foo"), 0).
+			if v2, ok := killed[v[0].Value.(ast.Var)]; ok {
+				// Invariant: killed vars are always bound to refs. Vars are never bound to
+				// calls if they are subsequently used as ref heads.
+				r := v2.Value.(ast.Ref)
+				var concat ast.Ref
+				for i := 0; i < len(r); i++ {
+					concat = append(concat, r[i])
+				}
+				for i := 1; i < len(v); i++ {
+					concat = append(concat, v[i])
+				}
+				t.Value = concat
+			}
+			for i := 1; i < len(v); i++ {
+				p.substitute(killed, v[i])
+			}
+			return true
+		}
+		return false
+	})
+}
+
+func (p *copyPropagator) check(headSet *headSet, expr *ast.Expr) (v ast.Var, t *ast.Term, kill bool) {
+
+	if expr.IsEquality() {
+		a, b := expr.Operand(0), expr.Operand(1)
+		v, t, kill = p.checkEq(a, b)
+		if kill {
+			return
+		}
+		v, t, kill = p.checkEq(b, a)
+		return
+	}
+
+	if expr.IsCall() {
+		terms := expr.Terms.([]*ast.Term)
+		output := terms[len(terms)-1]
+		av, isVar := output.Value.(ast.Var)
+		if !isVar || p.liveSet.Contains(av) || headSet.Connected(av) {
+			return
+		}
+		return av, ast.CallTerm(terms[:len(terms)-1]...), true
+	}
+
+	return
+}
+
+func (p *copyPropagator) checkEq(a, b *ast.Term) (v ast.Var, t *ast.Term, kill bool) {
+
+	av, isVar := a.Value.(ast.Var)
+	if !isVar || p.liveSet.Contains(av) {
+		return
+	}
+
+	switch b.Value.(type) {
+	case ast.Ref, ast.Call:
+		break
+	default:
+		return
+	}
+	return av, b, true
+}
+
+type headSet struct {
+	headVars ast.VarSet
+	parents  map[ast.Var]ast.Var
+}
+
+func newHeadSet(query ast.Body) *headSet {
+
+	s := &headSet{
+		parents:  map[ast.Var]ast.Var{},
+		headVars: ast.NewVarSet(),
+	}
+
+	for _, expr := range query {
+		if expr.IsEquality() {
+			a, b := expr.Operand(0), expr.Operand(1)
+			va, ok1 := a.Value.(ast.Var)
+			vb, ok2 := b.Value.(ast.Var)
+			if ok1 && ok2 {
+				s.merge(va, vb)
+			}
+		}
+		ast.WalkRefs(expr, func(v ast.Ref) bool {
+			s.headVars.Add(v[0].Value.(ast.Var))
+			return false
+		})
+	}
+
+	return s
+}
+
+func (s *headSet) Connected(v ast.Var) bool {
+	for head := range s.headVars {
+		if head == v {
+			return true
+		}
+		r1, ok1 := s.find(v)
+		r2, ok2 := s.find(head)
+		if ok1 && ok2 && r1 == r2 {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *headSet) merge(x, y ast.Var) {
+	r1 := s.makeSet(x)
+	r2 := s.makeSet(y)
+	if r1 != r2 {
+		s.parents[r1] = r2
+	}
+}
+
+func (s *headSet) find(x ast.Var) (ast.Var, bool) {
+	if parent, ok := s.parents[x]; ok {
+		if parent == x {
+			return parent, true
+		}
+		return s.find(parent)
+	}
+	return "", false
+}
+
+func (s *headSet) makeSet(x ast.Var) ast.Var {
+	if root, ok := s.find(x); ok {
+		return root
+	}
+	s.parents[x] = x
+	return x
+}

--- a/topdown/query.go
+++ b/topdown/query.go
@@ -145,6 +145,9 @@ func (q *Query) PartialRun(ctx context.Context) (partials []ast.Body, support []
 	}
 	q.startTimer(metrics.RegoPartialEval)
 	defer q.stopTimer(metrics.RegoPartialEval)
+
+	p := newCopyPropagator(q.query)
+
 	err = e.Run(func(e *eval) error {
 		// Build output from saved expressions.
 		body := ast.NewBody()
@@ -165,6 +168,7 @@ func (q *Query) PartialRun(ctx context.Context) (partials []ast.Body, support []
 		for i := range bindingExprs {
 			body.Append(bindingExprs[i])
 		}
+		body = p.Apply(body)
 		partials = append(partials, body)
 		return nil
 	})

--- a/topdown/topdown_partial_test.go
+++ b/topdown/topdown_partial_test.go
@@ -186,7 +186,7 @@ func TestTopDownPartialEval(t *testing.T) {
 				p[x] { x = {y: z}; y = "bar"; z = input.x }`,
 			},
 			wantQueries: []string{
-				`z1 = input.x; z1 = 1; x = {"foo": z1}`,
+				`input.x = 1; x = {"foo": input.x}`,
 			},
 		},
 		{
@@ -198,7 +198,7 @@ func TestTopDownPartialEval(t *testing.T) {
 				p = x { input.x = x }`,
 			},
 			wantQueries: []string{
-				`input.x = x1; x1 = 1`,
+				`input.x = 1`,
 			},
 		},
 		{
@@ -209,7 +209,7 @@ func TestTopDownPartialEval(t *testing.T) {
 				 p = 1 { input.y = x; x = 2 }`,
 			},
 			wantQueries: []string{
-				`input.y = x1; x1 = 2; 1 = x`,
+				`input.y = 2; 1 = x`,
 			},
 		},
 		{
@@ -220,7 +220,7 @@ func TestTopDownPartialEval(t *testing.T) {
 				p = x { input.x = x }`,
 			},
 			wantQueries: []string{
-				`input.x = x1; x1 = x`,
+				`input.x = x`,
 			},
 		},
 		{
@@ -231,7 +231,7 @@ func TestTopDownPartialEval(t *testing.T) {
 				p[[y, x]] { input.z = z; z = y; a = input.a; a = x }`,
 			},
 			wantQueries: []string{
-				`input.z = z1; z1 = x; a1 = input.a; a1 = y; x_term_0_0 = [x, y]`,
+				`input.z = x; input.a = y; x_term_0_0 = [x, y]`,
 			},
 		},
 		{
@@ -265,7 +265,7 @@ func TestTopDownPartialEval(t *testing.T) {
 				q = x { input.y = y; x =  y }`,
 			},
 			wantQueries: []string{
-				`input.x = y1; y1 = x1; input.y = y2; x2 = y2; x2 = z1; [x1, z1] = x`,
+				`[input.x, input.y] = x`,
 			},
 		},
 		{
@@ -282,7 +282,7 @@ func TestTopDownPartialEval(t *testing.T) {
 				`,
 			},
 			wantQueries: []string{
-				`b1 = input.b; "a" != b1; x = true`,
+				`"a" != input.b; x = true`,
 			},
 		},
 		{
@@ -293,11 +293,11 @@ func TestTopDownPartialEval(t *testing.T) {
 
 				p {
 					input = x
-					x[0] = true
+					x.foo = true
 				}`,
 			},
 			wantQueries: []string{
-				`input = x1; x1[0] = true; true = x`,
+				`input.foo = true; true = x`,
 			},
 		},
 		{
@@ -357,7 +357,7 @@ func TestTopDownPartialEval(t *testing.T) {
 				q = y { y = input.y }`,
 			},
 			wantQueries: []string{
-				`data.test.p = 1; y1 = input.y; y1 = 2`,
+				`data.test.p = 1; input.y = 2`,
 			},
 			unknowns: []string{
 				"input",
@@ -407,7 +407,7 @@ func TestTopDownPartialEval(t *testing.T) {
 			wantQueries: []string{
 				`data.test.s = y; x = "s"`,
 				`data.test.p = y; x = "p"`,
-				`x1 = input.x; x1 = y; x = "r"`,
+				`input.x = y; x = "r"`,
 			},
 		},
 		{
@@ -438,7 +438,7 @@ func TestTopDownPartialEval(t *testing.T) {
 				q = 100 { false } else = 200 { true }`,
 			},
 			wantQueries: []string{
-				`data.test.q = x1; x1 = x`,
+				`data.test.q = x`,
 			},
 		},
 		{
@@ -684,6 +684,83 @@ func TestTopDownPartialEval(t *testing.T) {
 
 				__not0_2__(x, y) { 0 = x; 1 = y }
 				__not0_2__(x, y) { 2 = x; 3 = y }`,
+			},
+		},
+		{
+			note:  "copy propagation: basic",
+			query: "input.x > 1",
+			wantQueries: []string{
+				"input.x > 1",
+			},
+		},
+		{
+			note:  "copy propagation: call terms",
+			query: "input.x+1 > 1",
+			wantQueries: []string{
+				"input.x+1 > 1",
+			},
+		},
+		{
+			note:  "copy propagation: virtual",
+			query: "data.test.p > 1",
+			modules: []string{
+				`package test
+
+				p = x { input.x = y; y = z; z = x }`,
+			},
+			wantQueries: []string{
+				`input.x > 1`,
+			},
+		},
+		{
+			note:  "copy propagation: virtual: call",
+			query: "data.test.p > 1",
+			modules: []string{
+				`package test
+
+				p = y { input.x = x; plus(x, 1, y) }`,
+			},
+			wantQueries: []string{
+				`input.x+1 > 1`,
+			},
+		},
+		{
+			note:  "copy propagation: composite",
+			query: "data.test.p[0][0] = 1",
+			modules: []string{
+				`package test
+
+				p = x { x = [input.x] }
+				`,
+			},
+			wantQueries: []string{
+				`input.x[0] = 1`,
+			},
+		},
+		{
+			note:  "copy propagation: reference head",
+			query: "data.test.p[0] > 1",
+			modules: []string{
+				`package test
+
+				p = x { input.x = x }`,
+			},
+			wantQueries: []string{
+				`input.x[0] > 1`,
+			},
+		},
+		{
+			note:  "copy propagation: reference head: call",
+			query: "data.test.p[0] > 1",
+			modules: []string{
+				`package test
+
+				p = x { sort(input.x, y); y = x }`,
+			},
+			wantQueries: []string{
+				// copy propagation cannot remove the intermediate variable currently because
+				// sort(input.x, y) is not killed (since y is ultimately used as a ref head.)
+				`sort(input.x, y1); y1 = x1; x1[0] > 1`,
 			},
 		},
 	}


### PR DESCRIPTION
These changes add a basic optimization to the result of partial
evaluation: copy propagation. Copy propagation removes unnecessary
variable assignments/intermediate variables from the query. In many
cases, this will completely remove all variables from the queries
returned by partial evaluation (leaving only references, scalars, and
composites.) This will be easier for non-OPA consumers to process as
they will not have to reason about variable assignments.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>