### PR TITLE
wasm: fix `with` handling in call_indirect optimization

### DIFF
--- a/internal/compiler/wasm/wasm.go
+++ b/internal/compiler/wasm/wasm.go
@@ -623,7 +623,7 @@ func (c *Compiler) emitMapping() error {
 		indices = append(indices, c.funcs[fn.Name])
 		mapping, ok = mapFunc(mapping, fn, i+int(elemOffset))
 		if !ok {
-			return errors.New("mapping function failed")
+			return fmt.Errorf("mapping function %v failed", fn.Name)
 		}
 	}
 

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -191,13 +191,13 @@ func (p *Planner) planRules(rules []*ast.Rule) (string, error) {
 
 	// Create function definition for rules.
 	fn := &ir.Func{
-		Name: fmt.Sprintf("g%d.%s", p.funcs.gen, path),
+		Name: fmt.Sprintf("g%d.%s", p.funcs.gen(), path),
 		Params: []ir.Local{
 			p.newLocal(), // input document
 			p.newLocal(), // data document
 		},
 		Return: p.newLocal(),
-		Path:   append([]string{fmt.Sprintf("g%d", p.funcs.gen)}, pathPieces...),
+		Path:   append([]string{fmt.Sprintf("g%d", p.funcs.gen())}, pathPieces...),
 	}
 
 	// Initialize parameters for functions.
@@ -2121,7 +2121,7 @@ func (p *Planner) optimizeLookup(t *ruletrie, ref ast.Ref) ([][]*ast.Rule, []ir.
 	// plan generation
 	lvar := p.newLocal()
 	stmts = append(stmts, &ir.MakeStringStmt{
-		Index:  p.getStringConst(fmt.Sprintf("g%d", p.funcs.gen)),
+		Index:  p.getStringConst(fmt.Sprintf("g%d", p.funcs.gen())),
 		Target: lvar,
 	})
 	locals = append(locals, lvar)

--- a/internal/planner/rules.go
+++ b/internal/planner/rules.go
@@ -10,39 +10,51 @@ import (
 // document => planned function names. The structure supports Push and Pop
 // operations so that the planner can shadow planned functions when 'with'
 // statements are found.
+// The "gen" numbers indicate the "generations"; whenever a 'with' statement
+// is planned (a new map is `Push()`ed), it will jump to a previously unused
+// number.
 type funcstack struct {
-	stack []map[string]string
+	stack []taggedPairs
+	next  int
+}
+
+type taggedPairs struct {
+	pairs map[string]string
 	gen   int
 }
 
 func newFuncstack() *funcstack {
 	return &funcstack{
-		stack: []map[string]string{
-			map[string]string{},
-		},
-		gen: 0,
-	}
+		stack: []taggedPairs{{pairs: map[string]string{}, gen: 0}},
+		next:  1}
+}
+
+func (p funcstack) last() taggedPairs {
+	return p.stack[len(p.stack)-1]
 }
 
 func (p funcstack) Add(key, value string) {
-	p.stack[len(p.stack)-1][key] = value
+	p.last().pairs[key] = value
 }
 
 func (p funcstack) Get(key string) (string, bool) {
-	value, ok := p.stack[len(p.stack)-1][key]
+	value, ok := p.last().pairs[key]
 	return value, ok
 }
 
 func (p *funcstack) Push(funcs map[string]string) {
-	p.stack = append(p.stack, funcs)
-	p.gen++
+	p.stack = append(p.stack, taggedPairs{pairs: funcs, gen: p.next})
+	p.next++
 }
 
 func (p *funcstack) Pop() map[string]string {
-	last := p.stack[len(p.stack)-1]
+	last := p.last()
 	p.stack = p.stack[:len(p.stack)-1]
-	p.gen++
-	return last
+	return last.pairs
+}
+
+func (p funcstack) gen() int {
+	return p.last().gen
 }
 
 // ruletrie implements a simple trie structure for organizing rules that may be

--- a/internal/planner/rules_test.go
+++ b/internal/planner/rules_test.go
@@ -1,0 +1,77 @@
+// Copyright 2021 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package planner
+
+import (
+	"testing"
+)
+
+func TestFuncstack(t *testing.T) {
+	fs := newFuncstack()
+
+	fs.Add("data.foo.bar", "g0.data.foo.bar")
+
+	fs.Push(map[string]string{}) // g0 -> g1
+	fs.Add("data.foo.bar", "g1.data.foo.bar")
+	f, ok := fs.Get("data.foo.bar")
+	if exp, act := true, ok; exp != act {
+		t.Fatal("expected func to be found")
+	}
+	if exp, act := "g1.data.foo.bar", f; exp != act {
+		t.Errorf("expected func to be %v, got %v", exp, act)
+	}
+	if exp, act := 1, fs.gen(); exp != act {
+		t.Errorf("expected fs gen to be %d, got %d", exp, act)
+	}
+
+	g1 := fs.Pop() // g1 -> g0
+	if exp, act := 1, len(g1); exp != act {
+		t.Errorf("expected g1 func map to have length %d, got %d", exp, act)
+	}
+	if exp, act := 0, fs.gen(); exp != act {
+		t.Errorf("expected fs gen to be %d, got %d", exp, act)
+	}
+
+	f, ok = fs.Get("data.foo.bar")
+	if exp, act := true, ok; exp != act {
+		t.Fatalf("expected func to be found")
+	}
+	if exp, act := "g0.data.foo.bar", f; exp != act {
+		t.Errorf("expected func to be %v, got %v", exp, act)
+	}
+
+	fs.Push(map[string]string{}) // g0 -> g2
+	fs.Add("data.foo.bar", "g2.data.foo.bar")
+	f, ok = fs.Get("data.foo.bar")
+	if exp, act := true, ok; exp != act {
+		t.Fatal("expected func to be found")
+	}
+	if exp, act := "g2.data.foo.bar", f; exp != act {
+		t.Errorf("expected func to be %v, got %v", exp, act)
+	}
+	if exp, act := 2, fs.gen(); exp != act {
+		t.Errorf("expected fs gen to be %d, got %d", exp, act)
+	}
+
+	fs.Push(map[string]string{}) // g2 -> g3
+	fs.Add("data.foo.bar", "g3.data.foo.bar")
+	f, ok = fs.Get("data.foo.bar")
+	if exp, act := true, ok; exp != act {
+		t.Fatal("expected func to be found")
+	}
+	if exp, act := "g3.data.foo.bar", f; exp != act {
+		t.Errorf("expected func to be %v, got %v", exp, act)
+	}
+	_ = fs.Pop() // g3 -> g2
+	_ = fs.Pop() // g2 -> g0
+	if exp, act := 0, fs.gen(); exp != act {
+		t.Errorf("expected fs gen to be %d, got %d", exp, act)
+	}
+
+	fs.Push(map[string]string{}) // g0 -> g4
+	if exp, act := 4, fs.gen(); exp != act {
+		t.Errorf("expected fs gen to be %d, got %d", exp, act)
+	}
+}

--- a/test/wasm/assets/016_with.yaml
+++ b/test/wasm/assets/016_with.yaml
@@ -311,3 +311,19 @@ cases:
     want_result: [
       {"x": [6, 7, [9,8]]}
     ]
+  - note: with and call_indirect gens
+    query: x := "b"; z := data.test[x]
+    modules:
+      - |
+        package test
+
+        a {
+          true with data.one as 1
+        }
+
+        b {
+          true
+        }
+    want_result:
+    - x: b
+      z: true


### PR DESCRIPTION
Recursively planning all the rules we've found in the optimization
case will make this happen:

Assume we're optimizing the call for data.foo[x] where x is a "seen"
variable. If we have rules for data.foo[x] (for some `x`) that involve
`with` statements, that bumps the funcstack generation in the planner.
The any subsequent planned rule for data.foo[x] will keep using that
bumped 'gen'; and it will eventually cause the CallDynamicStmt's first
path element -- 'gen' -- to not match any of those functions.
(Descriptions are difficult, there's a test case :D)
