### PR TITLE
Bigger buttons on liveblocks

### DIFF
--- a/docs/website/scripts/live-blocks/src/web/style.css
+++ b/docs/website/scripts/live-blocks/src/web/style.css
@@ -31,7 +31,7 @@
   flex-direction: row-reverse;
   display: flex;
   justify-content: flex-start;
-  font-size: 0.875em; /*TODO set for both this and codemirror, try setting it on container*/
+  font-size: 1.275em; /*TODO set for both this and codemirror, try setting it on container*/
   align-items: center;
 }
 


### PR DESCRIPTION
Very minor PR because I'm an idiot (See #1995) and didn't notice the buttons on existing docs site in the liveblocks. 

This makes them bigger, left is with change. Right is without change. 

![image](https://user-images.githubusercontent.com/1939288/72448704-5d291780-37af-11ea-885a-501375e9020e.png)

Note: Made the change based off the browser devtools, do I need to deploy to netify to test as part of the PR, felt relatively contained so haven't done so. 
