### PR TITLE
bundle: Fix for root overlaps on partial segments

### DIFF
--- a/plugins/bundle/plugin.go
+++ b/plugins/bundle/plugin.go
@@ -542,9 +542,9 @@ func (p *Plugin) hasRootsOverlap(ctx context.Context, txn storage.Transaction, b
 		if err != nil && !storage.IsNotFound(err) {
 			return err
 		}
-		for _, existingRoot := range otherRoots {
+		for i := range otherRoots {
 			for newRoot := range bundleRoots {
-				if strings.HasPrefix(newRoot, existingRoot) || strings.HasPrefix(existingRoot, newRoot) {
+				if bundle.RootPathsOverlap(otherRoots[i], newRoot) {
 					collisions[otherBundle] = append(collisions[otherBundle], newRoot)
 				}
 			}


### PR DESCRIPTION
We would previously detect overlapping roots on partial path segments
for bundle roots defined in manifests.

This changes to make them be full path segments or else they won't
conflict.

Fixes: #1654
Signed-off-by: Patrick East <east.patrick@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
