### PR TITLE
topdown: Fix PE unknown check to avoid saving unnecessarily

### DIFF
--- a/topdown/eval.go
+++ b/topdown/eval.go
@@ -1761,12 +1761,10 @@ func (e evalTree) eval(iter unifyIterator) error {
 
 func (e evalTree) finish(iter unifyIterator) error {
 
-	// During partial evaluation it may not be possible to compute the value
-	// for this reference if it refers to a virtual document so save the entire
-	// expression. See "save: full extent" test case for an example. We also
-	// need to account for the inlining controls here to prevent base documents
-	// from being inlined when they should not be.
-	save := e.e.unknown(e.ref, e.e.bindings)
+	// In some cases, it may not be possible to PE the ref. If the path refers
+	// to virtual docs that PE does not support or base documents where inlining
+	// has been disabled, then we have to save.
+	save := e.e.unknown(e.plugged, e.e.bindings)
 
 	if save {
 		return e.e.saveUnify(ast.NewTerm(e.plugged), e.rterm, e.bindings, e.rbindings, iter)

--- a/topdown/topdown_partial_test.go
+++ b/topdown/topdown_partial_test.go
@@ -104,6 +104,38 @@ func TestTopDownPartialEval(t *testing.T) {
 			},
 		},
 		{
+			note:  "iterate data - unknown key",
+			query: `data.test.p = true`,
+			data:  `{"x": {"foo": 7, "bar": 7}}`,
+			modules: []string{
+				`
+					package test
+
+					p {
+						input.x = k
+						data.x[k] = 7
+					}
+				`,
+			},
+			wantQueries: []string{`input.x = "foo"`, `input.x = "bar"`},
+		},
+		{
+			note:  "iterate data - unknown key undefined",
+			query: `data.test.p = true`,
+			data:  `{"x": {"foo": 8, "bar": 8}}`,
+			modules: []string{
+				`
+					package test
+
+					p {
+						input.x = k
+						data.x[k] = 7
+					}
+				`,
+			},
+			wantQueries: []string{},
+		},
+		{
 			note:  "iterate rules: partial object",
 			query: `data.test.p[x] = input.x`,
 			modules: []string{


### PR DESCRIPTION
The PE unknown check in the evalTree phase while finishing a ref was
incorrectly checking for unknowns on the unplugged ref. This mean that
if a ref element was unknown, that the expression would get saved and
evaluation would be skipped even though the ref key was
enumerated. This resulted in more results being generated by PE than
necessary and lead to expressions that could not be indexed.

Fixes #3552

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/main/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/main/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
