### PR TITLE
plugins/rest: SigV4 Signing for any AWS service

### DIFF
--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -384,9 +384,15 @@ keys:
 
 #### AWS Signature
 
-OPA will authenticate with an [AWS4 HMAC](https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-auth-using-authorization-header.html) signature. Two methods of obtaining the
+OPA will authenticate with an [AWS4 HMAC](https://docs.aws.amazon.com/general/latest/gr/sigv4_signing.html) signature. Several methods of obtaining the
 necessary credentials are available; exactly one must be specified to use the AWS signature
 authentication method.
+
+The AWS service for which to sign the request can be specified in the `service` field. If omitted, the default is `s3`.
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `services[_].credentials.s3_signing.service` | `string` | No | The AWS service to sign requests with, eg `execute-api` or `s3`. Default: `s3` |
 
 ##### Using Static Environment Credentials
 If specifying `environment_credentials`, OPA will expect to find environment variables

--- a/plugins/rest/rest_test.go
+++ b/plugins/rest/rest_test.go
@@ -136,6 +136,19 @@ func TestNew(t *testing.T) {
 			}`,
 		},
 		{
+			name: "ValidApiGatewayEnvCreds",
+			input: `{
+				"name": "foo",
+				"url": "http://localhost",
+				"credentials": {
+					"s3_signing": {
+						"service": "execute-api",
+						"environment_credentials": {}
+					}
+				}
+			}`,
+		},
+		{
 			name: "ValidS3MetadataCredsWithRole",
 			input: `{
 				"name": "foo",


### PR DESCRIPTION
### Notes
This adds a new `service` option to the `s3_signing` config, allowing for other AWS services (such
as API Gateway endpoints) to be used for bundles, decision logs etc.

For example:

```yaml
services:
  decision-log-service:
    url: https://myrestapi.execute-api.ap-southeast-2.amazonaws.com/prod/
    credentials:
      s3_signing:
        service: execute-api
        environment_credentials: {}

decision_logs:
  service: decision-log-service
  reporting:
    min_delay_seconds: 300
    max_delay_seconds: 600
```

If no service is specified, we default to `s3` to maintain backwards compatibility.

This updates the sigv4 signer to include the specified service in the signature, and to sign all
request headers for better compatibility with other AWS services, except an explicit ignore list,
as per https://github.com/aws/aws-sdk-go/blob/master/aws/signer/v4/v4.go#L92

Additionally, this fixes a bug in the signer where the body ReadCloser was consumed and not reset,
meaning requests that were signed were always sent with an empty body!

Fixes #3193

### Testing
* Set up an API Gateway endpoint with IAM auth to receive decision logs, ran OPA locally and verified logs were received successfully.
* Put a bundle in S3 and verified it could be retrieved successfully

Signed-off-by: Jack Stevenson <jacsteve@amazon.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
