### PR TITLE
OAuth2 JWT bearer grant type and JWT client auth

### DIFF
--- a/bundle/keys_test.go
+++ b/bundle/keys_test.go
@@ -7,7 +7,6 @@ package bundle
 import (
 	"crypto/rsa"
 	"fmt"
-	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -107,80 +106,6 @@ func TestGetPublicKey(t *testing.T) {
 
 			if !reflect.DeepEqual(kc, tc.kc) {
 				t.Fatalf("Expected key config %v but got %v", tc.kc, kc)
-			}
-		})
-	}
-}
-
-func TestParseKeysConfig(t *testing.T) {
-
-	key := `-----BEGIN PUBLIC KEY----- MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA7nJwME0QNM6g0Ou9Sylj lcIY4cnBcs8oWVHe74bJ7JTgYmDOk2CA14RE3wJNkUKERP/cRdesKDA/BToJXJUr oYvhjXxUYn+i3wK5vOGRY9WUtTF9paIIpIV4USUOwDh3ufhA9K3tyh+ZVsqn80em 0Lj2ME0EgScuk6u0/UYjjNvcmnQl+uDmghG8xBZh7TZW2+aceMwlb4LJIP36VRhg jKQGIxg2rW8ROXgJaFbNRCbiOUUqlq9SUZuhHo8TNOARXXxp9R4Fq7Cl7ZbwWtNP wAtM1y+Z+iyu/i91m0YLlU2XBOGLu9IA8IZjPlbCnk/SygpV9NNwTY9DSQ0QfXcP TGlsbFwzRzTlhH25wEl3j+2Ub9w/NX7Yo+j/Ei9eGZ8cq0bcvEwDeIo98HeNZWrL UUArayRYvh8zutOlzqehw8waFk9AxpfEp9oWekSz8gZw9OL773EhnglYxxjkPHNz k66CufLuTEf6uE9NLE5HnlQMbiqBFirIyAWGKyU3v2tphKvcogxmzzWA51p0GY0l GZvlLNt2NrJv2oGecyl3BLqHnBi+rGAosa/8XgfQT8RIk7YR/tDPDmPfaqSIc0po +NcHYEH82Yv+gfKSK++1fyssGCsSRJs8PFMuPGgv62fFrE/EHSsHJaNWojSYce/T rxm2RaHhw/8O4oKcfrbaRf8CAwEAAQ== -----END PUBLIC KEY-----`
-
-	config := fmt.Sprintf(`{"foo": {"algorithm": "HS256", "key": "FdFYFzERwC2uCBB46pZQi4GG85LujR8obt-KWRBICVQ"},
-			  				"bar": {"key": %v}
-				}`, key)
-
-	tests := map[string]struct {
-		input   string
-		result  map[string]*KeyConfig
-		wantErr bool
-		err     error
-	}{
-		"valid_config_one_key": {
-			`{"foo": {"algorithm": "HS256", "key": "FdFYFzERwC2uCBB46pZQi4GG85LujR8obt-KWRBICVQ"}}`,
-			map[string]*KeyConfig{"foo": {Key: "FdFYFzERwC2uCBB46pZQi4GG85LujR8obt-KWRBICVQ", Algorithm: "HS256"}},
-			false, nil,
-		},
-		"valid_config_two_key": {
-			config,
-			map[string]*KeyConfig{
-				"foo": {Key: "FdFYFzERwC2uCBB46pZQi4GG85LujR8obt-KWRBICVQ", Algorithm: "HS256"},
-				"bar": {Key: key, Algorithm: "RS256"},
-			},
-			false, nil,
-		},
-		"invalid_config_no_key": {
-			`{"foo": {"algorithm": "HS256"}}`,
-			nil,
-			true, fmt.Errorf("invalid keys configuration: verification key empty for key ID foo"),
-		},
-		"valid_config_default_alg": {
-			`{"foo": {"key": "FdFYFzERwC2uCBB46pZQi4GG85LujR8obt-KWRBICVQ"}}`,
-			map[string]*KeyConfig{"foo": {Key: "FdFYFzERwC2uCBB46pZQi4GG85LujR8obt-KWRBICVQ", Algorithm: "RS256"}},
-			false, nil,
-		},
-		"invalid_raw_key_config": {
-			`{"bar": [1,2,3]}`,
-			nil,
-			true, fmt.Errorf("json: cannot unmarshal array into Go value of type bundle.KeyConfig"),
-		},
-		"invalid_raw_config": {
-			`[1,2,3]`,
-			nil,
-			true, fmt.Errorf("json: cannot unmarshal array into Go value of type map[string]json.RawMessage"),
-		},
-	}
-
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-
-			kc, err := ParseKeysConfig([]byte(tc.input))
-			if tc.wantErr {
-				if err == nil {
-					t.Fatal("Expected error but got nil")
-				}
-
-				if tc.err != nil && tc.err.Error() != err.Error() {
-					t.Fatalf("Expected error message %v but got %v", tc.err.Error(), err.Error())
-				}
-			} else {
-				if err != nil {
-					t.Fatalf("Unexpected error %v", err)
-				}
-			}
-
-			if !reflect.DeepEqual(kc, tc.result) {
-				t.Fatalf("Expected key config %v but got %v", tc.result, kc)
 			}
 		})
 	}
@@ -287,67 +212,6 @@ EXrJfkELSzO66/ZSjyyWEczXHLyr+Q719BsaGsxie117zSNF6B6UXiitjCr/qQ==
 	})
 }
 
-func TestNewKeyConfig(t *testing.T) {
-	publicKey := `-----BEGIN PUBLIC KEY-----
-MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA9KaakMv1XKKDaSch3PFR
-3a27oaHp1GNTTNqvb1ZaHZXp+wuhYDwc/MTE67x9GCifvQBWzEGorgTq7aisiOyl
-vKifwz6/wQ+62WHKG/sqKn2Xikp3P63aBIPlZcHbkyyRmL62yeyuzYoGvLEYel+m
-z5SiKGBwviSY0Th2L4e5sGJuk2HOut6emxDi+E2Fuuj5zokFJvIT6Urlq8f3h6+l
-GeR6HUOXqoYVf7ff126GP7dticTVBgibxkkuJFmpvQSW6xmxruT4k6iwjzbZHY7P
-ypZ/TdlnuGC1cOpAVyU7k32IJ9CRbt3nwEf5U54LRXLLQjFixWZHwKdDiMTF4ws0
-+wIDAQAB
------END PUBLIC KEY-----`
-
-	files := map[string]string{
-		"public.pem": publicKey,
-	}
-
-	test.WithTempFS(files, func(rootDir string) {
-
-		kc, err := NewKeyConfig(filepath.Join(rootDir, "public.pem"), "RS256", "read")
-		if err != nil {
-			t.Fatalf("Unexpected error %v", err)
-		}
-
-		expected := &KeyConfig{
-			Key:       publicKey,
-			Algorithm: "RS256",
-			Scope:     "read",
-		}
-
-		if !reflect.DeepEqual(kc, expected) {
-			t.Fatalf("Expected key config %v but got %v", expected, kc)
-		}
-
-		// secret provided on command-line
-		kc, err = NewKeyConfig(publicKey, "HS256", "")
-		if err != nil {
-			t.Fatalf("Unexpected error %v", err)
-		}
-
-		expected = &KeyConfig{
-			Key:       publicKey,
-			Algorithm: "HS256",
-			Scope:     "",
-		}
-
-		if !reflect.DeepEqual(kc, expected) {
-			t.Fatalf("Expected key config %v but got %v", expected, kc)
-		}
-
-		// simulate error while reading file
-		err = os.Chmod(filepath.Join(rootDir, "public.pem"), 0111)
-		if err != nil {
-			t.Fatalf("Unexpected error %v", err)
-		}
-
-		_, err = NewKeyConfig(filepath.Join(rootDir, "public.pem"), "RS256", "read")
-		if err == nil {
-			t.Fatal("Expected error but got nil")
-		}
-	})
-}
-
 func TestGetClaimsErrors(t *testing.T) {
 	files := map[string]string{
 		"claims.json": `["foo", "read"]`,
@@ -373,49 +237,4 @@ func TestGetClaimsErrors(t *testing.T) {
 			t.Fatalf("Expected error message %v but got %v", errMsg, err.Error())
 		}
 	})
-}
-
-func TestKeyConfigEqual(t *testing.T) {
-	tests := map[string]struct {
-		a   *KeyConfig
-		b   *KeyConfig
-		exp bool
-	}{
-		"equal": {
-			&KeyConfig{
-				Key:       "foo",
-				Algorithm: "RS256",
-				Scope:     "read",
-			},
-			&KeyConfig{
-				Key:       "foo",
-				Algorithm: "RS256",
-				Scope:     "read",
-			},
-			true,
-		},
-		"not_equal": {
-			&KeyConfig{
-				Key:       "foo",
-				Algorithm: "RS256",
-				Scope:     "read",
-			},
-			&KeyConfig{
-				Key:       "foo",
-				Algorithm: "RS256",
-				Scope:     "write",
-			},
-			false,
-		},
-	}
-
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			actual := tc.a.Equal(tc.b)
-
-			if actual != tc.exp {
-				t.Fatalf("Expected config equal result %v but got %v", tc.exp, actual)
-			}
-		})
-	}
 }

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -17,6 +17,7 @@ import (
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/bundle"
 	"github.com/open-policy-agent/opa/compile"
+	"github.com/open-policy-agent/opa/keys"
 	"github.com/open-policy-agent/opa/util"
 )
 
@@ -317,11 +318,11 @@ func buildVerificationConfig(pubKey, pubKeyID, alg, scope string, excludeFiles [
 		return nil, nil
 	}
 
-	keyConfig, err := bundle.NewKeyConfig(pubKey, alg, scope)
+	keyConfig, err := keys.NewKeyConfig(pubKey, alg, scope)
 	if err != nil {
 		return nil, err
 	}
-	return bundle.NewVerificationConfig(map[string]*bundle.KeyConfig{pubKeyID: keyConfig}, pubKeyID, scope, excludeFiles), nil
+	return bundle.NewVerificationConfig(map[string]*keys.Config{pubKeyID: keyConfig}, pubKeyID, scope, excludeFiles), nil
 }
 
 func buildSigningConfig(key, alg, claimsFile string) *bundle.SigningConfig {

--- a/cmd/sign_test.go
+++ b/cmd/sign_test.go
@@ -9,6 +9,8 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/open-policy-agent/opa/keys"
+
 	"github.com/open-policy-agent/opa/internal/file/archive"
 
 	"github.com/open-policy-agent/opa/bundle"
@@ -117,12 +119,12 @@ func TestBundleSignVerification(t *testing.T) {
 		buf := archive.MustWriteTarGz(filesInBundle)
 
 		// bundle verification config
-		kc := bundle.KeyConfig{
+		kc := keys.Config{
 			Key:       "mysecret",
 			Algorithm: "HS256",
 		}
 
-		bvc := bundle.NewVerificationConfig(map[string]*bundle.KeyConfig{"foo": &kc}, "foo", "", nil)
+		bvc := bundle.NewVerificationConfig(map[string]*keys.Config{"foo": &kc}, "foo", "", nil)
 		reader := bundle.NewReader(buf).WithBundleVerificationConfig(bvc).WithBaseDir(rootDir)
 
 		_, err = reader.Read()

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -245,7 +245,7 @@ multiple services.
 Each service may optionally specify a credential mechanism by which OPA will authenticate
 itself to the service.
 
-#### Bearer token
+#### Bearer Token
 
 OPA will authenticate using the specified bearer token and schema; to enable bearer token
 authentication, either the token or the path to the token must be specified. If the latter is provided, on each request OPA will re-read the token from the file and use that token for authentication.
@@ -259,7 +259,7 @@ if unspecified.
 | `services[_].credentials.bearer.token_path` | `string` | Yes | Enables token-based authentication and supplies the path to the bearer token to authenticate with. |
 | `services[_].credentials.bearer.scheme` | `string` | No | Bearer token scheme to specify. |
 
-#### Client TLS certificate
+#### Client TLS Certificate
 
 OPA will present the specified TLS certificate to authenticate. The paths to the client certificate
 and the private key are required; the passphrase for the private key is only required if the
@@ -271,7 +271,7 @@ private key is encrypted.
 | `services[_].credentials.client_tls.private_key` | `string` | Yes | The path to the private key of the client certificate. |
 | `services[_].credentials.client_tls.private_key_passphrase` | `string` | No | The passphrase to use for the private key. |
 
-#### OAuth2 client credentials
+#### OAuth2 Client Credentials
 
 OPA will authenticate using a bearer token obtained through the OAuth2 [client credentials](https://tools.ietf.org/html/rfc6749#section-4.4) flow.
 Following successful authentication at the token endpoint the returned token will be cached for subsequent requests for the duration of its lifetime. Note that as per the [OAuth2 standard](https://tools.ietf.org/html/rfc6749#section-2.3.1), only the HTTPS scheme is supported for the token endpoint URL.
@@ -283,7 +283,104 @@ Following successful authentication at the token endpoint the returned token wil
 | `services[_].credentials.oauth2.client_secret` | `string` | Yes | The client secret to use for authentication. |
 | `services[_].credentials.oauth2.scopes` | `[]string` | No | Optional list of scopes to request for the token. |
 
-#### AWS signature
+#### OAuth2 Client Credentials JWT authentication
+
+OPA will authenticate using a bearer token obtained through the OAuth2 [client credentials](https://tools.ietf.org/html/rfc6749#section-4.4) flow.
+Rather than providing a client secret along with the request for an access token, the client [asserts](https://tools.ietf.org/html/rfc7521#section-4.2) its identity in the form of a signed JWT.
+Following successful authentication at the token endpoint the returned token will be cached for subsequent requests for the duration of its lifetime. Note that as per the [OAuth2 standard](https://tools.ietf.org/html/rfc6749#section-2.3.1), only the HTTPS scheme is supported for the token endpoint URL.
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `services[_].credentials.oauth2.token_url` | `string` | Yes | URL pointing to the token endpoint at the OAuth2 authorization server. |
+| `services[_].credentials.oauth2.grant_type` | `string` | No | Defaults to `client_credentials`. |
+| `services[_].credentials.oauth2.client_id` | `string` | No | The client ID to use for authentication. |
+| `services[_].credentials.oauth2.signing_key` | `string` | Yes | Reference to private key used for signing the JWT. |
+| `services[_].credentials.oauth2.additional_claims` | `map` | No | Map of claims to include in the JWT (see notes below) |
+| `services[_].credentials.oauth2.include_jti_claim` | `bool` | No | Include a uniquely generated `jti` claim in any issued JWT |
+| `services[_].credentials.oauth2.scopes` | `[]string` | No | Optional list of scopes to request for the token. |
+
+Two claims will always be included in the issued JWT: `iat` and `exp`. Any other claims will be populated from the `additional_claims` map.
+
+##### Example
+
+Using the client credentials grant type with JWT client authentication replacing client secret as the credential used at the token endpoint.
+
+```yaml
+services:
+  remote:
+    url: ${BUNDLE_SERVICE_URL}
+    credentials:
+      oauth2:
+        grant_type: client_credentials
+        client_id: opa-client
+        signing_key: jwt_signing_key # references the key in `keys` below
+        include_jti_claim: true
+        scopes:
+        - read
+        - write
+        additional_claims:
+          sub: opa-client
+          iss: opa-${POD_NAME}
+
+bundles:
+  authz:
+    service: remote
+    resource: bundles/http/example/authz.tar.gz
+
+keys:
+  jwt_signing_key:
+    algorithm: ES512
+    private_key: ${BUNDLE_SERVICE_SIGNING_KEY}
+```
+
+#### OAuth2 JWT Bearer Grant Type
+
+OPA will authenticate using a bearer token obtained through the OAuth2 [JWT authorization grant](https://tools.ietf.org/html/rfc7523#section-2.1) flow.
+Rather than providing a client secret along with the request for an access token, the client [asserts](https://tools.ietf.org/html/rfc7521#section-4.1) its identity in the form of a signed JWT.
+Following successful authentication at the token endpoint the returned token will be cached for subsequent requests for the duration of its lifetime. Note that as per the [OAuth2 standard](https://tools.ietf.org/html/rfc6749#section-2.3.1), only the HTTPS scheme is supported for the token endpoint URL.
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `services[_].credentials.oauth2.token_url` | `string` | Yes | URL pointing to the token endpoint at the OAuth2 authorization server. |
+| `services[_].credentials.oauth2.grant_type` | `string` | No | Must be set to `jwt_bearer` for JWT bearer grant type. Defaults to `client_credentials`. |
+| `services[_].credentials.oauth2.signing_key` | `string` | Yes | Reference to private key used for signing the JWT. |
+| `services[_].credentials.oauth2.additional_claims` | `map` | No | Map of claims to include in the JWT (see notes below) |
+| `services[_].credentials.oauth2.include_jti_claim` | `bool` | No | Include a uniquely generated `jti` claim in any issued JWT |
+| `services[_].credentials.oauth2.scopes` | `[]string` | No | Optional list of scopes to request for the token. |
+
+Two claims will always be included in the issued JWT: `iat` and `exp`. Any other claims will be populated from the `additional_claims` map.
+
+##### Example
+
+Using a [Google Cloud Storage](https://cloud.google.com/storage/) bucket as a bundle service backend from outside the
+cloud account (for access from inside the account, see the [GCP Metadata Token](#GCP Metadata Token) section).
+
+```yaml
+services:
+  gcp:
+    url: ${BUNDLE_SERVICE_URL}
+    credentials:
+      oauth2:
+        grant_type: jwt_bearer
+        signing_key: jwt_signing_key # references the key in `keys` below
+        scopes:
+        - https://www.googleapis.com/auth/devstorage.read_only
+        additional_claims:
+          aud: https://oauth2.googleapis.com/token
+          iss: opa-client@my-account.iam.gserviceaccount.com
+
+bundles:
+  authz:
+    service: gcp
+    resource: bundles/http/example/authz.tar.gz
+
+keys:
+  jwt_signing_key:
+    algorithm: RS256
+    private_key: ${BUNDLE_SERVICE_SIGNING_KEY}
+```
+
+#### AWS Signature
 
 OPA will authenticate with an [AWS4 HMAC](https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-auth-using-authorization-header.html) signature. Two methods of obtaining the
 necessary credentials are available; exactly one must be specified to use the AWS signature
@@ -522,7 +619,8 @@ Keys is a dictionary mapping the key name to the actual key and optionally the a
 
 | Field | Type | Required | Description |
 | --- | --- | --- | --- |
-| `keys[_].key` | `string` | Yes | Actual key to use for bundle signature verification. |
+| `keys[_].key` | `string` | Yes (unless `private_key` provided) | PEM encoded public key to use for signature verification. |
+| `keys[_].private_key` | `string` | Yes (unless `key` provided`) | PEM encoded private key to use for signing. |
 | `keys[_].algorithm` | `string` | No (default: `RS256`) | Name of the signing algorithm. |
 | `keys[_].scope` | `string` | No | Scope to use for bundle signature verification. |
 

--- a/download/download_test.go
+++ b/download/download_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 
 	"github.com/open-policy-agent/opa/bundle"
+	"github.com/open-policy-agent/opa/keys"
 	"github.com/open-policy-agent/opa/plugins/rest"
 )
 
@@ -198,7 +199,7 @@ func newTestFixture(t *testing.T) testFixture {
 		}
 	}`, ts.server.URL))
 
-	tc, err := rest.New(restConfig)
+	tc, err := rest.New(restConfig, map[string]*keys.Config{})
 
 	if err != nil {
 		t.Fatal(err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,6 +13,8 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/open-policy-agent/opa/keys"
+
 	"github.com/ghodss/yaml"
 
 	"github.com/open-policy-agent/opa/internal/strvals"
@@ -24,6 +26,7 @@ import (
 type ServiceOptions struct {
 	Raw        json.RawMessage
 	AuthPlugin func(string) rest.HTTPAuthPlugin
+	Keys       map[string]*keys.Config
 }
 
 // ParseServicesConfig returns a set of named service clients. The service
@@ -39,7 +42,7 @@ func ParseServicesConfig(opts ServiceOptions) (map[string]rest.Client, error) {
 
 	if err := util.Unmarshal(opts.Raw, &arr); err == nil {
 		for _, s := range arr {
-			client, err := rest.New(s, rest.AuthPluginLookup(opts.AuthPlugin))
+			client, err := rest.New(s, opts.Keys, rest.AuthPluginLookup(opts.AuthPlugin))
 			if err != nil {
 				return nil, err
 			}
@@ -47,7 +50,7 @@ func ParseServicesConfig(opts ServiceOptions) (map[string]rest.Client, error) {
 		}
 	} else if util.Unmarshal(opts.Raw, &obj) == nil {
 		for k := range obj {
-			client, err := rest.New(obj[k], rest.Name(k), rest.AuthPluginLookup(opts.AuthPlugin))
+			client, err := rest.New(obj[k], opts.Keys, rest.Name(k), rest.AuthPluginLookup(opts.AuthPlugin))
 			if err != nil {
 				return nil, err
 			}

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -12,6 +12,8 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/open-policy-agent/opa/keys"
+
 	"os"
 	"time"
 
@@ -67,7 +69,7 @@ func New(id string) (*Reporter, error) {
 		"url": %q,
 	}`, url))
 
-	client, err := rest.New(restConfig)
+	client, err := rest.New(restConfig, map[string]*keys.Config{})
 	if err != nil {
 		return nil, err
 	}

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -1,0 +1,100 @@
+package keys
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/open-policy-agent/opa/util"
+)
+
+const defaultSigningAlgorithm = "RS256"
+
+var supportedAlgos = map[string]struct{}{
+	"ES256": {}, "ES384": {}, "ES512": {},
+	"HS256": {}, "HS384": {}, "HS512": {},
+	"PS256": {}, "PS384": {}, "PS512": {},
+	"RS256": {}, "RS384": {}, "RS512": {},
+}
+
+// IsSupportedAlgorithm true if provided alg is supported
+func IsSupportedAlgorithm(alg string) bool {
+	_, ok := supportedAlgos[alg]
+	return ok
+}
+
+// Config holds the keys used to sign or verify bundles and tokens
+type Config struct {
+	Key        string `json:"key"`
+	PrivateKey string `json:"private_key"`
+	Algorithm  string `json:"algorithm"`
+	Scope      string `json:"scope"`
+}
+
+// Equal returns true if this key config is equal to the other.
+func (k *Config) Equal(other *Config) bool {
+	return other != nil && *k == *other
+}
+
+func (k *Config) validateAndInjectDefaults(id string) error {
+	if k.Key == "" && k.PrivateKey == "" {
+		return fmt.Errorf("invalid keys configuration: no keys provided for key ID %v", id)
+	}
+
+	if k.Algorithm == "" {
+		k.Algorithm = defaultSigningAlgorithm
+	}
+
+	if !IsSupportedAlgorithm(k.Algorithm) {
+		return fmt.Errorf("unsupported algorithm '%v'", k.Algorithm)
+	}
+
+	return nil
+}
+
+// NewKeyConfig return a new Config
+func NewKeyConfig(key, alg, scope string) (*Config, error) {
+	var pubKey string
+	if _, err := os.Stat(key); err == nil {
+		bs, err := ioutil.ReadFile(key)
+		if err != nil {
+			return nil, err
+		}
+		pubKey = string(bs)
+	} else if os.IsNotExist(err) {
+		pubKey = key
+	} else {
+		return nil, err
+	}
+
+	return &Config{
+		Key:       pubKey,
+		Algorithm: alg,
+		Scope:     scope,
+	}, nil
+}
+
+// ParseKeysConfig returns a map containing the key and the signing algorithm
+func ParseKeysConfig(raw json.RawMessage) (map[string]*Config, error) {
+	keys := map[string]*Config{}
+	var obj map[string]json.RawMessage
+
+	if err := util.Unmarshal(raw, &obj); err == nil {
+		for k := range obj {
+			var keyConfig Config
+			if err = util.Unmarshal(obj[k], &keyConfig); err != nil {
+				return nil, err
+			}
+
+			if err = keyConfig.validateAndInjectDefaults(k); err != nil {
+				return nil, err
+			}
+
+			keys[k] = &keyConfig
+		}
+	} else {
+		return nil, err
+	}
+	return keys, nil
+}

--- a/keys/keys_test.go
+++ b/keys/keys_test.go
@@ -1,0 +1,191 @@
+package keys
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/open-policy-agent/opa/util/test"
+)
+
+func TestParseKeysConfig(t *testing.T) {
+
+	key := `-----BEGIN PUBLIC KEY----- MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA7nJwME0QNM6g0Ou9Sylj lcIY4cnBcs8oWVHe74bJ7JTgYmDOk2CA14RE3wJNkUKERP/cRdesKDA/BToJXJUr oYvhjXxUYn+i3wK5vOGRY9WUtTF9paIIpIV4USUOwDh3ufhA9K3tyh+ZVsqn80em 0Lj2ME0EgScuk6u0/UYjjNvcmnQl+uDmghG8xBZh7TZW2+aceMwlb4LJIP36VRhg jKQGIxg2rW8ROXgJaFbNRCbiOUUqlq9SUZuhHo8TNOARXXxp9R4Fq7Cl7ZbwWtNP wAtM1y+Z+iyu/i91m0YLlU2XBOGLu9IA8IZjPlbCnk/SygpV9NNwTY9DSQ0QfXcP TGlsbFwzRzTlhH25wEl3j+2Ub9w/NX7Yo+j/Ei9eGZ8cq0bcvEwDeIo98HeNZWrL UUArayRYvh8zutOlzqehw8waFk9AxpfEp9oWekSz8gZw9OL773EhnglYxxjkPHNz k66CufLuTEf6uE9NLE5HnlQMbiqBFirIyAWGKyU3v2tphKvcogxmzzWA51p0GY0l GZvlLNt2NrJv2oGecyl3BLqHnBi+rGAosa/8XgfQT8RIk7YR/tDPDmPfaqSIc0po +NcHYEH82Yv+gfKSK++1fyssGCsSRJs8PFMuPGgv62fFrE/EHSsHJaNWojSYce/T rxm2RaHhw/8O4oKcfrbaRf8CAwEAAQ== -----END PUBLIC KEY-----`
+
+	config := fmt.Sprintf(`{"foo": {"algorithm": "HS256", "key": "FdFYFzERwC2uCBB46pZQi4GG85LujR8obt-KWRBICVQ"},
+			  				"bar": {"key": %v}
+				}`, key)
+
+	tests := map[string]struct {
+		input   string
+		result  map[string]*Config
+		wantErr bool
+		err     error
+	}{
+		"valid_config_one_key": {
+			`{"foo": {"algorithm": "HS256", "key": "FdFYFzERwC2uCBB46pZQi4GG85LujR8obt-KWRBICVQ"}}`,
+			map[string]*Config{"foo": {Key: "FdFYFzERwC2uCBB46pZQi4GG85LujR8obt-KWRBICVQ", Algorithm: "HS256"}},
+			false, nil,
+		},
+		"valid_config_two_key": {
+			config,
+			map[string]*Config{
+				"foo": {Key: "FdFYFzERwC2uCBB46pZQi4GG85LujR8obt-KWRBICVQ", Algorithm: "HS256"},
+				"bar": {Key: key, Algorithm: "RS256"},
+			},
+			false, nil,
+		},
+		"invalid_config_no_key": {
+			`{"foo": {"algorithm": "HS256"}}`,
+			nil,
+			true, fmt.Errorf("invalid keys configuration: no keys provided for key ID foo"),
+		},
+		"valid_config_default_alg": {
+			`{"foo": {"key": "FdFYFzERwC2uCBB46pZQi4GG85LujR8obt-KWRBICVQ"}}`,
+			map[string]*Config{"foo": {Key: "FdFYFzERwC2uCBB46pZQi4GG85LujR8obt-KWRBICVQ", Algorithm: "RS256"}},
+			false, nil,
+		},
+		"invalid_raw_key_config": {
+			`{"bar": [1,2,3]}`,
+			nil,
+			true, fmt.Errorf("json: cannot unmarshal array into Go value of type keys.Config"),
+		},
+		"invalid_raw_config": {
+			`[1,2,3]`,
+			nil,
+			true, fmt.Errorf("json: cannot unmarshal array into Go value of type map[string]json.RawMessage"),
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+
+			kc, err := ParseKeysConfig([]byte(tc.input))
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("Expected error but got nil")
+				}
+
+				if tc.err != nil && tc.err.Error() != err.Error() {
+					t.Fatalf("Expected error message %v but got %v", tc.err.Error(), err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("Unexpected error %v", err)
+				}
+			}
+
+			if !reflect.DeepEqual(kc, tc.result) {
+				t.Fatalf("Expected key config %v but got %v", tc.result, kc)
+			}
+		})
+	}
+}
+
+func TestNewKeyConfig(t *testing.T) {
+	publicKey := `-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA9KaakMv1XKKDaSch3PFR
+3a27oaHp1GNTTNqvb1ZaHZXp+wuhYDwc/MTE67x9GCifvQBWzEGorgTq7aisiOyl
+vKifwz6/wQ+62WHKG/sqKn2Xikp3P63aBIPlZcHbkyyRmL62yeyuzYoGvLEYel+m
+z5SiKGBwviSY0Th2L4e5sGJuk2HOut6emxDi+E2Fuuj5zokFJvIT6Urlq8f3h6+l
+GeR6HUOXqoYVf7ff126GP7dticTVBgibxkkuJFmpvQSW6xmxruT4k6iwjzbZHY7P
+ypZ/TdlnuGC1cOpAVyU7k32IJ9CRbt3nwEf5U54LRXLLQjFixWZHwKdDiMTF4ws0
++wIDAQAB
+-----END PUBLIC KEY-----`
+
+	files := map[string]string{
+		"public.pem": publicKey,
+	}
+
+	test.WithTempFS(files, func(rootDir string) {
+
+		kc, err := NewKeyConfig(filepath.Join(rootDir, "public.pem"), "RS256", "read")
+		if err != nil {
+			t.Fatalf("Unexpected error %v", err)
+		}
+
+		expected := &Config{
+			Key:       publicKey,
+			Algorithm: "RS256",
+			Scope:     "read",
+		}
+
+		if !reflect.DeepEqual(kc, expected) {
+			t.Fatalf("Expected key config %v but got %v", expected, kc)
+		}
+
+		// secret provided on command-line
+		kc, err = NewKeyConfig(publicKey, "HS256", "")
+		if err != nil {
+			t.Fatalf("Unexpected error %v", err)
+		}
+
+		expected = &Config{
+			Key:       publicKey,
+			Algorithm: "HS256",
+			Scope:     "",
+		}
+
+		if !reflect.DeepEqual(kc, expected) {
+			t.Fatalf("Expected key config %v but got %v", expected, kc)
+		}
+
+		// simulate error while reading file
+		err = os.Chmod(filepath.Join(rootDir, "public.pem"), 0111)
+		if err != nil {
+			t.Fatalf("Unexpected error %v", err)
+		}
+
+		_, err = NewKeyConfig(filepath.Join(rootDir, "public.pem"), "RS256", "read")
+		if err == nil {
+			t.Fatal("Expected error but got nil")
+		}
+	})
+}
+
+func TestKeyConfigEqual(t *testing.T) {
+	tests := map[string]struct {
+		a   *Config
+		b   *Config
+		exp bool
+	}{
+		"equal": {
+			&Config{
+				Key:       "foo",
+				Algorithm: "RS256",
+				Scope:     "read",
+			},
+			&Config{
+				Key:       "foo",
+				Algorithm: "RS256",
+				Scope:     "read",
+			},
+			true,
+		},
+		"not_equal": {
+			&Config{
+				Key:       "foo",
+				Algorithm: "RS256",
+				Scope:     "read",
+			},
+			&Config{
+				Key:       "foo",
+				Algorithm: "RS256",
+				Scope:     "write",
+			},
+			false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			actual := tc.a.Equal(tc.b)
+
+			if actual != tc.exp {
+				t.Fatalf("Expected config equal result %v but got %v", tc.exp, actual)
+			}
+		})
+	}
+}

--- a/plugins/bundle/config.go
+++ b/plugins/bundle/config.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/open-policy-agent/opa/bundle"
 	"github.com/open-policy-agent/opa/download"
+	"github.com/open-policy-agent/opa/keys"
 	"github.com/open-policy-agent/opa/util"
 )
 
@@ -78,7 +79,7 @@ func (b *ConfigBuilder) WithServices(services []string) *ConfigBuilder {
 }
 
 // WithKeyConfigs sets the public keys to verify a signed bundle
-func (b *ConfigBuilder) WithKeyConfigs(keys map[string]*bundle.KeyConfig) *ConfigBuilder {
+func (b *ConfigBuilder) WithKeyConfigs(keys map[string]*keys.Config) *ConfigBuilder {
 	b.keys = keys
 	return b
 }
@@ -115,7 +116,7 @@ func (b *ConfigBuilder) Parse() (*Config, error) {
 type ConfigBuilder struct {
 	raw      []byte
 	services []string
-	keys     map[string]*bundle.KeyConfig
+	keys     map[string]*keys.Config
 }
 
 // Config represents the configuration of the plugin.
@@ -152,7 +153,7 @@ func (c *Config) IsMultiBundle() bool {
 	return c.Name == ""
 }
 
-func (c *Config) validateAndInjectDefaults(services []string, keys map[string]*bundle.KeyConfig) error {
+func (c *Config) validateAndInjectDefaults(services []string, keys map[string]*keys.Config) error {
 	if c.Bundles == nil {
 		return c.validateAndInjectDefaultsLegacy(services)
 	}

--- a/plugins/bundle/config_test.go
+++ b/plugins/bundle/config_test.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/open-policy-agent/opa/keys"
+
 	"github.com/open-policy-agent/opa/bundle"
 
 	"github.com/ghodss/yaml"
@@ -225,7 +227,7 @@ func TestParseAndValidateBundlesConfig(t *testing.T) {
 		},
 	}
 
-	keys := map[string]*bundle.KeyConfig{"foo": {Key: "secret"}}
+	keys := map[string]*keys.Config{"foo": {Key: "secret"}}
 	for i := range tests {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
 			_, err := NewConfigBuilder().WithBytes([]byte(tests[i].conf)).WithServices(tests[i].services).

--- a/plugins/bundle/plugin_test.go
+++ b/plugins/bundle/plugin_test.go
@@ -20,6 +20,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/open-policy-agent/opa/keys"
+
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/bundle"
 	"github.com/open-policy-agent/opa/config"
@@ -1751,7 +1753,7 @@ func TestLoadSignedBundleFromDisk(t *testing.T) {
 	b := writeTestBundleToDisk(t, bundleDir, true)
 
 	src := Source{
-		Signing: bundle.NewVerificationConfig(map[string]*bundle.KeyConfig{"foo": {Key: "secret", Algorithm: "HS256"}}, "foo", "", nil),
+		Signing: bundle.NewVerificationConfig(map[string]*keys.Config{"foo": {Key: "secret", Algorithm: "HS256"}}, "foo", "", nil),
 	}
 
 	result, err := loadBundleFromDisk(dir, bundleName, &src)

--- a/plugins/discovery/config_test.go
+++ b/plugins/discovery/config_test.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/open-policy-agent/opa/bundle"
+	"github.com/open-policy-agent/opa/keys"
 )
 
 func TestConfigValidation(t *testing.T) {
@@ -64,7 +64,7 @@ func TestConfigValidation(t *testing.T) {
 		},
 	}
 
-	keys := map[string]*bundle.KeyConfig{"foo": {Key: "secret"}}
+	keys := map[string]*keys.Config{"foo": {Key: "secret"}}
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("TestConfigValidation_case_%d", i), func(t *testing.T) {
 			_, err := NewConfigBuilder().WithBytes([]byte(test.input)).WithServices(test.services).WithKeyConfigs(keys).Parse()

--- a/plugins/discovery/discovery.go
+++ b/plugins/discovery/discovery.go
@@ -11,8 +11,6 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/open-policy-agent/opa/metrics"
-
 	"github.com/sirupsen/logrus"
 
 	"github.com/open-policy-agent/opa/ast"
@@ -20,6 +18,8 @@ import (
 	"github.com/open-policy-agent/opa/config"
 	"github.com/open-policy-agent/opa/download"
 	cfg "github.com/open-policy-agent/opa/internal/config"
+	"github.com/open-policy-agent/opa/keys"
+	"github.com/open-policy-agent/opa/metrics"
 	"github.com/open-policy-agent/opa/plugins"
 	"github.com/open-policy-agent/opa/plugins/bundle"
 	"github.com/open-policy-agent/opa/plugins/logs"
@@ -232,6 +232,7 @@ func (c *Discovery) processBundle(ctx context.Context, b *bundleApi.Bundle) (*pl
 	opts := cfg.ServiceOptions{
 		Raw:        config.Services,
 		AuthPlugin: c.manager.AuthPlugin,
+		Keys:       c.manager.PublicKeys(),
 	}
 	services, err := cfg.ParseServicesConfig(opts)
 	if err != nil {
@@ -246,7 +247,7 @@ func (c *Discovery) processBundle(ctx context.Context, b *bundleApi.Bundle) (*pl
 	}
 
 	// check for updates to the keys provided in the boot config
-	keys, err := bundleApi.ParseKeysConfig(config.Keys)
+	keys, err := keys.ParseKeysConfig(config.Keys)
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/rest/gcp_test.go
+++ b/plugins/rest/gcp_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/open-policy-agent/opa/keys"
 )
 
 func TestGCPMetadataAuthPlugin(t *testing.T) {
@@ -31,7 +33,7 @@ func TestGCPMetadataAuthPlugin(t *testing.T) {
             }
         }
     }`, s.URL, ts.URL)
-	client, err := New([]byte(config))
+	client, err := New([]byte(config), map[string]*keys.Config{})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}

--- a/plugins/rest/rest.go
+++ b/plugins/rest/rest.go
@@ -15,6 +15,8 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/open-policy-agent/opa/keys"
+
 	"github.com/open-policy-agent/opa/internal/version"
 
 	"github.com/sirupsen/logrus"
@@ -48,6 +50,8 @@ type Config struct {
 		GCPMetadata *gcpMetadataAuthPlugin             `json:"gcp_metadata,omitempty"`
 		Plugin      *string                            `json:"plugin,omitempty"`
 	} `json:"credentials"`
+
+	keys map[string]*keys.Config
 }
 
 // Equal returns true if this client config is equal to the other.
@@ -124,7 +128,7 @@ func AuthPluginLookup(l func(string) HTTPAuthPlugin) func(*Client) {
 }
 
 // New returns a new Client for config.
-func New(config []byte, opts ...func(*Client)) (Client, error) {
+func New(config []byte, keys map[string]*keys.Config, opts ...func(*Client)) (Client, error) {
 	var parsedConfig Config
 
 	if err := util.Unmarshal(config, &parsedConfig); err != nil {
@@ -138,6 +142,8 @@ func New(config []byte, opts ...func(*Client)) (Client, error) {
 		*timeout = defaultResponseHeaderTimeoutSeconds
 		parsedConfig.ResponseHeaderTimeoutSeconds = timeout
 	}
+
+	parsedConfig.keys = keys
 
 	client := Client{
 		config: parsedConfig,

--- a/topdown/tokens.go
+++ b/topdown/tokens.go
@@ -866,7 +866,7 @@ func commonBuiltinJWTEncodeSign(inputHeaders, jwsPayload, jwkSrc string) (v ast.
 	if err != nil {
 		return nil, err
 	}
-	return ast.String(jwsCompact[:]), nil
+	return ast.String(jwsCompact), nil
 
 }
 


### PR DESCRIPTION
Allow OPA to issue JWT's which it uses to authenticate a configured
OAuth2 client, as described in RFC7523. This replaces the client_secret
as the actual credential and allows for either using an entirely new
grant type called "JWT bearer", or using the previously supported
client_credentials grant type, only with the client_secret replaced
by a signed JWT. This change covers both scenarios described in
RFC7523.

Other changes made to accomodate this feature:

- Add `private_key` attribute to keys struct to allow for both public and
private keys to be stored there.
- Refactored the keys configuration struct and logic to its
own package no longer coupled to bundles.

Closes #3055

Signed-off-by: Anders Eknert <anders@eknert.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
