### PR TITLE
Add Prepare API's to Rego objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 - Update topdown to return `eval_builtin_error` instead of
   `eval_internal_error`.
+- Remove `ast.WithInput()` option for `ast.QueryCompiler` and the `Input` field from
+  the `QueryContext` struct.
+- Add `rego.Rego#PrepareForEval()` and `rego.Rego#PrepareForPartial()` function to
+  pre-process the `Rego` object for performance improvements on subsequent `Eval`
+  or `Partial` calls.
+- Add new metric `rego_input_parse` and no longer count input parsing as time spent
+  in the `rego_query_compile` step.
 
 ## 0.10.7
 

--- a/ast/compile.go
+++ b/ast/compile.go
@@ -98,17 +98,11 @@ type CompilerStage func(*Compiler) *Error
 type QueryContext struct {
 	Package *Package
 	Imports []*Import
-	Input   Value
 }
 
 // NewQueryContext returns a new QueryContext object.
 func NewQueryContext() *QueryContext {
 	return &QueryContext{}
-}
-
-// InputDefined returns true if the input document is defined in qc.
-func (qc *QueryContext) InputDefined() bool {
-	return qc != nil && qc.Input != nil
 }
 
 // WithPackage sets the pkg on qc.
@@ -126,15 +120,6 @@ func (qc *QueryContext) WithImports(imports []*Import) *QueryContext {
 		qc = NewQueryContext()
 	}
 	qc.Imports = imports
-	return qc
-}
-
-// WithInput sets the input on qc.
-func (qc *QueryContext) WithInput(input Value) *QueryContext {
-	if qc == nil {
-		qc = NewQueryContext()
-	}
-	qc.Input = input
 	return qc
 }
 

--- a/ast/example_test.go
+++ b/ast/example_test.go
@@ -91,8 +91,7 @@ min_x = 100 { true }`
 			// instead.
 			ast.NewQueryContext().
 				WithPackage(ast.MustParsePackage(`package opa.example`)).
-				WithImports(ast.MustParseImports("import input.query_arg")).
-				WithInput(ast.MustParseTerm(`{"query_arg": 1000, "bar": [1,2,3]}`).Value),
+				WithImports(ast.MustParseImports("import input.query_arg")),
 		)
 
 	// Parse the input query to obtain the AST representation.

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -24,6 +24,7 @@ const (
 	RegoModuleParse   = "rego_module_parse"
 	RegoModuleCompile = "rego_module_compile"
 	RegoPartialEval   = "rego_partial_eval"
+	RegoInputParse    = "rego_input_parse"
 )
 
 // Metrics defines the interface for a collection of performance metrics in the

--- a/rego/rego.go
+++ b/rego/rego.go
@@ -26,7 +26,7 @@ import (
 
 const defaultPartialNamespace = "partial"
 
-// CompileResult represents sthe result of compiling a Rego query, zero or more
+// CompileResult represents the result of compiling a Rego query, zero or more
 // Rego modules, and arbitrary contextual data into an executable.
 type CompileResult struct {
 	Bytes []byte `json:"bytes"`
@@ -219,7 +219,7 @@ func Input(x interface{}) func(r *Rego) {
 	}
 }
 
-// ParsedInput returns an argument that set sthe Rego input document.
+// ParsedInput returns an argument that sets the Rego input document.
 func ParsedInput(x ast.Value) func(r *Rego) {
 	return func(r *Rego) {
 		r.input = x

--- a/rego/rego.go
+++ b/rego/rego.go
@@ -632,8 +632,6 @@ func (r *Rego) compileQuery(extras []extraStage, query ast.Body) (ast.QueryCompi
 		imports = append(imports, parsed...)
 	}
 
-	var input ast.Value
-
 	if r.rawInput != nil {
 		rawPtr := util.Reference(r.rawInput)
 		// roundtrip through json: this turns slices (e.g. []string, []bool) into
@@ -645,16 +643,12 @@ func (r *Rego) compileQuery(extras []extraStage, query ast.Body) (ast.QueryCompi
 		if err != nil {
 			return nil, nil, err
 		}
-		input = val
 		r.input = val
-	} else {
-		input = r.input
 	}
 
 	qctx := ast.NewQueryContext().
 		WithPackage(pkg).
-		WithImports(imports).
-		WithInput(input)
+		WithImports(imports)
 
 	qc := r.compiler.QueryCompiler().WithContext(qctx)
 

--- a/rego/rego_test.go
+++ b/rego/rego_test.go
@@ -13,11 +13,47 @@ import (
 
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/metrics"
+	"github.com/open-policy-agent/opa/storage"
 	"github.com/open-policy-agent/opa/storage/inmem"
 	"github.com/open-policy-agent/opa/topdown"
 	"github.com/open-policy-agent/opa/types"
 	"github.com/open-policy-agent/opa/util"
 )
+
+func assertEval(t *testing.T, r *Rego, expected string) {
+	t.Helper()
+	rs, err := r.Eval(context.Background())
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err.Error())
+	}
+	assertResultSet(t, rs, expected)
+}
+
+func assertPreparedEvalQueryEval(t *testing.T, pq PreparedEvalQuery, options []EvalOption, expected string) {
+	t.Helper()
+	rs, err := pq.Eval(context.Background(), options...)
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err.Error())
+	}
+	assertResultSet(t, rs, expected)
+}
+
+func assertResultSet(t *testing.T, rs ResultSet, expected string) {
+	t.Helper()
+	result := []interface{}{}
+
+	for i := range rs {
+		values := []interface{}{}
+		for j := range rs[i].Expressions {
+			values = append(values, rs[i].Expressions[j].Value)
+		}
+		result = append(result, values)
+	}
+
+	if !reflect.DeepEqual(result, util.MustUnmarshalJSON([]byte(expected))) {
+		t.Fatalf("Expected:\n\n%v\n\nGot:\n\n%v", expected, result)
+	}
+}
 
 func TestRegoEvalExpressionValue(t *testing.T) {
 
@@ -98,34 +134,13 @@ func TestRegoEvalExpressionValue(t *testing.T) {
 		},
 	}
 
-	ctx := context.Background()
-
 	for _, tc := range tests {
 		t.Run(tc.query, func(t *testing.T) {
 			r := New(
 				Query(tc.query),
 				Module("", module),
 			)
-
-			rs, err := r.Eval(ctx)
-
-			if err != nil {
-				t.Fatalf("Unexpected error: %v", err)
-			}
-
-			result := []interface{}{}
-
-			for i := range rs {
-				values := []interface{}{}
-				for j := range rs[i].Expressions {
-					values = append(values, rs[i].Expressions[j].Value)
-				}
-				result = append(result, values)
-			}
-
-			if !reflect.DeepEqual(result, util.MustUnmarshalJSON([]byte(tc.expected))) {
-				t.Fatalf("Expected:\n\n%v\n\nGot:\n\n%v", tc.expected, result)
-			}
+			assertEval(t, r, tc.expected)
 		})
 	}
 }
@@ -155,7 +170,6 @@ func TestRegoInputs(t *testing.T) {
 		"nil":                {nil, `[[null]]`},
 		"slice of interface": {[]interface{}{"a", 2, true}, `[[["a", 2, true]]]`},
 	}
-	ctx := context.Background()
 
 	for desc, tc := range tests {
 		t.Run(desc, func(t *testing.T) {
@@ -163,23 +177,7 @@ func TestRegoInputs(t *testing.T) {
 				Query("input"),
 				Input(tc.input),
 			)
-			rs, err := r.Eval(ctx)
-			if err != nil {
-				t.Fatalf("Unexpected error: %v", err)
-			}
-
-			result := []interface{}{}
-			for i := range rs {
-				values := []interface{}{}
-				for j := range rs[i].Expressions {
-					values = append(values, rs[i].Expressions[j].Value)
-				}
-				result = append(result, values)
-			}
-
-			if !reflect.DeepEqual(result, util.MustUnmarshalJSON([]byte(tc.expected))) {
-				t.Fatalf("Expected:\n\n%v\n\nGot:\n\n%v", tc.expected, result)
-			}
+			assertEval(t, r, tc.expected)
 		})
 	}
 }
@@ -304,6 +302,339 @@ func TestPartialRewriteEquals(t *testing.T) {
 		t.Errorf("expected 1 query but found %d: %+v", len(pq.Queries), pq)
 	}
 	if pq.Queries[0].String() != expectedQuery {
-		t.Errorf("unexpected query in result, expected='%s' found='%s'", expectedQuery, pq.Queries[0].String())
+		t.Errorf("unexpected query in result, expected='%s' found='%s'",
+			expectedQuery, pq.Queries[0].String())
 	}
+}
+
+func TestPrepareAndEvalNewInput(t *testing.T) {
+	module := `
+	package test
+	x = input.y
+	`
+
+	r := New(
+		Query("data.test.x"),
+		Module("", module),
+		Package("foo"),
+	)
+
+	pq, err := r.PrepareForEval(context.Background())
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err.Error())
+	}
+
+	assertPreparedEvalQueryEval(t, pq, []EvalOption{
+		EvalInput(map[string]int{"y": 1}),
+	}, "[[1]]")
+}
+
+func TestPrepareAndEvalNewMetrics(t *testing.T) {
+	module := `
+	package test
+	x = input.y
+	`
+
+	originalMetrics := metrics.New()
+
+	r := New(
+		Query("data.test.x"),
+		Module("", module),
+		Package("foo"),
+		Metrics(originalMetrics),
+	)
+
+	pq, err := r.PrepareForEval(context.Background())
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err.Error())
+	}
+
+	if len(originalMetrics.All()) == 0 {
+		t.Errorf("Expected metrics stored on 'originalMetrics' after Prepare()")
+	}
+
+	// Reset the original ones (for testing)
+	// and make a new one for the Eval
+	originalMetrics.Clear()
+	newMetrics := metrics.New()
+
+	assertPreparedEvalQueryEval(t, pq, []EvalOption{
+		EvalInput(map[string]int{"y": 1}),
+		EvalMetrics(newMetrics),
+	}, "[[1]]")
+
+	if len(originalMetrics.All()) > 0 {
+		t.Errorf("Expected no metrics stored on original Rego object metrics but found: %s",
+			originalMetrics.All())
+	}
+
+	if len(newMetrics.All()) == 0 {
+		t.Errorf("Expected metrics stored on 'newMetrics' after Prepare()")
+	}
+}
+
+func TestPrepareAndEvalNewTransaction(t *testing.T) {
+	module := `
+	package test
+	x = data.foo.y
+	`
+	ctx := context.Background()
+	store := inmem.New()
+	txn := storage.NewTransactionOrDie(ctx, store, storage.WriteParams)
+
+	path, ok := storage.ParsePath("/foo")
+	if !ok {
+		t.Fatalf("Unexpected error parsing path")
+	}
+
+	err := storage.MakeDir(ctx, store, txn, path)
+	if err != nil {
+		t.Fatalf("Unexpected error writing to store: %s", err.Error())
+	}
+
+	err = store.Write(ctx, txn, storage.AddOp, path, map[string]interface{}{"y": 1})
+	if err != nil {
+		t.Fatalf("Unexpected error writing to store: %s", err.Error())
+	}
+
+	r := New(
+		Query("data.test.x"),
+		Module("", module),
+		Store(store),
+		Transaction(txn),
+	)
+
+	pq, err := r.PrepareForEval(ctx)
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err.Error())
+	}
+
+	assertPreparedEvalQueryEval(t, pq, nil, "[[1]]")
+	store.Commit(ctx, txn)
+
+	// Update the store directly and get a new transaction
+	newTxn := storage.NewTransactionOrDie(ctx, store, storage.WriteParams)
+	err = store.Write(ctx, newTxn, storage.ReplaceOp, path, map[string]interface{}{"y": 2})
+	if err != nil {
+		t.Fatalf("Unexpected error writing to store: %s", err.Error())
+	}
+	defer store.Abort(ctx, newTxn)
+
+	// Expect that the old transaction and new transaction give
+	// different results.
+	assertPreparedEvalQueryEval(t, pq, []EvalOption{EvalTransaction(txn)}, "[[1]]")
+	assertPreparedEvalQueryEval(t, pq, []EvalOption{EvalTransaction(newTxn)}, "[[2]]")
+}
+
+func TestPrepareAndEvalIdempotent(t *testing.T) {
+	module := `
+	package test
+	x = input.y
+	`
+
+	r := New(
+		Query("data.test.x"),
+		Module("", module),
+		Package("foo"),
+	)
+
+	pq, err := r.PrepareForEval(context.Background())
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err.Error())
+	}
+
+	// Expect evaluating the same thing >1 time gives the same
+	// results each time.
+	for i := 0; i < 5; i++ {
+		assertPreparedEvalQueryEval(t, pq, []EvalOption{
+			EvalInput(map[string]int{"y": 1}),
+		}, "[[1]]")
+	}
+}
+
+func TestPrepareAndEvalOriginal(t *testing.T) {
+	module := `
+	package test
+	x = input.y
+	`
+
+	r := New(
+		Query("data.test.x"),
+		Module("", module),
+		Package("foo"),
+		Input(map[string]int{"y": 2}),
+	)
+
+	pq, err := r.PrepareForEval(context.Background())
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err.Error())
+	}
+
+	assertPreparedEvalQueryEval(t, pq, []EvalOption{
+		EvalInput(map[string]int{"y": 1}),
+	}, "[[1]]")
+
+	// Even after prepare and eval with different input
+	// expect that the original Rego object behaves
+	// as expected for Eval.
+
+	assertEval(t, r, "[[2]]")
+}
+
+func TestPrepareAndPartialResult(t *testing.T) {
+	module := `
+	package test
+	x = input.y
+	`
+
+	r := New(
+		Query("data.test.x"),
+		Module("", module),
+		Package("foo"),
+		Input(map[string]int{"y": 2}),
+	)
+
+	ctx := context.Background()
+
+	pq, err := r.PrepareForEval(ctx)
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err.Error())
+	}
+
+	assertPreparedEvalQueryEval(t, pq, []EvalOption{
+		EvalInput(map[string]int{"y": 1}),
+	}, "[[1]]")
+
+	// Even after prepare and eval with different input
+	// expect that the original Rego object behaves
+	// as expected for PartialResult.
+
+	partial, err := r.PartialResult(ctx)
+
+	r2 := partial.Rego(
+		Input(map[string]int{"y": 7}),
+	)
+	assertEval(t, r2, "[[7]]")
+}
+
+func TestPrepareWithPartialEval(t *testing.T) {
+	module := `
+	package test
+	x = input.y
+	`
+
+	r := New(
+		Query("data.test.x"),
+		Module("", module),
+		Package("foo"),
+	)
+
+	ctx := context.Background()
+
+	// Prepare the query and partially evaluate it
+	pq, err := r.PrepareForEval(ctx, WithPartialEval())
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err.Error())
+	}
+
+	assertPreparedEvalQueryEval(t, pq, []EvalOption{
+		EvalInput(map[string]int{"y": 1}),
+	}, "[[1]]")
+}
+
+func TestPrepareAndPartial(t *testing.T) {
+	mod := `
+	package test
+	default p = false
+	p {
+		input.x = 1
+	}
+	`
+	r := New(
+		Query("data.test.p == true"),
+		Module("test.rego", mod),
+	)
+
+	ctx := context.Background()
+
+	pq, err := r.PrepareForEval(ctx)
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err.Error())
+	}
+
+	assertPreparedEvalQueryEval(t, pq, []EvalOption{
+		EvalInput(map[string]int{"x": 1}),
+	}, "[[true]]")
+
+	// Even after prepare and eval with different input
+	// expect that the original Rego object behaves
+	// as expected for Partial.
+
+	partialQuery, err := r.Partial(ctx)
+	expectedQuery := "input.x = 1"
+	if len(partialQuery.Queries) != 1 {
+		t.Errorf("expected 1 query but found %d: %+v", len(partialQuery.Queries), pq)
+	}
+	if partialQuery.Queries[0].String() != expectedQuery {
+		t.Errorf("unexpected query in result, expected='%s' found='%s'",
+			expectedQuery, partialQuery.Queries[0].String())
+	}
+}
+
+func TestPrepareAndCompile(t *testing.T) {
+	module := `
+	package test
+	x = input.y
+	`
+
+	r := New(
+		Query("data.test.x"),
+		Module("", module),
+		Package("foo"),
+	)
+
+	ctx := context.Background()
+
+	pq, err := r.PrepareForEval(ctx)
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err.Error())
+	}
+
+	assertPreparedEvalQueryEval(t, pq, []EvalOption{
+		EvalInput(map[string]int{"y": 1}),
+	}, "[[1]]")
+
+	// Ensure that Compile still works after Prepare
+	// and its Eval has been called.
+	_, err = r.Compile(ctx)
+	if err != nil {
+		t.Errorf("Unexpected error when compiling: %s", err.Error())
+	}
+}
+
+func TestPartialResultWithInput(t *testing.T) {
+	mod := `
+	package test
+	default p = false
+	p {
+		input.x == 1
+	}
+	`
+	r := New(
+		Query("data.test.p"),
+		Module("test.rego", mod),
+	)
+
+	ctx := context.Background()
+	pr, err := r.PartialResult(ctx)
+
+	if err != nil {
+		t.Fatalf("unexpected error from Rego.PartialResult(): %s", err.Error())
+	}
+
+	r2 := pr.Rego(
+		Input(map[string]int{"x": 1}),
+	)
+
+	assertEval(t, r2, "[[true]]")
 }

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -591,11 +591,11 @@ func (r *REPL) recompile(ctx context.Context, cpy *ast.Module) error {
 	return nil
 }
 
-func (r *REPL) compileBody(ctx context.Context, compiler *ast.Compiler, body ast.Body, input ast.Value) (ast.Body, *ast.TypeEnv, error) {
+func (r *REPL) compileBody(ctx context.Context, compiler *ast.Compiler, body ast.Body) (ast.Body, *ast.TypeEnv, error) {
 	r.timerStart(metrics.RegoQueryCompile)
 	defer r.timerStop(metrics.RegoQueryCompile)
 
-	qctx := ast.NewQueryContext().WithInput(input)
+	qctx := ast.NewQueryContext()
 
 	if r.currentModuleID != "" {
 		qctx = qctx.WithPackage(r.modules[r.currentModuleID].Package).WithImports(r.modules[r.currentModuleID].Imports)
@@ -784,7 +784,7 @@ func (r *REPL) evalStatement(ctx context.Context, stmt interface{}) error {
 			}
 		}
 
-		compiledBody, typeEnv, err := r.compileBody(ctx, compiler, parsedBody, input)
+		compiledBody, typeEnv, err := r.compileBody(ctx, compiler, parsedBody)
 		if err != nil {
 			return err
 		}

--- a/topdown/topdown_partial_test.go
+++ b/topdown/topdown_partial_test.go
@@ -1510,9 +1510,6 @@ func prepareTest(ctx context.Context, t *testing.T, params fixtureParams, f func
 			}
 
 			queryContext := ast.NewQueryContext()
-			if input != nil {
-				queryContext = queryContext.WithInput(input.Value)
-			}
 
 			queryCompiler := compiler.QueryCompiler().WithContext(queryContext)
 


### PR DESCRIPTION
There are a handful of commits changing things, each has some details in their commit messages. High level view of the changes:

* Add `PrepareForEval()` function to Rego objects. This will parse modules and queries, then compile the modules and query (in turn parsing the imports and packages, as needed). The results are stored on the Rego object which is referenced from a PartialResult for future use...
* Add `PrepareForPartial()` function to Rego objects. Similar to `PrepareForEval` it handles parsing/pre-compiling as much as possible, but tailored for doing `Partial()` evaluations.
*  Add `PreparedEvalQuery` object with an `Eval` function which can then use the prepared parts of the queries. This Eval differs from the one on the Rego object by (optionally) taking in a new input, metric, or transaction.
* Add `PreparedPartialQuery` object with a `Partial` function. Similar to `PreparedEvalQuery` but for `Partial`
* Decouple input and QueryCompiler, in turn decoupling the compiled query and input
* Remove the `QueryCompiler.WithInput()` method. As-is it isn't used for anything. There is a risk that clients embedding OPA and calling the compile API's directly are expecting input to be on the query context passed to custom stages registered in the compile step.
* Add new metric for input parsing, it is not longer counted as part of the query compilation step.


In addition there are some options to potentially expose this via the HTTP server. As-is only golang API users can get any benefits by preparing Rego objects and re-using the PartialResult.


I updated the authz benchmark to use this new API and the results are pretty good:

Before:
```
BenchmarkAuthzForbidAuthn-8      	    5000	    252037 ns/op	   87950 B/op	    1993 allocs/op
BenchmarkAuthzForbidPath-8       	    5000	    322503 ns/op	  113304 B/op	    2798 allocs/op
BenchmarkAuthzForbidMethod-8     	    5000	    329911 ns/op	  114517 B/op	    2833 allocs/op
BenchmarkAuthzAllow10Paths-8     	    5000	    326845 ns/op	  113506 B/op	    2813 allocs/op
BenchmarkAuthzAllow100Paths-8    	    2000	    816802 ns/op	  316721 B/op	    9688 allocs/op
BenchmarkAuthzAllow1000Paths-8   	     200	   6075679 ns/op	 2346239 B/op	   79022 allocs/op
```

After:
```
BenchmarkAuthzForbidAuthn-8      	   50000	     30648 ns/op	   10955 B/op	     224 allocs/op
BenchmarkAuthzForbidPath-8       	   20000	     97358 ns/op	   35683 B/op	    1029 allocs/op
BenchmarkAuthzForbidMethod-8     	   10000	    103638 ns/op	   36929 B/op	    1064 allocs/op
BenchmarkAuthzAllow10Paths-8     	   10000	    101128 ns/op	   35974 B/op	    1044 allocs/op
BenchmarkAuthzAllow100Paths-8    	    2000	    616450 ns/op	  239879 B/op	    7920 allocs/op
BenchmarkAuthzAllow1000Paths-8   	     300	   6076363 ns/op	 2269655 B/op	   77260 allocs/op
```


Fixes: #1305