### PR TITLE
plugins/plugins: WARN state and optional message

### DIFF
--- a/plugins/plugins.go
+++ b/plugins/plugins.go
@@ -112,11 +112,17 @@ const (
 	// StateErr indicates that the Plugin is in an error state and should not
 	// be considered as functional.
 	StateErr State = "ERROR"
+
+	// StateWarn indicates the Plugin is operating, but in a potentially dangerous or
+	// degraded state. It may be used to indicate manual remediation is needed, or to
+	// alert admins of some other noteworthy state.
+	StateWarn State = "WARN"
 )
 
 // Status has a Plugin's current status plus an optional Message.
 type Status struct {
-	State State `json:"state"`
+	State   State  `json:"state"`
+	Message string `json:"message,omitempty"`
 }
 
 // StatusListener defines a handler to register for status updates.
@@ -569,7 +575,8 @@ func (m *Manager) copyPluginStatus() map[string]*Status {
 		var cpy *Status
 		if v != nil {
 			cpy = &Status{
-				State: v.State,
+				State:   v.State,
+				Message: v.Message,
 			}
 		}
 		statusCpy[k] = cpy

--- a/plugins/plugins_test.go
+++ b/plugins/plugins_test.go
@@ -48,10 +48,10 @@ func TestManagerPluginStatusListener(t *testing.T) {
 	}
 
 	// Push an update to a plugin, ensure current status is reflected and listeners were called
-	m.UpdatePluginStatus("p1", &Status{State: StateOK})
+	m.UpdatePluginStatus("p1", &Status{State: StateOK, Message: "foo"})
 	currentStatus = m.PluginStatus()
-	if len(currentStatus) != 1 || currentStatus["p1"].State != StateOK {
-		t.Fatalf("Expected 1 statuses in current plugin status map with state OK, got: %+v", currentStatus)
+	if len(currentStatus) != 1 || currentStatus["p1"].State != StateOK || currentStatus["p1"].Message != "foo" {
+		t.Fatalf("Expected 1 statuses in current plugin status map with state OK and message 'foo', got: %+v", currentStatus)
 	}
 	if !reflect.DeepEqual(currentStatus, l1Status) || !reflect.DeepEqual(l1Status, l2Status) {
 		t.Fatalf("Unexpected status in updates:\n\n\texpecting: %+v\n\n\tgot: l1: %+v  l2: %+v\n", currentStatus, l1Status, l2Status)
@@ -66,7 +66,7 @@ func TestManagerPluginStatusListener(t *testing.T) {
 	// Send another update, ensure the status is ok and the remaining listener is still called
 	m.UpdatePluginStatus("p2", &Status{State: StateErr})
 	currentStatus = m.PluginStatus()
-	if len(currentStatus) != 2 || currentStatus["p1"].State != StateOK || currentStatus["p2"].State != StateErr {
+	if len(currentStatus) != 2 || currentStatus["p1"].State != StateOK || currentStatus["p1"].Message != "foo" || currentStatus["p2"].State != StateErr {
 		t.Fatalf("Unexpected current plugin status, got: %+v", currentStatus)
 	}
 	if !reflect.DeepEqual(currentStatus, l2Status) {
@@ -82,7 +82,7 @@ func TestManagerPluginStatusListener(t *testing.T) {
 	// Ensure updates can still be sent with no listeners
 	m.UpdatePluginStatus("p2", &Status{State: StateOK})
 	currentStatus = m.PluginStatus()
-	if len(currentStatus) != 2 || currentStatus["p1"].State != StateOK || currentStatus["p2"].State != StateOK {
+	if len(currentStatus) != 2 || currentStatus["p1"].State != StateOK || currentStatus["p1"].Message != "foo" || currentStatus["p2"].State != StateOK {
 		t.Fatalf("Unexpected current plugin status, got: %+v", currentStatus)
 	}
 }


### PR DESCRIPTION
The WARN state can be used to signal admins that a plugin is in a
potentially dangerous or degraded state. The optional message may be
used to provide context about the warning.

Fixes #2932

Signed-off-by: Grant Shively <gshively@godaddy.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
