### PR TITLE
topdown: Return response headers with `http.send`

### DIFF
--- a/docs/content/policy-reference.md
+++ b/docs/content/policy-reference.md
@@ -593,6 +593,7 @@ The `response` object parameter will contain the following fields:
 | `status_code` | `number` | HTTP status code (e.g., `200`). |
 | `body` | `any` | Any JSON value. If the HTTP response message body was not deserialized from JSON, this field is set to `null`. |
 | `raw_body` | `string` | The entire raw HTTP response message body represented as a string. |
+| `headers` | `object` | An object containing the response headers. The values will be an array of strings, repeated headers are grouped under the same keys with all values in the array. |
 
 The table below shows examples of calling `http.send`:
 

--- a/topdown/http.go
+++ b/topdown/http.go
@@ -397,11 +397,21 @@ func executeHTTPRequest(bctx BuiltinContext, obj ast.Object) (ast.Value, error) 
 		json.NewDecoder(&buf).Decode(&resultBody)
 	}
 
+	respHeaders := map[string]interface{}{}
+	for headerName, values := range resp.Header {
+		var respValues []interface{}
+		for _, v := range values {
+			respValues = append(respValues, v)
+		}
+		respHeaders[headerName] = respValues
+	}
+
 	result := make(map[string]interface{})
 	result["status"] = resp.Status
 	result["status_code"] = resp.StatusCode
 	result["body"] = resultBody
 	result["raw_body"] = string(resultRawBody)
+	result["headers"] = respHeaders
 
 	resultObj, err := ast.InterfaceToValue(result)
 	if err != nil {


### PR DESCRIPTION
Previously we left them off the returned AST object, this will now
just massage them into valid types and pass them along into the
return value.

Fixes: #2238
Signed-off-by: Patrick East <east.patrick@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
