### PR TITLE
docs: Add decision ID note in API docs

### DIFF
--- a/docs/book/decision_logs.md
+++ b/docs/book/decision_logs.md
@@ -1,10 +1,12 @@
 # Decision Logs
 
-OPA can periodically report decision logs to remote HTTP servers. The
-decision logs contain events that describe policy queries. Each event
-includes the policy that was queried, the input to the query, bundle
-metadata, and other information that enables auditing and offline debugging
-of policy decisions.
+OPA can periodically report decision logs to remote HTTP servers. The decision
+logs contain events that describe policy queries. Each event includes the policy
+that was queried, the input to the query, bundle metadata, and other information
+that enables auditing and offline debugging of policy decisions.
+
+When decision logging is enabled the OPA server will include a `decision_id`
+field in API calls that return policy decisions.
 
 See the [Configuration Reference](configuration.md) for configuration details.
 

--- a/docs/book/rest-api.md
+++ b/docs/book/rest-api.md
@@ -997,6 +997,17 @@ The server returns 400 if either:
 The server returns 200 if the path refers to an undefined document. In this
 case, the response will not contain a `result` property.
 
+#### Response Message
+
+- **result** - The base or virtual document referred to by the URL path. If the
+  path is undefined, this key will be omitted.
+- **metrics** - If query metrics are enabled, this field contains query
+  performance metrics collected during the parse, compile, and evaluation steps.
+* **decision_id** - If decision logging is enabled, this field contains a string
+  that uniquely identifies the decision. The identifier will be included in the
+  decision log event for this decision. Callers can use the identifier for
+  correlation purposes.
+
 ### Get a Document (with Input)
 
 ```
@@ -1109,6 +1120,17 @@ The server returns 400 if either:
 
 The server returns 200 if the path refers to an undefined document. In this
 case, the response will not contain a `result` property.
+
+#### Response Message
+
+- **result** - The base or virtual document referred to by the URL path. If the
+  path is undefined, this key will be omitted.
+- **metrics** - If query metrics are enabled, this field contains query
+  performance metrics collected during the parse, compile, and evaluation steps.
+* **decision_id** - If decision logging is enabled, this field contains a string
+  that uniquely identifies the decision. The identifier will be included in the
+  decision log event for this decision. Callers can use the identifier for
+  correlation purposes.
 
 ### Get a Document (Webhook)
 


### PR DESCRIPTION
When decision logging is enabled, API calls for decisions will return a
decision ID, e.g., {"result": true, "decision_id": "abcdef1234"}.

Fixes #1061

Signed-off-by: Torin Sandall <torinsandall@gmail.com>