### PR TITLE
plugins/bundle: raise error on root conflict

### DIFF
--- a/plugins/bundle/plugin_test.go
+++ b/plugins/bundle/plugin_test.go
@@ -226,6 +226,73 @@ func TestPluginOneShotActivationRemovesOld(t *testing.T) {
 	}
 }
 
+func TestPluginOneShotActivationConflictingRoots(t *testing.T) {
+	ctx := context.Background()
+	manager := getTestManager()
+	plugin := Plugin{manager: manager, status: map[string]*Status{}, etags: map[string]string{}}
+	bundleNames := []string{"test-bundle1", "test-bundle2", "test-bundle3"}
+
+	for _, name := range bundleNames {
+		plugin.status[name] = &Status{Name: name}
+	}
+
+	// Start with non-conflicting updates
+	plugin.oneShot(ctx, bundleNames[0], download.Update{Bundle: &bundle.Bundle{
+		Manifest: bundle.Manifest{
+			Roots: &[]string{"a/b"},
+		},
+	}})
+
+	plugin.oneShot(ctx, bundleNames[1], download.Update{Bundle: &bundle.Bundle{
+		Manifest: bundle.Manifest{
+			Roots: &[]string{"a/c"},
+		},
+	}})
+
+	// ensure that both bundles are *not* in error status
+	ensureBundleStatus(t, &plugin, bundleNames, []bool{false, false, false})
+
+	// Add a third bundle that conflicts with one
+	plugin.oneShot(ctx, bundleNames[2], download.Update{Bundle: &bundle.Bundle{
+		Manifest: bundle.Manifest{
+			Roots: &[]string{"a/b/aa"},
+		},
+	}})
+
+	// ensure that both in the conflict go into error state
+	ensureBundleStatus(t, &plugin, bundleNames, []bool{false, false, true})
+
+	// Update to fix conflict
+	plugin.oneShot(ctx, bundleNames[2], download.Update{Bundle: &bundle.Bundle{
+		Manifest: bundle.Manifest{
+			Roots: &[]string{"b"},
+		},
+	}})
+
+	ensureBundleStatus(t, &plugin, bundleNames, []bool{false, false, false})
+
+	// Ensure empty roots conflict with all roots
+	plugin.oneShot(ctx, bundleNames[2], download.Update{Bundle: &bundle.Bundle{
+		Manifest: bundle.Manifest{
+			Roots: &[]string{""},
+		},
+	}})
+
+	ensureBundleStatus(t, &plugin, bundleNames, []bool{false, false, true})
+}
+
+func ensureBundleStatus(t *testing.T, p *Plugin, bundleNames []string, expectedErrs []bool) {
+	t.Helper()
+	for i, name := range bundleNames {
+		hasErr := p.status[name].Message != ""
+		if expectedErrs[i] && !hasErr {
+			t.Fatalf("expected bundle %s to be in an error state", name)
+		} else if !expectedErrs[i] && hasErr {
+			t.Fatalf("unexpected error state for bundle %s", name)
+		}
+	}
+}
+
 func TestPluginListener(t *testing.T) {
 
 	ctx := context.Background()


### PR DESCRIPTION
This changes to detect bundle root conflicts when "activating" a
bundle. The bundle in question will go into an error state and be
prevented from loading its data or policies.

If multiple bundles are being used, and one didn't define roots or
have a manifest (ie they claim all roots), it will conflict with all
other bundles and raise errors.

**Note: This does NOT affect bundles loaded from CLI with --data**

Fixes: #1635

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
