### PR TITLE
ast: Add ast.JSONWithOpt to complement ast.JSON

### DIFF
--- a/ast/term_test.go
+++ b/ast/term_test.go
@@ -939,6 +939,24 @@ func TestValueToInterface(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Expected error from JSON(%v)", term)
 	}
+
+	// Ordering option
+	//
+	// These inputs exercise all of the cases (i.e., sets nested in arrays, object keys, and object values.)
+	//
+	a, err := JSONWithOpt(MustParseTerm(`[{{3, 4}: {1, 2}}]`).Value, JSONOpt{SortSets: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	b, err := JSONWithOpt(MustParseTerm(`[{{4, 3}: {2, 1}}]`).Value, JSONOpt{SortSets: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(a, b) {
+		t.Fatalf("expcted %v = %v", a, b)
+	}
 }
 
 func assertTermEqual(t *testing.T, x *Term, y *Term) {

--- a/rego/rego.go
+++ b/rego/rego.go
@@ -107,6 +107,7 @@ type EvalContext struct {
 	indexing               bool
 	interQueryBuiltinCache cache.InterQueryCache
 	resolvers              []refResolver
+	sortSets               bool
 }
 
 // EvalOption defines a function to set an option on an EvalConfig
@@ -229,6 +230,13 @@ func EvalInterQueryBuiltinCache(c cache.InterQueryCache) EvalOption {
 func EvalResolver(ref ast.Ref, r resolver.Resolver) EvalOption {
 	return func(e *EvalContext) {
 		e.resolvers = append(e.resolvers, refResolver{ref, r})
+	}
+}
+
+// EvalSortSets causes the evaluator to sort sets before returning them as JSON arrays.
+func EvalSortSets(yes bool) EvalOption {
+	return func(e *EvalContext) {
+		e.sortSets = yes
 	}
 }
 
@@ -1946,7 +1954,7 @@ func (r *Rego) generateResult(qr topdown.QueryResult, ectx *EvalContext) (Result
 
 	result := newResult()
 	for k := range qr {
-		v, err := ast.JSON(qr[k].Value)
+		v, err := ast.JSONWithOpt(qr[k].Value, ast.JSONOpt{SortSets: ectx.sortSets})
 		if err != nil {
 			return result, err
 		}
@@ -1966,7 +1974,7 @@ func (r *Rego) generateResult(qr topdown.QueryResult, ectx *EvalContext) (Result
 		}
 
 		if k, ok := r.capture[expr]; ok {
-			v, err := ast.JSON(qr[k].Value)
+			v, err := ast.JSONWithOpt(qr[k].Value, ast.JSONOpt{SortSets: ectx.sortSets})
 			if err != nil {
 				return result, err
 			}


### PR DESCRIPTION
In some cases, the caller needs to be able to control the order that
sets are serialized into JSON arrays. This commit adds that wrapper
and exposes the option in the rego package.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
