### PR TITLE
Fix panic during safety check reordering

### DIFF
--- a/ast/compile.go
+++ b/ast/compile.go
@@ -2465,11 +2465,19 @@ func outputVarsForTerms(expr *Expr, safe VarSet) VarSet {
 		case *SetComprehension, *ArrayComprehension, *ObjectComprehension:
 			return true
 		case Ref:
-			if safe.Contains(r[0].Value.(Var)) {
-				output.Update(r.OutputVars())
-				return false
+			if v, ok := r[0].Value.(Var); ok {
+				if !safe.Contains(v) {
+					return true
+				}
+			} else {
+				for k := range r[0].Vars() {
+					if !safe.Contains(k) {
+						return true
+					}
+				}
 			}
-			return true
+			output.Update(r.OutputVars())
+			return false
 		}
 		return false
 	})

--- a/ast/compile_test.go
+++ b/ast/compile_test.go
@@ -178,6 +178,21 @@ func TestOutputVarsForNode(t *testing.T) {
 			query: "x = 1; y = x; z = y",
 			exp:   "{x, y, z}",
 		},
+		{
+			note:  "composite head",
+			query: "{1, 2}[1] = x",
+			exp:   `{x}`,
+		},
+		{
+			note:  "composite head",
+			query: "x = 1; {x, 2}[1] = y",
+			exp:   `{x, y}`,
+		},
+		{
+			note:  "composite head",
+			query: "{x, 2}[1] = y",
+			exp:   `set()`,
+		},
 	}
 
 	for _, tc := range tests {

--- a/ast/compile_test.go
+++ b/ast/compile_test.go
@@ -776,6 +776,8 @@ func TestCompilerCheckSafetyBodyErrors(t *testing.T) {
 		{"call-vars-input", "p { f(x, x) } f(x) = x { true }", `{x,}`},
 		{"call-no-output", "p { f(x) } f(x) = x { true }", `{x,}`},
 		{"call-too-few", "p { f(1,x) } f(x,y) { true }", "{x,}"},
+		{"object-key-comprehension", "p { { {p|x}: 0 } }", "{x,}"},
+		{"set-value-comprehension", "p { {1, {p|x}} }", "{x,}"},
 	}
 
 	makeErrMsg := func(varName string) string {

--- a/ast/parser_ext.go
+++ b/ast/parser_ext.go
@@ -430,15 +430,15 @@ func ParseBody(input string) (Body, error) {
 	for _, stmt := range stmts {
 		switch stmt := stmt.(type) {
 		case Body:
-			result = append(result, stmt...)
+			for i := range stmt {
+				result.Append(stmt[i])
+			}
 		case *Comment:
 			// skip
 		default:
 			return nil, fmt.Errorf("expected body but got %T", stmt)
 		}
 	}
-
-	setExprIndices(result)
 
 	return result, nil
 }
@@ -616,15 +616,6 @@ func parseModule(filename string, stmts []Statement, comments []*Comment) (*Modu
 	}
 
 	return nil, errs
-}
-
-func setExprIndices(x interface{}) {
-	WalkBodies(x, func(b Body) bool {
-		for i, expr := range b {
-			expr.Index = i
-		}
-		return false
-	})
 }
 
 func setRuleModule(rule *Rule, module *Module) {

--- a/ast/transform.go
+++ b/ast/transform.go
@@ -323,6 +323,7 @@ func transformHead(t Transformer, head *Head) (*Head, error) {
 	}
 	return h, nil
 }
+
 func transformArgs(t Transformer, args Args) (Args, error) {
 	y, err := Transform(t, args)
 	if err != nil {
@@ -345,6 +346,18 @@ func transformBody(t Transformer, body Body) (Body, error) {
 		return nil, fmt.Errorf("illegal transform: %T != %T", body, y)
 	}
 	return r, nil
+}
+
+func transformExpr(t Transformer, expr *Expr) (*Expr, error) {
+	y, err := Transform(t, expr)
+	if err != nil {
+		return nil, err
+	}
+	h, ok := y.(*Expr)
+	if !ok {
+		return nil, fmt.Errorf("illegal transform: %T != %T", expr, y)
+	}
+	return h, nil
 }
 
 func transformTerm(t Transformer, term *Term) (*Term, error) {

--- a/ast/unify.go
+++ b/ast/unify.go
@@ -27,6 +27,18 @@ func (u *unifier) isSafe(x Var) bool {
 	return u.safe.Contains(x) || u.unified.Contains(x)
 }
 
+func (u *unifier) isHeadSafe(r Ref) bool {
+	if v, ok := r[0].Value.(Var); ok {
+		return u.isSafe(v)
+	}
+	for v := range r[0].Vars() {
+		if !u.isSafe(v) {
+			return false
+		}
+	}
+	return true
+}
+
 func (u *unifier) unify(a *Term, b *Term) {
 
 	switch a := a.Value.(type) {
@@ -45,7 +57,7 @@ func (u *unifier) unify(a *Term, b *Term) {
 		case *Array, Object:
 			u.unifyAll(a, b)
 		case Ref:
-			if u.isSafe(b[0].Value.(Var)) {
+			if u.isHeadSafe(b) {
 				u.markSafe(a)
 			}
 		default:
@@ -53,7 +65,7 @@ func (u *unifier) unify(a *Term, b *Term) {
 		}
 
 	case Ref:
-		if u.isSafe(a[0].Value.(Var)) {
+		if u.isHeadSafe(a) {
 			switch b := b.Value.(type) {
 			case Var:
 				u.markSafe(b)


### PR DESCRIPTION
The compiler was panicking when it encountered object literal with a comprehension key because the comprehension body may be rewritten which would corrupt the object value.