### PR TITLE
Ensure all errors are in JSON formatted CLI output

### DIFF
--- a/ast/parser_ext.go
+++ b/ast/parser_ext.go
@@ -763,12 +763,13 @@ func (vt *varToRefTransformer) Transform(x interface{}) (interface{}, error) {
 	return x, nil
 }
 
-type parserErrorDetail struct {
-	line string
-	idx  int
+// ParserErrorDetail holds additional details for parser errors.
+type ParserErrorDetail struct {
+	Line string `json:"line"`
+	Idx  int    `json:"idx"`
 }
 
-func newParserErrorDetail(bs []byte, pos position) *parserErrorDetail {
+func newParserErrorDetail(bs []byte, pos position) *ParserErrorDetail {
 
 	offset := pos.offset
 
@@ -809,16 +810,17 @@ func newParserErrorDetail(bs []byte, pos position) *parserErrorDetail {
 	line := bs[begin:end]
 	index := offset - begin
 
-	return &parserErrorDetail{
-		line: string(line),
-		idx:  index,
+	return &ParserErrorDetail{
+		Line: string(line),
+		Idx:  index,
 	}
 }
 
-func (d parserErrorDetail) Lines() []string {
-	line := strings.TrimLeft(d.line, "\t") // remove leading tabs
-	tabCount := len(d.line) - len(line)
-	return []string{line, strings.Repeat(" ", d.idx-tabCount) + "^"}
+// Lines returns the pretty formatted line output for the error details.
+func (d ParserErrorDetail) Lines() []string {
+	line := strings.TrimLeft(d.Line, "\t") // remove leading tabs
+	tabCount := len(d.Line) - len(line)
+	return []string{line, strings.Repeat(" ", d.Idx-tabCount) + "^"}
 }
 
 func isNewLineChar(b byte) bool {

--- a/ast/parser_test.go
+++ b/ast/parser_test.go
@@ -1542,15 +1542,15 @@ func TestParseErrorDetails(t *testing.T) {
 
 	tests := []struct {
 		note  string
-		exp   *parserErrorDetail
+		exp   *ParserErrorDetail
 		err   string
 		input string
 	}{
 		{
 			note: "no match: bad rule name",
-			exp: &parserErrorDetail{
-				line: ".",
-				idx:  0,
+			exp: &ParserErrorDetail{
+				Line: ".",
+				Idx:  0,
 			},
 			input: `
 package test
@@ -1558,54 +1558,54 @@ package test
 		},
 		{
 			note: "no match: bad termination for comprehension",
-			exp: &parserErrorDetail{
-				line: "p = [true | true}",
-				idx:  16,
+			exp: &ParserErrorDetail{
+				Line: "p = [true | true}",
+				Idx:  16,
 			},
 			input: `
 package test
 p = [true | true}`},
 		{
 			note: "no match: non-terminated comprehension",
-			exp: &parserErrorDetail{
-				line: "p = [true | true",
-				idx:  15,
+			exp: &ParserErrorDetail{
+				Line: "p = [true | true",
+				Idx:  15,
 			},
 			input: `
 package test
 p = [true | true`},
 		{
 			note: "no match: expected expression",
-			exp: &parserErrorDetail{
-				line: "p { true; }",
-				idx:  10,
+			exp: &ParserErrorDetail{
+				Line: "p { true; }",
+				Idx:  10,
 			},
 			input: `
 package test
 p { true; }`},
 		{
 			note: "empty body",
-			exp: &parserErrorDetail{
-				line: "p { }",
-				idx:  2,
+			exp: &ParserErrorDetail{
+				Line: "p { }",
+				Idx:  2,
 			},
 			input: `
 package test
 p { }`},
 		{
 			note: "non-terminated string",
-			exp: &parserErrorDetail{
-				line: `p = "foo`,
-				idx:  4,
+			exp: &ParserErrorDetail{
+				Line: `p = "foo`,
+				Idx:  4,
 			},
 			input: `
 package test
 p = "foo`},
 		{
 			note: "rule with error begins with one tab",
-			exp: &parserErrorDetail{
-				line: "\tas",
-				idx:  2,
+			exp: &ParserErrorDetail{
+				Line: "\tas",
+				Idx:  2,
 			},
 			input: `
 package test
@@ -1615,9 +1615,9 @@ package test
 	 ^`},
 		{
 			note: "rule term with error begins with two tabs",
-			exp: &parserErrorDetail{
-				line: "\t\tas",
-				idx:  3,
+			exp: &ParserErrorDetail{
+				Line: "\t\tas",
+				Idx:  3,
 			},
 			input: `
 package test

--- a/cmd/eval_test.go
+++ b/cmd/eval_test.go
@@ -288,7 +288,7 @@ func TestEvalErrorJSONOutput(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if output["error"] == nil {
+	if output["errors"] == nil {
 		t.Fatalf("Expected error to be non-nil")
 	}
 

--- a/cmd/parse.go
+++ b/cmd/parse.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/open-policy-agent/opa/ast"
+	pr "github.com/open-policy-agent/opa/internal/presentation"
 	"github.com/open-policy-agent/opa/loader"
 	"github.com/open-policy-agent/opa/util"
 )
@@ -49,13 +50,14 @@ func parse(args []string) int {
 	}
 
 	result, err := loader.Rego(args[0])
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		return 1
-	}
 
 	switch parseParams.format.String() {
 	case parseFormatJSON:
+		if err != nil {
+			pr.JSON(os.Stderr, pr.Output{Errors: pr.NewOutputErrors(err)})
+			return 1
+		}
+
 		bs, err := json.MarshalIndent(result.Parsed, "", "  ")
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)

--- a/internal/presentation/presentation_test.go
+++ b/internal/presentation/presentation_test.go
@@ -1,0 +1,360 @@
+// Copyright 2019 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package presentation
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/loader"
+	"github.com/open-policy-agent/opa/rego"
+	"github.com/open-policy-agent/opa/storage"
+	"github.com/open-policy-agent/opa/storage/inmem"
+	"github.com/open-policy-agent/opa/util/test"
+)
+
+type testErrorWithMarshaller struct {
+	msg string
+}
+
+func (t *testErrorWithMarshaller) Error() string {
+	return t.msg
+}
+
+func (t *testErrorWithMarshaller) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Text string `json:"text"`
+	}{
+		Text: t.msg,
+	})
+}
+
+func validateJSONOutput(t *testing.T, testErr error, expected string) {
+	t.Helper()
+	output := Output{Errors: NewOutputErrors(testErr)}
+	var buf bytes.Buffer
+	err := JSON(&buf, output)
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
+
+	if buf.String() != expected {
+		t.Fatalf("Unexpected marshalled error value.\n Expected (len=%d):\n>>>\n%s\n<<<\n\nActual (len=%d):\n>>>>\n%s\n<<<<\n",
+			len(expected), expected, len(buf.String()), buf.String())
+	}
+}
+
+func TestOutputJSONErrorUnstructured(t *testing.T) {
+	err := errors.New("some text")
+	expected := `{
+  "errors": [
+    {
+      "message": "some text"
+    }
+  ]
+}
+`
+
+	validateJSONOutput(t, err, expected)
+}
+
+func TestOutputJSONErrorCustomMarshaller(t *testing.T) {
+	err := &testErrorWithMarshaller{
+		msg: "custom message",
+	}
+	expected := `{
+  "errors": [
+    {
+      "message": "custom message"
+    }
+  ]
+}
+`
+
+	validateJSONOutput(t, err, expected)
+}
+
+func TestOutputJSONErrorStructuredASTErr(t *testing.T) {
+	err := &ast.Error{
+		Code:    "1",
+		Message: "error message",
+	}
+	expected := `{
+  "errors": [
+    {
+      "message": "error message",
+      "code": "1"
+    }
+  ]
+}
+`
+
+	validateJSONOutput(t, err, expected)
+}
+
+func TestOutputJSONErrorStructuredStorageErr(t *testing.T) {
+	store := inmem.New()
+	txn := storage.NewTransactionOrDie(context.Background(), store)
+	err := store.Write(context.Background(), txn, storage.AddOp, storage.Path{}, map[string]interface{}{"foo": 1})
+	expected := `{
+  "errors": [
+    {
+      "message": "data write during read transaction",
+      "code": "storage_invalid_txn_error"
+    }
+  ]
+}
+`
+
+	validateJSONOutput(t, err, expected)
+}
+
+func TestOutputJSONErrorStructuredTopdownErr(t *testing.T) {
+	mod := `
+		package test
+
+		p(x) = y {
+			y = x[_]
+		}
+		
+		z := p([1, 2, 3])
+		`
+
+	_, err := rego.New(
+		rego.Module("test.rego", mod),
+		rego.Query("data.test.z"),
+	).Eval(context.Background())
+
+	expected := `{
+  "errors": [
+    {
+      "message": "functions must not produce multiple outputs for same inputs",
+      "code": "eval_conflict_error",
+      "location": {
+        "file": "test.rego",
+        "row": 4,
+        "col": 3
+      }
+    }
+  ]
+}
+`
+
+	validateJSONOutput(t, err, expected)
+}
+
+func TestOutputJSONErrorStructuredAstErr(t *testing.T) {
+	_, err := rego.New(rego.Query("count(0)")).Eval(context.Background())
+	expected := `{
+  "errors": [
+    {
+      "message": "count: invalid argument(s)",
+      "code": "rego_type_error",
+      "location": {
+        "file": "",
+        "row": 1,
+        "col": 1
+      },
+      "details": {
+        "have": [
+          {
+            "type": "number"
+          },
+          null
+        ],
+        "want": [
+          {
+            "of": [
+              {
+                "of": {
+                  "of": [],
+                  "type": "any"
+                },
+                "type": "set"
+              },
+              {
+                "dynamic": {
+                  "of": [],
+                  "type": "any"
+                },
+                "type": "array"
+              },
+              {
+                "dynamic": {
+                  "key": {
+                    "of": [],
+                    "type": "any"
+                  },
+                  "value": {
+                    "of": [],
+                    "type": "any"
+                  }
+                },
+                "type": "object"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "type": "any"
+          },
+          {
+            "type": "number"
+          }
+        ]
+      }
+    }
+  ]
+}
+`
+
+	validateJSONOutput(t, err, expected)
+}
+
+func TestOutputJSONErrorStructuredAstParseErr(t *testing.T) {
+	_, err := rego.New(
+		rego.Module("parse-err.rego", "!!!"),
+		rego.Query("!!!"),
+	).Eval(context.Background())
+
+	expected := `{
+  "errors": [
+    {
+      "message": "no match found",
+      "code": "rego_parse_error",
+      "location": {
+        "file": "parse-err.rego",
+        "row": 1,
+        "col": 1
+      },
+      "details": {
+        "line": "!!!",
+        "idx": 0
+      }
+    }
+  ]
+}
+`
+
+	validateJSONOutput(t, err, expected)
+}
+
+func TestOutputJSONErrorStructuredASTErrList(t *testing.T) {
+	c := ast.NewCompiler()
+	c.Compile(map[string]*ast.Module{
+		"error.rego": ast.MustParseModule(`
+package test
+
+q {
+	bad[reference]
+}
+`)})
+	c.Errors.Sort()
+	err := c.Errors
+
+	expected := `{
+  "errors": [
+    {
+      "message": "var bad is unsafe",
+      "code": "rego_unsafe_var_error",
+      "location": {
+        "file": "",
+        "row": 5,
+        "col": 2
+      }
+    },
+    {
+      "message": "var reference is unsafe",
+      "code": "rego_unsafe_var_error",
+      "location": {
+        "file": "",
+        "row": 5,
+        "col": 2
+      }
+    }
+  ]
+}
+`
+
+	validateJSONOutput(t, err, expected)
+}
+
+func TestOutputJSONErrorStructuredLoaderErrList(t *testing.T) {
+	files := map[string]string{
+		// bundle a
+		"a/data.json": "{{{",
+		"b/data.json": "...",
+	}
+
+	var err error
+	var tmpPath string
+	test.WithTempFS(files, func(path string) {
+		tmpPath = path
+		_, err = loader.All([]string{path})
+	})
+
+	expected := fmt.Sprintf(`{
+  "errors": [
+    {
+      "message": "%s/a/data.json: invalid character '{' looking for beginning of object key string"
+    },
+    {
+      "message": "%s/b/data.json: invalid character '.' looking for beginning of value"
+    }
+  ]
+}
+`, tmpPath, tmpPath)
+
+	validateJSONOutput(t, err, expected)
+}
+
+func TestOutputJSONErrorStructuredRegoErrList(t *testing.T) {
+	mod := `
+package test
+
+p {
+	bad_func1()
+}
+
+q {
+	bad_func2()
+}
+`
+	_, err := rego.New(
+		rego.Module("error.rego", mod),
+		rego.Query("data"),
+	).PrepareForEval(context.Background())
+
+	expected := `{
+  "errors": [
+    {
+      "message": "undefined function bad_func1",
+      "code": "rego_type_error",
+      "location": {
+        "file": "error.rego",
+        "row": 5,
+        "col": 2
+      }
+    },
+    {
+      "message": "undefined function bad_func2",
+      "code": "rego_type_error",
+      "location": {
+        "file": "error.rego",
+        "row": 9,
+        "col": 2
+      }
+    }
+  ]
+}
+`
+
+	validateJSONOutput(t, err, expected)
+}

--- a/loader/errors.go
+++ b/loader/errors.go
@@ -11,9 +11,10 @@ import (
 	"github.com/open-policy-agent/opa/ast"
 )
 
-type loaderErrors []error
+// Errors is a wrapper for multiple loader errors.
+type Errors []error
 
-func (e loaderErrors) Error() string {
+func (e Errors) Error() string {
 	if len(e) == 0 {
 		return "no error(s)"
 	}
@@ -27,7 +28,7 @@ func (e loaderErrors) Error() string {
 	return fmt.Sprintf("%v errors occurred during loading:\n", len(e)) + strings.Join(buf, "\n")
 }
 
-func (e *loaderErrors) Add(err error) {
+func (e *Errors) add(err error) {
 	if errs, ok := err.(ast.Errors); ok {
 		for i := range errs {
 			*e = append(*e, errs[i])

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -248,7 +248,7 @@ func (l *Result) withParent(p string) *Result {
 }
 
 func all(paths []string, filter Filter, f func(*Result, string, int) error) (*Result, error) {
-	errors := loaderErrors{}
+	errors := Errors{}
 	root := newResult()
 
 	for _, path := range paths {
@@ -274,17 +274,17 @@ func all(paths []string, filter Filter, f func(*Result, string, int) error) (*Re
 	return root, nil
 }
 
-func allRec(path string, filter Filter, errors *loaderErrors, loaded *Result, depth int, f func(*Result, string, int) error) {
+func allRec(path string, filter Filter, errors *Errors, loaded *Result, depth int, f func(*Result, string, int) error) {
 
 	path, err := fileurl.Clean(path)
 	if err != nil {
-		errors.Add(err)
+		errors.add(err)
 		return
 	}
 
 	info, err := os.Stat(path)
 	if err != nil {
-		errors.Add(err)
+		errors.add(err)
 		return
 	}
 
@@ -294,7 +294,7 @@ func allRec(path string, filter Filter, errors *loaderErrors, loaded *Result, de
 
 	if !info.IsDir() {
 		if err := f(loaded, path, depth); err != nil {
-			errors.Add(err)
+			errors.add(err)
 		}
 		return
 	}
@@ -307,7 +307,7 @@ func allRec(path string, filter Filter, errors *loaderErrors, loaded *Result, de
 
 	files, err := ioutil.ReadDir(path)
 	if err != nil {
-		errors.Add(err)
+		errors.add(err)
 		return
 	}
 

--- a/rego/rego.go
+++ b/rego/rego.go
@@ -1254,7 +1254,7 @@ func (r *Rego) parseModules(ctx context.Context, txn storage.Transaction, m metr
 	}
 
 	if len(errs) > 0 {
-		return errors.New(errs.Error())
+		return errs
 	}
 
 	return nil
@@ -1266,7 +1266,7 @@ func (r *Rego) loadFiles(ctx context.Context, txn storage.Transaction, m metrics
 
 	result, err := loader.Filtered(r.loadPaths.paths, r.loadPaths.filter)
 	if err != nil {
-		return fmt.Errorf("error loading paths: %s", err)
+		return err
 	}
 	for name, mod := range result.Modules {
 		r.parsedModules[name] = mod.Parsed
@@ -1275,7 +1275,7 @@ func (r *Rego) loadFiles(ctx context.Context, txn storage.Transaction, m metrics
 	if len(result.Documents) > 0 {
 		err = r.store.Write(ctx, txn, storage.AddOp, storage.Path{}, result.Documents)
 		if err != nil {
-			return fmt.Errorf("error writing loaded documents to store: %s", err)
+			return err
 		}
 	}
 	return nil

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -864,7 +864,7 @@ func (r *REPL) evalBody(ctx context.Context, compiler *ast.Compiler, input ast.V
 	rs, err := eval.Eval(ctx)
 
 	output := pr.Output{
-		Error:   err,
+		Errors:  pr.NewOutputErrors(err),
 		Result:  rs,
 		Metrics: r.metrics,
 	}
@@ -920,7 +920,7 @@ func (r *REPL) evalPartial(ctx context.Context, compiler *ast.Compiler, input as
 	output := pr.Output{
 		Metrics: r.metrics,
 		Partial: pq,
-		Error:   err,
+		Errors:  pr.NewOutputErrors(err),
 	}
 
 	switch r.explain {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -3027,7 +3027,10 @@ func TestBadQueryV1(t *testing.T) {
         "row": 1,
         "col": 1
       },
-      "details": {}
+      "details": {
+        "line": "^ -i",
+        "idx": 0
+      }
     }
   ]
 }`


### PR DESCRIPTION
Previously if the errors passed into the presentation Output were not
structured w/ JSON tags for marshaling the error would be an empty
string.

This changes to wrap the errors with a struct in cases where they
would otherwise not be formatted. We do this by forcing every error
into a structure and translating known error types into it.

Signed-off-by: Patrick East <east.patrick@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
