### PR TITLE
docs: Preprocess live-blocks with current OPA HEAD

### DIFF
--- a/docs/website/scripts/live-blocks/src/constants.js
+++ b/docs/website/scripts/live-blocks/src/constants.js
@@ -111,6 +111,7 @@ export const PLATFORMS = {
 // The folder where OPA binaries will be downloaded into.
 // NOTE: Update package.json with any changes
 export const OPA_CACHE_PATH = './opa_versions/'
+export const OPA_EDGE_PATH = '../../../../'  // Repo root
 
 // The amount of time between redownloads of the edge release (ms).
 export const OPA_EDGE_CACHE_PERIOD = 24 * 60 * 60 * 1000 // 1 day

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,15 +1,15 @@
 [build]
 publish = "docs/website/public"
-command = "make docs-production-build"
+command = "make build docs-production-build"
 
 [build.environment]
 HUGO_VERSION = "0.55.5"
 
 [context.deploy-preview]
-command = "make docs-preview-build"
+command = "make build docs-preview-build"
 
 [context.branch-deploy]
-command = "make docs-preview-build"
+command = "make build docs-preview-build"
 
 [dev]
 # "netlify dev" will serve the static content using netlify locally


### PR DESCRIPTION
This changes to no longer download the `edge` release binary (we still
publish one for anyone who wants to use the current master). This way
for PR's and for development we are going to process the `edge`
documentation with the version of OPA that is the current HEAD. For
the live site this will always be the current master branch.

Signed-off-by: Patrick East <east.patrick@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
