### PR TITLE
Unexport helper function to compute coverage

### DIFF
--- a/cover/cover.go
+++ b/cover/cover.go
@@ -78,7 +78,7 @@ func (c *Cover) Report(modules map[string]*ast.Module) (report Report) {
 	var overallCoverage float64
 
 	for _, fr := range report.Files {
-		fr.Coverage = fr.ComputeCoveragePercentage()
+		fr.Coverage = fr.computeCoveragePercentage()
 		coveredLoc += fr.locCovered()
 		notCoveredLoc += fr.locNotCovered()
 	}
@@ -194,8 +194,8 @@ func (fr *FileReport) locNotCovered() (loc int) {
 	return
 }
 
-// ComputeCoveragePercentage returns the code coverage percentage of the file
-func (fr *FileReport) ComputeCoveragePercentage() float64 {
+// computeCoveragePercentage returns the code coverage percentage of the file
+func (fr *FileReport) computeCoveragePercentage() float64 {
 	coveredLoc := fr.locCovered()
 	notCoveredLoc := fr.locNotCovered()
 	totalLoc := coveredLoc + notCoveredLoc

--- a/cover/cover_test.go
+++ b/cover/cover_test.go
@@ -106,10 +106,8 @@ baz {     # expect no exit
 	}
 
 	expectedCoveragePercentage := round(100.0*float64(len(expectedCovered))/float64(len(expectedCovered)+len(expectedNotCovered)), 2)
-	if expectedCoveragePercentage != fr.ComputeCoveragePercentage() {
-		t.Errorf("Expected coverage %f != %f",
-			expectedCoveragePercentage,
-			fr.ComputeCoveragePercentage())
+	if expectedCoveragePercentage != fr.Coverage {
+		t.Errorf("Expected coverage %f != %f", expectedCoveragePercentage, fr.Coverage)
 	}
 
 	// there's just one file, hence the overall coverage is equal to the


### PR DESCRIPTION
The helper function to compute coverage doesn't have to be exported
since the coverage is set as a field on the FileReport. Removing the
helper function in the spirit of minimizing the surface area of the
package.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>