### PR TITLE
wasm: allow for unknown data

### DIFF
--- a/internal/wasm/sdk/opa/opa_test.go
+++ b/internal/wasm/sdk/opa/opa_test.go
@@ -220,6 +220,15 @@ a = "c" { input > 2 }`,
 				{Result: `{{"x": true}}`},
 			},
 		},
+		{
+			Description: "Virtual extent, undefined data",
+			Policy: `package a.b
+			c = 3`,
+			Query: `data == {"a": {"b": {"c": 3 }}}`,
+			Evals: []Eval{
+				{Result: `{{}}`},
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/test/wasm/assets/test.js
+++ b/test/wasm/assets/test.js
@@ -158,11 +158,11 @@ async function instantiate(bytes, memory, data) {
 
     const addr2string = stringDecoder(memory);
 
-    let policy = { memory: memory };
+    let policy = { memory };
 
     policy.module = await WebAssembly.instantiate(bytes, {
         env: {
-            memory: memory,
+            memory,
             opa_abort: function (addr) {
                 throw { message: addr2string(addr) };
             },
@@ -194,7 +194,7 @@ async function instantiate(bytes, memory, data) {
         policy.builtins[builtins[key]] = key
     }
 
-    policy.dataAddr = loadJSON(policy.module, policy.memory, data || {});
+    policy.dataAddr = loadJSON(policy.module, policy.memory, data);
     policy.heapPtr = policy.module.instance.exports.opa_heap_ptr_get();
 
     return policy;

--- a/wasm/src/value.c
+++ b/wasm/src/value.c
@@ -687,6 +687,10 @@ void opa_value_free(opa_value *node)
 OPA_INTERNAL
 opa_value *opa_value_merge(opa_value *a, opa_value *b)
 {
+    if (a == NULL)
+    {
+        return b;
+    }
     if (opa_value_type(a) != OPA_OBJECT || opa_value_type(b) != OPA_OBJECT)
     {
         return a;

--- a/wasm/tests/test.c
+++ b/wasm/tests/test.c
@@ -1151,6 +1151,17 @@ void test_opa_value_merge_scalars(void)
     }
 }
 
+WASM_EXPORT(test_opa_value_merge_first_operand_null)
+void test_opa_value_merge_first_operand_null(void)
+{
+    test_str_eq("second operand string returns string", "\"foo\"", opa_json_dump(opa_value_merge(NULL, opa_string_terminated("foo"))));
+    test_str_eq("second operand object returns object", "{}", opa_json_dump(opa_value_merge(NULL, opa_object())));
+    test_str_eq("second operand number returns number", "1", opa_json_dump(opa_value_merge(NULL, opa_number_int(1))));
+    test_str_eq("second operand array returns array", "[]", opa_json_dump(opa_value_merge(NULL, opa_array())));
+    test_str_eq("second operand set returns set", "set()", opa_value_dump(opa_value_merge(NULL, opa_set())));
+    test_str_eq("second operand null returns null", "null", opa_json_dump(opa_value_merge(NULL, opa_null())));
+}
+
 WASM_EXPORT(test_opa_value_merge_simple)
 void test_opa_value_merge_simple(void)
 {


### PR DESCRIPTION
Before, the added/altered test cases would have failed: it came down to the
(undefined) data being a==NULL in opa_value_merge.

Fixes #3130.