### PR TITLE
docs: Remove deprecated fields from management pages

### DIFF
--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -729,5 +729,7 @@ included in the actual bundle gzipped tarball.
 
 The following `discovery` configuration fields are supported but deprecated:
 
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
 | `discovery.prefix` | `string` | No (default: `bundles`) | Deprecated: Use `resource` instead. Path prefix to use to download configuration from remote server. |
 | `discovery.name` | `string` | No | Deprecated: Use `resource` instead. Name of the discovery configuration to download. If `discovery.name` is specified and `discovery.resource` is unset, the `discovery.decision` field will default to the `discovery.name` value. |

--- a/docs/content/management-bundles.md
+++ b/docs/content/management-bundles.md
@@ -96,10 +96,6 @@ for verifying the signature of the bundle. See [this](#signing) section for deta
 
 See the following section for details on the bundle file format.
 
-> Note: The `bundle` config keyword will still work with the current versions
-of OPA, but has been deprecated. It is highly recommended to switch to the
-`bundles` configuration.
-
 #### Caching
 
 Services implementing the Bundle Service API should set the HTTP `Etag` header
@@ -688,7 +684,7 @@ curl --silent \
 
 #### Upload Bundle
 
-Uploading bundles to Azure Blob storage is easily done using the [azcopy](https://docs.microsoft.com/en-us/azure/storage/common/storage-use-azcopy-v10) tool. Make sure to first properly [authorize](https://docs.microsoft.com/en-us/azure/storage/common/storage-use-azcopy-authorize-azure-active-directory) the user to be able to upload to Blob storage. 
+Uploading bundles to Azure Blob storage is easily done using the [azcopy](https://docs.microsoft.com/en-us/azure/storage/common/storage-use-azcopy-v10) tool. Make sure to first properly [authorize](https://docs.microsoft.com/en-us/azure/storage/common/storage-use-azcopy-authorize-azure-active-directory) the user to be able to upload to Blob storage.
 
 By now you should be able to login interactively using `azcopy login --tenant-id <Active Directory tenant ID>`. Since you'll most likely will want to log in from scripts (to upload bundles programmatically), you should however create an Azure AD application, and a [service principal](https://docs.microsoft.com/en-us/azure/active-directory/develop/howto-create-service-principal-portal) to do so. Good news! If you've followed the Authentication steps above, you already have one.
 
@@ -782,7 +778,7 @@ bundles:
     service: blob
     resource: opa/bundle.tar.gz
 ```
-Note that the `$CLIENT_ID` is what is referred to as the "Application ID" inside your Azure account. 
+Note that the `$CLIENT_ID` is what is referred to as the "Application ID" inside your Azure account.
 Also note in particular how the `thumbprint` property is required for Azure. The value expected here can be found under "Certificates and Secrets" in your application's configuration.
 
 {{< figure src="thumbprint.png" width="150" caption="Certificate thumbprint" >}}
@@ -801,7 +797,7 @@ Nginx offers a simple but competent bundle server for those who prefer to host t
 
 #### Upload Bundle
 
-Either use the [nginx-upload-module](https://www.nginx.com/resources/wiki/modules/upload/) or upload bundles out-of-band with SSH or similar. 
+Either use the [nginx-upload-module](https://www.nginx.com/resources/wiki/modules/upload/) or upload bundles out-of-band with SSH or similar.
 
 #### Example OPA Configuration
 

--- a/docs/content/management-decision-logs.md
+++ b/docs/content/management-decision-logs.md
@@ -63,7 +63,6 @@ Decision log updates contain the following fields:
 | --- | --- | --- |
 | `[_].labels` | `object` | Set of key-value pairs that uniquely identify the OPA instance. |
 | `[_].decision_id` | `string` | Unique identifier generated for each decision for traceability. |
-| `[_].revision` | `string` | (Deprecated) Bundle revision that contained the policy used to produce the decision. Omitted when `bundles` are configured.  |
 | `[_].bundles` | `object` | Set of key-value pairs describing the bundles which contained policy used to produce the decision. |
 | `[_].bundles[_].revision` | `string` | Revision of the bundle at the time of evaluation. |
 | `[_].path` | `string` | Hierarchical policy decision path, e.g., `/http/example/authz/allow`. Receivers should tolerate slash-prefixed paths. |

--- a/docs/content/management-status.md
+++ b/docs/content/management-status.md
@@ -189,10 +189,6 @@ Status updates contain the following fields:
 | Field | Type | Description |
 | --- | --- | --- |
 | `labels` | `object` | Set of key-value pairs that uniquely identify the OPA instance. |
-| `bundle.name` | `string` | (Deprecated) Name of bundle that the OPA instance is configured to download. Omitted when `bundles` are configured. |
-| `bundle.active_revision` | `string` | (Deprecated) Opaque revision identifier of the last successful activation. Omitted when `bundles` are configured. |
-| `bundle.last_successful_download` | `string` | (Deprecated) RFC3339 timestamp of last successful bundle download. Omitted when `bundles` are configured. |
-| `bundle.last_successful_activation` | `string` | (Deprecated) RFC3339 timestamp of last successful bundle activation. Omitted when `bundles` are configured. |
 | `bundles` | `object` | Set of objects describing the status for each bundle configured with OPA. |
 | `bundles[_].name` | `string` | Name of bundle that the OPA instance is configured to download. |
 | `bundles[_].active_revision` | `string` | Opaque revision identifier of the last successful activation. |
@@ -201,6 +197,9 @@ Status updates contain the following fields:
 | `bundles[_].last_successful_download` | `string` | RFC3339 timestamp of last successful bundle download. |
 | `bundles[_].last_successful_activation` | `string` | RFC3339 timestamp of last successful bundle activation. |
 | `bundles[_].metrics` | `object` | Metrics from the last update of the bundle. |
+| `bundles[_].code` | `string` | If present, indicates error(s) occurred activating this bundle. |
+| `bundles[_].message` | `string` | Human readable messages describing the error(s). |
+| `bundles[_].errors` | `array` | Collection of detailed parse or compile errors that occurred during activation of this bundle. |
 | `discovery.name` | `string` | Name of discovery bundle that the OPA instance is configured to download. |
 | `discovery.active_revision` | `string` | Opaque revision identifier of the last successful discovery activation. |
 | `discovery.last_request` | `string` | RFC3339 timestamp of last discovery bundle request. This timestamp should be >= to the successful request timestamp in normal operation. |
@@ -210,15 +209,6 @@ Status updates contain the following fields:
 | `plugins` | `object` | A set of objects describing the state of configured plugins in OPA's runtime. |
 | `plugins[_].state` | `string` | The state of each plugin. |
 | `metrics.prometheus` | `object` | Global performance metrics for the OPA instance. |
-
-If the bundle download or activation failed, the status update will contain
-the following additional fields.
-
-| Field | Type | Description |
-| --- | --- | --- |
-| `bundle.code` | `string` | If present, indicates error(s) occurred. |
-| `bundle.message` | `string` | Human readable messages describing the error(s). |
-| `bundle.errors` | `array` | Collection of detailed parse or compile errors that occurred during activation. |
 
 If the discovery bundle download or activation failed, the status update will contain
 the following additional fields.


### PR DESCRIPTION
Since v0.26.0 the deprecated single bundle config section has
generated a warning on startup. This commit just removes stale
mentions of the section from the docs. Also, fix the deprecated field
table in the discovery config section.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/main/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/main/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
