### PR TITLE
Bump kube-mgmt container version to 0.8 in tutorial

### DIFF
--- a/docs/code/kubernetes-admission-control-validation/admission-controller.yaml
+++ b/docs/code/kubernetes-admission-control-validation/admission-controller.yaml
@@ -91,7 +91,7 @@ spec:
               mountPath: /certs
               name: opa-server
         - name: kube-mgmt
-          image: openpolicyagent/kube-mgmt:0.6
+          image: openpolicyagent/kube-mgmt:0.8
           args:
             - "--replicate-cluster=v1/namespaces"
             - "--replicate=extensions/v1beta1/ingresses"


### PR DESCRIPTION
The tutorial for the admission controller was using an older release of the
kube-mgmt sidecar. This just updates to the latest (as of now) tagged release.

Tested following the full tutorial and all steps work as expected with the new
version being used instead of 0.6.

Signed-off-by: Patrick East <east.patrick@gmail.com>