### PR TITLE
Add TLS option to specify CA file

### DIFF
--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -272,6 +272,8 @@ private key is encrypted.
 | `services[_].credentials.client_tls.cert` | `string` | Yes | The path to the client certificate to authenticate with. |
 | `services[_].credentials.client_tls.private_key` | `string` | Yes | The path to the private key of the client certificate. |
 | `services[_].credentials.client_tls.private_key_passphrase` | `string` | No | The passphrase to use for the private key. |
+| `services[_].credentials.client_tls.ca_cert` | `string` | No | The path to the root CA certificate. |
+| `services[_].credentials.client_tls.system_ca_required` | `bool` | No | Require system certificate appended with root CA certificate. |
 
 #### OAuth2 Client Credentials
 


### PR DESCRIPTION
As part of TLS configuration for bundle downloads, we currently have `cert` , `private_key` and `private_key_passphrase` fields for TLS authentication, no option available to specify CA file
Hence added an option `ca_cert` to specify CA file 
Additionally, a separate option `system_ca_required` to determine whether or not to bundle the system certificate pool with the desired CA file

Fixes: #1968
Signed-off-by: Arshad Saquib <arshad.saquib@styra.com>
