### PR TITLE
website: Rename link on frontpage to ecosystem page

### DIFF
--- a/docs/website/layouts/index.html
+++ b/docs/website/layouts/index.html
@@ -43,7 +43,7 @@
             </li>
             <li class="nav-item">
               <a class="nav-link"
-                 href="./docs/latest/ecosystem/">Integrations </a>
+                 href="./docs/latest/ecosystem/">Ecosystem </a>
             </li>
             <li class="nav-item">
               <a class="nav-link" href="./support">Support</a>

--- a/docs/website/static/support.html
+++ b/docs/website/static/support.html
@@ -39,12 +39,12 @@
                 <li class="nav-item">
                   <a class="nav-link" href="./docs/latest/">Documentation </a>
                 </li>
-                <!-- <li class="nav-item">
-                  <a class="nav-link" href="./docs/latest/get-started/">Tutorials </a>
-                </li> -->
+                <li class="nav-item">
+                  <a class="nav-link" href="./docs/latest/#running-opa">Download </a>
+                </li>
                 <li class="nav-item">
                   <a class="nav-link"
-                     href="./docs/latest/ecosystem/">Integrations </a>
+                     href="./docs/latest/ecosystem/">Ecosystem </a>
                 </li>
                 <li class="nav-item">
                   <a class="nav-link" href="./support">Support</a>


### PR DESCRIPTION
This was bother me for a while. We refer to this as the ecosystem page
but the link on the frontpage was titled "Integrations".

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
