### PR TITLE
Add additional net CIDR builtins

### DIFF
--- a/ast/builtins.go
+++ b/ast/builtins.go
@@ -165,6 +165,8 @@ var DefaultBuiltins = [...]*Builtin{
 
 	// CIDR
 	NetCIDROverlap,
+	NetCIDRIntersects,
+	NetCIDRContains,
 
 	// Glob
 	GlobMatch,
@@ -1356,9 +1358,21 @@ var GlobQuoteMeta = &Builtin{
  * Net CIDR
  */
 
-// NetCIDROverlap checks if an ip overlaps with cidr and returns true or false
-var NetCIDROverlap = &Builtin{
-	Name: "net.cidr_overlap",
+// NetCIDRIntersects checks if a cidr intersects with another cidr and returns true or false
+var NetCIDRIntersects = &Builtin{
+	Name: "net.cidr_intersects",
+	Decl: types.NewFunction(
+		types.Args(
+			types.S,
+			types.S,
+		),
+		types.B,
+	),
+}
+
+// NetCIDRContains checks if a cidr or ip is contained within another cidr and returns true or false
+var NetCIDRContains = &Builtin{
+	Name: "net.cidr_contains",
 	Decl: types.NewFunction(
 		types.Args(
 			types.S,
@@ -1381,6 +1395,18 @@ var SetDiff = &Builtin{
 			types.NewSet(types.A),
 		),
 		types.NewSet(types.A),
+	),
+}
+
+// NetCIDROverlap has been replaced by the `net.cidr_contains` built-in.
+var NetCIDROverlap = &Builtin{
+	Name: "net.cidr_overlap",
+	Decl: types.NewFunction(
+		types.Args(
+			types.S,
+			types.S,
+		),
+		types.B,
 	),
 }
 

--- a/docs/content/docs/language-reference.md
+++ b/docs/content/docs/language-reference.md
@@ -251,7 +251,8 @@ In order to trigger the use of HTTPs the user must provide one of the following 
 ### Net
 | Built-in | Description |
 | ------- |-------------|
-| <span class="opa-keep-it-together">``output := net.cidr_overlap(cidr, ip)``</span> | `output` is `true` if `ip` (e.g. `127.0.0.1`) overlaps with `cidr` (e.g. `127.0.0.1/24`) and false otherwise. Supports both IPv4 and IPv6 notations.|
+| <span class="opa-keep-it-together">``net.cidr_contains(cidr, cidr_or_ip)``</span> | `output` is `true` if `cidr_or_ip` (e.g. `127.0.0.64/26` or `127.0.0.1`) is contained within `cidr` (e.g. `127.0.0.1/24`) and false otherwise. Supports both IPv4 and IPv6 notations.|
+| <span class="opa-keep-it-together">``net.cidr_intersects(cidr1, cidr2)``</span> | `output` is `true` if `cidr1` (e.g. `192.168.0.0/16`) overlaps with `cidr2` (e.g. `192.168.1.0/24`) and false otherwise. Supports both IPv4 and IPv6 notations.|
 
 ### Rego
 | Built-in | Description |

--- a/topdown/cidr.go
+++ b/topdown/cidr.go
@@ -2,36 +2,117 @@ package topdown
 
 import (
 	"fmt"
+	"math/big"
 	"net"
 
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/topdown/builtins"
 )
 
-func builtinNetCIDROverlap(a, b ast.Value) (ast.Value, error) {
-	pattern, err := builtins.StringOperand(a, 1)
+func getNetFromOperand(v ast.Value) (*net.IPNet, error) {
+	subnetStringA, err := builtins.StringOperand(v, 1)
 	if err != nil {
 		return nil, err
 	}
 
-	match, err := builtins.StringOperand(b, 1)
+	_, cidrnet, err := net.ParseCIDR(string(subnetStringA))
 	if err != nil {
 		return nil, err
 	}
 
-	_, cidrnet, err := net.ParseCIDR(string(pattern))
+	return cidrnet, nil
+}
+
+func getLastIP(cidr *net.IPNet) (net.IP, error) {
+	prefixLen, bits := cidr.Mask.Size()
+	if prefixLen == 0 && bits == 0 {
+		// non-standard mask, see https://golang.org/pkg/net/#IPMask.Size
+		return nil, fmt.Errorf("CIDR mask is in non-standard format")
+	}
+	var lastIP []byte
+	if prefixLen == bits {
+		// Special case for single ip address ranges ex: 192.168.1.1/32
+		// We can just use the starting IP as the last IP
+		lastIP = cidr.IP
+	} else {
+		// Use big.Int's so we can handle ipv6 addresses
+		firstIPInt := new(big.Int)
+		firstIPInt.SetBytes(cidr.IP)
+		hostLen := uint(bits) - uint(prefixLen)
+		lastIPInt := big.NewInt(1)
+		lastIPInt.Lsh(lastIPInt, hostLen)
+		lastIPInt.Sub(lastIPInt, big.NewInt(1))
+		lastIPInt.Or(lastIPInt, firstIPInt)
+
+		ipBytes := firstIPInt.Bytes()
+		lastIP = make([]byte, bits/8)
+
+		// Pack our IP bytes into the end of the return array,
+		// since big.Int.Bytes() removes front zero padding.
+		for i := 1; i <= len(firstIPInt.Bytes()); i++ {
+			lastIP[len(lastIP)-i] = ipBytes[len(ipBytes)-i]
+		}
+	}
+
+	return lastIP, nil
+}
+
+func builtinNetCIDRIntersects(a, b ast.Value) (ast.Value, error) {
+	cidrnetA, err := getNetFromOperand(a)
 	if err != nil {
 		return nil, err
 	}
 
-	ip := net.ParseIP(string(match))
-	if ip == nil {
-		return nil, fmt.Errorf("not a valid textual representation of an IP address: %s", string(match))
+	cidrnetB, err := getNetFromOperand(b)
+	if err != nil {
+		return nil, err
 	}
 
-	return ast.Boolean(cidrnet.Contains(ip)), nil
+	// If either net contains the others starting IP they are overlapping
+	cidrsOverlap := (cidrnetA.Contains(cidrnetB.IP) || cidrnetB.Contains(cidrnetA.IP))
+
+	return ast.Boolean(cidrsOverlap), nil
+}
+
+func builtinNetCIDRContains(a, b ast.Value) (ast.Value, error) {
+	cidrnetA, err := getNetFromOperand(a)
+	if err != nil {
+		return nil, err
+	}
+
+	// b could be either an IP addressor CIDR string, try to parse it as an IP first, fall back to CIDR
+	bStr, err := builtins.StringOperand(b, 1)
+	if err != nil {
+		return nil, err
+	}
+
+	ip := net.ParseIP(string(bStr))
+	if ip != nil {
+		return ast.Boolean(cidrnetA.Contains(ip)), nil
+	}
+
+	// It wasn't an IP, try and parse it as a CIDR
+	cidrnetB, err := getNetFromOperand(b)
+	if err != nil {
+		return nil, fmt.Errorf("not a valid textual representation of an IP address or CIDR: %s", string(bStr))
+	}
+
+	// We can determine if cidr A contains cidr B iff A contains the starting address of B and the last address in B.
+	cidrContained := false
+	if cidrnetA.Contains(cidrnetB.IP) {
+		// Only spend time calculating the last IP if the starting IP is already verified to be in cidr A
+		lastIP, err := getLastIP(cidrnetB)
+		if err != nil {
+			return nil, err
+		}
+		cidrContained = cidrnetA.Contains(lastIP)
+	}
+
+	return ast.Boolean(cidrContained), nil
 }
 
 func init() {
-	RegisterFunctionalBuiltin2(ast.NetCIDROverlap.Name, builtinNetCIDROverlap)
+	RegisterFunctionalBuiltin2(ast.NetCIDROverlap.Name, builtinNetCIDRContains)
+	RegisterFunctionalBuiltin2(ast.NetCIDRIntersects.Name, builtinNetCIDRIntersects)
+	RegisterFunctionalBuiltin2(ast.NetCIDRContains.Name, builtinNetCIDRContains)
 }

--- a/topdown/cidr_test.go
+++ b/topdown/cidr_test.go
@@ -18,3 +18,49 @@ func TestNetCIDROverlap(t *testing.T) {
 		runTopDownTestCase(t, data, tc.note, tc.rules, tc.expected)
 	}
 }
+
+func TestNetCIDRSubnetOverlap(t *testing.T) {
+	tests := []struct {
+		note     string
+		rules    []string
+		expected interface{}
+	}{
+		{"cidr subnet overlaps", []string{`p[x] { net.cidr_intersects("192.168.1.0/25", "192.168.1.64/25", x) }`}, "[true]"},
+		{"cidr subnet does not overlap", []string{`p[x] { net.cidr_intersects("192.168.1.0/24", "192.168.2.0/24", x) }`}, "[false]"},
+		{"cidr ipv6 subnet overlaps", []string{`p[x] { net.cidr_intersects("fd1e:5bfe:8af3:9ddc::/64", "fd1e:5bfe:8af3:9ddc:1111::/72", x) }`}, "[true]"},
+		{"cidr ipv6 subnet does not overlap", []string{`p[x] { net.cidr_intersects("fd1e:5bfe:8af3:9ddc::/64", "2001:4860:4860::8888/32", x) }`}, "[false]"},
+		{"cidr subnet overlap malformed cidr a", []string{`p[x] { net.cidr_intersects("not-a-cidr", "192.168.1.0/24", x) }`}, new(Error)},
+		{"cidr subnet overlap malformed cidr b", []string{`p[x] { net.cidr_intersects("192.168.1.0/28", "not-a-cidr", x) }`}, new(Error)},
+	}
+
+	data := loadSmallTestData()
+
+	for _, tc := range tests {
+		runTopDownTestCase(t, data, tc.note, tc.rules, tc.expected)
+	}
+}
+
+func TestNetCIDRSubnetContains(t *testing.T) {
+	tests := []struct {
+		note     string
+		rules    []string
+		expected interface{}
+	}{
+		{"cidr contains subnet", []string{`p[x] { net.cidr_contains("10.0.0.0/8", "10.1.0.0/24", x) }`}, "[true]"},
+		{"cidr does not contain subnet", []string{`p[x] { net.cidr_contains("10.0.0.0/8", "192.168.1.0/24", x) }`}, "[false]"},
+		{"cidr contains single ip subnet", []string{`p[x] { net.cidr_contains("10.0.0.0/8", "10.1.1.1/32", x) }`}, "[true]"},
+		{"cidr contains subnet ipv6", []string{`p[x] { net.cidr_contains("2001:4860:4860::8888/32", "2001:4860:4860:1234::8888/40", x) }`}, "[true]"},
+		{"cidr contains single ip subnet ipv6", []string{`p[x] { net.cidr_contains("2001:4860:4860::8888/32", "2001:4860:4860:1234:5678:1234:5678:8888/128", x) }`}, "[true]"},
+		{"cidr does not contain subnet ipv6", []string{`p[x] { net.cidr_contains("2001:4860::/32", "fd1e:5bfe:8af3:9ddc::/64", x) }`}, "[false]"},
+		{"cidr subnet overlap malformed cidr a", []string{`p[x] { net.cidr_contains("not-a-cidr", "192.168.1.67", x) }`}, new(Error)},
+		{"cidr subnet overlap malformed cider b", []string{`p[x] { net.cidr_contains("192.168.1.0/28", "not-a-cidr", x) }`}, new(Error)},
+		{"cidr contains ip", []string{`p[x] { net.cidr_contains("10.0.0.0/8", "10.1.2.3", x) }`}, "[true]"},
+		{"cidr does not contain ip", []string{`p[x] { net.cidr_contains("10.0.0.0/8", "192.168.1.1", x) }`}, "[false]"},
+	}
+
+	data := loadSmallTestData()
+
+	for _, tc := range tests {
+		runTopDownTestCase(t, data, tc.note, tc.rules, tc.expected)
+	}
+}


### PR DESCRIPTION
This adds two new builtin CIDR helpers:

`net.cidr_intersects(cidr1, cidr2)` -- Returns true if cidr1 overlaps at all with cidr2
`net.cidr_contains(cidr, cidr_or_ip)` -- Returns true if cidr_or_ip is contained entirely inside cidr

Both support IPv4 and IPv6.

The `net.cidr_contains` is replacing the `net.cidr_overlap` function (now deprecated) that checked if
an ip was in a given cidr. This function is still available for backwards compatibility but is now
implemented via the same underlying code as `net.cidr_contains`.

Fixes: #1289
Signed-off-by: Patrick East <east.patrick@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
