### PR TITLE
Add Additional String Trimming Builtins

### DIFF
--- a/ast/builtins.go
+++ b/ast/builtins.go
@@ -103,6 +103,11 @@ var DefaultBuiltins = [...]*Builtin{
 	Split,
 	Replace,
 	Trim,
+	TrimLeft,
+	TrimPrefix,
+	TrimRight,
+	TrimSuffix,
+	TrimSpace,
 	Sprintf,
 
 	// Encoding
@@ -761,13 +766,74 @@ var Replace = &Builtin{
 	),
 }
 
-// Trim returns the given string will all leading or trailing instances of the second
+// Trim returns the given string with all leading or trailing instances of the second
 // argument removed.
 var Trim = &Builtin{
 	Name: "trim",
 	Decl: types.NewFunction(
 		types.Args(
 			types.S,
+			types.S,
+		),
+		types.S,
+	),
+}
+
+// TrimLeft returns the given string with all leading instances of second argument removed.
+var TrimLeft = &Builtin{
+	Name: "trim_left",
+	Decl: types.NewFunction(
+		types.Args(
+			types.S,
+			types.S,
+		),
+		types.S,
+	),
+}
+
+// TrimPrefix returns the given string without the second argument prefix string.
+// If the given string doesn't start with prefix, it is returned unchanged.
+var TrimPrefix = &Builtin{
+	Name: "trim_prefix",
+	Decl: types.NewFunction(
+		types.Args(
+			types.S,
+			types.S,
+		),
+		types.S,
+	),
+}
+
+// TrimRight returns the given string with all trailing instances of second argument removed.
+var TrimRight = &Builtin{
+	Name: "trim_right",
+	Decl: types.NewFunction(
+		types.Args(
+			types.S,
+			types.S,
+		),
+		types.S,
+	),
+}
+
+// TrimSuffix returns the given string without the second argument suffix string.
+// If the given string doesn't end with suffix, it is returned unchanged.
+var TrimSuffix = &Builtin{
+	Name: "trim_suffix",
+	Decl: types.NewFunction(
+		types.Args(
+			types.S,
+			types.S,
+		),
+		types.S,
+	),
+}
+
+// TrimSpace return the given string with all leading and trailing white space removed.
+var TrimSpace = &Builtin{
+	Name: "trim_space",
+	Decl: types.NewFunction(
+		types.Args(
 			types.S,
 		),
 		types.S,

--- a/topdown/strings.go
+++ b/topdown/strings.go
@@ -241,6 +241,71 @@ func builtinTrim(a, b ast.Value) (ast.Value, error) {
 	return ast.String(strings.Trim(string(s), string(c))), nil
 }
 
+func builtinTrimLeft(a, b ast.Value) (ast.Value, error) {
+	s, err := builtins.StringOperand(a, 1)
+	if err != nil {
+		return nil, err
+	}
+
+	c, err := builtins.StringOperand(b, 2)
+	if err != nil {
+		return nil, err
+	}
+
+	return ast.String(strings.TrimLeft(string(s), string(c))), nil
+}
+
+func builtinTrimPrefix(a, b ast.Value) (ast.Value, error) {
+	s, err := builtins.StringOperand(a, 1)
+	if err != nil {
+		return nil, err
+	}
+
+	pre, err := builtins.StringOperand(b, 2)
+	if err != nil {
+		return nil, err
+	}
+
+	return ast.String(strings.TrimPrefix(string(s), string(pre))), nil
+}
+
+func builtinTrimRight(a, b ast.Value) (ast.Value, error) {
+	s, err := builtins.StringOperand(a, 1)
+	if err != nil {
+		return nil, err
+	}
+
+	c, err := builtins.StringOperand(b, 2)
+	if err != nil {
+		return nil, err
+	}
+
+	return ast.String(strings.TrimRight(string(s), string(c))), nil
+}
+
+func builtinTrimSuffix(a, b ast.Value) (ast.Value, error) {
+	s, err := builtins.StringOperand(a, 1)
+	if err != nil {
+		return nil, err
+	}
+
+	suf, err := builtins.StringOperand(b, 2)
+	if err != nil {
+		return nil, err
+	}
+
+	return ast.String(strings.TrimSuffix(string(s), string(suf))), nil
+}
+
+func builtinTrimSpace(a ast.Value) (ast.Value, error) {
+	s, err := builtins.StringOperand(a, 1)
+	if err != nil {
+		return nil, err
+	}
+
+	return ast.String(strings.TrimSpace(string(s))), nil
+}
+
 func builtinSprintf(a, b ast.Value) (ast.Value, error) {
 	s, err := builtins.StringOperand(a, 1)
 	if err != nil {
@@ -287,5 +352,10 @@ func init() {
 	RegisterFunctionalBuiltin2(ast.Split.Name, builtinSplit)
 	RegisterFunctionalBuiltin3(ast.Replace.Name, builtinReplace)
 	RegisterFunctionalBuiltin2(ast.Trim.Name, builtinTrim)
+	RegisterFunctionalBuiltin2(ast.TrimLeft.Name, builtinTrimLeft)
+	RegisterFunctionalBuiltin2(ast.TrimPrefix.Name, builtinTrimPrefix)
+	RegisterFunctionalBuiltin2(ast.TrimRight.Name, builtinTrimRight)
+	RegisterFunctionalBuiltin2(ast.TrimSuffix.Name, builtinTrimSuffix)
+	RegisterFunctionalBuiltin1(ast.TrimSpace.Name, builtinTrimSpace)
 	RegisterFunctionalBuiltin2(ast.Sprintf.Name, builtinSprintf)
 }


### PR DESCRIPTION
Fixes #1801

This commit adds the following string trimming builtins
- TrimLeft(s string, cutset string) string
- TrimPrefix(s, prefix string) string
- TrimRight(s string, cutset string) string
- TrimSuffix(s, suffix string) string
- TrimSpace(s string) string

Signed-off-by: Hasit Mistry <hasitnm@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
