### PR TITLE
Ignore query command line option

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -137,6 +137,7 @@ the data document with the following syntax:
 	}
 
 	runCommand.Flags().StringVarP(&params.ConfigFile, "config-file", "c", "", "set path of configuration file")
+	runCommand.Flags().StringVarP(&params.IgnoreQueries, "ignored-query-parameters", "", "", "comma separated list of URL query parameters to ignore")
 	runCommand.Flags().BoolVarP(&serverMode, "server", "s", false, "start the runtime in server mode")
 	runCommand.Flags().StringVarP(&params.HistoryPath, "history", "H", historyPath(), "set path of history file")
 	params.Addrs = runCommand.Flags().StringSliceP("addr", "a", []string{defaultAddr}, "set listening address of the server (e.g., [ip]:<port> for TCP, unix://<path> for UNIX domain socket)")

--- a/docs/content/rest-api.md
+++ b/docs/content/rest-api.md
@@ -1982,6 +1982,16 @@ OPA currently supports the following query provenance information:
 - **revision**: The _revision_ string included in a .manifest file (if present) within a bundle.
 
 
+## Restricting Query Parameters
+Some OPA deployments may need to restrict certain query parameters for security and/or other reasons. You can tell OPA to silently ignore specific query parameters by using the _--ignored-query-parameters_ commandline option.  When specfied, OPA will ignore the comma separated list of query parameters on all REST API calls.  For example:
+
+```
+opa run -s --ignored-query-parameters=metrics,explain
+```
+The above commandline tells OPA to silently ignore both _metrics_ and _explain_ query parameters on all REST API calls.  The response for those calls will be exactly as if the query parameter(s) were not present in the URLs.
+
+Note that OPA will add a startup log message with the value of the _--ignored-query-parameters_ option to the log.
+
 ## Watches
 
 OPA can set watches on queries and report whenever the result of evaluating the query has changed. When a watch is set on a query, the requesting connection will be maintained as the query results are streamed back in HTTP Chunked Encoding format. A notification reflecting a certain change to the query results will be delivered _at most once_. That is, if a watch is set on `data.x`, and then multiple writes are made to `data.x`, say `1`, `2` and `3`, only the notification reflecting `data.x=3` is always seen eventually (assuming the watch is not ended, there are no connection problems, etc). The notifications reflecting `data.x=1` and `data.x=2` _might_ be seen. However, the notifications sent are guaranteed to be in order (`data.x=2` will always come after `data.x=1`, if it comes).

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -135,6 +135,10 @@ type Params struct {
 	// GracefulShutdownPeriod is the time (in seconds) to wait for the http
 	// server to shutdown gracefully.
 	GracefulShutdownPeriod int
+
+	// ignore queries are a list of query parameters that are ignored by
+	// the REST api.
+	IgnoreQueries string
 }
 
 // LoggingConfig stores the configuration for OPA's logging behaviour.
@@ -265,6 +269,7 @@ func (rt *Runtime) StartServer(ctx context.Context) {
 		WithDiagnosticsBuffer(rt.Params.DiagnosticsBuffer).
 		WithDecisionIDFactory(rt.decisionIDFactory).
 		WithDecisionLoggerWithErr(rt.decisionLogger).
+		WithIgnoreQueries(rt.Params.IgnoreQueries).
 		WithRuntime(rt.info).
 		Init(ctx)
 
@@ -276,6 +281,11 @@ func (rt *Runtime) StartServer(ctx context.Context) {
 		if err := rt.startWatcher(ctx, rt.Params.Paths, onReloadLogger); err != nil {
 			logrus.WithField("err", err).Fatalf("Unable to open watch.")
 		}
+	}
+
+	// Document configured ignored queries, since these are silently ignored.
+	if rt.Params.IgnoreQueries != "" {
+		logrus.WithField("params", rt.Params.IgnoreQueries).Infof("Ignored query parameters")
 	}
 
 	s.Handler = NewLoggingHandler(s.Handler)

--- a/server/types/types.go
+++ b/server/types/types.go
@@ -393,6 +393,44 @@ type QueryRequestV1 struct {
 	Query string `json:"query"`
 }
 
+// ignoreQueries is a map of all possible HTTP URL parameters with a default 'ignore' value.
+// All URL paramters will query this map to see if they should be ignored.
+var ignoreQueries = map[string]bool{
+	ParamQueryV1:            false,
+	ParamInputV1:            false,
+	ParamPrettyV1:           false,
+	ParamExplainV1:          false,
+	ParamMetricsV1:          false,
+	ParamInstrumentV1:       false,
+	ParamPartialV1:          false,
+	ParamProvenanceV1:       false,
+	ParamWatchV1:            false,
+	ParamBundleActivationV1: false,
+}
+
+func IgnoreQuery(param string) bool {
+	// Specifically catch the case where a new query
+	// parameter is not added to above map
+	return ignoreQueries[param]
+}
+
+func SetIgnoreQueries(queries string, state bool) error {
+
+	s := strings.Split(queries, ",")
+	for i, _ := range s {
+		if s[i] == "" {
+			continue
+		}
+		_, ok := ignoreQueries[s[i]]
+		if ok == false {
+			return fmt.Errorf("Invalid/Unknown query parameter: %s", s[i])
+		}
+		ignoreQueries[s[i]] = state
+	}
+
+	return nil
+}
+
 const (
 	// ParamQueryV1 defines the name of the HTTP URL parameter that specifies
 	// values for the request query.


### PR DESCRIPTION
This patch set introduces a new runtime command line option:  _--ignored-query-parameters_.  The option takes a comma separated list of OPA URL query parameters which are subsequently (silently) ignored when present on REST API requests.    

The effect is that the response is identical to a similar request that does not have the offending query parameter present.

This provides for an additional layer of security in certain production deployments.  For example,     Administrators that do not wish to reveal the contents of a ruleset via the _explain_ query parameter could start opa as:

```
opa run -s --ignored-query-parameters=explain ...
```
Subsequent REST API requests containing the _explain_ query parameter receive responses without the additional _explain_ output.

All current query parameters are eligible for this option.  Each value is checked against known values and OPA will fail to start with an invalid parameter specified. 

The effects of the option are global, meaning that **all** REST APIs are affected (assuming the ignored query parameter is enabled for that particular call).

Because the ignore test is in the hot-path for a request, no logging of attempted references  is made.   That said, the initial option string is written to the log during startup to reduce user's and/or admins astonishment factor.