### PR TITLE
docs(homepage): remove link

### DIFF
--- a/docs/website/layouts/index.html
+++ b/docs/website/layouts/index.html
@@ -121,18 +121,6 @@
               love) without sacrificing availability or performance.
             </p>
           </div>
-          <div class="mt-5 text-center blue">
-            <button class="btn btn-primary"><a><span>Learn More:</span></a> <a
-                      href="./docs/latest/kubernetes-introduction/">Kubernetes</a>
-              - <a
-                      href="./docs/latest/envoy-authorization/">Envoy</a> - <a
-                      href="./docs/latest/terraform/">Terraform</a> - <a
-                      href="./docs/latest/kafka-authorization/">Kafka</a>
-              -
-              <a href="https://blog.openpolicyagent.org/write-policy-in-opa-enforce-policy-in-sql-d9d24db93bf4">SQL</a>
-              - <a href="./docs/latest/ssh-and-sudo-authorization/">Linux</a>
-            </button>
-          </div>
           <div class="mt-5 text-center">
             <div class="styraText">
               <p>Created By</p><span> <a href="https://styra.com"><img


### PR DESCRIPTION
This patch set removes the first, possibly duplicate, set of the "Learn More"
link as outlined in issue #2208.

Closes: #2208

Signed-off-by: Tin Lam <tin@irrational.io>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
