### PR TITLE
topdown: Add net.cidr_expand built-in function

### DIFF
--- a/ast/builtins.go
+++ b/ast/builtins.go
@@ -179,6 +179,7 @@ var DefaultBuiltins = [...]*Builtin{
 	NetCIDROverlap,
 	NetCIDRIntersects,
 	NetCIDRContains,
+	NetCIDRExpand,
 
 	// Glob
 	GlobMatch,
@@ -1485,6 +1486,17 @@ var NetCIDRIntersects = &Builtin{
 			types.S,
 		),
 		types.B,
+	),
+}
+
+// NetCIDRExpand returns a set of hosts inside the specified cidr.
+var NetCIDRExpand = &Builtin{
+	Name: "net.cidr_expand",
+	Decl: types.NewFunction(
+		types.Args(
+			types.S,
+		),
+		types.NewSet(types.S),
 	),
 }
 

--- a/docs/content/policy-reference.md
+++ b/docs/content/policy-reference.md
@@ -557,6 +557,7 @@ The table below shows examples of calling `http.send`:
 | ------- |-------------|
 | <span class="opa-keep-it-together">``net.cidr_contains(cidr, cidr_or_ip)``</span> | `output` is `true` if `cidr_or_ip` (e.g. `127.0.0.64/26` or `127.0.0.1`) is contained within `cidr` (e.g. `127.0.0.1/24`) and false otherwise. Supports both IPv4 and IPv6 notations.|
 | <span class="opa-keep-it-together">``net.cidr_intersects(cidr1, cidr2)``</span> | `output` is `true` if `cidr1` (e.g. `192.168.0.0/16`) overlaps with `cidr2` (e.g. `192.168.1.0/24`) and false otherwise. Supports both IPv4 and IPv6 notations.|
+| <span class="opa-keep-it-together">``net.cidr_expand(cidr)``</span> | `output` is the set of hosts in `cidr`  (e.g., `net.cidr_expand("192.168.0.0/30")` generates 4 hosts: `{"192.168.0.0", "192.168.0.1", "192.168.0.2", "192.168.0.3"}` |
 
 ### Rego
 | Built-in | Description |

--- a/topdown/builtins.go
+++ b/topdown/builtins.go
@@ -29,6 +29,7 @@ type (
 	// built-in functions.
 	BuiltinContext struct {
 		Context  context.Context // request context that was passed when query started
+		Cancel   Cancel          // atomic value that signals evaluation to halt
 		Runtime  *ast.Term       // runtime information on the OPA instance
 		Cache    builtins.Cache  // built-in function state cache
 		Location *ast.Location   // location of built-in call

--- a/topdown/eval.go
+++ b/topdown/eval.go
@@ -576,6 +576,7 @@ func (e *eval) evalCall(terms []*ast.Term, iter unifyIterator) error {
 
 	bctx := BuiltinContext{
 		Context:  e.ctx,
+		Cancel:   e.cancel,
 		Runtime:  e.runtime,
 		Cache:    e.builtinCache,
 		Location: e.query[e.index].Location,


### PR DESCRIPTION
In some cases, policies may need to expand CIDRs to check if hosts in
the range are valid (e.g., due to limitations of external APIs being
accessed from inside the policy.)

This change adds a built-in function to enumerate the addresses in a
CIDR. The built-in function supports cancellation in case the range is
too large and taking too long to generate.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
