### PR TITLE
Show line of failure in `opa test`

### DIFF
--- a/cmd/test.go
+++ b/cmd/test.go
@@ -33,6 +33,7 @@ var testParams = struct {
 	threshold    float64
 	timeout      time.Duration
 	ignore       []string
+	failureLine  bool
 }{
 	outputFormat: util.NewEnumFlag(testPrettyOutput, []string{testPrettyOutput, testJSONOutput}),
 }
@@ -136,6 +137,7 @@ func opaTest(args []string) int {
 		SetStore(store).
 		EnableTracing(testParams.verbose).
 		SetCoverageTracer(coverTracer).
+		EnableFailureLine(testParams.failureLine).
 		SetRuntime(info)
 
 	ch, err := runner.Run(ctx, modules)
@@ -154,8 +156,9 @@ func opaTest(args []string) int {
 			}
 		default:
 			reporter = tester.PrettyReporter{
-				Verbose: testParams.verbose,
-				Output:  os.Stdout,
+				Verbose:     testParams.verbose,
+				FailureLine: testParams.failureLine,
+				Output:      os.Stdout,
 			}
 		}
 	} else {
@@ -191,8 +194,11 @@ func opaTest(args []string) int {
 	return exitCode
 }
 
+// --show-failure-line / -l
+
 func init() {
 	testCommand.Flags().BoolVarP(&testParams.verbose, "verbose", "v", false, "set verbose reporting mode")
+	testCommand.Flags().BoolVarP(&testParams.failureLine, "show-failure-line", "l", false, "show test failure line")
 	testCommand.Flags().DurationVarP(&testParams.timeout, "timeout", "t", time.Second*5, "set test timeout")
 	testCommand.Flags().VarP(testParams.outputFormat, "format", "f", "set output format")
 	testCommand.Flags().BoolVarP(&testParams.coverage, "coverage", "c", false, "report coverage (overrides debug tracing)")

--- a/tester/reporter.go
+++ b/tester/reporter.go
@@ -26,8 +26,9 @@ type Reporter interface {
 
 // PrettyReporter reports test results in a simple human readable format.
 type PrettyReporter struct {
-	Output  io.Writer
-	Verbose bool
+	Output      io.Writer
+	Verbose     bool
+	FailureLine bool
 }
 
 // Report prints the test report to the reporter's output.
@@ -66,9 +67,20 @@ func (r PrettyReporter) Report(ch chan *Result) error {
 
 	// Report individual tests.
 	for _, tr := range results {
-		if !tr.Pass() || r.Verbose {
-			fmt.Fprintln(r.Output, tr)
+		if r.Verbose {
 			dirty = true
+			fmt.Fprintln(r.Output, tr)
+		} else if !tr.Pass() {
+			dirty = true
+			if r.FailureLine {
+				if tr.FailedAt != nil {
+					fmt.Fprintf(r.Output, "%v (%s:%d) \n", tr, tr.FailedAt.Location.File, tr.FailedAt.Location.Row)
+				} else {
+					fmt.Fprintf(r.Output, "%v (test skipped because success not possible) \n", tr)
+				}
+			} else {
+				fmt.Fprintln(r.Output, tr)
+			}
 		}
 		if tr.Error != nil {
 			fmt.Fprintf(r.Output, "  %v\n", tr.Error)

--- a/tester/runner_test.go
+++ b/tester/runner_test.go
@@ -16,6 +16,78 @@ import (
 	"github.com/open-policy-agent/opa/util/test"
 )
 
+func TestRunner_EnableFailureLine(t *testing.T) {
+
+	ctx := context.Background()
+
+	files := map[string]string{
+		"/a_test.rego": `package foo
+			test_a { 
+				true
+				false
+				true
+			}
+			test_b { 
+				false
+				true
+			}
+			test_c {
+				input.x = 1  # indexer understands this
+			}`,
+	}
+
+	tests := map[[2]string]struct {
+		wantErr  bool
+		wantFail bool
+		FailRow  int
+	}{
+		{"data.foo", "test_a"}: {false, true, 4},
+		{"data.foo", "test_b"}: {false, true, 8},
+		{"data.foo", "test_c"}: {false, true, 0},
+	}
+
+	test.WithTempFS(files, func(d string) {
+		paths := []string{d}
+		modules, store, err := tester.Load(paths, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		ch, err := tester.NewRunner().EnableFailureLine(true).SetStore(store).Run(ctx, modules)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var rs []*tester.Result
+		for r := range ch {
+			rs = append(rs, r)
+		}
+		seen := map[[2]string]struct{}{}
+		for i := range rs {
+			k := [2]string{rs[i].Package, rs[i].Name}
+			seen[k] = struct{}{}
+			exp, ok := tests[k]
+			if !ok {
+				t.Errorf("Unexpected result for %v", k)
+			} else if exp.wantErr != (rs[i].Error != nil) || exp.wantFail != rs[i].Fail {
+				t.Errorf("Expected %v for %v but got: %v", exp, k, rs[i])
+			} else if exp.FailRow != 0 {
+				if rs[i].FailedAt == nil || rs[i].FailedAt.Location == nil {
+					t.Errorf("Failed line not set")
+				} else if rs[i].FailedAt.Location.Row != exp.FailRow {
+					t.Errorf("Expected Failed Line %v but got: %v", exp.FailRow, rs[i].FailedAt.Location.Row)
+				}
+			} else if rs[i].FailedAt != nil {
+				t.Errorf("Failed line set, but expected not set.")
+			}
+		}
+		// This makes sure all tests were executed
+		for k := range tests {
+			if _, ok := seen[k]; !ok {
+				t.Errorf("Expected result for %v", k)
+			}
+		}
+	})
+}
+
 func TestRun(t *testing.T) {
 
 	ctx := context.Background()
@@ -56,6 +128,7 @@ func TestRun(t *testing.T) {
 	}
 
 	test.WithTempFS(files, func(d string) {
+
 		rs, err := tester.Run(ctx, d)
 		if err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
Fixes #961
Added new option to opa test command (-l)
Verbose (-v) as precedence over (-l)
Example run:

opa test test.rego -l
data.foo.test_a: FAIL (754ns) (test.rego:4)
data.foo.test_b: FAIL (382ns) (test.rego:8)
-------------------------------------------------------
FAIL: 2/2

Signed-off-by: repenno <rapenno@gmail.com>