### PR TITLE
Add explanation mode to filter notes

### DIFF
--- a/cmd/eval.go
+++ b/cmd/eval.go
@@ -23,6 +23,7 @@ import (
 	"github.com/open-policy-agent/opa/rego"
 	"github.com/open-policy-agent/opa/storage/inmem"
 	"github.com/open-policy-agent/opa/topdown"
+	"github.com/open-policy-agent/opa/topdown/notes"
 	"github.com/open-policy-agent/opa/util"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -59,7 +60,7 @@ func newEvalCommandParams() evalCommandParams {
 			evalBindingsOutput,
 			evalPrettyOutput,
 		}),
-		explain: newExplainFlag([]string{explainModeOff, explainModeFull}),
+		explain: newExplainFlag([]string{explainModeOff, explainModeFull, explainModeNotes}),
 	}
 }
 
@@ -300,6 +301,8 @@ func eval(args []string, params evalCommandParams, w io.Writer) (bool, error) {
 	switch params.explain.String() {
 	case explainModeFull:
 		result.Explanation = *tracer
+	case explainModeNotes:
+		result.Explanation = notes.Filter(*tracer)
 	}
 
 	if m != nil {

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -6,6 +6,7 @@ package cmd
 
 import (
 	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/util"
 	"github.com/spf13/pflag"
 )
 
@@ -15,4 +16,18 @@ func setMaxErrors(fs *pflag.FlagSet, errLimit *int) {
 
 func setIgnore(fs *pflag.FlagSet, ignoreNames *[]string) {
 	fs.StringSliceVarP(ignoreNames, "ignore", "", []string{}, "set file and directory names to ignore during loading (e.g., '.*' excludes hidden files)")
+}
+
+const (
+	explainModeOff   = "off"
+	explainModeFull  = "full"
+	explainModeNotes = "notes"
+)
+
+func newExplainFlag(modes []string) *util.EnumFlag {
+	return util.NewEnumFlag(modes[0], modes)
+}
+
+func setExplain(fs *pflag.FlagSet, explain *util.EnumFlag) {
+	fs.VarP(explain, "explain", "", "enable query explanations")
 }

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -19,6 +19,7 @@ import (
 	pr "github.com/open-policy-agent/opa/internal/presentation"
 	"github.com/open-policy-agent/opa/profiler"
 	"github.com/open-policy-agent/opa/rego"
+	"github.com/open-policy-agent/opa/topdown/notes"
 
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/format"
@@ -61,8 +62,9 @@ type REPL struct {
 type explainMode int
 
 const (
-	explainOff   explainMode = iota
-	explainTrace explainMode = iota
+	explainOff explainMode = iota
+	explainTrace
+	explainNotes
 )
 
 const defaultPrettyLimit = 80
@@ -225,6 +227,8 @@ func (r *REPL) OneShot(ctx context.Context, line string) error {
 				return r.cmdPrettyLimit(cmd.args)
 			case "trace":
 				return r.cmdTrace()
+			case "notes":
+				return r.cmdNotes()
 			case "metrics":
 				return r.cmdMetrics()
 			case "instrument":
@@ -398,7 +402,8 @@ func (r *REPL) cmdShow(args []string) error {
 		return nil
 	} else if strings.Compare(args[0], "debug") == 0 {
 		debug := replDebug{
-			Trace:      r.traceEnabled(),
+			Trace:      r.explain == explainTrace,
+			Notes:      r.explain == explainNotes,
 			Metrics:    r.metricsEnabled(),
 			Instrument: r.instrument,
 			Profile:    r.profilerEnabled(),
@@ -417,13 +422,19 @@ func (r *REPL) cmdShow(args []string) error {
 // We use this struct to print REPL debug information in JSON string format.
 type replDebug struct {
 	Trace      bool `json:"trace"`
+	Notes      bool `json:"notes"`
 	Metrics    bool `json:"metrics"`
 	Instrument bool `json:"instrument"`
 	Profile    bool `json:"profile"`
 }
 
-func (r *REPL) traceEnabled() bool {
-	return r.explain == explainTrace
+func (r *REPL) cmdNotes() error {
+	if r.explain == explainNotes {
+		r.explain = explainOff
+	} else {
+		r.explain = explainNotes
+	}
+	return nil
 }
 
 func (r *REPL) cmdTrace() error {
@@ -467,7 +478,6 @@ func (r *REPL) profilerEnabled() bool {
 	return r.profiler
 }
 
-// This function cmdProfile will turn tracing (explain) off if profile is turned on
 func (r *REPL) cmdProfile() error {
 	if r.profiler {
 		r.profiler = false
@@ -835,7 +845,7 @@ func (r *REPL) evalBody(ctx context.Context, compiler *ast.Compiler, input ast.V
 		rego.Runtime(r.runtime),
 	}
 
-	if r.explain == explainTrace {
+	if r.explain != explainOff {
 		tracebuf = topdown.NewBufferTracer()
 		args = append(args, rego.Tracer(tracebuf))
 	}
@@ -857,11 +867,14 @@ func (r *REPL) evalBody(ctx context.Context, compiler *ast.Compiler, input ast.V
 	if r.profiler {
 		output.Profile = prof.ReportTopNResults(-1, pr.DefaultProfileSortOrder)
 	}
+
 	output = output.WithLimit(r.prettyLimit)
 
-	if r.explain != explainOff {
-		mangleTrace(ctx, r.store, r.txn, *tracebuf)
+	switch r.explain {
+	case explainTrace:
 		output.Explanation = *tracebuf
+	case explainNotes:
+		output.Explanation = notes.Filter(*tracebuf)
 	}
 
 	switch r.outputFormat {
@@ -903,8 +916,11 @@ func (r *REPL) evalPartial(ctx context.Context, compiler *ast.Compiler, input as
 		Error:   err,
 	}
 
-	if buf != nil {
+	switch r.explain {
+	case explainTrace:
 		output.Explanation = *buf
+	case explainNotes:
+		output.Explanation = notes.Filter(*buf)
 	}
 
 	switch r.outputFormat {
@@ -1053,7 +1069,8 @@ var builtin = [...]commandDesc{
 	{"json", []string{}, "set output format to JSON"},
 	{"pretty", []string{}, "set output format to pretty"},
 	{"pretty-limit", []string{}, "set pretty value output limit"},
-	{"trace", []string{}, "toggle full trace and turns off profiler"},
+	{"trace", []string{}, "toggle full trace"},
+	{"notes", []string{}, "toggle notes trace"},
 	{"metrics", []string{}, "toggle metrics"},
 	{"instrument", []string{}, "toggle instrumentation"},
 	{"profile", []string{}, "toggle profiler and turns off trace"},
@@ -1103,51 +1120,6 @@ func dumpStorage(ctx context.Context, store storage.Store, txn storage.Transacti
 	}
 	e := json.NewEncoder(w)
 	return e.Encode(data)
-}
-
-func mangleTrace(ctx context.Context, store storage.Store, txn storage.Transaction, trace []*topdown.Event) error {
-	for _, event := range trace {
-		if err := mangleEvent(ctx, store, txn, event); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func mangleEvent(ctx context.Context, store storage.Store, txn storage.Transaction, event *topdown.Event) error {
-
-	// Replace bindings with ref values with the values from storage.
-	cpy := event.Locals.Copy()
-	var err error
-	event.Locals.Iter(func(k, v ast.Value) bool {
-		if r, ok := v.(ast.Ref); ok {
-			var path storage.Path
-			path, err = storage.NewPathForRef(r)
-			if err != nil {
-				return true
-			}
-			var doc interface{}
-			doc, err = store.Read(ctx, txn, path)
-			if err != nil {
-				return true
-			}
-			v, err = ast.InterfaceToValue(doc)
-			if err != nil {
-				return true
-			}
-			cpy.Put(k, v)
-		}
-		return false
-	})
-	event.Locals = cpy
-
-	switch node := event.Node.(type) {
-	case *ast.Rule:
-		event.Node = node.Head //topdown.PlugHead(node.Head, event.Locals.Get)
-	case *ast.Expr:
-		event.Node = node // topdown.PlugExpr(node, event.Locals.Get)
-	}
-	return nil
 }
 
 func printHelp(output io.Writer, initPrompt string) {

--- a/repl/repl_test.go
+++ b/repl/repl_test.go
@@ -319,27 +319,39 @@ func TestShowDebug(t *testing.T) {
 	var buffer bytes.Buffer
 	repl := newRepl(store, &buffer)
 	repl.OneShot(ctx, "show debug")
-	expected := `{
-	"trace": false,
-	"metrics": false,
-	"instrument": false,
-	"profile": false
-}
-`
-	assertREPLText(t, buffer, expected)
+
+	var result replDebug
+
+	if err := util.Unmarshal(buffer.Bytes(), &result); err != nil {
+		t.Fatal(err)
+	}
+
+	var exp replDebug
+
+	if !reflect.DeepEqual(result, exp) {
+		t.Fatalf("Expected %+v but got %+v", exp, result)
+	}
+
 	buffer.Reset()
+
 	repl.OneShot(ctx, "trace")
 	repl.OneShot(ctx, "metrics")
 	repl.OneShot(ctx, "instrument")
 	repl.OneShot(ctx, "profile")
 	repl.OneShot(ctx, "show debug")
-	expected = `{
-	"trace": true,
-	"metrics": true,
-	"instrument": true,
-	"profile": true
-}
-`
+
+	exp.Trace = true
+	exp.Metrics = true
+	exp.Instrument = true
+	exp.Profile = true
+
+	if err := util.Unmarshal(buffer.Bytes(), &result); err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(result, exp) {
+		t.Fatalf("Expected %+v but got %+v", exp, result)
+	}
 }
 
 func TestShow(t *testing.T) {
@@ -1929,6 +1941,28 @@ Redo data.a[i].b.c[j] = x; data.a[k].b.c[x] = 1
 +---+---+---+---+`)
 	expected += "\n"
 
+	if expected != buffer.String() {
+		t.Fatalf("Expected output to be exactly:\n%v\n\nGot:\n\n%v\n", expected, buffer.String())
+	}
+}
+
+func TestEvalNotes(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore()
+	var buffer bytes.Buffer
+	repl := newRepl(store, &buffer)
+	repl.OneShot(ctx, `p { a = [1,2,3]; a[i] = x; x > 1; trace(sprintf("x = %d", [x])) }`)
+	repl.OneShot(ctx, "notes")
+	buffer.Reset()
+	repl.OneShot(ctx, "p")
+	expected := strings.TrimSpace(`Enter data.repl.p = _
+| Enter data.repl.p
+| | Note "x = 2"
+Redo data.repl.p = _
+| Redo data.repl.p
+| | Note "x = 3"
+true`)
+	expected += "\n"
 	if expected != buffer.String() {
 		t.Fatalf("Expected output to be exactly:\n%v\n\nGot:\n\n%v\n", expected, buffer.String())
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -38,6 +38,7 @@ import (
 	"github.com/open-policy-agent/opa/server/writer"
 	"github.com/open-policy-agent/opa/storage"
 	"github.com/open-policy-agent/opa/topdown"
+	"github.com/open-policy-agent/opa/topdown/notes"
 	"github.com/open-policy-agent/opa/util"
 	"github.com/open-policy-agent/opa/version"
 	"github.com/open-policy-agent/opa/watch"
@@ -1857,6 +1858,12 @@ func (s *Server) evalDiagnosticPolicy(r *http.Request) (logger diagnosticsLogger
 
 func (s *Server) getExplainResponse(explainMode types.ExplainModeV1, trace []*topdown.Event, pretty bool) (explanation types.TraceV1) {
 	switch explainMode {
+	case types.ExplainNotesV1:
+		var err error
+		explanation, err = types.NewTraceV1(notes.Filter(trace), pretty)
+		if err != nil {
+			break
+		}
 	case types.ExplainFullV1:
 		var err error
 		explanation, err = types.NewTraceV1(trace, pretty)
@@ -2105,6 +2112,8 @@ func getWatch(p []string) (watch bool) {
 func getExplain(p []string, zero types.ExplainModeV1) types.ExplainModeV1 {
 	for _, x := range p {
 		switch x {
+		case string(types.ExplainNotesV1):
+			return types.ExplainNotesV1
 		case string(types.ExplainFullV1):
 			return types.ExplainFullV1
 		}

--- a/server/types/types.go
+++ b/server/types/types.go
@@ -191,8 +191,9 @@ type ExplainModeV1 string
 
 // Explanation mode enumeration.
 const (
-	ExplainOffV1  ExplainModeV1 = "off"
-	ExplainFullV1 ExplainModeV1 = "full"
+	ExplainOffV1   ExplainModeV1 = "off"
+	ExplainFullV1  ExplainModeV1 = "full"
+	ExplainNotesV1 ExplainModeV1 = "notes"
 )
 
 // TraceV1 models the trace result returned for queries that include the

--- a/topdown/eval.go
+++ b/topdown/eval.go
@@ -253,13 +253,16 @@ func (e *eval) evalNot(iter evalIterator) error {
 	}
 
 	expr := e.query[e.index]
-	negation := expr.Complement().NoWith()
-	child := e.closure(ast.NewBody(negation))
+	negation := ast.NewBody(expr.Complement().NoWith())
+	child := e.closure(negation)
 
 	var defined bool
+	child.traceEnter(negation)
 
 	err := child.eval(func(*eval) error {
+		child.traceExit(negation)
 		defined = true
+		child.traceRedo(negation)
 		return nil
 	})
 

--- a/topdown/notes/notes.go
+++ b/topdown/notes/notes.go
@@ -1,0 +1,51 @@
+// Copyright 2019 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package notes
+
+import (
+	"github.com/open-policy-agent/opa/topdown"
+)
+
+// Filter returns a filtered trace that contains Note events contained in the
+// trace. The filtered trace also includes Enter and Redo events to explain the
+// lineage of the Note events.
+func Filter(trace []*topdown.Event) (result []*topdown.Event) {
+
+	qids := map[uint64]*topdown.Event{}
+
+	for _, event := range trace {
+		switch event.Op {
+		case topdown.NoteOp:
+			// Path will end with the Note event.
+			path := []*topdown.Event{event}
+
+			// Construct path of recorded Enter/Redo events that lead to the
+			// Note event. The path is constructed in reverse order by iterating
+			// backwards through the Enter/Redo events from the Note event.
+			curr := qids[event.QueryID]
+			var prev *topdown.Event
+
+			for curr != nil && curr != prev {
+				path = append(path, curr)
+				prev = curr
+				curr = qids[curr.ParentID]
+			}
+
+			// Add the path to the result, reversing it in the process.
+			for i := len(path) - 1; i >= 0; i-- {
+				result = append(result, path[i])
+			}
+
+			qids = map[uint64]*topdown.Event{}
+
+		case topdown.EnterOp, topdown.RedoOp:
+			if event.HasRule() || event.HasBody() {
+				qids[event.QueryID] = event
+			}
+		}
+	}
+
+	return result
+}

--- a/topdown/notes/notes_test.go
+++ b/topdown/notes/notes_test.go
@@ -1,0 +1,190 @@
+// Copyright 2019 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package notes
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/topdown"
+)
+
+func TestFilter(t *testing.T) {
+
+	tests := []struct {
+		note   string
+		module string
+		exp    string
+	}{
+		{
+			note: "lineage",
+			module: `package test
+
+			p { q }
+			q { r }
+			r { trace("R") }`,
+			exp: `
+Enter data.test.p = x
+| Enter data.test.p
+| | Enter data.test.q
+| | | Enter data.test.r
+| | | | Note "R"`,
+		},
+		{
+			note: "conjunction",
+			module: `package test
+
+			p { trace("P1"); trace("P2") }`,
+			exp: `
+Enter data.test.p = x
+| Enter data.test.p
+| | Note "P1"
+| | Note "P2"`,
+		},
+		{
+			note: "conjunction (multiple enters)",
+			module: `package test
+
+			p { q; r }
+			q { trace("Q") }
+			r { trace("Q") }
+			`,
+			exp: `
+Enter data.test.p = x
+| Enter data.test.p
+| | Enter data.test.q
+| | | Note "Q"
+| | Enter data.test.r
+| | | Note "Q"`,
+		},
+		{
+			note: "disjunction",
+			module: `package test
+
+			p { trace("P1") }
+			p { false }
+			p { trace("P2") }
+			`,
+			exp: `
+Enter data.test.p = x
+| Enter data.test.p
+| | Note "P1"
+Redo data.test.p = x
+| Enter data.test.p
+| | Note "P2"`,
+		},
+		{
+			note: "disjunction (failure)",
+			module: `package test
+
+			p { trace("P1") }
+			p { trace("P2"); false }
+			p { trace("P3") }
+			`,
+			exp: `
+Enter data.test.p = x
+| Enter data.test.p
+| | Note "P1"
+Redo data.test.p = x
+| Enter data.test.p
+| | Note "P2"
+| Enter data.test.p
+| | Note "P3"`,
+		},
+		{
+			note: "disjunction (iteration)",
+			module: `package test
+			q[1]
+			q[2]
+			p { q[x]; trace(sprintf("x=%d", [x])) }`,
+			exp: `
+Enter data.test.p = x
+| Enter data.test.p
+| | Note "x=1"
+Redo data.test.p = x
+| Redo data.test.p
+| | Note "x=2"`,
+		},
+		{
+			note: "parent child",
+			module: `package test
+
+			p { trace("P"); q }
+			q { trace("Q") }`,
+			exp: `
+Enter data.test.p = x
+| Enter data.test.p
+| | Note "P"
+| | Enter data.test.q
+| | | Note "Q"`,
+		},
+		{
+			note: "negation",
+			module: `package test
+
+			p { not q }
+			q = false { trace("Q") }`,
+			exp: `
+Enter data.test.p = x
+| Enter data.test.p
+| | Enter data.test.q
+| | | Enter data.test.q
+| | | | Note "Q"`,
+		},
+		{
+			note: "fail",
+			module: `package test
+
+			p { not q }
+			q { trace("P"); 1 = 2 }`,
+			exp: `
+Enter data.test.p = x
+| Enter data.test.p
+| | Enter data.test.q
+| | | Enter data.test.q
+| | | | Note "P"`,
+		},
+		{
+			note: "comprehensions",
+			module: `package test
+
+			p { [true | true; trace("X")] }`,
+			exp: `
+Enter data.test.p = x
+| Enter data.test.p
+| | Enter true; trace("X")
+| | | Note "X"`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.note, func(t *testing.T) {
+			buf := topdown.NewBufferTracer()
+			compiler := ast.MustCompileModules(map[string]string{
+				"test.rego": tc.module,
+			})
+			query := topdown.NewQuery(ast.MustParseBody("data.test.p = x")).WithCompiler(compiler).WithTracer(buf)
+			rs, err := query.Run(context.TODO())
+			if err != nil {
+				t.Fatal(err)
+			} else if len(rs) != 1 || !rs[0][ast.Var("x")].Equal(ast.BooleanTerm(true)) {
+				t.Fatalf("Unexpected result: %v", rs)
+			}
+
+			filtered := Filter(*buf)
+
+			buffer := bytes.NewBuffer(nil)
+			topdown.PrettyTrace(buffer, filtered)
+
+			if strings.TrimSpace(buffer.String()) != strings.TrimSpace(tc.exp) {
+				t.Fatalf("Expected:\n\n%v\n\nGot:\n\n%v", tc.exp, buffer.String())
+			}
+		})
+	}
+
+}

--- a/topdown/trace.go
+++ b/topdown/trace.go
@@ -157,7 +157,12 @@ func formatEvent(event *Event, depth int) string {
 	} else if event.Message != "" {
 		return fmt.Sprintf("%v%v %v %v", padding, event.Op, event.Node, event.Message)
 	} else {
-		return fmt.Sprintf("%v%v %v", padding, event.Op, event.Node)
+		switch node := event.Node.(type) {
+		case *ast.Rule:
+			return fmt.Sprintf("%v%v %v", padding, event.Op, node.Path())
+		default:
+			return fmt.Sprintf("%v%v %v", padding, event.Op, event.Node)
+		}
 	}
 }
 

--- a/topdown/trace_test.go
+++ b/topdown/trace_test.go
@@ -78,45 +78,45 @@ func TestPrettyTrace(t *testing.T) {
 	expected := `Enter data.test.p = _
 | Eval data.test.p = _
 | Index data.test.p = _ (matched 1 rule)
-| Enter p = true { data.test.q[x]; plus(x, 1, n) }
+| Enter data.test.p
 | | Eval data.test.q[x]
 | | Index data.test.q[x] (matched 1 rule)
-| | Enter q[x] { x = data.a[_] }
+| | Enter data.test.q
 | | | Eval x = data.a[_]
-| | | Exit q[x] { x = data.a[_] }
+| | | Exit data.test.q
 | | Eval plus(x, 1, n)
-| | Exit p = true { data.test.q[x]; plus(x, 1, n) }
+| | Exit data.test.p
 | Exit data.test.p = _
 Redo data.test.p = _
 | Redo data.test.p = _
-| Redo p = true { data.test.q[x]; plus(x, 1, n) }
+| Redo data.test.p
 | | Redo plus(x, 1, n)
 | | Redo data.test.q[x]
-| | Redo q[x] { x = data.a[_] }
+| | Redo data.test.q
 | | | Redo x = data.a[_]
-| | | Exit q[x] { x = data.a[_] }
+| | | Exit data.test.q
 | | Eval plus(x, 1, n)
-| | Exit p = true { data.test.q[x]; plus(x, 1, n) }
-| Redo p = true { data.test.q[x]; plus(x, 1, n) }
+| | Exit data.test.p
+| Redo data.test.p
 | | Redo plus(x, 1, n)
 | | Redo data.test.q[x]
-| | Redo q[x] { x = data.a[_] }
+| | Redo data.test.q
 | | | Redo x = data.a[_]
-| | | Exit q[x] { x = data.a[_] }
+| | | Exit data.test.q
 | | Eval plus(x, 1, n)
-| | Exit p = true { data.test.q[x]; plus(x, 1, n) }
-| Redo p = true { data.test.q[x]; plus(x, 1, n) }
+| | Exit data.test.p
+| Redo data.test.p
 | | Redo plus(x, 1, n)
 | | Redo data.test.q[x]
-| | Redo q[x] { x = data.a[_] }
+| | Redo data.test.q
 | | | Redo x = data.a[_]
-| | | Exit q[x] { x = data.a[_] }
+| | | Exit data.test.q
 | | Eval plus(x, 1, n)
-| | Exit p = true { data.test.q[x]; plus(x, 1, n) }
-| Redo p = true { data.test.q[x]; plus(x, 1, n) }
+| | Exit data.test.p
+| Redo data.test.p
 | | Redo plus(x, 1, n)
 | | Redo data.test.q[x]
-| | Redo q[x] { x = data.a[_] }
+| | Redo data.test.q
 | | | Redo x = data.a[_]
 `
 
@@ -171,65 +171,65 @@ func TestTraceNote(t *testing.T) {
 	expected := `Enter data.test.p = _
 | Eval data.test.p = _
 | Index data.test.p = _ (matched 1 rule)
-| Enter p = true { data.test.q[x]; plus(x, 1, n); sprintf("n= %v", [n], __local0__); trace(__local0__) }
+| Enter data.test.p
 | | Eval data.test.q[x]
 | | Index data.test.q[x] (matched 1 rule)
-| | Enter q[x] { x = data.a[_] }
+| | Enter data.test.q
 | | | Eval x = data.a[_]
-| | | Exit q[x] { x = data.a[_] }
+| | | Exit data.test.q
 | | Eval plus(x, 1, n)
 | | Eval sprintf("n= %v", [n], __local0__)
 | | Eval trace(__local0__)
 | | Note "n= 2"
-| | Exit p = true { data.test.q[x]; plus(x, 1, n); sprintf("n= %v", [n], __local0__); trace(__local0__) }
+| | Exit data.test.p
 | Exit data.test.p = _
 Redo data.test.p = _
 | Redo data.test.p = _
-| Redo p = true { data.test.q[x]; plus(x, 1, n); sprintf("n= %v", [n], __local0__); trace(__local0__) }
+| Redo data.test.p
 | | Redo trace(__local0__)
 | | Redo sprintf("n= %v", [n], __local0__)
 | | Redo plus(x, 1, n)
 | | Redo data.test.q[x]
-| | Redo q[x] { x = data.a[_] }
+| | Redo data.test.q
 | | | Redo x = data.a[_]
-| | | Exit q[x] { x = data.a[_] }
+| | | Exit data.test.q
 | | Eval plus(x, 1, n)
 | | Eval sprintf("n= %v", [n], __local0__)
 | | Eval trace(__local0__)
 | | Note "n= 3"
-| | Exit p = true { data.test.q[x]; plus(x, 1, n); sprintf("n= %v", [n], __local0__); trace(__local0__) }
-| Redo p = true { data.test.q[x]; plus(x, 1, n); sprintf("n= %v", [n], __local0__); trace(__local0__) }
+| | Exit data.test.p
+| Redo data.test.p
 | | Redo trace(__local0__)
 | | Redo sprintf("n= %v", [n], __local0__)
 | | Redo plus(x, 1, n)
 | | Redo data.test.q[x]
-| | Redo q[x] { x = data.a[_] }
+| | Redo data.test.q
 | | | Redo x = data.a[_]
-| | | Exit q[x] { x = data.a[_] }
+| | | Exit data.test.q
 | | Eval plus(x, 1, n)
 | | Eval sprintf("n= %v", [n], __local0__)
 | | Eval trace(__local0__)
 | | Note "n= 4"
-| | Exit p = true { data.test.q[x]; plus(x, 1, n); sprintf("n= %v", [n], __local0__); trace(__local0__) }
-| Redo p = true { data.test.q[x]; plus(x, 1, n); sprintf("n= %v", [n], __local0__); trace(__local0__) }
+| | Exit data.test.p
+| Redo data.test.p
 | | Redo trace(__local0__)
 | | Redo sprintf("n= %v", [n], __local0__)
 | | Redo plus(x, 1, n)
 | | Redo data.test.q[x]
-| | Redo q[x] { x = data.a[_] }
+| | Redo data.test.q
 | | | Redo x = data.a[_]
-| | | Exit q[x] { x = data.a[_] }
+| | | Exit data.test.q
 | | Eval plus(x, 1, n)
 | | Eval sprintf("n= %v", [n], __local0__)
 | | Eval trace(__local0__)
 | | Note "n= 5"
-| | Exit p = true { data.test.q[x]; plus(x, 1, n); sprintf("n= %v", [n], __local0__); trace(__local0__) }
-| Redo p = true { data.test.q[x]; plus(x, 1, n); sprintf("n= %v", [n], __local0__); trace(__local0__) }
+| | Exit data.test.p
+| Redo data.test.p
 | | Redo trace(__local0__)
 | | Redo sprintf("n= %v", [n], __local0__)
 | | Redo plus(x, 1, n)
 | | Redo data.test.q[x]
-| | Redo q[x] { x = data.a[_] }
+| | Redo data.test.q
 | | | Redo x = data.a[_]
 `
 


### PR DESCRIPTION
These changes extend OPA with an explanation mode that filters trace output to show note events. In addition, to the note events, the filter also includes enter/redo events that explain the rule where the note was emitted. The goal of the filter is to give users a way to easily inspect notes emitted by their policies during debugging.