### PR TITLE
Update JWT reference

### DIFF
--- a/docs/book/faq.md
+++ b/docs/book/faq.md
@@ -346,8 +346,9 @@ x := q[_]
 not p[x]
 ```
 
-## Java Web Tokens (JWTs)
-[Java Web Tokens (JWTs)](https://jwt.io/) is an industry standard for exchanging information between services.  Often it's used to represent information about the users logged into a system.  OPA has special-purpose code for dealing with JWTs.
+## JSON Web Tokens (JWTs)
+
+[JSON Web Tokens (JWTs)](https://jwt.io/) are an industry standard for exchanging information between services.  Often they are used to represent information about the users logged into a system.  OPA has special-purpose code for dealing with JWTs.
 
 All JWTs with OPA come in as strings.  That string is a JSON Web Token encoded with JWS Compact Serialization. JWE and JWS JSON Serialization are not supported.
 


### PR DESCRIPTION
In #1268, JSON Web Tokens are mistakenly referred to as Java Web Tokens. This PR addresses that.