### PR TITLE
topdown: Improved bindings implementation.

### DIFF
--- a/topdown/bindings.go
+++ b/topdown/bindings.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/open-policy-agent/opa/ast"
-	"github.com/open-policy-agent/opa/util"
 )
 
 type undo struct {
@@ -38,30 +37,12 @@ var sentinel = newBindings(math.MaxUint64, nil)
 
 type bindings struct {
 	id     uint64
-	values *util.HashMap
+	values bindingsArrayHashmap
 	instr  *Instrumentation
 }
 
 func newBindings(id uint64, instr *Instrumentation) *bindings {
-
-	eq := func(a, b util.T) bool {
-		v1, ok1 := a.(*ast.Term)
-		if ok1 {
-			v2 := b.(*ast.Term)
-			return v1.Equal(v2)
-		}
-		uv1 := a.(*value)
-		uv2 := b.(*value)
-		return uv1.equal(uv2)
-	}
-
-	hash := func(x util.T) int {
-		v := x.(*ast.Term)
-		return v.Hash()
-	}
-
-	values := util.NewHashMap(eq, hash)
-
+	values := newBindingsArrayHashmap()
 	return &bindings{id, values, instr}
 }
 
@@ -69,12 +50,11 @@ func (u *bindings) Iter(caller *bindings, iter func(*ast.Term, *ast.Term) error)
 
 	var err error
 
-	u.values.Iter(func(k, v util.T) bool {
+	u.values.Iter(func(k *ast.Term, v value) bool {
 		if err != nil {
 			return true
 		}
-		term := k.(*ast.Term)
-		err = iter(term, u.PlugNamespaced(term, caller))
+		err = iter(k, u.PlugNamespaced(k, caller))
 
 		return false
 	})
@@ -181,11 +161,7 @@ func (u *bindings) get(v *ast.Term) (value, bool) {
 	if u == nil {
 		return value{}, false
 	}
-	r, ok := u.values.Get(v)
-	if !ok {
-		return value{}, false
-	}
-	return r.(value), true
+	return u.values.Get(v)
 }
 
 func (u *bindings) String() string {
@@ -193,7 +169,7 @@ func (u *bindings) String() string {
 		return "()"
 	}
 	var buf []string
-	u.values.Iter(func(a, b util.T) bool {
+	u.values.Iter(func(a *ast.Term, b value) bool {
 		buf = append(buf, fmt.Sprintf("%v: %v", a, b))
 		return false
 	})
@@ -305,4 +281,113 @@ func (vis namespacingVisitor) namespaceTerm(a *ast.Term) *ast.Term {
 		return &cpy
 	}
 	return a
+}
+
+const maxLinearScan = 16
+
+// bindingsArrayHashMap uses an array with linear scan instead of a hash map for smaller # of entries. Hash maps start to show off their performance advantage only after 16 keys.
+type bindingsArrayHashmap struct {
+	n int // Entries in the array.
+	a *[maxLinearScan]bindingArrayKeyValue
+	m map[ast.Var]bindingArrayKeyValue
+}
+
+type bindingArrayKeyValue struct {
+	key   *ast.Term
+	value value
+}
+
+func newBindingsArrayHashmap() bindingsArrayHashmap {
+	return bindingsArrayHashmap{}
+}
+
+func (b *bindingsArrayHashmap) Put(key *ast.Term, value value) {
+	if b.m == nil {
+		if b.a == nil {
+			b.a = new([maxLinearScan]bindingArrayKeyValue)
+		} else if i := b.find(key); i >= 0 {
+			(*b.a)[i].value = value
+			return
+		}
+
+		if b.n < maxLinearScan {
+			(*b.a)[b.n] = bindingArrayKeyValue{key, value}
+			b.n++
+			return
+		}
+
+		// Array is full, revert to using the hash map instead.
+
+		b.m = make(map[ast.Var]bindingArrayKeyValue, maxLinearScan+1)
+		for _, kv := range *b.a {
+			b.m[kv.key.Value.(ast.Var)] = bindingArrayKeyValue{kv.key, kv.value}
+		}
+		b.m[key.Value.(ast.Var)] = bindingArrayKeyValue{key, value}
+
+		b.n = 0
+		return
+	}
+
+	b.m[key.Value.(ast.Var)] = bindingArrayKeyValue{key, value}
+}
+
+func (b *bindingsArrayHashmap) Get(key *ast.Term) (value, bool) {
+	if b.m == nil {
+		if i := b.find(key); i >= 0 {
+			return (*b.a)[i].value, true
+		}
+
+		return value{}, false
+	}
+
+	v, ok := b.m[key.Value.(ast.Var)]
+	if ok {
+		return v.value, true
+	}
+
+	return value{}, false
+}
+
+func (b *bindingsArrayHashmap) Delete(key *ast.Term) {
+	if b.m == nil {
+		if i := b.find(key); i >= 0 {
+			n := b.n - 1
+			if i < n {
+				(*b.a)[i] = (*b.a)[n]
+			}
+
+			b.n = n
+		}
+		return
+	}
+
+	delete(b.m, key.Value.(ast.Var))
+}
+
+func (b *bindingsArrayHashmap) Iter(f func(k *ast.Term, v value) bool) {
+	if b.m == nil {
+		for i := 0; i < b.n; i++ {
+			if f((*b.a)[i].key, (*b.a)[i].value) {
+				return
+			}
+		}
+		return
+	}
+
+	for _, v := range b.m {
+		if f(v.key, v.value) {
+			return
+		}
+	}
+}
+
+func (b *bindingsArrayHashmap) find(key *ast.Term) int {
+	v := key.Value.(ast.Var)
+	for i := 0; i < b.n; i++ {
+		if (*b.a)[i].key.Value.(ast.Var) == v {
+			return i
+		}
+	}
+
+	return -1
 }

--- a/topdown/bindings_test.go
+++ b/topdown/bindings_test.go
@@ -5,6 +5,8 @@
 package topdown
 
 import (
+	"fmt"
+	"strconv"
 	"testing"
 
 	"github.com/open-policy-agent/opa/ast"
@@ -28,4 +30,69 @@ func TestBindingsZeroValues(t *testing.T) {
 
 func term(s string) *ast.Term {
 	return ast.MustParseTerm(s)
+}
+
+func TestBindingsArrayHashmap(t *testing.T) {
+	var bindings bindings
+	b := newBindingsArrayHashmap()
+	keys := make(map[int]ast.Var, 0)
+
+	for i := 0; i < maxLinearScan+1; i++ {
+		b.Put(testBindingKey(i), testBindingValue(&bindings, i))
+		keys[i] = testBindingKey(i).Value.(ast.Var)
+
+		testBindingKeys(t, &bindings, &b, keys)
+	}
+
+	for i := 0; i < maxLinearScan+1; i++ {
+		b.Delete(testBindingKey(i))
+		delete(keys, i)
+
+		testBindingKeys(t, &bindings, &b, keys)
+	}
+}
+
+func testBindingKeys(t *testing.T, bindings *bindings, b *bindingsArrayHashmap, keys map[int]ast.Var) {
+	for k := range keys {
+		value := testBindingValue(bindings, k)
+		if v, ok := b.Get(testBindingKey(k)); !ok {
+			t.Errorf("value not found: %v", k)
+		} else if !v.equal(&value) {
+			t.Errorf("value not equal")
+		}
+	}
+
+	var found []ast.Var
+	b.Iter(func(k *ast.Term, v value) bool {
+		key := k.Value.(ast.Var)
+		if i, _ := strconv.Atoi(string(key)); !testBindingValue(bindings, i).equal(&v) {
+			t.Errorf("iteration value note equal")
+		}
+
+		found = append(found, key)
+		return false
+	})
+
+	if len(found) != len(keys) {
+		t.Errorf("all keys not found")
+	}
+
+next:
+	for _, a := range keys {
+		for _, b := range found {
+			if a == b {
+				continue next
+			}
+		}
+
+		t.Errorf("key not found")
+	}
+}
+
+func testBindingKey(key int) *ast.Term {
+	return ast.VarTerm(fmt.Sprintf("%d", key))
+}
+
+func testBindingValue(b *bindings, key int) value {
+	return value{b, ast.IntNumberTerm(key)}
 }


### PR DESCRIPTION
With less than 16 bindings, use a linear scan over a fixed array and
only after that revert to go native hash map.

benchmark                                        old ns/op      new ns/op      delta
BenchmarkMaskingNop-8                            147028         146386         -0.44%
BenchmarkMaskingErase-8                          175576         174712         -0.49%
BenchmarkAuthzForbidAuthn-8                      30951          30352          -1.94%
BenchmarkAuthzForbidPath-8                       96070          84999          -11.52%
BenchmarkAuthzForbidMethod-8                     102412         90611          -11.52%
BenchmarkAuthzAllow10Paths-8                     99315          88782          -10.61%
BenchmarkAuthzAllow100Paths-8                    620837         509178         -17.99%
BenchmarkAuthzAllow1000Paths-8                   5423305        4676025        -13.78%
BenchmarkRESTAuthzForbidAuthn-8                  472427         473979         +0.33%
BenchmarkRESTAuthzForbidPath-8                   546472         534150         -2.25%
BenchmarkRESTAuthzForbidMethod-8                 551292         537586         -2.49%
BenchmarkRESTAuthzAllow10Paths-8                 546016         532926         -2.40%
BenchmarkRESTAuthzAllow100Paths-8                1106900        1005035        -9.20%
BenchmarkRESTAuthzAllow1000Paths-8               6201083        5274038        -14.95%
BenchmarkScheduler10x30-8                        12109234       11219778       -7.35%
BenchmarkVirtualCache-8                          319            318            -0.31%
BenchmarkLargeJSON-8                             64250175       64843581       +0.92%
BenchmarkConcurrency1-8                          225302348      223577531      -0.77%
BenchmarkConcurrency2-8                          123043243      121214683      -1.49%
BenchmarkConcurrency4-8                          82315349       81626087       -0.84%
BenchmarkConcurrency8-8                          86436890       87351512       +1.06%
BenchmarkConcurrency4Readers1Writer-8            83207303       82139035       -1.28%
BenchmarkConcurrency8Writers-8                   243133059      238912579      -1.74%
BenchmarkVirtualDocs1x1-8                        10207          9705           -4.92%
BenchmarkVirtualDocs10x1-8                       10318          9833           -4.70%
BenchmarkVirtualDocs100x1-8                      10670          10177          -4.62%
BenchmarkVirtualDocs1000x1-8                     11480          11116          -3.17%
BenchmarkVirtualDocs10x10-8                      42270          39318          -6.98%
BenchmarkVirtualDocs100x10-8                     43851          40861          -6.82%
BenchmarkVirtualDocs1000x10-8                    47124          44372          -5.84%
BenchmarkPartialEval/1-8                         9141           9107           -0.37%
BenchmarkPartialEval/10-8                        9207           9167           -0.43%
BenchmarkPartialEval/100-8                       9608           9589           -0.20%
BenchmarkPartialEval/1000-8                      10151          10318          +1.65%
BenchmarkPartialEvalCompile/1-8                  3526382        3521465        -0.14%
BenchmarkPartialEvalCompile/10-8                 4955083        4853027        -2.06%
BenchmarkPartialEvalCompile/100-8                39194621       34259322       -12.59%
BenchmarkPartialEvalCompile/1000-8               2569744747     2052320958     -20.14%
BenchmarkWalk/100-8                              981309         973686         -0.78%
BenchmarkWalk/1000-8                             1057038        1050256        -0.64%
BenchmarkWalk/2000-8                             1151087        1144283        -0.59%
BenchmarkWalk/3000-8                             1245690        1234413        -0.91%
BenchmarkInliningFullScan/1000-8                 6533984        6189376        -5.27%
BenchmarkInliningFullScan/10000-8                72304105       68606901       -5.11%
BenchmarkInliningFullScan/300000-8               2403083361     2118352692     -11.85%

Signed-off-by: Teemu Koponen <koponen@styra.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
