### PR TITLE
loader: Update to accept file:// URLs.

### DIFF
--- a/cmd/eval.go
+++ b/cmd/eval.go
@@ -107,6 +107,10 @@ To evaluate a query against JSON data:
 
 	$ opa eval --data data.json 'data.names[_] = name'
 
+To evaluate a query against JSON data supplied with a file:// URL:
+
+	$ opa eval --data file:///path/to/file.json 'data'
+
 File Loading
 ------------
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -86,6 +86,10 @@ Data file and directory paths can be prefixed with the desired destination in
 the data document with the following syntax:
 
 	<dotted-path>:<file-path>
+
+File paths can be specified as URLs to resolve ambiguity in paths containing colons:
+
+	$ opa run file:///c:/path/to/data.json
 `,
 		Run: func(cmd *cobra.Command, args []string) {
 


### PR DESCRIPTION
The file loader splits paths on the first colon character and uses the
left-hand side for the prefix to root the document at under data. On
windows this is problematic because of drive lettesr (e.g., C:\X\Y\Z
is interpreted as load file at \X\Y\Z under data.C.

This change updates the loader to accept file:// URLs. This way
callers can unambiguously specify filenames that contain colon
characters. For now this will mainly be used by VS Code and other
programmatic callers. In future we can support other schemes (e.g., http).

Ref #1505

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
