### PR TITLE
Adding rule annotations with schema type checking support for OPA

### DIFF
--- a/ast/compile_test.go
+++ b/ast/compile_test.go
@@ -868,7 +868,8 @@ func TestCompilerCheckTypesWithSchema(t *testing.T) {
 	if err != nil {
 		t.Fatal("Unexpected error:", err)
 	}
-	schemaSet := &SchemaSet{ByPath: map[string]interface{}{"input": schema}}
+	schemaSet := NewSchemaSet()
+	schemaSet.ByPath.Put(InputRootRef, schema)
 	c.WithSchemas(schemaSet)
 	compileStages(c, c.checkTypes)
 	assertNotFailed(t, c)
@@ -4433,7 +4434,8 @@ func TestParseSchemaWithSchemaBadSchema(t *testing.T) {
 
 func TestWithSchema(t *testing.T) {
 	c := NewCompiler()
-	schemaSet := &SchemaSet{ByPath: map[string]interface{}{"input": objectSchema}}
+	schemaSet := NewSchemaSet()
+	schemaSet.ByPath.Put(InputRootRef, objectSchema)
 	c.WithSchemas(schemaSet)
 	if c.schemaSet == nil {
 		t.Fatalf("WithSchema did not set the schema correctly in the compiler")
@@ -4586,7 +4588,7 @@ const refSchema = `
           "null"
         ]
 	  },
-	  
+
       "kind": {
         "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
         "type": [

--- a/ast/env.go
+++ b/ast/env.go
@@ -11,8 +11,9 @@ import (
 
 // TypeEnv contains type info for static analysis such as type checking.
 type TypeEnv struct {
-	tree *typeTreeNode
-	next *TypeEnv
+	tree      *typeTreeNode
+	next      *TypeEnv
+	schemaSet *SchemaSet
 }
 
 // NewTypeEnv returns an empty TypeEnv.
@@ -20,6 +21,29 @@ func NewTypeEnv() *TypeEnv {
 	return &TypeEnv{
 		tree: newTypeTree(),
 	}
+}
+
+// WithSchemas sets the user-provided schemas
+func (env *TypeEnv) WithSchemas(schemas *SchemaSet) *TypeEnv {
+	env.schemaSet = schemas
+	return env
+}
+
+// GetPrefix returns the shortest prefix of ref that exists in env
+func (env *TypeEnv) GetPrefix(ref Ref) (Ref, types.Type) {
+	if len(ref) == 1 {
+		t := env.Get(ref)
+		if t != nil {
+			return ref, t
+		}
+	}
+	for i := 1; i < len(ref); i++ {
+		t := env.Get(ref[:i])
+		if t != nil {
+			return ref[:i], t
+		}
+	}
+	return nil, nil
 }
 
 // Get returns the type of x.

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -131,7 +131,7 @@ func addUnknownsFlag(fs *pflag.FlagSet, unknowns *[]string, value []string) {
 }
 
 func addSchemaFlag(fs *pflag.FlagSet, schemaPath *string) {
-	fs.StringVarP(schemaPath, "schema", "s", "", "set schema file path")
+	fs.StringVarP(schemaPath, "schema", "s", "", "set schema file path or directory path")
 }
 
 func addTargetFlag(fs *pflag.FlagSet, target *util.EnumFlag) {

--- a/go.mod
+++ b/go.mod
@@ -33,4 +33,6 @@ require (
 	golang.org/x/net v0.0.0-20201021035429-f5854403a974
 	golang.org/x/tools v0.1.0
 	golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba
+	golang.org/x/text v0.3.3 // indirect
+	gopkg.in/yaml.v2 v2.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -336,6 +336,8 @@ golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvx
 golang.org/x/lint v0.0.0-20190301231843-5614ed5bae6f/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
+golang.org/x/lint v0.0.0-20200302205851-738671d3881b h1:Wh+f8QHJXR411sJR8/vRBTZ7YapZaRvUcLFFJhusH0k=
+golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/lint v0.0.0-20201208152925-83fdc39ff7b5 h1:2M3HP5CCK1Si9FQhwnzYhXdG6DXeebvUHFpre8QvbyI=
 golang.org/x/lint v0.0.0-20201208152925-83fdc39ff7b5/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
@@ -361,6 +363,9 @@ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
+golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
+golang.org/x/net v0.0.0-20200927032502-5d4f70055728 h1:5wtQIAulKU5AbLQOkjxl32UufnIOqgBX72pS0AV14H0=
+golang.org/x/net v0.0.0-20200927032502-5d4f70055728/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974 h1:IX6qOQeG5uLjB/hjjwjedwfjND0hgjPMMyO1RoIXQNI=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -371,6 +376,7 @@ golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/rego/rego_test.go
+++ b/rego/rego_test.go
@@ -1861,11 +1861,14 @@ func TestPrepareAndCompileWithSchema(t *testing.T) {
 	var schema interface{}
 	err := util.Unmarshal([]byte(schemaBytes), &schema)
 
+	schemaSet := ast.NewSchemaSet()
+	schemaSet.ByPath.Put(ast.InputRootRef, schema)
+
 	r := New(
 		Query("data.test.x"),
 		Module("", module),
 		Package("foo"),
-		Schemas(&ast.SchemaSet{ByPath: map[string]interface{}{"input": schema}}),
+		Schemas(schemaSet),
 	)
 
 	ctx := context.Background()

--- a/types/types.go
+++ b/types/types.go
@@ -311,6 +311,16 @@ func (t *Object) DynamicValue() Type {
 	return t.dynamic.Value
 }
 
+// DynamicProperties returns the type of the object's dynamic elements.
+func (t *Object) DynamicProperties() *DynamicProperty {
+	return t.dynamic
+}
+
+// StaticProperties returns the type of the object's static elements.
+func (t *Object) StaticProperties() []*StaticProperty {
+	return t.static
+}
+
 // Keys returns the keys of the object's static elements.
 func (t *Object) Keys() []interface{} {
 	sl := make([]interface{}, 0, len(t.static))


### PR DESCRIPTION
New support to upload a directory of JSON schema file(s) via "opa eval --schema". Directory can contain schema file(s) for policy input document(s), and schema file(s) for contextual data document(s). These schema files are used then to improve static type checking and to get more precise error reports as you develop Rego code

Also, there is new support for adding annotations on Rules to specify the schemas to be used specifically for type checking the expressions within the scope of that Rule. It helps address issues with schema overloading, and provides even more precise type error reports for a Rego developer.

If your directory contains an `default-input-schema.json` file for the input's schema, that will become the **default** input schema for all rules. This can be overriden with other input schema files, as well and explicitly linked in the rule annotation.

For example: https://github.com/aavarghese/opa-schema-examples/blob/ruleAnnotation/acl/

Documentation for new "rule annotation" feature in https://github.com/aavarghese/opa/blob/ruleAnnotation/docs/content/schemas.md

This work is continuation of merged PR #3060.

Co-authored-by: @vazirim Mandana Vaziri mvaziri@us.ibm.com
Co-authored-by: @aavarghese Ansu Varghese avarghese@us.ibm.com
Co-authored-by: @tsandall Torin Sandall torinsandall@gmail.com

Note: addresses some points discussed in #1449

