### PR TITLE
Fix plugin config instantiation tests

### DIFF
--- a/plugins/rest/rest_test.go
+++ b/plugins/rest/rest_test.go
@@ -192,7 +192,21 @@ func TestNew(t *testing.T) {
 	for _, tc := range tests {
 		client, err := New([]byte(tc.input))
 		if err != nil && !tc.wantErr {
+			t.Fatalf("Unexpected parse error: %v", err)
+		}
+		plugin, err := client.config.authPlugin()
+		if err != nil {
+			if tc.wantErr {
+				continue
+			}
 			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		_, err = plugin.NewClient(client.config)
+		if err != nil && !tc.wantErr {
+			t.Fatalf("Unexpected error: %v", err)
+		} else if err == nil && tc.wantErr {
+			t.Fatalf("Excpected error for input %v", tc.input)
 		}
 
 		if *client.config.ResponseHeaderTimeoutSeconds != defaultResponseHeaderTimeoutSeconds {


### PR DESCRIPTION
While toying around with a custom credential plugin I noticed that changing the `wantErr` values had no effect to the outcome for the TestNew tests - they would always pass. This was due to:

1. The `New` function only unmarshalling the JSON config, not actually instantiating plugins and clients (which is where the validation step is done).
2. wantErr was only checked if false on errors, not its opposite, i.e. not if wantErr == true and error == nil.

Signed-off-by: Anders Eknert <anders.eknert@bisnode.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
