### PR TITLE
Rewrite == to = in queries passed to the compile API

### DIFF
--- a/ast/compile.go
+++ b/ast/compile.go
@@ -2181,9 +2181,11 @@ func rewriteComprehensionTerms(f *equalityFactory, node interface{}) (interface{
 // This stage should only run the safety check (since == is a built-in with no
 // outputs, so the inputs must not be marked as safe.)
 //
-// This stage is not executed by the query compiler because when callers specify
-// == instead of = they expect to receive a true/false/undefined result back
-// whereas with = the result is only ever true/undefined.
+// This stage is not executed by the query compiler by default because when
+// callers specify == instead of = they expect to receive a true/false/undefined
+// result back whereas with = the result is only ever true/undefined. For
+// partial evaluation cases we do want to rewrite == to = to simplify the
+// result.
 func rewriteEquals(x interface{}) {
 	doubleEq := Equal.Ref()
 	unifyOp := Equality.Ref()

--- a/rego/rego.go
+++ b/rego/rego.go
@@ -485,7 +485,12 @@ func (r *Rego) Partial(ctx context.Context) (*PartialQueries, error) {
 		return nil, err
 	}
 
-	_, compiled, err := r.compileQuery(nil, query)
+	_, compiled, err := r.compileQuery([]extraStage{
+		{
+			after: "CheckSafety",
+			stage: r.rewriteEqualsForPartialQueryCompile,
+		},
+	}, query)
 	if err != nil {
 		return nil, err
 	}
@@ -903,6 +908,25 @@ func (r *Rego) rewriteQueryForPartialEval(_ ast.QueryCompiler, query ast.Body) (
 	}
 
 	return ast.NewBody(ast.Equality.Expr(ast.Wildcard, term)), nil
+}
+
+// rewriteEqualsForPartialQueryCompile will rewrite == to = in queries. Normally
+// this wouldn't be done, except for handling queries with the `Partial` API
+// where rewriting them can substantially simplify the result, and it is unlikely
+// that the caller would need expression values.
+func (r *Rego) rewriteEqualsForPartialQueryCompile(_ ast.QueryCompiler, query ast.Body) (ast.Body, error) {
+	doubleEq := ast.Equal.Ref()
+	unifyOp := ast.Equality.Ref()
+	ast.WalkExprs(query, func(x *ast.Expr) bool {
+		if x.IsCall() {
+			operator := x.Operator()
+			if operator.Equal(doubleEq) && len(x.Operands()) == 2 {
+				x.SetOperator(ast.NewTerm(unifyOp))
+			}
+		}
+		return false
+	})
+	return query, nil
 }
 
 func (r *Rego) generateTermVar() *ast.Term {


### PR DESCRIPTION
Similar to what is done with module compilation we will rewrite “==“ to
“=“ operators in queries when using the `/compile` REST API or
`Rego.Partial(..)` API.

This does potentially mean a difference in API behavior for existing
OPA clients.

Fixes: #1280 
Signed-off-by: Patrick East <east.patrick@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
