### PR TITLE
build: set time stamps on file entries

### DIFF
--- a/internal/file/archive/tarball.go
+++ b/internal/file/archive/tarball.go
@@ -5,7 +5,24 @@ import (
 	"bytes"
 	"compress/gzip"
 	"strings"
+	"time"
 )
+
+// Writer allows writing file entries into a tarball.
+type Writer struct {
+	tw      *tar.Writer
+	modTime time.Time
+}
+
+// New returns a Writer for writing tar file entries into the passed
+// tar.Writer. All the file headers will have a mod time equal to the
+// time New() was called.
+func New(tw *tar.Writer) *Writer {
+	return &Writer{
+		tw:      tw,
+		modTime: time.Now(),
+	}
+}
 
 // MustWriteTarGz write the list of file names and content
 // into a tarball.
@@ -14,9 +31,10 @@ func MustWriteTarGz(files [][2]string) *bytes.Buffer {
 	gw := gzip.NewWriter(&buf)
 	defer gw.Close()
 	tw := tar.NewWriter(gw)
+	ar := New(tw)
 	defer tw.Close()
 	for _, file := range files {
-		if err := WriteFile(tw, file[0], []byte(file[1])); err != nil {
+		if err := ar.WriteFile(file[0], []byte(file[1])); err != nil {
 			panic(err)
 		}
 	}
@@ -24,19 +42,20 @@ func MustWriteTarGz(files [][2]string) *bytes.Buffer {
 }
 
 // WriteFile adds a file header with content to the given tar writer
-func WriteFile(tw *tar.Writer, path string, bs []byte) error {
+func (ar *Writer) WriteFile(path string, bs []byte) error {
 
 	hdr := &tar.Header{
 		Name:     "/" + strings.TrimLeft(path, "/"),
 		Mode:     0600,
 		Typeflag: tar.TypeReg,
 		Size:     int64(len(bs)),
+		ModTime:  ar.modTime,
 	}
 
-	if err := tw.WriteHeader(hdr); err != nil {
+	if err := ar.tw.WriteHeader(hdr); err != nil {
 		return err
 	}
 
-	_, err := tw.Write(bs)
+	_, err := ar.tw.Write(bs)
 	return err
 }


### PR DESCRIPTION
Fixes #3013. No frills, just the time we've started writing to the archive. All files will have the same timestamp.

    $ ../opa_darwin_amd64 build -t wasm -e data.foo.q foo.rego
    $ tar tzvf bundle.tar.gz
    tar: Removing leading `/' from member names
    -rw------- 0/0               3 2020-12-17 13:20 /data.json
    -rw------- 0/0              77 2020-12-17 13:20 /foo.rego
    -rw------- 0/0          556855 2020-12-17 13:20 /policy.wasm
    -rw------- 0/0              90 2020-12-17 13:20 /.manifest
    $ ls -al bundle.tar.gz
    -rw-r--r-- 1 stephan staff 174267 Dec 17 13:20 bundle.tar.gz
