### PR TITLE
Add response header timeout and update discovery bundle status

### DIFF
--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -25,6 +25,7 @@ The file can be either JSON or YAML format.
 services:
   acmecorp:
     url: https://example.com/control-plane-api/v1
+    response_header_timeout_seconds: 5
     credentials:
       bearer:
         token: "bGFza2RqZmxha3NkamZsa2Fqc2Rsa2ZqYWtsc2RqZmtramRmYWxkc2tm"
@@ -236,6 +237,7 @@ multiple services.
 | --- | --- | --- | --- |
 | `services[_].name` | `string` | Yes | Unique name for the service. Referred to by plugins. |
 | `services[_].url` | `string` | Yes | Base URL to contact the service with. |
+| `services[_].response_header_timeout_seconds` | `int64` | No (default: 10) | Amount of time to wait for a server's response headers after fully writing the request. This time does not include the time to read the response body. |
 | `services[_].headers` | `object` | No | HTTP headers to include in requests to the service. |
 | `services[_].allow_insecure_tls` | `bool` | No | Allow insecure TLS. |
 

--- a/docs/content/management.md
+++ b/docs/content/management.md
@@ -834,6 +834,8 @@ Status updates contain the following fields:
 | `bundles[_].metrics` | `object` | Metrics from the last update of the bundle. |
 | `discovery.name` | `string` | Name of discovery bundle that the OPA instance is configured to download. |
 | `discovery.active_revision` | `string` | Opaque revision identifier of the last successful discovery activation. |
+| `discovery.last_request` | `string` | RFC3339 timestamp of last discovery bundle request. This timestamp should be >= to the successful request timestamp in normal operation. |
+| `discovery.last_successful_request` | `string` | RFC3339 timestamp of last successful discovery bundle request. This timestamp should be >= to the successful download timestamp in normal operation. |
 | `discovery.last_successful_download` | `string` | RFC3339 timestamp of last successful discovery bundle download. |
 | `discovery.last_successful_activation` | `string` | RFC3339 timestamp of last successful discovery bundle activation. |
 | `plugins` | `object` | A set of objects describing the state of configured plugins in OPA's runtime. |

--- a/plugins/discovery/discovery.go
+++ b/plugins/discovery/discovery.go
@@ -133,6 +133,7 @@ func (c *Discovery) oneShot(ctx context.Context, u download.Update) {
 }
 
 func (c *Discovery) processUpdate(ctx context.Context, u download.Update) {
+	c.status.SetRequest()
 
 	if u.Error != nil {
 		c.logError("Discovery download failed: %v", u.Error)
@@ -141,8 +142,10 @@ func (c *Discovery) processUpdate(ctx context.Context, u download.Update) {
 		return
 	}
 
+	c.status.LastSuccessfulRequest = c.status.LastRequest
+
 	if u.Bundle != nil {
-		c.status.SetDownloadSuccess()
+		c.status.LastSuccessfulDownload = c.status.LastSuccessfulRequest
 
 		if err := c.reconfigure(ctx, u); err != nil {
 			c.logError("Discovery reconfiguration error occurred: %v", err)


### PR DESCRIPTION
These changes include:

* A new configurable timeout to the Services
config to set the amount of time to wait for the server's
response headers. Fixes: #2014

*  Logic to set the values for the last request and last successful request
in the discovery bundle status. Fixes: #2630

Signed-off-by: Ashutosh Narkar <anarkar4387@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
