### PR TITLE
Fix XSS in debug page

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"html/template"
 	"io"
 	"io/ioutil"
 	"net"
@@ -1803,7 +1804,7 @@ func renderQueryForm(w http.ResponseWriter, qStrs []string, inputStrs []string, 
 	<br><input type="submit" value="Submit"> Explain:
 	<input type="radio" name="explain" value="off" %v>Off
 	<input type="radio" name="explain" value="full" %v>Full
-	</form>`, query, input, explainRadioCheck[0], explainRadioCheck[1])
+	</form>`, template.HTMLEscapeString(query), template.HTMLEscapeString(input), explainRadioCheck[0], explainRadioCheck[1])
 }
 
 func renderQueryResult(w io.Writer, results interface{}, err error, t0 time.Time) {
@@ -1812,12 +1813,12 @@ func renderQueryResult(w io.Writer, results interface{}, err error, t0 time.Time
 	d := time.Since(t0)
 
 	if err != nil {
-		fmt.Fprintf(w, "Query error (took %v): <pre>%v</pre>", d, err)
+		fmt.Fprintf(w, "Query error (took %v): <pre>%v</pre>", d, template.HTMLEscapeString(err.Error()))
 	} else if err2 != nil {
-		fmt.Fprintf(w, "JSON marshal error: <pre>%v</pre>", err2)
+		fmt.Fprintf(w, "JSON marshal error: <pre>%v</pre>", template.HTMLEscapeString(err.Error()))
 	} else {
 		fmt.Fprintf(w, "Query results (took %v):<br>", d)
-		fmt.Fprintf(w, "<pre>%s</pre>", string(buf))
+		fmt.Fprintf(w, "<pre>%s</pre>", template.HTMLEscapeString(string(buf)))
 	}
 }
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1132,6 +1132,25 @@ func TestV1Pretty(t *testing.T) {
 	}
 }
 
+func TestIndexGetEscaped(t *testing.T) {
+	f := newFixture(t)
+	get, err := http.NewRequest(http.MethodGet, `/?q=</textarea><script>alert(1)</script>`, strings.NewReader(""))
+	if err != nil {
+		panic(err)
+	}
+	f.server.Handler.ServeHTTP(f.recorder, get)
+	if f.recorder.Code != 200 {
+		t.Errorf("Expected success but got: %v", f.recorder)
+		return
+	}
+	page := f.recorder.Body.String()
+	exp := "&lt;/textarea&gt;&lt;script&gt;alert(1)&lt;/script&gt;"
+	if !strings.Contains(page, exp) {
+		t.Fatalf("Expected page to contain escaped URL parameter but got: %v", page)
+	}
+
+}
+
 func TestIndexGet(t *testing.T) {
 	f := newFixture(t)
 	get, err := http.NewRequest(http.MethodGet, `/?q=foo = 1&input=`, strings.NewReader(""))


### PR DESCRIPTION
Previously the query/input/error forms were being returned to the client
unescaped. This would allow for XSS attacks against admins with access
to the OPA debug page. While this scenario is quite uncommon (e.g., OPA
should be configured to listen on localhost/unix domain, authenticate
and authorize requests, etc.) it's still a possibility.

These changes escape the query/input/error forms returned to the browser
to prevent XSS attacks.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>