### PR TITLE
docs: Add redirect for /docs/latest/get-started

### DIFF
--- a/docs/website/layouts/404.html
+++ b/docs/website/layouts/404.html
@@ -41,7 +41,6 @@
       <p class="headline--subtitle">Perhaps you could use one of the following:</p>
       <a href="/">Open Policy Agent Home Page</a>
       <a href="/docs/latest">Documentation</a>
-      <a href="/docs/latest/get-started">Tutorials</a>
       <a href="https://play.openpolicyagent.org">Playground</a>
     </header>
   </body>

--- a/docs/website/layouts/index.redirects
+++ b/docs/website/layouts/index.redirects
@@ -7,6 +7,7 @@
 
 # v0.14.0 re-org redirects
 # TODO: Remove at some point in the future when its more ok to break old links en-mass
+/docs/latest/get-started                            /docs/latest/
 /docs/latest/how-does-opa-work/                     /docs/latest/#how-does-opa-work
 /docs/latest/how-do-i-write-policies/               /docs/latest/policy-language/
 /docs/latest/how-do-i-test-policies/                /docs/latest/policy-testing/


### PR DESCRIPTION
In the re-org we got rid of the getting started section and instead
have a more comprehensive/interactive introduction page. This change
adds a redirect to send /docs/latest/get-started URLs to /docs/latest
instead.

We also remove the link to it in the custom 404 page. Its the same
as the documentation URL now.

Signed-off-by: Patrick East <east.patrick@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
