### PR TITLE
metrics: Add go default metrics

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -367,6 +367,7 @@ func (s *Server) initRouter() {
 	catchAllDur := duration.MustCurryWith(prometheus.Labels{"handler": PromHandlerCatch})
 	GetHealthDur := duration.MustCurryWith(prometheus.Labels{"handler": PromHandlerHealth})
 	promRegistry.MustRegister(duration)
+	promRegistry.MustRegister(prometheus.NewGoCollector())
 
 	router := s.router
 


### PR DESCRIPTION
See https://github.com/open-policy-agent/opa/issues/1231.

Should I adjust the documentation for this change? If yes, where would be the right place?

