### PR TITLE
bundle: Fix for overwriting data file keys

### DIFF
--- a/bundle/bundle_test.go
+++ b/bundle/bundle_test.go
@@ -11,9 +11,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/open-policy-agent/opa/internal/file/archive"
-
 	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/internal/file/archive"
 )
 
 func TestRead(t *testing.T) {
@@ -23,6 +22,7 @@ func TestRead(t *testing.T) {
 		{"/a/b/d/data.json", "true"},
 		{"/a/b/y/data.yaml", `foo: 1`},
 		{"/example/example.rego", `package example`},
+		{"/data.json", `{"x": {"y": true}, "a": {"b": {"z": true}}}}`},
 	}
 
 	buf := archive.MustWriteTarGz(files)
@@ -42,7 +42,11 @@ func TestRead(t *testing.T) {
 					"y": map[string]interface{}{
 						"foo": json.Number("1"),
 					},
+					"z": true,
 				},
+			},
+			"x": map[string]interface{}{
+				"y": true,
 			},
 		},
 		Modules: []ModuleFile{
@@ -55,7 +59,7 @@ func TestRead(t *testing.T) {
 	}
 
 	if !exp.Equal(bundle) {
-		t.Fatal("Exp:", exp, "\n\nGot:", bundle)
+		t.Fatal("\nExp:", exp, "\n\nGot:", bundle)
 	}
 }
 
@@ -216,6 +220,10 @@ func TestReadErrorBadContents(t *testing.T) {
 			{"a/b/c/data.json", "true"},
 		}},
 		{[][2]string{{"/test.rego", ""}}},
+		{[][2]string{
+			{"/a/b/data.json", `{"c": "foo"}`},
+			{"/data.json", `{"a": {"b": {"c": [123]}}}`},
+		}},
 	}
 	for _, test := range tests {
 		buf := archive.MustWriteTarGz(test.files)

--- a/internal/merge/merge.go
+++ b/internal/merge/merge.go
@@ -2,11 +2,11 @@
 // Use of this source code is governed by an Apache2
 // license that can be found in the LICENSE file.
 
-package loader
+package merge
 
-// mergeInterfaces returns the result of merging a and b. If a and b cannot be
+// InterfaceMaps returns the result of merging a and b. If a and b cannot be
 // merged because of conflicting key-value pairs, ok is false.
-func mergeInterfaces(a map[string]interface{}, b map[string]interface{}) (c map[string]interface{}, ok bool) {
+func InterfaceMaps(a map[string]interface{}, b map[string]interface{}) (c map[string]interface{}, ok bool) {
 
 	c = map[string]interface{}{}
 	for k := range a {
@@ -28,7 +28,7 @@ func mergeInterfaces(a map[string]interface{}, b map[string]interface{}) (c map[
 			return nil, false
 		}
 
-		c[k], ok = mergeInterfaces(existObj, addObj)
+		c[k], ok = InterfaceMaps(existObj, addObj)
 		if !ok {
 			return nil, false
 		}

--- a/internal/merge/merge.go
+++ b/internal/merge/merge.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by an Apache2
 // license that can be found in the LICENSE file.
 
+// Package merge contains helpers to merge data structures
+// frequently encountered in OPA.
 package merge
 
 // InterfaceMaps returns the result of merging a and b. If a and b cannot be

--- a/internal/merge/merge_test.go
+++ b/internal/merge/merge_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by an Apache2
 // license that can be found in the LICENSE file.
 
-package loader
+package merge
 
 import (
 	"reflect"
@@ -38,7 +38,7 @@ func TestMergeDocs(t *testing.T) {
 
 		if len(tc.c) == 0 {
 
-			c, ok := mergeInterfaces(a, b)
+			c, ok := InterfaceMaps(a, b)
 			if ok {
 				t.Errorf("Expected merge(%v,%v) == false but got: %v", a, b, c)
 			}
@@ -50,7 +50,7 @@ func TestMergeDocs(t *testing.T) {
 				panic(err)
 			}
 
-			c, ok := mergeInterfaces(a, b)
+			c, ok := InterfaceMaps(a, b)
 			if !ok || !reflect.DeepEqual(c, expected) {
 				t.Errorf("Expected merge(%v, %v) == %v but got: %v (ok: %v)", a, b, expected, c, ok)
 			}

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -14,14 +14,16 @@ import (
 	"strings"
 
 	"github.com/ghodss/yaml"
+	"github.com/pkg/errors"
+
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/bundle"
 	"github.com/open-policy-agent/opa/internal/file"
 	fileurl "github.com/open-policy-agent/opa/internal/file/url"
+	"github.com/open-policy-agent/opa/internal/merge"
 	"github.com/open-policy-agent/opa/storage"
 	"github.com/open-policy-agent/opa/storage/inmem"
 	"github.com/open-policy-agent/opa/util"
-	"github.com/pkg/errors"
 )
 
 // Result represents the result of successfully loading zero or more files.
@@ -226,7 +228,7 @@ func (l *Result) mergeDocument(path string, doc interface{}) error {
 	if !ok {
 		return unsupportedDocumentType(path)
 	}
-	merged, ok := mergeInterfaces(l.Documents, obj)
+	merged, ok := merge.InterfaceMaps(l.Documents, obj)
 	if !ok {
 		return mergeError(path)
 	}


### PR DESCRIPTION
This fixes the issue where the order of data files changed the end resulting data object loaded from bundles.

The main issue being that we were not merging the data files consistently, we would allow later data files to overwrite keys, or (if at the root path) the entire document.

This now shares the same merge algorithm that the loader uses.

Fixes: #1763 