### PR TITLE
server: Add message body to authorization policy input

### DIFF
--- a/docs/content/security.md
+++ b/docs/content/security.md
@@ -191,7 +191,31 @@ policy:
     # characters following a hyphen are uppercase. The rest are lowercase.
     # If the header key contains space or invalid header field bytes,
     # no conversion is performed.
-    "headers": {"...": [...]}
+    "headers": {"...": [...]},
+
+    # Request message body if present for applicable APIs.
+    #
+    # Example Request:
+    #
+    #   POST v1/data HTTP/1.1
+    #   Content-Type: application/json
+    #
+    #   {"input": {"action": "trade", "stock": "ACME"}}
+    #
+    # Example input.body Value:
+    #
+    #   {"input": {"action": "trade", "stock": "ACME"}}
+    #
+    # Example body check:
+    #
+    #   input.body.input.stock == "ACME"
+    #
+    # The 'body' field is provided for the following APIs:
+    #
+    #   * POST v1/data
+    #   * POST v0/data
+    #   * POST /
+    "body": ...,
 }
 ```
 

--- a/server/server.go
+++ b/server/server.go
@@ -2313,14 +2313,22 @@ func getExplain(p []string, zero types.ExplainModeV1) types.ExplainModeV1 {
 }
 
 func readInputV0(r *http.Request) (ast.Value, error) {
+
+	parsed, ok := authorizer.GetBodyOnContext(r.Context())
+	if ok {
+		return ast.InterfaceToValue(parsed)
+	}
+
 	bs, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		return nil, err
 	}
+
 	bs = bytes.TrimSpace(bs)
 	if len(bs) == 0 {
 		return nil, nil
 	}
+
 	var x interface{}
 
 	if strings.Contains(r.Header.Get("Content-Type"), "yaml") {
@@ -2343,6 +2351,16 @@ func readInputGetV1(str string) (ast.Value, error) {
 }
 
 func readInputPostV1(r *http.Request) (ast.Value, error) {
+
+	parsed, ok := authorizer.GetBodyOnContext(r.Context())
+	if ok {
+		if obj, ok := parsed.(map[string]interface{}); ok {
+			if input, ok := obj["input"]; ok {
+				return ast.InterfaceToValue(input)
+			}
+		}
+		return nil, nil
+	}
 
 	bs, err := ioutil.ReadAll(r.Body)
 


### PR DESCRIPTION
This commit updates the server's basic authorizer to include the
deserialized message body in the input to the authorization policy so
that the latter can make decisions based on policy query input
documents. The authorizer caches the parsed message body on the
request context and the server retrieves the value to avoid parsing twice.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
