### PR TITLE
wasm: Add support for comprehensions in the planner

### DIFF
--- a/internal/ir/pretty.go
+++ b/internal/ir/pretty.go
@@ -34,7 +34,7 @@ func (pp *prettyPrinter) After(x interface{}) {
 }
 
 func (pp *prettyPrinter) Visit(x interface{}) (Visitor, error) {
-	pp.writeIndent("%T %v", x, x)
+	pp.writeIndent("%T %+v", x, x)
 	return pp, nil
 }
 

--- a/internal/planner/planner_test.go
+++ b/internal/planner/planner_test.go
@@ -146,6 +146,14 @@ func TestPlannerHelloWorld(t *testing.T) {
 				q = 2 { false }
 			`},
 		},
+		{
+			note:    "comprehension",
+			queries: []string{`{x | input[_] = x}`},
+		},
+		{
+			note:    "closure",
+			queries: []string{`a = [1]; {x | a[_] = x}`},
+		},
 	}
 
 	for _, tc := range tests {

--- a/test/wasm/assets/014_comprehensions.yaml
+++ b/test/wasm/assets/014_comprehensions.yaml
@@ -1,0 +1,45 @@
+cases:
+- note: set comprehension
+  query: |
+    {x | input[_] = x} == {1,2,3}
+  input: [1,2,3]
+  return_code: 1
+- note: set comprehension (negative)
+  query: |
+    {x | input[_] = x; x > 1} == {1,2,3}
+  input: [1,2,3]
+  return_code: 0
+- note: array comprehension
+  query: |
+    [x | input[_] = x] == [1,2,3]
+  input: [1,2,3]
+  return_code: 1
+- note: array comprehension (negative)
+  query: |
+    [x | input[_] = x; x > 1] == [1,2,3]
+  input: [1,2,3]
+  return_code: 0
+- note: array comprehension unify
+  query: |
+    [x | input[_] = x] = [1,y,3]
+  input: [1,2,3]
+  return_code: 1
+- note: object comprehension
+  query: |
+    {k: v | input[k] = v} == {"a": 1, "b": 2}
+  input: {"a": 1, "b": 2}
+  return_code: 1
+- note: object comprehension (negative)
+  query: |
+    {k: v | input[k] = v; v > 1} == {"a": 1, "b": 2}
+  input: {"a": 1, "b": 2}
+  return_code: 0
+- note: object comprehension unify
+  query: |
+    {k: v | input[k] = v} = {"a": y, "b": z}
+  input: {"a": 1, "b": 2}
+  return_code: 1
+- note: closure
+  query: |
+    a = [1,2,3]; b = 1; {x | a[_] = x; x > b} == {2,3}
+  return_code: 1


### PR DESCRIPTION
This PR adds support for comprehensions in wasm compiled policies. The backend did not have to be changed since we already have built-ins for constructing collections dynamically.

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
