### PR TITLE
Add Prometheus metrics to the status updates

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -27,6 +27,13 @@ type Config struct {
 	Plugins                      map[string]json.RawMessage `json:"plugins"`
 	DefaultDecision              *string                    `json:"default_decision"`
 	DefaultAuthorizationDecision *string                    `json:"default_authorization_decision"`
+	MetricsProvider              *MetricsProviderConfig     `json:"metrics_provider"`
+}
+
+// MetricsProviderConfig represents metrics_provider config section
+type MetricsProviderConfig struct {
+	Name   string          `json:"name"`
+	Config json.RawMessage `json:"config"`
 }
 
 // ParseConfig returns a valid Config object with defaults injected. The id
@@ -85,6 +92,10 @@ func (c *Config) validateAndInjectDefaults(id string) error {
 
 	c.Labels["id"] = id
 	c.Labels["version"] = version.Version
+
+	if c.MetricsProvider == nil {
+		c.MetricsProvider = &MetricsProviderConfig{Name: "prometheus"}
+	}
 
 	return nil
 }

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -52,6 +52,9 @@ status:
   service: acmecorp
 
 default_decision: /http/example/authz/allow
+
+metrics_provider:
+    name: prometheus
 ```
 
 ## Environment Variable Substitution
@@ -343,6 +346,7 @@ server provenance, etc.
 | --- | --- | --- | --- |
 | `status.service` | `string` | Yes | Name of service to use to contact remote server. |
 | `status.partition_name` | `string` | No | Path segment to include in status updates. |
+| `status.include_metrics` | `boolean` | (default: `false`)  | Include Prometheus metrics in status updates. |
 
 ## Decision Logs
 
@@ -367,3 +371,15 @@ server provenance, etc.
 | `discovery.decision` | `string` | No (default: value of `discovery.name` configuration field) | Name of the OPA query that will be used to calculate the configuration |
 | `discovery.polling.min_delay_seconds` | `int64` | No (default: `60`) | Minimum amount of time to wait between configuration downloads. |
 | `discovery.polling.max_delay_seconds` | `int64` | No (default: `120`) | Maximum amount of time to wait between configuration downloads. |
+
+
+## Metrics provider
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `metrics_provider.name` | `string` | No | Name of the metrics provider to use. |
+| `metrics_provider.config` | `object` | No | Provider-specific configuration (not used as of now). |
+
+Available metrics providers:
+* `prometheus` (default)
+*  (empty string): do not collect metrics

--- a/docs/content/status.md
+++ b/docs/content/status.md
@@ -46,6 +46,75 @@ on the agent, updates will be sent to `/status`.
             "last_successful_download": "2018-01-01T00:00:00.000Z",
             "last_successful_activation": "2018-01-01T00:00:00.000Z"
         }
+    },
+    "metrics": {
+        "prometheus":  [
+            {
+                "help": "A summary of the GC invocation durations.",
+                "name": "go_gc_duration_seconds",
+                "type": 2,
+                "metric": [
+                    {
+                        "summary": {
+                            "quantile": [
+                                {
+                                    "quantile": 0,
+                                    "value": 0.000044358
+                                },
+                                {
+                                    "quantile": 0.25,
+                                    "value": 0.000045003
+                                },
+                                {
+                                    "quantile": 0.5,
+                                    "value": 0.000049726
+                                },
+                                {
+                                    "quantile": 0.75,
+                                    "value": 0.000219553
+                                },
+                                {
+                                    "quantile": 1,
+                                    "value": 0.000219553
+                                }
+                            ],
+                           "sample_count": 4,
+                           "sample_sum": 0.00035864
+                        }
+                    }
+                ]
+            },
+            {
+                "help": "Number of goroutines that currently exist.",
+                "name": "go_goroutines",
+                "type": 1,
+                "metric": [
+                    {
+                        "gauge": {
+                            "value": 11
+                        }
+                    }
+                ]
+            },
+            {
+                "help": "Information about the Go environment.",
+                "name": "go_info",
+                "type": 1,
+                "metric": [
+                    {
+                        "gauge": {
+                            "value": 1
+                        },
+                        "label": [
+                            {
+                                "name": "version",
+                                "value": "go1.12.7"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
     }
 }
 ```
@@ -68,6 +137,8 @@ Status updates contain the following fields:
 | `discovery.active_revision` | `string` | Opaque revision identifier of the last successful discovery activation. |
 | `discovery.last_successful_download` | `string` | RFC3339 timestamp of last successful discovery bundle download. |
 | `discovery.last_successful_activation` | `string` | RFC3339 timestamp of last successful discovery bundle activation. |
+| `metrics` | `object` | Application metrics. Optional, single key object. |
+| `metrics[provider_name]` | JSON (`interface{}`) | Metrics in provider-dependent format. |
 
 If the bundle download or activation failed, the status update will contain
 the following additional fields.

--- a/internal/metrics/dummy.go
+++ b/internal/metrics/dummy.go
@@ -1,0 +1,25 @@
+// Copyright 2019 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package metrics
+
+import (
+	"net/http"
+)
+
+type dummyProvider struct{}
+
+func (dummyProvider) RegisterEndpoints(registrar func(path, method string, handler http.Handler)) {}
+
+func (dummyProvider) InstrumentHandler(handler http.Handler, label string) http.Handler {
+	return handler
+}
+
+func (dummyProvider) Gather() (interface{}, error) {
+	return nil, nil
+}
+
+func (dummyProvider) Name() string {
+	return ""
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,0 +1,26 @@
+// Copyright 2019 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package metrics
+
+import (
+	"encoding/json"
+
+	"github.com/pkg/errors"
+
+	"github.com/open-policy-agent/opa/internal/metrics/prometheus"
+	"github.com/open-policy-agent/opa/metrics"
+)
+
+// NewGlobalMetrics creates a metrics provider instance given its name and config
+func NewGlobalMetrics(name string, config json.RawMessage) (metrics.GlobalMetrics, error) {
+	switch name {
+	case "":
+		return &dummyProvider{}, nil
+	case prometheus.ProviderName:
+		return prometheus.NewPrometheusProvider(), nil
+	default:
+		return nil, errors.Errorf("Invalid metrics provider %s.", name)
+	}
+}

--- a/internal/metrics/prometheus/prometheus.go
+++ b/internal/metrics/prometheus/prometheus.go
@@ -1,0 +1,107 @@
+// Copyright 2019 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package prometheus
+
+import (
+	"bufio"
+	"net"
+	"net/http"
+	"strconv"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+// ProviderName is the Prometheus provider name
+const ProviderName = "prometheus"
+
+// Provider is the prometheus
+type Provider struct {
+	registry             *prometheus.Registry
+	durationHistogram    *prometheus.HistogramVec
+	cancellationCounters *prometheus.CounterVec
+}
+
+// NewPrometheusProvider creates new instance of the prometheus provider
+func NewPrometheusProvider() *Provider {
+	registry := prometheus.NewRegistry()
+	registry.MustRegister(prometheus.NewGoCollector())
+	durationHistogram := prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name: "http_request_duration_seconds",
+			Help: "A histogram of duration for requests.",
+		},
+		[]string{"code", "handler", "method"},
+	)
+	registry.MustRegister(durationHistogram)
+
+	cancellationCounters := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "http_request_cancellations",
+			Help: "A count of cancelled requests.",
+		},
+		[]string{"code", "handler", "method"},
+	)
+
+	registry.MustRegister(cancellationCounters)
+	return &Provider{
+		registry:             registry,
+		durationHistogram:    durationHistogram,
+		cancellationCounters: cancellationCounters,
+	}
+}
+
+// RegisterEndpoints registers `/metrics` endpoint
+func (p *Provider) RegisterEndpoints(registrar func(path, method string, handler http.Handler)) {
+	registrar("/metrics", http.MethodGet, promhttp.HandlerFor(p.registry, promhttp.HandlerOpts{}))
+}
+
+// InstrumentHandler returned wrapped HTTP handler with added prometheus instrumentation
+func (p *Provider) InstrumentHandler(handler http.Handler, label string) http.Handler {
+	durationCollector := p.durationHistogram.MustCurryWith(prometheus.Labels{"handler": label})
+	cancellationsCollector := p.cancellationCounters.MustCurryWith(prometheus.Labels{"handler": label})
+	return promhttp.InstrumentHandlerDuration(durationCollector, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		csrw := &captureStatusResponseWriter{ResponseWriter: w, status: http.StatusOK}
+		var rw http.ResponseWriter
+		if h, ok := w.(http.Hijacker); ok {
+			rw = &hijacker{ResponseWriter: csrw, hijacker: h}
+		} else {
+			rw = csrw
+		}
+		handler.ServeHTTP(rw, r)
+		if r.Context().Err() != nil {
+			cancellationsCollector.With(prometheus.Labels{"code": strconv.Itoa(csrw.status), "method": r.Method}).Inc()
+		}
+	}))
+}
+
+// Gather collects and returns all registered metrics
+func (p *Provider) Gather() (interface{}, error) {
+	return p.registry.Gather()
+}
+
+// Name returns the provider name
+func (p *Provider) Name() string {
+	return ProviderName
+}
+
+type captureStatusResponseWriter struct {
+	http.ResponseWriter
+	status int
+}
+
+type hijacker struct {
+	http.ResponseWriter
+	hijacker http.Hijacker
+}
+
+func (h *hijacker) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return h.hijacker.Hijack()
+}
+
+func (c *captureStatusResponseWriter) WriteHeader(statusCode int) {
+	c.ResponseWriter.WriteHeader(statusCode)
+	c.status = statusCode
+}

--- a/metrics/global.go
+++ b/metrics/global.go
@@ -1,0 +1,17 @@
+// Copyright 2018 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package metrics
+
+import (
+	"net/http"
+)
+
+// GlobalMetrics abstracts metric providers API
+type GlobalMetrics interface {
+	RegisterEndpoints(registrar func(path, method string, handler http.Handler))
+	InstrumentHandler(handler http.Handler, label string) http.Handler
+	Gather() (interface{}, error)
+	Name() string
+}

--- a/plugins/discovery/discovery.go
+++ b/plugins/discovery/discovery.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/open-policy-agent/opa/metrics"
 
 	"github.com/open-policy-agent/opa/ast"
 	bundleApi "github.com/open-policy-agent/opa/bundle"
@@ -27,12 +28,13 @@ import (
 // started it will periodically download a configuration bundle and try to
 // reconfigure the OPA.
 type Discovery struct {
-	manager    *plugins.Manager
-	config     *Config
-	factories  map[string]plugins.Factory
-	downloader *download.Downloader // discovery bundle downloader
-	status     *bundle.Status       // discovery status
-	etag       string               // discovery bundle etag for caching purposes
+	manager       *plugins.Manager
+	config        *Config
+	factories     map[string]plugins.Factory
+	downloader    *download.Downloader // discovery bundle downloader
+	status        *bundle.Status       // discovery status
+	etag          string               // discovery bundle etag for caching purposes
+	globalMetrics metrics.GlobalMetrics
 }
 
 // Factories provides a set of factory functions to use for
@@ -40,6 +42,13 @@ type Discovery struct {
 func Factories(fs map[string]plugins.Factory) func(*Discovery) {
 	return func(d *Discovery) {
 		d.factories = fs
+	}
+}
+
+// WithMetrics sets the GlobalMetrics instance to use for instantiations
+func WithMetrics(globalMetrics metrics.GlobalMetrics) func(*Discovery) {
+	return func(d *Discovery) {
+		d.globalMetrics = globalMetrics
 	}
 }
 
@@ -59,7 +68,7 @@ func New(manager *plugins.Manager, opts ...func(*Discovery)) (*Discovery, error)
 	if err != nil {
 		return nil, err
 	} else if config == nil {
-		if _, err := getPluginSet(result.factories, manager, manager.Config); err != nil {
+		if _, err := getPluginSet(result.factories, manager, manager.Config, result.globalMetrics); err != nil {
 			return nil, err
 		}
 		return result, nil
@@ -144,7 +153,7 @@ func (c *Discovery) processUpdate(ctx context.Context, u download.Update) {
 
 func (c *Discovery) reconfigure(ctx context.Context, u download.Update) error {
 
-	config, ps, err := processBundle(ctx, c.manager, c.factories, u.Bundle, c.config.query)
+	config, ps, err := processBundle(ctx, c.manager, c.factories, u.Bundle, c.config.query, c.globalMetrics)
 	if err != nil {
 		return err
 	}
@@ -190,14 +199,14 @@ func (c *Discovery) logrusFields() logrus.Fields {
 	}
 }
 
-func processBundle(ctx context.Context, manager *plugins.Manager, factories map[string]plugins.Factory, b *bundleApi.Bundle, query string) (*config.Config, *pluginSet, error) {
+func processBundle(ctx context.Context, manager *plugins.Manager, factories map[string]plugins.Factory, b *bundleApi.Bundle, query string, globalMetrics metrics.GlobalMetrics) (*config.Config, *pluginSet, error) {
 
 	config, err := evaluateBundle(ctx, manager.ID, manager.Info, b, query)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	ps, err := getPluginSet(factories, manager, config)
+	ps, err := getPluginSet(factories, manager, config, globalMetrics)
 	return config, ps, err
 }
 
@@ -257,7 +266,7 @@ type pluginfactory struct {
 	config  interface{}
 }
 
-func getPluginSet(factories map[string]plugins.Factory, manager *plugins.Manager, config *config.Config) (*pluginSet, error) {
+func getPluginSet(factories map[string]plugins.Factory, manager *plugins.Manager, config *config.Config, globalMetrics metrics.GlobalMetrics) (*pluginSet, error) {
 
 	// Parse and validate plugin configurations.
 	pluginNames := []string{}
@@ -330,7 +339,7 @@ func getPluginSet(factories map[string]plugins.Factory, manager *plugins.Manager
 	}
 
 	if statusConfig != nil {
-		p, created := getStatusPlugin(manager, statusConfig)
+		p, created := getStatusPlugin(manager, statusConfig, globalMetrics)
 		if created {
 			starts = append(starts, p)
 		} else if p != nil {
@@ -366,12 +375,12 @@ func getDecisionLogsPlugin(m *plugins.Manager, config *logs.Config) (plugin *log
 	return plugin, created
 }
 
-func getStatusPlugin(m *plugins.Manager, config *status.Config) (plugin *status.Plugin, created bool) {
+func getStatusPlugin(m *plugins.Manager, config *status.Config, globalMetrics metrics.GlobalMetrics) (plugin *status.Plugin, created bool) {
 
 	plugin = status.Lookup(m)
 
 	if plugin == nil {
-		plugin = status.New(config, m)
+		plugin = status.New(config, m).WithMetrics(globalMetrics)
 		m.Register(status.Name, plugin)
 		registerBundleStatusUpdates(m)
 		created = true

--- a/plugins/discovery/discovery_test.go
+++ b/plugins/discovery/discovery_test.go
@@ -120,7 +120,7 @@ func TestProcessBundle(t *testing.T) {
 		}
 	`)
 
-	_, ps, err := processBundle(ctx, manager, nil, initialBundle, "data.config")
+	_, ps, err := processBundle(ctx, manager, nil, initialBundle, "data.config", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -139,7 +139,7 @@ func TestProcessBundle(t *testing.T) {
 		}
 	`)
 
-	_, ps, err = processBundle(ctx, manager, nil, updatedBundle, "data.config")
+	_, ps, err = processBundle(ctx, manager, nil, updatedBundle, "data.config", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -156,7 +156,7 @@ func TestProcessBundle(t *testing.T) {
 		}
 	`)
 
-	_, _, err = processBundle(ctx, manager, nil, updatedBundle, "data.config")
+	_, _, err = processBundle(ctx, manager, nil, updatedBundle, "data.config", nil)
 	if err == nil {
 		t.Fatal("Expected error but got success")
 	}
@@ -419,7 +419,7 @@ bundle:
   service: s2
 `
 	manager := getTestManager(t, conf)
-	_, err := getPluginSet(nil, manager, manager.Config)
+	_, err := getPluginSet(nil, manager, manager.Config, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}
@@ -455,7 +455,7 @@ bundles:
     service: s1
 `
 	manager := getTestManager(t, conf)
-	_, err := getPluginSet(nil, manager, manager.Config)
+	_, err := getPluginSet(nil, manager, manager.Config, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}

--- a/server/writer/writer.go
+++ b/server/writer/writer.go
@@ -16,7 +16,7 @@ import (
 
 // HTTPStatus is used to set a specific status code
 // Adapted from https://stackoverflow.com/questions/27711154/what-response-code-to-return-on-a-non-supported-http-method-on-rest
-func HTTPStatus(code int) func(w http.ResponseWriter, req *http.Request) {
+func HTTPStatus(code int) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
 		w.WriteHeader(code)
 	}


### PR DESCRIPTION
Prometheus metrics can give much of insight into OPA's health.
Run-time metrics are a natural part of the application state
so having them in status update seems like a right change
that can help server understand what's going in with the OPA
instance.

The commit also encapsulates all prometheus-related code in one package
and abstracts it with generic interface so that it would be possible
to add other metrics providers

Addresses #1606

Signed-off-by: Stan Lagun <stan@styra.com>
