### PR TITLE
refactor: Check for empty constant prefix while renaming ref

### DIFF
--- a/refactor/refactor.go
+++ b/refactor/refactor.go
@@ -93,8 +93,9 @@ func (r *Refactor) Move(q MoveQuery) (*MoveQueryResult, error) {
 					//          mapping: {"data.foo.bar": "data.baz"}
 					// In this scenario, we can relocate data.foo.bar but everything under data.foo
 					// (e.g., data.foo.baz, data.foo.qux, etc.) can't be relocated
-					if other.HasPrefix(s.ConstantPrefix()) {
-						msg := fmt.Sprintf("cannot rewrite `%v`: constant prefix `%v` of `%v` is too short", s, s.ConstantPrefix(), s)
+					r := s.ConstantPrefix()
+					if len(r) != 0 && other.HasPrefix(r) {
+						msg := fmt.Sprintf("cannot rewrite `%v`: constant prefix `%v` of `%v` is too short", s, r, s)
 						x := Error{Message: msg, Location: s[len(s)-1].Loc()}
 						return nil, x
 					}


### PR DESCRIPTION
This commit checks if the constant prefix of the ref is non-empty
before checking if it's a prefix of a source
ref. This is seen for example, when the ref represents a function call.

Signed-off-by: Ashutosh Narkar <anarkar4387@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/main/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/main/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
