### PR TITLE
Fix `net.cidr_contains` for partial match cases

### DIFF
--- a/topdown/cidr.go
+++ b/topdown/cidr.go
@@ -44,12 +44,12 @@ func getLastIP(cidr *net.IPNet) (net.IP, error) {
 		lastIPInt.Sub(lastIPInt, big.NewInt(1))
 		lastIPInt.Or(lastIPInt, firstIPInt)
 
-		ipBytes := firstIPInt.Bytes()
+		ipBytes := lastIPInt.Bytes()
 		lastIP = make([]byte, bits/8)
 
 		// Pack our IP bytes into the end of the return array,
 		// since big.Int.Bytes() removes front zero padding.
-		for i := 1; i <= len(firstIPInt.Bytes()); i++ {
+		for i := 1; i <= len(lastIPInt.Bytes()); i++ {
 			lastIP[len(lastIP)-i] = ipBytes[len(ipBytes)-i]
 		}
 	}

--- a/topdown/cidr_test.go
+++ b/topdown/cidr_test.go
@@ -19,7 +19,7 @@ func TestNetCIDROverlap(t *testing.T) {
 	}
 }
 
-func TestNetCIDRSubnetOverlap(t *testing.T) {
+func TestNetCIDRIntersects(t *testing.T) {
 	tests := []struct {
 		note     string
 		rules    []string
@@ -40,17 +40,19 @@ func TestNetCIDRSubnetOverlap(t *testing.T) {
 	}
 }
 
-func TestNetCIDRSubnetContains(t *testing.T) {
+func TestNetCIDRContains(t *testing.T) {
 	tests := []struct {
 		note     string
 		rules    []string
 		expected interface{}
 	}{
 		{"cidr contains subnet", []string{`p[x] { net.cidr_contains("10.0.0.0/8", "10.1.0.0/24", x) }`}, "[true]"},
+		{"cidr does not contain subnet partial", []string{`p[x] { net.cidr_contains("172.17.0.0/24", "172.17.0.0/16", x) }`}, "[false]"},
 		{"cidr does not contain subnet", []string{`p[x] { net.cidr_contains("10.0.0.0/8", "192.168.1.0/24", x) }`}, "[false]"},
 		{"cidr contains single ip subnet", []string{`p[x] { net.cidr_contains("10.0.0.0/8", "10.1.1.1/32", x) }`}, "[true]"},
 		{"cidr contains subnet ipv6", []string{`p[x] { net.cidr_contains("2001:4860:4860::8888/32", "2001:4860:4860:1234::8888/40", x) }`}, "[true]"},
 		{"cidr contains single ip subnet ipv6", []string{`p[x] { net.cidr_contains("2001:4860:4860::8888/32", "2001:4860:4860:1234:5678:1234:5678:8888/128", x) }`}, "[true]"},
+		{"cidr does not contain subnet partial ipv6", []string{`p[x] { net.cidr_contains("2001:4860::/96", "2001:4860::/32", x) }`}, "[false]"},
 		{"cidr does not contain subnet ipv6", []string{`p[x] { net.cidr_contains("2001:4860::/32", "fd1e:5bfe:8af3:9ddc::/64", x) }`}, "[false]"},
 		{"cidr subnet overlap malformed cidr a", []string{`p[x] { net.cidr_contains("not-a-cidr", "192.168.1.67", x) }`}, new(Error)},
 		{"cidr subnet overlap malformed cider b", []string{`p[x] { net.cidr_contains("192.168.1.0/28", "not-a-cidr", x) }`}, new(Error)},


### PR DESCRIPTION
The calculation for the last ip of a block had a typo switching the buffer
we created the last ip address from.. This meant we always returned the
first IP address in the range as the last one.

There was also a gap in the unit tests for these cases. Both are corrected
with this patch.

Fixes: #1303
Signed-off-by: Patrick East <east.patrick@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
