### PR TITLE
Bugfix: treat missing/empty roots as owning all paths

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -2086,7 +2086,13 @@ func (s *Server) checkPathScope(ctx context.Context, txn storage.Transaction, pa
 	spathParts := strings.Split(spath, "/")
 
 	for name, roots := range bundleRoots {
+		if roots == nil {
+			return types.BadRequestErr(fmt.Sprintf("all paths owned by bundle %q", name))
+		}
 		for _, root := range roots {
+			if root == "" {
+				return types.BadRequestErr(fmt.Sprintf("all paths owned by bundle %q", name))
+			}
 			if isPathOwned(spathParts, strings.Split(root, "/")) {
 				return types.BadRequestErr(fmt.Sprintf("path %v is owned by bundle %q", spath, name))
 			}


### PR DESCRIPTION
A bundle without a manifest, or a manifest with no roots declared, or a manifest with a `""` declared as one of the roots.. should all be considered owners of all paths.

Caused by change in PR [#3033](https://github.com/open-policy-agent/opa/pull/3033).

Fixes #3521

Signed-off-by: Anders Eknert <anders@eknert.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/main/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/main/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
