### PR TITLE
ast: Add rules/functions that contain errors to the type env

### DIFF
--- a/ast/check.go
+++ b/ast/check.go
@@ -48,6 +48,8 @@ func (tc *typeChecker) WithVarRewriter(f rewriteVars) *typeChecker {
 // TypeEnv will be able to resolve types of vars contained in the body.
 func (tc *typeChecker) CheckBody(env *TypeEnv, body Body) (*TypeEnv, Errors) {
 
+	errors := []*Error{}
+
 	if env == nil {
 		env = NewTypeEnv()
 	} else {
@@ -58,7 +60,7 @@ func (tc *typeChecker) CheckBody(env *TypeEnv, body Body) (*TypeEnv, Errors) {
 
 		closureErrs := tc.checkClosures(env, expr)
 		for _, err := range closureErrs {
-			tc.err(err)
+			errors = append(errors, err)
 		}
 
 		hasClosureErrors := len(closureErrs) > 0
@@ -66,7 +68,7 @@ func (tc *typeChecker) CheckBody(env *TypeEnv, body Body) (*TypeEnv, Errors) {
 		vis := newRefChecker(env, tc.varRewriter)
 		NewGenericVisitor(vis.Visit).Walk(expr)
 		for _, err := range vis.errs {
-			tc.err(err)
+			errors = append(errors, err)
 		}
 
 		hasRefErrors := len(vis.errs) > 0
@@ -78,14 +80,14 @@ func (tc *typeChecker) CheckBody(env *TypeEnv, body Body) (*TypeEnv, Errors) {
 			// likely to be the result of the more specific error.
 			skip := (hasClosureErrors || hasRefErrors) && causedByNilType(err)
 			if !skip {
-				tc.err(err)
+				errors = append(errors, err)
 			}
 		}
-
 		return true
 	})
 
-	return env, tc.errs
+	tc.err(errors)
+	return env, errors
 }
 
 // CheckTypes runs type checking on the rules returns a TypeEnv if no errors
@@ -205,6 +207,11 @@ func (tc *typeChecker) checkRule(env *TypeEnv, rule *Rule) {
 		if tpe != nil {
 			env.tree.Put(path, tpe)
 		}
+	} else {
+		// if the rule/function contains an error, add it to the type env
+		// so that expressions that refer to this rule/function
+		// do not encounter type errors
+		env.tree.Put(rule.Path(), types.A)
 	}
 }
 
@@ -239,6 +246,12 @@ func (tc *typeChecker) checkExprBuiltin(env *TypeEnv, expr *Expr) *Error {
 
 	if tpe == nil {
 		return NewError(TypeErr, expr.Location, "undefined function %v", name)
+	}
+
+	// check if the expression refers to a function that contains an error
+	_, ok := tpe.(types.Any)
+	if ok {
+		return nil
 	}
 
 	ftpe, ok := tpe.(*types.Function)
@@ -489,8 +502,8 @@ func unify1Set(env *TypeEnv, val Set, tpe *types.Set, union bool) bool {
 	})
 }
 
-func (tc *typeChecker) err(err *Error) {
-	tc.errs = append(tc.errs, err)
+func (tc *typeChecker) err(errors []*Error) {
+	tc.errs = append(tc.errs, errors...)
 }
 
 type refChecker struct {


### PR DESCRIPTION
Earlier if a rule/function contained an error, the type checker would not update the env with subsequent independent rules resulting in errors such as "undefined functions". This change add erroneous rules/functions to the env to avoid such type errors.

Fixes #2155

Fixes #2091

Signed-off-by: Ashutosh Narkar <anarkar4387@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
