### PR TITLE
Fix copy propagation panic in comprehensions

### DIFF
--- a/topdown/eval.go
+++ b/topdown/eval.go
@@ -636,14 +636,14 @@ func (e *eval) biunifyValues(a, b *ast.Term, b1, b2 *bindings, iter unifyIterato
 	compA := ast.IsComprehension(a.Value)
 	compB := ast.IsComprehension(b.Value)
 
-	if saveA || saveB || ((compA || compB) && e.partial()) {
+	if saveA || saveB {
 		return e.saveUnify(a, b, b1, b2, iter)
 	}
 
 	if compA {
-		return e.biunifyComprehension(a.Value, b, b1, b2, iter)
+		return e.biunifyComprehension(a, b, b1, b2, false, iter)
 	} else if compB {
-		return e.biunifyComprehension(b.Value, a, b2, b1, iter)
+		return e.biunifyComprehension(b, a, b2, b1, true, iter)
 	}
 
 	// Perform standard unification.
@@ -739,8 +739,13 @@ func (e *eval) biunifyRef(a, b *ast.Term, b1, b2 *bindings, iter unifyIterator) 
 	return eval.eval(iter)
 }
 
-func (e *eval) biunifyComprehension(a interface{}, b *ast.Term, b1, b2 *bindings, iter unifyIterator) error {
-	switch a := a.(type) {
+func (e *eval) biunifyComprehension(a, b *ast.Term, b1, b2 *bindings, swap bool, iter unifyIterator) error {
+
+	if e.partial() {
+		return e.biunifyComprehensionPartial(a, b, b1, b2, swap, iter)
+	}
+
+	switch a := a.Value.(type) {
 	case *ast.ArrayComprehension:
 		return e.biunifyComprehensionArray(a, b, b1, b2, iter)
 	case *ast.SetComprehension:
@@ -748,7 +753,56 @@ func (e *eval) biunifyComprehension(a interface{}, b *ast.Term, b1, b2 *bindings
 	case *ast.ObjectComprehension:
 		return e.biunifyComprehensionObject(a, b, b1, b2, iter)
 	}
+
 	return fmt.Errorf("illegal comprehension %T", a)
+}
+
+func (e *eval) biunifyComprehensionPartial(a, b *ast.Term, b1, b2 *bindings, swap bool, iter unifyIterator) error {
+
+	// Capture bindings available to the comprehension. We will add expressions
+	// to the comprehension body that ensure the comprehension body is safe.
+	// Currently this process adds _all_ bindings (even if they are not
+	// needed.) Eventually we may want to make the logic a bit smarter.
+	var extras []*ast.Expr
+
+	err := b1.Iter(sentinel, func(k, v *ast.Term) error {
+		extras = append(extras, ast.Equality.Expr(k, v))
+		return nil
+	})
+
+	if err != nil {
+		return err
+	}
+
+	// Namespace the variables in the body to avoid collision when the final
+	// queries returned by partial evaluation.
+	var body *ast.Body
+
+	switch a := a.Value.(type) {
+	case *ast.ArrayComprehension:
+		body = &a.Body
+	case *ast.SetComprehension:
+		body = &a.Body
+	case *ast.ObjectComprehension:
+		body = &a.Body
+	default:
+		return fmt.Errorf("illegal comprehension %T", a)
+	}
+
+	for _, e := range extras {
+		body.Append(e)
+	}
+
+	b1.Namespace(a, sentinel)
+
+	// The other term might need to be plugged so include the bindings. The
+	// bindings for the comprehension term are saved (for compatibility) but
+	// the eventual plug operation on the comprehension will be a no-op.
+	if !swap {
+		return e.saveUnify(a, b, b1, b2, iter)
+	}
+
+	return e.saveUnify(b, a, b2, b1, iter)
 }
 
 func (e *eval) biunifyComprehensionArray(x *ast.ArrayComprehension, b *ast.Term, b1, b2 *bindings, iter unifyIterator) error {

--- a/topdown/query.go
+++ b/topdown/query.go
@@ -172,9 +172,11 @@ func (q *Query) PartialRun(ctx context.Context) (partials []ast.Body, support []
 	err = e.Run(func(e *eval) error {
 		// Build output from saved expressions.
 		body := ast.NewBody()
+
 		for _, elem := range e.saveStack.Stack[len(e.saveStack.Stack)-1] {
 			body.Append(elem.Plug(e.bindings))
 		}
+
 		// Include bindings as exprs so that when caller evals the result, they
 		// can obtain values for the vars in their query.
 		bindingExprs := []*ast.Expr{}
@@ -182,13 +184,16 @@ func (q *Query) PartialRun(ctx context.Context) (partials []ast.Body, support []
 			bindingExprs = append(bindingExprs, ast.Equality.Expr(a, b))
 			return nil
 		})
+
 		// Sort binding expressions so that results are deterministic.
 		sort.Slice(bindingExprs, func(i, j int) bool {
 			return bindingExprs[i].Compare(bindingExprs[j]) < 0
 		})
+
 		for i := range bindingExprs {
 			body.Append(bindingExprs[i])
 		}
+
 		body = p.Apply(body)
 		partials = append(partials, body)
 		return nil

--- a/topdown/topdown_partial_test.go
+++ b/topdown/topdown_partial_test.go
@@ -448,12 +448,12 @@ func TestTopDownPartialEval(t *testing.T) {
 		{
 			note:        "comprehensions: save",
 			query:       `x = [true | true]; y = {true | true}; z = {a: true | a = "foo"}`,
-			wantQueries: []string{`x = [true | true]; y = {true | true}; z = {a: true | a = "foo"}`},
+			wantQueries: []string{`x = [true | true]; y = {true | true}; z = {a0: true | a0 = "foo"}`},
 		},
 		{
 			note:        "comprehensions: closure",
 			query:       `i = 1; xs = [x | x = data.foo[i]]`,
-			wantQueries: []string{`xs = [x | x = data.foo[1]]; i = 1`},
+			wantQueries: []string{`xs = [x0 | x0 = data.foo[i0]; i0 = 1]; i = 1`},
 		},
 		{
 			note:  "save: sub path",
@@ -1345,6 +1345,23 @@ func TestTopDownPartialEval(t *testing.T) {
 				__not1_0__ { input.x = 3; input.y = 3; input.z = 0 }
 				`,
 			},
+		},
+		{
+			note:  "comprehensions: ref heads (with namespacing)",
+			query: "data.test.p = true; input.x = x",
+			modules: []string{
+				`package test
+
+				p {
+					x = [0]; y = {true | x[0]}
+				}
+			`},
+			wantQueries: []string{`y1 = {true | x1[0]; x1 = [0]}; input.x = x`},
+		},
+		{
+			note:        "comprehensions: ref heads (with live vars)",
+			query:       "x = [0]; y = {true | x[0]}",
+			wantQueries: []string{`y = {true | x0[0]; x0 = [0]}; x = [0]`},
 		},
 	}
 


### PR DESCRIPTION
These changes address the panic that was happening during copy
propagation when a ref inside of a comprehension was plugged with a
composite value (or any value that would lead to an illegal ref). For
example:

x = [0]; [true | x[0] = 0]

In this case, when partial eval ran, the saved expression before copy
propagation ran would be the comprehension itself. The problem was that
the binding x/[0] would be plugged into the comprehension resulting in:

[true | [0][0] = 0]

While this could be considered legal, we don't currently support refs
like this (in the parser and in the evaluator). As a result, when copy
propagation encountered this ref, it panic-ed because it would assume
the ref head was a variable.

To deal with this issue, we have refactored how partial evaluation
handles comprehensions. Instead of simply saving the comprehension and
continuing, the implementation will (i) capture bindings that are in
scope and copy them into the comprehension body and (ii) namespace all
of the variables inside the comprehension.

An alternative would be to carefully plug comprehensions (such that ref
heads were not replaced) however this would still require namepsacing.
It would also require changes to copy propagation to ensure that ref
head vars that appear in the containing query are not killed.

In the future we can invest in (a) allowing references like [0][0] and
(b) extending partial evaluation to deal with comprehensions.

Fixes #1012

Signed-off-by: Torin Sandall <torinsandall@gmail.com>