### PR TITLE
Fix *-debug docker images to be ":debug" tag based

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 # Copyright 2019 The OPA Authors.  All rights reserved.
 # Use of this source code is governed by an Apache2
 # license that can be found in the LICENSE file.
+ARG VARIANT
 ARG BUILD_COMMIT
 # we cant use build-args in `COPY --from=...` below, so work around this
 # see: https://medium.com/@tonistiigi/advanced-multi-stage-build-patterns-6f741b852fae


### PR DESCRIPTION
We use the gcr.io/distroless/base:debug tag for the *-debug images of
OPA. At the point where we switched to the multi-stage build we dropped
defining the `VARIANT` argument so it wasn't being picked up correctly.

This lead to us just using gcr.io/distroless/base for the *-debug
image.. which isn't what we wanted.

Signed-off-by: Patrick East <east.patrick@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
