### PR TITLE
Add default decision configuration

### DIFF
--- a/docs/book/configuration.md
+++ b/docs/book/configuration.md
@@ -35,6 +35,8 @@ decision_logs:
 
 status:
   service: acmecorp
+
+default_decision: /http/example/authz/allow
 ```
 
 ## Services
@@ -56,6 +58,8 @@ multiple services.
 | Field | Type | Required | Description |
 | --- | --- | --- | --- |
 | `labels` | `object` | Yes | Set of key-value pairs that uniquely identify the OPA instance. Labels are included when OPA uploads decision logs and status information. |
+| `default_decision` | `string` | No (default: `/system/main`) | Set path of default policy decision used to serve queries against OPA's base URL. |
+| `default_authorization_decision` | `string` | No (default: `/system/authz/allow`) | Set path of default authorization decision for OPA's API. |
 
 ## Bundles
 

--- a/docs/book/rest-api.md
+++ b/docs/book/rest-api.md
@@ -1316,8 +1316,10 @@ Execute a simple query.
 
 OPA serves POST requests without a URL path by querying for the document at
 path `/data/system/main`. The content of that document defines the response
-entirely. The policy example below shows how to define a rule that will produce a
-value for the `/data/system/main` document.
+entirely. The policy example below shows how to define a rule that will
+produce a value for the `/data/system/main` document. You can configure OPA
+to use a different URL path to serve these queries. See the [Configuration Reference](configuration.md)
+for more information.
 
 The request message body is mapped to the [Input Document](/how-does-opa-work.md#the-input-document).
 
@@ -1373,7 +1375,7 @@ Content-Type: application/json
 - **404** - not found
 - **500** - server error
 
-If the `/data/system/main` document is undefined (e.g., because the administrator has not defined one) the server returns 404.
+If the default decision (defaulting to `/system/main`) is undefined, the server returns 404.
 
 ### Execute an Ad-hoc Query
 

--- a/server/authorizer/authorizer.go
+++ b/server/authorizer/authorizer.go
@@ -7,9 +7,8 @@ package authorizer
 
 import (
 	"net/http"
-	"strings"
-
 	"net/url"
+	"strings"
 
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/rego"
@@ -19,22 +18,27 @@ import (
 	"github.com/open-policy-agent/opa/storage"
 )
 
-// SystemAuthzPath is the path of the document that defines auth/z decisions for
-// OPA itself.
-const SystemAuthzPath = "data.system.authz.allow"
-
 // Basic provides policy-based authorization over incoming requests.
 type Basic struct {
 	inner    http.Handler
 	compiler func() *ast.Compiler
 	store    storage.Store
 	runtime  *ast.Term
+	decision string
 }
 
 // Runtime returns an argument that sets the runtime on the authorizer.
 func Runtime(term *ast.Term) func(*Basic) {
 	return func(b *Basic) {
 		b.runtime = term
+	}
+}
+
+// Decision returns an argument that sets the path of the authorization decision
+// to query.
+func Decision(ref ast.Ref) func(*Basic) {
+	return func(b *Basic) {
+		b.decision = ref.String()
 	}
 }
 
@@ -62,7 +66,7 @@ func (h *Basic) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	rego := rego.New(
-		rego.Query(SystemAuthzPath),
+		rego.Query(h.decision),
 		rego.Compiler(h.compiler()),
 		rego.Store(h.store),
 		rego.Input(input),

--- a/server/authorizer/authorizer_test.go
+++ b/server/authorizer/authorizer_test.go
@@ -163,7 +163,7 @@ func TestBasic(t *testing.T) {
 				req = identifier.SetIdentity(req, tc.identity)
 			}
 
-			NewBasic(&mockHandler{}, compiler, store).ServeHTTP(recorder, req)
+			NewBasic(&mockHandler{}, compiler, store, Decision(ast.MustParseRef("data.system.authz.allow"))).ServeHTTP(recorder, req)
 
 			if recorder.Code != tc.expectedStatus {
 				t.Fatalf("Expected status code %v but got: %v", tc.expectedStatus, recorder)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1787,6 +1787,8 @@ func TestDiagnostics(t *testing.T) {
 		WithStore(f.server.store).
 		WithManager(f.server.manager).
 		WithDiagnosticsBuffer(NewBoundedBuffer(8)).
+		WithDefaultDecision(ast.MustParseRef("data.system.main")).
+		WithDefaultAuthorizationDecision(ast.MustParseRef("data.system.authz.allow")).
 		Init(context.Background())
 
 	queriesOnly := `package system.diagnostics
@@ -2427,6 +2429,8 @@ func TestAuthorization(t *testing.T) {
 		WithStore(store).
 		WithManager(m).
 		WithAuthorization(AuthorizationBasic).
+		WithDefaultDecision(ast.MustParseRef("data.system.main")).
+		WithDefaultAuthorizationDecision(ast.MustParseRef("data.system.authz.allow")).
 		Init(ctx)
 
 	if err != nil {
@@ -2617,6 +2621,8 @@ func newFixture(t *testing.T) *fixture {
 		WithAddresses([]string{":8182"}).
 		WithStore(store).
 		WithManager(m).
+		WithDefaultDecision(ast.MustParseRef("data.system.main")).
+		WithDefaultAuthorizationDecision(ast.MustParseRef("data.system.authz.allow")).
 		Init(ctx)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
Previously, OPA would serve POST requests with an empty URL path by
querying data.system.main and returning the generated value. In some
cases, it's useful to be able to reconfigure OPA to use a different
document to serve these kinds of requests. The same goes for the OPA
authorization policy.

These changes make the default decision and default authorization
decision paths configurable.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>