### PR TITLE
server: add decision logging for undefined document error in v0 get r…

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -729,6 +729,12 @@ func (s *Server) v0QueryPath(w http.ResponseWriter, r *http.Request, path ast.Re
 	}
 
 	if len(rs) == 0 {
+		// Store decision logs with empty result and error.
+		err = diagLogger.Log(ctx, decisionID, r.RemoteAddr, path.String(), "", goInput, nil, nil, m, buf)
+		if err != nil {
+			writer.ErrorAuto(w, err)
+			return
+		}
 		writer.Error(w, 404, types.NewErrorV1(types.CodeUndefinedDocument, fmt.Sprintf("%v: %v", types.MsgUndefinedError, path)))
 		return
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -729,13 +729,18 @@ func (s *Server) v0QueryPath(w http.ResponseWriter, r *http.Request, path ast.Re
 	}
 
 	if len(rs) == 0 {
-		// Store decision logs with empty result and error.
-		err = diagLogger.Log(ctx, decisionID, r.RemoteAddr, path.String(), "", goInput, nil, nil, m, buf)
-		if err != nil {
-			writer.ErrorAuto(w, err)
+		// construct error to return to client.
+		err := types.NewErrorV1(types.CodeUndefinedDocument, fmt.Sprintf("%v: %v", types.MsgUndefinedError, path))
+
+		// emit decision log
+		if logErr := diagLogger.Log(ctx, decisionID, r.RemoteAddr, path.String(), "", goInput, nil, err, m, buf); logErr != nil {
+			// handle case where decision logging fails
+			writer.ErrorAuto(w, logErr)
 			return
 		}
-		writer.Error(w, 404, types.NewErrorV1(types.CodeUndefinedDocument, fmt.Sprintf("%v: %v", types.MsgUndefinedError, path)))
+
+		// send normal error back to the client
+		writer.Error(w, 404, err)
 		return
 	}
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -2579,6 +2579,16 @@ func TestDecisionLogging(t *testing.T) {
 			path:   "/data/fail_closed/decision_logger_err",
 			code:   500,
 		},
+		{
+			method: "POST",
+			v0:     true,
+			path:   "/data/test",
+			code:   404,
+			response: `{
+				"code": "undefined_document",
+				"message": "document missing or undefined: data.test"
+			  }`,
+		},
 	}
 
 	for _, r := range reqs {
@@ -2617,6 +2627,7 @@ func TestDecisionLogging(t *testing.T) {
 		{path: "data", wantErr: true},
 		{path: "data", wantErr: true},
 		{path: "data.system.main", wantErr: true},
+		{path: `data.test`, wantErr: true},
 	}
 
 	if len(decisions) != len(exp) {

--- a/server/types/types.go
+++ b/server/types/types.go
@@ -43,6 +43,11 @@ func NewErrorV1(code, f string, a ...interface{}) *ErrorV1 {
 	}
 }
 
+// This shall only used for debugging purpose.
+func (e *ErrorV1) Error() string {
+	return fmt.Sprintf("Code: %s, Message: %s", e.Code, e.Message)
+}
+
 // WithError updates e to include a detailed error.
 func (e *ErrorV1) WithError(err error) *ErrorV1 {
 	e.Errors = append(e.Errors, err)


### PR DESCRIPTION
…equest.

Signed-off-by: Xin Jin <xin@styra.com>

Decision log tests already in place.  This is needed so that in case of missing/undefined documents, decision logs can be emitted. On the consumer side, if there is no error and no result in a decision log, there is an error with OPA.

