### PR TITLE
envoy-authorization: fix token validity code

### DIFF
--- a/docs/content/envoy-authorization.md
+++ b/docs/content/envoy-authorization.md
@@ -127,7 +127,9 @@ allow {
 
 is_token_valid {
   token.valid
-  token.payload.nbf <= time.now_ns() < token.payload.exp
+  now := time.now_ns()
+  token.payload.nbf <= now
+  now < token.payload.exp
 }
 
 action_allowed {


### PR DESCRIPTION
Before, this would have been valid rego, but its meaning probably wasn't what was intended, compare:

```
> 1 < 2 <= 3
true
> 1 < 2
true
> true <= 3
true
> 1 < 1 < 3
true
> 1 < 1
false
```