### PR TITLE
Prepare v0.20.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file. This
 project adheres to [Semantic Versioning](http://semver.org/).
 
+## 0.20.3
+
+### Fixes
+
+- docs/content small output correction on terraform page ([#1772](https://github.com/open-policy-agent/opa/issues/1772))
+- format: Fix wildcards in nested refs
+
 ## 0.20.2
 
 ### Fixes

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Use of this source code is governed by an Apache2
 # license that can be found in the LICENSE file.
 
-VERSION := 0.20.2
+VERSION := 0.20.3
 
 CGO_ENABLED ?= 0
 

--- a/docs/content/terraform.md
+++ b/docs/content/terraform.md
@@ -858,7 +858,7 @@ This should return one of the two resources. The security group created by the m
 
 ```shell
 [
-"No security groups should be using HTTP , module.http_sg.aws_security_group.this_name_prefix[0] does"
+"No security groups should be using HTTP. Resource in violation: module.http_sg.aws_security_group.this_name_prefix[0]"
 ]
 ```
 

--- a/format/format.go
+++ b/format/format.go
@@ -550,7 +550,9 @@ func (w *writer) writeRef(x ast.Ref) {
 			case ast.Var:
 				w.writeBracketed(w.formatVar(p))
 			default:
-				w.writeBracketed(p.String())
+				w.write("[")
+				w.writeTerm(ast.NewTerm(p), nil)
+				w.write("]")
 			}
 		}
 	}

--- a/format/format_test.go
+++ b/format/format_test.go
@@ -258,6 +258,21 @@ foo[__wildcard1__][__wildcard0__].bar = bar[__wildcard1__][_][__wildcard0__].bar
 			expected: `__wildcard0__
 __wildcard0__[x]`,
 		},
+		{
+			note: "body shared wildcard - nested ref",
+			toFmt: ast.Body{
+				&ast.Expr{
+					Index: 0,
+					Terms: ast.VarTerm("$x"),
+				},
+				&ast.Expr{
+					Index: 1,
+					Terms: ast.RefTerm(ast.VarTerm("a"), ast.RefTerm(ast.VarTerm("$x"), ast.VarTerm("x"))),
+				},
+			},
+			expected: `__wildcard0__
+a[__wildcard0__[x]]`,
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Includes a fix for the doc content (so it will show up on "latest") and a fix for the formatter which affected the new `opa build` command 
