### PR TITLE
Update downloader's Etag based on bundle activation

### DIFF
--- a/docs/content/management.md
+++ b/docs/content/management.md
@@ -214,9 +214,13 @@ and data from multiple sources, you can implement your bundle service
 to generate bundles that are scoped to a subset of OPA's policy and
 data cache.
 
-> We recommend that whenever possible, you implement policy and data
+> 🚨 We recommend that whenever possible, you implement policy and data
 > aggregation centrally, however, in some cases that's not possible
-> (e.g., due to latency requirements.)
+> (e.g., due to latency requirements.).
+> When using multiple sources there are **no** ordering guarantees for which bundle loads first and
+  takes over some root. If multiple bundles conflict, but are loaded at different
+  times, OPA may go into an error state. It is highly recommended to use
+  the health check and include bundle state: [Monitoring OPA](../monitoring#health-checks)
 
 To scope bundles to a subset of OPA's policy and data cache, include
 a top-level `roots` key in the bundle that defines the roots of the
@@ -252,11 +256,6 @@ When OPA loads scoped bundles, it validates that:
 
 If bundle validation fails, OPA will report the validation error via
 the Status API.
-
-> **Warning!** There are *no* ordering guarantees for which bundle loads first and
-  takes over some root. If multiple bundles conflict, but are loaded at different
-  times, OPA may go into an error state. It is highly recommended to use
-  the health check and include bundle state: [Monitoring OPA](#health-checks)
 
 ### Debugging Your Bundles
 

--- a/download/download.go
+++ b/download/download.go
@@ -73,6 +73,11 @@ func (d *Downloader) WithLogAttrs(attrs [][2]string) *Downloader {
 	return d
 }
 
+// ClearCache resets the etag value on the downloader
+func (d *Downloader) ClearCache() {
+	d.etag = ""
+}
+
 // Start tells the Downloader to begin downloading bundles.
 func (d *Downloader) Start(ctx context.Context) {
 	go d.loop()
@@ -125,11 +130,11 @@ func (d *Downloader) oneShot(ctx context.Context) error {
 	m := metrics.New()
 	b, etag, err := d.download(ctx, m)
 
+	d.etag = etag
+
 	if d.f != nil {
 		d.f(ctx, Update{ETag: etag, Bundle: b, Error: err, Metrics: m})
 	}
-
-	d.etag = etag
 
 	return err
 }

--- a/plugins/bundle/plugin.go
+++ b/plugins/bundle/plugin.go
@@ -291,6 +291,7 @@ func (p *Plugin) process(ctx context.Context, name string, u download.Update) {
 	if u.Error != nil {
 		p.logError(name, "Bundle download failed: %v", u.Error)
 		p.status[name].SetError(u.Error)
+		p.downloaders[name].ClearCache()
 		return
 	}
 
@@ -305,6 +306,7 @@ func (p *Plugin) process(ctx context.Context, name string, u download.Update) {
 		if err := p.activate(ctx, name, u.Bundle); err != nil {
 			p.logError(name, "Bundle activation failed: %v", err)
 			p.status[name].SetError(err)
+			p.downloaders[name].ClearCache()
 			return
 		}
 

--- a/plugins/discovery/discovery.go
+++ b/plugins/discovery/discovery.go
@@ -134,6 +134,7 @@ func (c *Discovery) processUpdate(ctx context.Context, u download.Update) {
 	if u.Error != nil {
 		c.logError("Discovery download failed: %v", u.Error)
 		c.status.SetError(u.Error)
+		c.downloader.ClearCache()
 		return
 	}
 
@@ -143,6 +144,7 @@ func (c *Discovery) processUpdate(ctx context.Context, u download.Update) {
 		if err := c.reconfigure(ctx, u); err != nil {
 			c.logError("Discovery reconfiguration error occurred: %v", err)
 			c.status.SetError(err)
+			c.downloader.ClearCache()
 			return
 		}
 


### PR DESCRIPTION
This change updates how the Etag on the downloader object is set. See the commit message for more details.

Fixes #2220
Fixes #2279

Signed-off-by: Ashutosh Narkar <anarkar4387@gmail.com> 
<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
