### PR TITLE
Add support for scoped bundles

### DIFF
--- a/ast/term_test.go
+++ b/ast/term_test.go
@@ -419,6 +419,49 @@ func TestRefConcat(t *testing.T) {
 	}
 }
 
+func TestRefPtr(t *testing.T) {
+	cases := []string{
+		"",
+		"a",
+		"a/b",
+		"/a/b",
+		"/a/b/",
+		"a%2Fb",
+	}
+
+	for _, tc := range cases {
+		ref, err := PtrRef(DefaultRootDocument.Copy(), tc)
+		if err != nil {
+			t.Fatal("Unexpected error:", err)
+		}
+
+		ptr, err := ref.Ptr()
+		if err != nil {
+			t.Fatal("Unexpected error:", err)
+		}
+
+		roundtrip, err := PtrRef(DefaultRootDocument.Copy(), ptr)
+		if err != nil {
+			t.Fatal("Unexpected error:", err)
+		}
+
+		if !ref.Equal(roundtrip) {
+			t.Fatalf("Expected roundtrip of %q to be equal but got %v and %v", tc, ref, roundtrip)
+		}
+	}
+
+	if _, err := PtrRef(DefaultRootDocument.Copy(), "2%"); err == nil {
+		t.Fatalf("Expected error from %q", "2%")
+	}
+
+	ref := Ref{VarTerm("x"), IntNumberTerm(1)}
+
+	if _, err := ref.Ptr(); err == nil {
+		t.Fatal("Expected error from x[1]")
+	}
+
+}
+
 func TestSetEqual(t *testing.T) {
 	tests := []struct {
 		a        string

--- a/docs/book/SUMMARY.md
+++ b/docs/book/SUMMARY.md
@@ -113,6 +113,7 @@
 * [Bundles](bundles.md)
   * [Service API](bundles.md#bundle-service-api)
   * [File Format](bundles.md#bundle-file-format)
+  * [Multiple Sources](bundles.md#multiple-sources-of-policy-and-data)
 * [Status](status.md)
   * [Service API](status.md#status-service-api)
 * [Decision Logs](decision_logs.md)

--- a/docs/book/bundles.md
+++ b/docs/book/bundles.md
@@ -12,9 +12,10 @@ ensure that OPA has an up-to-date copy of policies and data required for
 enforcement at all times.
 
 OPA can only be configured to download one bundle at a time. You
-cannot configure OPA to download multiple bundles. If you need to
-provide OPA with data or policies from multiple sources, you should
-merge the data and policies within your bundle service.
+cannot configure OPA to download multiple bundles. By default, the OPA
+REST APIs will prevent you from modifying policy and data loaded via
+bundles. If you need to load policy and data from multiple sources,
+see the section below.
 
 See the [Configuration Reference](configuration.md) for configuration details.
 
@@ -104,9 +105,63 @@ metadata. The file should contain a JSON serialized object.
   bundle, the service should include a top-level `revision` field containing a
   `string` value that identifies the bundle revision.
 
+* If you expect to load additional data into OPA from outside the
+  bundle (e.g., via OPA's HTTP API) you should include a top-level
+  `roots` field containing of path prefixes that declare the scope of
+  the bundle. See the section below on managing data from multiple
+  sources. If the `roots` field is not included in the manifest it
+  defaults to `[""]` which means that ALL data and policy must come
+  from the bundle.
+
 OPA will only load data files named `data.json`, i.e., you MUST name files
 that contain data (which you want loaded into OPA) `data.json` -- otherwise
 they will be ignored.
+
+## Multiple Sources of Policy and Data
+
+By default, when OPA is configured to download policy and data from a
+bundle service, the entire content of OPA's policy and data cache is
+defined by the bundle. However, if you need to load OPA with policy
+and data from multiple sources, you can implement your bundle service
+to generate bundles that are scoped to a subset of OPA's policy and
+data cache.
+
+> We recommend that whenever possible, you implement policy and data
+> aggregation centrally, however, in some cases that's not possible
+> (e.g., due to latency requirements.)
+
+To scope bundles to a subset of OPA's policy and data cache, include
+a top-level `roots` key in the bundle that defines the roots of the
+`data` namespace that are owned by the bundle.
+
+For example, the following manifest would declare two roots
+(`acmecorp/policy` and `acmecorp/oncall`):
+
+```
+{
+    "roots": ["acmecorp/policy", "acmecorp/oncall"]
+}
+```
+
+If OPA was loaded with a bundle containing this manifest it would only
+erase and overwrite policy and data under these roots. Policy and data
+loaded under other roots is left intact.
+
+When OPA loads scoped bundles, it validates that:
+
+* The roots are not overlapping (e.g., `a/b/c` and `a/b` are
+  overlapped and will result in an error.)
+
+* The policies in the bundle are contained under the roots. This is
+  determined by inspecting the `package` statement in each of the
+  policy files. For example, given the manifest above, it would be an
+  error to include a policy file containing `package acmecorp.other`
+  because `acmecorp.other` is not contained in either of the roots.
+
+* The data in the bundle is contained under the roots.
+
+If bundle validation fails, OPA will report the validation error via
+the Status API.
 
 ## Debugging Your Bundles
 

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -1,0 +1,82 @@
+// Copyright 2019 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+// Package manifest implements helper functions for the stored manifest.
+package manifest
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/open-policy-agent/opa/bundle"
+	"github.com/open-policy-agent/opa/storage"
+	"github.com/open-policy-agent/opa/util"
+)
+
+var bundlePath = storage.MustParsePath("/system/bundle")
+var manifestPath = storage.MustParsePath("/system/bundle/manifest")
+var revisionPath = storage.MustParsePath("/system/bundle/manifest/revision")
+var rootsPath = storage.MustParsePath("/system/bundle/manifest/roots")
+
+// Write the manifest into the storage. This function is called when
+// the bundle is activated.
+func Write(ctx context.Context, store storage.Store, txn storage.Transaction, m bundle.Manifest) error {
+
+	var value interface{} = m
+
+	if err := util.RoundTrip(&value); err != nil {
+		return err
+	}
+
+	if err := storage.MakeDir(ctx, store, txn, bundlePath); err != nil {
+		return err
+	}
+
+	return store.Write(ctx, txn, storage.AddOp, manifestPath, value)
+}
+
+// ReadBundleRoots returns the roots specified in the currently
+// activated bundle. If there is no activated bundle, this function
+// will return storage NotFound error.
+func ReadBundleRoots(ctx context.Context, store storage.Store, txn storage.Transaction) ([]string, error) {
+
+	value, err := store.Read(ctx, txn, rootsPath)
+	if err != nil {
+		return nil, err
+	}
+
+	sl, ok := value.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("corrupt manifest roots")
+	}
+
+	roots := make([]string, len(sl))
+
+	for i := range sl {
+		roots[i], ok = sl[i].(string)
+		if !ok {
+			return nil, fmt.Errorf("corrupt manifest root")
+		}
+	}
+
+	return roots, nil
+}
+
+// ReadBundleRevision returns the revision in the currently activated
+// bundle. If there is no activated bundle, ths function will return
+// storage NotFound error.
+func ReadBundleRevision(ctx context.Context, store storage.Store, txn storage.Transaction) (string, error) {
+
+	value, err := store.Read(ctx, txn, revisionPath)
+	if err != nil {
+		return "", err
+	}
+
+	str, ok := value.(string)
+	if !ok {
+		return "", fmt.Errorf("corrupt manifest revision")
+	}
+
+	return str, nil
+}

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -152,21 +152,6 @@ func TestLoadDirRecursive(t *testing.T) {
 	})
 }
 
-var testBundle = bundle.Bundle{
-	Modules: []bundle.ModuleFile{
-		{
-			Path: "x.rego",
-			Raw: []byte(`
-				package baz
-
-				p = 1`),
-		},
-	},
-	Data: map[string]interface{}{
-		"foo": "bar",
-	},
-}
-
 func TestLoadBundle(t *testing.T) {
 
 	test.WithTempFS(nil, func(rootDir string) {
@@ -174,6 +159,25 @@ func TestLoadBundle(t *testing.T) {
 		f, err := os.Create(filepath.Join(rootDir, "bundle.tar.gz"))
 		if err != nil {
 			t.Fatal(err)
+		}
+
+		var testBundle = bundle.Bundle{
+			Modules: []bundle.ModuleFile{
+				{
+					Path: "x.rego",
+					Raw: []byte(`
+				package baz
+
+				p = 1`),
+				},
+			},
+			Data: map[string]interface{}{
+				"foo": "bar",
+			},
+			Manifest: bundle.Manifest{
+				Revision: "",
+				Roots:    &[]string{""},
+			},
 		}
 
 		if err := bundle.Write(f, testBundle); err != nil {
@@ -187,7 +191,7 @@ func TestLoadBundle(t *testing.T) {
 		}
 
 		actualData := testBundle.Data
-		actualData["system"] = map[string]interface{}{"bundle": map[string]interface{}{"manifest": map[string]interface{}{"revision": ""}}}
+		actualData["system"] = map[string]interface{}{"bundle": map[string]interface{}{"manifest": map[string]interface{}{"revision": "", "roots": []interface{}{""}}}}
 
 		if !reflect.DeepEqual(actualData, loaded.Documents) {
 			t.Fatalf("Expected %v but got: %v", actualData, loaded.Documents)
@@ -213,6 +217,25 @@ func TestLoadBundleSubDir(t *testing.T) {
 			t.Fatal(err)
 		}
 
+		var testBundle = bundle.Bundle{
+			Modules: []bundle.ModuleFile{
+				{
+					Path: "x.rego",
+					Raw: []byte(`
+				package baz
+
+				p = 1`),
+				},
+			},
+			Data: map[string]interface{}{
+				"foo": "bar",
+			},
+			Manifest: bundle.Manifest{
+				Revision: "",
+				Roots:    &[]string{""},
+			},
+		}
+
 		if err := bundle.Write(f, testBundle); err != nil {
 			t.Fatal(err)
 		}
@@ -222,6 +245,9 @@ func TestLoadBundleSubDir(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+
+		actualData := testBundle.Data
+		actualData["system"] = map[string]interface{}{"bundle": map[string]interface{}{"manifest": map[string]interface{}{"revision": "", "roots": []interface{}{""}}}}
 
 		if !reflect.DeepEqual(map[string]interface{}{"b": testBundle.Data}, loaded.Documents) {
 			t.Fatalf("Expected %v but got: %v", testBundle.Data, loaded.Documents)

--- a/plugins/bundle/plugin_test.go
+++ b/plugins/bundle/plugin_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"sort"
 	"testing"
 
 	"github.com/open-policy-agent/opa/ast"
@@ -40,6 +41,8 @@ func TestPluginOneShot(t *testing.T) {
 		},
 	}
 
+	b.Manifest.Init()
+
 	plugin.oneShot(ctx, download.Update{Bundle: &b})
 
 	txn := storage.NewTransactionOrDie(ctx, manager.Store)
@@ -61,7 +64,7 @@ func TestPluginOneShot(t *testing.T) {
 	}
 
 	data, err := manager.Store.Read(ctx, txn, storage.Path{})
-	expData := util.MustUnmarshalJSON([]byte(`{"foo": {"bar": 1, "baz": "qux"}, "system": {"bundle": {"manifest": {"revision": "quickbrownfaux"}}}}`))
+	expData := util.MustUnmarshalJSON([]byte(`{"foo": {"bar": 1, "baz": "qux"}, "system": {"bundle": {"manifest": {"revision": "quickbrownfaux", "roots": [""]}}}}`))
 	if err != nil {
 		t.Fatal(err)
 	} else if !reflect.DeepEqual(data, expData) {
@@ -75,17 +78,20 @@ func TestPluginOneShotCompileError(t *testing.T) {
 	ctx := context.Background()
 	manager := getTestManager()
 	plugin := Plugin{manager: manager, status: &Status{}}
+	raw1 := "package foo\n\np[x] { x = 1 }"
 
 	b1 := &bundle.Bundle{
 		Data: map[string]interface{}{"a": "b"},
 		Modules: []bundle.ModuleFile{
 			{
 				Path:   "/example.rego",
-				Parsed: ast.MustParseModule("package foo\n\np[x] { x = 1 }"),
+				Raw:    []byte(raw1),
+				Parsed: ast.MustParseModule(raw1),
 			},
 		},
 	}
 
+	b1.Manifest.Init()
 	plugin.oneShot(ctx, download.Update{Bundle: b1})
 
 	b2 := &bundle.Bundle{
@@ -98,8 +104,8 @@ func TestPluginOneShotCompileError(t *testing.T) {
 		},
 	}
 
+	b2.Manifest.Init()
 	plugin.oneShot(ctx, download.Update{Bundle: b2})
-
 	txn := storage.NewTransactionOrDie(ctx, manager.Store)
 
 	_, err := manager.Store.GetPolicy(ctx, txn, "/example.rego")
@@ -124,6 +130,7 @@ func TestPluginOneShotCompileError(t *testing.T) {
 		},
 	}
 
+	b3.Manifest.Init()
 	plugin.oneShot(ctx, download.Update{Bundle: b3})
 
 	txn = storage.NewTransactionOrDie(ctx, manager.Store)
@@ -163,6 +170,7 @@ func TestPluginOneShotActivatationRemovesOld(t *testing.T) {
 		},
 	}
 
+	b1.Manifest.Init()
 	plugin.oneShot(ctx, download.Update{Bundle: &b1})
 
 	module2 := `package example
@@ -182,6 +190,7 @@ func TestPluginOneShotActivatationRemovesOld(t *testing.T) {
 		},
 	}
 
+	b2.Manifest.Init()
 	plugin.oneShot(ctx, download.Update{Bundle: &b2})
 
 	err := storage.Txn(ctx, manager.Store, storage.TransactionParams{}, func(txn storage.Transaction) error {
@@ -233,6 +242,8 @@ func TestPluginListener(t *testing.T) {
 			},
 		},
 	}
+
+	b.Manifest.Init()
 
 	// Test that initial bundle is ok. Defer to separate goroutine so we can
 	// check result with channel.
@@ -303,6 +314,8 @@ func TestPluginListenerErrorClearedOn304(t *testing.T) {
 		Data: map[string]interface{}{"foo": "bar"},
 	}
 
+	b.Manifest.Init()
+
 	// Test that initial bundle is ok.
 	go plugin.oneShot(ctx, download.Update{Bundle: &b})
 	s1 := <-ch
@@ -326,6 +339,150 @@ func TestPluginListenerErrorClearedOn304(t *testing.T) {
 	if s3.ActiveRevision != "quickbrownfaux" || s3.Code != "" {
 		t.Fatal("Unexpected status update, got:", s3)
 	}
+}
+
+func TestPluginActivateScopedBundle(t *testing.T) {
+
+	ctx := context.Background()
+	manager := getTestManager()
+	plugin := Plugin{manager: manager, status: &Status{}}
+
+	// Transact test data and policies that represent data coming from
+	// _outside_ the bundle. The test will verify that data _outside_
+	// the bundle is both not erased and is overwritten appropriately.
+	//
+	// The test data claims a/{a1-6} where even paths are policy and
+	// odd paths are raw JSON.
+	if err := storage.Txn(ctx, manager.Store, storage.WriteParams, func(txn storage.Transaction) error {
+
+		externalData := map[string]interface{}{"a": map[string]interface{}{"a1": "x1", "a3": "x2", "a5": "x3"}}
+
+		if err := manager.Store.Write(ctx, txn, storage.AddOp, storage.Path{}, externalData); err != nil {
+			return err
+		}
+		if err := manager.Store.UpsertPolicy(ctx, txn, "some/id1", []byte(`package a.a2`)); err != nil {
+			return err
+		}
+		if err := manager.Store.UpsertPolicy(ctx, txn, "some/id2", []byte(`package a.a4`)); err != nil {
+			return err
+		}
+		if err := manager.Store.UpsertPolicy(ctx, txn, "some/id3", []byte(`package a.a6`)); err != nil {
+			return err
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Activate a bundle that is scoped to a/a1 and a/a2. This will
+	// erase and overwrite the external data at these paths but leave
+	// a3-6 untouched.
+	module := "package a.a2\n\nbar=1"
+
+	b := bundle.Bundle{
+		Manifest: bundle.Manifest{Revision: "quickbrownfaux", Roots: &[]string{"a/a1", "a/a2"}},
+		Data: map[string]interface{}{
+			"a": map[string]interface{}{
+				"a1": "foo",
+			},
+		},
+		Modules: []bundle.ModuleFile{
+			bundle.ModuleFile{
+				Path:   "bundle/id1",
+				Parsed: ast.MustParseModule(module),
+				Raw:    []byte(module),
+			},
+		},
+	}
+
+	b.Manifest.Init()
+
+	plugin.oneShot(ctx, download.Update{Bundle: &b})
+
+	// Ensure a/a3-6 are intact. a1-2 are overwritten by bundle.
+	if err := storage.Txn(ctx, manager.Store, storage.TransactionParams{}, func(txn storage.Transaction) error {
+		value, err := manager.Store.Read(ctx, txn, storage.Path{"a"})
+		if err != nil {
+			return err
+		}
+
+		expData := util.MustUnmarshalJSON([]byte(`{"a1": "foo", "a3": "x2", "a5": "x3"}`))
+
+		if !reflect.DeepEqual(value, expData) {
+			return fmt.Errorf("Expected %v but got %v", expData, value)
+		}
+
+		ids, err := manager.Store.ListPolicies(ctx, txn)
+		if err != nil {
+			return err
+		}
+
+		expIds := []string{"bundle/id1", "some/id2", "some/id3"}
+		sort.Strings(ids)
+
+		if !reflect.DeepEqual(ids, expIds) {
+			return fmt.Errorf("Expected ids %v but got %v", expIds, ids)
+		}
+
+		return nil
+
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Activate a bundle that is scoped to a/a3 ad a/a6.
+	module = "package a.a4\n\nbar=1"
+
+	b = bundle.Bundle{
+		Manifest: bundle.Manifest{Revision: "quickbrownfaux", Roots: &[]string{"a/a3", "a/a4"}},
+		Data: map[string]interface{}{
+			"a": map[string]interface{}{
+				"a3": "foo",
+			},
+		},
+		Modules: []bundle.ModuleFile{
+			bundle.ModuleFile{
+				Path:   "bundle/id2",
+				Parsed: ast.MustParseModule(module),
+				Raw:    []byte(module),
+			},
+		},
+	}
+
+	b.Manifest.Init()
+	plugin.oneShot(ctx, download.Update{Bundle: &b})
+
+	// Ensure a/a5-a6 are intact. a3 and a4 are overwritten by bundle.
+	if err := storage.Txn(ctx, manager.Store, storage.TransactionParams{}, func(txn storage.Transaction) error {
+		value, err := manager.Store.Read(ctx, txn, storage.Path{"a"})
+		if err != nil {
+			return err
+		}
+
+		expData := util.MustUnmarshalJSON([]byte(`{"a3": "foo", "a5": "x3"}`))
+
+		if !reflect.DeepEqual(value, expData) {
+			return fmt.Errorf("Expected %v but got %v", expData, value)
+		}
+
+		ids, err := manager.Store.ListPolicies(ctx, txn)
+		if err != nil {
+			return err
+		}
+
+		expIds := []string{"bundle/id2", "some/id3"}
+		sort.Strings(ids)
+
+		if !reflect.DeepEqual(ids, expIds) {
+			return fmt.Errorf("Expected ids %v but got %v", expIds, ids)
+		}
+
+		return nil
+
+	}); err != nil {
+		t.Fatal(err)
+	}
+
 }
 
 func getTestManager() *plugins.Manager {


### PR DESCRIPTION
These changes update OPA to support scoping on bundles. See #1201 for more information. In the future, we can extend scoping so that API callers can declare their own roots.