### PR TITLE
Add parameter to control partial eval inlining

### DIFF
--- a/cmd/eval.go
+++ b/cmd/eval.go
@@ -33,6 +33,7 @@ type evalCommandParams struct {
 	coverage          bool
 	partial           bool
 	unknowns          []string
+	disableInlining   []string
 	dataPaths         repeatedStringFlag
 	inputPath         string
 	imports           repeatedStringFlag
@@ -182,6 +183,7 @@ Set the output format with the --format flag.
 	evalCommand.Flags().BoolVarP(&params.coverage, "coverage", "", false, "report coverage")
 	evalCommand.Flags().BoolVarP(&params.partial, "partial", "p", false, "perform partial evaluation")
 	evalCommand.Flags().StringSliceVarP(&params.unknowns, "unknowns", "u", []string{"input"}, "set paths to treat as unknown during partial evaluation")
+	evalCommand.Flags().StringSliceVarP(&params.disableInlining, "disable-inlining", "", []string{}, "set paths of documents to exclude from inlining")
 	evalCommand.Flags().VarP(&params.dataPaths, "data", "d", "set data file(s) or directory path(s)")
 	evalCommand.Flags().StringVarP(&params.inputPath, "input", "i", "", "set input file path")
 	evalCommand.Flags().VarP(&params.imports, "import", "", "set query import(s)")
@@ -288,6 +290,8 @@ func eval(args []string, params evalCommandParams, w io.Writer) (bool, error) {
 	if params.partial {
 		regoArgs = append(regoArgs, rego.Unknowns(params.unknowns))
 	}
+
+	regoArgs = append(regoArgs, rego.DisableInlining(params.disableInlining))
 
 	var c *cover.Cover
 

--- a/rego/rego.go
+++ b/rego/rego.go
@@ -849,6 +849,7 @@ func (r *Rego) PrepareForEval(ctx context.Context, opts ...PrepareOption) (Prepa
 			partialNamespace: r.partialNamespace,
 			tracers:          r.tracers,
 			compiledQuery:    r.compiledQueries[partialResultQueryType],
+			instrumentation:  r.instrumentation,
 		}
 
 		pr, err := r.partialResult(ctx, ectx, ast.Wildcard)

--- a/topdown/instrumentation.go
+++ b/topdown/instrumentation.go
@@ -7,14 +7,18 @@ package topdown
 import "github.com/open-policy-agent/opa/metrics"
 
 const (
-	evalOpPlug             = "eval_op_plug"
-	evalOpResolve          = "eval_op_resolve"
-	evalOpRuleIndex        = "eval_op_rule_index"
-	evalOpBuiltinCall      = "eval_op_builtin_call"
-	evalOpVirtualCacheHit  = "eval_op_virtual_cache_hit"
-	evalOpVirtualCacheMiss = "eval_op_virtual_cache_miss"
-	evalOpBaseCacheHit     = "eval_op_base_cache_hit"
-	evalOpBaseCacheMiss    = "eval_op_base_cache_miss"
+	evalOpPlug                  = "eval_op_plug"
+	evalOpResolve               = "eval_op_resolve"
+	evalOpRuleIndex             = "eval_op_rule_index"
+	evalOpBuiltinCall           = "eval_op_builtin_call"
+	evalOpVirtualCacheHit       = "eval_op_virtual_cache_hit"
+	evalOpVirtualCacheMiss      = "eval_op_virtual_cache_miss"
+	evalOpBaseCacheHit          = "eval_op_base_cache_hit"
+	evalOpBaseCacheMiss         = "eval_op_base_cache_miss"
+	partialOpSaveUnify          = "partial_op_save_unify"
+	partialOpSaveSetContains    = "partial_op_save_set_contains"
+	partialOpSaveSetContainsRec = "partial_op_save_set_contains_rec"
+	partialOpCopyPropagation    = "partial_op_copy_propagation"
 )
 
 // Instrumentation implements helper functions to instrument query evaluation

--- a/topdown/query.go
+++ b/topdown/query.go
@@ -148,7 +148,7 @@ func (q *Query) PartialRun(ctx context.Context) (partials []ast.Body, support []
 		instr:         q.instr,
 		builtinCache:  builtins.Cache{},
 		virtualCache:  newVirtualCache(),
-		saveSet:       newSaveSet(q.unknowns, b),
+		saveSet:       newSaveSet(q.unknowns, b, q.instr),
 		saveStack:     newSaveStack(),
 		saveSupport:   newSaveSupport(),
 		saveNamespace: ast.StringTerm(q.partialNamespace),
@@ -170,6 +170,7 @@ func (q *Query) PartialRun(ctx context.Context) (partials []ast.Body, support []
 	p := copypropagation.New(livevars)
 
 	err = e.Run(func(e *eval) error {
+
 		// Build output from saved expressions.
 		body := ast.NewBody()
 
@@ -194,8 +195,7 @@ func (q *Query) PartialRun(ctx context.Context) (partials []ast.Body, support []
 			body.Append(bindingExprs[i])
 		}
 
-		body = p.Apply(body)
-		partials = append(partials, body)
+		partials = append(partials, applyCopyPropagation(p, e.instr, body))
 		return nil
 	})
 

--- a/topdown/save_test.go
+++ b/topdown/save_test.go
@@ -54,7 +54,7 @@ func TestSaveSet(t *testing.T) {
 		for i := range tc.terms {
 			terms[i] = ast.MustParseTerm(tc.terms[i])
 		}
-		saveSet := newSaveSet(terms, nil)
+		saveSet := newSaveSet(terms, nil, nil)
 		input := ast.MustParseTerm(tc.input)
 		if saveSet.Contains(input, nil) != tc.expected {
 			t.Errorf("Expected %v for %v contains %v", tc.expected, tc.terms, input)

--- a/topdown/topdown_partial_bench_test.go
+++ b/topdown/topdown_partial_bench_test.go
@@ -1,0 +1,77 @@
+package topdown
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/storage"
+	"github.com/open-policy-agent/opa/storage/inmem"
+)
+
+func BenchmarkInliningFullScan(b *testing.B) {
+
+	ctx := context.Background()
+	body := ast.MustParseBody("data.test.p = true")
+	unknowns := []*ast.Term{ast.MustParseTerm("input")}
+	compiler := ast.MustCompileModules(map[string]string{
+		"test.rego": `
+		package test
+
+		p {
+			data.a[i] == input
+		}
+		`,
+	})
+
+	sizes := []int{1000, 10000, 300000}
+
+	for _, n := range sizes {
+
+		b.Run(fmt.Sprint(n), func(b *testing.B) {
+
+			store := inmem.NewFromObject(generateInlineFullScanBenchmarkData(n))
+
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+
+				storage.Txn(ctx, store, storage.TransactionParams{}, func(txn storage.Transaction) error {
+
+					q := NewQuery(body).
+						WithCompiler(compiler).
+						WithStore(store).
+						WithTransaction(txn).
+						WithUnknowns(unknowns)
+
+					queries, support, err := q.PartialRun(ctx)
+					if err != nil {
+						b.Fatal(err)
+					}
+
+					if len(queries) != n {
+						b.Fatal("Expected", n, "queries")
+					} else if len(support) != 0 {
+						b.Fatal("Unexpected support")
+					}
+
+					return nil
+				})
+			}
+		})
+	}
+
+}
+
+func generateInlineFullScanBenchmarkData(n int) map[string]interface{} {
+
+	sl := make([]interface{}, n)
+	for i := range sl {
+		sl[i] = fmt.Sprint(i)
+	}
+
+	return map[string]interface{}{
+		"a": sl,
+	}
+}


### PR DESCRIPTION
This PR adds basic support for disabling inlining on specific virtual docs. This allows callers with knowledge of the policy to control how much inlining is performed. In some cases this can reduce partial eval latency significantly (e.g., by not having compute cross-products.) In the future we can extend OPA to automatically disable inlining based on a budget, knowledge of underlying base doc collection sizes, etc.