### PR TITLE
topdown: Improve pretty trace location details

### DIFF
--- a/internal/lcss/README.md
+++ b/internal/lcss/README.md
@@ -1,0 +1,3 @@
+# Longest Common Substring
+
+Original source https://github.com/vmarkovtsev/go-lcss

--- a/internal/lcss/lcss.go
+++ b/internal/lcss/lcss.go
@@ -1,0 +1,197 @@
+package lcss
+
+import "bytes"
+
+// LongestCommonSubstring returns the longest substring which is present in all the given strings.
+// https://en.wikipedia.org/wiki/Longest_common_substring_problem
+// Not to be confused with the Longest Common Subsequence.
+// Complexity:
+// * time: sum of `n_i*log(n_i)` where `n_i` is the length of each string.
+// * space: sum of `n_i`.
+// Returns a byte slice which is never a nil.
+//
+// ### Algorithm.
+// We build suffix arrays for each of the passed string and then follow the same procedure
+// as in merge sort: pick the least suffix in the lexicographical order. It is possible
+// because the suffix arrays are already sorted.
+// We record the last encountered suffixes from each of the strings and measure the longest
+// common prefix of those at each "merge sort" step.
+// The string comparisons are optimized by maintaining the char-level prefix tree of the "heads"
+// of the suffix array sequences.
+func LongestCommonSubstring(strs ...[]byte) []byte {
+	strslen := len(strs)
+	if strslen == 0 {
+		return []byte{}
+	}
+	if strslen == 1 {
+		return strs[0]
+	}
+	suffixes := make([][]int, strslen)
+	for i, str := range strs {
+		suffixes[i] = qsufsort(str)
+	}
+	return lcss(strs, suffixes)
+}
+
+func lcss(strs [][]byte, suffixes [][]int) []byte {
+	strslen := len(strs)
+	if strslen == 0 {
+		return []byte{}
+	}
+	if strslen == 1 {
+		return strs[0]
+	}
+	minstrlen := len(strs[0]) // minimum length of the strings
+	for _, str := range strs {
+		if minstrlen > len(str) {
+			minstrlen = len(str)
+		}
+	}
+	heads := make([]int, strslen)          // position in each suffix array
+	boilerplate := make([][]byte, strslen) // existing suffixes in the tree
+	boiling := 0                           // indicates how many distinct suffix arrays are presented in `boilerplate`
+	var root charNode                      // the character tree built on the strings from `boilerplate`
+	lcs := []byte{}                        // our function's return value, `var lcss []byte` does *not* work
+	for {
+		mini := -1
+		var minSuffixStr []byte
+		for i, head := range heads {
+			if head >= len(suffixes[i]) {
+				// this suffix array has been scanned till the end
+				continue
+			}
+			suffix := strs[i][suffixes[i][head]:]
+			if minSuffixStr == nil {
+				// initialize
+				mini = i
+				minSuffixStr = suffix
+			} else if bytes.Compare(minSuffixStr, suffix) > 0 {
+				// the current suffix is the smallest in the lexicographical order
+				mini = i
+				minSuffixStr = suffix
+			}
+		}
+		if mini == -1 {
+			// all heads exhausted
+			break
+		}
+		if boilerplate[mini] != nil {
+			// if we already have a suffix from this string, replace it with the new one
+			root.Remove(boilerplate[mini])
+		} else {
+			// we track the number of distinct strings which have been touched
+			// when `boiling` becomes strslen we can start measuring the longest common prefix
+			boiling++
+		}
+		boilerplate[mini] = minSuffixStr
+		root.Add(minSuffixStr)
+		heads[mini]++
+		if boiling == strslen && root.LongestCommonPrefixLength() > len(lcs) {
+			// all heads > 0, the current common prefix of the suffixes is the longest
+			lcs = root.LongestCommonPrefix()
+			if len(lcs) == minstrlen {
+				// early exit - we will never find a longer substring
+				break
+			}
+		}
+	}
+	return lcs
+}
+
+// charNode builds a tree of individual characters.
+// `used` is the counter for collecting garbage: those nodes which have `used`=0 are removed.
+// The root charNode always remains intact apart from `children`.
+// The tree supports 4 operations:
+// 1. Add() a new string.
+// 2. Remove() an existing string which was previously Add()-ed.
+// 3. LongestCommonPrefixLength().
+// 4. LongestCommonPrefix().
+type charNode struct {
+	char     byte
+	children []charNode
+	used     int
+}
+
+// Add includes a new string into the tree. We start from the root and
+// increment `used` of all the nodes we visit.
+func (cn *charNode) Add(str []byte) {
+	head := cn
+	for i, char := range str {
+		found := false
+		for j, child := range head.children {
+			if child.char == char {
+				head.children[j].used++
+				head = &head.children[j] // -> child
+				found = true
+				break
+			}
+		}
+		if !found {
+			// add the missing nodes one by one
+			for _, char = range str[i:] {
+				head.children = append(head.children, charNode{char: char, children: nil, used: 1})
+				head = &head.children[len(head.children)-1]
+			}
+			break
+		}
+	}
+}
+
+// Remove excludes a node which was previously Add()-ed.
+// We start from the root and decrement `used` of all the nodes we visit.
+// If there is a node with `used`=0, we erase it from the parent's list of children
+// and stop traversing the tree.
+func (cn *charNode) Remove(str []byte) {
+	stop := false
+	head := cn
+	for _, char := range str {
+		for j, child := range head.children {
+			if child.char != char {
+				continue
+			}
+			head.children[j].used--
+			var parent *charNode
+			head, parent = &head.children[j], head // shift to the child
+			if head.used == 0 {
+				parent.children = append(parent.children[:j], parent.children[j+1:]...)
+				// we can skip deleting the rest of the nodes - they have been already discarded
+				stop = true
+			}
+			break
+		}
+		if stop {
+			break
+		}
+	}
+}
+
+// LongestCommonPrefixLength returns the length of the longest common prefix of the strings
+// which are stored in the tree. We visit the children recursively starting from the root and
+// stop if `used` value decreases or there is more than one child.
+func (cn charNode) LongestCommonPrefixLength() int {
+	var result int
+	for head := cn; len(head.children) == 1 && head.children[0].used >= head.used; head = head.children[0] {
+
+		result++
+	}
+	return result
+}
+
+// LongestCommonPrefix returns the longest common prefix of the strings
+// which are stored in the tree. We compute the length by calling LongestCommonPrefixLength()
+// and then record the characters which we visit along the way from the root to the last node.
+func (cn charNode) LongestCommonPrefix() []byte {
+	result := make([]byte, cn.LongestCommonPrefixLength())
+	if len(result) == 0 {
+		return result
+	}
+	var i int
+	for head := cn.children[0]; ; head = head.children[0] {
+		result[i] = head.char
+		i++
+		if i == len(result) {
+			break
+		}
+	}
+	return result
+}

--- a/internal/lcss/lcss_test.go
+++ b/internal/lcss/lcss_test.go
@@ -1,0 +1,242 @@
+package lcss
+
+import (
+	"reflect"
+	"testing"
+)
+
+func assertEqual(t *testing.T, expected, actual interface{}) {
+	t.Helper()
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("Expected %v got %v", expected, actual)
+	}
+}
+
+func TestCharNodeAdd(t *testing.T) {
+	node := &charNode{}
+	node.Add([]byte("abc"))
+	assertEqual(t, byte(0), node.char)
+	assertEqual(t, 0, node.used)
+	assertEqual(t, 1, len(node.children))
+	assertEqual(t, byte('a'), node.children[0].char)
+	assertEqual(t, 1, node.children[0].used)
+	assertEqual(t, 1, len(node.children[0].children))
+	assertEqual(t, byte('b'), node.children[0].children[0].char)
+	assertEqual(t, 1, node.children[0].children[0].used)
+	assertEqual(t, 1, len(node.children[0].children[0].children))
+	assertEqual(t, byte('c'), node.children[0].children[0].children[0].char)
+	assertEqual(t, 1, node.children[0].children[0].children[0].used)
+	assertEqual(t, 0, len(node.children[0].children[0].children[0].children))
+	node.Add([]byte{})
+	assertEqual(t, byte(0), node.char)
+	assertEqual(t, 0, node.used)
+	assertEqual(t, 1, len(node.children))
+	node.Add([]byte("abd"))
+	assertEqual(t, byte(0), node.char)
+	assertEqual(t, 0, node.used)
+	assertEqual(t, 1, len(node.children))
+	assertEqual(t, byte('a'), node.children[0].char)
+	assertEqual(t, 2, node.children[0].used)
+	assertEqual(t, 1, len(node.children[0].children))
+	assertEqual(t, byte('b'), node.children[0].children[0].char)
+	assertEqual(t, 2, node.children[0].children[0].used)
+	assertEqual(t, 2, len(node.children[0].children[0].children))
+	assertEqual(t, byte('c'), node.children[0].children[0].children[0].char)
+	assertEqual(t, 1, node.children[0].children[0].children[0].used)
+	assertEqual(t, 0, len(node.children[0].children[0].children[0].children))
+	assertEqual(t, byte('d'), node.children[0].children[0].children[1].char)
+	assertEqual(t, 1, node.children[0].children[0].children[1].used)
+	assertEqual(t, 0, len(node.children[0].children[0].children[1].children))
+	node.Add([]byte("abc"))
+	assertEqual(t, byte(0), node.char)
+	assertEqual(t, 0, node.used)
+	assertEqual(t, 1, len(node.children))
+	assertEqual(t, byte('a'), node.children[0].char)
+	assertEqual(t, 3, node.children[0].used)
+	assertEqual(t, 1, len(node.children[0].children))
+	assertEqual(t, byte('b'), node.children[0].children[0].char)
+	assertEqual(t, 3, node.children[0].children[0].used)
+	assertEqual(t, 2, len(node.children[0].children[0].children))
+	assertEqual(t, byte('c'), node.children[0].children[0].children[0].char)
+	assertEqual(t, 2, node.children[0].children[0].children[0].used)
+	assertEqual(t, 0, len(node.children[0].children[0].children[0].children))
+	assertEqual(t, byte('d'), node.children[0].children[0].children[1].char)
+	assertEqual(t, 1, node.children[0].children[0].children[1].used)
+	assertEqual(t, 0, len(node.children[0].children[0].children[1].children))
+}
+
+func TestCharNodeRemove(t *testing.T) {
+	node := &charNode{}
+	node.Add([]byte("abc"))
+	node.Remove([]byte("abc"))
+	assertEqual(t, byte(0), node.char)
+	assertEqual(t, 0, node.used)
+	assertEqual(t, 0, len(node.children))
+	node.Add([]byte("abc"))
+	node.Add([]byte("abd"))
+	node.Remove([]byte("abc"))
+	assertEqual(t, byte(0), node.char)
+	assertEqual(t, 0, node.used)
+	assertEqual(t, 1, len(node.children))
+	assertEqual(t, byte('a'), node.children[0].char)
+	assertEqual(t, 1, node.children[0].used)
+	assertEqual(t, 1, len(node.children[0].children))
+	assertEqual(t, byte('b'), node.children[0].children[0].char)
+	assertEqual(t, 1, node.children[0].children[0].used)
+	assertEqual(t, 1, len(node.children[0].children[0].children))
+	assertEqual(t, byte('d'), node.children[0].children[0].children[0].char)
+	assertEqual(t, 1, node.children[0].children[0].children[0].used)
+	assertEqual(t, 0, len(node.children[0].children[0].children[0].children))
+	node.Remove([]byte{})
+	assertEqual(t, byte(0), node.char)
+	assertEqual(t, 0, node.used)
+	assertEqual(t, 1, len(node.children))
+	assertEqual(t, byte('a'), node.children[0].char)
+	assertEqual(t, 1, node.children[0].used)
+	assertEqual(t, 1, len(node.children[0].children))
+	assertEqual(t, byte('b'), node.children[0].children[0].char)
+	assertEqual(t, 1, node.children[0].children[0].used)
+	assertEqual(t, 1, len(node.children[0].children[0].children))
+	assertEqual(t, byte('d'), node.children[0].children[0].children[0].char)
+	assertEqual(t, 1, node.children[0].children[0].children[0].used)
+	assertEqual(t, 0, len(node.children[0].children[0].children[0].children))
+	node.Add([]byte("ab"))
+	node.Remove([]byte("ab"))
+	assertEqual(t, byte(0), node.char)
+	assertEqual(t, 0, node.used)
+	assertEqual(t, 1, len(node.children))
+	assertEqual(t, byte('a'), node.children[0].char)
+	assertEqual(t, 1, node.children[0].used)
+	assertEqual(t, 1, len(node.children[0].children))
+	assertEqual(t, byte('b'), node.children[0].children[0].char)
+	assertEqual(t, 1, node.children[0].children[0].used)
+	assertEqual(t, 1, len(node.children[0].children[0].children))
+	assertEqual(t, byte('d'), node.children[0].children[0].children[0].char)
+	assertEqual(t, 1, node.children[0].children[0].children[0].used)
+	assertEqual(t, 0, len(node.children[0].children[0].children[0].children))
+	node.Add([]byte("ab"))
+	node.Remove([]byte("abd"))
+	assertEqual(t, byte(0), node.char)
+	assertEqual(t, 0, node.used)
+	assertEqual(t, 1, len(node.children))
+	assertEqual(t, byte('a'), node.children[0].char)
+	assertEqual(t, 1, node.children[0].used)
+	assertEqual(t, 1, len(node.children[0].children))
+	assertEqual(t, byte('b'), node.children[0].children[0].char)
+	assertEqual(t, 1, node.children[0].children[0].used)
+	assertEqual(t, 0, len(node.children[0].children[0].children))
+}
+
+func TestCharNodeLongestCommonPrefixLength(t *testing.T) {
+	node := &charNode{}
+	assertEqual(t, 0, node.LongestCommonPrefixLength())
+	node.Add([]byte("abc"))
+	assertEqual(t, 3, node.LongestCommonPrefixLength())
+	node.Add([]byte("abd"))
+	assertEqual(t, 2, node.LongestCommonPrefixLength())
+	node.Remove([]byte("abd"))
+	assertEqual(t, 3, node.LongestCommonPrefixLength())
+	node.Add([]byte("ab"))
+	assertEqual(t, 2, node.LongestCommonPrefixLength())
+}
+
+func TestCharNodeLongestCommonPrefix(t *testing.T) {
+	node := &charNode{}
+	assertEqual(t, []byte{}, node.LongestCommonPrefix())
+	node.Add([]byte("abc"))
+	assertEqual(t, []byte("abc"), node.LongestCommonPrefix())
+	node.Add([]byte("abd"))
+	assertEqual(t, []byte("ab"), node.LongestCommonPrefix())
+	node.Remove([]byte("abd"))
+	assertEqual(t, []byte("abc"), node.LongestCommonPrefix())
+	node.Add([]byte("ab"))
+	assertEqual(t, []byte("ab"), node.LongestCommonPrefix())
+}
+
+func TestCharNodeBug1(t *testing.T) {
+	node := &charNode{}
+	node.Add([]byte("a"))
+	node.Add([]byte("a"))
+	node.Remove([]byte("a"))
+	node.Add([]byte("abbara"))
+	node.Add([]byte("abr"))
+
+	assertEqual(t, byte(0), node.char)
+	assertEqual(t, 0, node.used)
+	assertEqual(t, 1, len(node.children))
+	assertEqual(t, byte('a'), node.children[0].char)
+	assertEqual(t, 3, node.children[0].used)
+	assertEqual(t, 1, len(node.children[0].children))
+	assertEqual(t, byte('b'), node.children[0].children[0].char)
+	assertEqual(t, 2, node.children[0].children[0].used)
+	assertEqual(t, 2, len(node.children[0].children[0].children))
+	assertEqual(t, byte('b'), node.children[0].children[0].children[0].char)
+	assertEqual(t, 1, node.children[0].children[0].children[0].used)
+	assertEqual(t, 1, len(node.children[0].children[0].children[0].children))
+	assertEqual(t, byte('r'), node.children[0].children[0].children[1].char)
+	assertEqual(t, 1, node.children[0].children[0].children[1].used)
+	assertEqual(t, 0, len(node.children[0].children[0].children[1].children))
+	assertEqual(t, 1, node.LongestCommonPrefixLength())
+	assertEqual(t, []byte("a"), node.LongestCommonPrefix())
+}
+
+func TestCharNodeBug2(t *testing.T) {
+	node := &charNode{}
+	node.Add([]byte("habrahabr"))
+	node.Add([]byte("bbara"))
+	node.Add([]byte("mraja"))
+	node.Remove([]byte("habrahabr"))
+	node.Add([]byte("r"))
+	node.Remove([]byte("bbara"))
+	node.Add([]byte("ra"))
+	node.Remove([]byte("r"))
+	node.Add([]byte("rahabr"))
+	node.Remove([]byte("bbara"))
+	node.Add([]byte("ra"))
+	node.Remove([]byte("mraja"))
+	node.Add([]byte("raja"))
+
+	assertEqual(t, byte(0), node.char)
+	assertEqual(t, 0, node.used)
+	assertEqual(t, 1, len(node.children))
+	assertEqual(t, byte('r'), node.children[0].char)
+	assertEqual(t, 3, node.children[0].used)
+	assertEqual(t, 1, len(node.children[0].children))
+	assertEqual(t, byte('a'), node.children[0].children[0].char)
+	assertEqual(t, 3, node.children[0].children[0].used)
+	assertEqual(t, 2, len(node.children[0].children[0].children))
+	assertEqual(t, byte('h'), node.children[0].children[0].children[0].char)
+	assertEqual(t, 1, node.children[0].children[0].children[0].used)
+	assertEqual(t, 1, len(node.children[0].children[0].children[0].children))
+	assertEqual(t, byte('j'), node.children[0].children[0].children[1].char)
+	assertEqual(t, 1, node.children[0].children[0].children[1].used)
+	assertEqual(t, 1, len(node.children[0].children[0].children[1].children))
+	assertEqual(t, []byte("ra"), node.LongestCommonPrefix())
+}
+
+func TestLongestCommonSubstring(t *testing.T) {
+	assertEqual(t, []byte{}, LongestCommonSubstring())
+	assertEqual(t, []byte("abc"), LongestCommonSubstring([]byte("abc")))
+	assertEqual(t, []byte{}, LongestCommonSubstring([]byte("abc"), []byte{}))
+	assertEqual(t, []byte("ab"), LongestCommonSubstring([]byte("abc"), []byte("abd")))
+	assertEqual(t, []byte("bc"), LongestCommonSubstring([]byte("abc"), []byte("dbc")))
+	assertEqual(t, []byte("ab"), LongestCommonSubstring([]byte("ab"), []byte("abd")))
+	assertEqual(t, []byte("ABC"), LongestCommonSubstring(
+		[]byte("ABABC"), []byte("BABCA"), []byte("ABCBA")))
+	assertEqual(t, []byte("ra"), LongestCommonSubstring(
+		[]byte("habrahabr"),
+		[]byte("abbara"),
+		[]byte("humraja")))
+	assertEqual(t, []byte("abcdez"), LongestCommonSubstring(
+		[]byte("zxabcdezy"),
+		[]byte("yzabcdezx"),
+		[]byte("abcdez"),
+		[]byte("zyzxabcdez")))
+}
+
+func TestLongestCommonSubstringWithSuffixArrays(t *testing.T) {
+	assertEqual(t, []byte{}, lcss(nil, nil))
+	assertEqual(t, []byte("abc"), lcss(
+		[][]byte{[]byte("abc")}, [][]int{{1, 2, 3}}))
+}

--- a/internal/lcss/qsufsort.go
+++ b/internal/lcss/qsufsort.go
@@ -1,0 +1,169 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// This algorithm is based on "Faster Suffix Sorting"
+//   by N. Jesper Larsson and Kunihiko Sadakane
+// paper: http://www.larsson.dogma.net/ssrev-tr.pdf
+// code:  http://www.larsson.dogma.net/qsufsort.c
+
+// This algorithm computes the suffix array sa by computing its inverse.
+// Consecutive groups of suffixes in sa are labeled as sorted groups or
+// unsorted groups. For a given pass of the sorter, all suffixes are ordered
+// up to their first h characters, and sa is h-ordered. Suffixes in their
+// final positions and unambiguously sorted in h-order are in a sorted group.
+// Consecutive groups of suffixes with identical first h characters are an
+// unsorted group. In each pass of the algorithm, unsorted groups are sorted
+// according to the group number of their following suffix.
+
+// In the implementation, if sa[i] is negative, it indicates that i is
+// the first element of a sorted group of length -sa[i], and can be skipped.
+// An unsorted group sa[i:k] is given the group number of the index of its
+// last element, k-1. The group numbers are stored in the inverse slice (inv),
+// and when all groups are sorted, this slice is the inverse suffix array.
+
+package lcss
+
+import "sort"
+
+// qsufsort constructs the suffix array for a given string.
+func qsufsort(data []byte) []int {
+	// initial sorting by first byte of suffix
+	sa := sortedByFirstByte(data)
+	if len(sa) < 2 {
+		return sa
+	}
+	// initialize the group lookup table
+	// this becomes the inverse of the suffix array when all groups are sorted
+	inv := initGroups(sa, data)
+
+	// the index starts 1-ordered
+	sufSortable := &suffixSortable{sa: sa, inv: inv, h: 1}
+
+	for sa[0] > -len(sa) { // until all suffixes are one big sorted group
+		// The suffixes are h-ordered, make them 2*h-ordered
+		pi := 0 // pi is first position of first group
+		sl := 0 // sl is negated length of sorted groups
+		for pi < len(sa) {
+			if s := sa[pi]; s < 0 { // if pi starts sorted group
+				pi -= s // skip over sorted group
+				sl += s // add negated length to sl
+			} else { // if pi starts unsorted group
+				if sl != 0 {
+					sa[pi+sl] = sl // combine sorted groups before pi
+					sl = 0
+				}
+				pk := inv[s] + 1 // pk-1 is last position of unsorted group
+				sufSortable.sa = sa[pi:pk]
+				sort.Sort(sufSortable)
+				sufSortable.updateGroups(pi)
+				pi = pk // next group
+			}
+		}
+		if sl != 0 { // if the array ends with a sorted group
+			sa[pi+sl] = sl // combine sorted groups at end of sa
+		}
+
+		sufSortable.h *= 2 // double sorted depth
+	}
+
+	for i := range sa { // reconstruct suffix array from inverse
+		sa[inv[i]] = i
+	}
+	return sa
+}
+
+func sortedByFirstByte(data []byte) []int {
+	// total byte counts
+	var count [256]int
+	for _, b := range data {
+		count[b]++
+	}
+	// make count[b] equal index of first occurrence of b in sorted array
+	sum := 0
+	for b := range count {
+		count[b], sum = sum, count[b]+sum
+	}
+	// iterate through bytes, placing index into the correct spot in sa
+	sa := make([]int, len(data))
+	for i, b := range data {
+		sa[count[b]] = i
+		count[b]++
+	}
+	return sa
+}
+
+func initGroups(sa []int, data []byte) []int {
+	// label contiguous same-letter groups with the same group number
+	inv := make([]int, len(data))
+	prevGroup := len(sa) - 1
+	groupByte := data[sa[prevGroup]]
+	for i := len(sa) - 1; i >= 0; i-- {
+		if b := data[sa[i]]; b < groupByte {
+			if prevGroup == i+1 {
+				sa[i+1] = -1
+			}
+			groupByte = b
+			prevGroup = i
+		}
+		inv[sa[i]] = prevGroup
+		if prevGroup == 0 {
+			sa[0] = -1
+		}
+	}
+	// Separate out the final suffix to the start of its group.
+	// This is necessary to ensure the suffix "a" is before "aba"
+	// when using a potentially unstable sort.
+	lastByte := data[len(data)-1]
+	s := -1
+	for i := range sa {
+		if sa[i] >= 0 {
+			if data[sa[i]] == lastByte && s == -1 {
+				s = i
+			}
+			if sa[i] == len(sa)-1 {
+				sa[i], sa[s] = sa[s], sa[i]
+				inv[sa[s]] = s
+				sa[s] = -1 // mark it as an isolated sorted group
+				break
+			}
+		}
+	}
+	return inv
+}
+
+type suffixSortable struct {
+	sa  []int
+	inv []int
+	h   int
+	buf []int // common scratch space
+}
+
+func (x *suffixSortable) Len() int           { return len(x.sa) }
+func (x *suffixSortable) Less(i, j int) bool { return x.inv[x.sa[i]+x.h] < x.inv[x.sa[j]+x.h] }
+func (x *suffixSortable) Swap(i, j int)      { x.sa[i], x.sa[j] = x.sa[j], x.sa[i] }
+
+func (x *suffixSortable) updateGroups(offset int) {
+	bounds := x.buf[0:0]
+	group := x.inv[x.sa[0]+x.h]
+	for i := 1; i < len(x.sa); i++ {
+		if g := x.inv[x.sa[i]+x.h]; g > group {
+			bounds = append(bounds, i)
+			group = g
+		}
+	}
+	bounds = append(bounds, len(x.sa))
+	x.buf = bounds
+
+	// update the group numberings after all new groups are determined
+	prev := 0
+	for _, b := range bounds {
+		for i := prev; i < b; i++ {
+			x.inv[x.sa[i]] = offset + b - 1
+		}
+		if b-prev == 1 {
+			x.sa[prev] = -1
+		}
+		prev = b
+	}
+}

--- a/repl/repl_test.go
+++ b/repl/repl_test.go
@@ -1987,28 +1987,28 @@ func TestEvalTrace(t *testing.T) {
 	repl.OneShot(ctx, "trace")
 	repl.OneShot(ctx, `data.a[i].b.c[j] = x; data.a[k].b.c[x] = 1`)
 	expected := strings.TrimSpace(`
-query:1             Enter data.a[i].b.c[j] = x; data.a[k].b.c[x] = 1
-query:1             | Eval data.a[i].b.c[j] = x
-query:1             | Eval data.a[k].b.c[x] = 1
-query:1             | Fail data.a[k].b.c[x] = 1
-query:1             | Redo data.a[i].b.c[j] = x
-query:1             | Eval data.a[k].b.c[x] = 1
-query:1             | Exit data.a[i].b.c[j] = x; data.a[k].b.c[x] = 1
-query:1             Redo data.a[i].b.c[j] = x; data.a[k].b.c[x] = 1
-query:1             | Redo data.a[k].b.c[x] = 1
-query:1             | Redo data.a[i].b.c[j] = x
-query:1             | Eval data.a[k].b.c[x] = 1
-query:1             | Fail data.a[k].b.c[x] = 1
-query:1             | Redo data.a[i].b.c[j] = x
-query:1             | Eval data.a[k].b.c[x] = 1
-query:1             | Fail data.a[k].b.c[x] = 1
-query:1             | Redo data.a[i].b.c[j] = x
-query:1             | Eval data.a[k].b.c[x] = 1
-query:1             | Fail data.a[k].b.c[x] = 1
-query:1             | Redo data.a[i].b.c[j] = x
-query:1             | Eval data.a[k].b.c[x] = 1
-query:1             | Fail data.a[k].b.c[x] = 1
-query:1             | Redo data.a[i].b.c[j] = x
+query:1     Enter data.a[i].b.c[j] = x; data.a[k].b.c[x] = 1
+query:1     | Eval data.a[i].b.c[j] = x
+query:1     | Eval data.a[k].b.c[x] = 1
+query:1     | Fail data.a[k].b.c[x] = 1
+query:1     | Redo data.a[i].b.c[j] = x
+query:1     | Eval data.a[k].b.c[x] = 1
+query:1     | Exit data.a[i].b.c[j] = x; data.a[k].b.c[x] = 1
+query:1     Redo data.a[i].b.c[j] = x; data.a[k].b.c[x] = 1
+query:1     | Redo data.a[k].b.c[x] = 1
+query:1     | Redo data.a[i].b.c[j] = x
+query:1     | Eval data.a[k].b.c[x] = 1
+query:1     | Fail data.a[k].b.c[x] = 1
+query:1     | Redo data.a[i].b.c[j] = x
+query:1     | Eval data.a[k].b.c[x] = 1
+query:1     | Fail data.a[k].b.c[x] = 1
+query:1     | Redo data.a[i].b.c[j] = x
+query:1     | Eval data.a[k].b.c[x] = 1
+query:1     | Fail data.a[k].b.c[x] = 1
+query:1     | Redo data.a[i].b.c[j] = x
+query:1     | Eval data.a[k].b.c[x] = 1
+query:1     | Fail data.a[k].b.c[x] = 1
+query:1     | Redo data.a[i].b.c[j] = x
 +---+---+---+---+
 | i | j | k | x |
 +---+---+---+---+
@@ -2030,12 +2030,12 @@ func TestEvalNotes(t *testing.T) {
 	repl.OneShot(ctx, "notes")
 	buffer.Reset()
 	repl.OneShot(ctx, "p")
-	expected := strings.TrimSpace(`query:1             Enter data.repl.p = _
-query:1             | Enter data.repl.p
-note                | | Note "x = 2"
-query:1             Redo data.repl.p = _
-query:1             | Redo data.repl.p
-note                | | Note "x = 3"
+	expected := strings.TrimSpace(`query:1     Enter data.repl.p = _
+query:1     | Enter data.repl.p
+note        | | Note "x = 2"
+query:1     Redo data.repl.p = _
+query:1     | Redo data.repl.p
+note        | | Note "x = 3"
 true`)
 	expected += "\n"
 	if expected != buffer.String() {

--- a/topdown/eval.go
+++ b/topdown/eval.go
@@ -976,6 +976,7 @@ func getSavePairs(x *ast.Term, b *bindings, result []savePair) []savePair {
 
 func (e *eval) saveExpr(expr *ast.Expr, b *bindings, iter unifyIterator) error {
 	expr.With = e.query[e.index].With
+	expr.Location = e.query[e.index].Location
 	e.saveStack.Push(expr, b, b)
 	e.traceSave(expr)
 	err := iter()
@@ -987,6 +988,7 @@ func (e *eval) saveUnify(a, b *ast.Term, b1, b2 *bindings, iter unifyIterator) e
 	e.instr.startTimer(partialOpSaveUnify)
 	expr := ast.Equality.Expr(a, b)
 	expr.With = e.query[e.index].With
+	expr.Location = e.query[e.index].Location
 	pops := 0
 	if pairs := getSavePairs(a, b1, nil); len(pairs) > 0 {
 		pops += len(pairs)
@@ -1017,6 +1019,7 @@ func (e *eval) saveUnify(a, b *ast.Term, b1, b2 *bindings, iter unifyIterator) e
 func (e *eval) saveCall(declArgsLen int, terms []*ast.Term, iter unifyIterator) error {
 	expr := ast.NewExpr(terms)
 	expr.With = e.query[e.index].With
+	expr.Location = e.query[e.index].Location
 
 	// If call-site includes output value then partial eval must add vars in output
 	// position to the save set.


### PR DESCRIPTION
Previously we had a hard set width for location info in pretty trace
outputs. This changes to use a dynamic width up to a reasonable max
and then starts to shorten paths as possible by swapping in `...` for
the longest common substring of all paths.

To get the longest substring this brings in a couple files from
https://github.com/vmarkovtsev/go-lcss which implements an efficient
algorithm for it (rather than us implementing something fancy from
scratch). It's pretty isolated and is unlikely to need any updates
over time so the maintenance should be low.

Fixes: #2143

This also includes a fix for locations on "save" trace events. 