### PR TITLE
ast: Fix find operation on sets for non-empty refs

### DIFF
--- a/ast/term.go
+++ b/ast/term.go
@@ -1205,12 +1205,15 @@ func (s *set) Compare(other Value) int {
 	return termSliceCompare(s.keys, t.keys)
 }
 
-// Find returns the current value or a not found error.
+// Find returns the set or dereferences the element itself.
 func (s *set) Find(path Ref) (Value, error) {
 	if len(path) == 0 {
 		return s, nil
 	}
-	return nil, fmt.Errorf("find: not found")
+	if !s.Contains(path[0]) {
+		return nil, fmt.Errorf("find: not found")
+	}
+	return path[0].Value.Find(path[1:])
 }
 
 // Diff returns elements in s that are not in other.

--- a/ast/term_test.go
+++ b/ast/term_test.go
@@ -178,6 +178,7 @@ func TestFind(t *testing.T) {
 		expected interface{}
 	}{
 		{RefTerm(StringTerm("foo"), IntNumberTerm(1), StringTerm("bar")), MustParseTerm(`{2, 3, 4}`)},
+		{RefTerm(StringTerm("foo"), IntNumberTerm(1), StringTerm("bar"), IntNumberTerm(4)), MustParseTerm(`4`)},
 		{RefTerm(StringTerm("foo"), IntNumberTerm(2)), fmt.Errorf("not found")},
 		{RefTerm(StringTerm("baz"), StringTerm("qux"), IntNumberTerm(0)), MustParseTerm(`"hello"`)},
 	}


### PR DESCRIPTION
The find operation on sets was returning "not found" for non-empty
refs which was unexpected and resulted in evaluation failing. This
problem would only manifest if sets were provided as input or used
when mocking data. Since input is typically JSON (and does not
include sets) and data mocking is relatively new, we only ran into
this recently.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>