### PR TITLE
Extending REGO with hashing functions

### DIFF
--- a/ast/builtins.go
+++ b/ast/builtins.go
@@ -149,6 +149,9 @@ var DefaultBuiltins = [...]*Builtin{
 
 	// Crypto
 	CryptoX509ParseCertificates,
+	CryptoMd5,
+	CryptoSha1,
+	CryptoSha256,
 
 	// Graphs
 	WalkBuiltin,
@@ -1256,6 +1259,33 @@ var CryptoX509ParseCertificates = &Builtin{
 	Decl: types.NewFunction(
 		types.Args(types.S),
 		types.NewArray(nil, types.NewObject(nil, types.NewDynamicProperty(types.S, types.A))),
+	),
+}
+
+// CryptoMd5 returns a string representing the input string hashed with the md5 function
+var CryptoMd5 = &Builtin{
+	Name: "crypto.md5",
+	Decl: types.NewFunction(
+		types.Args(types.S),
+		types.S,
+	),
+}
+
+// CryptoSha1 returns a string representing the input string hashed with the sha1 function
+var CryptoSha1 = &Builtin{
+	Name: "crypto.sha1",
+	Decl: types.NewFunction(
+		types.Args(types.S),
+		types.S,
+	),
+}
+
+// CryptoSha256 returns a string representing the input string hashed with the sha256 function
+var CryptoSha256 = &Builtin{
+	Name: "crypto.sha256",
+	Decl: types.NewFunction(
+		types.Args(types.S),
+		types.S,
 	),
 }
 

--- a/docs/content/policy-reference.md
+++ b/docs/content/policy-reference.md
@@ -188,8 +188,8 @@ OPA provides two builtins that implement JSON Web Signature [RFC7515](https://to
  canonicalizations applied. Therefore, line breaks and whitespaces are significant.
 
 ``io.jwt.encode_sign()`` takes three Rego Objects as parameters and returns their JWS Compact Serialization. This builtin
- should be used by those that want to use rego objects for signing during policy evaluation. 
- 
+ should be used by those that want to use rego objects for signing during policy evaluation.
+
 > Note that with `io.jwt.encode_sign` the Rego objects are serialized to JSON with standard formatting applied
 > whereas the `io.jwt.encode_sign_raw` built-in will **not** affect whitespace of the strings passed in.
 > This will mean that the final encoded token may have different string values, but the decoded and parsed
@@ -502,6 +502,9 @@ Note that the opa executable will need access to the timezone files in the envir
 | Built-in | Description |
 | -------- | ----------- |
 | <span class="opa-keep-it-together">``output := crypto.x509.parse_certificates(string)``</span> | ``output`` is an array of X.509 certificates represented as JSON objects. |
+| <span class="opa-keep-it-together">``output := crypto.md5(string)``</span> | ``output`` is ``string`` md5 hashed. |
+| <span class="opa-keep-it-together">``output := crypto.sha1(string)``</span> | ``output`` is ``string`` sha1 hashed. |
+| <span class="opa-keep-it-together">``output := crypto.sha256(string)``</span> | ``output`` is ``string`` sha256 hashed. |
 
 ### Graphs
 

--- a/topdown/crypto_test.go
+++ b/topdown/crypto_test.go
@@ -58,3 +58,75 @@ func TestCryptoX509ParseCertificates(t *testing.T) {
 	}
 
 }
+
+func TestCryptoMd5(t *testing.T) {
+
+	tests := []struct {
+		note     string
+		rule     []string
+		expected interface{}
+	}{
+		{
+			note:     "crypto.md5 with string",
+			rule:     []string{`p[hash] { hash := crypto.md5("lorem ipsum") }`},
+			expected: `["80a751fde577028640c419000e33eba6"]`,
+		},
+	}
+
+	data := loadSmallTestData()
+
+	fmt.Println(data)
+
+	for _, tc := range tests {
+		runTopDownTestCase(t, data, tc.note, tc.rule, tc.expected)
+	}
+
+}
+
+func TestCryptoSha1(t *testing.T) {
+
+	tests := []struct {
+		note     string
+		rule     []string
+		expected interface{}
+	}{
+		{
+			note:     "crypto.sha1 with string",
+			rule:     []string{`p[hash] { hash := crypto.sha1("lorem ipsum") }`},
+			expected: `["bfb7759a67daeb65410490b4d98bb9da7d1ea2ce"]`,
+		},
+	}
+
+	data := loadSmallTestData()
+
+	fmt.Println(data)
+
+	for _, tc := range tests {
+		runTopDownTestCase(t, data, tc.note, tc.rule, tc.expected)
+	}
+
+}
+
+func TestCryptoSha256(t *testing.T) {
+
+	tests := []struct {
+		note     string
+		rule     []string
+		expected interface{}
+	}{
+		{
+			note:     "crypto.sha256 with string",
+			rule:     []string{`p[hash] { hash := crypto.sha256("lorem ipsum") }`},
+			expected: `["5e2bf57d3f40c4b6df69daf1936cb766f832374b4fc0259a7cbff06e2f70f269"]`,
+		},
+	}
+
+	data := loadSmallTestData()
+
+	fmt.Println(data)
+
+	for _, tc := range tests {
+		runTopDownTestCase(t, data, tc.note, tc.rule, tc.expected)
+	}
+
+}


### PR DESCRIPTION
**What**

This PR extends REGO with three hashing functions: md5, sha1, and sha256.

**Why**

Since starting using OPA, we've been struggling with exceptions. With this PR, dealing with exceptions becomes easier as the `input` can be hashed and saved in rego as part of an exception list (the example below is using conftest - see _deny[msg]_):

```rego
package pr_demo

exceptions_list = [
    "227bddb92cf471d1ca0e549cefcffa77783289be74eb4008d5b108f817669586",
    "e29b6884b1bdf94598f8a64b252323224ab037ba647aa830bf0993e7949567c0",
]

is_an_exception {
    i := sha256(json.marshal(input))
    i == exceptions_list[_]
}

whitelist_images = [
  "alpine",
]

image_is_whitelisted  {
  input[i].Cmd == "from"
  val := input[i].Value
  contains(val[0], whitelist_images[_])
}

deny[msg] {
  not is_an_exception
  not image_is_whitelisted
  msg = "The base image (FROM) in use is not whitelisted"
}

```

**Checklist**
- [x] All code changes should be accompanied with tests.
- [x] All changes to public APIs **must** be accompanied with docs.
- [x] Commit messages should explain _why_ you made the changes, not what you changed.
- [x] All commits must be signed off by the author. 