### PR TITLE
docs: Fix code fence in kubernetes-primer.md

### DIFF
--- a/docs/content/kubernetes-primer.md
+++ b/docs/content/kubernetes-primer.md
@@ -83,6 +83,7 @@ The admission review request to sent to OPA would look like this:
 When the `deny` rule is evaluated with the input above, the answer is:
 
 ```live:container_images:query:hidden
+```
 
 ```live:container_images:output
 ```


### PR DESCRIPTION
This PR adds a backtick to the live code block to fix
formatting issues in the documentation. This addresses the
examples in the `/docs/kubernetes-primer.md` document. The current
document/site does not render the live code block.

Signed-off-by: Rachel Leekin <rleekin@vmware.com>

Fixes #2177

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
