### PR TITLE
v0.9.1 How Do I Write Policies example output fix

### DIFF
--- a/docs/book/how-do-i-write-policies.md
+++ b/docs/book/how-do-i-write-policies.md
@@ -174,13 +174,13 @@ When we query for `q` we obtain a set of names:
 
 ```ruby
 > q[x]
-+----------+
-|    x     |
-+----------+
-| "prod"   |
-| "smoke1" |
-| "dev"    |
-+----------+
++----------+----------+
+|    x     |   q[x]   |
++----------+----------+
+| "prod"   | "prod"   |
+| "smoke1" | "smoke1" |
+| "dev"    | "dev"    |
++----------+----------+
 ```
 
 We can re-write the rule `r` from above to make use of `q`. We will call the new rule `p`:
@@ -201,7 +201,8 @@ Rules which have arguments can be queried with input values:
 ```ruby
 > q["smoke2"]
 undefined
-> q["dev"]
+> r {q["dev"]}
+> r
 true
 ```
 


### PR DESCRIPTION
The output from running the interactive
interpretter with v0.9.1 does not match
a few of the examples list in the
How Do I Write Policies section.

This updates the examples to match
the examples observed from running
the v0.9.1 cli.

Signed-off-by: Travis Tripp <os.travis.tripp@gmail.com>