### PR TITLE
docs: Update mobile navbar links to use "latest" tag

### DIFF
--- a/docs/website/layouts/partials/docs/navbar-link.html
+++ b/docs/website/layouts/partials/docs/navbar-link.html
@@ -1,0 +1,19 @@
+{{/* Expect to have context bound to ".ctx", and the top level
+     "version" and "pageUrl" passed in with the context.
+ */}}
+ {{- $latest     := index site.Data.releases 0 -}}
+ {{/* In the current "ctx" the file path refers to the doc we are linking to, not the page we are on */}}
+ {{- $contentVersion := index (split .ctx.File.Path "/") 1 -}}
+ {{- $isRoot := eq (len (split .ctx.File.Path "/")) 2 -}}
+{{- $title := cond (isset .ctx.Params "navtitle") (.ctx.Params.navtitle) .ctx.Title -}}
+{{- if not $isRoot -}}
+{{- if eq .version $contentVersion -}}
+{{- $linkRef := .ctx.URL -}}
+{{- if or (eq $contentVersion $latest) -}}
+{{- $linkRef = (replace $linkRef $contentVersion "latest") -}}
+{{- end -}}
+<a class="navbar-item" href="{{ $linkRef }}">
+  {{ $title }}
+</a>
+{{- end -}}
+{{- end -}}

--- a/docs/website/layouts/partials/docs/navbar.html
+++ b/docs/website/layouts/partials/docs/navbar.html
@@ -11,6 +11,8 @@
 {{ $tutorials := where $allDocs ".Params.kind" "eq" "tutorial" }}
 {{ $guides    := where $allDocs ".Params.kind" "eq" "guides" }}
 {{ $version   := index (split .File.Path "/") 1 }}
+{{ $latest    := index site.Data.releases 0 }}
+{{ $pageUrl   := .URL }}
 <nav class="navbar is-primary">
   <div class="navbar-brand is-hidden-tablet">
     <a class="navbar-item" href="{{ $home }}">
@@ -35,13 +37,7 @@
       </a>
 
       {{ range $docs }}
-      {{ $isRoot           := eq (len (split .File.Path "/")) 2 }}
-      {{ $isCurrentVersion := eq $version (index (split .File.Path "/") 1) }}
-      {{ if and (not $isRoot) $isCurrentVersion }}
-      <a class="navbar-item" href="{{ .URL }}">
-        {{ .Title }}
-      </a>
-      {{ end }}
+        {{ partial "docs/navbar-link.html" (dict "ctx" . "pageUrl" $pageUrl "version" $version) }}
       {{ end }}
 
       <br />
@@ -51,13 +47,7 @@
       </span>
 
       {{ range $tutorials }}
-      {{ $isRoot := eq (len (split .File.Path "/")) 2 }}
-      {{ $isCurrentVersion := eq $version (index (split .File.Path "/") 1) }}
-      {{ if and (not $isRoot) $isCurrentVersion }}
-      <a class="navbar-item" href="{{ .URL }}">
-        {{ .Title }}
-      </a>
-      {{ end }}
+        {{ partial "docs/navbar-link.html" (dict "ctx" . "pageUrl" $pageUrl "version" $version) }}
       {{ end }}
 
       <br />
@@ -67,13 +57,7 @@
       </span>
 
       {{ range $guides }}
-      {{ $isRoot := eq (len (split .File.Path "/")) 2 }}
-      {{ $isCurrentVersion := eq $version (index (split .File.Path "/") 1) }}
-      {{ if and (not $isRoot) $isCurrentVersion }}
-      <a class="navbar-item" href="{{ .URL }}">
-        {{ .Title }}
-      </a>
-      {{ end }}
+      {{ partial "docs/navbar-link.html" (dict "ctx" . "pageUrl" $pageUrl "version" $version) }}
       {{ end }}
     </div>
 


### PR DESCRIPTION
We did this for the sidenav urls but the mobile version was still using hard versions instead of "latest".