### PR TITLE
ast: Fix panic in parser post-processing of expressions

### DIFF
--- a/ast/parser_ext.go
+++ b/ast/parser_ext.go
@@ -164,6 +164,10 @@ func ParseRuleFromExpr(module *Module, expr *Expr) (*Rule, error) {
 	if expr.IsAssignment() {
 
 		lhs, rhs := expr.Operand(0), expr.Operand(1)
+		if lhs == nil || rhs == nil {
+			return nil, errors.New("assignment requires two operands")
+		}
+
 		rule, err := ParseCompleteDocRuleFromAssignmentExpr(module, lhs, rhs)
 
 		if err == nil {
@@ -203,6 +207,10 @@ func parseCompleteRuleFromEq(module *Module, expr *Expr) (rule *Rule, err error)
 	}()
 
 	lhs, rhs := expr.Operand(0), expr.Operand(1)
+	if lhs == nil || rhs == nil {
+		return nil, errors.New("assignment requires two operands")
+	}
+
 	rule, err = ParseCompleteDocRuleFromEqExpr(module, lhs, rhs)
 
 	if err == nil {

--- a/ast/parser_test.go
+++ b/ast/parser_test.go
@@ -1970,6 +1970,22 @@ data = {"bar": 2}`
 	package a
 	f(x)[x] = x { true }`
 
+	assignNoOperands := `
+	package a
+	assign()`
+
+	assignOneOperand := `
+	package a
+	assign(x)`
+
+	eqNoOperands := `
+	package a
+	eq()`
+
+	eqOneOperand := `
+	package a
+	eq(x)`
+
 	assertParseModuleError(t, "multiple expressions", multipleExprs)
 	assertParseModuleError(t, "non-equality", nonEquality)
 	assertParseModuleError(t, "non-var name", nonVarName)
@@ -1987,6 +2003,10 @@ data = {"bar": 2}`
 	assertParseModuleError(t, "number in ref", "package a\n12[3]()=4")
 	assertParseModuleError(t, "rule with args and key", callWithRuleKeyPartialObject)
 	assertParseModuleError(t, "rule with args and key", callWithRuleKeyPartialSet)
+	assertParseModuleError(t, "assign without operands", assignNoOperands)
+	assertParseModuleError(t, "assign with only one operand", assignOneOperand)
+	assertParseModuleError(t, "eq without operands", eqNoOperands)
+	assertParseModuleError(t, "eq with only one operand", eqOneOperand)
 
 	if _, err := ParseRuleFromExpr(&Module{}, &Expr{
 		Terms: struct{}{},


### PR DESCRIPTION
This commit fixes a panic caught in the fuzzer due to misuse of
operands returned by expr.Operand().

Fixes #2714

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
