### PR TITLE
rego+topdown: allow custom builtins via rego pkg to halt

### DIFF
--- a/rego/errors.go
+++ b/rego/errors.go
@@ -1,0 +1,18 @@
+package rego
+
+// HaltError is an error type to return from a custom function implementation
+// that will abort the evaluation process (analogous to topdown.Halt).
+type HaltError struct {
+	err error
+}
+
+// Error delegates to the wrapped error
+func (h *HaltError) Error() string {
+	return h.err.Error()
+}
+
+// NewHaltError wraps an error such that the evaluation process will stop
+// when it occurs.
+func NewHaltError(err error) error {
+	return &HaltError{err: err}
+}

--- a/rego/rego.go
+++ b/rego/rego.go
@@ -2457,6 +2457,14 @@ func parseStringsToRefs(s []string) ([]ast.Ref, error) {
 // was defined.
 func finishFunction(name string, bctx topdown.BuiltinContext, result *ast.Term, err error, iter func(*ast.Term) error) error {
 	if err != nil {
+		var e *HaltError
+		if errors.As(err, &e) {
+			return topdown.Halt{Err: &topdown.Error{
+				Code:     topdown.BuiltinErr,
+				Message:  fmt.Sprintf("%v: %v", name, e.Error()),
+				Location: bctx.Location,
+			}}
+		}
 		return &topdown.Error{
 			Code:     topdown.BuiltinErr,
 			Message:  fmt.Sprintf("%v: %v", name, err.Error()),

--- a/topdown/eval.go
+++ b/topdown/eval.go
@@ -2,6 +2,7 @@ package topdown
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"sort"
@@ -1528,11 +1529,12 @@ func (e evalBuiltin) eval(iter unifyIterator) error {
 	})
 
 	if err != nil {
-		if h, ok := err.(Halt); !ok {
+		var t Halt
+		if errors.As(err, &t) {
+			err = t.Err
+		} else {
 			e.e.builtinErrors.errs = append(e.e.builtinErrors.errs, err)
 			err = nil
-		} else {
-			err = h.Err
 		}
 	}
 


### PR DESCRIPTION
Before, functions provided via arguments to `rego.New()` hadn't been
able to halt the topdown evaluation.

Now, they do, if they return a `*rego.HaltError`.

Fixes #3534.
