### PR TITLE
docs: note race condition in admission controller

### DIFF
--- a/docs/content/kubernetes-tutorial.md
+++ b/docs/content/kubernetes-tutorial.md
@@ -10,6 +10,9 @@ For the purpose of the tutorial we will deploy two policies that ensure:
 
 - Ingress hostnames must be whitelisted on the Namespace containing the Ingress.
 - Two ingresses in different namespaces must not have the same hostname.
+  - Note: this behavior may suffer from a race condition in which two ingress with the same
+    hostname may both be allowed into the cluster.  This is because OPA evaluates policies
+    against an eventually-consistent view of the global cluster state.
 
 ## Prerequisites
 


### PR DESCRIPTION
Based on a [conversation in Slack](https://openpolicyagent.slack.com/archives/C1H19LW4F/p1580952581157900?thread_ts=1580951074.156600&cid=C1H19LW4F) it seems right to document the possible race condition, as it could lead to the documented policy not being enforced in all scenarios.