### PR TITLE
cmd/build: return error if there is more than one positional argument

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -32,8 +32,8 @@ executable that can be loaded into an enforcement point and evaluated with
 input values. By default, the build command produces WebAssembly (WASM)
 executables.`,
 	PreRunE: func(Cmd *cobra.Command, args []string) error {
-		if len(args) == 0 {
-			return fmt.Errorf("specify query argument")
+		if len(args) != 1 {
+			return fmt.Errorf("specify exactly one query argument")
 		}
 		return nil
 	},


### PR DESCRIPTION
Before, this would only return an error if there was no query argument.

However, I've run into this recently, running the erroneous command

    opa build -o out.wasm 'data.simplest.allow = x' simplest.rego

which produced no error, the resulting wasm file wasn't what I was
expecting.

With this change, the bad command line would give an error; and might
prompt the user to re-read the usage text and provide the proper command
instead,

    opa build -o out.wasm -d simplest.rego 'data.simplest.allow = x'

----

Alternatively to how it's done here, we could have provided the cobra
field

    Args: cobra.ExactArgs(1),

but the PreRunE function has a more specific error message. So, I've
taken the message from `opa deps`.

