### PR TITLE
Marshal the decision log in docs so Input and Result are not pointers

### DIFF
--- a/docs/content/extensions.md
+++ b/docs/content/extensions.md
@@ -204,6 +204,8 @@ that writes events to a stream (e.g., stdout/stderr).
 
 ```golang
 import (
+	"encoding/json"
+
 	"github.com/open-policy-agent/opa/plugins/logs"
 )
 
@@ -244,7 +246,8 @@ func (p *PrintlnLogger) Log(ctx context.Context, event logs.EventV1) error {
 	if p.config.Stderr {
 		w = os.Stderr
 	}
-	_, err := fmt.Fprintln(w, event)
+	e, _ := json.Marshal(event)
+	_, err := fmt.Fprintln(w, string(e))
 	if err != nil {
 		p.manager.UpdatePluginStatus(PluginName, &plugins.Status{State: plugins.StateErr})
 	}

--- a/docs/content/extensions.md
+++ b/docs/content/extensions.md
@@ -249,6 +249,7 @@ func (p *PrintlnLogger) Log(ctx context.Context, event logs.EventV1) error {
 	bs, err := json.Marshal(event)
 	if err != nil {
 		p.manager.UpdatePluginStatus(PluginName, &plugins.Status{State: plugins.StateErr})
+		return nil
 	}
 	_, err = fmt.Fprintln(w, string(bs))
 	if err != nil {

--- a/docs/content/extensions.md
+++ b/docs/content/extensions.md
@@ -247,6 +247,9 @@ func (p *PrintlnLogger) Log(ctx context.Context, event logs.EventV1) error {
 		w = os.Stderr
 	}
 	bs, err := json.Marshal(event)
+	if err != nil {
+		p.manager.UpdatePluginStatus(PluginName, &plugins.Status{State: plugins.StateErr})
+	}
 	_, err = fmt.Fprintln(w, string(bs))
 	if err != nil {
 		p.manager.UpdatePluginStatus(PluginName, &plugins.Status{State: plugins.StateErr})

--- a/docs/content/extensions.md
+++ b/docs/content/extensions.md
@@ -246,8 +246,8 @@ func (p *PrintlnLogger) Log(ctx context.Context, event logs.EventV1) error {
 	if p.config.Stderr {
 		w = os.Stderr
 	}
-	e, _ := json.Marshal(event)
-	_, err := fmt.Fprintln(w, string(e))
+	bs, err := json.Marshal(event)
+	_, err = fmt.Fprintln(w, string(bs))
 	if err != nil {
 		p.manager.UpdatePluginStatus(PluginName, &plugins.Status{State: plugins.StateErr})
 	}


### PR DESCRIPTION
I think this helps people who are not as familiar with go to get more expected results. The is issue is that because input and result are interfaces when event is printed to stdout without the map being marshalled to JSON both input and result are printed as memory pointers. This is confusing to someone less familiar with go as they may believe that their input is not present in the decision log. By adding Marshal the stdout will now be standard JSON which will then have result and input with the string values.


Signed-off-by: John Snow <john@styra.com>

