### PR TITLE
cmd: Ensure errors are in JSON formatted output

### DIFF
--- a/internal/presentation/presentation_test.go
+++ b/internal/presentation/presentation_test.go
@@ -1,0 +1,104 @@
+// Copyright 2019 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package presentation
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/open-policy-agent/opa/ast"
+)
+
+type testErrorWithMarshaller struct {
+	msg string
+}
+
+func (t *testErrorWithMarshaller) Error() string {
+	return t.msg
+}
+
+func (t *testErrorWithMarshaller) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Text string `json:"text"`
+	}{
+		Text: t.msg,
+	})
+}
+
+func TestOutputJSONErrors(t *testing.T) {
+	cases := []struct {
+		note     string
+		err      error
+		expected string
+	}{
+		{
+			note: "unstructured error",
+			err:  errors.New("some text"),
+			expected: `{
+  "error": "some text"
+}
+`,
+		},
+		{
+			note: "structured error",
+			err: &ast.Error{
+				Code:    "1",
+				Message: "error message",
+			},
+			expected: `{
+  "error": {
+    "code": "1",
+    "message": "error message"
+  }
+}
+`,
+		},
+		{
+			note: "structured error list",
+			err: ast.Errors{&ast.Error{
+				Code:    "1",
+				Message: "error message",
+			}},
+			expected: `{
+  "error": [
+    {
+      "code": "1",
+      "message": "error message"
+    }
+  ]
+}
+`,
+		},
+		{
+			note: "custom marshaller",
+			err: &testErrorWithMarshaller{
+				msg: "custom message",
+			},
+			expected: `{
+  "error": {
+    "text": "custom message"
+  }
+}
+`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.note, func(t *testing.T) {
+			output := Output{Error: tc.err}
+			var buf bytes.Buffer
+			err := JSON(&buf, output)
+			if err != nil {
+				t.Fatalf("Unexpected error: %s", err)
+			}
+
+			if buf.String() != tc.expected {
+				t.Fatalf("Unexpected marshalled error value.\n Expected:\n\n%s\n\nActual:\n\n%s\n\n", tc.expected, buf.String())
+			}
+		})
+	}
+}


### PR DESCRIPTION
Previously if the errors passed into the presentation Output were not
structured w/ JSON tags for marshalling the error would be an empty
string.

This changes to wrap the errors with a struct in cases where they
would otherwise not be formatted.

Signed-off-by: Patrick East <east.patrick@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
