### PR TITLE
book(language reference): fix "alteration" typo

### DIFF
--- a/docs/book/language-reference.md
+++ b/docs/book/language-reference.md
@@ -300,7 +300,7 @@ The grammar defined above makes use of the following syntax. See [the Wikipedia 
 ```
 []     optional (zero or one instances)
 {}     repetition (zero or more instances)
-|      alteration (one of the instances)
+|      alternation (one of the instances)
 ()     grouping (order of expansion)
 STRING JSON string
 NUMBER JSON number


### PR DESCRIPTION
Looks like @msorens didn't get around to fixing this. So, here we go.