### PR TITLE
live-blocks: Added an `include(<group name>)` tag.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -332,3 +332,8 @@ If you think a more specific tag could be added for your case, please create an 
 - `expect_error` - Any OPA error. This should generally not be used.
 
 > At this time, due to the way OPA loads modules on the CLI, expecting parse errors is not possible.
+
+Finally, outputs can also be tagged one or more times with `include(<group name>)`, which will include
+another group's module when evaluating (e.g. so that they can be imported).
+
+> If a query isn't specified for the output's group, when other modules are included the default becomes `data` instead of `data.<package name>`.

--- a/docs/website/scripts/live-blocks/src/preprocess/index.js
+++ b/docs/website/scripts/live-blocks/src/preprocess/index.js
@@ -4,7 +4,7 @@ import {promises as promFS} from 'fs'
 import cheerio from 'cheerio'
 
 import {batchMapFold, batchProcess, expectedErrorTags, infoFromLabel, println, report, toArray} from '../helpers.js'
-import {BLOCK_SELECTOR, BLOCK_TYPES, CLASSES, CSS_BUNDLE_BATH, ICONS, JS_BUNDLE_PATH, MAX_CONCUR_FILE_EVALS, MAX_CONCUR_FILES, TAG_TYPES, VERSION_EDGE} from '../constants.js'
+import {BLOCK_SELECTOR, BLOCK_TYPES, CLASSES, CSS_BUNDLE_BATH, ICONS, JS_BUNDLE_PATH, MAX_CONCUR_FILE_EVALS, MAX_CONCUR_FILES, STATIC_TAG_TYPES, VERSION_EDGE} from '../constants.js'
 import {ChainedError, OPAErrors} from '../errors.js'
 
 import localEval from './localEval.js'
@@ -161,12 +161,12 @@ function styleBlocks(groups) {
       block.set(content)
 
       // Hide if tagged
-      if (block.tags.includes(TAG_TYPES.HIDDEN)) {
+      if (block.tags.includes(STATIC_TAG_TYPES.HIDDEN)) {
         block.container.css('display', 'none')
       }
 
       // Merge if tagged
-      if (block.tags.includes(TAG_TYPES.MERGE_DOWN)) {
+      if (block.tags.includes(STATIC_TAG_TYPES.MERGE_DOWN)) {
         block.container.addClass(CLASSES.BLOCK_CONTAINER_MERGED_DOWN)
       }
 
@@ -207,7 +207,7 @@ async function populateOutputs(groups, opaVersion) {
 
       }
       // Errors are not from OPA, something bad happened.
-      throw new ChainedError(`${groupName} evaluation failed for an unexpectable reason (check for additional logs): ${e.message}`, e)
+      throw new ChainedError(`${groupName} evaluation failed for an unexpectable, possibly internal reason (check for additional logs): ${e.message}`, e)
     }
 
     // If there's not an error, one might have been expected.

--- a/docs/website/scripts/live-blocks/src/web/playground.js
+++ b/docs/website/scripts/live-blocks/src/web/playground.js
@@ -58,11 +58,12 @@ export async function shareToPlayground(groups, groupName) {
 
 // Constructs a the fetch options for querying the playground with a DataRequest. Throws an error with a user-friendly message if it can't.
 function createDataRequestOpts(groups, groupName) {
-  const {module, query, input} = getGroupData(groups, groupName) // Throws user-friendly messages.
+  const {module, package: pkg, query, input, included} = getGroupData(groups, groupName) // Throws user-friendly messages.
 
   try {
     const body = {} // In the format accepted by playground backend
-    body.rego_modules = {[EVAL_MODULE_NAME]: module}
+    body.rego_modules = {[EVAL_MODULE_NAME]: module, ...included}
+    body.query_package = pkg
     if (query) {
       body.rego = query
     }

--- a/docs/website/scripts/live-blocks/test/errors.test.js
+++ b/docs/website/scripts/live-blocks/test/errors.test.js
@@ -2,7 +2,7 @@ import {describe, it} from 'mocha'
 import {expect} from 'chai'
 
 import {ChainedError, OPAErrors} from '../src/errors'
-import {TAG_TYPES} from '../src/constants'
+import {STATIC_TAG_TYPES} from '../src/constants'
 
 describe('ChainedError', () => {
   it('uses a new message', () => {
@@ -28,21 +28,21 @@ describe('OPAErrors', () => {
   })
 
   it('can be constructed with a single OPA error', () => {
-    expect((new OPAErrors('', oe('rego_recursion_error'))).matchesExpected([TAG_TYPES.EXPECT_RECURSION])).to.be.true
-    expect((new OPAErrors('', oe('rego_recursion_error'))).matchesExpected([TAG_TYPES.EXPECT_BUILTIN_ERROR])).to.be.false
+    expect((new OPAErrors('', oe('rego_recursion_error'))).matchesExpected([STATIC_TAG_TYPES.EXPECT_RECURSION])).to.be.true
+    expect((new OPAErrors('', oe('rego_recursion_error'))).matchesExpected([STATIC_TAG_TYPES.EXPECT_BUILTIN_ERROR])).to.be.false
   })
 
   it('can be constructed with an array of OPA errors', () => {
-    expect((new OPAErrors('', [oe('rego_recursion_error'), oe('rego_compile_error')])).matchesExpected([TAG_TYPES.EXPECT_RECURSION, TAG_TYPES.EXPECT_COMPILE_ERROR])).to.be.true
-    expect((new OPAErrors('', [oe('rego_recursion_error'), oe('rego_compile_error')])).matchesExpected([TAG_TYPES.EXPECT_RECURSION, TAG_TYPES.EXPECT_UNSAFE_VAR])).to.be.false
+    expect((new OPAErrors('', [oe('rego_recursion_error'), oe('rego_compile_error')])).matchesExpected([STATIC_TAG_TYPES.EXPECT_RECURSION, STATIC_TAG_TYPES.EXPECT_COMPILE_ERROR])).to.be.true
+    expect((new OPAErrors('', [oe('rego_recursion_error'), oe('rego_compile_error')])).matchesExpected([STATIC_TAG_TYPES.EXPECT_RECURSION, STATIC_TAG_TYPES.EXPECT_UNSAFE_VAR])).to.be.false
   })
 
   it('can be constructed with undefined as the error', () => {
-    expect((new OPAErrors('', undefined)).matchesExpected([TAG_TYPES.EXPECT_UNDEFINED])).to.be.true
-    expect((new OPAErrors('', undefined)).matchesExpected([TAG_TYPES.EXPECT_BUILTIN_ERROR])).to.be.false
+    expect((new OPAErrors('', undefined)).matchesExpected([STATIC_TAG_TYPES.EXPECT_UNDEFINED])).to.be.true
+    expect((new OPAErrors('', undefined)).matchesExpected([STATIC_TAG_TYPES.EXPECT_BUILTIN_ERROR])).to.be.false
 
-    expect((new OPAErrors('', [undefined])).matchesExpected([TAG_TYPES.EXPECT_UNDEFINED])).to.be.true
-    expect((new OPAErrors('', [undefined])).matchesExpected([TAG_TYPES.EXPECT_BUILTIN_ERROR])).to.be.false
+    expect((new OPAErrors('', [undefined])).matchesExpected([STATIC_TAG_TYPES.EXPECT_UNDEFINED])).to.be.true
+    expect((new OPAErrors('', [undefined])).matchesExpected([STATIC_TAG_TYPES.EXPECT_BUILTIN_ERROR])).to.be.false
   })
 
   it('can\'t be constructed with improperly formatted OPA errors', () => {
@@ -60,41 +60,41 @@ describe('OPAErrors', () => {
   })
 
   it('can match with duplicate errors', () => {
-    expect((new OPAErrors('', [oe('rego_recursion_error'), oe('rego_recursion_error')])).matchesExpected([TAG_TYPES.EXPECT_RECURSION])).to.be.true
+    expect((new OPAErrors('', [oe('rego_recursion_error'), oe('rego_recursion_error')])).matchesExpected([STATIC_TAG_TYPES.EXPECT_RECURSION])).to.be.true
   })
 
   it('can match with duplicate tags', () => {
-    expect((new OPAErrors('', oe('rego_recursion_error'))).matchesExpected([TAG_TYPES.EXPECT_RECURSION, TAG_TYPES.EXPECT_RECURSION])).to.be.true
+    expect((new OPAErrors('', oe('rego_recursion_error'))).matchesExpected([STATIC_TAG_TYPES.EXPECT_RECURSION, STATIC_TAG_TYPES.EXPECT_RECURSION])).to.be.true
   })
 
   it('can match with non-error tags', () => {
-    expect((new OPAErrors('', oe('rego_recursion_error'))).matchesExpected([TAG_TYPES.HIDDEN, TAG_TYPES.EXPECT_RECURSION])).to.be.true
+    expect((new OPAErrors('', oe('rego_recursion_error'))).matchesExpected([STATIC_TAG_TYPES.HIDDEN, STATIC_TAG_TYPES.EXPECT_RECURSION])).to.be.true
   })
 
   it('requires all errors to be matched', () => {
-    expect((new OPAErrors('', oe('rego_recursion_error'))).matchesExpected([TAG_TYPES.HIDDEN])).to.be.false
-    expect((new OPAErrors('', [oe('rego_recursion_error'), oe('rego_compile_error')])).matchesExpected([TAG_TYPES.HIDDEN, TAG_TYPES.EXPECT_RECURSION])).to.be.false
+    expect((new OPAErrors('', oe('rego_recursion_error'))).matchesExpected([STATIC_TAG_TYPES.HIDDEN])).to.be.false
+    expect((new OPAErrors('', [oe('rego_recursion_error'), oe('rego_compile_error')])).matchesExpected([STATIC_TAG_TYPES.HIDDEN, STATIC_TAG_TYPES.EXPECT_RECURSION])).to.be.false
   })
 
   it('requires all error tags to match an error', () => {
-    expect((new OPAErrors('', oe('rego_recursion_error'))).matchesExpected([TAG_TYPES.HIDDEN])).to.be.false
-    expect((new OPAErrors('', [oe('rego_recursion_error'), oe('rego_compile_error')])).matchesExpected([TAG_TYPES.EXPECT_RECURSION, TAG_TYPES.EXPECT_COMPILE_ERROR, TAG_TYPES.EXPECT_ASSIGNED_ABOVE])).to.be.false
+    expect((new OPAErrors('', oe('rego_recursion_error'))).matchesExpected([STATIC_TAG_TYPES.HIDDEN])).to.be.false
+    expect((new OPAErrors('', [oe('rego_recursion_error'), oe('rego_compile_error')])).matchesExpected([STATIC_TAG_TYPES.EXPECT_RECURSION, STATIC_TAG_TYPES.EXPECT_COMPILE_ERROR, STATIC_TAG_TYPES.EXPECT_ASSIGNED_ABOVE])).to.be.false
   })
 
   it('child errors can be matched precisely', () => {
-    expect((new OPAErrors('', [{code: 'rego_compile_error', message: 'assigned above'}])).matchesExpected([TAG_TYPES.EXPECT_ASSIGNED_ABOVE])).to.be.true
-    expect((new OPAErrors('', [{code: 'rego_compile_error', message: 'assigned above'}, {code: 'rego_compile_error', message: 'referenced above'}])).matchesExpected([TAG_TYPES.EXPECT_ASSIGNED_ABOVE])).to.be.false
+    expect((new OPAErrors('', [{code: 'rego_compile_error', message: 'assigned above'}])).matchesExpected([STATIC_TAG_TYPES.EXPECT_ASSIGNED_ABOVE])).to.be.true
+    expect((new OPAErrors('', [{code: 'rego_compile_error', message: 'assigned above'}, {code: 'rego_compile_error', message: 'referenced above'}])).matchesExpected([STATIC_TAG_TYPES.EXPECT_ASSIGNED_ABOVE])).to.be.false
   })
 
   it('parent tags match children', () => {
-    expect((new OPAErrors('', [undefined, oe('rego_type_error'), oe('eval_type_error'), oe('fake_error')])).matchesExpected([TAG_TYPES.EXPECT_ERROR])).to.be.true
-    expect((new OPAErrors('', [oe('rego_type_error')])).matchesExpected([TAG_TYPES.EXPECT_REGO_ERROR])).to.be.true
-    expect((new OPAErrors('', [oe('eval_type_error')])).matchesExpected([TAG_TYPES.EXPECT_EVAL_ERROR])).to.be.true
-    expect((new OPAErrors('', [{code: 'rego_compile_error', message: 'assigned above'}])).matchesExpected([TAG_TYPES.EXPECT_COMPILE_ERROR])).to.be.true
+    expect((new OPAErrors('', [undefined, oe('rego_type_error'), oe('eval_type_error'), oe('fake_error')])).matchesExpected([STATIC_TAG_TYPES.EXPECT_ERROR])).to.be.true
+    expect((new OPAErrors('', [oe('rego_type_error')])).matchesExpected([STATIC_TAG_TYPES.EXPECT_REGO_ERROR])).to.be.true
+    expect((new OPAErrors('', [oe('eval_type_error')])).matchesExpected([STATIC_TAG_TYPES.EXPECT_EVAL_ERROR])).to.be.true
+    expect((new OPAErrors('', [{code: 'rego_compile_error', message: 'assigned above'}])).matchesExpected([STATIC_TAG_TYPES.EXPECT_COMPILE_ERROR])).to.be.true
   })
 
   it('undefined is only matched by its own tag and expect_error', () => {
-    expect((new OPAErrors('', undefined).matchesExpected([TAG_TYPES.EXPECT_ERROR, TAG_TYPES.EXPECT_UNDEFINED]))).to.be.true
-    expect((new OPAErrors('', undefined).matchesExpected([TAG_TYPES.EXPECT_EVAL_ERROR, TAG_TYPES.EXPECT_UNDEFINED]))).to.be.false
+    expect((new OPAErrors('', undefined).matchesExpected([STATIC_TAG_TYPES.EXPECT_ERROR, STATIC_TAG_TYPES.EXPECT_UNDEFINED]))).to.be.true
+    expect((new OPAErrors('', undefined).matchesExpected([STATIC_TAG_TYPES.EXPECT_EVAL_ERROR, STATIC_TAG_TYPES.EXPECT_UNDEFINED]))).to.be.false
   })
 })


### PR DESCRIPTION
This is contingent on multi-module support being added to the playground.