### PR TITLE
Add support for loading bundles via CLI params

### DIFF
--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -177,10 +177,10 @@ func (r *Reader) Read() (Bundle, error) {
 		if strings.HasSuffix(path, RegoExt) {
 			module, err := ast.ParseModule(path, buf.String())
 			if err != nil {
-				return bundle, errors.Wrap(err, "bundle load failed")
+				return bundle, err
 			}
 			if module == nil {
-				return bundle, errors.Wrap(fmt.Errorf("module '%s' is empty", path), "bundle load failed")
+				return bundle, fmt.Errorf("module '%s' is empty", path)
 			}
 
 			mf := ModuleFile{

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -73,17 +73,21 @@ an HTTP API for managing policies, reading and writing data, and executing
 queries.
 
 The runtime can be initialized with one or more files that contain policies or
-data. OPA supports both JSON and YAML data. If a directory is given, OPA will
-recursively load the files contained in the directory. When loading from
-directories, only files with known extensions are considered. The current set of
-file extensions that OPA will consider are:
+data. If the '--bundle' option is specified the paths will be treated as policy
+bundles and loaded following standard bundle conventions. The path can be a
+compressed archive file or a directory which will be treated as a bundle.
+Without the '--bundle' flag OPA will recursively load ALL rego, JSON, and YAML
+files.
+
+When loading from directories, only files with known extensions are considered.
+The current set of file extensions that OPA will consider are:
 
 	.json          # JSON data
 	.yaml or .yml  # YAML data
 	.rego          # Rego file
 
-Data file and directory paths can be prefixed with the desired destination in
-the data document with the following syntax:
+Non-bundle data file and directory paths can be prefixed with the desired
+destination in the data document with the following syntax:
 
 	<dotted-path>:<file-path>
 
@@ -156,6 +160,7 @@ File paths can be specified as URLs to resolve ambiguity in paths containing col
 	runCommand.Flags().IntVar(&params.GracefulShutdownPeriod, "shutdown-grace-period", 10, "set the time (in seconds) that the server will wait to gracefully shut down")
 	runCommand.Flags().StringArrayVar(&params.ConfigOverrides, "set", []string{}, "override config values on the command line (use commas to specify multiple values)")
 	runCommand.Flags().StringArrayVar(&params.ConfigOverrideFiles, "set-file", []string{}, "override config values with files on the command line (use commas to specify multiple values)")
+	runCommand.Flags().BoolVarP(&params.BundleMode, "bundle", "b", false, "load paths as bundle files or root directories")
 	setIgnore(runCommand.Flags(), &ignore)
 
 	usageTemplate := `Usage:

--- a/internal/file/archive/tarball.go
+++ b/internal/file/archive/tarball.go
@@ -1,0 +1,42 @@
+package archive
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"strings"
+)
+
+// MustWriteTarGz write the list of file names and content
+// into a tarball.
+func MustWriteTarGz(files [][2]string) *bytes.Buffer {
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	defer gw.Close()
+	tw := tar.NewWriter(gw)
+	defer tw.Close()
+	for _, file := range files {
+		if err := WriteFile(tw, file[0], []byte(file[1])); err != nil {
+			panic(err)
+		}
+	}
+	return &buf
+}
+
+// WriteFile adds a file header with content to the given tar writer
+func WriteFile(tw *tar.Writer, path string, bs []byte) error {
+
+	hdr := &tar.Header{
+		Name:     "/" + strings.TrimLeft(path, "/"),
+		Mode:     0600,
+		Typeflag: tar.TypeReg,
+		Size:     int64(len(bs)),
+	}
+
+	if err := tw.WriteHeader(hdr); err != nil {
+		return err
+	}
+
+	_, err := tw.Write(bs)
+	return err
+}

--- a/internal/file/loader.go
+++ b/internal/file/loader.go
@@ -1,0 +1,166 @@
+package file
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/pkg/errors"
+)
+
+// Descriptor contains information about a file and
+// can be used to read the file contents.
+type Descriptor struct {
+	path      string
+	reader    io.Reader
+	closer    io.Closer
+	closeOnce *sync.Once
+}
+
+func newDescriptor(path string, reader io.Reader) *Descriptor {
+	return &Descriptor{
+		path:   path,
+		reader: reader,
+	}
+}
+
+func (d *Descriptor) withCloser(closer io.Closer) *Descriptor {
+	d.closer = closer
+	d.closeOnce = new(sync.Once)
+	return d
+}
+
+// Path returns the path of the file.
+func (d *Descriptor) Path() string {
+	return d.path
+}
+
+// Read will read all the contents from the file the Descriptor refers to
+// into the dest writer up n bytes. Will return an io.EOF error
+// if EOF is encountered before n bytes are read.
+func (d *Descriptor) Read(dest io.Writer, n int64) (int64, error) {
+	n, err := io.CopyN(dest, d.reader, n)
+	return n, err
+}
+
+// Close the file, on some Loader implementations this might be a no-op.
+// It should *always* be called regardless of file.
+func (d *Descriptor) Close() error {
+	var err error
+	if d.closer != nil {
+		d.closeOnce.Do(func() {
+			err = d.closer.Close()
+		})
+	}
+	return err
+}
+
+// DirectoryLoader defines an interface which can be used to load
+// files from a directory by iterating over each one in the tree.
+type DirectoryLoader interface {
+	// NextFile must return io.EOF if there is no next value. The returned
+	// descriptor should *always* be closed when no longer needed.
+	NextFile() (*Descriptor, error)
+}
+
+type dirLoader struct {
+	root  string
+	files []string
+	idx   int
+}
+
+// NewDirectoryLoader returns a basic DirectoryLoader implementation
+// that will load files from a given root directory path.
+func NewDirectoryLoader(root string) DirectoryLoader {
+	d := dirLoader{
+		root: root,
+	}
+	return &d
+}
+
+// NextFile iterates to the next file in the directory tree
+// and returns a file Descriptor for the file.
+func (d *dirLoader) NextFile() (*Descriptor, error) {
+	// build a list of all files we will iterate over and read, but only one time
+	if d.files == nil {
+		d.files = []string{}
+		err := filepath.Walk(d.root, func(path string, info os.FileInfo, err error) error {
+			if info != nil && info.Mode().IsRegular() {
+				d.files = append(d.files, path)
+			}
+			return nil
+		})
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to list files")
+		}
+	}
+
+	// If done reading files then just return io.EOF
+	// errors for each NextFile() call
+	if d.idx >= len(d.files) {
+		return nil, io.EOF
+	}
+
+	fileName := d.files[d.idx]
+	d.idx++
+	fh, err := os.Open(fileName)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to open file %s", fileName)
+	}
+
+	// Trim off the root directory and return path as if chrooted
+	cleanedPath := strings.TrimPrefix(fileName, d.root)
+	if !strings.HasPrefix(cleanedPath, "/") {
+		cleanedPath = "/" + cleanedPath
+	}
+
+	f := newDescriptor(cleanedPath, fh).withCloser(fh)
+	return f, nil
+}
+
+type tarballLoader struct {
+	r  io.Reader
+	tr *tar.Reader
+}
+
+// NewTarballLoader returns a new DirectoryLoader that reads
+// files out of a gzipped tar archive.
+func NewTarballLoader(r io.Reader) DirectoryLoader {
+	l := tarballLoader{
+		r: r,
+	}
+	return &l
+}
+
+// NextFile iterates to the next file in the directory tree
+// and returns a file Descriptor for the file.
+func (t *tarballLoader) NextFile() (*Descriptor, error) {
+	if t.tr == nil {
+		gr, err := gzip.NewReader(t.r)
+		if err != nil {
+			return nil, errors.Wrap(err, "archive read failed")
+		}
+
+		t.tr = tar.NewReader(gr)
+	}
+
+	for {
+		header, err := t.tr.Next()
+		// Eventually we will get an io.EOF error when finished
+		// iterating through the archive
+		if err != nil {
+			return nil, err
+		}
+
+		// Keep iterating on the archive until we find a normal file
+		if header.Typeflag == tar.TypeReg {
+			// no need to close this descriptor after reading
+			f := newDescriptor(header.Name, t.tr)
+			return f, nil
+		}
+	}
+}

--- a/internal/file/loader_test.go
+++ b/internal/file/loader_test.go
@@ -1,0 +1,108 @@
+package file
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/open-policy-agent/opa/internal/file/archive"
+
+	"github.com/open-policy-agent/opa/util/test"
+)
+
+const testReadLimit = (1024 * 1024) + 1
+
+var archiveFiles = map[string]string{
+	"/a.json":                          "a",
+	"/a/b.json":                        "b",
+	"/a/b/c.json":                      "c",
+	"/some.txt":                        "text",
+	"/policy.rego":                     "package foo\n p = 1",
+	"/deeper/dir/path/than/others/foo": "bar",
+}
+
+func TestTarballLoader(t *testing.T) {
+
+	files := map[string]string{
+		"/archive.tar.gz": "",
+	}
+
+	test.WithTempFS(files, func(rootDir string) {
+		tarballFile := filepath.Join(rootDir, "archive.tar.gz")
+		f, err := os.Create(tarballFile)
+		if err != nil {
+			t.Fatalf("Unexpected error: %s", err)
+		}
+
+		var gzFiles [][2]string
+		for name, content := range archiveFiles {
+			gzFiles = append(gzFiles, [2]string{name, content})
+		}
+
+		_, err = f.Write(archive.MustWriteTarGz(gzFiles).Bytes())
+		if err != nil {
+			t.Fatalf("Unexpected error: %s", err)
+		}
+		f.Close()
+
+		f, err = os.Open(tarballFile)
+		if err != nil {
+			t.Fatalf("Unexpected error: %s", err)
+		}
+
+		loader := NewTarballLoader(f)
+		defer f.Close()
+
+		testLoader(t, loader, archiveFiles)
+
+	})
+
+}
+
+func TestDirectoryLoader(t *testing.T) {
+	test.WithTempFS(archiveFiles, func(rootDir string) {
+		loader := NewDirectoryLoader(rootDir)
+
+		testLoader(t, loader, archiveFiles)
+	})
+}
+
+func testLoader(t *testing.T, loader DirectoryLoader, expectedFiles map[string]string) {
+	t.Helper()
+
+	fileCount := 0
+	for {
+		f, err := loader.NextFile()
+		if err != nil && err != io.EOF {
+			t.Fatalf("Unexpected error: %s", err)
+		} else if err == io.EOF {
+			break
+		}
+
+		var buf bytes.Buffer
+		n, err := f.Read(&buf, testReadLimit)
+		f.Close() // always close, even on error
+		if err != nil && err != io.EOF {
+			t.Fatalf("Unexpected error: %s", err)
+		} else if err == nil && n >= testReadLimit {
+			t.Fatalf("Attempted to read too much data")
+		}
+
+		expectedContent, found := expectedFiles[f.Path()]
+		if !found {
+			t.Fatalf("Found unexpected file %s", f.Path())
+		}
+		if expectedContent != buf.String() {
+			t.Fatalf("Content mismatch for file %s\n\nExpected:\n%s\n\nActual:\n%s\n\n",
+				f.Path(), expectedContent, buf.String())
+		}
+
+		fileCount++
+	}
+
+	if fileCount != len(expectedFiles) {
+		t.Fatalf("Expected to read %d files, read %d", len(expectedFiles), fileCount)
+	}
+}

--- a/internal/storage/mock/mock.go
+++ b/internal/storage/mock/mock.go
@@ -8,10 +8,11 @@ package mock
 import (
 	"context"
 	"fmt"
+	"testing"
+
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/storage"
 	"github.com/open-policy-agent/opa/storage/inmem"
-	"testing"
 )
 
 // Transaction is a mock storage.Transaction implementation for use in testing.
@@ -147,32 +148,32 @@ func (s *Store) AssertValid(t *testing.T) {
 
 // Register just shims the call to the underlying inmem store
 func (s *Store) Register(ctx context.Context, txn storage.Transaction, config storage.TriggerConfig) (storage.TriggerHandle, error) {
-	return s.inmem.Register(ctx, txn, config)
+	return s.inmem.Register(ctx, getRealTxn(txn), config)
 }
 
 // ListPolicies just shims the call to the underlying inmem store
 func (s *Store) ListPolicies(ctx context.Context, txn storage.Transaction) ([]string, error) {
-	return s.ListPolicies(ctx, txn)
+	return s.inmem.ListPolicies(ctx, getRealTxn(txn))
 }
 
 // GetPolicy just shims the call to the underlying inmem store
 func (s *Store) GetPolicy(ctx context.Context, txn storage.Transaction, name string) ([]byte, error) {
-	return s.inmem.GetPolicy(ctx, txn, name)
+	return s.inmem.GetPolicy(ctx, getRealTxn(txn), name)
 }
 
 // UpsertPolicy just shims the call to the underlying inmem store
 func (s *Store) UpsertPolicy(ctx context.Context, txn storage.Transaction, name string, policy []byte) error {
-	return s.inmem.UpsertPolicy(ctx, txn, name, policy)
+	return s.inmem.UpsertPolicy(ctx, getRealTxn(txn), name, policy)
 }
 
 // DeletePolicy just shims the call to the underlying inmem store
 func (s *Store) DeletePolicy(ctx context.Context, txn storage.Transaction, name string) error {
-	return s.inmem.DeletePolicy(ctx, txn, name)
+	return s.inmem.DeletePolicy(ctx, getRealTxn(txn), name)
 }
 
 // Build just shims the call to the underlying inmem store
 func (s *Store) Build(ctx context.Context, txn storage.Transaction, ref ast.Ref) (storage.Index, error) {
-	return s.inmem.Build(ctx, txn, ref)
+	return s.inmem.Build(ctx, getRealTxn(txn), ref)
 }
 
 // NewTransaction will create a new transaction on the underlying inmem store
@@ -251,4 +252,9 @@ func (s *Store) Abort(ctx context.Context, txn storage.Transaction) {
 	s.inmem.Abort(ctx, mockTxn.txn)
 	mockTxn.Aborted++
 	return
+}
+
+func getRealTxn(txn storage.Transaction) storage.Transaction {
+	return txn.(*Transaction).txn
+
 }

--- a/internal/storage/mock/mock.go
+++ b/internal/storage/mock/mock.go
@@ -45,6 +45,7 @@ func (t *Transaction) safeToUse() bool {
 // Store is a mock storage.Store implementation for use in testing.
 type Store struct {
 	inmem        storage.Store
+	baseData     map[string]interface{}
 	Transactions []*Transaction
 	Reads        []*ReadCall
 	Writes       []*WriteCall
@@ -74,12 +75,25 @@ func New() *Store {
 	return s
 }
 
+// NewWithData creates a store with some initial data
+func NewWithData(data map[string]interface{}) *Store {
+	s := &Store{
+		baseData: data,
+	}
+	s.Reset()
+	return s
+}
+
 // Reset the store
 func (s *Store) Reset() {
 	s.Transactions = []*Transaction{}
 	s.Reads = []*ReadCall{}
 	s.Writes = []*WriteCall{}
-	s.inmem = inmem.New()
+	if s.baseData != nil {
+		s.inmem = inmem.NewFromObject(s.baseData)
+	} else {
+		s.inmem = inmem.New()
+	}
 }
 
 // GetTransaction will a transaction with a specific ID

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -27,6 +27,8 @@ const (
 	RegoModuleCompile = "rego_module_compile"
 	RegoPartialEval   = "rego_partial_eval"
 	RegoInputParse    = "rego_input_parse"
+	RegoLoadFiles     = "rego_load_files"
+	RegoLoadBundles   = "rego_load_bundles"
 )
 
 // Info contains attributes describing the underlying metrics provider.

--- a/rego/rego.go
+++ b/rego/rego.go
@@ -167,6 +167,22 @@ func EvalParsedUnknowns(unknowns []*ast.Term) EvalOption {
 	}
 }
 
+func (pq preparedQuery) Modules() map[string]*ast.Module {
+	mods := make(map[string]*ast.Module)
+
+	for name, mod := range pq.r.parsedModules {
+		mods[name] = mod
+	}
+
+	for _, b := range pq.r.bundles {
+		for _, mf := range b.Modules {
+			mods[mf.Path] = mf.Parsed
+		}
+	}
+
+	return mods
+}
+
 // newEvalContext creates a new EvalContext overlaying any EvalOptions over top
 // the Rego object on the preparedQuery. The returned function should be called
 // once the evaluation is complete to close any transactions that might have

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -18,6 +18,8 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/open-policy-agent/opa/bundle"
+
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/internal/prometheus"
 	"github.com/open-policy-agent/opa/internal/runtime"
@@ -95,6 +97,10 @@ type Params struct {
 	// Optional filter that will be passed to the file loader.
 	Filter loader.Filter
 
+	// BundleMode will enable treating the Paths provided as bundles rather than
+	// loading all data & policy files.
+	BundleMode bool
+
 	// Watch flag controls whether OPA will watch the Paths files for changes.
 	// If this flag is true, OPA will watch the Paths files for changes and
 	// reload the storage layer each time they change. This is useful for
@@ -149,7 +155,8 @@ type LoggingConfig struct {
 // NewParams returns a new Params object.
 func NewParams() Params {
 	return Params{
-		Output: os.Stdout,
+		Output:     os.Stdout,
+		BundleMode: false,
 	}
 }
 
@@ -178,9 +185,9 @@ func NewRuntime(ctx context.Context, params Params) (*Runtime, error) {
 		}
 	}
 
-	loaded, err := loader.Filtered(params.Paths, params.Filter)
+	loaded, err := loadPaths(params.Paths, params.Filter, params.BundleMode)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "load error")
 	}
 
 	store := inmem.New()
@@ -190,28 +197,31 @@ func NewRuntime(ctx context.Context, params Params) (*Runtime, error) {
 		return nil, err
 	}
 
-	if err := store.Write(ctx, txn, storage.AddOp, storage.Path{}, loaded.Documents); err != nil {
-		store.Abort(ctx, txn)
-		return nil, errors.Wrapf(err, "storage error")
+	if len(loaded.Documents) > 0 {
+		if err := store.Write(ctx, txn, storage.AddOp, storage.Path{}, loaded.Documents); err != nil {
+			return nil, errors.Wrap(err, "storage error")
+		}
 	}
 
+	if err := compileAndStoreInputs(ctx, store, txn, loaded, params.ErrorLimit); err != nil {
+		store.Abort(ctx, txn)
+		return nil, errors.Wrap(err, "compile error")
+	}
+
+	// Write the version *after* any data loaded from files or bundles to
+	// avoid it being deleted.
 	if err := storedversion.Write(ctx, store, txn); err != nil {
 		store.Abort(ctx, txn)
-		return nil, errors.Wrapf(err, "storage error")
-	}
-
-	if err := compileAndStoreInputs(ctx, store, txn, loaded.Modules, params.ErrorLimit); err != nil {
-		store.Abort(ctx, txn)
-		return nil, errors.Wrapf(err, "compile error")
+		return nil, errors.Wrap(err, "storage error")
 	}
 
 	if err := store.Commit(ctx, txn); err != nil {
-		return nil, errors.Wrapf(err, "storage error")
+		return nil, errors.Wrap(err, "storage error")
 	}
 
 	bs, err := loadConfig(params)
 	if err != nil {
-		return nil, errors.Wrapf(err, "config error")
+		return nil, errors.Wrap(err, "config error")
 	}
 
 	info, err := runtime.Term(runtime.Params{Config: bs})
@@ -221,14 +231,14 @@ func NewRuntime(ctx context.Context, params Params) (*Runtime, error) {
 
 	manager, err := plugins.New(bs, params.ID, store, plugins.Info(info))
 	if err != nil {
-		return nil, errors.Wrapf(err, "config error")
+		return nil, errors.Wrap(err, "config error")
 	}
 
 	metrics := prometheus.New(metrics.New(), errorLogger)
 
 	disco, err := discovery.New(manager, discovery.Factories(registeredPlugins), discovery.Metrics(metrics))
 	if err != nil {
-		return nil, errors.Wrapf(err, "config error")
+		return nil, errors.Wrap(err, "config error")
 	}
 
 	manager.Register("discovery", disco)
@@ -418,7 +428,7 @@ func (rt *Runtime) readWatcher(ctx context.Context, watcher *fsnotify.Watcher, p
 
 func (rt *Runtime) processWatcherUpdate(ctx context.Context, paths []string, removed string) error {
 
-	loaded, err := loader.Filtered(paths, rt.Params.Filter)
+	loaded, err := loadPaths(paths, rt.Params.Filter, rt.Params.BundleMode)
 	if err != nil {
 		return err
 	}
@@ -426,33 +436,36 @@ func (rt *Runtime) processWatcherUpdate(ctx context.Context, paths []string, rem
 	removed = loader.CleanPath(removed)
 
 	return storage.Txn(ctx, rt.Store, storage.WriteParams, func(txn storage.Transaction) error {
-		if err := rt.Store.Write(ctx, txn, storage.AddOp, storage.Path{}, loaded.Documents); err != nil {
-			return err
+		if len(loaded.Documents) > 0 {
+			if err := rt.Store.Write(ctx, txn, storage.AddOp, storage.Path{}, loaded.Documents); err != nil {
+				return err
+			}
 		}
-		ids, err := rt.Store.ListPolicies(ctx, txn)
-		if err != nil {
-			return err
-		}
-		for _, id := range ids {
-			if id == removed {
-				if err := rt.Store.DeletePolicy(ctx, txn, id); err != nil {
-					return err
-				}
-			} else if _, exists := loaded.Modules[id]; !exists {
-				// This branch get hit in two cases.
-				// 1. Another piece of code has access to the store and inserts
-				//    a policy out-of-band.
-				// 2. In between FS notification and loader.Filtered() call above, a
-				//    policy is removed from disk.
-				bs, err := rt.Store.GetPolicy(ctx, txn, id)
-				if err != nil {
-					return err
-				}
-				module, err := ast.ParseModule(id, string(bs))
-				if err != nil {
-					return err
-				}
-				if _, ok := loaded.Modules[id]; !ok {
+
+		if !rt.Params.BundleMode {
+			ids, err := rt.Store.ListPolicies(ctx, txn)
+			if err != nil {
+				return err
+			}
+			for _, id := range ids {
+				if id == removed {
+					if err := rt.Store.DeletePolicy(ctx, txn, id); err != nil {
+						return err
+					}
+				} else if _, exists := loaded.Modules[id]; !exists {
+					// This branch get hit in two cases.
+					// 1. Another piece of code has access to the store and inserts
+					//    a policy out-of-band.
+					// 2. In between FS notification and loader.Filtered() call above, a
+					//    policy is removed from disk.
+					bs, err := rt.Store.GetPolicy(ctx, txn, id)
+					if err != nil {
+						return err
+					}
+					module, err := ast.ParseModule(id, string(bs))
+					if err != nil {
+						return err
+					}
 					loaded.Modules[id] = &loader.RegoFile{
 						Name:   id,
 						Raw:    bs,
@@ -461,7 +474,11 @@ func (rt *Runtime) processWatcherUpdate(ctx context.Context, paths []string, rem
 				}
 			}
 		}
-		return compileAndStoreInputs(ctx, rt.Store, txn, loaded.Modules, -1)
+		if err := compileAndStoreInputs(ctx, rt.Store, txn, loaded, -1); err != nil {
+			return err
+		}
+
+		return nil
 	})
 }
 
@@ -486,21 +503,63 @@ func (rt *Runtime) gracefulServerShutdown(s *server.Server) error {
 	return nil
 }
 
-func compileAndStoreInputs(ctx context.Context, store storage.Store, txn storage.Transaction, modules map[string]*loader.RegoFile, errorLimit int) error {
+type loadResult struct {
+	loader.Result
+	Bundles map[string]*bundle.Bundle
+}
 
-	policies := make(map[string]*ast.Module, len(modules))
+func loadPaths(paths []string, filter loader.Filter, asBundle bool) (*loadResult, error) {
+	result := &loadResult{}
+	var err error
 
-	for id, parsed := range modules {
+	if asBundle {
+		result.Bundles = make(map[string]*bundle.Bundle, len(paths))
+		for _, path := range paths {
+			result.Bundles[path], err = loader.AsBundle(path)
+			if err != nil {
+				return nil, err
+			}
+		}
+	} else {
+		loaded, err := loader.Filtered(paths, filter)
+		if err != nil {
+			return nil, err
+		}
+		result.Modules = loaded.Modules
+		result.Documents = loaded.Documents
+	}
+
+	return result, nil
+}
+
+func compileAndStoreInputs(ctx context.Context, store storage.Store, txn storage.Transaction, loaded *loadResult, errorLimit int) error {
+
+	policies := make(map[string]*ast.Module, len(loaded.Modules))
+
+	for id, parsed := range loaded.Modules {
 		policies[id] = parsed.Parsed
 	}
 
 	c := ast.NewCompiler().SetErrorLimit(errorLimit).WithPathConflictsCheck(storage.NonEmpty(ctx, store, txn))
 
-	if c.Compile(policies); c.Failed() {
-		return c.Errors
+	opts := &bundle.ActivateOpts{
+		Ctx:          ctx,
+		Store:        store,
+		Txn:          txn,
+		Compiler:     c,
+		Metrics:      metrics.New(),
+		Bundles:      loaded.Bundles,
+		ExtraModules: policies,
 	}
 
-	for id, parsed := range modules {
+	err := bundle.Activate(opts)
+	if err != nil {
+		return err
+	}
+
+	// Policies in bundles will have already been added to the store, but
+	// modules loaded outside of bundles will need to be added manually.
+	for id, parsed := range loaded.Modules {
 		if err := store.UpsertPolicy(ctx, txn, id, parsed.Raw); err != nil {
 			return err
 		}

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -478,6 +478,11 @@ func (rt *Runtime) processWatcherUpdate(ctx context.Context, paths []string, rem
 			return err
 		}
 
+		// re-add the version as it might have been overwritten from loading data files
+		if err := storedversion.Write(ctx, rt.Store, txn); err != nil {
+			return err
+		}
+
 		return nil
 	})
 }

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -215,6 +215,13 @@ func testRuntimeProcessWatchEvents(t *testing.T, asBundle bool) {
 			t.Fatal(err)
 		}
 
+		txn := storage.NewTransactionOrDie(ctx, rt.Store)
+		_, err = rt.Store.Read(ctx, txn, storage.MustParsePath("/system/version"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		rt.Store.Abort(ctx, txn)
+
 		var buf bytes.Buffer
 
 		if err := rt.startWatcher(ctx, params.Paths, onReloadPrinter(&buf)); err != nil {
@@ -244,6 +251,13 @@ func testRuntimeProcessWatchEvents(t *testing.T, asBundle bool) {
 			if err != nil {
 				panic(err)
 			}
+
+			// Ensure the update didn't overwrite the system version information
+			_, err = rt.Store.Read(ctx, txn, storage.MustParsePath("/system/version"))
+			if err != nil {
+				t.Fatal(err)
+			}
+
 			rt.Store.Abort(ctx, txn)
 			if reflect.DeepEqual(val, expected) {
 				return // success

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -26,42 +26,96 @@ import (
 )
 
 func TestInit(t *testing.T) {
-	ctx := context.Background()
 
-	tmp1, err := ioutil.TempFile("", "docFile")
-	if err != nil {
-		panic(err)
-	}
-	defer os.Remove(tmp1.Name())
-
-	doc1 := `{"foo": "bar", "x": {"y": {"z": [1]}}}`
-	if _, err := tmp1.Write([]byte(doc1)); err != nil {
-		panic(err)
-	}
-	if err := tmp1.Close(); err != nil {
-		panic(err)
-	}
-
-	tmp2, err := ioutil.TempFile("", "policyFile")
-	if err != nil {
-		panic(err)
-	}
-	defer os.Remove(tmp2.Name())
 	mod1 := `package a.b.c
 
-import data.foo
+import data.a.foo
 
 p = true { foo = "bar" }
 p = true { 1 = 2 }`
-	if _, err := tmp2.Write([]byte(mod1)); err != nil {
-		panic(err)
-	}
-	if err := tmp2.Close(); err != nil {
-		panic(err)
+
+	mod2 := `package b.c.d
+
+import data.b.foo
+
+p = true { foo = "bar" }
+p = true { 1 = 2 }`
+
+	tests := []struct {
+		note         string
+		fs           map[string]string
+		loadParams   []string
+		expectedData map[string]string
+		expectedMods []string
+		asBundle     bool
+	}{
+		{
+			note: "load files",
+			fs: map[string]string{
+				"datafile":   `{"foo": "bar", "x": {"y": {"z": [1]}}}`,
+				"policyFile": mod1,
+			},
+			loadParams: []string{"datafile", "policyFile"},
+			expectedData: map[string]string{
+				"/foo": "bar",
+			},
+			expectedMods: []string{mod1},
+			asBundle:     false,
+		},
+		{
+			note: "load bundle",
+			fs: map[string]string{
+				"datafile":    `{"foo": "bar", "x": {"y": {"z": [1]}}}`, // Should be ignored
+				"data.json":   `{"foo": "not-bar"}`,
+				"policy.rego": mod1,
+			},
+			loadParams: []string{"/"},
+			expectedData: map[string]string{
+				"/foo": "not-bar",
+			},
+			expectedMods: []string{mod1},
+			asBundle:     true,
+		},
+		{
+			note: "load multiple bundles",
+			fs: map[string]string{
+				"/bundle1/a/data.json":   `{"foo": "bar1", "x": {"y": {"z": [1]}}}`, // Should be ignored
+				"/bundle1/a/policy.rego": mod1,
+				"/bundle1/a/.manifest":   `{"roots": ["a"]}`,
+				"/bundle2/b/data.json":   `{"foo": "bar2"}`,
+				"/bundle2/b/policy.rego": mod2,
+				"/bundle2/b/.manifest":   `{"roots": ["b"]}`,
+			},
+			loadParams: []string{"bundle1", "bundle2"},
+			expectedData: map[string]string{
+				"/a/foo": "bar1",
+				"/b/foo": "bar2",
+			},
+			expectedMods: []string{mod1, mod2},
+			asBundle:     true,
+		},
 	}
 
-	params := NewParams()
-	params.Paths = []string{tmp1.Name(), tmp2.Name()}
+	for _, tc := range tests {
+		t.Run(tc.note, func(t *testing.T) {
+			test.WithTempFS(tc.fs, func(rootDir string) {
+				params := NewParams()
+				for _, fileName := range tc.loadParams {
+					params.Paths = append(params.Paths, filepath.Join(rootDir, fileName))
+				}
+
+				params.BundleMode = tc.asBundle
+
+				testInitRuntime(t, params, tc.expectedData, tc.expectedMods)
+			})
+		})
+	}
+}
+
+func testInitRuntime(t *testing.T, params Params, expectedStoreData map[string]string, expectedMods []string) {
+	t.Helper()
+
+	ctx := context.Background()
 
 	rt, err := NewRuntime(ctx, params)
 	if err != nil {
@@ -70,10 +124,12 @@ p = true { 1 = 2 }`
 
 	txn := storage.NewTransactionOrDie(ctx, rt.Store)
 
-	node, err := rt.Store.Read(ctx, txn, storage.MustParsePath("/foo"))
-	if util.Compare(node, "bar") != 0 || err != nil {
-		t.Errorf("Expected %v but got %v (err: %v)", "bar", node, err)
-		return
+	for storePath, expected := range expectedStoreData {
+		node, err := rt.Store.Read(ctx, txn, storage.MustParsePath(storePath))
+		if util.Compare(node, expected) != 0 || err != nil {
+			t.Errorf("Expected %v but got %v (err: %v)", expected, node, err)
+			return
+		}
 	}
 
 	ids, err := rt.Store.ListPolicies(ctx, txn)
@@ -81,9 +137,23 @@ p = true { 1 = 2 }`
 		t.Fatal(err)
 	}
 
-	result, err := rt.Store.GetPolicy(ctx, txn, ids[0])
-	if err != nil || string(result) != mod1 {
-		t.Fatalf("Expected %v but got: %v (err: %v)", mod1, result, err)
+	if len(expectedMods) != len(ids) {
+		t.Fatalf("Expected %d modules, got %d", len(expectedMods), len(ids))
+	}
+
+	actualMods := map[string]struct{}{}
+	for _, id := range ids {
+		result, err := rt.Store.GetPolicy(ctx, txn, id)
+		if err != nil {
+			t.Fatalf("Unexpected error: %s", err)
+		}
+		actualMods[string(result)] = struct{}{}
+	}
+
+	for _, expectedMod := range expectedMods {
+		if _, found := actualMods[expectedMod]; !found {
+			t.Fatalf("Expected %v but got: %v", expectedMod, actualMods)
+		}
 	}
 
 	_, err = rt.Store.Read(ctx, txn, storage.MustParsePath("/system/version"))
@@ -118,6 +188,15 @@ func TestWatchPaths(t *testing.T) {
 }
 
 func TestRuntimeProcessWatchEvents(t *testing.T) {
+	testRuntimeProcessWatchEvents(t, false)
+}
+
+func TestRuntimeProcessWatchEventsWithBundle(t *testing.T) {
+	testRuntimeProcessWatchEvents(t, true)
+}
+
+func testRuntimeProcessWatchEvents(t *testing.T, asBundle bool) {
+	t.Helper()
 
 	ctx := context.Background()
 	fs := map[string]string{
@@ -129,6 +208,8 @@ func TestRuntimeProcessWatchEvents(t *testing.T) {
 	test.WithTempFS(fs, func(rootDir string) {
 		params := NewParams()
 		params.Paths = []string{rootDir}
+		params.BundleMode = asBundle
+
 		rt, err := NewRuntime(ctx, params)
 		if err != nil {
 			t.Fatal(err)
@@ -174,7 +255,14 @@ func TestRuntimeProcessWatchEvents(t *testing.T) {
 }
 
 func TestRuntimeProcessWatchEventPolicyError(t *testing.T) {
+	testRuntimeProcessWatchEventPolicyError(t, false)
+}
 
+func TestRuntimeProcessWatchEventPolicyErrorWithBundle(t *testing.T) {
+	testRuntimeProcessWatchEventPolicyError(t, true)
+}
+
+func testRuntimeProcessWatchEventPolicyError(t *testing.T, asBundle bool) {
 	ctx := context.Background()
 
 	fs := map[string]string{
@@ -187,6 +275,8 @@ func TestRuntimeProcessWatchEventPolicyError(t *testing.T) {
 	test.WithTempFS(fs, func(rootDir string) {
 		params := NewParams()
 		params.Paths = []string{rootDir}
+		params.BundleMode = asBundle
+
 		rt, err := NewRuntime(ctx, params)
 		if err != nil {
 			t.Fatal(err)

--- a/util/test/tempfs.go
+++ b/util/test/tempfs.go
@@ -13,7 +13,7 @@ import (
 // WithTempFS creates a temporary directory structure and invokes f with the
 // root directory path.
 func WithTempFS(files map[string]string, f func(string)) {
-	rootDir, cleanup, err := MakeTempFS("", "loader_test", files)
+	rootDir, cleanup, err := MakeTempFS("", "opa_test", files)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
This adds a `-b`/`--bundle` CLI param to opa eval, build, and test. To support this there are a bunch of underlying changes in the loader and bundle packages. Check out the individual commits for some more details. At a high level it changes:

* Support for multiple bundles being activated at the same time.
* Adds abstraction for loading files from a directory tree (archived or on the filesystem)
* Adds APIs to the Rego object to provide a path to either directory or file and load it as a bundle or via the file loader with a filter.
* Change some transaction lifecycle stuff in the Rego object to support writes/commits when loading files.
* Adds thee CLI parameters that use the new Rego params.