### PR TITLE
ast: Return an error when parsing an empty module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Compatibility Notes
+
+- The `ast.ParseModule` helper will now return an error if an empty module is provided.
+  Previously it would return a `nil` error and `nil` module. ([#2054](https://github.com/open-policy-agent/opa/issues/2054))
+  
 ## 0.17.2
 
 ### Fixes

--- a/ast/compilehelper.go
+++ b/ast/compilehelper.go
@@ -11,11 +11,12 @@ func CompileModules(modules map[string]string) (*Compiler, error) {
 	parsed := make(map[string]*Module, len(modules))
 
 	for f, module := range modules {
-		if pm, err := ParseModule(f, module); err != nil {
+		var pm *Module
+		var err error
+		if pm, err = ParseModule(f, module); err != nil {
 			return nil, err
-		} else if pm != nil {
-			parsed[f] = pm
 		}
+		parsed[f] = pm
 	}
 
 	compiler := NewCompiler()

--- a/ast/parser_ext.go
+++ b/ast/parser_ext.go
@@ -379,7 +379,7 @@ func ParseModule(filename, input string) (*Module, error) {
 	if err != nil {
 		return nil, err
 	}
-	return parseModule(stmts, comments)
+	return parseModule(filename, stmts, comments)
 }
 
 // ParseBody returns exactly one body.
@@ -599,10 +599,10 @@ func formatParserError(filename string, bs []byte, e *parserError) *Error {
 	return err
 }
 
-func parseModule(stmts []Statement, comments []*Comment) (*Module, error) {
+func parseModule(filename string, stmts []Statement, comments []*Comment) (*Module, error) {
 
 	if len(stmts) == 0 {
-		return nil, nil
+		return nil, NewError(ParseErr, &Location{File: filename}, "empty module")
 	}
 
 	var errs Errors

--- a/ast/parser_test.go
+++ b/ast/parser_test.go
@@ -1153,8 +1153,8 @@ f(x) { x > 1000 }`,
 
 func TestEmptyModule(t *testing.T) {
 	r, err := ParseModule("", "    ")
-	if err != nil {
-		t.Errorf("Expected nil for empty module: %s", err)
+	if err == nil {
+		t.Error("Expected error for empty module")
 		return
 	}
 	if r != nil {

--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -201,9 +201,6 @@ func (r *Reader) Read() (Bundle, error) {
 			if err != nil {
 				return bundle, err
 			}
-			if module == nil {
-				return bundle, fmt.Errorf("module '%s' is empty", fullPath)
-			}
 
 			mf := ModuleFile{
 				Path:   fullPath,

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -433,9 +433,6 @@ func loadRego(path string, bs []byte, m metrics.Metrics) (*RegoFile, error) {
 	if err != nil {
 		return nil, err
 	}
-	if module == nil {
-		return nil, emptyModuleError(path)
-	}
 	result := &RegoFile{
 		Name:   path,
 		Parsed: module,

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -467,8 +467,9 @@ func TestLoadErrors(t *testing.T) {
 			"bad_doc.json: bad document type",
 			"a.json: EOF",
 			"b.yaml: error converting YAML to JSON",
-			"empty.rego: empty policy",
+			"empty.rego:0: rego_parse_error: empty module",
 			"x2.json: merge error",
+			"rego_parse_error: empty module",
 		}
 
 		for _, s := range expected {

--- a/rego/rego_test.go
+++ b/rego/rego_test.go
@@ -1436,3 +1436,15 @@ func TestRegoCustomBuiltinPartialPropagate(t *testing.T) {
 	assertResultSet(t, rs, `[[true]]`)
 
 }
+
+func TestPrepareWithEmptyModule(t *testing.T) {
+	_, err := New(
+		Query("d"),
+		Module("example.rego", ""),
+	).PrepareForEval(context.Background())
+
+	expected := "1 error occurred: example.rego:0: rego_parse_error: empty module"
+	if err == nil || err.Error() != expected {
+		t.Fatalf("Expected error %s, got %s", expected, err)
+	}
+}


### PR DESCRIPTION
The documentation is pretty clear that a module must at least contain
a package, so it is safe to say that an empty file isn't valid.

Previously the helper would just return a nil module and nil error, it
will now return an error.

Fixes: #2054
Signed-off-by: Patrick East <east.patrick@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
