### PR TITLE
Add support for graceful shutdown of OPA server

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -155,6 +155,7 @@ the data document with the following syntax:
 	runCommand.Flags().VarP(authorization, "authorization", "", "set authorization scheme")
 	runCommand.Flags().VarP(logLevel, "log-level", "l", "set log level")
 	runCommand.Flags().VarP(logFormat, "log-format", "", "set log format")
+	runCommand.Flags().IntVar(&params.GracefulShutdownPeriod, "shutdown-grace-period", 10, "set the time (in seconds) that the server will wait to gracefully shut down")
 	setIgnore(runCommand.Flags(), &ignore)
 
 	usageTemplate := `Usage:


### PR DESCRIPTION
There is a new CLI option to configure the grace period:

`--shutdown-grace-period`

The option defaults to 10 seconds.

When a SIGINT or SIGTERM is sent the runtime will catch them and
attempt to gracefully shutdown the http servers. If the timeout is reached
it will log an error and continue with exiting (in a less graceful way).

Unit testing is a little bit light on this. Its touching some parts of the
code that aren't super easy to mock out. We can probably refactor
things in the future to make it easier.

Fixes: #1291
Signed-off-by: Patrick East <east.patrick@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
