### PR TITLE
rego: Fix godoc for rego.Rego() API

### DIFF
--- a/rego/rego.go
+++ b/rego/rego.go
@@ -49,9 +49,6 @@ type PartialResult struct {
 }
 
 // Rego returns an object that can be evaluated to produce a query result.
-// If rego.Rego#Prepare was used to create the PartialResult this may lose
-// the pre-parsed/compiled parts of the original Rego object. In those cases
-// using rego.PartialResult#Eval is likely to be more performant.
 func (pr PartialResult) Rego(options ...func(*Rego)) *Rego {
 	options = append(options, Compiler(pr.compiler), Store(pr.store), ParsedQuery(pr.body))
 	return New(options...)


### PR DESCRIPTION
The documentation was updated part way through adding the Prepare
helpers on the Rego object. Later on when PrepareForEval and
PrepareForPartial helpers were added and we stopped re-using
PartialResult this was left behind and is now incorrect.

Fixes: #1619
Signed-off-by: Patrick East <east.patrick@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
