### PR TITLE
Configurable persistence_directory

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -7,6 +7,8 @@ package config
 
 import (
 	"encoding/json"
+	"os"
+	"path/filepath"
 
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/internal/ref"
@@ -28,6 +30,7 @@ type Config struct {
 	DefaultDecision              *string                    `json:"default_decision"`
 	DefaultAuthorizationDecision *string                    `json:"default_authorization_decision"`
 	Caching                      json.RawMessage            `json:"caching"`
+	PersistenceDirectory         *string                    `json:"persistence_directory"`
 }
 
 // ParseConfig returns a valid Config object with defaults injected. The id
@@ -88,6 +91,18 @@ func (c *Config) validateAndInjectDefaults(id string) error {
 	c.Labels["version"] = version.Version
 
 	return nil
+}
+
+// GetPersistenceDirectory returns the configured persistence directory, or $PWD/.opa if none is configured
+func (c Config) GetPersistenceDirectory() (string, error) {
+	if c.PersistenceDirectory == nil {
+		pwd, err := os.Getwd()
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(pwd, ".opa"), nil
+	}
+	return *c.PersistenceDirectory, nil
 }
 
 const (

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -6,6 +6,8 @@ package config
 
 import (
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -66,5 +68,33 @@ func TestConfigPluginsEnabled(t *testing.T) {
 				t.Errorf("Expected %t but got %t", test.expected, actual)
 			}
 		})
+	}
+}
+
+func TestPersistDirectory(t *testing.T) {
+	pwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	c := Config{}
+	persistDir, err := c.GetPersistenceDirectory()
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	if persistDir != filepath.Join(pwd, ".opa") {
+		t.Errorf("expected persistDir to be %v, got %v", filepath.Join(pwd, ".opa"), persistDir)
+	}
+
+	dir := "/var/opa"
+	c.PersistenceDirectory = &dir
+	persistDir, err = c.GetPersistenceDirectory()
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	if persistDir != dir {
+		t.Errorf("expected peristDir %v and dir %v to be equal", persistDir, dir)
 	}
 }

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -58,6 +58,8 @@ status:
 
 default_decision: /http/example/authz/allow
 
+persistence_directory: /var/opa
+
 keys:
   global_key:
     algorithm: RS256
@@ -611,6 +613,7 @@ func init() {
 | `labels` | `object` | Yes | Set of key-value pairs that uniquely identify the OPA instance. Labels are included when OPA uploads decision logs and status information. |
 | `default_decision` | `string` | No (default: `/system/main`) | Set path of default policy decision used to serve queries against OPA's base URL. |
 | `default_authorization_decision` | `string` | No (default: `/system/authz/allow`) | Set path of default authorization decision for OPA's API. |
+| `persistence_directory` | `string` | No (default `$PWD/.opa`) | Set directory to use for persistence with options like `bundles[_].persist`. |
 | `plugins` | `object` | No (default: `{}`) | Location for custom plugin configuration. See [Plugins](../plugins) for details. |
 
 ### Keys

--- a/plugins/bundle/plugin.go
+++ b/plugins/bundle/plugin.go
@@ -86,7 +86,7 @@ func (p *Plugin) Start(ctx context.Context) error {
 
 	var err error
 
-	p.bundlePersistPath, err = getDefaultBundlePersistPath()
+	p.bundlePersistPath, err = p.getBundlePersistPath()
 	if err != nil {
 		return err
 	}
@@ -593,10 +593,11 @@ func loadBundleFromDisk(path, name string, src *Source) (*bundle.Bundle, error) 
 	}
 }
 
-func getDefaultBundlePersistPath() (string, error) {
-	pwd, err := os.Getwd()
+func (p *Plugin) getBundlePersistPath() (string, error) {
+	persistDir, err := p.manager.Config.GetPersistenceDirectory()
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(pwd, ".opa", "bundles"), nil
+
+	return filepath.Join(persistDir, "bundles"), nil
 }


### PR DESCRIPTION
This allows configuring the persistence_directory OPA should use for persisting
bundles to disk. While this currently only covers bundles I didn't want to close
the door for persisting other type of objects later, so the
persistence_directory option is kept at the top level of the configuration,
defaulting to $PWD/.opa if not provided.

Bundles will be persisted to ${persistence_directory}/bundles.

Closes #3085

Signed-off-by: Anders Eknert <anders@eknert.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
