### PR TITLE
tests: fix failing test on 32-bit arch

### DIFF
--- a/topdown/tokens_test.go
+++ b/topdown/tokens_test.go
@@ -113,7 +113,7 @@ OHoCIHmNX37JOqTcTzGn2u9+c8NlnvZ0uDvsd1BmKPaUmjmm
 	})
 	t.Run("Time", func(t *testing.T) {
 		now := time.Now()
-		wallclock := ast.UIntNumberTerm(uint64(now.UnixNano()))
+		wallclock := ast.NumberTerm(int64ToJSONNumber(now.UnixNano()))
 
 		t.Run("if provided, is parsed properly", func(t *testing.T) {
 			c := ast.NewObject()

--- a/topdown/tokens_test.go
+++ b/topdown/tokens_test.go
@@ -113,7 +113,7 @@ OHoCIHmNX37JOqTcTzGn2u9+c8NlnvZ0uDvsd1BmKPaUmjmm
 	})
 	t.Run("Time", func(t *testing.T) {
 		now := time.Now()
-		wallclock := ast.IntNumberTerm(int(now.UnixNano()))
+		wallclock := ast.UIntNumberTerm(uint64(now.UnixNano()))
 
 		t.Run("if provided, is parsed properly", func(t *testing.T) {
 			c := ast.NewObject()


### PR DESCRIPTION
Tests were failing on 32-bit arch due to an integer overflow.

```
GOARCH=386 go test ./topdown 
--- FAIL: TestParseTokenConstraints (0.00s)
    --- FAIL: TestParseTokenConstraints/Time (0.00s)
        --- FAIL: TestParseTokenConstraints/Time/if_provided,_is_parsed_properly (0.00s)
            tokens_test.go:123: parseTokenConstraints: token time constraint: must not be negative
        --- FAIL: TestParseTokenConstraints/Time/unset,_defaults_to_wallclock (0.00s)
            tokens_test.go:134: parseTokenConstraints: token time constraint: must not be negative
FAIL
FAIL    github.com/open-policy-agent/opa/topdown        5.510s
FAIL
```

The unix nano time (`int64`) was converted to an `int`, which caused an overflow on 32-bit architectures.