### PR TITLE
plugins/discovery: fix race in test

### DIFF
--- a/plugins/discovery/discovery_test.go
+++ b/plugins/discovery/discovery_test.go
@@ -1088,6 +1088,8 @@ func TestStatusMetricsForLogDrops(t *testing.T) {
 		}
 	}`)})
 
+	status.Lookup(manager).Stop(ctx)
+
 	entries := testLogger.Entries()
 	if len(entries) == 0 {
 		t.Fatal("Expected log entries but got none")


### PR DESCRIPTION
This one wasn't detected reliably, it sometimes appeared and
sometimes did not. Running the test in a loop in a low-resource
docker container make it come out.