### PR TITLE
Fix url error checking for go 1.14

### DIFF
--- a/plugins/rest/aws_test.go
+++ b/plugins/rest/aws_test.go
@@ -27,13 +27,15 @@ type metadataPayload struct {
 func assertEq(expected string, actual string, t *testing.T) {
 	t.Helper()
 	if actual != expected {
-		t.Error("expected error: ", expected, " but got: ", actual)
+		t.Error("expected: ", expected, " but got: ", actual)
 	}
 }
 
 func assertErr(expected string, actual error, t *testing.T) {
 	t.Helper()
-	assertEq(expected, actual.Error(), t)
+	if !strings.Contains(actual.Error(), expected) {
+		t.Errorf("Expected error to contain %s, got: %s", expected, actual.Error())
+	}
 }
 
 func TestEnvironmentCredentialService(t *testing.T) {
@@ -85,7 +87,7 @@ func TestMetadataCredentialService(t *testing.T) {
 		RegionName:      "us-east-1",
 		credServicePath: "this is not a URL"} // malformed
 	_, err := cs.credentials()
-	assertErr("Get this%20is%20not%20a%20URLmy_iam_role: unsupported protocol scheme \"\"", err, t)
+	assertErr("unsupported protocol scheme \"\"", err, t)
 
 	// wrong path: no role set but no ECS URI in environment
 	os.Unsetenv(ecsRelativePathEnvVar)


### PR DESCRIPTION
It seems as though go 1.14 changes some of the url errors to have
quotes around some fields. To make things compatible across a wider
number of platforms we can relax the checks a tiny bit to only look
at the actual error string and ignore the quoted part.

Signed-off-by: Patrick East <east.patrick@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
