### PR TITLE
Hid the overflow within .headline caused by the boat rocking

### DIFF
--- a/docs/static/css/home.css
+++ b/docs/static/css/home.css
@@ -369,6 +369,7 @@ main {
 }
 
 .headline {
+  overflow: hidden;
   position: relative;
   padding: 0 0 240px;
 }


### PR DESCRIPTION
The boat rocking was causing the webpage to allow for scrolling sideways at some points due to the 100% width element rotating slightly.
Rather than doing weird calculations to reduce it's size or put it in the middle or w/e it seemed easiest to allow it to rotate off the screen but have the overflow be hidden.

There seems to be no adverse effects when resizing in Firefox however it could be worth trying in other browsers.

![Image of the issue](https://user-images.githubusercontent.com/9866621/56584176-24b72d00-65d3-11e9-8c12-42f56c51c69a.png)
