### PR TITLE
namespace value not specified at creation of Secret so it causes an error for the "Kubernetes Tutorial"documentation

### DIFF
--- a/docs/content/kubernetes-tutorial.md
+++ b/docs/content/kubernetes-tutorial.md
@@ -94,7 +94,7 @@ openssl x509 -req -in server.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out s
 Create a Secret to store the TLS credentials for OPA:
 
 ```bash
-kubectl create secret tls opa-server --cert=server.crt --key=server.key
+kubectl create secret tls opa-server --cert=server.crt --key=server.key --namespace opa
 ```
 
 Next, use the file below to deploy OPA as an admission controller.


### PR DESCRIPTION
in "Kubernetes Tutorial" page at line 97 , you must specify a namespace for secret otherwise it causes an error like following screenshot : <br/>
![Screen Shot 2020-03-29 at 14 20 38](https://user-images.githubusercontent.com/16693043/77847907-32086e80-71c9-11ea-949c-bb8d72e5d9c8.png)

