### PR TITLE
docs: Remove openable tag from test examples

### DIFF
--- a/docs/content/policy-testing.md
+++ b/docs/content/policy-testing.md
@@ -42,7 +42,7 @@ To test this policy, we will create a separate Rego file that contains test case
 
 **example_test.rego**:
 
-```live:example/test:module:read_only,openable
+```live:example/test:module:read_only
 package authz
 
 test_post_allowed {
@@ -251,7 +251,7 @@ Below is the Rego file to test the above policy.
 
 **authz_test.rego**:
 
-```live:with_keyword/tests:module:read_only,openable
+```live:with_keyword/tests:module:read_only
 package authz
 
 policies = [{"name": "test_policy"}]


### PR DESCRIPTION
The test examples cannot be opened into the playground because they
require multiple files and the playground UI does not support that
today.

Fix #2073

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
