### PR TITLE
build: Remove packaging step from build-release.sh

### DIFF
--- a/build/build-release.sh
+++ b/build/build-release.sh
@@ -46,7 +46,6 @@ build_release() {
     GOOS=linux GOARCH=amd64 make build
     GOOS=windows GOARCH=amd64 make build
     mv opa_windows_amd64 opa_windows_amd64.exe
-    build_distro_packages
     mv opa_*_* $OUTPUT_DIR
 }
 
@@ -55,17 +54,6 @@ clone_repo() {
     cd /go/src/github.com/open-policy-agent/opa
     if [ -n "$VERSION" ]; then
         git checkout v${VERSION}
-    fi
-}
-
-build_distro_packages() {
-    if [ -f build/gen-deb.sh ]; then
-        make man
-        # If VERSION is not set, set it to `make version`
-        VERSION=${VERSION:-`make version`} make deb
-        mv opa_*.* $OUTPUT_DIR
-    else
-        echo "Skip building distro packages. Could not find gen-deb.sh."
     fi
 }
 


### PR DESCRIPTION
We will be doing the packaging steps in a separate workflow from the
current one that uses build-release.sh. For now this means just
removing the calls to make the deb file from the script.

Signed-off-by: Patrick East <east.patrick@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
