### PR TITLE
website: link to same page (if possible) from version picker

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -33,7 +33,7 @@ support backwards compatible URLs (from pre-netlify days) and to have the `lates
 version of the docs URLs work
 [openpolicyagent.org/docs/latest](https://openpolicyagent.org/docs/latest) the site
 relies on Netlify URL [redirects and rewrites](https://www.netlify.com/docs/redirects/)
-which are defined in [website/layouts/index.redirects](./webiste/layouts/index.redirects)
+which are defined in [website/layouts/index.redirects](./website/layouts/index.redirects)
 and are build into a `_redirects` file when the Hugo build happens via
 `make production-build` or `make preview-build`.
 
@@ -127,7 +127,7 @@ docker run --rm -it --net=host linkchecker/linkchecker $URL
 Note: You may need to adjust the `URL` (host and/or port) depending on the environment. For OSX
 and Windows the host might need to be `host.docker.internal` instead of `localhost`.
 
-> This link checker will work on best with Netlify previews! Just point it at the preview URL instead of the local server.
+> This link checker will work best with Netlify previews! Just point it at the preview URL instead of the local server.
   The "pretty url" feature seems to work best when deployed, running locally may result in erroneous links.
 
 ## Live Code Blocks

--- a/docs/website/layouts/_default/baseof.html
+++ b/docs/website/layouts/_default/baseof.html
@@ -1,5 +1,5 @@
 {{ $isDoc := eq .Section "docs" }}
-{{ $isHome       := .IsHome }}
+{{ $isHome := .IsHome }}
 {{ if $isHome }}
 {{/*  The homepage layouts/index.html template defines its own <head> content.  */}}
 {{ block "main" . }}

--- a/docs/website/layouts/partials/docs/dashboard-panel.html
+++ b/docs/website/layouts/partials/docs/dashboard-panel.html
@@ -3,6 +3,7 @@
 {{ $releases   := site.Data.releases }}
 {{ $latest     := index $releases 1 }}
 {{ $version    := index (split .File.Path "/") 1 }}
+{{ $page       := trim .RelPermalink "/" }}
 {{ $isLatest   := or (eq $version $latest) (eq $version "latest") }}
 <div class="dashboard-panel left has-background-white-bis is-hidden-mobile">
   <div class="dashboard-panel-header has-text-centered">
@@ -52,7 +53,11 @@
                     {{ if $isLatest }}
                         {{ $verRef = "latest" }}
                     {{ end }}
-                    <a href="/docs/{{ $verRef }}" class="dropdown-item">
+                    {{ $versionedLink := strings.Replace $page $version $verRef }}
+                    {{ if (eq (site.GetPage $versionedLink).Content "") }}
+                        {{ $versionedLink = printf "docs/%s" $verRef }}
+                    {{ end }}
+                    <a href="{{ printf "/%s" $versionedLink }}" class="dropdown-item">
                         {{ . }}
                         {{ if $isLatest }}
                           <span class="tag latest-tag is-success is-small has-text-weight-bold">


### PR DESCRIPTION
This might not be the most efficient or idiomatic way to do it, but
I think it works.

⚠️ Doesn't do in-page anchors, so selecting a different version when on
page /docs/v0.26.0/policy-performance/#benchmarking-queries will get
you to /docs/<other>/policy-performance/ only.

⚠️ Doesn't indicate where the link brings you -- this a UX faux pas, I think, but where possible, I'd think we now meet expectations...

Fixes #3023 to some extend. A little less annoying now, I hope.
