### PR TITLE
plugins/rest: Add option to specify CA for remote services

### DIFF
--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -242,6 +242,8 @@ multiple services.
 | `services[_].url` | `string` | Yes | Base URL to contact the service with. |
 | `services[_].response_header_timeout_seconds` | `int64` | No (default: 10) | Amount of time to wait for a server's response headers after fully writing the request. This time does not include the time to read the response body. |
 | `services[_].headers` | `object` | No | HTTP headers to include in requests to the service. |
+| `services[_].tls.ca_cert` | `string` | No | The path to the root CA certificate.  If not provided, this defaults to TLS using the host's root CA set. |
+| `services[_].tls.system_ca_required` | `bool` | No (default: `false`) | Require system certificate appended with root CA certificate. |
 | `services[_].allow_insecure_tls` | `bool` | No | Allow insecure TLS. |
 
 Each service may optionally specify a credential mechanism by which OPA will authenticate
@@ -272,8 +274,6 @@ private key is encrypted.
 | `services[_].credentials.client_tls.cert` | `string` | Yes | The path to the client certificate to authenticate with. |
 | `services[_].credentials.client_tls.private_key` | `string` | Yes | The path to the private key of the client certificate. |
 | `services[_].credentials.client_tls.private_key_passphrase` | `string` | No | The passphrase to use for the private key. |
-| `services[_].credentials.client_tls.ca_cert` | `string` | No | The path to the root CA certificate. |
-| `services[_].credentials.client_tls.system_ca_required` | `bool` | No | Require system certificate appended with root CA certificate. |
 
 #### OAuth2 Client Credentials
 

--- a/plugins/rest/rest.go
+++ b/plugins/rest/rest.go
@@ -42,6 +42,7 @@ type Config struct {
 	Headers                      map[string]string `json:"headers"`
 	AllowInsecureTLS             bool              `json:"allow_insecure_tls,omitempty"`
 	ResponseHeaderTimeoutSeconds *int64            `json:"response_header_timeout_seconds,omitempty"`
+	TLS                          *serverTLSConfig  `json:"tls,omitempty"`
 	Credentials                  struct {
 		Bearer      *bearerAuthPlugin                  `json:"bearer,omitempty"`
 		OAuth2      *oauth2ClientCredentialsAuthPlugin `json:"oauth2,omitempty"`
@@ -50,7 +51,6 @@ type Config struct {
 		GCPMetadata *gcpMetadataAuthPlugin             `json:"gcp_metadata,omitempty"`
 		Plugin      *string                            `json:"plugin,omitempty"`
 	} `json:"credentials"`
-
 	keys   map[string]*keys.Config
 	logger logging.Logger
 }


### PR DESCRIPTION
This change allows users to specify a certificate for the services
that implement the bundle, status etc. APIs. This cert will be
used to create the root CA pool.

Fixes: #1954

Signed-off-by: Ashutosh Narkar <anarkar4387@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/main/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/main/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
