### PR TITLE
topdown/cache: Check cache value size during insert operation

### DIFF
--- a/topdown/cache/cache.go
+++ b/topdown/cache/cache.go
@@ -123,7 +123,13 @@ func (c *cache) UpdateConfig(config *Config) {
 func (c *cache) unsafeInsert(k ast.Value, v InterQueryCacheValue) (dropped int) {
 	size := v.SizeInBytes()
 	limit := c.maxSizeBytes()
+
 	if limit > 0 {
+		if size > limit {
+			dropped++
+			return dropped
+		}
+
 		for key := c.l.Front(); key != nil && (c.usage+size > limit); key = key.Next() {
 			dropKey := key.Value.(ast.Value)
 			c.unsafeDelete(dropKey)

--- a/topdown/cache/cache_test.go
+++ b/topdown/cache/cache_test.go
@@ -80,9 +80,22 @@ func TestInsert(t *testing.T) {
 	}
 
 	cache := NewInterQueryCache(config)
-	cacheValue := newInterQueryCacheValue(ast.StringTerm("bar").Value, 20)
 
-	dropped := cache.Insert(ast.StringTerm("foo").Value, cacheValue)
+	// large cache value that exceeds limit
+	cacheValueLarge := newInterQueryCacheValue(ast.StringTerm("bar").Value, 40)
+	dropped := cache.Insert(ast.StringTerm("foo").Value, cacheValueLarge)
+
+	if dropped != 1 {
+		t.Fatal("Expected dropped to be one")
+	}
+
+	_, found := cache.Get(ast.StringTerm("foo").Value)
+	if found {
+		t.Fatal("Unexpected key \"foo\" in cache")
+	}
+
+	cacheValue := newInterQueryCacheValue(ast.StringTerm("bar").Value, 20)
+	dropped = cache.Insert(ast.StringTerm("foo").Value, cacheValue)
 
 	if dropped != 0 {
 		t.Fatal("Expected dropped to be zero")
@@ -96,7 +109,7 @@ func TestInsert(t *testing.T) {
 		t.Fatal("Expected dropped to be one")
 	}
 
-	_, found := cache.Get(ast.StringTerm("foo2").Value)
+	_, found = cache.Get(ast.StringTerm("foo2").Value)
 	if !found {
 		t.Fatal("Expected key \"foo2\" in cache")
 	}


### PR DESCRIPTION
Previously while inserting an item in the cache, there was no
check to see if the item's size exceeded the cache limit. This
would result in that item being added to cache which is incorrect
behavior.This change adds an item size check during a cache insert.

Signed-off-by: Ashutosh Narkar <anarkar4387@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/main/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/main/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
