### PR TITLE
Remove mention of plugin directory

### DIFF
--- a/docs/content/envoy-authorization.md
+++ b/docs/content/envoy-authorization.md
@@ -254,7 +254,6 @@ spec:
             mountPath: /policy
             name: opa-policy
           args:
-          - "--plugin-dir=/app"
           - "run" 
           - "--server"
           - "--set=plugins.envoy_ext_authz_grpc.addr=:9191"

--- a/docs/content/extensions.md
+++ b/docs/content/extensions.md
@@ -291,7 +291,7 @@ plugins:
     stderr: false
 ```
 
-Start OPA with the plugin directory and configuration file:
+Start OPA with the configuration file:
 
 ```bash
 ./opa++ run --server --config-file config.yaml


### PR DESCRIPTION
There was one dangling reference to plugin directory in the [Custom Plugins for OPA Daemon|https://www.openpolicyagent.org/docs/latest/extensions/#custom-plugins-for-opa-daemon] documentation and one to plugin-dir in the envoy authorization example.