### PR TITLE
Fix extra ‘v’ in older versions of the docs

### DIFF
--- a/docs/content/ceph-authorization.md
+++ b/docs/content/ceph-authorization.md
@@ -520,7 +520,7 @@ spec:
     spec:
       containers:
         - name: opa
-          image: openpolicyagent/opa:{{< latest >}}
+          image: openpolicyagent/opa:{{< current_version >}}
           ports:
           - name: http
             containerPort: 8181

--- a/docs/content/decision-logs.md
+++ b/docs/content/decision-logs.md
@@ -37,7 +37,7 @@ represents a policy decision returned by OPA.
     "labels": {
       "app": "my-example-app",
       "id": "1780d507-aea2-45cc-ae50-fa153c8e4a5a",
-      "version": "{{< latest >}}"
+      "version": "{{< current_version >}}"
     },
     "decision_id": "4ca636c1-55e4-417a-b1d8-4aceb67960d1",
     "revision": "W3sibCI6InN5cy9jYXRhbG9nIiwicyI6NDA3MX1d",

--- a/docs/content/deployments.md
+++ b/docs/content/deployments.md
@@ -17,7 +17,7 @@ recommend you review this section to familiarize yourself with the basics.
 
 OPA releases are available as images on Docker Hub.
 
-* [openpolicyagent/opa:{{< latest >}}](https://hub.docker.com/r/openpolicyagent/opa/)
+* [openpolicyagent/opa](https://hub.docker.com/r/openpolicyagent/opa/)
 
 ### Running with Docker
 
@@ -177,7 +177,7 @@ spec:
     spec:
       containers:
       - name: opa
-        image: openpolicyagent/opa:{{< latest >}}
+        image: openpolicyagent/opa:{{< current_docker_version >}}
         ports:
         - name: http
           containerPort: 8181
@@ -246,7 +246,7 @@ to call. For example:
 ```yaml
 containers:
 - name: opa
-  image: openpolicyagent/opa:{{< latest >}}
+  image: openpolicyagent/opa:{{< current_docker_version >}}
   ports:
   - name: http
     containerPort: 8181

--- a/docs/content/get-started.md
+++ b/docs/content/get-started.md
@@ -40,13 +40,13 @@ If this is your first time using OPA, download the latest executable for your sy
 On macOS (64-bit):
 
 ```shell
-curl -L -o opa https://github.com/open-policy-agent/opa/releases/download/{{< latest >}}/opa_darwin_amd64
+curl -L -o opa https://github.com/open-policy-agent/opa/releases/download/{{< current_version >}}/opa_darwin_amd64
 ```
 
 On Linux (64-bit):
 
 ```shell
-curl -L -o opa https://github.com/open-policy-agent/opa/releases/download/{{< latest >}}/opa_linux_amd64
+curl -L -o opa https://github.com/open-policy-agent/opa/releases/download/{{< current_version >}}/opa_linux_amd64
 ```
 
 > Windows users can obtain the OPA executable from [GitHub Releases](https://github.com/open-policy-agent/opa/releases). The steps below are the same for Windows users except the executable name will be different.

--- a/docs/content/http-api-authorization.md
+++ b/docs/content/http-api-authorization.md
@@ -33,7 +33,7 @@ First, create a `docker-compose.yml` file that runs OPA and the demo web server.
 version: '2'
 services:
   opa:
-    image: openpolicyagent/opa:{{< latest >}}
+    image: openpolicyagent/opa:{{< current_docker_version >}}
     ports:
       - 8181:8181
     # WARNING: OPA is NOT running with an authorization policy configured. This

--- a/docs/content/kafka-authorization.md
+++ b/docs/content/kafka-authorization.md
@@ -52,7 +52,7 @@ version: "2"
 services:
   opa:
     hostname: opa
-    image: openpolicyagent/opa:{{< latest >}}
+    image: openpolicyagent/opa:{{< current_docker_version >}}
     ports:
       - 8181:8181
     # WARNING: OPA is NOT running with an authorization policy configured. This

--- a/docs/content/kubernetes-admission-control.md
+++ b/docs/content/kubernetes-admission-control.md
@@ -173,7 +173,7 @@ spec:
         # authentication and authorization on the daemon. See the Security page for
         # details: https://www.openpolicyagent.org/docs/security.html.
         - name: opa
-          image: openpolicyagent/opa:{{< latest >}}
+          image: openpolicyagent/opa:{{< current_docker_version >}}
           args:
             - "run"
             - "--server"

--- a/docs/content/ssh-and-sudo-authorization.md
+++ b/docs/content/ssh-and-sudo-authorization.md
@@ -54,7 +54,7 @@ represent our backend and frontend hosts.
 version: '2'
 services:
   opa:
-    image: openpolicyagent/opa:{{< latest >}}
+    image: openpolicyagent/opa:{{< current_docker_version >}}
     ports:
       - 8181:8181
     # WARNING: OPA is NOT running with an authorization policy configured. This

--- a/docs/content/status.md
+++ b/docs/content/status.md
@@ -38,7 +38,7 @@ on the agent, updates will be sent to `/status`.
     "labels": {
         "app": "my-example-app",
         "id": "1780d507-aea2-45cc-ae50-fa153c8e4a5a",
-        "version": "{{< latest >}}"
+        "version": "{{< current_version >}}"
     },
     "bundle": {
         "name": "http/example/authz",

--- a/docs/website/layouts/shortcodes/current_docker_version.html
+++ b/docs/website/layouts/shortcodes/current_docker_version.html
@@ -1,0 +1,6 @@
+{{- $version := index (split $.Page.File.Path "/") 1 -}}
+{{- if (eq $version "edge") -}}
+latest
+{{- else -}}
+{{- strings.TrimPrefix "v" $version -}}
+{{- end -}}

--- a/docs/website/layouts/shortcodes/current_version.html
+++ b/docs/website/layouts/shortcodes/current_version.html
@@ -1,0 +1,1 @@
+{{ index (split $.Page.File.Path "/") 1 }}

--- a/docs/website/layouts/shortcodes/latest.html
+++ b/docs/website/layouts/shortcodes/latest.html
@@ -1,1 +1,11 @@
-{{ index site.Data.releases 0 }}
+{{/* TODO: Remove this once we drop these versions from the docs!!
+    The "latest" shortcode shouldn't be used in newer docs. Use
+    one of the more specific "current_version", "latest_version",
+    or "current_docker_version" instead.    
+*/}}
+{{- $version := index (split $.Page.File.Path "/") 1 -}}
+{{- if (or (eq $version "v0.10.6") (eq $version "v0.10.7")) -}}
+{{- strings.TrimPrefix "v" $version -}}
+{{- else -}}
+{{- $version -}}
+{{- end -}}

--- a/docs/website/layouts/shortcodes/latest_version.html
+++ b/docs/website/layouts/shortcodes/latest_version.html
@@ -1,0 +1,1 @@
+{{- index site.Data.releases 0 -}}


### PR DESCRIPTION
The older markdown still had `v{{< version >}}` shortcodes being used
which broke when the version changed to include the “v” in it.

This adds in some backwards compatibility logic for the shortcode and
adds newer, more specific, ones to replace it going forward. Part of
The issue is that typically the documentation will only want to
Reference the version that it is documenting and not always the
latest.

Fixes: #1382
Signed-off-by: Patrick East <east.patrick@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
