### PR TITLE
docs: Tweaks to improve consistency

### DIFF
--- a/docs/content/how-do-i-write-policies.md
+++ b/docs/content/how-do-i-write-policies.md
@@ -108,7 +108,7 @@ bodies can separate expressions with newlines and omit the semicolon:
 t2 {
     x := 42
     y := 41
-    x > 1
+    x > y
 }
 ```
 


### PR DESCRIPTION
The preceding example uses `x>y`, without which the variable `y`
is unused.