### PR TITLE
topdown: Fix bug in var rewriting during trace formatting

### DIFF
--- a/topdown/trace_test.go
+++ b/topdown/trace_test.go
@@ -340,3 +340,23 @@ func TestTraceRewrittenQueryVars(t *testing.T) {
 		t.Errorf("Expected %v but got %v", exp, node)
 	}
 }
+
+func TestTraceRewrittenVarsIssue2022(t *testing.T) {
+
+	input := &Event{
+		Node: &ast.Expr{
+			Terms: ast.VarTerm("foo"),
+		},
+		LocalMetadata: map[ast.Var]VarMetadata{
+			ast.Var("foo"): VarMetadata{Name: ast.Var("bar")},
+		},
+	}
+
+	output := rewrite(input)
+
+	if input.Node == output.Node {
+		t.Fatal("expected node to have been copied")
+	} else if !output.Node.(*ast.Expr).Equal(ast.NewExpr(ast.VarTerm("bar"))) {
+		t.Fatal("expected copy to contain rewritten var")
+	}
+}


### PR DESCRIPTION
This commit fixes a bug in the var rewritting improvement that was
introduced in v0.16.0. With this change the rewriting is performed on
the deep copied node as it should be. Also, this change updates the
rewriting to use the ast.TransformVars helper instead of the generic
visitor so that object keys and sets are handled properly.

Fixes #2022

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
