### PR TITLE
topdown: Remove unnecessary allocations for binding undos

### DIFF
--- a/topdown/bindings.go
+++ b/topdown/bindings.go
@@ -12,9 +12,8 @@ import (
 )
 
 type undo struct {
-	k    *ast.Term
-	u    *bindings
-	next *undo
+	k *ast.Term
+	u *bindings
 }
 
 func (u *undo) Undo() {
@@ -27,7 +26,6 @@ func (u *undo) Undo() {
 		return
 	}
 	u.u.delete(u.k)
-	u.next.Undo()
 }
 
 type bindings struct {
@@ -123,12 +121,13 @@ func (u *bindings) plugNamespaced(a *ast.Term, caller *bindings) *ast.Term {
 	return a
 }
 
-func (u *bindings) bind(a *ast.Term, b *ast.Term, other *bindings) *undo {
+func (u *bindings) bind(a *ast.Term, b *ast.Term, other *bindings, und *undo) {
 	u.values.Put(a, value{
 		u: other,
 		v: b,
 	})
-	return &undo{a, u, nil}
+	und.k = a
+	und.u = u
 }
 
 func (u *bindings) apply(a *ast.Term) (*ast.Term, *bindings) {

--- a/topdown/eval.go
+++ b/topdown/eval.go
@@ -800,21 +800,23 @@ func (e *eval) biunifyValues(a, b *ast.Term, b1, b2 *bindings, iter unifyIterato
 	_, varA := a.Value.(ast.Var)
 	_, varB := b.Value.(ast.Var)
 
+	var undo undo
+
 	if varA && varB {
 		if b1 == b2 && a.Equal(b) {
 			return iter()
 		}
-		undo := b1.bind(a, b, b2)
+		b1.bind(a, b, b2, &undo)
 		err := iter()
 		undo.Undo()
 		return err
 	} else if varA && !varB {
-		undo := b1.bind(a, b, b2)
+		b1.bind(a, b, b2, &undo)
 		err := iter()
 		undo.Undo()
 		return err
 	} else if varB && !varA {
-		undo := b2.bind(b, a, b1)
+		b2.bind(b, a, b1, &undo)
 		err := iter()
 		undo.Undo()
 		return err


### PR DESCRIPTION
The undo was being allocated on the heap unnecessarily. Removing the
heap allocation provides a slight speedup.

$ benchstat /tmp/old.txt /tmp/new.txt
name                      old time/op  new time/op  delta
ArrayIteration/10-20      24.7µs ± 1%  24.0µs ± 1%  -2.49%  (p=0.008n=5+5)
ArrayIteration/100-20      125µs ± 1%   122µs ± 1%  -2.88%  (p=0.008n=5+5)
ArrayIteration/1000-20    1.15ms ± 1%  1.12ms ± 1%  -2.66%  (p=0.008n=5+5)
ArrayIteration/10000-20   11.9ms ± 2%  11.6ms ± 1%  -2.52%  (p=0.008n=5+5)
SetIteration/10-20        28.3µs ± 1%  27.8µs ± 1%  -1.73%  (p=0.008n=5+5)
SetIteration/100-20        157µs ± 1%   154µs ± 1%  -1.81%  (p=0.008n=5+5)
SetIteration/1000-20      1.47ms ± 1%  1.44ms ± 1%  -2.00%  (p=0.008n=5+5)
SetIteration/10000-20     15.8ms ± 1%  16.0ms ± 4%    ~     (p=0.690n=5+5)
ObjectIteration/10-20     27.9µs ± 1%  27.8µs ± 1%    ~     (p=0.222n=5+5)
ObjectIteration/100-20     155µs ± 1%   152µs ± 1%  -1.96%  (p=0.016n=5+5)
ObjectIteration/1000-20   1.46ms ± 1%  1.44ms ± 1%  -1.73%  (p=0.008n=5+5)
ObjectIteration/10000-20  15.6ms ± 1%  15.2ms ± 2%  -2.50%  (p=0.016n=5+5)

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
