### PR TITLE
metrics: Include Add(uint64) on Counter object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Backwards Compatibility
+
+* The `github.com/open-policy-agent/opa/metrics#Counter` interface has been extended
+to require an `Add(uint64)` function. This change only affects users that have implemented
+their own version of the `github.com/open-policy-agent/opa/metrics#Metrics` interface
+(which is the factory for counters.)
+
 ## 0.19.1
 
 ### Fixes
@@ -127,6 +134,7 @@ ParseBasicABACModule-16                 36.5k ± 0%      0.7k ± 0%  -98.09%  (p
 - topdown: Improve pretty trace location details ([#2143](https://github.com/open-policy-agent/opa/issues/2143))
 - topdown: Include HTTP response headers in `http.send` output ([#2238](https://github.com/open-policy-agent/opa/issues/2238))
 - [Multiple](https://github.com/open-policy-agent/opa/commit/3eeb09c3e83749aff31e15bdfff5d82f3224c102) [important](https://github.com/open-policy-agent/opa/commit/29d8fbbef6facc96d03be3e07473d12e38acd843) [improvements](https://github.com/open-policy-agent/opa/commit/c5c85795aaa3701763f98d16308c5944f05f3da4) [to `http.send()`](https://github.com/open-policy-agent/opa/commit/ce92d19f655efffd6bda26006a2f4898cbdb69ed) [thanks to](https://github.com/open-policy-agent/opa/commit/351a7313df35e8de9e9474fd56a1a905cd51e0c1)  @jpeach
+
 ### Miscellaneous
 
 - [Added `man` target in the Makefile for `man` page generation!](https://github.com/open-policy-agent/opa/commit/4c81aa75c05e4dd69408b9c879be40f9f4369a2c) (thanks to @olivierlemasle)
@@ -134,10 +142,6 @@ ParseBasicABACModule-16                 36.5k ± 0%      0.7k ± 0%  -98.09%  (p
 - [Added link to Emacs mode for Rego](https://github.com/psibi/rego-mode) (thanks to @psibi)
 - [Added net.cidr_contains_matches built-in function](https://github.com/open-policy-agent/opa/pull/2221/commits/6ae4ed9e6578ffb272604a79b1ef9a944cda7782)
 - [Improved support for registering custom built-in functions](https://github.com/open-policy-agent/opa/blob/84b61c647a0d76e62043d6f52510411e8b00d2f0/docs/content/extensions.md)
-
-
-### Miscellaneous
-
 
 ## 0.18.0
 

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -267,6 +267,7 @@ func (h *histogram) Value() interface{} {
 type Counter interface {
 	Value() interface{}
 	Incr()
+	Add(n uint64)
 }
 
 type counter struct {
@@ -275,6 +276,10 @@ type counter struct {
 
 func (c *counter) Incr() {
 	atomic.AddUint64(&c.c, 1)
+}
+
+func (c *counter) Add(n uint64) {
+	atomic.AddUint64(&c.c, n)
 }
 
 func (c *counter) Value() interface{} {


### PR DESCRIPTION
This change is not backwards compatible but it is only a minor
inconvience for anyone who has re-implemented metrics.Metrics (which
feels highly unlikely anyway.)

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
