### PR TITLE
ast: Check for undefined functions before safety check

### DIFF
--- a/ast/check.go
+++ b/ast/check.go
@@ -218,6 +218,14 @@ func (tc *typeChecker) checkExprBuiltin(env *TypeEnv, expr *Expr) *Error {
 	args := expr.Operands()
 	pre := getArgTypes(env, args)
 
+	// NOTE(tsandall): undefined functions will have been caught earlier in the
+	// compiler. We check for undefined functions before the safety check so
+	// that references to non-existent functions result in undefined function
+	// errors as opposed to unsafe var errors.
+	//
+	// We cannot run type checking before the safety check because part of the
+	// type checker relies on reordering (in particular for references to local
+	// vars).
 	name := expr.Operator()
 	tpe := env.Get(name)
 


### PR DESCRIPTION
Previously, references to undefined functions were caught after the
safety check ran. As a result, if the function call contained one or
more unsafe variables, the compiler would report safety errors instead
of undefined function errors. This would hide the source of the
problem and result in confusion. For example, before:

> data.deadbeef(x)
1 error occurred: 1:1: rego_unsafe_var_error: var x is unsafe

After:

> data.deadbeef(x)
1 error occurred: 1:1: rego_type_error: undefined function data.deadbeef

Fixes #1141

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
