### PR TITLE
ast: Improved object iteration

### DIFF
--- a/ast/check.go
+++ b/ast/check.go
@@ -328,7 +328,7 @@ func unify2(env *TypeEnv, a *Term, typeA types.Type, b *Term, typeB types.Type) 
 	switch a.Value.(type) {
 	case *Array:
 		return unify2Array(env, a, typeA, b, typeB)
-	case Object:
+	case *object:
 		return unify2Object(env, a, typeA, b, typeB)
 	case Var:
 		switch b.Value.(type) {
@@ -336,7 +336,7 @@ func unify2(env *TypeEnv, a *Term, typeA types.Type, b *Term, typeB types.Type) 
 			return unify1(env, a, types.A, false) && unify1(env, b, env.Get(a), false)
 		case *Array:
 			return unify2Array(env, b, typeB, a, typeA)
-		case Object:
+		case *object:
 			return unify2Object(env, b, typeB, a, typeA)
 		}
 	}
@@ -365,7 +365,7 @@ func unify2Array(env *TypeEnv, a *Term, typeA types.Type, b *Term, typeB types.T
 func unify2Object(env *TypeEnv, a *Term, typeA types.Type, b *Term, typeB types.Type) bool {
 	obj := a.Value.(Object)
 	switch bv := b.Value.(type) {
-	case Object:
+	case *object:
 		cv := obj.Intersect(bv)
 		if obj.Len() == bv.Len() && bv.Len() == len(cv) {
 			for i := range cv {
@@ -401,7 +401,7 @@ func unify1(env *TypeEnv, term *Term, tpe types.Type, union bool) bool {
 			return unifies
 		}
 		return false
-	case Object:
+	case *object:
 		switch tpe := tpe.(type) {
 		case *types.Object:
 			return unify1Object(env, v, tpe, union)

--- a/ast/compare.go
+++ b/ast/compare.go
@@ -130,8 +130,8 @@ func Compare(a, b interface{}) int {
 	case *Array:
 		b := b.(*Array)
 		return termSliceCompare(a.elems, b.elems)
-	case Object:
-		b := b.(Object)
+	case *object:
+		b := b.(*object)
 		return a.Compare(b)
 	case Set:
 		b := b.(Set)

--- a/ast/compile.go
+++ b/ast/compile.go
@@ -1177,7 +1177,7 @@ func (c *Compiler) rewriteLocalVars() {
 				}
 
 				switch v := term.Value.(type) {
-				case Object:
+				case *object:
 					// Make a copy of the object because the keys may be mutated.
 					cpy, _ := v.Map(func(k, v *Term) (*Term, *Term, error) {
 						if vark, ok := k.Value.(Var); ok {
@@ -1252,7 +1252,7 @@ func (vis *ruleArgLocalRewriter) Visit(x interface{}) Visitor {
 		}
 		t.Value = gv
 		return nil
-	case Object:
+	case *object:
 		if cpy, err := v.Map(func(k, v *Term) (*Term, *Term, error) {
 			vcpy := v.Copy()
 			Walk(vis, vcpy)
@@ -2621,7 +2621,7 @@ func resolveRefsInRule(globals map[Var]Ref, rule *Rule) error {
 			vars.Add(x)
 
 		// Object keys cannot be pattern matched so only walk values.
-		case Object:
+		case *object:
 			x.Foreach(func(k, v *Term) {
 				vis.Walk(v)
 			})
@@ -2709,7 +2709,7 @@ func resolveRefsInTerm(globals map[Var]Ref, ignore *declaredVarStack, term *Term
 		cpy := *term
 		cpy.Value = fqn
 		return &cpy
-	case Object:
+	case *object:
 		cpy := *term
 		cpy.Value, _ = v.Map(func(k, v *Term) (*Term, *Term, error) {
 			k = resolveRefsInTerm(globals, ignore, k)
@@ -2990,7 +2990,7 @@ func rewriteDynamicsOne(original *Expr, f *equalityFactory, term *Term, result B
 			v.set(i, t)
 		}
 		return result, term
-	case Object:
+	case *object:
 		cpy := NewObject()
 		v.Foreach(func(key, value *Term) {
 			result, key = rewriteDynamicsOne(original, f, key, result)
@@ -3109,7 +3109,7 @@ func expandExprTerm(gen *localVarGenerator, term *Term) (support []*Expr, output
 		support = expandExprRef(gen, v)
 	case *Array:
 		support = expandExprTermArray(gen, v)
-	case Object:
+	case *object:
 		cpy, _ := v.Map(func(k, v *Term) (*Term, *Term, error) {
 			extras1, expandedKey := expandExprTerm(gen, k)
 			extras2, expandedValue := expandExprTerm(gen, v)
@@ -3439,7 +3439,7 @@ func rewriteDeclaredAssignment(g *localVarGenerator, stack *localDeclaredVars, e
 			return true
 		case *Array:
 			return false
-		case Object:
+		case *object:
 			v.Foreach(func(_, v *Term) {
 				WalkTerms(v, vis)
 			})
@@ -3487,7 +3487,7 @@ func rewriteDeclaredVarsInTerm(g *localVarGenerator, stack *localDeclaredVars, t
 			return true, errs
 		}
 		return false, errs
-	case Object:
+	case *object:
 		cpy, _ := v.Map(func(k, v *Term) (*Term, *Term, error) {
 			kcpy := k.Copy()
 			errs = rewriteDeclaredVarsInTermRecursive(g, stack, kcpy, errs)

--- a/ast/compile.go
+++ b/ast/compile.go
@@ -2622,9 +2622,9 @@ func resolveRefsInRule(globals map[Var]Ref, rule *Rule) error {
 
 		// Object keys cannot be pattern matched so only walk values.
 		case Object:
-			for _, k := range x.Keys() {
-				vis.Walk(x.Get(k))
-			}
+			x.Foreach(func(k, v *Term) {
+				vis.Walk(v)
+			})
 
 		// Skip terms that could contain vars that cannot be pattern matched.
 		case Set, *ArrayComprehension, *SetComprehension, *ObjectComprehension, Call:
@@ -2992,12 +2992,11 @@ func rewriteDynamicsOne(original *Expr, f *equalityFactory, term *Term, result B
 		return result, term
 	case Object:
 		cpy := NewObject()
-		for _, key := range v.Keys() {
-			value := v.Get(key)
+		v.Foreach(func(key, value *Term) {
 			result, key = rewriteDynamicsOne(original, f, key, result)
 			result, value = rewriteDynamicsOne(original, f, value, result)
 			cpy.Insert(key, value)
-		}
+		})
 		return result, NewTerm(cpy).SetLocation(term.Location)
 	case Set:
 		cpy := NewSet()

--- a/ast/env.go
+++ b/ast/env.go
@@ -56,7 +56,7 @@ func (env *TypeEnv) Get(x interface{}) types.Type {
 
 		return types.NewArray(static, dynamic)
 
-	case Object:
+	case *object:
 		static := []*types.StaticProperty{}
 		var dynamic *types.DynamicProperty
 

--- a/ast/policy.go
+++ b/ast/policy.go
@@ -1292,7 +1292,7 @@ func Copy(x interface{}) interface{} {
 		return x.Copy()
 	case Set:
 		return x.Copy()
-	case Object:
+	case *object:
 		return x.Copy()
 	case *Array:
 		return x.Copy()

--- a/ast/transform.go
+++ b/ast/transform.go
@@ -187,7 +187,7 @@ func Transform(t Transformer, x interface{}) (interface{}, error) {
 			}
 		}
 		return y, nil
-	case Object:
+	case *object:
 		return y.Map(func(k, v *Term) (*Term, *Term, error) {
 			k, err := transformTerm(t, k)
 			if err != nil {

--- a/ast/unify.go
+++ b/ast/unify.go
@@ -73,7 +73,7 @@ func (u *unifier) unify(a *Term, b *Term) {
 		switch b := b.Value.(type) {
 		case Var:
 			u.markSafe(b)
-		case Object:
+		case *object:
 			u.markAllSafe(b)
 		}
 	case *SetComprehension:
@@ -96,13 +96,13 @@ func (u *unifier) unify(a *Term, b *Term) {
 			}
 		}
 
-	case Object:
+	case *object:
 		switch b := b.Value.(type) {
 		case Var:
 			u.unifyAll(b, a)
 		case Ref:
 			u.markAllSafe(a)
-		case Object:
+		case *object:
 			if a.Len() == b.Len() {
 				a.Iter(func(k, v *Term) error {
 					if v2 := b.Get(k); v2 != nil {

--- a/ast/visit.go
+++ b/ast/visit.go
@@ -106,7 +106,7 @@ func walk(v Visitor, x interface{}) {
 		for _, t := range x {
 			Walk(w, t)
 		}
-	case Object:
+	case *object:
 		x.Foreach(func(k, vv *Term) {
 			Walk(w, k)
 			Walk(w, vv)
@@ -334,7 +334,7 @@ func (vis *GenericVisitor) Walk(x interface{}) {
 		for _, t := range x {
 			vis.Walk(t)
 		}
-	case Object:
+	case *object:
 		x.Foreach(func(k, v *Term) {
 			vis.Walk(k)
 			vis.Walk(x.Get(k))
@@ -452,7 +452,7 @@ func (vis *BeforeAfterVisitor) Walk(x interface{}) {
 		for _, t := range x {
 			vis.Walk(t)
 		}
-	case Object:
+	case *object:
 		x.Foreach(func(k, v *Term) {
 			vis.Walk(k)
 			vis.Walk(x.Get(k))
@@ -655,7 +655,7 @@ func (vis *VarVisitor) Walk(x interface{}) {
 		for _, t := range x {
 			vis.Walk(t)
 		}
-	case Object:
+	case *object:
 		x.Foreach(func(k, v *Term) {
 			vis.Walk(k)
 			vis.Walk(x.Get(k))

--- a/ast/visit.go
+++ b/ast/visit.go
@@ -335,10 +335,10 @@ func (vis *GenericVisitor) Walk(x interface{}) {
 			vis.Walk(t)
 		}
 	case Object:
-		for _, k := range x.Keys() {
+		x.Foreach(func(k, v *Term) {
 			vis.Walk(k)
 			vis.Walk(x.Get(k))
-		}
+		})
 	case *Array:
 		x.Foreach(func(t *Term) {
 			vis.Walk(t)
@@ -453,10 +453,10 @@ func (vis *BeforeAfterVisitor) Walk(x interface{}) {
 			vis.Walk(t)
 		}
 	case Object:
-		for _, k := range x.Keys() {
+		x.Foreach(func(k, v *Term) {
 			vis.Walk(k)
 			vis.Walk(x.Get(k))
-		}
+		})
 	case *Array:
 		x.Foreach(func(t *Term) {
 			vis.Walk(t)
@@ -521,9 +521,9 @@ func (vis *VarVisitor) Vars() VarSet {
 func (vis *VarVisitor) visit(v interface{}) bool {
 	if vis.params.SkipObjectKeys {
 		if o, ok := v.(Object); ok {
-			for _, k := range o.Keys() {
-				vis.Walk(o.Get(k))
-			}
+			o.Foreach(func(k, v *Term) {
+				vis.Walk(v)
+			})
 			return true
 		}
 	}
@@ -656,10 +656,10 @@ func (vis *VarVisitor) Walk(x interface{}) {
 			vis.Walk(t)
 		}
 	case Object:
-		for _, k := range x.Keys() {
+		x.Foreach(func(k, v *Term) {
 			vis.Walk(k)
 			vis.Walk(x.Get(k))
-		}
+		})
 	case *Array:
 		x.Foreach(func(t *Term) {
 			vis.Walk(t)

--- a/topdown/eval.go
+++ b/topdown/eval.go
@@ -717,18 +717,19 @@ func (e *eval) biunifyObjects(a, b ast.Object, b1, b2 *bindings, iter unifyItera
 		b = plugKeys(b, b2)
 	}
 
-	return e.biunifyObjectsRec(a, b, b1, b2, iter, a.Keys(), 0)
+	return e.biunifyObjectsRec(a, b, b1, b2, iter, a, 0)
 }
 
-func (e *eval) biunifyObjectsRec(a, b ast.Object, b1, b2 *bindings, iter unifyIterator, keys []*ast.Term, idx int) error {
-	if idx == len(keys) {
+func (e *eval) biunifyObjectsRec(a, b ast.Object, b1, b2 *bindings, iter unifyIterator, keys ast.Object, idx int) error {
+	if idx == keys.Len() {
 		return iter()
 	}
-	v2 := b.Get(keys[idx])
+	key, _ := keys.Elem(idx)
+	v2 := b.Get(key)
 	if v2 == nil {
 		return nil
 	}
-	return e.biunify(a.Get(keys[idx]), v2, b1, b2, func() error {
+	return e.biunify(a.Get(key), v2, b1, b2, func() error {
 		return e.biunifyObjectsRec(a, b, b1, b2, iter, keys, idx+1)
 	})
 }


### PR DESCRIPTION
The improved iteration doesn't require hashing keys as with complex keys the cost of hashing can become dominant. On a particular policy, this patch improved the evaluation time 10+%.

The second patch introducing the direct use of *object (instead of Object) is to help escape analysis and avoid introducing new mallocs within the ast package when passing a function parameter to Object.Foreach.

Major changes in the benchmarks:

```
RewriteDynamics/1-16                            268ns ± 3%     221ns ± 2%  -17.24%  (p=0.000 n=10+8)
RewriteDynamics/10-16                          2.60µs ± 1%    2.13µs ± 1%  -18.10%  (p=0.000 n=9+10)
RewriteDynamics/100-16                         27.9µs ± 1%    22.7µs ± 3%  -18.83%  (p=0.000 n=9+10)
RewriteDynamics/1000-16                         299µs ± 2%     239µs ± 4%  -19.97%  (p=0.000 n=9+10)
RewriteDynamics/10000-16                       3.69ms ± 8%    3.27ms ± 4%  -11.51%  (p=0.000 n=10+10)
RewriteDynamics/100000-16                      54.6ms ±11%    51.1ms ± 5%   -6.49%  (p=0.022 n=10+9)
ParseModuleRulesBase/1-16                      4.17µs ± 3%    4.15µs ± 2%     ~     (p=0.542 n=10+10)
ParseModuleRulesBase/10-16                     29.6µs ± 4%    28.6µs ± 2%   -3.31%  (p=0.001 n=10+10)
ParseModuleRulesBase/100-16                     277µs ± 1%     273µs ± 2%   -1.48%  (p=0.007 n=10+10)
ParseModuleRulesBase/1000-16                   3.00ms ± 1%    3.01ms ± 1%     ~     (p=0.720 n=9+10)
VirtualCache-16                                 274ns ± 2%     268ns ± 1%   -2.35%  (p=0.000 n=9+10)
LargeJSON-16                                   35.8ms ± 4%    33.8ms ± 5%   -5.55%  (p=0.003 n=10+10)
PartialEvalCompile/1-16                         741µs ± 4%     720µs ± 0%   -2.76%  (p=0.000 n=10+8)
PartialEvalCompile/10-16                       1.92ms ± 1%    1.85ms ± 2%   -3.66%  (p=0.000 n=9+10)
PartialEvalCompile/100-16                      30.4ms ± 3%    29.5ms ± 2%   -2.94%  (p=0.000 n=9+10)
PartialEvalCompile/1000-16                      2.04s ± 1%     1.95s ± 2%   -4.22%  (p=0.000 n=10+10)
Walk/100-16                                    53.1µs ± 3%    52.5µs ± 1%     ~     (p=0.052 n=10+10)
Walk/1000-16                                    116µs ± 1%     115µs ± 2%   -1.04%  (p=0.015 n=10+10)
Walk/2000-16                                    184µs ± 2%     184µs ± 1%     ~     (p=0.661 n=9+10)
Walk/3000-16                                    253µs ± 2%     249µs ± 0%   -1.78%  (p=0.000 n=10+7)
ComprehensionIndexing/arrays_10-16             77.6µs ± 5%    75.0µs ± 1%   -3.32%  (p=0.000 n=10+9)
ComprehensionIndexing/arrays_100-16             530µs ± 1%     510µs ± 2%   -3.80%  (p=0.000 n=8+9)
ComprehensionIndexing/arrays_1000-16           5.32ms ± 2%    5.30ms ± 1%     ~     (p=0.315 n=10+8)
ComprehensionIndexing/sets_10-16               78.7µs ± 1%    78.5µs ± 1%     ~     (p=0.247 n=10+10)
ComprehensionIndexing/sets_100-16               544µs ± 3%     533µs ± 2%   -1.97%  (p=0.007 n=10+10)
ComprehensionIndexing/sets_1000-16             5.65ms ± 3%    5.52ms ± 2%   -2.20%  (p=0.002 n=10+10)
ComprehensionIndexing/objects_10-16            82.1µs ± 0%    82.5µs ± 2%     ~     (p=0.436 n=10+10)
ComprehensionIndexing/objects_100-16            577µs ± 1%     572µs ± 2%     ~     (p=0.053 n=10+9)
ComprehensionIndexing/objects_1000-16          6.02ms ± 2%    5.92ms ± 3%   -1.55%  (p=0.035 n=10+9)
InliningFullScan/1000-16                       8.80ms ± 1%    8.77ms ± 1%     ~     (p=0.684 n=10+10)
InliningFullScan/10000-16                      91.2ms ± 1%    91.0ms ± 1%     ~     (p=0.315 n=8+10)
InliningFullScan/300000-16                      2.69s ± 2%     2.65s ± 1%   -1.50%  (p=0.002 n=10+9)
```

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
