### PR TITLE
Add API to disable rule indexing for evaluation

### DIFF
--- a/ast/index_test.go
+++ b/ast/index_test.go
@@ -559,3 +559,57 @@ func TestSplitStringEscaped(t *testing.T) {
 		})
 	}
 }
+
+func TestGetAllRules(t *testing.T) {
+	module := MustParseModule(`
+	package test
+	
+	default p = 42
+	
+	p {
+		input.x = "x1"
+		input.y = "y1"
+	} else {
+		true
+	} else {
+		input.z = "z1"
+	}
+
+	p {
+		input.z = "z1"      
+	}
+	`)
+
+	index := newBaseDocEqIndex(func(Ref) bool { return false })
+
+	ok := index.Build(module.Rules)
+	if !ok {
+		t.Fatalf("Expected index build to succeed")
+	}
+
+	result, err := index.AllRules(testResolver{input: MustParseTerm(`{}`)})
+	if err != nil {
+		t.Fatalf("Unexpected error during index lookup: %v", err)
+	}
+
+	expectedRules := NewRuleSet(
+		module.Rules[1],
+		module.Rules[2])
+
+	expectedElse := map[*Rule]RuleSet{
+		module.Rules[1]: []*Rule{
+			module.Rules[1].Else,
+			module.Rules[1].Else.Else,
+		},
+	}
+
+	if !NewRuleSet(result.Rules...).Equal(expectedRules) {
+		t.Fatalf("Expected rules to be %v but got: %v", expectedRules, result.Rules)
+	}
+
+	r1 := module.Rules[1]
+
+	if !NewRuleSet(result.Else[r1]...).Equal(expectedElse[r1]) {
+		t.Fatalf("Expected else to be %v but got: %v", result.Else[r1], expectedElse[r1])
+	}
+}

--- a/rego/rego_test.go
+++ b/rego/rego_test.go
@@ -460,6 +460,63 @@ func TestPreparedRegoTracerNoPropagate(t *testing.T) {
 	}
 }
 
+func TestRegoDisableIndexing(t *testing.T) {
+	tracer := topdown.NewBufferTracer()
+	mod := `
+	package test
+
+	p {
+		input.x = 1
+	}
+
+	p {
+		input.y = 1
+	}
+	`
+	pq, err := New(
+		Query("data"),
+		Module("foo.rego", mod),
+	).PrepareForEval(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error %s", err)
+	}
+
+	_, err = pq.Eval(
+		context.Background(),
+		EvalTracer(tracer),
+		EvalRuleIndexing(false),
+		EvalInput(map[string]interface{}{"x": 10}),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error %s", err)
+	}
+
+	var evalNodes []string
+	for _, e := range *tracer {
+		if e.Op == topdown.EvalOp {
+			evalNodes = append(evalNodes, string(e.Node.Loc().Text))
+		}
+	}
+
+	expectedEvalNodes := []string{
+		"input.x = 1",
+		"input.y = 1",
+	}
+
+	for _, expected := range expectedEvalNodes {
+		found := false
+		for _, actual := range evalNodes {
+			if actual == expected {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("Missing expected eval node in trace: %q\nGot: %q\n", expected, evalNodes)
+		}
+	}
+}
+
 func TestRegoCatchPathConflicts(t *testing.T) {
 	r := New(
 		Query("data"),

--- a/topdown/eval.go
+++ b/topdown/eval.go
@@ -37,6 +37,7 @@ type eval struct {
 	cancel          Cancel
 	query           ast.Body
 	index           int
+	indexing        bool
 	bindings        *bindings
 	store           storage.Store
 	baseCache       *baseCache
@@ -1012,7 +1013,14 @@ func (e *eval) getRules(ref ast.Ref) (*ast.IndexResult, error) {
 		return nil, nil
 	}
 
-	result, err := index.Lookup(e)
+	var result *ast.IndexResult
+	var err error
+	if e.indexing {
+		result, err = index.Lookup(e)
+	} else {
+		result, err = index.AllRules(e)
+	}
+
 	if err != nil {
 		return nil, err
 	}

--- a/topdown/query.go
+++ b/topdown/query.go
@@ -35,6 +35,7 @@ type Query struct {
 	genvarprefix     string
 	runtime          *ast.Term
 	builtins         map[string]*Builtin
+	indexing         bool
 }
 
 // Builtin represents a built-in function that queries can call.
@@ -48,6 +49,7 @@ func NewQuery(query ast.Body) *Query {
 	return &Query{
 		query:        query,
 		genvarprefix: ast.WildcardPrefix,
+		indexing:     true,
 	}
 }
 
@@ -142,6 +144,13 @@ func (q *Query) WithBuiltins(builtins map[string]*Builtin) *Query {
 	return q
 }
 
+// WithIndexing will enable or disable using rule indexing for the evaluation
+// of the query. The default is enabled.
+func (q *Query) WithIndexing(enabled bool) *Query {
+	q.indexing = enabled
+	return q
+}
+
 // PartialRun executes partial evaluation on the query with respect to unknown
 // values. Partial evaluation attempts to evaluate as much of the query as
 // possible without requiring values for the unknowns set on the query. The
@@ -180,6 +189,7 @@ func (q *Query) PartialRun(ctx context.Context) (partials []ast.Body, support []
 		disableInlining: q.disableInlining,
 		genvarprefix:    q.genvarprefix,
 		runtime:         q.runtime,
+		indexing:        q.indexing,
 	}
 	e.caller = e
 	q.startTimer(metrics.RegoPartialEval)
@@ -265,6 +275,7 @@ func (q *Query) Iter(ctx context.Context, iter func(QueryResult) error) error {
 		virtualCache: newVirtualCache(),
 		genvarprefix: q.genvarprefix,
 		runtime:      q.runtime,
+		indexing:     q.indexing,
 	}
 	e.caller = e
 	q.startTimer(metrics.RegoQueryEval)


### PR DESCRIPTION
For debugging we would like to have the ability to retrieve all rules
from the Index rather than the filtered ruleset. This API will simply
walk the tree and collect all of the rules.

This allows a client making evaluations to disable the rule indexing,
which particularly useful for debugging purposes.

Essentially this boils down to just calling `AllRules()` versus using
the `Lookup()` API on the index.

There is plumbing included to pass the flag in from the rego API's
down through to the topdown eval.

Signed-off-by: Patrick East <east.patrick@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
