### PR TITLE
bundle: Support for handling PEM file containing the public key

### DIFF
--- a/bundle/keys.go
+++ b/bundle/keys.go
@@ -79,12 +79,25 @@ type KeyConfig struct {
 }
 
 // NewKeyConfig return a new KeyConfig
-func NewKeyConfig(key, alg, scope string) *KeyConfig {
+func NewKeyConfig(key, alg, scope string) (*KeyConfig, error) {
+	var pubKey string
+	if _, err := os.Stat(key); err == nil {
+		bs, err := ioutil.ReadFile(key)
+		if err != nil {
+			return nil, err
+		}
+		pubKey = string(bs)
+	} else if os.IsNotExist(err) {
+		pubKey = key
+	} else {
+		return nil, err
+	}
+
 	return &KeyConfig{
-		Key:       key,
+		Key:       pubKey,
 		Algorithm: alg,
 		Scope:     scope,
-	}
+	}, nil
 }
 
 // ParseKeysConfig returns a map containing the public key and the signing algorithm

--- a/bundle/keys_test.go
+++ b/bundle/keys_test.go
@@ -7,6 +7,7 @@ package bundle
 import (
 	"crypto/rsa"
 	"fmt"
+	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -286,6 +287,67 @@ EXrJfkELSzO66/ZSjyyWEczXHLyr+Q719BsaGsxie117zSNF6B6UXiitjCr/qQ==
 	})
 }
 
+func TestNewKeyConfig(t *testing.T) {
+	publicKey := `-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA9KaakMv1XKKDaSch3PFR
+3a27oaHp1GNTTNqvb1ZaHZXp+wuhYDwc/MTE67x9GCifvQBWzEGorgTq7aisiOyl
+vKifwz6/wQ+62WHKG/sqKn2Xikp3P63aBIPlZcHbkyyRmL62yeyuzYoGvLEYel+m
+z5SiKGBwviSY0Th2L4e5sGJuk2HOut6emxDi+E2Fuuj5zokFJvIT6Urlq8f3h6+l
+GeR6HUOXqoYVf7ff126GP7dticTVBgibxkkuJFmpvQSW6xmxruT4k6iwjzbZHY7P
+ypZ/TdlnuGC1cOpAVyU7k32IJ9CRbt3nwEf5U54LRXLLQjFixWZHwKdDiMTF4ws0
++wIDAQAB
+-----END PUBLIC KEY-----`
+
+	files := map[string]string{
+		"public.pem": publicKey,
+	}
+
+	test.WithTempFS(files, func(rootDir string) {
+
+		kc, err := NewKeyConfig(filepath.Join(rootDir, "public.pem"), "RS256", "read")
+		if err != nil {
+			t.Fatalf("Unexpected error %v", err)
+		}
+
+		expected := &KeyConfig{
+			Key:       publicKey,
+			Algorithm: "RS256",
+			Scope:     "read",
+		}
+
+		if !reflect.DeepEqual(kc, expected) {
+			t.Fatalf("Expected key config %v but got %v", expected, kc)
+		}
+
+		// secret provided on command-line
+		kc, err = NewKeyConfig(publicKey, "HS256", "")
+		if err != nil {
+			t.Fatalf("Unexpected error %v", err)
+		}
+
+		expected = &KeyConfig{
+			Key:       publicKey,
+			Algorithm: "HS256",
+			Scope:     "",
+		}
+
+		if !reflect.DeepEqual(kc, expected) {
+			t.Fatalf("Expected key config %v but got %v", expected, kc)
+		}
+
+		// simulate error while reading file
+		err = os.Chmod(filepath.Join(rootDir, "public.pem"), 0111)
+		if err != nil {
+			t.Fatalf("Unexpected error %v", err)
+		}
+
+		_, err = NewKeyConfig(filepath.Join(rootDir, "public.pem"), "RS256", "read")
+		if err == nil {
+			t.Fatal("Expected error but got nil")
+		}
+	})
+}
+
 func TestGetClaimsErrors(t *testing.T) {
 	files := map[string]string{
 		"claims.json": `["foo", "read"]`,
@@ -320,13 +382,29 @@ func TestKeyConfigEqual(t *testing.T) {
 		exp bool
 	}{
 		"equal": {
-			NewKeyConfig("foo", "RS256", "read"),
-			NewKeyConfig("foo", "RS256", "read"),
+			&KeyConfig{
+				Key:       "foo",
+				Algorithm: "RS256",
+				Scope:     "read",
+			},
+			&KeyConfig{
+				Key:       "foo",
+				Algorithm: "RS256",
+				Scope:     "read",
+			},
 			true,
 		},
 		"not_equal": {
-			NewKeyConfig("foo", "RS256", "read"),
-			NewKeyConfig("foo", "RS256", "write"),
+			&KeyConfig{
+				Key:       "foo",
+				Algorithm: "RS256",
+				Scope:     "read",
+			},
+			&KeyConfig{
+				Key:       "foo",
+				Algorithm: "RS256",
+				Scope:     "write",
+			},
 			false,
 		},
 	}

--- a/cmd/build_test.go
+++ b/cmd/build_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -114,6 +115,25 @@ func TestBuildErrorVerifyNonBundle(t *testing.T) {
 		exp := "enable bundle mode (ie. --bundle) to verify or sign bundle files or directories"
 		if err.Error() != exp {
 			t.Fatalf("expected error message %v but got %v", exp, err.Error())
+		}
+	})
+}
+
+func TestBuildVerificationConfigError(t *testing.T) {
+	files := map[string]string{
+		"public.pem": "foo",
+	}
+
+	test.WithTempFS(files, func(rootDir string) {
+		// simulate error while reading file
+		err := os.Chmod(filepath.Join(rootDir, "public.pem"), 0111)
+		if err != nil {
+			t.Fatalf("Unexpected error %v", err)
+		}
+
+		_, err = buildVerificationConfig(filepath.Join(rootDir, "public.pem"), "default", "", "", nil)
+		if err == nil {
+			t.Fatal("Expected error but got nil")
 		}
 	})
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -250,7 +250,11 @@ func initRuntime(ctx context.Context, params runCmdParams, args []string) (*runt
 
 	params.rt.SkipBundleVerification = params.skipBundleVerify
 
-	params.rt.BundleVerificationConfig = buildVerificationConfig(params.pubKey, params.pubKeyID, params.algorithm, params.scope, params.excludeVerifyFiles)
+	bvc, err := buildVerificationConfig(params.pubKey, params.pubKeyID, params.algorithm, params.scope, params.excludeVerifyFiles)
+	if err != nil {
+		return nil, err
+	}
+	params.rt.BundleVerificationConfig = bvc
 
 	if params.rt.BundleVerificationConfig != nil && !params.rt.BundleMode {
 		return nil, fmt.Errorf("enable bundle mode (ie. --bundle) to verify bundle files or directories")


### PR DESCRIPTION
The "verification-key" flag used by the `run` and `build` commands
should be able to handle a PEM file containing a public key.
Earlier we were not checking if the value of the flag represents
a file on disk. This change will check if the value points to a
file, then read it contents and set the public key accordingly.

Fixes: #2796

Signed-off-by: Ashutosh Narkar <anarkar4387@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
