### PR TITLE
Add skip_cleanup: true to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ services:
 - docker
 deploy:
   - provider: script
+    skip_cleanup: true
     script: make deploy-travis
     on:
       repo: open-policy-agent/opa


### PR DESCRIPTION
This should prevent the linux executable from being deleted (it's
require by the image build.)

Signed-off-by: Torin Sandall <torinsandall@gmail.com>