### PR TITLE
wasm: exclude re2 code if no entrypoint found

### DIFF
--- a/internal/compiler/wasm/wasm.go
+++ b/internal/compiler/wasm/wasm.go
@@ -163,6 +163,16 @@ var builtinsFunctions = map[string]string{
 	ast.JSONFilter.Name:                 "builtin_json_filter",
 }
 
+// If none of these is called from a policy, the resulting wasm
+// module will not contain any RE2-related functions
+var builtinsUsingRE2 = [...]string{
+	builtinsFunctions[ast.RegexIsValid.Name],
+	builtinsFunctions[ast.RegexMatch.Name],
+	builtinsFunctions[ast.RegexMatchDeprecated.Name],
+	builtinsFunctions[ast.RegexFindAllStringSubmatch.Name],
+	builtinsFunctions[ast.GlobMatch.Name],
+}
+
 var builtinDispatchers = [...]string{
 	"opa_builtin0",
 	"opa_builtin1",


### PR DESCRIPTION
We know which builtins are backed by re2. So, we'll drop all the re2-
related code if they're not used.

With this, the no-op policy gets down to 116K.

Fixes #3250.

<details><summary>example policy.wasm dump from #3250</summary>

```

policy.wasm:	file format wasm 0x1

Section Details:

Type[29]:
 - type[0] (i32, i32, i32) -> i32
 - type[1] (i32, i32) -> i32
 - type[2] (i32, i32) -> nil
 - type[3] (i32, i32, i32, i32) -> nil
 - type[4] (i32) -> nil
 - type[5] (i32) -> i32
 - type[6] (i32, i32, i32, i32, i32) -> nil
 - type[7] (i32, i32, i32) -> nil
 - type[8] (i32, i32, i32, i32, i32, i32, i32) -> nil
 - type[9] (i32, i32, i32, i32) -> i32
 - type[10] (i32, i32, i32, i32, i32, i32) -> i32
 - type[11] (i32, i32, i32, i32, i32) -> i32
 - type[12] () -> i32
 - type[13] () -> nil
 - type[14] (i32, f64) -> i32
 - type[15] (i32, i64) -> i32
 - type[16] (i64, i32, i32) -> i32
 - type[17] (f64) -> i32
 - type[18] (i64) -> i32
 - type[19] (i32, i64) -> nil
 - type[20] (f64) -> f64
 - type[21] (i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32) -> i32
 - type[22] (i32, i32, i32, i32, f64, i32, i32, i32) -> i32
 - type[23] (i32, i32, i32, i32, i32, i32) -> nil
 - type[24] (i32, i32, i32, i32, i32, i32, i32) -> i32
 - type[25] (i32, i32, i64) -> i32
 - type[26] (i32, i32, i32, i64) -> i32
 - type[27] (i32, i32, i32, i32, i32, i32, i32, i32, i32) -> i32
 - type[28] (i32, i32, i32, i32, i32, i32, i32, i32) -> i32
Import[7]:
 - memory[0] pages: initial=2 <- env.memory
 - func[0] sig=4 <opa_abort> <- env.opa_abort
 - func[1] sig=1 <opa_builtin0> <- env.opa_builtin0
 - func[2] sig=0 <opa_builtin1> <- env.opa_builtin1
 - func[3] sig=9 <opa_builtin2> <- env.opa_builtin2
 - func[4] sig=11 <opa_builtin3> <- env.opa_builtin3
 - func[5] sig=10 <opa_builtin4> <- env.opa_builtin4
Function[677]:
 - func[6] sig=5
 - func[7] sig=5
 - func[8] sig=5
 - func[9] sig=5
 - func[10] sig=5
 - func[11] sig=5
 - func[12] sig=5
 - func[13] sig=5
 - func[14] sig=5
 - func[15] sig=5
 - func[16] sig=5
 - func[17] sig=5
 - func[18] sig=1
 - func[19] sig=1
 - func[20] sig=1
 - func[21] sig=1
 - func[22] sig=1
 - func[23] sig=1
 - func[24] sig=0
 - func[25] sig=1
 - func[26] sig=1
 - func[27] sig=5
 - func[28] sig=1
 - func[29] sig=1
 - func[30] sig=1
 - func[31] sig=1
 - func[32] sig=0
 - func[33] sig=0
 - func[34] sig=1
 - func[35] sig=12 <opa_eval_ctx_new>
 - func[36] sig=2 <opa_eval_ctx_set_input>
 - func[37] sig=2 <opa_eval_ctx_set_data>
 - func[38] sig=2 <opa_eval_ctx_set_entrypoint>
 - func[39] sig=5 <opa_eval_ctx_get_result>
 - func[40] sig=13
 - func[41] sig=5
 - func[42] sig=5
 - func[43] sig=9
 - func[44] sig=5
 - func[45] sig=5
 - func[46] sig=9
 - func[47] sig=5
 - func[48] sig=5
 - func[49] sig=5
 - func[50] sig=5
 - func[51] sig=3 <opa_runtime_error>
 - func[52] sig=1
 - func[53] sig=5 <opa_json_lex_read_number>
 - func[54] sig=5 <opa_json_lex_read_string>
 - func[55] sig=5 <opa_json_lex_read>
 - func[56] sig=0 <opa_json_parse_string>
 - func[57] sig=1 <opa_json_parse_token>
 - func[58] sig=0 <opa_json_parse_set>
 - func[59] sig=1 <opa_json_parse_object>
 - func[60] sig=1 <opa_json_parse>
 - func[61] sig=1 <opa_value_parse>
 - func[62] sig=1 <opa_json_writer_emit_boolean>
 - func[63] sig=14 <opa_json_writer_emit_float>
 - func[64] sig=15 <opa_json_writer_emit_integer>
 - func[65] sig=1 <opa_json_writer_emit_number>
 - func[66] sig=1 <opa_json_writer_emit_string>
 - func[67] sig=0 <opa_json_writer_emit_array_element>
 - func[68] sig=1 <opa_json_writer_emit_value>
 - func[69] sig=11 <opa_json_writer_emit_collection>
 - func[70] sig=0 <opa_json_writer_emit_set_element>
 - func[71] sig=1 <opa_json_writer_emit_set_literal>
 - func[72] sig=0 <opa_json_writer_emit_object_element>
 - func[73] sig=1 <opa_json_writer_write>
 - func[74] sig=5 <opa_json_dump>
 - func[75] sig=5 <opa_value_dump>
 - func[76] sig=12 <opa_heap_ptr_get>
 - func[77] sig=4 <opa_heap_ptr_set>
 - func[78] sig=5 <opa_malloc>
 - func[79] sig=4 <opa_free>
 - func[80] sig=1 <opa_realloc>
 - func[81] sig=5
 - func[82] sig=2
 - func[83] sig=13 <opa_memoize_init>
 - func[84] sig=13
 - func[85] sig=13
 - func[86] sig=2 <opa_memoize_insert>
 - func[87] sig=5 <opa_memoize_get>
 - func[88] sig=13 <opa_mpd_init>
 - func[89] sig=12
 - func[90] sig=12
 - func[91] sig=4
 - func[92] sig=5 <opa_number_to_bf>
 - func[93] sig=5
 - func[94] sig=5
 - func[95] sig=5
 - func[96] sig=5
 - func[97] sig=5
 - func[98] sig=5
 - func[99] sig=1
 - func[100] sig=5
 - func[101] sig=1
 - func[102] sig=1
 - func[103] sig=1
 - func[104] sig=1
 - func[105] sig=1
 - func[106] sig=5
 - func[107] sig=1
 - func[108] sig=5
 - func[109] sig=5
 - func[110] sig=5
 - func[111] sig=1
 - func[112] sig=1
 - func[113] sig=1
 - func[114] sig=0
 - func[115] sig=1
 - func[116] sig=1
 - func[117] sig=1
 - func[118] sig=1
 - func[119] sig=1
 - func[120] sig=1
 - func[121] sig=1
 - func[122] sig=5
 - func[123] sig=1
 - func[124] sig=5
 - func[125] sig=5 <opa_strlen>
 - func[126] sig=0 <opa_strncmp>
 - func[127] sig=5 <opa_isdigit>
 - func[128] sig=5 <opa_isspace>
 - func[129] sig=5 <opa_ishex>
 - func[130] sig=16 <opa_itoa>
 - func[131] sig=0 <opa_atoi64>
 - func[132] sig=0 <opa_atof64>
 - func[133] sig=1
 - func[134] sig=1
 - func[135] sig=1
 - func[136] sig=1
 - func[137] sig=1
 - func[138] sig=0
 - func[139] sig=1
 - func[140] sig=1
 - func[141] sig=1
 - func[142] sig=0
 - func[143] sig=1
 - func[144] sig=1
 - func[145] sig=1
 - func[146] sig=1
 - func[147] sig=1
 - func[148] sig=5
 - func[149] sig=0
 - func[150] sig=5
 - func[151] sig=5
 - func[152] sig=5
 - func[153] sig=5
 - func[154] sig=5
 - func[155] sig=5
 - func[156] sig=5
 - func[157] sig=5
 - func[158] sig=5
 - func[159] sig=5
 - func[160] sig=5 <opa_unicode_surrogate>
 - func[161] sig=0 <opa_unicode_decode_unit>
 - func[162] sig=1 <opa_unicode_decode_surrogate>
 - func[163] sig=9 <opa_unicode_decode_utf8>
 - func[164] sig=1 <opa_unicode_encode_utf8>
 - func[165] sig=0
 - func[166] sig=5
 - func[167] sig=5
 - func[168] sig=5
 - func[169] sig=5 <opa_value_type>
 - func[170] sig=5 <opa_value_hash>
 - func[171] sig=1 <opa_value_compare>
 - func[172] sig=1 <opa_object_get>
 - func[173] sig=1
 - func[174] sig=1
 - func[175] sig=1 <opa_value_get>
 - func[176] sig=1 <opa_value_compare_number>
 - func[177] sig=1 <opa_value_compare_object>
 - func[178] sig=1 <opa_value_compare_set>
 - func[179] sig=5 <opa_number_hash>
 - func[180] sig=1 <opa_value_iter>
 - func[181] sig=5 <opa_value_length>
 - func[182] sig=5 <opa_object_keys>
 - func[183] sig=2 <opa_array_append>
 - func[184] sig=4 <opa_value_free>
 - func[185] sig=1
 - func[186] sig=7 <opa_object_insert>
 - func[187] sig=2 <__opa_object_grow>
 - func[188] sig=5 <opa_boolean>
 - func[189] sig=17
 - func[190] sig=1
 - func[191] sig=18 <opa_number_int>
 - func[192] sig=1
 - func[193] sig=5
 - func[194] sig=5
 - func[195] sig=2 <opa_set_add>
 - func[196] sig=2 <__opa_set_grow>
 - func[197] sig=5
 - func[198] sig=5
 - func[199] sig=7
 - func[200] sig=12 <opa_null>
 - func[201] sig=5
 - func[202] sig=1 <opa_number_ref_allocated>
 - func[203] sig=19 <opa_number_init_int>
 - func[204] sig=5 <opa_string_terminated>
 - func[205] sig=1 <opa_string_allocated>
 - func[206] sig=12 <opa_array>
 - func[207] sig=5
 - func[208] sig=12 <opa_object>
 - func[209] sig=12 <opa_set>
 - func[210] sig=5
 - func[211] sig=19
 - func[212] sig=2
 - func[213] sig=0 <opa_value_add_path>
 - func[214] sig=1 <opa_value_remove_path>
 - func[215] sig=1
 - func[216] sig=2 <opa_mapping_init>
 - func[217] sig=5
 - func[218] sig=7
 - func[219] sig=2
 - func[220] sig=6
 - func[221] sig=0
 - func[222] sig=5
 - func[223] sig=2
 - func[224] sig=4
 - func[225] sig=4
 - func[226] sig=2
 - func[227] sig=5
 - func[228] sig=1
 - func[229] sig=7
 - func[230] sig=2
 - func[231] sig=2
 - func[232] sig=0
 - func[233] sig=2
 - func[234] sig=1
 - func[235] sig=0
 - func[236] sig=3
 - func[237] sig=1
 - func[238] sig=0
 - func[239] sig=2
 - func[240] sig=2
 - func[241] sig=5
 - func[242] sig=1
 - func[243] sig=5
 - func[244] sig=4
 - func[245] sig=1
 - func[246] sig=3
 - func[247] sig=0
 - func[248] sig=2
 - func[249] sig=2
 - func[250] sig=5 <isalpha>
 - func[251] sig=5 <isupper>
 - func[252] sig=5 <isspace>
 - func[253] sig=20
 - func[254] sig=9 <snprintf_>
 - func[255] sig=9 <_vsnprintf>
 - func[256] sig=3 <_out_buffer>
 - func[257] sig=3 <_out_null>
 - func[258] sig=21 <_ntoa_format>
 - func[259] sig=22 <_ftoa>
 - func[260] sig=22 <_etoa>
 - func[261] sig=0 <fprintf>
 - func[262] sig=9 <fwrite>
 - func[263] sig=1 <fputc>
 - func[264] sig=13 <abort>
 - func[265] sig=5 <malloc>
 - func[266] sig=4 <free>
 - func[267] sig=1 <calloc>
 - func[268] sig=1 <realloc>
 - func[269] sig=0 <strtol>
 - func[270] sig=0
 - func[271] sig=0
 - func[272] sig=0 <memcpy>
 - func[273] sig=0
 - func[274] sig=0 <memset>
 - func[275] sig=5
 - func[276] sig=11
 - func[277] sig=7
 - func[278] sig=0
 - func[279] sig=1 <_mpd_baseincr>
 - func[280] sig=6
 - func[281] sig=7
 - func[282] sig=3
 - func[283] sig=6
 - func[284] sig=9
 - func[285] sig=10
 - func[286] sig=6 <_mpd_baseshiftl>
 - func[287] sig=9 <_mpd_baseshiftr>
 - func[288] sig=9
 - func[289] sig=4 <mpd_defaultcontext>
 - func[290] sig=4 <mpd_maxcontext>
 - func[291] sig=9
 - func[292] sig=0
 - func[293] sig=3
 - func[294] sig=7 <fnt_dif2>
 - func[295] sig=0 <std_fnt>
 - func[296] sig=0 <std_inv_fnt>
 - func[297] sig=0 <four_step_fnt>
 - func[298] sig=0 <inv_four_step_fnt>
 - func[299] sig=3 <mpd_qset_string>
 - func[300] sig=1
 - func[301] sig=9
 - func[302] sig=9
 - func[303] sig=1
 - func[304] sig=1 <mpd_calloc>
 - func[305] sig=9 <mpd_realloc>
 - func[306] sig=0 <mpd_sh_alloc>
 - func[307] sig=12 <mpd_qnew>
 - func[308] sig=0 <mpd_switch_to_dyn>
 - func[309] sig=0 <mpd_realloc_dyn>
 - func[310] sig=5
 - func[311] sig=5
 - func[312] sig=5
 - func[313] sig=5
 - func[314] sig=5
 - func[315] sig=5
 - func[316] sig=5
 - func[317] sig=5
 - func[318] sig=5
 - func[319] sig=2 <mpd_uint_zero>
 - func[320] sig=4 <mpd_del>
 - func[321] sig=0 <mpd_qresize>
 - func[322] sig=4 <mpd_setdigits>
 - func[323] sig=4 <mpd_set_qnan>
 - func[324] sig=4 <mpd_set_negative>
 - func[325] sig=4 <mpd_set_positive>
 - func[326] sig=4 <mpd_set_dynamic_data>
 - func[327] sig=2 <mpd_set_flags>
 - func[328] sig=7 <mpd_qmaxcoeff>
 - func[329] sig=5
 - func[330] sig=7 <mpd_setspecial>
 - func[331] sig=7 <mpd_seterror>
 - func[332] sig=3 <mpd_qsset_ssize>
 - func[333] sig=7 <mpd_qfinalize>
 - func[334] sig=7 <_mpd_fix_nan>
 - func[335] sig=7 <_mpd_check_exp>
 - func[336] sig=1 <mpd_qshiftr_inplace>
 - func[337] sig=3
 - func[338] sig=3 <mpd_qset_i32>
 - func[339] sig=0
 - func[340] sig=0 <_mpd_get_rnd>
 - func[341] sig=1
 - func[342] sig=0 <mpd_qcopy>
 - func[343] sig=9 <mpd_qshiftl>
 - func[344] sig=3 <_mpd_apply_round_excess>
 - func[345] sig=0 <mpd_qcmp>
 - func[346] sig=1 <_mpd_cmp>
 - func[347] sig=11 <_mpd_basecmp>
 - func[348] sig=9
 - func[349] sig=6
 - func[350] sig=2
 - func[351] sig=6
 - func[352] sig=23
 - func[353] sig=6
 - func[354] sig=6
 - func[355] sig=3
 - func[356] sig=3
 - func[357] sig=3
 - func[358] sig=6
 - func[359] sig=6
 - func[360] sig=6
 - func[361] sig=6
 - func[362] sig=23
 - func[363] sig=6
 - func[364] sig=23
 - func[365] sig=6
 - func[366] sig=1
 - func[367] sig=23
 - func[368] sig=11
 - func[369] sig=10
 - func[370] sig=6
 - func[371] sig=6
 - func[372] sig=6
 - func[373] sig=3
 - func[374] sig=3
 - func[375] sig=3
 - func[376] sig=3
 - func[377] sig=3
 - func[378] sig=1
 - func[379] sig=11
 - func[380] sig=8
 - func[381] sig=0 <_mpd_getkernel>
 - func[382] sig=0 <_mpd_init_fnt_params>
 - func[383] sig=7 <_mpd_init_w3table>
 - func[384] sig=0 <six_step_fnt>
 - func[385] sig=0 <inv_six_step_fnt>
 - func[386] sig=0 <transpose_pow2>
 - func[387] sig=2 <squaretrans_pow2>
 - func[388] sig=9 <swap_halfrows_pow2>
 - func[389] sig=5
 - func[390] sig=5
 - func[391] sig=4
 - func[392] sig=5
 - func[393] sig=4
 - func[394] sig=13
 - func[395] sig=4
 - func[396] sig=1
 - func[397] sig=1
 - func[398] sig=0
 - func[399] sig=7
 - func[400] sig=0
 - func[401] sig=2
 - func[402] sig=0
 - func[403] sig=1
 - func[404] sig=2
 - func[405] sig=0
 - func[406] sig=0
 - func[407] sig=1
 - func[408] sig=11
 - func[409] sig=4
 - func[410] sig=7
 - func[411] sig=10
 - func[412] sig=0
 - func[413] sig=7
 - func[414] sig=7
 - func[415] sig=0
 - func[416] sig=24
 - func[417] sig=24
 - func[418] sig=1
 - func[419] sig=5
 - func[420] sig=5
 - func[421] sig=4
 - func[422] sig=3
 - func[423] sig=3
 - func[424] sig=3
 - func[425] sig=3
 - func[426] sig=11
 - func[427] sig=1
 - func[428] sig=23
 - func[429] sig=0
 - func[430] sig=3
 - func[431] sig=0
 - func[432] sig=3
 - func[433] sig=3
 - func[434] sig=4
 - func[435] sig=7
 - func[436] sig=3
 - func[437] sig=6
 - func[438] sig=3
 - func[439] sig=8
 - func[440] sig=25
 - func[441] sig=1
 - func[442] sig=1
 - func[443] sig=6
 - func[444] sig=2
 - func[445] sig=1
 - func[446] sig=15
 - func[447] sig=15
 - func[448] sig=4
 - func[449] sig=6
 - func[450] sig=8
 - func[451] sig=7
 - func[452] sig=2
 - func[453] sig=2
 - func[454] sig=4
 - func[455] sig=2
 - func[456] sig=2
 - func[457] sig=2
 - func[458] sig=2
 - func[459] sig=2
 - func[460] sig=26
 - func[461] sig=5
 - func[462] sig=9
 - func[463] sig=9
 - func[464] sig=1
 - func[465] sig=3
 - func[466] sig=0
 - func[467] sig=3
 - func[468] sig=23
 - func[469] sig=0
 - func[470] sig=2
 - func[471] sig=1
 - func[472] sig=1
 - func[473] sig=1
 - func[474] sig=1
 - func[475] sig=1
 - func[476] sig=1
 - func[477] sig=1
 - func[478] sig=1
 - func[479] sig=1
 - func[480] sig=1
 - func[481] sig=1
 - func[482] sig=1
 - func[483] sig=1
 - func[484] sig=1
 - func[485] sig=1
 - func[486] sig=1
 - func[487] sig=1
 - func[488] sig=27
 - func[489] sig=1
 - func[490] sig=4
 - func[491] sig=4
 - func[492] sig=4
 - func[493] sig=2
 - func[494] sig=28
 - func[495] sig=2
 - func[496] sig=2
 - func[497] sig=2
 - func[498] sig=1
 - func[499] sig=2
 - func[500] sig=5
 - func[501] sig=8
 - func[502] sig=9
 - func[503] sig=4
 - func[504] sig=10
 - func[505] sig=24
 - func[506] sig=24
 - func[507] sig=9
 - func[508] sig=2
 - func[509] sig=2
 - func[510] sig=2
 - func[511] sig=2
 - func[512] sig=2
 - func[513] sig=2
 - func[514] sig=0
 - func[515] sig=2
 - func[516] sig=0
 - func[517] sig=24
 - func[518] sig=5
 - func[519] sig=9
 - func[520] sig=2
 - func[521] sig=1
 - func[522] sig=0
 - func[523] sig=5
 - func[524] sig=1
 - func[525] sig=5
 - func[526] sig=9
 - func[527] sig=9
 - func[528] sig=10
 - func[529] sig=0
 - func[530] sig=11
 - func[531] sig=9
 - func[532] sig=5
 - func[533] sig=1
 - func[534] sig=5
 - func[535] sig=2
 - func[536] sig=5
 - func[537] sig=5
 - func[538] sig=5
 - func[539] sig=2
 - func[540] sig=0
 - func[541] sig=7
 - func[542] sig=3
 - func[543] sig=3
 - func[544] sig=3
 - func[545] sig=3
 - func[546] sig=3
 - func[547] sig=9
 - func[548] sig=3
 - func[549] sig=11
 - func[550] sig=9
 - func[551] sig=9
 - func[552] sig=1
 - func[553] sig=0
 - func[554] sig=4
 - func[555] sig=1
 - func[556] sig=4
 - func[557] sig=9
 - func[558] sig=10
 - func[559] sig=4
 - func[560] sig=2
 - func[561] sig=2
 - func[562] sig=2
 - func[563] sig=2
 - func[564] sig=2
 - func[565] sig=7
 - func[566] sig=6
 - func[567] sig=7
 - func[568] sig=7
 - func[569] sig=2
 - func[570] sig=2
 - func[571] sig=4
 - func[572] sig=5
 - func[573] sig=5
 - func[574] sig=4
 - func[575] sig=1
 - func[576] sig=7
 - func[577] sig=4
 - func[578] sig=1
 - func[579] sig=7
 - func[580] sig=4
 - func[581] sig=4
 - func[582] sig=23
 - func[583] sig=1
 - func[584] sig=7
 - func[585] sig=8
 - func[586] sig=23
 - func[587] sig=3
 - func[588] sig=4
 - func[589] sig=7
 - func[590] sig=0
 - func[591] sig=11
 - func[592] sig=7
 - func[593] sig=0
 - func[594] sig=7
 - func[595] sig=4
 - func[596] sig=0
 - func[597] sig=4
 - func[598] sig=5
 - func[599] sig=2
 - func[600] sig=2
 - func[601] sig=10
 - func[602] sig=24
 - func[603] sig=9
 - func[604] sig=4
 - func[605] sig=12
 - func[606] sig=4
 - func[607] sig=12
 - func[608] sig=0
 - func[609] sig=5
 - func[610] sig=2
 - func[611] sig=5
 - func[612] sig=4
 - func[613] sig=4
 - func[614] sig=2
 - func[615] sig=4
 - func[616] sig=2
 - func[617] sig=0
 - func[618] sig=1
 - func[619] sig=1
 - func[620] sig=1
 - func[621] sig=11
 - func[622] sig=0
 - func[623] sig=0
 - func[624] sig=0
 - func[625] sig=9
 - func[626] sig=0
 - func[627] sig=1
 - func[628] sig=2
 - func[629] sig=1
 - func[630] sig=1
 - func[631] sig=2
 - func[632] sig=2
 - func[633] sig=5
 - func[634] sig=3
 - func[635] sig=9
 - func[636] sig=0
 - func[637] sig=5
 - func[638] sig=0
 - func[639] sig=2
 - func[640] sig=1
 - func[641] sig=2
 - func[642] sig=4
 - func[643] sig=5
 - func[644] sig=4
 - func[645] sig=9
 - func[646] sig=0
 - func[647] sig=5
 - func[648] sig=9
 - func[649] sig=5
 - func[650] sig=5
 - func[651] sig=1
 - func[652] sig=0
 - func[653] sig=10
 - func[654] sig=1
 - func[655] sig=2
 - func[656] sig=1
 - func[657] sig=0
 - func[658] sig=9
 - func[659] sig=10
 - func[660] sig=9
 - func[661] sig=5
 - func[662] sig=4
 - func[663] sig=9
 - func[664] sig=4
 - func[665] sig=4
 - func[666] sig=10
 - func[667] sig=1
 - func[668] sig=4
 - func[669] sig=2
 - func[670] sig=2
 - func[671] sig=2
 - func[672] sig=2
 - func[673] sig=2
 - func[674] sig=0
 - func[675] sig=1
 - func[676] sig=1
 - func[677] sig=1
 - func[678] sig=1 <g0.data.test.main>
 - func[679] sig=5 <eval>
 - func[680] sig=12 <builtins>
 - func[681] sig=12 <entrypoints>
 - func[682] sig=13 <_initialize>
Table[1]:
 - table[0] type=funcref initial=75 max=75
Global[3]:
 - global[0] i32 mutable=1 - init i32=121904
 - global[1] i32 mutable=0 <opa_wasm_abi_version> - init i32=1
 - global[2] i32 mutable=0 <opa_wasm_abi_minor_version> - init i32=1
Export[21]:
 - func[35] <opa_eval_ctx_new> -> "opa_eval_ctx_new"
 - func[78] <opa_malloc> -> "opa_malloc"
 - func[36] <opa_eval_ctx_set_input> -> "opa_eval_ctx_set_input"
 - func[37] <opa_eval_ctx_set_data> -> "opa_eval_ctx_set_data"
 - func[38] <opa_eval_ctx_set_entrypoint> -> "opa_eval_ctx_set_entrypoint"
 - func[39] <opa_eval_ctx_get_result> -> "opa_eval_ctx_get_result"
 - func[60] <opa_json_parse> -> "opa_json_parse"
 - func[74] <opa_json_dump> -> "opa_json_dump"
 - func[61] <opa_value_parse> -> "opa_value_parse"
 - func[79] <opa_free> -> "opa_free"
 - func[75] <opa_value_dump> -> "opa_value_dump"
 - func[76] <opa_heap_ptr_get> -> "opa_heap_ptr_get"
 - func[77] <opa_heap_ptr_set> -> "opa_heap_ptr_set"
 - func[213] <opa_value_add_path> -> "opa_value_add_path"
 - func[214] <opa_value_remove_path> -> "opa_value_remove_path"
 - global[1] -> "opa_wasm_abi_version"
 - global[2] -> "opa_wasm_abi_minor_version"
 - func[679] <eval> -> "eval"
 - func[680] <builtins> -> "builtins"
 - func[681] <entrypoints> -> "entrypoints"
 - memory[0] -> "memory"
Start:
 - start function: 682
Elem[2]:
 - segment[0] flags=0 table=0 count=73 - init i32=1
  - elem[1] = func[171] <opa_value_compare>
  - elem[2] = func[67] <opa_json_writer_emit_array_element>
  - elem[3] = func[70] <opa_json_writer_emit_set_element>
  - elem[4] = func[72] <opa_json_writer_emit_object_element>
  - elem[5] = func[230]
  - elem[6] = func[231]
  - elem[7] = func[256] <_out_buffer>
  - elem[8] = func[257] <_out_null>
  - elem[9] = func[384] <six_step_fnt>
  - elem[10] = func[295] <std_fnt>
  - elem[11] = func[297] <four_step_fnt>
  - elem[12] = func[385] <inv_six_step_fnt>
  - elem[13] = func[296] <std_inv_fnt>
  - elem[14] = func[298] <inv_four_step_fnt>
  - elem[15] = func[265] <malloc>
  - elem[16] = func[268] <realloc>
  - elem[17] = func[267] <calloc>
  - elem[18] = func[266] <free>
  - elem[19] = func[419]
  - elem[20] = func[421]
  - elem[21] = func[437]
  - elem[22] = func[439]
  - elem[23] = func[435]
  - elem[24] = func[436]
  - elem[25] = func[420]
  - elem[26] = func[448]
  - elem[27] = func[449]
  - elem[28] = func[450]
  - elem[29] = func[451]
  - elem[30] = func[394]
  - elem[31] = func[490]
  - elem[32] = func[491]
  - elem[33] = func[492]
  - elem[34] = func[471]
  - elem[35] = func[473]
  - elem[36] = func[475]
  - elem[37] = func[477]
  - elem[38] = func[479]
  - elem[39] = func[481]
  - elem[40] = func[483]
  - elem[41] = func[485]
  - elem[42] = func[532]
  - elem[43] = func[554]
  - elem[44] = func[527]
  - elem[45] = func[528]
  - elem[46] = func[555]
  - elem[47] = func[529]
  - elem[48] = func[556]
  - elem[49] = func[557]
  - elem[50] = func[558]
  - elem[51] = func[583]
  - elem[52] = func[595]
  - elem[53] = func[597]
  - elem[54] = func[604]
  - elem[55] = func[606]
  - elem[56] = func[612]
  - elem[57] = func[644]
  - elem[58] = func[645]
  - elem[59] = func[646]
  - elem[60] = func[649]
  - elem[61] = func[662]
  - elem[62] = func[663]
  - elem[63] = func[653]
  - elem[64] = func[651]
  - elem[65] = func[652]
  - elem[66] = func[664]
  - elem[67] = func[658]
  - elem[68] = func[659]
  - elem[69] = func[656]
  - elem[70] = func[657]
  - elem[71] = func[665]
  - elem[72] = func[666]
  - elem[73] = func[667]
 - segment[1] flags=0 table=0 count=1 - init i32=74
  - elem[74] = func[678] <g0.data.test.main>
Code[677]:
 - func[6] size=3
 - func[7] size=3
 - func[8] size=3
 - func[9] size=3
 - func[10] size=3
 - func[11] size=3
 - func[12] size=3
 - func[13] size=3
 - func[14] size=3
 - func[15] size=3
 - func[16] size=3
 - func[17] size=3
 - func[18] size=3
 - func[19] size=3
 - func[20] size=3
 - func[21] size=3
 - func[22] size=3
 - func[23] size=3
 - func[24] size=3
 - func[25] size=3
 - func[26] size=3
 - func[27] size=3
 - func[28] size=3
 - func[29] size=3
 - func[30] size=3
 - func[31] size=3
 - func[32] size=3
 - func[33] size=3
 - func[34] size=3
 - func[35] size=31 <opa_eval_ctx_new>
 - func[36] size=9 <opa_eval_ctx_set_input>
 - func[37] size=9 <opa_eval_ctx_set_data>
 - func[38] size=9 <opa_eval_ctx_set_entrypoint>
 - func[39] size=7 <opa_eval_ctx_get_result>
 - func[40] size=3
 - func[41] size=3
 - func[42] size=3
 - func[43] size=3
 - func[44] size=3
 - func[45] size=3
 - func[46] size=3
 - func[47] size=3
 - func[48] size=3
 - func[49] size=3
 - func[50] size=3
 - func[51] size=186 <opa_runtime_error>
 - func[52] size=3
 - func[53] size=540 <opa_json_lex_read_number>
 - func[54] size=450 <opa_json_lex_read_string>
 - func[55] size=626 <opa_json_lex_read>
 - func[56] size=825 <opa_json_parse_string>
 - func[57] size=394 <opa_json_parse_token>
 - func[58] size=128 <opa_json_parse_set>
 - func[59] size=193 <opa_json_parse_object>
 - func[60] size=93 <opa_json_parse>
 - func[61] size=93 <opa_value_parse>
 - func[62] size=409 <opa_json_writer_emit_boolean>
 - func[63] size=286 <opa_json_writer_emit_float>
 - func[64] size=266 <opa_json_writer_emit_integer>
 - func[65] size=289 <opa_json_writer_emit_number>
 - func[66] size=1832 <opa_json_writer_emit_string>
 - func[67] size=20 <opa_json_writer_emit_array_element>
 - func[68] size=375 <opa_json_writer_emit_value>
 - func[69] size=549 <opa_json_writer_emit_collection>
 - func[70] size=12 <opa_json_writer_emit_set_element>
 - func[71] size=244 <opa_json_writer_emit_set_literal>
 - func[72] size=358 <opa_json_writer_emit_object_element>
 - func[73] size=244 <opa_json_writer_write>
 - func[74] size=76 <opa_json_dump>
 - func[75] size=77 <opa_value_dump>
 - func[76] size=11 <opa_heap_ptr_get>
 - func[77] size=372 <opa_heap_ptr_set>
 - func[78] size=899 <opa_malloc>
 - func[79] size=635 <opa_free>
 - func[80] size=50 <opa_realloc>
 - func[81] size=3
 - func[82] size=3
 - func[83] size=45 <opa_memoize_init>
 - func[84] size=3
 - func[85] size=3
 - func[86] size=35 <opa_memoize_insert>
 - func[87] size=90 <opa_memoize_get>
 - func[88] size=182 <opa_mpd_init>
 - func[89] size=3
 - func[90] size=3
 - func[91] size=3
 - func[92] size=468 <opa_number_to_bf>
 - func[93] size=3
 - func[94] size=3
 - func[95] size=3
 - func[96] size=3
 - func[97] size=3
 - func[98] size=3
 - func[99] size=3
 - func[100] size=3
 - func[101] size=3
 - func[102] size=3
 - func[103] size=3
 - func[104] size=3
 - func[105] size=3
 - func[106] size=3
 - func[107] size=3
 - func[108] size=3
 - func[109] size=3
 - func[110] size=3
 - func[111] size=3
 - func[112] size=3
 - func[113] size=3
 - func[114] size=3
 - func[115] size=3
 - func[116] size=3
 - func[117] size=3
 - func[118] size=3
 - func[119] size=3
 - func[120] size=3
 - func[121] size=3
 - func[122] size=3
 - func[123] size=3
 - func[124] size=3
 - func[125] size=31 <opa_strlen>
 - func[126] size=76 <opa_strncmp>
 - func[127] size=14 <opa_isdigit>
 - func[128] size=48 <opa_isspace>
 - func[129] size=32 <opa_ishex>
 - func[130] size=212 <opa_itoa>
 - func[131] size=138 <opa_atoi64>
 - func[132] size=578 <opa_atof64>
 - func[133] size=3
 - func[134] size=3
 - func[135] size=3
 - func[136] size=3
 - func[137] size=3
 - func[138] size=3
 - func[139] size=3
 - func[140] size=3
 - func[141] size=3
 - func[142] size=3
 - func[143] size=3
 - func[144] size=3
 - func[145] size=3
 - func[146] size=3
 - func[147] size=3
 - func[148] size=3
 - func[149] size=3
 - func[150] size=3
 - func[151] size=3
 - func[152] size=3
 - func[153] size=3
 - func[154] size=3
 - func[155] size=3
 - func[156] size=3
 - func[157] size=3
 - func[158] size=3
 - func[159] size=3
 - func[160] size=13 <opa_unicode_surrogate>
 - func[161] size=189 <opa_unicode_decode_unit>
 - func[162] size=53 <opa_unicode_decode_surrogate>
 - func[163] size=782 <opa_unicode_decode_utf8>
 - func[164] size=189 <opa_unicode_encode_utf8>
 - func[165] size=3
 - func[166] size=3
 - func[167] size=3
 - func[168] size=3
 - func[169] size=41 <opa_value_type>
 - func[170] size=441 <opa_value_hash>
 - func[171] size=536 <opa_value_compare>
 - func[172] size=77 <opa_object_get>
 - func[173] size=3
 - func[174] size=3
 - func[175] size=359 <opa_value_get>
 - func[176] size=370 <opa_value_compare_number>
 - func[177] size=579 <opa_value_compare_object>
 - func[178] size=1039 <opa_value_compare_set>
 - func[179] size=284 <opa_number_hash>
 - func[180] size=674 <opa_value_iter>
 - func[181] size=61 <opa_value_length>
 - func[182] size=448 <opa_object_keys>
 - func[183] size=221 <opa_array_append>
 - func[184] size=471 <opa_value_free>
 - func[185] size=3
 - func[186] size=263 <opa_object_insert>
 - func[187] size=403 <__opa_object_grow>
 - func[188] size=13 <opa_boolean>
 - func[189] size=3
 - func[190] size=3
 - func[191] size=29 <opa_number_int>
 - func[192] size=3
 - func[193] size=3
 - func[194] size=3
 - func[195] size=249 <opa_set_add>
 - func[196] size=403 <__opa_set_grow>
 - func[197] size=3
 - func[198] size=3
 - func[199] size=3
 - func[200] size=21 <opa_null>
 - func[201] size=3
 - func[202] size=43 <opa_number_ref_allocated>
 - func[203] size=17 <opa_number_init_int>
 - func[204] size=45 <opa_string_terminated>
 - func[205] size=36 <opa_string_allocated>
 - func[206] size=35 <opa_array>
 - func[207] size=3
 - func[208] size=120 <opa_object>
 - func[209] size=120 <opa_set>
 - func[210] size=3
 - func[211] size=3
 - func[212] size=3
 - func[213] size=468 <opa_value_add_path>
 - func[214] size=398 <opa_value_remove_path>
 - func[215] size=3
 - func[216] size=35 <opa_mapping_init>
 - func[217] size=3
 - func[218] size=3
 - func[219] size=3
 - func[220] size=3
 - func[221] size=3
 - func[222] size=3
 - func[223] size=3
 - func[224] size=3
 - func[225] size=3
 - func[226] size=3
 - func[227] size=3
 - func[228] size=3
 - func[229] size=3
 - func[230] size=3
 - func[231] size=3
 - func[232] size=3
 - func[233] size=3
 - func[234] size=3
 - func[235] size=3
 - func[236] size=3
 - func[237] size=3
 - func[238] size=3
 - func[239] size=3
 - func[240] size=3
 - func[241] size=3
 - func[242] size=3
 - func[243] size=3
 - func[244] size=3
 - func[245] size=3
 - func[246] size=3
 - func[247] size=3
 - func[248] size=3
 - func[249] size=3
 - func[250] size=14 <isalpha>
 - func[251] size=11 <isupper>
 - func[252] size=48 <isspace>
 - func[253] size=3
 - func[254] size=57 <snprintf_>
 - func[255] size=3350 <_vsnprintf>
 - func[256] size=22 <_out_buffer>
 - func[257] size=2 <_out_null>
 - func[258] size=735 <_ntoa_format>
 - func[259] size=1901 <_ftoa>
 - func[260] size=1083 <_etoa>
 - func[261] size=16 <fprintf>
 - func[262] size=16 <fwrite>
 - func[263] size=16 <fputc>
 - func[264] size=19 <abort>
 - func[265] size=10 <malloc>
 - func[266] size=10 <free>
 - func[267] size=20 <calloc>
 - func[268] size=12 <realloc>
 - func[269] size=503 <strtol>
 - func[270] size=3
 - func[271] size=3
 - func[272] size=54 <memcpy>
 - func[273] size=3
 - func[274] size=44 <memset>
 - func[275] size=3
 - func[276] size=3
 - func[277] size=3
 - func[278] size=3
 - func[279] size=108 <_mpd_baseincr>
 - func[280] size=3
 - func[281] size=3
 - func[282] size=3
 - func[283] size=3
 - func[284] size=3
 - func[285] size=3
 - func[286] size=1138 <_mpd_baseshiftl>
 - func[287] size=1558 <_mpd_baseshiftr>
 - func[288] size=3
 - func[289] size=60 <mpd_defaultcontext>
 - func[290] size=60 <mpd_maxcontext>
 - func[291] size=3
 - func[292] size=3
 - func[293] size=3
 - func[294] size=1078 <fnt_dif2>
 - func[295] size=128 <std_fnt>
 - func[296] size=128 <std_inv_fnt>
 - func[297] size=851 <four_step_fnt>
 - func[298] size=819 <inv_four_step_fnt>
 - func[299] size=2009 <mpd_qset_string>
 - func[300] size=3
 - func[301] size=3
 - func[302] size=3
 - func[303] size=3
 - func[304] size=48 <mpd_calloc>
 - func[305] size=63 <mpd_realloc>
 - func[306] size=65 <mpd_sh_alloc>
 - func[307] size=164 <mpd_qnew>
 - func[308] size=190 <mpd_switch_to_dyn>
 - func[309] size=147 <mpd_realloc_dyn>
 - func[310] size=3
 - func[311] size=3
 - func[312] size=3
 - func[313] size=3
 - func[314] size=3
 - func[315] size=3
 - func[316] size=3
 - func[317] size=3
 - func[318] size=3
 - func[319] size=26 <mpd_uint_zero>
 - func[320] size=75 <mpd_del>
 - func[321] size=190 <mpd_qresize>
 - func[322] size=245 <mpd_setdigits>
 - func[323] size=19 <mpd_set_qnan>
 - func[324] size=15 <mpd_set_negative>
 - func[325] size=16 <mpd_set_positive>
 - func[326] size=15 <mpd_set_dynamic_data>
 - func[327] size=19 <mpd_set_flags>
 - func[328] size=365 <mpd_qmaxcoeff>
 - func[329] size=3
 - func[330] size=220 <mpd_setspecial>
 - func[331] size=230 <mpd_seterror>
 - func[332] size=585 <mpd_qsset_ssize>
 - func[333] size=715 <mpd_qfinalize>
 - func[334] size=871 <_mpd_fix_nan>
 - func[335] size=1883 <_mpd_check_exp>
 - func[336] size=610 <mpd_qshiftr_inplace>
 - func[337] size=3
 - func[338] size=193 <mpd_qset_i32>
 - func[339] size=3
 - func[340] size=646 <_mpd_get_rnd>
 - func[341] size=3
 - func[342] size=284 <mpd_qcopy>
 - func[343] size=443 <mpd_qshiftl>
 - func[344] size=674 <_mpd_apply_round_excess>
 - func[345] size=85 <mpd_qcmp>
 - func[346] size=563 <_mpd_cmp>
 - func[347] size=1287 <_mpd_basecmp>
 - func[348] size=3
 - func[349] size=3
 - func[350] size=3
 - func[351] size=3
 - func[352] size=3
 - func[353] size=3
 - func[354] size=3
 - func[355] size=3
 - func[356] size=3
 - func[357] size=3
 - func[358] size=3
 - func[359] size=3
 - func[360] size=3
 - func[361] size=3
 - func[362] size=3
 - func[363] size=3
 - func[364] size=3
 - func[365] size=3
 - func[366] size=3
 - func[367] size=3
 - func[368] size=3
 - func[369] size=3
 - func[370] size=3
 - func[371] size=3
 - func[372] size=3
 - func[373] size=3
 - func[374] size=3
 - func[375] size=3
 - func[376] size=3
 - func[377] size=3
 - func[378] size=3
 - func[379] size=3
 - func[380] size=3
 - func[381] size=226 <_mpd_getkernel>
 - func[382] size=418 <_mpd_init_fnt_params>
 - func[383] size=258 <_mpd_init_w3table>
 - func[384] size=726 <six_step_fnt>
 - func[385] size=732 <inv_six_step_fnt>
 - func[386] size=587 <transpose_pow2>
 - func[387] size=770 <squaretrans_pow2>
 - func[388] size=848 <swap_halfrows_pow2>
 - func[389] size=3
 - func[390] size=3
 - func[391] size=3
 - func[392] size=3
 - func[393] size=3
 - func[394] size=3
 - func[395] size=3
 - func[396] size=3
 - func[397] size=3
 - func[398] size=3
 - func[399] size=3
 - func[400] size=3
 - func[401] size=3
 - func[402] size=3
 - func[403] size=3
 - func[404] size=3
 - func[405] size=3
 - func[406] size=3
 - func[407] size=3
 - func[408] size=3
 - func[409] size=3
 - func[410] size=3
 - func[411] size=3
 - func[412] size=3
 - func[413] size=3
 - func[414] size=3
 - func[415] size=3
 - func[416] size=3
 - func[417] size=3
 - func[418] size=3
 - func[419] size=3
 - func[420] size=3
 - func[421] size=3
 - func[422] size=3
 - func[423] size=3
 - func[424] size=3
 - func[425] size=3
 - func[426] size=3
 - func[427] size=3
 - func[428] size=3
 - func[429] size=3
 - func[430] size=3
 - func[431] size=3
 - func[432] size=3
 - func[433] size=3
 - func[434] size=3
 - func[435] size=3
 - func[436] size=3
 - func[437] size=3
 - func[438] size=3
 - func[439] size=3
 - func[440] size=3
 - func[441] size=3
 - func[442] size=3
 - func[443] size=3
 - func[444] size=3
 - func[445] size=3
 - func[446] size=3
 - func[447] size=3
 - func[448] size=3
 - func[449] size=3
 - func[450] size=3
 - func[451] size=3
 - func[452] size=3
 - func[453] size=3
 - func[454] size=3
 - func[455] size=3
 - func[456] size=3
 - func[457] size=3
 - func[458] size=3
 - func[459] size=3
 - func[460] size=3
 - func[461] size=3
 - func[462] size=3
 - func[463] size=3
 - func[464] size=3
 - func[465] size=3
 - func[466] size=3
 - func[467] size=3
 - func[468] size=3
 - func[469] size=3
 - func[470] size=3
 - func[471] size=3
 - func[472] size=3
 - func[473] size=3
 - func[474] size=3
 - func[475] size=3
 - func[476] size=3
 - func[477] size=3
 - func[478] size=3
 - func[479] size=3
 - func[480] size=3
 - func[481] size=3
 - func[482] size=3
 - func[483] size=3
 - func[484] size=3
 - func[485] size=3
 - func[486] size=3
 - func[487] size=3
 - func[488] size=3
 - func[489] size=3
 - func[490] size=3
 - func[491] size=3
 - func[492] size=3
 - func[493] size=3
 - func[494] size=3
 - func[495] size=3
 - func[496] size=3
 - func[497] size=3
 - func[498] size=3
 - func[499] size=3
 - func[500] size=3
 - func[501] size=3
 - func[502] size=3
 - func[503] size=3
 - func[504] size=3
 - func[505] size=3
 - func[506] size=3
 - func[507] size=3
 - func[508] size=3
 - func[509] size=3
 - func[510] size=3
 - func[511] size=3
 - func[512] size=3
 - func[513] size=3
 - func[514] size=3
 - func[515] size=3
 - func[516] size=3
 - func[517] size=3
 - func[518] size=3
 - func[519] size=3
 - func[520] size=3
 - func[521] size=3
 - func[522] size=3
 - func[523] size=3
 - func[524] size=3
 - func[525] size=3
 - func[526] size=3
 - func[527] size=3
 - func[528] size=3
 - func[529] size=3
 - func[530] size=3
 - func[531] size=3
 - func[532] size=3
 - func[533] size=3
 - func[534] size=3
 - func[535] size=3
 - func[536] size=3
 - func[537] size=3
 - func[538] size=3
 - func[539] size=3
 - func[540] size=3
 - func[541] size=3
 - func[542] size=3
 - func[543] size=3
 - func[544] size=3
 - func[545] size=3
 - func[546] size=3
 - func[547] size=3
 - func[548] size=3
 - func[549] size=3
 - func[550] size=3
 - func[551] size=3
 - func[552] size=3
 - func[553] size=3
 - func[554] size=3
 - func[555] size=3
 - func[556] size=3
 - func[557] size=3
 - func[558] size=3
 - func[559] size=3
 - func[560] size=3
 - func[561] size=3
 - func[562] size=3
 - func[563] size=3
 - func[564] size=3
 - func[565] size=3
 - func[566] size=3
 - func[567] size=3
 - func[568] size=3
 - func[569] size=3
 - func[570] size=3
 - func[571] size=3
 - func[572] size=3
 - func[573] size=3
 - func[574] size=3
 - func[575] size=3
 - func[576] size=3
 - func[577] size=3
 - func[578] size=3
 - func[579] size=3
 - func[580] size=3
 - func[581] size=3
 - func[582] size=3
 - func[583] size=3
 - func[584] size=3
 - func[585] size=3
 - func[586] size=3
 - func[587] size=3
 - func[588] size=3
 - func[589] size=3
 - func[590] size=3
 - func[591] size=3
 - func[592] size=3
 - func[593] size=3
 - func[594] size=3
 - func[595] size=3
 - func[596] size=3
 - func[597] size=3
 - func[598] size=3
 - func[599] size=3
 - func[600] size=3
 - func[601] size=3
 - func[602] size=3
 - func[603] size=3
 - func[604] size=3
 - func[605] size=3
 - func[606] size=3
 - func[607] size=3
 - func[608] size=3
 - func[609] size=3
 - func[610] size=3
 - func[611] size=3
 - func[612] size=3
 - func[613] size=3
 - func[614] size=3
 - func[615] size=3
 - func[616] size=3
 - func[617] size=3
 - func[618] size=3
 - func[619] size=3
 - func[620] size=3
 - func[621] size=3
 - func[622] size=3
 - func[623] size=3
 - func[624] size=3
 - func[625] size=3
 - func[626] size=3
 - func[627] size=3
 - func[628] size=3
 - func[629] size=3
 - func[630] size=3
 - func[631] size=3
 - func[632] size=3
 - func[633] size=3
 - func[634] size=3
 - func[635] size=3
 - func[636] size=3
 - func[637] size=3
 - func[638] size=3
 - func[639] size=3
 - func[640] size=3
 - func[641] size=3
 - func[642] size=3
 - func[643] size=3
 - func[644] size=3
 - func[645] size=3
 - func[646] size=3
 - func[647] size=3
 - func[648] size=3
 - func[649] size=3
 - func[650] size=3
 - func[651] size=3
 - func[652] size=3
 - func[653] size=3
 - func[654] size=3
 - func[655] size=3
 - func[656] size=3
 - func[657] size=3
 - func[658] size=3
 - func[659] size=3
 - func[660] size=3
 - func[661] size=3
 - func[662] size=3
 - func[663] size=3
 - func[664] size=3
 - func[665] size=3
 - func[666] size=3
 - func[667] size=3
 - func[668] size=3
 - func[669] size=3
 - func[670] size=3
 - func[671] size=3
 - func[672] size=3
 - func[673] size=3
 - func[674] size=3
 - func[675] size=3
 - func[676] size=3
 - func[677] size=84
 - func[678] size=124 <g0.data.test.main>
 - func[679] size=104 <eval>
 - func[680] size=11 <builtins>
 - func[681] size=28 <entrypoints>
 - func[682] size=13 <_initialize>
Data[5]:

Custom:
 - name: "name"
 - func[0] <opa_abort>
 - func[1] <opa_builtin0>
 - func[2] <opa_builtin1>
 - func[3] <opa_builtin2>
 - func[4] <opa_builtin3>
 - func[5] <opa_builtin4>
 - func[35] <opa_eval_ctx_new>
 - func[36] <opa_eval_ctx_set_input>
 - func[37] <opa_eval_ctx_set_data>
 - func[38] <opa_eval_ctx_set_entrypoint>
 - func[39] <opa_eval_ctx_get_result>
 - func[51] <opa_runtime_error>
 - func[53] <opa_json_lex_read_number>
 - func[54] <opa_json_lex_read_string>
 - func[55] <opa_json_lex_read>
 - func[56] <opa_json_parse_string>
 - func[57] <opa_json_parse_token>
 - func[58] <opa_json_parse_set>
 - func[59] <opa_json_parse_object>
 - func[60] <opa_json_parse>
 - func[61] <opa_value_parse>
 - func[62] <opa_json_writer_emit_boolean>
 - func[63] <opa_json_writer_emit_float>
 - func[64] <opa_json_writer_emit_integer>
 - func[65] <opa_json_writer_emit_number>
 - func[66] <opa_json_writer_emit_string>
 - func[67] <opa_json_writer_emit_array_element>
 - func[68] <opa_json_writer_emit_value>
 - func[69] <opa_json_writer_emit_collection>
 - func[70] <opa_json_writer_emit_set_element>
 - func[71] <opa_json_writer_emit_set_literal>
 - func[72] <opa_json_writer_emit_object_element>
 - func[73] <opa_json_writer_write>
 - func[74] <opa_json_dump>
 - func[75] <opa_value_dump>
 - func[76] <opa_heap_ptr_get>
 - func[77] <opa_heap_ptr_set>
 - func[78] <opa_malloc>
 - func[79] <opa_free>
 - func[80] <opa_realloc>
 - func[83] <opa_memoize_init>
 - func[86] <opa_memoize_insert>
 - func[87] <opa_memoize_get>
 - func[88] <opa_mpd_init>
 - func[92] <opa_number_to_bf>
 - func[125] <opa_strlen>
 - func[126] <opa_strncmp>
 - func[127] <opa_isdigit>
 - func[128] <opa_isspace>
 - func[129] <opa_ishex>
 - func[130] <opa_itoa>
 - func[131] <opa_atoi64>
 - func[132] <opa_atof64>
 - func[160] <opa_unicode_surrogate>
 - func[161] <opa_unicode_decode_unit>
 - func[162] <opa_unicode_decode_surrogate>
 - func[163] <opa_unicode_decode_utf8>
 - func[164] <opa_unicode_encode_utf8>
 - func[169] <opa_value_type>
 - func[170] <opa_value_hash>
 - func[171] <opa_value_compare>
 - func[172] <opa_object_get>
 - func[175] <opa_value_get>
 - func[176] <opa_value_compare_number>
 - func[177] <opa_value_compare_object>
 - func[178] <opa_value_compare_set>
 - func[179] <opa_number_hash>
 - func[180] <opa_value_iter>
 - func[181] <opa_value_length>
 - func[182] <opa_object_keys>
 - func[183] <opa_array_append>
 - func[184] <opa_value_free>
 - func[186] <opa_object_insert>
 - func[187] <__opa_object_grow>
 - func[188] <opa_boolean>
 - func[191] <opa_number_int>
 - func[195] <opa_set_add>
 - func[196] <__opa_set_grow>
 - func[200] <opa_null>
 - func[202] <opa_number_ref_allocated>
 - func[203] <opa_number_init_int>
 - func[204] <opa_string_terminated>
 - func[205] <opa_string_allocated>
 - func[206] <opa_array>
 - func[208] <opa_object>
 - func[209] <opa_set>
 - func[213] <opa_value_add_path>
 - func[214] <opa_value_remove_path>
 - func[216] <opa_mapping_init>
 - func[250] <isalpha>
 - func[251] <isupper>
 - func[252] <isspace>
 - func[254] <snprintf_>
 - func[255] <_vsnprintf>
 - func[256] <_out_buffer>
 - func[257] <_out_null>
 - func[258] <_ntoa_format>
 - func[259] <_ftoa>
 - func[260] <_etoa>
 - func[261] <fprintf>
 - func[262] <fwrite>
 - func[263] <fputc>
 - func[264] <abort>
 - func[265] <malloc>
 - func[266] <free>
 - func[267] <calloc>
 - func[268] <realloc>
 - func[269] <strtol>
 - func[272] <memcpy>
 - func[274] <memset>
 - func[279] <_mpd_baseincr>
 - func[286] <_mpd_baseshiftl>
 - func[287] <_mpd_baseshiftr>
 - func[289] <mpd_defaultcontext>
 - func[290] <mpd_maxcontext>
 - func[294] <fnt_dif2>
 - func[295] <std_fnt>
 - func[296] <std_inv_fnt>
 - func[297] <four_step_fnt>
 - func[298] <inv_four_step_fnt>
 - func[299] <mpd_qset_string>
 - func[304] <mpd_calloc>
 - func[305] <mpd_realloc>
 - func[306] <mpd_sh_alloc>
 - func[307] <mpd_qnew>
 - func[308] <mpd_switch_to_dyn>
 - func[309] <mpd_realloc_dyn>
 - func[319] <mpd_uint_zero>
 - func[320] <mpd_del>
 - func[321] <mpd_qresize>
 - func[322] <mpd_setdigits>
 - func[323] <mpd_set_qnan>
 - func[324] <mpd_set_negative>
 - func[325] <mpd_set_positive>
 - func[326] <mpd_set_dynamic_data>
 - func[327] <mpd_set_flags>
 - func[328] <mpd_qmaxcoeff>
 - func[330] <mpd_setspecial>
 - func[331] <mpd_seterror>
 - func[332] <mpd_qsset_ssize>
 - func[333] <mpd_qfinalize>
 - func[334] <_mpd_fix_nan>
 - func[335] <_mpd_check_exp>
 - func[336] <mpd_qshiftr_inplace>
 - func[338] <mpd_qset_i32>
 - func[340] <_mpd_get_rnd>
 - func[342] <mpd_qcopy>
 - func[343] <mpd_qshiftl>
 - func[344] <_mpd_apply_round_excess>
 - func[345] <mpd_qcmp>
 - func[346] <_mpd_cmp>
 - func[347] <_mpd_basecmp>
 - func[381] <_mpd_getkernel>
 - func[382] <_mpd_init_fnt_params>
 - func[383] <_mpd_init_w3table>
 - func[384] <six_step_fnt>
 - func[385] <inv_six_step_fnt>
 - func[386] <transpose_pow2>
 - func[387] <squaretrans_pow2>
 - func[388] <swap_halfrows_pow2>
 - func[678] <g0.data.test.main>
 - func[679] <eval>
 - func[680] <builtins>
 - func[681] <entrypoints>
 - func[682] <_initialize>
Custom:
 - name: "producers"
```
</details>