### PR TITLE
Remove usage of isKind() from internal/gojsonschema

### DIFF
--- a/internal/gojsonschema/README.md
+++ b/internal/gojsonschema/README.md
@@ -11,6 +11,8 @@ The modifications done are as below:
 
 2. Also, other changes in `gojsonschema`'s code include fixes to satisfy OPA's lint and format checker scripts. Hence, this `internal/gojsonschema` is in conformance with OPA's code style.
 
+3. Modernize usage of Go in `gojsonschema`, using conventions like type switching and language-built-in map accessing rather than helper methods. 
+
 [![GoDoc](https://godoc.org/github.com/xeipuuv/gojsonschema?status.svg)](https://godoc.org/github.com/xeipuuv/gojsonschema)
 [![Build Status](https://travis-ci.org/xeipuuv/gojsonschema.svg)](https://travis-ci.org/xeipuuv/gojsonschema)
 [![Go Report Card](https://goreportcard.com/badge/github.com/xeipuuv/gojsonschema)](https://goreportcard.com/report/github.com/xeipuuv/gojsonschema)

--- a/internal/gojsonschema/draft.go
+++ b/internal/gojsonschema/draft.go
@@ -17,7 +17,6 @@ package gojsonschema
 import (
 	"errors"
 	"math"
-	"reflect"
 
 	"github.com/xeipuuv/gojsonreference"
 )
@@ -88,29 +87,27 @@ func (dc draftConfigs) GetSchemaURL(draft Draft) string {
 }
 
 func parseSchemaURL(documentNode interface{}) (string, *Draft, error) {
-
-	if isKind(documentNode, reflect.Bool) {
+	if _, ok := documentNode.(bool); ok {
 		return "", nil, nil
 	}
 
-	if !isKind(documentNode, reflect.Map) {
+	m, ok := documentNode.(map[string]interface{})
+	if !ok {
 		return "", nil, errors.New("schema is invalid")
 	}
 
-	m := documentNode.(map[string]interface{})
-
-	if existsMapKey(m, KeySchema) {
-		if !isKind(m[KeySchema], reflect.String) {
+	if v, ok := m[KeySchema]; ok {
+		s, ok := v.(string)
+		if !ok {
 			return "", nil, errors.New(formatErrorDescription(
 				Locale.MustBeOfType(),
 				ErrorDetails{
 					"key":  KeySchema,
 					"type": TypeString,
-				},
-			))
+				}))
 		}
 
-		schemaReference, err := gojsonreference.NewJsonReference(m[KeySchema].(string))
+		schemaReference, err := gojsonreference.NewJsonReference(s)
 
 		if err != nil {
 			return "", nil, err

--- a/internal/gojsonschema/schema_test.go
+++ b/internal/gojsonschema/schema_test.go
@@ -222,11 +222,11 @@ func TestRefProperty(t *testing.T) {
 	// call the target function
 	s, err := NewSchema(schemaLoader)
 	if err != nil {
-		t.Errorf("Got error: %s", err.Error())
+		t.Fatalf("Got error: %s", err.Error())
 	}
 	result, err := s.Validate(documentLoader)
 	if err != nil {
-		t.Errorf("Got error: %s", err.Error())
+		t.Fatalf("Got error: %s", err.Error())
 	}
 	if !result.Valid() {
 		for _, err := range result.Errors() {
@@ -249,7 +249,7 @@ func TestFragmentLoader(t *testing.T) {
 	schema, err := NewSchema(schemaLoader)
 
 	if err != nil {
-		t.Errorf("Encountered error while loading schema: %s", err.Error())
+		t.Fatalf("Encountered error while loading schema: %s", err.Error())
 	}
 
 	validDocument := NewStringLoader(`5`)
@@ -360,7 +360,7 @@ func TestLocationIndependentIdentifier(t *testing.T) {
 
 	result, err := s.Validate(documentLoader)
 	if err != nil {
-		t.Errorf("Got error: %s", err.Error())
+		t.Fatalf("Got error: %s", err.Error())
 	}
 
 	if len(result.Errors()) != 2 || result.Errors()[0].Type() != "false" || result.Errors()[1].Type() != "number_all_of" {

--- a/internal/gojsonschema/utils.go
+++ b/internal/gojsonschema/utils.go
@@ -28,28 +28,7 @@ package gojsonschema
 import (
 	"encoding/json"
 	"math/big"
-	"reflect"
 )
-
-func isKind(what interface{}, kinds ...reflect.Kind) bool {
-	target := what
-	if isJSONNumber(what) {
-		// JSON Numbers are strings!
-		target = *mustBeNumber(what)
-	}
-	targetKind := reflect.ValueOf(target).Kind()
-	for _, kind := range kinds {
-		if targetKind == kind {
-			return true
-		}
-	}
-	return false
-}
-
-func existsMapKey(m map[string]interface{}, k string) bool {
-	_, ok := m[k]
-	return ok
-}
 
 func isStringInSlice(s []string, what string) bool {
 	for i := range s {
@@ -58,16 +37,6 @@ func isStringInSlice(s []string, what string) bool {
 		}
 	}
 	return false
-}
-
-// indexStringInSlice returns the index of the first instance of 'what' in s or -1 if it is not found in s.
-func indexStringInSlice(s []string, what string) int {
-	for i := range s {
-		if s[i] == what {
-			return i
-		}
-	}
-	return -1
 }
 
 func marshalToJSONString(value interface{}) (*string, error) {
@@ -131,41 +100,39 @@ const (
 )
 
 func mustBeInteger(what interface{}) *int {
-
-	if isJSONNumber(what) {
-
-		number := what.(json.Number)
-
-		isInt := checkJSONInteger(number)
-
-		if isInt {
-
-			int64Value, err := number.Int64()
-			if err != nil {
-				return nil
-			}
-
-			int32Value := int(int64Value)
-			return &int32Value
-		}
-
+	number, ok := what.(json.Number)
+	if !ok {
+		return nil
 	}
 
-	return nil
+	isInt := checkJSONInteger(number)
+	if !isInt {
+		return nil
+	}
+
+	int64Value, err := number.Int64()
+	if err != nil {
+		return nil
+	}
+
+	// This doesn't actually convert to an int32 value; it converts to the
+	// system-specific default integer. Assuming this is a valid int32 could cause
+	// bugs.
+	int32Value := int(int64Value)
+	return &int32Value
 }
 
 func mustBeNumber(what interface{}) *big.Rat {
-
-	if isJSONNumber(what) {
-		number := what.(json.Number)
-		float64Value, success := new(big.Rat).SetString(string(number))
-		if success {
-			return float64Value
-		}
+	number, ok := what.(json.Number)
+	if !ok {
+		return nil
 	}
 
+	float64Value, success := new(big.Rat).SetString(string(number))
+	if success {
+		return float64Value
+	}
 	return nil
-
 }
 
 func convertDocumentNode(val interface{}) interface{} {


### PR DESCRIPTION
While Go has had safe type assertions since the version 1, their use did not become standardized until around Go 1.3 - some time after the library we copied was written in 2013. This means the original author relied on a now-defunct (but then reasonable) practice of defining a convenience method for type assertions, `isKind`.

Unfortunately for us, checking for types using the reflect package in this way is both extremely inefficient and unsafe. In refactoring this library I've fixed several bugs which could have caused panics or an incorrect parse. I'll comment below cases where the right fix was ambiguous.

Additionally, the original code used a helper method for checking if a value existed in a map, and then extracted the value if it existed. As written, this retrieves the value from the map twice - doing double the work - as testing whether a value exists in a map and retrieving it can be done in the same statement. I've factored this method out as well.

I've taken the liberty of factoring out a few helper methods rather than repeat code.

If desired, I'm happy to write + run benchmarks to compare before+after since this should be significantly more performant than before, but I think the main wins in this PR are safer type assertions, fewer bugs, less code, and using more idiomatic Go.