### PR TITLE
build: Fix changelog.py to tolerate missing e-mail in commit message

### DIFF
--- a/build/changelog.py
+++ b/build/changelog.py
@@ -62,9 +62,10 @@ def is_maintainer(commit_message):
 
 def author_email(commit_message):
     match = re.search(r"<(.*@.*)>", commit_message)
-    author = match.group(1)
-    return str(author)
-
+    if match:
+        author = match.group(1)
+        return str(author)
+    return ""
 
 github_ids = {}
 def get_github_id(commit_message, commit_id, token):


### PR DESCRIPTION
The wasm-updater does not sign-off on changes so there is no e-mail
address in the commit message.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
