### PR TITLE
topdown/http: validate force_cache parameters

### DIFF
--- a/topdown/http_test.go
+++ b/topdown/http_test.go
@@ -1448,12 +1448,7 @@ func TestInterQueryCheckCacheError(t *testing.T) {
 	input := ast.MustParseTerm(`{"force_cache": true}`)
 	inputObj := input.Value.(ast.Object)
 
-	cache, err := newInterQueryCache(BuiltinContext{Context: context.Background()}, inputObj, true)
-	if err != nil {
-		t.Fatalf("unexpected error %v", err)
-	}
-
-	_, err = cache.CheckCache()
+	_, err := newHTTPRequestExecutor(BuiltinContext{Context: context.Background()}, inputObj)
 	if err == nil {
 		t.Fatal("expected error but got nil")
 	}


### PR DESCRIPTION
Earlier the validation of the force_cache parameters was performed
after creating the inter-query cache object. So if 'force_cache' was
set and 'force_cache_duration_seconds' was not provided, OPA in server mode
would correctly return an error but OPA running in repl mode would not
return an error and simply would fall back to using the intra-query cache.

This commit updates how the 'force_cache' parameters are validated so that
consistent behavior is seen in both repl and server modes.

Signed-off-by: Ashutosh Narkar <anarkar4387@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
