### PR TITLE
website: Fix example indentation on frontpage

### DIFF
--- a/docs/website/layouts/partials/home/use-cases.html
+++ b/docs/website/layouts/partials/home/use-cases.html
@@ -6,7 +6,10 @@
         <h2>Use Cases</h2>
 
         <div class="use-cases--content--columns">
-          <p>Open Policy Agent (OPA) is a general-purpose policy engine with uses ranging from authorization and admission control to data filtering. OPA provides greater flexibility and expressiveness than hard-coded service logic or ad-hoc domain-specific languages. And it comes with powerful tooling to help you get started.</p>
+          <p>Open Policy Agent (OPA) is a general-purpose policy engine with uses ranging from authorization and
+            admission control to data filtering. OPA provides greater flexibility and expressiveness than hard-coded
+            service logic or ad-hoc domain-specific languages. And it comes with powerful tooling to help you get
+            started.</p>
 
           <div>
             <p>Here are just a few examples of what you can do with OPA:</p>
@@ -15,7 +18,8 @@
               <li class="use-cases--toc--item"><a href="#admission-control">Kubernetes Admission Control</a></li>
               <li class="use-cases--toc--item"><a href="#api-authorization">HTTP API Authorization</a></li>
               <li class="use-cases--toc--item"><a href="#remote-access">Remote Access</a></li>
-              <li class="use-cases--toc--item"><a href="#partial-evaluation">Data Filtering with Partial Evaluation</a></li>
+              <li class="use-cases--toc--item"><a href="#partial-evaluation">Data Filtering with Partial Evaluation</a>
+              </li>
             </ul>
           </div>
         </div>
@@ -31,7 +35,10 @@
 
 
       <section id="admission-control" class="example">
-        <a class="action--scroll-up" href="/"><svg class="action-icon"><title>Scroll back</title><use xlink:href="#icon--arrow-up"/></svg></a>
+        <a class="action--scroll-up" href="/"><svg class="action-icon">
+            <title>Scroll back</title>
+            <use xlink:href="#icon--arrow-up" />
+          </svg></a>
 
         <h3 class="example--title">Kubernetes Admission Control</h3>
 
@@ -44,7 +51,7 @@
             <span class="example--editor--zoom-button" role="presentation"></span>
             <span class="example--editor--title">invariants.rego — ~/src/policies/admission-control/kubernetes</span>
           </div>
-<pre class="example--editor--body"><span class="code--comment"># Kubernetes Admission Control Invariants</span>
+          <pre class="example--editor--body"><span class="code--comment"># Kubernetes Admission Control Invariants</span>
 
 <span class="code--keyword">package</span> kubernetes.<span class="code--package">invariants</span>
 
@@ -57,21 +64,21 @@
 <span class="code--comment"># Generates a list of non-compliant ingresses identified by `namespace`
 # and ingress specification `name`.</span>
 <span class="code--rule">violations</span>[{
-<span class="code--string">"namespace"</span>: <span class="code--local">namespace</span>,
-<span class="code--string">"name"</span>: <span class="code--local">name</span>,
-<span class="code--string">"message"</span>: <span class="code--string">"ingress hostname must match whitelist"</span>
+    <span class="code--string">"namespace"</span>: <span class="code--local">namespace</span>,
+    <span class="code--string">"name"</span>: <span class="code--local">name</span>,
+    <span class="code--string">"message"</span>: <span class="code--string">"ingress hostname must match whitelist"</span>
 }] {
-<span class="code--local">ingress</span> <span class="code--operator">:=</span> <span class="code--package">ingresses</span>[<span class="code--local">namespace</span>][<span class="code--local">name</span>]
-<span class="code--local">host</span> <span class="code--operator">:=</span> <span class="code--local">ingress</span>.spec.rules[<span class="code--operator">_</span>].host
-<span class="code--keyword">not</span> <span class="code--rule">contains</span>(<span class="code--rule">whitelist</span>[<span class="code--local">namespace</span>], <span class="code--local">host</span>)
+    <span class="code--local">ingress</span> <span class="code--operator">:=</span> <span class="code--package">ingresses</span>[<span class="code--local">namespace</span>][<span class="code--local">name</span>]
+    <span class="code--local">host</span> <span class="code--operator">:=</span> <span class="code--local">ingress</span>.spec.rules[<span class="code--operator">_</span>].host
+    <span class="code--keyword">not</span> <span class="code--rule">contains</span>(<span class="code--rule">whitelist</span>[<span class="code--local">namespace</span>], <span class="code--local">host</span>)
 }
 
 <span class="code--comment"># Generates a list of allowed hostnames per namespace.</span>
 <span class="code--rule">whitelist</span>[<span class="code--local">namespace</span>] = <span class="code--local">hosts</span> {
-<span class="code--local">obj</span> <span class="code--operator">:=</span> <span class="code--package">namespaces</span>[<span class="code--local">namespace</span>]
-<span class="code--local">annotations</span> <span class="code--operator">:=</span> <span class="code--local">obj</span>.metadata.annotations
-<span class="code--local">annotation</span> <span class="code--operator">:=</span> <span class="code--local">annotations</span>[<span class="code--string">"acmecorp.com/hostname-whitelist"</span>]</span>
-<span class="code--local">hosts</span> <span class="code--operator">:=</span> <span class="code--keyword">json</span>.<span class="code--builtin">unmarshal</span>(<span class="code--local">annotation</span>)
+    <span class="code--local">obj</span> <span class="code--operator">:=</span> <span class="code--package">namespaces</span>[<span class="code--local">namespace</span>]
+    <span class="code--local">annotations</span> <span class="code--operator">:=</span> <span class="code--local">obj</span>.metadata.annotations
+    <span class="code--local">annotation</span> <span class="code--operator">:=</span> <span class="code--local">annotations</span>[<span class="code--string">"acmecorp.com/hostname-whitelist"</span>]</span>
+    <span class="code--local">hosts</span> <span class="code--operator">:=</span> <span class="code--keyword">json</span>.<span class="code--builtin">unmarshal</span>(<span class="code--local">annotation</span>)
 }
 
 <span class="code--comment"># ---------------------------------------------------------------------
@@ -79,7 +86,7 @@
 
 <span class="code--comment"># Checks if `list` includes an element matching `item`.</span>
 <span class="code--rule">contains</span>(<span class="code--local">list</span>, <span class="code--local">item</span>) {
-<span class="code--local">list</span>[<span class="code--operator">_</span>] <span class="code--operator">=</span> <span class="code--local">item</span>
+    <span class="code--local">list</span>[<span class="code--operator">_</span>] <span class="code--operator">=</span> <span class="code--local">item</span>
 }</pre>
         </div>
 
@@ -87,8 +94,11 @@
         <div class="example--wave--fg" role="presentation"></div>
       </section>
 
-      <section  id="api-authorization" class="example">
-        <a class="action--scroll-up" href="/"><svg class="action-icon"><title>Scroll back</title><use xlink:href="#icon--arrow-up"/></svg></a>
+      <section id="api-authorization" class="example">
+        <a class="action--scroll-up" href="/"><svg class="action-icon">
+            <title>Scroll back</title>
+            <use xlink:href="#icon--arrow-up" />
+          </svg></a>
 
         <h3 class="example--title">HTTP API Authorization</h3>
 
@@ -101,7 +111,7 @@
             <span class="example--editor--zoom-button" role="presentation"></span>
             <span class="example--editor--title">authz.rego — ~/src/policies/httpapi/acmecorp</span>
           </div>
-<pre class="example--editor--body"><span class="code--comment"># HTTP API Authorization</span>
+          <pre class="example--editor--body"><span class="code--comment"># HTTP API Authorization</span>
 
 <span class="code--keyword">package</span> acmecorp.<span class="code--package">authz</span>
 
@@ -109,16 +119,16 @@
 
 <span class="code--comment"># Allow people to read their own salaries.</span>
 <span class="code--rule">allow</span> {
-<span class="code--package">input</span>.method <span class="code--operator">=</span> <span class="code--string">"GET"</span>
-<span class="code--package">input</span>.path <span class="code--operator">=</span> [<span class="code--string">"salaries"</span>, <span class="code--local">employee_id</span>]
-<span class="code--package">input</span>.user <span class="code--operator">=</span> <span class="code--local">employee_id</span>
+    <span class="code--package">input</span>.method <span class="code--operator">=</span> <span class="code--string">"GET"</span>
+    <span class="code--package">input</span>.path <span class="code--operator">=</span> [<span class="code--string">"salaries"</span>, <span class="code--local">employee_id</span>]
+    <span class="code--package">input</span>.user <span class="code--operator">=</span> <span class="code--local">employee_id</span>
 }
 
 <span class="code--comment"># Also allow managers to read the salaries of people they manage.</span>
 <span class="code--rule">allow</span> {
-<span class="code--package">input</span>.method <span class="code--operator">=</span> <span class="code--string">"GET"</span>
-<span class="code--package">input</span>.path <span class="code--operator">=</span> [<span class="code--string">"salaries"</span>, <span class="code--local">employee_id</span>]
-<span class="code--package">input</span>.user <span class="code--operator">=</span> <span class="code--package">data</span>.manager_of[<span class="code--local">employee_id</span>]
+    <span class="code--package">input</span>.method <span class="code--operator">=</span> <span class="code--string">"GET"</span>
+    <span class="code--package">input</span>.path <span class="code--operator">=</span> [<span class="code--string">"salaries"</span>, <span class="code--local">employee_id</span>]
+    <span class="code--package">input</span>.user <span class="code--operator">=</span> <span class="code--package">data</span>.manager_of[<span class="code--local">employee_id</span>]
 }</pre>
         </div>
 
@@ -127,7 +137,10 @@
       </section>
 
       <section id="remote-access" class="example">
-        <a class="action--scroll-up" href="/"><svg class="action-icon"><title>Scroll back</title><use xlink:href="#icon--arrow-up"/></svg></a>
+        <a class="action--scroll-up" href="/"><svg class="action-icon">
+            <title>Scroll back</title>
+            <use xlink:href="#icon--arrow-up" />
+          </svg></a>
 
         <h3 class="example--title">Remote Access Authorization</h3>
 
@@ -140,7 +153,7 @@
             <span class="example--editor--zoom-button" role="presentation"></span>
             <span class="example--editor--title">invariants.rego — ~/src/policies/admission-control/kubernetes</span>
           </div>
-<pre class="example--editor--body"><span class="code--comment"># Fine-Grained SSH Authorization</span>
+          <pre class="example--editor--body"><span class="code--comment"># Fine-Grained SSH Authorization</span>
 
 <span class="code--keyword">package</span> ssh.<span class="code--package">fine_grained</span>
 
@@ -148,17 +161,17 @@
 # possess a certificate proving they are assigned to an application
 # running on the host.</span>
 <span class="code--rule">allow</span> {
-<span class="code--comment"># Extract the X.509 certificate provided in the policy query.</span>
-<span class="code--local">certs</span> <span class="code--operator">:=</span> <span class="code--builtin">crypto</span>.<span class="code--builtin">x509</span>.<span class="code--builtin">parse_certificates</span>(<span class="code--package">input</span>.certificates)
+    <span class="code--comment"># Extract the X.509 certificate provided in the policy query.</span>
+    <span class="code--local">certs</span> <span class="code--operator">:=</span> <span class="code--builtin">crypto</span>.<span class="code--builtin">x509</span>.<span class="code--builtin">parse_certificates</span>(<span class="code--package">input</span>.certificates)
 
-<span class="code--comment"># Check that the user is part of the "dev" organization for an app
-# running on this host.</span>
-<span class="code--local">certs</span>[<span class="code--local">i</span>].Subject.Organization[<span class="code--local">j</span>] <span class="code--operator">==</span> <span class="code--package">data</span>.host_info.apps[<span class="code--operator">_</span>]
-<span class="code--local">certs</span>[<span class="code--local">i</span>].Subject.OrganizationalUnit[<span class="code--local">j</span>] <span class="code--operator">==</span> <span class="code--string">"dev"</span>
+    <span class="code--comment"># Check that the user is part of the "dev" organization for an app
+    # running on this host.</span>
+    <span class="code--local">certs</span>[<span class="code--local">i</span>].Subject.Organization[<span class="code--local">j</span>] <span class="code--operator">==</span> <span class="code--package">data</span>.host_info.apps[<span class="code--operator">_</span>]
+    <span class="code--local">certs</span>[<span class="code--local">i</span>].Subject.OrganizationalUnit[<span class="code--local">j</span>] <span class="code--operator">==</span> <span class="code--string">"dev"</span>
 
-<span class="code--comment"># Check the certificate's validity period at the time of login.</span>
-<span class="code--builtin">time</span>.<span class="code--builtin">now_ns</span>() <span class="code--operator">>=</span> <span class="code--local">certs</span>[<span class="code--local">i</span>].NotBefore
-<span class="code--builtin">time</span>.<span class="code--builtin">now_ns</span>() <span class="code--operator"><=</span> <span class="code--local">certs</span>[<span class="code--local">i</span>].NotAfter
+    <span class="code--comment"># Check the certificate's validity period at the time of login.</span>
+    <span class="code--builtin">time</span>.<span class="code--builtin">now_ns</span>() <span class="code--operator">>=</span> <span class="code--local">certs</span>[<span class="code--local">i</span>].NotBefore
+    <span class="code--builtin">time</span>.<span class="code--builtin">now_ns</span>() <span class="code--operator"><=</span> <span class="code--local">certs</span>[<span class="code--local">i</span>].NotAfter
 }</pre>
         </div>
 
@@ -167,7 +180,10 @@
       </section>
 
       <section id="partial-evaluation" class="example">
-        <a class="action--scroll-up" href="/"><svg class="action-icon"><title>Scroll back</title><use xlink:href="#icon--arrow-up"/></svg></a>
+        <a class="action--scroll-up" href="/"><svg class="action-icon">
+            <title>Scroll back</title>
+            <use xlink:href="#icon--arrow-up" />
+          </svg></a>
 
         <h3 class="example--title">Data Filtering and Partial Evaluation</h3>
 
@@ -180,7 +196,7 @@
             <span class="example--editor--zoom-button" role="presentation"></span>
             <span class="example--editor--title">filtering.rego — ~/src/policies/partial-evaluation/app</span>
           </div>
-<pre class="example--editor--body"><span class="code--comment"># Partial Evaluation</span>
+          <pre class="example--editor--body"><span class="code--comment"># Partial Evaluation</span>
 
 <span class="code--keyword">package</span> app.<span class="code--package">filtering</span>
 
@@ -189,16 +205,16 @@
 
 <span class="code--comment"># Allow users to see their own posts.</span>
 <span class="code--rule">posts</span>[<span class="code--local">post</span>] {
-<span class="code--local">post</span> <span class="code--operator">:=</span> <span class="code--package">data</span>.posts[<span class="code--operator">_</span>]
-<span class="code--local">post</span>.owner <span class="code--operator">=</span> <span class="code--package">input</span>.subject.name
+    <span class="code--local">post</span> <span class="code--operator">:=</span> <span class="code--package">data</span>.posts[<span class="code--operator">_</span>]
+    <span class="code--local">post</span>.owner <span class="code--operator">=</span> <span class="code--package">input</span>.subject.name
 }
 
 <span class="code--comment"># Allow users to see posts from their own department</span>
 <span class="code--comment"># that they have sufficient clearance for.</span>
 <span class="code--rule">posts</span>[<span class="code--local">post</span>] {
-<span class="code--local">post</span> <span class="code--operator">:=</span> <span class="code--package">data</span>.posts[<span class="code--operator">_</span>]
-<span class="code--local">post</span>.department <span class="code--operator">=</span> <span class="code--package">input</span>.subject.department
-<span class="code--local">post</span>.security_level <span class="code--operator">&lt;=</span> <span class="code--package">input</span>.subject.clearance_level
+    <span class="code--local">post</span> <span class="code--operator">:=</span> <span class="code--package">data</span>.posts[<span class="code--operator">_</span>]
+    <span class="code--local">post</span>.department <span class="code--operator">=</span> <span class="code--package">input</span>.subject.department
+    <span class="code--local">post</span>.security_level <span class="code--operator">&lt;=</span> <span class="code--package">input</span>.subject.clearance_level
 }
 
 <span class="code--comment"># Example Output:</span>
@@ -213,9 +229,9 @@
 <span class="code--comment">#  data.posts[x].clearance_level &lt;= 3</span>
 
 </pre>
-    </div>
+        </div>
 
-    <div class="example--wave--bg" role="presentation"></div>
-    <div class="example--wave--fg" role="presentation"></div>
-  </section>
-</section>
+        <div class="example--wave--bg" role="presentation"></div>
+        <div class="example--wave--fg" role="presentation"></div>
+      </section>
+    </section>


### PR DESCRIPTION
In bb0d4e271b9adfbbfed174ae097a45174c7cb4a9 whitespace in the
these sections got wiped out which removed the indentation from the examples.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>