### PR TITLE
topdown: Remove unnecessary reference copy in biunify.

### DIFF
--- a/topdown/eval.go
+++ b/topdown/eval.go
@@ -747,7 +747,6 @@ func (e *eval) biunifyValues(a, b *ast.Term, b1, b2 *bindings, iter unifyIterato
 func (e *eval) biunifyRef(a, b *ast.Term, b1, b2 *bindings, iter unifyIterator) error {
 
 	ref := a.Value.(ast.Ref)
-	plugged := ref.Copy()
 
 	if ref[0].Equal(ast.DefaultRootDocument) {
 		node := e.compiler.RuleTree.Child(ref[0].Value)
@@ -756,7 +755,7 @@ func (e *eval) biunifyRef(a, b *ast.Term, b1, b2 *bindings, iter unifyIterator) 
 			e:         e,
 			ref:       ref,
 			pos:       1,
-			plugged:   plugged,
+			plugged:   ref.Copy(),
 			bindings:  b1,
 			rterm:     b,
 			rbindings: b2,


### PR DESCRIPTION
benchmark                                        old ns/op      new ns/op      delta
BenchmarkAuthzForbidAuthn-8                      30951          31066          +0.37%
BenchmarkAuthzForbidPath-8                       96070          92246          -3.98%
BenchmarkAuthzForbidMethod-8                     102412         98053          -4.26%
BenchmarkAuthzAllow10Paths-8                     99315          94630          -4.72%
BenchmarkAuthzAllow100Paths-8                    620837         569636         -8.25%
BenchmarkAuthzAllow1000Paths-8                   5423305        4989759        -7.99%
BenchmarkRESTAuthzForbidAuthn-8                  472427         468164         -0.90%
BenchmarkRESTAuthzForbidPath-8                   546472         539485         -1.28%
BenchmarkRESTAuthzForbidMethod-8                 551292         542250         -1.64%
BenchmarkRESTAuthzAllow10Paths-8                 546016         543514         -0.46%
BenchmarkRESTAuthzAllow100Paths-8                1106900        1067062        -3.60%
BenchmarkRESTAuthzAllow1000Paths-8               6201083        5758564        -7.14%
BenchmarkScheduler10x30-8                        12109234       11999058       -0.91%
BenchmarkVirtualCache-8                          319            318            -0.31%
BenchmarkLargeJSON-8                             64250175       64003512       -0.38%
BenchmarkConcurrency1-8                          225302348      224640355      -0.29%
BenchmarkConcurrency2-8                          123043243      123191567      +0.12%
BenchmarkConcurrency4-8                          82315349       82818885       +0.61%
BenchmarkConcurrency8-8                          86436890       87344438       +1.05%
BenchmarkConcurrency4Readers1Writer-8            83207303       82422231       -0.94%
BenchmarkConcurrency8Writers-8                   243133059      240754401      -0.98%
BenchmarkVirtualDocs1x1-8                        10207          9853           -3.47%
BenchmarkVirtualDocs10x1-8                       10318          9962           -3.45%
BenchmarkVirtualDocs100x1-8                      10670          10307          -3.40%
BenchmarkVirtualDocs1000x1-8                     11480          11128          -3.07%
BenchmarkVirtualDocs10x10-8                      42270          38672          -8.51%
BenchmarkVirtualDocs100x10-8                     43851          39887          -9.04%
BenchmarkVirtualDocs1000x10-8                    47124          42779          -9.22%
BenchmarkPartialEval/1-8                         9141           8640           -5.48%
BenchmarkPartialEval/10-8                        9207           8731           -5.17%
BenchmarkPartialEval/100-8                       9608           9071           -5.59%
BenchmarkPartialEval/1000-8                      10151          9496           -6.45%
BenchmarkPartialEvalCompile/1-8                  3526382        3518252        -0.23%
BenchmarkPartialEvalCompile/10-8                 4955083        4912449        -0.86%
BenchmarkPartialEvalCompile/100-8                39194621       37261807       -4.93%
BenchmarkPartialEvalCompile/1000-8               2569744747     2403576909     -6.47%
BenchmarkWalk/100-8                              981309         977657         -0.37%
BenchmarkWalk/1000-8                             1057038        1059198        +0.20%
BenchmarkWalk/2000-8                             1151087        1195227        +3.83%
BenchmarkWalk/3000-8                             1245690        1266726        +1.69%
BenchmarkInliningFullScan/1000-8                 6533984        6547674        +0.21%
BenchmarkInliningFullScan/10000-8                72304105       73341343       +1.43%
BenchmarkInliningFullScan/300000-8               2403083361     2282832415     -5.00%

Signed-off-by: Teemu Koponen <koponen@styra.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
