### PR TITLE
cmd: Add support for benchmarking partial evaluation queries

### DIFF
--- a/cmd/eval.go
+++ b/cmd/eval.go
@@ -218,8 +218,6 @@ Set the output format with the --format flag.
 
 	// Eval specific flags
 	evalCommand.Flags().BoolVarP(&params.coverage, "coverage", "", false, "report coverage")
-	evalCommand.Flags().BoolVarP(&params.partial, "partial", "p", false, "perform partial evaluation")
-	evalCommand.Flags().StringArrayVarP(&params.unknowns, "unknowns", "u", []string{"input"}, "set paths to treat as unknown during partial evaluation")
 	evalCommand.Flags().StringArrayVarP(&params.disableInlining, "disable-inlining", "", []string{}, "set paths of documents to exclude from inlining")
 	evalCommand.Flags().BoolVarP(&params.shallowInlining, "shallow-inlining", "", false, "disable inlining of rules that depend on unknowns")
 	evalCommand.Flags().BoolVar(&params.disableIndexing, "disable-indexing", false, "disable indexing optimizations")
@@ -232,6 +230,8 @@ Set the output format with the --format flag.
 	evalCommand.Flags().BoolVarP(&params.failDefined, "fail-defined", "", false, "exits with non-zero exit code on defined/non-empty result and errors")
 
 	// Shared flags
+	addPartialFlag(evalCommand.Flags(), &params.partial, false)
+	addUnknownsFlag(evalCommand.Flags(), &params.unknowns, []string{"input"})
 	addFailFlag(evalCommand.Flags(), &params.fail, false)
 	addDataFlag(evalCommand.Flags(), &params.dataPaths)
 	addBundleFlag(evalCommand.Flags(), &params.bundlePaths)

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -122,6 +122,14 @@ func addCapabilitiesFlag(fs *pflag.FlagSet, f *capabilitiesFlag) {
 	fs.VarP(f, "capabilities", "", "set capabilities.json file path")
 }
 
+func addPartialFlag(fs *pflag.FlagSet, partial *bool, value bool) {
+	fs.BoolVarP(partial, "partial", "p", value, "perform partial evaluation")
+}
+
+func addUnknownsFlag(fs *pflag.FlagSet, unknowns *[]string, value []string) {
+	fs.StringArrayVarP(unknowns, "unknowns", "u", value, "set paths to treat as unknown during partial evaluation")
+}
+
 const (
 	explainModeOff   = "off"
 	explainModeFull  = "full"


### PR DESCRIPTION
This change allows users to get an accurate estimate of partial eval
performance on their policies.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
