### PR TITLE
ast, compile: Update opa build --debug output

### DIFF
--- a/ast/compile.go
+++ b/ast/compile.go
@@ -1794,7 +1794,7 @@ func getComprehensionIndex(dbg debug.Debug, arity func(Ref) int, candidates VarS
 	unsafe := body.Vars(SafetyCheckVisitorParams).Diff(outputs).Diff(ReservedVars)
 
 	if len(unsafe) > 0 {
-		dbg.Printf("%s: unsafe vars: %v", expr.Location, unsafe)
+		dbg.Printf("%s: comprehension index: unsafe vars: %v", expr.Location, unsafe)
 		return nil
 	}
 
@@ -1804,7 +1804,7 @@ func getComprehensionIndex(dbg debug.Debug, arity func(Ref) int, candidates VarS
 	regressionVis := newComprehensionIndexRegressionCheckVisitor(candidates)
 	regressionVis.Walk(body)
 	if regressionVis.worse {
-		dbg.Printf("%s: output vars intersect candidates", expr.Location)
+		dbg.Printf("%s: comprehension index: output vars intersect candidates", expr.Location)
 		return nil
 	}
 
@@ -1814,7 +1814,7 @@ func getComprehensionIndex(dbg debug.Debug, arity func(Ref) int, candidates VarS
 	nestedVis := newComprehensionIndexNestedCandidateVisitor(candidates)
 	nestedVis.Walk(body)
 	if nestedVis.found {
-		dbg.Printf("%s: nested comprehensions close over candidates", expr.Location)
+		dbg.Printf("%s: comprehension index: nested comprehensions close over candidates", expr.Location)
 		return nil
 	}
 
@@ -1824,7 +1824,7 @@ func getComprehensionIndex(dbg debug.Debug, arity func(Ref) int, candidates VarS
 	// empty, there is no indexing to do.
 	indexVars := candidates.Intersect(outputs)
 	if len(indexVars) == 0 {
-		dbg.Printf("%s: no index vars", expr.Location)
+		dbg.Printf("%s: comprehension index: no index vars", expr.Location)
 		return nil
 	}
 
@@ -1846,7 +1846,7 @@ func getComprehensionIndex(dbg debug.Debug, arity func(Ref) int, candidates VarS
 			debugRes[i] = r
 		}
 	}
-	dbg.Printf("%s: comprehension index built with keys: %v", expr.Location, debugRes)
+	dbg.Printf("%s: comprehension index: built with keys: %v", expr.Location, debugRes)
 	return &ComprehensionIndex{Term: term, Keys: result}
 }
 


### PR DESCRIPTION
This commit tweaks the --debug output format to be slightly more
readable. The comprehension indexing messages now have a prefix to
make them more discernable and the optimizer output is now aggregated
so that it's more concise and clear what parameters are being passed
to partial evaluation.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/main/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/main/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
