### PR TITLE
Add documentation page titles

### DIFF
--- a/docs/layouts/docs/section.en.html
+++ b/docs/layouts/docs/section.en.html
@@ -1,3 +1,7 @@
+{{ define "title" }}
+{{ site.Title }} | Documentation
+{{ end }}
+
 {{ define "main" }}
 {{ partial "docs/dashboard.html" . }}
 {{ end }}

--- a/docs/layouts/docs/single.en.html
+++ b/docs/layouts/docs/single.en.html
@@ -1,3 +1,7 @@
+{{ define "title" }}
+{{ site.Title }} | {{ .Title }}
+{{ end }}
+
 {{ define "main" }}
 {{ partial "docs/dashboard.html" . }}
 {{ end }}


### PR DESCRIPTION
This PR adds documentation page titles. The main documentation page will have the title "Open Policy Agent | Documentation" and specific docs will have the title "Open Policy Agent | <title>" (e.g. "Open Policy Agent | Decision Logs").