### PR TITLE
Fix opa docker image versions in markdown templates

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -32,7 +32,7 @@ docker-serve:
 	docker run --rm -it \
 		-v $(CURDIR)/:/src \
 		-p 1313:1313 \
-		klakegg/hugo:0.53-ext server \
+		klakegg/hugo:0.55.5-ext server \
 			--source /src/website \
 			--contentDir generated
 

--- a/docs/content/ceph-authorization.md
+++ b/docs/content/ceph-authorization.md
@@ -520,7 +520,7 @@ spec:
     spec:
       containers:
         - name: opa
-          image: openpolicyagent/opa:{{< current_version >}}
+          image: openpolicyagent/opa:{{< current_docker_version >}}
           ports:
           - name: http
             containerPort: 8181

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@ publish = "docs/website/public"
 command = "make docs-production-build"
 
 [build.environment]
-HUGO_VERSION = "0.53"
+HUGO_VERSION = "0.55.5"
 
 [context.deploy-preview]
 command = "make docs-preview-build"


### PR DESCRIPTION
Some of the behavior for shortcodes inside markdown changed in hugo 0.55.0, and with the old version the shortcodes to insert image tags in our content wasn't working as expected.

Newer versions of hugo handle it correctly, so updating to use the newer version with netlify corrects the problem.

The ceph example also had the wrong shortcode :( 

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
