### PR TITLE
ci: Use a separate token for pushing code

### DIFF
--- a/.github/workflows/post-merge.yaml
+++ b/.github/workflows/post-merge.yaml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GH_PUSH_TOKEN }}
 
       - name: Generate
         run: make clean generate


### PR DESCRIPTION
The token used to push code needs to have enough permission to avoid the branch protection rules. This change pulls a token from the secrets configured on the repo.