### PR TITLE
discovery: Support `resource` configuration option

### DIFF
--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -70,8 +70,8 @@ services:
         token: "${BEARER_TOKEN}"
 
 discovery:
-  name: /example/discovery
-  prefix: configuration
+  name: example
+  resource: /configuration/example/discovery
 ```
 The environment variables `BASE_URL` and `BEARER_TOKEN` will be substituted in when the config
 file is loaded by the OPA runtime.
@@ -363,7 +363,8 @@ server provenance, etc.
 | Field | Type | Required | Description |
 | --- | --- | --- | --- |
 | `discovery.name` | `string` | Yes | Name of the discovery configuration to download. |
-| `discovery.prefix` | `string` | No (default: `bundles`) | Path prefix to use to download configuration from remote server. |
+| `discovery.resource` | `string` | No (default: `/bundles/<name>` | Resource path to use to download bundle from configured service. |
+| `discovery.prefix` | `string` | No (default: `bundles`) | Deprecated: Use `resource` instead. Path prefix to use to download configuration from remote server. |
 | `discovery.decision` | `string` | No (default: value of `discovery.name` configuration field) | Name of the OPA query that will be used to calculate the configuration |
 | `discovery.polling.min_delay_seconds` | `int64` | No (default: `60`) | Minimum amount of time to wait between configuration downloads. |
 | `discovery.polling.max_delay_seconds` | `int64` | No (default: `120`) | Maximum amount of time to wait between configuration downloads. |

--- a/plugins/discovery/config_test.go
+++ b/plugins/discovery/config_test.go
@@ -139,6 +139,14 @@ func TestConfigPath(t *testing.T) {
 			input: `{"name": "a/b/c"}`,
 			path:  "bundles/a/b/c",
 		},
+		{
+			input: `{"name": "a/b/c/", "resource": "x/y/z"}`,
+			path:  "x/y/z",
+		},
+		{
+			input: `{"name": "a/b/c", "prefix": "/bundles2", resource: "x/y/z"}`,
+			path:  "x/y/z",
+		},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
This makes the configuration of discovery bundles match the newer
`bundles` config style more closely.

The older style configuration with `prefix` is still supported (the
default behavior is still there if neither `resource` or `prefix` is
provided). It has just been marked as deprecated.

Fixes: #1597
Signed-off-by: Patrick East <east.patrick@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
