### PR TITLE
docs: Fixup style for function signatures

### DIFF
--- a/docs/content/wasm.md
+++ b/docs/content/wasm.md
@@ -82,19 +82,19 @@ The primary exported functions for interacting with policy modules are:
 
 | Function Signature | Description|
 | --- | --- |
-| `int32 eval(ctx_addr)` | Evaluates the loaded policy with the provided evaluation context. The return value is reserved for future use. |
-| `value_addr builtins(void)` | Returns the address of a mapping of built-in function names to numeric identifiers that are required by the policy. |
-| `ctx_addr opa_eval_ctx_new(void)` | Returns the address of a newly allocated evaluation context. |
-| `void opa_eval_ctx_set_input(ctx_addr, value_addr)` | Set the input value to use during evaluation. This must be called before each `eval()` call. If the input value is not set before evaluation, references to the `input` document result produce no results (i.e., they are undefined.) |
-| `void opa_eval_ctx_set_data(ctx_addr, value_addr)`  | Set the data value to use during evalutaion. This should be called before each `eval()` call. If the data value is not set before evalutaion, references to base `data` documents produce no results (i.e., they are undefined.) |
-| `value_addr opa_eval_ctx_get_result(ctx_addr)` | Get the result set produced by the evaluation process. |
-| `addr opa_malloc(int32 size)` | Allocates size bytes in the shared memory and returns the starting address. |
-| `value_addr opa_json_parse(str_addr, size)` | Parses the JSON serialized value starting at str_addr of size bytes and returns the address of the parsed value. The parsed value may refer to a null, boolean, number, string, array, or object value. |
-| `str_addr opa_json_dump(value_addr)` | Dumps the value referred to by `value_addr` to a null-terminated JSON serialized string and returns the address of the start of the string. |
-| `void opa_heap_ptr_set(addr)` | Set the heap pointer for the next evaluation. |
-| `addr opa_heap_ptr_get(void)` | Get the current heap pointer. |
-| `void opa_heap_top_set(addr)` | Set the heap top for the next evaluation. |
-| `addr opa_heap_top_get(void)` | Get the current heap top. |
+| <span class="opa-keep-it-together">`int32 eval(ctx_addr)`</span> | Evaluates the loaded policy with the provided evaluation context. The return value is reserved for future use. |
+| <span class="opa-keep-it-together">`value_addr builtins(void)`</span> | Returns the address of a mapping of built-in function names to numeric identifiers that are required by the policy. |
+| <span class="opa-keep-it-together">`ctx_addr opa_eval_ctx_new(void)`</span> | Returns the address of a newly allocated evaluation context. |
+| <span class="opa-keep-it-together">`void opa_eval_ctx_set_input(ctx_addr, value_addr)`</span> | Set the input value to use during evaluation. This must be called before each `eval()` call. If the input value is not set before evaluation, references to the `input` document result produce no results (i.e., they are undefined.) |
+| <span class="opa-keep-it-together">`void opa_eval_ctx_set_data(ctx_addr, value_addr)`</span>  | Set the data value to use during evalutaion. This should be called before each `eval()` call. If the data value is not set before evalutaion, references to base `data` documents produce no results (i.e., they are undefined.) |
+| <span class="opa-keep-it-together">`value_addr opa_eval_ctx_get_result(ctx_addr)`</span> | Get the result set produced by the evaluation process. |
+| <span class="opa-keep-it-together">`addr opa_malloc(int32 size)`</span> | Allocates size bytes in the shared memory and returns the starting address. |
+| <span class="opa-keep-it-together">`value_addr opa_json_parse(str_addr, size)`</span> | Parses the JSON serialized value starting at str_addr of size bytes and returns the address of the parsed value. The parsed value may refer to a null, boolean, number, string, array, or object value. |
+| <span class="opa-keep-it-together">`str_addr opa_json_dump(value_addr)`</span> | Dumps the value referred to by `value_addr` to a null-terminated JSON serialized string and returns the address of the start of the string. |
+| <span class="opa-keep-it-together">`void opa_heap_ptr_set(addr)`</span> | Set the heap pointer for the next evaluation. |
+| <span class="opa-keep-it-together">`addr opa_heap_ptr_get(void)`</span> | Get the current heap pointer. |
+| <span class="opa-keep-it-together">`void opa_heap_top_set(addr)`</span> | Set the heap top for the next evaluation. |
+| <span class="opa-keep-it-together">`addr opa_heap_top_get(void)`</span> | Get the current heap top. |
 
 The addresses passed and returned by the policy modules are 32-bit integer
 offsets into the shared memory region. The `value_addr` parameters and return
@@ -108,11 +108,11 @@ Policy modules require the following function imports at instantiation-time:
 | Namespace | Name | Params | Result | Description |
 | --- | --- | --- | --- | --- |
 | `env` | `opa_abort` | `(addr)` | `void` | Called if an internal error occurs. The `addr` refers to a null-terminated string in the shared memory buffer. |
-| `env` | `opa_builtin0` | `(builtin_id, ctx)` | `addr` | Called to dispatch the built-in function identified by the `builtin_id`. The `ctx` parameter reserved for future use. The result `addr` must refer to a value in the shared-memory buffer. The function accepts 0 arguments. |
-| `env` | `opa_builtin1` | `(builtin_id, ctx, _1)` | `addr` | Same as previous except the function accepts 1 argument. |
-| `env` | `opa_builtin2` | `(builtin_id, ctx, _1, _2)` | `addr` | Same as previous except the function accepts 2 arguments. |
-| `env` | `opa_builtin3` | `(builtin_id, ctx, _1, _2, _3)` | `addr` | Same as previous except the function accepts 3 arguments. |
-| `env` | `opa_builtin4` | `(builtin_id, ctx, _1, _2, _3, _4)` | `addr` | Same as previous except the function accepts 4 arguments. |
+| `env` | `opa_builtin0` | <span class="opa-keep-it-together">`(builtin_id, ctx)`</span> | `addr` | Called to dispatch the built-in function identified by the `builtin_id`. The `ctx` parameter reserved for future use. The result `addr` must refer to a value in the shared-memory buffer. The function accepts 0 arguments. |
+| `env` | `opa_builtin1` | <span class="opa-keep-it-together">`(builtin_id, ctx, _1)`</span> | `addr` | Same as previous except the function accepts 1 argument. |
+| `env` | `opa_builtin2` | <span class="opa-keep-it-together">`(builtin_id, ctx, _1, _2)`</span> | `addr` | Same as previous except the function accepts 2 arguments. |
+| `env` | `opa_builtin3` | <span class="opa-keep-it-together">`(builtin_id, ctx, _1, _2, _3)`</span> | `addr` | Same as previous except the function accepts 3 arguments. |
+| `env` | `opa_builtin4` | <span class="opa-keep-it-together">`(builtin_id, ctx, _1, _2, _3, _4)`</span> | `addr` | Same as previous except the function accepts 4 arguments. |
 
 The policy module also requires a shared memory buffer named `env.memory`.
 

--- a/docs/website/assets/sass/docs.sass
+++ b/docs/website/assets/sass/docs.sass
@@ -119,3 +119,6 @@ $panel-header-logo-width: 85%
 //  Work around for bulma css weird jumbo sized default margin-bottom
 .title:not(:last-child)
   margin-bottom: 0.2rem
+
+.opa-keep-it-together
+  white-space: nowrap

--- a/docs/website/assets/sass/style.sass
+++ b/docs/website/assets/sass/style.sass
@@ -18,6 +18,7 @@ $link: $opa-blue
 $family-sans-serif: "Helvetica Neue", Helvetica, Arial, sans-serif
 $hero-padding: 0
 $section-padding: 0 2rem
+$gap: 2px
 
 @import "bulma/sass/utilities/derived-variables"
 @import "bulma/bulma"


### PR DESCRIPTION
We use the `opa-keep-it-together` class all over in the policy
reference page, but it wasn't actually defined anywhere. At some point
we must have lost it.

This adds back in a definition for it and configures things so that
the function signatures will no longer word wrap.

Going along with this is a tweak to the bulma content width by
slimming down the `$gap` size for `.container`'s. For more info see:
https://bulma.io/documentation/layout/container/

End result is that the doc content is now taking up more of the
available space on the screen which helps display the tables of
built-in functions a little bit better. We may want to consider a
different format for the in the future.

Signed-off-by: Patrick East <east.patrick@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
