### PR TITLE
docs(rest-api): remove '{: .opa-tip}'

### DIFF
--- a/docs/book/rest-api.md
+++ b/docs/book/rest-api.md
@@ -637,7 +637,6 @@ public_servers[server] {
 ```
 
 > cURL's `-d/--data` flag removes newline characters from input files. Use the `--data-binary` flag instead.
-{: .opa-tip}
 
 #### Example Response
 


### PR DESCRIPTION
This didn't look like it was processed in any way, and showed up as-is
on the website:
<img width="745" alt="screen shot 2018-10-30 at 12 37 03" src="https://user-images.githubusercontent.com/870638/47715740-e7379f80-dc40-11e8-8d09-98a1c2ceadb6.png">
