### PR TITLE
Use 308 redirect instead of 301

### DIFF
--- a/server/server_test.go
+++ b/server/server_test.go
@@ -782,7 +782,7 @@ func TestCompileV1UnsafeBuiltin(t *testing.T) {
 func TestDataV1Redirection(t *testing.T) {
 	f := newFixture(t)
 	// Testing redirect at the root level
-	if err := f.v1(http.MethodPut, "/data/", `{"foo": [1,2,3]}`, 301, ""); err != nil {
+	if err := f.v1(http.MethodPut, "/data/", `{"foo": [1,2,3]}`, 308, ""); err != nil {
 		t.Fatalf("Unexpected error from PUT: %v", err)
 	}
 	locHdr := f.recorder.Header().Get("Location")
@@ -797,7 +797,7 @@ func TestDataV1Redirection(t *testing.T) {
 		t.Fatalf("Unexpected error from GET: %v", err)
 	}
 	// Now we test redirection a few levels down
-	if err := f.v1(http.MethodPut, "/data/a/b/c/", `{"foo": [1,2,3]}`, 301, ""); err != nil {
+	if err := f.v1(http.MethodPut, "/data/a/b/c/", `{"foo": [1,2,3]}`, 308, ""); err != nil {
 		t.Fatalf("Unexpected error from PUT: %v", err)
 	}
 	locHdrLv := f.recorder.Header().Get("Location")

--- a/vendor/github.com/gorilla/mux/regexp.go
+++ b/vendor/github.com/gorilla/mux/regexp.go
@@ -296,7 +296,7 @@ func (v *routeRegexpGroup) setMatch(req *http.Request, m *RouteMatch, r *Route) 
 					} else {
 						u.Path += "/"
 					}
-					m.Handler = http.RedirectHandler(u.String(), http.StatusMovedPermanently)
+					m.Handler = http.RedirectHandler(u.String(), http.StatusPermanentRedirect)
 				}
 			}
 		}


### PR DESCRIPTION
Some clients - browsers and postman especially - do not retain the HTTP Method when provided with a 301 or 302 redirect. This can get tricky when a user uses POST /v1/data and is redirected to /v1/data/. In response to this, https://tools.ietf.org/html/rfc7538 declares the 307 and 308 redirect status codes, which require that the http method and body be replayed exactly, but with the new "Location:"

Closes #2137

Signed-off-by: Michael Krotscheck <krotscheck@gmail.com>