### PR TITLE
ast: support for allOf in JSON schema type checker

### DIFF
--- a/internal/gojsonschema/schema.go
+++ b/internal/gojsonschema/schema.go
@@ -714,7 +714,7 @@ func (d *Schema) parseSchema(documentNode interface{}, currentSchema *SubSchema)
 	}
 	for _, v := range allOf {
 		newSchema := &SubSchema{Property: KeyAllOf, Parent: currentSchema, Ref: currentSchema.Ref}
-		currentSchema.allOf = append(currentSchema.allOf, newSchema)
+		currentSchema.AllOf = append(currentSchema.AllOf, newSchema)
 		err := d.parseSchema(v, newSchema)
 		if err != nil {
 			return err

--- a/internal/gojsonschema/subSchema.go
+++ b/internal/gojsonschema/subSchema.go
@@ -143,7 +143,7 @@ type SubSchema struct {
 	// validation : SubSchema
 	oneOf []*SubSchema
 	AnyOf []*SubSchema
-	allOf []*SubSchema
+	AllOf []*SubSchema
 	not   *SubSchema
 	_if   *SubSchema // if/else are golang keywords
 	_then *SubSchema

--- a/internal/gojsonschema/validation.go
+++ b/internal/gojsonschema/validation.go
@@ -325,10 +325,10 @@ func (v *SubSchema) validateSchema(currentSubSchema *SubSchema, currentNode inte
 
 	}
 
-	if len(currentSubSchema.allOf) > 0 {
+	if len(currentSubSchema.AllOf) > 0 {
 		nbValidated := 0
 
-		for _, allOfSchema := range currentSubSchema.allOf {
+		for _, allOfSchema := range currentSubSchema.AllOf {
 			validationResult := allOfSchema.subValidateWithContext(currentNode, context)
 			if validationResult.Valid() {
 				nbValidated++
@@ -336,7 +336,7 @@ func (v *SubSchema) validateSchema(currentSubSchema *SubSchema, currentNode inte
 			result.mergeErrors(validationResult)
 		}
 
-		if nbValidated != len(currentSubSchema.allOf) {
+		if nbValidated != len(currentSubSchema.AllOf) {
 			result.addInternalError(new(NumberAllOfError), context, currentNode, ErrorDetails{})
 		}
 	}


### PR DESCRIPTION
Currently OPA's schema checker does not support allOf. This commit parses allOf by merging all the subschemas into a single schema before converting to a Rego type. I also included a short explanation in schemas.md.

Related to: open-policy-agent#3592

Signed-off-by: Julia Friedman

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/main/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/main/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
