### PR TITLE
topdown: Fix data race in http.send test case

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ go-build: generate
 
 .PHONY: go-test
 go-test: generate
-	$(GO) test ./...
+	$(GO) test -tags=slow ./...
 
 .PHONY: perf
 perf: generate

--- a/topdown/http_slow_test.go
+++ b/topdown/http_slow_test.go
@@ -1,0 +1,123 @@
+// Copyright 2020 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+// +build slow
+
+package topdown
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestHTTPSendTimeout(t *testing.T) {
+
+	// Each test can tweak the response delay, default is 0 with no delay
+	var responseDelay time.Duration
+
+	tsMtx := sync.Mutex{}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tsMtx.Lock()
+		defer tsMtx.Unlock()
+		time.Sleep(responseDelay)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`hello`))
+	}))
+	// Note: We don't Close() the test server as it will block waiting for the
+	// timed out clients connections to shut down gracefully (they wont).
+	// We don't need to clean it up nicely for the unit test.
+
+	tests := []struct {
+		note           string
+		rule           string
+		input          string
+		defaultTimeout time.Duration
+		evalTimeout    time.Duration
+		serverDelay    time.Duration
+		expected       interface{}
+	}{
+		{
+			note:     "no timeout",
+			rule:     `p = x { http.send({"method": "get", "url": "%URL%" }, resp); x := remove_headers(resp) }`,
+			expected: `{"body": null, "raw_body": "hello", "status": "200 OK", "status_code": 200}`,
+		},
+		{
+			note:           "default timeout",
+			rule:           `p = x { http.send({"method": "get", "url": "%URL%" }, x) }`,
+			evalTimeout:    1 * time.Minute,
+			serverDelay:    5 * time.Second,
+			defaultTimeout: 500 * time.Millisecond,
+			expected:       &Error{Code: BuiltinErr, Message: "request timed out"},
+		},
+		{
+			note:           "eval timeout",
+			rule:           `p = x { http.send({"method": "get", "url": "%URL%" }, x) }`,
+			evalTimeout:    500 * time.Millisecond,
+			serverDelay:    5 * time.Second,
+			defaultTimeout: 1 * time.Minute,
+			expected:       &Error{Code: BuiltinErr, Message: "context deadline exceeded"},
+		},
+		{
+			note:           "param timeout less than default",
+			rule:           `p = x { http.send({"method": "get", "url": "%URL%", "timeout": "500ms"}, x) }`,
+			evalTimeout:    1 * time.Minute,
+			serverDelay:    5 * time.Second,
+			defaultTimeout: 1 * time.Minute,
+			expected:       &Error{Code: BuiltinErr, Message: "request timed out"},
+		},
+		{
+			note:           "param timeout greater than default",
+			rule:           `p = x { http.send({"method": "get", "url": "%URL%", "timeout": "500ms"}, x) }`,
+			evalTimeout:    1 * time.Minute,
+			serverDelay:    5 * time.Second,
+			defaultTimeout: 1 * time.Millisecond,
+			expected:       &Error{Code: BuiltinErr, Message: "request timed out"},
+		},
+		{
+			note:           "eval timeout less than param",
+			rule:           `p = x { http.send({"method": "get", "url": "%URL%", "timeout": "1m" }, x) }`,
+			evalTimeout:    500 * time.Millisecond,
+			serverDelay:    5 * time.Second,
+			defaultTimeout: 1 * time.Minute,
+			expected:       &Error{Code: BuiltinErr, Message: "context deadline exceeded"},
+		},
+	}
+
+	for _, tc := range tests {
+		tsMtx.Lock()
+		responseDelay = tc.serverDelay
+		tsMtx.Unlock()
+
+		ctx := context.Background()
+		var cancel context.CancelFunc
+		if tc.evalTimeout > 0 {
+			ctx, cancel = context.WithTimeout(ctx, tc.evalTimeout)
+		}
+
+		// TODO(patrick-east): Remove this along with the environment variable so that the "default" can't change
+		originalDefaultTimeout := defaultHTTPRequestTimeout
+		if tc.defaultTimeout > 0 {
+			defaultHTTPRequestTimeout = tc.defaultTimeout
+		}
+
+		rule := strings.ReplaceAll(tc.rule, "%URL%", ts.URL)
+		if e, ok := tc.expected.(*Error); ok {
+			e.Message = strings.ReplaceAll(e.Message, "%URL%", ts.URL)
+		}
+
+		runTopDownTestCaseWithContext(ctx, t, map[string]interface{}{}, tc.note, append(httpSendHelperRules, rule), nil, tc.input, tc.expected)
+
+		// Put back the default (may not have changed)
+		defaultHTTPRequestTimeout = originalDefaultTimeout
+		if cancel != nil {
+			cancel()
+		}
+	}
+}


### PR DESCRIPTION
The test case timeout parameters have been lowered by a few orders of
magnitude (but still large relative gaps) becaue otherwise the time
the topdown package jumps to >20s. If we see flakyness in CI we could
look at tagging these as "slow" and then only running them if requested.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
