### PR TITLE
ast: Fix panic in module parsing

### DIFF
--- a/ast/parser_ext.go
+++ b/ast/parser_ext.go
@@ -142,6 +142,10 @@ func ParseRuleFromExpr(module *Module, expr *Expr) (*Rule, error) {
 		return nil, fmt.Errorf("negated expressions cannot be used for rule head")
 	}
 
+	if _, ok := expr.Terms.(*SomeDecl); ok {
+		return nil, errors.New("some declarations cannot be used for rule head")
+	}
+
 	if term, ok := expr.Terms.(*Term); ok {
 		switch v := term.Value.(type) {
 		case Ref:
@@ -149,6 +153,12 @@ func ParseRuleFromExpr(module *Module, expr *Expr) (*Rule, error) {
 		default:
 			return nil, fmt.Errorf("%v cannot be used for rule name", TypeName(v))
 		}
+	}
+
+	if _, ok := expr.Terms.([]*Term); !ok {
+		// This is a defensive check in case other kinds of expression terms are
+		// introduced in the future.
+		return nil, errors.New("expression cannot be used for rule head")
 	}
 
 	if expr.IsAssignment() {

--- a/ast/parser_test.go
+++ b/ast/parser_test.go
@@ -1427,6 +1427,11 @@ data = {"bar": 2} { true }`
 
 	"foo" := 1`
 
+	someDecl := `
+	package a
+
+	some x`
+
 	assertParseModuleError(t, "multiple expressions", multipleExprs)
 	assertParseModuleError(t, "non-equality", nonEquality)
 	assertParseModuleError(t, "non-var name", nonVarName)
@@ -1437,6 +1442,13 @@ data = {"bar": 2} { true }`
 	assertParseModuleError(t, "non ref term", nonRefTerm)
 	assertParseModuleError(t, "zero args", zeroArgs)
 	assertParseModuleError(t, "assign to term", assignToTerm)
+	assertParseModuleError(t, "some decl", someDecl)
+
+	if _, err := ParseRuleFromExpr(&Module{}, &Expr{
+		Terms: struct{}{},
+	}); err == nil {
+		t.Fatal("expected error for unknown expression term type")
+	}
 }
 
 func TestWildcards(t *testing.T) {


### PR DESCRIPTION
If the module contained a some statement the parser would panic. This
change fixes the parser to just return an error indicating the some
statement cannot be interpreted as a rule.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
