### PR TITLE
rego: add ResultSet Allowed() helper

### DIFF
--- a/cmd/bench_test.go
+++ b/cmd/bench_test.go
@@ -227,7 +227,7 @@ func validateBenchMainPrep(t *testing.T, args []string, params benchmarkCommandP
 			return testing.BenchmarkResult{}, err
 		}
 
-		if len(rs) != 1 || rs[0].Expressions[0].Value != true {
+		if !rs.Allowed() {
 			t.Errorf("Unexpected results: %+v", rs)
 		}
 

--- a/docs/content/integration.md
+++ b/docs/content/integration.md
@@ -28,7 +28,7 @@ This page focuses predominantly on different ways to integrate with OPA's policy
 OPA supports different ways to evaluate policies.
 
 * The [REST API](../rest-api) returns decisions as JSON over HTTP.
-* The [Go API (GoDoc)](https://godoc.org/github.com/open-policy-agent/opa/rego) returns
+* The [Go API (GoDoc)](https://pkg.go.dev/github.com/open-policy-agent/opa/rego) returns
   decisions as simple Go types (`bool`, `string`, `map[string]interface{}`,
   etc.)
 * [WebAssembly](../wasm) compiles Rego policies into WASM instructions so they can be embedded and evaluated by any WebAssembly runtime
@@ -169,7 +169,7 @@ API Authorization](../http-api-authorization) tutorial.
 ### Integrating with the Go API
 
 Use the
-[github.com/open-policy-agent/opa/rego](https://godoc.org/github.com/open-policy-agent/opa/rego)
+[github.com/open-policy-agent/opa/rego](https://pkg.go.dev/github.com/open-policy-agent/opa/rego)
 package to embed OPA as a library inside services written in Go. To get started
 import the `rego` package:
 
@@ -264,8 +264,22 @@ if err != nil {
 }
 ```
 
+For the common case of policies evaluating to a single boolean value, there's
+a helper method: With `results.Allowed()`, the previous snippet can be shortened
+to
+
+```go
+results, err := query.Eval(ctx, rego.EvalInput(input))
+if err != nil {
+    // handle error
+}
+if !results.Allowed() {
+    // handle result
+}
+```
+
 For more examples of embedding OPA as a library see the
-[`rego`](https://godoc.org/github.com/open-policy-agent/opa/rego#pkg-examples)
+[`rego`](https://pkg.go.dev/github.com/open-policy-agent/opa/rego#pkg-examples)
 package in the Go documentation.
 
 ### WebAssembly (Wasm)
@@ -279,10 +293,10 @@ See [OPA Wasm docs](../wasm) for more details.
 
 A comparison of the different integration choices are summarized below.
 
-| Dimension | REST API | Go Lib | WASM (WIP) |
+| Dimension | REST API | Go Lib | Wasm |
 | --------- | -------- | ------ | ---------- |
 | Evaluation | Fast | Faster | Fastest |
-| Language | Any | Only Go | Any with WASM |
+| Language | Any | Only Go | Any with Wasm |
 | Operations | Update just OPA | Update entire service | Update service rarely |
 | Security | Must secure API | Enable only what is needed | Enable only what is needed |
 

--- a/rego/example_test.go
+++ b/rego/example_test.go
@@ -143,6 +143,38 @@ p = ["hello", "world"] { true }`,
 	// err: <nil>
 }
 
+func ExampleRego_Eval_allowed() {
+
+	ctx := context.Background()
+
+	// Create query that returns a single boolean value.
+	rego := rego.New(
+		rego.Query("data.authz.allow"),
+		rego.Module("example.rego",
+			`package authz
+
+default allow = false
+allow {
+	input.open == "sesame"
+}`,
+		),
+		rego.Input(map[string]interface{}{"open": "sesame"}),
+	)
+
+	// Run evaluation.
+	rs, err := rego.Eval(ctx)
+	if err != nil {
+		panic(err)
+	}
+
+	// Inspect result.
+	fmt.Println("allowed:", rs.Allowed())
+
+	// Output:
+	//
+	//	allowed: true
+}
+
 func ExampleRego_Eval_multipleDocuments() {
 
 	ctx := context.Background()
@@ -223,11 +255,13 @@ func ExampleRego_Eval_compiler() {
 	// Inspect results.
 	fmt.Println("len:", len(rs))
 	fmt.Println("value:", rs[0].Expressions[0].Value)
+	fmt.Println("allowed:", rs.Allowed()) // helper method
 
 	// Output:
 	//
 	// len: 1
 	// value: true
+	// allowed: true
 }
 
 func ExampleRego_Eval_storage() {
@@ -869,5 +903,4 @@ func ExampleRego_custom_function_global() {
 	// Output:
 	//
 	// [foo bar baz]
-
 }

--- a/rego/rego.go
+++ b/rego/rego.go
@@ -390,69 +390,6 @@ func (pq PreparedPartialQuery) Partial(ctx context.Context, options ...EvalOptio
 	return pq.r.partial(ctx, ectx)
 }
 
-// Result defines the output of Rego evaluation.
-type Result struct {
-	Expressions []*ExpressionValue `json:"expressions"`
-	Bindings    Vars               `json:"bindings,omitempty"`
-}
-
-func newResult() Result {
-	return Result{
-		Bindings: Vars{},
-	}
-}
-
-// Location defines a position in a Rego query or module.
-type Location struct {
-	Row int `json:"row"`
-	Col int `json:"col"`
-}
-
-// ExpressionValue defines the value of an expression in a Rego query.
-type ExpressionValue struct {
-	Value    interface{} `json:"value"`
-	Text     string      `json:"text"`
-	Location *Location   `json:"location"`
-}
-
-func newExpressionValue(expr *ast.Expr, value interface{}) *ExpressionValue {
-	result := &ExpressionValue{
-		Value: value,
-	}
-	if expr.Location != nil {
-		result.Text = string(expr.Location.Text)
-		result.Location = &Location{
-			Row: expr.Location.Row,
-			Col: expr.Location.Col,
-		}
-	}
-	return result
-}
-
-func (ev *ExpressionValue) String() string {
-	return fmt.Sprint(ev.Value)
-}
-
-// ResultSet represents a collection of output from Rego evaluation. An empty
-// result set represents an undefined query.
-type ResultSet []Result
-
-// Vars represents a collection of variable bindings. The keys are the variable
-// names and the values are the binding values.
-type Vars map[string]interface{}
-
-// WithoutWildcards returns a copy of v with wildcard variables removed.
-func (v Vars) WithoutWildcards() Vars {
-	n := Vars{}
-	for k, v := range v {
-		if ast.Var(k).IsWildcard() || ast.Var(k).IsGenerated() {
-			continue
-		}
-		n[k] = v
-	}
-	return n
-}
-
 // Errors represents a collection of errors returned when evaluating Rego.
 type Errors []error
 

--- a/rego/resultset.go
+++ b/rego/resultset.go
@@ -1,0 +1,70 @@
+package rego
+
+import (
+	"fmt"
+
+	"github.com/open-policy-agent/opa/ast"
+)
+
+// ResultSet represents a collection of output from Rego evaluation. An empty
+// result set represents an undefined query.
+type ResultSet []Result
+
+// Vars represents a collection of variable bindings. The keys are the variable
+// names and the values are the binding values.
+type Vars map[string]interface{}
+
+// WithoutWildcards returns a copy of v with wildcard variables removed.
+func (v Vars) WithoutWildcards() Vars {
+	n := Vars{}
+	for k, v := range v {
+		if ast.Var(k).IsWildcard() || ast.Var(k).IsGenerated() {
+			continue
+		}
+		n[k] = v
+	}
+	return n
+}
+
+// Result defines the output of Rego evaluation.
+type Result struct {
+	Expressions []*ExpressionValue `json:"expressions"`
+	Bindings    Vars               `json:"bindings,omitempty"`
+}
+
+func newResult() Result {
+	return Result{
+		Bindings: Vars{},
+	}
+}
+
+// Location defines a position in a Rego query or module.
+type Location struct {
+	Row int `json:"row"`
+	Col int `json:"col"`
+}
+
+// ExpressionValue defines the value of an expression in a Rego query.
+type ExpressionValue struct {
+	Value    interface{} `json:"value"`
+	Text     string      `json:"text"`
+	Location *Location   `json:"location"`
+}
+
+func newExpressionValue(expr *ast.Expr, value interface{}) *ExpressionValue {
+	result := &ExpressionValue{
+		Value: value,
+	}
+	if expr.Location != nil {
+		result.Text = string(expr.Location.Text)
+		result.Location = &Location{
+			Row: expr.Location.Row,
+			Col: expr.Location.Col,
+		}
+	}
+	return result
+}
+
+func (ev *ExpressionValue) String() string {
+	return fmt.Sprint(ev.Value)
+}

--- a/rego/resultset.go
+++ b/rego/resultset.go
@@ -68,3 +68,21 @@ func newExpressionValue(expr *ast.Expr, value interface{}) *ExpressionValue {
 func (ev *ExpressionValue) String() string {
 	return fmt.Sprint(ev.Value)
 }
+
+// Allowed is a helper method that'll return true iff there is only one expression
+// in the result set's only member, and that expression has the value `true`; and
+// there are no bindings.
+//
+// If bindings are present, this will yield `false`: it would be a pitfall to
+// return `true` for a query like `data.authz.allow = x`, which always has result
+// set element with value true, but could also have a binding `x: false`.
+func (rs ResultSet) Allowed() bool {
+	if len(rs) == 1 && len(rs[0].Bindings) == 0 {
+		if exprs := rs[0].Expressions; len(exprs) == 1 {
+			if b, ok := exprs[0].Value.(bool); ok {
+				return b
+			}
+		}
+	}
+	return false
+}

--- a/rego/resultset_test.go
+++ b/rego/resultset_test.go
@@ -1,0 +1,74 @@
+package rego_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/open-policy-agent/opa/rego"
+)
+
+func TestResultSetAllowed(t *testing.T) {
+	tests := []struct {
+		note     string
+		module   string
+		query    string
+		expected bool
+	}{
+		{
+			note: "simplest true",
+			module: `package authz
+allow { true }
+`,
+			query:    "data.authz.allow",
+			expected: true,
+		},
+		{
+			note: "simplest false",
+			module: `package authz
+default allow = false
+`,
+			query:    "data.authz.allow",
+			expected: false,
+		},
+		{
+			note: "true value + bindings",
+			module: `package authz
+allow { true }
+`,
+			query:    "data.authz.allow = x",
+			expected: false,
+		},
+		{
+			note: "object response, bound to var in query",
+			module: `package authz
+resp = { "allow": true } { true }
+`,
+			query:    "data.authz.resp = x",
+			expected: false,
+		},
+		{
+			note: "object response, treated as false",
+			module: `package authz
+resp = { "allow": true } { true }
+`,
+			query:    "data.authz.resp",
+			expected: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.note, func(t *testing.T) {
+			r := rego.New(
+				rego.Query(tc.query),
+				rego.Module("", tc.module),
+			)
+			rs, err := r.Eval(context.Background())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if exp, act := tc.expected, rs.Allowed(); exp != act {
+				t.Errorf("expected %v, got %v", exp, act)
+			}
+		})
+	}
+}

--- a/test/authz/authz_bench_test.go
+++ b/test/authz/authz_bench_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/open-policy-agent/opa/rego"
 	"github.com/open-policy-agent/opa/storage"
 	"github.com/open-policy-agent/opa/storage/inmem"
-	"github.com/open-policy-agent/opa/util"
 )
 
 func BenchmarkAuthzForbidAuthn(b *testing.B) {
@@ -86,7 +85,7 @@ func runAuthzBenchmark(b *testing.B, mode InputMode, numPaths int) {
 		}
 		b.StopTimer()
 
-		if len(rs) != 1 || util.Compare(rs[0].Expressions[0].Value, expected) != 0 {
+		if rs.Allowed() != expected {
 			b.Fatalf("Unexpected result: %v", rs)
 		}
 	}

--- a/test/authz/authz_test.go
+++ b/test/authz/authz_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/open-policy-agent/opa/rego"
 	"github.com/open-policy-agent/opa/storage"
 	"github.com/open-policy-agent/opa/storage/inmem"
-	"github.com/open-policy-agent/opa/util"
 )
 
 func TestAuthz(t *testing.T) {
@@ -50,7 +49,7 @@ func TestAuthz(t *testing.T) {
 		t.Fatalf("Unexpected error(s): %v", err)
 	}
 
-	if len(rs) != 1 || util.Compare(rs[0].Expressions[0].Value, expected) != 0 {
-		t.Fatalf("Unexpected result: %v", rs)
+	if rs.Allowed() != expected {
+		t.Fatalf("Unexpected result: want %v, got %v", expected, rs.Allowed())
 	}
 }


### PR DESCRIPTION
Sparked by @charlieegan3's post here, https://charlieegan3.com/posts/2021-05-08-authorization-dsls-in-go/, I've been playing with a the thought of exposing some nice-to-use helper methods for dealing with a `rego.ResultSet`.

This PR adds a very simple helper:
- `(ResultSet) Allowed() bool` that's a shortcut for the common "one value, a bool, indicating allowed-ness"