### PR TITLE
docs: Fix EBNF grammar to quote terms correctly

### DIFF
--- a/docs/content/policy-reference.md
+++ b/docs/content/policy-reference.md
@@ -706,15 +706,15 @@ package         = "package" ref
 import          = "import" package [ "as" var ]
 policy          = { rule }
 rule            = [ "default" ] rule-head { rule-body }
-rule-head       = var [ "(" rule-args ")" ] [ "[" term "]" ] [ ( ":=" / "=" ) term ]
+rule-head       = var [ "(" rule-args ")" ] [ "[" term "]" ] [ ( ":=" | "=" ) term ]
 rule-args       = term { "," term }
-rule-body       = [ else [ = term ] ] "{" query "}"
-query           = literal { ";" | [\r\n] literal }
+rule-body       = [ "else" [ = term ] ] "{" query "}"
+query           = literal { ( ";" | ( [CR] LF ) ) literal }
 literal         = ( some-decl | expr | "not" expr ) { with-modifier }
 with-modifier   = "with" term "as" term
 some-decl       = "some" var { "," var }
 expr            = term | expr-call | expr-infix
-expr-call       = var [ "." var ] "(" [ term { , term } ] ")"
+expr-call       = var [ "." var ] "(" [ term { "," term } ] ")"
 expr-infix      = [ term "=" ] term infix-operator term
 term            = ref | var | scalar | array | object | set | array-compr | object-compr | set-compr
 array-compr     = "[" term "|" rule-body "]"
@@ -755,4 +755,6 @@ NULL   JSON null
 CHAR   Unicode character
 ALPHA  ASCII characters A-Z and a-z
 DIGIT  ASCII characters 0-9
+CR     Carriage Return
+LF     Line Feed
 ```


### PR DESCRIPTION
A user pointed out that our EBNF grammar did not quote a few of the
terms correctly. This commit fixes those cases.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
