### PR TITLE
v0.14.1 backports and release prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file. This
 project adheres to [Semantic Versioning](http://semver.org/).
 
+## 0.14.1
+
+- Fix a number of links in the OPA documentation.
+- Fix issue with bundle root path comparisons on Windows.
+
 ## 0.14.0
 
 This release includes a large number of improvements to the docs as

--- a/Dockerfile.fuzzit
+++ b/Dockerfile.fuzzit
@@ -16,5 +16,5 @@ RUN apt-get update \
 	&& go get -u github.com/dvyukov/go-fuzz/go-fuzz github.com/dvyukov/go-fuzz/go-fuzz-build \
 	&& go-fuzz-build -libfuzzer -o ast-fuzzer.a ./ast/ \
     && clang -fsanitize=fuzzer ast-fuzzer.a -o ast-fuzzer \
-    && wget -q -O fuzzit https://github.com/fuzzitdev/fuzzit/releases/download/v2.4.29/fuzzit_Linux_x86_64 \
+	&& wget -q -O fuzzit https://github.com/fuzzitdev/fuzzit/releases/download/v2.4.52/fuzzit_Linux_x86_64 \
 	&& chmod a+x fuzzit

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Use of this source code is governed by an Apache2
 # license that can be found in the LICENSE file.
 
-VERSION := 0.14.0
+VERSION := 0.14.1
 
 GO := go
 GOVERSION := 1.12.9

--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -387,7 +387,9 @@ func insertValue(b *Bundle, path string, value interface{}) error {
 	// Remove leading / and . characters from the directory path. If the bundle
 	// was written with OPA then the paths will contain a leading slash. On the
 	// other hand, if the path is empty, filepath.Dir will return '.'.
-	dirpath := strings.TrimLeft(filepath.Dir(path), "/.")
+	// Note: filepath.Dir can return paths with '\' separators, always use
+	// filepath.ToSlash to keep them normalized.
+	dirpath := strings.TrimLeft(filepath.ToSlash(filepath.Dir(path)), "/.")
 	var key []string
 	if dirpath != "" {
 		key = strings.Split(dirpath, "/")

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -635,13 +635,13 @@ To get started download an OPA binary for your platform from GitHub releases:
 On macOS (64-bit):
 
 ```shell
-curl -L -o opa https://github.com/open-policy-agent/opa/releases/download/{{< current_version >}}/opa_darwin_amd64
+curl -L -o opa https://openpolicyagent.org/downloads/{{< current_version >}}/opa_darwin_amd64
 ```
 
 On Linux (64-bit):
 
 ```shell
-curl -L -o opa https://github.com/open-policy-agent/opa/releases/download/{{< current_version >}}/opa_linux_amd64
+curl -L -o opa https://openpolicyagent.org/downloads/{{< current_version >}}/opa_linux_amd64
 ```
 
 > Windows users can obtain the OPA executable from [GitHub

--- a/docs/content/management.md
+++ b/docs/content/management.md
@@ -63,7 +63,7 @@ By default, the OPA REST APIs will prevent you from modifying policy and data
 loaded via bundles. If you need to load policy and data from multiple sources,
 see the section below.
 
-See the [Configuration Reference](#configuration-reference) for configuration details.
+See the [Configuration Reference](../configuration) for configuration details.
 
 ### Bundle Service API
 
@@ -276,7 +276,7 @@ that enables auditing and offline debugging of policy decisions.
 When decision logging is enabled the OPA server will include a `decision_id`
 field in API calls that return policy decisions.
 
-See the [Configuration Reference](#configuration-reference) for configuration details.
+See the [Configuration Reference](../configuration) for configuration details.
 
 ### Decision Log Service API
 
@@ -351,7 +351,7 @@ decision_logs:
 ```
 
 This will dump all decision through the OPA logging system at the `info` level. See
-[Configuration Reference](#configuration-reference) for more details.
+[Configuration Reference](../configuration) for more details.
 
 
 ### Masking Sensitive Data
@@ -439,7 +439,7 @@ OPA instance. OPA automatically includes an `id` value in the label set that
 provides a globally unique identifier or the running OPA instance and a
 `version` value that provides the version of OPA.
 
-See the [Configuration Reference](#configuration-reference) for configuration details.
+See the [Configuration Reference](../configuration) for configuration details.
 
 ### Status Service API
 
@@ -653,7 +653,7 @@ reporting **cannot** be configured manually. Similarly, discovered configuration
 cannot override the original discovery settings in the configuration file that
 OPA was booted with.
 
-See the [Configuration Reference](#configuration-reference) for configuration details.
+See the [Configuration Reference](../configuration) for configuration details.
 
 ### Discovery Service API
 

--- a/docs/content/rest-api.md
+++ b/docs/content/rest-api.md
@@ -1370,7 +1370,7 @@ If the default decision (defaulting to `/system/main`) is undefined, the server 
 
 The policy example below shows how to define a rule that will
 produce a value for the `/data/system/main` document. You can configure OPA
-to use a different URL path to serve these queries. See the [Configuration Reference](../management/#configuration-reference)
+to use a different URL path to serve these queries. See the [Configuration Reference](../configuration)
 for more information.
 
 The request message body is mapped to the [Input Document](../#the-input-document).

--- a/docs/website/layouts/index.redirects
+++ b/docs/website/layouts/index.redirects
@@ -12,3 +12,8 @@
 # Legacy git book redirects
 /docs/{{ . }}.html /docs/latest/{{ . }}
 {{- end }}
+
+# Download URLs
+/downloads/edge/*       https://opa-releases.s3.amazonaws.com/edge/:splat 200
+/downloads/latest/*     https://github.com/open-policy-agent/opa/releases/download/{{ $latest }}/:splat 200
+/downloads/*            https://github.com/open-policy-agent/opa/releases/download/:splat 200

--- a/docs/website/layouts/shortcodes/current_opa_istio_docker_version.html
+++ b/docs/website/layouts/shortcodes/current_opa_istio_docker_version.html
@@ -1,5 +1,5 @@
 {{- $version := index (split $.Page.File.Path "/") 1 -}}
-{{- if (eq $version "edge") -}}
+{{- if or (eq $version "edge") (eq $version "latest") -}}
 latest-istio
 {{- else -}}
 {{- strings.TrimPrefix "v" $version -}}

--- a/docs/website/scripts/live-blocks/src/preprocess/acquireOPAVersion.js
+++ b/docs/website/scripts/live-blocks/src/preprocess/acquireOPAVersion.js
@@ -79,7 +79,7 @@ async function getAssetURL(version) {
   if (version === VERSION_LATEST) {
     releaseURL = `https://api.github.com/repos/open-policy-agent/opa/releases/latest`
   } else {
-    releaseURL = `https://api.github.com/repos/open-policy-agent/opa/releases/tags/v${version}`;
+    releaseURL = `https://api.github.com/repos/open-policy-agent/opa/releases/tags/${version}`;
   }
 
   try {


### PR DESCRIPTION
This PR includes a handful of cherry-picked fixes for documentation and bundle manifests for windows. I grouped them together with the updates to prep a v0.14.1 release.
