### PR TITLE
ast: Rewrite rule arguments

### DIFF
--- a/ast/check_test.go
+++ b/ast/check_test.go
@@ -958,7 +958,7 @@ func TestFunctionTypeInferenceUnappliedWithObjectVarKey(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Check inferrred type for reference to function.
+	// Check inferred type for reference to function.
 	tpe := env.Get(MustParseRef("data.test.f"))
 	exp := types.NewFunction([]types.Type{types.A}, types.NewObject(nil, types.NewDynamicProperty(types.A, types.N)))
 

--- a/ast/compile.go
+++ b/ast/compile.go
@@ -2074,7 +2074,7 @@ func outputVarsForExpr(expr *Expr, builtins map[string]*Builtin, arity func(Ref)
 		return outputVarsForExprBuiltin(expr, b, safe)
 	}
 
-	return outputVarsForExprCall(expr, builtins, arity, safe, terms)
+	return outputVarsForExprCall(expr, arity, safe, terms)
 }
 
 func outputVarsForExprBuiltin(expr *Expr, b *Builtin, safe VarSet) VarSet {
@@ -2127,7 +2127,7 @@ func outputVarsForExprEq(expr *Expr, safe VarSet) VarSet {
 	return output.Diff(safe)
 }
 
-func outputVarsForExprCall(expr *Expr, builtins map[string]*Builtin, arity func(Ref) int, safe VarSet, terms []*Term) VarSet {
+func outputVarsForExprCall(expr *Expr, arity func(Ref) int, safe VarSet, terms []*Term) VarSet {
 
 	output := outputVarsForExprRefs(expr, safe)
 

--- a/ast/compile.go
+++ b/ast/compile.go
@@ -1207,8 +1207,11 @@ func (vis *ruleArgLocalRewriter) Visit(x interface{}) Visitor {
 		// Scalars are no-ops. Comprehensions are handled above. Sets must not
 		// contain variables.
 		return nil
+	case Call:
+		vis.errs = append(vis.errs, NewError(CompileErr, t.Location, "rule arguments cannot contain calls"))
+		return nil
 	default:
-		// Recurse on refs, arrays, and calls. Any embedded
+		// Recurse on refs and arrays. Any embedded
 		// variables can be rewritten.
 		return vis
 	}

--- a/ast/env.go
+++ b/ast/env.go
@@ -129,6 +129,10 @@ func (env *TypeEnv) Get(x interface{}) types.Type {
 		}
 		return nil
 
+	// Calls.
+	case Call:
+		return nil
+
 	default:
 		panic("unreachable")
 	}


### PR DESCRIPTION
We now will rewrite any calls found in rule heads (specifically in
arguments).

The PR also includes a couple of small fixes for things I noticed while looking around in these files fixing the issue.

Fixes: #2081