### PR TITLE
Fix contrib link: pam_authz has been renamed pam_opa

### DIFF
--- a/docs/website/data/integrations.yaml
+++ b/docs/website/data/integrations.yaml
@@ -306,7 +306,7 @@ integrations:
     tutorials:
       - https://www.openpolicyagent.org/docs/ssh-and-sudo-authorization.html
     code:
-      - https://github.com/open-policy-agent/contrib/tree/master/pam_authz
+      - https://github.com/open-policy-agent/contrib/tree/master/pam_opa
     inventors:
       - styra
 


### PR DESCRIPTION
Integration pam_authz has been renamed pam_opa

Cf. https://github.com/open-policy-agent/contrib/commit/80435207
