### PR TITLE
Fix OPA test coverage issue for bundles

### DIFF
--- a/cmd/test.go
+++ b/cmd/test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -252,6 +253,17 @@ func opaTest(args []string) int {
 			}
 		}
 	} else {
+		//for test coverage with --bundle, retrieve modules from bundles
+		if modules == nil {
+			modules := map[string]*ast.Module{}
+			for path, b := range bundles {
+				for bundleName, mod := range b.ParsedModules(path) {
+					splitBundleName := strings.Split(bundleName, "/")
+					name := splitBundleName[len(splitBundleName)-1]
+					modules[name] = mod
+				}
+			}
+		}
 		reporter = tester.JSONCoverageReporter{
 			Cover:     cov,
 			Modules:   modules,

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -157,7 +157,7 @@ func opaTest(args []string) int {
 		Ignore: testParams.ignore,
 	}
 
-	var modules map[string]*ast.Module
+	modules := map[string]*ast.Module{}
 	var bundles map[string]*bundle.Bundle
 	var store storage.Store
 	var err error
@@ -255,7 +255,6 @@ func opaTest(args []string) int {
 	} else {
 		//for test coverage with --bundle, retrieve modules from bundles
 		if modules == nil {
-			modules := map[string]*ast.Module{}
 			for path, b := range bundles {
 				for bundleName, mod := range b.ParsedModules(path) {
 					splitBundleName := strings.Split(bundleName, "/")


### PR DESCRIPTION
This fix provides accurate coverage percentage for bundles while running OPA test
Aggregated modules with bundles if its provided (prior to this fix, modules was empty for test coverage on bundles) 

Fixes: #3324
Signed-off-by: Arshad Saquib <arshad.saquib@styra.com>

