### PR TITLE
wasm: Add support for composite reference operands

### DIFF
--- a/test/wasm/assets/002_iteration.yaml
+++ b/test/wasm/assets/002_iteration.yaml
@@ -61,3 +61,15 @@ cases:
       ]
     }
     return_code: 0
+  - note: iteration composite
+    query: a = {["t",1], ["u",2], ["v", 3]}; a[["v", v]]; v == 3
+    return_code: 1
+  - note: iteration composite (negative)
+    query: a = {["t",1], ["u",2], ["v", 3]}; a[["u", u]]; u == 3
+    return_code: 0
+  - note: no scan required
+    query: u = 2; a = {["t",1], ["u",2], ["v", 3]}; a[["u", u]]
+    return_code: 1
+  - note: no scan required (negative)
+    query: v = 2; a = {["t",1], ["u",2], ["v", 3]}; a[["v", v]]
+    return_code: 0


### PR DESCRIPTION
This commit updates the planner to support composite reference
operands, e.g., p[[1,x]]. The planner generates a dot operation if
the operand does not contain any free variables. Otherwise the
planner generates a scan operation and then unifies the scan key
with the reference operand before continuing.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
