### PR TITLE
Add Emacs mode for rego language

### DIFF
--- a/docs/content/editor-and-ide-support.md
+++ b/docs/content/editor-and-ide-support.md
@@ -14,6 +14,7 @@ evaluation, policy coverage, and more.
 | Editor | Link |
 | --- | --- |
 | Atom | [https://github.com/open-policy-agent/opa/tree/master/misc/syntax/atom](https://github.com/open-policy-agent/opa/tree/master/misc/syntax/atom) |
+| Emacs | [https://github.com/psibi/rego-mode](https://github.com/psibi/rego-mode) |
 | Sublime Text | [https://github.com/open-policy-agent/opa/tree/master/misc/syntax/sublime](https://github.com/open-policy-agent/opa/tree/master/misc/syntax/sublime) |
 | TextMate | [https://github.com/open-policy-agent/opa/tree/master/misc/syntax/textmate](https://github.com/open-policy-agent/opa/tree/master/misc/syntax/textmate) |
 | Vim | [https://github.com/tsandall/vim-rego](https://github.com/tsandall/vim-rego) |


### PR DESCRIPTION
Add Emacs major mode in the editor integration documentation

Signed-off-by: Sibi Prabakaran sibi@psibi.in 
