### PR TITLE
Return errors during eval tree enumeration

### DIFF
--- a/topdown/eval.go
+++ b/topdown/eval.go
@@ -1368,9 +1368,11 @@ func (e evalTree) enumerate(iter unifyIterator) error {
 
 	for k := range e.node.Children {
 		key := ast.NewTerm(k)
-		e.e.biunify(key, e.ref[e.pos], e.bindings, e.bindings, func() error {
+		if err := e.e.biunify(key, e.ref[e.pos], e.bindings, e.bindings, func() error {
 			return e.next(iter, key)
-		})
+		}); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/topdown/topdown_test.go
+++ b/topdown/topdown_test.go
@@ -699,6 +699,12 @@ iterate_ground[x] { data.topdown.virtual.constants[x] = 1 }
 		`package topdown.conflicts
 
 		k = "bar"`,
+		`package enum_errors.a.b.c
+
+p = x { x = 1/0 }`,
+		`package enum_errors.caller
+
+p[x] = y { data.enum_errors.a[x] = y }`,
 	})
 
 	store := inmem.NewFromObject(data)
@@ -748,6 +754,7 @@ iterate_ground[x] { data.topdown.virtual.constants[x] = 1 }
 	assertTopDownWithPath(t, compiler, store, "base/virtual: missing input value", []string{"topdown", "u"}, "{}", "{}")
 	assertTopDownWithPath(t, compiler, store, "iterate ground", []string{"topdown", "iterate_ground"}, "{}", `["p", "r"]`)
 	assertTopDownWithPath(t, compiler, store, "base/virtual: conflicts", []string{"topdown.conflicts"}, "{}", `{"k": "foo"}`)
+	assertTopDownWithPath(t, compiler, store, "enumerate virtual errors", []string{"enum_errors", "caller", "p"}, `{}`, fmt.Errorf("divide by zero"))
 }
 
 func TestTopDownNestedReferences(t *testing.T) {


### PR DESCRIPTION
Previously errors that occurred during tree enumeration were being
silently ignored. This would result in an undefined value for the
virtual document defined by the failing error.

Fixes #1272

Signed-off-by: Torin Sandall <torinsandall@gmail.com>