### PR TITLE
Build and tag rootless Docker image

### DIFF
--- a/Dockerfile_rootless.in
+++ b/Dockerfile_rootless.in
@@ -1,0 +1,18 @@
+# Copyright 2016 The OPA Authors.  All rights reserved.
+# Use of this source code is governed by an Apache2
+# license that can be found in the LICENSE file.
+
+FROM gcr.io/distroless/base
+
+MAINTAINER Torin Sandall <torinsandall@gmail.com>
+
+ADD opa_linux_GOARCH /opa
+
+# Any non-zero number will do, and unfortunately a named user will not,
+# as k8s pod securityContext runAsNonRoot can't resolve the user ID:
+# https://github.com/kubernetes/kubernetes/issues/40958
+USER 1
+
+ENTRYPOINT ["/opa"]
+
+CMD ["run"]

--- a/Makefile
+++ b/Makefile
@@ -77,23 +77,28 @@ image:
 image-quick:
 	sed -e 's/GOARCH/$(GOARCH)/g' Dockerfile.in > .Dockerfile_$(GOARCH)
 	sed -e 's/GOARCH/$(GOARCH)/g' Dockerfile_debug.in > .Dockerfile_debug_$(GOARCH)
+	sed -e 's/GOARCH/$(GOARCH)/g' Dockerfile_rootless.in > .Dockerfile_rootless_$(GOARCH)
 	docker build -t $(IMAGE):$(VERSION)	-f .Dockerfile_$(GOARCH) .
 	docker build -t $(IMAGE):$(VERSION)-debug -f .Dockerfile_debug_$(GOARCH) .
+	docker build -t $(IMAGE):$(VERSION)-rootless -f .Dockerfile_rootless_$(GOARCH) .
 
 .PHONY: push
 push:
 	docker push $(IMAGE):$(VERSION)
 	docker push $(IMAGE):$(VERSION)-debug
+	docker push $(IMAGE):$(VERSION)-rootless
 
 .PHONY: tag-latest
 tag-latest:
 	docker tag $(IMAGE):$(VERSION) $(IMAGE):latest
 	docker tag $(IMAGE):$(VERSION)-debug $(IMAGE):latest-debug
+	docker tag $(IMAGE):$(VERSION)-rootless $(IMAGE):latest-rootless
 
 .PHONY: push-latest
 push-latest:
 	docker push $(IMAGE):latest
 	docker push $(IMAGE):latest-debug
+	docker push $(IMAGE):latest-rootless
 
 .PHONY: docker-login
 docker-login:


### PR DESCRIPTION
Added a new `openpolicyagent/opa:latest-rootless` and `openpolicyagent/opa:${version}-rootless` image that does not run as root.

Did this instead of switching the existing image to maintain backwards compatibility for people who may be deploying the image as `root` and using the associated privileges to bind to privileged ports.

Fixes #1267.