### PR TITLE
[0.13.x] server: Fix panic in /health?bundle=true

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -110,7 +110,7 @@ type Server struct {
 	runtime           *ast.Term
 	httpListeners     []httpListener
 	bundleStatuses    map[string]*bundlePlugin.Status
-	bundleStatusMtx   *sync.RWMutex
+	bundleStatusMtx   sync.RWMutex
 }
 
 // Loop will contain all the calls from the server that we'll be listening on.
@@ -172,7 +172,6 @@ func (s *Server) Init(ctx context.Context) (*Server, error) {
 
 	bp := bundlePlugin.Lookup(s.manager)
 	if bp != nil {
-		s.bundleStatusMtx = new(sync.RWMutex)
 
 		// initialize statuses to empty defaults for server /health check
 		s.bundleStatuses = map[string]*bundlePlugin.Status{}


### PR DESCRIPTION
The issue was that with bundles loaded from the file system we would
not initialize the mutex used for checking bundle status.

This fixes the initialization and prevents the error. Health status
works as expected now.

Fixes: #1703
Signed-off-by: Patrick East <east.patrick@gmail.com>
(cherry picked from commit 3248c2d7189d9062590dfbe0637c6cb40c1f4a85)

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
