### PR TITLE
plugins: Include log drop count in the status plugin's metrics

### DIFF
--- a/plugins/discovery/discovery.go
+++ b/plugins/discovery/discovery.go
@@ -370,7 +370,7 @@ func getPluginSet(factories map[string]plugins.Factory, manager *plugins.Manager
 	}
 
 	if decisionLogsConfig != nil {
-		p, created := getDecisionLogsPlugin(manager, decisionLogsConfig)
+		p, created := getDecisionLogsPlugin(manager, decisionLogsConfig, m)
 		if created {
 			starts = append(starts, p)
 		} else if p != nil {
@@ -405,10 +405,10 @@ func getBundlePlugin(m *plugins.Manager, config *bundle.Config) (plugin *bundle.
 	return plugin, created
 }
 
-func getDecisionLogsPlugin(m *plugins.Manager, config *logs.Config) (plugin *logs.Plugin, created bool) {
+func getDecisionLogsPlugin(m *plugins.Manager, config *logs.Config, metrics metrics.Metrics) (plugin *logs.Plugin, created bool) {
 	plugin = logs.Lookup(m)
 	if plugin == nil {
-		plugin = logs.New(config, m)
+		plugin = logs.New(config, m).WithMetrics(metrics)
 		m.Register(logs.Name, plugin)
 		created = true
 	}


### PR DESCRIPTION
This change adds the count of the decision log events that
were dropped when the rate limit was exceeded to the status
plugin's metrics provider. These metrics are part of the periodic
status update and hence should allow control planes to monitor the
number of dropped log events.

Signed-off-by: Ashutosh Narkar <anarkar4387@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
