### PR TITLE
Refactor tracing interfaces to take ast.Node

### DIFF
--- a/topdown/eval.go
+++ b/topdown/eval.go
@@ -92,35 +92,35 @@ func (e *eval) partial() bool {
 	return e.saveSet != nil
 }
 
-func (e *eval) traceEnter(x interface{}) {
+func (e *eval) traceEnter(x ast.Node) {
 	e.traceEvent(EnterOp, x, "")
 }
 
-func (e *eval) traceExit(x interface{}) {
+func (e *eval) traceExit(x ast.Node) {
 	e.traceEvent(ExitOp, x, "")
 }
 
-func (e *eval) traceEval(x interface{}) {
+func (e *eval) traceEval(x ast.Node) {
 	e.traceEvent(EvalOp, x, "")
 }
 
-func (e *eval) traceFail(x interface{}) {
+func (e *eval) traceFail(x ast.Node) {
 	e.traceEvent(FailOp, x, "")
 }
 
-func (e *eval) traceRedo(x interface{}) {
+func (e *eval) traceRedo(x ast.Node) {
 	e.traceEvent(RedoOp, x, "")
 }
 
-func (e *eval) traceSave(x interface{}) {
+func (e *eval) traceSave(x ast.Node) {
 	e.traceEvent(SaveOp, x, "")
 }
 
-func (e *eval) traceIndex(x interface{}, msg string) {
+func (e *eval) traceIndex(x ast.Node, msg string) {
 	e.traceEvent(IndexOp, x, msg)
 }
 
-func (e *eval) traceEvent(op Op, x interface{}, msg string) {
+func (e *eval) traceEvent(op Op, x ast.Node, msg string) {
 
 	if e.tracer == nil || !e.tracer.Enabled() {
 		return

--- a/topdown/trace.go
+++ b/topdown/trace.go
@@ -47,7 +47,7 @@ const (
 // Event contains state associated with a tracing event.
 type Event struct {
 	Op       Op            // Identifies type of event.
-	Node     interface{}   // Contains AST node relevant to the event.
+	Node     ast.Node      // Contains AST node relevant to the event.
 	QueryID  uint64        // Identifies the query this event belongs to.
 	ParentID uint64        // Identifies the parent query this event belongs to.
 	Locals   *ast.ValueMap // Contains local variable bindings from the query context.

--- a/topdown/trace_test.go
+++ b/topdown/trace_test.go
@@ -34,7 +34,6 @@ func TestEventEqual(t *testing.T) {
 		{&Event{Node: ast.MustParseBody("true")}, &Event{Node: ast.MustParseBody("false")}, false},
 		{&Event{Node: ast.MustParseBody("true")[0]}, &Event{Node: ast.MustParseBody("false")[0]}, false},
 		{&Event{Node: ast.MustParseRule(`p = true { true }`)}, &Event{Node: ast.MustParseRule(`p = true { false }`)}, false},
-		{&Event{Node: "foo"}, &Event{Node: "foo"}, false}, // test some unsupported node type
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
Previously the tracing interfaces took interface{} because ast.Node did
not exist. Now that we have ast.Node we should use that instead as it
makes it easier to access generic AST information like source location.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>