### PR TITLE
plugins/logs: Refactor shutdown log flushing

### DIFF
--- a/plugins/logs/plugin_test.go
+++ b/plugins/logs/plugin_test.go
@@ -107,10 +107,6 @@ func TestPluginSingleBundle(t *testing.T) {
 	}
 }
 
-func TestPluginMultiBundle(t *testing.T) {
-
-}
-
 func TestPluginErrorNoResult(t *testing.T) {
 	ctx := context.Background()
 	manager, _ := plugins.New(nil, "test-instance-id", inmem.New())


### PR DESCRIPTION
This removes some time-related stuff from both the implementation and
the unit tests with the aim to make it less flakey.

For the implementation we will now rely only on the deadline set by
the original context. We don't mess with canceling it as the signal
that we've completed. We use a new more explicit done channel.

In the unit test we no longer check that it stopped immediately, it
will instead ensure that the plugin was forcefully stopped with logs
still in its buffer.