### PR TITLE
ci: Prevent commit loop if build is non-deterministic

### DIFF
--- a/.github/workflows/post-merge.yaml
+++ b/.github/workflows/post-merge.yaml
@@ -19,12 +19,26 @@ jobs:
       - name: Commit & Push
         shell: bash
         run: |
+          # Commit any changes and push as needed.
+
           # See https://github.com/actions/checkout#push-a-commit-using-the-built-in-token
-          git config user.name github-actions
-          git config user.email github-actions@github.com
+          AUTHOR=wasm-updater
+          git config user.name ${AUTHOR}
+          git config user.email ${AUTHOR}@github.com
+
+          # Prevent looping if the build was non-deterministic..
+          CAN_PUSH=1
+          if [[ "$(git log -1 --pretty=format:'%an')" == "${AUTHOR}" ]]; then
+              CAN_PUSH=0
+          fi
 
           if ./build/commit-wasm-bins.sh; then
-            git push
+            if [[ "${CAN_PUSH}" == "1" ]]; then
+              git push
+            else
+              echo "Previous commit was auto-generated -- Aborting!"
+              exit 1
+            fi
           else
             echo "No generated changes to push!"
           fi


### PR DESCRIPTION
The "post-merge" flow would trigger whenever a commit is pushed, which
includes when we auto-generate the wasm binaries. If (for whatever
reason) that generate step was non-deterministic it would potentially
mean the CI looping and adding commits until we manually intervene.

This changes to prevent the step from being able to commit on top of
another auto-generated commit.

Signed-off-by: Patrick East <east.patrick@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
