### PR TITLE
topdown: only amend comprehensions with used bindings

### DIFF
--- a/topdown/topdown_partial_test.go
+++ b/topdown/topdown_partial_test.go
@@ -2190,7 +2190,7 @@ func TestTopDownPartialEval(t *testing.T) {
 				q = {a | data.base[a]}`,
 			},
 			disableInlining: []string{"data.base.foo.bar"},
-			wantQueries:     []string{`x_ref_01 = {a2 | data.base[a2]; x_term_2_02 = true}; x_ref_01[input.x]`},
+			wantQueries:     []string{`x_ref_01 = {a2 | data.base[a2]}; x_ref_01[input.x]`},
 		},
 		{
 			note:  "shallow inlining: complete rules",
@@ -2448,6 +2448,111 @@ func TestTopDownPartialEval(t *testing.T) {
 				}
 			`},
 			wantQueries: []string{`y1 = {true | x1[0]; input.y = 1; x1 = [0]}; input.x = x`},
+		},
+		{
+			note:  "comprehensions: vars in scope, unused in comprehension",
+			query: `data.test.p`,
+			modules: []string{
+				`package test
+
+				p[x] { q[x] }
+				q[x] {
+					y = { 1 | input }
+					x = true
+				}
+			`},
+			wantQueries: []string{`data.partial.test.p`},
+			wantSupport: []string{`package partial.test
+				p[true] { y2 = {1 | input} }
+			`},
+		},
+		{
+			note:  "comprehensions: vars in scope, used in lhs body (set)",
+			query: `data.test.p`,
+			modules: []string{
+				`package test
+
+				p[x] { q[x] }
+				q[x] {
+					{ 1 | input; x } = y
+					x = true
+				}
+			`},
+			wantQueries: []string{`data.partial.test.p`},
+			wantSupport: []string{`package partial.test
+				p[true] { {1 | input; x2; x2 = true} = y2 }
+			`},
+		},
+		{
+			note:  "comprehensions: vars in scope, used in lhs term (set)",
+			query: `data.test.p`,
+			modules: []string{
+				`package test
+
+				p[x] { q[x] }
+				q[x] {
+					{ x | input } = y
+					x = true
+				}
+			`},
+			wantQueries: []string{`data.partial.test.p`},
+			wantSupport: []string{`package partial.test
+				p[true] { {x2 | input; x2 = true} = y2 }
+			`},
+		},
+		{
+			// NOTE(sr): To actually have the vars in the rhs, we'll need to provide two
+			// comprehensions -- otherwise, the arguments would be flipped and we'd have
+			// the vars in lhs again.
+			note:  "comprehensions: vars in scope, used in rhs body (set)",
+			query: `data.test.p`,
+			modules: []string{
+				`package test
+
+				p[x] { q[x] }
+				q[x] {
+					{ false | input }  = { true | input; x }
+					x = true
+				}
+			`},
+			wantQueries: []string{`data.partial.test.p`},
+			wantSupport: []string{`package partial.test
+				p[true] { {false | input} = {true | input; x2; x2 = true} }
+			`},
+		},
+		{
+			note:  "comprehensions: vars in scope, used in rhs term (set)",
+			query: `data.test.p`,
+			modules: []string{
+				`package test
+
+				p[x] { q[x] }
+				q[x] {
+					{ false | input } = { x | input }
+					x = true
+				}
+			`},
+			wantQueries: []string{`data.partial.test.p`},
+			wantSupport: []string{`package partial.test
+				p[true] { {false | input} = {x2 | input; x2 = true} }
+			`},
+		},
+		{
+			note:  "comprehensions: vars in scope, used in rhs value (object)",
+			query: `data.test.p`,
+			modules: []string{
+				`package test
+
+				p[x] { q[x] }
+				q[x] {
+					{ "foo": false | input } = { "foo": x | input }
+					x = true
+				}
+			`},
+			wantQueries: []string{`data.partial.test.p`},
+			wantSupport: []string{`package partial.test
+				p[true] { {"foo": false | input} = {"foo": x2 | input; x2 = true} }
+			`},
 		},
 		{
 			note:        "comprehensions: ref heads (with live vars)",


### PR DESCRIPTION
Before, all the available bindings had been added to the comprehension in

    package pkg
    p[x] { q[x] }
    q[x] {
            y := {1 | input} # <---
            x := "foo"
    }

So after partial eval, the support rule was

    p["foo"] {
            __local0__2 = {1 |
                    input
                    __local1__2 = x12
            }
    }

Now, only variables that are used in the comprehension in question are
added. The partial eval result becomes

    p["foo"] {
            __local0__2 = {1 | input}
    }

An extra round of the process was added when both lhs and rhs are
comprehensions.

Fixes #3557.
