### PR TITLE
Add time.add_date builtin

### DIFF
--- a/ast/builtins.go
+++ b/ast/builtins.go
@@ -161,6 +161,7 @@ var DefaultBuiltins = [...]*Builtin{
 	Date,
 	Clock,
 	Weekday,
+	AddDate,
 
 	// Crypto
 	CryptoX509ParseCertificates,
@@ -1410,6 +1411,20 @@ var Weekday = &Builtin{
 			),
 		),
 		types.S,
+	),
+}
+
+// AddDate returns the nanoseconds since epoch after adding years, months and days to nanoseconds.
+var AddDate = &Builtin{
+	Name: "time.add_date",
+	Decl: types.NewFunction(
+		types.Args(
+			types.N,
+			types.N,
+			types.N,
+			types.N,
+		),
+		types.N,
 	),
 }
 

--- a/docs/content/policy-reference.md
+++ b/docs/content/policy-reference.md
@@ -513,13 +513,14 @@ result_valid_hs256 := io.jwt.verify_hs256(result_hs256, "foo")
 
 | Built-in | Description |
 | -------- | ----------- |
-| <span class="opa-keep-it-together">``output := time.now_ns()``</span> | ``output`` is ``number`` representing the current time since epoch in nanoseconds. |
-| <span class="opa-keep-it-together">``output := time.parse_ns(layout, value)``</span> | ``output`` is ``number`` representing the time ``value`` in nanoseconds since epoch. See the [Go `time` package documentation](https://golang.org/pkg/time/#Parse) for more details on ``layout``. |
-| <span class="opa-keep-it-together">``output := time.parse_rfc3339_ns(value)``</span> | ``output`` is ``number`` representing the time ``value`` in nanoseconds since epoch. |
-| <span class="opa-keep-it-together">``output := time.parse_duration_ns(duration)``</span> | ``output`` is ``number`` representing the duration ``duration`` in nanoseconds. See the [Go `time` package documentation](https://golang.org/pkg/time/#ParseDuration) for more details on ``duration``. |
+| <span class="opa-keep-it-together">``output := time.now_ns()``</span> | ``output`` is a ``number`` representing the current time since epoch in nanoseconds. |
+| <span class="opa-keep-it-together">``output := time.parse_ns(layout, value)``</span> | ``output`` is a ``number`` representing the time ``value`` in nanoseconds since epoch. See the [Go `time` package documentation](https://golang.org/pkg/time/#Parse) for more details on ``layout``. |
+| <span class="opa-keep-it-together">``output := time.parse_rfc3339_ns(value)``</span> | ``output`` is a ``number`` representing the time ``value`` in nanoseconds since epoch. |
+| <span class="opa-keep-it-together">``output := time.parse_duration_ns(duration)``</span> | ``output`` is a ``number`` representing the duration ``duration`` in nanoseconds. See the [Go `time` package documentation](https://golang.org/pkg/time/#ParseDuration) for more details on ``duration``. |
 | <span class="opa-keep-it-together">``output := time.date(ns)``<br/>``output := time.date([ns, tz])``</span> | ``output`` is of the form ``[year, month, day]``, which includes the ``year``, ``month`` (0-12), and ``day`` (0-31) as ``number``s representing the date from the nanoseconds since epoch (``ns``) in the timezone (``tz``), if supplied, or as UTC.|
 | <span class="opa-keep-it-together">``output := time.clock(ns)``<br/>``output := time.clock([ns, tz])``</span> | ``output`` is of the form ``[hour, minute, second]``, which outputs the ``hour``, ``minute`` (0-59), and ``second`` (0-59) as ``number``s representing the time of day for the nanoseconds since epoch (``ns``) in the timezone (``tz``), if supplied, or as UTC. |
 | <span class="opa-keep-it-together">``day := time.weekday(ns)``<br/>``day := time.weekday([ns, tz])``</span> | outputs the ``day`` as ``string`` representing the day of the week for the nanoseconds since epoch (``ns``) in the timezone (``tz``), if supplied, or as UTC. |
+| <span class="opa-keep-it-together">``output := time.add_date(ns, years, months, days)``</span> | ``output`` is a ``number`` representing the time since epoch in nanoseconds after adding the ``years``, ``months`` and ``days`` to ``ns``. See the [Go `time` package documentation](https://golang.org/pkg/time/#Time.AddDate) for more details on ``add_date``. |
 
 > Multiple calls to the `time.now_ns` built-in function within a single policy
 evaluation query will always return the same value.

--- a/topdown/time.go
+++ b/topdown/time.go
@@ -114,6 +114,31 @@ func builtinWeekday(a ast.Value) (ast.Value, error) {
 	return ast.String(weekday), nil
 }
 
+func builtinAddDate(bctx BuiltinContext, operands []*ast.Term, iter func(*ast.Term) error) error {
+	t, err := tzTime(operands[0].Value)
+	if err != nil {
+		return err
+	}
+
+	years, err := builtins.IntOperand(operands[1].Value, 2)
+	if err != nil {
+		return err
+	}
+
+	months, err := builtins.IntOperand(operands[2].Value, 3)
+	if err != nil {
+		return err
+	}
+
+	days, err := builtins.IntOperand(operands[3].Value, 4)
+	if err != nil {
+		return err
+	}
+
+	result := t.AddDate(years, months, days)
+	return iter(ast.NewTerm(ast.Number(int64ToJSONNumber(result.UnixNano()))))
+}
+
 func tzTime(a ast.Value) (t time.Time, err error) {
 	var nVal ast.Value
 	loc := time.UTC
@@ -198,6 +223,7 @@ func init() {
 	RegisterFunctionalBuiltin1(ast.Date.Name, builtinDate)
 	RegisterFunctionalBuiltin1(ast.Clock.Name, builtinClock)
 	RegisterFunctionalBuiltin1(ast.Weekday.Name, builtinWeekday)
+	RegisterBuiltinFunc(ast.AddDate.Name, builtinAddDate)
 	tzCacheMutex = &sync.Mutex{}
 	tzCache = make(map[string]*time.Location)
 }

--- a/topdown/topdown_test.go
+++ b/topdown/topdown_test.go
@@ -1546,6 +1546,12 @@ func TestTopDownTime(t *testing.T) {
 
 	runTopDownTestCase(t, data, "weekday too big", []string{`
 		p = weekday { weekday := time.weekday(1582977600*1000*1000*1000*1000) }`}, &Error{Code: BuiltinErr, Message: "timestamp too big"})
+
+	runTopDownTestCase(t, data, "add_date year month day", []string{`
+		p = ns { ns := time.add_date(1585852421593912000, 3, 9, 12) }`}, "1705257221593912000")
+
+	runTopDownTestCase(t, data, "add_date negative values", []string{`
+		p = ns { ns := time.add_date(1585852421593912000, -1, -1, -1) }`}, "1551465221593912000")
 }
 
 func TestTopDownWalkBuiltin(t *testing.T) {


### PR DESCRIPTION
New builtin for adding years, months and days to a time
This might be useful for computing a day in the future or past
more easily

Fixes #1990

Signed-off-by: Frederic <frederic.vanreet@icloud.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
