### PR TITLE
Fix typo in docstring

### DIFF
--- a/rego/rego.go
+++ b/rego/rego.go
@@ -498,7 +498,7 @@ func (r *Rego) Partial(ctx context.Context) (*PartialQueries, error) {
 	return r.partial(ctx, compiled, txn, partialNamespace)
 }
 
-// Compile returnss a compiled policy query.
+// Compile returns a compiled policy query.
 func (r *Rego) Compile(ctx context.Context) (*CompileResult, error) {
 
 	pq, err := r.Partial(ctx)


### PR DESCRIPTION
Just fixing a typo I noticed browsing around the code.
<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
