### PR TITLE
Support for minimum TLS version for opa server

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -35,6 +35,7 @@ type runCmdParams struct {
 	skipVersionCheck   bool
 	authentication     *util.EnumFlag
 	authorization      *util.EnumFlag
+	minTLSVersion      *util.EnumFlag
 	logLevel           *util.EnumFlag
 	logFormat          *util.EnumFlag
 	algorithm          string
@@ -50,6 +51,7 @@ func newRunParams() runCmdParams {
 		rt:             runtime.NewParams(),
 		authentication: util.NewEnumFlag("off", []string{"token", "tls", "off"}),
 		authorization:  util.NewEnumFlag("off", []string{"basic", "off"}),
+		minTLSVersion:  util.NewEnumFlag("1.2", []string{"1.0", "1.1", "1.2", "1.3"}),
 		logLevel:       util.NewEnumFlag("info", []string{"debug", "info", "error"}),
 		logFormat:      util.NewEnumFlag("json", []string{"text", "json", "json-pretty"}),
 	}
@@ -178,6 +180,7 @@ To skip bundle verification, use the --skip-verify flag.
 	runCommand.Flags().StringVarP(&cmdParams.tlsCACertFile, "tls-ca-cert-file", "", "", "set path of TLS CA cert file")
 	runCommand.Flags().VarP(cmdParams.authentication, "authentication", "", "set authentication scheme")
 	runCommand.Flags().VarP(cmdParams.authorization, "authorization", "", "set authorization scheme")
+	runCommand.Flags().VarP(cmdParams.minTLSVersion, "min-tls-version", "", "set minimum tls version to be used by opa server, default is 1.2")
 	runCommand.Flags().VarP(cmdParams.logLevel, "log-level", "l", "set log level")
 	runCommand.Flags().VarP(cmdParams.logFormat, "log-format", "", "set log format")
 	runCommand.Flags().IntVar(&cmdParams.rt.GracefulShutdownPeriod, "shutdown-grace-period", 10, "set the time (in seconds) that the server will wait to gracefully shut down")
@@ -235,6 +238,7 @@ func initRuntime(ctx context.Context, params runCmdParams, args []string) (*runt
 
 	params.rt.Authentication = authenticationSchemes[params.authentication.String()]
 	params.rt.Authorization = authorizationScheme[params.authorization.String()]
+	params.rt.MinTLSVersion = params.minTLSVersion.String()
 	params.rt.Certificate = cert
 	params.rt.Logging = runtime.LoggingConfig{
 		Level:  params.logLevel.String(),

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -180,7 +180,7 @@ To skip bundle verification, use the --skip-verify flag.
 	runCommand.Flags().StringVarP(&cmdParams.tlsCACertFile, "tls-ca-cert-file", "", "", "set path of TLS CA cert file")
 	runCommand.Flags().VarP(cmdParams.authentication, "authentication", "", "set authentication scheme")
 	runCommand.Flags().VarP(cmdParams.authorization, "authorization", "", "set authorization scheme")
-	runCommand.Flags().VarP(cmdParams.minTLSVersion, "min-tls-version", "", "set minimum tls version to be used by opa server, default is 1.2")
+	runCommand.Flags().VarP(cmdParams.minTLSVersion, "min-tls-version", "", "set minimum TLS version to be used by OPA's server, default is 1.2")
 	runCommand.Flags().VarP(cmdParams.logLevel, "log-level", "l", "set log level")
 	runCommand.Flags().VarP(cmdParams.logFormat, "log-format", "", "set log format")
 	runCommand.Flags().IntVar(&cmdParams.rt.GracefulShutdownPeriod, "shutdown-grace-period", 10, "set the time (in seconds) that the server will wait to gracefully shut down")
@@ -223,6 +223,13 @@ func initRuntime(ctx context.Context, params runCmdParams, args []string) (*runt
 		"off":   server.AuthorizationOff,
 	}
 
+	minTLSVersions := map[string]uint16{
+		"1.0": tls.VersionTLS10,
+		"1.1": tls.VersionTLS11,
+		"1.2": tls.VersionTLS12,
+		"1.3": tls.VersionTLS13,
+	}
+
 	cert, err := loadCertificate(params.tlsCertFile, params.tlsPrivateKeyFile)
 	if err != nil {
 		return nil, err
@@ -238,7 +245,7 @@ func initRuntime(ctx context.Context, params runCmdParams, args []string) (*runt
 
 	params.rt.Authentication = authenticationSchemes[params.authentication.String()]
 	params.rt.Authorization = authorizationScheme[params.authorization.String()]
-	params.rt.MinTLSVersion = params.minTLSVersion.String()
+	params.rt.MinTLSVersion = minTLSVersions[params.minTLSVersion.String()]
 	params.rt.Certificate = cert
 	params.rt.Logging = runtime.LoggingConfig{
 		Level:  params.logLevel.String(),

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -101,7 +101,7 @@ type Params struct {
 
 	// MinVersion contains the minimum TLS version that is acceptable.
 	// If zero, TLS 1.2 is currently taken as the minimum.
-	MinTLSVersion string
+	MinTLSVersion uint16
 
 	// HistoryPath is the filename to store the interactive shell user
 	// input history.

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -360,6 +360,7 @@ func (rt *Runtime) Serve(ctx context.Context) error {
 	}
 
 	defer rt.Manager.Stop(ctx)
+
 	rt.server = server.New().
 		WithRouter(rt.Params.Router).
 		WithStore(rt.Store).

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -99,6 +99,10 @@ type Params struct {
 	// CertPool holds the CA certs trusted by the OPA server.
 	CertPool *x509.CertPool
 
+	// MinVersion contains the minimum TLS version that is acceptable.
+	// If zero, TLS 1.2 is currently taken as the minimum.
+	MinTLSVersion string
+
 	// HistoryPath is the filename to store the interactive shell user
 	// input history.
 	HistoryPath string
@@ -356,7 +360,6 @@ func (rt *Runtime) Serve(ctx context.Context) error {
 	}
 
 	defer rt.Manager.Stop(ctx)
-
 	rt.server = server.New().
 		WithRouter(rt.Params.Router).
 		WithStore(rt.Store).
@@ -372,7 +375,8 @@ func (rt *Runtime) Serve(ctx context.Context) error {
 		WithDecisionIDFactory(rt.decisionIDFactory).
 		WithDecisionLoggerWithErr(rt.decisionLogger).
 		WithRuntime(rt.Manager.Info).
-		WithMetrics(rt.metrics)
+		WithMetrics(rt.metrics).
+		WithMinTLSVersion(rt.Params.MinTLSVersion)
 
 	if rt.Params.DiagnosticAddrs != nil {
 		rt.server = rt.server.WithDiagnosticAddresses(*rt.Params.DiagnosticAddrs)

--- a/server/server.go
+++ b/server/server.go
@@ -480,7 +480,6 @@ func (b *baseHTTPListener) Type() httpListenerType {
 func isMinTLSVersionSupported(TLSVersion uint16) bool {
 	for _, version := range supportedTLSVersions {
 		if TLSVersion == version {
-
 			return true
 		}
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -59,17 +59,7 @@ const (
 	AuthenticationTLS
 )
 
-const (
-
-	//TLSVersion10 is a constant for tls version 1.0
-	TLSVersion10 = "1.0"
-	//TLSVersion11 is a constant for tls version 1.1
-	TLSVersion11 = "1.1"
-	//TLSVersion12 is a constant for tls version 1.2
-	TLSVersion12 = "1.2"
-	//TLSVersion13 is a constant for tls version 1.3
-	TLSVersion13 = "1.3"
-)
+var supportedTLSVersions = []uint16{tls.VersionTLS10, tls.VersionTLS11, tls.VersionTLS12, tls.VersionTLS13}
 
 // AuthorizationScheme enumerates the supported authorization schemes. The authorization
 // scheme determines how access to OPA is controlled.
@@ -80,6 +70,7 @@ const (
 	AuthorizationOff AuthorizationScheme = iota
 	AuthorizationBasic
 )
+
 const defaultMinTLSVersion = tls.VersionTLS12
 
 // Set of handlers for use in the "handler" dimension of the duration metric.
@@ -316,8 +307,12 @@ func (s *Server) WithRouter(router *mux.Router) *Server {
 	return s
 }
 
-func (s *Server) WithMinTLSVersion(minTLSVersion string) *Server {
-	s.minTLSVersion = getMinTLSVersion(minTLSVersion)
+func (s *Server) WithMinTLSVersion(minTLSVersion uint16) *Server {
+	if isMinTLSVersionSupported(minTLSVersion) {
+		s.minTLSVersion = minTLSVersion
+	} else {
+		s.minTLSVersion = defaultMinTLSVersion
+	}
 	return s
 }
 
@@ -482,20 +477,14 @@ func (b *baseHTTPListener) Type() httpListenerType {
 	return b.t
 }
 
-func getMinTLSVersion(minTLSVersion string) (minServerTlSVersion uint16) {
-	switch minTLSVersion {
-	case TLSVersion10:
-		minServerTlSVersion = tls.VersionTLS10
-	case TLSVersion11:
-		minServerTlSVersion = tls.VersionTLS11
-	case TLSVersion12:
-		minServerTlSVersion = tls.VersionTLS12
-	case TLSVersion13:
-		minServerTlSVersion = tls.VersionTLS13
-	default:
-		minServerTlSVersion = defaultMinTLSVersion
+func isMinTLSVersionSupported(TLSVersion uint16) bool {
+	for _, version := range supportedTLSVersions {
+		if TLSVersion == version {
+
+			return true
+		}
 	}
-	return
+	return false
 }
 
 func (s *Server) getListener(addr string, h http.Handler, t httpListenerType) (Loop, httpListener, error) {

--- a/test/e2e/tls/tls_test.go
+++ b/test/e2e/tls/tls_test.go
@@ -32,10 +32,9 @@ func fatal(err interface{}) {
 }
 
 func TestMain(m *testing.M) {
-	minTLSVersion := flag.String("--min-TLS-Version", "1.2", "minimum TLS Version")
+	minTLSVersion := flag.String("--min-tls-version", "1.2", "minimum TLS Version")
 	TLSVersion := minTLSVersions[*minTLSVersion]
 	flag.Parse()
-	var err error
 
 	caCertPEM, err := ioutil.ReadFile("testdata/ca.pem")
 	if err != nil {
@@ -126,7 +125,7 @@ func TestNotDefaultTLSVersion(t *testing.T) {
 
 	oldArgs := os.Args
 	defer func() { os.Args = oldArgs }()
-	os.Args = []string{"cmd", "--min-TLS-Version", "1.3"}
+	os.Args = []string{"cmd", "--min-tls-version", "1.3"}
 	endpoint := testRuntime.URL()
 	t.Run("server started with min TLS Version 1.3, client connecting with not supported TLS version", func(t *testing.T) {
 


### PR DESCRIPTION
Opa server now supports minimum TLS version. Since TLS 1.0 and 1.1 are deprecated, default minimum TLS version for opa server is TLS 1.2 . If someone wants to restrict opa to start with a specific minimum tls version, they can specify it using cmd line parameter --min-tls-version. TLS versions supported are 1.0, 1.1, 1.2, 1.3.
 
fixes #3226
Signed-off-by: Amruta Kale <amruta.kale@styra.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/main/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/main/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
