### PR TITLE
Update Makefile to set ldflags on go test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,11 +96,11 @@ install: generate
 
 .PHONY: test
 test: generate
-	$(GO) test ./...
+	$(GO) test -ldflags $(LDFLAGS) ./...
 
 .PHONY: perf
 perf: generate
-	$(GO) test -run=- -bench=. -benchmem ./...
+	$(GO) test -ldflags $(LDFLAGS) -run=- -bench=. -benchmem ./...
 
 .PHONY: check
 check: check-fmt check-vet check-lint


### PR DESCRIPTION
The version package variables were not being set which made it annoying
to test #986.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>