### PR TITLE
topdown: Add Host header support to http.send()

### DIFF
--- a/docs/content/policy-reference.md
+++ b/docs/content/policy-reference.md
@@ -574,6 +574,8 @@ The `request` object parameter may contain the following fields:
 | `timeout` | no | `string` or `number` | Timeout for the HTTP request with a default of 5 seconds (`5s`). Numbers provided are in nanoseconds. Strings must be a valid duration string where a duration string is a possibly signed sequence of decimal numbers, each with optional fraction and a unit suffix, such as "300ms", "-1.5h" or "2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h". A zero timeout means no timeout.|
 |`tls_insecure_skip_verify`| no | `bool` | Allows for skipping TLS verification when calling a network endpoint. Not recommended for production |
 
+If the `Host` header is included in `headers`, its value will be used as the `Host` header of the request. The `url` parameter will continue to specify the server to connect to.
+
 When sending HTTPS requests with client certificates at least one the following combinations must be included
 
  * ``tls_client_cert_file`` and ``tls_client_key_file``

--- a/topdown/http.go
+++ b/topdown/http.go
@@ -139,12 +139,22 @@ func addHeaders(req *http.Request, headers map[string]interface{}) (bool, error)
 	for k, v := range headers {
 		// Type assertion
 		header, ok := v.(string)
-		if ok {
+		if !ok {
+			return false, fmt.Errorf("invalid type for headers value %q", v)
+		}
+
+		// If the Host header is given, bump that up to
+		// the request. Otherwise, just collect it in the
+		// headers.
+		k := http.CanonicalHeaderKey(k)
+		switch k {
+		case "Host":
+			req.Host = header
+		default:
 			req.Header.Add(k, header)
-		} else {
-			return false, fmt.Errorf("invalid type for headers value")
 		}
 	}
+
 	return true, nil
 }
 


### PR DESCRIPTION
If the headers map given to `http.send` includes the `Host` header, hoist
it up to the request. This lets users specify the server to connect to
and the `Host` header to send independently, much like curl.

Signed-off-by: James Peach <jpeach@vmware.com>