### PR TITLE
Add support for multiple tracers

### DIFF
--- a/repl/repl_test.go
+++ b/repl/repl_test.go
@@ -335,27 +335,12 @@ func TestShowDebug(t *testing.T) {
 	repl.OneShot(ctx, "profile")
 	repl.OneShot(ctx, "show debug")
 	expected = `{
-	"trace": false,
+	"trace": true,
 	"metrics": true,
 	"instrument": true,
 	"profile": true
 }
 `
-	assertREPLText(t, buffer, expected)
-	buffer.Reset()
-	repl.OneShot(ctx, "metrics")
-	repl.OneShot(ctx, "instrument")
-	repl.OneShot(ctx, "profile")
-	repl.OneShot(ctx, "trace")
-	repl.OneShot(ctx, "show debug")
-	expected = `{
-	"trace": true,
-	"metrics": true,
-	"instrument": true,
-	"profile": false
-}
-`
-	buffer.Reset()
 }
 
 func TestShow(t *testing.T) {
@@ -1798,7 +1783,7 @@ func TestProfile(t *testing.T) {
 		"permissions": [{"resource": "foo123", "action": "read"}],
 	},
 ]
-	
+
 default allow = false
 
 	allow {

--- a/topdown/builtins.go
+++ b/topdown/builtins.go
@@ -58,7 +58,7 @@ type (
 		Runtime  *ast.Term      // runtime information on the OPA instance
 		Cache    builtins.Cache // built-in function state cache
 		Location *ast.Location  // location of built-in call
-		Tracer   Tracer         // tracer object for trace() built-in function
+		Tracers  []Tracer       // tracer objects for trace() built-in function
 		QueryID  uint64         // identifies query being evaluated
 		ParentID uint64         // identifies parent of query being evaluated
 	}

--- a/topdown/query.go
+++ b/topdown/query.go
@@ -26,7 +26,7 @@ type Query struct {
 	store            storage.Store
 	txn              storage.Transaction
 	input            *ast.Term
-	tracer           Tracer
+	tracers          []Tracer
 	unknowns         []*ast.Term
 	partialNamespace string
 	metrics          metrics.Metrics
@@ -76,9 +76,9 @@ func (q *Query) WithInput(input *ast.Term) *Query {
 	return q
 }
 
-// WithTracer sets the query tracer to use during evaluation. This is optional.
+// WithTracer adds a query tracer to use during evaluation. This is optional.
 func (q *Query) WithTracer(tracer Tracer) *Query {
-	q.tracer = tracer
+	q.tracers = append(q.tracers, tracer)
 	return q
 }
 
@@ -144,7 +144,7 @@ func (q *Query) PartialRun(ctx context.Context) (partials []ast.Body, support []
 		withCache:     newBaseCache(),
 		txn:           q.txn,
 		input:         q.input,
-		tracer:        q.tracer,
+		tracers:       q.tracers,
 		instr:         q.instr,
 		builtinCache:  builtins.Cache{},
 		virtualCache:  newVirtualCache(),
@@ -231,7 +231,7 @@ func (q *Query) Iter(ctx context.Context, iter func(QueryResult) error) error {
 		withCache:    newBaseCache(),
 		txn:          q.txn,
 		input:        q.input,
-		tracer:       q.tracer,
+		tracers:      q.tracers,
 		instr:        q.instr,
 		builtinCache: builtins.Cache{},
 		virtualCache: newVirtualCache(),

--- a/topdown/trace.go
+++ b/topdown/trace.go
@@ -204,7 +204,7 @@ func builtinTrace(bctx BuiltinContext, args []*ast.Term, iter func(*ast.Term) er
 		return handleBuiltinErr(ast.Trace.Name, bctx.Location, err)
 	}
 
-	if bctx.Tracer == nil || !bctx.Tracer.Enabled() {
+	if !traceIsEnabled(bctx.Tracers) {
 		return iter(ast.BooleanTerm(true))
 	}
 
@@ -214,9 +214,21 @@ func builtinTrace(bctx BuiltinContext, args []*ast.Term, iter func(*ast.Term) er
 		ParentID: bctx.ParentID,
 		Message:  string(str),
 	}
-	bctx.Tracer.Trace(evt)
+
+	for i := range bctx.Tracers {
+		bctx.Tracers[i].Trace(evt)
+	}
 
 	return iter(ast.BooleanTerm(true))
+}
+
+func traceIsEnabled(tracers []Tracer) bool {
+	for i := range tracers {
+		if tracers[i].Enabled() {
+			return true
+		}
+	}
+	return false
 }
 
 func init() {

--- a/topdown/trace_test.go
+++ b/topdown/trace_test.go
@@ -255,3 +255,30 @@ Redo data.test.p = _
 		t.Fatalf("Missing lines in trace:\n%v", strings.Join(a[min:], "\n"))
 	}
 }
+
+func TestMultipleTracers(t *testing.T) {
+
+	ctx := context.Background()
+
+	buf1 := NewBufferTracer()
+	buf2 := NewBufferTracer()
+	q := NewQuery(ast.MustParseBody("a = 1")).
+		WithTracer(buf1).
+		WithTracer(buf2)
+
+	_, err := q.Run(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(*buf1) != len(*buf2) {
+		t.Fatalf("Expected buffer lengths to be equal but got: %d and %d", len(*buf1), len(*buf2))
+	}
+
+	for i := range *buf1 {
+		if !(*buf1)[i].Equal((*buf2)[i]) {
+			t.Fatalf("Expected all events to be equal but at index %d got %v and %v", i, (*buf1)[i], (*buf2)[i])
+		}
+	}
+
+}


### PR DESCRIPTION
Previously the topdown evaluator only supported a single tracer. As a
result it was not easy to use multiple trace-based features (e.g.,
tracing and profiling) in conjunction.

These changes modify the evaluator to support multiple tracers. Instead
of adding a new interface to register N tracers, these changes just
overload the existing WithTracer function to add the passed tracer.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>