### PR TITLE
Makefile: Update ci-wasm target to generate wasm binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -227,12 +227,8 @@ ci-release-test:
 ci-check-working-copy: generate
 	./build/check-working-copy.sh
 
-# The ci-wasm target exists because we do not want to run the generate
-# target outside of Docker. This step duplicates the the wasm-rego-test target
-# above.
 .PHONY: ci-wasm
-ci-wasm: wasm-lib-test
-	GOVERSION=$(GOVERSION) ./build/run-wasm-rego-tests.sh
+ci-wasm: wasm-test
 
 .PHONY: build-linux
 build-linux: ensure-release-dir


### PR DESCRIPTION
With the latest CI changes to auto-generate the wasm binary and commit
post-merge we need to have the ci-wasm target run `go generate`. Since
the `wasm-test` target already does this, just re-use it.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
