### PR TITLE
Add Prometheus metrics to the status updates

### DIFF
--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -343,6 +343,7 @@ server provenance, etc.
 | --- | --- | --- | --- |
 | `status.service` | `string` | Yes | Name of service to use to contact remote server. |
 | `status.partition_name` | `string` | No | Path segment to include in status updates. |
+| `status.include_metrics` | `boolean` | (default: `false`)  | Include Prometheus metrics in status updates. |
 
 ## Decision Logs
 

--- a/docs/content/status.md
+++ b/docs/content/status.md
@@ -46,7 +46,74 @@ on the agent, updates will be sent to `/status`.
             "last_successful_download": "2018-01-01T00:00:00.000Z",
             "last_successful_activation": "2018-01-01T00:00:00.000Z"
         }
-    }
+    }, 
+    "metrics": [
+        {
+            "help": "A summary of the GC invocation durations.",
+            "name": "go_gc_duration_seconds",
+            "type": 2,
+            "metric": [
+                {
+                    "summary": {
+                        "quantile": [
+                            {
+                                "quantile": 0,
+                                "value": 0.000044358
+                            },
+                            {
+                                "quantile": 0.25,
+                                "value": 0.000045003
+                            },
+                            {
+                                "quantile": 0.5,
+                                "value": 0.000049726
+                            },
+                            {
+                                "quantile": 0.75,
+                                "value": 0.000219553
+                            },
+                            {
+                                "quantile": 1,
+                                "value": 0.000219553
+                            }
+                        ],
+                       "sample_count": 4,
+                       "sample_sum": 0.00035864
+                    }
+                }
+            ]
+        },
+        {
+            "help": "Number of goroutines that currently exist.",
+            "name": "go_goroutines",
+            "type": 1,
+            "metric": [
+                {
+                    "gauge": {
+                        "value": 11
+                    }
+                }
+            ]
+        },
+        {
+            "help": "Information about the Go environment.",
+            "name": "go_info",
+            "type": 1,
+            "metric": [
+                {
+                    "gauge": {
+                        "value": 1
+                    },
+                    "label": [
+                        {
+                            "name": "version",
+                            "value": "go1.12.7"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
 }
 ```
 
@@ -68,6 +135,7 @@ Status updates contain the following fields:
 | `discovery.active_revision` | `string` | Opaque revision identifier of the last successful discovery activation. |
 | `discovery.last_successful_download` | `string` | RFC3339 timestamp of last successful discovery bundle download. |
 | `discovery.last_successful_activation` | `string` | RFC3339 timestamp of last successful discovery bundle activation. |
+| `metrics` | `array` | Prometheus metrics as returned by the Gather method. See [Prometheus Go client](https://github.com/prometheus/client_golang/blob/v1.1.0/prometheus/registry.go) for exact format.|
 
 If the bundle download or activation failed, the status update will contain
 the following additional fields.

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -1,0 +1,19 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// GlobalMetricsRegistry is the Prometheus metrics registry singleton
+var GlobalMetricsRegistry *prometheus.Registry
+
+func init() {
+	ResetGlobalMetricsRegistry()
+}
+
+// ResetGlobalMetricsRegistry resets GlobalMetricsRegistry to it's default value.
+// This is needed by the unit tests that create many server instances and would try to register duplicate collectors in the registry
+func ResetGlobalMetricsRegistry() {
+	GlobalMetricsRegistry = prometheus.NewRegistry()
+	GlobalMetricsRegistry.MustRegister(prometheus.NewGoCollector())
+}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -174,6 +174,7 @@ func TestInitWithBundlePlugin(t *testing.T) {
 
 	m.Register(pluginBundle.Name, pluginBundle.New(bundleConf, m))
 
+	metrics.ResetGlobalMetricsRegistry()
 	server, err := New().
 		WithStore(store).
 		WithManager(m).
@@ -212,6 +213,7 @@ func TestInitWithBundlePluginMultiBundle(t *testing.T) {
 
 	m.Register(pluginBundle.Name, pluginBundle.New(bundleConf, m))
 
+	metrics.ResetGlobalMetricsRegistry()
 	server, err := New().
 		WithStore(store).
 		WithManager(m).
@@ -2271,6 +2273,7 @@ func TestPoliciesPathSlashes(t *testing.T) {
 
 func TestQueryPostBasic(t *testing.T) {
 	f := newFixture(t)
+	metrics.ResetGlobalMetricsRegistry()
 	f.server, _ = New().
 		WithAddresses([]string{":8182"}).
 		WithStore(f.server.store).
@@ -2552,6 +2555,7 @@ func TestQueryWatchMigrateInvalidate(t *testing.T) {
 
 func TestDiagnostics(t *testing.T) {
 	f := newFixture(t)
+	metrics.ResetGlobalMetricsRegistry()
 	f.server, _ = New().
 		WithAddresses([]string{":8182"}).
 		WithStore(f.server.store).
@@ -3368,7 +3372,7 @@ func TestAuthorization(t *testing.T) {
 	if err := store.Commit(ctx, txn); err != nil {
 		panic(err)
 	}
-
+	metrics.ResetGlobalMetricsRegistry()
 	server, err := New().
 		WithAddresses([]string{":8182"}).
 		WithStore(store).
@@ -3512,6 +3516,7 @@ func TestQueryBindingIterationError(t *testing.T) {
 		panic(err)
 	}
 
+	metrics.ResetGlobalMetricsRegistry()
 	server, err := New().WithStore(mock).WithManager(m).WithAddresses([]string{":8182"}).Init(ctx)
 	if err != nil {
 		panic(err)
@@ -3560,6 +3565,7 @@ func newFixture(t *testing.T) *fixture {
 		panic(err)
 	}
 
+	metrics.ResetGlobalMetricsRegistry()
 	server, err := New().
 		WithAddresses([]string{":8182"}).
 		WithStore(store).
@@ -3838,6 +3844,7 @@ allow {
 		t.Fatal(err)
 	}
 
+	metrics.ResetGlobalMetricsRegistry()
 	server, err := New().
 		WithAddresses([]string{"https://127.0.0.1:8182"}).
 		WithStore(store).


### PR DESCRIPTION
Prometheus metrics can give much of insight into OPA's health.
Run-time metrics are a natural part of the application state
so having them in status update seems like a right change
that can help server understand what's going in with the OPA
instance.

Addresses #1606

Signed-off-by: Stan Lagun <stan@styra.com>