### PR TITLE
bundle: Add more details to manifest root errors

### DIFF
--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -92,7 +92,7 @@ func (m *Manifest) validateAndInjectDefaults(b Bundle) error {
 			}
 		}
 		if !found {
-			return fmt.Errorf("manifest roots do not permit '%v' in %v", module.Parsed.Package, module.Path)
+			return fmt.Errorf("manifest roots %v do not permit '%v' in module '%v'", roots, module.Parsed.Package, module.Path)
 		}
 	}
 
@@ -111,7 +111,7 @@ func (m *Manifest) validateAndInjectDefaults(b Bundle) error {
 				}
 			}
 		}
-		return false, fmt.Errorf("manifest roots do not permit data at path %v", path)
+		return false, fmt.Errorf("manifest roots %v do not permit data at path '/%s' (hint: check bundle directory structure)", roots, path)
 	})
 }
 

--- a/bundle/bundle_test.go
+++ b/bundle/bundle_test.go
@@ -135,7 +135,7 @@ func TestReadRootValidation(t *testing.T) {
 				{"/.manifest", `{"revision": "abcd", "roots": []}`},
 				{"/x.rego", `package foo`},
 			},
-			err: "manifest roots do not permit 'package foo' in /x.rego",
+			err: "manifest roots [] do not permit 'package foo' in module '/x.rego'",
 		},
 		{
 			note: "err: overlapped",
@@ -158,7 +158,7 @@ func TestReadRootValidation(t *testing.T) {
 				{"/a.rego", `package b.c`},
 				{"/x.rego", `package c.e`},
 			},
-			err: "manifest roots do not permit 'package c.e' in /x.rego",
+			err: "manifest roots [a b c/d] do not permit 'package c.e' in module '/x.rego'",
 		},
 		{
 			note: "err: data outside scope",
@@ -167,7 +167,7 @@ func TestReadRootValidation(t *testing.T) {
 				{"/data.json", `{"a": 1}`},
 				{"/c/e/data.json", `"bad bad bad"`},
 			},
-			err: "manifest roots do not permit data at path c/e",
+			err: "manifest roots [a b c/d] do not permit data at path '/c/e'",
 		},
 	}
 

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -161,6 +161,9 @@ func AsBundle(path string) (*bundle.Bundle, error) {
 
 	br := bundle.NewCustomReader(bundleLoader)
 	b, err := br.Read()
+	if err != nil {
+		err = errors.Wrap(err, fmt.Sprintf("bundle %s", path))
+	}
 	return &b, err
 }
 
@@ -335,7 +338,11 @@ func loadKnownTypes(path string, bs []byte) (interface{}, error) {
 		return loadYAML(path, bs)
 	default:
 		if strings.HasSuffix(path, ".tar.gz") {
-			return loadBundleFile(bs)
+			r, err := loadBundleFile(bs)
+			if err != nil {
+				err = errors.Wrap(err, fmt.Sprintf("bundle %s", path))
+			}
+			return r, err
 		}
 	}
 	return nil, unrecognizedFile(path)

--- a/rego/rego.go
+++ b/rego/rego.go
@@ -1322,7 +1322,7 @@ func (r *Rego) loadBundles(ctx context.Context, txn storage.Transaction, m metri
 	for _, path := range r.bundlePaths {
 		bndl, err := loader.AsBundle(path)
 		if err != nil {
-			return fmt.Errorf("error loading bundle path %s: %s", path, err)
+			return fmt.Errorf("loading error: %s", err)
 		}
 		r.bundles[path] = bndl
 	}


### PR DESCRIPTION
The newer output ensures that the bundle name is shown, the roots being used, and a better representation of the path in question.

