### PR TITLE
Add is_valid and compare SemVer built-ins

### DIFF
--- a/ast/builtins.go
+++ b/ast/builtins.go
@@ -226,6 +226,10 @@ var DefaultBuiltins = [...]*Builtin{
 
 	// UUIDs
 	UUIDRFC4122,
+
+	//SemVers
+	SemVerIsValid,
+	SemVerCompare,
 }
 
 // BuiltinMap provides a convenient mapping of built-in names to
@@ -2064,6 +2068,32 @@ var ObjectGet = &Builtin{
 			types.A,
 		),
 		types.A,
+	),
+}
+
+// SemVerIsValid validiates a the term is a valid SemVer as a string, returns
+// false for all other input
+var SemVerIsValid = &Builtin{
+	Name: "semver.is_valid",
+	Decl: types.NewFunction(
+		types.Args(
+			types.A,
+		),
+		types.B,
+	),
+}
+
+// SemVerCompare compares valid SemVer formatted version strings. Given two
+// version strings, if A < B returns -1, if A > B returns 1. If A == B, returns
+// 0
+var SemVerCompare = &Builtin{
+	Name: "semver.compare",
+	Decl: types.NewFunction(
+		types.Args(
+			types.S,
+			types.S,
+		),
+		types.N,
 	),
 }
 

--- a/docs/content/policy-reference.md
+++ b/docs/content/policy-reference.md
@@ -952,6 +952,12 @@ net.cidr_contains_matches({["1.1.0.0/16", "foo"], "1.1.2.0/24"}, {"x": "1.1.1.12
 | ------- |-------------|
 | <span class="opa-keep-it-together">``output := uuid.rfc4122(str)``</span> | ``output`` is ``string`` representing a version 4 uuid. For any given str the output will be consistent throughout a query evaluation. |
 
+### Semantic Versions
+| Built-in | Description |
+| ------- |-------------|
+| <span class="opa-keep-it-together">``output := semver.is_valid(str)``</span> | ``output`` is a ``boolean``. ``true`` means the input is a valid SemVer string (e.g. "1.0.0"). ``false`` is returned for invalid version strings and non-string input. |
+| <span class="opa-keep-it-together">``output := semver.compare(str, str)``</span> | ``output`` is a ``number``. ``-1`` means the version in the first operand is less than the second. ``1`` means the version in the first operand is greater than the second. ``0`` means the versions are equal. Only valid SemVer strings are accepted e.g. ``1.2.3`` or ``0.1.0`` |
+
 ### Rego
 | Built-in | Description |
 | ------- |-------------|

--- a/go.mod
+++ b/go.mod
@@ -31,5 +31,5 @@ require (
 	golang.org/x/lint v0.0.0-20181023182221-1baf3a9d7d67
 	golang.org/x/tools v0.0.0-20190920225731-5eefd052ad72
 	gopkg.in/fsnotify.v1 v1.4.7
-	gopkg.in/yaml.v2 v2.2.1 // indirect
+	gopkg.in/yaml.v2 v2.2.1
 )

--- a/internal/semver/LICENSE
+++ b/internal/semver/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/internal/semver/semver.go
+++ b/internal/semver/semver.go
@@ -1,0 +1,235 @@
+// Copyright 2013-2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Semantic Versions http://semver.org
+
+// Package semver has been vendored from:
+// https://github.com/coreos/go-semver/tree/e214231b295a8ea9479f11b70b35d5acf3556d9b/semver
+// A number of the original functions of the package have been removed since
+// they are not required for our built-ins.
+package semver
+
+import (
+	"bytes"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// Version represents a parsed SemVer
+type Version struct {
+	Major      int64
+	Minor      int64
+	Patch      int64
+	PreRelease PreRelease
+	Metadata   string
+}
+
+// PreRelease represents a pre-release suffix string
+type PreRelease string
+
+func splitOff(input *string, delim string) (val string) {
+	parts := strings.SplitN(*input, delim, 2)
+
+	if len(parts) == 2 {
+		*input = parts[0]
+		val = parts[1]
+	}
+
+	return val
+}
+
+// NewVersion constucts new SemVers from strings
+func NewVersion(version string) (*Version, error) {
+	v := Version{}
+
+	if err := v.Set(version); err != nil {
+		return nil, err
+	}
+
+	return &v, nil
+}
+
+// Set parses and updates v from the given version string. Implements flag.Value
+func (v *Version) Set(version string) error {
+	metadata := splitOff(&version, "+")
+	preRelease := PreRelease(splitOff(&version, "-"))
+	dotParts := strings.SplitN(version, ".", 3)
+
+	if len(dotParts) != 3 {
+		return fmt.Errorf("%s is not in dotted-tri format", version)
+	}
+
+	if err := validateIdentifier(string(preRelease)); err != nil {
+		return fmt.Errorf("failed to validate pre-release: %v", err)
+	}
+
+	if err := validateIdentifier(metadata); err != nil {
+		return fmt.Errorf("failed to validate metadata: %v", err)
+	}
+
+	parsed := make([]int64, 3, 3)
+
+	for i, v := range dotParts[:3] {
+		val, err := strconv.ParseInt(v, 10, 64)
+		parsed[i] = val
+		if err != nil {
+			return err
+		}
+	}
+
+	v.Metadata = metadata
+	v.PreRelease = preRelease
+	v.Major = parsed[0]
+	v.Minor = parsed[1]
+	v.Patch = parsed[2]
+	return nil
+}
+
+func (v Version) String() string {
+	var buffer bytes.Buffer
+
+	fmt.Fprintf(&buffer, "%d.%d.%d", v.Major, v.Minor, v.Patch)
+
+	if v.PreRelease != "" {
+		fmt.Fprintf(&buffer, "-%s", v.PreRelease)
+	}
+
+	if v.Metadata != "" {
+		fmt.Fprintf(&buffer, "+%s", v.Metadata)
+	}
+
+	return buffer.String()
+}
+
+// Compare tests if v is less than, equal to, or greater than versionB,
+// returning -1, 0, or +1 respectively.
+func (v Version) Compare(versionB Version) int {
+	if cmp := recursiveCompare(v.Slice(), versionB.Slice()); cmp != 0 {
+		return cmp
+	}
+	return preReleaseCompare(v, versionB)
+}
+
+// Slice converts the comparable parts of the semver into a slice of integers.
+func (v Version) Slice() []int64 {
+	return []int64{v.Major, v.Minor, v.Patch}
+}
+
+// Slice splits the pre-release suffix string
+func (p PreRelease) Slice() []string {
+	preRelease := string(p)
+	return strings.Split(preRelease, ".")
+}
+
+func preReleaseCompare(versionA Version, versionB Version) int {
+	a := versionA.PreRelease
+	b := versionB.PreRelease
+
+	/* Handle the case where if two versions are otherwise equal it is the
+	 * one without a PreRelease that is greater */
+	if len(a) == 0 && (len(b) > 0) {
+		return 1
+	} else if len(b) == 0 && (len(a) > 0) {
+		return -1
+	}
+
+	// If there is a prerelease, check and compare each part.
+	return recursivePreReleaseCompare(a.Slice(), b.Slice())
+}
+
+func recursiveCompare(versionA []int64, versionB []int64) int {
+	if len(versionA) == 0 {
+		return 0
+	}
+
+	a := versionA[0]
+	b := versionB[0]
+
+	if a > b {
+		return 1
+	} else if a < b {
+		return -1
+	}
+
+	return recursiveCompare(versionA[1:], versionB[1:])
+}
+
+func recursivePreReleaseCompare(versionA []string, versionB []string) int {
+	// A larger set of pre-release fields has a higher precedence than a smaller set,
+	// if all of the preceding identifiers are equal.
+	if len(versionA) == 0 {
+		if len(versionB) > 0 {
+			return -1
+		}
+		return 0
+	} else if len(versionB) == 0 {
+		// We're longer than versionB so return 1.
+		return 1
+	}
+
+	a := versionA[0]
+	b := versionB[0]
+
+	aInt := false
+	bInt := false
+
+	aI, err := strconv.Atoi(versionA[0])
+	if err == nil {
+		aInt = true
+	}
+
+	bI, err := strconv.Atoi(versionB[0])
+	if err == nil {
+		bInt = true
+	}
+
+	// Numeric identifiers always have lower precedence than non-numeric identifiers.
+	if aInt && !bInt {
+		return -1
+	} else if !aInt && bInt {
+		return 1
+	}
+
+	// Handle Integer Comparison
+	if aInt && bInt {
+		if aI > bI {
+			return 1
+		} else if aI < bI {
+			return -1
+		}
+	}
+
+	// Handle String Comparison
+	if a > b {
+		return 1
+	} else if a < b {
+		return -1
+	}
+
+	return recursivePreReleaseCompare(versionA[1:], versionB[1:])
+}
+
+// validateIdentifier makes sure the provided identifier satisfies semver spec
+func validateIdentifier(id string) error {
+	if id != "" && !reIdentifier.MatchString(id) {
+		return fmt.Errorf("%s is not a valid semver identifier", id)
+	}
+	return nil
+}
+
+// reIdentifier is a regular expression used to check that pre-release and metadata
+// identifiers satisfy the spec requirements
+var reIdentifier = regexp.MustCompile(`^[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*$`)

--- a/internal/semver/semver_test.go
+++ b/internal/semver/semver_test.go
@@ -1,0 +1,110 @@
+// Copyright 2013-2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// vendored from: https://github.com/coreos/go-semver/tree/e214231b295a8ea9479f11b70b35d5acf3556d9b/semver
+package semver
+
+import (
+	"testing"
+)
+
+type fixture struct {
+	GreaterVersion string
+	LesserVersion  string
+}
+
+var fixtures = []fixture{
+	{"0.0.0", "0.0.0-foo"},
+	{"0.0.1", "0.0.0"},
+	{"1.0.0", "0.9.9"},
+	{"0.10.0", "0.9.0"},
+	{"0.99.0", "0.10.0"},
+	{"2.0.0", "1.2.3"},
+	{"0.0.0", "0.0.0-foo"},
+	{"0.0.1", "0.0.0"},
+	{"1.0.0", "0.9.9"},
+	{"0.10.0", "0.9.0"},
+	{"0.99.0", "0.10.0"},
+	{"2.0.0", "1.2.3"},
+	{"0.0.0", "0.0.0-foo"},
+	{"0.0.1", "0.0.0"},
+	{"1.0.0", "0.9.9"},
+	{"0.10.0", "0.9.0"},
+	{"0.99.0", "0.10.0"},
+	{"2.0.0", "1.2.3"},
+	{"1.2.3", "1.2.3-asdf"},
+	{"1.2.3", "1.2.3-4"},
+	{"1.2.3", "1.2.3-4-foo"},
+	{"1.2.3-5-foo", "1.2.3-5"},
+	{"1.2.3-5", "1.2.3-4"},
+	{"1.2.3-5-foo", "1.2.3-5-Foo"},
+	{"3.0.0", "2.7.2+asdf"},
+	{"3.0.0+foobar", "2.7.2"},
+	{"1.2.3-a.10", "1.2.3-a.5"},
+	{"1.2.3-a.b", "1.2.3-a.5"},
+	{"1.2.3-a.b", "1.2.3-a"},
+	{"1.2.3-a.b.c.10.d.5", "1.2.3-a.b.c.5.d.100"},
+	{"1.0.0", "1.0.0-rc.1"},
+	{"1.0.0-rc.2", "1.0.0-rc.1"},
+	{"1.0.0-rc.1", "1.0.0-beta.11"},
+	{"1.0.0-beta.11", "1.0.0-beta.2"},
+	{"1.0.0-beta.2", "1.0.0-beta"},
+	{"1.0.0-beta", "1.0.0-alpha.beta"},
+	{"1.0.0-alpha.beta", "1.0.0-alpha.1"},
+	{"1.0.0-alpha.1", "1.0.0-alpha"},
+	{"1.2.3-rc.1-1-1hash", "1.2.3-rc.2"},
+}
+
+func TestCompare(t *testing.T) {
+	for _, v := range fixtures {
+		gt, err := NewVersion(v.GreaterVersion)
+		if err != nil {
+			t.Error(err)
+		}
+
+		lt, err := NewVersion(v.LesserVersion)
+		if err != nil {
+			t.Error(err)
+		}
+
+		if gt.Compare(*lt) <= 0 {
+			t.Errorf("%s should be greater than %s", gt, lt)
+		}
+		if lt.Compare(*gt) > 0 {
+			t.Errorf("%s should not be greater than %s", lt, gt)
+		}
+	}
+}
+
+type fixtureJSON struct {
+	GreaterVersion *Version
+	LesserVersion  *Version
+}
+
+func TestBadInput(t *testing.T) {
+	bad := []string{
+		"1.2",
+		"1.2.3x",
+		"0x1.3.4",
+		"-1.2.3",
+		"1.2.3.4",
+		"0.88.0-11_e4e5dcabb",
+		"0.88.0+11_e4e5dcabb",
+	}
+	for _, b := range bad {
+		if _, err := NewVersion(b); err == nil {
+			t.Error("Improperly accepted value: ", b)
+		}
+	}
+}

--- a/topdown/semver.go
+++ b/topdown/semver.go
@@ -1,0 +1,60 @@
+// Copyright 2020 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package topdown
+
+import (
+	"fmt"
+
+	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/internal/semver"
+	"github.com/open-policy-agent/opa/topdown/builtins"
+)
+
+func builtinSemVerCompare(bctx BuiltinContext, args []*ast.Term, iter func(*ast.Term) error) error {
+	versionStringA, err := builtins.StringOperand(args[0].Value, 1)
+	if err != nil {
+		return err
+	}
+
+	versionStringB, err := builtins.StringOperand(args[1].Value, 2)
+	if err != nil {
+		return err
+	}
+
+	versionA, err := semver.NewVersion(string(versionStringA))
+	if err != nil {
+		return fmt.Errorf("operand 1: string %s is not a valid SemVer", versionStringA)
+	}
+	versionB, err := semver.NewVersion(string(versionStringB))
+	if err != nil {
+		return fmt.Errorf("operand 2: string %s is not a valid SemVer", versionStringB)
+	}
+
+	result := versionA.Compare(*versionB)
+
+	return iter(ast.IntNumberTerm(result))
+}
+
+func builtinSemVerIsValid(bctx BuiltinContext, args []*ast.Term, iter func(*ast.Term) error) error {
+	versionString, err := builtins.StringOperand(args[0].Value, 1)
+	if err != nil {
+		result := ast.BooleanTerm(false)
+		return iter(result)
+	}
+
+	result := true
+
+	_, err = semver.NewVersion(string(versionString))
+	if err != nil {
+		result = false
+	}
+
+	return iter(ast.BooleanTerm(result))
+}
+
+func init() {
+	RegisterBuiltinFunc(ast.SemVerCompare.Name, builtinSemVerCompare)
+	RegisterBuiltinFunc(ast.SemVerIsValid.Name, builtinSemVerIsValid)
+}

--- a/topdown/semver_test.go
+++ b/topdown/semver_test.go
@@ -1,0 +1,67 @@
+// Copyright 2020 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package topdown
+
+import (
+	"testing"
+
+	"github.com/open-policy-agent/opa/ast"
+)
+
+func TestSemVerCompare(t *testing.T) {
+	tests := []struct {
+		note     string
+		rules    []string
+		expected interface{}
+	}{
+		{"a < b", []string{`p = x { x = semver.compare("1.0.0", "2.0.0") }`}, "-1"},
+		{"a > b", []string{`p = x { x = semver.compare("2.0.0", "1.0.0") }`}, "1"},
+		{"a == b", []string{`p = x { x = semver.compare("1.0.0", "1.0.0") }`}, "0"},
+		{
+			"invalid type a",
+			[]string{`p = x { x = semver.compare(1, "1.0.0") }`},
+			ast.Errors{ast.NewError(ast.TypeErr, nil, "semver.compare: invalid argument(s)")},
+		},
+		{
+			"invalid type b",
+			[]string{`p = x { x = semver.compare("1.0.0", false) }`},
+			ast.Errors{ast.NewError(ast.TypeErr, nil, "semver.compare: invalid argument(s)")},
+		},
+		{
+			"invalid version a",
+			[]string{`p = x { x = semver.compare("1", "1.0.0") }`},
+			&Error{Code: BuiltinErr, Message: `semver.compare("1", "1.0.0"): eval_builtin_error: semver.compare: operand 1: string "1" is not a valid SemVer`},
+		},
+		{
+			"invalid version b",
+			[]string{`p = x { x = semver.compare("1.0.0", "1") }`},
+			&Error{Code: BuiltinErr, Message: `semver.compare("1.0.0", "1"): eval_builtin_error: semver.compare: operand 2: string "1" is not a valid SemVer`},
+		},
+	}
+
+	data := map[string]interface{}{}
+
+	for _, tc := range tests {
+		runTopDownTestCase(t, data, tc.note, tc.rules, tc.expected)
+	}
+}
+
+func TestSemVerIsValid(t *testing.T) {
+	tests := []struct {
+		note     string
+		rules    []string
+		expected interface{}
+	}{
+		{"valid", []string{`p = x { x = semver.is_valid("1.0.0") }`}, "true"},
+		{"invalid version", []string{`p = x { x = semver.is_valid("1") }`}, "false"},
+		{"invalid type", []string{`p = x { x = semver.is_valid(1) }`}, "false"},
+	}
+
+	data := map[string]interface{}{}
+
+	for _, tc := range tests {
+		runTopDownTestCase(t, data, tc.note, tc.rules, tc.expected)
+	}
+}


### PR DESCRIPTION
I recently wrote a [gist](https://gist.github.com/charlieegan3/76dbec05c65164ac98dfec74b1381c5a) to compare Semantic Version strings as a proof of concept for something I was working on. Given the domains that OPA is commonly used in, I thought this might be a useful built-in. Especially after learning that it was hardly trivial in Rego alone (see gist).

Our use case was comparing installed software with recommended/insecure versions of the same applications.

Here is an example of what the functions look like:

```
> semver.is_valid("1.0.0")
true
> semver.is_valid(1)
false
> semver.compare("1.0.0", "2.0.0")
-1
> semver.compare("2.0.0", "1.0.0")
1
> semver.compare("1.0.0", "1.0.0")
0
> semver.compare("1.0.0", "1")
1 error occurred: semver.compare("1.0.0", "1"): eval_builtin_error: semver.compare: operand 2: string "1" is not a valid SemVer
> semver.compare("1.0.0", 1)
1 error occurred: 1:1: rego_type_error: semver.compare: invalid argument(s)
        have: (string, number)
        want: (string, string, number)
```

I apologise in advance for not raising an issue first to discuss the idea - I found myself with some time today and took the opportunity. I won't be offended if you feel this is too specific :smile_cat: 


