### PR TITLE
format: Fix bug in ref formatting

### DIFF
--- a/format/format.go
+++ b/format/format.go
@@ -535,7 +535,7 @@ func (w *writer) writeTermParens(parens bool, term *ast.Term, comments []*ast.Co
 
 func (w *writer) writeRef(x ast.Ref) {
 	if len(x) > 0 {
-		w.write(x[0].Value.String())
+		w.writeTerm(x[0], nil)
 		path := x[1:]
 		for _, p := range path {
 			switch p := p.Value.(type) {

--- a/format/format_test.go
+++ b/format/format_test.go
@@ -243,6 +243,21 @@ input.arr[__wildcard0__].bar = qux
 foo[__wildcard1__][__wildcard0__].bar = bar[__wildcard1__][_][__wildcard0__].bar
 `,
 		},
+		{
+			note: "body shared wildcard - ref head",
+			toFmt: ast.Body{
+				&ast.Expr{
+					Index: 0,
+					Terms: ast.VarTerm("$x"),
+				},
+				&ast.Expr{
+					Index: 1,
+					Terms: ast.RefTerm(ast.VarTerm("$x"), ast.VarTerm("x")),
+				},
+			},
+			expected: `__wildcard0__
+__wildcard0__[x]`,
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
In 954196a6900082f055e1e11ff09f5caa2b3772a2 we fixed format to show
wildcard variable names if needed, however, ref heads were not handled
properly. This commit just modifies the ref printing to ensure that
heads are formatted properly.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
