### PR TITLE
tester: Fix tester.Result by removing conversion

### DIFF
--- a/tester/runner.go
+++ b/tester/runner.go
@@ -74,7 +74,7 @@ func (r Result) Pass() bool {
 }
 
 func (r *Result) String() string {
-	return fmt.Sprintf("%v.%v: %v (%v)", r.Package, r.Name, r.outcome(), r.Duration/time.Microsecond)
+	return fmt.Sprintf("%v.%v: %v (%v)", r.Package, r.Name, r.outcome(), r.Duration)
 }
 
 func (r *Result) outcome() string {


### PR DESCRIPTION
The tester.Result#String function was unnecessarily converting the
tester.Result#Duration field into microseconds. This made the reported
latency off by 3-orders of magnitude. This change was only tested
manually because asserting on an expected duration is going to be
flaky.

Fixes #1432

Signed-off-by: Torin Sandall <torinsandall@gmail.com>