### PR TITLE
rego_wasm_test.go: are these actually run?

### DIFF
--- a/rego/rego_wasm_test.go
+++ b/rego/rego_wasm_test.go
@@ -6,6 +6,18 @@
 
 package rego
 
+import (
+	"context"
+	"testing"
+
+	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/storage/inmem"
+)
+
+func TestFails(t *testing.T) {
+	t.Error("this won't pass")
+}
+
 func TestPrepareAndEvalWithWasmTarget(t *testing.T) {
 	mod := `
 	package test


### PR DESCRIPTION
📓 Sorry for the noise, I just need CI's take on this. I've gotten into the situation where those tests just wouldn't be picked up by any `go test -tags opa_wasm` command I came up with; I'm starting to wonder if they ever run. Let's see.