### PR TITLE
build: New flag for wasmer dependencies

### DIFF
--- a/build/check-vet.sh
+++ b/build/check-vet.sh
@@ -12,7 +12,7 @@ function opa::check_vet() {
     rc=0
     exit_code=0
     for pkg in $(opa::go_packages); do
-        go vet $pkg || rc=$?
+        go vet -tags=opa_wasmer $pkg || rc=$?
         if [[ $rc != 0 ]]; then
             exit_code=1
         fi

--- a/build/run-goimports.sh
+++ b/build/run-goimports.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-GOFLAGS=-mod=vendor GO111MODULE=on GOOS="" GOARCH="" go run ./vendor/golang.org/x/tools/cmd/goimports -local github.com/open-policy-agent/opa $@
+GOFLAGS=-mod=vendor GO111MODULE=on GOOS="" GOARCH="" go run -tags=wasmer ./vendor/golang.org/x/tools/cmd/goimports -local github.com/open-policy-agent/opa $@

--- a/resolver/wasm/nop.go
+++ b/resolver/wasm/nop.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by an Apache2
 // license that can be found in the LICENSE file.
 
-// +build !cgo
+// +build !opa_wasmer
 
 package wasm
 
@@ -14,36 +14,42 @@ import (
 	"github.com/open-policy-agent/opa/resolver"
 )
 
+// Resolver is a stub implementation of a resolver.Resolver.
 type Resolver struct {
 }
 
+// Entrypoints unimplemented.
 func (r *Resolver) Entrypoints() []ast.Ref {
 	panic("unreachable")
 }
 
+// Close unimplemented.
 func (r *Resolver) Close() {
 	panic("unreachable")
 }
 
+// Eval unimplemented.
 func (r *Resolver) Eval(ctx context.Context, input resolver.Input) (resolver.Result, error) {
 
 	panic("unreachable")
 }
 
+// SetData unimplemented.
 func (r *Resolver) SetData(data interface{}) error {
 	panic("unreachable")
 }
 
-// SetDataPath will set the provided data on the wasm instance at the specified path.
+// SetDataPath unimplemented.
 func (r *Resolver) SetDataPath(path []string, data interface{}) error {
 	panic("unreachable")
 }
 
-// RemoveDataPath will remove any data at the specified path.
+// RemoveDataPath unimplemented.
 func (r *Resolver) RemoveDataPath(path []string) error {
 	panic("unreachable")
 }
 
+// New unimplemented. Will always return an error.
 func New(entrypoints []ast.Ref, policy []byte, data interface{}) (*Resolver, error) {
 	return nil, errors.New("WebAssembly runtime not supported in this build")
 }

--- a/resolver/wasm/wasm.go
+++ b/resolver/wasm/wasm.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by an Apache2
 // license that can be found in the LICENSE file.
 
-// +build cgo
+// +build opa_wasmer
 
 package wasm
 


### PR DESCRIPTION
We would previously gate building the was resolver (and in turn pull
in the wasmer stuff) based on whether or not cgo was enabled. However
for library use-cases this isn't ideal as someone might be using cgo
for an unrelated reason, and not wish to enabled the wasmer code in
opa.

There is now a new go tag for the files called "wasmer" and a makefile
flag WASMER_ENABLED (default on) which will trigger it. This means
any libraries building OPA that want to have it enabled will need to
specify this tag with like `-tags=wasmer` or similar when building.

Signed-off-by: Patrick East <east.patrick@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
