### PR TITLE
topdown: Let units.parse_bytes support float values

### DIFF
--- a/topdown/parse_bytes.go
+++ b/topdown/parse_bytes.go
@@ -15,15 +15,15 @@ import (
 )
 
 const (
-	none int64 = 1
-	kb         = 1000
-	ki         = 1024
-	mb         = kb * 1000
-	mi         = ki * 1024
-	gb         = mb * 1000
-	gi         = mi * 1024
-	tb         = gb * 1000
-	ti         = gi * 1024
+	none float64 = 1
+	kb           = 1000
+	ki           = 1024
+	mb           = kb * 1000
+	mi           = ki * 1024
+	gb           = mb * 1000
+	gi           = mi * 1024
+	tb           = gb * 1000
+	ti           = gi * 1024
 )
 
 // The rune values for 0..9 as well as the period symbol (for parsing floats)
@@ -39,12 +39,12 @@ func errUnitNotRecognized(unit string) error {
 
 var (
 	errNoAmount       = parseNumBytesError("no byte amount provided")
-	errIntConv        = parseNumBytesError("could not parse byte amount to integer")
+	errNumConv        = parseNumBytesError("could not parse byte amount to a number")
 	errIncludesSpaces = parseNumBytesError("spaces not allowed in resource strings")
 )
 
 func builtinNumBytes(a ast.Value) (ast.Value, error) {
-	var m int64
+	var m float64
 
 	raw, err := builtins.StringOperand(a, 1)
 	if err != nil {
@@ -86,14 +86,14 @@ func builtinNumBytes(a ast.Value) (ast.Value, error) {
 		return nil, errUnitNotRecognized(unitStr)
 	}
 
-	num, err := strconv.ParseInt(numStr, 10, 64)
+	num, err := strconv.ParseFloat(numStr, 64)
 	if err != nil {
-		return nil, errIntConv
+		return nil, errNumConv
 	}
 
 	total := num * m
 
-	return builtins.IntToNumber(big.NewInt(total)), nil
+	return builtins.IntToNumber(big.NewInt(int64(total))), nil
 }
 
 // Makes the string lower case and removes spaces and quotation marks


### PR DESCRIPTION
Often users will provide amounts for something like memory as a fraction
of the most human-readable unit e.g. 1.5KB rather than 1500B. Allow
parse_bytes to support byte amounts provided this way, rounding down to
the nearest integer when something like 1.1KiB would leave a fractional
byte.

Fixes #3297

NB: I've not changed any docs since they are not specific about previously requiring an integer and I think the current wording is valid for floats too
