### PR TITLE
Remove support rule if default value is not needed

### DIFF
--- a/server/server_test.go
+++ b/server/server_test.go
@@ -197,7 +197,7 @@ func TestCompileV1(t *testing.T) {
 		data.a[i] = input.x
 	}
 
-	default r = false
+	default r = true
 	`
 
 	expQuery := func(s string) string {
@@ -263,7 +263,7 @@ func TestCompileV1(t *testing.T) {
 					`data.partial.test.r = true`,
 					`package partial.test
 
-					default r = false
+					default r = true
 					`)},
 			},
 		},

--- a/topdown/eval.go
+++ b/topdown/eval.go
@@ -1441,11 +1441,20 @@ func (e evalVirtualComplete) eval(iter unifyIterator) error {
 		return e.evalValue(iter)
 	}
 
-	if e.ir.Default == nil {
-		return e.partialEval(iter)
+	if e.ir.Default != nil {
+		rterm := e.rbindings.Plug(e.rterm)
+
+		// If the other term is not constant OR it's equal to the default value, then
+		// a support rule must be produced as the default value _may_ be required. On
+		// the other hand, if the other term is constant (i.e., it does not require
+		// evaluation) and it differs from the default value then the default value is
+		// _not_ required, so partially evaluate the rule normally.
+		if !ast.IsConstant(rterm.Value) || e.ir.Default.Head.Value.Equal(rterm) {
+			return e.partialEvalDefault(iter)
+		}
 	}
 
-	return e.partialEvalDefault(iter)
+	return e.partialEval(iter)
 }
 
 func (e evalVirtualComplete) evalValue(iter unifyIterator) error {

--- a/topdown/example_test.go
+++ b/topdown/example_test.go
@@ -224,7 +224,7 @@ func ExampleQuery_PartialRun() {
 		WithTransaction(txn)
 
 	// Execute partial evaluation.
-	partial, support, err := q.PartialRun(ctx)
+	partial, _, err := q.PartialRun(ctx)
 	if err != nil {
 		// Handle error.
 	}
@@ -235,13 +235,6 @@ func ExampleQuery_PartialRun() {
 
 	for i := range partial {
 		fmt.Println(partial[i])
-	}
-
-	fmt.Println()
-	fmt.Println("# partial evaluation support:")
-
-	for i := range support {
-		fmt.Println(support[i])
 	}
 
 	// Construct a new policy to contain the result of partial evaluation.
@@ -261,10 +254,6 @@ func ExampleQuery_PartialRun() {
 
 	// Compile the partially evaluated policy with the original policy.
 	modules["partial"] = module
-
-	for i, v := range support {
-		modules[fmt.Sprintf("partial_support_%d", i)] = v
-	}
 
 	if compiler.Compile(modules); compiler.Failed() {
 		// Handle error.
@@ -303,17 +292,11 @@ func ExampleQuery_PartialRun() {
 	// Output:
 	//
 	// # partial evaluation result:
-	// data.partial.example.allow = true
-	//
-	// # partial evaluation support:
-	// package partial.example
-	//
-	// allow = true { "dev" = input.group; "read_bucket" = input.permission }
-	// allow = true { "test" = input.group; "read_bucket" = input.permission }
-	// allow = true { "sre" = input.group; "read_bucket" = input.permission }
-	// allow = true { "sre" = input.group; "write_bucket" = input.permission }
-	// allow = true { "sre" = input.group; "delete_bucket" = input.permission }
-	// default allow = false
+	// "dev" = input.group; "read_bucket" = input.permission
+	// "test" = input.group; "read_bucket" = input.permission
+	// "sre" = input.group; "read_bucket" = input.permission
+	// "sre" = input.group; "write_bucket" = input.permission
+	// "sre" = input.group; "delete_bucket" = input.permission
 	//
 	// # evaluation results:
 	// input 1 allowed: true

--- a/topdown/topdown_partial_test.go
+++ b/topdown/topdown_partial_test.go
@@ -225,6 +225,19 @@ func TestTopDownPartialEval(t *testing.T) {
 			},
 		},
 		{
+			note:  "reference: default not required",
+			query: "data.test.p = true",
+			modules: []string{
+				`package test
+
+				default p = false
+				p {
+					input.x = 1
+				}`,
+			},
+			wantQueries: []string{`input.x = 1`},
+		},
+		{
 			note:  "namespace: complete",
 			query: "data.test.p = x",
 			modules: []string{
@@ -659,7 +672,7 @@ func TestTopDownPartialEval(t *testing.T) {
 				`package test
 				default p = false
 				p { q = true; s } # using q = true syntax to avoid dealing with implicit != false expr
-				default q = false
+				default q = true  # same value as expr above so default must be kept
 				q { r }
 				r { input.x = 1 }
 				r { input.y = 2 }
@@ -672,7 +685,7 @@ func TestTopDownPartialEval(t *testing.T) {
 				`package partial.test
 				q = true { input.x = 1 }
 				q = true { input.y = 2 }
-				default q = false
+				default q = true
 				p = true { data.partial.test.q = true; input.z = 3 }
 				default p = false
 				`,


### PR DESCRIPTION
Previously, partial eval would always generate a support rule when it
evaluated a rule with a default value. These changes tweak this
behaviour so that support rules are only generated if the default value
is required in the partial eval output. It's better to avoid generating
support rules as it simplifies the assumptions that the consumer of
partial eval can make.

Fixes #820

Signed-off-by: Torin Sandall <torinsandall@gmail.com>