### PR TITLE
wasm: Fix planning of ordered rules

### DIFF
--- a/test/wasm/assets/010_else.yaml
+++ b/test/wasm/assets/010_else.yaml
@@ -92,3 +92,21 @@ cases:
         else = 2 { false }
         else = 3 { true }
     want_defined: true
+  - note: short-circuit after failing
+    query: data.x.p = 1
+    modules:
+      - |
+        package x
+
+        # data.y[_] causes the planner to scan the virtual _and_ base document trees.
+        # The virtual document scan will succeed (because of the second module)
+        # but the base document scan will fail (because no base documents are loaded).
+        #
+        # This test ensures that the else keyword short-circuits as expected and does
+        # not evaluate the second block even though a failure has occurred.
+        p = x { x = data.y[_] }
+        else = 2 { true }
+      - |
+        package y
+        q = 1
+    want_defined: true


### PR DESCRIPTION
Previously the planner generated an instruction at the end of each
block to check if the return value was defined. If for any reason the
block were to set the return value but then fail before reaching the
end, the check would be skipped and execution would continue to the
next block that in turn could attempt to set the return value causing
a runtime error.

This commit modifies the planner to instead generate the return value
check at the beginning of each block except the first. This ensures
that blocks short-circuit (as expected for ordered rules) but it also
ensures that failures in previous block do not accidentally cause a
fallthrough to later blocks.

This issue was observed with a policy that happened to generate a scan
over the virtual _and_ base document trees.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
