### PR TITLE
plugins/bundle: Support for saving and reading bundles from disk

### DIFF
--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -39,6 +39,7 @@ bundles:
   authz:
     service: acmecorp
     resource: bundles/http/example/authz.tar.gz
+    persist: true
     polling:
       min_delay_seconds: 60
       max_delay_seconds: 120
@@ -388,6 +389,7 @@ included in the actual bundle gzipped tarball.
 | `bundles[_].service` | `string` | Yes | Name of service to use to contact remote server. |
 | `bundles[_].polling.min_delay_seconds` | `int64` | No (default: `60`) | Minimum amount of time to wait between bundle downloads. |
 | `bundles[_].polling.max_delay_seconds` | `int64` | No (default: `120`) | Maximum amount of time to wait between bundle downloads. |
+| `bundles[_].persist` | `bool` | No | Persist activated bundles to disk. |
 | `bundles[_].signing.keyid` | `string` | No | Name of the key to use for bundle signature verification. |
 | `bundles[_].signing.scope` | `string` | No | Scope to use for bundle signature verification. |
 | `bundles[_].signing.exclude_files` | `array` | No | Files in the bundle to exclude during verification. |

--- a/docs/content/management.md
+++ b/docs/content/management.md
@@ -97,6 +97,7 @@ bundles:
   authz:
     service: acmecorp
     resource: somedir/bundle.tar.gz
+    persist: true
     polling:
       min_delay_seconds: 10
       max_delay_seconds: 20
@@ -124,6 +125,10 @@ Bundle names can have any valid YAML characters in them, including `/`. This can
 be useful when relying on default `resource` behavior with a name like
 `authz/bundle.tar.gz` which results in a `resource` of
 `bundles/authz/bundle.tar.gz`.
+
+OPA can optionally save and read bundles from disk based on the value of the `bundles[_].persist`
+field. If this field is set, OPA will persist activated bundles to disk and load bundles from disk too in scenarios such as
+OPA being unable to communicate with the bundle server.
 
 The optional `bundles[_].signing` field can be used to specify the `keyid` and `scope` that should be used
 for verifying the signature of the bundle. See [this](#bundle-signature) section for details.

--- a/plugins/bundle/config.go
+++ b/plugins/bundle/config.go
@@ -42,6 +42,7 @@ func ParseConfig(config []byte, services []string) (*Config, error) {
 			Service:  parsedConfig.Service,
 			Resource: parsedConfig.generateLegacyResourcePath(),
 			Signing:  nil,
+			Persist:  false,
 		},
 	}
 
@@ -135,6 +136,7 @@ type Source struct {
 	Service  string                     `json:"service"`
 	Resource string                     `json:"resource"`
 	Signing  *bundle.VerificationConfig `json:"signing"`
+	Persist  bool                       `json:"persist"`
 }
 
 // IsMultiBundle returns whether or not the config is the newer multi-bundle


### PR DESCRIPTION
This commit adds support to persist and load bundles from disk.
A new field is introduced in OPA's bundle configuration that can
be optionally set to specify the location on disk to write and read
bundles. This feature will allow OPA to serve policy decisions in scenarios
such as OPA being unable to communicate with the bundle server.

Fixes #2097

Signed-off-by: Ashutosh Narkar <anarkar4387@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
