### PR TITLE
wasm: Memoize planned functions without positional args

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ race-detector: generate
 	$(GO) test $(GO_TAGS),slow -race -vet=off ./...
 
 .PHONY: test-coverage
-test-coverage:
+test-coverage: generate
 	$(GO) test $(GO_TAGS),slow -coverprofile=coverage.txt -covermode=atomic ./...
 
 .PHONY: perf
@@ -223,7 +223,7 @@ CI_GOLANG_DOCKER_MAKE := $(DOCKER) run \
 	make
 
 .PHONY: ci-go-%
-ci-go-%:
+ci-go-%: generate
 	$(CI_GOLANG_DOCKER_MAKE) $*
 
 .PHONY: ci-release-test

--- a/test/wasm/assets/016_with.yaml
+++ b/test/wasm/assets/016_with.yaml
@@ -284,3 +284,27 @@ cases:
         "z": -2,
       },
     ]
+  - note: with invalidates memoization
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p = [x, y, z] {
+          x = q
+          y = q with input as 7
+          z = r with input as 8
+        }
+
+        default q = 6
+
+        q = input
+
+        r = [t, s]
+
+        s = q
+
+        t = x { x = q with input as 9 }
+    want_result: [
+      {"x": [6, 7, [9,8]]}
+    ]

--- a/wasm/src/memoize.c
+++ b/wasm/src/memoize.c
@@ -1,0 +1,56 @@
+#include "memoize.h"
+#include "malloc.h"
+
+struct memoize {
+    struct memoize  *prev;
+    opa_object_t    *table;
+};
+
+static struct memoize *m = NULL;
+
+struct memoize *opa_memoize_alloc(struct memoize *prev)
+{
+    struct memoize *result = (struct memoize *)opa_malloc(sizeof(struct memoize));
+    result->prev = prev;
+    result->table = opa_cast_object(opa_object());
+    return result;
+}
+
+void opa_memoize_init(void)
+{
+    m = opa_memoize_alloc(NULL);
+}
+
+void opa_memoize_push(void)
+{
+    m = opa_memoize_alloc(m);
+}
+
+void opa_memoize_pop(void)
+{
+    // NOTE(tsandall): free() is not called because we assume the heap will be
+    // reset on the next eval() call.
+    m = m->prev;
+}
+
+void opa_memoize_insert(int32_t index, opa_value *value)
+{
+    // NOTE(tsandall): allocating a number is suboptimal but worst-case is ~1 per
+    // planned rule so overhead should be minimal compared to the rest of evaluation.
+    opa_value *key = opa_number_int(index);
+    opa_object_insert(m->table, key, value);
+}
+
+opa_value *opa_memoize_get(int32_t index)
+{
+    opa_number_t key;
+    opa_number_init_int(&key, index);
+    opa_object_elem_t *elem = opa_object_get(m->table, &key.hdr);
+
+    if (elem == NULL)
+    {
+        return NULL;
+    }
+
+    return elem->v;
+}

--- a/wasm/src/memoize.h
+++ b/wasm/src/memoize.h
@@ -1,0 +1,12 @@
+#ifndef OPA_MEMOIZE_H
+#define OPA_MEMOIZE_H
+
+#include "value.h"
+
+void opa_memoize_init(void);
+void opa_memoize_push(void);
+void opa_memoize_pop(void);
+void opa_memoize_insert(int32_t, opa_value *);
+opa_value *opa_memoize_get(int32_t);
+
+#endif

--- a/wasm/src/value.c
+++ b/wasm/src/value.c
@@ -930,6 +930,13 @@ opa_value *opa_number_ref_allocated(const char *s, size_t len)
     return &ret->hdr;
 }
 
+void opa_number_init_int(opa_number_t *n, long long v)
+{
+    n->hdr.type = OPA_NUMBER;
+    n->repr = OPA_NUMBER_REPR_INT;
+    n->v.i = v;
+}
+
 void opa_number_free(opa_number_t *n)
 {
     if (n->repr == OPA_NUMBER_REPR_REF)
@@ -1520,7 +1527,7 @@ int _validate_json_path(opa_value *path)
                 return -1;
         }
     }
- 
+
     return path_len;
 }
 
@@ -1593,7 +1600,7 @@ opa_errc opa_value_add_path(opa_value *data, opa_value *path, opa_value *v)
 //
 // Deleted values will be freed.
 opa_errc opa_value_remove_path(opa_value *data, opa_value *path)
-{ 
+{
     int path_len = _validate_json_path(path);
 
     if (path_len < 1)

--- a/wasm/src/value.h
+++ b/wasm/src/value.h
@@ -136,6 +136,7 @@ opa_value *opa_number_int(long long v);
 opa_value *opa_number_float(double v);
 opa_value *opa_number_ref(const char *s, size_t len);
 opa_value *opa_number_ref_allocated(const char *s, size_t len);
+void opa_number_init_int(opa_number_t *n, long long v);
 opa_value *opa_string(const char *v, size_t len);
 opa_value *opa_string_terminated(const char *v);
 opa_value *opa_string_allocated(const char *v, size_t len);


### PR DESCRIPTION
This commit updates the C library to expose a global key-value mapping
that can be initialized and supports push/pop operations for
shadowing. The key-value mapping is implemented using opa_object_t to
keep things simple. In the future, this could be replaced with
something more efficient.

The wasm compiler uses the key-value mapping to memoize calls to
planned functions that only depend on input and data. The compiler
uses the function index as the key and the function return value as
the value. The choice to memoize at the call-site as opposed to inside
planned functions was arbitrary.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
