### PR TITLE
topdown/index: index function rules using their arguments

### DIFF
--- a/ast/compile.go
+++ b/ast/compile.go
@@ -1162,7 +1162,7 @@ func (c *Compiler) rewriteExprTerms() {
 
 // rewriteTermsInHead will rewrite rules so that the head does not contain any
 // terms that require evaluation (e.g., refs or comprehensions). If the key or
-// value contains or more of these terms, the key or value will be moved into
+// value contains one or more of these terms, the key or value will be moved into
 // the body and assigned to a new variable. The new variable will replace the
 // key or value in the head.
 //

--- a/ast/compile_test.go
+++ b/ast/compile_test.go
@@ -2284,7 +2284,7 @@ func TestRewriteDeclaredVars(t *testing.T) {
 					f(input, "bar")
 				}
 
-				f(x,y) {
+				f(x, y) {
 					x[y]
 				}
 				`,

--- a/ast/index_test.go
+++ b/ast/index_test.go
@@ -575,6 +575,19 @@ func TestBaseDocEqIndexing(t *testing.T) {
 				`glob_f(a) = true { a = 12 }`,
 			},
 		},
+		{
+			note: "functions: multiple outputs for same inputs",
+			module: MustParseModule(`package test
+			f(x) = y { a = x; equal(a, 1, r); y = r }
+			f(x) = y { a = x; equal(a, 2, r); y = r }`),
+			ruleset: "f",
+			input:   `{}`,
+			args:    []Value{Number("1")},
+			expectedRS: []string{
+				`f(x) = y { a = x; equal(a, 1, r); y = r }`,
+				`f(x) = y { a = x; equal(a, 2, r); y = r }`,
+			},
+		},
 	}
 
 	for _, tc := range tests {

--- a/ast/index_test.go
+++ b/ast/index_test.go
@@ -17,8 +17,8 @@ type testResolver struct {
 }
 
 func (r testResolver) Resolve(ref Ref) (Value, error) {
-	if len(ref) == 1 {
-		if v, ok := ref[0].Value.(Number); ok {
+	if ref[0].Equal(FunctionArgRootDocument) {
+		if v, ok := ref[1].Value.(Number); ok {
 			if i, ok := v.Int(); ok && 0 <= i && i < len(r.args) {
 				return r.args[i], nil
 			}

--- a/ast/policy.go
+++ b/ast/policy.go
@@ -33,6 +33,11 @@ var InputRootDocument = VarTerm("input")
 // SchemaRootDocument names the document containing external data schemas.
 var SchemaRootDocument = VarTerm("schema")
 
+// FunctionArgRootDocument names the document containing function arguments.
+// It's only for internal usage, for referencing function arguments between
+// the index and topdown.
+var FunctionArgRootDocument = VarTerm("args")
+
 // RootDocumentNames contains the names of top-level documents that can be
 // referred to in modules and queries.
 //

--- a/ast/term.go
+++ b/ast/term.go
@@ -128,12 +128,12 @@ func As(v Value, x interface{}) error {
 
 // Resolver defines the interface for resolving references to native Go values.
 type Resolver interface {
-	Resolve(ref Ref) (value interface{}, err error)
+	Resolve(ref Ref) (interface{}, error)
 }
 
 // ValueResolver defines the interface for resolving references to AST values.
 type ValueResolver interface {
-	Resolve(ref Ref) (value Value, err error)
+	Resolve(ref Ref) (Value, error)
 }
 
 // UnknownValueErr indicates a ValueResolver was unable to resolve a reference
@@ -466,7 +466,7 @@ func IsComprehension(x Value) bool {
 // ContainsRefs returns true if the Value v contains refs.
 func ContainsRefs(v interface{}) bool {
 	found := false
-	WalkRefs(v, func(r Ref) bool {
+	WalkRefs(v, func(Ref) bool {
 		found = true
 		return found
 	})

--- a/topdown/eval.go
+++ b/topdown/eval.go
@@ -623,7 +623,13 @@ func (e *eval) evalCall(terms []*ast.Term, iter unifyIterator) error {
 	}
 
 	if ref[0].Equal(ast.DefaultRootDocument) {
-		ir, err := e.getRules(ref, args...)
+		var ir *ast.IndexResult
+		var err error
+		if e.partial() {
+			ir, err = e.getRules(ref)
+		} else {
+			ir, err = e.getRules(ref, args...)
+		}
 		if err != nil {
 			return err
 		}
@@ -1300,7 +1306,7 @@ func (e *evalResolver) Resolve(ref ast.Ref) (ast.Value, error) {
 	// in ref[0]. The callsite-local arguments are passed in e.args,
 	// index by argument index.
 	if i, ok := funArg(ref); ok {
-		if ast.IsScalar(e.args[i].Value) {
+		if i >= 0 && i < len(e.args) && ast.IsScalar(e.args[i].Value) {
 			e.e.instr.stopTimer(evalOpResolve)
 			return e.args[i].Value, nil
 		}

--- a/topdown/topdown_bench_test.go
+++ b/topdown/topdown_bench_test.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 	"text/template"
@@ -626,6 +627,51 @@ func BenchmarkComprehensionIndexing(b *testing.B) {
 			})
 		}
 	}
+}
+
+func BenchmarkFunctionArgumentIndex(b *testing.B) {
+	ctx := context.Background()
+
+	sizes := []int{10, 100, 1000}
+
+	for _, n := range sizes {
+		compiler := ast.MustCompileModules(map[string]string{
+			"test.rego": moduleWithDefs(n),
+		})
+		body := ast.MustParseBody(fmt.Sprintf("data.test.f(%d, x)", n))
+
+		b.Run(fmt.Sprint(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				q := NewQuery(body).
+					WithCompiler(compiler).
+					WithIndexing(true)
+
+				res, err := q.Run(ctx)
+				if err != nil {
+					b.Fatal(err)
+				}
+
+				if len(res) != 1 {
+					b.Fatalf("Expected one result, got %d", len(res))
+				}
+				if !ast.Boolean(true).Equal(res[0][ast.Var("x")].Value) {
+					b.Errorf("expected x=>true, got %v", res[0])
+				}
+			}
+		})
+	}
+}
+
+func moduleWithDefs(n int) string {
+	var b strings.Builder
+
+	b.WriteString(`package test
+`)
+	for i := 1; i <= n; i++ {
+		fmt.Fprintf(&b, `f(x) = y { y := true; x == %[1]d }
+`, i)
+	}
+	return b.String()
 }
 
 func genComprehensionIndexingData(n int) map[string]interface{} {

--- a/topdown/topdown_partial_test.go
+++ b/topdown/topdown_partial_test.go
@@ -2173,6 +2173,21 @@ func TestTopDownPartialEval(t *testing.T) {
 			},
 		},
 		{
+			note:    "shallow inlining: function with local var arg",
+			query:   "x := 10; data.test.f(x, y)",
+			shallow: true,
+			modules: []string{
+				`package test
+				f(x) = true { x = 10 }
+				f(x) = true { x = 12 }`,
+			},
+			wantQueries: []string{`data.partial.test.f(10, y); __localq0__ = 10`},
+			wantSupport: []string{
+				`package partial.test
+				f(__local0__1) = true { __local0__1 = 10 }`,
+			},
+		},
+		{
 			note:  "comprehensions: ref heads (with namespacing)",
 			query: "data.test.p = true; input.x = x",
 			modules: []string{ // include an unknown in the comprehension to force saving

--- a/topdown/topdown_partial_test.go
+++ b/topdown/topdown_partial_test.go
@@ -2173,21 +2173,6 @@ func TestTopDownPartialEval(t *testing.T) {
 			},
 		},
 		{
-			note:    "shallow inlining: function with local var arg",
-			query:   "x := 10; data.test.f(x, y)",
-			shallow: true,
-			modules: []string{
-				`package test
-				f(x) = true { x = 10 }
-				f(x) = true { x = 12 }`,
-			},
-			wantQueries: []string{`data.partial.test.f(10, y); __localq0__ = 10`},
-			wantSupport: []string{
-				`package partial.test
-				f(__local0__1) = true { __local0__1 = 10 }`,
-			},
-		},
-		{
 			note:  "comprehensions: ref heads (with namespacing)",
 			query: "data.test.p = true; input.x = x",
 			modules: []string{ // include an unknown in the comprehension to force saving


### PR DESCRIPTION
So far, we've been indexing function definitions, but only using references in their bodies, neglecting function arguments:

For these two function definitions, for a contrived example,
```rego
f(x) = y {
  x = 10
  input.a = "a"
  y := "ten a"
}
f(x) = y {
  x = 12
  input.a = "a"
  y := "twelve a"
}
```
we'd put them both into the index at `input.a ="a"`. When evaluating a call like `f(10)` with input `{"a": "a"}`, the lookup would, using `input.a`, yield both function bodies, and we'd evaluate them both.

Now, we'll add the equality checks `x = 10` and `x = 12`, so that the index lookup for `f(10)` with the same input will only yield the first rule body to evaluate.

The same applies to function arguments used in `glob.match` expressions, like
```rego
check_path(path) {
  glob.match("foo/bar/*", ["/"], path)
}
check_path(path) {
  glob.match("foo/baz/*", ["/"], path)
}
```
-- when evaluating `check_path("foo/bar/quz")`, only the first rule body will be considered.


-------

This is originally branched off of #3475. Turns out the overlap wasn't too bad; so I'll deal with rebasing whatever goes in second.