### PR TITLE
repl: Fix unknown argument processing

### DIFF
--- a/repl/repl.go
+++ b/repl/repl.go
@@ -482,18 +482,27 @@ func (r *REPL) cmdTypes() error {
 	return nil
 }
 
+var errUnknownUsage = fmt.Errorf("usage: unknown <input/data reference> [<input/data reference> [...]] (hint: try 'input')")
+
 func (r *REPL) cmdUnknown(s []string) error {
+
 	if len(s) == 0 && len(r.unknowns) == 0 {
-		return fmt.Errorf("usage: unknown <unknown-1> [<unknown-2> [...]] (hint: try just 'input')")
+		return errUnknownUsage
 	}
-	r.unknowns = make([]*ast.Term, len(s))
-	for i := range r.unknowns {
+
+	unknowns := make([]*ast.Term, len(s))
+
+	for i := range unknowns {
+
 		ref, err := ast.ParseRef(s[i])
 		if err != nil {
-			return err
+			return errUnknownUsage
 		}
-		r.unknowns[i] = ast.NewTerm(ref)
+
+		unknowns[i] = ast.NewTerm(ref)
 	}
+
+	r.unknowns = unknowns
 	return nil
 }
 

--- a/repl/repl_test.go
+++ b/repl/repl_test.go
@@ -549,6 +549,26 @@ func TestUnknownJSON(t *testing.T) {
 	}
 }
 
+func TestUnknownInvalid(t *testing.T) {
+	ctx := context.Background()
+	store := inmem.New()
+	var buffer bytes.Buffer
+	repl := newRepl(store, &buffer)
+
+	err := repl.OneShot(ctx, "unknown x-1")
+	if err == nil || !strings.Contains(err.Error(), "usage: unknown <input/data reference>") {
+		t.Fatal("expected error from setting bad unknown but got:", err)
+	}
+
+	// Ensure that partial evaluation has not been enabled.
+	buffer.Reset()
+	repl.OneShot(ctx, "1+2")
+	result := strings.TrimSpace(buffer.String())
+	if result != "3" {
+		t.Fatal("want true but got:", result)
+	}
+}
+
 func TestUnset(t *testing.T) {
 	ctx := context.Background()
 	store := inmem.New()


### PR DESCRIPTION
The REPL's internal state was getting corrupted if an invalid unknown
term was given. For example `unknown x-1` would result in the unknown
set being allocated but it would contain an illegal nil element.

This fix just updates the REPL to avoid corrupting the internal state
if any of the unknown arguments are invalid.

Fixes #1670

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
