### PR TITLE
docs/content/oauth-oidc.md: Fixed concat command in metadata discovery method

### DIFF
--- a/docs/content/oauth-oidc.md
+++ b/docs/content/oauth-oidc.md
@@ -16,7 +16,7 @@ package oidc
 issuers = {"https://issuer1.example.com", "https://issuer2.example.com"}
 
 metadata_discovery(issuer) = http.send({
-    "url": concat("", issuers[issuer], "/.well-known/openid-configuration",
+    "url": concat("", [issuers[issuer], "/.well-known/openid-configuration"]),
     "method": "GET",
     "force_cache": true,
     "force_cache_duration_seconds": 86400 # Cache response for 24 hours


### PR DESCRIPTION
docs/content/oauth-oidc.md:

The concat command to assemble the url for metadata discovery was not correctly formatted. Missing [] and ending ).


This is my commit message

Signed-off-by: Jonas Iggbom <jonas@curity.io>