### PR TITLE
docs: add mandatory `pathType` property to example Ingress resources

### DIFF
--- a/docs/content/kubernetes-primer.md
+++ b/docs/content/kubernetes-primer.md
@@ -267,6 +267,7 @@ request:
         http:
           paths:
           - path: /finance
+            pathType: Prefix
             backend:
               service:
                 name: banking
@@ -319,6 +320,7 @@ spec:
     http:
       paths:
       - path: /finance
+        pathType: Prefix
         backend:
           service:
             name: banking
@@ -348,6 +350,7 @@ request:
         http:
           paths:
           - path: /finance
+            pathType: Prefix
             backend:
               service:
                 name: banking


### PR DESCRIPTION
Missed this bit when updating the documentation on a previous PR.