### PR TITLE
Add support for non-zero exit code

### DIFF
--- a/cmd/eval.go
+++ b/cmd/eval.go
@@ -205,7 +205,7 @@ func eval(args []string, params evalCommandParams, w io.Writer) (int, error) {
 
 	info, err := runtime.Term(runtime.Params{})
 	if err != nil {
-		return err
+		return 2, err
 	}
 
 	regoArgs := []func(*rego.Rego){rego.Query(query), rego.Runtime(info)}

--- a/cmd/eval.go
+++ b/cmd/eval.go
@@ -190,7 +190,7 @@ Set the output format with the --format flag.
 	RootCommand.AddCommand(evalCommand)
 }
 
-func eval(args []string, params evalCommandParams) (exitCode int, err error) {
+func eval(args []string, params evalCommandParams) (int, error) {
 
 	var query string
 

--- a/cmd/eval.go
+++ b/cmd/eval.go
@@ -156,14 +156,12 @@ Set the output format with the --format flag.
 			return nil
 		},
 		Run: func(cmd *cobra.Command, args []string) {
-			if code, err := eval(args, params); err != nil {
+			code, err := eval(args, params)
+			if err != nil {
 				fmt.Fprintln(os.Stderr, err)
-				if params.fail {
-					os.Exit(code)
-				} else {
-					os.Exit(1)
-				}
-			} else if params.fail {
+				os.Exit(2)
+			}
+			if params.fail {
 				os.Exit(code)
 			}
 		},

--- a/cmd/eval.go
+++ b/cmd/eval.go
@@ -7,6 +7,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"strconv"
@@ -156,7 +157,7 @@ Set the output format with the --format flag.
 			return nil
 		},
 		Run: func(cmd *cobra.Command, args []string) {
-			code, err := eval(args, params)
+			code, err := eval(args, params, os.Stdout)
 			if err != nil {
 				fmt.Fprintln(os.Stderr, err)
 				os.Exit(2)
@@ -188,7 +189,7 @@ Set the output format with the --format flag.
 	RootCommand.AddCommand(evalCommand)
 }
 
-func eval(args []string, params evalCommandParams) (int, error) {
+func eval(args []string, params evalCommandParams, w io.Writer) (int, error) {
 
 	var query string
 
@@ -301,13 +302,13 @@ func eval(args []string, params evalCommandParams) (int, error) {
 	err = nil
 	switch params.outputFormat.String() {
 	case evalBindingsOutput:
-		err = pr.Bindings(os.Stdout, result)
+		err = pr.Bindings(w, result)
 	case evalValuesOutput:
-		err = pr.Values(os.Stdout, result)
+		err = pr.Values(w, result)
 	case evalPrettyOutput:
-		err = pr.Pretty(os.Stdout, result)
+		err = pr.Pretty(w, result)
 	default:
-		err = pr.JSON(os.Stdout, result)
+		err = pr.JSON(w, result)
 	}
 	if err != nil || result.Error != nil {
 		return 2, err

--- a/cmd/eval_test.go
+++ b/cmd/eval_test.go
@@ -1,0 +1,42 @@
+// Copyright 2018 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package cmd
+
+import (
+	"bufio"
+	"bytes"
+	"testing"
+
+	"github.com/open-policy-agent/opa/util"
+)
+
+func TestEvalExitCode(t *testing.T) {
+	params := evalCommandParams{
+		fail:         true,
+		explain:      util.NewEnumFlag(explainModeOff, []string{explainModeFull}),
+		outputFormat: util.NewEnumFlag(evalJSONOutput, []string{evalJSONOutput}),
+	}
+	tests := []struct {
+		note         string
+		query        string
+		expectedCode int
+	}{
+		{"defined result", "true=true", 0},
+		{"undefined result", "true = false", 1},
+		{"on error", "x = 1/0", 2},
+	}
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+	for _, tc := range tests {
+		code, err := eval([]string{tc.query}, params, writer)
+		if err != nil {
+			t.Fatalf("%v: Unexpected error %v", tc.note, err)
+		}
+		if code != tc.expectedCode {
+			t.Fatalf("%v: Expected code %v, got %v", tc.note, tc.expectedCode, code)
+		}
+	}
+}


### PR DESCRIPTION
Adds support for non-zero exit code when providing the --fail flag to
the eval command. 0 means no error, 1 means undefined result and 2 means
an error.
Fixes #981

Signed-off-by: Kim Christensen <kimworking@gmail.com>