### PR TITLE
cmd/build: don't package policy.wasm twice

### DIFF
--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -18,15 +18,13 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/open-policy-agent/opa/format"
-
-	"github.com/open-policy-agent/opa/internal/file/archive"
-	"github.com/open-policy-agent/opa/internal/merge"
-	"github.com/open-policy-agent/opa/metrics"
-
 	"github.com/pkg/errors"
 
 	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/format"
+	"github.com/open-policy-agent/opa/internal/file/archive"
+	"github.com/open-policy-agent/opa/internal/merge"
+	"github.com/open-policy-agent/opa/metrics"
 	"github.com/open-policy-agent/opa/util"
 )
 

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -12,11 +12,10 @@ import (
 	"os"
 	"strings"
 
-	"github.com/open-policy-agent/opa/ast"
-	"github.com/open-policy-agent/opa/bundle"
-
 	"github.com/spf13/cobra"
 
+	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/bundle"
 	"github.com/open-policy-agent/opa/compile"
 	"github.com/open-policy-agent/opa/util"
 )

--- a/compile/compile.go
+++ b/compile/compile.go
@@ -454,8 +454,6 @@ func (c *Compiler) compileWasm(ctx context.Context) error {
 		return err
 	}
 
-	c.bundle.Wasm = buf.Bytes()
-
 	modulePath := bundle.WasmFile
 
 	c.bundle.WasmModules = []bundle.WasmModuleFile{{

--- a/compile/compile_test.go
+++ b/compile/compile_test.go
@@ -447,6 +447,10 @@ func TestCompilerWasmTarget(t *testing.T) {
 			t.Fatal("expected to find compiled wasm module")
 		}
 
+		if len(compiler.bundle.Wasm) != 0 {
+			t.Error("expected NOT to find deprecated bundle `Wasm` value")
+		}
+
 		ensureEntrypointRemoved(t, compiler.bundle, "test/p")
 	})
 }


### PR DESCRIPTION
We had still been using the deprecated field, _and_ added a WasmModule
to the bundle, leading to two bundle file entries.

Fixes #3007.
