### PR TITLE
ast: Marshal non-string object keys when converting to interface{}

### DIFF
--- a/ast/check_test.go
+++ b/ast/check_test.go
@@ -101,14 +101,13 @@ func TestCheckInference(t *testing.T) {
 		}},
 		{"object-object-key", `x = {{{}: 1}: 1}`, map[Var]types.Type{
 			Var("x"): types.NewObject(
-				nil,
-				types.NewDynamicProperty(
-					types.NewObject(
-						[]*types.StaticProperty{types.NewStaticProperty(map[string]interface{}{}, types.N)},
-						nil,
-					),
+				[]*types.StaticProperty{types.NewStaticProperty(
+					map[string]interface{}{
+						"{}": json.Number("1"),
+					},
 					types.N,
-				),
+				)},
+				nil,
 			),
 		}},
 		{"sets", `x = {1, 2}; y = {{"foo", 1}, x}`, map[Var]types.Type{

--- a/ast/term.go
+++ b/ast/term.go
@@ -185,15 +185,20 @@ func ValueToInterface(v Value, resolver Resolver) (interface{}, error) {
 			if err != nil {
 				return err
 			}
-			asStr, stringKey := ki.(string)
-			if !stringKey {
-				return fmt.Errorf("object value has non-string key (%T)", ki)
+			var str string
+			var ok bool
+			if str, ok = ki.(string); !ok {
+				var buf bytes.Buffer
+				if err := json.NewEncoder(&buf).Encode(ki); err != nil {
+					return err
+				}
+				str = strings.TrimSpace(buf.String())
 			}
 			vi, err := ValueToInterface(v.Value, resolver)
 			if err != nil {
 				return err
 			}
-			buf[asStr] = vi
+			buf[str] = vi
 			return nil
 		})
 		if err != nil {

--- a/docs/content/policy-language.md
+++ b/docs/content/policy-language.md
@@ -308,6 +308,38 @@ d := {"a": a, "x": [b, c]}
 
 By defining composite values in terms of variables and references, rules can define abstractions over raw data and other rules.
 
+### Objects
+
+Objects are unordered key-value collections. In Rego, any value type can be
+used as an object key. For example, the following assignment maps port **numbers**
+to a list of IP addresses (represented as strings).
+
+```live:eg/objects:module:merge_down
+ips_by_port := {
+    80: ["1.1.1.1", "1.1.1.2"],
+    443: ["2.2.2.1"],
+}
+```
+```live:eg/objects/lookup:query:merge_down
+ips_by_port[80]
+```
+```live:eg/objects/lookup:output:merge_down
+```
+```live:eg/objects/iteration:query:merge_down
+some port; ips_by_port[port][_] == "2.2.2.1"
+```
+```live:eg/objects/iteration:output
+```
+
+When Rego values are converted to JSON non-string object keys are marshalled
+as strings (because JSON does not support non-string object keys).
+
+```live:eg/objects/marshal:query:merge_down
+ips_by_port
+```
+```live:eg/objects/marshal:output
+```
+
 ### Sets
 
 In addition to arrays and objects, Rego supports set values. Sets are unordered


### PR DESCRIPTION
Previously, when OPA attempted to convert an ast.Object to interface{}
it would error if the ast.Object contained any keys that were not
ast.String values. This behaviour was implemented because JSON only
supports object keys as strings.

This commit changes the conversion implementation to simply JSON
marshal non-string object keys when they are encountered. This way
we avoid runtime errors which can be difficult to debug.

Fixes #516

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
