### PR TITLE
Implement NO-OP signature signer and verifier

### DIFF
--- a/internal/jwx/jws/sign/interface.go
+++ b/internal/jwx/jws/sign/interface.go
@@ -43,3 +43,6 @@ type HMACSigner struct {
 	alg  jwa.SignatureAlgorithm
 	sign hmacSignFunc
 }
+
+// NOOPSigner does not sign the payload
+type NOOPSigner struct{}

--- a/internal/jwx/jws/sign/noop.go
+++ b/internal/jwx/jws/sign/noop.go
@@ -1,0 +1,17 @@
+package sign
+
+import "github.com/open-policy-agent/opa/internal/jwx/jwa"
+
+func newNOOPSigner() (Signer, error) {
+	return &NOOPSigner{}, nil
+}
+
+// Algorithm returns the signer algorithm
+func (n NOOPSigner) Algorithm() jwa.SignatureAlgorithm {
+	return jwa.NoSignature
+}
+
+// Sign is a NOOP that does nothing to the provided payload
+func (n NOOPSigner) Sign(payload []byte, key interface{}) ([]byte, error) {
+	return nil, nil
+}

--- a/internal/jwx/jws/sign/noop_test.go
+++ b/internal/jwx/jws/sign/noop_test.go
@@ -1,0 +1,39 @@
+package sign
+
+import (
+	"testing"
+
+	"github.com/open-policy-agent/opa/internal/jwx/jwa"
+)
+
+func TestNOOPSign(t *testing.T) {
+
+	t.Run("NOOPSigner Create", func(t *testing.T) {
+		_, err := newNOOPSigner()
+		if err != nil {
+			t.Fatalf("Signer creation failure: %v", err)
+		}
+	})
+
+	t.Run("NOOPSigner Sign", func(t *testing.T) {
+		test := struct {
+			payload []byte
+			key     interface{}
+		}{
+			[]byte("hello"), 5,
+		}
+
+		signer, err := newNOOPSigner()
+		if err != nil {
+			t.Fatalf("Signer creation failure: %v", jwa.NoSignature)
+		}
+
+		sig, err := signer.Sign(test.payload, test.key)
+		if err != nil {
+			t.Fatalf("Expected Sign to succeed: %v", err)
+		}
+		if sig != nil {
+			t.Fatalf("Expected no signature to be created")
+		}
+	})
+}

--- a/internal/jwx/jws/sign/sign.go
+++ b/internal/jwx/jws/sign/sign.go
@@ -19,6 +19,8 @@ func New(alg jwa.SignatureAlgorithm) (Signer, error) {
 		return newECDSA(alg)
 	case jwa.HS256, jwa.HS384, jwa.HS512:
 		return newHMAC(alg)
+	case jwa.NoSignature:
+		return newNOOPSigner()
 	default:
 		return nil, errors.Errorf(`unsupported signature algorithm %s`, alg)
 	}

--- a/internal/jwx/jws/verify/interface.go
+++ b/internal/jwx/jws/verify/interface.go
@@ -37,3 +37,6 @@ type ECDSAVerifier struct {
 type HMACVerifier struct {
 	signer sign.Signer
 }
+
+// NOOPVerifier does not verify the signature
+type NOOPVerifier struct{}

--- a/internal/jwx/jws/verify/noop.go
+++ b/internal/jwx/jws/verify/noop.go
@@ -1,0 +1,10 @@
+package verify
+
+func newNOOPVerifier() (*NOOPVerifier, error) {
+	return &NOOPVerifier{}, nil
+}
+
+// Verify does not verify the payload
+func (n NOOPVerifier) Verify(payload []byte, signature []byte, key interface{}) error {
+	return nil
+}

--- a/internal/jwx/jws/verify/noop_test.go
+++ b/internal/jwx/jws/verify/noop_test.go
@@ -1,0 +1,37 @@
+package verify
+
+import (
+	"testing"
+
+	"github.com/open-policy-agent/opa/internal/jwx/jwa"
+)
+
+func TestNOOPVerify(t *testing.T) {
+
+	t.Run("NOOPVerifier Create", func(t *testing.T) {
+		_, err := newNOOPVerifier()
+		if err != nil {
+			t.Fatalf("Verifier creation failure: %v", err)
+		}
+	})
+
+	t.Run("NOOPVerifier Verify", func(t *testing.T) {
+		test := struct {
+			payload   []byte
+			signature []byte
+			key       interface{}
+		}{
+			[]byte("foo"), []byte("bar"), 5,
+		}
+
+		verifier, err := newNOOPVerifier()
+		if err != nil {
+			t.Fatalf("Signer creation failure: %v", jwa.NoSignature)
+		}
+
+		err = verifier.Verify(test.payload, test.signature, test.key)
+		if err != nil {
+			t.Fatalf("Expected verify to succeed: %v", err)
+		}
+	})
+}

--- a/internal/jwx/jws/verify/verify.go
+++ b/internal/jwx/jws/verify/verify.go
@@ -22,6 +22,8 @@ func New(alg jwa.SignatureAlgorithm) (Verifier, error) {
 		return newECDSA(alg)
 	case jwa.HS256, jwa.HS384, jwa.HS512:
 		return newHMAC(alg)
+	case jwa.NoSignature:
+		return newNOOPVerifier()
 	default:
 		return nil, errors.Errorf(`unsupported signature algorithm: %s`, alg)
 	}


### PR DESCRIPTION
Despite being listed as a supported signature algorithm, there is no implementation
of a signer or verifier for "jwa.NoSignature". This Patch adds a simple NO-OP implementation
that does nothing :). Use case is tests creating tokens using "io.jwt.encode_sign()"
where the signature does not need to be verified.

Signed-off-by: Dave Alexander dave.alexander@hey.com

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
