### PR TITLE
docs: Update Kubernetes tutorial to create SAN certificate

### DIFF
--- a/docs/content/kubernetes-tutorial.md
+++ b/docs/content/kubernetes-tutorial.md
@@ -85,11 +85,11 @@ EOF
 
 ```bash
 openssl genrsa -out server.key 2048
-openssl req -new -key server.key -out server.csr -subj "/CN=opa.opa.svc" -config server.conf
+openssl req -new -key server.key -out server.csr -subj "/CN=opa.opa.svc" -addext "subjectAltName = DNS:opa.opa.svc" -config server.conf
 openssl x509 -req -in server.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out server.crt -days 100000 -extensions v3_req -extfile server.conf
 ```
 
-> Note: the Common Name value you give to openssl MUST match the name of the OPA service created below.
+> Note: the Common Name and Subject Alternative Name you give to openssl MUST match the name of the OPA service created below.
 
 Create a Secret to store the TLS credentials for OPA:
 


### PR DESCRIPTION
## Short description

Latest K8s `1.19` cannot communicate with OPA due to Go CN deprecation.

## Long description

Go 1.15 [deprecated CN support](https://golang.org/doc/go1.15#commonname) so latest Kubernetes `1.19` which is built on that version

```shell
$ kubectl version
Client Version: version.Info{Major:"1", Minor:"19", GitVersion:"v1.19.2", GitCommit:"f5743093fd1c663cb0cbc89748f730662345d44d", GitTreeState:"clean", BuildDate:"2020-09-16T13:41:02Z", GoVersion:"go1.15", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"19", GitVersion:"v1.19.2", GitCommit:"f5743093fd1c663cb0cbc89748f730662345d44d", GitTreeState:"clean", BuildDate:"2020-09-16T13:32:58Z", GoVersion:"go1.15", Compiler:"gc", Platform:"linux/amd64"}
```
has issues with CN only usage.

K8s API server cannot communicate with OPA and it logs the following:
```
W1010 17:08:38.525599       1 dispatcher.go:129] Failed calling webhook, failing open validating-webhook.openpolicyagent.org: failed calling webhook "validating-webhook.openpolicyagent.org": Post "https://opa.opa.svc:443/?timeout=30s": x509: certificate relies on legacy Common Name field, use SANs or temporarily enable Common Name matching with GODEBUG=x509ignoreCN=0
E1010 17:08:38.525631       1 dispatcher.go:130] failed calling webhook "validating-webhook.openpolicyagent.org": Post "https://opa.opa.svc:443/?timeout=30s": x509: certificate relies on legacy Common Name field, use SANs or temporarily enable Common Name matching with GODEBUG=x509ignoreCN=0
```

and OPA logs the following:
```
2020/10/10 17:08:38 http: TLS handshake error from 10.157.171.192:14074: remote error: tls: bad certificate
```

So Kubernetes tutorial updated to generate SAN certicate using the same hostname as in CN field.

---

Signed-off-by: Nikos Silvestros nsilvestros@yahoo.com
