### PR TITLE
topdown/copypropagation: Refactor and fix for safety of resulting queries

### DIFF
--- a/ast/compile_test.go
+++ b/ast/compile_test.go
@@ -63,9 +63,10 @@ func TestOutputVarsForNode(t *testing.T) {
 			exp:   `set()`,
 		},
 		{
-			note:  "built-ins",
-			query: `count([1,2,3], x)`,
-			exp:   "{x}",
+			note:    "built-ins",
+			query:   `count([1,2,3], x)`,
+			exp:     "{x}",
+			arities: map[string]int{"count": 1},
 		},
 		{
 			note:  "built-ins - input args",
@@ -201,7 +202,7 @@ func TestOutputVarsForNode(t *testing.T) {
 
 			vs := NewSet()
 
-			for v := range outputVarsForBody(body, BuiltinMap, arity, safe) {
+			for v := range outputVarsForBody(body, arity, safe) {
 				vs.Add(NewTerm(v))
 			}
 

--- a/topdown/copypropagation/copypropagation.go
+++ b/topdown/copypropagation/copypropagation.go
@@ -63,8 +63,9 @@ func (p *CopyPropagator) Apply(query ast.Body) (result ast.Body) {
 	}
 
 	// Compute set of vars that appear in the head of refs in the query. If a var
-	// is dereferenced, we cannot plug it with a constant value so the constant on
-	// the union-find root must be unset (e.g., [1][0] is not legal.)
+	// is dereferenced, we can plug it with a constant value, but it is not always
+	// optimal to do so.
+	// TODO: Improve the algorithm for when we should plug constants/calls/etc
 	headvars := ast.NewVarSet()
 	ast.WalkRefs(query, func(x ast.Ref) bool {
 		if v, ok := x[0].Value.(ast.Var); ok {
@@ -78,15 +79,15 @@ func (p *CopyPropagator) Apply(query ast.Body) (result ast.Body) {
 		return false
 	})
 
-	bindings := map[ast.Value]*binding{}
+	removedEqs := ast.NewValueMap()
 
 	for _, expr := range query {
 
 		pctx := &plugContext{
-			bindings: bindings,
-			uf:       uf,
-			negated:  expr.Negated,
-			headvars: headvars,
+			removedEqs: removedEqs,
+			uf:         uf,
+			negated:    expr.Negated,
+			headvars:   headvars,
 		}
 
 		if expr, keep := p.plugBindings(pctx, expr); keep {
@@ -104,7 +105,7 @@ func (p *CopyPropagator) Apply(query ast.Body) (result ast.Body) {
 	// from being added to the result. For example:
 	//
 	// - Given the following result: <empty>
-	// - Given the following bindings: x/input.x and y/input
+	// - Given the following removed equalities: "x = input.x" and "y = input"
 	// - Given the following liveset: {x}
 	//
 	// If this step were to run AFTER the following step, the output would be:
@@ -116,8 +117,8 @@ func (p *CopyPropagator) Apply(query ast.Body) (result ast.Body) {
 		if root, ok := uf.Find(v); ok {
 			if root.constant != nil {
 				result.Append(ast.Equality.Expr(ast.NewTerm(v), root.constant))
-			} else if b, ok := bindings[root.key]; ok {
-				result.Append(ast.Equality.Expr(ast.NewTerm(v), ast.NewTerm(b.v)))
+			} else if b := removedEqs.Get(root.key); b != nil {
+				result.Append(ast.Equality.Expr(ast.NewTerm(v), ast.NewTerm(b)))
 			} else if root.key != v {
 				result.Append(ast.Equality.Expr(ast.NewTerm(v), ast.NewTerm(root.key)))
 			}
@@ -132,8 +133,8 @@ func (p *CopyPropagator) Apply(query ast.Body) (result ast.Body) {
 	// killed we initialize the binding counter to zero and then increment it each
 	// time the binding is substituted. if the binding was never substituted it
 	// means the binding value must be added back into the query.
-	for _, b := range sortbindings(bindings) {
-		if !b.containedIn(result) {
+	for _, b := range sortbindings(removedEqs) {
+		if !containedIn(b.v, result) {
 			result.Append(ast.Equality.Expr(ast.NewTerm(b.k), ast.NewTerm(b.v)))
 		}
 	}
@@ -154,7 +155,7 @@ func (p *CopyPropagator) plugBindings(pctx *plugContext, expr *ast.Expr) (*ast.E
 	if term, ok := expr.Terms.(*ast.Term); ok {
 		if v, ok := term.Value.(ast.Var); ok {
 			if root, ok := pctx.uf.Find(v); ok {
-				if _, ok := pctx.bindings[root.key]; ok {
+				if b := pctx.removedEqs.Get(root.key); b != nil {
 					return nil, false
 				}
 			}
@@ -205,9 +206,9 @@ func (t bindingPlugTransform) plugBindingsVar(pctx *plugContext, v ast.Var) (res
 
 	// Apply binding list to substitute remaining vars.
 	if v, ok := result.(ast.Var); ok {
-		if b, ok := pctx.bindings[v]; ok {
-			if !pctx.negated || b.v.IsGround() {
-				result = b.v
+		if b := pctx.removedEqs.Get(v); b != nil {
+			if !pctx.negated || b.IsGround() {
+				result = b
 			}
 		}
 	}
@@ -226,11 +227,16 @@ func (t bindingPlugTransform) plugBindingsRef(pctx *plugContext, v ast.Ref) ast.
 
 	// Refs require special handling. If the head of the ref was killed, then
 	// the rest of the ref must be concatenated with the new base.
-	//
-	// Invariant: ref heads can only be replaced by refs (not calls).
-	if b, ok := pctx.bindings[v[0].Value.(ast.Var)]; ok {
-		if !pctx.negated || b.v.IsGround() {
-			result = b.v.(ast.Ref).Concat(v[1:])
+	if b := pctx.removedEqs.Get(v[0].Value); b != nil {
+		if !pctx.negated || b.IsGround() {
+			var base ast.Ref
+			switch x := b.(type) {
+			case ast.Ref:
+				base = x
+			default:
+				base = ast.Ref{ast.NewTerm(x)}
+			}
+			result = base.Concat(v[1:])
 		}
 	}
 
@@ -251,7 +257,7 @@ func (p *CopyPropagator) updateBindings(pctx *plugContext, expr *ast.Expr) bool 
 		k, v, keep := p.updateBindingsEq(a, b)
 		if !keep {
 			if v != nil {
-				pctx.bindings[k] = newbinding(k, v)
+				pctx.removedEqs.Put(k, v)
 			}
 			return false
 		}
@@ -259,7 +265,7 @@ func (p *CopyPropagator) updateBindings(pctx *plugContext, expr *ast.Expr) bool 
 		terms := expr.Terms.([]*ast.Term)
 		output := terms[len(terms)-1]
 		if k, ok := output.Value.(ast.Var); ok && !p.livevars.Contains(k) && !pctx.headvars.Contains(k) {
-			pctx.bindings[k] = newbinding(k, ast.CallTerm(terms[:len(terms)-1]...).Value)
+			pctx.removedEqs.Put(k, ast.CallTerm(terms[:len(terms)-1]...).Value)
 			return false
 		}
 	}
@@ -289,10 +295,10 @@ func (p *CopyPropagator) updateBindingsEqAsymmetric(a, b *ast.Term) (ast.Var, as
 }
 
 type plugContext struct {
-	bindings map[ast.Value]*binding
-	uf       *unionFind
-	headvars ast.VarSet
-	negated  bool
+	removedEqs *ast.ValueMap
+	uf         *unionFind
+	headvars   ast.VarSet
+	negated    bool
 }
 
 type binding struct {
@@ -300,15 +306,11 @@ type binding struct {
 	v ast.Value
 }
 
-func newbinding(k ast.Var, v ast.Value) *binding {
-	return &binding{k: k, v: v}
-}
-
-func (b *binding) containedIn(query ast.Body) bool {
+func containedIn(value ast.Value, x interface{}) bool {
 	var stop bool
-	switch v := b.v.(type) {
+	switch v := value.(type) {
 	case ast.Ref:
-		ast.WalkRefs(query, func(other ast.Ref) bool {
+		ast.WalkRefs(x, func(other ast.Ref) bool {
 			if stop || other.HasPrefix(v) {
 				stop = true
 				return stop
@@ -316,7 +318,7 @@ func (b *binding) containedIn(query ast.Body) bool {
 			return false
 		})
 	default:
-		ast.WalkTerms(query, func(other *ast.Term) bool {
+		ast.WalkTerms(x, func(other *ast.Term) bool {
 			if stop || other.Value.Compare(v) == 0 {
 				stop = true
 				return stop
@@ -327,11 +329,12 @@ func (b *binding) containedIn(query ast.Body) bool {
 	return stop
 }
 
-func sortbindings(bindings map[ast.Value]*binding) []*binding {
-	sorted := make([]*binding, 0, len(bindings))
-	for _, b := range bindings {
-		sorted = append(sorted, b)
-	}
+func sortbindings(bindings *ast.ValueMap) []*binding {
+	sorted := make([]*binding, 0, bindings.Len())
+	bindings.Iter(func(k ast.Value, v ast.Value) bool {
+		sorted = append(sorted, &binding{k, v})
+		return false
+	})
 	sort.Slice(sorted, func(i, j int) bool {
 		return sorted[i].k.Compare(sorted[j].k) < 0
 	})

--- a/topdown/copypropagation/copypropagation.go
+++ b/topdown/copypropagation/copypropagation.go
@@ -70,7 +70,7 @@ func (p *CopyPropagator) Apply(query ast.Body) (result ast.Body) {
 		if v, ok := x[0].Value.(ast.Var); ok {
 			if root, ok := uf.Find(v); ok {
 				root.constant = nil
-				headvars.Add(root.key)
+				headvars.Add(root.key.(ast.Var))
 			} else {
 				headvars.Add(v)
 			}
@@ -78,7 +78,7 @@ func (p *CopyPropagator) Apply(query ast.Body) (result ast.Body) {
 		return false
 	})
 
-	bindings := map[ast.Var]*binding{}
+	bindings := map[ast.Value]*binding{}
 
 	for _, expr := range query {
 
@@ -218,7 +218,7 @@ func (t bindingPlugTransform) plugBindingsVar(pctx *plugContext, v ast.Var) (res
 func (t bindingPlugTransform) plugBindingsRef(pctx *plugContext, v ast.Ref) ast.Ref {
 
 	// Apply union-find to remove redundant variables from input.
-	if root, ok := pctx.uf.Find(v[0].Value.(ast.Var)); ok {
+	if root, ok := pctx.uf.Find(v[0].Value); ok {
 		v[0].Value = root.Value()
 	}
 
@@ -289,14 +289,14 @@ func (p *CopyPropagator) updateBindingsEqAsymmetric(a, b *ast.Term) (ast.Var, as
 }
 
 type plugContext struct {
-	bindings map[ast.Var]*binding
+	bindings map[ast.Value]*binding
 	uf       *unionFind
 	headvars ast.VarSet
 	negated  bool
 }
 
 type binding struct {
-	k ast.Var
+	k ast.Value
 	v ast.Value
 }
 
@@ -327,7 +327,7 @@ func (b *binding) containedIn(query ast.Body) bool {
 	return stop
 }
 
-func sortbindings(bindings map[ast.Var]*binding) []*binding {
+func sortbindings(bindings map[ast.Value]*binding) []*binding {
 	sorted := make([]*binding, 0, len(bindings))
 	for _, b := range bindings {
 		sorted = append(sorted, b)
@@ -346,7 +346,7 @@ func sortbindings(bindings map[ast.Var]*binding) []*binding {
 // false.
 func makeDisjointSets(livevars ast.VarSet, query ast.Body) (*unionFind, bool) {
 	uf := newUnionFind(func(r1, r2 *unionFindRoot) (*unionFindRoot, *unionFindRoot) {
-		if livevars.Contains(r1.key) {
+		if v, ok := r1.key.(ast.Var); ok && livevars.Contains(v) {
 			return r1, r2
 		}
 		return r2, r1

--- a/topdown/copypropagation/unionfind.go
+++ b/topdown/copypropagation/unionfind.go
@@ -1,0 +1,92 @@
+// Copyright 2020 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package copypropagation
+
+import "github.com/open-policy-agent/opa/ast"
+
+type rankFunc func(*unionFindRoot, *unionFindRoot) (*unionFindRoot, *unionFindRoot)
+
+type unionFind struct {
+	roots   map[ast.Var]*unionFindRoot
+	parents map[ast.Var]ast.Var
+	rank    rankFunc
+}
+func newUnionFind(rank rankFunc) *unionFind {
+	return &unionFind{
+		roots:   map[ast.Var]*unionFindRoot{},
+		parents: map[ast.Var]ast.Var{},
+		rank:    rank,
+	}
+}
+
+func (uf *unionFind) MakeSet(v ast.Var) *unionFindRoot {
+
+	root, ok := uf.Find(v)
+	if ok {
+		return root
+	}
+
+	root = newUnionFindRoot(v)
+	uf.parents[v] = v
+	uf.roots[v] = root
+	return uf.roots[v]
+}
+
+func (uf *unionFind) Find(v ast.Var) (*unionFindRoot, bool) {
+
+	parent, ok := uf.parents[v]
+	if !ok {
+		return nil, false
+	}
+
+	if parent == v {
+		return uf.roots[v], true
+	}
+
+	return uf.Find(parent)
+}
+
+func (uf *unionFind) Merge(a, b ast.Var) (*unionFindRoot, bool) {
+
+	r1 := uf.MakeSet(a)
+	r2 := uf.MakeSet(b)
+
+	if r1 != r2 {
+
+		r1, r2 = uf.rank(r1, r2)
+
+		uf.parents[r2.key] = r1.key
+		delete(uf.roots, r2.key)
+
+		// Sets can have at most one constant value associated with them. When
+		// unioning, we must preserve this invariant. If a set has two constants,
+		// there will be no way to prove the query.
+		if r1.constant != nil && r2.constant != nil && !r1.constant.Equal(r2.constant) {
+			return nil, false
+		} else if r1.constant == nil {
+			r1.constant = r2.constant
+		}
+	}
+
+	return r1, true
+}
+
+type unionFindRoot struct {
+	key      ast.Var
+	constant *ast.Term
+}
+
+func newUnionFindRoot(key ast.Var) *unionFindRoot {
+	return &unionFindRoot{
+		key: key,
+	}
+}
+
+func (r *unionFindRoot) Value() ast.Value {
+	if r.constant != nil {
+		return r.constant.Value
+	}
+	return r.key
+}

--- a/topdown/copypropagation/unionfind.go
+++ b/topdown/copypropagation/unionfind.go
@@ -4,24 +4,34 @@
 
 package copypropagation
 
-import "github.com/open-policy-agent/opa/ast"
+import (
+	"fmt"
+
+	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/util"
+)
 
 type rankFunc func(*unionFindRoot, *unionFindRoot) (*unionFindRoot, *unionFindRoot)
 
 type unionFind struct {
-	roots   map[ast.Var]*unionFindRoot
-	parents map[ast.Var]ast.Var
+	roots   *util.HashMap
+	parents *ast.ValueMap
 	rank    rankFunc
 }
+
 func newUnionFind(rank rankFunc) *unionFind {
 	return &unionFind{
-		roots:   map[ast.Var]*unionFindRoot{},
-		parents: map[ast.Var]ast.Var{},
+		roots: util.NewHashMap(func(a util.T, b util.T) bool {
+			return a.(ast.Value).Compare(b.(ast.Value)) == 0
+		}, func(v util.T) int {
+			return v.(ast.Value).Hash()
+		}),
+		parents: ast.NewValueMap(),
 		rank:    rank,
 	}
 }
 
-func (uf *unionFind) MakeSet(v ast.Var) *unionFindRoot {
+func (uf *unionFind) MakeSet(v ast.Value) *unionFindRoot {
 
 	root, ok := uf.Find(v)
 	if ok {
@@ -29,26 +39,27 @@ func (uf *unionFind) MakeSet(v ast.Var) *unionFindRoot {
 	}
 
 	root = newUnionFindRoot(v)
-	uf.parents[v] = v
-	uf.roots[v] = root
-	return uf.roots[v]
+	uf.parents.Put(v, v)
+	uf.roots.Put(v, root)
+	return root
 }
 
-func (uf *unionFind) Find(v ast.Var) (*unionFindRoot, bool) {
+func (uf *unionFind) Find(v ast.Value) (*unionFindRoot, bool) {
 
-	parent, ok := uf.parents[v]
-	if !ok {
+	parent := uf.parents.Get(v)
+	if parent == nil {
 		return nil, false
 	}
 
-	if parent == v {
-		return uf.roots[v], true
+	if parent.Compare(v) == 0 {
+		r, ok := uf.roots.Get(v)
+		return r.(*unionFindRoot), ok
 	}
 
 	return uf.Find(parent)
 }
 
-func (uf *unionFind) Merge(a, b ast.Var) (*unionFindRoot, bool) {
+func (uf *unionFind) Merge(a, b ast.Value) (*unionFindRoot, bool) {
 
 	r1 := uf.MakeSet(a)
 	r2 := uf.MakeSet(b)
@@ -57,8 +68,8 @@ func (uf *unionFind) Merge(a, b ast.Var) (*unionFindRoot, bool) {
 
 		r1, r2 = uf.rank(r1, r2)
 
-		uf.parents[r2.key] = r1.key
-		delete(uf.roots, r2.key)
+		uf.parents.Put(r2.key, r1.key)
+		uf.roots.Delete(r2.key)
 
 		// Sets can have at most one constant value associated with them. When
 		// unioning, we must preserve this invariant. If a set has two constants,
@@ -73,12 +84,40 @@ func (uf *unionFind) Merge(a, b ast.Var) (*unionFindRoot, bool) {
 	return r1, true
 }
 
+func (uf *unionFind) String() string {
+	o := struct {
+		Roots   map[string]interface{}
+		Parents map[string]ast.Value
+	}{
+		map[string]interface{}{},
+		map[string]ast.Value{},
+	}
+
+	uf.roots.Iter(func(k util.T, v util.T) bool {
+		o.Roots[k.(ast.Value).String()] = struct {
+			Constant *ast.Term
+			Key      ast.Value
+		}{
+			v.(*unionFindRoot).constant,
+			v.(*unionFindRoot).key,
+		}
+		return true
+	})
+
+	uf.parents.Iter(func(k ast.Value, v ast.Value) bool {
+		o.Parents[k.String()] = v
+		return true
+	})
+
+	return string(util.MustMarshalJSON(o))
+}
+
 type unionFindRoot struct {
-	key      ast.Var
+	key      ast.Value
 	constant *ast.Term
 }
 
-func newUnionFindRoot(key ast.Var) *unionFindRoot {
+func newUnionFindRoot(key ast.Value) *unionFindRoot {
 	return &unionFindRoot{
 		key: key,
 	}
@@ -89,4 +128,8 @@ func (r *unionFindRoot) Value() ast.Value {
 		return r.constant.Value
 	}
 	return r.key
+}
+
+func (r *unionFindRoot) String() string {
+	return fmt.Sprintf("{key: %s, constant: %s", r.key, r.constant)
 }

--- a/topdown/copypropagation/unionfind_test.go
+++ b/topdown/copypropagation/unionfind_test.go
@@ -52,46 +52,35 @@ func TestUnionFindMakeSet(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		v       ast.Var
+		v       ast.Value
 		result  *unionFindRoot
-		parents map[ast.Var]ast.Var
-		roots   map[ast.Var]*unionFindRoot
+		parents map[ast.Value]ast.Value
+		roots   map[ast.Value]*unionFindRoot
 	}{
 		{
 			name:   "from empty",
 			v:      ast.Var("a"),
 			result: &unionFindRoot{key: ast.Var("a")},
-			parents: map[ast.Var]ast.Var{
-				ast.Var("a"): ast.Var("a"),
-			},
-			roots: map[ast.Var]*unionFindRoot{
-				ast.Var("a"): {key: ast.Var("a")},
-			},
 		},
 		{
 			name:   "add another var",
 			v:      ast.Var("b"),
 			result: &unionFindRoot{key: ast.Var("b")},
-			parents: map[ast.Var]ast.Var{
-				ast.Var("a"): ast.Var("a"),
-				ast.Var("b"): ast.Var("b"),
-			},
-			roots: map[ast.Var]*unionFindRoot{
-				ast.Var("a"): {key: ast.Var("a")},
-				ast.Var("b"): {key: ast.Var("b")},
-			},
 		},
 		{
 			name:   "add existing",
 			v:      ast.Var("b"),
 			result: &unionFindRoot{key: ast.Var("b")},
-			parents: map[ast.Var]ast.Var{
-				ast.Var("a"): ast.Var("a"),
-				ast.Var("b"): ast.Var("b"),
-			},
-			roots: map[ast.Var]*unionFindRoot{
-				ast.Var("b"): {key: ast.Var("b")},
-			},
+		},
+		{
+			name:   "add ref",
+			v:      ast.Ref{ast.StringTerm("foo")},
+			result: &unionFindRoot{key: ast.Ref{ast.StringTerm("foo")}},
+		},
+		{
+			name:   "add ref existing",
+			v:      ast.Ref{ast.StringTerm("foo")},
+			result: &unionFindRoot{key: ast.Ref{ast.StringTerm("foo")}},
 		},
 	}
 	for _, tc := range tests {
@@ -100,172 +89,109 @@ func TestUnionFindMakeSet(t *testing.T) {
 			if !reflect.DeepEqual(actual, tc.result) {
 				t.Errorf("MakeSet(%v) = %v, expected %v", tc.v, actual, tc.result)
 			}
-			if !reflect.DeepEqual(tc.parents, uf.parents) {
-				t.Errorf("uf.parents = %v, expected %v", uf.parents, tc.parents)
-			}
-			if !reflect.DeepEqual(tc.parents, uf.parents) {
-				t.Errorf("uf.roots = %v, expected %v", uf.roots, tc.roots)
-			}
 		})
 	}
 }
 
-func TestUnionFindFind(t *testing.T) {
-	tests := []struct {
-		name          string
-		uf            *unionFind
-		v             ast.Var
-		expectedRoot  *unionFindRoot
-		expectedFound bool
-	}{
-		{
-			name:          "empty uf",
-			uf:            newUnionFind(nil),
-			v:             ast.Var("a"),
-			expectedRoot:  nil,
-			expectedFound: false,
-		},
-		{
-			name: "is parent",
-			uf: &unionFind{
-				parents: map[ast.Var]ast.Var{
-					ast.Var("a"): ast.Var("a"),
-				},
-				roots: map[ast.Var]*unionFindRoot{
-					ast.Var("a"): newUnionFindRoot("a"),
-				},
-			},
-			v:             ast.Var("a"),
-			expectedRoot:  newUnionFindRoot("a"),
-			expectedFound: true,
-		},
-		{
-			name: "find parent",
-			uf: &unionFind{
-				parents: map[ast.Var]ast.Var{
-					ast.Var("a"): ast.Var("b"),
-					ast.Var("b"): ast.Var("c"),
-					ast.Var("c"): ast.Var("d"),
-					ast.Var("d"): ast.Var("d"),
-				},
-				roots: map[ast.Var]*unionFindRoot{
-					ast.Var("d"): newUnionFindRoot("d"),
-				},
-			},
-			v:             ast.Var("a"),
-			expectedRoot:  newUnionFindRoot("d"),
-			expectedFound: true,
-		},
+func TestUnionFindFindEmptyUF(t *testing.T) {
+	uf := newUnionFind(noopUnionFindRank)
+	actual, found := uf.Find(ast.Var("a"))
+	if found || actual != nil {
+		t.Error("Expected Find() to return (nil, false)")
 	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+}
 
-			actualRoot, actualFound := tc.uf.Find(tc.v)
-			if !reflect.DeepEqual(actualRoot, tc.expectedRoot) || actualFound != tc.expectedFound {
-				t.Errorf("Find(%v) got = (%v, %v), expected (%v, %v)", tc.v, actualRoot, actualFound, tc.expectedRoot, tc.expectedFound)
-			}
-		})
+func TestUnionFindFindIsParent(t *testing.T) {
+	uf := newUnionFind(noopUnionFindRank)
+
+	uf.MakeSet(ast.Var("a")) // "a" will have a parent "a"
+
+	actual, found := uf.Find(ast.Var("a"))
+
+	expected := newUnionFindRoot(ast.Var("a"))
+	if !found || actual.Value().Compare(expected.Value()) != 0 {
+		t.Errorf("Expected Find() to return (true, %+v)", expected)
+	}
+}
+
+func TestUnionFindFindParent(t *testing.T) {
+	fooBarRef := ast.Ref{ast.StringTerm("foo"), ast.StringTerm("bar"), ast.VarTerm("x")}
+	call := ast.Call{ast.RefTerm(ast.VarTerm("gt")), ast.NumberTerm("1"), ast.VarTerm("x")}
+
+	uf := newUnionFind(noopUnionFindRank)
+	uf.Merge(ast.Var("a"), ast.Var("b"))
+	uf.Merge(ast.Var("b"), ast.Var("c"))
+	uf.Merge(ast.Var("c"), fooBarRef)
+	uf.Merge(fooBarRef, ast.Var("d"))
+	uf.Merge(ast.Var("d"), call)
+	uf.Merge(call, ast.Var("e"))
+
+	actual, found := uf.Find(ast.Var("e"))
+
+	expected := newUnionFindRoot(ast.Var("a"))
+	if !found || actual.Value().Compare(expected.Value()) != 0 {
+		t.Errorf("Expected Find() to return (true, %+v)", expected)
 	}
 }
 
 func TestUnionFindMerge(t *testing.T) {
-	uf := newUnionFind(func(a *unionFindRoot, b *unionFindRoot) (*unionFindRoot, *unionFindRoot) {
-		return a, b
-	})
+	uf := newUnionFind(noopUnionFindRank)
 
 	tests := []struct {
 		name    string
-		a       ast.Var
-		b       ast.Var
+		a       ast.Value
+		b       ast.Value
 		result  *unionFindRoot
-		parents map[ast.Var]ast.Var
-		roots   map[ast.Var]*unionFindRoot
+		parents map[ast.Value]ast.Value
+		roots   map[ast.Value]*unionFindRoot
 	}{
 		{
 			name:   "empty uf",
 			a:      ast.Var("a"),
 			b:      ast.Var("b"),
-			result: newUnionFindRoot("a"),
-			parents: map[ast.Var]ast.Var{
-				ast.Var("a"): ast.Var("a"),
-				ast.Var("b"): ast.Var("a"),
-			},
-			roots: map[ast.Var]*unionFindRoot{
-				ast.Var("a"): {key: ast.Var("a")},
-			},
+			result: newUnionFindRoot(ast.Var("a")),
 		},
 		{
 			name:   "same values",
 			a:      ast.Var("a"),
 			b:      ast.Var("a"),
-			result: newUnionFindRoot("a"),
-			parents: map[ast.Var]ast.Var{
-				ast.Var("a"): ast.Var("a"),
-				ast.Var("b"): ast.Var("a"),
-			},
-			roots: map[ast.Var]*unionFindRoot{
-				ast.Var("a"): {key: ast.Var("a")},
-			},
+			result: newUnionFindRoot(ast.Var("a")),
 		},
 		{
 			name:   "same values higher rank result",
 			a:      ast.Var("b"),
 			b:      ast.Var("b"),
-			result: newUnionFindRoot("a"),
-			parents: map[ast.Var]ast.Var{
-				ast.Var("a"): ast.Var("a"),
-				ast.Var("b"): ast.Var("a"),
-			},
-			roots: map[ast.Var]*unionFindRoot{
-				ast.Var("a"): {key: ast.Var("a")},
-			},
+			result: newUnionFindRoot(ast.Var("a")),
 		},
 		{
 			name:   "transitive",
 			a:      ast.Var("b"),
 			b:      ast.Var("c"),
-			result: newUnionFindRoot("a"),
-			parents: map[ast.Var]ast.Var{
-				ast.Var("a"): ast.Var("a"),
-				ast.Var("b"): ast.Var("a"),
-				ast.Var("c"): ast.Var("a"),
-			},
-			roots: map[ast.Var]*unionFindRoot{
-				ast.Var("a"): {key: ast.Var("a")},
-			},
+			result: newUnionFindRoot(ast.Var("a")),
 		},
 		{
 			name:   "new roots",
 			a:      ast.Var("d"),
 			b:      ast.Var("e"),
-			result: newUnionFindRoot("d"),
-			parents: map[ast.Var]ast.Var{
-				ast.Var("a"): ast.Var("a"),
-				ast.Var("b"): ast.Var("a"),
-				ast.Var("c"): ast.Var("a"),
-				ast.Var("d"): ast.Var("d"),
-				ast.Var("e"): ast.Var("d"),
-			},
-			roots: map[ast.Var]*unionFindRoot{
-				ast.Var("a"): {key: ast.Var("a")},
-				ast.Var("d"): {key: ast.Var("d")},
-			},
+			result: newUnionFindRoot(ast.Var("d")),
 		},
 		{
 			name:   "combine roots",
 			a:      ast.Var("a"),
 			b:      ast.Var("e"),
-			result: newUnionFindRoot("a"),
-			parents: map[ast.Var]ast.Var{
-				ast.Var("a"): ast.Var("a"),
-				ast.Var("b"): ast.Var("a"),
-				ast.Var("c"): ast.Var("a"),
-				ast.Var("d"): ast.Var("a"),
-				ast.Var("e"): ast.Var("d"),
-			},
-			roots: map[ast.Var]*unionFindRoot{
-				ast.Var("a"): {key: ast.Var("a")},
-			},
+			result: newUnionFindRoot(ast.Var("a")),
+		},
+		{
+			name:   "new ref roots",
+			a:      ast.Ref{ast.StringTerm("foo"), ast.StringTerm("bar")},
+			b:      ast.Var("x"),
+			result: newUnionFindRoot(ast.Ref{ast.StringTerm("foo"), ast.StringTerm("bar")}),
+		},
+		{
+			name:   "combine ref roots",
+			a:      ast.Var("b"),
+			b:      ast.Ref{ast.StringTerm("foo"), ast.StringTerm("bar")},
+			result: newUnionFindRoot(ast.Var("a")),
 		},
 	}
 	for _, tc := range tests {
@@ -274,12 +200,10 @@ func TestUnionFindMerge(t *testing.T) {
 			if !reflect.DeepEqual(actualRoot, tc.result) || !canMerge {
 				t.Errorf("Merge(%v, %v) got = (%v, %v), expected (%v, true)", tc.a, tc.b, actualRoot, canMerge, tc.result)
 			}
-			if !reflect.DeepEqual(tc.parents, uf.parents) {
-				t.Errorf("uf.parents = %v, expected %v", uf.parents, tc.parents)
-			}
-			if !reflect.DeepEqual(tc.parents, uf.parents) {
-				t.Errorf("uf.roots = %v, expected %v", uf.roots, tc.roots)
-			}
 		})
 	}
+}
+
+var noopUnionFindRank = func(a *unionFindRoot, b *unionFindRoot) (*unionFindRoot, *unionFindRoot) {
+	return a, b
 }

--- a/topdown/copypropagation/unionfind_test.go
+++ b/topdown/copypropagation/unionfind_test.go
@@ -1,0 +1,285 @@
+// Copyright 2020 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package copypropagation
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/open-policy-agent/opa/ast"
+)
+
+func TestUnionFindRootValue(t *testing.T) {
+	tests := []struct {
+		name     string
+		root     unionFindRoot
+		expected ast.Value
+	}{
+		{
+			name:     "var only",
+			root:     unionFindRoot{key: ast.Var("foo")},
+			expected: ast.Var("foo"),
+		},
+		{
+			name:     "const only",
+			root:     unionFindRoot{constant: ast.StringTerm("foo")},
+			expected: ast.String("foo"),
+		},
+		{
+			name:     "const and var",
+			root:     unionFindRoot{key: ast.Var("foo"), constant: ast.StringTerm("bar")},
+			expected: ast.String("bar"),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &unionFindRoot{
+				key:      tc.root.key,
+				constant: tc.root.constant,
+			}
+			if got := r.Value(); tc.expected.Compare(got) != 0 {
+				t.Errorf("Value() = %v, expected %v", got, tc.expected)
+			}
+		})
+	}
+}
+
+func TestUnionFindMakeSet(t *testing.T) {
+
+	uf := newUnionFind(nil)
+
+	tests := []struct {
+		name    string
+		v       ast.Var
+		result  *unionFindRoot
+		parents map[ast.Var]ast.Var
+		roots   map[ast.Var]*unionFindRoot
+	}{
+		{
+			name:   "from empty",
+			v:      ast.Var("a"),
+			result: &unionFindRoot{key: ast.Var("a")},
+			parents: map[ast.Var]ast.Var{
+				ast.Var("a"): ast.Var("a"),
+			},
+			roots: map[ast.Var]*unionFindRoot{
+				ast.Var("a"): {key: ast.Var("a")},
+			},
+		},
+		{
+			name:   "add another var",
+			v:      ast.Var("b"),
+			result: &unionFindRoot{key: ast.Var("b")},
+			parents: map[ast.Var]ast.Var{
+				ast.Var("a"): ast.Var("a"),
+				ast.Var("b"): ast.Var("b"),
+			},
+			roots: map[ast.Var]*unionFindRoot{
+				ast.Var("a"): {key: ast.Var("a")},
+				ast.Var("b"): {key: ast.Var("b")},
+			},
+		},
+		{
+			name:   "add existing",
+			v:      ast.Var("b"),
+			result: &unionFindRoot{key: ast.Var("b")},
+			parents: map[ast.Var]ast.Var{
+				ast.Var("a"): ast.Var("a"),
+				ast.Var("b"): ast.Var("b"),
+			},
+			roots: map[ast.Var]*unionFindRoot{
+				ast.Var("b"): {key: ast.Var("b")},
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := uf.MakeSet(tc.v)
+			if !reflect.DeepEqual(actual, tc.result) {
+				t.Errorf("MakeSet(%v) = %v, expected %v", tc.v, actual, tc.result)
+			}
+			if !reflect.DeepEqual(tc.parents, uf.parents) {
+				t.Errorf("uf.parents = %v, expected %v", uf.parents, tc.parents)
+			}
+			if !reflect.DeepEqual(tc.parents, uf.parents) {
+				t.Errorf("uf.roots = %v, expected %v", uf.roots, tc.roots)
+			}
+		})
+	}
+}
+
+func TestUnionFindFind(t *testing.T) {
+	tests := []struct {
+		name          string
+		uf            *unionFind
+		v             ast.Var
+		expectedRoot  *unionFindRoot
+		expectedFound bool
+	}{
+		{
+			name:          "empty uf",
+			uf:            newUnionFind(nil),
+			v:             ast.Var("a"),
+			expectedRoot:  nil,
+			expectedFound: false,
+		},
+		{
+			name: "is parent",
+			uf: &unionFind{
+				parents: map[ast.Var]ast.Var{
+					ast.Var("a"): ast.Var("a"),
+				},
+				roots: map[ast.Var]*unionFindRoot{
+					ast.Var("a"): newUnionFindRoot("a"),
+				},
+			},
+			v:             ast.Var("a"),
+			expectedRoot:  newUnionFindRoot("a"),
+			expectedFound: true,
+		},
+		{
+			name: "find parent",
+			uf: &unionFind{
+				parents: map[ast.Var]ast.Var{
+					ast.Var("a"): ast.Var("b"),
+					ast.Var("b"): ast.Var("c"),
+					ast.Var("c"): ast.Var("d"),
+					ast.Var("d"): ast.Var("d"),
+				},
+				roots: map[ast.Var]*unionFindRoot{
+					ast.Var("d"): newUnionFindRoot("d"),
+				},
+			},
+			v:             ast.Var("a"),
+			expectedRoot:  newUnionFindRoot("d"),
+			expectedFound: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+
+			actualRoot, actualFound := tc.uf.Find(tc.v)
+			if !reflect.DeepEqual(actualRoot, tc.expectedRoot) || actualFound != tc.expectedFound {
+				t.Errorf("Find(%v) got = (%v, %v), expected (%v, %v)", tc.v, actualRoot, actualFound, tc.expectedRoot, tc.expectedFound)
+			}
+		})
+	}
+}
+
+func TestUnionFindMerge(t *testing.T) {
+	uf := newUnionFind(func(a *unionFindRoot, b *unionFindRoot) (*unionFindRoot, *unionFindRoot) {
+		return a, b
+	})
+
+	tests := []struct {
+		name    string
+		a       ast.Var
+		b       ast.Var
+		result  *unionFindRoot
+		parents map[ast.Var]ast.Var
+		roots   map[ast.Var]*unionFindRoot
+	}{
+		{
+			name:   "empty uf",
+			a:      ast.Var("a"),
+			b:      ast.Var("b"),
+			result: newUnionFindRoot("a"),
+			parents: map[ast.Var]ast.Var{
+				ast.Var("a"): ast.Var("a"),
+				ast.Var("b"): ast.Var("a"),
+			},
+			roots: map[ast.Var]*unionFindRoot{
+				ast.Var("a"): {key: ast.Var("a")},
+			},
+		},
+		{
+			name:   "same values",
+			a:      ast.Var("a"),
+			b:      ast.Var("a"),
+			result: newUnionFindRoot("a"),
+			parents: map[ast.Var]ast.Var{
+				ast.Var("a"): ast.Var("a"),
+				ast.Var("b"): ast.Var("a"),
+			},
+			roots: map[ast.Var]*unionFindRoot{
+				ast.Var("a"): {key: ast.Var("a")},
+			},
+		},
+		{
+			name:   "same values higher rank result",
+			a:      ast.Var("b"),
+			b:      ast.Var("b"),
+			result: newUnionFindRoot("a"),
+			parents: map[ast.Var]ast.Var{
+				ast.Var("a"): ast.Var("a"),
+				ast.Var("b"): ast.Var("a"),
+			},
+			roots: map[ast.Var]*unionFindRoot{
+				ast.Var("a"): {key: ast.Var("a")},
+			},
+		},
+		{
+			name:   "transitive",
+			a:      ast.Var("b"),
+			b:      ast.Var("c"),
+			result: newUnionFindRoot("a"),
+			parents: map[ast.Var]ast.Var{
+				ast.Var("a"): ast.Var("a"),
+				ast.Var("b"): ast.Var("a"),
+				ast.Var("c"): ast.Var("a"),
+			},
+			roots: map[ast.Var]*unionFindRoot{
+				ast.Var("a"): {key: ast.Var("a")},
+			},
+		},
+		{
+			name:   "new roots",
+			a:      ast.Var("d"),
+			b:      ast.Var("e"),
+			result: newUnionFindRoot("d"),
+			parents: map[ast.Var]ast.Var{
+				ast.Var("a"): ast.Var("a"),
+				ast.Var("b"): ast.Var("a"),
+				ast.Var("c"): ast.Var("a"),
+				ast.Var("d"): ast.Var("d"),
+				ast.Var("e"): ast.Var("d"),
+			},
+			roots: map[ast.Var]*unionFindRoot{
+				ast.Var("a"): {key: ast.Var("a")},
+				ast.Var("d"): {key: ast.Var("d")},
+			},
+		},
+		{
+			name:   "combine roots",
+			a:      ast.Var("a"),
+			b:      ast.Var("e"),
+			result: newUnionFindRoot("a"),
+			parents: map[ast.Var]ast.Var{
+				ast.Var("a"): ast.Var("a"),
+				ast.Var("b"): ast.Var("a"),
+				ast.Var("c"): ast.Var("a"),
+				ast.Var("d"): ast.Var("a"),
+				ast.Var("e"): ast.Var("d"),
+			},
+			roots: map[ast.Var]*unionFindRoot{
+				ast.Var("a"): {key: ast.Var("a")},
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			actualRoot, canMerge := uf.Merge(tc.a, tc.b)
+			if !reflect.DeepEqual(actualRoot, tc.result) || !canMerge {
+				t.Errorf("Merge(%v, %v) got = (%v, %v), expected (%v, true)", tc.a, tc.b, actualRoot, canMerge, tc.result)
+			}
+			if !reflect.DeepEqual(tc.parents, uf.parents) {
+				t.Errorf("uf.parents = %v, expected %v", uf.parents, tc.parents)
+			}
+			if !reflect.DeepEqual(tc.parents, uf.parents) {
+				t.Errorf("uf.roots = %v, expected %v", uf.roots, tc.roots)
+			}
+		})
+	}
+}

--- a/topdown/eval.go
+++ b/topdown/eval.go
@@ -463,7 +463,7 @@ func (e *eval) evalNotPartial(iter evalIterator) error {
 	// Run partial evaluation, plugging the result and applying copy propagation to
 	// each result. Since the result may require support, push a new query onto the
 	// save stack to avoid mutating the current save query.
-	p := copypropagation.New(unknowns).WithEnsureNonEmptyBody(true)
+	p := copypropagation.New(unknowns).WithEnsureNonEmptyBody(true).WithCompiler(e.compiler)
 	var savedQueries []ast.Body
 	e.saveStack.PushQuery(nil)
 
@@ -1822,7 +1822,7 @@ func (e evalVirtualPartial) partialEvalSupportRule(iter unifyIterator, rule *ast
 		}
 
 		head := ast.NewHead(rule.Head.Name, key, value)
-		p := copypropagation.New(head.Vars()).WithEnsureNonEmptyBody(true)
+		p := copypropagation.New(head.Vars()).WithEnsureNonEmptyBody(true).WithCompiler(e.e.compiler)
 
 		e.e.saveSupport.Insert(path, &ast.Rule{
 			Head:    head,
@@ -2057,7 +2057,7 @@ func (e evalVirtualComplete) partialEvalSupportRule(iter unifyIterator, rule *as
 		plugged := current.Plug(e.e.caller.bindings)
 
 		head := ast.NewHead(rule.Head.Name, nil, child.bindings.PlugNamespaced(rule.Head.Value, e.e.caller.bindings))
-		p := copypropagation.New(head.Vars()).WithEnsureNonEmptyBody(true)
+		p := copypropagation.New(head.Vars()).WithEnsureNonEmptyBody(true).WithCompiler(e.e.compiler)
 
 		e.e.saveSupport.Insert(path, &ast.Rule{
 			Head:    head,

--- a/topdown/query.go
+++ b/topdown/query.go
@@ -216,7 +216,7 @@ func (q *Query) PartialRun(ctx context.Context) (partials []ast.Body, support []
 		return false
 	})
 
-	p := copypropagation.New(livevars)
+	p := copypropagation.New(livevars).WithCompiler(q.compiler)
 
 	err = e.Run(func(e *eval) error {
 

--- a/topdown/topdown_partial_test.go
+++ b/topdown/topdown_partial_test.go
@@ -1207,6 +1207,41 @@ func TestTopDownPartialEval(t *testing.T) {
 			},
 		},
 		{
+			note:  "copy propagation: negation safety needs extra expr",
+			query: `data.test.p = true`,
+			modules: []string{
+				`package test
+
+				p {
+				  x = data.y[c]
+				  x.z = 1
+				  not x.z = 2
+				}
+				`,
+			},
+			unknowns: []string{`data.y`},
+			wantQueries: []string{
+				`data.y[c1].z = 1; not x1.z = 2; x1 = data.y[c1]`,
+			},
+		},
+		{
+			note:  "copy propagation: negation safety no extra expr",
+			query: `data.test.p = true`,
+			modules: []string{
+				`package test
+
+				p {
+				  x = data.y[c]
+				  not x.z = 2
+				}
+				`,
+			},
+			unknowns: []string{`data.y`},
+			wantQueries: []string{
+				`not x1.z = 2; x1 = data.y[c1]`,
+			},
+		},
+		{
 			note:  "copy propagation: rewrite object key (bug 1177)",
 			query: `data.test.p = true`,
 			modules: []string{

--- a/topdown/topdown_partial_test.go
+++ b/topdown/topdown_partial_test.go
@@ -1752,6 +1752,23 @@ func TestTopDownPartialEval(t *testing.T) {
 			query:       `not input with data.x as 1; data.x = 1`,
 			wantQueries: []string{},
 		},
+		{
+			note:  "multiple removed eqs",
+			query: "data.test.p",
+			modules: []string{`
+				package test
+
+				p = x { 
+					a = input.foo1
+					b = input.foo2
+					c = input.foo3
+					d = input.foo4
+					e = input.foo5
+					x = true
+				}`,
+			},
+			wantQueries: []string{"a1 = input.foo1; b1 = input.foo2; c1 = input.foo3; d1 = input.foo4; e1 = input.foo5"},
+		},
 	}
 
 	ctx := context.Background()


### PR DESCRIPTION
First set of changes are just refactoring which change a couple of things to make the copypropagation code a little more simple/readable/re-usable.

- Split out the unionfind data structure (and add tests for it)
- Add support for any type of ast.Value in the unionfind and copy propagation "bindings"
- Rename "bindings" to something that makes the code easier to understand.

The last commit addresses issue #2045. See the commit message for more details but the high level change is that we check if any removed equality was required for safety of some var in the result. If it is we add it back in the result.

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
