### PR TITLE
topdown: Fix panic in array.slice due to incorrect clamping

### DIFF
--- a/topdown/array.go
+++ b/topdown/array.go
@@ -49,24 +49,23 @@ func builtinArraySlice(a, i, j ast.Value) (ast.Value, error) {
 		return nil, err
 	}
 
-	// Return empty array if bounds cannot be clamped sensibly.
-	if (startIndex >= stopIndex) || (startIndex <= 0 && stopIndex <= 0) {
-		return arr[0:0], nil
-	}
-
-	// Clamp bounds to avoid out-of-range errors.
-	if startIndex < 0 {
-		startIndex = 0
-	}
-
-	if stopIndex > len(arr) {
+	// Clamp stopIndex to avoid out-of-range errors. If negative, clamp to zero.
+	// Otherwise, clamp to length of array.
+	if stopIndex < 0 {
+		stopIndex = 0
+	} else if stopIndex > len(arr) {
 		stopIndex = len(arr)
 	}
 
-	arrb := arr[startIndex:stopIndex]
+	// Clamp startIndex to avoid out-of-range errors. If negative, clamp to zero.
+	// Otherwise, clamp to stopIndex to avoid to avoid cases like arr[1:0].
+	if startIndex < 0 {
+		startIndex = 0
+	} else if startIndex > stopIndex {
+		startIndex = stopIndex
+	}
 
-	return arrb, nil
-
+	return arr[startIndex:stopIndex], nil
 }
 
 func init() {

--- a/topdown/array_test.go
+++ b/topdown/array_test.go
@@ -25,6 +25,8 @@ func TestTopDownArray(t *testing.T) {
 		{"slice: stopIndex < startIndex", []string{`p = x { x = array.slice([1,2,3,4,5], 4, 1) }`}, "[]"},
 		{"slice: clamp startIndex", []string{`p = x { x = array.slice([1,2,3,4,5], -1, 2) }`}, `[1,2]`},
 		{"slice: clamp stopIndex", []string{`p = x {x = array.slice([1,2,3,4,5], 3, 6) }`}, `[4,5]`},
+		{"slice: clamp both out of range", []string{"p = x { x = array.slice([], 1000, 2000) }"}, `[]`},
+		{"slice: clamp both out of range non-empty", []string{"p = x { x = array.slice([1,2,3], 1000, 2000) }"}, `[]`},
 	}
 
 	data := loadSmallTestData()


### PR DESCRIPTION
The built-in function implemented clamping in an odd way. With this
change, the stopIndex will always be [0, len(arr)] and the startIndex
will always be [0, clamped_stopIndex].

Fixes #2320

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
