### PR TITLE
plugins/logs: Fixes unintended mutation of result

### DIFF
--- a/internal/deepcopy/deepcopy.go
+++ b/internal/deepcopy/deepcopy.go
@@ -1,0 +1,27 @@
+// Copyright 2020 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package deepcopy
+
+// DeepCopy performs a recursive deep copy for nested slices/maps and
+// returns the copied object. Supports []interface{}
+// and map[string]interface{} only
+func DeepCopy(val interface{}) interface{} {
+	switch val := val.(type) {
+	case []interface{}:
+		cpy := make([]interface{}, len(val))
+		for i := range cpy {
+			cpy[i] = DeepCopy(val[i])
+		}
+		return cpy
+	case map[string]interface{}:
+		cpy := make(map[string]interface{}, len(val))
+		for k := range val {
+			cpy[k] = DeepCopy(val[k])
+		}
+		return cpy
+	default:
+		return val
+	}
+}

--- a/internal/deepcopy/deepcopy_test.go
+++ b/internal/deepcopy/deepcopy_test.go
@@ -1,0 +1,31 @@
+// Copyright 2020 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package deepcopy
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestDeepCopyMapRoot(t *testing.T) {
+	target := map[string]interface{}{
+		"a": map[string]interface{}{
+			"b": []interface{}{
+				"c",
+				"d",
+			},
+			"e": "f",
+		},
+		"x": "y",
+	}
+	result := DeepCopy(target).(map[string]interface{})
+	if !reflect.DeepEqual(target, result) {
+		t.Fatal("Expected result of DeepCopy to be DeepEqual with original.")
+	}
+	result["a"] = "mutated"
+	if target["a"] == "mutated" {
+		t.Fatal("Expected target to remain unmutated when the DeepCopy result was mutated")
+	}
+}

--- a/plugins/logs/plugin.go
+++ b/plugins/logs/plugin.go
@@ -706,17 +706,17 @@ func (p *Plugin) maskEvent(ctx context.Context, txn storage.Transaction, event *
 		return nil
 	}
 
-	mRules, err := resultValueToMaskRules(rs[0].Expressions[0].Value)
+	mRuleSet, err := newMaskRuleSet(
+		rs[0].Expressions[0].Value,
+		func(mRule *maskRule, err error) {
+			p.logError("mask rule skipped: %s: %s", mRule.String(), err.Error())
+		},
+	)
 	if err != nil {
 		return err
 	}
 
-	for _, mRule := range mRules {
-		err := mRule.Mask(event)
-		if err != nil {
-			p.logError("mask rule skipped: %s: %s", mRule.String(), err.Error())
-		}
-	}
+	mRuleSet.Mask(event)
 
 	return nil
 }

--- a/storage/inmem/txn.go
+++ b/storage/inmem/txn.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"strconv"
 
+	"github.com/open-policy-agent/opa/internal/deepcopy"
 	"github.com/open-policy-agent/opa/storage"
 )
 
@@ -204,7 +205,7 @@ func (txn *transaction) Read(path storage.Path) (interface{}, error) {
 		return data, nil
 	}
 
-	cpy := deepCopy(data)
+	cpy := deepcopy.DeepCopy(data)
 
 	for _, update := range merge {
 		cpy = update.Relative(path).Apply(cpy)
@@ -386,25 +387,6 @@ func (u *update) Relative(path storage.Path) *update {
 	cpy := *u
 	cpy.path = cpy.path[len(path):]
 	return &cpy
-}
-
-func deepCopy(val interface{}) interface{} {
-	switch val := val.(type) {
-	case []interface{}:
-		cpy := make([]interface{}, len(val))
-		for i := range cpy {
-			cpy[i] = deepCopy(val[i])
-		}
-		return cpy
-	case map[string]interface{}:
-		cpy := make(map[string]interface{}, len(val))
-		for k := range val {
-			cpy[k] = deepCopy(val[k])
-		}
-		return cpy
-	default:
-		return val
-	}
 }
 
 func ptr(data interface{}, path storage.Path) (interface{}, error) {


### PR DESCRIPTION
When mask rules targeted /result, it was modifying both the result
in the decision logs (intended) and the result in the API
response (unintended). Added a step to deep copy the result only once, if
there is at least one mask rule targeting the result.

Fixes #2752
Signed-off-by: Grant Shively gshively@godaddy.com

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
