### PR TITLE
Use “latest” in sidenav instead of explicit version

### DIFF
--- a/docs/website/layouts/index.redirects
+++ b/docs/website/layouts/index.redirects
@@ -9,8 +9,8 @@
 /docs/latest/*     /docs/{{ $latest }}/:splat     200
 
 {{- range $docRedirects }}
-/docs/{{ . }}     /docs/{{ $latest }}/{{ . }}
+/docs/{{ . }}     /docs/latest/{{ . }}
 
 # Legacy git book redirects
-/docs/{{ . }}.html /docs/{{ $latest }}/{{ . }}
+/docs/{{ . }}.html /docs/latest/{{ . }}
 {{- end }}

--- a/docs/website/layouts/partials/docs/article.html
+++ b/docs/website/layouts/partials/docs/article.html
@@ -5,7 +5,7 @@
   {{ with (eq $version "edge") }}
   <div class="message is-danger">
     <div class="message-body">
-      This version is still under development! Latest stable release is <a href="/docs/{{ $latest }}">{{ $latest }}</a>
+      This version is still under development! Latest stable release is <a href="/docs/latest">{{ $latest }}</a>
     </div>
   </div>
   {{ end }}

--- a/docs/website/layouts/partials/docs/dashboard.html
+++ b/docs/website/layouts/partials/docs/dashboard.html
@@ -45,7 +45,11 @@
           <div class="dropdown-content">
             {{ range $releases }}
             {{ $isLatest := eq . (index site.Data.releases 0) }}
-            <a href="/docs/{{ . }}" class="dropdown-item">
+            {{ $verRef := . }}
+            {{ if $isLatest }}
+              {{ $verRef = "latest" }}
+            {{ end }}
+            <a href="/docs/{{ $verRef }}" class="dropdown-item">
               {{ . }}
               {{ if $isLatest }}
               <span class="tag latest-tag is-success is-small has-text-weight-bold">

--- a/docs/website/layouts/partials/docs/sidenav-link.html
+++ b/docs/website/layouts/partials/docs/sidenav-link.html
@@ -1,0 +1,25 @@
+{{/* Expect to have context bound to ".ctx", and the top level
+     "version" and "pageUrl" passed in with the context.
+ */}}
+{{- $latest     := index site.Data.releases 0 -}}
+{{/* In the current "ctx" the file path refers to the doc we are linking to, not the page we are on */}}
+{{- $contentVersion := index (split .ctx.File.Path "/") 1 -}}
+{{- $isRoot := eq (len (split .ctx.File.Path "/")) 2 -}}
+{{- $isThisPage := eq .ctx.URL .pageUrl -}}
+{{- $title := cond (isset .ctx.Params "navtitle") (.ctx.Params.navtitle) .ctx.Title -}}
+{{- if not $isRoot -}}
+{{- if eq .version $contentVersion -}}
+{{- $linkRef := .ctx.URL -}}
+{{- if or (eq $contentVersion $latest) -}}
+{{- $linkRef = (replace $linkRef $contentVersion "latest") -}}
+{{- end -}}
+<a class="docs-nav-item{{ if $isThisPage }} is-active{{ end }}" href="{{ $linkRef }}">
+  {{ $title }}
+</a>
+{{- if $isThisPage -}}
+<div class="toc">
+  {{ .ctx.TableOfContents }}
+</div>
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/docs/website/layouts/partials/docs/sidenav.html
+++ b/docs/website/layouts/partials/docs/sidenav.html
@@ -6,11 +6,16 @@
 {{ $pageUrl    := .URL }}
 {{ $isDocsHome := eq .URL $docsHome.URL }}
 {{ $version    := index (split .File.Path "/") 1 }}
+{{ $latest     := index site.Data.releases 0 }}
 <span class="docs-nav-title">
   Documentation
 </span>
 
-<a class="docs-nav-item{{ if $isDocsHome }} is-active{{ end }}" href="{{ $docsHome.URL }}">
+{{ $docsHomeVersion := $version }}
+{{ if or (eq $version $latest) }}
+  {{ $docsHomeVersion = "latest" }}
+{{ end }}
+<a class="docs-nav-item{{ if $isDocsHome }} is-active{{ end }}" href="/docs/{{ $docsHomeVersion }}">
   {{ $docsHome.Name }}
 </a>
 
@@ -21,21 +26,7 @@
 {{ end }}
 
 {{ range $docs }}
-{{ $isRoot     := eq (len (split .File.Path "/")) 2 }}
-{{ if not $isRoot }}
-{{ $isThisPage := eq .URL $pageUrl }}
-{{ if eq $version (index (split .File.Path "/") 1) }}
-{{ $title      := cond (isset .Params "navtitle") (.Params.navtitle) .Title }}
-<a class="docs-nav-item{{ if $isThisPage }} is-active{{ end }}" href="{{ .URL }}">
-  {{ $title }}
-</a>
-{{ if $isThisPage }}
-<div class="toc">
-  {{ .TableOfContents }}
-</div>
-{{ end }}
-{{ end }}
-{{ end }}
+  {{ partial "docs/sidenav-link.html" (dict "ctx" . "pageUrl" $pageUrl "version" $version) }}
 {{ end }}
 
 <hr class="docs-nav-hr" />
@@ -45,21 +36,7 @@
 </span>
 
 {{ range $tutorials }}
-{{ $isRoot     := eq (len (split .File.Path "/")) 2 }}
-{{ if not $isRoot }}
-{{ $isThisPage := eq .URL $pageUrl }}
-{{ if eq $version (index (split .File.Path "/") 1) }}
-{{ $title      := cond (isset .Params "navtitle") (.Params.navtitle) .Title }}
-<a class="docs-nav-item{{ if $isThisPage }} is-active{{ end }}" href="{{ .URL }}">
-  {{ $title }}
-</a>
-{{ if $isThisPage }}
-<div class="toc">
-  {{ .TableOfContents }}
-</div>
-{{ end }}
-{{ end }}
-{{ end }}
+{{ partial "docs/sidenav-link.html" (dict "ctx" . "pageUrl" $pageUrl "version" $version) }}
 {{ end }}
 
 {{ with $guides }}
@@ -70,20 +47,6 @@
 </span>
 
 {{ range . }}
-{{ $isRoot     := eq (len (split .File.Path "/")) 2 }}
-{{ if not $isRoot }}
-{{ $isThisPage := eq .URL $pageUrl }}
-{{ if eq $version (index (split .File.Path "/") 1) }}
-{{ $title      := cond (isset .Params "navtitle") (.Params.navtitle) .Title }}
-<a class="docs-nav-item{{ if $isThisPage }} is-active{{ end }}" href="{{ .URL }}">
-  {{ $title }}
-</a>
-{{ if $isThisPage }}
-<div class="toc">
-  {{ .TableOfContents }}
-</div>
-{{ end }}
-{{ end }}
-{{ end }}
+{{ partial "docs/sidenav-link.html" (dict "ctx" . "pageUrl" $pageUrl "version" $version) }}
 {{ end }}
 {{ end }}

--- a/docs/website/layouts/partials/home/banner.html
+++ b/docs/website/layouts/partials/home/banner.html
@@ -2,9 +2,8 @@
 {{ $description := site.Params.description }}
 {{ $tagline     := site.Params.tagline }}
 {{ $socialMenu  := site.Menus.social }}
-{{ $latest      := index site.Data.releases 0 }}
-{{ $docs        := printf "/docs/%s" $latest }}
-{{ $getStarted  := printf "/docs/%s/get-started" $latest }}
+{{ $docs        := "/docs/latest" }}
+{{ $getStarted  := "/docs/latest/get-started" }}
 <header role="banner">
   <nav class="nav--banner" role="navigation">
     <ul class="nav--menu">


### PR DESCRIPTION
Before this the links were built with the explicit version, we now
check for whether some page is the latest version and swap in “latest”
for the url instead.

With this someone browsing the docs should get everything with the "latest" url and
only need to use the versioned ones for older versions. If you navigate to the latest
version explicitly it will still work but the links anywhere else will have the "latest"
alias used in them instead so it should get them back on track the next time they
navigate somewhere.

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
