### PR TITLE
docs: Force netlify redirects

### DIFF
--- a/docs/website/layouts/index.redirects
+++ b/docs/website/layouts/index.redirects
@@ -3,27 +3,27 @@
 {{- $docRedirects := site.Data.redirects }}
 
 # Redirect to latest doc version by default
-/docs     /docs/latest
+/docs     /docs/latest      301!
 
 # v0.14.0 re-org redirects
 # TODO: Remove at some point in the future when its more ok to break old links en-mass
-/docs/latest/get-started                            /docs/latest/
-/docs/latest/how-does-opa-work/                     /docs/latest/#how-does-opa-work
-/docs/latest/how-do-i-write-policies/               /docs/latest/policy-language/
-/docs/latest/how-do-i-test-policies/                /docs/latest/policy-testing/
-/docs/latest/language-reference/                    /docs/latest/policy-reference/
-/docs/latest/language-cheatsheet/                   /docs/latest/edge/policy-cheatsheet/
-/docs/latest/bundles/                               /docs/latest/management/#bundles
-/docs/latest/status/                                /docs/latest/management/#status
-/docs/latest/decision-logs/                         /docs/latest/management/#decision-logs
-/docs/latest/discovery/                             /docs/latest/management/#discovery
-/docs/latest/kubernetes-admission-control/          /docs/latest/kubernetes-tutorial/
+/docs/latest/get-started                            /docs/latest/                           301!
+/docs/latest/how-does-opa-work/                     /docs/latest/#how-does-opa-work         301!
+/docs/latest/how-do-i-write-policies/               /docs/latest/policy-language/           301!
+/docs/latest/how-do-i-test-policies/                /docs/latest/policy-testing/            301!
+/docs/latest/language-reference/                    /docs/latest/policy-reference/          301!
+/docs/latest/language-cheatsheet/                   /docs/latest/edge/policy-cheatsheet/    301!
+/docs/latest/bundles/                               /docs/latest/management/#bundles        301!
+/docs/latest/status/                                /docs/latest/management/#status         301!
+/docs/latest/decision-logs/                         /docs/latest/management/#decision-logs  301!
+/docs/latest/discovery/                             /docs/latest/management/#discovery      301!
+/docs/latest/kubernetes-admission-control/          /docs/latest/kubernetes-tutorial/       301!
 
 {{- range $docRedirects }}
-/docs/{{ . }}     /docs/latest/{{ . }}
+/docs/{{ . }}     /docs/latest/{{ . }}      301!
 
 # Legacy git book redirects
-/docs/{{ . }}.html /docs/latest/{{ . }}
+/docs/{{ . }}.html /docs/latest/{{ . }}     301!
 {{- end }}
 
 # Download URLs


### PR DESCRIPTION
Coming in the next few weeks the old redirects defined in `_redirects`
will not behave the same. To keep them working the same as before we
need to tell Netlify to force them (rather than looking for shadowed
pages). By specifying the return code and adding a `!` we achieve the
original behavior.

Signed-off-by: Patrick East <east.patrick@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
