### PR TITLE
build: Fix build-release.sh by removing obsolete make deps command

### DIFF
--- a/build/build-release.sh
+++ b/build/build-release.sh
@@ -42,7 +42,6 @@ elif [ -z "$SOURCE_URL" ]; then
 fi
 
 build_release() {
-    make deps
     GOOS=darwin GOARCH=amd64 make build
     GOOS=linux GOARCH=amd64 make build
     GOOS=windows GOARCH=amd64 make build


### PR DESCRIPTION
The deps target was removed when we switched to Go modules however the
build-release.sh script wasn't updated which broke the release
process.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
