### PR TITLE
rego: Add ParsedModule option to API

### DIFF
--- a/cmd/eval.go
+++ b/cmd/eval.go
@@ -245,10 +245,12 @@ func eval(args []string, params evalCommandParams, w io.Writer) (bool, error) {
 		if err != nil {
 			return false, err
 		}
+
 		regoArgs = append(regoArgs, rego.Store(inmem.NewFromObject(loadResult.Documents)))
+
 		for _, file := range loadResult.Modules {
 			parsedModules[file.Name] = file.Parsed
-			regoArgs = append(regoArgs, rego.Module(file.Name, string(file.Raw)))
+			regoArgs = append(regoArgs, rego.ParsedModule(file.Parsed))
 		}
 	}
 


### PR DESCRIPTION
These changes just add another option to the API to supply parsed
modules directly. This allows tools that rely on the file loader to
skip parsing of modules for a second time when running evaluation. For
large sets of modules this can reduce latency quite a bit.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>