### PR TITLE
topdown: Fix merge to copy input values if needed

### DIFF
--- a/topdown/input.go
+++ b/topdown/input.go
@@ -18,13 +18,22 @@ func mergeTermWithValues(exist *ast.Term, pairs [][2]*ast.Term) (*ast.Term, erro
 	var result *ast.Term
 	var init bool
 
-	for _, pair := range pairs {
+	for i, pair := range pairs {
 
 		if err := ast.IsValidImportPath(pair[0].Value); err != nil {
 			return nil, errBadPath
 		}
 
 		target := pair[0].Value.(ast.Ref)
+
+		// Copy the value if subsequent pairs in the slice would modify it.
+		for j := i + 1; j < len(pairs); j++ {
+			other := pairs[j][0].Value.(ast.Ref)
+			if len(other) > len(target) && other.HasPrefix(target) {
+				pair[1] = pair[1].Copy()
+				break
+			}
+		}
 
 		if len(target) == 1 {
 			result = pair[1]

--- a/topdown/input_test.go
+++ b/topdown/input_test.go
@@ -118,3 +118,29 @@ func TestMergeTermWithValues(t *testing.T) {
 		})
 	}
 }
+
+func TestMergeTermWithValuesInputsShouldBeImmutable(t *testing.T) {
+
+	initial := ast.MustParseTerm(`{"foo": 1}`)
+	expInitial := initial.Copy()
+	two := ast.MustParseTerm(`2`)
+
+	result, err := mergeTermWithValues(nil, [][2]*ast.Term{
+		{ast.MustParseTerm("input"), initial},
+		{ast.MustParseTerm("input.foo"), two},
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	exp := ast.MustParseTerm(`{"foo": 2}`)
+
+	if !result.Equal(exp) {
+		t.Fatalf("expected %v but got %v", exp, result)
+	}
+
+	if !initial.Equal(expInitial) {
+		t.Fatalf("expected input value to be unchanged but got %v (expected: %v)", initial, expInitial)
+	}
+}


### PR DESCRIPTION
This commit updates the merging logic to copy input values if
needed to prevent the input values from being mutated unexpectedly. A
copy is required if subsequent with statements would modify a previous
value--this can be caught by checking if any of the subsequent with
statement targets are prefixed by the current with statement target.

This change is required because although topdown plugs with statement
values before merging, the values are not deep copied--they are passed
by reference.

Fixes #2813

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
