### PR TITLE
wasm: Remove references to the heap top address

### DIFF
--- a/docs/content/wasm.md
+++ b/docs/content/wasm.md
@@ -121,8 +121,6 @@ The primary exported functions for interacting with policy modules are:
 | <span class="opa-keep-it-together">`str_addr opa_json_dump(value_addr)`</span> | Dumps the value referred to by `value_addr` to a null-terminated JSON serialized string and returns the address of the start of the string. |
 | <span class="opa-keep-it-together">`void opa_heap_ptr_set(addr)`</span> | Set the heap pointer for the next evaluation. |
 | <span class="opa-keep-it-together">`addr opa_heap_ptr_get(void)`</span> | Get the current heap pointer. |
-| <span class="opa-keep-it-together">`void opa_heap_top_set(addr)`</span> | Set the heap top for the next evaluation. |
-| <span class="opa-keep-it-together">`addr opa_heap_top_get(void)`</span> | Get the current heap top. |
 
 The addresses passed and returned by the policy modules are 32-bit integer
 offsets into the shared memory region. The `value_addr` parameters and return
@@ -216,11 +214,10 @@ is done by loading a JSON string into the shared memory buffer. Use `opa_malloc`
 and `opa_json_parse` followed by `opa_eval_ctx_set_data` to set the address on
 the evaluation context.
 
-After loading the external data use the `opa_heap_ptr_get` and
-`opa_heap_top_get` exported methods to save the current point in the heap before
-evaluation. After evaluation these should be reset by calling `opa_heap_ptr_set`
-and `opa_heap_top_set` to ensure that evaluation restarts back at the saved data
-and re-uses heap space. This is particularly important if re-evaluating many
+After loading the external data use the `opa_heap_ptr_get` exported method to save
+the current point in the heap before evaluation. After evaluation this should be
+reset by calling `opa_heap_ptr_set` to ensure that evaluation restarts back at the
+saved data and re-uses heap space. This is particularly important if re-evaluating many
 times with the same data.
 
 #### Results

--- a/test/wasm/assets/test.js
+++ b/test/wasm/assets/test.js
@@ -108,7 +108,7 @@ function dumpJSON(mod, memory, addr) {
 }
 
 function builtinCustomTest(a) {
-    return a+1;
+    return a + 1;
 }
 
 function builtinCustomTestImpure() {
@@ -128,7 +128,7 @@ function builtinCall(policy, func) {
     const impl = builtinFuncs[policy.builtins[func]];
 
     if (impl === undefined) {
-        throw {message: "not implemented: built-in " + func + ": " + policy.builtins[func]}
+        throw { message: "not implemented: built-in " + func + ": " + policy.builtins[func] }
     }
 
     var argArray = Array.prototype.slice.apply(arguments);
@@ -148,7 +148,7 @@ async function instantiate(bytes, memory, data) {
 
     const addr2string = stringDecoder(memory);
 
-    let policy = {memory: memory};
+    let policy = { memory: memory };
 
     policy.module = await WebAssembly.instantiate(bytes, {
         env: {
@@ -159,19 +159,19 @@ async function instantiate(bytes, memory, data) {
             opa_println: function (addr) {
                 console.log(addr2string(addr));
             },
-            opa_builtin0: function(func, ctx) {
+            opa_builtin0: function (func, ctx) {
                 return builtinCall(policy, func);
             },
-            opa_builtin1: function(func, ctx, v1) {
+            opa_builtin1: function (func, ctx, v1) {
                 return builtinCall(policy, func, v1);
             },
-            opa_builtin2: function(func, ctx, v1, v2) {
+            opa_builtin2: function (func, ctx, v1, v2) {
                 return builtinCall(policy, func, v1, v2);
             },
-            opa_builtin3: function(func, ctx, v1, v2, v3) {
+            opa_builtin3: function (func, ctx, v1, v2, v3) {
                 return builtinCall(policy, func, v1, v2, v3);
             },
-            opa_builtin4: function(func, ctx, v1, v2, v3, v4) {
+            opa_builtin4: function (func, ctx, v1, v2, v3, v4) {
                 return builtinCall(policy, func, v1, v2, v3, v4);
             },
         },
@@ -186,7 +186,6 @@ async function instantiate(bytes, memory, data) {
 
     policy.dataAddr = loadJSON(policy.module, policy.memory, data || {});
     policy.heapPtr = policy.module.instance.exports.opa_heap_ptr_get();
-    policy.heapTop = policy.module.instance.exports.opa_heap_top_get();
 
     return policy;
 }
@@ -194,7 +193,6 @@ async function instantiate(bytes, memory, data) {
 function evaluate(policy, input) {
 
     policy.module.instance.exports.opa_heap_ptr_set(policy.heapPtr);
-    policy.module.instance.exports.opa_heap_top_set(policy.heapTop);
 
     const inputAddr = loadJSON(policy.module, policy.memory, input);
     const ctxAddr = policy.module.instance.exports.opa_eval_ctx_new();


### PR DESCRIPTION
SDKs don't need to set the heap top address because it's managed by
the malloc implementation and should be left intact across
executions (otherwise the malloc implementation will keep allocating
more memory from the host because the top has been reset across
executions.)

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
