### PR TITLE
ast: Generic/BeforeAfter/Var Visitor specific Walk implementations.

### DIFF
--- a/ast/index.go
+++ b/ast/index.go
@@ -695,7 +695,7 @@ func eqOperandsToRefAndValue(isVirtual func(Ref) bool, a, b *Term) (Ref, Value, 
 			}
 			return stop
 		})
-		Walk(vis, b)
+		vis.Walk(b)
 		if !stop {
 			return ref, b, true
 		}

--- a/ast/parser_internal.go
+++ b/ast/parser_internal.go
@@ -123,7 +123,7 @@ func makeDefaultRule(loc *Location, name, operator, value interface{}) (interfac
 		return false
 	})
 
-	Walk(vis, term)
+	vis.Walk(term)
 
 	if err != nil {
 		return nil, err

--- a/ast/policy.go
+++ b/ast/policy.go
@@ -667,13 +667,13 @@ func (head *Head) Vars() VarSet {
 	vis := &VarVisitor{vars: VarSet{}}
 	// TODO: improve test coverage for this.
 	if head.Args != nil {
-		Walk(vis, head.Args)
+		vis.Walk(head.Args)
 	}
 	if head.Key != nil {
-		Walk(vis, head.Key)
+		vis.Walk(head.Key)
 	}
 	if head.Value != nil {
-		Walk(vis, head.Value)
+		vis.Walk(head.Value)
 	}
 	return vis.vars
 }
@@ -726,7 +726,7 @@ func (a Args) SetLoc(loc *Location) {
 // Vars returns a set of vars that appear in a.
 func (a Args) Vars() VarSet {
 	vis := &VarVisitor{vars: VarSet{}}
-	Walk(vis, a)
+	vis.Walk(a)
 	return vis.vars
 }
 
@@ -856,7 +856,7 @@ func (body Body) String() string {
 // control which vars are included.
 func (body Body) Vars(params VarVisitorParams) VarSet {
 	vis := NewVarVisitor().WithParams(params)
-	Walk(vis, body)
+	vis.Walk(body)
 	return vis.Vars()
 }
 
@@ -1147,7 +1147,7 @@ func (expr *Expr) UnmarshalJSON(bs []byte) error {
 // control which vars are included.
 func (expr *Expr) Vars(params VarVisitorParams) VarSet {
 	vis := NewVarVisitor().WithParams(params)
-	Walk(vis, expr)
+	vis.Walk(expr)
 	return vis.Vars()
 }
 

--- a/ast/pretty.go
+++ b/ast/pretty.go
@@ -18,7 +18,7 @@ func Pretty(w io.Writer, x interface{}) {
 		depth: -1,
 		w:     w,
 	}
-	WalkBeforeAndAfter(pp, x)
+	NewBeforeAfterVisitor(pp.Before, pp.After).Walk(x)
 }
 
 type prettyPrinter struct {
@@ -26,29 +26,19 @@ type prettyPrinter struct {
 	w     io.Writer
 }
 
-func (pp *prettyPrinter) Before(x interface{}) {
+func (pp *prettyPrinter) Before(x interface{}) bool {
 	switch x.(type) {
 	case *Term:
 	default:
 		pp.depth++
 	}
-}
 
-func (pp *prettyPrinter) After(x interface{}) {
-	switch x.(type) {
-	case *Term:
-	default:
-		pp.depth--
-	}
-}
-
-func (pp *prettyPrinter) Visit(x interface{}) Visitor {
 	switch x := x.(type) {
 	case *Term:
-		return pp
+		return false
 	case Args:
 		if len(x) == 0 {
-			return pp
+			return false
 		}
 		pp.writeType(x)
 	case *Expr:
@@ -63,7 +53,15 @@ func (pp *prettyPrinter) Visit(x interface{}) Visitor {
 	default:
 		pp.writeType(x)
 	}
-	return pp
+	return false
+}
+
+func (pp *prettyPrinter) After(x interface{}) {
+	switch x.(type) {
+	case *Term:
+	default:
+		pp.depth--
+	}
 }
 
 func (pp *prettyPrinter) writeValue(x interface{}) {

--- a/ast/term.go
+++ b/ast/term.go
@@ -463,14 +463,14 @@ func (term *Term) UnmarshalJSON(bs []byte) error {
 // Vars returns a VarSet with variables contained in this term.
 func (term *Term) Vars() VarSet {
 	vis := &VarVisitor{vars: VarSet{}}
-	Walk(vis, term)
+	vis.Walk(term)
 	return vis.vars
 }
 
 // IsConstant returns true if the AST value is constant.
 func IsConstant(v Value) bool {
 	found := false
-	Walk(&GenericVisitor{
+	vis := GenericVisitor{
 		func(x interface{}) bool {
 			switch x.(type) {
 			case Var, Ref, *ArrayComprehension, *ObjectComprehension, *SetComprehension, Call:
@@ -479,7 +479,8 @@ func IsConstant(v Value) bool {
 			}
 			return false
 		},
-	}, v)
+	}
+	vis.Walk(v)
 	return !found
 }
 
@@ -1080,7 +1081,7 @@ func (ref Ref) String() string {
 //  this expression in isolation.
 func (ref Ref) OutputVars() VarSet {
 	vis := NewVarVisitor().WithParams(VarVisitorParams{SkipRefHead: true})
-	Walk(vis, ref)
+	vis.Walk(ref)
 	return vis.Vars()
 }
 

--- a/ast/term_test.go
+++ b/ast/term_test.go
@@ -709,12 +709,13 @@ func TestSetOperations(t *testing.T) {
 func TestSetCopy(t *testing.T) {
 	orig := MustParseTerm("{1,2,3}")
 	cpy := orig.Copy()
-	Walk(NewGenericVisitor(func(x interface{}) bool {
+	vis := NewGenericVisitor(func(x interface{}) bool {
 		if Compare(IntNumberTerm(2), x) == 0 {
 			x.(*Term).Value = String("modified")
 		}
 		return false
-	}), orig)
+	})
+	vis.Walk(orig)
 	expOrig := MustParseTerm(`{1, "modified", 3}`)
 	expCpy := MustParseTerm(`{1,2,3}`)
 	if !expOrig.Equal(orig) {

--- a/ast/unify.go
+++ b/ast/unify.go
@@ -123,7 +123,7 @@ func (u *unifier) unify(a *Term, b *Term) {
 
 func (u *unifier) markAllSafe(x Value) {
 	vis := u.varVisitor()
-	Walk(vis, x)
+	vis.Walk(x)
 	for v := range vis.Vars() {
 		u.markSafe(v)
 	}
@@ -163,7 +163,7 @@ func (u *unifier) unifyAll(a Var, b Value) {
 		u.markAllSafe(b)
 	} else {
 		vis := u.varVisitor()
-		Walk(vis, b)
+		vis.Walk(b)
 		unsafe := vis.Vars().Diff(u.safe).Diff(u.unified)
 		if len(unsafe) == 0 {
 			u.markSafe(a)

--- a/format/format.go
+++ b/format/format.go
@@ -138,7 +138,7 @@ func (w *writer) writeModule(module *ast.Module) {
 			return false
 		}
 	})
-	ast.Walk(visitor, module)
+	visitor.Walk(module)
 
 	sort.Slice(comments, func(i, j int) bool {
 		return locLess(comments[i], comments[j])

--- a/rego/rego.go
+++ b/rego/rego.go
@@ -1949,7 +1949,7 @@ func iteration(x interface{}) bool {
 		return stopped
 	})
 
-	ast.Walk(vis, x)
+	vis.Walk(x)
 
 	return stopped
 }

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -1082,7 +1082,7 @@ func (r *REPL) printTypes(ctx context.Context, typeEnv *ast.TypeEnv, body ast.Bo
 		SkipRefHead: true,
 	})
 
-	ast.Walk(vis, body)
+	vis.Walk(body)
 
 	for v := range vis.Vars() {
 		fmt.Fprintf(r.output, "# %v: %v\n", v, typeEnv.Get(v))

--- a/topdown/eval.go
+++ b/topdown/eval.go
@@ -949,7 +949,7 @@ func getSavePairs(x *ast.Term, b *bindings, result []savePair) []savePair {
 		SkipClosures: true,
 		SkipRefHead:  true,
 	})
-	ast.Walk(vis, x)
+	vis.Walk(x)
 	for v := range vis.Vars() {
 		y, next := b.apply(ast.NewTerm(v))
 		result = getSavePairs(y, next, result)
@@ -2239,7 +2239,7 @@ func canInlineNegation(safe ast.VarSet, queries []ast.Body) bool {
 					SkipRefCallHead: true,
 					SkipClosures:    true,
 				})
-				ast.Walk(vis, expr)
+				vis.Walk(expr)
 				unsafe := vis.Vars().Diff(safe).Diff(ast.ReservedVars)
 				if len(unsafe) > 0 {
 					return false


### PR DESCRIPTION
Unlike the generic Walk implementations, they don't necessitate allocating the visitor itself from heap.

This deprecates ast.Visitor, ast.BeforeAndAfterVisitor, ast.Walk, and ast.WalkBeforeAndAfter.

Benchmarks changed:

    name                                  old time/op    new time/op    delta
    PartialEval/1-16                        6.41µs ± 1%    6.35µs ± 1%   -1.01%  (p=0.001 n=10+10)
    PartialEval/10-16                       6.47µs ± 1%    6.37µs ± 1%   -1.48%  (p=0.000 n=10+10)
    PartialEval/100-16                      6.81µs ± 1%    6.78µs ± 1%   -0.44%  (p=0.041 n=9+10)
    PartialEval/1000-16                     6.64µs ± 2%    6.57µs ± 2%   -1.02%  (p=0.037 n=10+10)
    PartialEvalCompile/1-16                 3.08ms ± 0%    2.99ms ± 0%   -2.73%  (p=0.000 n=8+9)
    PartialEvalCompile/10-16                4.17ms ± 0%    3.97ms ± 1%   -4.67%  (p=0.000 n=9+9)
    PartialEvalCompile/100-16               25.1ms ± 1%    22.9ms ± 1%   -8.67%  (p=0.000 n=9+10)
    PartialEvalCompile/1000-16               1.27s ± 2%     1.20s ± 1%   -5.37%  (p=0.000 n=10+9)
    InliningFullScan/1000-16                5.24ms ± 1%    4.83ms ± 1%   -7.75%  (p=0.000 n=10+10)
    InliningFullScan/10000-16               55.0ms ± 0%    51.0ms ± 1%   -7.25%  (p=0.000 n=9+10)
    InliningFullScan/300000-16               1.59s ± 1%     1.48s ± 1%   -6.63%  (p=0.000 n=9+9)

    name                                  old alloc/op   new alloc/op   delta
    Concurrency1-16                          100MB ± 0%     100MB ± 0%   -0.05%  (p=0.000 n=10+10)
    Concurrency2-16                          100MB ± 0%     100MB ± 0%   -0.05%  (p=0.000 n=10+10)
    Concurrency4-16                          100MB ± 0%     100MB ± 0%   -0.05%  (p=0.000 n=9+10)
    Concurrency8-16                          100MB ± 0%     100MB ± 0%   -0.05%  (p=0.000 n=10+10)
    Concurrency4Readers1Writer-16            100MB ± 0%     100MB ± 0%   -0.05%  (p=0.000 n=10+10)
    Concurrency8Writers-16                   100MB ± 0%     100MB ± 0%   -0.05%  (p=0.000 n=10+10)
    PartialEvalCompile/1-16                 1.31MB ± 0%    1.29MB ± 0%   -1.10%  (p=0.000 n=8+9)
    PartialEvalCompile/10-16                1.74MB ± 0%    1.70MB ± 0%   -2.42%  (p=0.000 n=9+10)
    PartialEvalCompile/100-16               8.90MB ± 0%    8.58MB ± 0%   -3.58%  (p=0.000 n=10+9)
    PartialEvalCompile/1000-16               370MB ± 0%     366MB ± 0%   -0.84%  (p=0.000 n=9+9)
    Walk/100-16                              361kB ± 0%     360kB ± 0%   -0.32%  (p=0.000 n=10+10)
    Walk/1000-16                             413kB ± 0%     412kB ± 0%   -0.28%  (p=0.000 n=10+10)
    Walk/2000-16                             471kB ± 0%     470kB ± 0%   -0.24%  (p=0.000 n=10+10)
    Walk/3000-16                             527kB ± 0%     526kB ± 0%   -0.22%  (p=0.000 n=9+10)
    InliningFullScan/1000-16                2.77MB ± 0%    2.68MB ± 0%   -3.18%  (p=0.000 n=9+10)
    InliningFullScan/10000-16               28.2MB ± 0%    27.4MB ± 0%   -3.12%  (p=0.000 n=10+10)
    InliningFullScan/300000-16               852MB ± 0%     825MB ± 0%   -3.10%  (p=0.000 n=10+9)