### PR TITLE
dosc: Use double-quote instead of single-quote in opa eval examples

### DIFF
--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -740,13 +740,13 @@ public_server[server] {                             # a server exists in the pub
 
 ```bash
 # Evaluate a trivial expression.
-./opa eval '1*2+3'
+./opa eval "1*2+3"
 
 # Evaluate a policy on the command line.
-./opa eval -i input.json -d example.rego 'data.example.violation[x]'
+./opa eval -i input.json -d example.rego "data.example.violation[x]"
 
 # Evaluate a policy on the command line and use the exit code.
-./opa eval --fail-defined -i input.json -d example.rego 'data.example.violation[x]'
+./opa eval --fail-defined -i input.json -d example.rego "data.example.violation[x]"
 echo $?
 ```
 


### PR DESCRIPTION
On Windows, cmd.exe does not parse out single-quote characters on the
command line so they get passed through to the parser which bails on
them. Just use double-quote characters to avoid this.

Fixes #2391

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
