### PR TITLE
ast/compile: use all vars from rule body for index candidates

### DIFF
--- a/ast/compile.go
+++ b/ast/compile.go
@@ -1833,8 +1833,8 @@ func (ci *ComprehensionIndex) String() string {
 
 func buildComprehensionIndices(dbg debug.Debug, arity func(Ref) int, candidates VarSet, rwVars map[Var]Var, node interface{}, result map[*Term]*ComprehensionIndex) uint64 {
 	var n uint64
+	cpy := candidates.Copy()
 	WalkBodies(node, func(b Body) bool {
-		cpy := candidates.Copy()
 		for _, expr := range b {
 			index := getComprehensionIndex(dbg, arity, cpy, rwVars, expr)
 			if index != nil {


### PR DESCRIPTION
Before, we'd only looked at the vars preceding the comprehension in the body
containing it. In the case of nested comprehensions, that would have excluded
the rule body OUTSIDE of the nested body.

Now, we'll accumulate candidates over multiple bodies -- capturing the ones
that had been missing before.

Fixes #3579.

-----------

I had a more involved fix first, but making it work with the query compiler, I realised that moving the `candiates.Copy()` does the trick, too.

The change to the existing tests also covers the issue underlying #3579, I believe.