### PR TITLE
wasm: put stack first, grow it to 8MiB.

### DIFF
--- a/internal/wasm/sdk/opa/opa.go
+++ b/internal/wasm/sdk/opa/opa.go
@@ -45,7 +45,7 @@ type Result struct {
 // initialized before invoking the Eval.
 func New() *OPA {
 	opa := &OPA{
-		memoryMinPages: 16,
+		memoryMinPages: 129,
 		memoryMaxPages: 0x10000, // 4GB
 		poolSize:       uint32(runtime.GOMAXPROCS(0)),
 		logError:       func(error) {},

--- a/test/wasm/assets/test.js
+++ b/test/wasm/assets/test.js
@@ -238,7 +238,7 @@ function namespace(cache, key) {
 
 async function test() {
 
-    const memory = new WebAssembly.Memory({ initial: 5 });
+    const memory = new WebAssembly.Memory({ initial: 129 });
     const t0 = now();
     var testCases = [];
     const files = readdirSync('.');

--- a/wasm/Makefile
+++ b/wasm/Makefile
@@ -149,6 +149,8 @@ $(WASM_OBJ_DIR)/opa.wasm: $(OBJS) $(CPP_OBJS) $(LIB_OBJS) $(LIB_MPDEC_OBJS) $(LI
 			--allow-undefined-file=src/undefined.symbols \
 			--import-memory \
 			--no-entry \
+			-z stack-size=8388608 \
+			--stack-first \
 			-o $@ $^
 	@wasm2wat $(WASM_OBJ_DIR)/opa.wasm > $(WASM_OBJ_DIR)/opa.wast
 


### PR DESCRIPTION
🚧 Just want to see the impact -- if any -- of this.

From how I understand this, https://surma.dev/things/c-to-webassembly/,
we should be able to modify the stack size at the time of `opa build`
if we keep the stack after data: it's all a matter of moving
`__heap_base`.
