### PR TITLE
ast: Report safety errors on line where expression starts

### DIFF
--- a/ast/compile_test.go
+++ b/ast/compile_test.go
@@ -344,8 +344,8 @@ func TestCompilerErrorLimit(t *testing.T) {
 
 	errs := c.Errors
 	exp := []string{
-		"2:2: rego_unsafe_var_error: var x is unsafe",
-		"2:2: rego_unsafe_var_error: var z is unsafe",
+		"2:20: rego_unsafe_var_error: var x is unsafe",
+		"2:20: rego_unsafe_var_error: var z is unsafe",
 		"rego_compile_error: error limit reached",
 	}
 
@@ -595,6 +595,30 @@ func TestCompilerCheckSafetyBodyErrors(t *testing.T) {
 			}
 
 		})
+	}
+}
+
+func TestCompilerCheckSafetyVarLoc(t *testing.T) {
+
+	_, err := CompileModules(map[string]string{"test.rego": `package test
+
+p {
+	not x
+	x > y
+}`})
+
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	errs := err.(Errors)
+
+	if !strings.Contains(errs[0].Message, "var x is unsafe") || errs[0].Location.Row != 4 {
+		t.Fatal("expected error on row 4 but got:", err)
+	}
+
+	if !strings.Contains(errs[1].Message, "var y is unsafe") || errs[1].Location.Row != 5 {
+		t.Fatal("expected y is unsafe on row 5 but got:", err)
 	}
 }
 

--- a/ast/term.go
+++ b/ast/term.go
@@ -74,7 +74,8 @@ func (loc *Location) String() string {
 
 // Compare returns -1, 0, or 1 to indicate if this loc is less than, equal to,
 // or greater than the other. Comparison is performed on the file, row, and
-// column of the Location (but not on the text.)
+// column of the Location (but not on the text.) Nil locations are greater than
+// non-nil locations.
 func (loc *Location) Compare(other *Location) int {
 	if loc == nil && other == nil {
 		return 0

--- a/ast/term_test.go
+++ b/ast/term_test.go
@@ -669,6 +669,86 @@ func TestValueToInterface(t *testing.T) {
 	}
 }
 
+func TestLocationCompare(t *testing.T) {
+
+	tests := []struct {
+		a   string
+		b   string
+		exp int
+	}{
+		{
+			a:   "",
+			b:   "",
+			exp: 0,
+		},
+		{
+			a:   "",
+			b:   `{"file": "a", "row": 1, "col": 1}`,
+			exp: 1,
+		},
+		{
+			a:   `{"file": "a", "row": 1, "col": 1}`,
+			b:   "",
+			exp: -1,
+		},
+		{
+			a:   `{"file": "a", "row": 1, "col": 1}`,
+			b:   `{"file": "a", "row": 1, "col": 1}`,
+			exp: 0,
+		},
+		{
+			a:   `{"file": "a", "row": 1, "col": 1}`,
+			b:   `{"file": "b", "row": 1, "col": 1}`,
+			exp: -1,
+		},
+		{
+			a:   `{"file": "b", "row": 1, "col": 1}`,
+			b:   `{"file": "a", "row": 1, "col": 1}`,
+			exp: 1,
+		},
+		{
+			a:   `{"file": "a", "row": 1, "col": 1}`,
+			b:   `{"file": "a", "row": 2, "col": 1}`,
+			exp: -1,
+		},
+		{
+			a:   `{"file": "a", "row": 2, "col": 1}`,
+			b:   `{"file": "a", "row": 1, "col": 1}`,
+			exp: 1,
+		},
+		{
+			a:   `{"file": "a", "row": 1, "col": 1}`,
+			b:   `{"file": "a", "row": 1, "col": 2}`,
+			exp: -1,
+		},
+		{
+			a:   `{"file": "a", "row": 1, "col": 2}`,
+			b:   `{"file": "a", "row": 1, "col": 1}`,
+			exp: 1,
+		},
+	}
+
+	unmarshal := func(s string) *Location {
+		if s != "" {
+			var loc Location
+			if err := util.Unmarshal([]byte(s), &loc); err != nil {
+				t.Fatal(err)
+			}
+			return &loc
+		}
+		return nil
+	}
+
+	for _, tc := range tests {
+		locA := unmarshal(tc.a)
+		locB := unmarshal(tc.b)
+		result := locA.Compare(locB)
+		if tc.exp != result {
+			t.Fatalf("Expected %v but got %v for %v.Compare(%v)", tc.exp, result, locA, locB)
+		}
+	}
+}
+
 func assertTermEqual(t *testing.T, x *Term, y *Term) {
 	if !x.Equal(y) {
 		t.Errorf("Failure on equality: \n%s and \n%s\n", x, y)


### PR DESCRIPTION
These changes just update the safety errors to report the line of the
expression where the error occurred instead of the rule/query that
contains the expressionm. Better locality should make it easier to
identify safety error causes.

Fixes #1497

Signed-off-by: Torin Sandall <torinsandall@gmail.com>