### PR TITLE
Fix type inferencing on object keys

### DIFF
--- a/ast/check.go
+++ b/ast/check.go
@@ -373,7 +373,8 @@ func unify1(env *TypeEnv, term *Term, tpe types.Type, union bool) bool {
 			return unify1Object(env, v, tpe, union)
 		case types.Any:
 			if types.Compare(tpe, types.A) == 0 {
-				v.Foreach(func(_, value *Term) {
+				v.Foreach(func(key, value *Term) {
+					unify1(env, key, types.A, true)
 					unify1(env, value, types.A, true)
 				})
 				return true


### PR DESCRIPTION
Given an = expression where both sides are unknown (e.g,. a = [1,x]
where a is ??? and x is ???) the inferencing will produce any types
for variables. However, there was a bug in the case that handles
objects where any was not produced for object _keys_, only
_values_. As a result, the object's type would remain partially
unknown and the checker generated errors.

This commit just corrects the inferencing to assign any to object keys
when the other side of the = expression is of type any.

Fixes #1361

Signed-off-by: Torin Sandall <torinsandall@gmail.com>