### PR TITLE
topdown: Fix panic in partial eval test of uuid built-in

### DIFF
--- a/topdown/uuid_test.go
+++ b/topdown/uuid_test.go
@@ -17,7 +17,7 @@ func TestUUIDRFC4122SeedingAndCaching(t *testing.T) {
 
 	query := `uuid.rfc4122("x",x); uuid.rfc4122("y", y); uuid.rfc4122("x",x2)`
 
-	q := NewQuery(ast.MustParseBody(query)).WithSeed(rand.New(rand.NewSource(0)))
+	q := NewQuery(ast.MustParseBody(query)).WithSeed(rand.New(rand.NewSource(0))).WithCompiler(ast.NewCompiler())
 
 	ctx := context.Background()
 
@@ -56,7 +56,7 @@ func TestUUIDRFC4122SeedError(t *testing.T) {
 
 	query := `uuid.rfc4122("x",x)`
 
-	q := NewQuery(ast.MustParseBody(query)).WithSeed(fakeSeedErrorReader{})
+	q := NewQuery(ast.MustParseBody(query)).WithSeed(fakeSeedErrorReader{}).WithCompiler(ast.NewCompiler())
 
 	_, err := q.Run(context.Background())
 
@@ -70,7 +70,7 @@ func TestUUIDRFC4122SavingDuringPartialEval(t *testing.T) {
 
 	query := `foo = "x"; uuid.rfc4122(foo,x)`
 
-	q := NewQuery(ast.MustParseBody(query)).WithSeed(rand.New(rand.NewSource(0)))
+	q := NewQuery(ast.MustParseBody(query)).WithSeed(rand.New(rand.NewSource(0))).WithCompiler(ast.NewCompiler())
 
 	queries, modules, err := q.PartialRun(context.Background())
 	if err != nil {


### PR DESCRIPTION
The recent copy propagation fix requires the compiler during partial
evaluation. In the new uuid built-in function test case, the compiler
was not being provided so it caused a panic.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
