### PR TITLE
Add nightly github action workflow with race detector job

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,0 +1,15 @@
+name: Nightly
+on:
+  schedule:
+    - cron:  '0 8 * * *'  # Daily, at 8:00 UTC
+
+jobs:
+  race-detector:
+    name: Go Race Detector
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Test with Race Detector
+        run: CGO_ENABLED=1 make ci-go-race-detector

--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,10 @@ go-build: generate
 go-test: generate
 	$(GO) test -tags=slow ./...
 
+.PHONY: race-detector
+race-detector: generate
+	$(GO) test -tags=slow -race -vet=off ./...
+
 .PHONY: test-coverage
 test-coverage:
 	$(GO) test -tags=slow -coverprofile=coverage.txt -covermode=atomic ./...
@@ -193,6 +197,7 @@ CI_GOLANG_DOCKER_MAKE := $(DOCKER) run \
 	-v $(PWD):/src \
 	-w /src \
 	-e GOCACHE=/src/.go/cache \
+	-e CGO_ENABLED=$(CGO_ENABLED) \
 	golang:$(GOVERSION) \
 	make
 

--- a/docs/devel/DEVELOPMENT.md
+++ b/docs/devel/DEVELOPMENT.md
@@ -162,3 +162,16 @@ OPA will need to have them configured to be able to run the full CI workflow.
 | DOCKER_IMAGE | Full docker image name (with org) to tag and publish images to. |
 | DOCKER_USER | Docker username for uploading release images. Will be used with `docker login` |
 | DOCKER_PASSWORD | Docker password or API token for the configured `DOCKER_USER`. Will be used with `docker login` |
+
+
+## Periodic Workflows
+
+Some of the Github Action workflows are triggered on a schedule, and not included in the
+post-merge, pull-request, etc actions. These are reserved for time consuming or potentially
+non-deterministic jobs (race detection tests, fuzzing, etc).
+
+Below is a list of workflows and links to their status:
+
+| Workflow | Description |
+|----------|-------------|
+| [![Nightly](https://github.com/open-policy-agent/opa/workflows/Nightly/badge.svg?branch=master)](https://github.com/open-policy-agent/opa/actions?query=workflow%3A"Nightly") | Runs once per day at 8:00 UTC. |


### PR DESCRIPTION
We will run the golang race detector nightly (to start with.. we'll
adjust the workflow as needed).

One thing to note is that currently cgo is required for the race
detector, so we have to enable it when running this make target.

Fixes: #2388
Signed-off-by: Patrick East <east.patrick@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
