### PR TITLE
Revert "plugins/logs: Close channel in unit test"

### DIFF
--- a/plugins/logs/plugin_test.go
+++ b/plugins/logs/plugin_test.go
@@ -549,14 +549,9 @@ func TestPluginTerminatesImmediatelyAfterGracefulShutdownPeriod(t *testing.T) {
 
 	timeBefore := time.Now()
 	fixture.plugin.Stop(timeoutCtx)
-	after := time.Now()
-
-	close(fixture.server.ch)
-
-	if after.Sub(timeBefore).Milliseconds() > 100 {
+	if time.Since(timeBefore).Milliseconds() > 100 {
 		t.Fatal("Expected forceful shutdown to be instantaneous.")
 	}
-
 }
 
 func TestPluginReconfigure(t *testing.T) {


### PR DESCRIPTION
This reverts commit ac06c3b73c2fe6ea0781d743dd69f7c999d6c166.

There are test failures because we are attempting to write on the closed channel: https://github.com/open-policy-agent/opa/runs/1355466937?check_suite_focus=true

It seems like even though the plugin shut down it may attempt to retry sending the log. Not sure if we really care or not (at that point it is sort of a "best effort" to get them out of OPA). In the meantime we don't want the tests being flakey so we can revert this.


<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
