### PR TITLE
Fix pretty query parameter for v0 API

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -951,7 +951,8 @@ func (s *Server) v0QueryPath(w http.ResponseWriter, r *http.Request, urlPath str
 		return
 	}
 
-	writer.JSON(w, 200, rs[0].Expressions[0].Value, false)
+	pretty := getBoolParam(r.URL, types.ParamPrettyV1, true)
+	writer.JSON(w, 200, rs[0].Expressions[0].Value, pretty)
 }
 
 func (s *Server) getCachedPreparedEvalQuery(key string, m metrics.Metrics) (*rego.PreparedEvalQuery, bool) {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -442,6 +442,17 @@ func TestDataV0(t *testing.T) {
 		input.flag = true
 	}
 	`
+	pretty := `{
+          "p": "hello",
+          "q": {
+            "foo": [
+              1,
+              2,
+              3,
+              4
+            ]
+          }
+        }`
 
 	f := newFixture(t)
 
@@ -455,6 +466,10 @@ func TestDataV0(t *testing.T) {
 
 	if err := f.v0(http.MethodPost, "/data/test/q/foo", `{"flag": true}`, 200, `[1,2,3,4]`); err != nil {
 		t.Fatalf("Expected response [1,2,3,4] but got: %v", err)
+	}
+
+	if err := f.v0(http.MethodPost, "/data/test?pretty=true", `{"flag": true}`, 200, pretty); err != nil {
+		t.Fatalf("Expected response %v but got: %v", pretty, err)
 	}
 
 	req := newReqV0(http.MethodPost, "/data/test/q", "")


### PR DESCRIPTION
This fixes indentation if pretty query parameter is set for v0 API
No major feature modification or changes in method, hence made no change to unit test 

Fixes: #3332
Signed-off-by: Arshad Saquib <arshad.saquib@styra.com>