### PR TITLE
Changing opa cli flag descriptions to match online docs

### DIFF
--- a/cmd/deps.go
+++ b/cmd/deps.go
@@ -20,10 +20,10 @@ import (
 )
 
 type depsCommandParams struct {
-	dataPaths   repeatedStringFlag
-	format      *util.EnumFlag
-	ignore      []string
-	bundlePaths repeatedStringFlag
+	dataPaths    repeatedStringFlag
+	outputFormat *util.EnumFlag
+	ignore       []string
+	bundlePaths  repeatedStringFlag
 }
 
 const (
@@ -35,7 +35,7 @@ func init() {
 
 	var params depsCommandParams
 
-	params.format = util.NewEnumFlag(depsFormatPretty, []string{
+	params.outputFormat = util.NewEnumFlag(depsFormatPretty, []string{
 		depsFormatPretty, depsFormatJSON,
 	})
 
@@ -56,10 +56,10 @@ func init() {
 		},
 	}
 
-	depsCommand.Flags().VarP(params.format, "format", "f", "set output format")
 	addIgnoreFlag(depsCommand.Flags(), &params.ignore)
 	addDataFlag(depsCommand.Flags(), &params.dataPaths)
 	addBundleFlag(depsCommand.Flags(), &params.bundlePaths)
+	addOutputFormat(depsCommand.Flags(), params.outputFormat)
 
 	RootCommand.AddCommand(depsCommand)
 }
@@ -123,7 +123,7 @@ func deps(args []string, params depsCommandParams) error {
 		Virtual: vrs,
 	}
 
-	switch params.format.String() {
+	switch params.outputFormat.String() {
 	case depsFormatJSON:
 		return presentation.JSON(os.Stdout, output)
 	default:

--- a/cmd/deps.go
+++ b/cmd/deps.go
@@ -57,8 +57,8 @@ func init() {
 	}
 
 	depsCommand.Flags().VarP(params.format, "format", "f", "set output format")
-	depsCommand.Flags().VarP(&params.dataPaths, "data", "d", "set data file(s) or directory path(s)")
-	depsCommand.Flags().VarP(&params.bundlePaths, "bundle", "b", "set bundle file(s) or directory path(s)")
+	depsCommand.Flags().VarP(&params.dataPaths, "data", "d", "set policy or data file(s). This flag can be repeated.")
+	depsCommand.Flags().VarP(&params.bundlePaths, "bundle", "b", "set bundle file(s) or directory path(s). This flag can be repeated.")
 	addIgnoreFlag(depsCommand.Flags(), &params.ignore)
 
 	RootCommand.AddCommand(depsCommand)

--- a/cmd/deps.go
+++ b/cmd/deps.go
@@ -57,9 +57,9 @@ func init() {
 	}
 
 	depsCommand.Flags().VarP(params.format, "format", "f", "set output format")
-	depsCommand.Flags().VarP(&params.dataPaths, "data", "d", "set policy or data file(s). This flag can be repeated.")
-	depsCommand.Flags().VarP(&params.bundlePaths, "bundle", "b", "set bundle file(s) or directory path(s). This flag can be repeated.")
 	addIgnoreFlag(depsCommand.Flags(), &params.ignore)
+	addDataFlag(depsCommand.Flags(), &params.dataPaths)
+	addBundleFlag(depsCommand.Flags(), &params.bundlePaths)
 
 	RootCommand.AddCommand(depsCommand)
 }

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -31,11 +31,11 @@ func addFailFlag(fs *pflag.FlagSet, fail *bool, value bool) {
 }
 
 func addDataFlag(fs *pflag.FlagSet, paths *repeatedStringFlag) {
-	fs.VarP(paths, "data", "d", "set data file(s) or directory path(s)")
+	fs.VarP(paths, "data", "d", "set policy or data file(s). This flag can be repeated.")
 }
 
 func addBundleFlag(fs *pflag.FlagSet, paths *repeatedStringFlag) {
-	fs.VarP(paths, "bundle", "b", "set bundle file(s) or directory path(s)")
+	fs.VarP(paths, "bundle", "b", "set bundle file(s) or directory path(s). This flag can be repeated.")
 }
 
 func addBundleModeFlag(fs *pflag.FlagSet, bundle *bool, value bool) {
@@ -47,7 +47,7 @@ func addInputFlag(fs *pflag.FlagSet, inputPath *string) {
 }
 
 func addImportFlag(fs *pflag.FlagSet, imports *repeatedStringFlag) {
-	fs.VarP(imports, "import", "", "set query import(s)")
+	fs.VarP(imports, "import", "", "set query import(s). This flag can be repeated.")
 }
 
 func addPackageFlag(fs *pflag.FlagSet, pkg *string) {


### PR DESCRIPTION
- Changed the data flag description to specify that it can take policy
or data files
- Suffixed some descriptions with "This flag can be repeated." where
applicable

Fixes: #2586
Signed-off-by: Alan Silva <alansq16@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->