### PR TITLE
wasm/sdk: handle random seed needed by 'uuid.rfc4122()'

### DIFF
--- a/internal/rego/opa/opa.go
+++ b/internal/rego/opa/opa.go
@@ -50,6 +50,7 @@ func (o *OPA) Eval(ctx context.Context, opts EvalOpts) (*Result, error) {
 		Input:   opts.Input,
 		Metrics: opts.Metrics,
 		Time:    opts.Time,
+		Seed:    opts.Seed,
 	}
 
 	res, err := o.opa.Eval(ctx, evalOptions)

--- a/internal/rego/opa/options.go
+++ b/internal/rego/opa/options.go
@@ -1,6 +1,7 @@
 package opa
 
 import (
+	"io"
 	"time"
 
 	"github.com/open-policy-agent/opa/metrics"
@@ -16,4 +17,5 @@ type EvalOpts struct {
 	Input   *interface{}
 	Metrics metrics.Metrics
 	Time    time.Time
+	Seed    io.Reader
 }

--- a/internal/wasm/sdk/internal/wasm/bindings.go
+++ b/internal/wasm/sdk/internal/wasm/bindings.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"strconv"
 	"time"
@@ -77,21 +78,23 @@ func (d *builtinDispatcher) SetMap(m map[int32]topdown.BuiltinFunc) {
 }
 
 // Reset is called in Eval before using the builtinDispatcher.
-func (d *builtinDispatcher) Reset(ctx context.Context, ns time.Time) {
+func (d *builtinDispatcher) Reset(ctx context.Context, seed io.Reader, ns time.Time) {
 	if ns.IsZero() {
 		ns = time.Now()
 	}
 	d.ctx = &topdown.BuiltinContext{
-		Context:  ctx,
-		Cancel:   topdown.NewCancel(),
-		Runtime:  nil,
-		Time:     ast.NumberTerm(json.Number(strconv.FormatInt(ns.UnixNano(), 10))),
-		Metrics:  metrics.New(),
-		Cache:    make(builtins.Cache),
-		Location: nil,
-		Tracers:  nil,
-		QueryID:  0,
-		ParentID: 0,
+		Context:      ctx,
+		Metrics:      metrics.New(),
+		Seed:         seed,
+		Time:         ast.NumberTerm(json.Number(strconv.FormatInt(ns.UnixNano(), 10))),
+		Cancel:       topdown.NewCancel(),
+		Runtime:      nil,
+		Cache:        make(builtins.Cache),
+		Location:     nil,
+		Tracers:      nil,
+		QueryTracers: nil,
+		QueryID:      0,
+		ParentID:     0,
 	}
 
 }

--- a/internal/wasm/sdk/internal/wasm/pool_test.go
+++ b/internal/wasm/sdk/internal/wasm/pool_test.go
@@ -8,6 +8,7 @@ package wasm_test
 
 import (
 	"context"
+	"math/rand"
 	"testing"
 	"time"
 
@@ -155,7 +156,7 @@ func ensurePoolResults(t *testing.T, ctx context.Context, testPool *wasm.Pool, p
 
 		toRelease = append(toRelease, vm)
 
-		result, err := vm.Eval(ctx, 0, nil, metrics.New(), time.Now())
+		result, err := vm.Eval(ctx, 0, nil, metrics.New(), rand.New(rand.NewSource(0)), time.Now())
 		if err != nil {
 			t.Fatalf("Unexpected error: %s", err)
 		}

--- a/internal/wasm/sdk/internal/wasm/vm.go
+++ b/internal/wasm/sdk/internal/wasm/vm.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"time"
 
 	"github.com/bytecodealliance/wasmtime-go"
@@ -239,7 +240,7 @@ func newVM(opts vmOpts) (*VM, error) {
 
 // Eval performs an evaluation of the specified entrypoint, with any provided
 // input, and returns the resulting value dumped to a string.
-func (i *VM) Eval(ctx context.Context, entrypoint int32, input *interface{}, metrics metrics.Metrics, ns time.Time) ([]byte, error) {
+func (i *VM) Eval(ctx context.Context, entrypoint int32, input *interface{}, metrics metrics.Metrics, seed io.Reader, ns time.Time) ([]byte, error) {
 	metrics.Timer("wasm_vm_eval").Start()
 	defer metrics.Timer("wasm_vm_eval").Stop()
 
@@ -249,7 +250,7 @@ func (i *VM) Eval(ctx context.Context, entrypoint int32, input *interface{}, met
 	// make use of it (e.g. `http.send`); and it will spawn a go routine
 	// cancelling the builtins that use topdown.Cancel, when the context is
 	// cancelled.
-	i.dispatcher.Reset(ctx, ns)
+	i.dispatcher.Reset(ctx, seed, ns)
 
 	err := i.setHeapState(ctx, i.evalHeapPtr)
 	if err != nil {

--- a/internal/wasm/sdk/opa/opa.go
+++ b/internal/wasm/sdk/opa/opa.go
@@ -7,6 +7,7 @@ package opa
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"runtime"
 	"sync"
 	"time"
@@ -159,6 +160,7 @@ type EvalOpts struct {
 	Input      *interface{}
 	Metrics    metrics.Metrics
 	Time       time.Time
+	Seed       io.Reader
 }
 
 // Eval evaluates the policy with the given input, returning the
@@ -182,7 +184,7 @@ func (o *OPA) Eval(ctx context.Context, opts EvalOpts) (*Result, error) {
 
 	defer o.pool.Release(instance, m)
 
-	result, err := instance.Eval(ctx, opts.Entrypoint, opts.Input, m, opts.Time)
+	result, err := instance.Eval(ctx, opts.Entrypoint, opts.Input, m, opts.Seed, opts.Time)
 	if err != nil {
 		return nil, err
 	}

--- a/rego/rego.go
+++ b/rego/rego.go
@@ -35,8 +35,13 @@ import (
 
 const (
 	defaultPartialNamespace = "partial"
-	targetWasm              = "wasm"
 	wasmVarPrefix           = "^"
+)
+
+// nolint: deadcode,varcheck
+const (
+	targetWasm = "wasm"
+	targetRego = "rego"
 )
 
 // CompileResult represents the result of compiling a Rego query, zero or more
@@ -1935,7 +1940,12 @@ func (r *Rego) evalWasm(ctx context.Context, ectx *EvalContext) (ResultSet, erro
 		input = &i
 	}
 
-	result, err := r.opa.Eval(ctx, opa.EvalOpts{Metrics: r.metrics, Input: input, Time: ectx.time})
+	result, err := r.opa.Eval(ctx, opa.EvalOpts{
+		Metrics: r.metrics,
+		Input:   input,
+		Time:    ectx.time,
+		Seed:    ectx.seed,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/rego/rego_test.go
+++ b/rego/rego_test.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"encoding/json"
 	"log"
-	"math/rand"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -1915,46 +1914,6 @@ func TestTimeSeedingOptions(t *testing.T) {
 		t.Fatal(err)
 	} else if len(rs2) != 1 || !reflect.DeepEqual(rs[0].Bindings["x"], rs3[0].Bindings["x"]) {
 		t.Fatal("expected old wall clock value")
-	}
-
-}
-
-func TestRandSeedingOptions(t *testing.T) {
-
-	ctx := context.Background()
-	seed := rand.New(rand.NewSource(0))
-
-	exp := "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8"
-
-	// Check expected uuid is returned.
-	rs, err := New(Query(`uuid.rfc4122("", x)`), Seed(seed)).Eval(ctx)
-	if err != nil {
-		t.Fatal(err)
-	} else if rs[0].Bindings["x"] != exp {
-		t.Fatalf("expected %q but got %q", exp, rs[0].Bindings["x"])
-	}
-
-	// Check that seed does not propagate to prepared query.
-	eval, err := New(Query(`uuid.rfc4122("", x)`), Seed(seed)).PrepareForEval(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	rs2, err := eval.Eval(ctx)
-	if err != nil {
-		t.Fatal(err)
-	} else if rs2[0].Bindings["x"] == exp {
-		t.Fatal("expected new uuid")
-	}
-
-	exp3 := "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75"
-
-	// Check that prepared query uses explicitly provided seed.
-	rs3, err := eval.Eval(ctx, EvalSeed(seed))
-	if err != nil {
-		t.Fatal(err)
-	} else if rs3[0].Bindings["x"] != exp3 {
-		t.Fatalf("expected %q but got %q", exp, rs3[0].Bindings["x"])
 	}
 
 }

--- a/rego/rego_wasmtarget_test.go
+++ b/rego/rego_wasmtarget_test.go
@@ -9,6 +9,7 @@ package rego
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -221,6 +222,50 @@ allow {
 			if time.Since(before) > 2*time.Second {
 				// if the cancelled execution took so long, it wasn't really cancelled
 				t.Errorf("expected cancellation, but test ran %s", time.Since(before))
+			}
+		})
+	}
+}
+
+func TestRandSeedingOptions(t *testing.T) {
+
+	ctx := context.Background()
+
+	exp := "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8"
+
+	for _, tgt := range []string{targetWasm, targetRego} {
+		t.Run(tgt, func(t *testing.T) {
+			seed := rand.New(rand.NewSource(0))
+
+			// Check expected uuid is returned.
+			rs, err := New(Query(`uuid.rfc4122("", x)`), Seed(seed), Target(tgt)).Eval(ctx)
+			if err != nil {
+				t.Fatal(err)
+			} else if rs[0].Bindings["x"] != exp {
+				t.Fatalf("expected %q but got %q", exp, rs[0].Bindings["x"])
+			}
+
+			// Check that seed does not propagate to prepared query.
+			eval, err := New(Query(`uuid.rfc4122("", x)`), Seed(seed)).PrepareForEval(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			rs2, err := eval.Eval(ctx)
+			if err != nil {
+				t.Fatal(err)
+			} else if rs2[0].Bindings["x"] == exp {
+				t.Fatal("expected new uuid")
+			}
+
+			exp3 := "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75"
+
+			// Check that prepared query uses explicitly provided seed.
+			rs3, err := eval.Eval(ctx, EvalSeed(seed))
+			if err != nil {
+				t.Fatal(err)
+			} else if rs3[0].Bindings["x"] != exp3 {
+				t.Fatalf("expected %q but got %q", exp, rs3[0].Bindings["x"])
 			}
 		})
 	}

--- a/topdown/uuid.go
+++ b/topdown/uuid.go
@@ -13,21 +13,20 @@ type uuidCachingKey string
 
 func builtinUUIDRFC4122(bctx BuiltinContext, args []*ast.Term, iter func(*ast.Term) error) error {
 
-	var result *ast.Term
 	var key = uuidCachingKey(args[0].Value.String())
 
-	if val, ok := bctx.Cache.Get(key); !ok {
-		s, err := uuid.New(bctx.Seed)
-		if err != nil {
-			return err
-		}
-
-		result = ast.NewTerm(ast.String(s))
-		bctx.Cache.Put(key, result)
-
-	} else {
-		result = val.(*ast.Term)
+	val, ok := bctx.Cache.Get(key)
+	if ok {
+		return iter(val.(*ast.Term))
 	}
+
+	s, err := uuid.New(bctx.Seed)
+	if err != nil {
+		return err
+	}
+
+	result := ast.NewTerm(ast.String(s))
+	bctx.Cache.Put(key, result)
 
 	return iter(result)
 }


### PR DESCRIPTION
There random seed to be used with the host-provided builtin uuid.rfc4122
was missing from the BuiltinContext that's created in the dispatcher. It
hadn't been thread through from rego to the vm call.

The unit tests for the builtin now run against both targets.

Also some style adjustments to the builtin code for uuid.rfc4122.

Fixes #3622.
