### PR TITLE
wasm+topdown: misc utf-8 related issues

### DIFF
--- a/internal/wasm/sdk/opa/opa_test.go
+++ b/internal/wasm/sdk/opa/opa_test.go
@@ -225,13 +225,6 @@ a = "c" { input > 2 }`,
 				{Result: `{{}}`},
 			},
 		},
-		{
-			Description: "Runtime error/bad utf8 input to count()",
-			Policy:      `a = count(base64.decode("2E84ZuPUd7zfvCZSNEchVpDEIj6PL7JfLpIqyxVG16k="))`,
-			Query:       "data.p.a = x",
-			Evals:       []Eval{{}},
-			WantErr:     "internal_error: string: invalid unicode",
-		},
 	}
 
 	for _, test := range tests {

--- a/test/cases/testdata/aggregates/test-aggregates-bad-utf8-runes.yaml
+++ b/test/cases/testdata/aggregates/test-aggregates-bad-utf8-runes.yaml
@@ -1,0 +1,15 @@
+cases:
+- data:
+  modules:
+  - |
+    package test
+
+    p[x] {
+      x := count(base64.decode("2E84ZuPUd7zfvCZSNEchVpDEIj6PL7JfLpIqyxVG16k="))
+    }
+  note: aggregates/count with invalid utf-8 chars (0xFFFD)
+  query: data.test.p = x
+  sort_bindings: true
+  want_result:
+  - x:
+    - 30

--- a/test/cases/testdata/strings/test-strings-indexof-unicode.yaml
+++ b/test/cases/testdata/strings/test-strings-indexof-unicode.yaml
@@ -1,0 +1,13 @@
+cases:
+- data:
+  modules:
+  - |
+    package test
+
+    p = x {
+      indexof("μx", "x", x)
+    }
+  note: 'strings/indexof: unicode'
+  query: data.test.p = x
+  want_result:
+  - x: 1

--- a/topdown/strings.go
+++ b/topdown/strings.go
@@ -97,9 +97,19 @@ func builtinIndexOf(a, b ast.Value) (ast.Value, error) {
 	if err != nil {
 		return nil, err
 	}
+	if len(string(search)) == 0 {
+		return nil, fmt.Errorf("empty search character")
+	}
 
-	index := strings.Index(string(base), string(search))
-	return ast.IntNumberTerm(index).Value, nil
+	baseRunes := []rune(string(base))
+	searchRune := []rune(string(search))[0]
+	for i, r := range baseRunes {
+		if r == searchRune {
+			return ast.IntNumberTerm(i).Value, nil
+		}
+	}
+
+	return ast.IntNumberTerm(-1).Value, nil
 }
 
 func builtinSubstring(a, b, c ast.Value) (ast.Value, error) {

--- a/wasm/src/aggregates.c
+++ b/wasm/src/aggregates.c
@@ -2,6 +2,7 @@
 #include "mpd.h"
 #include "std.h"
 #include "unicode.h"
+#include "re2/util/utf.h"
 
 OPA_BUILTIN
 opa_value *opa_agg_count(opa_value *v)
@@ -11,13 +12,12 @@ opa_value *opa_agg_count(opa_value *v)
     case OPA_STRING: {
         opa_string_t *s = opa_cast_string(v);
         int units = 0;
+        Rune rune;
 
-        for (int i = 0, len = 0; i < s->len; units++, i += len)
+        for (int i = 0, len = 0; i < s->len; i += len)
         {
-            if (opa_unicode_decode_utf8(s->v, i, s->len, &len) == -1)
-            {
-                opa_abort("string: invalid unicode");
-            }
+            len = chartorune(&rune, &s->v[i]);
+            units++;
         }
 
         return opa_number_int(units);

--- a/wasm/src/re2/util/utf.h
+++ b/wasm/src/re2/util/utf.h
@@ -20,7 +20,10 @@
 
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
 namespace re2 {
+#endif
 
 typedef signed int Rune;	/* Code-point values in Unicode 4.0 are 21 bits wide.*/
 
@@ -39,6 +42,9 @@ int fullrune(const char* s, int n);
 int utflen(const char* s);
 char* utfrune(const char*, Rune);
 
-}  // namespace re2
+#ifdef __cplusplus
+} // namespace re2
+} // extern "C"
+#endif
 
 #endif  // UTIL_UTF_H_


### PR DESCRIPTION
Previously, we'd bail out when the string count() is given contained
anything that isn't a valid utf-8 rune. Now, we'll have it count the
invalid chars -- they're replaced by chartorune() in the same manner
as happens when passing casting the string to []rune in golang:

    package main

    import (
    	"encoding/base64"
    	"fmt"
    )

    func main() {
    	sample, _ := base64.StdEncoding.DecodeString("2E84ZuPUd7zfvCZSNEchVpDEIj6PL7JfLpIqyxVG16k=")
    	fmt.Printf("% x\n%x\n%d, %d\n", sample, []rune(string(sample)), len(sample), len([]rune(string(sample))))
    }

This yields:

    d8 4f 38 66 e3 d4 77 bc df bc 26 52 34 47 21 56 90 c4 22 3e 8f 2f b2 5f 2e 92 2a cb 15 46 d7 a9
    [fffd 4f 38 66 fffd fffd 77 fffd 7fc 26 52 34 47 21 56 fffd fffd 22 3e fffd 2f fffd 5f 2e fffd 2a fffd 15 46 5e9]
    32, 30

Where fffd is the replacement char whenever something isn't a proper rune.

----------

Previously, indexof() would count unicode characters as strings, so

    indexof("μx", "x")

would return 2 insteads of 1.

Now, we're converting to rune and compare explicitly, returnig the
proper result.