### PR TITLE
cmd/test: default timeout 30s when benchmarking

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -75,7 +75,7 @@ func addBenchmemFlag(fs *pflag.FlagSet, benchMem *bool, value bool) {
 }
 
 func addCountFlag(fs *pflag.FlagSet, count *int, cmdType string) {
-	fs.IntVar(count, "count", 1, fmt.Sprintf("number of times to repeat each %s (default 1)", cmdType))
+	fs.IntVar(count, "count", 1, fmt.Sprintf("number of times to repeat each %s", cmdType))
 }
 
 func addMaxErrorsFlag(fs *pflag.FlagSet, errLimit *int) {


### PR DESCRIPTION
Fixes #3107.
