### PR TITLE
server: URL decode policy IDs

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1603,7 +1603,13 @@ func (s *Server) v1PoliciesDelete(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	pretty := getBoolParam(r.URL, types.ParamPrettyV1, true)
 	includeMetrics := getBoolParam(r.URL, types.ParamPrettyV1, true)
-	id := vars["path"]
+
+	id, err := url.PathUnescape(vars["path"])
+	if err != nil {
+		writer.ErrorString(w, http.StatusBadRequest, types.CodeInvalidParameter, err)
+		return
+	}
+
 	m := metrics.New()
 
 	txn, err := s.store.NewTransaction(ctx, storage.WriteParams)
@@ -1660,7 +1666,13 @@ func (s *Server) v1PoliciesDelete(w http.ResponseWriter, r *http.Request) {
 func (s *Server) v1PoliciesGet(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	vars := mux.Vars(r)
-	path := vars["path"]
+
+	path, err := url.PathUnescape(vars["path"])
+	if err != nil {
+		writer.ErrorString(w, http.StatusBadRequest, types.CodeInvalidParameter, err)
+		return
+	}
+
 	pretty := getBoolParam(r.URL, types.ParamPrettyV1, true)
 
 	txn, err := s.store.NewTransaction(ctx)
@@ -1737,7 +1749,13 @@ func (s *Server) v1PoliciesList(w http.ResponseWriter, r *http.Request) {
 func (s *Server) v1PoliciesPut(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	vars := mux.Vars(r)
-	path := vars["path"]
+
+	path, err := url.PathUnescape(vars["path"])
+	if err != nil {
+		writer.ErrorString(w, http.StatusBadRequest, types.CodeInvalidParameter, err)
+		return
+	}
+
 	includeMetrics := getBoolParam(r.URL, types.ParamMetricsV1, true)
 	pretty := getBoolParam(r.URL, types.ParamPrettyV1, true)
 	m := metrics.New()


### PR DESCRIPTION
Policy IDs will be decoded in GET, PUT, and DELETE requests to the /policies endpoint.  This will enable users to include non-alphanumeric characters in policy IDs, as well as leading forward slashes, by URL encoding the path component of their requests.

Fixes #2116


<!--
Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.
-->