### PR TITLE
Add timezone functionality to builtin time/date functions

### DIFF
--- a/ast/builtins.go
+++ b/ast/builtins.go
@@ -1078,7 +1078,7 @@ var ParseDurationNanos = &Builtin{
 var Date = &Builtin{
 	Name: "time.date",
 	Decl: types.NewFunction(
-		types.Args(types.N),
+		types.Args(types.A),
 		types.NewArray([]types.Type{types.N, types.N, types.N}, nil),
 	),
 }
@@ -1087,7 +1087,7 @@ var Date = &Builtin{
 var Clock = &Builtin{
 	Name: "time.clock",
 	Decl: types.NewFunction(
-		types.Args(types.N),
+		types.Args(types.A),
 		types.NewArray([]types.Type{types.N, types.N, types.N}, nil),
 	),
 }
@@ -1096,7 +1096,7 @@ var Clock = &Builtin{
 var Weekday = &Builtin{
 	Name: "time.weekday",
 	Decl: types.NewFunction(
-		types.Args(types.N),
+		types.Args(types.A),
 		types.S,
 	),
 }

--- a/ast/builtins.go
+++ b/ast/builtins.go
@@ -1078,7 +1078,12 @@ var ParseDurationNanos = &Builtin{
 var Date = &Builtin{
 	Name: "time.date",
 	Decl: types.NewFunction(
-		types.Args(types.A),
+		types.Args(
+			types.NewAny(
+				types.N,
+				types.NewArray([]types.Type{types.N, types.S}, nil),
+			),
+		),
 		types.NewArray([]types.Type{types.N, types.N, types.N}, nil),
 	),
 }
@@ -1087,7 +1092,12 @@ var Date = &Builtin{
 var Clock = &Builtin{
 	Name: "time.clock",
 	Decl: types.NewFunction(
-		types.Args(types.A),
+		types.Args(
+			types.NewAny(
+				types.N,
+				types.NewArray([]types.Type{types.N, types.S}, nil),
+			),
+		),
 		types.NewArray([]types.Type{types.N, types.N, types.N}, nil),
 	),
 }
@@ -1096,7 +1106,12 @@ var Clock = &Builtin{
 var Weekday = &Builtin{
 	Name: "time.weekday",
 	Decl: types.NewFunction(
-		types.Args(types.A),
+		types.Args(
+			types.NewAny(
+				types.N,
+				types.NewArray([]types.Type{types.N, types.S}, nil),
+			),
+		),
 		types.S,
 	),
 }

--- a/docs/content/language-reference.md
+++ b/docs/content/language-reference.md
@@ -194,12 +194,20 @@ If there are any unrecognized constraints then the token is considered invalid.
 | <span class="opa-keep-it-together">``output := time.parse_ns(layout, value)``</span> | ``output`` is ``number`` representing the time ``value`` in nanoseconds since epoch. See the [Go `time` package documentation](https://golang.org/pkg/time/#Parse) for more details on ``layout``. |
 | <span class="opa-keep-it-together">``output := time.parse_rfc3339_ns(value)``</span> | ``output`` is ``number`` representing the time ``value`` in nanoseconds since epoch. |
 | <span class="opa-keep-it-together">``output := time.parse_duration_ns(duration)``</span> | ``output`` is ``number`` representing the duration ``duration`` in nanoseconds. See the [Go `time` package documentation](https://golang.org/pkg/time/#ParseDuration) for more details on ``duration``. |
-| <span class="opa-keep-it-together">``output := time.date(ns)``</span> | ``output`` is of the form ``[year, month, day]``, which includes the ``year``, ``month`` (0-12), and ``day`` (0-31) as ``number``s representing the date from the nanoseconds since epoch (``ns``). |
-| <span class="opa-keep-it-together">``output := time.clock(ns)``</span> | ``output`` is of the form ``[hour, minute, second]``, which outputs the ``hour``, ``minute`` (0-59), and ``second`` (0-59) as ``number``s representing the time of day for the nanoseconds since epoch (``ns``). |
-| <span class="opa-keep-it-together">``day := time.weekday(ns)``</span> | outputs the ``day`` as ``string`` representing the day of the week for the nanoseconds since epoch (``ns``). |
+| <span class="opa-keep-it-together">``output := time.date(ns)``<br/>``output := time.date([ns, tz])``</span> | ``output`` is of the form ``[year, month, day]``, which includes the ``year``, ``month`` (0-12), and ``day`` (0-31) as ``number``s representing the date from the nanoseconds since epoch (``ns``) in the timezone (``tz``), if supplied, or as UTC.|
+| <span class="opa-keep-it-together">``output := time.clock(ns)``<br/>``output := time.clock([ns, tz])``</span> | ``output`` is of the form ``[hour, minute, second]``, which outputs the ``hour``, ``minute`` (0-59), and ``second`` (0-59) as ``number``s representing the time of day for the nanoseconds since epoch (``ns``) in the timezone (``tz``), if supplied, or as UTC. |
+| <span class="opa-keep-it-together">``day := time.weekday(ns)``<br/>``day := time.weekday([ns, tz])``</span> | outputs the ``day`` as ``string`` representing the day of the week for the nanoseconds since epoch (``ns``) in the timezone (``tz``), if supplied, or as UTC. |
 
 > Multiple calls to the `time.now_ns` built-in function within a single policy
 evaluation query will always return the same value.
+
+Timezones can be specified as 
+
+* an [IANA Time Zone](https://www.iana.org/time-zones) string e.g. "America/New_York"
+* "UTC" or "", which are equivalent to not passing a timezone (i.e. will return as UTC)
+* "Local", which will use the local timezone. 
+
+Note that the opa executable will need access to the timezone files in the environment it is running in (see the [Go time.LoadLocation()](https://golang.org/pkg/time/#LoadLocation) documentation for more information).
 
 ### Cryptography
 

--- a/topdown/time.go
+++ b/topdown/time.go
@@ -119,10 +119,9 @@ func tzTime(a ast.Value) (t time.Time, err error) {
 	switch va := a.(type) {
 	case ast.Array:
 
-		// not sure what error to return if passed an empty array, but if this isn't handled it panics if passed an empty array
-		// if len(va) == 0 {
-		// 	return time.Time{}, builtins.NewOperandElementErr(<something>)
-		// }
+		if len(va) == 0 {
+			return time.Time{}, builtins.NewOperandTypeErr(1, a, "either number (ns) or [number (ns), string (tz)]")
+		}
 
 		nVal, err = builtins.NumberOperand(va[0].Value, 1)
 		if err != nil {
@@ -159,6 +158,9 @@ func tzTime(a ast.Value) (t time.Time, err error) {
 
 	case ast.Number:
 		nVal = a
+
+	default:
+		return time.Time{}, builtins.NewOperandTypeErr(1, a, "either number (ns) or [number (ns), string (tz)]")
 	}
 
 	value, err := builtins.NumberOperand(nVal, 1)

--- a/topdown/topdown_test.go
+++ b/topdown/topdown_test.go
@@ -2062,7 +2062,13 @@ func TestTopDownTime(t *testing.T) {
 	`}, "100000000")
 
 	runTopDownTestCase(t, data, "date", []string{`
-		p = [year, month, day] { [year, month, day] := time.date(1517832000*1000*1000*1000) }`}, "[2018, 2, 5]")
+		p = [year, month, day] { [year, month, day] := time.date(1517814000*1000*1000*1000) }`}, "[2018, 2, 5]")
+
+	runTopDownTestCase(t, data, "date with LA tz", []string{`
+		p = [year, month, day] { [year, month, day] := time.date([ 1517814000*1000*1000*1000, "America/Los_Angeles" ]) }`}, "[2018, 2, 4]")
+
+	runTopDownTestCase(t, data, "date with empty tz", []string{`
+		p = [year, month, day] { [year, month, day] := time.date([ 1517832000*1000*1000*1000, "" ]) }`}, "[2018, 2, 5]")
 
 	runTopDownTestCase(t, data, "date leap day", []string{`
 		p = [year, month, day] { [year, month, day] := time.date(1582977600*1000*1000*1000) }`}, "[2020, 2, 29]")
@@ -2072,6 +2078,9 @@ func TestTopDownTime(t *testing.T) {
 
 	runTopDownTestCase(t, data, "clock", []string{`
 		p = [hour, minute, second] { [hour, minute, second] := time.clock(1517832000*1000*1000*1000) }`}, "[12, 0, 0]")
+
+	runTopDownTestCase(t, data, "clock with NY tz", []string{`
+		p = [hour, minute, second] { [hour, minute, second] := time.clock([ 1517832000*1000*1000*1000, "America/New_York" ]) }`}, "[7, 0, 0]")
 
 	runTopDownTestCase(t, data, "clock leap day", []string{`
 		p = [hour, minute, second] { [hour, minute, second] := time.clock(1582977600*1000*1000*1000) }`}, "[12, 0, 0]")


### PR DESCRIPTION
Adds timezone support per https://github.com/open-policy-agent/opa/issues/1422.

Signed-off-by: Craig Hooper <craig.hooper@gmail.com>
