### PR TITLE
Fix API doc indentation

### DIFF
--- a/docs/content/rest-api.md
+++ b/docs/content/rest-api.md
@@ -620,7 +620,7 @@ Create or update a policy module.
 
 If the policy module does not exist, it is created. If the policy module already exists, it is replaced.
 
-### Query Parameters
+#### Query Parameters
 
 - **pretty** - If parameter is `true`, response will formatted for humans.
 - **metrics** - Return compiler performance metrics in addition to result. See [Performance Metrics](#performance-metrics) for more detail.


### PR DESCRIPTION
fix a minor indentation issue with API doc:
  https://www.openpolicyagent.org/docs/latest/rest-api/#create-or-update-a-policy

Signed-off-by: Long Zhou <longz@vmware.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
