### PR TITLE
config: Add API to expose OPA's active config

### DIFF
--- a/docs/content/rest-api.md
+++ b/docs/content/rest-api.md
@@ -1828,3 +1828,67 @@ Content-Type: application/json
 ```json
 {}
 ```
+
+##  Config API
+
+The `/config` API endpoint returns OPA's active configuration. When the discovery feature is enabled, this API can be
+used to fetch the discovered configuration in the last evaluated discovery bundle. The `credentials` field in the
+[Services](../configuration#services) configuration and the `private_key` and `key` fields in the [Keys](../configuration#keys)
+configuration will be omitted from the API response.
+
+### Get Config
+
+```
+GET /v1/config HTTP/1.1
+```
+
+#### Query Parameters
+
+- **pretty** - If parameter is `true`, response will formatted for humans.
+
+#### Status Codes
+
+- **200** - no error
+- **500** - server error
+
+#### Example Request
+```http
+GET /v1/config HTTP/1.1
+```
+
+#### Example Response
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+```
+```json
+{
+  "services": {
+    "acmecorp": {
+      "url": "https://example.com/control-plane-api/v1"
+    }
+  },
+  "labels": {
+    "id": "test-id",
+    "version": "0.27.0"
+  },
+  "keys": {
+    "global_key": {
+      "scope": "read"
+    }
+  },
+  "decision_logs": {
+    "service": "acmecorp"
+  },
+  "status": {
+    "service": "acmecorp"
+  },
+  "bundles": {
+    "authz": {
+      "service": "acmecorp"
+    }
+  },
+  "default_authorization_decision": "/system/authz/allow",
+  "default_decision": "/system/main"
+}
+```

--- a/server/server.go
+++ b/server/server.go
@@ -76,6 +76,7 @@ const (
 	PromHandlerV1Query    = "v1/query"
 	PromHandlerV1Policies = "v1/policies"
 	PromHandlerV1Compile  = "v1/compile"
+	PromHandlerV1Config   = "v1/config"
 	PromHandlerIndex      = "index"
 	PromHandlerCatch      = "catchall"
 	PromHandlerHealth     = "health"
@@ -612,6 +613,7 @@ func (s *Server) initRouters() {
 	s.registerHandler(mainRouter, 1, "/query", http.MethodGet, s.instrumentHandler(s.v1QueryGet, PromHandlerV1Query))
 	s.registerHandler(mainRouter, 1, "/query", http.MethodPost, s.instrumentHandler(s.v1QueryPost, PromHandlerV1Query))
 	s.registerHandler(mainRouter, 1, "/compile", http.MethodPost, s.instrumentHandler(s.v1CompilePost, PromHandlerV1Compile))
+	s.registerHandler(mainRouter, 1, "/config", http.MethodGet, s.instrumentHandler(s.v1ConfigGet, PromHandlerV1Config))
 	mainRouter.Handle("/", s.instrumentHandler(s.unversionedPost, PromHandlerIndex)).Methods(http.MethodPost)
 	mainRouter.Handle("/", s.instrumentHandler(s.indexGet, PromHandlerIndex)).Methods(http.MethodGet)
 
@@ -2002,6 +2004,17 @@ func (s *Server) v1QueryPost(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writer.JSON(w, 200, results, pretty)
+}
+
+func (s *Server) v1ConfigGet(w http.ResponseWriter, r *http.Request) {
+	pretty := getBoolParam(r.URL, types.ParamPrettyV1, true)
+	result, err := s.manager.Config.ActiveConfig()
+	if err != nil {
+		writer.ErrorAuto(w, err)
+		return
+	}
+
+	writer.JSON(w, 200, result, pretty)
 }
 
 func (s *Server) checkPolicyIDScope(ctx context.Context, txn storage.Transaction, id string) error {


### PR DESCRIPTION
This commit adds a new API endpoint to fetch OPA's
active configuration. When the discovery feature is enabled,
this API can be used to fetch the discovered configuration
in the last evaluated discovery bundle.

Fixes: #2020

Signed-off-by: Ashutosh Narkar <anarkar4387@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
