### PR TITLE
cmd: Add tooling to support package renaming

### DIFF
--- a/cmd/refactor.go
+++ b/cmd/refactor.go
@@ -1,0 +1,178 @@
+// Copyright 2021 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/format"
+	fileurl "github.com/open-policy-agent/opa/internal/file/url"
+	"github.com/open-policy-agent/opa/loader"
+	"github.com/open-policy-agent/opa/refactor"
+)
+
+type moveCommandParams struct {
+	mapping   repeatedStringFlag
+	ignore    []string
+	overwrite bool
+}
+
+func init() {
+
+	var moveCommandParams moveCommandParams
+
+	var refactorCommand = &cobra.Command{
+		Use:    "refactor",
+		Short:  "Refactor Rego file(s)",
+		Hidden: true,
+	}
+
+	var moveCommand = &cobra.Command{
+		Use:   "move [file-path [...]]",
+		Short: "Rename packages and their references in Rego file(s)",
+		Long: `Rename packages and their references in Rego file(s).
+
+The 'move' command takes one or more Rego source file(s) and rewrites package paths and other references in them as per
+the mapping defined by the '-p' option. At least one mapping should be provided and should be of the form:
+
+	<from>:<to>
+
+The 'move' command formats the Rego modules after renaming packages, etc. and prints the formatted modules to stdout by default.
+If the '-w' option is supplied, the 'move' command will overwrite the source file instead.
+
+Example:
+--------
+
+"policy.rego" contains the below policy:
+ _ _ _ _ _ _ _ _ _ _ _ _ _
+| package lib.foo         |
+|                         |
+| default allow = false   |
+| _ _ _ _ _ _ _ _ _ _ _ _ |     
+	
+	$ opa refactor move -p data.lib.foo:data.baz.bar policy.rego
+
+The 'move' command outputs the below policy to stdout with the package name rewritten as per the mapping:
+
+ _ _ _ _ _ _ _ _ _ _ _ _ _
+| package baz.bar         |
+|                         |
+| default allow = false   |
+| _ _ _ _ _ _ _ _ _ _ _ _ | 
+`,
+		PreRunE: func(_ *cobra.Command, args []string) error {
+			return validateMoveArgs(args)
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := doMove(moveCommandParams, args, os.Stdout); err != nil {
+				fmt.Fprintln(os.Stderr, "error:", err)
+				os.Exit(1)
+			}
+		},
+	}
+
+	moveCommand.Flags().VarP(&moveCommandParams.mapping, "path", "p", "set the mapping that defines how references should be rewritten (ie. <from>:<to>). This flag can be repeated.")
+	moveCommand.Flags().BoolVarP(&moveCommandParams.overwrite, "write", "w", false, "overwrite the original source file")
+	addIgnoreFlag(moveCommand.Flags(), &moveCommandParams.ignore)
+	refactorCommand.AddCommand(moveCommand)
+	RootCommand.AddCommand(refactorCommand)
+}
+
+func doMove(params moveCommandParams, args []string, out io.Writer) error {
+	if len(params.mapping.v) == 0 {
+		return errors.New("specify at least one mapping of the form <from>:<to>")
+	}
+
+	srcDstMap, err := parseSrcDstMap(params.mapping.v)
+	if err != nil {
+		return err
+	}
+
+	modules := map[string]*ast.Module{}
+
+	f := loaderFilter{
+		Ignore: params.ignore,
+	}
+
+	result, err := loader.NewFileLoader().Filtered(args, f.Apply)
+	if err != nil {
+		return err
+	}
+
+	for _, m := range result.Modules {
+		modules[m.Name] = m.Parsed
+	}
+
+	mq := refactor.MoveQuery{
+		Modules:       modules,
+		SrcDstMapping: srcDstMap,
+	}.WithValidation(true)
+
+	movedModules, err := refactor.New().Move(mq)
+	if err != nil {
+		return err
+	}
+
+	for filename, mod := range movedModules.Result {
+		filename, err = fileurl.Clean(filename)
+		if err != nil {
+			return err
+		}
+
+		formatted, err := format.Ast(mod)
+		if err != nil {
+			return newError("failed to parse Rego source file: %v", err)
+		}
+
+		if params.overwrite {
+			info, err := os.Stat(filename)
+			if err != nil {
+				return err
+			}
+
+			outfile, err := os.OpenFile(filename, os.O_WRONLY|os.O_TRUNC, info.Mode())
+			if err != nil {
+				return newError("failed to open file for writing: %v", err)
+			}
+			defer outfile.Close()
+			out = outfile
+		}
+
+		_, err = out.Write(formatted)
+		if err != nil {
+			return newError("failed writing formatted contents: %v", err)
+		}
+	}
+
+	return nil
+}
+
+func parseSrcDstMap(data []string) (map[string]string, error) {
+	result := map[string]string{}
+
+	for _, d := range data {
+		parts := strings.Split(d, ":")
+		if len(parts) != 2 {
+			return nil, errors.New("expected mapping of the form <from>:<to>")
+		}
+
+		result[parts[0]] = parts[1]
+	}
+	return result, nil
+}
+
+func validateMoveArgs(args []string) error {
+	if len(args) == 0 {
+		return errors.New("specify at least one path containing policy files")
+	}
+	return nil
+}

--- a/cmd/refactor_test.go
+++ b/cmd/refactor_test.go
@@ -1,0 +1,157 @@
+package cmd
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/format"
+	"github.com/open-policy-agent/opa/util/test"
+)
+
+func TestDoMoveRenamePackage(t *testing.T) {
+
+	files := map[string]string{
+		"policy.rego": `package lib.foo
+
+# this is a comment
+default allow = false
+
+allow {
+        input.message == "hello"    # this is a comment too
+}`,
+	}
+
+	test.WithTempFS(files, func(path string) {
+
+		mappings := []string{"data.lib.foo:data.baz.bar"}
+
+		params := moveCommandParams{
+			mapping: newrepeatedStringFlag(mappings),
+		}
+
+		var buf bytes.Buffer
+
+		err := doMove(params, []string{path}, &buf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		expected := ast.MustParseModule(`package baz.bar
+
+# this is a comment
+default allow = false
+
+allow {
+        input.message == "hello"    # this is a comment too
+}`)
+
+		formatted := format.MustAst(expected)
+
+		if !reflect.DeepEqual(formatted, buf.Bytes()) {
+			t.Fatalf("Expected module:\n%v\n\nGot:\n%v\n", string(formatted), buf.String())
+		}
+	})
+}
+
+func TestDoMoveOverwriteFile(t *testing.T) {
+
+	files := map[string]string{
+		"policy.rego": `package lib.foo
+
+import data.x.q
+
+default allow = false
+`,
+	}
+
+	test.WithTempFS(files, func(path string) {
+
+		mappings := []string{"data.lib.foo:data.baz.bar", "data.x: data.hidden"}
+
+		params := moveCommandParams{
+			mapping:   newrepeatedStringFlag(mappings),
+			overwrite: true,
+		}
+
+		var buf bytes.Buffer
+
+		err := doMove(params, []string{path}, &buf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		data, err := ioutil.ReadFile(filepath.Join(path, "policy.rego"))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		actual := ast.MustParseModule(string(data))
+
+		expected := ast.MustParseModule(`package baz.bar
+		
+		import data.hidden.q
+	
+		default allow = false`)
+
+		if !expected.Equal(actual) {
+			t.Fatalf("Expected module:\n%v\n\nGot:\n%v\n", expected, actual)
+		}
+	})
+}
+
+func TestParseSrcDstMap(t *testing.T) {
+	actual, err := parseSrcDstMap([]string{"data.lib.foo:data.baz.bar", "data:data.acme"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := map[string]string{"data.lib.foo": "data.baz.bar", "data": "data.acme"}
+
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("Expected mapping %v but got %v", expected, actual)
+	}
+
+	_, err = parseSrcDstMap([]string{"data.lib.foo:data.baz.bar", "data::data.acme"})
+	if err == nil {
+		t.Fatal("Expected error but got nil")
+	}
+
+	_, err = parseSrcDstMap([]string{"data.lib.foo:data.baz.bar", "data%data.acme:foo:bar"})
+	if err == nil {
+		t.Fatal("Expected error but got nil")
+	}
+}
+
+func TestDoMoveNoMapping(t *testing.T) {
+	err := doMove(moveCommandParams{}, []string{}, os.Stdout)
+	if err == nil {
+		t.Fatal("Expected error but got nil")
+	}
+
+	msg := "specify at least one mapping of the form <from>:<to>"
+	if err.Error() != msg {
+		t.Fatalf("Expected error %v but got %v", msg, err.Error())
+	}
+}
+
+func TestValidateMoveArgs(t *testing.T) {
+	err := validateMoveArgs([]string{})
+	if err == nil {
+		t.Fatal("Expected error but got nil")
+	}
+
+	msg := "specify at least one path containing policy files"
+	if err.Error() != msg {
+		t.Fatalf("Expected error %v but got %v", msg, err.Error())
+	}
+
+	err = validateMoveArgs([]string{"foo"})
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/refactor/refactor.go
+++ b/refactor/refactor.go
@@ -1,0 +1,130 @@
+// Copyright 2021 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+// Package refactor implements different refactoring operations over Rego modules.
+package refactor
+
+import (
+	"fmt"
+
+	"github.com/open-policy-agent/opa/ast"
+)
+
+// Error defines the structure of errors returned by refactor.
+type Error struct {
+	Message  string        `json:"message"`
+	Location *ast.Location `json:"location,omitempty"`
+}
+
+func (e Error) Error() string {
+
+	if e.Location != nil {
+		return e.Location.Format(e.Message)
+	}
+
+	return e.Message
+}
+
+// Refactor implements different refactoring operations over Rego modules eg. renaming packages.
+type Refactor struct {
+}
+
+// New returns a new Refactor object.
+func New() *Refactor {
+	return &Refactor{}
+}
+
+// MoveQuery holds the set of Rego modules whose package paths and other references are to be rewritten
+// as per the mapping defined in SrcDstMapping.
+// If validate is true, the moved modules will be compiled to ensure they are valid.
+type MoveQuery struct {
+	Modules       map[string]*ast.Module
+	SrcDstMapping map[string]string
+	validate      bool
+}
+
+// WithValidation controls whether to compile moved modules to ensure they are valid.
+func (mq MoveQuery) WithValidation(v bool) MoveQuery {
+	mq.validate = v
+	return mq
+}
+
+// MoveQueryResult defines the output of a move query and holds the rewritten modules with updated packages paths
+// and references.
+type MoveQueryResult struct {
+	Result map[string]*ast.Module `json:"result"`
+}
+
+// validate validates moved modules by compiling them.
+func (mqr *MoveQueryResult) validate() error {
+	compiler := ast.NewCompiler()
+	compiler.Compile(mqr.Result)
+
+	if compiler.Failed() {
+		return compiler.Errors
+	}
+	return nil
+}
+
+// Move rewrites Rego code by updating package paths and other references in q's modules as per
+// the mapping specified in q.
+func (r *Refactor) Move(q MoveQuery) (*MoveQueryResult, error) {
+
+	for _, module := range q.Modules {
+		t := ast.NewGenericTransformer(func(x interface{}) (interface{}, error) {
+			if s, ok := x.(ast.Ref); ok {
+				// exact match
+				if val, found := q.SrcDstMapping[s.String()]; found {
+					return ast.ParseRef(val)
+				}
+
+				// prefix match
+				for k, v := range q.SrcDstMapping {
+					other, err := ast.ParseRef(k)
+					if err != nil {
+						return nil, err
+					}
+
+					if s.HasPrefix(other) {
+						newRef, err := ast.ParseRef(v)
+						if err != nil {
+							return nil, err
+						}
+						return newRef.Concat(s[len(other):]), nil
+					}
+
+					// check if a reference in the policy is a prefix of a source reference
+					// example: policy_reference = data.foo
+					//          mapping: {"data.foo.bar": "data.baz"}
+					// In this scenario, we can relocate data.foo.bar but everything under data.foo
+					// (e.g., data.foo.baz, data.foo.qux, etc.) can't be relocated
+					if other.HasPrefix(s.ConstantPrefix()) {
+						msg := fmt.Sprintf("cannot rewrite `%v`: constant prefix `%v` of `%v` is too short", s, s.ConstantPrefix(), s)
+						x := Error{Message: msg, Location: s[len(s)-1].Loc()}
+						return nil, x
+					}
+				}
+			}
+			return x, nil
+		})
+		_, err := ast.Transform(t, module)
+		if err != nil {
+			switch err.(type) {
+			case Error:
+				return nil, err
+			default:
+				return nil, Error{Message: err.Error()}
+			}
+		}
+	}
+
+	result := &MoveQueryResult{Result: q.Modules}
+
+	if q.validate {
+		if err := result.validate(); err != nil {
+			return nil, err
+		}
+	}
+	return result, nil
+}

--- a/refactor/refactor_test.go
+++ b/refactor/refactor_test.go
@@ -1,0 +1,337 @@
+package refactor
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/open-policy-agent/opa/ast"
+)
+
+func TestMoveRenamePackage(t *testing.T) {
+	module := ast.MustParseModule(`package lib.foo
+
+default allow = false
+
+allow {
+        input.message == "hello"
+}`)
+
+	modules := map[string]*ast.Module{
+		"policy.rego": module,
+	}
+
+	mappings := map[string]string{
+		"data.lib.foo": "data.baz.bar",
+	}
+
+	result, err := New().Move(MoveQuery{
+		Modules:       modules,
+		SrcDstMapping: mappings,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	actual := result.Result["policy.rego"]
+
+	expected := ast.MustParseModule(`package baz.bar
+
+default allow = false
+
+allow {
+        input.message == "hello"
+}`)
+
+	if !expected.Equal(actual) {
+		t.Fatalf("Expected module:\n%v\n\nGot:\n%v\n", expected, actual)
+	}
+}
+
+func TestMoveRenamePackagePrefix(t *testing.T) {
+	module1 := ast.MustParseModule(`package lib.foo
+
+default allow = false
+
+allow {
+        input.message == "hello"
+}`)
+
+	module2 := ast.MustParseModule(`package lib.bar
+
+allow {
+        input.message == "world"
+}`)
+
+	modules := map[string]*ast.Module{
+		"policy1.rego": module1,
+		"policy2.rego": module2,
+	}
+
+	mappings := map[string]string{
+		"data.lib": "data.hidden",
+	}
+
+	result, err := New().Move(MoveQuery{
+		Modules:       modules,
+		SrcDstMapping: mappings,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	actual1 := result.Result["policy1.rego"]
+	actual2 := result.Result["policy2.rego"]
+
+	expected1 := ast.MustParseModule(`package hidden.foo
+
+default allow = false
+
+allow {
+        input.message == "hello"
+}`)
+
+	expected2 := ast.MustParseModule(`package hidden.bar
+
+allow {
+        input.message == "world"
+}`)
+
+	if !expected1.Equal(actual1) {
+		t.Fatalf("Expected module:\n%v\n\nGot:\n%v\n", expected1, actual1)
+	}
+
+	if !expected2.Equal(actual2) {
+		t.Fatalf("Expected module:\n%v\n\nGot:\n%v\n", expected2, actual2)
+	}
+}
+
+func TestMovePrefixInjection(t *testing.T) {
+	module1 := ast.MustParseModule(`package a.b
+
+p { data.x.q }`)
+
+	module2 := ast.MustParseModule(`package x
+
+q = true`)
+
+	modules := map[string]*ast.Module{
+		"policy1.rego": module1,
+		"policy2.rego": module2,
+	}
+
+	mappings := map[string]string{
+		"data": "data.deadbeef",
+	}
+
+	result, err := New().Move(MoveQuery{
+		Modules:       modules,
+		SrcDstMapping: mappings,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	actual1 := result.Result["policy1.rego"]
+	actual2 := result.Result["policy2.rego"]
+
+	expected1 := ast.MustParseModule(`package deadbeef.a.b
+
+p {
+	data.deadbeef.x.q
+}`)
+
+	expected2 := ast.MustParseModule(`package deadbeef.x
+
+q = true`)
+
+	if !expected1.Equal(actual1) {
+		t.Fatalf("Expected module:\n%v\n\nGot:\n%v\n", expected1, actual1)
+	}
+
+	if !expected2.Equal(actual2) {
+		t.Fatalf("Expected module:\n%v\n\nGot:\n%v\n", expected2, actual2)
+	}
+}
+
+func TestMoveWithKeyword(t *testing.T) {
+	module1 := ast.MustParseModule(`package a.b
+
+import data.x.q as r
+
+p { r with data.foo as 7 }`)
+
+	module2 := ast.MustParseModule(`package x
+
+q { data.foo == 7 }`)
+
+	modules := map[string]*ast.Module{
+		"policy1.rego": module1,
+		"policy2.rego": module2,
+	}
+
+	mappings := map[string]string{
+		"data": "data.deadbeef",
+	}
+
+	result, err := New().Move(MoveQuery{
+		Modules:       modules,
+		SrcDstMapping: mappings,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	actual1 := result.Result["policy1.rego"]
+	actual2 := result.Result["policy2.rego"]
+
+	expected1 := ast.MustParseModule(`package deadbeef.a.b
+
+import data.deadbeef.x.q as r
+
+p {
+	r with data.deadbeef.foo as 7
+}`)
+
+	expected2 := ast.MustParseModule(`package deadbeef.x
+
+q {
+	data.deadbeef.foo == 7
+}`)
+
+	if !expected1.Equal(actual1) {
+		t.Fatalf("Expected module:\n%v\n\nGot:\n%v\n", expected1, actual1)
+	}
+
+	if !expected2.Equal(actual2) {
+		t.Fatalf("Expected module:\n%v\n\nGot:\n%v\n", expected2, actual2)
+	}
+}
+
+func TestMovePrefixTooShort(t *testing.T) {
+	module1 := ast.MustParseModule(`package foo.bar
+
+p = 7`)
+
+	module2 := ast.MustParseModule(`package a
+
+p = data.foo`)
+
+	modules := map[string]*ast.Module{
+		"policy1.rego": module1,
+		"policy2.rego": module2,
+	}
+
+	mappings := map[string]string{
+		"data.foo.bar": "data.baz",
+	}
+
+	_, err := New().Move(MoveQuery{
+		Modules:       modules,
+		SrcDstMapping: mappings,
+	})
+	if err == nil {
+		t.Fatal("Expected error but got nil")
+	}
+
+	errMsg := "cannot rewrite `data.foo`: constant prefix `data.foo` of `data.foo` is too short"
+	if !strings.Contains(err.Error(), errMsg) {
+		t.Fatalf("Expected error message %v but got %v", errMsg, err.Error())
+	}
+}
+
+func TestMoveConflictingRulesNoValidation(t *testing.T) {
+	module1 := ast.MustParseModule(`package a.b
+
+p[1]`)
+
+	module2 := ast.MustParseModule(`package b
+
+p = 7`)
+
+	modules := map[string]*ast.Module{
+		"policy1.rego": module1,
+		"policy2.rego": module2,
+	}
+
+	mappings := map[string]string{
+		"data.a": "data",
+	}
+
+	_, err := New().Move(MoveQuery{
+		Modules:       modules,
+		SrcDstMapping: mappings,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestMoveConflictingRulesWithValidation(t *testing.T) {
+	module1 := ast.MustParseModule(`package a.b
+
+p[1]`)
+
+	module2 := ast.MustParseModule(`package b
+
+p = 7`)
+
+	modules := map[string]*ast.Module{
+		"policy1.rego": module1,
+		"policy2.rego": module2,
+	}
+
+	mappings := map[string]string{
+		"data.a": "data",
+	}
+
+	_, err := New().Move(MoveQuery{
+		Modules:       modules,
+		SrcDstMapping: mappings,
+	}.WithValidation(true))
+	if err == nil {
+		t.Fatal("Expected error but got nil")
+	}
+
+	errMsg := "rego_type_error: conflicting rules named p found"
+	if !strings.Contains(err.Error(), errMsg) {
+		t.Fatalf("Expected error message %v but got %v", errMsg, err.Error())
+	}
+}
+
+func TestMoveBadSourceMapping(t *testing.T) {
+	module := ast.MustParseModule(`package lib.foo
+
+default allow = false
+
+allow {
+        input.message == "hello"
+}`)
+
+	modules := map[string]*ast.Module{
+		"policy.rego": module,
+	}
+
+	mappings := map[string]string{
+		"data.lib.": "data.hidden",
+	}
+
+	_, err := New().Move(MoveQuery{
+		Modules:       modules,
+		SrcDstMapping: mappings,
+	})
+	if err == nil {
+		t.Fatal("Expected error but got nil")
+	}
+
+	mappings = map[string]string{
+		"data.lib": "data.hidden.",
+	}
+
+	_, err = New().Move(MoveQuery{
+		Modules:       modules,
+		SrcDstMapping: mappings,
+	})
+	if err == nil {
+		t.Fatal("Expected error but got nil")
+	}
+}


### PR DESCRIPTION
This commit adds a new command to OPA to implement refactoring
operations over Rego modules. To start a new sub-command has been
added to support renaming package paths and other references.

Fixes: #3290

Signed-off-by: Ashutosh Narkar <anarkar4387@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
