### PR TITLE
Expand schema annotation support

### DIFF
--- a/ast/check.go
+++ b/ast/check.go
@@ -131,8 +131,16 @@ func (tc *typeChecker) CheckBody(env *TypeEnv, body Body) (*TypeEnv, Errors) {
 // TypeEnv will be able to resolve types of refs that refer to rules.
 func (tc *typeChecker) CheckTypes(env *TypeEnv, sorted []util.T) (*TypeEnv, Errors) {
 	env = tc.newEnv(env)
+	var as *annotationSet
+	if tc.ss != nil {
+		var errs Errors
+		as, errs = buildAnnotationSet(sorted)
+		if len(errs) > 0 {
+			return env, errs
+		}
+	}
 	for _, s := range sorted {
-		tc.checkRule(env, s.(*Rule))
+		tc.checkRule(env, as, s.(*Rule))
 	}
 	tc.errs.Sort()
 	return env, tc.errs
@@ -166,11 +174,11 @@ func (tc *typeChecker) checkClosures(env *TypeEnv, expr *Expr) Errors {
 	return result
 }
 
-func (tc *typeChecker) checkRule(env *TypeEnv, rule *Rule) {
+func (tc *typeChecker) checkRule(env *TypeEnv, as *annotationSet, rule *Rule) {
 
 	env = env.wrap()
 
-	if schemaAnnots := getRuleAnnotation(rule); schemaAnnots != nil {
+	if schemaAnnots := getRuleAnnotation(as, rule); schemaAnnots != nil {
 		for _, schemaAnnot := range schemaAnnots {
 			ref, refType, err := processAnnotation(tc.ss, schemaAnnot, env, rule)
 			if err != nil {
@@ -1129,29 +1137,32 @@ func getObjectType(ref Ref, o types.Type, rule *Rule, d *types.DynamicProperty) 
 	return getObjectTypeRec(keys, o, d), nil
 }
 
-func getRuleAnnotation(rule *Rule) (result []*SchemaAnnotation) {
-	for _, a := range rule.Module.Annotations {
-		other, ok := a.Node.(*Rule)
-		if !ok {
-			continue
-		}
-		if other == rule {
-			result = append(result, a.Schemas...)
-		}
+func getRuleAnnotation(as *annotationSet, rule *Rule) (result []*SchemaAnnotation) {
+
+	for _, x := range as.GetSubpackagesScope(rule.Module.Package.Path) {
+		result = append(result, x.Schemas...)
 	}
+
+	if x := as.GetPackageScope(rule.Module.Package); x != nil {
+		result = append(result, x.Schemas...)
+	}
+
+	if x := as.GetDocumentScope(rule.Path()); x != nil {
+		result = append(result, x.Schemas...)
+	}
+
+	for _, x := range as.GetRuleScope(rule) {
+		result = append(result, x.Schemas...)
+	}
+
 	return result
 }
 
-// NOTE: Currently, annotations must preceed the rule. In the future, this
-// restriction could be relaxed with other kinds of annotation scopes.
 func processAnnotation(ss *SchemaSet, annot *SchemaAnnotation, env *TypeEnv, rule *Rule) (Ref, types.Type, *Error) {
-	if ss == nil {
-		return nil, nil, NewError(TypeErr, rule.Location, "schemas need to be supplied for the annotation: %s", annot.Schema)
-	}
 
 	schema := ss.Get(annot.Schema)
 	if schema == nil {
-		return nil, nil, NewError(TypeErr, rule.Location, "schema does not exist for given path in annotation: %s", annot.Schema)
+		return nil, nil, NewError(TypeErr, rule.Location, "undefined schema: %v", annot.Schema)
 	}
 
 	tpe, err := loadSchema(schema)
@@ -1160,4 +1171,163 @@ func processAnnotation(ss *SchemaSet, annot *SchemaAnnotation, env *TypeEnv, rul
 	}
 
 	return annot.Path, tpe, nil
+}
+
+func errAnnotationRedeclared(a *Annotations, other *Location) *Error {
+	return NewError(TypeErr, a.Location, "%v annotation redeclared: %v", a.Scope, other)
+}
+
+type annotationSet struct {
+	byRule    map[*Rule][]*Annotations
+	byPackage map[*Package]*Annotations
+	byPath    *annotationTreeNode
+}
+
+func buildAnnotationSet(rules []util.T) (*annotationSet, Errors) {
+	as := newAnnotationSet()
+	processed := map[*Module]struct{}{}
+	var errs Errors
+	for _, x := range rules {
+		module := x.(*Rule).Module
+		if _, ok := processed[module]; ok {
+			continue
+		}
+		processed[module] = struct{}{}
+		for _, a := range module.Annotations {
+			if err := as.Add(a); err != nil {
+				errs = append(errs, err)
+			}
+		}
+	}
+	if len(errs) > 0 {
+		return nil, errs
+	}
+	return as, nil
+}
+
+func newAnnotationSet() *annotationSet {
+	return &annotationSet{
+		byRule:    map[*Rule][]*Annotations{},
+		byPackage: map[*Package]*Annotations{},
+		byPath:    newAnnotationTree(),
+	}
+}
+
+func (as *annotationSet) Add(a *Annotations) *Error {
+	switch a.Scope {
+	case annotationScopeRule:
+		rule := a.Node.(*Rule)
+		as.byRule[rule] = append(as.byRule[rule], a)
+	case annotationScopePackage:
+		pkg := a.Node.(*Package)
+		if exist, ok := as.byPackage[pkg]; ok {
+			return errAnnotationRedeclared(a, exist.Location)
+		}
+		as.byPackage[pkg] = a
+	case annotationScopeDocument:
+		rule := a.Node.(*Rule)
+		path := rule.Path()
+		x := as.byPath.Get(path)
+		if x != nil {
+			return errAnnotationRedeclared(a, x.Value.Location)
+		}
+		as.byPath.Insert(path, a)
+	case annotationScopeSubpackages:
+		pkg := a.Node.(*Package)
+		x := as.byPath.Get(pkg.Path)
+		if x != nil {
+			return errAnnotationRedeclared(a, x.Value.Location)
+		}
+		as.byPath.Insert(pkg.Path, a)
+	}
+	return nil
+}
+
+func (as *annotationSet) GetRuleScope(r *Rule) []*Annotations {
+	if as == nil {
+		return nil
+	}
+	return as.byRule[r]
+}
+
+func (as *annotationSet) GetSubpackagesScope(path Ref) []*Annotations {
+	if as == nil {
+		return nil
+	}
+	return as.byPath.Ancestors(path)
+}
+
+func (as *annotationSet) GetDocumentScope(path Ref) *Annotations {
+	if as == nil {
+		return nil
+	}
+	if node := as.byPath.Get(path); node != nil {
+		return node.Value
+	}
+	return nil
+}
+
+func (as *annotationSet) GetPackageScope(pkg *Package) *Annotations {
+	if as == nil {
+		return nil
+	}
+	return as.byPackage[pkg]
+}
+
+type annotationTreeNode struct {
+	Value    *Annotations
+	Children map[Value]*annotationTreeNode // we assume key elements are hashable (vars and strings only!)
+}
+
+func newAnnotationTree() *annotationTreeNode {
+	return &annotationTreeNode{
+		Value:    nil,
+		Children: map[Value]*annotationTreeNode{},
+	}
+}
+
+func (t *annotationTreeNode) Insert(path Ref, value *Annotations) {
+	node := t
+	for _, k := range path {
+		child, ok := node.Children[k.Value]
+		if !ok {
+			child = newAnnotationTree()
+			node.Children[k.Value] = child
+		}
+		node = child
+	}
+	node.Value = value
+}
+
+func (t *annotationTreeNode) Get(path Ref) *annotationTreeNode {
+	node := t
+	for _, k := range path {
+		if node == nil {
+			return nil
+		}
+		child, ok := node.Children[k.Value]
+		if !ok {
+			return nil
+		}
+		node = child
+	}
+	return node
+}
+
+func (t *annotationTreeNode) Ancestors(path Ref) (result []*Annotations) {
+	node := t
+	for _, k := range path {
+		if node == nil {
+			return result
+		}
+		child, ok := node.Children[k.Value]
+		if !ok {
+			return result
+		}
+		if child.Value != nil {
+			result = append(result, child.Value)
+		}
+		node = child
+	}
+	return result
 }

--- a/ast/check.go
+++ b/ast/check.go
@@ -1222,16 +1222,16 @@ func newAnnotationSet() *annotationSet {
 func (as *annotationSet) Add(a *Annotations) *Error {
 	switch a.Scope {
 	case annotationScopeRule:
-		rule := a.Node.(*Rule)
+		rule := a.node.(*Rule)
 		as.byRule[rule] = append(as.byRule[rule], a)
 	case annotationScopePackage:
-		pkg := a.Node.(*Package)
+		pkg := a.node.(*Package)
 		if exist, ok := as.byPackage[pkg]; ok {
 			return errAnnotationRedeclared(a, exist.Location)
 		}
 		as.byPackage[pkg] = a
 	case annotationScopeDocument:
-		rule := a.Node.(*Rule)
+		rule := a.node.(*Rule)
 		path := rule.Path()
 		x := as.byPath.Get(path)
 		if x != nil {
@@ -1239,7 +1239,7 @@ func (as *annotationSet) Add(a *Annotations) *Error {
 		}
 		as.byPath.Insert(path, a)
 	case annotationScopeSubpackages:
-		pkg := a.Node.(*Package)
+		pkg := a.node.(*Package)
 		x := as.byPath.Get(pkg.Path)
 		if x != nil {
 			return errAnnotationRedeclared(a, x.Value.Location)

--- a/ast/check.go
+++ b/ast/check.go
@@ -1160,9 +1160,15 @@ func getRuleAnnotation(as *annotationSet, rule *Rule) (result []*SchemaAnnotatio
 
 func processAnnotation(ss *SchemaSet, annot *SchemaAnnotation, env *TypeEnv, rule *Rule) (Ref, types.Type, *Error) {
 
-	schema := ss.Get(annot.Schema)
-	if schema == nil {
-		return nil, nil, NewError(TypeErr, rule.Location, "undefined schema: %v", annot.Schema)
+	var schema interface{}
+
+	if annot.Schema != nil {
+		schema = ss.Get(annot.Schema)
+		if schema == nil {
+			return nil, nil, NewError(TypeErr, rule.Location, "undefined schema: %v", annot.Schema)
+		}
+	} else if annot.Definition != nil {
+		schema = *annot.Definition
 	}
 
 	tpe, err := loadSchema(schema)

--- a/ast/check_test.go
+++ b/ast/check_test.go
@@ -1889,6 +1889,14 @@ package test
 # schemas:
 # - input: schema.number
 p { input = 7 }`},
+
+		{note: "inline definition", err: "test.rego:7: rego_type_error: match error", module: `package test
+
+# METADATA
+# scope: rule
+# schemas:
+# - input: {"type": "string"}
+p { input = 7 }`},
 	}
 
 	for _, tc := range tests {

--- a/ast/check_test.go
+++ b/ast/check_test.go
@@ -1451,57 +1451,6 @@ whocan[user] {
 		access[_] == input.operation
 }`
 
-	module5 := `
-package policy
-
-import data.acl
-import input
-
-default allow = false
-
-# METADATA
-# scope: rule
-# schemas:
-#   - badref: schema["whocan-input-schema"]
-whocan[user] {
-		access = acl[user]
-		access[_] == input.operation
-}`
-
-	module6 := `
-package policy
-
-import data.acl
-import input
-
-default allow = false
-
-# METADATA
-# scope: rule
-# schemas:
-#   - data/acl: schema/acl-schema
-whocan[user] {
-		access = acl[user]
-		access[_] == input.operation
-}`
-
-	module7 := `
-package policy
-
-import data.acl
-import input
-
-default allow = false
-
-# METADATA
-# scope: rule
-# schemas:
-#   - input= schema["whocan-input-schema"]
-whocan[user] {
-		access = acl[user]
-		access[_] == input.operation
-}`
-
 	module8 := `
 package policy
 
@@ -1821,9 +1770,6 @@ whocan[user] {
 		"correct data override":                                                           {module: module2, schemaSet: schemaSet},
 		"incorrect data override":                                                         {module: module3, schemaSet: schemaSet, err: "undefined ref: input.user"},
 		"schema not exist in annotation path":                                             {module: module4, schemaSet: schemaSet, err: "schema does not exist for given path in annotation"},
-		"non ref in annotation":                                                           {module: module5, schemaSet: schemaSet, err: "expected ref but got"},
-		"Ill-structured annotation with bad path":                                         {module: module6, schemaSet: schemaSet, err: "schema is not well formed in annotation"},
-		"Ill-structured (invalid) annotation":                                             {module: module7, schemaSet: schemaSet, err: "unable to unmarshall the metadata yaml in comment"},
 		"empty schema set":                                                                {module: module1, schemaSet: nil, err: "schemas need to be supplied for the annotation"},
 		"overriding ref with length greater than one and not existing":                    {module: module8, schemaSet: schemaSet, err: "undefined ref: input.apple.banana"},
 		"overriding ref with length greater than one and existing prefix":                 {module: module9, schemaSet: schemaSet},

--- a/ast/check_test.go
+++ b/ast/check_test.go
@@ -1897,6 +1897,15 @@ p { input = 7 }`},
 # schemas:
 # - input: {"type": "string"}
 p { input = 7 }`},
+		{note: "document scope is unordered", err: "test.rego:3: rego_type_error: match error", module: `package test
+
+p { input = 7 }
+
+# METADATA
+# scope: document
+# schemas:
+# - input: schema.string
+p { input = "foo" }`},
 	}
 
 	for _, tc := range tests {

--- a/ast/compare.go
+++ b/ast/compare.go
@@ -192,6 +192,9 @@ func Compare(a, b interface{}) int {
 	case *Package:
 		b := b.(*Package)
 		return a.Compare(b)
+	case *Annotations:
+		b := b.(*Annotations)
+		return a.Compare(b)
 	case *Module:
 		b := b.(*Module)
 		return a.Compare(b)
@@ -251,6 +254,8 @@ func sortOrder(x interface{}) int {
 		return 1001
 	case *Package:
 		return 1002
+	case *Annotations:
+		return 1003
 	case *Module:
 		return 10000
 	}
@@ -258,6 +263,25 @@ func sortOrder(x interface{}) int {
 }
 
 func importsCompare(a, b []*Import) int {
+	minLen := len(a)
+	if len(b) < minLen {
+		minLen = len(b)
+	}
+	for i := 0; i < minLen; i++ {
+		if cmp := a[i].Compare(b[i]); cmp != 0 {
+			return cmp
+		}
+	}
+	if len(a) < len(b) {
+		return -1
+	}
+	if len(b) < len(a) {
+		return 1
+	}
+	return 0
+}
+
+func annotationsCompare(a, b []*Annotations) int {
 	minLen := len(a)
 	if len(b) < minLen {
 		minLen = len(b)

--- a/ast/compare_test.go
+++ b/ast/compare_test.go
@@ -4,7 +4,9 @@
 
 package ast
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestCompare(t *testing.T) {
 
@@ -96,5 +98,215 @@ import input.x.z`)
 
 	if result != -1 {
 		t.Errorf("Expected %v to be less than %v but got: %v", a, b, result)
+	}
+
+	var err error
+
+	a, err = ParseModuleWithOpts("test.rego", `package a
+
+# METADATA
+# scope: rule
+# schemas:
+# - input: schema.a
+p := 7`, ParserOptions{ProcessAnnotation: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	b, err = ParseModuleWithOpts("test.rego", `package a
+
+# METADATA
+# scope: rule
+# schemas:
+# - input: schema.b
+p := 7`, ParserOptions{ProcessAnnotation: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result = Compare(a, b)
+
+	if result != -1 {
+		t.Errorf("Expected %v to be less than %v but got: %v", a, b, result)
+	}
+}
+
+func TestCompareAnnotations(t *testing.T) {
+
+	tests := []struct {
+		note string
+		a    string
+		b    string
+		exp  int
+	}{
+		{
+			note: "same",
+			a: `
+# METADATA
+# scope: a`,
+			b: `
+# METADATA
+# scope: a`,
+			exp: 0,
+		},
+		{
+			note: "unknown scope",
+			a: `
+# METADATA
+# scope: rule`,
+			b: `
+# METADATA
+# scope: a`,
+			exp: 1,
+		},
+		{
+			note: "unknown scope - less than",
+			a: `
+# METADATA
+# scope: a`,
+			b: `
+# METADATA
+# scope: rule`,
+			exp: -1,
+		},
+		{
+			note: "unknown scope - greater than - lexigraphical",
+			a: `
+# METADATA
+# scope: b`,
+			b: `
+# METADATA
+# scope: a`,
+			exp: 1,
+		},
+		{
+			note: "unknown scope - less than - lexigraphical",
+			a: `
+# METADATA
+# scope: b`,
+			b: `
+# METADATA
+# scope: c`,
+			exp: -1,
+		},
+		{
+			note: "schema",
+			a: `
+# METADATA
+# scope: rule
+# schemas:
+# - input: schema`,
+			b: `
+# METADATA
+# scope: rule
+# schemas:
+# - input: schema`,
+			exp: 0,
+		},
+		{
+			note: "schema - less than",
+			a: `
+# METADATA
+# scope: rule
+# schemas:
+# - input.a: schema`,
+			b: `
+# METADATA
+# scope: rule
+# schemas:
+# - input.b: schema`,
+			exp: -1,
+		},
+		{
+			note: "schema - greater than",
+			a: `
+# METADATA
+# scope: rule
+# schemas:
+# - input.b: schema`,
+			b: `
+# METADATA
+# scope: rule
+# schemas:
+# - input.a: schema`,
+			exp: 1,
+		},
+		{
+			note: "schema - less than (fewer)",
+			a: `
+# METADATA
+# scope: rule
+# schemas:
+# - input.a: schema`,
+			b: `
+# METADATA
+# scope: rule
+# schemas:
+# - input.a: schema
+# - input.b: schema`,
+			exp: -1,
+		},
+		{
+			note: "schema - greater than (more)",
+			a: `
+# METADATA
+# scope: rule
+# schemas:
+# - input.a: schema
+# - input.b: schema`,
+			b: `
+# METADATA
+# scope: rule
+# schemas:
+# - input.a: schema`,
+			exp: 1,
+		},
+		{
+			note: "schema - less than - lexigraphical",
+			a: `
+# METADATA
+# scope: rule
+# schemas:
+# - input: schema.a`,
+			b: `
+# METADATA
+# scope: rule
+# schemas:
+# - input: schema.b`,
+			exp: -1,
+		},
+		{
+			note: "schema - greater than - lexigraphical",
+			a: `
+# METADATA
+# scope: rule
+# schemas:
+# - input: schema.c`,
+			b: `
+# METADATA
+# scope: rule
+# schemas:
+# - input: schema.b`,
+			exp: 1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.note, func(t *testing.T) {
+			stmts, _, err := ParseStatementsWithOpts("test.rego", tc.a, ParserOptions{ProcessAnnotation: true})
+			if err != nil {
+				t.Fatal(err)
+			}
+			a := stmts[0].(*Annotations)
+			stmts, _, err = ParseStatementsWithOpts("test.rego", tc.b, ParserOptions{ProcessAnnotation: true})
+			if err != nil {
+				t.Fatal(err)
+			}
+			b := stmts[0].(*Annotations)
+			result := a.Compare(b)
+			if result != tc.exp {
+				t.Fatalf("Expected %d but got %v for %v and %v", tc.exp, result, a, b)
+			}
+		})
 	}
 }

--- a/ast/compare_test.go
+++ b/ast/compare_test.go
@@ -289,6 +289,41 @@ func TestCompareAnnotations(t *testing.T) {
 # - input: schema.b`,
 			exp: 1,
 		},
+		{
+			note: "definition",
+			a: `
+# METADATA
+# schemas:
+# - input: {"type": "string"}`,
+			b: `
+# METADATA
+# schemas:
+# - input: {"type": "string"}`,
+		},
+		{
+			note: "definition - less than schema",
+			a: `
+# METADATA
+# schemas:
+# - input: {"type": "string"}`,
+			b: `
+# METADATA
+# schemas:
+# - input: schema.a`,
+			exp: -1,
+		},
+		{
+			note: "schema - greater than definition",
+			a: `
+# METADATA
+# schemas:
+# - input: schema.a`,
+			b: `
+# METADATA
+# schemas:
+# - input: {"type": "string"}`,
+			exp: 1,
+		},
 	}
 
 	for _, tc := range tests {

--- a/ast/parser.go
+++ b/ast/parser.go
@@ -94,7 +94,11 @@ func (p *Parser) WithProcessAnnotation(processAnnotation bool) *Parser {
 }
 
 const (
-	annotationScopeRule = "rule"
+	annotationScopePackage     = "package"
+	annotationScopeImport      = "import"
+	annotationScopeRule        = "rule"
+	annotationScopeDocument    = "document"
+	annotationScopeSubpackages = "subpackages"
 )
 
 // Parse will read the Rego source and parse statements and

--- a/ast/parser.go
+++ b/ast/parser.go
@@ -5,11 +5,11 @@
 package ast
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
 	"math/big"
-	"strings"
 
 	"gopkg.in/yaml.v2"
 
@@ -93,75 +93,19 @@ func (p *Parser) WithProcessAnnotation(processAnnotation bool) *Parser {
 	return p
 }
 
-const metadata = "METADATA"
-const ruleScope = "rule"
-
-// Metadata is used to unmarshal the policy metadata information
-type Metadata struct {
-	Scope   string              `yaml:"scope"`
-	Schemas []map[string]string `yaml:"schemas"`
-}
-
-// getAnnotation returns annotations in the comment if any
-func (p *Parser) getAnnotation(rule *Rule, endYamlLine int) (Annotations, error) {
-	var metadataYaml []byte
-	var startYamlLine, currentYamlLine, prevYamlLine int
-	for i := 0; i < len(p.s.comments); i++ {
-		comment := p.s.comments[i]
-		currentYamlLine = comment.Location.Row
-		if currentYamlLine > endYamlLine { //comment comes after the rule - not relevant
-			break
-		}
-
-		if currentYamlLine != (prevYamlLine + 1) { //comment not part of the same block - not relevant
-			startYamlLine = 0
-			metadataYaml = nil
-		}
-
-		if strings.HasPrefix((strings.TrimSpace(string(comment.Text))), metadata) && comment.Location.Col == 1 { // found METADATA signalling start in a block comment
-			startYamlLine = currentYamlLine + 1
-			metadataYaml = make([]byte, 0)
-		}
-
-		if startYamlLine != 0 && currentYamlLine >= startYamlLine && currentYamlLine <= endYamlLine && comment.Location.Col == 1 { //build yaml content from block comment only
-			metadataYaml = append(metadataYaml, comment.Text...)
-			metadataYaml = append(metadataYaml, []byte("\n")...)
-		}
-		prevYamlLine = currentYamlLine
-	}
-
-	if prevYamlLine == endYamlLine && len(metadataYaml) > 0 {
-		metadata := &Metadata{}
-		err := yaml.Unmarshal(metadataYaml, metadata)
-		if err != nil {
-			return nil, fmt.Errorf("unable to unmarshall the metadata yaml in comment")
-		}
-
-		if metadata.Scope == ruleScope && metadata.Schemas != nil {
-			var sannot []SchemaAnnotation
-			for _, schemas := range metadata.Schemas {
-				for path, schema := range schemas {
-					sannot = append(sannot, SchemaAnnotation{Path: path, Schema: schema})
-				}
-			}
-			return &SchemaAnnotations{SchemaAnnotation: sannot,
-				Scope: ruleScope,
-				Rule:  rule}, nil
-		}
-	}
-	return nil, nil
-
-}
+const (
+	annotationScopeRule = "rule"
+)
 
 // Parse will read the Rego source and parse statements and
 // comments as they are found. Any errors encountered while
 // parsing will be accumulated and returned as a list of Errors.
-func (p *Parser) Parse() ([]Statement, []*Comment, []Annotations, Errors) {
+func (p *Parser) Parse() ([]Statement, []*Comment, Errors) {
 
 	var err error
 	p.s.s, err = scanner.New(p.r)
 	if err != nil {
-		return nil, nil, nil, Errors{
+		return nil, nil, Errors{
 			&Error{
 				Code:     ParseErr,
 				Message:  err.Error(),
@@ -174,7 +118,6 @@ func (p *Parser) Parse() ([]Statement, []*Comment, []Annotations, Errors) {
 	p.scan()
 
 	var stmts []Statement
-	var annotations []Annotations
 
 	// Read from the scanner until the last token is reached or no statements
 	// can be parsed. Attempt to parse package statements, import statements,
@@ -209,17 +152,6 @@ func (p *Parser) Parse() ([]Statement, []*Comment, []Annotations, Errors) {
 		if rules := p.parseRules(); rules != nil {
 			for i := range rules {
 				stmts = append(stmts, rules[i])
-				// Append schema annotation to rule if there is one, and if processAnnotation option is on
-				if p.po.ProcessAnnotation {
-					ruleLoc := rules[i].Location.Row
-					annot, err := p.getAnnotation(rules[i], ruleLoc-1)
-					if err != nil {
-						p.error(rules[i].Location, err.Error())
-					}
-					if annot != nil {
-						annotations = append(annotations, annot)
-					}
-				}
 			}
 			continue
 		} else if len(p.s.errors) > 0 {
@@ -237,7 +169,43 @@ func (p *Parser) Parse() ([]Statement, []*Comment, []Annotations, Errors) {
 		break
 	}
 
-	return stmts, p.s.comments, annotations, p.s.errors
+	if p.po.ProcessAnnotation {
+		stmts = p.parseAnnotations(stmts)
+	}
+
+	return stmts, p.s.comments, p.s.errors
+}
+
+func (p *Parser) parseAnnotations(stmts []Statement) []Statement {
+
+	var hint = []byte("METADATA")
+	var curr *metadataParser
+	var blocks []*metadataParser
+
+	for i := 0; i < len(p.s.comments); i++ {
+		if curr != nil {
+			if p.s.comments[i].Location.Row == p.s.comments[i-1].Location.Row+1 && p.s.comments[i].Location.Col == 1 {
+				curr.Append(p.s.comments[i])
+				continue
+			}
+			curr = nil
+		}
+		if bytes.HasPrefix(bytes.TrimSpace(p.s.comments[i].Text), hint) {
+			curr = newMetadataParser(p.s.comments[i].Location)
+			blocks = append(blocks, curr)
+		}
+	}
+
+	for _, b := range blocks {
+		a, err := b.Parse()
+		if err != nil {
+			p.error(b.loc, err.Error())
+		} else {
+			stmts = append(stmts, a)
+		}
+	}
+
+	return stmts
 }
 
 func (p *Parser) parsePackage() *Package {
@@ -1584,4 +1552,85 @@ func (p *Parser) validateDefaultRuleValue(rule *Rule) bool {
 
 	vis.Walk(rule.Head.Value.Value)
 	return valid
+}
+
+type rawAnnotation struct {
+	Scope   string                `json:"scope"`
+	Schemas []rawSchemaAnnotation `json:"schemas"`
+}
+
+type rawSchemaAnnotation map[string]string
+
+type metadataParser struct {
+	buf *bytes.Buffer
+	loc *location.Location
+}
+
+func newMetadataParser(loc *Location) *metadataParser {
+	return &metadataParser{loc: loc, buf: bytes.NewBuffer(nil)}
+}
+
+func (b *metadataParser) Append(c *Comment) {
+	b.buf.Write(bytes.TrimPrefix(c.Text, []byte(" ")))
+	b.buf.WriteByte('\n')
+}
+
+func (b *metadataParser) Parse() (*Annotations, error) {
+
+	var raw rawAnnotation
+
+	if len(bytes.TrimSpace(b.buf.Bytes())) == 0 {
+		return nil, fmt.Errorf("expected METADATA block, found whitespace")
+	}
+
+	// TODO(tsandall): how to improve locations of errors? The YAML parser
+	// doesn't include line numbers in the error API.
+	if err := yaml.Unmarshal(b.buf.Bytes(), &raw); err != nil {
+		return nil, err
+	}
+
+	var result Annotations
+	result.Scope = raw.Scope
+
+	for _, pair := range raw.Schemas {
+		var k, v string
+		for k, v = range pair {
+		}
+		kr, err := ParseRef(k)
+		if err != nil {
+			return nil, fmt.Errorf("invalid document reference")
+		}
+		vr, err := parseSchemaRef(v)
+		if err != nil {
+			return nil, err
+		}
+		result.Schemas = append(result.Schemas, &SchemaAnnotation{
+			Path:   kr,
+			Schema: vr,
+		})
+	}
+
+	result.Location = b.loc
+	return &result, nil
+}
+
+var errInvalidSchemaRef = fmt.Errorf("invalid schema reference")
+
+func parseSchemaRef(s string) (Ref, error) {
+
+	term, err := ParseTerm(s)
+	if err == nil {
+		switch v := term.Value.(type) {
+		case Var:
+			if term.Equal(SchemaRootDocument) {
+				return SchemaRootRef.Copy(), nil
+			}
+		case Ref:
+			if v.HasPrefix(SchemaRootRef) {
+				return v, nil
+			}
+		}
+	}
+
+	return nil, errInvalidSchemaRef
 }

--- a/ast/parser.go
+++ b/ast/parser.go
@@ -1616,6 +1616,9 @@ func (b *metadataParser) Parse() (*Annotations, error) {
 
 var errInvalidSchemaRef = fmt.Errorf("invalid schema reference")
 
+// NOTE(tsandall): 'schema' is not registered as a root because it's not
+// supported by the compiler or evaluator today. Once we fix that, we can remove
+// this function.
 func parseSchemaRef(s string) (Ref, error) {
 
 	term, err := ParseTerm(s)

--- a/ast/parser_ext.go
+++ b/ast/parser_ext.go
@@ -691,19 +691,23 @@ func validateAnnotationScopeAttachment(a *Annotations) *Error {
 		if _, ok := a.node.(*Rule); ok {
 			return nil
 		}
-		return newScopeAttachmentErr(a)
+		return newScopeAttachmentErr(a, "rule")
 	case annotationScopePackage, annotationScopeSubpackages:
 		if _, ok := a.node.(*Package); ok {
 			return nil
 		}
-		return newScopeAttachmentErr(a)
+		return newScopeAttachmentErr(a, "package")
 	}
 
 	return NewError(ParseErr, a.Loc(), "invalid annotation scope '%v'", a.Scope)
 }
 
-func newScopeAttachmentErr(a *Annotations) *Error {
-	return NewError(ParseErr, a.Loc(), "annotation scope '%v' cannot be applied to %v statement", a.Scope, TypeName(a.node))
+func newScopeAttachmentErr(a *Annotations, want string) *Error {
+	var have string
+	if a.node != nil {
+		have = fmt.Sprintf(" (have %v)", TypeName(a.node))
+	}
+	return NewError(ParseErr, a.Loc(), "annotation scope '%v' must be applied to %v%v", a.Scope, want, have)
 }
 
 func setRuleModule(rule *Rule, module *Module) {

--- a/ast/parser_ext.go
+++ b/ast/parser_ext.go
@@ -655,14 +655,14 @@ func parseModule(filename string, stmts []Statement, comments []*Comment) (*Modu
 			_, ok := stmt.(*Annotations)
 			if !ok {
 				if stmt.Loc().Row > a.Location.Row {
-					a.Node = stmt
+					a.node = stmt
 					break
 				}
 			}
 		}
 
 		if a.Scope == "" {
-			switch a.Node.(type) {
+			switch a.node.(type) {
 			case *Rule:
 				a.Scope = annotationScopeRule
 			case *Package:
@@ -688,12 +688,12 @@ func validateAnnotationScopeAttachment(a *Annotations) *Error {
 
 	switch a.Scope {
 	case annotationScopeRule, annotationScopeDocument:
-		if _, ok := a.Node.(*Rule); ok {
+		if _, ok := a.node.(*Rule); ok {
 			return nil
 		}
 		return newScopeAttachmentErr(a)
 	case annotationScopePackage, annotationScopeSubpackages:
-		if _, ok := a.Node.(*Package); ok {
+		if _, ok := a.node.(*Package); ok {
 			return nil
 		}
 		return newScopeAttachmentErr(a)
@@ -703,7 +703,7 @@ func validateAnnotationScopeAttachment(a *Annotations) *Error {
 }
 
 func newScopeAttachmentErr(a *Annotations) *Error {
-	return NewError(ParseErr, a.Loc(), "annotation scope '%v' cannot be applied to %v statement", a.Scope, TypeName(a.Node))
+	return NewError(ParseErr, a.Loc(), "annotation scope '%v' cannot be applied to %v statement", a.Scope, TypeName(a.node))
 }
 
 func setRuleModule(rule *Rule, module *Module) {

--- a/ast/parser_test.go
+++ b/ast/parser_test.go
@@ -2672,6 +2672,11 @@ func TestAnnotations(t *testing.T) {
 	schemaNetworks := MustParseRef("schema.networks")
 	schemaPorts := MustParseRef("schema.ports")
 
+	stringSchemaAsMap := map[string]interface{}{
+		"type": "string",
+	}
+	var stringSchema interface{} = stringSchemaAsMap
+
 	tests := []struct {
 		note           string
 		module         string
@@ -3073,6 +3078,24 @@ import data.foo.bar`,
 # scope: package
 import data.foo`,
 			expError: "test.rego:2: rego_parse_error: annotation scope 'package' cannot be applied to import statement",
+		},
+		{
+			note: "Inline schema definition",
+			module: `package test
+
+# METADATA
+# schemas:
+# - input: {"type": "string"}
+p { input = "str" }`,
+			expNumComments: 3,
+			expAnnotations: []*Annotations{
+				&Annotations{
+					Schemas: []*SchemaAnnotation{
+						{Path: InputRootRef, Definition: &stringSchema},
+					},
+					Scope: annotationScopeRule,
+				},
+			},
 		},
 	}
 

--- a/ast/parser_test.go
+++ b/ast/parser_test.go
@@ -3023,6 +3023,57 @@ p := 7`,
 				{Scope: annotationScopeRule},
 			},
 		},
+		{
+			note: "Default rule scope",
+			module: `
+package test
+
+# METADATA
+# {}
+p := 7`,
+			expNumComments: 2,
+			expAnnotations: []*Annotations{
+				{Scope: annotationScopeRule},
+			},
+		},
+		{
+			note: "Unknown scope",
+			module: `
+package test
+
+# METADATA
+# scope: deadbeef
+p := 7`,
+			expNumComments: 2,
+			expError:       "invalid annotation scope 'deadbeef'",
+		},
+		{
+			note: "Invalid rule scope/attachment",
+			module: `
+# METADATA
+# scope: rule
+package test
+
+p := 7`,
+			expNumComments: 2,
+			expError:       "annotation scope 'rule' cannot be applied to package statement",
+		},
+		{
+			note: "Scope attachment error: document on import",
+			module: `package test
+# METADATA
+# scope: document
+import data.foo.bar`,
+			expError: "test.rego:2: rego_parse_error: annotation scope 'document' cannot be applied to import statement",
+		},
+		{
+			note: "Scope attachment error: package on non-package",
+			module: `package test
+# METADATA
+# scope: package
+import data.foo`,
+			expError: "test.rego:2: rego_parse_error: annotation scope 'package' cannot be applied to import statement",
+		},
 	}
 
 	for _, tc := range tests {

--- a/ast/parser_test.go
+++ b/ast/parser_test.go
@@ -2832,7 +2832,7 @@ public_servers[server] {
 	ports[k].networks[l] = networks[m].id;
 	networks[m].public = true
 }`,
-			expError: "rego_parse_error: yaml: line 7: could not find expected ':'",
+			expError: "test.rego:14: rego_parse_error: yaml: line 7: could not find expected ':'",
 		},
 		{
 			note: "Ill-structured (invalid) annotation document path",

--- a/ast/parser_test.go
+++ b/ast/parser_test.go
@@ -3061,7 +3061,7 @@ package test
 
 p := 7`,
 			expNumComments: 2,
-			expError:       "annotation scope 'rule' cannot be applied to package statement",
+			expError:       "test.rego:2: rego_parse_error: annotation scope 'rule' must be applied to rule (have package)",
 		},
 		{
 			note: "Scope attachment error: document on import",
@@ -3069,7 +3069,15 @@ p := 7`,
 # METADATA
 # scope: document
 import data.foo.bar`,
-			expError: "test.rego:2: rego_parse_error: annotation scope 'document' cannot be applied to import statement",
+			expError: "test.rego:2: rego_parse_error: annotation scope 'document' must be applied to rule (have import)",
+		},
+		{
+			note: "Scope attachment error: unattached",
+			module: `package test
+
+# METADATA
+# scope: package`,
+			expError: "test.rego:3: rego_parse_error: annotation scope 'package' must be applied to package",
 		},
 		{
 			note: "Scope attachment error: package on non-package",
@@ -3077,7 +3085,7 @@ import data.foo.bar`,
 # METADATA
 # scope: package
 import data.foo`,
-			expError: "test.rego:2: rego_parse_error: annotation scope 'package' cannot be applied to import statement",
+			expError: "test.rego:2: rego_parse_error: annotation scope 'package' must be applied to package (have import)",
 		},
 		{
 			note: "Inline schema definition",

--- a/ast/parser_test.go
+++ b/ast/parser_test.go
@@ -2992,7 +2992,7 @@ public_servers_1[server] {
 						{Path: dataServers, Schema: schemaServers},
 					},
 					Scope: annotationScopeRule,
-					Node:  MustParseRule(`public_servers[server] { server = servers[i] }`),
+					node:  MustParseRule(`public_servers[server] { server = servers[i] }`),
 				},
 				&Annotations{
 					Schemas: []*SchemaAnnotation{
@@ -3001,7 +3001,7 @@ public_servers_1[server] {
 						{Path: dataPorts, Schema: schemaPorts},
 					},
 					Scope: annotationScopeRule,
-					Node:  MustParseRule(`public_servers_1[server] { ports[k].networks[l] = networks[m].id; networks[m].public = true }`),
+					node:  MustParseRule(`public_servers_1[server] { ports[k].networks[l] = networks[m].id; networks[m].public = true }`),
 				},
 			},
 		},

--- a/ast/policy.go
+++ b/ast/policy.go
@@ -305,6 +305,11 @@ func (s *SchemaAnnotation) Compare(other *SchemaAnnotation) int {
 	return 0
 }
 
+func (s *SchemaAnnotation) String() string {
+	bs, _ := json.Marshal(s)
+	return string(bs)
+}
+
 func scopeCompare(s1, s2 string) int {
 
 	o1 := scopeOrder(s1)

--- a/ast/policy.go
+++ b/ast/policy.go
@@ -154,8 +154,9 @@ type (
 
 	// SchemaAnnotation contains a schema declaration for the document identified by the path.
 	SchemaAnnotation struct {
-		Path   Ref `json:"path"`
-		Schema Ref `json:"schema"`
+		Path       Ref          `json:"path"`
+		Schema     Ref          `json:"schema,omitempty"`
+		Definition *interface{} `json:"definition,omitempty"`
 	}
 
 	// Package represents the namespace of the documents produced
@@ -300,6 +301,14 @@ func (s *SchemaAnnotation) Compare(other *SchemaAnnotation) int {
 
 	if cmp := s.Schema.Compare(other.Schema); cmp != 0 {
 		return cmp
+	}
+
+	if s.Definition != nil && other.Definition == nil {
+		return -1
+	} else if s.Definition == nil && other.Definition != nil {
+		return 1
+	} else if s.Definition != nil && other.Definition != nil {
+		return util.Compare(*s.Definition, *other.Definition)
 	}
 
 	return 0

--- a/ast/policy.go
+++ b/ast/policy.go
@@ -146,10 +146,10 @@ type (
 
 	// Annotations represents metadata attached to other AST nodes such as rules.
 	Annotations struct {
-		Node     Node                `json:"-"`
 		Location *Location           `json:"-"`
 		Scope    string              `json:"scope"`
 		Schemas  []*SchemaAnnotation `json:"schemas,omitempty"`
+		node     Node
 	}
 
 	// SchemaAnnotation contains a schema declaration for the document identified by the path.
@@ -281,7 +281,7 @@ func (s *Annotations) Copy(node Node) *Annotations {
 	for i := range cpy.Schemas {
 		cpy.Schemas[i] = s.Schemas[i].Copy()
 	}
-	cpy.Node = node
+	cpy.node = node
 	return &cpy
 }
 
@@ -404,7 +404,7 @@ func (mod *Module) Copy() *Module {
 
 	cpy.Annotations = make([]*Annotations, len(mod.Annotations))
 	for i := range mod.Annotations {
-		cpy.Annotations[i] = mod.Annotations[i].Copy(nodes[mod.Annotations[i].Node])
+		cpy.Annotations[i] = mod.Annotations[i].Copy(nodes[mod.Annotations[i].node])
 	}
 
 	return &cpy
@@ -420,7 +420,7 @@ func (mod *Module) String() string {
 
 	byNode := map[Node][]*Annotations{}
 	for _, a := range mod.Annotations {
-		byNode[a.Node] = append(byNode[a.Node], a)
+		byNode[a.node] = append(byNode[a.node], a)
 	}
 
 	appendAnnotationStrings := func(buf []string, node Node) []string {

--- a/ast/policy.go
+++ b/ast/policy.go
@@ -131,11 +131,11 @@ type (
 	// within a namespace (defined by the package) and optional
 	// dependencies on external documents (defined by imports).
 	Module struct {
-		Package    *Package      `json:"package"`
-		Imports    []*Import     `json:"imports,omitempty"`
-		Rules      []*Rule       `json:"rules,omitempty"`
-		Comments   []*Comment    `json:"comments,omitempty"`
-		Annotation []Annotations `json:"annotation,omitempty"`
+		Package     *Package       `json:"package"`
+		Imports     []*Import      `json:"imports,omitempty"`
+		Annotations []*Annotations `json:"annotations,omitempty"`
+		Rules       []*Rule        `json:"rules,omitempty"`
+		Comments    []*Comment     `json:"comments,omitempty"`
 	}
 
 	// Comment contains the raw text from the comment in the definition.
@@ -144,27 +144,18 @@ type (
 		Location *Location
 	}
 
-	// Annotations contains information extracted from metadata in comments
-	Annotations interface {
-		annotationMaker()
-
-		// NOTE(tsandall): these are temporary interfaces that are required to support copy operations.
-		// When we get rid of the rule pointers, these may not be needed.
-		copy(Node) Annotations
-		node() Node
+	// Annotations represents metadata attached to other AST nodes such as rules.
+	Annotations struct {
+		Node     Node                `json:"-"`
+		Location *Location           `json:"-"`
+		Scope    string              `json:"scope"`
+		Schemas  []*SchemaAnnotation `json:"schemas,omitempty"`
 	}
 
-	// SchemaAnnotations contains information about schemas
-	SchemaAnnotations struct {
-		SchemaAnnotation []SchemaAnnotation `json:"schemaannotation"`
-		Scope            string             `json:"scope"`
-		Rule             *Rule              `json:"-"`
-	}
-
-	// SchemaAnnotation contains information about a schema
+	// SchemaAnnotation contains a schema declaration for the document identified by the path.
 	SchemaAnnotation struct {
-		Path   string `json:"path"`
-		Schema string `json:"schema"`
+		Path   Ref `json:"path"`
+		Schema Ref `json:"schema"`
 	}
 
 	// Package represents the namespace of the documents produced
@@ -239,17 +230,108 @@ type (
 	}
 )
 
-func (s *SchemaAnnotations) copy(node Node) Annotations {
+func (s *Annotations) String() string {
+	bs, _ := json.Marshal(s)
+	return string(bs)
+}
+
+// Loc returns the location of this annotation.
+func (s *Annotations) Loc() *Location {
+	return s.Location
+}
+
+// SetLoc updates the location of this annotation.
+func (s *Annotations) SetLoc(l *Location) {
+	s.Location = l
+}
+
+// Compare returns an integer indicating if s is less than, equal to, or greater
+// than other.
+func (s *Annotations) Compare(other *Annotations) int {
+
+	if cmp := scopeCompare(s.Scope, other.Scope); cmp != 0 {
+		return cmp
+	}
+
+	max := len(s.Schemas)
+	if len(other.Schemas) < max {
+		max = len(other.Schemas)
+	}
+
+	for i := 0; i < max; i++ {
+		if cmp := s.Schemas[i].Compare(other.Schemas[i]); cmp != 0 {
+			return cmp
+		}
+	}
+
+	if len(s.Schemas) > len(other.Schemas) {
+		return 1
+	} else if len(s.Schemas) < len(other.Schemas) {
+		return -1
+	}
+
+	return 0
+}
+
+// Copy returns a deep copy of s.
+func (s *Annotations) Copy(node Node) *Annotations {
 	cpy := *s
-	cpy.Rule = node.(*Rule)
+	cpy.Schemas = make([]*SchemaAnnotation, len(s.Schemas))
+	for i := range cpy.Schemas {
+		cpy.Schemas[i] = s.Schemas[i].Copy()
+	}
+	cpy.Node = node
 	return &cpy
 }
 
-func (s *SchemaAnnotations) node() Node {
-	return s.Rule
+// Copy returns a deep copy of s.
+func (s *SchemaAnnotation) Copy() *SchemaAnnotation {
+	cpy := *s
+	return &cpy
 }
 
-func (*SchemaAnnotations) annotationMaker() {}
+// Compare returns an integer indicating if s is less than, equal to, or greater
+// than other.
+func (s *SchemaAnnotation) Compare(other *SchemaAnnotation) int {
+
+	if cmp := s.Path.Compare(other.Path); cmp != 0 {
+		return cmp
+	}
+
+	if cmp := s.Schema.Compare(other.Schema); cmp != 0 {
+		return cmp
+	}
+
+	return 0
+}
+
+func scopeCompare(s1, s2 string) int {
+
+	o1 := scopeOrder(s1)
+	o2 := scopeOrder(s2)
+
+	if o2 < o1 {
+		return 1
+	} else if o2 > o1 {
+		return -1
+	}
+
+	if s1 < s2 {
+		return -1
+	} else if s2 < s1 {
+		return 1
+	}
+
+	return 0
+}
+
+func scopeOrder(s string) int {
+	switch s {
+	case annotationScopeRule:
+		return 1
+	}
+	return 0
+}
 
 // Compare returns an integer indicating whether mod is less than, equal to,
 // or greater than other.
@@ -268,6 +350,9 @@ func (mod *Module) Compare(other *Module) int {
 	if cmp := importsCompare(mod.Imports, other.Imports); cmp != 0 {
 		return cmp
 	}
+	if cmp := annotationsCompare(mod.Annotations, other.Annotations); cmp != 0 {
+		return cmp
+	}
 	return rulesCompare(mod.Rules, other.Rules)
 }
 
@@ -276,32 +361,38 @@ func (mod *Module) Copy() *Module {
 	cpy := *mod
 	cpy.Rules = make([]*Rule, len(mod.Rules))
 
-	// NOTE(tsandall): only construct the map if annotations are present. This is a temporary
-	// workaround to deal with the lack of a stable index mapping annotations to rules.
-	var rules map[Node]Node
-	if len(mod.Annotation) > 0 {
-		rules = make(map[Node]Node, len(mod.Rules))
+	var nodes map[Node]Node
+
+	if len(mod.Annotations) > 0 {
+		nodes = make(map[Node]Node)
 	}
 
 	for i := range mod.Rules {
 		cpy.Rules[i] = mod.Rules[i].Copy()
 		cpy.Rules[i].Module = &cpy
-
-		if rules != nil {
-			rules[mod.Rules[i]] = cpy.Rules[i]
+		if nodes != nil {
+			nodes[mod.Rules[i]] = cpy.Rules[i]
 		}
-	}
-
-	cpy.Annotation = make([]Annotations, len(mod.Annotation))
-	for i := range mod.Annotation {
-		cpy.Annotation[i] = mod.Annotation[i].copy(rules[mod.Annotation[i].node()])
 	}
 
 	cpy.Imports = make([]*Import, len(mod.Imports))
 	for i := range mod.Imports {
 		cpy.Imports[i] = mod.Imports[i].Copy()
+		if nodes != nil {
+			nodes[mod.Imports[i]] = cpy.Imports[i]
+		}
 	}
+
 	cpy.Package = mod.Package.Copy()
+	if nodes != nil {
+		nodes[mod.Package] = cpy.Package
+	}
+
+	cpy.Annotations = make([]*Annotations, len(mod.Annotations))
+	for i := range mod.Annotations {
+		cpy.Annotations[i] = mod.Annotations[i].Copy(nodes[mod.Annotations[i].Node])
+	}
+
 	return &cpy
 }
 
@@ -312,16 +403,36 @@ func (mod *Module) Equal(other *Module) bool {
 
 func (mod *Module) String() string {
 	buf := []string{}
+
+	byNode := map[Node][]*Annotations{}
+	for _, a := range mod.Annotations {
+		byNode[a.Node] = append(byNode[a.Node], a)
+	}
+
+	appendAnnotationStrings := func(buf []string, node Node) []string {
+		if as, ok := byNode[node]; ok {
+			for i := range as {
+				buf = append(buf, "# METADATA")
+				buf = append(buf, "# "+as[i].String())
+			}
+		}
+		return buf
+	}
+
+	buf = appendAnnotationStrings(buf, mod.Package)
 	buf = append(buf, mod.Package.String())
+
 	if len(mod.Imports) > 0 {
 		buf = append(buf, "")
 		for _, imp := range mod.Imports {
+			buf = appendAnnotationStrings(buf, imp)
 			buf = append(buf, imp.String())
 		}
 	}
 	if len(mod.Rules) > 0 {
 		buf = append(buf, "")
 		for _, rule := range mod.Rules {
+			buf = appendAnnotationStrings(buf, rule)
 			buf = append(buf, rule.String())
 		}
 	}

--- a/ast/schema.go
+++ b/ast/schema.go
@@ -37,6 +37,9 @@ func (ss *SchemaSet) Put(path Ref, raw interface{}) {
 
 // Get returns the raw schema identified by the path.
 func (ss *SchemaSet) Get(path Ref) interface{} {
+	if ss == nil {
+		return nil
+	}
 	x, ok := ss.m.Get(path)
 	if !ok {
 		return nil

--- a/ast/transform.go
+++ b/ast/transform.go
@@ -59,6 +59,15 @@ func Transform(t Transformer, x interface{}) (interface{}, error) {
 				return nil, fmt.Errorf("illegal transform: %T != %T", y.Rules[i], rule)
 			}
 		}
+		for i := range y.Annotations {
+			a, err := Transform(t, y.Annotations[i])
+			if err != nil {
+				return nil, err
+			}
+			if y.Annotations[i], ok = a.(*Annotations); !ok {
+				return nil, fmt.Errorf("illegal transform: %T != %T", y.Annotations[i], a)
+			}
+		}
 		for i := range y.Comments {
 			comment, err := Transform(t, y.Comments[i])
 			if err != nil {

--- a/ast/transform_test.go
+++ b/ast/transform_test.go
@@ -93,11 +93,13 @@ p := 7`, ParserOptions{ProcessAnnotation: true})
 	exp, err := ParseModuleWithOpts("test.rego", `package test
 
 # METADATA
-# scope: deadbeef
+# scope: rule
 p := 7`, ParserOptions{ProcessAnnotation: true})
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	exp.Annotations[0].Scope = "deadbeef"
 
 	if resultMod.Compare(exp) != 0 {
 		t.Fatalf("expected:\n\n%v\n\ngot:\n\n%v", exp, resultMod)

--- a/ast/visit.go
+++ b/ast/visit.go
@@ -52,6 +52,9 @@ func walk(v Visitor, x interface{}) {
 		for _, r := range x.Rules {
 			Walk(w, r)
 		}
+		for _, a := range x.Annotations {
+			Walk(w, a)
+		}
 		for _, c := range x.Comments {
 			Walk(w, c)
 		}
@@ -280,6 +283,9 @@ func (vis *GenericVisitor) Walk(x interface{}) {
 		for _, r := range x.Rules {
 			vis.Walk(r)
 		}
+		for _, a := range x.Annotations {
+			vis.Walk(a)
+		}
 		for _, c := range x.Comments {
 			vis.Walk(c)
 		}
@@ -397,6 +403,9 @@ func (vis *BeforeAfterVisitor) Walk(x interface{}) {
 		}
 		for _, r := range x.Rules {
 			vis.Walk(r)
+		}
+		for _, a := range x.Annotations {
+			vis.Walk(a)
 		}
 		for _, c := range x.Comments {
 			vis.Walk(c)

--- a/ast/visit_test.go
+++ b/ast/visit_test.go
@@ -298,6 +298,28 @@ fn([x, y]) = z { json.unmarshal(x, z); z > y }
 	}
 }
 
+func TestVisitorAnnotations(t *testing.T) {
+
+	module, err := ParseModuleWithOpts("test.rego", `package test
+
+# METADATA
+# scope: rule
+p := 7`, ParserOptions{ProcessAnnotation: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	vis := &testVis{}
+
+	NewGenericVisitor(vis.Visit).Walk(module)
+
+	exp := 20
+
+	if len(vis.elems) != exp {
+		t.Fatalf("expected %d elements but got %v: %v", exp, len(vis.elems), vis.elems)
+	}
+}
+
 func TestWalkVars(t *testing.T) {
 	x := MustParseBody(`x = 1; data.abc[2] = y; y[z] = [q | q = 1]`)
 	found := NewVarSet()

--- a/cmd/parse.go
+++ b/cmd/parse.go
@@ -49,7 +49,7 @@ func parse(args []string, stdout io.Writer, stderr io.Writer) int {
 		return 0
 	}
 
-	result, err := loader.Rego(args[0])
+	result, err := loader.RegoWithOpts(args[0], ast.ParserOptions{ProcessAnnotation: true})
 
 	switch parseParams.format.String() {
 	case parseFormatJSON:

--- a/docs/content/schemas.md
+++ b/docs/content/schemas.md
@@ -154,6 +154,13 @@ allow {
 
 The annotation must be specified as YAML within a comment block that **must** start with `# METADATA`. Also, every line in the comment block containing the annotation **must** start at Column 1 in the module/file, or otherwise, they will be ignored.
 
+> 🚨 OPA will attempt to parse the YAML document in comments following the
+> initial `# METADATA` comment. If the YAML document cannot be parsed, OPA will
+> return an error. If you need to include additional comments between the
+> comment block and the next statement, include a blank line immediately after
+> the comment block containing the YAML document. This tells OPA that the
+> comment block containing the YAML document is finished
+
 The `schemas` field specifies an array associating schemas to data values. Paths must start with `input` or `data` (i.e., they must be fully-qualified.)
 
 The type checker derives a Rego Object type for the schema and an appropriate entry is added to the type environment before type checking the rule. This entry is removed upon exit from the rule.

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -282,7 +282,7 @@ func loadSchemas(schemaPath string) (*ast.SchemaSet, error) {
 		if err != nil {
 			return nil, err
 		}
-		ss.Put(ast.InputRootRef, schema)
+		ss.Put(ast.SchemaRootRef, schema)
 		return ss, nil
 
 	}

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -765,7 +765,7 @@ func TestSchemas(t *testing.T) {
 				"foo/bar/baz.json": `{"type": "string"}`,
 			},
 			exp: map[string]string{
-				"input": `{"type": "string"}`,
+				"schema": `{"type": "string"}`,
 			},
 		},
 		{
@@ -802,7 +802,12 @@ func TestSchemas(t *testing.T) {
 						t.Fatal("unexpected error:", err)
 					}
 					for k, v := range tc.exp {
-						key := ast.MustParseRef(k)
+						var key ast.Ref
+						if k == "schema" {
+							key = ast.SchemaRootRef.Copy()
+						} else {
+							key = ast.MustParseRef(k)
+						}
 						var schema interface{}
 						util.Unmarshal([]byte(v), &schema)
 						result := ss.Get(key)


### PR DESCRIPTION
This PR adds new annotation scopes (`document`, `package`, and `subpackages`) as well as inline schema definitions. I've updated the schema documentation to include a section describing the new scopes.