### PR TITLE
Use unique query paths and module id's for partial eval in the server

### DIFF
--- a/rego/rego.go
+++ b/rego/rego.go
@@ -1645,9 +1645,10 @@ func (r *Rego) partialResult(ctx context.Context, pCfg *PrepareConfig) (PartialR
 	}
 
 	// Update compiler with partial evaluation output.
-	r.compiler.Modules["__partialresult__"] = module
+	id := fmt.Sprintf("__partialresult__%s__", ectx.partialNamespace)
+	r.compiler.Modules[id] = module
 	for i, module := range pq.Support {
-		r.compiler.Modules[fmt.Sprintf("__partialsupport%d__", i)] = module
+		r.compiler.Modules[fmt.Sprintf("__partialsupport__%s__%d__", ectx.partialNamespace, i)] = module
 	}
 
 	r.metrics.Timer(metrics.RegoModuleCompile).Start()

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1066,6 +1066,12 @@ p = true { false }`
 			{http.MethodPost, "/data/testmod/p", `{"input": {"x": 1, "y": 2, "z": 9999}}`, 200, `{"result": true}`},
 			{http.MethodPost, "/data/testmod/p", `{"input": {"x": 1, "z": 3}}`, 200, `{"result": false}`},
 		}},
+		{"post partial idempotent", []tr{
+			{http.MethodPut, "/policies/test", testMod7, 200, ""},
+			{http.MethodPost, "/data/testmod/p?partial", `{"input": {"x": 1, "y": 2, "z": 9999}}`, 200, `{"result": true}`},
+			{http.MethodPost, "/data/testmod/q?partial", `{"input": {"x": 1, "z": 3}}`, 200, `{"result": [1]}`},
+			{http.MethodPost, "/data/testmod/p?partial", `{"input": {"x": 1, "y": 2, "z": 9999}}`, 200, `{"result": true}`},
+		}},
 		{"partial invalidate policy", []tr{
 			{http.MethodPut, "/policies/test", testMod7, 200, ""},
 			{http.MethodPost, "/data/testmod/p?partial", `{"input": {"x": 1, "y": 2, "z": 3}}`, 200, `{"result": true}`},


### PR DESCRIPTION
This is a combination of two changes to fix #2247 

First up we change the way that `rego.Rego` objects generate the partial result modules on the compiler. We will name them with more dynamic module id's so that >1 query can be partially evaluated sharing the same compiler.

Next we adjust the OPA server to specify a namespace when doing partial evaluation so that cached results have unique query paths.
