### PR TITLE
report: Support build-time telemetry URL

### DIFF
--- a/.github/workflows/post-merge.yaml
+++ b/.github/workflows/post-merge.yaml
@@ -36,6 +36,8 @@ jobs:
         timeout-minutes: 60
 
       - name: Build Release Binaries
+        env:
+          TELEMETRY_URL: ${{ secrets.TELEMETRY_URL }}
         run: make release-local
 
       - name: Deploy OPA Edge

--- a/.github/workflows/post-tag.yaml
+++ b/.github/workflows/post-tag.yaml
@@ -22,6 +22,8 @@ jobs:
         timeout-minutes: 60
 
       - name: Build Release Binaries
+        env:
+          TELEMETRY_URL: ${{ secrets.TELEMETRY_URL }}
         run: make release
 
       - name: Build and Deploy OPA Docker Images

--- a/docs/devel/DEVELOPMENT.md
+++ b/docs/devel/DEVELOPMENT.md
@@ -164,6 +164,7 @@ OPA will need to have them configured to be able to run the full CI workflow.
 | DOCKER_USER | Docker username for uploading release images. Will be used with `docker login` |
 | DOCKER_PASSWORD | Docker password or API token for the configured `DOCKER_USER`. Will be used with `docker login` |
 | SLACK_NOTIFICATION_WEBHOOK | Slack webhook for sending notifications. Optional -- If not provided the notification steps are skipped. |
+| TELEMETRY_URL | URL to inject at build-time for OPA version reporting. Optional -- If not provided the default value in OPA's source is used. |
 
 ## Periodic Workflows
 

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -20,9 +20,16 @@ import (
 	"github.com/open-policy-agent/opa/version"
 )
 
-const (
-	defaultExternalServiceURL = "https://telemetry.openpolicyagent.org"
-)
+// ExternalServiceURL is the base HTTP URL for a telemetry service.
+// If not otherwise specified it will use the hard coded default.
+//
+// Override at build time via:
+//
+//    -ldflags "-X github.com/open-policy-agent/opa/internal/report.ExternalServiceURL=<url>"
+//
+// This will be overridden if the OPA_TELEMETRY_SERVICE_URL environment variable
+// is provided.
+var ExternalServiceURL = "https://telemetry.openpolicyagent.org"
 
 // Reporter reports the version of the running OPA instance to an external service
 type Reporter struct {
@@ -53,7 +60,7 @@ func New(id string) (*Reporter, error) {
 
 	url := os.Getenv("OPA_TELEMETRY_SERVICE_URL")
 	if url == "" {
-		url = defaultExternalServiceURL
+		url = ExternalServiceURL
 	}
 
 	restConfig := []byte(fmt.Sprintf(`{

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -24,8 +24,8 @@ func TestNewReportDefaultURL(t *testing.T) {
 	}
 
 	actual := reporter.client.Config().URL
-	if actual != defaultExternalServiceURL {
-		t.Fatalf("Expected server URL %v but got %v", defaultExternalServiceURL, actual)
+	if actual != ExternalServiceURL {
+		t.Fatalf("Expected server URL %v but got %v", ExternalServiceURL, actual)
 	}
 }
 


### PR DESCRIPTION
We previously supported overriding via an environment variable, but
this meant for anyone who wanted to run their own telemetry endpoint
they would _always_ have to specify it while running their OPA's.

This change allows for someone to build OPA and encode the custom
url as the default. Ex:

```
make build TELEMETRY_URL=http://localhost:9876/custom/
```

Signed-off-by: Patrick East <east.patrick@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
