### PR TITLE
topdown: add the means to inspect non-halt built-in errors

### DIFF
--- a/topdown/builtins_test.go
+++ b/topdown/builtins_test.go
@@ -2,6 +2,7 @@ package topdown
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/open-policy-agent/opa/ast"
@@ -40,5 +41,29 @@ func TestCustomBuiltinIterator(t *testing.T) {
 		t.Fatal("Expected one result but got:", rs)
 	} else if !rs[0][ast.Var("x")].Equal(ast.IntNumberTerm(2)) {
 		t.Fatal("Expected x to be 2 but got:", rs[0])
+	}
+}
+
+func TestTopdownWithBuiltinErrors(t *testing.T) {
+	var errs []error
+	query := NewQuery(ast.MustParseBody(`startswith(input, "foo")`)).
+		WithInput(ast.MustParseTerm("{}")).
+		WithBuiltinErrors(func(es ...error) { errs = append(errs, es...) })
+
+	ctx := context.Background()
+
+	rs, err := query.Run(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exp, act := 0, len(rs); exp != act {
+		t.Fatalf("Expected %d results but got: %d", exp, act)
+	}
+	if exp, act := 1, len(errs); exp != act {
+		t.Fatalf("Expected %d errors but got: %d", exp, act)
+	}
+	var exp *Error
+	if act := errs[0]; !errors.As(act, &exp) {
+		t.Fatalf("expected %[1]T, got %[2]T: %[2]v", exp, act)
 	}
 }

--- a/topdown/topdown_test.go
+++ b/topdown/topdown_test.go
@@ -20,15 +20,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/open-policy-agent/opa/format"
-
 	"github.com/ghodss/yaml"
 
-	iCache "github.com/open-policy-agent/opa/topdown/cache"
-
 	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/format"
 	"github.com/open-policy-agent/opa/storage"
 	"github.com/open-policy-agent/opa/storage/inmem"
+	iCache "github.com/open-policy-agent/opa/topdown/cache"
 	"github.com/open-policy-agent/opa/types"
 	"github.com/open-policy-agent/opa/util"
 )


### PR DESCRIPTION
A bit of a sketch....  but this could be enough, I think. Naming is hard, so alternatives to `WithBuiltinErrors(func(...errors))` are appreciated 😄 


---------
Fixes #3742.