### PR TITLE
wasm: Put exceptions in place for json.patch cases

### DIFF
--- a/internal/wasm/sdk/test/e2e/exceptions.yaml
+++ b/internal/wasm/sdk/test/e2e/exceptions.yaml
@@ -12,3 +12,5 @@
 "withkeyword/with base doc exact value": "with target conflict issue - https://github.com/open-policy-agent/opa/issues/2922"
 "withkeyword/with base doc any index": "with target conflict issue - https://github.com/open-policy-agent/opa/issues/2922"
 "withkeyword/undefined_1": "with target conflict issue - https://github.com/open-policy-agent/opa/issues/2922"
+"jsonpatch/set": "unexpected panic or evaluation error - https://github.com/open-policy-agent/opa/issues/2949"
+"jsonpatch/json_patch_tests": "unexpected panic or evaluation error - https://github.com/open-policy-agent/opa/issues/2949"


### PR DESCRIPTION
The json.patch test cases are causing panics and runtime errors for
the wasm e2e tests. This commit puts an exception in place for them so
we can come back and fix later.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
