### PR TITLE
Add net.cidr_merge function to produce smallest possible list of CIDRs

### DIFF
--- a/ast/builtins.go
+++ b/ast/builtins.go
@@ -220,6 +220,7 @@ var DefaultBuiltins = [...]*Builtin{
 	NetCIDRContains,
 	NetCIDRContainsMatches,
 	NetCIDRExpand,
+	NetCIDRMerge,
 
 	// Glob
 	GlobMatch,
@@ -1999,6 +2000,20 @@ var NetCIDRContainsMatches = &Builtin{
 		types.NewSet(types.NewArray([]types.Type{types.A, types.A}, nil)),
 	),
 }
+
+// NetCIDRMerge merges IP addresses and subnets into the smallest possible list of CIDRs.
+var NetCIDRMerge = &Builtin{
+	Name: "net.cidr_merge",
+	Decl: types.NewFunction(
+		types.Args(netCidrMergeOperandType),
+		types.NewSet(types.S),
+	),
+}
+
+var netCidrMergeOperandType = types.NewAny(
+	types.NewArray(nil, types.NewAny(types.S)),
+	types.NewSet(types.S),
+)
 
 var netCidrContainsMatchesOperandType = types.NewAny(
 	types.S,

--- a/capabilities.json
+++ b/capabilities.json
@@ -1904,6 +1904,42 @@
       }
     },
     {
+      "name": "net.cidr_merge",
+      "decl": {
+        "args": [
+          {
+            "of": [
+              {
+                "dynamic": {
+                  "of": [
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "type": "any"
+                },
+                "type": "array"
+              },
+              {
+                "of": {
+                  "type": "string"
+                },
+                "type": "set"
+              }
+            ],
+            "type": "any"
+          }
+        ],
+        "result": {
+          "of": {
+            "type": "string"
+          },
+          "type": "set"
+        },
+        "type": "function"
+      }
+    },
+    {
       "name": "net.cidr_overlap",
       "decl": {
         "args": [

--- a/docs/content/policy-reference.md
+++ b/docs/content/policy-reference.md
@@ -914,6 +914,7 @@ The table below shows examples of calling `http.send`:
 | <span class="opa-keep-it-together">``output := net.cidr_contains_matches(cidrs, cidrs_or_ips)``</span> | `output` is a `set` of tuples identifying matches where `cidrs_or_ips` are contained within `cidrs`. This function is similar to `net.cidr_contains` except it allows callers to pass collections of CIDRs or IPs as arguments and returns the matches (as opposed to a boolean result indicating a match between two CIDRs/IPs.) See below for examples. |
 | <span class="opa-keep-it-together">``net.cidr_intersects(cidr1, cidr2)``</span> | `output` is `true` if `cidr1` (e.g. `192.168.0.0/16`) overlaps with `cidr2` (e.g. `192.168.1.0/24`) and false otherwise. Supports both IPv4 and IPv6 notations.|
 | <span class="opa-keep-it-together">``net.cidr_expand(cidr)``</span> | `output` is the set of hosts in `cidr`  (e.g., `net.cidr_expand("192.168.0.0/30")` generates 4 hosts: `{"192.168.0.0", "192.168.0.1", "192.168.0.2", "192.168.0.3"}` |
+| <span class="opa-keep-it-together">``net.cidr_merge(cidrs_or_ips)``</span> | `output` is the smallest possible set of CIDRs obtained after merging the provided list of IP addresses and subnets in `cidrs_or_ips`  (e.g., `net.cidr_merge(["192.0.128.0/24", "192.0.129.0/24"])` generates `{"192.0.128.0/23"}`. This function merges adjacent subnets where possible, those contained within others and also removes any duplicates. Supports both IPv4 and IPv6 notations. |
 
 **`net.cidr_contains_matches` examples**
 

--- a/internal/cidr/merge/merge.go
+++ b/internal/cidr/merge/merge.go
@@ -1,0 +1,367 @@
+// Copyright 2017-2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package merge provides helper functions for merging a list of
+// IP addresses and subnets into the smallest possible list of CIDRs.
+// Original Implementation: https://github.com/cilium/cilium
+package merge
+
+import (
+	"bytes"
+	"encoding/binary"
+	"math/big"
+	"net"
+)
+
+const (
+	ipv4BitLen = 8 * net.IPv4len
+	ipv6BitLen = 8 * net.IPv6len
+)
+
+var (
+	v4Mappedv6Prefix  = []byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff, 0xff}
+	defaultIPv4       = []byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff, 0xff, 0x0, 0x0, 0x0, 0x0}
+	defaultIPv6       = []byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}
+	upperIPv4         = []byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff, 0xff, 255, 255, 255, 255}
+	upperIPv6         = []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}
+	ipv4LeadingZeroes = []byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}
+)
+
+// RangeToCIDRs converts the range of IPs covered by firstIP and lastIP to
+// a list of CIDRs that contains all of the IPs covered by the range.
+func RangeToCIDRs(firstIP, lastIP net.IP) []*net.IPNet {
+	// First, create a CIDR that spans both IPs.
+	spanningCIDR := createSpanningCIDR(&firstIP, &lastIP)
+	firstIPSpanning, lastIPSpanning := GetAddressRange(spanningCIDR)
+
+	cidrList := []*net.IPNet{}
+
+	// If the first IP of the spanning CIDR passes the lower bound (firstIP),
+	// we need to split the spanning CIDR and only take the IPs that are
+	// greater than the value which we split on, as we do not want the lesser
+	// values since they are less than the lower-bound (firstIP).
+	if bytes.Compare(firstIPSpanning, firstIP) < 0 {
+		// Split on the previous IP of the first IP so that the right list of IPs
+		// of the partition includes the firstIP.
+		prevFirstRangeIP := GetPreviousIP(firstIP)
+		var bitLen int
+		if prevFirstRangeIP.To4() != nil {
+			bitLen = ipv4BitLen
+		} else {
+			bitLen = ipv6BitLen
+		}
+		_, _, right := partitionCIDR(spanningCIDR, net.IPNet{IP: prevFirstRangeIP, Mask: net.CIDRMask(bitLen, bitLen)})
+
+		// Append all CIDRs but the first, as this CIDR includes the upper
+		// bound of the spanning CIDR, which we still need to partition on.
+		cidrList = append(cidrList, right...)
+		spanningCIDR = *right[0]
+		cidrList = cidrList[1:]
+	}
+
+	// Conversely, if the last IP of the spanning CIDR passes the upper bound
+	// (lastIP), we need to split the spanning CIDR and only take the IPs that
+	// are greater than the value which we split on, as we do not want the greater
+	// values since they are greater than the upper-bound (lastIP).
+	if bytes.Compare(lastIPSpanning, lastIP) > 0 {
+		// Split on the next IP of the last IP so that the left list of IPs
+		// of the partition include the lastIP.
+		nextFirstRangeIP := getNextIP(lastIP)
+		var bitLen int
+		if nextFirstRangeIP.To4() != nil {
+			bitLen = ipv4BitLen
+		} else {
+			bitLen = ipv6BitLen
+		}
+		left, _, _ := partitionCIDR(spanningCIDR, net.IPNet{IP: nextFirstRangeIP, Mask: net.CIDRMask(bitLen, bitLen)})
+		cidrList = append(cidrList, left...)
+	} else {
+		// Otherwise, there is no need to partition; just use add the spanning
+		// CIDR to the list of networks.
+		cidrList = append(cidrList, &spanningCIDR)
+	}
+	return cidrList
+}
+
+// GetAddressRange returns the first and last addresses in the given CIDR range.
+func GetAddressRange(ipNet net.IPNet) (net.IP, net.IP) {
+	firstIP := make(net.IP, len(ipNet.IP))
+	lastIP := make(net.IP, len(ipNet.IP))
+
+	copy(firstIP, ipNet.IP)
+	copy(lastIP, ipNet.IP)
+
+	firstIP = firstIP.Mask(ipNet.Mask)
+	lastIP = lastIP.Mask(ipNet.Mask)
+
+	if firstIP.To4() != nil {
+		firstIP = append(v4Mappedv6Prefix, firstIP...)
+		lastIP = append(v4Mappedv6Prefix, lastIP...)
+	}
+
+	lastIPMask := make(net.IPMask, len(ipNet.Mask))
+	copy(lastIPMask, ipNet.Mask)
+	for i := range lastIPMask {
+		lastIPMask[len(lastIPMask)-i-1] = ^lastIPMask[len(lastIPMask)-i-1]
+		lastIP[net.IPv6len-i-1] = lastIP[net.IPv6len-i-1] | lastIPMask[len(lastIPMask)-i-1]
+	}
+
+	return firstIP, lastIP
+}
+
+// GetPreviousIP returns the previous IP from the given IP address.
+func GetPreviousIP(ip net.IP) net.IP {
+	// Cannot go lower than zero!
+	if ip.Equal(net.IP(defaultIPv4)) || ip.Equal(net.IP(defaultIPv6)) {
+		return ip
+	}
+
+	previousIP := make(net.IP, len(ip))
+	copy(previousIP, ip)
+
+	var overflow bool
+	var lowerByteBound int
+	if ip.To4() != nil {
+		lowerByteBound = net.IPv6len - net.IPv4len
+	} else {
+		lowerByteBound = 0
+	}
+	for i := len(ip) - 1; i >= lowerByteBound; i-- {
+		if overflow || i == len(ip)-1 {
+			previousIP[i]--
+		}
+		// Track if we have overflowed and thus need to continue subtracting.
+		if ip[i] == 0 && previousIP[i] == 255 {
+			overflow = true
+		} else {
+			overflow = false
+		}
+	}
+	return previousIP
+}
+
+// createSpanningCIDR returns a single IP network spanning the
+// the lower and upper bound IP addresses.
+func createSpanningCIDR(firstIP, lastIP *net.IP) net.IPNet {
+	// Don't want to modify the values of the provided range, so make copies.
+	lowest := *firstIP
+	highest := *lastIP
+
+	var isIPv4 bool
+	var spanningMaskSize, bitLen, byteLen int
+	if lowest.To4() != nil {
+		isIPv4 = true
+		bitLen = ipv4BitLen
+		byteLen = net.IPv4len
+	} else {
+		bitLen = ipv6BitLen
+		byteLen = net.IPv6len
+	}
+
+	if isIPv4 {
+		spanningMaskSize = ipv4BitLen
+	} else {
+		spanningMaskSize = ipv6BitLen
+	}
+
+	// Convert to big Int so we can easily do bitshifting on the IP addresses,
+	// since golang only provides up to 64-bit unsigned integers.
+	lowestBig := big.NewInt(0).SetBytes(lowest)
+	highestBig := big.NewInt(0).SetBytes(highest)
+
+	// Starting from largest mask / smallest range possible, apply a mask one bit
+	// larger in each iteration to the upper bound in the range  until we have
+	// masked enough to pass the lower bound in the range. This
+	// gives us the size of the prefix for the spanning CIDR to return as
+	// well as the IP for the CIDR prefix of the spanning CIDR.
+	for spanningMaskSize > 0 && lowestBig.Cmp(highestBig) < 0 {
+		spanningMaskSize--
+		mask := big.NewInt(1)
+		mask = mask.Lsh(mask, uint(bitLen-spanningMaskSize))
+		mask = mask.Mul(mask, big.NewInt(-1))
+		highestBig = highestBig.And(highestBig, mask)
+	}
+
+	// If ipv4, need to append 0s because math.Big gets rid of preceding zeroes.
+	if isIPv4 {
+		highest = append(ipv4LeadingZeroes, highestBig.Bytes()...)
+	} else {
+		highest = highestBig.Bytes()
+	}
+
+	// Int does not store leading zeroes.
+	if len(highest) == 0 {
+		highest = make([]byte, byteLen)
+	}
+
+	newNet := net.IPNet{IP: highest, Mask: net.CIDRMask(spanningMaskSize, bitLen)}
+	return newNet
+}
+
+// partitionCIDR returns a list of IP Networks partitioned upon excludeCIDR.
+// The first list contains the networks to the left of the excludeCIDR in the
+// partition,  the second is a list containing the excludeCIDR itself if it is
+// contained within the targetCIDR (nil otherwise), and the
+// third is a list containing the networks to the right of the excludeCIDR in
+// the partition.
+func partitionCIDR(targetCIDR net.IPNet, excludeCIDR net.IPNet) ([]*net.IPNet, []*net.IPNet, []*net.IPNet) {
+	var targetIsIPv4 bool
+	if targetCIDR.IP.To4() != nil {
+		targetIsIPv4 = true
+	}
+
+	targetFirstIP, targetLastIP := GetAddressRange(targetCIDR)
+	excludeFirstIP, excludeLastIP := GetAddressRange(excludeCIDR)
+
+	targetMaskSize, _ := targetCIDR.Mask.Size()
+	excludeMaskSize, _ := excludeCIDR.Mask.Size()
+
+	if bytes.Compare(excludeLastIP, targetFirstIP) < 0 {
+		return nil, nil, []*net.IPNet{&targetCIDR}
+	} else if bytes.Compare(targetLastIP, excludeFirstIP) < 0 {
+		return []*net.IPNet{&targetCIDR}, nil, nil
+	}
+
+	if targetMaskSize >= excludeMaskSize {
+		return nil, []*net.IPNet{&targetCIDR}, nil
+	}
+
+	left := []*net.IPNet{}
+	right := []*net.IPNet{}
+
+	newPrefixLen := targetMaskSize + 1
+
+	targetFirstCopy := make(net.IP, len(targetFirstIP))
+	copy(targetFirstCopy, targetFirstIP)
+
+	iLowerOld := make(net.IP, len(targetFirstCopy))
+	copy(iLowerOld, targetFirstCopy)
+
+	// Since golang only supports up to unsigned 64-bit integers, and we need
+	// to perform addition on addresses, use math/big library, which allows
+	// for manipulation of large integers.
+
+	// Used to track the current lower and upper bounds of the ranges to compare
+	// to excludeCIDR.
+	iLower := big.NewInt(0)
+	iUpper := big.NewInt(0)
+	iLower = iLower.SetBytes(targetFirstCopy)
+
+	var bitLen int
+
+	if targetIsIPv4 {
+		bitLen = ipv4BitLen
+	} else {
+		bitLen = ipv6BitLen
+	}
+	shiftAmount := (uint)(bitLen - newPrefixLen)
+
+	targetIPInt := big.NewInt(0)
+	targetIPInt.SetBytes(targetFirstIP.To16())
+
+	exp := big.NewInt(0)
+
+	// Use left shift for exponentiation
+	exp = exp.Lsh(big.NewInt(1), shiftAmount)
+	iUpper = iUpper.Add(targetIPInt, exp)
+
+	matched := big.NewInt(0)
+
+	for excludeMaskSize >= newPrefixLen {
+		// Append leading zeros to IPv4 addresses, as math.Big.Int does not
+		// append them when the IP address is copied from a byte array to
+		// math.Big.Int. Leading zeroes are required for parsing IPv4 addresses
+		// for use with net.IP / net.IPNet.
+		var iUpperBytes, iLowerBytes []byte
+		if targetIsIPv4 {
+			iUpperBytes = append(ipv4LeadingZeroes, iUpper.Bytes()...)
+			iLowerBytes = append(ipv4LeadingZeroes, iLower.Bytes()...)
+		} else {
+			iUpperBytesLen := len(iUpper.Bytes())
+			// Make sure that the number of bytes in the array matches what net
+			// package expects, as big package doesn't append leading zeroes.
+			if iUpperBytesLen != net.IPv6len {
+				numZeroesToAppend := net.IPv6len - iUpperBytesLen
+				zeroBytes := make([]byte, numZeroesToAppend)
+				iUpperBytes = append(zeroBytes, iUpper.Bytes()...)
+			} else {
+				iUpperBytes = iUpper.Bytes()
+
+			}
+
+			iLowerBytesLen := len(iLower.Bytes())
+			if iLowerBytesLen != net.IPv6len {
+				numZeroesToAppend := net.IPv6len - iLowerBytesLen
+				zeroBytes := make([]byte, numZeroesToAppend)
+				iLowerBytes = append(zeroBytes, iLower.Bytes()...)
+			} else {
+				iLowerBytes = iLower.Bytes()
+
+			}
+		}
+		// If the IP we are excluding over is of a higher value than the current
+		// CIDR prefix we are generating, add the CIDR prefix to the set of IPs
+		// to the left of the exclude CIDR
+		if bytes.Compare(excludeFirstIP, iUpperBytes) >= 0 {
+			left = append(left, &net.IPNet{IP: iLowerBytes, Mask: net.CIDRMask(newPrefixLen, bitLen)})
+			matched = matched.Set(iUpper)
+		} else {
+			// Same as above, but opposite.
+			right = append(right, &net.IPNet{IP: iUpperBytes, Mask: net.CIDRMask(newPrefixLen, bitLen)})
+			matched = matched.Set(iLower)
+		}
+
+		newPrefixLen++
+
+		if newPrefixLen > bitLen {
+			break
+		}
+
+		iLower = iLower.Set(matched)
+		iUpper = iUpper.Add(matched, big.NewInt(0).Lsh(big.NewInt(1), uint(bitLen-newPrefixLen)))
+
+	}
+	excludeList := []*net.IPNet{&excludeCIDR}
+
+	return left, excludeList, right
+}
+
+func getNextIP(ip net.IP) net.IP {
+	if ip.Equal(upperIPv4) || ip.Equal(upperIPv6) {
+		return ip
+	}
+
+	nextIP := make(net.IP, len(ip))
+	switch len(ip) {
+	case net.IPv4len:
+		ipU32 := binary.BigEndian.Uint32(ip)
+		ipU32++
+		binary.BigEndian.PutUint32(nextIP, ipU32)
+		return nextIP
+	case net.IPv6len:
+		ipU64 := binary.BigEndian.Uint64(ip[net.IPv6len/2:])
+		ipU64++
+		binary.BigEndian.PutUint64(nextIP[net.IPv6len/2:], ipU64)
+		if ipU64 == 0 {
+			ipU64 = binary.BigEndian.Uint64(ip[:net.IPv6len/2])
+			ipU64++
+			binary.BigEndian.PutUint64(nextIP[:net.IPv6len/2], ipU64)
+		} else {
+			copy(nextIP[:net.IPv6len/2], ip[:net.IPv6len/2])
+		}
+		return nextIP
+	default:
+		return ip
+	}
+}

--- a/test/cases/testdata/netcidrmerge/test-netcidrmerge0117.yaml
+++ b/test/cases/testdata/netcidrmerge/test-netcidrmerge0117.yaml
@@ -1,0 +1,210 @@
+cases:
+  - note: netcidrmerge/cidr single subnet
+    modules:
+      - |
+        package test
+
+        p = x {
+              net.cidr_merge(["192.0.128.0/24"], x)
+        }
+    query: data.test.p = x
+    want_result:
+        - x:
+          - 192.0.128.0/24
+  - note: netcidrmerge/cidr duplicate
+    modules:
+      - |
+        package test
+
+        p = x {
+          net.cidr_merge(["192.0.128.0/24", "192.0.128.0/24"], x)
+        }
+    query: data.test.p = x
+    want_result:
+      - x:
+          - 192.0.128.0/24
+  - note: netcidrmerge/cidr IPv4 zero address
+    modules:
+      - |
+        package test
+
+        p = x {
+          net.cidr_merge(["192.0.128.0/24", "0.0.0.0/0"], x)
+        }
+    query: data.test.p = x
+    want_result:
+      - x:
+          - 0.0.0.0/0
+  - note: netcidrmerge/cidr merge subnets case 1
+    modules:
+      - |
+        package test
+
+        p = x {
+          net.cidr_merge(["192.0.128.0/24", "192.0.129.0/24"], x)
+        }
+    query: data.test.p = x
+    want_result:
+      - x:
+          - 192.0.128.0/23
+  - note: netcidrmerge/cidr merge subnets case 2
+    modules:
+      - |
+        package test
+
+        p = x {
+          net.cidr_merge(["192.0.2.112/30", "192.0.2.116/31", "192.0.2.118/31"], x)
+        }
+    query: data.test.p = x
+    want_result:
+      - x:
+          - 192.0.2.112/29
+  - note: netcidrmerge/cidr no overlap case 1
+    modules:
+      - |
+        package test
+
+        p = x {
+          net.cidr_merge(["192.0.129.0/24", "192.0.130.0/24"], x)
+        }
+    query: data.test.p = x
+    want_result:
+      - x:
+          - 192.0.129.0/24
+          - 192.0.130.0/24
+  - note: netcidrmerge/cidr no overlap case 2
+    modules:
+      - |
+        package test
+
+        p = x {
+          net.cidr_merge(["192.0.2.112/30", "192.0.2.116/32", "192.0.2.118/31"], x)
+        }
+    query: data.test.p = x
+    want_result:
+      - x:
+          - 192.0.2.112/30
+          - 192.0.2.116/32
+          - 192.0.2.118/31
+  - note: netcidrmerge/cidr mix case 1
+    modules:
+      - |
+        package test
+
+        p = x {
+          net.cidr_merge(["192.0.2.112/31", "192.0.2.116/31", "192.0.2.118/31"], x)
+        }
+    query: data.test.p = x
+    want_result:
+      - x:
+          - 192.0.2.112/31
+          - 192.0.2.116/30
+  - note: netcidrmerge/cidr mix case 2
+    modules:
+      - |
+        package test
+
+        p = x {
+          net.cidr_merge(["192.0.1.254/31", "192.0.2.0/28", "192.0.2.16/28", "192.0.2.32/28", "192.0.2.48/28", "192.0.2.64/28", "192.0.2.80/28", "192.0.2.96/28", "192.0.2.112/28", "192.0.2.128/28", "192.0.2.144/28", "192.0.2.160/28", "192.0.2.176/28", "192.0.2.192/28", "192.0.2.208/28", "192.0.2.224/28", "192.0.2.240/28", "192.0.3.0/28"], x)
+        }
+    query: data.test.p = x
+    want_result:
+      - x:
+          - 192.0.1.254/31
+          - 192.0.2.0/24
+          - 192.0.3.0/28
+  - note: netcidrmerge/cidr IPv6 zero address case 1
+    modules:
+      - |
+        package test
+
+        p = x {
+          net.cidr_merge(["::/0", "fe80::1/128"], x)
+        }
+    query: data.test.p = x
+    want_result:
+      - x:
+          - ::/0
+  - note: netcidrmerge/cidr IPv6 zero address case 2
+    modules:
+      - |
+        package test
+
+        p = x {
+          net.cidr_merge(["::/0", "::192.0.2.0/124", "ff00::101/128"], x)
+        }
+    query: data.test.p = x
+    want_result:
+      - x:
+          - ::/0
+  - note: netcidrmerge/cidr IPv4 and IPv6
+    modules:
+      - |
+        package test
+
+        p = x {
+          net.cidr_merge(["fe80::/120", "192.0.2.0/24", "192.0.3.0/24", "192.0.4.0/25", "192.0.4.128/25"], x)
+        }
+    query: data.test.p = x
+    want_result:
+      - x:
+          - 192.0.2.0/23
+          - 192.0.4.0/24
+          - fe80::/120
+  - note: netcidrmerge/cidr empty
+    modules:
+      - |
+        package test
+
+        p = x {
+          net.cidr_merge([], x)
+        }
+    query: data.test.p = x
+    want_result:
+      - x: []
+  - note: netcidrmerge/cidr merge ip and subnets
+    modules:
+      - |
+        package test
+
+        p = x {
+          net.cidr_merge(["192.0.2.112", "192.0.2.116/31", "192.0.2.118/31"], x)
+        }
+    query: data.test.p = x
+    want_result:
+      - x:
+          - 192.0.2.0/24
+  - note: netcidrmerge/cidr merge ip addresses
+    modules:
+      - |
+        package test
+
+        p = x {
+          net.cidr_merge(["192.0.128.0", "192.0.129.0"], x)
+        }
+    query: data.test.p = x
+    want_result:
+      - x:
+          - 192.0.128.0/23
+  - note: netcidrmerge/cidr merge subnets set
+    modules:
+      - |
+        package test
+
+        p = x {
+          net.cidr_merge({"192.0.2.112/30", "192.0.2.116/31", "192.0.2.118/31"}, x)
+        }
+    query: data.test.p = x
+    want_result:
+      - x:
+          - 192.0.2.112/29
+  - note: netcidrmerge/cidr invalid IP
+    modules:
+      - |
+        package test
+
+        p = x {
+          net.cidr_merge(["foo"], x)
+        }
+    query: data.test.p = x
+    want_error_code: eval_builtin_error

--- a/topdown/cidr.go
+++ b/topdown/cidr.go
@@ -1,12 +1,15 @@
 package topdown
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"math/big"
 	"net"
+	"sort"
 
 	"github.com/open-policy-agent/opa/ast"
+	cidrMerge "github.com/open-policy-agent/opa/internal/cidr/merge"
 	"github.com/open-policy-agent/opa/topdown/builtins"
 )
 
@@ -210,6 +213,176 @@ func builtinNetCIDRExpand(bctx BuiltinContext, operands []*ast.Term, iter func(*
 	return iter(ast.NewTerm(result))
 }
 
+type cidrBlockRange struct {
+	First   *net.IP
+	Last    *net.IP
+	Network *net.IPNet
+}
+
+type cidrBlockRanges []*cidrBlockRange
+
+// Implement Sort interface
+func (c cidrBlockRanges) Len() int {
+	return len(c)
+}
+
+func (c cidrBlockRanges) Swap(i, j int) {
+	c[i], c[j] = c[j], c[i]
+}
+
+func (c cidrBlockRanges) Less(i, j int) bool {
+	// Compare last IP.
+	cmp := bytes.Compare(*c[i].Last, *c[j].Last)
+	if cmp < 0 {
+		return true
+	} else if cmp > 0 {
+		return false
+	}
+
+	// Then compare first IP.
+	cmp = bytes.Compare(*c[i].First, *c[i].First)
+	if cmp < 0 {
+		return true
+	} else if cmp > 0 {
+		return false
+	}
+
+	// Ranges are Equal.
+	return false
+}
+
+// builtinNetCIDRMerge merges the provided list of IP addresses and subnets into the smallest possible list of CIDRs.
+// It merges adjacent subnets where possible, those contained within others and also removes any duplicates.
+// Original Algorithm: https://github.com/netaddr/netaddr.
+func builtinNetCIDRMerge(bctx BuiltinContext, operands []*ast.Term, iter func(*ast.Term) error) error {
+	networks := []*net.IPNet{}
+
+	switch v := operands[0].Value.(type) {
+	case *ast.Array:
+		for i := 0; i < v.Len(); i++ {
+			network, err := generateIPNet(v.Elem(i))
+			if err != nil {
+				return err
+			}
+			networks = append(networks, network)
+		}
+	case ast.Set:
+		err := v.Iter(func(x *ast.Term) error {
+			network, err := generateIPNet(x)
+			if err != nil {
+				return err
+			}
+			networks = append(networks, network)
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+	default:
+		return errors.New("operand must be an array")
+	}
+
+	merged := evalNetCIDRMerge(networks)
+
+	result := ast.NewSet()
+	for _, network := range merged {
+		result.Add(ast.StringTerm(network.String()))
+	}
+
+	return iter(ast.NewTerm(result))
+}
+
+func evalNetCIDRMerge(networks []*net.IPNet) []*net.IPNet {
+	if len(networks) == 0 {
+		return nil
+	}
+
+	var ranges cidrBlockRanges
+
+	// For each CIDR, create an IP range. Sort them and merge when possible.
+	for _, network := range networks {
+		firstIP, lastIP := cidrMerge.GetAddressRange(*network)
+		ranges = append(ranges, &cidrBlockRange{
+			First:   &firstIP,
+			Last:    &lastIP,
+			Network: network,
+		})
+	}
+
+	// merge CIDRs.
+	merged := mergeCIDRs(ranges)
+
+	// convert ranges into an equivalent list of net.IPNet.
+	result := []*net.IPNet{}
+
+	for _, r := range merged {
+		// Not merged with any other CIDR.
+		if r.Network != nil {
+			result = append(result, r.Network)
+		} else {
+			// Find new network that represents the merged range.
+			rangeCIDRs := cidrMerge.RangeToCIDRs(*r.First, *r.Last)
+			result = append(result, rangeCIDRs...)
+		}
+	}
+	return result
+}
+
+func generateIPNet(term *ast.Term) (*net.IPNet, error) {
+	switch e := term.Value.(type) {
+	case ast.String:
+		network := &net.IPNet{}
+		// try to parse element as an IP first, fall back to CIDR
+		ip := net.ParseIP(string(e))
+		if ip != nil {
+			network.IP = ip
+			network.Mask = ip.DefaultMask()
+		} else {
+			var err error
+			_, network, err = net.ParseCIDR(string(e))
+			if err != nil {
+				return nil, err
+			}
+		}
+		return network, nil
+	default:
+		return nil, errors.New("element must be string")
+	}
+}
+
+func mergeCIDRs(ranges cidrBlockRanges) cidrBlockRanges {
+	sort.Sort(ranges)
+
+	// Merge adjacent CIDRs if possible.
+	for i := len(ranges) - 1; i > 0; i-- {
+		previousIP := cidrMerge.GetPreviousIP(*ranges[i].First)
+
+		// If the previous IP of the current network overlaps
+		// with the last IP of the previous network in the
+		// list, then merge the two ranges together.
+		if bytes.Compare(previousIP, *ranges[i-1].Last) <= 0 {
+			var firstIP *net.IP
+			if bytes.Compare(*ranges[i-1].First, *ranges[i].First) < 0 {
+				firstIP = ranges[i-1].First
+			} else {
+				firstIP = ranges[i].First
+			}
+
+			lastIPRange := make(net.IP, len(*ranges[i].Last))
+			copy(lastIPRange, *ranges[i].Last)
+
+			firstIPRange := make(net.IP, len(*firstIP))
+			copy(firstIPRange, *firstIP)
+
+			ranges[i-1] = &cidrBlockRange{First: &firstIPRange, Last: &lastIPRange, Network: nil}
+
+			// Delete ranges[i] since merged with the previous.
+			ranges = append(ranges[:i], ranges[i+1:]...)
+		}
+	}
+	return ranges
+}
+
 func incIP(ip net.IP) {
 	for j := len(ip) - 1; j >= 0; j-- {
 		ip[j]++
@@ -225,4 +398,5 @@ func init() {
 	RegisterFunctionalBuiltin2(ast.NetCIDRContains.Name, builtinNetCIDRContains)
 	RegisterBuiltinFunc(ast.NetCIDRContainsMatches.Name, builtinNetCIDRContainsMatches)
 	RegisterBuiltinFunc(ast.NetCIDRExpand.Name, builtinNetCIDRExpand)
+	RegisterBuiltinFunc(ast.NetCIDRMerge.Name, builtinNetCIDRMerge)
 }


### PR DESCRIPTION
This commit adds a new builtin to merge adjacent subnets and return the
smallest possible list of CIDRs.

To help with computing CIDR blocks between two
IP networks, an implemetation from https://github.com/cilium/cilium
is leveraged.

Fixes: #2692

Signed-off-by: Ashutosh Narkar <anarkar4387@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
