### PR TITLE
Add builtins related to string replacement

### DIFF
--- a/ast/builtins.go
+++ b/ast/builtins.go
@@ -84,6 +84,7 @@ var DefaultBuiltins = [...]*Builtin{
 	GlobsMatch,
 	RegexTemplateMatch,
 	RegexFind,
+	RegexFindAllStringSubmatch,
 
 	// Sets
 	SetDiff,
@@ -102,6 +103,7 @@ var DefaultBuiltins = [...]*Builtin{
 	EndsWith,
 	Split,
 	Replace,
+	ReplaceN,
 	Trim,
 	TrimLeft,
 	TrimPrefix,
@@ -572,6 +574,21 @@ var RegexMatch = &Builtin{
 	),
 }
 
+// RegexFindAllStringSubmatch returns an array of all successive matches of the expression.
+// It takes two strings and a number, the pattern, the value and number of matches to
+// return, -1 means all matches.
+var RegexFindAllStringSubmatch = &Builtin{
+	Name: "regex.find_all_string_submatch_n",
+	Decl: types.NewFunction(
+		types.Args(
+			types.S,
+			types.S,
+			types.N,
+		),
+		types.NewArray(nil, types.NewArray(nil, types.S)),
+	),
+}
+
 // RegexTemplateMatch takes two strings and evaluates to true if the string in the second
 // position matches the pattern in the first position.
 var RegexTemplateMatch = &Builtin{
@@ -760,6 +777,24 @@ var Replace = &Builtin{
 		types.Args(
 			types.S,
 			types.S,
+			types.S,
+		),
+		types.S,
+	),
+}
+
+// ReplaceN replaces a string from a list of old, new string pairs.
+// Replacements are performed in the order they appear in the target string, without overlapping matches.
+// The old string comparisons are done in argument order.
+var ReplaceN = &Builtin{
+	Name: "strings.replace_n",
+	Decl: types.NewFunction(
+		types.Args(
+			types.NewObject(
+				nil,
+				types.NewDynamicProperty(
+					types.S,
+					types.S)),
 			types.S,
 		),
 		types.S,

--- a/docs/content/policy-reference.md
+++ b/docs/content/policy-reference.md
@@ -77,6 +77,7 @@ complex types.
 | <span class="opa-keep-it-together">``output := indexof(string, search)``</span> | ``output`` is the index inside ``string`` where ``search`` first occurs, or -1 if ``search`` does not exist |
 | <span class="opa-keep-it-together">``output := lower(string)``</span> | ``output`` is ``string`` after converting to lower case |
 | <span class="opa-keep-it-together">``output := replace(string, old, new)``</span> | ``output`` is a ``string`` representing ``string`` with all instances of ``old`` replaced by ``new`` |
+| <span class="opa-keep-it-together">``output := strings.replace_n(patterns, string)``</span> | ``patterns`` is an object with old, new string key value pairs (e.g. ``{"old1": "new1", "old2": "new2", ...}``). ``output`` is a ``string`` with all old strings inside ``patterns`` replaced by the new strings |
 | <span class="opa-keep-it-together">``output := split(string, delimiter)``</span> | ``output`` is ``array[string]`` representing elements of ``string`` separated by ``delimiter`` |
 | <span class="opa-keep-it-together">``output := sprintf(string, values)``</span> | ``output`` is a ``string`` representing ``string`` formatted by the values in the ``array`` ``values``. |
 | <span class="opa-keep-it-together">``startswith(string, search)``</span> | true if ``string`` begins with ``search`` |
@@ -97,6 +98,7 @@ complex types.
 | <span class="opa-keep-it-together">``regex.globs_match(glob1, glob2)``</span> | true if the intersection of regex-style globs ``glob1`` and ``glob2`` matches a non-empty set of non-empty strings. The set of regex symbols is limited for this builtin: only ``.``, ``*``, ``+``, ``[``, ``-``, ``]`` and ``\`` are treated as special symbols. |
 | <span class="opa-keep-it-normal">``output := regex.template_match(patter, string, delimiter_start, delimiter_end)``</span> | ``output`` is true if ``string`` matches ``pattern``. ``pattern`` is a string containing ``0..n`` regular expressions delimited by ``delimiter_start`` and ``delimiter_end``. Example ``regex.template_match("urn:foo:{.*}", "urn:foo:bar:baz", "{", "}", x)`` returns ``true`` for ``x``. |
 | <span class="opa-keep-it-together">``output := regex.find_n(pattern, string, number)``</span> | ``output`` is an ``array[string]`` with the ``number`` of values matching the ``pattern``. A ``number`` of ``-1`` means all matches. |
+| <span class="opa-keep-it-together">``output := regex.find_all_string_submatch_n(pattern, string, number)``</span> | ``output`` is an ``array[array[string]]`` with the outer `array` including a ``number`` of matches which match the ``pattern``. A ``number`` of ``-1`` means all matches. |
 
 ### Glob
 | Built-in | Description |

--- a/topdown/regex.go
+++ b/topdown/regex.go
@@ -158,6 +158,38 @@ func builtinRegexFind(a, b, c ast.Value) (ast.Value, error) {
 	return arr, nil
 }
 
+func builtinRegexFindAllStringSubmatch(a, b, c ast.Value) (ast.Value, error) {
+	s1, err := builtins.StringOperand(a, 1)
+	if err != nil {
+		return nil, err
+	}
+	s2, err := builtins.StringOperand(b, 2)
+	if err != nil {
+		return nil, err
+	}
+	n, err := builtins.IntOperand(c, 3)
+	if err != nil {
+		return nil, err
+	}
+
+	re, err := getRegexp(string(s1))
+	if err != nil {
+		return nil, err
+	}
+	matches := re.FindAllStringSubmatch(string(s2), n)
+
+	outer := make(ast.Array, len(matches))
+	for i := range outer {
+		inner := make(ast.Array, len(matches[i]))
+		for j := range inner {
+			inner[j] = ast.StringTerm(matches[i][j])
+		}
+		outer[i] = ast.ArrayTerm(inner...)
+	}
+
+	return outer, nil
+}
+
 func init() {
 	regexpCache = map[string]*regexp.Regexp{}
 	RegisterFunctionalBuiltin2(ast.RegexMatch.Name, builtinRegexMatch)
@@ -165,4 +197,5 @@ func init() {
 	RegisterFunctionalBuiltin2(ast.GlobsMatch.Name, builtinGlobsMatch)
 	RegisterFunctionalBuiltin4(ast.RegexTemplateMatch.Name, builtinRegexMatchTemplate)
 	RegisterFunctionalBuiltin3(ast.RegexFind.Name, builtinRegexFind)
+	RegisterFunctionalBuiltin3(ast.RegexFindAllStringSubmatch.Name, builtinRegexFindAllStringSubmatch)
 }

--- a/topdown/regex_test.go
+++ b/topdown/regex_test.go
@@ -32,3 +32,23 @@ func TestRegexFind(t *testing.T) {
 		runTopDownTestCase(t, map[string]interface{}{}, tc.note, tc.rules, tc.expected)
 	}
 }
+
+func TestRegexFindAllStringSubmatch(t *testing.T) {
+	tests := []struct {
+		note     string
+		rules    []string
+		expected interface{}
+	}{
+		{"finds no matches", []string{`p[x] { x = regex.find_all_string_submatch_n("a(x*)b", "-", -1) }`}, `[[]]]`},
+		{"single match without captures", []string{`p[x] { x = regex.find_all_string_submatch_n("a(x*)b", "-ab-", -1) }`}, `[[["ab", ""]]]]`},
+		{"single match with a capture", []string{`p[x] { x = regex.find_all_string_submatch_n("a(x*)b", "-axxb-", -1) }`}, `[[["axxb", "xx"]]]]`},
+		{"multiple matches with captures-1", []string{`p[x] { x = regex.find_all_string_submatch_n("a(x*)b", "-ab-axb-", -1) }`}, `[[["ab", ""], ["axb", "x"]]]]`},
+		{"multiple matches with captures-2", []string{`p[x] { x = regex.find_all_string_submatch_n("a(x*)b", "-axxb-ab-", -1) }`}, `[[["axxb", "xx"], ["ab", ""]]]]`},
+		{"multiple patterns, matches, and captures", []string{`p[x] { x = regex.find_all_string_submatch_n("[^aouiye]([aouiye])([^aouiye])?", "somestri", -1) }`}, `[[["som", "o", "m"], ["ri", "i", ""]]]]`},
+		{"multiple patterns, matches, and captures with specified number of matches", []string{`p[x] { x = regex.find_all_string_submatch_n("[^aouiye]([aouiye])([^aouiye])?", "somestri", 1) }`}, `[[["som", "o", "m"]]]]`},
+	}
+
+	for _, tc := range tests {
+		runTopDownTestCase(t, map[string]interface{}{}, tc.note, tc.rules, tc.expected)
+	}
+}

--- a/topdown/strings.go
+++ b/topdown/strings.go
@@ -5,6 +5,7 @@
 package topdown
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -227,6 +228,36 @@ func builtinReplace(a, b, c ast.Value) (ast.Value, error) {
 	return ast.String(strings.Replace(string(s), string(old), string(new), -1)), nil
 }
 
+func builtinReplaceN(a, b ast.Value) (ast.Value, error) {
+	asJSON, err := ast.JSON(a)
+	if err != nil {
+		return nil, err
+	}
+	oldnewObj, ok := asJSON.(map[string]interface{})
+	if !ok {
+		return nil, builtins.NewOperandTypeErr(1, a, "object")
+	}
+
+	s, err := builtins.StringOperand(b, 2)
+	if err != nil {
+		return nil, err
+	}
+
+	var oldnewArr []string
+	for k, v := range oldnewObj {
+		strVal, ok := v.(string)
+		if !ok {
+			return nil, errors.New("non-string value found in pattern object")
+		}
+		oldnewArr = append(oldnewArr, k, strVal)
+	}
+
+	r := strings.NewReplacer(oldnewArr...)
+	replaced := r.Replace(string(s))
+
+	return ast.String(replaced), nil
+}
+
 func builtinTrim(a, b ast.Value) (ast.Value, error) {
 	s, err := builtins.StringOperand(a, 1)
 	if err != nil {
@@ -351,6 +382,7 @@ func init() {
 	RegisterFunctionalBuiltin1(ast.Lower.Name, builtinLower)
 	RegisterFunctionalBuiltin2(ast.Split.Name, builtinSplit)
 	RegisterFunctionalBuiltin3(ast.Replace.Name, builtinReplace)
+	RegisterFunctionalBuiltin2(ast.ReplaceN.Name, builtinReplaceN)
 	RegisterFunctionalBuiltin2(ast.Trim.Name, builtinTrim)
 	RegisterFunctionalBuiltin2(ast.TrimLeft.Name, builtinTrimLeft)
 	RegisterFunctionalBuiltin2(ast.TrimPrefix.Name, builtinTrimPrefix)

--- a/topdown/strings_test.go
+++ b/topdown/strings_test.go
@@ -95,3 +95,18 @@ func TestBuiltinTrimSpace(t *testing.T) {
 		runTopDownTestCase(t, map[string]interface{}{}, tc.note, tc.rules, tc.expected)
 	}
 }
+
+func TestReplaceN(t *testing.T) {
+	tests := []struct {
+		note     string
+		rules    []string
+		expected interface{}
+	}{
+		{"replace multiple patterns", []string{`p[x] { x = strings.replace_n({"<": "&lt;", ">": "&gt;"}, "This is <b>HTML</b>!") }`}, `["This is &lt;b&gt;HTML&lt;/b&gt;!"]`},
+		{"find no patterns", []string{`p[x] { x = strings.replace_n({"old1": "new1", "old2": "new2"}, "Everything is new1, new2") }`}, `["Everything is new1, new2"]`},
+	}
+
+	for _, tc := range tests {
+		runTopDownTestCase(t, map[string]interface{}{}, tc.note, tc.rules, tc.expected)
+	}
+}


### PR DESCRIPTION
Added the following functions inside the stdlib of go.

* [Regexp.FindAllStringSubmatch](https://golang.org/pkg/regexp/#Regexp.FindAllStringSubmatch) -> `regex.find_all_string_submatch_n`
* [Replacer.Replace](https://golang.org/pkg/strings/#Replacer.Replace) -> `replacer.replace`

Related Issue: #1804 

I'm not sure about the name of the function 🤔 Seems a bit long but couldn't come up with a better one.

Also, this is my first contribution to the code base. Apologies if I'm missing something.