### PR TITLE
rego: Avoid re-using transactions in compiler

### DIFF
--- a/rego/rego_test.go
+++ b/rego/rego_test.go
@@ -994,6 +994,38 @@ func TestPreparedPartialResultWithTracer(t *testing.T) {
 	}
 }
 
+func TestPartialResultSetsValidConflictChecker(t *testing.T) {
+	mod := `
+	package test
+	p {
+		true
+	}
+	`
+
+	c := ast.NewCompiler().WithPathConflictsCheck(func(_ []string) (bool, error) {
+		t.Fatal("Conflict check should not have been called")
+		return false, nil
+	})
+
+	r := New(
+		Query("data.test.p"),
+		Module("test.rego", mod),
+		PartialNamespace("test_ns1"),
+		Compiler(c),
+	)
+
+	ctx := context.Background()
+	pr, err := r.PartialResult(ctx)
+
+	if err != nil {
+		t.Fatalf("unexpected error from Rego.PartialResult(): %s", err.Error())
+	}
+
+	r2 := pr.Rego()
+
+	assertEval(t, r2, "[[true]]")
+}
+
 func TestMissingLocation(t *testing.T) {
 
 	// Create a query programmatically and evaluate it. The Location information


### PR DESCRIPTION
Any time we do a compilation in the Rego object (or helpers) we need
to be careful to setup a conflict check that is valid for the current
context (both literal golang ctx and current storage transaction).

This isn't much of a concern if the Rego instance owns the compiler,
but if an external one was provided we need to be careful to update
the conflict check before compiling.

This was already doing the "right thing" when activating bundles, but
for partial evaluation results that were being updated on the compiler
it was not.

Fixes: #2197
Signed-off-by: Patrick East <east.patrick@gmail.com>