### PR TITLE
Deterministic order of rules for optimized bundles

### DIFF
--- a/compile/compile_test.go
+++ b/compile/compile_test.go
@@ -350,9 +350,9 @@ func TestCompilerOptimizationL1(t *testing.T) {
 		optimizedExp := ast.MustParseModule(`
 			package test
 
-			q { input.x = 1 }
-			p { data.test.q = X; X }
 			default p = false
+			p { data.test.q = X; X }
+			q { input.x = 1 }
 		`)
 
 		// NOTE(tsandall): PE generates vars with wildcard prefix. Instead of
@@ -409,8 +409,8 @@ func TestCompilerOptimizationL2(t *testing.T) {
 		optimizedExp := ast.MustParseModule(`
 			package test
 
-			p { input.x = 1 }
 			default p = false
+			p { input.x = 1 }
 		`)
 
 		if len(compiler.bundle.Modules) != 2 {
@@ -872,10 +872,11 @@ func TestOptimizerOutput(t *testing.T) {
 				"optimized/test.rego": `
 					package test
 
+					default p = false
+
 					p = true { 1 = input.x }
 					p = true { 2 = input.x }
 
-					default p = false
 				`,
 				"test.rego": `
 					package test

--- a/rego/rego_test.go
+++ b/rego/rego_test.go
@@ -957,9 +957,9 @@ func TestPartialNamespace(t *testing.T) {
 	expSupport := ast.MustParseModule(`
 		package foo.test
 
-		p { input.x = 1 }
-
 		default p = false
+
+		p { input.x = 1 }
 	`)
 
 	if len(pq.Support) != 1 || !pq.Support[0].Equal(expSupport) {
@@ -1691,13 +1691,56 @@ func TestShallowInliningOption(t *testing.T) {
 	exp := ast.MustParseModule(`
 		package partial.test
 
-		q { 7 = input.x }
 		p { data.partial.test.q = true }
+		q { 7 = input.x }
 	`)
 
 	if len(pq.Support) != 1 || !pq.Support[0].Equal(exp) {
 		t.Fatal("expected module:", exp, "\n\ngot module:", pq.Support[0])
 	}
+}
+
+func TestRegoPartialResultSortedRules(t *testing.T) {
+	r := New(Query("data.test.p"), Module("example.rego", `
+		package test
+
+		default p = false
+
+		p {
+			r = (input.d * input.a) + input.c
+			r < s
+		}
+
+		p {
+			r = (input.d * input.b) + input.c
+			r < s
+		}
+
+		s = 100
+
+	`))
+
+	pq, err := r.Partial(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Without sorting of support rules, the output of the above partial evaluation
+	// resulted in a random order of the support rules (in this case two different possible outputs)
+	exp := ast.MustParseModule(
+		`package partial.test
+
+		default p = false
+
+		p = true { lt(plus(mul(input.d, input.a), input.c), 100) }
+		p = true { lt(plus(mul(input.d, input.b), input.c), 100) }
+		`,
+	)
+
+	if len(pq.Support) != 1 || !pq.Support[0].Equal(exp) {
+		t.Fatal("expected module:", exp, "\n\ngot module:", pq.Support[0])
+	}
+
 }
 
 func TestPrepareWithEmptyModule(t *testing.T) {

--- a/topdown/query.go
+++ b/topdown/query.go
@@ -370,6 +370,12 @@ func (q *Query) PartialRun(ctx context.Context) (partials []ast.Body, support []
 		err = e.builtinErrors.errs[0]
 	}
 
+	for i := range support {
+		sort.Slice(support[i].Rules, func(j, k int) bool {
+			return support[i].Rules[j].Compare(support[i].Rules[k]) < 0
+		})
+	}
+
 	return partials, support, err
 }
 


### PR DESCRIPTION
Before this fix, an optimized bundle would get
non-deterministic order of the support rules.

One example use case where it is necessary for the optimized
bundle to be deterministic is when a hash of the bundle is
used for version tag.

Fixes: #3453

Signed-off-by: Andre Håland <andre.haland@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/main/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/main/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
