### PR TITLE
Fix panic for modulo on floating-point numbers

### DIFF
--- a/topdown/arithmetic.go
+++ b/topdown/arithmetic.go
@@ -123,7 +123,15 @@ func builtinRem(a, b ast.Value) (ast.Value, error) {
 	n2, ok2 := b.(ast.Number)
 
 	if ok1 && ok2 {
-		i, err := arithRem(builtins.NumberToInt(n1), builtins.NumberToInt(n2))
+
+		op1, err1 := builtins.NumberToInt(n1)
+		op2, err2 := builtins.NumberToInt(n2)
+
+		if err1 != nil || err2 != nil {
+			return nil, fmt.Errorf("modulo on floating-point number")
+		}
+
+		i, err := arithRem(op1, op2)
 		if err != nil {
 			return nil, err
 		}

--- a/topdown/builtins/builtins.go
+++ b/topdown/builtins/builtins.go
@@ -157,12 +157,13 @@ func FloatToNumber(f *big.Float) ast.Number {
 }
 
 // NumberToInt converts n to a big int.
-func NumberToInt(n ast.Number) *big.Int {
+// If n cannot be converted to an big int, an error is returned.
+func NumberToInt(n ast.Number) (*big.Int, error) {
 	r, ok := new(big.Int).SetString(string(n), 10)
 	if !ok {
-		panic("illegal value")
+		return nil, fmt.Errorf("illegal value")
 	}
-	return r
+	return r, nil
 }
 
 // IntToNumber converts i to a number.

--- a/topdown/topdown_test.go
+++ b/topdown/topdown_test.go
@@ -1049,6 +1049,7 @@ func TestTopDownArithmetic(t *testing.T) {
 		{"abs", []string{`p = true { abs(-10, x); x = 10 }`}, "true"},
 		{"remainder", []string{`p = x { x = 7 % 4 }`}, "3"},
 		{"remainder+error", []string{`p = x { x = 7 % 0 }`}, fmt.Errorf("modulo by zero")},
+		{"remainder+error+floating", []string{`p = x { x = 1.1 % 1 }`}, fmt.Errorf("modulo on floating-point number")},
 		{"arity 1 ref dest", []string{`p = true { abs(-4, a[3]) }`}, "true"},
 		{"arity 1 ref dest (2)", []string{`p = true { not abs(-5, a[3]) }`}, "true"},
 		{"arity 2 ref dest", []string{`p = true { a[2] = 1 + 2 }`}, "true"},


### PR DESCRIPTION
Fixes #1245

Currently modulo operator (%) panics when the input is a floating point number. This change adds support to perform floating-point remainder operation on floating point numbers.

Signed-off-by: Ashutosh Narkar <anarkar4387@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
