### PR TITLE
chore: Update release-builder for Go 1.11

### DIFF
--- a/Dockerfile_release-builder.in
+++ b/Dockerfile_release-builder.in
@@ -14,4 +14,4 @@ ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 
-RUN npm install -g gitbook-cli gulp
+RUN npm install -g gitbook-cli

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ BUILD_COMMIT := $(shell ./build/get-build-commit.sh)
 BUILD_TIMESTAMP := $(shell ./build/get-build-timestamp.sh)
 BUILD_HOSTNAME := $(shell ./build/get-build-hostname.sh)
 
-RELEASE_BUILDER_VERSION := 1.0
+RELEASE_BUILDER_VERSION := 1.1
 
 LDFLAGS := "-X github.com/open-policy-agent/opa/version.Version=$(VERSION) \
 	-X github.com/open-policy-agent/opa/version.Vcs=$(BUILD_COMMIT) \

--- a/docs/devel/DEVELOPMENT.md
+++ b/docs/devel/DEVELOPMENT.md
@@ -16,7 +16,7 @@ Requirements:
 
 - Git
 - GitHub account (if you are contributing)
-- Go (version 1.10 is supported though older versiosn are likely to work)
+- Go (version 1.11 is supported though older versions are likely to work)
 - GNU Make
 
 ## Getting Started
@@ -118,3 +118,12 @@ parser generation explicitly you can run `make generate`.
 If you are modifying the Rego syntax you must commit the parser source file
 (ast/parser.go) that `make generate` produces when you are done. The generated
 code is kept in the repository so that commands such as `go get` work.
+
+## Go
+
+If you need to update the version of Go that OPA's CI and release
+builder use, update the Go version in the Makefile and .travis.yml
+files. You will also need to bump the version of the release builder
+and re-build it using the `release-builder` target. Note, you will
+need push access on the openpolicyagent DockerHub account to release
+the new version of the `release-builder` as this is not automated yet.


### PR DESCRIPTION
Also, remove gulp installation as that's not required with the new frontpage.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>