### PR TITLE
Allow indirect references

### DIFF
--- a/ast/compile.go
+++ b/ast/compile.go
@@ -2781,15 +2781,13 @@ func expandExprRef(gen *localVarGenerator, v []*Term) (support []*Expr) {
 	//
 	// to support these.  This only impacts the reference subject, i.e. the
 	// first item in the slice.
-	if len(v) > 0 {
-		var subject = v[0]
-		switch subject.Value.(type) {
-		case Array, Object, Set, *ArrayComprehension, *SetComprehension, *ObjectComprehension, Call:
-			f := newEqualityFactory(gen)
-			assignToLocal := f.Generate(subject)
-			support = append(support, assignToLocal)
-			v[0] = assignToLocal.Operand(0)
-		}
+	var subject = v[0]
+	switch subject.Value.(type) {
+	case Array, Object, Set, *ArrayComprehension, *SetComprehension, *ObjectComprehension, Call:
+		f := newEqualityFactory(gen)
+		assignToLocal := f.Generate(subject)
+		support = append(support, assignToLocal)
+		v[0] = assignToLocal.Operand(0)
 	}
 	return
 }

--- a/ast/compile_test.go
+++ b/ast/compile_test.go
@@ -893,6 +893,23 @@ func TestCompilerExprExpansion(t *testing.T) {
 				MustParseExpr("__local0__ = [[__local1__ | plus(z,1,__local2__); sum(y[__local2__], __local3__); eq(x, __local3__); plus(x, 1, __local1__)], __local4__]"),
 			},
 		},
+		{
+			note:  "indirect references",
+			input: `[1, 2, 3][i]`,
+			expected: []*Expr{
+				MustParseExpr("__local0__ = [1, 2, 3]"),
+				MustParseExpr("__local0__[i]"),
+			},
+		},
+		{
+			note:  "multiple indirect references",
+			input: `split(split("foo.bar:qux", ".")[_], ":")[i]`,
+			expected: []*Expr{
+				MustParseExpr(`split("foo.bar:qux", ".", __local0__)`),
+				MustParseExpr(`split(__local0__[_], ":", __local1__)`),
+				MustParseExpr(`__local1__[i]`),
+			},
+		},
 	}
 
 	for _, tc := range tests {

--- a/ast/parser.go
+++ b/ast/parser.go
@@ -314,36 +314,45 @@ var g = &grammar{
 						&labeledExpr{
 							pos:   position{line: 27, col: 16, offset: 598},
 							label: "head",
-							expr: &ruleRefExpr{
-								pos:  position{line: 27, col: 21, offset: 603},
-								name: "RuleHead",
+							expr: &choiceExpr{
+								pos: position{line: 27, col: 22, offset: 604},
+								alternatives: []interface{}{
+									&ruleRefExpr{
+										pos:  position{line: 27, col: 22, offset: 604},
+										name: "PartialRuleHead",
+									},
+									&ruleRefExpr{
+										pos:  position{line: 27, col: 40, offset: 622},
+										name: "RuleHead",
+									},
+								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 27, col: 30, offset: 612},
+							pos:  position{line: 27, col: 50, offset: 632},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 27, col: 32, offset: 614},
+							pos:   position{line: 27, col: 52, offset: 634},
 							label: "rest",
 							expr: &seqExpr{
-								pos: position{line: 27, col: 38, offset: 620},
+								pos: position{line: 27, col: 58, offset: 640},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 27, col: 38, offset: 620},
+										pos:  position{line: 27, col: 58, offset: 640},
 										name: "NonEmptyBraceEnclosedBody",
 									},
 									&zeroOrMoreExpr{
-										pos: position{line: 27, col: 64, offset: 646},
+										pos: position{line: 27, col: 84, offset: 666},
 										expr: &seqExpr{
-											pos: position{line: 27, col: 66, offset: 648},
+											pos: position{line: 27, col: 86, offset: 668},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 27, col: 66, offset: 648},
+													pos:  position{line: 27, col: 86, offset: 668},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 27, col: 68, offset: 650},
+													pos:  position{line: 27, col: 88, offset: 670},
 													name: "RuleExt",
 												},
 											},
@@ -357,139 +366,196 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "RuleHead",
-			pos:  position{line: 31, col: 1, offset: 719},
+			name: "PartialRuleHead",
+			pos:  position{line: 31, col: 1, offset: 739},
 			expr: &actionExpr{
-				pos: position{line: 31, col: 13, offset: 731},
-				run: (*parser).callonRuleHead1,
+				pos: position{line: 31, col: 20, offset: 758},
+				run: (*parser).callonPartialRuleHead1,
 				expr: &seqExpr{
-					pos: position{line: 31, col: 13, offset: 731},
+					pos: position{line: 31, col: 20, offset: 758},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 31, col: 13, offset: 731},
+							pos:   position{line: 31, col: 20, offset: 758},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 31, col: 18, offset: 736},
+								pos:  position{line: 31, col: 25, offset: 763},
 								name: "Var",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 31, col: 22, offset: 740},
+							pos:   position{line: 31, col: 29, offset: 767},
 							label: "args",
-							expr: &zeroOrOneExpr{
-								pos: position{line: 31, col: 27, offset: 745},
-								expr: &seqExpr{
-									pos: position{line: 31, col: 29, offset: 747},
-									exprs: []interface{}{
-										&ruleRefExpr{
-											pos:  position{line: 31, col: 29, offset: 747},
-											name: "_",
-										},
-										&litMatcher{
-											pos:        position{line: 31, col: 31, offset: 749},
-											val:        "(",
-											ignoreCase: false,
-										},
-										&ruleRefExpr{
-											pos:  position{line: 31, col: 35, offset: 753},
-											name: "_",
-										},
-										&ruleRefExpr{
-											pos:  position{line: 31, col: 37, offset: 755},
-											name: "Args",
-										},
-										&ruleRefExpr{
-											pos:  position{line: 31, col: 42, offset: 760},
-											name: "_",
-										},
-										&litMatcher{
-											pos:        position{line: 31, col: 44, offset: 762},
-											val:        ")",
-											ignoreCase: false,
-										},
-										&ruleRefExpr{
-											pos:  position{line: 31, col: 48, offset: 766},
-											name: "_",
-										},
+							expr: &seqExpr{
+								pos: position{line: 31, col: 36, offset: 774},
+								exprs: []interface{}{
+									&ruleRefExpr{
+										pos:  position{line: 31, col: 36, offset: 774},
+										name: "_",
+									},
+									&litMatcher{
+										pos:        position{line: 31, col: 38, offset: 776},
+										val:        "(",
+										ignoreCase: false,
+									},
+									&ruleRefExpr{
+										pos:  position{line: 31, col: 42, offset: 780},
+										name: "_",
+									},
+									&ruleRefExpr{
+										pos:  position{line: 31, col: 44, offset: 782},
+										name: "Args",
+									},
+									&ruleRefExpr{
+										pos:  position{line: 31, col: 49, offset: 787},
+										name: "_",
+									},
+									&litMatcher{
+										pos:        position{line: 31, col: 51, offset: 789},
+										val:        ")",
+										ignoreCase: false,
+									},
+									&ruleRefExpr{
+										pos:  position{line: 31, col: 55, offset: 793},
+										name: "_",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 31, col: 53, offset: 771},
-							label: "key",
-							expr: &zeroOrOneExpr{
-								pos: position{line: 31, col: 57, offset: 775},
-								expr: &seqExpr{
-									pos: position{line: 31, col: 59, offset: 777},
-									exprs: []interface{}{
-										&ruleRefExpr{
-											pos:  position{line: 31, col: 59, offset: 777},
-											name: "_",
-										},
-										&litMatcher{
-											pos:        position{line: 31, col: 61, offset: 779},
-											val:        "[",
-											ignoreCase: false,
-										},
-										&ruleRefExpr{
-											pos:  position{line: 31, col: 65, offset: 783},
-											name: "_",
-										},
-										&ruleRefExpr{
-											pos:  position{line: 31, col: 67, offset: 785},
-											name: "ExprTerm",
-										},
-										&ruleRefExpr{
-											pos:  position{line: 31, col: 76, offset: 794},
-											name: "_",
-										},
-										&litMatcher{
-											pos:        position{line: 31, col: 78, offset: 796},
-											val:        "]",
-											ignoreCase: false,
-										},
-										&ruleRefExpr{
-											pos:  position{line: 31, col: 82, offset: 800},
-											name: "_",
-										},
-									},
-								},
-							},
-						},
-						&labeledExpr{
-							pos:   position{line: 31, col: 87, offset: 805},
+							pos:   position{line: 31, col: 59, offset: 797},
 							label: "value",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 31, col: 93, offset: 811},
+								pos: position{line: 31, col: 65, offset: 803},
 								expr: &seqExpr{
-									pos: position{line: 31, col: 95, offset: 813},
+									pos: position{line: 31, col: 67, offset: 805},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 31, col: 95, offset: 813},
+											pos:  position{line: 31, col: 67, offset: 805},
 											name: "_",
 										},
 										&choiceExpr{
-											pos: position{line: 31, col: 99, offset: 817},
+											pos: position{line: 31, col: 71, offset: 809},
 											alternatives: []interface{}{
 												&litMatcher{
-													pos:        position{line: 31, col: 99, offset: 817},
+													pos:        position{line: 31, col: 71, offset: 809},
 													val:        ":=",
 													ignoreCase: false,
 												},
 												&litMatcher{
-													pos:        position{line: 31, col: 106, offset: 824},
+													pos:        position{line: 31, col: 78, offset: 816},
 													val:        "=",
 													ignoreCase: false,
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 31, col: 112, offset: 830},
+											pos:  position{line: 31, col: 84, offset: 822},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 31, col: 114, offset: 832},
+											pos:  position{line: 31, col: 86, offset: 824},
+											name: "ExprTerm",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "RuleHead",
+			pos:  position{line: 35, col: 1, offset: 909},
+			expr: &actionExpr{
+				pos: position{line: 35, col: 13, offset: 921},
+				run: (*parser).callonRuleHead1,
+				expr: &seqExpr{
+					pos: position{line: 35, col: 13, offset: 921},
+					exprs: []interface{}{
+						&labeledExpr{
+							pos:   position{line: 35, col: 13, offset: 921},
+							label: "name",
+							expr: &ruleRefExpr{
+								pos:  position{line: 35, col: 18, offset: 926},
+								name: "Var",
+							},
+						},
+						&labeledExpr{
+							pos:   position{line: 35, col: 22, offset: 930},
+							label: "key",
+							expr: &zeroOrOneExpr{
+								pos: position{line: 35, col: 26, offset: 934},
+								expr: &seqExpr{
+									pos: position{line: 35, col: 28, offset: 936},
+									exprs: []interface{}{
+										&ruleRefExpr{
+											pos:  position{line: 35, col: 28, offset: 936},
+											name: "_",
+										},
+										&litMatcher{
+											pos:        position{line: 35, col: 30, offset: 938},
+											val:        "[",
+											ignoreCase: false,
+										},
+										&ruleRefExpr{
+											pos:  position{line: 35, col: 34, offset: 942},
+											name: "_",
+										},
+										&ruleRefExpr{
+											pos:  position{line: 35, col: 36, offset: 944},
+											name: "ExprTerm",
+										},
+										&ruleRefExpr{
+											pos:  position{line: 35, col: 45, offset: 953},
+											name: "_",
+										},
+										&litMatcher{
+											pos:        position{line: 35, col: 47, offset: 955},
+											val:        "]",
+											ignoreCase: false,
+										},
+										&ruleRefExpr{
+											pos:  position{line: 35, col: 51, offset: 959},
+											name: "_",
+										},
+									},
+								},
+							},
+						},
+						&labeledExpr{
+							pos:   position{line: 35, col: 56, offset: 964},
+							label: "value",
+							expr: &zeroOrOneExpr{
+								pos: position{line: 35, col: 62, offset: 970},
+								expr: &seqExpr{
+									pos: position{line: 35, col: 64, offset: 972},
+									exprs: []interface{}{
+										&ruleRefExpr{
+											pos:  position{line: 35, col: 64, offset: 972},
+											name: "_",
+										},
+										&choiceExpr{
+											pos: position{line: 35, col: 68, offset: 976},
+											alternatives: []interface{}{
+												&litMatcher{
+													pos:        position{line: 35, col: 68, offset: 976},
+													val:        ":=",
+													ignoreCase: false,
+												},
+												&litMatcher{
+													pos:        position{line: 35, col: 75, offset: 983},
+													val:        "=",
+													ignoreCase: false,
+												},
+											},
+										},
+										&ruleRefExpr{
+											pos:  position{line: 35, col: 81, offset: 989},
+											name: "_",
+										},
+										&ruleRefExpr{
+											pos:  position{line: 35, col: 83, offset: 991},
 											name: "ExprTerm",
 										},
 									},
@@ -502,15 +568,15 @@ var g = &grammar{
 		},
 		{
 			name: "Args",
-			pos:  position{line: 35, col: 1, offset: 917},
+			pos:  position{line: 39, col: 1, offset: 1075},
 			expr: &actionExpr{
-				pos: position{line: 35, col: 9, offset: 925},
+				pos: position{line: 39, col: 9, offset: 1083},
 				run: (*parser).callonArgs1,
 				expr: &labeledExpr{
-					pos:   position{line: 35, col: 9, offset: 925},
+					pos:   position{line: 39, col: 9, offset: 1083},
 					label: "list",
 					expr: &ruleRefExpr{
-						pos:  position{line: 35, col: 14, offset: 930},
+						pos:  position{line: 39, col: 14, offset: 1088},
 						name: "ExprTermList",
 					},
 				},
@@ -518,41 +584,41 @@ var g = &grammar{
 		},
 		{
 			name: "Else",
-			pos:  position{line: 39, col: 1, offset: 974},
+			pos:  position{line: 43, col: 1, offset: 1132},
 			expr: &actionExpr{
-				pos: position{line: 39, col: 9, offset: 982},
+				pos: position{line: 43, col: 9, offset: 1140},
 				run: (*parser).callonElse1,
 				expr: &seqExpr{
-					pos: position{line: 39, col: 9, offset: 982},
+					pos: position{line: 43, col: 9, offset: 1140},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 39, col: 9, offset: 982},
+							pos:        position{line: 43, col: 9, offset: 1140},
 							val:        "else",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 39, col: 16, offset: 989},
+							pos:   position{line: 43, col: 16, offset: 1147},
 							label: "value",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 39, col: 22, offset: 995},
+								pos: position{line: 43, col: 22, offset: 1153},
 								expr: &seqExpr{
-									pos: position{line: 39, col: 24, offset: 997},
+									pos: position{line: 43, col: 24, offset: 1155},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 39, col: 24, offset: 997},
+											pos:  position{line: 43, col: 24, offset: 1155},
 											name: "_",
 										},
 										&litMatcher{
-											pos:        position{line: 39, col: 26, offset: 999},
+											pos:        position{line: 43, col: 26, offset: 1157},
 											val:        "=",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 39, col: 30, offset: 1003},
+											pos:  position{line: 43, col: 30, offset: 1161},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 39, col: 32, offset: 1005},
+											pos:  position{line: 43, col: 32, offset: 1163},
 											name: "Term",
 										},
 									},
@@ -560,17 +626,17 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 39, col: 40, offset: 1013},
+							pos:   position{line: 43, col: 40, offset: 1171},
 							label: "body",
 							expr: &seqExpr{
-								pos: position{line: 39, col: 47, offset: 1020},
+								pos: position{line: 43, col: 47, offset: 1178},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 39, col: 47, offset: 1020},
+										pos:  position{line: 43, col: 47, offset: 1178},
 										name: "_",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 39, col: 49, offset: 1022},
+										pos:  position{line: 43, col: 49, offset: 1180},
 										name: "NonEmptyBraceEnclosedBody",
 									},
 								},
@@ -582,15 +648,15 @@ var g = &grammar{
 		},
 		{
 			name: "RuleDup",
-			pos:  position{line: 43, col: 1, offset: 1111},
+			pos:  position{line: 47, col: 1, offset: 1269},
 			expr: &actionExpr{
-				pos: position{line: 43, col: 12, offset: 1122},
+				pos: position{line: 47, col: 12, offset: 1280},
 				run: (*parser).callonRuleDup1,
 				expr: &labeledExpr{
-					pos:   position{line: 43, col: 12, offset: 1122},
+					pos:   position{line: 47, col: 12, offset: 1280},
 					label: "b",
 					expr: &ruleRefExpr{
-						pos:  position{line: 43, col: 14, offset: 1124},
+						pos:  position{line: 47, col: 14, offset: 1282},
 						name: "NonEmptyBraceEnclosedBody",
 					},
 				},
@@ -598,16 +664,16 @@ var g = &grammar{
 		},
 		{
 			name: "RuleExt",
-			pos:  position{line: 47, col: 1, offset: 1220},
+			pos:  position{line: 51, col: 1, offset: 1378},
 			expr: &choiceExpr{
-				pos: position{line: 47, col: 12, offset: 1231},
+				pos: position{line: 51, col: 12, offset: 1389},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 47, col: 12, offset: 1231},
+						pos:  position{line: 51, col: 12, offset: 1389},
 						name: "Else",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 47, col: 19, offset: 1238},
+						pos:  position{line: 51, col: 19, offset: 1396},
 						name: "RuleDup",
 					},
 				},
@@ -615,16 +681,16 @@ var g = &grammar{
 		},
 		{
 			name: "Body",
-			pos:  position{line: 49, col: 1, offset: 1247},
+			pos:  position{line: 53, col: 1, offset: 1405},
 			expr: &choiceExpr{
-				pos: position{line: 49, col: 9, offset: 1255},
+				pos: position{line: 53, col: 9, offset: 1413},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 49, col: 9, offset: 1255},
+						pos:  position{line: 53, col: 9, offset: 1413},
 						name: "NonWhitespaceBody",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 49, col: 29, offset: 1275},
+						pos:  position{line: 53, col: 29, offset: 1433},
 						name: "BraceEnclosedBody",
 					},
 				},
@@ -632,39 +698,39 @@ var g = &grammar{
 		},
 		{
 			name: "NonEmptyBraceEnclosedBody",
-			pos:  position{line: 51, col: 1, offset: 1294},
+			pos:  position{line: 55, col: 1, offset: 1452},
 			expr: &actionExpr{
-				pos: position{line: 51, col: 30, offset: 1323},
+				pos: position{line: 55, col: 30, offset: 1481},
 				run: (*parser).callonNonEmptyBraceEnclosedBody1,
 				expr: &seqExpr{
-					pos: position{line: 51, col: 30, offset: 1323},
+					pos: position{line: 55, col: 30, offset: 1481},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 51, col: 30, offset: 1323},
+							pos:        position{line: 55, col: 30, offset: 1481},
 							val:        "{",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 51, col: 34, offset: 1327},
+							pos:  position{line: 55, col: 34, offset: 1485},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 51, col: 36, offset: 1329},
+							pos:   position{line: 55, col: 36, offset: 1487},
 							label: "val",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 51, col: 40, offset: 1333},
+								pos: position{line: 55, col: 40, offset: 1491},
 								expr: &ruleRefExpr{
-									pos:  position{line: 51, col: 40, offset: 1333},
+									pos:  position{line: 55, col: 40, offset: 1491},
 									name: "WhitespaceBody",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 51, col: 56, offset: 1349},
+							pos:  position{line: 55, col: 56, offset: 1507},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 51, col: 58, offset: 1351},
+							pos:        position{line: 55, col: 58, offset: 1509},
 							val:        "}",
 							ignoreCase: false,
 						},
@@ -674,39 +740,39 @@ var g = &grammar{
 		},
 		{
 			name: "BraceEnclosedBody",
-			pos:  position{line: 58, col: 1, offset: 1463},
+			pos:  position{line: 62, col: 1, offset: 1621},
 			expr: &actionExpr{
-				pos: position{line: 58, col: 22, offset: 1484},
+				pos: position{line: 62, col: 22, offset: 1642},
 				run: (*parser).callonBraceEnclosedBody1,
 				expr: &seqExpr{
-					pos: position{line: 58, col: 22, offset: 1484},
+					pos: position{line: 62, col: 22, offset: 1642},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 58, col: 22, offset: 1484},
+							pos:        position{line: 62, col: 22, offset: 1642},
 							val:        "{",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 58, col: 26, offset: 1488},
+							pos:  position{line: 62, col: 26, offset: 1646},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 58, col: 28, offset: 1490},
+							pos:   position{line: 62, col: 28, offset: 1648},
 							label: "val",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 58, col: 32, offset: 1494},
+								pos: position{line: 62, col: 32, offset: 1652},
 								expr: &ruleRefExpr{
-									pos:  position{line: 58, col: 32, offset: 1494},
+									pos:  position{line: 62, col: 32, offset: 1652},
 									name: "WhitespaceBody",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 58, col: 48, offset: 1510},
+							pos:  position{line: 62, col: 48, offset: 1668},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 58, col: 50, offset: 1512},
+							pos:        position{line: 62, col: 50, offset: 1670},
 							val:        "}",
 							ignoreCase: false,
 						},
@@ -716,39 +782,39 @@ var g = &grammar{
 		},
 		{
 			name: "WhitespaceBody",
-			pos:  position{line: 62, col: 1, offset: 1579},
+			pos:  position{line: 66, col: 1, offset: 1737},
 			expr: &actionExpr{
-				pos: position{line: 62, col: 19, offset: 1597},
+				pos: position{line: 66, col: 19, offset: 1755},
 				run: (*parser).callonWhitespaceBody1,
 				expr: &seqExpr{
-					pos: position{line: 62, col: 19, offset: 1597},
+					pos: position{line: 66, col: 19, offset: 1755},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 62, col: 19, offset: 1597},
+							pos:   position{line: 66, col: 19, offset: 1755},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 62, col: 24, offset: 1602},
+								pos:  position{line: 66, col: 24, offset: 1760},
 								name: "Literal",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 62, col: 32, offset: 1610},
+							pos:   position{line: 66, col: 32, offset: 1768},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 62, col: 37, offset: 1615},
+								pos: position{line: 66, col: 37, offset: 1773},
 								expr: &seqExpr{
-									pos: position{line: 62, col: 38, offset: 1616},
+									pos: position{line: 66, col: 38, offset: 1774},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 62, col: 38, offset: 1616},
+											pos:  position{line: 66, col: 38, offset: 1774},
 											name: "WhitespaceLiteralSeparator",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 62, col: 65, offset: 1643},
+											pos:  position{line: 66, col: 65, offset: 1801},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 62, col: 67, offset: 1645},
+											pos:  position{line: 66, col: 67, offset: 1803},
 											name: "Literal",
 										},
 									},
@@ -761,43 +827,43 @@ var g = &grammar{
 		},
 		{
 			name: "NonWhitespaceBody",
-			pos:  position{line: 66, col: 1, offset: 1695},
+			pos:  position{line: 70, col: 1, offset: 1853},
 			expr: &actionExpr{
-				pos: position{line: 66, col: 22, offset: 1716},
+				pos: position{line: 70, col: 22, offset: 1874},
 				run: (*parser).callonNonWhitespaceBody1,
 				expr: &seqExpr{
-					pos: position{line: 66, col: 22, offset: 1716},
+					pos: position{line: 70, col: 22, offset: 1874},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 66, col: 22, offset: 1716},
+							pos:   position{line: 70, col: 22, offset: 1874},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 66, col: 27, offset: 1721},
+								pos:  position{line: 70, col: 27, offset: 1879},
 								name: "Literal",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 66, col: 35, offset: 1729},
+							pos:   position{line: 70, col: 35, offset: 1887},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 66, col: 40, offset: 1734},
+								pos: position{line: 70, col: 40, offset: 1892},
 								expr: &seqExpr{
-									pos: position{line: 66, col: 42, offset: 1736},
+									pos: position{line: 70, col: 42, offset: 1894},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 66, col: 42, offset: 1736},
+											pos:  position{line: 70, col: 42, offset: 1894},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 66, col: 44, offset: 1738},
+											pos:  position{line: 70, col: 44, offset: 1896},
 											name: "NonWhitespaceLiteralSeparator",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 66, col: 74, offset: 1768},
+											pos:  position{line: 70, col: 74, offset: 1926},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 66, col: 76, offset: 1770},
+											pos:  position{line: 70, col: 76, offset: 1928},
 											name: "Literal",
 										},
 									},
@@ -810,14 +876,14 @@ var g = &grammar{
 		},
 		{
 			name: "WhitespaceLiteralSeparator",
-			pos:  position{line: 70, col: 1, offset: 1820},
+			pos:  position{line: 74, col: 1, offset: 1978},
 			expr: &seqExpr{
-				pos: position{line: 70, col: 31, offset: 1850},
+				pos: position{line: 74, col: 31, offset: 2008},
 				exprs: []interface{}{
 					&zeroOrMoreExpr{
-						pos: position{line: 70, col: 31, offset: 1850},
+						pos: position{line: 74, col: 31, offset: 2008},
 						expr: &charClassMatcher{
-							pos:        position{line: 70, col: 31, offset: 1850},
+							pos:        position{line: 74, col: 31, offset: 2008},
 							val:        "[ \\t]",
 							chars:      []rune{' ', '\t'},
 							ignoreCase: false,
@@ -825,36 +891,36 @@ var g = &grammar{
 						},
 					},
 					&choiceExpr{
-						pos: position{line: 70, col: 39, offset: 1858},
+						pos: position{line: 74, col: 39, offset: 2016},
 						alternatives: []interface{}{
 							&seqExpr{
-								pos: position{line: 70, col: 40, offset: 1859},
+								pos: position{line: 74, col: 40, offset: 2017},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 70, col: 40, offset: 1859},
+										pos:  position{line: 74, col: 40, offset: 2017},
 										name: "NonWhitespaceLiteralSeparator",
 									},
 									&zeroOrOneExpr{
-										pos: position{line: 70, col: 70, offset: 1889},
+										pos: position{line: 74, col: 70, offset: 2047},
 										expr: &ruleRefExpr{
-											pos:  position{line: 70, col: 70, offset: 1889},
+											pos:  position{line: 74, col: 70, offset: 2047},
 											name: "Comment",
 										},
 									},
 								},
 							},
 							&seqExpr{
-								pos: position{line: 70, col: 83, offset: 1902},
+								pos: position{line: 74, col: 83, offset: 2060},
 								exprs: []interface{}{
 									&zeroOrOneExpr{
-										pos: position{line: 70, col: 83, offset: 1902},
+										pos: position{line: 74, col: 83, offset: 2060},
 										expr: &ruleRefExpr{
-											pos:  position{line: 70, col: 83, offset: 1902},
+											pos:  position{line: 74, col: 83, offset: 2060},
 											name: "Comment",
 										},
 									},
 									&charClassMatcher{
-										pos:        position{line: 70, col: 92, offset: 1911},
+										pos:        position{line: 74, col: 92, offset: 2069},
 										val:        "[\\r\\n]",
 										chars:      []rune{'\r', '\n'},
 										ignoreCase: false,
@@ -869,25 +935,25 @@ var g = &grammar{
 		},
 		{
 			name: "NonWhitespaceLiteralSeparator",
-			pos:  position{line: 72, col: 1, offset: 1921},
+			pos:  position{line: 76, col: 1, offset: 2079},
 			expr: &litMatcher{
-				pos:        position{line: 72, col: 34, offset: 1954},
+				pos:        position{line: 76, col: 34, offset: 2112},
 				val:        ";",
 				ignoreCase: false,
 			},
 		},
 		{
 			name: "Literal",
-			pos:  position{line: 74, col: 1, offset: 1959},
+			pos:  position{line: 78, col: 1, offset: 2117},
 			expr: &choiceExpr{
-				pos: position{line: 74, col: 12, offset: 1970},
+				pos: position{line: 78, col: 12, offset: 2128},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 74, col: 12, offset: 1970},
+						pos:  position{line: 78, col: 12, offset: 2128},
 						name: "TermExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 74, col: 23, offset: 1981},
+						pos:  position{line: 78, col: 23, offset: 2139},
 						name: "SomeDecl",
 					},
 				},
@@ -895,27 +961,27 @@ var g = &grammar{
 		},
 		{
 			name: "SomeDecl",
-			pos:  position{line: 76, col: 1, offset: 1991},
+			pos:  position{line: 80, col: 1, offset: 2149},
 			expr: &actionExpr{
-				pos: position{line: 76, col: 13, offset: 2003},
+				pos: position{line: 80, col: 13, offset: 2161},
 				run: (*parser).callonSomeDecl1,
 				expr: &seqExpr{
-					pos: position{line: 76, col: 13, offset: 2003},
+					pos: position{line: 80, col: 13, offset: 2161},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 76, col: 13, offset: 2003},
+							pos:        position{line: 80, col: 13, offset: 2161},
 							val:        "some",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 76, col: 20, offset: 2010},
+							pos:  position{line: 80, col: 20, offset: 2168},
 							name: "ws",
 						},
 						&labeledExpr{
-							pos:   position{line: 76, col: 23, offset: 2013},
+							pos:   position{line: 80, col: 23, offset: 2171},
 							label: "symbols",
 							expr: &ruleRefExpr{
-								pos:  position{line: 76, col: 31, offset: 2021},
+								pos:  position{line: 80, col: 31, offset: 2179},
 								name: "SomeDeclList",
 							},
 						},
@@ -925,44 +991,44 @@ var g = &grammar{
 		},
 		{
 			name: "SomeDeclList",
-			pos:  position{line: 80, col: 1, offset: 2099},
+			pos:  position{line: 84, col: 1, offset: 2257},
 			expr: &actionExpr{
-				pos: position{line: 80, col: 17, offset: 2115},
+				pos: position{line: 84, col: 17, offset: 2273},
 				run: (*parser).callonSomeDeclList1,
 				expr: &seqExpr{
-					pos: position{line: 80, col: 17, offset: 2115},
+					pos: position{line: 84, col: 17, offset: 2273},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 80, col: 17, offset: 2115},
+							pos:   position{line: 84, col: 17, offset: 2273},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 80, col: 22, offset: 2120},
+								pos:  position{line: 84, col: 22, offset: 2278},
 								name: "Var",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 80, col: 26, offset: 2124},
+							pos:   position{line: 84, col: 26, offset: 2282},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 80, col: 31, offset: 2129},
+								pos: position{line: 84, col: 31, offset: 2287},
 								expr: &seqExpr{
-									pos: position{line: 80, col: 33, offset: 2131},
+									pos: position{line: 84, col: 33, offset: 2289},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 80, col: 33, offset: 2131},
+											pos:  position{line: 84, col: 33, offset: 2289},
 											name: "_",
 										},
 										&litMatcher{
-											pos:        position{line: 80, col: 35, offset: 2133},
+											pos:        position{line: 84, col: 35, offset: 2291},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 80, col: 39, offset: 2137},
+											pos:  position{line: 84, col: 39, offset: 2295},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 80, col: 41, offset: 2139},
+											pos:  position{line: 84, col: 41, offset: 2297},
 											name: "Var",
 										},
 									},
@@ -975,39 +1041,39 @@ var g = &grammar{
 		},
 		{
 			name: "TermExpr",
-			pos:  position{line: 84, col: 1, offset: 2193},
+			pos:  position{line: 88, col: 1, offset: 2351},
 			expr: &actionExpr{
-				pos: position{line: 84, col: 13, offset: 2205},
+				pos: position{line: 88, col: 13, offset: 2363},
 				run: (*parser).callonTermExpr1,
 				expr: &seqExpr{
-					pos: position{line: 84, col: 13, offset: 2205},
+					pos: position{line: 88, col: 13, offset: 2363},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 84, col: 13, offset: 2205},
+							pos:   position{line: 88, col: 13, offset: 2363},
 							label: "negated",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 84, col: 21, offset: 2213},
+								pos: position{line: 88, col: 21, offset: 2371},
 								expr: &ruleRefExpr{
-									pos:  position{line: 84, col: 21, offset: 2213},
+									pos:  position{line: 88, col: 21, offset: 2371},
 									name: "NotKeyword",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 84, col: 33, offset: 2225},
+							pos:   position{line: 88, col: 33, offset: 2383},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 84, col: 39, offset: 2231},
+								pos:  position{line: 88, col: 39, offset: 2389},
 								name: "LiteralExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 84, col: 51, offset: 2243},
+							pos:   position{line: 88, col: 51, offset: 2401},
 							label: "with",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 84, col: 56, offset: 2248},
+								pos: position{line: 88, col: 56, offset: 2406},
 								expr: &ruleRefExpr{
-									pos:  position{line: 84, col: 56, offset: 2248},
+									pos:  position{line: 88, col: 56, offset: 2406},
 									name: "WithKeywordList",
 								},
 							},
@@ -1018,43 +1084,43 @@ var g = &grammar{
 		},
 		{
 			name: "LiteralExpr",
-			pos:  position{line: 88, col: 1, offset: 2315},
+			pos:  position{line: 92, col: 1, offset: 2473},
 			expr: &actionExpr{
-				pos: position{line: 88, col: 16, offset: 2330},
+				pos: position{line: 92, col: 16, offset: 2488},
 				run: (*parser).callonLiteralExpr1,
 				expr: &seqExpr{
-					pos: position{line: 88, col: 16, offset: 2330},
+					pos: position{line: 92, col: 16, offset: 2488},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 88, col: 16, offset: 2330},
+							pos:   position{line: 92, col: 16, offset: 2488},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 88, col: 20, offset: 2334},
+								pos:  position{line: 92, col: 20, offset: 2492},
 								name: "ExprTerm",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 88, col: 29, offset: 2343},
+							pos:   position{line: 92, col: 29, offset: 2501},
 							label: "rest",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 88, col: 34, offset: 2348},
+								pos: position{line: 92, col: 34, offset: 2506},
 								expr: &seqExpr{
-									pos: position{line: 88, col: 36, offset: 2350},
+									pos: position{line: 92, col: 36, offset: 2508},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 88, col: 36, offset: 2350},
+											pos:  position{line: 92, col: 36, offset: 2508},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 88, col: 38, offset: 2352},
+											pos:  position{line: 92, col: 38, offset: 2510},
 											name: "LiteralExprOperator",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 88, col: 58, offset: 2372},
+											pos:  position{line: 92, col: 58, offset: 2530},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 88, col: 60, offset: 2374},
+											pos:  position{line: 92, col: 60, offset: 2532},
 											name: "ExprTerm",
 										},
 									},
@@ -1067,23 +1133,23 @@ var g = &grammar{
 		},
 		{
 			name: "LiteralExprOperator",
-			pos:  position{line: 92, col: 1, offset: 2448},
+			pos:  position{line: 96, col: 1, offset: 2606},
 			expr: &actionExpr{
-				pos: position{line: 92, col: 24, offset: 2471},
+				pos: position{line: 96, col: 24, offset: 2629},
 				run: (*parser).callonLiteralExprOperator1,
 				expr: &labeledExpr{
-					pos:   position{line: 92, col: 24, offset: 2471},
+					pos:   position{line: 96, col: 24, offset: 2629},
 					label: "val",
 					expr: &choiceExpr{
-						pos: position{line: 92, col: 30, offset: 2477},
+						pos: position{line: 96, col: 30, offset: 2635},
 						alternatives: []interface{}{
 							&litMatcher{
-								pos:        position{line: 92, col: 30, offset: 2477},
+								pos:        position{line: 96, col: 30, offset: 2635},
 								val:        ":=",
 								ignoreCase: false,
 							},
 							&litMatcher{
-								pos:        position{line: 92, col: 37, offset: 2484},
+								pos:        position{line: 96, col: 37, offset: 2642},
 								val:        "=",
 								ignoreCase: false,
 							},
@@ -1094,25 +1160,25 @@ var g = &grammar{
 		},
 		{
 			name: "NotKeyword",
-			pos:  position{line: 96, col: 1, offset: 2552},
+			pos:  position{line: 100, col: 1, offset: 2710},
 			expr: &actionExpr{
-				pos: position{line: 96, col: 15, offset: 2566},
+				pos: position{line: 100, col: 15, offset: 2724},
 				run: (*parser).callonNotKeyword1,
 				expr: &labeledExpr{
-					pos:   position{line: 96, col: 15, offset: 2566},
+					pos:   position{line: 100, col: 15, offset: 2724},
 					label: "val",
 					expr: &zeroOrOneExpr{
-						pos: position{line: 96, col: 19, offset: 2570},
+						pos: position{line: 100, col: 19, offset: 2728},
 						expr: &seqExpr{
-							pos: position{line: 96, col: 20, offset: 2571},
+							pos: position{line: 100, col: 20, offset: 2729},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 96, col: 20, offset: 2571},
+									pos:        position{line: 100, col: 20, offset: 2729},
 									val:        "not",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 96, col: 26, offset: 2577},
+									pos:  position{line: 100, col: 26, offset: 2735},
 									name: "ws",
 								},
 							},
@@ -1123,39 +1189,39 @@ var g = &grammar{
 		},
 		{
 			name: "WithKeywordList",
-			pos:  position{line: 100, col: 1, offset: 2614},
+			pos:  position{line: 104, col: 1, offset: 2772},
 			expr: &actionExpr{
-				pos: position{line: 100, col: 20, offset: 2633},
+				pos: position{line: 104, col: 20, offset: 2791},
 				run: (*parser).callonWithKeywordList1,
 				expr: &seqExpr{
-					pos: position{line: 100, col: 20, offset: 2633},
+					pos: position{line: 104, col: 20, offset: 2791},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 100, col: 20, offset: 2633},
+							pos:  position{line: 104, col: 20, offset: 2791},
 							name: "ws",
 						},
 						&labeledExpr{
-							pos:   position{line: 100, col: 23, offset: 2636},
+							pos:   position{line: 104, col: 23, offset: 2794},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 100, col: 28, offset: 2641},
+								pos:  position{line: 104, col: 28, offset: 2799},
 								name: "WithKeyword",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 100, col: 40, offset: 2653},
+							pos:   position{line: 104, col: 40, offset: 2811},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 100, col: 45, offset: 2658},
+								pos: position{line: 104, col: 45, offset: 2816},
 								expr: &seqExpr{
-									pos: position{line: 100, col: 47, offset: 2660},
+									pos: position{line: 104, col: 47, offset: 2818},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 100, col: 47, offset: 2660},
+											pos:  position{line: 104, col: 47, offset: 2818},
 											name: "ws",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 100, col: 50, offset: 2663},
+											pos:  position{line: 104, col: 50, offset: 2821},
 											name: "WithKeyword",
 										},
 									},
@@ -1168,48 +1234,48 @@ var g = &grammar{
 		},
 		{
 			name: "WithKeyword",
-			pos:  position{line: 104, col: 1, offset: 2726},
+			pos:  position{line: 108, col: 1, offset: 2884},
 			expr: &actionExpr{
-				pos: position{line: 104, col: 16, offset: 2741},
+				pos: position{line: 108, col: 16, offset: 2899},
 				run: (*parser).callonWithKeyword1,
 				expr: &seqExpr{
-					pos: position{line: 104, col: 16, offset: 2741},
+					pos: position{line: 108, col: 16, offset: 2899},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 104, col: 16, offset: 2741},
+							pos:        position{line: 108, col: 16, offset: 2899},
 							val:        "with",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 104, col: 23, offset: 2748},
+							pos:  position{line: 108, col: 23, offset: 2906},
 							name: "ws",
 						},
 						&labeledExpr{
-							pos:   position{line: 104, col: 26, offset: 2751},
+							pos:   position{line: 108, col: 26, offset: 2909},
 							label: "target",
 							expr: &ruleRefExpr{
-								pos:  position{line: 104, col: 33, offset: 2758},
+								pos:  position{line: 108, col: 33, offset: 2916},
 								name: "ExprTerm",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 104, col: 42, offset: 2767},
+							pos:  position{line: 108, col: 42, offset: 2925},
 							name: "ws",
 						},
 						&litMatcher{
-							pos:        position{line: 104, col: 45, offset: 2770},
+							pos:        position{line: 108, col: 45, offset: 2928},
 							val:        "as",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 104, col: 50, offset: 2775},
+							pos:  position{line: 108, col: 50, offset: 2933},
 							name: "ws",
 						},
 						&labeledExpr{
-							pos:   position{line: 104, col: 53, offset: 2778},
+							pos:   position{line: 108, col: 53, offset: 2936},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 104, col: 59, offset: 2784},
+								pos:  position{line: 108, col: 59, offset: 2942},
 								name: "ExprTerm",
 							},
 						},
@@ -1219,43 +1285,43 @@ var g = &grammar{
 		},
 		{
 			name: "ExprTerm",
-			pos:  position{line: 108, col: 1, offset: 2860},
+			pos:  position{line: 112, col: 1, offset: 3018},
 			expr: &actionExpr{
-				pos: position{line: 108, col: 13, offset: 2872},
+				pos: position{line: 112, col: 13, offset: 3030},
 				run: (*parser).callonExprTerm1,
 				expr: &seqExpr{
-					pos: position{line: 108, col: 13, offset: 2872},
+					pos: position{line: 112, col: 13, offset: 3030},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 108, col: 13, offset: 2872},
+							pos:   position{line: 112, col: 13, offset: 3030},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 108, col: 17, offset: 2876},
+								pos:  position{line: 112, col: 17, offset: 3034},
 								name: "RelationExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 108, col: 30, offset: 2889},
+							pos:   position{line: 112, col: 30, offset: 3047},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 108, col: 35, offset: 2894},
+								pos: position{line: 112, col: 35, offset: 3052},
 								expr: &seqExpr{
-									pos: position{line: 108, col: 37, offset: 2896},
+									pos: position{line: 112, col: 37, offset: 3054},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 108, col: 37, offset: 2896},
+											pos:  position{line: 112, col: 37, offset: 3054},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 108, col: 39, offset: 2898},
+											pos:  position{line: 112, col: 39, offset: 3056},
 											name: "RelationOperator",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 108, col: 56, offset: 2915},
+											pos:  position{line: 112, col: 56, offset: 3073},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 108, col: 58, offset: 2917},
+											pos:  position{line: 112, col: 58, offset: 3075},
 											name: "RelationExpr",
 										},
 									},
@@ -1268,47 +1334,47 @@ var g = &grammar{
 		},
 		{
 			name: "ExprTermPairList",
-			pos:  position{line: 112, col: 1, offset: 2993},
+			pos:  position{line: 116, col: 1, offset: 3151},
 			expr: &actionExpr{
-				pos: position{line: 112, col: 21, offset: 3013},
+				pos: position{line: 116, col: 21, offset: 3171},
 				run: (*parser).callonExprTermPairList1,
 				expr: &seqExpr{
-					pos: position{line: 112, col: 21, offset: 3013},
+					pos: position{line: 116, col: 21, offset: 3171},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 112, col: 21, offset: 3013},
+							pos:   position{line: 116, col: 21, offset: 3171},
 							label: "head",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 112, col: 26, offset: 3018},
+								pos: position{line: 116, col: 26, offset: 3176},
 								expr: &ruleRefExpr{
-									pos:  position{line: 112, col: 26, offset: 3018},
+									pos:  position{line: 116, col: 26, offset: 3176},
 									name: "ExprTermPair",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 112, col: 40, offset: 3032},
+							pos:   position{line: 116, col: 40, offset: 3190},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 112, col: 45, offset: 3037},
+								pos: position{line: 116, col: 45, offset: 3195},
 								expr: &seqExpr{
-									pos: position{line: 112, col: 47, offset: 3039},
+									pos: position{line: 116, col: 47, offset: 3197},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 112, col: 47, offset: 3039},
+											pos:  position{line: 116, col: 47, offset: 3197},
 											name: "_",
 										},
 										&litMatcher{
-											pos:        position{line: 112, col: 49, offset: 3041},
+											pos:        position{line: 116, col: 49, offset: 3199},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 112, col: 53, offset: 3045},
+											pos:  position{line: 116, col: 53, offset: 3203},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 112, col: 55, offset: 3047},
+											pos:  position{line: 116, col: 55, offset: 3205},
 											name: "ExprTermPair",
 										},
 									},
@@ -1316,13 +1382,13 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 112, col: 71, offset: 3063},
+							pos:  position{line: 116, col: 71, offset: 3221},
 							name: "_",
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 112, col: 73, offset: 3065},
+							pos: position{line: 116, col: 73, offset: 3223},
 							expr: &litMatcher{
-								pos:        position{line: 112, col: 73, offset: 3065},
+								pos:        position{line: 116, col: 73, offset: 3223},
 								val:        ",",
 								ignoreCase: false,
 							},
@@ -1333,47 +1399,47 @@ var g = &grammar{
 		},
 		{
 			name: "ExprTermList",
-			pos:  position{line: 116, col: 1, offset: 3119},
+			pos:  position{line: 120, col: 1, offset: 3277},
 			expr: &actionExpr{
-				pos: position{line: 116, col: 17, offset: 3135},
+				pos: position{line: 120, col: 17, offset: 3293},
 				run: (*parser).callonExprTermList1,
 				expr: &seqExpr{
-					pos: position{line: 116, col: 17, offset: 3135},
+					pos: position{line: 120, col: 17, offset: 3293},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 116, col: 17, offset: 3135},
+							pos:   position{line: 120, col: 17, offset: 3293},
 							label: "head",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 116, col: 22, offset: 3140},
+								pos: position{line: 120, col: 22, offset: 3298},
 								expr: &ruleRefExpr{
-									pos:  position{line: 116, col: 22, offset: 3140},
+									pos:  position{line: 120, col: 22, offset: 3298},
 									name: "ExprTerm",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 116, col: 32, offset: 3150},
+							pos:   position{line: 120, col: 32, offset: 3308},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 116, col: 37, offset: 3155},
+								pos: position{line: 120, col: 37, offset: 3313},
 								expr: &seqExpr{
-									pos: position{line: 116, col: 39, offset: 3157},
+									pos: position{line: 120, col: 39, offset: 3315},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 116, col: 39, offset: 3157},
+											pos:  position{line: 120, col: 39, offset: 3315},
 											name: "_",
 										},
 										&litMatcher{
-											pos:        position{line: 116, col: 41, offset: 3159},
+											pos:        position{line: 120, col: 41, offset: 3317},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 116, col: 45, offset: 3163},
+											pos:  position{line: 120, col: 45, offset: 3321},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 116, col: 47, offset: 3165},
+											pos:  position{line: 120, col: 47, offset: 3323},
 											name: "ExprTerm",
 										},
 									},
@@ -1381,13 +1447,13 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 116, col: 59, offset: 3177},
+							pos:  position{line: 120, col: 59, offset: 3335},
 							name: "_",
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 116, col: 61, offset: 3179},
+							pos: position{line: 120, col: 61, offset: 3337},
 							expr: &litMatcher{
-								pos:        position{line: 116, col: 61, offset: 3179},
+								pos:        position{line: 120, col: 61, offset: 3337},
 								val:        ",",
 								ignoreCase: false,
 							},
@@ -1398,39 +1464,39 @@ var g = &grammar{
 		},
 		{
 			name: "ExprTermPair",
-			pos:  position{line: 120, col: 1, offset: 3230},
+			pos:  position{line: 124, col: 1, offset: 3388},
 			expr: &actionExpr{
-				pos: position{line: 120, col: 17, offset: 3246},
+				pos: position{line: 124, col: 17, offset: 3404},
 				run: (*parser).callonExprTermPair1,
 				expr: &seqExpr{
-					pos: position{line: 120, col: 17, offset: 3246},
+					pos: position{line: 124, col: 17, offset: 3404},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 120, col: 17, offset: 3246},
+							pos:   position{line: 124, col: 17, offset: 3404},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 120, col: 21, offset: 3250},
+								pos:  position{line: 124, col: 21, offset: 3408},
 								name: "ExprTerm",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 120, col: 30, offset: 3259},
+							pos:  position{line: 124, col: 30, offset: 3417},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 120, col: 32, offset: 3261},
+							pos:        position{line: 124, col: 32, offset: 3419},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 120, col: 36, offset: 3265},
+							pos:  position{line: 124, col: 36, offset: 3423},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 120, col: 38, offset: 3267},
+							pos:   position{line: 124, col: 38, offset: 3425},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 120, col: 44, offset: 3273},
+								pos:  position{line: 124, col: 44, offset: 3431},
 								name: "ExprTerm",
 							},
 						},
@@ -1440,43 +1506,43 @@ var g = &grammar{
 		},
 		{
 			name: "RelationOperator",
-			pos:  position{line: 124, col: 1, offset: 3327},
+			pos:  position{line: 128, col: 1, offset: 3485},
 			expr: &actionExpr{
-				pos: position{line: 124, col: 21, offset: 3347},
+				pos: position{line: 128, col: 21, offset: 3505},
 				run: (*parser).callonRelationOperator1,
 				expr: &labeledExpr{
-					pos:   position{line: 124, col: 21, offset: 3347},
+					pos:   position{line: 128, col: 21, offset: 3505},
 					label: "val",
 					expr: &choiceExpr{
-						pos: position{line: 124, col: 26, offset: 3352},
+						pos: position{line: 128, col: 26, offset: 3510},
 						alternatives: []interface{}{
 							&litMatcher{
-								pos:        position{line: 124, col: 26, offset: 3352},
+								pos:        position{line: 128, col: 26, offset: 3510},
 								val:        "==",
 								ignoreCase: false,
 							},
 							&litMatcher{
-								pos:        position{line: 124, col: 33, offset: 3359},
+								pos:        position{line: 128, col: 33, offset: 3517},
 								val:        "!=",
 								ignoreCase: false,
 							},
 							&litMatcher{
-								pos:        position{line: 124, col: 40, offset: 3366},
+								pos:        position{line: 128, col: 40, offset: 3524},
 								val:        "<=",
 								ignoreCase: false,
 							},
 							&litMatcher{
-								pos:        position{line: 124, col: 47, offset: 3373},
+								pos:        position{line: 128, col: 47, offset: 3531},
 								val:        ">=",
 								ignoreCase: false,
 							},
 							&litMatcher{
-								pos:        position{line: 124, col: 54, offset: 3380},
+								pos:        position{line: 128, col: 54, offset: 3538},
 								val:        ">",
 								ignoreCase: false,
 							},
 							&litMatcher{
-								pos:        position{line: 124, col: 60, offset: 3386},
+								pos:        position{line: 128, col: 60, offset: 3544},
 								val:        "<",
 								ignoreCase: false,
 							},
@@ -1487,43 +1553,43 @@ var g = &grammar{
 		},
 		{
 			name: "RelationExpr",
-			pos:  position{line: 128, col: 1, offset: 3453},
+			pos:  position{line: 132, col: 1, offset: 3611},
 			expr: &actionExpr{
-				pos: position{line: 128, col: 17, offset: 3469},
+				pos: position{line: 132, col: 17, offset: 3627},
 				run: (*parser).callonRelationExpr1,
 				expr: &seqExpr{
-					pos: position{line: 128, col: 17, offset: 3469},
+					pos: position{line: 132, col: 17, offset: 3627},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 128, col: 17, offset: 3469},
+							pos:   position{line: 132, col: 17, offset: 3627},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 128, col: 21, offset: 3473},
+								pos:  position{line: 132, col: 21, offset: 3631},
 								name: "BitwiseOrExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 128, col: 35, offset: 3487},
+							pos:   position{line: 132, col: 35, offset: 3645},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 128, col: 40, offset: 3492},
+								pos: position{line: 132, col: 40, offset: 3650},
 								expr: &seqExpr{
-									pos: position{line: 128, col: 42, offset: 3494},
+									pos: position{line: 132, col: 42, offset: 3652},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 128, col: 42, offset: 3494},
+											pos:  position{line: 132, col: 42, offset: 3652},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 128, col: 44, offset: 3496},
+											pos:  position{line: 132, col: 44, offset: 3654},
 											name: "BitwiseOrOperator",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 128, col: 62, offset: 3514},
+											pos:  position{line: 132, col: 62, offset: 3672},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 128, col: 64, offset: 3516},
+											pos:  position{line: 132, col: 64, offset: 3674},
 											name: "BitwiseOrExpr",
 										},
 									},
@@ -1536,15 +1602,15 @@ var g = &grammar{
 		},
 		{
 			name: "BitwiseOrOperator",
-			pos:  position{line: 132, col: 1, offset: 3592},
+			pos:  position{line: 136, col: 1, offset: 3750},
 			expr: &actionExpr{
-				pos: position{line: 132, col: 22, offset: 3613},
+				pos: position{line: 136, col: 22, offset: 3771},
 				run: (*parser).callonBitwiseOrOperator1,
 				expr: &labeledExpr{
-					pos:   position{line: 132, col: 22, offset: 3613},
+					pos:   position{line: 136, col: 22, offset: 3771},
 					label: "val",
 					expr: &litMatcher{
-						pos:        position{line: 132, col: 26, offset: 3617},
+						pos:        position{line: 136, col: 26, offset: 3775},
 						val:        "|",
 						ignoreCase: false,
 					},
@@ -1553,43 +1619,43 @@ var g = &grammar{
 		},
 		{
 			name: "BitwiseOrExpr",
-			pos:  position{line: 136, col: 1, offset: 3683},
+			pos:  position{line: 140, col: 1, offset: 3841},
 			expr: &actionExpr{
-				pos: position{line: 136, col: 18, offset: 3700},
+				pos: position{line: 140, col: 18, offset: 3858},
 				run: (*parser).callonBitwiseOrExpr1,
 				expr: &seqExpr{
-					pos: position{line: 136, col: 18, offset: 3700},
+					pos: position{line: 140, col: 18, offset: 3858},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 136, col: 18, offset: 3700},
+							pos:   position{line: 140, col: 18, offset: 3858},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 136, col: 22, offset: 3704},
+								pos:  position{line: 140, col: 22, offset: 3862},
 								name: "BitwiseAndExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 136, col: 37, offset: 3719},
+							pos:   position{line: 140, col: 37, offset: 3877},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 136, col: 42, offset: 3724},
+								pos: position{line: 140, col: 42, offset: 3882},
 								expr: &seqExpr{
-									pos: position{line: 136, col: 44, offset: 3726},
+									pos: position{line: 140, col: 44, offset: 3884},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 136, col: 44, offset: 3726},
+											pos:  position{line: 140, col: 44, offset: 3884},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 136, col: 46, offset: 3728},
+											pos:  position{line: 140, col: 46, offset: 3886},
 											name: "BitwiseAndOperator",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 136, col: 65, offset: 3747},
+											pos:  position{line: 140, col: 65, offset: 3905},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 136, col: 67, offset: 3749},
+											pos:  position{line: 140, col: 67, offset: 3907},
 											name: "BitwiseAndExpr",
 										},
 									},
@@ -1602,15 +1668,15 @@ var g = &grammar{
 		},
 		{
 			name: "BitwiseAndOperator",
-			pos:  position{line: 140, col: 1, offset: 3826},
+			pos:  position{line: 144, col: 1, offset: 3984},
 			expr: &actionExpr{
-				pos: position{line: 140, col: 23, offset: 3848},
+				pos: position{line: 144, col: 23, offset: 4006},
 				run: (*parser).callonBitwiseAndOperator1,
 				expr: &labeledExpr{
-					pos:   position{line: 140, col: 23, offset: 3848},
+					pos:   position{line: 144, col: 23, offset: 4006},
 					label: "val",
 					expr: &litMatcher{
-						pos:        position{line: 140, col: 27, offset: 3852},
+						pos:        position{line: 144, col: 27, offset: 4010},
 						val:        "&",
 						ignoreCase: false,
 					},
@@ -1619,43 +1685,43 @@ var g = &grammar{
 		},
 		{
 			name: "BitwiseAndExpr",
-			pos:  position{line: 144, col: 1, offset: 3918},
+			pos:  position{line: 148, col: 1, offset: 4076},
 			expr: &actionExpr{
-				pos: position{line: 144, col: 19, offset: 3936},
+				pos: position{line: 148, col: 19, offset: 4094},
 				run: (*parser).callonBitwiseAndExpr1,
 				expr: &seqExpr{
-					pos: position{line: 144, col: 19, offset: 3936},
+					pos: position{line: 148, col: 19, offset: 4094},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 144, col: 19, offset: 3936},
+							pos:   position{line: 148, col: 19, offset: 4094},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 144, col: 23, offset: 3940},
+								pos:  position{line: 148, col: 23, offset: 4098},
 								name: "ArithExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 144, col: 33, offset: 3950},
+							pos:   position{line: 148, col: 33, offset: 4108},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 144, col: 38, offset: 3955},
+								pos: position{line: 148, col: 38, offset: 4113},
 								expr: &seqExpr{
-									pos: position{line: 144, col: 40, offset: 3957},
+									pos: position{line: 148, col: 40, offset: 4115},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 144, col: 40, offset: 3957},
+											pos:  position{line: 148, col: 40, offset: 4115},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 144, col: 42, offset: 3959},
+											pos:  position{line: 148, col: 42, offset: 4117},
 											name: "ArithOperator",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 144, col: 56, offset: 3973},
+											pos:  position{line: 148, col: 56, offset: 4131},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 144, col: 58, offset: 3975},
+											pos:  position{line: 148, col: 58, offset: 4133},
 											name: "ArithExpr",
 										},
 									},
@@ -1668,23 +1734,23 @@ var g = &grammar{
 		},
 		{
 			name: "ArithOperator",
-			pos:  position{line: 148, col: 1, offset: 4047},
+			pos:  position{line: 152, col: 1, offset: 4205},
 			expr: &actionExpr{
-				pos: position{line: 148, col: 18, offset: 4064},
+				pos: position{line: 152, col: 18, offset: 4222},
 				run: (*parser).callonArithOperator1,
 				expr: &labeledExpr{
-					pos:   position{line: 148, col: 18, offset: 4064},
+					pos:   position{line: 152, col: 18, offset: 4222},
 					label: "val",
 					expr: &choiceExpr{
-						pos: position{line: 148, col: 23, offset: 4069},
+						pos: position{line: 152, col: 23, offset: 4227},
 						alternatives: []interface{}{
 							&litMatcher{
-								pos:        position{line: 148, col: 23, offset: 4069},
+								pos:        position{line: 152, col: 23, offset: 4227},
 								val:        "+",
 								ignoreCase: false,
 							},
 							&litMatcher{
-								pos:        position{line: 148, col: 29, offset: 4075},
+								pos:        position{line: 152, col: 29, offset: 4233},
 								val:        "-",
 								ignoreCase: false,
 							},
@@ -1695,43 +1761,43 @@ var g = &grammar{
 		},
 		{
 			name: "ArithExpr",
-			pos:  position{line: 152, col: 1, offset: 4142},
+			pos:  position{line: 156, col: 1, offset: 4300},
 			expr: &actionExpr{
-				pos: position{line: 152, col: 14, offset: 4155},
+				pos: position{line: 156, col: 14, offset: 4313},
 				run: (*parser).callonArithExpr1,
 				expr: &seqExpr{
-					pos: position{line: 152, col: 14, offset: 4155},
+					pos: position{line: 156, col: 14, offset: 4313},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 152, col: 14, offset: 4155},
+							pos:   position{line: 156, col: 14, offset: 4313},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 152, col: 18, offset: 4159},
+								pos:  position{line: 156, col: 18, offset: 4317},
 								name: "FactorExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 152, col: 29, offset: 4170},
+							pos:   position{line: 156, col: 29, offset: 4328},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 152, col: 34, offset: 4175},
+								pos: position{line: 156, col: 34, offset: 4333},
 								expr: &seqExpr{
-									pos: position{line: 152, col: 36, offset: 4177},
+									pos: position{line: 156, col: 36, offset: 4335},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 152, col: 36, offset: 4177},
+											pos:  position{line: 156, col: 36, offset: 4335},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 152, col: 38, offset: 4179},
+											pos:  position{line: 156, col: 38, offset: 4337},
 											name: "FactorOperator",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 152, col: 53, offset: 4194},
+											pos:  position{line: 156, col: 53, offset: 4352},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 152, col: 55, offset: 4196},
+											pos:  position{line: 156, col: 55, offset: 4354},
 											name: "FactorExpr",
 										},
 									},
@@ -1744,28 +1810,28 @@ var g = &grammar{
 		},
 		{
 			name: "FactorOperator",
-			pos:  position{line: 156, col: 1, offset: 4270},
+			pos:  position{line: 160, col: 1, offset: 4428},
 			expr: &actionExpr{
-				pos: position{line: 156, col: 19, offset: 4288},
+				pos: position{line: 160, col: 19, offset: 4446},
 				run: (*parser).callonFactorOperator1,
 				expr: &labeledExpr{
-					pos:   position{line: 156, col: 19, offset: 4288},
+					pos:   position{line: 160, col: 19, offset: 4446},
 					label: "val",
 					expr: &choiceExpr{
-						pos: position{line: 156, col: 24, offset: 4293},
+						pos: position{line: 160, col: 24, offset: 4451},
 						alternatives: []interface{}{
 							&litMatcher{
-								pos:        position{line: 156, col: 24, offset: 4293},
+								pos:        position{line: 160, col: 24, offset: 4451},
 								val:        "*",
 								ignoreCase: false,
 							},
 							&litMatcher{
-								pos:        position{line: 156, col: 30, offset: 4299},
+								pos:        position{line: 160, col: 30, offset: 4457},
 								val:        "/",
 								ignoreCase: false,
 							},
 							&litMatcher{
-								pos:        position{line: 156, col: 36, offset: 4305},
+								pos:        position{line: 160, col: 36, offset: 4463},
 								val:        "%",
 								ignoreCase: false,
 							},
@@ -1776,39 +1842,39 @@ var g = &grammar{
 		},
 		{
 			name: "FactorExpr",
-			pos:  position{line: 160, col: 1, offset: 4371},
+			pos:  position{line: 164, col: 1, offset: 4529},
 			expr: &choiceExpr{
-				pos: position{line: 160, col: 15, offset: 4385},
+				pos: position{line: 164, col: 15, offset: 4543},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 160, col: 15, offset: 4385},
+						pos: position{line: 164, col: 15, offset: 4543},
 						run: (*parser).callonFactorExpr2,
 						expr: &seqExpr{
-							pos: position{line: 160, col: 17, offset: 4387},
+							pos: position{line: 164, col: 17, offset: 4545},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 160, col: 17, offset: 4387},
+									pos:        position{line: 164, col: 17, offset: 4545},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 160, col: 21, offset: 4391},
+									pos:  position{line: 164, col: 21, offset: 4549},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 160, col: 23, offset: 4393},
+									pos:   position{line: 164, col: 23, offset: 4551},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 160, col: 28, offset: 4398},
+										pos:  position{line: 164, col: 28, offset: 4556},
 										name: "ExprTerm",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 160, col: 37, offset: 4407},
+									pos:  position{line: 164, col: 37, offset: 4565},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 160, col: 39, offset: 4409},
+									pos:        position{line: 164, col: 39, offset: 4567},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -1816,13 +1882,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 162, col: 5, offset: 4442},
+						pos: position{line: 166, col: 5, offset: 4600},
 						run: (*parser).callonFactorExpr10,
 						expr: &labeledExpr{
-							pos:   position{line: 162, col: 5, offset: 4442},
+							pos:   position{line: 166, col: 5, offset: 4600},
 							label: "term",
 							expr: &ruleRefExpr{
-								pos:  position{line: 162, col: 10, offset: 4447},
+								pos:  position{line: 166, col: 10, offset: 4605},
 								name: "Term",
 							},
 						},
@@ -1832,53 +1898,53 @@ var g = &grammar{
 		},
 		{
 			name: "Call",
-			pos:  position{line: 166, col: 1, offset: 4478},
+			pos:  position{line: 170, col: 1, offset: 4636},
 			expr: &actionExpr{
-				pos: position{line: 166, col: 9, offset: 4486},
+				pos: position{line: 170, col: 9, offset: 4644},
 				run: (*parser).callonCall1,
 				expr: &seqExpr{
-					pos: position{line: 166, col: 9, offset: 4486},
+					pos: position{line: 170, col: 9, offset: 4644},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 166, col: 9, offset: 4486},
+							pos:   position{line: 170, col: 9, offset: 4644},
 							label: "operator",
 							expr: &choiceExpr{
-								pos: position{line: 166, col: 19, offset: 4496},
+								pos: position{line: 170, col: 19, offset: 4654},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 166, col: 19, offset: 4496},
+										pos:  position{line: 170, col: 19, offset: 4654},
 										name: "Ref",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 166, col: 25, offset: 4502},
+										pos:  position{line: 170, col: 25, offset: 4660},
 										name: "Var",
 									},
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 166, col: 30, offset: 4507},
+							pos:        position{line: 170, col: 30, offset: 4665},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 166, col: 34, offset: 4511},
+							pos:  position{line: 170, col: 34, offset: 4669},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 166, col: 36, offset: 4513},
+							pos:   position{line: 170, col: 36, offset: 4671},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 166, col: 41, offset: 4518},
+								pos:  position{line: 170, col: 41, offset: 4676},
 								name: "ExprTermList",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 166, col: 54, offset: 4531},
+							pos:  position{line: 170, col: 54, offset: 4689},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 166, col: 56, offset: 4533},
+							pos:        position{line: 170, col: 56, offset: 4691},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -1888,49 +1954,49 @@ var g = &grammar{
 		},
 		{
 			name: "Term",
-			pos:  position{line: 170, col: 1, offset: 4598},
+			pos:  position{line: 174, col: 1, offset: 4756},
 			expr: &actionExpr{
-				pos: position{line: 170, col: 9, offset: 4606},
+				pos: position{line: 174, col: 9, offset: 4764},
 				run: (*parser).callonTerm1,
 				expr: &seqExpr{
-					pos: position{line: 170, col: 9, offset: 4606},
+					pos: position{line: 174, col: 9, offset: 4764},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 170, col: 9, offset: 4606},
+							pos:   position{line: 174, col: 9, offset: 4764},
 							label: "val",
 							expr: &choiceExpr{
-								pos: position{line: 170, col: 15, offset: 4612},
+								pos: position{line: 174, col: 15, offset: 4770},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 170, col: 15, offset: 4612},
+										pos:  position{line: 174, col: 15, offset: 4770},
 										name: "Comprehension",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 170, col: 31, offset: 4628},
+										pos:  position{line: 174, col: 31, offset: 4786},
 										name: "Composite",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 170, col: 43, offset: 4640},
+										pos:  position{line: 174, col: 43, offset: 4798},
 										name: "Scalar",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 170, col: 52, offset: 4649},
+										pos:  position{line: 174, col: 52, offset: 4807},
 										name: "Call",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 170, col: 59, offset: 4656},
+										pos:  position{line: 174, col: 59, offset: 4814},
 										name: "Var",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 170, col: 65, offset: 4662},
+							pos:   position{line: 174, col: 65, offset: 4820},
 							label: "refs",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 170, col: 70, offset: 4667},
+								pos: position{line: 174, col: 70, offset: 4825},
 								expr: &ruleRefExpr{
-									pos:  position{line: 170, col: 70, offset: 4667},
+									pos:  position{line: 174, col: 70, offset: 4825},
 									name: "RefOperand",
 								},
 							},
@@ -1941,39 +2007,39 @@ var g = &grammar{
 		},
 		{
 			name: "TermPair",
-			pos:  position{line: 174, col: 1, offset: 4734},
+			pos:  position{line: 178, col: 1, offset: 4892},
 			expr: &actionExpr{
-				pos: position{line: 174, col: 13, offset: 4746},
+				pos: position{line: 178, col: 13, offset: 4904},
 				run: (*parser).callonTermPair1,
 				expr: &seqExpr{
-					pos: position{line: 174, col: 13, offset: 4746},
+					pos: position{line: 178, col: 13, offset: 4904},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 174, col: 13, offset: 4746},
+							pos:   position{line: 178, col: 13, offset: 4904},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 174, col: 17, offset: 4750},
+								pos:  position{line: 178, col: 17, offset: 4908},
 								name: "Term",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 174, col: 22, offset: 4755},
+							pos:  position{line: 178, col: 22, offset: 4913},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 174, col: 24, offset: 4757},
+							pos:        position{line: 178, col: 24, offset: 4915},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 174, col: 28, offset: 4761},
+							pos:  position{line: 178, col: 28, offset: 4919},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 174, col: 30, offset: 4763},
+							pos:   position{line: 178, col: 30, offset: 4921},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 174, col: 36, offset: 4769},
+								pos:  position{line: 178, col: 36, offset: 4927},
 								name: "Term",
 							},
 						},
@@ -1983,20 +2049,20 @@ var g = &grammar{
 		},
 		{
 			name: "Comprehension",
-			pos:  position{line: 178, col: 1, offset: 4819},
+			pos:  position{line: 182, col: 1, offset: 4977},
 			expr: &choiceExpr{
-				pos: position{line: 178, col: 18, offset: 4836},
+				pos: position{line: 182, col: 18, offset: 4994},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 178, col: 18, offset: 4836},
+						pos:  position{line: 182, col: 18, offset: 4994},
 						name: "ArrayComprehension",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 178, col: 39, offset: 4857},
+						pos:  position{line: 182, col: 39, offset: 5015},
 						name: "ObjectComprehension",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 178, col: 61, offset: 4879},
+						pos:  position{line: 182, col: 61, offset: 5037},
 						name: "SetComprehension",
 					},
 				},
@@ -2004,57 +2070,57 @@ var g = &grammar{
 		},
 		{
 			name: "ArrayComprehension",
-			pos:  position{line: 180, col: 1, offset: 4897},
+			pos:  position{line: 184, col: 1, offset: 5055},
 			expr: &actionExpr{
-				pos: position{line: 180, col: 23, offset: 4919},
+				pos: position{line: 184, col: 23, offset: 5077},
 				run: (*parser).callonArrayComprehension1,
 				expr: &seqExpr{
-					pos: position{line: 180, col: 23, offset: 4919},
+					pos: position{line: 184, col: 23, offset: 5077},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 180, col: 23, offset: 4919},
+							pos:        position{line: 184, col: 23, offset: 5077},
 							val:        "[",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 180, col: 27, offset: 4923},
+							pos:  position{line: 184, col: 27, offset: 5081},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 180, col: 29, offset: 4925},
+							pos:   position{line: 184, col: 29, offset: 5083},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 180, col: 34, offset: 4930},
+								pos:  position{line: 184, col: 34, offset: 5088},
 								name: "Term",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 180, col: 39, offset: 4935},
+							pos:  position{line: 184, col: 39, offset: 5093},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 180, col: 41, offset: 4937},
+							pos:        position{line: 184, col: 41, offset: 5095},
 							val:        "|",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 180, col: 45, offset: 4941},
+							pos:  position{line: 184, col: 45, offset: 5099},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 180, col: 47, offset: 4943},
+							pos:   position{line: 184, col: 47, offset: 5101},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 180, col: 52, offset: 4948},
+								pos:  position{line: 184, col: 52, offset: 5106},
 								name: "WhitespaceBody",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 180, col: 67, offset: 4963},
+							pos:  position{line: 184, col: 67, offset: 5121},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 180, col: 69, offset: 4965},
+							pos:        position{line: 184, col: 69, offset: 5123},
 							val:        "]",
 							ignoreCase: false,
 						},
@@ -2064,57 +2130,57 @@ var g = &grammar{
 		},
 		{
 			name: "ObjectComprehension",
-			pos:  position{line: 184, col: 1, offset: 5040},
+			pos:  position{line: 188, col: 1, offset: 5198},
 			expr: &actionExpr{
-				pos: position{line: 184, col: 24, offset: 5063},
+				pos: position{line: 188, col: 24, offset: 5221},
 				run: (*parser).callonObjectComprehension1,
 				expr: &seqExpr{
-					pos: position{line: 184, col: 24, offset: 5063},
+					pos: position{line: 188, col: 24, offset: 5221},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 184, col: 24, offset: 5063},
+							pos:        position{line: 188, col: 24, offset: 5221},
 							val:        "{",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 184, col: 28, offset: 5067},
+							pos:  position{line: 188, col: 28, offset: 5225},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 184, col: 30, offset: 5069},
+							pos:   position{line: 188, col: 30, offset: 5227},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 184, col: 35, offset: 5074},
+								pos:  position{line: 188, col: 35, offset: 5232},
 								name: "TermPair",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 184, col: 45, offset: 5084},
+							pos:  position{line: 188, col: 45, offset: 5242},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 184, col: 47, offset: 5086},
+							pos:        position{line: 188, col: 47, offset: 5244},
 							val:        "|",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 184, col: 51, offset: 5090},
+							pos:  position{line: 188, col: 51, offset: 5248},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 184, col: 53, offset: 5092},
+							pos:   position{line: 188, col: 53, offset: 5250},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 184, col: 58, offset: 5097},
+								pos:  position{line: 188, col: 58, offset: 5255},
 								name: "WhitespaceBody",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 184, col: 73, offset: 5112},
+							pos:  position{line: 188, col: 73, offset: 5270},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 184, col: 75, offset: 5114},
+							pos:        position{line: 188, col: 75, offset: 5272},
 							val:        "}",
 							ignoreCase: false,
 						},
@@ -2124,57 +2190,57 @@ var g = &grammar{
 		},
 		{
 			name: "SetComprehension",
-			pos:  position{line: 188, col: 1, offset: 5190},
+			pos:  position{line: 192, col: 1, offset: 5348},
 			expr: &actionExpr{
-				pos: position{line: 188, col: 21, offset: 5210},
+				pos: position{line: 192, col: 21, offset: 5368},
 				run: (*parser).callonSetComprehension1,
 				expr: &seqExpr{
-					pos: position{line: 188, col: 21, offset: 5210},
+					pos: position{line: 192, col: 21, offset: 5368},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 188, col: 21, offset: 5210},
+							pos:        position{line: 192, col: 21, offset: 5368},
 							val:        "{",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 188, col: 25, offset: 5214},
+							pos:  position{line: 192, col: 25, offset: 5372},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 188, col: 27, offset: 5216},
+							pos:   position{line: 192, col: 27, offset: 5374},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 188, col: 32, offset: 5221},
+								pos:  position{line: 192, col: 32, offset: 5379},
 								name: "Term",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 188, col: 37, offset: 5226},
+							pos:  position{line: 192, col: 37, offset: 5384},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 188, col: 39, offset: 5228},
+							pos:        position{line: 192, col: 39, offset: 5386},
 							val:        "|",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 188, col: 43, offset: 5232},
+							pos:  position{line: 192, col: 43, offset: 5390},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 188, col: 45, offset: 5234},
+							pos:   position{line: 192, col: 45, offset: 5392},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 188, col: 50, offset: 5239},
+								pos:  position{line: 192, col: 50, offset: 5397},
 								name: "WhitespaceBody",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 188, col: 65, offset: 5254},
+							pos:  position{line: 192, col: 65, offset: 5412},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 188, col: 67, offset: 5256},
+							pos:        position{line: 192, col: 67, offset: 5414},
 							val:        "}",
 							ignoreCase: false,
 						},
@@ -2184,20 +2250,20 @@ var g = &grammar{
 		},
 		{
 			name: "Composite",
-			pos:  position{line: 192, col: 1, offset: 5329},
+			pos:  position{line: 196, col: 1, offset: 5487},
 			expr: &choiceExpr{
-				pos: position{line: 192, col: 14, offset: 5342},
+				pos: position{line: 196, col: 14, offset: 5500},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 192, col: 14, offset: 5342},
+						pos:  position{line: 196, col: 14, offset: 5500},
 						name: "Object",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 192, col: 23, offset: 5351},
+						pos:  position{line: 196, col: 23, offset: 5509},
 						name: "Array",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 192, col: 31, offset: 5359},
+						pos:  position{line: 196, col: 31, offset: 5517},
 						name: "Set",
 					},
 				},
@@ -2205,24 +2271,24 @@ var g = &grammar{
 		},
 		{
 			name: "Scalar",
-			pos:  position{line: 194, col: 1, offset: 5364},
+			pos:  position{line: 198, col: 1, offset: 5522},
 			expr: &choiceExpr{
-				pos: position{line: 194, col: 11, offset: 5374},
+				pos: position{line: 198, col: 11, offset: 5532},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 194, col: 11, offset: 5374},
+						pos:  position{line: 198, col: 11, offset: 5532},
 						name: "Number",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 194, col: 20, offset: 5383},
+						pos:  position{line: 198, col: 20, offset: 5541},
 						name: "String",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 194, col: 29, offset: 5392},
+						pos:  position{line: 198, col: 29, offset: 5550},
 						name: "Bool",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 194, col: 36, offset: 5399},
+						pos:  position{line: 198, col: 36, offset: 5557},
 						name: "Null",
 					},
 				},
@@ -2230,36 +2296,36 @@ var g = &grammar{
 		},
 		{
 			name: "Object",
-			pos:  position{line: 196, col: 1, offset: 5405},
+			pos:  position{line: 200, col: 1, offset: 5563},
 			expr: &actionExpr{
-				pos: position{line: 196, col: 11, offset: 5415},
+				pos: position{line: 200, col: 11, offset: 5573},
 				run: (*parser).callonObject1,
 				expr: &seqExpr{
-					pos: position{line: 196, col: 11, offset: 5415},
+					pos: position{line: 200, col: 11, offset: 5573},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 196, col: 11, offset: 5415},
+							pos:        position{line: 200, col: 11, offset: 5573},
 							val:        "{",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 196, col: 15, offset: 5419},
+							pos:  position{line: 200, col: 15, offset: 5577},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 196, col: 17, offset: 5421},
+							pos:   position{line: 200, col: 17, offset: 5579},
 							label: "list",
 							expr: &ruleRefExpr{
-								pos:  position{line: 196, col: 22, offset: 5426},
+								pos:  position{line: 200, col: 22, offset: 5584},
 								name: "ExprTermPairList",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 196, col: 39, offset: 5443},
+							pos:  position{line: 200, col: 39, offset: 5601},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 196, col: 41, offset: 5445},
+							pos:        position{line: 200, col: 41, offset: 5603},
 							val:        "}",
 							ignoreCase: false,
 						},
@@ -2269,36 +2335,36 @@ var g = &grammar{
 		},
 		{
 			name: "Array",
-			pos:  position{line: 200, col: 1, offset: 5502},
+			pos:  position{line: 204, col: 1, offset: 5660},
 			expr: &actionExpr{
-				pos: position{line: 200, col: 10, offset: 5511},
+				pos: position{line: 204, col: 10, offset: 5669},
 				run: (*parser).callonArray1,
 				expr: &seqExpr{
-					pos: position{line: 200, col: 10, offset: 5511},
+					pos: position{line: 204, col: 10, offset: 5669},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 200, col: 10, offset: 5511},
+							pos:        position{line: 204, col: 10, offset: 5669},
 							val:        "[",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 200, col: 14, offset: 5515},
+							pos:  position{line: 204, col: 14, offset: 5673},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 200, col: 16, offset: 5517},
+							pos:   position{line: 204, col: 16, offset: 5675},
 							label: "list",
 							expr: &ruleRefExpr{
-								pos:  position{line: 200, col: 21, offset: 5522},
+								pos:  position{line: 204, col: 21, offset: 5680},
 								name: "ExprTermList",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 200, col: 34, offset: 5535},
+							pos:  position{line: 204, col: 34, offset: 5693},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 200, col: 36, offset: 5537},
+							pos:        position{line: 204, col: 36, offset: 5695},
 							val:        "]",
 							ignoreCase: false,
 						},
@@ -2308,16 +2374,16 @@ var g = &grammar{
 		},
 		{
 			name: "Set",
-			pos:  position{line: 204, col: 1, offset: 5593},
+			pos:  position{line: 208, col: 1, offset: 5751},
 			expr: &choiceExpr{
-				pos: position{line: 204, col: 8, offset: 5600},
+				pos: position{line: 208, col: 8, offset: 5758},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 204, col: 8, offset: 5600},
+						pos:  position{line: 208, col: 8, offset: 5758},
 						name: "SetEmpty",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 204, col: 19, offset: 5611},
+						pos:  position{line: 208, col: 19, offset: 5769},
 						name: "SetNonEmpty",
 					},
 				},
@@ -2325,24 +2391,24 @@ var g = &grammar{
 		},
 		{
 			name: "SetEmpty",
-			pos:  position{line: 206, col: 1, offset: 5624},
+			pos:  position{line: 210, col: 1, offset: 5782},
 			expr: &actionExpr{
-				pos: position{line: 206, col: 13, offset: 5636},
+				pos: position{line: 210, col: 13, offset: 5794},
 				run: (*parser).callonSetEmpty1,
 				expr: &seqExpr{
-					pos: position{line: 206, col: 13, offset: 5636},
+					pos: position{line: 210, col: 13, offset: 5794},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 206, col: 13, offset: 5636},
+							pos:        position{line: 210, col: 13, offset: 5794},
 							val:        "set(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 206, col: 20, offset: 5643},
+							pos:  position{line: 210, col: 20, offset: 5801},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 206, col: 22, offset: 5645},
+							pos:        position{line: 210, col: 22, offset: 5803},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -2352,36 +2418,36 @@ var g = &grammar{
 		},
 		{
 			name: "SetNonEmpty",
-			pos:  position{line: 211, col: 1, offset: 5722},
+			pos:  position{line: 215, col: 1, offset: 5880},
 			expr: &actionExpr{
-				pos: position{line: 211, col: 16, offset: 5737},
+				pos: position{line: 215, col: 16, offset: 5895},
 				run: (*parser).callonSetNonEmpty1,
 				expr: &seqExpr{
-					pos: position{line: 211, col: 16, offset: 5737},
+					pos: position{line: 215, col: 16, offset: 5895},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 211, col: 16, offset: 5737},
+							pos:        position{line: 215, col: 16, offset: 5895},
 							val:        "{",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 211, col: 20, offset: 5741},
+							pos:  position{line: 215, col: 20, offset: 5899},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 211, col: 22, offset: 5743},
+							pos:   position{line: 215, col: 22, offset: 5901},
 							label: "list",
 							expr: &ruleRefExpr{
-								pos:  position{line: 211, col: 27, offset: 5748},
+								pos:  position{line: 215, col: 27, offset: 5906},
 								name: "ExprTermList",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 211, col: 40, offset: 5761},
+							pos:  position{line: 215, col: 40, offset: 5919},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 211, col: 42, offset: 5763},
+							pos:        position{line: 215, col: 42, offset: 5921},
 							val:        "}",
 							ignoreCase: false,
 						},
@@ -2391,37 +2457,37 @@ var g = &grammar{
 		},
 		{
 			name: "Ref",
-			pos:  position{line: 215, col: 1, offset: 5817},
+			pos:  position{line: 219, col: 1, offset: 5975},
 			expr: &actionExpr{
-				pos: position{line: 215, col: 8, offset: 5824},
+				pos: position{line: 219, col: 8, offset: 5982},
 				run: (*parser).callonRef1,
 				expr: &seqExpr{
-					pos: position{line: 215, col: 8, offset: 5824},
+					pos: position{line: 219, col: 8, offset: 5982},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 215, col: 8, offset: 5824},
+							pos:   position{line: 219, col: 8, offset: 5982},
 							label: "head",
 							expr: &choiceExpr{
-								pos: position{line: 215, col: 14, offset: 5830},
+								pos: position{line: 219, col: 14, offset: 5988},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 215, col: 14, offset: 5830},
+										pos:  position{line: 219, col: 14, offset: 5988},
 										name: "Composite",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 215, col: 26, offset: 5842},
+										pos:  position{line: 219, col: 26, offset: 6000},
 										name: "Var",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 215, col: 31, offset: 5847},
+							pos:   position{line: 219, col: 31, offset: 6005},
 							label: "rest",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 215, col: 36, offset: 5852},
+								pos: position{line: 219, col: 36, offset: 6010},
 								expr: &ruleRefExpr{
-									pos:  position{line: 215, col: 36, offset: 5852},
+									pos:  position{line: 219, col: 36, offset: 6010},
 									name: "RefOperand",
 								},
 							},
@@ -2432,16 +2498,16 @@ var g = &grammar{
 		},
 		{
 			name: "RefOperand",
-			pos:  position{line: 219, col: 1, offset: 5920},
+			pos:  position{line: 223, col: 1, offset: 6078},
 			expr: &choiceExpr{
-				pos: position{line: 219, col: 15, offset: 5934},
+				pos: position{line: 223, col: 15, offset: 6092},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 219, col: 15, offset: 5934},
+						pos:  position{line: 223, col: 15, offset: 6092},
 						name: "RefOperandDot",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 219, col: 31, offset: 5950},
+						pos:  position{line: 223, col: 31, offset: 6108},
 						name: "RefOperandCanonical",
 					},
 				},
@@ -2449,23 +2515,23 @@ var g = &grammar{
 		},
 		{
 			name: "RefOperandDot",
-			pos:  position{line: 221, col: 1, offset: 5971},
+			pos:  position{line: 225, col: 1, offset: 6129},
 			expr: &actionExpr{
-				pos: position{line: 221, col: 18, offset: 5988},
+				pos: position{line: 225, col: 18, offset: 6146},
 				run: (*parser).callonRefOperandDot1,
 				expr: &seqExpr{
-					pos: position{line: 221, col: 18, offset: 5988},
+					pos: position{line: 225, col: 18, offset: 6146},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 221, col: 18, offset: 5988},
+							pos:        position{line: 225, col: 18, offset: 6146},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 221, col: 22, offset: 5992},
+							pos:   position{line: 225, col: 22, offset: 6150},
 							label: "val",
 							expr: &ruleRefExpr{
-								pos:  position{line: 221, col: 26, offset: 5996},
+								pos:  position{line: 225, col: 26, offset: 6154},
 								name: "Var",
 							},
 						},
@@ -2475,28 +2541,28 @@ var g = &grammar{
 		},
 		{
 			name: "RefOperandCanonical",
-			pos:  position{line: 225, col: 1, offset: 6059},
+			pos:  position{line: 229, col: 1, offset: 6217},
 			expr: &actionExpr{
-				pos: position{line: 225, col: 24, offset: 6082},
+				pos: position{line: 229, col: 24, offset: 6240},
 				run: (*parser).callonRefOperandCanonical1,
 				expr: &seqExpr{
-					pos: position{line: 225, col: 24, offset: 6082},
+					pos: position{line: 229, col: 24, offset: 6240},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 225, col: 24, offset: 6082},
+							pos:        position{line: 229, col: 24, offset: 6240},
 							val:        "[",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 225, col: 28, offset: 6086},
+							pos:   position{line: 229, col: 28, offset: 6244},
 							label: "val",
 							expr: &ruleRefExpr{
-								pos:  position{line: 225, col: 32, offset: 6090},
+								pos:  position{line: 229, col: 32, offset: 6248},
 								name: "ExprTerm",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 225, col: 41, offset: 6099},
+							pos:        position{line: 229, col: 41, offset: 6257},
 							val:        "]",
 							ignoreCase: false,
 						},
@@ -2506,15 +2572,15 @@ var g = &grammar{
 		},
 		{
 			name: "Var",
-			pos:  position{line: 229, col: 1, offset: 6128},
+			pos:  position{line: 233, col: 1, offset: 6286},
 			expr: &actionExpr{
-				pos: position{line: 229, col: 8, offset: 6135},
+				pos: position{line: 233, col: 8, offset: 6293},
 				run: (*parser).callonVar1,
 				expr: &labeledExpr{
-					pos:   position{line: 229, col: 8, offset: 6135},
+					pos:   position{line: 233, col: 8, offset: 6293},
 					label: "val",
 					expr: &ruleRefExpr{
-						pos:  position{line: 229, col: 12, offset: 6139},
+						pos:  position{line: 233, col: 12, offset: 6297},
 						name: "VarChecked",
 					},
 				},
@@ -2522,20 +2588,20 @@ var g = &grammar{
 		},
 		{
 			name: "VarChecked",
-			pos:  position{line: 233, col: 1, offset: 6194},
+			pos:  position{line: 237, col: 1, offset: 6352},
 			expr: &seqExpr{
-				pos: position{line: 233, col: 15, offset: 6208},
+				pos: position{line: 237, col: 15, offset: 6366},
 				exprs: []interface{}{
 					&labeledExpr{
-						pos:   position{line: 233, col: 15, offset: 6208},
+						pos:   position{line: 237, col: 15, offset: 6366},
 						label: "val",
 						expr: &ruleRefExpr{
-							pos:  position{line: 233, col: 19, offset: 6212},
+							pos:  position{line: 237, col: 19, offset: 6370},
 							name: "VarUnchecked",
 						},
 					},
 					&notCodeExpr{
-						pos: position{line: 233, col: 32, offset: 6225},
+						pos: position{line: 237, col: 32, offset: 6383},
 						run: (*parser).callonVarChecked4,
 					},
 				},
@@ -2543,21 +2609,21 @@ var g = &grammar{
 		},
 		{
 			name: "VarUnchecked",
-			pos:  position{line: 237, col: 1, offset: 6290},
+			pos:  position{line: 241, col: 1, offset: 6448},
 			expr: &actionExpr{
-				pos: position{line: 237, col: 17, offset: 6306},
+				pos: position{line: 241, col: 17, offset: 6464},
 				run: (*parser).callonVarUnchecked1,
 				expr: &seqExpr{
-					pos: position{line: 237, col: 17, offset: 6306},
+					pos: position{line: 241, col: 17, offset: 6464},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 237, col: 17, offset: 6306},
+							pos:  position{line: 241, col: 17, offset: 6464},
 							name: "VarStart",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 237, col: 26, offset: 6315},
+							pos: position{line: 241, col: 26, offset: 6473},
 							expr: &ruleRefExpr{
-								pos:  position{line: 237, col: 26, offset: 6315},
+								pos:  position{line: 241, col: 26, offset: 6473},
 								name: "VarChar",
 							},
 						},
@@ -2567,30 +2633,30 @@ var g = &grammar{
 		},
 		{
 			name: "Number",
-			pos:  position{line: 241, col: 1, offset: 6376},
+			pos:  position{line: 245, col: 1, offset: 6534},
 			expr: &actionExpr{
-				pos: position{line: 241, col: 11, offset: 6386},
+				pos: position{line: 245, col: 11, offset: 6544},
 				run: (*parser).callonNumber1,
 				expr: &seqExpr{
-					pos: position{line: 241, col: 11, offset: 6386},
+					pos: position{line: 245, col: 11, offset: 6544},
 					exprs: []interface{}{
 						&zeroOrOneExpr{
-							pos: position{line: 241, col: 11, offset: 6386},
+							pos: position{line: 245, col: 11, offset: 6544},
 							expr: &litMatcher{
-								pos:        position{line: 241, col: 11, offset: 6386},
+								pos:        position{line: 245, col: 11, offset: 6544},
 								val:        "-",
 								ignoreCase: false,
 							},
 						},
 						&choiceExpr{
-							pos: position{line: 241, col: 18, offset: 6393},
+							pos: position{line: 245, col: 18, offset: 6551},
 							alternatives: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 241, col: 18, offset: 6393},
+									pos:  position{line: 245, col: 18, offset: 6551},
 									name: "Float",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 241, col: 26, offset: 6401},
+									pos:  position{line: 245, col: 26, offset: 6559},
 									name: "Integer",
 								},
 							},
@@ -2601,16 +2667,16 @@ var g = &grammar{
 		},
 		{
 			name: "Float",
-			pos:  position{line: 245, col: 1, offset: 6466},
+			pos:  position{line: 249, col: 1, offset: 6624},
 			expr: &choiceExpr{
-				pos: position{line: 245, col: 10, offset: 6475},
+				pos: position{line: 249, col: 10, offset: 6633},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 245, col: 10, offset: 6475},
+						pos:  position{line: 249, col: 10, offset: 6633},
 						name: "ExponentFloat",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 245, col: 26, offset: 6491},
+						pos:  position{line: 249, col: 26, offset: 6649},
 						name: "PointFloat",
 					},
 				},
@@ -2618,25 +2684,25 @@ var g = &grammar{
 		},
 		{
 			name: "ExponentFloat",
-			pos:  position{line: 247, col: 1, offset: 6503},
+			pos:  position{line: 251, col: 1, offset: 6661},
 			expr: &seqExpr{
-				pos: position{line: 247, col: 18, offset: 6520},
+				pos: position{line: 251, col: 18, offset: 6678},
 				exprs: []interface{}{
 					&choiceExpr{
-						pos: position{line: 247, col: 20, offset: 6522},
+						pos: position{line: 251, col: 20, offset: 6680},
 						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 247, col: 20, offset: 6522},
+								pos:  position{line: 251, col: 20, offset: 6680},
 								name: "PointFloat",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 247, col: 33, offset: 6535},
+								pos:  position{line: 251, col: 33, offset: 6693},
 								name: "Integer",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 247, col: 43, offset: 6545},
+						pos:  position{line: 251, col: 43, offset: 6703},
 						name: "Exponent",
 					},
 				},
@@ -2644,19 +2710,19 @@ var g = &grammar{
 		},
 		{
 			name: "PointFloat",
-			pos:  position{line: 249, col: 1, offset: 6555},
+			pos:  position{line: 253, col: 1, offset: 6713},
 			expr: &seqExpr{
-				pos: position{line: 249, col: 15, offset: 6569},
+				pos: position{line: 253, col: 15, offset: 6727},
 				exprs: []interface{}{
 					&zeroOrOneExpr{
-						pos: position{line: 249, col: 15, offset: 6569},
+						pos: position{line: 253, col: 15, offset: 6727},
 						expr: &ruleRefExpr{
-							pos:  position{line: 249, col: 15, offset: 6569},
+							pos:  position{line: 253, col: 15, offset: 6727},
 							name: "Integer",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 249, col: 24, offset: 6578},
+						pos:  position{line: 253, col: 24, offset: 6736},
 						name: "Fraction",
 					},
 				},
@@ -2664,19 +2730,19 @@ var g = &grammar{
 		},
 		{
 			name: "Fraction",
-			pos:  position{line: 251, col: 1, offset: 6588},
+			pos:  position{line: 255, col: 1, offset: 6746},
 			expr: &seqExpr{
-				pos: position{line: 251, col: 13, offset: 6600},
+				pos: position{line: 255, col: 13, offset: 6758},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 251, col: 13, offset: 6600},
+						pos:        position{line: 255, col: 13, offset: 6758},
 						val:        ".",
 						ignoreCase: false,
 					},
 					&oneOrMoreExpr{
-						pos: position{line: 251, col: 17, offset: 6604},
+						pos: position{line: 255, col: 17, offset: 6762},
 						expr: &ruleRefExpr{
-							pos:  position{line: 251, col: 17, offset: 6604},
+							pos:  position{line: 255, col: 17, offset: 6762},
 							name: "DecimalDigit",
 						},
 					},
@@ -2685,19 +2751,19 @@ var g = &grammar{
 		},
 		{
 			name: "Exponent",
-			pos:  position{line: 253, col: 1, offset: 6619},
+			pos:  position{line: 257, col: 1, offset: 6777},
 			expr: &seqExpr{
-				pos: position{line: 253, col: 13, offset: 6631},
+				pos: position{line: 257, col: 13, offset: 6789},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 253, col: 13, offset: 6631},
+						pos:        position{line: 257, col: 13, offset: 6789},
 						val:        "e",
 						ignoreCase: true,
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 253, col: 18, offset: 6636},
+						pos: position{line: 257, col: 18, offset: 6794},
 						expr: &charClassMatcher{
-							pos:        position{line: 253, col: 18, offset: 6636},
+							pos:        position{line: 257, col: 18, offset: 6794},
 							val:        "[+-]",
 							chars:      []rune{'+', '-'},
 							ignoreCase: false,
@@ -2705,9 +2771,9 @@ var g = &grammar{
 						},
 					},
 					&oneOrMoreExpr{
-						pos: position{line: 253, col: 24, offset: 6642},
+						pos: position{line: 257, col: 24, offset: 6800},
 						expr: &ruleRefExpr{
-							pos:  position{line: 253, col: 24, offset: 6642},
+							pos:  position{line: 257, col: 24, offset: 6800},
 							name: "DecimalDigit",
 						},
 					},
@@ -2716,26 +2782,26 @@ var g = &grammar{
 		},
 		{
 			name: "Integer",
-			pos:  position{line: 255, col: 1, offset: 6657},
+			pos:  position{line: 259, col: 1, offset: 6815},
 			expr: &choiceExpr{
-				pos: position{line: 255, col: 12, offset: 6668},
+				pos: position{line: 259, col: 12, offset: 6826},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 255, col: 12, offset: 6668},
+						pos:        position{line: 259, col: 12, offset: 6826},
 						val:        "0",
 						ignoreCase: false,
 					},
 					&seqExpr{
-						pos: position{line: 255, col: 20, offset: 6676},
+						pos: position{line: 259, col: 20, offset: 6834},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 255, col: 20, offset: 6676},
+								pos:  position{line: 259, col: 20, offset: 6834},
 								name: "NonZeroDecimalDigit",
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 255, col: 40, offset: 6696},
+								pos: position{line: 259, col: 40, offset: 6854},
 								expr: &ruleRefExpr{
-									pos:  position{line: 255, col: 40, offset: 6696},
+									pos:  position{line: 259, col: 40, offset: 6854},
 									name: "DecimalDigit",
 								},
 							},
@@ -2746,16 +2812,16 @@ var g = &grammar{
 		},
 		{
 			name: "String",
-			pos:  position{line: 257, col: 1, offset: 6713},
+			pos:  position{line: 261, col: 1, offset: 6871},
 			expr: &choiceExpr{
-				pos: position{line: 257, col: 11, offset: 6723},
+				pos: position{line: 261, col: 11, offset: 6881},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 257, col: 11, offset: 6723},
+						pos:  position{line: 261, col: 11, offset: 6881},
 						name: "QuotedString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 257, col: 26, offset: 6738},
+						pos:  position{line: 261, col: 26, offset: 6896},
 						name: "RawString",
 					},
 				},
@@ -2763,30 +2829,30 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedString",
-			pos:  position{line: 259, col: 1, offset: 6749},
+			pos:  position{line: 263, col: 1, offset: 6907},
 			expr: &choiceExpr{
-				pos: position{line: 259, col: 17, offset: 6765},
+				pos: position{line: 263, col: 17, offset: 6923},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 259, col: 17, offset: 6765},
+						pos: position{line: 263, col: 17, offset: 6923},
 						run: (*parser).callonQuotedString2,
 						expr: &seqExpr{
-							pos: position{line: 259, col: 17, offset: 6765},
+							pos: position{line: 263, col: 17, offset: 6923},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 259, col: 17, offset: 6765},
+									pos:        position{line: 263, col: 17, offset: 6923},
 									val:        "\"",
 									ignoreCase: false,
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 259, col: 21, offset: 6769},
+									pos: position{line: 263, col: 21, offset: 6927},
 									expr: &ruleRefExpr{
-										pos:  position{line: 259, col: 21, offset: 6769},
+										pos:  position{line: 263, col: 21, offset: 6927},
 										name: "Char",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 259, col: 27, offset: 6775},
+									pos:        position{line: 263, col: 27, offset: 6933},
 									val:        "\"",
 									ignoreCase: false,
 								},
@@ -2794,27 +2860,27 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 261, col: 5, offset: 6835},
+						pos: position{line: 265, col: 5, offset: 6993},
 						run: (*parser).callonQuotedString8,
 						expr: &seqExpr{
-							pos: position{line: 261, col: 5, offset: 6835},
+							pos: position{line: 265, col: 5, offset: 6993},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 261, col: 5, offset: 6835},
+									pos:        position{line: 265, col: 5, offset: 6993},
 									val:        "\"",
 									ignoreCase: false,
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 261, col: 9, offset: 6839},
+									pos: position{line: 265, col: 9, offset: 6997},
 									expr: &ruleRefExpr{
-										pos:  position{line: 261, col: 9, offset: 6839},
+										pos:  position{line: 265, col: 9, offset: 6997},
 										name: "Char",
 									},
 								},
 								&notExpr{
-									pos: position{line: 261, col: 15, offset: 6845},
+									pos: position{line: 265, col: 15, offset: 7003},
 									expr: &litMatcher{
-										pos:        position{line: 261, col: 16, offset: 6846},
+										pos:        position{line: 265, col: 16, offset: 7004},
 										val:        "\"",
 										ignoreCase: false,
 									},
@@ -2827,22 +2893,22 @@ var g = &grammar{
 		},
 		{
 			name: "RawString",
-			pos:  position{line: 265, col: 1, offset: 6926},
+			pos:  position{line: 269, col: 1, offset: 7084},
 			expr: &actionExpr{
-				pos: position{line: 265, col: 14, offset: 6939},
+				pos: position{line: 269, col: 14, offset: 7097},
 				run: (*parser).callonRawString1,
 				expr: &seqExpr{
-					pos: position{line: 265, col: 14, offset: 6939},
+					pos: position{line: 269, col: 14, offset: 7097},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 265, col: 14, offset: 6939},
+							pos:        position{line: 269, col: 14, offset: 7097},
 							val:        "`",
 							ignoreCase: false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 265, col: 18, offset: 6943},
+							pos: position{line: 269, col: 18, offset: 7101},
 							expr: &charClassMatcher{
-								pos:        position{line: 265, col: 18, offset: 6943},
+								pos:        position{line: 269, col: 18, offset: 7101},
 								val:        "[^`]",
 								chars:      []rune{'`'},
 								ignoreCase: false,
@@ -2850,7 +2916,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 265, col: 24, offset: 6949},
+							pos:        position{line: 269, col: 24, offset: 7107},
 							val:        "`",
 							ignoreCase: false,
 						},
@@ -2860,26 +2926,26 @@ var g = &grammar{
 		},
 		{
 			name: "Bool",
-			pos:  position{line: 269, col: 1, offset: 7011},
+			pos:  position{line: 273, col: 1, offset: 7169},
 			expr: &actionExpr{
-				pos: position{line: 269, col: 9, offset: 7019},
+				pos: position{line: 273, col: 9, offset: 7177},
 				run: (*parser).callonBool1,
 				expr: &seqExpr{
-					pos: position{line: 269, col: 9, offset: 7019},
+					pos: position{line: 273, col: 9, offset: 7177},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 269, col: 9, offset: 7019},
+							pos:   position{line: 273, col: 9, offset: 7177},
 							label: "val",
 							expr: &choiceExpr{
-								pos: position{line: 269, col: 14, offset: 7024},
+								pos: position{line: 273, col: 14, offset: 7182},
 								alternatives: []interface{}{
 									&litMatcher{
-										pos:        position{line: 269, col: 14, offset: 7024},
+										pos:        position{line: 273, col: 14, offset: 7182},
 										val:        "true",
 										ignoreCase: false,
 									},
 									&litMatcher{
-										pos:        position{line: 269, col: 23, offset: 7033},
+										pos:        position{line: 273, col: 23, offset: 7191},
 										val:        "false",
 										ignoreCase: false,
 									},
@@ -2887,9 +2953,9 @@ var g = &grammar{
 							},
 						},
 						&notExpr{
-							pos: position{line: 269, col: 32, offset: 7042},
+							pos: position{line: 273, col: 32, offset: 7200},
 							expr: &ruleRefExpr{
-								pos:  position{line: 269, col: 33, offset: 7043},
+								pos:  position{line: 273, col: 33, offset: 7201},
 								name: "VarChar",
 							},
 						},
@@ -2899,22 +2965,22 @@ var g = &grammar{
 		},
 		{
 			name: "Null",
-			pos:  position{line: 273, col: 1, offset: 7104},
+			pos:  position{line: 277, col: 1, offset: 7262},
 			expr: &actionExpr{
-				pos: position{line: 273, col: 9, offset: 7112},
+				pos: position{line: 277, col: 9, offset: 7270},
 				run: (*parser).callonNull1,
 				expr: &seqExpr{
-					pos: position{line: 273, col: 9, offset: 7112},
+					pos: position{line: 277, col: 9, offset: 7270},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 273, col: 9, offset: 7112},
+							pos:        position{line: 277, col: 9, offset: 7270},
 							val:        "null",
 							ignoreCase: false,
 						},
 						&notExpr{
-							pos: position{line: 273, col: 16, offset: 7119},
+							pos: position{line: 277, col: 16, offset: 7277},
 							expr: &ruleRefExpr{
-								pos:  position{line: 273, col: 17, offset: 7120},
+								pos:  position{line: 277, col: 17, offset: 7278},
 								name: "VarChar",
 							},
 						},
@@ -2924,24 +2990,24 @@ var g = &grammar{
 		},
 		{
 			name: "VarStart",
-			pos:  position{line: 277, col: 1, offset: 7173},
+			pos:  position{line: 281, col: 1, offset: 7331},
 			expr: &ruleRefExpr{
-				pos:  position{line: 277, col: 13, offset: 7185},
+				pos:  position{line: 281, col: 13, offset: 7343},
 				name: "AsciiLetter",
 			},
 		},
 		{
 			name: "VarChar",
-			pos:  position{line: 279, col: 1, offset: 7198},
+			pos:  position{line: 283, col: 1, offset: 7356},
 			expr: &choiceExpr{
-				pos: position{line: 279, col: 12, offset: 7209},
+				pos: position{line: 283, col: 12, offset: 7367},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 279, col: 12, offset: 7209},
+						pos:  position{line: 283, col: 12, offset: 7367},
 						name: "AsciiLetter",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 279, col: 26, offset: 7223},
+						pos:  position{line: 283, col: 26, offset: 7381},
 						name: "DecimalDigit",
 					},
 				},
@@ -2949,9 +3015,9 @@ var g = &grammar{
 		},
 		{
 			name: "AsciiLetter",
-			pos:  position{line: 281, col: 1, offset: 7237},
+			pos:  position{line: 285, col: 1, offset: 7395},
 			expr: &charClassMatcher{
-				pos:        position{line: 281, col: 16, offset: 7252},
+				pos:        position{line: 285, col: 16, offset: 7410},
 				val:        "[A-Za-z_]",
 				chars:      []rune{'_'},
 				ranges:     []rune{'A', 'Z', 'a', 'z'},
@@ -2961,35 +3027,35 @@ var g = &grammar{
 		},
 		{
 			name: "Char",
-			pos:  position{line: 283, col: 1, offset: 7263},
+			pos:  position{line: 287, col: 1, offset: 7421},
 			expr: &choiceExpr{
-				pos: position{line: 283, col: 9, offset: 7271},
+				pos: position{line: 287, col: 9, offset: 7429},
 				alternatives: []interface{}{
 					&seqExpr{
-						pos: position{line: 283, col: 11, offset: 7273},
+						pos: position{line: 287, col: 11, offset: 7431},
 						exprs: []interface{}{
 							&notExpr{
-								pos: position{line: 283, col: 11, offset: 7273},
+								pos: position{line: 287, col: 11, offset: 7431},
 								expr: &ruleRefExpr{
-									pos:  position{line: 283, col: 12, offset: 7274},
+									pos:  position{line: 287, col: 12, offset: 7432},
 									name: "EscapedChar",
 								},
 							},
 							&anyMatcher{
-								line: 283, col: 24, offset: 7286,
+								line: 287, col: 24, offset: 7444,
 							},
 						},
 					},
 					&seqExpr{
-						pos: position{line: 283, col: 32, offset: 7294},
+						pos: position{line: 287, col: 32, offset: 7452},
 						exprs: []interface{}{
 							&litMatcher{
-								pos:        position{line: 283, col: 32, offset: 7294},
+								pos:        position{line: 287, col: 32, offset: 7452},
 								val:        "\\",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 283, col: 37, offset: 7299},
+								pos:  position{line: 287, col: 37, offset: 7457},
 								name: "EscapeSequence",
 							},
 						},
@@ -2999,9 +3065,9 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedChar",
-			pos:  position{line: 285, col: 1, offset: 7317},
+			pos:  position{line: 289, col: 1, offset: 7475},
 			expr: &charClassMatcher{
-				pos:        position{line: 285, col: 16, offset: 7332},
+				pos:        position{line: 289, col: 16, offset: 7490},
 				val:        "[\\x00-\\x1f\"\\\\]",
 				chars:      []rune{'"', '\\'},
 				ranges:     []rune{'\x00', '\x1f'},
@@ -3011,16 +3077,16 @@ var g = &grammar{
 		},
 		{
 			name: "EscapeSequence",
-			pos:  position{line: 287, col: 1, offset: 7348},
+			pos:  position{line: 291, col: 1, offset: 7506},
 			expr: &choiceExpr{
-				pos: position{line: 287, col: 19, offset: 7366},
+				pos: position{line: 291, col: 19, offset: 7524},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 287, col: 19, offset: 7366},
+						pos:  position{line: 291, col: 19, offset: 7524},
 						name: "SingleCharEscape",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 287, col: 38, offset: 7385},
+						pos:  position{line: 291, col: 38, offset: 7543},
 						name: "UnicodeEscape",
 					},
 				},
@@ -3028,9 +3094,9 @@ var g = &grammar{
 		},
 		{
 			name: "SingleCharEscape",
-			pos:  position{line: 289, col: 1, offset: 7400},
+			pos:  position{line: 293, col: 1, offset: 7558},
 			expr: &charClassMatcher{
-				pos:        position{line: 289, col: 21, offset: 7420},
+				pos:        position{line: 293, col: 21, offset: 7578},
 				val:        "[ \" \\\\ / b f n r t ]",
 				chars:      []rune{' ', '"', ' ', '\\', ' ', '/', ' ', 'b', ' ', 'f', ' ', 'n', ' ', 'r', ' ', 't', ' '},
 				ignoreCase: false,
@@ -3039,29 +3105,29 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeEscape",
-			pos:  position{line: 291, col: 1, offset: 7442},
+			pos:  position{line: 295, col: 1, offset: 7600},
 			expr: &seqExpr{
-				pos: position{line: 291, col: 18, offset: 7459},
+				pos: position{line: 295, col: 18, offset: 7617},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 291, col: 18, offset: 7459},
+						pos:        position{line: 295, col: 18, offset: 7617},
 						val:        "u",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 291, col: 22, offset: 7463},
+						pos:  position{line: 295, col: 22, offset: 7621},
 						name: "HexDigit",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 291, col: 31, offset: 7472},
+						pos:  position{line: 295, col: 31, offset: 7630},
 						name: "HexDigit",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 291, col: 40, offset: 7481},
+						pos:  position{line: 295, col: 40, offset: 7639},
 						name: "HexDigit",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 291, col: 49, offset: 7490},
+						pos:  position{line: 295, col: 49, offset: 7648},
 						name: "HexDigit",
 					},
 				},
@@ -3069,9 +3135,9 @@ var g = &grammar{
 		},
 		{
 			name: "DecimalDigit",
-			pos:  position{line: 293, col: 1, offset: 7500},
+			pos:  position{line: 297, col: 1, offset: 7658},
 			expr: &charClassMatcher{
-				pos:        position{line: 293, col: 17, offset: 7516},
+				pos:        position{line: 297, col: 17, offset: 7674},
 				val:        "[0-9]",
 				ranges:     []rune{'0', '9'},
 				ignoreCase: false,
@@ -3080,9 +3146,9 @@ var g = &grammar{
 		},
 		{
 			name: "NonZeroDecimalDigit",
-			pos:  position{line: 295, col: 1, offset: 7523},
+			pos:  position{line: 299, col: 1, offset: 7681},
 			expr: &charClassMatcher{
-				pos:        position{line: 295, col: 24, offset: 7546},
+				pos:        position{line: 299, col: 24, offset: 7704},
 				val:        "[1-9]",
 				ranges:     []rune{'1', '9'},
 				ignoreCase: false,
@@ -3091,9 +3157,9 @@ var g = &grammar{
 		},
 		{
 			name: "HexDigit",
-			pos:  position{line: 297, col: 1, offset: 7553},
+			pos:  position{line: 301, col: 1, offset: 7711},
 			expr: &charClassMatcher{
-				pos:        position{line: 297, col: 13, offset: 7565},
+				pos:        position{line: 301, col: 13, offset: 7723},
 				val:        "[0-9a-fA-F]",
 				ranges:     []rune{'0', '9', 'a', 'f', 'A', 'F'},
 				ignoreCase: false,
@@ -3103,11 +3169,11 @@ var g = &grammar{
 		{
 			name:        "ws",
 			displayName: "\"whitespace\"",
-			pos:         position{line: 299, col: 1, offset: 7578},
+			pos:         position{line: 303, col: 1, offset: 7736},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 299, col: 20, offset: 7597},
+				pos: position{line: 303, col: 20, offset: 7755},
 				expr: &charClassMatcher{
-					pos:        position{line: 299, col: 20, offset: 7597},
+					pos:        position{line: 303, col: 20, offset: 7755},
 					val:        "[ \\t\\r\\n]",
 					chars:      []rune{' ', '\t', '\r', '\n'},
 					ignoreCase: false,
@@ -3118,21 +3184,21 @@ var g = &grammar{
 		{
 			name:        "_",
 			displayName: "\"whitespace\"",
-			pos:         position{line: 301, col: 1, offset: 7609},
+			pos:         position{line: 305, col: 1, offset: 7767},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 301, col: 19, offset: 7627},
+				pos: position{line: 305, col: 19, offset: 7785},
 				expr: &choiceExpr{
-					pos: position{line: 301, col: 21, offset: 7629},
+					pos: position{line: 305, col: 21, offset: 7787},
 					alternatives: []interface{}{
 						&charClassMatcher{
-							pos:        position{line: 301, col: 21, offset: 7629},
+							pos:        position{line: 305, col: 21, offset: 7787},
 							val:        "[ \\t\\r\\n]",
 							chars:      []rune{' ', '\t', '\r', '\n'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 301, col: 33, offset: 7641},
+							pos:  position{line: 305, col: 33, offset: 7799},
 							name: "Comment",
 						},
 					},
@@ -3141,17 +3207,17 @@ var g = &grammar{
 		},
 		{
 			name: "Comment",
-			pos:  position{line: 303, col: 1, offset: 7653},
+			pos:  position{line: 307, col: 1, offset: 7811},
 			expr: &actionExpr{
-				pos: position{line: 303, col: 12, offset: 7664},
+				pos: position{line: 307, col: 12, offset: 7822},
 				run: (*parser).callonComment1,
 				expr: &seqExpr{
-					pos: position{line: 303, col: 12, offset: 7664},
+					pos: position{line: 307, col: 12, offset: 7822},
 					exprs: []interface{}{
 						&zeroOrMoreExpr{
-							pos: position{line: 303, col: 12, offset: 7664},
+							pos: position{line: 307, col: 12, offset: 7822},
 							expr: &charClassMatcher{
-								pos:        position{line: 303, col: 12, offset: 7664},
+								pos:        position{line: 307, col: 12, offset: 7822},
 								val:        "[ \\t]",
 								chars:      []rune{' ', '\t'},
 								ignoreCase: false,
@@ -3159,17 +3225,17 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 303, col: 19, offset: 7671},
+							pos:        position{line: 307, col: 19, offset: 7829},
 							val:        "#",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 303, col: 23, offset: 7675},
+							pos:   position{line: 307, col: 23, offset: 7833},
 							label: "text",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 303, col: 28, offset: 7680},
+								pos: position{line: 307, col: 28, offset: 7838},
 								expr: &charClassMatcher{
-									pos:        position{line: 303, col: 28, offset: 7680},
+									pos:        position{line: 307, col: 28, offset: 7838},
 									val:        "[^\\r\\n]",
 									chars:      []rune{'\r', '\n'},
 									ignoreCase: false,
@@ -3183,11 +3249,11 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 307, col: 1, offset: 7727},
+			pos:  position{line: 311, col: 1, offset: 7885},
 			expr: &notExpr{
-				pos: position{line: 307, col: 8, offset: 7734},
+				pos: position{line: 311, col: 8, offset: 7892},
 				expr: &anyMatcher{
-					line: 307, col: 9, offset: 7735,
+					line: 311, col: 9, offset: 7893,
 				},
 			},
 		},
@@ -3254,14 +3320,24 @@ func (p *parser) callonNormalRules1() (interface{}, error) {
 	return p.cur.onNormalRules1(stack["head"], stack["rest"])
 }
 
-func (c *current) onRuleHead1(name, args, key, value interface{}) (interface{}, error) {
-	return makeRuleHead(currentLocation(c), name, args, key, value)
+func (c *current) onPartialRuleHead1(name, args, value interface{}) (interface{}, error) {
+	return makeRuleHead(currentLocation(c), name, args, nil, value)
+}
+
+func (p *parser) callonPartialRuleHead1() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onPartialRuleHead1(stack["name"], stack["args"], stack["value"])
+}
+
+func (c *current) onRuleHead1(name, key, value interface{}) (interface{}, error) {
+	return makeRuleHead(currentLocation(c), name, nil, key, value)
 }
 
 func (p *parser) callonRuleHead1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onRuleHead1(stack["name"], stack["args"], stack["key"], stack["value"])
+	return p.cur.onRuleHead1(stack["name"], stack["key"], stack["value"])
 }
 
 func (c *current) onArgs1(list interface{}) (interface{}, error) {

--- a/ast/parser.go
+++ b/ast/parser.go
@@ -1892,35 +1892,47 @@ var g = &grammar{
 			expr: &actionExpr{
 				pos: position{line: 170, col: 9, offset: 4606},
 				run: (*parser).callonTerm1,
-				expr: &labeledExpr{
-					pos:   position{line: 170, col: 9, offset: 4606},
-					label: "val",
-					expr: &choiceExpr{
-						pos: position{line: 170, col: 15, offset: 4612},
-						alternatives: []interface{}{
-							&ruleRefExpr{
-								pos:  position{line: 170, col: 15, offset: 4612},
-								name: "Comprehension",
+				expr: &seqExpr{
+					pos: position{line: 170, col: 9, offset: 4606},
+					exprs: []interface{}{
+						&labeledExpr{
+							pos:   position{line: 170, col: 9, offset: 4606},
+							label: "val",
+							expr: &choiceExpr{
+								pos: position{line: 170, col: 15, offset: 4612},
+								alternatives: []interface{}{
+									&ruleRefExpr{
+										pos:  position{line: 170, col: 15, offset: 4612},
+										name: "Comprehension",
+									},
+									&ruleRefExpr{
+										pos:  position{line: 170, col: 31, offset: 4628},
+										name: "Composite",
+									},
+									&ruleRefExpr{
+										pos:  position{line: 170, col: 43, offset: 4640},
+										name: "Scalar",
+									},
+									&ruleRefExpr{
+										pos:  position{line: 170, col: 52, offset: 4649},
+										name: "Call",
+									},
+									&ruleRefExpr{
+										pos:  position{line: 170, col: 59, offset: 4656},
+										name: "Var",
+									},
+								},
 							},
-							&ruleRefExpr{
-								pos:  position{line: 170, col: 31, offset: 4628},
-								name: "Composite",
-							},
-							&ruleRefExpr{
-								pos:  position{line: 170, col: 43, offset: 4640},
-								name: "Scalar",
-							},
-							&ruleRefExpr{
-								pos:  position{line: 170, col: 52, offset: 4649},
-								name: "Call",
-							},
-							&ruleRefExpr{
-								pos:  position{line: 170, col: 59, offset: 4656},
-								name: "Ref",
-							},
-							&ruleRefExpr{
-								pos:  position{line: 170, col: 65, offset: 4662},
-								name: "Var",
+						},
+						&labeledExpr{
+							pos:   position{line: 170, col: 65, offset: 4662},
+							label: "refs",
+							expr: &zeroOrMoreExpr{
+								pos: position{line: 170, col: 70, offset: 4667},
+								expr: &ruleRefExpr{
+									pos:  position{line: 170, col: 70, offset: 4667},
+									name: "RefOperand",
+								},
 							},
 						},
 					},
@@ -1929,39 +1941,39 @@ var g = &grammar{
 		},
 		{
 			name: "TermPair",
-			pos:  position{line: 174, col: 1, offset: 4693},
+			pos:  position{line: 174, col: 1, offset: 4734},
 			expr: &actionExpr{
-				pos: position{line: 174, col: 13, offset: 4705},
+				pos: position{line: 174, col: 13, offset: 4746},
 				run: (*parser).callonTermPair1,
 				expr: &seqExpr{
-					pos: position{line: 174, col: 13, offset: 4705},
+					pos: position{line: 174, col: 13, offset: 4746},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 174, col: 13, offset: 4705},
+							pos:   position{line: 174, col: 13, offset: 4746},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 174, col: 17, offset: 4709},
+								pos:  position{line: 174, col: 17, offset: 4750},
 								name: "Term",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 174, col: 22, offset: 4714},
+							pos:  position{line: 174, col: 22, offset: 4755},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 174, col: 24, offset: 4716},
+							pos:        position{line: 174, col: 24, offset: 4757},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 174, col: 28, offset: 4720},
+							pos:  position{line: 174, col: 28, offset: 4761},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 174, col: 30, offset: 4722},
+							pos:   position{line: 174, col: 30, offset: 4763},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 174, col: 36, offset: 4728},
+								pos:  position{line: 174, col: 36, offset: 4769},
 								name: "Term",
 							},
 						},
@@ -1971,20 +1983,20 @@ var g = &grammar{
 		},
 		{
 			name: "Comprehension",
-			pos:  position{line: 178, col: 1, offset: 4778},
+			pos:  position{line: 178, col: 1, offset: 4819},
 			expr: &choiceExpr{
-				pos: position{line: 178, col: 18, offset: 4795},
+				pos: position{line: 178, col: 18, offset: 4836},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 178, col: 18, offset: 4795},
+						pos:  position{line: 178, col: 18, offset: 4836},
 						name: "ArrayComprehension",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 178, col: 39, offset: 4816},
+						pos:  position{line: 178, col: 39, offset: 4857},
 						name: "ObjectComprehension",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 178, col: 61, offset: 4838},
+						pos:  position{line: 178, col: 61, offset: 4879},
 						name: "SetComprehension",
 					},
 				},
@@ -1992,57 +2004,57 @@ var g = &grammar{
 		},
 		{
 			name: "ArrayComprehension",
-			pos:  position{line: 180, col: 1, offset: 4856},
+			pos:  position{line: 180, col: 1, offset: 4897},
 			expr: &actionExpr{
-				pos: position{line: 180, col: 23, offset: 4878},
+				pos: position{line: 180, col: 23, offset: 4919},
 				run: (*parser).callonArrayComprehension1,
 				expr: &seqExpr{
-					pos: position{line: 180, col: 23, offset: 4878},
+					pos: position{line: 180, col: 23, offset: 4919},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 180, col: 23, offset: 4878},
+							pos:        position{line: 180, col: 23, offset: 4919},
 							val:        "[",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 180, col: 27, offset: 4882},
+							pos:  position{line: 180, col: 27, offset: 4923},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 180, col: 29, offset: 4884},
+							pos:   position{line: 180, col: 29, offset: 4925},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 180, col: 34, offset: 4889},
+								pos:  position{line: 180, col: 34, offset: 4930},
 								name: "Term",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 180, col: 39, offset: 4894},
+							pos:  position{line: 180, col: 39, offset: 4935},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 180, col: 41, offset: 4896},
+							pos:        position{line: 180, col: 41, offset: 4937},
 							val:        "|",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 180, col: 45, offset: 4900},
+							pos:  position{line: 180, col: 45, offset: 4941},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 180, col: 47, offset: 4902},
+							pos:   position{line: 180, col: 47, offset: 4943},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 180, col: 52, offset: 4907},
+								pos:  position{line: 180, col: 52, offset: 4948},
 								name: "WhitespaceBody",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 180, col: 67, offset: 4922},
+							pos:  position{line: 180, col: 67, offset: 4963},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 180, col: 69, offset: 4924},
+							pos:        position{line: 180, col: 69, offset: 4965},
 							val:        "]",
 							ignoreCase: false,
 						},
@@ -2052,57 +2064,57 @@ var g = &grammar{
 		},
 		{
 			name: "ObjectComprehension",
-			pos:  position{line: 184, col: 1, offset: 4999},
+			pos:  position{line: 184, col: 1, offset: 5040},
 			expr: &actionExpr{
-				pos: position{line: 184, col: 24, offset: 5022},
+				pos: position{line: 184, col: 24, offset: 5063},
 				run: (*parser).callonObjectComprehension1,
 				expr: &seqExpr{
-					pos: position{line: 184, col: 24, offset: 5022},
+					pos: position{line: 184, col: 24, offset: 5063},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 184, col: 24, offset: 5022},
+							pos:        position{line: 184, col: 24, offset: 5063},
 							val:        "{",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 184, col: 28, offset: 5026},
+							pos:  position{line: 184, col: 28, offset: 5067},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 184, col: 30, offset: 5028},
+							pos:   position{line: 184, col: 30, offset: 5069},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 184, col: 35, offset: 5033},
+								pos:  position{line: 184, col: 35, offset: 5074},
 								name: "TermPair",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 184, col: 45, offset: 5043},
+							pos:  position{line: 184, col: 45, offset: 5084},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 184, col: 47, offset: 5045},
+							pos:        position{line: 184, col: 47, offset: 5086},
 							val:        "|",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 184, col: 51, offset: 5049},
+							pos:  position{line: 184, col: 51, offset: 5090},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 184, col: 53, offset: 5051},
+							pos:   position{line: 184, col: 53, offset: 5092},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 184, col: 58, offset: 5056},
+								pos:  position{line: 184, col: 58, offset: 5097},
 								name: "WhitespaceBody",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 184, col: 73, offset: 5071},
+							pos:  position{line: 184, col: 73, offset: 5112},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 184, col: 75, offset: 5073},
+							pos:        position{line: 184, col: 75, offset: 5114},
 							val:        "}",
 							ignoreCase: false,
 						},
@@ -2112,57 +2124,57 @@ var g = &grammar{
 		},
 		{
 			name: "SetComprehension",
-			pos:  position{line: 188, col: 1, offset: 5149},
+			pos:  position{line: 188, col: 1, offset: 5190},
 			expr: &actionExpr{
-				pos: position{line: 188, col: 21, offset: 5169},
+				pos: position{line: 188, col: 21, offset: 5210},
 				run: (*parser).callonSetComprehension1,
 				expr: &seqExpr{
-					pos: position{line: 188, col: 21, offset: 5169},
+					pos: position{line: 188, col: 21, offset: 5210},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 188, col: 21, offset: 5169},
+							pos:        position{line: 188, col: 21, offset: 5210},
 							val:        "{",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 188, col: 25, offset: 5173},
+							pos:  position{line: 188, col: 25, offset: 5214},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 188, col: 27, offset: 5175},
+							pos:   position{line: 188, col: 27, offset: 5216},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 188, col: 32, offset: 5180},
+								pos:  position{line: 188, col: 32, offset: 5221},
 								name: "Term",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 188, col: 37, offset: 5185},
+							pos:  position{line: 188, col: 37, offset: 5226},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 188, col: 39, offset: 5187},
+							pos:        position{line: 188, col: 39, offset: 5228},
 							val:        "|",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 188, col: 43, offset: 5191},
+							pos:  position{line: 188, col: 43, offset: 5232},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 188, col: 45, offset: 5193},
+							pos:   position{line: 188, col: 45, offset: 5234},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 188, col: 50, offset: 5198},
+								pos:  position{line: 188, col: 50, offset: 5239},
 								name: "WhitespaceBody",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 188, col: 65, offset: 5213},
+							pos:  position{line: 188, col: 65, offset: 5254},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 188, col: 67, offset: 5215},
+							pos:        position{line: 188, col: 67, offset: 5256},
 							val:        "}",
 							ignoreCase: false,
 						},
@@ -2172,20 +2184,20 @@ var g = &grammar{
 		},
 		{
 			name: "Composite",
-			pos:  position{line: 192, col: 1, offset: 5288},
+			pos:  position{line: 192, col: 1, offset: 5329},
 			expr: &choiceExpr{
-				pos: position{line: 192, col: 14, offset: 5301},
+				pos: position{line: 192, col: 14, offset: 5342},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 192, col: 14, offset: 5301},
+						pos:  position{line: 192, col: 14, offset: 5342},
 						name: "Object",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 192, col: 23, offset: 5310},
+						pos:  position{line: 192, col: 23, offset: 5351},
 						name: "Array",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 192, col: 31, offset: 5318},
+						pos:  position{line: 192, col: 31, offset: 5359},
 						name: "Set",
 					},
 				},
@@ -2193,24 +2205,24 @@ var g = &grammar{
 		},
 		{
 			name: "Scalar",
-			pos:  position{line: 194, col: 1, offset: 5323},
+			pos:  position{line: 194, col: 1, offset: 5364},
 			expr: &choiceExpr{
-				pos: position{line: 194, col: 11, offset: 5333},
+				pos: position{line: 194, col: 11, offset: 5374},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 194, col: 11, offset: 5333},
+						pos:  position{line: 194, col: 11, offset: 5374},
 						name: "Number",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 194, col: 20, offset: 5342},
+						pos:  position{line: 194, col: 20, offset: 5383},
 						name: "String",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 194, col: 29, offset: 5351},
+						pos:  position{line: 194, col: 29, offset: 5392},
 						name: "Bool",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 194, col: 36, offset: 5358},
+						pos:  position{line: 194, col: 36, offset: 5399},
 						name: "Null",
 					},
 				},
@@ -2218,36 +2230,36 @@ var g = &grammar{
 		},
 		{
 			name: "Object",
-			pos:  position{line: 196, col: 1, offset: 5364},
+			pos:  position{line: 196, col: 1, offset: 5405},
 			expr: &actionExpr{
-				pos: position{line: 196, col: 11, offset: 5374},
+				pos: position{line: 196, col: 11, offset: 5415},
 				run: (*parser).callonObject1,
 				expr: &seqExpr{
-					pos: position{line: 196, col: 11, offset: 5374},
+					pos: position{line: 196, col: 11, offset: 5415},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 196, col: 11, offset: 5374},
+							pos:        position{line: 196, col: 11, offset: 5415},
 							val:        "{",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 196, col: 15, offset: 5378},
+							pos:  position{line: 196, col: 15, offset: 5419},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 196, col: 17, offset: 5380},
+							pos:   position{line: 196, col: 17, offset: 5421},
 							label: "list",
 							expr: &ruleRefExpr{
-								pos:  position{line: 196, col: 22, offset: 5385},
+								pos:  position{line: 196, col: 22, offset: 5426},
 								name: "ExprTermPairList",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 196, col: 39, offset: 5402},
+							pos:  position{line: 196, col: 39, offset: 5443},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 196, col: 41, offset: 5404},
+							pos:        position{line: 196, col: 41, offset: 5445},
 							val:        "}",
 							ignoreCase: false,
 						},
@@ -2257,36 +2269,36 @@ var g = &grammar{
 		},
 		{
 			name: "Array",
-			pos:  position{line: 200, col: 1, offset: 5461},
+			pos:  position{line: 200, col: 1, offset: 5502},
 			expr: &actionExpr{
-				pos: position{line: 200, col: 10, offset: 5470},
+				pos: position{line: 200, col: 10, offset: 5511},
 				run: (*parser).callonArray1,
 				expr: &seqExpr{
-					pos: position{line: 200, col: 10, offset: 5470},
+					pos: position{line: 200, col: 10, offset: 5511},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 200, col: 10, offset: 5470},
+							pos:        position{line: 200, col: 10, offset: 5511},
 							val:        "[",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 200, col: 14, offset: 5474},
+							pos:  position{line: 200, col: 14, offset: 5515},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 200, col: 16, offset: 5476},
+							pos:   position{line: 200, col: 16, offset: 5517},
 							label: "list",
 							expr: &ruleRefExpr{
-								pos:  position{line: 200, col: 21, offset: 5481},
+								pos:  position{line: 200, col: 21, offset: 5522},
 								name: "ExprTermList",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 200, col: 34, offset: 5494},
+							pos:  position{line: 200, col: 34, offset: 5535},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 200, col: 36, offset: 5496},
+							pos:        position{line: 200, col: 36, offset: 5537},
 							val:        "]",
 							ignoreCase: false,
 						},
@@ -2296,16 +2308,16 @@ var g = &grammar{
 		},
 		{
 			name: "Set",
-			pos:  position{line: 204, col: 1, offset: 5552},
+			pos:  position{line: 204, col: 1, offset: 5593},
 			expr: &choiceExpr{
-				pos: position{line: 204, col: 8, offset: 5559},
+				pos: position{line: 204, col: 8, offset: 5600},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 204, col: 8, offset: 5559},
+						pos:  position{line: 204, col: 8, offset: 5600},
 						name: "SetEmpty",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 204, col: 19, offset: 5570},
+						pos:  position{line: 204, col: 19, offset: 5611},
 						name: "SetNonEmpty",
 					},
 				},
@@ -2313,24 +2325,24 @@ var g = &grammar{
 		},
 		{
 			name: "SetEmpty",
-			pos:  position{line: 206, col: 1, offset: 5583},
+			pos:  position{line: 206, col: 1, offset: 5624},
 			expr: &actionExpr{
-				pos: position{line: 206, col: 13, offset: 5595},
+				pos: position{line: 206, col: 13, offset: 5636},
 				run: (*parser).callonSetEmpty1,
 				expr: &seqExpr{
-					pos: position{line: 206, col: 13, offset: 5595},
+					pos: position{line: 206, col: 13, offset: 5636},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 206, col: 13, offset: 5595},
+							pos:        position{line: 206, col: 13, offset: 5636},
 							val:        "set(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 206, col: 20, offset: 5602},
+							pos:  position{line: 206, col: 20, offset: 5643},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 206, col: 22, offset: 5604},
+							pos:        position{line: 206, col: 22, offset: 5645},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -2340,36 +2352,36 @@ var g = &grammar{
 		},
 		{
 			name: "SetNonEmpty",
-			pos:  position{line: 211, col: 1, offset: 5681},
+			pos:  position{line: 211, col: 1, offset: 5722},
 			expr: &actionExpr{
-				pos: position{line: 211, col: 16, offset: 5696},
+				pos: position{line: 211, col: 16, offset: 5737},
 				run: (*parser).callonSetNonEmpty1,
 				expr: &seqExpr{
-					pos: position{line: 211, col: 16, offset: 5696},
+					pos: position{line: 211, col: 16, offset: 5737},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 211, col: 16, offset: 5696},
+							pos:        position{line: 211, col: 16, offset: 5737},
 							val:        "{",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 211, col: 20, offset: 5700},
+							pos:  position{line: 211, col: 20, offset: 5741},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 211, col: 22, offset: 5702},
+							pos:   position{line: 211, col: 22, offset: 5743},
 							label: "list",
 							expr: &ruleRefExpr{
-								pos:  position{line: 211, col: 27, offset: 5707},
+								pos:  position{line: 211, col: 27, offset: 5748},
 								name: "ExprTermList",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 211, col: 40, offset: 5720},
+							pos:  position{line: 211, col: 40, offset: 5761},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 211, col: 42, offset: 5722},
+							pos:        position{line: 211, col: 42, offset: 5763},
 							val:        "}",
 							ignoreCase: false,
 						},
@@ -2379,28 +2391,37 @@ var g = &grammar{
 		},
 		{
 			name: "Ref",
-			pos:  position{line: 215, col: 1, offset: 5776},
+			pos:  position{line: 215, col: 1, offset: 5817},
 			expr: &actionExpr{
-				pos: position{line: 215, col: 8, offset: 5783},
+				pos: position{line: 215, col: 8, offset: 5824},
 				run: (*parser).callonRef1,
 				expr: &seqExpr{
-					pos: position{line: 215, col: 8, offset: 5783},
+					pos: position{line: 215, col: 8, offset: 5824},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 215, col: 8, offset: 5783},
+							pos:   position{line: 215, col: 8, offset: 5824},
 							label: "head",
-							expr: &ruleRefExpr{
-								pos:  position{line: 215, col: 13, offset: 5788},
-								name: "Var",
+							expr: &choiceExpr{
+								pos: position{line: 215, col: 14, offset: 5830},
+								alternatives: []interface{}{
+									&ruleRefExpr{
+										pos:  position{line: 215, col: 14, offset: 5830},
+										name: "Composite",
+									},
+									&ruleRefExpr{
+										pos:  position{line: 215, col: 26, offset: 5842},
+										name: "Var",
+									},
+								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 215, col: 17, offset: 5792},
+							pos:   position{line: 215, col: 31, offset: 5847},
 							label: "rest",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 215, col: 22, offset: 5797},
+								pos: position{line: 215, col: 36, offset: 5852},
 								expr: &ruleRefExpr{
-									pos:  position{line: 215, col: 22, offset: 5797},
+									pos:  position{line: 215, col: 36, offset: 5852},
 									name: "RefOperand",
 								},
 							},
@@ -2411,16 +2432,16 @@ var g = &grammar{
 		},
 		{
 			name: "RefOperand",
-			pos:  position{line: 219, col: 1, offset: 5865},
+			pos:  position{line: 219, col: 1, offset: 5920},
 			expr: &choiceExpr{
-				pos: position{line: 219, col: 15, offset: 5879},
+				pos: position{line: 219, col: 15, offset: 5934},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 219, col: 15, offset: 5879},
+						pos:  position{line: 219, col: 15, offset: 5934},
 						name: "RefOperandDot",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 219, col: 31, offset: 5895},
+						pos:  position{line: 219, col: 31, offset: 5950},
 						name: "RefOperandCanonical",
 					},
 				},
@@ -2428,23 +2449,23 @@ var g = &grammar{
 		},
 		{
 			name: "RefOperandDot",
-			pos:  position{line: 221, col: 1, offset: 5916},
+			pos:  position{line: 221, col: 1, offset: 5971},
 			expr: &actionExpr{
-				pos: position{line: 221, col: 18, offset: 5933},
+				pos: position{line: 221, col: 18, offset: 5988},
 				run: (*parser).callonRefOperandDot1,
 				expr: &seqExpr{
-					pos: position{line: 221, col: 18, offset: 5933},
+					pos: position{line: 221, col: 18, offset: 5988},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 221, col: 18, offset: 5933},
+							pos:        position{line: 221, col: 18, offset: 5988},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 221, col: 22, offset: 5937},
+							pos:   position{line: 221, col: 22, offset: 5992},
 							label: "val",
 							expr: &ruleRefExpr{
-								pos:  position{line: 221, col: 26, offset: 5941},
+								pos:  position{line: 221, col: 26, offset: 5996},
 								name: "Var",
 							},
 						},
@@ -2454,28 +2475,28 @@ var g = &grammar{
 		},
 		{
 			name: "RefOperandCanonical",
-			pos:  position{line: 225, col: 1, offset: 6004},
+			pos:  position{line: 225, col: 1, offset: 6059},
 			expr: &actionExpr{
-				pos: position{line: 225, col: 24, offset: 6027},
+				pos: position{line: 225, col: 24, offset: 6082},
 				run: (*parser).callonRefOperandCanonical1,
 				expr: &seqExpr{
-					pos: position{line: 225, col: 24, offset: 6027},
+					pos: position{line: 225, col: 24, offset: 6082},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 225, col: 24, offset: 6027},
+							pos:        position{line: 225, col: 24, offset: 6082},
 							val:        "[",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 225, col: 28, offset: 6031},
+							pos:   position{line: 225, col: 28, offset: 6086},
 							label: "val",
 							expr: &ruleRefExpr{
-								pos:  position{line: 225, col: 32, offset: 6035},
+								pos:  position{line: 225, col: 32, offset: 6090},
 								name: "ExprTerm",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 225, col: 41, offset: 6044},
+							pos:        position{line: 225, col: 41, offset: 6099},
 							val:        "]",
 							ignoreCase: false,
 						},
@@ -2485,15 +2506,15 @@ var g = &grammar{
 		},
 		{
 			name: "Var",
-			pos:  position{line: 229, col: 1, offset: 6073},
+			pos:  position{line: 229, col: 1, offset: 6128},
 			expr: &actionExpr{
-				pos: position{line: 229, col: 8, offset: 6080},
+				pos: position{line: 229, col: 8, offset: 6135},
 				run: (*parser).callonVar1,
 				expr: &labeledExpr{
-					pos:   position{line: 229, col: 8, offset: 6080},
+					pos:   position{line: 229, col: 8, offset: 6135},
 					label: "val",
 					expr: &ruleRefExpr{
-						pos:  position{line: 229, col: 12, offset: 6084},
+						pos:  position{line: 229, col: 12, offset: 6139},
 						name: "VarChecked",
 					},
 				},
@@ -2501,20 +2522,20 @@ var g = &grammar{
 		},
 		{
 			name: "VarChecked",
-			pos:  position{line: 233, col: 1, offset: 6139},
+			pos:  position{line: 233, col: 1, offset: 6194},
 			expr: &seqExpr{
-				pos: position{line: 233, col: 15, offset: 6153},
+				pos: position{line: 233, col: 15, offset: 6208},
 				exprs: []interface{}{
 					&labeledExpr{
-						pos:   position{line: 233, col: 15, offset: 6153},
+						pos:   position{line: 233, col: 15, offset: 6208},
 						label: "val",
 						expr: &ruleRefExpr{
-							pos:  position{line: 233, col: 19, offset: 6157},
+							pos:  position{line: 233, col: 19, offset: 6212},
 							name: "VarUnchecked",
 						},
 					},
 					&notCodeExpr{
-						pos: position{line: 233, col: 32, offset: 6170},
+						pos: position{line: 233, col: 32, offset: 6225},
 						run: (*parser).callonVarChecked4,
 					},
 				},
@@ -2522,21 +2543,21 @@ var g = &grammar{
 		},
 		{
 			name: "VarUnchecked",
-			pos:  position{line: 237, col: 1, offset: 6235},
+			pos:  position{line: 237, col: 1, offset: 6290},
 			expr: &actionExpr{
-				pos: position{line: 237, col: 17, offset: 6251},
+				pos: position{line: 237, col: 17, offset: 6306},
 				run: (*parser).callonVarUnchecked1,
 				expr: &seqExpr{
-					pos: position{line: 237, col: 17, offset: 6251},
+					pos: position{line: 237, col: 17, offset: 6306},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 237, col: 17, offset: 6251},
+							pos:  position{line: 237, col: 17, offset: 6306},
 							name: "VarStart",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 237, col: 26, offset: 6260},
+							pos: position{line: 237, col: 26, offset: 6315},
 							expr: &ruleRefExpr{
-								pos:  position{line: 237, col: 26, offset: 6260},
+								pos:  position{line: 237, col: 26, offset: 6315},
 								name: "VarChar",
 							},
 						},
@@ -2546,30 +2567,30 @@ var g = &grammar{
 		},
 		{
 			name: "Number",
-			pos:  position{line: 241, col: 1, offset: 6321},
+			pos:  position{line: 241, col: 1, offset: 6376},
 			expr: &actionExpr{
-				pos: position{line: 241, col: 11, offset: 6331},
+				pos: position{line: 241, col: 11, offset: 6386},
 				run: (*parser).callonNumber1,
 				expr: &seqExpr{
-					pos: position{line: 241, col: 11, offset: 6331},
+					pos: position{line: 241, col: 11, offset: 6386},
 					exprs: []interface{}{
 						&zeroOrOneExpr{
-							pos: position{line: 241, col: 11, offset: 6331},
+							pos: position{line: 241, col: 11, offset: 6386},
 							expr: &litMatcher{
-								pos:        position{line: 241, col: 11, offset: 6331},
+								pos:        position{line: 241, col: 11, offset: 6386},
 								val:        "-",
 								ignoreCase: false,
 							},
 						},
 						&choiceExpr{
-							pos: position{line: 241, col: 18, offset: 6338},
+							pos: position{line: 241, col: 18, offset: 6393},
 							alternatives: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 241, col: 18, offset: 6338},
+									pos:  position{line: 241, col: 18, offset: 6393},
 									name: "Float",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 241, col: 26, offset: 6346},
+									pos:  position{line: 241, col: 26, offset: 6401},
 									name: "Integer",
 								},
 							},
@@ -2580,16 +2601,16 @@ var g = &grammar{
 		},
 		{
 			name: "Float",
-			pos:  position{line: 245, col: 1, offset: 6411},
+			pos:  position{line: 245, col: 1, offset: 6466},
 			expr: &choiceExpr{
-				pos: position{line: 245, col: 10, offset: 6420},
+				pos: position{line: 245, col: 10, offset: 6475},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 245, col: 10, offset: 6420},
+						pos:  position{line: 245, col: 10, offset: 6475},
 						name: "ExponentFloat",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 245, col: 26, offset: 6436},
+						pos:  position{line: 245, col: 26, offset: 6491},
 						name: "PointFloat",
 					},
 				},
@@ -2597,25 +2618,25 @@ var g = &grammar{
 		},
 		{
 			name: "ExponentFloat",
-			pos:  position{line: 247, col: 1, offset: 6448},
+			pos:  position{line: 247, col: 1, offset: 6503},
 			expr: &seqExpr{
-				pos: position{line: 247, col: 18, offset: 6465},
+				pos: position{line: 247, col: 18, offset: 6520},
 				exprs: []interface{}{
 					&choiceExpr{
-						pos: position{line: 247, col: 20, offset: 6467},
+						pos: position{line: 247, col: 20, offset: 6522},
 						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 247, col: 20, offset: 6467},
+								pos:  position{line: 247, col: 20, offset: 6522},
 								name: "PointFloat",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 247, col: 33, offset: 6480},
+								pos:  position{line: 247, col: 33, offset: 6535},
 								name: "Integer",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 247, col: 43, offset: 6490},
+						pos:  position{line: 247, col: 43, offset: 6545},
 						name: "Exponent",
 					},
 				},
@@ -2623,19 +2644,19 @@ var g = &grammar{
 		},
 		{
 			name: "PointFloat",
-			pos:  position{line: 249, col: 1, offset: 6500},
+			pos:  position{line: 249, col: 1, offset: 6555},
 			expr: &seqExpr{
-				pos: position{line: 249, col: 15, offset: 6514},
+				pos: position{line: 249, col: 15, offset: 6569},
 				exprs: []interface{}{
 					&zeroOrOneExpr{
-						pos: position{line: 249, col: 15, offset: 6514},
+						pos: position{line: 249, col: 15, offset: 6569},
 						expr: &ruleRefExpr{
-							pos:  position{line: 249, col: 15, offset: 6514},
+							pos:  position{line: 249, col: 15, offset: 6569},
 							name: "Integer",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 249, col: 24, offset: 6523},
+						pos:  position{line: 249, col: 24, offset: 6578},
 						name: "Fraction",
 					},
 				},
@@ -2643,19 +2664,19 @@ var g = &grammar{
 		},
 		{
 			name: "Fraction",
-			pos:  position{line: 251, col: 1, offset: 6533},
+			pos:  position{line: 251, col: 1, offset: 6588},
 			expr: &seqExpr{
-				pos: position{line: 251, col: 13, offset: 6545},
+				pos: position{line: 251, col: 13, offset: 6600},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 251, col: 13, offset: 6545},
+						pos:        position{line: 251, col: 13, offset: 6600},
 						val:        ".",
 						ignoreCase: false,
 					},
 					&oneOrMoreExpr{
-						pos: position{line: 251, col: 17, offset: 6549},
+						pos: position{line: 251, col: 17, offset: 6604},
 						expr: &ruleRefExpr{
-							pos:  position{line: 251, col: 17, offset: 6549},
+							pos:  position{line: 251, col: 17, offset: 6604},
 							name: "DecimalDigit",
 						},
 					},
@@ -2664,19 +2685,19 @@ var g = &grammar{
 		},
 		{
 			name: "Exponent",
-			pos:  position{line: 253, col: 1, offset: 6564},
+			pos:  position{line: 253, col: 1, offset: 6619},
 			expr: &seqExpr{
-				pos: position{line: 253, col: 13, offset: 6576},
+				pos: position{line: 253, col: 13, offset: 6631},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 253, col: 13, offset: 6576},
+						pos:        position{line: 253, col: 13, offset: 6631},
 						val:        "e",
 						ignoreCase: true,
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 253, col: 18, offset: 6581},
+						pos: position{line: 253, col: 18, offset: 6636},
 						expr: &charClassMatcher{
-							pos:        position{line: 253, col: 18, offset: 6581},
+							pos:        position{line: 253, col: 18, offset: 6636},
 							val:        "[+-]",
 							chars:      []rune{'+', '-'},
 							ignoreCase: false,
@@ -2684,9 +2705,9 @@ var g = &grammar{
 						},
 					},
 					&oneOrMoreExpr{
-						pos: position{line: 253, col: 24, offset: 6587},
+						pos: position{line: 253, col: 24, offset: 6642},
 						expr: &ruleRefExpr{
-							pos:  position{line: 253, col: 24, offset: 6587},
+							pos:  position{line: 253, col: 24, offset: 6642},
 							name: "DecimalDigit",
 						},
 					},
@@ -2695,26 +2716,26 @@ var g = &grammar{
 		},
 		{
 			name: "Integer",
-			pos:  position{line: 255, col: 1, offset: 6602},
+			pos:  position{line: 255, col: 1, offset: 6657},
 			expr: &choiceExpr{
-				pos: position{line: 255, col: 12, offset: 6613},
+				pos: position{line: 255, col: 12, offset: 6668},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 255, col: 12, offset: 6613},
+						pos:        position{line: 255, col: 12, offset: 6668},
 						val:        "0",
 						ignoreCase: false,
 					},
 					&seqExpr{
-						pos: position{line: 255, col: 20, offset: 6621},
+						pos: position{line: 255, col: 20, offset: 6676},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 255, col: 20, offset: 6621},
+								pos:  position{line: 255, col: 20, offset: 6676},
 								name: "NonZeroDecimalDigit",
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 255, col: 40, offset: 6641},
+								pos: position{line: 255, col: 40, offset: 6696},
 								expr: &ruleRefExpr{
-									pos:  position{line: 255, col: 40, offset: 6641},
+									pos:  position{line: 255, col: 40, offset: 6696},
 									name: "DecimalDigit",
 								},
 							},
@@ -2725,16 +2746,16 @@ var g = &grammar{
 		},
 		{
 			name: "String",
-			pos:  position{line: 257, col: 1, offset: 6658},
+			pos:  position{line: 257, col: 1, offset: 6713},
 			expr: &choiceExpr{
-				pos: position{line: 257, col: 11, offset: 6668},
+				pos: position{line: 257, col: 11, offset: 6723},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 257, col: 11, offset: 6668},
+						pos:  position{line: 257, col: 11, offset: 6723},
 						name: "QuotedString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 257, col: 26, offset: 6683},
+						pos:  position{line: 257, col: 26, offset: 6738},
 						name: "RawString",
 					},
 				},
@@ -2742,30 +2763,30 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedString",
-			pos:  position{line: 259, col: 1, offset: 6694},
+			pos:  position{line: 259, col: 1, offset: 6749},
 			expr: &choiceExpr{
-				pos: position{line: 259, col: 17, offset: 6710},
+				pos: position{line: 259, col: 17, offset: 6765},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 259, col: 17, offset: 6710},
+						pos: position{line: 259, col: 17, offset: 6765},
 						run: (*parser).callonQuotedString2,
 						expr: &seqExpr{
-							pos: position{line: 259, col: 17, offset: 6710},
+							pos: position{line: 259, col: 17, offset: 6765},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 259, col: 17, offset: 6710},
+									pos:        position{line: 259, col: 17, offset: 6765},
 									val:        "\"",
 									ignoreCase: false,
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 259, col: 21, offset: 6714},
+									pos: position{line: 259, col: 21, offset: 6769},
 									expr: &ruleRefExpr{
-										pos:  position{line: 259, col: 21, offset: 6714},
+										pos:  position{line: 259, col: 21, offset: 6769},
 										name: "Char",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 259, col: 27, offset: 6720},
+									pos:        position{line: 259, col: 27, offset: 6775},
 									val:        "\"",
 									ignoreCase: false,
 								},
@@ -2773,27 +2794,27 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 261, col: 5, offset: 6780},
+						pos: position{line: 261, col: 5, offset: 6835},
 						run: (*parser).callonQuotedString8,
 						expr: &seqExpr{
-							pos: position{line: 261, col: 5, offset: 6780},
+							pos: position{line: 261, col: 5, offset: 6835},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 261, col: 5, offset: 6780},
+									pos:        position{line: 261, col: 5, offset: 6835},
 									val:        "\"",
 									ignoreCase: false,
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 261, col: 9, offset: 6784},
+									pos: position{line: 261, col: 9, offset: 6839},
 									expr: &ruleRefExpr{
-										pos:  position{line: 261, col: 9, offset: 6784},
+										pos:  position{line: 261, col: 9, offset: 6839},
 										name: "Char",
 									},
 								},
 								&notExpr{
-									pos: position{line: 261, col: 15, offset: 6790},
+									pos: position{line: 261, col: 15, offset: 6845},
 									expr: &litMatcher{
-										pos:        position{line: 261, col: 16, offset: 6791},
+										pos:        position{line: 261, col: 16, offset: 6846},
 										val:        "\"",
 										ignoreCase: false,
 									},
@@ -2806,22 +2827,22 @@ var g = &grammar{
 		},
 		{
 			name: "RawString",
-			pos:  position{line: 265, col: 1, offset: 6871},
+			pos:  position{line: 265, col: 1, offset: 6926},
 			expr: &actionExpr{
-				pos: position{line: 265, col: 14, offset: 6884},
+				pos: position{line: 265, col: 14, offset: 6939},
 				run: (*parser).callonRawString1,
 				expr: &seqExpr{
-					pos: position{line: 265, col: 14, offset: 6884},
+					pos: position{line: 265, col: 14, offset: 6939},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 265, col: 14, offset: 6884},
+							pos:        position{line: 265, col: 14, offset: 6939},
 							val:        "`",
 							ignoreCase: false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 265, col: 18, offset: 6888},
+							pos: position{line: 265, col: 18, offset: 6943},
 							expr: &charClassMatcher{
-								pos:        position{line: 265, col: 18, offset: 6888},
+								pos:        position{line: 265, col: 18, offset: 6943},
 								val:        "[^`]",
 								chars:      []rune{'`'},
 								ignoreCase: false,
@@ -2829,7 +2850,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 265, col: 24, offset: 6894},
+							pos:        position{line: 265, col: 24, offset: 6949},
 							val:        "`",
 							ignoreCase: false,
 						},
@@ -2839,26 +2860,26 @@ var g = &grammar{
 		},
 		{
 			name: "Bool",
-			pos:  position{line: 269, col: 1, offset: 6956},
+			pos:  position{line: 269, col: 1, offset: 7011},
 			expr: &actionExpr{
-				pos: position{line: 269, col: 9, offset: 6964},
+				pos: position{line: 269, col: 9, offset: 7019},
 				run: (*parser).callonBool1,
 				expr: &seqExpr{
-					pos: position{line: 269, col: 9, offset: 6964},
+					pos: position{line: 269, col: 9, offset: 7019},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 269, col: 9, offset: 6964},
+							pos:   position{line: 269, col: 9, offset: 7019},
 							label: "val",
 							expr: &choiceExpr{
-								pos: position{line: 269, col: 14, offset: 6969},
+								pos: position{line: 269, col: 14, offset: 7024},
 								alternatives: []interface{}{
 									&litMatcher{
-										pos:        position{line: 269, col: 14, offset: 6969},
+										pos:        position{line: 269, col: 14, offset: 7024},
 										val:        "true",
 										ignoreCase: false,
 									},
 									&litMatcher{
-										pos:        position{line: 269, col: 23, offset: 6978},
+										pos:        position{line: 269, col: 23, offset: 7033},
 										val:        "false",
 										ignoreCase: false,
 									},
@@ -2866,9 +2887,9 @@ var g = &grammar{
 							},
 						},
 						&notExpr{
-							pos: position{line: 269, col: 32, offset: 6987},
+							pos: position{line: 269, col: 32, offset: 7042},
 							expr: &ruleRefExpr{
-								pos:  position{line: 269, col: 33, offset: 6988},
+								pos:  position{line: 269, col: 33, offset: 7043},
 								name: "VarChar",
 							},
 						},
@@ -2878,22 +2899,22 @@ var g = &grammar{
 		},
 		{
 			name: "Null",
-			pos:  position{line: 273, col: 1, offset: 7049},
+			pos:  position{line: 273, col: 1, offset: 7104},
 			expr: &actionExpr{
-				pos: position{line: 273, col: 9, offset: 7057},
+				pos: position{line: 273, col: 9, offset: 7112},
 				run: (*parser).callonNull1,
 				expr: &seqExpr{
-					pos: position{line: 273, col: 9, offset: 7057},
+					pos: position{line: 273, col: 9, offset: 7112},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 273, col: 9, offset: 7057},
+							pos:        position{line: 273, col: 9, offset: 7112},
 							val:        "null",
 							ignoreCase: false,
 						},
 						&notExpr{
-							pos: position{line: 273, col: 16, offset: 7064},
+							pos: position{line: 273, col: 16, offset: 7119},
 							expr: &ruleRefExpr{
-								pos:  position{line: 273, col: 17, offset: 7065},
+								pos:  position{line: 273, col: 17, offset: 7120},
 								name: "VarChar",
 							},
 						},
@@ -2903,24 +2924,24 @@ var g = &grammar{
 		},
 		{
 			name: "VarStart",
-			pos:  position{line: 277, col: 1, offset: 7118},
+			pos:  position{line: 277, col: 1, offset: 7173},
 			expr: &ruleRefExpr{
-				pos:  position{line: 277, col: 13, offset: 7130},
+				pos:  position{line: 277, col: 13, offset: 7185},
 				name: "AsciiLetter",
 			},
 		},
 		{
 			name: "VarChar",
-			pos:  position{line: 279, col: 1, offset: 7143},
+			pos:  position{line: 279, col: 1, offset: 7198},
 			expr: &choiceExpr{
-				pos: position{line: 279, col: 12, offset: 7154},
+				pos: position{line: 279, col: 12, offset: 7209},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 279, col: 12, offset: 7154},
+						pos:  position{line: 279, col: 12, offset: 7209},
 						name: "AsciiLetter",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 279, col: 26, offset: 7168},
+						pos:  position{line: 279, col: 26, offset: 7223},
 						name: "DecimalDigit",
 					},
 				},
@@ -2928,9 +2949,9 @@ var g = &grammar{
 		},
 		{
 			name: "AsciiLetter",
-			pos:  position{line: 281, col: 1, offset: 7182},
+			pos:  position{line: 281, col: 1, offset: 7237},
 			expr: &charClassMatcher{
-				pos:        position{line: 281, col: 16, offset: 7197},
+				pos:        position{line: 281, col: 16, offset: 7252},
 				val:        "[A-Za-z_]",
 				chars:      []rune{'_'},
 				ranges:     []rune{'A', 'Z', 'a', 'z'},
@@ -2940,35 +2961,35 @@ var g = &grammar{
 		},
 		{
 			name: "Char",
-			pos:  position{line: 283, col: 1, offset: 7208},
+			pos:  position{line: 283, col: 1, offset: 7263},
 			expr: &choiceExpr{
-				pos: position{line: 283, col: 9, offset: 7216},
+				pos: position{line: 283, col: 9, offset: 7271},
 				alternatives: []interface{}{
 					&seqExpr{
-						pos: position{line: 283, col: 11, offset: 7218},
+						pos: position{line: 283, col: 11, offset: 7273},
 						exprs: []interface{}{
 							&notExpr{
-								pos: position{line: 283, col: 11, offset: 7218},
+								pos: position{line: 283, col: 11, offset: 7273},
 								expr: &ruleRefExpr{
-									pos:  position{line: 283, col: 12, offset: 7219},
+									pos:  position{line: 283, col: 12, offset: 7274},
 									name: "EscapedChar",
 								},
 							},
 							&anyMatcher{
-								line: 283, col: 24, offset: 7231,
+								line: 283, col: 24, offset: 7286,
 							},
 						},
 					},
 					&seqExpr{
-						pos: position{line: 283, col: 32, offset: 7239},
+						pos: position{line: 283, col: 32, offset: 7294},
 						exprs: []interface{}{
 							&litMatcher{
-								pos:        position{line: 283, col: 32, offset: 7239},
+								pos:        position{line: 283, col: 32, offset: 7294},
 								val:        "\\",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 283, col: 37, offset: 7244},
+								pos:  position{line: 283, col: 37, offset: 7299},
 								name: "EscapeSequence",
 							},
 						},
@@ -2978,9 +2999,9 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedChar",
-			pos:  position{line: 285, col: 1, offset: 7262},
+			pos:  position{line: 285, col: 1, offset: 7317},
 			expr: &charClassMatcher{
-				pos:        position{line: 285, col: 16, offset: 7277},
+				pos:        position{line: 285, col: 16, offset: 7332},
 				val:        "[\\x00-\\x1f\"\\\\]",
 				chars:      []rune{'"', '\\'},
 				ranges:     []rune{'\x00', '\x1f'},
@@ -2990,16 +3011,16 @@ var g = &grammar{
 		},
 		{
 			name: "EscapeSequence",
-			pos:  position{line: 287, col: 1, offset: 7293},
+			pos:  position{line: 287, col: 1, offset: 7348},
 			expr: &choiceExpr{
-				pos: position{line: 287, col: 19, offset: 7311},
+				pos: position{line: 287, col: 19, offset: 7366},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 287, col: 19, offset: 7311},
+						pos:  position{line: 287, col: 19, offset: 7366},
 						name: "SingleCharEscape",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 287, col: 38, offset: 7330},
+						pos:  position{line: 287, col: 38, offset: 7385},
 						name: "UnicodeEscape",
 					},
 				},
@@ -3007,9 +3028,9 @@ var g = &grammar{
 		},
 		{
 			name: "SingleCharEscape",
-			pos:  position{line: 289, col: 1, offset: 7345},
+			pos:  position{line: 289, col: 1, offset: 7400},
 			expr: &charClassMatcher{
-				pos:        position{line: 289, col: 21, offset: 7365},
+				pos:        position{line: 289, col: 21, offset: 7420},
 				val:        "[ \" \\\\ / b f n r t ]",
 				chars:      []rune{' ', '"', ' ', '\\', ' ', '/', ' ', 'b', ' ', 'f', ' ', 'n', ' ', 'r', ' ', 't', ' '},
 				ignoreCase: false,
@@ -3018,29 +3039,29 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeEscape",
-			pos:  position{line: 291, col: 1, offset: 7387},
+			pos:  position{line: 291, col: 1, offset: 7442},
 			expr: &seqExpr{
-				pos: position{line: 291, col: 18, offset: 7404},
+				pos: position{line: 291, col: 18, offset: 7459},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 291, col: 18, offset: 7404},
+						pos:        position{line: 291, col: 18, offset: 7459},
 						val:        "u",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 291, col: 22, offset: 7408},
+						pos:  position{line: 291, col: 22, offset: 7463},
 						name: "HexDigit",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 291, col: 31, offset: 7417},
+						pos:  position{line: 291, col: 31, offset: 7472},
 						name: "HexDigit",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 291, col: 40, offset: 7426},
+						pos:  position{line: 291, col: 40, offset: 7481},
 						name: "HexDigit",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 291, col: 49, offset: 7435},
+						pos:  position{line: 291, col: 49, offset: 7490},
 						name: "HexDigit",
 					},
 				},
@@ -3048,9 +3069,9 @@ var g = &grammar{
 		},
 		{
 			name: "DecimalDigit",
-			pos:  position{line: 293, col: 1, offset: 7445},
+			pos:  position{line: 293, col: 1, offset: 7500},
 			expr: &charClassMatcher{
-				pos:        position{line: 293, col: 17, offset: 7461},
+				pos:        position{line: 293, col: 17, offset: 7516},
 				val:        "[0-9]",
 				ranges:     []rune{'0', '9'},
 				ignoreCase: false,
@@ -3059,9 +3080,9 @@ var g = &grammar{
 		},
 		{
 			name: "NonZeroDecimalDigit",
-			pos:  position{line: 295, col: 1, offset: 7468},
+			pos:  position{line: 295, col: 1, offset: 7523},
 			expr: &charClassMatcher{
-				pos:        position{line: 295, col: 24, offset: 7491},
+				pos:        position{line: 295, col: 24, offset: 7546},
 				val:        "[1-9]",
 				ranges:     []rune{'1', '9'},
 				ignoreCase: false,
@@ -3070,9 +3091,9 @@ var g = &grammar{
 		},
 		{
 			name: "HexDigit",
-			pos:  position{line: 297, col: 1, offset: 7498},
+			pos:  position{line: 297, col: 1, offset: 7553},
 			expr: &charClassMatcher{
-				pos:        position{line: 297, col: 13, offset: 7510},
+				pos:        position{line: 297, col: 13, offset: 7565},
 				val:        "[0-9a-fA-F]",
 				ranges:     []rune{'0', '9', 'a', 'f', 'A', 'F'},
 				ignoreCase: false,
@@ -3082,11 +3103,11 @@ var g = &grammar{
 		{
 			name:        "ws",
 			displayName: "\"whitespace\"",
-			pos:         position{line: 299, col: 1, offset: 7523},
+			pos:         position{line: 299, col: 1, offset: 7578},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 299, col: 20, offset: 7542},
+				pos: position{line: 299, col: 20, offset: 7597},
 				expr: &charClassMatcher{
-					pos:        position{line: 299, col: 20, offset: 7542},
+					pos:        position{line: 299, col: 20, offset: 7597},
 					val:        "[ \\t\\r\\n]",
 					chars:      []rune{' ', '\t', '\r', '\n'},
 					ignoreCase: false,
@@ -3097,21 +3118,21 @@ var g = &grammar{
 		{
 			name:        "_",
 			displayName: "\"whitespace\"",
-			pos:         position{line: 301, col: 1, offset: 7554},
+			pos:         position{line: 301, col: 1, offset: 7609},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 301, col: 19, offset: 7572},
+				pos: position{line: 301, col: 19, offset: 7627},
 				expr: &choiceExpr{
-					pos: position{line: 301, col: 21, offset: 7574},
+					pos: position{line: 301, col: 21, offset: 7629},
 					alternatives: []interface{}{
 						&charClassMatcher{
-							pos:        position{line: 301, col: 21, offset: 7574},
+							pos:        position{line: 301, col: 21, offset: 7629},
 							val:        "[ \\t\\r\\n]",
 							chars:      []rune{' ', '\t', '\r', '\n'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 301, col: 33, offset: 7586},
+							pos:  position{line: 301, col: 33, offset: 7641},
 							name: "Comment",
 						},
 					},
@@ -3120,17 +3141,17 @@ var g = &grammar{
 		},
 		{
 			name: "Comment",
-			pos:  position{line: 303, col: 1, offset: 7598},
+			pos:  position{line: 303, col: 1, offset: 7653},
 			expr: &actionExpr{
-				pos: position{line: 303, col: 12, offset: 7609},
+				pos: position{line: 303, col: 12, offset: 7664},
 				run: (*parser).callonComment1,
 				expr: &seqExpr{
-					pos: position{line: 303, col: 12, offset: 7609},
+					pos: position{line: 303, col: 12, offset: 7664},
 					exprs: []interface{}{
 						&zeroOrMoreExpr{
-							pos: position{line: 303, col: 12, offset: 7609},
+							pos: position{line: 303, col: 12, offset: 7664},
 							expr: &charClassMatcher{
-								pos:        position{line: 303, col: 12, offset: 7609},
+								pos:        position{line: 303, col: 12, offset: 7664},
 								val:        "[ \\t]",
 								chars:      []rune{' ', '\t'},
 								ignoreCase: false,
@@ -3138,17 +3159,17 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 303, col: 19, offset: 7616},
+							pos:        position{line: 303, col: 19, offset: 7671},
 							val:        "#",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 303, col: 23, offset: 7620},
+							pos:   position{line: 303, col: 23, offset: 7675},
 							label: "text",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 303, col: 28, offset: 7625},
+								pos: position{line: 303, col: 28, offset: 7680},
 								expr: &charClassMatcher{
-									pos:        position{line: 303, col: 28, offset: 7625},
+									pos:        position{line: 303, col: 28, offset: 7680},
 									val:        "[^\\r\\n]",
 									chars:      []rune{'\r', '\n'},
 									ignoreCase: false,
@@ -3162,11 +3183,11 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 307, col: 1, offset: 7672},
+			pos:  position{line: 307, col: 1, offset: 7727},
 			expr: &notExpr{
-				pos: position{line: 307, col: 8, offset: 7679},
+				pos: position{line: 307, col: 8, offset: 7734},
 				expr: &anyMatcher{
-					line: 307, col: 9, offset: 7680,
+					line: 307, col: 9, offset: 7735,
 				},
 			},
 		},
@@ -3556,14 +3577,14 @@ func (p *parser) callonCall1() (interface{}, error) {
 	return p.cur.onCall1(stack["operator"], stack["args"])
 }
 
-func (c *current) onTerm1(val interface{}) (interface{}, error) {
-	return val, nil
+func (c *current) onTerm1(val, refs interface{}) (interface{}, error) {
+	return makeRef(currentLocation(c), val, refs)
 }
 
 func (p *parser) callonTerm1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onTerm1(stack["val"])
+	return p.cur.onTerm1(stack["val"], stack["refs"])
 }
 
 func (c *current) onTermPair1(key, value interface{}) (interface{}, error) {

--- a/ast/parser_internal.go
+++ b/ast/parser_internal.go
@@ -213,6 +213,10 @@ func makeRuleHead(loc *Location, name, args, key, value interface{}) (interface{
 	head.Location = loc
 	head.Name = name.(*Term).Value.(Var)
 
+	if args != nil && key != nil {
+		return nil, fmt.Errorf("partial rules cannot take arguments")
+	}
+
 	if args != nil {
 		argSlice := args.([]interface{})
 		head.Args = argSlice[3].(Args)

--- a/ast/parser_internal.go
+++ b/ast/parser_internal.go
@@ -213,10 +213,6 @@ func makeRuleHead(loc *Location, name, args, key, value interface{}) (interface{
 	head.Location = loc
 	head.Name = name.(*Term).Value.(Var)
 
-	if args != nil && key != nil {
-		return nil, fmt.Errorf("partial rules cannot take arguments")
-	}
-
 	if args != nil {
 		argSlice := args.([]interface{})
 		head.Args = argSlice[3].(Args)
@@ -522,6 +518,10 @@ func makeRef(loc *Location, head, rest interface{}) (interface{}, error) {
 
 	headTerm := head.(*Term)
 	ifaceSlice := rest.([]interface{})
+
+	if len(ifaceSlice) == 0 {
+		return headTerm, nil
+	}
 
 	ref := make(Ref, len(ifaceSlice)+1)
 	ref[0] = headTerm

--- a/ast/parser_test.go
+++ b/ast/parser_test.go
@@ -1654,7 +1654,6 @@ func TestNamespacedBuiltins(t *testing.T) {
 		{`foo.bar.baz(1, 2)`, MustParseTerm("foo.bar.baz"), false},
 		{`foo.(1,2)`, nil, true},
 		{`foo.#.bar(1,2)`, nil, true},
-		{`foo(1,2,3).bar`, nil, true},
 	}
 
 	for _, tc := range tests {

--- a/ast/rego.peg
+++ b/ast/rego.peg
@@ -167,8 +167,8 @@ Call <- operator:(Ref / Var) "(" _ args:ExprTermList _ ")" {
     return makeCall(currentLocation(c), operator, args)
 }
 
-Term <- val:( Comprehension / Composite / Scalar / Call / Ref / Var ) {
-    return val, nil
+Term <- val:( Comprehension / Composite / Scalar / Call / Var ) refs:RefOperand* {
+    return makeRef(currentLocation(c), val, refs)
 }
 
 TermPair <- key:Term _ ":" _ value:Term {
@@ -212,7 +212,7 @@ SetNonEmpty <- '{' _ list:ExprTermList _ '}' {
     return makeSet(currentLocation(c), list)
 }
 
-Ref <- head:Var rest:RefOperand+ {
+Ref <- head:(Composite / Var) rest:RefOperand+ {
     return makeRef(currentLocation(c), head, rest)
 }
 

--- a/ast/rego.peg
+++ b/ast/rego.peg
@@ -24,12 +24,16 @@ DefaultRules <- "default" ws name:Var _ operator:( ":=" / "=" ) _ value:Term {
     return makeDefaultRule(currentLocation(c), name, operator, value)
 }
 
-NormalRules <- head:RuleHead _ rest:(NonEmptyBraceEnclosedBody ( _ RuleExt)* ) {
+NormalRules <- head:(PartialRuleHead / RuleHead) _ rest:(NonEmptyBraceEnclosedBody ( _ RuleExt)* ) {
     return makeRule(currentLocation(c), head, rest)
 }
 
-RuleHead <- name:Var args:( _ "(" _ Args _ ")" _ )? key:( _ "[" _ ExprTerm _ "]" _ )? value:( _ ( ":=" / "=" ) _ ExprTerm )? {
-    return makeRuleHead(currentLocation(c), name, args, key, value)
+PartialRuleHead <- name:Var args:( _ "(" _ Args _ ")" _ ) value:( _ ( ":=" / "=" ) _ ExprTerm )? {
+    return makeRuleHead(currentLocation(c), name, args, nil, value)
+}
+
+RuleHead <- name:Var key:( _ "[" _ ExprTerm _ "]" _ )? value:( _ ( ":=" / "=" ) _ ExprTerm )? {
+    return makeRuleHead(currentLocation(c), name, nil, key, value)
 }
 
 Args <- list:ExprTermList {

--- a/ast/term.go
+++ b/ast/term.go
@@ -1054,13 +1054,8 @@ func (ref Ref) String() string {
 	if len(ref) == 0 {
 		return ""
 	}
-	var buf []string
-	path := ref
-	switch v := ref[0].Value.(type) {
-	case Var:
-		buf = append(buf, string(v))
-		path = path[1:]
-	}
+	buf := []string{ref[0].Value.String()}
+	path := ref[1:]
 	for _, p := range path {
 		switch p := p.Value.(type) {
 		case String:

--- a/ast/term.go
+++ b/ast/term.go
@@ -939,6 +939,10 @@ func (ref Ref) Concat(terms []*Term) Ref {
 
 // Dynamic returns the offset of the first non-constant operand of ref.
 func (ref Ref) Dynamic() int {
+	switch ref[0].Value.(type) {
+	case Call:
+		return 0
+	}
 	for i := 1; i < len(ref); i++ {
 		if !IsConstant(ref[i].Value) {
 			return i

--- a/ast/term_test.go
+++ b/ast/term_test.go
@@ -413,6 +413,10 @@ func TestRefDynamic(t *testing.T) {
 	if a[:a.Dynamic()].Dynamic() != -1 {
 		t.Fatalf("Expected dynamic offset to be -1 for foo.bar")
 	}
+
+	if MustParseRef("f(x)[0]").Dynamic() != 0 {
+		t.Fatalf("Expected dynamic offset to be f(x) for foo.bar[baz.qux].corge")
+	}
 }
 
 func TestRefExtend(t *testing.T) {

--- a/ast/term_test.go
+++ b/ast/term_test.go
@@ -347,6 +347,8 @@ func TestTermString(t *testing.T) {
 	assertToString(t, RefTerm(VarTerm("foo"), StringTerm("bar"), VarTerm("i"), IntNumberTerm(0), StringTerm("baz")).Value, "foo.bar[i][0].baz")
 	assertToString(t, RefTerm(VarTerm("foo"), BooleanTerm(false), NullTerm(), StringTerm("bar")).Value, "foo[false][null].bar")
 	assertToString(t, RefTerm(VarTerm("p"), StringTerm("not")).Value, `p["not"]`)
+	assertToString(t, RefTerm(CallTerm(VarTerm("f"), VarTerm("x")), IntNumberTerm(0)).Value, "f(x)[0]")
+	assertToString(t, RefTerm(ArrayTerm(StringTerm("a"), StringTerm("b")), IntNumberTerm(0)).Value, "[\"a\", \"b\"][0]")
 	assertToString(t, ArrayTerm().Value, "[]")
 	assertToString(t, ObjectTerm().Value, "{}")
 	assertToString(t, SetTerm().Value, "set()")

--- a/docs/content/policy-language.md
+++ b/docs/content/policy-language.md
@@ -419,13 +419,16 @@ Both forms are valid, however, the dot-access style is typically more readable. 
   3. Variable keys which are described later.
   4. Composite keys which are described later.
 
-References are always prefixed with a variable that identifies the root
-document. In the example above this is `sites`. The root document may be:
+The prefix of a reference identifies the root document for that reference. In
+the example above this is `sites`. The root document may be:
 
   * a local variable inside a rule.
   * a rule inside the same package.
   * a document stored in OPA.
   * a documented temporarily provided to OPA as part of a transaction.
+  * an array, object or set, e.g. `[1, 2, 3][0]`.
+  * a function call, e.g. `split("a.b.c", ".")[1]`.
+  * a [comprehension](#comprehensions).
 
 ### Variable Keys
 

--- a/docs/content/policy-reference.md
+++ b/docs/content/policy-reference.md
@@ -526,8 +526,8 @@ query           = literal { ";" | [\r\n] literal }
 literal         = ( some-decl | expr | "not" expr ) { with-modifier }
 with-modifier   = "with" term "as" term
 some-decl       = "some" var { "," var }
-expr            = term | expr-built-in | expr-infix
-expr-built-in   = var [ "." var ] "(" [ term { , term } ] ")"
+expr            = term | expr-call | expr-infix
+expr-call       = var [ "." var ] "(" [ term { , term } ] ")"
 expr-infix      = [ term "=" ] term infix-operator term
 term            = ref | var | scalar | array | object | set | array-compr | object-compr | set-compr
 array-compr     = "[" term "|" rule-body "]"
@@ -537,7 +537,7 @@ infix-operator  = bool-operator | arith-operator | bin-operator
 bool-operator   = "==" | "!=" | "<" | ">" | ">=" | "<="
 arith-operator  = "+" | "-" | "*" | "/"
 bin-operator    = "&" | "|"
-ref             = var { ref-arg }
+ref             = ( var | array | object | set | array-compr | object-compr | set-compr | expr-call ) { ref-arg }
 ref-arg         = ref-arg-dot | ref-arg-brack
 ref-arg-brack   = "[" ( scalar | var | array | object | set | "_" ) "]"
 ref-arg-dot     = "." var

--- a/topdown/topdown_test.go
+++ b/topdown/topdown_test.go
@@ -918,6 +918,24 @@ func TestTopDownCompositeReferences(t *testing.T) {
 	}
 }
 
+func TestTopDownIndirectReferences(t *testing.T) {
+	tests := []struct {
+		note     string
+		rules    []string
+		expected interface{}
+	}{
+		{"array", []string{`p[x] {[1, 2, 3][x]}`}, "[0, 1, 2]"},
+		{"call", []string{`p {split("foo.bar", ".")[0] == "foo"}`}, "true"},
+		{"multiple call", []string{`p[x] {split(split("foo.bar:qux", ".")[_], ":")[i] = x}`}, `["foo", "bar", "qux"]`},
+	}
+
+	data := loadSmallTestData()
+
+	for _, tc := range tests {
+		runTopDownTestCase(t, data, tc.note, tc.rules, tc.expected)
+	}
+}
+
 func TestTopDownDisjunction(t *testing.T) {
 
 	tests := []struct {


### PR DESCRIPTION
This allows the reference operator to work in more places, namely:

 -  After partial rules, e.g.:

        split("foo.bar", ".")[1]

 -  After array/set/object terms, e.g.:

        [1, 2, 3][i]
        {"foo": 1}.foo

 -  After array/set/object comprehensions, e.g.:

        concat(", ", ["Hello", name]) | {"Tom", "Jerry"}[name]][1]

This change was originally requested in #1868.

Signed-off-by: Jasper Van der Jeugt <jasper@fugue.co>