### PR TITLE
docs: Add pretty download URLs

### DIFF
--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -635,13 +635,13 @@ To get started download an OPA binary for your platform from GitHub releases:
 On macOS (64-bit):
 
 ```shell
-curl -L -o opa https://github.com/open-policy-agent/opa/releases/download/{{< current_version >}}/opa_darwin_amd64
+curl -L -o opa https://openpolicyagent.org/downloads/{{< current_version >}}/opa_darwin_amd64
 ```
 
 On Linux (64-bit):
 
 ```shell
-curl -L -o opa https://github.com/open-policy-agent/opa/releases/download/{{< current_version >}}/opa_linux_amd64
+curl -L -o opa https://openpolicyagent.org/downloads/{{< current_version >}}/opa_linux_amd64
 ```
 
 > Windows users can obtain the OPA executable from [GitHub

--- a/docs/website/layouts/index.redirects
+++ b/docs/website/layouts/index.redirects
@@ -25,3 +25,8 @@
 # Legacy git book redirects
 /docs/{{ . }}.html /docs/latest/{{ . }}
 {{- end }}
+
+# Download URLs
+/downloads/edge/*       https://opa-releases.s3.amazonaws.com/edge/:splat 200
+/downloads/latest/*     https://github.com/open-policy-agent/opa/releases/download/{{ $latest }}/:splat 200
+/downloads/*            https://github.com/open-policy-agent/opa/releases/download/:splat 200


### PR DESCRIPTION
This gives nicer download URLs for OPA binaries via:

`https://openpolicyagent.org/downloads/<version>/<binary>`

Under the hood we just use Netlify to rewrite the url to the normal
github and s3 locations.

With this you can also use:

`https://openpolicyagent.org/downloads/edge/<binary>`

and

`https://openpolicyagent.org/downloads/latest/<binary>`

For quick links to the current master and latest release binaries.

Fixes: #1771
Signed-off-by: Patrick East <east.patrick@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
