### PR TITLE
.github: minor changes to ISSUE_TEMPLATE.md

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,12 +1,13 @@
-Thanks for opening an issue to request a feature or file a bug! If you provide some
-basic information it helps us address problems faster.
+<!-- Thanks for opening an issue to request a feature or file a bug!
+If you provide some basic information it helps us address problems faster. -->
 
-# Expected Behavior
+## Expected Behavior
 
-# Actual Behavior
+## Actual Behavior
 
-# Steps to Reproduce the Problem
+## Steps to Reproduce the Problem
 
+<!--
 If this is a bug report please provide as much detail as possible so that we can
 reproduce the problem. Examples:
 
@@ -16,10 +17,13 @@ reproduce the problem. Examples:
 * For server and CLI, the flags/configuration that you provided to OPA
 * For server, any relevant log messages from OPA
 * For Go and Wasm, the arguments you invoked OPA with
+-->
 
-# Additional Info
+## Additional Info
 
+<!--
 Any additional information you think might be helpful. Examples include the environment
 where OPA was running (e.g., if inside Kubernetes, what resource limits did you configure
 OPA with?), how long OPA had been running for, what was happening around the time
 when you identified the problem, etc.
+-->


### PR DESCRIPTION
- Markdown only allows one # title
- use comments so people don't have to remove content

Apparently, this repo isn't using the latest variant of how _issue templates_ can work in github: https://docs.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository#configuring-the-template-chooser -- but I've only been wanting to address a tiny pet-peeve of mine here.