### PR TITLE
Make default decision path configurable

### DIFF
--- a/docs/book/configuration.md
+++ b/docs/book/configuration.md
@@ -56,6 +56,7 @@ multiple services.
 | Field | Type | Required | Description |
 | --- | --- | --- | --- |
 | `labels` | `object` | Yes | Set of key-value pairs that uniquely identify the OPA instance. Labels are included when OPA uploads decision logs and status information. |
+| `default_decision` | `string` | No (default: `system/main`) | Path of policy decision to query for if client does not specify one. The actual policy query is constructed by converting the path into a reference (e.g., `system/main` becomes `data.system.main`.) |
 
 ## Bundles
 

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/server"
 	"github.com/open-policy-agent/opa/storage"
 	"github.com/open-policy-agent/opa/util"
 	"github.com/open-policy-agent/opa/util/test"
@@ -261,4 +262,31 @@ func TestRuntimeProcessWatchEventPolicyError(t *testing.T) {
 		}
 
 	})
+}
+
+func TestRuntimeConfigParsing(t *testing.T) {
+
+	empty := []byte("")
+	c1, err := newRuntimeConfig(empty)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if c1.DefaultDecision.Compare(server.DefaultDecision) != 0 {
+		t.Fatal("Expected default decision to be set to data.system.main but got:", c1.DefaultDecision)
+	}
+
+	example := []byte(`{
+		"default_decision": "/foo/bar",
+	}`)
+
+	c2, err := newRuntimeConfig(example)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if c2.DefaultDecision.Compare(ast.MustParseRef("data.foo.bar")) != 0 {
+		t.Fatal("Expected default decision to be set to data.foo.bar but got:", c2.DefaultDecision)
+	}
+
 }


### PR DESCRIPTION
These changes just make the default policy decision path configurable.
This path is used when callers execute unversioned POST requests against
OPA's HTTP API. Library integrations are free to implement behaviour.
Relying on this kind of behaviour simplifies integration because
services do not have to be configured with a path to query.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>