### PR TITLE
docs/website: Fix live-blocks interaction on edge/live pages

### DIFF
--- a/docs/website/scripts/live-blocks/src/constants.js
+++ b/docs/website/scripts/live-blocks/src/constants.js
@@ -124,7 +124,7 @@ export const CSS_BUNDLE_BATH = JS_BUNDLE_PATH.replace(/js/g, 'css')
 
 // --- UI ---
 // Blocks on pages that match this regex will be non interactive (for limiting live functionality to the version that the playground supports).
-export const NON_INTERACTIVE_PATH = /^(\/docs\/(?!=(latest|edge)))/
+export const INTERACTIVE_PATH = /^\/docs\/(latest|edge)/
 
 // The path to initially open a new tab to with when opening a group in the playground
 export const OPENING_IN_PLAYGROUND_PATH = '/live-blocks/opening-in-playground'

--- a/docs/website/scripts/live-blocks/src/web/index.js
+++ b/docs/website/scripts/live-blocks/src/web/index.js
@@ -7,7 +7,7 @@ import 'codemirror/lib/codemirror.css'
 import 'codemirror/mode/javascript/javascript'
 
 import './style.css'
-import {BASE_EDITOR_OPTS, BLOCK_SELECTOR, BLOCK_TYPES, CLASSES, EDITOR_MODES, HYDRATION_QUEUE_SORT_PERIOD, ICONS, NON_INTERACTIVE_PATH, LINE_NUMBERS_EDITOR_OPTS, OPENING_IN_PLAYGROUND_PATH, READ_ONLY_EDITOR_OPTS, STATIC_TAG_TYPES} from '../constants'
+import {BASE_EDITOR_OPTS, BLOCK_SELECTOR, BLOCK_TYPES, CLASSES, EDITOR_MODES, HYDRATION_QUEUE_SORT_PERIOD, ICONS, INTERACTIVE_PATH, LINE_NUMBERS_EDITOR_OPTS, OPENING_IN_PLAYGROUND_PATH, READ_ONLY_EDITOR_OPTS, STATIC_TAG_TYPES} from '../constants'
 import {batchProcess, delay, getAllGroupModules, getGroupField, handleLater, includedGroupNames, infoFromLabel, report} from '../helpers'
 import {OPAErrors} from '../errors'
 
@@ -266,10 +266,8 @@ function isInteractive(tags) {
   if (tags.includes(STATIC_TAG_TYPES.HIDDEN)) {
     return false
   }
-  if (NON_INTERACTIVE_PATH.test(window.location.pathname)) {
-    return false
-  }
-  return true
+  return INTERACTIVE_PATH.test(window.location.pathname);
+
 }
 
 // Determines whether a block should be editable based on its type, tags, and the current page's path.


### PR DESCRIPTION
This was changed as part of the homepage rework but ended up being
both unused and broken.. so reverting it back to the way it was
before.

The live blocks on the home page are not interactive, so this works
out fine as-is. In the future we may need to revisit.

Signed-off-by: Patrick East <east.patrick@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
