### PR TITLE
Add less aggressive partial evaluation mode to build command

### DIFF
--- a/ast/compile.go
+++ b/ast/compile.go
@@ -1753,6 +1753,7 @@ type TreeNode struct {
 	Key      Value
 	Values   []util.T
 	Children map[Value]*TreeNode
+	Sorted   []Value
 	Hide     bool
 }
 
@@ -1772,8 +1773,10 @@ func NewRuleTree(mtree *ModuleTreeNode) *TreeNode {
 
 	// Each rule set becomes a leaf node.
 	children := map[Value]*TreeNode{}
+	sorted := make([]Value, 0, len(ruleSets))
 
 	for key, rules := range ruleSets {
+		sorted = append(sorted, key)
 		children[key] = &TreeNode{
 			Key:      key,
 			Children: nil,
@@ -1782,14 +1785,20 @@ func NewRuleTree(mtree *ModuleTreeNode) *TreeNode {
 	}
 
 	// Each module in subpackage becomes child node.
-	for _, child := range mtree.Children {
+	for key, child := range mtree.Children {
+		sorted = append(sorted, key)
 		children[child.Key] = NewRuleTree(child)
 	}
+
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].Compare(sorted[j]) < 0
+	})
 
 	return &TreeNode{
 		Key:      mtree.Key,
 		Values:   nil,
 		Children: children,
+		Sorted:   sorted,
 		Hide:     mtree.Hide,
 	}
 }

--- a/ast/compile_test.go
+++ b/ast/compile_test.go
@@ -300,6 +300,19 @@ s[2] { true }`,
 	if !isVirtual(tree, MustParseRef("data.a.b.empty")) {
 		t.Fatal("Expected data.a.b.empty to be virtual")
 	}
+
+	abc := tree.Children[Var("data")].Children[String("a")].Children[String("b")].Children[String("c")]
+	exp := []Value{String("p"), String("q"), String("r"), String("s"), String("z")}
+
+	if len(abc.Sorted) != len(exp) {
+		t.Fatal("expected", exp, "but got", abc)
+	}
+
+	for i := range exp {
+		if exp[i].Compare(abc.Sorted[i]) != 0 {
+			t.Fatal("expected", exp, "but got", abc)
+		}
+	}
 }
 
 func TestCompilerEmpty(t *testing.T) {

--- a/ast/index.go
+++ b/ast/index.go
@@ -256,8 +256,13 @@ func (i *refindices) Sorted() []Ref {
 			return false
 		})
 
-		sort.Slice(i.sorted, func(i, j int) bool {
-			return counts[i] > counts[j]
+		sort.Slice(i.sorted, func(a, b int) bool {
+			if counts[a] > counts[b] {
+				return true
+			} else if counts[b] > counts[a] {
+				return false
+			}
+			return i.sorted[a][0].Loc().Compare(i.sorted[b][0].Loc()) < 0
 		})
 	}
 

--- a/cmd/eval.go
+++ b/cmd/eval.go
@@ -34,6 +34,7 @@ type evalCommandParams struct {
 	partial           bool
 	unknowns          []string
 	disableInlining   []string
+	shallowInlining   bool
 	disableIndexing   bool
 	dataPaths         repeatedStringFlag
 	inputPath         string
@@ -219,6 +220,7 @@ Set the output format with the --format flag.
 	evalCommand.Flags().BoolVarP(&params.partial, "partial", "p", false, "perform partial evaluation")
 	evalCommand.Flags().StringArrayVarP(&params.unknowns, "unknowns", "u", []string{"input"}, "set paths to treat as unknown during partial evaluation")
 	evalCommand.Flags().StringArrayVarP(&params.disableInlining, "disable-inlining", "", []string{}, "set paths of documents to exclude from inlining")
+	evalCommand.Flags().BoolVarP(&params.shallowInlining, "shallow-inlining", "", false, "disable inlining of rules that depend on unknowns")
 	evalCommand.Flags().BoolVar(&params.disableIndexing, "disable-indexing", false, "disable indexing optimizations")
 	evalCommand.Flags().BoolVarP(&params.instrument, "instrument", "", false, "enable query instrumentation metrics (implies --metrics)")
 	evalCommand.Flags().BoolVarP(&params.profile, "profile", "", false, "perform expression profiling")
@@ -436,7 +438,7 @@ func setupEval(args []string, params evalCommandParams) (*evalContext, error) {
 		regoArgs = append(regoArgs, rego.Unknowns(params.unknowns))
 	}
 
-	regoArgs = append(regoArgs, rego.DisableInlining(params.disableInlining))
+	regoArgs = append(regoArgs, rego.DisableInlining(params.disableInlining), rego.ShallowInlining(params.shallowInlining))
 
 	var c *cover.Cover
 

--- a/docs/content/policy-performance.md
+++ b/docs/content/policy-performance.md
@@ -679,6 +679,39 @@ loading 10,000 rules that implement an ACL-style authorization policy consumes a
 130MB of RAM while 100,000 rules implementing the same policy (but with 10x more tuples to check)
 consumes approximately 1.1GB of RAM.
 
+## Optimization Levels
+
+The `--optimize` (or `-O`) flag on the `opa build` command controls how bundles are optimized.
+
+> Optimization applies partial evaluation to precompute _known_ values in the policy. The goal of
+partial evaluation is to convert non-linear-time policies into linear-time policies.
+
+By specifying the `--optimize` flag, users can control how much time and resources are spent
+attempting to optimize the bundle. Generally, higher optimization levels require more time
+and resources. Currently, OPA supports three optimization levels. The exact optimizations applied
+in each level may change over time.
+
+### -O=0 (default)
+
+By default optimizations are disabled.
+
+### -O=1 (recommended)
+
+Policies are partially evaluated. Rules that do not depend on unknowns are evaluated and the
+virtual documents they produce are inlined into call sites. If a virtual virtual is required at
+evaluation time (e.g., because it is targetted by a `with` statement), then it will not be inlined.
+
+Rules that DO NOT depend on unknowns are also partially evaluated however the virtual documents
+they produce ARE NOT inlined into call sites. The output policy should be structurally similar
+to the input policy.
+
+### -O=2 (aggressive)
+
+Same as `-O=1` except virtual documents produced by rules that depend on unknowns may be inlined
+into call sites. In addition, more aggressive inlining is applied within rules. This includes
+[copy propagation](https://en.wikipedia.org/wiki/Copy_propagation) and inlining of certain negated
+statements that would otherwise generate support rules.
+
 ## Key Takeaways
 
 For high-performance use cases:

--- a/rego/rego.go
+++ b/rego/rego.go
@@ -447,6 +447,7 @@ type Rego struct {
 	unknowns             []string
 	parsedUnknowns       []*ast.Term
 	disableInlining      []string
+	shallowInlining      bool
 	skipPartialNamespace bool
 	partialNamespace     string
 	modules              []rawModule
@@ -747,6 +748,14 @@ func ParsedUnknowns(unknowns []*ast.Term) func(r *Rego) {
 func DisableInlining(paths []string) func(r *Rego) {
 	return func(r *Rego) {
 		r.disableInlining = paths
+	}
+}
+
+// ShallowInlining prevents rules that depend on unknown values from being inlined.
+// Rules that only depend on known values are inlined.
+func ShallowInlining(yes bool) func(r *Rego) {
+	return func(r *Rego) {
+		r.shallowInlining = yes
 	}
 }
 
@@ -1800,7 +1809,8 @@ func (r *Rego) partial(ctx context.Context, ectx *EvalContext) (*PartialQueries,
 		WithRuntime(r.runtime).
 		WithIndexing(ectx.indexing).
 		WithPartialNamespace(ectx.partialNamespace).
-		WithSkipPartialNamespace(r.skipPartialNamespace)
+		WithSkipPartialNamespace(r.skipPartialNamespace).
+		WithShallowInlining(r.shallowInlining)
 
 	for i := range ectx.tracers {
 		q = q.WithTracer(ectx.tracers[i])

--- a/topdown/eval.go
+++ b/topdown/eval.go
@@ -1630,7 +1630,7 @@ func (e evalTree) enumerate(iter unifyIterator) error {
 		return nil
 	}
 
-	for k := range e.node.Children {
+	for _, k := range e.node.Sorted {
 		key := ast.NewTerm(k)
 		if err := e.e.biunify(key, e.ref[e.pos], e.bindings, e.bindings, func() error {
 			return e.next(iter, key)
@@ -1679,7 +1679,10 @@ func (e evalTree) leaves(plugged ast.Ref, node *ast.TreeNode) (ast.Object, error
 
 	result := ast.NewObject()
 
-	for _, child := range node.Children {
+	for _, k := range node.Sorted {
+
+		child := node.Children[k]
+
 		if child.Hide {
 			continue
 		}

--- a/topdown/eval.go
+++ b/topdown/eval.go
@@ -1175,10 +1175,16 @@ func (e *eval) saveCall(declArgsLen int, terms []*ast.Term, iter unifyIterator) 
 
 func (e *eval) saveInlinedNegatedExprs(exprs []*ast.Expr, iter unifyIterator) error {
 
-	// This function does not include with statements on the exprs because
-	// they will have already been saved and therefore had their any relevant
-	// with statements set.
+	with := make([]*ast.With, len(e.query[e.index].With))
+
+	for i := range e.query[e.index].With {
+		cpy := e.query[e.index].With[i].Copy()
+		cpy.Value = e.bindings.PlugNamespaced(cpy.Value, e.caller.bindings)
+		with[i] = cpy
+	}
+
 	for _, expr := range exprs {
+		expr.With = with
 		e.saveStack.Push(expr, nil, nil)
 		e.traceSave(expr)
 	}

--- a/topdown/eval_test.go
+++ b/topdown/eval_test.go
@@ -123,3 +123,79 @@ func TestRefContainsNonScalar(t *testing.T) {
 	}
 
 }
+
+func TestContainsNestedRefOrCall(t *testing.T) {
+
+	tests := []struct {
+		note  string
+		input string
+		want  bool
+	}{
+		{
+			note:  "single term - negative",
+			input: "p[x]",
+			want:  false,
+		},
+		{
+			note:  "single term - positive ref",
+			input: "p[q[x]]",
+			want:  true,
+		},
+		{
+			note:  "single term - positive composite ref",
+			input: "[q[x]]",
+			want:  true,
+		},
+		{
+			note:  "single term - positive composite call",
+			input: "[f(x)]",
+			want:  true,
+		},
+		{
+			note:  "call expr - negative",
+			input: "f(x)",
+			want:  false,
+		},
+		{
+			note:  "call expr - positive ref",
+			input: "f(p[x])",
+			want:  true,
+		},
+		{
+			note:  "call expr - positive call",
+			input: "f(g(x))",
+			want:  true,
+		},
+		{
+			note:  "call expr - positive composite",
+			input: "f([g(x)])",
+			want:  true,
+		},
+		{
+			note:  "unify expr - negative",
+			input: "p[x] = q[y]",
+			want:  false,
+		},
+		{
+			note:  "unify expr - positive ref",
+			input: "p[x] = q[r[y]]",
+			want:  true,
+		},
+		{
+			note:  "unify expr - positive call",
+			input: "f(x) = g(h(y))",
+			want:  true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.note, func(t *testing.T) {
+			vis := newNestedCheckVisitor()
+			expr := ast.MustParseExpr(tc.input)
+			result := containsNestedRefOrCall(vis, expr)
+			if result != tc.want {
+				t.Fatal("Expected", tc.want, "but got", result)
+			}
+		})
+	}
+}

--- a/topdown/query.go
+++ b/topdown/query.go
@@ -306,7 +306,11 @@ func (q *Query) PartialRun(ctx context.Context) (partials []ast.Body, support []
 			body.Append(bindingExprs[i])
 		}
 
-		partials = append(partials, applyCopyPropagation(p, e.instr, body))
+		if !q.shallowInlining {
+			body = applyCopyPropagation(p, e.instr, body)
+		}
+
+		partials = append(partials, body)
 		return nil
 	})
 

--- a/topdown/save.go
+++ b/topdown/save.go
@@ -384,6 +384,7 @@ func ignoreDuringPartial(bi *ast.Builtin) bool {
 }
 
 type inliningControl struct {
+	shallow bool
 	disable []disableInliningFrame
 }
 

--- a/topdown/save.go
+++ b/topdown/save.go
@@ -344,7 +344,7 @@ func saveRequired(c *ast.Compiler, ic *inliningControl, icIgnoreInternal bool, s
 			case ast.Ref:
 				if ss.Contains(node, b) {
 					found = true
-				} else if ic.Disabled(v, icIgnoreInternal) {
+				} else if ic.Disabled(v.ConstantPrefix(), icIgnoreInternal) {
 					found = true
 				} else {
 					for _, rule := range c.GetRulesDynamic(v) {

--- a/topdown/topdown_partial_test.go
+++ b/topdown/topdown_partial_test.go
@@ -1362,7 +1362,14 @@ func TestTopDownPartialEval(t *testing.T) {
 				q { ((input.x + 7) / input.y) > 100 }`,
 			},
 			wantQueries: []string{
-				`not ((input.x + 7) / input.y) > 100`,
+				`not data.partial.__not1_0__`,
+			},
+			wantSupport: []string{
+				`package partial
+
+				__not1_0__ {
+					((input.x + 7) / input.y) > 100
+				}`,
 			},
 		},
 		{
@@ -1375,7 +1382,14 @@ func TestTopDownPartialEval(t *testing.T) {
 				q { a = input.x + 7; b = a / input.y; b > 100 }`,
 			},
 			wantQueries: []string{
-				`not ((input.x + 7) / input.y) > 100`,
+				`not data.partial.__not1_0__`,
+			},
+			wantSupport: []string{
+				`package partial
+
+				__not1_0__ {
+					((input.x + 7) / input.y) > 100
+				}`,
 			},
 		},
 		{
@@ -1481,7 +1495,14 @@ func TestTopDownPartialEval(t *testing.T) {
 				}`,
 			},
 			wantQueries: []string{
-				`input = x; not count(x) != 3`,
+				`input = x; not data.partial.__not0_1__(x)`,
+			},
+			wantSupport: []string{
+				`package partial
+
+				__not0_1__(x) {
+					count(x) != 3
+				}`,
 			},
 		},
 		{
@@ -1499,7 +1520,12 @@ func TestTopDownPartialEval(t *testing.T) {
 				}`,
 			},
 			wantQueries: []string{
-				`not count(input) > 3`,
+				`not data.partial.__not1_1__(input)`,
+			},
+			wantSupport: []string{
+				`package partial
+
+				__not1_1__(x1) { count(x1) > 3 }`,
 			},
 		},
 		{
@@ -1520,7 +1546,14 @@ func TestTopDownPartialEval(t *testing.T) {
 				}`,
 			},
 			wantQueries: []string{
-				`not sum([input.y, 1]) > 3`,
+				`not data.partial.__not1_3__(input.y)`,
+			},
+			wantSupport: []string{
+				`package partial
+
+				__not1_3__(z1) {
+					sum([z1, 1]) > 3
+				}`,
 			},
 		},
 		{
@@ -1583,7 +1616,12 @@ func TestTopDownPartialEval(t *testing.T) {
 				}
 			`},
 			wantQueries: []string{
-				`input[i1].a = "foo"; input[i1].b < 7`,
+				`input[i1].a = "foo"; data.partial.__not3_1__(input[i1])`,
+			},
+			wantSupport: []string{
+				`package partial
+
+				__not3_1__(__local0__3) { __local0__3.b < 7 }`,
 			},
 		},
 		{

--- a/topdown/topdown_partial_test.go
+++ b/topdown/topdown_partial_test.go
@@ -1953,6 +1953,21 @@ func TestTopDownPartialEval(t *testing.T) {
 			`},
 		},
 		{
+			note:  "disable inlining: ref prefix",
+			query: "data.test.p = true",
+			modules: []string{
+				`package test
+
+				p {
+					q[input.x]
+				}
+
+				q = {a | data.base[a]}`,
+			},
+			disableInlining: []string{"data.base.foo.bar"},
+			wantQueries:     []string{`x_ref_01 = {a2 | data.base[a2]; x_term_2_02 = true}; x_ref_01[input.x]`},
+		},
+		{
 			note:  "shallow inlining: complete rules",
 			query: "data.test.p = true",
 			modules: []string{

--- a/topdown/topdown_partial_test.go
+++ b/topdown/topdown_partial_test.go
@@ -1979,7 +1979,7 @@ func TestTopDownPartialEval(t *testing.T) {
 			wantSupport: []string{
 				`package partial.test
 
-				q = x2 { x2 = input.x }
+				q = x2 { y2 = input.x; x2 = y2 }
 				p { data.partial.test.q = 1 }
 				`,
 			},

--- a/topdown/topdown_test.go
+++ b/topdown/topdown_test.go
@@ -2920,14 +2920,20 @@ func loadSmallTestData() map[string]interface{} {
 }
 
 func runTopDownTestCase(t *testing.T, data map[string]interface{}, note string, rules []string, expected interface{}) {
+	t.Helper()
+
 	runTopDownTestCaseWithContext(context.Background(), t, data, note, rules, nil, "", expected)
 }
 
 func runTopDownTestCaseWithModules(t *testing.T, data map[string]interface{}, note string, rules []string, modules []string, input string, expected interface{}) {
+	t.Helper()
+
 	runTopDownTestCaseWithContext(context.Background(), t, data, note, rules, modules, input, expected)
 }
 
 func runTopDownTestCaseWithContext(ctx context.Context, t *testing.T, data map[string]interface{}, note string, rules []string, modules []string, input string, expected interface{}) {
+	t.Helper()
+
 	imports := []string{}
 	for k := range data {
 		imports = append(imports, "data."+k)
@@ -2949,10 +2955,13 @@ func runTopDownTestCaseWithContext(ctx context.Context, t *testing.T, data map[s
 }
 
 func assertTopDownWithPath(t *testing.T, compiler *ast.Compiler, store storage.Store, note string, path []string, input string, expected interface{}) {
+	t.Helper()
+
 	assertTopDownWithPathAndContext(context.Background(), t, compiler, store, note, path, input, expected)
 }
 
 func assertTopDownWithPathAndContext(ctx context.Context, t *testing.T, compiler *ast.Compiler, store storage.Store, note string, path []string, input string, expected interface{}) {
+	t.Helper()
 
 	var inputTerm *ast.Term
 
@@ -3003,6 +3012,7 @@ func assertTopDownWithPathAndContext(ctx context.Context, t *testing.T, compiler
 	}
 
 	testutil.Subtest(t, note, func(t *testing.T) {
+		t.Helper()
 
 		switch e := expected.(type) {
 		case *Error, error:
@@ -3063,6 +3073,7 @@ func assertTopDownWithPathAndContext(ctx context.Context, t *testing.T, compiler
 }
 
 func runTopDownPartialTestCase(ctx context.Context, t *testing.T, compiler *ast.Compiler, store storage.Store, txn storage.Transaction, input *ast.Term, output *ast.Term, body ast.Body, requiresSort bool, expected interface{}) {
+	t.Helper()
 
 	partialQuery := NewQuery(body).
 		WithCompiler(compiler).

--- a/util/test/subtest17.go
+++ b/util/test/subtest17.go
@@ -10,5 +10,6 @@ import "testing"
 
 // Subtest executes a sub-test f under test t.
 func Subtest(t *testing.T, name string, f func(*testing.T)) {
+	t.Helper()
 	t.Run(name, f)
 }


### PR DESCRIPTION
This PR contains a bunch of fixes to partial evaluation and a new optimization level for `opa build`.

The new optimization level (`-O=1`) does not inline rules that depend on unknowns. Only rules that are completely known at build-time are evaluated out of the policy. In addition, the copy propagation and negation inlining optimizations are disabled in this mode. This way the output from `opa build` should be structurally similar to the input policy (except for virtual docs that are completely known at build-time; those are removed.)

This PR also improves PE coverage so that references to the full extent partial set/object rules do not trigger an immediate save--instead, inlining is disabled and PE continues.

