### PR TITLE
Allow configuring logger + its fields in library usage

### DIFF
--- a/plugins/plugins_test.go
+++ b/plugins/plugins_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/open-policy-agent/opa/internal/storage/mock"
 	"github.com/open-policy-agent/opa/plugins/rest"
+	"github.com/open-policy-agent/opa/sdk"
 	"github.com/open-policy-agent/opa/storage/inmem"
 	"github.com/open-policy-agent/opa/topdown/cache"
 )
@@ -290,6 +291,20 @@ func TestPluginManagerAuthPlugin(t *testing.T) {
 		return
 	default:
 		t.Fatal("expected HTTPAuthPlugin to be myAuthPluginMock")
+	}
+}
+
+func TestPluginManagerLogger(t *testing.T) {
+
+	logger := sdk.NewStandardLogger().WithFields(map[string]interface{}{"context": "myloggincontext"})
+
+	m, err := New([]byte(`{}`), "test", inmem.New(), Logger(logger))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if m.Logger() != logger {
+		t.Fatal("Logger was not configured on plugin manager")
 	}
 }
 

--- a/plugins/rest/rest.go
+++ b/plugins/rest/rest.go
@@ -57,7 +57,9 @@ type Config struct {
 
 // Equal returns true if this client config is equal to the other.
 func (c *Config) Equal(other *Config) bool {
-	return reflect.DeepEqual(c, other)
+	otherWithoutLogger := *other
+	otherWithoutLogger.logger = c.logger
+	return reflect.DeepEqual(c, &otherWithoutLogger)
 }
 
 func (c *Config) authPlugin(authPluginLookup func(string) HTTPAuthPlugin) (HTTPAuthPlugin, error) {

--- a/sdk/logging.go
+++ b/sdk/logging.go
@@ -48,7 +48,13 @@ func NewStandardLogger() *StandardLogger {
 // WithFields provides additional fields to include in log output
 func (l *StandardLogger) WithFields(fields map[string]interface{}) Logger {
 	cp := *l
-	cp.fields = fields
+	cp.fields = make(map[string]interface{})
+	for k, v := range l.fields {
+		cp.fields[k] = v
+	}
+	for k, v := range fields {
+		cp.fields[k] = v
+	}
 	return &cp
 }
 

--- a/sdk/logging_test.go
+++ b/sdk/logging_test.go
@@ -1,0 +1,62 @@
+package sdk
+
+import (
+	"testing"
+)
+
+func TestWithFields(t *testing.T) {
+	logger := NewStandardLogger().WithFields(map[string]interface{}{"context": "contextvalue"})
+
+	var fieldvalue interface{}
+	var ok bool
+
+	if fieldvalue, ok = logger.(*StandardLogger).fields["context"]; !ok {
+		t.Fatal("Logger did not contain configured field")
+	}
+
+	if fieldvalue.(string) != "contextvalue" {
+		t.Fatal("Logger did not contain configured field value")
+	}
+}
+
+func TestWithFieldsOverrides(t *testing.T) {
+	logger := NewStandardLogger().
+		WithFields(map[string]interface{}{"context": "contextvalue"}).
+		WithFields(map[string]interface{}{"context": "changedcontextvalue"})
+
+	var fieldvalue interface{}
+	var ok bool
+
+	if fieldvalue, ok = logger.(*StandardLogger).fields["context"]; !ok {
+		t.Fatal("Logger did not contain configured field")
+	}
+
+	if fieldvalue.(string) != "changedcontextvalue" {
+		t.Fatal("Logger did not contain configured field value")
+	}
+}
+
+func TestWithFieldsMerges(t *testing.T) {
+	logger := NewStandardLogger().
+		WithFields(map[string]interface{}{"context": "contextvalue"}).
+		WithFields(map[string]interface{}{"anothercontext": "anothercontextvalue"})
+
+	var fieldvalue interface{}
+	var ok bool
+
+	if fieldvalue, ok = logger.(*StandardLogger).fields["context"]; !ok {
+		t.Fatal("Logger did not contain configured field")
+	}
+
+	if fieldvalue.(string) != "contextvalue" {
+		t.Fatal("Logger did not contain configured field value")
+	}
+
+	if fieldvalue, ok = logger.(*StandardLogger).fields["anothercontext"]; !ok {
+		t.Fatal("Logger did not contain configured field")
+	}
+
+	if fieldvalue.(string) != "anothercontextvalue" {
+		t.Fatal("Logger did not contain configured field value")
+	}
+}


### PR DESCRIPTION
When using OPA as a library in a Golang project that also uses logrus for logging, the log messages generated from OPA might be missing context or are hard to understand for users. 

This PR adds the ability to configure a plugin manager's logger using an option and also changes the `WithFields`method of `sdk.logger` to inherit the fields of the base logger. This allows to pre-define common fields on the log output that get propagated to log messages further down. 
