### PR TITLE
Added support for dynamically loading plugins and builtins 

### DIFF
--- a/cmd/plugins.go
+++ b/cmd/plugins.go
@@ -13,17 +13,17 @@ import (
 )
 
 func init() {
-	var builtinDir string
+	var pluginDir string
 
 	// flag is persistent (can be loaded on all children commands)
-	RootCommand.PersistentFlags().StringVar(&builtinDir, "builtin-dir", "", `set path to directory containing
-shared object files to dynamically load builtins`)
+	RootCommand.PersistentFlags().StringVar(&pluginDir, "plugin-dir", "", `set path to directory containing
+shared object files to dynamically load builtins and plugins`)
 
 	// Runs before *all* children commands
 	RootCommand.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
 		// only register custom plugins if directory specified
-		if builtinDir != "" {
-			err := runtime.RegisterBuiltinsFromDir(builtinDir)
+		if pluginDir != "" {
+			err := runtime.RegisterSharedObjectsFromDir(pluginDir)
 			if err != nil {
 				return err
 			}

--- a/cmd/plugins.go
+++ b/cmd/plugins.go
@@ -13,17 +13,17 @@ import (
 )
 
 func init() {
-	var pluginDir string
+	var builtinDir string
 
 	// flag is persistent (can be loaded on all children commands)
-	RootCommand.PersistentFlags().StringVar(&pluginDir, "plugin-dir", "", `set path to directory containing
-shared object files to dynamically load plugins and builtins`)
+	RootCommand.PersistentFlags().StringVar(&builtinDir, "builtin-dir", "", `set path to directory containing
+shared object files to dynamically load builtins`)
 
 	// Runs before *all* children commands
 	RootCommand.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
 		// only register custom plugins if directory specified
-		if pluginDir != "" {
-			err := runtime.RegisterBuiltinsFromDir(pluginDir)
+		if builtinDir != "" {
+			err := runtime.RegisterBuiltinsFromDir(builtinDir)
 			if err != nil {
 				return err
 			}

--- a/cmd/plugins.go
+++ b/cmd/plugins.go
@@ -1,0 +1,33 @@
+// Copyright 2018 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+// Specifies additional cmd commands that available to systems that can load plugins
+// +build linux,cgo darwin,cgo
+
+package cmd
+
+import (
+	"github.com/open-policy-agent/opa/runtime"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	var pluginDir string
+
+	// flag is persistent (can be loaded on all children commands)
+	RootCommand.PersistentFlags().StringVar(&pluginDir, "plugin-dir", "", `set path to directory containing
+shared object files to dynamically load plugins and builtins`)
+
+	// Runs before *all* children commands
+	RootCommand.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+		// only register custom plugins if directory specified
+		if pluginDir != "" {
+			err := runtime.RegisterBuiltinsFromDir(pluginDir)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -125,6 +125,7 @@ the data document with the following syntax:
 		},
 	}
 
+	runCommand.Flags().StringVarP(&params.PluginDir, "plugin-dir", "p", "", "set path to plugin directory")
 	runCommand.Flags().StringVarP(&params.ConfigFile, "config-file", "c", "", "set path of configuration file")
 	runCommand.Flags().BoolVarP(&serverMode, "server", "s", false, "start the runtime in server mode")
 	runCommand.Flags().StringVarP(&params.HistoryPath, "history", "H", historyPath(), "set path of history file")

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -125,7 +125,6 @@ the data document with the following syntax:
 		},
 	}
 
-	runCommand.Flags().StringVarP(&params.PluginDir, "plugin-dir", "p", "", "set path to plugin directory")
 	runCommand.Flags().StringVarP(&params.ConfigFile, "config-file", "c", "", "set path of configuration file")
 	runCommand.Flags().BoolVarP(&serverMode, "server", "s", false, "start the runtime in server mode")
 	runCommand.Flags().StringVarP(&params.HistoryPath, "history", "H", historyPath(), "set path of history file")

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -110,6 +110,7 @@ the data document with the following syntax:
 
 			ctx := context.Background()
 
+			// we do not need to set params.BuiltinDir since the flag will process everything
 			rt, err := runtime.NewRuntime(ctx, params)
 			if err != nil {
 				fmt.Fprintln(os.Stderr, "error:", err)

--- a/plugins/plugins.go
+++ b/plugins/plugins.go
@@ -22,6 +22,10 @@ type Plugin interface {
 	Stop(ctx context.Context)
 }
 
+// PluginInitFunc is a function that will initialize a plugin given configuration document config
+// The function should return the plugin if successful and and error if unsuccessful
+type PluginInitFunc func(m *Manager, config []byte) (Plugin, error)
+
 // Manager implements lifecycle management of plugins and gives plugins access
 // to engine-wide components like storage.
 type Manager struct {
@@ -130,6 +134,13 @@ func (m *Manager) Start(ctx context.Context) error {
 		_, err := m.Store.Register(ctx, txn, config)
 		return err
 	})
+}
+
+// Stop stops the manager, stopping all the plugins registered with it
+func (m *Manager) Stop(ctx context.Context) {
+	for _, p := range m.plugins {
+		p.Stop(ctx)
+	}
 }
 
 func (m *Manager) onCommit(ctx context.Context, txn storage.Transaction, event storage.TriggerEvent) {

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -21,6 +21,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/pkg/errors"
+
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/loader"
 	"github.com/open-policy-agent/opa/plugins"
@@ -30,6 +32,7 @@ import (
 	"github.com/open-policy-agent/opa/repl"
 	"github.com/open-policy-agent/opa/server"
 	"github.com/open-policy-agent/opa/storage"
+	"github.com/open-policy-agent/opa/storage/inmem"
 	"github.com/open-policy-agent/opa/util"
 	"github.com/open-policy-agent/opa/version"
 )
@@ -153,6 +156,84 @@ type Runtime struct {
 	Manager *plugins.Manager
 
 	decisionLogger func(context.Context, *server.Info)
+}
+
+// NewRuntime returns a new Runtime object initialized with params.
+func NewRuntime(ctx context.Context, params Params) (*Runtime, error) {
+
+	if params.ID == "" {
+		var err error
+		params.ID, err = generateInstanceID()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	loaded, err := loader.Filtered(params.Paths, params.Filter)
+	if err != nil {
+		return nil, err
+	}
+
+	store := inmem.New()
+
+	txn, err := store.NewTransaction(ctx, storage.WriteParams)
+	if err != nil {
+		return nil, err
+	}
+
+	// only register custom plugins if directory specified
+	if params.BuiltinDir != "" {
+		err = RegisterBuiltinsFromDir(params.BuiltinDir)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if err := store.Write(ctx, txn, storage.AddOp, storage.Path{}, loaded.Documents); err != nil {
+		store.Abort(ctx, txn)
+		return nil, errors.Wrapf(err, "storage error")
+	}
+
+	if err := compileAndStoreInputs(ctx, store, txn, loaded.Modules, params.ErrorLimit); err != nil {
+		store.Abort(ctx, txn)
+		return nil, errors.Wrapf(err, "compile error")
+	}
+
+	if err := store.Commit(ctx, txn); err != nil {
+		return nil, errors.Wrapf(err, "storage error")
+	}
+
+	// register before init
+	if params.PluginDir != "" {
+		err = RegisterPluginsFromDir(params.PluginDir)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	m, plugins, err := initPlugins(params.ID, store, params.ConfigFile)
+	if err != nil {
+		return nil, err
+	}
+
+	var decisionLogger func(context.Context, *server.Info)
+
+	if p, ok := plugins["decision_logs"]; ok {
+		decisionLogger = p.(*logs.Plugin).Log
+
+		if params.DecisionIDFactory == nil {
+			params.DecisionIDFactory = generateDecisionID
+		}
+	}
+
+	rt := &Runtime{
+		Store:          store,
+		Manager:        m,
+		Params:         params,
+		decisionLogger: decisionLogger,
+	}
+
+	return rt, nil
 }
 
 // StartServer starts the runtime in server mode. This function will block the calling goroutine.

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -97,12 +97,8 @@ type Params struct {
 	// where the contained document should be loaded.
 	Paths []string
 
-	// BuiltinDir is the path to a directory containing .builtin.so shared object files that
-	// OPA can load dynamically to create custom builtins.
-	BuiltinDir string
-
-	// PluginDir is the path to a directory containing .plugin.so shared object files that
-	// OPA can load dynamically to create custom builtins.
+	// PluginDir is the path to a directory containing .builtin.so and .plugin.so shared object files that
+	// OPA can load dynamically to create custom builtins and plugins.
 	PluginDir string
 
 	// Optional filter that will be passed to the file loader.
@@ -181,9 +177,8 @@ func NewRuntime(ctx context.Context, params Params) (*Runtime, error) {
 		return nil, err
 	}
 
-	// only register custom plugins if directory specified
-	if params.BuiltinDir != "" {
-		err = RegisterBuiltinsFromDir(params.BuiltinDir)
+	if params.PluginDir != "" {
+		err = RegisterSharedObjectsFromDir(params.PluginDir)
 		if err != nil {
 			return nil, err
 		}
@@ -201,14 +196,6 @@ func NewRuntime(ctx context.Context, params Params) (*Runtime, error) {
 
 	if err := store.Commit(ctx, txn); err != nil {
 		return nil, errors.Wrapf(err, "storage error")
-	}
-
-	// register before init
-	if params.PluginDir != "" {
-		err = RegisterPluginsFromDir(params.PluginDir)
-		if err != nil {
-			return nil, err
-		}
 	}
 
 	m, plugins, err := initPlugins(params.ID, store, params.ConfigFile)

--- a/runtime/runtime_noplugins.go
+++ b/runtime/runtime_noplugins.go
@@ -1,0 +1,82 @@
+// Copyright 2018 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+// +build !linux,!darwin !cgo
+
+package runtime
+
+// Contains parts of the runtime package that do not use the plugin package
+import (
+	"context"
+
+	"github.com/pkg/errors"
+
+	"github.com/open-policy-agent/opa/loader"
+	"github.com/open-policy-agent/opa/plugins/logs"
+	"github.com/open-policy-agent/opa/server"
+	"github.com/open-policy-agent/opa/storage"
+	"github.com/open-policy-agent/opa/storage/inmem"
+)
+
+// NewRuntime returns a new Runtime object initialized with params.
+func NewRuntime(ctx context.Context, params Params) (*Runtime, error) {
+
+	if params.ID == "" {
+		var err error
+		params.ID, err = generateInstanceID()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	loaded, err := loader.Filtered(params.Paths, params.Filter)
+	if err != nil {
+		return nil, err
+	}
+
+	store := inmem.New()
+
+	txn, err := store.NewTransaction(ctx, storage.WriteParams)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := store.Write(ctx, txn, storage.AddOp, storage.Path{}, loaded.Documents); err != nil {
+		store.Abort(ctx, txn)
+		return nil, errors.Wrapf(err, "storage error")
+	}
+
+	if err := compileAndStoreInputs(ctx, store, txn, loaded.Modules, params.ErrorLimit); err != nil {
+		store.Abort(ctx, txn)
+		return nil, errors.Wrapf(err, "compile error")
+	}
+
+	if err := store.Commit(ctx, txn); err != nil {
+		return nil, errors.Wrapf(err, "storage error")
+	}
+
+	m, plugins, err := initPlugins(params.ID, store, params.ConfigFile)
+	if err != nil {
+		return nil, err
+	}
+
+	var decisionLogger func(context.Context, *server.Info)
+
+	if p, ok := plugins["decision_logs"]; ok {
+		decisionLogger = p.(*logs.Plugin).Log
+
+		if params.DecisionIDFactory == nil {
+			params.DecisionIDFactory = generateDecisionID
+		}
+	}
+
+	rt := &Runtime{
+		Store:          store,
+		Manager:        m,
+		Params:         params,
+		decisionLogger: decisionLogger,
+	}
+
+	return rt, nil
+}

--- a/runtime/runtime_noplugins.go
+++ b/runtime/runtime_noplugins.go
@@ -8,12 +8,7 @@ package runtime
 
 // Contains parts of the runtime package that do not use the plugin package.
 
-// RegisterBuiltinsFromDir is a no-op. Plugin loading is limited to linux/darwin + cgo platforms for the time being.
-func RegisterBuiltinsFromDir(dir string) error {
-	return nil
-}
-
-// RegisterPluginsFromDir is a no-op. Plugin loading is limited to linux/darwin + cgo platforms for the time being.
-func RegisterPluginsFromDir(dir string) error {
+// RegisterSharedObjectsFromDir is a no-op. Dynamically loading shared objects is limited to linux/darwin + cgo platforms.
+func RegisterSharedObjectsFromDir(dir string) error {
 	return nil
 }

--- a/runtime/runtime_plugins.go
+++ b/runtime/runtime_plugins.go
@@ -92,7 +92,6 @@ func registerBuiltinFromFile(path string) error {
 		return fmt.Errorf("symbol Function was of an unrecognized type")
 	}
 
-	// TODO: replace with logging
 	fmt.Printf("Registered builtin %v from %v\n", builtin.Name, path)
 	return nil
 }
@@ -124,7 +123,6 @@ func registerPluginFromFile(path string) error {
 		return fmt.Errorf("symbol Builtin must be of type runtime.PluginInitFunc")
 	}
 
-	//TODO: replace this with appropriate logging method
 	fmt.Printf("Registered plugin %v from %v\n", name, path)
 	RegisterPlugin(*name, *initFunc)
 	return nil

--- a/runtime/runtime_plugins.go
+++ b/runtime/runtime_plugins.go
@@ -1,0 +1,159 @@
+// Copyright 2018 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+// +build linux,cgo darwin,cgo
+
+package runtime
+
+// Contains parts of the runtime package that use the plugin package
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"plugin"
+
+	"github.com/pkg/errors"
+
+	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/loader"
+	"github.com/open-policy-agent/opa/plugins/logs"
+	"github.com/open-policy-agent/opa/server"
+	"github.com/open-policy-agent/opa/storage"
+	"github.com/open-policy-agent/opa/storage/inmem"
+	"github.com/open-policy-agent/opa/topdown"
+)
+
+// NewRuntime returns a new Runtime object initialized with params.
+func NewRuntime(ctx context.Context, params Params) (*Runtime, error) {
+
+	if params.ID == "" {
+		var err error
+		params.ID, err = generateInstanceID()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	loaded, err := loader.Filtered(params.Paths, params.Filter)
+	if err != nil {
+		return nil, err
+	}
+
+	store := inmem.New()
+
+	txn, err := store.NewTransaction(ctx, storage.WriteParams)
+	if err != nil {
+		return nil, err
+	}
+
+	// only register custom plugins if directory specified
+	if params.BuiltinDir != "" {
+		err = RegisterBuiltinsFromDir(params.BuiltinDir)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if err := store.Write(ctx, txn, storage.AddOp, storage.Path{}, loaded.Documents); err != nil {
+		store.Abort(ctx, txn)
+		return nil, errors.Wrapf(err, "storage error")
+	}
+
+	if err := compileAndStoreInputs(ctx, store, txn, loaded.Modules, params.ErrorLimit); err != nil {
+		store.Abort(ctx, txn)
+		return nil, errors.Wrapf(err, "compile error")
+	}
+
+	if err := store.Commit(ctx, txn); err != nil {
+		return nil, errors.Wrapf(err, "storage error")
+	}
+
+	m, plugins, err := initPlugins(params.ID, store, params.ConfigFile)
+	if err != nil {
+		return nil, err
+	}
+
+	var decisionLogger func(context.Context, *server.Info)
+
+	if p, ok := plugins["decision_logs"]; ok {
+		decisionLogger = p.(*logs.Plugin).Log
+
+		if params.DecisionIDFactory == nil {
+			params.DecisionIDFactory = generateDecisionID
+		}
+	}
+
+	rt := &Runtime{
+		Store:          store,
+		Manager:        m,
+		Params:         params,
+		decisionLogger: decisionLogger,
+	}
+
+	return rt, nil
+}
+
+// RegisterBuiltinsFromDir recursively loads all custom builtins into OPA from dir. This function is idempotent.
+func RegisterBuiltinsFromDir(dir string) error {
+	return filepath.Walk(dir, registerBuiltinFromFile)
+}
+
+// loads the builtin from a file path
+func registerBuiltinFromFile(path string, f os.FileInfo, err error) error {
+	// skip anything that is a directory
+	if f.IsDir() {
+		return nil
+	}
+	// if error occurs during traversal to path, exit and crash
+	if err != nil {
+		return err
+	}
+
+	// TODO: for now, this function skips anything in the directory that does not have the expected file name -- is this what we want?
+	if ok, _ := filepath.Match("*.builtin.so", filepath.Base(path)); !ok {
+		return nil
+	}
+
+	// proceed to load the plugin
+	mod, err := plugin.Open(path)
+	if err != nil {
+		return err
+	}
+	builtinSym, err := mod.Lookup("Builtin")
+	if err != nil {
+		return err
+	}
+	functionSym, err := mod.Lookup("Function")
+	if err != nil {
+		return err
+	}
+
+	// type assert builtin symbol
+	builtin, ok := builtinSym.(*ast.Builtin)
+	if !ok {
+		return fmt.Errorf("symbol Builtin must be of type ast.Builtin")
+	}
+
+	// type assert function symbol
+	switch fnc := functionSym.(type) {
+	case *topdown.BuiltinFunc:
+		ast.RegisterBuiltin(builtin)
+		topdown.RegisterBuiltinFunc(builtin.Name, *fnc)
+	case *topdown.FunctionalBuiltin1:
+		ast.RegisterBuiltin(builtin)
+		topdown.RegisterFunctionalBuiltin1(builtin.Name, *fnc)
+	case *topdown.FunctionalBuiltin2:
+		ast.RegisterBuiltin(builtin)
+		topdown.RegisterFunctionalBuiltin2(builtin.Name, *fnc)
+	case *topdown.FunctionalBuiltin3:
+		ast.RegisterBuiltin(builtin)
+		topdown.RegisterFunctionalBuiltin3(builtin.Name, *fnc)
+	default:
+		return fmt.Errorf("symbol Function was of an unrecognized type")
+	}
+
+	return nil
+}

--- a/runtime/runtime_plugins.go
+++ b/runtime/runtime_plugins.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/loader"
+	"github.com/open-policy-agent/opa/plugins"
 	"github.com/open-policy-agent/opa/plugins/logs"
 	"github.com/open-policy-agent/opa/server"
 	"github.com/open-policy-agent/opa/storage"
@@ -71,6 +72,14 @@ func NewRuntime(ctx context.Context, params Params) (*Runtime, error) {
 		return nil, errors.Wrapf(err, "storage error")
 	}
 
+	// register before init
+	if params.PluginDir != "" {
+		err = RegisterPluginsFromDir(params.PluginDir)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	m, plugins, err := initPlugins(params.ID, store, params.ConfigFile)
 	if err != nil {
 		return nil, err
@@ -98,26 +107,40 @@ func NewRuntime(ctx context.Context, params Params) (*Runtime, error) {
 
 // RegisterBuiltinsFromDir recursively loads all custom builtins into OPA from dir. This function is idempotent.
 func RegisterBuiltinsFromDir(dir string) error {
-	return filepath.Walk(dir, registerBuiltinFromFile)
+	return filepath.Walk(dir, walker("*.builtin.so", registerBuiltinFromFile))
+}
+
+// RegisterPluginsFromDir recursively loads all custom plugins into OPA from dir. This function is idempotent
+func RegisterPluginsFromDir(dir string) error {
+	return filepath.Walk(dir, walker("*.plugin.so", registerPluginFromFile))
+}
+
+// walker returns a walkfunc that performs handler on every file that matches the file glob pattern.
+// it skips all files that do not match pattern TODO: is this what we want?
+func walker(pattern string, handler func(string) error) filepath.WalkFunc {
+	walk := func(path string, f os.FileInfo, err error) error {
+		// if error occurs during traversal to path, exit and crash
+		if err != nil {
+			return err
+		}
+		// skip anything that is a directory
+		if f.IsDir() {
+			return nil
+		}
+
+		if ok, err := filepath.Match(pattern, filepath.Base(path)); err != nil {
+			return err
+		} else if !ok {
+			return nil
+		}
+
+		return handler(path)
+	}
+	return walk
 }
 
 // loads the builtin from a file path
-func registerBuiltinFromFile(path string, f os.FileInfo, err error) error {
-	// skip anything that is a directory
-	if f.IsDir() {
-		return nil
-	}
-	// if error occurs during traversal to path, exit and crash
-	if err != nil {
-		return err
-	}
-
-	// TODO: for now, this function skips anything in the directory that does not have the expected file name -- is this what we want?
-	if ok, _ := filepath.Match("*.builtin.so", filepath.Base(path)); !ok {
-		return nil
-	}
-
-	// proceed to load the plugin
+func registerBuiltinFromFile(path string) error {
 	mod, err := plugin.Open(path)
 	if err != nil {
 		return err
@@ -155,5 +178,39 @@ func registerBuiltinFromFile(path string, f os.FileInfo, err error) error {
 		return fmt.Errorf("symbol Function was of an unrecognized type")
 	}
 
+	// TODO: replace with logging
+	fmt.Printf("Registered builtin %v from %v\n", builtin.Name, path)
+	return nil
+}
+
+func registerPluginFromFile(path string) error {
+	mod, err := plugin.Open(path)
+	if err != nil {
+		return err
+	}
+
+	nameSym, err := mod.Lookup("Name")
+	if err != nil {
+		return err
+	}
+	name, ok := nameSym.(*string)
+	if !ok {
+		return fmt.Errorf("symbol Name must be of type string")
+	}
+
+	pluginSym, err := mod.Lookup("Initializer")
+	if err != nil {
+		return err
+	}
+
+	// type assert initializer function
+	initFunc, ok := pluginSym.(*plugins.PluginInitFunc)
+	if !ok {
+		return fmt.Errorf("symbol Builtin must be of type runtime.PluginInitFunc")
+	}
+
+	//TODO: replace this with appropriate logging method
+	fmt.Printf("Registered plugin %v from %v\n", name, path)
+	RegisterPlugin(*name, *initFunc)
 	return nil
 }

--- a/runtime/runtime_plugins_test.go
+++ b/runtime/runtime_plugins_test.go
@@ -87,7 +87,7 @@ func TestRegisterBuiltinSingle(t *testing.T) {
 	defer cleanup()
 
 	builtinDir := filepath.Join(root, "/dir")
-	err := RegisterBuiltinsFromDir(builtinDir)
+	err := RegisterSharedObjectsFromDir(builtinDir)
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -123,7 +123,7 @@ func TestRegisterBuiltinRecursive(t *testing.T) {
 	defer cleanup()
 
 	builtinDir := filepath.Join(root, "/dir")
-	err := RegisterBuiltinsFromDir(builtinDir)
+	err := RegisterSharedObjectsFromDir(builtinDir)
 	if err != nil {
 		t.Fatalf(err.Error())
 	}

--- a/runtime/runtime_plugins_test.go
+++ b/runtime/runtime_plugins_test.go
@@ -1,0 +1,147 @@
+// Copyright 2018 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+// +build linux,cgo darwin,cgo
+
+package runtime
+
+import (
+	"fmt"
+	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/types"
+	"github.com/open-policy-agent/opa/util/test"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func makeBuiltinWithName(name string) string {
+	return fmt.Sprintf(`
+package main
+
+import (
+	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/types"
+	"github.com/open-policy-agent/opa/topdown"
+)
+
+var Builtin = ast.Builtin{
+	Name: "%v",
+	Decl: types.NewFunction(
+		types.Args(types.N, types.N),
+		types.B,
+	),
+}
+
+var Function topdown.FunctionalBuiltin2 = func(a, b ast.Value) (ast.Value, error) {
+	return ast.Boolean(true), nil
+}
+`, name)
+}
+
+func TestRegisterBuiltinSingle(t *testing.T) {
+
+	name := "builtinsingle"
+	files := map[string]string{
+		"/dir/equals.go": makeBuiltinWithName(name),
+	}
+
+	root, cleanup := makeDirWithBuiltin(files)
+	defer cleanup()
+
+	builtinDir := filepath.Join(root, "/dir")
+	err := RegisterBuiltinsFromDir(builtinDir)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	expected := &ast.Builtin{
+		Name: name,
+		Decl: types.NewFunction(
+			types.Args(types.N, types.N),
+			types.B,
+		),
+	}
+
+	// check that builtin function was loaded correctly
+	actual := ast.BuiltinMap[name]
+	if !reflect.DeepEqual(*expected, *actual) {
+		t.Fatalf("Expected builtin %v but got: %v", *expected, *actual)
+	}
+}
+
+func TestRegisterBuiltinRecursive(t *testing.T) {
+	names := []string{"shallow", "parallel", "deep", "deeper"}
+	ignored := []string{"ignore", "ignore2"}
+	files := map[string]string{
+		"/dir/shallow.go":            makeBuiltinWithName("shallow"),
+		"/dir/parallel.go":           makeBuiltinWithName("parallel"),
+		"/dir/deep/deep.go":          makeBuiltinWithName("deep"),
+		"/dir/deep/deeper/deeper.go": makeBuiltinWithName("deeper"),
+		"/other/ignore.go":           makeBuiltinWithName("ignore"),
+		"/ignore2.go":                makeBuiltinWithName("ignore2"),
+	}
+
+	root, cleanup := makeDirWithBuiltin(files)
+	defer cleanup()
+
+	builtinDir := filepath.Join(root, "/dir")
+	err := RegisterBuiltinsFromDir(builtinDir)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	expectedDecl := types.NewFunction(
+		types.Args(types.N, types.N),
+		types.B,
+	)
+
+	// check that every builtin is present
+	for _, name := range names {
+		actual, ok := ast.BuiltinMap[name]
+		if !ok {
+			t.Fatalf("builtin %v not present", name)
+		}
+		if actual.Name != name {
+			t.Fatalf("builtin %v has incorrect name %v", name, actual.Name)
+		}
+		if !reflect.DeepEqual(actual.Decl, expectedDecl) {
+			t.Fatalf("Expected builtin %v but got: %v", *expectedDecl, *actual.Decl)
+		}
+	}
+
+	// check that ignore is absent
+	for _, ignore := range ignored {
+		_, ok := ast.BuiltinMap[ignore]
+		if ok {
+			t.Fatalf("builtin %v incorrectly added", ignore)
+		}
+	}
+}
+
+// makeDirWithBuiltin creates a new temporary directory containing files.
+// it compiles all .go files into identically named .builtin.so files in the corresponding directory
+// It returns the root of the directory and a cleanup function.
+func makeDirWithBuiltin(files map[string]string) (root string, cleanup func()) {
+	root, cleanup, err := test.MakeTempFS("./", "loader_test", files)
+	if err != nil {
+		panic(err)
+	}
+	for file := range files {
+		if filepath.Ext(file) == ".go" {
+			src := filepath.Join(root, file)
+			so := strings.TrimSuffix(filepath.Base(src), ".go") + ".builtin.so"
+			out := filepath.Join(filepath.Dir(src), so)
+			// build latest version of shared object
+			cmd := exec.Command("go", "build", "-buildmode=plugin", "-o="+out, src)
+			res, err := cmd.Output()
+			if err != nil {
+				panic(string(res) + err.Error())
+			}
+		}
+	}
+	return
+}

--- a/runtime/runtime_plugins_test.go
+++ b/runtime/runtime_plugins_test.go
@@ -7,15 +7,19 @@
 package runtime
 
 import (
+	"context"
 	"fmt"
-	"github.com/open-policy-agent/opa/ast"
-	"github.com/open-policy-agent/opa/types"
-	"github.com/open-policy-agent/opa/util/test"
 	"os/exec"
 	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/types"
+	"github.com/open-policy-agent/opa/util/test"
+	"net/http"
+	"net/http/httptest"
 )
 
 func makeBuiltinWithName(name string) string {
@@ -42,6 +46,36 @@ var Function topdown.FunctionalBuiltin2 = func(a, b ast.Value) (ast.Value, error
 `, name)
 }
 
+// returns go code for a plugin named name that makes a single get request to url upon start
+func getPluginWithNameAndURL(name, url string) string {
+	return fmt.Sprintf(
+		`
+package main
+
+import (
+	"context"
+    "net/http"
+	"github.com/open-policy-agent/opa/plugins"
+)
+
+var Name = "%v"
+
+type Tester struct {}
+
+func (t *Tester) Start(ctx context.Context) error {
+    _, err := http.Get("%v")
+	return err
+}
+
+func (t *Tester) Stop(ctx context.Context) {
+	return
+}
+
+var Initializer plugins.PluginInitFunc = func(m *plugins.Manager, config []byte) (plugins.Plugin, error) {
+	return &Tester{}, nil
+}`, name, url)
+}
+
 func TestRegisterBuiltinSingle(t *testing.T) {
 
 	name := "builtinsingle"
@@ -49,7 +83,7 @@ func TestRegisterBuiltinSingle(t *testing.T) {
 		"/dir/equals.go": makeBuiltinWithName(name),
 	}
 
-	root, cleanup := makeDirWithBuiltin(files)
+	root, cleanup := makeDirWithSharedObjects(files, ".builtin.so")
 	defer cleanup()
 
 	builtinDir := filepath.Join(root, "/dir")
@@ -85,7 +119,7 @@ func TestRegisterBuiltinRecursive(t *testing.T) {
 		"/ignore2.go":                makeBuiltinWithName("ignore2"),
 	}
 
-	root, cleanup := makeDirWithBuiltin(files)
+	root, cleanup := makeDirWithSharedObjects(files, ".builtin.so")
 	defer cleanup()
 
 	builtinDir := filepath.Join(root, "/dir")
@@ -122,24 +156,199 @@ func TestRegisterBuiltinRecursive(t *testing.T) {
 	}
 }
 
-// makeDirWithBuiltin creates a new temporary directory containing files.
-// it compiles all .go files into identically named .builtin.so files in the corresponding directory
+// Tests that a plugins starts only once correctly
+func TestRegisterPluginSingle(t *testing.T) {
+	name := "test"
+
+	ch := make(chan struct{}, 10)
+
+	// server upon request sends item to channel
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		ch <- struct{}{}
+	}))
+	defer ts.Close()
+
+	config := `
+plugins:
+ test: test-message
+`
+
+	files := map[string]string{
+		"/dir/test.go": getPluginWithNameAndURL(name, ts.URL),
+		"/config.yaml": config,
+	}
+
+	root, cleanup := makeDirWithSharedObjects(files, ".plugin.so")
+	defer cleanup()
+
+	pluginDir := filepath.Join(root, "/dir")
+	params := NewParams()
+	params.PluginDir = pluginDir
+	params.ConfigFile = filepath.Join(root, "/config.yaml")
+	rt, err := NewRuntime(context.Background(), params)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	// make sure plugin loaded correctly
+	_, ok := registeredPlugins[name]
+	if !ok {
+		t.Fatalf("plugin not present in registeredPlugins map")
+	}
+
+	// make sure starting the manager kicks the plugin in
+	if err := rt.Manager.Start(context.Background()); err != nil {
+		t.Fatalf("Unable to initialize plugins.")
+	}
+
+	if len(ch) != 1 {
+		t.Fatalf("plugin started %v times", len(ch))
+	}
+	return
+}
+
+// Custom plugins should not start unless expressly specified under config
+func TestRegisterPluginsNoConfig(t *testing.T) {
+	name := "test"
+
+	ch := make(chan struct{}, 10)
+
+	// server upon request sends item to channel
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		ch <- struct{}{}
+	}))
+	defer ts.Close()
+
+	files := map[string]string{
+		"/dir/test.go": getPluginWithNameAndURL(name, ts.URL),
+	}
+
+	root, cleanup := makeDirWithSharedObjects(files, ".plugin.so")
+	defer cleanup()
+
+	pluginDir := filepath.Join(root, "/dir")
+	params := NewParams()
+	params.PluginDir = pluginDir
+	rt, err := NewRuntime(context.Background(), params)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	// make sure plugin loaded correctly
+	_, ok := registeredPlugins[name]
+	if !ok {
+		t.Fatalf("plugin not present in registeredPlugins map")
+	}
+
+	// make sure starting the manager kicks the plugin in
+	if err := rt.Manager.Start(context.Background()); err != nil {
+		t.Fatalf("Unable to initialize plugins.")
+	}
+
+	if len(ch) > 0 {
+		t.Fatalf("plugin started without config file")
+	}
+
+	return
+}
+
+// Tests that plugins have access to the config file
+func TestPluginsConfigAccess(t *testing.T) {
+
+	// init func checks for "secret" under check in config file
+	plugin := `
+package main
+
+import (
+	"context"
+    "fmt"
+	"github.com/open-policy-agent/opa/plugins"
+	"github.com/open-policy-agent/opa/util"
+)
+
+var Name = "test"
+
+type Tester struct {}
+
+func (t *Tester) Start(ctx context.Context) error {
+	return nil
+}
+
+func (t *Tester) Stop(ctx context.Context) {
+	return
+}
+
+var Initializer plugins.PluginInitFunc = func(m *plugins.Manager, config []byte) (plugins.Plugin, error) {
+	var test struct {
+		Key string
+	}
+
+	if err := util.Unmarshal(config, &test); err != nil {
+		return nil, err
+	}
+
+    if test.Key != "secret" {
+		return nil, fmt.Errorf("got %v, expected %v", test.Key, "secret")
+    }
+
+	return &Tester{}, nil
+}`
+
+	config := `
+plugins:
+  test:
+    key: secret
+`
+
+	files := map[string]string{
+		"/dir/test.go": plugin,
+		"/config.yaml": config,
+	}
+
+	root, cleanup := makeDirWithSharedObjects(files, ".plugin.so")
+	defer cleanup()
+
+	pluginDir := filepath.Join(root, "/dir")
+	params := NewParams()
+	params.PluginDir = pluginDir
+	params.ConfigFile = filepath.Join(root, "/config.yaml")
+	rt, err := NewRuntime(context.Background(), params)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	// make sure plugin loaded correctly
+	_, ok := registeredPlugins["test"]
+	if !ok {
+		t.Fatalf("plugin not present in registeredPlugins map")
+	}
+
+	// make sure starting the manager kicks the plugin in
+	if err := rt.Manager.Start(context.Background()); err != nil {
+		t.Fatalf("Unable to initialize plugins.")
+	}
+
+	return
+}
+
+// makeDirWithSharedObjects creates a new temporary directory containing files under the runtime directory
+// it compiles all .go files into shared object files with extension ext in the corresponding directory
 // It returns the root of the directory and a cleanup function.
-func makeDirWithBuiltin(files map[string]string) (root string, cleanup func()) {
-	root, cleanup, err := test.MakeTempFS("./", "loader_test", files)
+func makeDirWithSharedObjects(files map[string]string, ext string) (root string, cleanup func()) {
+	root, cleanup, err := test.MakeTempFS("./", "runtime_test_tempdir", files)
 	if err != nil {
 		panic(err)
 	}
 	for file := range files {
 		if filepath.Ext(file) == ".go" {
 			src := filepath.Join(root, file)
-			so := strings.TrimSuffix(filepath.Base(src), ".go") + ".builtin.so"
+			so := strings.TrimSuffix(filepath.Base(src), ".go") + ext
 			out := filepath.Join(filepath.Dir(src), so)
 			// build latest version of shared object
 			cmd := exec.Command("go", "build", "-buildmode=plugin", "-o="+out, src)
 			res, err := cmd.Output()
 			if err != nil {
-				panic(string(res) + err.Error())
+				panic(fmt.Sprintf("attempted to build %v to %v\n", src, out) + string(res) + err.Error())
 			}
 		}
 	}

--- a/scratch/config.yaml
+++ b/scratch/config.yaml
@@ -1,0 +1,2 @@
+plugins:
+  tick: no msg

--- a/scratch/config.yaml
+++ b/scratch/config.yaml
@@ -1,2 +1,0 @@
-plugins:
-  tick: no msg

--- a/util/test/tempfs.go
+++ b/util/test/tempfs.go
@@ -13,7 +13,7 @@ import (
 // WithTempFS creates a temporary directory structure and invokes f with the
 // root directory path.
 func WithTempFS(files map[string]string, f func(string)) {
-	rootDir, cleanup, err := MakeTempFS(files)
+	rootDir, cleanup, err := MakeTempFS("", "loader_test", files)
 	if err != nil {
 		panic(err)
 	}
@@ -21,12 +21,13 @@ func WithTempFS(files map[string]string, f func(string)) {
 	f(rootDir)
 }
 
-// MakeTempFS creates a temporary directory structure for test purposes. If the
-// creation fails, cleanup is nil and the caller does not have to invoke it. If
+// MakeTempFS creates a temporary directory structure for test purposes rooted at root.
+// If root is empty, the dir is created in the default system temp location.
+// If the creation fails, cleanup is nil and the caller does not have to invoke it. If
 // creation succeeds, the caller should invoke cleanup when they are done.
-func MakeTempFS(files map[string]string) (rootDir string, cleanup func(), err error) {
+func MakeTempFS(root, prefix string, files map[string]string) (rootDir string, cleanup func(), err error) {
 
-	rootDir, err = ioutil.TempDir("", "loader_test")
+	rootDir, err = ioutil.TempDir(root, prefix)
 
 	if err != nil {
 		return "", nil, err


### PR DESCRIPTION
All files that contain plugin specific tests/logic have build tag `+build linux,cgo darwin,cgo`. All files that have only non-plugin functionality have `+build !linux,!darwin !cgo`. This should allow OPA to build correctly with the latest functionality on all platforms.

Will add docs once approved.

Builtins:
- These can be loaded through calling runtime.Init with the correct values in the Params object
- Can be also accessed through the `--builtin-dir` flag from the command line on the root command; these will be loaded no matter what command is run
- Added tests
- If using OPA as a go library, can still idempotently load builtins using `runtime.RegisterBuiltinsFromDir`

Plugins:
- Plugins are only started if they are listed under the `plugins` tag in the config file, and can accept arbitrary JSON arguments as the value of that tag in the config file
- Added PluginInitFunc as a type
- Added PluginDir to Params
- Made RegisterPlugin idempotent
- Added `--plugin-dir` command line flag under the run command only
- If using OPA as a go library, can still idempotently load plugins using `runtime.RegisterPluginsFromDir`
- Added formal testing (but more should still be fleshed out)


NEW:

The loading system takes all .so files and simply executes an Init() error function from each of them. 
This is used to register plugins and builtins and offers maximum flexibility to the end user.