### PR TITLE
topdown: Add http.send support for setting the TLS server name

### DIFF
--- a/docs/content/policy-reference.md
+++ b/docs/content/policy-reference.md
@@ -572,7 +572,8 @@ The `request` object parameter may contain the following fields:
 | `tls_client_cert_file` | no | `string` | Path to file containing a client certificate in PEM encoded format. |
 | `tls_client_key_file` | no | `string` | Path to file containing a key  in PEM encoded format. |
 | `timeout` | no | `string` or `number` | Timeout for the HTTP request with a default of 5 seconds (`5s`). Numbers provided are in nanoseconds. Strings must be a valid duration string where a duration string is a possibly signed sequence of decimal numbers, each with optional fraction and a unit suffix, such as "300ms", "-1.5h" or "2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h". A zero timeout means no timeout.|
-| `tls_insecure_skip_verify` | no | `bool` | Allows for skipping TLS verification when calling a network endpoint. Not recommended for production |
+| `tls_insecure_skip_verify` | no | `bool` | Allows for skipping TLS verification when calling a network endpoint. Not recommended for production. |
+| `tls_server_name` | no | `string` | Sets the hostname that is sent in the client Server Name Indication and that be will be used for server certificate validation. If this is not set, the value of the `Host` header (if present) will be used. If neither are set, the host name from the requested URL is used. |
 
 If the `Host` header is included in `headers`, its value will be used as the `Host` header of the request. The `url` parameter will continue to specify the server to connect to.
 


### PR DESCRIPTION
If the caller sets the Host header, then we can reasonably impute that
they wanted to use that at the TLS layer as well. To handle test cases
where the caller needs to explicitly set the TLS server name, add a
`tls_server_name` parameter that overrides both the `Host` header and
the Go default.

Signed-off-by: James Peach <jpeach@vmware.com>
