### PR TITLE
tests: fix wasm tests

### DIFF
--- a/rego/rego_wasmtarget_test.go
+++ b/rego/rego_wasmtarget_test.go
@@ -6,6 +6,14 @@
 
 package rego
 
+import (
+	"context"
+	"testing"
+
+	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/storage/inmem"
+)
+
 func TestPrepareAndEvalWithWasmTarget(t *testing.T) {
 	mod := `
 	package test

--- a/repl/repl_wasmtarget_test.go
+++ b/repl/repl_wasmtarget_test.go
@@ -6,6 +6,12 @@
 
 package repl
 
+import (
+	"bytes"
+	"context"
+	"testing"
+)
+
 func TestReplWasmTarget(t *testing.T) {
 	ctx := context.Background()
 	store := newTestStore()


### PR DESCRIPTION
xyz_wasm_test.go makes go implicitly require the GOOS to be wasm.
That's not what we want here.

Example go test list before:

    $ go test --tags=opa_wasm ./repl -list TestReplWasmTarget
    ok      github.com/open-policy-agent/opa/repl   0.006s

After:

    $ go test --tags=opa_wasm ./repl -list TestReplWasmTarget
    TestReplWasmTarget
    ok      github.com/open-policy-agent/opa/repl   0.007s
