### PR TITLE
docs: Minor live blocks fixes and improvements.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -308,6 +308,7 @@ Some tags can be applied to any block:
 - `merge_down` - Visually merge this code block with the one below it (remove bottom margin).
 - `openable` - Add a button to the block that opens its group in the Rego Playground. This should typically
   only be used on complete module blocks.
+- `line_numbers` - Show line numbers in the block. This should be used sparingly; the code will visually shift when they appear.
 
 Outputs can also be tagged as expecting various errors. If one is tagged as expecting errors that do not occur
 or errors occur that it is not tagged as expecting, the build will fail noisily.

--- a/docs/website/scripts/live-blocks/README.md
+++ b/docs/website/scripts/live-blocks/README.md
@@ -135,10 +135,10 @@ The preprocessor handles all doc versions the same, downloading the correct vers
 (based on the file's path) from either GitHub or S3 (the latter for current edge builds).
 
 The web script always hydrates the blocks but only allows them to be edited if the page's path conforms
-with `EDITABLE_PATH` in `constants.js`. This restricts the live functionality to the current version of the
+with `INTERACTIVE_PATH` in `constants.js`. This restricts the live functionality to the current version of the
 Rego Playground.
 
 ## TODO
 
-The `EDITABLE_PATH` should eventually only allow the current docs but currently it only allows edge.
+The `INTERACTIVE_PATH` should eventually only allow the current docs but currently it only allows edge.
 Once doc updates are backported or there's a new OPA release, this will need to be updated in `src/constants.js`.

--- a/docs/website/scripts/live-blocks/src/constants.js
+++ b/docs/website/scripts/live-blocks/src/constants.js
@@ -62,6 +62,7 @@ export const TAG_TYPES = {
   READ_ONLY: 'read_only',
   MERGE_DOWN: 'merge_down',
   OPENABLE: 'openable',
+  LINE_NUMBERS: 'line_numbers',
   ...EXPECTED_ERROR_TAG_TYPES,
 }
 
@@ -106,8 +107,8 @@ export const JS_BUNDLE_PATH = pkg.browser.replace(/dist/, '/js')
 export const CSS_BUNDLE_BATH = JS_BUNDLE_PATH.replace(/js/g, 'css')
 
 // --- UI ---
-// Only blocks on pages whose paths match this regexp will be editable (for limiting live functionality to the version that the playground supports).
-export const EDITABLE_PATH = /^\/docs\/edge/ // TODO update to /^\/docs\/latest/ once backported and/or there's a new release.
+// Only blocks on pages whose paths match this regexp will be interactive (for limiting live functionality to the version that the playground supports).
+export const INTERACTIVE_PATH = /^\/docs\/edge/ // TODO update to /^\/docs\/latest/ once backported and/or there's a new release.
 
 // The path to initially open a new tab to with when opening a group in the playground
 export const OPENING_IN_PLAYGROUND_PATH = '/live-blocks/opening-in-playground'
@@ -123,6 +124,10 @@ export const BASE_EDITOR_OPTS = {
 export const READ_ONLY_EDITOR_OPTS = {
   readOnly: true,
   cursorBlinkRate: -1 // Hides cursor w/o readOnly = 'nocursor' so that editor can be focused and copy/pasting still works
+}
+
+export const LINE_NUMBERS_EDITOR_OPTS = {
+  lineNumbers: true,
 }
 
 const REGO_MODE = 'rego'

--- a/docs/website/scripts/live-blocks/src/web/style.css
+++ b/docs/website/scripts/live-blocks/src/web/style.css
@@ -115,12 +115,10 @@
   margin: 0 !important;
 }
 
-.live--block-container .cm-variable {
-  color: #003c66; /* Just overriding the default theme for variables (otherwise black), we may want a custom theme later. */
+.live--block-container .CodeMirror-gutter-wrapper {
+  transform: translateX(-1.5em); /* Undo positioning from sizer padding */
 }
 
-/* --- MISC --- */
-
-.content {
-  padding-bottom: 5rem !important; /* Fixes an weird bug that only seems to happen in certain cases (development environment and mobile) on firefox... */
+.live--block-container .cm-variable {
+  color: #003c66; /* Just overriding the default theme for variables (otherwise black), we may want a custom theme later. */
 }


### PR DESCRIPTION
- Allow "open" button for read_only blocks.
- Remove erroneous CSS.
- Added a tag for showing line numbers.
