### PR TITLE
Fix typo in bundle example

### DIFF
--- a/cmd/eval.go
+++ b/cmd/eval.go
@@ -178,7 +178,7 @@ Where /some/path contains:
 	  |     |
 	  |     +-- data.json
 	  |
-	  +-- baz_test.rego
+	  +-- baz.rego
 	  |
 	  +-- manifest.yaml
 


### PR DESCRIPTION
Updating `eval` docs to line up with example in bundle docs. The tree structure example included a file called `baz_test.rego`, however the comments below it referred to it as `baz.rego`