### PR TITLE
Inline negated expressions during partial eval

### DIFF
--- a/ast/visit.go
+++ b/ast/visit.go
@@ -332,19 +332,29 @@ func (vis *VarVisitor) Visit(v interface{}) Visitor {
 		}
 	}
 	if vis.params.SkipRefCallHead {
-		if expr, ok := v.(*Expr); ok {
-			if terms, ok := expr.Terms.([]*Term); ok {
+		switch v := v.(type) {
+		case *Expr:
+			if terms, ok := v.Terms.([]*Term); ok {
 				for _, t := range terms[0].Value.(Ref)[1:] {
 					Walk(vis, t)
 				}
 				for i := 1; i < len(terms); i++ {
 					Walk(vis, terms[i])
 				}
-				for _, w := range expr.With {
+				for _, w := range v.With {
 					Walk(vis, w)
 				}
 				return nil
 			}
+		case Call:
+			operator := v[0].Value.(Ref)
+			for i := 1; i < len(operator); i++ {
+				Walk(vis, operator[i])
+			}
+			for i := 1; i < len(v); i++ {
+				Walk(vis, v[i])
+			}
+			return nil
 		}
 	}
 	if v, ok := v.(Var); ok {

--- a/topdown/bindings.go
+++ b/topdown/bindings.go
@@ -6,6 +6,7 @@ package topdown
 
 import (
 	"fmt"
+	"math"
 	"strings"
 
 	"github.com/open-policy-agent/opa/ast"
@@ -30,6 +31,10 @@ func (u *undo) Undo() {
 	u.u.delete(u.k)
 	u.next.Undo()
 }
+
+// sentinel is a binding list that will never be used. The binding list
+// identifier increments from zero.
+var sentinel = newBindings(math.MaxUint64, nil)
 
 type bindings struct {
 	id     uint64

--- a/topdown/query.go
+++ b/topdown/query.go
@@ -186,14 +186,6 @@ func (q *Query) PartialRun(ctx context.Context) (partials []ast.Body, support []
 
 	support = e.saveSupport.List()
 
-	for _, m := range support {
-		ast.WalkRules(m, func(r *ast.Rule) bool {
-			p := copypropagation.New(r.Head.Vars()).WithEnsureNonEmptyBody(true)
-			r.Body = p.Apply(r.Body)
-			return false
-		})
-	}
-
 	return partials, support, err
 }
 

--- a/topdown/topdown_partial_test.go
+++ b/topdown/topdown_partial_test.go
@@ -29,6 +29,7 @@ func TestTopDownPartialEval(t *testing.T) {
 		input       string
 		wantQueries []string
 		wantSupport []string
+		ignoreOrder bool
 	}{
 		{
 			note:        "empty",
@@ -362,7 +363,7 @@ func TestTopDownPartialEval(t *testing.T) {
 				}
 				`},
 			wantQueries: []string{
-				`startswith(input.x, "foo"); _ = input.y; x = input.x`,
+				`x = input.x; _ = input.y; startswith(x, "foo")`,
 			},
 		},
 		{
@@ -375,7 +376,7 @@ func TestTopDownPartialEval(t *testing.T) {
 				}
 				`},
 			wantQueries: []string{
-				`startswith(input.y, "foo"); x = input.y`,
+				`x = input.y; startswith(x, "foo")`,
 			},
 		},
 		{
@@ -388,7 +389,7 @@ func TestTopDownPartialEval(t *testing.T) {
 				}
 				`},
 			wantQueries: []string{
-				`startswith(input.y, "foo"); y = input.y; z = input.z`,
+				`y = input.y; z = input.z; startswith(y, "foo")`,
 			},
 		},
 		{
@@ -401,7 +402,7 @@ func TestTopDownPartialEval(t *testing.T) {
 				}
 				`},
 			wantQueries: []string{
-				`startswith(input.y, "foo"); _ = input.z; y = input.y`,
+				`y = input.y; _ = input.z; startswith(y, "foo")`,
 			},
 		},
 		{
@@ -733,13 +734,9 @@ func TestTopDownPartialEval(t *testing.T) {
 			wantSupport: []string{
 				`package partial.test
 
-				p = true { input.x = 1; not data.partial.__not1_1__ }
+				p = true { input.x = 1; not input.z = 3 }
 				p = true { input.y = 2 }
 				default p = false
-				`,
-				`package partial
-
-				__not1_1__ { input.z = 3 }
 				`,
 			},
 		},
@@ -783,43 +780,6 @@ func TestTopDownPartialEval(t *testing.T) {
 
 				p = true { input.x = 1 }
 				default p = false`,
-			},
-		},
-		{
-			note:  "support: negation",
-			query: "data.test.p = true",
-			modules: []string{
-				`package test
-				p { input.x = 1; not q; not r }
-				q { input.y = 2 }
-				r { false }`,
-			},
-			wantQueries: []string{
-				`input.x = 1; not data.partial.__not1_1__`,
-			},
-			wantSupport: []string{
-				`package partial
-
-				__not1_1__ { input.y = 2 }`,
-			},
-		},
-		{
-			note:  "support: negation with input",
-			query: "input.x = x; input.y = y; not data.test.p[[x,y]]",
-			modules: []string{
-				`package test
-
-				p[[0, 1]]
-				p[[2, 3]]`,
-			},
-			wantQueries: []string{
-				`input.x = x; input.y = y; not data.partial.__not0_2__(x, y)`,
-			},
-			wantSupport: []string{
-				`package partial
-
-				__not0_2__(x, y) { x = 0; y = 1 }
-				__not0_2__(x, y) { x = 2; y = 3 }`,
 			},
 		},
 		{
@@ -937,7 +897,7 @@ func TestTopDownPartialEval(t *testing.T) {
 			note:  "copy propagation: live built-in output",
 			query: "plus(input, 1, x); x = y",
 			wantQueries: []string{
-				`plus(input, 1, y); x = y`,
+				`plus(input, 1, x); y = x`,
 			},
 		},
 		{
@@ -1015,12 +975,7 @@ func TestTopDownPartialEval(t *testing.T) {
 					y = 1
 				}
 			`},
-			wantQueries: []string{`not data.partial.__not1_0__`},
-			wantSupport: []string{`
-				package partial
-
-				__not1_0__ = true { input.x = 1 }`,
-			},
+			wantQueries: []string{`not input.x = 1`},
 		},
 		{
 			note:  "copy propagation: apply to support rules: head vars are live",
@@ -1038,12 +993,7 @@ func TestTopDownPartialEval(t *testing.T) {
 					a = y
 				}
 			`},
-			wantQueries: []string{`not data.partial.__not1_1__(input.x)`},
-			wantSupport: []string{`
-				package partial
-
-				__not1_1__(z) = true { z = 1 }`,
-			},
+			wantQueries: []string{`not input.x = 1`},
 		},
 		{
 			note:  "copy propagation: negation safety",
@@ -1061,15 +1011,8 @@ func TestTopDownPartialEval(t *testing.T) {
 				}`,
 			},
 			wantQueries: []string{
-				"not data.partial.__not1_1__(x1); x1 = input.x[i1]",
+				"not input.y = x1; x1 = input.x[i1]",
 			},
-			wantSupport: []string{`
-				package partial
-
-				__not1_1__(x) {
-					x = input.y
-				}
-			`},
 		},
 		{
 			note:  "save set vars are namespaced",
@@ -1081,6 +1024,273 @@ func TestTopDownPartialEval(t *testing.T) {
 			},
 			wantQueries: []string{
 				`input = x`,
+			},
+		},
+		{
+			note:  "negation: inline compound",
+			query: "data.test.p = true",
+			modules: []string{
+				`package test
+
+				p { not q }
+				q { ((input.x + 7) / input.y) > 100 }`,
+			},
+			wantQueries: []string{
+				`not ((input.x + 7) / input.y) > 100`,
+			},
+		},
+		{
+			note:  "negation: inline conjunction",
+			query: "data.test.p = true",
+			modules: []string{
+				`package test
+
+				p { not q }
+				q { a = input.x + 7; b = a / input.y; b > 100 }`,
+			},
+			wantQueries: []string{
+				`not ((input.x + 7) / input.y) > 100`,
+			},
+		},
+		{
+			note:  "negation: inline safety",
+			query: "data.test.p = true",
+			modules: []string{
+				`package test
+
+				p {
+					input.x = 1;					# no op
+					not q;							# support
+					not r;							# fail
+					not s;							# inline (simple)
+					input.z = [z]; z1 = z; t(z1)	# inline transitive
+				}
+
+				q {
+					input.a[i] = 1
+				}
+
+				r { false }
+
+				s { input.y = 2 }
+
+				t(z2) {
+					z2 = z3
+					z3[0] = 1
+				}
+				`,
+			},
+			wantQueries: []string{
+				`input.x = 1; not data.partial.__not1_1__; not input.y = 2; input.z = [z38]; z38[0] = 1`,
+			},
+			wantSupport: []string{
+				`package partial
+
+				__not1_1__ {
+					input.a[i3] = 1
+				}`,
+			},
+		},
+		{
+			note:  "negation: inline safety with live var",
+			query: "input = x; not data.test.f(x)",
+			modules: []string{
+				`package test
+
+				f(x) {
+					count(x) != 3
+				}`,
+			},
+			wantQueries: []string{
+				`input = x; not count(x) != 3`,
+			},
+		},
+		{
+			note:  "negation: inline namespacing",
+			query: "data.test.p = true",
+			modules: []string{
+				`package test
+
+				p {
+					input = x; not f(x)
+				}
+
+				f(x) {
+					count(x) > 3
+				}`,
+			},
+			wantQueries: []string{
+				`not count(input) > 3`,
+			},
+		},
+		{
+			note:  "negation: inline namespacing embedded",
+			query: "data.test.p = true",
+			modules: []string{
+				`package test
+
+				p {
+					y = input.y
+					z = y
+					x = [z, 1]
+					not f(x)
+				}
+
+				f(x) {
+					sum(x) > 3
+				}`,
+			},
+			wantQueries: []string{
+				`not sum([input.y, 1]) > 3`,
+			},
+		},
+		{
+			note:  "negation: inline disjunction",
+			query: "data.test.p = true",
+			modules: []string{
+				`package test
+
+				p { not q }
+				q { input.x = 1 }
+				q { input.x = 2 }
+				`,
+			},
+			wantQueries: []string{
+				`not input.x = 1; not input.x = 2`,
+			},
+			ignoreOrder: true,
+		},
+		{
+			note:  "negation: inline disjunction with args",
+			query: "data.test.p = true",
+			modules: []string{
+				`package test
+
+				p { input.x = x; not q(x) }
+				q(x) { x = 1 }
+				q(x) { x = 2 }`,
+			},
+			wantQueries: []string{
+				`not input.x = 1; not input.x = 2`,
+			},
+			ignoreOrder: true,
+		},
+		{
+			note:  "negation: inline double negation (for all or universal quantifier pattern)",
+			query: `data.test.p = true`,
+			modules: []string{`
+				package test
+
+				p {
+					x = input[i]
+					not f(x)
+				}
+
+				f(x) {
+					q[y]
+					not g(y, x)
+				}
+
+				g(1, x) {
+					x.a = "foo"
+				}
+
+				g(2, x) {
+					x.b < 7
+				}
+
+				q = {
+					1, 2
+				}
+			`},
+			wantQueries: []string{
+				`input[i1].a = "foo"; input[i1].b < 7`,
+			},
+		},
+		{
+			note:  "negation: inline cross product",
+			query: "data.test.p = true",
+			modules: []string{
+				`package test
+
+				p {
+					not q
+				}
+
+				q {
+					x = r[_]
+					not f(x)
+				}
+
+				f({"key": "a", "values": values}) {
+					input.x = values[_]
+				}
+
+				f({"key": "b", "values": values}) {
+					input.y = values[_]
+				}
+
+				f({"key": "c", "values": values}) {
+					input.z = values[_]
+				}
+
+				r = [
+					{"key": "a", "values": [1,2]},
+					{"key": "b", "values": [3,4,5]},
+					{"key": "c", "values": [6]},
+				]`,
+			},
+			wantQueries: []string{
+				`1 = input.x; 3 = input.y; 6 = input.z`,
+				`1 = input.x; 4 = input.y; 6 = input.z`,
+				`1 = input.x; 5 = input.y; 6 = input.z`,
+				`2 = input.x; 3 = input.y; 6 = input.z`,
+				`2 = input.x; 4 = input.y; 6 = input.z`,
+				`2 = input.x; 5 = input.y; 6 = input.z`,
+			},
+		},
+		{
+			note:  "negation: inline cross product with live vars",
+			query: "input.x = x; input.y = y; not data.test.p[[x,y]]",
+			modules: []string{
+				`package test
+
+					p[[0, 1]]
+					p[[2, 3]]`,
+			},
+			wantQueries: []string{
+				`input.x = x; input.y = y; not x = 0; not x = 2`,
+				`input.x = x; input.y = y; not x = 0; not y = 3`,
+				`input.x = x; input.y = y; not y = 1; not x = 2`,
+				`input.x = x; input.y = y; not y = 1; not y = 3`,
+			},
+		},
+		{
+			note:  "negation: cross product limit",
+			query: "data.test.p = true",
+			modules: []string{
+				`package test
+				p {
+					not q
+				}
+				q {
+					# size of cross product is 27 which exceeds default limit
+					a = {1,2,3}
+					a[x]
+					input.x = x
+					input.y = x
+					input.z = 0
+				}
+				`,
+			},
+			wantQueries: []string{`not data.partial.__not1_0__`},
+			wantSupport: []string{
+				`package partial
+
+				__not1_0__ { input.x = 1; input.y = 1; input.z = 0 }
+				__not1_0__ { input.x = 2; input.y = 2; input.z = 0 }
+				__not1_0__ { input.x = 3; input.y = 3; input.z = 0 }
+				`,
 			},
 		},
 	}
@@ -1139,9 +1349,9 @@ func TestTopDownPartialEval(t *testing.T) {
 			}
 
 			queriesA, queriesB := bodySet(partials), bodySet(expectedQueries)
-			if !queriesB.Equal(queriesA) {
-				missing := queriesB.Diff(queriesA)
-				extra := queriesA.Diff(queriesB)
+			if !queriesB.Equal(queriesA, tc.ignoreOrder) {
+				missing := queriesB.Diff(queriesA, tc.ignoreOrder)
+				extra := queriesA.Diff(queriesB, tc.ignoreOrder)
 				t.Errorf("Partial evaluation results differ. Expected %d queries but got %d queries:\nMissing:\n%v\nExtra:\n%v", len(queriesB), len(queriesA), missing, extra)
 			}
 
@@ -1241,26 +1451,50 @@ func (s bodySet) String() string {
 	return strings.Join(buf, "\n")
 }
 
-func (s bodySet) Contains(b ast.Body) bool {
+func (s bodySet) Contains(b ast.Body, ignoreOrder bool) bool {
 	for i := range s {
-		if s[i].Equal(b) {
-			return true
+		if ignoreOrder {
+			if bodyEqualUnordered(b, s[i]) {
+				return true
+			}
+		} else {
+			if s[i].Equal(b) {
+				return true
+			}
 		}
 	}
 	return false
 }
 
-func (s bodySet) Diff(other bodySet) (r bodySet) {
+func (s bodySet) Diff(other bodySet, ignoreOrder bool) (r bodySet) {
 	for i := range s {
-		if !other.Contains(s[i]) {
+		if !other.Contains(s[i], ignoreOrder) {
 			r = append(r, s[i])
 		}
 	}
 	return r
 }
 
-func (s bodySet) Equal(other bodySet) bool {
-	return len(s.Diff(other)) == 0 && len(other.Diff(s)) == 0
+func (s bodySet) Equal(other bodySet, ignoreOrder bool) bool {
+	return len(s.Diff(other, ignoreOrder)) == 0 && len(other.Diff(s, ignoreOrder)) == 0
+}
+
+func bodyEqualUnordered(a, b ast.Body) bool {
+	for i := range a {
+		found := false
+		for j := range b {
+			cpy := b[j].Copy()
+			cpy.Index = a[i].Index // overwrite index to ensure comparison is unordered.
+			if a[i].Compare(cpy) == 0 {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
 }
 
 type moduleSet []*ast.Module


### PR DESCRIPTION
Previously partial eval would generate support rules for the result of
negated expressions. With these changes, the result of partially
evaluating a negated expression may be inlined into the containing
query.

The result of partially evaluating a negated expression may be inlined
if:

- The query set resulting partial eval does not contain any positive,
  non-ground expressions. E.g., p[x] cannot be safely negated so it
  would still result in support rules.

- The size of the cross product that represents the inlined result is
  not larger than 16. This limit is arbitrary and in the future we can
  make it configurable as needed.

In the future it may be possible to make the inlining decision more
sophisticated. For now though, because copy propagation is applied to
the result, it's often possible to inline results (since all of the
variables are removed.)

With these changes we plug the partial eval results and apply copy
propagation DURING partial eval instead of at the very end. This avoids
the need for extra stage after copy propagation that would walk the
result set, inline negation, and then cleanup the queries and support
modules. While the latter approach would allow for global optimizations,
it would be more complicated and not be any better for now (since we
are not applying global optimization.) To support adding plugged
expressions to the save stack, we have updated the save stack to keep
track of whether a plug operation has been performed (if the bindings
are nil then it's assumed that the contents have been plugged.) This
prevents the caller from accidentally calling plug twice (which would
cause namespacing issues.)

As part of these changes, we have modified the union-find structure in
the copy propagation implementation to rank live vars higher than
candidates for removal. This avoids adding extra vars to the results
(which helps the odds of being able to inline.)

Signed-off-by: Torin Sandall <torinsandall@gmail.com>