### PR TITLE
build: Move VERSION into version/version.go

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Use of this source code is governed by an Apache2
 # license that can be found in the LICENSE file.
 
-VERSION := 0.24.0-dev
+VERSION := $(shell ./build/get-build-version.sh)
 
 CGO_ENABLED ?= 0
 

--- a/build/gen-dev-patch.sh
+++ b/build/gen-dev-patch.sh
@@ -40,7 +40,7 @@ cd $OPA_DIR
 LAST_VERSION=$(git describe --abbrev=0 --tags | cut -c 2-)
 
 update_makefile() {
-    sed -i='' -e "s/^VERSION[ \t]*:=[ \t]*.\+$/VERSION := $VERSION-dev/" Makefile
+    sed -i='' -e "s/Version\s\+=\s\+\".\+\"$/Version = \"$VERSION-dev\"/" version/version.go
 }
 
 update_changelog() {

--- a/build/gen-release-patch.sh
+++ b/build/gen-release-patch.sh
@@ -42,7 +42,7 @@ if [ -z "$LAST_VERSION" ]; then
 fi
 
 update_makefile() {
-    sed -i='' -e "s/^VERSION[ \t]*:=[ \t]*.\+$/VERSION := $VERSION/" Makefile
+    sed -i='' -e "s/Version\s\+=\s\+\".\+\"$/Version = \"$VERSION\"/" version/version.go
 }
 
 update_changelog() {

--- a/build/get-build-version.sh
+++ b/build/get-build-version.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+grep '^var Version' version/version.go | awk '{print $4}' | tr -d '"'

--- a/plugins/logs/plugin_test.go
+++ b/plugins/logs/plugin_test.go
@@ -29,8 +29,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	// call flag.Parse() here if TestMain uses flags
-	setVersion("XY.Z")
+	version.Version = "XY.Z"
 	os.Exit(m.Run())
 }
 
@@ -241,7 +240,7 @@ func TestPluginStartSameInput(t *testing.T) {
 		Labels: map[string]string{
 			"id":      "test-instance-id",
 			"app":     "example-app",
-			"version": getVersion(),
+			"version": version.Version,
 		},
 		Revision:    "399",
 		DecisionID:  "399",
@@ -313,7 +312,7 @@ func TestPluginStartChangingInputValues(t *testing.T) {
 		Labels: map[string]string{
 			"id":      "test-instance-id",
 			"app":     "example-app",
-			"version": getVersion(),
+			"version": version.Version,
 		},
 		Revision:    "399",
 		DecisionID:  "399",
@@ -374,7 +373,7 @@ func TestPluginStartChangingInputKeysAndValues(t *testing.T) {
 		Labels: map[string]string{
 			"id":      "test-instance-id",
 			"app":     "example-app",
-			"version": getVersion(),
+			"version": version.Version,
 		},
 		Revision:    "249",
 		DecisionID:  "249",
@@ -1117,16 +1116,6 @@ func generateInputMap(idx int) map[string]interface{} {
 	}
 	return result
 
-}
-
-func setVersion(opaVersion string) {
-	if version.Version == "" {
-		version.Version = opaVersion
-	}
-}
-
-func getVersion() string {
-	return version.Version
 }
 
 func getWellKnownMetrics() metrics.Metrics {

--- a/version/version.go
+++ b/version/version.go
@@ -5,10 +5,12 @@
 // Package version contains version information that is set at build time.
 package version
 
-// Version information that is displayed by the "version" command and used to
+// Version is the canonical version of OPA.
+var Version = "0.24.0-dev"
+
+// Additional version information that is displayed by the "version" command and used to
 // identify the version of running instances of OPA.
 var (
-	Version   = ""
 	Vcs       = ""
 	Timestamp = ""
 	Hostname  = ""


### PR DESCRIPTION
This way the semantic version is always set. Tested by generating a fake release:

Cutting the release:

```
(dev)torin:~/src/opa$ make release-patch VERSION=0.24.0 > ~/test.patch
(dev)torin:~/src/opa$ patch -p1 < ~/test.patch
(Stripping trailing CRs from patch; use --binary to disable.)
patching file CHANGELOG.md
(Stripping trailing CRs from patch; use --binary to disable.)
patching file capabilities/v0.24.0.json
(Stripping trailing CRs from patch; use --binary to disable.)
patching file version/version.go
(dev)[*]torin:~/src/opa$ git add .
(dev)[*]torin:~/src/opa$ git commit -a -m 'wip: prepare release'
[dev 077c73b0] wip: prepare release
 3 files changed, 3236 insertions(+), 2 deletions(-)
 create mode 100644 capabilities/v0.24.0.json
(dev)torin:~/src/opa$ git tag v0.24.0
```

Checking the patches:

```
(dev)torin:~/src/opa$ head -n 10 CHANGELOG.md
# Change Log

All notable changes to this project will be documented in this file. This
project adheres to [Semantic Versioning](http://semver.org/).

## 0.24.0

### Fixes

- ast: Fix compiler to expand exprs in rule args ([#2649](https://github.com/open-policy-agent/opa/issues/2649))
----------------8<------------------
```
```
(dev)torin:~/src/opa$ head -n 10 version/version.go
// Copyright 2016 The OPA Authors.  All rights reserved.
// Use of this source code is governed by an Apache2
// license that can be found in the LICENSE file.

// Package version contains version information that is set at build time.
package version

// Version is the canonical version of OPA.
var Version = "0.24.0"
```

Building and checking the version:

```
(dev)torin:~/src/opa$ make build
make[1]: Entering directory '/home/torin/src/opa/wasm'
make: '_obj/opa.wasm' is up to date.
make[1]: Leaving directory '/home/torin/src/opa/wasm'
cp wasm/_obj/opa.wasm internal/compiler/wasm/opa/opa.wasm
CGO_ENABLED=0 GO111MODULE=on GOFLAGS=-mod=vendor go generate
CGO_ENABLED=0 GO111MODULE=on GOFLAGS=-mod=vendor go build -o opa_linux_amd64 -ldflags " -X github.com/open-policy-agent/opa/version.Version=0.24.0 -X github.com/open-policy-agent/opa/version.Vcs=077c73b0 -X github.com/open-policy-agent/opa/version.Timestamp=2020-09-11T15:33:03Z -X github.com/open-policy-agent/opa/version.Hostname=bigbox.localdomain"
(dev)torin:~/src/opa$ ./opa_linux_amd64 version
Version: 0.24.0
Build Commit: 077c73b0
Build Timestamp: 2020-09-11T15:33:03Z
Build Hostname: bigbox.localdomain
```

Preparing for development of next release:

```
(dev)torin:~/src/opa$ make dev-patch VERSION=0.25.0 >~/test.patch
(dev)torin:~/src/opa$ patch -p1 < ~/test.patchpatch
(Stripping trailing CRs from patch; use --binary to disable.)
patching file CHANGELOG.md
(Stripping trailing CRs from patch; use --binary to disable.)
patching file version/version.go
(dev)[*]torin:~/src/opa$ git commit -a -m 'wip: prepare dev'
[dev 8f61e3e7] wip: prepare dev
 2 files changed, 3 insertions(+), 1 deletion(-)
```

Building development version and verifying the version number:

```
(dev)torin:~/src/opa$ make build
make[1]: Entering directory '/home/torin/src/opa/wasm'
make: '_obj/opa.wasm' is up to date.
make[1]: Leaving directory '/home/torin/src/opa/wasm'
cp wasm/_obj/opa.wasm internal/compiler/wasm/opa/opa.wasm
CGO_ENABLED=0 GO111MODULE=on GOFLAGS=-mod=vendor go generate
CGO_ENABLED=0 GO111MODULE=on GOFLAGS=-mod=vendor go build -o opa_linux_amd64 -ldflags " -X github.com/open-policy-agent/opa/version.Version=0.25.0-dev -X github.com/open-policy-agent/opa/version.Vcs=8f61e3e7 -X github.com/open-policy-agent/opa/version.Timestamp=2020-09-11T15:33:37Z -X github.com/open-policy-agent/opa/version.Hostname=bigbox.localdomain"
(dev)torin:~/src/opa$ ./opa_linux_amd64 version
Version: 0.25.0-dev
Build Commit: 8f61e3e7
Build Timestamp: 2020-09-11T15:33:37Z
Build Hostname: bigbox.localdomain
```

Verifying the CHANGELOG.md file is up-to-date for development:

```
(dev)torin:~/src/opa$ head -n 10 CHANGELOG.md
# Change Log

All notable changes to this project will be documented in this file. This
project adheres to [Semantic Versioning](http://semver.org/).

## Unreleased

## 0.24.0

### Fixes
```