### PR TITLE
Make network ids consistent so that opa eval examples work

### DIFF
--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -479,7 +479,7 @@ some n; public_network[n]
 Lastly, you can check if a value exists in the set using the same syntax:
 
 ```live:example/partial_set/exists:query:merge_down
-public_network["net3"]
+public_network["n3"]
 ```
 ```live:example/partial_set/exists:output
 ```

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -68,15 +68,15 @@ receives a JSON representation of the system as input:
         {"id": "busybox", "protocols": ["telnet"], "ports": ["p1"]}
     ],
     "networks": [
-        {"id": "net1", "public": false},
-        {"id": "net2", "public": false},
-        {"id": "net3", "public": true},
-        {"id": "net4", "public": true}
+        {"id": "n1", "public": false},
+        {"id": "n2", "public": false},
+        {"id": "n3", "public": true},
+        {"id": "n4", "public": true}
     ],
     "ports": [
-        {"id": "p1", "network": "net1"},
-        {"id": "p2", "network": "net3"},
-        {"id": "p3", "network": "net2"}
+        {"id": "p1", "network": "n1"},
+        {"id": "p2", "network": "n3"},
+        {"id": "p3", "network": "n2"}
     ]
 }
 ```
@@ -692,10 +692,10 @@ For example:
         {"id": "busybox", "protocols": ["telnet"], "ports": ["p1"]}
     ],
     "networks": [
-        {"id": "net1", "public": false},
-        {"id": "net2", "public": false},
-        {"id": "net3", "public": true},
-        {"id": "net4", "public": true}
+        {"id": "n1", "public": false},
+        {"id": "n2", "public": false},
+        {"id": "n3", "public": true},
+        {"id": "n4", "public": true}
     ],
     "ports": [
         {"id": "p1", "network": "n1"},


### PR DESCRIPTION
In the "Running OPA" /"Try OPA Eval" section of the docs and example `./opa eval -i input.json -d example.rego 'data.example.violation[x]'` is given.

This example doesn't return anything due to the network ids in the supplied json file being inconsistent.

This PR makes the two input json docs consistent between each other and internally so that the given example works.


