### PR TITLE
st: Make Set and Object string representation deterministic

### DIFF
--- a/ast/term.go
+++ b/ast/term.go
@@ -1199,9 +1199,10 @@ func (s *set) String() string {
 		return "set()"
 	}
 	buf := []string{}
-	s.Foreach(func(x *Term) {
+	sorted := s.Sorted()
+	for _, x := range sorted {
 		buf = append(buf, fmt.Sprint(x))
-	})
+	}
 	return "{" + strings.Join(buf, ", ") + "}"
 }
 
@@ -1806,9 +1807,11 @@ func (obj object) Len() int {
 
 func (obj object) String() string {
 	var buf []string
-	obj.Foreach(func(k, v *Term) {
+	sorted := termSliceSorted(obj.Keys())
+	for _, k := range sorted {
+		v := obj.Get(k)
 		buf = append(buf, fmt.Sprintf("%s: %s", k, v))
-	})
+	}
 	return "{" + strings.Join(buf, ", ") + "}"
 }
 
@@ -2207,6 +2210,15 @@ func (c Call) String() string {
 		args[i-1] = c[i].String()
 	}
 	return fmt.Sprintf("%v(%v)", c[0], strings.Join(args, ", "))
+}
+
+func termSliceSorted(a []*Term) []*Term {
+	b := make([]*Term, len(a))
+	for i := range b {
+		b[i] = a[i]
+	}
+	sort.Sort(termSlice(b))
+	return b
 }
 
 func termSliceCopy(a []*Term) []*Term {

--- a/ast/term_test.go
+++ b/ast/term_test.go
@@ -425,10 +425,14 @@ func TestTermString(t *testing.T) {
 	assertToString(t, ArrayTerm().Value, "[]")
 	assertToString(t, ObjectTerm().Value, "{}")
 	assertToString(t, SetTerm().Value, "set()")
-	assertToString(t, ArrayTerm(ObjectTerm(Item(VarTerm("foo"), ArrayTerm(RefTerm(VarTerm("bar"), VarTerm("i"))))), StringTerm("foo"), SetTerm(BooleanTerm(true), NullTerm()), FloatNumberTerm(42.1)).Value, "[{foo: [bar[i]]}, \"foo\", {true, null}, 42.1]")
+	assertToString(t, ArrayTerm(ObjectTerm(Item(VarTerm("foo"), ArrayTerm(RefTerm(VarTerm("bar"), VarTerm("i"))))), StringTerm("foo"), SetTerm(BooleanTerm(true), NullTerm()), FloatNumberTerm(42.1)).Value, "[{foo: [bar[i]]}, \"foo\", {null, true}, 42.1]")
 	assertToString(t, ArrayComprehensionTerm(ArrayTerm(VarTerm("x")), NewBody(&Expr{Terms: RefTerm(VarTerm("a"), VarTerm("i"))})).Value, `[[x] | a[i]]`)
 	assertToString(t, ObjectComprehensionTerm(VarTerm("y"), ArrayTerm(VarTerm("x")), NewBody(&Expr{Terms: RefTerm(VarTerm("a"), VarTerm("i"))})).Value, `{y: [x] | a[i]}`)
 	assertToString(t, SetComprehensionTerm(ArrayTerm(VarTerm("x")), NewBody(&Expr{Terms: RefTerm(VarTerm("a"), VarTerm("i"))})).Value, `{[x] | a[i]}`)
+
+	// ensure that objects and sets have deterministic String() results
+	assertToString(t, SetTerm(VarTerm("y"), VarTerm("x")).Value, "{x, y}")
+	assertToString(t, ObjectTerm([2]*Term{VarTerm("y"), VarTerm("b")}, [2]*Term{VarTerm("x"), VarTerm("a")}).Value, "{x: a, y: b}")
 }
 
 func TestRefHasPrefix(t *testing.T) {


### PR DESCRIPTION
This commit modifies the object and set String() implementations to
sort the keys so that the string representation is
deterministic. Previously the order was implicitly determined by insertion.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
