### PR TITLE
Add AWS_SESSION_TOKEN to aws environment credentials

### DIFF
--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -265,6 +265,8 @@ If specifying `environment_credentials`, OPA will expect to find environment var
 for `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_REGION`, in accordance with the
 convention used by the [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html).
 
+Please note that if you are using temporary IAM credentials (e.g. assumed IAM role credentials) you have to provide additional `AWS_SESSION_TOKEN` or `AWS_SECURITY_TOKEN` environment variable.
+
 | Field | Type | Required | Description |
 | --- | --- | --- | --- |
 | `services[_].credentials.s3_signing.environment_credentials` | `{}` | Yes | Enables AWS signing using environment variables to source the configuration and credentials |


### PR DESCRIPTION
AWS_SESSION_TOKEN or AWS_SECURITY_TOKEN is required when signing AWS requests
using ENV credentials from IAM assumed the role. Missing token
results with S3 403 error when trying to download the bundle.

Steps to reproduce the issue:
- Configure service to sign requests using environment variables.
- Instead of using IAM user credentials, assume IAM role and export result credentials.
- Bundle download fails with a 403 error due to missing SecurityToken.

In addition, this fix allows downloading bundles from s3 in AWS Lambda.

Signed-off-by: Kamil Piotrowski <kamil.piotrowski@nordcloud.com>
