### PR TITLE
fix eval command ignore flag support

### DIFF
--- a/cmd/eval.go
+++ b/cmd/eval.go
@@ -394,7 +394,7 @@ func setupEval(args []string, params evalCommandParams) (*evalContext, error) {
 
 	if len(params.dataPaths.v) > 0 {
 		f := loaderFilter{
-			Ignore: checkParams.ignore,
+			Ignore: params.ignore,
 		}
 		regoArgs = append(regoArgs, rego.Load(params.dataPaths.v, f.Apply))
 	}


### PR DESCRIPTION
This PR updates `eval` function to use local ignore flags, rather than incorrectly using `checkParams` package variable. 

Currently the ignore flags are not applied to the `eval` command. 

It is worth noting that  `ignore` flags are only applied to `--data` paths, and not `--bundle` paths. This may be tackled in separate PR.

Signed-off-by: p0tr3c <p0tr3c@protonmail.com>
