### PR TITLE
file/loader: Standardize on forward slash paths

### DIFF
--- a/internal/file/loader.go
+++ b/internal/file/loader.go
@@ -90,7 +90,7 @@ func (d *dirLoader) NextFile() (*Descriptor, error) {
 		d.files = []string{}
 		err := filepath.Walk(d.root, func(path string, info os.FileInfo, err error) error {
 			if info != nil && info.Mode().IsRegular() {
-				d.files = append(d.files, path)
+				d.files = append(d.files, filepath.ToSlash(path))
 			}
 			return nil
 		})


### PR DESCRIPTION
When loading files we would build the list with, on windows, potential
paths with backslashes rather than forward slashes. This is
problematic because the check to trim the prefix for returning file
descriptors based on the root of the bundle.. On windows it could, in
some cases, fail to do so. This results in additional prefixes on the
loaded data.

Signed-off-by: Patrick East <east.patrick@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
