### PR TITLE
Add Additional String Trimming Functions

### DIFF
--- a/ast/builtins.go
+++ b/ast/builtins.go
@@ -103,6 +103,11 @@ var DefaultBuiltins = [...]*Builtin{
 	Split,
 	Replace,
 	Trim,
+	TrimLeft,
+	TrimPrefix,
+	TrimRight,
+	TrimSuffix,
+	TrimSpace,
 	Sprintf,
 
 	// Encoding
@@ -761,13 +766,74 @@ var Replace = &Builtin{
 	),
 }
 
-// Trim returns the given string will all leading or trailing instances of the second
+// Trim returns the given string with all leading or trailing instances of the second
 // argument removed.
 var Trim = &Builtin{
 	Name: "trim",
 	Decl: types.NewFunction(
 		types.Args(
 			types.S,
+			types.S,
+		),
+		types.S,
+	),
+}
+
+// TrimLeft returns the given string with all leading instances of second argument removed.
+var TrimLeft = &Builtin{
+	Name: "trim_left",
+	Decl: types.NewFunction(
+		types.Args(
+			types.S,
+			types.S,
+		),
+		types.S,
+	),
+}
+
+// TrimPrefix returns the given string without the second argument prefix string.
+// If the given string doesn't start with prefix, it is returned unchanged.
+var TrimPrefix = &Builtin{
+	Name: "trim_prefix",
+	Decl: types.NewFunction(
+		types.Args(
+			types.S,
+			types.S,
+		),
+		types.S,
+	),
+}
+
+// TrimRight returns the given string with all trailing instances of second argument removed.
+var TrimRight = &Builtin{
+	Name: "trim_right",
+	Decl: types.NewFunction(
+		types.Args(
+			types.S,
+			types.S,
+		),
+		types.S,
+	),
+}
+
+// TrimSuffix returns the given string without the second argument suffix string.
+// If the given string doesn't end with suffix, it is returned unchanged.
+var TrimSuffix = &Builtin{
+	Name: "trim_suffix",
+	Decl: types.NewFunction(
+		types.Args(
+			types.S,
+			types.S,
+		),
+		types.S,
+	),
+}
+
+// TrimSpace return the given string with all leading and trailing white space removed.
+var TrimSpace = &Builtin{
+	Name: "trim_space",
+	Decl: types.NewFunction(
+		types.Args(
 			types.S,
 		),
 		types.S,

--- a/docs/content/policy-reference.md
+++ b/docs/content/policy-reference.md
@@ -82,6 +82,11 @@ complex types.
 | <span class="opa-keep-it-together">``startswith(string, search)``</span> | true if ``string`` begins with ``search`` |
 | <span class="opa-keep-it-together">``output := substring(string, start, length)``</span> | ``output`` is the portion of ``string`` from index ``start`` and having a length of ``length``.  If ``length`` is less than zero, ``length`` is the remainder of the ``string``. If ``start`` is greater than the length of the string, ``output`` is empty. It is invalid to pass a negative offset to this function. |
 | <span class="opa-keep-it-together">``output := trim(string, cutset)``</span> | ``output`` is a ``string`` representing ``string`` with all leading and trailing instances of the characters in ``cutset`` removed. |
+| <span class="opa-keep-it-together">``output := trim_left(string, cutset)``</span> | ``output`` is a ``string`` representing ``string`` with all leading instances of the characters in ``cutset`` removed. |
+| <span class="opa-keep-it-together">``output := trim_prefix(string, prefix)``</span> | ``output`` is a ``string`` representing ``string`` with leading instance of ``prefix`` removed. If ``string`` doesn't start with prefix, ``string`` is returned unchanged.|
+| <span class="opa-keep-it-together">``output := trim_right(string, cutset)``</span> | ``output`` is a ``string`` representing ``string`` with all trailing instances of the characters in ``cutset`` removed. |
+| <span class="opa-keep-it-together">``output := trim_suffix(string, prefix)``</span> | ``output`` is a ``string`` representing ``string`` with trailing instance of ``suffix`` removed. If ``string`` doesn't end with suffix, ``string`` is returned unchanged.|
+| <span class="opa-keep-it-together">``output := trim_space(string)``</span> | ``output`` is a ``string`` representing ``string`` with all leading and trailing white space removed.|
 | <span class="opa-keep-it-together">``output := upper(string)``</span> | ``output`` is ``string`` after converting to upper case |
 
 ### Regex

--- a/topdown/strings.go
+++ b/topdown/strings.go
@@ -241,6 +241,71 @@ func builtinTrim(a, b ast.Value) (ast.Value, error) {
 	return ast.String(strings.Trim(string(s), string(c))), nil
 }
 
+func builtinTrimLeft(a, b ast.Value) (ast.Value, error) {
+	s, err := builtins.StringOperand(a, 1)
+	if err != nil {
+		return nil, err
+	}
+
+	c, err := builtins.StringOperand(b, 2)
+	if err != nil {
+		return nil, err
+	}
+
+	return ast.String(strings.TrimLeft(string(s), string(c))), nil
+}
+
+func builtinTrimPrefix(a, b ast.Value) (ast.Value, error) {
+	s, err := builtins.StringOperand(a, 1)
+	if err != nil {
+		return nil, err
+	}
+
+	pre, err := builtins.StringOperand(b, 2)
+	if err != nil {
+		return nil, err
+	}
+
+	return ast.String(strings.TrimPrefix(string(s), string(pre))), nil
+}
+
+func builtinTrimRight(a, b ast.Value) (ast.Value, error) {
+	s, err := builtins.StringOperand(a, 1)
+	if err != nil {
+		return nil, err
+	}
+
+	c, err := builtins.StringOperand(b, 2)
+	if err != nil {
+		return nil, err
+	}
+
+	return ast.String(strings.TrimRight(string(s), string(c))), nil
+}
+
+func builtinTrimSuffix(a, b ast.Value) (ast.Value, error) {
+	s, err := builtins.StringOperand(a, 1)
+	if err != nil {
+		return nil, err
+	}
+
+	suf, err := builtins.StringOperand(b, 2)
+	if err != nil {
+		return nil, err
+	}
+
+	return ast.String(strings.TrimSuffix(string(s), string(suf))), nil
+}
+
+func builtinTrimSpace(a ast.Value) (ast.Value, error) {
+	s, err := builtins.StringOperand(a, 1)
+	if err != nil {
+		return nil, err
+	}
+
+	return ast.String(strings.TrimSpace(string(s))), nil
+}
+
 func builtinSprintf(a, b ast.Value) (ast.Value, error) {
 	s, err := builtins.StringOperand(a, 1)
 	if err != nil {
@@ -287,5 +352,10 @@ func init() {
 	RegisterFunctionalBuiltin2(ast.Split.Name, builtinSplit)
 	RegisterFunctionalBuiltin3(ast.Replace.Name, builtinReplace)
 	RegisterFunctionalBuiltin2(ast.Trim.Name, builtinTrim)
+	RegisterFunctionalBuiltin2(ast.TrimLeft.Name, builtinTrimLeft)
+	RegisterFunctionalBuiltin2(ast.TrimPrefix.Name, builtinTrimPrefix)
+	RegisterFunctionalBuiltin2(ast.TrimRight.Name, builtinTrimRight)
+	RegisterFunctionalBuiltin2(ast.TrimSuffix.Name, builtinTrimSuffix)
+	RegisterFunctionalBuiltin1(ast.TrimSpace.Name, builtinTrimSpace)
 	RegisterFunctionalBuiltin2(ast.Sprintf.Name, builtinSprintf)
 }

--- a/topdown/strings_test.go
+++ b/topdown/strings_test.go
@@ -1,0 +1,97 @@
+// Copyright 2019 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package topdown
+
+import "testing"
+
+func TestBuiltinTrim(t *testing.T) {
+	tests := []struct {
+		note     string
+		rules    []string
+		expected interface{}
+	}{
+		{"trims '!¡' from string", []string{`p[x] { x := trim("¡¡¡foo, bar!!!", "!¡") }`}, `["foo, bar"]`},
+		{"trims nothing from string", []string{`p[x] { x := trim("¡¡¡foo, bar!!!", "i") }`}, `["¡¡¡foo, bar!!!"]`},
+	}
+
+	for _, tc := range tests {
+		runTopDownTestCase(t, map[string]interface{}{}, tc.note, tc.rules, tc.expected)
+	}
+}
+
+func TestBuiltinTrimLeft(t *testing.T) {
+	tests := []struct {
+		note     string
+		rules    []string
+		expected interface{}
+	}{
+		{"trims leading '!¡' from string", []string{`p[x] { x := trim_left("¡¡¡foo, bar!!!", "!¡") }`}, `["foo, bar!!!"]`},
+		{"trims nothing from string", []string{`p[x] { x := trim_left("!!!foo, bar¡¡¡", "¡") }`}, `["!!!foo, bar¡¡¡"]`},
+	}
+
+	for _, tc := range tests {
+		runTopDownTestCase(t, map[string]interface{}{}, tc.note, tc.rules, tc.expected)
+	}
+}
+
+func TestBuiltinTrimPrefix(t *testing.T) {
+	tests := []struct {
+		note     string
+		rules    []string
+		expected interface{}
+	}{
+		{"trims prefix '!¡' from string", []string{`p[x] { x := trim_prefix("¡¡¡foo, bar!!!", "¡¡¡foo") }`}, `[", bar!!!"]`},
+		{"trims nothing from string", []string{`p[x] { x := trim_prefix("¡¡¡foo, bar!!!", "¡¡¡bar") }`}, `["¡¡¡foo, bar!!!"]`},
+	}
+
+	for _, tc := range tests {
+		runTopDownTestCase(t, map[string]interface{}{}, tc.note, tc.rules, tc.expected)
+	}
+}
+
+func TestBuiltinTrimRight(t *testing.T) {
+	tests := []struct {
+		note     string
+		rules    []string
+		expected interface{}
+	}{
+		{"trims trailing '!¡' from string", []string{`p[x] { x := trim_right("¡¡¡foo, bar!!!", "!¡") }`}, `["¡¡¡foo, bar"]`},
+		{"trims nothing from string", []string{`p[x] { x := trim_right("!!!foo, bar¡¡¡", "!") }`}, `["!!!foo, bar¡¡¡"]`},
+	}
+
+	for _, tc := range tests {
+		runTopDownTestCase(t, map[string]interface{}{}, tc.note, tc.rules, tc.expected)
+	}
+}
+
+func TestBuiltinTrimSuffix(t *testing.T) {
+	tests := []struct {
+		note     string
+		rules    []string
+		expected interface{}
+	}{
+		{"trims suffix '!¡' from string", []string{`p[x] { x := trim_suffix("¡¡¡foo, bar!!!", ", bar!!!") }`}, `["¡¡¡foo"]`},
+		{"trims nothing from string", []string{`p[x] { x := trim_suffix("¡¡¡foo, bar!!!", ", foo!!!") }`}, `["¡¡¡foo, bar!!!"]`},
+	}
+
+	for _, tc := range tests {
+		runTopDownTestCase(t, map[string]interface{}{}, tc.note, tc.rules, tc.expected)
+	}
+}
+
+func TestBuiltinTrimSpace(t *testing.T) {
+	tests := []struct {
+		note     string
+		rules    []string
+		expected interface{}
+	}{
+		{"trims all leading and trailing white space from string", []string{`p[x] { x := trim_space(" \t\n foo, bar \n\t\r\n") }`}, `["foo, bar"]`},
+		{"trims nothing from string", []string{`p[x] { x := trim_space("foo, bar") }`}, `["foo, bar"]`},
+	}
+
+	for _, tc := range tests {
+		runTopDownTestCase(t, map[string]interface{}{}, tc.note, tc.rules, tc.expected)
+	}
+}


### PR DESCRIPTION
This commit adds the following string trimming builtins

- TrimLeft(s string, cutset string) string
- TrimPrefix(s, prefix string) string
- TrimRight(s string, cutset string) string
- TrimSuffix(s, suffix string) string
- TrimSpace(s string) string

Signed-off-by: Hasit Mistry <hasitnm@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
