### PR TITLE
Raise error when loading empty module in bundle

### DIFF
--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -177,6 +177,10 @@ func (r *Reader) Read() (Bundle, error) {
 			if err != nil {
 				return bundle, errors.Wrap(err, "bundle load failed")
 			}
+			if module == nil {
+				return bundle, errors.Wrap(fmt.Errorf("module '%s' is empty", path), "bundle load failed")
+			}
+
 			file := ModuleFile{
 				Path:   path,
 				Raw:    buf.Bytes(),

--- a/bundle/bundle_test.go
+++ b/bundle/bundle_test.go
@@ -203,6 +203,7 @@ func TestReadErrorBadContents(t *testing.T) {
 			{"/a/b/data.json", "[1,2,3]"},
 			{"a/b/c/data.json", "true"},
 		}},
+		{[][2]string{{"/test.rego", ""}}},
 	}
 	for _, test := range tests {
 		buf := writeTarGz(test.files)

--- a/docs/content/bundles.md
+++ b/docs/content/bundles.md
@@ -125,9 +125,11 @@ metadata. The file should contain a JSON serialized object.
   defaults to `[""]` which means that ALL data and policy must come
   from the bundle.
 
-OPA will only load data files named `data.json`, i.e., you MUST name files
-that contain data (which you want loaded into OPA) `data.json` -- otherwise
-they will be ignored.
+* OPA will only load data files named `data.json`, i.e., you MUST name files
+  that contain data (which you want loaded into OPA) `data.json` -- otherwise
+  they will be ignored.
+
+* The `*.rego` policy files must be valid [Modules](/docs/{{< current_version >}}/how-do-i-write-policies#modules)
 
 ## Multiple Sources of Policy and Data
 


### PR DESCRIPTION
When we parse modules we won’t get an error back if the module contents
is empty, but we do get back a `nil` module value.

In the bundle loader we need to catch this before going further with
trying to load the module as it is not actually a valid module and
will break assumptions made about it.

According to the docs Modules must, at a minimum, have a package
declaration. With that in mind this seems like the right behavior to
enforce on the bundled rego files since we treat them as modules.

Fixes: #1393 