### PR TITLE
Fix parse metrics and plumb through to bundle status

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -59,7 +59,7 @@ func checkModules(args []string) int {
 
 	if checkParams.bundleMode {
 		for _, path := range args {
-			b, err := loader.AsBundle(path)
+			b, err := loader.NewFileLoader().AsBundle(path)
 			if err != nil {
 				outputErrors(err)
 				return 1
@@ -73,7 +73,7 @@ func checkModules(args []string) int {
 			Ignore: checkParams.ignore,
 		}
 
-		result, err := loader.Filtered(args, f.Apply)
+		result, err := loader.NewFileLoader().Filtered(args, f.Apply)
 		if err != nil {
 			outputErrors(err)
 			return 1

--- a/cmd/deps.go
+++ b/cmd/deps.go
@@ -78,7 +78,7 @@ func deps(args []string, params depsCommandParams) error {
 			Ignore: params.ignore,
 		}
 
-		result, err := loader.Filtered(params.dataPaths.v, f.Apply)
+		result, err := loader.NewFileLoader().Filtered(params.dataPaths.v, f.Apply)
 		if err != nil {
 			return err
 		}
@@ -90,7 +90,7 @@ func deps(args []string, params depsCommandParams) error {
 
 	if len(params.bundlePaths.v) > 0 {
 		for _, path := range params.bundlePaths.v {
-			b, err := loader.AsBundle(path)
+			b, err := loader.NewFileLoader().AsBundle(path)
 			if err != nil {
 				return err
 			}

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -343,6 +343,8 @@ server provenance, etc.
 | --- | --- | --- | --- |
 | `status.service` | `string` | Yes | Name of service to use to contact remote server. |
 | `status.partition_name` | `string` | No | Path segment to include in status updates. |
+| `status.console` | `boolean` | No (default: `false`) | Log the status updates locally at `info` level to the console. When enabled alongside a remote status update API the `service` must be configured, the default `service` selection will be disabled. |
+
 
 ### Decision Logs
 

--- a/docs/content/management.md
+++ b/docs/content/management.md
@@ -466,7 +466,12 @@ on the agent, updates will be sent to `/status`.
         "http/example/authz": {
             "active_revision": "TODO",
             "last_successful_download": "2018-01-01T00:00:00.000Z",
-            "last_successful_activation": "2018-01-01T00:00:00.000Z"
+            "last_successful_activation": "2018-01-01T00:00:00.000Z",
+            "metrics": {
+                "timer_rego_data_parse_ns": 12345,
+                "timer_rego_module_compile_ns": 12345,
+                "timer_rego_module_parse_ns": 12345
+             }
         }
     },
   "metrics": {
@@ -599,6 +604,7 @@ Status updates contain the following fields:
 | `bundles[_].active_revision` | `string` | Opaque revision identifier of the last successful activation. |
 | `bundles[_].last_successful_download` | `string` | RFC3339 timestamp of last successful bundle download. |
 | `bundles[_].last_successful_activation` | `string` | RFC3339 timestamp of last successful bundle activation. |
+| `bundles[_].metrics` | `object` | Metrics from the last update of the bundle. |
 | `discovery.name` | `string` | Name of discovery bundle that the OPA instance is configured to download. |
 | `discovery.active_revision` | `string` | Opaque revision identifier of the last successful discovery activation. |
 | `discovery.last_successful_download` | `string` | RFC3339 timestamp of last successful discovery bundle download. |
@@ -614,7 +620,7 @@ the following additional fields.
 | `bundle.message` | `string` | Human readable messages describing the error(s). |
 | `bundle.errors` | `array` | Collection of detailed parse or compile errors that occurred during activation. |
 
-If the bundle download or activation failed, the status update will contain
+If the discovery bundle download or activation failed, the status update will contain
 the following additional fields.
 
 | Field | Type | Description |

--- a/docs/content/management.md
+++ b/docs/content/management.md
@@ -632,6 +632,22 @@ the following additional fields.
 Services should reply with HTTP status `200 OK` if the status update is
 processed successfully.
 
+### Local Status Logs
+
+Local console logging of status updates can be enabled via the `console` config option.
+This does not require any remote server. Example of minimal config to enable:
+
+```yaml
+status:
+    console: true
+```
+This will dump all status updates through the OPA logging system at the `info` level. See
+[Configuration Reference](../configuration) for more details.
+
+> Warning: Status update messages are somewhat infrequent but can be very verbose! The
+>`metrics.prometheus` portion of the status update in particular can create a considerable
+> amount of log text at info level.
+
 ## Discovery
 
 

--- a/download/download.go
+++ b/download/download.go
@@ -15,6 +15,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
+	"github.com/open-policy-agent/opa/metrics"
+
 	"github.com/open-policy-agent/opa/bundle"
 	"github.com/open-policy-agent/opa/plugins/rest"
 	"github.com/open-policy-agent/opa/util"
@@ -28,9 +30,10 @@ const (
 // field will be non-nil. If a new bundle is available, the Bundle field will
 // be non-nil.
 type Update struct {
-	ETag   string
-	Bundle *bundle.Bundle
-	Error  error
+	ETag    string
+	Bundle  *bundle.Bundle
+	Error   error
+	Metrics metrics.Metrics
 }
 
 // Downloader implements low-level OPA bundle downloading. Downloader can be
@@ -119,11 +122,11 @@ func (d *Downloader) loop() {
 }
 
 func (d *Downloader) oneShot(ctx context.Context) error {
-
-	b, etag, err := d.download(ctx)
+	m := metrics.New()
+	b, etag, err := d.download(ctx, m)
 
 	if d.f != nil {
-		d.f(ctx, Update{ETag: etag, Bundle: b, Error: err})
+		d.f(ctx, Update{ETag: etag, Bundle: b, Error: err, Metrics: m})
 	}
 
 	d.etag = etag
@@ -131,7 +134,7 @@ func (d *Downloader) oneShot(ctx context.Context) error {
 	return err
 }
 
-func (d *Downloader) download(ctx context.Context) (*bundle.Bundle, string, error) {
+func (d *Downloader) download(ctx context.Context, m metrics.Metrics) (*bundle.Bundle, string, error) {
 
 	d.logDebug("Download starting.")
 
@@ -146,7 +149,9 @@ func (d *Downloader) download(ctx context.Context) (*bundle.Bundle, string, erro
 	case http.StatusOK:
 		if resp.Body != nil {
 			d.logDebug("Download in progress.")
-			b, err := bundle.NewReader(resp.Body).Read()
+			m.Timer(metrics.RegoLoadBundles).Start()
+			defer m.Timer(metrics.RegoLoadBundles).Stop()
+			b, err := bundle.NewReader(resp.Body).WithMetrics(m).Read()
 			if err != nil {
 				return nil, "", err
 			}

--- a/internal/presentation/presentation_test.go
+++ b/internal/presentation/presentation_test.go
@@ -297,7 +297,7 @@ func TestOutputJSONErrorStructuredLoaderErrList(t *testing.T) {
 	var tmpPath string
 	test.WithTempFS(files, func(path string) {
 		tmpPath = path
-		_, err = loader.All([]string{path})
+		_, err = loader.NewFileLoader().All([]string{path})
 	})
 
 	expected := fmt.Sprintf(`{

--- a/loader/errors.go
+++ b/loader/errors.go
@@ -38,13 +38,6 @@ func (e *Errors) add(err error) {
 	}
 }
 
-func newResult() *Result {
-	return &Result{
-		Documents: map[string]interface{}{},
-		Modules:   map[string]*RegoFile{},
-	}
-}
-
 type unsupportedDocumentType string
 
 func (path unsupportedDocumentType) Error() string {

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -16,6 +16,8 @@ import (
 	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
 
+	"github.com/open-policy-agent/opa/metrics"
+
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/bundle"
 	fileurl "github.com/open-policy-agent/opa/internal/file/url"
@@ -77,23 +79,42 @@ func GlobExcludeName(pattern string, minDepth int) Filter {
 	}
 }
 
-// All returns a Result object loaded (recursively) from the specified paths.
-func All(paths []string) (*Result, error) {
-	return Filtered(paths, nil)
+// FileLoader defines an interface for loading OPA data files
+// and Rego policies.
+type FileLoader interface {
+	All(paths []string) (*Result, error)
+	Filtered(paths []string, filter Filter) (*Result, error)
+	AsBundle(path string) (*bundle.Bundle, error)
+
+	WithMetrics(m metrics.Metrics) FileLoader
 }
 
-// AllRegos returns a Result object loaded (recursively) with all Rego source
-// files from the specified paths.
-func AllRegos(paths []string) (*Result, error) {
-	return Filtered(paths, func(_ string, info os.FileInfo, depth int) bool {
-		return !info.IsDir() && !strings.HasSuffix(info.Name(), bundle.RegoExt)
-	})
+// NewFileLoader returns a new FileLoader instance.
+func NewFileLoader() FileLoader {
+	return &fileLoader{
+		metrics: metrics.New(),
+	}
+}
+
+type fileLoader struct {
+	metrics metrics.Metrics
+}
+
+// WithMetrics provides the metrics instance to use while loading
+func (fl *fileLoader) WithMetrics(m metrics.Metrics) FileLoader {
+	fl.metrics = m
+	return fl
+}
+
+// All returns a Result object loaded (recursively) from the specified paths.
+func (fl fileLoader) All(paths []string) (*Result, error) {
+	return fl.Filtered(paths, nil)
 }
 
 // Filtered returns a Result object loaded (recursively) from the specified
 // paths while applying the given filters. If any filter returns true, the
 // file/directory is excluded.
-func Filtered(paths []string, filter Filter) (*Result, error) {
+func (fl fileLoader) Filtered(paths []string, filter Filter) (*Result, error) {
 	return all(paths, filter, func(curr *Result, path string, depth int) error {
 
 		bs, err := ioutil.ReadFile(path)
@@ -101,7 +122,7 @@ func Filtered(paths []string, filter Filter) (*Result, error) {
 			return err
 		}
 
-		result, err := loadKnownTypes(path, bs)
+		result, err := loadKnownTypes(path, bs, fl.metrics)
 		if err != nil {
 			if !isUnrecognizedFile(err) {
 				return err
@@ -109,7 +130,7 @@ func Filtered(paths []string, filter Filter) (*Result, error) {
 			if depth > 0 {
 				return nil
 			}
-			result, err = loadFileForAnyType(path, bs)
+			result, err = loadFileForAnyType(path, bs, fl.metrics)
 			if err != nil {
 				return err
 			}
@@ -119,23 +140,10 @@ func Filtered(paths []string, filter Filter) (*Result, error) {
 	})
 }
 
-// Rego returns a RegoFile object loaded from the given path.
-func Rego(path string) (*RegoFile, error) {
-	path, err := fileurl.Clean(path)
-	if err != nil {
-		return nil, err
-	}
-	bs, err := ioutil.ReadFile(path)
-	if err != nil {
-		return nil, err
-	}
-	return loadRego(path, bs)
-}
-
 // AsBundle loads a path as a bundle. If it is a single file
 // it will be treated as a normal tarball bundle. If a directory
 // is supplied it will be loaded as an unzipped bundle tree.
-func AsBundle(path string) (*bundle.Bundle, error) {
+func (fl fileLoader) AsBundle(path string) (*bundle.Bundle, error) {
 	path, err := fileurl.Clean(path)
 	if err != nil {
 		return nil, err
@@ -158,12 +166,55 @@ func AsBundle(path string) (*bundle.Bundle, error) {
 		bundleLoader = bundle.NewTarballLoader(fh)
 	}
 
-	br := bundle.NewCustomReader(bundleLoader)
+	br := bundle.NewCustomReader(bundleLoader).WithMetrics(fl.metrics)
 	b, err := br.Read()
 	if err != nil {
 		err = errors.Wrap(err, fmt.Sprintf("bundle %s", path))
 	}
 	return &b, err
+}
+
+// All returns a Result object loaded (recursively) from the specified paths.
+// Deprecated: Use FileLoader.Filtered() instead.
+func All(paths []string) (*Result, error) {
+	return NewFileLoader().Filtered(paths, nil)
+}
+
+// Filtered returns a Result object loaded (recursively) from the specified
+// paths while applying the given filters. If any filter returns true, the
+// file/directory is excluded.
+// Deprecated: Use FileLoader.Filtered() instead.
+func Filtered(paths []string, filter Filter) (*Result, error) {
+	return NewFileLoader().Filtered(paths, filter)
+}
+
+// AsBundle loads a path as a bundle. If it is a single file
+// it will be treated as a normal tarball bundle. If a directory
+// is supplied it will be loaded as an unzipped bundle tree.
+// Deprecated: Use FileLoader.AsBundle() instead.
+func AsBundle(path string) (*bundle.Bundle, error) {
+	return NewFileLoader().AsBundle(path)
+}
+
+// AllRegos returns a Result object loaded (recursively) with all Rego source
+// files from the specified paths.
+func AllRegos(paths []string) (*Result, error) {
+	return NewFileLoader().Filtered(paths, func(_ string, info os.FileInfo, depth int) bool {
+		return !info.IsDir() && !strings.HasSuffix(info.Name(), bundle.RegoExt)
+	})
+}
+
+// Rego returns a RegoFile object loaded from the given path.
+func Rego(path string) (*RegoFile, error) {
+	path, err := fileurl.Clean(path)
+	if err != nil {
+		return nil, err
+	}
+	bs, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return loadRego(path, bs, metrics.New())
 }
 
 // CleanPath returns the normalized version of a path that can be used as an identifier.
@@ -249,6 +300,13 @@ func (l *Result) withParent(p string) *Result {
 	}
 }
 
+func newResult() *Result {
+	return &Result{
+		Documents: map[string]interface{}{},
+		Modules:   map[string]*RegoFile{},
+	}
+}
+
 func all(paths []string, filter Filter, f func(*Result, string, int) error) (*Result, error) {
 	errors := Errors{}
 	root := newResult()
@@ -318,26 +376,17 @@ func allRec(path string, filter Filter, errors *Errors, loaded *Result, depth in
 	}
 }
 
-func exclude(filters []Filter, path string, info os.FileInfo, depth int) bool {
-	for _, f := range filters {
-		if f(path, info, depth) {
-			return true
-		}
-	}
-	return false
-}
-
-func loadKnownTypes(path string, bs []byte) (interface{}, error) {
+func loadKnownTypes(path string, bs []byte, m metrics.Metrics) (interface{}, error) {
 	switch filepath.Ext(path) {
 	case ".json":
-		return loadJSON(path, bs)
+		return loadJSON(path, bs, m)
 	case ".rego":
-		return Rego(path)
+		return loadRego(path, bs, m)
 	case ".yaml", ".yml":
-		return loadYAML(path, bs)
+		return loadYAML(path, bs, m)
 	default:
 		if strings.HasSuffix(path, ".tar.gz") {
-			r, err := loadBundleFile(bs)
+			r, err := loadBundleFile(bs, m)
 			if err != nil {
 				err = errors.Wrap(err, fmt.Sprintf("bundle %s", path))
 			}
@@ -347,34 +396,32 @@ func loadKnownTypes(path string, bs []byte) (interface{}, error) {
 	return nil, unrecognizedFile(path)
 }
 
-func loadFileForAnyType(path string, bs []byte) (interface{}, error) {
-	module, err := loadRego(path, bs)
+func loadFileForAnyType(path string, bs []byte, m metrics.Metrics) (interface{}, error) {
+	module, err := loadRego(path, bs, m)
 	if err == nil {
 		return module, nil
 	}
-	doc, err := loadJSON(path, bs)
+	doc, err := loadJSON(path, bs, m)
 	if err == nil {
 		return doc, nil
 	}
-	doc, err = loadYAML(path, bs)
+	doc, err = loadYAML(path, bs, m)
 	if err == nil {
 		return doc, nil
 	}
 	return nil, unrecognizedFile(path)
 }
 
-func loadBundleFile(bs []byte) (bundle.Bundle, error) {
+func loadBundleFile(bs []byte, m metrics.Metrics) (bundle.Bundle, error) {
 	tl := bundle.NewTarballLoader(bytes.NewBuffer(bs))
-	br := bundle.NewCustomReader(tl).IncludeManifestInData(true)
+	br := bundle.NewCustomReader(tl).WithMetrics(m).IncludeManifestInData(true)
 	return br.Read()
 }
 
-func loadBundleDir(path string) (bundle.Bundle, error) {
-	return bundle.Bundle{}, nil
-}
-
-func loadRego(path string, bs []byte) (*RegoFile, error) {
+func loadRego(path string, bs []byte, m metrics.Metrics) (*RegoFile, error) {
+	m.Timer(metrics.RegoModuleParse).Start()
 	module, err := ast.ParseModule(path, string(bs))
+	m.Timer(metrics.RegoModuleParse).Stop()
 	if err != nil {
 		return nil, err
 	}
@@ -389,22 +436,27 @@ func loadRego(path string, bs []byte) (*RegoFile, error) {
 	return result, nil
 }
 
-func loadJSON(path string, bs []byte) (interface{}, error) {
+func loadJSON(path string, bs []byte, m metrics.Metrics) (interface{}, error) {
+	m.Timer(metrics.RegoDataParse).Start()
 	buf := bytes.NewBuffer(bs)
 	decoder := util.NewJSONDecoder(buf)
 	var x interface{}
-	if err := decoder.Decode(&x); err != nil {
+	err := decoder.Decode(&x)
+	m.Timer(metrics.RegoDataParse).Stop()
+	if err != nil {
 		return nil, errors.Wrap(err, path)
 	}
 	return x, nil
 }
 
-func loadYAML(path string, bs []byte) (interface{}, error) {
+func loadYAML(path string, bs []byte, m metrics.Metrics) (interface{}, error) {
+	m.Timer(metrics.RegoDataParse).Start()
 	bs, err := yaml.YAMLToJSON(bs)
+	m.Timer(metrics.RegoDataParse).Stop()
 	if err != nil {
 		return nil, fmt.Errorf("%v: error converting YAML to JSON: %v", path, err)
 	}
-	return loadJSON(path, bs)
+	return loadJSON(path, bs, m)
 }
 
 func makeDir(path []string, x interface{}) (map[string]interface{}, bool) {

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -27,7 +27,7 @@ func TestLoadJSON(t *testing.T) {
 
 	test.WithTempFS(files, func(rootDir string) {
 
-		loaded, err := All([]string{filepath.Join(rootDir, "foo.json")})
+		loaded, err := NewFileLoader().All([]string{filepath.Join(rootDir, "foo.json")})
 
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
@@ -50,7 +50,7 @@ p = true { true }`}
 
 	test.WithTempFS(files, func(rootDir string) {
 		moduleFile := filepath.Join(rootDir, "foo.rego")
-		loaded, err := All([]string{moduleFile})
+		loaded, err := NewFileLoader().All([]string{moduleFile})
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
@@ -77,7 +77,7 @@ func TestLoadYAML(t *testing.T) {
 
 	test.WithTempFS(files, func(rootDir string) {
 		yamlFile := filepath.Join(rootDir, "foo.yml")
-		loaded, err := All([]string{yamlFile})
+		loaded, err := NewFileLoader().All([]string{yamlFile})
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
@@ -97,7 +97,7 @@ func TestLoadGuessYAML(t *testing.T) {
 	}
 	test.WithTempFS(files, func(rootDir string) {
 		yamlFile := filepath.Join(rootDir, "foo")
-		loaded, err := All([]string{yamlFile})
+		loaded, err := NewFileLoader().All([]string{yamlFile})
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
@@ -121,7 +121,7 @@ func TestLoadDirRecursive(t *testing.T) {
 	}
 
 	test.WithTempFS(files, func(rootDir string) {
-		loaded, err := All(mustListPaths(rootDir, false)[1:])
+		loaded, err := NewFileLoader().All(mustListPaths(rootDir, false)[1:])
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
@@ -185,7 +185,7 @@ func TestLoadBundle(t *testing.T) {
 		}
 
 		paths := mustListPaths(rootDir, false)[1:]
-		loaded, err := All(paths)
+		loaded, err := NewFileLoader().All(paths)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -241,7 +241,7 @@ func TestLoadBundleSubDir(t *testing.T) {
 		}
 
 		paths := mustListPaths(rootDir, false)[1:]
-		loaded, err := All(paths)
+		loaded, err := NewFileLoader().All(paths)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -270,7 +270,7 @@ func TestAsBundleWithDir(t *testing.T) {
 	}
 
 	test.WithTempFS(files, func(rootDir string) {
-		b, err := AsBundle(rootDir)
+		b, err := NewFileLoader().AsBundle(rootDir)
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
@@ -302,7 +302,7 @@ func TestAsBundleWithFileURLDir(t *testing.T) {
 	}
 
 	test.WithTempFS(files, func(rootDir string) {
-		b, err := AsBundle("file://" + rootDir)
+		b, err := NewFileLoader().AsBundle("file://" + rootDir)
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
@@ -362,7 +362,7 @@ func TestAsBundleWithFile(t *testing.T) {
 			t.Fatalf("Unexpected error: %s", err)
 		}
 
-		actual, err := AsBundle(path)
+		actual, err := NewFileLoader().AsBundle(path)
 		if err != nil {
 			t.Fatalf("Unexpected error: %s", err)
 		}
@@ -392,7 +392,7 @@ func TestLoadRooted(t *testing.T) {
 		paths[0] = "one.two:" + paths[0]
 		paths[1] = "three:" + paths[1]
 		paths[2] = "four:" + paths[2]
-		loaded, err := All(paths)
+		loaded, err := NewFileLoader().All(paths)
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
@@ -418,7 +418,7 @@ func TestGlobExcludeName(t *testing.T) {
 	test.WithTempFS(files, func(rootDir string) {
 		paths := mustListPaths(rootDir, false)[1:]
 		sort.Strings(paths)
-		result, err := Filtered(paths, GlobExcludeName(".*", 1))
+		result, err := NewFileLoader().Filtered(paths, GlobExcludeName(".*", 1))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -448,7 +448,7 @@ func TestLoadErrors(t *testing.T) {
 	test.WithTempFS(files, func(rootDir string) {
 		paths := mustListPaths(rootDir, false)[1:]
 		sort.Strings(paths)
-		_, err := All(paths)
+		_, err := NewFileLoader().All(paths)
 		if err == nil {
 			t.Fatalf("Expected failure")
 		}
@@ -486,7 +486,7 @@ func TestLoadFileURL(t *testing.T) {
 
 		paths[2] = "c:" + paths[2]
 
-		result, err := All(paths)
+		result, err := NewFileLoader().All(paths)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -499,7 +499,7 @@ func TestLoadFileURL(t *testing.T) {
 }
 
 func TestUnsupportedURLScheme(t *testing.T) {
-	_, err := All([]string{"http://openpolicyagent.org"})
+	_, err := NewFileLoader().All([]string{"http://openpolicyagent.org"})
 	if err == nil || !strings.Contains(err.Error(), "unsupported URL scheme: http://openpolicyagent.org") {
 		t.Fatal(err)
 	}

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -24,6 +24,7 @@ const (
 	RegoQueryEval     = "rego_query_eval"
 	RegoQueryParse    = "rego_query_parse"
 	RegoModuleParse   = "rego_module_parse"
+	RegoDataParse     = "rego_data_parse"
 	RegoModuleCompile = "rego_module_compile"
 	RegoPartialEval   = "rego_partial_eval"
 	RegoInputParse    = "rego_input_parse"

--- a/plugins/bundle/status.go
+++ b/plugins/bundle/status.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/open-policy-agent/opa/metrics"
+
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/server/types"
 )
@@ -19,13 +21,14 @@ const (
 
 // Status represents the status of processing a bundle.
 type Status struct {
-	Name                     string    `json:"name"`
-	ActiveRevision           string    `json:"active_revision,omitempty"`
-	LastSuccessfulActivation time.Time `json:"last_successful_activation,omitempty"`
-	LastSuccessfulDownload   time.Time `json:"last_successful_download,omitempty"`
-	Code                     string    `json:"code,omitempty"`
-	Message                  string    `json:"message,omitempty"`
-	Errors                   []error   `json:"errors,omitempty"`
+	Name                     string          `json:"name"`
+	ActiveRevision           string          `json:"active_revision,omitempty"`
+	LastSuccessfulActivation time.Time       `json:"last_successful_activation,omitempty"`
+	LastSuccessfulDownload   time.Time       `json:"last_successful_download,omitempty"`
+	Code                     string          `json:"code,omitempty"`
+	Message                  string          `json:"message,omitempty"`
+	Errors                   []error         `json:"errors,omitempty"`
+	Metrics                  metrics.Metrics `json:"metrics,omitempty"`
 }
 
 // SetActivateSuccess updates the status object to reflect a successful

--- a/plugins/logs/plugin.go
+++ b/plugins/logs/plugin.go
@@ -302,7 +302,7 @@ func (p *Plugin) Log(ctx context.Context, decision *server.Info) error {
 	}
 
 	if p.config.ConsoleLogs {
-		err := p.logEvent(ctx, event)
+		err := p.logEvent(event)
 		if err != nil {
 			p.logError("Failed to log to console: %v.", err)
 		}
@@ -577,7 +577,7 @@ func (p *Plugin) logrusFields() logrus.Fields {
 	}
 }
 
-func (p *Plugin) logEvent(ctx context.Context, event EventV1) error {
+func (p *Plugin) logEvent(event EventV1) error {
 	eventBuf, err := json.Marshal(&event)
 	if err != nil {
 		return err

--- a/plugins/status/plugin_test.go
+++ b/plugins/status/plugin_test.go
@@ -253,6 +253,60 @@ func TestMetrics(t *testing.T) {
 	}
 }
 
+func TestParseConfigUseDefaultServiceNoConsole(t *testing.T) {
+	services := []string{
+		"s0",
+		"s1",
+		"s3",
+	}
+
+	loggerConfig := []byte(fmt.Sprintf(`{
+		"console": false
+	}`))
+
+	config, err := ParseConfig([]byte(loggerConfig), services)
+
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+
+	if config.Service != services[0] {
+		t.Errorf("Expected %s service in config, actual = '%s'", services[0], config.Service)
+	}
+}
+
+func TestParseConfigDefaultServiceWithConsole(t *testing.T) {
+	services := []string{
+		"s0",
+		"s1",
+		"s3",
+	}
+
+	loggerConfig := []byte(fmt.Sprintf(`{
+		"console": true
+	}`))
+
+	config, err := ParseConfig([]byte(loggerConfig), services)
+
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+
+	if config.Service != "" {
+		t.Errorf("Expected no service in config, actual = '%s'", config.Service)
+	}
+}
+
+func TestParseConfigDefaultServiceWithNoServiceOrConsole(t *testing.T) {
+	loggerConfig := []byte(fmt.Sprintf(`{}`))
+
+	_, err := ParseConfig([]byte(loggerConfig), []string{})
+
+	if err == nil {
+		t.Errorf("Expected an error but err==nil")
+	}
+}
+
 type testFixture struct {
 	manager *plugins.Manager
 	plugin  *Plugin

--- a/rego/rego.go
+++ b/rego/rego.go
@@ -1329,7 +1329,7 @@ func (r *Rego) loadFiles(ctx context.Context, txn storage.Transaction, m metrics
 	m.Timer(metrics.RegoLoadFiles).Start()
 	defer m.Timer(metrics.RegoLoadFiles).Stop()
 
-	result, err := loader.Filtered(r.loadPaths.paths, r.loadPaths.filter)
+	result, err := loader.NewFileLoader().WithMetrics(m).Filtered(r.loadPaths.paths, r.loadPaths.filter)
 	if err != nil {
 		return err
 	}
@@ -1351,7 +1351,7 @@ func (r *Rego) loadBundles(ctx context.Context, txn storage.Transaction, m metri
 	defer m.Timer(metrics.RegoLoadBundles).Stop()
 
 	for _, path := range r.bundlePaths {
-		bndl, err := loader.AsBundle(path)
+		bndl, err := loader.NewFileLoader().WithMetrics(m).AsBundle(path)
 		if err != nil {
 			return fmt.Errorf("loading error: %s", err)
 		}

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -521,13 +521,13 @@ func loadPaths(paths []string, filter loader.Filter, asBundle bool) (*loadResult
 	if asBundle {
 		result.Bundles = make(map[string]*bundle.Bundle, len(paths))
 		for _, path := range paths {
-			result.Bundles[path], err = loader.AsBundle(path)
+			result.Bundles[path], err = loader.NewFileLoader().AsBundle(path)
 			if err != nil {
 				return nil, err
 			}
 		}
 	} else {
-		loaded, err := loader.Filtered(paths, filter)
+		loaded, err := loader.NewFileLoader().Filtered(paths, filter)
 		if err != nil {
 			return nil, err
 		}

--- a/tester/runner.go
+++ b/tester/runner.go
@@ -362,7 +362,7 @@ func (r *Runner) runTest(ctx context.Context, txn storage.Transaction, mod *ast.
 
 // Load returns modules and an in-memory store for running tests.
 func Load(args []string, filter loader.Filter) (map[string]*ast.Module, storage.Store, error) {
-	loaded, err := loader.Filtered(args, filter)
+	loaded, err := loader.NewFileLoader().Filtered(args, filter)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -390,7 +390,7 @@ func Load(args []string, filter loader.Filter) (map[string]*ast.Module, storage.
 func LoadBundles(args []string, filter loader.Filter) (map[string]*bundle.Bundle, error) {
 	bundles := map[string]*bundle.Bundle{}
 	for _, bundleDir := range args {
-		b, err := loader.AsBundle(bundleDir)
+		b, err := loader.NewFileLoader().AsBundle(bundleDir)
 		if err != nil {
 			return nil, fmt.Errorf("unable to load bundle %s: %s", bundleDir, err)
 		}


### PR DESCRIPTION
This combines a few commits that are all related to correct and enhance metrics for parsing/compiling bundles and other files with OPA.

At a high level:
* Adds a new more easily extendable (and mock-able) interface for loading files. The first of these extensions is an API for supplying metrics.
* Update the implementation of the file loader and bundle reader to use metrics objects everywhere that we parse or compile anything.
* Plumb through metrics from downloader to bundle status updates.
* To make it easier to test/see the bundle status updates I added the `console` logging option for status.