### PR TITLE
docs: Update path matching in the Envoy tutorial

### DIFF
--- a/docs/content/envoy-primer.md
+++ b/docs/content/envoy-primer.md
@@ -19,11 +19,6 @@ import input.attributes.request.http
 
 default allow = false
 
-token = {"valid": valid, "payload": payload} {
-    [_, encoded] := split(http.headers.authorization, " ")
-    [valid, _, payload] := io.jwt.decode_verify(encoded, {"secret": "secret"})
-}
-
 allow {
     is_token_valid
     action_allowed
@@ -51,8 +46,14 @@ action_allowed {
 action_allowed {
   http.method == "POST"
   token.payload.role == "admin"
-  glob.match("/people", [], http.path)
+  glob.match("/people", ["/"], http.path)
   lower(input.parsed_body.firstname) != base64url.decode(token.payload.sub)
+}
+
+
+token := {"valid": valid, "payload": payload} {
+    [_, encoded] := split(http.headers.authorization, " ")
+    [valid, _, payload] := io.jwt.decode_verify(encoded, {"secret": "secret"})
 }
 ```
 

--- a/docs/content/envoy-tutorial-standalone-envoy.md
+++ b/docs/content/envoy-tutorial-standalone-envoy.md
@@ -130,11 +130,6 @@ import input.attributes.request.http as http_request
 
 default allow = false
 
-token = {"valid": valid, "payload": payload} {
-    [_, encoded] := split(http_request.headers.authorization, " ")
-    [valid, _, payload] := io.jwt.decode_verify(encoded, {"secret": "secret"})
-}
-
 allow {
     is_token_valid
     action_allowed
@@ -150,20 +145,25 @@ is_token_valid {
 action_allowed {
   http_request.method == "GET"
   token.payload.role == "guest"
-  glob.match("/people*", [], http_request.path)
+  glob.match("/people", ["/"], http_request.path)
 }
 
 action_allowed {
   http_request.method == "GET"
   token.payload.role == "admin"
-  glob.match("/people*", [], http_request.path)
+  glob.match("/people", ["/"], http_request.path)
 }
 
 action_allowed {
   http_request.method == "POST"
   token.payload.role == "admin"
-  glob.match("/people", [], http_request.path)
+  glob.match("/people", ["/"], http_request.path)
   lower(input.parsed_body.firstname) != base64url.decode(token.payload.sub)
+}
+
+token := {"valid": valid, "payload": payload} {
+    [_, encoded] := split(http_request.headers.authorization, " ")
+    [valid, _, payload] := io.jwt.decode_verify(encoded, {"secret": "secret"})
 }
 ```
 


### PR DESCRIPTION
The path matching in the tutorial is wrong. For example:

> glob.match("/people*", [], "/peoplexyz")
true
> glob.match("/people*", [], "/peoplexxxx/1234")
true

This patch updates the examples so that the matches don't return false positives.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/main/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/main/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
