### PR TITLE
logs: console decision logging option 

### DIFF
--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -286,7 +286,7 @@ services:
 
 | Field | Type | Required | Description |
 | --- | --- | --- | --- |
-| `decision_logs.service` | `string` | Yes | Name of the service to use to contact remote server. |
+| `decision_logs.service` | `string` | No | Name of the service to use to contact remote server. If no `plugin` is specified, and `console` logging is disabled, this will default to the first `service` name defined in the Services configuration. |
 | `decision_logs.partition_name` | `string` | No | Path segment to include in status updates. |
 | `decision_logs.reporting.buffer_size_limit_bytes` | `int64` | No | Decision log buffer size limit in bytes. OPA will drop old events from the log if this limit is exceeded. By default, no limit is set. |
 | `decision_logs.reporting.upload_size_limit_bytes` | `int64` | No (default: `32768`) | Decision log upload size limit in bytes. OPA will chunk uploads to cap message body to this limit. |
@@ -294,6 +294,7 @@ services:
 | `decision_logs.reporting.max_delay_seconds` | `int64` | No (default: `600`) | Maximum amount of time to wait between uploads. |
 | `decision_logs.mask_decision` | `string` | No (default: `system/log/mask`) | Set path of masking decision. |
 | `decision_logs.plugin` | `string` | No | Use the named plugin for decision logging. If this field exists, the other configuration fields are not required. |
+| `decision_logs.console` | `boolean` | No (default: `false`) | Log the decisions locally at `info` level to the console. If enabled a `service` or `plugin` _must_ be specified | 
 
 ## Discovery
 

--- a/docs/content/decision-logs.md
+++ b/docs/content/decision-logs.md
@@ -77,9 +77,11 @@ usernames, passwords, etc.) Similarly, parts of the policy decision itself may
 be considered sensitive.
 
 By default, OPA queries the `data.system.log.mask` path prior to encoding and
-uploading decision logs. OPA provides the decision log event as input to the
-policy query and expects the query to return a set of JSON Pointers that refer
-to fields in the decision log event to erase.
+uploading decision logs or calling custom decision log plugins.
+
+OPA provides the decision log event as input to the policy query and expects
+the query to return a set of JSON Pointers that refer to fields in the decision
+log event to erase.
 
 For example, assume OPA is queried with the following `input` document:
 

--- a/docs/content/plugins.md
+++ b/docs/content/plugins.md
@@ -221,3 +221,6 @@ If everything worked you will see the Go struct representation of the decision
 log event written to stdout.
 
 The source code for this example can be found [here](https://github.com/open-policy-agent/contrib/tree/master/decision_logger_plugin_example).
+
+> If there is a mask policy set (see [Decision Logger](../decision-logs) for details) the `Event`
+  received by the demo plugin will potentially be different than the example documented.

--- a/plugins/logs/plugin_test.go
+++ b/plugins/logs/plugin_test.go
@@ -856,6 +856,60 @@ func newTestFixture(t *testing.T) testFixture {
 
 }
 
+func TestParseConfigUseDefaultServiceNoConsole(t *testing.T) {
+	services := []string{
+		"s0",
+		"s1",
+		"s3",
+	}
+
+	loggerConfig := []byte(fmt.Sprintf(`{
+		"console": false
+	}`))
+
+	config, err := ParseConfig([]byte(loggerConfig), services, nil)
+
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+
+	if config.Service != services[0] {
+		t.Errorf("Expected %s service in config, actual = '%s'", services[0], config.Service)
+	}
+}
+
+func TestParseConfigDefaultServiceWithConsole(t *testing.T) {
+	services := []string{
+		"s0",
+		"s1",
+		"s3",
+	}
+
+	loggerConfig := []byte(fmt.Sprintf(`{
+		"console": true
+	}`))
+
+	config, err := ParseConfig([]byte(loggerConfig), services, nil)
+
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+
+	if config.Service != "" {
+		t.Errorf("Expected no service in config, actual = '%s'", config.Service)
+	}
+}
+
+func TestParseConfigDefaultServiceWithNoServiceOrConsole(t *testing.T) {
+	loggerConfig := []byte(fmt.Sprintf(`{}`))
+
+	_, err := ParseConfig([]byte(loggerConfig), []string{}, nil)
+
+	if err == nil {
+		t.Errorf("Expected an error but err==nil")
+	}
+}
+
 type testServer struct {
 	t       *testing.T
 	expCode int

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -235,18 +235,29 @@ func NewRuntime(ctx context.Context, params Params) (*Runtime, error) {
 	return rt, nil
 }
 
-// StartServer starts the runtime in server mode. This function will block the calling goroutine.
+// StartServer starts the runtime in server mode. This function will block the
+// calling goroutine and will exit the program on error.
 func (rt *Runtime) StartServer(ctx context.Context) {
+	err := rt.Serve(ctx)
+	if err != nil {
+		os.Exit(1)
+	}
+}
 
+// Serve will start a new REST API server and listen for requests. This
+// will block until either: an error occurs, the context is canceled, or
+// a SIGTERM or SIGKILL signal is sent.
+func (rt *Runtime) Serve(ctx context.Context) error {
 	setupLogging(rt.Params.Logging)
 
 	logrus.WithFields(logrus.Fields{
 		"addrs":         *rt.Params.Addrs,
 		"insecure_addr": rt.Params.InsecureAddr,
-	}).Infof("First line of log stream.")
+	}).Info("Initializing server.")
 
 	if err := rt.Manager.Start(ctx); err != nil {
-		logrus.WithField("err", err).Fatalf("Failed to start plugins.")
+		logrus.WithField("err", err).Error("Failed to start plugins.")
+		return err
 	}
 
 	defer rt.Manager.Stop(ctx)
@@ -269,12 +280,14 @@ func (rt *Runtime) StartServer(ctx context.Context) {
 		Init(ctx)
 
 	if err != nil {
-		logrus.WithField("err", err).Fatalf("Unable to initialize server.")
+		logrus.WithField("err", err).Error("Unable to initialize server.")
+		return err
 	}
 
 	if rt.Params.Watch {
 		if err := rt.startWatcher(ctx, rt.Params.Paths, onReloadLogger); err != nil {
-			logrus.WithField("err", err).Fatalf("Unable to open watch.")
+			logrus.WithField("err", err).Error("Unable to open watch.")
+			return err
 		}
 	}
 
@@ -282,7 +295,8 @@ func (rt *Runtime) StartServer(ctx context.Context) {
 
 	loops, err := s.Listeners()
 	if err != nil {
-		logrus.WithField("err", err).Fatalf("Unable to create listeners.")
+		logrus.WithField("err", err).Error("Unable to create listeners.")
+		return err
 	}
 
 	errc := make(chan error)
@@ -292,22 +306,15 @@ func (rt *Runtime) StartServer(ctx context.Context) {
 		}(loop)
 	}
 
-	stopc := make(chan os.Signal)
-	signal.Notify(stopc, syscall.SIGINT, syscall.SIGTERM)
+	signalc := make(chan os.Signal)
+	signal.Notify(signalc, syscall.SIGINT, syscall.SIGTERM)
 
 	for {
 		select {
-		case <-stopc:
-			logrus.Info("Shutting down...")
-			ctx, cancel := context.WithTimeout(context.Background(), time.Duration(rt.Params.GracefulShutdownPeriod)*time.Second)
-			defer cancel()
-			err = s.Shutdown(ctx)
-			if err != nil {
-				logrus.WithField("err", err).Error("Failed to shutdown server gracefully.")
-			} else {
-				logrus.Info("Server shutdown.")
-			}
-			os.Exit(1)
+		case <-ctx.Done():
+			return rt.gracefulServerShutdown(s)
+		case <-signalc:
+			return rt.gracefulServerShutdown(s)
 		case err := <-errc:
 			logrus.WithField("err", err).Fatal("Listener failed.")
 		}
@@ -438,6 +445,19 @@ func (rt *Runtime) getBanner() string {
 	fmt.Fprintf(&buf, "\n")
 	fmt.Fprintf(&buf, "Run 'help' to see a list of commands.\n")
 	return buf.String()
+}
+
+func (rt *Runtime) gracefulServerShutdown(s *server.Server) error {
+	logrus.Info("Shutting down...")
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(rt.Params.GracefulShutdownPeriod)*time.Second)
+	defer cancel()
+	err := s.Shutdown(ctx)
+	if err != nil {
+		logrus.WithField("err", err).Error("Failed to shutdown server gracefully.")
+		return err
+	}
+	logrus.Info("Server shutdown.")
+	return nil
 }
 
 func compileAndStoreInputs(ctx context.Context, store storage.Store, txn storage.Transaction, modules map[string]*loader.RegoFile, errorLimit int) error {

--- a/test/e2e/logs/console_decision_logger_test.go
+++ b/test/e2e/logs/console_decision_logger_test.go
@@ -1,0 +1,116 @@
+// Copyright 2019 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package logs
+
+import (
+	"encoding/json"
+	"flag"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/open-policy-agent/opa/test/e2e"
+	"github.com/sirupsen/logrus/hooks/test"
+)
+
+var testRuntime *e2e.TestRuntime
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	testServerParams := e2e.NewAPIServerTestParams()
+
+	testServerParams.ConfigOverrides = []string{
+		"decision_logs.console=true",
+	}
+
+	var err error
+	testRuntime, err = e2e.NewTestRuntime(testServerParams)
+	if err != nil {
+		os.Exit(1)
+	}
+
+	os.Exit(testRuntime.RunAPIServerTests(m))
+}
+
+func TestDecisionLogWithInput(t *testing.T) {
+
+	// Setup a test hook on the global logrus logger (what
+	// the console decision logger uses)
+	hook := test.NewGlobal()
+
+	policy := `
+	package test
+
+	default allow = false
+
+	allow {
+		input.x == 1
+	}
+	`
+
+	err := testRuntime.UploadPolicy(t.Name(), strings.NewReader(policy))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	input := map[string]int{
+		"x": 1,
+	}
+
+	expected := true
+
+	resultJSON, err := testRuntime.GetDataWithInput("test/allow", input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	parsedBody := struct {
+		Result bool `json:"result"`
+	}{}
+
+	err = json.Unmarshal(resultJSON, &parsedBody)
+	if err != nil {
+		t.Fatalf("Failed to parse body: \n\nActual: %s\n\nExpected: {\"result\": BOOL}\n\nerr = %s ", string(resultJSON), err)
+	}
+
+	if parsedBody.Result != expected {
+		t.Fatalf("Unexpected result: %v", parsedBody.Result)
+	}
+
+	// Check for some important fields
+	expectedFields := map[string]bool{
+		"labels":      false,
+		"decision_id": false,
+		"path":        false,
+		"input":       false,
+		"result":      false,
+		"timestamp":   false,
+	}
+	var entry *logrus.Entry
+	for _, e := range hook.AllEntries() {
+		if e.Message == "Decision Log" {
+			entry = e
+		}
+	}
+
+	if entry == nil {
+		t.Fatalf("Did not find 'Decision Log' event in captured logrus entries")
+	}
+
+	// Ensure expected fields exist
+	for k := range entry.Data {
+		if _, ok := expectedFields[k]; ok {
+			expectedFields[k] = true
+		}
+	}
+
+	for field, found := range expectedFields {
+		if !found {
+			t.Errorf("Missing expected field in decision log: %s\n\nEntry: %+v\n\n", field, entry)
+		}
+	}
+}

--- a/test/e2e/testing.go
+++ b/test/e2e/testing.go
@@ -1,0 +1,216 @@
+// Copyright 2019 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/open-policy-agent/opa/runtime"
+	"github.com/open-policy-agent/opa/util"
+)
+
+const (
+	defaultAddr = ":8181" // default listening address for server
+)
+
+// NewAPIServerTestParams creates a new set of runtime.Params with enough
+// default values filled in to start the server. Options can/should
+// be customized for the test case.
+func NewAPIServerTestParams() runtime.Params {
+	params := runtime.NewParams()
+
+	// Add in some defaults
+	params.Addrs = &[]string{defaultAddr}
+
+	params.Logging = runtime.LoggingConfig{
+		Level:  "debug",
+		Format: "json-pretty",
+	}
+
+	params.GracefulShutdownPeriod = 10 // seconds
+
+	return params
+}
+
+func apiServerURL(params runtime.Params) (string, error) {
+
+	addr := (*params.Addrs)[0] // probably fine.. if not then test blows up ?
+
+	if strings.HasPrefix(addr, ":") {
+		addr = "localhost" + addr
+	}
+
+	if !strings.Contains(addr, "://") {
+		scheme := "http://"
+		if params.Certificate != nil {
+			scheme = "https://"
+		}
+		addr = scheme + addr
+	}
+
+	parsed, err := url.Parse(addr)
+	if err != nil {
+		return "", err
+	}
+
+	return parsed.String(), nil
+}
+
+// TestRuntime holds metadata and provides helper methods
+// to interact with the runtime being tested.
+type TestRuntime struct {
+	URL     string
+	Params  runtime.Params
+	Runtime *runtime.Runtime
+	Ctx     context.Context
+	Cancel  context.CancelFunc
+	Client  *http.Client
+}
+
+// NewTestRuntime returns a new TestRuntime which
+func NewTestRuntime(params runtime.Params) (*TestRuntime, error) {
+	ctx := context.Background()
+	ctx, cancel := context.WithCancel(ctx)
+
+	rt, err := runtime.NewRuntime(ctx, params)
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("Unable to create new runtime: %s", err)
+	}
+
+	url, err := apiServerURL(params)
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("Unable to determine runtime URL: %s", err)
+	}
+
+	return &TestRuntime{
+		URL:     url,
+		Params:  params,
+		Runtime: rt,
+		Ctx:     ctx,
+		Cancel:  cancel,
+		Client:  &http.Client{},
+	}, nil
+}
+
+// RunAPIServerTests will start the OPA runtime serving with a given
+// configuration. This is essentially a wrapper for `m.Run()` that
+// handles starting and stopping the local API server. The return
+// value is what should be used as the code in `os.Exit` in the
+// `TestMain` function.
+func (t *TestRuntime) RunAPIServerTests(m *testing.M) int {
+	// Start serving API requests in the background
+	done := make(chan error)
+	go func() {
+		err := t.Runtime.Serve(t.Ctx)
+		done <- err
+	}()
+
+	// wait for the server to be ready
+	err := t.waitForServer()
+	if err != nil {
+		return 1
+	}
+
+	// Actually run the unit tests/benchmarks
+	errc := m.Run()
+
+	// Wait for the API server to stop
+	t.Cancel()
+	err = <-done
+
+	if err != nil && errc == 0 {
+		// even if the tests passed return an error code if
+		// the server encountered an error
+		errc = 1
+	}
+
+	return errc
+}
+
+func (t *TestRuntime) waitForServer() error {
+	delay := time.Duration(100) * time.Millisecond
+	retries := 100 // 10 seconds before we give up
+	for i := 0; i < retries; i++ {
+		resp, err := http.Get(t.URL + "/health")
+		if err == nil && resp.StatusCode == http.StatusOK {
+			return nil
+		}
+		time.Sleep(delay)
+	}
+	return fmt.Errorf("API Server not ready in time")
+}
+
+// UploadPolicy will upload the given policy to the runtime via the v1 policy API
+func (t *TestRuntime) UploadPolicy(name string, policy io.Reader) error {
+	req, err := http.NewRequest("PUT", t.URL+"/v1/policies/"+name, policy)
+	if err != nil {
+		return fmt.Errorf("Unexpected error creating request: %s", err)
+	}
+	resp, err := t.Client.Do(req)
+	if err != nil {
+		return fmt.Errorf("Failed to PUT the test policy: %s", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("Unexpected response: %d %s", resp.StatusCode, resp.Status)
+	}
+	return nil
+}
+
+// UploadData will upload the given data to the runtime via the v1 data API
+func (t *TestRuntime) UploadData(data io.Reader) error {
+	client := &http.Client{}
+	req, err := http.NewRequest("PUT", t.URL+"/v1/data", data)
+	if err != nil {
+		return fmt.Errorf("Unexpected error creating request: %s", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("Failed to PUT data: %s", err)
+	}
+	if resp.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("Unexpected response: %d %s", resp.StatusCode, resp.Status)
+	}
+	return nil
+}
+
+// GetDataWithInput will use the v1 data API and POST with the given input. The returned
+// value is the full response body.
+func (t *TestRuntime) GetDataWithInput(path string, input interface{}) ([]byte, error) {
+	inputPayload := util.MustMarshalJSON(map[string]interface{}{
+		"input": input,
+	})
+
+	path = strings.TrimPrefix(path, "/")
+	if !strings.HasPrefix(path, "data") {
+		path = "data/" + path
+	}
+
+	resp, err := http.Post(t.URL+"/v1/"+path, "application/json", bytes.NewReader(inputPayload))
+	if err != nil {
+		return nil, fmt.Errorf("Unexpected error: %s", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("Unexpected response status: %d %s", resp.StatusCode, resp.Status)
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("Unexpected error reading response body: %s", err)
+	}
+
+	return body, nil
+}


### PR DESCRIPTION
Add option to log decision logs locally. They'll get logged via
Logrus at info level.

To enable configure OPA with something like:

```
decision_logs:
    console: true
```

This will work alongside remote services and plugins. It will also
log the masked events in the case a masking policy is set.

Fixes: #1334
Signed-off-by: Patrick East <east.patrick@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
