### PR TITLE
`(*Rego).Partial()` with default values

### DIFF
--- a/rego/example_test.go
+++ b/rego/example_test.go
@@ -538,6 +538,8 @@ func ExampleRego_Partial() {
 	// Define a simple policy for example purposes.
 	module := `package test
 
+	default allow = false
+
 	allow {
 		input.method = read_methods[_]
 		input.path = ["reviews", user]

--- a/rego/example_test.go
+++ b/rego/example_test.go
@@ -605,7 +605,7 @@ func ExampleRego_PartialWithOtherUnknowns() {
 	input["path"] = []string{"reviews", "alice"}
 
 	r := rego.New(
-		rego.Query("data.test.allow"),
+		rego.Query("data.test.allow == true"),
 		rego.Module("example.rego", module),
 		rego.Input(input),
 		rego.Unknowns([]string{}), // we know the input

--- a/rego/example_test.go
+++ b/rego/example_test.go
@@ -563,6 +563,9 @@ func ExampleRego_Partial() {
 	for i := range pq.Queries {
 		fmt.Printf("Query #%d: %v\n", i+1, pq.Queries[i])
 	}
+	for i := range pq.Support {
+		fmt.Printf("Support #%d: %v\n", i+1, pq.Support[i])
+	}
 
 	// Output:
 	//


### PR DESCRIPTION
This result seems a bit odd to me. First pushing the commit to show that it works now, and then the change to trigger the odd behaviour.

Concretely, when adding
```
default allow = false
```
to the test module, the output that was
```
Query #1: "GET" = input.method; input.path = ["reviews", _]; neq(input.is_admin, false)
Query #2: "GET" = input.method; input.path = ["reviews", user3]; user3 = input.user
```
becomes
```
Query #1: equal(data.partial.test.allow, true)
Support #1: package partial.test

allow = true { "GET" = input.method; input.path = ["reviews", _]; input.is_admin = _; neq(_, false) }
allow = true { "GET" = input.method; input.path = ["reviews", user]; input.user = user }
default allow = false
```

So, it seems to be adding a layer of indirection.

To illustrate why this seems odd, I've added an example that is closer to our real-world usage, and its output is
```
Query #1: neq(data.partial.test.allow, false)
Support #1: package partial.test

allow = true { true }
default allow = false
```

it seems like this could be further reduced -- am I wrong? I'm not sure if this really is a variant of #709 .