### PR TITLE
topdown: Invoke iterator when evaluating negation

### DIFF
--- a/topdown/eval.go
+++ b/topdown/eval.go
@@ -332,7 +332,7 @@ func (e *eval) evalNot(iter evalIterator) error {
 	}
 
 	if !defined {
-		return e.next(iter)
+		return iter(e)
 	}
 
 	e.traceFail(expr)
@@ -480,7 +480,7 @@ func (e *eval) evalNotPartial(iter evalIterator) error {
 	// If partial evaluation produced no results, the expression is always undefined
 	// so it does not have to be saved.
 	if len(savedQueries) == 0 {
-		return e.next(iter)
+		return iter(e)
 	}
 
 	// Check if the partial evaluation result can be inlined in this query. If not,
@@ -502,7 +502,7 @@ func (e *eval) evalNotPartial(iter evalIterator) error {
 	//	(!A && !C) || (!A && !D) || (!B && !C) || (!B && !D)
 	return complementedCartesianProduct(savedQueries, 0, nil, func(q ast.Body) error {
 		return e.saveInlinedNegatedExprs(q, func() error {
-			return e.next(iter)
+			return iter(e)
 		})
 	})
 }
@@ -1042,7 +1042,7 @@ func (e *eval) saveCall(declArgsLen int, terms []*ast.Term, iter unifyIterator) 
 
 func (e *eval) saveInlinedNegatedExprs(exprs []*ast.Expr, iter unifyIterator) error {
 
-	// This function does not have include with statements on the exprs because
+	// This function does not include with statements on the exprs because
 	// they will have already been saved and therefore had their any relevant
 	// with statements set.
 	for _, expr := range exprs {

--- a/topdown/topdown_partial_test.go
+++ b/topdown/topdown_partial_test.go
@@ -1728,6 +1728,17 @@ func TestTopDownPartialEval(t *testing.T) {
 			query:       "x = [0]; y = {true | x[0]; input.y = 1}", // include an unknown in the comprehension to force saving
 			wantQueries: []string{`y = {true | x[0]; input.y = 1; x = [0]}; x = [0]`},
 		},
+		{
+			note:        "negation: save inline negated with",
+			query:       `not input with data.x as 2; data.x = 1`,
+			data:        `{"x": 1}`,
+			wantQueries: []string{"not input"},
+		},
+		{
+			note:        "negation: save inline negated with (undefined)",
+			query:       `not input with data.x as 1; data.x = 1`,
+			wantQueries: []string{},
+		},
 	}
 
 	ctx := context.Background()

--- a/topdown/topdown_test.go
+++ b/topdown/topdown_test.go
@@ -2105,6 +2105,15 @@ func TestTopDownWithKeyword(t *testing.T) {
 				`q = x { r = x with input.a.c as 2 }`,
 				`p = x { q = x with input.a.b as 1 }`,
 			},
+		}, {
+			note:  "with not stack",
+			input: `{"a": {"d": 3}, "e": 4}`,
+			exp:   `{"a": {"b": 1, "c": 2, "d": 3}, "e": 4}`,
+			rules: []string{
+				`r = input { true }`,
+				`q = x { not false with input as {}; r = x with input.a.c as 2 }`,
+				`p = x { q = x with input.a.b as 1 }`,
+			},
 		},
 		{
 			note: "with stack (data)",
@@ -2118,6 +2127,23 @@ func TestTopDownWithKeyword(t *testing.T) {
 			rules: []string{
 				`r = data.test { true }`,
 				`q = x { r = x with data.test.a.c as 2 }`,
+				`p = x { q = x with data.test.a.b as 1 }`,
+			},
+		},
+		{
+			note: "with not stack (data)",
+			exp:  `{"a": {"b": 1, "c": 2, "d": 3}, "e": 4}`,
+			modules: []string{
+				`package test.a
+				d = 3`,
+				`package test
+				e = 4`,
+			},
+			rules: []string{
+				`r = data.test { true }`,
+				`n1 { data.test.a.z == 7 }`,
+				`n { not n1 } `,
+				`q = x { not n with data.test.a.z as 7; r = x with data.test.a.c as 2 }`,
 				`p = x { q = x with data.test.a.b as 1 }`,
 			},
 		},


### PR DESCRIPTION
In `evalNot` when it succeeds we were calling `e.next(..)` to continue
evaluation, but if the previous expression was from `evalWith` the
original state was not being restored. This caused the patched data
to persist for subsequent expression evaluation(s) until `iter()` was
used.

Similar treatment was required in `evalNotPartial` for the partial
evaluation case.

Fixes: #2142
Signed-off-by: Patrick East <east.patrick@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
