### PR TITLE
Bump xxhash to workaround checkptr errors with Go 1.14

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/open-policy-agent/opa
 go 1.12
 
 require (
-	github.com/OneOfOne/xxhash v1.2.3
+	github.com/OneOfOne/xxhash v1.2.7
 	github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 // indirect
 	github.com/cespare/xxhash v1.1.0 // indirect
 	github.com/fsnotify/fsnotify v1.4.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/OneOfOne/xxhash v1.2.3 h1:wS8NNaIgtzapuArKIAjsyXtEN/IUjQkbw90xszUdS40=
 github.com/OneOfOne/xxhash v1.2.3/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
+github.com/OneOfOne/xxhash v1.2.7 h1:fzrmmkskv067ZQbd9wERNGuxckWw67dyzoMG62p7LMo=
+github.com/OneOfOne/xxhash v1.2.7/go.mod h1:eZbhyaAYD41SGSSsnmcpxVoRiQ/MPUTjUdIIOT9Um7Q=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLMYoU8P317H5OQ+Via4RmuPwCS0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=

--- a/vendor/github.com/OneOfOne/xxhash/.travis.yml
+++ b/vendor/github.com/OneOfOne/xxhash/.travis.yml
@@ -2,11 +2,12 @@ language: go
 sudo: false
 
 go:
-  - 1.8
-  - 1.9
   - "1.10"
+  - "1.11"
+  - "1.12"
   - master
 
 script:
   - go test -tags safe ./...
   - go test ./...
+  -

--- a/vendor/github.com/OneOfOne/xxhash/go.mod
+++ b/vendor/github.com/OneOfOne/xxhash/go.mod
@@ -1,1 +1,3 @@
 module github.com/OneOfOne/xxhash
+
+go 1.11

--- a/vendor/github.com/OneOfOne/xxhash/xxhash.go
+++ b/vendor/github.com/OneOfOne/xxhash/xxhash.go
@@ -1,5 +1,7 @@
 package xxhash
 
+import "hash"
+
 const (
 	prime32x1 uint32 = 2654435761
 	prime32x2 uint32 = 2246822519
@@ -21,6 +23,9 @@ const (
 	zero64x3 = 0x0
 	zero64x4 = 0x61c8864e7a143579
 )
+
+func NewHash32() hash.Hash { return New32() }
+func NewHash64() hash.Hash { return New64() }
 
 // Checksum32 returns the checksum of the input data with the seed set to 0.
 func Checksum32(in []byte) uint32 {

--- a/vendor/github.com/OneOfOne/xxhash/xxhash_safe.go
+++ b/vendor/github.com/OneOfOne/xxhash/xxhash_safe.go
@@ -1,4 +1,4 @@
-// +build appengine safe ppc64le ppc64be mipsle mips
+// +build appengine safe ppc64le ppc64be mipsle mips s390x
 
 package xxhash
 

--- a/vendor/github.com/OneOfOne/xxhash/xxhash_unsafe.go
+++ b/vendor/github.com/OneOfOne/xxhash/xxhash_unsafe.go
@@ -4,6 +4,7 @@
 // +build !mipsle
 // +build !ppc64be
 // +build !mips
+// +build !s390x
 
 package xxhash
 
@@ -48,9 +49,10 @@ func (xx *XXHash64) WriteString(s string) (int, error) {
 		return 0, nil
 	}
 	ss := (*reflect.StringHeader)(unsafe.Pointer(&s))
-	return xx.Write((*[maxInt32]byte)(unsafe.Pointer(ss.Data))[:len(s)])
+	return xx.Write((*[maxInt32]byte)(unsafe.Pointer(ss.Data))[:len(s):len(s)])
 }
 
+//go:nocheckptr
 func checksum64(in []byte, seed uint64) uint64 {
 	var (
 		wordsLen = len(in) >> 3
@@ -102,6 +104,7 @@ func checksum64(in []byte, seed uint64) uint64 {
 	return mix64(h)
 }
 
+//go:nocheckptr
 func checksum64Short(in []byte, seed uint64) uint64 {
 	var (
 		h = seed + prime64x5 + uint64(len(in))

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/OneOfOne/xxhash v1.2.3
+# github.com/OneOfOne/xxhash v1.2.7
 github.com/OneOfOne/xxhash
 # github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973
 github.com/beorn7/perks/quantile


### PR DESCRIPTION
In Go 1.14 a 'checkptr' test was added to the -race build option to check for correct usage of unsafe.Pointer. Version 1.3.2 of OneOfOne/xxhash fails these checks causing OPA to fail these checks.

Version 1.3.6 of xxhash fixes these issues.

Tested with our previously failing code with OPA _replaced_ with these changes and runs as expected in Go 1.14.

Signed-off-by: Dan Dooley <dan@dooley.ac.nz>
