### PR TITLE
Add livenessProbe to demo deployment

### DIFF
--- a/docs/content/kubernetes-admission-control.md
+++ b/docs/content/kubernetes-admission-control.md
@@ -185,6 +185,20 @@ spec:
             - readOnly: true
               mountPath: /certs
               name: opa-server
+          readinessProbe:
+            httpGet:
+              path: /health
+              scheme: HTTPS
+              port: 443
+            initialDelaySeconds: 3
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /health
+              scheme: HTTPS
+              port: 443
+            initialDelaySeconds: 3
+            periodSeconds: 5
         - name: kube-mgmt
           image: openpolicyagent/kube-mgmt:0.8
           args:


### PR DESCRIPTION
I expect many install OPA following this guide (as we did). Recent PRs have made steps to 'productionize' this (e.g. [#1435](https://github.com/open-policy-agent/opa/pull/1435))

We had an incident involving the controller where a stuck container was not restarted. We would have been helped if a liveness probe was configured. We copied the docs and this is our bad but we'd like to do our best to make sure others don't make the same mistake.

I figured it'd be ok to use the health endpoint [here](https://github.com/open-policy-agent/opa/blob/master/docs/content/rest-api.md#health-api)

We've made this change and it seems to be working ok for us.