### PR TITLE
wasm: use llvm-12 toolchain, bump wabt/binaryen

### DIFF
--- a/wasm/Dockerfile
+++ b/wasm/Dockerfile
@@ -1,30 +1,30 @@
 FROM ubuntu:20.04
 
-ARG WABT_VERSION=1.0.20
-ARG BINARYEN_VERSION=version_99
+ARG WABT_VERSION=1.0.23
+ARG BINARYEN_VERSION=version_101
 
+ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y curl git build-essential python
 
-RUN bash -c 'echo -ne "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main\ndeb-src http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main" > /etc/apt/sources.list.d/llvm.list'
+RUN bash -c 'echo -ne "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-12 main\ndeb-src http://apt.llvm.org/focal/ llvm-toolchain-focal-12 main" > /etc/apt/sources.list.d/llvm.list'
 
 RUN curl -L https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
 
-ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
     apt-get install -y \
       cmake \
-      clang-11 \
-      libc++-11-dev \
-      libc++abi-11-dev \
-      lld-11 && \
-    update-alternatives --install /usr/bin/ld ld /usr/bin/lld-11 90 && \
-    update-alternatives --install /usr/bin/cc cc /usr/bin/clang-11 90 && \
-    update-alternatives --install /usr/bin/cpp cpp /usr/bin/clang++-11 90 && \
-    update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-11 90
+      clang-12 \
+      libc++-12-dev \
+      libc++abi-12-dev \
+      lld-12 && \
+    update-alternatives --install /usr/bin/ld ld /usr/bin/lld-12 90 && \
+    update-alternatives --install /usr/bin/cc cc /usr/bin/clang-12 90 && \
+    update-alternatives --install /usr/bin/cpp cpp /usr/bin/clang++-12 90 && \
+    update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-12 90
 
-RUN ln -s /usr/bin/clang-11 /usr/bin/clang && \
-    ln -s /usr/bin/clang++-11 /usr/bin/clang++ && \
-    ln -s /usr/bin/clang-cpp-11 /usr/bin/clang-cpp
+RUN ln -s /usr/bin/clang-12 /usr/bin/clang && \
+    ln -s /usr/bin/clang++-12 /usr/bin/clang++ && \
+    ln -s /usr/bin/clang-cpp-12 /usr/bin/clang-cpp
 
 RUN git clone https://github.com/WebAssembly/wabt && \
     cd wabt && \
@@ -40,7 +40,7 @@ RUN git clone https://github.com/WebAssembly/binaryen && \
 
 ENV PATH="/binaryen/bin:/wabt/out/clang/Debug:${PATH}"
 
-ENV CC=clang-11
-ENV CXX=clang++-11
+ENV CC=clang-12
+ENV CXX=clang++-12
 
 WORKDIR /src

--- a/wasm/Makefile
+++ b/wasm/Makefile
@@ -9,7 +9,7 @@ DOCKER_FLAGS += -it
 endif
 
 DOCKER_WASM_BUILDER_IMAGE ?= openpolicyagent/opa-wasm-builder
-WASM_BUILDER_VERSION := 1.3
+WASM_BUILDER_VERSION := 1.4
 WASM_BUILDER_IMAGE := $(DOCKER_WASM_BUILDER_IMAGE):$(WASM_BUILDER_VERSION)
 WASM_OBJ_DIR := _obj
 
@@ -33,10 +33,11 @@ CPPFLAGS += \
 	-fno-rtti \
 	-I src/lib \
 	-I src/libc++ \
-	-I /usr/lib/llvm-11/include/c++/v1 \
-	-I /usr/lib/llvm-11/lib/clang/11.0.0/include \
+	-I /usr/lib/llvm-12/include/c++/v1 \
+	-I /usr/lib/llvm-12/lib/clang/12.0.0/include \
 	-I src/re2 \
-	-D_LIBCPP_HAS_NO_THREADS
+	-D_LIBCPP_HAS_NO_THREADS \
+	-D_LIBCPP_HAS_NO_LIBRARY_ALIGNED_ALLOCATION
 
 ifeq ($(DEBUG), 1)
 CFLAGS += -O1 -gdwarf -DDEBUG
@@ -144,7 +145,7 @@ $(TEST_CPP_OBJS): $(WASM_OBJ_DIR)/tests/%.wasm: tests/%.cc
 	$(CXX) $(CPPFLAGS) -I src -c -o $@ $<
 
 $(WASM_OBJ_DIR)/opa.wasm: $(OBJS) $(CPP_OBJS) $(LIB_OBJS) $(LIB_MPDEC_OBJS) $(LIB_CPP_OBJS) $(RE2_RE2_OBJS) $(RE2_UTIL_OBJS)
-	wasm-ld-11 \
+	wasm-ld-12 \
 			--allow-undefined-file=src/undefined.symbols \
 			--import-memory \
 			--no-entry \
@@ -153,7 +154,7 @@ $(WASM_OBJ_DIR)/opa.wasm: $(OBJS) $(CPP_OBJS) $(LIB_OBJS) $(LIB_MPDEC_OBJS) $(LI
 
 $(WASM_OBJ_DIR)/opa-test.wasm: $(OBJS) $(CPP_OBJS) $(LIB_OBJS) $(LIB_MPDEC_OBJS) $(LIB_CPP_OBJS) $(RE2_RE2_OBJS) $(RE2_UTIL_OBJS) $(TEST_OBJS) $(TEST_CPP_OBJS)
 	@cat src/undefined.symbols tests/undefined.symbols > _obj/undefined.symbols
-	@wasm-ld-11 \
+	@wasm-ld-12 \
 			--allow-undefined-file=_obj/undefined.symbols \
 			--import-memory \
 			--no-entry \

--- a/wasm/src/libc++/minimal.cc
+++ b/wasm/src/libc++/minimal.cc
@@ -9,15 +9,7 @@ void* operator new(size_t size) {
     return opa_malloc(size);
 }
 
-void* operator new(unsigned long size, std::align_val_t) {
-    return opa_malloc(size);
-}
-
 void operator delete(void *p) {
-    opa_free(p);
-}
-
-void operator delete(void *p, std::align_val_t) {
     opa_free(p);
 }
 


### PR DESCRIPTION
There's more changes to the wasm files than in the last bump, 11.0.0 -> 11.1.0; so, it's not entirely straightforward to say what exactly has changed.

That said, our linking and optimization machinery is still intact, and the benchmarks we have don't indicate anything catastrophic:

```
name                                    old time/op  new time/op  delta
WASMArrayIteration/10-16                 423µs ± 5%   405µs ± 4%    ~     (p=0.095 n=5+5)
WASMArrayIteration/100-16                441µs ± 8%   414µs ± 4%  -5.98%  (p=0.032 n=5+5)
WASMArrayIteration/1000-16               572µs ± 2%   559µs ± 2%    ~     (p=0.056 n=5+5)
WASMArrayIteration/10000-16             2.18ms ± 1%  2.35ms ± 6%  +8.11%  (p=0.008 n=5+5)
WASMSetIteration/10-16                   443µs ± 3%   421µs ± 3%  -4.98%  (p=0.008 n=5+5)
WASMSetIteration/100-16                  452µs ± 4%   427µs ± 3%  -5.48%  (p=0.008 n=5+5)
WASMSetIteration/1000-16                 672µs ± 2%   644µs ± 2%  -4.24%  (p=0.008 n=5+5)
WASMSetIteration/10000-16               3.66ms ± 5%  3.46ms ± 5%    ~     (p=0.056 n=5+5)
WASMObjectIteration/10-16                440µs ± 6%   400µs ± 4%  -9.18%  (p=0.008 n=5+5)
WASMObjectIteration/100-16               463µs ± 5%   433µs ± 7%    ~     (p=0.056 n=5+5)
WASMObjectIteration/1000-16              716µs ± 3%   722µs ± 2%    ~     (p=0.421 n=5+5)
WASMObjectIteration/10000-16            3.93ms ±11%  4.14ms ± 3%    ~     (p=0.151 n=5+5)
WASMLargeJSON/10x10-16                   483µs ± 4%   470µs ± 1%    ~     (p=0.421 n=5+5)
WASMLargeJSON/10x100-16                  491µs ± 5%   491µs ± 2%    ~     (p=1.000 n=5+5)
WASMLargeJSON/10x1000-16                 880µs ± 2%   858µs ± 4%    ~     (p=0.222 n=5+5)
WASMLargeJSON/10x10000-16               5.56ms ± 7%  5.65ms ± 7%    ~     (p=0.548 n=5+5)
WASMLargeJSON/100x100-16                 686µs ± 3%   711µs ± 4%  +3.62%  (p=0.032 n=5+5)
WASMLargeJSON/100x1000-16               3.17ms ± 5%  3.13ms ± 6%    ~     (p=0.421 n=5+5)
WASMVirtualDocs/total=1/hit=1-16         426µs ± 6%   415µs ± 2%    ~     (p=0.151 n=5+5)
WASMVirtualDocs/total=10/hit=1-16        416µs ± 3%   415µs ± 2%    ~     (p=1.000 n=5+5)
WASMVirtualDocs/total=100/hit=1-16       437µs ± 5%   421µs ± 6%    ~     (p=0.151 n=5+5)
WASMVirtualDocs/total=1000/hit=1-16      492µs ± 5%   460µs ± 2%  -6.60%  (p=0.008 n=5+5)
WASMVirtualDocs/total=10/hit=10-16       424µs ± 3%   421µs ± 3%    ~     (p=0.841 n=5+5)
WASMVirtualDocs/total=100/hit=10-16      428µs ± 3%   418µs ± 4%    ~     (p=0.095 n=5+5)
WASMVirtualDocs/total=1000/hit=10-16     487µs ± 5%   474µs ± 4%    ~     (p=0.222 n=5+5)
WASMVirtualDocs/total=100/hit=100-16     465µs ± 3%   442µs ± 5%  -4.95%  (p=0.032 n=5+5)
WASMVirtualDocs/total=1000/hit=100-16    523µs ± 5%   496µs ± 4%    ~     (p=0.056 n=5+5)
WASMVirtualDocs/total=1000/hit=1000-16   804µs ± 1%   826µs ± 1%  +2.64%  (p=0.008 n=5+5)
```