### PR TITLE
docs: fixes grammar for 'expr-call' and 'expr-infix'

### DIFF
--- a/docs/content/policy-reference.md
+++ b/docs/content/policy-reference.md
@@ -1060,8 +1060,8 @@ literal         = ( some-decl | expr | "not" expr ) { with-modifier }
 with-modifier   = "with" term "as" term
 some-decl       = "some" var { "," var }
 expr            = term | expr-call | expr-infix
-expr-call       = var [ "." var ] "(" [ term { "," term } ] ")"
-expr-infix      = [ term "=" ] term infix-operator term
+expr-call       = var [ "." var ] "(" [ expr { "," expr } ] ")"
+expr-infix      = [ term "=" ] expr infix-operator expr
 term            = ref | var | scalar | array | object | set | array-compr | object-compr | set-compr
 array-compr     = "[" term "|" rule-body "]"
 set-compr       = "{" term "|" rule-body "}"


### PR DESCRIPTION
The grammar is currently defined as:

```
expr-call       = var [ "." var ] "(" [ term { "," term } ] ")"
expr-infix      = [ term "=" ] term infix-operator term
```

But the args for the expr-call or both sides of the infix-operation can by expressions too ?

Silly example:
```
allow { 
    count(array.concat([1,2], [3,4])) == count([1,2]) + count([3,4])
}
```

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
