### PR TITLE
bundle: Fix for module compile metric

### DIFF
--- a/bundle/store.go
+++ b/bundle/store.go
@@ -366,8 +366,8 @@ func writeData(ctx context.Context, store storage.Store, txn storage.Transaction
 
 func writeModules(ctx context.Context, store storage.Store, txn storage.Transaction, compiler *ast.Compiler, m metrics.Metrics, bundles map[string]*Bundle, extraModules map[string]*ast.Module, legacy bool) error {
 
-	m.Timer(metrics.RegoModuleCompile)
-	defer m.Timer(metrics.RegoModuleCompile)
+	m.Timer(metrics.RegoModuleCompile).Start()
+	defer m.Timer(metrics.RegoModuleCompile).Stop()
 
 	modules := map[string]*ast.Module{}
 

--- a/rego/rego_test.go
+++ b/rego/rego_test.go
@@ -321,8 +321,12 @@ func validateRegoMetrics(t *testing.T, m metrics.Metrics, expectedFields []strin
 	all := m.All()
 
 	for _, name := range expectedFields {
-		if _, ok := all[name]; !ok {
+		value, ok := all[name]
+		if !ok {
 			t.Errorf("expected to find %v but did not", name)
+		}
+		if value.(int64) == 0 {
+			t.Errorf("expected metric %v to have some non-zero value, but found 0", name)
 		}
 	}
 }


### PR DESCRIPTION
Previously we would have a value for the `timer_rego_module_compile_ns`
metric but it was always 0.

Turns out we never actually called start() and stop() on it. The unit
tests were just checking if it existed so this slipped by.. This
commit fixes both issues.

Signed-off-by: Patrick East <east.patrick@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
