### PR TITLE
rego: don't parse inputs for wasm target

### DIFF
--- a/rego/rego.go
+++ b/rego/rego.go
@@ -335,9 +335,11 @@ func (pq preparedQuery) newEvalContext(ctx context.Context, options []EvalOption
 			// Note that it could still be nil
 			ectx.rawInput = pq.r.rawInput
 		}
-		ectx.parsedInput, err = pq.r.parseRawInput(ectx.rawInput, ectx.metrics)
-		if err != nil {
-			return nil, finishFunc, err
+		if pq.r.target != targetWasm {
+			ectx.parsedInput, err = pq.r.parseRawInput(ectx.rawInput, ectx.metrics)
+			if err != nil {
+				return nil, finishFunc, err
+			}
 		}
 	}
 
@@ -1931,18 +1933,9 @@ func (r *Rego) eval(ctx context.Context, ectx *EvalContext) (ResultSet, error) {
 
 func (r *Rego) evalWasm(ctx context.Context, ectx *EvalContext) (ResultSet, error) {
 
-	var input *interface{}
-	if ectx.parsedInput != nil {
-		i, err := ast.JSON(ectx.parsedInput)
-		if err != nil {
-			return nil, err
-		}
-		input = &i
-	}
-
 	result, err := r.opa.Eval(ctx, opa.EvalOpts{
 		Metrics: r.metrics,
-		Input:   input,
+		Input:   ectx.rawInput,
 		Time:    ectx.time,
 		Seed:    ectx.seed,
 	})


### PR DESCRIPTION
opa.Eval() expects an input of type *interface{}; and for evaluations targetting
the wasm engine, we had been parsing the rawInput (*interface{}) into *ast.Value,
only to run ast.JSON() on it (going back to *interface{}) before passing it off
to the Wasm SDK.