### PR TITLE
Fix decision log hang

### DIFF
--- a/plugins/logs/plugin.go
+++ b/plugins/logs/plugin.go
@@ -420,7 +420,7 @@ func (p *Plugin) flushDecisions(ctx context.Context, cancel context.CancelFunc) 
 	defer cancel()
 
 	go func(ctx context.Context, cancel context.CancelFunc) {
-		for {
+		for ctx.Err() == nil {
 			ok, err := p.oneShot(ctx)
 			if err != nil {
 				p.logError("%v.", err)


### PR DESCRIPTION
..by breaking out of loop if context is cancelled.

Fixes #2792

Ping @patrick-east 

Signed-off-by: Anders Eknert <anders.eknert@bisnode.com>
