### PR TITLE
Fix mobile navbar dropdown

### DIFF
--- a/docs/layouts/partials/docs/navbar.html
+++ b/docs/layouts/partials/docs/navbar.html
@@ -10,6 +10,7 @@
 {{ $docs      := where $allDocs ".Params.kind" "eq" "documentation" }}
 {{ $tutorials := where $allDocs ".Params.kind" "eq" "tutorial" }}
 {{ $guides    := where $allDocs ".Params.kind" "eq" "guides" }}
+{{ $version   := index (split .File.Path "/") 1 }}
 <nav class="navbar is-primary">
   <div class="navbar-brand is-hidden-tablet">
     <a class="navbar-item" href="{{ $home }}">
@@ -34,8 +35,9 @@
       </a>
 
       {{ range $docs }}
-      {{ $isRoot := eq (len (split .File.Path "/")) 2 }}
-      {{ if not $isRoot }}
+      {{ $isRoot           := eq (len (split .File.Path "/")) 2 }}
+      {{ $isCurrentVersion := eq $version (index (split .File.Path "/") 1) }}
+      {{ if and (not $isRoot) $isCurrentVersion }}
       <a class="navbar-item" href="{{ .URL }}">
         {{ .Title }}
       </a>
@@ -50,7 +52,8 @@
 
       {{ range $tutorials }}
       {{ $isRoot := eq (len (split .File.Path "/")) 2 }}
-      {{ if not $isRoot }}
+      {{ $isCurrentVersion := eq $version (index (split .File.Path "/") 1) }}
+      {{ if and (not $isRoot) $isCurrentVersion }}
       <a class="navbar-item" href="{{ .URL }}">
         {{ .Title }}
       </a>
@@ -65,7 +68,8 @@
 
       {{ range $guides }}
       {{ $isRoot := eq (len (split .File.Path "/")) 2 }}
-      {{ if not $isRoot }}
+      {{ $isCurrentVersion := eq $version (index (split .File.Path "/") 1) }}
+      {{ if and (not $isRoot) $isCurrentVersion }}
       <a class="navbar-item" href="{{ .URL }}">
         {{ .Title }}
       </a>


### PR DESCRIPTION
At the moment, the mobile navbar dropdown is showing all docs for all versions. With this PR, only the docs in the currently selected version are shown.


<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->