### PR TITLE
docs: Fix opa-istio image version for latest version of the docs

### DIFF
--- a/docs/website/layouts/shortcodes/current_opa_istio_docker_version.html
+++ b/docs/website/layouts/shortcodes/current_opa_istio_docker_version.html
@@ -1,5 +1,5 @@
 {{- $version := index (split $.Page.File.Path "/") 1 -}}
-{{- if (eq $version "edge") -}}
+{{- if or (eq $version "edge") (eq $version "latest") -}}
 latest-istio
 {{- else -}}
 {{- strings.TrimPrefix "v" $version -}}


### PR DESCRIPTION
Since the url for the latest released version of the docs does not contain the OPA version, this change updates the shortcode to use the latest-istio tag for the opa-istio image for latest and edge versions of the OPA docs.

Signed-off-by: Ashutosh Narkar <anarkar4387@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
