### PR TITLE
bundle: Use full system path for bundle dir

### DIFF
--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -127,6 +127,7 @@ type Reader struct {
 	loader                DirectoryLoader
 	includeManifestInData bool
 	metrics               metrics.Metrics
+	baseDir               string
 }
 
 // NewReader returns a new Reader which is configured for reading tarballs.
@@ -154,6 +155,13 @@ func (r *Reader) IncludeManifestInData(includeManifestInData bool) *Reader {
 // WithMetrics sets the metrics object to be used while loading bundles
 func (r *Reader) WithMetrics(m metrics.Metrics) *Reader {
 	r.metrics = m
+	return r
+}
+
+// WithBaseDir sets a base directory for file paths of loaded Rego
+// modules. This will *NOT* affect the loaded path of data files.
+func (r *Reader) WithBaseDir(dir string) *Reader {
+	r.baseDir = dir
 	return r
 }
 
@@ -186,18 +194,19 @@ func (r *Reader) Read() (Bundle, error) {
 		path := filepath.ToSlash(f.Path())
 
 		if strings.HasSuffix(path, RegoExt) {
+			fullPath := r.fullPath(path)
 			r.metrics.Timer(metrics.RegoModuleParse).Start()
-			module, err := ast.ParseModule(path, buf.String())
+			module, err := ast.ParseModule(fullPath, buf.String())
 			r.metrics.Timer(metrics.RegoModuleParse).Stop()
 			if err != nil {
 				return bundle, err
 			}
 			if module == nil {
-				return bundle, fmt.Errorf("module '%s' is empty", path)
+				return bundle, fmt.Errorf("module '%s' is empty", fullPath)
 			}
 
 			mf := ModuleFile{
-				Path:   path,
+				Path:   fullPath,
 				Raw:    buf.Bytes(),
 				Parsed: module,
 			}
@@ -211,7 +220,7 @@ func (r *Reader) Read() (Bundle, error) {
 			r.metrics.Timer(metrics.RegoDataParse).Stop()
 
 			if err != nil {
-				return bundle, errors.Wrapf(err, "bundle load failed on %v", path)
+				return bundle, errors.Wrapf(err, "bundle load failed on %v", r.fullPath(path))
 			}
 
 			if err := insertValue(&bundle, path, value); err != nil {
@@ -227,7 +236,7 @@ func (r *Reader) Read() (Bundle, error) {
 			r.metrics.Timer(metrics.RegoDataParse).Stop()
 
 			if err != nil {
-				return bundle, errors.Wrapf(err, "bundle load failed on %v", path)
+				return bundle, errors.Wrapf(err, "bundle load failed on %v", r.fullPath(path))
 			}
 
 			if err := insertValue(&bundle, path, value); err != nil {
@@ -266,6 +275,13 @@ func (r *Reader) Read() (Bundle, error) {
 	}
 
 	return bundle, nil
+}
+
+func (r *Reader) fullPath(path string) string {
+	if r.baseDir != "" {
+		path = filepath.Join(r.baseDir, path)
+	}
+	return path
 }
 
 // Write serializes the Bundle and writes it to w.

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -167,10 +167,18 @@ func (fl fileLoader) AsBundle(path string) (*bundle.Bundle, error) {
 	}
 
 	br := bundle.NewCustomReader(bundleLoader).WithMetrics(fl.metrics)
+
+	// For bundle directories add the full path in front of module file names
+	// to simplify debugging.
+	if fi.IsDir() {
+		br.WithBaseDir(path)
+	}
+
 	b, err := br.Read()
 	if err != nil {
 		err = errors.Wrap(err, fmt.Sprintf("bundle %s", path))
 	}
+
 	return &b, err
 }
 

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -283,6 +283,16 @@ func TestAsBundleWithDir(t *testing.T) {
 			t.Fatalf("expected 2 modules, got %d", len(b.Modules))
 		}
 
+		expectedModulePaths := map[string]struct{}{
+			filepath.Join(rootDir, "foo/policy.rego"): {},
+			filepath.Join(rootDir, "base.rego"):       {},
+		}
+		for _, mf := range b.Modules {
+			if _, found := expectedModulePaths[mf.Path]; !found {
+				t.Errorf("Unexpected module file with path %s in bundle modules", mf.Path)
+			}
+		}
+
 		expectedData := util.MustUnmarshalJSON([]byte(`{"foo": [1,2,3]}`))
 		if !reflect.DeepEqual(b.Data, expectedData) {
 			t.Fatalf("expected data %+v, got %+v", expectedData, b.Data)


### PR DESCRIPTION
When reading a bundle from a directory we should be using the full
system path for the module files. This helps greatly with reducing
complexity of trying to read error messages. It also makes the
integration with tools like VSCode work better as they can provide
links from the console output file paths to the file in question.

This will not affect bundles loaded from tarballs.

Signed-off-by: Patrick East <east.patrick@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
