### PR TITLE
cmd/version: include golang version in output

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -44,6 +44,7 @@ func generateCmdOutput(out io.Writer, check bool) {
 	fmt.Fprintln(out, "Build Commit: "+version.Vcs)
 	fmt.Fprintln(out, "Build Timestamp: "+version.Timestamp)
 	fmt.Fprintln(out, "Build Hostname: "+version.Hostname)
+	fmt.Fprintln(out, "Go Version: "+version.GoVersion)
 
 	if check {
 		err := checkOPAUpdate(out)

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -79,13 +79,15 @@ func setTestVersion() {
 	version.Vcs = "12345"
 	version.Timestamp = "2020-05-14T06:22:38Z"
 	version.Hostname = "foo"
+	version.GoVersion = "1.14.7"
 }
 
 func getTestVersion() string {
 	return "Version: v0.20.0\n" +
 		"Build Commit: 12345\n" +
 		"Build Timestamp: 2020-05-14T06:22:38Z\n" +
-		"Build Hostname: foo\n"
+		"Build Hostname: foo\n" +
+		"Go Version: 1.14.7\n"
 }
 
 func getTestServer(update interface{}, statusCode int) (baseURL string, teardownFn func()) {

--- a/version/version.go
+++ b/version/version.go
@@ -5,8 +5,15 @@
 // Package version contains version information that is set at build time.
 package version
 
+import (
+	"runtime"
+)
+
 // Version is the canonical version of OPA.
 var Version = "0.24.0-dev"
+
+// GoVersion is the version of Go this was built with
+var GoVersion = runtime.Version()
 
 // Additional version information that is displayed by the "version" command and used to
 // identify the version of running instances of OPA.


### PR DESCRIPTION
I've seen this in other tools and I thought it was useful.

**To be discussed**: Would you think this should be included in the provenance API response data, too? (I'm inclined to say no...)