### PR TITLE
ast: Rewrite input document when passed as an operand to a call

### DIFF
--- a/ast/compile_test.go
+++ b/ast/compile_test.go
@@ -1971,6 +1971,32 @@ func TestRewriteDeclaredVars(t *testing.T) {
 			`,
 		},
 		{
+			note: "rewrite call with root document ref as arg",
+			module: `
+				package test
+
+				p {
+					f(input, "bar")
+				}
+
+				f(x,y) {
+					x[y]
+				}
+				`,
+			exp: `
+				package test
+
+				p = true {
+					__local2__ = input;
+					data.test.f(__local2__, "bar")
+				}
+
+				 f(__local0__, __local1__) = true {
+					__local0__[__local1__]
+				}
+			`,
+		},
+		{
 			note: "redeclare err",
 			module: `
 				package test
@@ -2198,6 +2224,8 @@ func TestCompilerRewriteDynamicTerms(t *testing.T) {
 		{`eq_with { [str] = [1] with input as 1 }`, `__local0__ = data.test.str with input as 1; [__local0__] = [1] with input as 1`},
 		{`term_with { [[str]] with input as 1 }`, `__local0__ = data.test.str with input as 1; [[__local0__]] with input as 1`},
 		{`call_with { count(str) with input as 1 }`, `__local0__ = data.test.str with input as 1; count(__local0__) with input as 1`},
+		{`call_func { f(input, "foo") } f(x,y) { x[y] }`, `__local2__ = input; data.test.f(__local2__, "foo")`},
+		{`call_func2 { f(input.foo, "foo") } f(x,y) { x[y] }`, `__local2__ = input.foo; data.test.f(__local2__, "foo")`},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
Earlier if a reference to the root of the input document was passed as operand in a call, it would not be rewritten to a local variable and substituted in the call. Refs to non-root input/data document would be rewritten. This was happening because we were updating the value of the input root ref term to a variable and as a result the compiler stage that rewrites the body of dynamic terms ('rewriteDynamicTerms') would not rewrite the input root ref. These changes modify the 'rewriteLocalVars' stage so that the value of root ref term is updated only if it has already been rewritten to a local variable. If it isn't, then it will be rewritten in a later stage.

Fixes #2084

Signed-off-by: Ashutosh Narkar <anarkar4387@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
