### PR TITLE
topdown: Fix units.parse_bytes implementation to use int64

### DIFF
--- a/topdown/parse_bytes.go
+++ b/topdown/parse_bytes.go
@@ -14,18 +14,16 @@ import (
 	"github.com/open-policy-agent/opa/topdown/builtins"
 )
 
-type multiplier int
-
 const (
-	none multiplier = 1
-	kb              = 1000
-	ki              = 1024
-	mb              = kb * 1000
-	mi              = ki * 1024
-	gb              = mb * 1000
-	gi              = mi * 1024
-	tb              = gb * 1000
-	ti              = gi * 1024
+	none int64 = 1
+	kb         = 1000
+	ki         = 1024
+	mb         = kb * 1000
+	mi         = ki * 1024
+	gb         = mb * 1000
+	gi         = mi * 1024
+	tb         = gb * 1000
+	ti         = gi * 1024
 )
 
 // The rune values for 0..9 as well as the period symbol (for parsing floats)
@@ -46,7 +44,7 @@ var (
 )
 
 func builtinNumBytes(a ast.Value) (ast.Value, error) {
-	var m multiplier
+	var m int64
 
 	raw, err := builtins.StringOperand(a, 1)
 	if err != nil {
@@ -88,14 +86,14 @@ func builtinNumBytes(a ast.Value) (ast.Value, error) {
 		return nil, errUnitNotRecognized(unitStr)
 	}
 
-	num, err := strconv.Atoi(numStr)
+	num, err := strconv.ParseInt(numStr, 10, 64)
 	if err != nil {
 		return nil, errIntConv
 	}
 
-	total := num * int(m)
+	total := num * m
 
-	return builtins.IntToNumber(big.NewInt(int64(total))), nil
+	return builtins.IntToNumber(big.NewInt(total)), nil
 }
 
 // Makes the string lower case and removes spaces and quotation marks


### PR DESCRIPTION
Fixes #1815

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
