### PR TITLE
Fix false positives in bundle root check

### DIFF
--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1330,7 +1330,7 @@ func TestBundleScope(t *testing.T) {
 
 	if err := bundle.WriteManifestToStore(ctx, f.server.store, txn, "test-bundle", bundle.Manifest{
 		Revision: "AAAAA",
-		Roots:    &[]string{"a/b/c", "x/y"},
+		Roots:    &[]string{"a/b/c", "x/y", "foobar"},
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -1366,6 +1366,12 @@ func TestBundleScope(t *testing.T) {
 			resp:   `{"code": "invalid_parameter", "message": "path a/b/c/d is owned by bundle \"test-bundle\""}`,
 		},
 		{
+			method: "PUT",
+			path:   "/data/a/b/d",
+			body:   "1",
+			code:   http.StatusNoContent,
+		},
+		{
 			method: "PATCH",
 			path:   "/data/a",
 			body:   `[{"path": "/b/c", "op": "add", "value": 1}]`,
@@ -1396,6 +1402,19 @@ func TestBundleScope(t *testing.T) {
 			path:   "/data/foo/bar",
 			body:   "1",
 			code:   http.StatusNoContent,
+		},
+		{
+			method: "PUT",
+			path:   "/data/foo",
+			body:   "1",
+			code:   http.StatusNoContent,
+		},
+		{
+			method: "PUT",
+			path:   "/data",
+			body:   `{"a": "b"}`,
+			code:   http.StatusBadRequest,
+			resp:   `{"code": "invalid_parameter", "message": "can't write to document root with bundle roots configured"}`,
 		},
 	}
 


### PR DESCRIPTION
Allow writing to /data/foo when /data/foobar is a bundle root.

Fixes #2868

Signed-off-by: Anders Eknert <anders@eknert.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
