### PR TITLE
wasm: Add support for multiple entrypoints

### DIFF
--- a/compile/compile.go
+++ b/compile/compile.go
@@ -149,6 +149,14 @@ func (c *Compiler) WithFilter(filter loader.Filter) *Compiler {
 	return c
 }
 
+// WithBundle sets the input bundle to compile. This should be used as an
+// alternative to reading from paths. This function overrides any file
+// loading options.
+func (c *Compiler) WithBundle(b *bundle.Bundle) *Compiler {
+	c.bundle = b
+	return c
+}
+
 // WithBundleVerificationConfig sets the key configuration to use to verify a signed bundle
 func (c *Compiler) WithBundleVerificationConfig(config *bundle.VerificationConfig) *Compiler {
 	c.bvc = config
@@ -258,6 +266,11 @@ func (c *Compiler) Bundle() *bundle.Bundle {
 }
 
 func (c *Compiler) initBundle() error {
+
+	// If the bundle is already set, skip file loading.
+	if c.bundle != nil {
+		return nil
+	}
 
 	// TODO(tsandall): the metrics object should passed through here so we that
 	// we can track read and parse times.

--- a/compile/compile_test.go
+++ b/compile/compile_test.go
@@ -60,7 +60,7 @@ func TestCompilerInitErrors(t *testing.T) {
 		{
 			note: "wasm compilation requires exactly one entrypoint",
 			c:    New().WithTarget("wasm"),
-			want: errors.New("wasm compilation requires exactly one entrypoint"),
+			want: errors.New("wasm compilation requires at least one entrypoint"),
 		},
 	}
 
@@ -412,12 +412,13 @@ func TestCompilerWasmTarget(t *testing.T) {
 	files := map[string]string{
 		"test.rego": `package test
 
-		p = true`,
+		p = 7
+		q = p+1`,
 	}
 
 	test.WithTempFS(files, func(root string) {
 
-		compiler := New().WithPaths(root).WithTarget("wasm").WithEntrypoints("test/p")
+		compiler := New().WithPaths(root).WithTarget("wasm").WithEntrypoints("test/p", "test/q")
 		err := compiler.Build(context.Background())
 		if err != nil {
 			t.Fatal(err)

--- a/compile/compile_test.go
+++ b/compile/compile_test.go
@@ -253,6 +253,32 @@ func TestCompilerLoadHonorsFilter(t *testing.T) {
 	})
 }
 
+func TestCompilerInputBundle(t *testing.T) {
+
+	b := &bundle.Bundle{
+		Modules: []bundle.ModuleFile{
+			bundle.ModuleFile{
+				URL:    "/foo.rego",
+				Path:   "/foo.rego",
+				Raw:    []byte("package test\np = 7"),
+				Parsed: ast.MustParseModule("package test\np = 7"),
+			},
+		},
+	}
+
+	compiler := New().WithBundle(b)
+
+	if err := compiler.Build(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	exp := "package test\n\np = 7\n"
+
+	if exp != string(compiler.Bundle().Modules[0].Raw) {
+		t.Fatalf("expected module to have been formatted (output different than expected):\n\ngot: %v\n\nwant: %v", string(compiler.Bundle().Modules[0].Raw), exp)
+	}
+}
+
 func TestCompilerError(t *testing.T) {
 	files := map[string]string{
 		"test.rego": `

--- a/compile/compile_test.go
+++ b/compile/compile_test.go
@@ -467,6 +467,8 @@ func TestCompilerOutput(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+
+		// Check that the written bundle is expected.
 		result, err := bundle.NewReader(buf).Read()
 		if err != nil {
 			t.Fatal(err)
@@ -485,6 +487,16 @@ func TestCompilerOutput(t *testing.T) {
 			t.Fatalf("expected:\n\n%v\n\ngot:\n\n%v", exp.Manifest, result.Manifest)
 		}
 
+		// Check that the returned bundle is the expected.
+		compiled := compiler.Bundle()
+
+		if !exp.Equal(*compiled) {
+			t.Fatalf("expected:\n\n%v\n\ngot:\n\n%v", *exp, *compiled)
+		}
+
+		if !exp.Manifest.Equal(compiled.Manifest) {
+			t.Fatalf("expected:\n\n%v\n\ngot:\n\n%v", exp.Manifest, compiled.Manifest)
+		}
 	})
 }
 

--- a/internal/compiler/wasm/wasm_test.go
+++ b/internal/compiler/wasm/wasm_test.go
@@ -16,8 +16,12 @@ import (
 func TestCompilerHelloWorld(t *testing.T) {
 
 	policy, err := planner.New().
-		WithQueries([]ast.Body{ast.MustParseBody(`input.foo = 1`)}).
-		Plan()
+		WithQueries([]planner.QuerySet{
+			{
+				Name:    "test",
+				Queries: []ast.Body{ast.MustParseBody(`input.foo = 1`)},
+			},
+		}).Plan()
 
 	if err != nil {
 		t.Fatal(err)

--- a/internal/ir/ir.go
+++ b/internal/ir/ir.go
@@ -16,7 +16,7 @@ type (
 	// Policy represents a planned policy query.
 	Policy struct {
 		Static *Static
-		Plan   *Plan
+		Plans  *Plans
 		Funcs  *Funcs
 	}
 
@@ -30,6 +30,11 @@ type (
 	// policy.
 	BuiltinFunc struct {
 		Name string
+	}
+
+	// Plans represents a collection of named query plans to expose in the policy.
+	Plans struct {
+		Plans []*Plan
 	}
 
 	// Funcs represents a collection of planned functions to include in the
@@ -52,6 +57,7 @@ type (
 	// Plan represents an ordered series of blocks to execute. Plan execution
 	// stops when a return statement is reached. Blocks are executed in-order.
 	Plan struct {
+		Name   string
 		Blocks []*Block
 	}
 
@@ -129,7 +135,7 @@ func (a *Func) String() string {
 }
 
 func (a *Plan) String() string {
-	return fmt.Sprintf("Plan (%d blocks)", len(a.Blocks))
+	return fmt.Sprintf("Plan %v (%d blocks)", a.Name, len(a.Blocks))
 }
 
 func (a *Block) String() string {

--- a/internal/ir/walk.go
+++ b/internal/ir/walk.go
@@ -45,7 +45,7 @@ func (w *walkerImpl) walk(x interface{}) {
 	switch x := x.(type) {
 	case *Policy:
 		w.walk(x.Static)
-		w.walk(x.Plan)
+		w.walk(x.Plans)
 		w.walk(x.Funcs)
 	case *Static:
 		for _, s := range x.Strings {
@@ -53,6 +53,10 @@ func (w *walkerImpl) walk(x interface{}) {
 		}
 		for _, f := range x.BuiltinFuncs {
 			w.walk(f)
+		}
+	case *Plans:
+		for _, pl := range x.Plans {
+			w.walk(pl)
 		}
 	case *Funcs:
 		for _, fn := range x.Funcs {

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -14,6 +14,13 @@ import (
 	"github.com/open-policy-agent/opa/internal/ir"
 )
 
+// QuerySet represents the input to the planner.
+type QuerySet struct {
+	Name          string
+	Queries       []ast.Body
+	RewrittenVars map[ast.Var]ast.Var
+}
+
 type planiter func() error
 type binaryiter func(ir.Local, ir.Local) error
 
@@ -24,19 +31,19 @@ type wasmBuiltin struct {
 
 // Planner implements a query planner for Rego queries.
 type Planner struct {
-	policy    *ir.Policy              // result of planning
-	queries   []ast.Body              // input query to plan
-	modules   []*ast.Module           // input modules to support queries
-	rewritten map[ast.Var]ast.Var     // rewritten query vars
-	strings   map[string]int          // global string constant indices
-	externs   map[string]struct{}     // built-in functions that are required in execution environment
-	decls     map[string]*ast.Builtin // built-in functions that may be provided in execution environment
-	rules     *ruletrie               // rules that may be planned
-	funcs     *funcstack              // functions that have been planned
-	curr      *ir.Block               // in-progress query block
-	vars      *varstack               // in-scope variables
-	ltarget   ir.Local                // target variable of last planned statement
-	lnext     ir.Local                // next variable to use
+	policy  *ir.Policy              // result of planning
+	queries []QuerySet              // input queries to plan
+	modules []*ast.Module           // input modules to support queries
+	strings map[string]int          // global string constant indices
+	externs map[string]struct{}     // built-in functions that are required in execution environment
+	decls   map[string]*ast.Builtin // built-in functions that may be provided in execution environment
+	rules   *ruletrie               // rules that may be planned
+	funcs   *funcstack              // functions that have been planned
+	plan    *ir.Plan                // in-progress query plan
+	curr    *ir.Block               // in-progress query block
+	vars    *varstack               // in-scope variables
+	ltarget ir.Local                // target variable of last planned statement
+	lnext   ir.Local                // next variable to use
 }
 
 // New returns a new Planner object.
@@ -44,7 +51,7 @@ func New() *Planner {
 	return &Planner{
 		policy: &ir.Policy{
 			Static: &ir.Static{},
-			Plan:   &ir.Plan{},
+			Plans:  &ir.Plans{},
 			Funcs:  &ir.Funcs{},
 		},
 		strings: map[string]int{},
@@ -66,8 +73,10 @@ func (p *Planner) WithBuiltinDecls(decls map[string]*ast.Builtin) *Planner {
 	return p
 }
 
-// WithQueries sets the query set to generate a plan for.
-func (p *Planner) WithQueries(queries []ast.Body) *Planner {
+// WithQueries sets the query sets to generate a plan for. The rewritten collection provides
+// a mapping of rewritten query vars for each query set. The planner uses rewritten variables
+// but the result set key will be the original variable name.
+func (p *Planner) WithQueries(queries []QuerySet) *Planner {
 	p.queries = queries
 	return p
 }
@@ -75,14 +84,6 @@ func (p *Planner) WithQueries(queries []ast.Body) *Planner {
 // WithModules sets the module set that contains query dependencies.
 func (p *Planner) WithModules(modules []*ast.Module) *Planner {
 	p.modules = modules
-	return p
-}
-
-// WithRewrittenVars sets a mapping of rewritten query vars on the planner. The
-// plan will use the rewritten variable name but the result set key will be the
-// original variable name.
-func (p *Planner) WithRewrittenVars(vs map[ast.Var]ast.Var) *Planner {
-	p.rewritten = vs
 	return p
 }
 
@@ -352,80 +353,86 @@ func (p *Planner) planFuncParams(params []ir.Local, args ast.Args, idx int, iter
 
 func (p *Planner) planQueries() error {
 
-	// Initialize the plan with a block that prepares the query result.
-	p.curr = &ir.Block{}
+	for _, qs := range p.queries {
 
-	// Build a set of variables appearing in the query and allocate strings for
-	// each one. The strings will be used in the result set objects.
-	qvs := ast.NewVarSet()
-
-	for _, q := range p.queries {
-		vs := q.Vars(ast.VarVisitorParams{SkipRefCallHead: true, SkipClosures: true}).Diff(ast.ReservedVars)
-		qvs.Update(vs)
-	}
-
-	lvarnames := make(map[ast.Var]ir.Local, len(qvs))
-
-	for _, qv := range qvs.Sorted() {
-		qv = p.rewrittenVar(qv)
-		if !qv.IsGenerated() && !qv.IsWildcard() {
-			stmt := &ir.MakeStringStmt{
-				Index:  p.getStringConst(string(qv)),
-				Target: p.newLocal(),
-			}
-			p.appendStmt(stmt)
-			lvarnames[qv] = stmt.Target
-		}
-	}
-
-	if len(p.curr.Stmts) > 0 {
-		p.appendBlock(p.curr)
-	}
-
-	lnext := p.lnext
-
-	for _, q := range p.queries {
-		p.lnext = lnext
-		p.vars.Push(map[ast.Var]ir.Local{})
+		// Initialize the plan with a block that prepares the query result.
+		p.plan = &ir.Plan{Name: qs.Name}
+		p.policy.Plans.Plans = append(p.policy.Plans.Plans, p.plan)
 		p.curr = &ir.Block{}
-		defined := false
-		qvs := q.Vars(ast.VarVisitorParams{SkipRefCallHead: true, SkipClosures: true}).Diff(ast.ReservedVars).Sorted()
 
-		if err := p.planQuery(q, 0, func() error {
+		// Build a set of variables appearing in the query and allocate strings for
+		// each one. The strings will be used in the result set objects.
+		qvs := ast.NewVarSet()
 
-			// Add an object containing variable bindings into the result set.
-			lr := p.newLocal()
-
-			p.appendStmt(&ir.MakeObjectStmt{
-				Target: lr,
-			})
-
-			for _, qv := range qvs {
-				rw := p.rewrittenVar(qv)
-				if !rw.IsGenerated() && !rw.IsWildcard() {
-					p.appendStmt(&ir.ObjectInsertStmt{
-						Object: lr,
-						Key:    lvarnames[rw],
-						Value:  p.vars.GetOrEmpty(qv),
-					})
-				}
-			}
-
-			p.appendStmt(&ir.ResultSetAdd{
-				Value: lr,
-			})
-
-			defined = true
-			return nil
-		}); err != nil {
-			return err
+		for _, q := range qs.Queries {
+			vs := q.Vars(ast.VarVisitorParams{SkipRefCallHead: true, SkipClosures: true}).Diff(ast.ReservedVars)
+			qvs.Update(vs)
 		}
 
-		p.vars.Pop()
+		lvarnames := make(map[ast.Var]ir.Local, len(qvs))
 
-		if defined {
+		for _, qv := range qvs.Sorted() {
+			qv = rewrittenVar(qs.RewrittenVars, qv)
+			if !qv.IsGenerated() && !qv.IsWildcard() {
+				stmt := &ir.MakeStringStmt{
+					Index:  p.getStringConst(string(qv)),
+					Target: p.newLocal(),
+				}
+				p.appendStmt(stmt)
+				lvarnames[qv] = stmt.Target
+			}
+		}
+
+		if len(p.curr.Stmts) > 0 {
 			p.appendBlock(p.curr)
 		}
+
+		lnext := p.lnext
+
+		for _, q := range qs.Queries {
+			p.lnext = lnext
+			p.vars.Push(map[ast.Var]ir.Local{})
+			p.curr = &ir.Block{}
+			defined := false
+			qvs := q.Vars(ast.VarVisitorParams{SkipRefCallHead: true, SkipClosures: true}).Diff(ast.ReservedVars).Sorted()
+
+			if err := p.planQuery(q, 0, func() error {
+
+				// Add an object containing variable bindings into the result set.
+				lr := p.newLocal()
+
+				p.appendStmt(&ir.MakeObjectStmt{
+					Target: lr,
+				})
+
+				for _, qv := range qvs {
+					rw := rewrittenVar(qs.RewrittenVars, qv)
+					if !rw.IsGenerated() && !rw.IsWildcard() {
+						p.appendStmt(&ir.ObjectInsertStmt{
+							Object: lr,
+							Key:    lvarnames[rw],
+							Value:  p.vars.GetOrEmpty(qv),
+						})
+					}
+				}
+
+				p.appendStmt(&ir.ResultSetAdd{
+					Value: lr,
+				})
+
+				defined = true
+				return nil
+			}); err != nil {
+				return err
+			}
+
+			p.vars.Pop()
+
+			if defined {
+				p.appendBlock(p.curr)
+			}
+		}
+
 	}
 
 	return nil
@@ -1848,12 +1855,12 @@ func (p *Planner) appendStmt(s ir.Stmt) {
 	p.curr.Stmts = append(p.curr.Stmts, s)
 }
 
-func (p *Planner) appendFunc(f *ir.Func) {
-	p.policy.Funcs.Funcs = append(p.policy.Funcs.Funcs, f)
+func (p *Planner) appendBlock(b *ir.Block) {
+	p.plan.Blocks = append(p.plan.Blocks, b)
 }
 
-func (p *Planner) appendBlock(b *ir.Block) {
-	p.policy.Plan.Blocks = append(p.policy.Plan.Blocks, b)
+func (p *Planner) appendFunc(f *ir.Func) {
+	p.policy.Funcs.Funcs = append(p.policy.Funcs.Funcs, f)
 }
 
 func (p *Planner) newLocal() ir.Local {
@@ -1862,8 +1869,8 @@ func (p *Planner) newLocal() ir.Local {
 	return x
 }
 
-func (p *Planner) rewrittenVar(k ast.Var) ast.Var {
-	rw, ok := p.rewritten[k]
+func rewrittenVar(vars map[ast.Var]ast.Var, k ast.Var) ast.Var {
+	rw, ok := vars[k]
 	if !ok {
 		return k
 	}

--- a/rego/rego.go
+++ b/rego/rego.go
@@ -1256,10 +1256,17 @@ func (r *Rego) Compile(ctx context.Context, opts ...CompileOption) (*CompileResu
 		decls[k] = v
 	}
 
+	const queryName = "eval" // NOTE(tsandall): the query name is arbitrary
+
 	policy, err := planner.New().
-		WithQueries(queries).
+		WithQueries([]planner.QuerySet{
+			{
+				Name:          queryName,
+				Queries:       queries,
+				RewrittenVars: r.compiledQueries[compileQueryType].compiler.RewrittenVars(),
+			},
+		}).
 		WithModules(modules).
-		WithRewrittenVars(r.compiledQueries[compileQueryType].compiler.RewrittenVars()).
 		WithBuiltinDecls(decls).
 		Plan()
 	if err != nil {

--- a/wasm/src/context.c
+++ b/wasm/src/context.c
@@ -7,6 +7,7 @@ opa_eval_ctx_t *opa_eval_ctx_new()
     ctx->input = NULL;
     ctx->data = NULL;
     ctx->result = NULL;
+    ctx->entrypoint = 0;
     return ctx;
 }
 
@@ -18,6 +19,11 @@ void opa_eval_ctx_set_input(opa_eval_ctx_t *ctx, opa_value *v)
 void opa_eval_ctx_set_data(opa_eval_ctx_t *ctx, opa_value *v)
 {
     ctx->data = v;
+}
+
+void opa_eval_ctx_set_entrypoint(opa_eval_ctx_t *ctx, int entrypoint)
+{
+    ctx->entrypoint = entrypoint;
 }
 
 opa_value *opa_eval_ctx_get_result(opa_eval_ctx_t *ctx)

--- a/wasm/src/context.h
+++ b/wasm/src/context.h
@@ -8,11 +8,13 @@ typedef struct
     opa_value *input;
     opa_value *data;
     opa_value *result;
+    int entrypoint;
 } opa_eval_ctx_t;
 
 opa_eval_ctx_t *opa_eval_ctx_new();
 void opa_eval_ctx_set_input(opa_eval_ctx_t *ctx, opa_value *v);
 void opa_eval_ctx_set_data(opa_eval_ctx_t *ctx, opa_value *v);
+void opa_eval_ctx_set_entrypoint(opa_eval_ctx_t *ctx, int entrypoint);
 opa_value *opa_eval_ctx_get_result(opa_eval_ctx_t *ctx);
 
 opa_value *opa_builtin0(int, void *);


### PR DESCRIPTION
This PR adds support for multiple entrypoints. See individual commit messages for details.

I don't have an end-to-end test for this feature yet. I'm going to look to see how much work it would be to overload the existing node-based testing we do.