### PR TITLE
ast: avoid extra work parsing objects vs obj comprehensions

### DIFF
--- a/ast/parser_test.go
+++ b/ast/parser_test.go
@@ -12,8 +12,6 @@ import (
 	"testing"
 )
 
-var _ = fmt.Printf
-
 const (
 	testModule = `
 # This policy module belongs the opa.example package.
@@ -3163,7 +3161,10 @@ func assertLocationText(t *testing.T, expected string, actual *Location) {
 }
 
 func assertParseError(t *testing.T, msg string, input string) {
-	assertParseErrorFunc(t, msg, input, func(string) {})
+	t.Helper()
+	t.Run(msg, func(t *testing.T) {
+		assertParseErrorFunc(t, msg, input, func(string) {})
+	})
 }
 
 func assertParseErrorContains(t *testing.T, msg string, input string, expected string) {
@@ -3275,7 +3276,9 @@ func assertParseOneExprNegated(t *testing.T, msg string, input string, correct *
 
 func assertParseOneTerm(t *testing.T, msg string, input string, correct *Term) {
 	t.Helper()
-	assertParseOneExpr(t, msg, input, &Expr{Terms: correct})
+	t.Run(msg, func(t *testing.T) {
+		assertParseOneExpr(t, msg, input, &Expr{Terms: correct})
+	})
 }
 
 func assertParseOneTermNegated(t *testing.T, msg string, input string, correct *Term) {


### PR DESCRIPTION
This change makes the parser cache the results of attempting to parse a certain offset.

The cache structure is a linked-list, each item carries its offset, the term parsed at that offset (if successful), and the post-state (including errors, if unsuccessful). When the parser tries to parse a term at a certain offset, it will first consult the cache.
When inserting something into the cache, each element that has an offset _after_ the inserted element will be dropped.

This is based on the observation that when re-visiting an offset that was already parsed (say, attempting to make sense of the input as a set comprehension after having attempted to parse it as a set) the later offsets never matter. So whenever an offset before a certain other offset is inserted into the cache, the latter offset's element will _never_ be retrieved.

----
I've attempted to do something more involved to selectively turn caching on and off, but I've found the result too brittle to be worth it. Even more so when changing stuff in the parser. The current approach is simple enough. (See the commit message for the most recent benchstat result, the stuff in the comments below is outdated.)