### PR TITLE
Improve formatting of empty ast.Body

### DIFF
--- a/ast/policy.go
+++ b/ast/policy.go
@@ -713,6 +713,9 @@ func (body Body) IsGround() bool {
 
 // Loc returns the location of the Body in the definition.
 func (body Body) Loc() *Location {
+	if len(body) == 0 {
+		return nil
+	}
 	return body[0].Location
 }
 

--- a/format/format_test.go
+++ b/format/format_test.go
@@ -29,6 +29,14 @@ func TestFormatNilLocation(t *testing.T) {
 	}
 }
 
+func TestFormatNilLocationEmptyBody(t *testing.T) {
+	b := ast.NewBody()
+	x, err := Ast(b)
+	if len(x) != 0 || err != nil {
+		t.Fatalf("Expected empty result but got: %q, err: %v", string(x), err)
+	}
+}
+
 func TestFormatSourceError(t *testing.T) {
 	rego := "testfiles/test.rego.error"
 	contents, err := ioutil.ReadFile(rego)

--- a/internal/presentation/presentation.go
+++ b/internal/presentation/presentation.go
@@ -254,7 +254,7 @@ func prettyASTNode(x interface{}) (string, int, error) {
 	setLocationRecursive(x)
 	bs, err := format.Ast(x)
 	if err != nil {
-		return "", 0, err
+		return "", 0, fmt.Errorf("format error: %v", err)
 	}
 	var maxLineWidth int
 	s := strings.Trim(strings.Replace(string(bs), "\t", "  ", -1), "\n")


### PR DESCRIPTION
Previously, if an empty ast.Body was passed to the formatting package,
it would trigger a panic because the location getter would try to index
into an empty slice.

These changes make the location getter tolerate empty bodies and the
format package tolerate nil locations on empty bodies.

Fixes #909

Signed-off-by: Torin Sandall <torinsandall@gmail.com>