### PR TITLE
wasm: Add support for rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,9 +132,7 @@ go-test: generate
 .PHONY: wasm-test
 wasm-test: generate
 ifeq ($(DOCKER_INSTALLED), 1)
-	@mkdir -p _test
-	@$(GO) run test/wasm/cmd/testgen.go --input-dir test/wasm/assets --output _test/testcases.tar.gz
-	@$(DOCKER) run -it --rm -e VERBOSE=$(VERBOSE) -v $(PWD):/src -w /src node:8 ./build/test-wasm.sh
+	@./build/run-wasm-tests.sh
 else
 	@echo "Docker not installed. Skipping WASM-based test execution."
 endif

--- a/build/run-wasm-tests.sh
+++ b/build/run-wasm-tests.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -e
+
+mkdir -p _test
+go run test/wasm/cmd/testgen.go --input-dir test/wasm/assets --output _test/testcases.tar.gz $@
+docker run -it --rm -e VERBOSE=$VERBOSE -v $PWD:/src -w /src node:8 bash -c 'mkdir -p /test; tar xzf _test/testcases.tar.gz -C /test; cd /test; node test.js opa.wasm'

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -73,7 +73,7 @@ func build(args []string) error {
 	}
 
 	r := rego.New(regoArgs...)
-	cr, err := r.Compile(ctx)
+	cr, err := r.Compile(ctx, rego.CompilePartial(true))
 	if err != nil {
 		return err
 	}

--- a/internal/compiler/wasm/wasm.go
+++ b/internal/compiler/wasm/wasm.go
@@ -378,6 +378,7 @@ func (c *Compiler) compileScanBlock(scan ir.ScanStmt) ([]instruction.Instruction
 	}
 
 	instrs = append(instrs, nested...)
+	instrs = append(instrs, instruction.Br{Index: 0})
 
 	return instrs, nil
 }

--- a/internal/compiler/wasm/wasm.go
+++ b/internal/compiler/wasm/wasm.go
@@ -432,6 +432,11 @@ func (c *Compiler) compileBlock(block ir.Block) ([]instruction.Instruction, erro
 			instrs = append(instrs, instruction.I32Const{Value: opaTypeObject})
 			instrs = append(instrs, instruction.I32Ne{})
 			instrs = append(instrs, instruction.BrIf{Index: 0})
+		case ir.IsUndefinedStmt:
+			instrs = append(instrs, instruction.GetLocal{Index: c.local(stmt.Source)})
+			instrs = append(instrs, instruction.I32Const{Value: 0})
+			instrs = append(instrs, instruction.I32Ne{})
+			instrs = append(instrs, instruction.BrIf{Index: 0})
 		case ir.ArrayAppendStmt:
 			instrs = append(instrs, instruction.GetLocal{Index: c.local(stmt.Array)})
 			instrs = append(instrs, instruction.GetLocal{Index: c.local(stmt.Value)})

--- a/internal/compiler/wasm/wasm.go
+++ b/internal/compiler/wasm/wasm.go
@@ -92,6 +92,8 @@ func (c *Compiler) Compile() (*module.Module, error) {
 	for _, stage := range c.stages {
 		if err := stage(); err != nil {
 			return nil, err
+		} else if len(c.errors) > 0 {
+			return nil, c.errors[0] // TODO(tsandall) return all errors.
 		}
 	}
 
@@ -624,7 +626,7 @@ func (c *Compiler) genLocal() uint32 {
 func (c *Compiler) function(name string) uint32 {
 	index, ok := c.funcs[name]
 	if !ok {
-		panic(fmt.Sprintf("illegal function name %q", name))
+		c.errors = append(c.errors, fmt.Errorf("illegal function reference %q", name))
 	}
 	return index
 }

--- a/internal/compiler/wasm/wasm.go
+++ b/internal/compiler/wasm/wasm.go
@@ -285,6 +285,18 @@ func (c *Compiler) compileBlock(block *ir.Block) ([]instruction.Instruction, err
 		case *ir.ReturnLocalStmt:
 			instrs = append(instrs, instruction.GetLocal{Index: c.local(stmt.Source)})
 			instrs = append(instrs, instruction.Return{})
+		case *ir.BlockStmt:
+			nested := make([]instruction.Instruction, len(stmt.Blocks))
+			for i := range stmt.Blocks {
+				block, err := c.compileBlock(stmt.Blocks[i])
+				if err != nil {
+					return nil, err
+				}
+				nested[i] = instruction.Block{Instrs: block}
+			}
+			instrs = append(instrs, instruction.Block{Instrs: nested})
+		case *ir.BreakStmt:
+			instrs = append(instrs, instruction.Br{Index: stmt.Index})
 		case *ir.CallStmt:
 			for _, arg := range stmt.Args {
 				instrs = append(instrs, instruction.GetLocal{Index: c.local(arg)})
@@ -436,6 +448,10 @@ func (c *Compiler) compileBlock(block *ir.Block) ([]instruction.Instruction, err
 			instrs = append(instrs, instruction.GetLocal{Index: c.local(stmt.Source)})
 			instrs = append(instrs, instruction.I32Const{Value: 0})
 			instrs = append(instrs, instruction.I32Ne{})
+			instrs = append(instrs, instruction.BrIf{Index: 0})
+		case *ir.IsDefinedStmt:
+			instrs = append(instrs, instruction.GetLocal{Index: c.local(stmt.Source)})
+			instrs = append(instrs, instruction.I32Eqz{})
 			instrs = append(instrs, instruction.BrIf{Index: 0})
 		case *ir.ArrayAppendStmt:
 			instrs = append(instrs, instruction.GetLocal{Index: c.local(stmt.Array)})

--- a/internal/ir/ir.go
+++ b/internal/ir/ir.go
@@ -15,14 +15,14 @@ import (
 type (
 	// Policy represents a planned policy query.
 	Policy struct {
-		Static Static
-		Plan   Plan
-		Funcs  Funcs
+		Static *Static
+		Plan   *Plan
+		Funcs  *Funcs
 	}
 
 	// Static represents a static data segment that is indexed into by the policy.
 	Static struct {
-		Strings []StringConst
+		Strings []*StringConst
 	}
 
 	// Funcs represents a collection of planned functions to include in the
@@ -38,14 +38,14 @@ type (
 		Name   string
 		Params []Local
 		Return Local
-		Blocks []Block // TODO(tsandall): should this be a plan?
+		Blocks []*Block // TODO(tsandall): should this be a plan?
 	}
 
 	// Plan represents an ordered series of blocks to execute. All plans contain a
 	// final block that returns indicating the plan result was undefined. Plan
 	// execution stops when a block returns a value. Blocks are executed in-order.
 	Plan struct {
-		Blocks []Block
+		Blocks []*Block
 	}
 
 	// Block represents an ordered sequence of statements to execute. Blocks are
@@ -119,15 +119,15 @@ const (
 	Input Local = 2
 )
 
-func (a Policy) String() string {
+func (a *Policy) String() string {
 	return "Policy"
 }
 
-func (a Static) String() string {
+func (a *Static) String() string {
 	return fmt.Sprintf("Static (%d strings)", len(a.Strings))
 }
 
-func (a Funcs) String() string {
+func (a *Funcs) String() string {
 	return fmt.Sprintf("Funcs (%d funcs)", len(a.Funcs))
 }
 
@@ -135,19 +135,19 @@ func (a *Func) String() string {
 	return fmt.Sprintf("%v (%d params: %v, %d blocks)", a.Name, len(a.Params), a.Params, len(a.Blocks))
 }
 
-func (a Plan) String() string {
+func (a *Plan) String() string {
 	return fmt.Sprintf("Plan (%d blocks)", len(a.Blocks))
 }
 
-func (a Block) String() string {
+func (a *Block) String() string {
 	return fmt.Sprintf("Block (%d statements)", len(a.Stmts))
 }
 
-func (a BooleanConst) typeMarker() {}
-func (a NullConst) typeMarker()    {}
-func (a IntConst) typeMarker()     {}
-func (a FloatConst) typeMarker()   {}
-func (a StringConst) typeMarker()  {}
+func (a *BooleanConst) typeMarker() {}
+func (a *NullConst) typeMarker()    {}
+func (a *IntConst) typeMarker()     {}
+func (a *FloatConst) typeMarker()   {}
+func (a *StringConst) typeMarker()  {}
 
 // ReturnStmt represents a return statement. Return statements halt execution of
 // a plan with the given code.
@@ -190,14 +190,14 @@ type ScanStmt struct {
 	Source Local
 	Key    Local
 	Value  Local
-	Block  Block
+	Block  *Block
 }
 
 // NotStmt represents a negated statement. The last statement in the negation
 // block will set the condition to false.
 type NotStmt struct {
 	Cond  Local
-	Block Block
+	Block *Block
 }
 
 // AssignBooleanStmt represents an assignment of a boolean value to a local variable.
@@ -310,6 +310,11 @@ type IsArrayStmt struct {
 
 // IsObjectStmt represents a dynamic type check on a local variable.
 type IsObjectStmt struct {
+	Source Local
+}
+
+// IsDefinedStmt represents a check of whether a local variable is defined.
+type IsDefinedStmt struct {
 	Source Local
 }
 

--- a/internal/ir/ir.go
+++ b/internal/ir/ir.go
@@ -313,6 +313,11 @@ type IsObjectStmt struct {
 	Source Local
 }
 
+// IsUndefinedStmt represents a check of whether local variable is undefined.
+type IsUndefinedStmt struct {
+	Source Local
+}
+
 // ArrayAppendStmt represents a dynamic append operation of a value
 // onto an array.
 type ArrayAppendStmt struct {

--- a/internal/ir/ir.go
+++ b/internal/ir/ir.go
@@ -168,6 +168,23 @@ type CallStmt struct {
 	Result Local
 }
 
+// BlockStmt represents a nested block. Nested blocks and break statements can
+// be used to short-circuit execution.
+type BlockStmt struct {
+	Blocks []*Block
+}
+
+func (a *BlockStmt) String() string {
+	return fmt.Sprintf("BlockStmt (%d blocks)", len(a.Blocks))
+}
+
+// BreakStmt represents a jump out of the current block. The index specifies how
+// many blocks to jump starting from zero (the current block). Execution will
+// continue from the end of the block that is jumped to.
+type BreakStmt struct {
+	Index uint32
+}
+
 // DotStmt represents a lookup operation on a value (e.g., array, object, etc.)
 // The source of a DotStmt may be a scalar value in which case the statement
 // will be undefined.

--- a/internal/ir/ir.go
+++ b/internal/ir/ir.go
@@ -355,6 +355,15 @@ type ObjectInsertStmt struct {
 	Object Local
 }
 
+// ObjectInsertOnceStmt represents a dynamic insert operation of a key/value
+// pair into an object. If the key already exists and the value differs,
+// execution aborts with a conflict error.
+type ObjectInsertOnceStmt struct {
+	Key    Local
+	Value  Local
+	Object Local
+}
+
 // SetAddStmt represents a dynamic add operation of an element into a set.
 type SetAddStmt struct {
 	Value Local

--- a/internal/ir/walk.go
+++ b/internal/ir/walk.go
@@ -49,11 +49,11 @@ func (w *walkerImpl) walk(x interface{}) {
 		w.walk(x.Static)
 		w.walk(x.Plan)
 		w.walk(x.Funcs)
-	case Static:
+	case *Static:
 		for _, s := range x.Strings {
 			w.walk(s)
 		}
-	case Funcs:
+	case *Funcs:
 		keys := make([]string, 0, len(x.Funcs))
 		for k := range x.Funcs {
 			keys = append(keys, k)
@@ -66,17 +66,17 @@ func (w *walkerImpl) walk(x interface{}) {
 		for _, b := range x.Blocks {
 			w.walk(b)
 		}
-	case Plan:
+	case *Plan:
 		for _, b := range x.Blocks {
 			w.walk(b)
 		}
-	case Block:
+	case *Block:
 		for _, s := range x.Stmts {
 			w.walk(s)
 		}
-	case ScanStmt:
+	case *ScanStmt:
 		w.walk(x.Block)
-	case NotStmt:
+	case *NotStmt:
 		w.walk(x.Block)
 	}
 }

--- a/internal/ir/walk.go
+++ b/internal/ir/walk.go
@@ -74,6 +74,10 @@ func (w *walkerImpl) walk(x interface{}) {
 		for _, s := range x.Stmts {
 			w.walk(s)
 		}
+	case *BlockStmt:
+		for _, b := range x.Blocks {
+			w.walk(b)
+		}
 	case *ScanStmt:
 		w.walk(x.Block)
 	case *NotStmt:

--- a/internal/ir/walk.go
+++ b/internal/ir/walk.go
@@ -4,6 +4,8 @@
 
 package ir
 
+import "sort"
+
 // Visitor defines the interface for visiting IR nodes.
 type Visitor interface {
 	Before(x interface{})
@@ -46,9 +48,23 @@ func (w *walkerImpl) walk(x interface{}) {
 	case *Policy:
 		w.walk(x.Static)
 		w.walk(x.Plan)
+		w.walk(x.Funcs)
 	case Static:
 		for _, s := range x.Strings {
 			w.walk(s)
+		}
+	case Funcs:
+		keys := make([]string, 0, len(x.Funcs))
+		for k := range x.Funcs {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			w.walk(x.Funcs[k])
+		}
+	case *Func:
+		for _, b := range x.Blocks {
+			w.walk(b)
 		}
 	case Plan:
 		for _, b := range x.Blocks {

--- a/internal/planner/functrie.go
+++ b/internal/planner/functrie.go
@@ -1,0 +1,62 @@
+package planner
+
+import (
+	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/internal/ir"
+)
+
+// functrie implements a simple trie structure for organizing planned functions.
+// The functions are organized to facilitate access when planning references
+// against the data document.
+type functrie struct {
+	children map[ast.Value]*functrie
+	fn       *ir.Func
+}
+
+func newFunctrie() *functrie {
+	return &functrie{
+		children: map[ast.Value]*functrie{},
+	}
+}
+
+func (t *functrie) Insert(key ast.Ref, fn *ir.Func) {
+	node := t
+	for _, elem := range key {
+		child, ok := node.children[elem.Value]
+		if !ok {
+			child = newFunctrie()
+			node.children[elem.Value] = child
+		}
+		node = child
+	}
+	node.fn = fn
+}
+
+func (t *functrie) Lookup(key ast.Ref) *ir.Func {
+	node := t
+	for _, elem := range key {
+		var ok bool
+		if node == nil {
+			return nil
+		} else if node, ok = node.children[elem.Value]; !ok {
+			return nil
+		}
+	}
+	return node.fn
+}
+
+func (t *functrie) Map() map[string]*ir.Func {
+	result := map[string]*ir.Func{}
+	t.toMap(result)
+	return result
+}
+
+func (t *functrie) toMap(result map[string]*ir.Func) {
+	if t.fn != nil {
+		result[t.fn.Name] = t.fn
+		return
+	}
+	for _, node := range t.children {
+		node.toMap(result)
+	}
+}

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -1000,7 +1000,13 @@ func (p *Planner) planRefRec(ref ast.Ref, index int, iter planiter) error {
 				return p.planRefRec(ref, index+1, iter)
 			})
 		}
-		p.ltarget = p.vars[v]
+		target := p.newLocal()
+		p.appendStmt(&ir.DotStmt{
+			Source: p.ltarget,
+			Key:    p.vars[v],
+			Target: target,
+		})
+		p.ltarget = target
 		return p.planRefRec(ref, index+1, iter)
 
 	default:

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -689,6 +689,7 @@ func (p *Planner) planArray(arr ast.Array, iter planiter) error {
 
 func (p *Planner) planArrayRec(arr ast.Array, index int, larr ir.Local, iter planiter) error {
 	if index == len(arr) {
+		p.ltarget = larr
 		return iter()
 	}
 
@@ -716,6 +717,7 @@ func (p *Planner) planObject(obj ast.Object, iter planiter) error {
 
 func (p *Planner) planObjectRec(obj ast.Object, index int, keys []*ast.Term, lobj ir.Local, iter planiter) error {
 	if index == len(keys) {
+		p.ltarget = lobj
 		return iter()
 	}
 
@@ -747,6 +749,7 @@ func (p *Planner) planSet(set ast.Set, iter planiter) error {
 
 func (p *Planner) planSetRec(set ast.Set, index int, elems []*ast.Term, lset ir.Local, iter planiter) error {
 	if index == len(elems) {
+		p.ltarget = lset
 		return iter()
 	}
 

--- a/internal/planner/planner_test.go
+++ b/internal/planner/planner_test.go
@@ -136,6 +136,16 @@ func TestPlannerHelloWorld(t *testing.T) {
 				p["b"] = 2
 			`},
 		},
+		{
+			note:    "virtual extent",
+			queries: []string{`data`},
+			modules: []string{`
+				package test
+
+				p = 1
+			#	q = 2 { false }
+			`},
+		},
 	}
 
 	for _, tc := range tests {

--- a/internal/planner/planner_test.go
+++ b/internal/planner/planner_test.go
@@ -118,6 +118,24 @@ func TestPlannerHelloWorld(t *testing.T) {
 				}
 			`},
 		},
+		{
+			note:    "partial set",
+			queries: []string{"data.test.p = {1,2}"},
+			modules: []string{`
+				package test
+				p[1]
+				p[2]
+			`},
+		},
+		{
+			note:    "partial object",
+			queries: []string{`data.test.p = {"a": 1, "b": 2}`},
+			modules: []string{`
+				package test
+				p["a"] = 1
+				p["b"] = 2
+			`},
+		},
 	}
 
 	for _, tc := range tests {

--- a/internal/planner/planner_test.go
+++ b/internal/planner/planner_test.go
@@ -106,6 +106,18 @@ func TestPlannerHelloWorld(t *testing.T) {
 				}
 			`},
 		},
+		{
+			note:    "else",
+			queries: []string{"data.test.p = 1"},
+			modules: []string{`
+				package test
+				p = 0 {
+					false
+				} else = 1 {
+					true
+				}
+			`},
+		},
 	}
 
 	for _, tc := range tests {

--- a/internal/planner/planner_test.go
+++ b/internal/planner/planner_test.go
@@ -96,6 +96,16 @@ func TestPlannerHelloWorld(t *testing.T) {
 				p = x { x = 10 }
 			`},
 		},
+		{
+			note:    "functions",
+			queries: []string{"data.test.f([1,x])"},
+			modules: []string{`
+				package test
+				f([a, b]) {
+					a = b
+				}
+			`},
+		},
 	}
 
 	for _, tc := range tests {

--- a/internal/wasm/instruction/control.go
+++ b/internal/wasm/instruction/control.go
@@ -73,6 +73,21 @@ func (i Loop) Instructions() []Instruction {
 	return i.Instrs
 }
 
+// Br represents a WASM br instruction.
+type Br struct {
+	Index uint32
+}
+
+// Op returns the opcode of the instruction.
+func (Br) Op() opcode.Opcode {
+	return opcode.Br
+}
+
+// ImmediateArgs returns the block index to break to.
+func (i Br) ImmediateArgs() []interface{} {
+	return []interface{}{i.Index}
+}
+
 // BrIf represents a WASM br_if instruction.
 type BrIf struct {
 	Index uint32

--- a/internal/wasm/module/module.go
+++ b/internal/wasm/module/module.go
@@ -277,6 +277,28 @@ func (tpe FunctionType) String() string {
 	return "(" + strings.Join(params, ", ") + ") -> (" + strings.Join(results, ", ") + ")"
 }
 
+// Equal returns true if tpe equals other.
+func (tpe FunctionType) Equal(other FunctionType) bool {
+
+	if len(tpe.Params) != len(other.Params) || len(tpe.Results) != len(other.Results) {
+		return false
+	}
+
+	for i := range tpe.Params {
+		if tpe.Params[i] != other.Params[i] {
+			return false
+		}
+	}
+
+	for i := range tpe.Results {
+		if tpe.Results[i] != other.Results[i] {
+			return false
+		}
+	}
+
+	return true
+}
+
 func (imp Import) String() string {
 	return fmt.Sprintf("%v %v.%v", imp.Descriptor.String(), imp.Module, imp.Name)
 }

--- a/rego/rego.go
+++ b/rego/rego.go
@@ -662,11 +662,28 @@ func (r *Rego) Compile(ctx context.Context) (*CompileResult, error) {
 		return nil, err
 	}
 
-	if len(pq.Support) > 0 {
-		return nil, fmt.Errorf("modules not supported")
+	if r.dump != nil {
+		if len(pq.Queries) != 0 {
+			msg := fmt.Sprintf("QUERIES (%d total):", len(pq.Queries))
+			fmt.Fprintln(r.dump, msg)
+			fmt.Fprintln(r.dump, strings.Repeat("-", len(msg)))
+			for i := range pq.Queries {
+				fmt.Println(pq.Queries[i])
+			}
+			fmt.Fprintln(r.dump)
+		}
+		if len(pq.Support) != 0 {
+			msg := fmt.Sprintf("SUPPORT (%d total):", len(pq.Support))
+			fmt.Fprintln(r.dump, msg)
+			fmt.Fprintln(r.dump, strings.Repeat("-", len(msg)))
+			for i := range pq.Support {
+				fmt.Println(pq.Support[i])
+			}
+			fmt.Fprintln(r.dump)
+		}
 	}
 
-	policy, err := planner.New().WithQueries(pq.Queries).Plan()
+	policy, err := planner.New().WithQueries(pq.Queries).WithModules(pq.Support).Plan()
 	if err != nil {
 		return nil, err
 	}

--- a/test/wasm/assets/002_iteration.yaml
+++ b/test/wasm/assets/002_iteration.yaml
@@ -23,3 +23,41 @@ cases:
     query: input.x[i].y[j] = 1
     input: {"x": [{"y": []}, {"y": [0]}, {"y": [0, 2]}]}
     return_code: 0
+  - note: iteration ground
+    query: input.x[i].y[i] = 2
+    input: {
+      "x": [
+        {
+          "y": [
+            1,
+            2,
+          ]
+        },
+        {
+          "y": [
+            1,
+            2,
+          ]
+        },
+      ]
+    }
+    return_code: 1
+  - note: iteration ground
+    query: input.x[i].y[i] = 1
+    input: {
+      "x": [
+        {
+          "y": [
+            2,
+            1,
+          ]
+        },
+        {
+          "y": [
+            1,
+            2,
+          ]
+        },
+      ]
+    }
+    return_code: 0

--- a/test/wasm/assets/007_complete.yaml
+++ b/test/wasm/assets/007_complete.yaml
@@ -1,6 +1,5 @@
 cases:
   - note: constants
-    disable_partial: true
     query: data.x.p = 1
     modules:
       - |
@@ -8,7 +7,6 @@ cases:
         p = 1
     return_code: 1
   - note: constants (negative)
-    disable_partial: true
     query: data.x.p = 1
     modules:
       - |
@@ -16,7 +14,6 @@ cases:
         p = 2
     return_code: 0
   - note: variable
-    disable_partial: true
     query: data.x.p = 1
     modules:
       - |
@@ -24,7 +21,6 @@ cases:
         p = y { x = 1; y = x }
     return_code: 1
   - note: variable (negative)
-    disable_partial: true
     query: data.x.p = 1
     modules:
       - |
@@ -32,7 +28,6 @@ cases:
         p = y { x = 2; y = x }
     return_code: 0
   - note: composites
-    disable_partial: true
     query: data.x.p = [1]
     modules:
       - |
@@ -40,7 +35,6 @@ cases:
         p = [x] { x = 1 }
     return_code: 1
   - note: composites (negative)
-    disable_partial: true
     query: data.x.p = [1]
     modules:
       - |
@@ -48,7 +42,6 @@ cases:
         p = [x] { x = 2 }
     return_code: 0
   - note: conjunction
-    disable_partial: true
     query: data.x.p = 1
     modules:
       - |
@@ -58,7 +51,6 @@ cases:
         r { true }
     return_code: 1
   - note: conjunction (negative)
-    disable_partial: true
     query: data.x.p = 1
     modules:
       - |
@@ -68,7 +60,6 @@ cases:
         r { false }
     return_code: 0
   - note: disjunction
-    disable_partial: true
     query: data.x.p = 2
     modules:
       - |
@@ -78,7 +69,6 @@ cases:
         p = 3 { false }
     return_code: 1
   - note: disjunction (negative)
-    disable_partial: true
     query: data.x.p = 1
     modules:
       - |
@@ -88,7 +78,6 @@ cases:
         p = 3 { true }
     return_code: 0
   - note: negation
-    disable_partial: true
     query: not data.x.p = 1
     modules:
       - |
@@ -96,7 +85,6 @@ cases:
         p = 1 { false }  # undefined
     return_code: 1
   - note: negation (negative)
-    disable_partial: true
     query: not data.x.p = 1
     modules:
       - |
@@ -104,7 +92,6 @@ cases:
         p = 1
     return_code: 0
   - note: chain
-    disable_partial: true
     query: data.x.p = 1
     modules:
       - |
@@ -114,7 +101,6 @@ cases:
         r = 1
     return_code: 1
   - note: chain (negative)
-    disable_partial: true
     query: data.x.p = 1
     modules:
       - |
@@ -124,7 +110,6 @@ cases:
         r = 2
     return_code: 0
   - note: chain input
-    disable_partial: true
     query: data.x.p = true
     modules:
       - |
@@ -135,7 +120,6 @@ cases:
     input: {"x": 1}
     return_code: 1
   - note: chain input (negative)
-    disable_partial: true
     query: data.x.p = true
     modules:
       - |
@@ -146,7 +130,6 @@ cases:
     input: {"x": 1}
     return_code: 0
   - note: iteration
-    disable_partial: true
     query: data.x.p = 1
     modules:
       - |
@@ -155,7 +138,6 @@ cases:
     input: [3,2,1]
     return_code: 1
   - note: iteration (negative)
-    disable_partial: true
     query: data.x.p = 1
     modules:
       - |
@@ -164,7 +146,6 @@ cases:
     input: [3,2,1]
     return_code: 0
   - note: conflict error
-    disable_partial: true
     query: data.x.p = 1
     modules:
       - |
@@ -173,7 +154,6 @@ cases:
         p = 2
     want_error: "unreachable"  # TODO(tsandall): replace with conflict error.
   - note: packages
-    disable_partial: true
     query: data.x.p = 1
     modules:
       - |

--- a/test/wasm/assets/007_complete.yaml
+++ b/test/wasm/assets/007_complete.yaml
@@ -164,3 +164,27 @@ cases:
         package y
         p = 1
     return_code: 1
+  - note: dereference
+    query: data.x.p[0].a = 1
+    modules:
+      - |
+        package x
+        p = [{
+          "a": 1,
+          "b": 2
+        }]
+    return_code: 1
+  - note: iteration embedded
+    query: data.x.p[i].a[j] = 1
+    modules:
+      - |
+        package x
+        p = [{"a": [2, 3]}, {"a": [3, 1]}, {"a": []}]
+    return_code: 1
+  - note: iteration embedded (negative)
+    query: data.x.p[i].a[j] = 1
+    modules:
+      - |
+        package x
+        p = [{"a": [2, 3]}, {"a": [3, 2]}, {"a": []}]
+    return_code: 0

--- a/test/wasm/assets/007_complete.yaml
+++ b/test/wasm/assets/007_complete.yaml
@@ -1,0 +1,170 @@
+cases:
+  - note: constants
+    disable_partial: true
+    query: data.x.p = 1
+    modules:
+      - |
+        package x
+        p = 1
+    return_code: 1
+  - note: constants (negative)
+    disable_partial: true
+    query: data.x.p = 1
+    modules:
+      - |
+        package x
+        p = 2
+    return_code: 0
+  - note: variable
+    disable_partial: true
+    query: data.x.p = 1
+    modules:
+      - |
+        package x
+        p = y { x = 1; y = x }
+    return_code: 1
+  - note: variable (negative)
+    disable_partial: true
+    query: data.x.p = 1
+    modules:
+      - |
+        package x
+        p = y { x = 2; y = x }
+    return_code: 0
+  - note: conjunction
+    disable_partial: true
+    query: data.x.p = 1
+    modules:
+      - |
+        package x
+        p = 1 { q; r }
+        q { true }
+        r { true }
+    return_code: 1
+  - note: conjunction (negative)
+    disable_partial: true
+    query: data.x.p = 1
+    modules:
+      - |
+        package x
+        p = 1 { q; r }
+        q { true }
+        r { false }
+    return_code: 0
+  - note: disjunction
+    disable_partial: true
+    query: data.x.p = 2
+    modules:
+      - |
+        package x
+        p = 1 { false }
+        p = 2 { true }
+        p = 3 { false }
+    return_code: 1
+  - note: disjunction (negative)
+    disable_partial: true
+    query: data.x.p = 1
+    modules:
+      - |
+        package x
+        p = 1 { false }
+        p = 2 { false }
+        p = 3 { true }
+    return_code: 0
+  - note: negation
+    disable_partial: true
+    query: not data.x.p = 1
+    modules:
+      - |
+        package x
+        p = 1 { false }  # undefined
+    return_code: 1
+  - note: negation (negative)
+    disable_partial: true
+    query: not data.x.p = 1
+    modules:
+      - |
+        package x
+        p = 1
+    return_code: 0
+  - note: chain
+    disable_partial: true
+    query: data.x.p = 1
+    modules:
+      - |
+        package x
+        p = q
+        q = r
+        r = 1
+    return_code: 1
+  - note: chain (negative)
+    disable_partial: true
+    query: data.x.p = 1
+    modules:
+      - |
+        package x
+        p = q
+        q = r
+        r = 2
+    return_code: 0
+  - note: chain input
+    disable_partial: true
+    query: data.x.p = true
+    modules:
+      - |
+        package x
+        p = q
+        q = r
+        r { input.x = 1 }
+    input: {"x": 1}
+    return_code: 1
+  - note: chain input (negative)
+    disable_partial: true
+    query: data.x.p = true
+    modules:
+      - |
+        package x
+        p = q
+        q = r
+        r { input.x = 2 }
+    input: {"x": 1}
+    return_code: 0
+  - note: iteration
+    disable_partial: true
+    query: data.x.p = 1
+    modules:
+      - |
+        package x
+        p = 1 { input[x] = 1 }
+    input: [3,2,1]
+    return_code: 1
+  - note: iteration (negative)
+    disable_partial: true
+    query: data.x.p = 1
+    modules:
+      - |
+        package x
+        p = 1 { input[x] = 4 }
+    input: [3,2,1]
+    return_code: 0
+  - note: conflict error
+    disable_partial: true
+    query: data.x.p = 1
+    modules:
+      - |
+        package x
+        p = 1
+        p = 2
+    want_error: "unreachable"  # TODO(tsandall): replace with conflict error.
+  - note: packages
+    disable_partial: true
+    query: data.x.p = 1
+    modules:
+      - |
+        package x
+        import data.y.p
+        p = p
+      - |
+        package y
+        p = 1
+    return_code: 1

--- a/test/wasm/assets/007_complete.yaml
+++ b/test/wasm/assets/007_complete.yaml
@@ -31,6 +31,22 @@ cases:
         package x
         p = y { x = 2; y = x }
     return_code: 0
+  - note: composites
+    disable_partial: true
+    query: data.x.p = [1]
+    modules:
+      - |
+        package x
+        p = [x] { x = 1 }
+    return_code: 1
+  - note: composites (negative)
+    disable_partial: true
+    query: data.x.p = [1]
+    modules:
+      - |
+        package x
+        p = [x] { x = 2 }
+    return_code: 0
   - note: conjunction
     disable_partial: true
     query: data.x.p = 1

--- a/test/wasm/assets/008_functions.yaml
+++ b/test/wasm/assets/008_functions.yaml
@@ -1,6 +1,5 @@
 cases:
   - note: identity
-    disable_partial: true
     query: data.x.f(1, 1)
     modules:
       - |
@@ -8,7 +7,6 @@ cases:
         f(x) = x
     return_code: 1
   - note: identity (negative)
-    disable_partial: true
     query: data.x.f(1, 2)
     modules:
       - |
@@ -16,7 +14,6 @@ cases:
         f(x) = x
     return_code: 0
   - note: identity implicit
-    disable_partial: true
     query: data.x.f(1) = 1
     modules:
       - |
@@ -24,7 +21,6 @@ cases:
         f(x) = x
     return_code: 1
   - note: identity implicit (negative)
-    disable_partial: true
     query: data.x.f(1) = 2
     modules:
       - |
@@ -32,7 +28,6 @@ cases:
         f(x) = x
     return_code: 0
   - note: composite arg
-    disable_partial: true
     query: data.x.f([1]) = 1
     modules:
       - |
@@ -40,7 +35,6 @@ cases:
         f(x) = x[0]
     return_code: 1
   - note: composite param
-    disable_partial: true
     query: data.x.f([1]) = 1
     modules:
       - |
@@ -48,7 +42,6 @@ cases:
         f([x]) = x
     return_code: 1
   - note: multiple params
-    disable_partial: true
     query: data.x.f(1, 2) = [2, 1]
     modules:
       - |
@@ -56,7 +49,6 @@ cases:
         f(x, y) = [y, x]
     return_code: 1
   - note: multiple params (negative)
-    disable_partial: true
     query: data.x.f(1, 2) = [2, 1]
     modules:
       - |
@@ -64,7 +56,6 @@ cases:
         f(x, y) = [x, x]
     return_code: 0
   - note: disjunction
-    disable_partial: true
     query: data.x.f(1) = 0
     modules:
       - |
@@ -73,7 +64,6 @@ cases:
         f(x) = 0 { x > 0 }
     return_code: 1
   - note: disjunction (negative)
-    disable_partial: true
     query: data.x.f(1) = 2
     modules:
       - |
@@ -82,7 +72,6 @@ cases:
         f(x) = 0 { x > 0 }
     return_code: 0
   - note: negation
-    disable_partial: true
     query: not data.x.f(-1)
     modules:
       - |
@@ -90,7 +79,6 @@ cases:
         f(x) = x { x >= 0 }
     return_code: 1
   - note: input
-    disable_partial: true
     query: data.x.f(1) = 1
     modules:
       - |
@@ -100,7 +88,6 @@ cases:
     input: {"x": 1}
     return_code: 1
   - note: input (negative)
-    disable_partial: true
     query: data.x.f(1) = 1
     modules:
       - |
@@ -110,7 +97,6 @@ cases:
     input: {"x": 2}
     return_code: 0
   - note: conflict error
-    disable_partial: true
     query: data.x.f(1) = 1
     modules:
       - |

--- a/test/wasm/assets/008_functions.yaml
+++ b/test/wasm/assets/008_functions.yaml
@@ -1,0 +1,120 @@
+cases:
+  - note: identity
+    disable_partial: true
+    query: data.x.f(1, 1)
+    modules:
+      - |
+        package x
+        f(x) = x
+    return_code: 1
+  - note: identity (negative)
+    disable_partial: true
+    query: data.x.f(1, 2)
+    modules:
+      - |
+        package x
+        f(x) = x
+    return_code: 0
+  - note: identity implicit
+    disable_partial: true
+    query: data.x.f(1) = 1
+    modules:
+      - |
+        package x
+        f(x) = x
+    return_code: 1
+  - note: identity implicit (negative)
+    disable_partial: true
+    query: data.x.f(1) = 2
+    modules:
+      - |
+        package x
+        f(x) = x
+    return_code: 0
+  - note: composite arg
+    disable_partial: true
+    query: data.x.f([1]) = 1
+    modules:
+      - |
+        package x
+        f(x) = x[0]
+    return_code: 1
+  - note: composite param
+    disable_partial: true
+    query: data.x.f([1]) = 1
+    modules:
+      - |
+        package x
+        f([x]) = x
+    return_code: 1
+  - note: multiple params
+    disable_partial: true
+    query: data.x.f(1, 2) = [2, 1]
+    modules:
+      - |
+        package x
+        f(x, y) = [y, x]
+    return_code: 1
+  - note: multiple params (negative)
+    disable_partial: true
+    query: data.x.f(1, 2) = [2, 1]
+    modules:
+      - |
+        package x
+        f(x, y) = [x, x]
+    return_code: 0
+  - note: disjunction
+    disable_partial: true
+    query: data.x.f(1) = 0
+    modules:
+      - |
+        package x
+        f(x) = 1 { x <= 0 }
+        f(x) = 0 { x > 0 }
+    return_code: 1
+  - note: disjunction (negative)
+    disable_partial: true
+    query: data.x.f(1) = 2
+    modules:
+      - |
+        package x
+        f(x) = 1 { x <= 0 }
+        f(x) = 0 { x > 0 }
+    return_code: 0
+  - note: negation
+    disable_partial: true
+    query: not data.x.f(-1)
+    modules:
+      - |
+        package x
+        f(x) = x { x >= 0 }
+    return_code: 1
+  - note: input
+    disable_partial: true
+    query: data.x.f(1) = 1
+    modules:
+      - |
+        package x
+        f(x) = g(x)
+        g(x) = x { input.x = x }
+    input: {"x": 1}
+    return_code: 1
+  - note: input (negative)
+    disable_partial: true
+    query: data.x.f(1) = 1
+    modules:
+      - |
+        package x
+        f(x) = g(x)
+        g(x) = x { input.x = x }
+    input: {"x": 2}
+    return_code: 0
+  - note: conflict error
+    disable_partial: true
+    query: data.x.f(1) = 1
+    modules:
+      - |
+        package x
+        f(x) = 1
+        f(x) = 2
+    want_error: "unreachable"  # TODO(tsandall): replace with conflict error.

--- a/test/wasm/assets/009_default.yaml
+++ b/test/wasm/assets/009_default.yaml
@@ -1,0 +1,36 @@
+cases:
+  - note: default
+    disable_partial: true
+    query: data.x.p = 1
+    modules:
+      - |
+        package x
+        default p = 1
+    return_code: 1
+  - note: default fallback
+    disable_partial: true
+    query: data.x.p = 1
+    modules:
+      - |
+        package x
+        default p = 1
+        p = 2 { false }
+    return_code: 1
+  - note: default fallback (negative)
+    disable_partial: true
+    query: data.x.p = 2
+    modules:
+      - |
+        package x
+        default p = 1
+        p = 2 { false }
+    return_code: 0
+  - note: default skipped
+    disable_partial: true
+    query: data.x.p = 2
+    modules:
+      - |
+        package x
+        default p = 1
+        p = 2
+    return_code: 1

--- a/test/wasm/assets/009_default.yaml
+++ b/test/wasm/assets/009_default.yaml
@@ -1,6 +1,5 @@
 cases:
   - note: default
-    disable_partial: true
     query: data.x.p = 1
     modules:
       - |
@@ -8,7 +7,6 @@ cases:
         default p = 1
     return_code: 1
   - note: default fallback
-    disable_partial: true
     query: data.x.p = 1
     modules:
       - |
@@ -17,7 +15,6 @@ cases:
         p = 2 { false }
     return_code: 1
   - note: default fallback (negative)
-    disable_partial: true
     query: data.x.p = 2
     modules:
       - |
@@ -26,7 +23,6 @@ cases:
         p = 2 { false }
     return_code: 0
   - note: default skipped
-    disable_partial: true
     query: data.x.p = 2
     modules:
       - |

--- a/test/wasm/assets/010_else.yaml
+++ b/test/wasm/assets/010_else.yaml
@@ -1,0 +1,94 @@
+cases:
+  - note: short circuit
+    query: data.x.p = 1
+    modules:
+      - |
+        package x
+        p = 1 { true }
+        else = 2 { true }
+    return_code: 1
+  - note: fallthrough
+    query: data.x.p = 2
+    modules:
+      - |
+        package x
+        p = 1 { false }
+        else = 2 { true }
+        else = 3 { true }
+    return_code: 1
+  - note: fallthrough second
+    query: data.x.p = 3
+    modules:
+      - |
+        package x
+        p = 1 { false }
+        else = 2 { false }
+        else = 3 { true }
+    return_code: 1
+  - note: fallthrough multiple
+    query: data.x.p = 5
+    modules:
+      - |
+        package x
+        p = 1 { false }
+        else = 2 { false }
+        else = 3 { false }
+        p = 4 { false }
+        else = 5 { true }
+    return_code: 1
+  - note: short circuit (iteration)
+    query: data.x.p = 1
+    modules:
+      - |
+        package x
+        p = 1 { input.x[_] = 1 }
+        else = 2 { true }
+    input: {"x": [3,2,1]}
+    return_code: 1
+  - note: fallthrough (iteration)
+    query: data.x.p = 1
+    modules:
+      - |
+        package x
+        p = 1 { input.x[_] = "deadbeef" }
+        else = 2 { input.x[_] = 1 }
+    input: {"x": [3,2,1]}
+    return_code: 0
+  - note: chain
+    query: data.x.p = 3
+    modules:
+      - |
+        package x
+        p = 1 { false }
+        else = q { true }
+        q = 2 { false }
+        else = r { true }
+        r = 3
+    return_code: 1
+  - note: chain (input)
+    query: data.x.p = 2
+    modules:
+      - |
+        package x
+        p = q
+        q = 1 { input.deadbeef = 1 }
+        else = 2 { input.x = 2 }
+    return_code: 1
+    input: {"x": 2}
+  - note: functions short circuit
+    query: data.x.f(1) = 1
+    modules:
+      - |
+        package x
+        f(x) = 1 { true }
+        else = 2 { true }
+    return_code: 1
+  - note: functions fallthrough
+    query: data.x.f(1) = 3
+    modules:
+      - |
+        package x
+        f(x) = 1 { false }
+        else = 2 { false }
+        else = 3 { true }
+    return_code: 1

--- a/test/wasm/assets/011_partialsets.yaml
+++ b/test/wasm/assets/011_partialsets.yaml
@@ -43,3 +43,70 @@ cases:
         p[[x]] { x = 1 }
         p[[y]] { y = 2 }
     return_code: 1
+  - note: set membership
+    query: data.x.p[1]
+    modules:
+      - |
+        package x
+        p[1]
+        p[2]
+    return_code: 1
+  - note: set membership (negative)
+    query: data.x.p[3]
+    modules:
+      - |
+        package x
+        p[1]
+        p[2]
+    return_code: 0
+  - note: set membership (negation)
+    query: not data.x.p[3]
+    modules:
+      - |
+        package x
+        p[1]
+        p[2]
+    return_code: 1
+  - note: set iteration
+    query: data.x.p[x]; x > 1
+    modules:
+      - |
+        package x
+        p[1]
+        p[2]
+    return_code: 1
+  - note: set iteration (negative)
+    query: data.x.p[x]; x > 2
+    modules:
+      - |
+        package x
+        p[1]
+        p[2]
+    return_code: 0
+  - note: set composites
+    query: a := [1,x]; data.x.p[a]; x == "y"
+    modules:
+      - |
+        package x
+        p[[1, "x"]]
+        p[[1, "y"]]
+        p[[2, "x"]]
+    return_code: 1
+  - note: set dereference
+    query: data.x.p[x].a == 1; x.b == "y"
+    modules:
+      - |
+        package x
+        p[{"a": 1, "b": "x"}]
+        p[{"a": 1, "b": "y"}]
+        p[{"a": 1, "b": "y"}]
+    return_code: 1
+  - note: set dereference (negative)
+    query: data.x.p[x].a == 100
+    modules:
+      - |
+        package x
+        p[{"a": 1}]
+        p[{"a": 2}]
+        p[{"a": 3}]
+    return_code: 0

--- a/test/wasm/assets/011_partialsets.yaml
+++ b/test/wasm/assets/011_partialsets.yaml
@@ -110,3 +110,25 @@ cases:
         p[{"a": 2}]
         p[{"a": 3}]
     return_code: 0
+  - note: set chain
+    query: data.x.p[x]; x = 2
+    modules:
+      - |
+        package x
+        p[x] { q[x]; r[x] }
+        q[1]
+        q[2]
+        q[3]
+        r[2]
+    return_code: 1
+  - note: set chain (negative)
+    query: data.x.p[x]; x = 2
+    modules:
+      - |
+        package x
+        p[x] { q[x]; r[x] }
+        q[1]
+        q[2]
+        q[3]
+        r[3]
+    return_code: 0

--- a/test/wasm/assets/011_partialsets.yaml
+++ b/test/wasm/assets/011_partialsets.yaml
@@ -1,6 +1,5 @@
 cases:
   - note: additive
-    disable_partial: true
     query: data.x.p = {2,1}
     modules:
       - |
@@ -9,7 +8,6 @@ cases:
         p[2]
     return_code: 1
   - note: additive (negative)
-    disable_partial: true
     query: data.x.p = {2,1}
     modules:
       - |
@@ -19,7 +17,6 @@ cases:
         p[3]
     return_code: 0
   - note: input
-    disable_partial: true
     query: data.x.p = {2,1}
     modules:
       - |
@@ -29,7 +26,6 @@ cases:
     return_code: 1
     input: {"x": 1, "y": 2}
   - note: input (negative)
-    disable_partial: true
     query: data.x.p = {2,1}
     modules:
       - |
@@ -40,7 +36,6 @@ cases:
     return_code: 1
     input: {"x": 1, "y": 2}
   - note: composites
-    disable_partial: true
     query: data.x.p = {[2],[1]}
     modules:
       - |

--- a/test/wasm/assets/011_partialsets.yaml
+++ b/test/wasm/assets/011_partialsets.yaml
@@ -1,0 +1,50 @@
+cases:
+  - note: additive
+    disable_partial: true
+    query: data.x.p = {2,1}
+    modules:
+      - |
+        package x
+        p[1]
+        p[2]
+    return_code: 1
+  - note: additive (negative)
+    disable_partial: true
+    query: data.x.p = {2,1}
+    modules:
+      - |
+        package x
+        p[1]
+        p[2]
+        p[3]
+    return_code: 0
+  - note: input
+    disable_partial: true
+    query: data.x.p = {2,1}
+    modules:
+      - |
+        package x
+        p[1] { input.x = 1 }
+        p[2] { input.y = 2 }
+    return_code: 1
+    input: {"x": 1, "y": 2}
+  - note: input (negative)
+    disable_partial: true
+    query: data.x.p = {2,1}
+    modules:
+      - |
+        package x
+        p[1] { input.x = 1 }
+        p[2] { input.y = 2 }
+        p[3] { input.z = 3 }
+    return_code: 1
+    input: {"x": 1, "y": 2}
+  - note: composites
+    disable_partial: true
+    query: data.x.p = {[2],[1]}
+    modules:
+      - |
+        package x
+        p[[x]] { x = 1 }
+        p[[y]] { y = 2 }
+    return_code: 1

--- a/test/wasm/assets/012_partialobjects.yaml
+++ b/test/wasm/assets/012_partialobjects.yaml
@@ -1,6 +1,5 @@
 cases:
   - note: additive
-    disable_partial: true
     query: 'data.x.p = {"a": 1, "b": 2}'
     modules:
       - |
@@ -9,7 +8,6 @@ cases:
         p["b"] = 2
     return_code: 1
   - note: additive (negative)
-    disable_partial: true
     query:  'data.x.p = {"a": 1, "b": 2}'
     modules:
       - |
@@ -19,7 +17,6 @@ cases:
         p["c"] = 3
     return_code: 0
   - note: input
-    disable_partial: true
     query: 'data.x.p = {"b": 2, "a": 1}'
     modules:
       - |
@@ -29,7 +26,6 @@ cases:
     return_code: 1
     input: {"x": 1, "y": 2}
   - note: input (negative)
-    disable_partial: true
     query: 'data.x.p = {"a": 1, "b": 2}'
     modules:
       - |
@@ -40,7 +36,6 @@ cases:
     return_code: 1
     input: {"x": 1, "y": 2}
   - note: composites
-    disable_partial: true
     query: 'data.x.p = {"a": [1], "b": [2]}'
     modules:
       - |
@@ -49,7 +44,6 @@ cases:
         p[x] = [y] { x = "b"; y = 2 }
     return_code: 1
   - note: conflict error
-    disable_partial: true
     query: 'data.x.p = {"a": 1}'
     modules:
       - |

--- a/test/wasm/assets/012_partialobjects.yaml
+++ b/test/wasm/assets/012_partialobjects.yaml
@@ -51,3 +51,17 @@ cases:
         p["x"] = 1
         p["x"] = 2
     want_error: "unreachable"  # TODO(tsandall): replace with conflict error
+  - note: object dereference
+    query: data.x.p.a.b = 1
+    modules:
+      - |
+        package x
+        p["a"] = {"b": 1}
+    return_code: 1
+  - note: object dereference (negative)
+    query: data.x.p.a.b = 1
+    modules:
+      - |
+        package x
+        p["a"] = {"b": 2}
+    return_code: 0

--- a/test/wasm/assets/012_partialobjects.yaml
+++ b/test/wasm/assets/012_partialobjects.yaml
@@ -1,0 +1,59 @@
+cases:
+  - note: additive
+    disable_partial: true
+    query: 'data.x.p = {"a": 1, "b": 2}'
+    modules:
+      - |
+        package x
+        p["a"] = 1
+        p["b"] = 2
+    return_code: 1
+  - note: additive (negative)
+    disable_partial: true
+    query:  'data.x.p = {"a": 1, "b": 2}'
+    modules:
+      - |
+        package x
+        p["a"] = 1
+        p["b"] = 2
+        p["c"] = 3
+    return_code: 0
+  - note: input
+    disable_partial: true
+    query: 'data.x.p = {"b": 2, "a": 1}'
+    modules:
+      - |
+        package x
+        p["a"] = 1 { input.x = 1 }
+        p["b"] = 2 { input.y = 2 }
+    return_code: 1
+    input: {"x": 1, "y": 2}
+  - note: input (negative)
+    disable_partial: true
+    query: 'data.x.p = {"a": 1, "b": 2}'
+    modules:
+      - |
+        package x
+        p["a"] = 1 { input.x = 1 }
+        p["b"] = 2 { input.y = 2 }
+        p["c"] = 3 { input.z = 3 }
+    return_code: 1
+    input: {"x": 1, "y": 2}
+  - note: composites
+    disable_partial: true
+    query: 'data.x.p = {"a": [1], "b": [2]}'
+    modules:
+      - |
+        package x
+        p[x] = [y] { x = "a"; y = 1 }
+        p[x] = [y] { x = "b"; y = 2 }
+    return_code: 1
+  - note: conflict error
+    disable_partial: true
+    query: 'data.x.p = {"a": 1}'
+    modules:
+      - |
+        package x
+        p["x"] = 1
+        p["x"] = 2
+    want_error: "unreachable"  # TODO(tsandall): replace with conflict error

--- a/test/wasm/assets/013_extent.yaml
+++ b/test/wasm/assets/013_extent.yaml
@@ -1,0 +1,57 @@
+cases:
+  - note: data extent
+    query: |
+      data == {
+        "x": {
+          "y": {
+            "p": 1,
+            "r": {
+              "a": 3
+            },
+            "s": {"elem1"}
+          }
+        }
+      }
+    modules:
+      - |
+        package x.y
+        p = 1
+        q = 2 { false }
+        r["a"] = 3
+        r["b"] = 4 { false }
+        s["elem1"]
+        s["elem2"] { false }
+    return_code: 1
+  - note: package extent
+    query: |
+      data.x == {"y": {"p": 1}}
+    modules:
+      - |
+        package x.y
+        p = 1
+        q = 2 { false }
+    return_code: 1
+  - note: all undefined
+    query: |
+      data.x == {"y": {}}
+    modules:
+      - |
+        package x.y
+        p = 1 { false }
+    return_code: 1
+  - note: skip functions
+    query: |
+      data.x == {"y": {"p": 1}}
+    modules:
+      - |
+        package x.y
+        p = 1
+        f(x) = x
+    return_code: 1
+  - note: empty package
+    query: |
+      data.x == {"y": {}}
+    modules:
+      - |
+        package x.y
+    return_code: 1

--- a/test/wasm/cmd/testgen.go
+++ b/test/wasm/cmd/testgen.go
@@ -34,13 +34,12 @@ type testCaseSet struct {
 }
 
 type testCase struct {
-	Note           string       `json:"note"`
-	Query          string       `json:"query"`
-	Modules        []string     `json:"modules"`
-	DisablePartial bool         `json:"disable_partial"`
-	Input          *interface{} `json:"input"`
-	ReturnCode     int          `json:"return_code"`
-	WantError      string       `json:"want_error"`
+	Note       string       `json:"note"`
+	Query      string       `json:"query"`
+	Modules    []string     `json:"modules"`
+	Input      *interface{} `json:"input"`
+	ReturnCode int          `json:"return_code"`
+	WantError  string       `json:"want_error"`
 }
 
 type compiledTestCaseSet struct {
@@ -61,7 +60,7 @@ func compileTestCases(ctx context.Context, tests testCaseSet) (*compiledTestCase
 		for idx, module := range tc.Modules {
 			args = append(args, rego.Module(fmt.Sprintf("module%d.rego", idx), module))
 		}
-		cr, err := rego.New(args...).Compile(ctx, rego.CompilePartial(!tc.DisablePartial))
+		cr, err := rego.New(args...).Compile(ctx)
 		if err != nil {
 			return nil, err
 		}

--- a/test/wasm/cmd/testgen.go
+++ b/test/wasm/cmd/testgen.go
@@ -24,8 +24,9 @@ import (
 )
 
 type params struct {
-	Output   string
-	InputDir string
+	Output          string
+	InputDir        string
+	TestFilePattern string
 }
 
 type testCaseSet struct {
@@ -94,7 +95,7 @@ func run(params params, args []string) error {
 	}
 
 	for i := range files {
-		if strings.HasSuffix(files[i].Name(), ".yaml") {
+		if ok, err := path.Match(params.TestFilePattern, files[i].Name()); ok {
 
 			err := func() error {
 				bs, err := ioutil.ReadFile(filepath.Join(params.InputDir, files[i].Name()))
@@ -127,6 +128,8 @@ func run(params params, args []string) error {
 			if err != nil {
 				return errors.Wrap(err, files[i].Name())
 			}
+		} else if err != nil {
+			return errors.Wrap(err, files[i].Name())
 		}
 	}
 
@@ -191,8 +194,9 @@ func main() {
 		},
 	}
 
-	command.Flags().StringVarP(&params.Output, "output", "o", "", "set path of output file")
-	command.Flags().StringVarP(&params.InputDir, "input-dir", "i", "", "set path of input directory containing test files")
+	command.Flags().StringVarP(&params.Output, "output", "", "", "set path of output file")
+	command.Flags().StringVarP(&params.InputDir, "input-dir", "", "", "set path of input directory containing test files")
+	command.Flags().StringVarP(&params.TestFilePattern, "file-pattern", "", "*.yaml", "set filename pattern to match test files against")
 
 	if err := command.Execute(); err != nil {
 		os.Exit(1)


### PR DESCRIPTION
The PR enables basic support for planning & compiling rules.

There was a bit of churn in the planner as more rule kinds were supported but not too bad. At this point all rules are handled by the same code path. Soon we will want to generate secondary functions for partial object/set rules but that'll likely take a different path.

The next step will be to flesh out support for references to virtual docs. Only refs that refer to the entire virtual doc are supported right now. The next PR will add support for dereferencing and iteration.