### PR TITLE
Add /health endpoint to OPA HTTP server

### DIFF
--- a/server/server_test.go
+++ b/server/server_test.go
@@ -44,6 +44,16 @@ type trw struct {
 	wait chan struct{}
 }
 
+func TestUnversionedGetHealth(t *testing.T) {
+
+	f := newFixture(t)
+
+	req := newReqUnversioned(http.MethodGet, "/health", "")
+	if err := f.executeRequest(req, 200, `{}`); err != nil {
+		t.Fatalf("Unexpected error while health check: %v", err)
+	}
+}
+
 func TestDataV0(t *testing.T) {
 	testMod1 := `package test
 


### PR DESCRIPTION
Fixes #1086

curl -v http://:8181/health
*  Trying ::1...
* TCP_NODELAY set
* Connected to  (::1) port 8181 (#0)
> GET /health HTTP/1.1
> Host: :8181
> User-Agent: curl/7.54.0
> Accept: */*
>
< HTTP/1.1 200 OK
< Content-Type: application/json
< Date: Mon, 07 Jan 2019 20:09:36 GMT
< Content-Length: 2
<
* Connection #0 to host  left intact
{}%

Signed-off-by: repenno <rapenno@gmail.com>