### PR TITLE
topdown: Mark vars as unknown in exprs saved due to with stmts

### DIFF
--- a/topdown/topdown_partial_test.go
+++ b/topdown/topdown_partial_test.go
@@ -626,6 +626,49 @@ func TestTopDownPartialEval(t *testing.T) {
 			wantQueries: []string{"data.test.q with data.foo as [input.x]"},
 		},
 		{
+			note:  "with: unknown value propagates to outputs (eq)",
+			query: "data.test.p = z",
+			modules: []string{
+				`package test
+
+				q = 1 { input.foo = 1 }
+				p = y { x = q with data.bar as input.bar; plus(x, 1, y) }`,
+			},
+			wantQueries: []string{"x1 = data.test.q with data.bar as input.bar; plus(x1, 1, z)"},
+		},
+		{
+			note:  "with: unknown value propagates to outputs (ref)",
+			query: "data.test.p = z",
+			modules: []string{
+				`package test
+
+				q[1] { input.foo = 1 }
+				p = y { q[x] with data.bar as input.bar; plus(x, 1, y) }`,
+			},
+			wantQueries: []string{"data.test.q[x1] with data.bar as input.bar; plus(x1, 1, z)"},
+		},
+		{
+			note:  "with: unknown value propagates to outputs (call)",
+			query: "data.test.p = z",
+			modules: []string{
+				`package test
+
+				f(t) = 1 { input.foo = t }
+				p = y { f(1, x) with data.bar as input.bar; plus(x, 1, y) }`,
+			},
+			wantQueries: []string{"data.test.f(1, x1) with data.bar as input.bar; plus(x1, 1, z)"},
+		},
+		{
+			note:  "with: unknown value propagates to outputs (built-in)",
+			query: "data.test.p = z",
+			modules: []string{
+				`package test
+
+				p = y { time.now_ns(x) with data.bar as input.bar; plus(x, 1, y) }`,
+			},
+			wantQueries: []string{"time.now_ns(x1) with data.bar as input.bar; plus(x1, 1, z)"},
+		},
+		{
 			note:  "with: ground prefix disabled",
 			query: "data.test.p = true",
 			modules: []string{


### PR DESCRIPTION
Previously, if an expression was saved due to a `with` statement
containing an unknown value, the vars in the expression were not
marked as unknown. This resulted in subsequent expressions that
depended on those unknowns being evaluated incorrectly.

This commit fixes the issue so that vars in the outputs from the
expression are marked as unknown.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
