### PR TITLE
compile: Add support for unknowns other than input

### DIFF
--- a/docs/content/policy-performance.md
+++ b/docs/content/policy-performance.md
@@ -714,6 +714,10 @@ Rules that depend on unknowns (directly or indirectly) are also partially evalua
 virtual documents they produce ARE NOT inlined into call sites. The output policy should be structurally
 similar to the input policy.
 
+The `opa build` automatically marks the `input` document as unknown. In addition to the `input` document,
+if `opa build` is invoked with the `-b`/`--bundle` flag, any `data` references NOT prefixed by the
+`.manifest` roots are also marked as unknown.
+
 ### -O=2 (aggressive)
 
 Same as `-O=1` except virtual documents produced by rules that depend on unknowns may be inlined


### PR DESCRIPTION
Previously the build command and the compile package would only mark
input as unknown. If documents under data needed to be treated as
unknown, there was no solution. This commit updates the compile
package to infer unknowns based on the bundle roots. If the policy
refers to a data document _outside_ of one of the bundle roots, that
data document will be marked as unknown during optimization/partial
eval.

Fixes #2581

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
