### PR TITLE
Docs: update discovery to alert when config with bundles

### DIFF
--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -722,3 +722,5 @@ included in the actual bundle gzipped tarball.
 | `discovery.signing.keyid` | `string` | No | Name of the key to use for bundle signature verification. |
 | `discovery.signing.scope` | `string` | No | Scope to use for bundle signature verification. |
 | `discovery.signing.exclude_files` | `array` | No | Files in the bundle to exclude during verification. |
+
+Note: discovery should be mutually exclusive with other kinds of configuration: if discovery is on, bundles/decision logs/status cannot be configured manually.


### PR DESCRIPTION
When configured discovery service with bundles, a vague error appears:
```
error: config error: plugins cannot be specified in the bootstrap configuration when discovery enabled
```
It stems from this issue https://github.com/open-policy-agent/opa/issues/987 but because the wording is unclear (I am not sure if bundles are considered plugins), so I try to add some notes in the discovery part