### PR TITLE
topdown: Pass metrics to built-ins and record http.send latency

### DIFF
--- a/topdown/builtins.go
+++ b/topdown/builtins.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/open-policy-agent/opa/metrics"
 	"github.com/open-policy-agent/opa/topdown/cache"
 
 	"github.com/open-policy-agent/opa/ast"
@@ -32,6 +33,7 @@ type (
 	// built-in functions.
 	BuiltinContext struct {
 		Context                context.Context       // request context that was passed when query started
+		Metrics                metrics.Metrics       // metrics registry for recording built-in specific metrics
 		Seed                   io.Reader             // randomization seed
 		Time                   *ast.Term             // wall clock time
 		Cancel                 Cancel                // atomic value that signals evaluation to halt

--- a/topdown/eval.go
+++ b/topdown/eval.go
@@ -8,11 +8,11 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/open-policy-agent/opa/topdown/cache"
-
 	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/metrics"
 	"github.com/open-policy-agent/opa/storage"
 	"github.com/open-policy-agent/opa/topdown/builtins"
+	"github.com/open-policy-agent/opa/topdown/cache"
 	"github.com/open-policy-agent/opa/topdown/copypropagation"
 )
 
@@ -33,6 +33,7 @@ func (f *queryIDFactory) Next() uint64 {
 
 type eval struct {
 	ctx                    context.Context
+	metrics                metrics.Metrics
 	seed                   io.Reader
 	time                   *ast.Term
 	queryID                uint64
@@ -621,6 +622,7 @@ func (e *eval) evalCall(terms []*ast.Term, iter unifyIterator) error {
 
 	bctx := BuiltinContext{
 		Context:                e.ctx,
+		Metrics:                e.metrics,
 		Seed:                   e.seed,
 		Time:                   e.time,
 		Cancel:                 e.cancel,


### PR DESCRIPTION
Previously the built-in functions had no way to record metrics for
performance monitoring or other purposes. With this change, built-in
functions can manipulate the evaluation metrics. Initially, only the
http.send function has been updated to report latency.

Fixes #2034

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
