### PR TITLE
ast: Fix module JSON unmarshalling

### DIFF
--- a/ast/policy.go
+++ b/ast/policy.go
@@ -271,6 +271,26 @@ func (mod *Module) RuleSet(name Var) RuleSet {
 	return rs
 }
 
+// UnmarshalJSON parses bs and stores the result in mod. The rules in the module
+// will have their module pointer set to mod.
+func (mod *Module) UnmarshalJSON(bs []byte) error {
+
+	// Declare a new type and use a type conversion to avoid recursively calling
+	// Module#UnmarshalJSON.
+	type module Module
+
+	if err := util.UnmarshalJSON(bs, (*module)(mod)); err != nil {
+		return err
+	}
+
+	WalkRules(mod, func(rule *Rule) bool {
+		rule.Module = mod
+		return false
+	})
+
+	return nil
+}
+
 // NewComment returns a new Comment object.
 func NewComment(text []byte) *Comment {
 	return &Comment{

--- a/ast/policy_test.go
+++ b/ast/policy_test.go
@@ -57,6 +57,9 @@ assigned := 1
 		t.Fatalf("Expected roundtripped module to be equal to original:\nExpected:\n\n%v\n\nGot:\n\n%v\n", mod, roundtrip)
 	}
 
+	if mod.Rules[3].Path().String() != "data.a.b.c.t" {
+		t.Fatal("expected path data.a.b.c.t for 4th rule in module but got:", mod.Rules[3].Path())
+	}
 }
 
 func TestBodyEmptyJSON(t *testing.T) {


### PR DESCRIPTION
Previously when a module was unmarshalled from JSON the rules
contained in the module would not have their module pointers set. This
would cause the Path() function on the rule objects to panic.

This change updates the module struct to walk the rules and set the
module pointer accordingly.

This was discussed in #1780

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
