### PR TITLE
Add OPS installation instructions for Homebrew

### DIFF
--- a/docs/book/get-started.md
+++ b/docs/book/get-started.md
@@ -39,6 +39,11 @@ On macOS (64-bit):
 curl -L -o opa https://github.com/open-policy-agent/opa/releases/download/v0.10.5/opa_darwin_amd64
 ```
 
+Alternatively, if you have Homebrew installed, on macOS you can simply do:
+```shell
+brew install opa
+```
+
 On Linux (64-bit):
 
 ```shell


### PR DESCRIPTION
Simple change in the docs to add instructions for installing OPA with the loved-by-many Homebrew tool.