### PR TITLE
Fix cross-compile issue in go generate step

### DIFF
--- a/build/gen-opa-wasm.sh
+++ b/build/gen-opa-wasm.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+set -e
+
+GOOS="" GOARCH="" go run $@

--- a/main.go
+++ b/main.go
@@ -19,4 +19,4 @@ func main() {
 //
 //go:generate pigeon -o ast/parser.go ast/rego.peg
 //go:generate goimports -w ast/parser.go
-//go:generate go run internal/cmd/genopawasm/main.go -o internal/compiler/wasm/opa/opa.go internal/compiler/wasm/opa/opa.wasm
+//go:generate build/gen-opa-wasm.sh internal/cmd/genopawasm/main.go -o internal/compiler/wasm/opa/opa.go internal/compiler/wasm/opa/opa.wasm


### PR DESCRIPTION
The WASM changes broke cross-compiling because go generate executes go
run ... which inherits the GOOS and GOARCH environment variables. To
resolve this we just wrap the go rnu ... command in a script that
overwrites the environment variables so that the host GOOS and GOARCH
are used. For some reason go generate does not allow you to specify
environment variables inline, e.g., FOO=BAR go run ...

Signed-off-by: Torin Sandall <torinsandall@gmail.com>