### PR TITLE
cmd: Fix shutdown race in "run" unit tests

### DIFF
--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -13,10 +13,7 @@ import (
 )
 
 func TestRunServerBase(t *testing.T) {
-	params := newRunParams()
-	params.rt.Addrs = &[]string{":0"}
-	params.rt.DiagnosticAddrs = &[]string{}
-	params.serverMode = true
+	params := newTestRunParams()
 	ctx, cancel := context.WithCancel(context.Background())
 
 	rt := initRuntime(ctx, params, nil)
@@ -25,7 +22,10 @@ func TestRunServerBase(t *testing.T) {
 
 	done := make(chan bool)
 	go func() {
-		startRuntime(ctx, rt, true)
+		err := rt.Serve(ctx)
+		if err != nil {
+			t.Errorf("Unexpected error: %s", err)
+		}
 		done <- true
 	}()
 
@@ -41,8 +41,7 @@ func TestRunServerBase(t *testing.T) {
 }
 
 func TestRunServerWithDiagnosticAddr(t *testing.T) {
-	params := newRunParams()
-	params.rt.Addrs = &[]string{":0"}
+	params := newTestRunParams()
 	params.rt.DiagnosticAddrs = &[]string{":0"}
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -52,7 +51,10 @@ func TestRunServerWithDiagnosticAddr(t *testing.T) {
 
 	done := make(chan bool)
 	go func() {
-		startRuntime(ctx, rt, true)
+		err := rt.Serve(ctx)
+		if err != nil {
+			t.Errorf("Unexpected error: %s", err)
+		}
 		done <- true
 	}()
 
@@ -73,6 +75,15 @@ func TestRunServerWithDiagnosticAddr(t *testing.T) {
 
 	cancel()
 	<-done
+}
+
+func newTestRunParams() runCmdParams {
+	params := newRunParams()
+	params.rt.GracefulShutdownPeriod = 1
+	params.rt.Addrs = &[]string{":0"}
+	params.rt.DiagnosticAddrs = &[]string{}
+	params.serverMode = true
+	return params
 }
 
 func validateBasicServe(t *testing.T, runtime *e2e.TestRuntime) {


### PR DESCRIPTION
The server was configured with a 0 second graceful shutdown period
which would periodically cause the shutdown to return an error.

This is corrected to have a 1 second shutdown period (plenty of time
as the tests should _NOT_ have any open client requests when they
finish, if they do they _should_ fail).

In addition we don't let the runtime do an os.Exit(1) on error, we
use the lower level `runtime.Serve()` API and catch the error in the
tests.

Signed-off-by: Patrick East <east.patrick@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
