### PR TITLE
cmd/parse: fix panic when parsing invalid JSON

### DIFF
--- a/cmd/parse.go
+++ b/cmd/parse.go
@@ -44,7 +44,6 @@ var parseCommand = &cobra.Command{
 }
 
 func parse(args []string) int {
-
 	if len(args) == 0 {
 		return 0
 	}
@@ -65,6 +64,10 @@ func parse(args []string) int {
 		}
 		fmt.Println(string(bs))
 	default:
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return 1
+		}
 		ast.Pretty(os.Stdout, result.Parsed)
 	}
 


### PR DESCRIPTION
In f1b9c758 (Ensure all errors are in JSON formatted CLI output,
2019-09-11), the existing error check was moved into the JSON output
case, but the default case wasn't updated to handle errors.