### PR TITLE
Return eval_builtin_error instead of eval_internal_error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+- Update topdown to return `eval_builtin_error` instead of
+  `eval_internal_error`.
+
 ## 0.10.7
 
 This release publishes the Hugo-based documentation to GitHub Pages :tada:

--- a/docs/content/docs/how-do-i-test-policies.md
+++ b/docs/content/docs/how-do-i-test-policies.md
@@ -150,7 +150,7 @@ of the tests that failed or errored.
 $ opa test pass_fail_error_test.rego
 data.example.test_failure: FAIL (253ns)
 data.example.test_error: ERROR (289ns)
-  pass_fail_error_test.rego:15: eval_internal_error: div: divide by zero
+  pass_fail_error_test.rego:15: eval_builtin_error: div: divide by zero
 --------------------------------------------------------------------------------
 PASS: 1/3
 FAIL: 1/3

--- a/topdown/builtins.go
+++ b/topdown/builtins.go
@@ -174,7 +174,7 @@ func handleBuiltinErr(name string, loc *ast.Location, err error) error {
 		}
 	default:
 		return &Error{
-			Code:     InternalErr,
+			Code:     BuiltinErr,
 			Message:  fmt.Sprintf("%v: %v", string(name), err.Error()),
 			Location: loc,
 		}

--- a/topdown/errors.go
+++ b/topdown/errors.go
@@ -36,6 +36,11 @@ const (
 	// a value of an inappropriate type.
 	TypeErr string = "eval_type_error"
 
+	// BuiltinErr indicates a built-in function received a semantically invalid
+	// input or encountered some kind of runtime error, e.g., connection
+	// timeout, connection refused, etc.
+	BuiltinErr string = "eval_builtin_error"
+
 	// WithMergeErr indicates that the real and replacement data could not be merged.
 	WithMergeErr string = "eval_with_merge_error"
 )

--- a/topdown/http_test.go
+++ b/topdown/http_test.go
@@ -590,7 +590,7 @@ func TestHTTPSClient(t *testing.T) {
 
 	t.Run("Negative Test: No Root Ca", func(t *testing.T) {
 
-		expectedResult := Error{Code: InternalErr, Message: "x509: certificate signed by unknown authority", Location: nil}
+		expectedResult := Error{Code: BuiltinErr, Message: "x509: certificate signed by unknown authority", Location: nil}
 		data := loadSmallTestData()
 		rule := []string{fmt.Sprintf(
 			`p = x { http.send({"method": "get", "url": "%s", "tls_client_cert_file": "%s", "tls_client_key_file": "%s"}, x) }`, s.URL, localClientCertFile, localClientKeyFile)}
@@ -601,7 +601,7 @@ func TestHTTPSClient(t *testing.T) {
 
 	t.Run("Negative Test: Wrong Cert/Key Pair", func(t *testing.T) {
 
-		expectedResult := Error{Code: InternalErr, Message: "tls: private key does not match public key", Location: nil}
+		expectedResult := Error{Code: BuiltinErr, Message: "tls: private key does not match public key", Location: nil}
 		data := loadSmallTestData()
 		rule := []string{fmt.Sprintf(
 			`p = x { http.send({"method": "get", "url": "%s", "tls_ca_cert_file": "%s", "tls_client_cert_file": "%s", "tls_client_key_file": "%s"}, x) }`, s.URL, localCaFile, localClientCert2File, localClientKeyFile)}
@@ -612,7 +612,7 @@ func TestHTTPSClient(t *testing.T) {
 
 	t.Run("Negative Test: System Certs do not include local rootCA", func(t *testing.T) {
 
-		expectedResult := Error{Code: InternalErr, Message: "x509: certificate signed by unknown authority", Location: nil}
+		expectedResult := Error{Code: BuiltinErr, Message: "x509: certificate signed by unknown authority", Location: nil}
 		data := loadSmallTestData()
 		rule := []string{fmt.Sprintf(
 			`p = x { http.send({"method": "get", "url": "%s", "tls_client_cert_file": "%s", "tls_client_key_file": "%s", "tls_use_system_certs": true}, x) }`, s.URL, localClientCertFile, localClientKeyFile)}


### PR DESCRIPTION
Previously unexpected built-in errors resulted in topdown returning
the eval_internal_error code. This makes it hard for callers to
differentiate between actual internal errors in topdown and errors
that are caused by, e.g., invalid built-in inputs.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>