### PR TITLE
opa test: add traces on errors

### DIFF
--- a/cmd/test.go
+++ b/cmd/test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/cover"
 	"github.com/open-policy-agent/opa/tester"
+	"github.com/open-policy-agent/opa/topdown"
 	"github.com/open-policy-agent/opa/util"
 	"github.com/spf13/cobra"
 )
@@ -118,6 +119,9 @@ func opaTest(args []string) int {
 	if testParams.coverage {
 		coverTracer = cover.New()
 		runner = runner.SetTracer(coverTracer)
+	} else if testParams.verbose ||
+		testParams.outputFormat.String() == testJSONOutput {
+		runner = runner.SetTracer(topdown.NewBufferTracer())
 	}
 
 	ch, err := runner.Run(ctx, modules)

--- a/tester/reporter.go
+++ b/tester/reporter.go
@@ -34,7 +34,7 @@ func (r PrettyReporter) Report(ch chan *Result) error {
 	dirty := false
 	var pass, fail, errs int
 
-	// Report individual tests.
+	var results, failures []*Result
 	for tr := range ch {
 		if tr.Pass() {
 			pass++
@@ -42,7 +42,27 @@ func (r PrettyReporter) Report(ch chan *Result) error {
 			errs++
 		} else if tr.Fail {
 			fail++
+			failures = append(failures, tr)
 		}
+		results = append(results, tr)
+	}
+
+	if fail > 0 && r.Verbose {
+		fmt.Fprintln(r.Output, "FAILURES")
+		r.hl()
+
+		for _, failure := range failures {
+			fmt.Fprintln(r.Output, failure)
+			fmt.Fprintln(r.Output)
+			fmt.Fprintln(r.Output, failure.Trace) // TODO: indent
+		}
+
+		fmt.Fprintln(r.Output, "\nSUMMARY")
+		r.hl()
+	}
+
+	// Report individual tests.
+	for _, tr := range results {
 		if !tr.Pass() || r.Verbose {
 			fmt.Fprintln(r.Output, tr)
 			dirty = true
@@ -54,7 +74,7 @@ func (r PrettyReporter) Report(ch chan *Result) error {
 
 	// Report summary of test.
 	if dirty {
-		fmt.Fprintln(r.Output, strings.Repeat("-", 80))
+		r.hl()
 	}
 
 	total := pass + fail + errs
@@ -74,6 +94,10 @@ func (r PrettyReporter) Report(ch chan *Result) error {
 	return nil
 }
 
+func (r PrettyReporter) hl() {
+	fmt.Fprintln(r.Output, strings.Repeat("-", 80))
+}
+
 // JSONReporter reports test results as array of JSON objects.
 type JSONReporter struct {
 	Output io.Writer
@@ -81,11 +105,12 @@ type JSONReporter struct {
 
 // Report prints the test report to the reporter's output.
 func (r JSONReporter) Report(ch chan *Result) error {
-	var results []*Result
+	var report []*Result
 	for tr := range ch {
-		results = append(results, tr)
+		report = append(report, tr)
 	}
-	bs, err := json.MarshalIndent(results, "", "  ")
+
+	bs, err := json.MarshalIndent(report, "", "  ")
 	if err != nil {
 		return err
 	}

--- a/tester/reporter_test.go
+++ b/tester/reporter_test.go
@@ -6,34 +6,33 @@ import (
 	"testing"
 )
 
-func TestPrettyReporter(t *testing.T) {
-
-	ts := []*Result{
-		{nil, "data.foo.bar", "test_baz", false, nil, 0},
-		{nil, "data.foo.bar", "test_qux", false, fmt.Errorf("some err"), 0},
-		{nil, "data.foo.bar", "test_corge", true, nil, 0},
-	}
-
+func TestPrettyReporterVerbose(t *testing.T) {
 	var buf bytes.Buffer
+	ts := []*Result{
+		{nil, "data.foo.bar", "test_baz", false, nil, 0, "trace test_baz"},
+		{nil, "data.foo.bar", "test_qux", false, fmt.Errorf("some err"), 0, "trace test_qux"},
+		{nil, "data.foo.bar", "test_corge", true, nil, 0, "trace test_corge"},
+	}
 
 	r := PrettyReporter{
 		Output:  &buf,
 		Verbose: true,
 	}
 
-	ch := make(chan *Result)
-	go func() {
-		for _, tr := range ts {
-			ch <- tr
-		}
-		close(ch)
-	}()
-
+	ch := resultsChan(ts)
 	if err := r.Report(ch); err != nil {
 		t.Fatal(err)
 	}
 
-	exp := `data.foo.bar.test_baz: PASS (0s)
+	exp := `FAILURES
+--------------------------------------------------------------------------------
+data.foo.bar.test_corge: FAIL (0s)
+
+trace test_corge
+
+SUMMARY
+--------------------------------------------------------------------------------
+data.foo.bar.test_baz: PASS (0s)
 data.foo.bar.test_qux: ERROR (0s)
   some err
 data.foo.bar.test_corge: FAIL (0s)
@@ -46,4 +45,94 @@ ERROR: 1/3
 	if exp != buf.String() {
 		t.Fatalf("Expected:\n\n%v\n\nGot:\n\n%v", exp, buf.String())
 	}
+}
+
+func TestPrettyReporter(t *testing.T) {
+	var buf bytes.Buffer
+	ts := []*Result{
+		{nil, "data.foo.bar", "test_baz", false, nil, 0, "trace test_baz"},
+		{nil, "data.foo.bar", "test_qux", false, fmt.Errorf("some err"), 0, "trace test_qux"},
+		{nil, "data.foo.bar", "test_corge", true, nil, 0, "trace test_corge"},
+	}
+
+	r := PrettyReporter{
+		Output:  &buf,
+		Verbose: false,
+	}
+	ch := resultsChan(ts)
+	if err := r.Report(ch); err != nil {
+		t.Fatal(err)
+	}
+
+	exp := `data.foo.bar.test_qux: ERROR (0s)
+  some err
+data.foo.bar.test_corge: FAIL (0s)
+--------------------------------------------------------------------------------
+PASS: 1/3
+FAIL: 1/3
+ERROR: 1/3
+`
+
+	if exp != buf.String() {
+		t.Fatalf("Expected:\n\n%v\n\nGot:\n\n%v", exp, buf.String())
+	}
+}
+
+func TestJSONReporter(t *testing.T) {
+	var buf bytes.Buffer
+	ts := []*Result{
+		{nil, "data.foo.bar", "test_baz", false, nil, 0, "trace test_baz"},
+		{nil, "data.foo.bar", "test_qux", false, fmt.Errorf("some err"), 0, "trace test_qux"},
+		{nil, "data.foo.bar", "test_corge", true, nil, 0, "trace test_corge"},
+	}
+
+	r := JSONReporter{
+		Output: &buf,
+	}
+	ch := resultsChan(ts)
+	if err := r.Report(ch); err != nil {
+		t.Fatal(err)
+	}
+
+	exp := `[
+  {
+    "location": null,
+    "package": "data.foo.bar",
+    "name": "test_baz",
+    "duration": 0,
+    "trace": "trace test_baz"
+  },
+  {
+    "location": null,
+    "package": "data.foo.bar",
+    "name": "test_qux",
+    "error": {},
+    "duration": 0,
+    "trace": "trace test_qux"
+  },
+  {
+    "location": null,
+    "package": "data.foo.bar",
+    "name": "test_corge",
+    "fail": true,
+    "duration": 0,
+    "trace": "trace test_corge"
+  }
+]
+`
+
+	if exp != buf.String() {
+		t.Fatalf("Expected:\n\n%v\n\nGot:\n\n%v", exp, buf.String())
+	}
+}
+
+func resultsChan(ts []*Result) chan *Result {
+	ch := make(chan *Result)
+	go func() {
+		for _, tr := range ts {
+			ch <- tr
+		}
+		close(ch)
+	}()
+	return ch
 }


### PR DESCRIPTION
This should be following the outline of https://github.com/open-policy-agent/opa/issues/856#issuecomment-408908578 closely.

I tend to agree that #961 would be quite cool, but I guess this is one step into the right direction, at least? 😃 