### PR TITLE
Refactored bundle sign/verify to use interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .vscode
 .idea
 *~
+*.swp
 
 # build artifacts
 coverage.txt

--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -53,6 +53,7 @@ type Bundle struct {
 // SignaturesConfig represents an array of JWTs that encapsulate the signatures for the bundle.
 type SignaturesConfig struct {
 	Signatures []string `json:"signatures,omitempty"`
+	Plugin     string   `json:"plugin,omitempty"`
 }
 
 // isEmpty returns if the SignaturesConfig is empty.
@@ -804,6 +805,10 @@ func (b *Bundle) GenerateSignature(signingConfig *SigningConfig, keyID string, u
 
 	if b.Signatures.isEmpty() {
 		b.Signatures = SignaturesConfig{}
+	}
+
+	if signingConfig.Plugin != "" {
+		b.Signatures.Plugin = signingConfig.Plugin
 	}
 
 	b.Signatures.Signatures = []string{string(token)}

--- a/bundle/keys.go
+++ b/bundle/keys.go
@@ -76,6 +76,7 @@ func (vc *VerificationConfig) GetPublicKey(id string) (*KeyConfig, error) {
 
 // SigningConfig represents the key configuration used to generate a signed bundle
 type SigningConfig struct {
+	Plugin     string
 	Key        string
 	Algorithm  string
 	ClaimsPath string
@@ -88,10 +89,19 @@ func NewSigningConfig(key, alg, claimsPath string) *SigningConfig {
 	}
 
 	return &SigningConfig{
+		Plugin:     defaultSignerID,
 		Key:        key,
 		Algorithm:  alg,
 		ClaimsPath: claimsPath,
 	}
+}
+
+// WithPlugin sets the signing plugin in the signing config
+func (s *SigningConfig) WithPlugin(plugin string) *SigningConfig {
+	if plugin != "" {
+		s.Plugin = plugin
+	}
+	return s
 }
 
 // GetPrivateKey returns the private key or secret from the signing config

--- a/bundle/verify_test.go
+++ b/bundle/verify_test.go
@@ -285,3 +285,35 @@ func TestVerifyBundleFile(t *testing.T) {
 		})
 	}
 }
+
+type CustomVerifier struct{}
+
+func (*CustomVerifier) VerifyBundleSignature(sc SignaturesConfig, bvc *VerificationConfig) (map[string]FileInfo, error) {
+	return map[string]FileInfo{}, nil
+}
+
+func TestCustomVerifier(t *testing.T) {
+	custom := &CustomVerifier{}
+	err := RegisterVerifier(defaultVerifierID, custom)
+	if err == nil {
+		t.Fatalf("Expected error when registering with default ID")
+	}
+	RegisterVerifier("_test", custom)
+	defaultVerifier, err := GetVerifier(defaultVerifierID)
+	if err != nil {
+		t.Fatalf("Unexpected error %v", err)
+	}
+	if _, isDefault := defaultVerifier.(*DefaultVerifier); !isDefault {
+		t.Fatalf("Expected DefaultVerifier to be registered at key %s", defaultVerifierID)
+	}
+	customVerifier, err := GetVerifier("_test")
+	if err != nil {
+		t.Fatalf("Unexpected error %v", err)
+	}
+	if _, isCustom := customVerifier.(*CustomVerifier); !isCustom {
+		t.Fatalf("Expected CustomVerifier to be registered at key _test")
+	}
+	if _, err = GetVerifier("_unregistered"); err == nil {
+		t.Fatalf("Expected error when no Verifier exists at provided key")
+	}
+}

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -40,6 +40,7 @@ type buildParams struct {
 	pubKeyID           string
 	claimsFile         string
 	excludeVerifyFiles []string
+	plugin             string
 }
 
 func newBuildParams() buildParams {
@@ -231,6 +232,7 @@ against OPA v0.22.0:
 
 	// bundle signing config
 	addSigningKeyFlag(buildCommand.Flags(), &buildParams.key)
+	addSigningPluginFlag(buildCommand.Flags(), &buildParams.plugin)
 	addClaimsFileFlag(buildCommand.Flags(), &buildParams.claimsFile)
 
 	RootCommand.AddCommand(buildCommand)
@@ -246,7 +248,7 @@ func dobuild(params buildParams, args []string) error {
 		return err
 	}
 
-	bsc := buildSigningConfig(params.key, params.algorithm, params.claimsFile)
+	bsc := buildSigningConfig(params.key, params.algorithm, params.claimsFile, params.plugin)
 
 	if bvc != nil || bsc != nil {
 		if !params.bundleMode {
@@ -324,10 +326,10 @@ func buildVerificationConfig(pubKey, pubKeyID, alg, scope string, excludeFiles [
 	return bundle.NewVerificationConfig(map[string]*keys.Config{pubKeyID: keyConfig}, pubKeyID, scope, excludeFiles), nil
 }
 
-func buildSigningConfig(key, alg, claimsFile string) *bundle.SigningConfig {
+func buildSigningConfig(key, alg, claimsFile, plugin string) *bundle.SigningConfig {
 	if key == "" {
 		return nil
 	}
 
-	return bundle.NewSigningConfig(key, alg, claimsFile)
+	return bundle.NewSigningConfig(key, alg, claimsFile).WithPlugin(plugin)
 }

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -98,6 +98,10 @@ func addSigningKeyFlag(fs *pflag.FlagSet, key *string) {
 	fs.StringVarP(key, "signing-key", "", "", "set the secret (HMAC) or path of the PEM file containing the private key (RSA and ECDSA)")
 }
 
+func addSigningPluginFlag(fs *pflag.FlagSet, plugin *string) {
+	fs.StringVarP(plugin, "signing-plugin", "", "", "name of the plugin to use for signing/verification (see https://openpolicyagent.org/docs/latest/management/#signature-plugin")
+}
+
 func addVerificationKeyFlag(fs *pflag.FlagSet, key *string) {
 	fs.StringVarP(key, "verification-key", "", "", "set the secret (HMAC) or path of the PEM file containing the public key (RSA and ECDSA)")
 }

--- a/cmd/sign.go
+++ b/cmd/sign.go
@@ -32,6 +32,7 @@ type signCmdParams struct {
 	claimsFile     string
 	outputFilePath string
 	bundleMode     bool
+	plugin         string
 }
 
 const (
@@ -150,6 +151,7 @@ https://www.openpolicyagent.org/docs/latest/management/#signature-format.
 	addSigningKeyFlag(signCommand.Flags(), &cmdParams.key)
 	addClaimsFileFlag(signCommand.Flags(), &cmdParams.claimsFile)
 	addSigningAlgFlag(signCommand.Flags(), &cmdParams.algorithm, defaultTokenSigningAlg)
+	addSigningPluginFlag(signCommand.Flags(), &cmdParams.plugin)
 
 	signCommand.Flags().StringVarP(&cmdParams.outputFilePath, "output-file-path", "o", ".", "set the location for the .signatures.json file")
 
@@ -172,8 +174,9 @@ func doSign(args []string, params signCmdParams) error {
 		return err
 	}
 
-	// generate the signed token
-	token, err := bundle.GenerateSignedToken(files, buildSigningConfig(params.key, params.algorithm, params.claimsFile), "")
+	signingConfig := buildSigningConfig(params.key, params.algorithm, params.claimsFile, params.plugin)
+
+	token, err := bundle.GenerateSignedToken(files, signingConfig, "")
 	if err != nil {
 		return err
 	}

--- a/docs/content/management.md
+++ b/docs/content/management.md
@@ -446,7 +446,21 @@ OPA out-of-band
 
 * `iss`: unused for verification even if present in payload
 
+#### Signature Plugin
 
+OPA supports the option to implement your own bundle signing and verification logic. This will be unnecessary 
+for most and is intended for advanced use cases, such as leveraging key-related services from cloud providers. 
+To implement your own signing and verification logic, you'll need to [extend OPA](../extensions). Here is
+[an example](https://github.com/open-policy-agent/contrib/tree/master/custom_bundle_signing) to get you started.
+
+When registering custom signing and verification plugins, you will need to register the Signer and the Verifier
+under the same plugin key, because the plugin key is stored in the signed bundle and informs OPA which Verifier
+is capable of verifying the bundle, e.g.
+
+```go
+bundle.RegisterSigner("custom", &CustomSigner{})
+bundle.RegisterVerifier("custom", &CustomVerifier{})
+```
 
 ## Decision Logs
 


### PR DESCRIPTION
It is now possible to register a custom implementation of the sign and verify functions.  We use this to implement Bundle Verification using AWS KMS.

Related to #2757 (this is a prerequisite).