### PR TITLE
Improve Docker tutorial example

### DIFF
--- a/docs/book/docker-authorization.md
+++ b/docs/book/docker-authorization.md
@@ -159,7 +159,7 @@ deny {
 seccomp_unconfined {
     # This expression asserts that the string on the right-hand side is equal
     # to an element in the array SecurityOpt referenced on the left-hand side.
-    input.Body.HostConfig.SecurityOpt[_] = "seccomp:unconfined"
+    input.Body.HostConfig.SecurityOpt[_] == "seccomp:unconfined"
 }
 EOF
 ```
@@ -221,15 +221,16 @@ default allow = false
 
 # allow if the user is granted read/write access.
 allow {
-    user_id = input.Headers["Authz-User"]
-    not users[user_id].readOnly
+    user_id := input.Headers["Authz-User"]
+    user := users[user_id]
+    not user.readOnly
 }
 
 # allow if the user is granted read-only access and the request is a GET.
 allow {
-    user_id = input.Headers["Authz-User"]
+    user_id := input.Headers["Authz-User"]
     users[user_id].readOnly
-    input.Method = "GET"
+    input.Method == "GET"
 }
 
 # users defines permissions for the user. In this case, we define a single


### PR DESCRIPTION
Previously the example policy at the end of the tutorial would allow
operations if the Authz-User was contained in the input headers but not
in the user mapping. This change makes sure that the user is defined in
the mapping.

Also, update the example to use := and == instead of = (which is
functionaly the same but better practice because they avoid capturing
globals.)

Fixes #880

Signed-off-by: Torin Sandall <torinsandall@gmail.com>