### PR TITLE
Fix unsafe support calls

### DIFF
--- a/topdown/eval.go
+++ b/topdown/eval.go
@@ -380,6 +380,14 @@ func (e *eval) evalNotPartialSupport(expr *ast.Expr, unknowns ast.VarSet, querie
 	path := term.Value.(ast.Ref)
 	head := ast.NewHead(ast.Var(supportName), nil, ast.BooleanTerm(true))
 
+	bodyVars := ast.NewVarSet()
+
+	for _, q := range queries {
+		bodyVars.Update(q.Vars(ast.VarVisitorParams{}))
+	}
+
+	unknowns = unknowns.Intersect(bodyVars)
+
 	// Make rule args. Sort them to ensure order is deterministic.
 	args := make([]*ast.Term, 0, len(unknowns))
 


### PR DESCRIPTION
The inlining changes introduced a bug in the support calls that are made
when the negation cannot be inlined. The support rule was being created
with one argument for each unknown in the entire save set. Since some of
those variables may not be preserved in the final result, it was
possible for the support call to become unsafe. To resolve this we only
add call args for the intersection of unknowns and vars that appear in
the result of partially evaluating the negated expression.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>