### PR TITLE
ci: add binary smoke tests (windows, macos)

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -173,6 +173,39 @@ jobs:
       - name: Test images
         run: make ci-image-smoke-test
 
+  smoke-test-binaries:
+    runs-on: ${{ matrix.os }}
+    needs: [go-build-linux, go-build-darwin, go-build-windows]
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            exec: opa_linux_amd64
+          - os: ubuntu-latest
+            exec: opa_linux_amd64_static
+            wasm: disabled
+          - os: macos-latest
+            exec: opa_darwin_amd64
+          - os: windows-latest
+            exec: opa_windows_amd64.exe
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Download release binaries
+        uses: actions/download-artifact@v2
+        with:
+          name: binaries
+          path: _release
+
+      - name: Test binaries (Rego)
+        run: make ci-binary-smoke-test-rego BINARY=${{ matrix.exec }}
+
+      - name: Test binaries (Wasm)
+        run: make ci-binary-smoke-test-wasm BINARY=${{ matrix.exec }}
+        if: matrix.wasm != 'disabled'
+
   nodejs-wasm-example:
     name: npm-opa-wasm
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -322,6 +322,11 @@ ci-image-smoke-test: image-quick
 	$(DOCKER) run $(DOCKER_IMAGE):$(VERSION)-rootless version
 	$(DOCKER) run $(DOCKER_IMAGE):$(VERSION)-static-ci-only version
 
+.PHONY: ci-binary-smoke-test-%
+ci-binary-smoke-test-%:
+	chmod +x "$(RELEASE_DIR)/$(BINARY)"
+	"$(RELEASE_DIR)/$(BINARY)" eval -t "$*" 'time.now_ns()'
+
 .PHONY: push
 push:
 	$(DOCKER) push $(DOCKER_IMAGE):$(VERSION)


### PR DESCRIPTION
With this change, we'll execute our binaries on macos, windows, and linux (-static); with wasm enabled where possible.

This closes a gap in CI we've had so far: no automated testing of binaries on windows and macos. It doesn't add too much over the docker image smoke tests we have for the different linux variants, but better safe than sorry (again) 😅 