### PR TITLE
Change `opa eval` input to parse as json first

### DIFF
--- a/cmd/eval.go
+++ b/cmd/eval.go
@@ -252,15 +252,20 @@ func eval(args []string, params evalCommandParams, w io.Writer) (bool, error) {
 		}
 	}
 
-	bs, err := readInputBytes(params)
+	inputBytes, err := readInputBytes(params)
 	if err != nil {
 		return false, err
-	} else if bs != nil {
-		term, err := ast.ParseTerm(string(bs))
+	} else if inputBytes != nil {
+		var input interface{}
+		err := util.Unmarshal(inputBytes, &input)
 		if err != nil {
-			return false, err
+			return false, fmt.Errorf("unable to parse input: %s", err.Error())
 		}
-		regoArgs = append(regoArgs, rego.ParsedInput(term.Value))
+		inputValue, err := ast.InterfaceToValue(input)
+		if err != nil {
+			return false, fmt.Errorf("unable to process input: %s", err.Error())
+		}
+		regoArgs = append(regoArgs, rego.ParsedInput(inputValue))
 	}
 
 	var tracer *topdown.BufferTracer


### PR DESCRIPTION
It was getting parsed from string -> ast.Term but the generated
parser is (apparently) not as performant as the json parser and then
using `ast.InterfaceToValue`.

Fixes: #1488
Signed-off-by: Patrick East <east.patrick@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
