### PR TITLE
topdown: changes the default for http.send parameter tls_use_system_certs to true

### DIFF
--- a/docs/content/policy-reference.md
+++ b/docs/content/policy-reference.md
@@ -854,7 +854,7 @@ The `request` object parameter may contain the following fields:
 | `headers` | no | `object` | HTTP headers to include in the request (e.g,. `{"X-Opa": "rules"}`). |
 | `enable_redirect` | no | `boolean` | Follow HTTP redirects. Default: `false`. |
 | `force_json_decode` | no | `boolean` | Decode the HTTP response message body as JSON even if the `Content-Type` header is missing. Default: `false`. |
-| `tls_use_system_certs` | no | `boolean` | Use the system certificate pool. Default: `false`. |
+| `tls_use_system_certs` | no | `boolean` | Use the system certificate pool. Default: `true` when `tls_ca_cert`, `tls_ca_cert_file`, `tls_ca_cert_env_variable` are unset. |
 | `tls_ca_cert` | no | `string` | String containing a root certificate in PEM encoded format. |
 | `tls_ca_cert_file` | no | `string` | Path to file containing a root certificate in PEM encoded format. |
 | `tls_ca_cert_env_variable` | no | `string` | Environment variable containing a root certificate in PEM encoded format. |

--- a/topdown/http.go
+++ b/topdown/http.go
@@ -244,7 +244,7 @@ func createHTTPRequest(bctx BuiltinContext, obj ast.Object) (*http.Request, *htt
 	var body *bytes.Buffer
 	var rawBody *bytes.Buffer
 	var enableRedirect bool
-	var tlsUseSystemCerts bool
+	var tlsUseSystemCerts *bool
 	var tlsConfig tls.Config
 	var customHeaders map[string]interface{}
 	var tlsInsecureSkipVerify bool
@@ -307,10 +307,11 @@ func createHTTPRequest(bctx BuiltinContext, obj ast.Object) (*http.Request, *htt
 		case "raw_body":
 			rawBody = bytes.NewBuffer([]byte(strVal))
 		case "tls_use_system_certs":
-			tlsUseSystemCerts, err = strconv.ParseBool(obj.Get(val).String())
+			tempTLSUseSystemCerts, err := strconv.ParseBool(obj.Get(val).String())
 			if err != nil {
 				return nil, nil, err
 			}
+			tlsUseSystemCerts = &tempTLSUseSystemCerts
 		case "tls_ca_cert":
 			tlsCaCert = bytes.Trim([]byte(strVal), "\"")
 		case "tls_ca_cert_file":
@@ -401,9 +402,16 @@ func createHTTPRequest(bctx BuiltinContext, obj ast.Object) (*http.Request, *htt
 		tlsConfig.Certificates = append(tlsConfig.Certificates, cert)
 	}
 
+	// Use system certs if no CA cert is provided
+	// or system certs flag is not set
+	if (len(tlsCaCert) != 0 || tlsCaCertFile != "" || tlsCaCertEnvVar != "") && tlsUseSystemCerts == nil {
+		trueValue := true
+		tlsUseSystemCerts = &trueValue
+	}
+
 	// Check the system certificates config first so that we
 	// load additional certificated into the correct pool.
-	if tlsUseSystemCerts {
+	if tlsUseSystemCerts != nil && *tlsUseSystemCerts {
 		pool, err := x509.SystemCertPool()
 		if err != nil {
 			return nil, nil, err


### PR DESCRIPTION

The default is set to true whenever the tls_ca_cert_file parameter or tls_ca_cert_env_variable parameter are unspecified

Fixes #2271

Signed-off-by: Olamide Omolola <omololaolamidex@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/main/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/main/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
