### PR TITLE
plugins/bundle: Pass copy of status to bulk listeners

### DIFF
--- a/plugins/bundle/plugin.go
+++ b/plugins/bundle/plugin.go
@@ -252,7 +252,15 @@ func (p *Plugin) oneShot(ctx context.Context, name string, u download.Update) {
 	}
 
 	for _, listener := range p.bulkListeners {
-		listener(p.status)
+		// Send a copy of the full status map to the bulk listeners.
+		// They shouldn't have access to the original underlying
+		// map, primarily for thread safety issues with modifications
+		// made to it.
+		statusCpy := map[string]*Status{}
+		for k, v := range p.status {
+			statusCpy[k] = v
+		}
+		listener(statusCpy)
 	}
 }
 


### PR DESCRIPTION
Previously it would pass a reference to the status map on the plugin,
which is potentially dangerous as the map can be changed (happens
explicitly on plugin reconfigure).

This now gives each bulk listener their own copy of the map.

Fixes: #1962
Signed-off-by: Patrick East <east.patrick@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
