### PR TITLE
ast: parse import without package in resolveRefs

### DIFF
--- a/ast/compile_test.go
+++ b/ast/compile_test.go
@@ -3872,6 +3872,13 @@ func TestQueryCompiler(t *testing.T) {
 			q:        "data.deadbeef(x)",
 			expected: fmt.Errorf("rego_type_error: undefined function data.deadbeef"),
 		},
+		{
+			note:     "imports resolved without package",
+			q:        "abc",
+			pkg:      "",
+			imports:  []string{"import input.xyz as abc"},
+			expected: "input.xyz",
+		},
 	}
 	for _, tc := range tests {
 		runQueryCompilerTest(t, tc.note, tc.q, tc.pkg, tc.imports, tc.expected)


### PR DESCRIPTION
Before, `resolveRefs` ignored Imports when Package is nil.
This caused `opa eval --import` option to be ignored without `--package` option.

This PR makes query compiler generate temporary package with name of ""
(empty string) when package is nil but import one or many imports are provided.

For example, we have two files.

`filter1.rego`
```
package f

getFamily(i) = { rtn |
  rtn := i.characters[_].family
}

getChildren(family) = { rtn |
  rtn := family[_].children
}
```

`data.json`
```
{
  "characters": [
    {
      "id": 0,
      "name": "Marty McFly",
      "cast": "Michael J. Fox",
      "family": {
        "children": [
          "Marty McFly Jr.",
          "Marlene McFly"
        ]
      },
      "occupation": "student"
    }
  ]
}
```

Before, we had this error because of no `--package` option.
```
opa eval -I --format=pretty -d filter1.rego --import 'data.f' 'f.getChildren(f.getFamily(input))' < data.json
2 errors occurred:
1:15: rego_type_error: undefined function f.getFamily
1:1: rego_type_error: undefined function f.getChildren
```

After this PR, we can use `--import` option without any explicit `--package` option.

```
opa eval -I --format=pretty -d filter1.rego --import 'data.f' 'f.getChildren(f.getFamily(input))' < data.json
[
  [
    "Marty McFly Jr.",
    "Marlene McFly"
  ]
]
```

Fixes #3228

Signed-off-by: Hiro Osaki <hiroyuki.osaki@gmail.com>

Thank you for reviewing this PR. 
<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
