### PR TITLE
wasm: fix "else-conflict 2"

### DIFF
--- a/internal/compiler/wasm/wasm.go
+++ b/internal/compiler/wasm/wasm.go
@@ -778,6 +778,9 @@ func (c *Compiler) compileBlock(block *ir.Block) ([]instruction.Instruction, err
 			instrs = append(instrs, instruction.I32Const{Value: 0})
 			instrs = append(instrs, instruction.I32Ne{})
 			instrs = append(instrs, instruction.BrIf{Index: 0})
+		case *ir.ResetLocalStmt:
+			instrs = append(instrs, instruction.I32Const{Value: 0})
+			instrs = append(instrs, instruction.SetLocal{Index: c.local(stmt.Target)})
 		case *ir.IsDefinedStmt:
 			instrs = append(instrs, instruction.GetLocal{Index: c.local(stmt.Source)})
 			instrs = append(instrs, instruction.I32Eqz{})

--- a/internal/compiler/wasm/wasm.go
+++ b/internal/compiler/wasm/wasm.go
@@ -664,6 +664,8 @@ func (c *Compiler) compileBlock(block *ir.Block) ([]instruction.Instruction, err
 			if err := c.compileScan(stmt, &instrs); err != nil {
 				return nil, err
 			}
+		case *ir.NopStmt:
+			instrs = append(instrs, instruction.Nop{})
 		case *ir.NotStmt:
 			if err := c.compileNot(stmt, &instrs); err != nil {
 				return nil, err

--- a/internal/ir/ir.go
+++ b/internal/ir/ir.go
@@ -476,6 +476,11 @@ type WithStmt struct {
 	Location
 }
 
+// NopStmt adds a nop instruction. Useful during development and debugging only.
+type NopStmt struct {
+	Location
+}
+
 // ResultSetAdd adds a value into the result set returned by the query plan.
 type ResultSetAdd struct {
 	Value Local

--- a/internal/ir/ir.go
+++ b/internal/ir/ir.go
@@ -267,6 +267,13 @@ type AssignVarOnceStmt struct {
 	Location
 }
 
+// ResetLocalStmt resets a local variable to 0.
+type ResetLocalStmt struct {
+	Target Local
+
+	Location
+}
+
 // MakeStringStmt constructs a local variable that refers to a string constant.
 type MakeStringStmt struct {
 	Index  int

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -266,7 +266,7 @@ func (p *Planner) planRules(rules []*ast.Rule) (string, error) {
 					switch rule.Head.DocKind() {
 					case ast.CompleteDoc:
 						return p.planTerm(rule.Head.Value, func() error {
-							p.appendStmt(&ir.AssignVarStmt{
+							p.appendStmt(&ir.AssignVarOnceStmt{
 								Target: lresult,
 								Source: p.ltarget,
 							})

--- a/internal/planner/planner_test.go
+++ b/internal/planner/planner_test.go
@@ -260,6 +260,41 @@ func TestPlannerHelloWorld(t *testing.T) {
 				}`,
 			},
 		},
+		{
+			note:    "multiple function outputs (single)",
+			queries: []string{`data.p.r`},
+			modules: []string{
+				`package p
+
+				p(a) = y {
+				  y = a[_]
+				}
+
+				r = y {
+				  data.p.p([1, 2, 3], y)
+				}
+				`,
+			},
+		},
+		{
+			note:    "multiple function outputs (multiple)",
+			queries: []string{`data.p.r`},
+			modules: []string{
+				`package p
+
+				p(1, a) = y {
+					y = a
+				}
+				p(x, y) = z {
+					z = x
+				}
+
+				r = y {
+					data.p.p(1, 0, y)
+				}
+				`,
+			},
+		},
 	}
 
 	for _, tc := range tests {

--- a/internal/wasm/sdk/opa/opa_test.go
+++ b/internal/wasm/sdk/opa/opa_test.go
@@ -121,6 +121,39 @@ a = "c" { input > 2 }`,
 			},
 			WantErr: "module.rego:3:1: var assignment conflict: internal error",
 		},
+		{
+			Description: "Runtime error/else conflict-1",
+			Query:       `data.p.q`,
+			Policy: `
+				q {
+					false
+				}
+				else = true {
+					true
+				}
+				q = false`,
+			Evals:   []Eval{{}},
+			WantErr: "module.rego:9:5: var assignment conflict: internal error",
+		},
+		{
+			Description: "Runtime error/else conflict-2",
+			Query:       `data.p.q`,
+			Policy: `
+				q {
+					false
+				}
+				else = false {
+					true
+				}
+				q {
+					false
+				}
+				else = true {
+					true
+				}`,
+			Evals:   []Eval{{}},
+			WantErr: "module.rego:12:5: var assignment conflict: internal error",
+		},
 		// NOTE(sr): The next two test cases were used to replicate issue
 		// https://github.com/open-policy-agent/opa/issues/2962 -- their raison d'être
 		// is thus questionable, but it might be good to keep them around a bit.

--- a/internal/wasm/sdk/test/e2e/exceptions.yaml
+++ b/internal/wasm/sdk/test/e2e/exceptions.yaml
@@ -1,4 +1,3 @@
 # Exception Format is <test name>: <reason>
 "jsonpatch/set": "unexpected panic or evaluation error - https://github.com/open-policy-agent/opa/issues/2949"
 "jsonpatch/json_patch_tests": "unexpected panic or evaluation error - https://github.com/open-policy-agent/opa/issues/2949"
-"elsekeyword/conflict-2": "expected error missing - https://github.com/open-policy-agent/opa/issues/2954"

--- a/internal/wasm/sdk/test/e2e/external_test.go
+++ b/internal/wasm/sdk/test/e2e/external_test.go
@@ -131,19 +131,13 @@ func assert(t *testing.T, tc cases.TestCase, result *opa.Result, err error) {
 			return
 		}
 		if err == nil {
+			if result != nil {
+				t.Fatalf("expected error, got result %s", result.Result)
+			}
 			t.Fatal("expected error")
 		}
 
-		// TODO: implement more specific error checking, for now log results and skip the test
-		if tc.WantErrorCode != nil {
-			t.Logf("\nExpected Code: %s\nGot Err: %s\n", *tc.WantErrorCode, err)
-		}
-
-		if tc.WantError != nil {
-			t.Logf("\nExpected Err: %s\nGot Err: %s\n", *tc.WantError, err)
-		}
-
-		t.Skip("Skipping test case: Error validation not supported")
+		assertErrorCode(t, *tc.WantErrorCode, err)
 	}
 }
 
@@ -204,7 +198,19 @@ func assertResultSet(t *testing.T, want []map[string]interface{}, sortBindings b
 	if !a.Equal(b) {
 		t.Fatalf("expected %v but got %v", a, b)
 	}
+}
 
+func assertErrorCode(t *testing.T, expected string, actual error) {
+	t.Helper()
+	switch expected {
+	case "eval_conflict_error":
+		exp := "var assignment conflict"
+		if !strings.Contains(actual.Error(), exp) {
+			t.Errorf("expected %q to contain %q", actual, exp)
+		}
+	default:
+		t.Errorf("unmatched error: %v (expected %s)", actual, expected)
+	}
 }
 
 func toAST(a interface{}) *ast.Term {

--- a/internal/wasm/sdk/test/e2e/external_test.go
+++ b/internal/wasm/sdk/test/e2e/external_test.go
@@ -204,9 +204,16 @@ func assertErrorCode(t *testing.T, expected string, actual error) {
 	t.Helper()
 	switch expected {
 	case "eval_conflict_error":
-		exp := "var assignment conflict"
-		if !strings.Contains(actual.Error(), exp) {
-			t.Errorf("expected %q to contain %q", actual, exp)
+		exps := []string{"var assignment conflict", "object insert conflict"}
+		found := false
+		for _, exp := range exps {
+			if strings.Contains(actual.Error(), exp) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected %q to contain one of %v", actual, exps)
 		}
 	default:
 		t.Errorf("unmatched error: %v (expected %s)", actual, expected)

--- a/test/cases/testdata/functionerrors/test-functionerrors-1012.yaml
+++ b/test/cases/testdata/functionerrors/test-functionerrors-1012.yaml
@@ -1,131 +1,15 @@
 cases:
 - data:
-    a:
-    - 1
-    - 2
-    - 3
-    - 4
-    b:
-      v1: hello
-      v2: goodbye
-    c:
-    - x:
-      - true
-      - false
-      - foo
-      "y":
-      - null
-      - 3.14159
-      z:
-        p: true
-        q: false
-    d:
-      e:
-      - bar
-      - baz
-    f:
-    - xs:
-      - 1
-      ys:
-      - 2
-    - xs:
-      - 2
-      ys:
-      - 3
-    g:
-      a:
-      - 1
-      - 0
-      - 0
-      - 0
-      b:
-      - 0
-      - 2
-      - 0
-      - 0
-      c:
-      - 0
-      - 0
-      - 0
-      - 4
-    h:
-    - - 1
-      - 2
-      - 3
-    - - 2
-      - 3
-      - 4
-    l:
-    - a: bob
-      b: -1
-      c:
-      - 1
-      - 2
-      - 3
-      - 4
-    - a: alice
-      b: 1
-      c:
-      - 2
-      - 3
-      - 4
-      - 5
-      d: null
-    m: []
-    numbers:
-    - "1"
-    - "2"
-    - "3"
-    - "4"
-    strings:
-      bar: 2
-      baz: 3
-      foo: 1
-    three: 3
   modules:
   - |
     package test1
 
-    p(__local0__) = y {
-      y = __local0__[_]
+    p(a) = y {
+      y = a[_]
     }
 
     r = y {
       data.test1.p([1, 2, 3], y)
-    }
-  - |
-    package test2
-
-    p(1, __local1__) = y {
-      y = __local1__
-    }
-
-    p(2, __local2__) = y {
-      __local7__ = __local2__ + 1
-      y = __local7__
-    }
-
-    r = y {
-      data.test2.p(3, 0, y)
-    }
-  - |
-    package test3
-
-    p(1, __local3__) = y {
-      y = __local3__
-    }
-
-    p(2, __local4__) = y {
-      __local8__ = __local4__ + 1
-      y = __local8__
-    }
-
-    p(__local5__, __local6__) = z {
-      z = __local5__
-    }
-
-    r = y {
-      data.test3.p(1, 0, y)
     }
   note: functionerrors/function output conflict single
   query: data.test1.r = x

--- a/test/cases/testdata/functionerrors/test-functionerrors-1013.yaml
+++ b/test/cases/testdata/functionerrors/test-functionerrors-1013.yaml
@@ -1,127 +1,15 @@
 cases:
 - data:
-    a:
-    - 1
-    - 2
-    - 3
-    - 4
-    b:
-      v1: hello
-      v2: goodbye
-    c:
-    - x:
-      - true
-      - false
-      - foo
-      "y":
-      - null
-      - 3.14159
-      z:
-        p: true
-        q: false
-    d:
-      e:
-      - bar
-      - baz
-    f:
-    - xs:
-      - 1
-      ys:
-      - 2
-    - xs:
-      - 2
-      ys:
-      - 3
-    g:
-      a:
-      - 1
-      - 0
-      - 0
-      - 0
-      b:
-      - 0
-      - 2
-      - 0
-      - 0
-      c:
-      - 0
-      - 0
-      - 0
-      - 4
-    h:
-    - - 1
-      - 2
-      - 3
-    - - 2
-      - 3
-      - 4
-    l:
-    - a: bob
-      b: -1
-      c:
-      - 1
-      - 2
-      - 3
-      - 4
-    - a: alice
-      b: 1
-      c:
-      - 2
-      - 3
-      - 4
-      - 5
-      d: null
-    m: []
-    numbers:
-    - "1"
-    - "2"
-    - "3"
-    - "4"
-    strings:
-      bar: 2
-      baz: 3
-      foo: 1
-    three: 3
   modules:
-  - |
-    package test3
-
-    p(1, __local3__) = y {
-      y = __local3__
-    }
-
-    p(2, __local4__) = y {
-      __local8__ = __local4__ + 1
-      y = __local8__
-    }
-
-    p(__local5__, __local6__) = z {
-      z = __local5__
-    }
-
-    r = y {
-      data.test3.p(1, 0, y)
-    }
-  - |
-    package test1
-
-    p(__local0__) = y {
-      y = __local0__[_]
-    }
-
-    r = y {
-      data.test1.p([1, 2, 3], y)
-    }
   - |
     package test2
 
-    p(1, __local1__) = y {
-      y = __local1__
+    p(1, a) = y {
+      y = a
     }
 
-    p(2, __local2__) = y {
-      __local7__ = __local2__ + 1
-      y = __local7__
+    p(2, b) = y {
+      y = b + 1
     }
 
     r = y {

--- a/test/cases/testdata/functionerrors/test-functionerrors-1014.yaml
+++ b/test/cases/testdata/functionerrors/test-functionerrors-1014.yaml
@@ -1,131 +1,19 @@
 cases:
 - data:
-    a:
-    - 1
-    - 2
-    - 3
-    - 4
-    b:
-      v1: hello
-      v2: goodbye
-    c:
-    - x:
-      - true
-      - false
-      - foo
-      "y":
-      - null
-      - 3.14159
-      z:
-        p: true
-        q: false
-    d:
-      e:
-      - bar
-      - baz
-    f:
-    - xs:
-      - 1
-      ys:
-      - 2
-    - xs:
-      - 2
-      ys:
-      - 3
-    g:
-      a:
-      - 1
-      - 0
-      - 0
-      - 0
-      b:
-      - 0
-      - 2
-      - 0
-      - 0
-      c:
-      - 0
-      - 0
-      - 0
-      - 4
-    h:
-    - - 1
-      - 2
-      - 3
-    - - 2
-      - 3
-      - 4
-    l:
-    - a: bob
-      b: -1
-      c:
-      - 1
-      - 2
-      - 3
-      - 4
-    - a: alice
-      b: 1
-      c:
-      - 2
-      - 3
-      - 4
-      - 5
-      d: null
-    m: []
-    numbers:
-    - "1"
-    - "2"
-    - "3"
-    - "4"
-    strings:
-      bar: 2
-      baz: 3
-      foo: 1
-    three: 3
   modules:
   - |
     package test3
 
-    p(1, __local3__) = y {
-      y = __local3__
+    p(1, a) = y {
+      y = a
     }
 
-    p(2, __local4__) = y {
-      __local8__ = __local4__ + 1
-      y = __local8__
-    }
-
-    p(__local5__, __local6__) = z {
-      z = __local5__
+    p(x, y) = z {
+      z = x
     }
 
     r = y {
       data.test3.p(1, 0, y)
-    }
-  - |
-    package test1
-
-    p(__local0__) = y {
-      y = __local0__[_]
-    }
-
-    r = y {
-      data.test1.p([1, 2, 3], y)
-    }
-  - |
-    package test2
-
-    p(1, __local1__) = y {
-      y = __local1__
-    }
-
-    p(2, __local2__) = y {
-      __local7__ = __local2__ + 1
-      y = __local7__
-    }
-
-    r = y {
-      data.test2.p(3, 0, y)
     }
   note: functionerrors/function output conflict multiple
   query: data.test3.r = x


### PR DESCRIPTION
There are two kinds of else conflicts in the e2e tests, and one had been failing in WASM (i.e., it didn't fail when it should).

With this change to the planner, the underlying issue is resolved:

With multiple rule bodies for one rule like this, where r1 and r2 both fail,

- r1
  - else1
- r2
  - else2

previously, else1 and else2 checked if the output variable used for both r1 and r2 was defined, and didn't run it was.
Topdown, however, evaluates both else1 and else2, and checks that they have the same outcome.

The output variable checking in WASM would prohibit else2 from being run when the output variable was set by else1.

**Now**, each rule and its else branches use an output variable _different from the overall output_; and an extra block writing that output variable's value into the overall output variable of that rule. The extra layering allows each else block to check **its rule body's output**, and not the overall rule output.