### PR TITLE
topdown: Fix trace to unmangle variables

### DIFF
--- a/cmd/eval_test.go
+++ b/cmd/eval_test.go
@@ -341,7 +341,7 @@ func TestEvalDebugTraceJSONOutput(t *testing.T) {
 	params.disableIndexing = true
 
 	mod := `package x
-	
+
 	p {
 		a := input.z
 		a == 1
@@ -416,7 +416,7 @@ func TestEvalDebugTraceJSONOutput(t *testing.T) {
 	expectedEvalLocationsAndVars := []locationAndVars{
 		{
 			location:    ast.NewLocation(nil, policyFile, 4, 3), // a := input.z
-			varBindings: map[string]string{},
+			varBindings: map[string]string{"__local0__": "a"},
 		},
 		{
 			location:    ast.NewLocation(nil, policyFile, 5, 3), // a == 1
@@ -424,7 +424,7 @@ func TestEvalDebugTraceJSONOutput(t *testing.T) {
 		},
 		{
 			location:    ast.NewLocation(nil, policyFile, 9, 3), // b := input.y
-			varBindings: map[string]string{},
+			varBindings: map[string]string{"__local1__": "b"},
 		},
 	}
 

--- a/topdown/eval.go
+++ b/topdown/eval.go
@@ -152,30 +152,33 @@ func (e *eval) traceEvent(op Op, x ast.Node, msg string) {
 	}
 
 	locals := ast.NewValueMap()
-	localMeta := map[string]VarMetadata{}
-	e.bindings.Iter(nil, func(k, v *ast.Term) error {
-		// Check if the var has a different name in the source policy
-		name := k.Value.(ast.Var)
-		if e.compiler != nil {
-			rewritten, ok := e.compiler.RewrittenVars[name]
-			if ok {
-				name = rewritten
-			} else if e.queryCompiler != nil {
-				rewritten, ok := e.queryCompiler.RewrittenVars()[name]
-				if ok {
-					name = rewritten
-				}
-			}
-		}
+	localMeta := map[ast.Var]VarMetadata{}
 
-		localMeta[k.Value.String()] = VarMetadata{
-			Name:     name.String(),
+	e.bindings.Iter(nil, func(k, v *ast.Term) error {
+		original := k.Value.(ast.Var)
+		rewritten, _ := e.rewrittenVar(original)
+		localMeta[original] = VarMetadata{
+			Name:     rewritten,
 			Location: k.Loc(),
 		}
 
 		// For backwards compatibility save a copy of the values too..
 		locals.Put(k.Value, v.Value)
 		return nil
+	})
+
+	ast.WalkTerms(x, func(term *ast.Term) bool {
+		if v, ok := term.Value.(ast.Var); ok {
+			if _, ok := localMeta[v]; !ok {
+				if rewritten, ok := e.rewrittenVar(v); ok {
+					localMeta[v] = VarMetadata{
+						Name:     rewritten,
+						Location: term.Loc(),
+					}
+				}
+			}
+		}
+		return false
 	})
 
 	var parentID uint64
@@ -1187,6 +1190,20 @@ func (e *eval) resolveReadFromStorage(ref ast.Ref, a ast.Value) (ast.Value, erro
 
 func (e *eval) generateVar(suffix string) *ast.Term {
 	return ast.VarTerm(fmt.Sprintf("%v_%v", e.genvarprefix, suffix))
+}
+
+func (e *eval) rewrittenVar(v ast.Var) (ast.Var, bool) {
+	if e.compiler != nil {
+		if rw, ok := e.compiler.RewrittenVars[v]; ok {
+			return rw, true
+		}
+	}
+	if e.queryCompiler != nil {
+		if rw, ok := e.queryCompiler.RewrittenVars()[v]; ok {
+			return rw, true
+		}
+	}
+	return v, false
 }
 
 type evalBuiltin struct {


### PR DESCRIPTION
For the longest time, topdown traces have included rewritten/mangled
variable names. This makes it difficult for people to understand the
trace because the variable names they used in their policy do not show
up in the trace. Now that we have the rewritten variable map readily
available during evaluation we can easily provide the user-supplied
variable names.

Technically this commit just fixes the presentation problem. The
inclusion of the variable mapping was done in
d1522c647594264ef5996621d3ae3d0d739d19b1.

This change also updates the trace emitting code to include local
metadata for all vars that appear in the AST node instead of just vars
that have bindings. This allows us to unmangle all variables in the
node (e.g., otherwise it would not be possible unmangle Enter nodes.)

Fixes #1208

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
