### PR TITLE
genopawasm: only unpack wasm and callgraph bytes once

### DIFF
--- a/internal/cmd/genopawasm/main.go
+++ b/internal/cmd/genopawasm/main.go
@@ -70,27 +70,42 @@ import (
 	"bytes"
 	"compress/gzip"
 	"io/ioutil"
+	"sync"
+)
+
+var (
+	bytesOnce        sync.Once
+	bs               []byte
+	callGraphCSVOnce sync.Once
+	callGraphCSV     []byte
 )
 
 // Bytes returns the OPA-WASM bytecode.
 func Bytes() ([]byte, error) {
-	gr, err := gzip.NewReader(bytes.NewBuffer(gzipped))
-	if err != nil {
-		return nil, err
-	}
-	return ioutil.ReadAll(gr)
+	var err error
+	bytesOnce.Do(func() {
+		gr, err := gzip.NewReader(bytes.NewBuffer(gzipped))
+		if err != nil {
+			return
+		}
+		bs, err = ioutil.ReadAll(gr)
+	})
+	return bs, err
 }
 
 // CallGraphCSV returns a CSV representation of the
 // OPA-WASM bytecode's call graph: 'caller,callee'
 func CallGraphCSV() ([]byte, error) {
-	cg, err := gzip.NewReader(bytes.NewBuffer(gzippedCallGraphCSV))
-	if err != nil {
-		return nil, err
-	}
-	return ioutil.ReadAll(cg)
+	var err error
+	callGraphCSVOnce.Do(func() {
+		cg, err := gzip.NewReader(bytes.NewBuffer(gzippedCallGraphCSV))
+		if err != nil {
+			return
+		}
+		callGraphCSV, err = ioutil.ReadAll(cg)
+	})
+	return callGraphCSV, err
 }
-
 `))
 
 	if err != nil {

--- a/internal/wasm/sdk/opa/opa_bench_test.go
+++ b/internal/wasm/sdk/opa/opa_bench_test.go
@@ -56,6 +56,12 @@ a = true`, "data.p.a = x")
 	}
 }
 
+func BenchmarkWasmCompilation(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = compileRegoToWasm("a = true", "data.p.a = x", false)
+	}
+}
+
 func BenchmarkWASMArrayIteration(b *testing.B) {
 	sizes := []int{10, 100, 1000, 10000}
 	for _, n := range sizes {


### PR DESCRIPTION
The result will always be the same, and on multiple calls to
rego.New() with the wasm target, repeating this work can be
avoided.

Once Go 1.17 is out and we can do something incompatible with
1.15, we can [switch to using the go:embed directive instead.](https://github.com/srenatus/opa/tree/sr/go1.16/use-go-embed-directive-for-wasm-base)
