### PR TITLE
ast: Update query compiler to reject empty queries

### DIFF
--- a/ast/compile.go
+++ b/ast/compile.go
@@ -1525,6 +1525,10 @@ func (qc *queryCompiler) runStageAfter(metricName string, query Body, s QueryCom
 
 func (qc *queryCompiler) Compile(query Body) (Body, error) {
 
+	if len(query) == 0 {
+		return nil, Errors{NewError(CompileErr, nil, "empty query cannot be compiled")}
+	}
+
 	query = query.Copy()
 
 	stages := []struct {

--- a/ast/compile_test.go
+++ b/ast/compile_test.go
@@ -3806,6 +3806,11 @@ func TestQueryCompiler(t *testing.T) {
 		expected interface{}
 	}{
 		{
+			note:     "empty query",
+			q:        "   \t \n # foo \n",
+			expected: fmt.Errorf("1 error occurred: rego_compile_error: empty query cannot be compiled"),
+		},
+		{
 			note:     "invalid eq",
 			q:        "eq()",
 			expected: fmt.Errorf("too few arguments"),


### PR DESCRIPTION
The compiler assumes that queries are non-empty, however, if the
parser is fed only whitespace and comments then the parsed query will
be empty. Since the compiler makes this assumption and many callers
will make a similar assumption, just reject empty queries at the
beginning.

This issue is unlikely to affect most users unless they send arbitrary
text selections into OPA (e.g., like `opa eval` does...)

Fixes #3625

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/main/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/main/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
