### PR TITLE
Fix IAM sample regex

### DIFF
--- a/docs/book/comparison-to-other-systems.md
+++ b/docs/book/comparison-to-other-systems.md
@@ -291,7 +291,7 @@ allow {
 # actions_match is true if input.action matches one in the list
 actions_match {
     # iterate over the actions in the list
-    actions := ["s3:List*","s3:Get*"]
+    actions := ["s3:List.*","s3:Get.*"]
     action := actions[_]
     # check if input.action matches an action
     regex.globs_match(input.action, action)
@@ -300,7 +300,7 @@ actions_match {
 # resources_match is true if input.resource matches one in the list
 resources_match {
     # iterate over the resources in the list
-    resources := ["arn:aws:s3:::confidential-data","arn:aws:s3:::confidential-data/*"]
+    resources := ["arn:aws:s3:::confidential-data","arn:aws:s3:::confidential-data/.*"]
     resource := resources[_]
     # check if input.resource matches a resource
     regex.globs_match(input.resource, resource)


### PR DESCRIPTION
As mentioned in #1282 , the wildcard expressions aren't allowed in `regex.globs_match`. This fixes the expression to be appropriate regex.

* This PR does not include code changes