### PR TITLE
Fix memoization bug in PE of partial object rules

### DIFF
--- a/topdown/eval.go
+++ b/topdown/eval.go
@@ -809,7 +809,6 @@ func (e *eval) biunifyRef(a, b *ast.Term, b1, b2 *bindings, iter unifyIterator) 
 
 	if ref[0].Equal(ast.DefaultRootDocument) {
 		node := e.compiler.RuleTree.Child(ref[0].Value)
-
 		eval := evalTree{
 			e:         e,
 			ref:       ref,
@@ -1806,7 +1805,7 @@ func (e evalVirtualPartial) eval(iter unifyIterator) error {
 
 	var cacheKey ast.Ref
 
-	if e.ir.Kind == ast.PartialObjectDoc {
+	if !e.e.unknown(e.ref[:e.pos+1], e.bindings) && e.ir.Kind == ast.PartialObjectDoc {
 		plugged := e.bindings.Plug(e.ref[e.pos+1])
 
 		if plugged.IsGround() {

--- a/topdown/topdown_partial_test.go
+++ b/topdown/topdown_partial_test.go
@@ -1963,6 +1963,32 @@ func TestTopDownPartialEval(t *testing.T) {
 			},
 			wantQueries: []string{"a1 = input.foo1; b1 = input.foo2; c1 = input.foo3; d1 = input.foo4; e1 = input.foo5"},
 		},
+		{
+			note:  "partial object rules not memoized",
+			query: "data.test.p",
+			modules: []string{`
+				package test
+
+				p { q.foo }
+				p { q.foo }
+
+				q[x] = 1 { input[x] }`,
+			},
+			wantQueries: []string{`input.foo`, `input.foo`},
+		},
+		{
+			note:  "partial set rules not memoized",
+			query: "data.test.p",
+			modules: []string{`
+				package test
+
+				p { q.foo }
+				p { q.foo }
+
+				q[x] { input[x] }`,
+			},
+			wantQueries: []string{`input.foo`, `input.foo`},
+		},
 	}
 
 	ctx := context.Background()


### PR DESCRIPTION
This PR fixes #2455 and contains an improvement on the new compile package implementation that's needed for performance reasons.