### PR TITLE
Add `json.remove` builtin

### DIFF
--- a/ast/builtins.go
+++ b/ast/builtins.go
@@ -133,6 +133,7 @@ var DefaultBuiltins = [...]*Builtin{
 
 	// JSON Object Manipulation
 	JSONFilter,
+	JSONRemove,
 
 	// Tokens
 	JWTDecode,
@@ -937,6 +938,41 @@ var JSONUnmarshal = &Builtin{
 // JSONFilter filters the JSON object
 var JSONFilter = &Builtin{
 	Name: "json.filter",
+	Decl: types.NewFunction(
+		types.Args(
+			types.NewObject(
+				nil,
+				types.NewDynamicProperty(types.A, types.A),
+			),
+			types.NewAny(
+				types.NewArray(
+					nil,
+					types.NewAny(
+						types.S,
+						types.NewArray(
+							nil,
+							types.A,
+						),
+					),
+				),
+				types.NewSet(
+					types.NewAny(
+						types.S,
+						types.NewArray(
+							nil,
+							types.A,
+						),
+					),
+				),
+			),
+		),
+		types.A,
+	),
+}
+
+// JSONRemove removes paths in the JSON object
+var JSONRemove = &Builtin{
+	Name: "json.remove",
 	Decl: types.NewFunction(
 		types.Args(
 			types.NewObject(

--- a/docs/content/policy-reference.md
+++ b/docs/content/policy-reference.md
@@ -73,11 +73,28 @@ complex types.
 | <span class="opa-keep-it-together">`output := object.remove(object, keys)`</span> | `output` is a new object which is the result of removing the specified `keys` from `object`. `keys` must be either an array, object, or set of keys. |
 | <span class="opa-keep-it-together">`output := object.union(objectA, objectB)`</span> | `output` is a new object which is the result of an asymmetric recursive union of two objects where conflicts are resolved by choosing the key from the right-hand object (`objectB`). For example: `object.union({"a": 1, "b": 2, "c": {"d": 3}}, {"a": 7, "c": {"d": 4, "e": 5}})` will result in `{"a": 7, "b": 2, "c": {"d": 4, "e": 5}}`  |
 | <span class="opa-keep-it-together">`filtered := object.filter(object, keys)`</span> | `filtered` is a new object with the remaining data from `object` with only keys specified in `keys` which is an array, object, or set of keys. For example: `object.filter({"a": {"b": "x", "c": "y"}, "d": "z"}, ["a"])` will result in `{"a": {"b": "x", "c": "y"}}`). |
-| <span class="opa-keep-it-together">`filtered := json.filter(object, paths)`</span> | `filtered` is the remaining data from `object` with only keys specified in `paths` which is an array or set of JSON string paths. For example: `json.filter({"a": {"b": "x", "c": "y"}}, ["a/b"])` will result in `{"a": {"b": "x"}}`). |
+| <span class="opa-keep-it-together">`filtered := json.filter(object, paths)`</span> | `filtered` is the remaining data from `object` with only keys specified in `paths` which is an array or set of JSON string paths. For example: `json.filter({"a": {"b": "x", "c": "y"}}, ["a/b"])` will result in `{"a": {"b": "x"}}`). Paths are not filtered in-order and are deduplicated before being evaluated. |
+| <span class="opa-keep-it-together">`output := json.remove(object, paths)`</span> | `output` is a new object which is the result of removing all keys specified in `paths` which is an array or set of JSON string paths. For example: `json.remove{"a": {"b": "x", "c": "y"}, ["a/b"]}` will result in `{"a": {"c": "y"}}`. Paths are not removed in-order and are deduplicated before being evaluated. | 
 
-> The `json` string `paths` may reference into array values by using index numbers. For example with the object `{"a": ["x", "y", "z"]}` the path `a[1]` references `y`
+* When `keys` are provided as an object only the top level keys on the object will be used, values are ignored. 
+  For example: `object.remove({"a": {"b": {"c": 2}}, "x": 123}, {"a": 1}) == {"x": 123}` regardless of the value
+  for key `a` in the keys object, the following `keys` object gives the same result
+  `object.remove({"a": {"b": {"c": 2}}, "x": 123}, {"a": {"b": {"foo": "bar"}}}) == {"x": 123}`.
 
-> When `keys` are provided as an object only the top level keys on the object will be used, values are ignored. For example: `object.remove({"a": {"b": {"c": 2}}, "x": 123}, {"a": 1}) == {"x": 123}` regardless of the value for key `a` in the keys object, the following `keys` object gives the same result `object.remove({"a": {"b": {"c": 2}}, "x": 123}, {"a": {"b": {"foo": "bar"}}}) == {"x": 123}` 
+
+* The `json` string `paths` may reference into array values by using index numbers. For example with the object
+  `{"a": ["x", "y", "z"]}` the path `a/1` references `y`. Nested structures are supported as well, for example:
+  `{"a": ["x", {"y": {"y1": {"y2": ["foo", "bar"]}}}, "z"]}` the path `a/1/y1/y2/0` references `"foo"`.
+
+
+* The `json` string `paths` support `~0`, or `~1` characters for `~` and `/` characters in key names.
+  It does not support `-` for last index of an array. For example the path `/foo~1bar~0` will reference `baz`
+  in `{ "foo/bar~": "baz" }`.
+
+
+* The `json` string `paths` may be an array of string path segments rather than a `/` separated string. For example
+  the path `a/b/c` can be passed in as `["a", "b", "c"]`.
+
 
 ### Strings
 

--- a/topdown/json.go
+++ b/topdown/json.go
@@ -5,11 +5,114 @@
 package topdown
 
 import (
+	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/topdown/builtins"
 )
+
+func builtinJSONRemove(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term) error) error {
+
+	// Expect an object and a string or array/set of strings
+	_, err := builtins.ObjectOperand(operands[0].Value, 1)
+	if err != nil {
+		return err
+	}
+
+	// Build a list of json pointers to remove
+	paths, err := getJSONPaths(operands[1].Value)
+	if err != nil {
+		return err
+	}
+
+	newObj, err := jsonRemove(operands[0], ast.NewTerm(pathsToObject(paths)))
+	if err != nil {
+		return err
+	}
+
+	if newObj == nil {
+		return nil
+	}
+
+	return iter(newObj)
+}
+
+// jsonRemove returns a new term that is the result of walking
+// through a and omitting removing any values that are in b but
+// have ast.Null values (ie leaf nodes for b).
+func jsonRemove(a *ast.Term, b *ast.Term) (*ast.Term, error) {
+	if b == nil {
+		// The paths diverged, return a
+		return a, nil
+	}
+
+	var bObj ast.Object
+	switch bValue := b.Value.(type) {
+	case ast.Object:
+		bObj = bValue
+	case ast.Null:
+		// Means we hit a leaf node on "b", dont add the value for a
+		return nil, nil
+	default:
+		// The paths diverged, return a
+		return a, nil
+	}
+
+	switch aValue := a.Value.(type) {
+	case ast.String, ast.Number, ast.Boolean, ast.Null:
+		return a, nil
+	case ast.Object:
+		newObj := ast.NewObject()
+		err := aValue.Iter(func(k *ast.Term, v *ast.Term) error {
+			// recurse and add the diff of sub objects as needed
+			diffValue, err := jsonRemove(v, bObj.Get(k))
+			if err != nil || diffValue == nil {
+				return err
+			}
+			newObj.Insert(k, diffValue)
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+		return ast.NewTerm(newObj), nil
+	case ast.Set:
+		newSet := ast.NewSet()
+		err := aValue.Iter(func(v *ast.Term) error {
+			// recurse and add the diff of sub objects as needed
+			diffValue, err := jsonRemove(v, bObj.Get(v))
+			if err != nil || diffValue == nil {
+				return err
+			}
+			newSet.Add(diffValue)
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+		return ast.NewTerm(newSet), nil
+	case ast.Array:
+		// When indexes are removed we shift left to close empty spots in the array
+		// as per the JSON patch spec.
+		var newArray ast.Array
+		for i, v := range aValue {
+			// recurse and add the diff of sub objects as needed
+			// Note: Keys in b will be strings for the index, eg path /a/1/b => {"a": {"1": {"b": null}}}
+			diffValue, err := jsonRemove(v, bObj.Get(ast.StringTerm(strconv.Itoa(i))))
+			if err != nil {
+				return nil, err
+			}
+			if diffValue != nil {
+				newArray = append(newArray, diffValue)
+			}
+		}
+		return ast.NewTerm(newArray), nil
+	default:
+		return nil, fmt.Errorf("invalid value type %T", a)
+	}
+}
 
 func builtinJSONFilter(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term) error) error {
 
@@ -20,31 +123,9 @@ func builtinJSONFilter(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Te
 	}
 
 	// Build a list of filter strings
-	var filters [][]ast.Value
-
-	switch v := operands[1].Value.(type) {
-	case ast.Array:
-		for _, f := range v {
-			filter, err := parsePath(f)
-			if err != nil {
-				return err
-			}
-			filters = append(filters, filter)
-		}
-	case ast.Set:
-		err := v.Iter(func(f *ast.Term) error {
-			filter, err := parsePath(f)
-			if err != nil {
-				return err
-			}
-			filters = append(filters, filter)
-			return nil
-		})
-		if err != nil {
-			return err
-		}
-	default:
-		return builtins.NewOperandTypeErr(2, v, "set", "array")
+	filters, err := getJSONPaths(operands[1].Value)
+	if err != nil {
+		return err
 	}
 
 	// Actually do the filtering
@@ -57,28 +138,60 @@ func builtinJSONFilter(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Te
 	return iter(ast.NewTerm(r))
 }
 
-func parsePath(path *ast.Term) ([]ast.Value, error) {
+func getJSONPaths(operand ast.Value) ([]ast.Ref, error) {
+	var paths []ast.Ref
+
+	switch v := operand.(type) {
+	case ast.Array:
+		for _, f := range v {
+			filter, err := parsePath(f)
+			if err != nil {
+				return nil, err
+			}
+			paths = append(paths, filter)
+		}
+	case ast.Set:
+		err := v.Iter(func(f *ast.Term) error {
+			filter, err := parsePath(f)
+			if err != nil {
+				return err
+			}
+			paths = append(paths, filter)
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+	default:
+		return nil, builtins.NewOperandTypeErr(2, v, "set", "array")
+	}
+
+	return paths, nil
+}
+
+func parsePath(path *ast.Term) (ast.Ref, error) {
 	// paths can either be a `/` separated json path or
 	// an array or set of values
-	var pathSegments []ast.Value
+	var pathSegments ast.Ref
 	switch p := path.Value.(type) {
 	case ast.String:
 		parts := strings.Split(strings.Trim(string(p), "/"), "/")
 		for _, part := range parts {
-			pathSegments = append(pathSegments, ast.String(part))
+			part = strings.ReplaceAll(strings.ReplaceAll(part, "~1", "/"), "~0", "~")
+			pathSegments = append(pathSegments, ast.StringTerm(part))
 		}
 	case ast.Array:
 		for _, term := range p {
-			pathSegments = append(pathSegments, term.Value)
+			pathSegments = append(pathSegments, term)
 		}
 	default:
-		return nil, builtins.NewOperandErr(2, "expected set or array containing string paths or list of path segments")
+		return nil, builtins.NewOperandErr(2, "must be one of {set, array} containing string paths or array of path segments but got %v", ast.TypeName(p))
 	}
 
 	return pathSegments, nil
 }
 
-func pathsToObject(paths [][]ast.Value) ast.Object {
+func pathsToObject(paths []ast.Ref) ast.Object {
 
 	root := ast.NewObject()
 
@@ -88,7 +201,7 @@ func pathsToObject(paths [][]ast.Value) ast.Object {
 
 		for i := 0; i < len(path)-1 && !done; i++ {
 
-			k := ast.NewTerm(path[i])
+			k := path[i]
 			child := node.Get(k)
 
 			if child == nil {
@@ -109,7 +222,7 @@ func pathsToObject(paths [][]ast.Value) ast.Object {
 		}
 
 		if !done {
-			node.Insert(ast.NewTerm(path[len(path)-1]), ast.NullTerm())
+			node.Insert(path[len(path)-1], ast.NullTerm())
 		}
 	}
 
@@ -118,4 +231,5 @@ func pathsToObject(paths [][]ast.Value) ast.Object {
 
 func init() {
 	RegisterBuiltinFunc(ast.JSONFilter.Name, builtinJSONFilter)
+	RegisterBuiltinFunc(ast.JSONRemove.Name, builtinJSONRemove)
 }

--- a/topdown/json_test.go
+++ b/topdown/json_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/topdown/builtins"
 )
 
 func TestBuiltinJSONFilter(t *testing.T) {
@@ -94,6 +95,19 @@ func TestBuiltinJSONFilter(t *testing.T) {
 	}
 }
 
+func TestBuiltinJSONFilterIdempotent(t *testing.T) {
+	rule := `
+	p {
+		# "base" should never be mutated
+		base := {"a": {"b": 2, "c": 3}}
+		json.filter(base, {"a/b"}) == {"a": {"b": 2}}
+		json.filter(base, {"a/c"}) == {"a": {"c": 3}}
+		base == {"a": {"b": 2, "c": 3}}
+	}
+	`
+	runTopDownTestCase(t, map[string]interface{}{}, t.Name(), []string{rule}, "true")
+}
+
 func TestFiltersToObject(t *testing.T) {
 	cases := []struct {
 		note     string
@@ -150,11 +164,26 @@ func TestFiltersToObject(t *testing.T) {
 			filters:  []string{`[[1], {2}]`, `"a/1/b"`},
 			expected: `{"a": {"1": {"b": null}}, [1]: {{2}: null}}`,
 		},
+		{
+			note:     "escaped tilde",
+			filters:  []string{`"a/~0b~0/c~0"`},
+			expected: `{"a": {"~b~": {"c~": null}}}`,
+		},
+		{
+			note:     "escaped slash",
+			filters:  []string{`"a/~1b~1c/d~1"`},
+			expected: `{"a": {"/b/c": {"d/": null}}}`,
+		},
+		{
+			note:     "mixed escapes",
+			filters:  []string{`"a/~0b~1c/d~1~0"`},
+			expected: `{"a": {"~b/c": {"d/~": null}}}`,
+		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.note, func(t *testing.T) {
-			var paths [][]ast.Value
+			var paths []ast.Ref
 			for _, path := range tc.filters {
 				parsedPath, err := parsePath(ast.MustParseTerm(path))
 				if err != nil {
@@ -169,4 +198,276 @@ func TestFiltersToObject(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBuiltinJSONRemove(t *testing.T) {
+	cases := []struct {
+		note     string
+		object   string
+		paths    string
+		input    string
+		expected interface{}
+	}{
+		{
+			note:     "base",
+			object:   `{"a": {"b": {"c": 7, "d": 8}}, "e": 9}`,
+			paths:    `{"a/b/c"}`,
+			expected: `{"a": {"b": {"d": 8}}, "e": 9}`,
+		},
+		{
+			note:     "multiple roots",
+			object:   `{"a": {"b": {"c": 7, "d": 8}}, "e": 9}`,
+			paths:    `{"a/b/c", "e"}`,
+			expected: `{"a": {"b": {"d": 8}}}`,
+		},
+		{
+			note:     "multiple roots array",
+			object:   `{"a": {"b": {"c": 7, "d": 8}}, "e": 9}`,
+			paths:    `["a/b/c", "e"]`,
+			expected: `{"a": {"b": {"d": 8}}}`,
+		},
+		{
+			note:     "shared roots",
+			object:   `{"a": {"b": {"c": 7, "d": 8}, "e": 9}}`,
+			paths:    `{"a/b/c", "a/e"}`,
+			expected: `{"a": {"b": {"d": 8}}}`,
+		},
+		{
+			note:     "conflict",
+			object:   `{"a": {"b": 7}, "c": 1}`,
+			paths:    `{"a", "a/b"}`,
+			expected: `{"c": 1}`,
+		},
+		{
+			note:     "empty list",
+			object:   `{"a": 7}`,
+			paths:    `set()`,
+			expected: `{"a": 7}`,
+		},
+		{
+			note:     "empty object",
+			object:   `{}`,
+			paths:    `{"a/b"}`,
+			expected: `{}`,
+		},
+		{
+			note:     "delete all",
+			object:   `{"a": {"b": 7}, "c": 1}`,
+			paths:    `{"a", "c"}`,
+			expected: `{}`,
+		},
+		{
+			note:     "delete last in object",
+			object:   `{"a": {"b": 7}, "c": 1}`,
+			paths:    `{"a/b", "c"}`,
+			expected: `{"a": {}}`,
+		},
+		{
+			note:     "arrays",
+			object:   `{"a": [{"b": 7, "c": 8}, {"d": 9}]}`,
+			paths:    `{"a/0/b", "a/1"}`,
+			expected: `{"a": [{"c": 8}]}`,
+		},
+		{
+			note:     "object with number keys",
+			object:   `{"a": [{"1":["b", "c", "d"]}, {"x": "y"}]}`,
+			paths:    `{"a/0/1/2"}`,
+			expected: `{"a": [{"1":["b", "c"]}, {"x": "y"}]}`,
+		},
+		{
+			note:     "arrays of roots",
+			object:   `{"a": {"b": {"c": 7, "d": 8}}, "e": 9}`,
+			paths:    `{["a", "b", "c"], ["e"]}`,
+			expected: `{"a": {"b": {"d": 8}}}`,
+		},
+		{
+			note:     "mixed root types",
+			object:   `{"a": {"b": {"c": 7, "d": 8, "x": 0}}, "e": 9}`,
+			paths:    `{["a", "b", "c"], "a/b/d"}`,
+			expected: `{"a": {"b": {"x": 0}}, "e": 9}`,
+		},
+		{
+			note:     "error invalid target type string",
+			object:   `"foo"`,
+			paths:    `{"a/b/c"}`,
+			expected: ast.Errors{ast.NewError(ast.TypeErr, nil, "json.remove: invalid argument(s)")},
+		},
+		{
+			note:     "error invalid target type number",
+			object:   `22`,
+			paths:    `{"a/b/c"}`,
+			expected: ast.Errors{ast.NewError(ast.TypeErr, nil, "json.remove: invalid argument(s)")},
+		},
+		{
+			note:     "error invalid target type boolean",
+			object:   `false`,
+			paths:    `{"a/b/c"}`,
+			expected: ast.Errors{ast.NewError(ast.TypeErr, nil, "json.remove: invalid argument(s)")},
+		},
+		{
+			note:     "error invalid target type set",
+			object:   `{"a"}`,
+			paths:    `{"a/b/c"}`,
+			expected: ast.Errors{ast.NewError(ast.TypeErr, nil, "json.remove: invalid argument(s)")},
+		},
+		{
+			note:     "error invalid target type array",
+			object:   `["a"]`,
+			paths:    `{"a/b/c"}`,
+			expected: ast.Errors{ast.NewError(ast.TypeErr, nil, "json.remove: invalid argument(s)")},
+		},
+		{
+			note:     "error invalid target type string input",
+			object:   `input.x`,
+			paths:    `{"a/b/c"}`,
+			input:    `{"x": "foo"}`,
+			expected: builtins.NewOperandErr(1, "must be object but got string"),
+		},
+		{
+			note:     "error invalid target type number input",
+			object:   `input.x`,
+			paths:    `{"a/b/c"}`,
+			input:    `{"x": 22}`,
+			expected: builtins.NewOperandErr(1, "must be object but got number"),
+		},
+		{
+			note:     "error invalid target type boolean input",
+			object:   `input.x`,
+			paths:    `{"a/b/c"}`,
+			input:    `{"x": true}`,
+			expected: builtins.NewOperandErr(1, "must be object but got boolean"),
+		},
+		{
+			note:     "error invalid target type array input",
+			object:   `input.x`,
+			paths:    `{"a/b/c"}`,
+			input:    `{"x": ["a", "b", "c"]}`,
+			expected: builtins.NewOperandErr(1, "must be object but got array"),
+		},
+		{
+			note:     "error invalid paths type string",
+			object:   `{"a": {"b": {"c": 123}}}`,
+			paths:    `"foo"`,
+			expected: ast.Errors{ast.NewError(ast.TypeErr, nil, "json.remove: invalid argument(s)")},
+		},
+		{
+			note:     "error invalid paths type number",
+			object:   `{"a": {"b": {"c": 123}}}`,
+			paths:    `22`,
+			expected: ast.Errors{ast.NewError(ast.TypeErr, nil, "json.remove: invalid argument(s)")},
+		},
+		{
+			note:     "error invalid paths type boolean",
+			object:   `{"a": {"b": {"c": 123}}}`,
+			paths:    `true`,
+			expected: ast.Errors{ast.NewError(ast.TypeErr, nil, "json.remove: invalid argument(s)")},
+		},
+		{
+			note:     "error invalid paths type object",
+			object:   `{"a": {"b": {"c": 123}}}`,
+			paths:    `{"x": 1}`,
+			expected: ast.Errors{ast.NewError(ast.TypeErr, nil, "json.remove: invalid argument(s)")},
+		},
+		{
+			note:     "error invalid paths type set with numbers",
+			object:   `{"a": {"b": {"c": 123}}}`,
+			paths:    `{"a", 1, 2, 3}`,
+			expected: ast.Errors{ast.NewError(ast.TypeErr, nil, "json.remove: invalid argument(s)")},
+		},
+		{
+			note:     "error invalid paths type set with objects",
+			object:   `{"a": {"b": {"c": 123}}}`,
+			paths:    `{"a", {"x": 1}, {"y": 2}}`,
+			expected: ast.Errors{ast.NewError(ast.TypeErr, nil, "json.remove: invalid argument(s)")},
+		},
+		{
+			note:     "error invalid paths type array with numbers",
+			object:   `{"a": {"b": {"c": 123}}}`,
+			paths:    `["a", 1, 2, 3]`,
+			expected: ast.Errors{ast.NewError(ast.TypeErr, nil, "json.remove: invalid argument(s)")},
+		},
+		{
+			note:     "error invalid paths type array with objects",
+			object:   `{"a": {"b": {"c": 123}}}`,
+			paths:    `["a", {"x": 1}, {"y": 2}]`,
+			expected: ast.Errors{ast.NewError(ast.TypeErr, nil, "json.remove: invalid argument(s)")},
+		},
+		{
+			note:     "error invalid paths type string",
+			object:   `{"a": {"b": {"c": 123}}}`,
+			paths:    `input.x`,
+			input:    `{"x": "foo"}`,
+			expected: builtins.NewOperandErr(2, "must be one of {set, array} but got string"),
+		},
+		{
+			note:     "error invalid paths type number",
+			object:   `{"a": {"b": {"c": 123}}}`,
+			paths:    `input.x`,
+			input:    `{"x": 22}`,
+			expected: builtins.NewOperandErr(2, "must be one of {set, array} but got number"),
+		},
+		{
+			note:     "error invalid paths type boolean",
+			object:   `{"a": {"b": {"c": 123}}}`,
+			paths:    `input.x`,
+			input:    `{"x": true}`,
+			expected: builtins.NewOperandErr(2, "must be one of {set, array} but got boolean"),
+		},
+		{
+			note:     "error invalid paths type object",
+			object:   `{"a": {"b": {"c": 123}}}`,
+			paths:    `input.x`,
+			input:    `{"x": {"y": 123}}`,
+			expected: builtins.NewOperandErr(2, "must be one of {set, array} but got object"),
+		},
+		{
+			note:     "error invalid paths type set with numbers",
+			object:   `{"a": {"b": {"c": 123}}}`,
+			paths:    `input.x`,
+			input:    `{"x": {"a", 1, 2, 3}}`,
+			expected: builtins.NewOperandErr(2, "must be one of {set, array} containing string paths or array of path segments but got number"),
+		},
+		{
+			note:     "error invalid paths type set with objects",
+			object:   `{"a": {"b": {"c": 123}}}`,
+			paths:    `input.x`,
+			input:    `{"x": {"a", {"x": 1}, {"y": 2}}}`,
+			expected: builtins.NewOperandErr(2, "must be one of {set, array} containing string paths or array of path segments but got object"),
+		},
+		{
+			note:     "error invalid paths type array with numbers",
+			object:   `{"a": {"b": {"c": 123}}}`,
+			paths:    `input.x`,
+			input:    `{"x": ["a", 1, 2, 3]}`,
+			expected: builtins.NewOperandErr(2, "must be one of {set, array} containing string paths or array of path segments but got number"),
+		},
+		{
+			note:     "error invalid paths type array with objects",
+			object:   `{"a": {"b": {"c": 123}}}`,
+			paths:    `input.x`,
+			input:    `{"x": ["a", {"x": 1}, {"y": 2}]}`,
+			expected: builtins.NewOperandErr(2, "must be one of {set, array} containing string paths or array of path segments but got object"),
+		},
+	}
+
+	for _, tc := range cases {
+		rules := []string{
+			fmt.Sprintf("p = x { x := json.remove(%s, %s) }", tc.object, tc.paths),
+		}
+		runTopDownTestCaseWithModules(t, map[string]interface{}{}, tc.note, rules, nil, tc.input, tc.expected)
+	}
+}
+
+func TestBuiltinJSONRemoveIdempotent(t *testing.T) {
+	rule := `
+	p {
+		# "base" should never be mutated
+		base := {"a": {"b": 2, "c": 3}}
+		json.remove(base, {"a"}) == {}
+		json.remove(base, {"a/b"}) == {"a": {"c": 3}}
+		json.remove(base, {"a/c"}) == {"a": {"b": 2}}
+		base == {"a": {"b": 2, "c": 3}}
+	}
+	`
+	runTopDownTestCase(t, map[string]interface{}{}, t.Name(), []string{rule}, "true")
 }


### PR DESCRIPTION
This adds in a new built-in function `json.remove` which will take in
an object and list of json pointer paths (similar to `json.filter`)
and create a new object with all of the paths removed from the base
object.

Reference: #1617
Signed-off-by: Patrick East <east.patrick@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
