### PR TITLE
bundles: Fix duplicate file names overriding modules

### DIFF
--- a/bundle/bundle_test.go
+++ b/bundle/bundle_test.go
@@ -292,3 +292,77 @@ func TestRootPathsOverlap(t *testing.T) {
 		})
 	}
 }
+
+func TestParsedModules(t *testing.T) {
+	cases := []struct {
+		note            string
+		bundle          Bundle
+		name            string
+		expectedModules []string
+	}{
+		{
+			note: "base",
+			bundle: Bundle{
+				Modules: []ModuleFile{
+					{
+						Path:   "/foo/policy.rego",
+						Parsed: ast.MustParseModule(`package foo`),
+						Raw:    []byte(`package foo`),
+					},
+				},
+			},
+			name: "test-bundle",
+			expectedModules: []string{
+				"test-bundle/foo/policy.rego",
+			},
+		},
+		{
+			note: "filepath name",
+			bundle: Bundle{
+				Modules: []ModuleFile{
+					{
+						Path:   "/foo/policy.rego",
+						Parsed: ast.MustParseModule(`package foo`),
+						Raw:    []byte(`package foo`),
+					},
+				},
+			},
+			name: "/some/system/path",
+			expectedModules: []string{
+				"/some/system/path/foo/policy.rego",
+			},
+		},
+		{
+			note: "file url name",
+			bundle: Bundle{
+				Modules: []ModuleFile{
+					{
+						Path:   "/foo/policy.rego",
+						Parsed: ast.MustParseModule(`package foo`),
+						Raw:    []byte(`package foo`),
+					},
+				},
+			},
+			name: "file:///some/system/path",
+			expectedModules: []string{
+				"/some/system/path/foo/policy.rego",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			parsedMods := tc.bundle.ParsedModules(tc.name)
+
+			for _, exp := range tc.expectedModules {
+				mod, ok := parsedMods[exp]
+				if !ok {
+					t.Fatalf("Missing expected module %s, got: %+v", exp, parsedMods)
+				}
+				if mod == nil {
+					t.Fatalf("Expected module to be non-nil")
+				}
+			}
+		})
+	}
+}

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -62,8 +62,8 @@ func checkModules(args []string) int {
 				outputErrors(err)
 				return 1
 			}
-			for _, mf := range b.Modules {
-				modules[mf.Path] = mf.Parsed
+			for name, mod := range b.ParsedModules(path) {
+				modules[name] = mod
 			}
 		}
 	} else {

--- a/cmd/deps.go
+++ b/cmd/deps.go
@@ -94,8 +94,8 @@ func deps(args []string, params depsCommandParams) error {
 				return err
 			}
 
-			for _, m := range b.Modules {
-				modules[m.Path] = m.Parsed
+			for name, mod := range b.ParsedModules(path) {
+				modules[name] = mod
 			}
 		}
 	}

--- a/plugins/discovery/discovery.go
+++ b/plugins/discovery/discovery.go
@@ -213,11 +213,7 @@ func processBundle(ctx context.Context, manager *plugins.Manager, factories map[
 
 func evaluateBundle(ctx context.Context, id string, info *ast.Term, b *bundleApi.Bundle, query string) (*config.Config, error) {
 
-	modules := map[string]*ast.Module{}
-
-	for _, file := range b.Modules {
-		modules[file.Path] = file.Parsed
-	}
+	modules := b.ParsedModules("discovery")
 
 	compiler := ast.NewCompiler()
 

--- a/rego/rego.go
+++ b/rego/rego.go
@@ -174,9 +174,9 @@ func (pq preparedQuery) Modules() map[string]*ast.Module {
 		mods[name] = mod
 	}
 
-	for _, b := range pq.r.bundles {
-		for _, mf := range b.Modules {
-			mods[mf.Path] = mf.Parsed
+	for path, b := range pq.r.bundles {
+		for name, mod := range b.ParsedModules(path) {
+			mods[name] = mod
 		}
 	}
 

--- a/tester/runner.go
+++ b/tester/runner.go
@@ -229,9 +229,9 @@ func (r *Runner) RunTests(ctx context.Context, txn storage.Transaction) (ch chan
 		if r.modules == nil {
 			r.modules = map[string]*ast.Module{}
 		}
-		for _, b := range r.bundles {
-			for _, mf := range b.Modules {
-				r.modules[mf.Path] = mf.Parsed
+		for path, b := range r.bundles {
+			for name, mod := range b.ParsedModules(path) {
+				r.modules[name] = mod
 			}
 		}
 	}


### PR DESCRIPTION
Previously we would internally reference modules by only their `path`
which was, for data files, the system path but bundles it is relative
to the root of the bundle. In theory data paths and bundle paths could
collide, but the real trouble is caused by multiple bundles. It was
very easy to have two bundles with identical file paths but different
packages and policies defined in them.

Internally we now reference bundle module id's as a combination of the
bundle name (or the file path for the bundle if loaded from CLI) and
the path within the bundle.

This does change the `id` a particular policy will show up at via the
storage ListPolicies and in turn REST API for OPA. This only affects
users that have switched to the `bundles` configuration option, or
that are using the `-b`/`--bundle` CLI options to load bundles. The
older style `bundle` config keyword and loading tarballs from as data
paths are still going to use the older ID.

Fixes: #1725
Signed-off-by: Patrick East <east.patrick@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
