### PR TITLE
build: Update to latest version of fuzzit

### DIFF
--- a/Dockerfile.fuzzit
+++ b/Dockerfile.fuzzit
@@ -16,5 +16,5 @@ RUN apt-get update \
 	&& go get -u github.com/dvyukov/go-fuzz/go-fuzz github.com/dvyukov/go-fuzz/go-fuzz-build \
 	&& go-fuzz-build -libfuzzer -o ast-fuzzer.a ./ast/ \
     && clang -fsanitize=fuzzer ast-fuzzer.a -o ast-fuzzer \
-    && wget -q -O fuzzit https://github.com/fuzzitdev/fuzzit/releases/download/v2.4.29/fuzzit_Linux_x86_64 \
+	&& wget -q -O fuzzit https://github.com/fuzzitdev/fuzzit/releases/download/v2.4.52/fuzzit_Linux_x86_64 \
 	&& chmod a+x fuzzit


### PR DESCRIPTION
The build is failing and the fuzzer output does not indicate what is
going wrong. The newest fuzzit behaves differently and seems to do
more work during the local-regression job. Updating to the latest to
see if this fixes it.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
