### PR TITLE
docs: Remove stray = from intro

### DIFF
--- a/docs/content/policy-language.md
+++ b/docs/content/policy-language.md
@@ -152,8 +152,8 @@ The order of expressions in a rule does not affect the document’s content.
 ```live:eg/expression_order:module
 s {
     x > y
-    y = 41
-    x = 42
+    y := 41
+    x := 42
 }
 ```
 


### PR DESCRIPTION
Previously we used x = 42 as an assignment in the policy language
document, when now we recommend using x := 42 in its place.

This particular occurrence may have been left intentionally
as = because it appears in a discussion of order-irrelevance, but
on balance the newer := still seems better.

Any thoughts as to leaving this as =?


<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
