### PR TITLE
docs: Use a single value for algolia version meta

### DIFF
--- a/docs/website/layouts/partials/meta.html
+++ b/docs/website/layouts/partials/meta.html
@@ -7,7 +7,6 @@
 {{ $twitter     := site.Params.social.twitter }}
 {{ $latest      := index site.Data.releases 0 }}
 {{ $version     := index (split .File.Path "/") 1 }}
-{{ $isLatest    := eq $latest $version }}
 
 <!-- Basic metadata -->
 <meta charset="utf-8">
@@ -46,11 +45,7 @@
 
 <!-- Algolia metadata -->
 <meta name="docsearch:language" content="en" />
-{{ if $isLatest }}
-<meta name="docsearch:version" content='["{{ $version }}", "latest"]' />
-{{ else }}
 <meta name="docsearch:version" content="{{ $version }}" />
-{{ end }}
 
 <!-- Site generator -->
 {{ hugo.Generator }}


### PR DESCRIPTION
As-is we have an array like `["v0.13.4", "latest"] but it seems that
we aren't referencing it as such, its trying to compare a string
version.

It looks like on the `latest` urls we would set the facetFilter to
be the explicit version, so we'll just stick with that for the meta
tags too.

Ref: https://discourse.algolia.com/t/docsearch-isnt-showing-results-on-newer-version-of-docs/8345/3