### PR TITLE
cmd/fmt: Only list files if there were changes

### DIFF
--- a/cmd/fmt.go
+++ b/cmd/fmt.go
@@ -19,11 +19,13 @@ import (
 	fileurl "github.com/open-policy-agent/opa/internal/file/url"
 )
 
-var fmtParams = struct {
+type fmtCommandParams struct {
 	overwrite bool
 	list      bool
 	diff      bool
-}{}
+}
+
+var fmtParams = fmtCommandParams{}
 
 var formatCommand = &cobra.Command{
 	Use:   "fmt [path [...]]",
@@ -67,8 +69,10 @@ func opaFmt(args []string) int {
 			fmt.Fprintln(os.Stderr, err)
 			return 1
 		}
-
-		if err := filepath.Walk(filename, formatFile); err != nil {
+		err = filepath.Walk(filename, func(path string, info os.FileInfo, err error) error {
+			return formatFile(&fmtParams, os.Stdout, path, info, err)
+		})
+		if err != nil {
 			switch err := err.(type) {
 			case fmtError:
 				fmt.Fprintln(os.Stderr, err.msg)
@@ -83,7 +87,7 @@ func opaFmt(args []string) int {
 	return 0
 }
 
-func formatFile(filename string, info os.FileInfo, err error) error {
+func formatFile(params *fmtCommandParams, out io.Writer, filename string, info os.FileInfo, err error) error {
 	if err != nil {
 		return err
 	}
@@ -106,26 +110,29 @@ func formatFile(filename string, info os.FileInfo, err error) error {
 		return newError("failed to parse Rego source file: %v", err)
 	}
 
-	var out io.Writer = os.Stdout
-	if fmtParams.list {
-		fmt.Fprintln(out, filename)
-		out = ioutil.Discard
-	}
+	changed := !bytes.Equal(contents, formatted)
 
-	if fmtParams.diff {
-		stdout, stderr, err := doDiff(contents, formatted)
-		if err != nil && stdout.Len() == 0 {
-			fmt.Fprintln(os.Stderr, stderr.String())
-			return newError("failed to diff formatting: %v", err)
+	if params.list {
+		if changed {
+			fmt.Fprintln(out, filename)
 		}
-
-		fmt.Fprintln(out, stdout.String())
-
-		// If we called diff, we shouldn't output to stdout.
-		out = ioutil.Discard
+		return nil
 	}
 
-	if fmtParams.overwrite {
+	if params.diff {
+		if changed {
+			stdout, stderr, err := doDiff(contents, formatted)
+			if err != nil && stdout.Len() == 0 {
+				fmt.Fprintln(os.Stderr, stderr.String())
+				return newError("failed to diff formatting: %v", err)
+			}
+
+			fmt.Fprintln(out, stdout.String())
+		}
+		return nil
+	}
+
+	if params.overwrite {
 		outfile, err := os.OpenFile(filename, os.O_WRONLY|os.O_TRUNC, info.Mode().Perm())
 		if err != nil {
 			return newError("failed to open file for writing: %v", err)
@@ -159,10 +166,6 @@ func formatStdin(r io.Reader, w io.Writer) error {
 }
 
 func doDiff(old, new []byte) (stdout, stderr bytes.Buffer, err error) {
-	if bytes.Equal(old, new) {
-		return stdout, stderr, nil
-	}
-
 	o, err := ioutil.TempFile("", ".opafmt")
 	if err != nil {
 		return stdout, stderr, err

--- a/cmd/fmt_test.go
+++ b/cmd/fmt_test.go
@@ -1,0 +1,155 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/open-policy-agent/opa/util/test"
+)
+
+func TestFmtFormatFile(t *testing.T) {
+	params := fmtCommandParams{}
+	var stdout bytes.Buffer
+
+	unformatted := `
+	package test
+	
+	p { a == 1; true
+		1 +    3
+	}
+
+	
+	`
+
+	formatted := `package test
+
+p {
+	a == 1
+	true
+	1 + 3
+}
+`
+
+	files := map[string]string{
+		"policy.rego": unformatted,
+	}
+
+	test.WithTempFS(files, func(path string) {
+		policyFile := filepath.Join(path, "policy.rego")
+		info, err := os.Stat(policyFile)
+		err = formatFile(&params, &stdout, policyFile, info, err)
+		if err != nil {
+			t.Fatalf("Unexpected error: %s", err)
+		}
+
+		actual := stdout.String()
+		if actual != formatted {
+			t.Fatalf("Expected:%s\n\nGot:\n%s\n\n", formatted, actual)
+		}
+	})
+}
+
+func TestFmtFormatFileNoChanges(t *testing.T) {
+	params := fmtCommandParams{}
+	var stdout bytes.Buffer
+
+	policyContent := `package test
+
+p {
+	a == 1
+	true
+	1 + 3
+}
+`
+
+	files := map[string]string{
+		"policy.rego": policyContent,
+	}
+
+	test.WithTempFS(files, func(path string) {
+		policyFile := filepath.Join(path, "policy.rego")
+		info, err := os.Stat(policyFile)
+		err = formatFile(&params, &stdout, policyFile, info, err)
+		if err != nil {
+			t.Fatalf("Unexpected error: %s", err)
+		}
+
+		actual := stdout.String()
+		if actual != policyContent {
+			t.Fatalf("Expected:%s\n\nGot:\n%s\n\n", policyContent, actual)
+		}
+	})
+}
+
+func TestFmtFormatFileDiff(t *testing.T) {
+	params := fmtCommandParams{
+		diff: true,
+	}
+	var stdout bytes.Buffer
+
+	policyContent := `package test
+
+p {
+	a == 1
+	true
+	1 + 3
+}
+`
+
+	files := map[string]string{
+		"policy.rego": policyContent,
+	}
+
+	test.WithTempFS(files, func(path string) {
+		policyFile := filepath.Join(path, "policy.rego")
+		info, err := os.Stat(policyFile)
+		err = formatFile(&params, &stdout, policyFile, info, err)
+		if err != nil {
+			t.Fatalf("Unexpected error: %s", err)
+		}
+
+		actual := stdout.String()
+
+		if len(actual) > 0 {
+			t.Fatalf("Expected no output, got:\n%s\n\n", actual)
+		}
+	})
+}
+
+func TestFmtFormatFileList(t *testing.T) {
+	params := fmtCommandParams{
+		list: true,
+	}
+	var stdout bytes.Buffer
+
+	policyContent := `package test
+
+p {
+	a == 1
+	true
+	1 + 3
+}
+`
+
+	files := map[string]string{
+		"policy.rego": policyContent,
+	}
+
+	test.WithTempFS(files, func(path string) {
+		policyFile := filepath.Join(path, "policy.rego")
+		info, err := os.Stat(policyFile)
+		err = formatFile(&params, &stdout, policyFile, info, err)
+		if err != nil {
+			t.Fatalf("Unexpected error: %s", err)
+		}
+
+		actual := strings.TrimSpace(stdout.String())
+
+		if len(actual) > 0 {
+			t.Fatalf("Expected no output, got:\n%s\n\n", actual)
+		}
+	})
+}


### PR DESCRIPTION
Fixes an issue introduced in https://github.com/open-policy-agent/opa/pull/2249
where we would now always list the filename, regardless of whether or
not the file had changes.

This corrects the behavior to only do it when there are changes in the
formatted output and the original content.

Fixes: #2295
Signed-off-by: Patrick East <east.patrick@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
