### PR TITLE
format: Fix formatter to start line after writing comments

### DIFF
--- a/format/format.go
+++ b/format/format.go
@@ -304,6 +304,10 @@ func (w *writer) writeBody(body ast.Body, comments []*ast.Comment) []*ast.Commen
 
 func (w *writer) writeExpr(expr *ast.Expr, comments []*ast.Comment) []*ast.Comment {
 	comments = w.insertComments(comments, expr.Location)
+	if !w.inline {
+		w.startLine()
+	}
+
 	if expr.Negated {
 		w.write("not ")
 	}

--- a/format/testfiles/test_issue_1560.rego
+++ b/format/testfiles/test_issue_1560.rego
@@ -1,0 +1,29 @@
+package x
+
+p {
+    symbol
+
+    # comment
+    some x
+}
+
+p {
+    symbol
+
+    # comment
+    f(x)
+}
+
+p {
+    symbol
+
+    # comment
+    not x
+}
+
+p {
+    symbol
+
+    # comment
+    not f(x)
+}

--- a/format/testfiles/test_issue_1560.rego.formatted
+++ b/format/testfiles/test_issue_1560.rego.formatted
@@ -1,0 +1,29 @@
+package x
+
+p {
+	symbol
+
+	# comment
+	some x
+}
+
+p {
+	symbol
+
+	# comment
+	f(x)
+}
+
+p {
+	symbol
+
+	# comment
+	not x
+}
+
+p {
+	symbol
+
+	# comment
+	not f(x)
+}


### PR DESCRIPTION
The formatter was not starting a new line after writing comments that
preceed an expression. As a result the first part of the expression
written (e.g., "not", function name, "some", etc.) would be written
without any indentation.

Fixes #1560

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
