### PR TITLE
wasm: Fix test runner to catch interrupts

### DIFF
--- a/build/run-wasm-tests.sh
+++ b/build/run-wasm-tests.sh
@@ -2,6 +2,32 @@
 
 set -e
 
-mkdir -p _test
-go run test/wasm/cmd/testgen.go --input-dir test/wasm/assets --output _test/testcases.tar.gz $@
-docker run -it --rm -e VERBOSE=$VERBOSE -v $PWD:/src -w /src node:8 bash -c 'mkdir -p /test; tar xzf _test/testcases.tar.gz -C /test; cd /test; node test.js opa.wasm'
+function interrupt {
+    echo "caught interrupt: exiting"
+    docker kill $container_name >/dev/null
+    exit 1
+}
+
+trap interrupt SIGINT SIGTERM
+
+# Generate the test tarball from the asset files.
+go run test/wasm/cmd/testgen.go \
+   --input-dir test/wasm/assets \
+   --output _test/testcases.tar.gz \
+   $@
+
+# Execute wasm tests inside a node container.
+container_name=opa-wasm-test-$RANDOM
+
+docker run \
+       --name $container_name \
+       --rm \
+       -e VERBOSE=$VERBOSE \
+       -v $PWD:/src \
+       -w /src \
+       node:8 \
+       sh -c 'mkdir -p /test; tar xzf _test/testcases.tar.gz -C /test; cd /test; node test.js opa.wasm' &
+
+# Wait for the docker run process to finish.
+docker_run_pid=$!
+wait $docker_run_pid

--- a/test/wasm/cmd/testgen.go
+++ b/test/wasm/cmd/testgen.go
@@ -76,6 +76,10 @@ func run(params params, args []string) error {
 
 	ctx := context.Background()
 
+	if err := os.MkdirAll(path.Dir(params.Output), 0755); err != nil {
+		return err
+	}
+
 	f, err := os.Create(params.Output)
 	if err != nil {
 		return err


### PR DESCRIPTION
These changes remove the -it flags from the docker run command used to
execute the Wasm tests. This will fix the original issue. In addition,
these changes update the test runner to catch interrupts so that
developers can still ctrl+c out of the test run.

Lastly, update the test generation program to create the directory
hierarchy instead of expecting the caller to do that.

Fixes #1431

Signed-off-by: Torin Sandall <torinsandall@gmail.com>