### PR TITLE
types: Use binary search for static property lookup

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -346,16 +346,21 @@ func (t *Object) MarshalJSON() ([]byte, error) {
 
 // Select returns the type of the named property.
 func (t *Object) Select(name interface{}) Type {
-	for _, p := range t.static {
-		if util.Compare(p.Key, name) == 0 {
-			return p.Value
-		}
+
+	pos := sort.Search(len(t.static), func(x int) bool {
+		return util.Compare(t.static[x].Key, name) >= 0
+	})
+
+	if pos < len(t.static) && util.Compare(t.static[pos].Key, name) == 0 {
+		return t.static[pos].Value
 	}
+
 	if t.dynamic != nil {
 		if Contains(t.dynamic.Key, TypeOf(name)) {
 			return t.dynamic.Value
 		}
 	}
+
 	return nil
 }
 

--- a/types/types_bench_test.go
+++ b/types/types_bench_test.go
@@ -1,0 +1,40 @@
+// Copyright 2021 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package types
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+)
+
+func BenchmarkSelect(b *testing.B) {
+	sizes := []int{1000, 10000, 100000}
+	for _, size := range sizes {
+		b.Run(fmt.Sprint(size), func(b *testing.B) {
+			tpe := generateType(size)
+			runSelectBenchmark(b, tpe, json.Number(fmt.Sprint(size-1)))
+		})
+	}
+}
+
+func runSelectBenchmark(b *testing.B, tpe Type, key interface{}) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if result := Select(tpe, key); result != nil {
+			if Compare(result, N) != 0 {
+				b.Fatal("expected number type")
+			}
+		}
+	}
+}
+
+func generateType(n int) Type {
+	static := make([]*StaticProperty, n)
+	for i := 0; i < n; i++ {
+		static[i] = NewStaticProperty(json.Number(fmt.Sprint(i)), N)
+	}
+	return NewObject(static, nil)
+}


### PR DESCRIPTION
The static properties are stored in sorted order so perform a binary
search to lookup instead of scanning all keys.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/main/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/main/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
