### PR TITLE
Fix coverage flag for test command

### DIFF
--- a/docs/book/how-do-i-test-policies.md
+++ b/docs/book/how-do-i-test-policies.md
@@ -221,7 +221,7 @@ If we run the coverage report on the original **example.rego** file without
 that line 8 is not covered.
 
 ```bash
-opa test --cover --format=json example.rego example_test.rego
+opa test --coverage --format=json example.rego example_test.rego
 ```
 
 ```json


### PR DESCRIPTION
Currently in the docs an old flag `--cover` is used for the coverage. This PR corrects the flag and makes the example run again. 