### PR TITLE
Fix panic caused by assignment rewriting

### DIFF
--- a/ast/compile_test.go
+++ b/ast/compile_test.go
@@ -1106,6 +1106,19 @@ func TestCompilerRewriteLocalAssignments(t *testing.T) {
 	head_array_comprehensions = [[x] | x := 1]
 	head_set_comprehensions = {[x] | x := 1}
 	head_object_comprehensions = {k: [x] | k := "foo"; x := 1}
+
+	rewritten_object_key {
+		k := "foo"
+		{k: 1}
+	}
+
+	rewritten_object_key_head[[{k: 1}]] {
+		k := "foo"
+	}
+
+	rewritten_object_key_head_value = [{k: 1}] {
+		k := "foo"
+	}
 	`)
 
 	c.Modules["test2"] = MustParseModule(`package test
@@ -1163,6 +1176,10 @@ func TestCompilerRewriteLocalAssignments(t *testing.T) {
 	head_array_comprehensions = [[__local21__] | __local21__ = 1]
 	head_set_comprehensions = {[__local22__] | __local22__ = 1}
 	head_object_comprehensions = {__local23__: [__local24__] | __local23__ = "foo"; __local24__ = 1}
+
+	rewritten_object_key = true { __local25__ = "foo"; {__local25__: 1} }
+	rewritten_object_key_head[[{__local26__: 1}]] { __local26__ = "foo" }
+	rewritten_object_key_head_value = [{__local27__: 1}] { __local27__ = "foo" }
 	`)
 
 	if len(module1.Rules) != len(expectedModule.Rules) {
@@ -2209,6 +2226,7 @@ func TestQueryCompilerRewrittenVars(t *testing.T) {
 		vars map[string]string
 	}{
 		{"assign", "a := 1", map[string]string{"__local0__": "a"}},
+		{"suppress only seen", "b = 1; a := b", map[string]string{"__local0__": "a"}},
 	}
 	for _, tc := range tests {
 		t.Run(tc.note, func(t *testing.T) {


### PR DESCRIPTION
During the assignment rewriting stages, variables that have been
assigned locally are rewritten, e.g., k := "foo"; {k: 1} becomes
__local0__ = "foo"; {__local0__: 1}. Previously, the rewriting would
simply mutate all of the term values without considering where the term
was defined. The problem with this was that it would corrupt the
object's hashtable if the rewritten term was an object key.

This commit resolves the issue by making a copy of the object key before
mutating the term value. This approach requires the compiler to copy the
object as well. If this proves to be a performance bottleneck, we can do
something more clever.

Note, it's arguable that the Object struct should not allow keys to be
mutated at all. This would be tricky given the current Object interface.
Perhaps we can improve this in the future to avoid similar issues.

These changes also resolve an issue with the rewritten var set returned
by the query compiler. Previously, all seen vars were returned in the
set (as opposed to only those that had been redeclared.) When the query
compiler inverts the map before returning it could accidentally elide
vars, e.g., given {a: b, b: b} if it inverted this to {b: a} then the
output would be correct but if it inverted this to {b: b} (which it
could depending on the iteration order) the output would be incorrect.

Fixes #1125

Signed-off-by: Torin Sandall <torinsandall@gmail.com>