### PR TITLE
cover: Exclude `some` expressions in coverage report

### DIFF
--- a/cover/cover.go
+++ b/cover/cover.go
@@ -58,7 +58,7 @@ func (c *Cover) Report(modules map[string]*ast.Module) (report Report) {
 			return false
 		})
 		ast.WalkExprs(module, func(x *ast.Expr) bool {
-			if hasFileLocation(x.Location) {
+			if includeExprInCoverage(x) {
 				if !report.IsCovered(x.Location.File, x.Location.Row) {
 					notCovered = append(notCovered, Position{x.Location.Row})
 				}
@@ -257,4 +257,16 @@ func hasFileLocation(loc *ast.Location) bool {
 // round returns the number with the specified precision.
 func round(number float64, precision int) float64 {
 	return math.Round(number*10*float64(precision)) / (10.0 * float64(precision))
+}
+
+// Check the expression and return true if it should be included in the coverage report
+func includeExprInCoverage(x *ast.Expr) bool {
+	includeExprType := true
+
+	switch x.Terms.(type) {
+	case *ast.SomeDecl:
+		includeExprType = false
+	}
+
+	return includeExprType && hasFileLocation(x.Location)
 }

--- a/cover/cover_test.go
+++ b/cover/cover_test.go
@@ -24,6 +24,7 @@ import data.deadbeef # expect not reported
 
 foo {
 	bar
+	p
 	not baz
 }
 
@@ -37,7 +38,14 @@ baz {     # expect no exit
 	true
 	false # expect eval but fail
 	true  # expect not covered
-}`
+}
+
+p {
+	some bar # should not be included in coverage report
+	bar = 1
+	bar + 1 == 2
+}
+`
 
 	parsedModule, err := ast.ParseModule("test.rego", module)
 	if err != nil {
@@ -67,16 +75,18 @@ baz {     # expect no exit
 	}
 
 	expectedCovered := []Position{
-		{5},      // foo head
-		{6}, {7}, // foo body
-		{10},             // bar head
-		{11}, {12}, {13}, // bar body
-		{17}, {18}, // baz body hits
+		{5},           // foo head
+		{6}, {7}, {8}, // foo body
+		{11},             // bar head
+		{12}, {13}, {14}, // bar body
+		{18}, {19}, // baz body hits
+		{23},       // p head
+		{25}, {26}, // p body
 	}
 
 	expectedNotCovered := []Position{
-		{16}, // baz head
-		{19}, // baz body miss
+		{17}, // baz head
+		{20}, // baz body miss
 	}
 
 	for _, exp := range expectedCovered {


### PR DESCRIPTION
They would previously show up as not-covered in any report. This
changes to simply omit them. They will never be int the resulting
covered or not-covered lists, or count against the % covered.

Fixes: #1972
Signed-off-by: Patrick East <east.patrick@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
