### PR TITLE
Fix eval formatting

### DIFF
--- a/cmd/eval.go
+++ b/cmd/eval.go
@@ -332,19 +332,19 @@ func eval(args []string, params evalCommandParams, w io.Writer) (bool, error) {
 	var parsedModules map[string]*ast.Module
 
 	if !params.partial {
-		pq, err := eval.PrepareForEval(ctx)
-		if err != nil {
-			return false, err
+		var pq rego.PreparedEvalQuery
+		pq, result.Error = eval.PrepareForEval(ctx)
+		if result.Error == nil {
+			parsedModules = pq.Modules()
+			result.Result, result.Error = pq.Eval(ctx)
 		}
-		parsedModules = pq.Modules()
-		result.Result, result.Error = pq.Eval(ctx)
 	} else {
-		pq, err := eval.PrepareForPartial(ctx)
-		if err != nil {
-			return false, err
+		var pq rego.PreparedPartialQuery
+		pq, result.Error = eval.PrepareForPartial(ctx)
+		if result.Error == nil {
+			parsedModules = pq.Modules()
+			result.Partial, result.Error = eval.Partial(ctx)
 		}
-		parsedModules = pq.Modules()
-		result.Partial, result.Error = eval.Partial(ctx)
 	}
 
 	switch params.explain.String() {

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -37,14 +37,16 @@ docker-serve:
 			--source /src/website \
 			--contentDir generated
 
-.PHONY: production-build
-production-build: clean generate
+.PHONY: hugo-production-build
+hugo-production-build:
 	hugo \
 		--source $(CURDIR)/website \
 		--contentDir generated \
 		--ignoreCache \
 		--minify
-	make live-blocks-inject
+
+.PHONY: production-build
+production-build: clean generate hugo-production-build live-blocks-inject
 
 .PHONY: preview-build
 preview-build: clean generate


### PR DESCRIPTION
This fixes the formatting for the output of `opa eval` and makes a quality of life change to the docs makefile to ease troubleshooting.
