### PR TITLE
dependencies: resolveRemainingVars incorrectly does not skip the refs.

### DIFF
--- a/dependencies/deps.go
+++ b/dependencies/deps.go
@@ -368,16 +368,16 @@ func resolveOthers(others []*ast.Expr, headVars ast.VarSet, joined map[ast.Var]*
 
 func resolveRemainingVars(joined map[ast.Var]*util.HashMap, visitor *skipVisitor, usedVars ast.VarSet, headVars ast.VarSet) {
 	for v, refs := range joined {
-		visit := visitor
-		visit.skipped = false
+		skipped := false
 
 		if headVars.Contains(v) || refs.Len() > 1 || usedVars.Contains(v) {
-			visit.skipped = true
+			skipped = true
 		}
 
 		refs.Iter(func(a, _ util.T) bool {
+			visitor.skipped = skipped
 			r := a.(ast.Ref)
-			ast.NewGenericVisitor(visit.Visit).Walk(r)
+			ast.NewGenericVisitor(visitor.Visit).Walk(r)
 			return false
 		})
 	}


### PR DESCRIPTION
In iterating the refs, the skipping state was not resetted between
iterations.

This is an unintended regression of
c44f3d714c15d4b345022d5ee8f93a8e81d608d3.

Signed-off-by: Teemu Koponen <koponen@styra.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
