### PR TITLE
ast: Fix set deep copy

### DIFF
--- a/ast/term.go
+++ b/ast/term.go
@@ -1199,7 +1199,7 @@ type set struct {
 func (s *set) Copy() Set {
 	cpy := NewSet()
 	s.Foreach(func(x *Term) {
-		cpy.Add(x)
+		cpy.Add(x.Copy())
 	})
 	return cpy
 }

--- a/ast/term_test.go
+++ b/ast/term_test.go
@@ -558,6 +558,25 @@ func TestSetOperations(t *testing.T) {
 	}
 }
 
+func TestSetCopy(t *testing.T) {
+	orig := MustParseTerm("{1,2,3}")
+	cpy := orig.Copy()
+	Walk(NewGenericVisitor(func(x interface{}) bool {
+		if Compare(IntNumberTerm(2), x) == 0 {
+			x.(*Term).Value = String("modified")
+		}
+		return false
+	}), orig)
+	expOrig := MustParseTerm(`{1, "modified", 3}`)
+	expCpy := MustParseTerm(`{1,2,3}`)
+	if !expOrig.Equal(orig) {
+		t.Errorf("Expected %v but got %v", expOrig, orig)
+	}
+	if !expCpy.Equal(cpy) {
+		t.Errorf("Expected %v but got %v", expCpy, cpy)
+	}
+}
+
 func TestArrayOperations(t *testing.T) {
 
 	arr := MustParseTerm(`[1,2,3,4]`).Value.(Array)


### PR DESCRIPTION
The deep copy operation was not calling Copy on the set elements. This
manifested in issues in the REPL where parsed queries are retained and
used after the query compile runs. Since the query compile deep copies
the parsed query before mutating it, the REPL's parsed query was
getting corrupted.

Fixes #1406

Signed-off-by: Torin Sandall <torinsandall@gmail.com>