### PR TITLE
travis: Build and push windows and darwin edge binaries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: go
 go_import_path: github.com/open-policy-agent/opa
 go:
 - "1.12.8"
+script: make travis-all
 install:
   # AWS CLI is required for pushing the edge binaries to S3.
   - pip install --user awscli


### PR DESCRIPTION
These changes update the travis build to produce windows/darwin
binaries in addition to the linux binary and push them to the S3
bucket holding the edge binaries. This lets users on windows/darwin
easily obtain the binary for tip of master. It also enables the live
docs build which is coming soon.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>