### PR TITLE
refactor: Remove unnecessary reference check

### DIFF
--- a/refactor/refactor.go
+++ b/refactor/refactor.go
@@ -74,12 +74,6 @@ func (r *Refactor) Move(q MoveQuery) (*MoveQueryResult, error) {
 	for _, module := range q.Modules {
 		t := ast.NewGenericTransformer(func(x interface{}) (interface{}, error) {
 			if s, ok := x.(ast.Ref); ok {
-				// exact match
-				if val, found := q.SrcDstMapping[s.String()]; found {
-					return ast.ParseRef(val)
-				}
-
-				// prefix match
 				for k, v := range q.SrcDstMapping {
 					other, err := ast.ParseRef(k)
 					if err != nil {


### PR DESCRIPTION
The policy ref was being compared to a source
ref by using the its string representation. This check is
not required as the prefix check on the ref that follows will
accomplish this w/o the need to convert ref to a string.

Signed-off-by: Ashutosh Narkar <anarkar4387@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
