### PR TITLE
Internal/prometheus: Add smaller buckets

### DIFF
--- a/internal/prometheus/prometheus.go
+++ b/internal/prometheus/prometheus.go
@@ -35,6 +35,18 @@ func New(inner metrics.Metrics, logger func(attrs map[string]interface{}, f stri
 		prometheus.HistogramOpts{
 			Name: "http_request_duration_seconds",
 			Help: "A histogram of duration for requests.",
+			Buckets: []float64{
+				1e-6, // 1 microsecond
+				5e-6,
+				1e-5,
+				5e-5,
+				1e-4,
+				5e-4,
+				1e-3, // 1 millisecond
+				0.01,
+				0.1,
+				1, // 1 second
+			},
 		},
 		[]string{"code", "handler", "method"},
 	)


### PR DESCRIPTION
I am not a Golang expert so please feel free to continue my work with another pull request or review mine.

This pull request ditches some higher granularity buckets in favour of adding a
few smaller ones. The bucket that I chose was based on https://www.openpolicyagent.org/docs/latest/policy-performance/#high-performance-policy-decisions
where the expectation is "policy evaluation has a budget on the order of 1 millisecond".
Also, I tried to stay within Prometheus's default 10 buckets.

This, when merged, should fix #3196


