### PR TITLE
opa test: handle code coverage percentage

### DIFF
--- a/cover/cover.go
+++ b/cover/cover.go
@@ -6,6 +6,8 @@
 package cover
 
 import (
+	"fmt"
+	"math"
 	"sort"
 
 	"github.com/open-policy-agent/opa/ast"
@@ -71,6 +73,22 @@ func (c *Cover) Report(modules map[string]*ast.Module) (report Report) {
 		}
 		fr.NotCovered = sortedPositionSliceToRangeSlice(notCovered)
 	}
+
+	var coveredLoc, notCoveredLoc int
+	var overallCoverage float64
+
+	for _, fr := range report.Files {
+		fr.Coverage = fr.ComputeCoveragePercentage()
+		coveredLoc += fr.locCovered()
+		notCoveredLoc += fr.locNotCovered()
+	}
+	totalLoc := coveredLoc + notCoveredLoc
+
+	if totalLoc != 0 {
+		overallCoverage = 100.0 * float64(coveredLoc) / float64(totalLoc)
+	}
+	report.Coverage = round(overallCoverage, 2)
+
 	return
 }
 
@@ -129,6 +147,7 @@ func (r Range) In(row int) bool {
 type FileReport struct {
 	Covered    []Range `json:"covered,omitempty"`
 	NotCovered []Range `json:"not_covered,omitempty"`
+	Coverage   float64 `json:"coverage,omitempty"`
 }
 
 // IsCovered returns true if the row is marked as covered in the report.
@@ -159,14 +178,58 @@ func (fr *FileReport) IsNotCovered(row int) bool {
 	return false
 }
 
+// locCovered returns the number of lines of code covered by tests
+func (fr *FileReport) locCovered() (loc int) {
+	for _, r := range fr.Covered {
+		loc += r.End.Row - r.Start.Row + 1
+	}
+	return
+}
+
+// locNotCovered returns the number of lines of code not covered by tests
+func (fr *FileReport) locNotCovered() (loc int) {
+	for _, r := range fr.NotCovered {
+		loc += r.End.Row - r.Start.Row + 1
+	}
+	return
+}
+
+// ComputeCoveragePercentage returns the code coverage percentage of the file
+func (fr *FileReport) ComputeCoveragePercentage() float64 {
+	coveredLoc := fr.locCovered()
+	notCoveredLoc := fr.locNotCovered()
+	totalLoc := coveredLoc + notCoveredLoc
+
+	if totalLoc == 0 {
+		return 0.0
+	}
+
+	return round(100.0*float64(coveredLoc)/float64(totalLoc), 2)
+}
+
 // Report represents a coverage report for a set of files.
 type Report struct {
-	Files map[string]*FileReport `json:"files"`
+	Files    map[string]*FileReport `json:"files"`
+	Coverage float64                `json:"coverage"`
 }
 
 // IsCovered returns true if the row in the given file is covered.
 func (r Report) IsCovered(file string, row int) bool {
 	return r.Files[file].IsCovered(row)
+}
+
+// CoverageThresholdError represents an error raised when the global
+// code coverage percenta is lower than the specified threshold.
+type CoverageThresholdError struct {
+	Coverage  float64
+	Threshold float64
+}
+
+func (e *CoverageThresholdError) Error() string {
+	return fmt.Sprintf(
+		"Code coverage threshold not met: got %.2f instead of %.2f",
+		e.Coverage,
+		e.Threshold)
 }
 
 func sortedPositionSliceToRangeSlice(sorted []Position) (result []Range) {
@@ -189,4 +252,9 @@ func sortedPositionSliceToRangeSlice(sorted []Position) (result []Range) {
 
 func hasFileLocation(loc *ast.Location) bool {
 	return loc != nil && loc.File != ""
+}
+
+// round returns the number with the specified precision.
+func round(number float64, precision int) float64 {
+	return math.Round(number*10*float64(precision)) / (10.0 * float64(precision))
 }

--- a/cover/cover_test.go
+++ b/cover/cover_test.go
@@ -71,7 +71,7 @@ baz {     # expect no exit
 		{6}, {7}, // foo body
 		{10},             // bar head
 		{11}, {12}, {13}, // bar body
-		{17}, // baz body hits
+		{17}, {18}, // baz body hits
 	}
 
 	expectedNotCovered := []Position{
@@ -91,6 +91,35 @@ baz {     # expect no exit
 		}
 	}
 
+	if len(expectedCovered) != fr.locCovered() {
+		t.Errorf(
+			"Expected %d loc to be covered, got %d instead",
+			len(expectedCovered),
+			fr.locCovered())
+	}
+
+	if len(expectedNotCovered) != fr.locNotCovered() {
+		t.Errorf(
+			"Expected %d loc to not be covered, got %d instead",
+			len(expectedNotCovered),
+			fr.locNotCovered())
+	}
+
+	expectedCoveragePercentage := round(100.0*float64(len(expectedCovered))/float64(len(expectedCovered)+len(expectedNotCovered)), 2)
+	if expectedCoveragePercentage != fr.ComputeCoveragePercentage() {
+		t.Errorf("Expected coverage %f != %f",
+			expectedCoveragePercentage,
+			fr.ComputeCoveragePercentage())
+	}
+
+	// there's just one file, hence the overall coverage is equal to the
+	// one of the only file report we have
+	if expectedCoveragePercentage != report.Coverage {
+		t.Errorf("Expected report coverage %f != %f",
+			expectedCoveragePercentage,
+			report.Coverage)
+	}
+
 	if t.Failed() {
 		bs, err := json.MarshalIndent(fr, "", "  ")
 		if err != nil {
@@ -98,5 +127,4 @@ baz {     # expect no exit
 		}
 		fmt.Println(string(bs))
 	}
-
 }

--- a/tester/reporter.go
+++ b/tester/reporter.go
@@ -123,9 +123,10 @@ func (r JSONReporter) Report(ch chan *Result) error {
 
 // JSONCoverageReporter reports coverage as a JSON structure.
 type JSONCoverageReporter struct {
-	Cover   *cover.Cover
-	Modules map[string]*ast.Module
-	Output  io.Writer
+	Cover     *cover.Cover
+	Modules   map[string]*ast.Module
+	Output    io.Writer
+	Threshold float64
 }
 
 // Report prints the test report to the reporter's output. If any tests fail or
@@ -140,6 +141,14 @@ func (r JSONCoverageReporter) Report(ch chan *Result) error {
 		}
 	}
 	report := r.Cover.Report(r.Modules)
+
+	if report.Coverage < r.Threshold {
+		return &cover.CoverageThresholdError{
+			Coverage:  report.Coverage,
+			Threshold: r.Threshold,
+		}
+	}
+
 	encoder := json.NewEncoder(r.Output)
 	encoder.SetIndent("", "  ")
 	return encoder.Encode(report)


### PR DESCRIPTION
This PR fixes issue #1029 by providing these changes.

## Show code coverage percentage inside of reports

Extend `opa test` to compute the code coverage percentage of each file and the overall one.

The `opa test --coverage` now returns the code coverage percentage per file and globally:

```
./opa_linux_amd64 test --coverage example
{
  "files": {
    "example/example.rego": {
      "covered": [
        {
          "start": {
            "row": 8
          },
          "end": {
            "row": 11
          }
        }
      ],
      "not_covered": [
        {
          "start": {
            "row": 3
          },
          "end": {
            "row": 5
          }
        }
      ],
      "coverage": 57.15
    },
    "example/example_test.rego": {
      "covered": [
        {
          "start": {
            "row": 11
          },
          "end": {
            "row": 12
          }
        },
        {
          "start": {
            "row": 15
          },
          "end": {
            "row": 16
          }
        }
      ],
      "coverage": 100
    }
  },
  "coverage": 72.75
}
```

## Exit with error when coverage threshold is not met

User can now specify a desired code coverage threshold that causes `opa test` to exit with an error when the global code coverage is not met:

```
$ ./opa_linux_amd64 test --coverage --threshold 80 example
{
  "files": {
    "example/example.rego": {
      "covered": [
        {
          "start": {
            "row": 8
          },
          "end": {
            "row": 11
          }
        }
      ],
      "not_covered": [
        {
          "start": {
            "row": 3
          },
          "end": {
            "row": 5
          }
        }
      ],
      "coverage": 57.15
    },
    "example/example_test.rego": {
      "covered": [
        {
          "start": {
            "row": 11
          },
          "end": {
            "row": 12
          }
        },
        {
          "start": {
            "row": 15
          },
          "end": {
            "row": 16
          }
        }
      ],
      "coverage": 100
    }
  },
  "coverage": 72.75
}
Error: code coverage threshold not met: got 72.75 instead of 80
$ echo $?
1
```