### PR TITLE
ast: Do not index expressions containing with statements

### DIFF
--- a/ast/index.go
+++ b/ast/index.go
@@ -223,6 +223,12 @@ func (i *refindices) Update(rule *Rule, expr *Expr) {
 		return
 	}
 
+	if len(expr.With) > 0 {
+		// NOTE(tsandall): In the future, we may need to consider expressions
+		// that have with statements applied to them.
+		return
+	}
+
 	op := expr.Operator()
 
 	if op.Equal(Equality.Ref()) || op.Equal(Equal.Ref()) {

--- a/ast/index_test.go
+++ b/ast/index_test.go
@@ -116,6 +116,8 @@ func TestBaseDocEqIndexing(t *testing.T) {
 		# include one rule that can be indexed to exercise merging of root non-indexable
 		# rules with other rules.
 		input.x = 1
+	} {
+		input.foo = "bar" with data.baz as "qux"
 	}
 
 	# exercise default keyword


### PR DESCRIPTION
The rule indexer was incorporating expressions that met the = or
glob.match requirements even if they had a with statement
applied. This caused false negatives for the index lookup result. In
practice, it's highly unlikely that users would write expressions that
could be indexed that also include with statements (e.g., `input.a = 1
with ...`) so it's unlikley that anyone is affected.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
