### PR TITLE
Fix typo in non-wasm error message

### DIFF
--- a/internal/rego/opa/nop.go
+++ b/internal/rego/opa/nop.go
@@ -20,7 +20,7 @@ type OPA struct {
 func New() *OPA {
 	fmt.Fprintf(os.Stderr, `WebAssembly runtime not supported in this build.
 ----------------------------------------------------------------------------------
-Please download an OPA binay with Wasm enabled from
+Please download an OPA binary with Wasm enabled from
   https://www.openpolicyagent.org/docs/latest/#running-opa
 or build it yourself (with Wasm enabled).
 ----------------------------------------------------------------------------------


### PR DESCRIPTION
The typo was actually reported by @johanneslarsson in a commit comment: https://github.com/open-policy-agent/opa/commit/f8ef59c1845f373008865e024147800164385e43#r51520552