### PR TITLE
server: Add request headers to authorization input

### DIFF
--- a/docs/content/security.md
+++ b/docs/content/security.md
@@ -171,7 +171,28 @@ policy:
         # URL parameters represented as an object of string arrays.
         # For example: metrics&explain=true is represented as
         # {"metrics": [""], "explain": ["true"]}
-        "params": <HTTP URL Parameters>
+        "params": <HTTP URL Parameters>,
+
+        # Request headers represented as an object of string arrays.
+        #
+        # Example Request Headers:
+        #
+        #   host: acmecorp.com
+        #   x-custom: secretvalue
+        #
+        # Example input.headers Value:
+        #
+        #   {"Host": ["acmecorp.com"], "X-Custom": ["mysecret"]}
+        #
+        # Example header check:
+        #
+        #   input.headers["X-Custom"][_] = "mysecret"
+        #
+        # Header keys follow canonical MIME form. The first character and any
+        # characters following a hyphen are uppercase. The rest are lowercase.
+        # If the header key contains space or invalid header field bytes,
+        # no conversion is performed.
+        "headers": <HTTP Headers>
     }
 }
 ```

--- a/server/authorizer/authorizer.go
+++ b/server/authorizer/authorizer.go
@@ -107,9 +107,10 @@ func makeInput(r *http.Request) (interface{}, error) {
 	query := r.URL.Query()
 
 	input := map[string]interface{}{
-		"path":   path,
-		"method": method,
-		"params": query,
+		"path":    path,
+		"method":  method,
+		"params":  query,
+		"headers": r.Header,
 	}
 
 	identity, ok := identifier.Identity(r)

--- a/server/authorizer/authorizer_test.go
+++ b/server/authorizer/authorizer_test.go
@@ -237,6 +237,11 @@ func TestMakeInput(t *testing.T) {
 		panic(err)
 	}
 
+	req.Header.Add("x-custom", "foo")
+	req.Header.Add("X-custom", "bar")
+	req.Header.Add("x-custom-2", "baz")
+	req.Header.Add("custom-header-3?", "wat")
+
 	query := req.URL.Query()
 
 	// set query parameters
@@ -256,6 +261,11 @@ func TestMakeInput(t *testing.T) {
 		  "path": ["foo","bar"],
 		  "method": "GET",
 		  "identity": "bob",
+		  "headers": {
+			"X-Custom": ["foo", "bar"],
+			"X-Custom-2": ["baz"],
+			"custom-header-3?": ["wat"]
+		  },
 		  "params": {"explain": ["full"], "pretty": ["true"]}
 		}
 	`))


### PR DESCRIPTION
These changes update the server to include request headers in the
authorization input document.

Fixes #1456

Signed-off-by: Torin Sandall <torinsandall@gmail.com>