### PR TITLE
envoy-authorization: de-clutter time.now_ns() usage

### DIFF
--- a/docs/content/envoy-authorization.md
+++ b/docs/content/envoy-authorization.md
@@ -127,9 +127,8 @@ allow {
 
 is_token_valid {
   token.valid
-  now := time.now_ns()
-  token.payload.nbf <= now
-  now < token.payload.exp
+  token.payload.nbf <= time.now_ns()
+  time.now_ns() < token.payload.exp
 }
 
 action_allowed {


### PR DESCRIPTION
I wasn't aware of time.now_ns() _caching_:

https://github.com/open-policy-agent/opa/blob/89c7f4b28fe84/topdown/time.go#L25-L39

To not give anyone the same (false) impression, let's fix this.
