### PR TITLE
Update downloader's Etag to last successful act value

### DIFF
--- a/download/download.go
+++ b/download/download.go
@@ -111,9 +111,14 @@ func (d *Downloader) WithBundlePersistence(persist bool) *Downloader {
 	return d
 }
 
-// ClearCache resets the etag value on the downloader
+// ClearCache is deprecated. Use SetCache instead.
 func (d *Downloader) ClearCache() {
 	d.etag = ""
+}
+
+// SetCache sets the given etag value on the downloader.
+func (d *Downloader) SetCache(etag string) {
+	d.etag = etag
 }
 
 // Start tells the Downloader to begin downloading bundles.

--- a/plugins/bundle/plugin.go
+++ b/plugins/bundle/plugin.go
@@ -369,7 +369,8 @@ func (p *Plugin) process(ctx context.Context, name string, u download.Update) {
 		p.log(name).Error("Bundle load failed: %v", u.Error)
 		p.status[name].SetError(u.Error)
 		if !p.stopped {
-			p.downloaders[name].ClearCache()
+			etag := p.etags[name]
+			p.downloaders[name].SetCache(etag)
 		}
 		return
 	}
@@ -386,7 +387,8 @@ func (p *Plugin) process(ctx context.Context, name string, u download.Update) {
 			p.log(name).Error("Bundle activation failed: %v", err)
 			p.status[name].SetError(err)
 			if !p.stopped {
-				p.downloaders[name].ClearCache()
+				etag := p.etags[name]
+				p.downloaders[name].SetCache(etag)
 			}
 			return
 		}
@@ -399,7 +401,8 @@ func (p *Plugin) process(ctx context.Context, name string, u download.Update) {
 				p.log(name).Error("Persisting bundle to disk failed: %v", err)
 				p.status[name].SetError(err)
 				if !p.stopped {
-					p.downloaders[name].ClearCache()
+					etag := p.etags[name]
+					p.downloaders[name].SetCache(etag)
 				}
 				return
 			}
@@ -617,6 +620,7 @@ func (p *Plugin) getBundlePersistPath() (string, error) {
 type bundleLoader interface {
 	Start(context.Context)
 	Stop(context.Context)
+	SetCache(string)
 	ClearCache()
 }
 
@@ -654,5 +658,9 @@ func (*fileLoader) Stop(context.Context) {
 }
 
 func (*fileLoader) ClearCache() {
+
+}
+
+func (*fileLoader) SetCache(string) {
 
 }


### PR DESCRIPTION
Earlier the client would reset the etag on the downloader
in case of downloader errors and bundle activation failures.
The drawback of this approach is that OPA could potentially download
the same version of a bundle multiple times thereby unnecessarily
adding to network traffic.

This change resolves the issue by allowing the client to set
the etag on the downloader to the last successful activation
etag value in case of failures.

Signed-off-by: Ashutosh Narkar <anarkar4387@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/main/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/main/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
