### PR TITLE
server should log error cause when returning HTTP 500 response

### DIFF
--- a/runtime/logging.go
+++ b/runtime/logging.go
@@ -40,7 +40,7 @@ func NewLoggingHandler(inner http.Handler) http.Handler {
 func (h *LoggingHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	requestID := atomic.AddUint64(&h.requestID, uint64(1))
 
-	recorder := newRecorder(w, r, requestID, loggingEnabled(logrus.DebugLevel))
+	recorder := newRecorder(w, r, requestID, loggingEnabled(logrus.InfoLevel))
 	t0 := time.Now()
 
 	if loggingEnabled(logrus.InfoLevel) {
@@ -94,10 +94,9 @@ func (h *LoggingHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			"resp_duration": float64(dt.Nanoseconds()) / 1e6,
 		}
 
-		if loggingEnabled(logrus.DebugLevel) {
+		if loggingEnabled(logrus.DebugLevel) || statusCode == 500 {
 			fields["resp_body"] = recorder.buf.String()
 		}
-
 		logrus.WithFields(fields).Info("Sent response.")
 	}
 }

--- a/x.rego
+++ b/x.rego
@@ -1,0 +1,3 @@
+package example
+
+p { 1 / 0 }


### PR DESCRIPTION
Fixes #1144

Original logging check changed to info. This is needed so response body is recorded
This makes sense independent of this PR
Response body is printed escaped. This might seem bad but it is recommended due to double quotes

INFO[2019-01-15T15:56:05-08:00] Sent response.                                client_addr="[::1]:63690" req_id=1 req_method=GET req_path=/v1/data resp_body="{\n  \"code\": \"internal_error\",\n  \"message\": \"error(s) occurred while evaluating query\",\n  \"errors\": [\n    {\n      \"code\": \"eval_internal_error\",\n      \"message\": \"div: divide by zero\",\n      \"location\": {\n        \"file\": \"x.rego\",\n        \"row\": 3,\n        \"col\": 5\n      }\n    }\n  ]\n}" resp_bytes=284 resp_duration=2.374724 resp_status=500

Signed-off-by: repenno <rapenno@gmail.com>