### PR TITLE
Add pre-commit integration

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,22 @@
+---
+- id: opa-fmt
+  name: opa/rego format
+  description: Format Open Policy Agent rego policy files
+  entry: pre-commit/opa-fmt.sh
+  language: script
+  types:
+    - file
+    - text
+  files: '\.rego$'
+
+- id: opa-test
+  name: opa/rego tests
+  description: Run Open Policy Agent rego tests
+  entry: pre-commit/opa-test.sh
+  language: script
+  types:
+    - file
+    - text
+  pass_filenames: false  # because it's really fast, just test the whole tree.
+  files: '\.rego$'
+  # In your config, supply args with the root path of where you keep your OPA tests.

--- a/pre-commit/opa-fmt.sh
+++ b/pre-commit/opa-fmt.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -o errexit -o nounset -o pipefail
+[[ -n "${PRE_COMMIT_VERBOSE:-}" ]] || set -o xtrace
+command -v opa >/dev/null || echo "opa not found on PATH. Install it: https://github.com/open-policy-agent/opa/releases"
+
+exit_code=0
+on_error() {
+    exit_code=3
+}
+
+for file_with_path in "${@}"; do
+  opa fmt --write "${file_with_path}" || on_error
+done
+
+exit "${exit_code}"

--- a/pre-commit/opa-test.sh
+++ b/pre-commit/opa-test.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -o errexit -o nounset -o pipefail
+[[ -n "${PRE_COMMIT_VERBOSE:-}" ]] || set -o xtrace
+command -v opa >/dev/null || echo "opa not found on PATH. Install it: https://github.com/open-policy-agent/opa/releases"
+
+opa test "${@}"


### PR DESCRIPTION
[pre-commit](https://pre-commit) is a nice local workflow optimisation for linting/formatting/fast-tests. It has various options; this is I think the simplest choice for integration since it leaves the installation and pinning of `opa` up to the user's choice.

It's possible to do this via docker or golang 'language', see https://pre-commit.com/#supported-languages, but the former takes the dependency on docker and the latter uses go get which is harder to pin for reproducibility

To try this out, make `.pre-commit-config.yaml` inside the root of a repo you want to try out with this content:

```yaml
  - repo: https://github.com/petemounce/opa
    rev: pre-commit
    hooks:
      - id: opa-fmt
      - id: opa-test
        args:
          - "path/to/your/rego_test_files"
```

(A more normal config would use a tag for `rev`, and would be pointed at your repository rather than my fork)

Then `pip install pre-commit` and then `pre-commit run --all-files --verbose`. I've made the underlying scripts set xtrace on if `PRE_COMMIT_VERBOSE` is set to anything, also.

For more information, https://pre-commit.com/#quick-start is decent, and the docs generally are good.