### PR TITLE
wasm: Small improvements to the test generator

### DIFF
--- a/build/run-wasm-rego-tests.sh
+++ b/build/run-wasm-rego-tests.sh
@@ -10,6 +10,7 @@
 set -ex
 
 GOVERSION=${GOVERSION:?"You must set the GOVERSION environment variable."}
+ASSETS=${ASSETS:-"$PWD/test/wasm/assets"}
 VERBOSE=${VERBOSE:-"0"}
 TESTGEN_CONTAINER_NAME="opa-wasm-testgen-container"
 TESTRUN_CONTAINER_NAME="opa-wasm-testrun-container"
@@ -46,12 +47,14 @@ function generate_testcases {
         -u $(id -u):$(id -g) \
         -v $PWD/.go/bin:/go/bin \
         -v $PWD:/src \
+        -v $ASSETS:/assets \
         -e GOCACHE=/src/.go/cache \
         -w /src \
         golang:$GOVERSION \
         sh -c 'make wasm-rego-testgen-install \
                 && wasm-rego-testgen \
-                --input-dir=/src/test/wasm/assets \
+                --input-dir=/assets \
+                --runner=/src/test/wasm/assets/test.js \
                 --output=/src/.go/cache/testcases.tar.gz'
 }
 


### PR DESCRIPTION
This patch has a few small changes to the generator and bash script:

* Accept out-of-tree asset directory in run script
* Accept YAML _and_ JSON asset files
* Accept runner path as separate argument

These changes make it easier to run tests from places other than the
in-tree asset dir.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
