### PR TITLE
Fix unmarshal json with json special characters

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -82,7 +82,7 @@ func Load(configFile string, overrides []string, overrideFiles []string) ([]byte
 
 		processedConf := subEnvVars(string(bytes))
 
-		if err := yaml.Unmarshal([]byte(processedConf), &baseConf); err != nil {
+		if err := util.Unmarshal([]byte(processedConf), &baseConf); err != nil {
 			return []byte{}, fmt.Errorf("failed to parse %s: %s", configFile, err)
 		}
 	}

--- a/util/json.go
+++ b/util/json.go
@@ -105,6 +105,9 @@ func Reference(x interface{}) *interface{} {
 
 // Unmarshal decodes a YAML or JSON value into the specified type.
 func Unmarshal(bs []byte, v interface{}) error {
+	if err := UnmarshalJSON(bs, v); err == nil {
+		return nil
+	}
 	bs, err := yaml.YAMLToJSON(bs)
 	if err != nil {
 		return err


### PR DESCRIPTION
`util.Unmarshal` was not possible to unmarshal a json string containing `\/` (which is an escaped `/`).
We used to call `util.UnmarshalJSON` after converting yaml to json, but we avoid this problem by calling `util.UnmarshalJSON` first.

I found this behavior in this project.
https://github.com/open-policy-agent/opa-envoy-plugin

More specifically, it seems that this event occurs in this call part of opa-envoy-plugin.
https://github.com/open-policy-agent/opa-envoy-plugin/blob/b60ae7e0bf3155f78149bcffee26b90c16982b61/envoyauth/request.go#L129