### PR TITLE
server: Pass transaction in decision log event

### DIFF
--- a/plugins/logs/plugin.go
+++ b/plugins/logs/plugin.go
@@ -281,7 +281,7 @@ func (p *Plugin) Log(ctx context.Context, decision *server.Info) error {
 		event.Error = decision.Error
 	}
 
-	err := p.maskEvent(ctx, &event)
+	err := p.maskEvent(ctx, decision.Txn, &event)
 	if err != nil {
 		// TODO(tsandall): see note below about error handling.
 		p.logError("Log event masking failed: %v.", err)
@@ -459,7 +459,7 @@ func (p *Plugin) bufferChunk(buffer *logBuffer, bs []byte) {
 	}
 }
 
-func (p *Plugin) maskEvent(ctx context.Context, event *EventV1) error {
+func (p *Plugin) maskEvent(ctx context.Context, txn storage.Transaction, event *EventV1) error {
 
 	err := func() error {
 
@@ -474,6 +474,7 @@ func (p *Plugin) maskEvent(ctx context.Context, event *EventV1) error {
 				rego.ParsedQuery(query),
 				rego.Compiler(p.manager.GetCompiler()),
 				rego.Store(p.manager.Store),
+				rego.Transaction(txn),
 				rego.Runtime(p.manager.Info),
 			)
 

--- a/plugins/logs/plugin_test.go
+++ b/plugins/logs/plugin_test.go
@@ -483,7 +483,7 @@ func TestPluginMasking(t *testing.T) {
 	event := &EventV1{
 		Input: &input,
 	}
-	if err := plugin.maskEvent(ctx, event); err != nil {
+	if err := plugin.maskEvent(ctx, nil, event); err != nil {
 		t.Fatal(err)
 	}
 
@@ -510,7 +510,7 @@ func TestPluginMasking(t *testing.T) {
 		Input: &input,
 	}
 
-	if err := plugin.maskEvent(ctx, event); err != nil {
+	if err := plugin.maskEvent(ctx, nil, event); err != nil {
 		t.Fatal(err)
 	}
 
@@ -544,7 +544,7 @@ func TestPluginMasking(t *testing.T) {
 		Input: &input,
 	}
 
-	if err := plugin.maskEvent(ctx, event); err != nil {
+	if err := plugin.maskEvent(ctx, nil, event); err != nil {
 		t.Fatal(err)
 	}
 
@@ -570,7 +570,7 @@ func TestPluginMasking(t *testing.T) {
 		Input: &input,
 	}
 
-	if err := plugin.maskEvent(ctx, event); err != nil {
+	if err := plugin.maskEvent(ctx, nil, event); err != nil {
 		t.Fatal(err)
 	}
 
@@ -739,7 +739,7 @@ func BenchmarkMaskingNop(b *testing.B) {
 
 		b.StartTimer()
 
-		if err := plugin.maskEvent(ctx, &event); err != nil {
+		if err := plugin.maskEvent(ctx, nil, &event); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -792,7 +792,7 @@ func BenchmarkMaskingErase(b *testing.B) {
 
 		b.StartTimer()
 
-		if err := plugin.maskEvent(ctx, &event); err != nil {
+		if err := plugin.maskEvent(ctx, nil, &event); err != nil {
 			b.Fatal(err)
 		}
 

--- a/server/buffer.go
+++ b/server/buffer.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/open-policy-agent/opa/metrics"
+	"github.com/open-policy-agent/opa/storage"
 	"github.com/open-policy-agent/opa/topdown"
 )
 
@@ -72,6 +73,7 @@ func (b *buffer) Iter(fn func(*Info)) {
 
 // Info contains information describing a policy decision.
 type Info struct {
+	Txn        storage.Transaction
 	Revision   string
 	DecisionID string
 	RemoteAddr string


### PR DESCRIPTION
These changes update the server to pass the server's open transaction
to the decision logger. This prevents the same goroutine from
recursively opening a new transcation when the log masking decision is
evaluated.

Alternatively we could update the server to close it's transaction
before logging the decision however this could lead to the log masking
decision being generated from a different policy revision. Another
alternative would be extend the storage layer to support recursive
transactions however this would be quite a bit more work.

We should investigate whether we can cheaply detect recursive
transactions in the store to avoid potential deadlocks in the future.

Also, delete opa binary that was accidentally committed to the repo.

Fixes #1543