### PR TITLE
Add website link checker

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,3 @@
+# Link checker artifacts
+bin/
+tmp/

--- a/docs/.htmltest.yml
+++ b/docs/.htmltest.yml
@@ -1,4 +1,3 @@
 DirectoryPath: website/public
 IgnoreDirectoryMissingTrailingSlash: true
 CheckExternal: false
-#IgnoreAltMissing: true

--- a/docs/.htmltest.yml
+++ b/docs/.htmltest.yml
@@ -1,0 +1,4 @@
+DirectoryPath: website/public
+IgnoreDirectoryMissingTrailingSlash: true
+CheckExternal: false
+#IgnoreAltMissing: true

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -66,3 +66,8 @@ preview-build:
 .PHONY: live-blocks-%
 live-blocks-%:
 	cd $(CURDIR)/website/scripts/live-blocks && npm run --silent $*
+
+.PHONY: check-links
+check-links:
+	curl https://raw.githubusercontent.com/wjdp/htmltest/master/godownloader.sh | bash
+	bin/htmltest

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -311,7 +311,7 @@ services:
 | `labels` | `object` | Yes | Set of key-value pairs that uniquely identify the OPA instance. Labels are included when OPA uploads decision logs and status information. |
 | `default_decision` | `string` | No (default: `/system/main`) | Set path of default policy decision used to serve queries against OPA's base URL. |
 | `default_authorization_decision` | `string` | No (default: `/system/authz/allow`) | Set path of default authorization decision for OPA's API. |
-| `plugins` | `object` | No (default: `{}`) | Location for custom plugin configuration. See [Plugins](../plugins) for details. |
+| `plugins` | `object` | No (default: `{}`) | Location for custom plugin configuration. See [Plugins](../extensions/#custom-plugins-for-opa-daemon) for details. |
 
 ### Bundles
 

--- a/docs/content/docker-authorization.md
+++ b/docs/content/docker-authorization.md
@@ -132,7 +132,7 @@ The output should be:
 Error response from daemon: authorization denied by plugin opa-docker-authz: request rejected by administrative policy
 ```
 
-To learn more about how rules define the content of documents, see: [How Does OPA Work?](../#how-does-opa-work)
+To learn more about how rules define the content of documents, see: [How Does OPA Work?](../how-does-opa-work)
 
 With this policy in place, users will not be able to run any Docker commands. Go
 ahead and try other commands such as `docker run` or `docker pull`. They will

--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -384,7 +384,7 @@ io.jwt.decode_verify(input.token, {
 ```live:jwt_decode/verify:output
 ```
 
-See the [Policy Reference](../policy-reference#tokens) for additional verification constraints.
+See the [Policy Reference](../policy-reference#token-signing) for additional verification constraints.
 
 To get certificates into the policy, you can either hardcode them or provide them as environmental variables to OPA and then use the `opa.runtime` builtin to retrieve those variables.
 

--- a/docs/content/integration.md
+++ b/docs/content/integration.md
@@ -244,5 +244,5 @@ telemetry information on OPA deployments.
 - See the [Decision Log API](../management/#decision-logs) for collecting a log of policy decisions made by agents.
 - See the [Health API](../rest-api#health-api) for checking agent deployment readiness and health.
 
-OPA also exports a [Prometheus API endpoint](../management/#prometheus) that can be scraped to obtain
+OPA also exports a [Prometheus API endpoint](../monitoring/#prometheus) that can be scraped to obtain
 insight into performance and errors.

--- a/docs/content/management.md
+++ b/docs/content/management.md
@@ -143,7 +143,7 @@ files in the bundle must be organized hierarchically into directories inside
 the tarball.
 
 > The hierarchical organization indicates to OPA where to load the data files
-> into the [the `data` Document](../#the-data-document).
+> into the the `data` Document.
 
 You can list the content of a bundle with `tar`.
 
@@ -256,7 +256,7 @@ the Status API.
 > **Warning!** There are *no* ordering guarantees for which bundle loads first and
   takes over some root. If multiple bundles conflict, but are loaded at different
   times, OPA may go into an error state. It is highly recommended to use
-  the health check and include bundle state: [Monitoring OPA](#health-checks)
+  the health check and include bundle state: [Monitoring OPA](../monitoring#health-checks)
 
 ### Debugging Your Bundles
 

--- a/docs/content/policy-language.md
+++ b/docs/content/policy-language.md
@@ -659,9 +659,8 @@ b
 
 ## Rules
 
-Rules define the content of [Virtual Documents](../#rules-and-virtual-documents) in
-OPA. When OPA evaluates a rule, we say OPA *generates* the content of the
-document that is defined by the rule.
+Rules define the content of Virtual Documents in OPA. When OPA evaluates a rule, we say OPA
+*generates* the content of the document that is defined by the rule.
 
 The sample code in this section make use of the data defined in [Examples](#example-data).
 
@@ -835,7 +834,7 @@ pi := 3.14156   # Redeclaration error because 'pi' already declared above.
 
 ### Functions
 
-Rego supports user-defined functions that can be called with the same semantics as [Built-in Functions](#built-in-functions). They have access to both the [the data Document](../#the-data-document) and [the input Document](../#the-input-document).
+Rego supports user-defined functions that can be called with the same semantics as [Built-in Functions](#built-in-functions). They have access to both the the data Document and the input Document.
 
 For example, the following function will return the result of trimming the spaces from a string and then splitting it by periods.
 
@@ -956,7 +955,7 @@ s(5, 3)
 
 ## Negation
 
-To generate the content of a [Virtual Document](../#rules-and-virtual-documents), OPA attempts to bind variables in the body of the rule such that all expressions in the rule evaluate to True.
+To generate the content of a Virtual Document, OPA attempts to bind variables in the body of the rule such that all expressions in the rule evaluate to True.
 
 This generates the correct result when the expressions represent assertions about what states should exist in the data stored in OPA. In some cases, you want to express that certain states *should not* exist in the data stored in OPA. In these cases, negation must be used.
 
@@ -1151,7 +1150,7 @@ Import statements declare dependencies that modules have on documents defined ou
 
 All modules contain implicit statements which import the `data` and `input` documents.
 
-Modules use the same syntax to declare dependencies on [Base Documents](../#base-documents) and [Virtual Documents](../#rules-and-virtual-documents).
+Modules use the same syntax to declare dependencies on Base Documents and Virtual Documents.
 
 ```live:import_data:module:read_only
 package opa.examples
@@ -1253,7 +1252,7 @@ behaviour of other rules.
 ## With Keyword
 
 The `with` keyword allows queries to programmatically specify values nested
-under the [input Document](../##the-input-document) and the [data Document](../#the-data-document).
+under the `input` Document and the `data` Document.
 
 For example, given the simple authorization policy in the [Imports](#imports)
 section, we can write a query that checks whether a particular request would be

--- a/docs/content/rest-api.md
+++ b/docs/content/rest-api.md
@@ -710,7 +710,7 @@ Content-Type: application/json
 
 ## Data API
 
-The Data API exposes endpoints for reading and writing documents in OPA. For an introduction to the different types of documents in OPA see [How Does OPA Work?](../#how-does-opa-work).
+The Data API exposes endpoints for reading and writing documents in OPA. For an introduction to the different types of documents in OPA see [How Does OPA Work?](../how-does-opa-work).
 
 ### Get a Document
 

--- a/docs/content/security.md
+++ b/docs/content/security.md
@@ -14,7 +14,7 @@ authorization so that:
 - Traffic between OPA and clients is encrypted.
 - Clients verify the OPA API endpoint identity.
 - OPA verifies client identities.
-- Clients are only granted access to specific APIs or sections of [The `data` Document](../#the-data-document).
+- Clients are only granted access to specific APIs or sections of the `data` Document.
 
 ## TLS and HTTPS
 

--- a/docs/website/layouts/index.html
+++ b/docs/website/layouts/index.html
@@ -11,10 +11,10 @@
           content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
     <!-- Bootstrap CSS -->
-    <link rel="stylesheet" href="css/bootstrap.min.css">
+    <link rel="stylesheet" href="/css/bootstrap.min.css">
 
     <title>Open Policy Agent</title>
-    <link rel="stylesheet" href="./css/home.css">
+    <link rel="stylesheet" href="/css/home.css">
   </head>
 
   <body data-spy="scroll" data-target=".navbar" data-offset="90">
@@ -22,8 +22,10 @@
     <nav class="navbar navbar-expand-lg navbar-dark bg-transparent">
       <div class="container">
 
-        <a class="navbar-brand" href="/"><img src="./img/logo-white.png"
-                                                 class="img-fluid"></a>
+        <a class="navbar-brand" href="/">
+          <img src="/img/logo-white.png" class="img-fluid" alt="OPA navbar logo">
+        </a>
+
         <button class="navbar-toggler navbar-toggler-right collapsed"
                 type="button" data-toggle="collapse"
                 data-target="#navb" aria-expanded="false">
@@ -36,17 +38,17 @@
 
           <ul class="navbar-nav">
             <li class="nav-item">
-              <a class="nav-link" href="./docs/latest/">Documentation </a>
+              <a class="nav-link" href="/docs/latest/">Documentation </a>
             </li>
             <!-- <li class="nav-item">
-              <a class="nav-link" href="./docs/latest/get-started/">Tutorials </a>
+              <a class="nav-link" href="/docs/latest/get-started/">Tutorials </a>
             </li> -->
             <li class="nav-item">
               <a class="nav-link"
-                 href="./docs/latest/ecosystem/">Integrations </a>
+                 href="/docs/latest/ecosystem/">Integrations </a>
             </li>
             <li class="nav-item">
-              <a class="nav-link" href="./support">Support</a>
+              <a class="nav-link" href="/support">Support</a>
             </li>
             <li class="nav-item">
               <a class="nav-link" href="https://play.openpolicyagent.org/">Playground</a>
@@ -56,19 +58,19 @@
             </li>
             <li class="nav-item social-nav-item">
               <a class="nav-link social-icon-link" href="https://twitter.com/openpolicyagent">
-                <img src="./img/twitter-icon.png" alt="Twitter">
+                <img src="/img/twitter-icon.png" alt="Twitter">
                 <div class="nav-link social-icon-title">Twitter</div>
               </a>
             </li>
             <li class="nav-item social-nav-item">
               <a class="nav-link social-icon-link" href="https://slack.openpolicyagent.org/">
-                <img src="./img/slack-icon.png" alt="Slack">
+                <img src="/img/slack-icon.png" alt="Slack">
                 <div class="nav-link social-icon-title">Slack</div>
               </a>
             </li>
             <li class="nav-item social-nav-item">
               <a class="nav-link social-icon-link" href="https://github.com/open-policy-agent/opa">
-                <img src="./img/github-icon.png" alt="GitHub">
+                <img src="/img/github-icon.png" alt="GitHub">
                 <div class="social-icon-title">GitHub</div>
               </a>
             </li>
@@ -80,9 +82,9 @@
   </div>
 
   <!-- <section id="homebackground">
-      <div class="bg"><img src="./img/homebg.png"></div>
-      <div class="cloud-top"><img src="./img/cloudAll.png"></div>
-      <div class="homepageconterimage"><img src="./img/homeBanner.png"></div>
+      <div class="bg"><img src="/img/homebg.png"></div>
+      <div class="cloud-top"><img src="/img/cloudAll.png"></div>
+      <div class="homepageconterimage"><img src="/img/homeBanner.png"></div>
     </section> -->
 
   <section id="homebackground">
@@ -94,9 +96,9 @@
       <div class="banner-subcontent">Flexible, fine-grained control for
         administrators across the stack
       </div>
-      <img src="./img/banner-image.png">
+      <img src="/img/banner-image.png" alt="OPA banner">
       <div class="mobile-view-Banner"><img
-                src="./img/opa-mobile-banner_mobile.png"></div>
+                src="/img/opa-mobile-banner_mobile.png" alt="OPA mobile banner"></div>
     </div>
   </section>
 
@@ -123,21 +125,21 @@
           </div>
           <div class="mt-5 text-center blue">
             <button class="btn btn-primary"><a><span>Learn More:</span></a> <a
-                      href="./docs/latest/kubernetes-introduction/">Kubernetes</a>
+                      href="/docs/latest/kubernetes-introduction/">Kubernetes</a>
               - <a
-                      href="./docs/latest/envoy-authorization/">Envoy</a> - <a
-                      href="./docs/latest/terraform/">Terraform</a> - <a
-                      href="./docs/latest/kafka-authorization/">Kafka</a>
+                      href="/docs/latest/envoy-authorization/">Envoy</a> - <a
+                      href="/docs/latest/terraform/">Terraform</a> - <a
+                      href="/docs/latest/kafka-authorization/">Kafka</a>
               -
               <a href="https://blog.openpolicyagent.org/write-policy-in-opa-enforce-policy-in-sql-d9d24db93bf4">SQL</a>
-              - <a href="./docs/latest/ssh-and-sudo-authorization/">Linux</a>
+              - <a href="/docs/latest/ssh-and-sudo-authorization/">Linux</a>
             </button>
           </div>
           <div class="mt-5 text-center">
             <div class="styraText">
               <p>Created By</p><span> <a href="https://styra.com"><img
-                          src="./img/styra-logo.jpg"
-                          class="img-fluid"></a></span>
+                          src="/img/styra-logo.jpg"
+                          class="img-fluid" alt="Styra logo"></a></span>
             </div>
           </div>
         </div>
@@ -236,7 +238,7 @@
 
   <section id="gray">
 
-    <div class="gray-top-image"><img src="./img/gray-top.png"></div>
+    <div class="gray-top-image"><img src="/img/gray-top.png" alt="Light grey background image"></div>
     <section id="declarative-policy">
 
       <div class="container">
@@ -253,19 +255,19 @@
                   <li class="nav-item">
                     <a class="nav-link nav-width active" data-toggle="tab"
                        href="#tabs-1" role="tab">
-                      <img src="./img/policyIcon-1.png">
+                      <img src="/img/policyIcon-1.png" alt="Kubernetes logo">
                       Kubernetes</a>
                   </li>
                   <li class="nav-item">
                     <a class="nav-link nav-width" data-toggle="tab"
                        href="#tabs-2" role="tab">
-                      <img src="./img/envoy-square.png">
+                      <img src="/img/envoy-square.png" alt="Envoy logo">
                       Envoy</a>
                   </li>
                   <li class="nav-item">
                     <a class="nav-link nav-width" data-toggle="tab"
                        href="#tabs-4" role="tab">
-                      <img src="./img/policyIcon-4.png">
+                      <img src="/img/policyIcon-4.png" alt="Application logo">
                       Application</a>
                   </li>
                 </ul>
@@ -805,13 +807,13 @@ allowed_pets[pet] {
                 <div class="declarativeBOx">
                   <a href="#kubernetes">
                     <div class="declarativeInnerBOx">
-                      <img src="./img/policyIcon-1.png"
-                           class="declarativeImage">
+                      <img src="/img/policyIcon-1.png"
+                           class="declarativeImage" alt="Kubernetes logo">
                       <p class="declarativeText">Kubernetes</p>
                     </div>
 
                     <div class="downArrow">
-                      <img src="./img/downArrow.svg">
+                      <img src="/img/downArrow.svg" alt="Down arrow">
                     </div>
                   </a>
 
@@ -822,13 +824,13 @@ allowed_pets[pet] {
                 <div class="declarativeBOx envoy">
                   <a href="#envoy">
                     <div class="declarativeInnerBOx ">
-                      <img src="./img/policyIcon-2.png"
-                           class="declarativeImage">
+                      <img src="/img/policyIcon-2.png"
+                           class="declarativeImage" alt="Envoy logo">
                       <p class="declarativeText">Envoy</p>
                     </div>
 
                     <div class="downArrow">
-                      <img src="./img/downArrow.svg">
+                      <img src="/img/downArrow.svg" alt="Down arrow">
                     </div>
                   </a>
 
@@ -839,13 +841,13 @@ allowed_pets[pet] {
                 <div class="declarativeBOx">
                   <a href="#application">
                     <div class="declarativeInnerBOx">
-                      <img src="./img/policyIcon-4.png"
-                           class="declarativeImage">
+                      <img src="/img/policyIcon-4.png"
+                           class="declarativeImage" alt="Application logo">
                       <p class="declarativeText">Application</p>
                     </div>
 
                     <div class="downArrow">
-                      <img src="./img/downArrow.svg">
+                      <img src="/img/downArrow.svg" alt="Down arrow">
                     </div>
                   </a>
 
@@ -857,7 +859,7 @@ allowed_pets[pet] {
           <div class="col-12 mt-3 mt-sm-5" id="kubernetes">
             <div class="declarative-policy-contentBox">
               <div class="declarative-policy-contentBox-header">
-                <img src="./img/policyIcon-1.png" class="declarativeImage">
+                <img src="/img/policyIcon-1.png" class="declarativeImage" alt="Kubernetes logo">
                 <p class="declarativeText">Kubernetes</p>
               </div>
               <div class="row">
@@ -1034,7 +1036,7 @@ deny[msg] {
           <div class="col-12 mt-3 mt-sm-5" id="envoy">
             <div class="declarative-policy-contentBox">
               <div class="declarative-policy-contentBox-header">
-                <img src="./img/policyIcon-2.png" class="declarativeImage">
+                <img src="/img/policyIcon-2.png" class="declarativeImage" alt="Envoy logo">
                 <p class="declarativeText declarativeEnvoy">Envoy</p>
               </div>
               <div class="row">
@@ -1245,7 +1247,7 @@ source_spiffe_id = client_id {
           <div class="col-12 mt-3 mt-sm-5" id="application">
             <div class="declarative-policy-contentBox">
               <div class="declarative-policy-contentBox-header">
-                <img src="./img/policyIcon-4.png" class="declarativeImage">
+                <img src="/img/policyIcon-4.png" class="declarativeImage" alt="Application logo">
                 <p class="declarativeText">Application</p>
               </div>
               <div class="row">
@@ -1421,14 +1423,14 @@ allowed_pets[pet] {
         <div class="col-12">
           <div class="mt-5 text-center blue">
             <button class="btn btn-primary"><span>Learn More:</span> <a
-                        href="./docs/latest/kubernetes-introduction/">Kubernetes</a>
+                        href="/docs/latest/kubernetes-introduction/">Kubernetes</a>
                 - <a
-                        href="./docs/latest/envoy-authorization/">Envoy</a> - <a
-                        href="./docs/latest/terraform/">Terraform</a> - <a
-                        href="./docs/latest/kafka-authorization/">Kafka</a>
+                        href="/docs/latest/envoy-authorization/">Envoy</a> - <a
+                        href="/docs/latest/terraform/">Terraform</a> - <a
+                        href="/docs/latest/kafka-authorization/">Kafka</a>
                 -
                 <a href="https://blog.openpolicyagent.org/write-policy-in-opa-enforce-policy-in-sql-d9d24db93bf4">SQL</a>
-                - <a href="./docs/latest/ssh-and-sudo-authorization/">Linux</a>
+                - <a href="/docs/latest/ssh-and-sudo-authorization/">Linux</a>
             </button>
           </div>
         </div>
@@ -1439,7 +1441,7 @@ allowed_pets[pet] {
 
   <section id="curveImage">
     <!-- <div class="curveImage-container"></div> -->
-    <img src="./img/curve.png">
+    <img src="/img/curve.png" alt="Curve image container">
   </section>
 
   <section id="architectural-flexibility">
@@ -1469,7 +1471,7 @@ allowed_pets[pet] {
               </div>
             </div>
             <div class="service-graphics">
-              <img src="./img/Deployment-Options-3.png">
+              <img src="/img/Deployment-Options-3.png" alt="Daemon logo">
               <div class="service-graphics-text">
                 <div class="row">
                   <div class="col-3"></div>
@@ -1500,7 +1502,7 @@ allowed_pets[pet] {
               <div class="service-subtext dark pt-5">
                 <h3>Service</h3>
                 <div class="service-smallCircle">
-                  <img src="./img/logo.png">
+                  <img src="/img/logo.png" alt="Library logo">
                   <!-- <div class="service-innertext dark">
                                 <h3>Services</h3>
                               </div> -->
@@ -1508,7 +1510,7 @@ allowed_pets[pet] {
               </div>
             </div>
             <div class="service-graphic">
-              <img src="./img/Deployment-Options-1.png">
+              <img src="/img/Deployment-Options-1.png" alt="Service logo">
               <div class="service-graphics-text">
                 <div class="row">
                   <div class="col-3"></div>
@@ -1535,8 +1537,8 @@ allowed_pets[pet] {
         <div class="col-12 mt-5">
           <div class="mt-5 text-center blue">
             <button class="btn btn-primary"><a><span>Learn More:</span></a> <a
-                      href="./docs/latest/deployments/">Daemon</a> - <a
-                      href="./docs/latest/integration/#integrating-with-the-go-api">Library</a>
+                      href="/docs/latest/deployments/">Daemon</a> - <a
+                      href="/docs/latest/integration/#integrating-with-the-go-api">Library</a>
             </button>
           </div>
         </div>
@@ -1546,7 +1548,7 @@ allowed_pets[pet] {
 
   <section id="curveImage">
     <!-- <div class="curveImage-container"></div> -->
-    <img src="./img/curve-up.png">
+    <img src="/img/curve-up.png" alt="Curve up background image">
   </section>
 
   <section id="policy-authoring">
@@ -1560,19 +1562,19 @@ allowed_pets[pet] {
       <div class="row text-center center-align-content">
         <div class="col-12 col-sm-12 col-md-12 col-lg-6  p-sm-0">
           <div class="policy-sharing center-align-content">
-            <img src="./img/tools-playground.png" class="img-fluid">
+            <img src="/img/tools-playground.png" class="img-fluid" alt="Rego Playground screenshot">
             <h4>Rego Playground for Policy Sharing</h4>
           </div>
         </div>
         <div class="col-12 col-sm-12 col-md-12 col-lg-6 p-sm-0">
           <div class="policy-sharing center-align-content">
-            <img src="./img/tools-vscode.png" class="img-fluid">
+            <img src="/img/tools-vscode.png" class="img-fluid" alt="Visual Studio Code screenshot">
             <h4>VS Code for Policy Authoring</h4>
           </div>
         </div>
         <div class="col-12 col-sm-12 col-md-12 col-lg-6 p-sm-0">
           <div class="policy-sharing center-align-content">
-            <img src="./img/tools-cli.png" class="img-fluid">
+            <img src="/img/tools-cli.png" class="img-fluid" alt="CLI and REPL screenshot">
             <h4>CLI and REPL for complete control</h4>
           </div>
         </div>
@@ -1591,7 +1593,7 @@ allowed_pets[pet] {
             <button class="btn btn-primary"><a><span>Learn More:</span></a>
               <a href="https://marketplace.visualstudio.com/items?itemName=tsandall.opa">VScode</a>
               - <a href="https://play.openpolicyagent.org/">Rego
-                Playground</a> - <a href="./docs/latest/#running-opa">General
+                Playground</a> - <a href="/docs/latest/#running-opa">General
                 Tooling</a></button>
           </div>
         </div>
@@ -1608,7 +1610,7 @@ allowed_pets[pet] {
             project.
           </div>
           <div class="footer-logo pb-4">
-            <img src="img/cloud-native-logo.png">
+            <img src="img/cloud-native-logo.png" alt="CNCF logo">
           </div>
           <div class="footer-bottom">
             © 2019 Open Policy Agent contributors. Licensed under the Apache

--- a/docs/website/layouts/partials/docs/dashboard-panel.html
+++ b/docs/website/layouts/partials/docs/dashboard-panel.html
@@ -8,7 +8,7 @@
   <div class="dashboard-panel-header has-text-centered">
     <div class="dashboard-panel-header-logo">
       <a href="{{ $home }}">
-        <img src="{{ $logo }}">
+        <img src="{{ $logo }}" alt="OPA sidebar logo">
       </a>
     </div>
 

--- a/docs/website/layouts/partials/docs/navbar.html
+++ b/docs/website/layouts/partials/docs/navbar.html
@@ -17,7 +17,7 @@
 <nav class="navbar is-primary">
   <div class="navbar-brand is-hidden-tablet">
     <a class="navbar-item" href="{{ $home }}">
-      <img src="{{ $logo }}">
+      <img src="{{ $logo }}" alt="OPA navbar logo">
     </a>
 
     <a role="button" class="navbar-burger burger" aria-label="menu" aria-expanded="false" data-target="mobile-menu">

--- a/docs/website/layouts/partials/meta.html
+++ b/docs/website/layouts/partials/meta.html
@@ -39,7 +39,7 @@
 <meta name="twitter:creator" content="@{{ $twitter }}">
 
 <!-- Links -->
-<link rel="canonical" content="{{ .Permalink }}">
+<link rel="canonical" href="{{ .Permalink }}">
 <link rel="shortcut icon" href="/favicon.png" type="image/x-icon"/>
 
 <!-- Algolia metadata -->

--- a/docs/website/layouts/shortcodes/figure.html
+++ b/docs/website/layouts/shortcodes/figure.html
@@ -1,10 +1,10 @@
 {{ $src     := .Get "src" }}
 {{ $version  := index (split $.Page.File.Path "/") 1 }}
-{{/* 
+{{/*
   TODO: Remove this check once we no longer have doc releases
    with non versioned images. As-is just point them to "edge" since
    that version will not have the image bundled with the versioned
-   markdown content. 
+   markdown content.
 */}}
 {{ if (hasPrefix $src "/img/") }}
 {{ $src = strings.TrimPrefix "/img/" $src }}
@@ -16,7 +16,7 @@
 {{ $width   := .Get "width" | default 50 }}
 {{ $alt     := cond (isset .Params "caption") $caption (.Get "alt" | markdownify) }}
 <figure class="figure">
-  <img src="{{ $relPath }}" width="{{ $width }}%">
+  <img src="{{ $relPath }}" width="{{ $width }}%" alt="{{ $alt }}">
 
   {{ with $caption }}
   <figcaption class="has-text-weight-light">

--- a/docs/website/scripts/live-blocks/static/opening-in-playground.html
+++ b/docs/website/scripts/live-blocks/static/opening-in-playground.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
   <head>
     <title>Opening...</title>
@@ -19,6 +20,6 @@
     </style>
   </head>
   <body>
-    <img src="/live-blocks/icons/opening.svg" class="opening">
+    <img src="/live-blocks/icons/opening.svg" class="opening" alt="Opening icon">
   </body>
 </html>

--- a/docs/website/static/support.html
+++ b/docs/website/static/support.html
@@ -24,7 +24,7 @@
           <div class="container">
 
             <a class="navbar-brand" href="/"><img src="./img/logo-white.png"
-                                                     class="img-fluid"></a>
+                                                     class="img-fluid" alt="OPA navbar logo"></a>
             <button class="navbar-toggler navbar-toggler-right collapsed"
                     type="button" data-toggle="collapse"
                     data-target="#navb" aria-expanded="false">
@@ -47,7 +47,7 @@
                      href="./docs/latest/ecosystem/">Integrations </a>
                 </li>
                 <li class="nav-item">
-                  <a class="nav-link" href="./support">Support</a>
+                  <a class="nav-link" href="/support">Support</a>
                 </li>
                 <li class="nav-item">
                   <a class="nav-link" href="https://play.openpolicyagent.org/">Playground</a>
@@ -96,7 +96,7 @@
             <div class="card" onclick="window.open('https://registration.styra.com/openpolicyagentsupport')">
               <div class="card-body">
                 <div class="support-card-content d-flex flex-row align-items-center flex-wrap-sm">
-                  <img class="card-img align-middle" src="../img/logos/styra-logo.png"/>
+                  <img class="card-img align-middle" src="/img/logos/styra-logo.png" alt="Styra logo">
                   <div class="card-text">
                     <span class="align-middle">Styra is the original creator of Open Policy
                       Agent and provides support, professional services, training, and
@@ -110,8 +110,8 @@
         </section>
       </div>
 
-      <div class="bg"><img src="./img/homebg.png"></div>
-      <div class="cloud-top"><img src="./img/cloudAll.png"></div>
+      <div class="bg"><img src="/img/homebg.png" alt="Home background"></div>
+      <div class="cloud-top"><img src="/img/cloudAll.png" alt="Cloud background"></div>
 
     </div>
 


### PR DESCRIPTION
This PR adds a link checker for the website. It can be run using `make check-links`. It assumes that the website has already been built, checks only internal links, and has *not* yet been added to the CI pipeline (it's currently intended only to be run locally).

The PR also includes some link fixes in `/docs/latest` and adds some missing image `alt`s.