### PR TITLE
docs: Replace backticks with quotes in ssh policy comments.

### DIFF
--- a/docs/book/ssh-and-sudo-authorization.md
+++ b/docs/book/ssh-and-sudo-authorization.md
@@ -159,8 +159,8 @@ allow {
 
 # Allow access to any user who contributed to the code running on the host.
 #
-# This rule gets the `host_id` value from the file `/etc/host_identity.json`.
-# It is available in the input under `pull_responses` because we
+# This rule gets the "host_id" value from the file "/etc/host_identity.json".
+# It is available in the input under "pull_responses" because we
 # asked for it in our pull policy above.
 #
 # It then compares all the contributors for that host against the username


### PR DESCRIPTION
Fixes #1260

The Policy comment had backticks around some words which when pasted in the terminal were incorrectly interpreted as bash commands and file names.

Signed-off-by: Ashutosh Narkar <anarkar4387@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
