### PR TITLE
wasm: dynamically dispatch data functions with "seen" ref pieces using call_indirect

### DIFF
--- a/compile/compile.go
+++ b/compile/compile.go
@@ -432,14 +432,16 @@ func (c *Compiler) compileWasm(ctx context.Context) error {
 	}
 
 	// Plan the query sets.
-	policy, err := planner.New().
+	p := planner.New().
 		WithQueries(queries).
 		WithModules(modules).
-		WithBuiltinDecls(builtins).
-		Plan()
-
+		WithBuiltinDecls(builtins)
+	policy, err := p.Plan()
 	if err != nil {
 		return err
+	}
+	for _, d := range p.Debug() {
+		c.debug.Add(Debug{Message: d.Message, Location: d.Location})
 	}
 
 	// Compile the policy into a wasm binary.

--- a/internal/ir/ir.go
+++ b/internal/ir/ir.go
@@ -53,6 +53,7 @@ type (
 		Params []Local
 		Return Local
 		Blocks []*Block // TODO(tsandall): should this be a plan?
+		Path   []string // optional: if non-nil, include in data function tree
 	}
 
 	// Plan represents an ordered series of blocks to execute. Plan execution
@@ -138,7 +139,7 @@ func (a *Funcs) String() string {
 }
 
 func (a *Func) String() string {
-	return fmt.Sprintf("%v (%d params: %v, %d blocks)", a.Name, len(a.Params), a.Params, len(a.Blocks))
+	return fmt.Sprintf("%v (%d params: %v, %d blocks, path: %v)", a.Name, len(a.Params), a.Params, len(a.Blocks), a.Path)
 }
 
 func (a *Plan) String() string {
@@ -168,6 +169,16 @@ type CallStmt struct {
 	Func   string
 	Args   []Local
 	Result Local
+
+	Location
+}
+
+// CallDynamicStmt represents an indirect (data) function call. The result should
+// be stored in the result local.
+type CallDynamicStmt struct {
+	Args   []Local
+	Result Local
+	Path   []Local
 
 	Location
 }

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -137,7 +137,13 @@ func (p *Planner) buildFunctrie() error {
 
 func (p *Planner) planRules(rules []*ast.Rule) (string, error) {
 
-	path := rules[0].Path().String()
+	pathRef := rules[0].Path()
+	path := pathRef.String()
+
+	var pathPieces []string
+	for i := 1; /* skip `data` */ i < len(pathRef); i++ {
+		pathPieces = append(pathPieces, string(pathRef[i].Value.(ast.String)))
+	}
 
 	if funcName, ok := p.funcs.Get(path); ok {
 		return funcName, nil
@@ -168,6 +174,7 @@ func (p *Planner) planRules(rules []*ast.Rule) (string, error) {
 			p.newLocal(), // data document
 		},
 		Return: p.newLocal(),
+		Path:   append([]string{fmt.Sprintf("g%d", p.funcs.gen)}, pathPieces...),
 	}
 
 	// Initialize parameters for functions.
@@ -1471,7 +1478,7 @@ func (p *Planner) planRefRec(ref ast.Ref, index int, iter planiter) error {
 		})
 	}
 
-	return p.planScan(ref[index], func(lkey ir.Local) error {
+	return p.planScan(ref[index], func(ir.Local) error {
 		return p.planRefRec(ref, index+1, iter)
 	})
 }
@@ -1490,6 +1497,37 @@ func (p *Planner) planRefData(virtual *ruletrie, base *baseptr, ref ast.Ref, ind
 	// plan has to materialize the full extent of the referenced value.
 	if index >= len(ref) {
 		return p.planRefDataExtent(virtual, base, iter)
+	}
+
+	// On the first iteration, we check if this can be optimized using a
+	// CallDynamicStatement
+	// NOTE(sr): we do it on the first index because later on, the recursion
+	// on subtrees of virtual already lost parts of the path we've taken.
+	if index == 1 {
+		rulesets, stmts, locals, index, optimize := p.optimizeLookup(virtual, ref)
+		if optimize {
+			// plan rules
+			for _, rules := range rulesets {
+				if _, err := p.planRules(rules); err != nil {
+					return err
+				}
+			}
+			// plan MakeStringStmts needed for ground ref[j]
+			for _, stmt := range stmts {
+				p.appendStmt(stmt)
+			}
+
+			p.ltarget = p.newLocal()
+			p.appendStmt(&ir.CallDynamicStmt{
+				Args: []ir.Local{
+					p.vars.GetOrEmpty(ast.InputRootDocument.Value.(ast.Var)),
+					p.vars.GetOrEmpty(ast.DefaultRootDocument.Value.(ast.Var)),
+				},
+				Path:   locals,
+				Result: p.ltarget,
+			})
+			return p.planRefRec(ref, index+1, iter)
+		}
 	}
 
 	// If the reference operand is ground then either continue to the next
@@ -1940,4 +1978,140 @@ func rewrittenVar(vars map[ast.Var]ast.Var, k ast.Var) ast.Var {
 		return k
 	}
 	return rw
+}
+
+// optimizeLookup returns a set of rulesets and required statements planning
+// the locals (strings) needed with the used local variables, and the index
+// into ref's parth that is still to be planned; if the passed ref's vars
+// allow for optimization using CallDynamicStmt.
+//
+// It's possible iff
+// - all vars in ref have been seen
+// - all ground terms (strings) match some child key on their respective
+//   layer of the ruletrie
+// - there are no child trees left (only rulesets) if we're done checking
+//   ref
+//
+// The last condition is necessary because we don't deal with _which key a
+// var actually matched_ -- so we don't know which subtree to evaluate
+// with the results.
+func (p *Planner) optimizeLookup(t *ruletrie, ref ast.Ref) ([][]*ast.Rule, []ir.Stmt, []ir.Local, int, bool) {
+	dont := func() ([][]*ast.Rule, []ir.Stmt, []ir.Local, int, bool) {
+		return nil, nil, nil, 0, false
+	}
+	if t == nil {
+		return dont()
+	}
+
+	nodes := []*ruletrie{t}
+	opt := false
+	var index int
+
+	// ref[0] is data, ignore
+	for i := 1; i < len(ref); i++ {
+		index = i
+		r := ref[i]
+		var nextNodes []*ruletrie
+
+		switch r := r.Value.(type) {
+		case ast.Var:
+			// check if it's been "seen" before
+			_, ok := p.vars.Get(r)
+			if !ok {
+				return dont()
+			}
+			opt = true
+			// take all children, they might match
+			for _, node := range nodes {
+				for _, child := range node.Children() {
+					if node := node.Get(child); node != nil {
+						nextNodes = append(nextNodes, node)
+					}
+				}
+			}
+		case ast.String:
+			// take matching children
+			for _, node := range nodes {
+				if node := node.Get(r); node != nil {
+					nextNodes = append(nextNodes, node)
+				}
+			}
+		default:
+			return dont() // TODO(sr): think more about this
+		}
+
+		nodes = nextNodes
+
+		// if all nodes have 0 children, abort ref check and optimize
+		all := true
+		for _, node := range nodes {
+			all = all && len(node.Children()) == 0
+		}
+		if all {
+			break
+		}
+	}
+
+	var res [][]*ast.Rule
+
+	// if there hasn't been any var, we're not making things better by
+	// introducing CallDynamicStmt
+	if !opt {
+		return dont()
+	}
+
+	// we're done with ref, check if there's only ruleset leaves; collect rules
+	for _, node := range nodes {
+		if index == len(ref)-1 {
+			if len(node.Children()) > 0 {
+				return dont()
+			}
+		}
+		res = append(res, node.Rules())
+	}
+
+	// If we've made it here, optimization is possible -- let's plan strings!
+	// NOTE(sr): this is a bit of a dirty side-effect; the code here assumes
+	// that the returned block and locals are going to be used. Technically,
+	// it might still be discarded, and we've planned a few strings we don't
+	// actually need.
+	var stmts []ir.Stmt
+	var locals []ir.Local
+
+	// plan generation
+	lvar := p.newLocal()
+	stmts = append(stmts, &ir.MakeStringStmt{
+		Index:  p.getStringConst(fmt.Sprintf("g%d", p.funcs.gen)),
+		Target: lvar,
+	})
+	locals = append(locals, lvar)
+
+	for i := 1; i <= index; i++ {
+		switch r := ref[i].Value.(type) {
+		case ast.Var:
+			lv, ok := p.vars.Get(r)
+			if !ok {
+				return dont()
+			}
+			locals = append(locals, lv)
+		case ast.String:
+			// plan string
+			lvar := p.newLocal()
+			stmts = append(stmts, &ir.MakeStringStmt{
+				Index:  p.getStringConst(string(r)),
+				Target: lvar,
+			})
+			locals = append(locals, lvar)
+		}
+	}
+
+	return res, stmts, locals, index, true
+}
+
+func (p *Planner) seenVar(ref *ast.Term) (bool, bool) {
+	if v, ok := ref.Value.(ast.Var); ok {
+		_, ok := p.vars.Get(v)
+		return true, ok
+	}
+	return false, false
 }

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -2060,14 +2060,19 @@ func (p *Planner) optimizeLookup(t *ruletrie, ref ast.Ref) ([][]*ast.Rule, []ir.
 		return dont()
 	}
 
-	// we're done with ref, check if there's only ruleset leaves; collect rules
 	for _, node := range nodes {
+		// we're done with ref, check if there's only ruleset leaves; collect rules
 		if index == len(ref)-1 {
 			if len(node.Children()) > 0 {
 				return dont()
 			}
 		}
-		res = append(res, node.Rules())
+		if rules := node.Rules(); len(rules) > 0 {
+			res = append(res, rules)
+		}
+	}
+	if len(res) == 0 {
+		return dont()
 	}
 
 	// If we've made it here, optimization is possible -- let's plan strings!

--- a/internal/planner/planner_test.go
+++ b/internal/planner/planner_test.go
@@ -295,6 +295,28 @@ func TestPlannerHelloWorld(t *testing.T) {
 				`,
 			},
 		},
+		{
+			note:    "cross product with non-ground refs to packages (simplified)",
+			queries: []string{`x := "aaa"; y := "bbb"; z := "q"; w := data.foo[x].bar[y].baz[z]`},
+			modules: []string{`package foo.aaa.bar.bbb.baz
+p = 1
+q = 2`,
+				`package foo.ccc.bar.bbb.baz
+p = 10
+q = 20`,
+			},
+		},
+		{
+			note: `non-ground refs to packages (including "with")`,
+			// NOTE(sr): data.foo.bbb does not change the outcomes, but triggers
+			// a gen++ in p.funcs, leading to g1, g2 function being planned and
+			// referenced
+			queries: []string{`x := "aaa"; y := "bbb"; z := "q"; w := data.foo[x].bar[y].baz[z] with data.foo.bbb as true`},
+			modules: []string{`package foo.aaa.bar.bbb.baz
+p = 1
+q = 2`,
+			},
+		},
 	}
 
 	for _, tc := range tests {
@@ -573,6 +595,17 @@ a {
 				&ir.ScanStmt{}:         `module-0.rego:3:3: data.test1[_].y = "z"`,
 			},
 		},
+		{
+			note:    "CallDynamicStmt optimization",
+			queries: []string{`x := "a"; data.test[x] = y`},
+			modules: []string{`package test
+a {
+  true
+}`},
+			exps: map[ir.Stmt]string{
+				&ir.CallDynamicStmt{}: "<query>:1:11: data.test[x] = y",
+			},
+		},
 	}
 
 	for _, tc := range tests {
@@ -651,5 +684,220 @@ func TestMultipleNamedQueries(t *testing.T) {
 		t.Fatal("expected two plans")
 	} else if policy.Plans.Plans[0].Name != "q1" || policy.Plans.Plans[1].Name != "q2" {
 		t.Fatal("expected to find plans for 'q1' and 'q2'")
+	}
+}
+
+func ref(r string) ast.Ref {
+	return ast.MustParseRef("data." + r)[1:]
+}
+
+func TestOptimizeLookup(t *testing.T) {
+	r0, r1, r2 := ast.Rule{}, ast.Rule{}, ast.Rule{}
+
+	t.Run("seen variable (last), one ruleset", func(t *testing.T) {
+		r := newRuletrie()
+		val := r.LookupOrInsert(ref("foo.bar"))
+		val.rules = append(val.rules, &r0, &r1, &r2)
+
+		p := New()
+		l := p.newLocal()
+		p.vars.Put(ast.Var("x"), l)
+
+		rulesets, stmts, locals, index, opt := p.optimizeLookup(r, ast.MustParseRef("data.foo[x]"))
+		if exp, act := true, opt; exp != act {
+			t.Errorf("expected 'optimize' %v, got %v\n", exp, act)
+		}
+		if exp, act := 2, index; exp != act {
+			t.Errorf("expected 'index' %d, got %d\n", exp, act)
+		}
+		if exp, act := 1, len(rulesets); exp != act {
+			t.Fatalf("expected %d rulesets, got %d\n", exp, act)
+		}
+		if exp, act := 3, len(rulesets[0]); exp != act {
+			t.Errorf("expected %d rules, got %d\n", exp, act)
+		}
+		// 3 = g0 + foo + x
+		if exp, act := 3, len(locals); exp != act {
+			t.Fatalf("expected %d locals, got %d\n", exp, act)
+		}
+		if exp, act := l, locals[len(locals)-1]; exp != act {
+			t.Errorf("expected last local to be %v, got %v\n", exp, act)
+		}
+		if exp, act := 2, len(stmts); exp != act {
+			t.Fatalf("expected %d statements in stmts, got %d\n", exp, act)
+		}
+		for i, stmt := range stmts {
+			_, ok := stmt.(*ir.MakeStringStmt)
+			if !ok {
+				t.Fatalf("expected stmt[%d] to be *ir.MakeStringStmt, got %T\n", i, stmt)
+			}
+		}
+	})
+
+	t.Run("ref shorter than ruletrie depth", func(t *testing.T) {
+		r := newRuletrie()
+		val := r.LookupOrInsert(ref("foo.bar.baz"))
+		val.rules = append(val.rules, &r0, &r1, &r2)
+
+		p := New()
+		l := p.newLocal()
+		p.vars.Put(ast.Var("x"), l)
+
+		_, _, _, _, opt := p.optimizeLookup(r, ast.MustParseRef("data.foo[x]"))
+		if exp, act := false, opt; exp != act {
+			t.Errorf("expected 'optimize' %v, got %v\n", exp, act)
+		}
+	})
+
+	t.Run("seen variable (last), multiple rulesets", func(t *testing.T) {
+		r := newRuletrie()
+		val := r.LookupOrInsert(ref("foo.bar"))
+		val.rules = append(val.rules, &r0, &r1)
+		val = r.LookupOrInsert(ref("foo.baz"))
+		val.rules = append(val.rules, &r2)
+
+		p := New()
+		p.vars.Put(ast.Var("x"), p.newLocal())
+
+		rulesets, _, _, _, opt := p.optimizeLookup(r, ast.MustParseRef("data.foo[x]"))
+		if exp, act := true, opt; exp != act {
+			t.Errorf("expected 'optimize' %v, got %v\n", exp, act)
+		}
+		if exp, act := 2, len(rulesets); exp != act {
+			t.Fatalf("expected %d rulesets, got %d\n", exp, act)
+		}
+		if exp, act := 2, len(rulesets[0]); exp != act {
+			t.Errorf("expected %d rules in ruleset 0, got %d\n", exp, act)
+		}
+		if exp, act := 1, len(rulesets[1]); exp != act {
+			t.Errorf("expected %d rules in ruleset 1, got %d\n", exp, act)
+		}
+	})
+
+	t.Run("unseen variable (last)", func(t *testing.T) {
+		r := newRuletrie()
+		val := r.LookupOrInsert(ref("foo.bar"))
+		val.rules = append(val.rules, &r0, &r1, &r2)
+
+		p := New()
+
+		_, _, _, _, opt := p.optimizeLookup(r, ast.MustParseRef("data.foo[x]"))
+		if exp, act := false, opt; exp != act {
+			t.Errorf("expected 'optimize' %v, got %v\n", exp, act)
+		}
+	})
+
+	t.Run("all ground refs", func(t *testing.T) {
+		r := newRuletrie()
+		val := r.LookupOrInsert(ref("foo.bar.baz"))
+		val.rules = append(val.rules, &r0, &r1, &r2)
+
+		p := New()
+
+		_, _, _, _, opt := p.optimizeLookup(r, ast.MustParseRef("data.foo.bar.baz"))
+		if exp, act := false, opt; exp != act {
+			t.Errorf("expected 'optimize' %v, got %v\n", exp, act)
+		}
+	})
+
+	t.Run("multiple seen vars, one rule set", func(t *testing.T) {
+		r := newRuletrie()
+		val := r.LookupOrInsert(ref("foo.aaa.bar.bbb.q"))
+		val.rules = append(val.rules, &r0, &r1, &r2)
+
+		p := New()
+		lx, ly := p.newLocal(), p.newLocal()
+		p.vars.Put(ast.Var("x"), lx)
+		p.vars.Put(ast.Var("y"), ly)
+
+		rulesets, stmts, locals, index, opt := p.optimizeLookup(r, ast.MustParseRef("data.foo[x].bar[y].q"))
+		if exp, act := true, opt; exp != act {
+			t.Errorf("expected 'optimize' %v, got %v\n", exp, act)
+		}
+		if exp, act := 5, index; exp != act {
+			t.Errorf("expected 'index' %d, got %d\n", exp, act)
+		}
+		if exp, act := 1, len(rulesets); exp != act {
+			t.Fatalf("expected %d rulesets, got %d\n", exp, act)
+		}
+		if exp, act := 3, len(rulesets[0]); exp != act {
+			t.Errorf("expected %d rules in ruleset 0, got %d\n", exp, act)
+		}
+		// 6 = g0 + foo + x + bar + y + q
+		if exp, act := 6, len(locals); exp != act {
+			t.Fatalf("expected %d locals, got %d\n", exp, act)
+		}
+		// 4 = MakeStringStmt for "g0" + "foo" + "bar" + "q"
+		if exp, act := 4, len(stmts); exp != act {
+			t.Fatalf("expected %d statements in stmts, got %d\n", exp, act)
+		}
+	})
+
+	t.Run("one seen var, one unseen, one rule set", func(t *testing.T) {
+		r := newRuletrie()
+		val := r.LookupOrInsert(ref("foo.aaa.bar.bbb.q"))
+		val.rules = append(val.rules, &r0, &r1, &r2)
+
+		p := New()
+		p.vars.Put(ast.Var("x"), p.newLocal())
+
+		_, _, _, _, opt := p.optimizeLookup(r, ast.MustParseRef("data.foo[x].bar[y].q"))
+		if exp, act := false, opt; exp != act {
+			t.Errorf("expected 'optimize' %v, got %v\n", exp, act)
+		}
+	})
+
+	t.Run("one seen var, one rule set and children left", func(t *testing.T) {
+		r := newRuletrie()
+		val := r.LookupOrInsert(ref("foo.aaa.bar.bbb.q"))
+		val.rules = append(val.rules, &r0)
+		val = r.LookupOrInsert(ref("foo.ccc.bar"))
+		val.rules = append(val.rules, &r1, &r2)
+
+		p := New()
+		p.vars.Put(ast.Var("x"), p.newLocal())
+
+		_, _, _, _, opt := p.optimizeLookup(r, ast.MustParseRef("data.foo[x].bar"))
+		if exp, act := false, opt; exp != act {
+			t.Errorf("expected 'optimize' %v, got %v\n", exp, act)
+		}
+	})
+
+	t.Run("ref goes into the rules' result", func(t *testing.T) {
+		r := newRuletrie()
+		val := r.LookupOrInsert(ref("foo.aaa.bar.q"))
+		val.rules = append(val.rules, &r0, &r1, &r2)
+
+		p := New()
+		p.vars.Put(ast.Var("x"), p.newLocal())
+
+		rulesets, stmts, locals, index, opt := p.optimizeLookup(r, ast.MustParseRef("data.foo[x].bar.q.p.r"))
+		if exp, act := true, opt; exp != act {
+			t.Errorf("expected 'optimize' %v, got %v\n", exp, act)
+		}
+		if exp, act := 4, index; exp != act {
+			t.Errorf("expected 'index' %d, got %d\n", exp, act)
+		}
+		if exp, act := 1, len(rulesets); exp != act {
+			t.Fatalf("expected %d rulesets, got %d\n", exp, act)
+		}
+		if exp, act := 3, len(rulesets[0]); exp != act {
+			t.Errorf("expected %d rules in ruleset 0, got %d\n", exp, act)
+		}
+		// 5 = g0 + foo + x + bar + q
+		if exp, act := 5, len(locals); exp != act {
+			t.Fatalf("expected %d locals, got %d\n", exp, act)
+		}
+		// 4 = MakeStringStmt for "g0" + "foo" + "bar" + "q"
+		if exp, act := 4, len(stmts); exp != act {
+			t.Fatalf("expected %d statements in stmts, got %d\n", exp, act)
+		}
+	})
+}
+
+func expectNoError(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
 	}
 }

--- a/internal/wasm/encoding/encoding_test.go
+++ b/internal/wasm/encoding/encoding_test.go
@@ -88,7 +88,10 @@ func TestRoundtripOPA(t *testing.T) {
 	// Note(sr): We don't have this set by any other means, so manually set it, and
 	// check the write->read roundtrip at least.
 	module1.Names.Module = "foo"
-	module1.Names.Locals = []module.LocalNameMap{{FuncIndex: 1172, NameMap: module.NameMap{Index: 0, Name: "data"}}}
+	module1.Names.Locals = []module.LocalNameMap{{FuncIndex: 35, NameMap: module.NameMap{Index: 0, Name: "data"}}}
+	// Note(sr): This isn't a great choice, but it has the right signature: type[13] () -> nil
+	var start uint32 = 40 // func[40] sig=13 <__force_import_opa_builtins>
+	module1.Start.FuncIndex = &start
 
 	// TODO(tsandall): when all instructions are handled by reader, add logic to
 	// check code section contents.

--- a/internal/wasm/instruction/control.go
+++ b/internal/wasm/instruction/control.go
@@ -9,7 +9,7 @@ import (
 	"github.com/open-policy-agent/opa/internal/wasm/types"
 )
 
-// Unreachable reprsents an unreachable opcode.
+// Unreachable represents a WASM unreachable instruction.
 type Unreachable struct {
 	NoImmediateArgs
 }
@@ -116,6 +116,22 @@ func (Call) Op() opcode.Opcode {
 // ImmediateArgs returns the function index.
 func (i Call) ImmediateArgs() []interface{} {
 	return []interface{}{i.Index}
+}
+
+// CallIndirect represents a WASM call_indirect instruction.
+type CallIndirect struct {
+	Index    uint32 // type index
+	Reserved byte   // zero for now
+}
+
+// Op returns the opcode of the instruction.
+func (CallIndirect) Op() opcode.Opcode {
+	return opcode.CallIndirect
+}
+
+// ImmediateArgs returns the function index.
+func (i CallIndirect) ImmediateArgs() []interface{} {
+	return []interface{}{i.Index, i.Reserved}
 }
 
 // Return represents a WASM return instruction.

--- a/internal/wasm/instruction/numeric.go
+++ b/internal/wasm/instruction/numeric.go
@@ -137,3 +137,63 @@ type I32LeS struct {
 func (I32LeS) Op() opcode.Opcode {
 	return opcode.I32LeS
 }
+
+// I32Add represents the WASM i32.add instruction.
+type I32Add struct {
+	NoImmediateArgs
+}
+
+// Op returns the opcode of the instruction.
+func (I32Add) Op() opcode.Opcode {
+	return opcode.I32Add
+}
+
+// I64Add represents the WASM i64.add instruction.
+type I64Add struct {
+	NoImmediateArgs
+}
+
+// Op returns the opcode of the instruction.
+func (I64Add) Op() opcode.Opcode {
+	return opcode.I64Add
+}
+
+// F32Add represents the WASM f32.add instruction.
+type F32Add struct {
+	NoImmediateArgs
+}
+
+// Op returns the opcode of the instruction.
+func (F32Add) Op() opcode.Opcode {
+	return opcode.F32Add
+}
+
+// F64Add represents the WASM f64.add instruction.
+type F64Add struct {
+	NoImmediateArgs
+}
+
+// Op returns the opcode of the instruction.
+func (F64Add) Op() opcode.Opcode {
+	return opcode.F64Add
+}
+
+// I32Mul represents the WASM i32.mul instruction.
+type I32Mul struct {
+	NoImmediateArgs
+}
+
+// Op returns the opcode of the instruction.
+func (I32Mul) Op() opcode.Opcode {
+	return opcode.I32Mul
+}
+
+// I32Sub represents the WASM i32.sub instruction.
+type I32Sub struct {
+	NoImmediateArgs
+}
+
+// Op returns the opcode of the instruction.
+func (I32Sub) Op() opcode.Opcode {
+	return opcode.I32Sub
+}

--- a/internal/wasm/instruction/parametric.go
+++ b/internal/wasm/instruction/parametric.go
@@ -1,0 +1,29 @@
+// Copyright 2021 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package instruction
+
+import (
+	"github.com/open-policy-agent/opa/internal/wasm/opcode"
+)
+
+// Drop reprsents a WASM drop instruction.
+type Drop struct {
+	NoImmediateArgs
+}
+
+// Op returns the opcode of the instruction.
+func (Drop) Op() opcode.Opcode {
+	return opcode.Drop
+}
+
+// Select reprsents a WASM select instruction.
+type Select struct {
+	NoImmediateArgs
+}
+
+// Op returns the opcode of the instruction.
+func (Select) Op() opcode.Opcode {
+	return opcode.Select
+}

--- a/internal/wasm/module/module.go
+++ b/internal/wasm/module/module.go
@@ -16,6 +16,7 @@ type (
 	// Module represents a WASM module.
 	Module struct {
 		Version  uint32
+		Start    StartSection
 		Type     TypeSection
 		Import   ImportSection
 		Function FunctionSection
@@ -27,6 +28,11 @@ type (
 		Data     DataSection
 		Customs  []CustomSection
 		Names    NameSection
+	}
+
+	// StartSection represents a WASM start section.
+	StartSection struct {
+		FuncIndex *uint32
 	}
 
 	// TypeSection represents a WASM type section.

--- a/internal/wasm/sdk/opa/opa_test.go
+++ b/internal/wasm/sdk/opa/opa_test.go
@@ -197,6 +197,15 @@ a = "c" { input > 2 }`,
 				Eval{Input: `{"re": "a(x*)b(y|z)c"}`, Result: `{{"x":[["axxxbyc","xxx","y"]]}}`},
 			},
 		},
+		{
+			Description: "simplified",
+			Query:       `x := "q"; y := data.p[x]`,
+			Policy: `p = 1
+			q = 2`,
+			Evals: []Eval{
+				{Result: `{{"y": 2, "x": "q"}}`},
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/test/wasm/assets/019_call_indirect_optimization.yaml
+++ b/test/wasm/assets/019_call_indirect_optimization.yaml
@@ -72,3 +72,16 @@ cases:
       - x: q
         a: bar
         z: 1
+  - note: memoization
+    query: |
+      x := "q"; z := data.foo[x]; w := data.foo[x]
+    modules:
+      - |
+        package foo
+        q = 1 {
+          custom_builtin_test_memoization() == 100
+        }
+    want_result:
+      - x: q
+        z: 1
+        w: 1

--- a/test/wasm/assets/019_call_indirect_optimization.yaml
+++ b/test/wasm/assets/019_call_indirect_optimization.yaml
@@ -1,0 +1,74 @@
+cases:
+  - note: non_opt
+    query: |
+      z := data.foo.q
+    modules:
+      - |
+        package foo
+        q = 1
+    want_result:
+      - z: 1
+  - note: simplest
+    query: |
+      x := "q"; z := data.foo[x]
+    modules:
+      - |
+        package foo
+        q = 1
+    want_result:
+      - x: q
+        z: 1
+  - note: two packages, one irrelevant
+    query: |
+      x := "q"; z := data.foo[x]
+    modules:
+      - |
+        package foo
+        q = 1
+      - |
+        package bar
+        q = 2
+    want_result:
+      - x: q
+        z: 1
+  - note: more layers
+    query: |
+      x := "aaa"; u := "ccc"; z := "q"; w := data.foo[x].bar[u].baz[z]
+    modules:
+      - |
+        package foo.aaa.bar.ccc.baz
+        q = 1
+      - |
+        package foo.aaa.bar.ddd.baz
+        q = 2
+    want_result:
+      - x: aaa
+        u: ccc
+        w: 1
+        z: q
+  - note: leftover ref when optimization planned
+    query: |
+      x := "aaa"; z := "q"; w := data.foo[x].bar[z].foo.baz
+    modules:
+      - |
+        package foo.aaa.bar
+        q = {
+          "foo": {
+            "baz": 100
+          }
+        }
+    want_result:
+      - x: aaa
+        z: q
+        w: 100
+  - note: lookup involving 'with'
+    query: |
+      x := "q"; a := "bar"; z := data.foo[a][x] with data.foo.baz as 200
+    modules:
+      - |
+        package foo.bar
+        q = 1
+    want_result:
+      - x: q
+        a: bar
+        z: 1

--- a/test/wasm/assets/test.js
+++ b/test/wasm/assets/test.js
@@ -86,7 +86,7 @@ function loadJSON(mod, memory, value) {
     const parsedAddr = mod.instance.exports.opa_json_parse(rawAddr, str.length);
 
     if (parsedAddr == 0) {
-        throw "failed to parse json value"
+        throw "failed to parse json value";
     }
 
     return parsedAddr;
@@ -114,9 +114,20 @@ function builtinCustomTestImpure() {
     return "foo";
 }
 
+var run = false;
+
+function builtinCustomTestMemoization() {
+    if (run) {
+      throw "should have been memoized";
+    }
+    run = true
+    return 100;
+}
+
 const builtinFuncs = {
     custom_builtin_test: builtinCustomTest,
     custom_builtin_test_impure: builtinCustomTestImpure,
+    custom_builtin_test_memoization: builtinCustomTestMemoization,
 }
 
 // builtinCall dispatches the built-in function. Arguments are deserialized from

--- a/test/wasm/cmd/wasm-rego-testgen/main.go
+++ b/test/wasm/cmd/wasm-rego-testgen/main.go
@@ -80,6 +80,13 @@ func compileTestCases(ctx context.Context, tests cases.Set) (*compiledTestCaseSe
 					types.N,
 				),
 			}),
+			rego.FunctionDecl(&rego.Function{
+				Name: "custom_builtin_test_memoization",
+				Decl: types.NewFunction(
+					[]types.Type{},
+					types.N,
+				),
+			}),
 		}
 
 		for idx, module := range tc.Modules {

--- a/wasm/src/value.c
+++ b/wasm/src/value.c
@@ -1659,7 +1659,6 @@ opa_errc opa_value_remove_path(opa_value *data, opa_value *path)
 // Lookup path in the passed mapping object. Returns 0 if it can't
 // be found, or of there's no function index leaf when we've run out
 // of path pieces.
-// TODO(sr): reconsider ^^
 int opa_lookup(opa_value *mapping, opa_value *path) {
     int path_len = _validate_json_path(path);
     if (path_len < 1)

--- a/wasm/src/value.c
+++ b/wasm/src/value.c
@@ -1666,13 +1666,12 @@ int opa_lookup(opa_value *mapping, opa_value *path) {
         return 0;
     }
 
-    opa_array_t *p = opa_cast_array(path);
     opa_value *curr = mapping;
 
-    for (int i = 0; i < path_len; i++)
+    for (opa_value *idx = opa_value_iter(path, NULL); idx != NULL; idx = opa_value_iter(path, idx))
     {
-        opa_value *k = opa_value_get_array_native(p, i);
-        opa_value *next = opa_value_get(curr, k);
+        opa_value *key = opa_value_get(path, idx);
+        opa_value *next = opa_value_get(curr, key);
         if (next == NULL)
         {
             return 0;

--- a/wasm/src/value.c
+++ b/wasm/src/value.c
@@ -1,5 +1,6 @@
 #include <mpdecimal.h>
 
+#include "json.h"
 #include "malloc.h"
 #include "mpd.h"
 #include "str.h"
@@ -1653,4 +1654,57 @@ opa_errc opa_value_remove_path(opa_value *data, opa_value *path)
     opa_object_remove(opa_cast_object(curr), opa_value_get_array_native(p, path_len-1));
 
     return OPA_ERR_OK;
+}
+
+// Lookup path in the passed mapping object. Returns 0 if it can't
+// be found, or of there's no function index leaf when we've run out
+// of path pieces.
+// TODO(sr): reconsider ^^
+int opa_lookup(opa_value *mapping, opa_value *path) {
+    int path_len = _validate_json_path(path);
+    if (path_len < 1)
+    {
+        return 0;
+    }
+
+    opa_array_t *p = opa_cast_array(path);
+    opa_value *curr = mapping;
+
+    for (int i = 0; i < path_len; i++)
+    {
+        opa_value *k = opa_value_get_array_native(p, i);
+        opa_value *next = opa_value_get(curr, k);
+        if (next == NULL)
+        {
+            return 0;
+        }
+        curr = next;
+    }
+    if (curr->type == OPA_NUMBER) {
+        long long i;
+        if (opa_number_try_int(opa_cast_number(curr), &i) == 0) {
+            return i;
+        }
+    }
+    return 0;
+}
+
+// global variable used for storing the parsed mapping JSON
+static opa_value *mapping;
+
+// Called from the WASM-generated '_initialize' function with the
+// address of the mapping string and its length. Parses the JSON
+// string it expects, sets the *mapping variable accordingly.
+OPA_INTERNAL
+void opa_mapping_init(const char *s, const int l) {
+    if (mapping == NULL) {
+        mapping = opa_json_parse(s, l);
+    }
+}
+
+// Lookup mapped function index from global mapping (initialized by
+// opa_mapping_init).
+OPA_INTERNAL
+int opa_mapping_lookup(opa_value *path) {
+    return opa_lookup(mapping, path);
 }

--- a/wasm/src/value.h
+++ b/wasm/src/value.h
@@ -170,6 +170,10 @@ void opa_set_free(opa_set_t *set);
 void opa_set_add(opa_set_t *set, opa_value *v);
 opa_set_elem_t *opa_set_get(opa_set_t *set, opa_value *v);
 
+int opa_lookup(opa_value *mapping, opa_value *path);
+int opa_mapping_lookup(opa_value *path);
+void opa_mapping_init(const char *s, const int l);
+
 #ifdef __cplusplus
 }
 #endif

--- a/wasm/tests/test.c
+++ b/wasm/tests/test.c
@@ -3209,3 +3209,40 @@ void test_regex()
         }
     }
 }
+
+void test_opa_lookup(void)
+{
+    opa_array_t *path1 = opa_cast_array(opa_array());
+    opa_array_append(path1, opa_string_terminated("foo"));
+    opa_array_append(path1, opa_string_terminated("bar"));
+    opa_array_append(path1, opa_string_terminated("baz"));
+
+    opa_object_t *mock_mapping = opa_cast_object(opa_object());
+    opa_object_t *obj1 = opa_cast_object(opa_object());
+    opa_object_insert(obj1, opa_string_terminated("baz"), opa_number_int(1));
+    opa_object_t *obj2 = opa_cast_object(opa_object());
+    opa_object_insert(obj2, opa_string_terminated("bar"), &obj1->hdr);
+    opa_object_insert(mock_mapping, opa_string_terminated("foo"), &obj2->hdr);
+
+    opa_value *empty_mapping = opa_object();
+
+    opa_object_t *smaller_mapping = opa_cast_object(opa_object());
+    opa_object_t *obj3 = opa_cast_object(opa_object());
+    opa_object_insert(obj3, opa_string_terminated("bar"), opa_number_int(2));
+    opa_object_insert(smaller_mapping, opa_string_terminated("foo"), &obj3->hdr);
+
+    test("opa_lookup/hit", opa_lookup(&mock_mapping->hdr, &path1->hdr) == 1);
+    test("opa_lookup/miss", opa_lookup(empty_mapping, &path1->hdr) == -1);
+    test("opa_lookup/miss/less", opa_lookup(&smaller_mapping->hdr, &path1->hdr) == -1); // TODO(sr) will this be what we want?
+}
+
+void test_opa_mapping_init(void)
+{
+    opa_string_t *s = opa_cast_string(opa_string_terminated("{\"foo\": {\"bar\": 123}}"));
+    opa_mapping_init(s->v, s->len);
+
+    opa_array_t *path1 = opa_cast_array(opa_array());
+    opa_array_append(path1, opa_string_terminated("foo"));
+    opa_array_append(path1, opa_string_terminated("bar"));
+    test("opa_mapping_init/opa_lookup_works", opa_mapping_lookup(&path1->hdr) == 123);
+}

--- a/wasm/tests/test.c
+++ b/wasm/tests/test.c
@@ -3232,8 +3232,8 @@ void test_opa_lookup(void)
     opa_object_insert(smaller_mapping, opa_string_terminated("foo"), &obj3->hdr);
 
     test("opa_lookup/hit", opa_lookup(&mock_mapping->hdr, &path1->hdr) == 1);
-    test("opa_lookup/miss", opa_lookup(empty_mapping, &path1->hdr) == -1);
-    test("opa_lookup/miss/less", opa_lookup(&smaller_mapping->hdr, &path1->hdr) == -1); // TODO(sr) will this be what we want?
+    test("opa_lookup/miss", opa_lookup(empty_mapping, &path1->hdr) == 0);
+    test("opa_lookup/miss/less", opa_lookup(&smaller_mapping->hdr, &path1->hdr) == 0);
 }
 
 void test_opa_mapping_init(void)


### PR DESCRIPTION
1. write an object corresponding to data paths into the module data
2. initialize an opa_object_t from that using `_initialize`, called
   as the module's Start function
3. write out CallDynamicStmts in IR when the ref is not all ground,
   but its vars have been seen
4. compile those CallDynamicStmts to call_indirect invocations in
   WASM, preceded by a lookup using the path in the object prepared
   in (2.)
5. if the lookup fails to come up with a result, the eval goes
   undefined

-----
What it looks like:

With t.rego as

    package t

    p {
      data.foo[input.x].bar.p
    }

and foo.rego as

    package foo.a.bar

    p = true

when building policy.wasm using `opa build -t wasm -e t/p t.rego foo.rego`,
the body of function `g0.data.t.p` will contain

    i32.const 5
    call $opa_array_with_cap
    local.set $11
    local.get $11
    local.get $7
    call $opa_array_append
    local.get $11
    local.get $8
    call $opa_array_append
    local.get $11
    local.get $6
    call $opa_array_append
    local.get $11
    local.get $9
    call $opa_array_append
    local.get $11
    local.get $10
    call $opa_array_append
    local.get $0
    local.get $1
    local.get $11
    call $opa_mapping_lookup
    local.tee $12
    i32.eqz
    br_if $block
    local.get $12
    call_indirect $29 (type $1)
    local.tee $13
    i32.eqz
    br_if $block

Where the array-related functions build an array of

    ["g0", "foo", input.x, "bar", "p"]

and pass that to `opa_mapping_lookup` to determine the element index to
pass to `call_indirect`. The lookup function returns 74 from the JSON
blob put into the data section,

    (data $38 (i32.const 56485)
      "{\"g0\": {\"foo\": {\"a\": {\"bar\": {\"p\": 74}}}, \"t\": {\"p\": 75}}}")

iff input.x happens to be "a". Otherwise, it'll return 0, and the result
will end up being undefined.

Element 74 of the modules func table is, of course, $g0.data.foo.a.bar.p:

    (elem $33 (i32.const 74)
      $g0.data.foo.a.bar.p $g0.data.t.p)

($33 is some id of that piece of function table, an artifact of the
`wavm disassemble` output.)

-----

Fixes #2936.