### PR TITLE
Fix overflow of landing page

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -406,7 +406,7 @@ main {
   height: 320px;
   position: relative;
   top: -170px;
-  width: 100%;
+  width: 98%;
 }
 
 @keyframes rock {
@@ -699,7 +699,7 @@ main {
   .headline--wave--bg::after {
     background-position: center 51%;
     background-size: 288px;
-    width: 100%;
+    width: 96%;
   }
 }
 


### PR DESCRIPTION
The landing page of [OPA's main website](https://www.openpolicyagent.org/) overflows in the X direction because of the rock animation of the boat object.

## BEFORE
On desktops:
![opa1](https://user-images.githubusercontent.com/22499864/54557853-22fdb680-49e2-11e9-89e5-3a551b5d55b0.png)
On mobile devices:
![opa2](https://user-images.githubusercontent.com/22499864/54557854-22fdb680-49e2-11e9-93c8-793ffe3751d9.png)

## AFTER
On desktops:
![opa3](https://user-images.githubusercontent.com/22499864/54557855-23964d00-49e2-11e9-8975-ddfd78f8c758.png)
On mobile devies:
![opa4](https://user-images.githubusercontent.com/22499864/54557856-23964d00-49e2-11e9-96f6-44029134ee8e.png)