### PR TITLE
ast: Optimize set/object lookups and Number comparison.

### DIFF
--- a/ast/compare.go
+++ b/ast/compare.go
@@ -5,6 +5,7 @@
 package ast
 
 import (
+	"encoding/json"
 	"fmt"
 	"math/big"
 )
@@ -84,6 +85,18 @@ func Compare(a, b interface{}) int {
 		}
 		return 1
 	case Number:
+		if ai, err := json.Number(a).Int64(); err == nil {
+			if bi, err := json.Number(b.(Number)).Int64(); err == nil {
+				if ai == bi {
+					return 0
+				}
+				if ai < bi {
+					return -1
+				}
+				return 1
+			}
+		}
+
 		bigA, ok := new(big.Float).SetString(string(a))
 		if !ok {
 			panic("illegal value")

--- a/ast/compare_test.go
+++ b/ast/compare_test.go
@@ -27,6 +27,9 @@ func TestCompare(t *testing.T) {
 		// Numbers
 		{"0", "1", -1},
 		{"1", "0", 1},
+		{"0", "0", 0},
+		{"0", "1.5", -1},
+		{"1.5", "0", 1},
 
 		// Object comparisons are consistent
 		{`{1: 2, 3: 4}`, `{4: 3, 1: 2}`, -1},


### PR DESCRIPTION
Lookups for sets and objects use their own type specific equality
checks instead of relying on the general purpose Compare. This
improves the performance about 25%. The duplication of code is
unavoidable to avoid the allocations, unfortunately.

Number comparison is now allocation free for integers. This because
Int64() of json.Number uses allocation free strconv.ParseInt
internally. This shows up in the additional 60% improvement of set
membership benchmarks as they use integer keys.

Most notable improvements in benchmarks:

benchmark                                        old ns/op      new ns/op      delta
BenchmarkObjectLookup/5-8                        37.3           31.9           -14.48%
BenchmarkObjectLookup/50-8                       44.7           39.7           -11.19%
BenchmarkObjectLookup/500-8                      46.6           41.7           -10.52%
BenchmarkObjectLookup/5000-8                     43.6           38.4           -11.93%
BenchmarkSetIntersection/5-8                     2309           928            -59.81%
BenchmarkSetIntersection/50-8                    24562          9121           -62.87%
BenchmarkSetIntersection/500-8                   260022         93373          -64.09%
BenchmarkSetIntersection/5000-8                  2796645        1035045        -62.99%
BenchmarkSetIntersectionDifferentSize/4-8        1774           781            -55.98%
BenchmarkSetIntersectionDifferentSize/50-8       1847           875            -52.63%
BenchmarkSetIntersectionDifferentSize/500-8      1849           864            -53.27%
BenchmarkSetIntersectionDifferentSize/5000-8     1884           890            -52.76%
BenchmarkSetMembership/5-8                       339            55.1           -83.75%
BenchmarkSetMembership/50-8                      383            65.3           -82.95%
BenchmarkSetMembership/500-8                     403            70.5           -82.51%
BenchmarkSetMembership/5000-8                    418            75.1           -82.03%
BenchmarkConcurrency1-8                          219100992      218699478      -0.18%
BenchmarkConcurrency2-8                          121519274      119096088      -1.99%
BenchmarkConcurrency4-8                          88765327       78934589       -11.07%
BenchmarkConcurrency8-8                          93624724       82432804       -11.95%
BenchmarkConcurrency4Readers1Writer-8            90931759       80533879       -11.43%
BenchmarkConcurrency8Writers-8                   237043373      233709595      -1.41%

Signed-off-by: Teemu Koponen <koponen@styra.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
