### PR TITLE
profiler: Group expressions with missing locations

### DIFF
--- a/profiler/profiler.go
+++ b/profiler/profiler.go
@@ -130,6 +130,10 @@ func (p *Profiler) Trace(event *topdown.Event) {
 }
 
 func (p *Profiler) processExpr(expr *ast.Expr, eventType topdown.Op) {
+	if expr.Location == nil {
+		// add fake location to group expressions without a location
+		expr.Location = ast.NewLocation([]byte("???"), "", 0, 0)
+	}
 
 	// set the active timer on the first expression
 	if p.activeTimer.IsZero() {


### PR DESCRIPTION
Previously the profiler would panic if it encountered an expression with no location info. This change groups such expressions by giving them a fake location so that their evaluation results can be captured.

Signed-off-by: Ashutosh Narkar <anarkar4387@gmail.com>

Fixes #2134 

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
