### PR TITLE
Add support for command line bundle loading

### DIFF
--- a/docs/book/bundles.md
+++ b/docs/book/bundles.md
@@ -130,3 +130,17 @@ metadata. The file should contain a JSON serialized object.
 * If the bundle service is capable of serving different revisions of the same
   bundle, the service should include a top-level `revision` field containing a
   `string` value that identifies the bundle revision.
+
+OPA will only load data files named `data.json`, i.e., you MUST name files
+that contain data (which you want loaded into OPA) `data.json` -- otherwise
+they will be ignored.
+
+## Debugging Your Bundles
+
+When you run OPA, you can provide bundle files over the command line. This
+allows you to manually check that your bundles include all of the files that
+you intended and that they are structured correctly. For example:
+
+```bash
+opa run bundle.tar.gz
+```

--- a/loader/merge.go
+++ b/loader/merge.go
@@ -4,9 +4,9 @@
 
 package loader
 
-// mergeDocs returns the result of merging a and b. If a and b cannot be merged
-// because of conflicting key-value pairs, ok is false.
-func mergeDocs(a map[string]interface{}, b map[string]interface{}) (c map[string]interface{}, ok bool) {
+// mergeInterfaces returns the result of merging a and b. If a and b cannot be
+// merged because of conflicting key-value pairs, ok is false.
+func mergeInterfaces(a map[string]interface{}, b map[string]interface{}) (c map[string]interface{}, ok bool) {
 
 	c = map[string]interface{}{}
 	for k := range a {
@@ -28,7 +28,7 @@ func mergeDocs(a map[string]interface{}, b map[string]interface{}) (c map[string
 			return nil, false
 		}
 
-		c[k], ok = mergeDocs(existObj, addObj)
+		c[k], ok = mergeInterfaces(existObj, addObj)
 		if !ok {
 			return nil, false
 		}

--- a/loader/merge_test.go
+++ b/loader/merge_test.go
@@ -38,7 +38,7 @@ func TestMergeDocs(t *testing.T) {
 
 		if len(tc.c) == 0 {
 
-			c, ok := mergeDocs(a, b)
+			c, ok := mergeInterfaces(a, b)
 			if ok {
 				t.Errorf("Expected merge(%v,%v) == false but got: %v", a, b, c)
 			}
@@ -50,7 +50,7 @@ func TestMergeDocs(t *testing.T) {
 				panic(err)
 			}
 
-			c, ok := mergeDocs(a, b)
+			c, ok := mergeInterfaces(a, b)
 			if !ok || !reflect.DeepEqual(c, expected) {
 				t.Errorf("Expected merge(%v, %v) == %v but got: %v (ok: %v)", a, b, expected, c, ok)
 			}


### PR DESCRIPTION
Previously OPA would only load JSON/YAML/Rego files off the command
line. With these changes, OPA will load .tar.gz files and interpret them
as bundles. This is useful if you want to test your bundles locally with
OPA without running OPA as a server, configuring it to pull down the
bundle, etc.

Fixes #870

Signed-off-by: Torin Sandall <torinsandall@gmail.com>