### PR TITLE
format: Fix panic with else blocks and comments

### DIFF
--- a/format/format.go
+++ b/format/format.go
@@ -308,6 +308,12 @@ func (w *writer) writeElse(rule *ast.Rule, comments []*ast.Comment) []*ast.Comme
 	rule.Else.Head.Args = nil
 	comments = w.insertComments(comments, rule.Else.Head.Location)
 
+	if hasCommentAbove && !wasInline {
+		// The comments would have ended the line, be sure to start one again
+		// before writing the rest of the "else" rule.
+		w.startLine()
+	}
+
 	// For backwards compatibility adjust the rule head value location
 	// TODO: Refactor the logic for inserting comments, or special
 	// case comments in a rule head value so this can be removed
@@ -1005,9 +1011,6 @@ func dedupComments(comments []*ast.Comment) []*ast.Comment {
 
 // startLine begins a line with the current indentation level.
 func (w *writer) startLine() {
-	if w.inline {
-		panic("currently in a line")
-	}
 	w.inline = true
 	for i := 0; i < w.level; i++ {
 		w.write(w.indent)
@@ -1016,9 +1019,6 @@ func (w *writer) startLine() {
 
 // endLine ends a line with a newline.
 func (w *writer) endLine() {
-	if !w.inline {
-		panic("not in a line")
-	}
 	w.inline = false
 	if w.beforeEnd != nil && !w.delay {
 		w.write(" " + w.beforeEnd.String())

--- a/format/testfiles/test_issue_2420.rego
+++ b/format/testfiles/test_issue_2420.rego
@@ -1,0 +1,11 @@
+package example
+
+allow {
+    some_condition
+}
+
+# some comments
+
+else {
+    another_condition
+}

--- a/format/testfiles/test_issue_2420.rego.formatted
+++ b/format/testfiles/test_issue_2420.rego.formatted
@@ -1,0 +1,11 @@
+package example
+
+allow {
+	some_condition
+}
+
+# some comments
+
+else {
+	another_condition
+}


### PR DESCRIPTION
When an else block had a comment in between it and the rule body we
were not starting a new line, which triggers a panic in the formatter.

This corrects the issue, and also removes the panics. If the functions
are not called correctly the formatting will be off and tests will
fail. There is little benefit in them causing a panic.

Fixes: #2420
Signed-off-by: Patrick East <east.patrick@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
