### PR TITLE
Add a basic decision logger that just uses Logrus

### DIFF
--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -135,6 +135,7 @@ opa run --set-file "services.acmecorp.credentials.bearer.token=/var/run/secrets/
 It will read the contents of the file and set the config value with the token.
 
 ### Override Limitations
+#### Lists
 If using arrays/lists in the configuration the `--set` and `--set-file` overrides will not be able to
 patch sub-objects of the list. They will overwrite the entire index with the new object.
 
@@ -164,6 +165,23 @@ services:
 Because the entire `0` index was overwritten.
 
 It is highly recommended to use objects/maps instead of lists for configuration for this reason.
+
+#### Empty objects
+If you need to set an empty object with the CLI overrides, for example with plugin configuration like:
+
+```yaml
+decision_logger:
+  plugin: my_plugin
+
+plugins:
+  my_plugin:
+    # empty
+```
+
+You can do this by setting the value with `null`. For example:
+```
+opa run --set "decision_logger.plugin=my_plugin" --set "plugins.my_plugin=null"
+```
 
 ## Services
 

--- a/docs/content/decision-logs.md
+++ b/docs/content/decision-logs.md
@@ -67,3 +67,21 @@ Decision log updates contain the following fields:
 | `[_].requested_by` | `string` | Identifier for client that executed policy query, e.g., the client address. |
 | `[_].timestamp` | `string` | RFC3999 timestamp of policy decision. |
 | `[_].metrics` | `object` | Key-value pairs of [performance metrics](../rest-api#performance-metrics). |
+
+### Basic Decision Logger
+There is a `basic_decision_logger` plugin available for use with OPA that will log to stdout
+alongside the OPA server log messages.
+
+To enable this configure the server with:
+
+```yaml
+decision_logger:
+  plugin: basic_decision_logger
+
+plugins:
+  basic_decision_logger:
+```
+
+There are currently no config options for the the plugin.
+
+> **WARNING:** The decision logs contain unfiltered inputs and results. This may contain sensitive data!

--- a/docs/content/plugins.md
+++ b/docs/content/plugins.md
@@ -183,7 +183,7 @@ Finally, register your factory with OPA:
 
 ```golang
 func Init() {
-    runtime.RegisterPlugin("println_decision_logger", Factory{})
+    runtime.RegisterPlugin("println_decision_logger", new(Factory))
 }
 ```
 

--- a/plugins/logs/basic/plugin.go
+++ b/plugins/logs/basic/plugin.go
@@ -1,0 +1,79 @@
+// Copyright 2019 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package basic
+
+import (
+	"context"
+	"encoding/json"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/open-policy-agent/opa/plugins"
+	"github.com/open-policy-agent/opa/plugins/logs"
+	"github.com/open-policy-agent/opa/util"
+)
+
+type config struct {
+}
+
+// DecisionLogger is a local decision logger implementing logs.Logger
+// which will use Logrus to output logs.
+type DecisionLogger struct {
+	config config
+}
+
+// Start the plugin
+func (p *DecisionLogger) Start(ctx context.Context) error {
+	// No-op.
+	return nil
+}
+
+// Stop the plugin
+func (p *DecisionLogger) Stop(ctx context.Context) {
+	// No-op.
+}
+
+// Reconfigure the plugin
+func (p *DecisionLogger) Reconfigure(ctx context.Context, cfg interface{}) {
+	p.config = cfg.(config)
+}
+
+// Log an event (decision)
+func (p *DecisionLogger) Log(ctx context.Context, event logs.EventV1) error {
+	eventBuf, err := json.Marshal(&event)
+	if err != nil {
+		return err
+	}
+	fields := log.Fields{}
+	err = json.Unmarshal(eventBuf, &fields)
+	if err != nil {
+		return err
+	}
+	log.WithFields(fields).Info("Decision Log")
+	return nil
+}
+
+// DecisionLoggerFactory implements the plugins.Factory interface for the basic decision logger
+type DecisionLoggerFactory struct{}
+
+// New creates an instance of the basic DecisionLogger
+func (f *DecisionLoggerFactory) New(_ *plugins.Manager, cfg interface{}) plugins.Plugin {
+	logger := &DecisionLogger{
+		config: cfg.(config),
+	}
+
+	return logger
+}
+
+// Validate parses the config for the plugin
+func (f *DecisionLoggerFactory) Validate(_ *plugins.Manager, cfg []byte) (interface{}, error) {
+	parsedConfig := config{}
+	err := util.Unmarshal(cfg, &parsedConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return parsedConfig, err
+}

--- a/plugins/logs/basic/plugin_test.go
+++ b/plugins/logs/basic/plugin_test.go
@@ -1,0 +1,52 @@
+// Copyright 2019 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package basic
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/open-policy-agent/opa/metrics"
+	"github.com/open-policy-agent/opa/plugins/logs"
+)
+
+func TestFactory(t *testing.T) {
+	f := DecisionLoggerFactory{}
+
+	rawCfg := []byte("{}")
+	cfg, err := f.Validate(nil, rawCfg)
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err.Error())
+	}
+
+	p := f.New(nil, cfg)
+	if p == nil {
+		t.Fatalf("Plugin should not be nil")
+	}
+}
+
+func TestLog(t *testing.T) {
+	p := DecisionLogger{}
+	entry := logs.EventV1{
+		Labels: map[string]string{
+			"id":      "test-instance-id",
+			"app":     "example-app",
+			"version": "1.2.3",
+		},
+		Revision:    "399",
+		DecisionID:  "399",
+		Path:        "tda/bar",
+		Result:      nil,
+		RequestedBy: "test",
+		Timestamp:   time.Now(),
+		Metrics:     metrics.New().All(),
+	}
+
+	err := p.Log(context.Background(), entry)
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err.Error())
+	}
+}

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -25,6 +25,7 @@ import (
 	"github.com/open-policy-agent/opa/plugins"
 	"github.com/open-policy-agent/opa/plugins/discovery"
 	"github.com/open-policy-agent/opa/plugins/logs"
+	"github.com/open-policy-agent/opa/plugins/logs/basic"
 	"github.com/open-policy-agent/opa/repl"
 	"github.com/open-policy-agent/opa/server"
 	"github.com/open-policy-agent/opa/storage"
@@ -48,6 +49,13 @@ func RegisterPlugin(name string, factory plugins.Factory) {
 	registeredPluginsMux.Lock()
 	defer registeredPluginsMux.Unlock()
 	registeredPlugins[name] = factory
+}
+
+func registerSystemPlugins() {
+	// Any plugins that are always included with the OPA runtime should be
+	// registered here. It causes a dependency cycle to register them in
+	// their own init function and to do blank imports with the runtime..
+	RegisterPlugin("basic_decision_logger", new(basic.DecisionLoggerFactory))
 }
 
 // Params stores the configuration for an OPA instance.
@@ -575,4 +583,5 @@ func uuid4() (string, error) {
 
 func init() {
 	registeredPlugins = make(map[string]plugins.Factory)
+	registerSystemPlugins()
 }


### PR DESCRIPTION
The new `basic_decision_logger` is a plugin but always included with
OPA. When enabled it will log decisions via Logrus at the `info`
level.  It is turned off by default.

Fixes: #1334
Signed-off-by: Patrick East <east.patrick@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
