### PR TITLE
Fix partial eval to apply saved terms

### DIFF
--- a/topdown/save.go
+++ b/topdown/save.go
@@ -2,6 +2,8 @@ package topdown
 
 import (
 	"container/list"
+	"fmt"
+	"strings"
 
 	"github.com/open-policy-agent/opa/ast"
 )
@@ -79,6 +81,16 @@ func (ss *saveSet) Vars(caller *bindings) ast.VarSet {
 	return result
 }
 
+func (ss *saveSet) String() string {
+	var buf []string
+
+	for x := ss.l.Front(); x != nil; x = x.Next() {
+		buf = append(buf, x.Value.(*saveSetElem).String())
+	}
+
+	return "(" + strings.Join(buf, " ") + ")"
+}
+
 type saveSetElem struct {
 	refs []ast.Ref
 	vars []*ast.Term
@@ -121,6 +133,10 @@ func (sse *saveSetElem) Contains(t *ast.Term, b *bindings) bool {
 		return sse.containsVar(other[0], b)
 	}
 	return false
+}
+
+func (sse *saveSetElem) String() string {
+	return fmt.Sprintf("(refs: %v, vars: %v, b: %v)", sse.refs, sse.vars, sse.b)
 }
 
 func (sse *saveSetElem) containsVar(t *ast.Term, b *bindings) bool {

--- a/topdown/topdown_partial_test.go
+++ b/topdown/topdown_partial_test.go
@@ -226,6 +226,29 @@ func TestTopDownPartialEval(t *testing.T) {
 			},
 		},
 		{
+			note:  "reference: head: applied",
+			query: "data.test.p = true",
+			modules: []string{
+				`package test
+
+				p {
+					q[x]
+					x.a = 1
+				}
+
+				q[x] {
+					input[x]
+					x.b = 2
+				}`,
+			},
+			wantQueries: []string{`
+				input[x_term_1_01]
+				x_term_1_01.b = 2
+				x_term_1_01
+				x_term_1_01.a = 1
+			`},
+		},
+		{
 			note:  "reference: default not required",
 			query: "data.test.p = true",
 			modules: []string{


### PR DESCRIPTION
Previously we were not applying the bindings to vars before adding them
to the save set. This meant the biunifier and the save set were out of
sync, e.g., a the biunifier would have (w/(x,1), 2) while the save set
had (w, 2). Therefore, when an expression like w = y was applied, the
result would be x = y which would not be saved. These changes modify
evaluation to apply vars before adding them to the save set. This way
the save set would correctly have (x, 1) in the case above.

Also, add String() function to save set for future debugging.

Fixes #1074