### PR TITLE
Remove shorthand for --plugin-dir flag

### DIFF
--- a/cmd/plugins.go
+++ b/cmd/plugins.go
@@ -9,10 +9,11 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/spf13/cobra"
 	"os"
 	"path/filepath"
 	"plugin"
+
+	"github.com/spf13/cobra"
 )
 
 // registerSharedObjectsFromDir recursively loads all .so files in dir into OPA.
@@ -68,7 +69,7 @@ func init() {
 	var pluginDir string
 
 	// flag is persistent (can be loaded on all children commands)
-	RootCommand.PersistentFlags().StringVarP(&pluginDir, "plugin-dir", "p", "", `set directory path to load built-in and plugin shared object files from`)
+	RootCommand.PersistentFlags().StringVarP(&pluginDir, "plugin-dir", "", "", `set directory path to load built-in and plugin shared object files from`)
 
 	// Runs before *all* children commands
 	RootCommand.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
We will probably want to use -p at some other point and this feature is
not likely to be needed in interactive environments.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>