### PR TITLE
Only write one trailing newline at end of file

### DIFF
--- a/format/format.go
+++ b/format/format.go
@@ -153,8 +153,11 @@ func (w *writer) writeModule(module *ast.Module) {
 		comments = w.writeRules(rules, comments)
 	}
 
-	for _, c := range comments {
+	for i, c := range comments {
 		w.writeLine(c.String())
+		if i == len(comments)-1 {
+			w.write("\n")
+		}
 	}
 }
 
@@ -837,6 +840,9 @@ func (w *writer) startLine() {
 		panic("currently in a line")
 	}
 	w.inline = true
+	if w.buf.Len() > 0 {
+		w.write("\n")
+	}
 	for i := 0; i < w.level; i++ {
 		w.write(w.indent)
 	}
@@ -853,7 +859,6 @@ func (w *writer) endLine() {
 		w.beforeEnd = nil
 	}
 	w.delay = false
-	w.write("\n")
 }
 
 // beforeLineEnd registers a comment to be printed at the end of the current line.

--- a/repl/repl_test.go
+++ b/repl/repl_test.go
@@ -322,7 +322,7 @@ func TestShow(t *testing.T) {
 
 	repl.OneShot(ctx, `package repl_test`)
 	repl.OneShot(ctx, "show")
-	assertREPLText(t, buffer, "package repl_test\n\n")
+	assertREPLText(t, buffer, "package repl_test\n")
 	buffer.Reset()
 
 	repl.OneShot(ctx, "import input.xyz")
@@ -330,7 +330,7 @@ func TestShow(t *testing.T) {
 
 	expected := `package repl_test
 
-import input.xyz` + "\n\n"
+import input.xyz` + "\n"
 	assertREPLText(t, buffer, expected)
 	buffer.Reset()
 
@@ -340,7 +340,7 @@ import input.xyz` + "\n\n"
 	expected = `package repl_test
 
 import data.foo as bar
-import input.xyz` + "\n\n"
+import input.xyz` + "\n"
 	assertREPLText(t, buffer, expected)
 	buffer.Reset()
 
@@ -357,14 +357,14 @@ import input.xyz
 
 p[1]
 
-p[2]` + "\n\n"
+p[2]` + "\n"
 	assertREPLText(t, buffer, expected)
 	buffer.Reset()
 
 	repl.OneShot(ctx, "package abc")
 	repl.OneShot(ctx, "show")
 
-	assertREPLText(t, buffer, "package abc\n\n")
+	assertREPLText(t, buffer, "package abc\n")
 	buffer.Reset()
 
 	repl.OneShot(ctx, "package repl_test")


### PR DESCRIPTION
opa fmt should only add one newline at the end of the file