### PR TITLE
bundle: Ensure data paths use `/` separators for key

### DIFF
--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -387,7 +387,9 @@ func insertValue(b *Bundle, path string, value interface{}) error {
 	// Remove leading / and . characters from the directory path. If the bundle
 	// was written with OPA then the paths will contain a leading slash. On the
 	// other hand, if the path is empty, filepath.Dir will return '.'.
-	dirpath := strings.TrimLeft(filepath.Dir(path), "/.")
+	// Note: filepath.Dir can return paths with '\' separators, always use
+	// filepath.ToSlash to keep them normalized.
+	dirpath := strings.TrimLeft(filepath.ToSlash(filepath.Dir(path)), "/.")
 	var key []string
 	if dirpath != "" {
 		key = strings.Split(dirpath, "/")


### PR DESCRIPTION
Turns out on windows the filepath.Dir() call will give back paths that
are using `\` separators. This is problematic when we then go to split
the path with `/` to get the key. We need to make sure they are always
normalized to `/` separators.

Fixes: #1713
Signed-off-by: Patrick East <east.patrick@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
