### PR TITLE
topdown: Base document dereference with composite

### DIFF
--- a/topdown/eval.go
+++ b/topdown/eval.go
@@ -1114,6 +1114,10 @@ func (e *eval) Resolve(ref ast.Ref) (ast.Value, error) {
 }
 
 func (e *eval) resolveReadFromStorage(ref ast.Ref, a ast.Value) (ast.Value, error) {
+	if refContainsNonScalar(ref) {
+		return a, nil
+	}
+
 	path, err := storage.NewPathForRef(ref)
 	if err != nil {
 		if !storage.IsNotFound(err) {
@@ -2299,6 +2303,15 @@ func mergeObjects(objA, objB ast.Object) (result ast.Object, ok bool) {
 func refSliceContainsPrefix(sl []ast.Ref, prefix ast.Ref) bool {
 	for _, ref := range sl {
 		if ref.HasPrefix(prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func refContainsNonScalar(ref ast.Ref) bool {
+	for _, term := range ref[1:] {
+		if !ast.IsScalar(term.Value) {
 			return true
 		}
 	}

--- a/topdown/eval_test.go
+++ b/topdown/eval_test.go
@@ -73,3 +73,53 @@ func TestMergeError(t *testing.T) {
 		t.Fatal("Expected error")
 	}
 }
+
+func TestRefContainsNonScalar(t *testing.T) {
+	cases := []struct {
+		note     string
+		ref      ast.Ref
+		expected bool
+	}{
+		{
+			note:     "empty ref",
+			ref:      ast.MustParseRef("data"),
+			expected: false,
+		},
+		{
+			note:     "string ref",
+			ref:      ast.MustParseRef(`data.foo["bar"]`),
+			expected: false,
+		},
+		{
+			note:     "number ref",
+			ref:      ast.MustParseRef("data.foo[1]"),
+			expected: false,
+		},
+		{
+			note:     "set ref",
+			ref:      ast.MustParseRef("data.foo[{0}]"),
+			expected: true,
+		},
+		{
+			note:     "array ref",
+			ref:      ast.MustParseRef(`data.foo[["bar"]]`),
+			expected: true,
+		},
+		{
+			note:     "object ref",
+			ref:      ast.MustParseRef(`data.foo[{"bar": 1}]`),
+			expected: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.note, func(t *testing.T) {
+			actual := refContainsNonScalar(tc.ref)
+
+			if actual != tc.expected {
+				t.Errorf("Expected %t for %s", tc.expected, tc.ref)
+			}
+		})
+	}
+
+}

--- a/topdown/topdown_test.go
+++ b/topdown/topdown_test.go
@@ -2672,6 +2672,25 @@ p[x] { data.a[i] = x }`,
 	}
 }
 
+func TestTopDownCompositeBaseDereference(t *testing.T) {
+	tests := []struct {
+		note     string
+		rule     string
+		expected interface{}
+	}{
+		// Expect that each of these will evaluate without any errors raised
+		{"array", `p { not data.a[[0]] }`, "true"},
+		{"object", `p { not data.a[{"b": "c"}] }`, "true"},
+		{"set", `p { not data.a[["b"]] }`, "true"},
+	}
+
+	data := loadSmallTestData()
+
+	for _, tc := range tests {
+		runTopDownTestCase(t, data, tc.note, []string{tc.rule}, tc.expected)
+	}
+}
+
 func compileModules(input []string) *ast.Compiler {
 
 	mods := map[string]*ast.Module{}


### PR DESCRIPTION
Previously this would raise an error when attempting to build the
storage path for some ref like `data.foo[["bar"]]`, but there isn't
really any reason why it should halt evaluation. It should just
be undefined.

This changes to look for this type of ref _before_ handing it off to
the store and will just return undefined now instead.

Fixes: #1057
Signed-off-by: Patrick East <east.patrick@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
