### PR TITLE
topdown: Provide rewritten query vars in traces

### DIFF
--- a/rego/rego.go
+++ b/rego/rego.go
@@ -1478,6 +1478,7 @@ func (r *Rego) compileQuery(query ast.Body, m metrics.Metrics, extras []extraSta
 func (r *Rego) eval(ctx context.Context, ectx *EvalContext) (ResultSet, error) {
 
 	q := topdown.NewQuery(ectx.compiledQuery.query).
+		WithQueryCompiler(ectx.compiledQuery.compiler).
 		WithCompiler(r.compiler).
 		WithStore(r.store).
 		WithTransaction(ectx.txn).
@@ -1655,6 +1656,7 @@ func (r *Rego) partial(ctx context.Context, ectx *EvalContext) (*PartialQueries,
 	}
 
 	q := topdown.NewQuery(ectx.compiledQuery.query).
+		WithQueryCompiler(ectx.compiledQuery.compiler).
 		WithCompiler(r.compiler).
 		WithStore(r.store).
 		WithTransaction(ectx.txn).

--- a/topdown/eval.go
+++ b/topdown/eval.go
@@ -36,6 +36,7 @@ type eval struct {
 	caller          *eval
 	cancel          Cancel
 	query           ast.Body
+	queryCompiler   ast.QueryCompiler
 	index           int
 	indexing        bool
 	bindings        *bindings
@@ -159,6 +160,11 @@ func (e *eval) traceEvent(op Op, x ast.Node, msg string) {
 			rewritten, ok := e.compiler.RewrittenVars[name]
 			if ok {
 				name = rewritten
+			} else if e.queryCompiler != nil {
+				rewritten, ok := e.queryCompiler.RewrittenVars()[name]
+				if ok {
+					name = rewritten
+				}
 			}
 		}
 


### PR DESCRIPTION
This plumbs through the query compiler to the topdown query and eval
objects. We then use it to get rewritten vars when creating trace
events.

Signed-off-by: Patrick East <east.patrick@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
