### PR TITLE
ast, topdown: Improve indexer to understand function args

### DIFF
--- a/ast/compile.go
+++ b/ast/compile.go
@@ -1162,7 +1162,7 @@ func (c *Compiler) rewriteExprTerms() {
 
 // rewriteTermsInHead will rewrite rules so that the head does not contain any
 // terms that require evaluation (e.g., refs or comprehensions). If the key or
-// value contains or more of these terms, the key or value will be moved into
+// value contains one or more of these terms, the key or value will be moved into
 // the body and assigned to a new variable. The new variable will replace the
 // key or value in the head.
 //

--- a/ast/compile_test.go
+++ b/ast/compile_test.go
@@ -2284,7 +2284,7 @@ func TestRewriteDeclaredVars(t *testing.T) {
 					f(input, "bar")
 				}
 
-				f(x,y) {
+				f(x, y) {
 					x[y]
 				}
 				`,

--- a/ast/policy.go
+++ b/ast/policy.go
@@ -33,6 +33,11 @@ var InputRootDocument = VarTerm("input")
 // SchemaRootDocument names the document containing external data schemas.
 var SchemaRootDocument = VarTerm("schema")
 
+// FunctionArgRootDocument names the document containing function arguments.
+// It's only for internal usage, for referencing function arguments between
+// the index and topdown.
+var FunctionArgRootDocument = VarTerm("args")
+
 // RootDocumentNames contains the names of top-level documents that can be
 // referred to in modules and queries.
 //

--- a/ast/term.go
+++ b/ast/term.go
@@ -128,12 +128,12 @@ func As(v Value, x interface{}) error {
 
 // Resolver defines the interface for resolving references to native Go values.
 type Resolver interface {
-	Resolve(ref Ref) (value interface{}, err error)
+	Resolve(ref Ref) (interface{}, error)
 }
 
 // ValueResolver defines the interface for resolving references to AST values.
 type ValueResolver interface {
-	Resolve(ref Ref) (value Value, err error)
+	Resolve(ref Ref) (Value, error)
 }
 
 // UnknownValueErr indicates a ValueResolver was unable to resolve a reference
@@ -466,7 +466,7 @@ func IsComprehension(x Value) bool {
 // ContainsRefs returns true if the Value v contains refs.
 func ContainsRefs(v interface{}) bool {
 	found := false
-	WalkRefs(v, func(r Ref) bool {
+	WalkRefs(v, func(Ref) bool {
 		found = true
 		return found
 	})

--- a/topdown/topdown_bench_test.go
+++ b/topdown/topdown_bench_test.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 	"text/template"
@@ -626,6 +627,51 @@ func BenchmarkComprehensionIndexing(b *testing.B) {
 			})
 		}
 	}
+}
+
+func BenchmarkFunctionArgumentIndex(b *testing.B) {
+	ctx := context.Background()
+
+	sizes := []int{10, 100, 1000}
+
+	for _, n := range sizes {
+		compiler := ast.MustCompileModules(map[string]string{
+			"test.rego": moduleWithDefs(n),
+		})
+		body := ast.MustParseBody(fmt.Sprintf("data.test.f(%d, x)", n))
+
+		b.Run(fmt.Sprint(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				q := NewQuery(body).
+					WithCompiler(compiler).
+					WithIndexing(true)
+
+				res, err := q.Run(ctx)
+				if err != nil {
+					b.Fatal(err)
+				}
+
+				if len(res) != 1 {
+					b.Fatalf("Expected one result, got %d", len(res))
+				}
+				if !ast.Boolean(true).Equal(res[0][ast.Var("x")].Value) {
+					b.Errorf("expected x=>true, got %v", res[0])
+				}
+			}
+		})
+	}
+}
+
+func moduleWithDefs(n int) string {
+	var b strings.Builder
+
+	b.WriteString(`package test
+`)
+	for i := 1; i <= n; i++ {
+		fmt.Fprintf(&b, `f(x) = y { y := true; x == %[1]d }
+`, i)
+	}
+	return b.String()
 }
 
 func genComprehensionIndexingData(n int) map[string]interface{} {


### PR DESCRIPTION
This commit improves the rule indexer to understand function
args. Function arguments are stored via their argument index, to allow
for different variable names (as re-written by the compiler). So, for

    f(x, y, z) = { x = 10; y = 12; z > 1 }

the indexer will store the rule at

    - args[0]: scalar(10) args[1]: scalar(12)

The callsite-local function arguments are handed off to evalResolver,
which enhances eval's Resolve() method.

Benchmark results:

    name                           old time/op    new time/op    delta
    FunctionArgumentIndex/10-16      23.2µs ± 6%     6.1µs ± 1%  -73.75%  (p=0.008 n=5+5)
    FunctionArgumentIndex/100-16      187µs ± 2%       6µs ± 1%  -96.70%  (p=0.008 n=5+5)
    FunctionArgumentIndex/1000-16    2.23ms ± 3%    0.01ms ± 2%  -99.68%  (p=0.008 n=5+5)

    name                           old alloc/op   new alloc/op   delta
    FunctionArgumentIndex/10-16      20.3kB ± 0%     5.3kB ± 0%  -74.13%  (p=0.008 n=5+5)
    FunctionArgumentIndex/100-16      174kB ± 0%       5kB ± 0%  -96.98%  (p=0.008 n=5+5)
    FunctionArgumentIndex/1000-16    1.76MB ± 0%    0.01MB ± 0%  -99.70%  (p=0.008 n=5+5)

    name                           old allocs/op  new allocs/op  delta
    FunctionArgumentIndex/10-16         296 ± 0%        91 ± 0%  -69.26%  (p=0.008 n=5+5)
    FunctionArgumentIndex/100-16      2.29k ± 0%     0.09k ± 0%  -96.02%  (p=0.008 n=5+5)
    FunctionArgumentIndex/1000-16     22.1k ± 0%      0.1k ± 0%  -99.59%  (p=0.008 n=5+5

Signed-off-by: Stephan Renatus <stephan.renatus@gmail.com>
Signed-off-by: Torin Sandall <torinsandall@gmail.com>

Co-authored-by: Stephan Renatus <stephan.renatus@gmail.com>
Co-authored-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/main/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/main/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
