### PR TITLE
docs: Update OPA-Envoy plugin config to use path field

### DIFF
--- a/docs/content/envoy-tutorial-standalone-envoy.md
+++ b/docs/content/envoy-tutorial-standalone-envoy.md
@@ -287,7 +287,7 @@ spec:
         - "--addr=localhost:8181"
         - "--diagnostic-addr=0.0.0.0:8282"
         - "--set=plugins.envoy_ext_authz_grpc.addr=:9191"
-        - "--set=plugins.envoy_ext_authz_grpc.query=data.envoy.authz.allow"
+        - "--set=plugins.envoy_ext_authz_grpc.path=envoy/authz/allow"
         - "--set=decision_logs.console=true"
         - "--ignore=.*"
         - "/policy/policy.rego"


### PR DESCRIPTION
This commit removes the deprecated query field of the
OPA-Envoy config in the Envoy tutorial and replaces it
with the path field.

Signed-off-by: Ashutosh Narkar <anarkar4387@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
