### PR TITLE
Add legacy gitbook url redirect for doc pages

### DIFF
--- a/docs/layouts/index.redirects
+++ b/docs/layouts/index.redirects
@@ -9,5 +9,8 @@
 
 {{- range $docRedirects }}
 /docs/{{ . }}     /docs/v{{ $latest }}/{{ . }}
+
+# Legacy git book redirects
+/docs/{{ . }}.html /docs/v{{ $latest }}/{{ . }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
The older gitbook urls had the pages suffixed with `.html` but the newer netlify ones do not.

This provides a redirect shim to help keep old links alive.

Fixes: 1346
Signed-off-by: Patrick East <east.patrick@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
