### PR TITLE
plugins/discovery: Fix log drop checking flaky test

### DIFF
--- a/plugins/discovery/discovery_test.go
+++ b/plugins/discovery/discovery_test.go
@@ -999,10 +999,6 @@ func TestStatusUpdatesTimestamp(t *testing.T) {
 
 func TestStatusMetricsForLogDrops(t *testing.T) {
 
-	ts := testServer{t: t}
-	ts.Start()
-	defer ts.Stop()
-
 	logLevel := logrus.GetLevel()
 	defer logrus.SetLevel(logLevel)
 
@@ -1013,14 +1009,14 @@ func TestStatusMetricsForLogDrops(t *testing.T) {
 
 	ctx := context.Background()
 
-	manager, err := plugins.New([]byte(fmt.Sprintf(`{
-			"services": {
-				"localhost": {
-					"url": %q
-				}
-			},
-			"discovery": {"name": "config"}
-		}`, ts.server.URL)), "test-id", inmem.New())
+	manager, err := plugins.New([]byte(`{
+		"services": {
+			"localhost": {
+				"url": "http://localhost:9999"
+			}
+		},
+		"discovery": {"name": "config"},
+	}`), "test-id", inmem.New())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1095,7 +1091,7 @@ func TestStatusMetricsForLogDrops(t *testing.T) {
 	// trigger a status update
 	disco.oneShot(ctx, download.Update{ETag: "etag-1", Bundle: makeDataBundle(1, `{
 		"config": {
-			"bundle": {"name": "test1"}
+			"bundles": {"test-bundle": {"service": "localhost"}}
 		}
 	}`)})
 


### PR DESCRIPTION
The test that checks for log drops was utilizing the
test server and would fail sporadically from an unmarshalling
error in the test server.

This change updates the test to not use the test server as
it's not required to meet the goal of the test.

Flaky test run -> https://github.com/open-policy-agent/opa/pull/3358/checks?check_run_id=2296217448#step:3:316  

Signed-off-by: Ashutosh Narkar <anarkar4387@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
