### PR TITLE
format: Deep copy inputs to avoid mutating the caller's copy

### DIFF
--- a/ast/policy.go
+++ b/ast/policy.go
@@ -315,6 +315,14 @@ func (c *Comment) String() string {
 	return "#" + string(c.Text)
 }
 
+// Copy returns a deep copy of c.
+func (c *Comment) Copy() *Comment {
+	cpy := *c
+	cpy.Text = make([]byte, len(c.Text))
+	copy(cpy.Text, c.Text)
+	return &cpy
+}
+
 // Equal returns true if this comment equals the other comment.
 // Unlike other equality checks on AST nodes, comment equality
 // depends on location.
@@ -1249,6 +1257,53 @@ func (w *With) Loc() *Location {
 // SetLoc sets the location on w.
 func (w *With) SetLoc(loc *Location) {
 	w.Location = loc
+}
+
+// Copy returns a deep copy of the AST node x. If x is not an AST node, x is returned unmodified.
+func Copy(x interface{}) interface{} {
+	switch x := x.(type) {
+	case *Module:
+		return x.Copy()
+	case *Package:
+		return x.Copy()
+	case *Import:
+		return x.Copy()
+	case *Rule:
+		return x.Copy()
+	case *Head:
+		return x.Copy()
+	case Args:
+		return x.Copy()
+	case Body:
+		return x.Copy()
+	case *Expr:
+		return x.Copy()
+	case *With:
+		return x.Copy()
+	case *SomeDecl:
+		return x.Copy()
+	case *Term:
+		return x.Copy()
+	case *ArrayComprehension:
+		return x.Copy()
+	case *SetComprehension:
+		return x.Copy()
+	case *ObjectComprehension:
+		return x.Copy()
+	case Set:
+		return x.Copy()
+	case Object:
+		return x.Copy()
+	case Array:
+		return x.Copy()
+	case Ref:
+		return x.Copy()
+	case Call:
+		return x.Copy()
+	case *Comment:
+		return x.Copy()
+	}
+	return x
 }
 
 // RuleSet represents a collection of rules that produce a virtual document.

--- a/ast/policy_test.go
+++ b/ast/policy_test.go
@@ -10,6 +10,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/open-policy-agent/opa/ast/location"
 	"github.com/open-policy-agent/opa/util"
 )
 
@@ -511,6 +512,24 @@ func TestSomeDeclString(t *testing.T) {
 
 	if result != expected {
 		t.Fatalf("Expected %v but got %v", expected, result)
+	}
+}
+
+func TestCommentCopy(t *testing.T) {
+	comment := &Comment{
+		Text:     []byte("foo bar baz"),
+		Location: &location.Location{}, // location must be set for comment equality
+	}
+
+	cpy := comment.Copy()
+	if !cpy.Equal(comment) {
+		t.Fatal("expected copy to be equal")
+	}
+
+	comment.Text[1] = '0'
+
+	if cpy.Equal(comment) {
+		t.Fatal("expected copy to be unmodified")
 	}
 }
 

--- a/compile/compile.go
+++ b/compile/compile.go
@@ -300,7 +300,7 @@ func (c *Compiler) compileWasm(ctx context.Context) error {
 	}
 
 	store := inmem.NewFromObject(c.bundle.Data)
-	resultSym := ast.VarTerm(ast.WildcardPrefix + "result")
+	resultSym := ast.VarTerm(ast.WildcardPrefix + "__result__")
 
 	cr, err := rego.New(
 		rego.ParsedQuery(ast.NewBody(ast.Equality.Expr(resultSym, c.entrypointrefs[0]))),
@@ -377,7 +377,7 @@ func (o *optimizer) Do(ctx context.Context) error {
 	}
 
 	store := inmem.NewFromObject(data)
-	resultsym := ast.VarTerm(o.resultsymprefix + "result")
+	resultsym := ast.VarTerm(o.resultsymprefix + "__result__")
 	usedFilenames := map[string]int{}
 
 	// NOTE(tsandall): the entrypoints are optimized in order so that the optimization

--- a/compile/compile_test.go
+++ b/compile/compile_test.go
@@ -523,9 +523,9 @@ func TestOptimizerOutput(t *testing.T) {
 				"optimized/test.rego": `
 					package test
 
-					p = result { 1 = input.x; result = true }
-					p = result { 2 = input.x; result = true }
-					p = result { 3 = input.x; result = true }
+					p = __result__ { 1 = input.x; __result__ = true }
+					p = __result__ { 2 = input.x; __result__ = true }
+					p = __result__ { 3 = input.x; __result__ = true }
 				`,
 				"test.rego": `
 					package test
@@ -589,12 +589,12 @@ func TestOptimizerOutput(t *testing.T) {
 				"optimized/test.rego": `
 					package test
 
-					p = result { 1 = input.x; result = true }
+					p = __result__ { 1 = input.x; __result__ = true }
 				`,
 				"optimized/test.1.rego": `
 					package test
 
-					r = result { 1 = input.x; result = true }
+					r = __result__ { 1 = input.x; __result__ = true }
 				`,
 				"test.rego": `
 					package test
@@ -617,7 +617,7 @@ func TestOptimizerOutput(t *testing.T) {
 				"optimized/test.rego": `
 					package test
 
-					foo = result { result = {"bar": {"p": true}} }`,
+					foo = __result__ { __result__ = {"bar": {"p": true}} }`,
 			},
 		},
 		{
@@ -647,7 +647,7 @@ func TestOptimizerOutput(t *testing.T) {
 				"optimized/test.1.rego": `
 					package test
 
-					p = result { data.test.q[input.x]; result = true }
+					p = __result__ { data.test.q[input.x]; __result__ = true }
 				`,
 				"optimized/test.rego": `
 					package test
@@ -679,8 +679,8 @@ func TestOptimizerOutput(t *testing.T) {
 			wantModules: map[string]string{
 				"optimized/partial/0/0.rego": `
 					package test["foo bar"]
-					p = result { 1 = input.x; result = true }
-					p = result { 2 = input.x; result = true }
+					p = __result__ { 1 = input.x; __result__ = true }
+					p = __result__ { 2 = input.x; __result__ = true }
 				`,
 				"x.rego": `
 					package test["foo bar"]
@@ -719,7 +719,7 @@ func TestOptimizerOutput(t *testing.T) {
 				"optimized/test.rego": `
 					package test
 
-					p = result { not data.partial.__not1_0__; result = true }
+					p = __result__ { not data.partial.__not1_0__; __result__ = true }
 				`,
 				"test.rego": `
 					package test

--- a/format/format_test.go
+++ b/format/format_test.go
@@ -238,9 +238,9 @@ func TestFormatAST(t *testing.T) {
 					},
 				},
 			},
-			expected: `input.arr[__wildcard0__]["some key"][_] = bar
-input.arr[__wildcard0__].bar = qux
-foo[__wildcard1__][__wildcard0__].bar = bar[__wildcard1__][_][__wildcard0__].bar
+			expected: `input.arr[_01]["some key"][_] = bar
+input.arr[_01].bar = qux
+foo[_03][_01].bar = bar[_03][_][_01].bar
 `,
 		},
 		{
@@ -252,11 +252,11 @@ foo[__wildcard1__][__wildcard0__].bar = bar[__wildcard1__][_][__wildcard0__].bar
 				},
 				&ast.Expr{
 					Index: 1,
-					Terms: ast.RefTerm(ast.VarTerm("$x"), ast.VarTerm("x")),
+					Terms: ast.RefTerm(ast.VarTerm("$x"), ast.VarTerm("y")),
 				},
 			},
-			expected: `__wildcard0__
-__wildcard0__[x]`,
+			expected: `_x
+_x[y]`,
 		},
 		{
 			note: "body shared wildcard - nested ref",
@@ -267,11 +267,11 @@ __wildcard0__[x]`,
 				},
 				&ast.Expr{
 					Index: 1,
-					Terms: ast.RefTerm(ast.VarTerm("a"), ast.RefTerm(ast.VarTerm("$x"), ast.VarTerm("x"))),
+					Terms: ast.RefTerm(ast.VarTerm("a"), ast.RefTerm(ast.VarTerm("$x"), ast.VarTerm("y"))),
 				},
 			},
-			expected: `__wildcard0__
-a[__wildcard0__[x]]`,
+			expected: `_x
+a[_x[y]]`,
 		},
 		{
 			note: "body shared wildcard - nested ref array",
@@ -282,11 +282,11 @@ a[__wildcard0__[x]]`,
 				},
 				&ast.Expr{
 					Index: 1,
-					Terms: ast.RefTerm(ast.VarTerm("a"), ast.RefTerm(ast.VarTerm("$x"), ast.VarTerm("x"), ast.ArrayTerm(ast.VarTerm("y"), ast.VarTerm("z")))),
+					Terms: ast.RefTerm(ast.VarTerm("a"), ast.RefTerm(ast.VarTerm("$x"), ast.VarTerm("y"), ast.ArrayTerm(ast.VarTerm("z"), ast.VarTerm("w")))),
 				},
 			},
-			expected: `__wildcard0__
-a[__wildcard0__[x][[y, z]]]`,
+			expected: `_x
+a[_x[y][[z, w]]]`,
 		},
 	}
 
@@ -303,6 +303,32 @@ a[__wildcard0__[x][[y, z]]]`,
 			}
 		})
 	}
+}
+
+func TestFormatDeepCopy(t *testing.T) {
+
+	original := ast.Body{
+		&ast.Expr{
+			Index: 0,
+			Terms: ast.VarTerm("$x"),
+		},
+		&ast.Expr{
+			Index: 1,
+			Terms: ast.RefTerm(ast.VarTerm("$x"), ast.VarTerm("y")),
+		},
+	}
+
+	cpy := original.Copy()
+
+	_, err := Ast(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !cpy.Equal(original) {
+		t.Fatal("expected original to be unmodified")
+	}
+
 }
 
 func differsAt(a, b []byte) (int, int) {


### PR DESCRIPTION
As part of this change, also update the format package to unmangle the
variables slightly differently--just remove the wildcard prefix
instead of translating the variable names. This makes it easier to
tell where the variables came from in the first place and is a bit
less complicated.

Fixes #2439

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
