### PR TITLE
Add plugin status plumbing and update server to use it

### DIFF
--- a/docs/content/kubernetes-tutorial.md
+++ b/docs/content/kubernetes-tutorial.md
@@ -187,7 +187,7 @@ spec:
               name: opa-server
           readinessProbe:
             httpGet:
-              path: /health
+              path: /health?plugins&bundle
               scheme: HTTPS
               port: 443
             initialDelaySeconds: 3

--- a/docs/content/monitoring.md
+++ b/docs/content/monitoring.md
@@ -30,3 +30,8 @@ scrape_configs:
 
 OPA exposes a `/health` API endpoint that can be used to perform health checks.
 See [Health API](../rest-api#health-api) for details.
+
+### Status API
+
+OPA provides a plugin which can push status to a remote service.
+See [Status API](../management#status) for details.

--- a/docs/content/rest-api.md
+++ b/docs/content/rest-api.md
@@ -2045,18 +2045,18 @@ that the server is operational. Optionally it can account for bundle activation 
 (useful for "ready" checks at startup).
 
 #### Query Parameters
-`bundle` - Boolean parameter to account for bundle activation status in response.
+`bundles` - Boolean parameter to account for bundle activation status in response. This includes
+            any discovery bundles or bundles defined in the loaded discovery configuration.
 `plugins` - Boolean parameter to account for plugin status in response.
 
 #### Status Codes
-- **200** - OPA service is healthy. If `bundle=true` then all configured bundles have
+- **200** - OPA service is healthy. If the `bundles` option is specified then all configured bundles have
             been activated. If the `plugins` option is specified then all plugins are in an OK state.
-- **500** - OPA service is not healthy. If `bundle=true` this can mean any of the configured
+- **500** - OPA service is not healthy. If the `bundles` option is specified this can mean any of the configured
             bundles have not yet been activated. If the `plugins` option is specified then at least one
             plugin is in a non-OK state.
-            
 
-> *Note*: The bundle activation check is only for initial startup. Subsequent downloads
+> *Note*: The bundle activation check is only for initial bundle activation. Subsequent downloads
   will not affect the health check. The [Status](../management/#status)
   API should be used for more fine-grained bundle status monitoring.
 
@@ -2067,7 +2067,7 @@ GET /health HTTP/1.1
 
 #### Example Request (bundle activation)
 ```http
-GET /health?bundle=true HTTP/1.1
+GET /health?bundles HTTP/1.1
 ```
 
 #### Example Request (plugin status)

--- a/docs/content/rest-api.md
+++ b/docs/content/rest-api.md
@@ -2046,12 +2046,15 @@ that the server is operational. Optionally it can account for bundle activation 
 
 #### Query Parameters
 `bundle` - Boolean parameter to account for bundle activation status in response.
+`plugins` - Boolean parameter to account for plugin status in response.
 
 #### Status Codes
 - **200** - OPA service is healthy. If `bundle=true` then all configured bundles have
-            been activated.
+            been activated. If the `plugins` option is specified then all plugins are in an OK state.
 - **500** - OPA service is not healthy. If `bundle=true` this can mean any of the configured
-            bundles have not yet been activated.
+            bundles have not yet been activated. If the `plugins` option is specified then at least one
+            plugin is in a non-OK state.
+            
 
 > *Note*: The bundle activation check is only for initial startup. Subsequent downloads
   will not affect the health check. The [Status](../management/#status)
@@ -2065,6 +2068,11 @@ GET /health HTTP/1.1
 #### Example Request (bundle activation)
 ```http
 GET /health?bundle=true HTTP/1.1
+```
+
+#### Example Request (plugin status)
+```http
+GET /health?plugins HTTP/1.1
 ```
 
 #### Healthy Response

--- a/plugins/bundle/plugin.go
+++ b/plugins/bundle/plugin.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"reflect"
 	"sync"
+	"time"
 
 	"github.com/sirupsen/logrus"
 
@@ -36,6 +37,7 @@ type Plugin struct {
 	mtx           sync.Mutex
 	cfgMtx        sync.Mutex
 	legacyConfig  bool
+	ready         bool
 }
 
 // New returns a new Plugin with the given config.
@@ -53,8 +55,10 @@ func New(parsedConfig *Config, manager *plugins.Manager) *Plugin {
 		status:      initialStatus,
 		downloaders: make(map[string]*download.Downloader),
 		etags:       make(map[string]string),
+		ready:       false,
 	}
-	p.initDownloaders()
+
+	manager.UpdatePluginStatus(Name, &plugins.Status{State: plugins.StateNotReady})
 	return p
 }
 
@@ -75,6 +79,7 @@ func Lookup(manager *plugins.Manager) *Plugin {
 func (p *Plugin) Start(ctx context.Context) error {
 	p.mtx.Lock()
 	defer p.mtx.Unlock()
+	p.initDownloaders()
 	for name, dl := range p.downloaders {
 		p.logInfo(name, "Starting bundle downloader.")
 		dl.Start(ctx)
@@ -160,6 +165,8 @@ func (p *Plugin) Reconfigure(ctx context.Context, config interface{}) {
 		panic(errors.New("Unable deactivate bundle: " + err.Error()))
 	}
 
+	readyNow := p.ready
+
 	for name, source := range p.config.Bundles {
 		_, updated := updatedBundles[name]
 		_, isNew := newBundles[name]
@@ -173,8 +180,15 @@ func (p *Plugin) Reconfigure(ctx context.Context, config interface{}) {
 			}
 			p.downloaders[name] = p.newDownloader(name, source)
 			p.downloaders[name].Start(ctx)
+			readyNow = false
 		}
 	}
+
+	if !readyNow {
+		p.ready = false
+		p.manager.UpdatePluginStatus(Name, &plugins.Status{State: plugins.StateNotReady})
+	}
+
 }
 
 // Register a listener to receive status updates. The name must be comparable.
@@ -298,6 +312,23 @@ func (p *Plugin) process(ctx context.Context, name string, u download.Update) {
 			p.logInfo(name, "Bundle downloaded and activated successfully.")
 		}
 		p.etags[name] = u.ETag
+
+		// If the plugin wasn't ready yet then check if we are now after activating this bundle.
+		if !p.ready {
+			readyNow := true // optimistically
+			for _, status := range p.status {
+				if len(status.Errors) > 0 || (status.LastSuccessfulActivation == time.Time{}) {
+					readyNow = false // Not ready yet, check again on next bundle activation.
+					break
+				}
+			}
+
+			if readyNow {
+				p.ready = true
+				p.manager.UpdatePluginStatus(Name, &plugins.Status{State: plugins.StateOK})
+			}
+
+		}
 		return
 	}
 

--- a/plugins/discovery/discovery_test.go
+++ b/plugins/discovery/discovery_test.go
@@ -372,12 +372,14 @@ func TestStatusUpdates(t *testing.T) {
 
 	for !ok && time.Since(t0) < time.Second {
 		updates = ts.Updates()
-		ok = len(updates) == 5 &&
-			updates[0].Discovery.ActiveRevision == "test-revision-1" && updates[0].Discovery.Code == "" &&
-			updates[1].Discovery.ActiveRevision == "test-revision-1" && updates[1].Discovery.Code == "bundle_error" &&
-			updates[2].Discovery.ActiveRevision == "test-revision-2" && updates[2].Discovery.Code == "" &&
-			updates[3].Discovery.ActiveRevision == "test-revision-2" && updates[3].Discovery.Code == "bundle_error" &&
-			updates[4].Discovery.ActiveRevision == "test-revision-2" && updates[4].Discovery.Code == ""
+		ok = len(updates) == 7 &&
+			updates[0].Plugins["discovery"].State == plugins.StateNotReady && updates[0].Plugins["status"].State == plugins.StateOK &&
+			updates[1].Plugins["discovery"].State == plugins.StateOK && updates[1].Plugins["status"].State == plugins.StateOK &&
+			updates[2].Plugins["discovery"].State == plugins.StateOK && updates[2].Discovery.ActiveRevision == "test-revision-1" && updates[2].Discovery.Code == "" &&
+			updates[3].Plugins["discovery"].State == plugins.StateOK && updates[3].Discovery.ActiveRevision == "test-revision-1" && updates[3].Discovery.Code == "bundle_error" &&
+			updates[4].Plugins["discovery"].State == plugins.StateOK && updates[4].Discovery.ActiveRevision == "test-revision-2" && updates[4].Discovery.Code == "" &&
+			updates[5].Plugins["discovery"].State == plugins.StateOK && updates[5].Discovery.ActiveRevision == "test-revision-2" && updates[5].Discovery.Code == "bundle_error" &&
+			updates[6].Plugins["discovery"].State == plugins.StateOK && updates[6].Discovery.ActiveRevision == "test-revision-2" && updates[6].Discovery.Code == ""
 	}
 
 	if !ok {

--- a/plugins/logs/plugin.go
+++ b/plugins/logs/plugin.go
@@ -234,6 +234,8 @@ func New(parsedConfig *Config, manager *plugins.Manager) *Plugin {
 
 	manager.RegisterCompilerTrigger(plugin.compilerUpdated)
 
+	manager.UpdatePluginStatus(Name, &plugins.Status{State: plugins.StateNotReady})
+
 	return plugin
 }
 
@@ -252,6 +254,7 @@ func Lookup(manager *plugins.Manager) *Plugin {
 func (p *Plugin) Start(ctx context.Context) error {
 	p.logInfo("Starting decision logger.")
 	go p.loop()
+	p.manager.UpdatePluginStatus(Name, &plugins.Status{State: plugins.StateOK})
 	return nil
 }
 
@@ -261,6 +264,7 @@ func (p *Plugin) Stop(ctx context.Context) {
 	done := make(chan struct{})
 	p.stop <- done
 	_ = <-done
+	p.manager.UpdatePluginStatus(Name, &plugins.Status{State: plugins.StateNotReady})
 }
 
 // Log appends a decision log event to the buffer for uploading.

--- a/plugins/logs/plugin_test.go
+++ b/plugins/logs/plugin_test.go
@@ -446,6 +446,8 @@ func TestPluginReconfigure(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	ensurePluginState(t, fixture.plugin, plugins.StateOK)
+
 	minDelay := 2
 	maxDelay := 3
 
@@ -460,7 +462,10 @@ func TestPluginReconfigure(t *testing.T) {
 	config, _ := ParseConfig(pluginConfig, fixture.manager.Services(), nil)
 
 	fixture.plugin.Reconfigure(ctx, config)
+	ensurePluginState(t, fixture.plugin, plugins.StateOK)
+
 	fixture.plugin.Stop(ctx)
+	ensurePluginState(t, fixture.plugin, plugins.StateNotReady)
 
 	actualMin := time.Duration(*fixture.plugin.config.Reporting.MinDelaySeconds) / time.Nanosecond
 	expectedMin := time.Duration(minDelay) * time.Second
@@ -887,7 +892,13 @@ func newTestFixture(t *testing.T) testFixture {
 
 	config, _ := ParseConfig([]byte(pluginConfig), manager.Services(), nil)
 
+	if s, ok := manager.PluginStatus()[Name]; ok {
+		t.Fatalf("Unexpected status found in plugin manager for %s: %+v", Name, s)
+	}
+
 	p := New(config, manager)
+
+	ensurePluginState(t, p, plugins.StateNotReady)
 
 	return testFixture{
 		manager: manager,
@@ -1025,4 +1036,16 @@ func getWellKnownMetrics() metrics.Metrics {
 	m := metrics.New()
 	m.Counter("test_counter").Incr()
 	return m
+}
+
+func ensurePluginState(t *testing.T, p *Plugin, state plugins.State) {
+	t.Helper()
+	status, ok := p.manager.PluginStatus()[Name]
+	if !ok {
+		t.Fatalf("Expected to find state for %s, found nil", Name)
+		return
+	}
+	if status.State != state {
+		t.Fatalf("Unexpected status state found in plugin manager for %s:\n\n\tFound:%+v\n\n\tExpected: %s", Name, status.State, plugins.StateOK)
+	}
 }

--- a/plugins/plugins_test.go
+++ b/plugins/plugins_test.go
@@ -1,0 +1,116 @@
+// Copyright 2020 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package plugins
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/open-policy-agent/opa/storage/inmem"
+)
+
+func TestManagerPluginStatusListener(t *testing.T) {
+	m, err := New([]byte{}, "test", inmem.New())
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
+
+	// Start by registering a single listener and validate that it was registered correctly
+	var l1Status map[string]*Status
+	m.RegisterPluginStatusListener("l1", func(status map[string]*Status) {
+		l1Status = status
+	})
+	if len(m.pluginStatusListeners) != 1 || m.pluginStatusListeners["l1"] == nil {
+		t.Fatalf("Expected a single listener named 'l1' got: %+v", m.pluginStatusListeners)
+	}
+
+	// Register a second one, validate both are there
+	var l2Status map[string]*Status
+	m.RegisterPluginStatusListener("l2", func(status map[string]*Status) {
+		l2Status = status
+	})
+	if len(m.pluginStatusListeners) != 2 || m.pluginStatusListeners["l2"] == nil {
+		t.Fatalf("Expected a two listeners named 'l1' and 'l2' got: %+v", m.pluginStatusListeners)
+	}
+
+	// Ensure starting statuses are empty by default
+	currentStatus := m.PluginStatus()
+	if len(currentStatus) != 0 {
+		t.Fatalf("Expected 0 statuses in current plugin status map, got: %+v", currentStatus)
+	}
+
+	// Push an update to a plugin, ensure current status is reflected and listeners were called
+	m.UpdatePluginStatus("p1", &Status{State: StateOK})
+	currentStatus = m.PluginStatus()
+	if len(currentStatus) != 1 || currentStatus["p1"].State != StateOK {
+		t.Fatalf("Expected 1 statuses in current plugin status map with state OK, got: %+v", currentStatus)
+	}
+	if !reflect.DeepEqual(currentStatus, l1Status) || !reflect.DeepEqual(l1Status, l2Status) {
+		t.Fatalf("Unexpected status in updates:\n\n\texpecting: %+v\n\n\tgot: l1: %+v  l2: %+v\n", currentStatus, l1Status, l2Status)
+	}
+
+	// Unregister the first listener, ensure it is removed
+	m.UnregisterPluginStatusListener("l1")
+	if len(m.pluginStatusListeners) != 1 || m.pluginStatusListeners["l2"] == nil {
+		t.Fatalf("Expected a single listeners named 'l2' got: %+v", m.pluginStatusListeners)
+	}
+
+	// Send another update, ensure the status is ok and the remaining listener is still called
+	m.UpdatePluginStatus("p2", &Status{State: StateErr})
+	currentStatus = m.PluginStatus()
+	if len(currentStatus) != 2 || currentStatus["p1"].State != StateOK || currentStatus["p2"].State != StateErr {
+		t.Fatalf("Unexpected current plugin status, got: %+v", currentStatus)
+	}
+	if !reflect.DeepEqual(currentStatus, l2Status) {
+		t.Fatalf("Unexpected status in updates:\n\n\texpecting: %+v\n\n\tgot: %+v\n", currentStatus, l2Status)
+	}
+
+	// Unregister the last listener
+	m.UnregisterPluginStatusListener("l2")
+	if len(m.pluginStatusListeners) != 0 {
+		t.Fatalf("Expected zero listeners got: %+v", m.pluginStatusListeners)
+	}
+
+	// Ensure updates can still be sent with no listeners
+	m.UpdatePluginStatus("p2", &Status{State: StateOK})
+	currentStatus = m.PluginStatus()
+	if len(currentStatus) != 2 || currentStatus["p1"].State != StateOK || currentStatus["p2"].State != StateOK {
+		t.Fatalf("Unexpected current plugin status, got: %+v", currentStatus)
+	}
+}
+
+func TestPluginStatusUpdateOnStartAndStop(t *testing.T) {
+	m, err := New([]byte{}, "test", inmem.New())
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
+
+	m.Register("p1", &testPlugin{m})
+
+	err = m.Start(context.Background())
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
+
+	m.Stop(context.Background())
+}
+
+type testPlugin struct {
+	m *Manager
+}
+
+func (p *testPlugin) Start(ctx context.Context) error {
+	p.m.UpdatePluginStatus("p1", &Status{State: StateOK})
+	return nil
+}
+
+func (p *testPlugin) Stop(ctx context.Context) {
+	p.m.UpdatePluginStatus("p1", &Status{State: StateNotReady})
+}
+
+func (p *testPlugin) Reconfigure(ctx context.Context, config interface{}) {
+	p.m.UpdatePluginStatus("p1", &Status{State: StateNotReady})
+}

--- a/server/server.go
+++ b/server/server.go
@@ -900,7 +900,8 @@ func (s *Server) bundlesReady(pluginStatuses map[string]*plugins.Status) bool {
 
 func (s *Server) unversionedGetHealth(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	includeBundleStatus := getBoolParam(r.URL, types.ParamBundleActivationV1, true)
+	includeBundleStatus := getBoolParam(r.URL, types.ParamBundleActivationV1, true) ||
+		getBoolParam(r.URL, types.ParamBundlesActivationV1, true)
 	includePluginStatus := getBoolParam(r.URL, types.ParamPluginsV1, true)
 
 	// Ensure the server can evaluate a simple query

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -67,7 +67,7 @@ func TestUnversionedGetHealthBundleNoBundleSet(t *testing.T) {
 
 	f := newFixture(t)
 
-	req := newReqUnversioned(http.MethodGet, "/health?bundle=true", "")
+	req := newReqUnversioned(http.MethodGet, "/health?bundles=true", "")
 	if err := f.executeRequest(req, 200, `{}`); err != nil {
 		t.Fatalf("Unexpected error while health check: %v", err)
 	}
@@ -82,7 +82,7 @@ func TestUnversionedGetHealthCheckOnlyBundlePlugin(t *testing.T) {
 	f.server.manager.UpdatePluginStatus("bundle", &plugins.Status{State: plugins.StateNotReady})
 
 	// The bundle hasn't been activated yet, expect the health check to fail
-	req := newReqUnversioned(http.MethodGet, "/health?bundle=true", "")
+	req := newReqUnversioned(http.MethodGet, "/health?bundles=true", "")
 	if err := f.executeRequest(req, 500, `{}`); err != nil {
 		t.Fatal(err)
 	}
@@ -91,7 +91,7 @@ func TestUnversionedGetHealthCheckOnlyBundlePlugin(t *testing.T) {
 	f.server.manager.UpdatePluginStatus("bundle", &plugins.Status{State: plugins.StateOK})
 
 	// The heath check should now respond as healthy
-	req = newReqUnversioned(http.MethodGet, "/health?bundle=true", "")
+	req = newReqUnversioned(http.MethodGet, "/health?bundles=true", "")
 	if err := f.executeRequest(req, 200, `{}`); err != nil {
 		t.Fatal(err)
 	}
@@ -105,7 +105,7 @@ func TestUnversionedGetHealthCheckDiscoveryWithBundle(t *testing.T) {
 	f.server.manager.UpdatePluginStatus("discovery", &plugins.Status{State: plugins.StateNotReady})
 
 	// The discovery bundle hasn't been activated yet, expect the health check to fail
-	req := newReqUnversioned(http.MethodGet, "/health?bundle=true", "")
+	req := newReqUnversioned(http.MethodGet, "/health?bundles=true", "")
 	if err := f.executeRequest(req, 500, `{}`); err != nil {
 		t.Fatal(err)
 	}
@@ -115,7 +115,7 @@ func TestUnversionedGetHealthCheckDiscoveryWithBundle(t *testing.T) {
 	f.server.manager.UpdatePluginStatus("bundle", &plugins.Status{State: plugins.StateNotReady})
 
 	// The discovery bundle is OK, but the newly configured bundle hasn't been activated yet, expect the health check to fail
-	req = newReqUnversioned(http.MethodGet, "/health?bundle=true", "")
+	req = newReqUnversioned(http.MethodGet, "/health?bundles=true", "")
 	if err := f.executeRequest(req, 500, `{}`); err != nil {
 		t.Fatal(err)
 	}
@@ -124,7 +124,7 @@ func TestUnversionedGetHealthCheckDiscoveryWithBundle(t *testing.T) {
 	f.server.manager.UpdatePluginStatus("bundle", &plugins.Status{State: plugins.StateOK})
 
 	// The heath check should now respond as healthy
-	req = newReqUnversioned(http.MethodGet, "/health?bundle=true", "")
+	req = newReqUnversioned(http.MethodGet, "/health?bundles=true", "")
 	if err := f.executeRequest(req, 200, `{}`); err != nil {
 		t.Fatal(err)
 	}
@@ -448,7 +448,7 @@ func TestUnversionedGetHealthCheckBundleAndPlugins(t *testing.T) {
 				f.server.manager.UpdatePluginStatus(name, status)
 			}
 
-			req := newReqUnversioned(http.MethodGet, "/health?plugins&bundle", "")
+			req := newReqUnversioned(http.MethodGet, "/health?plugins&bundles", "")
 			if err := f.executeRequest(req, tc.exp, `{}`); err != nil {
 				t.Fatal(err)
 			}

--- a/server/types/types.go
+++ b/server/types/types.go
@@ -427,7 +427,18 @@ const (
 	// ParamBundleActivationV1 defines the name of the HTTP URL parameter that
 	// indicates the client wants to include bundle activation in the results
 	// of the health API.
+	// Deprecated: Use ParamBundlesActivationV1 instead.
 	ParamBundleActivationV1 = "bundle"
+
+	// ParamBundlesActivationV1 defines the name of the HTTP URL parameter that
+	// indicates the client wants to include bundle activation in the results
+	// of the health API.
+	ParamBundlesActivationV1 = "bundles"
+
+	// ParamPluginsV1 defines the name of the HTTP URL parameter that
+	// indicates the client wants to include bundle status in the results
+	// of the health API.
+	ParamPluginsV1 = "plugins"
 )
 
 // BadRequestErr represents an error condition raised if the caller passes


### PR DESCRIPTION
This PR adds in a concept of plugin's being able to report their own status to the plugin manager. There is then plumbing added for status update listeners, which the status plugin does. The OPA server has been updated to use the plugin statuses for the bundle and discovery plugin to more correctly report on `/health?bundle=true` for readiness probes (it used to not include discovery at all). In addition the server has a new option for `/health?plugins` that will return a status based on _all_ plugins registered (and reporting status). This gives plugin developers a way to influence the result of the health check if a plugin goes into an error state or needs time to initialize.

Its broken up into smaller bite-sized commits, each with a commit message explaining more about what changed.

Fixes: #2010 
Fixes: #2015 