### PR TITLE
bundle: Remove extra root name in bundle file id's

### DIFF
--- a/bundle/file.go
+++ b/bundle/file.go
@@ -76,6 +76,20 @@ type dirLoader struct {
 // NewDirectoryLoader returns a basic DirectoryLoader implementation
 // that will load files from a given root directory path.
 func NewDirectoryLoader(root string) DirectoryLoader {
+
+	if len(root) > 1 {
+		// Normalize relative directories, ex "./src/bundle" -> "src/bundle"
+		// We don't need an absolute path, but this makes the joined/trimmed
+		// paths more uniform.
+		if root[0] == '.' && root[1] == filepath.Separator {
+			if len(root) == 2 {
+				root = root[:1] // "./" -> "."
+			} else {
+				root = root[2:] // remove leading "./"
+			}
+		}
+	}
+
 	d := dirLoader{
 		root: root,
 	}

--- a/bundle/file_test.go
+++ b/bundle/file_test.go
@@ -106,3 +106,67 @@ func testLoader(t *testing.T, loader DirectoryLoader, expectedFiles map[string]s
 		t.Fatalf("Expected to read %d files, read %d", len(expectedFiles), fileCount)
 	}
 }
+
+func TestNewDirectoryLoaderNormalizedRoot(t *testing.T) {
+	cases := []struct {
+		note     string
+		root     string
+		expected string
+	}{
+		{
+			note:     "abs",
+			root:     "/a/b/c",
+			expected: "/a/b/c",
+		},
+		{
+			note:     "trailing slash",
+			root:     "/a/b/c/",
+			expected: "/a/b/c/",
+		},
+		{
+			note:     "empty",
+			root:     "",
+			expected: "",
+		},
+		{
+			note:     "single abs",
+			root:     "/",
+			expected: "/",
+		},
+		{
+			note:     "single relative",
+			root:     "foo",
+			expected: "foo",
+		},
+		{
+			note:     "single relative dot",
+			root:     ".",
+			expected: ".",
+		},
+		{
+			note:     "single relative dot slash",
+			root:     "./",
+			expected: ".",
+		},
+		{
+			note:     "relative leading dot slash",
+			root:     "./a/b/c",
+			expected: "a/b/c",
+		},
+		{
+			note:     "relative",
+			root:     "a/b/c",
+			expected: "a/b/c",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.note, func(t *testing.T) {
+			l := NewDirectoryLoader(tc.root)
+			actual := l.(*dirLoader).root
+			if actual != tc.expected {
+				t.Fatalf("Expected root %s got %s", tc.expected, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Previously if we provided a "root" to the bundle directory loader that
was a relative path, it would matter whether or not it was prefixed
with "./". The logic to trim that path from the paths found walking
the root was not taking into account the prefix so the resulting ones
that had "./" would leave behind the root path.

Later on the bundle loader would generate a "full" path to set on the
module file for its location which is the root+path.. which resulted
in duplicate "root"s on those id's.

To fix this we just normalize the relative paths in the directory
loader so that we can not worry about what type of relative path it
is.

Fixes: #2117
Signed-off-by: Patrick East <east.patrick@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
