### PR TITLE
cmd: Fix opa eval to specify profiler tracer correctly

### DIFF
--- a/cmd/eval.go
+++ b/cmd/eval.go
@@ -320,7 +320,7 @@ func eval(args []string, params evalCommandParams, w io.Writer) (bool, error) {
 	var p *profiler.Profiler
 	if params.profile {
 		p = profiler.New()
-		regoArgs = append(regoArgs, rego.Tracer(p))
+		evalArgs = append(evalArgs, rego.EvalTracer(p))
 	}
 
 	if params.partial {

--- a/cmd/eval_test.go
+++ b/cmd/eval_test.go
@@ -50,6 +50,38 @@ func TestEvalExitCode(t *testing.T) {
 	}
 }
 
+func TestEvalWithProfiler(t *testing.T) {
+	files := map[string]string{
+		"x.rego": `package x
+
+p = 1`,
+	}
+
+	test.WithTempFS(files, func(path string) {
+
+		params := newEvalCommandParams()
+		params.profile = true
+		params.dataPaths = newrepeatedStringFlag([]string{path})
+
+		var buf bytes.Buffer
+
+		defined, err := eval([]string{"data"}, params, &buf)
+		if !defined || err != nil {
+			t.Fatalf("Unexpected undefined or error: %v", err)
+		}
+
+		var output presentation.Output
+
+		if err := util.NewJSONDecoder(&buf).Decode(&output); err != nil {
+			t.Fatal(err)
+		}
+
+		if len(output.Profile) == 0 {
+			t.Fatal("Expected profile output to be non-empty")
+		}
+	})
+}
+
 func TestEvalWithCoverage(t *testing.T) {
 
 	files := map[string]string{


### PR DESCRIPTION
b0c875c374b7f9723612269ebdc4db55d5b8bb42 missed the profiling
tracer. As a result, the profiling tracer was not being used during evaluation.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
