### PR TITLE
cmd/test: rewrite duplicate test_* rule names

### DIFF
--- a/tester/reporter.go
+++ b/tester/reporter.go
@@ -166,7 +166,6 @@ func (w indentingWriter) Write(bs []byte) (int, error) {
 				return written, err
 			}
 			written += wrote
-			indent = false
 		}
 		wrote, err := w.w.Write([]byte{b})
 		if err != nil {

--- a/tester/reporter_test.go
+++ b/tester/reporter_test.go
@@ -1,4 +1,4 @@
-package tester
+package tester_test
 
 import (
 	"bytes"
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/tester"
 	"github.com/open-policy-agent/opa/topdown"
 	"github.com/open-policy-agent/opa/util"
 )
@@ -27,13 +28,13 @@ func TestPrettyReporterVerbose(t *testing.T) {
 
 	// supply fake trace events for each kind of event to ensure that only failures
 	// report traces.
-	ts := []*Result{
+	ts := []*tester.Result{
 		{nil, "data.foo.bar", "test_baz", false, nil, 0, getFakeTraceEvents()},
 		{nil, "data.foo.bar", "test_qux", false, fmt.Errorf("some err"), 0, getFakeTraceEvents()},
 		{nil, "data.foo.bar", "test_corge", true, nil, 0, getFakeTraceEvents()},
 	}
 
-	r := PrettyReporter{
+	r := tester.PrettyReporter{
 		Output:  &buf,
 		Verbose: true,
 	}
@@ -71,13 +72,13 @@ func TestPrettyReporter(t *testing.T) {
 
 	// supply fake trace events to verify that traces are suppressed without verbose
 	// flag.
-	ts := []*Result{
+	ts := []*tester.Result{
 		{nil, "data.foo.bar", "test_baz", false, nil, 0, getFakeTraceEvents()},
 		{nil, "data.foo.bar", "test_qux", false, fmt.Errorf("some err"), 0, getFakeTraceEvents()},
 		{nil, "data.foo.bar", "test_corge", true, nil, 0, getFakeTraceEvents()},
 	}
 
-	r := PrettyReporter{
+	r := tester.PrettyReporter{
 		Output:  &buf,
 		Verbose: false,
 	}
@@ -102,13 +103,13 @@ ERROR: 1/3
 
 func TestJSONReporter(t *testing.T) {
 	var buf bytes.Buffer
-	ts := []*Result{
+	ts := []*tester.Result{
 		{nil, "data.foo.bar", "test_baz", false, nil, 0, getFakeTraceEvents()},
 		{nil, "data.foo.bar", "test_qux", false, fmt.Errorf("some err"), 0, getFakeTraceEvents()},
 		{nil, "data.foo.bar", "test_corge", true, nil, 0, getFakeTraceEvents()},
 	}
 
-	r := JSONReporter{
+	r := tester.JSONReporter{
 		Output: &buf,
 	}
 
@@ -241,8 +242,8 @@ func TestJSONReporter(t *testing.T) {
 	}
 }
 
-func resultsChan(ts []*Result) chan *Result {
-	ch := make(chan *Result)
+func resultsChan(ts []*tester.Result) chan *tester.Result {
+	ch := make(chan *tester.Result)
 	go func() {
 		for _, tr := range ts {
 			ch <- tr

--- a/tester/runner.go
+++ b/tester/runner.go
@@ -133,6 +133,21 @@ func (r *Runner) EnableTracing(yes bool) *Runner {
 // Run executes all tests contained in supplied modules.
 func (r *Runner) Run(ctx context.Context, modules map[string]*ast.Module) (ch chan *Result, err error) {
 
+	// rewrite duplicate test_* rule names
+	count := map[string]int{}
+	for _, mod := range modules {
+		for _, rule := range mod.Rules {
+			name := rule.Head.Name.String()
+			if !strings.HasPrefix(name, TestPrefix) {
+				continue
+			}
+			if k, ok := count[name]; ok {
+				rule.Head.Name = ast.Var(fmt.Sprintf("%s#%02d", name, k))
+			}
+			count[name]++
+		}
+	}
+
 	if r.compiler == nil {
 		r.compiler = ast.NewCompiler()
 	}

--- a/tester/runner_test.go
+++ b/tester/runner_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by an Apache2
 // license that can be found in the LICENSE file.
 
-package tester
+package tester_test
 
 import (
 	"context"
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/tester"
 	"github.com/open-policy-agent/opa/topdown"
 	"github.com/open-policy-agent/opa/types"
 	"github.com/open-policy-agent/opa/util/test"
@@ -45,7 +46,7 @@ func TestRun(t *testing.T) {
 	}
 
 	test.WithTempFS(files, func(d string) {
-		rs, err := Run(ctx, d)
+		rs, err := tester.Run(ctx, d)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -97,7 +98,7 @@ func TestRunnerCancel(t *testing.T) {
 	}
 
 	test.WithTempFS(files, func(d string) {
-		results, err := Run(ctx, d)
+		results, err := tester.Run(ctx, d)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/tester/runner_test.go
+++ b/tester/runner_test.go
@@ -32,6 +32,9 @@ func TestRun(t *testing.T) {
 			test_err { conflict }
 			conflict = true
 			conflict = false
+			test_duplicate { false }
+			test_duplicate { true }
+			test_duplicate { true }
 			`,
 	}
 
@@ -42,6 +45,9 @@ func TestRun(t *testing.T) {
 		{"data.foo", "test_pass"}:          {false, false},
 		{"data.foo", "test_fail"}:          {false, true},
 		{"data.foo", "test_fail_non_bool"}: {false, true},
+		{"data.foo", "test_duplicate"}:     {false, true},
+		{"data.foo", "test_duplicate#01"}:  {false, false},
+		{"data.foo", "test_duplicate#02"}:  {false, false},
 		{"data.foo", "test_err"}:           {true, false},
 	}
 


### PR DESCRIPTION
Fixes #976.

This follows the same logic as Go's `t.Run()` when called with duplicate
names, i.e.

    func TestTest(t *testing.T) {
            t.Run("duplicate", func(t *testing.T) { t.Fail() })
            t.Run("duplicate", func(t *testing.T) {})
    }

would output

    --- FAIL: TestTest (0.00s)
        --- FAIL: TestTest/duplicate (0.00s)
        --- PASS: TestTest/duplicate#01 (0.00s)

`opa test` now behaves the same (see [updated tests](https://github.com/open-policy-agent/opa/pull/982/files#diff-7a209e3ecd96215c78bf56d6ddfd0d58R48)).