### PR TITLE
Plugin improvements and custom decision loggers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .DS_Store
 .vscode
 .idea
+*~
 
 # build artifacts
 coverage

--- a/cmd/plugins_test.go
+++ b/cmd/plugins_test.go
@@ -159,10 +159,12 @@ func (t *Tester) Reconfigure(ctx context.Context, config interface{}) {
 	return
 }
 
-var Initializer plugins.PluginInitFunc = func(m *plugins.Manager, config []byte) (plugins.Plugin, error) {
-	var test struct {
-		Key string
-	}
+type Config struct { Key string }
+
+type Factory struct {}
+
+func (f Factory) Validate(_ *plugins.Manager, config []byte) (interface{}, error) {
+	test := Config{}
 
 	if err := util.Unmarshal(config, &test); err != nil {
 		return nil, err
@@ -172,11 +174,15 @@ var Initializer plugins.PluginInitFunc = func(m *plugins.Manager, config []byte)
 		return nil, fmt.Errorf("got " + test.Key + ", expected secret")
 	}
 
-	return &Tester{}, nil
+    return test, nil
+}
+
+func (f Factory) New(_ *plugins.Manager, config interface{}) plugins.Plugin {
+	return &Tester{}
 }
 
 func Init() error {
-	runtime.RegisterPlugin(Name, Initializer)
+	runtime.RegisterPlugin(Name, Factory{})
 	return nil
 }
 `, name, url)

--- a/docs/book/SUMMARY.md
+++ b/docs/book/SUMMARY.md
@@ -124,6 +124,7 @@
 * [Security](security.md)
   * [TLS and HTTPS](security.md#tls-and-https)
   * [Authentication and Authorization](security.md#authentication-and-authorization)
+* [Plugins](plugins.md)
 * [FAQ](faq.md)
 * [Comparison to Other Systems](comparison-to-other-systems.md)
   * [RBAC](comparison-to-other-systems.md#role-based-access-control-rbac)

--- a/docs/book/configuration.md
+++ b/docs/book/configuration.md
@@ -74,6 +74,7 @@ multiple services.
 | `labels` | `object` | Yes | Set of key-value pairs that uniquely identify the OPA instance. Labels are included when OPA uploads decision logs and status information. |
 | `default_decision` | `string` | No (default: `/system/main`) | Set path of default policy decision used to serve queries against OPA's base URL. |
 | `default_authorization_decision` | `string` | No (default: `/system/authz/allow`) | Set path of default authorization decision for OPA's API. |
+| `plugins` | `object` | No (default: `{}`) | Location for custom plugin configuration. See [Plugins](plugins.md) for details. |
 
 ## Bundles
 
@@ -101,6 +102,7 @@ multiple services.
 | `decision_logs.reporting.upload_size_limit_bytes` | `int64` | No (default: `32768`) | Decision log upload size limit in bytes. OPA will chunk uploads to cap message body to this limit. |
 | `decision_logs.reporting.min_delay_seconds` | `int64` | No (default: `300`) | Minimum amount of time to wait between uploads. |
 | `decision_logs.reporting.max_delay_seconds` | `int64` | No (default: `600`) | Maximum amount of time to wait between uploads. |
+| `decision_logs.plugin` | `string` | No | Use the named plugin for decision logging. If this field exists, the other configuration fields are not required. |
 
 ## Discovery
 

--- a/docs/book/plugins.md
+++ b/docs/book/plugins.md
@@ -1,0 +1,216 @@
+# Plugins (Experimental)
+
+OPA can be extended with custom built-in functions and plugins that
+implement functionality like support for new protocols.
+
+> This page focuses on how to build [Go
+> plugins](https://golang.org/pkg/plugin/) that can be loaded when OPA
+> starts however the steps are similar if you are embedding OPA as a
+> library or building from source.
+
+## Building Go Plugins
+
+At minimum, your Go plugin must implement the following:
+
+```golang
+package main
+
+func Init() error {
+	 // your init function
+}
+```
+
+When OPA starts, it will invoke the `Init` function which can:
+
+* Register custom built-in functions.
+* Register custom OPA plugins (e.g., decision loggers, servers, etc.)
+* ...or do anything else.
+
+See the sections below for examples.
+
+To build your plugin into a shared object file (`.so`), you will
+(minimally) run the following command:
+
+```bash
+go build -buildmode=plugin -o=plugin.so plugin.go
+```
+
+This will produce a file named `plugin.so` that you can pass to OPA
+with the `--plugin-dir` flag. OPA will load all of the `.so` files out
+of the directory you give it.
+
+```bash
+opa --plugin-dir=/path/to/plugins run
+```
+
+**NOTE:** You must build your plugin against the same version of the
+  OPA that will eventually load the shared object file. If you build
+  your plugin against a different version of the OPA source, the OPA
+  will fail to start. You will see an error message like:
+
+```
+Error: plugin.Open("plugin/logger"): plugin was built with a different version of package github.com/open-policy-agent/opa/ast
+```
+
+## Built-in Functions
+
+To implement custom built-in functions your `Init` function should call:
+
+- `ast.RegisterBuiltin` to declare the built-in function.
+- `topdown.RegisterFunctionalBuiltin[X]` to register the built-in function implementation (where X is replaced by the number of parameters your function receives.)
+
+For example:
+
+```golang
+package main
+
+import (
+	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/types"
+	"github.com/open-policy-agent/opa/topdown"
+)
+
+var HelloBuiltin = &ast.Builtin{
+	Name: "hello",
+	Decl: types.NewFunction(
+		types.Args(types.S),
+		types.S,
+	),
+}
+
+func HelloImpl(a ast.Value) (ast.Value, error) {
+	s, err := builtins.StringOperand(1, a)
+	if err != nil {
+		return nil, err
+	}
+	return ast.String("hello, " + string(s)), nil
+}
+
+func Init() error {
+	ast.RegisterBuiltin(HelloBuiltin)
+	topdown.RegisterFunctionalBuiltin1(HelloBuiltin.Name, HelloImpl)
+	return nil
+}
+```
+
+If you build this file into a shared object and start OPA with it you can call it like other built-in functions:
+
+```
+> hello("bob")
+"hello, bob"
+```
+
+For more details on implementing built-in functions, see the [OPA Go Documentation](https://godoc.org/github.com/open-policy-agent/opa/topdown#example-RegisterFunctionalBuiltin1).
+
+## Custom Plugins
+
+OPA defines a plugin interface that allows you to customize certain
+behaviour like decision logging or add new behaviour like different
+query APIs. To implement a custom plugin you must implement two
+interfaces:
+
+- [github.com/open-policy-agent/opa/plugins#Factory](https://godoc.org/github.com/open-policy-agent/opa/plugins#Factory) to instantiate your plugin.
+- [github.com/open-policy-agent/opa/plugins#Plugin](https://godoc.org/github.com/open-policy-agent/opa/plugins#Plugin) to provide your plugin behavior.
+
+You can register your factory with OPA by calling [github.com/open-policy-agent/opa/runtime#RegisterPlugin](https://godoc.org/github.com/open-policy-agent/opa/runtime#RegisterPlugin) inside your `Init` function.
+
+### Putting It Together
+
+The example below shows how you can implement a custom [Decision Logger](decision_logs.md)
+that writes events to a stream (e.g., stdout/stderr).
+
+```golang
+type Config struct {
+	Stderr bool `json:"stderr"` // false => stdout, true => stderr
+}
+
+type PrintlnLogger struct {
+	mtx sync.Mutex
+	config Config
+}
+
+func (p *PrintlnLogger) Start(ctx context.Context) error {
+	// No-op.
+	return nil
+}
+
+func (p *PrintlnLogger) Stop(ctx context.Context) {
+	// No-op.
+}
+
+func (p *PrintlnLogger) Reconfigure(ctx context.Context, config interface{}) {
+    p.mtx.Lock()
+    defer p.mtx.Unlock()
+    p.config = config.(Config)
+}
+
+func (p *PrintlnLogger) Log(ctx context.Context, event logs.EventV1) {
+    p.mtx.Lock()
+    defer p.mtx.Unlock()
+    w := os.Stdout
+    if p.config.Stderr {
+        w = os.Stderr
+    }
+    fmt.Fprintln(w, event) // ignoring errors!
+}
+```
+
+Next, implement a factory function that instantiates your plugin:
+
+```golang
+type Factory struct{}
+
+func (Factory) New(_ *plugins.Manager, config interface{}) plugins.Plugin {
+	return &PrintlnLogger{
+		config: config.(Config),
+	}
+}
+
+func (Factory) Validate(_ *plugins.Manager, config []byte) (interface{}, error) {
+	parsedConfig := Config{}
+	return parsedConfig, util.Unmarshal(config, &parsedConfig)
+}
+```
+
+Finally, register your factory with OPA:
+
+```golang
+func Init() {
+    runtime.RegisterPlugin("println_decision_logger", Factory{})
+}
+```
+
+To test your plugin, build a shared object file:
+
+```
+go build -buildmode=plugin -o=plugin.so main.go
+```
+
+Define an OPA configuration file that will use your plugin:
+
+**config.yaml**:
+
+```yaml
+decision_logs:
+  plugin: println_decision_logger
+plugins:
+  println_decision_logger:
+    stderr: false
+```
+
+Start OPA with the plugin directory and configuration file:
+
+```bash
+opa --plugin-dir $PWD run --server --config-file config.yaml
+```
+
+Exercise the plugin via the OPA API:
+
+```
+curl localhost:8181/v1/data
+```
+
+If everything worked you will see the Go struct representation of the decision
+log event written to stdout.
+
+The source code for this example can be found [here](https://github.com/open-policy-agent/contrib/tree/master/decision_logger_plugin_example).

--- a/docs/book/plugins.md
+++ b/docs/book/plugins.md
@@ -68,6 +68,7 @@ import (
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/types"
 	"github.com/open-policy-agent/opa/topdown"
+	"github.com/open-policy-agent/opa/topdown/builtins"
 )
 
 var HelloBuiltin = &ast.Builtin{
@@ -79,7 +80,7 @@ var HelloBuiltin = &ast.Builtin{
 }
 
 func HelloImpl(a ast.Value) (ast.Value, error) {
-	s, err := builtins.StringOperand(1, a)
+	s, err := builtins.StringOperand(a, 1)
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/discovery/discovery.go
+++ b/plugins/discovery/discovery.go
@@ -289,7 +289,7 @@ func getPluginSet(factories map[string]plugins.Factory, manager *plugins.Manager
 		return nil, err
 	}
 
-	decisionLogsConfig, err := logs.ParseConfig(config.DecisionLogs, manager.Services())
+	decisionLogsConfig, err := logs.ParseConfig(config.DecisionLogs, manager.Services(), pluginNames)
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/discovery/discovery_test.go
+++ b/plugins/discovery/discovery_test.go
@@ -153,6 +153,18 @@ func TestProcessBundle(t *testing.T) {
 
 }
 
+type testFactory struct {
+	p *reconfigureTestPlugin
+}
+
+func (f testFactory) Validate(*plugins.Manager, []byte) (interface{}, error) {
+	return nil, nil
+}
+
+func (f testFactory) New(*plugins.Manager, interface{}) plugins.Plugin {
+	return f.p
+}
+
 type reconfigureTestPlugin struct {
 	counts map[string]int
 }
@@ -185,12 +197,9 @@ func TestReconfigure(t *testing.T) {
 	}
 
 	testPlugin := &reconfigureTestPlugin{counts: map[string]int{}}
+	testFactory := testFactory{p: testPlugin}
 
-	disco, err := New(manager, CustomPlugins(map[string]plugins.PluginInitFunc{
-		"test_plugin": func(*plugins.Manager, []byte) (plugins.Plugin, error) {
-			return testPlugin, nil
-		},
-	}))
+	disco, err := New(manager, Factories(map[string]plugins.Factory{"test_plugin": testFactory}))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This PR contains two commits. The first improves the plugin system so that custom plugins can be managed more like bundles/status/logs. The second makes the decision logger backend pluggable.

I considered implementing the decision logger feature in a more generic manner that would have worked for other components like status and bundle but eventually decided against that (it felt like overkill). If we find ourselves needing to make the other components pluggable, we could revisit the implementation.