### PR TITLE
docs/website: correct is_token_valid logic on envoy page fixes: #2395

### DIFF
--- a/docs/content/envoy-authorization.md
+++ b/docs/content/envoy-authorization.md
@@ -145,8 +145,9 @@ allow {
 
 is_token_valid {
   token.valid
-  token.payload.nbf <= time.now_ns()
-  time.now_ns() < token.payload.exp
+  now := time.now_ns() / 1000000000
+  token.payload.nbf <= now
+  now < token.payload.exp
 }
 
 action_allowed {


### PR DESCRIPTION
correct is_token_valid logic for envoy example closes #2395
Signed-off-by: Anthony Barbieri <anthonyabarbieri@gmail.com>

