### PR TITLE
Add JSON output format to REPL partial evaluation output

### DIFF
--- a/repl/repl.go
+++ b/repl/repl.go
@@ -890,15 +890,7 @@ func (r *REPL) evalPartial(ctx context.Context, compiler *ast.Compiler, input as
 		r.printMetrics(r.metrics)
 	}
 
-	for i := range pq.Queries {
-		fmt.Fprintln(r.output, pq.Queries[i])
-	}
-
-	for i := range pq.Support {
-		fmt.Fprintln(r.output)
-		fmt.Fprintf(r.output, "# support module %d\n", i+1)
-		fmt.Fprintln(r.output, pq.Support[i])
-	}
+	r.printPartialResults(pq)
 
 	return nil
 }
@@ -984,6 +976,29 @@ func (r *REPL) printResults(keys []resultKey, results rego.ResultSet) {
 		r.printJSON(output)
 	default:
 		r.printPretty(keys, results)
+	}
+}
+
+func (r *REPL) printPartialResults(pq *rego.PartialQueries) {
+
+	switch r.outputFormat {
+	case "json":
+		r.printJSON(pq)
+	default:
+		r.printPartialPretty(pq)
+	}
+}
+
+func (r *REPL) printPartialPretty(pq *rego.PartialQueries) {
+
+	for i := range pq.Queries {
+		fmt.Fprintln(r.output, pq.Queries[i])
+	}
+
+	for i := range pq.Support {
+		fmt.Fprintln(r.output)
+		fmt.Fprintf(r.output, "# support module %d\n", i+1)
+		fmt.Fprintln(r.output, pq.Support[i])
 	}
 }
 

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -886,6 +886,10 @@ func (r *REPL) evalPartial(ctx context.Context, compiler *ast.Compiler, input as
 		r.printTrace(ctx, compiler, *buf)
 	}
 
+	if r.metrics != nil {
+		r.printMetrics(r.metrics)
+	}
+
 	for i := range pq.Queries {
 		fmt.Fprintln(r.output, pq.Queries[i])
 	}

--- a/repl/repl_test.go
+++ b/repl/repl_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/rego"
 	"github.com/open-policy-agent/opa/storage"
 	"github.com/open-policy-agent/opa/storage/inmem"
 	"github.com/open-policy-agent/opa/util"
@@ -397,6 +398,33 @@ input.x = 3; i = 2; x = 3
 
 	if !strings.Contains(output, "timer_rego_partial_eval_ns") {
 		t.Fatal("Expected timer_rego_partial_eval_ns but got:\n\n", output)
+	}
+}
+
+func TestUnknownJSON(t *testing.T) {
+	ctx := context.Background()
+	store := inmem.New()
+	var buffer bytes.Buffer
+	repl := newRepl(store, &buffer)
+
+	repl.OneShot(ctx, "xs = [1,2,3]")
+
+	err := repl.OneShot(ctx, "unknown input")
+	if err != nil {
+		t.Fatal("Unexpected command error:", err)
+	}
+
+	repl.OneShot(ctx, "json")
+	repl.OneShot(ctx, "data.repl.xs[i] = x; input.x = x")
+
+	var result rego.PartialQueries
+
+	if err := json.NewDecoder(&buffer).Decode(&result); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(result.Queries) != 3 {
+		t.Fatalf("Expected exactly 3 queries in partial evaluation output but got: %v", result)
 	}
 }
 


### PR DESCRIPTION
These changes are fairly self-explanatory. Previously, the REPL would only print the string representation of partial evaluation results. In debugging cases, it's useful to be able to inspect the AST in JSON (e.g., if there are wildcard variables.)