### PR TITLE
decision_logs: Update interface to return error

### DIFF
--- a/docs/book/plugins.md
+++ b/docs/book/plugins.md
@@ -145,7 +145,7 @@ func (p *PrintlnLogger) Reconfigure(ctx context.Context, config interface{}) {
     p.config = config.(Config)
 }
 
-func (p *PrintlnLogger) Log(ctx context.Context, event logs.EventV1) {
+func (p *PrintlnLogger) Log(ctx context.Context, event logs.EventV1) error {
     p.mtx.Lock()
     defer p.mtx.Unlock()
     w := os.Stdout
@@ -153,6 +153,7 @@ func (p *PrintlnLogger) Log(ctx context.Context, event logs.EventV1) {
         w = os.Stderr
     }
     fmt.Fprintln(w, event) // ignoring errors!
+    return nil
 }
 ```
 

--- a/plugins/logs/plugin.go
+++ b/plugins/logs/plugin.go
@@ -26,7 +26,8 @@ import (
 // Logger defines the interface for decision logging plugins.
 type Logger interface {
 	plugins.Plugin
-	Log(context.Context, EventV1)
+
+	Log(context.Context, EventV1) error
 }
 
 // EventV1 represents a decision log event.
@@ -213,7 +214,7 @@ func (p *Plugin) Stop(ctx context.Context) {
 }
 
 // Log appends a decision log event to the buffer for uploading.
-func (p *Plugin) Log(ctx context.Context, decision *server.Info) {
+func (p *Plugin) Log(ctx context.Context, decision *server.Info) error {
 
 	path := strings.Replace(strings.TrimPrefix(decision.Path, "data."), ".", "/", -1)
 
@@ -240,11 +241,9 @@ func (p *Plugin) Log(ctx context.Context, decision *server.Info) {
 	if p.config.Plugin != nil {
 		proxy, ok := p.manager.Plugin(*p.config.Plugin).(Logger)
 		if !ok {
-			p.logError("Plugin does not implement Logger interface. Dropping event.")
-			return
+			return fmt.Errorf("plugin does not implement Logger interface")
 		}
-		proxy.Log(ctx, event)
-		return
+		return proxy.Log(ctx, event)
 	}
 
 	p.mtx.Lock()
@@ -252,13 +251,18 @@ func (p *Plugin) Log(ctx context.Context, decision *server.Info) {
 
 	result, err := p.enc.Write(event)
 	if err != nil {
+		// TODO(tsandall): revisit this now that we have an API that
+		// can return an error. Should the default behaviour be to
+		// fail-closed as we do for plugins?
 		p.logError("Log encoding failed: %v.", err)
-		return
+		return nil
 	}
 
 	if result != nil {
 		p.bufferChunk(p.buffer, result)
 	}
+
+	return nil
 }
 
 // Reconfigure notifies the plugin with a new configuration.

--- a/plugins/logs/plugin_test.go
+++ b/plugins/logs/plugin_test.go
@@ -44,8 +44,9 @@ func (p *testPlugin) Stop(context.Context) {
 func (p *testPlugin) Reconfigure(context.Context, interface{}) {
 }
 
-func (p *testPlugin) Log(_ context.Context, event EventV1) {
+func (p *testPlugin) Log(_ context.Context, event EventV1) error {
 	p.events = append(p.events, event)
+	return nil
 }
 
 func TestPluginCustomBackend(t *testing.T) {

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -250,7 +250,7 @@ func (rt *Runtime) StartServer(ctx context.Context) {
 		WithAuthorization(rt.Params.Authorization).
 		WithDiagnosticsBuffer(rt.Params.DiagnosticsBuffer).
 		WithDecisionIDFactory(rt.decisionIDFactory).
-		WithDecisionLogger(rt.decisionLogger).
+		WithDecisionLoggerWithErr(rt.decisionLogger).
 		WithRuntime(rt.info).
 		Init(ctx)
 
@@ -318,12 +318,12 @@ func (rt *Runtime) decisionIDFactory() string {
 	return ""
 }
 
-func (rt *Runtime) decisionLogger(ctx context.Context, event *server.Info) {
+func (rt *Runtime) decisionLogger(ctx context.Context, event *server.Info) error {
 	plugin := logs.Lookup(rt.Manager)
 	if plugin == nil {
-		return
+		return nil
 	}
-	plugin.Log(ctx, event)
+	return plugin.Log(ctx, event)
 }
 
 func (rt *Runtime) startWatcher(ctx context.Context, paths []string, onReload func(time.Duration, error)) error {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -2212,8 +2212,12 @@ func TestDecisionLogging(t *testing.T) {
 	f.server = f.server.WithDecisionIDFactory(func() string {
 		nextID++
 		return fmt.Sprint(nextID)
-	}).WithDecisionLogger(func(_ context.Context, info *Info) {
+	}).WithDecisionLoggerWithErr(func(_ context.Context, info *Info) error {
+		if info.Path == "data.fail_closed.decision_logger_err" {
+			return fmt.Errorf("some error")
+		}
 		decisions = append(decisions, info)
+		return nil
 	})
 
 	reqs := []struct {
@@ -2293,6 +2297,11 @@ func TestDecisionLogging(t *testing.T) {
 		{
 			raw:  newReqUnversioned("POST", "/", ""),
 			code: 500,
+		},
+		{
+			method: "POST",
+			path:   "/data/fail_closed/decision_logger_err",
+			code:   500,
 		},
 	}
 


### PR DESCRIPTION
Previously, the decision logger interface did not allow plugin
implementations to return an error. In some cases, implementations may
prefer to make OPA fail-closed if the event cannot be emitted.

This is a backwards incompatible change to the custom decision logger
API that was added in v0.10.3 and it deprecates the old diagnostic
interface as well.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>