### PR TITLE
topdown: Fix for unsafe negated query in partial results

### DIFF
--- a/topdown/copypropagation/copypropagation.go
+++ b/topdown/copypropagation/copypropagation.go
@@ -352,12 +352,6 @@ func sortbindings(bindings map[ast.Var]*binding) []*binding {
 	return sorted
 }
 
-type unionFind struct {
-	roots   map[ast.Var]*unionFindRoot
-	parents map[ast.Var]ast.Var
-	rank    rankFunc
-}
-
 // makeDisjointSets builds the union-find structure for the query. The structure
 // is built by processing all of the equality exprs in the query. Sets represent
 // vars that must be equal to each other. In addition to vars, each set can have
@@ -397,86 +391,6 @@ func makeDisjointSets(livevars ast.VarSet, query ast.Body) (*unionFind, bool) {
 	}
 
 	return uf, true
-}
-
-type rankFunc func(*unionFindRoot, *unionFindRoot) (*unionFindRoot, *unionFindRoot)
-
-func newUnionFind(rank rankFunc) *unionFind {
-	return &unionFind{
-		roots:   map[ast.Var]*unionFindRoot{},
-		parents: map[ast.Var]ast.Var{},
-		rank:    rank,
-	}
-}
-
-func (uf *unionFind) MakeSet(v ast.Var) *unionFindRoot {
-
-	root, ok := uf.Find(v)
-	if ok {
-		return root
-	}
-
-	root = newUnionFindRoot(v)
-	uf.parents[v] = v
-	uf.roots[v] = root
-	return uf.roots[v]
-}
-
-func (uf *unionFind) Find(v ast.Var) (*unionFindRoot, bool) {
-
-	parent, ok := uf.parents[v]
-	if !ok {
-		return nil, false
-	}
-
-	if parent == v {
-		return uf.roots[v], true
-	}
-
-	return uf.Find(parent)
-}
-
-func (uf *unionFind) Merge(a, b ast.Var) (*unionFindRoot, bool) {
-
-	r1 := uf.MakeSet(a)
-	r2 := uf.MakeSet(b)
-
-	if r1 != r2 {
-
-		r1, r2 = uf.rank(r1, r2)
-
-		uf.parents[r2.key] = r1.key
-		delete(uf.roots, r2.key)
-
-		// Sets can have at most one constant value associated with them. When
-		// unioning, we must preserve this invariant. If a set has two constants,
-		// there will be no way to prove the query.
-		if r1.constant != nil && r2.constant != nil && !r1.constant.Equal(r2.constant) {
-			return nil, false
-		} else if r1.constant == nil {
-			r1.constant = r2.constant
-		}
-	}
-
-	return r1, true
-}
-
-type unionFindRoot struct {
-	key      ast.Var
-	constant *ast.Term
-}
-
-func newUnionFindRoot(key ast.Var) *unionFindRoot {
-	return &unionFindRoot{
-		key: key,
-	}
-}
-
-func (r *unionFindRoot) Value() ast.Value {
-	if r.constant != nil {
-		return r.constant.Value
-	}
-	return r.key
 }
 
 func isNoop(expr *ast.Expr) bool {

--- a/topdown/copypropagation/unionfind.go
+++ b/topdown/copypropagation/unionfind.go
@@ -1,0 +1,92 @@
+// Copyright 2020 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package copypropagation
+
+import "github.com/open-policy-agent/opa/ast"
+
+type rankFunc func(*unionFindRoot, *unionFindRoot) (*unionFindRoot, *unionFindRoot)
+
+type unionFind struct {
+	roots   map[ast.Var]*unionFindRoot
+	parents map[ast.Var]ast.Var
+	rank    rankFunc
+}
+func newUnionFind(rank rankFunc) *unionFind {
+	return &unionFind{
+		roots:   map[ast.Var]*unionFindRoot{},
+		parents: map[ast.Var]ast.Var{},
+		rank:    rank,
+	}
+}
+
+func (uf *unionFind) MakeSet(v ast.Var) *unionFindRoot {
+
+	root, ok := uf.Find(v)
+	if ok {
+		return root
+	}
+
+	root = newUnionFindRoot(v)
+	uf.parents[v] = v
+	uf.roots[v] = root
+	return uf.roots[v]
+}
+
+func (uf *unionFind) Find(v ast.Var) (*unionFindRoot, bool) {
+
+	parent, ok := uf.parents[v]
+	if !ok {
+		return nil, false
+	}
+
+	if parent == v {
+		return uf.roots[v], true
+	}
+
+	return uf.Find(parent)
+}
+
+func (uf *unionFind) Merge(a, b ast.Var) (*unionFindRoot, bool) {
+
+	r1 := uf.MakeSet(a)
+	r2 := uf.MakeSet(b)
+
+	if r1 != r2 {
+
+		r1, r2 = uf.rank(r1, r2)
+
+		uf.parents[r2.key] = r1.key
+		delete(uf.roots, r2.key)
+
+		// Sets can have at most one constant value associated with them. When
+		// unioning, we must preserve this invariant. If a set has two constants,
+		// there will be no way to prove the query.
+		if r1.constant != nil && r2.constant != nil && !r1.constant.Equal(r2.constant) {
+			return nil, false
+		} else if r1.constant == nil {
+			r1.constant = r2.constant
+		}
+	}
+
+	return r1, true
+}
+
+type unionFindRoot struct {
+	key      ast.Var
+	constant *ast.Term
+}
+
+func newUnionFindRoot(key ast.Var) *unionFindRoot {
+	return &unionFindRoot{
+		key: key,
+	}
+}
+
+func (r *unionFindRoot) Value() ast.Value {
+	if r.constant != nil {
+		return r.constant.Value
+	}
+	return r.key
+}

--- a/topdown/copypropagation/unionfind.go
+++ b/topdown/copypropagation/unionfind.go
@@ -4,24 +4,34 @@
 
 package copypropagation
 
-import "github.com/open-policy-agent/opa/ast"
+import (
+	"fmt"
+
+	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/util"
+)
 
 type rankFunc func(*unionFindRoot, *unionFindRoot) (*unionFindRoot, *unionFindRoot)
 
 type unionFind struct {
-	roots   map[ast.Var]*unionFindRoot
-	parents map[ast.Var]ast.Var
+	roots   *util.HashMap
+	parents *ast.ValueMap
 	rank    rankFunc
 }
+
 func newUnionFind(rank rankFunc) *unionFind {
 	return &unionFind{
-		roots:   map[ast.Var]*unionFindRoot{},
-		parents: map[ast.Var]ast.Var{},
+		roots: util.NewHashMap(func(a util.T, b util.T) bool {
+			return a.(ast.Value).Compare(b.(ast.Value)) == 0
+		}, func(v util.T) int {
+			return v.(ast.Value).Hash()
+		}),
+		parents: ast.NewValueMap(),
 		rank:    rank,
 	}
 }
 
-func (uf *unionFind) MakeSet(v ast.Var) *unionFindRoot {
+func (uf *unionFind) MakeSet(v ast.Value) *unionFindRoot {
 
 	root, ok := uf.Find(v)
 	if ok {
@@ -29,26 +39,27 @@ func (uf *unionFind) MakeSet(v ast.Var) *unionFindRoot {
 	}
 
 	root = newUnionFindRoot(v)
-	uf.parents[v] = v
-	uf.roots[v] = root
-	return uf.roots[v]
+	uf.parents.Put(v, v)
+	uf.roots.Put(v, root)
+	return root
 }
 
-func (uf *unionFind) Find(v ast.Var) (*unionFindRoot, bool) {
+func (uf *unionFind) Find(v ast.Value) (*unionFindRoot, bool) {
 
-	parent, ok := uf.parents[v]
-	if !ok {
+	parent := uf.parents.Get(v)
+	if parent == nil {
 		return nil, false
 	}
 
-	if parent == v {
-		return uf.roots[v], true
+	if parent.Compare(v) == 0 {
+		r, ok := uf.roots.Get(v)
+		return r.(*unionFindRoot), ok
 	}
 
 	return uf.Find(parent)
 }
 
-func (uf *unionFind) Merge(a, b ast.Var) (*unionFindRoot, bool) {
+func (uf *unionFind) Merge(a, b ast.Value) (*unionFindRoot, bool) {
 
 	r1 := uf.MakeSet(a)
 	r2 := uf.MakeSet(b)
@@ -57,8 +68,8 @@ func (uf *unionFind) Merge(a, b ast.Var) (*unionFindRoot, bool) {
 
 		r1, r2 = uf.rank(r1, r2)
 
-		uf.parents[r2.key] = r1.key
-		delete(uf.roots, r2.key)
+		uf.parents.Put(r2.key, r1.key)
+		uf.roots.Delete(r2.key)
 
 		// Sets can have at most one constant value associated with them. When
 		// unioning, we must preserve this invariant. If a set has two constants,
@@ -73,12 +84,40 @@ func (uf *unionFind) Merge(a, b ast.Var) (*unionFindRoot, bool) {
 	return r1, true
 }
 
+func (uf *unionFind) String() string {
+	o := struct {
+		Roots   map[string]interface{}
+		Parents map[string]ast.Value
+	}{
+		map[string]interface{}{},
+		map[string]ast.Value{},
+	}
+
+	uf.roots.Iter(func(k util.T, v util.T) bool {
+		o.Roots[k.(ast.Value).String()] = struct {
+			Constant *ast.Term
+			Key      ast.Value
+		}{
+			v.(*unionFindRoot).constant,
+			v.(*unionFindRoot).key,
+		}
+		return true
+	})
+
+	uf.parents.Iter(func(k ast.Value, v ast.Value) bool {
+		o.Parents[k.String()] = v
+		return true
+	})
+
+	return string(util.MustMarshalJSON(o))
+}
+
 type unionFindRoot struct {
-	key      ast.Var
+	key      ast.Value
 	constant *ast.Term
 }
 
-func newUnionFindRoot(key ast.Var) *unionFindRoot {
+func newUnionFindRoot(key ast.Value) *unionFindRoot {
 	return &unionFindRoot{
 		key: key,
 	}
@@ -89,4 +128,8 @@ func (r *unionFindRoot) Value() ast.Value {
 		return r.constant.Value
 	}
 	return r.key
+}
+
+func (r *unionFindRoot) String() string {
+	return fmt.Sprintf("{key: %s, constant: %s", r.key, r.constant)
 }

--- a/topdown/copypropagation/unionfind_test.go
+++ b/topdown/copypropagation/unionfind_test.go
@@ -52,46 +52,35 @@ func TestUnionFindMakeSet(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		v       ast.Var
+		v       ast.Value
 		result  *unionFindRoot
-		parents map[ast.Var]ast.Var
-		roots   map[ast.Var]*unionFindRoot
+		parents map[ast.Value]ast.Value
+		roots   map[ast.Value]*unionFindRoot
 	}{
 		{
 			name:   "from empty",
 			v:      ast.Var("a"),
 			result: &unionFindRoot{key: ast.Var("a")},
-			parents: map[ast.Var]ast.Var{
-				ast.Var("a"): ast.Var("a"),
-			},
-			roots: map[ast.Var]*unionFindRoot{
-				ast.Var("a"): {key: ast.Var("a")},
-			},
 		},
 		{
 			name:   "add another var",
 			v:      ast.Var("b"),
 			result: &unionFindRoot{key: ast.Var("b")},
-			parents: map[ast.Var]ast.Var{
-				ast.Var("a"): ast.Var("a"),
-				ast.Var("b"): ast.Var("b"),
-			},
-			roots: map[ast.Var]*unionFindRoot{
-				ast.Var("a"): {key: ast.Var("a")},
-				ast.Var("b"): {key: ast.Var("b")},
-			},
 		},
 		{
 			name:   "add existing",
 			v:      ast.Var("b"),
 			result: &unionFindRoot{key: ast.Var("b")},
-			parents: map[ast.Var]ast.Var{
-				ast.Var("a"): ast.Var("a"),
-				ast.Var("b"): ast.Var("b"),
-			},
-			roots: map[ast.Var]*unionFindRoot{
-				ast.Var("b"): {key: ast.Var("b")},
-			},
+		},
+		{
+			name:   "add ref",
+			v:      ast.Ref{ast.StringTerm("foo")},
+			result: &unionFindRoot{key: ast.Ref{ast.StringTerm("foo")}},
+		},
+		{
+			name:   "add ref existing",
+			v:      ast.Ref{ast.StringTerm("foo")},
+			result: &unionFindRoot{key: ast.Ref{ast.StringTerm("foo")}},
 		},
 	}
 	for _, tc := range tests {
@@ -100,172 +89,109 @@ func TestUnionFindMakeSet(t *testing.T) {
 			if !reflect.DeepEqual(actual, tc.result) {
 				t.Errorf("MakeSet(%v) = %v, expected %v", tc.v, actual, tc.result)
 			}
-			if !reflect.DeepEqual(tc.parents, uf.parents) {
-				t.Errorf("uf.parents = %v, expected %v", uf.parents, tc.parents)
-			}
-			if !reflect.DeepEqual(tc.parents, uf.parents) {
-				t.Errorf("uf.roots = %v, expected %v", uf.roots, tc.roots)
-			}
 		})
 	}
 }
 
-func TestUnionFindFind(t *testing.T) {
-	tests := []struct {
-		name          string
-		uf            *unionFind
-		v             ast.Var
-		expectedRoot  *unionFindRoot
-		expectedFound bool
-	}{
-		{
-			name:          "empty uf",
-			uf:            newUnionFind(nil),
-			v:             ast.Var("a"),
-			expectedRoot:  nil,
-			expectedFound: false,
-		},
-		{
-			name: "is parent",
-			uf: &unionFind{
-				parents: map[ast.Var]ast.Var{
-					ast.Var("a"): ast.Var("a"),
-				},
-				roots: map[ast.Var]*unionFindRoot{
-					ast.Var("a"): newUnionFindRoot("a"),
-				},
-			},
-			v:             ast.Var("a"),
-			expectedRoot:  newUnionFindRoot("a"),
-			expectedFound: true,
-		},
-		{
-			name: "find parent",
-			uf: &unionFind{
-				parents: map[ast.Var]ast.Var{
-					ast.Var("a"): ast.Var("b"),
-					ast.Var("b"): ast.Var("c"),
-					ast.Var("c"): ast.Var("d"),
-					ast.Var("d"): ast.Var("d"),
-				},
-				roots: map[ast.Var]*unionFindRoot{
-					ast.Var("d"): newUnionFindRoot("d"),
-				},
-			},
-			v:             ast.Var("a"),
-			expectedRoot:  newUnionFindRoot("d"),
-			expectedFound: true,
-		},
+func TestUnionFindFindEmptyUF(t *testing.T) {
+	uf := newUnionFind(noopUnionFindRank)
+	actual, found := uf.Find(ast.Var("a"))
+	if found || actual != nil {
+		t.Error("Expected Find() to return (nil, false)")
 	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+}
 
-			actualRoot, actualFound := tc.uf.Find(tc.v)
-			if !reflect.DeepEqual(actualRoot, tc.expectedRoot) || actualFound != tc.expectedFound {
-				t.Errorf("Find(%v) got = (%v, %v), expected (%v, %v)", tc.v, actualRoot, actualFound, tc.expectedRoot, tc.expectedFound)
-			}
-		})
+func TestUnionFindFindIsParent(t *testing.T) {
+	uf := newUnionFind(noopUnionFindRank)
+
+	uf.MakeSet(ast.Var("a")) // "a" will have a parent "a"
+
+	actual, found := uf.Find(ast.Var("a"))
+
+	expected := newUnionFindRoot(ast.Var("a"))
+	if !found || actual.Value().Compare(expected.Value()) != 0 {
+		t.Errorf("Expected Find() to return (true, %+v)", expected)
+	}
+}
+
+func TestUnionFindFindParent(t *testing.T) {
+	fooBarRef := ast.Ref{ast.StringTerm("foo"), ast.StringTerm("bar"), ast.VarTerm("x")}
+	call := ast.Call{ast.RefTerm(ast.VarTerm("gt")), ast.NumberTerm("1"), ast.VarTerm("x")}
+
+	uf := newUnionFind(noopUnionFindRank)
+	uf.Merge(ast.Var("a"), ast.Var("b"))
+	uf.Merge(ast.Var("b"), ast.Var("c"))
+	uf.Merge(ast.Var("c"), fooBarRef)
+	uf.Merge(fooBarRef, ast.Var("d"))
+	uf.Merge(ast.Var("d"), call)
+	uf.Merge(call, ast.Var("e"))
+
+	actual, found := uf.Find(ast.Var("e"))
+
+	expected := newUnionFindRoot(ast.Var("a"))
+	if !found || actual.Value().Compare(expected.Value()) != 0 {
+		t.Errorf("Expected Find() to return (true, %+v)", expected)
 	}
 }
 
 func TestUnionFindMerge(t *testing.T) {
-	uf := newUnionFind(func(a *unionFindRoot, b *unionFindRoot) (*unionFindRoot, *unionFindRoot) {
-		return a, b
-	})
+	uf := newUnionFind(noopUnionFindRank)
 
 	tests := []struct {
 		name    string
-		a       ast.Var
-		b       ast.Var
+		a       ast.Value
+		b       ast.Value
 		result  *unionFindRoot
-		parents map[ast.Var]ast.Var
-		roots   map[ast.Var]*unionFindRoot
+		parents map[ast.Value]ast.Value
+		roots   map[ast.Value]*unionFindRoot
 	}{
 		{
 			name:   "empty uf",
 			a:      ast.Var("a"),
 			b:      ast.Var("b"),
-			result: newUnionFindRoot("a"),
-			parents: map[ast.Var]ast.Var{
-				ast.Var("a"): ast.Var("a"),
-				ast.Var("b"): ast.Var("a"),
-			},
-			roots: map[ast.Var]*unionFindRoot{
-				ast.Var("a"): {key: ast.Var("a")},
-			},
+			result: newUnionFindRoot(ast.Var("a")),
 		},
 		{
 			name:   "same values",
 			a:      ast.Var("a"),
 			b:      ast.Var("a"),
-			result: newUnionFindRoot("a"),
-			parents: map[ast.Var]ast.Var{
-				ast.Var("a"): ast.Var("a"),
-				ast.Var("b"): ast.Var("a"),
-			},
-			roots: map[ast.Var]*unionFindRoot{
-				ast.Var("a"): {key: ast.Var("a")},
-			},
+			result: newUnionFindRoot(ast.Var("a")),
 		},
 		{
 			name:   "same values higher rank result",
 			a:      ast.Var("b"),
 			b:      ast.Var("b"),
-			result: newUnionFindRoot("a"),
-			parents: map[ast.Var]ast.Var{
-				ast.Var("a"): ast.Var("a"),
-				ast.Var("b"): ast.Var("a"),
-			},
-			roots: map[ast.Var]*unionFindRoot{
-				ast.Var("a"): {key: ast.Var("a")},
-			},
+			result: newUnionFindRoot(ast.Var("a")),
 		},
 		{
 			name:   "transitive",
 			a:      ast.Var("b"),
 			b:      ast.Var("c"),
-			result: newUnionFindRoot("a"),
-			parents: map[ast.Var]ast.Var{
-				ast.Var("a"): ast.Var("a"),
-				ast.Var("b"): ast.Var("a"),
-				ast.Var("c"): ast.Var("a"),
-			},
-			roots: map[ast.Var]*unionFindRoot{
-				ast.Var("a"): {key: ast.Var("a")},
-			},
+			result: newUnionFindRoot(ast.Var("a")),
 		},
 		{
 			name:   "new roots",
 			a:      ast.Var("d"),
 			b:      ast.Var("e"),
-			result: newUnionFindRoot("d"),
-			parents: map[ast.Var]ast.Var{
-				ast.Var("a"): ast.Var("a"),
-				ast.Var("b"): ast.Var("a"),
-				ast.Var("c"): ast.Var("a"),
-				ast.Var("d"): ast.Var("d"),
-				ast.Var("e"): ast.Var("d"),
-			},
-			roots: map[ast.Var]*unionFindRoot{
-				ast.Var("a"): {key: ast.Var("a")},
-				ast.Var("d"): {key: ast.Var("d")},
-			},
+			result: newUnionFindRoot(ast.Var("d")),
 		},
 		{
 			name:   "combine roots",
 			a:      ast.Var("a"),
 			b:      ast.Var("e"),
-			result: newUnionFindRoot("a"),
-			parents: map[ast.Var]ast.Var{
-				ast.Var("a"): ast.Var("a"),
-				ast.Var("b"): ast.Var("a"),
-				ast.Var("c"): ast.Var("a"),
-				ast.Var("d"): ast.Var("a"),
-				ast.Var("e"): ast.Var("d"),
-			},
-			roots: map[ast.Var]*unionFindRoot{
-				ast.Var("a"): {key: ast.Var("a")},
-			},
+			result: newUnionFindRoot(ast.Var("a")),
+		},
+		{
+			name:   "new ref roots",
+			a:      ast.Ref{ast.StringTerm("foo"), ast.StringTerm("bar")},
+			b:      ast.Var("x"),
+			result: newUnionFindRoot(ast.Ref{ast.StringTerm("foo"), ast.StringTerm("bar")}),
+		},
+		{
+			name:   "combine ref roots",
+			a:      ast.Var("b"),
+			b:      ast.Ref{ast.StringTerm("foo"), ast.StringTerm("bar")},
+			result: newUnionFindRoot(ast.Var("a")),
 		},
 	}
 	for _, tc := range tests {
@@ -274,12 +200,10 @@ func TestUnionFindMerge(t *testing.T) {
 			if !reflect.DeepEqual(actualRoot, tc.result) || !canMerge {
 				t.Errorf("Merge(%v, %v) got = (%v, %v), expected (%v, true)", tc.a, tc.b, actualRoot, canMerge, tc.result)
 			}
-			if !reflect.DeepEqual(tc.parents, uf.parents) {
-				t.Errorf("uf.parents = %v, expected %v", uf.parents, tc.parents)
-			}
-			if !reflect.DeepEqual(tc.parents, uf.parents) {
-				t.Errorf("uf.roots = %v, expected %v", uf.roots, tc.roots)
-			}
 		})
 	}
+}
+
+var noopUnionFindRank = func(a *unionFindRoot, b *unionFindRoot) (*unionFindRoot, *unionFindRoot) {
+	return a, b
 }

--- a/topdown/copypropagation/unionfind_test.go
+++ b/topdown/copypropagation/unionfind_test.go
@@ -1,0 +1,285 @@
+// Copyright 2020 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package copypropagation
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/open-policy-agent/opa/ast"
+)
+
+func TestUnionFindRootValue(t *testing.T) {
+	tests := []struct {
+		name     string
+		root     unionFindRoot
+		expected ast.Value
+	}{
+		{
+			name:     "var only",
+			root:     unionFindRoot{key: ast.Var("foo")},
+			expected: ast.Var("foo"),
+		},
+		{
+			name:     "const only",
+			root:     unionFindRoot{constant: ast.StringTerm("foo")},
+			expected: ast.String("foo"),
+		},
+		{
+			name:     "const and var",
+			root:     unionFindRoot{key: ast.Var("foo"), constant: ast.StringTerm("bar")},
+			expected: ast.String("bar"),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &unionFindRoot{
+				key:      tc.root.key,
+				constant: tc.root.constant,
+			}
+			if got := r.Value(); tc.expected.Compare(got) != 0 {
+				t.Errorf("Value() = %v, expected %v", got, tc.expected)
+			}
+		})
+	}
+}
+
+func TestUnionFindMakeSet(t *testing.T) {
+
+	uf := newUnionFind(nil)
+
+	tests := []struct {
+		name    string
+		v       ast.Var
+		result  *unionFindRoot
+		parents map[ast.Var]ast.Var
+		roots   map[ast.Var]*unionFindRoot
+	}{
+		{
+			name:   "from empty",
+			v:      ast.Var("a"),
+			result: &unionFindRoot{key: ast.Var("a")},
+			parents: map[ast.Var]ast.Var{
+				ast.Var("a"): ast.Var("a"),
+			},
+			roots: map[ast.Var]*unionFindRoot{
+				ast.Var("a"): {key: ast.Var("a")},
+			},
+		},
+		{
+			name:   "add another var",
+			v:      ast.Var("b"),
+			result: &unionFindRoot{key: ast.Var("b")},
+			parents: map[ast.Var]ast.Var{
+				ast.Var("a"): ast.Var("a"),
+				ast.Var("b"): ast.Var("b"),
+			},
+			roots: map[ast.Var]*unionFindRoot{
+				ast.Var("a"): {key: ast.Var("a")},
+				ast.Var("b"): {key: ast.Var("b")},
+			},
+		},
+		{
+			name:   "add existing",
+			v:      ast.Var("b"),
+			result: &unionFindRoot{key: ast.Var("b")},
+			parents: map[ast.Var]ast.Var{
+				ast.Var("a"): ast.Var("a"),
+				ast.Var("b"): ast.Var("b"),
+			},
+			roots: map[ast.Var]*unionFindRoot{
+				ast.Var("b"): {key: ast.Var("b")},
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := uf.MakeSet(tc.v)
+			if !reflect.DeepEqual(actual, tc.result) {
+				t.Errorf("MakeSet(%v) = %v, expected %v", tc.v, actual, tc.result)
+			}
+			if !reflect.DeepEqual(tc.parents, uf.parents) {
+				t.Errorf("uf.parents = %v, expected %v", uf.parents, tc.parents)
+			}
+			if !reflect.DeepEqual(tc.parents, uf.parents) {
+				t.Errorf("uf.roots = %v, expected %v", uf.roots, tc.roots)
+			}
+		})
+	}
+}
+
+func TestUnionFindFind(t *testing.T) {
+	tests := []struct {
+		name          string
+		uf            *unionFind
+		v             ast.Var
+		expectedRoot  *unionFindRoot
+		expectedFound bool
+	}{
+		{
+			name:          "empty uf",
+			uf:            newUnionFind(nil),
+			v:             ast.Var("a"),
+			expectedRoot:  nil,
+			expectedFound: false,
+		},
+		{
+			name: "is parent",
+			uf: &unionFind{
+				parents: map[ast.Var]ast.Var{
+					ast.Var("a"): ast.Var("a"),
+				},
+				roots: map[ast.Var]*unionFindRoot{
+					ast.Var("a"): newUnionFindRoot("a"),
+				},
+			},
+			v:             ast.Var("a"),
+			expectedRoot:  newUnionFindRoot("a"),
+			expectedFound: true,
+		},
+		{
+			name: "find parent",
+			uf: &unionFind{
+				parents: map[ast.Var]ast.Var{
+					ast.Var("a"): ast.Var("b"),
+					ast.Var("b"): ast.Var("c"),
+					ast.Var("c"): ast.Var("d"),
+					ast.Var("d"): ast.Var("d"),
+				},
+				roots: map[ast.Var]*unionFindRoot{
+					ast.Var("d"): newUnionFindRoot("d"),
+				},
+			},
+			v:             ast.Var("a"),
+			expectedRoot:  newUnionFindRoot("d"),
+			expectedFound: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+
+			actualRoot, actualFound := tc.uf.Find(tc.v)
+			if !reflect.DeepEqual(actualRoot, tc.expectedRoot) || actualFound != tc.expectedFound {
+				t.Errorf("Find(%v) got = (%v, %v), expected (%v, %v)", tc.v, actualRoot, actualFound, tc.expectedRoot, tc.expectedFound)
+			}
+		})
+	}
+}
+
+func TestUnionFindMerge(t *testing.T) {
+	uf := newUnionFind(func(a *unionFindRoot, b *unionFindRoot) (*unionFindRoot, *unionFindRoot) {
+		return a, b
+	})
+
+	tests := []struct {
+		name    string
+		a       ast.Var
+		b       ast.Var
+		result  *unionFindRoot
+		parents map[ast.Var]ast.Var
+		roots   map[ast.Var]*unionFindRoot
+	}{
+		{
+			name:   "empty uf",
+			a:      ast.Var("a"),
+			b:      ast.Var("b"),
+			result: newUnionFindRoot("a"),
+			parents: map[ast.Var]ast.Var{
+				ast.Var("a"): ast.Var("a"),
+				ast.Var("b"): ast.Var("a"),
+			},
+			roots: map[ast.Var]*unionFindRoot{
+				ast.Var("a"): {key: ast.Var("a")},
+			},
+		},
+		{
+			name:   "same values",
+			a:      ast.Var("a"),
+			b:      ast.Var("a"),
+			result: newUnionFindRoot("a"),
+			parents: map[ast.Var]ast.Var{
+				ast.Var("a"): ast.Var("a"),
+				ast.Var("b"): ast.Var("a"),
+			},
+			roots: map[ast.Var]*unionFindRoot{
+				ast.Var("a"): {key: ast.Var("a")},
+			},
+		},
+		{
+			name:   "same values higher rank result",
+			a:      ast.Var("b"),
+			b:      ast.Var("b"),
+			result: newUnionFindRoot("a"),
+			parents: map[ast.Var]ast.Var{
+				ast.Var("a"): ast.Var("a"),
+				ast.Var("b"): ast.Var("a"),
+			},
+			roots: map[ast.Var]*unionFindRoot{
+				ast.Var("a"): {key: ast.Var("a")},
+			},
+		},
+		{
+			name:   "transitive",
+			a:      ast.Var("b"),
+			b:      ast.Var("c"),
+			result: newUnionFindRoot("a"),
+			parents: map[ast.Var]ast.Var{
+				ast.Var("a"): ast.Var("a"),
+				ast.Var("b"): ast.Var("a"),
+				ast.Var("c"): ast.Var("a"),
+			},
+			roots: map[ast.Var]*unionFindRoot{
+				ast.Var("a"): {key: ast.Var("a")},
+			},
+		},
+		{
+			name:   "new roots",
+			a:      ast.Var("d"),
+			b:      ast.Var("e"),
+			result: newUnionFindRoot("d"),
+			parents: map[ast.Var]ast.Var{
+				ast.Var("a"): ast.Var("a"),
+				ast.Var("b"): ast.Var("a"),
+				ast.Var("c"): ast.Var("a"),
+				ast.Var("d"): ast.Var("d"),
+				ast.Var("e"): ast.Var("d"),
+			},
+			roots: map[ast.Var]*unionFindRoot{
+				ast.Var("a"): {key: ast.Var("a")},
+				ast.Var("d"): {key: ast.Var("d")},
+			},
+		},
+		{
+			name:   "combine roots",
+			a:      ast.Var("a"),
+			b:      ast.Var("e"),
+			result: newUnionFindRoot("a"),
+			parents: map[ast.Var]ast.Var{
+				ast.Var("a"): ast.Var("a"),
+				ast.Var("b"): ast.Var("a"),
+				ast.Var("c"): ast.Var("a"),
+				ast.Var("d"): ast.Var("a"),
+				ast.Var("e"): ast.Var("d"),
+			},
+			roots: map[ast.Var]*unionFindRoot{
+				ast.Var("a"): {key: ast.Var("a")},
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			actualRoot, canMerge := uf.Merge(tc.a, tc.b)
+			if !reflect.DeepEqual(actualRoot, tc.result) || !canMerge {
+				t.Errorf("Merge(%v, %v) got = (%v, %v), expected (%v, true)", tc.a, tc.b, actualRoot, canMerge, tc.result)
+			}
+			if !reflect.DeepEqual(tc.parents, uf.parents) {
+				t.Errorf("uf.parents = %v, expected %v", uf.parents, tc.parents)
+			}
+			if !reflect.DeepEqual(tc.parents, uf.parents) {
+				t.Errorf("uf.roots = %v, expected %v", uf.roots, tc.roots)
+			}
+		})
+	}
+}


### PR DESCRIPTION
In copy propogation we ran into issues where an expression was negated
and required a variable in it to show up in a non-negated expression
to be safe. We had the binding for the var and could have created it
but there were two issues:

1) We didn't resolve the variable binding for refs in negated
   expressions. This left the "wrong" thing in the result.

2) Once we had the unified representation for the value in the result
   we needed to ensure that not only was the binding contained in the
   result somewhere, but it needed to appear in a non-negated
   expression.

The copy propagation code will then add an equality expression for
bindings that are left over and that are not safely contained in the
result. However, we don't always need the full equality expression.

If the key isn't found anywhere in the result we don't need the lhs of
the equality. We are essentially adding a variable that will be
ignored when all we care is that the rhs is defined. So now we will
only generate an expression for the rhs in those cases.

Fixes: #2045
Signed-off-by: Patrick East <east.patrick@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
