### PR TITLE
logs: Update decision logger to support masking

### DIFF
--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -238,6 +238,7 @@ services:
 | `decision_logs.reporting.upload_size_limit_bytes` | `int64` | No (default: `32768`) | Decision log upload size limit in bytes. OPA will chunk uploads to cap message body to this limit. |
 | `decision_logs.reporting.min_delay_seconds` | `int64` | No (default: `300`) | Minimum amount of time to wait between uploads. |
 | `decision_logs.reporting.max_delay_seconds` | `int64` | No (default: `600`) | Maximum amount of time to wait between uploads. |
+| `decision_logs.mask_decision` | `string` | No (default: `system/log/mask`) | Set path of masking decision. |
 | `decision_logs.plugin` | `string` | No | Use the named plugin for decision logging. If this field exists, the other configuration fields are not required. |
 
 ## Discovery

--- a/plugins/logs/plugin_test.go
+++ b/plugins/logs/plugin_test.go
@@ -20,7 +20,9 @@ import (
 	"github.com/open-policy-agent/opa/metrics"
 	"github.com/open-policy-agent/opa/plugins"
 	"github.com/open-policy-agent/opa/server"
+	"github.com/open-policy-agent/opa/storage"
 	"github.com/open-policy-agent/opa/storage/inmem"
+	"github.com/open-policy-agent/opa/util"
 	"github.com/open-policy-agent/opa/version"
 )
 
@@ -432,6 +434,373 @@ func TestPluginReconfigure(t *testing.T) {
 	if actualMax != expectedMax {
 		t.Fatalf("Expected maximum polling interval: %v but got %v", expectedMax, actualMax)
 	}
+}
+
+func TestPluginMasking(t *testing.T) {
+
+	// Setup masking fixture. Populate store with simple masking policy.
+	ctx := context.Background()
+	store := inmem.New()
+
+	err := storage.Txn(ctx, store, storage.WriteParams, func(txn storage.Transaction) error {
+		if err := store.UpsertPolicy(ctx, txn, "test.rego", []byte(`
+			package system.log
+			mask["/input/password"] {
+				input.input.is_sensitive
+			}
+		`)); err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create and start manager. Start is required so that stored policies
+	// get compiled and made available to the plugin.
+	manager, err := plugins.New(nil, "test", store)
+	if err != nil {
+		t.Fatal(err)
+	} else if err := manager.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// Instantiate the plugin.
+	cfg := &Config{Service: "svc"}
+	cfg.validateAndInjectDefaults([]string{"svc"}, nil)
+	plugin := New(cfg, manager)
+
+	if err := plugin.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// Test input that requires masking.
+	var input interface{} = map[string]interface{}{
+		"is_sensitive": true,
+		"password":     "secret",
+	}
+	event := &EventV1{
+		Input: &input,
+	}
+	if err := plugin.maskEvent(ctx, event); err != nil {
+		t.Fatal(err)
+	}
+
+	var exp interface{} = map[string]interface{}{
+		"is_sensitive": true,
+	}
+
+	if !reflect.DeepEqual(exp, *event.Input) {
+		t.Fatalf("Expected %v but got %v:", exp, *event.Input)
+	}
+
+	expErased := []string{"/input/password"}
+
+	if !reflect.DeepEqual(expErased, event.Erased) {
+		t.Fatalf("Expected %v but got %v:", expErased, event.Erased)
+	}
+
+	// Test input that DOES NOT require masking.
+	input = map[string]interface{}{
+		"password": "secret", // is_sensitive not set.
+	}
+
+	event = &EventV1{
+		Input: &input,
+	}
+
+	if err := plugin.maskEvent(ctx, event); err != nil {
+		t.Fatal(err)
+	}
+
+	exp = map[string]interface{}{
+		"password": "secret",
+	}
+
+	if !reflect.DeepEqual(exp, *event.Input) {
+		t.Fatalf("Expected %v but got %v:", exp, *event.Input)
+	}
+
+	if len(event.Erased) != 0 {
+		t.Fatalf("Expected empty set but got %v", event.Erased)
+	}
+
+	// Update policy to mask all of input and exercise.
+	err = storage.Txn(ctx, store, storage.WriteParams, func(txn storage.Transaction) error {
+		if err := store.UpsertPolicy(ctx, txn, "test.rego", []byte(`
+			package system.log
+			mask["/input"]
+		`)); err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	event = &EventV1{
+		Input: &input,
+	}
+
+	if err := plugin.maskEvent(ctx, event); err != nil {
+		t.Fatal(err)
+	}
+
+	if event.Input != nil {
+		t.Fatalf("Expected input to be nil but got: %v", *event.Input)
+	}
+
+	// Reconfigure and ensure that mask is invalidated.
+	maskDecision := "dead/beef"
+	newConfig := &Config{Service: "svc", MaskDecision: &maskDecision}
+	if err := newConfig.validateAndInjectDefaults([]string{"svc"}, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	plugin.Reconfigure(ctx, newConfig)
+
+	input = map[string]interface{}{
+		"password":     "secret",
+		"is_sensitive": true,
+	}
+
+	event = &EventV1{
+		Input: &input,
+	}
+
+	if err := plugin.maskEvent(ctx, event); err != nil {
+		t.Fatal(err)
+	}
+
+	exp = map[string]interface{}{
+		"password":     "secret",
+		"is_sensitive": true,
+	}
+
+	if !reflect.DeepEqual(exp, input) {
+		t.Fatalf("Expected %v but got modified input %v", exp, input)
+	}
+
+}
+
+const largeEvent = `{
+	"_id": "15596749567705615560",
+	"decision_id": "0e67fda0-170b-454d-9f5e-29691073f97e",
+	"input": {
+	  "apiVersion": "admission.k8s.io/v1beta1",
+	  "kind": "AdmissionReview",
+	  "request": {
+		"kind": {
+		  "group": "",
+		  "kind": "Pod",
+		  "version": "v1"
+		},
+		"namespace": "demo",
+		"object": {
+		  "metadata": {
+			"creationTimestamp": "2019-06-04T19:02:35Z",
+			"labels": {
+			  "run": "nginx"
+			},
+			"name": "nginx",
+			"namespace": "demo",
+			"uid": "507e4c3c-86fb-11e9-b289-42010a8000b2"
+		  },
+		  "spec": {
+			"containers": [
+			  {
+				"image": "nginx",
+				"imagePullPolicy": "Always",
+				"name": "nginx",
+				"resources": {},
+				"terminationMessagePath": "/dev/termination-log",
+				"terminationMessagePolicy": "File",
+				"volumeMounts": [
+				  {
+					"mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+					"name": "default-token-5vjbc",
+					"readOnly": true
+				  }
+				]
+			  }
+			],
+			"dnsPolicy": "ClusterFirst",
+			"priority": 0,
+			"restartPolicy": "Never",
+			"schedulerName": "default-scheduler",
+			"securityContext": {},
+			"serviceAccount": "default",
+			"serviceAccountName": "default",
+			"terminationGracePeriodSeconds": 30,
+			"tolerations": [
+			  {
+				"effect": "NoExecute",
+				"key": "node.kubernetes.io/not-ready",
+				"operator": "Exists",
+				"tolerationSeconds": 300
+			  },
+			  {
+				"effect": "NoExecute",
+				"key": "node.kubernetes.io/unreachable",
+				"operator": "Exists",
+				"tolerationSeconds": 300
+			  }
+			],
+			"volumes": [
+			  {
+				"name": "default-token-5vjbc",
+				"secret": {
+				  "secretName": "default-token-5vjbc"
+				}
+			  }
+			]
+		  },
+		  "status": {
+			"phase": "Pending",
+			"qosClass": "BestEffort"
+		  }
+		},
+		"oldObject": null,
+		"operation": "CREATE",
+		"resource": {
+		  "group": "",
+		  "resource": "pods",
+		  "version": "v1"
+		},
+		"userInfo": {
+		  "groups": [
+			"system:serviceaccounts",
+			"system:serviceaccounts:opa-system",
+			"system:authenticated"
+		  ],
+		  "username": "system:serviceaccount:opa-system:default"
+		}
+	  }
+	},
+	"labels": {
+	  "id": "462a43bd-6a5f-4530-9386-30b0f4e0c8af",
+	  "policy-type": "kubernetes/admission_control",
+	  "system-type": "kubernetes",
+	  "version": "0.10.5"
+	},
+	"metrics": {
+	  "timer_rego_module_compile_ns": 222,
+	  "timer_rego_module_parse_ns": 313,
+	  "timer_rego_query_compile_ns": 121360,
+	  "timer_rego_query_eval_ns": 923279,
+	  "timer_rego_query_parse_ns": 287152,
+	  "timer_server_handler_ns": 2563846
+	},
+	"path": "admission_control/main",
+	"requested_by": "10.52.0.1:53848",
+	"result": {
+	  "apiVersion": "admission.k8s.io/v1beta1",
+	  "kind": "AdmissionReview",
+	  "response": {
+		"allowed": false,
+		"status": {
+		  "reason": "Resource Pod/demo/nginx includes container image 'nginx' from prohibited registry"
+		}
+	  }
+	},
+	"revision": "jafsdkjfhaslkdfjlaksdjflaksjdflkajsdlkfjasldkfjlaksdjflkasdjflkasjdflkajsdflkjasdklfjalsdjf",
+	"timestamp": "2019-06-04T19:02:35.692Z"
+  }`
+
+func BenchmarkMaskingNop(b *testing.B) {
+
+	ctx := context.Background()
+	store := inmem.New()
+
+	manager, err := plugins.New(nil, "test", store)
+	if err != nil {
+		b.Fatal(err)
+	} else if err := manager.Start(ctx); err != nil {
+		b.Fatal(err)
+	}
+
+	cfg := &Config{Service: "svc"}
+	cfg.validateAndInjectDefaults([]string{"svc"}, nil)
+	plugin := New(cfg, manager)
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+
+		b.StopTimer()
+
+		var event EventV1
+
+		if err := util.UnmarshalJSON([]byte(largeEvent), &event); err != nil {
+			b.Fatal(err)
+		}
+
+		b.StartTimer()
+
+		if err := plugin.maskEvent(ctx, &event); err != nil {
+			b.Fatal(err)
+		}
+	}
+
+}
+
+func BenchmarkMaskingErase(b *testing.B) {
+
+	ctx := context.Background()
+	store := inmem.New()
+
+	err := storage.Txn(ctx, store, storage.WriteParams, func(txn storage.Transaction) error {
+		if err := store.UpsertPolicy(ctx, txn, "test.rego", []byte(`
+			package system.log
+
+			mask["/input"] {
+				input.input.request.kind.kind == "Pod"
+			}
+		`)); err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	manager, err := plugins.New(nil, "test", store)
+	if err != nil {
+		b.Fatal(err)
+	} else if err := manager.Start(ctx); err != nil {
+		b.Fatal(err)
+	}
+
+	cfg := &Config{Service: "svc"}
+	cfg.validateAndInjectDefaults([]string{"svc"}, nil)
+	plugin := New(cfg, manager)
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+
+		b.StopTimer()
+
+		var event EventV1
+
+		if err := util.UnmarshalJSON([]byte(largeEvent), &event); err != nil {
+			b.Fatal(err)
+		}
+
+		b.StartTimer()
+
+		if err := plugin.maskEvent(ctx, &event); err != nil {
+			b.Fatal(err)
+		}
+
+		if event.Input != nil {
+			b.Fatal("Expected input to be erased")
+		}
+	}
+
 }
 
 type testFixture struct {

--- a/plugins/logs/ptr.go
+++ b/plugins/logs/ptr.go
@@ -1,0 +1,139 @@
+package logs
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/open-policy-agent/opa/util"
+)
+
+type ptr []string
+
+func parsePtr(str string) (ptr, error) {
+
+	if len(str) == 0 {
+		return nil, fmt.Errorf("mask must be non-empty")
+	} else if str[0] != '/' {
+		return nil, fmt.Errorf("mask must be slash-prefixed")
+	}
+
+	parts := strings.Split(str[1:], "/")
+
+	if parts[0] != "input" && parts[0] != "result" {
+		return nil, fmt.Errorf("mask prefix not allowed")
+	}
+
+	for i := range parts {
+		var err error
+		parts[i], err = url.QueryUnescape(parts[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return ptr(parts), nil
+}
+
+func (p ptr) String() string {
+
+	escaped := make([]string, len(p))
+
+	for i := range escaped {
+		escaped[i] = url.QueryEscape(p[i])
+	}
+
+	return "/" + strings.Join(escaped, "/")
+}
+
+func (p ptr) Erase(event *EventV1) {
+
+	if len(p) == 1 {
+		switch p[0] {
+		case "input":
+			event.Input = nil
+		case "result":
+			event.Result = nil
+		default:
+			panic("illegal value")
+		}
+	} else {
+		var node interface{}
+
+		switch p[0] {
+		case "input":
+			if event.Input != nil {
+				node = *event.Input
+			}
+		case "result":
+			if event.Result != nil {
+				node = *event.Result
+			}
+		}
+
+		parent := p[1 : len(p)-1].lookup(node)
+		parentObj, ok := parent.(map[string]interface{})
+		if !ok {
+			return
+		}
+
+		fld := p[len(p)-1]
+		if _, ok := parentObj[fld]; !ok {
+			return
+		}
+
+		delete(parentObj, fld)
+	}
+
+	event.Erased = append(event.Erased, p.String())
+}
+
+func (p ptr) lookup(node interface{}) interface{} {
+	for i := 0; i < len(p); i++ {
+		switch v := node.(type) {
+		case map[string]interface{}:
+			var ok bool
+			if node, ok = v[p[i]]; !ok {
+				return nil
+			}
+		case []interface{}:
+			idx, err := strconv.Atoi(p[i])
+			if err != nil {
+				return nil
+			} else if idx < 0 || idx >= len(v) {
+				return nil
+			}
+			node = v[idx]
+		default:
+			return nil
+		}
+	}
+
+	return node
+}
+
+func resultValueToPtrs(rv interface{}) ([]ptr, error) {
+
+	bs, err := json.Marshal(rv)
+	if err != nil {
+		return nil, err
+	}
+
+	var value []string
+
+	if err := util.Unmarshal(bs, &value); err != nil {
+		return nil, err
+	}
+
+	result := make([]ptr, len(value))
+
+	for i := range result {
+		if result[i], err = parsePtr(value[i]); err != nil {
+			return nil, err
+		}
+	}
+
+	return result, nil
+}

--- a/plugins/logs/ptr_test.go
+++ b/plugins/logs/ptr_test.go
@@ -1,0 +1,237 @@
+package logs
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/open-policy-agent/opa/util"
+)
+
+func TestParsePtr(t *testing.T) {
+
+	tests := []struct {
+		note   string
+		input  string
+		expErr error
+		expPtr ptr
+	}{
+		{
+			note:   "empty",
+			input:  "",
+			expErr: fmt.Errorf("mask must be non-empty"),
+		},
+		{
+			note:   "missing slash",
+			input:  "foo/bar",
+			expErr: fmt.Errorf("mask must be slash-prefixed"),
+		},
+		{
+			note:   "no prefix",
+			input:  "/",
+			expErr: fmt.Errorf("mask prefix not allowed"),
+		},
+		{
+			note:   "bad prefix key",
+			input:  "/labels/foo",
+			expErr: fmt.Errorf("mask prefix not allowed"),
+		},
+		{
+			note:   "standard",
+			input:  "/input/a/b/c",
+			expPtr: ptr{"input", "a", "b", "c"},
+		},
+		{
+			note:   "escaping",
+			input:  "/input/a/%2F%2F/b",
+			expPtr: ptr{"input", "a", "//", "b"},
+		},
+		{
+			note:   "bad escape",
+			input:  "/input/a/%F/b",
+			expErr: fmt.Errorf("invalid URL escape"),
+		},
+		{
+			note:   "empty component",
+			input:  "/input//foo",
+			expPtr: ptr{"input", "", "foo"},
+		},
+		{
+			note:   "result",
+			input:  "/result/a",
+			expPtr: ptr{"result", "a"},
+		},
+		{
+			note:   "root",
+			input:  "/input",
+			expPtr: ptr{"input"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.note, func(t *testing.T) {
+			result, err := parsePtr(tc.input)
+			if tc.expErr != nil {
+				if err == nil {
+					t.Fatalf("Expected error but got: %v", result)
+				} else if !strings.Contains(err.Error(), tc.expErr.Error()) {
+					t.Fatalf("Expected error: %v, but got error: %v", tc.expErr, err)
+				}
+			} else {
+				if err != nil {
+					t.Fatal("Unexpected error:", err)
+				}
+				if !reflect.DeepEqual(result, tc.expPtr) {
+					t.Fatalf("Expected %v but got %v", tc.expPtr, result)
+				}
+			}
+		})
+	}
+}
+
+func TestPtrString(t *testing.T) {
+
+	result := ptr{"input", "foo/bar", "baz", ""}.String()
+	exp := "/input/foo%2Fbar/baz/"
+
+	if result != exp {
+		t.Fatalf("Expected %q but got %q", exp, result)
+	}
+}
+
+func TestPtrErase(t *testing.T) {
+
+	tests := []struct {
+		note  string
+		ptr   string
+		event string
+		exp   string
+	}{
+		{
+			note:  "erase input",
+			ptr:   "/input",
+			event: `{"input": {"a": 1}}`,
+			exp:   `{"erased": ["/input"]}`,
+		},
+		{
+			note:  "erase result",
+			ptr:   "/result",
+			event: `{"result": "foo"}`,
+			exp:   `{"erased": ["/result"]}`,
+		},
+		{
+			note:  "erase: undefined input",
+			ptr:   "/input/foo",
+			event: `{}`,
+			exp:   `{}`,
+		},
+		{
+			note:  "erase: undefined result",
+			ptr:   "/result/foo",
+			event: `{}`,
+			exp:   `{}`,
+		},
+		{
+			note:  "erase: undefined node",
+			ptr:   "/input/foo",
+			event: `{"input": {"bar": 1}}`,
+			exp:   `{"input": {"bar": 1}}`,
+		},
+		{
+			note:  "erase: undefined node-2",
+			ptr:   "/input/foo/bar",
+			event: `{"input": {"foo": 1}}`,
+			exp:   `{"input": {"foo": 1}}`,
+		},
+		{
+			note:  "erase: undefined object: missing key",
+			ptr:   "/input/foo/bar/baz",
+			event: `{"input": {"foo": {}}}`,
+			exp:   `{"input": {"foo": {}}}`,
+		},
+		{
+			note:  "erase: undefined scalar",
+			ptr:   "/input/foo/bar/baz",
+			event: `{"input": {"foo": 1}}`,
+			exp:   `{"input": {"foo": 1}}`,
+		},
+		{
+			note:  "erase: undefined array: non-int index",
+			ptr:   "/input/foo/bar/baz", // bar is invalid
+			event: `{"input": {"foo": [{"baz": 1}]}}`,
+			exp:   `{"input": {"foo": [{"baz": 1}]}}`,
+		},
+		{
+			note:  "erase: undefined array: negative index",
+			ptr:   "/input/foo/-1/baz",
+			event: `{"input": {"foo": [{"baz": 1}]}}`,
+			exp:   `{"input": {"foo": [{"baz": 1}]}}`,
+		},
+		{
+			note:  "erase: undefined array: index out of range",
+			ptr:   "/input/foo/1/baz",
+			event: `{"input": {"foo": [{"baz": 1}]}}`,
+			exp:   `{"input": {"foo": [{"baz": 1}]}}`,
+		},
+		{
+			note:  "erase: undefined array: remove element",
+			ptr:   "/input/foo/0",
+			event: `{"input": {"foo": [1]}}`,
+			exp:   `{"input": {"foo": [1]}}`,
+		},
+		{
+			note:  "erase: object key",
+			ptr:   "/input/foo",
+			event: `{"input": {"bar": 1, "foo": [{"baz": 1}]}}`,
+			exp:   `{"input": {"bar": 1}, "erased": ["/input/foo"]}`,
+		},
+		{
+			note:  "erase: object key (multiple)",
+			ptr:   "/input/bar",
+			event: `{"input": {"bar": 1}, "erased": ["/input/foo"]}`,
+			exp:   `{"input": {}, "erased": ["/input/foo", "/input/bar"]}`,
+		},
+		{
+			note:  "erase: object key (nested array)",
+			ptr:   "/input/foo/0/bar",
+			event: `{"input": {"foo": [{"bar": 1, "baz": 2}]}}`,
+			exp:   `{"input": {"foo": [{"baz": 2}]}, "erased": ["/input/foo/0/bar"]}`,
+		},
+		{
+			note:  "erase: result key",
+			ptr:   "/result/foo/bar/baz",
+			event: `{"result": {"foo": {"bar": {"baz": 1}}}}`,
+			exp:   `{"result": {"foo": {"bar": {}}}, "erased": ["/result/foo/bar/baz"]}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.note, func(t *testing.T) {
+
+			ptr, err := parsePtr(tc.ptr)
+			if err != nil {
+				panic(err)
+			}
+
+			var exp EventV1
+			if err := util.UnmarshalJSON([]byte(tc.exp), &exp); err != nil {
+				panic(err)
+			}
+
+			var event EventV1
+			if err := util.UnmarshalJSON([]byte(tc.event), &event); err != nil {
+				panic(err)
+			}
+
+			ptr.Erase(&event)
+
+			if !reflect.DeepEqual(event, exp) {
+				bs1, _ := json.MarshalIndent(exp, "", "  ")
+				bs2, _ := json.MarshalIndent(event, "", "  ")
+				t.Fatalf("Expected: %s\nGot: %s", bs1, bs2)
+			}
+		})
+	}
+}

--- a/rego/rego.go
+++ b/rego/rego.go
@@ -276,14 +276,17 @@ type ExpressionValue struct {
 }
 
 func newExpressionValue(expr *ast.Expr, value interface{}) *ExpressionValue {
-	return &ExpressionValue{
+	result := &ExpressionValue{
 		Value: value,
-		Text:  string(expr.Location.Text),
-		Location: &Location{
+	}
+	if expr.Location != nil {
+		result.Text = string(expr.Location.Text)
+		result.Location = &Location{
 			Row: expr.Location.Row,
 			Col: expr.Location.Col,
-		},
+		}
 	}
+	return result
 }
 
 func (ev *ExpressionValue) String() string {

--- a/rego/rego_test.go
+++ b/rego/rego_test.go
@@ -704,3 +704,21 @@ func TestPartialResultWithInput(t *testing.T) {
 
 	assertEval(t, r2, "[[true]]")
 }
+
+func TestMissingLocation(t *testing.T) {
+
+	// Create a query programmatically and evaluate it. The Location information
+	// is not set so the resulting expression value will not have it.
+	r := New(ParsedQuery(ast.NewBody(ast.NewExpr(ast.BooleanTerm(true)))))
+	rs, err := r.Eval(context.Background())
+
+	if err != nil {
+		t.Fatal(err)
+	} else if len(rs) == 0 || !rs[0].Expressions[0].Value.(bool) {
+		t.Fatal("Unexpected result set:", rs)
+	}
+
+	if rs[0].Expressions[0].Location != nil {
+		t.Fatal("Expected location data to be unset.")
+	}
+}


### PR DESCRIPTION
These changes enhance the in-built decision logger to support masking
of input and result fields for cases where sensitive information is
passed to OPA (or generated by the policy.)

Also, fix rego package to avoid panic-ing on programmatically created
queriest that lack Location information.

Fixes #779

Signed-off-by: Torin Sandall <torinsandall@gmail.com>