### PR TITLE
server: Abort write transaction when parsing fails

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1505,6 +1505,7 @@ func (s *Server) v1PoliciesPut(w http.ResponseWriter, r *http.Request) {
 	m.Timer(metrics.RegoModuleParse).Stop()
 
 	if err != nil {
+		s.store.Abort(ctx, txn)
 		switch err := err.(type) {
 		case ast.Errors:
 			writer.Error(w, http.StatusBadRequest, types.NewErrorV1(types.CodeInvalidParameter, types.MsgCompileModuleError).WithASTErrors(err))
@@ -1515,6 +1516,7 @@ func (s *Server) v1PoliciesPut(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if parsedMod == nil {
+		s.store.Abort(ctx, txn)
 		writer.Error(w, http.StatusBadRequest, types.NewErrorV1(types.CodeInvalidParameter, "empty module"))
 		return
 	}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1696,6 +1696,24 @@ func TestPoliciesPutV1ParseError(t *testing.T) {
 	if name.Compare(ast.String("test")) != 0 {
 		t.Fatalf("Expected name ot equal test but got: %v", name)
 	}
+
+	req = newReqV1(http.MethodPut, "/policies/test", ``)
+	f.reset()
+	f.server.Handler.ServeHTTP(f.recorder, req)
+	if f.recorder.Code != 400 {
+		t.Fatalf("Expected bad request but got %v", f.recorder)
+	}
+
+	req = newReqV1(http.MethodPut, "/policies/test", `
+	package a.b.c
+
+	p = true`)
+	f.reset()
+	f.server.Handler.ServeHTTP(f.recorder, req)
+	if f.recorder.Code != 200 {
+		t.Fatalf("Expected ok but got %v", f.recorder)
+	}
+
 }
 
 func TestPoliciesPutV1CompileError(t *testing.T) {


### PR DESCRIPTION
The server was leaking the write transaction when parsing failed which
caused subsequent updates to block. In future we should refactor the
handler implementations to avoid having to manually abort on each
error path.

Fixes #1478

Signed-off-by: Torin Sandall <torinsandall@gmail.com>