### PR TITLE
wasm: emit unreachable instruction after opa_abort()

### DIFF
--- a/internal/wasm/sdk/opa/opa_test.go
+++ b/internal/wasm/sdk/opa/opa_test.go
@@ -225,6 +225,13 @@ a = "c" { input > 2 }`,
 				{Result: `{{}}`},
 			},
 		},
+		{
+			Description: "Runtime error/bad utf8 input to count()",
+			Policy:      `a = count(base64.decode("2E84ZuPUd7zfvCZSNEchVpDEIj6PL7JfLpIqyxVG16k="))`,
+			Query:       "data.p.a = x",
+			Evals:       []Eval{{}},
+			WantErr:     "internal_error: string: invalid unicode",
+		},
 	}
 
 	for _, test := range tests {

--- a/wasm/src/json.c
+++ b/wasm/src/json.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 
+#include "stdlib.h"
 #include "str.h"
 #include "value.h"
 #include "json.h"

--- a/wasm/src/lib/stdio.c
+++ b/wasm/src/lib/stdio.c
@@ -2,6 +2,7 @@
 #include "printf.h"
 
 #include "../std.h"
+#include "stdlib.h"
 
 struct _FILE {};
 

--- a/wasm/src/lib/stdlib.c
+++ b/wasm/src/lib/stdlib.c
@@ -15,6 +15,12 @@ void abort(void)
     }
 }
 
+void opa_abort(const char *msg)
+{
+    opa_abort_(msg);
+    __builtin_unreachable();
+}
+
 void *malloc(size_t size)
 {
     return opa_malloc(size);

--- a/wasm/src/lib/stdlib.h
+++ b/wasm/src/lib/stdlib.h
@@ -7,6 +7,8 @@
 extern "C" {
 #endif
 
+void opa_abort(const char *msg);
+__attribute__((import_name("opa_abort"))) void opa_abort_(const char *msg);
 void abort(void);
 void *malloc(size_t size);
 void free(void *ptr);

--- a/wasm/src/malloc.c
+++ b/wasm/src/malloc.c
@@ -1,5 +1,6 @@
 #include <string.h>
 #include "std.h"
+#include "stdlib.h"
 
 #define WASM_PAGE_SIZE (65536)
 

--- a/wasm/src/std.h
+++ b/wasm/src/std.h
@@ -11,7 +11,6 @@ extern "C" {
 #define container_of(ptr, type, member)                             \
     ((type *)(void *)( ((char *)(ptr) - offsetof(type, member) )))
 
-void opa_abort(const char *msg);
 void opa_println(const char *msg);
 
 #ifdef DEBUG

--- a/wasm/src/undefined.symbols
+++ b/wasm/src/undefined.symbols
@@ -1,4 +1,3 @@
-opa_abort
 opa_println
 opa_builtin0
 opa_builtin1


### PR DESCRIPTION
It's become apparent that a call to opa_abort in opa_agg_count did NOT
stop execution. Failures in bad input there haven't been thoroughly tested.

Comparing to the calls to opa_abort that happen in compiler-emitted code
(as opposed to calls in the C portion of our wasm code base), we find that
they are always emitting `unreachable` after the call to opa_abort.

As it turns out, doing the same thing in the C parts fixes the problem.
It thus seems like this is somehow related to changes in wasmtime's
cranelift (or its backend). It's never wrong to give the compiler some
more information that we can readily share, so let's put some `unreachable`
into the their proper places.

To avoid touching the entire code base of the C parts, we're defining a
function called `opa_abort(msg)` that'll call `opa_abort_(msg)` followed
by `__builtin_unreachable()`, which gives us that instruction. `opa_abort_`
in turn is imported as `opa_abort`, to keep compatibility with any SDKs
out there.

Signed-off-by: Stephan Renatus <stephan.renatus@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/main/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/main/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
