### PR TITLE
fix: bundle download failed - context canceled

### DIFF
--- a/plugins/rest/rest.go
+++ b/plugins/rest/rest.go
@@ -216,10 +216,7 @@ func (c Client) Do(ctx context.Context, method, path string) (*http.Response, er
 		req.Header.Add(key, value)
 	}
 
-	hCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
-	req = req.WithContext(hCtx)
+	req = req.WithContext(ctx)
 
 	err = c.config.authPrepare(req)
 	if err != nil {


### PR DESCRIPTION
After upgrading to 0.23.1 bundle download fails — "context canceled loop"

```text
[INFO] Initializing server.
  addrs = |
      [
        ":8181"
      ]
  diagnostic-addrs = []
  insecure_addr = ""

[INFO] Starting bundle downloader.
  plugin = "bundle"
  name = "default"

[INFO] Starting decision logger.
  plugin = "decision_logs"

[ERROR] Bundle download failed: bundle read failed: archive read failed: context canceled
  plugin = "bundle"
  name = "default"

[ERROR] Bundle download failed: bundle read failed: archive read failed: context canceled
  plugin = "bundle"
  name = "default"

[ERROR] Bundle download failed: bundle read failed: archive read failed: context canceled
  plugin = "bundle"
  name = "default"

[ERROR] Bundle download failed: bundle read failed: archive read failed: context canceled
  plugin = "bundle"
  name = "default"

[ERROR] Bundle download failed: bundle read failed: archive read failed: context canceled
  plugin = "bundle"
  name = "default"

[ERROR] Bundle download failed: bundle read failed: archive read failed: context canceled
  plugin = "bundle"
  name = "default"

[ERROR] Bundle download failed: bundle read failed: archive read failed: context canceled
  plugin = "bundle"
  name = "default"

[ERROR] Bundle download failed: bundle read failed: archive read failed: context canceled
  plugin = "bundle"
  name = "default"
```

After removing this code (introduced in https://github.com/open-policy-agent/opa/commit/b48aba82b0920b1114d4c64d3a22ffa9f6259017#diff-f4076aa50c92ccd52544c8f6e44238e6R219-R220) 

```golang
defer cancel()
```

the problem goes away.

