### PR TITLE
Allow unregistering built-ins

### DIFF
--- a/ast/builtins.go
+++ b/ast/builtins.go
@@ -23,6 +23,20 @@ func RegisterBuiltin(b *Builtin) {
 	}
 }
 
+// UnregisterBuiltin removes a built-in function from the registry.
+func UnregisterBuiltin(name string) {
+	idx := 0
+	for _, b := range Builtins {
+		if b.Name != name {
+			Builtins[idx] = b
+			idx++
+		}
+	}
+	Builtins = Builtins[:idx]
+
+	delete(BuiltinMap, name)
+}
+
 // DefaultBuiltins is the registry of built-in functions supported in OPA
 // by default. When adding a new built-in function to OPA, update this
 // list.

--- a/topdown/builtins.go
+++ b/topdown/builtins.go
@@ -100,6 +100,11 @@ func RegisterFunctionalBuiltin4(name string, fun FunctionalBuiltin4) {
 	builtinFunctions[name] = functionalWrapper4(name, fun)
 }
 
+// UnregisterBuiltin removes a built-in function from the evaluation engine.
+func UnregisterBuiltin(name string) {
+	delete(builtinFunctions, name)
+}
+
 // BuiltinEmpty is used to signal that the built-in function evaluated, but the
 // result is undefined so evaluation should not continue.
 type BuiltinEmpty struct{}

--- a/topdown/example_test.go
+++ b/topdown/example_test.go
@@ -378,3 +378,26 @@ func ExampleRegisterFunctionalBuiltin1() {
 	//
 	// x: "CUSTOM"
 }
+
+func ExampleUnregisterBuiltin() {
+	// Rego includes a number of built-in functions. In some cases, you may not
+	// want all builtins to be available to a program. This test shows how to
+	// remove a built-in.
+
+	// Strictly speaking, only the first call is necessary but it is safer to
+	// remove the implementation as well as the definition.
+	ast.UnregisterBuiltin("re_match")
+	topdown.UnregisterBuiltin("re_match")
+
+	// This query should not compile because the `re_match` built-in is no
+	// longer available.
+	compiler := ast.NewCompiler()
+	_, err := compiler.QueryCompiler().Compile(ast.MustParseBody(`re_match("a", "a")`))
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	// Output:
+	//
+	// 1 error occurred: 1:1: rego_type_error: undefined function re_match
+}


### PR DESCRIPTION
This patch allows users to unregister certain built-ins.

The primary use case is that we want to be able to embed OPA into a
highly sandboxed application.  To this end, we would like to disable a
few built-ins, with `http.send` being the main culprit.

Signed-off-by: Jasper Van der Jeugt <jasper@fugue.co>