### PR TITLE
topdown: Fix corrupt object panic caused by copy propagation

### DIFF
--- a/topdown/topdown_partial_test.go
+++ b/topdown/topdown_partial_test.go
@@ -1047,6 +1047,22 @@ func TestTopDownPartialEval(t *testing.T) {
 			},
 		},
 		{
+			note:  "copy propagation: rewrite object key (bug 1177)",
+			query: `data.test.p = true`,
+			modules: []string{
+				`
+					package test
+
+					p {
+						x = input.x
+						y = input.y
+						x = {y: 1}
+					}
+				`,
+			},
+			wantQueries: []string{`input.x = {input.y: 1}`},
+		},
+		{
 			note:  "save set vars are namespaced",
 			query: "input = x; data.test.f(1)",
 			modules: []string{


### PR DESCRIPTION
Mutating term values used as object keys (or set elements) is not safe
because the underlying hashtables get corrupted. This a known issue
that was previously fixed in the compiler (#1125). The simplest
solution in this case is to use the ast.Transform helper instead of
ast.Walk so that a copy of object and set terms is made.

Fixes #1177

Signed-off-by: Torin Sandall <torinsandall@gmail.com>