### PR TITLE
Fix discarded logs on chunk upload failure

### DIFF
--- a/plugins/logs/plugin.go
+++ b/plugins/logs/plugin.go
@@ -585,17 +585,18 @@ func (p *Plugin) oneShot(ctx context.Context) (ok bool, err error) {
 	}
 
 	for bs := oldBuffer.Pop(); bs != nil; bs = oldBuffer.Pop() {
-		err := uploadChunk(ctx, p.manager.Client(p.config.Service), p.config.PartitionName, bs)
+		if err == nil {
+			err = uploadChunk(ctx, p.manager.Client(p.config.Service), p.config.PartitionName, bs)
+		}
 		if err != nil {
 			// requeue the chunk
 			p.mtx.Lock()
 			p.bufferChunk(p.buffer, bs)
 			p.mtx.Unlock()
-			return false, err
 		}
 	}
 
-	return true, nil
+	return err == nil, err
 }
 
 func (p *Plugin) reconfigure(config interface{}) {


### PR DESCRIPTION
If the size of the decision logs buffered exceeeds that of `upload_size_limit_bytes`, the upload will be split into chunks. If one of the attempted uploads return with an error the chunk is stored in the "new" buffer and will be re-attempted at the next invocation of the `oneShot` method. However, once that is done the function returns, leaving any decisions left in the buffer to be discarded.

I've reproduced this by queuing up decisions in OPA above `upload_size_limit_bytes` and having an external mock server on the receiving end which randomly responds with non-OK status codes. Not having written too much golang (yet!) I could however use some guidance in porting these to the OPA test suite.

As for the fix itself - an alternative (and perhaps more sensible?) approach would be to stop uploading at first error but to push all remaining chunks in the old buffer into the new one to be preserved for next invocation.

Signed-off-by: Anders Eknert <anders.eknert@bisnode.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
