### PR TITLE
config: add version to labels

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -9,6 +9,8 @@ import (
 	"encoding/json"
 	"strings"
 
+	"github.com/open-policy-agent/opa/version"
+
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/util"
 )
@@ -27,7 +29,7 @@ type Config struct {
 }
 
 // ParseConfig returns a valid Config object with defaults injected. The id
-// parameter will be set in the labels map.
+// and version parameters will be set in the labels map.
 func ParseConfig(raw []byte, id string) (*Config, error) {
 	var result Config
 	if err := util.Unmarshal(raw, &result); err != nil {
@@ -81,6 +83,7 @@ func (c *Config) validateAndInjectDefaults(id string) error {
 	}
 
 	c.Labels["id"] = id
+	c.Labels["version"] = version.Version
 
 	return nil
 }

--- a/docs/book/decision_logs.md
+++ b/docs/book/decision_logs.md
@@ -32,7 +32,8 @@ represents a policy decision returned by OPA.
   {
     "labels": {
       "app": "my-example-app",
-      "id": "1780d507-aea2-45cc-ae50-fa153c8e4a5a"
+      "id": "1780d507-aea2-45cc-ae50-fa153c8e4a5a",
+      "version": "v0.10.3"
     },
     "decision_id": "4ca636c1-55e4-417a-b1d8-4aceb67960d1",
     "revision": "W3sibCI6InN5cy9jYXRhbG9nIiwicyI6NDA3MX1d",
@@ -61,5 +62,4 @@ Decision log updates contain the following fields:
 | `[_].result` | `any` | Policy decision returned to the client, e.g., `true` or `false`. |
 | `[_].requested_by` | `string` | Identifier for client that executed policy query, e.g., the client address. |
 | `[_].timestamp` | `string` | RFC3999 timestamp of policy decision. |
-| `[_].version` | `string` | Version of the OPA instance that generated the event. |
 | `[_].metrics` | `object` | Key-value pairs of [performance metrics](rest-api.md#performance-metrics). |

--- a/docs/book/status.md
+++ b/docs/book/status.md
@@ -10,7 +10,8 @@ will include error information describing the failure.
 
 The status updates will include a set of labels that uniquely identify the
 OPA instance. OPA automatically includes an `id` value in the label set that
-provides a globally unique identifier or the running OPA instance.
+provides a globally unique identifier or the running OPA instance and a
+`version` value that provides the version of OPA.
 
 See the [Configuration Reference](configuration.md) for configuration details.
 
@@ -32,7 +33,8 @@ on the agent, updates will be sent to `/status`.
 {
     "labels": {
         "app": "my-example-app",
-        "id": "1780d507-aea2-45cc-ae50-fa153c8e4a5a"
+        "id": "1780d507-aea2-45cc-ae50-fa153c8e4a5a",
+        "version": "v0.10.3"
     },
     "bundle": {
         "name": "http/example/authz",

--- a/plugins/discovery/discovery_test.go
+++ b/plugins/discovery/discovery_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"reflect"
 	"testing"
 	"time"
@@ -22,7 +23,15 @@ import (
 	"github.com/open-policy-agent/opa/plugins/status"
 	"github.com/open-policy-agent/opa/storage/inmem"
 	"github.com/open-policy-agent/opa/util"
+	"github.com/open-policy-agent/opa/version"
 )
+
+func TestMain(m *testing.M) {
+	if version.Version == "" {
+		version.Version = "unit-test"
+	}
+	os.Exit(m.Run())
+}
 
 func TestEvaluateBundle(t *testing.T) {
 
@@ -222,7 +231,7 @@ func TestReconfigure(t *testing.T) {
 	disco.oneShot(ctx, download.Update{Bundle: initialBundle})
 
 	// Verify labels are unchanged
-	exp := map[string]string{"x": "y", "id": "test-id"}
+	exp := map[string]string{"x": "y", "id": "test-id", "version": version.Version}
 	if !reflect.DeepEqual(manager.Labels(), exp) {
 		t.Errorf("Expected labels to be unchanged (%v) but got %v", exp, manager.Labels())
 	}

--- a/plugins/logs/plugin.go
+++ b/plugins/logs/plugin.go
@@ -19,7 +19,6 @@ import (
 	"github.com/open-policy-agent/opa/plugins/rest"
 	"github.com/open-policy-agent/opa/server"
 	"github.com/open-policy-agent/opa/util"
-	"github.com/open-policy-agent/opa/version"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -42,7 +41,6 @@ type EventV1 struct {
 	Error       error                  `json:"error,omitempty"`
 	RequestedBy string                 `json:"requested_by"`
 	Timestamp   time.Time              `json:"timestamp"`
-	Version     string                 `json:"version"`
 	Metrics     map[string]interface{} `json:"metrics,omitempty"`
 }
 
@@ -229,7 +227,6 @@ func (p *Plugin) Log(ctx context.Context, decision *server.Info) {
 		Result:      decision.Results,
 		RequestedBy: decision.RemoteAddr,
 		Timestamp:   decision.Timestamp,
-		Version:     version.Version,
 	}
 
 	if decision.Metrics != nil {

--- a/plugins/logs/plugin_test.go
+++ b/plugins/logs/plugin_test.go
@@ -193,8 +193,9 @@ func TestPluginStartSameInput(t *testing.T) {
 
 	exp := EventV1{
 		Labels: map[string]string{
-			"id":  "test-instance-id",
-			"app": "example-app",
+			"id":      "test-instance-id",
+			"app":     "example-app",
+			"version": getVersion(),
 		},
 		Revision:    "399",
 		DecisionID:  "399",
@@ -203,7 +204,6 @@ func TestPluginStartSameInput(t *testing.T) {
 		Result:      &result,
 		RequestedBy: "test",
 		Timestamp:   ts,
-		Version:     getVersion(),
 		Metrics:     msAsFloat64,
 	}
 
@@ -265,8 +265,9 @@ func TestPluginStartChangingInputValues(t *testing.T) {
 
 	exp := EventV1{
 		Labels: map[string]string{
-			"id":  "test-instance-id",
-			"app": "example-app",
+			"id":      "test-instance-id",
+			"app":     "example-app",
+			"version": getVersion(),
 		},
 		Revision:    "399",
 		DecisionID:  "399",
@@ -275,7 +276,6 @@ func TestPluginStartChangingInputValues(t *testing.T) {
 		Result:      &result,
 		RequestedBy: "test",
 		Timestamp:   ts,
-		Version:     getVersion(),
 	}
 
 	if !reflect.DeepEqual(chunk4[expLen4-1], exp) {
@@ -326,8 +326,9 @@ func TestPluginStartChangingInputKeysAndValues(t *testing.T) {
 
 	exp := EventV1{
 		Labels: map[string]string{
-			"id":  "test-instance-id",
-			"app": "example-app",
+			"id":      "test-instance-id",
+			"app":     "example-app",
+			"version": getVersion(),
 		},
 		Revision:    "249",
 		DecisionID:  "249",
@@ -336,7 +337,6 @@ func TestPluginStartChangingInputKeysAndValues(t *testing.T) {
 		Result:      &result,
 		RequestedBy: "test",
 		Timestamp:   ts,
-		Version:     getVersion(),
 	}
 
 	if !reflect.DeepEqual(chunk2[len(chunk2)-1], exp) {

--- a/plugins/status/plugin_test.go
+++ b/plugins/status/plugin_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"reflect"
 	"testing"
 	"time"
@@ -17,7 +18,15 @@ import (
 	"github.com/open-policy-agent/opa/plugins/bundle"
 	"github.com/open-policy-agent/opa/storage/inmem"
 	"github.com/open-policy-agent/opa/util"
+	"github.com/open-policy-agent/opa/version"
 )
+
+func TestMain(m *testing.M) {
+	if version.Version == "" {
+		version.Version = "unit-test"
+	}
+	os.Exit(m.Run())
+}
 
 func TestPluginStart(t *testing.T) {
 
@@ -37,8 +46,9 @@ func TestPluginStart(t *testing.T) {
 
 	exp := UpdateRequestV1{
 		Labels: map[string]string{
-			"id":  "test-instance-id",
-			"app": "example-app",
+			"id":      "test-instance-id",
+			"app":     "example-app",
+			"version": version.Version,
 		},
 		Bundle: status,
 	}
@@ -66,8 +76,9 @@ func TestPluginStartDiscovery(t *testing.T) {
 
 	exp := UpdateRequestV1{
 		Labels: map[string]string{
-			"id":  "test-instance-id",
-			"app": "example-app",
+			"id":      "test-instance-id",
+			"app":     "example-app",
+			"version": version.Version,
 		},
 		Discovery: status,
 	}


### PR DESCRIPTION
Adds OPA version to the config labels, so that the version
appears in status updates. Previously, decision logs had a
top-level version field. This removes that field because
version will be contained in the labels instead.

This introduces a non-backwards compatible change to the 
decision log EventV1 struct

Signed-off-by: Andy Curtis <arcurtis@gmail.com>