### PR TITLE
build: Fix image to include ca-certificates from distroless

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@
 
 ARG BASE
 
+FROM gcr.io/distroless/base as certs
+
 FROM ${BASE}
 
 # Any non-zero number will do, and unfortunately a named user will not, as k8s
@@ -13,6 +15,7 @@ FROM ${BASE}
 ARG USER=0
 
 MAINTAINER Torin Sandall <torinsandall@gmail.com>
+COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY opa_linux_amd64 /opa
 USER ${USER}
 ENTRYPOINT ["/opa"]


### PR DESCRIPTION
The scratch base image does not contain ca-certificates which meant
that the version check was failing because of TLS errors while
connecting to telemetry.openpolicyagent.org.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
