### PR TITLE
Resolve references inside indirect references

### DIFF
--- a/ast/compile.go
+++ b/ast/compile.go
@@ -2212,7 +2212,7 @@ func resolveRef(globals map[Var]Ref, ignore *declaredVarStack, ref Ref) Ref {
 			} else {
 				r = append(r, x)
 			}
-		case Ref, Array, Object, Set:
+		case Ref, Array, Object, Set, *ArrayComprehension, *SetComprehension, *ObjectComprehension, Call:
 			r = append(r, resolveRefsInTerm(globals, ignore, x))
 		default:
 			r = append(r, x)

--- a/topdown/topdown_test.go
+++ b/topdown/topdown_test.go
@@ -927,6 +927,8 @@ func TestTopDownIndirectReferences(t *testing.T) {
 		{"array", []string{`p[x] {[1, 2, 3][x]}`}, "[0, 1, 2]"},
 		{"call", []string{`p {split("foo.bar", ".")[0] == "foo"}`}, "true"},
 		{"multiple call", []string{`p[x] {split(split("foo.bar:qux", ".")[_], ":")[i] = x}`}, `["foo", "bar", "qux"]`},
+		{"user call", []string{`f(x) = [x] {true}`, `p[x] {x = f(1)[0]}`}, "[1]"},
+		{"user call in comprehension", []string{`f(x) = [x] {true}`, `p[x] {x = [y | y = f(1)][_][_]}`}, "[1]"},
 	}
 
 	data := loadSmallTestData()


### PR DESCRIPTION
As @tsandall commented in #1868, there appeared to be a problem with
indirect references that have user-defined functions:

    > f(x) = [x] { true }
    Rule 'f' defined in package repl. Type 'show' to see rules.
    > f(1)[0]
    1 error occurred: 1:1: rego_type_error: undefined function f

The problem is that this `f` was not resolved to `data.repl.f` by the
`ResolveRefs` phase: with the new AST that supports indirect references,
we need to recursively call `ResolveRefs` in more cases.

Signed-off-by: Jasper Van der Jeugt <jasper@fugue.co>