### PR TITLE
wasm: Add support for time option via rego package

### DIFF
--- a/internal/rego/opa/nop.go
+++ b/internal/rego/opa/nop.go
@@ -8,23 +8,10 @@ package opa
 
 import (
 	"context"
-
-	"github.com/open-policy-agent/opa/metrics"
 )
 
 // OPA is a stub implementation of a opa.OPA.
 type OPA struct {
-}
-
-// Result is a stub implementation of a opa.Result.
-type Result struct {
-	Result []byte
-}
-
-// EvalOpts is a stub implementation of a opa.EvalOpts.
-type EvalOpts struct {
-	Input   *interface{}
-	Metrics metrics.Metrics
 }
 
 // New unimplemented.

--- a/internal/rego/opa/opa.go
+++ b/internal/rego/opa/opa.go
@@ -8,24 +8,13 @@ package opa
 
 import (
 	"context"
+
 	wopa "github.com/open-policy-agent/opa/internal/wasm/sdk/opa"
-	"github.com/open-policy-agent/opa/metrics"
 )
 
 // OPA is an implementation of the OPA SDK.
 type OPA struct {
 	opa *wopa.OPA
-}
-
-// Result holds the evaluation result.
-type Result struct {
-	Result []byte
-}
-
-// EvalOpts define options for performing an evaluation.
-type EvalOpts struct {
-	Input   *interface{}
-	Metrics metrics.Metrics
 }
 
 // New constructs a new OPA instance.
@@ -60,6 +49,7 @@ func (o *OPA) Eval(ctx context.Context, opts EvalOpts) (*Result, error) {
 	evalOptions := wopa.EvalOpts{
 		Input:   opts.Input,
 		Metrics: opts.Metrics,
+		Time:    opts.Time,
 	}
 
 	res, err := o.opa.Eval(ctx, evalOptions)

--- a/internal/rego/opa/options.go
+++ b/internal/rego/opa/options.go
@@ -1,0 +1,19 @@
+package opa
+
+import (
+	"time"
+
+	"github.com/open-policy-agent/opa/metrics"
+)
+
+// Result holds the evaluation result.
+type Result struct {
+	Result []byte
+}
+
+// EvalOpts define options for performing an evaluation.
+type EvalOpts struct {
+	Input   *interface{}
+	Metrics metrics.Metrics
+	Time    time.Time
+}

--- a/internal/wasm/sdk/internal/wasm/bindings.go
+++ b/internal/wasm/sdk/internal/wasm/bindings.go
@@ -63,12 +63,15 @@ func (d *builtinDispatcher) SetMap(m map[int32]topdown.BuiltinFunc) {
 }
 
 // Reset is called in Eval before using the builtinDispatcher.
-func (d *builtinDispatcher) Reset(ctx context.Context) {
+func (d *builtinDispatcher) Reset(ctx context.Context, ns time.Time) {
+	if ns.IsZero() {
+		ns = time.Now()
+	}
 	d.ctx = &topdown.BuiltinContext{
 		Context:  ctx,
 		Cancel:   topdown.NewCancel(),
 		Runtime:  nil,
-		Time:     ast.NumberTerm(json.Number(strconv.FormatInt(time.Now().UnixNano(), 10))),
+		Time:     ast.NumberTerm(json.Number(strconv.FormatInt(ns.UnixNano(), 10))),
 		Metrics:  metrics.New(),
 		Cache:    make(builtins.Cache),
 		Location: nil,

--- a/internal/wasm/sdk/internal/wasm/pool_test.go
+++ b/internal/wasm/sdk/internal/wasm/pool_test.go
@@ -9,6 +9,7 @@ package wasm_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/bundle"
@@ -20,7 +21,7 @@ import (
 
 func TestPoolCopyParsedDataOnInit(t *testing.T) {
 	module := `package test
-	
+
 	p = data.a
 	`
 	data := []byte(`{
@@ -49,7 +50,7 @@ func TestPoolCopyParsedDataOnInit(t *testing.T) {
 
 func TestPoolCopyParsedDataUpdateFull(t *testing.T) {
 	module := `package test
-	
+
 	p = data.a
 	`
 	data := []byte(`{"a": 123}`)
@@ -80,7 +81,7 @@ func TestPoolCopyParsedDataUpdateFull(t *testing.T) {
 
 func TestPoolCopyParsedDataUpdatePartial(t *testing.T) {
 	module := `package test
-	
+
 	p = data.a
 	`
 	data := []byte(`{}`)
@@ -149,7 +150,7 @@ func ensurePoolResults(t *testing.T, testPool *wasm.Pool, poolSize int, expected
 
 		toRelease = append(toRelease, vm)
 
-		result, err := vm.Eval(context.Background(), 0, nil, metrics.New())
+		result, err := vm.Eval(context.Background(), 0, nil, metrics.New(), time.Now())
 		if err != nil {
 			t.Fatalf("Unexpected error: %s", err)
 		}

--- a/internal/wasm/sdk/internal/wasm/vm.go
+++ b/internal/wasm/sdk/internal/wasm/vm.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/bytecodealliance/wasmtime-go"
 	_ "github.com/bytecodealliance/wasmtime-go/build/include"        // to include the C headers.
@@ -210,7 +211,7 @@ func newVM(opts vmOpts) (*VM, error) {
 
 // Eval performs an evaluation of the specified entrypoint, with any provided
 // input, and returns the resulting value dumped to a string.
-func (i *VM) Eval(ctx context.Context, entrypoint int32, input *interface{}, metrics metrics.Metrics) ([]byte, error) {
+func (i *VM) Eval(ctx context.Context, entrypoint int32, input *interface{}, metrics metrics.Metrics, ns time.Time) ([]byte, error) {
 	metrics.Timer("wasm_vm_eval").Start()
 	defer metrics.Timer("wasm_vm_eval").Stop()
 
@@ -224,7 +225,7 @@ func (i *VM) Eval(ctx context.Context, entrypoint int32, input *interface{}, met
 	// make use of it (e.g. `http.send`); and it will spawn a go routine
 	// cancelling the builtins that use topdown.Cancel, when the context is
 	// cancelled.
-	i.dispatcher.Reset(ctx)
+	i.dispatcher.Reset(ctx, ns)
 
 	// Interrupt the VM if the context is cancelled.
 	done := make(chan struct{})

--- a/internal/wasm/sdk/opa/opa.go
+++ b/internal/wasm/sdk/opa/opa.go
@@ -11,6 +11,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/bytecodealliance/wasmtime-go"
 
@@ -157,6 +158,7 @@ type EvalOpts struct {
 	Entrypoint int32
 	Input      *interface{}
 	Metrics    metrics.Metrics
+	Time       time.Time
 }
 
 // Eval evaluates the policy with the given input, returning the
@@ -180,7 +182,7 @@ func (o *OPA) Eval(ctx context.Context, opts EvalOpts) (*Result, error) {
 
 	defer o.pool.Release(instance, m)
 
-	result, err := instance.Eval(ctx, opts.Entrypoint, opts.Input, m)
+	result, err := instance.Eval(ctx, opts.Entrypoint, opts.Input, m, opts.Time)
 	if t, ok := err.(*wasmtime.Trap); ok && strings.HasPrefix(t.Message(), "wasm trap: interrupt") {
 		return nil, errors.ErrCancelled
 	}

--- a/rego/rego.go
+++ b/rego/rego.go
@@ -1889,7 +1889,7 @@ func (r *Rego) evalWasm(ctx context.Context, ectx *EvalContext) (ResultSet, erro
 		input = &i
 	}
 
-	result, err := r.opa.Eval(ctx, opa.EvalOpts{Metrics: r.metrics, Input: input})
+	result, err := r.opa.Eval(ctx, opa.EvalOpts{Metrics: r.metrics, Input: input, Time: ectx.time})
 	if err != nil {
 		return nil, err
 	}

--- a/rego/rego_wasmtarget_test.go
+++ b/rego/rego_wasmtarget_test.go
@@ -98,6 +98,21 @@ func TestPrepareAndEvalWithWasmTargetModulesOnCompiler(t *testing.T) {
 	}, "[[true]]")
 }
 
+func TestWasmTimeOfDay(t *testing.T) {
+
+	ctx := context.Background()
+	pq, err := New(Query("time.now_ns()"), Target("wasm")).PrepareForEval(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Unix(1615397269, 0)
+
+	assertPreparedEvalQueryEval(t, pq, []EvalOption{
+		EvalTime(now),
+	}, "[[1615397269000000000]]")
+}
+
 func TestEvalWithContextTimeout(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 		select {


### PR DESCRIPTION
This commit updates the rego package to propagate the time option all
the way down to the SDK and into the built-in dispatcher. This way
callers can control the time-of-day observed by wasm compiled policies.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
