### PR TITLE
Fixes JSON schema test failing with Go 1.17 rc

### DIFF
--- a/internal/gojsonschema/testdata/draft7/optional/format/time.json
+++ b/internal/gojsonschema/testdata/draft7/optional/format/time.json
@@ -15,7 +15,7 @@
             },
             {
                 "description": "only RFC3339 not all of ISO 8601 are valid",
-                "data": "01:01:01,1111",
+                "data": "14:30",
                 "valid": false
             }
         ]


### PR DESCRIPTION
Replace the time `01:01:01,1111` by `14:30`, which is a ISO 8601 valid time, but not a RFC3339 "full time", and is rejected as such by the `TimeFormatChecker`.

Fixes #3589

