### PR TITLE
Fixed various typos on user-facing tutorials

### DIFF
--- a/docs/book/kubernetes-admission-control.md
+++ b/docs/book/kubernetes-admission-control.md
@@ -118,9 +118,9 @@ webhooks:
 EOF
 ```
 
-The generated configuration file inclues a base64 encoded representation of the CA certificate so that TLS connections can be established between the Kubernetes API server and OPA.
+The generated configuration file includes a base64 encoded representation of the CA certificate so that TLS connections can be established between the Kubernetes API server and OPA.
 
-Finally, register OPA as and admission controller:
+Finally, register OPA as an admission controller:
 
 ```bash
 kubectl apply -f webhook-configuration.yaml
@@ -221,13 +221,13 @@ kubectl create -f ingress-ok.yaml -n production
 kubectl create -f ingress-bad.yaml -n qa
 ```
 
-The second Ingress is rejected because it's hostname does not match the whitelist in the `qa` namespace.
+The second Ingress is rejected because its hostname does not match the whitelist in the `qa` namespace.
 
 ### 6. Modify the policy and exercise the changes
 
 OPA allows you to modify policies on-the-fly without recompiling any of the services that offload policy decisions to it.
 
-To enforce the second half of the policy from the start of this tutorial you can load another policy into OPA that rejects Ingress objects in different namespaces from sharing the same hostname.
+To enforce the second half of the policy from the start of this tutorial you can load another policy into OPA that prevents Ingress objects in different namespaces from sharing the same hostname.
 
 [ingress-conflicts.rego](https://github.com/open-policy-agent/opa/blob/master/docs/book/tutorials/kubernetes-admission-control-validation/ingress-conflicts.rego):
 
@@ -238,7 +238,7 @@ kubectl create configmap ingress-conflicts --from-file=ingress-conflicts.rego
 ```
 
 The OPA sidecar annotates ConfigMaps containing policies to indicate if they
-were installed successfully. Verify the ConfigMap was installed successfully.
+were installed successfully. Verify that the ConfigMap was installed successfully:
 
 ```
 kubectl get configmap ingress-conflicts -o yaml

--- a/docs/book/tutorials/kubernetes-admission-control-validation/admission-controller.yaml
+++ b/docs/book/tutorials/kubernetes-admission-control-validation/admission-controller.yaml
@@ -1,4 +1,4 @@
-# Grant OPA/kube-mgmt read-only access to resources. This let's kube-mgmt
+# Grant OPA/kube-mgmt read-only access to resources. This lets kube-mgmt
 # replicate resources into OPA so they can be used in policies.
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
This PR fixes a few typos found while taking this tutorial: https://www.openpolicyagent.org/docs/kubernetes-admission-control.html

While those typos are trivial, the tutorial is user-facing and therefore I believe it would benefit from being typos-free.