### PR TITLE
Add path conflict checks

### DIFF
--- a/ast/compile_test.go
+++ b/ast/compile_test.go
@@ -619,11 +619,28 @@ f { true }
 
 g(1) { true }
 g(1,2) { true }`,
+		"mod5.rego": `package badrules.dataoverlap
+
+p { true }`,
+		"mod6.rego": `package badrules.existserr
+
+p { true }`,
+	})
+
+	c.WithPathConflictsCheck(func(path []string) (bool, error) {
+		if reflect.DeepEqual(path, []string{"badrules", "dataoverlap", "p"}) {
+			return true, nil
+		} else if reflect.DeepEqual(path, []string{"badrules", "existserr", "p"}) {
+			return false, fmt.Errorf("unexpected error")
+		}
+		return false, nil
 	})
 
 	compileStages(c, c.checkRuleConflicts)
 
 	expected := []string{
+		"rego_compile_error: conflict check for data path badrules/existserr/p: unexpected error",
+		"rego_compile_error: conflicting rule for data path badrules/dataoverlap/p found",
 		"rego_type_error: conflicting rules named f found",
 		"rego_type_error: conflicting rules named g found",
 		"rego_type_error: conflicting rules named p found",

--- a/ast/conflicts.go
+++ b/ast/conflicts.go
@@ -1,0 +1,48 @@
+// Copyright 2019 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package ast
+
+import (
+	"strings"
+)
+
+// CheckPathConflicts returns a set of errors indicating paths that
+// are in conflict with the result of the provided callable.
+func CheckPathConflicts(c *Compiler, exists func([]string) (bool, error)) Errors {
+	var errs Errors
+
+	root := c.RuleTree.Child(DefaultRootDocument.Value)
+	if root == nil {
+		return nil
+	}
+
+	for _, node := range root.Children {
+		errs = append(errs, checkDocumentConflicts(node, exists, nil)...)
+	}
+
+	return errs
+}
+
+func checkDocumentConflicts(node *TreeNode, exists func([]string) (bool, error), path []string) Errors {
+
+	path = append(path, string(node.Key.(String)))
+
+	if len(node.Values) > 0 {
+		s := strings.Join(path, "/")
+		if ok, err := exists(path); err != nil {
+			return Errors{NewError(CompileErr, node.Values[0].(*Rule).Loc(), "conflict check for data path %v: %v", s, err.Error())}
+		} else if ok {
+			return Errors{NewError(CompileErr, node.Values[0].(*Rule).Loc(), "conflicting rule for data path %v found", s)}
+		}
+	}
+
+	var errs Errors
+
+	for _, child := range node.Children {
+		errs = append(errs, checkDocumentConflicts(child, exists, path)...)
+	}
+
+	return errs
+}

--- a/docs/book/how-does-opa-work.md
+++ b/docs/book/how-does-opa-work.md
@@ -184,6 +184,16 @@ GET https://example.com/v1/data/servers HTTP/1.1
 GET https://example.com/v1/data/opa/examples/violations HTTP/1.1
 ```
 
+> Since the `data` document includes both base and virtual documents,
+> it is possible to query for both at the same time. The easiest way
+> to illustrate this is to query for _all_ of `data` at once. Note,
+> OPA does NOT allow base and virtual documents to overlap. For
+> example, if you try to load a rule that defines a virtual document
+> at path a/b/c (which is already defined by a base document), OPA
+> will return an error. Similarly, if you try to load a base document
+> into a path that is already defined by a virtual document, OPA will
+> also return an error.
+
 ### The `input` Document
 
 In some cases, policies require input values. In addition to the built-in

--- a/plugins/bundle/plugin.go
+++ b/plugins/bundle/plugin.go
@@ -212,7 +212,9 @@ func (p *Plugin) activate(ctx context.Context, b *bundle.Bundle) error {
 			modules[file.Path] = file.Parsed
 		}
 
-		compiler := ast.NewCompiler()
+		compiler := ast.NewCompiler().
+			WithPathConflictsCheck(storage.NonEmpty(ctx, p.manager.Store, txn))
+
 		if compiler.Compile(modules); compiler.Failed() {
 			return compiler.Errors
 		}

--- a/rego/rego_test.go
+++ b/rego/rego_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/metrics"
+	"github.com/open-policy-agent/opa/storage/inmem"
 	"github.com/open-policy-agent/opa/topdown"
 	"github.com/open-policy-agent/opa/types"
 	"github.com/open-policy-agent/opa/util"
@@ -253,5 +254,22 @@ func TestRegoMetrics(t *testing.T) {
 		if _, ok := all[name]; !ok {
 			t.Errorf("expected to find %v but did not", name)
 		}
+	}
+}
+
+func TestRegoCatchPathConflicts(t *testing.T) {
+	r := New(
+		Query("data"),
+		Module("test.rego", "package x\np=1"),
+		Store(inmem.NewFromObject(map[string]interface{}{
+			"x": map[string]interface{}{"p": 1},
+		})),
+	)
+
+	ctx := context.Background()
+	_, err := r.Eval(ctx)
+
+	if err == nil {
+		t.Fatal("expected error")
 	}
 }

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -413,7 +413,7 @@ func compileAndStoreInputs(ctx context.Context, store storage.Store, txn storage
 		policies[id] = parsed.Parsed
 	}
 
-	c := ast.NewCompiler().SetErrorLimit(errorLimit)
+	c := ast.NewCompiler().SetErrorLimit(errorLimit).WithPathConflictsCheck(storage.NonEmpty(ctx, store, txn))
 
 	if c.Compile(policies); c.Failed() {
 		return c.Errors

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -1,0 +1,68 @@
+package storage_test
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/open-policy-agent/opa/storage"
+	"github.com/open-policy-agent/opa/storage/inmem"
+)
+
+func TestNonEmpty(t *testing.T) {
+
+	cases := []struct {
+		content string
+		path    string
+		exp     bool
+	}{
+		{
+			content: `{}`,
+			path:    "a/b/c",
+			exp:     false,
+		},
+		{
+			content: `{"a": {}}`,
+			path:    "a/b/c",
+			exp:     false,
+		},
+		{
+			content: `{"a": {"b": {}}}`,
+			path:    "a/b/c",
+			exp:     false,
+		},
+		{
+			content: `{"a": {"b": {"c": {}}}}`,
+			path:    "a/b/c",
+			exp:     true,
+		},
+		{
+			content: `{"a": {"b": "x"}}`,
+			path:    "a/b/c",
+			exp:     true,
+		},
+		{
+			content: `{"a": "x"}`,
+			path:    "a/b/c",
+			exp:     true,
+		},
+	}
+
+	ctx := context.Background()
+
+	for _, tc := range cases {
+		store := inmem.NewFromReader(bytes.NewBufferString(tc.content))
+		storage.Txn(ctx, store, storage.TransactionParams{}, func(txn storage.Transaction) error {
+			nonEmpty, err := storage.NonEmpty(ctx, store, txn)(strings.Split(tc.path, "/"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if nonEmpty != tc.exp {
+				t.Errorf("Expected %v for %v on %v but got", tc.exp, tc.path, tc.content)
+			}
+			return nil
+		})
+	}
+
+}


### PR DESCRIPTION
Previously there were no checks in place to ensure that base and
virtual documents do not overlap. As a result, if users loaded raw
JSON and rules into OPA that overlapped, the evaluation results were
not well defined. With these changes, we can detect the overlap and
reject updates (to policies or data) that would cause inconsistent
results.

Fixes #1207

Signed-off-by: Torin Sandall <torinsandall@gmail.com>