### PR TITLE
wasm: misc optimizations (less locals, blocks, interning strings and booleans)

### DIFF
--- a/internal/compiler/wasm/wasm.go
+++ b/internal/compiler/wasm/wasm.go
@@ -38,6 +38,8 @@ const (
 	opaTypeString
 	opaTypeArray
 	opaTypeObject
+	opaTypeSet
+	opaTypeStringInterned
 )
 
 const (
@@ -406,7 +408,7 @@ func (c *Compiler) compileStrings() error {
 		c.opaStringAddrs[i] = uint32(buf.Len()) + uint32(c.stringOffset)
 		size := 12
 		b := make([]byte, size)
-		binary.LittleEndian.PutUint16(b[0:], uint16(opaTypeString))
+		binary.LittleEndian.PutUint16(b[0:], uint16(opaTypeStringInterned))
 		binary.LittleEndian.PutUint32(b[4:], uint32(len(s.Value)))
 		binary.LittleEndian.PutUint32(b[8:], c.stringAddrs[i])
 		n, err := buf.Write(b)

--- a/internal/compiler/wasm/wasm.go
+++ b/internal/compiler/wasm/wasm.go
@@ -1265,11 +1265,17 @@ func (c *Compiler) compileCallDynamicStmt(stmt *ir.CallDynamicStmt, result *[]in
 
 	// append to it:
 	for _, lv := range stmt.Path {
-		block.Instrs = append(block.Instrs,
-			instruction.GetLocal{Index: larray},
-			instruction.GetLocal{Index: c.local(lv)},
-			instruction.Call{Index: c.function(opaArrayAppend)},
-		)
+		block.Instrs = append(block.Instrs, instruction.GetLocal{Index: larray})
+		if sIdx, ok := lv.(ir.StringIndex); ok {
+			block.Instrs = append(block.Instrs,
+				instruction.I32Const{Value: c.stringAddr(int(sIdx))},
+				instruction.Call{Index: c.function(opaStringTerminated)},
+			)
+		}
+		if loc, ok := lv.(ir.Local); ok {
+			block.Instrs = append(block.Instrs, instruction.GetLocal{Index: c.local(loc)})
+		}
+		block.Instrs = append(block.Instrs, instruction.Call{Index: c.function(opaArrayAppend)})
 	}
 
 	// prep stack for later call_indirect

--- a/internal/compiler/wasm/wasm.go
+++ b/internal/compiler/wasm/wasm.go
@@ -984,16 +984,6 @@ func (c *Compiler) compileBlock(block *ir.Block) ([]instruction.Instruction, err
 		case *ir.MakeNullStmt:
 			instrs = append(instrs, instruction.Call{Index: c.function(opaNull)})
 			instrs = append(instrs, instruction.SetLocal{Index: c.local(stmt.Target)})
-		case *ir.MakeBooleanStmt:
-			instr := instruction.I32Const{}
-			if stmt.Value {
-				instr.Value = 1
-			} else {
-				instr.Value = 0
-			}
-			instrs = append(instrs, instr)
-			instrs = append(instrs, instruction.Call{Index: c.function(opaBoolean)})
-			instrs = append(instrs, instruction.SetLocal{Index: c.local(stmt.Target)})
 		case *ir.MakeNumberFloatStmt:
 			instrs = append(instrs, instruction.F64Const{Value: stmt.Value})
 			instrs = append(instrs, instruction.Call{Index: c.function(opaNumberFloat)})
@@ -1006,9 +996,6 @@ func (c *Compiler) compileBlock(block *ir.Block) ([]instruction.Instruction, err
 			instrs = append(instrs, instruction.I32Const{Value: c.stringAddr(stmt.Index)})
 			instrs = append(instrs, instruction.I32Const{Value: int32(len(c.policy.Static.Strings[stmt.Index].Value))})
 			instrs = append(instrs, instruction.Call{Index: c.function(opaNumberRef)})
-			instrs = append(instrs, instruction.SetLocal{Index: c.local(stmt.Target)})
-		case *ir.MakeStringStmt:
-			instrs = append(instrs, instruction.I32Const{Value: c.opaStringAddr(stmt.Index)})
 			instrs = append(instrs, instruction.SetLocal{Index: c.local(stmt.Target)})
 		case *ir.MakeArrayStmt:
 			instrs = append(instrs, instruction.I32Const{Value: stmt.Capacity})

--- a/internal/compiler/wasm/wasm.go
+++ b/internal/compiler/wasm/wasm.go
@@ -1417,20 +1417,20 @@ func (c *Compiler) compileCallStmt(stmt *ir.CallStmt, result *[]instruction.Inst
 
 func (c *Compiler) compileInternalCall(stmt *ir.CallStmt, index uint32, result *[]instruction.Instruction) error {
 
-	block := instruction.Block{}
+	instrs := []instruction.Instruction{}
 
 	// Prepare function args and call.
 	for _, arg := range stmt.Args {
-		block.Instrs = append(block.Instrs, c.instrRead(arg))
+		instrs = append(instrs, c.instrRead(arg))
 	}
 
-	block.Instrs = append(block.Instrs,
+	instrs = append(instrs,
 		instruction.Call{Index: index},
 		instruction.TeeLocal{Index: c.local(stmt.Result)},
 		instruction.I32Eqz{},
-		instruction.BrIf{Index: 1})
+		instruction.BrIf{Index: 0})
 
-	*result = append(*result, block)
+	*result = append(*result, instrs...)
 
 	return nil
 }

--- a/internal/compiler/wasm/wasm.go
+++ b/internal/compiler/wasm/wasm.go
@@ -962,8 +962,18 @@ func (c *Compiler) compileBlock(block *ir.Block) ([]instruction.Instruction, err
 			instrs = append(instrs, instruction.I32LtS{})
 			instrs = append(instrs, instruction.BrIf{Index: 0})
 		case *ir.NotEqualStmt:
-			if stmt.A == stmt.B {
+			if stmt.A == stmt.B { // same local, same bool constant, or same string constant
 				instrs = append(instrs, instruction.Br{Index: 0})
+				continue
+			}
+			_, okA := stmt.A.(ir.Bool)
+			if _, okB := stmt.B.(ir.Bool); okA && okB {
+				// not equal (checked above), but both booleans => not equal
+				continue
+			}
+			_, okA = stmt.A.(ir.StringIndex)
+			if _, okB := stmt.B.(ir.StringIndex); okA && okB {
+				// not equal (checked above), but both strings => not equal
 				continue
 			}
 			instrs = append(instrs, c.instrRead(stmt.A))

--- a/internal/compiler/wasm/wasm.go
+++ b/internal/compiler/wasm/wasm.go
@@ -702,12 +702,10 @@ func (c *Compiler) compileFunc(fn *ir.Func) error {
 
 	// memoization: get
 	if memoize {
-		c.appendInstr(instruction.Block{Instrs: []instruction.Instruction{
-			instruction.I32Const{Value: int32(idx)},
-			instruction.Call{Index: c.function(opaMemoizeGet)},
-			instruction.TeeLocal{Index: c.local(fn.Return)},
-			instruction.I32Eqz{},
-			instruction.BrIf{Index: 0},
+		c.appendInstr(instruction.I32Const{Value: int32(idx)})
+		c.appendInstr(instruction.Call{Index: c.function(opaMemoizeGet)})
+		c.appendInstr(instruction.TeeLocal{Index: c.local(fn.Return)})
+		c.appendInstr(instruction.If{Instrs: []instruction.Instruction{
 			instruction.GetLocal{Index: c.local(fn.Return)},
 			instruction.Return{},
 		}})

--- a/internal/compiler/wasm/wasm.go
+++ b/internal/compiler/wasm/wasm.go
@@ -954,6 +954,7 @@ func (c *Compiler) compileBlock(block *ir.Block) ([]instruction.Instruction, err
 				// Booleans and strings would lead to the BrIf (since opa_value_get
 				// on them returns 0), so let's skip that.
 				instrs = append(instrs, instruction.Br{Index: 0})
+				break
 			}
 		case *ir.LenStmt:
 			instrs = append(instrs, c.instrRead(stmt.Source))
@@ -1047,16 +1048,22 @@ func (c *Compiler) compileBlock(block *ir.Block) ([]instruction.Instruction, err
 				instrs = append(instrs, instruction.Call{Index: c.function(opaValueType)})
 				instrs = append(instrs, instruction.I32Const{Value: opaTypeArray})
 				instrs = append(instrs, instruction.I32Ne{})
+				instrs = append(instrs, instruction.BrIf{Index: 0})
+			} else {
+				instrs = append(instrs, instruction.Br{Index: 0})
+				break
 			}
-			instrs = append(instrs, instruction.BrIf{Index: 0})
 		case *ir.IsObjectStmt:
 			if loc, ok := stmt.Source.(ir.Local); ok {
 				instrs = append(instrs, instruction.GetLocal{Index: c.local(loc)})
 				instrs = append(instrs, instruction.Call{Index: c.function(opaValueType)})
 				instrs = append(instrs, instruction.I32Const{Value: opaTypeObject})
 				instrs = append(instrs, instruction.I32Ne{})
+				instrs = append(instrs, instruction.BrIf{Index: 0})
+			} else {
+				instrs = append(instrs, instruction.Br{Index: 0})
+				break
 			}
-			instrs = append(instrs, instruction.BrIf{Index: 0})
 		case *ir.IsUndefinedStmt:
 			instrs = append(instrs, instruction.GetLocal{Index: c.local(stmt.Source)})
 			instrs = append(instrs, instruction.I32Const{Value: 0})

--- a/internal/compiler/wasm/wasm.go
+++ b/internal/compiler/wasm/wasm.go
@@ -61,7 +61,6 @@ const (
 	opaSet               = "opa_set"
 	opaSetAdd            = "opa_set_add"
 	opaStringTerminated  = "opa_string_terminated"
-	opaValueBooleanSet   = "opa_value_boolean_set"
 	opaValueNumberSetInt = "opa_value_number_set_int"
 	opaValueCompare      = "opa_value_compare"
 	opaValueGet          = "opa_value_get"
@@ -920,14 +919,6 @@ func (c *Compiler) compileBlock(block *ir.Block) ([]instruction.Instruction, err
 					instruction.SetLocal{Index: c.local(stmt.Target)},
 				},
 			})
-		case *ir.AssignBooleanStmt:
-			instrs = append(instrs, instruction.GetLocal{Index: c.local(stmt.Target)})
-			if stmt.Value {
-				instrs = append(instrs, instruction.I32Const{Value: 1})
-			} else {
-				instrs = append(instrs, instruction.I32Const{Value: 0})
-			}
-			instrs = append(instrs, instruction.Call{Index: c.function(opaValueBooleanSet)})
 		case *ir.AssignIntStmt:
 			instrs = append(instrs, instruction.GetLocal{Index: c.local(stmt.Target)})
 			instrs = append(instrs, instruction.I64Const{Value: stmt.Value})

--- a/internal/compiler/wasm/wasm.go
+++ b/internal/compiler/wasm/wasm.go
@@ -902,10 +902,12 @@ func (c *Compiler) compileBlock(block *ir.Block) ([]instruction.Instruction, err
 			instrs = append(instrs, instruction.Call{Index: c.function(opaNumberSize)})
 			instrs = append(instrs, instruction.SetLocal{Index: c.local(stmt.Target)})
 		case *ir.EqualStmt:
-			instrs = append(instrs, c.instrRead(stmt.A))
-			instrs = append(instrs, c.instrRead(stmt.B))
-			instrs = append(instrs, instruction.Call{Index: c.function(opaValueCompare)})
-			instrs = append(instrs, instruction.BrIf{Index: 0})
+			if stmt.A != stmt.B { // constants, or locals, being equal here can skip the check
+				instrs = append(instrs, c.instrRead(stmt.A))
+				instrs = append(instrs, c.instrRead(stmt.B))
+				instrs = append(instrs, instruction.Call{Index: c.function(opaValueCompare)})
+				instrs = append(instrs, instruction.BrIf{Index: 0})
+			}
 		case *ir.LessThanStmt:
 			instrs = append(instrs, c.instrRead(stmt.A))
 			instrs = append(instrs, c.instrRead(stmt.B))
@@ -935,10 +937,12 @@ func (c *Compiler) compileBlock(block *ir.Block) ([]instruction.Instruction, err
 			instrs = append(instrs, instruction.I32LtS{})
 			instrs = append(instrs, instruction.BrIf{Index: 0})
 		case *ir.NotEqualStmt:
-			instrs = append(instrs, c.instrRead(stmt.A))
-			instrs = append(instrs, c.instrRead(stmt.B))
-			instrs = append(instrs, instruction.Call{Index: c.function(opaValueCompare)})
-			instrs = append(instrs, instruction.I32Eqz{})
+			if stmt.A != stmt.B {
+				instrs = append(instrs, c.instrRead(stmt.A))
+				instrs = append(instrs, c.instrRead(stmt.B))
+				instrs = append(instrs, instruction.Call{Index: c.function(opaValueCompare)})
+				instrs = append(instrs, instruction.I32Eqz{})
+			}
 			instrs = append(instrs, instruction.BrIf{Index: 0})
 		case *ir.MakeNullStmt:
 			instrs = append(instrs, instruction.Call{Index: c.function(opaNull)})

--- a/internal/ir/ir.go
+++ b/internal/ir/ir.go
@@ -185,15 +185,20 @@ type CallDynamicStmt struct {
 
 // LocalOrConst is a tagged union of the two types, Local and StringIndex.
 // It's used with CallDynamicStmt.
-type LocalOrConst interface{ localOrString() }
+type LocalOrConst interface{ localOrConst() }
 
-func (Local) localOrString() {}
+func (Local) localOrConst() {}
 
 // StringIndex represents the index into the plan's list of constant strings
 // of a constant string.
 type StringIndex int
 
-func (StringIndex) localOrString() {}
+func (StringIndex) localOrConst() {}
+
+// Bool represents a constant boolean.
+type Bool bool
+
+func (Bool) localOrConst() {}
 
 // BlockStmt represents a nested block. Nested blocks and break statements can
 // be used to short-circuit execution.
@@ -298,7 +303,7 @@ type ResetLocalStmt struct {
 }
 
 // MakeStringStmt constructs a local variable that refers to a string constant.
-type MakeStringStmt struct {
+type MakeStringStmt struct { // TODO(sr): unused, remove
 	Index  int
 	Target Local
 
@@ -313,7 +318,7 @@ type MakeNullStmt struct {
 }
 
 // MakeBooleanStmt constructs a local variable that refers to a boolean value.
-type MakeBooleanStmt struct {
+type MakeBooleanStmt struct { // TODO(sr): unused, remove
 	Value  bool
 	Target Local
 

--- a/internal/ir/ir.go
+++ b/internal/ir/ir.go
@@ -302,24 +302,8 @@ type ResetLocalStmt struct {
 	Location
 }
 
-// MakeStringStmt constructs a local variable that refers to a string constant.
-type MakeStringStmt struct { // TODO(sr): unused, remove
-	Index  int
-	Target Local
-
-	Location
-}
-
 // MakeNullStmt constructs a local variable that refers to a null value.
 type MakeNullStmt struct {
-	Target Local
-
-	Location
-}
-
-// MakeBooleanStmt constructs a local variable that refers to a boolean value.
-type MakeBooleanStmt struct { // TODO(sr): unused, remove
-	Value  bool
 	Target Local
 
 	Location

--- a/internal/ir/ir.go
+++ b/internal/ir/ir.go
@@ -178,10 +178,22 @@ type CallStmt struct {
 type CallDynamicStmt struct {
 	Args   []Local
 	Result Local
-	Path   []Local
+	Path   []LocalOrStringConst
 
 	Location
 }
+
+// LocalOrStringConst is a tagged union of the two types, Local and StringIndex.
+// It's used with CallDynamicStmt.
+type LocalOrStringConst interface{ localOrString() }
+
+func (Local) localOrString() {}
+
+// StringIndex represents the index into the plan's list of constant strings
+// of a constant string.
+type StringIndex int
+
+func (StringIndex) localOrString() {}
 
 // BlockStmt represents a nested block. Nested blocks and break statements can
 // be used to short-circuit execution.

--- a/internal/ir/ir.go
+++ b/internal/ir/ir.go
@@ -167,7 +167,7 @@ type ReturnLocalStmt struct {
 // result local.
 type CallStmt struct {
 	Func   string
-	Args   []Local
+	Args   []LocalOrConst
 	Result Local
 
 	Location
@@ -178,14 +178,14 @@ type CallStmt struct {
 type CallDynamicStmt struct {
 	Args   []Local
 	Result Local
-	Path   []LocalOrStringConst
+	Path   []LocalOrConst
 
 	Location
 }
 
-// LocalOrStringConst is a tagged union of the two types, Local and StringIndex.
+// LocalOrConst is a tagged union of the two types, Local and StringIndex.
 // It's used with CallDynamicStmt.
-type LocalOrStringConst interface{ localOrString() }
+type LocalOrConst interface{ localOrString() }
 
 func (Local) localOrString() {}
 
@@ -220,8 +220,8 @@ type BreakStmt struct {
 // The source of a DotStmt may be a scalar value in which case the statement
 // will be undefined.
 type DotStmt struct {
-	Source Local
-	Key    Local
+	Source LocalOrConst
+	Key    LocalOrConst
 	Target Local
 
 	Location
@@ -230,7 +230,7 @@ type DotStmt struct {
 // LenStmt represents a length() operation on a local variable. The
 // result is stored in the target local variable.
 type LenStmt struct {
-	Source Local
+	Source LocalOrConst
 	Target Local
 
 	Location
@@ -273,7 +273,7 @@ type AssignIntStmt struct {
 
 // AssignVarStmt represents an assignment of one local variable to another.
 type AssignVarStmt struct {
-	Source Local
+	Source LocalOrConst
 	Target Local
 
 	Location
@@ -285,7 +285,7 @@ type AssignVarStmt struct {
 // TODO(tsandall): is there a better name for this?
 type AssignVarOnceStmt struct {
 	Target Local
-	Source Local
+	Source LocalOrConst
 
 	Location
 }
@@ -369,62 +369,62 @@ type MakeSetStmt struct {
 
 // EqualStmt represents an value-equality check of two local variables.
 type EqualStmt struct {
-	A Local
-	B Local
+	A LocalOrConst
+	B LocalOrConst
 
 	Location
 }
 
 // LessThanStmt represents a < check of two local variables.
 type LessThanStmt struct {
-	A Local
-	B Local
+	A LocalOrConst
+	B LocalOrConst
 
 	Location
 }
 
 // LessThanEqualStmt represents a <= check of two local variables.
 type LessThanEqualStmt struct {
-	A Local
-	B Local
+	A LocalOrConst
+	B LocalOrConst
 
 	Location
 }
 
 // GreaterThanStmt represents a > check of two local variables.
 type GreaterThanStmt struct {
-	A Local
-	B Local
+	A LocalOrConst
+	B LocalOrConst
 
 	Location
 }
 
 // GreaterThanEqualStmt represents a >= check of two local variables.
 type GreaterThanEqualStmt struct {
-	A Local
-	B Local
+	A LocalOrConst
+	B LocalOrConst
 
 	Location
 }
 
 // NotEqualStmt represents a != check of two local variables.
 type NotEqualStmt struct {
-	A Local
-	B Local
+	A LocalOrConst
+	B LocalOrConst
 
 	Location
 }
 
 // IsArrayStmt represents a dynamic type check on a local variable.
 type IsArrayStmt struct {
-	Source Local
+	Source LocalOrConst
 
 	Location
 }
 
 // IsObjectStmt represents a dynamic type check on a local variable.
 type IsObjectStmt struct {
-	Source Local
+	Source LocalOrConst
 
 	Location
 }
@@ -446,7 +446,7 @@ type IsUndefinedStmt struct {
 // ArrayAppendStmt represents a dynamic append operation of a value
 // onto an array.
 type ArrayAppendStmt struct {
-	Value Local
+	Value LocalOrConst
 	Array Local
 
 	Location
@@ -455,8 +455,8 @@ type ArrayAppendStmt struct {
 // ObjectInsertStmt represents a dynamic insert operation of a
 // key/value pair into an object.
 type ObjectInsertStmt struct {
-	Key    LocalOrStringConst
-	Value  Local
+	Key    LocalOrConst
+	Value  LocalOrConst
 	Object Local
 
 	Location
@@ -466,8 +466,8 @@ type ObjectInsertStmt struct {
 // pair into an object. If the key already exists and the value differs,
 // execution aborts with a conflict error.
 type ObjectInsertOnceStmt struct {
-	Key    Local
-	Value  Local
+	Key    LocalOrConst
+	Value  LocalOrConst
 	Object Local
 
 	Location
@@ -486,7 +486,7 @@ type ObjectMergeStmt struct {
 
 // SetAddStmt represents a dynamic add operation of an element into a set.
 type SetAddStmt struct {
-	Value Local
+	Value LocalOrConst
 	Set   Local
 
 	Location
@@ -500,7 +500,7 @@ type SetAddStmt struct {
 type WithStmt struct {
 	Local Local
 	Path  []int
-	Value Local
+	Value LocalOrConst
 	Block *Block
 
 	Location

--- a/internal/ir/ir.go
+++ b/internal/ir/ir.go
@@ -259,14 +259,6 @@ type NotStmt struct {
 	Location
 }
 
-// AssignBooleanStmt represents an assignment of a boolean value to a local variable.
-type AssignBooleanStmt struct {
-	Value  bool
-	Target Local
-
-	Location
-}
-
 // AssignIntStmt represents an assignment of an integer value to a
 // local variable.
 type AssignIntStmt struct {

--- a/internal/ir/ir.go
+++ b/internal/ir/ir.go
@@ -455,7 +455,7 @@ type ArrayAppendStmt struct {
 // ObjectInsertStmt represents a dynamic insert operation of a
 // key/value pair into an object.
 type ObjectInsertStmt struct {
-	Key    Local
+	Key    LocalOrStringConst
 	Value  Local
 	Object Local
 

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -715,14 +715,9 @@ func (p *Planner) dataRefsShadowRuletrie(refs []ast.Ref) bool {
 
 func (p *Planner) planExprTerm(e *ast.Expr, iter planiter) error {
 	return p.planTerm(e.Terms.(*ast.Term), func() error {
-		falsy := p.newLocal()
-		p.appendStmt(&ir.MakeBooleanStmt{
-			Value:  false,
-			Target: falsy,
-		})
 		p.appendStmt(&ir.NotEqualStmt{
 			A: p.ltarget,
-			B: falsy,
+			B: ir.Bool(false),
 		})
 		return iter()
 	})
@@ -889,16 +884,9 @@ func (p *Planner) planExprCallFunc(name string, arity int, operands []*ast.Term,
 				Result: ltarget,
 			})
 
-			falsy := p.newLocal()
-
-			p.appendStmt(&ir.MakeBooleanStmt{
-				Value:  false,
-				Target: falsy,
-			})
-
 			p.appendStmt(&ir.NotEqualStmt{
 				A: ltarget,
-				B: falsy,
+				B: ir.Bool(false),
 			})
 
 			return iter()
@@ -1213,15 +1201,7 @@ func (p *Planner) planNull(null ast.Null, iter planiter) error {
 
 func (p *Planner) planBoolean(b ast.Boolean, iter planiter) error {
 
-	target := p.newLocal()
-
-	p.appendStmt(&ir.MakeBooleanStmt{
-		Value:  bool(b),
-		Target: target,
-	})
-
-	p.ltarget = target
-
+	p.ltarget = ir.Bool(b)
 	return iter()
 }
 

--- a/internal/planner/planner_test.go
+++ b/internal/planner/planner_test.go
@@ -370,10 +370,10 @@ func (*cmpWalker) Before(interface{}) {}
 func (*cmpWalker) After(interface{})  {}
 
 // Visit takes, for example,
-//     *ir.MakeStringStmt{Location: ir.Location{Index:0, Col:1, Row:1}},
-// and for the first MakeStringSlice it finds, extracts its location,
+//     *ir.MakeNullStmt{Location: ir.Location{Index:0, Col:1, Row:1}},
+// and for the first MakeNullStmt it finds, extracts its location,
 // and compares it to the one passed was needle. Other fields of the
-// struct, such as Index and Target for ir.MakeStringStmt, are ignored.
+// struct, such as Target for ir.MakeNullStmt, are ignored.
 //
 // Caveat: If NO value of the desired type is found, there's no error
 // returned. This trap can be avoided by starting with a failing test,

--- a/internal/planner/planner_test.go
+++ b/internal/planner/planner_test.go
@@ -422,13 +422,6 @@ func TestPlannerLocations(t *testing.T) {
 		where   func(*ir.Policy) interface{} // where to start walking search for `exps`
 	}{
 		{
-			note:    "hello world",
-			queries: []string{"input.a = 1"},
-			exps: map[ir.Stmt]string{
-				&ir.MakeStringStmt{}: "<query>:1:1: input.a = 1",
-			},
-		},
-		{
 			note:    "complete rule reference",
 			queries: []string{"data.test.p = 10"},
 			modules: []string{`

--- a/internal/wasm/instruction/control.go
+++ b/internal/wasm/instruction/control.go
@@ -56,6 +56,29 @@ func (i Block) Instructions() []Instruction {
 	return i.Instrs
 }
 
+// If represents a WASM if instruction.
+// NOTE(sr): we only use if with one branch so far!
+type If struct {
+	NoImmediateArgs
+	Type   *types.ValueType
+	Instrs []Instruction
+}
+
+// Op returns the opcode of the instruction.
+func (If) Op() opcode.Opcode {
+	return opcode.If
+}
+
+// BlockType returns the type of the if's THEN branch.
+func (i If) BlockType() *types.ValueType {
+	return i.Type
+}
+
+// Instructions represents the instructions contained in the if's THEN branch.
+func (i If) Instructions() []Instruction {
+	return i.Instrs
+}
+
 // Loop represents a WASM loop instruction.
 type Loop struct {
 	NoImmediateArgs

--- a/internal/wasm/instruction/control.go
+++ b/internal/wasm/instruction/control.go
@@ -9,6 +9,11 @@ import (
 	"github.com/open-policy-agent/opa/internal/wasm/types"
 )
 
+// !!! If you find yourself adding support for more control
+//     instructions (br_table, if, ...), please adapt the
+//     `withControlInstr` functions of
+//     `compiler/wasm/optimizations.go`
+
 // Unreachable represents a WASM unreachable instruction.
 type Unreachable struct {
 	NoImmediateArgs

--- a/wasm/src/aggregates.c
+++ b/wasm/src/aggregates.c
@@ -278,13 +278,13 @@ opa_value *opa_agg_all(opa_value *v)
 
         for (int i = 0; i < a->len; i++)
         {
-            if (opa_value_type(a->elems[i].v) != OPA_BOOLEAN || opa_cast_boolean(a->elems[i].v)->v == FALSE)
+            if (opa_value_type(a->elems[i].v) != OPA_BOOLEAN || opa_cast_boolean(a->elems[i].v)->v == false)
             {
-                return opa_boolean(FALSE);
+                return opa_boolean(false);
             }
         }
 
-        return opa_boolean(TRUE);
+        return opa_boolean(true);
     }
     case OPA_SET: {
         opa_set_t *s = opa_cast_set(v);
@@ -293,14 +293,14 @@ opa_value *opa_agg_all(opa_value *v)
         {
             for (opa_set_elem_t *elem = s->buckets[i]; elem != NULL; elem = elem->next)
             {
-                if (opa_value_type(elem->v) != OPA_BOOLEAN || opa_cast_boolean(elem->v)->v == FALSE)
+                if (opa_value_type(elem->v) != OPA_BOOLEAN || opa_cast_boolean(elem->v)->v == false)
                 {
-                    return opa_boolean(FALSE);
+                    return opa_boolean(false);
                 }
             }
         }
 
-        return opa_boolean(TRUE);
+        return opa_boolean(true);
     }
     default:
         return NULL;
@@ -317,23 +317,23 @@ opa_value *opa_agg_any(opa_value *v)
 
         for (int i = 0; i < a->len; i++)
         {
-            if (opa_value_type(a->elems[i].v) == OPA_BOOLEAN && opa_cast_boolean(a->elems[i].v)->v == TRUE)
+            if (opa_value_type(a->elems[i].v) == OPA_BOOLEAN && opa_cast_boolean(a->elems[i].v)->v == true)
             {
-                return opa_boolean(TRUE);
+                return opa_boolean(true);
             }
         }
 
-        return opa_boolean(FALSE);
+        return opa_boolean(false);
     }
     case OPA_SET: {
         opa_set_t *s = opa_cast_set(v);
         if (s->len == 0)
         {
-            return opa_boolean(FALSE);
+            return opa_boolean(false);
         }
 
-        opa_boolean_t b = { .hdr.type = OPA_BOOLEAN, .v = TRUE};
-        return opa_boolean(opa_set_get(s, &b.hdr) == NULL ? FALSE : TRUE);
+        opa_boolean_t b = { .hdr.type = OPA_BOOLEAN, .v = true};
+        return opa_boolean(opa_set_get(s, &b.hdr) == NULL ? false : true);
     }
     default:
         return NULL;

--- a/wasm/src/cidr.c
+++ b/wasm/src/cidr.c
@@ -34,7 +34,7 @@ static bool parse_ip(const char *src, int n, ip_net *dst)
         }
     }
 
-    return FALSE;
+    return false;
 }
 
 static bool parse_cidr(const char *src, size_t n, ip_net *dst)
@@ -51,21 +51,21 @@ static bool parse_cidr(const char *src, size_t n, ip_net *dst)
 
     if (slash == NULL)
     {
-        return FALSE;
+        return false;
     }
 
     const char *addr = src;
     const size_t len = slash - src;
     if (!parse_ip(addr, len, dst))
     {
-        return FALSE;
+        return false;
     }
 
     const char *mask = slash + 1;
     long long bits;
     if (opa_atoi64(mask, n - len - 1, &bits) == -1 || bits < 0 || bits > dst->len*8)
     {
-        return FALSE;
+        return false;
     }
 
     for (int i = 0; i < dst->len; i++)
@@ -85,7 +85,7 @@ static bool parse_cidr(const char *src, size_t n, ip_net *dst)
         dst->ip[i] &= dst->mask[i];
     }
 
-    return TRUE;
+    return true;
 }
 
 // returns true if a contains b.
@@ -93,7 +93,7 @@ static bool contains(ip_net *a, ip_net *b)
 {
     if (a->len != b->len)
     {
-        return FALSE;
+        return false;
     }
 
     for (int i = 0; i < a->len; i++)
@@ -112,7 +112,7 @@ static bool contains(ip_net *a, ip_net *b)
             //   ~b   | 00001111
             // a & ~b | 00001000
             //
-            return FALSE;
+            return false;
         }
 
         // Since b mask may be longer than a, use the a mask to ignore
@@ -122,11 +122,11 @@ static bool contains(ip_net *a, ip_net *b)
         // mask length.
         if (a->ip[i] != (b->ip[i] & a->mask[i]))
         {
-            return FALSE;
+            return false;
         }
     }
 
-    return TRUE;
+    return true;
 }
 
 OPA_BUILTIN
@@ -149,7 +149,7 @@ opa_value *opa_cidr_contains(opa_value *a, opa_value *b)
         return NULL;
     }
 
-    return opa_boolean(contains(&ip_a, &ip_b) ? TRUE : FALSE);
+    return opa_boolean(contains(&ip_a, &ip_b));
 }
 
 OPA_BUILTIN
@@ -167,7 +167,7 @@ opa_value *opa_cidr_intersects(opa_value *a, opa_value *b)
         return NULL;
     }
 
-    return opa_boolean(contains(&ip_a, &ip_b) || contains(&ip_b, &ip_a) ? TRUE : FALSE);
+    return opa_boolean(contains(&ip_a, &ip_b) || contains(&ip_b, &ip_a));
 }
 
 /*

--- a/wasm/src/conversions.c
+++ b/wasm/src/conversions.c
@@ -12,7 +12,7 @@ opa_value *opa_to_number(opa_value *v)
     case OPA_BOOLEAN:
     {
         opa_boolean_t *a = opa_cast_boolean(v);
-        return a->v == FALSE ? opa_number_int(0) : opa_number_int(1);
+        return opa_number_int(a->v ? 1 : 0);
     }
     case OPA_NUMBER:
        return v;

--- a/wasm/src/encoding.c
+++ b/wasm/src/encoding.c
@@ -230,11 +230,11 @@ opa_value *opa_base64_is_valid(opa_value *a)
     unsigned char *dec = base64_decode((const unsigned char*)s->v, s->len, &len);
     if (dec == NULL)
     {
-        return opa_boolean(FALSE);
+        return opa_boolean(false);
     }
 
     free(dec);
-    return opa_boolean(TRUE);
+    return opa_boolean(true);
 }
 
 OPA_BUILTIN

--- a/wasm/src/json.c
+++ b/wasm/src/json.c
@@ -668,9 +668,9 @@ opa_value *opa_json_parse_token(opa_json_lex *ctx, int token)
     case OPA_JSON_TOKEN_NULL:
         return opa_null();
     case OPA_JSON_TOKEN_TRUE:
-        return opa_boolean(TRUE);
+        return opa_boolean(true);
     case OPA_JSON_TOKEN_FALSE:
-        return opa_boolean(FALSE);
+        return opa_boolean(false);
     case OPA_JSON_TOKEN_NUMBER:
         return opa_json_parse_number(ctx->buf, ctx->buf_end - ctx->buf);
     case OPA_JSON_TOKEN_STRING:

--- a/wasm/src/memoize.c
+++ b/wasm/src/memoize.c
@@ -53,10 +53,5 @@ opa_value *opa_memoize_get(int32_t index)
     opa_number_init_int(&key, index);
     opa_object_elem_t *elem = opa_object_get(m->table, &key.hdr);
 
-    if (elem == NULL)
-    {
-        return NULL;
-    }
-
-    return elem->v;
+    return elem == NULL ? NULL : elem->v;
 }

--- a/wasm/src/std.h
+++ b/wasm/src/std.h
@@ -1,6 +1,7 @@
 #ifndef OPA_STD_H
 #define OPA_STD_H
 
+#include <stdbool.h>
 #include <stddef.h>
 
 #ifdef __cplusplus
@@ -23,15 +24,6 @@ void opa_println(const char *msg);
     } while (0)
 #else
 #define TRACE(...)
-#endif
-
-#define TRUE        (1)
-#define FALSE       (0)
-
-#ifndef __cplusplus
-#define true    (1)
-#define false   (0)
-#define bool    int
 #endif
 
 // Functions to be exported from the WASM module

--- a/wasm/src/strings.c
+++ b/wasm/src/strings.c
@@ -142,7 +142,7 @@ opa_value *opa_strings_contains(opa_value *a, opa_value *b)
     opa_string_t *s = opa_cast_string(a);
     opa_string_t *substr = opa_cast_string(b);
 
-    return opa_boolean(strings_indexof(s, 0, substr) >= 0 ? TRUE : FALSE);
+    return opa_boolean(strings_indexof(s, 0, substr) >= 0);
 }
 
 OPA_BUILTIN
@@ -158,18 +158,18 @@ opa_value *opa_strings_endswith(opa_value *a, opa_value *b)
 
     if (s->len < suffix->len)
     {
-        return opa_boolean(FALSE);
+        return opa_boolean(false);
     }
 
     for (int i = 0; i < suffix->len; i++)
     {
         if (s->v[s->len - suffix->len + i] != suffix->v[i])
         {
-            return opa_boolean(FALSE);
+            return opa_boolean(false);
         }
     }
 
-    return opa_boolean(TRUE);
+    return opa_boolean(true);
 }
 
 OPA_BUILTIN
@@ -428,10 +428,10 @@ opa_value *opa_strings_startswith(opa_value *a, opa_value *b)
 
     if (s->len < prefix->len)
     {
-        return opa_boolean(FALSE);
+        return opa_boolean(false);
     }
 
-    return opa_strncmp(s->v, prefix->v, prefix->len) == 0 ? opa_boolean(TRUE) : opa_boolean(FALSE);
+    return opa_boolean(opa_strncmp(s->v, prefix->v, prefix->len) == 0);
 }
 
 OPA_BUILTIN
@@ -759,7 +759,7 @@ opa_value *opa_strings_lower(opa_value *a)
     }
 
     opa_string_t *s = opa_cast_string(a);
-    int is_ascii = TRUE;
+    int is_ascii = true;
 
     for (int i = 0; i < s->len && is_ascii; i++)
     {
@@ -834,7 +834,7 @@ opa_value *opa_strings_upper(opa_value *a)
     }
 
     opa_string_t *s = opa_cast_string(a);
-    int is_ascii = TRUE;
+    int is_ascii = true;
 
     for (int i = 0; i < s->len && is_ascii; i++)
     {

--- a/wasm/src/types.c
+++ b/wasm/src/types.c
@@ -46,7 +46,7 @@ opa_value *opa_types_is_null(opa_value *v)
 OPA_BUILTIN
 opa_value *opa_types_name(opa_value *v)
 {
-    switch (v->type)
+    switch (opa_value_type(v))
     {
     case OPA_NULL:
         return opa_string("null", 4);

--- a/wasm/src/unicode.c
+++ b/wasm/src/unicode.c
@@ -6,9 +6,9 @@
 
 // Tests whether the code point is an utf-16 surrogate (encoded
 // representation of low or high bits).
-int opa_unicode_surrogate(int codepoint)
+bool opa_unicode_surrogate(int codepoint)
 {
-    return 0xd800 <= codepoint && codepoint < 0xe000 ? TRUE : FALSE;
+    return 0xd800 <= codepoint && codepoint < 0xe000;
 }
 
 // Reads the unicode UTF-16 code unit \uXXXX escaping.
@@ -236,26 +236,26 @@ const static range16_t white_spaces[] = {
 };
 
 // is16 reports whether codepoint is in the sorted slice of 16-bit ranges.
-int is16(const range16_t *ranges, int n, uint16_t cp)
+bool is16(const range16_t *ranges, int n, uint16_t cp)
 {
     for (int i = 0; i < n; i++)
     {
         if (cp < ranges[i].lo)
         {
-            return FALSE;
+            return false;
         }
 
         if (cp <= ranges[i].hi)
         {
-            return ranges[i].stride == 1 || (cp-ranges[i].lo)%ranges[i].stride == 0 ? TRUE : FALSE;
+            return ranges[i].stride == 1 || (cp-ranges[i].lo)%ranges[i].stride == 0;
         }
     }
 
-    return FALSE;
+    return false;
 }
 
 // is returns true if the codepoint is in the range table.
-static int is(const range16_t *r16, int l16, int cp)
+static bool is(const range16_t *r16, int l16, int cp)
 {
     if (l16 > 0 && cp <= r16[l16-1].hi)
     {
@@ -265,11 +265,11 @@ static int is(const range16_t *r16, int l16, int cp)
     // TODO: Check for 32-bit ranges here, if such tables needed.
     // TODO: For any future larger tables, implement binary search.
 
-    return FALSE;
+    return false;
 }
 
 // Returns true if the codepoint is a whitespace.
-int opa_unicode_is_space(int cp)
+bool opa_unicode_is_space(int cp)
 {
     if (cp <= 0xff) { // Latin1
         return cp == '\t' || cp == '\n' || cp == '\v' || cp ==  '\f' || cp ==  '\r' || cp == ' ' || cp == 0x85 || cp == 0xa0;

--- a/wasm/src/unicode.h
+++ b/wasm/src/unicode.h
@@ -1,6 +1,8 @@
 #ifndef OPA_UNICODE_H
 #define OPA_UNICODE_H
 
+#include "std.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -9,9 +11,9 @@ int opa_unicode_decode_surrogate(int codepoint1, int codepoint2);
 int opa_unicode_decode_unit(const char *in, int i, int len);
 int opa_unicode_decode_utf8(const char *in, int i, int len, int *olen);
 int opa_unicode_encode_utf8(int codepoint, char *out);
-int opa_unicode_is_space(int codepoint);
+bool opa_unicode_is_space(int codepoint);
 int opa_unicode_last_utf8(const char *in, int start, int end);
-int opa_unicode_surrogate(int codepoint);
+bool opa_unicode_surrogate(int codepoint);
 int opa_unicode_to_lower(int codepoint);
 int opa_unicode_to_upper(int codepoint);
 

--- a/wasm/src/value.c
+++ b/wasm/src/value.c
@@ -21,41 +21,27 @@ static void __opa_set_add_elem(opa_set_t *set, opa_set_elem_t *new, size_t hash)
 OPA_INTERNAL
 int opa_value_type(opa_value *node)
 {
-	return node->type;
+    // For all intents and purposes, interned strings are strings.
+    // Only opa_value_free and opa_value_shallow_copy handle them
+    // separately, by refering to node->type directly.
+    return (node->type == OPA_STRING_INTERNED) ? OPA_STRING : node->type;
 }
 
 opa_value *opa_value_get_object(opa_object_t *obj, opa_value *key)
 {
     opa_object_elem_t *elem = opa_object_get(obj, key);
-
-    if (elem != NULL)
-    {
-        return elem->v;
-    }
-
-    return NULL;
+    return elem == NULL ? NULL : elem->v;
 }
 
 opa_value *opa_value_get_set(opa_set_t *set, opa_value *key)
 {
     opa_set_elem_t *elem = opa_set_get(set, key);
-
-    if (elem != NULL)
-    {
-        return elem->v;
-    }
-
-    return NULL;
+    return elem == NULL ? NULL : elem->v;
 }
 
 opa_value *opa_value_get_array_native(opa_array_t *arr, long long i)
 {
-    if (i >= arr->len)
-    {
-        return NULL;
-    }
-
-    return arr->elems[i].v;
+    return i >= arr->len ? NULL : arr->elems[i].v;
 }
 
 opa_value *opa_value_get_array(opa_array_t *arr, opa_value *key)
@@ -279,7 +265,7 @@ size_t opa_value_length_string(opa_string_t *str)
 OPA_INTERNAL
 size_t opa_value_length(opa_value *node)
 {
-    switch (node->type)
+    switch (opa_value_type(node))
     {
     case OPA_ARRAY:
         return opa_value_length_array(opa_cast_array(node));
@@ -487,29 +473,28 @@ int opa_value_compare_set(opa_set_t *a, opa_set_t *b)
 OPA_INTERNAL
 int opa_value_compare(opa_value *a, opa_value *b)
 {
-    if (a == NULL && b == NULL)
+    if (a == b)
     {
         return 0;
     }
-    else if (b == NULL)
+    if (b == NULL)
     {
         return 1;
     }
-    else if (a == NULL)
+    if (a == NULL)
     {
         return -1;
     }
-
-    if (a->type < b->type)
+    if (opa_value_type(a) < opa_value_type(b))
     {
         return -1;
     }
-    else if (b->type < a->type)
+    if (opa_value_type(b) < opa_value_type(a))
     {
         return 1;
     }
 
-    switch (a->type)
+    switch (opa_value_type(a))
     {
     case OPA_NULL:
         return 0;
@@ -635,7 +620,7 @@ size_t opa_set_hash(opa_set_t *o) {
 }
 
 size_t opa_value_hash(opa_value *node) {
-    switch (node->type)
+    switch (opa_value_type(node))
     {
     case OPA_NULL:
         return 0;
@@ -656,9 +641,10 @@ size_t opa_value_hash(opa_value *node) {
     return 0;
 }
 
+OPA_INTERNAL
 void opa_value_free(opa_value *node)
 {
-    switch (node->type)
+    switch (node->type) // bypass opa_value_type: don't free OPA_STRING_INTERNED
     {
     case OPA_NULL:
         opa_free(node);
@@ -821,7 +807,7 @@ opa_value *opa_value_shallow_copy_set(opa_set_t *s)
 
 opa_value *opa_value_shallow_copy(opa_value *node)
 {
-    switch (node->type)
+    switch (node->type) // bypass opa_value_type: pass OPA_STRING_INTERNED along as-is
     {
     case OPA_NULL:
         return node;
@@ -837,6 +823,8 @@ opa_value *opa_value_shallow_copy(opa_value *node)
         return opa_value_shallow_copy_object(opa_cast_object(node));
     case OPA_SET:
         return opa_value_shallow_copy_set(opa_cast_set(node));
+    case OPA_STRING_INTERNED:
+        return node;
     }
 
     return NULL;
@@ -1535,7 +1523,6 @@ int _validate_json_path(opa_value *path)
     }
 
     int path_len = opa_value_length(path);
-
     if (path_len == 0)
     {
         return -1;
@@ -1544,12 +1531,9 @@ int _validate_json_path(opa_value *path)
     for (int i = 0; i < path_len-1; i++)
     {
         opa_value *v = opa_value_get_array_native(opa_cast_array(path), i);
-        switch (v->type)
+        if (opa_value_type(v) != OPA_STRING)
         {
-            case OPA_STRING:
-                continue;
-            default:
-                return -1;
+            return -1;
         }
     }
 

--- a/wasm/src/value.c
+++ b/wasm/src/value.c
@@ -21,10 +21,19 @@ static void __opa_set_add_elem(opa_set_t *set, opa_set_elem_t *new, size_t hash)
 OPA_INTERNAL
 int opa_value_type(opa_value *node)
 {
-    // For all intents and purposes, interned strings are strings.
+    // For all intents and purposes, interned strings are strings,
+    // interned booleans are booleans.
     // Only opa_value_free and opa_value_shallow_copy handle them
     // separately, by refering to node->type directly.
-    return (node->type == OPA_STRING_INTERNED) ? OPA_STRING : node->type;
+    switch (node->type)
+    {
+    case OPA_STRING_INTERNED:
+        return OPA_STRING;
+    case OPA_BOOLEAN_INTERNED:
+        return OPA_BOOLEAN;
+    default:
+        return node->type;
+    }
 }
 
 opa_value *opa_value_get_object(opa_object_t *obj, opa_value *key)
@@ -824,6 +833,7 @@ opa_value *opa_value_shallow_copy(opa_value *node)
     case OPA_SET:
         return opa_value_shallow_copy_set(opa_cast_set(node));
     case OPA_STRING_INTERNED:
+    case OPA_BOOLEAN_INTERNED:
         return node;
     }
 

--- a/wasm/src/value.c
+++ b/wasm/src/value.c
@@ -1164,13 +1164,6 @@ opa_value *opa_set_with_cap(size_t n)
 }
 
 OPA_INTERNAL
-void opa_value_boolean_set(opa_value *v, int b)
-{
-    opa_boolean_t *ret = opa_cast_boolean(v);
-    ret->v = b;
-}
-
-OPA_INTERNAL
 void opa_value_number_set_int(opa_value *v, long long i)
 {
 	opa_number_t *ret = opa_cast_number(v);

--- a/wasm/src/value.c
+++ b/wasm/src/value.c
@@ -883,13 +883,17 @@ opa_value *opa_null()
     return ret;
 }
 
-OPA_INTERNAL
-opa_value *opa_boolean(bool v)
+opa_value *opa_boolean_allocated(bool v)
 {
     opa_boolean_t *ret = (opa_boolean_t *)opa_malloc(sizeof(opa_boolean_t));
     ret->hdr.type = OPA_BOOLEAN;
     ret->v = v;
     return &ret->hdr;
+}
+
+opa_value *opa_boolean(bool v)
+{
+    return opa_boolean_allocated(v);
 }
 
 OPA_INTERNAL

--- a/wasm/src/value.c
+++ b/wasm/src/value.c
@@ -560,7 +560,7 @@ fnv1a32(size_t hash, const void *input, size_t len)
 }
 
 size_t opa_boolean_hash(opa_boolean_t *b) {
-    return b->v == FALSE ? 0 : 1;
+    return b->v ? 0 : 1;
 }
 
 size_t opa_number_hash(opa_number_t *n) {
@@ -874,7 +874,7 @@ opa_value *opa_null()
 }
 
 OPA_INTERNAL
-opa_value *opa_boolean(int v)
+opa_value *opa_boolean(bool v)
 {
     opa_boolean_t *ret = (opa_boolean_t *)opa_malloc(sizeof(opa_boolean_t));
     ret->hdr.type = OPA_BOOLEAN;

--- a/wasm/src/value.h
+++ b/wasm/src/value.h
@@ -32,7 +32,7 @@ struct opa_value
 typedef struct
 {
     opa_value hdr;
-    int v;
+    bool v;
 } opa_boolean_t;
 
 typedef struct
@@ -131,7 +131,7 @@ opa_errc opa_value_add_path(opa_value *data, opa_value *path, opa_value *v);
 opa_errc opa_value_remove_path(opa_value *data, opa_value *path);
 
 opa_value *opa_null();
-opa_value *opa_boolean(int v);
+opa_value *opa_boolean(bool v);
 opa_value *opa_number_size(size_t v);
 opa_value *opa_number_int(long long v);
 opa_value *opa_number_float(double v);

--- a/wasm/src/value.h
+++ b/wasm/src/value.h
@@ -149,7 +149,6 @@ opa_value *opa_object();
 opa_value *opa_set();
 opa_value *opa_set_with_cap(size_t cap);
 
-void opa_value_boolean_set(opa_value *v, int b);
 void opa_value_number_set_int(opa_value *v, long long i);
 
 int opa_number_try_int(opa_number_t *n, long long *i);

--- a/wasm/src/value.h
+++ b/wasm/src/value.h
@@ -16,6 +16,7 @@ extern "C" {
 #define OPA_ARRAY (5)
 #define OPA_OBJECT (6)
 #define OPA_SET (7)
+#define OPA_STRING_INTERNED (8)
 
 #define OPA_NUMBER_REPR_INT (1)
 #define OPA_NUMBER_REPR_FLOAT (2)

--- a/wasm/src/value.h
+++ b/wasm/src/value.h
@@ -17,6 +17,7 @@ extern "C" {
 #define OPA_OBJECT (6)
 #define OPA_SET (7)
 #define OPA_STRING_INTERNED (8)
+#define OPA_BOOLEAN_INTERNED (9) // TODO(sr): make an "interned" bitmask?
 
 #define OPA_NUMBER_REPR_INT (1)
 #define OPA_NUMBER_REPR_FLOAT (2)

--- a/wasm/tests/test.c
+++ b/wasm/tests/test.c
@@ -495,12 +495,12 @@ void test_opa_value_compare(void)
     test("none/some", opa_value_compare(NULL, opa_null()) < 0);
     test("some/none", opa_value_compare(opa_null(), NULL) > 0);
     test("null", opa_value_compare(opa_null(), opa_null()) == 0);
-    test("null/boolean", opa_value_compare(opa_boolean(TRUE), opa_null()) > 0);
-    test("true/true", opa_value_compare(opa_boolean(TRUE), opa_boolean(TRUE)) == 0);
-    test("true/false", opa_value_compare(opa_boolean(TRUE), opa_boolean(FALSE)) > 0);
-    test("false/true", opa_value_compare(opa_boolean(FALSE), opa_boolean(TRUE)) < 0);
-    test("false/false", opa_value_compare(opa_boolean(FALSE), opa_boolean(FALSE)) == 0);
-    test("number/boolean", opa_value_compare(opa_number_int(100), opa_boolean(TRUE)) > 0);
+    test("null/boolean", opa_value_compare(opa_boolean(true), opa_null()) > 0);
+    test("true/true", opa_value_compare(opa_boolean(true), opa_boolean(true)) == 0);
+    test("true/false", opa_value_compare(opa_boolean(true), opa_boolean(false)) > 0);
+    test("false/true", opa_value_compare(opa_boolean(false), opa_boolean(true)) < 0);
+    test("false/false", opa_value_compare(opa_boolean(false), opa_boolean(false)) == 0);
+    test("number/boolean", opa_value_compare(opa_number_int(100), opa_boolean(true)) > 0);
     test("integers", opa_value_compare(opa_number_int(100), opa_number_int(99)) > 0);
     test("integers", opa_value_compare(opa_number_int(100), opa_number_int(101)) < 0);
     test("integers", opa_value_compare(opa_number_int(100), opa_number_int(100)) == 0);
@@ -620,8 +620,8 @@ WASM_EXPORT(test_opa_json_parse_scalar)
 void test_opa_json_parse_scalar(void)
 {
     test("null", parse_crunch("null", opa_null()));
-    test("true", parse_crunch("true", opa_boolean(TRUE)));
-    test("false", parse_crunch("false", opa_boolean(FALSE)));
+    test("true", parse_crunch("true", opa_boolean(true)));
+    test("false", parse_crunch("false", opa_boolean(false)));
     test("strings", parse_crunch("\"hello\"", opa_string_terminated("hello")));
     test("strings: escaped quote", parse_crunch("\"a\\\"b\"", opa_string_terminated("a\"b")));
     test("strings: escaped reverse solidus", parse_crunch("\"a\\\\b\"", opa_string_terminated("a\\b")));
@@ -1247,8 +1247,8 @@ WASM_EXPORT(test_opa_json_dump)
 void test_opa_json_dump(void)
 {
     test("null", opa_strcmp(opa_json_dump(opa_null()), "null") == 0);
-    test("false", opa_strcmp(opa_json_dump(opa_boolean(0)), "false") == 0);
-    test("true", opa_strcmp(opa_json_dump(opa_boolean(1)), "true") == 0);
+    test("false", opa_strcmp(opa_json_dump(opa_boolean(false)), "false") == 0);
+    test("true", opa_strcmp(opa_json_dump(opa_boolean(true)), "true") == 0);
     test("strings", opa_strcmp(opa_json_dump(opa_string_terminated("hello\"world")), "\"hello\\\"world\"") == 0);
     test("strings utf-8", opa_strcmp(opa_json_dump(opa_string_terminated("\xed\xba\xad")), "\"\xed\xba\xad\"") == 0);
     test("numbers", opa_strcmp(opa_json_dump(opa_number_int(127)), "127") == 0);
@@ -1291,8 +1291,8 @@ void test_opa_json_dump(void)
     test("objects", opa_strcmp(opa_json_dump(obj), "{\"k1\":\"v1\",\"k2\":\"v2\"}") == 0);
 
     opa_value *terminators = opa_array();
-    opa_array_append(opa_cast_array(terminators), opa_boolean(1));
-    opa_array_append(opa_cast_array(terminators), opa_boolean(0));
+    opa_array_append(opa_cast_array(terminators), opa_boolean(true));
+    opa_array_append(opa_cast_array(terminators), opa_boolean(false));
     opa_array_append(opa_cast_array(terminators), opa_null());
 
     test("bool/null terminators", opa_strcmp(opa_json_dump(terminators), "[true,false,null]") == 0);
@@ -1721,48 +1721,48 @@ void test_aggregates(void)
     test("sort/set", opa_value_compare(opa_agg_sort(&set->hdr), &arr_sorted->hdr) == 0);
 
     opa_array_t *arr_trues = opa_cast_array(opa_array());
-    opa_array_append(arr_trues, opa_boolean(TRUE));
-    opa_array_append(arr_trues, opa_boolean(TRUE));
+    opa_array_append(arr_trues, opa_boolean(true));
+    opa_array_append(arr_trues, opa_boolean(true));
 
     opa_array_t *arr_mixed = opa_cast_array(opa_array());
-    opa_array_append(arr_mixed, opa_boolean(TRUE));
-    opa_array_append(arr_mixed, opa_boolean(FALSE));
+    opa_array_append(arr_mixed, opa_boolean(true));
+    opa_array_append(arr_mixed, opa_boolean(false));
 
     opa_array_t *arr_falses = opa_cast_array(opa_array());
-    opa_array_append(arr_falses, opa_boolean(FALSE));
-    opa_array_append(arr_falses, opa_boolean(FALSE));
+    opa_array_append(arr_falses, opa_boolean(false));
+    opa_array_append(arr_falses, opa_boolean(false));
 
-    test("all/array trues", opa_value_compare(opa_agg_all(&arr_trues->hdr), opa_boolean(TRUE)) == 0);
-    test("all/array mixed", opa_value_compare(opa_agg_all(&arr_mixed->hdr), opa_boolean(FALSE)) == 0);
-    test("all/array falses", opa_value_compare(opa_agg_all(&arr_falses->hdr), opa_boolean(FALSE)) == 0);
-    test("any/array trues", opa_value_compare(opa_agg_any(&arr_trues->hdr), opa_boolean(TRUE)) == 0);
-    test("any/array mixed", opa_value_compare(opa_agg_any(&arr_mixed->hdr), opa_boolean(TRUE)) == 0);
-    test("any/array falses", opa_value_compare(opa_agg_any(&arr_falses->hdr), opa_boolean(FALSE)) == 0);
+    test("all/array trues", opa_value_compare(opa_agg_all(&arr_trues->hdr), opa_boolean(true)) == 0);
+    test("all/array mixed", opa_value_compare(opa_agg_all(&arr_mixed->hdr), opa_boolean(false)) == 0);
+    test("all/array falses", opa_value_compare(opa_agg_all(&arr_falses->hdr), opa_boolean(false)) == 0);
+    test("any/array trues", opa_value_compare(opa_agg_any(&arr_trues->hdr), opa_boolean(true)) == 0);
+    test("any/array mixed", opa_value_compare(opa_agg_any(&arr_mixed->hdr), opa_boolean(true)) == 0);
+    test("any/array falses", opa_value_compare(opa_agg_any(&arr_falses->hdr), opa_boolean(false)) == 0);
 
     opa_set_t *set_trues = opa_cast_set(opa_set());
-    opa_set_add(set_trues, opa_boolean(TRUE));
-    opa_set_add(set_trues, opa_boolean(TRUE));
+    opa_set_add(set_trues, opa_boolean(true));
+    opa_set_add(set_trues, opa_boolean(true));
 
     opa_set_t *set_mixed = opa_cast_set(opa_set());
-    opa_set_add(set_mixed, opa_boolean(TRUE));
-    opa_set_add(set_mixed, opa_boolean(FALSE));
+    opa_set_add(set_mixed, opa_boolean(true));
+    opa_set_add(set_mixed, opa_boolean(false));
 
     opa_set_t *set_falses = opa_cast_set(opa_set());
-    opa_set_add(set_falses, opa_boolean(FALSE));
-    opa_set_add(set_falses, opa_boolean(FALSE));
+    opa_set_add(set_falses, opa_boolean(false));
+    opa_set_add(set_falses, opa_boolean(false));
 
-    test("all/set trues", opa_value_compare(opa_agg_all(&set_trues->hdr), opa_boolean(TRUE)) == 0);
-    test("all/set mixed", opa_value_compare(opa_agg_all(&set_mixed->hdr), opa_boolean(FALSE)) == 0);
-    test("all/set falses", opa_value_compare(opa_agg_all(&set_falses->hdr), opa_boolean(FALSE)) == 0);
-    test("any/set trues", opa_value_compare(opa_agg_any(&set_trues->hdr), opa_boolean(TRUE)) == 0);
-    test("any/set mixed", opa_value_compare(opa_agg_any(&set_mixed->hdr), opa_boolean(TRUE)) == 0);
-    test("any/set falses", opa_value_compare(opa_agg_any(&set_falses->hdr), opa_boolean(FALSE)) == 0);
+    test("all/set trues", opa_value_compare(opa_agg_all(&set_trues->hdr), opa_boolean(true)) == 0);
+    test("all/set mixed", opa_value_compare(opa_agg_all(&set_mixed->hdr), opa_boolean(false)) == 0);
+    test("all/set falses", opa_value_compare(opa_agg_all(&set_falses->hdr), opa_boolean(false)) == 0);
+    test("any/set trues", opa_value_compare(opa_agg_any(&set_trues->hdr), opa_boolean(true)) == 0);
+    test("any/set mixed", opa_value_compare(opa_agg_any(&set_mixed->hdr), opa_boolean(true)) == 0);
+    test("any/set falses", opa_value_compare(opa_agg_any(&set_falses->hdr), opa_boolean(false)) == 0);
 }
 
 WASM_EXPORT(test_base64)
 void test_base64(void)
 {
-    test("base64/is_valid", opa_value_compare(opa_base64_is_valid(opa_string_terminated("YWJjMTIzIT8kKiYoKSctPUB+")), opa_boolean(TRUE)) == 0);
+    test("base64/is_valid", opa_value_compare(opa_base64_is_valid(opa_string_terminated("YWJjMTIzIT8kKiYoKSctPUB+")), opa_boolean(true)) == 0);
     test("base64/encode", opa_value_compare(opa_base64_encode(opa_string_terminated("abc123!?$*&()'-=@~")), opa_string_terminated("YWJjMTIzIT8kKiYoKSctPUB+")) == 0);
     test("base64/encode", opa_value_compare(opa_base64_encode(opa_string_terminated("This is a long string that should not be split to many lines")),
                                             opa_string_terminated("VGhpcyBpcyBhIGxvbmcgc3RyaW5nIHRoYXQgc2hvdWxkIG5vdCBiZSBzcGxpdCB0byBtYW55IGxpbmVz")) == 0);
@@ -1793,8 +1793,8 @@ void test_object(void)
     test("object/get (key found)", opa_value_compare(builtin_object_get(&obj->hdr, opa_string_terminated("a"), opa_number_int(2)), opa_number_int(1)) == 0);
     test("object/get (string key not found)", opa_value_compare(builtin_object_get(&obj->hdr, opa_string_terminated("d"), opa_number_int(2)), opa_number_int(2)) == 0);
     test("object/get (integer key not found)", opa_value_compare(builtin_object_get(&obj->hdr, opa_number_int(1), opa_number_int(2)), opa_number_int(2)) == 0);
-    test("object/get (boolean default value)", opa_value_compare(builtin_object_get(&obj->hdr, opa_number_int(1), opa_boolean(TRUE)), opa_boolean(TRUE)) == 0);
-    test("object/get (non-object operand)", opa_value_compare(builtin_object_get(opa_string_terminated("a"), opa_number_int(1), opa_boolean(TRUE)), NULL) == 0);
+    test("object/get (boolean default value)", opa_value_compare(builtin_object_get(&obj->hdr, opa_number_int(1), opa_boolean(true)), opa_boolean(true)) == 0);
+    test("object/get (non-object operand)", opa_value_compare(builtin_object_get(opa_string_terminated("a"), opa_number_int(1), opa_boolean(true)), NULL) == 0);
 
     opa_object_t *obj_keys = opa_cast_object(opa_object());
     opa_object_insert(obj_keys, opa_string_terminated("a"), opa_number_int(0));
@@ -2277,7 +2277,7 @@ void test_json_remove(void)
 
     test("jsonremove/error (invalid first operand - number)", opa_value_compare(builtin_json_remove(opa_number_int(22),  opa_set()), NULL) == 0);
 
-    test("jsonremove/error (invalid first operand - boolean)", opa_value_compare(builtin_json_remove(opa_boolean(TRUE),  opa_set()), NULL) == 0);
+    test("jsonremove/error (invalid first operand - boolean)", opa_value_compare(builtin_json_remove(opa_boolean(true),  opa_set()), NULL) == 0);
 
     test("jsonremove/error (invalid first operand - array)", opa_value_compare(builtin_json_remove(opa_array(),  opa_set()), NULL) == 0);
 
@@ -2285,7 +2285,7 @@ void test_json_remove(void)
 
     test("jsonremove/error (invalid second operand - number)", opa_value_compare(builtin_json_remove(opa_object(), opa_number_int(22)), NULL) == 0);
 
-    test("jsonremove/error (invalid second operand - boolean)", opa_value_compare(builtin_json_remove(opa_object(), opa_boolean(TRUE)), NULL) == 0);
+    test("jsonremove/error (invalid second operand - boolean)", opa_value_compare(builtin_json_remove(opa_object(), opa_boolean(true)), NULL) == 0);
 
     test("jsonremove/error (invalid second operand - object)", opa_value_compare(builtin_json_remove(opa_object(), opa_object()), NULL) == 0);
 
@@ -2458,7 +2458,7 @@ void test_json_filter(void)
 
     test("jsonfilter/error (invalid first operand - number)", opa_value_compare(builtin_json_filter(opa_number_int(22),  opa_set()), NULL) == 0);
 
-    test("jsonfilter/error (invalid first operand - boolean)", opa_value_compare(builtin_json_filter(opa_boolean(TRUE),  opa_set()), NULL) == 0);
+    test("jsonfilter/error (invalid first operand - boolean)", opa_value_compare(builtin_json_filter(opa_boolean(true),  opa_set()), NULL) == 0);
 
     test("jsonfilter/error (invalid first operand - array)", opa_value_compare(builtin_json_filter(opa_array(),  opa_set()), NULL) == 0);
 
@@ -2466,7 +2466,7 @@ void test_json_filter(void)
 
     test("jsonfilter/error (invalid second operand - number)", opa_value_compare(builtin_json_filter(opa_object(), opa_number_int(22)), NULL) == 0);
 
-    test("jsonfilter/error (invalid second operand - boolean)", opa_value_compare(builtin_json_filter(opa_object(), opa_boolean(TRUE)), NULL) == 0);
+    test("jsonfilter/error (invalid second operand - boolean)", opa_value_compare(builtin_json_filter(opa_object(), opa_boolean(true)), NULL) == 0);
 
     test("jsonfilter/error (invalid second operand - object)", opa_value_compare(builtin_json_filter(opa_object(), opa_object()), NULL) == 0);
 }
@@ -2607,31 +2607,31 @@ void test_strings(void)
     test("concat/set1", opa_value_compare(opa_strings_concat(join, &set1->hdr), opa_string_terminated("foo")) == 0);
     test("concat/set2", opa_value_compare(opa_strings_concat(join, &set2->hdr), opa_string_terminated("bar--foo")) == 0);
 
-    test("contains/__", opa_value_compare(opa_strings_contains(opa_string_terminated(""), opa_string_terminated("")), opa_boolean(TRUE)) == 0);
-    test("contains/_a", opa_value_compare(opa_strings_contains(opa_string_terminated(""), opa_string_terminated("a")), opa_boolean(FALSE)) == 0);
-    test("contains/a_", opa_value_compare(opa_strings_contains(opa_string_terminated("a"), opa_string_terminated("")), opa_boolean(TRUE)) == 0);
-    test("contains/aa", opa_value_compare(opa_strings_contains(opa_string_terminated("a"), opa_string_terminated("a")), opa_boolean(TRUE)) == 0);
-    test("contains/ab", opa_value_compare(opa_strings_contains(opa_string_terminated("a"), opa_string_terminated("b")), opa_boolean(FALSE)) == 0);
-    test("contains/aab", opa_value_compare(opa_strings_contains(opa_string_terminated("a"), opa_string_terminated("ab")), opa_boolean(FALSE)) == 0);
-    test("contains/abb", opa_value_compare(opa_strings_contains(opa_string_terminated("ab"), opa_string_terminated("b")), opa_boolean(TRUE)) == 0);
-    test("contains/aab", opa_value_compare(opa_strings_contains(opa_string_terminated("aa"), opa_string_terminated("b")), opa_boolean(FALSE)) == 0);
-    test("contains/abab", opa_value_compare(opa_strings_contains(opa_string_terminated("ab"), opa_string_terminated("ab")), opa_boolean(TRUE)) == 0);
-    test("contains/abaa", opa_value_compare(opa_strings_contains(opa_string_terminated("ab"), opa_string_terminated("aa")), opa_boolean(FALSE)) == 0);
-    test("contains/abcbc", opa_value_compare(opa_strings_contains(opa_string_terminated("abc"), opa_string_terminated("bc")), opa_boolean(TRUE)) == 0);
-    test("contains/abcbd", opa_value_compare(opa_strings_contains(opa_string_terminated("abc"), opa_string_terminated("bd")), opa_boolean(FALSE)) == 0);
+    test("contains/__", opa_value_compare(opa_strings_contains(opa_string_terminated(""), opa_string_terminated("")), opa_boolean(true)) == 0);
+    test("contains/_a", opa_value_compare(opa_strings_contains(opa_string_terminated(""), opa_string_terminated("a")), opa_boolean(false)) == 0);
+    test("contains/a_", opa_value_compare(opa_strings_contains(opa_string_terminated("a"), opa_string_terminated("")), opa_boolean(true)) == 0);
+    test("contains/aa", opa_value_compare(opa_strings_contains(opa_string_terminated("a"), opa_string_terminated("a")), opa_boolean(true)) == 0);
+    test("contains/ab", opa_value_compare(opa_strings_contains(opa_string_terminated("a"), opa_string_terminated("b")), opa_boolean(false)) == 0);
+    test("contains/aab", opa_value_compare(opa_strings_contains(opa_string_terminated("a"), opa_string_terminated("ab")), opa_boolean(false)) == 0);
+    test("contains/abb", opa_value_compare(opa_strings_contains(opa_string_terminated("ab"), opa_string_terminated("b")), opa_boolean(true)) == 0);
+    test("contains/aab", opa_value_compare(opa_strings_contains(opa_string_terminated("aa"), opa_string_terminated("b")), opa_boolean(false)) == 0);
+    test("contains/abab", opa_value_compare(opa_strings_contains(opa_string_terminated("ab"), opa_string_terminated("ab")), opa_boolean(true)) == 0);
+    test("contains/abaa", opa_value_compare(opa_strings_contains(opa_string_terminated("ab"), opa_string_terminated("aa")), opa_boolean(false)) == 0);
+    test("contains/abcbc", opa_value_compare(opa_strings_contains(opa_string_terminated("abc"), opa_string_terminated("bc")), opa_boolean(true)) == 0);
+    test("contains/abcbd", opa_value_compare(opa_strings_contains(opa_string_terminated("abc"), opa_string_terminated("bd")), opa_boolean(false)) == 0);
 
-    test("endswith/__", opa_value_compare(opa_strings_endswith(opa_string_terminated(""), opa_string_terminated("")), opa_boolean(TRUE)) == 0);
-    test("endswith/_a", opa_value_compare(opa_strings_endswith(opa_string_terminated(""), opa_string_terminated("a")), opa_boolean(FALSE)) == 0);
-    test("endswith/a_", opa_value_compare(opa_strings_endswith(opa_string_terminated("a"), opa_string_terminated("")), opa_boolean(TRUE)) == 0);
-    test("endswith/aa", opa_value_compare(opa_strings_endswith(opa_string_terminated("a"), opa_string_terminated("a")), opa_boolean(TRUE)) == 0);
-    test("endswith/ab", opa_value_compare(opa_strings_endswith(opa_string_terminated("a"), opa_string_terminated("b")), opa_boolean(FALSE)) == 0);
-    test("endswith/aab", opa_value_compare(opa_strings_endswith(opa_string_terminated("a"), opa_string_terminated("ab")), opa_boolean(FALSE)) == 0);
-    test("endswith/abb", opa_value_compare(opa_strings_endswith(opa_string_terminated("ab"), opa_string_terminated("b")), opa_boolean(TRUE)) == 0);
-    test("endswith/aab", opa_value_compare(opa_strings_endswith(opa_string_terminated("aa"), opa_string_terminated("b")), opa_boolean(FALSE)) == 0);
-    test("endswith/abab", opa_value_compare(opa_strings_endswith(opa_string_terminated("ab"), opa_string_terminated("ab")), opa_boolean(TRUE)) == 0);
-    test("endswith/abaa", opa_value_compare(opa_strings_endswith(opa_string_terminated("ab"), opa_string_terminated("aa")), opa_boolean(FALSE)) == 0);
-    test("endswith/abcbc", opa_value_compare(opa_strings_endswith(opa_string_terminated("abc"), opa_string_terminated("bc")), opa_boolean(TRUE)) == 0);
-    test("endswith/abcbd", opa_value_compare(opa_strings_endswith(opa_string_terminated("abc"), opa_string_terminated("bd")), opa_boolean(FALSE)) == 0);
+    test("endswith/__", opa_value_compare(opa_strings_endswith(opa_string_terminated(""), opa_string_terminated("")), opa_boolean(true)) == 0);
+    test("endswith/_a", opa_value_compare(opa_strings_endswith(opa_string_terminated(""), opa_string_terminated("a")), opa_boolean(false)) == 0);
+    test("endswith/a_", opa_value_compare(opa_strings_endswith(opa_string_terminated("a"), opa_string_terminated("")), opa_boolean(true)) == 0);
+    test("endswith/aa", opa_value_compare(opa_strings_endswith(opa_string_terminated("a"), opa_string_terminated("a")), opa_boolean(true)) == 0);
+    test("endswith/ab", opa_value_compare(opa_strings_endswith(opa_string_terminated("a"), opa_string_terminated("b")), opa_boolean(false)) == 0);
+    test("endswith/aab", opa_value_compare(opa_strings_endswith(opa_string_terminated("a"), opa_string_terminated("ab")), opa_boolean(false)) == 0);
+    test("endswith/abb", opa_value_compare(opa_strings_endswith(opa_string_terminated("ab"), opa_string_terminated("b")), opa_boolean(true)) == 0);
+    test("endswith/aab", opa_value_compare(opa_strings_endswith(opa_string_terminated("aa"), opa_string_terminated("b")), opa_boolean(false)) == 0);
+    test("endswith/abab", opa_value_compare(opa_strings_endswith(opa_string_terminated("ab"), opa_string_terminated("ab")), opa_boolean(true)) == 0);
+    test("endswith/abaa", opa_value_compare(opa_strings_endswith(opa_string_terminated("ab"), opa_string_terminated("aa")), opa_boolean(false)) == 0);
+    test("endswith/abcbc", opa_value_compare(opa_strings_endswith(opa_string_terminated("abc"), opa_string_terminated("bc")), opa_boolean(true)) == 0);
+    test("endswith/abcbd", opa_value_compare(opa_strings_endswith(opa_string_terminated("abc"), opa_string_terminated("bd")), opa_boolean(false)) == 0);
 
     test("format_int/2_0", opa_value_compare(opa_strings_format_int(opa_number_float(0), opa_number_int(2)), opa_string_terminated("0")) == 0);
     test("format_int/2_1", opa_value_compare(opa_strings_format_int(opa_number_float(1), opa_number_int(2)), opa_string_terminated("1")) == 0);
@@ -2723,18 +2723,18 @@ void test_strings(void)
     opa_array_append(arr6, opa_string_terminated(""));
     test("split/empty", opa_value_compare(opa_strings_split(opa_string_terminated(""), opa_string_terminated(",")), &arr6->hdr) == 0);
 
-    test("startswith/__", opa_value_compare(opa_strings_startswith(opa_string_terminated(""), opa_string_terminated("")), opa_boolean(TRUE)) == 0);
-    test("startswith/_a", opa_value_compare(opa_strings_startswith(opa_string_terminated(""), opa_string_terminated("a")), opa_boolean(FALSE)) == 0);
-    test("startswith/a_", opa_value_compare(opa_strings_startswith(opa_string_terminated("a"), opa_string_terminated("")), opa_boolean(TRUE)) == 0);
-    test("startswith/aa", opa_value_compare(opa_strings_startswith(opa_string_terminated("a"), opa_string_terminated("a")), opa_boolean(TRUE)) == 0);
-    test("startswith/ab", opa_value_compare(opa_strings_startswith(opa_string_terminated("a"), opa_string_terminated("b")), opa_boolean(FALSE)) == 0);
-    test("startswith/aab", opa_value_compare(opa_strings_startswith(opa_string_terminated("a"), opa_string_terminated("ab")), opa_boolean(FALSE)) == 0);
-    test("startswith/aba", opa_value_compare(opa_strings_startswith(opa_string_terminated("ab"), opa_string_terminated("a")), opa_boolean(TRUE)) == 0);
-    test("startswith/aab", opa_value_compare(opa_strings_startswith(opa_string_terminated("aa"), opa_string_terminated("b")), opa_boolean(FALSE)) == 0);
-    test("startswith/abab", opa_value_compare(opa_strings_startswith(opa_string_terminated("ab"), opa_string_terminated("ab")), opa_boolean(TRUE)) == 0);
-    test("startswith/abaa", opa_value_compare(opa_strings_startswith(opa_string_terminated("ab"), opa_string_terminated("aa")), opa_boolean(FALSE)) == 0);
-    test("startswith/abcab", opa_value_compare(opa_strings_startswith(opa_string_terminated("abc"), opa_string_terminated("ab")), opa_boolean(TRUE)) == 0);
-    test("startswith/abcac", opa_value_compare(opa_strings_startswith(opa_string_terminated("abc"), opa_string_terminated("ac")), opa_boolean(FALSE)) == 0);
+    test("startswith/__", opa_value_compare(opa_strings_startswith(opa_string_terminated(""), opa_string_terminated("")), opa_boolean(true)) == 0);
+    test("startswith/_a", opa_value_compare(opa_strings_startswith(opa_string_terminated(""), opa_string_terminated("a")), opa_boolean(false)) == 0);
+    test("startswith/a_", opa_value_compare(opa_strings_startswith(opa_string_terminated("a"), opa_string_terminated("")), opa_boolean(true)) == 0);
+    test("startswith/aa", opa_value_compare(opa_strings_startswith(opa_string_terminated("a"), opa_string_terminated("a")), opa_boolean(true)) == 0);
+    test("startswith/ab", opa_value_compare(opa_strings_startswith(opa_string_terminated("a"), opa_string_terminated("b")), opa_boolean(false)) == 0);
+    test("startswith/aab", opa_value_compare(opa_strings_startswith(opa_string_terminated("a"), opa_string_terminated("ab")), opa_boolean(false)) == 0);
+    test("startswith/aba", opa_value_compare(opa_strings_startswith(opa_string_terminated("ab"), opa_string_terminated("a")), opa_boolean(true)) == 0);
+    test("startswith/aab", opa_value_compare(opa_strings_startswith(opa_string_terminated("aa"), opa_string_terminated("b")), opa_boolean(false)) == 0);
+    test("startswith/abab", opa_value_compare(opa_strings_startswith(opa_string_terminated("ab"), opa_string_terminated("ab")), opa_boolean(true)) == 0);
+    test("startswith/abaa", opa_value_compare(opa_strings_startswith(opa_string_terminated("ab"), opa_string_terminated("aa")), opa_boolean(false)) == 0);
+    test("startswith/abcab", opa_value_compare(opa_strings_startswith(opa_string_terminated("abc"), opa_string_terminated("ab")), opa_boolean(true)) == 0);
+    test("startswith/abcac", opa_value_compare(opa_strings_startswith(opa_string_terminated("abc"), opa_string_terminated("ac")), opa_boolean(false)) == 0);
 
     test("substring/_00", opa_value_compare(opa_strings_substring(opa_string_terminated(""), opa_number_int(0), opa_number_int(0)), opa_string_terminated("")) == 0);
     test("substring/_0-1", opa_value_compare(opa_strings_substring(opa_string_terminated(""), opa_number_int(0), opa_number_int(-1)), opa_string_terminated("")) == 0);
@@ -2842,8 +2842,8 @@ WASM_EXPORT(test_to_number)
 void test_to_number(void)
 {
     test("to_number/null", opa_value_compare(opa_to_number(opa_null()), opa_number_int(0)) == 0);
-    test("to_number/false", opa_value_compare(opa_to_number(opa_boolean(0)), opa_number_int(0)) == 0);
-    test("to_number/true", opa_value_compare(opa_to_number(opa_boolean(1)), opa_number_int(1)) == 0);
+    test("to_number/false", opa_value_compare(opa_to_number(opa_boolean(false)), opa_number_int(0)) == 0);
+    test("to_number/true", opa_value_compare(opa_to_number(opa_boolean(true)), opa_number_int(1)) == 0);
     test("to_number/nop", opa_value_compare(opa_to_number(opa_number_int(1)), opa_number_int(1)) == 0);
     test("to_number/integer", opa_value_compare(opa_to_number(opa_string_terminated("10")), opa_number_int(10)) == 0);
     test("to_number/float", opa_value_compare(opa_to_number(opa_string_terminated("3.5")), opa_number_float(3.5)) == 0);
@@ -2854,23 +2854,23 @@ void test_to_number(void)
 WASM_EXPORT(test_cidr_contains)
 void test_cidr_contains(void)
 {
-    test("cidr/contains", opa_value_compare(opa_cidr_contains(opa_string_terminated("10.0.0.0/8"), opa_string_terminated("10.1.0.0/24")), opa_boolean(TRUE)) == 0);
-    test("cidr/contains", opa_value_compare(opa_cidr_contains(opa_string_terminated("172.17.0.0/24"), opa_string_terminated("172.17.0.0/16")), opa_boolean(FALSE)) == 0);
-    test("cidr/contains", opa_value_compare(opa_cidr_contains(opa_string_terminated("10.0.0.0/8"), opa_string_terminated("192.168.1.0/24")), opa_boolean(FALSE)) == 0);
-    test("cidr/contains", opa_value_compare(opa_cidr_contains(opa_string_terminated("10.0.0.0/8"), opa_string_terminated("10.1.1.1/32")), opa_boolean(TRUE)) == 0);
-    test("cidr/contains", opa_value_compare(opa_cidr_contains(opa_string_terminated("2001:4860:4860::8888/32"), opa_string_terminated("2001:4860:4860:1234::8888/40")), opa_boolean(TRUE)) == 0);
-    test("cidr/contains", opa_value_compare(opa_cidr_contains(opa_string_terminated("2001:4860:4860::8888/32"), opa_string_terminated("2001:4860:4860:1234:5678:1234:5678:8888/128")), opa_boolean(TRUE)) == 0);
-    test("cidr/contains", opa_value_compare(opa_cidr_contains(opa_string_terminated("2001:4860::/96"), opa_string_terminated("2001:4860::/32")), opa_boolean(FALSE)) == 0);
-    test("cidr/contains", opa_value_compare(opa_cidr_contains(opa_string_terminated("2001:4860::/32"), opa_string_terminated("fd1e:5bfe:8af3:9ddc::/64")), opa_boolean(FALSE)) == 0);
+    test("cidr/contains", opa_value_compare(opa_cidr_contains(opa_string_terminated("10.0.0.0/8"), opa_string_terminated("10.1.0.0/24")), opa_boolean(true)) == 0);
+    test("cidr/contains", opa_value_compare(opa_cidr_contains(opa_string_terminated("172.17.0.0/24"), opa_string_terminated("172.17.0.0/16")), opa_boolean(false)) == 0);
+    test("cidr/contains", opa_value_compare(opa_cidr_contains(opa_string_terminated("10.0.0.0/8"), opa_string_terminated("192.168.1.0/24")), opa_boolean(false)) == 0);
+    test("cidr/contains", opa_value_compare(opa_cidr_contains(opa_string_terminated("10.0.0.0/8"), opa_string_terminated("10.1.1.1/32")), opa_boolean(true)) == 0);
+    test("cidr/contains", opa_value_compare(opa_cidr_contains(opa_string_terminated("2001:4860:4860::8888/32"), opa_string_terminated("2001:4860:4860:1234::8888/40")), opa_boolean(true)) == 0);
+    test("cidr/contains", opa_value_compare(opa_cidr_contains(opa_string_terminated("2001:4860:4860::8888/32"), opa_string_terminated("2001:4860:4860:1234:5678:1234:5678:8888/128")), opa_boolean(true)) == 0);
+    test("cidr/contains", opa_value_compare(opa_cidr_contains(opa_string_terminated("2001:4860::/96"), opa_string_terminated("2001:4860::/32")), opa_boolean(false)) == 0);
+    test("cidr/contains", opa_value_compare(opa_cidr_contains(opa_string_terminated("2001:4860::/32"), opa_string_terminated("fd1e:5bfe:8af3:9ddc::/64")), opa_boolean(false)) == 0);
     test("cidr/contains", opa_cidr_contains(opa_string_terminated("not-a-cidr"), opa_string_terminated("192.168.1.67")) == NULL);
     test("cidr/contains", opa_cidr_contains(opa_string_terminated("192.168.1.0/28"), opa_string_terminated("not-a-cidr")) == NULL);
-    test("cidr/contains", opa_value_compare(opa_cidr_contains(opa_string_terminated("10.0.0.0/8"), opa_string_terminated("10.1.2.3")), opa_boolean(TRUE)) == 0);
-    test("cidr/contains", opa_value_compare(opa_cidr_contains(opa_string_terminated("10.0.0.0/8"), opa_string_terminated("192.168.1.1")), opa_boolean(FALSE)) == 0);
+    test("cidr/contains", opa_value_compare(opa_cidr_contains(opa_string_terminated("10.0.0.0/8"), opa_string_terminated("10.1.2.3")), opa_boolean(true)) == 0);
+    test("cidr/contains", opa_value_compare(opa_cidr_contains(opa_string_terminated("10.0.0.0/8"), opa_string_terminated("192.168.1.1")), opa_boolean(false)) == 0);
 
-    test("cidr/contains", opa_value_compare(opa_cidr_intersects(opa_string_terminated("192.168.1.0/25"), opa_string_terminated("192.168.1.64/25")), opa_boolean(TRUE)) == 0);
-    test("cidr/contains", opa_value_compare(opa_cidr_intersects(opa_string_terminated("192.168.1.0/24"), opa_string_terminated("192.168.2.0/24")), opa_boolean(FALSE)) == 0);
-    test("cidr/contains", opa_value_compare(opa_cidr_intersects(opa_string_terminated("fd1e:5bfe:8af3:9ddc::/64"), opa_string_terminated("fd1e:5bfe:8af3:9ddc:1111::/72")), opa_boolean(TRUE)) == 0);
-    test("cidr/contains", opa_value_compare(opa_cidr_intersects(opa_string_terminated("fd1e:5bfe:8af3:9ddc::/64"), opa_string_terminated("2001:4860:4860::8888/32")), opa_boolean(FALSE)) == 0);
+    test("cidr/contains", opa_value_compare(opa_cidr_intersects(opa_string_terminated("192.168.1.0/25"), opa_string_terminated("192.168.1.64/25")), opa_boolean(true)) == 0);
+    test("cidr/contains", opa_value_compare(opa_cidr_intersects(opa_string_terminated("192.168.1.0/24"), opa_string_terminated("192.168.2.0/24")), opa_boolean(false)) == 0);
+    test("cidr/contains", opa_value_compare(opa_cidr_intersects(opa_string_terminated("fd1e:5bfe:8af3:9ddc::/64"), opa_string_terminated("fd1e:5bfe:8af3:9ddc:1111::/72")), opa_boolean(true)) == 0);
+    test("cidr/contains", opa_value_compare(opa_cidr_intersects(opa_string_terminated("fd1e:5bfe:8af3:9ddc::/64"), opa_string_terminated("2001:4860:4860::8888/32")), opa_boolean(false)) == 0);
     test("cidr/contains", opa_cidr_intersects(opa_string_terminated("not-a-cidr"), opa_string_terminated("192.168.1.0/24")) == NULL);
     test("cidr/contains", opa_cidr_intersects(opa_string_terminated("192.168.1.0/28"), opa_string_terminated("not-a-cidr")) == NULL);
 }
@@ -3108,8 +3108,8 @@ static void test_submatch_string(const char *s, sequence *seq, opa_value *result
 WASM_EXPORT(test_regex)
 void test_regex(void)
 {
-    test("regex/is_valid", opa_value_compare(opa_regex_is_valid(opa_string_terminated(".*")), opa_boolean(1)) == 0);
-    test("regex/is_valid_non_string", opa_value_compare(opa_regex_is_valid(opa_number_int(123)), opa_boolean(0)) == 0);
+    test("regex/is_valid", opa_value_compare(opa_regex_is_valid(opa_string_terminated(".*")), opa_boolean(true)) == 0);
+    test("regex/is_valid_non_string", opa_value_compare(opa_regex_is_valid(opa_number_int(123)), opa_boolean(false)) == 0);
 
     typedef struct {
         const char *pat;


### PR DESCRIPTION
Mixed bag of optimizations:

- [x] interning some strings:
  - for the `ir.StringConst` of a plan, we emit, in addition to the data section with the zero-terminated character strings, another one: a section of `opa_value *` of type `OPA_STRING`, mimicking what they would look like if we had called `opa_string_terminated` on the pointers of the first section
  - whenever there's an `ir.MakeStringStmt`, we're emitting a constant pointer to the `opa_value` we've got in that new section

  This measure should reduce the number of heap allocations performed needlessly.
- [x] for `call_indirect`: we're saving a few locals that had only been used because the generated code was having two parts: one for materializing the strings into locals, and another one for wrapping those locals into an array.
   - A small restructuring in the planner/compiler allows us to materialize the strings right before they're appended to the array used with `opa_mapping_lookup`
  
   - Together with the interning change, we end up with
    ```
    i32.const 8
    call $opa_array_with_cap
    local.set $80
    local.get $80
    i32.const <addr of interned string 1>
    call $opa_array_append
    local.get $80
    i32.const <addr of interned string 2>
    call $opa_array_append
    local.get $80
    local.get $10
    call $opa_array_append
    ```

- [x] Interning `opa_boolean`: unless explicitly required, we probably never care about being able to change these in place. So, if we'd ever like to do that, there's `opa_boolean_allocated` now. The rest will be interned to one of two memory locations, corresponding to true/false. It allows us a few more shortcuts in the compiler, too. And saves locals.

- [x] avoid `block` where possible: if its instructions don't have any `br_if` or `br`, they can safely be included without the `block` wrapping them.
- [x] use one-branched `if` instead of `block` for checking memoization
- [x] inline `block` used with internal function calls

Those last three points where done after comparing our wasm with the wasm that passed through wasm-opt. There's much more going one, but these seemed like low-hanging fruit. 🍎 