### PR TITLE
Add debug tracing mode

### DIFF
--- a/ast/map.go
+++ b/ast/map.go
@@ -4,7 +4,11 @@
 
 package ast
 
-import "github.com/open-policy-agent/opa/util"
+import (
+	"encoding/json"
+
+	"github.com/open-policy-agent/opa/util"
+)
 
 // ValueMap represents a key/value map between AST term values. Any type of term
 // can be used as a key in the map.
@@ -18,6 +22,21 @@ func NewValueMap() *ValueMap {
 		hashMap: util.NewHashMap(valueEq, valueHash),
 	}
 	return vs
+}
+
+// MarshalJSON provides a custom marshaller for the ValueMap which
+// will include the key, value, and value type.
+func (vs *ValueMap) MarshalJSON() ([]byte, error) {
+	var tmp []map[string]interface{}
+	vs.Iter(func(k Value, v Value) bool {
+		tmp = append(tmp, map[string]interface{}{
+			"name":  k.String(),
+			"type":  TypeName(v),
+			"value": v,
+		})
+		return false
+	})
+	return json.Marshal(tmp)
 }
 
 // Copy returns a shallow copy of the ValueMap.

--- a/tester/reporter_test.go
+++ b/tester/reporter_test.go
@@ -195,6 +195,8 @@ func TestJSONReporter(t *testing.T) {
 		  "QueryID": 0,
 		  "ParentID": 0,
 		  "Locals": null,
+          "LocalMetadata": null,
+		  "Location": null,
 		  "Message": ""
 		}
 	  ]
@@ -233,6 +235,8 @@ func TestJSONReporter(t *testing.T) {
 		  "QueryID": 0,
 		  "ParentID": 0,
 		  "Locals": null,
+		  "LocalMetadata": null,
+		  "Location": null,
 		  "Message": ""
 		}
 	  ]
@@ -271,6 +275,8 @@ func TestJSONReporter(t *testing.T) {
 		  "QueryID": 0,
 		  "ParentID": 0,
 		  "Locals": null,
+		  "LocalMetadata": null,
+		  "Location": null,
 		  "Message": ""
 		}
 	  ]  }

--- a/topdown/trace.go
+++ b/topdown/trace.go
@@ -44,14 +44,23 @@ const (
 	IndexOp Op = "Index"
 )
 
+// VarMetadata provides some user facing information about
+// a variable in some policy.
+type VarMetadata struct {
+	Name     string        `json:"name"`
+	Location *ast.Location `json:"location"`
+}
+
 // Event contains state associated with a tracing event.
 type Event struct {
-	Op       Op            // Identifies type of event.
-	Node     ast.Node      // Contains AST node relevant to the event.
-	QueryID  uint64        // Identifies the query this event belongs to.
-	ParentID uint64        // Identifies the parent query this event belongs to.
-	Locals   *ast.ValueMap // Contains local variable bindings from the query context.
-	Message  string        // Contains message for Note events.
+	Op            Op                     // Identifies type of event.
+	Node          ast.Node               // Contains AST node relevant to the event.
+	Location      *ast.Location          // The location of the Node this event relates to.
+	QueryID       uint64                 // Identifies the query this event belongs to.
+	ParentID      uint64                 // Identifies the parent query this event belongs to.
+	Locals        *ast.ValueMap          // Contains local variable bindings from the query context.
+	LocalMetadata map[string]VarMetadata // Contains metadata for the local variable bindings.
+	Message       string                 // Contains message for Note events.
 }
 
 // HasRule returns true if the Event contains an ast.Rule.


### PR DESCRIPTION
This adds a new option for eval which will disable indexing so
that variable bindings for rules that would otherwise not evaluate
can be found.

This also adds to (and corrects) the JSON marshalled trace events. We
now have extra metadata about the local variables, a working JSON
marshaller for the `Locals` (which includes type info), and the event
nodes location information.

Fixes: #1697
Signed-off-by: Patrick East <east.patrick@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
