### PR TITLE
download: Add support for http long polling

### DIFF
--- a/download/config.go
+++ b/download/config.go
@@ -16,8 +16,9 @@ const (
 
 // PollingConfig represents polling configuration for the downloader.
 type PollingConfig struct {
-	MinDelaySeconds *int64 `json:"min_delay_seconds,omitempty"` // min amount of time to wait between successful poll attempts
-	MaxDelaySeconds *int64 `json:"max_delay_seconds,omitempty"` // max amount of time to wait between poll attempts
+	MinDelaySeconds           *int64 `json:"min_delay_seconds,omitempty"`            // min amount of time to wait between successful poll attempts
+	MaxDelaySeconds           *int64 `json:"max_delay_seconds,omitempty"`            // max amount of time to wait between poll attempts
+	LongPollingTimeoutSeconds *int64 `json:"long_polling_timeout_seconds,omitempty"` // max amount of time the server should wait before issuing a timeout if there's no update available
 }
 
 // Config represents the configuration for the downloader.
@@ -52,6 +53,11 @@ func (c *Config) ValidateAndInjectDefaults() error {
 	maxSeconds := int64(time.Duration(max) * time.Second)
 	c.Polling.MaxDelaySeconds = &maxSeconds
 
-	return nil
+	if c.Polling.LongPollingTimeoutSeconds != nil {
+		if *c.Polling.LongPollingTimeoutSeconds < 1 {
+			return fmt.Errorf("'long_polling_timeout_seconds' must be at least 1")
+		}
+	}
 
+	return nil
 }

--- a/download/config_test.go
+++ b/download/config_test.go
@@ -64,6 +64,15 @@ func TestConfigValidation(t *testing.T) {
 			expMin: time.Second * 10,
 			expMax: time.Second * 30,
 		},
+		{
+			note: "long polling timeout < 1",
+			input: `{
+				"polling": {
+					"long_polling_timeout_seconds": 0
+				}
+			}`,
+			wantErr: true,
+		},
 	}
 
 	for _, test := range tests {

--- a/plugins/rest/rest.go
+++ b/plugins/rest/rest.go
@@ -182,6 +182,12 @@ func (c Client) Config() *Config {
 	return &c.config
 }
 
+// SetResponseHeaderTimeout sets the "ResponseHeaderTimeout" in the http client's Transport
+func (c Client) SetResponseHeaderTimeout(timeout *int64) Client {
+	c.config.ResponseHeaderTimeoutSeconds = timeout
+	return c
+}
+
 // Logger returns the logger assigned to the Client
 func (c Client) Logger() sdk.Logger {
 	return c.logger


### PR DESCRIPTION
Earlier the downloader package only supported the http
short polling technique where the client sends periodic
requests to the server to fetch bundles. A drawback of this
method is that a low polling frequency could add unnecessary
burden on the server and network.

This commit adds support for http long polling which helps
to minimize server/network resource usage and also reduces
the delay in delivery of updates to the client.

Signed-off-by: Ashutosh Narkar <anarkar4387@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/main/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/main/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
