### PR TITLE
Fix parser to avoid duplicate comments in AST

### DIFF
--- a/ast/parser_internal.go
+++ b/ast/parser_internal.go
@@ -564,9 +564,12 @@ func makeComments(c *current, text interface{}) (interface{}, error) {
 
 	comment := NewComment(buf.Bytes())
 	comment.Location = currentLocation(c)
-	comments := c.globalStore[commentsKey].([]*Comment)
-	comments = append(comments, comment)
-	c.globalStore[commentsKey] = comments
-
+	comments := c.globalStore[commentsKey].(map[commentKey]*Comment)
+	key := commentKey{
+		File: comment.Location.File,
+		Row:  comment.Location.Row,
+		Col:  comment.Location.Col,
+	}
+	comments[key] = comment
 	return comment, nil
 }

--- a/ast/policy.go
+++ b/ast/policy.go
@@ -5,6 +5,7 @@
 package ast
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"math/rand"
@@ -284,6 +285,13 @@ func (c *Comment) SetLoc(loc *Location) {
 
 func (c *Comment) String() string {
 	return "#" + string(c.Text)
+}
+
+// Equal returns true if this comment equals the other comment.
+// Unlike other equality checks on AST nodes, comment equality
+// depends on location.
+func (c *Comment) Equal(other *Comment) bool {
+	return c.Location.Equal(other.Location) && bytes.Equal(c.Text, other.Text)
 }
 
 // Compare returns an integer indicating whether pkg is less than, equal to,


### PR DESCRIPTION
The parser was accumulating comments in a parser-global slice. If the
parser backtracked, the comments were not thrown away. Because most
successful parses seem to backtrack, this meant that most ASTs contained
duplicated comments.

This change simply modifies the parser to accumulate the comments in a
set that just gets sorted at the end.

Fixes #426