### PR TITLE
Improvements to decision logging

### DIFF
--- a/docs/book/decision_logs.md
+++ b/docs/book/decision_logs.md
@@ -55,8 +55,11 @@ Decision log updates contain the following fields:
 | `[_].labels` | `object` | Set of key-value pairs that uniquely identify the OPA instance. |
 | `[_].decision_id` | `string` | Unique identifier generated for each decision for traceability. |
 | `[_].revision` | `string` | Bundle revision that contained the policy used to produce the decision. |
-| `[_].path` | `string` | Hierarchical policy decision path, e.g., `/http/example/authz/allow`. |
+| `[_].path` | `string` | Hierarchical policy decision path, e.g., `/http/example/authz/allow`. Receivers should tolerate slash-prefixed paths. |
+| `[_].query` | `string` | Ad-hoc Rego query received by Query API. |
 | `[_].input` | `any` | Input data provided in the policy query. |
 | `[_].result` | `any` | Policy decision returned to the client, e.g., `true` or `false`. |
 | `[_].requested_by` | `string` | Identifier for client that executed policy query, e.g., the client address. |
 | `[_].timestamp` | `string` | RFC3999 timestamp of policy decision. |
+| `[_].version` | `string` | Version of the OPA instance that generated the event. |
+| `[_].metrics` | `object` | Key-value pairs of [performance metrics](rest-api.md#performance-metrics). |

--- a/docs/book/rest-api.md
+++ b/docs/book/rest-api.md
@@ -1859,6 +1859,7 @@ OPA currently supports the following query performance metrics:
 - **timer_rego_query_eval_ns**: time taken (in nanonseconds) to evaluate the query.
 - **timer_rego_module_parse_ns**: time taken (in nanoseconds) to parse the input policy module.
 - **timer_rego_module_compile_ns**: time taken (in nanoseconds) to compile the loaded policy modules.
+- **timer_server_handler_ns**: time take (in nanoseconds) to handle the API request.
 
 OPA also supports query instrumentation. To enable query instrumentation,
 specify the `instrument=true` query parameter when executing the API call.

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -238,5 +238,5 @@ func (c *counter) Incr() {
 }
 
 func (c *counter) Value() interface{} {
-	return *c
+	return uint64(*c)
 }

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -17,6 +17,7 @@ import (
 
 // Well-known metric names.
 const (
+	ServerHandler     = "server_handler"
 	RegoQueryCompile  = "rego_query_compile"
 	RegoQueryEval     = "rego_query_eval"
 	RegoQueryParse    = "rego_query_parse"

--- a/plugins/logs/plugin.go
+++ b/plugins/logs/plugin.go
@@ -32,15 +32,16 @@ type Logger interface {
 
 // EventV1 represents a decision log event.
 type EventV1 struct {
-	Labels      map[string]string `json:"labels"`
-	DecisionID  string            `json:"decision_id"`
-	Revision    string            `json:"revision,omitempty"`
-	Path        string            `json:"path"`
-	Input       *interface{}      `json:"input,omitempty"`
-	Result      *interface{}      `json:"result,omitempty"`
-	RequestedBy string            `json:"requested_by"`
-	Timestamp   time.Time         `json:"timestamp"`
-	Version     string            `json:"version"`
+	Labels      map[string]string      `json:"labels"`
+	DecisionID  string                 `json:"decision_id"`
+	Revision    string                 `json:"revision,omitempty"`
+	Path        string                 `json:"path"`
+	Input       *interface{}           `json:"input,omitempty"`
+	Result      *interface{}           `json:"result,omitempty"`
+	RequestedBy string                 `json:"requested_by"`
+	Timestamp   time.Time              `json:"timestamp"`
+	Version     string                 `json:"version"`
+	Metrics     map[string]interface{} `json:"metrics,omitempty"`
 }
 
 const (
@@ -226,6 +227,10 @@ func (p *Plugin) Log(ctx context.Context, decision *server.Info) {
 		RequestedBy: decision.RemoteAddr,
 		Timestamp:   decision.Timestamp,
 		Version:     version.Version,
+	}
+
+	if decision.Metrics != nil {
+		event.Metrics = decision.Metrics.All()
 	}
 
 	if p.config.Plugin != nil {

--- a/plugins/logs/plugin.go
+++ b/plugins/logs/plugin.go
@@ -38,6 +38,7 @@ type EventV1 struct {
 	Path        string                 `json:"path"`
 	Input       *interface{}           `json:"input,omitempty"`
 	Result      *interface{}           `json:"result,omitempty"`
+	Error       error                  `json:"error,omitempty"`
 	RequestedBy string                 `json:"requested_by"`
 	Timestamp   time.Time              `json:"timestamp"`
 	Version     string                 `json:"version"`
@@ -231,6 +232,10 @@ func (p *Plugin) Log(ctx context.Context, decision *server.Info) {
 
 	if decision.Metrics != nil {
 		event.Metrics = decision.Metrics.All()
+	}
+
+	if decision.Error != nil {
+		event.Error = decision.Error
 	}
 
 	if p.config.Plugin != nil {

--- a/plugins/logs/plugin.go
+++ b/plugins/logs/plugin.go
@@ -223,7 +223,7 @@ func (p *Plugin) Log(ctx context.Context, decision *server.Info) {
 		DecisionID:  decision.DecisionID,
 		Revision:    decision.Revision,
 		Path:        path,
-		Input:       &decision.Input,
+		Input:       decision.Input,
 		Result:      decision.Results,
 		RequestedBy: decision.RemoteAddr,
 		Timestamp:   decision.Timestamp,

--- a/plugins/logs/plugin.go
+++ b/plugins/logs/plugin.go
@@ -35,7 +35,8 @@ type EventV1 struct {
 	Labels      map[string]string      `json:"labels"`
 	DecisionID  string                 `json:"decision_id"`
 	Revision    string                 `json:"revision,omitempty"`
-	Path        string                 `json:"path"`
+	Path        string                 `json:"path,omitempty"`
+	Query       string                 `json:"query,omitempty"`
 	Input       *interface{}           `json:"input,omitempty"`
 	Result      *interface{}           `json:"result,omitempty"`
 	Error       error                  `json:"error,omitempty"`
@@ -216,13 +217,14 @@ func (p *Plugin) Stop(ctx context.Context) {
 // Log appends a decision log event to the buffer for uploading.
 func (p *Plugin) Log(ctx context.Context, decision *server.Info) {
 
-	path := strings.Replace(strings.TrimPrefix(decision.Query, "data."), ".", "/", -1)
+	path := strings.Replace(strings.TrimPrefix(decision.Path, "data."), ".", "/", -1)
 
 	event := EventV1{
 		Labels:      p.manager.Labels(),
 		DecisionID:  decision.DecisionID,
 		Revision:    decision.Revision,
 		Path:        path,
+		Query:       decision.Query,
 		Input:       decision.Input,
 		Result:      decision.Results,
 		RequestedBy: decision.RemoteAddr,

--- a/plugins/logs/plugin_test.go
+++ b/plugins/logs/plugin_test.go
@@ -109,12 +109,14 @@ func TestPluginStartSameInput(t *testing.T) {
 
 	testMetrics := getWellKnownMetrics()
 
+	var input interface{} = map[string]interface{}{"method": "GET"}
+
 	for i := 0; i < 400; i++ {
 		fixture.plugin.Log(ctx, &server.Info{
 			Revision:   fmt.Sprint(i),
 			DecisionID: fmt.Sprint(i),
 			Query:      "data.tda.bar",
-			Input:      map[string]interface{}{"method": "GET"},
+			Input:      &input,
 			Results:    &result,
 			RemoteAddr: "test",
 			Timestamp:  ts,
@@ -183,7 +185,7 @@ func TestPluginStartChangingInputValues(t *testing.T) {
 		panic(err)
 	}
 
-	var input map[string]interface{}
+	var input interface{}
 
 	for i := 0; i < 400; i++ {
 		input = map[string]interface{}{"method": getValueForMethod(i), "path": getValueForPath(i), "user": getValueForUser(i)}
@@ -192,7 +194,7 @@ func TestPluginStartChangingInputValues(t *testing.T) {
 			Revision:   fmt.Sprint(i),
 			DecisionID: fmt.Sprint(i),
 			Query:      "data.foo.bar",
-			Input:      input,
+			Input:      &input,
 			Results:    &result,
 			RemoteAddr: "test",
 			Timestamp:  ts,
@@ -254,7 +256,7 @@ func TestPluginStartChangingInputKeysAndValues(t *testing.T) {
 		panic(err)
 	}
 
-	var input map[string]interface{}
+	var input interface{}
 
 	for i := 0; i < 250; i++ {
 		input = generateInputMap(i)
@@ -263,7 +265,7 @@ func TestPluginStartChangingInputKeysAndValues(t *testing.T) {
 			Revision:   fmt.Sprint(i),
 			DecisionID: fmt.Sprint(i),
 			Query:      "data.foo.bar",
-			Input:      input,
+			Input:      &input,
 			Results:    &result,
 			RemoteAddr: "test",
 			Timestamp:  ts,
@@ -309,12 +311,13 @@ func TestPluginRequeue(t *testing.T) {
 
 	fixture.server.ch = make(chan []EventV1, 1)
 
+	var input interface{} = map[string]interface{}{"method": "GET"}
 	var result1 interface{} = false
 
 	fixture.plugin.Log(ctx, &server.Info{
 		DecisionID: "abc",
 		Query:      "data.foo.bar",
-		Input:      map[string]interface{}{"method": "GET"},
+		Input:      &input,
 		Results:    &result1,
 		RemoteAddr: "test",
 		Timestamp:  time.Now().UTC(),

--- a/server/buffer.go
+++ b/server/buffer.go
@@ -76,6 +76,7 @@ type Info struct {
 	DecisionID string
 	RemoteAddr string
 	Query      string
+	Path       string
 	Timestamp  time.Time
 	Input      *interface{}
 	Results    *interface{}

--- a/server/buffer.go
+++ b/server/buffer.go
@@ -77,7 +77,7 @@ type Info struct {
 	RemoteAddr string
 	Query      string
 	Timestamp  time.Time
-	Input      interface{}
+	Input      *interface{}
 	Results    *interface{}
 	Error      error
 	Metrics    metrics.Metrics

--- a/server/buffer_test.go
+++ b/server/buffer_test.go
@@ -14,7 +14,7 @@ import (
 func TestBufferAutoErase(t *testing.T) {
 	buf := NewBoundedBuffer(30)
 	for i := 0; i < 100; i++ {
-		buf.Push(&Info{Query: fmt.Sprint(i)})
+		buf.Push(&Info{Path: fmt.Sprint(i)})
 	}
 
 	var i uint64 = 70
@@ -23,8 +23,8 @@ func TestBufferAutoErase(t *testing.T) {
 			t.Fatal("Ran off the end of the buffer")
 		}
 
-		if in.Query != fmt.Sprint(i) {
-			t.Fatalf("Expected query to be %d, got %s", i, in.Query)
+		if in.Path != fmt.Sprint(i) {
+			t.Fatalf("Expected query to be %d, got %s", i, in.Path)
 		}
 		i++
 	})
@@ -53,7 +53,7 @@ func testBufferRandomSize(t *testing.T, cap int) {
 		switch r := rand.Intn(threshold + 1); {
 		case r < threshold:
 			pushes++
-			buf.Push(&Info{Query: fmt.Sprint(cur)})
+			buf.Push(&Info{Path: fmt.Sprint(cur)})
 
 			cur++
 			if size == cap {
@@ -74,8 +74,8 @@ func testBufferRandomSize(t *testing.T, cap int) {
 					t.Fatal("Ran off the end of the buffer")
 				}
 
-				if i.Query != fmt.Sprint(j) {
-					t.Fatalf("Expected query to be %d, got %s", j, i.Query)
+				if i.Path != fmt.Sprint(j) {
+					t.Fatalf("Expected query to be %d, got %s", j, i.Path)
 				}
 				j++
 			})

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -2126,6 +2126,12 @@ func TestDecisionLogging(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Decision log event input should be nil because we didn't
+	// provide a body.
+	if decisions[0].Input != nil {
+		t.Fatalf("Expected nil input for decision but got: %v", decisions[0])
+	}
+
 	if err := f.v1("GET", "/data", "", 200, `{"result": {}}`); err != nil {
 		t.Fatal(err)
 	}
@@ -2144,8 +2150,12 @@ func TestDecisionLogging(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if len(decisions) != 5 {
-		t.Fatalf("Expected exactly 5 decisions but got: %d", len(decisions))
+	if err := f.v1("POST", "/query", `{"query": "data=x"}`, 200, `{"result": [{"x": {}}]}`); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(decisions) != 6 {
+		t.Fatalf("Expected exactly 6 decisions but got: %d", len(decisions))
 	}
 
 	// Verify decisions contain metrics.ServerHandler timer.

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/metrics"
 	"github.com/open-policy-agent/opa/plugins"
 	"github.com/open-policy-agent/opa/server/identifier"
 	"github.com/open-policy-agent/opa/server/types"
@@ -1192,6 +1193,7 @@ func TestDataMetrics(t *testing.T) {
 		"timer_rego_query_parse_ns",
 		"timer_rego_query_compile_ns",
 		"timer_rego_query_eval_ns",
+		"timer_server_handler_ns",
 	}
 
 	for _, key := range expected {
@@ -1216,6 +1218,7 @@ func TestDataMetrics(t *testing.T) {
 		"timer_rego_query_compile_ns",
 		"timer_rego_query_eval_ns",
 		"timer_rego_partial_eval_ns",
+		"timer_server_handler_ns",
 	}
 
 	for _, key := range expected {
@@ -2143,6 +2146,13 @@ func TestDecisonLogging(t *testing.T) {
 
 	if len(decisions) != 5 {
 		t.Fatalf("Expected exactly 5 decisions but got: %d", len(decisions))
+	}
+
+	// Verify decisions contain metrics.ServerHandler timer.
+	for i, d := range decisions {
+		if d.Metrics.Timer(metrics.ServerHandler).Value() == 0 {
+			t.Fatalf("Expected server handler timer to be started on decision %d but got %v", i, d)
+		}
 	}
 }
 

--- a/server/types/types.go
+++ b/server/types/types.go
@@ -143,6 +143,7 @@ type DiagnosticsResponseElementV1 struct {
 	DecisionID  string       `json:"decision_id,omitempty"`
 	RemoteAddr  string       `json:"remote_addr"`
 	Query       string       `json:"query"`
+	Path        string       `json:"path"`
 	Timestamp   string       `json:"timestamp"`
 	Input       interface{}  `json:"input,omitempty"`
 	Result      *interface{} `json:"result,omitempty"`


### PR DESCRIPTION
This PR contains a handful of small changes to the decision logging feature. At a high-level:

* Add metrics in events
* Add server_handler timer to metrics
* Add errors to events
* Fix input attribute modelling
* Fix path/query modelling
* Fix error events to include decision ID