### PR TITLE
Auto-generate configuration tables

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -102,3 +102,10 @@ latest = "..."
 
 Change the value of `latest` and commit that change to `master` to change the displayed
 version in the docs.
+
+## Configuration tables
+
+The [Configuration Reference](https://openpolicyagent.org/docs/configuration) doc contains
+a series of tables that detail OPA's configuration parameters. Those tables are
+auto-generated from the [`configuration.yaml`](./data/configuration.yaml) file, which you
+should update if the configuration parameters change.

--- a/docs/content/docs/configuration.md
+++ b/docs/content/docs/configuration.md
@@ -57,64 +57,27 @@ Services represent endpoints that implement one or more control plane APIs
 such as the Bundle or Status APIs. OPA configuration files may contain
 multiple services.
 
-| Field | Type | Required | Description |
-| --- | --- | --- | --- |
-| `services[_].name` | `string` | Yes | Unique name for the service. Referred to by plugins. |
-| `services[_].url` | `string` | Yes | Base URL to contact the service with. |
-| `services[_].headers` | `object` | No | HTTP headers to include in requests to the service. |
-| `services[_].allow_insecure_tls` | `bool` | No | Allow insecure TLS. |
-| `services[_].credentials.bearer.token` | `string` | No | Enables token-based authentication and supplies the bearer token to authenticate with. |
-| `services[_].credentials.bearer.scheme` | `string` | No | Bearer token scheme to specify. |
-| `services[_].credentials.client_tls.cert` | `string` | No | The path to the client certificate to authenticate with. |
-| `services[_].credentials.client_tls.private_key` | `string` | No | The path to the private key of the client certificate. |
-| `services[_].credentials.client_tls.private_key_passphrase` | `string` | No | The passphrase to use for the private key. |
+{{< config "Services" >}}
 
 > Services can be defined as an array or object. When defined as an object, the
 > object keys override the `services[_].name` fields.
 
 ## Miscellaenous
 
-| Field | Type | Required | Description |
-| --- | --- | --- | --- |
-| `labels` | `object` | Yes | Set of key-value pairs that uniquely identify the OPA instance. Labels are included when OPA uploads decision logs and status information. |
-| `default_decision` | `string` | No (default: `/system/main`) | Set path of default policy decision used to serve queries against OPA's base URL. |
-| `default_authorization_decision` | `string` | No (default: `/system/authz/allow`) | Set path of default authorization decision for OPA's API. |
-| `plugins` | `object` | No (default: `{}`) | Location for custom plugin configuration. See [Plugins](plugins.md) for details. |
+{{< config "Miscellaneous" >}}
 
 ## Bundles
 
-| Field | Type | Required | Description |
-| --- | --- | --- | --- |
-| `bundle.name` | `string` | Yes | Name of the bundle to download. |
-| `bundle.prefix` | `string` | No (default: `bundles`) | Path prefix to use to download bundle from remote server. |
-| `bundle.service` | `string` | Yes | Name of service to use to contact remote server. |
-| `bundle.polling.min_delay_seconds` | `int64` | No (default: `60`) | Minimum amount of time to wait between bundle downloads. |
-| `bundle.polling.max_delay_seconds` | `int64` | No (default: `120`) | Maximum amount of time to wait between bundle downloads. |
+{{< config "Bundles" >}}
 
 ## Status
 
-| Field | Type | Required | Description |
-| --- | --- | --- | --- |
-| `status.service` | `string` | Yes | Name of service to use to contact remote server. |
-| `status.partition_name` | `string` | No | Path segment to include in status updates. |
+{{< config "Status" >}}
 
 ## Decision Logs
 
-| Field | Type | Required | Description |
-| --- | --- | --- | --- |
-| `decision_logs.service` | `string` | Yes | Name of the service to use to contact remote server. |
-| `decision_logs.partition_name` | `string` | No | Path segment to include in status updates. |
-| `decision_logs.reporting.buffer_size_limit_bytes` | `int64` | No | Decision log buffer size limit in bytes. OPA will drop old events from the log if this limit is exceeded. By default, no limit is set. |
-| `decision_logs.reporting.upload_size_limit_bytes` | `int64` | No (default: `32768`) | Decision log upload size limit in bytes. OPA will chunk uploads to cap message body to this limit. |
-| `decision_logs.reporting.min_delay_seconds` | `int64` | No (default: `300`) | Minimum amount of time to wait between uploads. |
-| `decision_logs.reporting.max_delay_seconds` | `int64` | No (default: `600`) | Maximum amount of time to wait between uploads. |
-| `decision_logs.plugin` | `string` | No | Use the named plugin for decision logging. If this field exists, the other configuration fields are not required. |
+{{< config "Decision Logs" >}}
 
 ## Discovery
 
-| Field | Type | Required | Description |
-| --- | --- | --- | --- |
-| `discovery.name` | `string` | Yes | Name of the discovery configuration to download. |
-| `discovery.prefix` | `string` | No (default: `bundles`) | Path prefix to use to download configuration from remote server. |
-| `discovery.polling.min_delay_seconds` | `int64` | No (default: `60`) | Minimum amount of time to wait between configuration downloads. |
-| `discovery.polling.max_delay_seconds` | `int64` | No (default: `120`) | Maximum amount of time to wait between configuration downloads. |
+{{< config "Discovery" >}}

--- a/docs/data/configuration.yaml
+++ b/docs/data/configuration.yaml
@@ -1,0 +1,138 @@
+Services:
+- field: services[_].name
+  type: string
+  required: true
+  description: Unique name for the service. Referred to by plugins.
+- field: services[_].url
+  type: string
+  required: true
+  description: Base URL to contact the service with.
+- field: services[_].headers
+  type: object
+  required: false
+  description: HTTP headers to include in requests to the service.
+- field: services[_].allow_insecure_tls
+  type: bool
+  required: false
+  description: Allow insecure TLS.
+- field: services[_].credentials.bearer.token
+  type: string
+  required: false
+  description: Enables token-based authentication and supplies the bearer token to authenticate with.
+- field: services[_].credentials.bearer.scheme
+  type: string
+  required: false
+  description: Bearer token scheme to specify.
+- field: services[_].credentials.client_tls.cert
+  type: string
+  required: false
+  description: The path to the client certificate to authenticate with.
+- field: services[_].credentials.client_tls.private_key
+  type: string
+  required: false
+  description: The path to the private key of the client certificate.
+Miscellaneous:
+- field: labels
+  type: object
+  required: true
+  description: Set of key-value pairs that uniquely identify the OPA instance. Labels are included when OPA uploads decision logs and status information.
+- field: default_decision
+  type: string
+  required: false
+  default: /system/main
+  description: Set path of default policy decision used to serve queries against OPA’s base URL.
+- field: default_authorization_decision
+  type: string
+  required: false
+  default: /system/authz/allow
+  description: Set path of default authorization decision for OPA’s API.
+- field: plugins
+  type: object
+  required: false
+  description: Location for custom plugin configuration. See [Plugins](../plugins) for details.
+  default: '{}'
+Bundles:
+- field: bundle.name
+  type: string
+  required: true
+  description: Name of the bundle to download.
+- field: bundle.prefix
+  type: string
+  required: false
+  default: bundles
+  description: Path prefix to use to download bundle from remote server.
+- field: bundle.service
+  type: string
+  required: true
+  description: Name of service to use to contact remote server.
+- field: bundle.polling.min_delay_seconds
+  type: int64
+  required: false
+  default: 60
+  description: Minimum amount of time to wait between bundle downloads.
+- field: bundle.polling.max_delay_seconds
+  type: int64
+  required: false
+  default: 120
+  description: Maximum amount of time to wait between bundle downloads.
+Status:
+- field: status.service
+  type: string
+  required: true
+  description: Name of service to use to contact remote server.
+- field: status.partition_name
+  type: string
+  required: false
+  description: Path segment to include in status updates.
+"Decision Logs":
+- field: decision_logs.service
+  type: string
+  required: true
+  description: Name of the service to use to contact remote server.
+- field: decision_logs.partition_name
+  type: string
+  required: false
+  description: Path segment to include in status updates.
+- field: decision_logs.reporting.buffer_size_limit_bytes
+  type: int64
+  required: false
+  description: Decision log buffer size limit in bytes. OPA will drop old events from the log if this limit is exceeded. By default, no limit is set.
+- field: decision_logs.reporting.upload_size_limit_bytes
+  type: int64
+  required: false
+  default: 32768
+  description: Decision log upload size limit in bytes. OPA will chunk uploads to cap message body to this limit.
+- field: decision_logs.reporting.min_delay_seconds
+  type: int64
+  required: false
+  default: 300
+  description: Minimum amount of time to wait between uploads.
+- field: decision_logs.reporting.max_delay_seconds
+  type: int64
+  required: false
+  default: 600
+  description: Maximum amount of time to wait between uploads.
+- field: decision_logs.plugin
+  type: string
+  required: false
+  description: Use the named plugin for decision logging. If this field exists, the other configuration fields are not required.
+Discovery:
+- field: discovery.name
+  type: string
+  required: true
+  description: Name of the discovery configuration to download.
+- field: discovery.prefix
+  type: string
+  required: false
+  default: bundles
+  description: Path prefix to use to download configuration from remote server.
+- field: discovery.polling.min_delay_seconds
+  type: int64
+  required: false
+  default: 0
+  description: Minimum amount of time to wait between configuration downloads.
+- field: discovery.polling.max_delay_seconds
+  type: int64
+  required: false
+  default: 120
+  description: Maximum amount of time to wait between configuration downloads.

--- a/docs/layouts/shortcodes/config.html
+++ b/docs/layouts/shortcodes/config.html
@@ -1,0 +1,46 @@
+{{ $section := .Get 0 }}
+{{ $configs := index site.Data.configuration $section }}
+<table class="config-table">
+  <thead>
+    <tr>
+      <th>
+        Field
+      </th>
+      <th>
+        Type
+      </th>
+      <th>
+        Required
+      </th>
+      <th>
+        Description
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    {{ range $configs }}
+    {{ $required := cond (eq .required true) "Yes" "No" }}
+    <tr>
+      <td>
+        <code>
+          {{ .field }}
+        </code>
+      </td>
+      <td>
+        <code>
+          {{ .type }}
+        </code>
+      </td>
+      <td>
+        {{ $required }}{{ with .default }}
+        <br /><br />
+        Default: <code>{{ . }}</code>
+        {{ end }}
+      </td>
+      <td>
+        {{ .description | markdownify }}
+      </td>
+    </tr>
+    {{ end }}
+  </tbody>
+</table>


### PR DESCRIPTION
This PR adds the capability to auto-generate configuration tables from YAML.

@tsandall We can add similar auto-generation for other data tables if you'd like.