### PR TITLE
Additive updates to services when discovery enabled

### DIFF
--- a/docs/content/management.md
+++ b/docs/content/management.md
@@ -944,6 +944,8 @@ configuration labels or environment variables.
 
 ### Limitations
 
-The discovery feature cannot be used to dynamically modify `services`, `labels`
-and `discovery`. This means that these configuration settings should be included
-in the bootup configuration file provided to OPA.
+In practice, discovery services do not change frequently. These configuration sections are treated as
+immutable to avoid accidental configuration errors rendering OPA unable to discover a new configuration.
+If the discovered configuration changes the `discovery` or `labels` sections,
+those changes are ignored. If the discovered configuration changes the discovery service,
+an error will be logged.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,48 @@
+// Copyright 2020 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+// Package config implements helper functions to parse OPA's configuration.
+package config
+
+import (
+	"encoding/json"
+
+	"github.com/open-policy-agent/opa/plugins/rest"
+	"github.com/open-policy-agent/opa/util"
+)
+
+// ParseServicesConfig returns a set of named service clients. The service
+// clients can be specified either as an array or as a map. Some systems (e.g.,
+// Helm) do not have proper support for configuration values nested under
+// arrays, so just support both here.
+func ParseServicesConfig(raw json.RawMessage) (map[string]rest.Client, error) {
+
+	services := map[string]rest.Client{}
+
+	var arr []json.RawMessage
+	var obj map[string]json.RawMessage
+
+	if err := util.Unmarshal(raw, &arr); err == nil {
+		for _, s := range arr {
+			client, err := rest.New(s)
+			if err != nil {
+				return nil, err
+			}
+			services[client.Service()] = client
+		}
+	} else if util.Unmarshal(raw, &obj) == nil {
+		for k := range obj {
+			client, err := rest.New(obj[k], rest.Name(k))
+			if err != nil {
+				return nil, err
+			}
+			services[client.Service()] = client
+		}
+	} else {
+		// Return error from array decode as that is the default format.
+		return nil, err
+	}
+
+	return services, nil
+}

--- a/plugins/discovery/discovery_test.go
+++ b/plugins/discovery/discovery_test.go
@@ -120,7 +120,7 @@ func TestProcessBundle(t *testing.T) {
 		}
 	`)
 
-	_, ps, err := processBundle(ctx, manager, nil, initialBundle, "data.config", nil)
+	ps, err := processBundle(ctx, manager, nil, initialBundle, "data.config", "default", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -139,7 +139,7 @@ func TestProcessBundle(t *testing.T) {
 		}
 	`)
 
-	_, ps, err = processBundle(ctx, manager, nil, updatedBundle, "data.config", nil)
+	ps, err = processBundle(ctx, manager, nil, updatedBundle, "data.config", "default", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -156,7 +156,7 @@ func TestProcessBundle(t *testing.T) {
 		}
 	`)
 
-	_, _, err = processBundle(ctx, manager, nil, updatedBundle, "data.config", nil)
+	_, err = processBundle(ctx, manager, nil, updatedBundle, "data.config", "default", nil)
 	if err == nil {
 		t.Fatal("Expected error but got success")
 	}
@@ -272,6 +272,227 @@ func TestReconfigure(t *testing.T) {
 		t.Errorf("Expected one plugin start and one reconfig but got %v", testPlugin)
 	}
 
+}
+
+func TestReconfigureWithUpdates(t *testing.T) {
+
+	ctx := context.Background()
+
+	manager, err := plugins.New([]byte(`{
+		"labels": {"x": "y"},
+		"services": {
+			"localhost": {
+				"url": "http://localhost:9999"
+			}
+		},
+		"discovery": {"name": "config"},
+	}`), "test-id", inmem.New())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	disco, err := New(manager)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	initialBundle := makeDataBundle(1, `
+		{
+			"config": {
+				"bundle": {"name": "test1"},
+				"status": {},
+				"decision_logs": {}
+			}
+		}
+	`)
+
+	err = disco.reconfigure(ctx, download.Update{Bundle: initialBundle})
+	if err != nil {
+		t.Fatalf("Unexpected error %v", err)
+	}
+
+	originalConfig := disco.config
+	// update the discovery configuration and check
+	// the boot configuration is not overwritten
+	updatedBundle := makeDataBundle(2, `
+		{
+			"config": {
+				"discovery": {
+					"name": "config",
+					"decision": "/foo/bar"
+				}
+			}
+		}
+	`)
+
+	err = disco.reconfigure(ctx, download.Update{Bundle: updatedBundle})
+	if err != nil {
+		t.Fatalf("Unexpected error %v", err)
+	}
+
+	if !reflect.DeepEqual(originalConfig, disco.config) {
+		t.Fatal("Discovery configuration updated")
+	}
+
+	// no update to the discovery configuration and check no error generated
+	updatedBundle = makeDataBundle(3, `
+		{
+			"config": {
+				"discovery": {
+					"name": "config"
+				}
+			}
+		}
+	`)
+
+	err = disco.reconfigure(ctx, download.Update{Bundle: updatedBundle})
+	if err != nil {
+		t.Fatalf("Unexpected error %v", err)
+	}
+
+	if !reflect.DeepEqual(originalConfig, disco.config) {
+		t.Fatal("Discovery configuration updated")
+	}
+
+	// update the discovery service and check that error generated
+	updatedBundle = makeDataBundle(4, `
+		{
+			"config": {
+				"services": {
+					"localhost": {
+						"url": "http://localhost:9999",
+						"credentials": {"bearer": {"token": "blah"}}
+					}
+				}
+			}
+		}
+	`)
+
+	err = disco.reconfigure(ctx, download.Update{Bundle: updatedBundle})
+	if err == nil {
+		t.Fatal("Expected error but got nil")
+	}
+
+	expectedErrMsg := "updates to the discovery service are not allowed"
+	if err.Error() != expectedErrMsg {
+		t.Fatalf("Expected error message: %v but got: %v", expectedErrMsg, err.Error())
+	}
+
+	// no update to the discovery service and check no error generated
+	updatedBundle = makeDataBundle(5, `
+		{
+			"config": {
+				"services": {
+					"localhost": {
+						"url": "http://localhost:9999"
+					}
+				}
+			}
+		}
+	`)
+
+	err = disco.reconfigure(ctx, download.Update{Bundle: updatedBundle})
+	if err != nil {
+		t.Fatalf("Unexpected error %v", err)
+	}
+
+	// add a new service and a new bundle
+	updatedBundle = makeDataBundle(6, `
+		{
+			"config": {
+				"services": {
+					"acmecorp": {
+						"url": "http://localhost:8181"
+					}
+				},
+				"bundles": {
+					"authz": {
+						"service": "acmecorp"
+					}
+				}
+			}
+		}
+	`)
+
+	err = disco.reconfigure(ctx, download.Update{Bundle: updatedBundle})
+	if err != nil {
+		t.Fatalf("Unexpected error %v", err)
+	}
+
+	if len(disco.manager.Services()) != 2 {
+		t.Fatalf("Expected two services but got %v\n", len(disco.manager.Services()))
+	}
+
+	bPlugin := bundle.Lookup(disco.manager)
+	config := bPlugin.Config()
+	expected := "acmecorp"
+	if config.Bundles["authz"].Service != expected {
+		t.Fatalf("Expected service %v for bundle authz but got %v", expected, config.Bundles["authz"].Service)
+	}
+
+	// update existing bundle's config and add a new bundle
+	updatedBundle = makeDataBundle(7, `
+		{
+			"config": {
+				"bundles": {
+					"authz": {
+						"service": "localhost",
+						"resource": "foo/bar"
+					},
+					"main": {
+						"resource": "baz/bar"
+					}
+				}
+			}
+		}
+	`)
+
+	err = disco.reconfigure(ctx, download.Update{Bundle: updatedBundle})
+	if err != nil {
+		t.Fatalf("Unexpected error %v", err)
+	}
+
+	bPlugin = bundle.Lookup(disco.manager)
+	config = bPlugin.Config()
+	expectedSvc := "localhost"
+	if config.Bundles["authz"].Service != expectedSvc {
+		t.Fatalf("Expected service %v for bundle authz but got %v", expectedSvc, config.Bundles["authz"].Service)
+	}
+
+	expectedRes := "foo/bar"
+	if config.Bundles["authz"].Resource != expectedRes {
+		t.Fatalf("Expected resource %v for bundle authz but got %v", expectedRes, config.Bundles["authz"].Resource)
+	}
+
+	expectedSvcs := map[string]bool{"localhost": true, "acmecorp": true}
+	if _, ok := expectedSvcs[config.Bundles["main"].Service]; !ok {
+		t.Fatalf("Expected service for bundle main to be one of [%v, %v] but got %v", "localhost", "acmecorp", config.Bundles["main"].Service)
+	}
+
+	// update existing (non-discovery)service's config
+	updatedBundle = makeDataBundle(8, `
+		{
+			"config": {
+				"services": {
+					"acmecorp": {
+						"url": "http://localhost:8181",
+						"credentials": {"bearer": {"token": "blah"}}
+						}
+				},
+				"bundles": {
+					"authz": {
+						"service": "localhost",
+						"resource": "foo/bar"
+					}
+				}
+			}
+		}
+	`)
+
+	err = disco.reconfigure(ctx, download.Update{Bundle: updatedBundle})
+	if err != nil {
+		t.Fatalf("Unexpected error %v", err)
+	}
 }
 
 type testServer struct {

--- a/plugins/rest/rest.go
+++ b/plugins/rest/rest.go
@@ -42,6 +42,11 @@ type Config struct {
 	} `json:"credentials"`
 }
 
+// Equal returns true if this client config is equal to the other.
+func (c *Config) Equal(other *Config) bool {
+	return reflect.DeepEqual(c, other)
+}
+
 func (c *Config) authPlugin() (HTTPAuthPlugin, error) {
 	// reflection avoids need for this code to change as auth plugins are added
 	s := reflect.ValueOf(c.Credentials)
@@ -117,6 +122,11 @@ func New(config []byte, opts ...func(*Client)) (Client, error) {
 // Service returns the name of the service this Client is configured for.
 func (c Client) Service() string {
 	return c.config.Name
+}
+
+// Config returns this Client's configuration
+func (c Client) Config() *Config {
+	return &c.config
 }
 
 // WithHeader returns a shallow copy of the client with a header to include the


### PR DESCRIPTION
Earlier with discovery enabled, there was no protection against accidental
changes to the discovery service. This change prevents the discovery service
from being modified by checking it's config in the service bundle.

Fixes #2058


<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
