### PR TITLE
Fix const types in internal/jwx/jwk/key_ops.go and repl/repl.go

### DIFF
--- a/internal/jwx/jwk/key_ops.go
+++ b/internal/jwx/jwk/key_ops.go
@@ -30,13 +30,13 @@ var keyOps = map[string]struct{}{"sign": {}, "verify": {}, "encrypt": {}, "decry
 // KeyOperation constants
 const (
 	KeyOpSign       KeyOperation = "sign"       // (compute digital signature or MAC)
-	KeyOpVerify                  = "verify"     // (verify digital signature or MAC)
-	KeyOpEncrypt                 = "encrypt"    // (encrypt content)
-	KeyOpDecrypt                 = "decrypt"    // (decrypt content and validate decryption, if applicable)
-	KeyOpWrapKey                 = "wrapKey"    // (encrypt key)
-	KeyOpUnwrapKey               = "unwrapKey"  // (decrypt key and validate decryption, if applicable)
-	KeyOpDeriveKey               = "deriveKey"  // (derive key)
-	KeyOpDeriveBits              = "deriveBits" // (derive bits not to be used as a key)
+	KeyOpVerify     KeyOperation = "verify"     // (verify digital signature or MAC)
+	KeyOpEncrypt    KeyOperation = "encrypt"    // (encrypt content)
+	KeyOpDecrypt    KeyOperation = "decrypt"    // (decrypt content and validate decryption, if applicable)
+	KeyOpWrapKey    KeyOperation = "wrapKey"    // (encrypt key)
+	KeyOpUnwrapKey  KeyOperation = "unwrapKey"  // (decrypt key and validate decryption, if applicable)
+	KeyOpDeriveKey  KeyOperation = "deriveKey"  // (derive key)
+	KeyOpDeriveBits KeyOperation = "deriveBits" // (derive bits not to be used as a key)
 )
 
 // Accept determines if Key Operation is valid

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -69,9 +69,9 @@ type explainMode string
 
 const (
 	explainOff   explainMode = "off"
-	explainFull              = "full"
-	explainNotes             = "notes"
-	explainFails             = "fails"
+	explainFull  explainMode = "full"
+	explainNotes explainMode = "notes"
+	explainFails explainMode = "fails"
 )
 
 const defaultPrettyLimit = 80


### PR DESCRIPTION
This was flagged by staticcheck, reported in #3020.

See also https://staticcheck.io/docs/checks#SA9004