### PR TITLE
wasm: Do not emit unreachable instructions after opa_abort calls

### DIFF
--- a/internal/compiler/wasm/wasm.go
+++ b/internal/compiler/wasm/wasm.go
@@ -602,7 +602,6 @@ func (c *Compiler) compilePlans() error {
 	main.Instrs = append(main.Instrs,
 		instruction.I32Const{Value: c.builtinStringAddr(errIllegalEntrypoint)},
 		instruction.Call{Index: c.function(opaAbort)},
-		instruction.Unreachable{},
 	)
 
 	c.appendInstr(main)
@@ -1576,8 +1575,7 @@ func getLowestFreeElementSegmentOffset(m *module.Module) (int32, error) {
 
 // runtimeErrorAbort uses the passed source location to build the
 // arguments for a call to opa_runtime_error(file, row, col, msg).
-// It returns the instructions that make up the function call with
-// arguments, followed by Unreachable.
+// It returns the instructions that make up the function call.
 func (c *Compiler) runtimeErrorAbort(loc ir.Location, errType int) []instruction.Instruction {
 	index, row, col := loc.Index, loc.Row, loc.Col
 	return []instruction.Instruction{
@@ -1586,6 +1584,5 @@ func (c *Compiler) runtimeErrorAbort(loc ir.Location, errType int) []instruction
 		instruction.I32Const{Value: int32(col)},
 		instruction.I32Const{Value: c.builtinStringAddr(errType)},
 		instruction.Call{Index: c.function(opaRuntimeError)},
-		instruction.Unreachable{},
 	}
 }


### PR DESCRIPTION
The unreachable instructions cause a crash in the Go runtime on
macOS. It's unclear why they are ever executed after calling
opa_abort/opa_runtime_error but this was observed to fix the issue.

In the future it would be nice to get rid of the panics in the
Go-defined functions like opa_abort. Instead of panicking those
functions should return traps. The problem is that currently returning
a trap requires closing over a store related object which introduces a
memory leak.

Fixes #3168

Signed-off-by: Torin Sandall <torinsandall@gmail.com>