### PR TITLE
Update build to enable CGO

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -2,7 +2,7 @@
 # Use of this source code is governed by an Apache2
 # license that can be found in the LICENSE file.
 
-FROM scratch
+FROM gcr.io/distroless/base
 
 MAINTAINER Torin Sandall <torinsandall@gmail.com>
 

--- a/Dockerfile_debug.in
+++ b/Dockerfile_debug.in
@@ -1,8 +1,8 @@
-# Copyright 2017 The OPA Authors.  All rights reserved.
+# Copyright 2018 The OPA Authors.  All rights reserved.
 # Use of this source code is governed by an Apache2
 # license that can be found in the LICENSE file.
 
-FROM alpine
+FROM gcr.io/distroless/base:debug
 
 MAINTAINER Torin Sandall <torinsandall@gmail.com>
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,6 @@ GO := go
 GOVERSION := 1.10
 GOARCH := $(shell go env GOARCH)
 GOOS := $(shell go env GOOS)
-DISABLE_CGO := CGO_ENABLED=0
 
 BIN := opa_$(GOOS)_$(GOARCH)
 
@@ -54,7 +53,7 @@ generate:
 
 .PHONY: build
 build: generate
-	$(DISABLE_CGO) $(GO) build -o $(BIN) -ldflags $(LDFLAGS)
+	$(GO) build -o $(BIN) -ldflags $(LDFLAGS)
 
 .PHONY: image
 image:
@@ -64,42 +63,42 @@ image:
 .PHONY: image-quick
 image-quick:
 	sed -e 's/GOARCH/$(GOARCH)/g' Dockerfile.in > .Dockerfile_$(GOARCH)
-	sed -e 's/GOARCH/$(GOARCH)/g' Dockerfile_alpine.in > .Dockerfile_alpine_$(GOARCH)
+	sed -e 's/GOARCH/$(GOARCH)/g' Dockerfile_debug.in > .Dockerfile_debug_$(GOARCH)
 	docker build -t $(IMAGE):$(VERSION)	-f .Dockerfile_$(GOARCH) .
-	docker build -t $(IMAGE):$(VERSION)-alpine -f .Dockerfile_alpine_$(GOARCH) .
+	docker build -t $(IMAGE):$(VERSION)-debug -f .Dockerfile_debug_$(GOARCH) .
 
 .PHONY: push
 push:
 	docker push $(IMAGE):$(VERSION)
-	docker push $(IMAGE):$(VERSION)-alpine
+	docker push $(IMAGE):$(VERSION)-debug
 
 .PHONY: tag-latest
 tag-latest:
 	docker tag $(IMAGE):$(VERSION) $(IMAGE):latest
-	docker tag $(IMAGE):$(VERSION)-alpine $(IMAGE):latest-alpine
+	docker tag $(IMAGE):$(VERSION)-debug $(IMAGE):latest-debug
 
 .PHONY: push-latest
 push-latest:
 	docker push $(IMAGE):latest
-	docker push $(IMAGE):latest-alpine
+	docker push $(IMAGE):latest-debug
 
 .PHONY: install
 install: generate
-	$(DISABLE_CGO) $(GO) install -ldflags $(LDFLAGS)
+	$(GO) install -ldflags $(LDFLAGS)
 
 .PHONY: test
 test: generate
-	$(DISABLE_CGO) $(GO) test $(PACKAGES)
+	$(GO) test $(PACKAGES)
 
 COVER_PACKAGES=$(PACKAGES)
 $(COVER_PACKAGES):
 	@mkdir -p coverage/$(shell dirname $@)
-	$(DISABLE_CGO) $(GO) test -covermode=count -coverprofile=coverage/$(shell dirname $@)/coverage.out $@
+	$(GO) test -covermode=count -coverprofile=coverage/$(shell dirname $@)/coverage.out $@
 	$(GO) tool cover -html=coverage/$(shell dirname $@)/coverage.out || true
 
 .PHONY: perf
 perf: generate
-	$(DISABLE_CGO) $(GO) test -v -run=donotruntests -bench=. $(PACKAGES) | grep "^Benchmark"
+	$(GO) test -v -run=donotruntests -bench=. $(PACKAGES) | grep "^Benchmark"
 
 .PHONY: perf-regression
 perf-regression:


### PR DESCRIPTION
These changes modify the build to leave CGO enabled (as opposed to
disabling it explicitly.) This will make it possible to load Go
libraries dynamically.

Since CGO is enabled, we have cannot use the scratch or alpine base
images any more. To replace them, we are using the "distroless" images
from GoogleContainerTools[1]. These images are intended to run
statically compiled languages like Go and Rust. They have a minimal
number of dependencies (importantly, glibc) and produce relatively small
images (~30MB.) The old images were ~20MB in size.

These changes enable a second "debug" image flavor which is based off
distroless "debug". This image includes a shell and other things that
are useful for debug purposes. In addition, the image includes the
"diff" program which is used by opa fmt --diff and required by the
open-policy-agent/library repo build.

[1] https://github.com/GoogleContainerTools/distroless

Signed-off-by: Torin Sandall <torinsandall@gmail.com>