### PR TITLE
topdown: Improve rand.intn implementation

### DIFF
--- a/ast/builtins.go
+++ b/ast/builtins.go
@@ -259,6 +259,7 @@ var IgnoreDuringPartialEval = []*Builtin{
 	NowNanos,
 	HTTPSend,
 	UUIDRFC4122,
+	RandIntn,
 }
 
 /**

--- a/docs/content/policy-reference.md
+++ b/docs/content/policy-reference.md
@@ -276,6 +276,7 @@ complex types.
 | <span class="opa-keep-it-together">``output := floor(x)``</span>    | ``output`` is ``x`` rounded down the nearest integer | ✅ |
 | <span class="opa-keep-it-together">``output := abs(x)``</span>    | ``output`` is the absolute value of ``x`` | ✅ |
 | <span class="opa-keep-it-together">``output := numbers.range(a, b)``</span> | ``output`` is the range of integer numbers between ``a`` and ``b`` (inclusive). If ``a`` == ``b`` then ``output`` == ``[a]``. If ``a`` < ``b`` the range is in ascending order. If ``a`` > ``b`` the range is in descending order. | ✅ |
+  <span class="opa-keep-it-together">``output := rand.intn(str, n)``</span> |  ``output`` is a ``number`` in the range [0, abs(``n``)). If ``n`` is 0, then ``output`` is 0. For any given (``str``, ``n``) pair the output will be consistent throughout a query evaluation. | SDK-dependent |
 
 ### Aggregates
 

--- a/topdown/builtins.go
+++ b/topdown/builtins.go
@@ -6,14 +6,15 @@ package topdown
 
 import (
 	"context"
+	"encoding/binary"
 	"fmt"
 	"io"
-
-	"github.com/open-policy-agent/opa/metrics"
-	"github.com/open-policy-agent/opa/topdown/cache"
+	"math/rand"
 
 	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/metrics"
 	"github.com/open-policy-agent/opa/topdown/builtins"
+	"github.com/open-policy-agent/opa/topdown/cache"
 )
 
 type (
@@ -34,7 +35,7 @@ type (
 	BuiltinContext struct {
 		Context                context.Context       // request context that was passed when query started
 		Metrics                metrics.Metrics       // metrics registry for recording built-in specific metrics
-		Seed                   io.Reader             // randomization seed
+		Seed                   io.Reader             // randomization source
 		Time                   *ast.Term             // wall clock time
 		Cancel                 Cancel                // atomic value that signals evaluation to halt
 		Runtime                *ast.Term             // runtime information on the OPA instance
@@ -46,6 +47,7 @@ type (
 		TraceEnabled           bool                  // indicates whether tracing is enabled for the evaluation
 		QueryID                uint64                // identifies query being evaluated
 		ParentID               uint64                // identifies parent of query being evaluated
+		rand                   *rand.Rand            // randomization source for non-security-sensitive operations
 	}
 
 	// BuiltinFunc defines an interface for implementing built-in functions.
@@ -55,6 +57,25 @@ type (
 	// value.
 	BuiltinFunc func(bctx BuiltinContext, operands []*ast.Term, iter func(*ast.Term) error) error
 )
+
+// Rand returns a random number generator based on the Seed for this built-in
+// context. The random number will be re-used across multiple calls to this
+// function. If a random number generator cannot be created, an error is
+// returned.
+func (bctx *BuiltinContext) Rand() (*rand.Rand, error) {
+
+	if bctx.rand != nil {
+		return bctx.rand, nil
+	}
+
+	seed, err := readInt64(bctx.Seed)
+	if err != nil {
+		return nil, err
+	}
+
+	bctx.rand = rand.New(rand.NewSource(seed))
+	return bctx.rand, nil
+}
 
 // RegisterBuiltinFunc adds a new built-in function to the evaluation engine.
 func RegisterBuiltinFunc(name string, f BuiltinFunc) {
@@ -167,4 +188,13 @@ func handleBuiltinErr(name string, loc *ast.Location, err error) error {
 			Location: loc,
 		}
 	}
+}
+
+func readInt64(r io.Reader) (int64, error) {
+	bs := make([]byte, 8)
+	n, err := io.ReadFull(r, bs)
+	if n != len(bs) || err != nil {
+		return 0, err
+	}
+	return int64(binary.BigEndian.Uint64(bs)), nil
 }

--- a/topdown/numbers_test.go
+++ b/topdown/numbers_test.go
@@ -1,0 +1,103 @@
+package topdown
+
+import (
+	"context"
+	"math/rand"
+	"testing"
+
+	"github.com/open-policy-agent/opa/ast"
+)
+
+func TestRandIntnZero(t *testing.T) {
+
+	qrs, err := NewQuery(ast.MustParseBody(`rand.intn("x", 0, out)`)).Run(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	} else if len(qrs) != 1 {
+		t.Fatal("expected one result")
+	}
+
+	exp := ast.MustParseTerm(`{{out: 0}}`)
+
+	result := queryResultSetToTerm(qrs)
+
+	if !result.Equal(exp) {
+		t.Fatalf("expected %v but got %v", exp, result)
+	}
+}
+
+func TestRandIntnNegative(t *testing.T) {
+
+	qrs, err := NewQuery(ast.MustParseBody(`rand.intn("x", -100, out)`)).Run(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	} else if len(qrs) != 1 {
+		t.Fatal("expected one result")
+	}
+
+	x, ok := qrs[0][ast.Var("out")].Value.(ast.Number).Int()
+	if !ok {
+		t.Fatal("expected int")
+	}
+
+	if x < 0 || x >= 100 {
+		t.Fatal("expected x to be [0, 100)")
+	}
+}
+
+func TestRandIntnSeedingAndCaching(t *testing.T) {
+
+	query := `rand.intn("x", 100000, x); rand.intn("x", 1000, y); rand.intn("x", 100000, x2); rand.intn("y", 1000, z)`
+
+	q := NewQuery(ast.MustParseBody(query)).WithSeed(rand.New(rand.NewSource(0))).WithCompiler(ast.NewCompiler())
+
+	ctx := context.Background()
+
+	qrs, err := q.Run(ctx)
+	if err != nil {
+		t.Fatal(err)
+	} else if len(qrs) != 1 {
+		t.Fatal("expected exactly one result but got:", qrs)
+	}
+
+	exp := ast.MustParseTerm(`
+		{
+			{
+				x: 88007,
+				x2: 88007,
+				y: 796,
+				z: 101
+			}
+		}
+	`)
+
+	result := queryResultSetToTerm(qrs)
+
+	if !result.Equal(exp) {
+		t.Fatalf("expected %v but got %v", exp, result)
+	}
+
+}
+
+func TestRandIntnSavingDuringPartialEval(t *testing.T) {
+
+	query := `x = "x"; y = 100; rand.intn(x, y, z)`
+	c := ast.NewCompiler().
+		WithCapabilities(&ast.Capabilities{Builtins: []*ast.Builtin{ast.RandIntn}})
+	c.Compile(nil)
+
+	q := NewQuery(ast.MustParseBody(query)).WithSeed(rand.New(rand.NewSource(0))).WithCompiler(c)
+
+	queries, modules, err := q.PartialRun(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	} else if len(modules) > 0 {
+		t.Fatal("expected no support")
+	}
+
+	exp := ast.MustParseBody(`rand.intn("x", 100, z); x = "x"; y = 100`)
+
+	if len(queries) != 1 || !queries[0].Equal(exp) {
+		t.Fatalf("expected %v but got: %v", exp, queries)
+	}
+}


### PR DESCRIPTION
This commit combines a few improvements to the rand.intn
implementation:

* Zero and negative integers do not cause an error. In most cases, we
  try to make built-in functions return sensible results (rather than
  halting evaluation or being undefined.) In this case, it's easy
  enough to handle zero and negative integers.

* Use the built-in context seed to generate the source for the rand
  call. This helps ensure that rand.intn calls can be
  reproduced.

* Use dedicated cache key type instead of overloading uuidCachingKey.

* Add test coverage for caching, partial eval, etc.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/main/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/main/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
