### PR TITLE
build: Force module mode and using only the vendor directory

### DIFF
--- a/build/gen-opa-wasm.sh
+++ b/build/gen-opa-wasm.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-GOOS="" GOARCH="" go run $@
+GOFLAGS=-mod=vendor GO111MODULE=on GOOS="" GOARCH="" go run $@

--- a/build/run-goimports.sh
+++ b/build/run-goimports.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-GOOS="" GOARCH="" go run ./vendor/golang.org/x/tools/cmd/goimports -local github.com/open-policy-agent/opa $@
+GOFLAGS=-mod=vendor GO111MODULE=on GOOS="" GOARCH="" go run ./vendor/golang.org/x/tools/cmd/goimports -local github.com/open-policy-agent/opa $@

--- a/build/run-pigeon.sh
+++ b/build/run-pigeon.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-GOOS="" GOARCH="" go run ./vendor/github.com/mna/pigeon $@
+GOFLAGS=-mod=vendor GO111MODULE=on GOOS="" GOARCH="" go run ./vendor/github.com/mna/pigeon $@

--- a/build/utils.sh
+++ b/build/utils.sh
@@ -4,6 +4,9 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
+export GO111MODULE=on
+export GOFLAGS=-mod=vendor
+
 function opa::go_packages() {
     for pkg in $(go list ./.../ 2>/dev/null | grep -v vendor); do
         echo $pkg


### PR DESCRIPTION
There are a handful of scripts that were making `go run` calls without
the required environment vars setup force go to use modules and only
use the vendor directory.

For golang 1.11/12 if OPA was in a path outside of the GOPATH it would
switch into module mode automatically (by default) and then try to
fetch packages and stuff remotely rather than use the vendor dir.

For golang 1.13+ any directory for OPA would (by default) result in
trying to use the remote modules rather than vendor dir.

Fixes: #2063
Signed-off-by: Patrick East <east.patrick@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
