### PR TITLE
ast: Fix for `with` node locations

### DIFF
--- a/ast/parser.go
+++ b/ast/parser.go
@@ -572,10 +572,9 @@ func (p *Parser) parseWith() []*With {
 
 	for {
 
-		// NOTE(tsandall): location is not being set correctly on with
-		// statements. need special test case for this.
-
-		var with With
+		with := With{
+			Location: p.s.Loc(),
+		}
 		p.scan()
 
 		if p.s.tok != tokens.Ident {
@@ -604,6 +603,8 @@ func (p *Parser) parseWith() []*With {
 		if with.Value = p.parseTermRelation(); with.Value == nil {
 			return nil
 		}
+
+		with.Location.Text = p.s.Text(with.Location.Offset, p.s.lastEnd)
 
 		withs = append(withs, &with)
 

--- a/format/testfiles/test.rego
+++ b/format/testfiles/test.rego
@@ -195,6 +195,18 @@ declare1 := 1
 
 declare2 := 2 { false }
 
+multi_line_with {
+    fn(1) with input.a as "a"
+                with input.b as "b"
+            with input.c as {
+                "foo": "bar",
+            }
+                with input.d as [
+                    1,
+                    2,
+                    3]
+}
+
 # more comments!
 # more comments!
 # more comments!

--- a/format/testfiles/test.rego.formatted
+++ b/format/testfiles/test.rego.formatted
@@ -230,6 +230,17 @@ declare2 := 2 {
 	false
 }
 
+multi_line_with {
+	fn(1) with input.a as "a"
+		 with input.b as "b"
+		 with input.c as {"foo": "bar"}
+		 with input.d as [
+			1,
+			2,
+			3,
+		]
+}
+
 # more comments!
 # more comments!
 # more comments!


### PR DESCRIPTION
We were not setting locations on `with` expressions. This adds in
support for doing so.

Signed-off-by: Patrick East <east.patrick@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
