### PR TITLE
Add additional compiler metrics for each stage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ project adheres to [Semantic Versioning](http://semver.org/).
   or `Partial` calls.
 - Add new metric `rego_input_parse` and no longer count input parsing as time spent
   in the `rego_query_compile` step.
+- Add new compiler metrics for each stage using `compiler_stage_*` and
+  `query_compiler_stage_*` naming for each. These are enabled when
+  instrumentation is turned on for the Rego API, REPL, and REST API.
+- Change the `ast.Compiler` and `ast.QueryCompiler` API's for `WithExtraStage`
+  to require both a stage name and metric name.
+  
 
 ## 0.10.7
 

--- a/docs/content/rest-api.md
+++ b/docs/content/rest-api.md
@@ -1924,6 +1924,7 @@ Content-Type: application/json
 
 OPA currently supports the following query performance metrics:
 
+- **timer_rego_input_parse_ns**: time taken (in nanoseconds) to parse the input
 - **timer_rego_query_parse_ns**: time taken (in nanonseconds) to parse the query.
 - **timer_rego_query_compile_ns**: time taken (in nanonseconds) to compile the query.
 - **timer_rego_query_eval_ns**: time taken (in nanonseconds) to evaluate the query.
@@ -1936,6 +1937,10 @@ specify the `instrument=true` query parameter when executing the API call.
 Query instrumentation can help diagnose performance problems, however, it can
 add significant overhead to query evaluation. We recommend leaving query
 instrumentation off unless you are debugging a performance problem.
+
+When instrumentation is enabled there are several additional performance metrics
+for the compilation stages. They follow the format of `timer_compile_stage_*_ns`
+and `timer_query_compile_stage_*_ns` for the query and module compilation stages.
 
 ## Provenance
 
@@ -1980,7 +1985,6 @@ OPA currently supports the following query provenance information:
 - **build_timestamp**: The timestamp when this instance was built.
 - **build_host**: The hostname where this instance was built.
 - **revision**: The _revision_ string included in a .manifest file (if present) within a bundle.
-
 
 ## Watches
 

--- a/rego/rego_test.go
+++ b/rego/rego_test.go
@@ -255,6 +255,72 @@ func TestRegoMetrics(t *testing.T) {
 	}
 }
 
+func TestRegoInstrumentExtraEvalCompilerStage(t *testing.T) {
+	m := metrics.New()
+	r := New(Query("foo = 1"), Module("foo.rego", "package x"), Metrics(m), Instrument(true))
+	ctx := context.Background()
+	_, err := r.Eval(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	exp := []string{
+		"timer_query_compile_stage_rewrite_to_capture_value_ns",
+	}
+
+	all := m.All()
+
+	for _, name := range exp {
+		if _, ok := all[name]; !ok {
+			t.Errorf("expected to find %v but did not", name)
+		}
+	}
+}
+
+func TestRegoInstrumentExtraPartialCompilerStage(t *testing.T) {
+	m := metrics.New()
+	r := New(Query("foo = 1"), Module("foo.rego", "package x"), Metrics(m), Instrument(true))
+	ctx := context.Background()
+	_, err := r.Partial(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	exp := []string{
+		"timer_query_compile_stage_rewrite_equals_ns",
+	}
+
+	all := m.All()
+
+	for _, name := range exp {
+		if _, ok := all[name]; !ok {
+			t.Errorf("Expected to find %v but did not", name)
+		}
+	}
+}
+
+func TestRegoInstrumentExtraPartialResultCompilerStage(t *testing.T) {
+	m := metrics.New()
+	r := New(Query("input.x"), Module("foo.rego", "package x"), Metrics(m), Instrument(true))
+	ctx := context.Background()
+	_, err := r.PartialResult(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	exp := []string{
+		"timer_query_compile_stage_rewrite_for_partial_eval_ns",
+	}
+
+	all := m.All()
+
+	for _, name := range exp {
+		if _, ok := all[name]; !ok {
+			t.Errorf("Expected to find '%v' in metrics\n\nActual:\n %+v", name, all)
+		}
+	}
+}
+
 func TestRegoCatchPathConflicts(t *testing.T) {
 	r := New(
 		Query("data"),

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -583,6 +583,10 @@ func (r *REPL) recompile(ctx context.Context, cpy *ast.Module) error {
 
 	compiler := ast.NewCompiler().SetErrorLimit(r.errLimit)
 
+	if r.instrument {
+		compiler.WithMetrics(r.metrics)
+	}
+
 	if compiler.Compile(policies); compiler.Failed() {
 		return compiler.Errors
 	}
@@ -632,6 +636,10 @@ func (r *REPL) compileRule(ctx context.Context, rule *ast.Rule, unset bool) erro
 	}
 
 	compiler := ast.NewCompiler().SetErrorLimit(r.errLimit)
+
+	if r.instrument {
+		compiler.WithMetrics(r.metrics)
+	}
 
 	if compiler.Compile(policies); compiler.Failed() {
 		mod.Rules = prev
@@ -728,6 +736,10 @@ func (r *REPL) loadCompiler(ctx context.Context) (*ast.Compiler, error) {
 	}
 
 	compiler := ast.NewCompiler().SetErrorLimit(r.errLimit)
+
+	if r.instrument {
+		compiler.WithMetrics(r.metrics)
+	}
 
 	if compiler.Compile(policies); compiler.Failed() {
 		return nil, compiler.Errors


### PR DESCRIPTION
Each stage of the compiler now has its own timer when instrumentation
is enabled.

To keep things consistent the naming follows the lowercase and
underscore style that the existing ones have. Each stage now needs
to define not only its name but its metric name too.

This does make a change to the ast compiler API by requiring the
additional naming information when adding extra stages.

And example of the new metrics:

```
+----------------------------------------------------------+--------------------+
|                          METRIC                          |       VALUE        |
+----------------------------------------------------------+--------------------+
| counter_eval_op_virtual_cache_miss                       | 1                  |
| histogram_eval_op_plug_75%                               | 881                |

<snip>

| histogram_eval_op_rule_index_min                         | 12995              |
| histogram_eval_op_rule_index_stddev                      | 0                  |
| timer_compile_stage_check_recursion_ns                   | 3080               |
| timer_compile_stage_check_rule_conflicts_ns              | 3141               |
| timer_compile_stage_check_safety_rule_bodies_ns          | 26366              |
| timer_compile_stage_check_safety_rule_heads_ns           | 10365              |
| timer_compile_stage_check_types_ns                       | 13269              |
| timer_compile_stage_rebuild_indices_ns                   | 13742              |
| timer_compile_stage_resolve_refs_ns                      | 20219              |
| timer_compile_stage_rewrite_assignments_ns               | 27630              |
| timer_compile_stage_rewrite_comprehension_terms_ns       | 10804              |
| timer_compile_stage_rewrite_dynamic_terms_ns             | 12036              |
| timer_compile_stage_rewrite_equals_ns                    | 7569               |
| timer_compile_stage_rewrite_expr_terms_ns                | 14067              |
| timer_compile_stage_rewrite_refs_in_head_ns              | 25290              |
| timer_compile_stage_rewrite_with_values_ns               | 9931               |
| timer_compile_stage_set_graph_ns                         | 11567              |
| timer_compile_stage_set_module_tree_ns                   | 3739               |
| timer_compile_stage_set_rule_tree_ns                     | 3093               |
| timer_eval_op_plug_ns                                    | 3203               |
| timer_eval_op_rule_index_ns                              | 12995              |
| timer_query_compile_stage_check_safety_ns                | 60071              |
| timer_query_compile_stage_check_types_ns                 | 55424              |
| timer_query_compile_stage_resolve_refs_ns                | 20801              |
| timer_query_compile_stage_rewrite_assignments_ns         | 20198              |
| timer_query_compile_stage_rewrite_comprehension_terms_ns | 10297              |
| timer_query_compile_stage_rewrite_dynamic_terms_ns       | 10086              |
| timer_query_compile_stage_rewrite_expr_terms_ns          | 9161               |
| timer_query_compile_stage_rewrite_to_capture_value_ns    | 21270              |
| timer_query_compile_stage_rewrite_with_values_ns         | 7114               |
| timer_rego_input_parse_ns                                | 575                |
| timer_rego_module_compile_ns                             | 423224             |
| timer_rego_module_parse_ns                               | 481                |
| timer_rego_query_compile_ns                              | 237144             |
| timer_rego_query_eval_ns                                 | 149115             |
| timer_rego_query_parse_ns                                | 344023             |
+----------------------------------------------------------+--------------------+
```

Fixes: #1059

Signed-off-by: Patrick East <east.patrick@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
