### PR TITLE
fix static check error in reader.go

### DIFF
--- a/internal/wasm/encoding/reader.go
+++ b/internal/wasm/encoding/reader.go
@@ -142,7 +142,7 @@ func readSections(r io.Reader, m *module.Module) error {
 
 		switch id {
 		case constant.CustomSectionID, constant.ElementSectionID, constant.StartSectionID, constant.MemorySectionID:
-			break
+			continue
 		case constant.TypeSectionID:
 			if err := readTypeSection(bufr, &m.Type); err != nil {
 				return errors.Wrap(err, "type section")


### PR DESCRIPTION

`break` will break switch, `continue` will run next for loop. the two expression get the same result, but continue will eliminate the error in staticcheck [SA4011](https://staticcheck.io/docs/checks#SA4011)
