### PR TITLE
allow to configure more then 1 service with discovery

### DIFF
--- a/docs/content/management.md
+++ b/docs/content/management.md
@@ -294,6 +294,7 @@ services:
 discovery:
   name: /example/discovery
   prefix: configuration
+  service: acmecorp
 ```
 
 Using the boot configuration above, OPA will fetch discovery bundles from:
@@ -301,14 +302,14 @@ Using the boot configuration above, OPA will fetch discovery bundles from:
 ```
 https://example.com/control-plane-api/v1/configuration/example/discovery
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^
-services[0].url                          |                   |
+services[discovery.service].url                          |                   |
                                          + discovery.prefix  |
                                                              + discovery.name
 ```
 
 > The `discovery.prefix` field defaults to `bundles`. The default is convenient if
 you want to serve discovery bundles and normal bundles from the same API
-endpoint.
+endpoint. If only one service is defined, there is no need to set `discovery.service`.
 
 OPA generates it's subsequent configuration by querying the Rego and JSON files
 contained inside the discovery bundle. The query is defined by the

--- a/plugins/discovery/config.go
+++ b/plugins/discovery/config.go
@@ -73,7 +73,10 @@ func (c *Config) validateAndInjectDefaults(services []string) error {
 }
 
 func (c *Config) getServiceFromList(service string, services []string) (string, error) {
-	if service == "" && len(services) != 0 {
+	if service == "" {
+		if len(services) != 1 {
+			return nil, fmt.Errorf("more than one service is defined")
+		}
 		return services[0], nil
 	}
 	for _, svc := range services {

--- a/plugins/discovery/config.go
+++ b/plugins/discovery/config.go
@@ -75,7 +75,7 @@ func (c *Config) validateAndInjectDefaults(services []string) error {
 func (c *Config) getServiceFromList(service string, services []string) (string, error) {
 	if service == "" {
 		if len(services) != 1 {
-			return nil, fmt.Errorf("more than one service is defined")
+			return "", fmt.Errorf("more than one service is defined")
 		}
 		return services[0], nil
 	}

--- a/plugins/discovery/config.go
+++ b/plugins/discovery/config.go
@@ -19,7 +19,7 @@ type Config struct {
 	Name            *string `json:"name"`     // name of the discovery bundle
 	Prefix          *string `json:"prefix"`   // path prefix for downloader
 	Decision        *string `json:"decision"` // the name of the query to run on the bundle to get the config
-	Service          string  `json:"service"` // the name of the service used to download discovery bundle from
+	Service         string  `json:"service"`  // the name of the service used to download discovery bundle from
 
 	service string
 	path    string
@@ -53,20 +53,12 @@ func (c *Config) validateAndInjectDefaults(services []string) error {
 		c.Prefix = &s
 	}
 
-	if (c.Service == "") {
-		if len(services) != 1 {
-			return fmt.Errorf("discovery requires exactly one service")
-		}
-
-		c.service = services[0]
-	} else {
-		service, err := c.getServiceFromList(c.Service, services)
-		if err != nil {
-			return fmt.Errorf("invalid configuration for decision service: %s", err.Error())
-		}
-
-		c.service = service
+	service, err := c.getServiceFromList(c.Service, services)
+	if err != nil {
+		return fmt.Errorf("invalid configuration for decision service: %s", err.Error())
 	}
+
+	c.service = service
 
 	decision := c.Decision
 

--- a/plugins/discovery/config_test.go
+++ b/plugins/discovery/config_test.go
@@ -101,7 +101,7 @@ func TestConfigService(t *testing.T) {
 		service  string
 	}{
 		{
-			input:    `{}`,
+			input:    `{"name": "a/b/c"}`,
 			services: []string{"service1"},
 			service:  "service1",
 		},

--- a/plugins/discovery/config_test.go
+++ b/plugins/discovery/config_test.go
@@ -21,6 +21,16 @@ func TestConfigValidation(t *testing.T) {
 			wantErr:  true,
 		},
 		{
+			input:    `{"name": "a/b/c", "service": "service1"}`,
+			services: []string{"service2"},
+			wantErr:  true,
+		},
+		{
+			input:    `{"name": "a/b/c", "service": "service1"}`,
+			services: []string{"service1", "service2"},
+			wantErr:  false,
+		},
+		{
 			input:    `{"name": "a/b/c"}`,
 			services: []string{"service1", "service2"},
 			wantErr:  true,
@@ -78,6 +88,38 @@ func TestConfigDecision(t *testing.T) {
 			}
 
 			if c.query != test.decision {
+				t.Fail()
+			}
+		})
+	}
+}
+
+func TestConfigService(t *testing.T) {
+	tests := []struct {
+		input    string
+		services []string
+		service  string
+	}{
+		{
+			input:    `{}`,
+			services: []string{"service1"},
+			service:  "service1",
+		},
+		{
+			input:    `{"name": "a/b/c", "service": "service1"}`,
+			services: []string{"service1", "service2"},
+			service:  "service1",
+		},
+	}
+
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("TestConfigService_case_%d", i), func(t *testing.T) {
+			c, err := ParseConfig([]byte(test.input), test.services)
+			if err != nil {
+				t.Fatal("unexpected error while parsing config")
+			}
+
+			if c.service != test.service {
 				t.Fail()
 			}
 		})


### PR DESCRIPTION
Signed-off-by: omerlh <omerl@soluto.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->

close #1714

In the issue, we also discussed enabling to change only services that are not used by discovery. I think this should be moved to a separate issue, as currently it is not supported at all to change service by discovery.

I'll be happy to get feedback on the changes - added `Service` field to discovery, exactly like in bundle source. If that looks good, I'll add tests + documentation.