### PR TITLE
tester: Report missing lines in test coverage

### DIFF
--- a/cmd/test.go
+++ b/cmd/test.go
@@ -236,7 +236,7 @@ func opaTest(args []string) int {
 			}
 		}
 	} else {
-		reporter = tester.JSONCoverageReporter{
+		reporter = tester.PrettyCoverageReporter{
 			Cover:     cov,
 			Modules:   modules,
 			Output:    os.Stdout,

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -236,11 +236,21 @@ func opaTest(args []string) int {
 			}
 		}
 	} else {
-		reporter = tester.PrettyCoverageReporter{
-			Cover:     cov,
-			Modules:   modules,
-			Output:    os.Stdout,
-			Threshold: testParams.threshold,
+		if testParams.outputFormat.String() == "json" {
+			reporter = tester.JSONCoverageReporter{
+				Cover:     cov,
+				Modules:   modules,
+				Output:    os.Stdout,
+				Threshold: testParams.threshold,
+			}
+		} else {
+			reporter = tester.PrettyCoverageReporter{
+				Verbose:   testParams.verbose,
+				Cover:     cov,
+				Modules:   modules,
+				Output:    os.Stdout,
+				Threshold: testParams.threshold,
+			}
 		}
 	}
 


### PR DESCRIPTION
With the --threshold flag set, opa did not report the missing lines,
making it difficult to understand where the problem is. This commit
modifies opa test so that the pretty format reports text instead of
JSON, and shows the lines not covered if the threshold is not met.

Fixes #2562
Signed-off-by: Aditya <aditya10699@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
