### PR TITLE
example_test: use PartialResult instead of PartialEval

### DIFF
--- a/rego/example_test.go
+++ b/rego/example_test.go
@@ -465,7 +465,7 @@ func ExampleRego_PartialResult() {
 		rego.Store(store),
 	)
 
-	pr, err := r.PartialEval(ctx)
+	pr, err := r.PartialResult(ctx)
 	if err != nil {
 		// Handle error.
 	}


### PR DESCRIPTION
Fixes #2294 