### PR TITLE
cmd/fmt: Always write to stdout

### DIFF
--- a/cmd/fmt.go
+++ b/cmd/fmt.go
@@ -106,10 +106,6 @@ func formatFile(filename string, info os.FileInfo, err error) error {
 		return newError("failed to parse Rego source file: %v", err)
 	}
 
-	if bytes.Equal(formatted, contents) {
-		return nil
-	}
-
 	var out io.Writer = os.Stdout
 	if fmtParams.list {
 		fmt.Fprintln(out, filename)
@@ -158,15 +154,15 @@ func formatStdin(r io.Reader, w io.Writer) error {
 		return err
 	}
 
-	if !bytes.Equal(formatted, contents) {
-		_, err := w.Write(formatted)
-		return err
-	}
-
-	return nil
+	_, err = w.Write(formatted)
+	return err
 }
 
 func doDiff(old, new []byte) (stdout, stderr bytes.Buffer, err error) {
+	if bytes.Equal(old, new) {
+		return stdout, stderr, nil
+	}
+
 	o, err := ioutil.TempFile("", ".opafmt")
 	if err != nil {
 		return stdout, stderr, err


### PR DESCRIPTION
There was an explicit check that would prevent writing to stdout if
the formatting didn't change anything.

This makes sense for the "write to file" or "diff" options as we can
save work by bailing out early, but if configured to write the file
contents to stdout we should do so in all cases.

Fixes: #2235
Signed-off-by: Patrick East <east.patrick@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
