### PR TITLE
rego: Fix panic when partial evaluating w/ tracers

### DIFF
--- a/rego/rego.go
+++ b/rego/rego.go
@@ -1713,7 +1713,7 @@ func (r *Rego) partial(ctx context.Context, ectx *EvalContext) (*PartialQueries,
 		WithIndexing(ectx.indexing)
 
 	for i := range ectx.tracers {
-		q = q.WithTracer(r.tracers[i])
+		q = q.WithTracer(ectx.tracers[i])
 	}
 
 	if ectx.parsedInput != nil {


### PR DESCRIPTION
There was a typo from a while back that caused problems with this. It
would only occur in cases where the Rego object was created without
tracers, prepared, and then partially evaluated with tracers supplied
as part of the evaluation context. Any of the other code paths would
actually work as the original Rego object would still have them and
the (wrong) reference wouldn't cause a panic.

At some point more recently we changed `opa eval` to split up its
options for the Rego object and evaluation. Doing this caused the
problem to surface when doing anything with `opa eval -p --explain ..`

Fixes: #2007
Signed-off-by: Patrick East <east.patrick@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
