### PR TITLE
Fix performance impact of bundle activation on policy queries

### DIFF
--- a/storage/inmem/inmem.go
+++ b/storage/inmem/inmem.go
@@ -81,8 +81,10 @@ type handle struct {
 
 func (db *store) NewTransaction(ctx context.Context, params ...storage.TransactionParams) (storage.Transaction, error) {
 	var write bool
+	var context *storage.Context
 	if len(params) > 0 {
 		write = params[0].Write
+		context = params[0].Context
 	}
 	xid := atomic.AddUint64(&db.xid, uint64(1))
 	if write {
@@ -90,7 +92,7 @@ func (db *store) NewTransaction(ctx context.Context, params ...storage.Transacti
 	} else {
 		db.rmu.RLock()
 	}
-	return newTransaction(xid, write, db), nil
+	return newTransaction(xid, write, context, db), nil
 }
 
 func (db *store) Commit(ctx context.Context, txn storage.Transaction) error {

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -44,6 +44,34 @@ type TransactionParams struct {
 
 	// Write indicates if this transaction will perform any write operations.
 	Write bool
+
+	// Context contains key/value pairs passed to triggers.
+	Context *Context
+}
+
+// Context is a simple container for key/value pairs.
+type Context struct {
+	values map[interface{}]interface{}
+}
+
+// NewContext returns a new context object.
+func NewContext() *Context {
+	return &Context{
+		values: map[interface{}]interface{}{},
+	}
+}
+
+// Get returns the key value in the context.
+func (ctx *Context) Get(key interface{}) interface{} {
+	if ctx == nil {
+		return nil
+	}
+	return ctx.values[key]
+}
+
+// Put adds a key/value pair to the context.
+func (ctx *Context) Put(key, value interface{}) {
+	ctx.values[key] = value
 }
 
 // WriteParams specifies the TransactionParams for a write transaction.
@@ -117,8 +145,9 @@ type DataEvent struct {
 
 // TriggerEvent describes the changes that caused the trigger to be invoked.
 type TriggerEvent struct {
-	Policy []PolicyEvent
-	Data   []DataEvent
+	Policy  []PolicyEvent
+	Data    []DataEvent
+	Context *Context
 }
 
 // IsZero returns true if the TriggerEvent indicates no changes occurred. This


### PR DESCRIPTION
These changes resolve #1515 by caching the compiler created during bundle activation and passing it through to the manager's trigger callback. See the commit messages for a bit more info.