### PR TITLE
server: Add wrapper for GET v1/config response

### DIFF
--- a/docs/content/rest-api.md
+++ b/docs/content/rest-api.md
@@ -1863,32 +1863,34 @@ Content-Type: application/json
 ```
 ```json
 {
-  "services": {
-    "acmecorp": {
-      "url": "https://example.com/control-plane-api/v1"
-    }
-  },
-  "labels": {
-    "id": "test-id",
-    "version": "0.27.0"
-  },
-  "keys": {
-    "global_key": {
-      "scope": "read"
-    }
-  },
-  "decision_logs": {
-    "service": "acmecorp"
-  },
-  "status": {
-    "service": "acmecorp"
-  },
-  "bundles": {
-    "authz": {
+  "result": {
+    "services": {
+      "acmecorp": {
+        "url": "https://example.com/control-plane-api/v1"
+      }
+    },
+    "labels": {
+      "id": "test-id",
+      "version": "0.27.0"
+    },
+    "keys": {
+      "global_key": {
+        "scope": "read"
+      }
+    },
+    "decision_logs": {
       "service": "acmecorp"
-    }
-  },
-  "default_authorization_decision": "/system/authz/allow",
-  "default_decision": "/system/main"
+    },
+    "status": {
+      "service": "acmecorp"
+    },
+    "bundles": {
+      "authz": {
+        "service": "acmecorp"
+      }
+    },
+    "default_authorization_decision": "/system/authz/allow",
+    "default_decision": "/system/main"
+  }
 }
 ```

--- a/server/server.go
+++ b/server/server.go
@@ -2014,7 +2014,10 @@ func (s *Server) v1ConfigGet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writer.JSON(w, 200, result, pretty)
+	var resp types.ConfigResponseV1
+	resp.Result = &result
+
+	writer.JSON(w, http.StatusOK, resp, pretty)
 }
 
 func (s *Server) checkPolicyIDScope(ctx context.Context, txn storage.Transaction, id string) error {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1205,13 +1205,15 @@ func TestConfigV1(t *testing.T) {
 
 	f.server.manager.Config = conf
 
-	expected := map[string]interface{}{}
-	expected["labels"] = map[string]interface{}{"id": "foo", "version": version.Version, "region": "west"}
-	expected["keys"] = map[string]interface{}{"global_key": map[string]interface{}{"algorithm": "HS256"}}
-	expected["services"] = map[string]interface{}{"acmecorp": map[string]interface{}{"url": "https://example.com/control-plane-api/v1"}}
-	expected["default_authorization_decision"] = "/system/authz/allow"
-	expected["default_decision"] = "/system/main"
-
+	expected := map[string]interface{}{
+		"result": map[string]interface{}{
+			"labels":                         map[string]interface{}{"id": "foo", "version": version.Version, "region": "west"},
+			"keys":                           map[string]interface{}{"global_key": map[string]interface{}{"algorithm": "HS256"}},
+			"services":                       map[string]interface{}{"acmecorp": map[string]interface{}{"url": "https://example.com/control-plane-api/v1"}},
+			"default_authorization_decision": "/system/authz/allow",
+			"default_decision":               "/system/main",
+		},
+	}
 	bs, err := json.Marshal(expected)
 	if err != nil {
 		t.Fatal(err)

--- a/server/types/types.go
+++ b/server/types/types.go
@@ -373,6 +373,11 @@ type QueryRequestV1 struct {
 	Query string `json:"query"`
 }
 
+// ConfigResponseV1 models the response message for Config API operations.
+type ConfigResponseV1 struct {
+	Result *interface{} `json:"result,omitempty"`
+}
+
 const (
 	// ParamQueryV1 defines the name of the HTTP URL parameter that specifies
 	// values for the request query.


### PR DESCRIPTION
This commit just tweaks the new v1/config response to include a
wrapper that nests the config object under a "result" key in the
response. This makes GET v1/config consistent with other OPA APIs and
future-proofs the API to some extent (e.g., if we need to include
additional fields in the future, they do not necessarily have to be
included in the config object itself.)

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
