### PR TITLE
types: Fix constant select on array types

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -182,11 +182,13 @@ func (t *Array) Len() int {
 
 // Select returns the type of element at the zero-based pos.
 func (t *Array) Select(pos int) Type {
-	if len(t.static) > pos {
-		return t.static[pos]
-	}
-	if t.dynamic != nil {
-		return t.dynamic
+	if pos >= 0 {
+		if len(t.static) > pos {
+			return t.static[pos]
+		}
+		if t.dynamic != nil {
+			return t.dynamic
+		}
 	}
 	return nil
 }

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -192,6 +192,8 @@ func TestSelect(t *testing.T) {
 		{"static", NewArray([]Type{S}, nil), json.Number("0"), S},
 		{"dynamic", NewArray(nil, S), json.Number("100"), S},
 		{"out of range", NewArray([]Type{S, N, B}, nil), json.Number("4"), nil},
+		{"out of range negative", NewArray([]Type{S, N, B}, nil), json.Number("-4"), nil},
+		{"negative", NewArray([]Type{S, N, B}, nil), json.Number("-2"), nil},
 		{"non int", NewArray([]Type{S, N, B}, nil), json.Number("1.5"), nil},
 		{"non int-2", NewArray([]Type{S, N, B}, nil), 1, nil},
 		{"static", NewObject([]*StaticProperty{NewStaticProperty("hello", S)}, nil), "hello", S},


### PR DESCRIPTION
If a negative array index was hardcoded in the policy it would cause a
panic (e.g., arr[-1]). This patch just fixes the select function to
return nil like it does for out-of-bounds.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
