### PR TITLE
docs/envoy-authorization: update to transport APIv3, Envoy 1.17

### DIFF
--- a/docs/content/envoy-authorization.md
+++ b/docs/content/envoy-authorization.md
@@ -48,63 +48,74 @@ Save the configuration as **envoy.yaml**:
 ```yaml
 static_resources:
   listeners:
-    - address:
-        socket_address:
-          address: 0.0.0.0
-          port_value: 8000
-      filter_chains:
-        - filters:
-            - name: envoy.http_connection_manager
-              typed_config:
-                "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
-                codec_type: auto
-                stat_prefix: ingress_http
-                route_config:
-                  name: local_route
-                  virtual_hosts:
-                    - name: backend
-                      domains:
-                        - "*"
-                      routes:
-                        - match:
-                            prefix: "/"
-                          route:
-                            cluster: service
-                http_filters:
-                  - name: envoy.ext_authz
-                    typed_config:
-                      "@type": type.googleapis.com/envoy.config.filter.http.ext_authz.v2.ExtAuthz
-                      with_request_body:
-                        max_request_bytes: 8192
-                        allow_partial_message: true
-                      failure_mode_allow: false
-                      grpc_service:
-                        google_grpc:
-                          target_uri: 127.0.0.1:9191
-                          stat_prefix: ext_authz
-                        timeout: 0.5s
-                  - name: envoy.router
-                    typed_config: {}
+  - address:
+      socket_address:
+        address: 0.0.0.0
+        port_value: 8000
+    filter_chains:
+    - filters:
+      - name: envoy.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          codec_type: auto
+          stat_prefix: ingress_http
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: backend
+              domains:
+              - "*"
+              routes:
+              - match:
+                  prefix: "/"
+                route:
+                  cluster: service
+          http_filters:
+          - name: envoy.ext_authz
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz
+              transport_api_version: V3
+              with_request_body:
+                max_request_bytes: 8192
+                allow_partial_message: true
+              failure_mode_allow: false
+              grpc_service:
+                google_grpc:
+                  target_uri: 127.0.0.1:9191
+                  stat_prefix: ext_authz
+                timeout: 0.5s
+          - name: envoy.filters.http.router
   clusters:
-    - name: service
-      connect_timeout: 0.25s
-      type: strict_dns
-      lb_policy: round_robin
-      load_assignment:
-        cluster_name: service
-        endpoints:
-          - lb_endpoints:
-              - endpoint:
-                  address:
-                    socket_address:
-                      address: 127.0.0.1
-                      port_value: 8080
+  - name: service
+    connect_timeout: 0.25s
+    type: strict_dns
+    lb_policy: round_robin
+    load_assignment:
+      cluster_name: service
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: 127.0.0.1
+                port_value: 8080
 admin:
   access_log_path: "/dev/null"
   address:
     socket_address:
       address: 0.0.0.0
       port_value: 8001
+layered_runtime:
+  layers:
+    - name: static_layer_0
+      static_layer:
+        envoy:
+          resource_limits:
+            listener:
+              example_listener_name:
+                connection_limit: 10000
+        overload:
+          global_downstream_max_connections: 50000
 ```
 
 Create the ConfigMap:
@@ -187,16 +198,16 @@ data.envoy.authz.allow
 ```live:example:input
 {
   "attributes": {
-      "request": {
-          "http": {
-              "method": "GET",
-                "path": "/people",
-                "headers": {
-                  "authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoiZ3Vlc3QiLCJzdWIiOiJZV3hwWTJVPSIsIm5iZiI6MTUxNDg1MTEzOSwiZXhwIjoxNjQxMDgxNTM5fQ.K5DnnbbIOspRbpCr2IKXE9cPVatGOCBrBQobQmBmaeU"
-                }
-            }
+    "request": {
+      "http": {
+        "method": "GET",
+        "path": "/people",
+        "headers": {
+          "authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoiZ3Vlc3QiLCJzdWIiOiJZV3hwWTJVPSIsIm5iZiI6MTUxNDg1MTEzOSwiZXhwIjoxNjQxMDgxNTM5fQ.K5DnnbbIOspRbpCr2IKXE9cPVatGOCBrBQobQmBmaeU"
         }
+      }
     }
+  }
 }
 ```
 
@@ -259,63 +270,62 @@ spec:
             runAsNonRoot: false
             runAsUser: 0
       containers:
-        - name: app
-          image: openpolicyagent/demo-test-server:v1
-          ports:
-            - containerPort: 8080
-        - name: envoy
-          image: envoyproxy/envoy:v1.14.4
-          securityContext:
-            runAsUser: 1111
-          volumeMounts:
-          - readOnly: true
-            mountPath: /config
-            name: proxy-config
-          args:
-          - "envoy"
-          - "--config-path"
-          - "/config/envoy.yaml"
-        - name: opa
-          # Note: openpolicyagent/opa:latest-envoy is created by retagging
-          # the latest released image of OPA-Envoy.
-          image: openpolicyagent/opa:{{< current_opa_envoy_docker_version >}}
-          securityContext:
-            runAsUser: 1111
-          volumeMounts:
-          - readOnly: true
-            mountPath: /policy
-            name: opa-policy
-          args:
-          - "run"
-          - "--server"
-          - "--addr=localhost:8181"
-          - "--diagnostic-addr=0.0.0.0:8282"
-          - "--set=plugins.envoy_ext_authz_grpc.addr=:9191"
-          - "--set=plugins.envoy_ext_authz_grpc.query=data.envoy.authz.allow"
-          - "--set=decision_logs.console=true"
-          - "--ignore=.*"
-          - "/policy/policy.rego"
-          livenessProbe:
-            httpGet:
-              path: /health?plugins
-              scheme: HTTP
-              port: 8282
-            initialDelaySeconds: 5
-            periodSeconds: 5
-          readinessProbe:
-            httpGet:
-              path: /health?plugins
-              scheme: HTTP
-              port: 8282
-            initialDelaySeconds: 5
-            periodSeconds: 5
+      - name: app
+        image: openpolicyagent/demo-test-server:v1
+        ports:
+        - containerPort: 8080
+      - name: envoy
+        image: envoyproxy/envoy:v1.17.0
+        volumeMounts:
+        - readOnly: true
+          mountPath: /config
+          name: proxy-config
+        args:
+        - "envoy"
+        - "--config-path"
+        - "/config/envoy.yaml"
+        env:
+        - name: ENVOY_UID
+          value: "1111"
+      - name: opa
+        # Note: openpolicyagent/opa:latest-envoy is created by retagging
+        # the latest released image of OPA-Envoy.
+        image: openpolicyagent/opa:{{< current_opa_envoy_docker_version >}}
+        volumeMounts:
+        - readOnly: true
+          mountPath: /policy
+          name: opa-policy
+        args:
+        - "run"
+        - "--server"
+        - "--addr=localhost:8181"
+        - "--diagnostic-addr=0.0.0.0:8282"
+        - "--set=plugins.envoy_ext_authz_grpc.addr=:9191"
+        - "--set=plugins.envoy_ext_authz_grpc.query=data.envoy.authz.allow"
+        - "--set=decision_logs.console=true"
+        - "--ignore=.*"
+        - "/policy/policy.rego"
+        livenessProbe:
+          httpGet:
+            path: /health?plugins
+            scheme: HTTP
+            port: 8282
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /health?plugins
+            scheme: HTTP
+            port: 8282
+          initialDelaySeconds: 5
+          periodSeconds: 5
       volumes:
-        - name: proxy-config
-          configMap:
-            name: proxy-config
-        - name: opa-policy
-          secret:
-            secretName: opa-policy
+      - name: proxy-config
+        configMap:
+          name: proxy-config
+      - name: opa-policy
+        secret:
+          secretName: opa-policy
 ```
 
 ```bash


### PR DESCRIPTION
Recent versions of envoy's docker container have changed the way
dropping privileges works:

- it happens by default
- it's not driven by `securityContext.runAsUser`

So in the docker container's entrypoint, the environment will be
set up: /dev/std{err,out} will be chowned to an unprivileged user,
which will have uid ENVOY_UID. Hence we set that env variable to
match the UID we us with iptables in open-policy-agent/proxy_init.

Fixes #3101 and the issue described in #3091.