### PR TITLE
Improve error message when using an invalid object key

### DIFF
--- a/ast/term.go
+++ b/ast/term.go
@@ -228,16 +228,16 @@ func ValueToInterface(v Value, resolver Resolver) (interface{}, error) {
 		return buf, nil
 	case Object:
 		buf := map[string]interface{}{}
-		err := v.Iter(func(k, v *Term) error {
+		err := v.Iter(func(k, value *Term) error {
 			ki, err := ValueToInterface(k.Value, resolver)
 			if err != nil {
 				return err
 			}
 			asStr, stringKey := ki.(string)
 			if !stringKey {
-				return fmt.Errorf("object value has non-string key (%T)", ki)
+				return fmt.Errorf("object value (%v) has non-string key of type (%T), value (%v)", v, ki, ki)
 			}
-			vi, err := ValueToInterface(v.Value, resolver)
+			vi, err := ValueToInterface(value.Value, resolver)
 			if err != nil {
 				return err
 			}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -59,6 +59,28 @@ func TestUnversionedGetHealth(t *testing.T) {
 	}
 }
 
+func TestInvalidKeyV1(t *testing.T) {
+	testPolicy := `package foo
+
+	g[app] = zone {
+    	app = ["foo"]
+    	zone = 456
+	}
+	`
+	f := newFixture(t)
+
+	if err := f.v1(http.MethodPut, "/policies/foo", testPolicy, 200, ""); err != nil {
+		t.Fatalf("Unexpected error while creating policy: %v", err)
+	}
+
+	if err := f.v1(http.MethodGet, "/data/foo", "", 500, `{
+    "code": "internal_error",
+    "message": "object value ({[\"foo\"]: 456}) has non-string key of type ([]interface {}), value ([foo])"
+}`); err != nil {
+		t.Fatalf("Unexpected error from GET: %v", err)
+	}
+}
+
 func TestDataV0(t *testing.T) {
 	testMod1 := `package test
 


### PR DESCRIPTION
Fixes #516

* Changed the error string to include the immediate outer object, key
type and value.
* Fix the shadowing of variable v by the function called by Iter so
object can be printed.

Signed-off-by: repenno <rapenno@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
