### PR TITLE
wasm: Plan default rule bodies

### DIFF
--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -275,13 +275,17 @@ func (p *Planner) planRules(rules []*ast.Rule) (string, error) {
 
 		p.curr = fn.Blocks[len(fn.Blocks)-1]
 
-		if err := p.planTerm(defaultRule.Head.Value, func() error {
-			p.appendStmt(&ir.AssignVarStmt{
-				Target: fn.Return,
-				Source: p.ltarget,
+		err := p.planQuery(defaultRule.Body, 0, func() error {
+			return p.planTerm(defaultRule.Head.Value, func() error {
+				p.appendStmt(&ir.AssignVarOnceStmt{
+					Target: fn.Return,
+					Source: p.ltarget,
+				})
+				return nil
 			})
-			return nil
-		}); err != nil {
+		})
+
+		if err != nil {
 			return "", err
 		}
 	}

--- a/test/wasm/assets/009_default.yaml
+++ b/test/wasm/assets/009_default.yaml
@@ -30,3 +30,19 @@ cases:
         default p = 1
         p = 2
     want_defined: true
+  - note: default requires eval
+    query: data.x.p = []
+    modules:
+      - |
+        package x
+        default p = [1 | false]
+        p = "deadbeef" { false }
+    want_defined: True
+  - note: default requires eval
+    query: data.x.p = [1]
+    modules:
+      - |
+        package x
+        default p = [1 | true]
+        p = "deadbeef" { false }
+    want_defined: true


### PR DESCRIPTION
The planner was assuming that default rule values were always
constants however they just need to be guaranteed to be defined at
runtime. The semantic checks in the compiler permit comprehensions so
the planner has to run query planning on the rule body.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
