### PR TITLE
test/e2e: stop running benchmarks that output decision logs in GHA

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,10 @@ test-coverage: generate
 perf: generate
 	$(GO) test $(GO_TAGS),slow $(GO_TEST_TIMEOUT) -run=- -bench=. -benchmem ./...
 
+.PHONY: perf-noisy
+perf-noisy: generate
+	$(GO) test $(GO_TAGS),slow,noisy $(GO_TEST_TIMEOUT) -run=- -bench=. -benchmem ./...
+
 .PHONY: wasm-sdk-e2e-test
 wasm-sdk-e2e-test: generate
 	$(GO) test $(GO_TAGS),slow,wasm_sdk_e2e $(GO_TEST_TIMEOUT) -v ./internal/wasm/sdk/test/e2e

--- a/test/e2e/logs/console/console_decision_logger_benchmark_test.go
+++ b/test/e2e/logs/console/console_decision_logger_benchmark_test.go
@@ -1,6 +1,9 @@
 // Copyright 2020 The OPA Authors.  All rights reserved.
 // Use of this source code is governed by an Apache2
 // license that can be found in the LICENSE file.
+
+// +build noisy
+
 package console
 
 import (

--- a/test/e2e/logs/console/console_decision_logger_test.go
+++ b/test/e2e/logs/console/console_decision_logger_test.go
@@ -11,13 +11,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/open-policy-agent/opa/plugins"
-	"github.com/open-policy-agent/opa/runtime"
-
 	"github.com/sirupsen/logrus"
-
 	"github.com/sirupsen/logrus/hooks/test"
 
+	"github.com/open-policy-agent/opa/plugins"
+	"github.com/open-policy-agent/opa/runtime"
 	"github.com/open-policy-agent/opa/test/e2e"
 )
 

--- a/test/e2e/logs/remote/remote_decision_logger_benchmark_test.go
+++ b/test/e2e/logs/remote/remote_decision_logger_benchmark_test.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by an Apache2
 // license that can be found in the LICENSE file.
 
+// +build noisy
+
 package remote
 
 import (


### PR DESCRIPTION
If you want to run them, use `make perf-noisy`.
