### PR TITLE
Fix crash in v0.27.0 when s3_signing is configured

### DIFF
--- a/plugins/rest/rest_auth.go
+++ b/plugins/rest/rest_auth.go
@@ -466,6 +466,9 @@ func (ap *awsSigningAuthPlugin) NewClient(c Config) (*http.Client, error) {
 		}
 	}
 
+	if ap.logger == nil {
+		ap.logger = c.logger
+	}
 	if ap.AWSService == "" {
 		ap.AWSService = awsSigv4SigningDefaultService
 	}


### PR DESCRIPTION
This was caused by new logger not getting properly initialized in NewClient
call.

Fixes #3255

Signed-off-by: Anders Eknert <anders@eknert.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
