### PR TITLE
docs/content: fix go integration example

### DIFF
--- a/docs/content/integration.md
+++ b/docs/content/integration.md
@@ -179,6 +179,28 @@ parameterized with different options like the query, policy module(s), data
 store, etc.
 
 ```go
+
+module := `
+package example.authz
+
+default allow = false
+
+allow {
+    some id
+    input.method = "GET"
+    input.path = ["salary", id]
+    input.subject.user = id
+}
+
+allow {
+    is_admin
+}
+
+is_admin {
+    input.subject.groups[_] = "admin"
+}
+`
+
 query, err := rego.New(
     rego.Query("x = data.example.authz.allow"),
     rego.Module("example.rego", module),
@@ -202,7 +224,8 @@ input := map[string]interface{}{
     },
 }
 
-results, err := query.Eval(context.Context, rego.EvalInput(input))
+ctx := context.TODO()
+results, err := query.Eval(ctx, rego.EvalInput(input))
 ```
 
 The `rego.PreparedEvalQuery#Eval` function returns a _result set_ that contains
@@ -221,6 +244,7 @@ if err != nil {
     // Handle unexpected result type.
 } else {
     // Handle result/decision.
+    // fmt.Printf("%+v", results) => [{Expressions:[true] Bindings:map[x:true]}]
 }
 ```
 


### PR DESCRIPTION
Hi, I found two small pieces make the example not working. I found these two changes can make it work

1. module should be policy string above
2. pass context instance for `.Eval`

also add decision output in the example

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
