### PR TITLE
feat: server wait for bundle activation

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -164,6 +164,7 @@ To skip bundle verification, use the --skip-verify flag.
 
 	addConfigFileFlag(runCommand.Flags(), &cmdParams.rt.ConfigFile)
 	runCommand.Flags().BoolVarP(&cmdParams.serverMode, "server", "s", false, "start the runtime in server mode")
+	runCommand.Flags().IntVar(&cmdParams.rt.ReadyTimeout, "ready-timeout", 0, "wait (in seconds) for configured plugins before starting server (value <= 0 disables ready check)")
 	runCommand.Flags().StringVarP(&cmdParams.rt.HistoryPath, "history", "H", historyPath(), "set path of history file")
 	cmdParams.rt.Addrs = runCommand.Flags().StringSliceP("addr", "a", []string{defaultAddr}, "set listening address of the server (e.g., [ip]:<port> for TCP, unix://<path> for UNIX domain socket)")
 	cmdParams.rt.DiagnosticAddrs = runCommand.Flags().StringSlice("diagnostic-addr", []string{}, "set read-only diagnostic listening address of the server for /health and /metric APIs (e.g., [ip]:<port> for TCP, unix://<path> for UNIX domain socket)")

--- a/util/wait.go
+++ b/util/wait.go
@@ -1,0 +1,34 @@
+// Copyright 2020 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package util
+
+import (
+	"fmt"
+	"time"
+)
+
+// WaitFunc will call passed function at an interval and return nil
+// as soon this function returns true.
+// If timeout is reached before the passed in function returns true
+// an error is returned.
+func WaitFunc(fun func() bool, interval, timeout time.Duration) error {
+	if fun() {
+		return nil
+	}
+	ticker := time.NewTicker(interval)
+	timer := time.NewTimer(timeout)
+	defer ticker.Stop()
+	defer timer.Stop()
+	for {
+		select {
+		case <-timer.C:
+			return fmt.Errorf("timeout")
+		case <-ticker.C:
+			if fun() {
+				return nil
+			}
+		}
+	}
+}

--- a/util/wait_test.go
+++ b/util/wait_test.go
@@ -1,0 +1,43 @@
+// Copyright 2020 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package util
+
+import (
+	"testing"
+	"time"
+)
+
+func TestWaitFunc(t *testing.T) {
+	trueAfter := func(after time.Duration) func() bool {
+		t := time.Now().Add(after)
+		return func() bool {
+			return time.Now().After(t)
+		}
+	}
+
+	cases := []struct {
+		trueAfter  time.Duration
+		interval   time.Duration
+		timeout    time.Duration
+		shouldFail bool
+	}{
+		{0, 1 * time.Millisecond, 3 * time.Millisecond, false},
+		{2 * time.Millisecond, 1 * time.Millisecond, 4 * time.Millisecond, false},
+		{3 * time.Millisecond, 1 * time.Millisecond, 2 * time.Millisecond, true},
+		{3 * time.Millisecond, 5 * time.Millisecond, 4 * time.Millisecond, true},
+	}
+
+	for _, c := range cases {
+		err := WaitFunc(trueAfter(c.trueAfter), c.interval, c.timeout)
+		if err != nil && c.shouldFail {
+			continue
+		}
+		if err != nil {
+			t.Error(err)
+		} else if c.shouldFail {
+			t.Errorf("Expected error for case: %+v", c)
+		}
+	}
+}


### PR DESCRIPTION
A new flag introduced `--wait-bundle-timeout`.
This flag controls how long OPA server will wait for configured bundles
to be activated/loaded before listening for incoming traffic.

```bash
opa run -s --wait-bundle-timeout 10s -c config.yaml
```

This can be useful if you can't use the /health?bundle=true endpoint to check for "operational readiness", and 
want to make sure the OPA server is "operational ready" before serving any traffic.

Came across this "obstacle" when running an OPA server in Google Cloud Run, where there's no way of configuring/using a health check. Cloud Run will start serving traffic as soon as the listening `PORT` is open, and so when using OPA server with bundle service, the server is not yet "operational ready".

I guess this could have been solved by some (rather complex) startup script/docker-entrypoint, and I don't know if this kind of issue has already been discussed 🤷‍♂️ .. 