### PR TITLE
build: Fix rpath to refer to absolute location

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ USER ${USER}
 
 ARG BIN_DIR=.
 COPY ${BIN_DIR}/opa_docker_amd64 /opa
-COPY ./vendor/github.com/wasmerio/go-ext-wasm/wasmer/libwasmer.so /libwasmer.so
+COPY ./vendor/github.com/wasmerio/go-ext-wasm/wasmer/libwasmer.so /usr/lib/opa/libwasmer.so
 
 ENTRYPOINT ["/opa"]
 CMD ["run"]

--- a/Makefile
+++ b/Makefile
@@ -244,7 +244,7 @@ ci-wasm: wasm-test
 
 .PHONY: build-docker
 build-docker: ensure-release-dir
-	CGO_LDFLAGS="-Wl,-rpath -Wl,./$$ORIGIN" $(GO) build $(GO_TAGS) -o $(RELEASE_DIR)/opa_docker_$(GOARCH) -ldflags $(LDFLAGS)
+	CGO_LDFLAGS="-Wl,-rpath,/usr/lib/opa" $(GO) build $(GO_TAGS) -o $(RELEASE_DIR)/opa_docker_$(GOARCH) -ldflags $(LDFLAGS)
 
 .PHONY: build-linux
 build-linux: ensure-release-dir


### PR DESCRIPTION
We originally set the rpath to be relative to the $ORIGIN which
apparently changes if the working directory is overriden. This change
just fixes the rpath to contain /usr/lib/opa and then updates the
Dockerfile to copy the libwasmer.so file into this new directory.

Fixes #2974

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
