### PR TITLE
Split out management from 'OPA' APIs: now have two Open API Specifications

### DIFF
--- a/docs/content/open-api/openapi.yaml
+++ b/docs/content/open-api/openapi.yaml
@@ -1,0 +1,220 @@
+openapi: 3.0.3
+info:
+  title: Open Policy Agent (OPA) REST API
+  description: |-
+    OPA provides policy-based control for cloud native environments.
+
+    # Try it in your browser
+
+    Once you have [set your Docker image up](https://www.openpolicyagent.org/docs/latest/deployments/), you can test the API from inside your browser. The following assumes the server is running on localhost:8181.
+
+    The following 'endpoints' (such as `PUT /v1/policies/example1`) provide reference documentation for the OPA REST API. To try out API calls:
+    1. Navigate to an endpoint
+    2. Click **Try it out** - in the right-hand (black) panel
+    3. Customize the **Request body** and/or **Parameters**.
+    4. Click **Execute**.
+
+    You will see the cURL request submitted to the API server and the corresponding response.
+  version: '0.25.2'
+  contact:
+    name: The OPA team
+    url: 'https://github.com/open-policy-agent/opa'
+  license:
+    name: Apache 2.0
+    url: 'https://www.apache.org/licenses/LICENSE-2.0'
+servers:
+  - url: 'http://localhost:8181'
+    description: Docker
+tags:
+  - name: Policy API
+    description: Allows you to add, remove and modify policy modules. *Policy module identifiers are only used for management purposes. They are not used outside the Policy API.*
+  - name: Data API
+    description: Exposes endpoints for reading and writing documents in OPA. For an explanation to the different types of documents, see [The OPA Document Model](https://www.openpolicyagent.org/docs/latest/philosophy/#the-opa-document-model)
+  - name: Query API
+    description: Posting queries to OPA
+  - name: Compile API
+    description: Posting partial queries to OPA
+paths:
+  '/users/{userId}':
+    parameters:
+      - schema:
+          type: integer
+        name: userId
+        in: path
+        required: true
+        description: Id of an existing user.
+    get:
+      summary: Get User Info by User ID
+      tags: []
+      responses:
+        '200':
+          description: User Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+              examples:
+                Get User Alice Smith:
+                  value:
+                    id: 142
+                    firstName: Alice
+                    lastName: Smith
+                    email: alice.smith@gmail.com
+                    dateOfBirth: '1997-10-31'
+                    emailVerified: true
+                    signUpDate: '2019-08-24'
+        '404':
+          description: User Not Found
+      operationId: get-users-userId
+      description: Retrieve the information of the user with the matching user ID.
+    patch:
+      summary: Update User Information
+      operationId: patch-users-userId
+      responses:
+        '200':
+          description: User Updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+              examples:
+                Updated User Rebecca Baker:
+                  value:
+                    id: 13
+                    firstName: Rebecca
+                    lastName: Baker
+                    email: rebecca@gmail.com
+                    dateOfBirth: '1985-10-02'
+                    emailVerified: false
+                    createDate: '2019-08-24'
+        '404':
+          description: User Not Found
+        '409':
+          description: Email Already Taken
+      description: Update the infromation of an existing user.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                firstName:
+                  type: string
+                lastName:
+                  type: string
+                email:
+                  type: string
+                  description: 'If a new email is given, the user''s email verified property will be set to false.'
+                dateOfBirth:
+                  type: string
+            examples:
+              Update First Name:
+                value:
+                  firstName: Rebecca
+              Update Email:
+                value:
+                  email: rebecca@gmail.com
+              Update Last Name & Date of Birth:
+                value:
+                  lastName: Baker
+                  dateOfBirth: '1985-10-02'
+        description: Patch user properties to update.
+  /user:
+    post:
+      summary: Create New User
+      operationId: post-user
+      responses:
+        '200':
+          description: User Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+              examples:
+                New User Bob Fellow:
+                  value:
+                    id: 12
+                    firstName: Bob
+                    lastName: Fellow
+                    email: bob.fellow@gmail.com
+                    dateOfBirth: '1996-08-24'
+                    emailVerified: false
+                    createDate: '2020-11-18'
+        '400':
+          description: Missing Required Information
+        '409':
+          description: Email Already Taken
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                firstName:
+                  type: string
+                lastName:
+                  type: string
+                email:
+                  type: string
+                dateOfBirth:
+                  type: string
+                  format: date
+              required:
+                - firstName
+                - lastName
+                - email
+                - dateOfBirth
+            examples:
+              Create User Bob Fellow:
+                value:
+                  firstName: Bob
+                  lastName: Fellow
+                  email: bob.fellow@gmail.com
+                  dateOfBirth: '1996-08-24'
+        description: Post the necessary fields for the API to create a new user.
+      description: Create a new user.
+components:
+  schemas:
+    User:
+      title: User
+      type: object
+      description: ''
+      x-examples:
+        Alice Smith:
+          id: 142
+          firstName: Alice
+          lastName: Smith
+          email: alice.smith@gmail.com
+          dateOfBirth: '1997-10-31'
+          emailVerified: true
+          signUpDate: '2019-08-24'
+      properties:
+        id:
+          type: integer
+          description: Unique identifier for the given user.
+        firstName:
+          type: string
+        lastName:
+          type: string
+        email:
+          type: string
+          format: email
+        dateOfBirth:
+          type: string
+          format: date
+          example: '1997-10-31'
+        emailVerified:
+          type: boolean
+          description: Set to true if the user's email has been verified.
+        createDate:
+          type: string
+          format: date
+          description: The date that the user was created.
+      required:
+        - id
+        - firstName
+        - lastName
+        - email
+        - emailVerified
+  securitySchemes: {}
+security: []


### PR DESCRIPTION
- openapi.yaml is the set of OPA APIs
- management.yaml is the set of managment APIs

In the latter, beware of limitatons in the OAS; for instance the specification regards Bundle service and Discovery service API as being identical since it can't tell the difference between GET {path1}/{path2} and GET {path3}/{path4}. Hence rejects. I've retained the former.

This limitation may be addressed in version 4 of the OAS (due in late 2021 to early 2022).