### PR TITLE
ast: fix panic in ParseModule() with all space chars, starting with tab

### DIFF
--- a/ast/parser_ext.go
+++ b/ast/parser_ext.go
@@ -749,7 +749,11 @@ func newParserErrorDetail(bs []byte, offset int) *ParserErrorDetail {
 func (d ParserErrorDetail) Lines() []string {
 	line := strings.TrimLeft(d.Line, "\t") // remove leading tabs
 	tabCount := len(d.Line) - len(line)
-	return []string{line, strings.Repeat(" ", d.Idx-tabCount) + "^"}
+	indent := d.Idx - tabCount
+	if indent < 0 {
+		indent = 0
+	}
+	return []string{line, strings.Repeat(" ", indent) + "^"}
 }
 
 func isNewLineChar(b byte) bool {

--- a/ast/parser_test.go
+++ b/ast/parser_test.go
@@ -2221,6 +2221,17 @@ p = true {
 			err: `1 error occurred: test.rego:4: rego_parse_error: unexpected as keyword
 	as
 	^`},
+		{
+			note: "input is tab and space tokens only",
+			exp: &ParserErrorDetail{
+				Line: "\t\v\f ",
+				Idx:  0,
+			},
+			input: "\t\v\f ",
+			// NOTE(sr): With the unprintable control characters, the output is pretty
+			// useless. But it's also quite an edge case.
+			err: "1 error occurred: test.rego:1: rego_parse_error: illegal token\n\t\v\f \n\t^",
+		},
 	}
 
 	for _, tc := range tests {
@@ -2231,7 +2242,7 @@ p = true {
 			}
 			detail := err.(Errors)[0].Details
 			if !reflect.DeepEqual(detail, tc.exp) {
-				t.Fatalf("Expected %v but got: %v", tc.exp, detail)
+				t.Errorf("Expected %v but got: %v", tc.exp, detail)
 			}
 			if tc.err != "" && tc.err != err.Error() {
 				t.Fatalf("Expected error string %q but got: %q", tc.err, err.Error())


### PR DESCRIPTION
The specific combination where the first character is a tab, and the rest
are falling under `unicode.IsSpace()` would lead to strings.Repeat being
fed an empty count (to determine the position of the error pointer).

Displaying different "spaces" in a discernable way isn't solved here,
but I think it's also an edge case we can accept as-is.
