### PR TITLE
wasm: Fix planner to check call expression for false return value

### DIFF
--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -678,7 +678,7 @@ func (p *Planner) planExprCall(e *ast.Expr, iter planiter) error {
 
 		if len(operands) == arity {
 			// rule: f(x) = x { ... }
-			// call: f(x) == 1 or f(x) # result not captured
+			// call: f(x) # result not captured
 			return p.planCallArgs(operands, 0, args, func(args []ir.Local) error {
 				p.ltarget = p.newLocal()
 				p.appendStmt(&ir.CallStmt{
@@ -686,6 +686,19 @@ func (p *Planner) planExprCall(e *ast.Expr, iter planiter) error {
 					Args:   args,
 					Result: p.ltarget,
 				})
+
+				falsy := p.newLocal()
+
+				p.appendStmt(&ir.MakeBooleanStmt{
+					Value:  false,
+					Target: falsy,
+				})
+
+				p.appendStmt(&ir.NotEqualStmt{
+					A: p.ltarget,
+					B: falsy,
+				})
+
 				return iter()
 			})
 		} else if len(operands) == arity+1 {

--- a/test/wasm/assets/008_functions.yaml
+++ b/test/wasm/assets/008_functions.yaml
@@ -104,3 +104,19 @@ cases:
         f(x) = 1
         f(x) = 2
     want_error: var assignment conflict
+  - note: 'false result'
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+        f(x) = false
+        p = true { f(1) }
+    want_defined: false
+  - note: 'negated false result'
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+        f(x) = false
+        p = true { not f(1) }
+    want_defined: true


### PR DESCRIPTION
The planner was not checking call expression results for false return
values that ought to cause evaluation to fail. This meant that
evaluation would continue to the next expression.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
