### PR TITLE
ci: Use the ci container to build binary for make image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ generate: wasm-lib-build
 build: go-build
 
 .PHONY: image
-image: build-docker
+image: ci-go-build-docker
 	@$(MAKE) image-quick
 
 .PHONY: install


### PR DESCRIPTION
The `make image` target was relying on the build-docker target to
build the binary that goes into docker image. The problem is that
build-docker runs on the host and can therefore produce a binary for
the wrong environment.

This change just updates the image target to rely on
ci-go-build-docker instead which runs go build inside of a docker
container and ensures the environment is correct.

Since the user is already trying to build a docker image, it seems
reasonable to require docker to build the binary (normally we try to
avoid this dependency for plain binary builds.)

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
