### PR TITLE
cmd/run: explain how to set input

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -91,6 +91,10 @@ destination in the data document with the following syntax:
 
 	<dotted-path>:<file-path>
 
+When working with rules that operate on input, you can set repl.input like so:
+
+	repl.input:/path/to/data.json
+
 File paths can be specified as URLs to resolve ambiguity in paths containing colons:
 
 	$ opa run file:///c:/path/to/data.json


### PR DESCRIPTION
I struggled with this for a while today until I stumbled across a brief
mention somewhere on the OPA website. I didn't see notes to set
repl.input anywhere else in "opa run --help" or in "help input" from the
REPL. Mentioning in the command help seemed more appropriate since "help
input" is contained in the repl package which may be used in other
contexts where the user doesn't have a way to provide repl.input.
