### PR TITLE
runtime: Make plugin readiness timeout tests a bit more forgiving

### DIFF
--- a/runtime/plugins_test.go
+++ b/runtime/plugins_test.go
@@ -171,7 +171,8 @@ func TestWaitPluginsReady(t *testing.T) {
 		})
 
 		go func() {
-			time.Sleep(2 * time.Millisecond)
+			time.Sleep(100 * time.Millisecond)
+
 			rt.Manager.UpdatePluginStatus("test", &plugins.Status{
 				State: plugins.StateOK,
 			})
@@ -188,7 +189,7 @@ func TestWaitPluginsReady(t *testing.T) {
 			t.Fatal("Expected timeout error")
 		}
 
-		if err := rt.waitPluginsReady(1*time.Millisecond, 3*time.Millisecond); err != nil {
+		if err := rt.waitPluginsReady(1*time.Millisecond, time.Second); err != nil {
 			t.Fatal(err)
 		}
 	})


### PR DESCRIPTION
We were starting to see test flakes because the timeouts were not very
forgiving. Bumping them so that the difference is orders of magnitude
to account for environments like GHA.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
