### PR TITLE
topdown: Copy package path and save term when namespacing off

### DIFF
--- a/topdown/eval.go
+++ b/topdown/eval.go
@@ -2600,7 +2600,7 @@ func (e *eval) comprehensionIndex(term *ast.Term) *ast.ComprehensionIndex {
 func (e *eval) savePackagePathAndTerm(plugged, ref ast.Ref) (ast.Ref, *ast.Term) {
 
 	if e.skipSaveNamespace {
-		return plugged, ast.NewTerm(ref)
+		return plugged.Copy(), ast.NewTerm(ref.Copy())
 	}
 
 	return plugged.Insert(e.saveNamespace, 1), ast.NewTerm(ref.Insert(e.saveNamespace, 1))


### PR DESCRIPTION
The package path was being mutated after support modules were
created. If a single reference generated multiple support modules,
then the resulting support modules would have the wrong package
path. This only happens when partial namespacing is disabled because
the normal code path implicitly copies the refs when injecting the
namespace into th the package path.

Fixes #3302

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
