### PR TITLE
bundle: Make the DirectoryLoader public

### DIFF
--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -23,7 +23,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/open-policy-agent/opa/ast"
-	"github.com/open-policy-agent/opa/internal/file"
 	"github.com/open-policy-agent/opa/util"
 )
 
@@ -124,19 +123,18 @@ type ModuleFile struct {
 
 // Reader contains the reader to load the bundle from.
 type Reader struct {
-	loader                file.DirectoryLoader
+	loader                DirectoryLoader
 	includeManifestInData bool
 }
 
-// NewReader returns a new Reader.
-// Deprecated: Use NewCustomReader with TarballLoader instead
+// NewReader returns a new Reader which is configured for reading tarballs.
 func NewReader(r io.Reader) *Reader {
-	return NewCustomReader(file.NewTarballLoader(r))
+	return NewCustomReader(NewTarballLoader(r))
 }
 
 // NewCustomReader returns a new Reader configured to use the
 // specified DirectoryLoader.
-func NewCustomReader(loader file.DirectoryLoader) *Reader {
+func NewCustomReader(loader DirectoryLoader) *Reader {
 	nr := Reader{
 		loader: loader,
 	}

--- a/bundle/file.go
+++ b/bundle/file.go
@@ -1,4 +1,4 @@
-package file
+package bundle
 
 import (
 	"archive/tar"

--- a/bundle/file_test.go
+++ b/bundle/file_test.go
@@ -1,4 +1,4 @@
-package file
+package bundle
 
 import (
 	"bytes"

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/bundle"
-	"github.com/open-policy-agent/opa/internal/file"
 	fileurl "github.com/open-policy-agent/opa/internal/file/url"
 	"github.com/open-policy-agent/opa/internal/merge"
 	"github.com/open-policy-agent/opa/storage"
@@ -147,16 +146,16 @@ func AsBundle(path string) (*bundle.Bundle, error) {
 		return nil, fmt.Errorf("error reading %q: %s", path, err)
 	}
 
-	var bundleLoader file.DirectoryLoader
+	var bundleLoader bundle.DirectoryLoader
 
 	if fi.IsDir() {
-		bundleLoader = file.NewDirectoryLoader(path)
+		bundleLoader = bundle.NewDirectoryLoader(path)
 	} else {
 		fh, err := os.Open(path)
 		if err != nil {
 			return nil, err
 		}
-		bundleLoader = file.NewTarballLoader(fh)
+		bundleLoader = bundle.NewTarballLoader(fh)
 	}
 
 	br := bundle.NewCustomReader(bundleLoader)
@@ -365,7 +364,7 @@ func loadFileForAnyType(path string, bs []byte) (interface{}, error) {
 }
 
 func loadBundleFile(bs []byte) (bundle.Bundle, error) {
-	tl := file.NewTarballLoader(bytes.NewBuffer(bs))
+	tl := bundle.NewTarballLoader(bytes.NewBuffer(bs))
 	br := bundle.NewCustomReader(tl).IncludeManifestInData(true)
 	return br.Read()
 }


### PR DESCRIPTION
Previously we had it in an internal package but used by a public API,
which basically means it can't actually be used outside of OPA.
Initial thinking was that this was an OK situation, but by popular
demand we are making it available to everyone so OPA as a lib users
can use the bundle loading API's.

Fixes: #1840
Signed-off-by: Patrick East <east.patrick@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
