### PR TITLE
Timeout flag on individual test cases in opa test command

### DIFF
--- a/cmd/test.go
+++ b/cmd/test.go
@@ -113,7 +113,7 @@ Example test run:
 }
 
 func opaTest(args []string) int {
-	ctx, cancel := context.WithTimeout(context.Background(), testParams.timeout)
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	filter := loaderFilter{
@@ -175,7 +175,8 @@ func opaTest(args []string) int {
 		EnableFailureLine(testParams.failureLine).
 		SetRuntime(info).
 		SetModules(modules).
-		SetBundles(bundles)
+		SetBundles(bundles).
+		SetTimeout(testParams.timeout)
 
 	ch, err := runner.RunTests(ctx, txn)
 	if err != nil {

--- a/tester/runner.go
+++ b/tester/runner.go
@@ -107,7 +107,9 @@ type Runner struct {
 
 // NewRunner returns a new runner.
 func NewRunner() *Runner {
-	return &Runner{}
+	return &Runner{
+		timeout: 5 * time.Second,
+	}
 }
 
 // SetCompiler sets the compiler used by the runner.

--- a/tester/runner.go
+++ b/tester/runner.go
@@ -7,6 +7,7 @@ package tester
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -341,7 +342,7 @@ func (r *Runner) runTest(ctx context.Context, txn storage.Transaction, mod *ast.
 
 	if err != nil {
 		tr.Error = err
-		if topdown.IsCancel(err) {
+		if topdown.IsCancel(err) && !errors.Is(ctx.Err(), context.DeadlineExceeded) {
 			stop = true
 		}
 	} else if len(rs) == 0 {

--- a/tester/runner.go
+++ b/tester/runner.go
@@ -269,9 +269,11 @@ func (r *Runner) RunTests(ctx context.Context, txn storage.Transaction) (ch chan
 				if !strings.HasPrefix(string(rule.Head.Name), TestPrefix) {
 					continue
 				}
-				runCtx, cancel := context.WithTimeout(ctx, r.timeout)
-				defer cancel()
-				tr, stop := r.runTest(runCtx, txn, module, rule)
+				tr, stop := func() (*Result, bool) {
+					runCtx, cancel := context.WithTimeout(ctx, r.timeout)
+					defer cancel()
+					return r.runTest(runCtx, txn, module, rule)
+				}()
 				ch <- tr
 				if stop {
 					return

--- a/tester/runner.go
+++ b/tester/runner.go
@@ -7,7 +7,6 @@ package tester
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -346,7 +345,7 @@ func (r *Runner) runTest(ctx context.Context, txn storage.Transaction, mod *ast.
 
 	if err != nil {
 		tr.Error = err
-		if topdown.IsCancel(err) && !errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		if topdown.IsCancel(err) && !(ctx.Err() == context.DeadlineExceeded) {
 			stop = true
 		}
 	} else if len(rs) == 0 {

--- a/tester/runner_test.go
+++ b/tester/runner_test.go
@@ -198,7 +198,7 @@ func TestRunner_Timeout(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		duration, err := time.ParseDuration("1ns")
+		duration, err := time.ParseDuration("15ms")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -212,6 +212,9 @@ func TestRunner_Timeout(t *testing.T) {
 		}
 		if !topdown.IsCancel(results[0].Error) {
 			t.Fatalf("Expected cancel error but got: %v", results[0].Error)
+		}
+		if topdown.IsCancel(results[1].Error) {
+			t.Fatalf("Expected no error for second test, but it timed out")
 		}
 	})
 }


### PR DESCRIPTION
Implement the test timeout at individual test level to make it easier to scale rego test when using the --timeout flag.

Fixes #1788 

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
