### PR TITLE
Add memory comparison builtin.

### DIFF
--- a/ast/builtins.go
+++ b/ast/builtins.go
@@ -193,6 +193,7 @@ var DefaultBuiltins = [...]*Builtin{
 
 	// Units
 	UnitsParseBytes,
+	UnitsCompareMemory,
 }
 
 // BuiltinMap provides a convenient mapping of built-in names to
@@ -900,6 +901,18 @@ var UnitsParseBytes = &Builtin{
 	Name: "units.parse_bytes",
 	Decl: types.NewFunction(
 		types.Args(
+			types.S,
+		),
+		types.N,
+	),
+}
+
+// UnitsCompareMemory compares size of memory sizes such as 1Ei, 0.5G.
+var UnitsCompareMemory = &Builtin{
+	Name: "units.compare_memory",
+	Decl: types.NewFunction(
+		types.Args(
+			types.S,
 			types.S,
 		),
 		types.N,

--- a/docs/content/policy-reference.md
+++ b/docs/content/policy-reference.md
@@ -148,7 +148,7 @@ The following table shows examples of how ``glob.match`` works:
 | Built-in | Description |
 | --- | --- |
 | <span class="opa-keep-it-together">``output := units.parse_bytes(x)``</span> | ``output`` is ``x`` converted to a number with support for standard byte units (e.g., KB, KiB, etc.) KB, MB, GB, and TB are treated as decimal units and KiB, MiB, GiB, and TiB are treated as binary units. |
-
+| <span class="opa-keep-it-together">``output := units.compare_memory(x, y)``</span> | ``output`` is ``0`` if x is equal to y; ``-1`` if x is smaller than y and ``1`` if x is greater than y|
 ### Types
 
 | Built-in | Description |

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/gobwas/glob v0.2.3
 	github.com/gogo/protobuf v1.3.0 // indirect
 	github.com/golang/protobuf v0.0.0-20181025225059-d3de96c4c28e // indirect
+	github.com/google/gofuzz v1.0.0
 	github.com/gorilla/mux v0.0.0-20181024020800-521ea7b17d02
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
@@ -32,5 +33,6 @@ require (
 	golang.org/x/lint v0.0.0-20181023182221-1baf3a9d7d67
 	golang.org/x/tools v0.0.0-20190920225731-5eefd052ad72
 	gopkg.in/fsnotify.v1 v1.4.7
+	gopkg.in/inf.v0 v0.9.1
 	gopkg.in/yaml.v2 v2.2.1
 )

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,8 @@ github.com/gogo/protobuf v1.3.0 h1:G8O7TerXerS4F6sx9OV7/nRfJdnXgHZu/S/7F2SN+UE=
 github.com/gogo/protobuf v1.3.0/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/golang/protobuf v0.0.0-20181025225059-d3de96c4c28e h1:+RasoGgq0ljH8THLqlTAOxyz87eBeA6cx7sD0KnGQGQ=
 github.com/golang/protobuf v0.0.0-20181025225059-d3de96c4c28e/go.mod h1:Qd/q+1AKNOZr9uGQzbzCmRO6sUih6GTPZv6a1/R87v0=
+github.com/google/gofuzz v1.0.0 h1:A8PeW59pxE9IoFRqBp37U+mSNaQoZ46F1f0f863XSXw=
+github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/gorilla/mux v0.0.0-20181024020800-521ea7b17d02 h1:hsoQua/9DqRrTqNB9E0hbJLp1DctU92ZmRo3cF6reyE=
 github.com/gorilla/mux v0.0.0-20181024020800-521ea7b17d02/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
@@ -87,5 +89,7 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
+gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
+gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/yaml.v2 v2.2.1 h1:mUhvW9EsL+naU5Q3cakzfE91YhliOondGd6ZrsDBHQE=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/internal/resource/amount.go
+++ b/internal/resource/amount.go
@@ -1,0 +1,301 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import (
+	"math/big"
+	"strconv"
+
+	inf "gopkg.in/inf.v0"
+)
+
+// Scale is used for getting and setting the base-10 scaled value.
+// Base-2 scales are omitted for mathematical simplicity.
+// See Quantity.ScaledValue for more details.
+type Scale int32
+
+// infScale adapts a Scale value to an inf.Scale value.
+func (s Scale) infScale() inf.Scale {
+	return inf.Scale(-s) // inf.Scale is upside-down
+}
+
+// Scales
+const (
+	Nano  Scale = -9
+	Micro Scale = -6
+	Milli Scale = -3
+	Kilo  Scale = 3
+	Mega  Scale = 6
+	Giga  Scale = 9
+	Tera  Scale = 12
+	Peta  Scale = 15
+	Exa   Scale = 18
+)
+
+// Zero bytes
+var (
+	Zero = int64Amount{}
+
+	// Used by quantity strings - treat as read only
+	zeroBytes = []byte("0")
+)
+
+// int64Amount represents a fixed precision numerator and arbitrary scale exponent. It is faster
+// than operations on inf.Dec for values that can be represented as int64.
+// +k8s:openapi-gen=true
+type int64Amount struct {
+	value int64
+	scale Scale
+}
+
+// Sign returns 0 if the value is zero, -1 if it is less than 0, or 1 if it is greater than 0.
+func (a int64Amount) Sign() int {
+	switch {
+	case a.value == 0:
+		return 0
+	case a.value > 0:
+		return 1
+	default:
+		return -1
+	}
+}
+
+// AsInt64 returns the current amount as an int64 at scale 0, or false if the value cannot be
+// represented in an int64 OR would result in a loss of precision. This method is intended as
+// an optimization to avoid calling AsDec.
+func (a int64Amount) AsInt64() (int64, bool) {
+	if a.scale == 0 {
+		return a.value, true
+	}
+	if a.scale < 0 {
+		// TODO: attempt to reduce factors, although it is assumed that factors are reduced prior
+		// to the int64Amount being created.
+		return 0, false
+	}
+	return positiveScaleInt64(a.value, a.scale)
+}
+
+// AsScaledInt64 returns an int64 representing the value of this amount at the specified scale,
+// rounding up, or false if that would result in overflow. (1e20).AsScaledInt64(1) would result
+// in overflow because 1e19 is not representable as an int64. Note that setting a scale larger
+// than the current value may result in loss of precision - i.e. (1e-6).AsScaledInt64(0) would
+// return 1, because 0.000001 is rounded up to 1.
+func (a int64Amount) AsScaledInt64(scale Scale) (result int64, ok bool) {
+	if a.scale < scale {
+		result, _ = negativeScaleInt64(a.value, scale-a.scale)
+		return result, true
+	}
+	return positiveScaleInt64(a.value, a.scale-scale)
+}
+
+// AsDec returns an inf.Dec representation of this value.
+func (a int64Amount) AsDec() *inf.Dec {
+	var base inf.Dec
+	base.SetUnscaled(a.value)
+	base.SetScale(inf.Scale(-a.scale))
+	return &base
+}
+
+// Cmp returns 0 if a and b are equal, 1 if a is greater than b, or -1 if a is less than b.
+func (a int64Amount) Cmp(b int64Amount) int {
+	switch {
+	case a.scale == b.scale:
+		// compare only the unscaled portion
+	case a.scale > b.scale:
+		result, remainder, exact := divideByScaleInt64(b.value, a.scale-b.scale)
+		if !exact {
+			return a.AsDec().Cmp(b.AsDec())
+		}
+		if result == a.value {
+			switch {
+			case remainder == 0:
+				return 0
+			case remainder > 0:
+				return -1
+			default:
+				return 1
+			}
+		}
+		b.value = result
+	default:
+		result, remainder, exact := divideByScaleInt64(a.value, b.scale-a.scale)
+		if !exact {
+			return a.AsDec().Cmp(b.AsDec())
+		}
+		if result == b.value {
+			switch {
+			case remainder == 0:
+				return 0
+			case remainder > 0:
+				return 1
+			default:
+				return -1
+			}
+		}
+		a.value = result
+	}
+
+	switch {
+	case a.value == b.value:
+		return 0
+	case a.value < b.value:
+		return -1
+	default:
+		return 1
+	}
+}
+
+// Add adds two int64Amounts together, matching scales. It will return false and not mutate
+// a if overflow or underflow would result.
+func (a *int64Amount) Add(b int64Amount) bool {
+	switch {
+	case b.value == 0:
+		return true
+	case a.value == 0:
+		a.value = b.value
+		a.scale = b.scale
+		return true
+	case a.scale == b.scale:
+		c, ok := int64Add(a.value, b.value)
+		if !ok {
+			return false
+		}
+		a.value = c
+	case a.scale > b.scale:
+		c, ok := positiveScaleInt64(a.value, a.scale-b.scale)
+		if !ok {
+			return false
+		}
+		c, ok = int64Add(c, b.value)
+		if !ok {
+			return false
+		}
+		a.scale = b.scale
+		a.value = c
+	default:
+		c, ok := positiveScaleInt64(b.value, b.scale-a.scale)
+		if !ok {
+			return false
+		}
+		c, ok = int64Add(a.value, c)
+		if !ok {
+			return false
+		}
+		a.value = c
+	}
+	return true
+}
+
+// Sub removes the value of b from the current amount, or returns false if underflow would result.
+func (a *int64Amount) Sub(b int64Amount) bool {
+	return a.Add(int64Amount{value: -b.value, scale: b.scale})
+}
+
+// AsScale adjusts this amount to set a minimum scale, rounding up, and returns true iff no precision
+// was lost. (1.1e5).AsScale(5) would return 1.1e5, but (1.1e5).AsScale(6) would return 1e6.
+func (a int64Amount) AsScale(scale Scale) (int64Amount, bool) {
+	if a.scale >= scale {
+		return a, true
+	}
+	result, exact := negativeScaleInt64(a.value, scale-a.scale)
+	return int64Amount{value: result, scale: scale}, exact
+}
+
+// AsCanonicalBytes accepts a buffer to write the base-10 string value of this field to, and returns
+// either that buffer or a larger buffer and the current exponent of the value. The value is adjusted
+// until the exponent is a multiple of 3 - i.e. 1.1e5 would return "110", 3.
+func (a int64Amount) AsCanonicalBytes(out []byte) (result []byte, exponent int32) {
+	mantissa := a.value
+	exponent = int32(a.scale)
+
+	amount, times := removeInt64Factors(mantissa, 10)
+	exponent += int32(times)
+
+	// make sure exponent is a multiple of 3
+	var ok bool
+	switch exponent % 3 {
+	case 1, -2:
+		amount, ok = int64MultiplyScale10(amount)
+		if !ok {
+			return infDecAmount{a.AsDec()}.AsCanonicalBytes(out)
+		}
+		exponent = exponent - 1
+	case 2, -1:
+		amount, ok = int64MultiplyScale100(amount)
+		if !ok {
+			return infDecAmount{a.AsDec()}.AsCanonicalBytes(out)
+		}
+		exponent = exponent - 2
+	}
+	return strconv.AppendInt(out, amount, 10), exponent
+}
+
+// AsCanonicalBase1024Bytes accepts a buffer to write the base-1024 string value of this field to, and returns
+// either that buffer or a larger buffer and the current exponent of the value. 2048 is 2 * 1024 ^ 1 and would
+// return []byte("2048"), 1.
+func (a int64Amount) AsCanonicalBase1024Bytes(out []byte) (result []byte, exponent int32) {
+	value, ok := a.AsScaledInt64(0)
+	if !ok {
+		return infDecAmount{a.AsDec()}.AsCanonicalBase1024Bytes(out)
+	}
+	amount, exponent := removeInt64Factors(value, 1024)
+	return strconv.AppendInt(out, amount, 10), exponent
+}
+
+// infDecAmount implements common operations over an inf.Dec that are specific to the quantity
+// representation.
+type infDecAmount struct {
+	*inf.Dec
+}
+
+// AsScale adjusts this amount to set a minimum scale, rounding up, and returns true iff no precision
+// was lost. (1.1e5).AsScale(5) would return 1.1e5, but (1.1e5).AsScale(6) would return 1e6.
+func (a infDecAmount) AsScale(scale Scale) (infDecAmount, bool) {
+	tmp := &inf.Dec{}
+	tmp.Round(a.Dec, scale.infScale(), inf.RoundUp)
+	return infDecAmount{tmp}, tmp.Cmp(a.Dec) == 0
+}
+
+// AsCanonicalBytes accepts a buffer to write the base-10 string value of this field to, and returns
+// either that buffer or a larger buffer and the current exponent of the value. The value is adjusted
+// until the exponent is a multiple of 3 - i.e. 1.1e5 would return "110", 3.
+func (a infDecAmount) AsCanonicalBytes(out []byte) (result []byte, exponent int32) {
+	mantissa := a.Dec.UnscaledBig()
+	exponent = int32(-a.Dec.Scale())
+	amount := big.NewInt(0).Set(mantissa)
+	// move all factors of 10 into the exponent for easy reasoning
+	amount, times := removeBigIntFactors(amount, bigTen)
+	exponent += times
+
+	// make sure exponent is a multiple of 3
+	for exponent%3 != 0 {
+		amount.Mul(amount, bigTen)
+		exponent--
+	}
+
+	return append(out, amount.String()...), exponent
+}
+
+// AsCanonicalBase1024Bytes accepts a buffer to write the base-1024 string value of this field to, and returns
+// either that buffer or a larger buffer and the current exponent of the value. 2048 is 2 * 1024 ^ 1 and would
+// return []byte("2048"), 1.
+func (a infDecAmount) AsCanonicalBase1024Bytes(out []byte) (result []byte, exponent int32) {
+	tmp := &inf.Dec{}
+	tmp.Round(a.Dec, 0, inf.RoundUp)
+	amount, exponent := removeBigIntFactors(tmp.UnscaledBig(), big1024)
+	return append(out, amount.String()...), exponent
+}

--- a/internal/resource/amount_test.go
+++ b/internal/resource/amount_test.go
@@ -1,0 +1,162 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import (
+	"testing"
+)
+
+func TestInt64AmountAsInt64(t *testing.T) {
+	for _, test := range []struct {
+		value  int64
+		scale  Scale
+		result int64
+		ok     bool
+	}{
+		{100, 0, 100, true},
+		{100, 1, 1000, true},
+		{100, -5, 0, false},
+		{100, 100, 0, false},
+	} {
+		r, ok := int64Amount{value: test.value, scale: test.scale}.AsInt64()
+		if r != test.result {
+			t.Errorf("%v: unexpected result: %d", test, r)
+		}
+		if ok != test.ok {
+			t.Errorf("%v: unexpected ok: %t", test, ok)
+		}
+	}
+}
+
+func TestInt64AmountAdd(t *testing.T) {
+	for _, test := range []struct {
+		a, b, c int64Amount
+		ok      bool
+	}{
+		{int64Amount{value: 100, scale: 1}, int64Amount{value: 10, scale: 2}, int64Amount{value: 200, scale: 1}, true},
+		{int64Amount{value: 100, scale: 1}, int64Amount{value: 1, scale: 2}, int64Amount{value: 110, scale: 1}, true},
+		{int64Amount{value: 100, scale: 1}, int64Amount{value: 1, scale: 100}, int64Amount{value: 1, scale: 100}, false},
+		{int64Amount{value: -5, scale: 2}, int64Amount{value: 50, scale: 1}, int64Amount{value: 0, scale: 1}, true},
+		{int64Amount{value: -5, scale: 2}, int64Amount{value: 5, scale: 2}, int64Amount{value: 0, scale: 2}, true},
+
+		{int64Amount{value: mostPositive, scale: -1}, int64Amount{value: 1, scale: -1}, int64Amount{value: 0, scale: -1}, false},
+		{int64Amount{value: mostPositive, scale: -1}, int64Amount{value: 0, scale: -1}, int64Amount{value: mostPositive, scale: -1}, true},
+		{int64Amount{value: mostPositive / 10, scale: 1}, int64Amount{value: 10, scale: 0}, int64Amount{value: mostPositive, scale: -1}, false},
+	} {
+		c := test.a
+		ok := c.Add(test.b)
+		if ok != test.ok {
+			t.Errorf("%v: unexpected ok: %t", test, ok)
+		}
+		if ok {
+			if c != test.c {
+				t.Errorf("%v: unexpected result: %d", test, c)
+			}
+		} else {
+			if c != test.a {
+				t.Errorf("%v: overflow addition mutated source: %d", test, c)
+			}
+		}
+
+		// addition is commutative
+		c = test.b
+		if ok := c.Add(test.a); ok != test.ok {
+			t.Errorf("%v: unexpected ok: %t", test, ok)
+		}
+		if ok {
+			if c != test.c {
+				t.Errorf("%v: unexpected result: %d", test, c)
+			}
+		} else {
+			if c != test.b {
+				t.Errorf("%v: overflow addition mutated source: %d", test, c)
+			}
+		}
+	}
+}
+func TestInt64AsCanonicalString(t *testing.T) {
+	for _, test := range []struct {
+		value    int64
+		scale    Scale
+		result   string
+		exponent int32
+	}{
+		{100, 0, "100", 0},
+		{100, 1, "1", 3},
+		{100, -1, "10", 0},
+		{10800, -10, "1080", -9},
+	} {
+		r, exp := int64Amount{value: test.value, scale: test.scale}.AsCanonicalBytes(nil)
+		if string(r) != test.result {
+			t.Errorf("%v: unexpected result: %s", test, r)
+		}
+		if exp != test.exponent {
+			t.Errorf("%v: unexpected exponent: %d", test, exp)
+		}
+	}
+}
+
+func TestAmountSign(t *testing.T) {
+	table := []struct {
+		i      int64Amount
+		expect int
+	}{
+		{int64Amount{value: -50, scale: 1}, -1},
+		{int64Amount{value: 0, scale: 1}, 0},
+		{int64Amount{value: 300, scale: 1}, 1},
+		{int64Amount{value: -50, scale: -8}, -1},
+		{int64Amount{value: 50, scale: -8}, 1},
+		{int64Amount{value: 0, scale: -8}, 0},
+		{int64Amount{value: -50, scale: 0}, -1},
+		{int64Amount{value: 50, scale: 0}, 1},
+		{int64Amount{value: 0, scale: 0}, 0},
+	}
+	for _, testCase := range table {
+		if result := testCase.i.Sign(); result != testCase.expect {
+			t.Errorf("i: %v, Expected: %v, Actual: %v", testCase.i, testCase.expect, result)
+		}
+	}
+}
+
+func TestInt64AmountAsScaledInt64(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		i      int64Amount
+		scaled Scale
+		result int64
+		ok     bool
+	}{
+		{"test when i.scale < scaled ", int64Amount{value: 100, scale: 0}, 5, 1, true},
+		{"test when i.scale = scaled", int64Amount{value: 100, scale: 1}, 1, 100, true},
+		{"test when i.scale > scaled and result doesn't overflow", int64Amount{value: 100, scale: 5}, 2, 100000, true},
+		{"test when i.scale > scaled and result overflows", int64Amount{value: 876, scale: 30}, 4, 0, false},
+		{"test when i.scale < 0 and fraction exists", int64Amount{value: 93, scale: -1}, 0, 10, true},
+		{"test when i.scale < 0 and fraction doesn't exist", int64Amount{value: 100, scale: -1}, 0, 10, true},
+		{"test when i.value < 0 and fraction exists", int64Amount{value: -1932, scale: 2}, 4, -20, true},
+		{"test when i.value < 0 and fraction doesn't exists", int64Amount{value: -1900, scale: 2}, 4, -19, true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			r, ok := test.i.AsScaledInt64(test.scaled)
+			if r != test.result {
+				t.Errorf("%v: expected result: %d, got result: %d", test.name, test.result, r)
+			}
+			if ok != test.ok {
+				t.Errorf("%v: expected ok: %t, got ok: %t", test.name, test.ok, ok)
+			}
+		})
+	}
+}

--- a/internal/resource/math.go
+++ b/internal/resource/math.go
@@ -1,0 +1,314 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import (
+	"math/big"
+
+	inf "gopkg.in/inf.v0"
+)
+
+const (
+	// maxInt64Factors is the highest value that will be checked when removing factors of 10 from an int64.
+	// It is also the maximum decimal digits that can be represented with an int64.
+	maxInt64Factors = 18
+)
+
+var (
+	// Commonly needed big.Int values-- treat as read only!
+	bigTen      = big.NewInt(10)
+	bigZero     = big.NewInt(0)
+	bigOne      = big.NewInt(1)
+	bigThousand = big.NewInt(1000)
+	big1024     = big.NewInt(1024)
+
+	// Commonly needed inf.Dec values-- treat as read only!
+	decZero      = inf.NewDec(0, 0)
+	decOne       = inf.NewDec(1, 0)
+	decMinusOne  = inf.NewDec(-1, 0)
+	decThousand  = inf.NewDec(1000, 0)
+	dec1024      = inf.NewDec(1024, 0)
+	decMinus1024 = inf.NewDec(-1024, 0)
+
+	// Largest (in magnitude) number allowed.
+	maxAllowed = infDecAmount{inf.NewDec((1<<63)-1, 0)} // == max int64
+
+	// MaxMilliValue is the maximum value we can represent milli-units for.
+	// Compare with the return value of Quantity.Value() to
+	// see if it's safe to use Quantity.MilliValue().
+	MaxMilliValue = int64(((1 << 63) - 1) / 1000)
+)
+
+const mostNegative = -(mostPositive + 1)
+const mostPositive = 1<<63 - 1
+
+// int64Add returns a+b, or false if that would overflow int64.
+func int64Add(a, b int64) (int64, bool) {
+	c := a + b
+	switch {
+	case a > 0 && b > 0:
+		if c < 0 {
+			return 0, false
+		}
+	case a < 0 && b < 0:
+		if c > 0 {
+			return 0, false
+		}
+		if a == mostNegative && b == mostNegative {
+			return 0, false
+		}
+	}
+	return c, true
+}
+
+// int64Multiply returns a*b, or false if that would overflow or underflow int64.
+func int64Multiply(a, b int64) (int64, bool) {
+	if a == 0 || b == 0 || a == 1 || b == 1 {
+		return a * b, true
+	}
+	if a == mostNegative || b == mostNegative {
+		return 0, false
+	}
+	c := a * b
+	return c, c/b == a
+}
+
+// int64MultiplyScale returns a*b, assuming b is greater than one, or false if that would overflow or underflow int64.
+// Use when b is known to be greater than one.
+func int64MultiplyScale(a int64, b int64) (int64, bool) {
+	if a == 0 || a == 1 {
+		return a * b, true
+	}
+	if a == mostNegative && b != 1 {
+		return 0, false
+	}
+	c := a * b
+	return c, c/b == a
+}
+
+// int64MultiplyScale10 multiplies a by 10, or returns false if that would overflow. This method is faster than
+// int64Multiply(a, 10) because the compiler can optimize constant factor multiplication.
+func int64MultiplyScale10(a int64) (int64, bool) {
+	if a == 0 || a == 1 {
+		return a * 10, true
+	}
+	if a == mostNegative {
+		return 0, false
+	}
+	c := a * 10
+	return c, c/10 == a
+}
+
+// int64MultiplyScale100 multiplies a by 100, or returns false if that would overflow. This method is faster than
+// int64Multiply(a, 100) because the compiler can optimize constant factor multiplication.
+func int64MultiplyScale100(a int64) (int64, bool) {
+	if a == 0 || a == 1 {
+		return a * 100, true
+	}
+	if a == mostNegative {
+		return 0, false
+	}
+	c := a * 100
+	return c, c/100 == a
+}
+
+// int64MultiplyScale1000 multiplies a by 1000, or returns false if that would overflow. This method is faster than
+// int64Multiply(a, 1000) because the compiler can optimize constant factor multiplication.
+func int64MultiplyScale1000(a int64) (int64, bool) {
+	if a == 0 || a == 1 {
+		return a * 1000, true
+	}
+	if a == mostNegative {
+		return 0, false
+	}
+	c := a * 1000
+	return c, c/1000 == a
+}
+
+// positiveScaleInt64 multiplies base by 10^scale, returning false if the
+// value overflows. Passing a negative scale is undefined.
+func positiveScaleInt64(base int64, scale Scale) (int64, bool) {
+	switch scale {
+	case 0:
+		return base, true
+	case 1:
+		return int64MultiplyScale10(base)
+	case 2:
+		return int64MultiplyScale100(base)
+	case 3:
+		return int64MultiplyScale1000(base)
+	case 6:
+		return int64MultiplyScale(base, 1000000)
+	case 9:
+		return int64MultiplyScale(base, 1000000000)
+	default:
+		value := base
+		var ok bool
+		for i := Scale(0); i < scale; i++ {
+			if value, ok = int64MultiplyScale(value, 10); !ok {
+				return 0, false
+			}
+		}
+		return value, true
+	}
+}
+
+// negativeScaleInt64 reduces base by the provided scale, rounding up, until the
+// value is zero or the scale is reached. Passing a negative scale is undefined.
+// The value returned, if not exact, is rounded away from zero.
+func negativeScaleInt64(base int64, scale Scale) (result int64, exact bool) {
+	if scale == 0 {
+		return base, true
+	}
+
+	value := base
+	var fraction bool
+	for i := Scale(0); i < scale; i++ {
+		if !fraction && value%10 != 0 {
+			fraction = true
+		}
+		value = value / 10
+		if value == 0 {
+			if fraction {
+				if base > 0 {
+					return 1, false
+				}
+				return -1, false
+			}
+			return 0, true
+		}
+	}
+	if fraction {
+		if base > 0 {
+			value++
+		} else {
+			value--
+		}
+	}
+	return value, !fraction
+}
+
+func pow10Int64(b int64) int64 {
+	switch b {
+	case 0:
+		return 1
+	case 1:
+		return 10
+	case 2:
+		return 100
+	case 3:
+		return 1000
+	case 4:
+		return 10000
+	case 5:
+		return 100000
+	case 6:
+		return 1000000
+	case 7:
+		return 10000000
+	case 8:
+		return 100000000
+	case 9:
+		return 1000000000
+	case 10:
+		return 10000000000
+	case 11:
+		return 100000000000
+	case 12:
+		return 1000000000000
+	case 13:
+		return 10000000000000
+	case 14:
+		return 100000000000000
+	case 15:
+		return 1000000000000000
+	case 16:
+		return 10000000000000000
+	case 17:
+		return 100000000000000000
+	case 18:
+		return 1000000000000000000
+	default:
+		return 0
+	}
+}
+
+// negativeScaleInt64 returns the result of dividing base by scale * 10 and the remainder, or
+// false if no such division is possible. Dividing by negative scales is undefined.
+func divideByScaleInt64(base int64, scale Scale) (result, remainder int64, exact bool) {
+	if scale == 0 {
+		return base, 0, true
+	}
+	// the max scale representable in base 10 in an int64 is 18 decimal places
+	if scale >= 18 {
+		return 0, base, false
+	}
+	divisor := pow10Int64(int64(scale))
+	return base / divisor, base % divisor, true
+}
+
+// removeInt64Factors divides in a loop; the return values have the property that
+// value == result * base ^ scale
+func removeInt64Factors(value int64, base int64) (result int64, times int32) {
+	times = 0
+	result = value
+	negative := result < 0
+	if negative {
+		result = -result
+	}
+	switch base {
+	// allow the compiler to optimize the common cases
+	case 10:
+		for result >= 10 && result%10 == 0 {
+			times++
+			result = result / 10
+		}
+	// allow the compiler to optimize the common cases
+	case 1024:
+		for result >= 1024 && result%1024 == 0 {
+			times++
+			result = result / 1024
+		}
+	default:
+		for result >= base && result%base == 0 {
+			times++
+			result = result / base
+		}
+	}
+	if negative {
+		result = -result
+	}
+	return result, times
+}
+
+// removeBigIntFactors divides in a loop; the return values have the property that
+// d == result * factor ^ times
+// d may be modified in place.
+// If d == 0, then the return values will be (0, 0)
+func removeBigIntFactors(d, factor *big.Int) (result *big.Int, times int32) {
+	q := big.NewInt(0)
+	m := big.NewInt(0)
+	for d.Cmp(bigZero) != 0 {
+		q.DivMod(d, factor, m)
+		if m.Cmp(bigZero) != 0 {
+			break
+		}
+		times++
+		d, q = q, d
+	}
+	return d, times
+}

--- a/internal/resource/math_test.go
+++ b/internal/resource/math_test.go
@@ -1,0 +1,211 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import (
+	"testing"
+)
+
+func TestDetectOverflowAdd(t *testing.T) {
+	for _, test := range []struct {
+		a, b int64
+		c    int64
+		ok   bool
+	}{
+		{0, 0, 0, true},
+		{-1, 1, 0, true},
+		{0, 1, 1, true},
+		{2, 2, 4, true},
+		{2, -2, 0, true},
+		{-2, -2, -4, true},
+
+		{mostNegative, -1, 0, false},
+		{mostNegative, 1, mostNegative + 1, true},
+		{mostPositive, -1, mostPositive - 1, true},
+		{mostPositive, 1, 0, false},
+
+		{mostNegative, mostPositive, -1, true},
+		{mostPositive, mostNegative, -1, true},
+		{mostPositive, mostPositive, 0, false},
+		{mostNegative, mostNegative, 0, false},
+
+		{-mostPositive, mostNegative, 0, false},
+		{mostNegative, -mostPositive, 0, false},
+		{-mostPositive, -mostPositive, 0, false},
+	} {
+		c, ok := int64Add(test.a, test.b)
+		if c != test.c {
+			t.Errorf("%v: unexpected result: %d", test, c)
+		}
+		if ok != test.ok {
+			t.Errorf("%v: unexpected overflow: %t", test, ok)
+		}
+		// addition is commutative
+		d, ok2 := int64Add(test.b, test.a)
+		if c != d || ok != ok2 {
+			t.Errorf("%v: not commutative: %d %t", test, d, ok2)
+		}
+	}
+}
+
+func TestDetectOverflowMultiply(t *testing.T) {
+	for _, test := range []struct {
+		a, b int64
+		c    int64
+		ok   bool
+	}{
+		{0, 0, 0, true},
+		{-1, 1, -1, true},
+		{-1, -1, 1, true},
+		{1, 1, 1, true},
+		{0, 1, 0, true},
+		{1, 0, 0, true},
+		{2, 2, 4, true},
+		{2, -2, -4, true},
+		{-2, -2, 4, true},
+
+		{mostNegative, -1, 0, false},
+		{mostNegative, 1, mostNegative, true},
+		{mostPositive, -1, -mostPositive, true},
+		{mostPositive, 1, mostPositive, true},
+
+		{mostNegative, mostPositive, 0, false},
+		{mostPositive, mostNegative, 0, false},
+		{mostPositive, mostPositive, 1, false},
+		{mostNegative, mostNegative, 0, false},
+
+		{-mostPositive, mostNegative, 0, false},
+		{mostNegative, -mostPositive, 0, false},
+		{-mostPositive, -mostPositive, 1, false},
+	} {
+		c, ok := int64Multiply(test.a, test.b)
+		if c != test.c {
+			t.Errorf("%v: unexpected result: %d", test, c)
+		}
+		if ok != test.ok {
+			t.Errorf("%v: unexpected overflow: %t", test, ok)
+		}
+		// multiplication is commutative
+		d, ok2 := int64Multiply(test.b, test.a)
+		if c != d || ok != ok2 {
+			t.Errorf("%v: not commutative: %d %t", test, d, ok2)
+		}
+	}
+}
+
+func TestDetectOverflowScale(t *testing.T) {
+	for _, a := range []int64{0, -1, 1, 10, -10, mostPositive, mostNegative, -mostPositive} {
+		for _, b := range []int64{1, 2, 10, 100, 1000, mostPositive} {
+			expect, expectOk := int64Multiply(a, b)
+
+			c, ok := int64MultiplyScale(a, b)
+			if c != expect {
+				t.Errorf("%d*%d: unexpected result: %d", a, b, c)
+			}
+			if ok != expectOk {
+				t.Errorf("%d*%d: unexpected overflow: %t", a, b, ok)
+			}
+		}
+		for _, test := range []struct {
+			base int64
+			fn   func(a int64) (int64, bool)
+		}{
+			{10, int64MultiplyScale10},
+			{100, int64MultiplyScale100},
+			{1000, int64MultiplyScale1000},
+		} {
+			expect, expectOk := int64Multiply(a, test.base)
+			c, ok := test.fn(a)
+			if c != expect {
+				t.Errorf("%d*%d: unexpected result: %d", a, test.base, c)
+			}
+			if ok != expectOk {
+				t.Errorf("%d*%d: unexpected overflow: %t", a, test.base, ok)
+			}
+		}
+	}
+}
+
+func TestRemoveInt64Factors(t *testing.T) {
+	for _, test := range []struct {
+		value  int64
+		max    int64
+		result int64
+		scale  int32
+	}{
+		{100, 10, 1, 2},
+		{100, 10, 1, 2},
+		{100, 100, 1, 1},
+		{1, 10, 1, 0},
+	} {
+		r, s := removeInt64Factors(test.value, test.max)
+		if r != test.result {
+			t.Errorf("%v: unexpected result: %d", test, r)
+		}
+		if s != test.scale {
+			t.Errorf("%v: unexpected scale: %d", test, s)
+		}
+	}
+}
+
+func TestNegativeScaleInt64(t *testing.T) {
+	for _, test := range []struct {
+		base   int64
+		scale  Scale
+		result int64
+		exact  bool
+	}{
+		{1234567, 0, 1234567, true},
+		{1234567, 1, 123457, false},
+		{1234567, 2, 12346, false},
+		{1234567, 3, 1235, false},
+		{1234567, 4, 124, false},
+
+		{-1234567, 0, -1234567, true},
+		{-1234567, 1, -123457, false},
+		{-1234567, 2, -12346, false},
+		{-1234567, 3, -1235, false},
+		{-1234567, 4, -124, false},
+
+		{1000, 0, 1000, true},
+		{1000, 1, 100, true},
+		{1000, 2, 10, true},
+		{1000, 3, 1, true},
+		{1000, 4, 1, false},
+
+		{-1000, 0, -1000, true},
+		{-1000, 1, -100, true},
+		{-1000, 2, -10, true},
+		{-1000, 3, -1, true},
+		{-1000, 4, -1, false},
+
+		{0, 0, 0, true},
+		{0, 1, 0, true},
+		{0, 2, 0, true},
+
+		// negative scale is undefined behavior
+		{1000, -1, 1000, true},
+	} {
+		result, exact := negativeScaleInt64(test.base, test.scale)
+		if result != test.result {
+			t.Errorf("%v: unexpected result: %d", test, result)
+		}
+		if exact != test.exact {
+			t.Errorf("%v: unexpected exact: %t", test, exact)
+		}
+	}
+}

--- a/internal/resource/quantity.go
+++ b/internal/resource/quantity.go
@@ -1,0 +1,719 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"math/big"
+	"strconv"
+	"strings"
+
+	inf "gopkg.in/inf.v0"
+)
+
+// Quantity is a fixed-point representation of a number.
+// It provides convenient marshaling/unmarshaling in JSON and YAML,
+// in addition to String() and AsInt64() accessors.
+//
+// The serialization format is:
+//
+// <quantity>        ::= <signedNumber><suffix>
+//   (Note that <suffix> may be empty, from the "" case in <decimalSI>.)
+// <digit>           ::= 0 | 1 | ... | 9
+// <digits>          ::= <digit> | <digit><digits>
+// <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits>
+// <sign>            ::= "+" | "-"
+// <signedNumber>    ::= <number> | <sign><number>
+// <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI>
+// <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei
+//   (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)
+// <decimalSI>       ::= m | "" | k | M | G | T | P | E
+//   (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)
+// <decimalExponent> ::= "e" <signedNumber> | "E" <signedNumber>
+//
+// No matter which of the three exponent forms is used, no quantity may represent
+// a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal
+// places. Numbers larger or more precise will be capped or rounded up.
+// (E.g.: 0.1m will rounded up to 1m.)
+// This may be extended in the future if we require larger or smaller quantities.
+//
+// When a Quantity is parsed from a string, it will remember the type of suffix
+// it had, and will use the same type again when it is serialized.
+//
+// Before serializing, Quantity will be put in "canonical form".
+// This means that Exponent/suffix will be adjusted up or down (with a
+// corresponding increase or decrease in Mantissa) such that:
+//   a. No precision is lost
+//   b. No fractional digits will be emitted
+//   c. The exponent (or suffix) is as large as possible.
+// The sign will be omitted unless the number is negative.
+//
+// Examples:
+//   1.5 will be serialized as "1500m"
+//   1.5Gi will be serialized as "1536Mi"
+//
+// Note that the quantity will NEVER be internally represented by a
+// floating point number. That is the whole point of this exercise.
+//
+// Non-canonical values will still parse as long as they are well formed,
+// but will be re-emitted in their canonical form. (So always use canonical
+// form, or don't diff.)
+//
+// This format is intended to make it difficult to use these numbers without
+// writing some sort of special handling code in the hopes that that will
+// cause implementors to also use a fixed point implementation.
+//
+// +protobuf=true
+// +protobuf.embed=string
+// +protobuf.options.marshal=false
+// +protobuf.options.(gogoproto.goproto_stringer)=false
+// +k8s:deepcopy-gen=true
+// +k8s:openapi-gen=true
+type Quantity struct {
+	// i is the quantity in int64 scaled form, if d.Dec == nil
+	i int64Amount
+	// d is the quantity in inf.Dec form if d.Dec != nil
+	d infDecAmount
+	// s is the generated value of this quantity to avoid recalculation
+	s string
+
+	// Change Format at will. See the comment for Canonicalize for
+	// more details.
+	Format
+}
+
+// CanonicalValue allows a quantity amount to be converted to a string.
+type CanonicalValue interface {
+	// AsCanonicalBytes returns a byte array representing the string representation
+	// of the value mantissa and an int32 representing its exponent in base-10. Callers may
+	// pass a byte slice to the method to avoid allocations.
+	AsCanonicalBytes(out []byte) ([]byte, int32)
+	// AsCanonicalBase1024Bytes returns a byte array representing the string representation
+	// of the value mantissa and an int32 representing its exponent in base-1024. Callers
+	// may pass a byte slice to the method to avoid allocations.
+	AsCanonicalBase1024Bytes(out []byte) ([]byte, int32)
+}
+
+// Format lists the three possible formattings of a quantity.
+type Format string
+
+// Units
+const (
+	DecimalExponent = Format("DecimalExponent") // e.g., 12e6
+	BinarySI        = Format("BinarySI")        // e.g., 12Mi (12 * 2^20)
+	DecimalSI       = Format("DecimalSI")       // e.g., 12M  (12 * 10^6)
+)
+
+// MustParse turns the given string into a quantity or panics; for tests
+// or others cases where you know the string is valid.
+func MustParse(str string) Quantity {
+	q, err := ParseQuantity(str)
+	if err != nil {
+		panic(fmt.Errorf("cannot parse '%v': %v", str, err))
+	}
+	return q
+}
+
+const (
+	// splitREString is used to separate a number from its suffix; as such,
+	// this is overly permissive, but that's OK-- it will be checked later.
+	splitREString = "^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
+)
+
+// Errors that could happen while parsing a string.
+var (
+	ErrFormatWrong = errors.New("quantities must match the regular expression '" + splitREString + "'")
+	ErrNumeric     = errors.New("unable to parse numeric part of quantity")
+	ErrSuffix      = errors.New("unable to parse quantity's suffix")
+)
+
+// parseQuantityString is a fast scanner for quantity values.
+func parseQuantityString(str string) (positive bool, value, num, denom, suffix string, err error) {
+	positive = true
+	pos := 0
+	end := len(str)
+
+	// handle leading sign
+	if pos < end {
+		switch str[0] {
+		case '-':
+			positive = false
+			pos++
+		case '+':
+			pos++
+		}
+	}
+
+	// strip leading zeros
+Zeroes:
+	for i := pos; ; i++ {
+		if i >= end {
+			num = "0"
+			value = num
+			return
+		}
+		switch str[i] {
+		case '0':
+			pos++
+		default:
+			break Zeroes
+		}
+	}
+
+	// extract the numerator
+Num:
+	for i := pos; ; i++ {
+		if i >= end {
+			num = str[pos:end]
+			value = str[0:end]
+			return
+		}
+		switch str[i] {
+		case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
+		default:
+			num = str[pos:i]
+			pos = i
+			break Num
+		}
+	}
+
+	// if we stripped all numerator positions, always return 0
+	if len(num) == 0 {
+		num = "0"
+	}
+
+	// handle a denominator
+	if pos < end && str[pos] == '.' {
+		pos++
+	Denom:
+		for i := pos; ; i++ {
+			if i >= end {
+				denom = str[pos:end]
+				value = str[0:end]
+				return
+			}
+			switch str[i] {
+			case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
+			default:
+				denom = str[pos:i]
+				pos = i
+				break Denom
+			}
+		}
+		// TODO: we currently allow 1.G, but we may not want to in the future.
+		// if len(denom) == 0 {
+		// 	err = ErrFormatWrong
+		// 	return
+		// }
+	}
+	value = str[0:pos]
+
+	// grab the elements of the suffix
+	suffixStart := pos
+	for i := pos; ; i++ {
+		if i >= end {
+			suffix = str[suffixStart:end]
+			return
+		}
+		if !strings.ContainsAny(str[i:i+1], "eEinumkKMGTP") {
+			pos = i
+			break
+		}
+	}
+	if pos < end {
+		switch str[pos] {
+		case '-', '+':
+			pos++
+		}
+	}
+Suffix:
+	for i := pos; ; i++ {
+		if i >= end {
+			suffix = str[suffixStart:end]
+			return
+		}
+		switch str[i] {
+		case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
+		default:
+			break Suffix
+		}
+	}
+	// we encountered a non decimal in the Suffix loop, but the last character
+	// was not a valid exponent
+	err = ErrFormatWrong
+	return
+}
+
+// ParseQuantity turns str into a Quantity, or returns an error.
+func ParseQuantity(str string) (Quantity, error) {
+	if len(str) == 0 {
+		return Quantity{}, ErrFormatWrong
+	}
+	if str == "0" {
+		return Quantity{Format: DecimalSI, s: str}, nil
+	}
+
+	positive, value, num, denom, suf, err := parseQuantityString(str)
+	if err != nil {
+		return Quantity{}, err
+	}
+
+	base, exponent, format, ok := quantitySuffixer.interpret(suffix(suf))
+	if !ok {
+		return Quantity{}, ErrSuffix
+	}
+
+	precision := int32(0)
+	scale := int32(0)
+	mantissa := int64(1)
+	switch format {
+	case DecimalExponent, DecimalSI:
+		scale = exponent
+		precision = maxInt64Factors - int32(len(num)+len(denom))
+	case BinarySI:
+		scale = 0
+		switch {
+		case exponent >= 0 && len(denom) == 0:
+			// only handle positive binary numbers with the fast path
+			mantissa = int64(int64(mantissa) << uint64(exponent))
+			// 1Mi (2^20) has ~6 digits of decimal precision, so exponent*3/10 -1 is roughly the precision
+			precision = 15 - int32(len(num)) - int32(float32(exponent)*3/10) - 1
+		default:
+			precision = -1
+		}
+	}
+
+	if precision >= 0 {
+		// if we have a denominator, shift the entire value to the left by the number of places in the
+		// denominator
+		scale -= int32(len(denom))
+		if scale >= int32(Nano) {
+			shifted := num + denom
+
+			var value int64
+			value, err := strconv.ParseInt(shifted, 10, 64)
+			if err != nil {
+				return Quantity{}, ErrNumeric
+			}
+			if result, ok := int64Multiply(value, int64(mantissa)); ok {
+				if !positive {
+					result = -result
+				}
+				// if the number is in canonical form, reuse the string
+				switch format {
+				case BinarySI:
+					if exponent%10 == 0 && (value&0x07 != 0) {
+						return Quantity{i: int64Amount{value: result, scale: Scale(scale)}, Format: format, s: str}, nil
+					}
+				default:
+					if scale%3 == 0 && !strings.HasSuffix(shifted, "000") && shifted[0] != '0' {
+						return Quantity{i: int64Amount{value: result, scale: Scale(scale)}, Format: format, s: str}, nil
+					}
+				}
+				return Quantity{i: int64Amount{value: result, scale: Scale(scale)}, Format: format}, nil
+			}
+		}
+	}
+
+	amount := new(inf.Dec)
+	if _, ok := amount.SetString(value); !ok {
+		return Quantity{}, ErrNumeric
+	}
+
+	// So that no one but us has to think about suffixes, remove it.
+	if base == 10 {
+		amount.SetScale(amount.Scale() + Scale(exponent).infScale())
+	} else if base == 2 {
+		// numericSuffix = 2 ** exponent
+		numericSuffix := big.NewInt(1).Lsh(bigOne, uint(exponent))
+		ub := amount.UnscaledBig()
+		amount.SetUnscaledBig(ub.Mul(ub, numericSuffix))
+	}
+
+	// Cap at min/max bounds.
+	sign := amount.Sign()
+	if sign == -1 {
+		amount.Neg(amount)
+	}
+
+	// This rounds non-zero values up to the minimum representable value, under the theory that
+	// if you want some resources, you should get some resources, even if you asked for way too small
+	// of an amount.  Arguably, this should be inf.RoundHalfUp (normal rounding), but that would have
+	// the side effect of rounding values < .5n to zero.
+	if v, ok := amount.Unscaled(); v != int64(0) || !ok {
+		amount.Round(amount, Nano.infScale(), inf.RoundUp)
+	}
+
+	// The max is just a simple cap.
+	// TODO: this prevents accumulating quantities greater than int64, for instance quota across a cluster
+	if format == BinarySI && amount.Cmp(maxAllowed.Dec) > 0 {
+		amount.Set(maxAllowed.Dec)
+	}
+
+	if format == BinarySI && amount.Cmp(decOne) < 0 && amount.Cmp(decZero) > 0 {
+		// This avoids rounding and hopefully confusion, too.
+		format = DecimalSI
+	}
+	if sign == -1 {
+		amount.Neg(amount)
+	}
+
+	return Quantity{d: infDecAmount{amount}, Format: format}, nil
+}
+
+// DeepCopy returns a deep-copy of the Quantity value.  Note that the method
+// receiver is a value, so we can mutate it in-place and return it.
+func (q Quantity) DeepCopy() Quantity {
+	if q.d.Dec != nil {
+		tmp := &inf.Dec{}
+		q.d.Dec = tmp.Set(q.d.Dec)
+	}
+	return q
+}
+
+// CanonicalizeBytes returns the canonical form of q and its suffix (see comment on Quantity).
+//
+// Note about BinarySI:
+// * If q.Format is set to BinarySI and q.Amount represents a non-zero value between
+//   -1 and +1, it will be emitted as if q.Format were DecimalSI.
+// * Otherwise, if q.Format is set to BinarySI, fractional parts of q.Amount will be
+//   rounded up. (1.1i becomes 2i.)
+func (q *Quantity) CanonicalizeBytes(out []byte) (result, suffix []byte) {
+	if q.IsZero() {
+		return zeroBytes, nil
+	}
+
+	var rounded CanonicalValue
+	format := q.Format
+	switch format {
+	case DecimalExponent, DecimalSI:
+	case BinarySI:
+		if q.CmpInt64(-1024) > 0 && q.CmpInt64(1024) < 0 {
+			// This avoids rounding and hopefully confusion, too.
+			format = DecimalSI
+		} else {
+			var exact bool
+			if rounded, exact = q.AsScale(0); !exact {
+				// Don't lose precision-- show as DecimalSI
+				format = DecimalSI
+			}
+		}
+	default:
+		format = DecimalExponent
+	}
+
+	// TODO: If BinarySI formatting is requested but would cause rounding, upgrade to
+	// one of the other formats.
+	switch format {
+	case DecimalExponent, DecimalSI:
+		number, exponent := q.AsCanonicalBytes(out)
+		suffix, _ := quantitySuffixer.constructBytes(10, exponent, format)
+		return number, suffix
+	default:
+		// format must be BinarySI
+		number, exponent := rounded.AsCanonicalBase1024Bytes(out)
+		suffix, _ := quantitySuffixer.constructBytes(2, exponent*10, format)
+		return number, suffix
+	}
+}
+
+// AsInt64 returns a representation of the current value as an int64 if a fast conversion
+// is possible. If false is returned, callers must use the inf.Dec form of this quantity.
+func (q *Quantity) AsInt64() (int64, bool) {
+	if q.d.Dec != nil {
+		return 0, false
+	}
+	return q.i.AsInt64()
+}
+
+// ToDec promotes the quantity in place to use an inf.Dec representation and returns itself.
+func (q *Quantity) ToDec() *Quantity {
+	if q.d.Dec == nil {
+		q.d.Dec = q.i.AsDec()
+		q.i = int64Amount{}
+	}
+	return q
+}
+
+// AsDec returns the quantity as represented by a scaled inf.Dec.
+func (q *Quantity) AsDec() *inf.Dec {
+	if q.d.Dec != nil {
+		return q.d.Dec
+	}
+	q.d.Dec = q.i.AsDec()
+	q.i = int64Amount{}
+	return q.d.Dec
+}
+
+// AsCanonicalBytes returns the canonical byte representation of this quantity as a mantissa
+// and base 10 exponent. The out byte slice may be passed to the method to avoid an extra
+// allocation.
+func (q *Quantity) AsCanonicalBytes(out []byte) (result []byte, exponent int32) {
+	if q.d.Dec != nil {
+		return q.d.AsCanonicalBytes(out)
+	}
+	return q.i.AsCanonicalBytes(out)
+}
+
+// IsZero returns true if the quantity is equal to zero.
+func (q *Quantity) IsZero() bool {
+	if q.d.Dec != nil {
+		return q.d.Dec.Sign() == 0
+	}
+	return q.i.value == 0
+}
+
+// Sign returns 0 if the quantity is zero, -1 if the quantity is less than zero, or 1 if the
+// quantity is greater than zero.
+func (q *Quantity) Sign() int {
+	if q.d.Dec != nil {
+		return q.d.Dec.Sign()
+	}
+	return q.i.Sign()
+}
+
+// AsScale returns the current value, rounded up to the provided scale, and returns
+// false if the scale resulted in a loss of precision.
+func (q *Quantity) AsScale(scale Scale) (CanonicalValue, bool) {
+	if q.d.Dec != nil {
+		return q.d.AsScale(scale)
+	}
+	return q.i.AsScale(scale)
+}
+
+// RoundUp updates the quantity to the provided scale, ensuring that the value is at
+// least 1. False is returned if the rounding operation resulted in a loss of precision.
+// Negative numbers are rounded away from zero (-9 scale 1 rounds to -10).
+func (q *Quantity) RoundUp(scale Scale) bool {
+	if q.d.Dec != nil {
+		q.s = ""
+		d, exact := q.d.AsScale(scale)
+		q.d = d
+		return exact
+	}
+	// avoid clearing the string value if we have already calculated it
+	if q.i.scale >= scale {
+		return true
+	}
+	q.s = ""
+	i, exact := q.i.AsScale(scale)
+	q.i = i
+	return exact
+}
+
+// Add adds the provide y quantity to the current value. If the current value is zero,
+// the format of the quantity will be updated to the format of y.
+func (q *Quantity) Add(y Quantity) {
+	q.s = ""
+	if q.d.Dec == nil && y.d.Dec == nil {
+		if q.i.value == 0 {
+			q.Format = y.Format
+		}
+		if q.i.Add(y.i) {
+			return
+		}
+	} else if q.IsZero() {
+		q.Format = y.Format
+	}
+	q.ToDec().d.Dec.Add(q.d.Dec, y.AsDec())
+}
+
+// Sub subtracts the provided quantity from the current value in place. If the current
+// value is zero, the format of the quantity will be updated to the format of y.
+func (q *Quantity) Sub(y Quantity) {
+	q.s = ""
+	if q.IsZero() {
+		q.Format = y.Format
+	}
+	if q.d.Dec == nil && y.d.Dec == nil && q.i.Sub(y.i) {
+		return
+	}
+	q.ToDec().d.Dec.Sub(q.d.Dec, y.AsDec())
+}
+
+// Cmp returns 0 if the quantity is equal to y, -1 if the quantity is less than y, or 1 if the
+// quantity is greater than y.
+func (q *Quantity) Cmp(y Quantity) int {
+	if q.d.Dec == nil && y.d.Dec == nil {
+		return q.i.Cmp(y.i)
+	}
+	return q.AsDec().Cmp(y.AsDec())
+}
+
+// CmpInt64 returns 0 if the quantity is equal to y, -1 if the quantity is less than y, or 1 if the
+// quantity is greater than y.
+func (q *Quantity) CmpInt64(y int64) int {
+	if q.d.Dec != nil {
+		return q.d.Dec.Cmp(inf.NewDec(y, inf.Scale(0)))
+	}
+	return q.i.Cmp(int64Amount{value: y})
+}
+
+// Neg sets quantity to be the negative value of itself.
+func (q *Quantity) Neg() {
+	q.s = ""
+	if q.d.Dec == nil {
+		q.i.value = -q.i.value
+		return
+	}
+	q.d.Dec.Neg(q.d.Dec)
+}
+
+// Equal checks equality of two Quantities. This is useful for testing with
+// cmp.Equal.
+func (q Quantity) Equal(v Quantity) bool {
+	return q.Cmp(v) == 0
+}
+
+// int64QuantityExpectedBytes is the expected width in bytes of the canonical string representation
+// of most Quantity values.
+const int64QuantityExpectedBytes = 18
+
+// String formats the Quantity as a string, caching the result if not calculated.
+// String is an expensive operation and caching this result significantly reduces the cost of
+// normal parse / marshal operations on Quantity.
+func (q *Quantity) String() string {
+	if len(q.s) == 0 {
+		result := make([]byte, 0, int64QuantityExpectedBytes)
+		number, suffix := q.CanonicalizeBytes(result)
+		number = append(number, suffix...)
+		q.s = string(number)
+	}
+	return q.s
+}
+
+// MarshalJSON implements the json.Marshaller interface.
+func (q Quantity) MarshalJSON() ([]byte, error) {
+	if len(q.s) > 0 {
+		out := make([]byte, len(q.s)+2)
+		out[0], out[len(out)-1] = '"', '"'
+		copy(out[1:], q.s)
+		return out, nil
+	}
+	result := make([]byte, int64QuantityExpectedBytes, int64QuantityExpectedBytes)
+	result[0] = '"'
+	number, suffix := q.CanonicalizeBytes(result[1:1])
+	// if the same slice was returned to us that we passed in, avoid another allocation by copying number into
+	// the source slice and returning that
+	if len(number) > 0 && &number[0] == &result[1] && (len(number)+len(suffix)+2) <= int64QuantityExpectedBytes {
+		number = append(number, suffix...)
+		number = append(number, '"')
+		return result[:1+len(number)], nil
+	}
+	// if CanonicalizeBytes needed more space than our slice provided, we may need to allocate again so use
+	// append
+	result = result[:1]
+	result = append(result, number...)
+	result = append(result, suffix...)
+	result = append(result, '"')
+	return result, nil
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface.
+// TODO: Remove support for leading/trailing whitespace
+func (q *Quantity) UnmarshalJSON(value []byte) error {
+	l := len(value)
+	if l == 4 && bytes.Equal(value, []byte("null")) {
+		q.d.Dec = nil
+		q.i = int64Amount{}
+		return nil
+	}
+	if l >= 2 && value[0] == '"' && value[l-1] == '"' {
+		value = value[1 : l-1]
+	}
+
+	parsed, err := ParseQuantity(strings.TrimSpace(string(value)))
+	if err != nil {
+		return err
+	}
+
+	// This copy is safe because parsed will not be referred to again.
+	*q = parsed
+	return nil
+}
+
+// NewQuantity returns a new Quantity representing the given
+// value in the given format.
+func NewQuantity(value int64, format Format) *Quantity {
+	return &Quantity{
+		i:      int64Amount{value: value},
+		Format: format,
+	}
+}
+
+// NewMilliQuantity returns a new Quantity representing the given
+// value * 1/1000 in the given format. Note that BinarySI formatting
+// will round fractional values, and will be changed to DecimalSI for
+// values x where (-1 < x < 1) && (x != 0).
+func NewMilliQuantity(value int64, format Format) *Quantity {
+	return &Quantity{
+		i:      int64Amount{value: value, scale: -3},
+		Format: format,
+	}
+}
+
+// NewScaledQuantity returns a new Quantity representing the given
+// value * 10^scale in DecimalSI format.
+func NewScaledQuantity(value int64, scale Scale) *Quantity {
+	return &Quantity{
+		i:      int64Amount{value: value, scale: scale},
+		Format: DecimalSI,
+	}
+}
+
+// Value returns the unscaled value of q rounded up to the nearest integer away from 0.
+func (q *Quantity) Value() int64 {
+	return q.ScaledValue(0)
+}
+
+// MilliValue returns the value of ceil(q * 1000); this could overflow an int64;
+// if that's a concern, call Value() first to verify the number is small enough.
+func (q *Quantity) MilliValue() int64 {
+	return q.ScaledValue(Milli)
+}
+
+// ScaledValue returns the value of ceil(q / 10^scale).
+// For example, NewQuantity(1, DecimalSI).ScaledValue(Milli) returns 1000.
+// This could overflow an int64.
+// To detect overflow, call Value() first and verify the expected magnitude.
+func (q *Quantity) ScaledValue(scale Scale) int64 {
+	if q.d.Dec == nil {
+		i, _ := q.i.AsScaledInt64(scale)
+		return i
+	}
+	dec := q.d.Dec
+	return scaledValue(dec.UnscaledBig(), int(dec.Scale()), int(scale.infScale()))
+}
+
+// Set sets q's value to be value.
+func (q *Quantity) Set(value int64) {
+	q.SetScaled(value, 0)
+}
+
+// SetMilli sets q's value to be value * 1/1000.
+func (q *Quantity) SetMilli(value int64) {
+	q.SetScaled(value, Milli)
+}
+
+// SetScaled sets q's value to be value * 10^scale
+func (q *Quantity) SetScaled(value int64, scale Scale) {
+	q.s = ""
+	q.d.Dec = nil
+	q.i = int64Amount{value: value, scale: scale}
+}

--- a/internal/resource/quantity_test.go
+++ b/internal/resource/quantity_test.go
@@ -1,0 +1,1353 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import (
+	"encoding/json"
+	"math/rand"
+	"strings"
+	"testing"
+	"unicode"
+
+	fuzz "github.com/google/gofuzz"
+
+	inf "gopkg.in/inf.v0"
+)
+
+func amount(i int64, exponent int) infDecAmount {
+	// See the below test-- scale is the negative of an exponent.
+	return infDecAmount{inf.NewDec(i, inf.Scale(-exponent))}
+}
+
+func dec(i int64, exponent int) infDecAmount {
+	// See the below test-- scale is the negative of an exponent.
+	return infDecAmount{inf.NewDec(i, inf.Scale(-exponent))}
+}
+
+func decQuantity(i int64, exponent int, format Format) Quantity {
+	return Quantity{d: dec(i, exponent), Format: format}
+}
+
+func intQuantity(i int64, exponent Scale, format Format) Quantity {
+	return Quantity{i: int64Amount{value: i, scale: exponent}, Format: format}
+}
+
+func TestDec(t *testing.T) {
+	table := []struct {
+		got    infDecAmount
+		expect string
+	}{
+		{dec(1, 0), "1"},
+		{dec(1, 1), "10"},
+		{dec(5, 2), "500"},
+		{dec(8, 3), "8000"},
+		{dec(2, 0), "2"},
+		{dec(1, -1), "0.1"},
+		{dec(3, -2), "0.03"},
+		{dec(4, -3), "0.004"},
+	}
+
+	for _, item := range table {
+		if e, a := item.expect, item.got.Dec.String(); e != a {
+			t.Errorf("expected %v, got %v", e, a)
+		}
+	}
+}
+
+// TestQuantityParseZero ensures that when a 0 quantity is passed, its string value is 0
+func TestQuantityParseZero(t *testing.T) {
+	zero := MustParse("0")
+	if expected, actual := "0", zero.String(); expected != actual {
+		t.Errorf("Expected %v, actual %v", expected, actual)
+	}
+}
+
+// TestQuantityParseNonNumericPanic ensures that when a non-numeric string is parsed
+// it panics
+func TestQuantityParseNonNumericPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("MustParse did not panic")
+		}
+	}()
+	_ = MustParse("Non-Numeric")
+}
+
+// TestQuantityAddZeroPreservesSuffix verifies that a suffix is preserved
+// independent of the order of operations when adding a zero and non-zero val
+func TestQuantityAddZeroPreservesSuffix(t *testing.T) {
+	testValues := []string{"100m", "1Gi"}
+	zero := MustParse("0")
+	for _, testValue := range testValues {
+		value := MustParse(testValue)
+		v1 := value.DeepCopy()
+		// ensure non-zero + zero = non-zero (suffix preserved)
+		v1.Add(zero)
+		// ensure zero + non-zero = non-zero (suffix preserved)
+		v2 := zero.DeepCopy()
+		v2.Add(value)
+
+		if v1.String() != testValue {
+			t.Errorf("Expected %v, actual %v", testValue, v1.String())
+			continue
+		}
+		if v2.String() != testValue {
+			t.Errorf("Expected %v, actual %v", testValue, v2.String())
+		}
+	}
+}
+
+// TestQuantitySubZeroPreservesSuffix verifies that a suffix is preserved
+// independent of the order of operations when subtracting a zero and non-zero val
+func TestQuantitySubZeroPreservesSuffix(t *testing.T) {
+	testValues := []string{"100m", "1Gi"}
+	zero := MustParse("0")
+	for _, testValue := range testValues {
+		value := MustParse(testValue)
+		v1 := value.DeepCopy()
+		// ensure non-zero - zero = non-zero (suffix preserved)
+		v1.Sub(zero)
+		// ensure we preserved the input value
+		if v1.String() != testValue {
+			t.Errorf("Expected %v, actual %v", testValue, v1.String())
+		}
+
+		// ensure zero - non-zero = -non-zero (suffix preserved)
+		v2 := zero.DeepCopy()
+		v2.Sub(value)
+		negVal := value.DeepCopy()
+		negVal.Neg()
+		if v2.String() != negVal.String() {
+			t.Errorf("Expected %v, actual %v", negVal.String(), v2.String())
+		}
+	}
+}
+
+// TestQuantityCanocicalizeZero verifies that you get 0 as canonical value if internal value is 0, and not 0<suffix>
+func TestQuantityCanocicalizeZero(t *testing.T) {
+	val := MustParse("1000m")
+	val.i.Sub(int64Amount{value: 1})
+	zero := Quantity{i: val.i, Format: DecimalSI}
+	if expected, actual := "0", zero.String(); expected != actual {
+		t.Errorf("Expected %v, actual %v", expected, actual)
+	}
+}
+
+func TestQuantityCmp(t *testing.T) {
+	// Test when d is nil
+	table := []struct {
+		x      string
+		y      string
+		expect int
+	}{
+		{"0", "0", 0},
+		{"100m", "50m", 1},
+		{"50m", "100m", -1},
+		{"10000T", "100Gi", 1},
+	}
+	for _, testCase := range table {
+		q1 := MustParse(testCase.x)
+		q2 := MustParse(testCase.y)
+		if result := q1.Cmp(q2); result != testCase.expect {
+			t.Errorf("X: %v, Y: %v, Expected: %v, Actual: %v", testCase.x, testCase.y, testCase.expect, result)
+		}
+	}
+	// Test when i is {0,0}
+	table2 := []struct {
+		x      *inf.Dec
+		y      *inf.Dec
+		expect int
+	}{
+		{dec(0, 0).Dec, dec(0, 0).Dec, 0},
+		{nil, dec(0, 0).Dec, 0},
+		{dec(0, 0).Dec, nil, 0},
+		{nil, nil, 0},
+		{nil, dec(10, 0).Dec, -1},
+		{nil, dec(-10, 0).Dec, 1},
+		{dec(10, 0).Dec, nil, 1},
+		{dec(-10, 0).Dec, nil, -1},
+	}
+	for _, testCase := range table2 {
+		q1 := Quantity{d: infDecAmount{testCase.x}, Format: DecimalSI}
+		q2 := Quantity{d: infDecAmount{testCase.y}, Format: DecimalSI}
+		if result := q1.Cmp(q2); result != testCase.expect {
+			t.Errorf("X: %v, Y: %v, Expected: %v, Actual: %v", testCase.x, testCase.y, testCase.expect, result)
+		}
+	}
+}
+
+func TestParseQuantityString(t *testing.T) {
+	table := []struct {
+		input              string
+		positive           bool
+		value              string
+		num, denom, suffix string
+	}{
+		{"0.025Ti", true, "0.025", "0", "025", "Ti"},
+		{"1.025Ti", true, "1.025", "1", "025", "Ti"},
+		{"-1.025Ti", false, "-1.025", "1", "025", "Ti"},
+		{".", true, ".", "0", "", ""},
+		{"-.", false, "-.", "0", "", ""},
+		{"1E-3", true, "1", "1", "", "E-3"},
+	}
+	for _, test := range table {
+		positive, value, num, denom, suffix, err := parseQuantityString(test.input)
+		if err != nil {
+			t.Errorf("%s: error: %v", test.input, err)
+			continue
+		}
+		if positive != test.positive || value != test.value || num != test.num || denom != test.denom || suffix != test.suffix {
+			t.Errorf("%s: unmatched: %t %q %q %q %q", test.input, positive, value, num, denom, suffix)
+		}
+	}
+}
+
+func TestQuantityParse(t *testing.T) {
+	if _, err := ParseQuantity(""); err == nil {
+		t.Errorf("expected empty string to return error")
+	}
+
+	table := []struct {
+		input  string
+		expect Quantity
+	}{
+		{"0", decQuantity(0, 0, DecimalSI)},
+		{"0n", decQuantity(0, 0, DecimalSI)},
+		{"0u", decQuantity(0, 0, DecimalSI)},
+		{"0m", decQuantity(0, 0, DecimalSI)},
+		{"0Ki", decQuantity(0, 0, BinarySI)},
+		{"0k", decQuantity(0, 0, DecimalSI)},
+		{"0Mi", decQuantity(0, 0, BinarySI)},
+		{"0M", decQuantity(0, 0, DecimalSI)},
+		{"0Gi", decQuantity(0, 0, BinarySI)},
+		{"0G", decQuantity(0, 0, DecimalSI)},
+		{"0Ti", decQuantity(0, 0, BinarySI)},
+		{"0T", decQuantity(0, 0, DecimalSI)},
+
+		// Quantity less numbers are allowed
+		{"1", decQuantity(1, 0, DecimalSI)},
+
+		// Binary suffixes
+		{"1Ki", decQuantity(1024, 0, BinarySI)},
+		{"8Ki", decQuantity(8*1024, 0, BinarySI)},
+		{"7Mi", decQuantity(7*1024*1024, 0, BinarySI)},
+		{"6Gi", decQuantity(6*1024*1024*1024, 0, BinarySI)},
+		{"5Ti", decQuantity(5*1024*1024*1024*1024, 0, BinarySI)},
+		{"4Pi", decQuantity(4*1024*1024*1024*1024*1024, 0, BinarySI)},
+		{"3Ei", decQuantity(3*1024*1024*1024*1024*1024*1024, 0, BinarySI)},
+
+		{"10Ti", decQuantity(10*1024*1024*1024*1024, 0, BinarySI)},
+		{"100Ti", decQuantity(100*1024*1024*1024*1024, 0, BinarySI)},
+
+		// Decimal suffixes
+		{"5n", decQuantity(5, -9, DecimalSI)},
+		{"4u", decQuantity(4, -6, DecimalSI)},
+		{"3m", decQuantity(3, -3, DecimalSI)},
+		{"9", decQuantity(9, 0, DecimalSI)},
+		{"8k", decQuantity(8, 3, DecimalSI)},
+		{"50k", decQuantity(5, 4, DecimalSI)},
+		{"7M", decQuantity(7, 6, DecimalSI)},
+		{"6G", decQuantity(6, 9, DecimalSI)},
+		{"5T", decQuantity(5, 12, DecimalSI)},
+		{"40T", decQuantity(4, 13, DecimalSI)},
+		{"300T", decQuantity(3, 14, DecimalSI)},
+		{"2P", decQuantity(2, 15, DecimalSI)},
+		{"1E", decQuantity(1, 18, DecimalSI)},
+
+		// Decimal exponents
+		{"1E-3", decQuantity(1, -3, DecimalExponent)},
+		{"1e3", decQuantity(1, 3, DecimalExponent)},
+		{"1E6", decQuantity(1, 6, DecimalExponent)},
+		{"1e9", decQuantity(1, 9, DecimalExponent)},
+		{"1E12", decQuantity(1, 12, DecimalExponent)},
+		{"1e15", decQuantity(1, 15, DecimalExponent)},
+		{"1E18", decQuantity(1, 18, DecimalExponent)},
+
+		// Nonstandard but still parsable
+		{"1e14", decQuantity(1, 14, DecimalExponent)},
+		{"1e13", decQuantity(1, 13, DecimalExponent)},
+		{"1e3", decQuantity(1, 3, DecimalExponent)},
+		{"100.035k", decQuantity(100035, 0, DecimalSI)},
+
+		// Things that look like floating point
+		{"0.001", decQuantity(1, -3, DecimalSI)},
+		{"0.0005k", decQuantity(5, -1, DecimalSI)},
+		{"0.005", decQuantity(5, -3, DecimalSI)},
+		{"0.05", decQuantity(5, -2, DecimalSI)},
+		{"0.5", decQuantity(5, -1, DecimalSI)},
+		{"0.00050k", decQuantity(5, -1, DecimalSI)},
+		{"0.00500", decQuantity(5, -3, DecimalSI)},
+		{"0.05000", decQuantity(5, -2, DecimalSI)},
+		{"0.50000", decQuantity(5, -1, DecimalSI)},
+		{"0.5e0", decQuantity(5, -1, DecimalExponent)},
+		{"0.5e-1", decQuantity(5, -2, DecimalExponent)},
+		{"0.5e-2", decQuantity(5, -3, DecimalExponent)},
+		{"0.5e0", decQuantity(5, -1, DecimalExponent)},
+		{"10.035M", decQuantity(10035, 3, DecimalSI)},
+
+		{"1.2e3", decQuantity(12, 2, DecimalExponent)},
+		{"1.3E+6", decQuantity(13, 5, DecimalExponent)},
+		{"1.40e9", decQuantity(14, 8, DecimalExponent)},
+		{"1.53E12", decQuantity(153, 10, DecimalExponent)},
+		{"1.6e15", decQuantity(16, 14, DecimalExponent)},
+		{"1.7E18", decQuantity(17, 17, DecimalExponent)},
+
+		{"9.01", decQuantity(901, -2, DecimalSI)},
+		{"8.1k", decQuantity(81, 2, DecimalSI)},
+		{"7.123456M", decQuantity(7123456, 0, DecimalSI)},
+		{"6.987654321G", decQuantity(6987654321, 0, DecimalSI)},
+		{"5.444T", decQuantity(5444, 9, DecimalSI)},
+		{"40.1T", decQuantity(401, 11, DecimalSI)},
+		{"300.2T", decQuantity(3002, 11, DecimalSI)},
+		{"2.5P", decQuantity(25, 14, DecimalSI)},
+		{"1.01E", decQuantity(101, 16, DecimalSI)},
+
+		// Things that saturate/round
+		{"3.001n", decQuantity(4, -9, DecimalSI)},
+		{"1.1E-9", decQuantity(2, -9, DecimalExponent)},
+		{"0.0000000001", decQuantity(1, -9, DecimalSI)},
+		{"0.0000000005", decQuantity(1, -9, DecimalSI)},
+		{"0.00000000050", decQuantity(1, -9, DecimalSI)},
+		{"0.5e-9", decQuantity(1, -9, DecimalExponent)},
+		{"0.9n", decQuantity(1, -9, DecimalSI)},
+		{"0.00000012345", decQuantity(124, -9, DecimalSI)},
+		{"0.00000012354", decQuantity(124, -9, DecimalSI)},
+		{"9Ei", Quantity{d: maxAllowed, Format: BinarySI}},
+		{"9223372036854775807Ki", Quantity{d: maxAllowed, Format: BinarySI}},
+		{"12E", decQuantity(12, 18, DecimalSI)},
+
+		// We'll accept fractional binary stuff, too.
+		{"100.035Ki", decQuantity(10243584, -2, BinarySI)},
+		{"0.5Mi", decQuantity(.5*1024*1024, 0, BinarySI)},
+		{"0.05Gi", decQuantity(536870912, -1, BinarySI)},
+		{"0.025Ti", decQuantity(274877906944, -1, BinarySI)},
+
+		// Things written by trolls
+		{"0.000000000001Ki", decQuantity(2, -9, DecimalSI)}, // rounds up, changes format
+		{".001", decQuantity(1, -3, DecimalSI)},
+		{".0001k", decQuantity(100, -3, DecimalSI)},
+		{"1.", decQuantity(1, 0, DecimalSI)},
+		{"1.G", decQuantity(1, 9, DecimalSI)},
+	}
+
+	for _, asDec := range []bool{false, true} {
+		for _, item := range table {
+			got, err := ParseQuantity(item.input)
+			if err != nil {
+				t.Errorf("%v: unexpected error: %v", item.input, err)
+				continue
+			}
+			if asDec {
+				got.AsDec()
+			}
+
+			if e, a := item.expect, got; e.Cmp(a) != 0 {
+				t.Errorf("%v: expected %v, got %v", item.input, e.String(), a.String())
+			}
+			if e, a := item.expect.Format, got.Format; e != a {
+				t.Errorf("%v: expected %#v, got %#v", item.input, e, a)
+			}
+
+			if asDec {
+				if i, ok := got.AsInt64(); i != 0 || ok {
+					t.Errorf("%v: expected inf.Dec to return false for AsInt64: %d", item.input, i)
+				}
+				continue
+			}
+			i, ok := item.expect.AsInt64()
+			if !ok {
+				continue
+			}
+			j, ok := got.AsInt64()
+			if !ok {
+				if got.d.Dec == nil && got.i.scale >= 0 {
+					t.Errorf("%v: is an int64Amount, but can't return AsInt64: %v", item.input, got)
+				}
+				continue
+			}
+			if i != j {
+				t.Errorf("%v: expected equivalent representation as int64: %d %d", item.input, i, j)
+			}
+		}
+
+		for _, item := range table {
+			got, err := ParseQuantity(item.input)
+			if err != nil {
+				t.Errorf("%v: unexpected error: %v", item.input, err)
+				continue
+			}
+
+			if asDec {
+				got.AsDec()
+			}
+
+			// verify that we can decompose the input and get the same result by building up from the base.
+			positive, _, num, denom, suffix, err := parseQuantityString(item.input)
+			if err != nil {
+				t.Errorf("%v: unexpected error: %v", item.input, err)
+				continue
+			}
+			if got.Sign() >= 0 && !positive || got.Sign() < 0 && positive {
+				t.Errorf("%v: positive was incorrect: %t", item.input, positive)
+				continue
+			}
+			var value string
+			if !positive {
+				value = "-"
+			}
+			value += num
+			if len(denom) > 0 {
+				value += "." + denom
+			}
+			value += suffix
+			if len(value) == 0 {
+				t.Errorf("%v: did not parse correctly, %q %q %q", item.input, num, denom, suffix)
+			}
+			expected, err := ParseQuantity(value)
+			if err != nil {
+				t.Errorf("%v: unexpected error for %s: %v", item.input, value, err)
+				continue
+			}
+			if expected.Cmp(got) != 0 {
+				t.Errorf("%v: not the same as %s", item.input, value)
+				continue
+			}
+		}
+
+		// Try the negative version of everything
+		desired := &inf.Dec{}
+		expect := Quantity{d: infDecAmount{Dec: desired}}
+		for _, item := range table {
+			got, err := ParseQuantity("-" + strings.TrimLeftFunc(item.input, unicode.IsSpace))
+			if err != nil {
+				t.Errorf("-%v: unexpected error: %v", item.input, err)
+				continue
+			}
+			if asDec {
+				got.AsDec()
+			}
+
+			expected := item.expect
+			desired.Neg(expected.AsDec())
+
+			if e, a := expect, got; e.Cmp(a) != 0 {
+				t.Errorf("%v: expected %s, got %s", item.input, e.String(), a.String())
+			}
+			if e, a := expected.Format, got.Format; e != a {
+				t.Errorf("%v: expected %#v, got %#v", item.input, e, a)
+			}
+		}
+
+		// Try everything with an explicit +
+		for _, item := range table {
+			got, err := ParseQuantity("+" + strings.TrimLeftFunc(item.input, unicode.IsSpace))
+			if err != nil {
+				t.Errorf("-%v: unexpected error: %v", item.input, err)
+				continue
+			}
+			if asDec {
+				got.AsDec()
+			}
+
+			if e, a := item.expect, got; e.Cmp(a) != 0 {
+				t.Errorf("%v(%t): expected %s, got %s", item.input, asDec, e.String(), a.String())
+			}
+			if e, a := item.expect.Format, got.Format; e != a {
+				t.Errorf("%v: expected %#v, got %#v", item.input, e, a)
+			}
+		}
+	}
+
+	invalid := []string{
+		"1.1.M",
+		"1+1.0M",
+		"0.1mi",
+		"0.1am",
+		"aoeu",
+		".5i",
+		"1i",
+		"-3.01i",
+		"-3.01e-",
+
+		// trailing whitespace is forbidden
+		" 1",
+		"1 ",
+	}
+	for _, item := range invalid {
+		_, err := ParseQuantity(item)
+		if err == nil {
+			t.Errorf("%v parsed unexpectedly", item)
+		}
+	}
+}
+
+func TestQuantityRoundUp(t *testing.T) {
+	table := []struct {
+		in     string
+		scale  Scale
+		expect Quantity
+		ok     bool
+	}{
+		{"9.01", -3, decQuantity(901, -2, DecimalSI), true},
+		{"9.01", -2, decQuantity(901, -2, DecimalSI), true},
+		{"9.01", -1, decQuantity(91, -1, DecimalSI), false},
+		{"9.01", 0, decQuantity(10, 0, DecimalSI), false},
+		{"9.01", 1, decQuantity(10, 0, DecimalSI), false},
+		{"9.01", 2, decQuantity(100, 0, DecimalSI), false},
+
+		{"-9.01", -3, decQuantity(-901, -2, DecimalSI), true},
+		{"-9.01", -2, decQuantity(-901, -2, DecimalSI), true},
+		{"-9.01", -1, decQuantity(-91, -1, DecimalSI), false},
+		{"-9.01", 0, decQuantity(-10, 0, DecimalSI), false},
+		{"-9.01", 1, decQuantity(-10, 0, DecimalSI), false},
+		{"-9.01", 2, decQuantity(-100, 0, DecimalSI), false},
+	}
+
+	for _, asDec := range []bool{false, true} {
+		for _, item := range table {
+			got, err := ParseQuantity(item.in)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			expect := item.expect.DeepCopy()
+			if asDec {
+				got.AsDec()
+			}
+			if ok := got.RoundUp(item.scale); ok != item.ok {
+				t.Errorf("%s(%d,%t): unexpected ok: %t", item.in, item.scale, asDec, ok)
+			}
+			if got.Cmp(expect) != 0 {
+				t.Errorf("%s(%d,%t): unexpected round: %s vs %s", item.in, item.scale, asDec, got.String(), expect.String())
+			}
+		}
+	}
+}
+
+func TestQuantityCmpInt64AndDec(t *testing.T) {
+	table := []struct {
+		a, b Quantity
+		cmp  int
+	}{
+		{intQuantity(901, -2, DecimalSI), intQuantity(901, -2, DecimalSI), 0},
+		{intQuantity(90, -1, DecimalSI), intQuantity(901, -2, DecimalSI), -1},
+		{intQuantity(901, -2, DecimalSI), intQuantity(900, -2, DecimalSI), 1},
+		{intQuantity(0, 0, DecimalSI), intQuantity(0, 0, DecimalSI), 0},
+		{intQuantity(0, 1, DecimalSI), intQuantity(0, -1, DecimalSI), 0},
+		{intQuantity(0, -1, DecimalSI), intQuantity(0, 1, DecimalSI), 0},
+		{intQuantity(800, -3, DecimalSI), intQuantity(1, 0, DecimalSI), -1},
+		{intQuantity(800, -3, DecimalSI), intQuantity(79, -2, DecimalSI), 1},
+
+		{intQuantity(mostPositive, 0, DecimalSI), intQuantity(1, -1, DecimalSI), 1},
+		{intQuantity(mostPositive, 1, DecimalSI), intQuantity(1, 0, DecimalSI), 1},
+		{intQuantity(mostPositive, 1, DecimalSI), intQuantity(1, 1, DecimalSI), 1},
+		{intQuantity(mostPositive, 1, DecimalSI), intQuantity(0, 1, DecimalSI), 1},
+		{intQuantity(mostPositive, -16, DecimalSI), intQuantity(1, 3, DecimalSI), -1},
+
+		{intQuantity(mostNegative, 0, DecimalSI), intQuantity(0, 0, DecimalSI), -1},
+		{intQuantity(mostNegative, -18, DecimalSI), intQuantity(-1, 0, DecimalSI), -1},
+		{intQuantity(mostNegative, -19, DecimalSI), intQuantity(-1, 0, DecimalSI), 1},
+
+		{intQuantity(1*1000000*1000000*1000000, -17, DecimalSI), intQuantity(1, 1, DecimalSI), 0},
+		{intQuantity(1*1000000*1000000*1000000, -17, DecimalSI), intQuantity(-10, 0, DecimalSI), 1},
+		{intQuantity(-1*1000000*1000000*1000000, -17, DecimalSI), intQuantity(-10, 0, DecimalSI), 0},
+		{intQuantity(1*1000000*1000000*1000000, -17, DecimalSI), intQuantity(1, 0, DecimalSI), 1},
+
+		{intQuantity(1*1000000*1000000*1000000+1, -17, DecimalSI), intQuantity(1, 1, DecimalSI), 1},
+		{intQuantity(1*1000000*1000000*1000000-1, -17, DecimalSI), intQuantity(1, 1, DecimalSI), -1},
+	}
+
+	for _, item := range table {
+		if cmp := item.a.Cmp(item.b); cmp != item.cmp {
+			t.Errorf("%#v: unexpected Cmp: %d", item, cmp)
+		}
+		if cmp := item.b.Cmp(item.a); cmp != -item.cmp {
+			t.Errorf("%#v: unexpected inverted Cmp: %d", item, cmp)
+		}
+	}
+
+	for _, item := range table {
+		a, b := item.a.DeepCopy(), item.b.DeepCopy()
+		a.AsDec()
+		if cmp := a.Cmp(b); cmp != item.cmp {
+			t.Errorf("%#v: unexpected Cmp: %d", item, cmp)
+		}
+		if cmp := b.Cmp(a); cmp != -item.cmp {
+			t.Errorf("%#v: unexpected inverted Cmp: %d", item, cmp)
+		}
+	}
+
+	for _, item := range table {
+		a, b := item.a.DeepCopy(), item.b.DeepCopy()
+		b.AsDec()
+		if cmp := a.Cmp(b); cmp != item.cmp {
+			t.Errorf("%#v: unexpected Cmp: %d", item, cmp)
+		}
+		if cmp := b.Cmp(a); cmp != -item.cmp {
+			t.Errorf("%#v: unexpected inverted Cmp: %d", item, cmp)
+		}
+	}
+
+	for _, item := range table {
+		a, b := item.a.DeepCopy(), item.b.DeepCopy()
+		a.AsDec()
+		b.AsDec()
+		if cmp := a.Cmp(b); cmp != item.cmp {
+			t.Errorf("%#v: unexpected Cmp: %d", item, cmp)
+		}
+		if cmp := b.Cmp(a); cmp != -item.cmp {
+			t.Errorf("%#v: unexpected inverted Cmp: %d", item, cmp)
+		}
+	}
+}
+
+func TestQuantityNeg(t *testing.T) {
+	table := []struct {
+		a   Quantity
+		out string
+	}{
+		{intQuantity(901, -2, DecimalSI), "-9010m"},
+		{decQuantity(901, -2, DecimalSI), "-9010m"},
+	}
+
+	for i, item := range table {
+		out := item.a.DeepCopy()
+		out.Neg()
+		if out.Cmp(item.a) == 0 {
+			t.Errorf("%d: negating an item should not mutate the source: %s", i, out.String())
+		}
+		if out.String() != item.out {
+			t.Errorf("%d: negating did not equal exact value: %s", i, out.String())
+		}
+	}
+}
+
+func TestQuantityString(t *testing.T) {
+	table := []struct {
+		in        Quantity
+		expect    string
+		alternate string
+	}{
+		{decQuantity(1024*1024*1024, 0, BinarySI), "1Gi", "1024Mi"},
+		{decQuantity(300*1024*1024, 0, BinarySI), "300Mi", "307200Ki"},
+		{decQuantity(6*1024, 0, BinarySI), "6Ki", ""},
+		{decQuantity(1001*1024*1024*1024, 0, BinarySI), "1001Gi", "1025024Mi"},
+		{decQuantity(1024*1024*1024*1024, 0, BinarySI), "1Ti", "1024Gi"},
+		{decQuantity(5, 0, BinarySI), "5", "5000m"},
+		{decQuantity(500, -3, BinarySI), "500m", "0.5"},
+		{decQuantity(1, 9, DecimalSI), "1G", "1000M"},
+		{decQuantity(1000, 6, DecimalSI), "1G", "0.001T"},
+		{decQuantity(1000000, 3, DecimalSI), "1G", ""},
+		{decQuantity(1000000000, 0, DecimalSI), "1G", ""},
+		{decQuantity(1, -3, DecimalSI), "1m", "1000u"},
+		{decQuantity(80, -3, DecimalSI), "80m", ""},
+		{decQuantity(1080, -3, DecimalSI), "1080m", "1.08"},
+		{decQuantity(108, -2, DecimalSI), "1080m", "1080000000n"},
+		{decQuantity(10800, -4, DecimalSI), "1080m", ""},
+		{decQuantity(300, 6, DecimalSI), "300M", ""},
+		{decQuantity(1, 12, DecimalSI), "1T", ""},
+		{decQuantity(1234567, 6, DecimalSI), "1234567M", ""},
+		{decQuantity(1234567, -3, BinarySI), "1234567m", ""},
+		{decQuantity(3, 3, DecimalSI), "3k", ""},
+		{decQuantity(1025, 0, BinarySI), "1025", ""},
+		{decQuantity(0, 0, DecimalSI), "0", ""},
+		{decQuantity(0, 0, BinarySI), "0", ""},
+		{decQuantity(1, 9, DecimalExponent), "1e9", ".001e12"},
+		{decQuantity(1, -3, DecimalExponent), "1e-3", "0.001e0"},
+		{decQuantity(1, -9, DecimalExponent), "1e-9", "1000e-12"},
+		{decQuantity(80, -3, DecimalExponent), "80e-3", ""},
+		{decQuantity(300, 6, DecimalExponent), "300e6", ""},
+		{decQuantity(1, 12, DecimalExponent), "1e12", ""},
+		{decQuantity(1, 3, DecimalExponent), "1e3", ""},
+		{decQuantity(3, 3, DecimalExponent), "3e3", ""},
+		{decQuantity(3, 3, DecimalSI), "3k", ""},
+		{decQuantity(0, 0, DecimalExponent), "0", "00"},
+		{decQuantity(1, -9, DecimalSI), "1n", ""},
+		{decQuantity(80, -9, DecimalSI), "80n", ""},
+		{decQuantity(1080, -9, DecimalSI), "1080n", ""},
+		{decQuantity(108, -8, DecimalSI), "1080n", ""},
+		{decQuantity(10800, -10, DecimalSI), "1080n", ""},
+		{decQuantity(1, -6, DecimalSI), "1u", ""},
+		{decQuantity(80, -6, DecimalSI), "80u", ""},
+		{decQuantity(1080, -6, DecimalSI), "1080u", ""},
+	}
+	for _, item := range table {
+		got := item.in.String()
+		if e, a := item.expect, got; e != a {
+			t.Errorf("%#v: expected %v, got %v", item.in, e, a)
+		}
+		q, err := ParseQuantity(item.expect)
+		if err != nil {
+			t.Errorf("%#v: unexpected error: %v", item.expect, err)
+		}
+		if len(q.s) == 0 || q.s != item.expect {
+			t.Errorf("%#v: did not copy canonical string on parse: %s", item.expect, q.s)
+		}
+		if len(item.alternate) == 0 {
+			continue
+		}
+		q, err = ParseQuantity(item.alternate)
+		if err != nil {
+			t.Errorf("%#v: unexpected error: %v", item.expect, err)
+			continue
+		}
+		if len(q.s) != 0 {
+			t.Errorf("%#v: unexpected nested string: %v", item.expect, q.s)
+		}
+		if q.String() != item.expect {
+			t.Errorf("%#v: unexpected alternate canonical: %v", item.expect, q.String())
+		}
+		if len(q.s) == 0 || q.s != item.expect {
+			t.Errorf("%#v: did not set canonical string on ToString: %s", item.expect, q.s)
+		}
+	}
+	desired := &inf.Dec{} // Avoid modifying the values in the table.
+	for _, item := range table {
+		if item.in.Cmp(Quantity{}) == 0 {
+			// Don't expect it to print "-0" ever
+			continue
+		}
+		q := item.in
+		q.d = infDecAmount{desired.Neg(q.AsDec())}
+		if e, a := "-"+item.expect, q.String(); e != a {
+			t.Errorf("%#v: expected %v, got %v", item.in, e, a)
+		}
+	}
+}
+
+func TestQuantityParseEmit(t *testing.T) {
+	table := []struct {
+		in     string
+		expect string
+	}{
+		{"1Ki", "1Ki"},
+		{"1Mi", "1Mi"},
+		{"1Gi", "1Gi"},
+		{"1024Mi", "1Gi"},
+		{"1000M", "1G"},
+		{".001Ki", "1024m"},
+		{".000001Ki", "1024u"},
+		{".000000001Ki", "1024n"},
+		{".000000000001Ki", "2n"},
+	}
+
+	for _, item := range table {
+		q, err := ParseQuantity(item.in)
+		if err != nil {
+			t.Errorf("Couldn't parse %v", item.in)
+			continue
+		}
+		if e, a := item.expect, q.String(); e != a {
+			t.Errorf("%#v: expected %v, got %v", item.in, e, a)
+		}
+	}
+	for _, item := range table {
+		q, err := ParseQuantity("-" + item.in)
+		if err != nil {
+			t.Errorf("Couldn't parse %v", item.in)
+			continue
+		}
+		if q.Cmp(Quantity{}) == 0 {
+			continue
+		}
+		if e, a := "-"+item.expect, q.String(); e != a {
+			t.Errorf("%#v: expected %v, got %v (%#v)", item.in, e, a, q.i)
+		}
+	}
+}
+
+var fuzzer = fuzz.New().Funcs(
+	func(q *Quantity, c fuzz.Continue) {
+		q.i = Zero
+		if c.RandBool() {
+			q.Format = BinarySI
+			if c.RandBool() {
+				dec := &inf.Dec{}
+				q.d = infDecAmount{Dec: dec}
+				dec.SetScale(0)
+				dec.SetUnscaled(c.Int63())
+				return
+			}
+			// Be sure to test cases like 1Mi
+			dec := &inf.Dec{}
+			q.d = infDecAmount{Dec: dec}
+			dec.SetScale(0)
+			dec.SetUnscaled(c.Int63n(1024) << uint(10*c.Intn(5)))
+			return
+		}
+		if c.RandBool() {
+			q.Format = DecimalSI
+		} else {
+			q.Format = DecimalExponent
+		}
+		if c.RandBool() {
+			dec := &inf.Dec{}
+			q.d = infDecAmount{Dec: dec}
+			dec.SetScale(inf.Scale(c.Intn(4)))
+			dec.SetUnscaled(c.Int63())
+			return
+		}
+		// Be sure to test cases like 1M
+		dec := &inf.Dec{}
+		q.d = infDecAmount{Dec: dec}
+		dec.SetScale(inf.Scale(3 - c.Intn(15)))
+		dec.SetUnscaled(c.Int63n(1000))
+	},
+)
+
+func TestQuantityDeepCopy(t *testing.T) {
+	// Test when d is nil
+	slice := []string{"0", "100m", "50m", "10000T"}
+	for _, testCase := range slice {
+		q := MustParse(testCase)
+		if result := q.DeepCopy(); result != q {
+			t.Errorf("Expected: %v, Actual: %v", q, result)
+		}
+	}
+	table := []*inf.Dec{
+		dec(0, 0).Dec,
+		dec(10, 0).Dec,
+		dec(-10, 0).Dec,
+	}
+	// Test when i is {0,0}
+	for _, testCase := range table {
+		q := Quantity{d: infDecAmount{testCase}, Format: DecimalSI}
+		result := q.DeepCopy()
+		if q.d.Cmp(result.AsDec()) != 0 {
+			t.Errorf("Expected: %v, Actual: %v", q.String(), result.String())
+		}
+		result = Quantity{d: infDecAmount{dec(2, 0).Dec}, Format: DecimalSI}
+		if q.d.Cmp(result.AsDec()) == 0 {
+			t.Errorf("Modifying result has affected q")
+		}
+	}
+}
+
+func TestJSON(t *testing.T) {
+	for i := 0; i < 500; i++ {
+		q := &Quantity{}
+		fuzzer.Fuzz(q)
+		b, err := json.Marshal(q)
+		if err != nil {
+			t.Errorf("error encoding %v: %v", q, err)
+			continue
+		}
+		q2 := &Quantity{}
+		err = json.Unmarshal(b, q2)
+		if err != nil {
+			t.Logf("%d: %s", i, string(b))
+			t.Errorf("%v: error decoding %v: %v", q, string(b), err)
+		}
+		if q2.Cmp(*q) != 0 {
+			t.Errorf("Expected equal: %v, %v (json was '%v')", q, q2, string(b))
+		}
+	}
+}
+
+func TestJSONWhitespace(t *testing.T) {
+	q := Quantity{}
+	testCases := []struct {
+		in     string
+		expect string
+	}{
+		{`" 1"`, "1"},
+		{`"1 "`, "1"},
+		{`1`, "1"},
+		{` 1`, "1"},
+		{`1 `, "1"},
+		{`10`, "10"},
+		{`-1`, "-1"},
+		{` -1`, "-1"},
+	}
+	for _, test := range testCases {
+		if err := json.Unmarshal([]byte(test.in), &q); err != nil {
+			t.Errorf("%q: %v", test.in, err)
+		}
+		if q.String() != test.expect {
+			t.Errorf("unexpected string: %q", q.String())
+		}
+	}
+}
+
+func TestMilliNewSet(t *testing.T) {
+	table := []struct {
+		value  int64
+		format Format
+		expect string
+		exact  bool
+	}{
+		{1, DecimalSI, "1m", true},
+		{1000, DecimalSI, "1", true},
+		{1234000, DecimalSI, "1234", true},
+		{1024, BinarySI, "1024m", false}, // Format changes
+		{1000000, "invalidFormatDefaultsToExponent", "1e3", true},
+		{1024 * 1024, BinarySI, "1048576m", false}, // Format changes
+	}
+
+	for _, item := range table {
+		q := NewMilliQuantity(item.value, item.format)
+		if e, a := item.expect, q.String(); e != a {
+			t.Errorf("Expected %v, got %v; %#v", e, a, q)
+		}
+		if !item.exact {
+			continue
+		}
+		q2, err := ParseQuantity(q.String())
+		if err != nil {
+			t.Errorf("Round trip failed on %v", q)
+		}
+		if e, a := item.value, q2.MilliValue(); e != a {
+			t.Errorf("Expected %v, got %v", e, a)
+		}
+	}
+
+	for _, item := range table {
+		q := NewQuantity(0, item.format)
+		q.SetMilli(item.value)
+		if e, a := item.expect, q.String(); e != a {
+			t.Errorf("Set: Expected %v, got %v; %#v", e, a, q)
+		}
+	}
+}
+
+func TestNewSet(t *testing.T) {
+	table := []struct {
+		value  int64
+		format Format
+		expect string
+	}{
+		{1, DecimalSI, "1"},
+		{1000, DecimalSI, "1k"},
+		{1234000, DecimalSI, "1234k"},
+		{1024, BinarySI, "1Ki"},
+		{1000000, "invalidFormatDefaultsToExponent", "1e6"},
+		{1024 * 1024, BinarySI, "1Mi"},
+	}
+
+	for _, asDec := range []bool{false, true} {
+		for _, item := range table {
+			q := NewQuantity(item.value, item.format)
+			if asDec {
+				q.ToDec()
+			}
+			if e, a := item.expect, q.String(); e != a {
+				t.Errorf("Expected %v, got %v; %#v", e, a, q)
+			}
+			q2, err := ParseQuantity(q.String())
+			if err != nil {
+				t.Errorf("Round trip failed on %v", q)
+			}
+			if e, a := item.value, q2.Value(); e != a {
+				t.Errorf("Expected %v, got %v", e, a)
+			}
+		}
+
+		for _, item := range table {
+			q := NewQuantity(0, item.format)
+			q.Set(item.value)
+			if asDec {
+				q.ToDec()
+			}
+			if e, a := item.expect, q.String(); e != a {
+				t.Errorf("Set: Expected %v, got %v; %#v", e, a, q)
+			}
+		}
+	}
+}
+
+func TestNewScaledSet(t *testing.T) {
+	table := []struct {
+		value  int64
+		scale  Scale
+		expect string
+	}{
+		{1, Nano, "1n"},
+		{1000, Nano, "1u"},
+		{1, Micro, "1u"},
+		{1000, Micro, "1m"},
+		{1, Milli, "1m"},
+		{1000, Milli, "1"},
+		{1, 0, "1"},
+		{0, Nano, "0"},
+		{0, Micro, "0"},
+		{0, Milli, "0"},
+		{0, 0, "0"},
+	}
+
+	for _, item := range table {
+		q := NewScaledQuantity(item.value, item.scale)
+		if e, a := item.expect, q.String(); e != a {
+			t.Errorf("Expected %v, got %v; %#v", e, a, q)
+		}
+		q2, err := ParseQuantity(q.String())
+		if err != nil {
+			t.Errorf("Round trip failed on %v", q)
+		}
+		if e, a := item.value, q2.ScaledValue(item.scale); e != a {
+			t.Errorf("Expected %v, got %v", e, a)
+		}
+		q3 := NewQuantity(0, DecimalSI)
+		q3.SetScaled(item.value, item.scale)
+		if q.Cmp(*q3) != 0 {
+			t.Errorf("Expected %v and %v to be equal", q, q3)
+		}
+	}
+}
+
+func TestScaledValue(t *testing.T) {
+	table := []struct {
+		fromScale Scale
+		toScale   Scale
+		expected  int64
+	}{
+		{Nano, Nano, 1},
+		{Nano, Micro, 1},
+		{Nano, Milli, 1},
+		{Nano, 0, 1},
+		{Micro, Nano, 1000},
+		{Micro, Micro, 1},
+		{Micro, Milli, 1},
+		{Micro, 0, 1},
+		{Milli, Nano, 1000 * 1000},
+		{Milli, Micro, 1000},
+		{Milli, Milli, 1},
+		{Milli, 0, 1},
+		{0, Nano, 1000 * 1000 * 1000},
+		{0, Micro, 1000 * 1000},
+		{0, Milli, 1000},
+		{0, 0, 1},
+		{2, -2, 100 * 100},
+	}
+
+	for _, item := range table {
+		q := NewScaledQuantity(1, item.fromScale)
+		if e, a := item.expected, q.ScaledValue(item.toScale); e != a {
+			t.Errorf("%v to %v: Expected %v, got %v", item.fromScale, item.toScale, e, a)
+		}
+	}
+}
+
+func TestUninitializedNoCrash(t *testing.T) {
+	var q Quantity
+
+	q.Value()
+	q.MilliValue()
+	q.DeepCopy()
+	_ = q.String()
+	q.MarshalJSON()
+}
+
+func TestDeepCopy(t *testing.T) {
+	q := NewQuantity(5, DecimalSI)
+	c := q.DeepCopy()
+	c.Set(6)
+	if q.Value() == 6 {
+		t.Errorf("Copy didn't")
+	}
+}
+
+func TestSub(t *testing.T) {
+	tests := []struct {
+		a        Quantity
+		b        Quantity
+		expected Quantity
+	}{
+		{decQuantity(10, 0, DecimalSI), decQuantity(1, 1, DecimalSI), decQuantity(0, 0, DecimalSI)},
+		{decQuantity(10, 0, DecimalSI), decQuantity(1, 0, BinarySI), decQuantity(9, 0, DecimalSI)},
+		{decQuantity(10, 0, BinarySI), decQuantity(1, 0, DecimalSI), decQuantity(9, 0, BinarySI)},
+		{Quantity{Format: DecimalSI}, decQuantity(50, 0, DecimalSI), decQuantity(-50, 0, DecimalSI)},
+		{decQuantity(50, 0, DecimalSI), Quantity{Format: DecimalSI}, decQuantity(50, 0, DecimalSI)},
+		{Quantity{Format: DecimalSI}, Quantity{Format: DecimalSI}, decQuantity(0, 0, DecimalSI)},
+	}
+
+	for i, test := range tests {
+		test.a.Sub(test.b)
+		if test.a.Cmp(test.expected) != 0 {
+			t.Errorf("[%d] Expected %q, got %q", i, test.expected.String(), test.a.String())
+		}
+	}
+}
+
+func TestNeg(t *testing.T) {
+	tests := []struct {
+		a        Quantity
+		b        Quantity
+		expected Quantity
+	}{
+		{a: intQuantity(0, 0, DecimalSI), expected: intQuantity(0, 0, DecimalSI)},
+		{a: Quantity{}, expected: Quantity{}},
+		{a: intQuantity(10, 0, BinarySI), expected: intQuantity(-10, 0, BinarySI)},
+		{a: intQuantity(-10, 0, BinarySI), expected: intQuantity(10, 0, BinarySI)},
+		{a: decQuantity(0, 0, DecimalSI), expected: intQuantity(0, 0, DecimalSI)},
+		{a: decQuantity(10, 0, BinarySI), expected: intQuantity(-10, 0, BinarySI)},
+		{a: decQuantity(-10, 0, BinarySI), expected: intQuantity(10, 0, BinarySI)},
+	}
+
+	for i, test := range tests {
+		a := test.a.DeepCopy()
+		a.Neg()
+		// ensure value is same
+		if a.Cmp(test.expected) != 0 {
+			t.Errorf("[%d] Expected %q, got %q", i, test.expected.String(), a.String())
+		}
+	}
+}
+
+func TestAdd(t *testing.T) {
+	tests := []struct {
+		a        Quantity
+		b        Quantity
+		expected Quantity
+	}{
+		{decQuantity(10, 0, DecimalSI), decQuantity(1, 1, DecimalSI), decQuantity(20, 0, DecimalSI)},
+		{decQuantity(10, 0, DecimalSI), decQuantity(1, 0, BinarySI), decQuantity(11, 0, DecimalSI)},
+		{decQuantity(10, 0, BinarySI), decQuantity(1, 0, DecimalSI), decQuantity(11, 0, BinarySI)},
+		{Quantity{Format: DecimalSI}, decQuantity(50, 0, DecimalSI), decQuantity(50, 0, DecimalSI)},
+		{decQuantity(50, 0, DecimalSI), Quantity{Format: DecimalSI}, decQuantity(50, 0, DecimalSI)},
+		{Quantity{Format: DecimalSI}, Quantity{Format: DecimalSI}, decQuantity(0, 0, DecimalSI)},
+	}
+
+	for i, test := range tests {
+		test.a.Add(test.b)
+		if test.a.Cmp(test.expected) != 0 {
+			t.Errorf("[%d] Expected %q, got %q", i, test.expected.String(), test.a.String())
+		}
+	}
+}
+
+func TestAddSubRoundTrip(t *testing.T) {
+	for k := -10; k <= 10; k++ {
+		q := Quantity{Format: DecimalSI}
+		var order []int64
+		for i := 0; i < 100; i++ {
+			j := rand.Int63()
+			order = append(order, j)
+			q.Add(*NewScaledQuantity(j, Scale(k)))
+		}
+		for _, j := range order {
+			q.Sub(*NewScaledQuantity(j, Scale(k)))
+		}
+		if !q.IsZero() {
+			t.Errorf("addition and subtraction did not cancel: %s", &q)
+		}
+	}
+}
+
+func TestAddSubRoundTripAcrossScales(t *testing.T) {
+	q := Quantity{Format: DecimalSI}
+	var order []int64
+	for i := 0; i < 100; i++ {
+		j := rand.Int63()
+		order = append(order, j)
+		q.Add(*NewScaledQuantity(j, Scale(j%20-10)))
+	}
+	for _, j := range order {
+		q.Sub(*NewScaledQuantity(j, Scale(j%20-10)))
+	}
+	if !q.IsZero() {
+		t.Errorf("addition and subtraction did not cancel: %s", &q)
+	}
+}
+
+func TestNegateRoundTrip(t *testing.T) {
+	for _, asDec := range []bool{false, true} {
+		for k := -10; k <= 10; k++ {
+			for i := 0; i < 100; i++ {
+				j := rand.Int63()
+				q := *NewScaledQuantity(j, Scale(k))
+				if asDec {
+					q.AsDec()
+				}
+
+				b := q.DeepCopy()
+				b.Neg()
+				b.Neg()
+				if b.Cmp(q) != 0 {
+					t.Errorf("double negation did not cancel: %s", &q)
+				}
+			}
+		}
+	}
+}
+func benchmarkQuantities() []Quantity {
+	return []Quantity{
+		intQuantity(1024*1024*1024, 0, BinarySI),
+		intQuantity(1024*1024*1024*1024, 0, BinarySI),
+		intQuantity(1000000, 3, DecimalSI),
+		intQuantity(1000000000, 0, DecimalSI),
+		intQuantity(1, -3, DecimalSI),
+		intQuantity(80, -3, DecimalSI),
+		intQuantity(1080, -3, DecimalSI),
+		intQuantity(0, 0, BinarySI),
+		intQuantity(1, 9, DecimalExponent),
+		intQuantity(1, -9, DecimalSI),
+		intQuantity(1000000, 10, DecimalSI),
+	}
+}
+
+func BenchmarkQuantityString(b *testing.B) {
+	values := benchmarkQuantities()
+	b.ResetTimer()
+	var s string
+	for i := 0; i < b.N; i++ {
+		q := values[i%len(values)]
+		q.s = ""
+		s = q.String()
+	}
+	b.StopTimer()
+	if len(s) == 0 {
+		b.Fatal(s)
+	}
+}
+
+func BenchmarkQuantityStringPrecalc(b *testing.B) {
+	values := benchmarkQuantities()
+	for i := range values {
+		_ = values[i].String()
+	}
+	b.ResetTimer()
+	var s string
+	for i := 0; i < b.N; i++ {
+		q := values[i%len(values)]
+		s = q.String()
+	}
+	b.StopTimer()
+	if len(s) == 0 {
+		b.Fatal(s)
+	}
+}
+
+func BenchmarkQuantityStringBinarySI(b *testing.B) {
+	values := benchmarkQuantities()
+	for i := range values {
+		values[i].Format = BinarySI
+	}
+	b.ResetTimer()
+	var s string
+	for i := 0; i < b.N; i++ {
+		q := values[i%len(values)]
+		q.s = ""
+		s = q.String()
+	}
+	b.StopTimer()
+	if len(s) == 0 {
+		b.Fatal(s)
+	}
+}
+
+func BenchmarkQuantityMarshalJSON(b *testing.B) {
+	values := benchmarkQuantities()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		q := values[i%len(values)]
+		q.s = ""
+		if _, err := q.MarshalJSON(); err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.StopTimer()
+}
+
+func BenchmarkQuantityUnmarshalJSON(b *testing.B) {
+	values := benchmarkQuantities()
+	var json [][]byte
+	for _, v := range values {
+		data, _ := v.MarshalJSON()
+		json = append(json, data)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var q Quantity
+		if err := q.UnmarshalJSON(json[i%len(values)]); err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.StopTimer()
+}
+
+func BenchmarkParseQuantity(b *testing.B) {
+	values := benchmarkQuantities()
+	var strings []string
+	for _, v := range values {
+		strings = append(strings, v.String())
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := ParseQuantity(strings[i%len(values)]); err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.StopTimer()
+}
+
+func BenchmarkCanonicalize(b *testing.B) {
+	values := benchmarkQuantities()
+	b.ResetTimer()
+	buffer := make([]byte, 0, 100)
+	for i := 0; i < b.N; i++ {
+		s, _ := values[i%len(values)].CanonicalizeBytes(buffer)
+		if len(s) == 0 {
+			b.Fatal(s)
+		}
+	}
+	b.StopTimer()
+}
+
+func BenchmarkQuantityRoundUp(b *testing.B) {
+	values := benchmarkQuantities()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		q := values[i%len(values)]
+		copied := q
+		copied.RoundUp(-3)
+	}
+	b.StopTimer()
+}
+
+func BenchmarkQuantityCopy(b *testing.B) {
+	values := benchmarkQuantities()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		values[i%len(values)].DeepCopy()
+	}
+	b.StopTimer()
+}
+
+func BenchmarkQuantityAdd(b *testing.B) {
+	values := benchmarkQuantities()
+	base := &Quantity{}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		q := values[i%len(values)]
+		base.d.Dec = nil
+		base.i = int64Amount{value: 100}
+		base.Add(q)
+	}
+	b.StopTimer()
+}
+
+func BenchmarkQuantityCmp(b *testing.B) {
+	values := benchmarkQuantities()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		q := values[i%len(values)]
+		if q.Cmp(q) != 0 {
+			b.Fatal(q)
+		}
+	}
+	b.StopTimer()
+}

--- a/internal/resource/scale_int.go
+++ b/internal/resource/scale_int.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import (
+	"math"
+	"math/big"
+	"sync"
+)
+
+var (
+	// A sync pool to reduce allocation.
+	intPool  sync.Pool
+	maxInt64 = big.NewInt(math.MaxInt64)
+)
+
+func init() {
+	intPool.New = func() interface{} {
+		return &big.Int{}
+	}
+}
+
+// scaledValue scales given unscaled value from scale to new Scale and returns
+// an int64. It ALWAYS rounds up the result when scale down. The final result might
+// overflow.
+//
+// scale, newScale represents the scale of the unscaled decimal.
+// The mathematical value of the decimal is unscaled * 10**(-scale).
+func scaledValue(unscaled *big.Int, scale, newScale int) int64 {
+	dif := scale - newScale
+	if dif == 0 {
+		return unscaled.Int64()
+	}
+
+	// Handle scale up
+	// This is an easy case, we do not need to care about rounding and overflow.
+	// If any intermediate operation causes overflow, the result will overflow.
+	if dif < 0 {
+		return unscaled.Int64() * int64(math.Pow10(-dif))
+	}
+
+	// Handle scale down
+	// We have to be careful about the intermediate operations.
+
+	// fast path when unscaled < max.Int64 and exp(10,dif) < max.Int64
+	const log10MaxInt64 = 19
+	if unscaled.Cmp(maxInt64) < 0 && dif < log10MaxInt64 {
+		divide := int64(math.Pow10(dif))
+		result := unscaled.Int64() / divide
+		mod := unscaled.Int64() % divide
+		if mod != 0 {
+			return result + 1
+		}
+		return result
+	}
+
+	// We should only convert back to int64 when getting the result.
+	divisor := intPool.Get().(*big.Int)
+	exp := intPool.Get().(*big.Int)
+	result := intPool.Get().(*big.Int)
+	defer func() {
+		intPool.Put(divisor)
+		intPool.Put(exp)
+		intPool.Put(result)
+	}()
+
+	// divisor = 10^(dif)
+	// TODO: create loop up table if exp costs too much.
+	divisor.Exp(bigTen, exp.SetInt64(int64(dif)), nil)
+	// reuse exp
+	remainder := exp
+
+	// result = unscaled / divisor
+	// remainder = unscaled % divisor
+	result.DivMod(unscaled, divisor, remainder)
+	if remainder.Sign() != 0 {
+		return result.Int64() + 1
+	}
+
+	return result.Int64()
+}

--- a/internal/resource/scale_int_test.go
+++ b/internal/resource/scale_int_test.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import (
+	"math"
+	"math/big"
+	"testing"
+)
+
+func TestScaledValueInternal(t *testing.T) {
+	tests := []struct {
+		unscaled *big.Int
+		scale    int
+		newScale int
+
+		want int64
+	}{
+		// remain scale
+		{big.NewInt(1000), 0, 0, 1000},
+
+		// scale down
+		{big.NewInt(1000), 0, -3, 1},
+		{big.NewInt(1000), 3, 0, 1},
+		{big.NewInt(0), 3, 0, 0},
+
+		// always round up
+		{big.NewInt(999), 3, 0, 1},
+		{big.NewInt(500), 3, 0, 1},
+		{big.NewInt(499), 3, 0, 1},
+		{big.NewInt(1), 3, 0, 1},
+		// large scaled value does not lose precision
+		{big.NewInt(0).Sub(maxInt64, bigOne), 1, 0, (math.MaxInt64-1)/10 + 1},
+		// large intermediate result.
+		{big.NewInt(1).Exp(big.NewInt(10), big.NewInt(100), nil), 100, 0, 1},
+
+		// scale up
+		{big.NewInt(0), 0, 3, 0},
+		{big.NewInt(1), 0, 3, 1000},
+		{big.NewInt(1), -3, 0, 1000},
+		{big.NewInt(1000), -3, 2, 100000000},
+		{big.NewInt(0).Div(big.NewInt(math.MaxInt64), bigThousand), 0, 3,
+			(math.MaxInt64 / 1000) * 1000},
+	}
+
+	for i, tt := range tests {
+		old := (&big.Int{}).Set(tt.unscaled)
+		got := scaledValue(tt.unscaled, tt.scale, tt.newScale)
+		if got != tt.want {
+			t.Errorf("#%d: got = %v, want %v", i, got, tt.want)
+		}
+		if tt.unscaled.Cmp(old) != 0 {
+			t.Errorf("#%d: unscaled = %v, want %v", i, tt.unscaled, old)
+		}
+	}
+}
+
+func BenchmarkScaledValueSmall(b *testing.B) {
+	s := big.NewInt(1000)
+	for i := 0; i < b.N; i++ {
+		scaledValue(s, 3, 0)
+	}
+}
+
+func BenchmarkScaledValueLarge(b *testing.B) {
+	s := big.NewInt(math.MaxInt64)
+	s.Mul(s, big.NewInt(1000))
+	for i := 0; i < b.N; i++ {
+		scaledValue(s, 10, 0)
+	}
+}

--- a/internal/resource/suffix.go
+++ b/internal/resource/suffix.go
@@ -1,0 +1,198 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import (
+	"strconv"
+)
+
+type suffix string
+
+// suffixer can interpret and construct suffixes.
+type suffixer interface {
+	interpret(suffix) (base, exponent int32, fmt Format, ok bool)
+	construct(base, exponent int32, fmt Format) (s suffix, ok bool)
+	constructBytes(base, exponent int32, fmt Format) (s []byte, ok bool)
+}
+
+// quantitySuffixer handles suffixes for all three formats that quantity
+// can handle.
+var quantitySuffixer = newSuffixer()
+
+type bePair struct {
+	base, exponent int32
+}
+
+type listSuffixer struct {
+	suffixToBE      map[suffix]bePair
+	beToSuffix      map[bePair]suffix
+	beToSuffixBytes map[bePair][]byte
+}
+
+func (ls *listSuffixer) addSuffix(s suffix, pair bePair) {
+	if ls.suffixToBE == nil {
+		ls.suffixToBE = map[suffix]bePair{}
+	}
+	if ls.beToSuffix == nil {
+		ls.beToSuffix = map[bePair]suffix{}
+	}
+	if ls.beToSuffixBytes == nil {
+		ls.beToSuffixBytes = map[bePair][]byte{}
+	}
+	ls.suffixToBE[s] = pair
+	ls.beToSuffix[pair] = s
+	ls.beToSuffixBytes[pair] = []byte(s)
+}
+
+func (ls *listSuffixer) lookup(s suffix) (base, exponent int32, ok bool) {
+	pair, ok := ls.suffixToBE[s]
+	if !ok {
+		return 0, 0, false
+	}
+	return pair.base, pair.exponent, true
+}
+
+func (ls *listSuffixer) construct(base, exponent int32) (s suffix, ok bool) {
+	s, ok = ls.beToSuffix[bePair{base, exponent}]
+	return
+}
+
+func (ls *listSuffixer) constructBytes(base, exponent int32) (s []byte, ok bool) {
+	s, ok = ls.beToSuffixBytes[bePair{base, exponent}]
+	return
+}
+
+type suffixHandler struct {
+	decSuffixes listSuffixer
+	binSuffixes listSuffixer
+}
+
+type fastLookup struct {
+	*suffixHandler
+}
+
+func (l fastLookup) interpret(s suffix) (base, exponent int32, format Format, ok bool) {
+	switch s {
+	case "":
+		return 10, 0, DecimalSI, true
+	case "n":
+		return 10, -9, DecimalSI, true
+	case "u":
+		return 10, -6, DecimalSI, true
+	case "m":
+		return 10, -3, DecimalSI, true
+	case "k":
+		return 10, 3, DecimalSI, true
+	case "M":
+		return 10, 6, DecimalSI, true
+	case "G":
+		return 10, 9, DecimalSI, true
+	}
+	return l.suffixHandler.interpret(s)
+}
+
+func newSuffixer() suffixer {
+	sh := &suffixHandler{}
+
+	// IMPORTANT: if you change this section you must change fastLookup
+
+	sh.binSuffixes.addSuffix("Ki", bePair{2, 10})
+	sh.binSuffixes.addSuffix("Mi", bePair{2, 20})
+	sh.binSuffixes.addSuffix("Gi", bePair{2, 30})
+	sh.binSuffixes.addSuffix("Ti", bePair{2, 40})
+	sh.binSuffixes.addSuffix("Pi", bePair{2, 50})
+	sh.binSuffixes.addSuffix("Ei", bePair{2, 60})
+	// Don't emit an error when trying to produce
+	// a suffix for 2^0.
+	sh.decSuffixes.addSuffix("", bePair{2, 0})
+
+	sh.decSuffixes.addSuffix("n", bePair{10, -9})
+	sh.decSuffixes.addSuffix("u", bePair{10, -6})
+	sh.decSuffixes.addSuffix("m", bePair{10, -3})
+	sh.decSuffixes.addSuffix("", bePair{10, 0})
+	sh.decSuffixes.addSuffix("k", bePair{10, 3})
+	sh.decSuffixes.addSuffix("M", bePair{10, 6})
+	sh.decSuffixes.addSuffix("G", bePair{10, 9})
+	sh.decSuffixes.addSuffix("T", bePair{10, 12})
+	sh.decSuffixes.addSuffix("P", bePair{10, 15})
+	sh.decSuffixes.addSuffix("E", bePair{10, 18})
+
+	return fastLookup{sh}
+}
+
+func (sh *suffixHandler) construct(base, exponent int32, fmt Format) (s suffix, ok bool) {
+	switch fmt {
+	case DecimalSI:
+		return sh.decSuffixes.construct(base, exponent)
+	case BinarySI:
+		return sh.binSuffixes.construct(base, exponent)
+	case DecimalExponent:
+		if base != 10 {
+			return "", false
+		}
+		if exponent == 0 {
+			return "", true
+		}
+		return suffix("e" + strconv.FormatInt(int64(exponent), 10)), true
+	}
+	return "", false
+}
+
+func (sh *suffixHandler) constructBytes(base, exponent int32, format Format) (s []byte, ok bool) {
+	switch format {
+	case DecimalSI:
+		return sh.decSuffixes.constructBytes(base, exponent)
+	case BinarySI:
+		return sh.binSuffixes.constructBytes(base, exponent)
+	case DecimalExponent:
+		if base != 10 {
+			return nil, false
+		}
+		if exponent == 0 {
+			return nil, true
+		}
+		result := make([]byte, 8, 8)
+		result[0] = 'e'
+		number := strconv.AppendInt(result[1:1], int64(exponent), 10)
+		if &result[1] == &number[0] {
+			return result[:1+len(number)], true
+		}
+		result = append(result[:1], number...)
+		return result, true
+	}
+	return nil, false
+}
+
+func (sh *suffixHandler) interpret(suffix suffix) (base, exponent int32, fmt Format, ok bool) {
+	// Try lookup tables first
+	if b, e, ok := sh.decSuffixes.lookup(suffix); ok {
+		return b, e, DecimalSI, true
+	}
+	if b, e, ok := sh.binSuffixes.lookup(suffix); ok {
+		return b, e, BinarySI, true
+	}
+
+	if len(suffix) > 1 && (suffix[0] == 'E' || suffix[0] == 'e') {
+		parsed, err := strconv.ParseInt(string(suffix[1:]), 10, 64)
+		if err != nil {
+			return 0, 0, DecimalExponent, false
+		}
+		return 10, int32(parsed), DecimalExponent, true
+	}
+
+	return 0, 0, DecimalExponent, false
+}

--- a/vendor/github.com/google/gofuzz/.travis.yml
+++ b/vendor/github.com/google/gofuzz/.travis.yml
@@ -1,0 +1,13 @@
+language: go
+
+go:
+  - 1.4
+  - 1.3
+  - 1.2
+  - tip
+
+install:
+  - if ! go get code.google.com/p/go.tools/cmd/cover; then go get golang.org/x/tools/cmd/cover; fi
+
+script:
+  - go test -cover

--- a/vendor/github.com/google/gofuzz/CONTRIBUTING.md
+++ b/vendor/github.com/google/gofuzz/CONTRIBUTING.md
@@ -1,0 +1,67 @@
+# How to contribute #
+
+We'd love to accept your patches and contributions to this project.  There are
+a just a few small guidelines you need to follow.
+
+
+## Contributor License Agreement ##
+
+Contributions to any Google project must be accompanied by a Contributor
+License Agreement.  This is not a copyright **assignment**, it simply gives
+Google permission to use and redistribute your contributions as part of the
+project.
+
+  * If you are an individual writing original source code and you're sure you
+    own the intellectual property, then you'll need to sign an [individual
+    CLA][].
+
+  * If you work for a company that wants to allow you to contribute your work,
+    then you'll need to sign a [corporate CLA][].
+
+You generally only need to submit a CLA once, so if you've already submitted
+one (even if it was for a different project), you probably don't need to do it
+again.
+
+[individual CLA]: https://developers.google.com/open-source/cla/individual
+[corporate CLA]: https://developers.google.com/open-source/cla/corporate
+
+
+## Submitting a patch ##
+
+  1. It's generally best to start by opening a new issue describing the bug or
+     feature you're intending to fix.  Even if you think it's relatively minor,
+     it's helpful to know what people are working on.  Mention in the initial
+     issue that you are planning to work on that bug or feature so that it can
+     be assigned to you.
+
+  1. Follow the normal process of [forking][] the project, and setup a new
+     branch to work in.  It's important that each group of changes be done in
+     separate branches in order to ensure that a pull request only includes the
+     commits related to that bug or feature.
+
+  1. Go makes it very simple to ensure properly formatted code, so always run
+     `go fmt` on your code before committing it.  You should also run
+     [golint][] over your code.  As noted in the [golint readme][], it's not
+     strictly necessary that your code be completely "lint-free", but this will
+     help you find common style issues.
+
+  1. Any significant changes should almost always be accompanied by tests.  The
+     project already has good test coverage, so look at some of the existing
+     tests if you're unsure how to go about it.  [gocov][] and [gocov-html][]
+     are invaluable tools for seeing which parts of your code aren't being
+     exercised by your tests.
+
+  1. Do your best to have [well-formed commit messages][] for each change.
+     This provides consistency throughout the project, and ensures that commit
+     messages are able to be formatted properly by various git tools.
+
+  1. Finally, push the commits to your fork and submit a [pull request][].
+
+[forking]: https://help.github.com/articles/fork-a-repo
+[golint]: https://github.com/golang/lint
+[golint readme]: https://github.com/golang/lint/blob/master/README
+[gocov]: https://github.com/axw/gocov
+[gocov-html]: https://github.com/matm/gocov-html
+[well-formed commit messages]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
+[squash]: http://git-scm.com/book/en/Git-Tools-Rewriting-History#Squashing-Commits
+[pull request]: https://help.github.com/articles/creating-a-pull-request

--- a/vendor/github.com/google/gofuzz/LICENSE
+++ b/vendor/github.com/google/gofuzz/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/google/gofuzz/README.md
+++ b/vendor/github.com/google/gofuzz/README.md
@@ -1,0 +1,71 @@
+gofuzz
+======
+
+gofuzz is a library for populating go objects with random values.
+
+[![GoDoc](https://godoc.org/github.com/google/gofuzz?status.png)](https://godoc.org/github.com/google/gofuzz)
+[![Travis](https://travis-ci.org/google/gofuzz.svg?branch=master)](https://travis-ci.org/google/gofuzz)
+
+This is useful for testing:
+
+* Do your project's objects really serialize/unserialize correctly in all cases?
+* Is there an incorrectly formatted object that will cause your project to panic?
+
+Import with ```import "github.com/google/gofuzz"```
+
+You can use it on single variables:
+```go
+f := fuzz.New()
+var myInt int
+f.Fuzz(&myInt) // myInt gets a random value.
+```
+
+You can use it on maps:
+```go
+f := fuzz.New().NilChance(0).NumElements(1, 1)
+var myMap map[ComplexKeyType]string
+f.Fuzz(&myMap) // myMap will have exactly one element.
+```
+
+Customize the chance of getting a nil pointer:
+```go
+f := fuzz.New().NilChance(.5)
+var fancyStruct struct {
+  A, B, C, D *string
+}
+f.Fuzz(&fancyStruct) // About half the pointers should be set.
+```
+
+You can even customize the randomization completely if needed:
+```go
+type MyEnum string
+const (
+        A MyEnum = "A"
+        B MyEnum = "B"
+)
+type MyInfo struct {
+        Type MyEnum
+        AInfo *string
+        BInfo *string
+}
+
+f := fuzz.New().NilChance(0).Funcs(
+        func(e *MyInfo, c fuzz.Continue) {
+                switch c.Intn(2) {
+                case 0:
+                        e.Type = A
+                        c.Fuzz(&e.AInfo)
+                case 1:
+                        e.Type = B
+                        c.Fuzz(&e.BInfo)
+                }
+        },
+)
+
+var myObject MyInfo
+f.Fuzz(&myObject) // Type will correspond to whether A or B info is set.
+```
+
+See more examples in ```example_test.go```.
+
+Happy testing!

--- a/vendor/github.com/google/gofuzz/doc.go
+++ b/vendor/github.com/google/gofuzz/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package fuzz is a library for populating go objects with random values.
+package fuzz

--- a/vendor/github.com/google/gofuzz/fuzz.go
+++ b/vendor/github.com/google/gofuzz/fuzz.go
@@ -1,0 +1,487 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fuzz
+
+import (
+	"fmt"
+	"math/rand"
+	"reflect"
+	"time"
+)
+
+// fuzzFuncMap is a map from a type to a fuzzFunc that handles that type.
+type fuzzFuncMap map[reflect.Type]reflect.Value
+
+// Fuzzer knows how to fill any object with random fields.
+type Fuzzer struct {
+	fuzzFuncs        fuzzFuncMap
+	defaultFuzzFuncs fuzzFuncMap
+	r                *rand.Rand
+	nilChance        float64
+	minElements      int
+	maxElements      int
+	maxDepth         int
+}
+
+// New returns a new Fuzzer. Customize your Fuzzer further by calling Funcs,
+// RandSource, NilChance, or NumElements in any order.
+func New() *Fuzzer {
+	return NewWithSeed(time.Now().UnixNano())
+}
+
+func NewWithSeed(seed int64) *Fuzzer {
+	f := &Fuzzer{
+		defaultFuzzFuncs: fuzzFuncMap{
+			reflect.TypeOf(&time.Time{}): reflect.ValueOf(fuzzTime),
+		},
+
+		fuzzFuncs:   fuzzFuncMap{},
+		r:           rand.New(rand.NewSource(seed)),
+		nilChance:   .2,
+		minElements: 1,
+		maxElements: 10,
+		maxDepth:    100,
+	}
+	return f
+}
+
+// Funcs adds each entry in fuzzFuncs as a custom fuzzing function.
+//
+// Each entry in fuzzFuncs must be a function taking two parameters.
+// The first parameter must be a pointer or map. It is the variable that
+// function will fill with random data. The second parameter must be a
+// fuzz.Continue, which will provide a source of randomness and a way
+// to automatically continue fuzzing smaller pieces of the first parameter.
+//
+// These functions are called sensibly, e.g., if you wanted custom string
+// fuzzing, the function `func(s *string, c fuzz.Continue)` would get
+// called and passed the address of strings. Maps and pointers will always
+// be made/new'd for you, ignoring the NilChange option. For slices, it
+// doesn't make much sense to  pre-create them--Fuzzer doesn't know how
+// long you want your slice--so take a pointer to a slice, and make it
+// yourself. (If you don't want your map/pointer type pre-made, take a
+// pointer to it, and make it yourself.) See the examples for a range of
+// custom functions.
+func (f *Fuzzer) Funcs(fuzzFuncs ...interface{}) *Fuzzer {
+	for i := range fuzzFuncs {
+		v := reflect.ValueOf(fuzzFuncs[i])
+		if v.Kind() != reflect.Func {
+			panic("Need only funcs!")
+		}
+		t := v.Type()
+		if t.NumIn() != 2 || t.NumOut() != 0 {
+			panic("Need 2 in and 0 out params!")
+		}
+		argT := t.In(0)
+		switch argT.Kind() {
+		case reflect.Ptr, reflect.Map:
+		default:
+			panic("fuzzFunc must take pointer or map type")
+		}
+		if t.In(1) != reflect.TypeOf(Continue{}) {
+			panic("fuzzFunc's second parameter must be type fuzz.Continue")
+		}
+		f.fuzzFuncs[argT] = v
+	}
+	return f
+}
+
+// RandSource causes f to get values from the given source of randomness.
+// Use if you want deterministic fuzzing.
+func (f *Fuzzer) RandSource(s rand.Source) *Fuzzer {
+	f.r = rand.New(s)
+	return f
+}
+
+// NilChance sets the probability of creating a nil pointer, map, or slice to
+// 'p'. 'p' should be between 0 (no nils) and 1 (all nils), inclusive.
+func (f *Fuzzer) NilChance(p float64) *Fuzzer {
+	if p < 0 || p > 1 {
+		panic("p should be between 0 and 1, inclusive.")
+	}
+	f.nilChance = p
+	return f
+}
+
+// NumElements sets the minimum and maximum number of elements that will be
+// added to a non-nil map or slice.
+func (f *Fuzzer) NumElements(atLeast, atMost int) *Fuzzer {
+	if atLeast > atMost {
+		panic("atLeast must be <= atMost")
+	}
+	if atLeast < 0 {
+		panic("atLeast must be >= 0")
+	}
+	f.minElements = atLeast
+	f.maxElements = atMost
+	return f
+}
+
+func (f *Fuzzer) genElementCount() int {
+	if f.minElements == f.maxElements {
+		return f.minElements
+	}
+	return f.minElements + f.r.Intn(f.maxElements-f.minElements+1)
+}
+
+func (f *Fuzzer) genShouldFill() bool {
+	return f.r.Float64() > f.nilChance
+}
+
+// MaxDepth sets the maximum number of recursive fuzz calls that will be made
+// before stopping.  This includes struct members, pointers, and map and slice
+// elements.
+func (f *Fuzzer) MaxDepth(d int) *Fuzzer {
+	f.maxDepth = d
+	return f
+}
+
+// Fuzz recursively fills all of obj's fields with something random.  First
+// this tries to find a custom fuzz function (see Funcs).  If there is no
+// custom function this tests whether the object implements fuzz.Interface and,
+// if so, calls Fuzz on it to fuzz itself.  If that fails, this will see if
+// there is a default fuzz function provided by this package.  If all of that
+// fails, this will generate random values for all primitive fields and then
+// recurse for all non-primitives.
+//
+// This is safe for cyclic or tree-like structs, up to a limit.  Use the
+// MaxDepth method to adjust how deep you need it to recurse.
+//
+// obj must be a pointer. Only exported (public) fields can be set (thanks,
+// golang :/ ) Intended for tests, so will panic on bad input or unimplemented
+// fields.
+func (f *Fuzzer) Fuzz(obj interface{}) {
+	v := reflect.ValueOf(obj)
+	if v.Kind() != reflect.Ptr {
+		panic("needed ptr!")
+	}
+	v = v.Elem()
+	f.fuzzWithContext(v, 0)
+}
+
+// FuzzNoCustom is just like Fuzz, except that any custom fuzz function for
+// obj's type will not be called and obj will not be tested for fuzz.Interface
+// conformance.  This applies only to obj and not other instances of obj's
+// type.
+// Not safe for cyclic or tree-like structs!
+// obj must be a pointer. Only exported (public) fields can be set (thanks, golang :/ )
+// Intended for tests, so will panic on bad input or unimplemented fields.
+func (f *Fuzzer) FuzzNoCustom(obj interface{}) {
+	v := reflect.ValueOf(obj)
+	if v.Kind() != reflect.Ptr {
+		panic("needed ptr!")
+	}
+	v = v.Elem()
+	f.fuzzWithContext(v, flagNoCustomFuzz)
+}
+
+const (
+	// Do not try to find a custom fuzz function.  Does not apply recursively.
+	flagNoCustomFuzz uint64 = 1 << iota
+)
+
+func (f *Fuzzer) fuzzWithContext(v reflect.Value, flags uint64) {
+	fc := &fuzzerContext{fuzzer: f}
+	fc.doFuzz(v, flags)
+}
+
+// fuzzerContext carries context about a single fuzzing run, which lets Fuzzer
+// be thread-safe.
+type fuzzerContext struct {
+	fuzzer   *Fuzzer
+	curDepth int
+}
+
+func (fc *fuzzerContext) doFuzz(v reflect.Value, flags uint64) {
+	if fc.curDepth >= fc.fuzzer.maxDepth {
+		return
+	}
+	fc.curDepth++
+	defer func() { fc.curDepth-- }()
+
+	if !v.CanSet() {
+		return
+	}
+
+	if flags&flagNoCustomFuzz == 0 {
+		// Check for both pointer and non-pointer custom functions.
+		if v.CanAddr() && fc.tryCustom(v.Addr()) {
+			return
+		}
+		if fc.tryCustom(v) {
+			return
+		}
+	}
+
+	if fn, ok := fillFuncMap[v.Kind()]; ok {
+		fn(v, fc.fuzzer.r)
+		return
+	}
+	switch v.Kind() {
+	case reflect.Map:
+		if fc.fuzzer.genShouldFill() {
+			v.Set(reflect.MakeMap(v.Type()))
+			n := fc.fuzzer.genElementCount()
+			for i := 0; i < n; i++ {
+				key := reflect.New(v.Type().Key()).Elem()
+				fc.doFuzz(key, 0)
+				val := reflect.New(v.Type().Elem()).Elem()
+				fc.doFuzz(val, 0)
+				v.SetMapIndex(key, val)
+			}
+			return
+		}
+		v.Set(reflect.Zero(v.Type()))
+	case reflect.Ptr:
+		if fc.fuzzer.genShouldFill() {
+			v.Set(reflect.New(v.Type().Elem()))
+			fc.doFuzz(v.Elem(), 0)
+			return
+		}
+		v.Set(reflect.Zero(v.Type()))
+	case reflect.Slice:
+		if fc.fuzzer.genShouldFill() {
+			n := fc.fuzzer.genElementCount()
+			v.Set(reflect.MakeSlice(v.Type(), n, n))
+			for i := 0; i < n; i++ {
+				fc.doFuzz(v.Index(i), 0)
+			}
+			return
+		}
+		v.Set(reflect.Zero(v.Type()))
+	case reflect.Array:
+		if fc.fuzzer.genShouldFill() {
+			n := v.Len()
+			for i := 0; i < n; i++ {
+				fc.doFuzz(v.Index(i), 0)
+			}
+			return
+		}
+		v.Set(reflect.Zero(v.Type()))
+	case reflect.Struct:
+		for i := 0; i < v.NumField(); i++ {
+			fc.doFuzz(v.Field(i), 0)
+		}
+	case reflect.Chan:
+		fallthrough
+	case reflect.Func:
+		fallthrough
+	case reflect.Interface:
+		fallthrough
+	default:
+		panic(fmt.Sprintf("Can't handle %#v", v.Interface()))
+	}
+}
+
+// tryCustom searches for custom handlers, and returns true iff it finds a match
+// and successfully randomizes v.
+func (fc *fuzzerContext) tryCustom(v reflect.Value) bool {
+	// First: see if we have a fuzz function for it.
+	doCustom, ok := fc.fuzzer.fuzzFuncs[v.Type()]
+	if !ok {
+		// Second: see if it can fuzz itself.
+		if v.CanInterface() {
+			intf := v.Interface()
+			if fuzzable, ok := intf.(Interface); ok {
+				fuzzable.Fuzz(Continue{fc: fc, Rand: fc.fuzzer.r})
+				return true
+			}
+		}
+		// Finally: see if there is a default fuzz function.
+		doCustom, ok = fc.fuzzer.defaultFuzzFuncs[v.Type()]
+		if !ok {
+			return false
+		}
+	}
+
+	switch v.Kind() {
+	case reflect.Ptr:
+		if v.IsNil() {
+			if !v.CanSet() {
+				return false
+			}
+			v.Set(reflect.New(v.Type().Elem()))
+		}
+	case reflect.Map:
+		if v.IsNil() {
+			if !v.CanSet() {
+				return false
+			}
+			v.Set(reflect.MakeMap(v.Type()))
+		}
+	default:
+		return false
+	}
+
+	doCustom.Call([]reflect.Value{v, reflect.ValueOf(Continue{
+		fc:   fc,
+		Rand: fc.fuzzer.r,
+	})})
+	return true
+}
+
+// Interface represents an object that knows how to fuzz itself.  Any time we
+// find a type that implements this interface we will delegate the act of
+// fuzzing itself.
+type Interface interface {
+	Fuzz(c Continue)
+}
+
+// Continue can be passed to custom fuzzing functions to allow them to use
+// the correct source of randomness and to continue fuzzing their members.
+type Continue struct {
+	fc *fuzzerContext
+
+	// For convenience, Continue implements rand.Rand via embedding.
+	// Use this for generating any randomness if you want your fuzzing
+	// to be repeatable for a given seed.
+	*rand.Rand
+}
+
+// Fuzz continues fuzzing obj. obj must be a pointer.
+func (c Continue) Fuzz(obj interface{}) {
+	v := reflect.ValueOf(obj)
+	if v.Kind() != reflect.Ptr {
+		panic("needed ptr!")
+	}
+	v = v.Elem()
+	c.fc.doFuzz(v, 0)
+}
+
+// FuzzNoCustom continues fuzzing obj, except that any custom fuzz function for
+// obj's type will not be called and obj will not be tested for fuzz.Interface
+// conformance.  This applies only to obj and not other instances of obj's
+// type.
+func (c Continue) FuzzNoCustom(obj interface{}) {
+	v := reflect.ValueOf(obj)
+	if v.Kind() != reflect.Ptr {
+		panic("needed ptr!")
+	}
+	v = v.Elem()
+	c.fc.doFuzz(v, flagNoCustomFuzz)
+}
+
+// RandString makes a random string up to 20 characters long. The returned string
+// may include a variety of (valid) UTF-8 encodings.
+func (c Continue) RandString() string {
+	return randString(c.Rand)
+}
+
+// RandUint64 makes random 64 bit numbers.
+// Weirdly, rand doesn't have a function that gives you 64 random bits.
+func (c Continue) RandUint64() uint64 {
+	return randUint64(c.Rand)
+}
+
+// RandBool returns true or false randomly.
+func (c Continue) RandBool() bool {
+	return randBool(c.Rand)
+}
+
+func fuzzInt(v reflect.Value, r *rand.Rand) {
+	v.SetInt(int64(randUint64(r)))
+}
+
+func fuzzUint(v reflect.Value, r *rand.Rand) {
+	v.SetUint(randUint64(r))
+}
+
+func fuzzTime(t *time.Time, c Continue) {
+	var sec, nsec int64
+	// Allow for about 1000 years of random time values, which keeps things
+	// like JSON parsing reasonably happy.
+	sec = c.Rand.Int63n(1000 * 365 * 24 * 60 * 60)
+	c.Fuzz(&nsec)
+	*t = time.Unix(sec, nsec)
+}
+
+var fillFuncMap = map[reflect.Kind]func(reflect.Value, *rand.Rand){
+	reflect.Bool: func(v reflect.Value, r *rand.Rand) {
+		v.SetBool(randBool(r))
+	},
+	reflect.Int:     fuzzInt,
+	reflect.Int8:    fuzzInt,
+	reflect.Int16:   fuzzInt,
+	reflect.Int32:   fuzzInt,
+	reflect.Int64:   fuzzInt,
+	reflect.Uint:    fuzzUint,
+	reflect.Uint8:   fuzzUint,
+	reflect.Uint16:  fuzzUint,
+	reflect.Uint32:  fuzzUint,
+	reflect.Uint64:  fuzzUint,
+	reflect.Uintptr: fuzzUint,
+	reflect.Float32: func(v reflect.Value, r *rand.Rand) {
+		v.SetFloat(float64(r.Float32()))
+	},
+	reflect.Float64: func(v reflect.Value, r *rand.Rand) {
+		v.SetFloat(r.Float64())
+	},
+	reflect.Complex64: func(v reflect.Value, r *rand.Rand) {
+		panic("unimplemented")
+	},
+	reflect.Complex128: func(v reflect.Value, r *rand.Rand) {
+		panic("unimplemented")
+	},
+	reflect.String: func(v reflect.Value, r *rand.Rand) {
+		v.SetString(randString(r))
+	},
+	reflect.UnsafePointer: func(v reflect.Value, r *rand.Rand) {
+		panic("unimplemented")
+	},
+}
+
+// randBool returns true or false randomly.
+func randBool(r *rand.Rand) bool {
+	if r.Int()&1 == 1 {
+		return true
+	}
+	return false
+}
+
+type charRange struct {
+	first, last rune
+}
+
+// choose returns a random unicode character from the given range, using the
+// given randomness source.
+func (r *charRange) choose(rand *rand.Rand) rune {
+	count := int64(r.last - r.first)
+	return r.first + rune(rand.Int63n(count))
+}
+
+var unicodeRanges = []charRange{
+	{' ', '~'},           // ASCII characters
+	{'\u00a0', '\u02af'}, // Multi-byte encoded characters
+	{'\u4e00', '\u9fff'}, // Common CJK (even longer encodings)
+}
+
+// randString makes a random string up to 20 characters long. The returned string
+// may include a variety of (valid) UTF-8 encodings.
+func randString(r *rand.Rand) string {
+	n := r.Intn(20)
+	runes := make([]rune, n)
+	for i := range runes {
+		runes[i] = unicodeRanges[r.Intn(len(unicodeRanges))].choose(r)
+	}
+	return string(runes)
+}
+
+// randUint64 makes random 64 bit numbers.
+// Weirdly, rand doesn't have a function that gives you 64 random bits.
+func randUint64(r *rand.Rand) uint64 {
+	return uint64(r.Uint32())<<32 | uint64(r.Uint32())
+}

--- a/vendor/github.com/google/gofuzz/go.mod
+++ b/vendor/github.com/google/gofuzz/go.mod
@@ -1,0 +1,3 @@
+module github.com/google/gofuzz
+
+go 1.12

--- a/vendor/gopkg.in/inf.v0/LICENSE
+++ b/vendor/gopkg.in/inf.v0/LICENSE
@@ -1,0 +1,28 @@
+Copyright (c) 2012 Péter Surányi. Portions Copyright (c) 2009 The Go
+Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/gopkg.in/inf.v0/dec.go
+++ b/vendor/gopkg.in/inf.v0/dec.go
@@ -1,0 +1,615 @@
+// Package inf (type inf.Dec) implements "infinite-precision" decimal
+// arithmetic.
+// "Infinite precision" describes two characteristics: practically unlimited
+// precision for decimal number representation and no support for calculating
+// with any specific fixed precision.
+// (Although there is no practical limit on precision, inf.Dec can only
+// represent finite decimals.)
+//
+// This package is currently in experimental stage and the API may change.
+//
+// This package does NOT support:
+//  - rounding to specific precisions (as opposed to specific decimal positions)
+//  - the notion of context (each rounding must be explicit)
+//  - NaN and Inf values, and distinguishing between positive and negative zero
+//  - conversions to and from float32/64 types
+//
+// Features considered for possible addition:
+//  + formatting options
+//  + Exp method
+//  + combined operations such as AddRound/MulAdd etc
+//  + exchanging data in decimal32/64/128 formats
+//
+package inf // import "gopkg.in/inf.v0"
+
+// TODO:
+//  - avoid excessive deep copying (quo and rounders)
+
+import (
+	"fmt"
+	"io"
+	"math/big"
+	"strings"
+)
+
+// A Dec represents a signed arbitrary-precision decimal.
+// It is a combination of a sign, an arbitrary-precision integer coefficient
+// value, and a signed fixed-precision exponent value.
+// The sign and the coefficient value are handled together as a signed value
+// and referred to as the unscaled value.
+// (Positive and negative zero values are not distinguished.)
+// Since the exponent is most commonly non-positive, it is handled in negated
+// form and referred to as scale.
+//
+// The mathematical value of a Dec equals:
+//
+//  unscaled * 10**(-scale)
+//
+// Note that different Dec representations may have equal mathematical values.
+//
+//  unscaled  scale  String()
+//  -------------------------
+//         0      0    "0"
+//         0      2    "0.00"
+//         0     -2    "0"
+//         1      0    "1"
+//       100      2    "1.00"
+//        10      0   "10"
+//         1     -1   "10"
+//
+// The zero value for a Dec represents the value 0 with scale 0.
+//
+// Operations are typically performed through the *Dec type.
+// The semantics of the assignment operation "=" for "bare" Dec values is
+// undefined and should not be relied on.
+//
+// Methods are typically of the form:
+//
+//	func (z *Dec) Op(x, y *Dec) *Dec
+//
+// and implement operations z = x Op y with the result as receiver; if it
+// is one of the operands it may be overwritten (and its memory reused).
+// To enable chaining of operations, the result is also returned. Methods
+// returning a result other than *Dec take one of the operands as the receiver.
+//
+// A "bare" Quo method (quotient / division operation) is not provided, as the
+// result is not always a finite decimal and thus in general cannot be
+// represented as a Dec.
+// Instead, in the common case when rounding is (potentially) necessary,
+// QuoRound should be used with a Scale and a Rounder.
+// QuoExact or QuoRound with RoundExact can be used in the special cases when it
+// is known that the result is always a finite decimal.
+//
+type Dec struct {
+	unscaled big.Int
+	scale    Scale
+}
+
+// Scale represents the type used for the scale of a Dec.
+type Scale int32
+
+const scaleSize = 4 // bytes in a Scale value
+
+// Scaler represents a method for obtaining the scale to use for the result of
+// an operation on x and y.
+type scaler interface {
+	Scale(x *Dec, y *Dec) Scale
+}
+
+var bigInt = [...]*big.Int{
+	big.NewInt(0), big.NewInt(1), big.NewInt(2), big.NewInt(3), big.NewInt(4),
+	big.NewInt(5), big.NewInt(6), big.NewInt(7), big.NewInt(8), big.NewInt(9),
+	big.NewInt(10),
+}
+
+var exp10cache [64]big.Int = func() [64]big.Int {
+	e10, e10i := [64]big.Int{}, bigInt[1]
+	for i := range e10 {
+		e10[i].Set(e10i)
+		e10i = new(big.Int).Mul(e10i, bigInt[10])
+	}
+	return e10
+}()
+
+// NewDec allocates and returns a new Dec set to the given int64 unscaled value
+// and scale.
+func NewDec(unscaled int64, scale Scale) *Dec {
+	return new(Dec).SetUnscaled(unscaled).SetScale(scale)
+}
+
+// NewDecBig allocates and returns a new Dec set to the given *big.Int unscaled
+// value and scale.
+func NewDecBig(unscaled *big.Int, scale Scale) *Dec {
+	return new(Dec).SetUnscaledBig(unscaled).SetScale(scale)
+}
+
+// Scale returns the scale of x.
+func (x *Dec) Scale() Scale {
+	return x.scale
+}
+
+// Unscaled returns the unscaled value of x for u and true for ok when the
+// unscaled value can be represented as int64; otherwise it returns an undefined
+// int64 value for u and false for ok. Use x.UnscaledBig().Int64() to avoid
+// checking the validity of the value when the check is known to be redundant.
+func (x *Dec) Unscaled() (u int64, ok bool) {
+	u = x.unscaled.Int64()
+	var i big.Int
+	ok = i.SetInt64(u).Cmp(&x.unscaled) == 0
+	return
+}
+
+// UnscaledBig returns the unscaled value of x as *big.Int.
+func (x *Dec) UnscaledBig() *big.Int {
+	return &x.unscaled
+}
+
+// SetScale sets the scale of z, with the unscaled value unchanged, and returns
+// z.
+// The mathematical value of the Dec changes as if it was multiplied by
+// 10**(oldscale-scale).
+func (z *Dec) SetScale(scale Scale) *Dec {
+	z.scale = scale
+	return z
+}
+
+// SetUnscaled sets the unscaled value of z, with the scale unchanged, and
+// returns z.
+func (z *Dec) SetUnscaled(unscaled int64) *Dec {
+	z.unscaled.SetInt64(unscaled)
+	return z
+}
+
+// SetUnscaledBig sets the unscaled value of z, with the scale unchanged, and
+// returns z.
+func (z *Dec) SetUnscaledBig(unscaled *big.Int) *Dec {
+	z.unscaled.Set(unscaled)
+	return z
+}
+
+// Set sets z to the value of x and returns z.
+// It does nothing if z == x.
+func (z *Dec) Set(x *Dec) *Dec {
+	if z != x {
+		z.SetUnscaledBig(x.UnscaledBig())
+		z.SetScale(x.Scale())
+	}
+	return z
+}
+
+// Sign returns:
+//
+//	-1 if x <  0
+//	 0 if x == 0
+//	+1 if x >  0
+//
+func (x *Dec) Sign() int {
+	return x.UnscaledBig().Sign()
+}
+
+// Neg sets z to -x and returns z.
+func (z *Dec) Neg(x *Dec) *Dec {
+	z.SetScale(x.Scale())
+	z.UnscaledBig().Neg(x.UnscaledBig())
+	return z
+}
+
+// Cmp compares x and y and returns:
+//
+//   -1 if x <  y
+//    0 if x == y
+//   +1 if x >  y
+//
+func (x *Dec) Cmp(y *Dec) int {
+	xx, yy := upscale(x, y)
+	return xx.UnscaledBig().Cmp(yy.UnscaledBig())
+}
+
+// Abs sets z to |x| (the absolute value of x) and returns z.
+func (z *Dec) Abs(x *Dec) *Dec {
+	z.SetScale(x.Scale())
+	z.UnscaledBig().Abs(x.UnscaledBig())
+	return z
+}
+
+// Add sets z to the sum x+y and returns z.
+// The scale of z is the greater of the scales of x and y.
+func (z *Dec) Add(x, y *Dec) *Dec {
+	xx, yy := upscale(x, y)
+	z.SetScale(xx.Scale())
+	z.UnscaledBig().Add(xx.UnscaledBig(), yy.UnscaledBig())
+	return z
+}
+
+// Sub sets z to the difference x-y and returns z.
+// The scale of z is the greater of the scales of x and y.
+func (z *Dec) Sub(x, y *Dec) *Dec {
+	xx, yy := upscale(x, y)
+	z.SetScale(xx.Scale())
+	z.UnscaledBig().Sub(xx.UnscaledBig(), yy.UnscaledBig())
+	return z
+}
+
+// Mul sets z to the product x*y and returns z.
+// The scale of z is the sum of the scales of x and y.
+func (z *Dec) Mul(x, y *Dec) *Dec {
+	z.SetScale(x.Scale() + y.Scale())
+	z.UnscaledBig().Mul(x.UnscaledBig(), y.UnscaledBig())
+	return z
+}
+
+// Round sets z to the value of x rounded to Scale s using Rounder r, and
+// returns z.
+func (z *Dec) Round(x *Dec, s Scale, r Rounder) *Dec {
+	return z.QuoRound(x, NewDec(1, 0), s, r)
+}
+
+// QuoRound sets z to the quotient x/y, rounded using the given Rounder to the
+// specified scale.
+//
+// If the rounder is RoundExact but the result can not be expressed exactly at
+// the specified scale, QuoRound returns nil, and the value of z is undefined.
+//
+// There is no corresponding Div method; the equivalent can be achieved through
+// the choice of Rounder used.
+//
+func (z *Dec) QuoRound(x, y *Dec, s Scale, r Rounder) *Dec {
+	return z.quo(x, y, sclr{s}, r)
+}
+
+func (z *Dec) quo(x, y *Dec, s scaler, r Rounder) *Dec {
+	scl := s.Scale(x, y)
+	var zzz *Dec
+	if r.UseRemainder() {
+		zz, rA, rB := new(Dec).quoRem(x, y, scl, true, new(big.Int), new(big.Int))
+		zzz = r.Round(new(Dec), zz, rA, rB)
+	} else {
+		zz, _, _ := new(Dec).quoRem(x, y, scl, false, nil, nil)
+		zzz = r.Round(new(Dec), zz, nil, nil)
+	}
+	if zzz == nil {
+		return nil
+	}
+	return z.Set(zzz)
+}
+
+// QuoExact sets z to the quotient x/y and returns z when x/y is a finite
+// decimal. Otherwise it returns nil and the value of z is undefined.
+//
+// The scale of a non-nil result is "x.Scale() - y.Scale()" or greater; it is
+// calculated so that the remainder will be zero whenever x/y is a finite
+// decimal.
+func (z *Dec) QuoExact(x, y *Dec) *Dec {
+	return z.quo(x, y, scaleQuoExact{}, RoundExact)
+}
+
+// quoRem sets z to the quotient x/y with the scale s, and if useRem is true,
+// it sets remNum and remDen to the numerator and denominator of the remainder.
+// It returns z, remNum and remDen.
+//
+// The remainder is normalized to the range -1 < r < 1 to simplify rounding;
+// that is, the results satisfy the following equation:
+//
+//  x / y = z + (remNum/remDen) * 10**(-z.Scale())
+//
+// See Rounder for more details about rounding.
+//
+func (z *Dec) quoRem(x, y *Dec, s Scale, useRem bool,
+	remNum, remDen *big.Int) (*Dec, *big.Int, *big.Int) {
+	// difference (required adjustment) compared to "canonical" result scale
+	shift := s - (x.Scale() - y.Scale())
+	// pointers to adjusted unscaled dividend and divisor
+	var ix, iy *big.Int
+	switch {
+	case shift > 0:
+		// increased scale: decimal-shift dividend left
+		ix = new(big.Int).Mul(x.UnscaledBig(), exp10(shift))
+		iy = y.UnscaledBig()
+	case shift < 0:
+		// decreased scale: decimal-shift divisor left
+		ix = x.UnscaledBig()
+		iy = new(big.Int).Mul(y.UnscaledBig(), exp10(-shift))
+	default:
+		ix = x.UnscaledBig()
+		iy = y.UnscaledBig()
+	}
+	// save a copy of iy in case it to be overwritten with the result
+	iy2 := iy
+	if iy == z.UnscaledBig() {
+		iy2 = new(big.Int).Set(iy)
+	}
+	// set scale
+	z.SetScale(s)
+	// set unscaled
+	if useRem {
+		// Int division
+		_, intr := z.UnscaledBig().QuoRem(ix, iy, new(big.Int))
+		// set remainder
+		remNum.Set(intr)
+		remDen.Set(iy2)
+	} else {
+		z.UnscaledBig().Quo(ix, iy)
+	}
+	return z, remNum, remDen
+}
+
+type sclr struct{ s Scale }
+
+func (s sclr) Scale(x, y *Dec) Scale {
+	return s.s
+}
+
+type scaleQuoExact struct{}
+
+func (sqe scaleQuoExact) Scale(x, y *Dec) Scale {
+	rem := new(big.Rat).SetFrac(x.UnscaledBig(), y.UnscaledBig())
+	f2, f5 := factor2(rem.Denom()), factor(rem.Denom(), bigInt[5])
+	var f10 Scale
+	if f2 > f5 {
+		f10 = Scale(f2)
+	} else {
+		f10 = Scale(f5)
+	}
+	return x.Scale() - y.Scale() + f10
+}
+
+func factor(n *big.Int, p *big.Int) int {
+	// could be improved for large factors
+	d, f := n, 0
+	for {
+		dd, dm := new(big.Int).DivMod(d, p, new(big.Int))
+		if dm.Sign() == 0 {
+			f++
+			d = dd
+		} else {
+			break
+		}
+	}
+	return f
+}
+
+func factor2(n *big.Int) int {
+	// could be improved for large factors
+	f := 0
+	for ; n.Bit(f) == 0; f++ {
+	}
+	return f
+}
+
+func upscale(a, b *Dec) (*Dec, *Dec) {
+	if a.Scale() == b.Scale() {
+		return a, b
+	}
+	if a.Scale() > b.Scale() {
+		bb := b.rescale(a.Scale())
+		return a, bb
+	}
+	aa := a.rescale(b.Scale())
+	return aa, b
+}
+
+func exp10(x Scale) *big.Int {
+	if int(x) < len(exp10cache) {
+		return &exp10cache[int(x)]
+	}
+	return new(big.Int).Exp(bigInt[10], big.NewInt(int64(x)), nil)
+}
+
+func (x *Dec) rescale(newScale Scale) *Dec {
+	shift := newScale - x.Scale()
+	switch {
+	case shift < 0:
+		e := exp10(-shift)
+		return NewDecBig(new(big.Int).Quo(x.UnscaledBig(), e), newScale)
+	case shift > 0:
+		e := exp10(shift)
+		return NewDecBig(new(big.Int).Mul(x.UnscaledBig(), e), newScale)
+	}
+	return x
+}
+
+var zeros = []byte("00000000000000000000000000000000" +
+	"00000000000000000000000000000000")
+var lzeros = Scale(len(zeros))
+
+func appendZeros(s []byte, n Scale) []byte {
+	for i := Scale(0); i < n; i += lzeros {
+		if n > i+lzeros {
+			s = append(s, zeros...)
+		} else {
+			s = append(s, zeros[0:n-i]...)
+		}
+	}
+	return s
+}
+
+func (x *Dec) String() string {
+	if x == nil {
+		return "<nil>"
+	}
+	scale := x.Scale()
+	s := []byte(x.UnscaledBig().String())
+	if scale <= 0 {
+		if scale != 0 && x.unscaled.Sign() != 0 {
+			s = appendZeros(s, -scale)
+		}
+		return string(s)
+	}
+	negbit := Scale(-((x.Sign() - 1) / 2))
+	// scale > 0
+	lens := Scale(len(s))
+	if lens-negbit <= scale {
+		ss := make([]byte, 0, scale+2)
+		if negbit == 1 {
+			ss = append(ss, '-')
+		}
+		ss = append(ss, '0', '.')
+		ss = appendZeros(ss, scale-lens+negbit)
+		ss = append(ss, s[negbit:]...)
+		return string(ss)
+	}
+	// lens > scale
+	ss := make([]byte, 0, lens+1)
+	ss = append(ss, s[:lens-scale]...)
+	ss = append(ss, '.')
+	ss = append(ss, s[lens-scale:]...)
+	return string(ss)
+}
+
+// Format is a support routine for fmt.Formatter. It accepts the decimal
+// formats 'd' and 'f', and handles both equivalently.
+// Width, precision, flags and bases 2, 8, 16 are not supported.
+func (x *Dec) Format(s fmt.State, ch rune) {
+	if ch != 'd' && ch != 'f' && ch != 'v' && ch != 's' {
+		fmt.Fprintf(s, "%%!%c(dec.Dec=%s)", ch, x.String())
+		return
+	}
+	fmt.Fprintf(s, x.String())
+}
+
+func (z *Dec) scan(r io.RuneScanner) (*Dec, error) {
+	unscaled := make([]byte, 0, 256) // collects chars of unscaled as bytes
+	dp, dg := -1, -1                 // indexes of decimal point, first digit
+loop:
+	for {
+		ch, _, err := r.ReadRune()
+		if err == io.EOF {
+			break loop
+		}
+		if err != nil {
+			return nil, err
+		}
+		switch {
+		case ch == '+' || ch == '-':
+			if len(unscaled) > 0 || dp >= 0 { // must be first character
+				r.UnreadRune()
+				break loop
+			}
+		case ch == '.':
+			if dp >= 0 {
+				r.UnreadRune()
+				break loop
+			}
+			dp = len(unscaled)
+			continue // don't add to unscaled
+		case ch >= '0' && ch <= '9':
+			if dg == -1 {
+				dg = len(unscaled)
+			}
+		default:
+			r.UnreadRune()
+			break loop
+		}
+		unscaled = append(unscaled, byte(ch))
+	}
+	if dg == -1 {
+		return nil, fmt.Errorf("no digits read")
+	}
+	if dp >= 0 {
+		z.SetScale(Scale(len(unscaled) - dp))
+	} else {
+		z.SetScale(0)
+	}
+	_, ok := z.UnscaledBig().SetString(string(unscaled), 10)
+	if !ok {
+		return nil, fmt.Errorf("invalid decimal: %s", string(unscaled))
+	}
+	return z, nil
+}
+
+// SetString sets z to the value of s, interpreted as a decimal (base 10),
+// and returns z and a boolean indicating success. The scale of z is the
+// number of digits after the decimal point (including any trailing 0s),
+// or 0 if there is no decimal point. If SetString fails, the value of z
+// is undefined but the returned value is nil.
+func (z *Dec) SetString(s string) (*Dec, bool) {
+	r := strings.NewReader(s)
+	_, err := z.scan(r)
+	if err != nil {
+		return nil, false
+	}
+	_, _, err = r.ReadRune()
+	if err != io.EOF {
+		return nil, false
+	}
+	// err == io.EOF => scan consumed all of s
+	return z, true
+}
+
+// Scan is a support routine for fmt.Scanner; it sets z to the value of
+// the scanned number. It accepts the decimal formats 'd' and 'f', and
+// handles both equivalently. Bases 2, 8, 16 are not supported.
+// The scale of z is the number of digits after the decimal point
+// (including any trailing 0s), or 0 if there is no decimal point.
+func (z *Dec) Scan(s fmt.ScanState, ch rune) error {
+	if ch != 'd' && ch != 'f' && ch != 's' && ch != 'v' {
+		return fmt.Errorf("Dec.Scan: invalid verb '%c'", ch)
+	}
+	s.SkipSpace()
+	_, err := z.scan(s)
+	return err
+}
+
+// Gob encoding version
+const decGobVersion byte = 1
+
+func scaleBytes(s Scale) []byte {
+	buf := make([]byte, scaleSize)
+	i := scaleSize
+	for j := 0; j < scaleSize; j++ {
+		i--
+		buf[i] = byte(s)
+		s >>= 8
+	}
+	return buf
+}
+
+func scale(b []byte) (s Scale) {
+	for j := 0; j < scaleSize; j++ {
+		s <<= 8
+		s |= Scale(b[j])
+	}
+	return
+}
+
+// GobEncode implements the gob.GobEncoder interface.
+func (x *Dec) GobEncode() ([]byte, error) {
+	buf, err := x.UnscaledBig().GobEncode()
+	if err != nil {
+		return nil, err
+	}
+	buf = append(append(buf, scaleBytes(x.Scale())...), decGobVersion)
+	return buf, nil
+}
+
+// GobDecode implements the gob.GobDecoder interface.
+func (z *Dec) GobDecode(buf []byte) error {
+	if len(buf) == 0 {
+		return fmt.Errorf("Dec.GobDecode: no data")
+	}
+	b := buf[len(buf)-1]
+	if b != decGobVersion {
+		return fmt.Errorf("Dec.GobDecode: encoding version %d not supported", b)
+	}
+	l := len(buf) - scaleSize - 1
+	err := z.UnscaledBig().GobDecode(buf[:l])
+	if err != nil {
+		return err
+	}
+	z.SetScale(scale(buf[l : l+scaleSize]))
+	return nil
+}
+
+// MarshalText implements the encoding.TextMarshaler interface.
+func (x *Dec) MarshalText() ([]byte, error) {
+	return []byte(x.String()), nil
+}
+
+// UnmarshalText implements the encoding.TextUnmarshaler interface.
+func (z *Dec) UnmarshalText(data []byte) error {
+	_, ok := z.SetString(string(data))
+	if !ok {
+		return fmt.Errorf("invalid inf.Dec")
+	}
+	return nil
+}

--- a/vendor/gopkg.in/inf.v0/rounder.go
+++ b/vendor/gopkg.in/inf.v0/rounder.go
@@ -1,0 +1,145 @@
+package inf
+
+import (
+	"math/big"
+)
+
+// Rounder represents a method for rounding the (possibly infinite decimal)
+// result of a division to a finite Dec. It is used by Dec.Round() and
+// Dec.Quo().
+//
+// See the Example for results of using each Rounder with some sample values.
+//
+type Rounder rounder
+
+// See http://speleotrove.com/decimal/damodel.html#refround for more detailed
+// definitions of these rounding modes.
+var (
+	RoundDown     Rounder // towards 0
+	RoundUp       Rounder // away from 0
+	RoundFloor    Rounder // towards -infinity
+	RoundCeil     Rounder // towards +infinity
+	RoundHalfDown Rounder // to nearest; towards 0 if same distance
+	RoundHalfUp   Rounder // to nearest; away from 0 if same distance
+	RoundHalfEven Rounder // to nearest; even last digit if same distance
+)
+
+// RoundExact is to be used in the case when rounding is not necessary.
+// When used with Quo or Round, it returns the result verbatim when it can be
+// expressed exactly with the given precision, and it returns nil otherwise.
+// QuoExact is a shorthand for using Quo with RoundExact.
+var RoundExact Rounder
+
+type rounder interface {
+
+	// When UseRemainder() returns true, the Round() method is passed the
+	// remainder of the division, expressed as the numerator and denominator of
+	// a rational.
+	UseRemainder() bool
+
+	// Round sets the rounded value of a quotient to z, and returns z.
+	// quo is rounded down (truncated towards zero) to the scale obtained from
+	// the Scaler in Quo().
+	//
+	// When the remainder is not used, remNum and remDen are nil.
+	// When used, the remainder is normalized between -1 and 1; that is:
+	//
+	//  -|remDen| < remNum < |remDen|
+	//
+	// remDen has the same sign as y, and remNum is zero or has the same sign
+	// as x.
+	Round(z, quo *Dec, remNum, remDen *big.Int) *Dec
+}
+
+type rndr struct {
+	useRem bool
+	round  func(z, quo *Dec, remNum, remDen *big.Int) *Dec
+}
+
+func (r rndr) UseRemainder() bool {
+	return r.useRem
+}
+
+func (r rndr) Round(z, quo *Dec, remNum, remDen *big.Int) *Dec {
+	return r.round(z, quo, remNum, remDen)
+}
+
+var intSign = []*big.Int{big.NewInt(-1), big.NewInt(0), big.NewInt(1)}
+
+func roundHalf(f func(c int, odd uint) (roundUp bool)) func(z, q *Dec, rA, rB *big.Int) *Dec {
+	return func(z, q *Dec, rA, rB *big.Int) *Dec {
+		z.Set(q)
+		brA, brB := rA.BitLen(), rB.BitLen()
+		if brA < brB-1 {
+			// brA < brB-1 => |rA| < |rB/2|
+			return z
+		}
+		roundUp := false
+		srA, srB := rA.Sign(), rB.Sign()
+		s := srA * srB
+		if brA == brB-1 {
+			rA2 := new(big.Int).Lsh(rA, 1)
+			if s < 0 {
+				rA2.Neg(rA2)
+			}
+			roundUp = f(rA2.Cmp(rB)*srB, z.UnscaledBig().Bit(0))
+		} else {
+			// brA > brB-1 => |rA| > |rB/2|
+			roundUp = true
+		}
+		if roundUp {
+			z.UnscaledBig().Add(z.UnscaledBig(), intSign[s+1])
+		}
+		return z
+	}
+}
+
+func init() {
+	RoundExact = rndr{true,
+		func(z, q *Dec, rA, rB *big.Int) *Dec {
+			if rA.Sign() != 0 {
+				return nil
+			}
+			return z.Set(q)
+		}}
+	RoundDown = rndr{false,
+		func(z, q *Dec, rA, rB *big.Int) *Dec {
+			return z.Set(q)
+		}}
+	RoundUp = rndr{true,
+		func(z, q *Dec, rA, rB *big.Int) *Dec {
+			z.Set(q)
+			if rA.Sign() != 0 {
+				z.UnscaledBig().Add(z.UnscaledBig(), intSign[rA.Sign()*rB.Sign()+1])
+			}
+			return z
+		}}
+	RoundFloor = rndr{true,
+		func(z, q *Dec, rA, rB *big.Int) *Dec {
+			z.Set(q)
+			if rA.Sign()*rB.Sign() < 0 {
+				z.UnscaledBig().Add(z.UnscaledBig(), intSign[0])
+			}
+			return z
+		}}
+	RoundCeil = rndr{true,
+		func(z, q *Dec, rA, rB *big.Int) *Dec {
+			z.Set(q)
+			if rA.Sign()*rB.Sign() > 0 {
+				z.UnscaledBig().Add(z.UnscaledBig(), intSign[2])
+			}
+			return z
+		}}
+	RoundHalfDown = rndr{true, roundHalf(
+		func(c int, odd uint) bool {
+			return c > 0
+		})}
+	RoundHalfUp = rndr{true, roundHalf(
+		func(c int, odd uint) bool {
+			return c >= 0
+		})}
+	RoundHalfEven = rndr{true, roundHalf(
+		func(c int, odd uint) bool {
+			return c > 0 || c == 0 && odd == 1
+		})}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -15,6 +15,8 @@ github.com/gobwas/glob/util/runes
 github.com/gobwas/glob/util/strings
 # github.com/golang/protobuf v0.0.0-20181025225059-d3de96c4c28e
 github.com/golang/protobuf/proto
+# github.com/google/gofuzz v1.0.0
+github.com/google/gofuzz
 # github.com/gorilla/mux v0.0.0-20181024020800-521ea7b17d02
 github.com/gorilla/mux
 # github.com/inconshreveable/mousetrap v1.0.0
@@ -81,5 +83,7 @@ golang.org/x/tools/internal/module
 golang.org/x/tools/internal/semver
 # gopkg.in/fsnotify.v1 v1.4.7
 gopkg.in/fsnotify.v1
+# gopkg.in/inf.v0 v0.9.1
+gopkg.in/inf.v0
 # gopkg.in/yaml.v2 v2.2.1
 gopkg.in/yaml.v2


### PR DESCRIPTION
This fulfills part of this issue https://github.com/open-policy-agent/opa/issues/1802.
For short, there are no memory comparison buitins to compare memory sizes supported by k8s resources. 
While we can use the existing units.parse_byte to parse it to byte and then compare, it only supports up to TB and the k8s resources requires EB, see https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#meaning-of-memory. 

Signed-off-by: Xin Jin <xin@styra.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
