### PR TITLE
docs: Fix mention of reference head var

### DIFF
--- a/docs/content/how-do-i-write-policies.md
+++ b/docs/content/how-do-i-write-policies.md
@@ -421,7 +421,7 @@ Both forms are valid, however, the dot-access style is typically more readable. 
   4. Composite keys which are described later.
 
 References are always prefixed with a variable that identifies the root
-document. In the example above this is `p`. The root document may be:
+document. In the example above this is `sites`. The root document may be:
 
   * a local variable inside a rule.
   * a rule inside the same package.


### PR DESCRIPTION
This actually goes back to the very first draft of the language
reference.

Fixes #1477

Signed-off-by: Torin Sandall <torinsandall@gmail.com>