### PR TITLE
Fix copy propagation substitution for ref heads

### DIFF
--- a/topdown/topdown_partial_test.go
+++ b/topdown/topdown_partial_test.go
@@ -785,6 +785,35 @@ func TestTopDownPartialEval(t *testing.T) {
 				`input.x = ["foo", a1]; a1 = input.y`,
 			},
 		},
+		{
+			note:  "copy propagation: union-find replace head",
+			query: "data.test.p = true",
+			modules: []string{
+				`package test
+
+				p {
+					input = y
+					x = y
+					x.foo = 1
+				}`,
+			},
+			wantQueries: []string{`input.foo = 1`},
+		},
+		{
+			note:  "copy propagation: union-find skip ref head",
+			query: "data.test.p = true",
+			modules: []string{
+				`package test
+
+				p {
+					input = y
+					x = y
+					x.foo = 1
+					x = {"foo": 1}
+				}`,
+			},
+			wantQueries: []string{`input.foo = 1; input = {"foo": 1}`},
+		},
 	}
 
 	ctx := context.Background()


### PR DESCRIPTION
Previously, copy propagation was not substituting ref heads with the
root from the union-find structure. The result was inconsistent queries
being returned. Ref heads were not substituted because the visitor
short-circuits on refs to apply the binding list and then only recurses
on the tail terms.

With these changes, copy propagation substitutes vars and ref heads with
the union-find roots at the same time.

Secondly, these changes fix buggy logic for setting the union-find root
constant. Previously, if the root constant was non-nil, and the copy
propagator tried to unset it, the check would fail and be silently
ignored. In this case, removing the helper function makes the logic
clearer and fixes the bug.

Fixes #816

Signed-off-by: Torin Sandall <torinsandall@gmail.com>