### PR TITLE
docs: update opa-envoy-plugin and contrib default branch

### DIFF
--- a/docs/content/envoy-tutorial-istio.md
+++ b/docs/content/envoy-tutorial-istio.md
@@ -27,7 +27,7 @@ See Istio's [Quick Start](https://istio.io/docs/setup/kubernetes/install/kuberne
 ### 1. Install OPA-Envoy
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/opa-envoy-plugin/master/examples/istio/quick_start.yaml
+kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/opa-envoy-plugin/main/examples/istio/quick_start.yaml
 ```
 
 The `quick_start.yaml` manifest defines the following resources:
@@ -122,7 +122,7 @@ The `quick_start.yaml` manifest defines the following resources:
     ```live:example:output
     ```
 
-    An example of the complete input received by OPA can be seen [here](https://github.com/open-policy-agent/opa-envoy-plugin/tree/master/examples/istio#example-input).
+    An example of the complete input received by OPA can be seen [here](https://github.com/open-policy-agent/opa-envoy-plugin/tree/main/examples/istio#example-input).
 
     > In typical deployments the policy would either be built into the OPA container
     > image or it would fetched dynamically via the [Bundle
@@ -193,4 +193,4 @@ This tutorial also showed a sample OPA policy that returns a `boolean` decision
 to indicate whether a request should be allowed or not.
 
 More details about the tutorial can be seen
-[here](https://github.com/open-policy-agent/opa-envoy-plugin/tree/master/examples/istio).
+[here](https://github.com/open-policy-agent/opa-envoy-plugin/tree/main/examples/istio).

--- a/docs/content/envoy-tutorial-standalone-envoy.md
+++ b/docs/content/envoy-tutorial-standalone-envoy.md
@@ -329,7 +329,7 @@ example-app-67c644b9cb-bbqgh   3/3     Running   0          8s
 
 > The `proxy-init` container installs iptables rules to redirect all container
   traffic through the Envoy proxy sidecar. More information can be found
-  [here](https://github.com/open-policy-agent/contrib/tree/master/envoy_iptables).
+  [here](https://github.com/open-policy-agent/contrib/tree/main/envoy_iptables).
 
 
 ### 5. Create a Service to expose HTTP server

--- a/docs/content/extensions.md
+++ b/docs/content/extensions.md
@@ -331,7 +331,7 @@ If everything worked you will see the Go struct representation of the decision
 log event written to stdout.
 
 The source code for this example can be found
-[here](https://github.com/open-policy-agent/contrib/tree/master/decision_logger_plugin_example).
+[here](https://github.com/open-policy-agent/contrib/tree/main/decision_logger_plugin_example).
 
 > If there is a mask policy set (see [Decision
   Logger](../management-decision-logs) for details) the `Event` received by the

--- a/docs/content/http-api-authorization.md
+++ b/docs/content/http-api-authorization.md
@@ -118,7 +118,7 @@ docker-compose -f docker-compose.yml up
 
 Every time the demo web server receives an HTTP request, it
 asks OPA to decide whether an HTTP API is authorized or not
-using a single RESTful API call.  An example code is [here](https://github.com/open-policy-agent/contrib/blob/master/api_authz/docker/echo_server.py),
+using a single RESTful API call.  An example code is [here](https://github.com/open-policy-agent/contrib/blob/main/api_authz/docker/echo_server.py),
 but the crux of the (Python) code is shown below.
 
 ```python

--- a/docs/content/kafka-authorization.md
+++ b/docs/content/kafka-authorization.md
@@ -151,7 +151,7 @@ They are only provided for convenience/test purposes.
 
 #### Kafka Authorizer JAR File
 
-The Kafka image used in this tutorial includes a pre-installed JAR file that implements the [Kafka Authorizer](https://kafka.apache.org/documentation/#security_authz) interface. For more information on the authorizer see [open-policy-agent/contrib/kafka_authorizer](https://github.com/open-policy-agent/contrib/tree/master/kafka_authorizer).
+The Kafka image used in this tutorial includes a pre-installed JAR file that implements the [Kafka Authorizer](https://kafka.apache.org/documentation/#security_authz) interface. For more information on the authorizer see [open-policy-agent/contrib/kafka_authorizer](https://github.com/open-policy-agent/contrib/tree/main/kafka_authorizer).
 
 ### 2. Define a policy to restrict consumer access to topics containing Personally Identifiable Information (PII).
 

--- a/docs/content/management-bundles.md
+++ b/docs/content/management-bundles.md
@@ -411,7 +411,7 @@ The signature verification process uses each of the fields in the JWT header and
 OPA supports the option to implement your own bundle signing and verification logic. This will be unnecessary
 for most and is intended for advanced use cases, such as leveraging key-related services from cloud providers.
 To implement your own signing and verification logic, you'll need to [extend OPA](../extensions). Here is
-[an example](https://github.com/open-policy-agent/contrib/tree/master/custom_bundle_signing) to get you started.
+[an example](https://github.com/open-policy-agent/contrib/tree/main/custom_bundle_signing) to get you started.
 
 When registering custom signing and verification plugins, you will need to register the Signer and the Verifier
 under the same plugin key, because the plugin key is stored in the signed bundle and informs OPA which Verifier

--- a/docs/content/ssh-and-sudo-authorization.md
+++ b/docs/content/ssh-and-sudo-authorization.md
@@ -16,7 +16,7 @@ host-level access controls over SSH and sudo.
 Linux-PAM can be configured to delegate authorization decisions to plugins
 (shared libraries). In this case, we have created an OPA-based plugin that can
 be configured to authorize SSH and sudo access. The OPA-based Linux-PAM plugin
-used in this tutorial can be found at [open-policy-agent/contrib](https://github.com/open-policy-agent/contrib/tree/master/pam_opa).
+used in this tutorial can be found at [open-policy-agent/contrib](https://github.com/open-policy-agent/contrib/tree/main/pam_opa).
 
 For this tutorial, our desired policy is:
 
@@ -110,7 +110,7 @@ In another terminal, load the policies and data into OPA that will control acces
 
 First, create a policy that will tell the PAM module to collect context that is required for authorization.
 For more details on what this policy should look like, see
-[this documentation](https://github.com/open-policy-agent/contrib/tree/master/pam_authz/pam#pull).
+[this documentation](https://github.com/open-policy-agent/contrib/tree/main/pam_authz/pam#pull).
 
 **pull.rego**:
 
@@ -133,7 +133,7 @@ curl -X PUT --data-binary @pull.rego \
 Next, create the policies that will authorize SSH and sudo requests.
 The `input` which makes up the authorization context in the policy below will also
 include some default values, such as the username making the request. See
-[this documentation](https://github.com/open-policy-agent/contrib/tree/master/pam_authz/pam#authz)
+[this documentation](https://github.com/open-policy-agent/contrib/tree/main/pam_authz/pam#authz)
 to get a better understanding of what the `input` to the authorization policy will look like.
 
 Unlike the *pull* policy, we'll create separate *authz* policies
@@ -259,7 +259,7 @@ You will see a lot of verbose logs from `sudo` as the PAM module goes through th
 This is intended so you can study how the PAM module works.
 You can disable verbose logging by changing the `log_level` argument in the PAM
 configuration. For more details see
-[this documentation](https://github.com/open-policy-agent/contrib/tree/master/pam_authz/pam#configuration).
+[this documentation](https://github.com/open-policy-agent/contrib/tree/main/pam_authz/pam#configuration).
 
 ### 4. SSH as a user without the `admin` role.
 


### PR DESCRIPTION
These aren't required, since github resolves the `master` links properly.
Anyways, let's clean these up.
