### PR TITLE
Do not write .manifest into bundles unnecessarily

### DIFF
--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -697,6 +697,10 @@ func (w *Writer) writeWasm(tw *tar.Writer, bundle Bundle) error {
 
 func writeManifest(tw *tar.Writer, bundle Bundle) error {
 
+	if bundle.Manifest.Equal(Manifest{}) {
+		return nil
+	}
+
 	var buf bytes.Buffer
 
 	if err := json.NewEncoder(&buf).Encode(bundle.Manifest); err != nil {

--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -139,6 +139,10 @@ func (m Manifest) Equal(other Manifest) bool {
 		}
 	}
 
+	if !reflect.DeepEqual(m.Metadata, other.Metadata) {
+		return false
+	}
+
 	return m.rootSet().Equal(other.rootSet())
 }
 
@@ -152,6 +156,15 @@ func (m Manifest) Copy() Manifest {
 	wasmModules := make([]WasmResolver, len(m.WasmResolvers))
 	copy(wasmModules, m.WasmResolvers)
 	m.WasmResolvers = wasmModules
+
+	metadata := m.Metadata
+
+	if metadata != nil {
+		m.Metadata = make(map[string]interface{})
+		for k, v := range metadata {
+			m.Metadata[k] = v
+		}
+	}
 
 	return m
 }

--- a/bundle/bundle_test.go
+++ b/bundle/bundle_test.go
@@ -29,6 +29,55 @@ func TestManifestAddRoot(t *testing.T) {
 	m.rootSet().Equal(stringSet{"x/y": struct{}{}, "y/z": struct{}{}})
 }
 
+func TestManifestEqual(t *testing.T) {
+	var m Manifest
+	var n Manifest
+
+	assertEqual := func() {
+		t.Helper()
+		if !m.Equal(n) {
+			t.Fatal("expected manifests to be equal")
+		}
+	}
+
+	assertNotEqual := func() {
+		t.Helper()
+		if m.Equal(n) {
+			t.Fatal("expected manifests to be different")
+		}
+	}
+
+	assertEqual()
+
+	n.Revision = "xxx"
+	assertNotEqual()
+
+	m.Revision = "xxx"
+	assertEqual()
+
+	n.WasmResolvers = append(n.WasmResolvers, WasmResolver{})
+	assertNotEqual()
+
+	m.WasmResolvers = append(m.WasmResolvers, WasmResolver{})
+	assertEqual()
+
+	n.WasmResolvers[0].Module = "yyy"
+	assertNotEqual()
+
+	m.WasmResolvers[0].Module = "yyy"
+	assertEqual()
+
+	n.Metadata = map[string]interface{}{
+		"foo": "bar",
+	}
+	assertNotEqual()
+
+	m.Metadata = map[string]interface{}{
+		"foo": "bar",
+	}
+	assertEqual()
+}
+
 func TestRead(t *testing.T) {
 	testReadBundle(t, "")
 }
@@ -178,7 +227,7 @@ func TestManifestMetadata(t *testing.T) {
 			"metadata": {
 				"foo": {
 					"version": "1.0.0"
-				} 
+				}
 			}
 		}`},
 	}

--- a/cmd/eval.go
+++ b/cmd/eval.go
@@ -538,6 +538,8 @@ func readInputBytes(params evalCommandParams) ([]byte, error) {
 	return nil, nil
 }
 
+const stringType = "string"
+
 type repeatedStringFlag struct {
 	v     []string
 	isSet bool
@@ -551,7 +553,7 @@ func newrepeatedStringFlag(val []string) repeatedStringFlag {
 }
 
 func (f *repeatedStringFlag) Type() string {
-	return "string"
+	return stringType
 }
 
 func (f *repeatedStringFlag) String() string {

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -171,7 +171,7 @@ func newcapabilitiesFlag() *capabilitiesFlag {
 }
 
 func (f *capabilitiesFlag) Type() string {
-	return "string"
+	return stringType
 }
 
 func (f *capabilitiesFlag) String() string {
@@ -187,4 +187,26 @@ func (f *capabilitiesFlag) Set(s string) error {
 	defer fd.Close()
 	f.C, err = ast.LoadCapabilitiesJSON(fd)
 	return err
+}
+
+type stringptrFlag struct {
+	v     *string
+	isSet bool
+}
+
+func (f *stringptrFlag) Type() string {
+	return stringType
+}
+
+func (f *stringptrFlag) String() string {
+	if f.v == nil {
+		return ""
+	}
+	return *f.v
+}
+
+func (f *stringptrFlag) Set(s string) error {
+	f.v = &s
+	f.isSet = true
+	return nil
 }


### PR DESCRIPTION
The first commit is just cleanup. The second commit implements the fix.