### PR TITLE
CI: Skip pushing wasm builder unless required

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -314,7 +314,7 @@ push-image: docker-login image-quick push
 
 .PHONY: push-wasm-builder-image
 push-wasm-builder-image: docker-login
-	$(MAKE) -C wasm builder push-builder
+	$(MAKE) -C wasm push-builder
 
 .PHONY: deploy-ci
 deploy-ci: push-image tag-edge push-edge push-binary-edge

--- a/wasm/Makefile
+++ b/wasm/Makefile
@@ -39,7 +39,7 @@ ensure-builder:
 
 .PHONY: push-builder
 push-builder:
-	$(DOCKER) push $(WASM_BUILDER_IMAGE)
+	$(DOCKER) pull $(WASM_BUILDER_IMAGE) || ($(MAKE) builder && $(DOCKER) push $(WASM_BUILDER_IMAGE))
 
 .PHONY: build
 build:


### PR DESCRIPTION
The `push-builder` target will now check if the tag is already
available via a test with `docker pull`. It will only build and
push if the image is not available remotely.

Signed-off-by: Patrick East <east.patrick@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
