### PR TITLE
plugins/bundle: Include last successful request timestamp in status

### DIFF
--- a/docs/content/management.md
+++ b/docs/content/management.md
@@ -431,7 +431,7 @@ updates contain status information for OPA itself as well as the
 [Bundles](#bundles) that have been downloaded and activated.
 
 OPA sends status reports whenever one of the following happens:
- 
+
 * Bundles are downloaded and activated -- If the bundle download or activation fails for any reason, the status update
   will include error information describing the failure. This includes Discovery bundles.
 * A plugin state has changed -- All plugin status is reported, and an update to any plugin will
@@ -468,6 +468,8 @@ on the agent, updates will be sent to `/status`.
   "bundles": {
     "http/example/authz": {
       "active_revision": "ABC",
+      "last_request": "2018-01-01T00:00:00.000Z",
+      "last_successful_request": "2018-01-01T00:00:00.000Z",
       "last_successful_download": "2018-01-01T00:00:00.000Z",
       "last_successful_activation": "2018-01-01T00:00:00.000Z",
       "metrics": {
@@ -616,6 +618,8 @@ Status updates contain the following fields:
 | `bundles` | `object` | Set of objects describing the status for each bundle configured with OPA. |
 | `bundles[_].name` | `string` | Name of bundle that the OPA instance is configured to download. |
 | `bundles[_].active_revision` | `string` | Opaque revision identifier of the last successful activation. |
+| `bundles[_].last_request` | `string` | RFC3339 timestamp of last bundle request. This timestamp should be >= to the successful request timestamp in normal operation. |
+| `bundles[_].last_successful_request` | `string` | RFC3339 timestamp of last successful bundle request. This timestamp should be >= to the successful download timestamp in normal operation. |
 | `bundles[_].last_successful_download` | `string` | RFC3339 timestamp of last successful bundle download. |
 | `bundles[_].last_successful_activation` | `string` | RFC3339 timestamp of last successful bundle activation. |
 | `bundles[_].metrics` | `object` | Metrics from the last update of the bundle. |

--- a/plugins/bundle/plugin.go
+++ b/plugins/bundle/plugin.go
@@ -286,14 +286,18 @@ func (p *Plugin) process(ctx context.Context, name string, u download.Update) {
 		p.status[name].Metrics = metrics.New()
 	}
 
+	p.status[name].SetRequest()
+
 	if u.Error != nil {
 		p.logError(name, "Bundle download failed: %v", u.Error)
 		p.status[name].SetError(u.Error)
 		return
 	}
 
+	p.status[name].LastSuccessfulRequest = p.status[name].LastRequest
+
 	if u.Bundle != nil {
-		p.status[name].SetDownloadSuccess()
+		p.status[name].LastSuccessfulDownload = p.status[name].LastSuccessfulRequest
 
 		p.status[name].Metrics.Timer(metrics.RegoLoadBundles).Start()
 		defer p.status[name].Metrics.Timer(metrics.RegoLoadBundles).Stop()

--- a/plugins/bundle/status.go
+++ b/plugins/bundle/status.go
@@ -25,6 +25,8 @@ type Status struct {
 	ActiveRevision           string          `json:"active_revision,omitempty"`
 	LastSuccessfulActivation time.Time       `json:"last_successful_activation,omitempty"`
 	LastSuccessfulDownload   time.Time       `json:"last_successful_download,omitempty"`
+	LastSuccessfulRequest    time.Time       `json:"last_successful_request,omitempty"`
+	LastRequest              time.Time       `json:"last_request,omitempty"`
 	Code                     string          `json:"code,omitempty"`
 	Message                  string          `json:"message,omitempty"`
 	Errors                   []error         `json:"errors,omitempty"`
@@ -42,6 +44,11 @@ func (s *Status) SetActivateSuccess(revision string) {
 // download.
 func (s *Status) SetDownloadSuccess() {
 	s.LastSuccessfulDownload = time.Now().UTC()
+}
+
+// SetRequest updates the status object to reflect a download attempt.
+func (s *Status) SetRequest() {
+	s.LastRequest = time.Now().UTC()
 }
 
 // SetError updates the status object to reflect a failure to download or


### PR DESCRIPTION
This commit updates the bundle plugin to record the last successful
download _attempt_ timestamp in the bundle status. This way Status API
implementations can easily check whether the OPA has been able to
recently check-in for bundle updates.

Fixes #2009

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
