### PR TITLE
Update docs on console logging

### DIFF
--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -681,7 +681,7 @@ included in the actual bundle gzipped tarball.
 | --- | --- | --- | --- |
 | `status.service` | `string` | Yes | Name of service to use to contact remote server. |
 | `status.partition_name` | `string` | No | Path segment to include in status updates. |
-| `status.console` | `boolean` | No (default: `false`) | Log the status updates locally at `info` level to the console. When enabled alongside a remote status update API the `service` must be configured, the default `service` selection will be disabled. |
+| `status.console` | `boolean` | No (default: `false`) | Log the status updates locally to the console. When enabled alongside a remote status update API the `service` must be configured, the default `service` selection will be disabled. |
 
 
 ### Decision Logs
@@ -696,7 +696,7 @@ included in the actual bundle gzipped tarball.
 | `decision_logs.reporting.max_delay_seconds` | `int64` | No (default: `600`) | Maximum amount of time to wait between uploads. |
 | `decision_logs.mask_decision` | `string` | No (default: `system/log/mask`) | Set path of masking decision. |
 | `decision_logs.plugin` | `string` | No | Use the named plugin for decision logging. If this field exists, the other configuration fields are not required. |
-| `decision_logs.console` | `boolean` | No (default: `false`) | Log the decisions locally at `info` level to the console. When enabled alongside a remote decision logging API the `service` must be configured, the default `service` selection will be disabled. |
+| `decision_logs.console` | `boolean` | No (default: `false`) | Log the decisions locally to the console. When enabled alongside a remote decision logging API the `service` must be configured, the default `service` selection will be disabled. |
 
 ### Discovery
 

--- a/docs/content/management.md
+++ b/docs/content/management.md
@@ -532,7 +532,7 @@ decision_logs:
     console: true
 ```
 
-This will dump all decision through the OPA logging system at the `info` level. See
+This will dump all decisions to the console. See
 [Configuration Reference](../configuration) for more details.
 
 ### Masking Sensitive Data
@@ -911,7 +911,7 @@ This does not require any remote server. Example of minimal config to enable:
 status:
     console: true
 ```
-This will dump all status updates through the OPA logging system at the `info` level. See
+This will dump all status updates to the console. See
 [Configuration Reference](../configuration) for more details.
 
 > Warning: Status update messages are somewhat infrequent but can be very verbose! The


### PR DESCRIPTION
The console logging of decisions or status updates is no longer coupled to
to the "application logger" and not affected by the log level set there.
Seems the docs wasn't updated to reflect this.

Signed-off-by: Anders Eknert <anders@eknert.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
