### PR TITLE
repl: Enable pretty mode to print `true` flag

### DIFF
--- a/repl/repl_test.go
+++ b/repl/repl_test.go
@@ -907,6 +907,44 @@ func TestEvalConstantRule(t *testing.T) {
 	}
 }
 
+func TestEvalBooleanFlags(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore()
+	var buffer bytes.Buffer
+	repl := newRepl(store, &buffer)
+	repl.OneShot(ctx, "flags = [true, true]")
+	repl.OneShot(ctx, "flags[_]")
+	expected := strings.TrimSpace(`
+Rule 'flags' defined in package repl. Type 'show' to see rules.
++----------+
+| flags[_] |
++----------+
+| true     |
+| true     |
++----------+`)
+	result := strings.TrimSpace(buffer.String())
+	if result != expected {
+		t.Errorf("Expected a single column with boolean output but got:\n%v", result)
+	}
+	buffer.Reset()
+
+	repl.OneShot(ctx, `flags2 = [true, "x", 1]`)
+	repl.OneShot(ctx, "flags2[_]")
+	expected = strings.TrimSpace(`
+Rule 'flags2' defined in package repl. Type 'show' to see rules.
++-----------+
+| flags2[_] |
++-----------+
+| true      |
+| "x"       |
+| 1         |
++-----------+`)
+	result = strings.TrimSpace(buffer.String())
+	if result != expected {
+		t.Errorf("Expected a single column with boolean output but got:\n%v", result)
+	}
+}
+
 func TestEvalConstantRuleDefaultRootDoc(t *testing.T) {
 	ctx := context.Background()
 	store := newTestStore()


### PR DESCRIPTION
# Details
As #2338 comments say, current REPL with pretty-printing is not capable to display valid boolean flags.
If a boolean expression has `true` value, the iteration should show them without ignoring.

# Appendix
At first, I tried to print values except for false like @tsandall wrote:
```
> x[_]
+------+
| x[_] |
+------+
| 1    |
| 1    |
+------+
```

However, it may confuse you because the values look like `int`, not `bool`.
So I implemented the function to print a raw `true`.
```
> x[_]
+------+
| x[_] |
+------+
| true |
| true |
+------+
```


Fixes #2338 
Signed-off-by: Seiji Takahashi <timaki.st@gmail.com>