### PR TITLE
remove unimplemented "none" signature algorithm from docs

### DIFF
--- a/docs/content/policy-reference.md
+++ b/docs/content/policy-reference.md
@@ -483,7 +483,6 @@ The following algorithms are supported:
 	HS256       "HS256" // HMAC using SHA-256
 	HS384       "HS384" // HMAC using SHA-384
 	HS512       "HS512" // HMAC using SHA-512
-	NoSignature "none"
 	PS256       "PS256" // RSASSA-PSS using SHA256 and MGF1-SHA256
 	PS384       "PS384" // RSASSA-PSS using SHA384 and MGF1-SHA384
 	PS512       "PS512" // RSASSA-PSS using SHA512 and MGF1-SHA512


### PR DESCRIPTION
Based on discussion in https://github.com/open-policy-agent/opa/pull/2937 the "none" signature algorithm is currently unimplemented as both a signer and a verifier, and there are no plans to add an implementation.

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
