### PR TITLE
wasm: include source location in runtime errors

### DIFF
--- a/internal/ir/walk.go
+++ b/internal/ir/walk.go
@@ -26,7 +26,9 @@ type walkerImpl struct {
 }
 
 func (w *walkerImpl) walk(x interface{}) {
-
+	if w.err != nil { // abort on error
+		return
+	}
 	if x == nil {
 		return
 	}
@@ -52,6 +54,9 @@ func (w *walkerImpl) walk(x interface{}) {
 			w.walk(s)
 		}
 		for _, f := range x.BuiltinFuncs {
+			w.walk(f)
+		}
+		for _, f := range x.Files {
 			w.walk(f)
 		}
 	case *Plans:

--- a/internal/wasm/sdk/opa/opa_test.go
+++ b/internal/wasm/sdk/opa/opa_test.go
@@ -30,6 +30,7 @@ func TestOPA(t *testing.T) {
 		Query       string
 		Data        string
 		Evals       []Eval
+		WantErr     string // "" means no error expected
 	}{
 		{
 			Description: "No input, no data, static policy",
@@ -39,6 +40,7 @@ func TestOPA(t *testing.T) {
 				Eval{Result: `{{"x": true}}`},
 				Eval{Result: `{{"x": true}}`},
 			},
+			WantErr: "",
 		},
 		{
 			Description: "Only input changing",
@@ -48,6 +50,7 @@ func TestOPA(t *testing.T) {
 				Eval{Input: "false", Result: `{{"x": false}}`},
 				Eval{Input: "true", Result: `{{"x": true}}`},
 			},
+			WantErr: "",
 		},
 		{
 			Description: "Only data changing",
@@ -58,6 +61,7 @@ func TestOPA(t *testing.T) {
 				Eval{Result: `{{"x": false}}`},
 				Eval{NewData: `{"q": true}`, Result: `{{"x": true}}`},
 			},
+			WantErr: "",
 		},
 		{
 			Description: "Only policy changing",
@@ -68,6 +72,7 @@ func TestOPA(t *testing.T) {
 				Eval{Result: `{{"x": false}}`},
 				Eval{NewPolicy: `a = data.r`, Result: `{{"x": true}}`},
 			},
+			WantErr: "",
 		},
 		{
 			Description: "Policy and data changing",
@@ -78,6 +83,7 @@ func TestOPA(t *testing.T) {
 				Eval{Result: `{{"x": 0}}`},
 				Eval{NewPolicy: `a = data.r`, NewData: `{"q": 2, "r": 3}`, Result: `{{"x": 3}}`},
 			},
+			WantErr: "",
 		},
 		{
 			Description: "Builtins",
@@ -87,6 +93,7 @@ func TestOPA(t *testing.T) {
 				Eval{NewData: `{"q": []}`, Result: `{{"x": 0}}`},
 				Eval{NewData: `{"q": [1, 2]}`, Result: `{{"x": 5}}`},
 			},
+			WantErr: "",
 		},
 		{
 			Description: "Undefined decision",
@@ -95,6 +102,45 @@ func TestOPA(t *testing.T) {
 			Evals: []Eval{
 				Eval{Result: `set()`},
 			},
+			WantErr: "",
+		},
+		{
+			Description: "Runtime error/object insert conflict",
+			Policy:      `a = { "a": y | y := [1, 2][_] }`,
+			Query:       "data.p.a.a = x",
+			Evals:       []Eval{{}},
+			WantErr:     "module.rego:2:5: object insert conflict: internal error",
+		},
+		{
+			Description: "Runtime error/var assignment conflict",
+			Policy: `a = "b" { input > 1 }
+a = "c" { input > 2 }`,
+			Query: "data.p.a = x",
+			Evals: []Eval{
+				{Input: "3"},
+			},
+			WantErr: "module.rego:3:1: var assignment conflict: internal error",
+		},
+		{
+			Description: "Runtime error/object merge conflict",
+			Policy:      `a = false`,
+			Query:       "data.p = x",
+			Data:        `{"p": {"a": true}}`,
+			Evals:       []Eval{{}},
+			WantErr:     "<query>:1:1: object merge conflict: internal error",
+		},
+		{
+			Description: "Runtime error/with target conflict in policy",
+			Policy:      `a = x { input = x with input.foo as 1 with input.foo.bar as 2 }`,
+			Query:       "data.p = x",
+			Evals:       []Eval{{}},
+			WantErr:     "module.rego:2:9: with target conflict: internal error",
+		},
+		{
+			Description: "Runtime error/with target conflict in query",
+			Query:       "input = x with input.foo as 1 with input.foo.bar as 2",
+			Evals:       []Eval{{}},
+			WantErr:     "<query>:1:1: with target conflict: internal error",
 		},
 		// NOTE(sr): The next two test cases were used to replicate issue
 		// https://github.com/open-policy-agent/opa/issues/2962 -- their raison d'être
@@ -184,7 +230,16 @@ func TestOPA(t *testing.T) {
 
 				r, err := instance.Eval(context.Background(), opa.EvalOpts{Input: parseJSON(eval.Input)})
 				if err != nil {
-					t.Fatalf(err.Error())
+					if test.WantErr == "" { // no error desired
+						t.Fatal(err.Error())
+					}
+					if expected, actual := test.WantErr, err.Error(); expected != actual {
+						t.Fatalf("expected error %q, got %q", expected, actual)
+					}
+					return
+				}
+				if test.WantErr != "" {
+					t.Fatalf("expected error %q, got nil", test.WantErr)
 				}
 
 				expected := ast.MustParseTerm(eval.Result)

--- a/test/wasm/assets/007_complete.yaml
+++ b/test/wasm/assets/007_complete.yaml
@@ -152,7 +152,7 @@ cases:
         package x
         p = 1
         p = 2
-    want_error: "var assignment conflict"
+    want_error: "module0.rego:3:1: var assignment conflict"
   - note: packages
     query: data.x.p = 1
     modules:

--- a/test/wasm/assets/008_functions.yaml
+++ b/test/wasm/assets/008_functions.yaml
@@ -103,7 +103,7 @@ cases:
         package x
         f(x) = 1
         f(x) = 2
-    want_error: var assignment conflict
+    want_error: "module0.rego:3:1: var assignment conflict"
   - note: 'false result'
     query: data.test.p = x
     modules:

--- a/test/wasm/assets/012_partialobjects.yaml
+++ b/test/wasm/assets/012_partialobjects.yaml
@@ -50,7 +50,7 @@ cases:
         package x
         p["x"] = 1
         p["x"] = 2
-    want_error: "object insert conflict"
+    want_error: "module0.rego:3:1: object insert conflict"
   - note: object dereference
     query: data.x.p.a.b = 1
     modules:

--- a/test/wasm/assets/013_virtual.yaml
+++ b/test/wasm/assets/013_virtual.yaml
@@ -185,7 +185,7 @@ cases:
       package test
 
       x = []
-    want_error: object merge conflict
+    want_error: "<query>:1:1: object merge conflict"
   - note: merge iteration
     query: |
       data.test[x].foo == {"q": 1, "p": 3}; x == "a"

--- a/test/wasm/assets/016_with.yaml
+++ b/test/wasm/assets/016_with.yaml
@@ -229,7 +229,7 @@ cases:
   - note: with conflict
     query: |
       input = x with input.foo as 1 with input.foo.bar as 2
-    want_error: with target conflict
+    want_error: "<query>:1:1: with target conflict"
   - note: with virtual doc iteration
     query: |
       x := data[i][j] with data.bar.p as 3 with data.bar.q as 4; y = data.bar.p; z = data.bar.q

--- a/wasm/src/error.c
+++ b/wasm/src/error.c
@@ -1,0 +1,19 @@
+#include "error.h"
+#include "malloc.h"
+#include "mpd.h"
+#include "printf.h"
+#include "str.h"
+
+void opa_runtime_error(const char *loc, int row, int col, const char *msg)
+{
+    char row_str[sizeof(row)*8+1];
+    char col_str[sizeof(col)*8+1];
+    opa_itoa(row, row_str, 10);
+    opa_itoa(col, col_str, 10);
+    // 5 = ":" + ":" + ": " + \0
+    size_t len = opa_strlen(loc)+opa_strlen(row_str)+opa_strlen(col_str)+opa_strlen(msg)+5;
+    char *err = (char *)opa_malloc(len);
+    snprintf(err, len, "%s:%s:%s: %s", loc, row_str, col_str, msg);
+
+    opa_abort(err);
+}

--- a/wasm/src/error.h
+++ b/wasm/src/error.h
@@ -1,0 +1,6 @@
+#ifndef OPA_STRINGS_H
+#define OPA_STRINGS_H
+
+void opa_runtime_error(const char *loc, int row, int col, const char *msg);
+
+#endif


### PR DESCRIPTION
Note that due to the mapping of rego to imperative code, the errors
may look different than what you'd expect. For example, with this rego,

    package fr

    p {
      f(3)
    }

    f(x) = "y" {
      x > 1
    }

    f(x) = "z" {
      x > 2
    }

the runtime error is

    fun_rets.rego:12:3: var assignment conflict

Whereas `opa eval` gives you

    $ opa eval 'data.fr.p' -d fun_rets.rego --format=pretty
    1 error occurred: fun_rets.rego:11: eval_conflict_error: functions must not produce multiple outputs for same inputs

To get here, we're adding a new section to the static part of an ir.Policy: Files.
It's carrying the file name constants, and one special entry called `<query>`.

Most of the work in this change is ensuring that source location info is properly
carried over into the IR statements from AST nodes. There are new tests for the
planner "TestLocations", to assert a bunch of those mappings for different structures.
They attempt to not cover every statement, but a few select ones for each case.

The mappings works in an indirect way: there's a location stored in the planner's
state, `p.loc`, and it's used from `p.appendStmt`. For some constructions that bypass
this helper, there is an extra method, `p.appendStmtToBlock`, to carry over the location
from p.loc into the statements added that way.

Also:

* internal/ir: change location struct to include file and text

  This helps with debugging:

      | | | | *ir.BlockStmt BlockStmt (1 blocks)
      | | | | | *ir.Block Block (6 statements)
      | | | | | | *ir.MakeNumberRefStmt &{Index:1 Target:6 Location:{Index:0 Col:23 Row:4 file:module-0.rego text:1 > 0}}
      | | | | | | *ir.MakeNumberRefStmt &{Index:2 Target:7 Location:{Index:0 Col:23 Row:4 file:module-0.rego text:1 > 0}}
      | | | | | | *ir.GreaterThanStmt &{A:6 B:7 Location:{Index:0 Col:23 Row:4 file:module-0.rego text:1 > 0}}
      | | | | | | *ir.MakeStringStmt &{Index:3 Target:8 Location:{Index:0 Col:23 Row:4 file:module-0.rego text:1 > 0}}
      | | | | | | *ir.MakeStringStmt &{Index:4 Target:9 Location:{Index:0 Col:23 Row:4 file:module-0.rego text:1 > 0}}
      | | | | | | *ir.ObjectInsertOnceStmt &{Key:8 Value:9 Object:5 Location:{Index:0 Col:23 Row:4 file:module-0.rego text:1 > 0}}
      | | | | *ir.AssignVarOnceStmt &{Target:2 Source:5 Location:{Index:0 Col:23 Row:4 file:module-0.rego text:1 > 0}}

  The fields are intentionally not exported, so they don't make their way
  into the WASM module.

* Fixes error return of ir.Walk()

  w.err would be ignored for the code path that walks leaves on the same level:

      w.walk(x.Static) // error set here
      w.walk(x.Plans)  // would be overwritten here
      w.walk(x.Funcs)


--------
Fixes #2862.