### PR TITLE
Fix bug in test runner rule name dedup

### DIFF
--- a/tester/runner.go
+++ b/tester/runner.go
@@ -148,10 +148,11 @@ func (r *Runner) Run(ctx context.Context, modules map[string]*ast.Module) (ch ch
 			if !strings.HasPrefix(name, TestPrefix) {
 				continue
 			}
-			if k, ok := count[name]; ok {
+			key := rule.Path().String()
+			if k, ok := count[key]; ok {
 				rule.Head.Name = ast.Var(fmt.Sprintf("%s#%02d", name, k))
 			}
-			count[name]++
+			count[key]++
 		}
 	}
 

--- a/tester/runner_test.go
+++ b/tester/runner_test.go
@@ -36,6 +36,9 @@ func TestRun(t *testing.T) {
 			test_duplicate { true }
 			test_duplicate { true }
 			`,
+		"/b_test.rego": `package bar
+
+		test_duplicate { true }`,
 	}
 
 	tests := map[[2]string]struct {
@@ -49,6 +52,7 @@ func TestRun(t *testing.T) {
 		{"data.foo", "test_duplicate#01"}:  {false, false},
 		{"data.foo", "test_duplicate#02"}:  {false, false},
 		{"data.foo", "test_err"}:           {true, false},
+		{"data.bar", "test_duplicate"}:     {false, false},
 	}
 
 	test.WithTempFS(files, func(d string) {


### PR DESCRIPTION
The test runner was using the rule name as the cache key for
deduplication purposes. If test rules in two different packages had the
same name, the second one would be rewritten which could cause
unexpected errors.

These changes simply update the runner to use the rule path (which is
the package path + rule name) because that ought to be unique.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>