### PR TITLE
Add ability to disable trace event var plugging

### DIFF
--- a/cover/cover.go
+++ b/cover/cover.go
@@ -31,6 +31,13 @@ func (c *Cover) Enabled() bool {
 	return true
 }
 
+// Config returns the standard Tracer configuration for the Cover tracer
+func (c *Cover) Config() topdown.TraceConfig {
+	return topdown.TraceConfig{
+		PlugLocalVars: false, // Event variable metadata is not required for the Coverage report
+	}
+}
+
 // Report returns a coverage Report for the given modules.
 func (c *Cover) Report(modules map[string]*ast.Module) (report Report) {
 	report.Files = map[string]*FileReport{}

--- a/cover/cover_bench_test.go
+++ b/cover/cover_bench_test.go
@@ -1,0 +1,78 @@
+// Copyright 2020 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package cover
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/rego"
+)
+
+func BenchmarkCoverBigLocalVar(b *testing.B) {
+	iterations := []int{1, 100, 1000}
+	vars := []int{1, 10}
+
+	for _, iterationCount := range iterations {
+		for _, varCount := range vars {
+			name := fmt.Sprintf("%dVars%dIterations", varCount, iterationCount)
+			b.Run(name, func(b *testing.B) {
+				cover := New()
+				module := generateModule(varCount, iterationCount)
+
+				_, err := ast.ParseModule("test.rego", module)
+				if err != nil {
+					b.Fatal(err)
+				}
+
+				ctx := context.Background()
+
+				pq, err := rego.New(
+					rego.Module("test.rego", module),
+					rego.Query("data.test.p"),
+				).PrepareForEval(ctx)
+
+				if err != nil {
+					b.Fatal(err)
+				}
+
+				b.ResetTimer()
+
+				for i := 0; i < b.N; i++ {
+					b.StartTimer()
+					_, err = pq.Eval(ctx, rego.EvalTracer(cover))
+					b.StopTimer()
+
+					if err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		}
+	}
+}
+
+func generateModule(numVars int, dataSize int) string {
+	sb := strings.Builder{}
+	sb.WriteString(`package test
+
+p {
+	x := a
+	v := x[i]
+`)
+	for i := 0; i < numVars; i++ {
+		sb.WriteString(fmt.Sprintf("\tv%d := x[i+%d]\n", i, i))
+	}
+	sb.WriteString("\tfalse\n}\n")
+	sb.WriteString("\na := [\n")
+	for i := 0; i < dataSize; i++ {
+		sb.WriteString(fmt.Sprintf("\t%d,\n", i))
+	}
+	sb.WriteString("]\n")
+	return sb.String()
+}

--- a/cover/cover_test.go
+++ b/cover/cover_test.go
@@ -8,10 +8,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"testing"
 
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/rego"
+	"github.com/open-policy-agent/opa/topdown"
 )
 
 func TestCover(t *testing.T) {
@@ -134,5 +136,18 @@ p {
 			t.Fatal(err)
 		}
 		fmt.Println(string(bs))
+	}
+}
+
+func TestCoverTraceConfig(t *testing.T) {
+	ct := topdown.CustomTracer(New())
+	conf := ct.Config()
+
+	expected := topdown.TraceConfig{
+		PlugLocalVars: false,
+	}
+
+	if !reflect.DeepEqual(expected, conf) {
+		t.Fatalf("Expected config: %+v, got %+v", expected, conf)
 	}
 }

--- a/profiler/profiler.go
+++ b/profiler/profiler.go
@@ -38,6 +38,13 @@ func (p *Profiler) Enabled() bool {
 	return true
 }
 
+// Config returns the standard Tracer configuration for the profiler
+func (p *Profiler) Config() topdown.TraceConfig {
+	return topdown.TraceConfig{
+		PlugLocalVars: false, // Event variable metadata is not required for the Profiler
+	}
+}
+
 // ReportByFile returns a profiler report for expressions grouped by the
 // file name. For each file the results are sorted by increasing row number.
 func (p *Profiler) ReportByFile() (report Report) {

--- a/profiler/profiler_bench_test.go
+++ b/profiler/profiler_bench_test.go
@@ -1,0 +1,78 @@
+// Copyright 2020 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package profiler
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/rego"
+)
+
+func BenchmarkProfilerBigLocalVar(b *testing.B) {
+	iterations := []int{1, 100, 1000}
+	vars := []int{1, 10}
+
+	for _, iterationCount := range iterations {
+		for _, varCount := range vars {
+			name := fmt.Sprintf("%dVars%dIterations", varCount, iterationCount)
+			b.Run(name, func(b *testing.B) {
+				profiler := New()
+				module := generateModule(varCount, iterationCount)
+
+				_, err := ast.ParseModule("test.rego", module)
+				if err != nil {
+					b.Fatal(err)
+				}
+
+				ctx := context.Background()
+
+				pq, err := rego.New(
+					rego.Module("test.rego", module),
+					rego.Query("data.test.p"),
+				).PrepareForEval(ctx)
+
+				if err != nil {
+					b.Fatal(err)
+				}
+
+				b.ResetTimer()
+
+				for i := 0; i < b.N; i++ {
+					b.StartTimer()
+					_, err = pq.Eval(ctx, rego.EvalTracer(profiler))
+					b.StopTimer()
+
+					if err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		}
+	}
+}
+
+func generateModule(numVars int, dataSize int) string {
+	sb := strings.Builder{}
+	sb.WriteString(`package test
+
+p {
+	x := a
+	v := x[i]
+`)
+	for i := 0; i < numVars; i++ {
+		sb.WriteString(fmt.Sprintf("\tv%d := x[i+%d]\n", i, i))
+	}
+	sb.WriteString("\tfalse\n}\n")
+	sb.WriteString("\na := [\n")
+	for i := 0; i < dataSize; i++ {
+		sb.WriteString(fmt.Sprintf("\t%d,\n", i))
+	}
+	sb.WriteString("]\n")
+	return sb.String()
+}

--- a/profiler/profiler_test.go
+++ b/profiler/profiler_test.go
@@ -7,6 +7,7 @@ package profiler
 import (
 	"context"
 	_ "encoding/json"
+	"reflect"
 	"testing"
 	"time"
 
@@ -477,5 +478,18 @@ allowed_operations = [
 			t.Fatalf("Index %v: Expected location %v but got %v", idx, expectedLocation[idx], string(actualExprStat.Location.Text))
 		}
 
+	}
+}
+
+func TestProfilerTraceConfig(t *testing.T) {
+	ct := topdown.CustomTracer(New())
+	conf := ct.Config()
+
+	expected := topdown.TraceConfig{
+		PlugLocalVars: false,
+	}
+
+	if !reflect.DeepEqual(expected, conf) {
+		t.Fatalf("Expected config: %+v, got %+v", expected, conf)
 	}
 }

--- a/topdown/query_test.go
+++ b/topdown/query_test.go
@@ -1,0 +1,141 @@
+// Copyright 2020 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package topdown
+
+import (
+	"context"
+	"testing"
+
+	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/storage"
+	"github.com/open-policy-agent/opa/storage/inmem"
+)
+
+func TestQueryTracerDontPlugLocalVars(t *testing.T) {
+
+	cases := []struct {
+		note         string
+		tracerConfs  []TraceConfig
+		expectLocals bool
+	}{
+		{
+			note: "plug locals single tracer",
+			tracerConfs: []TraceConfig{
+				{PlugLocalVars: true},
+			},
+			expectLocals: true,
+		},
+		{
+			note: "dont plug locals single tracer",
+			tracerConfs: []TraceConfig{
+				{PlugLocalVars: false},
+			},
+			expectLocals: false,
+		},
+		{
+			note: "plug locals multiple tracers",
+			tracerConfs: []TraceConfig{
+				{PlugLocalVars: true},
+				{PlugLocalVars: true},
+				{PlugLocalVars: true},
+			},
+			expectLocals: true,
+		},
+		{
+			note: "dont plug locals multiple tracers",
+			tracerConfs: []TraceConfig{
+				{PlugLocalVars: false},
+				{PlugLocalVars: false},
+				{PlugLocalVars: false},
+			},
+			expectLocals: false,
+		},
+		{
+			note: "plug locals multiple plugins mixed",
+			tracerConfs: []TraceConfig{
+				{PlugLocalVars: false},
+				{PlugLocalVars: true},
+				{PlugLocalVars: false},
+			},
+			expectLocals: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.note, func(t *testing.T) {
+
+			ctx := context.Background()
+			store := inmem.New()
+			inputTerm := &ast.Term{}
+			txn := storage.NewTransactionOrDie(ctx, store)
+			defer store.Abort(ctx, txn)
+
+			compiler := compileModules([]string{
+				`package x
+	
+	p {
+		a := [1, 2, 3]
+		f(a[_])
+	}
+	
+	f(x) {
+		x == 3
+	}
+	
+	`})
+
+			query := NewQuery(ast.MustParseBody("data.x.p")).
+				WithCompiler(compiler).
+				WithStore(store).
+				WithTransaction(txn).
+				WithInput(inputTerm)
+
+			var tracers []*testTracer
+			for _, conf := range tc.tracerConfs {
+				tt := &testTracer{
+					events: []*Event{},
+					conf:   conf,
+				}
+				tracers = append(tracers, tt)
+				query = query.WithTracer(tt)
+			}
+
+			_, err := query.Run(ctx)
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+
+			// Even if the individual tracer didn't specify for local metadata
+			// they will _all_ either have it or not.
+			for _, tt := range tracers {
+				for _, e := range tt.events {
+					if !tc.expectLocals && e.LocalMetadata != nil {
+						t.Fatalf("Expected event LocalMetadata to nil")
+					}
+					if tc.expectLocals && e.LocalMetadata == nil {
+						t.Fatalf("Expected event LocalMetadata to be non-nil")
+					}
+				}
+			}
+		})
+	}
+}
+
+type testTracer struct {
+	events []*Event
+	conf   TraceConfig
+}
+
+func (n *testTracer) Enabled() bool {
+	return true
+}
+
+func (n *testTracer) Trace(e *Event) {
+	n.events = append(n.events, e)
+}
+
+func (n *testTracer) Config() TraceConfig {
+	return n.conf
+}

--- a/topdown/trace_test.go
+++ b/topdown/trace_test.go
@@ -1010,3 +1010,16 @@ func TestShortTraceFileNames(t *testing.T) {
 		})
 	}
 }
+
+func TestBufferTracerTraceConfig(t *testing.T) {
+	ct := CustomTracer(NewBufferTracer())
+	conf := ct.Config()
+
+	expected := TraceConfig{
+		PlugLocalVars: true,
+	}
+
+	if !reflect.DeepEqual(expected, conf) {
+		t.Fatalf("Expected config: %+v, got %+v", expected, conf)
+	}
+}


### PR DESCRIPTION
This PR makes a few changes:

* Introduces a new `topdown.CustomTracer` interface which builds on top of the `topdown.Tracer`, but allows for Tracer implementations to supply their configuration requirements for evaluation time.
* Changes the `topdown.Query` and `topdown.Eval` to check if any tracers require variable metadata (via their configuration, as applicable). If none do then that step is skipped on each trace event.
* Updates the profiler and coverage tracers to take advantage of this, and reducing their overhead pretty significantly (Fixing #2245). Results from my dev machine before and after for coverage tracing on a query:

```
name                                                                old time/op    new time/op    delta
BenchmarkCoverBigLocalVar/1Vars1Iterations-8        41.0µs ± 3%    20.8µs ± 4%  -49.30%  (p=0.000 n=8+9)
BenchmarkCoverBigLocalVar/10Vars1Iterations-8       55.8µs ± 2%    23.7µs ±11%  -57.44%  (p=0.000 n=10+10)
BenchmarkCoverBigLocalVar/1Vars100Iterations-8      2.91ms ± 2%    0.38ms ± 7%  -87.07%  (p=0.000 n=9+10)
BenchmarkCoverBigLocalVar/10Vars100Iterations-8     35.4ms ± 1%     2.7ms ± 0%  -92.51%  (p=0.000 n=9+8)
BenchmarkCoverBigLocalVar/1Vars1000Iterations-8      156ms ± 0%       4ms ± 1%  -97.74%  (p=0.000 n=8+9)
BenchmarkCoverBigLocalVar/10Vars1000Iterations-8     1.17s ± 2%     0.03s ± 0%  -97.70%  (p=0.000 n=10+10)

name                                                                old alloc/op   new alloc/op   delta
BenchmarkCoverBigLocalVar/1Vars1Iterations-8        22.4kB ± 0%     9.9kB ± 0%  -55.68%  (p=0.002 n=8+10)
BenchmarkCoverBigLocalVar/10Vars1Iterations-8       25.9kB ± 0%    10.7kB ± 0%  -58.87%  (p=0.000 n=10+8)
BenchmarkCoverBigLocalVar/1Vars100Iterations-8      1.45MB ± 0%    0.18MB ± 0%  -87.30%  (p=0.000 n=10+10)
BenchmarkCoverBigLocalVar/10Vars100Iterations-8     17.7MB ± 0%     1.2MB ± 0%  -93.32%  (p=0.000 n=10+10)
BenchmarkCoverBigLocalVar/1Vars1000Iterations-8     65.4MB ± 0%     1.8MB ± 0%  -97.31%  (p=0.000 n=10+10)
BenchmarkCoverBigLocalVar/10Vars1000Iterations-8     498MB ± 0%      12MB ± 0%  -97.56%  (p=0.000 n=9+10)

name                                                                old allocs/op  new allocs/op  delta
BenchmarkCoverBigLocalVar/1Vars1Iterations-8           355 ± 0%       171 ± 0%  -51.83%  (p=0.000 n=10+10)
BenchmarkCoverBigLocalVar/10Vars1Iterations-8          401 ± 0%       185 ± 0%  -53.87%  (p=0.000 n=10+10)
BenchmarkCoverBigLocalVar/1Vars100Iterations-8       13.9k ± 0%      4.6k ± 0%  -66.81%  (p=0.000 n=10+10)
BenchmarkCoverBigLocalVar/10Vars100Iterations-8       133k ± 0%       30k ± 0%  -77.75%  (p=0.000 n=10+10)
BenchmarkCoverBigLocalVar/1Vars1000Iterations-8       138k ± 0%       46k ± 0%  -66.70%  (p=0.000 n=10+10)
BenchmarkCoverBigLocalVar/10Vars1000Iterations-8     1.38M ± 0%     0.31M ± 0%  -77.87%  (p=0.000 n=8+10)
```

The buffer tracer was left with its original behavior, and any existing tracers will continue to work the same way as before. Implementors must opt-in by adding the new required functions to meet the `topdown.CustomTracer` interface.
