### PR TITLE
build: Remove codecov check

### DIFF
--- a/.github/workflows/post-merge.yaml
+++ b/.github/workflows/post-merge.yaml
@@ -57,13 +57,6 @@ jobs:
         run: make ci-go-test-coverage
         timeout-minutes: 30
 
-      - name: Codecov Upload
-        uses: codecov/codecov-action@v1
-        with:
-          flags: unittests
-          file: ./coverage.txt
-          fail_ci_if_error: false
-
   deploy-edge:
     name: Push Edge Release
     runs-on: ubuntu-18.04

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -28,13 +28,6 @@ jobs:
         run: make ci-go-test-coverage
         timeout-minutes: 30
 
-      - name: Codecov Upload
-        uses: codecov/codecov-action@v1
-        with:
-          flags: unittests
-          file: ./coverage.txt
-          fail_ci_if_error: false
-
   go-perf:
     name: Go Perf
     runs-on: ubuntu-18.04

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,8 +1,0 @@
-comment: false
-github_checks:
-  annotations: false
-coverage:
-  status:
-    project: off
-ignore:
-  - "internal/gojsonschema"  # ignore new gojsonschema repo and all its contents


### PR DESCRIPTION
The codecov check is not providing any value. Over time we have had to
tweak the check parameters because of false-positives. As well, the
service is often unavailable when clicking through from GitHub. The
final straw was today when the check stopped showing inside of PRs. At
this point everyone is ignoring it.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
