### PR TITLE
CI: Skip asset upload/push when missing config

### DIFF
--- a/.github/workflows/post-merge.yaml
+++ b/.github/workflows/post-merge.yaml
@@ -48,6 +48,8 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           DOCKER_IMAGE: ${{ secrets.DOCKER_IMAGE }}
           S3_RELEASE_BUCKET: ${{ secrets.S3_RELEASE_BUCKET }}
+        # Only run if required secrets are provided
+        if: ${{ env.S3_RELEASE_BUCKET && env.AWS_ACCESS_KEY_ID && env.AWS_SECRET_ACCESS_KEY && env.DOCKER_USER && env.DOCKER_PASSWORD }}
         run: make deploy-ci
 
   deploy-wasm-builder:
@@ -62,4 +64,6 @@ jobs:
           DOCKER_USER: ${{ secrets.DOCKER_USER }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
           DOCKER_WASM_BUILDER_IMAGE: ${{ secrets.DOCKER_WASM_BUILDER_IMAGE }}
+        # Only run if required secrets are provided
+        if: ${{ env.DOCKER_USER && env.DOCKER_PASSWORD }}
         run: make push-wasm-builder-image

--- a/.github/workflows/post-tag.yaml
+++ b/.github/workflows/post-tag.yaml
@@ -27,10 +27,13 @@ jobs:
         run: make release
 
       - name: Build and Deploy OPA Docker Images
+        id: build-and-deploy
         env:
           DOCKER_USER: ${{ secrets.DOCKER_USER }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
           DOCKER_IMAGE: ${{ secrets.DOCKER_IMAGE }}
+        # Only run if required secrets are provided
+        if: ${{ env.DOCKER_USER && env.DOCKER_PASSWORD }}
         run: make release-ci
 
       - name: Create or Update Release

--- a/docs/devel/DEVELOPMENT.md
+++ b/docs/devel/DEVELOPMENT.md
@@ -149,20 +149,19 @@ files in the root of this repository:
 OPA uses Github Actions defined in the [.github/workflows](../../.github/workflows)
 directory.
 
-## Required Secrets
+## Github Action Secrets
 
-The following secrets are assumed to be configured for the Repository. Any fork of
-OPA will need to have them configured to be able to run the full CI workflow.
+The following secrets are used by the Github Action workflows:
 
 | Name | Description |
 |------|-------------|
-| S3_RELEASE_BUCKET | AWS S3 Bucket name to upload `edge` release binaries to. |
-| AWS_ACCESS_KEY_ID | AWS credentials required to upload to the configured `S3_RELEASE_BUCKET`. |
-| AWS_SECRET_ACCESS_KEY | AWS credentials required to upload to the configured `S3_RELEASE_BUCKET`. |
-| DOCKER_IMAGE | Full docker image name (with org) to tag and publish OPA images. |
-| DOCKER_WASM_BUILDER_IMAGE | Full docker image name (with org) to tag and publish WASM builder images. |
-| DOCKER_USER | Docker username for uploading release images. Will be used with `docker login` |
-| DOCKER_PASSWORD | Docker password or API token for the configured `DOCKER_USER`. Will be used with `docker login` |
+| S3_RELEASE_BUCKET | AWS S3 Bucket name to upload `edge` release binaries to. Optional -- If not provided the release upload steps are skipped. |
+| AWS_ACCESS_KEY_ID | AWS credentials required to upload to the configured `S3_RELEASE_BUCKET`. Optional -- If not provided the release upload steps are skipped. |
+| AWS_SECRET_ACCESS_KEY | AWS credentials required to upload to the configured `S3_RELEASE_BUCKET`. Optional -- If not provided the release upload steps are skipped. |
+| DOCKER_IMAGE | Full docker image name (with org) to tag and publish OPA images. Optional -- If not provided the image defaults to `openpolicyagent/opa`. |
+| DOCKER_WASM_BUILDER_IMAGE | Full docker image name (with org) to tag and publish WASM builder images. Optional -- If not provided the image defaults to `openpolicyagent/opa-wasm-builder`. |
+| DOCKER_USER | Docker username for uploading release images. Will be used with `docker login`. Optional -- If not provided the image push steps are skipped. |
+| DOCKER_PASSWORD | Docker password or API token for the configured `DOCKER_USER`. Will be used with `docker login`. Optional -- If not provided the image push steps are skipped. |
 | SLACK_NOTIFICATION_WEBHOOK | Slack webhook for sending notifications. Optional -- If not provided the notification steps are skipped. |
 | TELEMETRY_URL | URL to inject at build-time for OPA version reporting. Optional -- If not provided the default value in OPA's source is used. |
 


### PR DESCRIPTION
Previously we had some required configuration for the Github Actions,
and forks of OPA would need to set them _and_ have the underlying
infra configured (eg, docker registries, s3 bucket, etc).

Now it will check if the secrets are set, and if any required ones
are missing it will skip the steps.

This significantly lowers the bar for OPA forks to be able to run the
normal action workflows without getting errors. The only lost
functionality is primarily around publishing release assets, which
is not required for dev forks, and other forks can opt int to pieces
they care about (eg, only want to publish docker images and no
s3 release assets).

Signed-off-by: Patrick East <east.patrick@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
