### PR TITLE
docs: Clarify kube-mgmt/Gatekeeper K8s docs

### DIFF
--- a/docs/content/kubernetes-debugging.md
+++ b/docs/content/kubernetes-debugging.md
@@ -9,6 +9,9 @@ Kubernetes there are a few things you can check to make sure everything is
 configured correctly. If none of these tips work, feel free to join
 [slack.openpolicyagent.org](https://slack.openpolicyagent.org) and ask for help.
 
+The tips below cover the OPA-Kubernetes integration that uses kube-mgmt.
+The [OPA Gatekeeper version](https://github.com/open-policy-agent/gatekeeper) has its own docs.
+
 ### Check for the `openpolicyagent.org/policy-status` annotation on ConfigMaps containing policies
 
 If you are loading policies into OPA via

--- a/docs/content/kubernetes-introduction.md
+++ b/docs/content/kubernetes-introduction.md
@@ -57,7 +57,7 @@ If you want to kick the tires:
 **Recommendation**: OPA Gatekeeper is currently in beta. If you are getting
 started with admission control, we recommend you try it out.
 
-## How Does It Work With Plain OPA?
+## How Does It Work With Plain OPA and Kube-mgmt?
 
 The Kubernetes API Server is configured to query OPA for admission control
 decisions when objects (e.g., Pods, Services, etc.) are created, updated, or

--- a/docs/content/kubernetes-primer.md
+++ b/docs/content/kubernetes-primer.md
@@ -5,7 +5,8 @@ weight: 2
 ---
 
 Read this page if you are new to Kubernetes admission control with OPA and want
-to learn how to write policies for Kubernetes.
+to learn how to write policies for Kubernetes.  It covers the version
+that uses kube-mgmt. The [OPA Gatekeeper version](https://github.com/open-policy-agent/gatekeeper) has its own docs.
 
 ## Writing Policies
 

--- a/docs/content/kubernetes-tutorial.md
+++ b/docs/content/kubernetes-tutorial.md
@@ -5,6 +5,7 @@ weight: 10
 ---
 
 This tutorial shows how to deploy OPA as an admission controller from scratch.
+It covers the OPA-kubernetes version that uses kube-mgmt.  The [OPA Gatekeeper version](https://github.com/open-policy-agent/gatekeeper) has its own docs.
 For the purpose of the tutorial we will deploy two policies that ensure:
 
 - Ingress hostnames must be whitelisted on the Namespace containing the Ingress.


### PR DESCRIPTION
Previously the docs detailing the OPA-k8s integration only distinguished
between v1 (kube-mgmt) and v3 (gatekeeper) in the introduction page.
The debugging, primer, and tutorial pages did not explicitly state
which version they were detailing.

This change clarifies that those pages refer to the kube-mgmt
version and provide a pointer to the Gatekeeper readme.

Signed-off-by: Tim Hinrichs <tim@styra.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
