### PR TITLE
topdown: Fix loss of precision in arithmetic and aggregate builtins

### DIFF
--- a/topdown/aggregates_test.go
+++ b/topdown/aggregates_test.go
@@ -20,6 +20,7 @@ func TestTopDownAggregates(t *testing.T) {
 		{"sum set", []string{`p = x { sum({1, 2, 3, 4}, x) }`}, "10"},
 		{"sum virtual", []string{`p[x] { sum([y | q[y]], x) }`, `q[x] { a[_] = x }`}, "[10]"},
 		{"sum virtual set", []string{`p = x { sum(q, x) }`, `q[x] { a[_] = x }`}, "10"},
+		{"bug 2469 - precision", []string{"p = true { sum([49649733057, 1]) == 49649733058 }"}, "true"},
 		{"product", []string{"p { product([1,2,3,4], 24) }"}, "true"},
 		{"product set", []string{`p = x { product({1, 2, 3, 4}, x) }`}, "24"},
 		{"max", []string{`p[x] { max([1, 2, 3, 4], x) }`}, "[4]"},

--- a/topdown/builtins/builtins.go
+++ b/topdown/builtins/builtins.go
@@ -168,7 +168,7 @@ func NumberToFloat(n ast.Number) *big.Float {
 
 // FloatToNumber converts f to a number.
 func FloatToNumber(f *big.Float) ast.Number {
-	return ast.Number(f.String())
+	return ast.Number(f.Text('g', -1))
 }
 
 // NumberToInt converts n to a big int.

--- a/topdown/topdown_test.go
+++ b/topdown/topdown_test.go
@@ -1106,6 +1106,7 @@ func TestTopDownArithmetic(t *testing.T) {
 		{"arity 1 ref dest (2)", []string{`p = true { not abs(-5, a[3]) }`}, "true"},
 		{"arity 2 ref dest", []string{`p = true { a[2] = 1 + 2 }`}, "true"},
 		{"arity 2 ref dest (2)", []string{`p = true { not a[2] = 2 + 3 }`}, "true"},
+		{"bug 2469 - precision", []string{"p = true { 49649733057 + 1 == 49649733058 }"}, "true"},
 	}
 
 	data := loadSmallTestData()


### PR DESCRIPTION
The the arithmetic and aggregate builtin functions make use of
builtins.FloatToNumber to convert big floats back into AST number
values for returning to the evaluator. Previously the
builtins.FloatToNumber function used big.Float#String to perform the
conversion--however, this function sets the default precision to 10
which causes loss of precision. The fix simply updates the helper
function to use big.Float#Text instead and set precision to -1 which
uses as many places as necessary. In future, we may want to give users
control over precision to aid in situations where clients cannot deal
with large JSON numbers.

Fixes #2469

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
