### PR TITLE
ast: Treat array.items as dynamic element type

### DIFF
--- a/ast/compile.go
+++ b/ast/compile.go
@@ -902,7 +902,7 @@ func parseSchema(schema interface{}) (types.Type, error) {
 			return types.N, nil
 
 		} else if subSchema.Types.Contains("object") {
-			if subSchema.PropertiesChildren != nil && len(subSchema.PropertiesChildren) > 0 {
+			if len(subSchema.PropertiesChildren) > 0 {
 				staticProps := make([]*types.StaticProperty, 0, len(subSchema.PropertiesChildren))
 				for _, pSchema := range subSchema.PropertiesChildren {
 					newtype, err := parseSchema(pSchema)
@@ -916,7 +916,15 @@ func parseSchema(schema interface{}) (types.Type, error) {
 			return types.NewObject(nil, types.NewDynamicProperty(types.A, types.A)), nil
 
 		} else if subSchema.Types.Contains("array") {
-			if subSchema.ItemsChildren != nil && len(subSchema.ItemsChildren) > 0 {
+			if len(subSchema.ItemsChildren) > 0 {
+				if subSchema.ItemsChildrenIsSingleSchema {
+					iSchema := subSchema.ItemsChildren[0]
+					newtype, err := parseSchema(iSchema)
+					if err != nil {
+						return nil, fmt.Errorf("unexpected schema type %v", iSchema)
+					}
+					return types.NewArray(nil, newtype), nil
+				}
 				newTypes := make([]types.Type, 0, len(subSchema.ItemsChildren))
 				for i := 0; i != len(subSchema.ItemsChildren); i++ {
 					iSchema := subSchema.ItemsChildren[i]

--- a/internal/gojsonschema/schema.go
+++ b/internal/gojsonschema/schema.go
@@ -314,7 +314,7 @@ func (d *Schema) parseSchema(documentNode interface{}, currentSchema *SubSchema)
 				default:
 					return invalidType(StringSchema+"/"+StringArrayOfSchemas, KeyItems)
 				}
-				currentSchema.itemsChildrenIsSingleSchema = false
+				currentSchema.ItemsChildrenIsSingleSchema = false
 			}
 		case map[string]interface{}, bool:
 			newSchema := &SubSchema{Parent: currentSchema, Property: KeyItems}
@@ -324,7 +324,7 @@ func (d *Schema) parseSchema(documentNode interface{}, currentSchema *SubSchema)
 			if err != nil {
 				return err
 			}
-			currentSchema.itemsChildrenIsSingleSchema = true
+			currentSchema.ItemsChildrenIsSingleSchema = true
 		default:
 			return invalidType(StringSchema+"/"+StringArrayOfSchemas, KeyItems)
 		}

--- a/internal/gojsonschema/subSchema.go
+++ b/internal/gojsonschema/subSchema.go
@@ -102,7 +102,7 @@ type SubSchema struct {
 	// hierarchy
 	Parent                      *SubSchema
 	ItemsChildren               []*SubSchema
-	itemsChildrenIsSingleSchema bool
+	ItemsChildrenIsSingleSchema bool
 	PropertiesChildren          []*SubSchema
 
 	// validation : number / integer

--- a/internal/gojsonschema/validation.go
+++ b/internal/gojsonschema/validation.go
@@ -462,7 +462,7 @@ func (v *SubSchema) validateArray(currentSubSchema *SubSchema, value []interface
 	nbValues := len(value)
 
 	// TODO explain
-	if currentSubSchema.itemsChildrenIsSingleSchema {
+	if currentSubSchema.ItemsChildrenIsSingleSchema {
 		for i := range value {
 			subContext := NewJSONContext(strconv.Itoa(i), context)
 			validationResult := currentSubSchema.ItemsChildren[0].subValidateWithContext(value[i], subContext)


### PR DESCRIPTION
This commit fixes the conversion to treat array.items schema as the
dynamic element type in arrays as opposed to the static element
type. If array.items is defined as an object then it applies to ALL
elements in the array. On the other hand, if array.items is defined as
an array then it applies pairwise to the elements in the array.

In order to fix this, we have to expose a new field from the schema library.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/main/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/main/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
