### PR TITLE
Partially evaluate expressions containing with statements

### DIFF
--- a/ast/index.go
+++ b/ast/index.go
@@ -223,6 +223,12 @@ func (i *refindices) Update(rule *Rule, expr *Expr) {
 		return
 	}
 
+	if len(expr.With) > 0 {
+		// NOTE(tsandall): In the future, we may need to consider expressions
+		// that have with statements applied to them.
+		return
+	}
+
 	op := expr.Operator()
 
 	if op.Equal(Equality.Ref()) || op.Equal(Equal.Ref()) {

--- a/ast/index_test.go
+++ b/ast/index_test.go
@@ -116,6 +116,8 @@ func TestBaseDocEqIndexing(t *testing.T) {
 		# include one rule that can be indexed to exercise merging of root non-indexable
 		# rules with other rules.
 		input.x = 1
+	} {
+		input.foo = "bar" with data.baz as "qux"
 	}
 
 	# exercise default keyword


### PR DESCRIPTION
This is the first of a few changes that will improve the coverage of partial evaluation. Previously partial evaluation would immediately save expressions containing with statements. Now, the evaluator continues but re-applies the with statements when expressions are saved. In the future, we'll want to avoid adding (or remove) unnecessary with statements.