### PR TITLE
Add maintainers for gatekeeper-library

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -5,10 +5,10 @@ The following table lists OPA project maintainers and areas of expertise in alph
 | Name | GitHub | Email | Organization | Repositories/Area of Expertise | Added/Renewed On |
 | --- | --- | --- | --- | --- | --- |
 | Ash Narkar | @ashutosh-narkar | anarkar4387@gmail.com | Styra | opa, opa-istio-plugin | 2020-04-14 |
-| Craig Tabita | @ctab | ctab@google.com | Google | gatekeeper | 2020-04-14 |
-| Max Smythe | @maxsmythe | smythe@google.com | Google | frameworks/constraints, gatekeeper | 2020-04-14 |
+| Craig Tabita | @ctab | ctab@google.com | Google | gatekeeper, gatekeeper-library | 2020-04-14 |
+| Max Smythe | @maxsmythe | smythe@google.com | Google | frameworks/constraints, gatekeeper, gatekeeper-library | 2020-04-14 |
 | Patrick East | @patrick-east | east.patrick@gmail.com | Styra | opa | 2020-04-14 |
-| Rita Zhang | @ritazh | rita.z.zhang@gmail.com | Microsoft | frameworks/constraints, gatekeeper | 2020-04-14 |
-| Sertaç Özercan | @sozercan | sozercan@gmail.com | Microsoft | gatekeeper | 2020-04-14 |
+| Rita Zhang | @ritazh | rita.z.zhang@gmail.com | Microsoft | frameworks/constraints, gatekeeper, gatekeeper-library | 2020-04-14 |
+| Sertaç Özercan | @sozercan | sozercan@gmail.com | Microsoft | gatekeeper, gatekeeper-library | 2020-04-14 |
 | Tim Hinrichs | @timothyhinrichs | timothy.l.hinrichs@gmail.com | Styra | all repositories | 2020-04-14 |
 | Torin Sandall | @tsandall | torinsandall@gmail.com | Styra | all repositories | 2020-04-14 |


### PR DESCRIPTION
Adding the same maintainers who maintain the gatekeeper repo to the gatekeeper-library repo