### PR TITLE
Fix release patch script to support LAST_VERSION

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -212,6 +212,7 @@ release-local:
 .PHONY: release-patch
 release-patch:
 	@docker run -it --rm \
+		-e LAST_VERSION=$(LAST_VERSION) \
 		-v $(PWD):/_src \
 		python:2.7 \
 		/_src/build/gen-release-patch.sh --version=$(VERSION) --source-url=/_src

--- a/build/gen-release-patch.sh
+++ b/build/gen-release-patch.sh
@@ -37,7 +37,9 @@ fi
 git clone $SOURCE_URL $OPA_DIR
 cd $OPA_DIR
 
-LAST_VERSION=$(git describe --abbrev=0 --tags)
+if [ -z "$LAST_VERSION" ]; then
+    LAST_VERSION=$(git describe --abbrev=0 --tags)
+fi
 
 update_makefile() {
     sed -i='' -e "s/^VERSION[ \t]*:=[ \t]*.\+$/VERSION := $VERSION/" Makefile


### PR DESCRIPTION
Previously the release script always computed LAST_VERSION from tags. We
recently published 0.9.3-rc tags for test purposes. This was preventing
thes cript generating the patch for the markdown/yaml files in the docs
that refer to the OPA version. These changes allow the caller to control
the LAST_VERSION so the docs get updated accordingly.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>