### PR TITLE
Fix Package stringer to handle bad inputs

### DIFF
--- a/ast/policy.go
+++ b/ast/policy.go
@@ -318,6 +318,11 @@ func (pkg *Package) SetLoc(loc *Location) {
 }
 
 func (pkg *Package) String() string {
+	if pkg == nil {
+		return "<illegal nil package>"
+	} else if len(pkg.Path) <= 1 {
+		return fmt.Sprintf("package <illegal path %q>", pkg.Path)
+	}
 	// Omit head as all packages have the DefaultRootDocument prepended at parse time.
 	path := make(Ref, len(pkg.Path)-1)
 	path[0] = VarTerm(string(pkg.Path[1].Value.(String)))

--- a/ast/policy_test.go
+++ b/ast/policy_test.go
@@ -88,6 +88,23 @@ func TestPackageString(t *testing.T) {
 	if result1 != expected1 {
 		t.Errorf("Expected %v but got %v", expected1, result1)
 	}
+
+	var nilPkg *Package
+
+	expNil := "<illegal nil package>"
+	if nilPkg.String() != expNil {
+		t.Fatal("Unexpected package repr:", nilPkg.String())
+	}
+
+	badPathPkg := &Package{
+		Path: RefTerm(VarTerm("x")).Value.(Ref),
+	}
+
+	expBadPath := "package <illegal path \"x\">"
+	if badPathPkg.String() != expBadPath {
+		t.Fatal("Unexpected package repr:", badPathPkg.String())
+	}
+
 }
 
 func TestImportEquals(t *testing.T) {


### PR DESCRIPTION
If users are constructing modules programatically they may accidentally
construct package paths with illegal values. Before this change, calling
.String() on the package would result in a panic. With these changes the
.String() function will no longer panic, instead it will return a string
representation that does not parse and indicates the source of the
issue.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>