### PR TITLE
ci: unflake "go perf"

### DIFF
--- a/internal/wasm/sdk/examples/basic/main.go
+++ b/internal/wasm/sdk/examples/basic/main.go
@@ -92,7 +92,7 @@ func main() {
 
 	// Evaluate the new policy.
 
-	if err := rego.SetPolicy(policy); err != nil {
+	if err := rego.SetPolicy(ctx, policy); err != nil {
 		fmt.Printf("error: %v\n", err)
 		return
 	}

--- a/internal/wasm/sdk/internal/wasm/pool.go
+++ b/internal/wasm/sdk/internal/wasm/pool.go
@@ -153,7 +153,7 @@ func (p *Pool) Release(vm *VM, metrics metrics.Metrics) {
 // are constructed in advance before touching the pool.  Returns
 // either ErrNotReady, ErrInvalidPolicy or ErrInternal if an error
 // occurs.
-func (p *Pool) SetPolicyData(policy []byte, data []byte) error {
+func (p *Pool) SetPolicyData(ctx context.Context, policy []byte, data []byte) error {
 	p.dataMtx.Lock()
 	defer p.dataMtx.Unlock()
 
@@ -196,7 +196,7 @@ func (p *Pool) SetPolicyData(policy []byte, data []byte) error {
 		return nil
 	}
 
-	err := p.setPolicyData(policy, data)
+	err := p.setPolicyData(ctx, policy, data)
 	if err != nil {
 		return fmt.Errorf("%v: %w", err, errors.ErrInternal)
 	}
@@ -207,31 +207,31 @@ func (p *Pool) SetPolicyData(policy []byte, data []byte) error {
 // SetDataPath will update the current data on the VMs by setting the value at the
 // specified path. If an error occurs the instance is still in a valid state, however
 // the data will not have been modified.
-func (p *Pool) SetDataPath(path []string, value interface{}) error {
+func (p *Pool) SetDataPath(ctx context.Context, path []string, value interface{}) error {
 	p.dataMtx.Lock()
 	defer p.dataMtx.Unlock()
 	return p.updateVMs(func(vm *VM, opts vmOpts) error {
-		return vm.SetDataPath(path, value)
+		return vm.SetDataPath(ctx, path, value)
 	})
 }
 
 // RemoveDataPath will update the current data on the VMs by removing the value at the
 // specified path. If an error occurs the instance is still in a valid state, however
 // the data will not have been modified.
-func (p *Pool) RemoveDataPath(path []string) error {
+func (p *Pool) RemoveDataPath(ctx context.Context, path []string) error {
 	p.dataMtx.Lock()
 	defer p.dataMtx.Unlock()
 	return p.updateVMs(func(vm *VM, _ vmOpts) error {
-		return vm.RemoveDataPath(path)
+		return vm.RemoveDataPath(ctx, path)
 	})
 }
 
 // setPolicyData reinitializes the VMs one at a time.
-func (p *Pool) setPolicyData(policy []byte, data []byte) error {
+func (p *Pool) setPolicyData(ctx context.Context, policy []byte, data []byte) error {
 	return p.updateVMs(func(vm *VM, opts vmOpts) error {
 		opts.policy = policy
 		opts.data = data
-		return vm.SetPolicyData(opts)
+		return vm.SetPolicyData(ctx, opts)
 	})
 }
 

--- a/internal/wasm/sdk/opa/loader/file/loader.go
+++ b/internal/wasm/sdk/opa/loader/file/loader.go
@@ -38,7 +38,7 @@ type Loader struct {
 
 // policyData captures the functions used in setting the policy and data.
 type policyData interface {
-	SetPolicyData(policy []byte, data *interface{}) error
+	SetPolicyData(ctx context.Context, policy []byte, data *interface{}) error
 }
 
 // New constructs a new file loader periodically reloading the bundle
@@ -143,7 +143,7 @@ func (l *Loader) Load(ctx context.Context) error {
 		data = &v
 	}
 
-	return l.pd.SetPolicyData(b.WasmModules[0].Raw, data)
+	return l.pd.SetPolicyData(ctx, b.WasmModules[0].Raw, data)
 }
 
 // poller periodically downloads the bundle.

--- a/internal/wasm/sdk/opa/loader/file/loader_test.go
+++ b/internal/wasm/sdk/opa/loader/file/loader_test.go
@@ -79,7 +79,7 @@ type testPolicyData struct {
 	updated chan struct{}
 }
 
-func (pd *testPolicyData) SetPolicyData(policy []byte, data *interface{}) error {
+func (pd *testPolicyData) SetPolicyData(_ context.Context, policy []byte, data *interface{}) error {
 	pd.Lock()
 	defer pd.Unlock()
 

--- a/internal/wasm/sdk/opa/loader/http/loader.go
+++ b/internal/wasm/sdk/opa/loader/http/loader.go
@@ -15,9 +15,8 @@ import (
 	"time"
 
 	"github.com/open-policy-agent/opa/bundle"
-	"github.com/open-policy-agent/opa/internal/wasm/sdk/opa/errors"
-
 	"github.com/open-policy-agent/opa/internal/wasm/sdk/opa"
+	"github.com/open-policy-agent/opa/internal/wasm/sdk/opa/errors"
 )
 
 const (
@@ -54,7 +53,7 @@ type Loader struct {
 
 // policyData captures the functions used in setting the policy and data.
 type policyData interface {
-	SetPolicyData(policy []byte, data *interface{}) error
+	SetPolicyData(ctx context.Context, policy []byte, data *interface{}) error
 }
 
 // New constructs a new HTTP loader periodically downloading a bundle
@@ -199,7 +198,7 @@ func (l *Loader) Load(ctx context.Context) error {
 		data = &v
 	}
 
-	return l.pd.SetPolicyData(bundle.WasmModules[0].Raw, data)
+	return l.pd.SetPolicyData(ctx, bundle.WasmModules[0].Raw, data)
 }
 
 // get executes HTTP GET.

--- a/internal/wasm/sdk/opa/loader/http/loader_test.go
+++ b/internal/wasm/sdk/opa/loader/http/loader_test.go
@@ -93,7 +93,7 @@ type testPolicyData struct {
 	updated chan struct{}
 }
 
-func (pd *testPolicyData) SetPolicyData(policy []byte, data *interface{}) error {
+func (pd *testPolicyData) SetPolicyData(_ context.Context, policy []byte, data *interface{}) error {
 	pd.Lock()
 	defer pd.Unlock()
 

--- a/internal/wasm/sdk/opa/opa.go
+++ b/internal/wasm/sdk/opa/opa.go
@@ -58,6 +58,7 @@ func New() *OPA {
 // configuration. If the configuration is invalid, it returns
 // ErrInvalidConfig.
 func (o *OPA) Init() (*OPA, error) {
+	ctx := context.Background()
 	if o.configErr != nil {
 		return nil, o.configErr
 	}
@@ -65,7 +66,7 @@ func (o *OPA) Init() (*OPA, error) {
 	o.pool = wasm.NewPool(o.poolSize, o.memoryMinPages, o.memoryMaxPages)
 
 	if len(o.policy) != 0 {
-		if err := o.pool.SetPolicyData(o.policy, o.data); err != nil {
+		if err := o.pool.SetPolicyData(ctx, o.policy, o.data); err != nil {
 			return nil, err
 		}
 	}
@@ -76,7 +77,7 @@ func (o *OPA) Init() (*OPA, error) {
 // SetData updates the data for the subsequent Eval calls.  Returns
 // either ErrNotReady, ErrInvalidPolicyOrData, or ErrInternal if an
 // error occurs.
-func (o *OPA) SetData(v interface{}) error {
+func (o *OPA) SetData(ctx context.Context, v interface{}) error {
 	if o.pool == nil {
 		return errors.ErrNotReady
 	}
@@ -89,27 +90,27 @@ func (o *OPA) SetData(v interface{}) error {
 	o.mutex.Lock()
 	defer o.mutex.Unlock()
 
-	return o.setPolicyData(o.policy, raw)
+	return o.setPolicyData(ctx, o.policy, raw)
 }
 
 // SetDataPath will update the current data on the VMs by setting the value at the
 // specified path. If an error occurs the instance is still in a valid state, however
 // the data will not have been modified.
-func (o *OPA) SetDataPath(path []string, value interface{}) error {
-	return o.pool.SetDataPath(path, value)
+func (o *OPA) SetDataPath(ctx context.Context, path []string, value interface{}) error {
+	return o.pool.SetDataPath(ctx, path, value)
 }
 
 // RemoveDataPath will update the current data on the VMs by removing the value at the
 // specified path. If an error occurs the instance is still in a valid state, however
 // the data will not have been modified.
-func (o *OPA) RemoveDataPath(path []string) error {
-	return o.pool.RemoveDataPath(path)
+func (o *OPA) RemoveDataPath(ctx context.Context, path []string) error {
+	return o.pool.RemoveDataPath(ctx, path)
 }
 
 // SetPolicy updates the policy for the subsequent Eval calls.
 // Returns either ErrNotReady, ErrInvalidPolicy or ErrInternal if an
 // error occurs.
-func (o *OPA) SetPolicy(p []byte) error {
+func (o *OPA) SetPolicy(ctx context.Context, p []byte) error {
 	if o.pool == nil {
 		return errors.ErrNotReady
 	}
@@ -117,13 +118,13 @@ func (o *OPA) SetPolicy(p []byte) error {
 	o.mutex.Lock()
 	defer o.mutex.Unlock()
 
-	return o.setPolicyData(p, o.data)
+	return o.setPolicyData(ctx, p, o.data)
 }
 
 // SetPolicyData updates both the policy and data for the subsequent
 // Eval calls.  Returns either ErrNotReady, ErrInvalidPolicyOrData, or
 // ErrInternal if an error occurs.
-func (o *OPA) SetPolicyData(policy []byte, data *interface{}) error {
+func (o *OPA) SetPolicyData(ctx context.Context, policy []byte, data *interface{}) error {
 	if o.pool == nil {
 		return errors.ErrNotReady
 	}
@@ -140,11 +141,11 @@ func (o *OPA) SetPolicyData(policy []byte, data *interface{}) error {
 	o.mutex.Lock()
 	defer o.mutex.Unlock()
 
-	return o.setPolicyData(policy, raw)
+	return o.setPolicyData(ctx, policy, raw)
 }
 
-func (o *OPA) setPolicyData(policy []byte, data []byte) error {
-	if err := o.pool.SetPolicyData(policy, data); err != nil {
+func (o *OPA) setPolicyData(ctx context.Context, policy []byte, data []byte) error {
+	if err := o.pool.SetPolicyData(ctx, policy, data); err != nil {
 		return err
 	}
 

--- a/plugins/plugins.go
+++ b/plugins/plugins.go
@@ -650,7 +650,7 @@ func (m *Manager) onCommit(ctx context.Context, txn storage.Transaction, event s
 			}
 			m.setWasmResolvers(resolvers)
 		} else {
-			err := m.updateWasmResolversData(event)
+			err := m.updateWasmResolversData(ctx, event)
 			if err != nil {
 				panic(err)
 			}
@@ -694,7 +694,7 @@ func requiresWasmResolverReload(event storage.TriggerEvent) bool {
 	return false
 }
 
-func (m *Manager) updateWasmResolversData(event storage.TriggerEvent) error {
+func (m *Manager) updateWasmResolversData(ctx context.Context, event storage.TriggerEvent) error {
 	m.wasmResolversMtx.Lock()
 	defer m.wasmResolversMtx.Unlock()
 
@@ -706,9 +706,9 @@ func (m *Manager) updateWasmResolversData(event storage.TriggerEvent) error {
 		for _, dataEvent := range event.Data {
 			var err error
 			if dataEvent.Removed {
-				err = resolver.RemoveDataPath(dataEvent.Path)
+				err = resolver.RemoveDataPath(ctx, dataEvent.Path)
 			} else {
-				err = resolver.SetDataPath(dataEvent.Path, dataEvent.Data)
+				err = resolver.SetDataPath(ctx, dataEvent.Path, dataEvent.Data)
 			}
 			if err != nil {
 				return fmt.Errorf("failed to update wasm runtime data: %s", err)

--- a/resolver/wasm/nop.go
+++ b/resolver/wasm/nop.go
@@ -29,27 +29,27 @@ func (r *Resolver) Close() {
 }
 
 // Eval unimplemented.
-func (r *Resolver) Eval(ctx context.Context, input resolver.Input) (resolver.Result, error) {
+func (r *Resolver) Eval(context.Context, resolver.Input) (resolver.Result, error) {
 
 	panic("unreachable")
 }
 
 // SetData unimplemented.
-func (r *Resolver) SetData(data interface{}) error {
+func (r *Resolver) SetData(context.Context, interface{}) error {
 	panic("unreachable")
 }
 
 // SetDataPath unimplemented.
-func (r *Resolver) SetDataPath(path []string, data interface{}) error {
+func (r *Resolver) SetDataPath(context.Context, []string, interface{}) error {
 	panic("unreachable")
 }
 
 // RemoveDataPath unimplemented.
-func (r *Resolver) RemoveDataPath(path []string) error {
+func (r *Resolver) RemoveDataPath(context.Context, []string) error {
 	panic("unreachable")
 }
 
 // New unimplemented. Will always return an error.
-func New(entrypoints []ast.Ref, policy []byte, data interface{}) (*Resolver, error) {
+func New([]ast.Ref, []byte, interface{}) (*Resolver, error) {
 	return nil, errors.New("WebAssembly runtime not supported in this build")
 }

--- a/resolver/wasm/wasm.go
+++ b/resolver/wasm/wasm.go
@@ -120,18 +120,18 @@ func (r *Resolver) Eval(ctx context.Context, input resolver.Input) (resolver.Res
 }
 
 // SetData will update the external data for the Wasm instance.
-func (r *Resolver) SetData(data interface{}) error {
-	return r.o.SetData(data)
+func (r *Resolver) SetData(ctx context.Context, data interface{}) error {
+	return r.o.SetData(ctx, data)
 }
 
 // SetDataPath will set the provided data on the wasm instance at the specified path.
-func (r *Resolver) SetDataPath(path []string, data interface{}) error {
-	return r.o.SetDataPath(path, data)
+func (r *Resolver) SetDataPath(ctx context.Context, path []string, data interface{}) error {
+	return r.o.SetDataPath(ctx, path, data)
 }
 
 // RemoveDataPath will remove any data at the specified path.
-func (r *Resolver) RemoveDataPath(path []string) error {
-	return r.o.RemoveDataPath(path)
+func (r *Resolver) RemoveDataPath(ctx context.Context, path []string) error {
+	return r.o.RemoveDataPath(ctx, path)
 }
 
 func getResult(evalResult *opa.Result) (ast.Value, error) {

--- a/server/server.go
+++ b/server/server.go
@@ -1502,6 +1502,7 @@ func (s *Server) v1DataPost(w http.ResponseWriter, r *http.Request) {
 			result.Explanation, err = types.NewTraceV1(*buf, pretty)
 			if err != nil {
 				writer.ErrorAuto(w, err)
+				return
 			}
 		}
 		err = logger.Log(ctx, txn, decisionID, r.RemoteAddr, urlPath, "", goInput, input, nil, nil, m)

--- a/topdown/http.go
+++ b/topdown/http.go
@@ -158,6 +158,14 @@ func handleHTTPSendErr(bctx BuiltinContext, err error) error {
 	if urlErr, ok := err.(*url.Error); ok && urlErr.Timeout() && bctx.Context.Err() == nil {
 		err = fmt.Errorf("%s %s: request timed out", urlErr.Op, urlErr.URL)
 	}
+	if err := bctx.Context.Err(); err != nil {
+		return Halt{
+			Err: &Error{
+				Code:    CancelErr,
+				Message: fmt.Sprintf("http.send: timed out (%s)", err.Error()),
+			},
+		}
+	}
 	return handleBuiltinErr(ast.HTTPSend.Name, bctx.Location, err)
 }
 

--- a/topdown/http_slow_test.go
+++ b/topdown/http_slow_test.go
@@ -62,7 +62,7 @@ func TestHTTPSendTimeout(t *testing.T) {
 			evalTimeout:    500 * time.Millisecond,
 			serverDelay:    5 * time.Second,
 			defaultTimeout: 1 * time.Minute,
-			expected:       &Error{Code: BuiltinErr, Message: "context deadline exceeded"},
+			expected:       &Error{Code: CancelErr, Message: "timed out (context deadline exceeded)"},
 		},
 		{
 			note:           "param timeout less than default",
@@ -86,7 +86,7 @@ func TestHTTPSendTimeout(t *testing.T) {
 			evalTimeout:    500 * time.Millisecond,
 			serverDelay:    5 * time.Second,
 			defaultTimeout: 1 * time.Minute,
-			expected:       &Error{Code: BuiltinErr, Message: "context deadline exceeded"},
+			expected:       &Error{Code: CancelErr, Message: "timed out (context deadline exceeded)"},
 		},
 	}
 
@@ -96,9 +96,8 @@ func TestHTTPSendTimeout(t *testing.T) {
 		tsMtx.Unlock()
 
 		ctx := context.Background()
-		var cancel context.CancelFunc
 		if tc.evalTimeout > 0 {
-			ctx, cancel = context.WithTimeout(ctx, tc.evalTimeout)
+			ctx, _ = context.WithTimeout(ctx, tc.evalTimeout)
 		}
 
 		// TODO(patrick-east): Remove this along with the environment variable so that the "default" can't change
@@ -116,8 +115,5 @@ func TestHTTPSendTimeout(t *testing.T) {
 
 		// Put back the default (may not have changed)
 		defaultHTTPRequestTimeout = originalDefaultTimeout
-		if cancel != nil {
-			cancel()
-		}
 	}
 }


### PR DESCRIPTION

Now, when an interrupt happens, we'll clean up after ourselves: we keep calling
a cheap function to ensure that the trap has been trapped on.

To get there, we'll move the "defer-recover" further down the call stack.

👉 Also, this changes the cancellation error returned by the topdown builtin. It no
longer is a builtinError with a message indicating that the context was cancelled
(or its deadline reached), but return a CancelErr, the same thing that happens via
the other cancellation mechanisms involved topdown's Cancel (like in cidr.expand).

Compared with master, this isn't worse:

    name                       old time/op    new time/op    delta
    RESTAuthzForbidAuthn-16       542µs ±15%     525µs ±12%    ~     (p=0.841 n=5+5)
    RESTAuthzForbidPath-16        818µs ± 2%     827µs ± 2%    ~     (p=0.556 n=4+5)
    RESTAuthzForbidMethod-16      864µs ± 2%     851µs ± 4%    ~     (p=0.310 n=5+5)
    RESTAuthzAllow10Paths-16      896µs ±20%     855µs ± 5%    ~     (p=1.000 n=5+5)
    RESTAuthzAllow100Paths-16    4.28ms ± 3%    4.07ms ± 3%  -4.97%  (p=0.008 n=5+5)

    name                       old alloc/op   new alloc/op   delta
    RESTAuthzForbidAuthn-16      68.8kB ± 1%    67.2kB ± 1%  -2.28%  (p=0.008 n=5+5)
    RESTAuthzForbidPath-16       68.5kB ± 0%    66.9kB ± 0%  -2.33%  (p=0.008 n=5+5)
    RESTAuthzForbidMethod-16     68.5kB ± 0%    66.9kB ± 0%  -2.33%  (p=0.008 n=5+5)
    RESTAuthzAllow10Paths-16     68.5kB ± 0%    66.9kB ± 0%  -2.33%  (p=0.008 n=5+5)
    RESTAuthzAllow100Paths-16    69.1kB ± 0%    67.5kB ± 0%  -2.31%  (p=0.008 n=5+5)

    name                       old allocs/op  new allocs/op  delta
    RESTAuthzForbidAuthn-16       1.73k ± 1%     1.64k ± 1%  -5.17%  (p=0.008 n=5+5)
    RESTAuthzForbidPath-16        1.72k ± 0%     1.63k ± 0%    ~     (p=0.079 n=4+5)
    RESTAuthzForbidMethod-16      1.72k ± 0%     1.63k ± 0%  -5.13%  (p=0.008 n=5+5)
    RESTAuthzAllow10Paths-16      1.72k ± 0%     1.63k ± 0%  -5.13%  (p=0.008 n=5+5)
    RESTAuthzAllow100Paths-16     1.72k ± 0%     1.63k ± 0%  -5.16%  (p=0.008 n=5+5)

👉 Also, we're threading through some context arguments we hadn't had before. (See the two commits.)

👉 Also, I've added what I believe to be a missing return stmt in the handler code, please see the comment on the code added below.

------
Reproducing the flaky test behaviour locally using docker desktop goes as follows,

1. throttle your docker performance (I've used 2 CPU, 4G memory)
2. edit your makefile:
```diff
diff --git a/Makefile b/Makefile
index d16dc2f0..de26c42e 100644
--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,10 @@ test-coverage: generate
 perf: generate
        $(GO) test $(GO_TAGS),slow $(GO_TEST_TIMEOUT) -run=- -bench=. -benchmem ./...

+.PHONY: flake
+flake:
+       while $(GO) test $(GO_TAGS),slow $(GO_TEST_TIMEOUT) -run=- -bench=. -benchmem ./test/e2e/wasm/authz ; do echo ; done;
+
 .PHONY: perf-noisy
 perf-noisy: generate
        $(GO) test $(GO_TAGS),slow,noisy $(GO_TEST_TIMEOUT) -run=- -bench=. -benchmem ./...
```
3. run `make ci-go-flake`

It'll run until it fails. Keep it running for some time to convince yourself that it's less likely to fail than before. (On master, it doesn't take long on my machine.)

-------
Fixes #3272 