### PR TITLE
wasm: Fix planning of virtual document extent

### DIFF
--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -1541,9 +1541,9 @@ func (p *Planner) planRefDataExtent(virtual *ruletrie, base *baseptr, iter plani
 				Target: target,
 			}
 			p.appendStmt(stmt)
-			p.appendStmt(&ir.BreakStmt{Index: 1})
 		}
 
+		p.appendStmt(&ir.BreakStmt{Index: 1})
 		return nil
 	})
 
@@ -1552,6 +1552,9 @@ func (p *Planner) planRefDataExtent(virtual *ruletrie, base *baseptr, iter plani
 	}
 
 	inner := p.curr
+
+	// Fallback to virtual document value if base document is undefined.
+	// Otherwise, this block is undefined.
 	p.curr = &ir.Block{}
 	p.appendStmt(&ir.BlockStmt{Blocks: []*ir.Block{inner}})
 
@@ -1560,6 +1563,8 @@ func (p *Planner) planRefDataExtent(virtual *ruletrie, base *baseptr, iter plani
 			Source: vtarget,
 			Target: target,
 		})
+	} else {
+		p.appendStmt(&ir.BreakStmt{Index: 1})
 	}
 
 	outer := p.curr

--- a/test/wasm/assets/013_virtual.yaml
+++ b/test/wasm/assets/013_virtual.yaml
@@ -9,6 +9,26 @@ cases:
       data == {"x": {"y": 1, "z": 2}}
     data: {"x": {"y": 1, "z": "deadbeef"}}
     want_defined: false
+  - note: base data extent path
+    query: |
+      data.x == {"y": 1, "z": 2}
+    data: {'x': {'y': 1, 'z': 2}}
+    want_defined: true
+  - note: base data extent path (negative)
+    query: |
+      data.deadbeef
+    data: {'x': {'y': 1, 'z': 2}}
+    want_defined: false
+  - note: base data extent path-2
+    query: |
+      data.x.y == 1
+    data: {'x': {'y': 1, 'z': 2}}
+    want_defined: true
+  - note: base data extent path-2 (negative)
+    query: |
+      data.x.deadbeef
+    data: {'x': {'y': 1, 'z': 2}}
+    want_defined: false
   - note: base data iteration
     query: data.foo[x] = y; x == "b"; y == 2
     data: {"foo": {"a": 1, "b": 2, "c": 3}}


### PR DESCRIPTION
This change updates the planner to generate breaks when the virtual
node is empty. Previously the planner was NOT generating breaks which
meant that if the base path dereferencing failed, execution would
simply continue from the next statement in the query (or if this was
the last statement in the query, a result would be generated.)

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
