### PR TITLE
fixes usage of fmt command

### DIFF
--- a/cmd/fmt.go
+++ b/cmd/fmt.go
@@ -25,7 +25,7 @@ var fmtParams = struct {
 }{}
 
 var formatCommand = &cobra.Command{
-	Use:   "fmt",
+	Use:   "fmt <path> [path [...]]",
 	Short: "Format Rego source files",
 	Long: `Format Rego source files.
 

--- a/cmd/fmt.go
+++ b/cmd/fmt.go
@@ -25,11 +25,12 @@ var fmtParams = struct {
 }{}
 
 var formatCommand = &cobra.Command{
-	Use:   "fmt <path> [path [...]]",
+	Use:   "fmt [path [...]]",
 	Short: "Format Rego source files",
 	Long: `Format Rego source files.
 
-The 'fmt' command takes a Rego source file and outputs a reformatted version.
+The 'fmt' command takes a Rego source file and outputs a reformatted version. If no file path
+is provided - this tool will use stdin.
 The format of the output is not defined specifically; whatever this tool outputs
 is considered correct format (with the exception of bugs).
 


### PR DESCRIPTION
Fixes the usage of the `fmt` command to indicate that you can (and must) provide a set of files / paths. This is consistent with other commands like `check`. 

This behavior can be replicated locally by running:

```bash
opa fmt 
```

which hangs forever.

This block of code also indicates this functionality: 

https://github.com/open-policy-agent/opa/blob/1a673b8fd6cc48ec6959cda44994b809dd333e91/cmd/fmt.go#L60-L74