### PR TITLE
Safe composite returns containing unknown values in partial eval

### DIFF
--- a/topdown/topdown_partial_test.go
+++ b/topdown/topdown_partial_test.go
@@ -418,6 +418,65 @@ func TestTopDownPartialEval(t *testing.T) {
 			},
 		},
 		{
+			note:  "save: function with call composite result (array)",
+			query: `split(input, "@", [x]); startswith(x, "foo")`,
+			wantQueries: []string{
+				`split(input, "@", [x]); startswith(x, "foo")`,
+			},
+		},
+		{
+			note:  "save: function with call composite result (array, nested)",
+			query: `data.test.foo(input, [[x, _]]); startswith(x, "foo")`,
+			modules: []string{
+				`package test
+				foo(a) = o {
+				  o := [[a.x, a.y]]
+				}
+				`},
+			wantQueries: []string{
+				`data.test.foo(input, [[x, _]]); startswith(x, "foo")`,
+			},
+		},
+		{
+			note:  "save: function with call composite result (object)",
+			query: `data.test.foo(input, {"x": y}); startswith(y, "foo")`,
+			modules: []string{
+				`package test
+				foo(a) = o {
+				  o := { "x": a.y }
+				}
+				`},
+			wantQueries: []string{
+				`data.test.foo(input, {"x": y}); startswith(y, "foo")`,
+			},
+		},
+		{
+			note:  "save: function with call composite result (object, nested)",
+			query: `data.test.foo(input, {"x": [y, z]}); startswith(y, "foo")`,
+			modules: []string{
+				`package test
+				foo(a) = o {
+				  o := { "x": [a.y, a.z] }
+				}
+				`},
+			wantQueries: []string{
+				`data.test.foo(input, {"x": [y, z]}); startswith(y, "foo")`,
+			},
+		},
+		{
+			note:  "save: function with call composite result (array/object, mixed)",
+			query: `data.test.foo(input, {"x": [ { "a": y }, _]}); startswith(y, "foo")`,
+			modules: []string{
+				`package test
+				foo(a) = o {
+				  o := { "x": [ {"a": a.y }, a.z] }
+				}
+				`},
+			wantQueries: []string{
+				`data.test.foo(input, {"x": [{"a": y}, _]}); startswith(y, "foo")`,
+			},
+		},
+		{
 			note:  "save: with",
 			query: "data.test.p = true",
 			modules: []string{


### PR DESCRIPTION
This should address #833. I'm not sure if the case for `ast.Object` is sufficient (can we match keys?).

This is the errors we get on master with the added test cases:

```
    --- FAIL: TestTopDownPartialEval/save:_call_composite_result_(array) (0.00s)
    	/Users/stephan/go/src/github.com/open-policy-agent/opa/topdown/topdown_partial_test.go:911: startswith(x, "foo"): eval_type_error: startswith: operand 1 must be string but got var
    --- FAIL: TestTopDownPartialEval/save:_call_composite_result_(array,_nested) (0.00s)
    	/Users/stephan/go/src/github.com/open-policy-agent/opa/topdown/topdown_partial_test.go:911: startswith(x, "foo"): eval_type_error: startswith: operand 1 must be string but got var
    --- FAIL: TestTopDownPartialEval/save:_call_composite_result_(object) (0.00s)
    	/Users/stephan/go/src/github.com/open-policy-agent/opa/topdown/topdown_partial_test.go:911: startswith(y, "foo"): eval_type_error: startswith: operand 1 must be string but got var
    --- FAIL: TestTopDownPartialEval/save:_call_composite_result_(object,_nested) (0.00s)
    	/Users/stephan/go/src/github.com/open-policy-agent/opa/topdown/topdown_partial_test.go:911: startswith(y, "foo"): eval_type_error: startswith: operand 1 must be string but got var
```