### PR TITLE
build: remove run-pigeon.sh

### DIFF
--- a/build/run-pigeon.sh
+++ b/build/run-pigeon.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-GOFLAGS=-mod=vendor GO111MODULE=on GOOS="" GOARCH="" go run ./vendor/github.com/mna/pigeon $@


### PR DESCRIPTION
We don't use this anymore. (`git grep pigeon` yields nothing.)
