### PR TITLE
compile/wasm: fix capabilities issue with `opa build -t wasm`

### DIFF
--- a/compile/compile.go
+++ b/compile/compile.go
@@ -416,6 +416,10 @@ func (c *Compiler) compileWasm(ctx context.Context) error {
 	compiler := wasm.New()
 	found := false
 	have := compiler.ABIVersion()
+	if c.capabilities.WasmABIVersions == nil { // discern nil from len=0
+		c.debug.Printf("no wasm ABI versions in capabilities, building for %v", have)
+		found = true
+	}
 	for _, v := range c.capabilities.WasmABIVersions {
 		if v.Version == have.Version && v.Minor <= have.Minor {
 			found = true


### PR DESCRIPTION
We now discern:

1. If there's no Wasm ABI version array at all in the capabilities of
   the `opa` binary used to build a Wasm bundle.
2. If the provided capabilities.json contains EMPTY Wasm ABI versions
   array.

(1.) would happen if the binary itself has no support for running the
Wasm module, i.e. it was built without the `opa_wasm` go tag. Anyways,
such a binary is perfactly capable of emitting wasm code, so that's
what we'll allow it to do (with this change).

(2.) still gives you the option to disable building wasm bundles via
capabilities.json, but it's an edge case: usually, you'd use it to
control the ABI versions you're building for. If you want, however,
you can still say "none" by providing an empty array.

----
Fixes #3270.