### PR TITLE
live-blocks: Fix for new playground undefined eval response

### DIFF
--- a/docs/website/scripts/live-blocks/src/web/playground.js
+++ b/docs/website/scripts/live-blocks/src/web/playground.js
@@ -27,6 +27,9 @@ export async function playgroundEval(groups, groupName) {
     if (parsed.pretty) {
       return parsed.pretty.replace(/\n$/, '') // Some responses may have trailing newlines
     }
+    if (parsed.result === null) {
+      throw new OPAErrors("undefined decision", undefined)
+    }
     // Else throw below
   } else if (parsed.message) { // The server returned a non-200 code and a message
     const message = parsed.message.replace(/\n$/, '') // Some messages may have trailing newlines


### PR DESCRIPTION
The playground changed to just return a null result rather than
returning a 4xx error for the response. We need to catch this case
and raise the expected OPAError in the live blocks scripts to keep
the UI behavior the same.

Signed-off-by: Patrick East <east.patrick@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
