### PR TITLE
Fix 794: update error status when transient errors pass

### DIFF
--- a/plugins/bundle/plugin.go
+++ b/plugins/bundle/plugin.go
@@ -294,7 +294,6 @@ func (p *Plugin) activate(ctx context.Context, b bundle.Bundle) error {
 		}
 
 		if err := p.writeManifest(ctx, txn, b.Manifest); err != nil {
-			fmt.Println("manifest write err:", err)
 			return err
 		}
 


### PR DESCRIPTION
See second commit for detailed description.