### PR TITLE
rego, server: Fix panic caused by compiler misuse

### DIFF
--- a/rego/rego_test.go
+++ b/rego/rego_test.go
@@ -1548,6 +1548,25 @@ func TestRegoCustomBuiltinPartialPropagate(t *testing.T) {
 
 }
 
+func TestRegoPartialResultRecursiveRefs(t *testing.T) {
+
+	r := New(Query("data"), Module("test.rego", `package foo.bar
+
+	default p = false
+
+	p { input.x = 1 }`))
+
+	_, err := r.PartialResult(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	if !IsPartialEvaluationNotEffectiveErr(err) {
+		t.Fatal("expected ineffective partial eval error")
+	}
+
+}
+
 func TestSkipPartialNamespaceOption(t *testing.T) {
 	r := New(Query("data.test.p"), Module("example.rego", `
 		package test

--- a/server/server.go
+++ b/server/server.go
@@ -2151,12 +2151,15 @@ func (s *Server) makeRego(ctx context.Context, partial bool, txn storage.Transac
 		defer s.mtx.Unlock()
 		pr, ok := s.partials[queryPath]
 		if !ok {
-			opts = append(opts, rego.PartialNamespace(namespace))
-			r := rego.New(opts...)
+			peopts := append(opts, rego.PartialNamespace(namespace))
+			r := rego.New(peopts...)
 			var err error
 			pr, err = r.PartialResult(ctx)
 			if err != nil {
-				return nil, err
+				if !rego.IsPartialEvaluationNotEffectiveErr(err) {
+					return nil, err
+				}
+				return rego.New(opts...), nil
 			}
 			s.partials[queryPath] = pr
 		}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1064,6 +1064,27 @@ p = true { false }`
 			{http.MethodPut, "/data/x", `1`, 204, ""},
 			{http.MethodPost, "/data/testmod/p?partial", "", 200, `{"result": true}`},
 		}},
+		{"partial ineffective fallback to normal", []tr{
+			{http.MethodPut, "/policies/test", testMod7, 200, ""},
+			{http.MethodPost, "/data?partial", "", 200, `{
+				"result": {
+					"testmod": {
+					"p": false,
+					"q": [],
+					"r": []
+					}
+				}
+			}`},
+			{http.MethodPost, "/data", "", 200, `{
+				"result": {
+					"testmod": {
+					"p": false,
+					"q": [],
+					"r": []
+					}
+				}
+			}`},
+		}},
 		{"evaluation conflict", []tr{
 			{http.MethodPut, "/policies/test", testMod4, 200, ""},
 			{http.MethodPost, "/data/testmod/p", "", 500, `{


### PR DESCRIPTION
Previously the rego package would construct rules for each of the
PE query results when PartialResult() was invoked--however, it would not
check if those rules would be recursive. If the user queried for
`data` (or `data.<partialnamespace>`) then PE would return an
(essentially) unmodified copy of the query and the rego package would
happily construct a rule from it--since the rule is namespaced under
data this leads to a recursion error.

The problem is that the recursion error was caught by running the
compiler--however, since the compiler is shared by the server and
other components and since compile operations do not rollback changes
on error, this approach left OPA in an inconsistent state. Some of the
compiler data structures like the rule tree would include the PE
result but any structures built by stages after the recursion check
would be incomplete. This causes issues for the evaluator because it
(rightfully) assumes that the compiler data structures are consistent.

Since we can assume that PE results are valid and do not contain
semantic errors and we do not intend to support the lazy PE API in the
future, this commit fixes the issue/panic by modifying the rego
package to check for recursion in the rules that it constructs. This
is relatively simple since it merely has to check for prefixes in the
refs contained in the PE query result. If recursion is caught, the
rego package returns an error signalling that PE was ineffective. In
this case, the server just falls back to normal eval.

Fixes #2197

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
