### PR TITLE
Fix to indent 4 spaces instead of a tab

### DIFF
--- a/docs/book/tutorials/kubernetes-admission-control-validation/ingress-conflicts.rego
+++ b/docs/book/tutorials/kubernetes-admission-control-validation/ingress-conflicts.rego
@@ -3,9 +3,9 @@ package kubernetes.admission
 import data.kubernetes.ingresses
 
 deny[msg] {
-	input.request.kind.kind = "Ingress"
+    input.request.kind.kind = "Ingress"
     input.request.operation = "CREATE"
-	host = input.request.object.spec.rules[_].host
+    host = input.request.object.spec.rules[_].host
     ingress = ingresses[other_ns][other_ingress]
     other_ns != input.request.namespace
     ingress.spec.rules[_].host = host

--- a/docs/book/tutorials/kubernetes-admission-control-validation/ingress-whitelist.rego
+++ b/docs/book/tutorials/kubernetes-admission-control-validation/ingress-whitelist.rego
@@ -5,32 +5,32 @@ import data.kubernetes.namespaces
 deny[msg] {
     input.request.kind.kind = "Ingress"
     input.request.operation = "CREATE"
-	host = input.request.object.spec.rules[_].host
-	not fqdn_matches_any(host, valid_ingress_hosts)
-	msg = sprintf("invalid ingress host %q", [host])
+    host = input.request.object.spec.rules[_].host
+    not fqdn_matches_any(host, valid_ingress_hosts)
+    msg = sprintf("invalid ingress host %q", [host])
 }
 
 valid_ingress_hosts = {host |
-	whitelist = namespaces[input.request.namespace].metadata.annotations["ingress-whitelist"]
-	hosts = split(whitelist, ",")
-	host = hosts[_]
+    whitelist = namespaces[input.request.namespace].metadata.annotations["ingress-whitelist"]
+    hosts = split(whitelist, ",")
+    host = hosts[_]
 }
 
 fqdn_matches_any(str, patterns) {
-	fqdn_matches(str, patterns[_])
+    fqdn_matches(str, patterns[_])
 }
 
 fqdn_matches(str, pattern) {
-	pattern_parts = split(pattern, ".")
-	pattern_parts[0] = "*"
-	str_parts = split(str, ".")
-	n_pattern_parts = count(pattern_parts)
-	n_str_parts = count(str_parts)
-	suffix = trim(pattern, "*.")
-	endswith(str, suffix)
+    pattern_parts = split(pattern, ".")
+    pattern_parts[0] = "*"
+    str_parts = split(str, ".")
+    n_pattern_parts = count(pattern_parts)
+    n_str_parts = count(str_parts)
+    suffix = trim(pattern, "*.")
+    endswith(str, suffix)
 }
 
 fqdn_matches(str, pattern) {
-	not contains(pattern, "*")
-	str = pattern
+    not contains(pattern, "*")
+    str = pattern
 }


### PR DESCRIPTION
On the document, all rego files are indented with 4 spaces. Thus this
commit fixes to indent 4 spaces instead of a tab.

- https://www.openpolicyagent.org/docs/kubernetes-admission-control.html

Signed-off-by: Kazuki Suda <kazuki.suda@gmail.com>