### PR TITLE
topdown: make the TLS server name test more robust

### DIFF
--- a/topdown/http_test.go
+++ b/topdown/http_test.go
@@ -1100,8 +1100,7 @@ func TestHTTPSClient(t *testing.T) {
 		hostname := "notpresent"
 
 		expected := &Error{Code: BuiltinErr, Message: fmt.Sprintf(
-			"http.send: Get %s: x509: certificate is valid for localhost, not %s",
-			url, hostname)}
+			"x509: certificate is valid for localhost, not %s", hostname)}
 
 		data := loadSmallTestData()
 		rule := []string{fmt.Sprintf(
@@ -1118,8 +1117,7 @@ func TestHTTPSClient(t *testing.T) {
 		hostname := "notpresent"
 
 		expected := &Error{Code: BuiltinErr, Message: fmt.Sprintf(
-			"http.send: Get %s: x509: certificate is valid for localhost, not %s",
-			url, hostname)}
+			"x509: certificate is valid for localhost, not %s", hostname)}
 
 		data := loadSmallTestData()
 		rule := []string{fmt.Sprintf(


### PR DESCRIPTION
The Go HTTP library may quote the URL in a HTTP error message, possibly
depending on platform or Go version. Since the URL doesn't matter for
verifying the error, we can just remove it from the match target.

Signed-off-by: James Peach <jpeach@vmware.com>