### PR TITLE
Remove heap allocations from AST set with open addressing.

### DIFF
--- a/ast/term.go
+++ b/ast/term.go
@@ -1127,13 +1127,17 @@ type Set interface {
 
 // NewSet returns a new Set containing t.
 func NewSet(t ...*Term) Set {
-	s := &set{
-		elems: map[int]*setElem{},
-	}
+	s := newset(len(t))
 	for i := range t {
 		s.Add(t[i])
 	}
 	return s
+}
+
+func newset(n int) *set {
+	return &set{
+		elems: make(map[int]*Term, n),
+	}
 }
 
 // SetTerm returns a new Term representing a set containing terms t.
@@ -1145,21 +1149,8 @@ func SetTerm(t ...*Term) *Term {
 }
 
 type set struct {
-	elems map[int]*setElem
+	elems map[int]*Term
 	keys  []*Term
-}
-
-type setElem struct {
-	elem *Term
-	next *setElem
-}
-
-func (s *setElem) String() string {
-	buf := []string{}
-	for c := s; c != nil; c = c.next {
-		buf = append(buf, fmt.Sprint(c.elem))
-	}
-	return strings.Join(buf, "->")
 }
 
 // Copy returns a deep copy of s.
@@ -1193,7 +1184,7 @@ func (s *set) String() string {
 	}
 	buf := []string{}
 	s.Foreach(func(x *Term) {
-		buf = append(buf, x.String())
+		buf = append(buf, fmt.Sprint(x))
 	})
 	return "{" + strings.Join(buf, ", ") + "}"
 }
@@ -1235,9 +1226,15 @@ func (s *set) Diff(other Set) Set {
 
 // Intersect returns the set containing elements in both s and other.
 func (s *set) Intersect(other Set) Set {
-	r := NewSet()
+	o := other.(*set)
+	n, m := s.Len(), o.Len()
+	if m < n {
+		n = m
+	}
+
+	r := newset(n)
 	s.Foreach(func(x *Term) {
-		if other.Contains(x) {
+		if o.Contains(x) {
 			r.Add(x)
 		}
 	})
@@ -1355,25 +1352,28 @@ func (s *set) Sorted() Array {
 
 func (s *set) insert(x *Term) {
 	hash := x.Hash()
-	head := s.elems[hash]
-	for curr := head; curr != nil; curr = curr.next {
-		if Compare(curr.elem, x) == 0 {
+	for curr, ok := s.elems[hash]; ok; {
+		if Compare(curr, x) == 0 {
 			return
 		}
+
+		hash++
+		curr, ok = s.elems[hash]
 	}
-	s.elems[hash] = &setElem{
-		elem: x,
-		next: head,
-	}
+
+	s.elems[hash] = x
 	s.keys = append(s.keys, x)
 }
 
-func (s *set) get(x *Term) *setElem {
+func (s *set) get(x *Term) *Term {
 	hash := x.Hash()
-	for curr := s.elems[hash]; curr != nil; curr = curr.next {
-		if Compare(curr.elem, x) == 0 {
+	for curr, ok := s.elems[hash]; ok; {
+		if Compare(curr, x) == 0 {
 			return curr
 		}
+
+		hash++
+		curr, ok = s.elems[hash]
 	}
 	return nil
 }


### PR DESCRIPTION
This removes about 15% of the mallocs and speeds up the set operations
roughly the same.

Signed-off-by: Teemu Koponen <koponen@styra.com>