### PR TITLE
topdown: Address negative duration for the current age of http response

### DIFF
--- a/docs/content/policy-reference.md
+++ b/docs/content/policy-reference.md
@@ -893,6 +893,12 @@ cached response is in fact still fresh. If the server responds with a `200` (`OK
 with the new response. On a `304` (`Not Modified`) server response, `http.send` will update the headers in cached response with
 their corresponding values in the `304` response.
 
+> `http.send` uses the `Date` response header to calculate the current age of the response by comparing it with the current time.
+> This value is used to determine the freshness of the cached response. As per https://tools.ietf.org/html/rfc7231#section-7.1.1.2,
+> an origin server MUST NOT send a `Date` header field if it does not have a clock capable of providing a reasonable
+> approximation of the current instance in Coordinated Universal Time. Hence, if `http.send` encounters a scenario where current
+> age of the response is represented as a negative duration, the cached response will be considered as stale.
+
 The table below shows examples of calling `http.send`:
 
 | Example |  Comments |


### PR DESCRIPTION
The current age of a http response is calculated as the difference
between the current time and the value contained in the "Date" response
header. There are couple of scenarios that could lead to the current age
being represented as a negative duration.

1. Since the value of "Date" response header is parsed using Go's
time.Parse method, it does not contain a monotonic clock reading. As a result,
the time.Sub method uses wall clock readings to determine the difference between
current time and the parsed version of the response time.

2. The server could set a value for the "Date" response header which may not be a true indication of
when the response was generated.

This change updates the logic that determines whether a cached response is fresh or not,
to treat the resposne as stale if the current response age is represented as a negative duration.

Signed-off-by: Ashutosh Narkar <anarkar4387@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
