### PR TITLE
topdown: Remove a defer in query iteration, Resolve and namespace plu…

### DIFF
--- a/topdown/bindings.go
+++ b/topdown/bindings.go
@@ -96,8 +96,11 @@ func (u *bindings) Plug(a *ast.Term) *ast.Term {
 func (u *bindings) PlugNamespaced(a *ast.Term, caller *bindings) *ast.Term {
 	if u != nil {
 		u.instr.startTimer(evalOpPlug)
-		defer u.instr.stopTimer(evalOpPlug)
+		t := u.plugNamespaced(a, caller)
+		u.instr.stopTimer(evalOpPlug)
+		return t
 	}
+
 	return u.plugNamespaced(a, caller)
 }
 

--- a/topdown/query.go
+++ b/topdown/query.go
@@ -250,8 +250,7 @@ func (q *Query) Iter(ctx context.Context, iter func(QueryResult) error) error {
 		runtime:      q.runtime,
 	}
 	q.startTimer(metrics.RegoQueryEval)
-	defer q.stopTimer(metrics.RegoQueryEval)
-	return e.Run(func(e *eval) error {
+	err := e.Run(func(e *eval) error {
 		qr := QueryResult{}
 		e.bindings.Iter(nil, func(k, v *ast.Term) error {
 			qr[k.Value.(ast.Var)] = v
@@ -259,6 +258,8 @@ func (q *Query) Iter(ctx context.Context, iter func(QueryResult) error) error {
 		})
 		return iter(qr)
 	})
+	q.stopTimer(metrics.RegoQueryEval)
+	return err
 }
 
 func (q *Query) startTimer(name string) {


### PR DESCRIPTION
…gging.

benchmark                                        old ns/op      new ns/op      delta
BenchmarkAuthzForbidAuthn-8                      30951          29843          -3.58%
BenchmarkAuthzForbidPath-8                       96070          92109          -4.12%
BenchmarkAuthzForbidMethod-8                     102412         98219          -4.09%
BenchmarkAuthzAllow10Paths-8                     99315          95928          -3.41%
BenchmarkAuthzAllow100Paths-8                    620837         573777         -7.58%
BenchmarkAuthzAllow1000Paths-8                   5423305        5122304        -5.55%
BenchmarkRESTAuthzForbidAuthn-8                  472427         471722         -0.15%
BenchmarkRESTAuthzForbidPath-8                   546472         541098         -0.98%
BenchmarkRESTAuthzForbidMethod-8                 551292         546369         -0.89%
BenchmarkRESTAuthzAllow10Paths-8                 546016         543006         -0.55%
BenchmarkRESTAuthzAllow100Paths-8                1106900        1074213        -2.95%
BenchmarkRESTAuthzAllow1000Paths-8               6201083        5792436        -6.59%
BenchmarkScheduler10x30-8                        12109234       11521351       -4.85%
BenchmarkVirtualCache-8                          319            317            -0.63%
BenchmarkLargeJSON-8                             64250175       63661170       -0.92%
BenchmarkConcurrency1-8                          225302348      222786134      -1.12%
BenchmarkConcurrency2-8                          123043243      121400689      -1.33%
BenchmarkConcurrency4-8                          82315349       81387120       -1.13%
BenchmarkConcurrency8-8                          86436890       86645796       +0.24%
BenchmarkConcurrency4Readers1Writer-8            83207303       82113216       -1.31%
BenchmarkConcurrency8Writers-8                   243133059      238111491      -2.07%
BenchmarkVirtualDocs1x1-8                        10207          9333           -8.56%
BenchmarkVirtualDocs10x1-8                       10318          9542           -7.52%
BenchmarkVirtualDocs100x1-8                      10670          9883           -7.38%
BenchmarkVirtualDocs1000x1-8                     11480          10652          -7.21%
BenchmarkVirtualDocs10x10-8                      42270          38637          -8.59%
BenchmarkVirtualDocs100x10-8                     43851          40123          -8.50%
BenchmarkVirtualDocs1000x10-8                    47124          43187          -8.35%
BenchmarkPartialEval/1-8                         9141           8388           -8.24%
BenchmarkPartialEval/10-8                        9207           8395           -8.82%
BenchmarkPartialEval/100-8                       9608           8829           -8.11%
BenchmarkPartialEval/1000-8                      10151          9419           -7.21%
BenchmarkPartialEvalCompile/1-8                  3526382        3527348        +0.03%
BenchmarkPartialEvalCompile/10-8                 4955083        4925630        -0.59%
BenchmarkPartialEvalCompile/100-8                39194621       37077972       -5.40%
BenchmarkPartialEvalCompile/1000-8               2569744747     2385974743     -7.15%
BenchmarkWalk/100-8                              981309         975551         -0.59%
BenchmarkWalk/1000-8                             1057038        1062497        +0.52%
BenchmarkWalk/2000-8                             1151087        1151410        +0.03%
BenchmarkWalk/3000-8                             1245690        1235872        -0.79%
BenchmarkInliningFullScan/1000-8                 6533984        6351564        -2.79%
BenchmarkInliningFullScan/10000-8                72304105       70040441       -3.13%
BenchmarkInliningFullScan/300000-8               2403083361     2276058961     -5.29%

Signed-off-by: Teemu Koponen <koponen@styra.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
