### PR TITLE
Add REST client option for OAuth2 client credentials

### DIFF
--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -271,6 +271,18 @@ private key is encrypted.
 | `services[_].credentials.client_tls.private_key` | `string` | Yes | The path to the private key of the client certificate. |
 | `services[_].credentials.client_tls.private_key_passphrase` | `string` | No | The passphrase to use for the private key. |
 
+#### OAuth2 client credentials
+
+OPA will authenticate using a bearer token obtained through the OAuth2 [client credentials](https://tools.ietf.org/html/rfc6749#section-4.4) flow.
+Following successful authentication at the token endpoint the returned token will be cached for subsequent requests for the duration of its lifetime. Note that as per the [OAuth2 standard](https://tools.ietf.org/html/rfc6749#section-2.3.1), only the HTTPS scheme is supported for the token endpoint URL.
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `services[_].credentials.oauth2.token_url` | `string` | Yes | URL pointing to the token endpoint at the OAuth2 authorization server. |
+| `services[_].credentials.oauth2.client_id` | `string` | Yes | The client ID to use for authentication. |
+| `services[_].credentials.oauth2.client_secret` | `string` | Yes | The client secret to use for authentication. |
+| `services[_].credentials.oauth2.scopes` | `[]string` | No | Optional list of scopes to request for the token. |
+
 #### AWS signature
 
 OPA will authenticate with an [AWS4 HMAC](https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-auth-using-authorization-header.html) signature. Two methods of obtaining the

--- a/plugins/rest/rest.go
+++ b/plugins/rest/rest.go
@@ -41,9 +41,10 @@ type Config struct {
 	AllowInsureTLS               bool              `json:"allow_insecure_tls,omitempty"`
 	ResponseHeaderTimeoutSeconds *int64            `json:"response_header_timeout_seconds,omitempty"`
 	Credentials                  struct {
-		Bearer    *bearerAuthPlugin     `json:"bearer,omitempty"`
-		ClientTLS *clientTLSAuthPlugin  `json:"client_tls,omitempty"`
-		S3Signing *awsSigningAuthPlugin `json:"s3_signing,omitempty"`
+		Bearer    *bearerAuthPlugin                  `json:"bearer,omitempty"`
+		OAuth2    *oauth2ClientCredentialsAuthPlugin `json:"oauth2,omitempty"`
+		ClientTLS *clientTLSAuthPlugin               `json:"client_tls,omitempty"`
+		S3Signing *awsSigningAuthPlugin              `json:"s3_signing,omitempty"`
 	} `json:"credentials"`
 }
 


### PR DESCRIPTION
Allows OPA to obtain OAuth2 access tokens and present them as bearer tokens for authentication at remote endpoints.

Tested against the AWS Cognito authorization server.

Fixes #1205

Signed-off-by: Anders Eknert <anders.eknert@bisnode.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
