### PR TITLE
ast: Fix type check for objects with non-json keys

### DIFF
--- a/ast/check_test.go
+++ b/ast/check_test.go
@@ -99,6 +99,18 @@ func TestCheckInference(t *testing.T) {
 			Var("x"): types.NewObject([]*types.StaticProperty{{Key: json.Number("1"), Value: types.N}}, nil),
 			Var("y"): types.N,
 		}},
+		{"object-object-key", `x = {{{}: 1}: 1}`, map[Var]types.Type{
+			Var("x"): types.NewObject(
+				nil,
+				types.NewDynamicProperty(
+					types.NewObject(
+						[]*types.StaticProperty{types.NewStaticProperty(map[string]interface{}{}, types.N)},
+						nil,
+					),
+					types.N,
+				),
+			),
+		}},
 		{"sets", `x = {1, 2}; y = {{"foo", 1}, x}`, map[Var]types.Type{
 			Var("x"): types.NewSet(types.N),
 			Var("y"): types.NewSet(

--- a/ast/env.go
+++ b/ast/env.go
@@ -63,16 +63,16 @@ func (env *TypeEnv) Get(x interface{}) types.Type {
 		x.Foreach(func(k, v *Term) {
 			if IsConstant(k.Value) {
 				kjson, err := JSON(k.Value)
-				if err != nil {
-					panic("unreachable")
+				if err == nil {
+					tpe := env.Get(v)
+					static = append(static, types.NewStaticProperty(kjson, tpe))
+					return
 				}
-				tpe := env.Get(v)
-				static = append(static, types.NewStaticProperty(kjson, tpe))
-			} else {
-				typeK := env.Get(k.Value)
-				typeV := env.Get(v.Value)
-				dynamic = types.NewDynamicProperty(typeK, typeV)
 			}
+			// Can't handle it as a static property, fallback to dynamic
+			typeK := env.Get(k.Value)
+			typeV := env.Get(v.Value)
+			dynamic = types.NewDynamicProperty(typeK, typeV)
 		})
 
 		if len(static) == 0 && dynamic == nil {


### PR DESCRIPTION
Previously if there was a non-json key it would `panic("unreachable")`
but it can fall back to using the dynamic property for these types.

Fixes: #2183
Signed-off-by: Patrick East <east.patrick@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
