### PR TITLE
Require signature only when signer configured

### DIFF
--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -535,7 +535,7 @@ func (r *Reader) checkSignaturesAndDescriptors(signatures SignaturesConfig) erro
 		return nil
 	}
 
-	if signatures.isEmpty() && r.verificationConfig != nil {
+	if signatures.isEmpty() && r.verificationConfig != nil && r.verificationConfig.KeyID != "" {
 		return fmt.Errorf("bundle missing .signatures.json file")
 	}
 

--- a/bundle/bundle_test.go
+++ b/bundle/bundle_test.go
@@ -228,9 +228,14 @@ func TestReadWithSignatures(t *testing.T) {
 			nil,
 			true, fmt.Errorf("verification key not provided"),
 		},
-		"no_signatures_file": {
+		"no_signatures_file_no_keyid": {
 			[][2]string{{"/.manifest", `{"revision": "quickbrownfaux"}`}},
 			NewVerificationConfig(map[string]*KeyConfig{}, "", "", nil),
+			false, nil,
+		},
+		"no_signatures_file": {
+			[][2]string{{"/.manifest", `{"revision": "quickbrownfaux"}`}},
+			NewVerificationConfig(map[string]*KeyConfig{}, "somekey", "", nil),
 			true, fmt.Errorf("bundle missing .signatures.json file"),
 		},
 		"no_signatures": {


### PR DESCRIPTION
As the docs state, signature verification should only be triggered if a keyid is present in the signing block of a bundle configuration. This was not actually the case though as merely the presence of keys in the config would force signatur verification, even if not referenced by the bundle configuration.

Fixes #3028

Signed-off-by: Anders Eknert <anders@eknert.com>