### PR TITLE
Fix bug in local declaration rewriting

### DIFF
--- a/ast/compile.go
+++ b/ast/compile.go
@@ -2597,8 +2597,15 @@ func rewriteDeclaredVarsInTerm(g *localVarGenerator, stack *localDeclaredVars, t
 }
 
 func rewriteDeclaredVarsInTermRecursive(g *localVarGenerator, stack *localDeclaredVars, term *Term, errs Errors) Errors {
-	WalkTerms(term, func(term *Term) bool {
-		_, errs = rewriteDeclaredVarsInTerm(g, stack, term, errs)
+	WalkNodes(term, func(n Node) bool {
+		switch n := n.(type) {
+		case *With:
+			_, errs = rewriteDeclaredVarsInTerm(g, stack, n.Value, errs)
+			return true
+		case *Term:
+			_, errs = rewriteDeclaredVarsInTerm(g, stack, n, errs)
+			return false
+		}
 		return false
 	})
 	return errs

--- a/ast/compile_test.go
+++ b/ast/compile_test.go
@@ -1119,6 +1119,11 @@ func TestCompilerRewriteLocalAssignments(t *testing.T) {
 	rewritten_object_key_head_value = [{k: 1}] {
 		k := "foo"
 	}
+
+	skip_with_target_in_assignment {
+		input := 1
+		a := [true | true with input as 2; true with input as 3]
+	}
 	`)
 
 	c.Modules["test2"] = MustParseModule(`package test
@@ -1180,6 +1185,11 @@ func TestCompilerRewriteLocalAssignments(t *testing.T) {
 	rewritten_object_key = true { __local25__ = "foo"; {__local25__: 1} }
 	rewritten_object_key_head[[{__local26__: 1}]] { __local26__ = "foo" }
 	rewritten_object_key_head_value = [{__local27__: 1}] { __local27__ = "foo" }
+
+	skip_with_target_in_assignment {
+		__local28__ = 1
+		__local29__ = [true | true with input as 2; true with input as 3]
+	}
 	`)
 
 	if len(module1.Rules) != len(expectedModule.Rules) {


### PR DESCRIPTION
The rewriting was accidentally including the ref head (i.e., input or
data) in the seen stack when recursing on the right hand side of the
declaration statement. This meant that if multiple with modifiers were
applied within the term (e.g., inside a comprehension), then the 2nd
would cause the subsequent with target semantic check to fail.

The fix simply updates the rewriting step to ignore the with target in
this case (like we already do for other statements.)

Signed-off-by: Torin Sandall <torinsandall@gmail.com>