### PR TITLE
topdown/cover/profiler: Tracing framework performance improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Backwards Compatibility
+
+* `topdown.Tracer` has been deprecated in favor of a newer interface
+  `topdown.QueryTracer`.  
+* All tracers (regardless of interface implementation) will now only be checked
+  for being enabled at the beginning of query evaluation rather than on a
+  per-event basis.
+* `topdown.BuiltinContext#Tracers` has been deprecated in favor of
+  `topdown.BuiltinContext#QueryTracers`. The older `Tracers` field will be `nil`
+  starting this release, and eventually removed.
+
 ## 0.20.5
 
 ### Fixes

--- a/cover/cover.go
+++ b/cover/cover.go
@@ -100,7 +100,13 @@ func (c *Cover) Report(modules map[string]*ast.Module) (report Report) {
 }
 
 // Trace updates the coverage state.
+// Deprecated: Use TraceEvent instead.
 func (c *Cover) Trace(event *topdown.Event) {
+	c.TraceEvent(*event)
+}
+
+// TraceEvent updates the coverage state.
+func (c *Cover) TraceEvent(event topdown.Event) {
 	switch event.Op {
 	case topdown.ExitOp:
 		if rule, ok := event.Node.(*ast.Rule); ok {

--- a/cover/cover_test.go
+++ b/cover/cover_test.go
@@ -140,7 +140,7 @@ p {
 }
 
 func TestCoverTraceConfig(t *testing.T) {
-	ct := topdown.CustomTracer(New())
+	ct := topdown.QueryTracer(New())
 	conf := ct.Config()
 
 	expected := topdown.TraceConfig{

--- a/profiler/profiler.go
+++ b/profiler/profiler.go
@@ -123,7 +123,13 @@ func (p *Profiler) ReportTopNResults(numResults int, criteria []string) []ExprSt
 }
 
 // Trace updates the profiler state.
+// Deprecated: Use TraceEvent instead.
 func (p *Profiler) Trace(event *topdown.Event) {
+	p.TraceEvent(*event)
+}
+
+// TraceEvent updates the coverage state.
+func (p *Profiler) TraceEvent(event topdown.Event) {
 	switch event.Op {
 	case topdown.EvalOp:
 		if expr, ok := event.Node.(*ast.Expr); ok && expr != nil {

--- a/profiler/profiler_test.go
+++ b/profiler/profiler_test.go
@@ -482,7 +482,7 @@ allowed_operations = [
 }
 
 func TestProfilerTraceConfig(t *testing.T) {
-	ct := topdown.CustomTracer(New())
+	ct := topdown.QueryTracer(New())
 	conf := ct.Config()
 
 	expected := topdown.TraceConfig{

--- a/topdown/builtins.go
+++ b/topdown/builtins.go
@@ -29,15 +29,17 @@ type (
 	// BuiltinContext contains context from the evaluator that may be used by
 	// built-in functions.
 	BuiltinContext struct {
-		Context  context.Context // request context that was passed when query started
-		Seed     io.Reader       // randomization seed
-		Cancel   Cancel          // atomic value that signals evaluation to halt
-		Runtime  *ast.Term       // runtime information on the OPA instance
-		Cache    builtins.Cache  // built-in function state cache
-		Location *ast.Location   // location of built-in call
-		Tracers  []Tracer        // tracer objects for trace() built-in function
-		QueryID  uint64          // identifies query being evaluated
-		ParentID uint64          // identifies parent of query being evaluated
+		Context      context.Context // request context that was passed when query started
+		Seed         io.Reader       // randomization seed
+		Cancel       Cancel          // atomic value that signals evaluation to halt
+		Runtime      *ast.Term       // runtime information on the OPA instance
+		Cache        builtins.Cache  // built-in function state cache
+		Location     *ast.Location   // location of built-in call
+		Tracers      []Tracer        // Deprecated: Use QueryTracers instead
+		QueryTracers []QueryTracer   // tracer objects for trace() built-in function
+		TraceEnabled bool            // indicates whether tracing is enabled for the evaluation
+		QueryID      uint64          // identifies query being evaluated
+		ParentID     uint64          // identifies parent of query being evaluated
 	}
 
 	// BuiltinFunc defines an interface for implementing built-in functions.

--- a/topdown/query_test.go
+++ b/topdown/query_test.go
@@ -6,6 +6,7 @@ package topdown
 
 import (
 	"context"
+	"reflect"
 	"testing"
 
 	"github.com/open-policy-agent/opa/ast"
@@ -66,43 +67,22 @@ func TestQueryTracerDontPlugLocalVars(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.note, func(t *testing.T) {
 
-			ctx := context.Background()
-			store := inmem.New()
-			inputTerm := &ast.Term{}
-			txn := storage.NewTransactionOrDie(ctx, store)
-			defer store.Abort(ctx, txn)
+			query := initTracerTestQuery()
 
-			compiler := compileModules([]string{
-				`package x
-	
-	p {
-		a := [1, 2, 3]
-		f(a[_])
-	}
-	
-	f(x) {
-		x == 3
-	}
-	
-	`})
-
-			query := NewQuery(ast.MustParseBody("data.x.p")).
-				WithCompiler(compiler).
-				WithStore(store).
-				WithTransaction(txn).
-				WithInput(inputTerm)
-
-			var tracers []*testTracer
+			var tracers []*testQueryTracer
 			for _, conf := range tc.tracerConfs {
-				tt := &testTracer{
-					events: []*Event{},
-					conf:   conf,
+				tt := &testQueryTracer{
+					events:  []*Event{},
+					conf:    conf,
+					enabled: true,
+					t:       t,
 				}
 				tracers = append(tracers, tt)
-				query = query.WithTracer(tt)
+
+				query = query.WithQueryTracer(tt)
 			}
 
-			_, err := query.Run(ctx)
+			_, err := query.Run(context.Background())
 			if err != nil {
 				t.Fatalf("Unexpected error: %v", err)
 			}
@@ -123,19 +103,140 @@ func TestQueryTracerDontPlugLocalVars(t *testing.T) {
 	}
 }
 
-type testTracer struct {
-	events []*Event
-	conf   TraceConfig
+func TestLegacyTracerUpgrade(t *testing.T) {
+
+	query := initTracerTestQuery()
+
+	tracer := &testQueryTracer{
+		events:  []*Event{},
+		conf:    TraceConfig{PlugLocalVars: false},
+		enabled: true,
+		t:       t,
+	}
+
+	// Call with older API, expect to be "upgraded" to QueryTracer
+	// If the deprecated Trace() API is called the test will fail.
+	query.WithTracer(tracer)
+
+	_, err := query.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
 }
 
-func (n *testTracer) Enabled() bool {
+func TestLegacyTracerBackwardsCompatibility(t *testing.T) {
+	t.Helper()
+	query := initTracerTestQuery()
+
+	// Using a tracer that does _not_ implement the newer
+	// QueryTracer interface, only the deprecated Tracer one.
+	tracer := &testLegacyTracer{
+		events: []*Event{},
+	}
+
+	query.WithTracer(tracer)
+
+	// For comparison use a buffer tracer and the new interface
+	bt := NewBufferTracer()
+	query.WithQueryTracer(bt)
+
+	_, err := query.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if len(*bt) != len(tracer.events) {
+		t.Fatalf("Expected %d events on the test tracer, got %d", len(*bt), len(tracer.events))
+	}
+
+	if !reflect.DeepEqual([]*Event(*bt), tracer.events) {
+		t.Fatalf("Expected same events on test tracer and BufferTracer")
+	}
+}
+
+func TestDisabledTracer(t *testing.T) {
+	query := initTracerTestQuery()
+
+	tracer := &testQueryTracer{
+		events:  []*Event{},
+		conf:    TraceConfig{PlugLocalVars: false},
+		enabled: false,
+		t:       t,
+	}
+
+	// Both API's should ignore the disabled tracer
+	query.WithTracer(tracer)
+	query.WithQueryTracer(tracer)
+
+	_, err := query.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if len(tracer.events) > 0 {
+		t.Fatalf("Expected no events on test tracer, got %d", len(tracer.events))
+	}
+}
+
+func initTracerTestQuery() *Query {
+	ctx := context.Background()
+	store := inmem.New()
+	inputTerm := &ast.Term{}
+	txn := storage.NewTransactionOrDie(ctx, store)
+	defer store.Abort(ctx, txn)
+
+	compiler := compileModules([]string{
+		`package x
+	
+	p {
+		a := [1, 2, 3]
+		f(a[_])
+	}
+	
+	f(x) {
+		x == 3
+	}
+	
+	`})
+
+	return NewQuery(ast.MustParseBody("data.x.p")).
+		WithCompiler(compiler).
+		WithStore(store).
+		WithTransaction(txn).
+		WithInput(inputTerm)
+}
+
+type testQueryTracer struct {
+	events  []*Event
+	conf    TraceConfig
+	enabled bool
+	t       *testing.T
+}
+
+func (n *testQueryTracer) Enabled() bool {
+	return n.enabled
+}
+
+func (n *testQueryTracer) Trace(e *Event) {
+	n.t.Errorf("Unexpected call to Trace() with event %v", e)
+}
+
+func (n *testQueryTracer) TraceEvent(e Event) {
+	n.events = append(n.events, &e)
+}
+
+func (n *testQueryTracer) Config() TraceConfig {
+	return n.conf
+}
+
+type testLegacyTracer struct {
+	events []*Event
+}
+
+func (n *testLegacyTracer) Enabled() bool {
 	return true
 }
 
-func (n *testTracer) Trace(e *Event) {
+func (n *testLegacyTracer) Trace(e *Event) {
 	n.events = append(n.events, e)
-}
-
-func (n *testTracer) Config() TraceConfig {
-	return n.conf
 }

--- a/topdown/trace_test.go
+++ b/topdown/trace_test.go
@@ -1012,7 +1012,7 @@ func TestShortTraceFileNames(t *testing.T) {
 }
 
 func TestBufferTracerTraceConfig(t *testing.T) {
-	ct := CustomTracer(NewBufferTracer())
+	ct := QueryTracer(NewBufferTracer())
 	conf := ct.Config()
 
 	expected := TraceConfig{


### PR DESCRIPTION
This renames a recently introduces (but not released)
`topdown.CustomTracer` to now be a `topdown.QueryTracer`. A new API is
added to replace the older `Trace()` API. Making this change has a
substantial impact on performance by eliminating allocations.

The `topdown.Query` and `topdown.eval` will now exclusively use the
new interface, but a compatibility layer is provided to wrap older
`topdown.Tracer` implementations with a shim `topdown.QueryTracer`
to provide transparent backwards compatibility for existing
integrations. In addition if a newer `QueryTracer` is passed into the
older `WithTracer()` API it will be "upgraded" to the newer type
without needing to be wrapped.

The `topdown.BufferTracer` is updated to support the new interface.

** Backwards Compatibility Changes: **

* `topdown.Tracer` has been deprecated in favor of a newer interface
  `topdown.QueryTracer`.
* All tracers (regardless of interface implementation) will now only
  be checked for being enabled at the beginning of query evaluation
  rather than on a per-event basis.
* `topdown.BuiltinContext#Tracers` has been deprecated in favor of
  `topdown.BuiltinContext#QueryTracers`. The older `Tracers` field
  will be `nil` starting this release, and eventually removed.

The PR also includes changes for the profiler and coverage tracers to
take advantage of the new interface.