### PR TITLE
Add `object` builtins

### DIFF
--- a/ast/builtins.go
+++ b/ast/builtins.go
@@ -125,6 +125,9 @@ var DefaultBuiltins = [...]*Builtin{
 	YAMLMarshal,
 	YAMLUnmarshal,
 
+	// JSON Object Manipulation
+	JSONFilter,
+
 	// Tokens
 	JWTDecode,
 	JWTVerifyRS256,
@@ -917,6 +920,24 @@ var JSONUnmarshal = &Builtin{
 	Name: "json.unmarshal",
 	Decl: types.NewFunction(
 		types.Args(types.S),
+		types.A,
+	),
+}
+
+// JSONFilter filters the JSON object
+var JSONFilter = &Builtin{
+	Name: "json.filter",
+	Decl: types.NewFunction(
+		types.Args(
+			types.NewObject(
+				nil,
+				types.NewDynamicProperty(types.A, types.A),
+			),
+			types.NewAny(
+				types.NewArray(nil, types.S),
+				types.NewSet(types.S),
+			),
+		),
 		types.A,
 	),
 }

--- a/ast/builtins.go
+++ b/ast/builtins.go
@@ -125,6 +125,11 @@ var DefaultBuiltins = [...]*Builtin{
 	YAMLMarshal,
 	YAMLUnmarshal,
 
+	// Object Manipulation
+	ObjectUnion,
+	ObjectRemove,
+	ObjectFilter,
+
 	// JSON Object Manipulation
 	JSONFilter,
 
@@ -936,6 +941,60 @@ var JSONFilter = &Builtin{
 			types.NewAny(
 				types.NewArray(nil, types.S),
 				types.NewSet(types.S),
+			),
+		),
+		types.A,
+	),
+}
+
+// ObjectUnion creates a new object that is the asymmetric union of two objects
+var ObjectUnion = &Builtin{
+	Name: "object.union",
+	Decl: types.NewFunction(
+		types.Args(
+			types.NewObject(
+				nil,
+				types.NewDynamicProperty(types.A, types.A),
+			),
+			types.NewObject(
+				nil,
+				types.NewDynamicProperty(types.A, types.A),
+			),
+		),
+		types.A,
+	),
+}
+
+// ObjectRemove Removes specified keys from an object
+var ObjectRemove = &Builtin{
+	Name: "object.remove",
+	Decl: types.NewFunction(
+		types.Args(
+			types.NewObject(
+				nil,
+				types.NewDynamicProperty(types.A, types.A),
+			),
+			types.NewAny(
+				types.NewArray(nil, types.A),
+				types.NewSet(types.A),
+			),
+		),
+		types.A,
+	),
+}
+
+// ObjectFilter filters the object by keeping only specified keys
+var ObjectFilter = &Builtin{
+	Name: "object.filter",
+	Decl: types.NewFunction(
+		types.Args(
+			types.NewObject(
+				nil,
+				types.NewDynamicProperty(types.A, types.A),
+			),
+			types.NewAny(
+				types.NewArray(nil, types.A),
+				types.NewSet(types.A),
 			),
 		),
 		types.A,

--- a/docs/content/policy-reference.md
+++ b/docs/content/policy-reference.md
@@ -66,6 +66,13 @@ complex types.
 | <span class="opa-keep-it-together">``output := intersection(set[set])``</span> | ``output`` is the intersection of the sets in the input set  |
 | <span class="opa-keep-it-together">``output := union(set[set])``</span> | ``output`` is the union of the sets in the input set  |
 
+### Objects
+| Built-in | Description |
+| -------- | ----------- |
+| <span class="opa-keep-it-together">``filtered := json.filter(object, paths)``</span> | ``filtered`` is the remaining data from ``object`` with only keys specified in ``paths`` which is an array or set of strings. For example: ``json.filter({"a": {"b": "x", "c": "y"},}, ["a/b"]`` will result in ``{"a": {"b": "x"}}``). |
+
+The ``json`` object paths may reference into array values by using index numbers. For example with the object ``{"a": ["x", "y", "z"]}`` the path `a[1]` references `y`
+
 ### Strings
 
 | Built-in | Description |

--- a/docs/content/policy-reference.md
+++ b/docs/content/policy-reference.md
@@ -69,9 +69,12 @@ complex types.
 ### Objects
 | Built-in | Description |
 | -------- | ----------- |
-| <span class="opa-keep-it-together">``filtered := json.filter(object, paths)``</span> | ``filtered`` is the remaining data from ``object`` with only keys specified in ``paths`` which is an array or set of strings. For example: ``json.filter({"a": {"b": "x", "c": "y"},}, ["a/b"]`` will result in ``{"a": {"b": "x"}}``). |
+| <span class="opa-keep-it-together">`output := object.remove(object, keys)`</span> | `output` is a new object which is the result of removing the specified `keys` from `object`. `keys` must be either an array or set of keys. |
+| <span class="opa-keep-it-together">`output := object.union(objectA, objectB)`</span> | `output` is a new object which is the result of an asymmetric recursive union of two objects where conflicts are resolved by choosing the key from the left-hand object. For example: `object.union({"a": 1, "b": 2}, {"a": 7, "c": 3})` will result in `{"a": 1, "b": 2, "c": 3}`  |
+| <span class="opa-keep-it-together">`filtered := object.filter(object, keys)`</span> | `filtered` is the remaining data from `object` with only keys specified in `keys` which is an array or set of keys. For example: `object.filter({"a": {"b": "x", "c": "y"}, "d": "z"}, ["a"]` will result in `{"a": {"b": "x", "c": "y"}}`). |
+| <span class="opa-keep-it-together">`filtered := json.filter(object, paths)`</span> | `filtered` is the remaining data from `object` with only keys specified in `paths` which is an array or set of JSON string paths. For example: `json.filter({"a": {"b": "x", "c": "y"}}, ["a/b"]` will result in `{"a": {"b": "x"}}`). |
 
-The ``json`` object paths may reference into array values by using index numbers. For example with the object ``{"a": ["x", "y", "z"]}`` the path `a[1]` references `y`
+The `json` string `paths` may reference into array values by using index numbers. For example with the object `{"a": ["x", "y", "z"]}` the path `a[1]` references `y`
 
 ### Strings
 

--- a/topdown/json.go
+++ b/topdown/json.go
@@ -1,0 +1,94 @@
+// Copyright 2019 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package topdown
+
+import (
+	"strings"
+
+	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/topdown/builtins"
+)
+
+func builtinJSONFilter(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term) error) error {
+
+	// Ensure we have the right parameters, expect an object and a string or array/set of strings
+	obj, err := builtins.ObjectOperand(operands[0].Value, 1)
+	if err != nil {
+		return err
+	}
+
+	// Build a list of filter strings
+	var filters []ast.String
+
+	switch v := operands[1].Value.(type) {
+	case ast.Array:
+		for _, f := range v {
+			filterString, ok := f.Value.(ast.String)
+			if !ok {
+				return builtins.NewOperandErr(2, "Expected a set or array containing only strings")
+			}
+			filters = append(filters, filterString)
+		}
+	case ast.Set:
+		err := v.Iter(func(f *ast.Term) error {
+			filterString, ok := f.Value.(ast.String)
+			if !ok {
+				return builtins.NewOperandErr(2, "Expected a set or array containing only strings")
+			}
+			filters = append(filters, filterString)
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+	default:
+		return builtins.NewOperandTypeErr(2, v, "set", "array")
+	}
+
+	// Actually do the filtering
+	filterObj := jsonPathsToObject(filters)
+	r, err := obj.Filter(filterObj)
+	if err != nil {
+		return err
+	}
+
+	return iter(ast.NewTerm(r))
+}
+
+func jsonPathsToObject(paths []ast.String) ast.Object {
+	result := ast.NewObject()
+	for _, filter := range paths {
+		s := strings.Split(strings.Trim(string(filter), "/"), "/")
+		o := result
+
+		for len(s) > 0 {
+			key := ast.StringTerm(s[0])
+			s = s[1:]
+			hasKey := o.Get(key) != nil
+
+			if !hasKey && len(s) > 0 {
+				next := ast.NewObject()
+				o.Insert(key, ast.NewTerm(next))
+				o = next
+			} else if !hasKey && len(s) == 0 {
+				o.Insert(key, ast.NullTerm())
+			} else if hasKey {
+				t := o.Get(key)
+				if t.Value.Compare(ast.Null{}) == 0 {
+					break // done with path, another shorter path has already been here
+				} else if len(s) == 0 {
+					o.Insert(key, ast.NullTerm())
+				} else {
+					o = t.Value.(ast.Object)
+				}
+			}
+		}
+	}
+	return result
+}
+
+func init() {
+	RegisterBuiltinFunc(ast.JSONFilter.Name, builtinJSONFilter)
+}

--- a/topdown/json_test.go
+++ b/topdown/json_test.go
@@ -1,0 +1,146 @@
+// Copyright 2019 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package topdown
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/open-policy-agent/opa/ast"
+)
+
+func TestBuiltinJSONFilter(t *testing.T) {
+	cases := []struct {
+		note     string
+		object   string
+		filters  string
+		expected interface{}
+	}{
+		{
+			note:     "base",
+			object:   `{"a": {"b": {"c": 7, "d": 8}}, "e": 9}`,
+			filters:  `{"a/b/c"}`,
+			expected: `{"a": {"b": {"c": 7}}}`,
+		},
+		{
+			note:     "multiple roots",
+			object:   `{"a": {"b": {"c": 7, "d": 8}}, "e": 9}`,
+			filters:  `{"a/b/c", "e"}`,
+			expected: `{"a": {"b": {"c": 7}}, "e": 9}`,
+		},
+		{
+			note:     "multiple roots array",
+			object:   `{"a": {"b": {"c": 7, "d": 8}}, "e": 9}`,
+			filters:  `["a/b/c", "e"]`,
+			expected: `{"a": {"b": {"c": 7}}, "e": 9}`,
+		},
+		{
+			note:     "shared roots",
+			object:   `{"a": {"b": {"c": 7, "d": 8}, "e": 9}}`,
+			filters:  `{"a/b/c", "a/e"}`,
+			expected: `{"a": {"b": {"c": 7}, "e": 9}}`,
+		},
+		{
+			note:     "conflict",
+			object:   `{"a": {"b": 7}}`,
+			filters:  `{"a", "a/b"}`,
+			expected: `{"a": {"b": 7}}`,
+		},
+		{
+			note:     "empty list",
+			object:   `{"a": 7}`,
+			filters:  `set()`,
+			expected: `{}`,
+		},
+		{
+			note:     "empty object",
+			object:   `{}`,
+			filters:  `{"a/b"}`,
+			expected: `{}`,
+		},
+		{
+			note:     "arrays",
+			object:   `{"a": [{"b": 7, "c": 8}, {"d": 9}]}`,
+			filters:  `{"a/0/b", "a/1"}`,
+			expected: `{"a": [{"b": 7}, {"d": 9}]}`,
+		},
+		{
+			note:     "object with number keys",
+			object:   `{"a": [{"1":["b", "c", "d"]}, {"x": "y"}]}`,
+			filters:  `{"a/0/1/2"}`,
+			expected: `{"a": [{"1": ["d"]}]}`,
+		},
+	}
+
+	for _, tc := range cases {
+		rules := []string{
+			fmt.Sprintf("p = x { x := json.filter(%s, %s) }", tc.object, tc.filters),
+		}
+		runTopDownTestCase(t, map[string]interface{}{}, tc.note, rules, tc.expected)
+	}
+}
+
+func TestFiltersToObject(t *testing.T) {
+	cases := []struct {
+		note     string
+		filters  []ast.String
+		expected *ast.Term
+	}{
+		{
+			note:     "base",
+			filters:  []ast.String{"a/b/c"},
+			expected: ast.MustParseTerm(`{"a": {"b": {"c": null}}}`),
+		},
+		{
+			note:     "root prefixed",
+			filters:  []ast.String{"/a/b/c"},
+			expected: ast.MustParseTerm(`{"a": {"b": {"c": null}}}`),
+		},
+		{
+			note:     "trailing slash",
+			filters:  []ast.String{"a/b/c/"},
+			expected: ast.MustParseTerm(`{"a": {"b": {"c": null}}}`),
+		},
+		{
+			note:     "different roots",
+			filters:  []ast.String{"a/b/c", "d/e/f"},
+			expected: ast.MustParseTerm(`{"a": {"b": {"c": null}}, "d": {"e": {"f": null}}}`),
+		},
+		{
+			note:     "shared root",
+			filters:  []ast.String{"a/b/c", "a/b/d"},
+			expected: ast.MustParseTerm(`{"a": {"b": {"c": null, "d": null}}}`),
+		},
+		{
+			note:     "multiple shares at different points",
+			filters:  []ast.String{"a/b/c", "a/b/d", "a/e/f"},
+			expected: ast.MustParseTerm(`{"a": {"b": {"c": null, "d": null}, "e": {"f": null}}}`),
+		},
+		{
+			note:     "conflict with one ordering",
+			filters:  []ast.String{"a", "a/b"},
+			expected: ast.MustParseTerm(`{"a": null}`),
+		},
+		{
+			note:     "conflict with reverse ordering",
+			filters:  []ast.String{"a/b", "a"},
+			expected: ast.MustParseTerm(`{"a": null}`),
+		},
+		{
+			note:     "arrays",
+			filters:  []ast.String{"a/1/c", "a/1/b"},
+			expected: ast.MustParseTerm(`{"a": {"1": {"c": null, "b": null}}}`),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.note, func(t *testing.T) {
+			actual := jsonPathsToObject(tc.filters)
+			if actual.Compare(tc.expected.Value) != 0 {
+				t.Errorf("Unexpected object from filters:\n\nExpected:\n\t%s\n\nActual:\n\t%s\n\n", tc.expected.Value.String(), actual.String())
+			}
+		})
+	}
+}

--- a/topdown/object.go
+++ b/topdown/object.go
@@ -1,0 +1,110 @@
+// Copyright 2019 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package topdown
+
+import (
+	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/topdown/builtins"
+)
+
+func builtinObjectUnion(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term) error) error {
+	objA, err := builtins.ObjectOperand(operands[0].Value, 1)
+	if err != nil {
+		return err
+	}
+
+	objB, err := builtins.ObjectOperand(operands[1].Value, 2)
+	if err != nil {
+		return err
+	}
+
+	r := mergeWithOverwrite(objA, objB)
+
+	return iter(ast.NewTerm(r))
+}
+
+func builtinObjectRemove(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term) error) error {
+	// Expect an object and a string or array/set of keys
+	obj, err := builtins.ObjectOperand(operands[0].Value, 1)
+	if err != nil {
+		return err
+	}
+
+	// Build a set of keys to remove
+	keysToRemove := keysFromSetOrArray(operands[1].Value)
+
+	r := ast.NewObject()
+	obj.Foreach(func(key *ast.Term, value *ast.Term) {
+		if !keysToRemove.Contains(key) {
+			r.Insert(key, value)
+		}
+	})
+
+	return iter(ast.NewTerm(r))
+}
+
+func mergeWithOverwrite(objA, objB ast.Object) ast.Object {
+	merged, _ := objA.MergeWith(objB, func(v1, v2 *ast.Term) (*ast.Term, bool) {
+		originalValueObj, ok2 := v1.Value.(ast.Object)
+		updateValueObj, ok1 := v2.Value.(ast.Object)
+		if !ok1 || !ok2 {
+			// If we can't merge, stick with the left-hand value
+			return v1, false
+		}
+
+		// Recursively update the existing value
+		merged := mergeWithOverwrite(originalValueObj, updateValueObj)
+		return ast.NewTerm(merged), false
+	})
+	return merged
+}
+
+func builtinObjectFilter(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term) error) error {
+	// Expect an object and a string or array/set of keys
+	obj, err := builtins.ObjectOperand(operands[0].Value, 1)
+	if err != nil {
+		return err
+	}
+
+	// Build a new object from the supplied filter keys
+	keys := keysFromSetOrArray(operands[1].Value)
+	filterObj := ast.NewObject()
+	keys.Foreach(func(key *ast.Term) {
+		filterObj.Insert(key, ast.NullTerm())
+	})
+
+	// Actually do the filtering
+	r, err := obj.Filter(filterObj)
+	if err != nil {
+		return err
+	}
+
+	return iter(ast.NewTerm(r))
+}
+
+// keysFromSetOrArray returns an array of key values
+// from a supplied ast array or set value
+func keysFromSetOrArray(arrayOrSet ast.Value) ast.Set {
+	keys := ast.NewSet()
+
+	switch v := arrayOrSet.(type) {
+	case ast.Array:
+		for _, f := range v {
+			keys.Add(f)
+		}
+	case ast.Set:
+		_ = v.Iter(func(f *ast.Term) error {
+			keys.Add(f)
+			return nil
+		})
+	}
+	return keys
+}
+
+func init() {
+	RegisterBuiltinFunc(ast.ObjectUnion.Name, builtinObjectUnion)
+	RegisterBuiltinFunc(ast.ObjectRemove.Name, builtinObjectRemove)
+	RegisterBuiltinFunc(ast.ObjectFilter.Name, builtinObjectFilter)
+}

--- a/topdown/object_test.go
+++ b/topdown/object_test.go
@@ -1,0 +1,201 @@
+// Copyright 2019 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package topdown
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestBuiltinObjectUnion(t *testing.T) {
+	cases := []struct {
+		note     string
+		objectA  string
+		objectB  string
+		expected interface{}
+	}{
+		{
+			note:     "both empty",
+			objectA:  `{}`,
+			objectB:  `{}`,
+			expected: `{}`,
+		},
+		{
+			note:     "left empty",
+			objectA:  `{}`,
+			objectB:  `{"a": 1}`,
+			expected: `{"a": 1}`,
+		},
+		{
+			note:     "right empty",
+			objectA:  `{"a": 1}`,
+			objectB:  `{}`,
+			expected: `{"a": 1}`,
+		},
+		{
+			note:     "base",
+			objectA:  `{"a": 1}`,
+			objectB:  `{"b": 2}`,
+			expected: `{"a": 1, "b": 2}`,
+		},
+		{
+			note:     "nested",
+			objectA:  `{"a": {"b": {"c": 1}}}`,
+			objectB:  `{"b": 2}`,
+			expected: `{"a": {"b": {"c": 1}}, "b": 2}`,
+		},
+		{
+			note:     "nested reverse",
+			objectA:  `{"b": 2}`,
+			objectB:  `{"a": {"b": {"c": 1}}}`,
+			expected: `{"a": {"b": {"c": 1}}, "b": 2}`,
+		},
+		{
+			note:     "conflict simple",
+			objectA:  `{"a": 1}`,
+			objectB:  `{"a": 2}`,
+			expected: `{"a": 1}`,
+		},
+		{
+			note:     "conflict nested and extra field",
+			objectA:  `{"a": 1}`,
+			objectB:  `{"a": {"b": {"c": 1}}, "d": 7}`,
+			expected: `{"a": 1, "d": 7}`,
+		},
+		{
+			note:     "conflict multiple",
+			objectA:  `{"a": {"b": {"c": 1}}, "e": 1}`,
+			objectB:  `{"a": {"b": "foo", "b1": "bar"}, "d": 7, "e": 17}`,
+			expected: `{"a": {"b": {"c": 1}, "b1": "bar"}, "d": 7, "e": 1}`,
+		},
+	}
+
+	for _, tc := range cases {
+		rules := []string{
+			fmt.Sprintf("p = x { x := object.union(%s, %s) }", tc.objectA, tc.objectB),
+		}
+		runTopDownTestCase(t, map[string]interface{}{}, tc.note, rules, tc.expected)
+	}
+}
+
+func TestBuiltinObjectRemove(t *testing.T) {
+	cases := []struct {
+		note     string
+		object   string
+		keys     string
+		expected interface{}
+	}{
+		{
+			note:     "base",
+			object:   `{"a": 1, "b": {"c": 3}}`,
+			keys:     `{"a"}`,
+			expected: `{"b": {"c": 3}}`,
+		},
+		{
+			note:     "multiple keys set",
+			object:   `{"a": 1, "b": {"c": 3}, "d": 4}`,
+			keys:     `{"d", "b"}`,
+			expected: `{"a": 1}`,
+		},
+		{
+			note:     "multiple keys array",
+			object:   `{"a": 1, "b": {"c": 3}, "d": 4}`,
+			keys:     `["d", "b"]`,
+			expected: `{"a": 1}`,
+		},
+		{
+			note:     "empty object",
+			object:   `{}`,
+			keys:     `{"a", "b"}`,
+			expected: `{}`,
+		},
+		{
+			note:     "empty keys",
+			object:   `{"a": 1, "b": {"c": 3}}`,
+			keys:     `set()`,
+			expected: `{"a": 1, "b": {"c": 3}}`,
+		},
+		{
+			note:     "key doesnt exist",
+			object:   `{"a": 1, "b": {"c": 3}}`,
+			keys:     `{"z"}`,
+			expected: `{"a": 1, "b": {"c": 3}}`,
+		},
+	}
+
+	for _, tc := range cases {
+		rules := []string{
+			fmt.Sprintf("p = x { x := object.remove(%s, %s) }", tc.object, tc.keys),
+		}
+		runTopDownTestCase(t, map[string]interface{}{}, tc.note, rules, tc.expected)
+	}
+}
+
+func TestBuiltinObjectRemoveNonStringKey(t *testing.T) {
+	rules := []string{
+		`p { x := object.remove({"a": 1, [[7]]: 2}, {[[7]]}); x == {"a": 1} }`,
+	}
+	runTopDownTestCase(t, map[string]interface{}{}, "non string root", rules, "true")
+}
+
+func TestBuiltinObjectFilter(t *testing.T) {
+	cases := []struct {
+		note     string
+		object   string
+		filters  string
+		expected interface{}
+	}{
+		{
+			note:     "base",
+			object:   `{"a": {"b": {"c": 7, "d": 8}}, "e": 9}`,
+			filters:  `{"a"}`,
+			expected: `{"a": {"b": {"c": 7, "d": 8}}}`,
+		},
+		{
+			note:     "multiple roots",
+			object:   `{"a": 1, "b": 2, "c": 3, "e": 9}`,
+			filters:  `{"a", "e"}`,
+			expected: `{"a": 1, "e": 9}`,
+		},
+		{
+			note:     "multiple roots",
+			object:   `{"a": 1, "b": 2, "c": 3, "e": 9}`,
+			filters:  `["a", "e"]`,
+			expected: `{"a": 1, "e": 9}`,
+		},
+		{
+			note:     "duplicate roots",
+			object:   `{"a": {"b": {"c": 7, "d": 8}}, "e": 9}`,
+			filters:  `{"a", "a"}`,
+			expected: `{"a": {"b": {"c": 7, "d": 8}}}`,
+		},
+		{
+			note:     "empty list",
+			object:   `{"a": 7}`,
+			filters:  `set()`,
+			expected: `{}`,
+		},
+		{
+			note:     "empty object",
+			object:   `{}`,
+			filters:  `{"a"}`,
+			expected: `{}`,
+		},
+	}
+
+	for _, tc := range cases {
+		rules := []string{
+			fmt.Sprintf("p = x { x := object.filter(%s, %s) }", tc.object, tc.filters),
+		}
+		runTopDownTestCase(t, map[string]interface{}{}, tc.note, rules, tc.expected)
+	}
+}
+
+func TestBuiltinObjectFilterNonStringKey(t *testing.T) {
+	rules := []string{
+		`p { x := object.filter({"a": 1, [[7]]: 2}, {[[7]]}); x == {[[7]]: 2} }`,
+	}
+	runTopDownTestCase(t, map[string]interface{}{}, "non string root", rules, "true")
+}


### PR DESCRIPTION
This commit adds in the following built-ins:

`object.remove`
`object.union`
`object.filter`

All of which are helpers for object manipulation in policies.

Reference: #1617
