### PR TITLE
Improve opa test --verbose and --explain flag usage

### DIFF
--- a/cmd/test.go
+++ b/cmd/test.go
@@ -116,6 +116,12 @@ The optional "gobench" output format conforms to the Go Benchmark Data Format.
 		if len(args) == 0 {
 			return fmt.Errorf("specify at least one file")
 		}
+
+		// If an --explain flag was set, turn on verbose output
+		if testParams.explain.IsSet() {
+			testParams.verbose = true
+		}
+
 		return nil
 	},
 

--- a/cmd/test_test.go
+++ b/cmd/test_test.go
@@ -1,0 +1,192 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/open-policy-agent/opa/rego"
+	"github.com/open-policy-agent/opa/topdown"
+)
+
+func TestFilterTraceDefault(t *testing.T) {
+	p := newTestCommandParams()
+	p.verbose = false
+	expected := `Enter data.testing.test_p = _
+| Enter data.testing.test_p
+| | Enter data.testing.p
+| | | Enter data.testing.q
+| | | | Enter data.testing.r
+| | | | | Fail x = data.x
+| | | | Fail data.testing.r[x]
+| | | Fail data.testing.q.foo
+| | Fail data.testing.p with data.x as "bar"
+| Fail data.testing.test_p = _
+`
+	verifyFilteredTrace(t, p, expected)
+}
+
+func TestFilterTraceVerbose(t *testing.T) {
+	p := newTestCommandParams()
+	p.verbose = true
+	expected := `Enter data.testing.test_p = _
+| Enter data.testing.test_p
+| | Enter data.testing.p
+| | | Note "test test"
+| | | Enter data.testing.q
+| | | | Note "got this far"
+| | | | Enter data.testing.r
+| | | | | Note "got this far2"
+| | | | | Fail x = data.x
+| | | | Fail data.testing.r[x]
+| | | Fail data.testing.q.foo
+| | Fail data.testing.p with data.x as "bar"
+| Fail data.testing.test_p = _
+`
+	verifyFilteredTrace(t, p, expected)
+}
+
+func TestFilterTraceExplainFails(t *testing.T) {
+	p := newTestCommandParams()
+	p.explain.Set(explainModeFails)
+	expected := `Enter data.testing.test_p = _
+| Enter data.testing.test_p
+| | Enter data.testing.p
+| | | Enter data.testing.q
+| | | | Enter data.testing.r
+| | | | | Fail x = data.x
+| | | | Fail data.testing.r[x]
+| | | Fail data.testing.q.foo
+| | Fail data.testing.p with data.x as "bar"
+| Fail data.testing.test_p = _
+`
+	verifyFilteredTrace(t, p, expected)
+}
+
+func TestFilterTraceExplainNotes(t *testing.T) {
+	p := newTestCommandParams()
+	p.explain.Set(explainModeNotes)
+	expected := `Enter data.testing.test_p = _
+| Enter data.testing.test_p
+| | Enter data.testing.p
+| | | Note "test test"
+| | | Enter data.testing.q
+| | | | Note "got this far"
+| | | | Enter data.testing.r
+| | | | | Note "got this far2"
+`
+	verifyFilteredTrace(t, p, expected)
+}
+
+func TestFilterTraceExplainFull(t *testing.T) {
+	p := newTestCommandParams()
+	p.explain.Set(explainModeFull)
+	expected := `Enter data.testing.test_p = _
+| Eval data.testing.test_p = _
+| Index data.testing.test_p = _ (matched 1 rule)
+| Enter data.testing.test_p
+| | Eval data.testing.p with data.x as "bar"
+| | Index data.testing.p with data.x as "bar" (matched 1 rule)
+| | Enter data.testing.p
+| | | Eval data.testing.x
+| | | Index data.testing.x (matched 1 rule)
+| | | Enter data.testing.x
+| | | | Eval data.testing.y
+| | | | Index data.testing.y (matched 1 rule)
+| | | | Enter data.testing.y
+| | | | | Eval true
+| | | | | Exit data.testing.y
+| | | | Exit data.testing.x
+| | | Eval trace("test test")
+| | | Note "test test"
+| | | Eval data.testing.q.foo
+| | | Index data.testing.q.foo (matched 1 rule)
+| | | Enter data.testing.q
+| | | | Eval trace("got this far")
+| | | | Note "got this far"
+| | | | Eval data.testing.r[x]
+| | | | Index data.testing.r[__local0__] (matched 1 rule)
+| | | | Enter data.testing.r
+| | | | | Eval trace("got this far2")
+| | | | | Note "got this far2"
+| | | | | Eval x = data.x
+| | | | | Fail x = data.x
+| | | | | Redo trace("got this far2")
+| | | | Fail data.testing.r[x]
+| | | | Redo trace("got this far")
+| | | Fail data.testing.q.foo
+| | | Redo trace("test test")
+| | | Redo data.testing.x
+| | | Redo data.testing.x
+| | | | Redo data.testing.y
+| | | | Redo data.testing.y
+| | | | | Redo true
+| | Fail data.testing.p with data.x as "bar"
+| Fail data.testing.test_p = _
+`
+	verifyFilteredTrace(t, p, expected)
+}
+
+func verifyFilteredTrace(t *testing.T, params *testCommandParams, expected string) {
+	filtered := filterTrace(params, failTrace(t))
+
+	var buff bytes.Buffer
+	topdown.PrettyTrace(&buff, filtered)
+	actual := buff.String()
+
+	if actual != expected {
+		t.Fatalf("Expected:\n\n%s\n\nGot:\n\n%s\n\n", expected, actual)
+	}
+}
+
+func failTrace(t *testing.T) []*topdown.Event {
+	t.Helper()
+	mod := `
+	package testing
+	
+	p {
+		x  # Always true
+		trace("test test")
+		q["foo"]
+	}
+	
+	x {
+		y
+	}
+	
+	y {
+		true
+	}
+	
+	q[x] {
+		some x
+		trace("got this far")
+		r[x]
+		trace("got this far1")
+	}
+	
+	r[x] {
+		trace("got this far2")
+		x := data.x
+	}
+	
+	test_p {
+		p with data.x as "bar"
+	}
+	`
+
+	tracer := topdown.NewBufferTracer()
+
+	_, err := rego.New(
+		rego.Module("test.rego", mod),
+		rego.Trace(true),
+		rego.Tracer(tracer),
+		rego.Query("data.testing.test_p"),
+	).Eval(context.Background())
+
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
+
+	return *tracer
+}

--- a/topdown/lineage/lineage.go
+++ b/topdown/lineage/lineage.go
@@ -11,7 +11,7 @@ import (
 // Notes returns a filtered trace that contains Note events and context to
 // understand where the Note was emitted.
 func Notes(trace []*topdown.Event) []*topdown.Event {
-	return filter(trace, func(event *topdown.Event) bool {
+	return Filter(trace, func(event *topdown.Event) bool {
 		return event.Op == topdown.NoteOp
 	})
 }
@@ -19,12 +19,15 @@ func Notes(trace []*topdown.Event) []*topdown.Event {
 // Fails returns a filtered trace that contains Fail events and context to
 // understand where the Fail occurred.
 func Fails(trace []*topdown.Event) []*topdown.Event {
-	return filter(trace, func(event *topdown.Event) bool {
+	return Filter(trace, func(event *topdown.Event) bool {
 		return event.Op == topdown.FailOp
 	})
 }
 
-func filter(trace []*topdown.Event, filter func(*topdown.Event) bool) (result []*topdown.Event) {
+// Filter will filter a given trace using the specified filter function. The
+// filtering function should return true for events that should be kept, false
+// for events that should be filtered out.
+func Filter(trace []*topdown.Event, filter func(*topdown.Event) bool) (result []*topdown.Event) {
 
 	qids := map[uint64]*topdown.Event{}
 

--- a/util/enumflag.go
+++ b/util/enumflag.go
@@ -41,6 +41,11 @@ func (f *EnumFlag) String() string {
 	return f.vs[f.i]
 }
 
+// IsSet will return true if the EnumFlag has been set.
+func (f *EnumFlag) IsSet() bool {
+	return f.i != -1
+}
+
 // Set sets the enum value. If s is not a valid enum value, an error is
 // returned.
 func (f *EnumFlag) Set(s string) error {

--- a/util/enumflag_test.go
+++ b/util/enumflag_test.go
@@ -17,12 +17,20 @@ func TestEnumFlag(t *testing.T) {
 		t.Fatalf("Expected default value to be foo but got: %v", flag.String())
 	}
 
+	if flag.IsSet() {
+		t.Fatalf("Expected IsSet() to be false")
+	}
+
 	if err := flag.Set("bar"); err != nil {
 		t.Fatalf("Unexpected error on set: %v", err)
 	}
 
 	if flag.String() != "bar" {
 		t.Fatalf("Expected value to be bar but got: %v", flag.String())
+	}
+
+	if !flag.IsSet() {
+		t.Fatalf("Expected IsSet() to be true")
 	}
 
 	if !strings.Contains(flag.Type(), "foo,bar,baz") {


### PR DESCRIPTION
This is adding support for two features (related enough to group together in a single PR).

First up is making the `opa test` `--explain` flag automatically turn on verbose output. This should help for anyone who is trying to see a trace (by providing the flag) and then being surprised when no trace output is shown.

The second one is to make it so that the default trace output shown when _only_ specifying `-v`/`--verbose` includes both "fail" and "note" events. This should help users more easily troubleshoot why tests failed without having to use `--explain full` and sifting through all of the output.

Closes: #2068
Closes: #2069