### PR TITLE
Add location information into pretty printed trace output.

### DIFF
--- a/internal/presentation/presentation.go
+++ b/internal/presentation/presentation.go
@@ -444,7 +444,7 @@ func prettyProfile(w io.Writer, profile []profiler.ExprStats) error {
 }
 
 func prettyExplanation(w io.Writer, explanation []*topdown.Event) error {
-	topdown.PrettyTrace(w, explanation)
+	topdown.PrettyTraceWithLocation(w, explanation)
 	return nil
 }
 

--- a/repl/repl_test.go
+++ b/repl/repl_test.go
@@ -1987,28 +1987,28 @@ func TestEvalTrace(t *testing.T) {
 	repl.OneShot(ctx, "trace")
 	repl.OneShot(ctx, `data.a[i].b.c[j] = x; data.a[k].b.c[x] = 1`)
 	expected := strings.TrimSpace(`
-Enter data.a[i].b.c[j] = x; data.a[k].b.c[x] = 1
-| Eval data.a[i].b.c[j] = x
-| Eval data.a[k].b.c[x] = 1
-| Fail data.a[k].b.c[x] = 1
-| Redo data.a[i].b.c[j] = x
-| Eval data.a[k].b.c[x] = 1
-| Exit data.a[i].b.c[j] = x; data.a[k].b.c[x] = 1
-Redo data.a[i].b.c[j] = x; data.a[k].b.c[x] = 1
-| Redo data.a[k].b.c[x] = 1
-| Redo data.a[i].b.c[j] = x
-| Eval data.a[k].b.c[x] = 1
-| Fail data.a[k].b.c[x] = 1
-| Redo data.a[i].b.c[j] = x
-| Eval data.a[k].b.c[x] = 1
-| Fail data.a[k].b.c[x] = 1
-| Redo data.a[i].b.c[j] = x
-| Eval data.a[k].b.c[x] = 1
-| Fail data.a[k].b.c[x] = 1
-| Redo data.a[i].b.c[j] = x
-| Eval data.a[k].b.c[x] = 1
-| Fail data.a[k].b.c[x] = 1
-| Redo data.a[i].b.c[j] = x
+query:1             Enter data.a[i].b.c[j] = x; data.a[k].b.c[x] = 1
+query:1             | Eval data.a[i].b.c[j] = x
+query:1             | Eval data.a[k].b.c[x] = 1
+query:1             | Fail data.a[k].b.c[x] = 1
+query:1             | Redo data.a[i].b.c[j] = x
+query:1             | Eval data.a[k].b.c[x] = 1
+query:1             | Exit data.a[i].b.c[j] = x; data.a[k].b.c[x] = 1
+query:1             Redo data.a[i].b.c[j] = x; data.a[k].b.c[x] = 1
+query:1             | Redo data.a[k].b.c[x] = 1
+query:1             | Redo data.a[i].b.c[j] = x
+query:1             | Eval data.a[k].b.c[x] = 1
+query:1             | Fail data.a[k].b.c[x] = 1
+query:1             | Redo data.a[i].b.c[j] = x
+query:1             | Eval data.a[k].b.c[x] = 1
+query:1             | Fail data.a[k].b.c[x] = 1
+query:1             | Redo data.a[i].b.c[j] = x
+query:1             | Eval data.a[k].b.c[x] = 1
+query:1             | Fail data.a[k].b.c[x] = 1
+query:1             | Redo data.a[i].b.c[j] = x
+query:1             | Eval data.a[k].b.c[x] = 1
+query:1             | Fail data.a[k].b.c[x] = 1
+query:1             | Redo data.a[i].b.c[j] = x
 +---+---+---+---+
 | i | j | k | x |
 +---+---+---+---+
@@ -2030,12 +2030,12 @@ func TestEvalNotes(t *testing.T) {
 	repl.OneShot(ctx, "notes")
 	buffer.Reset()
 	repl.OneShot(ctx, "p")
-	expected := strings.TrimSpace(`Enter data.repl.p = _
-| Enter data.repl.p
-| | Note "x = 2"
-Redo data.repl.p = _
-| Redo data.repl.p
-| | Note "x = 3"
+	expected := strings.TrimSpace(`query:1             Enter data.repl.p = _
+query:1             | Enter data.repl.p
+note                | | Note "x = 2"
+query:1             Redo data.repl.p = _
+query:1             | Redo data.repl.p
+note                | | Note "x = 3"
 true`)
 	expected += "\n"
 	if expected != buffer.String() {


### PR DESCRIPTION
This PR adds another method to the topdown trace package for printing traces with location information. The location information max length is capped at 19 characters (15 for file size, a colon, and 3 for line information). Filenames will be concatenated if over 15 characters long.

Fixes #2070

Signed-off-by: Lennard Eijsackers <lennardeijsackers92@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
