### PR TITLE
format: Fix wildcards in nested refs

### DIFF
--- a/format/format.go
+++ b/format/format.go
@@ -550,7 +550,9 @@ func (w *writer) writeRef(x ast.Ref) {
 			case ast.Var:
 				w.writeBracketed(w.formatVar(p))
 			default:
-				w.writeBracketed(p.String())
+				w.write("[")
+				w.writeTerm(ast.NewTerm(p), nil)
+				w.write("]")
 			}
 		}
 	}

--- a/format/format_test.go
+++ b/format/format_test.go
@@ -258,6 +258,21 @@ foo[__wildcard1__][__wildcard0__].bar = bar[__wildcard1__][_][__wildcard0__].bar
 			expected: `__wildcard0__
 __wildcard0__[x]`,
 		},
+		{
+			note: "body shared wildcard - nested ref",
+			toFmt: ast.Body{
+				&ast.Expr{
+					Index: 0,
+					Terms: ast.VarTerm("$x"),
+				},
+				&ast.Expr{
+					Index: 1,
+					Terms: ast.RefTerm(ast.VarTerm("a"), ast.RefTerm(ast.VarTerm("$x"), ast.VarTerm("x"))),
+				},
+			},
+			expected: `__wildcard0__
+a[__wildcard0__[x]]`,
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Previously if we had nested refs we wouldn't print the wildcards with
names, which could cause issues with the resulting policy.

Signed-off-by: Patrick East <east.patrick@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
