### PR TITLE
topdown: Add urlquery.decode_object builtin

### DIFF
--- a/ast/builtins.go
+++ b/ast/builtins.go
@@ -135,6 +135,7 @@ var DefaultBuiltins = [...]*Builtin{
 	URLQueryDecode,
 	URLQueryEncode,
 	URLQueryEncodeObject,
+	URLQueryDecodeObject,
 	YAMLMarshal,
 	YAMLUnmarshal,
 
@@ -1280,6 +1281,17 @@ var URLQueryEncodeObject = &Builtin{
 						types.NewArray(nil, types.S),
 						types.NewSet(types.S))))),
 		types.S,
+	),
+}
+
+// URLQueryDecodeObject decodes the given URL query string into an object.
+var URLQueryDecodeObject = &Builtin{
+	Name: "urlquery.decode_object",
+	Decl: types.NewFunction(
+		types.Args(types.S),
+		types.NewObject(nil, types.NewDynamicProperty(
+			types.S,
+			types.NewArray(nil, types.S))),
 	),
 }
 

--- a/capabilities.json
+++ b/capabilities.json
@@ -3044,6 +3044,31 @@
       }
     },
     {
+      "name": "urlquery.decode_object",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "dynamic": {
+            "key": {
+              "type": "string"
+            },
+            "value": {
+              "dynamic": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "type": "function"
+      }
+    },
+    {
       "name": "urlquery.encode",
       "decl": {
         "args": [

--- a/docs/content/policy-reference.md
+++ b/docs/content/policy-reference.md
@@ -447,6 +447,7 @@ The following table shows examples of how ``glob.match`` works:
 | <span class="opa-keep-it-together">``output := urlquery.encode(string)``</span> | ``output`` is ``string`` serialized to a URL query parameter encoded string |
 | <span class="opa-keep-it-together">``output := urlquery.encode_object(object)``</span> | ``output`` is ``object`` serialized to a URL query parameter encoded string |
 | <span class="opa-keep-it-together">``output := urlquery.decode(string)``</span> | ``output`` is ``string`` deserialized from a URL query parameter encoded string |
+| <span class="opa-keep-it-together">``output := urlquery.decode_object(string)``</span> | ``output`` is ``object`` deserialized from a URL query parameter string |
 | <span class="opa-keep-it-together">``output := json.marshal(x)``</span> | ``output`` is ``x`` serialized to a JSON string |
 | <span class="opa-keep-it-together">``output := json.unmarshal(string)``</span> | ``output`` is ``string`` deserialized to a term from a JSON encoded string |
 | <span class="opa-keep-it-together">``output := yaml.marshal(x)``</span> | ``output`` is ``x`` serialized to a YAML string |

--- a/test/cases/testdata/urlbuiltins/test-urlbuiltins-1076.yaml
+++ b/test/cases/testdata/urlbuiltins/test-urlbuiltins-1076.yaml
@@ -1,0 +1,34 @@
+cases:
+- modules:
+  - |
+    package decode_object
+
+    p = x {
+      x = urlquery.decode_object("a=value_a1&b=value_b&a=value_a2")
+    }
+  note: urlbuiltins/decode_object multiple
+  query: data.decode_object.p = x
+  want_result:
+  - x: {"a": ["value_a1", "value_a2"], "b": ["value_b"]}
+- modules:
+  - |
+    package decode_object
+
+    p = x {
+      x = urlquery.decode_object("a=value_a1&b")
+    }
+  note: urlbuiltins/decode_object empty parameter
+  query: data.decode_object.p = x
+  want_result:
+  - x: {"a": ["value_a1"], "b": [""]}
+- modules:
+  - |
+    package decode_object
+
+    p = x {
+      x = urlquery.decode_object("")
+    }
+  note: urlbuiltins/decode_object empty string
+  query: data.decode_object.p = x
+  want_result:
+  - x: {}


### PR DESCRIPTION
This builtin is the reverse of the encode_object builtin and
makes it easier to use the URI query parameters in policies

Fixes #2647

Signed-off-by: Frederic <frederic.vanreet@icloud.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
