### PR TITLE
docs: Add links to homepage

### DIFF
--- a/docs/content/policy-reference.md
+++ b/docs/content/policy-reference.md
@@ -139,13 +139,13 @@ The following table shows examples of how ``glob.match`` works:
 
 | Built-in | Description |
 | ------- |-------------|
-| <span class="opa-keep-it-together">``output := is_number(x)``</span> | ``output`` is ``true`` if ``x`` is a number |
-| <span class="opa-keep-it-together">``output := is_string(x)``</span> | ``output`` is ``true`` if ``x`` is a string |
-| <span class="opa-keep-it-together">``output := is_boolean(x)``</span> | ``output`` is ``true`` if ``x`` is a boolean |
-| <span class="opa-keep-it-together">``output := is_array(x)``</span> | ``output`` is ``true`` if ``x`` is an array |
-| <span class="opa-keep-it-together">``output := is_set(x)``</span> | ``output`` is ``true`` if ``x`` is a set |
-| <span class="opa-keep-it-together">``output := is_object(x)``</span> | ``output`` is ``true`` if ``x`` is an object |
-| <span class="opa-keep-it-together">``output := is_null(x)``</span> | ``output`` is ``true`` if ``x`` is null |
+| <span class="opa-keep-it-together">``output := is_number(x)``</span> | ``output`` is ``true`` if ``x`` is a number; otherwise undefined|
+| <span class="opa-keep-it-together">``output := is_string(x)``</span> | ``output`` is ``true`` if ``x`` is a string; otherwise undefined |
+| <span class="opa-keep-it-together">``output := is_boolean(x)``</span> | ``output`` is ``true`` if ``x`` is a boolean; otherwise undefined |
+| <span class="opa-keep-it-together">``output := is_array(x)``</span> | ``output`` is ``true`` if ``x`` is an array; otherwise undefined |
+| <span class="opa-keep-it-together">``output := is_set(x)``</span> | ``output`` is ``true`` if ``x`` is a set; otherwise undefined |
+| <span class="opa-keep-it-together">``output := is_object(x)``</span> | ``output`` is ``true`` if ``x`` is an object; otherwise undefined |
+| <span class="opa-keep-it-together">``output := is_null(x)``</span> | ``output`` is ``true`` if ``x`` is null; otherwise undefined |
 | <span class="opa-keep-it-together">``output := type_name(x)``</span> | ``output`` is the type of ``x`` |
 
 ### Encoding

--- a/docs/website/layouts/partials/home/banner.html
+++ b/docs/website/layouts/partials/home/banner.html
@@ -3,6 +3,14 @@
 {{ $tagline     := site.Params.tagline }}
 {{ $socialMenu  := site.Menus.social }}
 {{ $docs        := "/docs/latest" }}
+{{ $introduction  := "/docs/latest" }}
+{{ $tutorial  := "/docs/latest/get-started" }}
+{{ $policyLanguage  := "/docs/latest/policy-language" }}
+{{ $kubernetes  := "/docs/latest/kubernetes-introduction" }}
+{{ $microservices  := "/docs/latest/http-api-authorization" }}
+{{ $kafka  := "/docs/latest/kafka-authorization" }}
+{{ $terraform  := "/docs/latest/terraform" }}
+{{ $opaSummit  := "https://www.papercall.io/opa-summit" }}
 {{ $getStarted  := "/docs/latest/get-started" }}
 <header role="banner">
   <nav class="nav--banner" role="navigation">
@@ -63,13 +71,39 @@
       </p>
 
       <p class="headline--nav">
-        <a id="headline--get-started" href="{{ $getStarted }}" rel="help">
-          Get started
+        <span class="headline--navtitle">Core Docs</span>  
+        <a id="headline--get-started" class="headline--link" href="{{ $introduction }}" rel="help">
+          Introduction
         </a>
+        <a class="headline--link" href="{{ $tutorial }}" rel="help">
+          Tutorial
+        </a>
+        <a class="headline--link" href="{{ $policyLanguage }}" rel="help">
+          Policy Language
+        </a>
+      </p>
+      <p class="headline--nav">
+          <span class="headline--navtitle">Use Cases</span> 
+          <a class="headline--link" href="{{ $kubernetes }}" rel="help">
+            Kubernetes
+          </a>
+          <a class="headline--link" href="{{ $microservices }}" rel="help">
+            Microservice APIs
+          </a>
+          <a class="headline--link" href="{{ $kafka }}" rel="help">
+            Kafka
+          </a>
+          <a class="headline--link" href="{{ $terraform }}" rel="help">
+              Terraform
+          </a>
+      </p>
+      <p class="headline--nav">
+          <span class="headline--navtitle">Events</span> 
+          <a class="headline--link" href="{{ $opaSummit }}" rel="help">
+            OPA Summit
+          </a>
+      </p>
 
-        <a id="headline--learn-more" href="{{ $docs }}" rel="help">
-          Learn more
-        </a>
       </p>
     </div>
 

--- a/docs/website/static/css/home.css
+++ b/docs/website/static/css/home.css
@@ -77,12 +77,11 @@ p {
   margin-bottom: 1.3em;
 }
 
-ul, {
+ul {
   list-style: none;
 }
 
-#headline--get-started,
-#headline--learn-more {
+.headline--link {
   border: solid 2px #008391;
   border-radius: 6px;
   display: inline-block;
@@ -92,16 +91,25 @@ ul, {
   text-align: center;
   text-decoration: none;
   width: 180px;
-}
-
-#headline--get-started {
+  /* background-color: #fff;
+  color: #008391; */
   background-color: #008391;
   color: #fff;
 }
 
-#headline--learn-more {
-  background-color: #fff;
-  color: #008391;
+.headline--navtitle {
+  width: 100px;
+  float: left;
+  text-align: left;
+  vertical-align: middle;
+  line-height: 44px;
+  color: rgba(0, 0, 0, .54);
+  /* font-size: 1.25em; */
+
+}
+#headline--get-started {
+  background-color: #008391;
+  color: #fff;
 }
 
 footer {


### PR DESCRIPTION
Previously, there were no links from the homepage to any of the
more detailed docs about use cases and even mention of use cases
was below the fold.

This change adds links to use cases at the very top of the page,
along with pointers to core docs and the OPA summit.

Signed-off-by: Tim Hinrichs <tim@styra.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
