### PR TITLE
Add timeout for `http.send` builtin

### DIFF
--- a/docs/content/policy-reference.md
+++ b/docs/content/policy-reference.md
@@ -543,7 +543,7 @@ The `request` object parameter may contain the following fields:
 | `tls_client_key_env_variable` | no | `string` | Environment variable containing a client key in PEM encoded format. |
 | `tls_client_cert_file` | no | `string` | Path to file containing a client certificate in PEM encoded format. |
 | `tls_client_key_file` | no | `string` | Path to file containing a key  in PEM encoded format. |
-
+| `timeout` | no | `string` or `number` | Timeout for the HTTP request with a default of 5 seconds (`5s`). Numbers provided are in nanoseconds. Strings must be a valid duration string where a duration string is a possibly signed sequence of decimal numbers, each with optional fraction and a unit suffix, such as "300ms", "-1.5h" or "2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h". A zero timeout means no timeout.|
 
 To trigger the use of HTTPs the user must provide one of the following combinations:
 

--- a/topdown/topdown_test.go
+++ b/topdown/topdown_test.go
@@ -2868,10 +2868,14 @@ func loadSmallTestData() map[string]interface{} {
 }
 
 func runTopDownTestCase(t *testing.T, data map[string]interface{}, note string, rules []string, expected interface{}) {
-	runTopDownTestCaseWithModules(t, data, note, rules, nil, "", expected)
+	runTopDownTestCaseWithContext(context.Background(), t, data, note, rules, nil, "", expected)
 }
 
 func runTopDownTestCaseWithModules(t *testing.T, data map[string]interface{}, note string, rules []string, modules []string, input string, expected interface{}) {
+	runTopDownTestCaseWithContext(context.Background(), t, data, note, rules, modules, input, expected)
+}
+
+func runTopDownTestCaseWithContext(ctx context.Context, t *testing.T, data map[string]interface{}, note string, rules []string, modules []string, input string, expected interface{}) {
 	imports := []string{}
 	for k := range data {
 		imports = append(imports, "data."+k)
@@ -2889,10 +2893,14 @@ func runTopDownTestCaseWithModules(t *testing.T, data map[string]interface{}, no
 
 	store := inmem.NewFromObject(data)
 
-	assertTopDownWithPath(t, compiler, store, note, []string{"p"}, input, expected)
+	assertTopDownWithPathAndContext(ctx, t, compiler, store, note, []string{"p"}, input, expected)
 }
 
 func assertTopDownWithPath(t *testing.T, compiler *ast.Compiler, store storage.Store, note string, path []string, input string, expected interface{}) {
+	assertTopDownWithPathAndContext(context.Background(), t, compiler, store, note, path, input, expected)
+}
+
+func assertTopDownWithPathAndContext(ctx context.Context, t *testing.T, compiler *ast.Compiler, store storage.Store, note string, path []string, input string, expected interface{}) {
 
 	var inputTerm *ast.Term
 
@@ -2900,7 +2908,6 @@ func assertTopDownWithPath(t *testing.T, compiler *ast.Compiler, store storage.S
 		inputTerm = ast.MustParseTerm(input)
 	}
 
-	ctx := context.Background()
 	txn := storage.NewTransactionOrDie(ctx, store)
 
 	defer store.Abort(ctx, txn)


### PR DESCRIPTION
There is a new optional `timeout` option to specify with `http.send`
which will set a client timeout on the request. This will override the
default 5 second timeout.

This change also corrects the request to use the builtin context. This
means that if the evaluation is canceled the request will also now be
canceled.

There is an environment variable for adjusting the default timeout
which we should aim to remove in future OPA versions (when
appropriate). For now though it is still supported, and will panic if
supplied with an invalid value rather than previously ignoring it and
effectively disable the timeout (0 == unlimited).

Fixes: #2099
Signed-off-by: Patrick East <east.patrick@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
