### PR TITLE
cmd/run: remove superfluous [flags] from usageTemplate

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -159,7 +159,7 @@ File paths can be specified as URLs to resolve ambiguity in paths containing col
 	setIgnore(runCommand.Flags(), &ignore)
 
 	usageTemplate := `Usage:
-  {{.UseLine}} [flags] [files]
+  {{.UseLine}} [files]
 
 Flags:
 {{.LocalFlags.FlagUsages | trimRightSpace}}


### PR DESCRIPTION
Before vs after:

    $ opa run --help | grep flags
      opa run [flags] [flags] [files]
    $ ./opa_darwin_amd64 run --help | grep flags
      opa_darwin_amd64 run [flags] [files]