### PR TITLE
cmd/fmt: Add flag to return non zero exit code on diff

### DIFF
--- a/cmd/fmt.go
+++ b/cmd/fmt.go
@@ -23,6 +23,7 @@ type fmtCommandParams struct {
 	overwrite bool
 	list      bool
 	diff      bool
+	fail      bool
 }
 
 var fmtParams = fmtCommandParams{}
@@ -45,7 +46,10 @@ original and formatted source.
 
 If the '-l' option is supplied, the 'fmt' command will output the names of files
 that would change if formatted. The '-l' option will suppress any other output
-to stdout from the 'fmt' command.`,
+to stdout from the 'fmt' command.
+
+If the '-e' option is supplied, the 'fmt' command will return a non zero exit
+code if a file would be reformatted.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		os.Exit(opaFmt(args))
 	},
@@ -111,6 +115,12 @@ func formatFile(params *fmtCommandParams, out io.Writer, filename string, info o
 	}
 
 	changed := !bytes.Equal(contents, formatted)
+
+	if params.fail {
+		if changed {
+			return newError("unexpected diff")
+		}
+	}
 
 	if params.list {
 		if changed {
@@ -209,5 +219,6 @@ func init() {
 	formatCommand.Flags().BoolVarP(&fmtParams.overwrite, "write", "w", false, "overwrite the original source file")
 	formatCommand.Flags().BoolVarP(&fmtParams.list, "list", "l", false, "list all files who would change when formatted")
 	formatCommand.Flags().BoolVarP(&fmtParams.diff, "diff", "d", false, "only display a diff of the changes")
+	formatCommand.Flags().BoolVar(&fmtParams.fail, "fail", false, "non zero exit code on reformat")
 	RootCommand.AddCommand(formatCommand)
 }


### PR DESCRIPTION
Running fmt during CI/CD is a common practice to ensure
files being merged are properly formatted. While this
can be accomplished with shell commands the OPA docker
image doesn't ship with a shell so adding this flag to
return a non zero error code allows the docker image to
be used in CI/CD.

Fixes: #2149

Signed-off-by: Joshua Shanks <jjshanks@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/main/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/main/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
