### PR TITLE
wasm: also emit `opa_wasm_abi_minor_version`

### DIFF
--- a/ast/capabilities.go
+++ b/ast/capabilities.go
@@ -15,16 +15,23 @@ import (
 // Capabilities defines a structure containing data that describes the capablilities
 // or features supported by a particular version of OPA.
 type Capabilities struct {
-	Builtins        []*Builtin `json:"builtins"` // builtins is a set of built-in functions that are supported.
-	WasmABIVersions []int      `json:"wasm_abi_versions"`
+	Builtins        []*Builtin       `json:"builtins"` // builtins is a set of built-in functions that are supported.
+	WasmABIVersions []WasmABIVersion `json:"wasm_abi_versions"`
+}
+
+// WasmABIVersion captures the Wasm ABI version. Its `Minor` version is indicating
+// backwards-compatible changes.
+type WasmABIVersion struct {
+	Version int `json:"version"`
+	Minor   int `json:"minor_version"`
 }
 
 // CapabilitiesForThisVersion returns the capabilities of this version of OPA.
 func CapabilitiesForThisVersion() *Capabilities {
+	f := &Capabilities{}
 
-	f := &Capabilities{
-		Builtins:        []*Builtin{},
-		WasmABIVersions: capabilities.ABIVersions(),
+	for _, vers := range capabilities.ABIVersions() {
+		f.WasmABIVersions = append(f.WasmABIVersions, WasmABIVersion{Version: vers[0], Minor: vers[1]})
 	}
 
 	for _, bi := range Builtins {

--- a/capabilities.json
+++ b/capabilities.json
@@ -3381,6 +3381,9 @@
     }
   ],
   "wasm_abi_versions": [
-    1
+    {
+      "version": 1,
+      "minor_version": 0
+    }
   ]
 }

--- a/compile/compile.go
+++ b/compile/compile.go
@@ -432,8 +432,9 @@ func (c *Compiler) compileWasm(ctx context.Context) error {
 
 	compiler := wasm.New()
 	found := false
+	have := compiler.ABIVersion()
 	for _, v := range c.capabilities.WasmABIVersions {
-		if v == compiler.ABIVersion() {
+		if v.Version == have.Version && v.Minor <= have.Minor {
 			found = true
 			break
 		}

--- a/compile/compile_test.go
+++ b/compile/compile_test.go
@@ -428,7 +428,7 @@ func TestCompilerOptimizationL2(t *testing.T) {
 }
 
 // NOTE(sr): we override this to not depend on build tags in tests
-func wasmABIVersions(vs ...int) *ast.Capabilities {
+func wasmABIVersions(vs ...ast.WasmABIVersion) *ast.Capabilities {
 	caps := ast.CapabilitiesForThisVersion()
 	caps.WasmABIVersions = vs
 	return caps
@@ -445,7 +445,7 @@ func TestCompilerWasmTarget(t *testing.T) {
 	test.WithTempFS(files, func(root string) {
 
 		compiler := New().WithPaths(root).WithTarget("wasm").WithEntrypoints("test/p", "test/q").
-			WithCapabilities(wasmABIVersions(1))
+			WithCapabilities(wasmABIVersions(ast.WasmABIVersion{Version: 1}))
 		err := compiler.Build(context.Background())
 		if err != nil {
 			t.Fatal(err)
@@ -474,7 +474,7 @@ func TestCompilerWasmTargetWithCapabilitiesMismatch(t *testing.T) {
 	test.WithTempFS(files, func(root string) {
 
 		compiler := New().WithPaths(root).WithTarget("wasm").WithEntrypoints("test/p", "test/q").
-			WithCapabilities(wasmABIVersions(0, 2))
+			WithCapabilities(wasmABIVersions(ast.WasmABIVersion{Version: 0}, ast.WasmABIVersion{Version: 1, Minor: 2}, ast.WasmABIVersion{Version: 2}))
 		err := compiler.Build(context.Background())
 		if err == nil {
 			t.Fatal("expected err, got nil")
@@ -498,7 +498,7 @@ func TestCompilerWasmTargetMultipleEntrypoints(t *testing.T) {
 	test.WithTempFS(files, func(root string) {
 
 		compiler := New().WithPaths(root).WithTarget("wasm").WithEntrypoints("test/p", "policy/authz").
-			WithCapabilities(wasmABIVersions(1))
+			WithCapabilities(wasmABIVersions(ast.WasmABIVersion{Version: 1}))
 		err := compiler.Build(context.Background())
 		if err != nil {
 			t.Fatal(err)
@@ -543,7 +543,7 @@ func TestCompilerWasmTargetEntrypointDependents(t *testing.T) {
 	test.WithTempFS(files, func(root string) {
 
 		compiler := New().WithPaths(root).WithTarget("wasm").WithEntrypoints("test/r", "test/z").
-			WithCapabilities(wasmABIVersions(1))
+			WithCapabilities(wasmABIVersions(ast.WasmABIVersion{Version: 1}))
 		err := compiler.Build(context.Background())
 		if err != nil {
 			t.Fatal(err)
@@ -595,7 +595,7 @@ func TestCompilerWasmTargetLazyCompile(t *testing.T) {
 	test.WithTempFS(files, func(root string) {
 
 		compiler := New().WithPaths(root).WithTarget("wasm").WithEntrypoints("test/p").WithOptimizationLevel(1).
-			WithCapabilities(wasmABIVersions(1))
+			WithCapabilities(wasmABIVersions(ast.WasmABIVersion{Version: 1}))
 		err := compiler.Build(context.Background())
 		if err != nil {
 			t.Fatal(err)

--- a/docs/content/wasm.md
+++ b/docs/content/wasm.md
@@ -110,16 +110,21 @@ Wasm modules built using OPA 0.27.0 onwards contain a global variable named
 `opa_wasm_abi_version` that has a constant i32 value indicating the ABI version
 this module requires. Described below you find ABI version 1.
 
+There's another i32 constant exported, `opa_wasm_abi_minor_version`, used
+to track backwards-compatible changes.
+
 Using tools like `wasm-objdump` (`wasm-objdump -x policy.wasm`), the ABI
 version can be found here:
 
 ```
-Global[2]:
+Global[3]:
  - global[0] i32 mutable=1 - init i32=121904
  - global[1] i32 mutable=0 <opa_wasm_abi_version> - init i32=1
+ - global[2] i32 mutable=0 <opa_wasm_abi_minor_version> - init i32=0
 Export[19]:
 [...]
  - global[1] -> "opa_wasm_abi_version"
+ - global[2] -> "opa_wasm_abi_minor_version"
 ```
 
 Note the `i32=1` of `global[1]`, exported by the name of `opa_wasm_abi_version`.

--- a/internal/compiler/wasm/wasm.go
+++ b/internal/compiler/wasm/wasm.go
@@ -225,14 +225,11 @@ func New() *Compiler {
 
 // ABIVersion returns the Wasm ABI version this compiler
 // emits.
-func (*Compiler) ABIVersion() int {
-	return opaWasmABIVersionVal
-}
-
-// ABIMinorVersion returns the Wasm ABI mior version this
-// compiler emits.
-func (*Compiler) ABIMinorVersion() int {
-	return opaWasmABIMinorVersionVal
+func (*Compiler) ABIVersion() ast.WasmABIVersion {
+	return ast.WasmABIVersion{
+		Version: opaWasmABIVersionVal,
+		Minor:   opaWasmABIMinorVersionVal,
+	}
 }
 
 // WithPolicy sets the policy to compile.

--- a/internal/wasm/sdk/opa/capabilities/capabilities.go
+++ b/internal/wasm/sdk/opa/capabilities/capabilities.go
@@ -6,9 +6,10 @@
 
 package capabilities
 
-var wasmABIVersions = [...]int{1}
+const abiVersion = 1
+const abiMinorVersion = 0
 
 // ABIVersions returns the ABI versions that this SDK supports
-func ABIVersions() []int {
-	return wasmABIVersions[:]
+func ABIVersions() [][2]int {
+	return [][2]int{{abiVersion, abiMinorVersion}}
 }

--- a/internal/wasm/sdk/opa/capabilities/capabilities_nowasm.go
+++ b/internal/wasm/sdk/opa/capabilities/capabilities_nowasm.go
@@ -8,6 +8,6 @@ package capabilities
 
 // ABIVersions returns the supported Wasm ABI versions for this
 // build: none
-func ABIVersions() []int {
+func ABIVersions() [][2]int {
 	return nil
 }


### PR DESCRIPTION
This is meant for declaring minor versions: backwards-compatible changes.

TODO:
- [x] Document this
- [x] capabilities