### PR TITLE
topdown: Correct glob default delimeter

### DIFF
--- a/topdown/glob.go
+++ b/topdown/glob.go
@@ -24,6 +24,10 @@ func builtinGlobMatch(a, b, c ast.Value) (ast.Value, error) {
 		return nil, err
 	}
 
+	if len(delimiters) == 0 {
+		delimiters = []rune{'.'}
+	}
+
 	match, err := builtins.StringOperand(c, 3)
 	if err != nil {
 		return nil, err

--- a/topdown/glob_test.go
+++ b/topdown/glob_test.go
@@ -30,6 +30,10 @@ func TestGlobMatch(t *testing.T) {
 		{"glob match with pattern-alternatives list (fat)", []string{`p[x] { glob.match("{cat,bat,[fr]at}", [], "fat", x) }`}, "[true]"},
 		{"glob match with pattern-alternatives list (rat)", []string{`p[x] { glob.match("{cat,bat,[fr]at}", [], "rat", x) }`}, "[true]"},
 		{"glob no match with pattern-alternatives list", []string{`p[x] { glob.match("{cat,bat,[fr]at}", [], "at", x) }`}, "[false]"},
+		{"glob match single with . delimiter", []string{`p[x] { glob.match("*", ["."], "foo", x) }`}, "[true]"},
+		{"glob match single with default delimiter", []string{`p[x] { glob.match("*", [], "foo", x) }`}, "[true]"},
+		{"glob no match single with . delimiter", []string{`p[x] { glob.match("*", ["."], "foo.bar", x) }`}, "[false]"},
+		{"glob no match single with default delimiter", []string{`p[x] { glob.match("*", [], "foo.bar", x) }`}, "[false]"},
 	}
 
 	data := loadSmallTestData()


### PR DESCRIPTION
The documentation says that the default delimeter for glob is `["."]`
but the implementation did not actually do this (for the normal built
in).

This corrects the implementation to actually default to the correct
value when it is omitted.

Fixes: #2039
Signed-off-by: Patrick East <east.patrick@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
