### PR TITLE
fix codeql go version; use ioutil.Discard.

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -32,6 +32,15 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v2
 
+    - id: go_version
+      name: Read go version
+      run: echo "::set-output name=go_version::$(cat .go-version)"
+
+    - name: Install Go (${{ steps.go_version.outputs.go_version }})
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ steps.go_version.outputs.go_version }}
+
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v1

--- a/cmd/fmt_test.go
+++ b/cmd/fmt_test.go
@@ -2,7 +2,7 @@ package cmd
 
 import (
 	"bytes"
-	"io"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -176,7 +176,7 @@ p {
 	test.WithTempFS(files, func(path string) {
 		policyFile := filepath.Join(path, "policy.rego")
 		info, err := os.Stat(policyFile)
-		err = formatFile(&params, io.Discard, policyFile, info, err)
+		err = formatFile(&params, ioutil.Discard, policyFile, info, err)
 		if err != nil {
 			t.Fatalf("Expected error but did not recieve one")
 		}
@@ -205,7 +205,7 @@ func TestFmtFailFileChanges(t *testing.T) {
 	test.WithTempFS(files, func(path string) {
 		policyFile := filepath.Join(path, "policy.rego")
 		info, err := os.Stat(policyFile)
-		err = formatFile(&params, io.Discard, policyFile, info, err)
+		err = formatFile(&params, ioutil.Discard, policyFile, info, err)
 		if err == nil {
 			t.Fatalf("Unexpected error: %s", err)
 		}


### PR DESCRIPTION
I had proposed that in a PR review... not thinking that it meant
we couldn't run tests using Go 1.15. My assumption that using

    go 1.15

in go.mod would protect us from that was wrong, apparently.