### PR TITLE
Add regex.is_valid built-in function

### DIFF
--- a/ast/builtins.go
+++ b/ast/builtins.go
@@ -87,6 +87,7 @@ var DefaultBuiltins = [...]*Builtin{
 	CastArray,
 
 	// Regular Expressions
+	RegexIsValid,
 	RegexMatch,
 	RegexSplit,
 	GlobsMatch,
@@ -672,6 +673,17 @@ var RegexMatch = &Builtin{
 	Decl: types.NewFunction(
 		types.Args(
 			types.S,
+			types.S,
+		),
+		types.B,
+	),
+}
+
+// RegexIsValid returns true if the regex pattern string is valid, otherwise false.
+var RegexIsValid = &Builtin{
+	Name: "regex.is_valid",
+	Decl: types.NewFunction(
+		types.Args(
 			types.S,
 		),
 		types.B,

--- a/ast/builtins.go
+++ b/ast/builtins.go
@@ -89,6 +89,7 @@ var DefaultBuiltins = [...]*Builtin{
 	// Regular Expressions
 	RegexIsValid,
 	RegexMatch,
+	RegexMatchDeprecated,
 	RegexSplit,
 	GlobsMatch,
 	RegexTemplateMatch,
@@ -669,7 +670,7 @@ var ToNumber = &Builtin{
 // RegexMatch takes two strings and evaluates to true if the string in the second
 // position matches the pattern in the first position.
 var RegexMatch = &Builtin{
-	Name: "re_match",
+	Name: "regex.match",
 	Decl: types.NewFunction(
 		types.Args(
 			types.S,
@@ -1136,6 +1137,20 @@ var JSONRemove = &Builtin{
 					),
 				),
 			),
+		),
+		types.A,
+	),
+}
+
+// ObjectGet returns takes an object and returns a value under its key if
+// present, otherwise it returns the default.
+var ObjectGet = &Builtin{
+	Name: "object.get",
+	Decl: types.NewFunction(
+		types.Args(
+			types.NewObject(nil, types.NewDynamicProperty(types.A, types.A)),
+			types.A,
+			types.A,
 		),
 		types.A,
 	),
@@ -1983,6 +1998,36 @@ var netCidrContainsMatchesOperandType = types.NewAny(
 )
 
 /**
+ * Semantic Versions
+ */
+
+// SemVerIsValid validiates a the term is a valid SemVer as a string, returns
+// false for all other input
+var SemVerIsValid = &Builtin{
+	Name: "semver.is_valid",
+	Decl: types.NewFunction(
+		types.Args(
+			types.A,
+		),
+		types.B,
+	),
+}
+
+// SemVerCompare compares valid SemVer formatted version strings. Given two
+// version strings, if A < B returns -1, if A > B returns 1. If A == B, returns
+// 0
+var SemVerCompare = &Builtin{
+	Name: "semver.compare",
+	Decl: types.NewFunction(
+		types.Args(
+			types.S,
+			types.S,
+		),
+		types.N,
+	),
+}
+
+/**
  * Deprecated built-ins.
  */
 
@@ -2069,43 +2114,15 @@ var CastObject = &Builtin{
 	),
 }
 
-// ObjectGet returns takes an object and returns a value under its key if
-// present, otherwise it returns the default.
-var ObjectGet = &Builtin{
-	Name: "object.get",
+// RegexMatchDeprecated declares `re_match` which has been deprecated. Use `regex.match` instead.
+var RegexMatchDeprecated = &Builtin{
+	Name: "re_match",
 	Decl: types.NewFunction(
 		types.Args(
-			types.NewObject(nil, types.NewDynamicProperty(types.A, types.A)),
-			types.A,
-			types.A,
-		),
-		types.A,
-	),
-}
-
-// SemVerIsValid validiates a the term is a valid SemVer as a string, returns
-// false for all other input
-var SemVerIsValid = &Builtin{
-	Name: "semver.is_valid",
-	Decl: types.NewFunction(
-		types.Args(
-			types.A,
+			types.S,
+			types.S,
 		),
 		types.B,
-	),
-}
-
-// SemVerCompare compares valid SemVer formatted version strings. Given two
-// version strings, if A < B returns -1, if A > B returns 1. If A == B, returns
-// 0
-var SemVerCompare = &Builtin{
-	Name: "semver.compare",
-	Decl: types.NewFunction(
-		types.Args(
-			types.S,
-			types.S,
-		),
-		types.N,
 	),
 }
 

--- a/docs/content/policy-reference.md
+++ b/docs/content/policy-reference.md
@@ -362,6 +362,7 @@ complex types.
 | Built-in | Description |
 | ------- |-------------|
 | <span class="opa-keep-it-together">``re_match(pattern, value)``</span> | true if the ``value`` matches the regex ``pattern`` |
+| <span class="opa-keep-it-together">``output := regex.is_valid(pattern)``</span> | ``output`` is a ``boolean`` that indicates if ``pattern` is a valid regex pattern. The detailed syntax for regex patterns is defined by https://github.com/google/re2/wiki/Syntax. |
 | <span class="opa-keep-it-together">``output := regex.split(pattern, string)``</span> | ``output`` is ``array[string]`` representing elements of ``string`` separated by ``pattern`` |
 | <span class="opa-keep-it-together">``regex.globs_match(glob1, glob2)``</span> | true if the intersection of regex-style globs ``glob1`` and ``glob2`` matches a non-empty set of non-empty strings. The set of regex symbols is limited for this builtin: only ``.``, ``*``, ``+``, ``[``, ``-``, ``]`` and ``\`` are treated as special symbols. |
 | <span class="opa-keep-it-normal">``output := regex.template_match(pattern, string, delimiter_start, delimiter_end)``</span> | ``output`` is true if ``string`` matches ``pattern``. ``pattern`` is a string containing ``0..n`` regular expressions delimited by ``delimiter_start`` and ``delimiter_end``. Example ``regex.template_match("urn:foo:{.*}", "urn:foo:bar:baz", "{", "}")`` returns ``true``. |

--- a/docs/content/policy-reference.md
+++ b/docs/content/policy-reference.md
@@ -361,7 +361,7 @@ complex types.
 ### Regex
 | Built-in | Description |
 | ------- |-------------|
-| <span class="opa-keep-it-together">``re_match(pattern, value)``</span> | true if the ``value`` matches the regex ``pattern`` |
+| <span class="opa-keep-it-together">``output := regex.match(pattern, value)``</span> | ``output`` is a ``boolean`` that indicates if ``value`` matches the regex ``pattern``. |
 | <span class="opa-keep-it-together">``output := regex.is_valid(pattern)``</span> | ``output`` is a ``boolean`` that indicates if ``pattern` is a valid regex pattern. The detailed syntax for regex patterns is defined by https://github.com/google/re2/wiki/Syntax. |
 | <span class="opa-keep-it-together">``output := regex.split(pattern, string)``</span> | ``output`` is ``array[string]`` representing elements of ``string`` separated by ``pattern`` |
 | <span class="opa-keep-it-together">``regex.globs_match(glob1, glob2)``</span> | true if the intersection of regex-style globs ``glob1`` and ``glob2`` matches a non-empty set of non-empty strings. The set of regex symbols is limited for this builtin: only ``.``, ``*``, ``+``, ``[``, ``-``, ``]`` and ``\`` are treated as special symbols. |

--- a/topdown/regex.go
+++ b/topdown/regex.go
@@ -209,6 +209,7 @@ func init() {
 	regexpCache = map[string]*regexp.Regexp{}
 	RegisterBuiltinFunc(ast.RegexIsValid.Name, builtinRegexIsValid)
 	RegisterFunctionalBuiltin2(ast.RegexMatch.Name, builtinRegexMatch)
+	RegisterFunctionalBuiltin2(ast.RegexMatchDeprecated.Name, builtinRegexMatch)
 	RegisterFunctionalBuiltin2(ast.RegexSplit.Name, builtinRegexSplit)
 	RegisterFunctionalBuiltin2(ast.GlobsMatch.Name, builtinGlobsMatch)
 	RegisterFunctionalBuiltin4(ast.RegexTemplateMatch.Name, builtinRegexMatchTemplate)

--- a/topdown/regex_test.go
+++ b/topdown/regex_test.go
@@ -1,6 +1,36 @@
 package topdown
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestRegexIsValid(t *testing.T) {
+	tests := []struct {
+		note     string
+		rules    []string
+		expected interface{}
+	}{
+		{
+			note:     "bad operand type",
+			rules:    []string{"p = x { regex.is_valid(data.num, x) }"},
+			expected: "false",
+		},
+		{
+			note:     "bad pattern",
+			rules:    []string{"p = x { regex.is_valid(`++`, x) }"},
+			expected: "false",
+		},
+		{
+			note:     "good pattern",
+			rules:    []string{"p = x { regex.is_valid(`.+`, x) }"},
+			expected: "true",
+		},
+	}
+	for _, tc := range tests {
+		runTopDownTestCase(t, map[string]interface{}{"num": json.Number("10")}, tc.note, tc.rules, tc.expected)
+	}
+}
 
 func TestRegexMatchTemplate(t *testing.T) {
 	tests := []struct {

--- a/topdown/topdown_test.go
+++ b/topdown/topdown_test.go
@@ -1275,6 +1275,7 @@ func TestTopDownRegexMatch(t *testing.T) {
 
 		{"re_match: raw", []string{fmt.Sprintf(`p = true { re_match(%s, "foo[1]") }`, "`^[a-z]+\\[[0-9]+\\]$`")}, "true"},
 		{"re_match: raw: undefined", []string{fmt.Sprintf(`p = true { re_match(%s, "foo[\"bar\"]") }`, "`^[a-z]+\\[[0-9]+\\]$`")}, ""},
+		{"regex.match", []string{`p = true { regex.match("^[a-z]+\\[[0-9]+\\]$", "foo[1]") }`}, "true"},
 	}
 
 	data := loadSmallTestData()


### PR DESCRIPTION
I think this is quite self-contained/explanatory. I've also updated the docs to refer to `regex.match` so that we move away from `re_match`.

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
