### PR TITLE
topdown: respect shallow inlining for functions depending on unknowns

### DIFF
--- a/topdown/eval.go
+++ b/topdown/eval.go
@@ -618,10 +618,15 @@ func (e *eval) evalCall(terms []*ast.Term, iter unifyIterator) error {
 	ref := terms[0].Value.(ast.Ref)
 
 	if ref[0].Equal(ast.DefaultRootDocument) {
+		ir, err := e.getRules(ref)
+		if err != nil {
+			return err
+		}
 		eval := evalFunc{
 			e:     e,
 			ref:   ref,
 			terms: terms,
+			ir:    ir,
 		}
 		return eval.eval(iter)
 	}
@@ -1497,31 +1502,40 @@ type evalFunc struct {
 	e     *eval
 	ref   ast.Ref
 	terms []*ast.Term
+	ir    *ast.IndexResult
 }
 
 func (e evalFunc) eval(iter unifyIterator) error {
 
-	ir, err := e.e.getRules(e.ref)
-	if err != nil {
-		return err
-	}
-
 	// default functions aren't supported:
 	// https://github.com/open-policy-agent/opa/issues/2445
-	if len(ir.Rules) == 0 {
+	if len(e.ir.Rules) == 0 {
 		return nil
 	}
 
-	argCount := len(ir.Rules[0].Head.Args)
+	argCount := len(e.ir.Rules[0].Head.Args)
 
-	if len(ir.Else) > 0 && e.e.unknown(e.e.query[e.e.index], e.e.bindings) {
+	if len(e.ir.Else) > 0 && e.e.unknown(e.e.query[e.e.index], e.e.bindings) {
 		// Partial evaluation of ordered rules is not supported currently. Save the
 		// expression and continue. This could be revisited in the future.
 		return e.e.saveCall(argCount, e.terms, iter)
 	}
 
+	if e.e.partial() && e.e.inliningControl.shallow && len(e.ir.Rules) > 1 {
+		// check if the function definitions, or any of the arguments
+		// contain something unknown
+		unknown := e.e.unknown(e.ref, e.e.bindings)
+		for i := 1; !unknown && i <= argCount; i++ {
+			unknown = e.e.unknown(e.terms[i], e.e.bindings)
+		}
+		if unknown {
+			return e.partialEvalSupport(iter)
+		}
+	}
+
 	var cacheKey ast.Ref
 	var hit bool
+	var err error
 	if !e.e.partial() {
 		cacheKey, hit, err = e.evalCache(argCount, iter)
 		if err != nil {
@@ -1533,13 +1547,13 @@ func (e evalFunc) eval(iter unifyIterator) error {
 
 	var prev *ast.Term
 
-	for i := range ir.Rules {
-		next, err := e.evalOneRule(iter, ir.Rules[i], cacheKey, prev)
+	for i := range e.ir.Rules {
+		next, err := e.evalOneRule(iter, e.ir.Rules[i], cacheKey, prev)
 		if err != nil {
 			return err
 		}
 		if next == nil {
-			for _, rule := range ir.Else[ir.Rules[i]] {
+			for _, rule := range e.ir.Else[e.ir.Rules[i]] {
 				next, err = e.evalOneRule(iter, rule, cacheKey, prev)
 				if err != nil {
 					return err
@@ -1649,6 +1663,75 @@ func (e evalFunc) evalOneRule(iter unifyIterator, rule *ast.Rule, cacheKey ast.R
 	})
 
 	return result, err
+}
+
+func (e evalFunc) partialEvalSupport(iter unifyIterator) error {
+
+	path := e.e.namespaceRef(e.ref)
+	term := ast.NewTerm(path)
+
+	if !e.e.saveSupport.Exists(path) {
+		for _, rule := range e.ir.Rules {
+			err := e.partialEvalSupportRule(rule, path)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	if !e.e.saveSupport.Exists(path) { // we haven't saved anything, nothing to call
+		return nil
+	}
+
+	return e.e.saveCall(len(e.terms), append([]*ast.Term{term}, e.terms[1:]...), iter)
+}
+
+func (e evalFunc) partialEvalSupportRule(rule *ast.Rule, path ast.Ref) error {
+
+	child := e.e.child(rule.Body)
+	child.traceEnter(rule)
+
+	e.e.saveStack.PushQuery(nil)
+
+	// treat the function arguments as unknown during rule body evaluation
+	var args []*ast.Term
+	ast.WalkVars(rule.Head.Args, func(v ast.Var) bool {
+		args = append(args, ast.VarTerm(string(v)))
+		return false
+	})
+	e.e.saveSet.Push(args, child.bindings)
+
+	err := child.eval(func(child *eval) error {
+		child.traceExit(rule)
+
+		current := e.e.saveStack.PopQuery()
+		plugged := current.Plug(e.e.caller.bindings)
+
+		// Skip this rule body if it fails to type-check.
+		// Type-checking failure means the rule body will never succeed.
+		if e.e.compiler.PassesTypeCheck(plugged) {
+			head := &ast.Head{
+				Name:  rule.Head.Name,
+				Value: child.bindings.PlugNamespaced(rule.Head.Value, e.e.caller.bindings),
+				Args:  make([]*ast.Term, len(rule.Head.Args)),
+			}
+			for i, a := range rule.Head.Args {
+				head.Args[i] = child.bindings.PlugNamespaced(a, e.e.caller.bindings)
+			}
+
+			e.e.saveSupport.Insert(path, &ast.Rule{
+				Head: head,
+				Body: plugged,
+			})
+		}
+		child.traceRedo(rule)
+		e.e.saveStack.PushQuery(current)
+		return nil
+	})
+
+	e.e.saveSet.Pop()
+	e.e.saveStack.PopQuery()
+	return err
 }
 
 type evalTree struct {
@@ -2125,7 +2208,8 @@ func (e evalVirtualPartial) evalOneRuleContinue(iter unifyIterator, rule *ast.Ru
 
 func (e evalVirtualPartial) partialEvalSupport(iter unifyIterator) error {
 
-	path, term := e.e.savePackagePathAndTerm(e.plugged[:e.pos+1], e.ref)
+	path := e.e.namespaceRef(e.plugged[:e.pos+1])
+	term := ast.NewTerm(e.e.namespaceRef(e.ref))
 
 	var defined bool
 
@@ -2414,7 +2498,8 @@ func (e evalVirtualComplete) partialEval(iter unifyIterator) error {
 
 func (e evalVirtualComplete) partialEvalSupport(iter unifyIterator) error {
 
-	path, term := e.e.savePackagePathAndTerm(e.plugged[:e.pos+1], e.ref)
+	path := e.e.namespaceRef(e.plugged[:e.pos+1])
+	term := ast.NewTerm(e.e.namespaceRef(e.ref))
 
 	if !e.e.saveSupport.Exists(path) {
 
@@ -2638,13 +2723,11 @@ func (e *eval) comprehensionIndex(term *ast.Term) *ast.ComprehensionIndex {
 	return e.compiler.ComprehensionIndex(term)
 }
 
-func (e *eval) savePackagePathAndTerm(plugged, ref ast.Ref) (ast.Ref, *ast.Term) {
-
+func (e *eval) namespaceRef(ref ast.Ref) ast.Ref {
 	if e.skipSaveNamespace {
-		return plugged.Copy(), ast.NewTerm(ref.Copy())
+		return ref.Copy()
 	}
-
-	return plugged.Insert(e.saveNamespace, 1), ast.NewTerm(ref.Insert(e.saveNamespace, 1))
+	return ref.Insert(e.saveNamespace, 1)
 }
 
 type savePair struct {

--- a/topdown/save.go
+++ b/topdown/save.go
@@ -57,7 +57,7 @@ func (ss *saveSet) contains(t *ast.Term, b *bindings) bool {
 	return false
 }
 
-// ContainsRecursive retruns true if the term t is or contains a term that is
+// ContainsRecursive returns true if the term t is or contains a term that is
 // contained in the save set. This function will close over the binding list
 // when it encounters vars.
 func (ss *saveSet) ContainsRecursive(t *ast.Term, b *bindings) bool {

--- a/topdown/topdown_partial_test.go
+++ b/topdown/topdown_partial_test.go
@@ -1821,6 +1821,30 @@ func TestTopDownPartialEval(t *testing.T) {
 			},
 		},
 		{
+			note:  "function inlining: output checked",
+			query: "data.test.p = true",
+			modules: []string{`
+					package test
+					f(x) = y {
+						y = x == 1
+					}
+					p {
+						f(input)
+					}
+				`},
+			wantQueryASTs: []ast.Body{
+				ast.NewBody(
+					ast.NewExpr(
+						ast.CallTerm(
+							ast.NewTerm(ast.Equal.Ref()),
+							ast.NewTerm(ast.InputRootRef),
+							ast.IntNumberTerm(1),
+						),
+					),
+				),
+			},
+		},
+		{
 			note:  "disable inlining: complete doc",
 			query: "data.test.p = true",
 			modules: []string{`
@@ -2150,7 +2174,7 @@ func TestTopDownPartialEval(t *testing.T) {
 			},
 		},
 		{
-			note:  "shallow inlining: function output checked",
+			note:  "shallow inlining: function not inlined if no unknowns in rule bodies, but in args",
 			query: "data.test.p = true",
 			modules: []string{`
 					package test
@@ -2158,7 +2182,9 @@ func TestTopDownPartialEval(t *testing.T) {
 					f(x) = y {
 						y = x == 1
 					}
-
+					f(x) = y {
+						y = x == 2
+					}
 					p {
 						f(input)
 					}
@@ -2168,8 +2194,114 @@ func TestTopDownPartialEval(t *testing.T) {
 			wantSupport: []string{
 				`package partial.test
 
-				p = true { __local2__1 = input; __local2__1 = __local0__2; equal(__local0__2, 1, __local1__2); y2 = __local1__2; y2 }
-				`,
+				p = true { __local4__1 = input; data.partial.test.f(__local4__1) }
+				f(__local0__2) = y2 { equal(__local0__2, 1, __local2__2); y2 = __local2__2 }
+				f(__local1__3) = y3 { equal(__local1__3, 2, __local3__3); y3 = __local3__3 }`,
+			},
+		},
+		{
+			note:  "shallow inlining: function inlined if no unknowns in args but only one rule body",
+			query: "data.test.p = true",
+			modules: []string{`
+					package test
+
+					f(x) = y {
+						y = x == 1
+					}
+					p {
+						f(input)
+					}
+				`},
+			shallow:     true,
+			wantQueries: []string{"data.partial.test.p = true"},
+			wantSupport: []string{
+				`package partial.test
+
+				p = true { __local2__1 = input; __local2__1 = __local0__2; equal(__local0__2, 1, __local1__2); y2 = __local1__2; y2 }`,
+			},
+		},
+		{
+			note:    "shallow inlining: function with unknowns in rule body",
+			query:   "data.test.f(1, x)",
+			shallow: true,
+			modules: []string{
+				`package test
+				f(x) = true { input.x = x }
+				f(x) = false { input.y = x }`,
+			},
+			wantQueries: []string{`data.partial.test.f(1, x)`},
+			wantSupport: []string{
+				`package partial.test
+				f(__local0__2) = true { input.x = __local0__2 }
+				f(__local1__1) = false { input.y = __local1__1 }`,
+			},
+		},
+		{
+			note:    "shallow inlining: functions with no unknowns in rule body or output, always true",
+			query:   "data.test.f(1, y)",
+			shallow: true,
+			modules: []string{
+				`package test
+				f(x) = true { x >= 1 }
+				f(x) = false { x < 0 }
+				f(x) = "meow" { false }`,
+			},
+			wantQueries: []string{`y = true`},
+		},
+		{
+			note:    "shallow inlining: functions with multiple args, no unknowns",
+			query:   "data.test.f(1, [1,2,3], y)",
+			shallow: true,
+			modules: []string{
+				`package test
+				f(x, y) = true { x > 1 }
+				f(x, y) = false {
+					x <= 0
+					count(y) == 3
+				}`,
+			},
+			wantQueries: []string{},
+		},
+		{
+			note:    "shallow inlining: functions that are always undefined",
+			query:   "data.test.f(1, y)",
+			shallow: true,
+			modules: []string{
+				`package test
+				f(x) = "uhm" { input.x = "x"; false }
+				f(x) = "like" { input.y = "y"; false }
+				f(x) = "whatever" { false }`,
+			},
+			wantQueries: []string{},
+		},
+		{
+			note:    "shallow inlining: functions with non-var arguments",
+			query:   "data.test.f(1, y)",
+			shallow: true,
+			modules: []string{
+				`package test
+				f(true) = true
+				f(x) = false { x != true }`,
+			},
+			wantQueries: []string{`y = false`},
+		},
+		{
+			note:    "shallow inlining: functions with unknown call-site arguments",
+			query:   "input = x; data.test.f([1, x])",
+			shallow: true,
+			modules: []string{
+				`package test
+				f([x, y]) {
+				  z = 7
+				  x > (y+z)
+				}
+				f(_) = false`, // two bodies to trigger shallow inlining
+			},
+			wantQueries: []string{`input = x; data.partial.test.f([1, x])`},
+			wantSupport: []string{
+				`package partial.test
+				f(__local2__2) = false { true }
+				f([__local0__1, __local1__1]) = true { plus(__local1__1, 7, __local3__1); gt(__local0__1, __local3__1) }`,
 			},
 		},
 		{


### PR DESCRIPTION
Fixes #3463.

----
Update: added a few commits, we're now partially evaluating the function bodies (into support) and reference the function from support where we had been referencing the non-PE'ed function before.

To do this, we're treating the function arguments (those that are variables, that is), as **unknown** during the eval of the function bodies. That could lead to more inefficient outcomes (compared to non-shallow PE), i.e., function bodies will not disappear if there's an argument that's used. (See the added test cases.)