### PR TITLE
topdown: memoize partial set results

### DIFF
--- a/ast/term.go
+++ b/ast/term.go
@@ -399,7 +399,7 @@ func (term *Term) Hash() int {
 	return term.Value.Hash()
 }
 
-// IsGround returns true if this terms' Value is ground.
+// IsGround returns true if this term's Value is ground.
 func (term *Term) IsGround() bool {
 	return term.Value.IsGround()
 }

--- a/topdown/topdown_partial_test.go
+++ b/topdown/topdown_partial_test.go
@@ -2246,13 +2246,13 @@ func TestTopDownPartialEval(t *testing.T) {
 				`
 					package partial.test
 
-					p { not data.partial.__not1_1_3__ }
+					p { not data.partial.__not1_1_4__ }
 					p { not data.partial.__not1_1_5__ }
 				`,
 				`
 					package partial
 
-					__not1_1_3__ { input[1] = x_term_3_01; x_term_3_01 }
+					__not1_1_4__ { input[1] = x_term_4_01; x_term_4_01 }
 					__not1_1_5__ { input[2] = x_term_5_01; x_term_5_01 }
 				`,
 			},

--- a/topdown/trace_test.go
+++ b/topdown/trace_test.go
@@ -87,6 +87,17 @@ func TestPrettyTrace(t *testing.T) {
 | | Enter data.test.q
 | | | Eval x = data.a[_]
 | | | Exit data.test.q
+| | Redo data.test.q
+| | | Redo x = data.a[_]
+| | | Exit data.test.q
+| | Redo data.test.q
+| | | Redo x = data.a[_]
+| | | Exit data.test.q
+| | Redo data.test.q
+| | | Redo x = data.a[_]
+| | | Exit data.test.q
+| | Redo data.test.q
+| | | Redo x = data.a[_]
 | | Eval plus(x, 1, n)
 | | Exit data.test.p
 | Exit data.test.p = _
@@ -95,32 +106,21 @@ Redo data.test.p = _
 | Redo data.test.p
 | | Redo plus(x, 1, n)
 | | Redo data.test.q[x]
-| | Redo data.test.q
-| | | Redo x = data.a[_]
-| | | Exit data.test.q
 | | Eval plus(x, 1, n)
 | | Exit data.test.p
 | Redo data.test.p
 | | Redo plus(x, 1, n)
 | | Redo data.test.q[x]
-| | Redo data.test.q
-| | | Redo x = data.a[_]
-| | | Exit data.test.q
 | | Eval plus(x, 1, n)
 | | Exit data.test.p
 | Redo data.test.p
 | | Redo plus(x, 1, n)
 | | Redo data.test.q[x]
-| | Redo data.test.q
-| | | Redo x = data.a[_]
-| | | Exit data.test.q
 | | Eval plus(x, 1, n)
 | | Exit data.test.p
 | Redo data.test.p
 | | Redo plus(x, 1, n)
 | | Redo data.test.q[x]
-| | Redo data.test.q
-| | | Redo x = data.a[_]
 `
 
 	a := strings.Split(expected, "\n")
@@ -180,6 +180,17 @@ query:3     | | Index data.test.q (matched 1 rule)
 query:4     | | Enter data.test.q
 query:4     | | | Eval x = data.a[_]
 query:4     | | | Exit data.test.q
+query:4     | | Redo data.test.q
+query:4     | | | Redo x = data.a[_]
+query:4     | | | Exit data.test.q
+query:4     | | Redo data.test.q
+query:4     | | | Redo x = data.a[_]
+query:4     | | | Exit data.test.q
+query:4     | | Redo data.test.q
+query:4     | | | Redo x = data.a[_]
+query:4     | | | Exit data.test.q
+query:4     | | Redo data.test.q
+query:4     | | | Redo x = data.a[_]
 query:3     | | Eval plus(x, 1, n)
 query:3     | | Exit data.test.p
 query:1     | Exit data.test.p = _
@@ -188,32 +199,21 @@ query:1     | Redo data.test.p = _
 query:3     | Redo data.test.p
 query:3     | | Redo plus(x, 1, n)
 query:3     | | Redo data.test.q[x]
-query:4     | | Redo data.test.q
-query:4     | | | Redo x = data.a[_]
-query:4     | | | Exit data.test.q
 query:3     | | Eval plus(x, 1, n)
 query:3     | | Exit data.test.p
 query:3     | Redo data.test.p
 query:3     | | Redo plus(x, 1, n)
 query:3     | | Redo data.test.q[x]
-query:4     | | Redo data.test.q
-query:4     | | | Redo x = data.a[_]
-query:4     | | | Exit data.test.q
 query:3     | | Eval plus(x, 1, n)
 query:3     | | Exit data.test.p
 query:3     | Redo data.test.p
 query:3     | | Redo plus(x, 1, n)
 query:3     | | Redo data.test.q[x]
-query:4     | | Redo data.test.q
-query:4     | | | Redo x = data.a[_]
-query:4     | | | Exit data.test.q
 query:3     | | Eval plus(x, 1, n)
 query:3     | | Exit data.test.p
 query:3     | Redo data.test.p
 query:3     | | Redo plus(x, 1, n)
 query:3     | | Redo data.test.q[x]
-query:4     | | Redo data.test.q
-query:4     | | | Redo x = data.a[_]
 `
 
 	a := strings.Split(expected, "\n")
@@ -243,15 +243,13 @@ func TestPrettyTraceWithLocationTruncatedPaths(t *testing.T) {
 	ctx := context.Background()
 
 	compiler := ast.MustCompileModules(map[string]string{
-		"authz_bundle/com/foo/bar/baz/qux/acme/corp/internal/authz/policies/abac/v1/beta/policy.rego": `
-		package test
+		"authz_bundle/com/foo/bar/baz/qux/acme/corp/internal/authz/policies/abac/v1/beta/policy.rego": `package test
 
 		import data.utils.q
 
 		p = true { q[x]; plus(x, 1, n) }
 		`,
-		"authz_bundle/com/foo/bar/baz/qux/acme/corp/internal/authz/policies/utils/utils.rego": `
-		package utils
+		"authz_bundle/com/foo/bar/baz/qux/acme/corp/internal/authz/policies/utils/utils.rego": `package utils
 
 		q[x] { x = data.a[_] }
 		`,
@@ -276,46 +274,46 @@ func TestPrettyTraceWithLocationTruncatedPaths(t *testing.T) {
 	expected := `query:1                                                              Enter data.test.p = _
 query:1                                                              | Eval data.test.p = _
 query:1                                                              | Index data.test.p (matched 1 rule)
-authz_bundle/...ternal/authz/policies/abac/v1/beta/policy.rego:6     | Enter data.test.p
-authz_bundle/...ternal/authz/policies/abac/v1/beta/policy.rego:6     | | Eval data.utils.q[x]
-authz_bundle/...ternal/authz/policies/abac/v1/beta/policy.rego:6     | | Index data.utils.q (matched 1 rule)
-authz_bundle/...ternal/authz/policies/utils/utils.rego:4             | | Enter data.utils.q
-authz_bundle/...ternal/authz/policies/utils/utils.rego:4             | | | Eval x = data.a[_]
-authz_bundle/...ternal/authz/policies/utils/utils.rego:4             | | | Exit data.utils.q
-authz_bundle/...ternal/authz/policies/abac/v1/beta/policy.rego:6     | | Eval plus(x, 1, n)
-authz_bundle/...ternal/authz/policies/abac/v1/beta/policy.rego:6     | | Exit data.test.p
+authz_bundle/...ternal/authz/policies/abac/v1/beta/policy.rego:5     | Enter data.test.p
+authz_bundle/...ternal/authz/policies/abac/v1/beta/policy.rego:5     | | Eval data.utils.q[x]
+authz_bundle/...ternal/authz/policies/abac/v1/beta/policy.rego:5     | | Index data.utils.q (matched 1 rule)
+authz_bundle/...ternal/authz/policies/utils/utils.rego:3             | | Enter data.utils.q
+authz_bundle/...ternal/authz/policies/utils/utils.rego:3             | | | Eval x = data.a[_]
+authz_bundle/...ternal/authz/policies/utils/utils.rego:3             | | | Exit data.utils.q
+authz_bundle/...ternal/authz/policies/utils/utils.rego:3             | | Redo data.utils.q
+authz_bundle/...ternal/authz/policies/utils/utils.rego:3             | | | Redo x = data.a[_]
+authz_bundle/...ternal/authz/policies/utils/utils.rego:3             | | | Exit data.utils.q
+authz_bundle/...ternal/authz/policies/utils/utils.rego:3             | | Redo data.utils.q
+authz_bundle/...ternal/authz/policies/utils/utils.rego:3             | | | Redo x = data.a[_]
+authz_bundle/...ternal/authz/policies/utils/utils.rego:3             | | | Exit data.utils.q
+authz_bundle/...ternal/authz/policies/utils/utils.rego:3             | | Redo data.utils.q
+authz_bundle/...ternal/authz/policies/utils/utils.rego:3             | | | Redo x = data.a[_]
+authz_bundle/...ternal/authz/policies/utils/utils.rego:3             | | | Exit data.utils.q
+authz_bundle/...ternal/authz/policies/utils/utils.rego:3             | | Redo data.utils.q
+authz_bundle/...ternal/authz/policies/utils/utils.rego:3             | | | Redo x = data.a[_]
+authz_bundle/...ternal/authz/policies/abac/v1/beta/policy.rego:5     | | Eval plus(x, 1, n)
+authz_bundle/...ternal/authz/policies/abac/v1/beta/policy.rego:5     | | Exit data.test.p
 query:1                                                              | Exit data.test.p = _
 query:1                                                              Redo data.test.p = _
 query:1                                                              | Redo data.test.p = _
-authz_bundle/...ternal/authz/policies/abac/v1/beta/policy.rego:6     | Redo data.test.p
-authz_bundle/...ternal/authz/policies/abac/v1/beta/policy.rego:6     | | Redo plus(x, 1, n)
-authz_bundle/...ternal/authz/policies/abac/v1/beta/policy.rego:6     | | Redo data.utils.q[x]
-authz_bundle/...ternal/authz/policies/utils/utils.rego:4             | | Redo data.utils.q
-authz_bundle/...ternal/authz/policies/utils/utils.rego:4             | | | Redo x = data.a[_]
-authz_bundle/...ternal/authz/policies/utils/utils.rego:4             | | | Exit data.utils.q
-authz_bundle/...ternal/authz/policies/abac/v1/beta/policy.rego:6     | | Eval plus(x, 1, n)
-authz_bundle/...ternal/authz/policies/abac/v1/beta/policy.rego:6     | | Exit data.test.p
-authz_bundle/...ternal/authz/policies/abac/v1/beta/policy.rego:6     | Redo data.test.p
-authz_bundle/...ternal/authz/policies/abac/v1/beta/policy.rego:6     | | Redo plus(x, 1, n)
-authz_bundle/...ternal/authz/policies/abac/v1/beta/policy.rego:6     | | Redo data.utils.q[x]
-authz_bundle/...ternal/authz/policies/utils/utils.rego:4             | | Redo data.utils.q
-authz_bundle/...ternal/authz/policies/utils/utils.rego:4             | | | Redo x = data.a[_]
-authz_bundle/...ternal/authz/policies/utils/utils.rego:4             | | | Exit data.utils.q
-authz_bundle/...ternal/authz/policies/abac/v1/beta/policy.rego:6     | | Eval plus(x, 1, n)
-authz_bundle/...ternal/authz/policies/abac/v1/beta/policy.rego:6     | | Exit data.test.p
-authz_bundle/...ternal/authz/policies/abac/v1/beta/policy.rego:6     | Redo data.test.p
-authz_bundle/...ternal/authz/policies/abac/v1/beta/policy.rego:6     | | Redo plus(x, 1, n)
-authz_bundle/...ternal/authz/policies/abac/v1/beta/policy.rego:6     | | Redo data.utils.q[x]
-authz_bundle/...ternal/authz/policies/utils/utils.rego:4             | | Redo data.utils.q
-authz_bundle/...ternal/authz/policies/utils/utils.rego:4             | | | Redo x = data.a[_]
-authz_bundle/...ternal/authz/policies/utils/utils.rego:4             | | | Exit data.utils.q
-authz_bundle/...ternal/authz/policies/abac/v1/beta/policy.rego:6     | | Eval plus(x, 1, n)
-authz_bundle/...ternal/authz/policies/abac/v1/beta/policy.rego:6     | | Exit data.test.p
-authz_bundle/...ternal/authz/policies/abac/v1/beta/policy.rego:6     | Redo data.test.p
-authz_bundle/...ternal/authz/policies/abac/v1/beta/policy.rego:6     | | Redo plus(x, 1, n)
-authz_bundle/...ternal/authz/policies/abac/v1/beta/policy.rego:6     | | Redo data.utils.q[x]
-authz_bundle/...ternal/authz/policies/utils/utils.rego:4             | | Redo data.utils.q
-authz_bundle/...ternal/authz/policies/utils/utils.rego:4             | | | Redo x = data.a[_]
+authz_bundle/...ternal/authz/policies/abac/v1/beta/policy.rego:5     | Redo data.test.p
+authz_bundle/...ternal/authz/policies/abac/v1/beta/policy.rego:5     | | Redo plus(x, 1, n)
+authz_bundle/...ternal/authz/policies/abac/v1/beta/policy.rego:5     | | Redo data.utils.q[x]
+authz_bundle/...ternal/authz/policies/abac/v1/beta/policy.rego:5     | | Eval plus(x, 1, n)
+authz_bundle/...ternal/authz/policies/abac/v1/beta/policy.rego:5     | | Exit data.test.p
+authz_bundle/...ternal/authz/policies/abac/v1/beta/policy.rego:5     | Redo data.test.p
+authz_bundle/...ternal/authz/policies/abac/v1/beta/policy.rego:5     | | Redo plus(x, 1, n)
+authz_bundle/...ternal/authz/policies/abac/v1/beta/policy.rego:5     | | Redo data.utils.q[x]
+authz_bundle/...ternal/authz/policies/abac/v1/beta/policy.rego:5     | | Eval plus(x, 1, n)
+authz_bundle/...ternal/authz/policies/abac/v1/beta/policy.rego:5     | | Exit data.test.p
+authz_bundle/...ternal/authz/policies/abac/v1/beta/policy.rego:5     | Redo data.test.p
+authz_bundle/...ternal/authz/policies/abac/v1/beta/policy.rego:5     | | Redo plus(x, 1, n)
+authz_bundle/...ternal/authz/policies/abac/v1/beta/policy.rego:5     | | Redo data.utils.q[x]
+authz_bundle/...ternal/authz/policies/abac/v1/beta/policy.rego:5     | | Eval plus(x, 1, n)
+authz_bundle/...ternal/authz/policies/abac/v1/beta/policy.rego:5     | | Exit data.test.p
+authz_bundle/...ternal/authz/policies/abac/v1/beta/policy.rego:5     | Redo data.test.p
+authz_bundle/...ternal/authz/policies/abac/v1/beta/policy.rego:5     | | Redo plus(x, 1, n)
+authz_bundle/...ternal/authz/policies/abac/v1/beta/policy.rego:5     | | Redo data.utils.q[x]
 `
 
 	a := strings.Split(expected, "\n")
@@ -530,6 +528,12 @@ query:1                                                              | Fail data
 }
 
 func TestTraceDuplicate(t *testing.T) {
+	// NOTE(sr): We're explicitly bypassing a caching optimization here:
+	// When the first query for a partial is `p[x]`, and `x` is not ground,
+	// we'll have the evaluation eval the full extent of the partial and
+	// cache that. Thus the second `p[1]` here will not trigger a duplicate
+	// event, because the query eval uses a different code path.
+	// Having `p[1]` queried first will side-step the caching optimization.
 	module := `package test
 
 	p[1]
@@ -545,7 +549,7 @@ func TestTraceDuplicate(t *testing.T) {
 	defer store.Abort(ctx, txn)
 
 	tracer := NewBufferTracer()
-	query := NewQuery(ast.MustParseBody("data.test.p[x] = _")).
+	query := NewQuery(ast.MustParseBody("data.test.p[1]; data.test.p[x] = _")).
 		WithCompiler(compiler).
 		WithStore(store).
 		WithTransaction(txn).
@@ -571,7 +575,7 @@ func TestTraceDuplicate(t *testing.T) {
 func TestTraceNote(t *testing.T) {
 	module := `package test
 
-	p = true { q[x]; plus(x, 1, n); trace(sprintf("n= %v", [n])) }
+	p = true { q[x]; plus(x, 1, n); trace(sprintf("n=%v", [n])) }
 	q[x] { x = data.a[_] }`
 
 	ctx := context.Background()
@@ -602,60 +606,60 @@ func TestTraceNote(t *testing.T) {
 | | Enter data.test.q
 | | | Eval x = data.a[_]
 | | | Exit data.test.q
+| | Redo data.test.q
+| | | Redo x = data.a[_]
+| | | Exit data.test.q
+| | Redo data.test.q
+| | | Redo x = data.a[_]
+| | | Exit data.test.q
+| | Redo data.test.q
+| | | Redo x = data.a[_]
+| | | Exit data.test.q
+| | Redo data.test.q
+| | | Redo x = data.a[_]
 | | Eval plus(x, 1, n)
-| | Eval sprintf("n= %v", [n], __local0__)
+| | Eval sprintf("n=%v", [n], __local0__)
 | | Eval trace(__local0__)
-| | Note "n= 2"
+| | Note "n=2"
 | | Exit data.test.p
 | Exit data.test.p = _
 Redo data.test.p = _
 | Redo data.test.p = _
 | Redo data.test.p
 | | Redo trace(__local0__)
-| | Redo sprintf("n= %v", [n], __local0__)
+| | Redo sprintf("n=%v", [n], __local0__)
 | | Redo plus(x, 1, n)
 | | Redo data.test.q[x]
-| | Redo data.test.q
-| | | Redo x = data.a[_]
-| | | Exit data.test.q
 | | Eval plus(x, 1, n)
-| | Eval sprintf("n= %v", [n], __local0__)
+| | Eval sprintf("n=%v", [n], __local0__)
 | | Eval trace(__local0__)
-| | Note "n= 3"
+| | Note "n=3"
 | | Exit data.test.p
 | Redo data.test.p
 | | Redo trace(__local0__)
-| | Redo sprintf("n= %v", [n], __local0__)
+| | Redo sprintf("n=%v", [n], __local0__)
 | | Redo plus(x, 1, n)
 | | Redo data.test.q[x]
-| | Redo data.test.q
-| | | Redo x = data.a[_]
-| | | Exit data.test.q
 | | Eval plus(x, 1, n)
-| | Eval sprintf("n= %v", [n], __local0__)
+| | Eval sprintf("n=%v", [n], __local0__)
 | | Eval trace(__local0__)
-| | Note "n= 4"
+| | Note "n=4"
 | | Exit data.test.p
 | Redo data.test.p
 | | Redo trace(__local0__)
-| | Redo sprintf("n= %v", [n], __local0__)
+| | Redo sprintf("n=%v", [n], __local0__)
 | | Redo plus(x, 1, n)
 | | Redo data.test.q[x]
-| | Redo data.test.q
-| | | Redo x = data.a[_]
-| | | Exit data.test.q
 | | Eval plus(x, 1, n)
-| | Eval sprintf("n= %v", [n], __local0__)
+| | Eval sprintf("n=%v", [n], __local0__)
 | | Eval trace(__local0__)
-| | Note "n= 5"
+| | Note "n=5"
 | | Exit data.test.p
 | Redo data.test.p
 | | Redo trace(__local0__)
-| | Redo sprintf("n= %v", [n], __local0__)
+| | Redo sprintf("n=%v", [n], __local0__)
 | | Redo plus(x, 1, n)
 | | Redo data.test.q[x]
-| | Redo data.test.q
-| | | Redo x = data.a[_]
 `
 
 	a := strings.Split(expected, "\n")
@@ -684,7 +688,7 @@ Redo data.test.p = _
 func TestTraceNoteWithLocation(t *testing.T) {
 	module := `package test
 
-	p = true { q[x]; plus(x, 1, n); trace(sprintf("n= %v", [n])) }
+	p = true { q[x]; plus(x, 1, n); trace(sprintf("n=%v", [n])) }
 	q[x] { x = data.a[_] }`
 
 	ctx := context.Background()
@@ -715,60 +719,60 @@ query:3     | | Index data.test.q (matched 1 rule)
 query:4     | | Enter data.test.q
 query:4     | | | Eval x = data.a[_]
 query:4     | | | Exit data.test.q
+query:4     | | Redo data.test.q
+query:4     | | | Redo x = data.a[_]
+query:4     | | | Exit data.test.q
+query:4     | | Redo data.test.q
+query:4     | | | Redo x = data.a[_]
+query:4     | | | Exit data.test.q
+query:4     | | Redo data.test.q
+query:4     | | | Redo x = data.a[_]
+query:4     | | | Exit data.test.q
+query:4     | | Redo data.test.q
+query:4     | | | Redo x = data.a[_]
 query:3     | | Eval plus(x, 1, n)
-query:3     | | Eval sprintf("n= %v", [n], __local0__)
+query:3     | | Eval sprintf("n=%v", [n], __local0__)
 query:3     | | Eval trace(__local0__)
-query:3     | | Note "n= 2"
+query:3     | | Note "n=2"
 query:3     | | Exit data.test.p
 query:1     | Exit data.test.p = _
 query:1     Redo data.test.p = _
 query:1     | Redo data.test.p = _
 query:3     | Redo data.test.p
 query:3     | | Redo trace(__local0__)
-query:3     | | Redo sprintf("n= %v", [n], __local0__)
+query:3     | | Redo sprintf("n=%v", [n], __local0__)
 query:3     | | Redo plus(x, 1, n)
 query:3     | | Redo data.test.q[x]
-query:4     | | Redo data.test.q
-query:4     | | | Redo x = data.a[_]
-query:4     | | | Exit data.test.q
 query:3     | | Eval plus(x, 1, n)
-query:3     | | Eval sprintf("n= %v", [n], __local0__)
+query:3     | | Eval sprintf("n=%v", [n], __local0__)
 query:3     | | Eval trace(__local0__)
-query:3     | | Note "n= 3"
+query:3     | | Note "n=3"
 query:3     | | Exit data.test.p
 query:3     | Redo data.test.p
 query:3     | | Redo trace(__local0__)
-query:3     | | Redo sprintf("n= %v", [n], __local0__)
+query:3     | | Redo sprintf("n=%v", [n], __local0__)
 query:3     | | Redo plus(x, 1, n)
 query:3     | | Redo data.test.q[x]
-query:4     | | Redo data.test.q
-query:4     | | | Redo x = data.a[_]
-query:4     | | | Exit data.test.q
 query:3     | | Eval plus(x, 1, n)
-query:3     | | Eval sprintf("n= %v", [n], __local0__)
+query:3     | | Eval sprintf("n=%v", [n], __local0__)
 query:3     | | Eval trace(__local0__)
-query:3     | | Note "n= 4"
+query:3     | | Note "n=4"
 query:3     | | Exit data.test.p
 query:3     | Redo data.test.p
 query:3     | | Redo trace(__local0__)
-query:3     | | Redo sprintf("n= %v", [n], __local0__)
+query:3     | | Redo sprintf("n=%v", [n], __local0__)
 query:3     | | Redo plus(x, 1, n)
 query:3     | | Redo data.test.q[x]
-query:4     | | Redo data.test.q
-query:4     | | | Redo x = data.a[_]
-query:4     | | | Exit data.test.q
 query:3     | | Eval plus(x, 1, n)
-query:3     | | Eval sprintf("n= %v", [n], __local0__)
+query:3     | | Eval sprintf("n=%v", [n], __local0__)
 query:3     | | Eval trace(__local0__)
-query:3     | | Note "n= 5"
+query:3     | | Note "n=5"
 query:3     | | Exit data.test.p
 query:3     | Redo data.test.p
 query:3     | | Redo trace(__local0__)
-query:3     | | Redo sprintf("n= %v", [n], __local0__)
+query:3     | | Redo sprintf("n=%v", [n], __local0__)
 query:3     | | Redo plus(x, 1, n)
 query:3     | | Redo data.test.q[x]
-query:4     | | Redo data.test.q
-query:4     | | | Redo x = data.a[_]
 `
 
 	a := strings.Split(expected, "\n")


### PR DESCRIPTION
We can either cache individual elements (`data.foo.p["bar"]`), or the
full extent of a partial set/object. A cached full extent of the partial
would be used when evaluating individual elements of the partial.

If the first encounter with a partial set/object has to materialize the
full extent with a variable key, like `data.foo.p[x]`, then we cache the
fully-evaluated result for `data.foo.p`.

Fixes #822.
