### PR TITLE
website: resolve "latest" to latest version in shortcodes

### DIFF
--- a/docs/website/layouts/shortcodes/current_docker_version.html
+++ b/docs/website/layouts/shortcodes/current_docker_version.html
@@ -1,6 +1,8 @@
 {{- $version := index (split $.Page.File.Path "/") 1 -}}
-{{- if or (eq $version "edge") (eq $version "latest") -}}
-{{ $version }}
+{{- if eq $version "latest" -}}
+{{- strings.TrimPrefix "v" (index site.Data.releases 1) -}}
+{{- else if eq $version "edge" -}}
+edge
 {{- else -}}
 {{- strings.TrimPrefix "v" $version -}}
 {{- end -}}

--- a/docs/website/layouts/shortcodes/current_version.html
+++ b/docs/website/layouts/shortcodes/current_version.html
@@ -1,1 +1,6 @@
-{{ index (split $.Page.File.Path "/") 1 }}
+{{- $version := index (split $.Page.File.Path "/") 1 -}}
+{{- if (eq $version "latest") -}}
+{{- index site.Data.releases 1 -}}
+{{- else -}}
+{{- $version -}}
+{{- end -}}


### PR DESCRIPTION
This came up in the discussion of #3426.

Note that there's two ways to access the current "latest" version:

https://www.openpolicyagent.org/docs/latest/http-api-authorization/
https://www.openpolicyagent.org/docs/v0.28.0/http-api-authorization/

For both sites, the shortcodes now resolve to "0.28.0". Before, the
first one would show "latest", the second "0.28.0".
