### PR TITLE
secret creation to opa namespace since deployment is namespaced

### DIFF
--- a/docs/content/kubernetes-tutorial.md
+++ b/docs/content/kubernetes-tutorial.md
@@ -94,7 +94,7 @@ openssl x509 -req -in server.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out s
 Create a Secret to store the TLS credentials for OPA:
 
 ```bash
-kubectl create secret tls opa-server --cert=server.crt --key=server.key
+kubectl create secret tls opa-server --cert=server.crt --key=server.key -n opa
 ```
 
 Next, use the file below to deploy OPA as an admission controller.


### PR DESCRIPTION
The deployment object in the yaml at line 165 is namespaced to opa. But the secret creation command in the documentation is for the default namespace.

If I follow the documentation, I would expect the gatekeeper pod to be up and running. but it fails to find the secret in the opa namespace

So changed the secret creation to opa namespace.