### PR TITLE
plugins, plugins/rest: Support custom auth plugins

### DIFF
--- a/plugins/discovery/discovery.go
+++ b/plugins/discovery/discovery.go
@@ -229,7 +229,11 @@ func (c *Discovery) processBundle(ctx context.Context, b *bundleApi.Bundle) (*pl
 	// unrecoverable (without keeping track of changes and rolling back...)
 
 	// check for updates to the discovery service
-	services, err := cfg.ParseServicesConfig(config.Services)
+	opts := cfg.ServiceOptions{
+		Raw:        config.Services,
+		AuthPlugin: c.manager.AuthPlugin,
+	}
+	services, err := cfg.ParseServicesConfig(opts)
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/rest/gcp.go
+++ b/plugins/rest/gcp.go
@@ -75,12 +75,12 @@ func (ap *gcpMetadataAuthPlugin) NewClient(c Config) (*http.Client, error) {
 		ap.IdentityTokenPath = defaultIdentityTokenPath
 	}
 
-	t, err := defaultTLSConfig(c)
+	t, err := DefaultTLSConfig(c)
 	if err != nil {
 		return nil, err
 	}
 
-	return defaultRoundTripperClient(t, *c.ResponseHeaderTimeoutSeconds), nil
+	return DefaultRoundTripperClient(t, *c.ResponseHeaderTimeoutSeconds), nil
 }
 
 func (ap *gcpMetadataAuthPlugin) Prepare(req *http.Request) error {

--- a/plugins/rest/rest_auth.go
+++ b/plugins/rest/rest_auth.go
@@ -21,8 +21,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// defaultTLSConfig defines standard TLS configurations based on the Config
-func defaultTLSConfig(c Config) (*tls.Config, error) {
+// DefaultTLSConfig defines standard TLS configurations based on the Config
+func DefaultTLSConfig(c Config) (*tls.Config, error) {
 	t := &tls.Config{}
 	url, err := url.Parse(c.URL)
 	if err != nil {
@@ -34,8 +34,8 @@ func defaultTLSConfig(c Config) (*tls.Config, error) {
 	return t, nil
 }
 
-// defaultRoundTripperClient is a reasonable set of defaults for HTTP auth plugins
-func defaultRoundTripperClient(t *tls.Config, timeout int64) *http.Client {
+// DefaultRoundTripperClient is a reasonable set of defaults for HTTP auth plugins
+func DefaultRoundTripperClient(t *tls.Config, timeout int64) *http.Client {
 	// Ensure we use a http.Transport with proper settings: the zero values are not
 	// a good choice, as they cause leaking connections:
 	// https://github.com/golang/go/issues/19620
@@ -54,11 +54,11 @@ func defaultRoundTripperClient(t *tls.Config, timeout int64) *http.Client {
 type defaultAuthPlugin struct{}
 
 func (ap *defaultAuthPlugin) NewClient(c Config) (*http.Client, error) {
-	t, err := defaultTLSConfig(c)
+	t, err := DefaultTLSConfig(c)
 	if err != nil {
 		return nil, err
 	}
-	return defaultRoundTripperClient(t, *c.ResponseHeaderTimeoutSeconds), nil
+	return DefaultRoundTripperClient(t, *c.ResponseHeaderTimeoutSeconds), nil
 }
 
 func (ap *defaultAuthPlugin) Prepare(req *http.Request) error {
@@ -73,7 +73,7 @@ type bearerAuthPlugin struct {
 }
 
 func (ap *bearerAuthPlugin) NewClient(c Config) (*http.Client, error) {
-	t, err := defaultTLSConfig(c)
+	t, err := DefaultTLSConfig(c)
 	if err != nil {
 		return nil, err
 	}
@@ -86,7 +86,7 @@ func (ap *bearerAuthPlugin) NewClient(c Config) (*http.Client, error) {
 		ap.Scheme = "Bearer"
 	}
 
-	return defaultRoundTripperClient(t, *c.ResponseHeaderTimeoutSeconds), nil
+	return DefaultRoundTripperClient(t, *c.ResponseHeaderTimeoutSeconds), nil
 }
 
 func (ap *bearerAuthPlugin) Prepare(req *http.Request) error {
@@ -128,7 +128,7 @@ type oauth2Token struct {
 }
 
 func (ap *oauth2ClientCredentialsAuthPlugin) NewClient(c Config) (*http.Client, error) {
-	t, err := defaultTLSConfig(c)
+	t, err := DefaultTLSConfig(c)
 	if err != nil {
 		return nil, err
 	}
@@ -146,7 +146,7 @@ func (ap *oauth2ClientCredentialsAuthPlugin) NewClient(c Config) (*http.Client, 
 		ap.Scopes = &[]string{}
 	}
 
-	return defaultRoundTripperClient(t, *c.ResponseHeaderTimeoutSeconds), nil
+	return DefaultRoundTripperClient(t, *c.ResponseHeaderTimeoutSeconds), nil
 }
 
 // requestToken tries to obtain an access token using the client credentials flow
@@ -164,7 +164,7 @@ func (ap *oauth2ClientCredentialsAuthPlugin) requestToken() (*oauth2Token, error
 	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	r.SetBasicAuth(ap.ClientID, ap.ClientSecret)
 
-	client := defaultRoundTripperClient(&tls.Config{InsecureSkipVerify: ap.tlsSkipVerify}, 10)
+	client := DefaultRoundTripperClient(&tls.Config{InsecureSkipVerify: ap.tlsSkipVerify}, 10)
 	response, err := client.Do(r)
 	if err != nil {
 		return nil, err
@@ -218,7 +218,7 @@ type clientTLSAuthPlugin struct {
 }
 
 func (ap *clientTLSAuthPlugin) NewClient(c Config) (*http.Client, error) {
-	tlsConfig, err := defaultTLSConfig(c)
+	tlsConfig, err := DefaultTLSConfig(c)
 	if err != nil {
 		return nil, err
 	}
@@ -281,7 +281,7 @@ func (ap *clientTLSAuthPlugin) NewClient(c Config) (*http.Client, error) {
 	}
 
 	tlsConfig.Certificates = []tls.Certificate{cert}
-	client := defaultRoundTripperClient(tlsConfig, *c.ResponseHeaderTimeoutSeconds)
+	client := DefaultRoundTripperClient(tlsConfig, *c.ResponseHeaderTimeoutSeconds)
 	return client, nil
 }
 
@@ -307,7 +307,7 @@ func (ap *awsSigningAuthPlugin) awsCredentialService() awsCredentialService {
 }
 
 func (ap *awsSigningAuthPlugin) NewClient(c Config) (*http.Client, error) {
-	t, err := defaultTLSConfig(c)
+	t, err := DefaultTLSConfig(c)
 	if err != nil {
 		return nil, err
 	}
@@ -331,7 +331,7 @@ func (ap *awsSigningAuthPlugin) NewClient(c Config) (*http.Client, error) {
 			return nil, err
 		}
 	}
-	return defaultRoundTripperClient(t, *c.ResponseHeaderTimeoutSeconds), nil
+	return DefaultRoundTripperClient(t, *c.ResponseHeaderTimeoutSeconds), nil
 }
 
 func (ap *awsSigningAuthPlugin) Prepare(req *http.Request) error {


### PR DESCRIPTION
Some notes on the implementation:

- Passing along the authPluginLookup function to avoid a circular import between plugins and plugins/rest.
- Updated `DefaultRoundTripperClient` and `DefaultTLSConfig` to be exported so that custom auth plugins can use them. If this isn't appropriate just lmk.
- This approach seems a little messy to me, but I was having a hard time figuring out how else to implement it that avoided the circular import.
- I nested `plugin` under `custom` for credentials in case there was additional config needed for custom auth.

Plugins that implement the HTTPAuthPlugin can be used with a new credentials options under services:

```
services:
  my_service:
    credentials:
        plugin: my_plugin
plugins:
  my_plugin: {}
```

Fixes #2758

Signed-off-by: Grant Shively <gshively@godaddy.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
