### PR TITLE
server: Wrap decision log error messages

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -2400,7 +2400,7 @@ func (l decisionLogger) Log(ctx context.Context, txn storage.Transaction, decisi
 
 	if l.logger != nil {
 		if err := l.logger(ctx, info); err != nil {
-			return err
+			return errors.Wrap(err, "decision_logs")
 		}
 	}
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -2780,6 +2780,22 @@ func TestDecisionLogging(t *testing.T) {
 
 }
 
+func TestDecisionLogErrorMessage(t *testing.T) {
+
+	f := newFixture(t)
+
+	f.server.WithDecisionLoggerWithErr(func(context.Context, *Info) error {
+		return fmt.Errorf("xxx")
+	})
+
+	if err := f.v1(http.MethodPost, "/data", "", 500, `{
+		"code": "internal_error",
+		"message": "decision_logs: xxx"
+	}`); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestWatchParams(t *testing.T) {
 	f := newFixture(t)
 	r1 := newMockConn()


### PR DESCRIPTION
Previously the server didn't wrap the error messages which made it
hard to determine the source of internal errors coming back from OPA
when deployed with a custom decision logger.

Fixes #1367

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
