### PR TITLE
Add graph.reachable builtin

### DIFF
--- a/ast/builtins.go
+++ b/ast/builtins.go
@@ -179,6 +179,7 @@ var DefaultBuiltins = [...]*Builtin{
 
 	// Graphs
 	WalkBuiltin,
+	ReachableBuiltin,
 
 	// Sort
 	Sort,
@@ -1610,6 +1611,26 @@ var WalkBuiltin = &Builtin{
 			},
 			nil,
 		),
+	),
+}
+
+// ReachableBuiltin computes the set of reachable nodes in the graph from a set
+// of starting nodes.
+var ReachableBuiltin = &Builtin{
+	Name: "graph.reachable",
+	Decl: types.NewFunction(
+		types.Args(
+			types.NewObject(
+				nil,
+				types.NewDynamicProperty(
+					types.A,
+					types.NewAny(
+						types.NewSet(types.A),
+						types.NewArray(nil, types.A)),
+				)),
+			types.NewAny(types.NewSet(types.A), types.NewArray(nil, types.A)),
+		),
+		types.NewSet(types.A),
 	),
 }
 

--- a/docs/content/policy-reference.md
+++ b/docs/content/policy-reference.md
@@ -555,6 +555,39 @@ Note that the opa executable will need access to the timezone files in the envir
 | Built-in | Description |
 | --- | --- |
 | <span class="opa-keep-it-together">``walk(x, [path, value])``</span> | ``walk`` is a relation that produces ``path`` and ``value`` pairs for documents under ``x``. ``path`` is ``array`` representing a pointer to ``value`` in ``x``.  Queries can use ``walk`` to traverse documents nested under ``x`` (recursively). |
+| <span class="opa-keep-it-together">``output := graph.reachable(graph, initial)``</span> | ``output`` is the set of vertices [reachable](https://en.wikipedia.org/wiki/Reachability) from the ``initial`` vertices in the directed ``graph``.  ``initial`` is a set or array of vertices, and ``graph`` is an object containing a set or array of neighboring vertices. |
+
+A common class of recursive rules can be reduced to a graph reachability
+problem, so `graph.reachable` is useful for more than just graph analysis.
+This usually requires some pre- and postprocessing.  The following example
+shows you how to "flatten" a hierarchy of access permissions.
+
+```live:graph/reachable/example:module
+package graph_reachable_example
+
+org_chart_data = {
+  "ceo": {},
+  "human_resources": {"owner": "ceo", "access": ["salaries", "complaints"]},
+  "staffing": {"owner": "human_resources", "access": ["interviews"]},
+  "internships": {"owner": "staffing", "access": ["blog"]}
+}
+
+org_chart_graph[entity_name] = edges {
+  org_chart_data[entity_name]
+  edges := {neighbor | org_chart_data[neighbor].owner == entity_name}
+}
+
+org_chart_permissions[entity_name] = access {
+  org_chart_data[entity_name]
+  reachable := graph.reachable(org_chart_graph, {entity_name})
+  access := {item | reachable[k]; item := org_chart_data[k].access[_]}
+}
+```
+```live:graph/reachable/example:query
+org_chart_permissions[entity_name]
+```
+```live:graph/reachable/example:output
+```
 
 ### HTTP
 

--- a/topdown/reachable.go
+++ b/topdown/reachable.go
@@ -1,0 +1,63 @@
+// Copyright 2020 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package topdown
+
+import (
+	"github.com/open-policy-agent/opa/ast"
+)
+
+// Helper: sets of vertices can be represented as Arrays or Sets.
+func foreachVertex(collection *ast.Term, f func(*ast.Term)) {
+	switch v := collection.Value.(type) {
+	case ast.Set:
+		v.Foreach(f)
+	case ast.Array:
+		for _, t := range v {
+			f(t)
+		}
+	}
+}
+
+func builtinReachable(bctx BuiltinContext, args []*ast.Term, iter func(*ast.Term) error) error {
+	// Return the empty set if the first argument is not an object.
+	graph, ok := args[0].Value.(ast.Object)
+	if !ok {
+		return iter(ast.NewTerm(ast.NewSet()))
+	}
+
+	// This is a queue that holds all nodes we still need to visit.  It is
+	// initialised to the initial set of nodes we start out with.
+	queue := []*ast.Term{}
+	foreachVertex(args[1], func(t *ast.Term) {
+		queue = append(queue, t)
+	})
+
+	// This is the set of nodes we have reached.
+	reached := ast.NewSet()
+
+	// Keep going as long as we have nodes in the queue.
+	for len(queue) > 0 {
+		// Get the edges for this node.  If the node was not in the graph,
+		// `edges` will be `nil` and we can ignore it.
+		node := queue[0]
+		if edges := graph.Get(node); edges != nil {
+			// Add all the newly discovered neighbors.
+			foreachVertex(edges, func(neighbor *ast.Term) {
+				if !reached.Contains(neighbor) {
+					queue = append(queue, neighbor)
+				}
+			})
+			// Mark the node as reached.
+			reached.Add(node)
+		}
+		queue = queue[1:]
+	}
+
+	return iter(ast.NewTerm(reached))
+}
+
+func init() {
+	RegisterBuiltinFunc(ast.ReachableBuiltin.Name, builtinReachable)
+}

--- a/topdown/reachable_test.go
+++ b/topdown/reachable_test.go
@@ -1,0 +1,101 @@
+// Copyright 2020 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package topdown
+
+import (
+	"testing"
+)
+
+func TestReachable(t *testing.T) {
+	data := map[string]interface{}{}
+	modules := []string{}
+	tests := []struct {
+		note     string
+		rules    []string
+		expected interface{}
+		input    string
+	}{
+		{
+			"empty",
+			[]string{`p = x {x := graph.reachable({}, {"a"})}`},
+			`[]`,
+			`{}`,
+		},
+		{
+			"cycle",
+			[]string{
+				`p = x {
+				  x := sort(graph.reachable(
+				    {
+				      "a": {"b"},
+				      "b": {"c"},
+				      "c": {"a"},
+				    },
+				    {"a"}
+				  ))
+				}`},
+			`["a", "b", "c"]`,
+			`{}`,
+		},
+		{
+			"components",
+			[]string{
+				`p = x {
+				  x := sort(graph.reachable(
+				    {
+				      "a": {"b", "c"},
+				      "b": {"d"},
+				      "c": {"d"},
+				      "d": set(),
+				      "e": {"f"},
+				      "f": {"e"},
+				      "x": {"x"},
+				    },
+				    {"b", "e"}
+				  ))
+				}`},
+			`["b", "d", "e", "f"]`,
+			`{}`,
+		},
+		{
+			"arrays",
+			[]string{
+				`p = x {
+				  x := sort(graph.reachable(
+				    {
+				      "a": ["b"],
+				      "b": ["c"],
+				      "c": ["a"],
+				    },
+				    ["a"]
+				  ))
+				}`},
+			`["a", "b", "c"]`,
+			`{}`,
+		},
+		{
+			"malformed 1",
+			[]string{`p = x {x := graph.reachable(input.graph, input.initial)}`},
+			`[]`,
+			`{"graph": 1, "initial": [1]}`,
+		},
+		{
+			"malformed 2",
+			[]string{`p = x {x := graph.reachable(input.graph, input.initial)}`},
+			`["a"]`,
+			`{"graph": {"a": null}, "initial": ["a"]}`,
+		},
+		{
+			"malformed 3",
+			[]string{`p = x {x := graph.reachable(input.graph, input.initial)}`},
+			`[]`,
+			`{"graph": {"a": []}, "initial": "a"}`,
+		},
+	}
+
+	for _, tc := range tests {
+		runTopDownTestCaseWithModules(t, data, tc.note, tc.rules, modules, tc.input, tc.expected)
+	}
+}


### PR DESCRIPTION
This is a first stab at the solution I proposed in #947.

Some questions:

1. `graph.reachable` currently takes sets (an object of sets in the first
    argument, and an initial set in the second argument).  Should this be
    extended so it also accepts arrays?

2.  I am working on `Term`s directly in the actual implementation.  This
    probably has some overhead compared to working on a `map[string]`
    directly; but the downside of the latter is that we'd need constrain
    the graph nodes to strings.

And TODOs:

- [x] Add documentation.