### PR TITLE
internal/wasm/sdk: Fix race in http loader shutdown

### DIFF
--- a/internal/wasm/sdk/opa/http/loader.go
+++ b/internal/wasm/sdk/opa/http/loader.go
@@ -142,7 +142,7 @@ func (l *Loader) poller() {
 
 		select {
 		case <-time.After(time.Duration(float64((l.maxDelay-l.minDelay))*rand.Float64()) + l.minDelay):
-		case <-l.closing:
+		case <-ctx.Done():
 			return
 		}
 	}


### PR DESCRIPTION
We would potentially set the `closing` channel to nil while a
goroutine was still attempting to read from it. This change corrects
the ordering so that the goroutine will catch when we start to close
and would trigger the for-loop in poller() to stop by cancelling the
context, rather than the select in the loop watching the `closing`
channel directly. This ensures that the context is cancelled before
returning, and that there isn't a race on the readers for `closing`.

Fixes: #2884

Signed-off-by: Patrick East <east.patrick@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
