### PR TITLE
plugins/bundle: Fix default size limit

### DIFF
--- a/plugins/bundle/config.go
+++ b/plugins/bundle/config.go
@@ -38,11 +38,12 @@ func ParseConfig(config []byte, services []string) (*Config, error) {
 	// was configured with `bundles` in the newer format.
 	parsedConfig.Bundles = map[string]*Source{
 		parsedConfig.Name: {
-			Config:   parsedConfig.Config,
-			Service:  parsedConfig.Service,
-			Resource: parsedConfig.generateLegacyResourcePath(),
-			Signing:  nil,
-			Persist:  false,
+			Config:         parsedConfig.Config,
+			Service:        parsedConfig.Service,
+			Resource:       parsedConfig.generateLegacyResourcePath(),
+			Signing:        nil,
+			Persist:        false,
+			SizeLimitBytes: bundle.DefaultSizeLimitBytes,
 		},
 	}
 

--- a/plugins/bundle/config_test.go
+++ b/plugins/bundle/config_test.go
@@ -154,6 +154,10 @@ func TestLegacyDownloadPath(t *testing.T) {
 			if b.Resource != test.result {
 				t.Errorf("Expected resource %q on bundle with name %q, actual: %s", test.result, test.name, b.Resource)
 			}
+
+			if b.SizeLimitBytes != bundle.DefaultSizeLimitBytes {
+				t.Errorf("Expected bundle %q to have the default size limit configured", test.name)
+			}
 		})
 	}
 }


### PR DESCRIPTION
For the deprecated `bundle` config style bundle configuration we were
not setting the default bundle size limit, instead a zero value was
being propagated through when we "upgraded" the older style config
to the newer values.

This corrects that issue by always setting it to the default size
limit, which maintains the previous behavior.

Signed-off-by: Patrick East <east.patrick@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
