### PR TITLE
topdown: Fix panic in rand.intn function

### DIFF
--- a/topdown/numbers.go
+++ b/topdown/numbers.go
@@ -66,6 +66,8 @@ func builtinRandIntn(bctx BuiltinContext, args []*ast.Term, iter func(*ast.Term)
 	n, err := builtins.IntOperand(args[1].Value, 2)
 	if err != nil {
 		return err
+	} else if n <= 0 {
+		return fmt.Errorf("invalid argument (n must be > 0)")
 	}
 
 	var key = uuidCachingKey(fmt.Sprintf("%s-%d", strOp, n))


### PR DESCRIPTION
This commit just puts an error check in place to the panic from the
stdlib when rand.intn is called with an input < 1.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/main/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/main/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
