### PR TITLE
server: pass instrumentation via rego.EvalInstrument

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1228,6 +1228,7 @@ func (s *Server) v1DataGet(w http.ResponseWriter, r *http.Request) {
 		rego.EvalMetrics(m),
 		rego.EvalQueryTracer(buf),
 		rego.EvalInterQueryBuiltinCache(s.interQueryBuiltinCache),
+		rego.EvalInstrument(includeInstrumentation),
 	}
 
 	rs, err := preparedQuery.Eval(
@@ -1434,6 +1435,7 @@ func (s *Server) v1DataPost(w http.ResponseWriter, r *http.Request) {
 		rego.EvalMetrics(m),
 		rego.EvalQueryTracer(buf),
 		rego.EvalInterQueryBuiltinCache(s.interQueryBuiltinCache),
+		rego.EvalInstrument(includeInstrumentation),
 	}
 
 	rs, err := preparedQuery.Eval(

--- a/test/e2e/authz/authz_bench_integration_test.go
+++ b/test/e2e/authz/authz_bench_integration_test.go
@@ -102,6 +102,7 @@ func runAuthzBenchmark(b *testing.B, mode testAuthz.InputMode, numPaths int) {
 		if err != nil {
 			b.Fatalf("unexpected error reading response body: %s", err)
 		}
+		resp.Close()
 
 		parsedBody := struct {
 			Result bool `json:"result"`

--- a/test/e2e/logs/remote/remote_decision_logger_benchmark_test.go
+++ b/test/e2e/logs/remote/remote_decision_logger_benchmark_test.go
@@ -115,6 +115,7 @@ func runAuthzBenchmark(b *testing.B, mode testAuthz.InputMode, numPaths int) {
 		if err != nil {
 			b.Fatalf("unexpected error reading response body: %s", err)
 		}
+		resp.Close()
 
 		parsedBody := struct {
 			Result bool `json:"result"`

--- a/test/e2e/metrics/metrics_test.go
+++ b/test/e2e/metrics/metrics_test.go
@@ -75,3 +75,117 @@ func TestMetricsEndpoint(t *testing.T) {
 		}
 	}
 }
+
+type response struct {
+	Result  bool                   `json:"result"`
+	Metrics map[string]interface{} `json:"metrics"`
+}
+
+func TestRequestWithInstrumentationV1DataAPI(t *testing.T) {
+
+	policy := `
+	package test
+	p = true
+	q = true
+	`
+
+	err := testRuntime.UploadPolicy(t.Name(), strings.NewReader(policy))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var resp response
+	if err := testRuntime.GetDataWithInputTyped("test/p?instrument", nil, &resp); err != nil {
+		t.Fatal(err)
+	}
+
+	if !resp.Result {
+		t.Fatalf("Unexpected response: %+v", resp)
+	}
+
+	assertInstrumentationMetricsInMap(t, true, resp.Metrics)
+
+	// run another request, this should re-use the compiled query
+	var resp2 response
+	if err := testRuntime.GetDataWithInputTyped("test/p?instrument", nil, &resp2); err != nil {
+		t.Fatal(err)
+	}
+
+	if !resp2.Result {
+		t.Fatalf("Unexpected response: %+v", resp2)
+	}
+
+	assertInstrumentationMetricsInMap(t, false, resp2.Metrics)
+
+	// GET data endpoint
+	var resp3 response
+	if err := testRuntime.GetDataWithInputTyped("test/q?instrument", nil, &resp3); err != nil {
+		t.Fatal(err)
+	}
+
+	if !resp.Result {
+		t.Fatalf("Unexpected response: %+v", resp3)
+	}
+
+	assertInstrumentationMetricsInMap(t, true, resp3.Metrics)
+
+	// 2nd GET data endpoint
+	var resp4 response
+	if err := testRuntime.GetDataWithInputTyped("test/q?instrument", nil, &resp4); err != nil {
+		t.Fatal(err)
+	}
+
+	if !resp.Result {
+		t.Fatalf("Unexpected response: %+v", resp4)
+	}
+
+	assertInstrumentationMetricsInMap(t, false, resp4.Metrics)
+}
+
+func assertInstrumentationMetricsInMap(t *testing.T, includeCompile bool, metrics map[string]interface{}) {
+	expectedKeys := []string{
+		"counter_server_query_cache_hit",
+		"counter_eval_op_virtual_cache_miss",
+		"histogram_eval_op_plug",
+		"timer_eval_op_plug_ns",
+		"timer_rego_input_parse_ns",
+		"timer_rego_query_eval_ns",
+		"timer_server_handler_ns",
+	}
+	compileStageKeys := []string{
+		"timer_rego_query_parse_ns",
+		"timer_rego_query_compile_ns",
+		"timer_query_compile_stage_build_comprehension_index_ns",
+		"timer_query_compile_stage_check_safety_ns",
+		"timer_query_compile_stage_check_types_ns",
+		"timer_query_compile_stage_check_undefined_funcs_ns",
+		"timer_query_compile_stage_check_unsafe_builtins_ns",
+		"timer_query_compile_stage_resolve_refs_ns",
+		"timer_query_compile_stage_rewrite_comprehension_terms_ns",
+		"timer_query_compile_stage_rewrite_dynamic_terms_ns",
+		"timer_query_compile_stage_rewrite_expr_terms_ns",
+		"timer_query_compile_stage_rewrite_local_vars_ns",
+		"timer_query_compile_stage_rewrite_to_capture_value_ns",
+		"timer_query_compile_stage_rewrite_with_values_ns",
+	}
+
+	if includeCompile {
+		expectedKeys = append(expectedKeys, compileStageKeys...)
+	}
+
+	for _, key := range expectedKeys {
+		if metrics[key] == nil {
+			t.Errorf("Expected to find key %q in metrics response", key)
+		}
+	}
+	if !includeCompile {
+		for _, key := range compileStageKeys {
+			if metrics[key] != nil {
+				t.Errorf("Expected NOT to find key %q in metrics response", key)
+			}
+		}
+	}
+	if t.Failed() {
+		t.Logf("metrics response: %v\n", metrics)
+	}
+}

--- a/test/e2e/wasm/authz/authz_bench_integration_test.go
+++ b/test/e2e/wasm/authz/authz_bench_integration_test.go
@@ -155,6 +155,7 @@ func runAuthzBenchmark(b *testing.B, mode testAuthz.InputMode, numPaths int) {
 		if err != nil {
 			b.Fatalf("unexpected error reading response body: %s", err)
 		}
+		resp.Close()
 
 		parsedBody := struct {
 			Result bool `json:"result"`


### PR DESCRIPTION
Fixes #3000.

The assertions on the response metrics object should be enough to
cover the bug -- depending on what is happening during eval, the
keys of that object may differ. (E.g. if there's a ref to be resolved,
that operation is timed; if there are none, there's no timer data.)

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
