### PR TITLE
server/server: exclude-plugin param in /health route

### DIFF
--- a/docs/content/rest-api.md
+++ b/docs/content/rest-api.md
@@ -1787,6 +1787,10 @@ that the server is operational. Optionally it can account for bundle activation 
 `bundles` - Boolean parameter to account for bundle activation status in response. This includes
             any discovery bundles or bundles defined in the loaded discovery configuration.
 `plugins` - Boolean parameter to account for plugin status in response.
+`exclude-plugin` - String parameter to exclude a plugin from status checks. Can be added multiple 
+            times. Does nothing if `plugins` is not true. This parameter is useful for special use cases
+            where a plugin depends on the server being fully initialized before it can fully intialize
+            itself.
 
 #### Status Codes
 - **200** - OPA service is healthy. If the `bundles` option is specified then all configured bundles have
@@ -1812,6 +1816,11 @@ GET /health?bundles HTTP/1.1
 #### Example Request (plugin status)
 ```http
 GET /health?plugins HTTP/1.1
+```
+
+#### Example Request (plugin status with exclude)
+```http
+GET /health?plugins&exclude-plugin=decision-logs&exclude-plugin=status HTTP/1.1
 ```
 
 #### Healthy Response

--- a/server/types/types.go
+++ b/server/types/types.go
@@ -431,6 +431,11 @@ const (
 	// of the health API.
 	ParamPluginsV1 = "plugins"
 
+	// ParamExcludePluginV1 defines the name of the HTTP URL parameter that
+	// indicates the client wants to exclude plugin status in the results
+	// of the health API for the specified plugin(s)
+	ParamExcludePluginV1 = "exclude-plugin"
+
 	// ParamStrictBuiltinErrors names the HTTP URL parameter that indicates the client
 	// wants built-in function errors to be treated as fatal.
 	ParamStrictBuiltinErrors = "strict-builtin-errors"


### PR DESCRIPTION
- Added a new querystring param to the /health route: `exclude-plugin`
  - Can be specified multiple times
  - Value is the name of a plugin that should be excluded from the OK
    status check performed when the `plugins` qs param is specified

Fixes #3713

Signed-off-by: Grant Shively <gshively@godaddy.com>


Will add tests once implementation is discussed and approved

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/main/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/main/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
