### PR TITLE
opa eval: add '--count=#' flag

### DIFF
--- a/cmd/bench.go
+++ b/cmd/bench.go
@@ -13,11 +13,10 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/open-policy-agent/opa/compile"
-
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
 
+	"github.com/open-policy-agent/opa/compile"
 	"github.com/open-policy-agent/opa/internal/presentation"
 	"github.com/open-policy-agent/opa/metrics"
 	"github.com/open-policy-agent/opa/rego"
@@ -121,10 +120,11 @@ func benchMain(args []string, params benchmarkCommandParams, w io.Writer, r benc
 
 	ctx := context.Background()
 	var benchFunc func(context.Context, ...rego.EvalOption) error
+	rg := rego.New(ectx.regoArgs...)
 
 	if !params.partial {
 		// Take the eval context and prepare anything else we possible can before benchmarking the evaluation
-		pq, err := ectx.r.PrepareForEval(ctx)
+		pq, err := rg.PrepareForEval(ctx)
 		if err != nil {
 			errRender := renderBenchmarkError(params, err, w)
 			return 1, errRender
@@ -141,7 +141,7 @@ func benchMain(args []string, params benchmarkCommandParams, w io.Writer, r benc
 		}
 	} else {
 		// As with normal evaluation, prepare as much as possible up front.
-		pq, err := ectx.r.PrepareForPartial(ctx)
+		pq, err := rg.PrepareForPartial(ctx)
 		if err != nil {
 			errRender := renderBenchmarkError(params, err, w)
 			return 1, errRender

--- a/cmd/bench_test.go
+++ b/cmd/bench_test.go
@@ -216,7 +216,8 @@ func validateBenchMainPrep(t *testing.T, args []string, params benchmarkCommandP
 	mockRunner.onRun = func(ctx context.Context, ectx *evalContext, params benchmarkCommandParams, f func(context.Context, ...rego.EvalOption) error) (testing.BenchmarkResult, error) {
 
 		// cheat and use the ectx to evalute the query to ensure the input setup on it was valid
-		pq, err := ectx.r.PrepareForEval(ctx)
+		r := rego.New(ectx.regoArgs...)
+		pq, err := r.PrepareForEval(ctx)
 		if err != nil {
 			return testing.BenchmarkResult{}, err
 		}

--- a/docs/content/policy-performance.md
+++ b/docs/content/policy-performance.md
@@ -286,6 +286,7 @@ The `opa eval` command provides the following profiler options:
 | <span class="opa-keep-it-together">`--profile`</span> | Enables expression profiling and outputs profiler results. | off |
 | <span class="opa-keep-it-together">`--profile-sort`</span> | Criteria to sort the expression profiling results. This options implies `--profile`. | total_time_ns => num_eval => num_redo => file => line |
 | <span class="opa-keep-it-together">`--profile-limit`</span> | Desired number of profiling results sorted on the given criteria. This options implies `--profile`. | 10 |
+| <span class="opa-keep-it-together">`--count`</span> | Desired number of evaluations that profiling metrics are to be captured for. With `--format=pretty`, the output will contain min, max, mean and the 90th and 99th percentile. All collected percentiles can be found in the JSON output. | 1 |
 
 #### Sort criteria for the profile results
 
@@ -401,6 +402,43 @@ false
 ```
 As seen from the above table, all results are displayed. The profile results are
 sorted on the default sort criteria.
+
+To evaluation the policy multiple times, and aggregate the profiling data over those
+runs, pass `--count=NUMBER`:
+
+
+```bash
+opa eval --data rbac.rego --profile --format=pretty --count=10 'data.rbac.allow'
+```
+
+**Sample Output**
+```ruby
+false
++------------------------------+---------+----------+---------------+----------------+---------------+
+|            METRIC            |   MIN   |   MAX    |     MEAN      |      90%       |      99%      |
++------------------------------+---------+----------+---------------+----------------+---------------+
+| timer_rego_load_files_ns     | 349969  | 2549399  | 1.4760619e+06 | 2.5312689e+06  | 2.549399e+06  |
+| timer_rego_module_compile_ns | 1087507 | 24537496 | 1.120074e+07  | 2.41699473e+07 | 2.4537496e+07 |
+| timer_rego_module_parse_ns   | 275531  | 1915263  | 1.126406e+06  | 1.9016968e+06  | 1.915263e+06  |
+| timer_rego_query_compile_ns  | 61663   | 64395    | 63062.5       | 64374.1        | 64395         |
+| timer_rego_query_eval_ns     | 161812  | 1198092  | 637754        | 1.1846622e+06  | 1.198092e+06  |
+| timer_rego_query_parse_ns    | 6078    | 6078     | 6078          | 6078           | 6078          |
++------------------------------+---------+----------+---------------+----------------+---------------+
++----------+-------------+-------------+-------------+-------------+----------+----------+-----------------+
+|   MIN    |     MAX     |    MEAN     |     90%     |     99%     | NUM EVAL | NUM REDO |    LOCATION     |
++----------+-------------+-------------+-------------+-------------+----------+----------+-----------------+
+| 43.875µs | 26.135469ms | 11.494512ms | 25.746215ms | 26.135469ms | 1        | 1        | data.rbac.allow |
+| 21.478µs | 211.461µs   | 98.102µs    | 205.72µs    | 211.461µs   | 1        | 1        | rbac.rego:13    |
+| 19.652µs | 123.537µs   | 73.161µs    | 122.75µs    | 123.537µs   | 1        | 1        | rbac.rego:40    |
+| 12.303µs | 117.277µs   | 61.59µs     | 116.733µs   | 117.277µs   | 2        | 1        | rbac.rego:50    |
+| 12.224µs | 93.214µs    | 51.289µs    | 92.217µs    | 93.214µs    | 1        | 1        | rbac.rego:44    |
+| 5.561µs  | 84.121µs    | 43.002µs    | 83.469µs    | 84.121µs    | 1        | 1        | rbac.rego:51    |
+| 5.56µs   | 71.712µs    | 36.545µs    | 71.158µs    | 71.712µs    | 1        | 0        | rbac.rego:45    |
+| 4.958µs  | 66.04µs     | 33.161µs    | 65.636µs    | 66.04µs     | 1        | 2        | rbac.rego:49    |
+| 4.326µs  | 65.836µs    | 30.461µs    | 65.083µs    | 65.836µs    | 1        | 1        | rbac.rego:6     |
+| 3.948µs  | 43.399µs    | 24.167µs    | 43.055µs    | 43.399µs    | 1        | 2        | rbac.rego:55    |
++----------+-------------+-------------+-------------+-------------+----------+----------+-----------------+
+```
 
 ##### Example: Display top `5` profile results
 

--- a/internal/presentation/presentation.go
+++ b/internal/presentation/presentation.go
@@ -109,14 +109,16 @@ func (o DepAnalysisOutput) sort() {
 
 // Output contains the result of evaluation to be presented.
 type Output struct {
-	Errors      OutputErrors         `json:"errors,omitempty"`
-	Result      rego.ResultSet       `json:"result,omitempty"`
-	Partial     *rego.PartialQueries `json:"partial,omitempty"`
-	Metrics     metrics.Metrics      `json:"metrics,omitempty"`
-	Explanation []*topdown.Event     `json:"explanation,omitempty"`
-	Profile     []profiler.ExprStats `json:"profile,omitempty"`
-	Coverage    *cover.Report        `json:"coverage,omitempty"`
-	limit       int
+	Errors            OutputErrors                   `json:"errors,omitempty"`
+	Result            rego.ResultSet                 `json:"result,omitempty"`
+	Partial           *rego.PartialQueries           `json:"partial,omitempty"`
+	Metrics           metrics.Metrics                `json:"metrics,omitempty"`
+	AggregatedMetrics map[string]interface{}         `json:"aggregated_metrics,omitempty"`
+	Explanation       []*topdown.Event               `json:"explanation,omitempty"`
+	Profile           []profiler.ExprStats           `json:"profile,omitempty"`
+	AggregatedProfile []profiler.ExprStatsAggregated `json:"aggregated_profile,omitempty"`
+	Coverage          *cover.Report                  `json:"coverage,omitempty"`
+	limit             int
 }
 
 // WithLimit sets the output limit to set on stringified values.
@@ -306,6 +308,16 @@ func Pretty(w io.Writer, r Output) error {
 			return err
 		}
 	}
+	if len(r.AggregatedMetrics) > 0 {
+		if err := prettyAggregatedMetrics(w, r.AggregatedMetrics, r.limit); err != nil {
+			return err
+		}
+	}
+	if len(r.AggregatedProfile) > 0 {
+		if err := prettyAggregatedProfile(w, r.AggregatedProfile); err != nil {
+			return err
+		}
+	}
 	if r.Coverage != nil {
 		if err := prettyCoverage(w, r.Coverage); err != nil {
 			return err
@@ -458,6 +470,18 @@ func prettyMetrics(w io.Writer, m metrics.Metrics, limit int) error {
 	return nil
 }
 
+var statKeys = []string{"min", "max", "mean", "90%", "99%"}
+
+func prettyAggregatedMetrics(w io.Writer, ms map[string]interface{}, limit int) error {
+	keys := []string{"metric"}
+	tableMetrics := generateTableWithKeys(w, append(keys, statKeys...)...)
+	populateTableAggregatedMetrics(ms, tableMetrics, limit)
+	if tableMetrics.NumLines() > 0 {
+		tableMetrics.Render()
+	}
+	return nil
+}
+
 func prettyProfile(w io.Writer, profile []profiler.ExprStats) error {
 	tableProfile := generateTableProfile(w)
 	for _, rs := range profile {
@@ -468,6 +492,30 @@ func prettyProfile(w io.Writer, profile []profiler.ExprStats) error {
 		numRedo := strconv.FormatInt(int64(rs.NumRedo), 10)
 		loc := rs.Location.String()
 		line = append(line, timeNsStr, numEval, numRedo, loc)
+		tableProfile.Append(line)
+	}
+	if tableProfile.NumLines() > 0 {
+		tableProfile.Render()
+	}
+	return nil
+}
+
+func prettyAggregatedProfile(w io.Writer, profile []profiler.ExprStatsAggregated) error {
+	tableProfile := generateTableWithKeys(w, append(statKeys, "num eval", "num redo", "location")...)
+	for _, rs := range profile {
+		line := []string{}
+		for _, k := range statKeys {
+			v := rs.ExprTimeNsStats.(map[string]interface{})[k]
+			if f, ok := v.(float64); ok {
+				line = append(line, time.Duration(f).String())
+			} else if i, ok := v.(int64); ok {
+				line = append(line, time.Duration(i).String())
+			}
+		}
+		numEval := strconv.FormatInt(int64(rs.NumEval), 10)
+		numRedo := strconv.FormatInt(int64(rs.NumRedo), 10)
+		loc := rs.Location.String()
+		line = append(line, numEval, numRedo, loc)
 		tableProfile.Append(line)
 	}
 	if tableProfile.NumLines() > 0 {
@@ -533,20 +581,25 @@ func printPrettyRow(table *tablewriter.Table, keys []resultKey, result rego.Resu
 }
 
 func generateTableMetrics(writer io.Writer) *tablewriter.Table {
+	return generateTableWithKeys(writer, "Metric", "Value")
+}
+
+func generateTableWithKeys(writer io.Writer, keys ...string) *tablewriter.Table {
 	table := tablewriter.NewWriter(writer)
-	table.SetHeader([]string{"Metric", "Value"})
+	aligns := []int{}
+	var hdrs []string
+	for _, k := range keys {
+		hdrs = append(hdrs, strings.Title((k)))
+		aligns = append(aligns, tablewriter.ALIGN_LEFT)
+	}
+	table.SetHeader(hdrs)
 	table.SetAlignment(tablewriter.ALIGN_CENTER)
-	table.SetColumnAlignment([]int{tablewriter.ALIGN_LEFT, tablewriter.ALIGN_LEFT})
+	table.SetColumnAlignment(aligns)
 	return table
 }
 
 func generateTableProfile(writer io.Writer) *tablewriter.Table {
-	table := tablewriter.NewWriter(writer)
-	table.SetHeader([]string{"Time", "Num Eval", "Num Redo", "Location"})
-	table.SetAlignment(tablewriter.ALIGN_CENTER)
-	table.SetColumnAlignment([]int{tablewriter.ALIGN_LEFT, tablewriter.ALIGN_LEFT,
-		tablewriter.ALIGN_LEFT, tablewriter.ALIGN_LEFT})
-	return table
+	return generateTableWithKeys(writer, "Time", "Num Eval", "Num Redo", "Location")
 }
 
 func populateTableMetrics(m metrics.Metrics, table *tablewriter.Table, prettyLimit int) {
@@ -567,6 +620,20 @@ func populateTableMetrics(m metrics.Metrics, table *tablewriter.Table, prettyLim
 				lines = append(lines, line)
 			}
 		}
+	}
+	sortMetricRows(lines)
+	table.AppendBulk(lines)
+}
+
+func populateTableAggregatedMetrics(ms map[string]interface{}, table *tablewriter.Table, prettyLimit int) {
+	lines := [][]string{}
+	for name, vals := range ms {
+		line := []string{name}
+		vs := vals.(map[string]interface{})
+		for _, k := range statKeys {
+			line = append(line, checkStrLimit(fmt.Sprintf("%v", vs[k]), prettyLimit))
+		}
+		lines = append(lines, line)
 	}
 	sortMetricRows(lines)
 	table.AppendBulk(lines)


### PR DESCRIPTION
`opa eval --count=# --profile` will now evaluate the query # times,
and display aggregated results for metrics and the expression-time
profile.

Before, `opa eval --profile` would yield output like this (JSON):

    "metrics": {
      "timer_rego_external_resolve_ns": 233,
      "timer_rego_load_files_ns": 138866,
      "timer_rego_module_compile_ns": 432654,
      "timer_rego_module_parse_ns": 81454,
      "timer_rego_query_compile_ns": 54892,
      "timer_rego_query_eval_ns": 135624,
      "timer_rego_query_parse_ns": 3886
    },
    "profile": [
      {
        "total_time_ns": 75705,
        "num_eval": 4,
        "num_redo": 2,
        "location": {
          "file": "t.rego",
          "row": 8,
          "col": 2
        }
      },

Now, both of these are replaced by "aggragated_" variants that
include some statistics:

    "aggregated_metrics": {
      "timer_rego_external_resolve_ns": {
        "75%": 1618.5,
        "90%": 1933.8000000000002,
        "95%": 1954,
        "99%": 1954,
        "99.9%": 1954,
        "99.99%": 1954,
        "count": 10,
        "max": 1954,
        "mean": 1137.1,
        "median": 1140,
        "min": 311,
        "stddev": 514.9278493148337
      },

and

    "aggregated_profile": [
      {
        "total_time_ns_stats": {
          "75%": 63369.75,
          "90%": 69523.5,
          "95%": 69691,
          "99%": 69691,
          "99.9%": 69691,
          "99.99%": 69691,
          "count": 10,
          "max": 69691,
          "mean": 39030.9,
          "median": 53758.5,
          "min": 3390,
          "stddev": 27635.790954666016
        },
        "num_eval": 1,
        "num_redo": 1,
        "location": {
          "file": "t.rego",
          "row": 9,
          "col": 2
        }
      }

The table format has been adjusted as well, but quickly becomes
unwieldy:

```
+------------------------------+---------+----------+---------------+----------------+---------------+
|            METRIC            |   MIN   |   MAX    |     MEAN      |      90%       |      99%      |
+------------------------------+---------+----------+---------------+----------------+---------------+
| timer_rego_load_files_ns     | 349969  | 2549399  | 1.4760619e+06 | 2.5312689e+06  | 2.549399e+06  |
| timer_rego_module_compile_ns | 1087507 | 24537496 | 1.120074e+07  | 2.41699473e+07 | 2.4537496e+07 |
| timer_rego_module_parse_ns   | 275531  | 1915263  | 1.126406e+06  | 1.9016968e+06  | 1.915263e+06  |
| timer_rego_query_compile_ns  | 61663   | 64395    | 63062.5       | 64374.1        | 64395         |
| timer_rego_query_eval_ns     | 161812  | 1198092  | 637754        | 1.1846622e+06  | 1.198092e+06  |
| timer_rego_query_parse_ns    | 6078    | 6078     | 6078          | 6078           | 6078          |
+------------------------------+---------+----------+---------------+----------------+---------------+
+----------+-------------+-------------+-------------+-------------+----------+----------+-----------------+
|   MIN    |     MAX     |    MEAN     |     90%     |     99%     | NUM EVAL | NUM REDO |    LOCATION     |
+----------+-------------+-------------+-------------+-------------+----------+----------+-----------------+
| 43.875µs | 26.135469ms | 11.494512ms | 25.746215ms | 26.135469ms | 1        | 1        | data.rbac.allow |
| 21.478µs | 211.461µs   | 98.102µs    | 205.72µs    | 211.461µs   | 1        | 1        | rbac.rego:13    |
| 19.652µs | 123.537µs   | 73.161µs    | 122.75µs    | 123.537µs   | 1        | 1        | rbac.rego:40    |
| 12.303µs | 117.277µs   | 61.59µs     | 116.733µs   | 117.277µs   | 2        | 1        | rbac.rego:50    |
| 12.224µs | 93.214µs    | 51.289µs    | 92.217µs    | 93.214µs    | 1        | 1        | rbac.rego:44    |
| 5.561µs  | 84.121µs    | 43.002µs    | 83.469µs    | 84.121µs    | 1        | 1        | rbac.rego:51    |
| 5.56µs   | 71.712µs    | 36.545µs    | 71.158µs    | 71.712µs    | 1        | 0        | rbac.rego:45    |
| 4.958µs  | 66.04µs     | 33.161µs    | 65.636µs    | 66.04µs     | 1        | 2        | rbac.rego:49    |
| 4.326µs  | 65.836µs    | 30.461µs    | 65.083µs    | 65.836µs    | 1        | 1        | rbac.rego:6     |
| 3.948µs  | 43.399µs    | 24.167µs    | 43.055µs    | 43.399µs    | 1        | 2        | rbac.rego:55    |
+----------+-------------+-------------+-------------+-------------+----------+----------+-----------------+
```

Fixes #3651.
