### PR TITLE
Fix broken link in index.md

### DIFF
--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -109,7 +109,7 @@ Similarly, if you edit the queries or rules in the examples below the output
 will change. As you read through this section, try changing the input, queries,
 and rules and observe the difference in output.
 >
-> 💻 They can also be run locally on your machine using the [`opa eval` command, here are setup instructions.](#Running-OPA)
+> 💻 They can also be run locally on your machine using the [`opa eval` command, here are setup instructions.](#running-opa)
 
 ### References
 


### PR DESCRIPTION
There is a link in `/docs/content/_index.md` which is a css id anchor for the same page.
Anchors are case-sensitive.

The link was capitalised, whereas the id used on the page is lowercase.
Changing the capitalisation to be lowercase fixed the link.

No tests added as this change is docs related.
