### PR TITLE
plugins/status: add plugin support

### DIFF
--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -694,6 +694,7 @@ included in the actual bundle gzipped tarball.
 | `status.service` | `string` | Yes | Name of service to use to contact remote server. |
 | `status.partition_name` | `string` | No | Path segment to include in status updates. |
 | `status.console` | `boolean` | No (default: `false`) | Log the status updates locally to the console. When enabled alongside a remote status update API the `service` must be configured, the default `service` selection will be disabled. |
+| `status.plugin` | `string` | No | Use the named plugin for status updates. If this field exists, the other configuration fields are not required. |
 
 
 ### Decision Logs

--- a/docs/content/management.md
+++ b/docs/content/management.md
@@ -686,6 +686,21 @@ to track **remove** vs **upsert** mask operations.
 }
 ```
 
+### Decision Logs Plugin
+
+If the default decision logging behavior does not work for your use case, you can implement your own plugin to customize decision logging, e.g. use a different transport, transform logs, etc.
+
+```yaml
+decision_logs:
+  plugin: my_decision_logs
+
+plugins:
+  my_decision_logs:
+    some: property 
+```
+
+Check out [this example](extensions#putting-it-together) to learn how to build and register the plugin with OPA.
+
 ## Status
 
 OPA can periodically report status updates to remote HTTP servers. The
@@ -931,6 +946,21 @@ This will dump all status updates to the console. See
 > Warning: Status update messages are somewhat infrequent but can be very verbose! The
 >`metrics.prometheus` portion of the status update in particular can create a considerable
 > amount of log text at info level.
+
+### Status Plugin
+
+If the default status logging behavior does not work for your use case, you can implement your own plugin to customize status logging, e.g. use a different transport, transform logs, etc.
+
+```yaml
+status:
+  plugin: my_status_logs
+
+plugins:
+  my_status_logs:
+    some: property 
+```
+
+Check out [this example](extensions#putting-it-together) for a custom decision logs plugin, and adapt it for the [Logger interface](https://pkg.go.dev/github.com/open-policy-agent/opa/plugins/status#Logger) defined in the status plugin.
 
 ## Discovery
 

--- a/plugins/discovery/discovery.go
+++ b/plugins/discovery/discovery.go
@@ -351,7 +351,7 @@ func getPluginSet(factories map[string]plugins.Factory, manager *plugins.Manager
 		return nil, err
 	}
 
-	statusConfig, err := status.ParseConfig(config.Status, manager.Services())
+	statusConfig, err := status.ParseConfig(config.Status, manager.Services(), pluginNames)
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/logs/plugin_test.go
+++ b/plugins/logs/plugin_test.go
@@ -804,7 +804,7 @@ func TestPluginRateLimitDropCountStatus(t *testing.T) {
 			"console": true,
 		}`))
 
-	config, _ := status.ParseConfig(pluginConfig, fixture.manager.Services())
+	config, _ := status.ParseConfig(pluginConfig, fixture.manager.Services(), nil)
 	p := status.New(config, fixture.manager).WithMetrics(fixture.plugin.metrics)
 
 	fixture.manager.Register(status.Name, p)


### PR DESCRIPTION
Added support for plugins in status plugin, similar to the pattern
employed in the decision logs plugin. By setting `status.plugin`
in configuration, you can override how the status plugin sends status
updates.

Related to #3047

Signed-off-by: Grant Shively <gshively@godaddy.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
