### PR TITLE
topdown: Wrap all builtin functions for errors normalization

### DIFF
--- a/topdown/cidr_test.go
+++ b/topdown/cidr_test.go
@@ -2,7 +2,6 @@ package topdown
 
 import (
 	"context"
-	"net"
 	"testing"
 	"time"
 
@@ -120,7 +119,7 @@ func TestNetCIDRExpand(t *testing.T) {
 			rules: []string{
 				`p = x { net.cidr_expand("192.168.1.1/33", x) }`,
 			},
-			expected: &net.ParseError{Type: "CIDR address", Text: "192.168.1.1/33"},
+			expected: &Error{Code: BuiltinErr, Message: "net.cidr_expand: invalid CIDR address: 192.168.1.1/33"},
 		},
 	}
 

--- a/topdown/object_test.go
+++ b/topdown/object_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/open-policy-agent/opa/ast"
-	"github.com/open-policy-agent/opa/topdown/builtins"
 )
 
 func TestObjectGet(t *testing.T) {
@@ -146,7 +145,7 @@ func TestBuiltinObjectUnion(t *testing.T) {
 			objectA:  `input.a`,
 			objectB:  `{"b": 2}`,
 			input:    `{"a": [1, 2, 3]}`,
-			expected: builtins.NewOperandErr(1, "must be object but got array"),
+			expected: &Error{Code: TypeErr, Message: "object.union: operand 1 must be object but got array"},
 		},
 		{
 			note:     "error wrong rhs type",
@@ -159,7 +158,7 @@ func TestBuiltinObjectUnion(t *testing.T) {
 			objectA:  `{"a": 1}`,
 			objectB:  `input.b`,
 			input:    `{"b": [1, 2, 3]}`,
-			expected: builtins.NewOperandErr(2, "must be object but got array"),
+			expected: &Error{Code: TypeErr, Message: "object.union: operand 2 must be object but got array"},
 		},
 		{
 			note:     "error wrong both params",
@@ -262,35 +261,35 @@ func TestBuiltinObjectRemove(t *testing.T) {
 			object:   `input.x`,
 			keys:     `{"a"}`,
 			input:    `{"x": ["a"]}`,
-			expected: builtins.NewOperandErr(1, "must be object but got array"),
+			expected: &Error{Code: TypeErr, Message: "object.remove: operand 1 must be object but got array"},
 		},
 		{
 			note:     "error invalid object param type bool input",
 			object:   `input.x`,
 			keys:     `{"a"}`,
 			input:    `{"x": false}`,
-			expected: builtins.NewOperandErr(1, "must be object but got boolean"),
+			expected: &Error{Code: TypeErr, Message: "object.remove: operand 1 must be object but got boolean"},
 		},
 		{
 			note:     "error invalid object param type number input",
 			object:   `input.x`,
 			keys:     `{"a"}`,
 			input:    `{"x": 123}`,
-			expected: builtins.NewOperandErr(1, "must be object but got number"),
+			expected: &Error{Code: TypeErr, Message: "object.remove: operand 1 must be object but got number"},
 		},
 		{
 			note:     "error invalid object param type string input",
 			object:   `input.x`,
 			keys:     `{"a"}`,
 			input:    `{"x": "foo"}`,
-			expected: builtins.NewOperandErr(1, "must be object but got string"),
+			expected: &Error{Code: TypeErr, Message: "object.remove: operand 1 must be object but got string"},
 		},
 		{
 			note:     "error invalid object param type nil input",
 			object:   `input.x`,
 			keys:     `{"a"}`,
 			input:    `{"x": none}`,
-			expected: builtins.NewOperandErr(1, "must be object but got var"),
+			expected: &Error{Code: TypeErr, Message: "object.remove: operand 1 must be object but got var"},
 		},
 		{
 			note:     "error invalid key param type string",
@@ -309,28 +308,28 @@ func TestBuiltinObjectRemove(t *testing.T) {
 			object:   `{"a": 1}`,
 			keys:     `input.x`,
 			input:    `{"x": "foo"}`,
-			expected: builtins.NewOperandErr(2, "must be one of {object, string, array} but got string"),
+			expected: &Error{Code: TypeErr, Message: "object.remove: operand 2 must be one of {object, string, array} but got string"},
 		},
 		{
 			note:     "error invalid key param type boolean input",
 			object:   `{"a": 1}`,
 			keys:     `input.x`,
 			input:    `{"x": true}`,
-			expected: builtins.NewOperandErr(2, "must be one of {object, string, array} but got boolean"),
+			expected: &Error{Code: TypeErr, Message: "object.remove: operand 2 must be one of {object, string, array} but got boolean"},
 		},
 		{
 			note:     "error invalid key param type number input",
 			object:   `{"a": 1}`,
 			keys:     `input.x`,
 			input:    `{"x": 22}`,
-			expected: builtins.NewOperandErr(2, "must be one of {object, string, array} but got number"),
+			expected: &Error{Code: TypeErr, Message: "object.remove: operand 2 must be one of {object, string, array} but got number"},
 		},
 		{
 			note:     "error invalid key param type nil input",
 			object:   `{"a": 1}`,
 			keys:     `input.x`,
 			input:    `{"x": none}`,
-			expected: builtins.NewOperandErr(2, "must be one of {object, string, array} but got var"),
+			expected: &Error{Code: TypeErr, Message: "object.remove: operand 2 must be one of {object, string, array} but got var"},
 		},
 	}
 
@@ -442,35 +441,35 @@ func TestBuiltinObjectFilter(t *testing.T) {
 			object:   `input.x`,
 			filters:  `{"a"}`,
 			input:    `{"x": ["a"]}`,
-			expected: builtins.NewOperandErr(1, "must be object but got array"),
+			expected: &Error{Code: TypeErr, Message: "object.filter: operand 1 must be object but got array"},
 		},
 		{
 			note:     "error invalid object param type bool input",
 			object:   `input.x`,
 			filters:  `{"a"}`,
 			input:    `{"x": false}`,
-			expected: builtins.NewOperandErr(1, "must be object but got boolean"),
+			expected: &Error{Code: TypeErr, Message: "object.filter: operand 1 must be object but got boolean"},
 		},
 		{
 			note:     "error invalid object param type number input",
 			object:   `input.x`,
 			filters:  `{"a"}`,
 			input:    `{"x": 123}`,
-			expected: builtins.NewOperandErr(1, "must be object but got number"),
+			expected: &Error{Code: TypeErr, Message: "object.filter: operand 1 must be object but got number"},
 		},
 		{
 			note:     "error invalid object param type string input",
 			object:   `input.x`,
 			filters:  `{"a"}`,
 			input:    `{"x": "foo"}`,
-			expected: builtins.NewOperandErr(1, "must be object but got string"),
+			expected: &Error{Code: TypeErr, Message: "object.filter: operand 1 must be object but got string"},
 		},
 		{
 			note:     "error invalid object param type nil input",
 			object:   `input.x`,
 			filters:  `{"a"}`,
 			input:    `{"x": none}`,
-			expected: builtins.NewOperandErr(1, "must be object but got var"),
+			expected: &Error{Code: TypeErr, Message: "object.filter: operand 1 must be object but got var"},
 		},
 		{
 			note:     "error invalid key param type string",
@@ -489,28 +488,28 @@ func TestBuiltinObjectFilter(t *testing.T) {
 			object:   `{"a": 1}`,
 			filters:  `input.x`,
 			input:    `{"x": "foo"}`,
-			expected: builtins.NewOperandErr(2, "must be one of {object, string, array} but got string"),
+			expected: &Error{Code: TypeErr, Message: "object.filter: operand 2 must be one of {object, string, array} but got string"},
 		},
 		{
 			note:     "error invalid key param type boolean input",
 			object:   `{"a": 1}`,
 			filters:  `input.x`,
 			input:    `{"x": true}`,
-			expected: builtins.NewOperandErr(2, "must be one of {object, string, array} but got boolean"),
+			expected: &Error{Code: TypeErr, Message: "object.filter: operand 2 must be one of {object, string, array} but got boolean"},
 		},
 		{
 			note:     "error invalid key param type number input",
 			object:   `{"a": 1}`,
 			filters:  `input.x`,
 			input:    `{"x": 22}`,
-			expected: builtins.NewOperandErr(2, "must be one of {object, string, array} but got number"),
+			expected: &Error{Code: TypeErr, Message: "object.filter: operand 2 must be one of {object, string, array} but got number"},
 		},
 		{
 			note:     "error invalid key param type nil input",
 			object:   `{"a": 1}`,
 			filters:  `input.x`,
 			input:    `{"x": none}`,
-			expected: builtins.NewOperandErr(2, "must be one of {object, string, array} but got var"),
+			expected: &Error{Code: TypeErr, Message: "object.filter: operand 2 must be one of {object, string, array} but got var"},
 		},
 	}
 


### PR DESCRIPTION
The older RegisterFunctionalBuiltinX functions would do this and it
gave the builtin error messaging/typing a nice uniform look and feel.

This changes the newer RegisterBuiltinFunc to do the same thing, so
any builtin will now either return a nil error or a `*topdown.Error`.
With an appropriate code, location, and message.

Fixes: #2101
Signed-off-by: Patrick East <east.patrick@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
