### PR TITLE
Add internal/oracle package for querying ASTs with text locations

### DIFF
--- a/ast/compile.go
+++ b/ast/compile.go
@@ -243,16 +243,14 @@ func NewCompiler() *Compiler {
 		// load additional modules. If any stages run before resolution, they
 		// need to be re-run after resolution.
 		{"ResolveRefs", "compile_stage_resolve_refs", c.resolveAllRefs},
-
+		{"SetModuleTree", "compile_stage_set_module_tree", c.setModuleTree},
+		{"SetRuleTree", "compile_stage_set_rule_tree", c.setRuleTree},
 		// The local variable generator must be initialized after references are
 		// resolved and the dynamic module loader has run but before subsequent
 		// stages that need to generate variables.
 		{"InitLocalVarGen", "compile_stage_init_local_var_gen", c.initLocalVarGen},
-
 		{"RewriteLocalVars", "compile_stage_rewrite_local_vars", c.rewriteLocalVars},
 		{"RewriteExprTerms", "compile_stage_rewrite_expr_terms", c.rewriteExprTerms},
-		{"SetModuleTree", "compile_stage_set_module_tree", c.setModuleTree},
-		{"SetRuleTree", "compile_stage_set_rule_tree", c.setRuleTree},
 		{"SetGraph", "compile_stage_set_graph", c.setGraph},
 		{"RewriteComprehensionTerms", "compile_stage_rewrite_comprehension_terms", c.rewriteComprehensionTerms},
 		{"RewriteRefsInHead", "compile_stage_rewrite_refs_in_head", c.rewriteRefsInHead},

--- a/ast/parser_test.go
+++ b/ast/parser_test.go
@@ -1818,12 +1818,12 @@ func TestLocation(t *testing.T) {
 func TestRuleFromBody(t *testing.T) {
 	testModule := `package a.b.c
 
-pi = 3.14159 { true }
+pi = 3.14159
 p[x] { x = 1 }
-greeting = "hello" { true }
-cores = [{0: 1}, {1: 2}] { true }
-wrapper = cores[0][1] { true }
-pi = [3, 1, 4, x, y, z] { true }
+greeting = "hello"
+cores = [{0: 1}, {1: 2}]
+wrapper = cores[0][1]
+pi = [3, 1, 4, x, y, z]
 foo["bar"] = "buz"
 foo["9"] = "10"
 foo.buz = "bar"
@@ -1860,10 +1860,35 @@ d1 := 1234
 		},
 	})
 
+	// Verify the rule and rule and rule head col/loc values
+	module, err := ParseModule("test.rego", testModule)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for i := range module.Rules {
+		col := module.Rules[i].Location.Col
+		if col != 1 {
+			t.Fatalf("expected rule %v column to be 1 but got %v", module.Rules[i].Head.Name, col)
+		}
+		row := module.Rules[i].Location.Row
+		if row != 3+i { // 'pi' rule stats on row 3
+			t.Fatalf("expected rule %v row to be %v but got %v", module.Rules[i].Head.Name, 3+i, row)
+		}
+		col = module.Rules[i].Head.Location.Col
+		if col != 1 {
+			t.Fatalf("expected rule head %v column to be 1 but got %v", module.Rules[i].Head.Name, col)
+		}
+		row = module.Rules[i].Head.Location.Row
+		if row != 3+i { // 'pi' rule stats on row 3
+			t.Fatalf("expected rule head %v row to be %v but got %v", module.Rules[i].Head.Name, 3+i, row)
+		}
+	}
+
 	mockModule := `package ex
 
-input = {"foo": 1} { true }
-data = {"bar": 2} { true }`
+input = {"foo": 1}
+data = {"bar": 2}`
 
 	assertParseModule(t, "rule name: input/data", mockModule, &Module{
 		Package: MustParsePackage(`package ex`),
@@ -2434,7 +2459,7 @@ func TestParserText(t *testing.T) {
 
 func TestRuleText(t *testing.T) {
 	input := ` package test
-	
+
 r[x] = y {
 	x = input.a
 	x = "foo"
@@ -2445,7 +2470,7 @@ r[x] = y {
 	x = input.c
 	x = "baz"
 }
-	
+
 r[x] = y {
 	x = input.d
 	x = "qux"

--- a/cmd/oracle.go
+++ b/cmd/oracle.go
@@ -1,0 +1,172 @@
+// Copyright 2020 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/bundle"
+	"github.com/open-policy-agent/opa/internal/oracle"
+	"github.com/open-policy-agent/opa/internal/presentation"
+	"github.com/open-policy-agent/opa/loader"
+)
+
+type findDefinitionParams struct {
+	stdinBuffer bool
+	bundlePaths repeatedStringFlag
+}
+
+func init() {
+
+	var findDefinitionParams findDefinitionParams
+
+	var oracleCommand = &cobra.Command{
+		Use:    "oracle",
+		Short:  "Answer questions about Rego",
+		Long:   "Answer questions about Rego.",
+		Hidden: true,
+	}
+
+	var findDefinitionCommand = &cobra.Command{
+		Use:   "find-definition",
+		Short: "Find the location of a definition",
+		Long: `Find the location of a definition.
+
+The 'find-definition' command outputs the location of the definition of the symbol
+or value referred to by the location passed as a positional argument. The location
+should be of the form:
+
+	<filename>:<offset>
+
+The offset can be specified as a decimal or hexadecimal number. The output format
+specifies the file, row, and column of the definition:
+
+	{
+		"result": {
+			"file": "/path/to/some/policy.rego",
+			"row": 18,
+			"col": 1
+		}
+	}
+
+If the 'find-definition' command cannot find a location it will print an error
+reason. The exit status will be zero in this case:
+
+	{
+		"error": "no match found"
+	}
+
+If an unexpected error occurs (e.g., a file read error) the subcommand will print
+the error reason to stderr and exit with a non-zero status code.
+
+If the --stdin-buffer flag is supplied the 'find-definition' subcommand will
+consume stdin and treat the bytes read as the content of the file referenced
+by the input location.`,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 1 {
+				return errors.New("expected exactly one position <filename>:<offset>")
+			}
+			_, _, err := parseFilenameOffset(args[0])
+			return err
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := dofindDefinition(findDefinitionParams, os.Stdin, os.Stdout, args); err != nil {
+				fmt.Fprintln(os.Stderr, "error:", err)
+				os.Exit(1)
+			}
+		},
+	}
+
+	findDefinitionCommand.Flags().BoolVarP(&findDefinitionParams.stdinBuffer, "stdin-buffer", "", false, "read buffer from stdin")
+	addBundleFlag(findDefinitionCommand.Flags(), &findDefinitionParams.bundlePaths)
+	oracleCommand.AddCommand(findDefinitionCommand)
+	RootCommand.AddCommand(oracleCommand)
+}
+
+func dofindDefinition(params findDefinitionParams, stdin io.Reader, stdout io.Writer, args []string) error {
+
+	filename, offset, err := parseFilenameOffset(args[0])
+	if err != nil {
+		return err
+	}
+
+	var b *bundle.Bundle
+
+	if len(params.bundlePaths.v) != 0 {
+		if len(params.bundlePaths.v) > 1 {
+			return errors.New("not implemented: multiple bundle paths")
+		}
+		b, err = loader.NewFileLoader().AsBundle(params.bundlePaths.v[0])
+		if err != nil {
+			return err
+		}
+	}
+
+	modules := map[string]*ast.Module{}
+
+	if b != nil {
+		for _, mf := range b.Modules {
+			modules[mf.Path] = mf.Parsed
+		}
+	}
+
+	var bs []byte
+
+	if params.stdinBuffer {
+		bs, err = ioutil.ReadAll(stdin)
+		if err != nil {
+			return err
+		}
+	}
+
+	result, err := oracle.New().FindDefinition(oracle.DefinitionQuery{
+		Buffer:   bs,
+		Filename: filename,
+		Pos:      offset,
+		Modules:  modules,
+	})
+
+	if err != nil {
+		return presentation.JSON(stdout, map[string]interface{}{
+			"error": err,
+		})
+	}
+
+	return presentation.JSON(stdout, result)
+}
+
+func parseFilenameOffset(s string) (string, int, error) {
+	if strings.HasPrefix(s, "file://") {
+		s = strings.TrimPrefix(s, "file://")
+	}
+
+	parts := strings.Split(s, ":")
+	if len(parts) != 2 {
+		return "", 0, errors.New("expected <filename>:<offset> argument")
+	}
+
+	base := 10
+	str := parts[1]
+	if strings.HasPrefix(parts[1], "0x") {
+		base = 16
+		str = parts[1][2:]
+	}
+
+	offset, err := strconv.ParseInt(str, base, 64)
+	if err != nil {
+		return "", 0, err
+	}
+
+	return parts[0], int(offset), nil
+}

--- a/cmd/oracle_test.go
+++ b/cmd/oracle_test.go
@@ -1,0 +1,150 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"path"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/open-policy-agent/opa/util"
+	"github.com/open-policy-agent/opa/util/test"
+)
+
+func TestOracleFindDefinition(t *testing.T) {
+
+	onDiskModule := `package test
+
+p { r }
+
+r = true`
+
+	stdin := bytes.NewBufferString(`package test
+
+p { q }
+
+q = true`)
+
+	files := map[string]string{"test.rego": onDiskModule}
+
+	test.WithTempFS(files, func(rootDir string) {
+
+		params := findDefinitionParams{
+			bundlePaths: repeatedStringFlag{
+				v:     []string{rootDir},
+				isSet: true,
+			},
+			stdinBuffer: true,
+		}
+
+		stdout := bytes.NewBuffer(nil)
+
+		err := dofindDefinition(params, stdin, stdout, []string{path.Join(rootDir, "test.rego:10")})
+		expectJSON(t, err, stdout, `{"error": {"code": "oracle_no_match_found"}}`)
+
+		err = dofindDefinition(params, stdin, stdout, []string{path.Join(rootDir, "test.rego:15")})
+		expectJSON(t, err, stdout, `{"error": {"code": "oracle_no_definition_found"}}`)
+
+		err = dofindDefinition(params, stdin, stdout, []string{path.Join(rootDir, "test.rego:18")})
+		expectJSON(t, err, stdout, fmt.Sprintf(`{"result": {
+			"file": %q,
+			"row": 5,
+			"col": 1
+		}}`, path.Join(rootDir, "test.rego")))
+	})
+}
+
+func expectJSON(t *testing.T, err error, buffer *bytes.Buffer, exp string) {
+	t.Helper()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var x interface{}
+	if err := util.UnmarshalJSON(buffer.Bytes(), &x); err != nil {
+		t.Fatal(err)
+	}
+	var y interface{}
+	if err := util.UnmarshalJSON([]byte(exp), &y); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(x, y) {
+		t.Fatalf("expected %v but got %v", y, x)
+	}
+	buffer.Reset()
+}
+
+func TestOracleParseFilenameOffset(t *testing.T) {
+
+	tests := []struct {
+		input    string
+		wantFile string
+		wantPos  int
+	}{
+		{
+			input:    "x.rego:10",
+			wantFile: "x.rego",
+			wantPos:  10,
+		},
+		{
+			input:    "/x.rego:10",
+			wantFile: "/x.rego",
+			wantPos:  10,
+		},
+		{
+			input:    "x.rego:0x10",
+			wantFile: "x.rego",
+			wantPos:  16,
+		},
+		{
+			input:    "file://x.rego:10",
+			wantFile: "x.rego",
+			wantPos:  10,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			filename, pos, err := parseFilenameOffset(tc.input)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if tc.wantFile != filename || tc.wantPos != pos {
+				t.Fatalf("expected %v:%v but got %v:%v", tc.wantFile, tc.wantPos, filename, pos)
+			}
+		})
+	}
+
+}
+
+func TestOracleParseFilenameOffsetError(t *testing.T) {
+
+	tests := []struct {
+		input   string
+		wantErr error
+	}{
+		{
+			input:   "x.rego",
+			wantErr: errors.New("expected <filename>:<offset> argument"),
+		},
+		{
+			input:   "x.rego:",
+			wantErr: errors.New("invalid syntax"),
+		},
+		{
+			input:   "x.rego:3.14",
+			wantErr: errors.New("invalid syntax"),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			_, _, err := parseFilenameOffset(tc.input)
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr.Error()) {
+				t.Fatalf("expected %v but got %v", tc.wantErr, err)
+			}
+		})
+	}
+
+}

--- a/internal/oracle/oracle.go
+++ b/internal/oracle/oracle.go
@@ -1,0 +1,228 @@
+package oracle
+
+import (
+	"errors"
+
+	"github.com/open-policy-agent/opa/ast"
+)
+
+// Error defines the structure of errors returned by the oracle.
+type Error struct {
+	Code string `json:"code"`
+}
+
+func (e Error) Error() string {
+	return e.Code
+}
+
+// Oracle implements different queries over ASTs, e.g., find definition.
+type Oracle struct {
+}
+
+// New returns a new Oracle object.
+func New() *Oracle {
+	return &Oracle{}
+}
+
+// DefinitionQuery defines a Rego definition query.
+type DefinitionQuery struct {
+	Filename string                 // name of file to search for position inside of
+	Pos      int                    // position to search for
+	Modules  map[string]*ast.Module // workspace modules; buffer may shadow a file inside the workspace
+	Buffer   []byte                 // buffer that overrides module with filename
+}
+
+var (
+	// ErrNoDefinitionFound indicates the position was valid but no matching definition was found.
+	ErrNoDefinitionFound = Error{Code: "oracle_no_definition_found"}
+
+	// ErrNoMatchFound indicates the position was invalid.
+	ErrNoMatchFound = Error{Code: "oracle_no_match_found"}
+)
+
+// DefinitionQueryResult defines output of a definition query.
+type DefinitionQueryResult struct {
+	Result *ast.Location `json:"result"`
+}
+
+// FindDefinition returns the location of the definition referred to by the symbol
+// at the position in q.
+func (o *Oracle) FindDefinition(q DefinitionQuery) (*DefinitionQueryResult, error) {
+
+	// TODO(tsandall): how can we cache the results of compilation and parsing so that
+	// multiple queries can be executed without having to re-compute the same values?
+	// Ditto for caching across runs. Avoid repeating the same work.
+	compiler, parsed, err := compileUpto("SetRuleTree", q.Modules, q.Buffer, q.Filename)
+	if err != nil {
+		return nil, err
+	}
+
+	stack := findContainingNodeStack(compiler.Modules[q.Filename], q.Pos)
+	if len(stack) == 0 {
+		return nil, ErrNoMatchFound
+	}
+
+	// Walk outwards from the match location, attempting to find the definition via
+	// references to imports or other rules. This handles intra-module, intra-package,
+	// and inter-package references.
+	for i := len(stack) - 1; i >= 0; i-- {
+		if term, ok := stack[i].(*ast.Term); ok {
+			if ref, ok := term.Value.(ast.Ref); ok {
+				prefix := ref.ConstantPrefix()
+				if rules := compiler.GetRulesExact(prefix); len(rules) > 0 {
+					return &DefinitionQueryResult{rules[0].Location}, nil
+				}
+				for _, imp := range parsed.Imports {
+					if path, ok := imp.Path.Value.(ast.Ref); ok {
+						if prefix.HasPrefix(path) {
+							return &DefinitionQueryResult{imp.Path.Location}, nil
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// If the match is a variable, walk inward to find the first occurence of the variable
+	// in function arguments or the body.
+	top := stack[len(stack)-1]
+	if term, ok := top.(*ast.Term); ok {
+		if name, ok := term.Value.(ast.Var); ok {
+			for i := 0; i < len(stack); i++ {
+				switch node := stack[i].(type) {
+				case *ast.Rule:
+					if match := walkToFirstOccurrence(node.Head.Args, name); match != nil {
+						return &DefinitionQueryResult{match.Location}, nil
+					}
+				case ast.Body:
+					if match := walkToFirstOccurrence(node, name); match != nil {
+						return &DefinitionQueryResult{match.Location}, nil
+					}
+				}
+			}
+		}
+	}
+
+	return nil, ErrNoDefinitionFound
+}
+
+func walkToFirstOccurrence(node ast.Node, needle ast.Var) (match *ast.Term) {
+	ast.WalkNodes(node, func(x ast.Node) bool {
+		if match == nil {
+			switch x := x.(type) {
+			case *ast.SomeDecl:
+				// NOTE(tsandall): The visitor doesn't traverse into some decl terms
+				// so special case here.
+				for i := range x.Symbols {
+					if x.Symbols[i].Value.Compare(needle) == 0 {
+						match = x.Symbols[i]
+						break
+					}
+				}
+			case *ast.Term:
+				if x.Value.Compare(needle) == 0 {
+					match = x
+				}
+			}
+		}
+		return match != nil
+	})
+	return match
+}
+
+func compileUpto(stage string, modules map[string]*ast.Module, bs []byte, filename string) (*ast.Compiler, *ast.Module, error) {
+
+	compiler := ast.NewCompiler()
+
+	if stage != "" {
+		compiler = compiler.WithStageAfter(stage, ast.CompilerStageDefinition{
+			Name: "halt",
+			Stage: func(c *ast.Compiler) *ast.Error {
+				return &ast.Error{
+					Code: "halt",
+				}
+			},
+		})
+	}
+
+	var module *ast.Module
+
+	if len(bs) > 0 {
+		var err error
+		module, err = ast.ParseModule(filename, string(bs))
+		if err != nil {
+			return nil, nil, err
+		}
+	} else {
+		module = modules[filename]
+	}
+
+	if modules == nil {
+		modules = map[string]*ast.Module{}
+	}
+
+	if len(bs) > 0 {
+		modules[filename] = module
+	}
+
+	compiler.Compile(modules)
+
+	if stage != "" {
+		if err := halted(compiler); err != nil {
+			return nil, nil, err
+		}
+	}
+
+	return compiler, module, nil
+}
+
+func halted(c *ast.Compiler) error {
+	if c.Failed() && len(c.Errors) == 1 && c.Errors[0].Code == "halt" {
+		return nil
+	} else if len(c.Errors) > 0 {
+		return c.Errors
+	}
+	// NOTE(tsandall): this indicate an internal error in the compiler and should
+	// not be reachable.
+	return errors.New("unreachable: did not halt")
+}
+
+func findContainingNodeStack(module *ast.Module, pos int) []ast.Node {
+
+	var matches []ast.Node
+
+	ast.WalkNodes(module, func(x ast.Node) bool {
+
+		min, max := getLocMinMax(x)
+
+		if pos < min || pos >= max {
+			return true
+		}
+
+		matches = append(matches, x)
+		return false
+	})
+
+	return matches
+}
+
+func getLocMinMax(x ast.Node) (int, int) {
+
+	if x.Loc() == nil {
+		return -1, -1
+	}
+
+	loc := x.Loc()
+	min := loc.Offset
+
+	// Special case bodies because location text is only for the first expr.
+	if body, ok := x.(ast.Body); ok {
+		extraLoc := body[len(body)-1].Loc()
+		if extraLoc == nil {
+			return -1, -1
+		}
+		return min, extraLoc.Offset + len(extraLoc.Text)
+	}
+
+	return min, min + len(loc.Text)
+}

--- a/internal/oracle/oracle_test.go
+++ b/internal/oracle/oracle_test.go
@@ -1,0 +1,491 @@
+package oracle
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/open-policy-agent/opa/ast"
+)
+
+func TestOracleFindDefinitionErrors(t *testing.T) {
+
+	cases := []struct {
+		note    string
+		buffer  string
+		modules map[string]string
+		pos     int
+		exp     error
+	}{
+		{
+			note:   "buffer parse error",
+			buffer: `package`,
+			exp:    errors.New("buffer.rego:1: rego_parse_error: unexpected eof token"),
+		},
+		{
+			note: "compile error",
+			buffer: `package test
+
+# NOTE(tsandall): if we relax this check then this test case becomes obsolete.
+f(input)`,
+			exp: errors.New("buffer.rego:4: rego_compile_error: args must not shadow input"),
+		},
+		{
+			note: "no matching node",
+			buffer: `package test
+
+p { q }
+
+q = true`,
+			pos: 100,
+			exp: ErrNoMatchFound,
+		},
+		{
+			note: "no good match - literal",
+			buffer: `package test
+
+p { q > 1 }`,
+			pos: 22, // this points at the number '1'
+			exp: ErrNoDefinitionFound,
+		},
+		{
+			note: "no good match - rule name",
+			buffer: `package test
+
+p { q > 1 }`,
+			pos: 14, // this points at the rule 'p'
+			exp: ErrNoDefinitionFound,
+		},
+		{
+			note: "no good match - rule whitespace",
+			buffer: `package test
+
+p { q > 1 }`,
+			pos: 21, // this points at the whitespace after '>'
+			exp: ErrNoDefinitionFound,
+		},
+		{
+			note: "no match - negative",
+			buffer: `package test
+
+p = 1`,
+			pos: -100,
+			exp: ErrNoMatchFound,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.note, func(t *testing.T) {
+			modules := map[string]*ast.Module{}
+			for k, v := range tc.modules {
+				var err error
+				modules[k], err = ast.ParseModule(k, v)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			o := New()
+			result, err := o.FindDefinition(DefinitionQuery{
+				Modules:  modules,
+				Buffer:   []byte(tc.buffer),
+				Filename: "buffer.rego",
+				Pos:      tc.pos,
+			})
+			if err == nil || result != nil {
+				t.Fatal("expected error but got:", err, "result:", result)
+			}
+			if !strings.Contains(err.Error(), tc.exp.Error()) {
+				t.Fatalf("expected %v but got %v", tc.exp, err)
+			}
+		})
+	}
+}
+
+func TestOracleFindDefinition(t *testing.T) {
+
+	const aBufferModule = `package test
+
+import data.foo.s
+import data.foo.bar as t
+
+p {
+    q
+    [r]
+    s[t]
+}
+
+r = true
+q = true`
+
+	const aSecondBufferModule = `package test
+
+p {
+	q
+}`
+
+	const aThirdBufferModule = `package test
+
+f(x) {
+	input.foo[x]
+}
+
+u {
+	some x
+	x = 1
+}
+
+v {
+	x := 1
+	x < 10
+}
+
+w {
+	y[i]
+	i > 1
+}
+
+m {
+	[i, j] = [1, 2]
+	j > i
+}
+
+x = "deadbeef"
+y[1]
+`
+
+	const fooModule = `package foo
+
+s = input
+bar = 7`
+
+	cases := []struct {
+		note    string
+		modules map[string]string
+		pos     int
+		exp     *ast.Location
+	}{
+		{
+			note: "q - a var in the body",
+			modules: map[string]string{
+				"buffer.rego": aBufferModule,
+			},
+			pos: 66,
+			exp: &ast.Location{
+				File:   "buffer.rego",
+				Row:    13,
+				Col:    1,
+				Offset: 97,
+				Text:   []byte("q = true"),
+			},
+		},
+		{
+			note: "r - another var but embedded",
+			modules: map[string]string{
+				"buffer.rego": aBufferModule,
+			},
+			pos: 73,
+			exp: &ast.Location{
+				File:   "buffer.rego",
+				Row:    12,
+				Col:    1,
+				Offset: 88,
+				Text:   []byte("r = true"),
+			},
+		},
+		{
+			note: "s - reference to other module",
+			modules: map[string]string{
+				"buffer.rego": aBufferModule,
+				"foo.rego":    fooModule,
+			},
+			pos: 80,
+			exp: &ast.Location{
+				File:   "foo.rego",
+				Row:    3,
+				Col:    1,
+				Offset: 13,
+				Text:   []byte("s = input"),
+			},
+		},
+		{
+			note: "s - reference to other module but non symbol node",
+			modules: map[string]string{
+				"buffer.rego": aBufferModule,
+				"foo.rego":    fooModule,
+			},
+			pos: 81, // this refers to the '[' character following 's'--this exercises the case where position does not refer to a symbol
+			exp: &ast.Location{
+				File:   "foo.rego",
+				Row:    3,
+				Col:    1,
+				Offset: 13,
+				Text:   []byte("s = input"),
+			},
+		},
+		{
+			note: "s - reference to other module that is not loaded",
+			modules: map[string]string{
+				"buffer.rego": aBufferModule,
+			},
+			pos: 80,
+			exp: &ast.Location{
+				File:   "buffer.rego",
+				Row:    3,
+				Col:    8,
+				Offset: 21,
+				Text:   []byte("data.foo.s"),
+			},
+		},
+		{
+			note: "t - embedded ref and import alias",
+			modules: map[string]string{
+				"buffer.rego": aBufferModule,
+				"foo.rego":    fooModule,
+			},
+			pos: 82,
+			exp: &ast.Location{
+				File:   "foo.rego",
+				Row:    4,
+				Col:    1,
+				Offset: 17,
+				Text:   []byte("bar = 7"),
+			},
+		},
+		{
+			note: "t - embedded ref and import alias without other module loaded",
+			modules: map[string]string{
+				"buffer.rego": aBufferModule,
+			},
+			pos: 82,
+			exp: &ast.Location{
+				File:   "buffer.rego",
+				Row:    4,
+				Col:    8,
+				Offset: 39,
+				Text:   []byte("data.foo.bar"),
+			},
+		},
+		{
+			note: "intra-package ref",
+			modules: map[string]string{
+				"buffer.rego": aSecondBufferModule, // use a different module that references q in main buffer module used above
+				"test.rego":   aBufferModule,
+			},
+			pos: 19,
+			exp: &ast.Location{
+				File:   "test.rego",
+				Row:    13,
+				Col:    1,
+				Offset: 97,
+				Text:   []byte("q = true"),
+			},
+		},
+		{
+			note: "intra-rule: function argument",
+			modules: map[string]string{
+				"buffer.rego": aThirdBufferModule,
+			},
+			pos: 32,
+			exp: &ast.Location{
+				File:   "buffer.rego",
+				Row:    3,
+				Col:    3,
+				Offset: 16,
+				Text:   []byte("x"),
+			},
+		},
+		{
+			note: "intra-rule: some decl",
+			modules: map[string]string{
+				"buffer.rego": aThirdBufferModule,
+			},
+			pos: 51,
+			exp: &ast.Location{
+				File:   "buffer.rego",
+				Row:    8,
+				Col:    7,
+				Offset: 48,
+				Text:   []byte("x"),
+			},
+		},
+		{
+			note: "intra-rule: assignment",
+			modules: map[string]string{
+				"buffer.rego": aThirdBufferModule,
+			},
+			pos: 73,
+			exp: &ast.Location{
+				File:   "buffer.rego",
+				Row:    13,
+				Col:    2,
+				Offset: 65,
+				Text:   []byte("x"),
+			},
+		},
+		{
+			note: "intra-rule: ref output",
+			modules: map[string]string{
+				"buffer.rego": aThirdBufferModule,
+			},
+			pos: 94,
+			exp: &ast.Location{
+				File:   "buffer.rego",
+				Row:    18,
+				Col:    4,
+				Offset: 90,
+				Text:   []byte("i"),
+			},
+		},
+		{
+			note: "intra-rule: unify output",
+			modules: map[string]string{
+				"buffer.rego": aThirdBufferModule,
+			},
+			pos: 129,
+			exp: &ast.Location{
+				File:   "buffer.rego",
+				Row:    23,
+				Col:    3,
+				Offset: 109,
+				Text:   []byte("i"),
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.note, func(t *testing.T) {
+			modules := map[string]*ast.Module{}
+			for k, v := range tc.modules {
+				var err error
+				modules[k], err = ast.ParseModule(k, v)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			o := New()
+			result, err := o.FindDefinition(DefinitionQuery{
+				Modules:  modules,
+				Buffer:   []byte(tc.modules["buffer.rego"]),
+				Filename: "buffer.rego",
+				Pos:      tc.pos,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if tc.exp.Compare(result.Result) != 0 {
+				var expText string
+				var gotText string
+				if tc.exp != nil {
+					expText = string(tc.exp.Text)
+				}
+				if result != nil {
+					gotText = string(result.Result.Text)
+				}
+				t.Fatalf("\n\nwant:\n\n\t%#v\n\ngot:\n\n\t%#v\n\nwant (text):\n\n\t%q\n\ngot (text):\n\n\t%q", tc.exp, result, expText, gotText)
+			}
+		})
+	}
+}
+
+func TestFindContainingNodeStack(t *testing.T) {
+	const trivial = `package test
+
+p {
+    q
+    r
+}
+
+r = true
+q = true`
+
+	module := ast.MustParseModule(trivial)
+	module.Package.Location = nil // unset the package location to test nil tolerance
+
+	// offset 28 is the first 'r' variable
+	result := findContainingNodeStack(module, 28)
+
+	exp := []*ast.Location{
+		module.Rules[0].Loc(),
+		module.Rules[0].Body.Loc(),
+		module.Rules[0].Body[1].Loc(),
+		module.Rules[0].Body[1].Terms.(*ast.Term).Loc(),
+	}
+
+	if len(result) != len(exp) {
+		t.Fatal("expected an exact set of location pointers but got different number:", len(result), "result:", result)
+	}
+
+	for i := 0; i < len(result); i++ {
+		if result[i].Loc() != exp[i] {
+			t.Fatal("expected exact location pointers but found difference on i =", i, "result:", result)
+		}
+	}
+
+	// Exercise special case for bodies.
+	module.Rules[0].Body[1].Location = nil
+	result = findContainingNodeStack(module, 28)
+
+	exp = []*ast.Location{
+		module.Rules[0].Loc(),
+	}
+
+	if len(result) != len(exp) {
+		t.Fatal("expected an exact set of location pointers but got different number:", len(result), "result:", result)
+	}
+
+	for i := 0; i < len(result); i++ {
+		if result[i].Loc() != exp[i] {
+			t.Fatal("expected exact location pointers but found difference on i =", i, "result:", result)
+		}
+	}
+
+}
+
+func TestCompileUptoNoModules(t *testing.T) {
+
+	compiler, module, err := compileUpto("SetRuleTree", nil, []byte("package test\np=1"), "test.rego")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rules := compiler.GetRulesExact(ast.MustParseRef("data.test.p"))
+	if len(rules) != 1 {
+		t.Fatal("unexpected rules:", rules)
+	}
+
+	if module == nil {
+		t.Fatal("expected parsed module")
+	}
+
+}
+
+func TestCompileUptoNoBuffer(t *testing.T) {
+
+	compiler, module, err := compileUpto("SetRuleTree", map[string]*ast.Module{
+		"test.rego": ast.MustParseModule("package test\np=1"),
+	}, nil, "test.rego")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rules := compiler.GetRulesExact(ast.MustParseRef("data.test.p"))
+	if len(rules) != 1 {
+		t.Fatal("unexpected rules:", rules)
+	}
+
+	if module == nil {
+		t.Fatal("expected parsed module")
+	}
+
+}
+
+func TestCompileUptoBadStageName(t *testing.T) {
+
+	_, _, err := compileUpto("DEADBEEF", map[string]*ast.Module{
+		"test.rego": ast.MustParseModule("package test\np=1"),
+	}, nil, "test.rego")
+
+	if err.Error() != "unreachable: did not halt" {
+		t.Fatal("expected halt error but got:", err)
+	}
+}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -956,7 +956,7 @@ p = true { false }`
                   "location": {
                     "file": "testmod",
                     "row": 2,
-                    "col": 5
+                    "col": 1
                   }
                 }
               ]
@@ -3762,6 +3762,7 @@ func (f *fixture) reset() {
 }
 
 func executeRequests(t *testing.T, reqs []tr) {
+	t.Helper()
 	f := newFixture(t)
 	for i, req := range reqs {
 		if err := f.v1(req.method, req.path, req.body, req.code, req.resp); err != nil {
@@ -3772,6 +3773,7 @@ func executeRequests(t *testing.T, reqs []tr) {
 
 // Runs through an array of test cases against the v0 REST API tree
 func executeRequestsv0(t *testing.T, reqs []tr) {
+	t.Helper()
 	f := newFixture(t)
 	for i, req := range reqs {
 		if err := f.v0(req.method, req.path, req.body, req.code, req.resp); err != nil {


### PR DESCRIPTION
This PR adds a new `oracle` command (which is hidden for now) that can be be home for tools that answer queries over policy files. The first oracle command that's implemented is `find-definition` which returns the location of the definition referred to by the filename/offset provided as input.