### PR TITLE
Add profiler to OPA eval command

### DIFF
--- a/docs/book/SUMMARY.md
+++ b/docs/book/SUMMARY.md
@@ -110,6 +110,7 @@
   * [Decision Logs](decision_logs.md)
     * [Configuration](decision_logs.md#decision-log-configuration)
     * [Service API](decision_logs.md#decision-log-service-api)
+  * [Profiler](profiler.md)
   * [Monitoring & Diagnostics](monitoring-diagnostics.md)
     * [Prometheus](monitoring-diagnostics.md#prometheus)
     * [Diagnostics](monitoring-diagnostics.md#prometheus)

--- a/docs/book/book.json
+++ b/docs/book/book.json
@@ -5,7 +5,8 @@
     "collapsible-menu",
     "custom-favicon",
     "ga",
-    "-fontsettings"
+    "-fontsettings",
+    "ace"
   ],
   "pluginsConfig": {
     "layout": {

--- a/docs/book/profiler.md
+++ b/docs/book/profiler.md
@@ -1,0 +1,324 @@
+# Profiler
+
+This page describes how to use the code profiler for Rego. The Profiler
+captures the following information about Rego expressions:
+
+  * Expression Time
+  * Number of Evaluations
+  * Number of Re-Evaluations (Redo)
+  * Expression Location in source code
+
+OPA's `eval` command provides the following profiler options
+
+| Command line Option        | Detail                                                        | Default |
+|:--------------------------:|:-------------------------------------------------------------:|:-----:|
+| `profile`                  | Returns profiling results sorted by the default or given criteria              | NA |
+| `profile-sort`             | Criteria to sort the expression profiling results. This options implies `--profile`. |  total_time_ns => num_eval => num_redo => file => line |
+| `profile-limit`            | Desired number of profiling results sorted on the given criteria. This options implies `--profile`. |  10 |
+
+## Sort criteria for the profile results
+  * `total_time_ns` - Results are displayed is decreasing order of _expression evaluation time_
+  * `num_eval`  - Results are displayed is decreasing order of _number of times an expression is evaluated_
+  * `num_redo`  - Results are displayed is decreasing order of _number of times an expression is re-evaluated(redo)_
+  * `file`  - Results are sorted in reverse alphabetical order based on the _rego source filename_
+  * `line`  - Results are displayed is decreasing order of _expression line number_ in the source file
+
+When the sort criteria is not provided `total_time_ns` has the **highest** priority
+while `line` has the **lowest**.
+
+#### Example Policy
+The different profiling examples shown later on this page use the below
+sample policy.
+
+{%ace edit=true, lang='python'%}
+package rbac
+
+# Example input request.
+input = {
+	"subject": "bob",
+	"resource": "foo123",
+	"action": "write",
+}
+
+# Example RBAC configuration.
+bindings = [
+	{
+		"user": "alice",
+		"roles": ["dev", "test"],
+	},
+	{
+		"user": "bob",
+		"roles": ["test"],
+	},
+]
+
+roles = [
+	{
+		"name": "dev",
+		"permissions": [
+			{"resource": "foo123", "action": "write"},
+			{"resource": "foo123", "action": "read"},
+		],
+	},
+	{
+		"name": "test",
+		"permissions": [{"resource": "foo123", "action": "read"}],
+	},
+]
+
+# Example RBAC policy implementation.
+
+default allow = false
+
+allow {
+	user_has_role[role_name]
+	role_has_permission[role_name]
+}
+
+user_has_role[role_name] {
+	binding := bindings[_]
+	binding.user = input.subject
+	role_name := binding.roles[_]
+}
+
+role_has_permission[role_name] {
+	role := roles[_]
+	role_name := role.name
+	perm := role.permissions[_]
+	perm.resource = input.resource
+	perm.action = input.action
+}
+{%endace%}
+
+#### Example: Display `ALL` profile results with `default` ordering criteria
+
+```bash
+opa eval --data foo --profile 'data.rbac.allow'
+```
+
+**Sample Profile Output**
+```json
+{
+  "profile": [
+    {
+      "total_time_ns": 38588,
+      "num_eval": 1,
+      "num_redo": 1,
+      "location": {
+        "file": "foo/rbac.rego",
+        "row": 41,
+        "col": 2
+      }
+    },
+    {
+      "total_time_ns": 32783,
+      "num_eval": 1,
+      "num_redo": 1,
+      "location": {
+        "file": "",
+        "row": 1,
+        "col": 1
+      }
+    },
+    {
+      "total_time_ns": 26262,
+      "num_eval": 1,
+      "num_redo": 1,
+      "location": {
+        "file": "foo/rbac.rego",
+        "row": 11,
+        "col": 12
+      }
+    },
+    {
+      "total_time_ns": 19181,
+      "num_eval": 2,
+      "num_redo": 1,
+      "location": {
+        "file": "foo/rbac.rego",
+        "row": 47,
+        "col": 2
+      }
+    },
+    {
+      "total_time_ns": 16817,
+      "num_eval": 1,
+      "num_redo": 1,
+      "location": {
+        "file": "foo/rbac.rego",
+        "row": 38,
+        "col": 1
+      }
+    },
+    {
+      "total_time_ns": 12827,
+      "num_eval": 1,
+      "num_redo": 2,
+      "location": {
+        "file": "foo/rbac.rego",
+        "row": 46,
+        "col": 2
+      }
+    },
+    {
+      "total_time_ns": 11176,
+      "num_eval": 1,
+      "num_redo": 1,
+      "location": {
+        "file": "foo/rbac.rego",
+        "row": 55,
+        "col": 2
+      }
+    },
+    {
+      "total_time_ns": 10275,
+      "num_eval": 1,
+      "num_redo": 0,
+      "location": {
+        "file": "foo/rbac.rego",
+        "row": 56,
+        "col": 2
+      }
+    },
+    {
+      "total_time_ns": 10274,
+      "num_eval": 1,
+      "num_redo": 2,
+      "location": {
+        "file": "foo/rbac.rego",
+        "row": 52,
+        "col": 2
+      }
+    },
+    {
+      "total_time_ns": 9304,
+      "num_eval": 1,
+      "num_redo": 1,
+      "location": {
+        "file": "foo/rbac.rego",
+        "row": 4,
+        "col": 9
+      }
+    }
+  ]
+}
+```
+The above output shows the profile results sorted on the default sort criteria.
+
+#### Example: Display `ALL` profile results with `default` ordering criteria with `pretty` formatter
+```bash
+opa eval --data foo --profile --format=pretty 'data.rbac.allow'
+```
+
+**Sample Output**
+```ruby
+false
+
++----------+----------+----------+------------------+
+|   TIME   | NUM EVAL | NUM REDO |     LOCATION     |
++----------+----------+----------+------------------+
+| 70.945µs | 1        | 1        | data.rbac.allow  |
+| 32.02µs  | 1        | 1        | foo/rbac.rego:41 |
+| 24.175µs | 1        | 1        | foo/rbac.rego:11 |
+| 18.263µs | 2        | 1        | foo/rbac.rego:47 |
+| 15.763µs | 1        | 1        | foo/rbac.rego:38 |
+| 11.645µs | 1        | 2        | foo/rbac.rego:46 |
+| 11.023µs | 1        | 1        | foo/rbac.rego:55 |
+| 10.267µs | 1        | 0        | foo/rbac.rego:56 |
+| 9.84µs   | 1        | 1        | foo/rbac.rego:48 |
+| 9.441µs  | 1        | 2        | foo/rbac.rego:52 |
++----------+----------+----------+------------------+
+
++------------------------------+-----------+
+|             NAME             |   VALUE   |
++------------------------------+-----------+
+| timer_rego_query_compile_ns  | 63763     |
+| timer_rego_query_eval_ns     | 255809    |
+| timer_rego_query_parse_ns    | 138497172 |
+| timer_rego_module_compile_ns | 34227625  |
++------------------------------+-----------+
+```
+As seen from the above table, all results are dislayed. The profile results are
+sorted on the default sort criteria.
+
+#### Example: Display top `5` profile results
+```bash
+opa eval --data foo --profile-limit 5 --format=pretty 'data.rbac.allow'
+```
+
+**Sample Output**
+```ruby
+false
+
++----------+----------+----------+------------------+
+|   TIME   | NUM EVAL | NUM REDO |     LOCATION     |
++----------+----------+----------+------------------+
+| 56.298µs | 1        | 1        | foo/rbac.rego:41 |
+| 52.851µs | 1        | 1        | data.rbac.allow  |
+| 41.498µs | 2        | 1        | foo/rbac.rego:47 |
+| 38.146µs | 1        | 1        | foo/rbac.rego:4  |
+| 24.714µs | 1        | 1        | foo/rbac.rego:38 |
++----------+----------+----------+------------------+
+
++------------------------------+-----------+
+|             NAME             |   VALUE   |
++------------------------------+-----------+
+| timer_rego_query_parse_ns    | 139512691 |
+| timer_rego_module_compile_ns | 31450043  |
+| timer_rego_query_compile_ns  | 71703     |
+| timer_rego_query_eval_ns     | 357086    |
++------------------------------+-----------+
+```
+The profile results are sorted on the default sort criteria.
+Also `--profile` option is implied and does not need to be provided.
+
+#### Example: Display top `5` profile results based on the `number of times an expression is evaluated`
+```bash
+opa  eval --data foo --profile-limit 5 --profile-sort num_eval --format=pretty 'data.rbac.allow'
+```
+
+**Sample Profile Output**
+```ruby
++----------+----------+----------+------------------+
+|   TIME   | NUM EVAL | NUM REDO |     LOCATION     |
++----------+----------+----------+------------------+
+| 20.036µs | 2        | 1        | foo/rbac.rego:47 |
+| 9.295µs  | 2        | 1        | foo/rbac.rego:53 |
+| 37.609µs | 1        | 1        | foo/rbac.rego:41 |
+| 33.43µs  | 1        | 1        | data.rbac.allow  |
+| 24.19µs  | 1        | 1        | foo/rbac.rego:11 |
++----------+----------+----------+------------------+
+```
+As seen from the above table, the results are arranged first in decreasing
+order of number of evaluations and if two expressions have been evaluated
+the same number of times, the default criteria is used since no other sort criteria is provided. 
+In this case, total_time_ns => num_redo => file => line.
+Also `--profile` option is implied and does not need to be provided.
+
+#### Example: Display top `5` profile results based on the `number of times an expression is evaluated` and `number of times an expression is re-evaluated`
+```bash
+opa eval --data foo --profile-limit 5 --profile-sort num_eval,num_redo --format=pretty 'data.rbac.allow'
+```
+
+**Sample Profile Output**
+```ruby
++----------+----------+----------+------------------+
+|   TIME   | NUM EVAL | NUM REDO |     LOCATION     |
++----------+----------+----------+------------------+
+| 19.158µs | 2        | 1        | foo/rbac.rego:47 |
+| 7.86µs   | 2        | 1        | foo/rbac.rego:53 |
+| 11.526µs | 1        | 2        | foo/rbac.rego:46 |
+| 9.435µs  | 1        | 2        | foo/rbac.rego:52 |
+| 37.436µs | 1        | 1        | foo/rbac.rego:41 |
++----------+----------+----------+------------------+
+```
+As seen from the above table, result are first arranged based on _number of evaluations_,
+then _number of re-evaluations_ and finally the default criteria is used.
+In this case, total_time_ns => file => line.
+The `--profile-sort` options accepts repeated or comma-separated values for the criteria.
+The order of the criteria on the command line determine their priority.
+
+Another way to get the same output as above would be the following:
+```bash
+opa eval --data foo --profile-limit 5 --profile-sort num_eval --profile-sort num_redo --format=pretty 'data.rbac.allow'
+```

--- a/presentation/presentation.go
+++ b/presentation/presentation.go
@@ -1,0 +1,243 @@
+// Copyright 2018 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+// Package presentation prints results of an expression evaluation in
+// json and tabular formats.
+package presentation
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/olekukonko/tablewriter"
+	"github.com/open-policy-agent/opa/profiler"
+	"github.com/open-policy-agent/opa/rego"
+)
+
+// EvalResult holds the results from evaluation, profiling and metrics.
+type EvalResult struct {
+	Result      rego.ResultSet         `json:"result,omitempty"`
+	Explanation []string               `json:"explanation,omitempty"`
+	Metrics     map[string]interface{} `json:"metrics,omitempty"`
+	Profile     []profiler.ExprStats   `json:"profile,omitempty"`
+}
+
+// PrintJSON prints indented json output.
+func PrintJSON(writer io.Writer, x interface{}) error {
+	buf, err := json.MarshalIndent(x, "", "  ")
+	if err != nil {
+		return err
+	}
+	fmt.Fprintln(writer, string(buf))
+	return nil
+}
+
+// PrintPretty prints expressions, bindings, metrics and profiling output
+// in a tabular format.
+func PrintPretty(writer io.Writer, result EvalResult, prettyLimit int) {
+
+	// Bindings Table
+	PrintPrettyBinding(writer, result, prettyLimit)
+
+	// Metrics Table
+	PrintPrettyMetrics(writer, result, prettyLimit)
+
+	// Profile Table
+	PrintPrettyProfile(writer, result)
+}
+
+// PrintPrettyBinding prints bindings in a tabular format
+func PrintPrettyBinding(writer io.Writer, result EvalResult, prettyLimit int) {
+	keys := generateResultKeys(result.Result)
+	tableBindings := generateTableBindings(writer, keys, result, prettyLimit)
+
+	if tableBindings.NumLines() > 0 {
+		fmt.Println()
+		tableBindings.Render()
+	}
+}
+
+// PrintPrettyMetrics prints metrics in a tabular format
+func PrintPrettyMetrics(writer io.Writer, result EvalResult, prettyLimit int) {
+	tableMetrics := generateTableMetrics(writer)
+	populateTableMetrics(result.Metrics, tableMetrics, prettyLimit)
+	if tableMetrics.NumLines() > 0 {
+		fmt.Println()
+		tableMetrics.Render()
+	}
+}
+
+// PrintPrettyProfile prints profiling stats in a tabular format
+func PrintPrettyProfile(writer io.Writer, result EvalResult) {
+	tableProfile := generateTableProfile(writer)
+	for _, rs := range result.Profile {
+		line := []string{}
+		timeNs := time.Duration(rs.ExprTimeNs) * time.Nanosecond
+		timeNsStr := timeNs.String()
+		numEval := strconv.FormatInt(int64(rs.NumEval), 10)
+		numRedo := strconv.FormatInt(int64(rs.NumRedo), 10)
+		loc := rs.Location.String()
+		line = append(line, timeNsStr, numEval, numRedo, loc)
+		tableProfile.Append(line)
+	}
+	if tableProfile.NumLines() > 0 {
+		fmt.Println()
+		tableProfile.Render()
+	}
+}
+
+func checkStrLimit(input string, limit int) string {
+	if limit > 0 && len(input) > limit {
+		input = input[:limit] + "..."
+		return input
+	}
+	return input
+}
+
+func generateTableBindings(writer io.Writer, keys []resultKey, result EvalResult, prettyLimit int) *tablewriter.Table {
+	table := tablewriter.NewWriter(writer)
+	table.SetAlignment(tablewriter.ALIGN_CENTER)
+	table.SetAutoFormatHeaders(false)
+	header := make([]string, len(keys))
+	for i := range header {
+		header[i] = keys[i].string()
+	}
+	table.SetHeader(header)
+	alignment := make([]int, len(keys))
+	for i := range header {
+		alignment[i] = tablewriter.ALIGN_LEFT
+	}
+	table.SetColumnAlignment(alignment)
+
+	for _, row := range result.Result {
+		printPrettyRow(table, keys, row, prettyLimit)
+	}
+	return table
+}
+
+func printPrettyRow(table *tablewriter.Table, keys []resultKey, result rego.Result, prettyLimit int) {
+	buf := []string{}
+	for _, k := range keys {
+		v, ok := k.selectVarValue(result)
+		if ok {
+			js, err := json.Marshal(v)
+			if err != nil {
+				buf = append(buf, err.Error())
+			} else {
+				s := checkStrLimit(string(js), prettyLimit)
+				buf = append(buf, s)
+			}
+		}
+	}
+	table.Append(buf)
+}
+
+func generateTableMetrics(writer io.Writer) *tablewriter.Table {
+	table := tablewriter.NewWriter(writer)
+	table.SetHeader([]string{"Name", "Value"})
+	table.SetAlignment(tablewriter.ALIGN_CENTER)
+	table.SetColumnAlignment([]int{tablewriter.ALIGN_LEFT, tablewriter.ALIGN_LEFT})
+	return table
+}
+
+func generateTableProfile(writer io.Writer) *tablewriter.Table {
+	table := tablewriter.NewWriter(writer)
+	table.SetHeader([]string{"Time", "Num Eval", "Num Redo", "Location"})
+	table.SetAlignment(tablewriter.ALIGN_CENTER)
+	table.SetColumnAlignment([]int{tablewriter.ALIGN_LEFT, tablewriter.ALIGN_LEFT,
+		tablewriter.ALIGN_LEFT, tablewriter.ALIGN_LEFT})
+	return table
+}
+
+func populateTableMetrics(data map[string]interface{}, table *tablewriter.Table, prettyLimit int) {
+	lines := [][]string{}
+	for varName, varValueInterface := range data {
+		val, ok := varValueInterface.(map[string]interface{})
+		if !ok {
+			line := []string{}
+			varValue := checkStrLimit(fmt.Sprintf("%v", varValueInterface), prettyLimit)
+			line = append(line, varName, varValue)
+			lines = append(lines, line)
+		} else {
+			for k, v := range val {
+				line := []string{}
+				newVarName := fmt.Sprintf("%v_%v", varName, k)
+				value := checkStrLimit(fmt.Sprintf("%v", v), prettyLimit)
+				line = append(line, newVarName, value)
+				lines = append(lines, line)
+			}
+		}
+	}
+	sortMetricRows(lines)
+	table.AppendBulk(lines)
+}
+
+func sortMetricRows(data [][]string) {
+	sort.Slice(data, func(i, j int) bool {
+		return data[i][0] < data[j][0]
+	})
+}
+
+type resultKey struct {
+	varName   string
+	exprIndex int
+	exprText  string
+}
+
+func resultKeyLess(a, b resultKey) bool {
+	if a.varName != "" {
+		if b.varName == "" {
+			return true
+		}
+		return a.varName < b.varName
+	}
+	return a.exprIndex < b.exprIndex
+}
+
+func (rk resultKey) string() string {
+	if rk.varName != "" {
+		return rk.varName
+	}
+	return rk.exprText
+}
+
+func (rk resultKey) selectVarValue(result rego.Result) (interface{}, bool) {
+	if rk.varName != "" {
+		return result.Bindings[rk.varName], true
+	}
+	val := result.Expressions[rk.exprIndex].Value
+	if _, ok := val.(bool); ok {
+		return nil, false
+	}
+	return val, true
+}
+
+func generateResultKeys(rs rego.ResultSet) []resultKey {
+	keys := []resultKey{}
+	if len(rs) != 0 {
+		for k := range rs[0].Bindings {
+			keys = append(keys, resultKey{
+				varName: k,
+			})
+		}
+
+		for i, expr := range rs[0].Expressions {
+			if _, ok := expr.Value.(bool); !ok {
+				keys = append(keys, resultKey{
+					exprIndex: i,
+					exprText:  expr.Text,
+				})
+			}
+		}
+
+		sort.Slice(keys, func(i, j int) bool {
+			return resultKeyLess(keys[i], keys[j])
+		})
+	}
+	return keys
+}

--- a/profiler/profiler.go
+++ b/profiler/profiler.go
@@ -74,14 +74,20 @@ func (p *Profiler) ReportTopNResults(numResults int, criteria []string) []ExprSt
 
 	// allowed criteria for sorting results
 	allowedCriteria := map[string]lessFunc{}
-	allowedCriteria["EvalTime"] = func(stat1, stat2 *ExprStats) bool {
+	allowedCriteria["total_time_ns"] = func(stat1, stat2 *ExprStats) bool {
 		return stat1.ExprTimeNs > stat2.ExprTimeNs
 	}
-	allowedCriteria["NumEval"] = func(stat1, stat2 *ExprStats) bool {
+	allowedCriteria["num_eval"] = func(stat1, stat2 *ExprStats) bool {
 		return stat1.NumEval > stat2.NumEval
 	}
-	allowedCriteria["NumRedo"] = func(stat1, stat2 *ExprStats) bool {
+	allowedCriteria["num_redo"] = func(stat1, stat2 *ExprStats) bool {
 		return stat1.NumRedo > stat2.NumRedo
+	}
+	allowedCriteria["file"] = func(stat1, stat2 *ExprStats) bool {
+		return stat1.Location.File > stat2.Location.File
+	}
+	allowedCriteria["line"] = func(stat1, stat2 *ExprStats) bool {
+		return stat1.Location.Row > stat2.Location.Row
 	}
 
 	sortFuncs := []lessFunc{}

--- a/profiler/profiler_test.go
+++ b/profiler/profiler_test.go
@@ -255,7 +255,7 @@ baz {
 		t.Fatal(err)
 	}
 
-	stats := profiler.ReportTopNResults(5, []string{"EvalTime"})
+	stats := profiler.ReportTopNResults(5, []string{"total_time_ns"})
 
 	expectedResLen := 5
 	if len(stats) != expectedResLen {
@@ -316,7 +316,7 @@ baz {
 		t.Fatal(err)
 	}
 
-	stats := profiler.ReportTopNResults(5, []string{"NumEval", "EvalTime"})
+	stats := profiler.ReportTopNResults(5, []string{"num_eval", "total_time_ns"})
 
 	expectedResLen := 5
 	if len(stats) != expectedResLen {
@@ -383,7 +383,7 @@ baz {
 		t.Fatal(err)
 	}
 
-	stats := profiler.ReportTopNResults(10, []string{"NumEval", "NumRedo", "EvalTime"})
+	stats := profiler.ReportTopNResults(10, []string{"num_eval", "num_redo", "total_time_ns"})
 
 	expectedResLen := 10
 	if len(stats) != expectedResLen {


### PR DESCRIPTION
This pull request has changes to add the `profiler` to the `eval` command.

This PR depends on https://github.com/open-policy-agent/opa/pull/808 .


Signed-off-by: Ashutosh Narkar <anarkar4387@gmail.com>