### PR TITLE
Add param to include bundle activation in /health response

### DIFF
--- a/docs/content/deployments.md
+++ b/docs/content/deployments.md
@@ -261,18 +261,17 @@ containers:
     name: example-policy
   livenessProbe:
     httpGet:
-      path: /health
       scheme: HTTP              # assumes OPA listens on localhost:8181
       port: 8181
     initialDelaySeconds: 5      # tune these periods for your environemnt
     periodSeconds: 5
   readinessProbe:
     httpGet:
-      path: /health
+      path: /health?bundle=true  # Include bundle activation in readiness
       scheme: HTTP
       port: 8181
     initialDelaySeconds: 5
     periodSeconds: 5
 ```
 
-See the [Monitoring](../monitoring) documentation for more detail on the `/health` API endpoint.
+See the [Health API](/docs/{{< current_version >}}/rest-api#health-api) documentation for more detail on the `/health` API endpoint.

--- a/docs/content/monitoring.md
+++ b/docs/content/monitoring.md
@@ -26,12 +26,7 @@ scrape_configs:
 ## Health Checks
 
 OPA exposes a `/health` API endpoint that can be used to perform health checks.
-The `/health` API endpoint executes a simple built-in policy query to verify
-that the server is operational. Clients should check that OPA returns an HTTP
-`200 OK` status. If a non-200 status is returned, clients should alarm.
-
-> The current health check implementation does not take into account bundle
-> activation.
+See [Health API](/docs/{{< current_version >}}/rest-api#health-api) for details.
 
 ## Diagnostics (Deprecated)
 

--- a/docs/content/rest-api.md
+++ b/docs/content/rest-api.md
@@ -1979,3 +1979,49 @@ The `bindings` field is a JSON object mapping `string`s to JSON values that desc
 If the watch was set on a data reference instead of a query, the `result` field will simply be the value of the document requested, instead of an array of values.
 
 
+## Health API
+
+The `/health` API endpoint executes a simple built-in policy query to verify
+that the server is operational. Optionally it can account for bundle activation as well
+(useful for "ready" checks at startup).
+
+#### Query Parameters
+`bundle` - Boolean parameter to account for bundle activation status in response.
+
+#### Status Codes
+- **200** - OPA service is healthy. If `bundle=true` the configured bundle has
+            been activated.
+- **500** - OPA service is not healthy. If `bundle=true` this can mean the
+            configured bundle has not yet been activated.
+
+> *Note*: The bundle activation check is only for initial startup. Subsequent downloads
+  will not affect the health check. The [Status](/docs/{{< current_version >}}/status)
+  API should be used for more fine-grained bundle status monitoring.
+
+#### Example Request
+```http
+GET /health HTTP/1.1
+```
+
+#### Example Request (bundle activation)
+```http
+GET /health?bundle=true HTTP/1.1
+```
+
+#### Healthy Response
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+```
+```json
+{}
+```
+
+#### Unhealthy Response
+```http
+HTTP/1.1 500 Internal Server Error
+Content-Type: application/json
+```
+```json
+{}
+```

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -29,6 +30,7 @@ import (
 	"github.com/open-policy-agent/opa/internal/manifest"
 	"github.com/open-policy-agent/opa/metrics"
 	"github.com/open-policy-agent/opa/plugins"
+	pluginBundle "github.com/open-policy-agent/opa/plugins/bundle"
 	"github.com/open-policy-agent/opa/server/identifier"
 	"github.com/open-policy-agent/opa/server/types"
 	"github.com/open-policy-agent/opa/storage"
@@ -58,6 +60,75 @@ func TestUnversionedGetHealth(t *testing.T) {
 	req := newReqUnversioned(http.MethodGet, "/health", "")
 	if err := f.executeRequest(req, 200, `{}`); err != nil {
 		t.Fatalf("Unexpected error while health check: %v", err)
+	}
+}
+
+func TestUnversionedGetHealthBundleNoBundleSet(t *testing.T) {
+
+	f := newFixture(t)
+
+	req := newReqUnversioned(http.MethodGet, "/health?bundle=true", "")
+	if err := f.executeRequest(req, 200, `{}`); err != nil {
+		t.Fatalf("Unexpected error while health check: %v", err)
+	}
+}
+
+func TestUnversionedGetHealthCheckBundleActivation(t *testing.T) {
+
+	f := newFixture(t)
+
+	// Initialize the server as if a bundle plugin was
+	// configured on the manager.
+	f.server.hasBundle = true
+	f.server.bundleStatusMtx = new(sync.RWMutex)
+
+	// The bundle hasnt been activated yet, expect it to be activated
+	req := newReqUnversioned(http.MethodGet, "/health?bundle=true", "")
+	if err := f.executeRequest(req, 500, `{}`); err != nil {
+		t.Fatalf("Unexpected error while health check: %v", err)
+	}
+
+	// Set the bundle to be activated.
+	status := pluginBundle.Status{}
+	status.SetActivateSuccess("")
+	f.server.updateBundleStatus(status)
+
+	// The heath check should now respond as healthy
+	req = newReqUnversioned(http.MethodGet, "/health?bundle=true", "")
+	if err := f.executeRequest(req, 200, `{}`); err != nil {
+		t.Fatalf("Unexpected error while health check: %v", err)
+	}
+}
+
+func TestInitWithBundlePlugin(t *testing.T) {
+	store := inmem.New()
+	m, err := plugins.New([]byte{}, "test", store)
+	if err != nil {
+		t.Fatalf("Unexpected error creating plugin manager: %s", err.Error())
+	}
+
+	m.Register(pluginBundle.Name, new(pluginBundle.Plugin))
+
+	server, err := New().
+		WithStore(store).
+		WithManager(m).
+		Init(context.Background())
+
+	if err != nil {
+		t.Fatalf("Unexpected error initializing server: %s", err.Error())
+	}
+
+	if server.hasBundle == false {
+		t.Error("server.hasBundle should be true")
+	}
+
+	if server.bundleStatusMtx == nil {
+		t.Error("server.bundleStatusMtx should be initialized")
+	}
+
+	isActivated := server.bundleActivated()
+	if isActivated {
+		t.Error("bundle should not be initialized to activated")
 	}
 }
 

--- a/server/types/types.go
+++ b/server/types/types.go
@@ -418,6 +418,11 @@ const (
 	// ParamWatchV1 defines the name of the HTTP URL parameter that indicates
 	// the client wants to set a watch on the current query or data reference.
 	ParamWatchV1 = "watch"
+
+	// ParamBundleActivationV1 defines the name of the HTTP URL parameter that
+	// indicates the client wants to include bundle activation in the results
+	// of the health API.
+	ParamBundleActivationV1 = "bundle"
 )
 
 // BadRequestErr represents an error condition raised if the caller passes


### PR DESCRIPTION
There is a new parameter for /health REST API which will include the
Configured bundle activation in the response. Example:

GET /health?bundle=true HTTP/1.1

Without the parameter the behavior stays the same, with it the server
will respond with 500’s until the status has been updated with an
activation time.

The docs for kubernetes ready probe has been updated to show this as
it makes for a better ready check than the original behavior when
remote bundles are being used.

Fixes: #1153
Signed-off-by: Patrick East <east.patrick@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
