### PR TITLE
topdown: move arg count below ir.Empty()

### DIFF
--- a/test/cases/testdata/functions/test-functions-unused-arg.yaml
+++ b/test/cases/testdata/functions/test-functions-unused-arg.yaml
@@ -1,0 +1,12 @@
+cases:
+- data:
+  modules:
+  - |
+    package p
+    
+    f(x) {
+        r = input.that_is_not_there
+    }
+  note: basic call
+  query: data.p.f(1)
+  want_result: []

--- a/topdown/eval.go
+++ b/topdown/eval.go
@@ -1506,11 +1506,11 @@ func (e evalFunc) eval(iter unifyIterator) error {
 		return err
 	}
 
-	argCount := len(ir.Rules[0].Head.Args)
-
 	if ir.Empty() {
 		return nil
 	}
+
+	argCount := len(ir.Rules[0].Head.Args)
 
 	if len(ir.Else) > 0 && e.e.unknown(e.e.query[e.e.index], e.e.bindings) {
 		// Partial evaluation of ordered rules is not supported currently. Save the


### PR DESCRIPTION
...to avoid a panic at run time.

Fixes #3501.
