### PR TITLE
Exclude node_modules dir from release script

### DIFF
--- a/build/gen-release-patch.sh
+++ b/build/gen-release-patch.sh
@@ -59,7 +59,7 @@ EOF
 }
 
 update_docs() {
-    find ./docs/ \( -name "*.md" -o -name "*.yaml" \) -exec sed -i='' s/${LAST_VERSION:1}/$VERSION/g {} \;
+    find ./docs/ -not -path "./docs/book/node_modules/*" \( -name "*.md" -o -name "*.yaml" \) -exec sed -i='' s/${LAST_VERSION:1}/$VERSION/g {} \;
 }
 
 main() {


### PR DESCRIPTION
This commit updates build/gen-release-patch.sh to
exclude node_modules directory to prevent unwanted
parsing of its file contents by sed tool.
Additional tests are not required as the final build
does not depend on parsing of node_modules.
I ran existing tests and they are all passing.

Fixes #1237

Signed-off-by: Ravi Soni <soniravi829@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
