### PR TITLE
CI: Add slack notifications for periodic jobs

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -14,6 +14,17 @@ jobs:
       - name: Test with Race Detector
         run: CGO_ENABLED=1 make ci-go-race-detector
 
+      - name: Slack Notification
+        uses: rtCamp/action-slack-notify@v2.1.0
+        if: ${{ failure() && secrets.SLACK_NOTIFICATION_WEBHOOK != "" }}
+        env:
+          SLACK_COLOR: '#FF0000'
+          SLACK_ICON_EMOJI: ':x:'
+          SLACK_MESSAGE: 'OPA Race Detector Test Failure!'
+          SLACK_USERNAME: Github Actions
+          SLACK_WEBHOOK: ${{ secrets.SLACK_NOTIFICATION_WEBHOOK }}
+          SLACK_FOOTER: 'Github Action Slack Notification'
+
   fuzzer:
     name: Go Fuzzer
     runs-on: ubuntu-latest
@@ -29,3 +40,14 @@ jobs:
         with:
           name: workdir
           path: ./build/fuzzer/workdir
+
+      - name: Slack Notification
+        uses: rtCamp/action-slack-notify@v2.1.0
+        if: ${{ failure() && secrets.SLACK_NOTIFICATION_WEBHOOK != "" }}
+        env:
+          SLACK_COLOR: '#FF0000'
+          SLACK_ICON_EMOJI: ':x:'
+          SLACK_MESSAGE: 'OPA Fuzzer Test Failure!'
+          SLACK_USERNAME: Github Actions
+          SLACK_WEBHOOK: ${{ secrets.SLACK_NOTIFICATION_WEBHOOK }}
+          SLACK_FOOTER: 'Github Action Slack Notification'

--- a/docs/devel/DEVELOPMENT.md
+++ b/docs/devel/DEVELOPMENT.md
@@ -163,7 +163,7 @@ OPA will need to have them configured to be able to run the full CI workflow.
 | DOCKER_WASM_BUILDER_IMAGE | Full docker image name (with org) to tag and publish WASM builder images. |
 | DOCKER_USER | Docker username for uploading release images. Will be used with `docker login` |
 | DOCKER_PASSWORD | Docker password or API token for the configured `DOCKER_USER`. Will be used with `docker login` |
-
+| SLACK_NOTIFICATION_WEBHOOK | Slack webhook for sending notifications. Optional -- If not provided the notification steps are skipped. |
 
 ## Periodic Workflows
 


### PR DESCRIPTION
We are using a 3rd party action to simplify this. It appears to be
relatively well used, and the code looked pretty safe. It only has
access to the slack webhook secret, which is itself restricted in
permissions, so the risk is minimal.

It is configured to post a message for jobs that fail to the OPA
slack in the #development channel.

Signed-off-by: Patrick East <east.patrick@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
