### PR TITLE
ci: run npm-opa-wasm example

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -89,3 +89,28 @@ jobs:
       - name: Build and Test Wasm SDK
         run: make ci-go-wasm-sdk-e2e-test
         timeout-minutes: 30
+
+  nodejs-wasm-example:
+    name: npm-opa-wasm
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Build OPA
+        run: |
+          make ci-go-build-linux
+          ln -s _release/*/opa_linux_amd64 opa
+          echo $(pwd) >> $GITHUB_PATH
+
+      - name: Check out npm-opa-wasm
+        uses: actions/checkout@v2
+        with:
+          repository: open-policy-agent/npm-opa-wasm
+          path: npm-opa-wasm
+
+      - name: Run npm-opa-wasm nodejs-app examples
+        run: |
+          npm install
+          ./e2e.sh
+        working-directory: npm-opa-wasm


### PR DESCRIPTION
This attempts to give us some more safety for WASM-related changes.
We don't want to break the SDK!

It's introducing some coordination efforts in the future: when a WASM-
related change is supposed to be merged that requires SDKs to change,
we'll have to merge that into npm-opa-wasm first, before the PR can go
in. However, it's better to have this sort of breaking change smoke
test.

I'm undecided whether it's better in nightly or the per-PR checks. It doesn't
take too long, if I also wouldn't want to pile on too much stuff into per-PR
actions 🤔 

👉  Prompted by #3092.