### PR TITLE
Add built-in function to get runtime info

### DIFF
--- a/ast/builtins.go
+++ b/ast/builtins.go
@@ -158,6 +158,9 @@ var DefaultBuiltins = [...]*Builtin{
 	// Rego
 	RegoParseModule,
 
+	// OPA
+	OPARuntime,
+
 	// Tracing
 	Trace,
 
@@ -1260,6 +1263,20 @@ var RegoParseModule = &Builtin{
 			types.S,
 		),
 		types.NewObject(nil, types.NewDynamicProperty(types.S, types.A)), // TODO(tsandall): import AST schema
+	),
+}
+
+/**
+ * OPA
+ */
+
+// OPARuntime returns an object containing OPA runtime information such as the
+// configuration that OPA was booted with.
+var OPARuntime = &Builtin{
+	Name: "opa.runtime",
+	Decl: types.NewFunction(
+		nil,
+		types.NewObject(nil, types.NewDynamicProperty(types.S, types.A)),
 	),
 }
 

--- a/cmd/eval.go
+++ b/cmd/eval.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/open-policy-agent/opa/ast"
 	pr "github.com/open-policy-agent/opa/internal/presentation"
+	"github.com/open-policy-agent/opa/internal/runtime"
 	"github.com/open-policy-agent/opa/loader"
 	"github.com/open-policy-agent/opa/metrics"
 	"github.com/open-policy-agent/opa/profiler"
@@ -195,7 +196,12 @@ func eval(args []string, params evalCommandParams) (err error) {
 		query = args[0]
 	}
 
-	regoArgs := []func(*rego.Rego){rego.Query(query)}
+	info, err := runtime.Term(runtime.Params{})
+	if err != nil {
+		return err
+	}
+
+	regoArgs := []func(*rego.Rego){rego.Query(query), rego.Runtime(info)}
 
 	if len(params.imports.v) > 0 {
 		regoArgs = append(regoArgs, rego.Imports(params.imports.v))

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -10,6 +10,8 @@ import (
 	"os"
 	"time"
 
+	"github.com/open-policy-agent/opa/internal/runtime"
+
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/cover"
 	"github.com/open-policy-agent/opa/tester"
@@ -110,6 +112,12 @@ func opaTest(args []string) int {
 		return 1
 	}
 
+	info, err := runtime.Term(runtime.Params{})
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+
 	var cov *cover.Cover
 	var coverTracer topdown.Tracer
 
@@ -122,7 +130,8 @@ func opaTest(args []string) int {
 		SetCompiler(compiler).
 		SetStore(store).
 		EnableTracing(testParams.verbose).
-		SetCoverageTracer(coverTracer)
+		SetCoverageTracer(coverTracer).
+		SetRuntime(info)
 
 	ch, err := runner.Run(ctx, modules)
 	if err != nil {

--- a/docs/book/language-reference.md
+++ b/docs/book/language-reference.md
@@ -193,6 +193,11 @@ evaluation query will always return the same value.
 | ------- |--------|-------------|
 | <span class="opa-keep-it-together">``rego.parse_module(filename, string, output)``</span> | 2 | ``rego.parse_module`` parses the input ``string`` as a Rego module and returns the AST as a JSON object ``output``. |
 
+### OPA
+| Built-in | Inputs | Description |
+| ------- |--------|-------------|
+| <span class="opa-keep-it-together">``opa.runtime(output)``</span> | 0 | ``opa.runtime`` returns a JSON object ``output`` that describes the runtime environment where OPA is deployed. **Caution**: Policies that depend on the output of ``opa.runtime`` may return different answers depending on how OPA was started. If possible, prefer using an explicit `input` or `data` value instead of `opa.runtime`. The ``output`` of ``opa.runtime`` will include a ``"config"`` key if OPA was started with a configuration file. The ``output`` of ``opa.runtime`` will include a ``"env"`` key containing the environment variables that the OPA process was started with. |
+
 ### Debugging
 | Built-in | Inputs | Description |
 | ------- |--------|-------------|

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -1,0 +1,61 @@
+// Copyright 2018 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+// Package runtime contains utilities to return runtime information on the OPA instance.
+package runtime
+
+import (
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/util"
+)
+
+// Params controls the types of runtime information to return.
+type Params struct {
+	ConfigFile string
+}
+
+// Term returns the runtime information as an ast.Term object.
+func Term(params Params) (*ast.Term, error) {
+
+	obj := ast.NewObject()
+
+	if params.ConfigFile != "" {
+
+		bs, err := ioutil.ReadFile(params.ConfigFile)
+		if err != nil {
+			return nil, err
+		}
+
+		var x interface{}
+		if err := util.Unmarshal(bs, &x); err != nil {
+			return nil, err
+		}
+
+		v, err := ast.InterfaceToValue(x)
+		if err != nil {
+			return nil, err
+		}
+
+		obj.Insert(ast.StringTerm("config"), ast.NewTerm(v))
+	}
+
+	env := ast.NewObject()
+
+	for _, s := range os.Environ() {
+		parts := strings.SplitN(s, "=", 2)
+		if len(parts) == 1 {
+			env.Insert(ast.StringTerm(parts[0]), ast.NullTerm())
+		} else if len(parts) > 1 {
+			env.Insert(ast.StringTerm(parts[0]), ast.StringTerm(parts[1]))
+		}
+	}
+
+	obj.Insert(ast.StringTerm("env"), ast.NewTerm(env))
+
+	return ast.NewTerm(obj), nil
+}

--- a/rego/rego.go
+++ b/rego/rego.go
@@ -151,6 +151,7 @@ type Rego struct {
 	capture          map[*ast.Expr]ast.Var // map exprs to generated capture vars
 	termVarID        int
 	dump             io.Writer
+	runtime          *ast.Term
 }
 
 // Dump returns an argument that sets the writer to dump debugging information to.
@@ -298,6 +299,14 @@ func Tracer(t topdown.Tracer) func(r *Rego) {
 		if t != nil {
 			r.tracer = t
 		}
+	}
+}
+
+// Runtime returns an argument that sets the runtime data to provide to the
+// evaluation engine.
+func Runtime(term *ast.Term) func(r *Rego) {
+	return func(r *Rego) {
+		r.runtime = term
 	}
 }
 
@@ -638,7 +647,8 @@ func (r *Rego) eval(ctx context.Context, qc ast.QueryCompiler, compiled ast.Body
 		WithStore(r.store).
 		WithTransaction(txn).
 		WithMetrics(r.metrics).
-		WithInstrumentation(r.instrumentation)
+		WithInstrumentation(r.instrumentation).
+		WithRuntime(r.runtime)
 
 	if r.tracer != nil {
 		q = q.WithTracer(r.tracer)
@@ -775,7 +785,7 @@ func (r *Rego) partial(ctx context.Context, compiled ast.Body, txn storage.Trans
 		WithMetrics(r.metrics).
 		WithInstrumentation(r.instrumentation).
 		WithUnknowns(unknowns).
-		WithPartialNamespace(partialNamespace)
+		WithRuntime(r.runtime)
 
 	if r.tracer != nil {
 		q = q.WithTracer(r.tracer)

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -32,8 +32,9 @@ import (
 
 // REPL represents an instance of the interactive shell.
 type REPL struct {
-	output io.Writer
-	store  storage.Store
+	output  io.Writer
+	store   storage.Store
+	runtime *ast.Term
 
 	modules         map[string]*ast.Module
 	currentModuleID string
@@ -292,6 +293,12 @@ func (r *REPL) DisableMultiLineBuffering(yes bool) *REPL {
 // is undefined.
 func (r *REPL) DisableUndefinedOutput(yes bool) *REPL {
 	r.undefinedDisabled = yes
+	return r
+}
+
+// WithRuntime sets the runtime data to provide to the evaluation engine.
+func (r *REPL) WithRuntime(term *ast.Term) *REPL {
+	r.runtime = term
 	return r
 }
 
@@ -796,6 +803,7 @@ func (r *REPL) evalBody(ctx context.Context, compiler *ast.Compiler, input ast.V
 		rego.Metrics(r.metrics),
 		rego.Tracer(buf),
 		rego.Instrument(r.instrument),
+		rego.Runtime(r.runtime),
 	)
 
 	rs, err := eval.Eval(ctx)
@@ -843,6 +851,7 @@ func (r *REPL) evalPartial(ctx context.Context, compiler *ast.Compiler, input as
 		rego.Tracer(buf),
 		rego.Instrument(r.instrument),
 		rego.ParsedUnknowns(r.unknowns),
+		rego.Runtime(r.runtime),
 	)
 
 	pq, err := eval.Partial(ctx)

--- a/tester/runner.go
+++ b/tester/runner.go
@@ -92,6 +92,7 @@ type Runner struct {
 	store    storage.Store
 	cover    topdown.Tracer
 	trace    bool
+	runtime  *ast.Term
 }
 
 // NewRunner returns a new runner.
@@ -127,6 +128,12 @@ func (r *Runner) EnableTracing(yes bool) *Runner {
 	if r.trace {
 		r.cover = nil
 	}
+	return r
+}
+
+// SetRuntime sets runtime information to expose to the evaluation engine.
+func (r *Runner) SetRuntime(term *ast.Term) *Runner {
+	r.runtime = term
 	return r
 }
 
@@ -206,6 +213,7 @@ func (r *Runner) runTest(ctx context.Context, mod *ast.Module, rule *ast.Rule) (
 		rego.Compiler(r.compiler),
 		rego.Query(rule.Path().String()),
 		rego.Tracer(tracer),
+		rego.Runtime(r.runtime),
 	)
 
 	t0 := time.Now()

--- a/topdown/builtins.go
+++ b/topdown/builtins.go
@@ -55,11 +55,12 @@ type (
 	// BuiltinContext contains context from the evaluator that may be used by
 	// built-in functions.
 	BuiltinContext struct {
-		Cache    builtins.Cache
-		Location *ast.Location
-		Tracer   Tracer
-		QueryID  uint64
-		ParentID uint64
+		Runtime  *ast.Term      // runtime information on the OPA instance
+		Cache    builtins.Cache // built-in function state cache
+		Location *ast.Location  // location of built-in call
+		Tracer   Tracer         // tracer object for trace() built-in function
+		QueryID  uint64         // identifies query being evaluated
+		ParentID uint64         // identifies parent of query being evaluated
 	}
 
 	// BuiltinFunc defines an interface for implementing built-in functions.

--- a/topdown/eval.go
+++ b/topdown/eval.go
@@ -48,6 +48,7 @@ type eval struct {
 	saveSupport   *saveSupport
 	saveNamespace *ast.Term
 	genvarprefix  string
+	runtime       *ast.Term
 }
 
 func (e *eval) Run(iter evalIterator) error {
@@ -482,6 +483,7 @@ func (e *eval) evalCall(terms []*ast.Term, iter unifyIterator) error {
 	}
 
 	bctx := BuiltinContext{
+		Runtime:  e.runtime,
 		Cache:    e.builtinCache,
 		Location: e.query[e.index].Location,
 		Tracer:   e.tracer,

--- a/topdown/query.go
+++ b/topdown/query.go
@@ -32,6 +32,7 @@ type Query struct {
 	metrics          metrics.Metrics
 	instr            *Instrumentation
 	genvarprefix     string
+	runtime          *ast.Term
 }
 
 // NewQuery returns a new Query object that can be run.
@@ -110,6 +111,13 @@ func (q *Query) WithPartialNamespace(ns string) *Query {
 	return q
 }
 
+// WithRuntime sets the runtime data to execute the query with. The runtime data
+// can be returned by the `opa.runtime` built-in function.
+func (q *Query) WithRuntime(runtime *ast.Term) *Query {
+	q.runtime = runtime
+	return q
+}
+
 // PartialRun executes partial evaluation on the query with respect to unknown
 // values. Partial evaluation attempts to evaluate as much of the query as
 // possible without requiring values for the unknowns set on the query. The
@@ -144,6 +152,7 @@ func (q *Query) PartialRun(ctx context.Context) (partials []ast.Body, support []
 		saveSupport:   newSaveSupport(),
 		saveNamespace: ast.StringTerm(q.partialNamespace),
 		genvarprefix:  q.genvarprefix,
+		runtime:       q.runtime,
 	}
 	q.startTimer(metrics.RegoPartialEval)
 	defer q.stopTimer(metrics.RegoPartialEval)
@@ -220,6 +229,7 @@ func (q *Query) Iter(ctx context.Context, iter func(QueryResult) error) error {
 		builtinCache: builtins.Cache{},
 		virtualCache: newVirtualCache(),
 		genvarprefix: q.genvarprefix,
+		runtime:      q.runtime,
 	}
 	q.startTimer(metrics.RegoQueryEval)
 	defer q.stopTimer(metrics.RegoQueryEval)

--- a/topdown/runtime.go
+++ b/topdown/runtime.go
@@ -1,0 +1,20 @@
+// Copyright 2018 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package topdown
+
+import "github.com/open-policy-agent/opa/ast"
+
+func builtinOPARuntime(bctx BuiltinContext, _ []*ast.Term, iter func(*ast.Term) error) error {
+
+	if bctx.Runtime == nil {
+		return iter(ast.ObjectTerm())
+	}
+
+	return iter(bctx.Runtime)
+}
+
+func init() {
+	RegisterBuiltinFunc(ast.OPARuntime.Name, builtinOPARuntime)
+}

--- a/topdown/runtime_test.go
+++ b/topdown/runtime_test.go
@@ -1,0 +1,46 @@
+// Copyright 2018 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+package topdown
+
+import (
+	"context"
+	"testing"
+
+	"github.com/open-policy-agent/opa/ast"
+)
+
+func TestOPARuntime(t *testing.T) {
+
+	ctx := context.Background()
+	q := NewQuery(ast.MustParseBody("opa.runtime(x)")) // no runtime info
+	rs, err := q.Run(ctx)
+	if err != nil {
+		t.Fatal(err)
+	} else if len(rs) != 1 {
+		t.Fatal("Expected result set to contain exactly one result")
+	}
+
+	term := rs[0][ast.Var("x")]
+	exp := ast.ObjectTerm()
+
+	if ast.Compare(term, exp) != 0 {
+		t.Fatalf("Expected %v but got %v", exp, term)
+	}
+
+	q = NewQuery(ast.MustParseBody("opa.runtime(x)")).WithRuntime(ast.MustParseTerm(`{"config": {"a": 1}}`))
+	rs, err = q.Run(ctx)
+	if err != nil {
+		t.Fatal(err)
+	} else if len(rs) != 1 {
+		t.Fatal("Expected result set to contain exactly one result")
+	}
+
+	term = rs[0][ast.Var("x")]
+	exp = ast.MustParseTerm(`{"config": {"a": 1}}`)
+
+	if ast.Compare(term, exp) != 0 {
+		t.Fatalf("Expected %v but got %v", exp, term)
+	}
+
+}


### PR DESCRIPTION
These changes add support for accessing runtime information inside of
policies. In some cases, policies need to access environment variables
or configuration that OPA was booted with. These changes add a built-in
function that allows policies to gain access to this information. The
built-in function itself is relatively trivial. Most of the required
changes were plumbing the runtime information from the entrypoint down
into the evaluation engine. The alternative would have been to introduce
a global variable containing this information however that would be have
been harder to reason about in library integrations.

Fixes #420

Signed-off-by: Torin Sandall <torinsandall@gmail.com>