### PR TITLE
Update test runner to set Fail to true

### DIFF
--- a/docs/book/how-do-i-test-policies.md
+++ b/docs/book/how-do-i-test-policies.md
@@ -169,7 +169,7 @@ $ opa test --format=json pass_fail_error_test.rego
     },
     "package": "data.example",
     "name": "test_ok",
-    "duration": 610111
+    "duration": 618515
   },
   {
     "location": {
@@ -179,8 +179,8 @@ $ opa test --format=json pass_fail_error_test.rego
     },
     "package": "data.example",
     "name": "test_failure",
-    "fail": false,
-    "duration": 325989
+    "fail": true,
+    "duration": 322177
   },
   {
     "location": {
@@ -199,7 +199,7 @@ $ opa test --format=json pass_fail_error_test.rego
         "col": 5
       }
     },
-    "duration": 325903
+    "duration": 345148
   }
 ]
 ```

--- a/tester/reporter.go
+++ b/tester/reporter.go
@@ -40,7 +40,7 @@ func (r PrettyReporter) Report(ch chan *Result) error {
 			pass++
 		} else if tr.Error != nil {
 			errs++
-		} else if tr.Fail != nil {
+		} else if tr.Fail {
 			fail++
 		}
 		if !tr.Pass() || r.Verbose {

--- a/tester/reporter_test.go
+++ b/tester/reporter_test.go
@@ -8,12 +8,10 @@ import (
 
 func TestPrettyReporter(t *testing.T) {
 
-	var badResult interface{} = "fail"
-
 	ts := []*Result{
-		{nil, "data.foo.bar", "test_baz", nil, nil, 0},
-		{nil, "data.foo.bar", "test_qux", nil, fmt.Errorf("some err"), 0},
-		{nil, "data.foo.bar", "test_corge", &badResult, nil, 0},
+		{nil, "data.foo.bar", "test_baz", false, nil, 0},
+		{nil, "data.foo.bar", "test_qux", false, fmt.Errorf("some err"), 0},
+		{nil, "data.foo.bar", "test_corge", true, nil, 0},
 	}
 
 	var buf bytes.Buffer

--- a/tester/runner_test.go
+++ b/tester/runner_test.go
@@ -56,7 +56,7 @@ func TestRun(t *testing.T) {
 			exp, ok := tests[k]
 			if !ok {
 				t.Errorf("Unexpected result for %v", k)
-			} else if exp.wantErr != (rs[i].Error != nil) || exp.wantFail != (rs[i].Fail != nil) {
+			} else if exp.wantErr != (rs[i].Error != nil) || exp.wantFail != rs[i].Fail {
 				t.Errorf("Expected %v for %v but got: %v", exp, k, rs[i])
 			}
 		}


### PR DESCRIPTION
Previously the test runner would set fail to the value generated by the
test rule or false on undefined. The intent was to communicate the value
generated by the rule. In practice users are not writing tests that
generate values other than true so this is essentially unnecessary.

Fixes #954

Signed-off-by: Torin Sandall <torinsandall@gmail.com>