### PR TITLE
Update policy-cheatsheet.md

### DIFF
--- a/docs/content/policy-cheatsheet.md
+++ b/docs/content/policy-cheatsheet.md
@@ -244,7 +244,7 @@ f(x) = "C" { x >= 70; x < 80 }
 x := {"a": true, "b": false}
 y := {"b": "foo", "c": 4}
 z := {"a": true, "b": "foo", "c": 4}
-merge_objects(x, y) == z
+merge_objects(x, y) = z
 ```
 
 ```live:rules/merge:module:read_only


### PR DESCRIPTION
line 247 had an extra = which caused the merge_objects example to fail. I removed it.

Demonstrated working code here: https://play.openpolicyagent.org/p/0kF5RVZ7c6