### PR TITLE
plugins/rest/aws: Include port in Host header

### DIFF
--- a/plugins/rest/aws.go
+++ b/plugins/rest/aws.go
@@ -286,11 +286,11 @@ func signV4(req *http.Request, credService awsCredentialService, theTime time.Ti
 	dateNow := now.Format("20060102")
 	iso8601Now := now.Format("20060102T150405Z")
 
-	// certain mandatory headers for V4 signing
 	awsHeaders := map[string]string{
-		"host":                 req.URL.Hostname(),
+		"host":                 req.URL.Host,
 		"x-amz-content-sha256": bodyHexHash,
-		"x-amz-date":           iso8601Now}
+		"x-amz-date":           iso8601Now,
+	}
 
 	// the security token header is necessary for ephemeral credentials, e.g. from
 	// the EC2 metadata service


### PR DESCRIPTION
The AWS v4 signing feature for bundle requests would automatically
add a `Host` header by using the URL hostname. This would break for
URLs that specified a port number (eg: https://127.0.0.1:9000/). That
causes issues with sending a valid request.

This commit changes to use the `URL.Host` which will have the full
`host:port` string, when a port was specified.

Fixes: #2568
Signed-off-by: Patrick East <east.patrick@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
