### PR TITLE
topdown: Add raw_body parameter to http.send

### DIFF
--- a/topdown/topdown_test.go
+++ b/topdown/topdown_test.go
@@ -2979,7 +2979,7 @@ func assertTopDownWithPath(t *testing.T, compiler *ast.Compiler, store storage.S
 			}
 
 			if util.Compare(expected, result) != 0 {
-				t.Fatalf("Unexpected result:\nGot: %v\nExp:\n%v", result, expected)
+				t.Fatalf("Unexpected result:\nGot: %+v\nExp:\n%+v", result, expected)
 			}
 
 			// If the test case involved the input document, re-run it with partial


### PR DESCRIPTION
Instead of changing the behaviour of the body parameter (which is
always sent as JSON) just add a new parameter that gives the caller
complete control over the message body.

Fixes #1903

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
