### PR TITLE
ci: enable dependabot for wasmtime-go

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    allow:
+      - dependency-name: github.com/bytecodealliance/wasmtime-go
+    schedule:
+      interval: daily


### PR DESCRIPTION
I suppose we could use it for more than just this dependency, but it's
a start. Commonly, I've been watching this project, but it would be nice
if the bot did it instead.
