### PR TITLE
Refactor compiler to iterate over modules in order

### DIFF
--- a/ast/compile_test.go
+++ b/ast/compile_test.go
@@ -2263,12 +2263,21 @@ func getCompilerWithParsedModules(mods map[string]string) *Compiler {
 // helper function to run compiler upto given stage. If nil is provided, a
 // normal compile run is performed.
 func compileStages(c *Compiler, upto func()) {
+
+	for name := range c.Modules {
+		c.sorted = append(c.sorted, name)
+	}
+
+	sort.Strings(c.sorted)
 	c.SetErrorLimit(0)
+
 	if upto == nil {
 		c.compile()
 		return
 	}
+
 	target := reflect.ValueOf(upto)
+
 	for _, fn := range c.stages {
 		if fn(); c.Failed() {
 			return


### PR DESCRIPTION
These changes fix an annoying issue where the ordering of errors across
multiple files was non-deterministic. This was caused due to the fact
that iteration over maps in Go is non-deterministic.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>