### PR TITLE
topdown: Update the logic to calculate the size of cache item

### DIFF
--- a/topdown/http.go
+++ b/topdown/http.go
@@ -953,7 +953,7 @@ func formatHTTPResponseToAST(resp *http.Response, forceJSONDecode bool) (ast.Val
 		return nil, 0, err
 	}
 
-	return resultObj, len(resultRawBody), nil
+	return resultObj, len(resultObj.String()), nil
 }
 
 func getResponseHeaders(headers http.Header) map[string]interface{} {


### PR DESCRIPTION
Previously when inserting an item in the inter-query cache, only
the size of the raw string representing the HTTP response message body
was used to calculate the amount of memory used by the item. This was
errornous as the actual item inserted in the cache would hold not only the
raw string but also the json representation of the message body.
As a result, the cache would end up consuming more memory
than the user-defined cache size limit. This change now returns a more accurate
measure of the cache item size.

Fixes: #3024

Signed-off-by: Ashutosh Narkar <anarkar4387@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
