### PR TITLE
Add new explanation mode "fails"

### DIFF
--- a/cmd/eval.go
+++ b/cmd/eval.go
@@ -23,7 +23,7 @@ import (
 	"github.com/open-policy-agent/opa/rego"
 	"github.com/open-policy-agent/opa/storage/inmem"
 	"github.com/open-policy-agent/opa/topdown"
-	"github.com/open-policy-agent/opa/topdown/notes"
+	"github.com/open-policy-agent/opa/topdown/lineage"
 	"github.com/open-policy-agent/opa/util"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -62,7 +62,7 @@ func newEvalCommandParams() evalCommandParams {
 			evalBindingsOutput,
 			evalPrettyOutput,
 		}),
-		explain: newExplainFlag([]string{explainModeOff, explainModeFull, explainModeNotes}),
+		explain: newExplainFlag([]string{explainModeOff, explainModeFull, explainModeNotes, explainModeFails}),
 	}
 }
 
@@ -330,7 +330,9 @@ func eval(args []string, params evalCommandParams, w io.Writer) (bool, error) {
 	case explainModeFull:
 		result.Explanation = *tracer
 	case explainModeNotes:
-		result.Explanation = notes.Filter(*tracer)
+		result.Explanation = lineage.Notes(*tracer)
+	case explainModeFails:
+		result.Explanation = lineage.Fails(*tracer)
 	}
 
 	if m != nil {

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -22,6 +22,7 @@ const (
 	explainModeOff   = "off"
 	explainModeFull  = "full"
 	explainModeNotes = "notes"
+	explainModeFails = "fails"
 )
 
 func newExplainFlag(modes []string) *util.EnumFlag {

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/open-policy-agent/opa/internal/runtime"
 	"github.com/open-policy-agent/opa/storage"
-	"github.com/open-policy-agent/opa/topdown/notes"
+	"github.com/open-policy-agent/opa/topdown/lineage"
 
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/cover"
@@ -39,7 +39,7 @@ var testParams = struct {
 	failureLine  bool
 }{
 	outputFormat: util.NewEnumFlag(testPrettyOutput, []string{testPrettyOutput, testJSONOutput}),
-	explain:      newExplainFlag([]string{explainModeFull, explainModeNotes}),
+	explain:      newExplainFlag([]string{explainModeFails, explainModeFull, explainModeNotes}),
 }
 
 var testCommand = &cobra.Command{
@@ -194,7 +194,9 @@ func opaTest(args []string) int {
 			}
 			switch testParams.explain.String() {
 			case explainModeNotes:
-				tr.Trace = notes.Filter(tr.Trace)
+				tr.Trace = lineage.Notes(tr.Trace)
+			case explainModeFails:
+				tr.Trace = lineage.Fails(tr.Trace)
 			}
 			dup <- tr
 		}

--- a/repl/repl_test.go
+++ b/repl/repl_test.go
@@ -320,13 +320,14 @@ func TestShowDebug(t *testing.T) {
 	repl := newRepl(store, &buffer)
 	repl.OneShot(ctx, "show debug")
 
-	var result replDebug
+	var result replDebugState
 
 	if err := util.Unmarshal(buffer.Bytes(), &result); err != nil {
 		t.Fatal(err)
 	}
 
-	var exp replDebug
+	var exp replDebugState
+	exp.Explain = explainOff
 
 	if !reflect.DeepEqual(result, exp) {
 		t.Fatalf("Expected %+v but got %+v", exp, result)
@@ -340,7 +341,7 @@ func TestShowDebug(t *testing.T) {
 	repl.OneShot(ctx, "profile")
 	repl.OneShot(ctx, "show debug")
 
-	exp.Trace = true
+	exp.Explain = explainFull
 	exp.Metrics = true
 	exp.Instrument = true
 	exp.Profile = true

--- a/server/server.go
+++ b/server/server.go
@@ -38,7 +38,7 @@ import (
 	"github.com/open-policy-agent/opa/server/writer"
 	"github.com/open-policy-agent/opa/storage"
 	"github.com/open-policy-agent/opa/topdown"
-	"github.com/open-policy-agent/opa/topdown/notes"
+	"github.com/open-policy-agent/opa/topdown/lineage"
 	"github.com/open-policy-agent/opa/util"
 	"github.com/open-policy-agent/opa/version"
 	"github.com/open-policy-agent/opa/watch"
@@ -1965,7 +1965,13 @@ func (s *Server) getExplainResponse(explainMode types.ExplainModeV1, trace []*to
 	switch explainMode {
 	case types.ExplainNotesV1:
 		var err error
-		explanation, err = types.NewTraceV1(notes.Filter(trace), pretty)
+		explanation, err = types.NewTraceV1(lineage.Notes(trace), pretty)
+		if err != nil {
+			break
+		}
+	case types.ExplainFailsV1:
+		var err error
+		explanation, err = types.NewTraceV1(lineage.Fails(trace), pretty)
 		if err != nil {
 			break
 		}

--- a/server/types/types.go
+++ b/server/types/types.go
@@ -199,6 +199,7 @@ const (
 	ExplainOffV1   ExplainModeV1 = "off"
 	ExplainFullV1  ExplainModeV1 = "full"
 	ExplainNotesV1 ExplainModeV1 = "notes"
+	ExplainFailsV1 ExplainModeV1 = "fails"
 )
 
 // TraceV1 models the trace result returned for queries that include the

--- a/topdown/lineage/lineage_test.go
+++ b/topdown/lineage/lineage_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by an Apache2
 // license that can be found in the LICENSE file.
 
-package notes
+package lineage
 
 import (
 	"bytes"
@@ -176,7 +176,7 @@ Enter data.test.p = x
 				t.Fatalf("Unexpected result: %v", rs)
 			}
 
-			filtered := Filter(*buf)
+			filtered := Notes(*buf)
 
 			buffer := bytes.NewBuffer(nil)
 			topdown.PrettyTrace(buffer, filtered)


### PR DESCRIPTION
These changes add a new explanation mode for filtering fail events during evaluation. These changes also update the tester to use the new mode when running in verbose mode. Since tests only pass if all statements in the test rule succeed, reporting failures should help better identify the source of errors. Once this lands we can explore adding support for output expected vs. actual values (#1581).