### PR TITLE
Fix docs on JWT HMAC encoding

### DIFF
--- a/docs/content/policy-reference.md
+++ b/docs/content/policy-reference.md
@@ -498,7 +498,7 @@ The following algorithms are supported:
 | <span class="opa-keep-it-together">``output := io.jwt.encode_sign_raw(headers, payload, key)``</span> | ``headers``, ``payload`` and  ``key`` as strings that represent the JWS Protected Header, JWS Payload and JSON Web Key ([RFC7517](https://tools.ietf.org/html/rfc7517)) respectively.|
 | <span class="opa-keep-it-together">``output := io.jwt.encode_sign(headers, payload, key)``</span> | ``headers``, ``payload`` and  ``key`` are JSON objects that represent the JWS Protected Header, JWS Payload and JSON Web Key ([RFC7517](https://tools.ietf.org/html/rfc7517)) respectively.|
 
-> Note that the key's provided should be base64 encoded as per the specification ([RFC7517](https://tools.ietf.org/html/rfc7517)).
+> Note that the key's provided should be base64 encoded (without padding) as per the specification ([RFC7517](https://tools.ietf.org/html/rfc7517)).
 > This differs from the plain text secrets provided with the algorithm specific verify built-ins described below.
 
 #### Token Signing Examples
@@ -723,7 +723,7 @@ Start with using the `io.jwt.encode_sign_raw` built-in:
 raw_result_hs256 := io.jwt.encode_sign_raw(
     `{"alg":"HS256","typ":"JWT"}`,
     `{}`,
-    `{"kty":"oct","k":"Zm9v"}`  	# "Zm9v" is the base64 URL encoded string "foo"
+    `{"kty":"oct","k":"Zm9v"}`  	# "Zm9v" == base64url.encode_no_pad("foo")
 )
 
 # Important!! - Use the un-encoded plain text secret to verify and decode


### PR DESCRIPTION
HMAC JWT encoding would previously break when base64 URL encoding resulted in padded output. This small doc fix should hopefully make it obvious that padding should be avoided, which is now possible with @johanneslarsson 's  PR.

Fixes #2870

Signed-off-by: Anders Eknert <anders.eknert@bisnode.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
