### PR TITLE
rego: pass inter-query builtin cache to wasm sdk

### DIFF
--- a/internal/rego/opa/opa.go
+++ b/internal/rego/opa/opa.go
@@ -47,10 +47,11 @@ func (o *OPA) Init() (*OPA, error) {
 // Eval evaluates the policy.
 func (o *OPA) Eval(ctx context.Context, opts EvalOpts) (*Result, error) {
 	evalOptions := wopa.EvalOpts{
-		Input:   opts.Input,
-		Metrics: opts.Metrics,
-		Time:    opts.Time,
-		Seed:    opts.Seed,
+		Input:                  opts.Input,
+		Metrics:                opts.Metrics,
+		Time:                   opts.Time,
+		Seed:                   opts.Seed,
+		InterQueryBuiltinCache: opts.InterQueryBuiltinCache,
 	}
 
 	res, err := o.opa.Eval(ctx, evalOptions)

--- a/internal/rego/opa/options.go
+++ b/internal/rego/opa/options.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/open-policy-agent/opa/metrics"
+	"github.com/open-policy-agent/opa/topdown/cache"
 )
 
 // Result holds the evaluation result.
@@ -14,8 +15,9 @@ type Result struct {
 
 // EvalOpts define options for performing an evaluation.
 type EvalOpts struct {
-	Input   *interface{}
-	Metrics metrics.Metrics
-	Time    time.Time
-	Seed    io.Reader
+	Input                  *interface{}
+	Metrics                metrics.Metrics
+	Time                   time.Time
+	Seed                   io.Reader
+	InterQueryBuiltinCache cache.InterQueryCache
 }

--- a/internal/wasm/sdk/internal/wasm/bindings.go
+++ b/internal/wasm/sdk/internal/wasm/bindings.go
@@ -22,6 +22,7 @@ import (
 	"github.com/open-policy-agent/opa/metrics"
 	"github.com/open-policy-agent/opa/topdown"
 	"github.com/open-policy-agent/opa/topdown/builtins"
+	"github.com/open-policy-agent/opa/topdown/cache"
 )
 
 func opaFunctions(dispatcher *builtinDispatcher, store *wasmtime.Store) map[string]wasmtime.AsExtern {
@@ -79,7 +80,7 @@ func (d *builtinDispatcher) SetMap(m map[int32]topdown.BuiltinFunc) {
 }
 
 // Reset is called in Eval before using the builtinDispatcher.
-func (d *builtinDispatcher) Reset(ctx context.Context, seed io.Reader, ns time.Time) {
+func (d *builtinDispatcher) Reset(ctx context.Context, seed io.Reader, ns time.Time, iqbCache cache.InterQueryCache) {
 	if ns.IsZero() {
 		ns = time.Now()
 	}
@@ -87,18 +88,19 @@ func (d *builtinDispatcher) Reset(ctx context.Context, seed io.Reader, ns time.T
 		seed = rand.Reader
 	}
 	d.ctx = &topdown.BuiltinContext{
-		Context:      ctx,
-		Metrics:      metrics.New(),
-		Seed:         seed,
-		Time:         ast.NumberTerm(json.Number(strconv.FormatInt(ns.UnixNano(), 10))),
-		Cancel:       topdown.NewCancel(),
-		Runtime:      nil,
-		Cache:        make(builtins.Cache),
-		Location:     nil,
-		Tracers:      nil,
-		QueryTracers: nil,
-		QueryID:      0,
-		ParentID:     0,
+		Context:                ctx,
+		Metrics:                metrics.New(),
+		Seed:                   seed,
+		Time:                   ast.NumberTerm(json.Number(strconv.FormatInt(ns.UnixNano(), 10))),
+		Cancel:                 topdown.NewCancel(),
+		Runtime:                nil,
+		Cache:                  make(builtins.Cache),
+		Location:               nil,
+		Tracers:                nil,
+		QueryTracers:           nil,
+		QueryID:                0,
+		ParentID:               0,
+		InterQueryBuiltinCache: iqbCache,
 	}
 
 }

--- a/internal/wasm/sdk/internal/wasm/pool_test.go
+++ b/internal/wasm/sdk/internal/wasm/pool_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/open-policy-agent/opa/compile"
 	"github.com/open-policy-agent/opa/internal/wasm/sdk/internal/wasm"
 	"github.com/open-policy-agent/opa/metrics"
+	"github.com/open-policy-agent/opa/topdown/cache"
 	"github.com/open-policy-agent/opa/util"
 )
 
@@ -156,7 +157,8 @@ func ensurePoolResults(t *testing.T, ctx context.Context, testPool *wasm.Pool, p
 
 		toRelease = append(toRelease, vm)
 
-		result, err := vm.Eval(ctx, 0, nil, metrics.New(), rand.New(rand.NewSource(0)), time.Now())
+		cfg, _ := cache.ParseCachingConfig(nil)
+		result, err := vm.Eval(ctx, 0, nil, metrics.New(), rand.New(rand.NewSource(0)), time.Now(), cache.NewInterQueryCache(cfg))
 		if err != nil {
 			t.Fatalf("Unexpected error: %s", err)
 		}

--- a/internal/wasm/sdk/internal/wasm/vm.go
+++ b/internal/wasm/sdk/internal/wasm/vm.go
@@ -19,6 +19,7 @@ import (
 	sdk_errors "github.com/open-policy-agent/opa/internal/wasm/sdk/opa/errors"
 	"github.com/open-policy-agent/opa/metrics"
 	"github.com/open-policy-agent/opa/topdown"
+	"github.com/open-policy-agent/opa/topdown/cache"
 )
 
 // VM is a wrapper around a Wasm VM instance
@@ -267,9 +268,15 @@ func getABIVersion(i *wasmtime.Instance, store wasmtime.Storelike) (int32, int32
 
 // Eval performs an evaluation of the specified entrypoint, with any provided
 // input, and returns the resulting value dumped to a string.
-func (i *VM) Eval(ctx context.Context, entrypoint int32, input *interface{}, metrics metrics.Metrics, seed io.Reader, ns time.Time) ([]byte, error) {
+func (i *VM) Eval(ctx context.Context,
+	entrypoint int32,
+	input *interface{},
+	metrics metrics.Metrics,
+	seed io.Reader,
+	ns time.Time,
+	iqbCache cache.InterQueryCache) ([]byte, error) {
 	if i.abiMinorVersion < int32(2) {
-		return i.evalCompat(ctx, entrypoint, input, metrics, seed, ns)
+		return i.evalCompat(ctx, entrypoint, input, metrics, seed, ns, iqbCache)
 	}
 
 	metrics.Timer("wasm_vm_eval").Start()
@@ -311,7 +318,7 @@ func (i *VM) Eval(ctx context.Context, entrypoint int32, input *interface{}, met
 	// make use of it (e.g. `http.send`); and it will spawn a go routine
 	// cancelling the builtins that use topdown.Cancel, when the context is
 	// cancelled.
-	i.dispatcher.Reset(ctx, seed, ns)
+	i.dispatcher.Reset(ctx, seed, ns, iqbCache)
 
 	metrics.Timer("wasm_vm_eval_call").Start()
 	resultAddr, err := i.evalOneOff(ctx, int32(entrypoint), i.dataAddr, inputAddr, inputLen, heapPtr)
@@ -333,7 +340,13 @@ func (i *VM) Eval(ctx context.Context, entrypoint int32, input *interface{}, met
 // evalCompat evaluates a policy using multiple calls into the VM to set the stage.
 // It's been superceded with ABI version 1.2, but still here for compatibility with
 // Wasm modules lacking the needed export (i.e., ABI 1.1).
-func (i *VM) evalCompat(ctx context.Context, entrypoint int32, input *interface{}, metrics metrics.Metrics, seed io.Reader, ns time.Time) ([]byte, error) {
+func (i *VM) evalCompat(ctx context.Context,
+	entrypoint int32,
+	input *interface{},
+	metrics metrics.Metrics,
+	seed io.Reader,
+	ns time.Time,
+	iqbCache cache.InterQueryCache) ([]byte, error) {
 	metrics.Timer("wasm_vm_eval").Start()
 	defer metrics.Timer("wasm_vm_eval").Stop()
 
@@ -343,7 +356,7 @@ func (i *VM) evalCompat(ctx context.Context, entrypoint int32, input *interface{
 	// make use of it (e.g. `http.send`); and it will spawn a go routine
 	// cancelling the builtins that use topdown.Cancel, when the context is
 	// cancelled.
-	i.dispatcher.Reset(ctx, seed, ns)
+	i.dispatcher.Reset(ctx, seed, ns, iqbCache)
 
 	err := i.setHeapState(ctx, i.evalHeapPtr)
 	if err != nil {

--- a/internal/wasm/sdk/opa/opa.go
+++ b/internal/wasm/sdk/opa/opa.go
@@ -16,6 +16,7 @@ import (
 	"github.com/open-policy-agent/opa/internal/wasm/sdk/opa/errors"
 	sdk_errors "github.com/open-policy-agent/opa/internal/wasm/sdk/opa/errors"
 	"github.com/open-policy-agent/opa/metrics"
+	"github.com/open-policy-agent/opa/topdown/cache"
 )
 
 var errNotReady = errors.New(errors.NotReadyErr, "")
@@ -156,11 +157,12 @@ func (o *OPA) setPolicyData(ctx context.Context, policy []byte, data []byte) err
 
 // EvalOpts define options for performing an evaluation
 type EvalOpts struct {
-	Entrypoint int32
-	Input      *interface{}
-	Metrics    metrics.Metrics
-	Time       time.Time
-	Seed       io.Reader
+	Entrypoint             int32
+	Input                  *interface{}
+	Metrics                metrics.Metrics
+	Time                   time.Time
+	Seed                   io.Reader
+	InterQueryBuiltinCache cache.InterQueryCache
 }
 
 // Eval evaluates the policy with the given input, returning the
@@ -184,7 +186,7 @@ func (o *OPA) Eval(ctx context.Context, opts EvalOpts) (*Result, error) {
 
 	defer o.pool.Release(instance, m)
 
-	result, err := instance.Eval(ctx, opts.Entrypoint, opts.Input, m, opts.Seed, opts.Time)
+	result, err := instance.Eval(ctx, opts.Entrypoint, opts.Input, m, opts.Seed, opts.Time, opts.InterQueryBuiltinCache)
 	if err != nil {
 		return nil, err
 	}

--- a/rego/rego.go
+++ b/rego/rego.go
@@ -1939,10 +1939,11 @@ func (r *Rego) evalWasm(ctx context.Context, ectx *EvalContext) (ResultSet, erro
 		input = &i
 	}
 	result, err := r.opa.Eval(ctx, opa.EvalOpts{
-		Metrics: r.metrics,
-		Input:   input,
-		Time:    ectx.time,
-		Seed:    ectx.seed,
+		Metrics:                r.metrics,
+		Input:                  input,
+		Time:                   ectx.time,
+		Seed:                   ectx.seed,
+		InterQueryBuiltinCache: ectx.interQueryBuiltinCache,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Found when looking into #3716.

With this change, multiple calls to a wasm-backed eval that uses http.send
would re-use the results (if caching permits).
