### PR TITLE
wasm: fix some string-handling issues in regex/glob matching

### DIFF
--- a/internal/wasm/sdk/internal/wasm/bindings.go
+++ b/internal/wasm/sdk/internal/wasm/bindings.go
@@ -6,6 +6,7 @@ package wasm
 
 // #include <stdlib.h>
 //
+// extern void opa_println(void *context, int32_t addr);
 // extern void opa_abort(void *context, int32_t addr);
 // extern int32_t opa_builtin0(void *context, int32_t builtin_id, int32_t ctx);
 // extern int32_t opa_builtin1(void *context, int32_t builtin_id, int32_t ctx, int32_t arg0);
@@ -21,7 +22,12 @@ import (
 )
 
 func opaFunctions(imports *wasm.Imports) (*wasm.Imports, error) {
-	imports, err := imports.AppendFunction("opa_abort", opa_abort, C.opa_abort)
+	imports, err := imports.AppendFunction("opa_println", opa_println, C.opa_println)
+	if err != nil {
+		return nil, err
+	}
+
+	imports, err = imports.AppendFunction("opa_abort", opa_abort, C.opa_abort)
 	if err != nil {
 		return nil, err
 	}
@@ -47,6 +53,11 @@ func opaFunctions(imports *wasm.Imports) (*wasm.Imports, error) {
 	}
 
 	return imports.AppendFunction("opa_builtin4", opa_builtin4, C.opa_builtin4)
+}
+
+//export opa_println
+func opa_println(ctx unsafe.Pointer, addr int32) {
+	getVM(ctx).Println(addr)
 }
 
 //export opa_abort

--- a/internal/wasm/sdk/internal/wasm/vm.go
+++ b/internal/wasm/sdk/internal/wasm/vm.go
@@ -378,7 +378,18 @@ func (i *VM) Abort(arg int32) {
 		panic("invalid abort argument")
 	}
 
-	panic(abortError{message: string(data[0:n])})
+	panic(abortError{message: string(data[:n])})
+}
+
+// Println is invoked if the policy WASM code calls opa_println().
+func (i *VM) Println(arg int32) {
+	data := i.memory.Data()[arg:]
+	n := bytes.IndexByte(data, 0)
+	if n == -1 {
+		panic("invalid opa_println argument")
+	}
+
+	fmt.Printf("opa_println(): %s\n", string(data[:n]))
 }
 
 type builtinError struct {

--- a/wasm/src/glob.cc
+++ b/wasm/src/glob.cc
@@ -81,7 +81,7 @@ opa_value *opa_glob_match(opa_value *pattern, opa_value *delimiters, opa_value *
     {
         re2 = i->second;
     } else {
-        std::string error = glob_translate(opa_cast_string(pattern)->v, opa_cast_string(pattern)->len, v, &re2);
+        std::string error = glob_translate(p->v, p->len, v, &re2);
         if (!error.empty())
         {
             return NULL;

--- a/wasm/src/regex.cc
+++ b/wasm/src/regex.cc
@@ -16,8 +16,9 @@ opa_value *opa_regex_is_valid(opa_value *pattern)
         return opa_boolean(false);
     }
 
+    std::string pat(opa_cast_string(pattern)->v, opa_cast_string(pattern)->len);
     re2::RE2::Options options;
-    re2::RE2 re(opa_cast_string(pattern)->v, options);
+    re2::RE2 re(pat, options);
     return opa_boolean(re.ok());
 }
 
@@ -67,15 +68,17 @@ opa_value *opa_regex_match(opa_value *pattern, opa_value *value)
     {
         return NULL;
     }
-
-    re2::RE2* re = compile(opa_cast_string(pattern)->v);
+    std::string pat(opa_cast_string(pattern)->v, opa_cast_string(pattern)->len);
+    re2::RE2* re = compile(pat.c_str());
     if (re == NULL)
     {
         // TODO: return an error.
         return NULL;
     }
 
-    bool match = re2::RE2::PartialMatch(opa_cast_string(value)->v, *re);
+    std::string v(opa_cast_string(value)->v, opa_cast_string(value)->len);
+    bool match = re2::RE2::PartialMatch(v, *re);
+
     reuse(re);
     return opa_boolean(match);
 }
@@ -93,7 +96,8 @@ opa_value *opa_regex_find_all_string_submatch(opa_value *pattern, opa_value *val
         return NULL;
     }
 
-    re2::RE2* re = compile(opa_cast_string(pattern)->v);
+    std::string pat(opa_cast_string(pattern)->v, opa_cast_string(pattern)->len);
+    re2::RE2* re = compile(pat.c_str());
     if (re == NULL)
     {
         // TODO: return an error.


### PR DESCRIPTION
Before, the opa_string_t's *char was used as-is; disregarding its length.
With certain inputs in consequent evaluations, this would end up using old
characters from a previous evaluation.

For example, evaluation

    regex.match("^world$", input.message)

with input.message going through the sequence

    "no-world"
    "world"

would end up running the RE2 PartialMatch against the values

    "no-world"
    "worldrld"

and the second evaluation would thus wrongly fail.

Since glob.match is using regex.match underneath, it would show a similar
behaviour, as noted in #2962

Fixes #2962.

In the same spirit, changed some string usages in regex.is_valid and regex.find_all_string_submatch_n.

⚠️ I'm by no means an expert in C++, please review carefully. Any advise is appreciated, of course! 😃 

Also provides an `opa_println` function for the WASM SDK... While that function is not used usually, with this change, it **can** be used for debugging purposes during development.