### PR TITLE
ast: Disqualify indexing if candidate found in nested comprehension

### DIFF
--- a/ast/compile_test.go
+++ b/ast/compile_test.go
@@ -3527,6 +3527,21 @@ func TestCompilerBuildComprehensionIndexKeySet(t *testing.T) {
 				}`,
 		},
 		{
+			note: "skip: due to nested comprehension containing candidate",
+			module: `
+				package test
+
+				p {
+					x = input[i]                # 'x' is a candidate
+					y = 2                       # 'y' is a candidate
+					z = [1 |
+						x = data.foo[j]             # 'x' is an index key
+						t = [1 | data.bar[k] = y]   # 'y' disqualifies indexing because it is nested inside a comprehension
+					]
+				}
+			`,
+		},
+		{
 			note: "skip: avoid increasing runtime (func arg)",
 			module: `
 				package test

--- a/docs/content/policy-performance.md
+++ b/docs/content/policy-performance.md
@@ -228,7 +228,7 @@ In order to be indexed, comprehensions must meet the following conditions:
 1. The expression containing the comprehension does not include a `with` statement.
 1. The expression containing the comprehension is not negated.
 1. The comprehension body is safe when considered independent from the outer query.
-1. The comprehension body closes over at least one variable in the outer query and none of these variables appear as outputs in references or `walk()` calls.
+1. The comprehension body closes over at least one variable in the outer query and none of these variables appear as outputs in references or `walk()` calls or inside nested comprehensions.
 
 The following examples show cases that are NOT indexed:
 
@@ -261,6 +261,14 @@ not_indexed_because_no_closure {
 not_indexed_because_reference_operand_closure {
   x := input[y].x
   ys := [y | x == input[y].z[_]]
+}
+
+not_indexed_because_nested_closure {
+  x = 1
+  y = 2
+  _ = [i |
+    x == input.foo[i]
+    _ = [j | y == input.bar[j]]]
 }
 ```
 


### PR DESCRIPTION
In v0.20. we added support for indexing and caching of comprehensions
in certain cases. There was a bug in the index construction that
allowed for comprehensions to be indexed and cached
incorrectly. Specifically, if any of the candidate keys appear in
nested comprehensions, indexing should not be performed because the
evaluator does not close over variable bindings from the outer scope
when evaluating the comprehension (because this would require cache
invalidation if there were multiple assignments to the variables in
the outer scope).

This fix updates the compiler to check if the candidates appear inside
of any nested comprehensions. If a match is found, no indexing is
performed.

Fixes #2497

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
