### PR TITLE
Add a new inter-query cache to cache responses across queries

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -27,6 +27,7 @@ type Config struct {
 	Keys                         json.RawMessage            `json:"keys"`
 	DefaultDecision              *string                    `json:"default_decision"`
 	DefaultAuthorizationDecision *string                    `json:"default_authorization_decision"`
+	Caching                      json.RawMessage            `json:"caching"`
 }
 
 // ParseConfig returns a valid Config object with defaults injected. The id

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -61,6 +61,10 @@ keys:
     algorithm: RS256
     key: <PEM_encoded_public_key>
     scope: read
+
+caching:
+  inter_query_builtin_cache:
+    max_size_bytes: 10000000
 ```
 
 #### Environment Variable Substitution
@@ -356,6 +360,14 @@ The following signing algorithms are supported:
 | `RS256` | RSASSA-PKCS-v1.5 using SHA-256 |
 | `RS384` | RSASSA-PKCS-v1.5 using SHA-384 |
 | `RS512` | RSASSA-PKCS-v1.5 using SHA-512 |
+
+### Caching
+
+Caching represents the configuration of the inter-query cache that built-in functions can utilize.
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `caching.inter_query_builtin_cache.max_size_bytes` | `int64` | No | Inter-query cache size limit in bytes. OPA will drop old items from the cache if this limit is exceeded. By default, no limit is set. |
 
 ### Bundles
 

--- a/docs/content/policy-reference.md
+++ b/docs/content/policy-reference.md
@@ -859,6 +859,7 @@ The `request` object parameter may contain the following fields:
 | `timeout` | no | `string` or `number` | Timeout for the HTTP request with a default of 5 seconds (`5s`). Numbers provided are in nanoseconds. Strings must be a valid duration string where a duration string is a possibly signed sequence of decimal numbers, each with optional fraction and a unit suffix, such as "300ms", "-1.5h" or "2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h". A zero timeout means no timeout.|
 | `tls_insecure_skip_verify` | no | `bool` | Allows for skipping TLS verification when calling a network endpoint. Not recommended for production. |
 | `tls_server_name` | no | `string` | Sets the hostname that is sent in the client Server Name Indication and that be will be used for server certificate validation. If this is not set, the value of the `Host` header (if present) will be used. If neither are set, the host name from the requested URL is used. |
+| `cache` | no | `boolean` | Cache HTTP response across OPA queries. Default: `false`. |
 
 If the `Host` header is included in `headers`, its value will be used as the `Host` header of the request. The `url` parameter will continue to specify the server to connect to.
 
@@ -879,6 +880,17 @@ The `response` object parameter will contain the following fields:
 | `body` | `any` | Any JSON value. If the HTTP response message body was not deserialized from JSON, this field is set to `null`. |
 | `raw_body` | `string` | The entire raw HTTP response message body represented as a string. |
 | `headers` | `object` | An object containing the response headers. The values will be an array of strings, repeated headers are grouped under the same keys with all values in the array. |
+
+If the `cache` field in the `request` object is `true`, `http.send` will return a cached response after it checks its freshness and validity.
+
+`http.send` uses the `Cache-Control` and `Expires` response headers to check the freshness of the cached response.
+Specifically if the [max-age](https://tools.ietf.org/html/rfc7234#section-5.2.2.8) `Cache-Control` directive is set, `http.send`
+will use it to determine if the cached response is fresh or not. If `max-age` is not set, the `Expires` header will be used instead.
+
+If the cached response is stale, `http.send` uses the `Etag` and `Last-Modified` response headers to check with the server if the
+cached response is in fact still fresh. If the server responds with a `200` (`OK`) response, `http.send` will update the cache
+with the new response. On a `304` (`Not Modified`) server response, `http.send` will update the headers in cached response with
+their corresponding values in the `304` response.
 
 The table below shows examples of calling `http.send`:
 

--- a/topdown/builtins.go
+++ b/topdown/builtins.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/open-policy-agent/opa/topdown/cache"
+
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/topdown/builtins"
 )
@@ -29,18 +31,19 @@ type (
 	// BuiltinContext contains context from the evaluator that may be used by
 	// built-in functions.
 	BuiltinContext struct {
-		Context      context.Context // request context that was passed when query started
-		Seed         io.Reader       // randomization seed
-		Time         *ast.Term       // wall clock time
-		Cancel       Cancel          // atomic value that signals evaluation to halt
-		Runtime      *ast.Term       // runtime information on the OPA instance
-		Cache        builtins.Cache  // built-in function state cache
-		Location     *ast.Location   // location of built-in call
-		Tracers      []Tracer        // Deprecated: Use QueryTracers instead
-		QueryTracers []QueryTracer   // tracer objects for trace() built-in function
-		TraceEnabled bool            // indicates whether tracing is enabled for the evaluation
-		QueryID      uint64          // identifies query being evaluated
-		ParentID     uint64          // identifies parent of query being evaluated
+		Context                context.Context       // request context that was passed when query started
+		Seed                   io.Reader             // randomization seed
+		Time                   *ast.Term             // wall clock time
+		Cancel                 Cancel                // atomic value that signals evaluation to halt
+		Runtime                *ast.Term             // runtime information on the OPA instance
+		Cache                  builtins.Cache        // built-in function state cache
+		InterQueryBuiltinCache cache.InterQueryCache // cross-query built-in function state cache
+		Location               *ast.Location         // location of built-in call
+		Tracers                []Tracer              // Deprecated: Use QueryTracers instead
+		QueryTracers           []QueryTracer         // tracer objects for trace() built-in function
+		TraceEnabled           bool                  // indicates whether tracing is enabled for the evaluation
+		QueryID                uint64                // identifies query being evaluated
+		ParentID               uint64                // identifies parent of query being evaluated
 	}
 
 	// BuiltinFunc defines an interface for implementing built-in functions.

--- a/topdown/cache/cache.go
+++ b/topdown/cache/cache.go
@@ -1,0 +1,144 @@
+// Copyright 2020 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+// Package cache defines the inter-query cache interface that can cache data across queries
+package cache
+
+import (
+	"container/list"
+
+	"github.com/open-policy-agent/opa/ast"
+
+	"sync"
+
+	"github.com/open-policy-agent/opa/util"
+)
+
+const (
+	defaultMaxSizeBytes = int64(0) // unlimited
+)
+
+// Config represents the configuration of the inter-query cache.
+type Config struct {
+	InterQueryBuiltinCache InterQueryBuiltinCacheConfig `json:"inter_query_builtin_cache"`
+}
+
+// InterQueryBuiltinCacheConfig represents the configuration of the inter-query cache that built-in functions can utilize.
+type InterQueryBuiltinCacheConfig struct {
+	MaxSizeBytes *int64 `json:"max_size_bytes,omitempty"`
+}
+
+// ParseCachingConfig returns the config for the inter-query cache.
+func ParseCachingConfig(raw []byte) (*Config, error) {
+	if raw == nil {
+		maxSize := new(int64)
+		*maxSize = defaultMaxSizeBytes
+		return &Config{InterQueryBuiltinCache: InterQueryBuiltinCacheConfig{MaxSizeBytes: maxSize}}, nil
+	}
+
+	var config Config
+
+	if err := util.Unmarshal(raw, &config); err == nil {
+		if err = config.validateAndInjectDefaults(); err != nil {
+			return nil, err
+		}
+	} else {
+		return nil, err
+	}
+
+	return &config, nil
+}
+
+func (c *Config) validateAndInjectDefaults() error {
+	if c.InterQueryBuiltinCache.MaxSizeBytes == nil {
+		maxSize := new(int64)
+		*maxSize = defaultMaxSizeBytes
+		c.InterQueryBuiltinCache.MaxSizeBytes = maxSize
+	}
+	return nil
+}
+
+// InterQueryCacheValue defines the interface for the data that the inter-query cache holds.
+type InterQueryCacheValue interface {
+	SizeInBytes() int64
+}
+
+// InterQueryCache defines the interface for the inter-query cache.
+type InterQueryCache interface {
+	Get(key ast.Value) (value InterQueryCacheValue, found bool)
+	Insert(key ast.Value, value InterQueryCacheValue) int
+	Delete(key ast.Value)
+}
+
+// NewInterQueryCache returns a new inter-query cache.
+func NewInterQueryCache(config *Config) InterQueryCache {
+	return &cache{
+		items: map[string]InterQueryCacheValue{},
+		usage: 0,
+		limit: *config.InterQueryBuiltinCache.MaxSizeBytes,
+		l:     list.New(),
+	}
+}
+
+type cache struct {
+	items map[string]InterQueryCacheValue
+	usage int64
+	limit int64
+	l     *list.List
+	mtx   sync.Mutex
+}
+
+// Insert inserts a key k into the cache with value v.
+func (c *cache) Insert(k ast.Value, v InterQueryCacheValue) (dropped int) {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+	return c.unsafeInsert(k, v)
+}
+
+// Get returns the value in the cache for k.
+func (c *cache) Get(k ast.Value) (InterQueryCacheValue, bool) {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+	return c.unsafeGet(k)
+}
+
+// Delete deletes the value in the cache for k.
+func (c *cache) Delete(k ast.Value) {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+	c.unsafeDelete(k)
+}
+
+func (c *cache) unsafeInsert(k ast.Value, v InterQueryCacheValue) (dropped int) {
+	size := v.SizeInBytes()
+
+	if c.limit > 0 {
+		for key := c.l.Front(); key != nil && (c.usage+size > c.limit); key = key.Next() {
+			dropKey := key.Value.(ast.Value)
+			c.unsafeDelete(dropKey)
+			c.l.Remove(key)
+			dropped++
+		}
+	}
+
+	c.items[k.String()] = v
+	c.l.PushBack(k)
+	c.usage += size
+	return dropped
+}
+
+func (c *cache) unsafeGet(k ast.Value) (InterQueryCacheValue, bool) {
+	value, ok := c.items[k.String()]
+	return value, ok
+}
+
+func (c *cache) unsafeDelete(k ast.Value) {
+	value, ok := c.unsafeGet(k)
+	if !ok {
+		return
+	}
+
+	c.usage -= int64(value.SizeInBytes())
+	delete(c.items, k.String())
+}

--- a/topdown/cache/cache_test.go
+++ b/topdown/cache/cache_test.go
@@ -1,0 +1,144 @@
+// Copyright 2020 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package cache
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/open-policy-agent/opa/ast"
+)
+
+func TestParseCachingConfig(t *testing.T) {
+	maxSize := new(int64)
+	*maxSize = defaultMaxSizeBytes
+	expected := &Config{InterQueryBuiltinCache: InterQueryBuiltinCacheConfig{MaxSizeBytes: maxSize}}
+
+	tests := map[string]struct {
+		input   []byte
+		wantErr bool
+	}{
+		"empty_config": {
+			input:   nil,
+			wantErr: false,
+		},
+		"default_limit": {
+			input:   []byte(`{"inter_query_builtin_cache": {},}`),
+			wantErr: false,
+		},
+		"bad_limit": {
+			input:   []byte(`{"inter_query_builtin_cache": {"max_size_bytes": "100"},}`),
+			wantErr: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+
+			config, err := ParseCachingConfig(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("Expected error but got nil")
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("Unexpected error %v", err)
+				}
+			}
+
+			if !tc.wantErr && !reflect.DeepEqual(config, expected) {
+				t.Fatalf("want %v got %v", expected, config)
+			}
+		})
+	}
+
+	// cache limit specified
+	in := `{"inter_query_builtin_cache": {"max_size_bytes": 100},}`
+
+	config, err := ParseCachingConfig([]byte(in))
+	if err != nil {
+		t.Fatalf("Unexpected error %v", err)
+	}
+
+	limit := int64(100)
+	expected.InterQueryBuiltinCache.MaxSizeBytes = &limit
+
+	if !reflect.DeepEqual(config, expected) {
+		t.Fatalf("want %v got %v", expected, config)
+	}
+}
+
+func TestInsert(t *testing.T) {
+
+	in := `{"inter_query_builtin_cache": {"max_size_bytes": 20},}` // 20 byte limit for test purposes
+
+	config, err := ParseCachingConfig([]byte(in))
+	if err != nil {
+		t.Fatalf("Unexpected error %v", err)
+	}
+
+	cache := NewInterQueryCache(config)
+	cacheValue := newInterQueryCacheValue(ast.StringTerm("bar").Value, 20)
+
+	dropped := cache.Insert(ast.StringTerm("foo").Value, cacheValue)
+
+	if dropped != 0 {
+		t.Fatal("Expected dropped to be zero")
+	}
+
+	// exceed cache limit
+	cacheValue2 := newInterQueryCacheValue(ast.StringTerm("bar2").Value, 20)
+	dropped = cache.Insert(ast.StringTerm("foo2").Value, cacheValue2)
+
+	if dropped != 1 {
+		t.Fatal("Expected dropped to be one")
+	}
+
+	_, found := cache.Get(ast.StringTerm("foo2").Value)
+	if !found {
+		t.Fatal("Expected key \"foo2\" in cache")
+	}
+
+	_, found = cache.Get(ast.StringTerm("foo").Value)
+	if found {
+		t.Fatal("Unexpected key \"foo\" in cache")
+	}
+}
+
+func TestDelete(t *testing.T) {
+	config, err := ParseCachingConfig(nil)
+	if err != nil {
+		t.Fatalf("Unexpected error %v", err)
+	}
+
+	cache := NewInterQueryCache(config)
+	cacheValue := newInterQueryCacheValue(ast.StringTerm("bar").Value, 20)
+
+	dropped := cache.Insert(ast.StringTerm("foo").Value, cacheValue)
+
+	if dropped != 0 {
+		t.Fatal("Expected dropped to be zero")
+	}
+
+	cache.Delete(ast.StringTerm("foo").Value)
+
+	_, found := cache.Get(ast.StringTerm("foo").Value)
+	if found {
+		t.Fatal("Unexpected key \"foo\" in cache")
+	}
+}
+
+type testInterQueryCacheValue struct {
+	value ast.Value
+	size  int
+}
+
+func newInterQueryCacheValue(value ast.Value, size int) *testInterQueryCacheValue {
+	return &testInterQueryCacheValue{value: value, size: size}
+}
+
+func (p testInterQueryCacheValue) SizeInBytes() int64 {
+	return int64(p.size)
+}

--- a/topdown/http_test.go
+++ b/topdown/http_test.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -61,9 +62,9 @@ func TestHTTPGetRequest(t *testing.T) {
 	expectedResult["body"] = body
 	expectedResult["raw_body"] = "[{\"id\":\"1\",\"firstname\":\"John\"}]\n"
 	expectedResult["headers"] = map[string]interface{}{
-		"Content-Length": []interface{}{"32"},
-		"Content-Type":   []interface{}{"text/plain; charset=utf-8"},
-		"Test-Header":    []interface{}{"test-value"},
+		"content-length": []interface{}{"32"},
+		"content-type":   []interface{}{"text/plain; charset=utf-8"},
+		"test-header":    []interface{}{"test-value"},
 	}
 
 	resultObj, err := ast.InterfaceToValue(expectedResult)
@@ -116,8 +117,8 @@ func TestHTTPGetRequestTlsInsecureSkipVerify(t *testing.T) {
 	expectedResult["body"] = body
 	expectedResult["raw_body"] = "[{\"id\":\"1\",\"firstname\":\"John\"}]\n"
 	expectedResult["headers"] = map[string]interface{}{
-		"Content-Length": []interface{}{"32"},
-		"Content-Type":   []interface{}{"text/plain; charset=utf-8"},
+		"content-length": []interface{}{"32"},
+		"content-type":   []interface{}{"text/plain; charset=utf-8"},
 	}
 
 	resultObj, err := ast.InterfaceToValue(expectedResult)
@@ -167,8 +168,8 @@ func TestHTTPEnableJSONDecode(t *testing.T) {
 	expectedResult["body"] = nil
 	expectedResult["raw_body"] = "*Hello World®"
 	expectedResult["headers"] = map[string]interface{}{
-		"Content-Length": []interface{}{"14"},
-		"Content-Type":   []interface{}{"text/plain; charset=utf-8"},
+		"content-length": []interface{}{"14"},
+		"content-type":   []interface{}{"text/plain; charset=utf-8"},
 	}
 
 	resultObj, err := ast.InterfaceToValue(expectedResult)
@@ -276,8 +277,8 @@ func TestHTTPHostHeader(t *testing.T) {
 		"body":        t.Name(),
 		"raw_body":    fmt.Sprintf("\"%s\"\n", t.Name()),
 		"headers": map[string]interface{}{
-			"Content-Length": []interface{}{"21"},
-			"Content-Type":   []interface{}{"application/json"},
+			"content-length": []interface{}{"21"},
+			"content-type":   []interface{}{"application/json"},
 		},
 	})
 	if err != nil {
@@ -335,14 +336,14 @@ func TestHTTPPostRequest(t *testing.T) {
 				"status_code": 200,
 				"body": {"id": "2", "firstname": "Joe"},
 				"raw_body": "{\"firstname\":\"Joe\",\"id\":\"2\"}",
-				"headers": {"Content-Type": ["application/json"], "Content-Length": ["28"]}
+				"headers": {"content-type": ["application/json"], "content-length": ["28"]}
 			}`,
 		},
 		{
 			note: "raw_body",
 			params: `{
 				"method": "post",
-				"headers": {"Content-Type": "application/x-www-form-encoded"},
+				"headers": {"content-type": "application/x-www-form-encoded"},
 				"raw_body": "username=foobar&password=baz"
 			}`,
 			expected: `{
@@ -350,14 +351,14 @@ func TestHTTPPostRequest(t *testing.T) {
 				"status_code": 200,
 				"body": null,
 				"raw_body": "username=foobar&password=baz",
-				"headers": {"Content-Type": ["application/x-www-form-encoded"], "Content-Length": ["28"]}
+				"headers": {"content-type": ["application/x-www-form-encoded"], "content-length": ["28"]}
 			}`,
 		},
 		{
 			note: "raw_body overrides body",
 			params: `{
 				"method": "post",
-				"headers": {"Content-Type": "application/x-www-form-encoded"},
+				"headers": {"content-type": "application/x-www-form-encoded"},
 				"body": {"foo": 1},
 				"raw_body": "username=foobar&password=baz"
 			}`,
@@ -366,14 +367,14 @@ func TestHTTPPostRequest(t *testing.T) {
 				"status_code": 200,
 				"body": null,
 				"raw_body": "username=foobar&password=baz",
-				"headers": {"Content-Type": ["application/x-www-form-encoded"], "Content-Length": ["28"]}
+				"headers": {"content-type": ["application/x-www-form-encoded"], "content-length": ["28"]}
 			}`,
 		},
 		{
 			note: "raw_body bad type",
 			params: `{
 				"method": "post",
-				"headers": {"Content-Type": "application/x-www-form-encoded"},
+				"headers": {"content-type": "application/x-www-form-encoded"},
 				"raw_body": {"bar": "bar"}
 			}`,
 			expected: &Error{Code: BuiltinErr, Message: "\"raw_body\" must be a string"},
@@ -447,8 +448,8 @@ func TestHTTDeleteRequest(t *testing.T) {
 	expectedResult["body"] = body
 	expectedResult["raw_body"] = "[{\"id\":\"1\",\"firstname\":\"John\"}]\n"
 	expectedResult["headers"] = map[string]interface{}{
-		"Content-Length": []interface{}{"32"},
-		"Content-Type":   []interface{}{"application/json"},
+		"content-length": []interface{}{"32"},
+		"content-type":   []interface{}{"application/json"},
 	}
 
 	resultObj, err := ast.InterfaceToValue(expectedResult)
@@ -606,9 +607,9 @@ func TestHTTPRedirectDisable(t *testing.T) {
 	expectedResult["status"] = "301 Moved Permanently"
 	expectedResult["status_code"] = http.StatusMovedPermanently
 	expectedResult["headers"] = map[string]interface{}{
-		"Content-Length": []interface{}{"40"},
-		"Content-Type":   []interface{}{"text/html; charset=utf-8"},
-		"Location":       []interface{}{"/test"},
+		"content-length": []interface{}{"40"},
+		"content-type":   []interface{}{"text/html; charset=utf-8"},
+		"location":       []interface{}{"/test"},
 	}
 
 	resultObj, err := ast.InterfaceToValue(expectedResult)
@@ -641,7 +642,7 @@ func TestHTTPRedirectEnable(t *testing.T) {
 	expectedResult["body"] = nil
 	expectedResult["raw_body"] = ""
 	expectedResult["headers"] = map[string]interface{}{
-		"Content-Length": []interface{}{"0"},
+		"content-length": []interface{}{"0"},
 	}
 
 	resultObj, err := ast.InterfaceToValue(expectedResult)
@@ -781,6 +782,507 @@ func TestHTTPSendCaching(t *testing.T) {
 	}
 }
 
+func TestHTTPSendInterQueryCaching(t *testing.T) {
+	tests := []struct {
+		note             string
+		ruleTemplate     string
+		headers          map[string][]string
+		body             string
+		response         string
+		expectedReqCount int
+	}{
+		{
+			note:             "http.send GET single",
+			ruleTemplate:     `p = x { http.send({"method": "get", "url": "%URL%", "force_json_decode": true, "cache": true}, r); x = r.body }`,
+			headers:          map[string][]string{"Cache-Control": {"max-age=290304000, public"}},
+			response:         `{"x": 1}`,
+			expectedReqCount: 1,
+		},
+		{
+			note: "http.send GET cache hit (max_age_response_fresh)",
+			ruleTemplate: `p = x {
+									r1 = http.send({"method": "get", "url": "%URL%", "force_json_decode": true, "cache": true})
+									r2 = http.send({"method": "get", "url": "%URL%", "force_json_decode": true, "cache": true})  # cached and fresh
+									r3 = http.send({"method": "get", "url": "%URL%", "force_json_decode": true, "cache": true})  # cached and fresh
+									r1 == r2
+									r2 == r3
+									x = r1.body
+								}`,
+			headers:          map[string][]string{"Cache-Control": {"max-age=290304000, public"}},
+			response:         `{"x": 1}`,
+			expectedReqCount: 1,
+		},
+		{
+			note: "http.send GET cache hit (expires_header_response_fresh)",
+			ruleTemplate: `p = x {
+									r1 = http.send({"method": "get", "url": "%URL%", "force_json_decode": true, "cache": true})
+									r2 = http.send({"method": "get", "url": "%URL%", "force_json_decode": true, "cache": true})  # cached and fresh
+									r3 = http.send({"method": "get", "url": "%URL%", "force_json_decode": true, "cache": true})  # cached and fresh
+									r1 == r2
+									r2 == r3
+									x = r1.body
+								}`,
+			headers:          map[string][]string{"Expires": {"Wed, 31 Dec 2115 07:28:00 GMT"}},
+			response:         `{"x": 1}`,
+			expectedReqCount: 1,
+		},
+		{
+			note: "http.send GET no-store cache",
+			ruleTemplate: `p = x {
+									r1 = http.send({"method": "get", "url": "%URL%", "force_json_decode": true, "cache": true})
+									r2 = http.send({"method": "get", "url": "%URL%", "force_json_decode": true, "cache": true})  # not cached
+									r3 = http.send({"method": "get", "url": "%URL%", "force_json_decode": true, "cache": true})  # not cached
+									r1 == r2
+									r2 == r3
+									x = r1.body
+								}`,
+			headers:          map[string][]string{"Cache-Control": {"no-store"}},
+			response:         `{"x": 1}`,
+			expectedReqCount: 3,
+		},
+		{
+			note: "http.send GET (response_stale_revalidate_with_etag)",
+			ruleTemplate: `p = x {
+									r1 = http.send({"method": "get", "url": "%URL%", "force_json_decode": true, "cache": true})
+									r2 = http.send({"method": "get", "url": "%URL%", "force_json_decode": true, "cache": true}) # stale
+									r3 = http.send({"method": "get", "url": "%URL%", "force_json_decode": true, "cache": true}) # stale
+									r1 == r2
+									r2 == r3
+									x = r1.body
+								}`,
+			headers:          map[string][]string{"Cache-Control": {"max-age=0, public"}, "Etag": {"1234"}},
+			response:         `{"x": 1}`,
+			expectedReqCount: 3,
+		},
+		{
+			note: "http.send GET (response_stale_revalidate_with_last_modified)",
+			ruleTemplate: `p = x {
+									r1 = http.send({"method": "get", "url": "%URL%", "force_json_decode": true, "cache": true})
+									r2 = http.send({"method": "get", "url": "%URL%", "force_json_decode": true, "cache": true}) # stale
+									r3 = http.send({"method": "get", "url": "%URL%", "force_json_decode": true, "cache": true}) # stale
+									r1 == r2
+									r2 == r3
+									x = r1.body
+								}`,
+			headers:          map[string][]string{"Cache-Control": {"max-age=0, public"}, "Last-Modified": {"Wed, 31 Dec 2115 07:28:00 GMT"}},
+			response:         `{"x": 1}`,
+			expectedReqCount: 3,
+		},
+	}
+
+	data := loadSmallTestData()
+
+	for _, tc := range tests {
+		t.Run(tc.note, func(t *testing.T) {
+
+			var requests []*http.Request
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requests = append(requests, r)
+				headers := w.Header()
+
+				for k, v := range tc.headers {
+					headers[k] = v
+				}
+
+				etag := w.Header().Get("etag")
+				lm := w.Header().Get("last-modified")
+
+				if etag != "" {
+					if r.Header.Get("if-none-match") == etag {
+						w.WriteHeader(http.StatusNotModified)
+					}
+				} else if lm != "" {
+					if r.Header.Get("if-modified-since") == lm {
+						w.WriteHeader(http.StatusNotModified)
+					}
+				} else {
+					w.WriteHeader(http.StatusOK)
+				}
+				w.Write([]byte(tc.response))
+			}))
+			defer ts.Close()
+
+			runTopDownTestCase(t, data, tc.note, []string{strings.ReplaceAll(tc.ruleTemplate, "%URL%", ts.URL)}, tc.response)
+
+			// Note: The runTopDownTestCase ends up evaluating twice (once with and once without partial
+			// eval first), so expect 2x the total request count the test case specified.
+			actualCount := len(requests) / 2
+			if actualCount != tc.expectedReqCount {
+				t.Fatalf("Expected to get %d requests, got %d", tc.expectedReqCount, actualCount)
+			}
+		})
+	}
+}
+
+func TestHTTPSendInterQueryCachingModifiedResp(t *testing.T) {
+	tests := []struct {
+		note             string
+		ruleTemplate     string
+		headers          map[string][]string
+		body             string
+		response         string
+		expectedReqCount int
+	}{
+		{
+			note: "http.send GET (response_stale_revalidate_with_etag)",
+			ruleTemplate: `p = x {
+									r1 = http.send({"method": "get", "url": "%URL%", "force_json_decode": true, "cache": true})
+									r2 = http.send({"method": "get", "url": "%URL%", "force_json_decode": true, "cache": true}) # stale
+									r3 = http.send({"method": "get", "url": "%URL%", "force_json_decode": true, "cache": true}) # cached and fresh
+									r1 == r2
+									r2 == r3
+									x = r1.body
+								}`,
+			headers:          map[string][]string{"Cache-Control": {"max-age=0, public"}, "Etag": {"1234"}, "location": {"/test"}},
+			response:         `{"x": 1}`,
+			expectedReqCount: 2,
+		},
+		{
+			note: "http.send GET (response_stale_revalidate_with_no_etag)",
+			ruleTemplate: `p = x {
+									r1 = http.send({"method": "get", "url": "%URL%", "force_json_decode": true, "cache": true})
+									r2 = http.send({"method": "get", "url": "%URL%", "force_json_decode": true, "cache": true}) # stale
+									r1 == r2
+									x = r1.body
+								}`,
+			headers:          map[string][]string{"Cache-Control": {"max-age=0, public"}},
+			response:         `{"x": 1}`,
+			expectedReqCount: 2,
+		},
+	}
+
+	data := loadSmallTestData()
+
+	for _, tc := range tests {
+		t.Run(tc.note, func(t *testing.T) {
+
+			var requests []*http.Request
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requests = append(requests, r)
+				headers := w.Header()
+
+				for k, v := range tc.headers {
+					headers[k] = v
+				}
+
+				etag := w.Header().Get("etag")
+
+				if r.Header.Get("if-none-match") != "" {
+					if r.Header.Get("if-none-match") == etag {
+						// add new headers and update existing header value
+						headers["Cache-Control"] = []string{"max-age=290304000, public"}
+						headers["foo"] = []string{"bar"}
+						w.WriteHeader(http.StatusNotModified)
+					}
+				} else {
+					w.WriteHeader(http.StatusOK)
+				}
+				w.Write([]byte(tc.response))
+			}))
+			defer ts.Close()
+
+			runTopDownTestCase(t, data, tc.note, []string{strings.ReplaceAll(tc.ruleTemplate, "%URL%", ts.URL)}, tc.response)
+
+			// Note: The runTopDownTestCase ends up evaluating twice (once with and once without partial
+			// eval first), so expect 2x the total request count the test case specified.
+			actualCount := len(requests) / 2
+			if actualCount != tc.expectedReqCount {
+				t.Fatalf("Expected to get %d requests, got %d", tc.expectedReqCount, actualCount)
+			}
+		})
+	}
+}
+
+func TestHTTPSendInterQueryCachingNewResp(t *testing.T) {
+	tests := []struct {
+		note             string
+		ruleTemplate     string
+		headers          map[string][]string
+		body             string
+		response         string
+		expectedReqCount int
+	}{
+		{
+			note: "http.send GET (response_stale_revalidate_with_etag)",
+			ruleTemplate: `p = x {
+									r1 = http.send({"method": "get", "url": "%URL%", "force_json_decode": true, "cache": true})
+									r2 = http.send({"method": "get", "url": "%URL%", "force_json_decode": true, "cache": true}) # stale
+									r3 = http.send({"method": "get", "url": "%URL%", "force_json_decode": true, "cache": true}) # cached and fresh
+									x = r1.body
+								}`,
+			headers:          map[string][]string{"Cache-Control": {"max-age=0, public"}, "Etag": {"1234"}, "location": {"/test"}},
+			response:         `{"x": 1}`,
+			expectedReqCount: 2,
+		},
+	}
+
+	data := loadSmallTestData()
+
+	for _, tc := range tests {
+		t.Run(tc.note, func(t *testing.T) {
+
+			var requests []*http.Request
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requests = append(requests, r)
+				headers := w.Header()
+
+				for k, v := range tc.headers {
+					headers[k] = v
+				}
+
+				etag := w.Header().Get("etag")
+
+				if r.Header.Get("if-none-match") != "" {
+					if r.Header.Get("if-none-match") == etag {
+						headers["Cache-Control"] = []string{"max-age=290304000, public"}
+					}
+				}
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte(tc.response))
+			}))
+			defer ts.Close()
+
+			runTopDownTestCase(t, data, tc.note, []string{strings.ReplaceAll(tc.ruleTemplate, "%URL%", ts.URL)}, tc.response)
+
+			// Note: The runTopDownTestCase ends up evaluating twice (once with and once without partial
+			// eval first), so expect 2x the total request count the test case specified.
+			actualCount := len(requests) / 2
+			if actualCount != tc.expectedReqCount {
+				t.Fatalf("Expected to get %d requests, got %d", tc.expectedReqCount, actualCount)
+			}
+		})
+	}
+}
+
+func TestInsertIntoHTTPSendInterQueryCacheError(t *testing.T) {
+	tests := []struct {
+		note             string
+		ruleTemplate     string
+		headers          map[string][]string
+		body             string
+		response         string
+		expectedReqCount int
+	}{
+		{
+			note: "http.send GET (bad_expires_header_value)",
+			ruleTemplate: `p = x {
+									r1 = http.send({"method": "get", "url": "%URL%", "force_json_decode": true, "cache": true}) # fallback to normal cache
+									r2 = http.send({"method": "get", "url": "%URL%", "force_json_decode": true, "cache": true}) # retrieved from normal cache
+									r1 == r2
+									x = r1.body
+								}`,
+			headers:          map[string][]string{"Cache-Control": {"max-age=0, public"}, "Expires": {"Wed, 32 Dec 2115 07:28:00 GMT"}},
+			response:         `{"x": 1}`,
+			expectedReqCount: 1,
+		},
+		{
+			note: "http.send GET (bad_date_header_value)",
+			ruleTemplate: `p = x {
+									r1 = http.send({"method": "get", "url": "%URL%", "force_json_decode": true, "cache": true}) # fallback to normal cache
+									r2 = http.send({"method": "get", "url": "%URL%", "force_json_decode": true, "cache": true}) # retrieved from normal cache
+									r1 == r2
+									x = r1.body
+								}`,
+			headers:          map[string][]string{"Cache-Control": {"max-age=0, public"}, "Date": {"Wed, 32 Dec 2115 07:28:00 GMT"}},
+			response:         `{"x": 1}`,
+			expectedReqCount: 1,
+		},
+		{
+			note: "http.send GET (bad_cache_control_header_value)",
+			ruleTemplate: `p = x {
+									r1 = http.send({"method": "get", "url": "%URL%", "force_json_decode": true, "cache": true}) # fallback to normal cache
+									r2 = http.send({"method": "get", "url": "%URL%", "force_json_decode": true, "cache": true}) # retrieved from normal cache
+									r1 == r2
+									x = r1.body
+								}`,
+			headers:          map[string][]string{"Cache-Control": {"max-age=\"foo\", public"}},
+			response:         `{"x": 1}`,
+			expectedReqCount: 1,
+		},
+	}
+
+	data := loadSmallTestData()
+
+	for _, tc := range tests {
+		t.Run(tc.note, func(t *testing.T) {
+
+			var requests []*http.Request
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requests = append(requests, r)
+				headers := w.Header()
+
+				for k, v := range tc.headers {
+					headers[k] = v
+				}
+
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte(tc.response))
+			}))
+			defer ts.Close()
+
+			runTopDownTestCase(t, data, tc.note, []string{strings.ReplaceAll(tc.ruleTemplate, "%URL%", ts.URL)}, tc.response)
+
+			// Note: The runTopDownTestCase ends up evaluating twice (once with and once without partial
+			// eval first), so expect 2x the total request count the test case specified.
+			actualCount := len(requests) / 2
+			if actualCount != tc.expectedReqCount {
+				t.Fatalf("Expected to get %d requests, got %d", tc.expectedReqCount, actualCount)
+			}
+		})
+	}
+}
+
+func TestGetResponseHeaderDateEmpty(t *testing.T) {
+	_, err := getResponseHeaderDate(http.Header{"Date": {""}})
+	if err == nil {
+		t.Fatal("Expected error but got nil")
+	}
+
+	expected := "no date header"
+	if err.Error() != expected {
+		t.Fatalf("Expected error message %v but got %v", expected, err.Error())
+	}
+}
+
+func TestParseMaxAgeCacheDirective(t *testing.T) {
+	tests := []struct {
+		note      string
+		input     map[string]string
+		expected  deltaSeconds
+		wantError bool
+		err       error
+	}{
+		{
+			note:      "max age not set",
+			input:     nil,
+			expected:  deltaSeconds(-1),
+			wantError: false,
+			err:       nil,
+		},
+		{
+			note:      "max age out of range",
+			input:     map[string]string{"max-age": "214748364888"},
+			expected:  deltaSeconds(math.MaxInt32),
+			wantError: false,
+			err:       nil,
+		},
+		{
+			note:      "max age greater than MaxInt32",
+			input:     map[string]string{"max-age": "2147483648"},
+			expected:  deltaSeconds(math.MaxInt32),
+			wantError: false,
+			err:       nil,
+		},
+		{
+			note:      "max age less than MaxInt32",
+			input:     map[string]string{"max-age": "21"},
+			expected:  deltaSeconds(21),
+			wantError: false,
+			err:       nil,
+		},
+		{
+			note:      "max age bad format",
+			input:     map[string]string{"max-age": "21,21"},
+			expected:  deltaSeconds(-1),
+			wantError: true,
+			err:       fmt.Errorf("strconv.ParseUint: parsing \"21,21\": invalid syntax"),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.note, func(t *testing.T) {
+
+			actual, err := parseMaxAgeCacheDirective(tc.input)
+			if tc.wantError {
+				if err == nil {
+					t.Fatal("Expected error but got nil")
+				}
+
+				if tc.err != nil && tc.err.Error() != err.Error() {
+					t.Fatalf("Expected error message %v but got %v", tc.err.Error(), err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("Unexpected error %v", err)
+				}
+			}
+
+			if actual != tc.expected {
+				t.Fatalf("Expected value for max-age %v but got %v", tc.expected, actual)
+			}
+
+		})
+	}
+}
+
+func TestGetBoolValFromReqObj(t *testing.T) {
+	validInput := ast.MustParseTerm(`{"cache": true}`)
+	validInputObj := validInput.Value.(ast.Object)
+
+	invalidInput := ast.MustParseTerm(`{"cache": "true"}`)
+	invalidInputObj := invalidInput.Value.(ast.Object)
+
+	tests := []struct {
+		note      string
+		input     ast.Object
+		key       *ast.Term
+		expected  bool
+		wantError bool
+		err       error
+	}{
+		{
+			note:      "valid input",
+			input:     validInputObj,
+			key:       ast.StringTerm("cache"),
+			expected:  true,
+			wantError: false,
+			err:       nil,
+		},
+		{
+			note:      "invalid input",
+			input:     invalidInputObj,
+			key:       ast.StringTerm("cache"),
+			expected:  false,
+			wantError: true,
+			err:       fmt.Errorf("invalid value for \"cache\" field"),
+		},
+		{
+			note:      "non existent key",
+			input:     validInputObj,
+			key:       ast.StringTerm("foo"),
+			expected:  false,
+			wantError: false,
+			err:       nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.note, func(t *testing.T) {
+
+			actual, err := getBoolValFromReqObj(tc.input, tc.key)
+			if tc.wantError {
+				if err == nil {
+					t.Fatal("Expected error but got nil")
+				}
+
+				if tc.err != nil && tc.err.Error() != err.Error() {
+					t.Fatalf("Expected error message %v but got %v", tc.err.Error(), err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("Unexpected error %v", err)
+				}
+			}
+
+			if actual != tc.expected {
+				t.Fatalf("Expected value for key %v is %v but got %v", tc.key, tc.expected, actual)
+			}
+
+		})
+	}
+
+}
+
 func getTestServer() (baseURL string, teardownFn func()) {
 	mux := http.NewServeMux()
 	ts := httptest.NewServer(mux)
@@ -891,8 +1393,8 @@ func TestHTTPSClient(t *testing.T) {
 		}
 		expectedResult["body"] = bodyMap
 		expectedResult["headers"] = map[string]interface{}{
-			"Content-Length": []interface{}{"22"},
-			"Content-Type":   []interface{}{"application/json"},
+			"content-length": []interface{}{"22"},
+			"content-type":   []interface{}{"application/json"},
 		}
 
 		resultObj, err := ast.InterfaceToValue(expectedResult)
@@ -917,7 +1419,7 @@ func TestHTTPSClient(t *testing.T) {
 			"body":        nil,
 			"raw_body":    "",
 			"headers": map[string]interface{}{
-				"Content-Length": []interface{}{"0"},
+				"content-length": []interface{}{"0"},
 			},
 		}
 
@@ -961,7 +1463,7 @@ func TestHTTPSClient(t *testing.T) {
 			"body":        nil,
 			"raw_body":    "",
 			"headers": map[string]interface{}{
-				"Content-Length": []interface{}{"0"},
+				"content-length": []interface{}{"0"},
 			},
 		}
 
@@ -988,7 +1490,7 @@ func TestHTTPSClient(t *testing.T) {
 			"body":        nil,
 			"raw_body":    "",
 			"headers": map[string]interface{}{
-				"Content-Length": []interface{}{"0"},
+				"content-length": []interface{}{"0"},
 			},
 		}
 
@@ -1015,7 +1517,7 @@ func TestHTTPSClient(t *testing.T) {
 			"body":        nil,
 			"raw_body":    "",
 			"headers": map[string]interface{}{
-				"Content-Length": []interface{}{"0"},
+				"content-length": []interface{}{"0"},
 			},
 		}
 
@@ -1042,7 +1544,7 @@ func TestHTTPSClient(t *testing.T) {
 			"body":        nil,
 			"raw_body":    "",
 			"headers": map[string]interface{}{
-				"Content-Length": []interface{}{"0"},
+				"content-length": []interface{}{"0"},
 			},
 		}
 
@@ -1196,7 +1698,7 @@ func TestHTTPSNoClientCerts(t *testing.T) {
 			"body":        nil,
 			"raw_body":    "",
 			"headers": map[string]interface{}{
-				"Content-Length": []interface{}{"0"},
+				"content-length": []interface{}{"0"},
 			},
 		}
 
@@ -1227,7 +1729,7 @@ func TestHTTPSNoClientCerts(t *testing.T) {
 			"body":        nil,
 			"raw_body":    "",
 			"headers": map[string]interface{}{
-				"Content-Length": []interface{}{"0"},
+				"content-length": []interface{}{"0"},
 			},
 		}
 
@@ -1254,7 +1756,7 @@ func TestHTTPSNoClientCerts(t *testing.T) {
 			"body":        nil,
 			"raw_body":    "",
 			"headers": map[string]interface{}{
-				"Content-Length": []interface{}{"0"},
+				"content-length": []interface{}{"0"},
 			},
 		}
 
@@ -1281,7 +1783,7 @@ func TestHTTPSNoClientCerts(t *testing.T) {
 			"body":        nil,
 			"raw_body":    "",
 			"headers": map[string]interface{}{
-				"Content-Length": []interface{}{"0"},
+				"content-length": []interface{}{"0"},
 			},
 		}
 
@@ -1308,7 +1810,7 @@ func TestHTTPSNoClientCerts(t *testing.T) {
 			"body":        nil,
 			"raw_body":    "",
 			"headers": map[string]interface{}{
-				"Content-Length": []interface{}{"0"},
+				"content-length": []interface{}{"0"},
 			},
 		}
 
@@ -1341,7 +1843,7 @@ func TestHTTPSNoClientCerts(t *testing.T) {
 
 var httpSendHelperRules = []string{
 	`clean_headers(resp) = cleaned {
-		cleaned = json.remove(resp, ["headers/Date"])
+		cleaned = json.remove(resp, ["headers/date"])
 	}`,
 	`remove_headers(resp) = no_headers {
 		no_headers = object.remove(resp, ["headers"])


### PR DESCRIPTION
This commit adds a new inter-query cache that built-in
functions can use to cache responses across queries.

The OPA config includes a new "caching" field that can be used
to set the size of the cache. By default there is no limit.

This change also updates `http.send` to optionally utilize the
inter-query cache.

Fixes #1753

Signed-off-by: Ashutosh Narkar <anarkar4387@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
