### PR TITLE
Add OPA version to decision logs

### DIFF
--- a/plugins/logs/plugin.go
+++ b/plugins/logs/plugin.go
@@ -8,6 +8,7 @@ package logs
 import (
 	"context"
 	"fmt"
+	"github.com/open-policy-agent/opa/version"
 	"math/rand"
 	"net/http"
 	"reflect"
@@ -33,6 +34,7 @@ type EventV1 struct {
 	Result      *interface{}      `json:"result,omitempty"`
 	RequestedBy string            `json:"requested_by"`
 	Timestamp   time.Time         `json:"timestamp"`
+	Version     string            `json:"version"`
 }
 
 const (
@@ -205,6 +207,7 @@ func (p *Plugin) Log(ctx context.Context, decision *server.Info) {
 		Result:      decision.Results,
 		RequestedBy: decision.RemoteAddr,
 		Timestamp:   decision.Timestamp,
+		Version:     version.Version,
 	}
 
 	p.mtx.Lock()


### PR DESCRIPTION
Fixes #1089 

Decision logs now contain build version. All tests pass.

=== RUN   TestPluginStartSameInput
--- PASS: TestPluginStartSameInput (0.02s)
=== RUN   TestPluginStartChangingInputValues
--- PASS: TestPluginStartChangingInputValues (0.01s)
=== RUN   TestPluginStartChangingInputKeysAndValues
--- PASS: TestPluginStartChangingInputKeysAndValues (0.01s)
=== RUN   TestPluginRequeue
--- PASS: TestPluginRequeue (0.00s)
=== RUN   TestPluginReconfigure
time="2019-01-09T09:34:03-08:00" level=info msg="Starting decision log uploader." plugin=decision_logs
time="2019-01-09T09:34:03-08:00" level=info msg="Log upload skipped." plugin=decision_logs
time="2019-01-09T09:34:03-08:00" level=info msg="Stopping decision log uploader." plugin=decision_logs
time="2019-01-09T09:34:03-08:00" level=info msg="Decision log uploader configuration changed." plugin=decision_logs
time="2019-01-09T09:34:03-08:00" level=info msg="Log upload skipped." plugin=decision_logs
--- PASS: TestPluginReconfigure (0.00s)
PASS

Signed-off-by: repenno <rapenno@gmail.com>