### PR TITLE
Add User-Agent to rest client as default header

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -7,6 +7,8 @@ package version
 
 import (
 	"context"
+	"fmt"
+	"runtime"
 
 	"github.com/open-policy-agent/opa/storage"
 	"github.com/open-policy-agent/opa/version"
@@ -33,3 +35,6 @@ func Write(ctx context.Context, store storage.Store, txn storage.Transaction) er
 
 	return nil
 }
+
+// UserAgent defines the current OPA instances User-Agent default header value
+var UserAgent = fmt.Sprintf("Open Policy Agent/%s (%s, %s)", version.Version, runtime.GOOS, runtime.GOARCH)

--- a/plugins/rest/rest.go
+++ b/plugins/rest/rest.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"github.com/open-policy-agent/opa/internal/version"
 	"io"
 	"net/http"
 	"reflect"
@@ -177,7 +178,9 @@ func (c Client) Do(ctx context.Context, method, path string) (*http.Response, er
 		return nil, err
 	}
 
-	headers := map[string]string{}
+	headers := map[string]string{
+		"User-Agent": version.UserAgent,
+	}
 
 	// Copy custom headers from config.
 	for key, value := range c.config.Headers {

--- a/plugins/rest/rest_test.go
+++ b/plugins/rest/rest_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"github.com/open-policy-agent/opa/internal/version"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -334,6 +335,11 @@ func (t *testServer) handle(w http.ResponseWriter, r *http.Request) {
 			t.t.Fatal("Expected client certificate but didn't get any")
 		}
 	}
+	ua := r.Header.Get("user-Agent")
+	if ua != version.UserAgent {
+		t.t.Errorf("Unexpected User-Agent string: %s", ua)
+	}
+
 	w.WriteHeader(200)
 }
 

--- a/topdown/http.go
+++ b/topdown/http.go
@@ -9,6 +9,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"github.com/open-policy-agent/opa/internal/version"
 	"io"
 	"io/ioutil"
 	"strconv"
@@ -268,6 +269,10 @@ func executeHTTPRequest(bctx BuiltinContext, obj ast.Object) (ast.Value, error) 
 	if len(customHeaders) != 0 {
 		if ok, err := addHeaders(req, customHeaders); !ok {
 			return nil, err
+		}
+		// Don't overwrite or append to one that was set in the custom headers
+		if _, hasUA := customHeaders["User-Agent"]; !hasUA {
+			req.Header.Add("User-Agent", version.UserAgent)
 		}
 	}
 


### PR DESCRIPTION
This can be overridden by custom header configuration for services,
or requests but will default to something like:

`Open Policy Agent/<version> (<os>, <arch>)`

This is set on all outbound requests for status, decision logs, bundle
and discovery downloads, http requests from policies, etc.

Signed-off-by: Patrick East <east.patrick@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
