### PR TITLE
tests: fix tests failing on 32-bit arch

### DIFF
--- a/rego/example_test.go
+++ b/rego/example_test.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"math/rand"
 	"os"
 	"strings"
 
@@ -785,16 +784,16 @@ func ExampleRego_custom_function_caching() {
 
 	type builtinCacheKey string
 
-	source := rand.NewSource(0)
+	i := 0
 
 	r := rego.New(
 		// An example query that uses a custom function.
-		rego.Query(`x = myrandom("foo"); y = myrandom("foo")`),
+		rego.Query(`x = mycounter("foo"); y = mycounter("foo")`),
 
 		// A custom function that uses caching.
 		rego.FunctionDyn(
 			&rego.Function{
-				Name:    "myrandom",
+				Name:    "mycounter",
 				Memoize: true,
 				Decl: types.NewFunction(
 					types.Args(types.S), // one string input
@@ -802,7 +801,8 @@ func ExampleRego_custom_function_caching() {
 				),
 			},
 			func(_ topdown.BuiltinContext, args []*ast.Term) (*ast.Term, error) {
-				return ast.IntNumberTerm(int(source.Int63())), nil
+				i++
+				return ast.IntNumberTerm(i), nil
 			},
 		),
 	)
@@ -817,8 +817,8 @@ func ExampleRego_custom_function_caching() {
 
 	// Output:
 	//
-	// x: 8717895732742165505
-	// y: 8717895732742165505
+	// x: 1
+	// y: 1
 }
 
 func ExampleRego_custom_function_global() {

--- a/topdown/parse_bytes_test.go
+++ b/topdown/parse_bytes_test.go
@@ -14,7 +14,7 @@ func TestNumBytes(t *testing.T) {
 	t.Run("SuccessfulParse", func(t *testing.T) {
 		tests := []struct {
 			note, rule string
-			expected   int
+			expected   int64
 		}{
 			{"zero", `0`, 0},
 			{"raw number", `12345`, 12345},
@@ -89,7 +89,7 @@ func TestNumBytes(t *testing.T) {
 	})
 }
 
-func runNumBytesParseTest(t *testing.T, note, rule string, expected int) {
+func runNumBytesParseTest(t *testing.T, note, rule string, expected int64) {
 	t.Helper()
 
 	num := parseIntFromString(t, rule)
@@ -139,7 +139,7 @@ func runExpectedFailureTest(t *testing.T, s string, expectedErr error) {
 	}
 }
 
-func parseIntFromString(t *testing.T, s string) int {
+func parseIntFromString(t *testing.T, s string) int64 {
 	sVal := ast.StringTerm(s).Value
 	val, err := builtinNumBytes(sVal)
 
@@ -148,7 +148,7 @@ func parseIntFromString(t *testing.T, s string) int {
 	}
 
 	i := val.(ast.Number)
-	num, ok := i.Int()
+	num, ok := i.Int64()
 	if !ok {
 		t.Fatalf("numbytes err: could not parse value %s into int", val.String())
 	}

--- a/util/graph_test.go
+++ b/util/graph_test.go
@@ -167,9 +167,9 @@ func TestDFSPath(t *testing.T) {
 	}
 
 	t3 := newTestTraversal(g)
-	p3 := DFSPath(t3, t3.Equals, 1, 0xdeadbeef)
+	p3 := DFSPath(t3, t3.Equals, 1, 0xadbeef)
 	if len(p3) != 0 {
-		t.Errorf("Expected DFS(1,0xdeadbeef to be empty but got: %v", p3)
+		t.Errorf("Expected DFS(1,0xadbeef to be empty but got: %v", p3)
 	}
 
 }


### PR DESCRIPTION
E.g. `GOARCH=386 go test ./...`

- Some tests were failing because of Int overflow
- Test `ExampleRego_custom_function_caching` was failing because it was dependent of rand default seed on 64bits arch