### PR TITLE
Bring back fuzzit

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -13,3 +13,15 @@ jobs:
 
       - name: Test with Race Detector
         run: CGO_ENABLED=1 make ci-go-race-detector
+
+  fuzzit:
+    name: Fuzzit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Run Fuzzit
+        run: make docker-run-fuzzit
+        env:
+          FUZZIT_API_KEY: ${{ secrets.FUZZIT_API_KEY }}

--- a/Dockerfile.fuzzit
+++ b/Dockerfile.fuzzit
@@ -1,0 +1,20 @@
+# Copyright 2019 The OPA Authors.  All rights reserved.
+# Use of this source code is governed by an Apache2
+# license that can be found in the LICENSE file.
+
+ARG GOVERSION
+
+FROM golang:${GOVERSION}
+
+ARG GOARCH=amd64
+WORKDIR /go/src/github.com/open-policy-agent/opa
+
+COPY . .
+
+RUN apt-get update \
+	&& apt-get install -y clang \
+	&& go get -u github.com/dvyukov/go-fuzz/go-fuzz github.com/dvyukov/go-fuzz/go-fuzz-build \
+	&& go-fuzz-build -libfuzzer -o ast-fuzzer.a ./ast/ \
+    && clang -fsanitize=fuzzer ast-fuzzer.a -o ast-fuzzer \
+	&& wget -q -O fuzzit https://github.com/fuzzitdev/fuzzit/releases/download/v2.4.52/fuzzit_Linux_x86_64 \
+	&& chmod a+x fuzzit

--- a/Dockerfile.fuzzit
+++ b/Dockerfile.fuzzit
@@ -6,15 +6,11 @@ ARG GOVERSION
 
 FROM golang:${GOVERSION}
 
-ARG GOARCH=amd64
-WORKDIR /go/src/github.com/open-policy-agent/opa
-
-COPY . .
-
 RUN apt-get update \
-	&& apt-get install -y clang \
-	&& go get -u github.com/dvyukov/go-fuzz/go-fuzz github.com/dvyukov/go-fuzz/go-fuzz-build \
-	&& go-fuzz-build -libfuzzer -o ast-fuzzer.a ./ast/ \
-    && clang -fsanitize=fuzzer ast-fuzzer.a -o ast-fuzzer \
-	&& wget -q -O fuzzit https://github.com/fuzzitdev/fuzzit/releases/download/v2.4.52/fuzzit_Linux_x86_64 \
-	&& chmod a+x fuzzit
+	&& apt-get install -y clang
+
+RUN go get -u github.com/dvyukov/go-fuzz/go-fuzz github.com/dvyukov/go-fuzz/go-fuzz-build
+
+RUN wget -q -O fuzzit https://github.com/fuzzitdev/fuzzit/releases/download/v2.4.77/fuzzit_Linux_x86_64
+RUN chmod a+x fuzzit
+RUN mv fuzzit /bin/

--- a/ast/fuzz.go
+++ b/ast/fuzz.go
@@ -2,19 +2,7 @@
 
 package ast
 
-import (
-	"regexp"
-)
-
-// nested { and [ tokens cause the parse time to explode.
-// see: https://github.com/mna/pigeon/issues/75
-var blacklistRegexp = regexp.MustCompile(`[{(\[]{5,}`)
-
 func Fuzz(data []byte) int {
-
-	if blacklistRegexp.Match(data) {
-		return -1
-	}
 
 	str := string(data)
 	_, _, err := ParseStatements("", str)

--- a/build/fuzzit.sh
+++ b/build/fuzzit.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -ex
+
+# Expects to be run in openpolicyagent/fuzzer docker image from the root of the project.
+
+OPA_DIR=$(dirname "${BASH_SOURCE}")/..
+cd ${OPA_DIR}
+go-fuzz-build -libfuzzer -o ast-fuzzer.a ./ast/
+clang -fsanitize=fuzzer ast-fuzzer.a -o ast-fuzzer
+fuzzit create job --type "fuzzing" opa/ast ast-fuzzer

--- a/docs/devel/DEVELOPMENT.md
+++ b/docs/devel/DEVELOPMENT.md
@@ -163,6 +163,7 @@ OPA will need to have them configured to be able to run the full CI workflow.
 | DOCKER_WASM_BUILDER_IMAGE | Full docker image name (with org) to tag and publish WASM builder images. |
 | DOCKER_USER | Docker username for uploading release images. Will be used with `docker login` |
 | DOCKER_PASSWORD | Docker password or API token for the configured `DOCKER_USER`. Will be used with `docker login` |
+| FUZZIT_API_KEY | API Key for [Fuzzit](https://app.fuzzit.dev/) | 
 
 
 ## Periodic Workflows


### PR DESCRIPTION
It will be added as another job for the "nightly" github action workflow. We now can remove the blacklist stuff too from our fuzzer entrypoint as we have the updated parser that won't choke on them.

The results appear to be async, so this will just start a job over on https://app.fuzzit.dev/orgs/opa/targets/ast and we'll have to monitor results there. We can iterate on this however we need, but for now this should be ok.

Closes: #1843