### PR TITLE
Separate console logger for plugins

### DIFF
--- a/plugins/logs/plugin.go
+++ b/plugins/logs/plugin.go
@@ -775,7 +775,7 @@ func (p *Plugin) logEvent(event EventV1) error {
 	if err != nil {
 		return err
 	}
-	logrus.WithFields(fields).WithFields(logrus.Fields{
+	plugins.GetConsoleLogger().WithFields(fields).WithFields(logrus.Fields{
 		"type": "openpolicyagent.org/decision_logs",
 	}).Info("Decision Log")
 	return nil

--- a/plugins/plugins.go
+++ b/plugins/plugins.go
@@ -10,6 +10,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/bundle"
 	"github.com/open-policy-agent/opa/config"
@@ -145,6 +147,14 @@ type Manager struct {
 type managerContextKey string
 
 const managerCompilerContextKey = managerContextKey("compiler")
+
+// Dedicated logger for plugins logging to console independently of configured --log-level
+var logrusConsole = logrus.New()
+
+// GetConsoleLogger return plugin console logger
+func GetConsoleLogger() *logrus.Logger {
+	return logrusConsole
+}
 
 // SetCompilerOnContext puts the compiler into the storage context. Calling this
 // function before committing updated policies to storage allows the manager to

--- a/plugins/status/plugin.go
+++ b/plugins/status/plugin.go
@@ -331,7 +331,7 @@ func (p *Plugin) logUpdate(update *UpdateRequestV1) error {
 	if err != nil {
 		return err
 	}
-	logrus.WithFields(fields).WithFields(logrus.Fields{
+	plugins.GetConsoleLogger().WithFields(fields).WithFields(logrus.Fields{
 		"type": "openpolicyagent.org/status",
 	}).Info("Status Log")
 	return nil

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -703,16 +703,21 @@ func onReloadPrinter(output io.Writer) func(time.Duration, error) {
 }
 
 func setupLogging(config LoggingConfig) {
+	var formatter logrus.Formatter
 	switch config.Format {
 	case "text":
-		logrus.SetFormatter(&prettyFormatter{})
+		formatter = &prettyFormatter{}
 	case "json-pretty":
-		logrus.SetFormatter(&logrus.JSONFormatter{PrettyPrint: true})
+		formatter = &logrus.JSONFormatter{PrettyPrint: true}
 	case "json":
 		fallthrough
 	default:
-		logrus.SetFormatter(&logrus.JSONFormatter{})
+		formatter = &logrus.JSONFormatter{}
 	}
+	logrus.SetFormatter(formatter)
+	// While the plugin console logger logs independently of the configured --log-level,
+	// it should follow the configured --log-format
+	plugins.GetConsoleLogger().SetFormatter(formatter)
 
 	lvl := logrus.InfoLevel
 


### PR DESCRIPTION
This allows logging to console for decisions and status (and possibly other use cases) without having to follow the generic --log-level.

Fixes #2733

Signed-off-by: Anders Eknert <anders.eknert@bisnode.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
