### PR TITLE
ast, rego: Refactor unsafe built-in handling

### DIFF
--- a/ast/compile.go
+++ b/ast/compile.go
@@ -170,6 +170,13 @@ type QueryCompiler interface {
 	// to Compile will take the QueryContext into account.
 	WithContext(qctx *QueryContext) QueryCompiler
 
+	// WithUnsafeBuiltins sets the built-in functions to treat as unsafe and not
+	// allow inside of queries. By default the query compiler inherits the
+	// compiler's unsafe built-in functions. This function allows callers to
+	// override that set. If an empty (non-nil) map is provided, all built-ins
+	// are allowed.
+	WithUnsafeBuiltins(unsafe map[string]struct{}) QueryCompiler
+
 	// WithStageAfter registers a stage to run during query compilation after
 	// the named stage.
 	WithStageAfter(after string, stage QueryCompilerStageDefinition) QueryCompiler
@@ -1036,11 +1043,12 @@ func (c *Compiler) setGraph() {
 }
 
 type queryCompiler struct {
-	compiler  *Compiler
-	qctx      *QueryContext
-	typeEnv   *TypeEnv
-	rewritten map[Var]Var
-	after     map[string][]QueryCompilerStageDefinition
+	compiler       *Compiler
+	qctx           *QueryContext
+	typeEnv        *TypeEnv
+	rewritten      map[Var]Var
+	after          map[string][]QueryCompilerStageDefinition
+	unsafeBuiltins map[string]struct{}
 }
 
 func newQueryCompiler(compiler *Compiler) QueryCompiler {
@@ -1059,6 +1067,11 @@ func (qc *queryCompiler) WithContext(qctx *QueryContext) QueryCompiler {
 
 func (qc *queryCompiler) WithStageAfter(after string, stage QueryCompilerStageDefinition) QueryCompiler {
 	qc.after[after] = append(qc.after[after], stage)
+	return qc
+}
+
+func (qc *queryCompiler) WithUnsafeBuiltins(unsafe map[string]struct{}) QueryCompiler {
+	qc.unsafeBuiltins = unsafe
 	return qc
 }
 
@@ -1213,7 +1226,13 @@ func (qc *queryCompiler) checkTypes(qctx *QueryContext, body Body) (Body, error)
 }
 
 func (qc *queryCompiler) checkUnsafeBuiltins(qctx *QueryContext, body Body) (Body, error) {
-	errs := checkUnsafeBuiltins(qc.compiler.unsafeBuiltinsMap, body)
+	var unsafe map[string]struct{}
+	if qc.unsafeBuiltins != nil {
+		unsafe = qc.unsafeBuiltins
+	} else {
+		unsafe = qc.compiler.unsafeBuiltinsMap
+	}
+	errs := checkUnsafeBuiltins(unsafe, body)
 	if len(errs) > 0 {
 		return nil, errs
 	}

--- a/ast/compile_test.go
+++ b/ast/compile_test.go
@@ -2861,6 +2861,17 @@ func TestQueryCompilerWithStageAfterWithMetrics(t *testing.T) {
 	}
 }
 
+func TestQueryCompilerWithUnsafeBuiltins(t *testing.T) {
+	c := NewCompiler().WithUnsafeBuiltins(map[string]struct{}{
+		"count": struct{}{},
+	})
+
+	_, err := c.QueryCompiler().WithUnsafeBuiltins(map[string]struct{}{}).Compile(MustParseBody("count([])"))
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func assertCompilerErrorStrings(t *testing.T, compiler *Compiler, expected []string) {
 	result := compilerErrsToStringSlice(compiler.Errors)
 

--- a/rego/rego.go
+++ b/rego/rego.go
@@ -599,20 +599,13 @@ func PrintTrace(w io.Writer, r *Rego) {
 	topdown.PrettyTrace(w, *r.tracebuf)
 }
 
-// UnsafeBuiltins is a helper that sets a set of unsafe builtins on the
-// compiler.
-//
-// If a rule or query is found to refer to an unsafe a built-in function, an
-// error will be returned when the Rego object is executed.
+// UnsafeBuiltins sets the built-in functions to treat as unsafe and not allow.
+// This option is ignored for module compilation if the caller supplies the
+// compiler. This option is always honored for query compilation. Provide an
+// empty (non-nil) map to disable checks on queries.
 func UnsafeBuiltins(unsafeBuiltins map[string]struct{}) func(r *Rego) {
 	return func(r *Rego) {
-		if r.unsafeBuiltins == nil && len(unsafeBuiltins) > 0 {
-			r.unsafeBuiltins = make(map[string]struct{})
-		}
-
-		for name := range unsafeBuiltins {
-			r.unsafeBuiltins[name] = struct{}{}
-		}
+		r.unsafeBuiltins = unsafeBuiltins
 	}
 }
 
@@ -630,7 +623,7 @@ func New(options ...func(r *Rego)) *Rego {
 	}
 
 	if r.compiler == nil {
-		r.compiler = ast.NewCompiler()
+		r.compiler = ast.NewCompiler().WithUnsafeBuiltins(r.unsafeBuiltins)
 	}
 
 	if r.store == nil {
@@ -653,10 +646,6 @@ func New(options ...func(r *Rego)) *Rego {
 
 	if r.partialNamespace == "" {
 		r.partialNamespace = defaultPartialNamespace
-	}
-
-	if r.unsafeBuiltins != nil {
-		r.compiler.WithUnsafeBuiltins(r.unsafeBuiltins)
 	}
 
 	return r
@@ -1174,7 +1163,9 @@ func (r *Rego) compileQuery(query ast.Body, m metrics.Metrics, extras []extraSta
 		WithPackage(pkg).
 		WithImports(imports)
 
-	qc := r.compiler.QueryCompiler().WithContext(qctx)
+	qc := r.compiler.QueryCompiler().
+		WithContext(qctx).
+		WithUnsafeBuiltins(r.unsafeBuiltins)
 
 	for _, extra := range extras {
 		qc = qc.WithStageAfter(extra.after, extra.stage)

--- a/test/e2e/concurrency/concurrency_test.go
+++ b/test/e2e/concurrency/concurrency_test.go
@@ -1,0 +1,63 @@
+package metrics
+
+import (
+	"flag"
+	"os"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/open-policy-agent/opa/test/e2e"
+)
+
+var testRuntime *e2e.TestRuntime
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	testServerParams := e2e.NewAPIServerTestParams()
+
+	var err error
+	testRuntime, err = e2e.NewTestRuntime(testServerParams)
+	if err != nil {
+		os.Exit(1)
+	}
+
+	os.Exit(testRuntime.RunAPIServerTests(m))
+}
+
+func TestConcurrency(t *testing.T) {
+
+	policy := `
+	package test
+	p = true
+	`
+
+	err := testRuntime.UploadPolicy(t.Name(), strings.NewReader(policy))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var wg sync.WaitGroup
+
+	for i := 0; i < runtime.NumCPU(); i++ {
+		wg.Add(1)
+		go func() {
+			for n := 0; n < 1000; n++ {
+				dr := struct {
+					Result bool `json:"result"`
+				}{}
+				if err := testRuntime.GetDataWithInputTyped("test/p", nil, &dr); err != nil {
+					t.Fatal(err)
+				}
+				if !dr.Result {
+					t.Fatalf("Unexpected response: %+v", dr)
+				}
+			}
+			wg.Done()
+		}()
+	}
+
+	wg.Wait()
+
+}


### PR DESCRIPTION
Previously the rego package was modifying the compiler's unsafe
built-in set each time a query was evaluated or prepared. This
resulted in concurrent write panics in the server (since the server
and other callers assume the compiler is immutable and can be shared
across goroutines.)

These changes update how unsafe built-ins are specified. The query
compiler continues to inherit the set from the compiler but there are
two important differences:

1. Callers can provide unsafe built-ins to the query compiler. This
allows callers to override the behaviour of the compiler if they need
to.

2. The rego package does not set unsafe built-ins if the compiler is
provided by the caller. This ensures that the compiler is not modified
concurrently.

With these changes the rego package doesn't union unsafe built-ins
like it used to. Since this feature was only added recently it's
unlikely anyone is relying on it.

Fixes #1666

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
