### PR TITLE
watch directories

### DIFF
--- a/loader/loader.go
+++ b/loader/loader.go
@@ -302,6 +302,25 @@ func Paths(path string, recurse bool) (paths []string, err error) {
 	return paths, err
 }
 
+// Dirs converts all filepaths to directories to use in the file watcher.
+// Some types of events will not register on the files themselves, so
+// watch the directory to prevent this problem
+func Dirs(paths []string) []string {
+	unique := map[string]struct{}{}
+
+	for _, path := range paths {
+		// TODO: /dir/dir will register top level directory /dir
+		dir := filepath.Dir(path)
+		unique[dir] = struct{}{}
+	}
+
+	var u []string
+	for k := range unique {
+		u = append(u, k)
+	}
+	return u
+}
+
 // SplitPrefix returns a tuple specifying the document prefix and the file
 // path.
 func SplitPrefix(path string) ([]string, string) {


### PR DESCRIPTION
Watching files only works in situations where standard files are in
use. In k8s, configmaps are mounted via a set of symlinks. In those
situations, you will only get file events when watching the directory
containing the symlink. Since by default, configmaps are mounted as
directories, I don't expect many people to find regressions when using this.

Signed-off-by: Drew Wells <drew.wells00@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
