### PR TITLE
plugins: Add support to specify bearer token path

### DIFF
--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -232,12 +232,13 @@ itself to the service.
 #### Bearer token
 
 OPA will authenticate using the specified bearer token and schema; to enable bearer token
-authentication, the token must be specified. The schema is optional and will default to `Bearer`
+authentication, either the token or the path to the token must be specified. The schema is optional and will default to `Bearer`
 if unspecified.
 
 | Field | Type | Required | Description |
 | --- | --- | --- | --- |
 | `services[_].credentials.bearer.token` | `string` | Yes | Enables token-based authentication and supplies the bearer token to authenticate with. |
+| `services[_].credentials.bearer.token_path` | `string` | Yes | Enables token-based authentication and supplies the path to the bearer token to authenticate with. |
 | `services[_].credentials.bearer.scheme` | `string` | No | Bearer token scheme to specify. |
 
 #### Client TLS certificate


### PR DESCRIPTION
This change updates the bearer token config to allow clients to specify
a path to the token. With this refreshing tokens becomes easier as OPA
will now reload the token from file.

Fixes #2241

Signed-off-by: Ashutosh Narkar <anarkar4387@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
