### PR TITLE
planner: actually plan the exclude set comparison (bugfix)

### DIFF
--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -1597,12 +1597,12 @@ func (p *Planner) planRefData(virtual *ruletrie, base *baseptr, ref ast.Ref, ind
 		return p.planScan(ref[index], func(lkey ir.Local) error {
 			if lexclude != nil {
 				lignore := p.newLocal()
-				b := &ir.Block{}
-				p.appendStmtToBlock(&ir.DotStmt{
-					Source: *lexclude,
-					Key:    lkey,
-					Target: lignore,
-				}, b)
+				p.appendStmt(&ir.NotStmt{
+					Block: p.blockWithStmt(&ir.DotStmt{
+						Source: *lexclude,
+						Key:    lkey,
+						Target: lignore,
+					})})
 			}
 
 			// Assume that virtual sub trees have been visited already so


### PR DESCRIPTION
This was introduced with the source location mapping, #2960.

The set was planned, but never the check for not being a member of the set hadn't been appended; the block just dangles there and is forgotten. Somehow, the `ir.NotStmt` wrapping, while crucial, also got lost. 😬 