### PR TITLE
topdown: fix http.send flaky tests

### DIFF
--- a/topdown/http_test.go
+++ b/topdown/http_test.go
@@ -978,6 +978,9 @@ func TestHTTPSendInterQueryCaching(t *testing.T) {
 
 	data := loadSmallTestData()
 
+	t0 := time.Now()
+	opts := setTime(t0)
+
 	for _, tc := range tests {
 		t.Run(tc.note, func(t *testing.T) {
 
@@ -989,6 +992,8 @@ func TestHTTPSendInterQueryCaching(t *testing.T) {
 				for k, v := range tc.headers {
 					headers[k] = v
 				}
+
+				headers.Set("Date", t0.Format(time.RFC1123))
 
 				etag := w.Header().Get("etag")
 				lm := w.Header().Get("last-modified")
@@ -1008,7 +1013,7 @@ func TestHTTPSendInterQueryCaching(t *testing.T) {
 			}))
 			defer ts.Close()
 
-			runTopDownTestCase(t, data, tc.note, []string{strings.ReplaceAll(tc.ruleTemplate, "%URL%", ts.URL)}, tc.response)
+			runTopDownTestCase(t, data, tc.note, []string{strings.ReplaceAll(tc.ruleTemplate, "%URL%", ts.URL)}, tc.response, opts)
 
 			// Note: The runTopDownTestCase ends up evaluating twice (once with and once without partial
 			// eval first), so expect 2x the total request count the test case specified.
@@ -1095,6 +1100,9 @@ func TestHTTPSendInterQueryForceCaching(t *testing.T) {
 
 	data := loadSmallTestData()
 
+	t0 := time.Now()
+	opts := setTime(t0)
+
 	for _, tc := range tests {
 		t.Run(tc.note, func(t *testing.T) {
 
@@ -1107,12 +1115,14 @@ func TestHTTPSendInterQueryForceCaching(t *testing.T) {
 					headers[k] = v
 				}
 
+				headers.Set("Date", t0.Format(time.RFC1123))
+
 				w.WriteHeader(http.StatusOK)
 				w.Write([]byte(tc.response))
 			}))
 			defer ts.Close()
 
-			runTopDownTestCase(t, data, tc.note, []string{strings.ReplaceAll(tc.ruleTemplate, "%URL%", ts.URL)}, tc.response)
+			runTopDownTestCase(t, data, tc.note, []string{strings.ReplaceAll(tc.ruleTemplate, "%URL%", ts.URL)}, tc.response, opts)
 
 			// Note: The runTopDownTestCase ends up evaluating twice (once with and once without partial
 			// eval first), so expect 2x the total request count the test case specified.
@@ -1162,6 +1172,9 @@ func TestHTTPSendInterQueryCachingModifiedResp(t *testing.T) {
 
 	data := loadSmallTestData()
 
+	t0 := time.Now()
+	opts := setTime(t0)
+
 	for _, tc := range tests {
 		t.Run(tc.note, func(t *testing.T) {
 
@@ -1173,6 +1186,8 @@ func TestHTTPSendInterQueryCachingModifiedResp(t *testing.T) {
 				for k, v := range tc.headers {
 					headers[k] = v
 				}
+
+				headers.Set("Date", t0.Format(time.RFC1123))
 
 				etag := w.Header().Get("etag")
 
@@ -1190,7 +1205,7 @@ func TestHTTPSendInterQueryCachingModifiedResp(t *testing.T) {
 			}))
 			defer ts.Close()
 
-			runTopDownTestCase(t, data, tc.note, []string{strings.ReplaceAll(tc.ruleTemplate, "%URL%", ts.URL)}, tc.response)
+			runTopDownTestCase(t, data, tc.note, []string{strings.ReplaceAll(tc.ruleTemplate, "%URL%", ts.URL)}, tc.response, opts)
 
 			// Note: The runTopDownTestCase ends up evaluating twice (once with and once without partial
 			// eval first), so expect 2x the total request count the test case specified.
@@ -1227,6 +1242,9 @@ func TestHTTPSendInterQueryCachingNewResp(t *testing.T) {
 
 	data := loadSmallTestData()
 
+	t0 := time.Now()
+	opts := setTime(t0)
+
 	for _, tc := range tests {
 		t.Run(tc.note, func(t *testing.T) {
 
@@ -1238,6 +1256,8 @@ func TestHTTPSendInterQueryCachingNewResp(t *testing.T) {
 				for k, v := range tc.headers {
 					headers[k] = v
 				}
+
+				headers.Set("Date", t0.Format(time.RFC1123))
 
 				etag := w.Header().Get("etag")
 
@@ -1251,7 +1271,7 @@ func TestHTTPSendInterQueryCachingNewResp(t *testing.T) {
 			}))
 			defer ts.Close()
 
-			runTopDownTestCase(t, data, tc.note, []string{strings.ReplaceAll(tc.ruleTemplate, "%URL%", ts.URL)}, tc.response)
+			runTopDownTestCase(t, data, tc.note, []string{strings.ReplaceAll(tc.ruleTemplate, "%URL%", ts.URL)}, tc.response, opts)
 
 			// Note: The runTopDownTestCase ends up evaluating twice (once with and once without partial
 			// eval first), so expect 2x the total request count the test case specified.


### PR DESCRIPTION
One of the steps to determine if a cached response is
fresh or not is to compute the difference between the wall clock
time set on the builtin context and the value of the Date
response header.

If the Date response header is not explicitly set, the
Go test server sets it to time.Now(). The test runner
also sets the time on the query that runs the test to
the current time (ie. time.Now()).

Ideally the time at which OPA checks if a cached response is
fresh or not should be greater than response orignation time
(ie. Date header value) set by the server. But the manner in
which the tests are setup this is not the case resulting in
incorrectly marking a fresh cached response as stale and thereby
causing test failures. This change updates the test runner such
that the time on the topdown.Query can be explicitly set and
also modifies the inter-query cache related test cases to
contain the response date header set to the same value as the query time.

Signed-off-by: Ashutosh Narkar <anarkar4387@gmail.com>
Co-authored-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
