### PR TITLE
wasm: Memory export support for compiled policies.

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -15,11 +15,13 @@ import (
 )
 
 var buildParams = struct {
-	outputFile  string
-	debug       bool
-	dataPaths   repeatedStringFlag
-	ignore      []string
-	bundlePaths repeatedStringFlag
+	outputFile   string
+	debug        bool
+	exportMemory bool
+	memoryLimit  uint32
+	dataPaths    repeatedStringFlag
+	ignore       []string
+	bundlePaths  repeatedStringFlag
 }{}
 
 var buildCommand = &cobra.Command{
@@ -72,7 +74,7 @@ func build(args []string) error {
 	}
 
 	r := rego.New(regoArgs...)
-	cr, err := r.Compile(ctx, rego.CompilePartial(false))
+	cr, err := r.Compile(ctx, rego.CompilePartial(false), rego.CompileExportMemory(buildParams.exportMemory), rego.CompileMemoryLimit(buildParams.memoryLimit))
 	if err != nil {
 		return err
 	}
@@ -90,6 +92,8 @@ func build(args []string) error {
 
 func init() {
 	buildCommand.Flags().StringVarP(&buildParams.outputFile, "output", "o", "policy.wasm", "set the filename of the compiled policy")
+	buildCommand.Flags().BoolVarP(&buildParams.exportMemory, "export-memory", "e", false, "enable exporting of memory in the compiled policy")
+	buildCommand.Flags().Uint32VarP(&buildParams.memoryLimit, "memory-limit", "m", 0, "set the memory limit of the compiled policy with exported memory (0 means no limit)")
 	buildCommand.Flags().BoolVarP(&buildParams.debug, "debug", "D", false, "enable debug output")
 	buildCommand.Flags().VarP(&buildParams.dataPaths, "data", "d", "set data file(s) or directory path(s)")
 	buildCommand.Flags().VarP(&buildParams.bundlePaths, "bundle", "b", "set bundle file(s) or directory path(s)")

--- a/internal/wasm/encoding/reader.go
+++ b/internal/wasm/encoding/reader.go
@@ -142,7 +142,7 @@ func readSections(r io.Reader, m *module.Module) error {
 		bufr := bytes.NewReader(buf)
 
 		switch id {
-		case constant.CustomSectionID, constant.StartSectionID, constant.MemorySectionID:
+		case constant.CustomSectionID, constant.StartSectionID:
 			continue
 		case constant.TypeSectionID:
 			if err := readTypeSection(bufr, &m.Type); err != nil {
@@ -159,6 +159,10 @@ func readSections(r io.Reader, m *module.Module) error {
 		case constant.TableSectionID:
 			if err := readTableSection(bufr, &m.Table); err != nil {
 				return errors.Wrap(err, "table section")
+			}
+		case constant.MemorySectionID:
+			if err := readMemorySection(bufr, &m.Memory); err != nil {
+				return errors.Wrap(err, "memory section")
 			}
 		case constant.FunctionSectionID:
 			if err := readFunctionSection(bufr, &m.Function); err != nil {
@@ -251,6 +255,27 @@ func readTableSection(r io.Reader, s *module.TableSection) error {
 		}
 
 		s.Tables = append(s.Tables, table)
+	}
+
+	return nil
+}
+
+func readMemorySection(r io.Reader, s *module.MemorySection) error {
+
+	n, err := leb128.ReadVarUint32(r)
+	if err != nil {
+		return err
+	}
+
+	for i := uint32(0); i < n; i++ {
+
+		var memory module.Memory
+
+		if err := readLimits(r, &memory.Mem.Lim); err != nil {
+			return err
+		}
+
+		s.Memories = append(s.Memories, memory)
 	}
 
 	return nil

--- a/internal/wasm/encoding/writer.go
+++ b/internal/wasm/encoding/writer.go
@@ -50,6 +50,10 @@ func WriteModule(w io.Writer, module *module.Module) error {
 		return err
 	}
 
+	if err := writeMemorySection(w, module.Memory); err != nil {
+		return err
+	}
+
 	if err := writeGlobalSection(w, module.Global); err != nil {
 		return err
 	}
@@ -228,6 +232,32 @@ func writeTableSection(w io.Writer, s module.TableSection) error {
 			return fmt.Errorf("illegal table element type")
 		}
 		if err := writeLimits(&buf, table.Lim); err != nil {
+			return err
+		}
+	}
+
+	return writeRawSection(w, &buf)
+
+}
+
+func writeMemorySection(w io.Writer, s module.MemorySection) error {
+
+	if len(s.Memories) == 0 {
+		return nil
+	}
+
+	if err := writeByte(w, constant.MemorySectionID); err != nil {
+		return err
+	}
+
+	var buf bytes.Buffer
+
+	if err := leb128.WriteVarUint32(&buf, uint32(len(s.Memories))); err != nil {
+		return err
+	}
+
+	for _, memory := range s.Memories {
+		if err := writeLimits(&buf, memory.Mem.Lim); err != nil {
 			return err
 		}
 	}

--- a/internal/wasm/module/module.go
+++ b/internal/wasm/module/module.go
@@ -20,6 +20,7 @@ type (
 		Import   ImportSection
 		Function FunctionSection
 		Table    TableSection
+		Memory   MemorySection
 		Element  ElementSection
 		Global   GlobalSection
 		Export   ExportSection
@@ -45,6 +46,11 @@ type (
 	// TableSection represents a WASM table section.
 	TableSection struct {
 		Tables []Table
+	}
+
+	// MemorySection represents a WASM memory section.
+	MemorySection struct {
+		Memories []Memory
 	}
 
 	// ElementSection represents a WASM element section.
@@ -139,6 +145,11 @@ type (
 	Table struct {
 		Type types.ElementType
 		Lim  Limit
+	}
+
+	// Memory represents a WASM memory statement.
+	Memory struct {
+		Mem MemType
 	}
 
 	// Global represents a WASM global statement.


### PR DESCRIPTION
Developer can decide whether the compiled policies are to import or
export their memory. This is for wasm runtimes not supporting memory
importing.

This patch takes the approach to modify the pre-built OPA binary at
the compilation time as necessary. The alternative would have been to
have two versions of the pre-built binary, one with memory import and
one with memory export.

The default is still to import the memory as before. That is, the
developer has to explicitly enable the exporting when using either go
build or rego package to compile policies to wasm.

Signed-off-by: Teemu Koponen <koponen@styra.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
