### PR TITLE
cmd/fmt: fix incorrect help text

### DIFF
--- a/cmd/fmt.go
+++ b/cmd/fmt.go
@@ -48,7 +48,7 @@ If the '-l' option is supplied, the 'fmt' command will output the names of files
 that would change if formatted. The '-l' option will suppress any other output
 to stdout from the 'fmt' command.
 
-If the '-e' option is supplied, the 'fmt' command will return a non zero exit
+If the '--fail' option is supplied, the 'fmt' command will return a non zero exit
 code if a file would be reformatted.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		os.Exit(opaFmt(args))


### PR DESCRIPTION
The help text for opa fmt stated that -e could
be used as shorthand. This is not correct.
This commit changed to the correct flag --fail.

Fixes: #3518

Signed-off-by: Andre Håland <andre.haland@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/main/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/main/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
