### PR TITLE
travis: Update Travis deployments to support release branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ services:
 deploy:
 
 
-  # This deployment is mutually exclusive with the next deployment. This
+  # This deployment is mutually exclusive with the other deployments. This
   # deployment builds and publishes the docker image whenever changes are
   # committed to master. The latest tag is not updated.
   - provider: script
@@ -23,14 +23,25 @@ deploy:
       branch: master
       tags: false
 
-  # This deployment is mutually exclusive with the previous deployment. This
+  # This deployment is mutually exclusive with the other deployments. This
   # deployment builds and publishes the docker image whenver a new tag is
-  # created. The latest tag is updated to point to the image produced by this
-  # deployment.
+  # created on the master branch. The latest tag is updated to point to the
+  # image produced by this deployment.
   - provider: script
     skip_cleanup: true  # do not delete artifacts because linux executable is needed
     script: make release-travis
     on:
       repo: open-policy-agent/opa
       branch: master
+      tags: true
+
+  # This deployment is mutually exclusive with the other deployments. This
+  # deployment builds and publishes the docker image whenver a new tag is
+  # created on a release branch.
+  - provider: script
+    skip_cleanup: true  # do not delete artifacts because linux executable is needed
+    script: make release-bugfix-travis
+    on:
+      repo: open-policy-agent/opa
+      condition: $TRAVIS_BRANCH =~ ^release-.*$
       tags: true

--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,9 @@ deploy-travis: docker-login image-quick push
 .PHONY: release-travis
 release-travis: deploy-travis tag-latest push-latest
 
+.PHONY: release-bugfix-travis
+release-bugfix-travis: deploy-travis
+
 .PHONY: install
 install: generate
 	$(GO) install -ldflags $(LDFLAGS)
@@ -171,7 +174,7 @@ clean: wasm-clean
 	rm -fr _test
 
 # The docs-% pattern target will shim to the
-# makefile in ./docs 
+# makefile in ./docs
 .PHONY: docs-%
 docs-%:
 	$(MAKE) -C docs $*


### PR DESCRIPTION
Previously, the Travis configuration would only trigger deployments
for the master branch. Also, the release-travis step would re-tag
:latest which is not what we want for release branches.

These changes add a new Travis deployment for release branches that
does not re-tag :latest and _will_ trigger for tags on release
branches.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>