### PR TITLE
topdown, rego: Add parameter to set wall clock time

### DIFF
--- a/topdown/builtins.go
+++ b/topdown/builtins.go
@@ -31,6 +31,7 @@ type (
 	BuiltinContext struct {
 		Context      context.Context // request context that was passed when query started
 		Seed         io.Reader       // randomization seed
+		Time         *ast.Term       // wall clock time
 		Cancel       Cancel          // atomic value that signals evaluation to halt
 		Runtime      *ast.Term       // runtime information on the OPA instance
 		Cache        builtins.Cache  // built-in function state cache

--- a/topdown/eval.go
+++ b/topdown/eval.go
@@ -32,6 +32,7 @@ func (f *queryIDFactory) Next() uint64 {
 type eval struct {
 	ctx                context.Context
 	seed               io.Reader
+	time               *ast.Term
 	queryID            uint64
 	queryIDFact        *queryIDFactory
 	parent             *eval
@@ -613,6 +614,7 @@ func (e *eval) evalCall(terms []*ast.Term, iter unifyIterator) error {
 	bctx := BuiltinContext{
 		Context:      e.ctx,
 		Seed:         e.seed,
+		Time:         e.time,
 		Cancel:       e.cancel,
 		Runtime:      e.runtime,
 		Cache:        e.builtinCache,

--- a/topdown/time.go
+++ b/topdown/time.go
@@ -16,26 +16,11 @@ import (
 	"github.com/open-policy-agent/opa/topdown/builtins"
 )
 
-type nowKeyID string
-
-var nowKey = nowKeyID("time.now_ns")
 var tzCache map[string]*time.Location
 var tzCacheMutex *sync.Mutex
 
 func builtinTimeNowNanos(bctx BuiltinContext, _ []*ast.Term, iter func(*ast.Term) error) error {
-
-	exist, ok := bctx.Cache.Get(nowKey)
-	var now *ast.Term
-
-	if !ok {
-		curr := time.Now()
-		now = ast.NewTerm(ast.Number(int64ToJSONNumber(curr.UnixNano())))
-		bctx.Cache.Put(nowKey, now)
-	} else {
-		now = exist.(*ast.Term)
-	}
-
-	return iter(now)
+	return iter(bctx.Time)
 }
 
 func builtinTimeParseNanos(a, b ast.Value) (ast.Value, error) {

--- a/topdown/time_test.go
+++ b/topdown/time_test.go
@@ -1,0 +1,45 @@
+// Copyright 2020 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package topdown
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/open-policy-agent/opa/ast"
+)
+
+func TestTimeSeeding(t *testing.T) {
+
+	query := `time.now_ns(x)`
+	clock := time.Now()
+	q := NewQuery(ast.MustParseBody(query)).WithTime(clock).WithCompiler(ast.NewCompiler())
+
+	ctx := context.Background()
+
+	qrs, err := q.Run(ctx)
+	if err != nil {
+		t.Fatal(err)
+	} else if len(qrs) != 1 {
+		t.Fatal("expected exactly one result but got:", qrs)
+	}
+
+	exp := ast.MustParseTerm(fmt.Sprintf(`
+		{
+			{
+				x: %v
+			}
+		}
+	`, clock.UnixNano()))
+
+	result := queryResultSetToTerm(qrs)
+
+	if !result.Equal(exp) {
+		t.Fatalf("expected %v but got %v", exp, result)
+	}
+
+}


### PR DESCRIPTION
Previously topdown did not expose a way for the caller to set the wall
clock time. This makes it impossible to reliably replay policy queries
that depend on time of day. With this change, callers can supply the
wall clock time to use for time.now_ns() calls.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
