### PR TITLE
runtime: Fix data race in runtime package test

### DIFF
--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/open-policy-agent/opa/storage"
 	"github.com/open-policy-agent/opa/util"
 	"github.com/open-policy-agent/opa/util/test"
-	"github.com/open-policy-agent/opa/version"
 )
 
 func TestWatchPaths(t *testing.T) {
@@ -275,7 +274,6 @@ func TestCheckOPAUpdateLoopNoUpdate(t *testing.T) {
 	baseURL, teardown := getTestServer(exp, http.StatusOK)
 	defer teardown()
 
-	version.Version = "v0.20.0"
 	testCheckOPAUpdateLoop(t, baseURL, "OPA is up to date.")
 }
 
@@ -291,7 +289,6 @@ func TestCheckOPAUpdateLoopWithNewUpdate(t *testing.T) {
 	baseURL, teardown := getTestServer(exp, http.StatusOK)
 	defer teardown()
 
-	version.Version = "v0.20.0"
 	testCheckOPAUpdateLoop(t, baseURL, "OPA is out of date.")
 }
 


### PR DESCRIPTION
The runtime tests for the telemetry reporting feature contained a data
race because they were setting the version.Version variable which is
read by the runtime in other test cases. Since we now have the
version.Version value set in the source code, we do not have to
overwrite it in the test implementation.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
