### PR TITLE
Add 'provenance' query parameter

### DIFF
--- a/docs/content/rest-api.md
+++ b/docs/content/rest-api.md
@@ -725,6 +725,7 @@ The path separator is used to access values inside object and array documents. I
 
 - **input** - Provide an input document. Format is a JSON value that will be used as the value for the input document.
 - **pretty** - If parameter is `true`, response will formatted for humans.
+- **provenance** - If parameter is `true`, response will include build/version info in addition to the result.  See [Provenance](#provenance) for more detail.
 - **explain** - Return query explanation in addition to result. Values: **full**.
 - **metrics** - Return query performance metrics in addition to result. See [Performance Metrics](#performance-metrics) for more detail.
 - **instrument** - Instrument query evaluation and return a superset of performance metrics in addition to result. See [Performance Metrics](#performance-metrics) for more detail.
@@ -1042,6 +1043,7 @@ The request body contains an object that specifies a value for [The input Docume
 
 - **partial** - Use the partial evaluation (optimization) when evaluating the query.
 - **pretty** - If parameter is `true`, response will formatted for humans.
+- **provenance** - If parameter is `true`, response will include build/version info in addition to the result.  See [Provenance](#provenance) for more detail.
 - **explain** - Return query explanation in addition to result. Values: **full**.
 - **metrics** - Return query performance metrics in addition to result. See [Performance Metrics](#performance-metrics) for more detail.
 - **instrument** - Instrument query evaluation and return a superset of performance metrics in addition to result. See [Performance Metrics](#performance-metrics) for more detail.
@@ -1934,6 +1936,51 @@ specify the `instrument=true` query parameter when executing the API call.
 Query instrumentation can help diagnose performance problems, however, it can
 add significant overhead to query evaluation. We recommend leaving query
 instrumentation off unless you are debugging a performance problem.
+
+## Provenance
+
+OPA can report provenance information at runtime. Provenance information can
+be requested on individual API calls and are returned inline with the API
+response. To obtain provenance information on an API call, specify the
+`provenance=true` query parameter when executing the API call. Provenance information
+is currently supported for the following APIs:
+
+- Data API (GET and POST)
+
+For example:
+
+```http
+POST /v1/data/example?provenance=true HTTP/1.1
+```
+
+Response:
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+```
+
+```json
+{
+  "provenance": {
+    "build_commit": "1955fc4d",
+    "build_host": "foo.com",
+    "build_timestamp": "2019-04-29T23:42:04Z",
+    "revision": "ID-b1298a6c-6ad8-11e9-a26f-d38b5ceadad5",
+    "version": "0.10.8-dev"
+  },
+  "result": true
+}
+```
+
+OPA currently supports the following query provenance information:
+
+- **version**: The version of this OPA instance.
+- **build_commit**: The git commit id of this OPA build.
+- **build_timestamp**: The timestamp when this instance was built.
+- **build_host**: The hostname where this instance was built.
+- **revision**: The _revision_ string included in a .manifest file (if present) within a bundle.
+
 
 ## Watches
 

--- a/server/server.go
+++ b/server/server.go
@@ -892,6 +892,7 @@ func (s *Server) v1DataGet(w http.ResponseWriter, r *http.Request) {
 	explainMode := getExplain(r.URL.Query()["explain"], types.ExplainOffV1)
 	includeMetrics := getBoolParam(r.URL, types.ParamMetricsV1, true)
 	includeInstrumentation := getBoolParam(r.URL, types.ParamInstrumentV1, true)
+	provenance := getBoolParam(r.URL, types.ParamProvenanceV1, true)
 
 	m.Timer(metrics.RegoQueryParse).Start()
 
@@ -970,6 +971,10 @@ func (s *Server) v1DataGet(w http.ResponseWriter, r *http.Request) {
 
 	if includeMetrics || includeInstrumentation {
 		result.Metrics = m.All()
+	}
+
+	if provenance {
+		result.Provenance = getProvenance(s.revision)
 	}
 
 	if len(rs) == 0 {
@@ -1072,6 +1077,7 @@ func (s *Server) v1DataPost(w http.ResponseWriter, r *http.Request) {
 	includeMetrics := getBoolParam(r.URL, types.ParamMetricsV1, true)
 	includeInstrumentation := getBoolParam(r.URL, types.ParamInstrumentV1, true)
 	partial := getBoolParam(r.URL, types.ParamPartialV1, true)
+	provenance := getBoolParam(r.URL, types.ParamProvenanceV1, true)
 
 	m.Timer(metrics.RegoQueryParse).Start()
 
@@ -1143,6 +1149,10 @@ func (s *Server) v1DataPost(w http.ResponseWriter, r *http.Request) {
 
 	if includeMetrics || includeInstrumentation {
 		result.Metrics = m.All()
+	}
+
+	if provenance {
+		result.Provenance = getProvenance(s.revision)
 	}
 
 	if len(rs) == 0 {
@@ -2364,4 +2374,15 @@ func parseURL(s string, useHTTPSByDefault bool) (*url.URL, error) {
 		s = scheme + s
 	}
 	return url.Parse(s)
+}
+
+func getProvenance(revision string) *types.ProvenanceV1 {
+
+	return &types.ProvenanceV1{
+		Version:   version.Version,
+		Vcs:       version.Vcs,
+		Timestamp: version.Timestamp,
+		Hostname:  version.Hostname,
+		Revision:  revision,
+	}
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/open-policy-agent/opa/storage/inmem"
 	"github.com/open-policy-agent/opa/util"
 	"github.com/open-policy-agent/opa/util/test"
+	"github.com/open-policy-agent/opa/version"
 	"github.com/pkg/errors"
 )
 
@@ -1359,6 +1360,32 @@ p = [1, 2, 3, 4] { true }`, 200, "")
 		t.Fatalf("Expected %v but got: %v", expected, result.Result)
 	}
 
+}
+
+func TestDataProvenance(t *testing.T) {
+
+	f := newFixture(t)
+
+	// Dummy up since we are not using ld...
+	// Note:  No bundle 'revision'...
+	version.Version = "0.10.7"
+	version.Vcs = "ac23eb45"
+	version.Timestamp = "today"
+	version.Hostname = "foo.bar.com"
+
+	req := newReqV1(http.MethodPost, "/data?provenance", "")
+	f.reset()
+	f.server.Handler.ServeHTTP(f.recorder, req)
+
+	var result types.DataResponseV1
+
+	if err := util.NewJSONDecoder(f.recorder.Body).Decode(&result); err != nil {
+		t.Fatalf("Unexpected JSON decode error: %v", err)
+	}
+
+	if result.Provenance == nil {
+		t.Fatalf("Expected non-nil provenance: %v", result.Provenance)
+	}
 }
 
 func TestDataMetrics(t *testing.T) {

--- a/server/types/types.go
+++ b/server/types/types.go
@@ -118,6 +118,15 @@ func (p PolicyV1) Equal(other PolicyV1) bool {
 	return p.ID == other.ID && p.Raw == other.Raw && p.AST.Equal(other.AST)
 }
 
+// ProvenanceV1 models a collection of build/version information.
+type ProvenanceV1 struct {
+	Version   string `json:"version"`
+	Vcs       string `json:"build_commit"`
+	Timestamp string `json:"build_timestamp"`
+	Hostname  string `json:"build_hostname"`
+	Revision  string `json:"revision,omitempty"`
+}
+
 // DataRequestV1 models the request message for Data API POST operations.
 type DataRequestV1 struct {
 	Input *interface{} `json:"input"`
@@ -125,10 +134,11 @@ type DataRequestV1 struct {
 
 // DataResponseV1 models the response message for Data API read operations.
 type DataResponseV1 struct {
-	DecisionID  string       `json:"decision_id,omitempty"`
-	Explanation TraceV1      `json:"explanation,omitempty"`
-	Metrics     MetricsV1    `json:"metrics,omitempty"`
-	Result      *interface{} `json:"result,omitempty"`
+	DecisionID  string        `json:"decision_id,omitempty"`
+	Provenance  *ProvenanceV1 `json:"provenance,omitempty"`
+	Explanation TraceV1       `json:"explanation,omitempty"`
+	Metrics     MetricsV1     `json:"metrics,omitempty"`
+	Result      *interface{}  `json:"result,omitempty"`
 }
 
 // DiagnosticsResponseV1 models the response message for diagnostics reads.
@@ -414,6 +424,10 @@ const (
 	// the client wants the partial evaluation optimization to be used during
 	// query evaluation.
 	ParamPartialV1 = "partial"
+
+	// ParamProvenanceV1 defines the name of the HTTP URL parameter that indicates
+	// the client wants build and version information in addition to the result.
+	ParamProvenanceV1 = "provenance"
 
 	// ParamWatchV1 defines the name of the HTTP URL parameter that indicates
 	// the client wants to set a watch on the current query or data reference.


### PR DESCRIPTION
(I did not create an issue for this as it seemed a quite straightforward minor feature.  If that is desired, please let me know and I'll write one up...  -PWM) 

This patch-set adds a new query parameter to OPA.  The _provenance=true_ parameter will include build/version information in the response to v1 Data GET/POST requests if specified on the URL.

The intent is to enable callers to obtain OPA provenance data along with specific policy responses, certain use cases my want/need to log this information along with other caller-specific datum.

A sample output (prettied) might look like:

```
{
  "provenance": {
    "build_commit": "61639aab",
    "build_hostname": "foo.bar.com",
    "build_timestamp": "2019-04-29T23:51:06Z",
    "revision": "playful-puppies with-kittens-and-unicorns",
    "version": "0.10.8-dev"
  },
  "result": true
}
```

The output includes a bundle .mainfest's _revision_ field, if present.   This allows the caller to record not only build/version data, but also a policy bundle identifier.