### PR TITLE
docs: Fix config reference doc links

### DIFF
--- a/docs/content/management.md
+++ b/docs/content/management.md
@@ -63,7 +63,7 @@ By default, the OPA REST APIs will prevent you from modifying policy and data
 loaded via bundles. If you need to load policy and data from multiple sources,
 see the section below.
 
-See the [Configuration Reference](#configuration-reference) for configuration details.
+See the [Configuration Reference](../configuration) for configuration details.
 
 ### Bundle Service API
 
@@ -276,7 +276,7 @@ that enables auditing and offline debugging of policy decisions.
 When decision logging is enabled the OPA server will include a `decision_id`
 field in API calls that return policy decisions.
 
-See the [Configuration Reference](#configuration-reference) for configuration details.
+See the [Configuration Reference](../configuration) for configuration details.
 
 ### Decision Log Service API
 
@@ -351,7 +351,7 @@ decision_logs:
 ```
 
 This will dump all decision through the OPA logging system at the `info` level. See
-[Configuration Reference](#configuration-reference) for more details.
+[Configuration Reference](../configuration) for more details.
 
 
 ### Masking Sensitive Data
@@ -439,7 +439,7 @@ OPA instance. OPA automatically includes an `id` value in the label set that
 provides a globally unique identifier or the running OPA instance and a
 `version` value that provides the version of OPA.
 
-See the [Configuration Reference](#configuration-reference) for configuration details.
+See the [Configuration Reference](../configuration) for configuration details.
 
 ### Status Service API
 
@@ -653,7 +653,7 @@ reporting **cannot** be configured manually. Similarly, discovered configuration
 cannot override the original discovery settings in the configuration file that
 OPA was booted with.
 
-See the [Configuration Reference](#configuration-reference) for configuration details.
+See the [Configuration Reference](../configuration) for configuration details.
 
 ### Discovery Service API
 

--- a/docs/content/rest-api.md
+++ b/docs/content/rest-api.md
@@ -1370,7 +1370,7 @@ If the default decision (defaulting to `/system/main`) is undefined, the server 
 
 The policy example below shows how to define a rule that will
 produce a value for the `/data/system/main` document. You can configure OPA
-to use a different URL path to serve these queries. See the [Configuration Reference](../management/#configuration-reference)
+to use a different URL path to serve these queries. See the [Configuration Reference](../configuration)
 for more information.
 
 The request message body is mapped to the [Input Document](../#the-input-document).


### PR DESCRIPTION
We pulled the config docs out into their own section from the
/management page. In the process we missed some links that needed
updating.

Signed-off-by: Patrick East <east.patrick@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
