### PR TITLE
Add map of rewritten vars to Compiler

### DIFF
--- a/ast/compile_bench_test.go
+++ b/ast/compile_bench_test.go
@@ -20,7 +20,7 @@ func BenchmarkRewriteDynamics(b *testing.B) {
 
 	for i := range sizes {
 		b.Run(fmt.Sprint(sizes[i]), func(b *testing.B) {
-			factory := newEqualityFactory(newLocalVarGenerator(nil))
+			factory := newEqualityFactory(newLocalVarGenerator("q", nil))
 			b.ResetTimer()
 			for n := 0; n < b.N; n++ {
 				for _, body := range queries[i] {

--- a/ast/compile_test.go
+++ b/ast/compile_test.go
@@ -893,7 +893,7 @@ func TestCompilerExprExpansion(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.note, func(t *testing.T) {
-			gen := newLocalVarGenerator(NullTerm())
+			gen := newLocalVarGenerator("", NullTerm())
 			expr := MustParseExpr(tc.input)
 			result := expandExpr(gen, expr.Copy())
 			if len(result) != len(tc.expected) {
@@ -2944,7 +2944,7 @@ func TestQueryCompiler(t *testing.T) {
 			q:        "a := 1; [b, c] := data.foo",
 			pkg:      "",
 			imports:  nil,
-			expected: "__local0__ = 1; [__local1__, __local2__] = data.foo",
+			expected: "__localq0__ = 1; [__localq1__, __localq2__] = data.foo",
 		},
 		{
 			note:     "exports resolved",
@@ -2965,7 +2965,7 @@ func TestQueryCompiler(t *testing.T) {
 			q:        "[x[i] | a = [[1], [2]]; x = a[j]]",
 			pkg:      "",
 			imports:  nil,
-			expected: "[__local0__ | a = [[1], [2]]; x = a[j]; __local0__ = x[i]]",
+			expected: "[__localq0__ | a = [[1], [2]]; x = a[j]; __localq0__ = x[i]]",
 		},
 		{
 			note:     "unsafe vars",
@@ -3000,7 +3000,7 @@ func TestQueryCompiler(t *testing.T) {
 			q:        `1 with input as [z]`,
 			pkg:      "package a.b.c",
 			imports:  nil,
-			expected: `__local1__ = data.a.b.c.z; __local0__ = [__local1__]; 1 with input as __local0__`,
+			expected: `__localq1__ = data.a.b.c.z; __localq0__ = [__localq1__]; 1 with input as __localq0__`,
 		},
 		{
 			note:     "unsafe exprs",
@@ -3033,8 +3033,8 @@ func TestQueryCompilerRewrittenVars(t *testing.T) {
 		q    string
 		vars map[string]string
 	}{
-		{"assign", "a := 1", map[string]string{"__local0__": "a"}},
-		{"suppress only seen", "b = 1; a := b", map[string]string{"__local0__": "a"}},
+		{"assign", "a := 1", map[string]string{"__localq0__": "a"}},
+		{"suppress only seen", "b = 1; a := b", map[string]string{"__localq0__": "a"}},
 	}
 	for _, tc := range tests {
 		t.Run(tc.note, func(t *testing.T) {

--- a/ast/example_test.go
+++ b/ast/example_test.go
@@ -109,5 +109,5 @@ min_x = 100 { true }`
 
 	// Output:
 	//
-	// Compiled: data.opa.example.p[x]; __local0__ = input.query_arg; lt(x, __local0__)
+	// Compiled: data.opa.example.p[x]; __localq0__ = input.query_arg; lt(x, __localq0__)
 }


### PR DESCRIPTION
This adds a map of rewritten variables to the `ast.Compiler` and makes them unique from `queryCompiler` variables which now will be in the form of `__qlocalX__` to distinguish them.

The map of rewritten variables will be handy for resolving names for user facing messages (errors, tracing, etc).