### PR TITLE
Revert "#1293: docs(): updating query api input example to match expected"

### DIFF
--- a/docs/content/rest-api.md
+++ b/docs/content/rest-api.md
@@ -1390,18 +1390,14 @@ main = msg {
 
 #### Example Request
 
-Request
 ```http
 POST /
 Content-Type: application/json
 ```
 
-Input
 ```json
 {
-  "input": {
-    "user": ["alice"]
-  }
+  "user": ["alice"]
 }
 ```
 


### PR DESCRIPTION
Reverts open-policy-agent/opa#1480

The doc example before was actually correct with regards to the input format for the default query endpoint.