### PR TITLE
ast: Fix ordering of rule type checking errors

### DIFF
--- a/ast/check.go
+++ b/ast/check.go
@@ -92,6 +92,7 @@ func (tc *typeChecker) CheckTypes(env *TypeEnv, sorted []util.T) (*TypeEnv, Erro
 	for _, s := range sorted {
 		tc.checkRule(env, s.(*Rule))
 	}
+	tc.errs.Sort()
 	return env, tc.errs
 }
 

--- a/ast/errors.go
+++ b/ast/errors.go
@@ -6,6 +6,7 @@ package ast
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 )
 
@@ -29,6 +30,21 @@ func (e Errors) Error() string {
 	}
 
 	return fmt.Sprintf("%d errors occurred:\n%s", len(e), strings.Join(s, "\n"))
+}
+
+// Sort sorts the error slice by location. If the locations are equal then the
+// error message is compared.
+func (e Errors) Sort() {
+	sort.Slice(e, func(i, j int) bool {
+		a := e[i]
+		b := e[j]
+
+		if cmp := a.Location.Compare(b.Location); cmp != 0 {
+			return cmp < 0
+		}
+
+		return a.Error() < b.Error()
+	})
 }
 
 const (


### PR DESCRIPTION
Previously the type checker would not sort errors before returning
them. As a result, the ordering of errors would depend on the order of
rules passed to the type checker (which is non-deterministic due to Go
map iteration order.)

These changes update the type checker to sort errors by location
before before returning them. This way the errors reported by opa test
and opa check and everything else are consistent across runs.

Fixes #1620

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
