### PR TITLE
Fix copy propagator type assertion panic

### DIFF
--- a/topdown/copypropagation/copypropagation.go
+++ b/topdown/copypropagation/copypropagation.go
@@ -61,9 +61,11 @@ func (p *CopyPropagator) Apply(query ast.Body) (result ast.Body) {
 	headvars := ast.NewVarSet()
 	ast.WalkRefs(query, func(x ast.Ref) bool {
 		if v, ok := x[0].Value.(ast.Var); ok {
-			headvars.Add(v)
 			if root, ok := uf.Find(v); ok {
 				root.constant = nil
+				headvars.Add(root.key)
+			} else {
+				headvars.Add(v)
 			}
 		}
 		return false

--- a/topdown/topdown_partial_test.go
+++ b/topdown/topdown_partial_test.go
@@ -900,6 +900,22 @@ func TestTopDownPartialEval(t *testing.T) {
 			},
 		},
 		{
+			note:  "copy propagation: reference head: call transitive with union-find",
+			query: "data.test.p = true",
+			modules: []string{
+				`package test
+
+				p {
+					split(input, ":", x)
+					y = x
+					y[0]
+				}`,
+			},
+			wantQueries: []string{
+				`split(input, ":", x1); x1[0]`,
+			},
+		},
+		{
 			note:  "copy propagation: live built-in output",
 			query: "plus(input, 1, x); x = y",
 			wantQueries: []string{


### PR DESCRIPTION
The copy propagator was not taking the union-find subsitutions into
account when building the headvar set. As a result, bindings were being
added for call expressions when the var would later be substituted for a
ref head (which ultimately would cause a panic when the ref head was
substituted for the call).

These changes update the copy propagator to add the union-find root to
the headvar set instead of the headvar. This way the headvar
construction is consistent with the binding plug and update below.

Fixes #912

Signed-off-by: Torin Sandall <torinsandall@gmail.com>