### PR TITLE
Fix panic in parser error detail construction

### DIFF
--- a/ast/parser_test.go
+++ b/ast/parser_test.go
@@ -1420,6 +1420,16 @@ func TestParseErrorDetails(t *testing.T) {
 		input string
 	}{
 		{
+			note: "no match: bad rule name",
+			exp: &parserErrorDetail{
+				line: ".",
+				idx:  0,
+			},
+			input: `
+package test
+.`,
+		},
+		{
 			note: "no match: bad termination for comprehension",
 			exp: &parserErrorDetail{
 				line: "p = [true | true}",


### PR DESCRIPTION
The parser was panic-ing when constructing an error detail because it
could index into the line with a negative offset. These changes improve
the improve the checks against the position input.

Fixes #948

Signed-off-by: Torin Sandall <torinsandall@gmail.com>