### PR TITLE
docs: Add details for `.`'s in `--set` keys

### DIFF
--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -183,6 +183,36 @@ You can do this by setting the value with `null`. For example:
 opa run --set "decision_logger.plugin=my_plugin" --set "plugins.my_plugin=null"
 ```
 
+#### Keys with Special Characters
+
+If you have a key which contains a special character (`.`, `=`, etc), like `opa.example.com`, and want to use
+the `--set` or `--set-file` options you will need to escape the character with a backslash (`\`).
+
+For example a config section like:
+
+```yaml
+services:
+  opa.example.com:
+    url: https://opa.example.com
+```
+
+Could be specified with something like:
+
+`--set services.opa\.example\.com.url=https://opa.example.com`
+
+
+Note that when using it in a shell you may need to put it in quotes or escape the `\`
+character too. For example:
+
+
+`--set services."opa\.example\.com".url=https://opa.example.com`
+
+_or_
+
+`--set services.opa\\.example\\.com.url=https://opa.example.com`
+
+Where the end result passed into OPA still has the `\.` preserved.
+
 ## Services
 
 Services represent endpoints that implement one or more control plane APIs


### PR DESCRIPTION
It is not very discoverable as to how the `--set` options work when
keys have `.` characters in them. This adds in a section to the config
docs on how to do it.

Signed-off-by: Patrick East <east.patrick@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
