### PR TITLE
ast: Fix parser to include body on else if needed

### DIFF
--- a/ast/parser.go
+++ b/ast/parser.go
@@ -394,6 +394,8 @@ func (p *Parser) parseElse(head *Head) *Rule {
 		}
 
 		if p.s.tok != tokens.LBrace {
+			rule.Body = NewBody(NewExpr(BooleanTerm(true)))
+			setLocRecursive(rule.Body, rule.Location)
 			return &rule
 		}
 

--- a/ast/parser_test.go
+++ b/ast/parser_test.go
@@ -1334,7 +1334,7 @@ func TestRuleElseKeyword(t *testing.T) {
 	} else {
 		x != 150
 	}
-	
+
 	_ {
 		x > 0
 	} else {
@@ -1342,6 +1342,14 @@ func TestRuleElseKeyword(t *testing.T) {
 	} else {
 		x > -100
 	}
+
+	nobody = 1 {
+		false
+	} else = 7
+
+	nobody_f(x) = 1 {
+		false
+	} else = 7
 	`
 
 	parsed, err := ParseModule("", mod)
@@ -1430,6 +1438,36 @@ func TestRuleElseKeyword(t *testing.T) {
 						},
 						Body: MustParseBody(`x > -100`),
 					},
+				},
+			},
+			{
+				Head: &Head{
+					Name:  Var("nobody"),
+					Value: IntNumberTerm(1),
+				},
+				Body: MustParseBody("false"),
+				Else: &Rule{
+					Head: &Head{
+						Name:  Var("nobody"),
+						Value: IntNumberTerm(7),
+					},
+					Body: MustParseBody("true"),
+				},
+			},
+			{
+				Head: &Head{
+					Name:  Var("nobody_f"),
+					Args:  Args{VarTerm("x")},
+					Value: IntNumberTerm(1),
+				},
+				Body: MustParseBody("false"),
+				Else: &Rule{
+					Head: &Head{
+						Name:  Var("nobody_f"),
+						Args:  Args{VarTerm("x")},
+						Value: IntNumberTerm(7),
+					},
+					Body: MustParseBody("true"),
 				},
 			},
 		},


### PR DESCRIPTION
In other places where the body can be implied, the parser includes a
body containing a single "true" expression. Do the same for else.

Fixes #2353

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
