### PR TITLE
server: Tweak server error string format

### DIFF
--- a/server/types/types.go
+++ b/server/types/types.go
@@ -45,7 +45,7 @@ func NewErrorV1(code, f string, a ...interface{}) *ErrorV1 {
 
 // This shall only used for debugging purpose.
 func (e *ErrorV1) Error() string {
-	return fmt.Sprintf("Code: %s, Message: %s", e.Code, e.Message)
+	return fmt.Sprintf("%s: %s", e.Code, e.Message)
 }
 
 // WithError updates e to include a detailed error.


### PR DESCRIPTION
This just tweaks the error string format introduced in #1530 to be
consistent with other error strings in OPA (e.g., topdown, ast, etc.)

Signed-off-by: Torin Sandall <torinsandall@gmail.com>