### PR TITLE
add `allow_net` to capabilities, use it to disable fetching remote schemas

### DIFF
--- a/ast/capabilities.go
+++ b/ast/capabilities.go
@@ -15,8 +15,18 @@ import (
 // Capabilities defines a structure containing data that describes the capablilities
 // or features supported by a particular version of OPA.
 type Capabilities struct {
-	Builtins        []*Builtin       `json:"builtins"` // builtins is a set of built-in functions that are supported.
+	// builtins is a set of built-in functions that are supported.
+	Builtins        []*Builtin       `json:"builtins"`
 	WasmABIVersions []WasmABIVersion `json:"wasm_abi_versions"`
+
+	// allow_net is an array of hostnames or IP addresses, that an OPA instance is
+	// allowed to connect to.
+	// If omitted, ANY host can be connected to. If empty, NO host can be connected to.
+	// As of now, this only controls fetching remote refs for using JSON Schemas in
+	// the type checker.
+	// TODO(sr): support ports to further restrict connection peers
+	// TODO(sr): support restricting `http.send` using the same mechanism (see https://github.com/open-policy-agent/opa/issues/3665)
+	AllowNet []string `json:"allow_net,omitempty"`
 }
 
 // WasmABIVersion captures the Wasm ABI version. Its `Minor` version is indicating

--- a/ast/schema.go
+++ b/ast/schema.go
@@ -47,9 +47,9 @@ func (ss *SchemaSet) Get(path Ref) interface{} {
 	return x
 }
 
-func loadSchema(raw interface{}, fetchRemote bool) (types.Type, error) {
+func loadSchema(raw interface{}, allowNet []string) (types.Type, error) {
 
-	jsonSchema, err := compileSchema(raw, fetchRemote)
+	jsonSchema, err := compileSchema(raw, allowNet)
 	if err != nil {
 		return nil, err
 	}

--- a/ast/schema.go
+++ b/ast/schema.go
@@ -47,16 +47,16 @@ func (ss *SchemaSet) Get(path Ref) interface{} {
 	return x
 }
 
-func loadSchema(raw interface{}) (types.Type, error) {
+func loadSchema(raw interface{}, fetchRemote bool) (types.Type, error) {
 
-	jsonSchema, err := compileSchema(raw)
+	jsonSchema, err := compileSchema(raw, fetchRemote)
 	if err != nil {
-		return nil, fmt.Errorf("compile failed: %s", err.Error())
+		return nil, err
 	}
 
 	tpe, err := parseSchema(jsonSchema.RootSchema)
 	if err != nil {
-		return nil, fmt.Errorf("error when type checking %v", err)
+		return nil, fmt.Errorf("type checking: %w", err)
 	}
 
 	return tpe, nil

--- a/ast/testdata/_definitions.json
+++ b/ast/testdata/_definitions.json
@@ -1,0 +1,18864 @@
+{
+  "definitions": {
+    "io.k8s.api.admissionregistration.v1beta1.MutatingWebhookConfiguration": {
+      "description": "MutatingWebhookConfiguration describes the configuration of and admission webhook that accept or reject and may change the object.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "MutatingWebhookConfiguration"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata."
+        },
+        "webhooks": {
+          "description": "Webhooks is a list of webhooks and the affected resources and operations.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.admissionregistration.v1beta1.Webhook"
+          },
+          "type": "array",
+          "x-kubernetes-patch-merge-key": "name",
+          "x-kubernetes-patch-strategy": "merge"
+        }
+      },
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "admissionregistration.k8s.io",
+          "kind": "MutatingWebhookConfiguration",
+          "version": "v1beta1"
+        }
+      ]
+    },
+    "io.k8s.api.admissionregistration.v1beta1.MutatingWebhookConfigurationList": {
+      "description": "MutatingWebhookConfigurationList is a list of MutatingWebhookConfiguration.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "List of MutatingWebhookConfiguration.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.admissionregistration.v1beta1.MutatingWebhookConfiguration"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "MutatingWebhookConfigurationList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds"
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "admissionregistration.k8s.io",
+          "kind": "MutatingWebhookConfigurationList",
+          "version": "v1beta1"
+        }
+      ]
+    },
+    "io.k8s.api.admissionregistration.v1beta1.RuleWithOperations": {
+      "description": "RuleWithOperations is a tuple of Operations and Resources. It is recommended to make sure that all the tuple expansions are valid.",
+      "properties": {
+        "apiGroups": {
+          "description": "APIGroups is the API groups the resources belong to. '*' is all groups. If '*' is present, the length of the slice must be one. Required.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "apiVersions": {
+          "description": "APIVersions is the API versions the resources belong to. '*' is all versions. If '*' is present, the length of the slice must be one. Required.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "operations": {
+          "description": "Operations is the operations the admission hook cares about - CREATE, UPDATE, or * for all operations. If '*' is present, the length of the slice must be one. Required.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "resources": {
+          "description": "Resources is a list of resources this rule applies to.\n\nFor example: 'pods' means pods. 'pods/log' means the log subresource of pods. '*' means all resources, but not subresources. 'pods/*' means all subresources of pods. '*/scale' means all scale subresources. '*/*' means all resources and their subresources.\n\nIf wildcard is present, the validation rule will ensure resources do not overlap with each other.\n\nDepending on the enclosing object, subresources might not be allowed. Required.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "scope": {
+          "description": "scope specifies the scope of this rule. Valid values are \"Cluster\", \"Namespaced\", and \"*\" \"Cluster\" means that only cluster-scoped resources will match this rule. Namespace API objects are cluster-scoped. \"Namespaced\" means that only namespaced resources will match this rule. \"*\" means that there are no scope restrictions. Subresources match the scope of their parent resource. Default is \"*\".",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.admissionregistration.v1beta1.ServiceReference": {
+      "description": "ServiceReference holds a reference to Service.legacy.k8s.io",
+      "properties": {
+        "name": {
+          "description": "`name` is the name of the service. Required",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "`namespace` is the namespace of the service. Required",
+          "type": "string"
+        },
+        "path": {
+          "description": "`path` is an optional URL path which will be sent in any request to this service.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "namespace",
+        "name"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.admissionregistration.v1beta1.ValidatingWebhookConfiguration": {
+      "description": "ValidatingWebhookConfiguration describes the configuration of and admission webhook that accept or reject and object without changing it.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "ValidatingWebhookConfiguration"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata."
+        },
+        "webhooks": {
+          "description": "Webhooks is a list of webhooks and the affected resources and operations.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.admissionregistration.v1beta1.Webhook"
+          },
+          "type": "array",
+          "x-kubernetes-patch-merge-key": "name",
+          "x-kubernetes-patch-strategy": "merge"
+        }
+      },
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "admissionregistration.k8s.io",
+          "kind": "ValidatingWebhookConfiguration",
+          "version": "v1beta1"
+        }
+      ]
+    },
+    "io.k8s.api.admissionregistration.v1beta1.ValidatingWebhookConfigurationList": {
+      "description": "ValidatingWebhookConfigurationList is a list of ValidatingWebhookConfiguration.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "List of ValidatingWebhookConfiguration.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.admissionregistration.v1beta1.ValidatingWebhookConfiguration"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "ValidatingWebhookConfigurationList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds"
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "admissionregistration.k8s.io",
+          "kind": "ValidatingWebhookConfigurationList",
+          "version": "v1beta1"
+        }
+      ]
+    },
+    "io.k8s.api.admissionregistration.v1beta1.Webhook": {
+      "description": "Webhook describes an admission webhook and the resources and operations it applies to.",
+      "properties": {
+        "admissionReviewVersions": {
+          "description": "AdmissionReviewVersions is an ordered list of preferred `AdmissionReview` versions the Webhook expects. API server will try to use first version in the list which it supports. If none of the versions specified in this list supported by API server, validation will fail for this object. If a persisted webhook configuration specifies allowed versions and does not include any versions known to the API Server, calls to the webhook will fail and be subject to the failure policy. Default to `['v1beta1']`.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "clientConfig": {
+          "$ref": "#/definitions/io.k8s.api.admissionregistration.v1beta1.WebhookClientConfig",
+          "description": "ClientConfig defines how to communicate with the hook. Required"
+        },
+        "failurePolicy": {
+          "description": "FailurePolicy defines how unrecognized errors from the admission endpoint are handled - allowed values are Ignore or Fail. Defaults to Ignore.",
+          "type": "string"
+        },
+        "name": {
+          "description": "The name of the admission webhook. Name should be fully qualified, e.g., imagepolicy.kubernetes.io, where \"imagepolicy\" is the name of the webhook, and kubernetes.io is the name of the organization. Required.",
+          "type": "string"
+        },
+        "namespaceSelector": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+          "description": "NamespaceSelector decides whether to run the webhook on an object based on whether the namespace for that object matches the selector. If the object itself is a namespace, the matching is performed on object.metadata.labels. If the object is another cluster scoped resource, it never skips the webhook.\n\nFor example, to run the webhook on any objects whose namespace is not associated with \"runlevel\" of \"0\" or \"1\";  you will set the selector as follows: \"namespaceSelector\": {\n  \"matchExpressions\": [\n    {\n      \"key\": \"runlevel\",\n      \"operator\": \"NotIn\",\n      \"values\": [\n        \"0\",\n        \"1\"\n      ]\n    }\n  ]\n}\n\nIf instead you want to only run the webhook on any objects whose namespace is associated with the \"environment\" of \"prod\" or \"staging\"; you will set the selector as follows: \"namespaceSelector\": {\n  \"matchExpressions\": [\n    {\n      \"key\": \"environment\",\n      \"operator\": \"In\",\n      \"values\": [\n        \"prod\",\n        \"staging\"\n      ]\n    }\n  ]\n}\n\nSee https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/ for more examples of label selectors.\n\nDefault to the empty LabelSelector, which matches everything."
+        },
+        "rules": {
+          "description": "Rules describes what operations on what resources/subresources the webhook cares about. The webhook cares about an operation if it matches _any_ Rule. However, in order to prevent ValidatingAdmissionWebhooks and MutatingAdmissionWebhooks from putting the cluster in a state which cannot be recovered from without completely disabling the plugin, ValidatingAdmissionWebhooks and MutatingAdmissionWebhooks are never called on admission requests for ValidatingWebhookConfiguration and MutatingWebhookConfiguration objects.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.admissionregistration.v1beta1.RuleWithOperations"
+          },
+          "type": "array"
+        },
+        "sideEffects": {
+          "description": "SideEffects states whether this webhookk has side effects. Acceptable values are: Unknown, None, Some, NoneOnDryRun Webhooks with side effects MUST implement a reconciliation system, since a request may be rejected by a future step in the admission change and the side effects therefore need to be undone. Requests with the dryRun attribute will be auto-rejected if they match a webhook with sideEffects == Unknown or Some. Defaults to Unknown.",
+          "type": "string"
+        },
+        "timeoutSeconds": {
+          "description": "TimeoutSeconds specifies the timeout for this webhook. After the timeout passes, the webhook call will be ignored or the API call will fail based on the failure policy. The timeout value must be between 1 and 30 seconds. Default to 30 seconds.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "name",
+        "clientConfig"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.admissionregistration.v1beta1.WebhookClientConfig": {
+      "description": "WebhookClientConfig contains the information to make a TLS connection with the webhook",
+      "properties": {
+        "caBundle": {
+          "description": "`caBundle` is a PEM encoded CA bundle which will be used to validate the webhook's server certificate. If unspecified, system trust roots on the apiserver are used.",
+          "format": "byte",
+          "type": "string"
+        },
+        "service": {
+          "$ref": "#/definitions/io.k8s.api.admissionregistration.v1beta1.ServiceReference",
+          "description": "`service` is a reference to the service for this webhook. Either `service` or `url` must be specified.\n\nIf the webhook is running within the cluster, then you should use `service`.\n\nPort 443 will be used if it is open, otherwise it is an error."
+        },
+        "url": {
+          "description": "`url` gives the location of the webhook, in standard URL form (`scheme://host:port/path`). Exactly one of `url` or `service` must be specified.\n\nThe `host` should not refer to a service running in the cluster; use the `service` field instead. The host might be resolved via external DNS in some apiservers (e.g., `kube-apiserver` cannot resolve in-cluster DNS as that would be a layering violation). `host` may also be an IP address.\n\nPlease note that using `localhost` or `127.0.0.1` as a `host` is risky unless you take great care to run this webhook on all hosts which run an apiserver which might need to make calls to this webhook. Such installs are likely to be non-portable, i.e., not easy to turn up in a new cluster.\n\nThe scheme must be \"https\"; the URL must begin with \"https://\".\n\nA path is optional, and if present may be any string permissible in a URL. You may use the path to pass an arbitrary string to the webhook, for example, a cluster identifier.\n\nAttempting to use a user or basic auth e.g. \"user:password@\" is not allowed. Fragments (\"#...\") and query parameters (\"?...\") are not allowed, either.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.apps.v1.ControllerRevision": {
+      "description": "ControllerRevision implements an immutable snapshot of state data. Clients are responsible for serializing and deserializing the objects that contain their internal state. Once a ControllerRevision has been successfully created, it can not be updated. The API Server will fail validation of all requests that attempt to mutate the Data field. ControllerRevisions may, however, be deleted. Note that, due to its use by both the DaemonSet and StatefulSet controllers for update and rollback, this object is beta. However, it may be subject to name and representation changes in future releases, and clients should not depend on its stability. It is primarily for internal use by controllers.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "data": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.runtime.RawExtension",
+          "description": "Data is the serialized representation of the state."
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "ControllerRevision"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+        },
+        "revision": {
+          "description": "Revision indicates the revision of the state represented by Data.",
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "revision"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "apps",
+          "kind": "ControllerRevision",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.apps.v1.ControllerRevisionList": {
+      "description": "ControllerRevisionList is a resource containing a list of ControllerRevision objects.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "Items is the list of ControllerRevisions",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.apps.v1.ControllerRevision"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "ControllerRevisionList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "apps",
+          "kind": "ControllerRevisionList",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.apps.v1.DaemonSet": {
+      "description": "DaemonSet represents the configuration of a daemon set.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "DaemonSet"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.apps.v1.DaemonSetSpec",
+          "description": "The desired behavior of this daemon set. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status"
+        },
+        "status": {
+          "$ref": "#/definitions/io.k8s.api.apps.v1.DaemonSetStatus",
+          "description": "The current status of this daemon set. This data may be out of date by some window of time. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status"
+        }
+      },
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "apps",
+          "kind": "DaemonSet",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.apps.v1.DaemonSetCondition": {
+      "description": "DaemonSetCondition describes the state of a DaemonSet at a certain point.",
+      "properties": {
+        "lastTransitionTime": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "Last time the condition transitioned from one status to another."
+        },
+        "message": {
+          "description": "A human readable message indicating details about the transition.",
+          "type": "string"
+        },
+        "reason": {
+          "description": "The reason for the condition's last transition.",
+          "type": "string"
+        },
+        "status": {
+          "description": "Status of the condition, one of True, False, Unknown.",
+          "type": "string"
+        },
+        "type": {
+          "description": "Type of DaemonSet condition.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "status"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.apps.v1.DaemonSetList": {
+      "description": "DaemonSetList is a collection of daemon sets.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "A list of daemon sets.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.apps.v1.DaemonSet"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "DaemonSetList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "apps",
+          "kind": "DaemonSetList",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.apps.v1.DaemonSetSpec": {
+      "description": "DaemonSetSpec is the specification of a daemon set.",
+      "properties": {
+        "minReadySeconds": {
+          "description": "The minimum number of seconds for which a newly created DaemonSet pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready).",
+          "format": "int32",
+          "type": "integer"
+        },
+        "revisionHistoryLimit": {
+          "description": "The number of old history to retain to allow rollback. This is a pointer to distinguish between explicit zero and not specified. Defaults to 10.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "selector": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+          "description": "A label query over pods that are managed by the daemon set. Must match in order to be controlled. It must match the pod template's labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors"
+        },
+        "template": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.PodTemplateSpec",
+          "description": "An object that describes the pod that will be created. The DaemonSet will create exactly one copy of this pod on every node that matches the template's node selector (or on every node if no node selector is specified). More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template"
+        },
+        "updateStrategy": {
+          "$ref": "#/definitions/io.k8s.api.apps.v1.DaemonSetUpdateStrategy",
+          "description": "An update strategy to replace existing DaemonSet pods with new pods."
+        }
+      },
+      "required": [
+        "selector",
+        "template"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.apps.v1.DaemonSetStatus": {
+      "description": "DaemonSetStatus represents the current status of a daemon set.",
+      "properties": {
+        "collisionCount": {
+          "description": "Count of hash collisions for the DaemonSet. The DaemonSet controller uses this field as a collision avoidance mechanism when it needs to create the name for the newest ControllerRevision.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "conditions": {
+          "description": "Represents the latest available observations of a DaemonSet's current state.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.apps.v1.DaemonSetCondition"
+          },
+          "type": "array",
+          "x-kubernetes-patch-merge-key": "type",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "currentNumberScheduled": {
+          "description": "The number of nodes that are running at least 1 daemon pod and are supposed to run the daemon pod. More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/",
+          "format": "int32",
+          "type": "integer"
+        },
+        "desiredNumberScheduled": {
+          "description": "The total number of nodes that should be running the daemon pod (including nodes correctly running the daemon pod). More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/",
+          "format": "int32",
+          "type": "integer"
+        },
+        "numberAvailable": {
+          "description": "The number of nodes that should be running the daemon pod and have one or more of the daemon pod running and available (ready for at least spec.minReadySeconds)",
+          "format": "int32",
+          "type": "integer"
+        },
+        "numberMisscheduled": {
+          "description": "The number of nodes that are running the daemon pod, but are not supposed to run the daemon pod. More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/",
+          "format": "int32",
+          "type": "integer"
+        },
+        "numberReady": {
+          "description": "The number of nodes that should be running the daemon pod and have one or more of the daemon pod running and ready.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "numberUnavailable": {
+          "description": "The number of nodes that should be running the daemon pod and have none of the daemon pod running and available (ready for at least spec.minReadySeconds)",
+          "format": "int32",
+          "type": "integer"
+        },
+        "observedGeneration": {
+          "description": "The most recent generation observed by the daemon set controller.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "updatedNumberScheduled": {
+          "description": "The total number of nodes that are running updated daemon pod",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "currentNumberScheduled",
+        "numberMisscheduled",
+        "desiredNumberScheduled",
+        "numberReady"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.apps.v1.DaemonSetUpdateStrategy": {
+      "description": "DaemonSetUpdateStrategy is a struct used to control the update strategy for a DaemonSet.",
+      "properties": {
+        "rollingUpdate": {
+          "$ref": "#/definitions/io.k8s.api.apps.v1.RollingUpdateDaemonSet",
+          "description": "Rolling update config params. Present only if type = \"RollingUpdate\"."
+        },
+        "type": {
+          "description": "Type of daemon set update. Can be \"RollingUpdate\" or \"OnDelete\". Default is RollingUpdate.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.apps.v1.Deployment": {
+      "description": "Deployment enables declarative updates for Pods and ReplicaSets.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "Deployment"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object metadata."
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.apps.v1.DeploymentSpec",
+          "description": "Specification of the desired behavior of the Deployment."
+        },
+        "status": {
+          "$ref": "#/definitions/io.k8s.api.apps.v1.DeploymentStatus",
+          "description": "Most recently observed status of the Deployment."
+        }
+      },
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "apps",
+          "kind": "Deployment",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.apps.v1.DeploymentCondition": {
+      "description": "DeploymentCondition describes the state of a deployment at a certain point.",
+      "properties": {
+        "lastTransitionTime": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "Last time the condition transitioned from one status to another."
+        },
+        "lastUpdateTime": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "The last time this condition was updated."
+        },
+        "message": {
+          "description": "A human readable message indicating details about the transition.",
+          "type": "string"
+        },
+        "reason": {
+          "description": "The reason for the condition's last transition.",
+          "type": "string"
+        },
+        "status": {
+          "description": "Status of the condition, one of True, False, Unknown.",
+          "type": "string"
+        },
+        "type": {
+          "description": "Type of deployment condition.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "status"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.apps.v1.DeploymentList": {
+      "description": "DeploymentList is a list of Deployments.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "Items is the list of Deployments.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.apps.v1.Deployment"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "DeploymentList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "Standard list metadata."
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "apps",
+          "kind": "DeploymentList",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.apps.v1.DeploymentSpec": {
+      "description": "DeploymentSpec is the specification of the desired behavior of the Deployment.",
+      "properties": {
+        "minReadySeconds": {
+          "description": "Minimum number of seconds for which a newly created pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready)",
+          "format": "int32",
+          "type": "integer"
+        },
+        "paused": {
+          "description": "Indicates that the deployment is paused.",
+          "type": "boolean"
+        },
+        "progressDeadlineSeconds": {
+          "description": "The maximum time in seconds for a deployment to make progress before it is considered to be failed. The deployment controller will continue to process failed deployments and a condition with a ProgressDeadlineExceeded reason will be surfaced in the deployment status. Note that progress will not be estimated during the time a deployment is paused. Defaults to 600s.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "replicas": {
+          "description": "Number of desired pods. This is a pointer to distinguish between explicit zero and not specified. Defaults to 1.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "revisionHistoryLimit": {
+          "description": "The number of old ReplicaSets to retain to allow rollback. This is a pointer to distinguish between explicit zero and not specified. Defaults to 10.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "selector": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+          "description": "Label selector for pods. Existing ReplicaSets whose pods are selected by this will be the ones affected by this deployment. It must match the pod template's labels."
+        },
+        "strategy": {
+          "$ref": "#/definitions/io.k8s.api.apps.v1.DeploymentStrategy",
+          "description": "The deployment strategy to use to replace existing pods with new ones.",
+          "x-kubernetes-patch-strategy": "retainKeys"
+        },
+        "template": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.PodTemplateSpec",
+          "description": "Template describes the pods that will be created."
+        }
+      },
+      "required": [
+        "selector",
+        "template"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.apps.v1.DeploymentStatus": {
+      "description": "DeploymentStatus is the most recently observed status of the Deployment.",
+      "properties": {
+        "availableReplicas": {
+          "description": "Total number of available pods (ready for at least minReadySeconds) targeted by this deployment.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "collisionCount": {
+          "description": "Count of hash collisions for the Deployment. The Deployment controller uses this field as a collision avoidance mechanism when it needs to create the name for the newest ReplicaSet.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "conditions": {
+          "description": "Represents the latest available observations of a deployment's current state.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.apps.v1.DeploymentCondition"
+          },
+          "type": "array",
+          "x-kubernetes-patch-merge-key": "type",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "observedGeneration": {
+          "description": "The generation observed by the deployment controller.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "readyReplicas": {
+          "description": "Total number of ready pods targeted by this deployment.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "replicas": {
+          "description": "Total number of non-terminated pods targeted by this deployment (their labels match the selector).",
+          "format": "int32",
+          "type": "integer"
+        },
+        "unavailableReplicas": {
+          "description": "Total number of unavailable pods targeted by this deployment. This is the total number of pods that are still required for the deployment to have 100% available capacity. They may either be pods that are running but not yet available or pods that still have not been created.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "updatedReplicas": {
+          "description": "Total number of non-terminated pods targeted by this deployment that have the desired template spec.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.apps.v1.DeploymentStrategy": {
+      "description": "DeploymentStrategy describes how to replace existing pods with new ones.",
+      "properties": {
+        "rollingUpdate": {
+          "$ref": "#/definitions/io.k8s.api.apps.v1.RollingUpdateDeployment",
+          "description": "Rolling update config params. Present only if DeploymentStrategyType = RollingUpdate."
+        },
+        "type": {
+          "description": "Type of deployment. Can be \"Recreate\" or \"RollingUpdate\". Default is RollingUpdate.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.apps.v1.ReplicaSet": {
+      "description": "ReplicaSet ensures that a specified number of pod replicas are running at any given time.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "ReplicaSet"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "If the Labels of a ReplicaSet are empty, they are defaulted to be the same as the Pod(s) that the ReplicaSet manages. Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.apps.v1.ReplicaSetSpec",
+          "description": "Spec defines the specification of the desired behavior of the ReplicaSet. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status"
+        },
+        "status": {
+          "$ref": "#/definitions/io.k8s.api.apps.v1.ReplicaSetStatus",
+          "description": "Status is the most recently observed status of the ReplicaSet. This data may be out of date by some window of time. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status"
+        }
+      },
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "apps",
+          "kind": "ReplicaSet",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.apps.v1.ReplicaSetCondition": {
+      "description": "ReplicaSetCondition describes the state of a replica set at a certain point.",
+      "properties": {
+        "lastTransitionTime": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "The last time the condition transitioned from one status to another."
+        },
+        "message": {
+          "description": "A human readable message indicating details about the transition.",
+          "type": "string"
+        },
+        "reason": {
+          "description": "The reason for the condition's last transition.",
+          "type": "string"
+        },
+        "status": {
+          "description": "Status of the condition, one of True, False, Unknown.",
+          "type": "string"
+        },
+        "type": {
+          "description": "Type of replica set condition.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "status"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.apps.v1.ReplicaSetList": {
+      "description": "ReplicaSetList is a collection of ReplicaSets.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "List of ReplicaSets. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.apps.v1.ReplicaSet"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "ReplicaSetList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds"
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "apps",
+          "kind": "ReplicaSetList",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.apps.v1.ReplicaSetSpec": {
+      "description": "ReplicaSetSpec is the specification of a ReplicaSet.",
+      "properties": {
+        "minReadySeconds": {
+          "description": "Minimum number of seconds for which a newly created pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready)",
+          "format": "int32",
+          "type": "integer"
+        },
+        "replicas": {
+          "description": "Replicas is the number of desired replicas. This is a pointer to distinguish between explicit zero and unspecified. Defaults to 1. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller",
+          "format": "int32",
+          "type": "integer"
+        },
+        "selector": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+          "description": "Selector is a label query over pods that should match the replica count. Label keys and values that must match in order to be controlled by this replica set. It must match the pod template's labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors"
+        },
+        "template": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.PodTemplateSpec",
+          "description": "Template is the object that describes the pod that will be created if insufficient replicas are detected. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template"
+        }
+      },
+      "required": [
+        "selector"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.apps.v1.ReplicaSetStatus": {
+      "description": "ReplicaSetStatus represents the current status of a ReplicaSet.",
+      "properties": {
+        "availableReplicas": {
+          "description": "The number of available replicas (ready for at least minReadySeconds) for this replica set.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "conditions": {
+          "description": "Represents the latest available observations of a replica set's current state.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.apps.v1.ReplicaSetCondition"
+          },
+          "type": "array",
+          "x-kubernetes-patch-merge-key": "type",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "fullyLabeledReplicas": {
+          "description": "The number of pods that have labels matching the labels of the pod template of the replicaset.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration reflects the generation of the most recently observed ReplicaSet.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "readyReplicas": {
+          "description": "The number of ready replicas for this replica set.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "replicas": {
+          "description": "Replicas is the most recently oberved number of replicas. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "replicas"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.apps.v1.RollingUpdateDaemonSet": {
+      "description": "Spec to control the desired behavior of daemon set rolling update.",
+      "properties": {
+        "maxUnavailable": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.util.intstr.IntOrString",
+          "description": "The maximum number of DaemonSet pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of total number of DaemonSet pods at the start of the update (ex: 10%). Absolute number is calculated from percentage by rounding up. This cannot be 0. Default value is 1. Example: when this is set to 30%, at most 30% of the total number of nodes that should be running the daemon pod (i.e. status.desiredNumberScheduled) can have their pods stopped for an update at any given time. The update starts by stopping at most 30% of those DaemonSet pods and then brings up new DaemonSet pods in their place. Once the new pods are available, it then proceeds onto other DaemonSet pods, thus ensuring that at least 70% of original number of DaemonSet pods are available at all times during the update."
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.apps.v1.RollingUpdateDeployment": {
+      "description": "Spec to control the desired behavior of rolling update.",
+      "properties": {
+        "maxSurge": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.util.intstr.IntOrString",
+          "description": "The maximum number of pods that can be scheduled above the desired number of pods. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. Defaults to 25%. Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when the rolling update starts, such that the total number of old and new pods do not exceed 130% of desired pods. Once old pods have been killed, new ReplicaSet can be scaled up further, ensuring that total number of pods running at any time during the update is at most 130% of desired pods."
+        },
+        "maxUnavailable": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.util.intstr.IntOrString",
+          "description": "The maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. Defaults to 25%. Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired pods immediately when the rolling update starts. Once new pods are ready, old ReplicaSet can be scaled down further, followed by scaling up the new ReplicaSet, ensuring that the total number of pods available at all times during the update is at least 70% of desired pods."
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.apps.v1.RollingUpdateStatefulSetStrategy": {
+      "description": "RollingUpdateStatefulSetStrategy is used to communicate parameter for RollingUpdateStatefulSetStrategyType.",
+      "properties": {
+        "partition": {
+          "description": "Partition indicates the ordinal at which the StatefulSet should be partitioned. Default value is 0.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.apps.v1.StatefulSet": {
+      "description": "StatefulSet represents a set of pods with consistent identities. Identities are defined as:\n - Network: A single stable DNS and hostname.\n - Storage: As many VolumeClaims as requested.\nThe StatefulSet guarantees that a given network identity will always map to the same storage identity.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "StatefulSet"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.apps.v1.StatefulSetSpec",
+          "description": "Spec defines the desired identities of pods in this set."
+        },
+        "status": {
+          "$ref": "#/definitions/io.k8s.api.apps.v1.StatefulSetStatus",
+          "description": "Status is the current status of Pods in this StatefulSet. This data may be out of date by some window of time."
+        }
+      },
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "apps",
+          "kind": "StatefulSet",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.apps.v1.StatefulSetCondition": {
+      "description": "StatefulSetCondition describes the state of a statefulset at a certain point.",
+      "properties": {
+        "lastTransitionTime": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "Last time the condition transitioned from one status to another."
+        },
+        "message": {
+          "description": "A human readable message indicating details about the transition.",
+          "type": "string"
+        },
+        "reason": {
+          "description": "The reason for the condition's last transition.",
+          "type": "string"
+        },
+        "status": {
+          "description": "Status of the condition, one of True, False, Unknown.",
+          "type": "string"
+        },
+        "type": {
+          "description": "Type of statefulset condition.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "status"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.apps.v1.StatefulSetList": {
+      "description": "StatefulSetList is a collection of StatefulSets.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.apps.v1.StatefulSet"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "StatefulSetList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "apps",
+          "kind": "StatefulSetList",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.apps.v1.StatefulSetSpec": {
+      "description": "A StatefulSetSpec is the specification of a StatefulSet.",
+      "properties": {
+        "podManagementPolicy": {
+          "description": "podManagementPolicy controls how pods are created during initial scale up, when replacing pods on nodes, or when scaling down. The default policy is `OrderedReady`, where pods are created in increasing order (pod-0, then pod-1, etc) and the controller will wait until each pod is ready before continuing. When scaling down, the pods are removed in the opposite order. The alternative policy is `Parallel` which will create pods in parallel to match the desired scale without waiting, and on scale down will delete all pods at once.",
+          "type": "string"
+        },
+        "replicas": {
+          "description": "replicas is the desired number of replicas of the given Template. These are replicas in the sense that they are instantiations of the same Template, but individual replicas also have a consistent identity. If unspecified, defaults to 1.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "revisionHistoryLimit": {
+          "description": "revisionHistoryLimit is the maximum number of revisions that will be maintained in the StatefulSet's revision history. The revision history consists of all revisions not represented by a currently applied StatefulSetSpec version. The default value is 10.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "selector": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+          "description": "selector is a label query over pods that should match the replica count. It must match the pod template's labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors"
+        },
+        "serviceName": {
+          "description": "serviceName is the name of the service that governs this StatefulSet. This service must exist before the StatefulSet, and is responsible for the network identity of the set. Pods get DNS/hostnames that follow the pattern: pod-specific-string.serviceName.default.svc.cluster.local where \"pod-specific-string\" is managed by the StatefulSet controller.",
+          "type": "string"
+        },
+        "template": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.PodTemplateSpec",
+          "description": "template is the object that describes the pod that will be created if insufficient replicas are detected. Each pod stamped out by the StatefulSet will fulfill this Template, but have a unique identity from the rest of the StatefulSet."
+        },
+        "updateStrategy": {
+          "$ref": "#/definitions/io.k8s.api.apps.v1.StatefulSetUpdateStrategy",
+          "description": "updateStrategy indicates the StatefulSetUpdateStrategy that will be employed to update Pods in the StatefulSet when a revision is made to Template."
+        },
+        "volumeClaimTemplates": {
+          "description": "volumeClaimTemplates is a list of claims that pods are allowed to reference. The StatefulSet controller is responsible for mapping network identities to claims in a way that maintains the identity of a pod. Every claim in this list must have at least one matching (by name) volumeMount in one container in the template. A claim in this list takes precedence over any volumes in the template, with the same name.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.PersistentVolumeClaim"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "selector",
+        "template",
+        "serviceName"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.apps.v1.StatefulSetStatus": {
+      "description": "StatefulSetStatus represents the current state of a StatefulSet.",
+      "properties": {
+        "collisionCount": {
+          "description": "collisionCount is the count of hash collisions for the StatefulSet. The StatefulSet controller uses this field as a collision avoidance mechanism when it needs to create the name for the newest ControllerRevision.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "conditions": {
+          "description": "Represents the latest available observations of a statefulset's current state.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.apps.v1.StatefulSetCondition"
+          },
+          "type": "array",
+          "x-kubernetes-patch-merge-key": "type",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "currentReplicas": {
+          "description": "currentReplicas is the number of Pods created by the StatefulSet controller from the StatefulSet version indicated by currentRevision.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "currentRevision": {
+          "description": "currentRevision, if not empty, indicates the version of the StatefulSet used to generate Pods in the sequence [0,currentReplicas).",
+          "type": "string"
+        },
+        "observedGeneration": {
+          "description": "observedGeneration is the most recent generation observed for this StatefulSet. It corresponds to the StatefulSet's generation, which is updated on mutation by the API Server.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "readyReplicas": {
+          "description": "readyReplicas is the number of Pods created by the StatefulSet controller that have a Ready Condition.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "replicas": {
+          "description": "replicas is the number of Pods created by the StatefulSet controller.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "updateRevision": {
+          "description": "updateRevision, if not empty, indicates the version of the StatefulSet used to generate Pods in the sequence [replicas-updatedReplicas,replicas)",
+          "type": "string"
+        },
+        "updatedReplicas": {
+          "description": "updatedReplicas is the number of Pods created by the StatefulSet controller from the StatefulSet version indicated by updateRevision.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "replicas"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.apps.v1.StatefulSetUpdateStrategy": {
+      "description": "StatefulSetUpdateStrategy indicates the strategy that the StatefulSet controller will use to perform updates. It includes any additional parameters necessary to perform the update for the indicated strategy.",
+      "properties": {
+        "rollingUpdate": {
+          "$ref": "#/definitions/io.k8s.api.apps.v1.RollingUpdateStatefulSetStrategy",
+          "description": "RollingUpdate is used to communicate parameters when Type is RollingUpdateStatefulSetStrategyType."
+        },
+        "type": {
+          "description": "Type indicates the type of the StatefulSetUpdateStrategy. Default is RollingUpdate.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.apps.v1beta1.ControllerRevision": {
+      "description": "DEPRECATED - This group version of ControllerRevision is deprecated by apps/v1beta2/ControllerRevision. See the release notes for more information. ControllerRevision implements an immutable snapshot of state data. Clients are responsible for serializing and deserializing the objects that contain their internal state. Once a ControllerRevision has been successfully created, it can not be updated. The API Server will fail validation of all requests that attempt to mutate the Data field. ControllerRevisions may, however, be deleted. Note that, due to its use by both the DaemonSet and StatefulSet controllers for update and rollback, this object is beta. However, it may be subject to name and representation changes in future releases, and clients should not depend on its stability. It is primarily for internal use by controllers.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "data": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.runtime.RawExtension",
+          "description": "Data is the serialized representation of the state."
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "ControllerRevision"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+        },
+        "revision": {
+          "description": "Revision indicates the revision of the state represented by Data.",
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "revision"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "apps",
+          "kind": "ControllerRevision",
+          "version": "v1beta1"
+        }
+      ]
+    },
+    "io.k8s.api.apps.v1beta1.ControllerRevisionList": {
+      "description": "ControllerRevisionList is a resource containing a list of ControllerRevision objects.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "Items is the list of ControllerRevisions",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.apps.v1beta1.ControllerRevision"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "ControllerRevisionList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "apps",
+          "kind": "ControllerRevisionList",
+          "version": "v1beta1"
+        }
+      ]
+    },
+    "io.k8s.api.apps.v1beta1.Deployment": {
+      "description": "DEPRECATED - This group version of Deployment is deprecated by apps/v1beta2/Deployment. See the release notes for more information. Deployment enables declarative updates for Pods and ReplicaSets.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "Deployment"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object metadata."
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.apps.v1beta1.DeploymentSpec",
+          "description": "Specification of the desired behavior of the Deployment."
+        },
+        "status": {
+          "$ref": "#/definitions/io.k8s.api.apps.v1beta1.DeploymentStatus",
+          "description": "Most recently observed status of the Deployment."
+        }
+      },
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "apps",
+          "kind": "Deployment",
+          "version": "v1beta1"
+        }
+      ]
+    },
+    "io.k8s.api.apps.v1beta1.DeploymentCondition": {
+      "description": "DeploymentCondition describes the state of a deployment at a certain point.",
+      "properties": {
+        "lastTransitionTime": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "Last time the condition transitioned from one status to another."
+        },
+        "lastUpdateTime": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "The last time this condition was updated."
+        },
+        "message": {
+          "description": "A human readable message indicating details about the transition.",
+          "type": "string"
+        },
+        "reason": {
+          "description": "The reason for the condition's last transition.",
+          "type": "string"
+        },
+        "status": {
+          "description": "Status of the condition, one of True, False, Unknown.",
+          "type": "string"
+        },
+        "type": {
+          "description": "Type of deployment condition.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "status"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.apps.v1beta1.DeploymentList": {
+      "description": "DeploymentList is a list of Deployments.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "Items is the list of Deployments.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.apps.v1beta1.Deployment"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "DeploymentList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "Standard list metadata."
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "apps",
+          "kind": "DeploymentList",
+          "version": "v1beta1"
+        }
+      ]
+    },
+    "io.k8s.api.apps.v1beta1.DeploymentRollback": {
+      "description": "DEPRECATED. DeploymentRollback stores the information required to rollback a deployment.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "DeploymentRollback"
+          ]
+        },
+        "name": {
+          "description": "Required: This must match the Name of a deployment.",
+          "type": "string"
+        },
+        "rollbackTo": {
+          "$ref": "#/definitions/io.k8s.api.apps.v1beta1.RollbackConfig",
+          "description": "The config of this deployment rollback."
+        },
+        "updatedAnnotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "The annotations to be updated to a deployment",
+          "type": "object"
+        }
+      },
+      "required": [
+        "name",
+        "rollbackTo"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "apps",
+          "kind": "DeploymentRollback",
+          "version": "v1beta1"
+        }
+      ]
+    },
+    "io.k8s.api.apps.v1beta1.DeploymentSpec": {
+      "description": "DeploymentSpec is the specification of the desired behavior of the Deployment.",
+      "properties": {
+        "minReadySeconds": {
+          "description": "Minimum number of seconds for which a newly created pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready)",
+          "format": "int32",
+          "type": "integer"
+        },
+        "paused": {
+          "description": "Indicates that the deployment is paused.",
+          "type": "boolean"
+        },
+        "progressDeadlineSeconds": {
+          "description": "The maximum time in seconds for a deployment to make progress before it is considered to be failed. The deployment controller will continue to process failed deployments and a condition with a ProgressDeadlineExceeded reason will be surfaced in the deployment status. Note that progress will not be estimated during the time a deployment is paused. Defaults to 600s.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "replicas": {
+          "description": "Number of desired pods. This is a pointer to distinguish between explicit zero and not specified. Defaults to 1.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "revisionHistoryLimit": {
+          "description": "The number of old ReplicaSets to retain to allow rollback. This is a pointer to distinguish between explicit zero and not specified. Defaults to 2.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "rollbackTo": {
+          "$ref": "#/definitions/io.k8s.api.apps.v1beta1.RollbackConfig",
+          "description": "DEPRECATED. The config this deployment is rolling back to. Will be cleared after rollback is done."
+        },
+        "selector": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+          "description": "Label selector for pods. Existing ReplicaSets whose pods are selected by this will be the ones affected by this deployment."
+        },
+        "strategy": {
+          "$ref": "#/definitions/io.k8s.api.apps.v1beta1.DeploymentStrategy",
+          "description": "The deployment strategy to use to replace existing pods with new ones.",
+          "x-kubernetes-patch-strategy": "retainKeys"
+        },
+        "template": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.PodTemplateSpec",
+          "description": "Template describes the pods that will be created."
+        }
+      },
+      "required": [
+        "template"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.apps.v1beta1.DeploymentStatus": {
+      "description": "DeploymentStatus is the most recently observed status of the Deployment.",
+      "properties": {
+        "availableReplicas": {
+          "description": "Total number of available pods (ready for at least minReadySeconds) targeted by this deployment.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "collisionCount": {
+          "description": "Count of hash collisions for the Deployment. The Deployment controller uses this field as a collision avoidance mechanism when it needs to create the name for the newest ReplicaSet.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "conditions": {
+          "description": "Represents the latest available observations of a deployment's current state.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.apps.v1beta1.DeploymentCondition"
+          },
+          "type": "array",
+          "x-kubernetes-patch-merge-key": "type",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "observedGeneration": {
+          "description": "The generation observed by the deployment controller.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "readyReplicas": {
+          "description": "Total number of ready pods targeted by this deployment.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "replicas": {
+          "description": "Total number of non-terminated pods targeted by this deployment (their labels match the selector).",
+          "format": "int32",
+          "type": "integer"
+        },
+        "unavailableReplicas": {
+          "description": "Total number of unavailable pods targeted by this deployment. This is the total number of pods that are still required for the deployment to have 100% available capacity. They may either be pods that are running but not yet available or pods that still have not been created.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "updatedReplicas": {
+          "description": "Total number of non-terminated pods targeted by this deployment that have the desired template spec.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.apps.v1beta1.DeploymentStrategy": {
+      "description": "DeploymentStrategy describes how to replace existing pods with new ones.",
+      "properties": {
+        "rollingUpdate": {
+          "$ref": "#/definitions/io.k8s.api.apps.v1beta1.RollingUpdateDeployment",
+          "description": "Rolling update config params. Present only if DeploymentStrategyType = RollingUpdate."
+        },
+        "type": {
+          "description": "Type of deployment. Can be \"Recreate\" or \"RollingUpdate\". Default is RollingUpdate.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.apps.v1beta1.RollbackConfig": {
+      "description": "DEPRECATED.",
+      "properties": {
+        "revision": {
+          "description": "The revision to rollback to. If set to 0, rollback to the last revision.",
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.apps.v1beta1.RollingUpdateDeployment": {
+      "description": "Spec to control the desired behavior of rolling update.",
+      "properties": {
+        "maxSurge": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.util.intstr.IntOrString",
+          "description": "The maximum number of pods that can be scheduled above the desired number of pods. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. Defaults to 25%. Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when the rolling update starts, such that the total number of old and new pods do not exceed 130% of desired pods. Once old pods have been killed, new ReplicaSet can be scaled up further, ensuring that total number of pods running at any time during the update is at most 130% of desired pods."
+        },
+        "maxUnavailable": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.util.intstr.IntOrString",
+          "description": "The maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. Defaults to 25%. Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired pods immediately when the rolling update starts. Once new pods are ready, old ReplicaSet can be scaled down further, followed by scaling up the new ReplicaSet, ensuring that the total number of pods available at all times during the update is at least 70% of desired pods."
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.apps.v1beta1.RollingUpdateStatefulSetStrategy": {
+      "description": "RollingUpdateStatefulSetStrategy is used to communicate parameter for RollingUpdateStatefulSetStrategyType.",
+      "properties": {
+        "partition": {
+          "description": "Partition indicates the ordinal at which the StatefulSet should be partitioned.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.apps.v1beta1.Scale": {
+      "description": "Scale represents a scaling request for a resource.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "Scale"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata."
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.apps.v1beta1.ScaleSpec",
+          "description": "defines the behavior of the scale. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status."
+        },
+        "status": {
+          "$ref": "#/definitions/io.k8s.api.apps.v1beta1.ScaleStatus",
+          "description": "current status of the scale. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status. Read-only."
+        }
+      },
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "apps",
+          "kind": "Scale",
+          "version": "v1beta1"
+        }
+      ]
+    },
+    "io.k8s.api.apps.v1beta1.ScaleSpec": {
+      "description": "ScaleSpec describes the attributes of a scale subresource",
+      "properties": {
+        "replicas": {
+          "description": "desired number of instances for the scaled object.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.apps.v1beta1.ScaleStatus": {
+      "description": "ScaleStatus represents the current status of a scale subresource.",
+      "properties": {
+        "replicas": {
+          "description": "actual number of observed instances of the scaled object.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "selector": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "label query over pods that should match the replicas count. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors",
+          "type": "object"
+        },
+        "targetSelector": {
+          "description": "label selector for pods that should match the replicas count. This is a serializated version of both map-based and more expressive set-based selectors. This is done to avoid introspection in the clients. The string will be in the same format as the query-param syntax. If the target type only supports map-based selectors, both this field and map-based selector field are populated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors",
+          "type": "string"
+        }
+      },
+      "required": [
+        "replicas"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.apps.v1beta1.StatefulSet": {
+      "description": "DEPRECATED - This group version of StatefulSet is deprecated by apps/v1beta2/StatefulSet. See the release notes for more information. StatefulSet represents a set of pods with consistent identities. Identities are defined as:\n - Network: A single stable DNS and hostname.\n - Storage: As many VolumeClaims as requested.\nThe StatefulSet guarantees that a given network identity will always map to the same storage identity.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "StatefulSet"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.apps.v1beta1.StatefulSetSpec",
+          "description": "Spec defines the desired identities of pods in this set."
+        },
+        "status": {
+          "$ref": "#/definitions/io.k8s.api.apps.v1beta1.StatefulSetStatus",
+          "description": "Status is the current status of Pods in this StatefulSet. This data may be out of date by some window of time."
+        }
+      },
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "apps",
+          "kind": "StatefulSet",
+          "version": "v1beta1"
+        }
+      ]
+    },
+    "io.k8s.api.apps.v1beta1.StatefulSetCondition": {
+      "description": "StatefulSetCondition describes the state of a statefulset at a certain point.",
+      "properties": {
+        "lastTransitionTime": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "Last time the condition transitioned from one status to another."
+        },
+        "message": {
+          "description": "A human readable message indicating details about the transition.",
+          "type": "string"
+        },
+        "reason": {
+          "description": "The reason for the condition's last transition.",
+          "type": "string"
+        },
+        "status": {
+          "description": "Status of the condition, one of True, False, Unknown.",
+          "type": "string"
+        },
+        "type": {
+          "description": "Type of statefulset condition.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "status"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.apps.v1beta1.StatefulSetList": {
+      "description": "StatefulSetList is a collection of StatefulSets.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.apps.v1beta1.StatefulSet"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "StatefulSetList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "apps",
+          "kind": "StatefulSetList",
+          "version": "v1beta1"
+        }
+      ]
+    },
+    "io.k8s.api.apps.v1beta1.StatefulSetSpec": {
+      "description": "A StatefulSetSpec is the specification of a StatefulSet.",
+      "properties": {
+        "podManagementPolicy": {
+          "description": "podManagementPolicy controls how pods are created during initial scale up, when replacing pods on nodes, or when scaling down. The default policy is `OrderedReady`, where pods are created in increasing order (pod-0, then pod-1, etc) and the controller will wait until each pod is ready before continuing. When scaling down, the pods are removed in the opposite order. The alternative policy is `Parallel` which will create pods in parallel to match the desired scale without waiting, and on scale down will delete all pods at once.",
+          "type": "string"
+        },
+        "replicas": {
+          "description": "replicas is the desired number of replicas of the given Template. These are replicas in the sense that they are instantiations of the same Template, but individual replicas also have a consistent identity. If unspecified, defaults to 1.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "revisionHistoryLimit": {
+          "description": "revisionHistoryLimit is the maximum number of revisions that will be maintained in the StatefulSet's revision history. The revision history consists of all revisions not represented by a currently applied StatefulSetSpec version. The default value is 10.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "selector": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+          "description": "selector is a label query over pods that should match the replica count. If empty, defaulted to labels on the pod template. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors"
+        },
+        "serviceName": {
+          "description": "serviceName is the name of the service that governs this StatefulSet. This service must exist before the StatefulSet, and is responsible for the network identity of the set. Pods get DNS/hostnames that follow the pattern: pod-specific-string.serviceName.default.svc.cluster.local where \"pod-specific-string\" is managed by the StatefulSet controller.",
+          "type": "string"
+        },
+        "template": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.PodTemplateSpec",
+          "description": "template is the object that describes the pod that will be created if insufficient replicas are detected. Each pod stamped out by the StatefulSet will fulfill this Template, but have a unique identity from the rest of the StatefulSet."
+        },
+        "updateStrategy": {
+          "$ref": "#/definitions/io.k8s.api.apps.v1beta1.StatefulSetUpdateStrategy",
+          "description": "updateStrategy indicates the StatefulSetUpdateStrategy that will be employed to update Pods in the StatefulSet when a revision is made to Template."
+        },
+        "volumeClaimTemplates": {
+          "description": "volumeClaimTemplates is a list of claims that pods are allowed to reference. The StatefulSet controller is responsible for mapping network identities to claims in a way that maintains the identity of a pod. Every claim in this list must have at least one matching (by name) volumeMount in one container in the template. A claim in this list takes precedence over any volumes in the template, with the same name.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.PersistentVolumeClaim"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "template",
+        "serviceName"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.apps.v1beta1.StatefulSetStatus": {
+      "description": "StatefulSetStatus represents the current state of a StatefulSet.",
+      "properties": {
+        "collisionCount": {
+          "description": "collisionCount is the count of hash collisions for the StatefulSet. The StatefulSet controller uses this field as a collision avoidance mechanism when it needs to create the name for the newest ControllerRevision.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "conditions": {
+          "description": "Represents the latest available observations of a statefulset's current state.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.apps.v1beta1.StatefulSetCondition"
+          },
+          "type": "array",
+          "x-kubernetes-patch-merge-key": "type",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "currentReplicas": {
+          "description": "currentReplicas is the number of Pods created by the StatefulSet controller from the StatefulSet version indicated by currentRevision.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "currentRevision": {
+          "description": "currentRevision, if not empty, indicates the version of the StatefulSet used to generate Pods in the sequence [0,currentReplicas).",
+          "type": "string"
+        },
+        "observedGeneration": {
+          "description": "observedGeneration is the most recent generation observed for this StatefulSet. It corresponds to the StatefulSet's generation, which is updated on mutation by the API Server.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "readyReplicas": {
+          "description": "readyReplicas is the number of Pods created by the StatefulSet controller that have a Ready Condition.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "replicas": {
+          "description": "replicas is the number of Pods created by the StatefulSet controller.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "updateRevision": {
+          "description": "updateRevision, if not empty, indicates the version of the StatefulSet used to generate Pods in the sequence [replicas-updatedReplicas,replicas)",
+          "type": "string"
+        },
+        "updatedReplicas": {
+          "description": "updatedReplicas is the number of Pods created by the StatefulSet controller from the StatefulSet version indicated by updateRevision.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "replicas"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.apps.v1beta1.StatefulSetUpdateStrategy": {
+      "description": "StatefulSetUpdateStrategy indicates the strategy that the StatefulSet controller will use to perform updates. It includes any additional parameters necessary to perform the update for the indicated strategy.",
+      "properties": {
+        "rollingUpdate": {
+          "$ref": "#/definitions/io.k8s.api.apps.v1beta1.RollingUpdateStatefulSetStrategy",
+          "description": "RollingUpdate is used to communicate parameters when Type is RollingUpdateStatefulSetStrategyType."
+        },
+        "type": {
+          "description": "Type indicates the type of the StatefulSetUpdateStrategy.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.apps.v1beta2.ControllerRevision": {
+      "description": "DEPRECATED - This group version of ControllerRevision is deprecated by apps/v1/ControllerRevision. See the release notes for more information. ControllerRevision implements an immutable snapshot of state data. Clients are responsible for serializing and deserializing the objects that contain their internal state. Once a ControllerRevision has been successfully created, it can not be updated. The API Server will fail validation of all requests that attempt to mutate the Data field. ControllerRevisions may, however, be deleted. Note that, due to its use by both the DaemonSet and StatefulSet controllers for update and rollback, this object is beta. However, it may be subject to name and representation changes in future releases, and clients should not depend on its stability. It is primarily for internal use by controllers.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "data": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.runtime.RawExtension",
+          "description": "Data is the serialized representation of the state."
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "ControllerRevision"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
+        },
+        "revision": {
+          "description": "Revision indicates the revision of the state represented by Data.",
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "revision"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "apps",
+          "kind": "ControllerRevision",
+          "version": "v1beta2"
+        }
+      ]
+    },
+    "io.k8s.api.apps.v1beta2.ControllerRevisionList": {
+      "description": "ControllerRevisionList is a resource containing a list of ControllerRevision objects.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "Items is the list of ControllerRevisions",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.apps.v1beta2.ControllerRevision"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "ControllerRevisionList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "apps",
+          "kind": "ControllerRevisionList",
+          "version": "v1beta2"
+        }
+      ]
+    },
+    "io.k8s.api.apps.v1beta2.DaemonSet": {
+      "description": "DEPRECATED - This group version of DaemonSet is deprecated by apps/v1/DaemonSet. See the release notes for more information. DaemonSet represents the configuration of a daemon set.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "DaemonSet"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.apps.v1beta2.DaemonSetSpec",
+          "description": "The desired behavior of this daemon set. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
+        },
+        "status": {
+          "$ref": "#/definitions/io.k8s.api.apps.v1beta2.DaemonSetStatus",
+          "description": "The current status of this daemon set. This data may be out of date by some window of time. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
+        }
+      },
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "apps",
+          "kind": "DaemonSet",
+          "version": "v1beta2"
+        }
+      ]
+    },
+    "io.k8s.api.apps.v1beta2.DaemonSetCondition": {
+      "description": "DaemonSetCondition describes the state of a DaemonSet at a certain point.",
+      "properties": {
+        "lastTransitionTime": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "Last time the condition transitioned from one status to another."
+        },
+        "message": {
+          "description": "A human readable message indicating details about the transition.",
+          "type": "string"
+        },
+        "reason": {
+          "description": "The reason for the condition's last transition.",
+          "type": "string"
+        },
+        "status": {
+          "description": "Status of the condition, one of True, False, Unknown.",
+          "type": "string"
+        },
+        "type": {
+          "description": "Type of DaemonSet condition.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "status"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.apps.v1beta2.DaemonSetList": {
+      "description": "DaemonSetList is a collection of daemon sets.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "A list of daemon sets.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.apps.v1beta2.DaemonSet"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "DaemonSetList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "apps",
+          "kind": "DaemonSetList",
+          "version": "v1beta2"
+        }
+      ]
+    },
+    "io.k8s.api.apps.v1beta2.DaemonSetSpec": {
+      "description": "DaemonSetSpec is the specification of a daemon set.",
+      "properties": {
+        "minReadySeconds": {
+          "description": "The minimum number of seconds for which a newly created DaemonSet pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready).",
+          "format": "int32",
+          "type": "integer"
+        },
+        "revisionHistoryLimit": {
+          "description": "The number of old history to retain to allow rollback. This is a pointer to distinguish between explicit zero and not specified. Defaults to 10.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "selector": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+          "description": "A label query over pods that are managed by the daemon set. Must match in order to be controlled. It must match the pod template's labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors"
+        },
+        "template": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.PodTemplateSpec",
+          "description": "An object that describes the pod that will be created. The DaemonSet will create exactly one copy of this pod on every node that matches the template's node selector (or on every node if no node selector is specified). More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template"
+        },
+        "updateStrategy": {
+          "$ref": "#/definitions/io.k8s.api.apps.v1beta2.DaemonSetUpdateStrategy",
+          "description": "An update strategy to replace existing DaemonSet pods with new pods."
+        }
+      },
+      "required": [
+        "selector",
+        "template"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.apps.v1beta2.DaemonSetStatus": {
+      "description": "DaemonSetStatus represents the current status of a daemon set.",
+      "properties": {
+        "collisionCount": {
+          "description": "Count of hash collisions for the DaemonSet. The DaemonSet controller uses this field as a collision avoidance mechanism when it needs to create the name for the newest ControllerRevision.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "conditions": {
+          "description": "Represents the latest available observations of a DaemonSet's current state.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.apps.v1beta2.DaemonSetCondition"
+          },
+          "type": "array",
+          "x-kubernetes-patch-merge-key": "type",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "currentNumberScheduled": {
+          "description": "The number of nodes that are running at least 1 daemon pod and are supposed to run the daemon pod. More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/",
+          "format": "int32",
+          "type": "integer"
+        },
+        "desiredNumberScheduled": {
+          "description": "The total number of nodes that should be running the daemon pod (including nodes correctly running the daemon pod). More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/",
+          "format": "int32",
+          "type": "integer"
+        },
+        "numberAvailable": {
+          "description": "The number of nodes that should be running the daemon pod and have one or more of the daemon pod running and available (ready for at least spec.minReadySeconds)",
+          "format": "int32",
+          "type": "integer"
+        },
+        "numberMisscheduled": {
+          "description": "The number of nodes that are running the daemon pod, but are not supposed to run the daemon pod. More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/",
+          "format": "int32",
+          "type": "integer"
+        },
+        "numberReady": {
+          "description": "The number of nodes that should be running the daemon pod and have one or more of the daemon pod running and ready.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "numberUnavailable": {
+          "description": "The number of nodes that should be running the daemon pod and have none of the daemon pod running and available (ready for at least spec.minReadySeconds)",
+          "format": "int32",
+          "type": "integer"
+        },
+        "observedGeneration": {
+          "description": "The most recent generation observed by the daemon set controller.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "updatedNumberScheduled": {
+          "description": "The total number of nodes that are running updated daemon pod",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "currentNumberScheduled",
+        "numberMisscheduled",
+        "desiredNumberScheduled",
+        "numberReady"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.apps.v1beta2.DaemonSetUpdateStrategy": {
+      "description": "DaemonSetUpdateStrategy is a struct used to control the update strategy for a DaemonSet.",
+      "properties": {
+        "rollingUpdate": {
+          "$ref": "#/definitions/io.k8s.api.apps.v1beta2.RollingUpdateDaemonSet",
+          "description": "Rolling update config params. Present only if type = \"RollingUpdate\"."
+        },
+        "type": {
+          "description": "Type of daemon set update. Can be \"RollingUpdate\" or \"OnDelete\". Default is RollingUpdate.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.apps.v1beta2.Deployment": {
+      "description": "DEPRECATED - This group version of Deployment is deprecated by apps/v1/Deployment. See the release notes for more information. Deployment enables declarative updates for Pods and ReplicaSets.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "Deployment"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object metadata."
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.apps.v1beta2.DeploymentSpec",
+          "description": "Specification of the desired behavior of the Deployment."
+        },
+        "status": {
+          "$ref": "#/definitions/io.k8s.api.apps.v1beta2.DeploymentStatus",
+          "description": "Most recently observed status of the Deployment."
+        }
+      },
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "apps",
+          "kind": "Deployment",
+          "version": "v1beta2"
+        }
+      ]
+    },
+    "io.k8s.api.apps.v1beta2.DeploymentCondition": {
+      "description": "DeploymentCondition describes the state of a deployment at a certain point.",
+      "properties": {
+        "lastTransitionTime": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "Last time the condition transitioned from one status to another."
+        },
+        "lastUpdateTime": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "The last time this condition was updated."
+        },
+        "message": {
+          "description": "A human readable message indicating details about the transition.",
+          "type": "string"
+        },
+        "reason": {
+          "description": "The reason for the condition's last transition.",
+          "type": "string"
+        },
+        "status": {
+          "description": "Status of the condition, one of True, False, Unknown.",
+          "type": "string"
+        },
+        "type": {
+          "description": "Type of deployment condition.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "status"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.apps.v1beta2.DeploymentList": {
+      "description": "DeploymentList is a list of Deployments.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "Items is the list of Deployments.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.apps.v1beta2.Deployment"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "DeploymentList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "Standard list metadata."
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "apps",
+          "kind": "DeploymentList",
+          "version": "v1beta2"
+        }
+      ]
+    },
+    "io.k8s.api.apps.v1beta2.DeploymentSpec": {
+      "description": "DeploymentSpec is the specification of the desired behavior of the Deployment.",
+      "properties": {
+        "minReadySeconds": {
+          "description": "Minimum number of seconds for which a newly created pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready)",
+          "format": "int32",
+          "type": "integer"
+        },
+        "paused": {
+          "description": "Indicates that the deployment is paused.",
+          "type": "boolean"
+        },
+        "progressDeadlineSeconds": {
+          "description": "The maximum time in seconds for a deployment to make progress before it is considered to be failed. The deployment controller will continue to process failed deployments and a condition with a ProgressDeadlineExceeded reason will be surfaced in the deployment status. Note that progress will not be estimated during the time a deployment is paused. Defaults to 600s.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "replicas": {
+          "description": "Number of desired pods. This is a pointer to distinguish between explicit zero and not specified. Defaults to 1.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "revisionHistoryLimit": {
+          "description": "The number of old ReplicaSets to retain to allow rollback. This is a pointer to distinguish between explicit zero and not specified. Defaults to 10.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "selector": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+          "description": "Label selector for pods. Existing ReplicaSets whose pods are selected by this will be the ones affected by this deployment. It must match the pod template's labels."
+        },
+        "strategy": {
+          "$ref": "#/definitions/io.k8s.api.apps.v1beta2.DeploymentStrategy",
+          "description": "The deployment strategy to use to replace existing pods with new ones.",
+          "x-kubernetes-patch-strategy": "retainKeys"
+        },
+        "template": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.PodTemplateSpec",
+          "description": "Template describes the pods that will be created."
+        }
+      },
+      "required": [
+        "selector",
+        "template"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.apps.v1beta2.DeploymentStatus": {
+      "description": "DeploymentStatus is the most recently observed status of the Deployment.",
+      "properties": {
+        "availableReplicas": {
+          "description": "Total number of available pods (ready for at least minReadySeconds) targeted by this deployment.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "collisionCount": {
+          "description": "Count of hash collisions for the Deployment. The Deployment controller uses this field as a collision avoidance mechanism when it needs to create the name for the newest ReplicaSet.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "conditions": {
+          "description": "Represents the latest available observations of a deployment's current state.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.apps.v1beta2.DeploymentCondition"
+          },
+          "type": "array",
+          "x-kubernetes-patch-merge-key": "type",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "observedGeneration": {
+          "description": "The generation observed by the deployment controller.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "readyReplicas": {
+          "description": "Total number of ready pods targeted by this deployment.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "replicas": {
+          "description": "Total number of non-terminated pods targeted by this deployment (their labels match the selector).",
+          "format": "int32",
+          "type": "integer"
+        },
+        "unavailableReplicas": {
+          "description": "Total number of unavailable pods targeted by this deployment. This is the total number of pods that are still required for the deployment to have 100% available capacity. They may either be pods that are running but not yet available or pods that still have not been created.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "updatedReplicas": {
+          "description": "Total number of non-terminated pods targeted by this deployment that have the desired template spec.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.apps.v1beta2.DeploymentStrategy": {
+      "description": "DeploymentStrategy describes how to replace existing pods with new ones.",
+      "properties": {
+        "rollingUpdate": {
+          "$ref": "#/definitions/io.k8s.api.apps.v1beta2.RollingUpdateDeployment",
+          "description": "Rolling update config params. Present only if DeploymentStrategyType = RollingUpdate."
+        },
+        "type": {
+          "description": "Type of deployment. Can be \"Recreate\" or \"RollingUpdate\". Default is RollingUpdate.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.apps.v1beta2.ReplicaSet": {
+      "description": "DEPRECATED - This group version of ReplicaSet is deprecated by apps/v1/ReplicaSet. See the release notes for more information. ReplicaSet ensures that a specified number of pod replicas are running at any given time.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "ReplicaSet"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "If the Labels of a ReplicaSet are empty, they are defaulted to be the same as the Pod(s) that the ReplicaSet manages. Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.apps.v1beta2.ReplicaSetSpec",
+          "description": "Spec defines the specification of the desired behavior of the ReplicaSet. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
+        },
+        "status": {
+          "$ref": "#/definitions/io.k8s.api.apps.v1beta2.ReplicaSetStatus",
+          "description": "Status is the most recently observed status of the ReplicaSet. This data may be out of date by some window of time. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
+        }
+      },
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "apps",
+          "kind": "ReplicaSet",
+          "version": "v1beta2"
+        }
+      ]
+    },
+    "io.k8s.api.apps.v1beta2.ReplicaSetCondition": {
+      "description": "ReplicaSetCondition describes the state of a replica set at a certain point.",
+      "properties": {
+        "lastTransitionTime": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "The last time the condition transitioned from one status to another."
+        },
+        "message": {
+          "description": "A human readable message indicating details about the transition.",
+          "type": "string"
+        },
+        "reason": {
+          "description": "The reason for the condition's last transition.",
+          "type": "string"
+        },
+        "status": {
+          "description": "Status of the condition, one of True, False, Unknown.",
+          "type": "string"
+        },
+        "type": {
+          "description": "Type of replica set condition.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "status"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.apps.v1beta2.ReplicaSetList": {
+      "description": "ReplicaSetList is a collection of ReplicaSets.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "List of ReplicaSets. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.apps.v1beta2.ReplicaSet"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "ReplicaSetList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "apps",
+          "kind": "ReplicaSetList",
+          "version": "v1beta2"
+        }
+      ]
+    },
+    "io.k8s.api.apps.v1beta2.ReplicaSetSpec": {
+      "description": "ReplicaSetSpec is the specification of a ReplicaSet.",
+      "properties": {
+        "minReadySeconds": {
+          "description": "Minimum number of seconds for which a newly created pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready)",
+          "format": "int32",
+          "type": "integer"
+        },
+        "replicas": {
+          "description": "Replicas is the number of desired replicas. This is a pointer to distinguish between explicit zero and unspecified. Defaults to 1. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller",
+          "format": "int32",
+          "type": "integer"
+        },
+        "selector": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+          "description": "Selector is a label query over pods that should match the replica count. Label keys and values that must match in order to be controlled by this replica set. It must match the pod template's labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors"
+        },
+        "template": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.PodTemplateSpec",
+          "description": "Template is the object that describes the pod that will be created if insufficient replicas are detected. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template"
+        }
+      },
+      "required": [
+        "selector"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.apps.v1beta2.ReplicaSetStatus": {
+      "description": "ReplicaSetStatus represents the current status of a ReplicaSet.",
+      "properties": {
+        "availableReplicas": {
+          "description": "The number of available replicas (ready for at least minReadySeconds) for this replica set.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "conditions": {
+          "description": "Represents the latest available observations of a replica set's current state.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.apps.v1beta2.ReplicaSetCondition"
+          },
+          "type": "array",
+          "x-kubernetes-patch-merge-key": "type",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "fullyLabeledReplicas": {
+          "description": "The number of pods that have labels matching the labels of the pod template of the replicaset.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration reflects the generation of the most recently observed ReplicaSet.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "readyReplicas": {
+          "description": "The number of ready replicas for this replica set.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "replicas": {
+          "description": "Replicas is the most recently oberved number of replicas. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "replicas"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.apps.v1beta2.RollingUpdateDaemonSet": {
+      "description": "Spec to control the desired behavior of daemon set rolling update.",
+      "properties": {
+        "maxUnavailable": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.util.intstr.IntOrString",
+          "description": "The maximum number of DaemonSet pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of total number of DaemonSet pods at the start of the update (ex: 10%). Absolute number is calculated from percentage by rounding up. This cannot be 0. Default value is 1. Example: when this is set to 30%, at most 30% of the total number of nodes that should be running the daemon pod (i.e. status.desiredNumberScheduled) can have their pods stopped for an update at any given time. The update starts by stopping at most 30% of those DaemonSet pods and then brings up new DaemonSet pods in their place. Once the new pods are available, it then proceeds onto other DaemonSet pods, thus ensuring that at least 70% of original number of DaemonSet pods are available at all times during the update."
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.apps.v1beta2.RollingUpdateDeployment": {
+      "description": "Spec to control the desired behavior of rolling update.",
+      "properties": {
+        "maxSurge": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.util.intstr.IntOrString",
+          "description": "The maximum number of pods that can be scheduled above the desired number of pods. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. Defaults to 25%. Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when the rolling update starts, such that the total number of old and new pods do not exceed 130% of desired pods. Once old pods have been killed, new ReplicaSet can be scaled up further, ensuring that total number of pods running at any time during the update is at most 130% of desired pods."
+        },
+        "maxUnavailable": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.util.intstr.IntOrString",
+          "description": "The maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. Defaults to 25%. Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired pods immediately when the rolling update starts. Once new pods are ready, old ReplicaSet can be scaled down further, followed by scaling up the new ReplicaSet, ensuring that the total number of pods available at all times during the update is at least 70% of desired pods."
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.apps.v1beta2.RollingUpdateStatefulSetStrategy": {
+      "description": "RollingUpdateStatefulSetStrategy is used to communicate parameter for RollingUpdateStatefulSetStrategyType.",
+      "properties": {
+        "partition": {
+          "description": "Partition indicates the ordinal at which the StatefulSet should be partitioned. Default value is 0.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.apps.v1beta2.Scale": {
+      "description": "Scale represents a scaling request for a resource.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "Scale"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata."
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.apps.v1beta2.ScaleSpec",
+          "description": "defines the behavior of the scale. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status."
+        },
+        "status": {
+          "$ref": "#/definitions/io.k8s.api.apps.v1beta2.ScaleStatus",
+          "description": "current status of the scale. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status. Read-only."
+        }
+      },
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "apps",
+          "kind": "Scale",
+          "version": "v1beta2"
+        }
+      ]
+    },
+    "io.k8s.api.apps.v1beta2.ScaleSpec": {
+      "description": "ScaleSpec describes the attributes of a scale subresource",
+      "properties": {
+        "replicas": {
+          "description": "desired number of instances for the scaled object.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.apps.v1beta2.ScaleStatus": {
+      "description": "ScaleStatus represents the current status of a scale subresource.",
+      "properties": {
+        "replicas": {
+          "description": "actual number of observed instances of the scaled object.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "selector": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "label query over pods that should match the replicas count. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors",
+          "type": "object"
+        },
+        "targetSelector": {
+          "description": "label selector for pods that should match the replicas count. This is a serializated version of both map-based and more expressive set-based selectors. This is done to avoid introspection in the clients. The string will be in the same format as the query-param syntax. If the target type only supports map-based selectors, both this field and map-based selector field are populated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors",
+          "type": "string"
+        }
+      },
+      "required": [
+        "replicas"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.apps.v1beta2.StatefulSet": {
+      "description": "DEPRECATED - This group version of StatefulSet is deprecated by apps/v1/StatefulSet. See the release notes for more information. StatefulSet represents a set of pods with consistent identities. Identities are defined as:\n - Network: A single stable DNS and hostname.\n - Storage: As many VolumeClaims as requested.\nThe StatefulSet guarantees that a given network identity will always map to the same storage identity.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "StatefulSet"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.apps.v1beta2.StatefulSetSpec",
+          "description": "Spec defines the desired identities of pods in this set."
+        },
+        "status": {
+          "$ref": "#/definitions/io.k8s.api.apps.v1beta2.StatefulSetStatus",
+          "description": "Status is the current status of Pods in this StatefulSet. This data may be out of date by some window of time."
+        }
+      },
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "apps",
+          "kind": "StatefulSet",
+          "version": "v1beta2"
+        }
+      ]
+    },
+    "io.k8s.api.apps.v1beta2.StatefulSetCondition": {
+      "description": "StatefulSetCondition describes the state of a statefulset at a certain point.",
+      "properties": {
+        "lastTransitionTime": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "Last time the condition transitioned from one status to another."
+        },
+        "message": {
+          "description": "A human readable message indicating details about the transition.",
+          "type": "string"
+        },
+        "reason": {
+          "description": "The reason for the condition's last transition.",
+          "type": "string"
+        },
+        "status": {
+          "description": "Status of the condition, one of True, False, Unknown.",
+          "type": "string"
+        },
+        "type": {
+          "description": "Type of statefulset condition.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "status"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.apps.v1beta2.StatefulSetList": {
+      "description": "StatefulSetList is a collection of StatefulSets.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.apps.v1beta2.StatefulSet"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "StatefulSetList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "apps",
+          "kind": "StatefulSetList",
+          "version": "v1beta2"
+        }
+      ]
+    },
+    "io.k8s.api.apps.v1beta2.StatefulSetSpec": {
+      "description": "A StatefulSetSpec is the specification of a StatefulSet.",
+      "properties": {
+        "podManagementPolicy": {
+          "description": "podManagementPolicy controls how pods are created during initial scale up, when replacing pods on nodes, or when scaling down. The default policy is `OrderedReady`, where pods are created in increasing order (pod-0, then pod-1, etc) and the controller will wait until each pod is ready before continuing. When scaling down, the pods are removed in the opposite order. The alternative policy is `Parallel` which will create pods in parallel to match the desired scale without waiting, and on scale down will delete all pods at once.",
+          "type": "string"
+        },
+        "replicas": {
+          "description": "replicas is the desired number of replicas of the given Template. These are replicas in the sense that they are instantiations of the same Template, but individual replicas also have a consistent identity. If unspecified, defaults to 1.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "revisionHistoryLimit": {
+          "description": "revisionHistoryLimit is the maximum number of revisions that will be maintained in the StatefulSet's revision history. The revision history consists of all revisions not represented by a currently applied StatefulSetSpec version. The default value is 10.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "selector": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+          "description": "selector is a label query over pods that should match the replica count. It must match the pod template's labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors"
+        },
+        "serviceName": {
+          "description": "serviceName is the name of the service that governs this StatefulSet. This service must exist before the StatefulSet, and is responsible for the network identity of the set. Pods get DNS/hostnames that follow the pattern: pod-specific-string.serviceName.default.svc.cluster.local where \"pod-specific-string\" is managed by the StatefulSet controller.",
+          "type": "string"
+        },
+        "template": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.PodTemplateSpec",
+          "description": "template is the object that describes the pod that will be created if insufficient replicas are detected. Each pod stamped out by the StatefulSet will fulfill this Template, but have a unique identity from the rest of the StatefulSet."
+        },
+        "updateStrategy": {
+          "$ref": "#/definitions/io.k8s.api.apps.v1beta2.StatefulSetUpdateStrategy",
+          "description": "updateStrategy indicates the StatefulSetUpdateStrategy that will be employed to update Pods in the StatefulSet when a revision is made to Template."
+        },
+        "volumeClaimTemplates": {
+          "description": "volumeClaimTemplates is a list of claims that pods are allowed to reference. The StatefulSet controller is responsible for mapping network identities to claims in a way that maintains the identity of a pod. Every claim in this list must have at least one matching (by name) volumeMount in one container in the template. A claim in this list takes precedence over any volumes in the template, with the same name.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.PersistentVolumeClaim"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "selector",
+        "template",
+        "serviceName"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.apps.v1beta2.StatefulSetStatus": {
+      "description": "StatefulSetStatus represents the current state of a StatefulSet.",
+      "properties": {
+        "collisionCount": {
+          "description": "collisionCount is the count of hash collisions for the StatefulSet. The StatefulSet controller uses this field as a collision avoidance mechanism when it needs to create the name for the newest ControllerRevision.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "conditions": {
+          "description": "Represents the latest available observations of a statefulset's current state.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.apps.v1beta2.StatefulSetCondition"
+          },
+          "type": "array",
+          "x-kubernetes-patch-merge-key": "type",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "currentReplicas": {
+          "description": "currentReplicas is the number of Pods created by the StatefulSet controller from the StatefulSet version indicated by currentRevision.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "currentRevision": {
+          "description": "currentRevision, if not empty, indicates the version of the StatefulSet used to generate Pods in the sequence [0,currentReplicas).",
+          "type": "string"
+        },
+        "observedGeneration": {
+          "description": "observedGeneration is the most recent generation observed for this StatefulSet. It corresponds to the StatefulSet's generation, which is updated on mutation by the API Server.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "readyReplicas": {
+          "description": "readyReplicas is the number of Pods created by the StatefulSet controller that have a Ready Condition.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "replicas": {
+          "description": "replicas is the number of Pods created by the StatefulSet controller.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "updateRevision": {
+          "description": "updateRevision, if not empty, indicates the version of the StatefulSet used to generate Pods in the sequence [replicas-updatedReplicas,replicas)",
+          "type": "string"
+        },
+        "updatedReplicas": {
+          "description": "updatedReplicas is the number of Pods created by the StatefulSet controller from the StatefulSet version indicated by updateRevision.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "replicas"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.apps.v1beta2.StatefulSetUpdateStrategy": {
+      "description": "StatefulSetUpdateStrategy indicates the strategy that the StatefulSet controller will use to perform updates. It includes any additional parameters necessary to perform the update for the indicated strategy.",
+      "properties": {
+        "rollingUpdate": {
+          "$ref": "#/definitions/io.k8s.api.apps.v1beta2.RollingUpdateStatefulSetStrategy",
+          "description": "RollingUpdate is used to communicate parameters when Type is RollingUpdateStatefulSetStrategyType."
+        },
+        "type": {
+          "description": "Type indicates the type of the StatefulSetUpdateStrategy. Default is RollingUpdate.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.auditregistration.v1alpha1.AuditSink": {
+      "description": "AuditSink represents a cluster level audit sink",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "AuditSink"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.auditregistration.v1alpha1.AuditSinkSpec",
+          "description": "Spec defines the audit configuration spec"
+        }
+      },
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "auditregistration.k8s.io",
+          "kind": "AuditSink",
+          "version": "v1alpha1"
+        }
+      ]
+    },
+    "io.k8s.api.auditregistration.v1alpha1.AuditSinkList": {
+      "description": "AuditSinkList is a list of AuditSink items.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "List of audit configurations.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.auditregistration.v1alpha1.AuditSink"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "AuditSinkList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "auditregistration.k8s.io",
+          "kind": "AuditSinkList",
+          "version": "v1alpha1"
+        }
+      ]
+    },
+    "io.k8s.api.auditregistration.v1alpha1.AuditSinkSpec": {
+      "description": "AuditSinkSpec holds the spec for the audit sink",
+      "properties": {
+        "policy": {
+          "$ref": "#/definitions/io.k8s.api.auditregistration.v1alpha1.Policy",
+          "description": "Policy defines the policy for selecting which events should be sent to the webhook required"
+        },
+        "webhook": {
+          "$ref": "#/definitions/io.k8s.api.auditregistration.v1alpha1.Webhook",
+          "description": "Webhook to send events required"
+        }
+      },
+      "required": [
+        "policy",
+        "webhook"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.auditregistration.v1alpha1.Policy": {
+      "description": "Policy defines the configuration of how audit events are logged",
+      "properties": {
+        "level": {
+          "description": "The Level that all requests are recorded at. available options: None, Metadata, Request, RequestResponse required",
+          "type": "string"
+        },
+        "stages": {
+          "description": "Stages is a list of stages for which events are created.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "level"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.auditregistration.v1alpha1.ServiceReference": {
+      "description": "ServiceReference holds a reference to Service.legacy.k8s.io",
+      "properties": {
+        "name": {
+          "description": "`name` is the name of the service. Required",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "`namespace` is the namespace of the service. Required",
+          "type": "string"
+        },
+        "path": {
+          "description": "`path` is an optional URL path which will be sent in any request to this service.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "namespace",
+        "name"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.auditregistration.v1alpha1.Webhook": {
+      "description": "Webhook holds the configuration of the webhook",
+      "properties": {
+        "clientConfig": {
+          "$ref": "#/definitions/io.k8s.api.auditregistration.v1alpha1.WebhookClientConfig",
+          "description": "ClientConfig holds the connection parameters for the webhook required"
+        },
+        "throttle": {
+          "$ref": "#/definitions/io.k8s.api.auditregistration.v1alpha1.WebhookThrottleConfig",
+          "description": "Throttle holds the options for throttling the webhook"
+        }
+      },
+      "required": [
+        "clientConfig"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.auditregistration.v1alpha1.WebhookClientConfig": {
+      "description": "WebhookClientConfig contains the information to make a connection with the webhook",
+      "properties": {
+        "caBundle": {
+          "description": "`caBundle` is a PEM encoded CA bundle which will be used to validate the webhook's server certificate. If unspecified, system trust roots on the apiserver are used.",
+          "format": "byte",
+          "type": "string"
+        },
+        "service": {
+          "$ref": "#/definitions/io.k8s.api.auditregistration.v1alpha1.ServiceReference",
+          "description": "`service` is a reference to the service for this webhook. Either `service` or `url` must be specified.\n\nIf the webhook is running within the cluster, then you should use `service`.\n\nPort 443 will be used if it is open, otherwise it is an error."
+        },
+        "url": {
+          "description": "`url` gives the location of the webhook, in standard URL form (`scheme://host:port/path`). Exactly one of `url` or `service` must be specified.\n\nThe `host` should not refer to a service running in the cluster; use the `service` field instead. The host might be resolved via external DNS in some apiservers (e.g., `kube-apiserver` cannot resolve in-cluster DNS as that would be a layering violation). `host` may also be an IP address.\n\nPlease note that using `localhost` or `127.0.0.1` as a `host` is risky unless you take great care to run this webhook on all hosts which run an apiserver which might need to make calls to this webhook. Such installs are likely to be non-portable, i.e., not easy to turn up in a new cluster.\n\nThe scheme must be \"https\"; the URL must begin with \"https://\".\n\nA path is optional, and if present may be any string permissible in a URL. You may use the path to pass an arbitrary string to the webhook, for example, a cluster identifier.\n\nAttempting to use a user or basic auth e.g. \"user:password@\" is not allowed. Fragments (\"#...\") and query parameters (\"?...\") are not allowed, either.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.auditregistration.v1alpha1.WebhookThrottleConfig": {
+      "description": "WebhookThrottleConfig holds the configuration for throttling events",
+      "properties": {
+        "burst": {
+          "description": "ThrottleBurst is the maximum number of events sent at the same moment default 15 QPS",
+          "format": "int64",
+          "type": "integer"
+        },
+        "qps": {
+          "description": "ThrottleQPS maximum number of batches per second default 10 QPS",
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.authentication.v1.TokenReview": {
+      "description": "TokenReview attempts to authenticate a token to a known user. Note: TokenReview requests may be cached by the webhook token authenticator plugin in the kube-apiserver.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "TokenReview"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.authentication.v1.TokenReviewSpec",
+          "description": "Spec holds information about the request being evaluated"
+        },
+        "status": {
+          "$ref": "#/definitions/io.k8s.api.authentication.v1.TokenReviewStatus",
+          "description": "Status is filled in by the server and indicates whether the request can be authenticated."
+        }
+      },
+      "required": [
+        "spec"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "authentication.k8s.io",
+          "kind": "TokenReview",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.authentication.v1.TokenReviewSpec": {
+      "description": "TokenReviewSpec is a description of the token authentication request.",
+      "properties": {
+        "audiences": {
+          "description": "Audiences is a list of the identifiers that the resource server presented with the token identifies as. Audience-aware token authenticators will verify that the token was intended for at least one of the audiences in this list. If no audiences are provided, the audience will default to the audience of the Kubernetes apiserver.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "token": {
+          "description": "Token is the opaque bearer token.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.authentication.v1.TokenReviewStatus": {
+      "description": "TokenReviewStatus is the result of the token authentication request.",
+      "properties": {
+        "audiences": {
+          "description": "Audiences are audience identifiers chosen by the authenticator that are compatible with both the TokenReview and token. An identifier is any identifier in the intersection of the TokenReviewSpec audiences and the token's audiences. A client of the TokenReview API that sets the spec.audiences field should validate that a compatible audience identifier is returned in the status.audiences field to ensure that the TokenReview server is audience aware. If a TokenReview returns an empty status.audience field where status.authenticated is \"true\", the token is valid against the audience of the Kubernetes API server.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "authenticated": {
+          "description": "Authenticated indicates that the token was associated with a known user.",
+          "type": "boolean"
+        },
+        "error": {
+          "description": "Error indicates that the token couldn't be checked",
+          "type": "string"
+        },
+        "user": {
+          "$ref": "#/definitions/io.k8s.api.authentication.v1.UserInfo",
+          "description": "User is the UserInfo associated with the provided token."
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.authentication.v1.UserInfo": {
+      "description": "UserInfo holds the information about the user needed to implement the user.Info interface.",
+      "properties": {
+        "extra": {
+          "additionalProperties": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "description": "Any additional information provided by the authenticator.",
+          "type": "object"
+        },
+        "groups": {
+          "description": "The names of groups this user is a part of.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "uid": {
+          "description": "A unique value that identifies this user across time. If this user is deleted and another user by the same name is added, they will have different UIDs.",
+          "type": "string"
+        },
+        "username": {
+          "description": "The name that uniquely identifies this user among all active users.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.authentication.v1beta1.TokenReview": {
+      "description": "TokenReview attempts to authenticate a token to a known user. Note: TokenReview requests may be cached by the webhook token authenticator plugin in the kube-apiserver.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "TokenReview"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.authentication.v1beta1.TokenReviewSpec",
+          "description": "Spec holds information about the request being evaluated"
+        },
+        "status": {
+          "$ref": "#/definitions/io.k8s.api.authentication.v1beta1.TokenReviewStatus",
+          "description": "Status is filled in by the server and indicates whether the request can be authenticated."
+        }
+      },
+      "required": [
+        "spec"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "authentication.k8s.io",
+          "kind": "TokenReview",
+          "version": "v1beta1"
+        }
+      ]
+    },
+    "io.k8s.api.authentication.v1beta1.TokenReviewSpec": {
+      "description": "TokenReviewSpec is a description of the token authentication request.",
+      "properties": {
+        "audiences": {
+          "description": "Audiences is a list of the identifiers that the resource server presented with the token identifies as. Audience-aware token authenticators will verify that the token was intended for at least one of the audiences in this list. If no audiences are provided, the audience will default to the audience of the Kubernetes apiserver.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "token": {
+          "description": "Token is the opaque bearer token.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.authentication.v1beta1.TokenReviewStatus": {
+      "description": "TokenReviewStatus is the result of the token authentication request.",
+      "properties": {
+        "audiences": {
+          "description": "Audiences are audience identifiers chosen by the authenticator that are compatible with both the TokenReview and token. An identifier is any identifier in the intersection of the TokenReviewSpec audiences and the token's audiences. A client of the TokenReview API that sets the spec.audiences field should validate that a compatible audience identifier is returned in the status.audiences field to ensure that the TokenReview server is audience aware. If a TokenReview returns an empty status.audience field where status.authenticated is \"true\", the token is valid against the audience of the Kubernetes API server.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "authenticated": {
+          "description": "Authenticated indicates that the token was associated with a known user.",
+          "type": "boolean"
+        },
+        "error": {
+          "description": "Error indicates that the token couldn't be checked",
+          "type": "string"
+        },
+        "user": {
+          "$ref": "#/definitions/io.k8s.api.authentication.v1beta1.UserInfo",
+          "description": "User is the UserInfo associated with the provided token."
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.authentication.v1beta1.UserInfo": {
+      "description": "UserInfo holds the information about the user needed to implement the user.Info interface.",
+      "properties": {
+        "extra": {
+          "additionalProperties": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "description": "Any additional information provided by the authenticator.",
+          "type": "object"
+        },
+        "groups": {
+          "description": "The names of groups this user is a part of.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "uid": {
+          "description": "A unique value that identifies this user across time. If this user is deleted and another user by the same name is added, they will have different UIDs.",
+          "type": "string"
+        },
+        "username": {
+          "description": "The name that uniquely identifies this user among all active users.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.authorization.v1.LocalSubjectAccessReview": {
+      "description": "LocalSubjectAccessReview checks whether or not a user or group can perform an action in a given namespace. Having a namespace scoped resource makes it much easier to grant namespace scoped policy that includes permissions checking.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "LocalSubjectAccessReview"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.authorization.v1.SubjectAccessReviewSpec",
+          "description": "Spec holds information about the request being evaluated.  spec.namespace must be equal to the namespace you made the request against.  If empty, it is defaulted."
+        },
+        "status": {
+          "$ref": "#/definitions/io.k8s.api.authorization.v1.SubjectAccessReviewStatus",
+          "description": "Status is filled in by the server and indicates whether the request is allowed or not"
+        }
+      },
+      "required": [
+        "spec"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "authorization.k8s.io",
+          "kind": "LocalSubjectAccessReview",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.authorization.v1.NonResourceAttributes": {
+      "description": "NonResourceAttributes includes the authorization attributes available for non-resource requests to the Authorizer interface",
+      "properties": {
+        "path": {
+          "description": "Path is the URL path of the request",
+          "type": "string"
+        },
+        "verb": {
+          "description": "Verb is the standard HTTP verb",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.authorization.v1.NonResourceRule": {
+      "description": "NonResourceRule holds information that describes a rule for the non-resource",
+      "properties": {
+        "nonResourceURLs": {
+          "description": "NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path.  \"*\" means all.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "verbs": {
+          "description": "Verb is a list of kubernetes non-resource API verbs, like: get, post, put, delete, patch, head, options.  \"*\" means all.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "verbs"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.authorization.v1.ResourceAttributes": {
+      "description": "ResourceAttributes includes the authorization attributes available for resource requests to the Authorizer interface",
+      "properties": {
+        "group": {
+          "description": "Group is the API Group of the Resource.  \"*\" means all.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name is the name of the resource being requested for a \"get\" or deleted for a \"delete\". \"\" (empty) means all.",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace is the namespace of the action being requested.  Currently, there is no distinction between no namespace and all namespaces \"\" (empty) is defaulted for LocalSubjectAccessReviews \"\" (empty) is empty for cluster-scoped resources \"\" (empty) means \"all\" for namespace scoped resources from a SubjectAccessReview or SelfSubjectAccessReview",
+          "type": "string"
+        },
+        "resource": {
+          "description": "Resource is one of the existing resource types.  \"*\" means all.",
+          "type": "string"
+        },
+        "subresource": {
+          "description": "Subresource is one of the existing resource types.  \"\" means none.",
+          "type": "string"
+        },
+        "verb": {
+          "description": "Verb is a kubernetes resource API verb, like: get, list, watch, create, update, delete, proxy.  \"*\" means all.",
+          "type": "string"
+        },
+        "version": {
+          "description": "Version is the API Version of the Resource.  \"*\" means all.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.authorization.v1.ResourceRule": {
+      "description": "ResourceRule is the list of actions the subject is allowed to perform on resources. The list ordering isn't significant, may contain duplicates, and possibly be incomplete.",
+      "properties": {
+        "apiGroups": {
+          "description": "APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of the enumerated resources in any API group will be allowed.  \"*\" means all.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "resourceNames": {
+          "description": "ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.  \"*\" means all.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "resources": {
+          "description": "Resources is a list of resources this rule applies to.  \"*\" means all in the specified apiGroups.\n \"*/foo\" represents the subresource 'foo' for all resources in the specified apiGroups.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "verbs": {
+          "description": "Verb is a list of kubernetes resource API verbs, like: get, list, watch, create, update, delete, proxy.  \"*\" means all.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "verbs"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.authorization.v1.SelfSubjectAccessReview": {
+      "description": "SelfSubjectAccessReview checks whether or the current user can perform an action.  Not filling in a spec.namespace means \"in all namespaces\".  Self is a special case, because users should always be able to check whether they can perform an action",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "SelfSubjectAccessReview"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.authorization.v1.SelfSubjectAccessReviewSpec",
+          "description": "Spec holds information about the request being evaluated.  user and groups must be empty"
+        },
+        "status": {
+          "$ref": "#/definitions/io.k8s.api.authorization.v1.SubjectAccessReviewStatus",
+          "description": "Status is filled in by the server and indicates whether the request is allowed or not"
+        }
+      },
+      "required": [
+        "spec"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "authorization.k8s.io",
+          "kind": "SelfSubjectAccessReview",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.authorization.v1.SelfSubjectAccessReviewSpec": {
+      "description": "SelfSubjectAccessReviewSpec is a description of the access request.  Exactly one of ResourceAuthorizationAttributes and NonResourceAuthorizationAttributes must be set",
+      "properties": {
+        "nonResourceAttributes": {
+          "$ref": "#/definitions/io.k8s.api.authorization.v1.NonResourceAttributes",
+          "description": "NonResourceAttributes describes information for a non-resource access request"
+        },
+        "resourceAttributes": {
+          "$ref": "#/definitions/io.k8s.api.authorization.v1.ResourceAttributes",
+          "description": "ResourceAuthorizationAttributes describes information for a resource access request"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.authorization.v1.SelfSubjectRulesReview": {
+      "description": "SelfSubjectRulesReview enumerates the set of actions the current user can perform within a namespace. The returned list of actions may be incomplete depending on the server's authorization mode, and any errors experienced during the evaluation. SelfSubjectRulesReview should be used by UIs to show/hide actions, or to quickly let an end user reason about their permissions. It should NOT Be used by external systems to drive authorization decisions as this raises confused deputy, cache lifetime/revocation, and correctness concerns. SubjectAccessReview, and LocalAccessReview are the correct way to defer authorization decisions to the API server.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "SelfSubjectRulesReview"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.authorization.v1.SelfSubjectRulesReviewSpec",
+          "description": "Spec holds information about the request being evaluated."
+        },
+        "status": {
+          "$ref": "#/definitions/io.k8s.api.authorization.v1.SubjectRulesReviewStatus",
+          "description": "Status is filled in by the server and indicates the set of actions a user can perform."
+        }
+      },
+      "required": [
+        "spec"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "authorization.k8s.io",
+          "kind": "SelfSubjectRulesReview",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.authorization.v1.SelfSubjectRulesReviewSpec": {
+      "properties": {
+        "namespace": {
+          "description": "Namespace to evaluate rules for. Required.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.authorization.v1.SubjectAccessReview": {
+      "description": "SubjectAccessReview checks whether or not a user or group can perform an action.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "SubjectAccessReview"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.authorization.v1.SubjectAccessReviewSpec",
+          "description": "Spec holds information about the request being evaluated"
+        },
+        "status": {
+          "$ref": "#/definitions/io.k8s.api.authorization.v1.SubjectAccessReviewStatus",
+          "description": "Status is filled in by the server and indicates whether the request is allowed or not"
+        }
+      },
+      "required": [
+        "spec"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "authorization.k8s.io",
+          "kind": "SubjectAccessReview",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.authorization.v1.SubjectAccessReviewSpec": {
+      "description": "SubjectAccessReviewSpec is a description of the access request.  Exactly one of ResourceAuthorizationAttributes and NonResourceAuthorizationAttributes must be set",
+      "properties": {
+        "extra": {
+          "additionalProperties": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "description": "Extra corresponds to the user.Info.GetExtra() method from the authenticator.  Since that is input to the authorizer it needs a reflection here.",
+          "type": "object"
+        },
+        "groups": {
+          "description": "Groups is the groups you're testing for.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "nonResourceAttributes": {
+          "$ref": "#/definitions/io.k8s.api.authorization.v1.NonResourceAttributes",
+          "description": "NonResourceAttributes describes information for a non-resource access request"
+        },
+        "resourceAttributes": {
+          "$ref": "#/definitions/io.k8s.api.authorization.v1.ResourceAttributes",
+          "description": "ResourceAuthorizationAttributes describes information for a resource access request"
+        },
+        "uid": {
+          "description": "UID information about the requesting user.",
+          "type": "string"
+        },
+        "user": {
+          "description": "User is the user you're testing for. If you specify \"User\" but not \"Groups\", then is it interpreted as \"What if User were not a member of any groups",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.authorization.v1.SubjectAccessReviewStatus": {
+      "description": "SubjectAccessReviewStatus",
+      "properties": {
+        "allowed": {
+          "description": "Allowed is required. True if the action would be allowed, false otherwise.",
+          "type": "boolean"
+        },
+        "denied": {
+          "description": "Denied is optional. True if the action would be denied, otherwise false. If both allowed is false and denied is false, then the authorizer has no opinion on whether to authorize the action. Denied may not be true if Allowed is true.",
+          "type": "boolean"
+        },
+        "evaluationError": {
+          "description": "EvaluationError is an indication that some error occurred during the authorization check. It is entirely possible to get an error and be able to continue determine authorization status in spite of it. For instance, RBAC can be missing a role, but enough roles are still present and bound to reason about the request.",
+          "type": "string"
+        },
+        "reason": {
+          "description": "Reason is optional.  It indicates why a request was allowed or denied.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "allowed"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.authorization.v1.SubjectRulesReviewStatus": {
+      "description": "SubjectRulesReviewStatus contains the result of a rules check. This check can be incomplete depending on the set of authorizers the server is configured with and any errors experienced during evaluation. Because authorization rules are additive, if a rule appears in a list it's safe to assume the subject has that permission, even if that list is incomplete.",
+      "properties": {
+        "evaluationError": {
+          "description": "EvaluationError can appear in combination with Rules. It indicates an error occurred during rule evaluation, such as an authorizer that doesn't support rule evaluation, and that ResourceRules and/or NonResourceRules may be incomplete.",
+          "type": "string"
+        },
+        "incomplete": {
+          "description": "Incomplete is true when the rules returned by this call are incomplete. This is most commonly encountered when an authorizer, such as an external authorizer, doesn't support rules evaluation.",
+          "type": "boolean"
+        },
+        "nonResourceRules": {
+          "description": "NonResourceRules is the list of actions the subject is allowed to perform on non-resources. The list ordering isn't significant, may contain duplicates, and possibly be incomplete.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.authorization.v1.NonResourceRule"
+          },
+          "type": "array"
+        },
+        "resourceRules": {
+          "description": "ResourceRules is the list of actions the subject is allowed to perform on resources. The list ordering isn't significant, may contain duplicates, and possibly be incomplete.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.authorization.v1.ResourceRule"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "resourceRules",
+        "nonResourceRules",
+        "incomplete"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.authorization.v1beta1.LocalSubjectAccessReview": {
+      "description": "LocalSubjectAccessReview checks whether or not a user or group can perform an action in a given namespace. Having a namespace scoped resource makes it much easier to grant namespace scoped policy that includes permissions checking.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "LocalSubjectAccessReview"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.authorization.v1beta1.SubjectAccessReviewSpec",
+          "description": "Spec holds information about the request being evaluated.  spec.namespace must be equal to the namespace you made the request against.  If empty, it is defaulted."
+        },
+        "status": {
+          "$ref": "#/definitions/io.k8s.api.authorization.v1beta1.SubjectAccessReviewStatus",
+          "description": "Status is filled in by the server and indicates whether the request is allowed or not"
+        }
+      },
+      "required": [
+        "spec"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "authorization.k8s.io",
+          "kind": "LocalSubjectAccessReview",
+          "version": "v1beta1"
+        }
+      ]
+    },
+    "io.k8s.api.authorization.v1beta1.NonResourceAttributes": {
+      "description": "NonResourceAttributes includes the authorization attributes available for non-resource requests to the Authorizer interface",
+      "properties": {
+        "path": {
+          "description": "Path is the URL path of the request",
+          "type": "string"
+        },
+        "verb": {
+          "description": "Verb is the standard HTTP verb",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.authorization.v1beta1.NonResourceRule": {
+      "description": "NonResourceRule holds information that describes a rule for the non-resource",
+      "properties": {
+        "nonResourceURLs": {
+          "description": "NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path.  \"*\" means all.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "verbs": {
+          "description": "Verb is a list of kubernetes non-resource API verbs, like: get, post, put, delete, patch, head, options.  \"*\" means all.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "verbs"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.authorization.v1beta1.ResourceAttributes": {
+      "description": "ResourceAttributes includes the authorization attributes available for resource requests to the Authorizer interface",
+      "properties": {
+        "group": {
+          "description": "Group is the API Group of the Resource.  \"*\" means all.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name is the name of the resource being requested for a \"get\" or deleted for a \"delete\". \"\" (empty) means all.",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace is the namespace of the action being requested.  Currently, there is no distinction between no namespace and all namespaces \"\" (empty) is defaulted for LocalSubjectAccessReviews \"\" (empty) is empty for cluster-scoped resources \"\" (empty) means \"all\" for namespace scoped resources from a SubjectAccessReview or SelfSubjectAccessReview",
+          "type": "string"
+        },
+        "resource": {
+          "description": "Resource is one of the existing resource types.  \"*\" means all.",
+          "type": "string"
+        },
+        "subresource": {
+          "description": "Subresource is one of the existing resource types.  \"\" means none.",
+          "type": "string"
+        },
+        "verb": {
+          "description": "Verb is a kubernetes resource API verb, like: get, list, watch, create, update, delete, proxy.  \"*\" means all.",
+          "type": "string"
+        },
+        "version": {
+          "description": "Version is the API Version of the Resource.  \"*\" means all.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.authorization.v1beta1.ResourceRule": {
+      "description": "ResourceRule is the list of actions the subject is allowed to perform on resources. The list ordering isn't significant, may contain duplicates, and possibly be incomplete.",
+      "properties": {
+        "apiGroups": {
+          "description": "APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of the enumerated resources in any API group will be allowed.  \"*\" means all.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "resourceNames": {
+          "description": "ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.  \"*\" means all.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "resources": {
+          "description": "Resources is a list of resources this rule applies to.  \"*\" means all in the specified apiGroups.\n \"*/foo\" represents the subresource 'foo' for all resources in the specified apiGroups.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "verbs": {
+          "description": "Verb is a list of kubernetes resource API verbs, like: get, list, watch, create, update, delete, proxy.  \"*\" means all.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "verbs"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.authorization.v1beta1.SelfSubjectAccessReview": {
+      "description": "SelfSubjectAccessReview checks whether or the current user can perform an action.  Not filling in a spec.namespace means \"in all namespaces\".  Self is a special case, because users should always be able to check whether they can perform an action",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "SelfSubjectAccessReview"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.authorization.v1beta1.SelfSubjectAccessReviewSpec",
+          "description": "Spec holds information about the request being evaluated.  user and groups must be empty"
+        },
+        "status": {
+          "$ref": "#/definitions/io.k8s.api.authorization.v1beta1.SubjectAccessReviewStatus",
+          "description": "Status is filled in by the server and indicates whether the request is allowed or not"
+        }
+      },
+      "required": [
+        "spec"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "authorization.k8s.io",
+          "kind": "SelfSubjectAccessReview",
+          "version": "v1beta1"
+        }
+      ]
+    },
+    "io.k8s.api.authorization.v1beta1.SelfSubjectAccessReviewSpec": {
+      "description": "SelfSubjectAccessReviewSpec is a description of the access request.  Exactly one of ResourceAuthorizationAttributes and NonResourceAuthorizationAttributes must be set",
+      "properties": {
+        "nonResourceAttributes": {
+          "$ref": "#/definitions/io.k8s.api.authorization.v1beta1.NonResourceAttributes",
+          "description": "NonResourceAttributes describes information for a non-resource access request"
+        },
+        "resourceAttributes": {
+          "$ref": "#/definitions/io.k8s.api.authorization.v1beta1.ResourceAttributes",
+          "description": "ResourceAuthorizationAttributes describes information for a resource access request"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.authorization.v1beta1.SelfSubjectRulesReview": {
+      "description": "SelfSubjectRulesReview enumerates the set of actions the current user can perform within a namespace. The returned list of actions may be incomplete depending on the server's authorization mode, and any errors experienced during the evaluation. SelfSubjectRulesReview should be used by UIs to show/hide actions, or to quickly let an end user reason about their permissions. It should NOT Be used by external systems to drive authorization decisions as this raises confused deputy, cache lifetime/revocation, and correctness concerns. SubjectAccessReview, and LocalAccessReview are the correct way to defer authorization decisions to the API server.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "SelfSubjectRulesReview"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.authorization.v1beta1.SelfSubjectRulesReviewSpec",
+          "description": "Spec holds information about the request being evaluated."
+        },
+        "status": {
+          "$ref": "#/definitions/io.k8s.api.authorization.v1beta1.SubjectRulesReviewStatus",
+          "description": "Status is filled in by the server and indicates the set of actions a user can perform."
+        }
+      },
+      "required": [
+        "spec"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "authorization.k8s.io",
+          "kind": "SelfSubjectRulesReview",
+          "version": "v1beta1"
+        }
+      ]
+    },
+    "io.k8s.api.authorization.v1beta1.SelfSubjectRulesReviewSpec": {
+      "properties": {
+        "namespace": {
+          "description": "Namespace to evaluate rules for. Required.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.authorization.v1beta1.SubjectAccessReview": {
+      "description": "SubjectAccessReview checks whether or not a user or group can perform an action.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "SubjectAccessReview"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.authorization.v1beta1.SubjectAccessReviewSpec",
+          "description": "Spec holds information about the request being evaluated"
+        },
+        "status": {
+          "$ref": "#/definitions/io.k8s.api.authorization.v1beta1.SubjectAccessReviewStatus",
+          "description": "Status is filled in by the server and indicates whether the request is allowed or not"
+        }
+      },
+      "required": [
+        "spec"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "authorization.k8s.io",
+          "kind": "SubjectAccessReview",
+          "version": "v1beta1"
+        }
+      ]
+    },
+    "io.k8s.api.authorization.v1beta1.SubjectAccessReviewSpec": {
+      "description": "SubjectAccessReviewSpec is a description of the access request.  Exactly one of ResourceAuthorizationAttributes and NonResourceAuthorizationAttributes must be set",
+      "properties": {
+        "extra": {
+          "additionalProperties": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "description": "Extra corresponds to the user.Info.GetExtra() method from the authenticator.  Since that is input to the authorizer it needs a reflection here.",
+          "type": "object"
+        },
+        "group": {
+          "description": "Groups is the groups you're testing for.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "nonResourceAttributes": {
+          "$ref": "#/definitions/io.k8s.api.authorization.v1beta1.NonResourceAttributes",
+          "description": "NonResourceAttributes describes information for a non-resource access request"
+        },
+        "resourceAttributes": {
+          "$ref": "#/definitions/io.k8s.api.authorization.v1beta1.ResourceAttributes",
+          "description": "ResourceAuthorizationAttributes describes information for a resource access request"
+        },
+        "uid": {
+          "description": "UID information about the requesting user.",
+          "type": "string"
+        },
+        "user": {
+          "description": "User is the user you're testing for. If you specify \"User\" but not \"Group\", then is it interpreted as \"What if User were not a member of any groups",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.authorization.v1beta1.SubjectAccessReviewStatus": {
+      "description": "SubjectAccessReviewStatus",
+      "properties": {
+        "allowed": {
+          "description": "Allowed is required. True if the action would be allowed, false otherwise.",
+          "type": "boolean"
+        },
+        "denied": {
+          "description": "Denied is optional. True if the action would be denied, otherwise false. If both allowed is false and denied is false, then the authorizer has no opinion on whether to authorize the action. Denied may not be true if Allowed is true.",
+          "type": "boolean"
+        },
+        "evaluationError": {
+          "description": "EvaluationError is an indication that some error occurred during the authorization check. It is entirely possible to get an error and be able to continue determine authorization status in spite of it. For instance, RBAC can be missing a role, but enough roles are still present and bound to reason about the request.",
+          "type": "string"
+        },
+        "reason": {
+          "description": "Reason is optional.  It indicates why a request was allowed or denied.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "allowed"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.authorization.v1beta1.SubjectRulesReviewStatus": {
+      "description": "SubjectRulesReviewStatus contains the result of a rules check. This check can be incomplete depending on the set of authorizers the server is configured with and any errors experienced during evaluation. Because authorization rules are additive, if a rule appears in a list it's safe to assume the subject has that permission, even if that list is incomplete.",
+      "properties": {
+        "evaluationError": {
+          "description": "EvaluationError can appear in combination with Rules. It indicates an error occurred during rule evaluation, such as an authorizer that doesn't support rule evaluation, and that ResourceRules and/or NonResourceRules may be incomplete.",
+          "type": "string"
+        },
+        "incomplete": {
+          "description": "Incomplete is true when the rules returned by this call are incomplete. This is most commonly encountered when an authorizer, such as an external authorizer, doesn't support rules evaluation.",
+          "type": "boolean"
+        },
+        "nonResourceRules": {
+          "description": "NonResourceRules is the list of actions the subject is allowed to perform on non-resources. The list ordering isn't significant, may contain duplicates, and possibly be incomplete.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.authorization.v1beta1.NonResourceRule"
+          },
+          "type": "array"
+        },
+        "resourceRules": {
+          "description": "ResourceRules is the list of actions the subject is allowed to perform on resources. The list ordering isn't significant, may contain duplicates, and possibly be incomplete.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.authorization.v1beta1.ResourceRule"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "resourceRules",
+        "nonResourceRules",
+        "incomplete"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.autoscaling.v1.CrossVersionObjectReference": {
+      "description": "CrossVersionObjectReference contains enough information to let you identify the referred resource.",
+      "properties": {
+        "apiVersion": {
+          "description": "API version of the referent",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds\"",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+          "type": "string"
+        }
+      },
+      "required": [
+        "kind",
+        "name"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.autoscaling.v1.HorizontalPodAutoscaler": {
+      "description": "configuration of a horizontal pod autoscaler.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "HorizontalPodAutoscaler"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v1.HorizontalPodAutoscalerSpec",
+          "description": "behaviour of autoscaler. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status."
+        },
+        "status": {
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v1.HorizontalPodAutoscalerStatus",
+          "description": "current information about the autoscaler."
+        }
+      },
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "autoscaling",
+          "kind": "HorizontalPodAutoscaler",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.autoscaling.v1.HorizontalPodAutoscalerList": {
+      "description": "list of horizontal pod autoscaler objects.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "list of horizontal pod autoscaler objects.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.autoscaling.v1.HorizontalPodAutoscaler"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "HorizontalPodAutoscalerList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "Standard list metadata."
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "autoscaling",
+          "kind": "HorizontalPodAutoscalerList",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.autoscaling.v1.HorizontalPodAutoscalerSpec": {
+      "description": "specification of a horizontal pod autoscaler.",
+      "properties": {
+        "maxReplicas": {
+          "description": "upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "minReplicas": {
+          "description": "lower limit for the number of pods that can be set by the autoscaler, default 1.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "scaleTargetRef": {
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v1.CrossVersionObjectReference",
+          "description": "reference to scaled resource; horizontal pod autoscaler will learn the current resource consumption and will set the desired number of pods by using its Scale subresource."
+        },
+        "targetCPUUtilizationPercentage": {
+          "description": "target average CPU utilization (represented as a percentage of requested CPU) over all the pods; if not specified the default autoscaling policy will be used.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "scaleTargetRef",
+        "maxReplicas"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.autoscaling.v1.HorizontalPodAutoscalerStatus": {
+      "description": "current status of a horizontal pod autoscaler",
+      "properties": {
+        "currentCPUUtilizationPercentage": {
+          "description": "current average CPU utilization over all pods, represented as a percentage of requested CPU, e.g. 70 means that an average pod is using now 70% of its requested CPU.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "currentReplicas": {
+          "description": "current number of replicas of pods managed by this autoscaler.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "desiredReplicas": {
+          "description": "desired number of replicas of pods managed by this autoscaler.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "lastScaleTime": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "last time the HorizontalPodAutoscaler scaled the number of pods; used by the autoscaler to control how often the number of pods is changed."
+        },
+        "observedGeneration": {
+          "description": "most recent generation observed by this autoscaler.",
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "currentReplicas",
+        "desiredReplicas"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.autoscaling.v1.Scale": {
+      "description": "Scale represents a scaling request for a resource.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "Scale"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata."
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v1.ScaleSpec",
+          "description": "defines the behavior of the scale. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status."
+        },
+        "status": {
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v1.ScaleStatus",
+          "description": "current status of the scale. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status. Read-only."
+        }
+      },
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "autoscaling",
+          "kind": "Scale",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.autoscaling.v1.ScaleSpec": {
+      "description": "ScaleSpec describes the attributes of a scale subresource.",
+      "properties": {
+        "replicas": {
+          "description": "desired number of instances for the scaled object.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.autoscaling.v1.ScaleStatus": {
+      "description": "ScaleStatus represents the current status of a scale subresource.",
+      "properties": {
+        "replicas": {
+          "description": "actual number of observed instances of the scaled object.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "selector": {
+          "description": "label query over pods that should match the replicas count. This is same as the label selector but in the string format to avoid introspection by clients. The string will be in the same format as the query-param syntax. More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors",
+          "type": "string"
+        }
+      },
+      "required": [
+        "replicas"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.autoscaling.v2beta1.CrossVersionObjectReference": {
+      "description": "CrossVersionObjectReference contains enough information to let you identify the referred resource.",
+      "properties": {
+        "apiVersion": {
+          "description": "API version of the referent",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds\"",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+          "type": "string"
+        }
+      },
+      "required": [
+        "kind",
+        "name"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.autoscaling.v2beta1.ExternalMetricSource": {
+      "description": "ExternalMetricSource indicates how to scale on a metric not associated with any Kubernetes object (for example length of queue in cloud messaging service, or QPS from loadbalancer running outside of cluster). Exactly one \"target\" type should be set.",
+      "properties": {
+        "metricName": {
+          "description": "metricName is the name of the metric in question.",
+          "type": "string"
+        },
+        "metricSelector": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+          "description": "metricSelector is used to identify a specific time series within a given metric."
+        },
+        "targetAverageValue": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity",
+          "description": "targetAverageValue is the target per-pod value of global metric (as a quantity). Mutually exclusive with TargetValue."
+        },
+        "targetValue": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity",
+          "description": "targetValue is the target value of the metric (as a quantity). Mutually exclusive with TargetAverageValue."
+        }
+      },
+      "required": [
+        "metricName"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.autoscaling.v2beta1.ExternalMetricStatus": {
+      "description": "ExternalMetricStatus indicates the current value of a global metric not associated with any Kubernetes object.",
+      "properties": {
+        "currentAverageValue": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity",
+          "description": "currentAverageValue is the current value of metric averaged over autoscaled pods."
+        },
+        "currentValue": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity",
+          "description": "currentValue is the current value of the metric (as a quantity)"
+        },
+        "metricName": {
+          "description": "metricName is the name of a metric used for autoscaling in metric system.",
+          "type": "string"
+        },
+        "metricSelector": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+          "description": "metricSelector is used to identify a specific time series within a given metric."
+        }
+      },
+      "required": [
+        "metricName",
+        "currentValue"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.autoscaling.v2beta1.HorizontalPodAutoscaler": {
+      "description": "HorizontalPodAutoscaler is the configuration for a horizontal pod autoscaler, which automatically manages the replica count of any resource implementing the scale subresource based on the metrics specified.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "HorizontalPodAutoscaler"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "metadata is the standard object metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v2beta1.HorizontalPodAutoscalerSpec",
+          "description": "spec is the specification for the behaviour of the autoscaler. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status."
+        },
+        "status": {
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v2beta1.HorizontalPodAutoscalerStatus",
+          "description": "status is the current information about the autoscaler."
+        }
+      },
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "autoscaling",
+          "kind": "HorizontalPodAutoscaler",
+          "version": "v2beta1"
+        }
+      ]
+    },
+    "io.k8s.api.autoscaling.v2beta1.HorizontalPodAutoscalerCondition": {
+      "description": "HorizontalPodAutoscalerCondition describes the state of a HorizontalPodAutoscaler at a certain point.",
+      "properties": {
+        "lastTransitionTime": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "lastTransitionTime is the last time the condition transitioned from one status to another"
+        },
+        "message": {
+          "description": "message is a human-readable explanation containing details about the transition",
+          "type": "string"
+        },
+        "reason": {
+          "description": "reason is the reason for the condition's last transition.",
+          "type": "string"
+        },
+        "status": {
+          "description": "status is the status of the condition (True, False, Unknown)",
+          "type": "string"
+        },
+        "type": {
+          "description": "type describes the current condition",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "status"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.autoscaling.v2beta1.HorizontalPodAutoscalerList": {
+      "description": "HorizontalPodAutoscaler is a list of horizontal pod autoscaler objects.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "items is the list of horizontal pod autoscaler objects.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.autoscaling.v2beta1.HorizontalPodAutoscaler"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "HorizontalPodAutoscalerList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "metadata is the standard list metadata."
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "autoscaling",
+          "kind": "HorizontalPodAutoscalerList",
+          "version": "v2beta1"
+        }
+      ]
+    },
+    "io.k8s.api.autoscaling.v2beta1.HorizontalPodAutoscalerSpec": {
+      "description": "HorizontalPodAutoscalerSpec describes the desired functionality of the HorizontalPodAutoscaler.",
+      "properties": {
+        "maxReplicas": {
+          "description": "maxReplicas is the upper limit for the number of replicas to which the autoscaler can scale up. It cannot be less that minReplicas.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "metrics": {
+          "description": "metrics contains the specifications for which to use to calculate the desired replica count (the maximum replica count across all metrics will be used).  The desired replica count is calculated multiplying the ratio between the target value and the current value by the current number of pods.  Ergo, metrics used must decrease as the pod count is increased, and vice-versa.  See the individual metric source types for more information about how each type of metric must respond.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.autoscaling.v2beta1.MetricSpec"
+          },
+          "type": "array"
+        },
+        "minReplicas": {
+          "description": "minReplicas is the lower limit for the number of replicas to which the autoscaler can scale down. It defaults to 1 pod.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "scaleTargetRef": {
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v2beta1.CrossVersionObjectReference",
+          "description": "scaleTargetRef points to the target resource to scale, and is used to the pods for which metrics should be collected, as well as to actually change the replica count."
+        }
+      },
+      "required": [
+        "scaleTargetRef",
+        "maxReplicas"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.autoscaling.v2beta1.HorizontalPodAutoscalerStatus": {
+      "description": "HorizontalPodAutoscalerStatus describes the current status of a horizontal pod autoscaler.",
+      "properties": {
+        "conditions": {
+          "description": "conditions is the set of conditions required for this autoscaler to scale its target, and indicates whether or not those conditions are met.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.autoscaling.v2beta1.HorizontalPodAutoscalerCondition"
+          },
+          "type": "array"
+        },
+        "currentMetrics": {
+          "description": "currentMetrics is the last read state of the metrics used by this autoscaler.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.autoscaling.v2beta1.MetricStatus"
+          },
+          "type": "array"
+        },
+        "currentReplicas": {
+          "description": "currentReplicas is current number of replicas of pods managed by this autoscaler, as last seen by the autoscaler.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "desiredReplicas": {
+          "description": "desiredReplicas is the desired number of replicas of pods managed by this autoscaler, as last calculated by the autoscaler.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "lastScaleTime": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "lastScaleTime is the last time the HorizontalPodAutoscaler scaled the number of pods, used by the autoscaler to control how often the number of pods is changed."
+        },
+        "observedGeneration": {
+          "description": "observedGeneration is the most recent generation observed by this autoscaler.",
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "currentReplicas",
+        "desiredReplicas",
+        "conditions"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.autoscaling.v2beta1.MetricSpec": {
+      "description": "MetricSpec specifies how to scale based on a single metric (only `type` and one other matching field should be set at once).",
+      "properties": {
+        "external": {
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v2beta1.ExternalMetricSource",
+          "description": "external refers to a global metric that is not associated with any Kubernetes object. It allows autoscaling based on information coming from components running outside of cluster (for example length of queue in cloud messaging service, or QPS from loadbalancer running outside of cluster)."
+        },
+        "object": {
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v2beta1.ObjectMetricSource",
+          "description": "object refers to a metric describing a single kubernetes object (for example, hits-per-second on an Ingress object)."
+        },
+        "pods": {
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v2beta1.PodsMetricSource",
+          "description": "pods refers to a metric describing each pod in the current scale target (for example, transactions-processed-per-second).  The values will be averaged together before being compared to the target value."
+        },
+        "resource": {
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v2beta1.ResourceMetricSource",
+          "description": "resource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing each pod in the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the \"pods\" source."
+        },
+        "type": {
+          "description": "type is the type of metric source.  It should be one of \"Object\", \"Pods\" or \"Resource\", each mapping to a matching field in the object.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.autoscaling.v2beta1.MetricStatus": {
+      "description": "MetricStatus describes the last-read state of a single metric.",
+      "properties": {
+        "external": {
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v2beta1.ExternalMetricStatus",
+          "description": "external refers to a global metric that is not associated with any Kubernetes object. It allows autoscaling based on information coming from components running outside of cluster (for example length of queue in cloud messaging service, or QPS from loadbalancer running outside of cluster)."
+        },
+        "object": {
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v2beta1.ObjectMetricStatus",
+          "description": "object refers to a metric describing a single kubernetes object (for example, hits-per-second on an Ingress object)."
+        },
+        "pods": {
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v2beta1.PodsMetricStatus",
+          "description": "pods refers to a metric describing each pod in the current scale target (for example, transactions-processed-per-second).  The values will be averaged together before being compared to the target value."
+        },
+        "resource": {
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v2beta1.ResourceMetricStatus",
+          "description": "resource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing each pod in the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the \"pods\" source."
+        },
+        "type": {
+          "description": "type is the type of metric source.  It will be one of \"Object\", \"Pods\" or \"Resource\", each corresponds to a matching field in the object.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.autoscaling.v2beta1.ObjectMetricSource": {
+      "description": "ObjectMetricSource indicates how to scale on a metric describing a kubernetes object (for example, hits-per-second on an Ingress object).",
+      "properties": {
+        "averageValue": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity",
+          "description": "averageValue is the target value of the average of the metric across all relevant pods (as a quantity)"
+        },
+        "metricName": {
+          "description": "metricName is the name of the metric in question.",
+          "type": "string"
+        },
+        "selector": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+          "description": "selector is the string-encoded form of a standard kubernetes label selector for the given metric When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping When unset, just the metricName will be used to gather metrics."
+        },
+        "target": {
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v2beta1.CrossVersionObjectReference",
+          "description": "target is the described Kubernetes object."
+        },
+        "targetValue": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity",
+          "description": "targetValue is the target value of the metric (as a quantity)."
+        }
+      },
+      "required": [
+        "target",
+        "metricName",
+        "targetValue"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.autoscaling.v2beta1.ObjectMetricStatus": {
+      "description": "ObjectMetricStatus indicates the current value of a metric describing a kubernetes object (for example, hits-per-second on an Ingress object).",
+      "properties": {
+        "averageValue": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity",
+          "description": "averageValue is the current value of the average of the metric across all relevant pods (as a quantity)"
+        },
+        "currentValue": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity",
+          "description": "currentValue is the current value of the metric (as a quantity)."
+        },
+        "metricName": {
+          "description": "metricName is the name of the metric in question.",
+          "type": "string"
+        },
+        "selector": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+          "description": "selector is the string-encoded form of a standard kubernetes label selector for the given metric When set in the ObjectMetricSource, it is passed as an additional parameter to the metrics server for more specific metrics scoping. When unset, just the metricName will be used to gather metrics."
+        },
+        "target": {
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v2beta1.CrossVersionObjectReference",
+          "description": "target is the described Kubernetes object."
+        }
+      },
+      "required": [
+        "target",
+        "metricName",
+        "currentValue"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.autoscaling.v2beta1.PodsMetricSource": {
+      "description": "PodsMetricSource indicates how to scale on a metric describing each pod in the current scale target (for example, transactions-processed-per-second). The values will be averaged together before being compared to the target value.",
+      "properties": {
+        "metricName": {
+          "description": "metricName is the name of the metric in question",
+          "type": "string"
+        },
+        "selector": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+          "description": "selector is the string-encoded form of a standard kubernetes label selector for the given metric When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping When unset, just the metricName will be used to gather metrics."
+        },
+        "targetAverageValue": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity",
+          "description": "targetAverageValue is the target value of the average of the metric across all relevant pods (as a quantity)"
+        }
+      },
+      "required": [
+        "metricName",
+        "targetAverageValue"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.autoscaling.v2beta1.PodsMetricStatus": {
+      "description": "PodsMetricStatus indicates the current value of a metric describing each pod in the current scale target (for example, transactions-processed-per-second).",
+      "properties": {
+        "currentAverageValue": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity",
+          "description": "currentAverageValue is the current value of the average of the metric across all relevant pods (as a quantity)"
+        },
+        "metricName": {
+          "description": "metricName is the name of the metric in question",
+          "type": "string"
+        },
+        "selector": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+          "description": "selector is the string-encoded form of a standard kubernetes label selector for the given metric When set in the PodsMetricSource, it is passed as an additional parameter to the metrics server for more specific metrics scoping. When unset, just the metricName will be used to gather metrics."
+        }
+      },
+      "required": [
+        "metricName",
+        "currentAverageValue"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.autoscaling.v2beta1.ResourceMetricSource": {
+      "description": "ResourceMetricSource indicates how to scale on a resource metric known to Kubernetes, as specified in requests and limits, describing each pod in the current scale target (e.g. CPU or memory).  The values will be averaged together before being compared to the target.  Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the \"pods\" source.  Only one \"target\" type should be set.",
+      "properties": {
+        "name": {
+          "description": "name is the name of the resource in question.",
+          "type": "string"
+        },
+        "targetAverageUtilization": {
+          "description": "targetAverageUtilization is the target value of the average of the resource metric across all relevant pods, represented as a percentage of the requested value of the resource for the pods.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "targetAverageValue": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity",
+          "description": "targetAverageValue is the target value of the average of the resource metric across all relevant pods, as a raw value (instead of as a percentage of the request), similar to the \"pods\" metric source type."
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.autoscaling.v2beta1.ResourceMetricStatus": {
+      "description": "ResourceMetricStatus indicates the current value of a resource metric known to Kubernetes, as specified in requests and limits, describing each pod in the current scale target (e.g. CPU or memory).  Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the \"pods\" source.",
+      "properties": {
+        "currentAverageUtilization": {
+          "description": "currentAverageUtilization is the current value of the average of the resource metric across all relevant pods, represented as a percentage of the requested value of the resource for the pods.  It will only be present if `targetAverageValue` was set in the corresponding metric specification.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "currentAverageValue": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity",
+          "description": "currentAverageValue is the current value of the average of the resource metric across all relevant pods, as a raw value (instead of as a percentage of the request), similar to the \"pods\" metric source type. It will always be set, regardless of the corresponding metric specification."
+        },
+        "name": {
+          "description": "name is the name of the resource in question.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "currentAverageValue"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.autoscaling.v2beta2.CrossVersionObjectReference": {
+      "description": "CrossVersionObjectReference contains enough information to let you identify the referred resource.",
+      "properties": {
+        "apiVersion": {
+          "description": "API version of the referent",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds\"",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+          "type": "string"
+        }
+      },
+      "required": [
+        "kind",
+        "name"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.autoscaling.v2beta2.ExternalMetricSource": {
+      "description": "ExternalMetricSource indicates how to scale on a metric not associated with any Kubernetes object (for example length of queue in cloud messaging service, or QPS from loadbalancer running outside of cluster).",
+      "properties": {
+        "metric": {
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v2beta2.MetricIdentifier",
+          "description": "metric identifies the target metric by name and selector"
+        },
+        "target": {
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v2beta2.MetricTarget",
+          "description": "target specifies the target value for the given metric"
+        }
+      },
+      "required": [
+        "metric",
+        "target"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.autoscaling.v2beta2.ExternalMetricStatus": {
+      "description": "ExternalMetricStatus indicates the current value of a global metric not associated with any Kubernetes object.",
+      "properties": {
+        "current": {
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v2beta2.MetricValueStatus",
+          "description": "current contains the current value for the given metric"
+        },
+        "metric": {
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v2beta2.MetricIdentifier",
+          "description": "metric identifies the target metric by name and selector"
+        }
+      },
+      "required": [
+        "metric",
+        "current"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscaler": {
+      "description": "HorizontalPodAutoscaler is the configuration for a horizontal pod autoscaler, which automatically manages the replica count of any resource implementing the scale subresource based on the metrics specified.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "HorizontalPodAutoscaler"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "metadata is the standard object metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerSpec",
+          "description": "spec is the specification for the behaviour of the autoscaler. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status."
+        },
+        "status": {
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerStatus",
+          "description": "status is the current information about the autoscaler."
+        }
+      },
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "autoscaling",
+          "kind": "HorizontalPodAutoscaler",
+          "version": "v2beta2"
+        }
+      ]
+    },
+    "io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerCondition": {
+      "description": "HorizontalPodAutoscalerCondition describes the state of a HorizontalPodAutoscaler at a certain point.",
+      "properties": {
+        "lastTransitionTime": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "lastTransitionTime is the last time the condition transitioned from one status to another"
+        },
+        "message": {
+          "description": "message is a human-readable explanation containing details about the transition",
+          "type": "string"
+        },
+        "reason": {
+          "description": "reason is the reason for the condition's last transition.",
+          "type": "string"
+        },
+        "status": {
+          "description": "status is the status of the condition (True, False, Unknown)",
+          "type": "string"
+        },
+        "type": {
+          "description": "type describes the current condition",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "status"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerList": {
+      "description": "HorizontalPodAutoscalerList is a list of horizontal pod autoscaler objects.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "items is the list of horizontal pod autoscaler objects.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscaler"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "HorizontalPodAutoscalerList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "metadata is the standard list metadata."
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "autoscaling",
+          "kind": "HorizontalPodAutoscalerList",
+          "version": "v2beta2"
+        }
+      ]
+    },
+    "io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerSpec": {
+      "description": "HorizontalPodAutoscalerSpec describes the desired functionality of the HorizontalPodAutoscaler.",
+      "properties": {
+        "maxReplicas": {
+          "description": "maxReplicas is the upper limit for the number of replicas to which the autoscaler can scale up. It cannot be less that minReplicas.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "metrics": {
+          "description": "metrics contains the specifications for which to use to calculate the desired replica count (the maximum replica count across all metrics will be used).  The desired replica count is calculated multiplying the ratio between the target value and the current value by the current number of pods.  Ergo, metrics used must decrease as the pod count is increased, and vice-versa.  See the individual metric source types for more information about how each type of metric must respond. If not set, the default metric will be set to 80% average CPU utilization.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.autoscaling.v2beta2.MetricSpec"
+          },
+          "type": "array"
+        },
+        "minReplicas": {
+          "description": "minReplicas is the lower limit for the number of replicas to which the autoscaler can scale down. It defaults to 1 pod.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "scaleTargetRef": {
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v2beta2.CrossVersionObjectReference",
+          "description": "scaleTargetRef points to the target resource to scale, and is used to the pods for which metrics should be collected, as well as to actually change the replica count."
+        }
+      },
+      "required": [
+        "scaleTargetRef",
+        "maxReplicas"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerStatus": {
+      "description": "HorizontalPodAutoscalerStatus describes the current status of a horizontal pod autoscaler.",
+      "properties": {
+        "conditions": {
+          "description": "conditions is the set of conditions required for this autoscaler to scale its target, and indicates whether or not those conditions are met.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerCondition"
+          },
+          "type": "array"
+        },
+        "currentMetrics": {
+          "description": "currentMetrics is the last read state of the metrics used by this autoscaler.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.autoscaling.v2beta2.MetricStatus"
+          },
+          "type": "array"
+        },
+        "currentReplicas": {
+          "description": "currentReplicas is current number of replicas of pods managed by this autoscaler, as last seen by the autoscaler.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "desiredReplicas": {
+          "description": "desiredReplicas is the desired number of replicas of pods managed by this autoscaler, as last calculated by the autoscaler.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "lastScaleTime": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "lastScaleTime is the last time the HorizontalPodAutoscaler scaled the number of pods, used by the autoscaler to control how often the number of pods is changed."
+        },
+        "observedGeneration": {
+          "description": "observedGeneration is the most recent generation observed by this autoscaler.",
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "currentReplicas",
+        "desiredReplicas",
+        "conditions"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.autoscaling.v2beta2.MetricIdentifier": {
+      "description": "MetricIdentifier defines the name and optionally selector for a metric",
+      "properties": {
+        "name": {
+          "description": "name is the name of the given metric",
+          "type": "string"
+        },
+        "selector": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+          "description": "selector is the string-encoded form of a standard kubernetes label selector for the given metric When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping. When unset, just the metricName will be used to gather metrics."
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.autoscaling.v2beta2.MetricSpec": {
+      "description": "MetricSpec specifies how to scale based on a single metric (only `type` and one other matching field should be set at once).",
+      "properties": {
+        "external": {
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v2beta2.ExternalMetricSource",
+          "description": "external refers to a global metric that is not associated with any Kubernetes object. It allows autoscaling based on information coming from components running outside of cluster (for example length of queue in cloud messaging service, or QPS from loadbalancer running outside of cluster)."
+        },
+        "object": {
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v2beta2.ObjectMetricSource",
+          "description": "object refers to a metric describing a single kubernetes object (for example, hits-per-second on an Ingress object)."
+        },
+        "pods": {
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v2beta2.PodsMetricSource",
+          "description": "pods refers to a metric describing each pod in the current scale target (for example, transactions-processed-per-second).  The values will be averaged together before being compared to the target value."
+        },
+        "resource": {
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v2beta2.ResourceMetricSource",
+          "description": "resource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing each pod in the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the \"pods\" source."
+        },
+        "type": {
+          "description": "type is the type of metric source.  It should be one of \"Object\", \"Pods\" or \"Resource\", each mapping to a matching field in the object.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.autoscaling.v2beta2.MetricStatus": {
+      "description": "MetricStatus describes the last-read state of a single metric.",
+      "properties": {
+        "external": {
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v2beta2.ExternalMetricStatus",
+          "description": "external refers to a global metric that is not associated with any Kubernetes object. It allows autoscaling based on information coming from components running outside of cluster (for example length of queue in cloud messaging service, or QPS from loadbalancer running outside of cluster)."
+        },
+        "object": {
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v2beta2.ObjectMetricStatus",
+          "description": "object refers to a metric describing a single kubernetes object (for example, hits-per-second on an Ingress object)."
+        },
+        "pods": {
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v2beta2.PodsMetricStatus",
+          "description": "pods refers to a metric describing each pod in the current scale target (for example, transactions-processed-per-second).  The values will be averaged together before being compared to the target value."
+        },
+        "resource": {
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v2beta2.ResourceMetricStatus",
+          "description": "resource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing each pod in the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the \"pods\" source."
+        },
+        "type": {
+          "description": "type is the type of metric source.  It will be one of \"Object\", \"Pods\" or \"Resource\", each corresponds to a matching field in the object.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.autoscaling.v2beta2.MetricTarget": {
+      "description": "MetricTarget defines the target value, average value, or average utilization of a specific metric",
+      "properties": {
+        "averageUtilization": {
+          "description": "averageUtilization is the target value of the average of the resource metric across all relevant pods, represented as a percentage of the requested value of the resource for the pods. Currently only valid for Resource metric source type",
+          "format": "int32",
+          "type": "integer"
+        },
+        "averageValue": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity",
+          "description": "averageValue is the target value of the average of the metric across all relevant pods (as a quantity)"
+        },
+        "type": {
+          "description": "type represents whether the metric type is Utilization, Value, or AverageValue",
+          "type": "string"
+        },
+        "value": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity",
+          "description": "value is the target value of the metric (as a quantity)."
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.autoscaling.v2beta2.MetricValueStatus": {
+      "description": "MetricValueStatus holds the current value for a metric",
+      "properties": {
+        "averageUtilization": {
+          "description": "currentAverageUtilization is the current value of the average of the resource metric across all relevant pods, represented as a percentage of the requested value of the resource for the pods.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "averageValue": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity",
+          "description": "averageValue is the current value of the average of the metric across all relevant pods (as a quantity)"
+        },
+        "value": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity",
+          "description": "value is the current value of the metric (as a quantity)."
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.autoscaling.v2beta2.ObjectMetricSource": {
+      "description": "ObjectMetricSource indicates how to scale on a metric describing a kubernetes object (for example, hits-per-second on an Ingress object).",
+      "properties": {
+        "describedObject": {
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v2beta2.CrossVersionObjectReference"
+        },
+        "metric": {
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v2beta2.MetricIdentifier",
+          "description": "metric identifies the target metric by name and selector"
+        },
+        "target": {
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v2beta2.MetricTarget",
+          "description": "target specifies the target value for the given metric"
+        }
+      },
+      "required": [
+        "describedObject",
+        "target",
+        "metric"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.autoscaling.v2beta2.ObjectMetricStatus": {
+      "description": "ObjectMetricStatus indicates the current value of a metric describing a kubernetes object (for example, hits-per-second on an Ingress object).",
+      "properties": {
+        "current": {
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v2beta2.MetricValueStatus",
+          "description": "current contains the current value for the given metric"
+        },
+        "describedObject": {
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v2beta2.CrossVersionObjectReference"
+        },
+        "metric": {
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v2beta2.MetricIdentifier",
+          "description": "metric identifies the target metric by name and selector"
+        }
+      },
+      "required": [
+        "metric",
+        "current",
+        "describedObject"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.autoscaling.v2beta2.PodsMetricSource": {
+      "description": "PodsMetricSource indicates how to scale on a metric describing each pod in the current scale target (for example, transactions-processed-per-second). The values will be averaged together before being compared to the target value.",
+      "properties": {
+        "metric": {
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v2beta2.MetricIdentifier",
+          "description": "metric identifies the target metric by name and selector"
+        },
+        "target": {
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v2beta2.MetricTarget",
+          "description": "target specifies the target value for the given metric"
+        }
+      },
+      "required": [
+        "metric",
+        "target"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.autoscaling.v2beta2.PodsMetricStatus": {
+      "description": "PodsMetricStatus indicates the current value of a metric describing each pod in the current scale target (for example, transactions-processed-per-second).",
+      "properties": {
+        "current": {
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v2beta2.MetricValueStatus",
+          "description": "current contains the current value for the given metric"
+        },
+        "metric": {
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v2beta2.MetricIdentifier",
+          "description": "metric identifies the target metric by name and selector"
+        }
+      },
+      "required": [
+        "metric",
+        "current"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.autoscaling.v2beta2.ResourceMetricSource": {
+      "description": "ResourceMetricSource indicates how to scale on a resource metric known to Kubernetes, as specified in requests and limits, describing each pod in the current scale target (e.g. CPU or memory).  The values will be averaged together before being compared to the target.  Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the \"pods\" source.  Only one \"target\" type should be set.",
+      "properties": {
+        "name": {
+          "description": "name is the name of the resource in question.",
+          "type": "string"
+        },
+        "target": {
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v2beta2.MetricTarget",
+          "description": "target specifies the target value for the given metric"
+        }
+      },
+      "required": [
+        "name",
+        "target"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.autoscaling.v2beta2.ResourceMetricStatus": {
+      "description": "ResourceMetricStatus indicates the current value of a resource metric known to Kubernetes, as specified in requests and limits, describing each pod in the current scale target (e.g. CPU or memory).  Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the \"pods\" source.",
+      "properties": {
+        "current": {
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v2beta2.MetricValueStatus",
+          "description": "current contains the current value for the given metric"
+        },
+        "name": {
+          "description": "Name is the name of the resource in question.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "current"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.batch.v1.Job": {
+      "description": "Job represents the configuration of a single job.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "Job"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.batch.v1.JobSpec",
+          "description": "Specification of the desired behavior of a job. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status"
+        },
+        "status": {
+          "$ref": "#/definitions/io.k8s.api.batch.v1.JobStatus",
+          "description": "Current status of a job. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status"
+        }
+      },
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "batch",
+          "kind": "Job",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.batch.v1.JobCondition": {
+      "description": "JobCondition describes current state of a job.",
+      "properties": {
+        "lastProbeTime": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "Last time the condition was checked."
+        },
+        "lastTransitionTime": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "Last time the condition transit from one status to another."
+        },
+        "message": {
+          "description": "Human readable message indicating details about last transition.",
+          "type": "string"
+        },
+        "reason": {
+          "description": "(brief) reason for the condition's last transition.",
+          "type": "string"
+        },
+        "status": {
+          "description": "Status of the condition, one of True, False, Unknown.",
+          "type": "string"
+        },
+        "type": {
+          "description": "Type of job condition, Complete or Failed.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "status"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.batch.v1.JobList": {
+      "description": "JobList is a collection of jobs.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "items is the list of Jobs.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.batch.v1.Job"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "JobList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "batch",
+          "kind": "JobList",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.batch.v1.JobSpec": {
+      "description": "JobSpec describes how the job execution will look like.",
+      "properties": {
+        "activeDeadlineSeconds": {
+          "description": "Specifies the duration in seconds relative to the startTime that the job may be active before the system tries to terminate it; value must be positive integer",
+          "format": "int64",
+          "type": "integer"
+        },
+        "backoffLimit": {
+          "description": "Specifies the number of retries before marking this job failed. Defaults to 6",
+          "format": "int32",
+          "type": "integer"
+        },
+        "completions": {
+          "description": "Specifies the desired number of successfully finished pods the job should be run with.  Setting to nil means that the success of any pod signals the success of all pods, and allows parallelism to have any positive value.  Setting to 1 means that parallelism is limited to 1 and the success of that pod signals the success of the job. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/",
+          "format": "int32",
+          "type": "integer"
+        },
+        "manualSelector": {
+          "description": "manualSelector controls generation of pod labels and pod selectors. Leave `manualSelector` unset unless you are certain what you are doing. When false or unset, the system pick labels unique to this job and appends those labels to the pod template.  When true, the user is responsible for picking unique labels and specifying the selector.  Failure to pick a unique label may cause this and other jobs to not function correctly.  However, You may see `manualSelector=true` in jobs that were created with the old `extensions/v1beta1` API. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/#specifying-your-own-pod-selector",
+          "type": "boolean"
+        },
+        "parallelism": {
+          "description": "Specifies the maximum desired number of pods the job should run at any given time. The actual number of pods running in steady state will be less than this number when ((.spec.completions - .status.successful) < .spec.parallelism), i.e. when the work left to do is less than max parallelism. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/",
+          "format": "int32",
+          "type": "integer"
+        },
+        "selector": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+          "description": "A label query over pods that should match the pod count. Normally, the system sets this field for you. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors"
+        },
+        "template": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.PodTemplateSpec",
+          "description": "Describes the pod that will be created when executing a job. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/"
+        },
+        "ttlSecondsAfterFinished": {
+          "description": "ttlSecondsAfterFinished limits the lifetime of a Job that has finished execution (either Complete or Failed). If this field is set, ttlSecondsAfterFinished after the Job finishes, it is eligible to be automatically deleted. When the Job is being deleted, its lifecycle guarantees (e.g. finalizers) will be honored. If this field is unset, the Job won't be automatically deleted. If this field is set to zero, the Job becomes eligible to be deleted immediately after it finishes. This field is alpha-level and is only honored by servers that enable the TTLAfterFinished feature.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "template"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.batch.v1.JobStatus": {
+      "description": "JobStatus represents the current state of a Job.",
+      "properties": {
+        "active": {
+          "description": "The number of actively running pods.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "completionTime": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "Represents time when the job was completed. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC."
+        },
+        "conditions": {
+          "description": "The latest available observations of an object's current state. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.batch.v1.JobCondition"
+          },
+          "type": "array",
+          "x-kubernetes-patch-merge-key": "type",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "failed": {
+          "description": "The number of pods which reached phase Failed.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "startTime": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "Represents time when the job was acknowledged by the job controller. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC."
+        },
+        "succeeded": {
+          "description": "The number of pods which reached phase Succeeded.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.batch.v1beta1.CronJob": {
+      "description": "CronJob represents the configuration of a single cron job.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "CronJob"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.batch.v1beta1.CronJobSpec",
+          "description": "Specification of the desired behavior of a cron job, including the schedule. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status"
+        },
+        "status": {
+          "$ref": "#/definitions/io.k8s.api.batch.v1beta1.CronJobStatus",
+          "description": "Current status of a cron job. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status"
+        }
+      },
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "batch",
+          "kind": "CronJob",
+          "version": "v1beta1"
+        }
+      ]
+    },
+    "io.k8s.api.batch.v1beta1.CronJobList": {
+      "description": "CronJobList is a collection of cron jobs.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "items is the list of CronJobs.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.batch.v1beta1.CronJob"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "CronJobList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "batch",
+          "kind": "CronJobList",
+          "version": "v1beta1"
+        }
+      ]
+    },
+    "io.k8s.api.batch.v1beta1.CronJobSpec": {
+      "description": "CronJobSpec describes how the job execution will look like and when it will actually run.",
+      "properties": {
+        "concurrencyPolicy": {
+          "description": "Specifies how to treat concurrent executions of a Job. Valid values are: - \"Allow\" (default): allows CronJobs to run concurrently; - \"Forbid\": forbids concurrent runs, skipping next run if previous run hasn't finished yet; - \"Replace\": cancels currently running job and replaces it with a new one",
+          "type": "string"
+        },
+        "failedJobsHistoryLimit": {
+          "description": "The number of failed finished jobs to retain. This is a pointer to distinguish between explicit zero and not specified. Defaults to 1.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "jobTemplate": {
+          "$ref": "#/definitions/io.k8s.api.batch.v1beta1.JobTemplateSpec",
+          "description": "Specifies the job that will be created when executing a CronJob."
+        },
+        "schedule": {
+          "description": "The schedule in Cron format, see https://en.wikipedia.org/wiki/Cron.",
+          "type": "string"
+        },
+        "startingDeadlineSeconds": {
+          "description": "Optional deadline in seconds for starting the job if it misses scheduled time for any reason.  Missed jobs executions will be counted as failed ones.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "successfulJobsHistoryLimit": {
+          "description": "The number of successful finished jobs to retain. This is a pointer to distinguish between explicit zero and not specified. Defaults to 3.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "suspend": {
+          "description": "This flag tells the controller to suspend subsequent executions, it does not apply to already started executions.  Defaults to false.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "schedule",
+        "jobTemplate"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.batch.v1beta1.CronJobStatus": {
+      "description": "CronJobStatus represents the current state of a cron job.",
+      "properties": {
+        "active": {
+          "description": "A list of pointers to currently running jobs.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.ObjectReference"
+          },
+          "type": "array"
+        },
+        "lastScheduleTime": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "Information when was the last time the job was successfully scheduled."
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.batch.v1beta1.JobTemplateSpec": {
+      "description": "JobTemplateSpec describes the data a Job should have when created from a template",
+      "properties": {
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object's metadata of the jobs created from this template. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.batch.v1.JobSpec",
+          "description": "Specification of the desired behavior of the job. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.batch.v2alpha1.CronJob": {
+      "description": "CronJob represents the configuration of a single cron job.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "CronJob"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.batch.v2alpha1.CronJobSpec",
+          "description": "Specification of the desired behavior of a cron job, including the schedule. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status"
+        },
+        "status": {
+          "$ref": "#/definitions/io.k8s.api.batch.v2alpha1.CronJobStatus",
+          "description": "Current status of a cron job. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status"
+        }
+      },
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "batch",
+          "kind": "CronJob",
+          "version": "v2alpha1"
+        }
+      ]
+    },
+    "io.k8s.api.batch.v2alpha1.CronJobList": {
+      "description": "CronJobList is a collection of cron jobs.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "items is the list of CronJobs.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.batch.v2alpha1.CronJob"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "CronJobList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "batch",
+          "kind": "CronJobList",
+          "version": "v2alpha1"
+        }
+      ]
+    },
+    "io.k8s.api.batch.v2alpha1.CronJobSpec": {
+      "description": "CronJobSpec describes how the job execution will look like and when it will actually run.",
+      "properties": {
+        "concurrencyPolicy": {
+          "description": "Specifies how to treat concurrent executions of a Job. Valid values are: - \"Allow\" (default): allows CronJobs to run concurrently; - \"Forbid\": forbids concurrent runs, skipping next run if previous run hasn't finished yet; - \"Replace\": cancels currently running job and replaces it with a new one",
+          "type": "string"
+        },
+        "failedJobsHistoryLimit": {
+          "description": "The number of failed finished jobs to retain. This is a pointer to distinguish between explicit zero and not specified.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "jobTemplate": {
+          "$ref": "#/definitions/io.k8s.api.batch.v2alpha1.JobTemplateSpec",
+          "description": "Specifies the job that will be created when executing a CronJob."
+        },
+        "schedule": {
+          "description": "The schedule in Cron format, see https://en.wikipedia.org/wiki/Cron.",
+          "type": "string"
+        },
+        "startingDeadlineSeconds": {
+          "description": "Optional deadline in seconds for starting the job if it misses scheduled time for any reason.  Missed jobs executions will be counted as failed ones.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "successfulJobsHistoryLimit": {
+          "description": "The number of successful finished jobs to retain. This is a pointer to distinguish between explicit zero and not specified.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "suspend": {
+          "description": "This flag tells the controller to suspend subsequent executions, it does not apply to already started executions.  Defaults to false.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "schedule",
+        "jobTemplate"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.batch.v2alpha1.CronJobStatus": {
+      "description": "CronJobStatus represents the current state of a cron job.",
+      "properties": {
+        "active": {
+          "description": "A list of pointers to currently running jobs.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.ObjectReference"
+          },
+          "type": "array"
+        },
+        "lastScheduleTime": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "Information when was the last time the job was successfully scheduled."
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.batch.v2alpha1.JobTemplateSpec": {
+      "description": "JobTemplateSpec describes the data a Job should have when created from a template",
+      "properties": {
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object's metadata of the jobs created from this template. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.batch.v1.JobSpec",
+          "description": "Specification of the desired behavior of the job. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.certificates.v1beta1.CertificateSigningRequest": {
+      "description": "Describes a certificate signing request",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "CertificateSigningRequest"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.certificates.v1beta1.CertificateSigningRequestSpec",
+          "description": "The certificate request itself and any additional information."
+        },
+        "status": {
+          "$ref": "#/definitions/io.k8s.api.certificates.v1beta1.CertificateSigningRequestStatus",
+          "description": "Derived information about the request."
+        }
+      },
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "certificates.k8s.io",
+          "kind": "CertificateSigningRequest",
+          "version": "v1beta1"
+        }
+      ]
+    },
+    "io.k8s.api.certificates.v1beta1.CertificateSigningRequestCondition": {
+      "properties": {
+        "lastUpdateTime": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "timestamp for the last update to this condition"
+        },
+        "message": {
+          "description": "human readable message with details about the request state",
+          "type": "string"
+        },
+        "reason": {
+          "description": "brief reason for the request state",
+          "type": "string"
+        },
+        "type": {
+          "description": "request approval state, currently Approved or Denied.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.certificates.v1beta1.CertificateSigningRequestList": {
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.certificates.v1beta1.CertificateSigningRequest"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "CertificateSigningRequestList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "certificates.k8s.io",
+          "kind": "CertificateSigningRequestList",
+          "version": "v1beta1"
+        }
+      ]
+    },
+    "io.k8s.api.certificates.v1beta1.CertificateSigningRequestSpec": {
+      "description": "This information is immutable after the request is created. Only the Request and Usages fields can be set on creation, other fields are derived by Kubernetes and cannot be modified by users.",
+      "properties": {
+        "extra": {
+          "additionalProperties": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "description": "Extra information about the requesting user. See user.Info interface for details.",
+          "type": "object"
+        },
+        "groups": {
+          "description": "Group information about the requesting user. See user.Info interface for details.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "request": {
+          "description": "Base64-encoded PKCS#10 CSR data",
+          "format": "byte",
+          "type": "string"
+        },
+        "uid": {
+          "description": "UID information about the requesting user. See user.Info interface for details.",
+          "type": "string"
+        },
+        "usages": {
+          "description": "allowedUsages specifies a set of usage contexts the key will be valid for. See: https://tools.ietf.org/html/rfc5280#section-4.2.1.3\n     https://tools.ietf.org/html/rfc5280#section-4.2.1.12",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "username": {
+          "description": "Information about the requesting user. See user.Info interface for details.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "request"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.certificates.v1beta1.CertificateSigningRequestStatus": {
+      "properties": {
+        "certificate": {
+          "description": "If request was approved, the controller will place the issued certificate here.",
+          "format": "byte",
+          "type": "string"
+        },
+        "conditions": {
+          "description": "Conditions applied to the request, such as approval or denial.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.certificates.v1beta1.CertificateSigningRequestCondition"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.coordination.v1.Lease": {
+      "description": "Lease defines a lease concept.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "Lease"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.coordination.v1.LeaseSpec",
+          "description": "Specification of the Lease. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status"
+        }
+      },
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "coordination.k8s.io",
+          "kind": "Lease",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.coordination.v1.LeaseList": {
+      "description": "LeaseList is a list of Lease objects.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "Items is a list of schema objects.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.coordination.v1.Lease"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "LeaseList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "coordination.k8s.io",
+          "kind": "LeaseList",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.coordination.v1.LeaseSpec": {
+      "description": "LeaseSpec is a specification of a Lease.",
+      "properties": {
+        "acquireTime": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime",
+          "description": "acquireTime is a time when the current lease was acquired."
+        },
+        "holderIdentity": {
+          "description": "holderIdentity contains the identity of the holder of a current lease.",
+          "type": "string"
+        },
+        "leaseDurationSeconds": {
+          "description": "leaseDurationSeconds is a duration that candidates for a lease need to wait to force acquire it. This is measure against time of last observed RenewTime.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "leaseTransitions": {
+          "description": "leaseTransitions is the number of transitions of a lease between holders.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "renewTime": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime",
+          "description": "renewTime is a time when the current holder of a lease has last updated the lease."
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.coordination.v1beta1.Lease": {
+      "description": "Lease defines a lease concept.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "Lease"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.coordination.v1beta1.LeaseSpec",
+          "description": "Specification of the Lease. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status"
+        }
+      },
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "coordination.k8s.io",
+          "kind": "Lease",
+          "version": "v1beta1"
+        }
+      ]
+    },
+    "io.k8s.api.coordination.v1beta1.LeaseList": {
+      "description": "LeaseList is a list of Lease objects.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "Items is a list of schema objects.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.coordination.v1beta1.Lease"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "LeaseList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "coordination.k8s.io",
+          "kind": "LeaseList",
+          "version": "v1beta1"
+        }
+      ]
+    },
+    "io.k8s.api.coordination.v1beta1.LeaseSpec": {
+      "description": "LeaseSpec is a specification of a Lease.",
+      "properties": {
+        "acquireTime": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime",
+          "description": "acquireTime is a time when the current lease was acquired."
+        },
+        "holderIdentity": {
+          "description": "holderIdentity contains the identity of the holder of a current lease.",
+          "type": "string"
+        },
+        "leaseDurationSeconds": {
+          "description": "leaseDurationSeconds is a duration that candidates for a lease need to wait to force acquire it. This is measure against time of last observed RenewTime.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "leaseTransitions": {
+          "description": "leaseTransitions is the number of transitions of a lease between holders.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "renewTime": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime",
+          "description": "renewTime is a time when the current holder of a lease has last updated the lease."
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.AWSElasticBlockStoreVolumeSource": {
+      "description": "Represents a Persistent Disk resource in AWS.\n\nAn AWS EBS disk must exist before mounting to a container. The disk must also be in the same AWS zone as the kubelet. An AWS EBS disk can only be mounted as read/write once. AWS EBS volumes support ownership management and SELinux relabeling.",
+      "properties": {
+        "fsType": {
+          "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+          "type": "string"
+        },
+        "partition": {
+          "description": "The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).",
+          "format": "int32",
+          "type": "integer"
+        },
+        "readOnly": {
+          "description": "Specify \"true\" to force and set the ReadOnly property in VolumeMounts to \"true\". If omitted, the default is \"false\". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+          "type": "boolean"
+        },
+        "volumeID": {
+          "description": "Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+          "type": "string"
+        }
+      },
+      "required": [
+        "volumeID"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.Affinity": {
+      "description": "Affinity is a group of affinity scheduling rules.",
+      "properties": {
+        "nodeAffinity": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.NodeAffinity",
+          "description": "Describes node affinity scheduling rules for the pod."
+        },
+        "podAffinity": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.PodAffinity",
+          "description": "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s))."
+        },
+        "podAntiAffinity": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.PodAntiAffinity",
+          "description": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s))."
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.AttachedVolume": {
+      "description": "AttachedVolume describes a volume attached to a node",
+      "properties": {
+        "devicePath": {
+          "description": "DevicePath represents the device path where the volume should be available",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the attached volume",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "devicePath"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.AzureDiskVolumeSource": {
+      "description": "AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.",
+      "properties": {
+        "cachingMode": {
+          "description": "Host Caching mode: None, Read Only, Read Write.",
+          "type": "string"
+        },
+        "diskName": {
+          "description": "The Name of the data disk in the blob storage",
+          "type": "string"
+        },
+        "diskURI": {
+          "description": "The URI the data disk in the blob storage",
+          "type": "string"
+        },
+        "fsType": {
+          "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Expected values Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared",
+          "type": "string"
+        },
+        "readOnly": {
+          "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "diskName",
+        "diskURI"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.AzureFilePersistentVolumeSource": {
+      "description": "AzureFile represents an Azure File Service mount on the host and bind mount to the pod.",
+      "properties": {
+        "readOnly": {
+          "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+          "type": "boolean"
+        },
+        "secretName": {
+          "description": "the name of secret that contains Azure Storage Account Name and Key",
+          "type": "string"
+        },
+        "secretNamespace": {
+          "description": "the namespace of the secret that contains Azure Storage Account Name and Key default is the same as the Pod",
+          "type": "string"
+        },
+        "shareName": {
+          "description": "Share Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "secretName",
+        "shareName"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.AzureFileVolumeSource": {
+      "description": "AzureFile represents an Azure File Service mount on the host and bind mount to the pod.",
+      "properties": {
+        "readOnly": {
+          "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+          "type": "boolean"
+        },
+        "secretName": {
+          "description": "the name of secret that contains Azure Storage Account Name and Key",
+          "type": "string"
+        },
+        "shareName": {
+          "description": "Share Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "secretName",
+        "shareName"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.Binding": {
+      "description": "Binding ties one object to another; for example, a pod is bound to a node by a scheduler. Deprecated in 1.7, please use the bindings subresource of pods instead.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "Binding"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+        },
+        "target": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ObjectReference",
+          "description": "The target object that you want to bind to the standard object."
+        }
+      },
+      "required": [
+        "target"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "",
+          "kind": "Binding",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.core.v1.CSIPersistentVolumeSource": {
+      "description": "Represents storage that is managed by an external CSI volume driver (Beta feature)",
+      "properties": {
+        "controllerPublishSecretRef": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.SecretReference",
+          "description": "ControllerPublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI ControllerPublishVolume and ControllerUnpublishVolume calls. This field is optional, and may be empty if no secret is required. If the secret object contains more than one secret, all secrets are passed."
+        },
+        "driver": {
+          "description": "Driver is the name of the driver to use for this volume. Required.",
+          "type": "string"
+        },
+        "fsType": {
+          "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\".",
+          "type": "string"
+        },
+        "nodePublishSecretRef": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.SecretReference",
+          "description": "NodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and may be empty if no secret is required. If the secret object contains more than one secret, all secrets are passed."
+        },
+        "nodeStageSecretRef": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.SecretReference",
+          "description": "NodeStageSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodeStageVolume and NodeStageVolume and NodeUnstageVolume calls. This field is optional, and may be empty if no secret is required. If the secret object contains more than one secret, all secrets are passed."
+        },
+        "readOnly": {
+          "description": "Optional: The value to pass to ControllerPublishVolumeRequest. Defaults to false (read/write).",
+          "type": "boolean"
+        },
+        "volumeAttributes": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Attributes of the volume to publish.",
+          "type": "object"
+        },
+        "volumeHandle": {
+          "description": "VolumeHandle is the unique volume name returned by the CSI volume plugin\u2019s CreateVolume to refer to the volume on all subsequent calls. Required.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "driver",
+        "volumeHandle"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.CSIVolumeSource": {
+      "description": "Represents a source location of a volume to mount, managed by an external CSI driver",
+      "properties": {
+        "driver": {
+          "description": "Driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.",
+          "type": "string"
+        },
+        "fsType": {
+          "description": "Filesystem type to mount. Ex. \"ext4\", \"xfs\", \"ntfs\". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.",
+          "type": "string"
+        },
+        "nodePublishSecretRef": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference",
+          "description": "NodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed."
+        },
+        "readOnly": {
+          "description": "Specifies a read-only configuration for the volume. Defaults to false (read/write).",
+          "type": "boolean"
+        },
+        "volumeAttributes": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "VolumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.",
+          "type": "object"
+        }
+      },
+      "required": [
+        "driver"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.Capabilities": {
+      "description": "Adds and removes POSIX capabilities from running containers.",
+      "properties": {
+        "add": {
+          "description": "Added capabilities",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "drop": {
+          "description": "Removed capabilities",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.CephFSPersistentVolumeSource": {
+      "description": "Represents a Ceph Filesystem mount that lasts the lifetime of a pod Cephfs volumes do not support ownership management or SELinux relabeling.",
+      "properties": {
+        "monitors": {
+          "description": "Required: Monitors is a collection of Ceph monitors More info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "path": {
+          "description": "Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
+          "type": "string"
+        },
+        "readOnly": {
+          "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it",
+          "type": "boolean"
+        },
+        "secretFile": {
+          "description": "Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it",
+          "type": "string"
+        },
+        "secretRef": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.SecretReference",
+          "description": "Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it"
+        },
+        "user": {
+          "description": "Optional: User is the rados user name, default is admin More info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it",
+          "type": "string"
+        }
+      },
+      "required": [
+        "monitors"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.CephFSVolumeSource": {
+      "description": "Represents a Ceph Filesystem mount that lasts the lifetime of a pod Cephfs volumes do not support ownership management or SELinux relabeling.",
+      "properties": {
+        "monitors": {
+          "description": "Required: Monitors is a collection of Ceph monitors More info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "path": {
+          "description": "Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
+          "type": "string"
+        },
+        "readOnly": {
+          "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it",
+          "type": "boolean"
+        },
+        "secretFile": {
+          "description": "Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it",
+          "type": "string"
+        },
+        "secretRef": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference",
+          "description": "Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it"
+        },
+        "user": {
+          "description": "Optional: User is the rados user name, default is admin More info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it",
+          "type": "string"
+        }
+      },
+      "required": [
+        "monitors"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.CinderPersistentVolumeSource": {
+      "description": "Represents a cinder volume resource in Openstack. A Cinder volume must exist before mounting to a container. The volume must also be in the same region as the kubelet. Cinder volumes support ownership management and SELinux relabeling.",
+      "properties": {
+        "fsType": {
+          "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://releases.k8s.io/HEAD/examples/mysql-cinder-pd/README.md",
+          "type": "string"
+        },
+        "readOnly": {
+          "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://releases.k8s.io/HEAD/examples/mysql-cinder-pd/README.md",
+          "type": "boolean"
+        },
+        "secretRef": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.SecretReference",
+          "description": "Optional: points to a secret object containing parameters used to connect to OpenStack."
+        },
+        "volumeID": {
+          "description": "volume id used to identify the volume in cinder More info: https://releases.k8s.io/HEAD/examples/mysql-cinder-pd/README.md",
+          "type": "string"
+        }
+      },
+      "required": [
+        "volumeID"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.CinderVolumeSource": {
+      "description": "Represents a cinder volume resource in Openstack. A Cinder volume must exist before mounting to a container. The volume must also be in the same region as the kubelet. Cinder volumes support ownership management and SELinux relabeling.",
+      "properties": {
+        "fsType": {
+          "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://releases.k8s.io/HEAD/examples/mysql-cinder-pd/README.md",
+          "type": "string"
+        },
+        "readOnly": {
+          "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://releases.k8s.io/HEAD/examples/mysql-cinder-pd/README.md",
+          "type": "boolean"
+        },
+        "secretRef": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference",
+          "description": "Optional: points to a secret object containing parameters used to connect to OpenStack."
+        },
+        "volumeID": {
+          "description": "volume id used to identify the volume in cinder More info: https://releases.k8s.io/HEAD/examples/mysql-cinder-pd/README.md",
+          "type": "string"
+        }
+      },
+      "required": [
+        "volumeID"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ClientIPConfig": {
+      "description": "ClientIPConfig represents the configurations of Client IP based session affinity.",
+      "properties": {
+        "timeoutSeconds": {
+          "description": "timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && <=86400(for 1 day) if ServiceAffinity == \"ClientIP\". Default value is 10800(for 3 hours).",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ComponentCondition": {
+      "description": "Information about the condition of a component.",
+      "properties": {
+        "error": {
+          "description": "Condition error code for a component. For example, a health check error code.",
+          "type": "string"
+        },
+        "message": {
+          "description": "Message about the condition for a component. For example, information about a health check.",
+          "type": "string"
+        },
+        "status": {
+          "description": "Status of the condition for a component. Valid values for \"Healthy\": \"True\", \"False\", or \"Unknown\".",
+          "type": "string"
+        },
+        "type": {
+          "description": "Type of condition for a component. Valid value: \"Healthy\"",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "status"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ComponentStatus": {
+      "description": "ComponentStatus (and ComponentStatusList) holds the cluster validation info.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "conditions": {
+          "description": "List of component conditions observed",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.ComponentCondition"
+          },
+          "type": "array",
+          "x-kubernetes-patch-merge-key": "type",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "ComponentStatus"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+        }
+      },
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "",
+          "kind": "ComponentStatus",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.core.v1.ComponentStatusList": {
+      "description": "Status of all the conditions for the component as a list of ComponentStatus objects.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "List of ComponentStatus objects.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.ComponentStatus"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "ComponentStatusList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds"
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "",
+          "kind": "ComponentStatusList",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.core.v1.ConfigMap": {
+      "description": "ConfigMap holds configuration data for pods to consume.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "binaryData": {
+          "additionalProperties": {
+            "format": "byte",
+            "type": "string"
+          },
+          "description": "BinaryData contains the binary data. Each key must consist of alphanumeric characters, '-', '_' or '.'. BinaryData can contain byte sequences that are not in the UTF-8 range. The keys stored in BinaryData must not overlap with the ones in the Data field, this is enforced during validation process. Using this field will require 1.10+ apiserver and kubelet.",
+          "type": "object"
+        },
+        "data": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Data contains the configuration data. Each key must consist of alphanumeric characters, '-', '_' or '.'. Values with non-UTF-8 byte sequences must use the BinaryData field. The keys stored in Data must not overlap with the keys in the BinaryData field, this is enforced during validation process.",
+          "type": "object"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "ConfigMap"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+        }
+      },
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "",
+          "kind": "ConfigMap",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.core.v1.ConfigMapEnvSource": {
+      "description": "ConfigMapEnvSource selects a ConfigMap to populate the environment variables with.\n\nThe contents of the target ConfigMap's Data field will represent the key-value pairs as environment variables.",
+      "properties": {
+        "name": {
+          "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+          "type": "string"
+        },
+        "optional": {
+          "description": "Specify whether the ConfigMap must be defined",
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ConfigMapKeySelector": {
+      "description": "Selects a key from a ConfigMap.",
+      "properties": {
+        "key": {
+          "description": "The key to select.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+          "type": "string"
+        },
+        "optional": {
+          "description": "Specify whether the ConfigMap or it's key must be defined",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "key"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ConfigMapList": {
+      "description": "ConfigMapList is a resource containing a list of ConfigMap objects.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "Items is the list of ConfigMaps.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.ConfigMap"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "ConfigMapList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "",
+          "kind": "ConfigMapList",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.core.v1.ConfigMapNodeConfigSource": {
+      "description": "ConfigMapNodeConfigSource contains the information to reference a ConfigMap as a config source for the Node.",
+      "properties": {
+        "kubeletConfigKey": {
+          "description": "KubeletConfigKey declares which key of the referenced ConfigMap corresponds to the KubeletConfiguration structure This field is required in all cases.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name is the metadata.name of the referenced ConfigMap. This field is required in all cases.",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace is the metadata.namespace of the referenced ConfigMap. This field is required in all cases.",
+          "type": "string"
+        },
+        "resourceVersion": {
+          "description": "ResourceVersion is the metadata.ResourceVersion of the referenced ConfigMap. This field is forbidden in Node.Spec, and required in Node.Status.",
+          "type": "string"
+        },
+        "uid": {
+          "description": "UID is the metadata.UID of the referenced ConfigMap. This field is forbidden in Node.Spec, and required in Node.Status.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "namespace",
+        "name",
+        "kubeletConfigKey"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ConfigMapProjection": {
+      "description": "Adapts a ConfigMap into a projected volume.\n\nThe contents of the target ConfigMap's Data field will be presented in a projected volume as files using the keys in the Data field as the file names, unless the items element is populated with specific mappings of keys to paths. Note that this is identical to a configmap volume source without the default mode.",
+      "properties": {
+        "items": {
+          "description": "If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.KeyToPath"
+          },
+          "type": "array"
+        },
+        "name": {
+          "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+          "type": "string"
+        },
+        "optional": {
+          "description": "Specify whether the ConfigMap or it's keys must be defined",
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ConfigMapVolumeSource": {
+      "description": "Adapts a ConfigMap into a volume.\n\nThe contents of the target ConfigMap's Data field will be presented in a volume as files using the keys in the Data field as the file names, unless the items element is populated with specific mappings of keys to paths. ConfigMap volumes support ownership management and SELinux relabeling.",
+      "properties": {
+        "defaultMode": {
+          "description": "Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "items": {
+          "description": "If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.KeyToPath"
+          },
+          "type": "array"
+        },
+        "name": {
+          "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+          "type": "string"
+        },
+        "optional": {
+          "description": "Specify whether the ConfigMap or it's keys must be defined",
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.Container": {
+      "description": "A single application container that you want to run within a pod.",
+      "properties": {
+        "args": {
+          "description": "Arguments to the entrypoint. The docker image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "command": {
+          "description": "Entrypoint array. Not executed within a shell. The docker image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "env": {
+          "description": "List of environment variables to set in the container. Cannot be updated.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.EnvVar"
+          },
+          "type": "array",
+          "x-kubernetes-patch-merge-key": "name",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "envFrom": {
+          "description": "List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.EnvFromSource"
+          },
+          "type": "array"
+        },
+        "image": {
+          "description": "Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.",
+          "type": "string"
+        },
+        "imagePullPolicy": {
+          "description": "Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
+          "type": "string"
+        },
+        "lifecycle": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.Lifecycle",
+          "description": "Actions that the management system should take in response to container lifecycle events. Cannot be updated."
+        },
+        "livenessProbe": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.Probe",
+          "description": "Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes"
+        },
+        "name": {
+          "description": "Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.",
+          "type": "string"
+        },
+        "ports": {
+          "description": "List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default \"0.0.0.0\" address inside a container will be accessible from the network. Cannot be updated.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.ContainerPort"
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "containerPort",
+            "protocol"
+          ],
+          "x-kubernetes-list-type": "map",
+          "x-kubernetes-patch-merge-key": "containerPort",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "readinessProbe": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.Probe",
+          "description": "Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes"
+        },
+        "resources": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ResourceRequirements",
+          "description": "Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/"
+        },
+        "securityContext": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.SecurityContext",
+          "description": "Security options the pod should run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/ More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/"
+        },
+        "stdin": {
+          "description": "Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.",
+          "type": "boolean"
+        },
+        "stdinOnce": {
+          "description": "Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false",
+          "type": "boolean"
+        },
+        "terminationMessagePath": {
+          "description": "Optional: Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.",
+          "type": "string"
+        },
+        "terminationMessagePolicy": {
+          "description": "Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.",
+          "type": "string"
+        },
+        "tty": {
+          "description": "Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.",
+          "type": "boolean"
+        },
+        "volumeDevices": {
+          "description": "volumeDevices is the list of block devices to be used by the container. This is a beta feature.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.VolumeDevice"
+          },
+          "type": "array",
+          "x-kubernetes-patch-merge-key": "devicePath",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "volumeMounts": {
+          "description": "Pod volumes to mount into the container's filesystem. Cannot be updated.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.VolumeMount"
+          },
+          "type": "array",
+          "x-kubernetes-patch-merge-key": "mountPath",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "workingDir": {
+          "description": "Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ContainerImage": {
+      "description": "Describe a container image",
+      "properties": {
+        "names": {
+          "description": "Names by which this image is known. e.g. [\"k8s.gcr.io/hyperkube:v1.0.7\", \"dockerhub.io/google_containers/hyperkube:v1.0.7\"]",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "sizeBytes": {
+          "description": "The size of the image in bytes.",
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "names"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ContainerPort": {
+      "description": "ContainerPort represents a network port in a single container.",
+      "properties": {
+        "containerPort": {
+          "description": "Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "hostIP": {
+          "description": "What host IP to bind the external port to.",
+          "type": "string"
+        },
+        "hostPort": {
+          "description": "Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "name": {
+          "description": "If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.",
+          "type": "string"
+        },
+        "protocol": {
+          "description": "Protocol for port. Must be UDP, TCP, or SCTP. Defaults to \"TCP\".",
+          "type": "string"
+        }
+      },
+      "required": [
+        "containerPort"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ContainerState": {
+      "description": "ContainerState holds a possible state of container. Only one of its members may be specified. If none of them is specified, the default one is ContainerStateWaiting.",
+      "properties": {
+        "running": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ContainerStateRunning",
+          "description": "Details about a running container"
+        },
+        "terminated": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ContainerStateTerminated",
+          "description": "Details about a terminated container"
+        },
+        "waiting": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ContainerStateWaiting",
+          "description": "Details about a waiting container"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ContainerStateRunning": {
+      "description": "ContainerStateRunning is a running state of a container.",
+      "properties": {
+        "startedAt": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "Time at which the container was last (re-)started"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ContainerStateTerminated": {
+      "description": "ContainerStateTerminated is a terminated state of a container.",
+      "properties": {
+        "containerID": {
+          "description": "Container's ID in the format 'docker://<container_id>'",
+          "type": "string"
+        },
+        "exitCode": {
+          "description": "Exit status from the last termination of the container",
+          "format": "int32",
+          "type": "integer"
+        },
+        "finishedAt": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "Time at which the container last terminated"
+        },
+        "message": {
+          "description": "Message regarding the last termination of the container",
+          "type": "string"
+        },
+        "reason": {
+          "description": "(brief) reason from the last termination of the container",
+          "type": "string"
+        },
+        "signal": {
+          "description": "Signal from the last termination of the container",
+          "format": "int32",
+          "type": "integer"
+        },
+        "startedAt": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "Time at which previous execution of the container started"
+        }
+      },
+      "required": [
+        "exitCode"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ContainerStateWaiting": {
+      "description": "ContainerStateWaiting is a waiting state of a container.",
+      "properties": {
+        "message": {
+          "description": "Message regarding why the container is not yet running.",
+          "type": "string"
+        },
+        "reason": {
+          "description": "(brief) reason the container is not yet running.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ContainerStatus": {
+      "description": "ContainerStatus contains details for the current status of this container.",
+      "properties": {
+        "containerID": {
+          "description": "Container's ID in the format 'docker://<container_id>'.",
+          "type": "string"
+        },
+        "image": {
+          "description": "The image the container is running. More info: https://kubernetes.io/docs/concepts/containers/images",
+          "type": "string"
+        },
+        "imageID": {
+          "description": "ImageID of the container's image.",
+          "type": "string"
+        },
+        "lastState": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ContainerState",
+          "description": "Details about the container's last termination condition."
+        },
+        "name": {
+          "description": "This must be a DNS_LABEL. Each container in a pod must have a unique name. Cannot be updated.",
+          "type": "string"
+        },
+        "ready": {
+          "description": "Specifies whether the container has passed its readiness probe.",
+          "type": "boolean"
+        },
+        "restartCount": {
+          "description": "The number of times the container has been restarted, currently based on the number of dead containers that have not yet been removed. Note that this is calculated from dead containers. But those containers are subject to garbage collection. This value will get capped at 5 by GC.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "state": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ContainerState",
+          "description": "Details about the container's current condition."
+        }
+      },
+      "required": [
+        "name",
+        "ready",
+        "restartCount",
+        "image",
+        "imageID"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.DaemonEndpoint": {
+      "description": "DaemonEndpoint contains information about a single Daemon endpoint.",
+      "properties": {
+        "Port": {
+          "description": "Port number of the given endpoint.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "Port"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.DownwardAPIProjection": {
+      "description": "Represents downward API info for projecting into a projected volume. Note that this is identical to a downwardAPI volume source without the default mode.",
+      "properties": {
+        "items": {
+          "description": "Items is a list of DownwardAPIVolume file",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.DownwardAPIVolumeFile"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.DownwardAPIVolumeFile": {
+      "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+      "properties": {
+        "fieldRef": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ObjectFieldSelector",
+          "description": "Required: Selects a field of the pod: only annotations, labels, name and namespace are supported."
+        },
+        "mode": {
+          "description": "Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "path": {
+          "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+          "type": "string"
+        },
+        "resourceFieldRef": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ResourceFieldSelector",
+          "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported."
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.DownwardAPIVolumeSource": {
+      "description": "DownwardAPIVolumeSource represents a volume containing downward API info. Downward API volumes support ownership management and SELinux relabeling.",
+      "properties": {
+        "defaultMode": {
+          "description": "Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "items": {
+          "description": "Items is a list of downward API volume file",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.DownwardAPIVolumeFile"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.EmptyDirVolumeSource": {
+      "description": "Represents an empty directory for a pod. Empty directory volumes support ownership management and SELinux relabeling.",
+      "properties": {
+        "medium": {
+          "description": "What type of storage medium should back this directory. The default is \"\" which means to use the node's default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+          "type": "string"
+        },
+        "sizeLimit": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity",
+          "description": "Total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.EndpointAddress": {
+      "description": "EndpointAddress is a tuple that describes single IP address.",
+      "properties": {
+        "hostname": {
+          "description": "The Hostname of this endpoint",
+          "type": "string"
+        },
+        "ip": {
+          "description": "The IP of this endpoint. May not be loopback (127.0.0.0/8), link-local (169.254.0.0/16), or link-local multicast ((224.0.0.0/24). IPv6 is also accepted but not fully supported on all platforms. Also, certain kubernetes components, like kube-proxy, are not IPv6 ready.",
+          "type": "string"
+        },
+        "nodeName": {
+          "description": "Optional: Node hosting this endpoint. This can be used to determine endpoints local to a node.",
+          "type": "string"
+        },
+        "targetRef": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ObjectReference",
+          "description": "Reference to object providing the endpoint."
+        }
+      },
+      "required": [
+        "ip"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.EndpointPort": {
+      "description": "EndpointPort is a tuple that describes a single port.",
+      "properties": {
+        "name": {
+          "description": "The name of this port (corresponds to ServicePort.Name). Must be a DNS_LABEL. Optional only if one port is defined.",
+          "type": "string"
+        },
+        "port": {
+          "description": "The port number of the endpoint.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "protocol": {
+          "description": "The IP protocol for this port. Must be UDP, TCP, or SCTP. Default is TCP.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "port"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.EndpointSubset": {
+      "description": "EndpointSubset is a group of addresses with a common set of ports. The expanded set of endpoints is the Cartesian product of Addresses x Ports. For example, given:\n  {\n    Addresses: [{\"ip\": \"10.10.1.1\"}, {\"ip\": \"10.10.2.2\"}],\n    Ports:     [{\"name\": \"a\", \"port\": 8675}, {\"name\": \"b\", \"port\": 309}]\n  }\nThe resulting set of endpoints can be viewed as:\n    a: [ 10.10.1.1:8675, 10.10.2.2:8675 ],\n    b: [ 10.10.1.1:309, 10.10.2.2:309 ]",
+      "properties": {
+        "addresses": {
+          "description": "IP addresses which offer the related ports that are marked as ready. These endpoints should be considered safe for load balancers and clients to utilize.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.EndpointAddress"
+          },
+          "type": "array"
+        },
+        "notReadyAddresses": {
+          "description": "IP addresses which offer the related ports but are not currently marked as ready because they have not yet finished starting, have recently failed a readiness check, or have recently failed a liveness check.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.EndpointAddress"
+          },
+          "type": "array"
+        },
+        "ports": {
+          "description": "Port numbers available on the related IP addresses.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.EndpointPort"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.Endpoints": {
+      "description": "Endpoints is a collection of endpoints that implement the actual service. Example:\n  Name: \"mysvc\",\n  Subsets: [\n    {\n      Addresses: [{\"ip\": \"10.10.1.1\"}, {\"ip\": \"10.10.2.2\"}],\n      Ports: [{\"name\": \"a\", \"port\": 8675}, {\"name\": \"b\", \"port\": 309}]\n    },\n    {\n      Addresses: [{\"ip\": \"10.10.3.3\"}],\n      Ports: [{\"name\": \"a\", \"port\": 93}, {\"name\": \"b\", \"port\": 76}]\n    },\n ]",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "Endpoints"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+        },
+        "subsets": {
+          "description": "The set of all endpoints is the union of all subsets. Addresses are placed into subsets according to the IPs they share. A single address with multiple ports, some of which are ready and some of which are not (because they come from different containers) will result in the address being displayed in different subsets for the different ports. No address will appear in both Addresses and NotReadyAddresses in the same subset. Sets of addresses and ports that comprise a service.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.EndpointSubset"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "",
+          "kind": "Endpoints",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.core.v1.EndpointsList": {
+      "description": "EndpointsList is a list of endpoints.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "List of endpoints.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.Endpoints"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "EndpointsList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds"
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "",
+          "kind": "EndpointsList",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.core.v1.EnvFromSource": {
+      "description": "EnvFromSource represents the source of a set of ConfigMaps",
+      "properties": {
+        "configMapRef": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ConfigMapEnvSource",
+          "description": "The ConfigMap to select from"
+        },
+        "prefix": {
+          "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
+          "type": "string"
+        },
+        "secretRef": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.SecretEnvSource",
+          "description": "The Secret to select from"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.EnvVar": {
+      "description": "EnvVar represents an environment variable present in a Container.",
+      "properties": {
+        "name": {
+          "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+          "type": "string"
+        },
+        "value": {
+          "description": "Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
+          "type": "string"
+        },
+        "valueFrom": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.EnvVarSource",
+          "description": "Source for the environment variable's value. Cannot be used if value is not empty."
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.EnvVarSource": {
+      "description": "EnvVarSource represents a source for the value of an EnvVar.",
+      "properties": {
+        "configMapKeyRef": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ConfigMapKeySelector",
+          "description": "Selects a key of a ConfigMap."
+        },
+        "fieldRef": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ObjectFieldSelector",
+          "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP."
+        },
+        "resourceFieldRef": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ResourceFieldSelector",
+          "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported."
+        },
+        "secretKeyRef": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.SecretKeySelector",
+          "description": "Selects a key of a secret in the pod's namespace"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.Event": {
+      "description": "Event is a report of an event somewhere in the cluster.",
+      "properties": {
+        "action": {
+          "description": "What action was taken/failed regarding to the Regarding object.",
+          "type": "string"
+        },
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "count": {
+          "description": "The number of times this event has occurred.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "eventTime": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime",
+          "description": "Time when this Event was first observed."
+        },
+        "firstTimestamp": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "The time at which the event was first recorded. (Time of server receipt is in TypeMeta.)"
+        },
+        "involvedObject": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ObjectReference",
+          "description": "The object that this event is about."
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "Event"
+          ]
+        },
+        "lastTimestamp": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "The time at which the most recent occurrence of this event was recorded."
+        },
+        "message": {
+          "description": "A human-readable description of the status of this operation.",
+          "type": "string"
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+        },
+        "reason": {
+          "description": "This should be a short, machine understandable string that gives the reason for the transition into the object's current status.",
+          "type": "string"
+        },
+        "related": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ObjectReference",
+          "description": "Optional secondary object for more complex actions."
+        },
+        "reportingComponent": {
+          "description": "Name of the controller that emitted this Event, e.g. `kubernetes.io/kubelet`.",
+          "type": "string"
+        },
+        "reportingInstance": {
+          "description": "ID of the controller instance, e.g. `kubelet-xyzf`.",
+          "type": "string"
+        },
+        "series": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.EventSeries",
+          "description": "Data about the Event series this event represents or nil if it's a singleton Event."
+        },
+        "source": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.EventSource",
+          "description": "The component reporting this event. Should be a short machine understandable string."
+        },
+        "type": {
+          "description": "Type of this event (Normal, Warning), new types could be added in the future",
+          "type": "string"
+        }
+      },
+      "required": [
+        "metadata",
+        "involvedObject"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "",
+          "kind": "Event",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.core.v1.EventList": {
+      "description": "EventList is a list of events.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "List of events",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.Event"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "EventList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds"
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "",
+          "kind": "EventList",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.core.v1.EventSeries": {
+      "description": "EventSeries contain information on series of events, i.e. thing that was/is happening continuously for some time.",
+      "properties": {
+        "count": {
+          "description": "Number of occurrences in this series up to the last heartbeat time",
+          "format": "int32",
+          "type": "integer"
+        },
+        "lastObservedTime": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime",
+          "description": "Time of the last occurrence observed"
+        },
+        "state": {
+          "description": "State of this Series: Ongoing or Finished",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.EventSource": {
+      "description": "EventSource contains information for an event.",
+      "properties": {
+        "component": {
+          "description": "Component from which the event is generated.",
+          "type": "string"
+        },
+        "host": {
+          "description": "Node name on which the event is generated.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ExecAction": {
+      "description": "ExecAction describes a \"run in container\" action.",
+      "properties": {
+        "command": {
+          "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.FCVolumeSource": {
+      "description": "Represents a Fibre Channel volume. Fibre Channel volumes can only be mounted as read/write once. Fibre Channel volumes support ownership management and SELinux relabeling.",
+      "properties": {
+        "fsType": {
+          "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+          "type": "string"
+        },
+        "lun": {
+          "description": "Optional: FC target lun number",
+          "format": "int32",
+          "type": "integer"
+        },
+        "readOnly": {
+          "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+          "type": "boolean"
+        },
+        "targetWWNs": {
+          "description": "Optional: FC target worldwide names (WWNs)",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "wwids": {
+          "description": "Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.FlexPersistentVolumeSource": {
+      "description": "FlexPersistentVolumeSource represents a generic persistent volume resource that is provisioned/attached using an exec based plugin.",
+      "properties": {
+        "driver": {
+          "description": "Driver is the name of the driver to use for this volume.",
+          "type": "string"
+        },
+        "fsType": {
+          "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". The default filesystem depends on FlexVolume script.",
+          "type": "string"
+        },
+        "options": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Optional: Extra command options if any.",
+          "type": "object"
+        },
+        "readOnly": {
+          "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+          "type": "boolean"
+        },
+        "secretRef": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.SecretReference",
+          "description": "Optional: SecretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts."
+        }
+      },
+      "required": [
+        "driver"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.FlexVolumeSource": {
+      "description": "FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.",
+      "properties": {
+        "driver": {
+          "description": "Driver is the name of the driver to use for this volume.",
+          "type": "string"
+        },
+        "fsType": {
+          "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". The default filesystem depends on FlexVolume script.",
+          "type": "string"
+        },
+        "options": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Optional: Extra command options if any.",
+          "type": "object"
+        },
+        "readOnly": {
+          "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+          "type": "boolean"
+        },
+        "secretRef": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference",
+          "description": "Optional: SecretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts."
+        }
+      },
+      "required": [
+        "driver"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.FlockerVolumeSource": {
+      "description": "Represents a Flocker volume mounted by the Flocker agent. One and only one of datasetName and datasetUUID should be set. Flocker volumes do not support ownership management or SELinux relabeling.",
+      "properties": {
+        "datasetName": {
+          "description": "Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated",
+          "type": "string"
+        },
+        "datasetUUID": {
+          "description": "UUID of the dataset. This is unique identifier of a Flocker dataset",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.GCEPersistentDiskVolumeSource": {
+      "description": "Represents a Persistent Disk resource in Google Compute Engine.\n\nA GCE PD must exist before mounting to a container. The disk must also be in the same GCE project and zone as the kubelet. A GCE PD can only be mounted as read/write once or read-only many times. GCE PDs support ownership management and SELinux relabeling.",
+      "properties": {
+        "fsType": {
+          "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+          "type": "string"
+        },
+        "partition": {
+          "description": "The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+          "format": "int32",
+          "type": "integer"
+        },
+        "pdName": {
+          "description": "Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+          "type": "string"
+        },
+        "readOnly": {
+          "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "pdName"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.GitRepoVolumeSource": {
+      "description": "Represents a volume that is populated with the contents of a git repository. Git repo volumes do not support ownership management. Git repo volumes support SELinux relabeling.\n\nDEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.",
+      "properties": {
+        "directory": {
+          "description": "Target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.",
+          "type": "string"
+        },
+        "repository": {
+          "description": "Repository URL",
+          "type": "string"
+        },
+        "revision": {
+          "description": "Commit hash for the specified revision.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "repository"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.GlusterfsPersistentVolumeSource": {
+      "description": "Represents a Glusterfs mount that lasts the lifetime of a pod. Glusterfs volumes do not support ownership management or SELinux relabeling.",
+      "properties": {
+        "endpoints": {
+          "description": "EndpointsName is the endpoint name that details Glusterfs topology. More info: https://releases.k8s.io/HEAD/examples/volumes/glusterfs/README.md#create-a-pod",
+          "type": "string"
+        },
+        "endpointsNamespace": {
+          "description": "EndpointsNamespace is the namespace that contains Glusterfs endpoint. If this field is empty, the EndpointNamespace defaults to the same namespace as the bound PVC. More info: https://releases.k8s.io/HEAD/examples/volumes/glusterfs/README.md#create-a-pod",
+          "type": "string"
+        },
+        "path": {
+          "description": "Path is the Glusterfs volume path. More info: https://releases.k8s.io/HEAD/examples/volumes/glusterfs/README.md#create-a-pod",
+          "type": "string"
+        },
+        "readOnly": {
+          "description": "ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://releases.k8s.io/HEAD/examples/volumes/glusterfs/README.md#create-a-pod",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "endpoints",
+        "path"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.GlusterfsVolumeSource": {
+      "description": "Represents a Glusterfs mount that lasts the lifetime of a pod. Glusterfs volumes do not support ownership management or SELinux relabeling.",
+      "properties": {
+        "endpoints": {
+          "description": "EndpointsName is the endpoint name that details Glusterfs topology. More info: https://releases.k8s.io/HEAD/examples/volumes/glusterfs/README.md#create-a-pod",
+          "type": "string"
+        },
+        "path": {
+          "description": "Path is the Glusterfs volume path. More info: https://releases.k8s.io/HEAD/examples/volumes/glusterfs/README.md#create-a-pod",
+          "type": "string"
+        },
+        "readOnly": {
+          "description": "ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://releases.k8s.io/HEAD/examples/volumes/glusterfs/README.md#create-a-pod",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "endpoints",
+        "path"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.HTTPGetAction": {
+      "description": "HTTPGetAction describes an action based on HTTP Get requests.",
+      "properties": {
+        "host": {
+          "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+          "type": "string"
+        },
+        "httpHeaders": {
+          "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.HTTPHeader"
+          },
+          "type": "array"
+        },
+        "path": {
+          "description": "Path to access on the HTTP server.",
+          "type": "string"
+        },
+        "port": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.util.intstr.IntOrString",
+          "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME."
+        },
+        "scheme": {
+          "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "port"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.HTTPHeader": {
+      "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+      "properties": {
+        "name": {
+          "description": "The header field name",
+          "type": "string"
+        },
+        "value": {
+          "description": "The header field value",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "value"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.Handler": {
+      "description": "Handler defines a specific action that should be taken",
+      "properties": {
+        "exec": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ExecAction",
+          "description": "One and only one of the following should be specified. Exec specifies the action to take."
+        },
+        "httpGet": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.HTTPGetAction",
+          "description": "HTTPGet specifies the http request to perform."
+        },
+        "tcpSocket": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.TCPSocketAction",
+          "description": "TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.HostAlias": {
+      "description": "HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.",
+      "properties": {
+        "hostnames": {
+          "description": "Hostnames for the above IP address.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "ip": {
+          "description": "IP address of the host file entry.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.HostPathVolumeSource": {
+      "description": "Represents a host path mapped into a pod. Host path volumes do not support ownership management or SELinux relabeling.",
+      "properties": {
+        "path": {
+          "description": "Path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+          "type": "string"
+        },
+        "type": {
+          "description": "Type for HostPath Volume Defaults to \"\" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ISCSIPersistentVolumeSource": {
+      "description": "ISCSIPersistentVolumeSource represents an ISCSI disk. ISCSI volumes can only be mounted as read/write once. ISCSI volumes support ownership management and SELinux relabeling.",
+      "properties": {
+        "chapAuthDiscovery": {
+          "description": "whether support iSCSI Discovery CHAP authentication",
+          "type": "boolean"
+        },
+        "chapAuthSession": {
+          "description": "whether support iSCSI Session CHAP authentication",
+          "type": "boolean"
+        },
+        "fsType": {
+          "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi",
+          "type": "string"
+        },
+        "initiatorName": {
+          "description": "Custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.",
+          "type": "string"
+        },
+        "iqn": {
+          "description": "Target iSCSI Qualified Name.",
+          "type": "string"
+        },
+        "iscsiInterface": {
+          "description": "iSCSI Interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).",
+          "type": "string"
+        },
+        "lun": {
+          "description": "iSCSI Target Lun number.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "portals": {
+          "description": "iSCSI Target Portal List. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "readOnly": {
+          "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.",
+          "type": "boolean"
+        },
+        "secretRef": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.SecretReference",
+          "description": "CHAP Secret for iSCSI target and initiator authentication"
+        },
+        "targetPortal": {
+          "description": "iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
+          "type": "string"
+        }
+      },
+      "required": [
+        "targetPortal",
+        "iqn",
+        "lun"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ISCSIVolumeSource": {
+      "description": "Represents an ISCSI disk. ISCSI volumes can only be mounted as read/write once. ISCSI volumes support ownership management and SELinux relabeling.",
+      "properties": {
+        "chapAuthDiscovery": {
+          "description": "whether support iSCSI Discovery CHAP authentication",
+          "type": "boolean"
+        },
+        "chapAuthSession": {
+          "description": "whether support iSCSI Session CHAP authentication",
+          "type": "boolean"
+        },
+        "fsType": {
+          "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi",
+          "type": "string"
+        },
+        "initiatorName": {
+          "description": "Custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.",
+          "type": "string"
+        },
+        "iqn": {
+          "description": "Target iSCSI Qualified Name.",
+          "type": "string"
+        },
+        "iscsiInterface": {
+          "description": "iSCSI Interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).",
+          "type": "string"
+        },
+        "lun": {
+          "description": "iSCSI Target Lun number.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "portals": {
+          "description": "iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "readOnly": {
+          "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.",
+          "type": "boolean"
+        },
+        "secretRef": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference",
+          "description": "CHAP Secret for iSCSI target and initiator authentication"
+        },
+        "targetPortal": {
+          "description": "iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
+          "type": "string"
+        }
+      },
+      "required": [
+        "targetPortal",
+        "iqn",
+        "lun"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.KeyToPath": {
+      "description": "Maps a string key to a path within a volume.",
+      "properties": {
+        "key": {
+          "description": "The key to project.",
+          "type": "string"
+        },
+        "mode": {
+          "description": "Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "path": {
+          "description": "The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "key",
+        "path"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.Lifecycle": {
+      "description": "Lifecycle describes actions that the management system should take in response to container lifecycle events. For the PostStart and PreStop lifecycle handlers, management of the container blocks until the action is complete, unless the container process fails, in which case the handler is aborted.",
+      "properties": {
+        "postStart": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.Handler",
+          "description": "PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks"
+        },
+        "preStop": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.Handler",
+          "description": "PreStop is called immediately before a container is terminated due to an API request or management event such as liveness probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The reason for termination is passed to the handler. The Pod's termination grace period countdown begins before the PreStop hooked is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod's termination grace period. Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.LimitRange": {
+      "description": "LimitRange sets resource usage limits for each kind of resource in a Namespace.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "LimitRange"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.LimitRangeSpec",
+          "description": "Spec defines the limits enforced. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status"
+        }
+      },
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "",
+          "kind": "LimitRange",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.core.v1.LimitRangeItem": {
+      "description": "LimitRangeItem defines a min/max usage limit for any resource that matches on kind.",
+      "properties": {
+        "default": {
+          "additionalProperties": {
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
+          },
+          "description": "Default resource requirement limit value by resource name if resource limit is omitted.",
+          "type": "object"
+        },
+        "defaultRequest": {
+          "additionalProperties": {
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
+          },
+          "description": "DefaultRequest is the default resource requirement request value by resource name if resource request is omitted.",
+          "type": "object"
+        },
+        "max": {
+          "additionalProperties": {
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
+          },
+          "description": "Max usage constraints on this kind by resource name.",
+          "type": "object"
+        },
+        "maxLimitRequestRatio": {
+          "additionalProperties": {
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
+          },
+          "description": "MaxLimitRequestRatio if specified, the named resource must have a request and limit that are both non-zero where limit divided by request is less than or equal to the enumerated value; this represents the max burst for the named resource.",
+          "type": "object"
+        },
+        "min": {
+          "additionalProperties": {
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
+          },
+          "description": "Min usage constraints on this kind by resource name.",
+          "type": "object"
+        },
+        "type": {
+          "description": "Type of resource that this limit applies to.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.LimitRangeList": {
+      "description": "LimitRangeList is a list of LimitRange items.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "Items is a list of LimitRange objects. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.LimitRange"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "LimitRangeList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds"
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "",
+          "kind": "LimitRangeList",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.core.v1.LimitRangeSpec": {
+      "description": "LimitRangeSpec defines a min/max usage limit for resources that match on kind.",
+      "properties": {
+        "limits": {
+          "description": "Limits is the list of LimitRangeItem objects that are enforced.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.LimitRangeItem"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "limits"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.LoadBalancerIngress": {
+      "description": "LoadBalancerIngress represents the status of a load-balancer ingress point: traffic intended for the service should be sent to an ingress point.",
+      "properties": {
+        "hostname": {
+          "description": "Hostname is set for load-balancer ingress points that are DNS based (typically AWS load-balancers)",
+          "type": "string"
+        },
+        "ip": {
+          "description": "IP is set for load-balancer ingress points that are IP based (typically GCE or OpenStack load-balancers)",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.LoadBalancerStatus": {
+      "description": "LoadBalancerStatus represents the status of a load-balancer.",
+      "properties": {
+        "ingress": {
+          "description": "Ingress is a list containing ingress points for the load-balancer. Traffic intended for the service should be sent to these ingress points.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.LoadBalancerIngress"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.LocalObjectReference": {
+      "description": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
+      "properties": {
+        "name": {
+          "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.LocalVolumeSource": {
+      "description": "Local represents directly-attached storage with node affinity (Beta feature)",
+      "properties": {
+        "fsType": {
+          "description": "Filesystem type to mount. It applies only when the Path is a block device. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". The default value is to auto-select a fileystem if unspecified.",
+          "type": "string"
+        },
+        "path": {
+          "description": "The full path to the volume on the node. It can be either a directory or block device (disk, partition, ...).",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.NFSVolumeSource": {
+      "description": "Represents an NFS mount that lasts the lifetime of a pod. NFS volumes do not support ownership management or SELinux relabeling.",
+      "properties": {
+        "path": {
+          "description": "Path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+          "type": "string"
+        },
+        "readOnly": {
+          "description": "ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+          "type": "boolean"
+        },
+        "server": {
+          "description": "Server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+          "type": "string"
+        }
+      },
+      "required": [
+        "server",
+        "path"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.Namespace": {
+      "description": "Namespace provides a scope for Names. Use of multiple namespaces is optional.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "Namespace"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.NamespaceSpec",
+          "description": "Spec defines the behavior of the Namespace. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status"
+        },
+        "status": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.NamespaceStatus",
+          "description": "Status describes the current status of a Namespace. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status"
+        }
+      },
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "",
+          "kind": "Namespace",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.core.v1.NamespaceList": {
+      "description": "NamespaceList is a list of Namespaces.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "Items is the list of Namespace objects in the list. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.Namespace"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "NamespaceList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds"
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "",
+          "kind": "NamespaceList",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.core.v1.NamespaceSpec": {
+      "description": "NamespaceSpec describes the attributes on a Namespace.",
+      "properties": {
+        "finalizers": {
+          "description": "Finalizers is an opaque list of values that must be empty to permanently remove object from storage. More info: https://kubernetes.io/docs/tasks/administer-cluster/namespaces/",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.NamespaceStatus": {
+      "description": "NamespaceStatus is information about the current status of a Namespace.",
+      "properties": {
+        "phase": {
+          "description": "Phase is the current lifecycle phase of the namespace. More info: https://kubernetes.io/docs/tasks/administer-cluster/namespaces/",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.Node": {
+      "description": "Node is a worker node in Kubernetes. Each node will have a unique identifier in the cache (i.e. in etcd).",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "Node"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.NodeSpec",
+          "description": "Spec defines the behavior of a node. https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status"
+        },
+        "status": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.NodeStatus",
+          "description": "Most recently observed status of the node. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status"
+        }
+      },
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "",
+          "kind": "Node",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.core.v1.NodeAddress": {
+      "description": "NodeAddress contains information for the node's address.",
+      "properties": {
+        "address": {
+          "description": "The node address.",
+          "type": "string"
+        },
+        "type": {
+          "description": "Node address type, one of Hostname, ExternalIP or InternalIP.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "address"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.NodeAffinity": {
+      "description": "Node affinity is a group of node affinity scheduling rules.",
+      "properties": {
+        "preferredDuringSchedulingIgnoredDuringExecution": {
+          "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.PreferredSchedulingTerm"
+          },
+          "type": "array"
+        },
+        "requiredDuringSchedulingIgnoredDuringExecution": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.NodeSelector",
+          "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node."
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.NodeCondition": {
+      "description": "NodeCondition contains condition information for a node.",
+      "properties": {
+        "lastHeartbeatTime": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "Last time we got an update on a given condition."
+        },
+        "lastTransitionTime": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "Last time the condition transit from one status to another."
+        },
+        "message": {
+          "description": "Human readable message indicating details about last transition.",
+          "type": "string"
+        },
+        "reason": {
+          "description": "(brief) reason for the condition's last transition.",
+          "type": "string"
+        },
+        "status": {
+          "description": "Status of the condition, one of True, False, Unknown.",
+          "type": "string"
+        },
+        "type": {
+          "description": "Type of node condition.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "status"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.NodeConfigSource": {
+      "description": "NodeConfigSource specifies a source of node configuration. Exactly one subfield (excluding metadata) must be non-nil.",
+      "properties": {
+        "configMap": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ConfigMapNodeConfigSource",
+          "description": "ConfigMap is a reference to a Node's ConfigMap"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.NodeConfigStatus": {
+      "description": "NodeConfigStatus describes the status of the config assigned by Node.Spec.ConfigSource.",
+      "properties": {
+        "active": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.NodeConfigSource",
+          "description": "Active reports the checkpointed config the node is actively using. Active will represent either the current version of the Assigned config, or the current LastKnownGood config, depending on whether attempting to use the Assigned config results in an error."
+        },
+        "assigned": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.NodeConfigSource",
+          "description": "Assigned reports the checkpointed config the node will try to use. When Node.Spec.ConfigSource is updated, the node checkpoints the associated config payload to local disk, along with a record indicating intended config. The node refers to this record to choose its config checkpoint, and reports this record in Assigned. Assigned only updates in the status after the record has been checkpointed to disk. When the Kubelet is restarted, it tries to make the Assigned config the Active config by loading and validating the checkpointed payload identified by Assigned."
+        },
+        "error": {
+          "description": "Error describes any problems reconciling the Spec.ConfigSource to the Active config. Errors may occur, for example, attempting to checkpoint Spec.ConfigSource to the local Assigned record, attempting to checkpoint the payload associated with Spec.ConfigSource, attempting to load or validate the Assigned config, etc. Errors may occur at different points while syncing config. Earlier errors (e.g. download or checkpointing errors) will not result in a rollback to LastKnownGood, and may resolve across Kubelet retries. Later errors (e.g. loading or validating a checkpointed config) will result in a rollback to LastKnownGood. In the latter case, it is usually possible to resolve the error by fixing the config assigned in Spec.ConfigSource. You can find additional information for debugging by searching the error message in the Kubelet log. Error is a human-readable description of the error state; machines can check whether or not Error is empty, but should not rely on the stability of the Error text across Kubelet versions.",
+          "type": "string"
+        },
+        "lastKnownGood": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.NodeConfigSource",
+          "description": "LastKnownGood reports the checkpointed config the node will fall back to when it encounters an error attempting to use the Assigned config. The Assigned config becomes the LastKnownGood config when the node determines that the Assigned config is stable and correct. This is currently implemented as a 10-minute soak period starting when the local record of Assigned config is updated. If the Assigned config is Active at the end of this period, it becomes the LastKnownGood. Note that if Spec.ConfigSource is reset to nil (use local defaults), the LastKnownGood is also immediately reset to nil, because the local default config is always assumed good. You should not make assumptions about the node's method of determining config stability and correctness, as this may change or become configurable in the future."
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.NodeDaemonEndpoints": {
+      "description": "NodeDaemonEndpoints lists ports opened by daemons running on the Node.",
+      "properties": {
+        "kubeletEndpoint": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.DaemonEndpoint",
+          "description": "Endpoint on which Kubelet is listening."
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.NodeList": {
+      "description": "NodeList is the whole list of all Nodes which have been registered with master.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "List of nodes",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.Node"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "NodeList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds"
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "",
+          "kind": "NodeList",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.core.v1.NodeSelector": {
+      "description": "A node selector represents the union of the results of one or more label queries over a set of nodes; that is, it represents the OR of the selectors represented by the node selector terms.",
+      "properties": {
+        "nodeSelectorTerms": {
+          "description": "Required. A list of node selector terms. The terms are ORed.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.NodeSelectorTerm"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "nodeSelectorTerms"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.NodeSelectorRequirement": {
+      "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+      "properties": {
+        "key": {
+          "description": "The label key that the selector applies to.",
+          "type": "string"
+        },
+        "operator": {
+          "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+          "type": "string"
+        },
+        "values": {
+          "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "key",
+        "operator"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.NodeSelectorTerm": {
+      "description": "A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+      "properties": {
+        "matchExpressions": {
+          "description": "A list of node selector requirements by node's labels.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.NodeSelectorRequirement"
+          },
+          "type": "array"
+        },
+        "matchFields": {
+          "description": "A list of node selector requirements by node's fields.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.NodeSelectorRequirement"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.NodeSpec": {
+      "description": "NodeSpec describes the attributes that a node is created with.",
+      "properties": {
+        "configSource": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.NodeConfigSource",
+          "description": "If specified, the source to get node configuration from The DynamicKubeletConfig feature gate must be enabled for the Kubelet to use this field"
+        },
+        "externalID": {
+          "description": "Deprecated. Not all kubelets will set this field. Remove field after 1.13. see: https://issues.k8s.io/61966",
+          "type": "string"
+        },
+        "podCIDR": {
+          "description": "PodCIDR represents the pod IP range assigned to the node.",
+          "type": "string"
+        },
+        "providerID": {
+          "description": "ID of the node assigned by the cloud provider in the format: <ProviderName>://<ProviderSpecificNodeID>",
+          "type": "string"
+        },
+        "taints": {
+          "description": "If specified, the node's taints.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.Taint"
+          },
+          "type": "array"
+        },
+        "unschedulable": {
+          "description": "Unschedulable controls node schedulability of new pods. By default, node is schedulable. More info: https://kubernetes.io/docs/concepts/nodes/node/#manual-node-administration",
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.NodeStatus": {
+      "description": "NodeStatus is information about the current status of a node.",
+      "properties": {
+        "addresses": {
+          "description": "List of addresses reachable to the node. Queried from cloud provider, if available. More info: https://kubernetes.io/docs/concepts/nodes/node/#addresses",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.NodeAddress"
+          },
+          "type": "array",
+          "x-kubernetes-patch-merge-key": "type",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "allocatable": {
+          "additionalProperties": {
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
+          },
+          "description": "Allocatable represents the resources of a node that are available for scheduling. Defaults to Capacity.",
+          "type": "object"
+        },
+        "capacity": {
+          "additionalProperties": {
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
+          },
+          "description": "Capacity represents the total resources of a node. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#capacity",
+          "type": "object"
+        },
+        "conditions": {
+          "description": "Conditions is an array of current observed node conditions. More info: https://kubernetes.io/docs/concepts/nodes/node/#condition",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.NodeCondition"
+          },
+          "type": "array",
+          "x-kubernetes-patch-merge-key": "type",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "config": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.NodeConfigStatus",
+          "description": "Status of the config assigned to the node via the dynamic Kubelet config feature."
+        },
+        "daemonEndpoints": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.NodeDaemonEndpoints",
+          "description": "Endpoints of daemons running on the Node."
+        },
+        "images": {
+          "description": "List of container images on this node",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.ContainerImage"
+          },
+          "type": "array"
+        },
+        "nodeInfo": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.NodeSystemInfo",
+          "description": "Set of ids/uuids to uniquely identify the node. More info: https://kubernetes.io/docs/concepts/nodes/node/#info"
+        },
+        "phase": {
+          "description": "NodePhase is the recently observed lifecycle phase of the node. More info: https://kubernetes.io/docs/concepts/nodes/node/#phase The field is never populated, and now is deprecated.",
+          "type": "string"
+        },
+        "volumesAttached": {
+          "description": "List of volumes that are attached to the node.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.AttachedVolume"
+          },
+          "type": "array"
+        },
+        "volumesInUse": {
+          "description": "List of attachable volumes in use (mounted) by the node.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.NodeSystemInfo": {
+      "description": "NodeSystemInfo is a set of ids/uuids to uniquely identify the node.",
+      "properties": {
+        "architecture": {
+          "description": "The Architecture reported by the node",
+          "type": "string"
+        },
+        "bootID": {
+          "description": "Boot ID reported by the node.",
+          "type": "string"
+        },
+        "containerRuntimeVersion": {
+          "description": "ContainerRuntime Version reported by the node through runtime remote API (e.g. docker://1.5.0).",
+          "type": "string"
+        },
+        "kernelVersion": {
+          "description": "Kernel Version reported by the node from 'uname -r' (e.g. 3.16.0-0.bpo.4-amd64).",
+          "type": "string"
+        },
+        "kubeProxyVersion": {
+          "description": "KubeProxy Version reported by the node.",
+          "type": "string"
+        },
+        "kubeletVersion": {
+          "description": "Kubelet Version reported by the node.",
+          "type": "string"
+        },
+        "machineID": {
+          "description": "MachineID reported by the node. For unique machine identification in the cluster this field is preferred. Learn more from man(5) machine-id: http://man7.org/linux/man-pages/man5/machine-id.5.html",
+          "type": "string"
+        },
+        "operatingSystem": {
+          "description": "The Operating System reported by the node",
+          "type": "string"
+        },
+        "osImage": {
+          "description": "OS Image reported by the node from /etc/os-release (e.g. Debian GNU/Linux 7 (wheezy)).",
+          "type": "string"
+        },
+        "systemUUID": {
+          "description": "SystemUUID reported by the node. For unique machine identification MachineID is preferred. This field is specific to Red Hat hosts https://access.redhat.com/documentation/en-US/Red_Hat_Subscription_Management/1/html/RHSM/getting-system-uuid.html",
+          "type": "string"
+        }
+      },
+      "required": [
+        "machineID",
+        "systemUUID",
+        "bootID",
+        "kernelVersion",
+        "osImage",
+        "containerRuntimeVersion",
+        "kubeletVersion",
+        "kubeProxyVersion",
+        "operatingSystem",
+        "architecture"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ObjectFieldSelector": {
+      "description": "ObjectFieldSelector selects an APIVersioned field of an object.",
+      "properties": {
+        "apiVersion": {
+          "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+          "type": "string"
+        },
+        "fieldPath": {
+          "description": "Path of the field to select in the specified API version.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "fieldPath"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ObjectReference": {
+      "description": "ObjectReference contains enough information to let you inspect or modify the referred object.",
+      "properties": {
+        "apiVersion": {
+          "description": "API version of the referent.",
+          "type": "string"
+        },
+        "fieldPath": {
+          "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object.",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+          "type": "string"
+        },
+        "resourceVersion": {
+          "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency",
+          "type": "string"
+        },
+        "uid": {
+          "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.PersistentVolume": {
+      "description": "PersistentVolume (PV) is a storage resource provisioned by an administrator. It is analogous to a node. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "PersistentVolume"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.PersistentVolumeSpec",
+          "description": "Spec defines a specification of a persistent volume owned by the cluster. Provisioned by an administrator. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistent-volumes"
+        },
+        "status": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.PersistentVolumeStatus",
+          "description": "Status represents the current information/status for the persistent volume. Populated by the system. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistent-volumes"
+        }
+      },
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "",
+          "kind": "PersistentVolume",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.core.v1.PersistentVolumeClaim": {
+      "description": "PersistentVolumeClaim is a user's request for and claim to a persistent volume",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "PersistentVolumeClaim"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.PersistentVolumeClaimSpec",
+          "description": "Spec defines the desired characteristics of a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims"
+        },
+        "status": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.PersistentVolumeClaimStatus",
+          "description": "Status represents the current information/status of a persistent volume claim. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims"
+        }
+      },
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "",
+          "kind": "PersistentVolumeClaim",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.core.v1.PersistentVolumeClaimCondition": {
+      "description": "PersistentVolumeClaimCondition contails details about state of pvc",
+      "properties": {
+        "lastProbeTime": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "Last time we probed the condition."
+        },
+        "lastTransitionTime": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "Last time the condition transitioned from one status to another."
+        },
+        "message": {
+          "description": "Human-readable message indicating details about last transition.",
+          "type": "string"
+        },
+        "reason": {
+          "description": "Unique, this should be a short, machine understandable string that gives the reason for condition's last transition. If it reports \"ResizeStarted\" that means the underlying persistent volume is being resized.",
+          "type": "string"
+        },
+        "status": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "status"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.PersistentVolumeClaimList": {
+      "description": "PersistentVolumeClaimList is a list of PersistentVolumeClaim items.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "A list of persistent volume claims. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.PersistentVolumeClaim"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "PersistentVolumeClaimList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds"
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "",
+          "kind": "PersistentVolumeClaimList",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.core.v1.PersistentVolumeClaimSpec": {
+      "description": "PersistentVolumeClaimSpec describes the common attributes of storage devices and allows a Source for provider-specific attributes",
+      "properties": {
+        "accessModes": {
+          "description": "AccessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "dataSource": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.TypedLocalObjectReference",
+          "description": "This field requires the VolumeSnapshotDataSource alpha feature gate to be enabled and currently VolumeSnapshot is the only supported data source. If the provisioner can support VolumeSnapshot data source, it will create a new volume and data will be restored to the volume at the same time. If the provisioner does not support VolumeSnapshot data source, volume will not be created and the failure will be reported as an event. In the future, we plan to support more data source types and the behavior of the provisioner may change."
+        },
+        "resources": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ResourceRequirements",
+          "description": "Resources represents the minimum resources the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources"
+        },
+        "selector": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+          "description": "A label query over volumes to consider for binding."
+        },
+        "storageClassName": {
+          "description": "Name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",
+          "type": "string"
+        },
+        "volumeMode": {
+          "description": "volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec. This is a beta feature.",
+          "type": "string"
+        },
+        "volumeName": {
+          "description": "VolumeName is the binding reference to the PersistentVolume backing this claim.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.PersistentVolumeClaimStatus": {
+      "description": "PersistentVolumeClaimStatus is the current status of a persistent volume claim.",
+      "properties": {
+        "accessModes": {
+          "description": "AccessModes contains the actual access modes the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "capacity": {
+          "additionalProperties": {
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
+          },
+          "description": "Represents the actual resources of the underlying volume.",
+          "type": "object"
+        },
+        "conditions": {
+          "description": "Current Condition of persistent volume claim. If underlying persistent volume is being resized then the Condition will be set to 'ResizeStarted'.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.PersistentVolumeClaimCondition"
+          },
+          "type": "array",
+          "x-kubernetes-patch-merge-key": "type",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "phase": {
+          "description": "Phase represents the current phase of PersistentVolumeClaim.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.PersistentVolumeClaimVolumeSource": {
+      "description": "PersistentVolumeClaimVolumeSource references the user's PVC in the same namespace. This volume finds the bound PV and mounts that volume for the pod. A PersistentVolumeClaimVolumeSource is, essentially, a wrapper around another type of volume that is owned by someone else (the system).",
+      "properties": {
+        "claimName": {
+          "description": "ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+          "type": "string"
+        },
+        "readOnly": {
+          "description": "Will force the ReadOnly setting in VolumeMounts. Default false.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "claimName"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.PersistentVolumeList": {
+      "description": "PersistentVolumeList is a list of PersistentVolume items.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "List of persistent volumes. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.PersistentVolume"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "PersistentVolumeList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds"
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "",
+          "kind": "PersistentVolumeList",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.core.v1.PersistentVolumeSpec": {
+      "description": "PersistentVolumeSpec is the specification of a persistent volume.",
+      "properties": {
+        "accessModes": {
+          "description": "AccessModes contains all ways the volume can be mounted. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "awsElasticBlockStore": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.AWSElasticBlockStoreVolumeSource",
+          "description": "AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore"
+        },
+        "azureDisk": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.AzureDiskVolumeSource",
+          "description": "AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod."
+        },
+        "azureFile": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.AzureFilePersistentVolumeSource",
+          "description": "AzureFile represents an Azure File Service mount on the host and bind mount to the pod."
+        },
+        "capacity": {
+          "additionalProperties": {
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
+          },
+          "description": "A description of the persistent volume's resources and capacity. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#capacity",
+          "type": "object"
+        },
+        "cephfs": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.CephFSPersistentVolumeSource",
+          "description": "CephFS represents a Ceph FS mount on the host that shares a pod's lifetime"
+        },
+        "cinder": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.CinderPersistentVolumeSource",
+          "description": "Cinder represents a cinder volume attached and mounted on kubelets host machine More info: https://releases.k8s.io/HEAD/examples/mysql-cinder-pd/README.md"
+        },
+        "claimRef": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ObjectReference",
+          "description": "ClaimRef is part of a bi-directional binding between PersistentVolume and PersistentVolumeClaim. Expected to be non-nil when bound. claim.VolumeName is the authoritative bind between PV and PVC. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#binding"
+        },
+        "csi": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.CSIPersistentVolumeSource",
+          "description": "CSI represents storage that is handled by an external CSI driver (Beta feature)."
+        },
+        "fc": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.FCVolumeSource",
+          "description": "FC represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod."
+        },
+        "flexVolume": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.FlexPersistentVolumeSource",
+          "description": "FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin."
+        },
+        "flocker": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.FlockerVolumeSource",
+          "description": "Flocker represents a Flocker volume attached to a kubelet's host machine and exposed to the pod for its usage. This depends on the Flocker control service being running"
+        },
+        "gcePersistentDisk": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.GCEPersistentDiskVolumeSource",
+          "description": "GCEPersistentDisk represents a GCE Disk resource that is attached to a kubelet's host machine and then exposed to the pod. Provisioned by an admin. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk"
+        },
+        "glusterfs": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.GlusterfsPersistentVolumeSource",
+          "description": "Glusterfs represents a Glusterfs volume that is attached to a host and exposed to the pod. Provisioned by an admin. More info: https://releases.k8s.io/HEAD/examples/volumes/glusterfs/README.md"
+        },
+        "hostPath": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.HostPathVolumeSource",
+          "description": "HostPath represents a directory on the host. Provisioned by a developer or tester. This is useful for single-node development and testing only! On-host storage is not supported in any way and WILL NOT WORK in a multi-node cluster. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath"
+        },
+        "iscsi": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ISCSIPersistentVolumeSource",
+          "description": "ISCSI represents an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod. Provisioned by an admin."
+        },
+        "local": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.LocalVolumeSource",
+          "description": "Local represents directly-attached storage with node affinity"
+        },
+        "mountOptions": {
+          "description": "A list of mount options, e.g. [\"ro\", \"soft\"]. Not validated - mount will simply fail if one is invalid. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes/#mount-options",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "nfs": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.NFSVolumeSource",
+          "description": "NFS represents an NFS mount on the host. Provisioned by an admin. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs"
+        },
+        "nodeAffinity": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.VolumeNodeAffinity",
+          "description": "NodeAffinity defines constraints that limit what nodes this volume can be accessed from. This field influences the scheduling of pods that use this volume."
+        },
+        "persistentVolumeReclaimPolicy": {
+          "description": "What happens to a persistent volume when released from its claim. Valid options are Retain (default for manually created PersistentVolumes), Delete (default for dynamically provisioned PersistentVolumes), and Recycle (deprecated). Recycle must be supported by the volume plugin underlying this PersistentVolume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#reclaiming",
+          "type": "string"
+        },
+        "photonPersistentDisk": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.PhotonPersistentDiskVolumeSource",
+          "description": "PhotonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine"
+        },
+        "portworxVolume": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.PortworxVolumeSource",
+          "description": "PortworxVolume represents a portworx volume attached and mounted on kubelets host machine"
+        },
+        "quobyte": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.QuobyteVolumeSource",
+          "description": "Quobyte represents a Quobyte mount on the host that shares a pod's lifetime"
+        },
+        "rbd": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.RBDPersistentVolumeSource",
+          "description": "RBD represents a Rados Block Device mount on the host that shares a pod's lifetime. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md"
+        },
+        "scaleIO": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ScaleIOPersistentVolumeSource",
+          "description": "ScaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes."
+        },
+        "storageClassName": {
+          "description": "Name of StorageClass to which this persistent volume belongs. Empty value means that this volume does not belong to any StorageClass.",
+          "type": "string"
+        },
+        "storageos": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.StorageOSPersistentVolumeSource",
+          "description": "StorageOS represents a StorageOS volume that is attached to the kubelet's host machine and mounted into the pod More info: https://releases.k8s.io/HEAD/examples/volumes/storageos/README.md"
+        },
+        "volumeMode": {
+          "description": "volumeMode defines if a volume is intended to be used with a formatted filesystem or to remain in raw block state. Value of Filesystem is implied when not included in spec. This is a beta feature.",
+          "type": "string"
+        },
+        "vsphereVolume": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.VsphereVirtualDiskVolumeSource",
+          "description": "VsphereVolume represents a vSphere volume attached and mounted on kubelets host machine"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.PersistentVolumeStatus": {
+      "description": "PersistentVolumeStatus is the current status of a persistent volume.",
+      "properties": {
+        "message": {
+          "description": "A human-readable message indicating details about why the volume is in this state.",
+          "type": "string"
+        },
+        "phase": {
+          "description": "Phase indicates if a volume is available, bound to a claim, or released by a claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#phase",
+          "type": "string"
+        },
+        "reason": {
+          "description": "Reason is a brief CamelCase string that describes any failure and is meant for machine parsing and tidy display in the CLI.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.PhotonPersistentDiskVolumeSource": {
+      "description": "Represents a Photon Controller persistent disk resource.",
+      "properties": {
+        "fsType": {
+          "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+          "type": "string"
+        },
+        "pdID": {
+          "description": "ID that identifies Photon Controller persistent disk",
+          "type": "string"
+        }
+      },
+      "required": [
+        "pdID"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.Pod": {
+      "description": "Pod is a collection of containers that can run on a host. This resource is created by clients and scheduled onto hosts.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "Pod"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.PodSpec",
+          "description": "Specification of the desired behavior of the pod. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status"
+        },
+        "status": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.PodStatus",
+          "description": "Most recently observed status of the pod. This data may not be up to date. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status"
+        }
+      },
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "",
+          "kind": "Pod",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.core.v1.PodAffinity": {
+      "description": "Pod affinity is a group of inter pod affinity scheduling rules.",
+      "properties": {
+        "preferredDuringSchedulingIgnoredDuringExecution": {
+          "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.WeightedPodAffinityTerm"
+          },
+          "type": "array"
+        },
+        "requiredDuringSchedulingIgnoredDuringExecution": {
+          "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.PodAffinityTerm"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.PodAffinityTerm": {
+      "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+      "properties": {
+        "labelSelector": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+          "description": "A label query over a set of resources, in this case pods."
+        },
+        "namespaces": {
+          "description": "namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means \"this pod's namespace\"",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "topologyKey": {
+          "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "topologyKey"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.PodAntiAffinity": {
+      "description": "Pod anti affinity is a group of inter pod anti affinity scheduling rules.",
+      "properties": {
+        "preferredDuringSchedulingIgnoredDuringExecution": {
+          "description": "The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.WeightedPodAffinityTerm"
+          },
+          "type": "array"
+        },
+        "requiredDuringSchedulingIgnoredDuringExecution": {
+          "description": "If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.PodAffinityTerm"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.PodCondition": {
+      "description": "PodCondition contains details for the current condition of this pod.",
+      "properties": {
+        "lastProbeTime": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "Last time we probed the condition."
+        },
+        "lastTransitionTime": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "Last time the condition transitioned from one status to another."
+        },
+        "message": {
+          "description": "Human-readable message indicating details about last transition.",
+          "type": "string"
+        },
+        "reason": {
+          "description": "Unique, one-word, CamelCase reason for the condition's last transition.",
+          "type": "string"
+        },
+        "status": {
+          "description": "Status is the status of the condition. Can be True, False, Unknown. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions",
+          "type": "string"
+        },
+        "type": {
+          "description": "Type is the type of the condition. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "status"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.PodDNSConfig": {
+      "description": "PodDNSConfig defines the DNS parameters of a pod in addition to those generated from DNSPolicy.",
+      "properties": {
+        "nameservers": {
+          "description": "A list of DNS name server IP addresses. This will be appended to the base nameservers generated from DNSPolicy. Duplicated nameservers will be removed.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "options": {
+          "description": "A list of DNS resolver options. This will be merged with the base options generated from DNSPolicy. Duplicated entries will be removed. Resolution options given in Options will override those that appear in the base DNSPolicy.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.PodDNSConfigOption"
+          },
+          "type": "array"
+        },
+        "searches": {
+          "description": "A list of DNS search domains for host-name lookup. This will be appended to the base search paths generated from DNSPolicy. Duplicated search paths will be removed.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.PodDNSConfigOption": {
+      "description": "PodDNSConfigOption defines DNS resolver options of a pod.",
+      "properties": {
+        "name": {
+          "description": "Required.",
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.PodList": {
+      "description": "PodList is a list of Pods.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "List of pods. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.Pod"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "PodList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds"
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "",
+          "kind": "PodList",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.core.v1.PodReadinessGate": {
+      "description": "PodReadinessGate contains the reference to a pod condition",
+      "properties": {
+        "conditionType": {
+          "description": "ConditionType refers to a condition in the pod's condition list with matching type.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "conditionType"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.PodSecurityContext": {
+      "description": "PodSecurityContext holds pod-level security attributes and common container settings. Some fields are also present in container.securityContext.  Field values of container.securityContext take precedence over field values of PodSecurityContext.",
+      "properties": {
+        "fsGroup": {
+          "description": "A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod:\n\n1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw----\n\nIf unset, the Kubelet will not modify the ownership and permissions of any volume.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "runAsGroup": {
+          "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "runAsNonRoot": {
+          "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+          "type": "boolean"
+        },
+        "runAsUser": {
+          "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "seLinuxOptions": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.SELinuxOptions",
+          "description": "The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container."
+        },
+        "supplementalGroups": {
+          "description": "A list of groups applied to the first process run in each container, in addition to the container's primary GID.  If unspecified, no groups will be added to any container.",
+          "items": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "type": "array"
+        },
+        "sysctls": {
+          "description": "Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported sysctls (by the container runtime) might fail to launch.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.Sysctl"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.PodSpec": {
+      "description": "PodSpec is a description of a pod.",
+      "properties": {
+        "activeDeadlineSeconds": {
+          "description": "Optional duration in seconds the pod may be active on the node relative to StartTime before the system will actively try to mark it failed and kill associated containers. Value must be a positive integer.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "affinity": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.Affinity",
+          "description": "If specified, the pod's scheduling constraints"
+        },
+        "automountServiceAccountToken": {
+          "description": "AutomountServiceAccountToken indicates whether a service account token should be automatically mounted.",
+          "type": "boolean"
+        },
+        "containers": {
+          "description": "List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.Container"
+          },
+          "type": "array",
+          "x-kubernetes-patch-merge-key": "name",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "dnsConfig": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.PodDNSConfig",
+          "description": "Specifies the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS configuration based on DNSPolicy."
+        },
+        "dnsPolicy": {
+          "description": "Set DNS policy for the pod. Defaults to \"ClusterFirst\". Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy. To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'.",
+          "type": "string"
+        },
+        "enableServiceLinks": {
+          "description": "EnableServiceLinks indicates whether information about services should be injected into pod's environment variables, matching the syntax of Docker links. Optional: Defaults to true.",
+          "type": "boolean"
+        },
+        "hostAliases": {
+          "description": "HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified. This is only valid for non-hostNetwork pods.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.HostAlias"
+          },
+          "type": "array",
+          "x-kubernetes-patch-merge-key": "ip",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "hostIPC": {
+          "description": "Use the host's ipc namespace. Optional: Default to false.",
+          "type": "boolean"
+        },
+        "hostNetwork": {
+          "description": "Host networking requested for this pod. Use the host's network namespace. If this option is set, the ports that will be used must be specified. Default to false.",
+          "type": "boolean"
+        },
+        "hostPID": {
+          "description": "Use the host's pid namespace. Optional: Default to false.",
+          "type": "boolean"
+        },
+        "hostname": {
+          "description": "Specifies the hostname of the Pod If not specified, the pod's hostname will be set to a system-defined value.",
+          "type": "string"
+        },
+        "imagePullSecrets": {
+          "description": "ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference"
+          },
+          "type": "array",
+          "x-kubernetes-patch-merge-key": "name",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "initContainers": {
+          "description": "List of initialization containers belonging to the pod. Init containers are executed in order prior to containers being started. If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy. The name for an init container or normal container must be unique among all containers. Init containers may not have Lifecycle actions, Readiness probes, or Liveness probes. The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit for each resource type, and then using the max of of that value or the sum of the normal containers. Limits are applied to init containers in a similar fashion. Init containers cannot currently be added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.Container"
+          },
+          "type": "array",
+          "x-kubernetes-patch-merge-key": "name",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "nodeName": {
+          "description": "NodeName is a request to schedule this pod onto a specific node. If it is non-empty, the scheduler simply schedules this pod onto that node, assuming that it fits resource requirements.",
+          "type": "string"
+        },
+        "nodeSelector": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/",
+          "type": "object"
+        },
+        "priority": {
+          "description": "The priority value. Various system components use this field to find the priority of the pod. When Priority Admission Controller is enabled, it prevents users from setting this field. The admission controller populates this field from PriorityClassName. The higher the value, the higher the priority.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "priorityClassName": {
+          "description": "If specified, indicates the pod's priority. \"system-node-critical\" and \"system-cluster-critical\" are two special keywords which indicate the highest priorities with the former being the highest priority. Any other name must be defined by creating a PriorityClass object with that name. If not specified, the pod priority will be default or zero if there is no default.",
+          "type": "string"
+        },
+        "readinessGates": {
+          "description": "If specified, all readiness gates will be evaluated for pod readiness. A pod is ready when all its containers are ready AND all conditions specified in the readiness gates have status equal to \"True\" More info: https://git.k8s.io/enhancements/keps/sig-network/0007-pod-ready%2B%2B.md",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.PodReadinessGate"
+          },
+          "type": "array"
+        },
+        "restartPolicy": {
+          "description": "Restart policy for all containers within the pod. One of Always, OnFailure, Never. Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy",
+          "type": "string"
+        },
+        "runtimeClassName": {
+          "description": "RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run. If unset or empty, the \"legacy\" RuntimeClass will be used, which is an implicit class with an empty definition that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md This is an alpha feature and may change in the future.",
+          "type": "string"
+        },
+        "schedulerName": {
+          "description": "If specified, the pod will be dispatched by specified scheduler. If not specified, the pod will be dispatched by default scheduler.",
+          "type": "string"
+        },
+        "securityContext": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.PodSecurityContext",
+          "description": "SecurityContext holds pod-level security attributes and common container settings. Optional: Defaults to empty.  See type description for default values of each field."
+        },
+        "serviceAccount": {
+          "description": "DeprecatedServiceAccount is a depreciated alias for ServiceAccountName. Deprecated: Use serviceAccountName instead.",
+          "type": "string"
+        },
+        "serviceAccountName": {
+          "description": "ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/",
+          "type": "string"
+        },
+        "shareProcessNamespace": {
+          "description": "Share a single process namespace between all of the containers in a pod. When this is set containers will be able to view and signal processes from other containers in the same pod, and the first process in each container will not be assigned PID 1. HostPID and ShareProcessNamespace cannot both be set. Optional: Default to false. This field is beta-level and may be disabled with the PodShareProcessNamespace feature.",
+          "type": "boolean"
+        },
+        "subdomain": {
+          "description": "If specified, the fully qualified Pod hostname will be \"<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>\". If not specified, the pod will not have a domainname at all.",
+          "type": "string"
+        },
+        "terminationGracePeriodSeconds": {
+          "description": "Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period will be used instead. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. Defaults to 30 seconds.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "tolerations": {
+          "description": "If specified, the pod's tolerations.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.Toleration"
+          },
+          "type": "array"
+        },
+        "volumes": {
+          "description": "List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.Volume"
+          },
+          "type": "array",
+          "x-kubernetes-patch-merge-key": "name",
+          "x-kubernetes-patch-strategy": "merge,retainKeys"
+        }
+      },
+      "required": [
+        "containers"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.PodStatus": {
+      "description": "PodStatus represents information about the status of a pod. Status may trail the actual state of a system, especially if the node that hosts the pod cannot contact the control plane.",
+      "properties": {
+        "conditions": {
+          "description": "Current service state of pod. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.PodCondition"
+          },
+          "type": "array",
+          "x-kubernetes-patch-merge-key": "type",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "containerStatuses": {
+          "description": "The list has one entry per container in the manifest. Each entry is currently the output of `docker inspect`. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-and-container-status",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.ContainerStatus"
+          },
+          "type": "array"
+        },
+        "hostIP": {
+          "description": "IP address of the host to which the pod is assigned. Empty if not yet scheduled.",
+          "type": "string"
+        },
+        "initContainerStatuses": {
+          "description": "The list has one entry per init container in the manifest. The most recent successful init container will have ready = true, the most recently started container will have startTime set. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-and-container-status",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.ContainerStatus"
+          },
+          "type": "array"
+        },
+        "message": {
+          "description": "A human readable message indicating details about why the pod is in this condition.",
+          "type": "string"
+        },
+        "nominatedNodeName": {
+          "description": "nominatedNodeName is set only when this pod preempts other pods on the node, but it cannot be scheduled right away as preemption victims receive their graceful termination periods. This field does not guarantee that the pod will be scheduled on this node. Scheduler may decide to place the pod elsewhere if other nodes become available sooner. Scheduler may also decide to give the resources on this node to a higher priority pod that is created after preemption. As a result, this field may be different than PodSpec.nodeName when the pod is scheduled.",
+          "type": "string"
+        },
+        "phase": {
+          "description": "The phase of a Pod is a simple, high-level summary of where the Pod is in its lifecycle. The conditions array, the reason and message fields, and the individual container status arrays contain more detail about the pod's status. There are five possible phase values:\n\nPending: The pod has been accepted by the Kubernetes system, but one or more of the container images has not been created. This includes time before being scheduled as well as time spent downloading images over the network, which could take a while. Running: The pod has been bound to a node, and all of the containers have been created. At least one container is still running, or is in the process of starting or restarting. Succeeded: All containers in the pod have terminated in success, and will not be restarted. Failed: All containers in the pod have terminated, and at least one container has terminated in failure. The container either exited with non-zero status or was terminated by the system. Unknown: For some reason the state of the pod could not be obtained, typically due to an error in communicating with the host of the pod.\n\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-phase",
+          "type": "string"
+        },
+        "podIP": {
+          "description": "IP address allocated to the pod. Routable at least within the cluster. Empty if not yet allocated.",
+          "type": "string"
+        },
+        "qosClass": {
+          "description": "The Quality of Service (QOS) classification assigned to the pod based on resource requirements See PodQOSClass type for available QOS classes More info: https://git.k8s.io/community/contributors/design-proposals/node/resource-qos.md",
+          "type": "string"
+        },
+        "reason": {
+          "description": "A brief CamelCase message indicating details about why the pod is in this state. e.g. 'Evicted'",
+          "type": "string"
+        },
+        "startTime": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "RFC 3339 date and time at which the object was acknowledged by the Kubelet. This is before the Kubelet pulled the container image(s) for the pod."
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.PodTemplate": {
+      "description": "PodTemplate describes a template for creating copies of a predefined pod.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "PodTemplate"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+        },
+        "template": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.PodTemplateSpec",
+          "description": "Template defines the pods that will be created from this pod template. https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status"
+        }
+      },
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "",
+          "kind": "PodTemplate",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.core.v1.PodTemplateList": {
+      "description": "PodTemplateList is a list of PodTemplates.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "List of pod templates",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.PodTemplate"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "PodTemplateList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds"
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "",
+          "kind": "PodTemplateList",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.core.v1.PodTemplateSpec": {
+      "description": "PodTemplateSpec describes the data a pod should have when created from a template",
+      "properties": {
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.PodSpec",
+          "description": "Specification of the desired behavior of the pod. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.PortworxVolumeSource": {
+      "description": "PortworxVolumeSource represents a Portworx volume resource.",
+      "properties": {
+        "fsType": {
+          "description": "FSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+          "type": "string"
+        },
+        "readOnly": {
+          "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+          "type": "boolean"
+        },
+        "volumeID": {
+          "description": "VolumeID uniquely identifies a Portworx volume",
+          "type": "string"
+        }
+      },
+      "required": [
+        "volumeID"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.PreferredSchedulingTerm": {
+      "description": "An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
+      "properties": {
+        "preference": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.NodeSelectorTerm",
+          "description": "A node selector term, associated with the corresponding weight."
+        },
+        "weight": {
+          "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "weight",
+        "preference"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.Probe": {
+      "description": "Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.",
+      "properties": {
+        "exec": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ExecAction",
+          "description": "One and only one of the following should be specified. Exec specifies the action to take."
+        },
+        "failureThreshold": {
+          "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "httpGet": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.HTTPGetAction",
+          "description": "HTTPGet specifies the http request to perform."
+        },
+        "initialDelaySeconds": {
+          "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+          "format": "int32",
+          "type": "integer"
+        },
+        "periodSeconds": {
+          "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "successThreshold": {
+          "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "tcpSocket": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.TCPSocketAction",
+          "description": "TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported"
+        },
+        "timeoutSeconds": {
+          "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ProjectedVolumeSource": {
+      "description": "Represents a projected volume source",
+      "properties": {
+        "defaultMode": {
+          "description": "Mode bits to use on created files by default. Must be a value between 0 and 0777. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "sources": {
+          "description": "list of volume projections",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.VolumeProjection"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "sources"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.QuobyteVolumeSource": {
+      "description": "Represents a Quobyte mount that lasts the lifetime of a pod. Quobyte volumes do not support ownership management or SELinux relabeling.",
+      "properties": {
+        "group": {
+          "description": "Group to map volume access to Default is no group",
+          "type": "string"
+        },
+        "readOnly": {
+          "description": "ReadOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.",
+          "type": "boolean"
+        },
+        "registry": {
+          "description": "Registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes",
+          "type": "string"
+        },
+        "tenant": {
+          "description": "Tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin",
+          "type": "string"
+        },
+        "user": {
+          "description": "User to map volume access to Defaults to serivceaccount user",
+          "type": "string"
+        },
+        "volume": {
+          "description": "Volume is a string that references an already created Quobyte volume by name.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "registry",
+        "volume"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.RBDPersistentVolumeSource": {
+      "description": "Represents a Rados Block Device mount that lasts the lifetime of a pod. RBD volumes support ownership management and SELinux relabeling.",
+      "properties": {
+        "fsType": {
+          "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd",
+          "type": "string"
+        },
+        "image": {
+          "description": "The rados image name. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it",
+          "type": "string"
+        },
+        "keyring": {
+          "description": "Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it",
+          "type": "string"
+        },
+        "monitors": {
+          "description": "A collection of Ceph monitors. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "pool": {
+          "description": "The rados pool name. Default is rbd. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it",
+          "type": "string"
+        },
+        "readOnly": {
+          "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it",
+          "type": "boolean"
+        },
+        "secretRef": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.SecretReference",
+          "description": "SecretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it"
+        },
+        "user": {
+          "description": "The rados user name. Default is admin. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it",
+          "type": "string"
+        }
+      },
+      "required": [
+        "monitors",
+        "image"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.RBDVolumeSource": {
+      "description": "Represents a Rados Block Device mount that lasts the lifetime of a pod. RBD volumes support ownership management and SELinux relabeling.",
+      "properties": {
+        "fsType": {
+          "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd",
+          "type": "string"
+        },
+        "image": {
+          "description": "The rados image name. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it",
+          "type": "string"
+        },
+        "keyring": {
+          "description": "Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it",
+          "type": "string"
+        },
+        "monitors": {
+          "description": "A collection of Ceph monitors. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "pool": {
+          "description": "The rados pool name. Default is rbd. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it",
+          "type": "string"
+        },
+        "readOnly": {
+          "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it",
+          "type": "boolean"
+        },
+        "secretRef": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference",
+          "description": "SecretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it"
+        },
+        "user": {
+          "description": "The rados user name. Default is admin. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it",
+          "type": "string"
+        }
+      },
+      "required": [
+        "monitors",
+        "image"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ReplicationController": {
+      "description": "ReplicationController represents the configuration of a replication controller.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "ReplicationController"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "If the Labels of a ReplicationController are empty, they are defaulted to be the same as the Pod(s) that the replication controller manages. Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ReplicationControllerSpec",
+          "description": "Spec defines the specification of the desired behavior of the replication controller. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status"
+        },
+        "status": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ReplicationControllerStatus",
+          "description": "Status is the most recently observed status of the replication controller. This data may be out of date by some window of time. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status"
+        }
+      },
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "",
+          "kind": "ReplicationController",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.core.v1.ReplicationControllerCondition": {
+      "description": "ReplicationControllerCondition describes the state of a replication controller at a certain point.",
+      "properties": {
+        "lastTransitionTime": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "The last time the condition transitioned from one status to another."
+        },
+        "message": {
+          "description": "A human readable message indicating details about the transition.",
+          "type": "string"
+        },
+        "reason": {
+          "description": "The reason for the condition's last transition.",
+          "type": "string"
+        },
+        "status": {
+          "description": "Status of the condition, one of True, False, Unknown.",
+          "type": "string"
+        },
+        "type": {
+          "description": "Type of replication controller condition.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "status"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ReplicationControllerList": {
+      "description": "ReplicationControllerList is a collection of replication controllers.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "List of replication controllers. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.ReplicationController"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "ReplicationControllerList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds"
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "",
+          "kind": "ReplicationControllerList",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.core.v1.ReplicationControllerSpec": {
+      "description": "ReplicationControllerSpec is the specification of a replication controller.",
+      "properties": {
+        "minReadySeconds": {
+          "description": "Minimum number of seconds for which a newly created pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready)",
+          "format": "int32",
+          "type": "integer"
+        },
+        "replicas": {
+          "description": "Replicas is the number of desired replicas. This is a pointer to distinguish between explicit zero and unspecified. Defaults to 1. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#what-is-a-replicationcontroller",
+          "format": "int32",
+          "type": "integer"
+        },
+        "selector": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Selector is a label query over pods that should match the Replicas count. If Selector is empty, it is defaulted to the labels present on the Pod template. Label keys and values that must match in order to be controlled by this replication controller, if empty defaulted to labels on Pod template. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors",
+          "type": "object"
+        },
+        "template": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.PodTemplateSpec",
+          "description": "Template is the object that describes the pod that will be created if insufficient replicas are detected. This takes precedence over a TemplateRef. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ReplicationControllerStatus": {
+      "description": "ReplicationControllerStatus represents the current status of a replication controller.",
+      "properties": {
+        "availableReplicas": {
+          "description": "The number of available replicas (ready for at least minReadySeconds) for this replication controller.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "conditions": {
+          "description": "Represents the latest available observations of a replication controller's current state.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.ReplicationControllerCondition"
+          },
+          "type": "array",
+          "x-kubernetes-patch-merge-key": "type",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "fullyLabeledReplicas": {
+          "description": "The number of pods that have labels matching the labels of the pod template of the replication controller.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration reflects the generation of the most recently observed replication controller.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "readyReplicas": {
+          "description": "The number of ready replicas for this replication controller.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "replicas": {
+          "description": "Replicas is the most recently oberved number of replicas. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#what-is-a-replicationcontroller",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "replicas"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ResourceFieldSelector": {
+      "description": "ResourceFieldSelector represents container resources (cpu, memory) and their output format",
+      "properties": {
+        "containerName": {
+          "description": "Container name: required for volumes, optional for env vars",
+          "type": "string"
+        },
+        "divisor": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity",
+          "description": "Specifies the output format of the exposed resources, defaults to \"1\""
+        },
+        "resource": {
+          "description": "Required: resource to select",
+          "type": "string"
+        }
+      },
+      "required": [
+        "resource"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ResourceQuota": {
+      "description": "ResourceQuota sets aggregate quota restrictions enforced per namespace",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "ResourceQuota"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ResourceQuotaSpec",
+          "description": "Spec defines the desired quota. https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status"
+        },
+        "status": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ResourceQuotaStatus",
+          "description": "Status defines the actual enforced quota and its current usage. https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status"
+        }
+      },
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "",
+          "kind": "ResourceQuota",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.core.v1.ResourceQuotaList": {
+      "description": "ResourceQuotaList is a list of ResourceQuota items.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "Items is a list of ResourceQuota objects. More info: https://kubernetes.io/docs/concepts/policy/resource-quotas/",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.ResourceQuota"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "ResourceQuotaList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds"
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "",
+          "kind": "ResourceQuotaList",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.core.v1.ResourceQuotaSpec": {
+      "description": "ResourceQuotaSpec defines the desired hard limits to enforce for Quota.",
+      "properties": {
+        "hard": {
+          "additionalProperties": {
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
+          },
+          "description": "hard is the set of desired hard limits for each named resource. More info: https://kubernetes.io/docs/concepts/policy/resource-quotas/",
+          "type": "object"
+        },
+        "scopeSelector": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ScopeSelector",
+          "description": "scopeSelector is also a collection of filters like scopes that must match each object tracked by a quota but expressed using ScopeSelectorOperator in combination with possible values. For a resource to match, both scopes AND scopeSelector (if specified in spec), must be matched."
+        },
+        "scopes": {
+          "description": "A collection of filters that must match each object tracked by a quota. If not specified, the quota matches all objects.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ResourceQuotaStatus": {
+      "description": "ResourceQuotaStatus defines the enforced hard limits and observed use.",
+      "properties": {
+        "hard": {
+          "additionalProperties": {
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
+          },
+          "description": "Hard is the set of enforced hard limits for each named resource. More info: https://kubernetes.io/docs/concepts/policy/resource-quotas/",
+          "type": "object"
+        },
+        "used": {
+          "additionalProperties": {
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
+          },
+          "description": "Used is the current observed total usage of the resource in the namespace.",
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ResourceRequirements": {
+      "description": "ResourceRequirements describes the compute resource requirements.",
+      "properties": {
+        "limits": {
+          "additionalProperties": {
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
+          },
+          "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
+          "type": "object"
+        },
+        "requests": {
+          "additionalProperties": {
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
+          },
+          "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.SELinuxOptions": {
+      "description": "SELinuxOptions are the labels to be applied to the container",
+      "properties": {
+        "level": {
+          "description": "Level is SELinux level label that applies to the container.",
+          "type": "string"
+        },
+        "role": {
+          "description": "Role is a SELinux role label that applies to the container.",
+          "type": "string"
+        },
+        "type": {
+          "description": "Type is a SELinux type label that applies to the container.",
+          "type": "string"
+        },
+        "user": {
+          "description": "User is a SELinux user label that applies to the container.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ScaleIOPersistentVolumeSource": {
+      "description": "ScaleIOPersistentVolumeSource represents a persistent ScaleIO volume",
+      "properties": {
+        "fsType": {
+          "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Default is \"xfs\"",
+          "type": "string"
+        },
+        "gateway": {
+          "description": "The host address of the ScaleIO API Gateway.",
+          "type": "string"
+        },
+        "protectionDomain": {
+          "description": "The name of the ScaleIO Protection Domain for the configured storage.",
+          "type": "string"
+        },
+        "readOnly": {
+          "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+          "type": "boolean"
+        },
+        "secretRef": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.SecretReference",
+          "description": "SecretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail."
+        },
+        "sslEnabled": {
+          "description": "Flag to enable/disable SSL communication with Gateway, default false",
+          "type": "boolean"
+        },
+        "storageMode": {
+          "description": "Indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.",
+          "type": "string"
+        },
+        "storagePool": {
+          "description": "The ScaleIO Storage Pool associated with the protection domain.",
+          "type": "string"
+        },
+        "system": {
+          "description": "The name of the storage system as configured in ScaleIO.",
+          "type": "string"
+        },
+        "volumeName": {
+          "description": "The name of a volume already created in the ScaleIO system that is associated with this volume source.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "gateway",
+        "system",
+        "secretRef"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ScaleIOVolumeSource": {
+      "description": "ScaleIOVolumeSource represents a persistent ScaleIO volume",
+      "properties": {
+        "fsType": {
+          "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Default is \"xfs\".",
+          "type": "string"
+        },
+        "gateway": {
+          "description": "The host address of the ScaleIO API Gateway.",
+          "type": "string"
+        },
+        "protectionDomain": {
+          "description": "The name of the ScaleIO Protection Domain for the configured storage.",
+          "type": "string"
+        },
+        "readOnly": {
+          "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+          "type": "boolean"
+        },
+        "secretRef": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference",
+          "description": "SecretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail."
+        },
+        "sslEnabled": {
+          "description": "Flag to enable/disable SSL communication with Gateway, default false",
+          "type": "boolean"
+        },
+        "storageMode": {
+          "description": "Indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.",
+          "type": "string"
+        },
+        "storagePool": {
+          "description": "The ScaleIO Storage Pool associated with the protection domain.",
+          "type": "string"
+        },
+        "system": {
+          "description": "The name of the storage system as configured in ScaleIO.",
+          "type": "string"
+        },
+        "volumeName": {
+          "description": "The name of a volume already created in the ScaleIO system that is associated with this volume source.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "gateway",
+        "system",
+        "secretRef"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ScopeSelector": {
+      "description": "A scope selector represents the AND of the selectors represented by the scoped-resource selector requirements.",
+      "properties": {
+        "matchExpressions": {
+          "description": "A list of scope selector requirements by scope of the resources.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.ScopedResourceSelectorRequirement"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ScopedResourceSelectorRequirement": {
+      "description": "A scoped-resource selector requirement is a selector that contains values, a scope name, and an operator that relates the scope name and values.",
+      "properties": {
+        "operator": {
+          "description": "Represents a scope's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist.",
+          "type": "string"
+        },
+        "scopeName": {
+          "description": "The name of the scope that the selector applies to.",
+          "type": "string"
+        },
+        "values": {
+          "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "scopeName",
+        "operator"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.Secret": {
+      "description": "Secret holds secret data of a certain type. The total bytes of the values in the Data field must be less than MaxSecretSize bytes.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "data": {
+          "additionalProperties": {
+            "format": "byte",
+            "type": "string"
+          },
+          "description": "Data contains the secret data. Each key must consist of alphanumeric characters, '-', '_' or '.'. The serialized form of the secret data is a base64 encoded string, representing the arbitrary (possibly non-string) data value here. Described in https://tools.ietf.org/html/rfc4648#section-4",
+          "type": "object"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "Secret"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+        },
+        "stringData": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "stringData allows specifying non-binary secret data in string form. It is provided as a write-only convenience method. All keys and values are merged into the data field on write, overwriting any existing values. It is never output when reading from the API.",
+          "type": "object"
+        },
+        "type": {
+          "description": "Used to facilitate programmatic handling of secret data.",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "",
+          "kind": "Secret",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.core.v1.SecretEnvSource": {
+      "description": "SecretEnvSource selects a Secret to populate the environment variables with.\n\nThe contents of the target Secret's Data field will represent the key-value pairs as environment variables.",
+      "properties": {
+        "name": {
+          "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+          "type": "string"
+        },
+        "optional": {
+          "description": "Specify whether the Secret must be defined",
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.SecretKeySelector": {
+      "description": "SecretKeySelector selects a key of a Secret.",
+      "properties": {
+        "key": {
+          "description": "The key of the secret to select from.  Must be a valid secret key.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+          "type": "string"
+        },
+        "optional": {
+          "description": "Specify whether the Secret or it's key must be defined",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "key"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.SecretList": {
+      "description": "SecretList is a list of Secret.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "Items is a list of secret objects. More info: https://kubernetes.io/docs/concepts/configuration/secret",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.Secret"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "SecretList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds"
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "",
+          "kind": "SecretList",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.core.v1.SecretProjection": {
+      "description": "Adapts a secret into a projected volume.\n\nThe contents of the target Secret's Data field will be presented in a projected volume as files using the keys in the Data field as the file names. Note that this is identical to a secret volume source without the default mode.",
+      "properties": {
+        "items": {
+          "description": "If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.KeyToPath"
+          },
+          "type": "array"
+        },
+        "name": {
+          "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+          "type": "string"
+        },
+        "optional": {
+          "description": "Specify whether the Secret or its key must be defined",
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.SecretReference": {
+      "description": "SecretReference represents a Secret Reference. It has enough information to retrieve secret in any namespace",
+      "properties": {
+        "name": {
+          "description": "Name is unique within a namespace to reference a secret resource.",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace defines the space within which the secret name must be unique.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.SecretVolumeSource": {
+      "description": "Adapts a Secret into a volume.\n\nThe contents of the target Secret's Data field will be presented in a volume as files using the keys in the Data field as the file names. Secret volumes support ownership management and SELinux relabeling.",
+      "properties": {
+        "defaultMode": {
+          "description": "Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "items": {
+          "description": "If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.KeyToPath"
+          },
+          "type": "array"
+        },
+        "optional": {
+          "description": "Specify whether the Secret or it's keys must be defined",
+          "type": "boolean"
+        },
+        "secretName": {
+          "description": "Name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.SecurityContext": {
+      "description": "SecurityContext holds security configuration that will be applied to a container. Some fields are present in both SecurityContext and PodSecurityContext.  When both are set, the values in SecurityContext take precedence.",
+      "properties": {
+        "allowPrivilegeEscalation": {
+          "description": "AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN",
+          "type": "boolean"
+        },
+        "capabilities": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.Capabilities",
+          "description": "The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime."
+        },
+        "privileged": {
+          "description": "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.",
+          "type": "boolean"
+        },
+        "procMount": {
+          "description": "procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.",
+          "type": "string"
+        },
+        "readOnlyRootFilesystem": {
+          "description": "Whether this container has a read-only root filesystem. Default is false.",
+          "type": "boolean"
+        },
+        "runAsGroup": {
+          "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "runAsNonRoot": {
+          "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+          "type": "boolean"
+        },
+        "runAsUser": {
+          "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "seLinuxOptions": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.SELinuxOptions",
+          "description": "The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence."
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.Service": {
+      "description": "Service is a named abstraction of software service (for example, mysql) consisting of local port (for example 3306) that the proxy listens on, and the selector that determines which pods will answer requests sent through the proxy.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "Service"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ServiceSpec",
+          "description": "Spec defines the behavior of a service. https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status"
+        },
+        "status": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ServiceStatus",
+          "description": "Most recently observed status of the service. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status"
+        }
+      },
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "",
+          "kind": "Service",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.core.v1.ServiceAccount": {
+      "description": "ServiceAccount binds together: * a name, understood by users, and perhaps by peripheral systems, for an identity * a principal that can be authenticated and authorized * a set of secrets",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "automountServiceAccountToken": {
+          "description": "AutomountServiceAccountToken indicates whether pods running as this service account should have an API token automatically mounted. Can be overridden at the pod level.",
+          "type": "boolean"
+        },
+        "imagePullSecrets": {
+          "description": "ImagePullSecrets is a list of references to secrets in the same namespace to use for pulling any images in pods that reference this ServiceAccount. ImagePullSecrets are distinct from Secrets because Secrets can be mounted in the pod, but ImagePullSecrets are only accessed by the kubelet. More info: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "ServiceAccount"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+        },
+        "secrets": {
+          "description": "Secrets is the list of secrets allowed to be used by pods running using this ServiceAccount. More info: https://kubernetes.io/docs/concepts/configuration/secret",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.ObjectReference"
+          },
+          "type": "array",
+          "x-kubernetes-patch-merge-key": "name",
+          "x-kubernetes-patch-strategy": "merge"
+        }
+      },
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "",
+          "kind": "ServiceAccount",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.core.v1.ServiceAccountList": {
+      "description": "ServiceAccountList is a list of ServiceAccount objects",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "List of ServiceAccounts. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.ServiceAccount"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "ServiceAccountList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds"
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "",
+          "kind": "ServiceAccountList",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.core.v1.ServiceAccountTokenProjection": {
+      "description": "ServiceAccountTokenProjection represents a projected service account token volume. This projection can be used to insert a service account token into the pods runtime filesystem for use against APIs (Kubernetes API Server or otherwise).",
+      "properties": {
+        "audience": {
+          "description": "Audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.",
+          "type": "string"
+        },
+        "expirationSeconds": {
+          "description": "ExpirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "path": {
+          "description": "Path is the path relative to the mount point of the file to project the token into.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ServiceList": {
+      "description": "ServiceList holds a list of services.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "List of services",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.Service"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "ServiceList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds"
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "",
+          "kind": "ServiceList",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.core.v1.ServicePort": {
+      "description": "ServicePort contains information on service's port.",
+      "properties": {
+        "name": {
+          "description": "The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. This maps to the 'Name' field in EndpointPort objects. Optional if only one ServicePort is defined on this service.",
+          "type": "string"
+        },
+        "nodePort": {
+          "description": "The port on each node on which this service is exposed when type=NodePort or LoadBalancer. Usually assigned by the system. If specified, it will be allocated to the service if unused or else creation of the service will fail. Default is to auto-allocate a port if the ServiceType of this Service requires one. More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport",
+          "format": "int32",
+          "type": "integer"
+        },
+        "port": {
+          "description": "The port that will be exposed by this service.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "protocol": {
+          "description": "The IP protocol for this port. Supports \"TCP\", \"UDP\", and \"SCTP\". Default is TCP.",
+          "type": "string"
+        },
+        "targetPort": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.util.intstr.IntOrString",
+          "description": "Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod's container ports. If this is not specified, the value of the 'port' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the 'port' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service"
+        }
+      },
+      "required": [
+        "port"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ServiceSpec": {
+      "description": "ServiceSpec describes the attributes that a user creates on a service.",
+      "properties": {
+        "clusterIP": {
+          "description": "clusterIP is the IP address of the service and is usually assigned randomly by the master. If an address is specified manually and is not in use by others, it will be allocated to the service; otherwise, creation of the service will fail. This field can not be changed through updates. Valid values are \"None\", empty string (\"\"), or a valid IP address. \"None\" can be specified for headless services when proxying is not required. Only applies to types ClusterIP, NodePort, and LoadBalancer. Ignored if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies",
+          "type": "string"
+        },
+        "externalIPs": {
+          "description": "externalIPs is a list of IP addresses for which nodes in the cluster will also accept traffic for this service.  These IPs are not managed by Kubernetes.  The user is responsible for ensuring that traffic arrives at a node with this IP.  A common example is external load-balancers that are not part of the Kubernetes system.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "externalName": {
+          "description": "externalName is the external reference that kubedns or equivalent will return as a CNAME record for this service. No proxying will be involved. Must be a valid RFC-1123 hostname (https://tools.ietf.org/html/rfc1123) and requires Type to be ExternalName.",
+          "type": "string"
+        },
+        "externalTrafficPolicy": {
+          "description": "externalTrafficPolicy denotes if this Service desires to route external traffic to node-local or cluster-wide endpoints. \"Local\" preserves the client source IP and avoids a second hop for LoadBalancer and Nodeport type services, but risks potentially imbalanced traffic spreading. \"Cluster\" obscures the client source IP and may cause a second hop to another node, but should have good overall load-spreading.",
+          "type": "string"
+        },
+        "healthCheckNodePort": {
+          "description": "healthCheckNodePort specifies the healthcheck nodePort for the service. If not specified, HealthCheckNodePort is created by the service api backend with the allocated nodePort. Will use user-specified nodePort value if specified by the client. Only effects when Type is set to LoadBalancer and ExternalTrafficPolicy is set to Local.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "loadBalancerIP": {
+          "description": "Only applies to Service Type: LoadBalancer LoadBalancer will get created with the IP specified in this field. This feature depends on whether the underlying cloud-provider supports specifying the loadBalancerIP when a load balancer is created. This field will be ignored if the cloud-provider does not support the feature.",
+          "type": "string"
+        },
+        "loadBalancerSourceRanges": {
+          "description": "If specified and supported by the platform, this will restrict traffic through the cloud-provider load-balancer will be restricted to the specified client IPs. This field will be ignored if the cloud-provider does not support the feature.\" More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "ports": {
+          "description": "The list of ports that are exposed by this service. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.ServicePort"
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "port",
+            "protocol"
+          ],
+          "x-kubernetes-list-type": "map",
+          "x-kubernetes-patch-merge-key": "port",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "publishNotReadyAddresses": {
+          "description": "publishNotReadyAddresses, when set to true, indicates that DNS implementations must publish the notReadyAddresses of subsets for the Endpoints associated with the Service. The default value is false. The primary use case for setting this field is to use a StatefulSet's Headless Service to propagate SRV records for its Pods without respect to their readiness for purpose of peer discovery.",
+          "type": "boolean"
+        },
+        "selector": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Route service traffic to pods with label keys and values matching this selector. If empty or not present, the service is assumed to have an external process managing its endpoints, which Kubernetes will not modify. Only applies to types ClusterIP, NodePort, and LoadBalancer. Ignored if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/",
+          "type": "object"
+        },
+        "sessionAffinity": {
+          "description": "Supports \"ClientIP\" and \"None\". Used to maintain session affinity. Enable client IP based session affinity. Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies",
+          "type": "string"
+        },
+        "sessionAffinityConfig": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.SessionAffinityConfig",
+          "description": "sessionAffinityConfig contains the configurations of session affinity."
+        },
+        "type": {
+          "description": "type determines how the Service is exposed. Defaults to ClusterIP. Valid options are ExternalName, ClusterIP, NodePort, and LoadBalancer. \"ExternalName\" maps to the specified externalName. \"ClusterIP\" allocates a cluster-internal IP address for load-balancing to endpoints. Endpoints are determined by the selector or if that is not specified, by manual construction of an Endpoints object. If clusterIP is \"None\", no virtual IP is allocated and the endpoints are published as a set of endpoints rather than a stable IP. \"NodePort\" builds on ClusterIP and allocates a port on every node which routes to the clusterIP. \"LoadBalancer\" builds on NodePort and creates an external load-balancer (if supported in the current cloud) which routes to the clusterIP. More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ServiceStatus": {
+      "description": "ServiceStatus represents the current status of a service.",
+      "properties": {
+        "loadBalancer": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.LoadBalancerStatus",
+          "description": "LoadBalancer contains the current status of the load-balancer, if one is present."
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.SessionAffinityConfig": {
+      "description": "SessionAffinityConfig represents the configurations of session affinity.",
+      "properties": {
+        "clientIP": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ClientIPConfig",
+          "description": "clientIP contains the configurations of Client IP based session affinity."
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.StorageOSPersistentVolumeSource": {
+      "description": "Represents a StorageOS persistent volume resource.",
+      "properties": {
+        "fsType": {
+          "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+          "type": "string"
+        },
+        "readOnly": {
+          "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+          "type": "boolean"
+        },
+        "secretRef": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ObjectReference",
+          "description": "SecretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted."
+        },
+        "volumeName": {
+          "description": "VolumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.",
+          "type": "string"
+        },
+        "volumeNamespace": {
+          "description": "VolumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to \"default\" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.StorageOSVolumeSource": {
+      "description": "Represents a StorageOS persistent volume resource.",
+      "properties": {
+        "fsType": {
+          "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+          "type": "string"
+        },
+        "readOnly": {
+          "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+          "type": "boolean"
+        },
+        "secretRef": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference",
+          "description": "SecretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted."
+        },
+        "volumeName": {
+          "description": "VolumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.",
+          "type": "string"
+        },
+        "volumeNamespace": {
+          "description": "VolumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to \"default\" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.Sysctl": {
+      "description": "Sysctl defines a kernel parameter to be set",
+      "properties": {
+        "name": {
+          "description": "Name of a property to set",
+          "type": "string"
+        },
+        "value": {
+          "description": "Value of a property to set",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "value"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.TCPSocketAction": {
+      "description": "TCPSocketAction describes an action based on opening a socket",
+      "properties": {
+        "host": {
+          "description": "Optional: Host name to connect to, defaults to the pod IP.",
+          "type": "string"
+        },
+        "port": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.util.intstr.IntOrString",
+          "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME."
+        }
+      },
+      "required": [
+        "port"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.Taint": {
+      "description": "The node this Taint is attached to has the \"effect\" on any pod that does not tolerate the Taint.",
+      "properties": {
+        "effect": {
+          "description": "Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.",
+          "type": "string"
+        },
+        "key": {
+          "description": "Required. The taint key to be applied to a node.",
+          "type": "string"
+        },
+        "timeAdded": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints."
+        },
+        "value": {
+          "description": "Required. The taint value corresponding to the taint key.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "key",
+        "effect"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.Toleration": {
+      "description": "The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.",
+      "properties": {
+        "effect": {
+          "description": "Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
+          "type": "string"
+        },
+        "key": {
+          "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+          "type": "string"
+        },
+        "operator": {
+          "description": "Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.",
+          "type": "string"
+        },
+        "tolerationSeconds": {
+          "description": "TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "value": {
+          "description": "Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.TopologySelectorLabelRequirement": {
+      "description": "A topology selector requirement is a selector that matches given label. This is an alpha feature and may change in the future.",
+      "properties": {
+        "key": {
+          "description": "The label key that the selector applies to.",
+          "type": "string"
+        },
+        "values": {
+          "description": "An array of string values. One value must match the label to be selected. Each entry in Values is ORed.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "key",
+        "values"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.TopologySelectorTerm": {
+      "description": "A topology selector term represents the result of label queries. A null or empty topology selector term matches no objects. The requirements of them are ANDed. It provides a subset of functionality as NodeSelectorTerm. This is an alpha feature and may change in the future.",
+      "properties": {
+        "matchLabelExpressions": {
+          "description": "A list of topology selector requirements by labels.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.TopologySelectorLabelRequirement"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.TypedLocalObjectReference": {
+      "description": "TypedLocalObjectReference contains enough information to let you locate the typed referenced object inside the same namespace.",
+      "properties": {
+        "apiGroup": {
+          "description": "APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is the type of resource being referenced",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name is the name of resource being referenced",
+          "type": "string"
+        }
+      },
+      "required": [
+        "kind",
+        "name"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.Volume": {
+      "description": "Volume represents a named volume in a pod that may be accessed by any container in the pod.",
+      "properties": {
+        "awsElasticBlockStore": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.AWSElasticBlockStoreVolumeSource",
+          "description": "AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore"
+        },
+        "azureDisk": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.AzureDiskVolumeSource",
+          "description": "AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod."
+        },
+        "azureFile": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.AzureFileVolumeSource",
+          "description": "AzureFile represents an Azure File Service mount on the host and bind mount to the pod."
+        },
+        "cephfs": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.CephFSVolumeSource",
+          "description": "CephFS represents a Ceph FS mount on the host that shares a pod's lifetime"
+        },
+        "cinder": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.CinderVolumeSource",
+          "description": "Cinder represents a cinder volume attached and mounted on kubelets host machine More info: https://releases.k8s.io/HEAD/examples/mysql-cinder-pd/README.md"
+        },
+        "configMap": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ConfigMapVolumeSource",
+          "description": "ConfigMap represents a configMap that should populate this volume"
+        },
+        "csi": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.CSIVolumeSource",
+          "description": "CSI (Container Storage Interface) represents storage that is handled by an external CSI driver (Alpha feature)."
+        },
+        "downwardAPI": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.DownwardAPIVolumeSource",
+          "description": "DownwardAPI represents downward API about the pod that should populate this volume"
+        },
+        "emptyDir": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.EmptyDirVolumeSource",
+          "description": "EmptyDir represents a temporary directory that shares a pod's lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir"
+        },
+        "fc": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.FCVolumeSource",
+          "description": "FC represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod."
+        },
+        "flexVolume": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.FlexVolumeSource",
+          "description": "FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin."
+        },
+        "flocker": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.FlockerVolumeSource",
+          "description": "Flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running"
+        },
+        "gcePersistentDisk": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.GCEPersistentDiskVolumeSource",
+          "description": "GCEPersistentDisk represents a GCE Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk"
+        },
+        "gitRepo": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.GitRepoVolumeSource",
+          "description": "GitRepo represents a git repository at a particular revision. DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container."
+        },
+        "glusterfs": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.GlusterfsVolumeSource",
+          "description": "Glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime. More info: https://releases.k8s.io/HEAD/examples/volumes/glusterfs/README.md"
+        },
+        "hostPath": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.HostPathVolumeSource",
+          "description": "HostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath"
+        },
+        "iscsi": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ISCSIVolumeSource",
+          "description": "ISCSI represents an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://releases.k8s.io/HEAD/examples/volumes/iscsi/README.md"
+        },
+        "name": {
+          "description": "Volume's name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+          "type": "string"
+        },
+        "nfs": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.NFSVolumeSource",
+          "description": "NFS represents an NFS mount on the host that shares a pod's lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs"
+        },
+        "persistentVolumeClaim": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.PersistentVolumeClaimVolumeSource",
+          "description": "PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims"
+        },
+        "photonPersistentDisk": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.PhotonPersistentDiskVolumeSource",
+          "description": "PhotonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine"
+        },
+        "portworxVolume": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.PortworxVolumeSource",
+          "description": "PortworxVolume represents a portworx volume attached and mounted on kubelets host machine"
+        },
+        "projected": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ProjectedVolumeSource",
+          "description": "Items for all in one resources secrets, configmaps, and downward API"
+        },
+        "quobyte": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.QuobyteVolumeSource",
+          "description": "Quobyte represents a Quobyte mount on the host that shares a pod's lifetime"
+        },
+        "rbd": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.RBDVolumeSource",
+          "description": "RBD represents a Rados Block Device mount on the host that shares a pod's lifetime. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md"
+        },
+        "scaleIO": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ScaleIOVolumeSource",
+          "description": "ScaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes."
+        },
+        "secret": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.SecretVolumeSource",
+          "description": "Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret"
+        },
+        "storageos": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.StorageOSVolumeSource",
+          "description": "StorageOS represents a StorageOS volume attached and mounted on Kubernetes nodes."
+        },
+        "vsphereVolume": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.VsphereVirtualDiskVolumeSource",
+          "description": "VsphereVolume represents a vSphere volume attached and mounted on kubelets host machine"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.VolumeDevice": {
+      "description": "volumeDevice describes a mapping of a raw block device within a container.",
+      "properties": {
+        "devicePath": {
+          "description": "devicePath is the path inside of the container that the device will be mapped to.",
+          "type": "string"
+        },
+        "name": {
+          "description": "name must match the name of a persistentVolumeClaim in the pod",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "devicePath"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.VolumeMount": {
+      "description": "VolumeMount describes a mounting of a Volume within a container.",
+      "properties": {
+        "mountPath": {
+          "description": "Path within the container at which the volume should be mounted.  Must not contain ':'.",
+          "type": "string"
+        },
+        "mountPropagation": {
+          "description": "mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.",
+          "type": "string"
+        },
+        "name": {
+          "description": "This must match the Name of a Volume.",
+          "type": "string"
+        },
+        "readOnly": {
+          "description": "Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.",
+          "type": "boolean"
+        },
+        "subPath": {
+          "description": "Path within the volume from which the container's volume should be mounted. Defaults to \"\" (volume's root).",
+          "type": "string"
+        },
+        "subPathExpr": {
+          "description": "Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to \"\" (volume's root). SubPathExpr and SubPath are mutually exclusive. This field is alpha in 1.14.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "mountPath"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.VolumeNodeAffinity": {
+      "description": "VolumeNodeAffinity defines constraints that limit what nodes this volume can be accessed from.",
+      "properties": {
+        "required": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.NodeSelector",
+          "description": "Required specifies hard node constraints that must be met."
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.VolumeProjection": {
+      "description": "Projection that may be projected along with other supported volume types",
+      "properties": {
+        "configMap": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ConfigMapProjection",
+          "description": "information about the configMap data to project"
+        },
+        "downwardAPI": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.DownwardAPIProjection",
+          "description": "information about the downwardAPI data to project"
+        },
+        "secret": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.SecretProjection",
+          "description": "information about the secret data to project"
+        },
+        "serviceAccountToken": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ServiceAccountTokenProjection",
+          "description": "information about the serviceAccountToken data to project"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.VsphereVirtualDiskVolumeSource": {
+      "description": "Represents a vSphere volume resource.",
+      "properties": {
+        "fsType": {
+          "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+          "type": "string"
+        },
+        "storagePolicyID": {
+          "description": "Storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.",
+          "type": "string"
+        },
+        "storagePolicyName": {
+          "description": "Storage Policy Based Management (SPBM) profile name.",
+          "type": "string"
+        },
+        "volumePath": {
+          "description": "Path that identifies vSphere volume vmdk",
+          "type": "string"
+        }
+      },
+      "required": [
+        "volumePath"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.WeightedPodAffinityTerm": {
+      "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+      "properties": {
+        "podAffinityTerm": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.PodAffinityTerm",
+          "description": "Required. A pod affinity term, associated with the corresponding weight."
+        },
+        "weight": {
+          "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "weight",
+        "podAffinityTerm"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.events.v1beta1.Event": {
+      "description": "Event is a report of an event somewhere in the cluster. It generally denotes some state change in the system.",
+      "properties": {
+        "action": {
+          "description": "What action was taken/failed regarding to the regarding object.",
+          "type": "string"
+        },
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "deprecatedCount": {
+          "description": "Deprecated field assuring backward compatibility with core.v1 Event type",
+          "format": "int32",
+          "type": "integer"
+        },
+        "deprecatedFirstTimestamp": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "Deprecated field assuring backward compatibility with core.v1 Event type"
+        },
+        "deprecatedLastTimestamp": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "Deprecated field assuring backward compatibility with core.v1 Event type"
+        },
+        "deprecatedSource": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.EventSource",
+          "description": "Deprecated field assuring backward compatibility with core.v1 Event type"
+        },
+        "eventTime": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime",
+          "description": "Required. Time when this Event was first observed."
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "Event"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+        },
+        "note": {
+          "description": "Optional. A human-readable description of the status of this operation. Maximal length of the note is 1kB, but libraries should be prepared to handle values up to 64kB.",
+          "type": "string"
+        },
+        "reason": {
+          "description": "Why the action was taken.",
+          "type": "string"
+        },
+        "regarding": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ObjectReference",
+          "description": "The object this Event is about. In most cases it's an Object reporting controller implements. E.g. ReplicaSetController implements ReplicaSets and this event is emitted because it acts on some changes in a ReplicaSet object."
+        },
+        "related": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ObjectReference",
+          "description": "Optional secondary object for more complex actions. E.g. when regarding object triggers a creation or deletion of related object."
+        },
+        "reportingController": {
+          "description": "Name of the controller that emitted this Event, e.g. `kubernetes.io/kubelet`.",
+          "type": "string"
+        },
+        "reportingInstance": {
+          "description": "ID of the controller instance, e.g. `kubelet-xyzf`.",
+          "type": "string"
+        },
+        "series": {
+          "$ref": "#/definitions/io.k8s.api.events.v1beta1.EventSeries",
+          "description": "Data about the Event series this event represents or nil if it's a singleton Event."
+        },
+        "type": {
+          "description": "Type of this event (Normal, Warning), new types could be added in the future.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "eventTime"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "events.k8s.io",
+          "kind": "Event",
+          "version": "v1beta1"
+        }
+      ]
+    },
+    "io.k8s.api.events.v1beta1.EventList": {
+      "description": "EventList is a list of Event objects.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "Items is a list of schema objects.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.events.v1beta1.Event"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "EventList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "events.k8s.io",
+          "kind": "EventList",
+          "version": "v1beta1"
+        }
+      ]
+    },
+    "io.k8s.api.events.v1beta1.EventSeries": {
+      "description": "EventSeries contain information on series of events, i.e. thing that was/is happening continuously for some time.",
+      "properties": {
+        "count": {
+          "description": "Number of occurrences in this series up to the last heartbeat time",
+          "format": "int32",
+          "type": "integer"
+        },
+        "lastObservedTime": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime",
+          "description": "Time when last Event from the series was seen before last heartbeat."
+        },
+        "state": {
+          "description": "Information whether this series is ongoing or finished.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "count",
+        "lastObservedTime",
+        "state"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.extensions.v1beta1.AllowedCSIDriver": {
+      "description": "AllowedCSIDriver represents a single inline CSI Driver that is allowed to be used.",
+      "properties": {
+        "name": {
+          "description": "Name is the registered name of the CSI driver",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.extensions.v1beta1.AllowedFlexVolume": {
+      "description": "AllowedFlexVolume represents a single Flexvolume that is allowed to be used. Deprecated: use AllowedFlexVolume from policy API Group instead.",
+      "properties": {
+        "driver": {
+          "description": "driver is the name of the Flexvolume driver.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "driver"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.extensions.v1beta1.AllowedHostPath": {
+      "description": "AllowedHostPath defines the host volume conditions that will be enabled by a policy for pods to use. It requires the path prefix to be defined. Deprecated: use AllowedHostPath from policy API Group instead.",
+      "properties": {
+        "pathPrefix": {
+          "description": "pathPrefix is the path prefix that the host volume must match. It does not support `*`. Trailing slashes are trimmed when validating the path prefix with a host path.\n\nExamples: `/foo` would allow `/foo`, `/foo/` and `/foo/bar` `/foo` would not allow `/food` or `/etc/foo`",
+          "type": "string"
+        },
+        "readOnly": {
+          "description": "when set to true, will allow host volumes matching the pathPrefix only if all volume mounts are readOnly.",
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.extensions.v1beta1.DaemonSet": {
+      "description": "DEPRECATED - This group version of DaemonSet is deprecated by apps/v1beta2/DaemonSet. See the release notes for more information. DaemonSet represents the configuration of a daemon set.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "DaemonSet"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.DaemonSetSpec",
+          "description": "The desired behavior of this daemon set. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
+        },
+        "status": {
+          "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.DaemonSetStatus",
+          "description": "The current status of this daemon set. This data may be out of date by some window of time. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
+        }
+      },
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "extensions",
+          "kind": "DaemonSet",
+          "version": "v1beta1"
+        }
+      ]
+    },
+    "io.k8s.api.extensions.v1beta1.DaemonSetCondition": {
+      "description": "DaemonSetCondition describes the state of a DaemonSet at a certain point.",
+      "properties": {
+        "lastTransitionTime": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "Last time the condition transitioned from one status to another."
+        },
+        "message": {
+          "description": "A human readable message indicating details about the transition.",
+          "type": "string"
+        },
+        "reason": {
+          "description": "The reason for the condition's last transition.",
+          "type": "string"
+        },
+        "status": {
+          "description": "Status of the condition, one of True, False, Unknown.",
+          "type": "string"
+        },
+        "type": {
+          "description": "Type of DaemonSet condition.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "status"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.extensions.v1beta1.DaemonSetList": {
+      "description": "DaemonSetList is a collection of daemon sets.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "A list of daemon sets.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.DaemonSet"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "DaemonSetList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "extensions",
+          "kind": "DaemonSetList",
+          "version": "v1beta1"
+        }
+      ]
+    },
+    "io.k8s.api.extensions.v1beta1.DaemonSetSpec": {
+      "description": "DaemonSetSpec is the specification of a daemon set.",
+      "properties": {
+        "minReadySeconds": {
+          "description": "The minimum number of seconds for which a newly created DaemonSet pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready).",
+          "format": "int32",
+          "type": "integer"
+        },
+        "revisionHistoryLimit": {
+          "description": "The number of old history to retain to allow rollback. This is a pointer to distinguish between explicit zero and not specified. Defaults to 10.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "selector": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+          "description": "A label query over pods that are managed by the daemon set. Must match in order to be controlled. If empty, defaulted to labels on Pod template. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors"
+        },
+        "template": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.PodTemplateSpec",
+          "description": "An object that describes the pod that will be created. The DaemonSet will create exactly one copy of this pod on every node that matches the template's node selector (or on every node if no node selector is specified). More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template"
+        },
+        "templateGeneration": {
+          "description": "DEPRECATED. A sequence number representing a specific generation of the template. Populated by the system. It can be set only during the creation.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "updateStrategy": {
+          "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.DaemonSetUpdateStrategy",
+          "description": "An update strategy to replace existing DaemonSet pods with new pods."
+        }
+      },
+      "required": [
+        "template"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.extensions.v1beta1.DaemonSetStatus": {
+      "description": "DaemonSetStatus represents the current status of a daemon set.",
+      "properties": {
+        "collisionCount": {
+          "description": "Count of hash collisions for the DaemonSet. The DaemonSet controller uses this field as a collision avoidance mechanism when it needs to create the name for the newest ControllerRevision.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "conditions": {
+          "description": "Represents the latest available observations of a DaemonSet's current state.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.DaemonSetCondition"
+          },
+          "type": "array",
+          "x-kubernetes-patch-merge-key": "type",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "currentNumberScheduled": {
+          "description": "The number of nodes that are running at least 1 daemon pod and are supposed to run the daemon pod. More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/",
+          "format": "int32",
+          "type": "integer"
+        },
+        "desiredNumberScheduled": {
+          "description": "The total number of nodes that should be running the daemon pod (including nodes correctly running the daemon pod). More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/",
+          "format": "int32",
+          "type": "integer"
+        },
+        "numberAvailable": {
+          "description": "The number of nodes that should be running the daemon pod and have one or more of the daemon pod running and available (ready for at least spec.minReadySeconds)",
+          "format": "int32",
+          "type": "integer"
+        },
+        "numberMisscheduled": {
+          "description": "The number of nodes that are running the daemon pod, but are not supposed to run the daemon pod. More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/",
+          "format": "int32",
+          "type": "integer"
+        },
+        "numberReady": {
+          "description": "The number of nodes that should be running the daemon pod and have one or more of the daemon pod running and ready.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "numberUnavailable": {
+          "description": "The number of nodes that should be running the daemon pod and have none of the daemon pod running and available (ready for at least spec.minReadySeconds)",
+          "format": "int32",
+          "type": "integer"
+        },
+        "observedGeneration": {
+          "description": "The most recent generation observed by the daemon set controller.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "updatedNumberScheduled": {
+          "description": "The total number of nodes that are running updated daemon pod",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "currentNumberScheduled",
+        "numberMisscheduled",
+        "desiredNumberScheduled",
+        "numberReady"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.extensions.v1beta1.DaemonSetUpdateStrategy": {
+      "properties": {
+        "rollingUpdate": {
+          "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.RollingUpdateDaemonSet",
+          "description": "Rolling update config params. Present only if type = \"RollingUpdate\"."
+        },
+        "type": {
+          "description": "Type of daemon set update. Can be \"RollingUpdate\" or \"OnDelete\". Default is OnDelete.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.extensions.v1beta1.Deployment": {
+      "description": "DEPRECATED - This group version of Deployment is deprecated by apps/v1beta2/Deployment. See the release notes for more information. Deployment enables declarative updates for Pods and ReplicaSets.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "Deployment"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object metadata."
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.DeploymentSpec",
+          "description": "Specification of the desired behavior of the Deployment."
+        },
+        "status": {
+          "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.DeploymentStatus",
+          "description": "Most recently observed status of the Deployment."
+        }
+      },
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "extensions",
+          "kind": "Deployment",
+          "version": "v1beta1"
+        }
+      ]
+    },
+    "io.k8s.api.extensions.v1beta1.DeploymentCondition": {
+      "description": "DeploymentCondition describes the state of a deployment at a certain point.",
+      "properties": {
+        "lastTransitionTime": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "Last time the condition transitioned from one status to another."
+        },
+        "lastUpdateTime": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "The last time this condition was updated."
+        },
+        "message": {
+          "description": "A human readable message indicating details about the transition.",
+          "type": "string"
+        },
+        "reason": {
+          "description": "The reason for the condition's last transition.",
+          "type": "string"
+        },
+        "status": {
+          "description": "Status of the condition, one of True, False, Unknown.",
+          "type": "string"
+        },
+        "type": {
+          "description": "Type of deployment condition.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "status"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.extensions.v1beta1.DeploymentList": {
+      "description": "DeploymentList is a list of Deployments.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "Items is the list of Deployments.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.Deployment"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "DeploymentList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "Standard list metadata."
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "extensions",
+          "kind": "DeploymentList",
+          "version": "v1beta1"
+        }
+      ]
+    },
+    "io.k8s.api.extensions.v1beta1.DeploymentRollback": {
+      "description": "DEPRECATED. DeploymentRollback stores the information required to rollback a deployment.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "DeploymentRollback"
+          ]
+        },
+        "name": {
+          "description": "Required: This must match the Name of a deployment.",
+          "type": "string"
+        },
+        "rollbackTo": {
+          "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.RollbackConfig",
+          "description": "The config of this deployment rollback."
+        },
+        "updatedAnnotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "The annotations to be updated to a deployment",
+          "type": "object"
+        }
+      },
+      "required": [
+        "name",
+        "rollbackTo"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "extensions",
+          "kind": "DeploymentRollback",
+          "version": "v1beta1"
+        }
+      ]
+    },
+    "io.k8s.api.extensions.v1beta1.DeploymentSpec": {
+      "description": "DeploymentSpec is the specification of the desired behavior of the Deployment.",
+      "properties": {
+        "minReadySeconds": {
+          "description": "Minimum number of seconds for which a newly created pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready)",
+          "format": "int32",
+          "type": "integer"
+        },
+        "paused": {
+          "description": "Indicates that the deployment is paused and will not be processed by the deployment controller.",
+          "type": "boolean"
+        },
+        "progressDeadlineSeconds": {
+          "description": "The maximum time in seconds for a deployment to make progress before it is considered to be failed. The deployment controller will continue to process failed deployments and a condition with a ProgressDeadlineExceeded reason will be surfaced in the deployment status. Note that progress will not be estimated during the time a deployment is paused. This is set to the max value of int32 (i.e. 2147483647) by default, which means \"no deadline\".",
+          "format": "int32",
+          "type": "integer"
+        },
+        "replicas": {
+          "description": "Number of desired pods. This is a pointer to distinguish between explicit zero and not specified. Defaults to 1.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "revisionHistoryLimit": {
+          "description": "The number of old ReplicaSets to retain to allow rollback. This is a pointer to distinguish between explicit zero and not specified. This is set to the max value of int32 (i.e. 2147483647) by default, which means \"retaining all old RelicaSets\".",
+          "format": "int32",
+          "type": "integer"
+        },
+        "rollbackTo": {
+          "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.RollbackConfig",
+          "description": "DEPRECATED. The config this deployment is rolling back to. Will be cleared after rollback is done."
+        },
+        "selector": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+          "description": "Label selector for pods. Existing ReplicaSets whose pods are selected by this will be the ones affected by this deployment."
+        },
+        "strategy": {
+          "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.DeploymentStrategy",
+          "description": "The deployment strategy to use to replace existing pods with new ones.",
+          "x-kubernetes-patch-strategy": "retainKeys"
+        },
+        "template": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.PodTemplateSpec",
+          "description": "Template describes the pods that will be created."
+        }
+      },
+      "required": [
+        "template"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.extensions.v1beta1.DeploymentStatus": {
+      "description": "DeploymentStatus is the most recently observed status of the Deployment.",
+      "properties": {
+        "availableReplicas": {
+          "description": "Total number of available pods (ready for at least minReadySeconds) targeted by this deployment.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "collisionCount": {
+          "description": "Count of hash collisions for the Deployment. The Deployment controller uses this field as a collision avoidance mechanism when it needs to create the name for the newest ReplicaSet.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "conditions": {
+          "description": "Represents the latest available observations of a deployment's current state.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.DeploymentCondition"
+          },
+          "type": "array",
+          "x-kubernetes-patch-merge-key": "type",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "observedGeneration": {
+          "description": "The generation observed by the deployment controller.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "readyReplicas": {
+          "description": "Total number of ready pods targeted by this deployment.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "replicas": {
+          "description": "Total number of non-terminated pods targeted by this deployment (their labels match the selector).",
+          "format": "int32",
+          "type": "integer"
+        },
+        "unavailableReplicas": {
+          "description": "Total number of unavailable pods targeted by this deployment. This is the total number of pods that are still required for the deployment to have 100% available capacity. They may either be pods that are running but not yet available or pods that still have not been created.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "updatedReplicas": {
+          "description": "Total number of non-terminated pods targeted by this deployment that have the desired template spec.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.extensions.v1beta1.DeploymentStrategy": {
+      "description": "DeploymentStrategy describes how to replace existing pods with new ones.",
+      "properties": {
+        "rollingUpdate": {
+          "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.RollingUpdateDeployment",
+          "description": "Rolling update config params. Present only if DeploymentStrategyType = RollingUpdate."
+        },
+        "type": {
+          "description": "Type of deployment. Can be \"Recreate\" or \"RollingUpdate\". Default is RollingUpdate.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.extensions.v1beta1.FSGroupStrategyOptions": {
+      "description": "FSGroupStrategyOptions defines the strategy type and options used to create the strategy. Deprecated: use FSGroupStrategyOptions from policy API Group instead.",
+      "properties": {
+        "ranges": {
+          "description": "ranges are the allowed ranges of fs groups.  If you would like to force a single fs group then supply a single range with the same start and end. Required for MustRunAs.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.IDRange"
+          },
+          "type": "array"
+        },
+        "rule": {
+          "description": "rule is the strategy that will dictate what FSGroup is used in the SecurityContext.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.extensions.v1beta1.HTTPIngressPath": {
+      "description": "HTTPIngressPath associates a path regex with a backend. Incoming urls matching the path are forwarded to the backend.",
+      "properties": {
+        "backend": {
+          "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.IngressBackend",
+          "description": "Backend defines the referenced service endpoint to which the traffic will be forwarded to."
+        },
+        "path": {
+          "description": "Path is an extended POSIX regex as defined by IEEE Std 1003.1, (i.e this follows the egrep/unix syntax, not the perl syntax) matched against the path of an incoming request. Currently it can contain characters disallowed from the conventional \"path\" part of a URL as defined by RFC 3986. Paths must begin with a '/'. If unspecified, the path defaults to a catch all sending traffic to the backend.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "backend"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.extensions.v1beta1.HTTPIngressRuleValue": {
+      "description": "HTTPIngressRuleValue is a list of http selectors pointing to backends. In the example: http://<host>/<path>?<searchpart> -> backend where where parts of the url correspond to RFC 3986, this resource will be used to match against everything after the last '/' and before the first '?' or '#'.",
+      "properties": {
+        "paths": {
+          "description": "A collection of paths that map requests to backends.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.HTTPIngressPath"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "paths"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.extensions.v1beta1.HostPortRange": {
+      "description": "HostPortRange defines a range of host ports that will be enabled by a policy for pods to use.  It requires both the start and end to be defined. Deprecated: use HostPortRange from policy API Group instead.",
+      "properties": {
+        "max": {
+          "description": "max is the end of the range, inclusive.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "min": {
+          "description": "min is the start of the range, inclusive.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "min",
+        "max"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.extensions.v1beta1.IDRange": {
+      "description": "IDRange provides a min/max of an allowed range of IDs. Deprecated: use IDRange from policy API Group instead.",
+      "properties": {
+        "max": {
+          "description": "max is the end of the range, inclusive.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "min": {
+          "description": "min is the start of the range, inclusive.",
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "min",
+        "max"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.extensions.v1beta1.IPBlock": {
+      "description": "DEPRECATED 1.9 - This group version of IPBlock is deprecated by networking/v1/IPBlock. IPBlock describes a particular CIDR (Ex. \"192.168.1.1/24\") that is allowed to the pods matched by a NetworkPolicySpec's podSelector. The except entry describes CIDRs that should not be included within this rule.",
+      "properties": {
+        "cidr": {
+          "description": "CIDR is a string representing the IP Block Valid examples are \"192.168.1.1/24\"",
+          "type": "string"
+        },
+        "except": {
+          "description": "Except is a slice of CIDRs that should not be included within an IP Block Valid examples are \"192.168.1.1/24\" Except values will be rejected if they are outside the CIDR range",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "cidr"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.extensions.v1beta1.Ingress": {
+      "description": "Ingress is a collection of rules that allow inbound connections to reach the endpoints defined by a backend. An Ingress can be configured to give services externally-reachable urls, load balance traffic, terminate SSL, offer name based virtual hosting etc. DEPRECATED - This group version of Ingress is deprecated by networking.k8s.io/v1beta1 Ingress. See the release notes for more information.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "Ingress"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.IngressSpec",
+          "description": "Spec is the desired state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
+        },
+        "status": {
+          "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.IngressStatus",
+          "description": "Status is the current state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
+        }
+      },
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "extensions",
+          "kind": "Ingress",
+          "version": "v1beta1"
+        }
+      ]
+    },
+    "io.k8s.api.extensions.v1beta1.IngressBackend": {
+      "description": "IngressBackend describes all endpoints for a given service and port.",
+      "properties": {
+        "serviceName": {
+          "description": "Specifies the name of the referenced service.",
+          "type": "string"
+        },
+        "servicePort": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.util.intstr.IntOrString",
+          "description": "Specifies the port of the referenced service."
+        }
+      },
+      "required": [
+        "serviceName",
+        "servicePort"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.extensions.v1beta1.IngressList": {
+      "description": "IngressList is a collection of Ingress.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "Items is the list of Ingress.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.Ingress"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "IngressList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "extensions",
+          "kind": "IngressList",
+          "version": "v1beta1"
+        }
+      ]
+    },
+    "io.k8s.api.extensions.v1beta1.IngressRule": {
+      "description": "IngressRule represents the rules mapping the paths under a specified host to the related backend services. Incoming requests are first evaluated for a host match, then routed to the backend associated with the matching IngressRuleValue.",
+      "properties": {
+        "host": {
+          "description": "Host is the fully qualified domain name of a network host, as defined by RFC 3986. Note the following deviations from the \"host\" part of the URI as defined in the RFC: 1. IPs are not allowed. Currently an IngressRuleValue can only apply to the\n\t  IP in the Spec of the parent Ingress.\n2. The `:` delimiter is not respected because ports are not allowed.\n\t  Currently the port of an Ingress is implicitly :80 for http and\n\t  :443 for https.\nBoth these may change in the future. Incoming requests are matched against the host before the IngressRuleValue. If the host is unspecified, the Ingress routes all traffic based on the specified IngressRuleValue.",
+          "type": "string"
+        },
+        "http": {
+          "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.HTTPIngressRuleValue"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.extensions.v1beta1.IngressSpec": {
+      "description": "IngressSpec describes the Ingress the user wishes to exist.",
+      "properties": {
+        "backend": {
+          "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.IngressBackend",
+          "description": "A default backend capable of servicing requests that don't match any rule. At least one of 'backend' or 'rules' must be specified. This field is optional to allow the loadbalancer controller or defaulting logic to specify a global default."
+        },
+        "rules": {
+          "description": "A list of host rules used to configure the Ingress. If unspecified, or no rule matches, all traffic is sent to the default backend.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.IngressRule"
+          },
+          "type": "array"
+        },
+        "tls": {
+          "description": "TLS configuration. Currently the Ingress only supports a single TLS port, 443. If multiple members of this list specify different hosts, they will be multiplexed on the same port according to the hostname specified through the SNI TLS extension, if the ingress controller fulfilling the ingress supports SNI.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.IngressTLS"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.extensions.v1beta1.IngressStatus": {
+      "description": "IngressStatus describe the current state of the Ingress.",
+      "properties": {
+        "loadBalancer": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.LoadBalancerStatus",
+          "description": "LoadBalancer contains the current status of the load-balancer."
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.extensions.v1beta1.IngressTLS": {
+      "description": "IngressTLS describes the transport layer security associated with an Ingress.",
+      "properties": {
+        "hosts": {
+          "description": "Hosts are a list of hosts included in the TLS certificate. The values in this list must match the name/s used in the tlsSecret. Defaults to the wildcard host setting for the loadbalancer controller fulfilling this Ingress, if left unspecified.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "secretName": {
+          "description": "SecretName is the name of the secret used to terminate SSL traffic on 443. Field is left optional to allow SSL routing based on SNI hostname alone. If the SNI host in a listener conflicts with the \"Host\" header field used by an IngressRule, the SNI host is used for termination and value of the Host header is used for routing.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.extensions.v1beta1.NetworkPolicy": {
+      "description": "DEPRECATED 1.9 - This group version of NetworkPolicy is deprecated by networking/v1/NetworkPolicy. NetworkPolicy describes what network traffic is allowed for a set of Pods",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "NetworkPolicy"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.NetworkPolicySpec",
+          "description": "Specification of the desired behavior for this NetworkPolicy."
+        }
+      },
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "extensions",
+          "kind": "NetworkPolicy",
+          "version": "v1beta1"
+        }
+      ]
+    },
+    "io.k8s.api.extensions.v1beta1.NetworkPolicyEgressRule": {
+      "description": "DEPRECATED 1.9 - This group version of NetworkPolicyEgressRule is deprecated by networking/v1/NetworkPolicyEgressRule. NetworkPolicyEgressRule describes a particular set of traffic that is allowed out of pods matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and to. This type is beta-level in 1.8",
+      "properties": {
+        "ports": {
+          "description": "List of destination ports for outgoing traffic. Each item in this list is combined using a logical OR. If this field is empty or missing, this rule matches all ports (traffic not restricted by port). If this field is present and contains at least one item, then this rule allows traffic only if the traffic matches at least one port in the list.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.NetworkPolicyPort"
+          },
+          "type": "array"
+        },
+        "to": {
+          "description": "List of destinations for outgoing traffic of pods selected for this rule. Items in this list are combined using a logical OR operation. If this field is empty or missing, this rule matches all destinations (traffic not restricted by destination). If this field is present and contains at least one item, this rule allows traffic only if the traffic matches at least one item in the to list.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.NetworkPolicyPeer"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.extensions.v1beta1.NetworkPolicyIngressRule": {
+      "description": "DEPRECATED 1.9 - This group version of NetworkPolicyIngressRule is deprecated by networking/v1/NetworkPolicyIngressRule. This NetworkPolicyIngressRule matches traffic if and only if the traffic matches both ports AND from.",
+      "properties": {
+        "from": {
+          "description": "List of sources which should be able to access the pods selected for this rule. Items in this list are combined using a logical OR operation. If this field is empty or missing, this rule matches all sources (traffic not restricted by source). If this field is present and contains at least on item, this rule allows traffic only if the traffic matches at least one item in the from list.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.NetworkPolicyPeer"
+          },
+          "type": "array"
+        },
+        "ports": {
+          "description": "List of ports which should be made accessible on the pods selected for this rule. Each item in this list is combined using a logical OR. If this field is empty or missing, this rule matches all ports (traffic not restricted by port). If this field is present and contains at least one item, then this rule allows traffic only if the traffic matches at least one port in the list.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.NetworkPolicyPort"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.extensions.v1beta1.NetworkPolicyList": {
+      "description": "DEPRECATED 1.9 - This group version of NetworkPolicyList is deprecated by networking/v1/NetworkPolicyList. Network Policy List is a list of NetworkPolicy objects.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "Items is a list of schema objects.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.NetworkPolicy"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "NetworkPolicyList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "extensions",
+          "kind": "NetworkPolicyList",
+          "version": "v1beta1"
+        }
+      ]
+    },
+    "io.k8s.api.extensions.v1beta1.NetworkPolicyPeer": {
+      "description": "DEPRECATED 1.9 - This group version of NetworkPolicyPeer is deprecated by networking/v1/NetworkPolicyPeer.",
+      "properties": {
+        "ipBlock": {
+          "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.IPBlock",
+          "description": "IPBlock defines policy on a particular IPBlock. If this field is set then neither of the other fields can be."
+        },
+        "namespaceSelector": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+          "description": "Selects Namespaces using cluster-scoped labels. This field follows standard label selector semantics; if present but empty, it selects all namespaces.\n\nIf PodSelector is also set, then the NetworkPolicyPeer as a whole selects the Pods matching PodSelector in the Namespaces selected by NamespaceSelector. Otherwise it selects all Pods in the Namespaces selected by NamespaceSelector."
+        },
+        "podSelector": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+          "description": "This is a label selector which selects Pods. This field follows standard label selector semantics; if present but empty, it selects all pods.\n\nIf NamespaceSelector is also set, then the NetworkPolicyPeer as a whole selects the Pods matching PodSelector in the Namespaces selected by NamespaceSelector. Otherwise it selects the Pods matching PodSelector in the policy's own Namespace."
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.extensions.v1beta1.NetworkPolicyPort": {
+      "description": "DEPRECATED 1.9 - This group version of NetworkPolicyPort is deprecated by networking/v1/NetworkPolicyPort.",
+      "properties": {
+        "port": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.util.intstr.IntOrString",
+          "description": "If specified, the port on the given protocol.  This can either be a numerical or named port on a pod.  If this field is not provided, this matches all port names and numbers. If present, only traffic on the specified protocol AND port will be matched."
+        },
+        "protocol": {
+          "description": "Optional.  The protocol (TCP, UDP, or SCTP) which traffic must match. If not specified, this field defaults to TCP.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.extensions.v1beta1.NetworkPolicySpec": {
+      "description": "DEPRECATED 1.9 - This group version of NetworkPolicySpec is deprecated by networking/v1/NetworkPolicySpec.",
+      "properties": {
+        "egress": {
+          "description": "List of egress rules to be applied to the selected pods. Outgoing traffic is allowed if there are no NetworkPolicies selecting the pod (and cluster policy otherwise allows the traffic), OR if the traffic matches at least one egress rule across all of the NetworkPolicy objects whose podSelector matches the pod. If this field is empty then this NetworkPolicy limits all outgoing traffic (and serves solely to ensure that the pods it selects are isolated by default). This field is beta-level in 1.8",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.NetworkPolicyEgressRule"
+          },
+          "type": "array"
+        },
+        "ingress": {
+          "description": "List of ingress rules to be applied to the selected pods. Traffic is allowed to a pod if there are no NetworkPolicies selecting the pod OR if the traffic source is the pod's local node, OR if the traffic matches at least one ingress rule across all of the NetworkPolicy objects whose podSelector matches the pod. If this field is empty then this NetworkPolicy does not allow any traffic (and serves solely to ensure that the pods it selects are isolated by default).",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.NetworkPolicyIngressRule"
+          },
+          "type": "array"
+        },
+        "podSelector": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+          "description": "Selects the pods to which this NetworkPolicy object applies.  The array of ingress rules is applied to any pods selected by this field. Multiple network policies can select the same set of pods.  In this case, the ingress rules for each are combined additively. This field is NOT optional and follows standard label selector semantics. An empty podSelector matches all pods in this namespace."
+        },
+        "policyTypes": {
+          "description": "List of rule types that the NetworkPolicy relates to. Valid options are \"Ingress\", \"Egress\", or \"Ingress,Egress\". If this field is not specified, it will default based on the existence of Ingress or Egress rules; policies that contain an Egress section are assumed to affect Egress, and all policies (whether or not they contain an Ingress section) are assumed to affect Ingress. If you want to write an egress-only policy, you must explicitly specify policyTypes [ \"Egress\" ]. Likewise, if you want to write a policy that specifies that no egress is allowed, you must specify a policyTypes value that include \"Egress\" (since such a policy would not include an Egress section and would otherwise default to just [ \"Ingress\" ]). This field is beta-level in 1.8",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "podSelector"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.extensions.v1beta1.PodSecurityPolicy": {
+      "description": "PodSecurityPolicy governs the ability to make requests that affect the Security Context that will be applied to a pod and container. Deprecated: use PodSecurityPolicy from policy API Group instead.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "PodSecurityPolicy"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.PodSecurityPolicySpec",
+          "description": "spec defines the policy enforced."
+        }
+      },
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "extensions",
+          "kind": "PodSecurityPolicy",
+          "version": "v1beta1"
+        }
+      ]
+    },
+    "io.k8s.api.extensions.v1beta1.PodSecurityPolicyList": {
+      "description": "PodSecurityPolicyList is a list of PodSecurityPolicy objects. Deprecated: use PodSecurityPolicyList from policy API Group instead.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "items is a list of schema objects.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.PodSecurityPolicy"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "PodSecurityPolicyList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "extensions",
+          "kind": "PodSecurityPolicyList",
+          "version": "v1beta1"
+        }
+      ]
+    },
+    "io.k8s.api.extensions.v1beta1.PodSecurityPolicySpec": {
+      "description": "PodSecurityPolicySpec defines the policy enforced. Deprecated: use PodSecurityPolicySpec from policy API Group instead.",
+      "properties": {
+        "allowPrivilegeEscalation": {
+          "description": "allowPrivilegeEscalation determines if a pod can request to allow privilege escalation. If unspecified, defaults to true.",
+          "type": "boolean"
+        },
+        "allowedCSIDrivers": {
+          "description": "AllowedCSIDrivers is a whitelist of inline CSI drivers that must be explicitly set to be embedded within a pod spec. An empty value means no CSI drivers can run inline within a pod spec.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.AllowedCSIDriver"
+          },
+          "type": "array"
+        },
+        "allowedCapabilities": {
+          "description": "allowedCapabilities is a list of capabilities that can be requested to add to the container. Capabilities in this field may be added at the pod author's discretion. You must not list a capability in both allowedCapabilities and requiredDropCapabilities.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "allowedFlexVolumes": {
+          "description": "allowedFlexVolumes is a whitelist of allowed Flexvolumes.  Empty or nil indicates that all Flexvolumes may be used.  This parameter is effective only when the usage of the Flexvolumes is allowed in the \"volumes\" field.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.AllowedFlexVolume"
+          },
+          "type": "array"
+        },
+        "allowedHostPaths": {
+          "description": "allowedHostPaths is a white list of allowed host paths. Empty indicates that all host paths may be used.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.AllowedHostPath"
+          },
+          "type": "array"
+        },
+        "allowedProcMountTypes": {
+          "description": "AllowedProcMountTypes is a whitelist of allowed ProcMountTypes. Empty or nil indicates that only the DefaultProcMountType may be used. This requires the ProcMountType feature flag to be enabled.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "allowedUnsafeSysctls": {
+          "description": "allowedUnsafeSysctls is a list of explicitly allowed unsafe sysctls, defaults to none. Each entry is either a plain sysctl name or ends in \"*\" in which case it is considered as a prefix of allowed sysctls. Single * means all unsafe sysctls are allowed. Kubelet has to whitelist all allowed unsafe sysctls explicitly to avoid rejection.\n\nExamples: e.g. \"foo/*\" allows \"foo/bar\", \"foo/baz\", etc. e.g. \"foo.*\" allows \"foo.bar\", \"foo.baz\", etc.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "defaultAddCapabilities": {
+          "description": "defaultAddCapabilities is the default set of capabilities that will be added to the container unless the pod spec specifically drops the capability.  You may not list a capability in both defaultAddCapabilities and requiredDropCapabilities. Capabilities added here are implicitly allowed, and need not be included in the allowedCapabilities list.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "defaultAllowPrivilegeEscalation": {
+          "description": "defaultAllowPrivilegeEscalation controls the default setting for whether a process can gain more privileges than its parent process.",
+          "type": "boolean"
+        },
+        "forbiddenSysctls": {
+          "description": "forbiddenSysctls is a list of explicitly forbidden sysctls, defaults to none. Each entry is either a plain sysctl name or ends in \"*\" in which case it is considered as a prefix of forbidden sysctls. Single * means all sysctls are forbidden.\n\nExamples: e.g. \"foo/*\" forbids \"foo/bar\", \"foo/baz\", etc. e.g. \"foo.*\" forbids \"foo.bar\", \"foo.baz\", etc.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "fsGroup": {
+          "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.FSGroupStrategyOptions",
+          "description": "fsGroup is the strategy that will dictate what fs group is used by the SecurityContext."
+        },
+        "hostIPC": {
+          "description": "hostIPC determines if the policy allows the use of HostIPC in the pod spec.",
+          "type": "boolean"
+        },
+        "hostNetwork": {
+          "description": "hostNetwork determines if the policy allows the use of HostNetwork in the pod spec.",
+          "type": "boolean"
+        },
+        "hostPID": {
+          "description": "hostPID determines if the policy allows the use of HostPID in the pod spec.",
+          "type": "boolean"
+        },
+        "hostPorts": {
+          "description": "hostPorts determines which host port ranges are allowed to be exposed.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.HostPortRange"
+          },
+          "type": "array"
+        },
+        "privileged": {
+          "description": "privileged determines if a pod can request to be run as privileged.",
+          "type": "boolean"
+        },
+        "readOnlyRootFilesystem": {
+          "description": "readOnlyRootFilesystem when set to true will force containers to run with a read only root file system.  If the container specifically requests to run with a non-read only root file system the PSP should deny the pod. If set to false the container may run with a read only root file system if it wishes but it will not be forced to.",
+          "type": "boolean"
+        },
+        "requiredDropCapabilities": {
+          "description": "requiredDropCapabilities are the capabilities that will be dropped from the container.  These are required to be dropped and cannot be added.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "runAsGroup": {
+          "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.RunAsGroupStrategyOptions",
+          "description": "RunAsGroup is the strategy that will dictate the allowable RunAsGroup values that may be set. If this field is omitted, the pod's RunAsGroup can take any value. This field requires the RunAsGroup feature gate to be enabled."
+        },
+        "runAsUser": {
+          "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.RunAsUserStrategyOptions",
+          "description": "runAsUser is the strategy that will dictate the allowable RunAsUser values that may be set."
+        },
+        "seLinux": {
+          "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.SELinuxStrategyOptions",
+          "description": "seLinux is the strategy that will dictate the allowable labels that may be set."
+        },
+        "supplementalGroups": {
+          "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.SupplementalGroupsStrategyOptions",
+          "description": "supplementalGroups is the strategy that will dictate what supplemental groups are used by the SecurityContext."
+        },
+        "volumes": {
+          "description": "volumes is a white list of allowed volume plugins. Empty indicates that no volumes may be used. To allow all volumes you may use '*'.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "seLinux",
+        "runAsUser",
+        "supplementalGroups",
+        "fsGroup"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.extensions.v1beta1.ReplicaSet": {
+      "description": "DEPRECATED - This group version of ReplicaSet is deprecated by apps/v1beta2/ReplicaSet. See the release notes for more information. ReplicaSet ensures that a specified number of pod replicas are running at any given time.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "ReplicaSet"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "If the Labels of a ReplicaSet are empty, they are defaulted to be the same as the Pod(s) that the ReplicaSet manages. Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.ReplicaSetSpec",
+          "description": "Spec defines the specification of the desired behavior of the ReplicaSet. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
+        },
+        "status": {
+          "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.ReplicaSetStatus",
+          "description": "Status is the most recently observed status of the ReplicaSet. This data may be out of date by some window of time. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
+        }
+      },
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "extensions",
+          "kind": "ReplicaSet",
+          "version": "v1beta1"
+        }
+      ]
+    },
+    "io.k8s.api.extensions.v1beta1.ReplicaSetCondition": {
+      "description": "ReplicaSetCondition describes the state of a replica set at a certain point.",
+      "properties": {
+        "lastTransitionTime": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "The last time the condition transitioned from one status to another."
+        },
+        "message": {
+          "description": "A human readable message indicating details about the transition.",
+          "type": "string"
+        },
+        "reason": {
+          "description": "The reason for the condition's last transition.",
+          "type": "string"
+        },
+        "status": {
+          "description": "Status of the condition, one of True, False, Unknown.",
+          "type": "string"
+        },
+        "type": {
+          "description": "Type of replica set condition.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "status"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.extensions.v1beta1.ReplicaSetList": {
+      "description": "ReplicaSetList is a collection of ReplicaSets.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "List of ReplicaSets. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.ReplicaSet"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "ReplicaSetList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "extensions",
+          "kind": "ReplicaSetList",
+          "version": "v1beta1"
+        }
+      ]
+    },
+    "io.k8s.api.extensions.v1beta1.ReplicaSetSpec": {
+      "description": "ReplicaSetSpec is the specification of a ReplicaSet.",
+      "properties": {
+        "minReadySeconds": {
+          "description": "Minimum number of seconds for which a newly created pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready)",
+          "format": "int32",
+          "type": "integer"
+        },
+        "replicas": {
+          "description": "Replicas is the number of desired replicas. This is a pointer to distinguish between explicit zero and unspecified. Defaults to 1. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller",
+          "format": "int32",
+          "type": "integer"
+        },
+        "selector": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+          "description": "Selector is a label query over pods that should match the replica count. If the selector is empty, it is defaulted to the labels present on the pod template. Label keys and values that must match in order to be controlled by this replica set. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors"
+        },
+        "template": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.PodTemplateSpec",
+          "description": "Template is the object that describes the pod that will be created if insufficient replicas are detected. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.extensions.v1beta1.ReplicaSetStatus": {
+      "description": "ReplicaSetStatus represents the current status of a ReplicaSet.",
+      "properties": {
+        "availableReplicas": {
+          "description": "The number of available replicas (ready for at least minReadySeconds) for this replica set.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "conditions": {
+          "description": "Represents the latest available observations of a replica set's current state.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.ReplicaSetCondition"
+          },
+          "type": "array",
+          "x-kubernetes-patch-merge-key": "type",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "fullyLabeledReplicas": {
+          "description": "The number of pods that have labels matching the labels of the pod template of the replicaset.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration reflects the generation of the most recently observed ReplicaSet.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "readyReplicas": {
+          "description": "The number of ready replicas for this replica set.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "replicas": {
+          "description": "Replicas is the most recently oberved number of replicas. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "replicas"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.extensions.v1beta1.RollbackConfig": {
+      "description": "DEPRECATED.",
+      "properties": {
+        "revision": {
+          "description": "The revision to rollback to. If set to 0, rollback to the last revision.",
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.extensions.v1beta1.RollingUpdateDaemonSet": {
+      "description": "Spec to control the desired behavior of daemon set rolling update.",
+      "properties": {
+        "maxUnavailable": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.util.intstr.IntOrString",
+          "description": "The maximum number of DaemonSet pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of total number of DaemonSet pods at the start of the update (ex: 10%). Absolute number is calculated from percentage by rounding up. This cannot be 0. Default value is 1. Example: when this is set to 30%, at most 30% of the total number of nodes that should be running the daemon pod (i.e. status.desiredNumberScheduled) can have their pods stopped for an update at any given time. The update starts by stopping at most 30% of those DaemonSet pods and then brings up new DaemonSet pods in their place. Once the new pods are available, it then proceeds onto other DaemonSet pods, thus ensuring that at least 70% of original number of DaemonSet pods are available at all times during the update."
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.extensions.v1beta1.RollingUpdateDeployment": {
+      "description": "Spec to control the desired behavior of rolling update.",
+      "properties": {
+        "maxSurge": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.util.intstr.IntOrString",
+          "description": "The maximum number of pods that can be scheduled above the desired number of pods. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. By default, a value of 1 is used. Example: when this is set to 30%, the new RC can be scaled up immediately when the rolling update starts, such that the total number of old and new pods do not exceed 130% of desired pods. Once old pods have been killed, new RC can be scaled up further, ensuring that total number of pods running at any time during the update is at most 130% of desired pods."
+        },
+        "maxUnavailable": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.util.intstr.IntOrString",
+          "description": "The maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. By default, a fixed value of 1 is used. Example: when this is set to 30%, the old RC can be scaled down to 70% of desired pods immediately when the rolling update starts. Once new pods are ready, old RC can be scaled down further, followed by scaling up the new RC, ensuring that the total number of pods available at all times during the update is at least 70% of desired pods."
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.extensions.v1beta1.RunAsGroupStrategyOptions": {
+      "description": "RunAsGroupStrategyOptions defines the strategy type and any options used to create the strategy. Deprecated: use RunAsGroupStrategyOptions from policy API Group instead.",
+      "properties": {
+        "ranges": {
+          "description": "ranges are the allowed ranges of gids that may be used. If you would like to force a single gid then supply a single range with the same start and end. Required for MustRunAs.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.IDRange"
+          },
+          "type": "array"
+        },
+        "rule": {
+          "description": "rule is the strategy that will dictate the allowable RunAsGroup values that may be set.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "rule"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.extensions.v1beta1.RunAsUserStrategyOptions": {
+      "description": "RunAsUserStrategyOptions defines the strategy type and any options used to create the strategy. Deprecated: use RunAsUserStrategyOptions from policy API Group instead.",
+      "properties": {
+        "ranges": {
+          "description": "ranges are the allowed ranges of uids that may be used. If you would like to force a single uid then supply a single range with the same start and end. Required for MustRunAs.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.IDRange"
+          },
+          "type": "array"
+        },
+        "rule": {
+          "description": "rule is the strategy that will dictate the allowable RunAsUser values that may be set.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "rule"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.extensions.v1beta1.SELinuxStrategyOptions": {
+      "description": "SELinuxStrategyOptions defines the strategy type and any options used to create the strategy. Deprecated: use SELinuxStrategyOptions from policy API Group instead.",
+      "properties": {
+        "rule": {
+          "description": "rule is the strategy that will dictate the allowable labels that may be set.",
+          "type": "string"
+        },
+        "seLinuxOptions": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.SELinuxOptions",
+          "description": "seLinuxOptions required to run as; required for MustRunAs More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/"
+        }
+      },
+      "required": [
+        "rule"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.extensions.v1beta1.Scale": {
+      "description": "represents a scaling request for a resource.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "Scale"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata."
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.ScaleSpec",
+          "description": "defines the behavior of the scale. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status."
+        },
+        "status": {
+          "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.ScaleStatus",
+          "description": "current status of the scale. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status. Read-only."
+        }
+      },
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "extensions",
+          "kind": "Scale",
+          "version": "v1beta1"
+        }
+      ]
+    },
+    "io.k8s.api.extensions.v1beta1.ScaleSpec": {
+      "description": "describes the attributes of a scale subresource",
+      "properties": {
+        "replicas": {
+          "description": "desired number of instances for the scaled object.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.extensions.v1beta1.ScaleStatus": {
+      "description": "represents the current status of a scale subresource.",
+      "properties": {
+        "replicas": {
+          "description": "actual number of observed instances of the scaled object.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "selector": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "label query over pods that should match the replicas count. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors",
+          "type": "object"
+        },
+        "targetSelector": {
+          "description": "label selector for pods that should match the replicas count. This is a serializated version of both map-based and more expressive set-based selectors. This is done to avoid introspection in the clients. The string will be in the same format as the query-param syntax. If the target type only supports map-based selectors, both this field and map-based selector field are populated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors",
+          "type": "string"
+        }
+      },
+      "required": [
+        "replicas"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.extensions.v1beta1.SupplementalGroupsStrategyOptions": {
+      "description": "SupplementalGroupsStrategyOptions defines the strategy type and options used to create the strategy. Deprecated: use SupplementalGroupsStrategyOptions from policy API Group instead.",
+      "properties": {
+        "ranges": {
+          "description": "ranges are the allowed ranges of supplemental groups.  If you would like to force a single supplemental group then supply a single range with the same start and end. Required for MustRunAs.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.IDRange"
+          },
+          "type": "array"
+        },
+        "rule": {
+          "description": "rule is the strategy that will dictate what supplemental groups is used in the SecurityContext.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.networking.v1.IPBlock": {
+      "description": "IPBlock describes a particular CIDR (Ex. \"192.168.1.1/24\") that is allowed to the pods matched by a NetworkPolicySpec's podSelector. The except entry describes CIDRs that should not be included within this rule.",
+      "properties": {
+        "cidr": {
+          "description": "CIDR is a string representing the IP Block Valid examples are \"192.168.1.1/24\"",
+          "type": "string"
+        },
+        "except": {
+          "description": "Except is a slice of CIDRs that should not be included within an IP Block Valid examples are \"192.168.1.1/24\" Except values will be rejected if they are outside the CIDR range",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "cidr"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.networking.v1.NetworkPolicy": {
+      "description": "NetworkPolicy describes what network traffic is allowed for a set of Pods",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "NetworkPolicy"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.networking.v1.NetworkPolicySpec",
+          "description": "Specification of the desired behavior for this NetworkPolicy."
+        }
+      },
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "networking.k8s.io",
+          "kind": "NetworkPolicy",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.networking.v1.NetworkPolicyEgressRule": {
+      "description": "NetworkPolicyEgressRule describes a particular set of traffic that is allowed out of pods matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and to. This type is beta-level in 1.8",
+      "properties": {
+        "ports": {
+          "description": "List of destination ports for outgoing traffic. Each item in this list is combined using a logical OR. If this field is empty or missing, this rule matches all ports (traffic not restricted by port). If this field is present and contains at least one item, then this rule allows traffic only if the traffic matches at least one port in the list.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.networking.v1.NetworkPolicyPort"
+          },
+          "type": "array"
+        },
+        "to": {
+          "description": "List of destinations for outgoing traffic of pods selected for this rule. Items in this list are combined using a logical OR operation. If this field is empty or missing, this rule matches all destinations (traffic not restricted by destination). If this field is present and contains at least one item, this rule allows traffic only if the traffic matches at least one item in the to list.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.networking.v1.NetworkPolicyPeer"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.networking.v1.NetworkPolicyIngressRule": {
+      "description": "NetworkPolicyIngressRule describes a particular set of traffic that is allowed to the pods matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and from.",
+      "properties": {
+        "from": {
+          "description": "List of sources which should be able to access the pods selected for this rule. Items in this list are combined using a logical OR operation. If this field is empty or missing, this rule matches all sources (traffic not restricted by source). If this field is present and contains at least on item, this rule allows traffic only if the traffic matches at least one item in the from list.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.networking.v1.NetworkPolicyPeer"
+          },
+          "type": "array"
+        },
+        "ports": {
+          "description": "List of ports which should be made accessible on the pods selected for this rule. Each item in this list is combined using a logical OR. If this field is empty or missing, this rule matches all ports (traffic not restricted by port). If this field is present and contains at least one item, then this rule allows traffic only if the traffic matches at least one port in the list.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.networking.v1.NetworkPolicyPort"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.networking.v1.NetworkPolicyList": {
+      "description": "NetworkPolicyList is a list of NetworkPolicy objects.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "Items is a list of schema objects.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.networking.v1.NetworkPolicy"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "NetworkPolicyList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "networking.k8s.io",
+          "kind": "NetworkPolicyList",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.networking.v1.NetworkPolicyPeer": {
+      "description": "NetworkPolicyPeer describes a peer to allow traffic from. Only certain combinations of fields are allowed",
+      "properties": {
+        "ipBlock": {
+          "$ref": "#/definitions/io.k8s.api.networking.v1.IPBlock",
+          "description": "IPBlock defines policy on a particular IPBlock. If this field is set then neither of the other fields can be."
+        },
+        "namespaceSelector": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+          "description": "Selects Namespaces using cluster-scoped labels. This field follows standard label selector semantics; if present but empty, it selects all namespaces.\n\nIf PodSelector is also set, then the NetworkPolicyPeer as a whole selects the Pods matching PodSelector in the Namespaces selected by NamespaceSelector. Otherwise it selects all Pods in the Namespaces selected by NamespaceSelector."
+        },
+        "podSelector": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+          "description": "This is a label selector which selects Pods. This field follows standard label selector semantics; if present but empty, it selects all pods.\n\nIf NamespaceSelector is also set, then the NetworkPolicyPeer as a whole selects the Pods matching PodSelector in the Namespaces selected by NamespaceSelector. Otherwise it selects the Pods matching PodSelector in the policy's own Namespace."
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.networking.v1.NetworkPolicyPort": {
+      "description": "NetworkPolicyPort describes a port to allow traffic on",
+      "properties": {
+        "port": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.util.intstr.IntOrString",
+          "description": "The port on the given protocol. This can either be a numerical or named port on a pod. If this field is not provided, this matches all port names and numbers."
+        },
+        "protocol": {
+          "description": "The protocol (TCP, UDP, or SCTP) which traffic must match. If not specified, this field defaults to TCP.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.networking.v1.NetworkPolicySpec": {
+      "description": "NetworkPolicySpec provides the specification of a NetworkPolicy",
+      "properties": {
+        "egress": {
+          "description": "List of egress rules to be applied to the selected pods. Outgoing traffic is allowed if there are no NetworkPolicies selecting the pod (and cluster policy otherwise allows the traffic), OR if the traffic matches at least one egress rule across all of the NetworkPolicy objects whose podSelector matches the pod. If this field is empty then this NetworkPolicy limits all outgoing traffic (and serves solely to ensure that the pods it selects are isolated by default). This field is beta-level in 1.8",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.networking.v1.NetworkPolicyEgressRule"
+          },
+          "type": "array"
+        },
+        "ingress": {
+          "description": "List of ingress rules to be applied to the selected pods. Traffic is allowed to a pod if there are no NetworkPolicies selecting the pod (and cluster policy otherwise allows the traffic), OR if the traffic source is the pod's local node, OR if the traffic matches at least one ingress rule across all of the NetworkPolicy objects whose podSelector matches the pod. If this field is empty then this NetworkPolicy does not allow any traffic (and serves solely to ensure that the pods it selects are isolated by default)",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.networking.v1.NetworkPolicyIngressRule"
+          },
+          "type": "array"
+        },
+        "podSelector": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+          "description": "Selects the pods to which this NetworkPolicy object applies. The array of ingress rules is applied to any pods selected by this field. Multiple network policies can select the same set of pods. In this case, the ingress rules for each are combined additively. This field is NOT optional and follows standard label selector semantics. An empty podSelector matches all pods in this namespace."
+        },
+        "policyTypes": {
+          "description": "List of rule types that the NetworkPolicy relates to. Valid options are \"Ingress\", \"Egress\", or \"Ingress,Egress\". If this field is not specified, it will default based on the existence of Ingress or Egress rules; policies that contain an Egress section are assumed to affect Egress, and all policies (whether or not they contain an Ingress section) are assumed to affect Ingress. If you want to write an egress-only policy, you must explicitly specify policyTypes [ \"Egress\" ]. Likewise, if you want to write a policy that specifies that no egress is allowed, you must specify a policyTypes value that include \"Egress\" (since such a policy would not include an Egress section and would otherwise default to just [ \"Ingress\" ]). This field is beta-level in 1.8",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "podSelector"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.networking.v1beta1.HTTPIngressPath": {
+      "description": "HTTPIngressPath associates a path regex with a backend. Incoming urls matching the path are forwarded to the backend.",
+      "properties": {
+        "backend": {
+          "$ref": "#/definitions/io.k8s.api.networking.v1beta1.IngressBackend",
+          "description": "Backend defines the referenced service endpoint to which the traffic will be forwarded to."
+        },
+        "path": {
+          "description": "Path is an extended POSIX regex as defined by IEEE Std 1003.1, (i.e this follows the egrep/unix syntax, not the perl syntax) matched against the path of an incoming request. Currently it can contain characters disallowed from the conventional \"path\" part of a URL as defined by RFC 3986. Paths must begin with a '/'. If unspecified, the path defaults to a catch all sending traffic to the backend.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "backend"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.networking.v1beta1.HTTPIngressRuleValue": {
+      "description": "HTTPIngressRuleValue is a list of http selectors pointing to backends. In the example: http://<host>/<path>?<searchpart> -> backend where where parts of the url correspond to RFC 3986, this resource will be used to match against everything after the last '/' and before the first '?' or '#'.",
+      "properties": {
+        "paths": {
+          "description": "A collection of paths that map requests to backends.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.networking.v1beta1.HTTPIngressPath"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "paths"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.networking.v1beta1.Ingress": {
+      "description": "Ingress is a collection of rules that allow inbound connections to reach the endpoints defined by a backend. An Ingress can be configured to give services externally-reachable urls, load balance traffic, terminate SSL, offer name based virtual hosting etc.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "Ingress"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.networking.v1beta1.IngressSpec",
+          "description": "Spec is the desired state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status"
+        },
+        "status": {
+          "$ref": "#/definitions/io.k8s.api.networking.v1beta1.IngressStatus",
+          "description": "Status is the current state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status"
+        }
+      },
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "networking.k8s.io",
+          "kind": "Ingress",
+          "version": "v1beta1"
+        }
+      ]
+    },
+    "io.k8s.api.networking.v1beta1.IngressBackend": {
+      "description": "IngressBackend describes all endpoints for a given service and port.",
+      "properties": {
+        "serviceName": {
+          "description": "Specifies the name of the referenced service.",
+          "type": "string"
+        },
+        "servicePort": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.util.intstr.IntOrString",
+          "description": "Specifies the port of the referenced service."
+        }
+      },
+      "required": [
+        "serviceName",
+        "servicePort"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.networking.v1beta1.IngressList": {
+      "description": "IngressList is a collection of Ingress.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "Items is the list of Ingress.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.networking.v1beta1.Ingress"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "IngressList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "networking.k8s.io",
+          "kind": "IngressList",
+          "version": "v1beta1"
+        }
+      ]
+    },
+    "io.k8s.api.networking.v1beta1.IngressRule": {
+      "description": "IngressRule represents the rules mapping the paths under a specified host to the related backend services. Incoming requests are first evaluated for a host match, then routed to the backend associated with the matching IngressRuleValue.",
+      "properties": {
+        "host": {
+          "description": "Host is the fully qualified domain name of a network host, as defined by RFC 3986. Note the following deviations from the \"host\" part of the URI as defined in the RFC: 1. IPs are not allowed. Currently an IngressRuleValue can only apply to the\n\t  IP in the Spec of the parent Ingress.\n2. The `:` delimiter is not respected because ports are not allowed.\n\t  Currently the port of an Ingress is implicitly :80 for http and\n\t  :443 for https.\nBoth these may change in the future. Incoming requests are matched against the host before the IngressRuleValue. If the host is unspecified, the Ingress routes all traffic based on the specified IngressRuleValue.",
+          "type": "string"
+        },
+        "http": {
+          "$ref": "#/definitions/io.k8s.api.networking.v1beta1.HTTPIngressRuleValue"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.networking.v1beta1.IngressSpec": {
+      "description": "IngressSpec describes the Ingress the user wishes to exist.",
+      "properties": {
+        "backend": {
+          "$ref": "#/definitions/io.k8s.api.networking.v1beta1.IngressBackend",
+          "description": "A default backend capable of servicing requests that don't match any rule. At least one of 'backend' or 'rules' must be specified. This field is optional to allow the loadbalancer controller or defaulting logic to specify a global default."
+        },
+        "rules": {
+          "description": "A list of host rules used to configure the Ingress. If unspecified, or no rule matches, all traffic is sent to the default backend.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.networking.v1beta1.IngressRule"
+          },
+          "type": "array"
+        },
+        "tls": {
+          "description": "TLS configuration. Currently the Ingress only supports a single TLS port, 443. If multiple members of this list specify different hosts, they will be multiplexed on the same port according to the hostname specified through the SNI TLS extension, if the ingress controller fulfilling the ingress supports SNI.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.networking.v1beta1.IngressTLS"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.networking.v1beta1.IngressStatus": {
+      "description": "IngressStatus describe the current state of the Ingress.",
+      "properties": {
+        "loadBalancer": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.LoadBalancerStatus",
+          "description": "LoadBalancer contains the current status of the load-balancer."
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.networking.v1beta1.IngressTLS": {
+      "description": "IngressTLS describes the transport layer security associated with an Ingress.",
+      "properties": {
+        "hosts": {
+          "description": "Hosts are a list of hosts included in the TLS certificate. The values in this list must match the name/s used in the tlsSecret. Defaults to the wildcard host setting for the loadbalancer controller fulfilling this Ingress, if left unspecified.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "secretName": {
+          "description": "SecretName is the name of the secret used to terminate SSL traffic on 443. Field is left optional to allow SSL routing based on SNI hostname alone. If the SNI host in a listener conflicts with the \"Host\" header field used by an IngressRule, the SNI host is used for termination and value of the Host header is used for routing.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.node.v1alpha1.RuntimeClass": {
+      "description": "RuntimeClass defines a class of container runtime supported in the cluster. The RuntimeClass is used to determine which container runtime is used to run all containers in a pod. RuntimeClasses are (currently) manually defined by a user or cluster provisioner, and referenced in the PodSpec. The Kubelet is responsible for resolving the RuntimeClassName reference before running the pod.  For more details, see https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "RuntimeClass"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.node.v1alpha1.RuntimeClassSpec",
+          "description": "Specification of the RuntimeClass More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status"
+        }
+      },
+      "required": [
+        "spec"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "node.k8s.io",
+          "kind": "RuntimeClass",
+          "version": "v1alpha1"
+        }
+      ]
+    },
+    "io.k8s.api.node.v1alpha1.RuntimeClassList": {
+      "description": "RuntimeClassList is a list of RuntimeClass objects.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "Items is a list of schema objects.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.node.v1alpha1.RuntimeClass"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "RuntimeClassList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "node.k8s.io",
+          "kind": "RuntimeClassList",
+          "version": "v1alpha1"
+        }
+      ]
+    },
+    "io.k8s.api.node.v1alpha1.RuntimeClassSpec": {
+      "description": "RuntimeClassSpec is a specification of a RuntimeClass. It contains parameters that are required to describe the RuntimeClass to the Container Runtime Interface (CRI) implementation, as well as any other components that need to understand how the pod will be run. The RuntimeClassSpec is immutable.",
+      "properties": {
+        "runtimeHandler": {
+          "description": "RuntimeHandler specifies the underlying runtime and configuration that the CRI implementation will use to handle pods of this class. The possible values are specific to the node & CRI configuration.  It is assumed that all handlers are available on every node, and handlers of the same name are equivalent on every node. For example, a handler called \"runc\" might specify that the runc OCI runtime (using native Linux containers) will be used to run the containers in a pod. The RuntimeHandler must conform to the DNS Label (RFC 1123) requirements and is immutable.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "runtimeHandler"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.node.v1beta1.RuntimeClass": {
+      "description": "RuntimeClass defines a class of container runtime supported in the cluster. The RuntimeClass is used to determine which container runtime is used to run all containers in a pod. RuntimeClasses are (currently) manually defined by a user or cluster provisioner, and referenced in the PodSpec. The Kubelet is responsible for resolving the RuntimeClassName reference before running the pod.  For more details, see https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "handler": {
+          "description": "Handler specifies the underlying runtime and configuration that the CRI implementation will use to handle pods of this class. The possible values are specific to the node & CRI configuration.  It is assumed that all handlers are available on every node, and handlers of the same name are equivalent on every node. For example, a handler called \"runc\" might specify that the runc OCI runtime (using native Linux containers) will be used to run the containers in a pod. The Handler must conform to the DNS Label (RFC 1123) requirements, and is immutable.",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "RuntimeClass"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+        }
+      },
+      "required": [
+        "handler"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "node.k8s.io",
+          "kind": "RuntimeClass",
+          "version": "v1beta1"
+        }
+      ]
+    },
+    "io.k8s.api.node.v1beta1.RuntimeClassList": {
+      "description": "RuntimeClassList is a list of RuntimeClass objects.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "Items is a list of schema objects.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.node.v1beta1.RuntimeClass"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "RuntimeClassList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "node.k8s.io",
+          "kind": "RuntimeClassList",
+          "version": "v1beta1"
+        }
+      ]
+    },
+    "io.k8s.api.policy.v1beta1.AllowedCSIDriver": {
+      "description": "AllowedCSIDriver represents a single inline CSI Driver that is allowed to be used.",
+      "properties": {
+        "name": {
+          "description": "Name is the registered name of the CSI driver",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.policy.v1beta1.AllowedFlexVolume": {
+      "description": "AllowedFlexVolume represents a single Flexvolume that is allowed to be used.",
+      "properties": {
+        "driver": {
+          "description": "driver is the name of the Flexvolume driver.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "driver"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.policy.v1beta1.AllowedHostPath": {
+      "description": "AllowedHostPath defines the host volume conditions that will be enabled by a policy for pods to use. It requires the path prefix to be defined.",
+      "properties": {
+        "pathPrefix": {
+          "description": "pathPrefix is the path prefix that the host volume must match. It does not support `*`. Trailing slashes are trimmed when validating the path prefix with a host path.\n\nExamples: `/foo` would allow `/foo`, `/foo/` and `/foo/bar` `/foo` would not allow `/food` or `/etc/foo`",
+          "type": "string"
+        },
+        "readOnly": {
+          "description": "when set to true, will allow host volumes matching the pathPrefix only if all volume mounts are readOnly.",
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.policy.v1beta1.Eviction": {
+      "description": "Eviction evicts a pod from its node subject to certain policies and safety constraints. This is a subresource of Pod.  A request to cause such an eviction is created by POSTing to .../pods/<pod name>/evictions.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "deleteOptions": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions",
+          "description": "DeleteOptions may be provided"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "Eviction"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "ObjectMeta describes the pod that is being evicted."
+        }
+      },
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "policy",
+          "kind": "Eviction",
+          "version": "v1beta1"
+        }
+      ]
+    },
+    "io.k8s.api.policy.v1beta1.FSGroupStrategyOptions": {
+      "description": "FSGroupStrategyOptions defines the strategy type and options used to create the strategy.",
+      "properties": {
+        "ranges": {
+          "description": "ranges are the allowed ranges of fs groups.  If you would like to force a single fs group then supply a single range with the same start and end. Required for MustRunAs.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.policy.v1beta1.IDRange"
+          },
+          "type": "array"
+        },
+        "rule": {
+          "description": "rule is the strategy that will dictate what FSGroup is used in the SecurityContext.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.policy.v1beta1.HostPortRange": {
+      "description": "HostPortRange defines a range of host ports that will be enabled by a policy for pods to use.  It requires both the start and end to be defined.",
+      "properties": {
+        "max": {
+          "description": "max is the end of the range, inclusive.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "min": {
+          "description": "min is the start of the range, inclusive.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "min",
+        "max"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.policy.v1beta1.IDRange": {
+      "description": "IDRange provides a min/max of an allowed range of IDs.",
+      "properties": {
+        "max": {
+          "description": "max is the end of the range, inclusive.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "min": {
+          "description": "min is the start of the range, inclusive.",
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "min",
+        "max"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.policy.v1beta1.PodDisruptionBudget": {
+      "description": "PodDisruptionBudget is an object to define the max disruption that can be caused to a collection of pods",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "PodDisruptionBudget"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.policy.v1beta1.PodDisruptionBudgetSpec",
+          "description": "Specification of the desired behavior of the PodDisruptionBudget."
+        },
+        "status": {
+          "$ref": "#/definitions/io.k8s.api.policy.v1beta1.PodDisruptionBudgetStatus",
+          "description": "Most recently observed status of the PodDisruptionBudget."
+        }
+      },
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "policy",
+          "kind": "PodDisruptionBudget",
+          "version": "v1beta1"
+        }
+      ]
+    },
+    "io.k8s.api.policy.v1beta1.PodDisruptionBudgetList": {
+      "description": "PodDisruptionBudgetList is a collection of PodDisruptionBudgets.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.policy.v1beta1.PodDisruptionBudget"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "PodDisruptionBudgetList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "policy",
+          "kind": "PodDisruptionBudgetList",
+          "version": "v1beta1"
+        }
+      ]
+    },
+    "io.k8s.api.policy.v1beta1.PodDisruptionBudgetSpec": {
+      "description": "PodDisruptionBudgetSpec is a description of a PodDisruptionBudget.",
+      "properties": {
+        "maxUnavailable": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.util.intstr.IntOrString",
+          "description": "An eviction is allowed if at most \"maxUnavailable\" pods selected by \"selector\" are unavailable after the eviction, i.e. even in absence of the evicted pod. For example, one can prevent all voluntary evictions by specifying 0. This is a mutually exclusive setting with \"minAvailable\"."
+        },
+        "minAvailable": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.util.intstr.IntOrString",
+          "description": "An eviction is allowed if at least \"minAvailable\" pods selected by \"selector\" will still be available after the eviction, i.e. even in the absence of the evicted pod.  So for example you can prevent all voluntary evictions by specifying \"100%\"."
+        },
+        "selector": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+          "description": "Label query over pods whose evictions are managed by the disruption budget."
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.policy.v1beta1.PodDisruptionBudgetStatus": {
+      "description": "PodDisruptionBudgetStatus represents information about the status of a PodDisruptionBudget. Status may trail the actual state of a system.",
+      "properties": {
+        "currentHealthy": {
+          "description": "current number of healthy pods",
+          "format": "int32",
+          "type": "integer"
+        },
+        "desiredHealthy": {
+          "description": "minimum desired number of healthy pods",
+          "format": "int32",
+          "type": "integer"
+        },
+        "disruptedPods": {
+          "additionalProperties": {
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+          },
+          "description": "DisruptedPods contains information about pods whose eviction was processed by the API server eviction subresource handler but has not yet been observed by the PodDisruptionBudget controller. A pod will be in this map from the time when the API server processed the eviction request to the time when the pod is seen by PDB controller as having been marked for deletion (or after a timeout). The key in the map is the name of the pod and the value is the time when the API server processed the eviction request. If the deletion didn't occur and a pod is still there it will be removed from the list automatically by PodDisruptionBudget controller after some time. If everything goes smooth this map should be empty for the most of the time. Large number of entries in the map may indicate problems with pod deletions.",
+          "type": "object"
+        },
+        "disruptionsAllowed": {
+          "description": "Number of pod disruptions that are currently allowed.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "expectedPods": {
+          "description": "total number of pods counted by this disruption budget",
+          "format": "int32",
+          "type": "integer"
+        },
+        "observedGeneration": {
+          "description": "Most recent generation observed when updating this PDB status. PodDisruptionsAllowed and other status informatio is valid only if observedGeneration equals to PDB's object generation.",
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "disruptionsAllowed",
+        "currentHealthy",
+        "desiredHealthy",
+        "expectedPods"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.policy.v1beta1.PodSecurityPolicy": {
+      "description": "PodSecurityPolicy governs the ability to make requests that affect the Security Context that will be applied to a pod and container.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "PodSecurityPolicy"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.policy.v1beta1.PodSecurityPolicySpec",
+          "description": "spec defines the policy enforced."
+        }
+      },
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "policy",
+          "kind": "PodSecurityPolicy",
+          "version": "v1beta1"
+        }
+      ]
+    },
+    "io.k8s.api.policy.v1beta1.PodSecurityPolicyList": {
+      "description": "PodSecurityPolicyList is a list of PodSecurityPolicy objects.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "items is a list of schema objects.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.policy.v1beta1.PodSecurityPolicy"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "PodSecurityPolicyList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "policy",
+          "kind": "PodSecurityPolicyList",
+          "version": "v1beta1"
+        }
+      ]
+    },
+    "io.k8s.api.policy.v1beta1.PodSecurityPolicySpec": {
+      "description": "PodSecurityPolicySpec defines the policy enforced.",
+      "properties": {
+        "allowPrivilegeEscalation": {
+          "description": "allowPrivilegeEscalation determines if a pod can request to allow privilege escalation. If unspecified, defaults to true.",
+          "type": "boolean"
+        },
+        "allowedCSIDrivers": {
+          "description": "AllowedCSIDrivers is a whitelist of inline CSI drivers that must be explicitly set to be embedded within a pod spec. An empty value means no CSI drivers can run inline within a pod spec.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.policy.v1beta1.AllowedCSIDriver"
+          },
+          "type": "array"
+        },
+        "allowedCapabilities": {
+          "description": "allowedCapabilities is a list of capabilities that can be requested to add to the container. Capabilities in this field may be added at the pod author's discretion. You must not list a capability in both allowedCapabilities and requiredDropCapabilities.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "allowedFlexVolumes": {
+          "description": "allowedFlexVolumes is a whitelist of allowed Flexvolumes.  Empty or nil indicates that all Flexvolumes may be used.  This parameter is effective only when the usage of the Flexvolumes is allowed in the \"volumes\" field.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.policy.v1beta1.AllowedFlexVolume"
+          },
+          "type": "array"
+        },
+        "allowedHostPaths": {
+          "description": "allowedHostPaths is a white list of allowed host paths. Empty indicates that all host paths may be used.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.policy.v1beta1.AllowedHostPath"
+          },
+          "type": "array"
+        },
+        "allowedProcMountTypes": {
+          "description": "AllowedProcMountTypes is a whitelist of allowed ProcMountTypes. Empty or nil indicates that only the DefaultProcMountType may be used. This requires the ProcMountType feature flag to be enabled.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "allowedUnsafeSysctls": {
+          "description": "allowedUnsafeSysctls is a list of explicitly allowed unsafe sysctls, defaults to none. Each entry is either a plain sysctl name or ends in \"*\" in which case it is considered as a prefix of allowed sysctls. Single * means all unsafe sysctls are allowed. Kubelet has to whitelist all allowed unsafe sysctls explicitly to avoid rejection.\n\nExamples: e.g. \"foo/*\" allows \"foo/bar\", \"foo/baz\", etc. e.g. \"foo.*\" allows \"foo.bar\", \"foo.baz\", etc.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "defaultAddCapabilities": {
+          "description": "defaultAddCapabilities is the default set of capabilities that will be added to the container unless the pod spec specifically drops the capability.  You may not list a capability in both defaultAddCapabilities and requiredDropCapabilities. Capabilities added here are implicitly allowed, and need not be included in the allowedCapabilities list.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "defaultAllowPrivilegeEscalation": {
+          "description": "defaultAllowPrivilegeEscalation controls the default setting for whether a process can gain more privileges than its parent process.",
+          "type": "boolean"
+        },
+        "forbiddenSysctls": {
+          "description": "forbiddenSysctls is a list of explicitly forbidden sysctls, defaults to none. Each entry is either a plain sysctl name or ends in \"*\" in which case it is considered as a prefix of forbidden sysctls. Single * means all sysctls are forbidden.\n\nExamples: e.g. \"foo/*\" forbids \"foo/bar\", \"foo/baz\", etc. e.g. \"foo.*\" forbids \"foo.bar\", \"foo.baz\", etc.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "fsGroup": {
+          "$ref": "#/definitions/io.k8s.api.policy.v1beta1.FSGroupStrategyOptions",
+          "description": "fsGroup is the strategy that will dictate what fs group is used by the SecurityContext."
+        },
+        "hostIPC": {
+          "description": "hostIPC determines if the policy allows the use of HostIPC in the pod spec.",
+          "type": "boolean"
+        },
+        "hostNetwork": {
+          "description": "hostNetwork determines if the policy allows the use of HostNetwork in the pod spec.",
+          "type": "boolean"
+        },
+        "hostPID": {
+          "description": "hostPID determines if the policy allows the use of HostPID in the pod spec.",
+          "type": "boolean"
+        },
+        "hostPorts": {
+          "description": "hostPorts determines which host port ranges are allowed to be exposed.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.policy.v1beta1.HostPortRange"
+          },
+          "type": "array"
+        },
+        "privileged": {
+          "description": "privileged determines if a pod can request to be run as privileged.",
+          "type": "boolean"
+        },
+        "readOnlyRootFilesystem": {
+          "description": "readOnlyRootFilesystem when set to true will force containers to run with a read only root file system.  If the container specifically requests to run with a non-read only root file system the PSP should deny the pod. If set to false the container may run with a read only root file system if it wishes but it will not be forced to.",
+          "type": "boolean"
+        },
+        "requiredDropCapabilities": {
+          "description": "requiredDropCapabilities are the capabilities that will be dropped from the container.  These are required to be dropped and cannot be added.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "runAsGroup": {
+          "$ref": "#/definitions/io.k8s.api.policy.v1beta1.RunAsGroupStrategyOptions",
+          "description": "RunAsGroup is the strategy that will dictate the allowable RunAsGroup values that may be set. If this field is omitted, the pod's RunAsGroup can take any value. This field requires the RunAsGroup feature gate to be enabled."
+        },
+        "runAsUser": {
+          "$ref": "#/definitions/io.k8s.api.policy.v1beta1.RunAsUserStrategyOptions",
+          "description": "runAsUser is the strategy that will dictate the allowable RunAsUser values that may be set."
+        },
+        "seLinux": {
+          "$ref": "#/definitions/io.k8s.api.policy.v1beta1.SELinuxStrategyOptions",
+          "description": "seLinux is the strategy that will dictate the allowable labels that may be set."
+        },
+        "supplementalGroups": {
+          "$ref": "#/definitions/io.k8s.api.policy.v1beta1.SupplementalGroupsStrategyOptions",
+          "description": "supplementalGroups is the strategy that will dictate what supplemental groups are used by the SecurityContext."
+        },
+        "volumes": {
+          "description": "volumes is a white list of allowed volume plugins. Empty indicates that no volumes may be used. To allow all volumes you may use '*'.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "seLinux",
+        "runAsUser",
+        "supplementalGroups",
+        "fsGroup"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.policy.v1beta1.RunAsGroupStrategyOptions": {
+      "description": "RunAsGroupStrategyOptions defines the strategy type and any options used to create the strategy.",
+      "properties": {
+        "ranges": {
+          "description": "ranges are the allowed ranges of gids that may be used. If you would like to force a single gid then supply a single range with the same start and end. Required for MustRunAs.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.policy.v1beta1.IDRange"
+          },
+          "type": "array"
+        },
+        "rule": {
+          "description": "rule is the strategy that will dictate the allowable RunAsGroup values that may be set.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "rule"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.policy.v1beta1.RunAsUserStrategyOptions": {
+      "description": "RunAsUserStrategyOptions defines the strategy type and any options used to create the strategy.",
+      "properties": {
+        "ranges": {
+          "description": "ranges are the allowed ranges of uids that may be used. If you would like to force a single uid then supply a single range with the same start and end. Required for MustRunAs.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.policy.v1beta1.IDRange"
+          },
+          "type": "array"
+        },
+        "rule": {
+          "description": "rule is the strategy that will dictate the allowable RunAsUser values that may be set.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "rule"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.policy.v1beta1.SELinuxStrategyOptions": {
+      "description": "SELinuxStrategyOptions defines the strategy type and any options used to create the strategy.",
+      "properties": {
+        "rule": {
+          "description": "rule is the strategy that will dictate the allowable labels that may be set.",
+          "type": "string"
+        },
+        "seLinuxOptions": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.SELinuxOptions",
+          "description": "seLinuxOptions required to run as; required for MustRunAs More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/"
+        }
+      },
+      "required": [
+        "rule"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.policy.v1beta1.SupplementalGroupsStrategyOptions": {
+      "description": "SupplementalGroupsStrategyOptions defines the strategy type and options used to create the strategy.",
+      "properties": {
+        "ranges": {
+          "description": "ranges are the allowed ranges of supplemental groups.  If you would like to force a single supplemental group then supply a single range with the same start and end. Required for MustRunAs.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.policy.v1beta1.IDRange"
+          },
+          "type": "array"
+        },
+        "rule": {
+          "description": "rule is the strategy that will dictate what supplemental groups is used in the SecurityContext.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.rbac.v1.AggregationRule": {
+      "description": "AggregationRule describes how to locate ClusterRoles to aggregate into the ClusterRole",
+      "properties": {
+        "clusterRoleSelectors": {
+          "description": "ClusterRoleSelectors holds a list of selectors which will be used to find ClusterRoles and create the rules. If any of the selectors match, then the ClusterRole's permissions will be added",
+          "items": {
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.rbac.v1.ClusterRole": {
+      "description": "ClusterRole is a cluster level, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding or ClusterRoleBinding.",
+      "properties": {
+        "aggregationRule": {
+          "$ref": "#/definitions/io.k8s.api.rbac.v1.AggregationRule",
+          "description": "AggregationRule is an optional field that describes how to build the Rules for this ClusterRole. If AggregationRule is set, then the Rules are controller managed and direct changes to Rules will be stomped by the controller."
+        },
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "ClusterRole"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object's metadata."
+        },
+        "rules": {
+          "description": "Rules holds all the PolicyRules for this ClusterRole",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.rbac.v1.PolicyRule"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "rbac.authorization.k8s.io",
+          "kind": "ClusterRole",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.rbac.v1.ClusterRoleBinding": {
+      "description": "ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference a ClusterRole in the global namespace, and adds who information via Subject.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "ClusterRoleBinding"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object's metadata."
+        },
+        "roleRef": {
+          "$ref": "#/definitions/io.k8s.api.rbac.v1.RoleRef",
+          "description": "RoleRef can only reference a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error."
+        },
+        "subjects": {
+          "description": "Subjects holds references to the objects the role applies to.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.rbac.v1.Subject"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "roleRef"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "rbac.authorization.k8s.io",
+          "kind": "ClusterRoleBinding",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.rbac.v1.ClusterRoleBindingList": {
+      "description": "ClusterRoleBindingList is a collection of ClusterRoleBindings",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "Items is a list of ClusterRoleBindings",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.rbac.v1.ClusterRoleBinding"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "ClusterRoleBindingList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "Standard object's metadata."
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "rbac.authorization.k8s.io",
+          "kind": "ClusterRoleBindingList",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.rbac.v1.ClusterRoleList": {
+      "description": "ClusterRoleList is a collection of ClusterRoles",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "Items is a list of ClusterRoles",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.rbac.v1.ClusterRole"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "ClusterRoleList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "Standard object's metadata."
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "rbac.authorization.k8s.io",
+          "kind": "ClusterRoleList",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.rbac.v1.PolicyRule": {
+      "description": "PolicyRule holds information that describes a policy rule, but does not contain information about who the rule applies to or which namespace the rule applies to.",
+      "properties": {
+        "apiGroups": {
+          "description": "APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of the enumerated resources in any API group will be allowed.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "nonResourceURLs": {
+          "description": "NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding. Rules can either apply to API resources (such as \"pods\" or \"secrets\") or non-resource URL paths (such as \"/api\"),  but not both.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "resourceNames": {
+          "description": "ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "resources": {
+          "description": "Resources is a list of resources this rule applies to.  ResourceAll represents all resources.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "verbs": {
+          "description": "Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestrictions contained in this rule.  VerbAll represents all kinds.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "verbs"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.rbac.v1.Role": {
+      "description": "Role is a namespaced, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "Role"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object's metadata."
+        },
+        "rules": {
+          "description": "Rules holds all the PolicyRules for this Role",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.rbac.v1.PolicyRule"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "rbac.authorization.k8s.io",
+          "kind": "Role",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.rbac.v1.RoleBinding": {
+      "description": "RoleBinding references a role, but does not contain it.  It can reference a Role in the same namespace or a ClusterRole in the global namespace. It adds who information via Subjects and namespace information by which namespace it exists in.  RoleBindings in a given namespace only have effect in that namespace.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "RoleBinding"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object's metadata."
+        },
+        "roleRef": {
+          "$ref": "#/definitions/io.k8s.api.rbac.v1.RoleRef",
+          "description": "RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error."
+        },
+        "subjects": {
+          "description": "Subjects holds references to the objects the role applies to.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.rbac.v1.Subject"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "roleRef"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "rbac.authorization.k8s.io",
+          "kind": "RoleBinding",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.rbac.v1.RoleBindingList": {
+      "description": "RoleBindingList is a collection of RoleBindings",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "Items is a list of RoleBindings",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.rbac.v1.RoleBinding"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "RoleBindingList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "Standard object's metadata."
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "rbac.authorization.k8s.io",
+          "kind": "RoleBindingList",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.rbac.v1.RoleList": {
+      "description": "RoleList is a collection of Roles",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "Items is a list of Roles",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.rbac.v1.Role"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "RoleList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "Standard object's metadata."
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "rbac.authorization.k8s.io",
+          "kind": "RoleList",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.rbac.v1.RoleRef": {
+      "description": "RoleRef contains information that points to the role being used",
+      "properties": {
+        "apiGroup": {
+          "description": "APIGroup is the group for the resource being referenced",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is the type of resource being referenced",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name is the name of resource being referenced",
+          "type": "string"
+        }
+      },
+      "required": [
+        "apiGroup",
+        "kind",
+        "name"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.rbac.v1.Subject": {
+      "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.",
+      "properties": {
+        "apiGroup": {
+          "description": "APIGroup holds the API group of the referenced subject. Defaults to \"\" for ServiceAccount subjects. Defaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\". If the Authorizer does not recognized the kind value, the Authorizer should report an error.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the object being referenced.",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty the Authorizer should report an error.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "kind",
+        "name"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.rbac.v1alpha1.AggregationRule": {
+      "description": "AggregationRule describes how to locate ClusterRoles to aggregate into the ClusterRole",
+      "properties": {
+        "clusterRoleSelectors": {
+          "description": "ClusterRoleSelectors holds a list of selectors which will be used to find ClusterRoles and create the rules. If any of the selectors match, then the ClusterRole's permissions will be added",
+          "items": {
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.rbac.v1alpha1.ClusterRole": {
+      "description": "ClusterRole is a cluster level, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding or ClusterRoleBinding.",
+      "properties": {
+        "aggregationRule": {
+          "$ref": "#/definitions/io.k8s.api.rbac.v1alpha1.AggregationRule",
+          "description": "AggregationRule is an optional field that describes how to build the Rules for this ClusterRole. If AggregationRule is set, then the Rules are controller managed and direct changes to Rules will be stomped by the controller."
+        },
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "ClusterRole"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object's metadata."
+        },
+        "rules": {
+          "description": "Rules holds all the PolicyRules for this ClusterRole",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.rbac.v1alpha1.PolicyRule"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "rbac.authorization.k8s.io",
+          "kind": "ClusterRole",
+          "version": "v1alpha1"
+        }
+      ]
+    },
+    "io.k8s.api.rbac.v1alpha1.ClusterRoleBinding": {
+      "description": "ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference a ClusterRole in the global namespace, and adds who information via Subject.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "ClusterRoleBinding"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object's metadata."
+        },
+        "roleRef": {
+          "$ref": "#/definitions/io.k8s.api.rbac.v1alpha1.RoleRef",
+          "description": "RoleRef can only reference a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error."
+        },
+        "subjects": {
+          "description": "Subjects holds references to the objects the role applies to.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.rbac.v1alpha1.Subject"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "roleRef"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "rbac.authorization.k8s.io",
+          "kind": "ClusterRoleBinding",
+          "version": "v1alpha1"
+        }
+      ]
+    },
+    "io.k8s.api.rbac.v1alpha1.ClusterRoleBindingList": {
+      "description": "ClusterRoleBindingList is a collection of ClusterRoleBindings",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "Items is a list of ClusterRoleBindings",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.rbac.v1alpha1.ClusterRoleBinding"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "ClusterRoleBindingList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "Standard object's metadata."
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "rbac.authorization.k8s.io",
+          "kind": "ClusterRoleBindingList",
+          "version": "v1alpha1"
+        }
+      ]
+    },
+    "io.k8s.api.rbac.v1alpha1.ClusterRoleList": {
+      "description": "ClusterRoleList is a collection of ClusterRoles",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "Items is a list of ClusterRoles",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.rbac.v1alpha1.ClusterRole"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "ClusterRoleList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "Standard object's metadata."
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "rbac.authorization.k8s.io",
+          "kind": "ClusterRoleList",
+          "version": "v1alpha1"
+        }
+      ]
+    },
+    "io.k8s.api.rbac.v1alpha1.PolicyRule": {
+      "description": "PolicyRule holds information that describes a policy rule, but does not contain information about who the rule applies to or which namespace the rule applies to.",
+      "properties": {
+        "apiGroups": {
+          "description": "APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of the enumerated resources in any API group will be allowed.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "nonResourceURLs": {
+          "description": "NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path This name is intentionally different than the internal type so that the DefaultConvert works nicely and because the ordering may be different. Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding. Rules can either apply to API resources (such as \"pods\" or \"secrets\") or non-resource URL paths (such as \"/api\"),  but not both.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "resourceNames": {
+          "description": "ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "resources": {
+          "description": "Resources is a list of resources this rule applies to.  ResourceAll represents all resources.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "verbs": {
+          "description": "Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestrictions contained in this rule.  VerbAll represents all kinds.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "verbs"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.rbac.v1alpha1.Role": {
+      "description": "Role is a namespaced, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "Role"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object's metadata."
+        },
+        "rules": {
+          "description": "Rules holds all the PolicyRules for this Role",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.rbac.v1alpha1.PolicyRule"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "rbac.authorization.k8s.io",
+          "kind": "Role",
+          "version": "v1alpha1"
+        }
+      ]
+    },
+    "io.k8s.api.rbac.v1alpha1.RoleBinding": {
+      "description": "RoleBinding references a role, but does not contain it.  It can reference a Role in the same namespace or a ClusterRole in the global namespace. It adds who information via Subjects and namespace information by which namespace it exists in.  RoleBindings in a given namespace only have effect in that namespace.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "RoleBinding"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object's metadata."
+        },
+        "roleRef": {
+          "$ref": "#/definitions/io.k8s.api.rbac.v1alpha1.RoleRef",
+          "description": "RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error."
+        },
+        "subjects": {
+          "description": "Subjects holds references to the objects the role applies to.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.rbac.v1alpha1.Subject"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "roleRef"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "rbac.authorization.k8s.io",
+          "kind": "RoleBinding",
+          "version": "v1alpha1"
+        }
+      ]
+    },
+    "io.k8s.api.rbac.v1alpha1.RoleBindingList": {
+      "description": "RoleBindingList is a collection of RoleBindings",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "Items is a list of RoleBindings",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.rbac.v1alpha1.RoleBinding"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "RoleBindingList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "Standard object's metadata."
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "rbac.authorization.k8s.io",
+          "kind": "RoleBindingList",
+          "version": "v1alpha1"
+        }
+      ]
+    },
+    "io.k8s.api.rbac.v1alpha1.RoleList": {
+      "description": "RoleList is a collection of Roles",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "Items is a list of Roles",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.rbac.v1alpha1.Role"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "RoleList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "Standard object's metadata."
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "rbac.authorization.k8s.io",
+          "kind": "RoleList",
+          "version": "v1alpha1"
+        }
+      ]
+    },
+    "io.k8s.api.rbac.v1alpha1.RoleRef": {
+      "description": "RoleRef contains information that points to the role being used",
+      "properties": {
+        "apiGroup": {
+          "description": "APIGroup is the group for the resource being referenced",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is the type of resource being referenced",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name is the name of resource being referenced",
+          "type": "string"
+        }
+      },
+      "required": [
+        "apiGroup",
+        "kind",
+        "name"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.rbac.v1alpha1.Subject": {
+      "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion holds the API group and version of the referenced subject. Defaults to \"v1\" for ServiceAccount subjects. Defaults to \"rbac.authorization.k8s.io/v1alpha1\" for User and Group subjects.",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\". If the Authorizer does not recognized the kind value, the Authorizer should report an error.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the object being referenced.",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty the Authorizer should report an error.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "kind",
+        "name"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.rbac.v1beta1.AggregationRule": {
+      "description": "AggregationRule describes how to locate ClusterRoles to aggregate into the ClusterRole",
+      "properties": {
+        "clusterRoleSelectors": {
+          "description": "ClusterRoleSelectors holds a list of selectors which will be used to find ClusterRoles and create the rules. If any of the selectors match, then the ClusterRole's permissions will be added",
+          "items": {
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.rbac.v1beta1.ClusterRole": {
+      "description": "ClusterRole is a cluster level, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding or ClusterRoleBinding.",
+      "properties": {
+        "aggregationRule": {
+          "$ref": "#/definitions/io.k8s.api.rbac.v1beta1.AggregationRule",
+          "description": "AggregationRule is an optional field that describes how to build the Rules for this ClusterRole. If AggregationRule is set, then the Rules are controller managed and direct changes to Rules will be stomped by the controller."
+        },
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "ClusterRole"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object's metadata."
+        },
+        "rules": {
+          "description": "Rules holds all the PolicyRules for this ClusterRole",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.rbac.v1beta1.PolicyRule"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "rbac.authorization.k8s.io",
+          "kind": "ClusterRole",
+          "version": "v1beta1"
+        }
+      ]
+    },
+    "io.k8s.api.rbac.v1beta1.ClusterRoleBinding": {
+      "description": "ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference a ClusterRole in the global namespace, and adds who information via Subject.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "ClusterRoleBinding"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object's metadata."
+        },
+        "roleRef": {
+          "$ref": "#/definitions/io.k8s.api.rbac.v1beta1.RoleRef",
+          "description": "RoleRef can only reference a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error."
+        },
+        "subjects": {
+          "description": "Subjects holds references to the objects the role applies to.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.rbac.v1beta1.Subject"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "roleRef"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "rbac.authorization.k8s.io",
+          "kind": "ClusterRoleBinding",
+          "version": "v1beta1"
+        }
+      ]
+    },
+    "io.k8s.api.rbac.v1beta1.ClusterRoleBindingList": {
+      "description": "ClusterRoleBindingList is a collection of ClusterRoleBindings",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "Items is a list of ClusterRoleBindings",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.rbac.v1beta1.ClusterRoleBinding"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "ClusterRoleBindingList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "Standard object's metadata."
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "rbac.authorization.k8s.io",
+          "kind": "ClusterRoleBindingList",
+          "version": "v1beta1"
+        }
+      ]
+    },
+    "io.k8s.api.rbac.v1beta1.ClusterRoleList": {
+      "description": "ClusterRoleList is a collection of ClusterRoles",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "Items is a list of ClusterRoles",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.rbac.v1beta1.ClusterRole"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "ClusterRoleList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "Standard object's metadata."
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "rbac.authorization.k8s.io",
+          "kind": "ClusterRoleList",
+          "version": "v1beta1"
+        }
+      ]
+    },
+    "io.k8s.api.rbac.v1beta1.PolicyRule": {
+      "description": "PolicyRule holds information that describes a policy rule, but does not contain information about who the rule applies to or which namespace the rule applies to.",
+      "properties": {
+        "apiGroups": {
+          "description": "APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of the enumerated resources in any API group will be allowed.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "nonResourceURLs": {
+          "description": "NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding. Rules can either apply to API resources (such as \"pods\" or \"secrets\") or non-resource URL paths (such as \"/api\"),  but not both.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "resourceNames": {
+          "description": "ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "resources": {
+          "description": "Resources is a list of resources this rule applies to.  '*' represents all resources in the specified apiGroups. '*/foo' represents the subresource 'foo' for all resources in the specified apiGroups.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "verbs": {
+          "description": "Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestrictions contained in this rule.  VerbAll represents all kinds.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "verbs"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.rbac.v1beta1.Role": {
+      "description": "Role is a namespaced, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "Role"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object's metadata."
+        },
+        "rules": {
+          "description": "Rules holds all the PolicyRules for this Role",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.rbac.v1beta1.PolicyRule"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "rbac.authorization.k8s.io",
+          "kind": "Role",
+          "version": "v1beta1"
+        }
+      ]
+    },
+    "io.k8s.api.rbac.v1beta1.RoleBinding": {
+      "description": "RoleBinding references a role, but does not contain it.  It can reference a Role in the same namespace or a ClusterRole in the global namespace. It adds who information via Subjects and namespace information by which namespace it exists in.  RoleBindings in a given namespace only have effect in that namespace.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "RoleBinding"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object's metadata."
+        },
+        "roleRef": {
+          "$ref": "#/definitions/io.k8s.api.rbac.v1beta1.RoleRef",
+          "description": "RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error."
+        },
+        "subjects": {
+          "description": "Subjects holds references to the objects the role applies to.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.rbac.v1beta1.Subject"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "roleRef"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "rbac.authorization.k8s.io",
+          "kind": "RoleBinding",
+          "version": "v1beta1"
+        }
+      ]
+    },
+    "io.k8s.api.rbac.v1beta1.RoleBindingList": {
+      "description": "RoleBindingList is a collection of RoleBindings",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "Items is a list of RoleBindings",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.rbac.v1beta1.RoleBinding"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "RoleBindingList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "Standard object's metadata."
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "rbac.authorization.k8s.io",
+          "kind": "RoleBindingList",
+          "version": "v1beta1"
+        }
+      ]
+    },
+    "io.k8s.api.rbac.v1beta1.RoleList": {
+      "description": "RoleList is a collection of Roles",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "Items is a list of Roles",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.rbac.v1beta1.Role"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "RoleList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "Standard object's metadata."
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "rbac.authorization.k8s.io",
+          "kind": "RoleList",
+          "version": "v1beta1"
+        }
+      ]
+    },
+    "io.k8s.api.rbac.v1beta1.RoleRef": {
+      "description": "RoleRef contains information that points to the role being used",
+      "properties": {
+        "apiGroup": {
+          "description": "APIGroup is the group for the resource being referenced",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is the type of resource being referenced",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name is the name of resource being referenced",
+          "type": "string"
+        }
+      },
+      "required": [
+        "apiGroup",
+        "kind",
+        "name"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.rbac.v1beta1.Subject": {
+      "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.",
+      "properties": {
+        "apiGroup": {
+          "description": "APIGroup holds the API group of the referenced subject. Defaults to \"\" for ServiceAccount subjects. Defaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\". If the Authorizer does not recognized the kind value, the Authorizer should report an error.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the object being referenced.",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty the Authorizer should report an error.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "kind",
+        "name"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.scheduling.v1.PriorityClass": {
+      "description": "PriorityClass defines mapping from a priority class name to the priority integer value. The value can be any valid integer.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "description": {
+          "description": "description is an arbitrary string that usually provides guidelines on when this priority class should be used.",
+          "type": "string"
+        },
+        "globalDefault": {
+          "description": "globalDefault specifies whether this PriorityClass should be considered as the default priority for pods that do not have any priority class. Only one PriorityClass can be marked as `globalDefault`. However, if more than one PriorityClasses exists with their `globalDefault` field set to true, the smallest value of such global default PriorityClasses will be used as the default priority.",
+          "type": "boolean"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "PriorityClass"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+        },
+        "value": {
+          "description": "The value of this priority class. This is the actual priority that pods receive when they have the name of this class in their pod spec.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "scheduling.k8s.io",
+          "kind": "PriorityClass",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.scheduling.v1.PriorityClassList": {
+      "description": "PriorityClassList is a collection of priority classes.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "items is the list of PriorityClasses",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.scheduling.v1.PriorityClass"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "PriorityClassList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "Standard list metadata More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "scheduling.k8s.io",
+          "kind": "PriorityClassList",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.scheduling.v1alpha1.PriorityClass": {
+      "description": "DEPRECATED - This group version of PriorityClass is deprecated by scheduling.k8s.io/v1/PriorityClass. PriorityClass defines mapping from a priority class name to the priority integer value. The value can be any valid integer.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "description": {
+          "description": "description is an arbitrary string that usually provides guidelines on when this priority class should be used.",
+          "type": "string"
+        },
+        "globalDefault": {
+          "description": "globalDefault specifies whether this PriorityClass should be considered as the default priority for pods that do not have any priority class. Only one PriorityClass can be marked as `globalDefault`. However, if more than one PriorityClasses exists with their `globalDefault` field set to true, the smallest value of such global default PriorityClasses will be used as the default priority.",
+          "type": "boolean"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "PriorityClass"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+        },
+        "value": {
+          "description": "The value of this priority class. This is the actual priority that pods receive when they have the name of this class in their pod spec.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "scheduling.k8s.io",
+          "kind": "PriorityClass",
+          "version": "v1alpha1"
+        }
+      ]
+    },
+    "io.k8s.api.scheduling.v1alpha1.PriorityClassList": {
+      "description": "PriorityClassList is a collection of priority classes.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "items is the list of PriorityClasses",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.scheduling.v1alpha1.PriorityClass"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "PriorityClassList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "Standard list metadata More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "scheduling.k8s.io",
+          "kind": "PriorityClassList",
+          "version": "v1alpha1"
+        }
+      ]
+    },
+    "io.k8s.api.scheduling.v1beta1.PriorityClass": {
+      "description": "DEPRECATED - This group version of PriorityClass is deprecated by scheduling.k8s.io/v1/PriorityClass. PriorityClass defines mapping from a priority class name to the priority integer value. The value can be any valid integer.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "description": {
+          "description": "description is an arbitrary string that usually provides guidelines on when this priority class should be used.",
+          "type": "string"
+        },
+        "globalDefault": {
+          "description": "globalDefault specifies whether this PriorityClass should be considered as the default priority for pods that do not have any priority class. Only one PriorityClass can be marked as `globalDefault`. However, if more than one PriorityClasses exists with their `globalDefault` field set to true, the smallest value of such global default PriorityClasses will be used as the default priority.",
+          "type": "boolean"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "PriorityClass"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
+        },
+        "value": {
+          "description": "The value of this priority class. This is the actual priority that pods receive when they have the name of this class in their pod spec.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "scheduling.k8s.io",
+          "kind": "PriorityClass",
+          "version": "v1beta1"
+        }
+      ]
+    },
+    "io.k8s.api.scheduling.v1beta1.PriorityClassList": {
+      "description": "PriorityClassList is a collection of priority classes.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "items is the list of PriorityClasses",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.scheduling.v1beta1.PriorityClass"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "PriorityClassList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "scheduling.k8s.io",
+          "kind": "PriorityClassList",
+          "version": "v1beta1"
+        }
+      ]
+    },
+    "io.k8s.api.settings.v1alpha1.PodPreset": {
+      "description": "PodPreset is a policy resource that defines additional runtime requirements for a Pod.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "PodPreset"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.settings.v1alpha1.PodPresetSpec"
+        }
+      },
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "settings.k8s.io",
+          "kind": "PodPreset",
+          "version": "v1alpha1"
+        }
+      ]
+    },
+    "io.k8s.api.settings.v1alpha1.PodPresetList": {
+      "description": "PodPresetList is a list of PodPreset objects.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "Items is a list of schema objects.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.settings.v1alpha1.PodPreset"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "PodPresetList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "settings.k8s.io",
+          "kind": "PodPresetList",
+          "version": "v1alpha1"
+        }
+      ]
+    },
+    "io.k8s.api.settings.v1alpha1.PodPresetSpec": {
+      "description": "PodPresetSpec is a description of a pod preset.",
+      "properties": {
+        "env": {
+          "description": "Env defines the collection of EnvVar to inject into containers.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.EnvVar"
+          },
+          "type": "array"
+        },
+        "envFrom": {
+          "description": "EnvFrom defines the collection of EnvFromSource to inject into containers.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.EnvFromSource"
+          },
+          "type": "array"
+        },
+        "selector": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+          "description": "Selector is a label query over a set of resources, in this case pods. Required."
+        },
+        "volumeMounts": {
+          "description": "VolumeMounts defines the collection of VolumeMount to inject into containers.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.VolumeMount"
+          },
+          "type": "array"
+        },
+        "volumes": {
+          "description": "Volumes defines the collection of Volume to inject into the pod.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.Volume"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.storage.v1.StorageClass": {
+      "description": "StorageClass describes the parameters for a class of storage for which PersistentVolumes can be dynamically provisioned.\n\nStorageClasses are non-namespaced; the name of the storage class according to etcd is in ObjectMeta.Name.",
+      "properties": {
+        "allowVolumeExpansion": {
+          "description": "AllowVolumeExpansion shows whether the storage class allow volume expand",
+          "type": "boolean"
+        },
+        "allowedTopologies": {
+          "description": "Restrict the node topologies where volumes can be dynamically provisioned. Each volume plugin defines its own supported topology specifications. An empty TopologySelectorTerm list means there is no topology restriction. This field is only honored by servers that enable the VolumeScheduling feature.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.TopologySelectorTerm"
+          },
+          "type": "array"
+        },
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "StorageClass"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+        },
+        "mountOptions": {
+          "description": "Dynamically provisioned PersistentVolumes of this storage class are created with these mountOptions, e.g. [\"ro\", \"soft\"]. Not validated - mount of the PVs will simply fail if one is invalid.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "parameters": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Parameters holds the parameters for the provisioner that should create volumes of this storage class.",
+          "type": "object"
+        },
+        "provisioner": {
+          "description": "Provisioner indicates the type of the provisioner.",
+          "type": "string"
+        },
+        "reclaimPolicy": {
+          "description": "Dynamically provisioned PersistentVolumes of this storage class are created with this reclaimPolicy. Defaults to Delete.",
+          "type": "string"
+        },
+        "volumeBindingMode": {
+          "description": "VolumeBindingMode indicates how PersistentVolumeClaims should be provisioned and bound.  When unset, VolumeBindingImmediate is used. This field is only honored by servers that enable the VolumeScheduling feature.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "provisioner"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "storage.k8s.io",
+          "kind": "StorageClass",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.storage.v1.StorageClassList": {
+      "description": "StorageClassList is a collection of storage classes.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "Items is the list of StorageClasses",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.storage.v1.StorageClass"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "StorageClassList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "Standard list metadata More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "storage.k8s.io",
+          "kind": "StorageClassList",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.storage.v1.VolumeAttachment": {
+      "description": "VolumeAttachment captures the intent to attach or detach the specified volume to/from the specified node.\n\nVolumeAttachment objects are non-namespaced.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "VolumeAttachment"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.storage.v1.VolumeAttachmentSpec",
+          "description": "Specification of the desired attach/detach volume behavior. Populated by the Kubernetes system."
+        },
+        "status": {
+          "$ref": "#/definitions/io.k8s.api.storage.v1.VolumeAttachmentStatus",
+          "description": "Status of the VolumeAttachment request. Populated by the entity completing the attach or detach operation, i.e. the external-attacher."
+        }
+      },
+      "required": [
+        "spec"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "storage.k8s.io",
+          "kind": "VolumeAttachment",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.storage.v1.VolumeAttachmentList": {
+      "description": "VolumeAttachmentList is a collection of VolumeAttachment objects.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "Items is the list of VolumeAttachments",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.storage.v1.VolumeAttachment"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "VolumeAttachmentList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "Standard list metadata More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "storage.k8s.io",
+          "kind": "VolumeAttachmentList",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.storage.v1.VolumeAttachmentSource": {
+      "description": "VolumeAttachmentSource represents a volume that should be attached. Right now only PersistenVolumes can be attached via external attacher, in future we may allow also inline volumes in pods. Exactly one member can be set.",
+      "properties": {
+        "persistentVolumeName": {
+          "description": "Name of the persistent volume to attach.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.storage.v1.VolumeAttachmentSpec": {
+      "description": "VolumeAttachmentSpec is the specification of a VolumeAttachment request.",
+      "properties": {
+        "attacher": {
+          "description": "Attacher indicates the name of the volume driver that MUST handle this request. This is the name returned by GetPluginName().",
+          "type": "string"
+        },
+        "nodeName": {
+          "description": "The node that the volume should be attached to.",
+          "type": "string"
+        },
+        "source": {
+          "$ref": "#/definitions/io.k8s.api.storage.v1.VolumeAttachmentSource",
+          "description": "Source represents the volume that should be attached."
+        }
+      },
+      "required": [
+        "attacher",
+        "source",
+        "nodeName"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.storage.v1.VolumeAttachmentStatus": {
+      "description": "VolumeAttachmentStatus is the status of a VolumeAttachment request.",
+      "properties": {
+        "attachError": {
+          "$ref": "#/definitions/io.k8s.api.storage.v1.VolumeError",
+          "description": "The last error encountered during attach operation, if any. This field must only be set by the entity completing the attach operation, i.e. the external-attacher."
+        },
+        "attached": {
+          "description": "Indicates the volume is successfully attached. This field must only be set by the entity completing the attach operation, i.e. the external-attacher.",
+          "type": "boolean"
+        },
+        "attachmentMetadata": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Upon successful attach, this field is populated with any information returned by the attach operation that must be passed into subsequent WaitForAttach or Mount calls. This field must only be set by the entity completing the attach operation, i.e. the external-attacher.",
+          "type": "object"
+        },
+        "detachError": {
+          "$ref": "#/definitions/io.k8s.api.storage.v1.VolumeError",
+          "description": "The last error encountered during detach operation, if any. This field must only be set by the entity completing the detach operation, i.e. the external-attacher."
+        }
+      },
+      "required": [
+        "attached"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.storage.v1.VolumeError": {
+      "description": "VolumeError captures an error encountered during a volume operation.",
+      "properties": {
+        "message": {
+          "description": "String detailing the error encountered during Attach or Detach operation. This string may be logged, so it should not contain sensitive information.",
+          "type": "string"
+        },
+        "time": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "Time the error was encountered."
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.storage.v1alpha1.VolumeAttachment": {
+      "description": "VolumeAttachment captures the intent to attach or detach the specified volume to/from the specified node.\n\nVolumeAttachment objects are non-namespaced.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "VolumeAttachment"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.storage.v1alpha1.VolumeAttachmentSpec",
+          "description": "Specification of the desired attach/detach volume behavior. Populated by the Kubernetes system."
+        },
+        "status": {
+          "$ref": "#/definitions/io.k8s.api.storage.v1alpha1.VolumeAttachmentStatus",
+          "description": "Status of the VolumeAttachment request. Populated by the entity completing the attach or detach operation, i.e. the external-attacher."
+        }
+      },
+      "required": [
+        "spec"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "storage.k8s.io",
+          "kind": "VolumeAttachment",
+          "version": "v1alpha1"
+        }
+      ]
+    },
+    "io.k8s.api.storage.v1alpha1.VolumeAttachmentList": {
+      "description": "VolumeAttachmentList is a collection of VolumeAttachment objects.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "Items is the list of VolumeAttachments",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.storage.v1alpha1.VolumeAttachment"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "VolumeAttachmentList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "Standard list metadata More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "storage.k8s.io",
+          "kind": "VolumeAttachmentList",
+          "version": "v1alpha1"
+        }
+      ]
+    },
+    "io.k8s.api.storage.v1alpha1.VolumeAttachmentSource": {
+      "description": "VolumeAttachmentSource represents a volume that should be attached. Right now only PersistenVolumes can be attached via external attacher, in future we may allow also inline volumes in pods. Exactly one member can be set.",
+      "properties": {
+        "persistentVolumeName": {
+          "description": "Name of the persistent volume to attach.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.storage.v1alpha1.VolumeAttachmentSpec": {
+      "description": "VolumeAttachmentSpec is the specification of a VolumeAttachment request.",
+      "properties": {
+        "attacher": {
+          "description": "Attacher indicates the name of the volume driver that MUST handle this request. This is the name returned by GetPluginName().",
+          "type": "string"
+        },
+        "nodeName": {
+          "description": "The node that the volume should be attached to.",
+          "type": "string"
+        },
+        "source": {
+          "$ref": "#/definitions/io.k8s.api.storage.v1alpha1.VolumeAttachmentSource",
+          "description": "Source represents the volume that should be attached."
+        }
+      },
+      "required": [
+        "attacher",
+        "source",
+        "nodeName"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.storage.v1alpha1.VolumeAttachmentStatus": {
+      "description": "VolumeAttachmentStatus is the status of a VolumeAttachment request.",
+      "properties": {
+        "attachError": {
+          "$ref": "#/definitions/io.k8s.api.storage.v1alpha1.VolumeError",
+          "description": "The last error encountered during attach operation, if any. This field must only be set by the entity completing the attach operation, i.e. the external-attacher."
+        },
+        "attached": {
+          "description": "Indicates the volume is successfully attached. This field must only be set by the entity completing the attach operation, i.e. the external-attacher.",
+          "type": "boolean"
+        },
+        "attachmentMetadata": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Upon successful attach, this field is populated with any information returned by the attach operation that must be passed into subsequent WaitForAttach or Mount calls. This field must only be set by the entity completing the attach operation, i.e. the external-attacher.",
+          "type": "object"
+        },
+        "detachError": {
+          "$ref": "#/definitions/io.k8s.api.storage.v1alpha1.VolumeError",
+          "description": "The last error encountered during detach operation, if any. This field must only be set by the entity completing the detach operation, i.e. the external-attacher."
+        }
+      },
+      "required": [
+        "attached"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.storage.v1alpha1.VolumeError": {
+      "description": "VolumeError captures an error encountered during a volume operation.",
+      "properties": {
+        "message": {
+          "description": "String detailing the error encountered during Attach or Detach operation. This string maybe logged, so it should not contain sensitive information.",
+          "type": "string"
+        },
+        "time": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "Time the error was encountered."
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.storage.v1beta1.CSIDriver": {
+      "description": "CSIDriver captures information about a Container Storage Interface (CSI) volume driver deployed on the cluster. CSI drivers do not need to create the CSIDriver object directly. Instead they may use the cluster-driver-registrar sidecar container. When deployed with a CSI driver it automatically creates a CSIDriver object representing the driver. Kubernetes attach detach controller uses this object to determine whether attach is required. Kubelet uses this object to determine whether pod information needs to be passed on mount. CSIDriver objects are non-namespaced.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "CSIDriver"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object metadata. metadata.Name indicates the name of the CSI driver that this object refers to; it MUST be the same name returned by the CSI GetPluginName() call for that driver. The driver name must be 63 characters or less, beginning and ending with an alphanumeric character ([a-z0-9A-Z]) with dashes (-), dots (.), and alphanumerics between. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.storage.v1beta1.CSIDriverSpec",
+          "description": "Specification of the CSI Driver."
+        }
+      },
+      "required": [
+        "spec"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "storage.k8s.io",
+          "kind": "CSIDriver",
+          "version": "v1beta1"
+        }
+      ]
+    },
+    "io.k8s.api.storage.v1beta1.CSIDriverList": {
+      "description": "CSIDriverList is a collection of CSIDriver objects.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "items is the list of CSIDriver",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.storage.v1beta1.CSIDriver"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "CSIDriverList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "Standard list metadata More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "storage.k8s.io",
+          "kind": "CSIDriverList",
+          "version": "v1beta1"
+        }
+      ]
+    },
+    "io.k8s.api.storage.v1beta1.CSIDriverSpec": {
+      "description": "CSIDriverSpec is the specification of a CSIDriver.",
+      "properties": {
+        "attachRequired": {
+          "description": "attachRequired indicates this CSI volume driver requires an attach operation (because it implements the CSI ControllerPublishVolume() method), and that the Kubernetes attach detach controller should call the attach volume interface which checks the volumeattachment status and waits until the volume is attached before proceeding to mounting. The CSI external-attacher coordinates with CSI volume driver and updates the volumeattachment status when the attach operation is complete. If the CSIDriverRegistry feature gate is enabled and the value is specified to false, the attach operation will be skipped. Otherwise the attach operation will be called.",
+          "type": "boolean"
+        },
+        "podInfoOnMount": {
+          "description": "If set to true, podInfoOnMount indicates this CSI volume driver requires additional pod information (like podName, podUID, etc.) during mount operations. If set to false, pod information will not be passed on mount. Default is false. The CSI driver specifies podInfoOnMount as part of driver deployment. If true, Kubelet will pass pod information as VolumeContext in the CSI NodePublishVolume() calls. The CSI driver is responsible for parsing and validating the information passed in as VolumeContext. The following VolumeConext will be passed if podInfoOnMount is set to true. This list might grow, but the prefix will be used. \"csi.storage.k8s.io/pod.name\": pod.Name \"csi.storage.k8s.io/pod.namespace\": pod.Namespace \"csi.storage.k8s.io/pod.uid\": string(pod.UID)",
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.storage.v1beta1.CSINode": {
+      "description": "CSINode holds information about all CSI drivers installed on a node. CSI drivers do not need to create the CSINode object directly. As long as they use the node-driver-registrar sidecar container, the kubelet will automatically populate the CSINode object for the CSI driver as part of kubelet plugin registration. CSINode has the same name as a node. If the object is missing, it means either there are no CSI Drivers available on the node, or the Kubelet version is low enough that it doesn't create this object. CSINode has an OwnerReference that points to the corresponding node object.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "CSINode"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "metadata.name must be the Kubernetes node name."
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.storage.v1beta1.CSINodeSpec",
+          "description": "spec is the specification of CSINode"
+        }
+      },
+      "required": [
+        "spec"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "storage.k8s.io",
+          "kind": "CSINode",
+          "version": "v1beta1"
+        }
+      ]
+    },
+    "io.k8s.api.storage.v1beta1.CSINodeDriver": {
+      "description": "CSINodeDriver holds information about the specification of one CSI driver installed on a node",
+      "properties": {
+        "name": {
+          "description": "This is the name of the CSI driver that this object refers to. This MUST be the same name returned by the CSI GetPluginName() call for that driver.",
+          "type": "string"
+        },
+        "nodeID": {
+          "description": "nodeID of the node from the driver point of view. This field enables Kubernetes to communicate with storage systems that do not share the same nomenclature for nodes. For example, Kubernetes may refer to a given node as \"node1\", but the storage system may refer to the same node as \"nodeA\". When Kubernetes issues a command to the storage system to attach a volume to a specific node, it can use this field to refer to the node name using the ID that the storage system will understand, e.g. \"nodeA\" instead of \"node1\". This field is required.",
+          "type": "string"
+        },
+        "topologyKeys": {
+          "description": "topologyKeys is the list of keys supported by the driver. When a driver is initialized on a cluster, it provides a set of topology keys that it understands (e.g. \"company.com/zone\", \"company.com/region\"). When a driver is initialized on a node, it provides the same topology keys along with values. Kubelet will expose these topology keys as labels on its own node object. When Kubernetes does topology aware provisioning, it can use this list to determine which labels it should retrieve from the node object and pass back to the driver. It is possible for different nodes to use different topology keys. This can be empty if driver does not support topology.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "name",
+        "nodeID"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.storage.v1beta1.CSINodeList": {
+      "description": "CSINodeList is a collection of CSINode objects.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "items is the list of CSINode",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.storage.v1beta1.CSINode"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "CSINodeList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "Standard list metadata More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "storage.k8s.io",
+          "kind": "CSINodeList",
+          "version": "v1beta1"
+        }
+      ]
+    },
+    "io.k8s.api.storage.v1beta1.CSINodeSpec": {
+      "description": "CSINodeSpec holds information about the specification of all CSI drivers installed on a node",
+      "properties": {
+        "drivers": {
+          "description": "drivers is a list of information of all CSI Drivers existing on a node. If all drivers in the list are uninstalled, this can become empty.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.storage.v1beta1.CSINodeDriver"
+          },
+          "type": "array",
+          "x-kubernetes-patch-merge-key": "name",
+          "x-kubernetes-patch-strategy": "merge"
+        }
+      },
+      "required": [
+        "drivers"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.storage.v1beta1.StorageClass": {
+      "description": "StorageClass describes the parameters for a class of storage for which PersistentVolumes can be dynamically provisioned.\n\nStorageClasses are non-namespaced; the name of the storage class according to etcd is in ObjectMeta.Name.",
+      "properties": {
+        "allowVolumeExpansion": {
+          "description": "AllowVolumeExpansion shows whether the storage class allow volume expand",
+          "type": "boolean"
+        },
+        "allowedTopologies": {
+          "description": "Restrict the node topologies where volumes can be dynamically provisioned. Each volume plugin defines its own supported topology specifications. An empty TopologySelectorTerm list means there is no topology restriction. This field is only honored by servers that enable the VolumeScheduling feature.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.TopologySelectorTerm"
+          },
+          "type": "array"
+        },
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "StorageClass"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+        },
+        "mountOptions": {
+          "description": "Dynamically provisioned PersistentVolumes of this storage class are created with these mountOptions, e.g. [\"ro\", \"soft\"]. Not validated - mount of the PVs will simply fail if one is invalid.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "parameters": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Parameters holds the parameters for the provisioner that should create volumes of this storage class.",
+          "type": "object"
+        },
+        "provisioner": {
+          "description": "Provisioner indicates the type of the provisioner.",
+          "type": "string"
+        },
+        "reclaimPolicy": {
+          "description": "Dynamically provisioned PersistentVolumes of this storage class are created with this reclaimPolicy. Defaults to Delete.",
+          "type": "string"
+        },
+        "volumeBindingMode": {
+          "description": "VolumeBindingMode indicates how PersistentVolumeClaims should be provisioned and bound.  When unset, VolumeBindingImmediate is used. This field is only honored by servers that enable the VolumeScheduling feature.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "provisioner"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "storage.k8s.io",
+          "kind": "StorageClass",
+          "version": "v1beta1"
+        }
+      ]
+    },
+    "io.k8s.api.storage.v1beta1.StorageClassList": {
+      "description": "StorageClassList is a collection of storage classes.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "Items is the list of StorageClasses",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.storage.v1beta1.StorageClass"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "StorageClassList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "Standard list metadata More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "storage.k8s.io",
+          "kind": "StorageClassList",
+          "version": "v1beta1"
+        }
+      ]
+    },
+    "io.k8s.api.storage.v1beta1.VolumeAttachment": {
+      "description": "VolumeAttachment captures the intent to attach or detach the specified volume to/from the specified node.\n\nVolumeAttachment objects are non-namespaced.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "VolumeAttachment"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.storage.v1beta1.VolumeAttachmentSpec",
+          "description": "Specification of the desired attach/detach volume behavior. Populated by the Kubernetes system."
+        },
+        "status": {
+          "$ref": "#/definitions/io.k8s.api.storage.v1beta1.VolumeAttachmentStatus",
+          "description": "Status of the VolumeAttachment request. Populated by the entity completing the attach or detach operation, i.e. the external-attacher."
+        }
+      },
+      "required": [
+        "spec"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "storage.k8s.io",
+          "kind": "VolumeAttachment",
+          "version": "v1beta1"
+        }
+      ]
+    },
+    "io.k8s.api.storage.v1beta1.VolumeAttachmentList": {
+      "description": "VolumeAttachmentList is a collection of VolumeAttachment objects.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "Items is the list of VolumeAttachments",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.storage.v1beta1.VolumeAttachment"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "VolumeAttachmentList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "Standard list metadata More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "storage.k8s.io",
+          "kind": "VolumeAttachmentList",
+          "version": "v1beta1"
+        }
+      ]
+    },
+    "io.k8s.api.storage.v1beta1.VolumeAttachmentSource": {
+      "description": "VolumeAttachmentSource represents a volume that should be attached. Right now only PersistenVolumes can be attached via external attacher, in future we may allow also inline volumes in pods. Exactly one member can be set.",
+      "properties": {
+        "persistentVolumeName": {
+          "description": "Name of the persistent volume to attach.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.storage.v1beta1.VolumeAttachmentSpec": {
+      "description": "VolumeAttachmentSpec is the specification of a VolumeAttachment request.",
+      "properties": {
+        "attacher": {
+          "description": "Attacher indicates the name of the volume driver that MUST handle this request. This is the name returned by GetPluginName().",
+          "type": "string"
+        },
+        "nodeName": {
+          "description": "The node that the volume should be attached to.",
+          "type": "string"
+        },
+        "source": {
+          "$ref": "#/definitions/io.k8s.api.storage.v1beta1.VolumeAttachmentSource",
+          "description": "Source represents the volume that should be attached."
+        }
+      },
+      "required": [
+        "attacher",
+        "source",
+        "nodeName"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.storage.v1beta1.VolumeAttachmentStatus": {
+      "description": "VolumeAttachmentStatus is the status of a VolumeAttachment request.",
+      "properties": {
+        "attachError": {
+          "$ref": "#/definitions/io.k8s.api.storage.v1beta1.VolumeError",
+          "description": "The last error encountered during attach operation, if any. This field must only be set by the entity completing the attach operation, i.e. the external-attacher."
+        },
+        "attached": {
+          "description": "Indicates the volume is successfully attached. This field must only be set by the entity completing the attach operation, i.e. the external-attacher.",
+          "type": "boolean"
+        },
+        "attachmentMetadata": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Upon successful attach, this field is populated with any information returned by the attach operation that must be passed into subsequent WaitForAttach or Mount calls. This field must only be set by the entity completing the attach operation, i.e. the external-attacher.",
+          "type": "object"
+        },
+        "detachError": {
+          "$ref": "#/definitions/io.k8s.api.storage.v1beta1.VolumeError",
+          "description": "The last error encountered during detach operation, if any. This field must only be set by the entity completing the detach operation, i.e. the external-attacher."
+        }
+      },
+      "required": [
+        "attached"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.storage.v1beta1.VolumeError": {
+      "description": "VolumeError captures an error encountered during a volume operation.",
+      "properties": {
+        "message": {
+          "description": "String detailing the error encountered during Attach or Detach operation. This string may be logged, so it should not contain sensitive information.",
+          "type": "string"
+        },
+        "time": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "Time the error was encountered."
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceColumnDefinition": {
+      "description": "CustomResourceColumnDefinition specifies a column for server side printing.",
+      "properties": {
+        "JSONPath": {
+          "description": "JSONPath is a simple JSON path, i.e. with array notation.",
+          "type": "string"
+        },
+        "description": {
+          "description": "description is a human readable description of this column.",
+          "type": "string"
+        },
+        "format": {
+          "description": "format is an optional OpenAPI type definition for this column. The 'name' format is applied to the primary identifier column to assist in clients identifying column is the resource name. See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types for more.",
+          "type": "string"
+        },
+        "name": {
+          "description": "name is a human readable name for the column.",
+          "type": "string"
+        },
+        "priority": {
+          "description": "priority is an integer defining the relative importance of this column compared to others. Lower numbers are considered higher priority. Columns that may be omitted in limited space scenarios should be given a higher priority.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "type": {
+          "description": "type is an OpenAPI type definition for this column. See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types for more.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "type",
+        "JSONPath"
+      ],
+      "type": "object"
+    },
+    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceConversion": {
+      "description": "CustomResourceConversion describes how to convert different versions of a CR.",
+      "properties": {
+        "conversionReviewVersions": {
+          "description": "ConversionReviewVersions is an ordered list of preferred `ConversionReview` versions the Webhook expects. API server will try to use first version in the list which it supports. If none of the versions specified in this list supported by API server, conversion will fail for this object. If a persisted Webhook configuration specifies allowed versions and does not include any versions known to the API Server, calls to the webhook will fail. Default to `['v1beta1']`.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "strategy": {
+          "description": "`strategy` specifies the conversion strategy. Allowed values are: - `None`: The converter only change the apiVersion and would not touch any other field in the CR. - `Webhook`: API Server will call to an external webhook to do the conversion. Additional information is needed for this option.",
+          "type": "string"
+        },
+        "webhookClientConfig": {
+          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.WebhookClientConfig",
+          "description": "`webhookClientConfig` is the instructions for how to call the webhook if strategy is `Webhook`. This field is alpha-level and is only honored by servers that enable the CustomResourceWebhookConversion feature."
+        }
+      },
+      "required": [
+        "strategy"
+      ],
+      "type": "object"
+    },
+    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinition": {
+      "description": "CustomResourceDefinition represents a resource that should be exposed on the API server.  Its name MUST be in the format <.spec.name>.<.spec.group>.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "CustomResourceDefinition"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinitionSpec",
+          "description": "Spec describes how the user wants the resources to appear"
+        },
+        "status": {
+          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinitionStatus",
+          "description": "Status indicates the actual state of the CustomResourceDefinition"
+        }
+      },
+      "required": [
+        "spec"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "apiextensions.k8s.io",
+          "kind": "CustomResourceDefinition",
+          "version": "v1beta1"
+        }
+      ]
+    },
+    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinitionCondition": {
+      "description": "CustomResourceDefinitionCondition contains details for the current condition of this pod.",
+      "properties": {
+        "lastTransitionTime": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "Last time the condition transitioned from one status to another."
+        },
+        "message": {
+          "description": "Human-readable message indicating details about last transition.",
+          "type": "string"
+        },
+        "reason": {
+          "description": "Unique, one-word, CamelCase reason for the condition's last transition.",
+          "type": "string"
+        },
+        "status": {
+          "description": "Status is the status of the condition. Can be True, False, Unknown.",
+          "type": "string"
+        },
+        "type": {
+          "description": "Type is the type of the condition.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "status"
+      ],
+      "type": "object"
+    },
+    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinitionList": {
+      "description": "CustomResourceDefinitionList is a list of CustomResourceDefinition objects.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "Items individual CustomResourceDefinitions",
+          "items": {
+            "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinition"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "CustomResourceDefinitionList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "apiextensions.k8s.io",
+          "kind": "CustomResourceDefinitionList",
+          "version": "v1beta1"
+        }
+      ]
+    },
+    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinitionNames": {
+      "description": "CustomResourceDefinitionNames indicates the names to serve this CustomResourceDefinition",
+      "properties": {
+        "categories": {
+          "description": "Categories is a list of grouped resources custom resources belong to (e.g. 'all')",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is the serialized kind of the resource.  It is normally CamelCase and singular.",
+          "type": "string"
+        },
+        "listKind": {
+          "description": "ListKind is the serialized kind of the list for this resource.  Defaults to <kind>List.",
+          "type": "string"
+        },
+        "plural": {
+          "description": "Plural is the plural name of the resource to serve.  It must match the name of the CustomResourceDefinition-registration too: plural.group and it must be all lowercase.",
+          "type": "string"
+        },
+        "shortNames": {
+          "description": "ShortNames are short names for the resource.  It must be all lowercase.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "singular": {
+          "description": "Singular is the singular name of the resource.  It must be all lowercase  Defaults to lowercased <kind>",
+          "type": "string"
+        }
+      },
+      "required": [
+        "plural",
+        "kind"
+      ],
+      "type": "object"
+    },
+    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinitionSpec": {
+      "description": "CustomResourceDefinitionSpec describes how a user wants their resource to appear",
+      "properties": {
+        "additionalPrinterColumns": {
+          "description": "AdditionalPrinterColumns are additional columns shown e.g. in kubectl next to the name. Defaults to a created-at column. Optional, the global columns for all versions. Top-level and per-version columns are mutually exclusive.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceColumnDefinition"
+          },
+          "type": "array"
+        },
+        "conversion": {
+          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceConversion",
+          "description": "`conversion` defines conversion settings for the CRD."
+        },
+        "group": {
+          "description": "Group is the group this resource belongs in",
+          "type": "string"
+        },
+        "names": {
+          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinitionNames",
+          "description": "Names are the names used to describe this custom resource"
+        },
+        "scope": {
+          "description": "Scope indicates whether this resource is cluster or namespace scoped.  Default is namespaced",
+          "type": "string"
+        },
+        "subresources": {
+          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceSubresources",
+          "description": "Subresources describes the subresources for CustomResource Optional, the global subresources for all versions. Top-level and per-version subresources are mutually exclusive."
+        },
+        "validation": {
+          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceValidation",
+          "description": "Validation describes the validation methods for CustomResources Optional, the global validation schema for all versions. Top-level and per-version schemas are mutually exclusive."
+        },
+        "version": {
+          "description": "Version is the version this resource belongs in Should be always first item in Versions field if provided. Optional, but at least one of Version or Versions must be set. Deprecated: Please use `Versions`.",
+          "type": "string"
+        },
+        "versions": {
+          "description": "Versions is the list of all supported versions for this resource. If Version field is provided, this field is optional. Validation: All versions must use the same validation schema for now. i.e., top level Validation field is applied to all of these versions. Order: The version name will be used to compute the order. If the version string is \"kube-like\", it will sort above non \"kube-like\" version strings, which are ordered lexicographically. \"Kube-like\" versions start with a \"v\", then are followed by a number (the major version), then optionally the string \"alpha\" or \"beta\" and another number (the minor version). These are sorted first by GA > beta > alpha (where GA is a version with no suffix such as beta or alpha), and then by comparing major version, then minor version. An example sorted list of versions: v10, v2, v1, v11beta2, v10beta3, v3beta1, v12alpha1, v11alpha2, foo1, foo10.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinitionVersion"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "group",
+        "names",
+        "scope"
+      ],
+      "type": "object"
+    },
+    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinitionStatus": {
+      "description": "CustomResourceDefinitionStatus indicates the state of the CustomResourceDefinition",
+      "properties": {
+        "acceptedNames": {
+          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinitionNames",
+          "description": "AcceptedNames are the names that are actually being used to serve discovery They may be different than the names in spec."
+        },
+        "conditions": {
+          "description": "Conditions indicate state for particular aspects of a CustomResourceDefinition",
+          "items": {
+            "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinitionCondition"
+          },
+          "type": "array"
+        },
+        "storedVersions": {
+          "description": "StoredVersions are all versions of CustomResources that were ever persisted. Tracking these versions allows a migration path for stored versions in etcd. The field is mutable so the migration controller can first finish a migration to another version (i.e. that no old objects are left in the storage), and then remove the rest of the versions from this list. None of the versions in this list can be removed from the spec.Versions field.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "conditions",
+        "acceptedNames",
+        "storedVersions"
+      ],
+      "type": "object"
+    },
+    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinitionVersion": {
+      "description": "CustomResourceDefinitionVersion describes a version for CRD.",
+      "properties": {
+        "additionalPrinterColumns": {
+          "description": "AdditionalPrinterColumns are additional columns shown e.g. in kubectl next to the name. Defaults to a created-at column. Top-level and per-version columns are mutually exclusive. Per-version columns must not all be set to identical values (top-level columns should be used instead) This field is alpha-level and is only honored by servers that enable the CustomResourceWebhookConversion feature. NOTE: CRDs created prior to 1.13 populated the top-level additionalPrinterColumns field by default. To apply an update that changes to per-version additionalPrinterColumns, the top-level additionalPrinterColumns field must be explicitly set to null",
+          "items": {
+            "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceColumnDefinition"
+          },
+          "type": "array"
+        },
+        "name": {
+          "description": "Name is the version name, e.g. \u201cv1\u201d, \u201cv2beta1\u201d, etc.",
+          "type": "string"
+        },
+        "schema": {
+          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceValidation",
+          "description": "Schema describes the schema for CustomResource used in validation, pruning, and defaulting. Top-level and per-version schemas are mutually exclusive. Per-version schemas must not all be set to identical values (top-level validation schema should be used instead) This field is alpha-level and is only honored by servers that enable the CustomResourceWebhookConversion feature."
+        },
+        "served": {
+          "description": "Served is a flag enabling/disabling this version from being served via REST APIs",
+          "type": "boolean"
+        },
+        "storage": {
+          "description": "Storage flags the version as storage version. There must be exactly one flagged as storage version.",
+          "type": "boolean"
+        },
+        "subresources": {
+          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceSubresources",
+          "description": "Subresources describes the subresources for CustomResource Top-level and per-version subresources are mutually exclusive. Per-version subresources must not all be set to identical values (top-level subresources should be used instead) This field is alpha-level and is only honored by servers that enable the CustomResourceWebhookConversion feature."
+        }
+      },
+      "required": [
+        "name",
+        "served",
+        "storage"
+      ],
+      "type": "object"
+    },
+    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceSubresourceScale": {
+      "description": "CustomResourceSubresourceScale defines how to serve the scale subresource for CustomResources.",
+      "properties": {
+        "labelSelectorPath": {
+          "description": "LabelSelectorPath defines the JSON path inside of a CustomResource that corresponds to Scale.Status.Selector. Only JSON paths without the array notation are allowed. Must be a JSON Path under .status. Must be set to work with HPA. If there is no value under the given path in the CustomResource, the status label selector value in the /scale subresource will default to the empty string.",
+          "type": "string"
+        },
+        "specReplicasPath": {
+          "description": "SpecReplicasPath defines the JSON path inside of a CustomResource that corresponds to Scale.Spec.Replicas. Only JSON paths without the array notation are allowed. Must be a JSON Path under .spec. If there is no value under the given path in the CustomResource, the /scale subresource will return an error on GET.",
+          "type": "string"
+        },
+        "statusReplicasPath": {
+          "description": "StatusReplicasPath defines the JSON path inside of a CustomResource that corresponds to Scale.Status.Replicas. Only JSON paths without the array notation are allowed. Must be a JSON Path under .status. If there is no value under the given path in the CustomResource, the status replica value in the /scale subresource will default to 0.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "specReplicasPath",
+        "statusReplicasPath"
+      ],
+      "type": "object"
+    },
+    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceSubresourceStatus": {
+      "description": "CustomResourceSubresourceStatus defines how to serve the status subresource for CustomResources. Status is represented by the `.status` JSON path inside of a CustomResource. When set, * exposes a /status subresource for the custom resource * PUT requests to the /status subresource take a custom resource object, and ignore changes to anything except the status stanza * PUT/POST/PATCH requests to the custom resource ignore changes to the status stanza",
+      "type": "object"
+    },
+    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceSubresources": {
+      "description": "CustomResourceSubresources defines the status and scale subresources for CustomResources.",
+      "properties": {
+        "scale": {
+          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceSubresourceScale",
+          "description": "Scale denotes the scale subresource for CustomResources"
+        },
+        "status": {
+          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceSubresourceStatus",
+          "description": "Status denotes the status subresource for CustomResources"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceValidation": {
+      "description": "CustomResourceValidation is a list of validation methods for CustomResources.",
+      "properties": {
+        "openAPIV3Schema": {
+          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaProps",
+          "description": "OpenAPIV3Schema is the OpenAPI v3 schema to be validated against."
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.ExternalDocumentation": {
+      "description": "ExternalDocumentation allows referencing an external resource for extended documentation.",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSON": {
+      "description": "JSON represents any valid JSON value. These types are supported: bool, int64, float64, string, []interface{}, map[string]interface{} and nil."
+    },
+    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaProps": {
+      "description": "JSONSchemaProps is a JSON-Schema following Specification Draft 4 (http://json-schema.org/).",
+      "properties": {
+        "$ref": {
+          "type": "string"
+        },
+        "$schema": {
+          "type": "string"
+        },
+        "additionalItems": {
+          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaPropsOrBool"
+        },
+        "additionalProperties": {
+          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaPropsOrBool"
+        },
+        "allOf": {
+          "items": {
+            "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaProps"
+          },
+          "type": "array"
+        },
+        "anyOf": {
+          "items": {
+            "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaProps"
+          },
+          "type": "array"
+        },
+        "default": {
+          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSON"
+        },
+        "definitions": {
+          "additionalProperties": {
+            "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaProps"
+          },
+          "type": "object"
+        },
+        "dependencies": {
+          "additionalProperties": {
+            "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaPropsOrStringArray"
+          },
+          "type": "object"
+        },
+        "description": {
+          "type": "string"
+        },
+        "enum": {
+          "items": {
+            "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSON"
+          },
+          "type": "array"
+        },
+        "example": {
+          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSON"
+        },
+        "exclusiveMaximum": {
+          "type": "boolean"
+        },
+        "exclusiveMinimum": {
+          "type": "boolean"
+        },
+        "externalDocs": {
+          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.ExternalDocumentation"
+        },
+        "format": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "items": {
+          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaPropsOrArray"
+        },
+        "maxItems": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "maxLength": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "maxProperties": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "maximum": {
+          "format": "double",
+          "type": "number"
+        },
+        "minItems": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "minLength": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "minProperties": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "minimum": {
+          "format": "double",
+          "type": "number"
+        },
+        "multipleOf": {
+          "format": "double",
+          "type": "number"
+        },
+        "not": {
+          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaProps"
+        },
+        "nullable": {
+          "type": "boolean"
+        },
+        "oneOf": {
+          "items": {
+            "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaProps"
+          },
+          "type": "array"
+        },
+        "pattern": {
+          "type": "string"
+        },
+        "patternProperties": {
+          "additionalProperties": {
+            "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaProps"
+          },
+          "type": "object"
+        },
+        "properties": {
+          "additionalProperties": {
+            "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaProps"
+          },
+          "type": "object"
+        },
+        "required": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "title": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "uniqueItems": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaPropsOrArray": {
+      "description": "JSONSchemaPropsOrArray represents a value that can either be a JSONSchemaProps or an array of JSONSchemaProps. Mainly here for serialization purposes."
+    },
+    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaPropsOrBool": {
+      "description": "JSONSchemaPropsOrBool represents JSONSchemaProps or a boolean value. Defaults to true for the boolean property."
+    },
+    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaPropsOrStringArray": {
+      "description": "JSONSchemaPropsOrStringArray represents a JSONSchemaProps or a string array."
+    },
+    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.ServiceReference": {
+      "description": "ServiceReference holds a reference to Service.legacy.k8s.io",
+      "properties": {
+        "name": {
+          "description": "`name` is the name of the service. Required",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "`namespace` is the namespace of the service. Required",
+          "type": "string"
+        },
+        "path": {
+          "description": "`path` is an optional URL path which will be sent in any request to this service.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "namespace",
+        "name"
+      ],
+      "type": "object"
+    },
+    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.WebhookClientConfig": {
+      "description": "WebhookClientConfig contains the information to make a TLS connection with the webhook. It has the same field as admissionregistration.v1beta1.WebhookClientConfig.",
+      "properties": {
+        "caBundle": {
+          "description": "`caBundle` is a PEM encoded CA bundle which will be used to validate the webhook's server certificate. If unspecified, system trust roots on the apiserver are used.",
+          "format": "byte",
+          "type": "string"
+        },
+        "service": {
+          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.ServiceReference",
+          "description": "`service` is a reference to the service for this webhook. Either `service` or `url` must be specified.\n\nIf the webhook is running within the cluster, then you should use `service`.\n\nPort 443 will be used if it is open, otherwise it is an error."
+        },
+        "url": {
+          "description": "`url` gives the location of the webhook, in standard URL form (`scheme://host:port/path`). Exactly one of `url` or `service` must be specified.\n\nThe `host` should not refer to a service running in the cluster; use the `service` field instead. The host might be resolved via external DNS in some apiservers (e.g., `kube-apiserver` cannot resolve in-cluster DNS as that would be a layering violation). `host` may also be an IP address.\n\nPlease note that using `localhost` or `127.0.0.1` as a `host` is risky unless you take great care to run this webhook on all hosts which run an apiserver which might need to make calls to this webhook. Such installs are likely to be non-portable, i.e., not easy to turn up in a new cluster.\n\nThe scheme must be \"https\"; the URL must begin with \"https://\".\n\nA path is optional, and if present may be any string permissible in a URL. You may use the path to pass an arbitrary string to the webhook, for example, a cluster identifier.\n\nAttempting to use a user or basic auth e.g. \"user:password@\" is not allowed. Fragments (\"#...\") and query parameters (\"?...\") are not allowed, either.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.apimachinery.pkg.api.resource.Quantity": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "number"
+        }
+      ]
+    },
+    "io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup": {
+      "description": "APIGroup contains the name, the supported versions, and the preferred version of a group.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "APIGroup"
+          ]
+        },
+        "name": {
+          "description": "name is the name of the group.",
+          "type": "string"
+        },
+        "preferredVersion": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.GroupVersionForDiscovery",
+          "description": "preferredVersion is the version preferred by the API server, which probably is the storage version."
+        },
+        "serverAddressByClientCIDRs": {
+          "description": "a map of client CIDR to server address that is serving this group. This is to help clients reach servers in the most network-efficient way possible. Clients can use the appropriate server address as per the CIDR that they match. In case of multiple matches, clients should use the longest matching CIDR. The server returns only those CIDRs that it thinks that the client can match. For example: the master will return an internal IP CIDR only, if the client reaches the server using an internal IP. Server looks at X-Forwarded-For header or X-Real-Ip header or request.RemoteAddr (in that order) to get the client IP.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ServerAddressByClientCIDR"
+          },
+          "type": "array"
+        },
+        "versions": {
+          "description": "versions are the versions supported in this group.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.GroupVersionForDiscovery"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "name",
+        "versions"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "",
+          "kind": "APIGroup",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.apimachinery.pkg.apis.meta.v1.APIGroupList": {
+      "description": "APIGroupList is a list of APIGroup, to allow clients to discover the API at /apis.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "groups": {
+          "description": "groups is a list of APIGroup.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "APIGroupList"
+          ]
+        }
+      },
+      "required": [
+        "groups"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "",
+          "kind": "APIGroupList",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.apimachinery.pkg.apis.meta.v1.APIResource": {
+      "description": "APIResource specifies the name of a resource and whether it is namespaced.",
+      "properties": {
+        "categories": {
+          "description": "categories is a list of the grouped resources this resource belongs to (e.g. 'all')",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "group": {
+          "description": "group is the preferred group of the resource.  Empty implies the group of the containing resource list. For subresources, this may have a different value, for example: Scale\".",
+          "type": "string"
+        },
+        "kind": {
+          "description": "kind is the kind for the resource (e.g. 'Foo' is the kind for a resource 'foo')",
+          "type": "string"
+        },
+        "name": {
+          "description": "name is the plural name of the resource.",
+          "type": "string"
+        },
+        "namespaced": {
+          "description": "namespaced indicates if a resource is namespaced or not.",
+          "type": "boolean"
+        },
+        "shortNames": {
+          "description": "shortNames is a list of suggested short names of the resource.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "singularName": {
+          "description": "singularName is the singular name of the resource.  This allows clients to handle plural and singular opaquely. The singularName is more correct for reporting status on a single item and both singular and plural are allowed from the kubectl CLI interface.",
+          "type": "string"
+        },
+        "storageVersionHash": {
+          "description": "The hash value of the storage version, the version this resource is converted to when written to the data store. Value must be treated as opaque by clients. Only equality comparison on the value is valid. This is an alpha feature and may change or be removed in the future. The field is populated by the apiserver only if the StorageVersionHash feature gate is enabled. This field will remain optional even if it graduates.",
+          "type": "string"
+        },
+        "verbs": {
+          "description": "verbs is a list of supported kube verbs (this includes get, list, watch, create, update, patch, delete, deletecollection, and proxy)",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "version": {
+          "description": "version is the preferred version of the resource.  Empty implies the version of the containing resource list For subresources, this may have a different value, for example: v1 (while inside a v1beta1 version of the core resource's group)\".",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "singularName",
+        "namespaced",
+        "kind",
+        "verbs"
+      ],
+      "type": "object"
+    },
+    "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+      "description": "APIResourceList is a list of APIResource, it is used to expose the name of the resources supported in a specific group and version, and if the resource is namespaced.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "groupVersion": {
+          "description": "groupVersion is the group and version this APIResourceList is for.",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "APIResourceList"
+          ]
+        },
+        "resources": {
+          "description": "resources contains the name of the resources and if they are namespaced.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.APIResource"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "groupVersion",
+        "resources"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "",
+          "kind": "APIResourceList",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.apimachinery.pkg.apis.meta.v1.APIVersions": {
+      "description": "APIVersions lists the versions that are available, to allow clients to discover the API at /api, which is the root path of the legacy v1 API.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "APIVersions"
+          ]
+        },
+        "serverAddressByClientCIDRs": {
+          "description": "a map of client CIDR to server address that is serving this group. This is to help clients reach servers in the most network-efficient way possible. Clients can use the appropriate server address as per the CIDR that they match. In case of multiple matches, clients should use the longest matching CIDR. The server returns only those CIDRs that it thinks that the client can match. For example: the master will return an internal IP CIDR only, if the client reaches the server using an internal IP. Server looks at X-Forwarded-For header or X-Real-Ip header or request.RemoteAddr (in that order) to get the client IP.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ServerAddressByClientCIDR"
+          },
+          "type": "array"
+        },
+        "versions": {
+          "description": "versions are the api versions that are available.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "versions",
+        "serverAddressByClientCIDRs"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "",
+          "kind": "APIVersions",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions": {
+      "description": "DeleteOptions may be provided when deleting an API object.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "dryRun": {
+          "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "gracePeriodSeconds": {
+          "description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "DeleteOptions"
+          ]
+        },
+        "orphanDependents": {
+          "description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+          "type": "boolean"
+        },
+        "preconditions": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Preconditions",
+          "description": "Must be fulfilled before a deletion is carried out. If not possible, a 409 Conflict status will be returned."
+        },
+        "propagationPolicy": {
+          "description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "",
+          "kind": "DeleteOptions",
+          "version": "v1"
+        },
+        {
+          "group": "admission.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1beta1"
+        },
+        {
+          "group": "admissionregistration.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1beta1"
+        },
+        {
+          "group": "apiextensions.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1beta1"
+        },
+        {
+          "group": "apiregistration.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1"
+        },
+        {
+          "group": "apiregistration.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1beta1"
+        },
+        {
+          "group": "apps",
+          "kind": "DeleteOptions",
+          "version": "v1"
+        },
+        {
+          "group": "apps",
+          "kind": "DeleteOptions",
+          "version": "v1beta1"
+        },
+        {
+          "group": "apps",
+          "kind": "DeleteOptions",
+          "version": "v1beta2"
+        },
+        {
+          "group": "auditregistration.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1alpha1"
+        },
+        {
+          "group": "authentication.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1"
+        },
+        {
+          "group": "authentication.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1beta1"
+        },
+        {
+          "group": "authorization.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1"
+        },
+        {
+          "group": "authorization.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1beta1"
+        },
+        {
+          "group": "autoscaling",
+          "kind": "DeleteOptions",
+          "version": "v1"
+        },
+        {
+          "group": "autoscaling",
+          "kind": "DeleteOptions",
+          "version": "v2beta1"
+        },
+        {
+          "group": "autoscaling",
+          "kind": "DeleteOptions",
+          "version": "v2beta2"
+        },
+        {
+          "group": "batch",
+          "kind": "DeleteOptions",
+          "version": "v1"
+        },
+        {
+          "group": "batch",
+          "kind": "DeleteOptions",
+          "version": "v1beta1"
+        },
+        {
+          "group": "batch",
+          "kind": "DeleteOptions",
+          "version": "v2alpha1"
+        },
+        {
+          "group": "certificates.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1beta1"
+        },
+        {
+          "group": "coordination.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1"
+        },
+        {
+          "group": "coordination.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1beta1"
+        },
+        {
+          "group": "events.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1beta1"
+        },
+        {
+          "group": "extensions",
+          "kind": "DeleteOptions",
+          "version": "v1beta1"
+        },
+        {
+          "group": "imagepolicy.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1alpha1"
+        },
+        {
+          "group": "networking.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1"
+        },
+        {
+          "group": "networking.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1beta1"
+        },
+        {
+          "group": "node.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1alpha1"
+        },
+        {
+          "group": "node.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1beta1"
+        },
+        {
+          "group": "policy",
+          "kind": "DeleteOptions",
+          "version": "v1beta1"
+        },
+        {
+          "group": "rbac.authorization.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1"
+        },
+        {
+          "group": "rbac.authorization.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1alpha1"
+        },
+        {
+          "group": "rbac.authorization.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1beta1"
+        },
+        {
+          "group": "scheduling.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1"
+        },
+        {
+          "group": "scheduling.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1alpha1"
+        },
+        {
+          "group": "scheduling.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1beta1"
+        },
+        {
+          "group": "settings.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1alpha1"
+        },
+        {
+          "group": "storage.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1"
+        },
+        {
+          "group": "storage.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1alpha1"
+        },
+        {
+          "group": "storage.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1beta1"
+        }
+      ]
+    },
+    "io.k8s.apimachinery.pkg.apis.meta.v1.Fields": {
+      "description": "Fields stores a set of fields in a data structure like a Trie. To understand how this is used, see: https://github.com/kubernetes-sigs/structured-merge-diff",
+      "type": "object"
+    },
+    "io.k8s.apimachinery.pkg.apis.meta.v1.GroupVersionForDiscovery": {
+      "description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
+      "properties": {
+        "groupVersion": {
+          "description": "groupVersion specifies the API group and version in the form \"group/version\"",
+          "type": "string"
+        },
+        "version": {
+          "description": "version specifies the version in the form of \"version\". This is to save the clients the trouble of splitting the GroupVersion.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "groupVersion",
+        "version"
+      ],
+      "type": "object"
+    },
+    "io.k8s.apimachinery.pkg.apis.meta.v1.Initializer": {
+      "description": "Initializer is information about an initializer that has not yet completed.",
+      "properties": {
+        "name": {
+          "description": "name of the process that is responsible for initializing this object.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "io.k8s.apimachinery.pkg.apis.meta.v1.Initializers": {
+      "description": "Initializers tracks the progress of initialization.",
+      "properties": {
+        "pending": {
+          "description": "Pending is a list of initializers that must execute in order before this object is visible. When the last pending initializer is removed, and no failing result is set, the initializers struct will be set to nil and the object is considered as initialized and visible to all clients.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Initializer"
+          },
+          "type": "array",
+          "x-kubernetes-patch-merge-key": "name",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "result": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Status",
+          "description": "If result is set with the Failure field, the object will be persisted to storage and then deleted, ensuring that other clients can observe the deletion."
+        }
+      },
+      "required": [
+        "pending"
+      ],
+      "type": "object"
+    },
+    "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+      "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+      "properties": {
+        "matchExpressions": {
+          "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelectorRequirement"
+          },
+          "type": "array"
+        },
+        "matchLabels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelectorRequirement": {
+      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+      "properties": {
+        "key": {
+          "description": "key is the label key that the selector applies to.",
+          "type": "string",
+          "x-kubernetes-patch-merge-key": "key",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "operator": {
+          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+          "type": "string"
+        },
+        "values": {
+          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "key",
+        "operator"
+      ],
+      "type": "object"
+    },
+    "io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta": {
+      "description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.",
+      "properties": {
+        "continue": {
+          "description": "continue may be set if the user set a limit on the number of items returned, and indicates that the server has more data available. The value is opaque and may be used to issue another request to the endpoint that served this list to retrieve the next set of available objects. Continuing a consistent list may not be possible if the server configuration has changed or more than a few minutes have passed. The resourceVersion field returned when using this continue value will be identical to the value in the first response, unless you have received this token from an error message.",
+          "type": "string"
+        },
+        "resourceVersion": {
+          "description": "String that identifies the server's internal version of this object that can be used by clients to determine when objects have changed. Value must be treated as opaque by clients and passed unmodified back to the server. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency",
+          "type": "string"
+        },
+        "selfLink": {
+          "description": "selfLink is a URL representing this object. Populated by the system. Read-only.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.apimachinery.pkg.apis.meta.v1.ManagedFieldsEntry": {
+      "description": "ManagedFieldsEntry is a workflow-id, a FieldSet and the group version of the resource that the fieldset applies to.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the version of this resource that this field set applies to. The format is \"group/version\" just like the top-level APIVersion field. It is necessary to track the version of a field set because it cannot be automatically converted.",
+          "type": "string"
+        },
+        "fields": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Fields",
+          "description": "Fields identifies a set of fields."
+        },
+        "manager": {
+          "description": "Manager is an identifier of the workflow managing these fields.",
+          "type": "string"
+        },
+        "operation": {
+          "description": "Operation is the type of operation which lead to this ManagedFieldsEntry being created. The only valid values for this field are 'Apply' and 'Update'.",
+          "type": "string"
+        },
+        "time": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "Time is timestamp of when these fields were set. It should always be empty if Operation is 'Apply'"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime": {
+      "description": "MicroTime is version of Time with microsecond level precision.",
+      "format": "date-time",
+      "type": "string"
+    },
+    "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+      "description": "ObjectMeta is metadata that all persisted resources must have, which includes all objects users must create.",
+      "properties": {
+        "annotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
+          "type": "object"
+        },
+        "clusterName": {
+          "description": "The name of the cluster which the object belongs to. This is used to distinguish resources with same name and namespace in different clusters. This field is not set anywhere right now and apiserver is going to ignore it if set in create or update request.",
+          "type": "string"
+        },
+        "creationTimestamp": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\n\nPopulated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+        },
+        "deletionGracePeriodSeconds": {
+          "description": "Number of seconds allowed for this object to gracefully terminate before it will be removed from the system. Only set when deletionTimestamp is also set. May only be shortened. Read-only.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "deletionTimestamp": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client. The resource is expected to be deleted (no longer visible from resource lists, and not reachable by name) after the time in this field, once the finalizers list is empty. As long as the finalizers list contains items, deletion is blocked. Once the deletionTimestamp is set, this value may not be unset or be set further into the future, although it may be shortened or the resource may be deleted prior to this time. For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination signal to the containers in the pod. After that 30 seconds, the Kubelet will send a hard termination signal (SIGKILL) to the container and after cleanup, remove the pod from the API. In the presence of network partitions, this object may still exist after this timestamp, until an administrator or automated process can determine the resource is fully terminated. If not set, graceful deletion of the object has not been requested.\n\nPopulated by the system when a graceful deletion is requested. Read-only. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+        },
+        "finalizers": {
+          "description": "Must be empty before the object is deleted from the registry. Each entry is an identifier for the responsible component that will remove the entry from the list. If the deletionTimestamp of the object is non-nil, entries in this list can only be removed.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "generateName": {
+          "description": "GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.\n\nIf this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).\n\nApplied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#idempotency",
+          "type": "string"
+        },
+        "generation": {
+          "description": "A sequence number representing a specific generation of the desired state. Populated by the system. Read-only.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "initializers": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Initializers",
+          "description": "An initializer is a controller which enforces some system invariant at object creation time. This field is a list of initializers that have not yet acted on this object. If nil or empty, this object has been completely initialized. Otherwise, the object is considered uninitialized and is hidden (in list/watch and get calls) from clients that haven't explicitly asked to observe uninitialized objects.\n\nWhen an object is created, the system will populate this list with the current set of initializers. Only privileged users may set or modify this list. Once it is empty, it may not be modified further by any user.\n\nDEPRECATED - initializers are an alpha field and will be removed in v1.15."
+        },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+          "type": "object"
+        },
+        "managedFields": {
+          "description": "ManagedFields maps workflow-id and version to the set of fields that are managed by that workflow. This is mostly for internal housekeeping, and users typically shouldn't need to set or understand this field. A workflow can be the user's name, a controller's name, or the name of a specific apply path like \"ci-cd\". The set of fields is always in the version that the workflow used when modifying the object.\n\nThis field is alpha and can be changed or removed without notice.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ManagedFieldsEntry"
+          },
+          "type": "array"
+        },
+        "name": {
+          "description": "Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace defines the space within each name must be unique. An empty namespace is equivalent to the \"default\" namespace, but \"default\" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.\n\nMust be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces",
+          "type": "string"
+        },
+        "ownerReferences": {
+          "description": "List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference"
+          },
+          "type": "array",
+          "x-kubernetes-patch-merge-key": "uid",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "resourceVersion": {
+          "description": "An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.\n\nPopulated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency",
+          "type": "string"
+        },
+        "selfLink": {
+          "description": "SelfLink is a URL representing this object. Populated by the system. Read-only.",
+          "type": "string"
+        },
+        "uid": {
+          "description": "UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.\n\nPopulated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference": {
+      "description": "OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.",
+      "properties": {
+        "apiVersion": {
+          "description": "API version of the referent.",
+          "type": "string"
+        },
+        "blockOwnerDeletion": {
+          "description": "If true, AND if the owner has the \"foregroundDeletion\" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. Defaults to false. To set this field, a user needs \"delete\" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.",
+          "type": "boolean"
+        },
+        "controller": {
+          "description": "If true, this reference points to the managing controller.",
+          "type": "boolean"
+        },
+        "kind": {
+          "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+          "type": "string"
+        },
+        "uid": {
+          "description": "UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids",
+          "type": "string"
+        }
+      },
+      "required": [
+        "apiVersion",
+        "kind",
+        "name",
+        "uid"
+      ],
+      "type": "object"
+    },
+    "io.k8s.apimachinery.pkg.apis.meta.v1.Patch": {
+      "description": "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body.",
+      "type": "object"
+    },
+    "io.k8s.apimachinery.pkg.apis.meta.v1.Preconditions": {
+      "description": "Preconditions must be fulfilled before an operation (update, delete, etc.) is carried out.",
+      "properties": {
+        "resourceVersion": {
+          "description": "Specifies the target ResourceVersion",
+          "type": "string"
+        },
+        "uid": {
+          "description": "Specifies the target UID.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.apimachinery.pkg.apis.meta.v1.ServerAddressByClientCIDR": {
+      "description": "ServerAddressByClientCIDR helps the client to determine the server address that they should use, depending on the clientCIDR that they match.",
+      "properties": {
+        "clientCIDR": {
+          "description": "The CIDR with which clients can match their IP to figure out the server address that they should use.",
+          "type": "string"
+        },
+        "serverAddress": {
+          "description": "Address of this server, suitable for a client that matches the above CIDR. This can be a hostname, hostname:port, IP or IP:port.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "clientCIDR",
+        "serverAddress"
+      ],
+      "type": "object"
+    },
+    "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+      "description": "Status is a return value for calls that don't return other objects.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "code": {
+          "description": "Suggested HTTP return code for this status, 0 if not set.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "details": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails",
+          "description": "Extended data associated with the reason.  Each reason may define its own extended details. This field is optional and the data returned is not guaranteed to conform to any schema except that defined by the reason type."
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "Status"
+          ]
+        },
+        "message": {
+          "description": "A human-readable description of the status of this operation.",
+          "type": "string"
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds"
+        },
+        "reason": {
+          "description": "A machine-readable description of why this operation is in the \"Failure\" status. If this value is empty there is no information available. A Reason clarifies an HTTP status code but does not override it.",
+          "type": "string"
+        },
+        "status": {
+          "description": "Status of the operation. One of: \"Success\" or \"Failure\". More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "",
+          "kind": "Status",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.apimachinery.pkg.apis.meta.v1.StatusCause": {
+      "description": "StatusCause provides more information about an api.Status failure, including cases when multiple errors are encountered.",
+      "properties": {
+        "field": {
+          "description": "The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.\n\nExamples:\n  \"name\" - the field \"name\" on the current resource\n  \"items[0].name\" - the field \"name\" on the first array entry in \"items\"",
+          "type": "string"
+        },
+        "message": {
+          "description": "A human-readable description of the cause of the error.  This field may be presented as-is to a reader.",
+          "type": "string"
+        },
+        "reason": {
+          "description": "A machine-readable description of the cause of the error. If this value is empty there is no information available.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+      "description": "StatusDetails is a set of additional properties that MAY be set by the server to provide additional information about a response. The Reason field of a Status object defines what attributes will be set. Clients must ignore fields that do not match the defined type of each attribute, and should assume that any attribute may be empty, invalid, or under defined.",
+      "properties": {
+        "causes": {
+          "description": "The Causes array includes more details associated with the StatusReason failure. Not all StatusReasons may provide detailed causes.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.StatusCause"
+          },
+          "type": "array"
+        },
+        "group": {
+          "description": "The group attribute of the resource associated with the status StatusReason.",
+          "type": "string"
+        },
+        "kind": {
+          "description": "The kind attribute of the resource associated with the status StatusReason. On some operations may differ from the requested resource Kind. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string"
+        },
+        "name": {
+          "description": "The name attribute of the resource associated with the status StatusReason (when there is a single name which can be described).",
+          "type": "string"
+        },
+        "retryAfterSeconds": {
+          "description": "If specified, the time in seconds before the operation should be retried. Some errors may indicate the client must take an alternate action - for those errors this field may indicate how long to wait before taking the alternate action.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "uid": {
+          "description": "UID of the resource. (when there is a single resource which can be described). More info: http://kubernetes.io/docs/user-guide/identifiers#uids",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+      "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
+      "format": "date-time",
+      "type": "string"
+    },
+    "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+      "description": "Event represents a single event to a watched resource.",
+      "properties": {
+        "object": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.runtime.RawExtension",
+          "description": "Object is:\n * If Type is Added or Modified: the new state of the object.\n * If Type is Deleted: the state of the object immediately before deletion.\n * If Type is Error: *Status is recommended; other types may make sense\n   depending on context."
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "object"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "",
+          "kind": "WatchEvent",
+          "version": "v1"
+        },
+        {
+          "group": "admission.k8s.io",
+          "kind": "WatchEvent",
+          "version": "v1beta1"
+        },
+        {
+          "group": "admissionregistration.k8s.io",
+          "kind": "WatchEvent",
+          "version": "v1beta1"
+        },
+        {
+          "group": "apiextensions.k8s.io",
+          "kind": "WatchEvent",
+          "version": "v1beta1"
+        },
+        {
+          "group": "apiregistration.k8s.io",
+          "kind": "WatchEvent",
+          "version": "v1"
+        },
+        {
+          "group": "apiregistration.k8s.io",
+          "kind": "WatchEvent",
+          "version": "v1beta1"
+        },
+        {
+          "group": "apps",
+          "kind": "WatchEvent",
+          "version": "v1"
+        },
+        {
+          "group": "apps",
+          "kind": "WatchEvent",
+          "version": "v1beta1"
+        },
+        {
+          "group": "apps",
+          "kind": "WatchEvent",
+          "version": "v1beta2"
+        },
+        {
+          "group": "auditregistration.k8s.io",
+          "kind": "WatchEvent",
+          "version": "v1alpha1"
+        },
+        {
+          "group": "authentication.k8s.io",
+          "kind": "WatchEvent",
+          "version": "v1"
+        },
+        {
+          "group": "authentication.k8s.io",
+          "kind": "WatchEvent",
+          "version": "v1beta1"
+        },
+        {
+          "group": "authorization.k8s.io",
+          "kind": "WatchEvent",
+          "version": "v1"
+        },
+        {
+          "group": "authorization.k8s.io",
+          "kind": "WatchEvent",
+          "version": "v1beta1"
+        },
+        {
+          "group": "autoscaling",
+          "kind": "WatchEvent",
+          "version": "v1"
+        },
+        {
+          "group": "autoscaling",
+          "kind": "WatchEvent",
+          "version": "v2beta1"
+        },
+        {
+          "group": "autoscaling",
+          "kind": "WatchEvent",
+          "version": "v2beta2"
+        },
+        {
+          "group": "batch",
+          "kind": "WatchEvent",
+          "version": "v1"
+        },
+        {
+          "group": "batch",
+          "kind": "WatchEvent",
+          "version": "v1beta1"
+        },
+        {
+          "group": "batch",
+          "kind": "WatchEvent",
+          "version": "v2alpha1"
+        },
+        {
+          "group": "certificates.k8s.io",
+          "kind": "WatchEvent",
+          "version": "v1beta1"
+        },
+        {
+          "group": "coordination.k8s.io",
+          "kind": "WatchEvent",
+          "version": "v1"
+        },
+        {
+          "group": "coordination.k8s.io",
+          "kind": "WatchEvent",
+          "version": "v1beta1"
+        },
+        {
+          "group": "events.k8s.io",
+          "kind": "WatchEvent",
+          "version": "v1beta1"
+        },
+        {
+          "group": "extensions",
+          "kind": "WatchEvent",
+          "version": "v1beta1"
+        },
+        {
+          "group": "imagepolicy.k8s.io",
+          "kind": "WatchEvent",
+          "version": "v1alpha1"
+        },
+        {
+          "group": "networking.k8s.io",
+          "kind": "WatchEvent",
+          "version": "v1"
+        },
+        {
+          "group": "networking.k8s.io",
+          "kind": "WatchEvent",
+          "version": "v1beta1"
+        },
+        {
+          "group": "node.k8s.io",
+          "kind": "WatchEvent",
+          "version": "v1alpha1"
+        },
+        {
+          "group": "node.k8s.io",
+          "kind": "WatchEvent",
+          "version": "v1beta1"
+        },
+        {
+          "group": "policy",
+          "kind": "WatchEvent",
+          "version": "v1beta1"
+        },
+        {
+          "group": "rbac.authorization.k8s.io",
+          "kind": "WatchEvent",
+          "version": "v1"
+        },
+        {
+          "group": "rbac.authorization.k8s.io",
+          "kind": "WatchEvent",
+          "version": "v1alpha1"
+        },
+        {
+          "group": "rbac.authorization.k8s.io",
+          "kind": "WatchEvent",
+          "version": "v1beta1"
+        },
+        {
+          "group": "scheduling.k8s.io",
+          "kind": "WatchEvent",
+          "version": "v1"
+        },
+        {
+          "group": "scheduling.k8s.io",
+          "kind": "WatchEvent",
+          "version": "v1alpha1"
+        },
+        {
+          "group": "scheduling.k8s.io",
+          "kind": "WatchEvent",
+          "version": "v1beta1"
+        },
+        {
+          "group": "settings.k8s.io",
+          "kind": "WatchEvent",
+          "version": "v1alpha1"
+        },
+        {
+          "group": "storage.k8s.io",
+          "kind": "WatchEvent",
+          "version": "v1"
+        },
+        {
+          "group": "storage.k8s.io",
+          "kind": "WatchEvent",
+          "version": "v1alpha1"
+        },
+        {
+          "group": "storage.k8s.io",
+          "kind": "WatchEvent",
+          "version": "v1beta1"
+        }
+      ]
+    },
+    "io.k8s.apimachinery.pkg.runtime.RawExtension": {
+      "description": "RawExtension is used to hold extensions in external versions.\n\nTo use this, make a field which has RawExtension as its type in your external, versioned struct, and Object in your internal struct. You also need to register your various plugin types.\n\n// Internal package: type MyAPIObject struct {\n\truntime.TypeMeta `json:\",inline\"`\n\tMyPlugin runtime.Object `json:\"myPlugin\"`\n} type PluginA struct {\n\tAOption string `json:\"aOption\"`\n}\n\n// External package: type MyAPIObject struct {\n\truntime.TypeMeta `json:\",inline\"`\n\tMyPlugin runtime.RawExtension `json:\"myPlugin\"`\n} type PluginA struct {\n\tAOption string `json:\"aOption\"`\n}\n\n// On the wire, the JSON will look something like this: {\n\t\"kind\":\"MyAPIObject\",\n\t\"apiVersion\":\"v1\",\n\t\"myPlugin\": {\n\t\t\"kind\":\"PluginA\",\n\t\t\"aOption\":\"foo\",\n\t},\n}\n\nSo what happens? Decode first uses json or yaml to unmarshal the serialized data into your external MyAPIObject. That causes the raw JSON to be stored, but not unpacked. The next step is to copy (using pkg/conversion) into the internal struct. The runtime package's DefaultScheme has conversion functions installed which will unpack the JSON stored in RawExtension, turning it into the correct object type, and storing it in the Object. (TODO: In the case where the object is of an unknown type, a runtime.Unknown object will be created and stored.)",
+      "properties": {
+        "Raw": {
+          "description": "Raw is the underlying serialization of this object.",
+          "format": "byte",
+          "type": "string"
+        }
+      },
+      "required": [
+        "Raw"
+      ],
+      "type": "object"
+    },
+    "io.k8s.apimachinery.pkg.util.intstr.IntOrString": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "integer"
+        }
+      ]
+    },
+    "io.k8s.apimachinery.pkg.version.Info": {
+      "description": "Info contains versioning information. how we'll want to distribute that information.",
+      "properties": {
+        "buildDate": {
+          "type": "string"
+        },
+        "compiler": {
+          "type": "string"
+        },
+        "gitCommit": {
+          "type": "string"
+        },
+        "gitTreeState": {
+          "type": "string"
+        },
+        "gitVersion": {
+          "type": "string"
+        },
+        "goVersion": {
+          "type": "string"
+        },
+        "major": {
+          "type": "string"
+        },
+        "minor": {
+          "type": "string"
+        },
+        "platform": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "major",
+        "minor",
+        "gitVersion",
+        "gitCommit",
+        "gitTreeState",
+        "buildDate",
+        "goVersion",
+        "compiler",
+        "platform"
+      ],
+      "type": "object"
+    },
+    "io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.APIService": {
+      "description": "APIService represents a server for a particular GroupVersion. Name must be \"version.group\".",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "APIService"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.APIServiceSpec",
+          "description": "Spec contains information for locating and communicating with a server"
+        },
+        "status": {
+          "$ref": "#/definitions/io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.APIServiceStatus",
+          "description": "Status contains derived information about an API server"
+        }
+      },
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "apiregistration.k8s.io",
+          "kind": "APIService",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.APIServiceCondition": {
+      "description": "APIServiceCondition describes the state of an APIService at a particular point",
+      "properties": {
+        "lastTransitionTime": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "Last time the condition transitioned from one status to another."
+        },
+        "message": {
+          "description": "Human-readable message indicating details about last transition.",
+          "type": "string"
+        },
+        "reason": {
+          "description": "Unique, one-word, CamelCase reason for the condition's last transition.",
+          "type": "string"
+        },
+        "status": {
+          "description": "Status is the status of the condition. Can be True, False, Unknown.",
+          "type": "string"
+        },
+        "type": {
+          "description": "Type is the type of the condition.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "status"
+      ],
+      "type": "object"
+    },
+    "io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.APIServiceList": {
+      "description": "APIServiceList is a list of APIService objects.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "items": {
+            "$ref": "#/definitions/io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.APIService"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "APIServiceList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "apiregistration.k8s.io",
+          "kind": "APIServiceList",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.APIServiceSpec": {
+      "description": "APIServiceSpec contains information for locating and communicating with a server. Only https is supported, though you are able to disable certificate verification.",
+      "properties": {
+        "caBundle": {
+          "description": "CABundle is a PEM encoded CA bundle which will be used to validate an API server's serving certificate. If unspecified, system trust roots on the apiserver are used.",
+          "format": "byte",
+          "type": "string"
+        },
+        "group": {
+          "description": "Group is the API group name this server hosts",
+          "type": "string"
+        },
+        "groupPriorityMinimum": {
+          "description": "GroupPriorityMininum is the priority this group should have at least. Higher priority means that the group is preferred by clients over lower priority ones. Note that other versions of this group might specify even higher GroupPriorityMininum values such that the whole group gets a higher priority. The primary sort is based on GroupPriorityMinimum, ordered highest number to lowest (20 before 10). The secondary sort is based on the alphabetical comparison of the name of the object.  (v1.bar before v1.foo) We'd recommend something like: *.k8s.io (except extensions) at 18000 and PaaSes (OpenShift, Deis) are recommended to be in the 2000s",
+          "format": "int32",
+          "type": "integer"
+        },
+        "insecureSkipTLSVerify": {
+          "description": "InsecureSkipTLSVerify disables TLS certificate verification when communicating with this server. This is strongly discouraged.  You should use the CABundle instead.",
+          "type": "boolean"
+        },
+        "service": {
+          "$ref": "#/definitions/io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.ServiceReference",
+          "description": "Service is a reference to the service for this API server.  It must communicate on port 443 If the Service is nil, that means the handling for the API groupversion is handled locally on this server. The call will simply delegate to the normal handler chain to be fulfilled."
+        },
+        "version": {
+          "description": "Version is the API version this server hosts.  For example, \"v1\"",
+          "type": "string"
+        },
+        "versionPriority": {
+          "description": "VersionPriority controls the ordering of this API version inside of its group.  Must be greater than zero. The primary sort is based on VersionPriority, ordered highest to lowest (20 before 10). Since it's inside of a group, the number can be small, probably in the 10s. In case of equal version priorities, the version string will be used to compute the order inside a group. If the version string is \"kube-like\", it will sort above non \"kube-like\" version strings, which are ordered lexicographically. \"Kube-like\" versions start with a \"v\", then are followed by a number (the major version), then optionally the string \"alpha\" or \"beta\" and another number (the minor version). These are sorted first by GA > beta > alpha (where GA is a version with no suffix such as beta or alpha), and then by comparing major version, then minor version. An example sorted list of versions: v10, v2, v1, v11beta2, v10beta3, v3beta1, v12alpha1, v11alpha2, foo1, foo10.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "service",
+        "groupPriorityMinimum",
+        "versionPriority"
+      ],
+      "type": "object"
+    },
+    "io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.APIServiceStatus": {
+      "description": "APIServiceStatus contains derived information about an API server",
+      "properties": {
+        "conditions": {
+          "description": "Current service state of apiService.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.APIServiceCondition"
+          },
+          "type": "array",
+          "x-kubernetes-patch-merge-key": "type",
+          "x-kubernetes-patch-strategy": "merge"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.ServiceReference": {
+      "description": "ServiceReference holds a reference to Service.legacy.k8s.io",
+      "properties": {
+        "name": {
+          "description": "Name is the name of the service",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace is the namespace of the service",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.kube-aggregator.pkg.apis.apiregistration.v1beta1.APIService": {
+      "description": "APIService represents a server for a particular GroupVersion. Name must be \"version.group\".",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "APIService"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.kube-aggregator.pkg.apis.apiregistration.v1beta1.APIServiceSpec",
+          "description": "Spec contains information for locating and communicating with a server"
+        },
+        "status": {
+          "$ref": "#/definitions/io.k8s.kube-aggregator.pkg.apis.apiregistration.v1beta1.APIServiceStatus",
+          "description": "Status contains derived information about an API server"
+        }
+      },
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "apiregistration.k8s.io",
+          "kind": "APIService",
+          "version": "v1beta1"
+        }
+      ]
+    },
+    "io.k8s.kube-aggregator.pkg.apis.apiregistration.v1beta1.APIServiceCondition": {
+      "description": "APIServiceCondition describes the state of an APIService at a particular point",
+      "properties": {
+        "lastTransitionTime": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "Last time the condition transitioned from one status to another."
+        },
+        "message": {
+          "description": "Human-readable message indicating details about last transition.",
+          "type": "string"
+        },
+        "reason": {
+          "description": "Unique, one-word, CamelCase reason for the condition's last transition.",
+          "type": "string"
+        },
+        "status": {
+          "description": "Status is the status of the condition. Can be True, False, Unknown.",
+          "type": "string"
+        },
+        "type": {
+          "description": "Type is the type of the condition.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "status"
+      ],
+      "type": "object"
+    },
+    "io.k8s.kube-aggregator.pkg.apis.apiregistration.v1beta1.APIServiceList": {
+      "description": "APIServiceList is a list of APIService objects.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "items": {
+            "$ref": "#/definitions/io.k8s.kube-aggregator.pkg.apis.apiregistration.v1beta1.APIService"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": [
+            "APIServiceList"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "apiregistration.k8s.io",
+          "kind": "APIServiceList",
+          "version": "v1beta1"
+        }
+      ]
+    },
+    "io.k8s.kube-aggregator.pkg.apis.apiregistration.v1beta1.APIServiceSpec": {
+      "description": "APIServiceSpec contains information for locating and communicating with a server. Only https is supported, though you are able to disable certificate verification.",
+      "properties": {
+        "caBundle": {
+          "description": "CABundle is a PEM encoded CA bundle which will be used to validate an API server's serving certificate. If unspecified, system trust roots on the apiserver are used.",
+          "format": "byte",
+          "type": "string"
+        },
+        "group": {
+          "description": "Group is the API group name this server hosts",
+          "type": "string"
+        },
+        "groupPriorityMinimum": {
+          "description": "GroupPriorityMininum is the priority this group should have at least. Higher priority means that the group is preferred by clients over lower priority ones. Note that other versions of this group might specify even higher GroupPriorityMininum values such that the whole group gets a higher priority. The primary sort is based on GroupPriorityMinimum, ordered highest number to lowest (20 before 10). The secondary sort is based on the alphabetical comparison of the name of the object.  (v1.bar before v1.foo) We'd recommend something like: *.k8s.io (except extensions) at 18000 and PaaSes (OpenShift, Deis) are recommended to be in the 2000s",
+          "format": "int32",
+          "type": "integer"
+        },
+        "insecureSkipTLSVerify": {
+          "description": "InsecureSkipTLSVerify disables TLS certificate verification when communicating with this server. This is strongly discouraged.  You should use the CABundle instead.",
+          "type": "boolean"
+        },
+        "service": {
+          "$ref": "#/definitions/io.k8s.kube-aggregator.pkg.apis.apiregistration.v1beta1.ServiceReference",
+          "description": "Service is a reference to the service for this API server.  It must communicate on port 443 If the Service is nil, that means the handling for the API groupversion is handled locally on this server. The call will simply delegate to the normal handler chain to be fulfilled."
+        },
+        "version": {
+          "description": "Version is the API version this server hosts.  For example, \"v1\"",
+          "type": "string"
+        },
+        "versionPriority": {
+          "description": "VersionPriority controls the ordering of this API version inside of its group.  Must be greater than zero. The primary sort is based on VersionPriority, ordered highest to lowest (20 before 10). Since it's inside of a group, the number can be small, probably in the 10s. In case of equal version priorities, the version string will be used to compute the order inside a group. If the version string is \"kube-like\", it will sort above non \"kube-like\" version strings, which are ordered lexicographically. \"Kube-like\" versions start with a \"v\", then are followed by a number (the major version), then optionally the string \"alpha\" or \"beta\" and another number (the minor version). These are sorted first by GA > beta > alpha (where GA is a version with no suffix such as beta or alpha), and then by comparing major version, then minor version. An example sorted list of versions: v10, v2, v1, v11beta2, v10beta3, v3beta1, v12alpha1, v11alpha2, foo1, foo10.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "service",
+        "groupPriorityMinimum",
+        "versionPriority"
+      ],
+      "type": "object"
+    },
+    "io.k8s.kube-aggregator.pkg.apis.apiregistration.v1beta1.APIServiceStatus": {
+      "description": "APIServiceStatus contains derived information about an API server",
+      "properties": {
+        "conditions": {
+          "description": "Current service state of apiService.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.kube-aggregator.pkg.apis.apiregistration.v1beta1.APIServiceCondition"
+          },
+          "type": "array",
+          "x-kubernetes-patch-merge-key": "type",
+          "x-kubernetes-patch-strategy": "merge"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.kube-aggregator.pkg.apis.apiregistration.v1beta1.ServiceReference": {
+      "description": "ServiceReference holds a reference to Service.legacy.k8s.io",
+      "properties": {
+        "name": {
+          "description": "Name is the name of the service",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace is the namespace of the service",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    }
+  }
+}

--- a/cmd/bench.go
+++ b/cmd/bench.go
@@ -45,6 +45,7 @@ func newBenchmarkEvalParams() benchmarkCommandParams {
 				benchmarkGoBenchOutput,
 			}),
 			target: util.NewEnumFlag(compile.TargetRego, []string{compile.TargetRego, compile.TargetWasm}),
+			schema: &schemaFlags{},
 		},
 	}
 }
@@ -97,7 +98,7 @@ The optional "gobench" output format conforms to the Go Benchmark Data Format.
 	addMetricsFlag(benchCommand.Flags(), &params.metrics, true)
 	addOutputFormat(benchCommand.Flags(), params.outputFormat)
 	addIgnoreFlag(benchCommand.Flags(), &params.ignore)
-	addSchemaFlag(benchCommand.Flags(), &params.schemaPath)
+	addSchemaFlags(benchCommand.Flags(), params.schema)
 	addTargetFlag(benchCommand.Flags(), params.target)
 
 	// Shared benchmark flags

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -63,27 +63,27 @@ The 'build' command packages OPA policy and data files into bundles. Bundles are
 gzipped tarballs containing policies and data. Paths referring to directories are
 loaded recursively.
 
-	$ ls
-	example.rego
+    $ ls
+    example.rego
 
-	$ opa build -b .
+    $ opa build -b .
 
 You can load bundles into OPA on the command-line:
 
-	$ ls
-	bundle.tar.gz example.rego
+    $ ls
+    bundle.tar.gz example.rego
 
-	$ opa run bundle.tar.gz
+    $ opa run bundle.tar.gz
 
 You can also configure OPA to download bundles from remote HTTP endpoints:
 
-	$ opa run --server \
-		--set bundles.example.resource=bundle.tar.gz \
-		--set services.example.url=http://localhost:8080
+    $ opa run --server \
+        --set bundles.example.resource=bundle.tar.gz \
+        --set services.example.url=http://localhost:8080
 
 Inside another terminal in the same directory, serve the bundle via HTTP:
 
-	$ python3 -m http.server --bind localhost 8080
+    $ python3 -m http.server --bind localhost 8080
 
 For more information on bundles see https://www.openpolicyagent.org/docs/latest/management.
 
@@ -131,21 +131,21 @@ https://www.openpolicyagent.org/docs/latest/management/#signature-verification.
 
 Example:
 
-	$ opa build --verification-key /path/to/public_key.pem --signing-key /path/to/private_key.pem --bundle foo
+    $ opa build --verification-key /path/to/public_key.pem --signing-key /path/to/private_key.pem --bundle foo
 
 Where foo has the following structure:
 
-	foo/
-	  |
-	  +-- bar/
-	  |     |
-	  |     +-- data.json
-	  |
-	  +-- policy.rego
-	  |
-	  +-- .manifest
-	  |
-	  +-- .signatures.json
+    foo/
+      |
+      +-- bar/
+      |     |
+      |     +-- data.json
+      |
+      +-- policy.rego
+      |
+      +-- .manifest
+      |
+      +-- .signatures.json
 
 
 The 'build' command will verify the signatures using the public key provided by the --verification-key flag.
@@ -170,35 +170,35 @@ The capabilities define the built-in functions and other language features that 
 may depend on. For example, the following capabilities file only permits the policy to
 depend on the "plus" built-in function ('+'):
 
-	{
-		"builtins": [
-			{
-				"name": "plus",
-				"infix": "+",
-				"decl": {
-					"type": "function",
-					"args": [
-						{
-							"type": "number"
-						},
-						{
-							"type": "number"
-						}
-					],
-					"result": {
-						"type": "number"
-					}
-				}
-			}
-		]
-	}
+    {
+        "builtins": [
+            {
+                "name": "plus",
+                "infix": "+",
+                "decl": {
+                    "type": "function",
+                    "args": [
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "type": "number"
+                        }
+                    ],
+                    "result": {
+                        "type": "number"
+                    }
+                }
+            }
+        ]
+    }
 
-Capablities can be used to validate policies against a specific version of OPA.
+Capabilities can be used to validate policies against a specific version of OPA.
 The OPA repository contains a set of capabilities files for each OPA release. For example,
 the following command builds a directory of policies ('./policies') and validates them
 against OPA v0.22.0:
 
-	opa build ./policies --capabilities $OPA_SRC/capabilities/v0.22.0.json
+    opa build ./policies --capabilities $OPA_SRC/capabilities/v0.22.0.json
 `,
 		PreRunE: func(Cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -44,10 +44,10 @@ type buildParams struct {
 }
 
 func newBuildParams() buildParams {
-	var buildParams buildParams
-	buildParams.capabilities = newcapabilitiesFlag()
-	buildParams.target = util.NewEnumFlag(compile.TargetRego, []string{compile.TargetRego, compile.TargetWasm})
-	return buildParams
+	return buildParams{
+		capabilities: newcapabilitiesFlag(),
+		target:       util.NewEnumFlag(compile.TargetRego, []string{compile.TargetRego, compile.TargetWasm}),
+	}
 }
 
 func init() {

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -23,12 +23,13 @@ var checkParams = struct {
 	ignore       []string
 	bundleMode   bool
 	capabilities *capabilitiesFlag
-	schemaPath   string
+	schema       *schemaFlags
 }{
 	format: util.NewEnumFlag(checkFormatPretty, []string{
 		checkFormatPretty, checkFormatJSON,
 	}),
 	capabilities: newcapabilitiesFlag(),
+	schema:       &schemaFlags{},
 }
 
 const (
@@ -61,7 +62,7 @@ func checkModules(args []string) int {
 
 	modules := map[string]*ast.Module{}
 
-	ss, err := loader.Schemas(checkParams.schemaPath)
+	ss, err := loader.Schemas(checkParams.schema.path)
 	if err != nil {
 		outputErrors(err)
 		return 1
@@ -110,7 +111,8 @@ func checkModules(args []string) int {
 	compiler := ast.NewCompiler().
 		SetErrorLimit(checkParams.errLimit).
 		WithCapabilities(capabilities).
-		WithSchemas(ss)
+		WithSchemas(ss).
+		WithFetchRemoteSchemas(checkParams.schema.fetchRemote)
 
 	compiler.Compile(modules)
 
@@ -151,6 +153,6 @@ func init() {
 	checkCommand.Flags().VarP(checkParams.format, "format", "f", "set output format")
 	addBundleModeFlag(checkCommand.Flags(), &checkParams.bundleMode, false)
 	addCapabilitiesFlag(checkCommand.Flags(), checkParams.capabilities)
-	addSchemaFlag(checkCommand.Flags(), &checkParams.schemaPath)
+	addSchemaFlags(checkCommand.Flags(), checkParams.schema)
 	RootCommand.AddCommand(checkCommand)
 }

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -111,8 +111,7 @@ func checkModules(args []string) int {
 	compiler := ast.NewCompiler().
 		SetErrorLimit(checkParams.errLimit).
 		WithCapabilities(capabilities).
-		WithSchemas(ss).
-		WithFetchRemoteSchemas(!checkParams.schema.dontFetchRemote)
+		WithSchemas(ss)
 
 	compiler.Compile(modules)
 

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -112,7 +112,7 @@ func checkModules(args []string) int {
 		SetErrorLimit(checkParams.errLimit).
 		WithCapabilities(capabilities).
 		WithSchemas(ss).
-		WithFetchRemoteSchemas(checkParams.schema.fetchRemote)
+		WithFetchRemoteSchemas(!checkParams.schema.dontFetchRemote)
 
 	compiler.Compile(modules)
 

--- a/cmd/eval.go
+++ b/cmd/eval.go
@@ -152,15 +152,15 @@ Examples
 
 To evaluate a simple query:
 
-	$ opa eval 'x = 1; y = 2; x < y'
+    $ opa eval 'x = 1; y = 2; x < y'
 
 To evaluate a query against JSON data:
 
-	$ opa eval --data data.json 'data.names[_] = name'
+    $ opa eval --data data.json 'data.names[_] = name'
 
 To evaluate a query against JSON data supplied with a file:// URL:
 
-	$ opa eval --data file:///path/to/file.json 'data'
+    $ opa eval --data file:///path/to/file.json 'data'
 
 
 File & Bundle Loading
@@ -170,19 +170,19 @@ The --bundle flag will load data files and Rego files contained
 in the bundle specified by the path. It can be either a
 compressed tar archive bundle file or a directory tree.
 
-	$ opa eval --bundle /some/path 'data'
+    $ opa eval --bundle /some/path 'data'
 
 Where /some/path contains:
 
-	foo/
-	  |
-	  +-- bar/
-	  |     |
-	  |     +-- data.json
-	  |
-	  +-- baz.rego
-	  |
-	  +-- manifest.yaml
+    foo/
+      |
+      +-- bar/
+      |     |
+      |     +-- data.json
+      |
+      +-- baz.rego
+      |
+      +-- manifest.yaml
 
 The JSON file 'foo/bar/data.json' would be loaded and rooted under
 'data.foo.bar' and the 'foo/baz.rego' would be loaded and rooted under the
@@ -201,10 +201,10 @@ Output Formats
 
 Set the output format with the --format flag.
 
-	--format=json      : output raw query results as JSON
-	--format=values    : output line separated JSON arrays containing expression values
-	--format=bindings  : output line separated JSON objects containing variable bindings
-	--format=pretty    : output query results in a human-readable format
+    --format=json      : output raw query results as JSON
+    --format=values    : output line separated JSON arrays containing expression values
+    --format=bindings  : output line separated JSON objects containing variable bindings
+    --format=pretty    : output query results in a human-readable format
 
 Schema
 ------

--- a/cmd/eval.go
+++ b/cmd/eval.go
@@ -488,7 +488,7 @@ func setupEval(args []string, params evalCommandParams) (*evalContext, error) {
 	}
 	regoArgs = append(regoArgs,
 		rego.Schemas(schemaSet),
-		rego.FetchRemoteSchemas(params.schema.fetchRemote))
+		rego.FetchRemoteSchemas(!params.schema.dontFetchRemote))
 
 	var tracer *topdown.BufferTracer
 

--- a/cmd/eval_test.go
+++ b/cmd/eval_test.go
@@ -412,7 +412,7 @@ func TestEvalWithSchemaFileWithRemoteRef(t *testing.T) {
 		test.WithTempFS(files, func(path string) {
 			params := newEvalCommandParams()
 			params.inputPath = filepath.Join(path, "input.json")
-			params.schema = &schemaFlags{path: filepath.Join(path, "schema.json"), fetchRemote: false}
+			params.schema = &schemaFlags{path: filepath.Join(path, "schema.json"), dontFetchRemote: true}
 			_ = params.dataPaths.Set(filepath.Join(path, "p.rego"))
 
 			var buf bytes.Buffer
@@ -437,7 +437,7 @@ func TestEvalWithSchemaFileWithRemoteRef(t *testing.T) {
 		test.WithTempFS(files, func(path string) {
 			params := newEvalCommandParams()
 			params.inputPath = filepath.Join(path, "input.json")
-			params.schema = &schemaFlags{path: filepath.Join(path, "schema.json"), fetchRemote: true}
+			params.schema = &schemaFlags{path: filepath.Join(path, "schema.json"), dontFetchRemote: false}
 			_ = params.dataPaths.Set(filepath.Join(path, "p.rego"))
 
 			var buf bytes.Buffer

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -135,13 +135,11 @@ func addUnknownsFlag(fs *pflag.FlagSet, unknowns *[]string, value []string) {
 }
 
 type schemaFlags struct {
-	path            string
-	dontFetchRemote bool
+	path string
 }
 
 func addSchemaFlags(fs *pflag.FlagSet, schema *schemaFlags) {
 	fs.StringVarP(&schema.path, "schema", "s", "", "set schema file path or directory path")
-	fs.BoolVar(&schema.dontFetchRemote, "disable-remote-schemas", false, "disable fetching remote schemas when referenced")
 }
 
 func addTargetFlag(fs *pflag.FlagSet, target *util.EnumFlag) {

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -135,13 +135,13 @@ func addUnknownsFlag(fs *pflag.FlagSet, unknowns *[]string, value []string) {
 }
 
 type schemaFlags struct {
-	path        string
-	fetchRemote bool
+	path            string
+	dontFetchRemote bool
 }
 
 func addSchemaFlags(fs *pflag.FlagSet, schema *schemaFlags) {
 	fs.StringVarP(&schema.path, "schema", "s", "", "set schema file path or directory path")
-	fs.BoolVar(&schema.fetchRemote, "fetch-remote-schemas", false, "fetch remote schemas when referenced")
+	fs.BoolVar(&schema.dontFetchRemote, "disable-remote-schemas", false, "disable fetching remote schemas when referenced")
 }
 
 func addTargetFlag(fs *pflag.FlagSet, target *util.EnumFlag) {

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -134,8 +134,14 @@ func addUnknownsFlag(fs *pflag.FlagSet, unknowns *[]string, value []string) {
 	fs.StringArrayVarP(unknowns, "unknowns", "u", value, "set paths to treat as unknown during partial evaluation")
 }
 
-func addSchemaFlag(fs *pflag.FlagSet, schemaPath *string) {
-	fs.StringVarP(schemaPath, "schema", "s", "", "set schema file path or directory path")
+type schemaFlags struct {
+	path        string
+	fetchRemote bool
+}
+
+func addSchemaFlags(fs *pflag.FlagSet, schema *schemaFlags) {
+	fs.StringVarP(&schema.path, "schema", "s", "", "set schema file path or directory path")
+	fs.BoolVar(&schema.fetchRemote, "fetch-remote-schemas", false, "fetch remote schemas when referenced")
 }
 
 func addTargetFlag(fs *pflag.FlagSet, target *util.EnumFlag) {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -67,11 +67,11 @@ func init() {
 
 To run the interactive shell:
 
-	$ opa run
+    $ opa run
 
 To run the server:
 
-	$ opa run -s
+    $ opa run -s
 
 The 'run' command starts an instance of the OPA runtime. The OPA runtime can be
 started as an interactive shell or a server.
@@ -91,23 +91,23 @@ files.
 When loading from directories, only files with known extensions are considered.
 The current set of file extensions that OPA will consider are:
 
-	.json          # JSON data
-	.yaml or .yml  # YAML data
-	.rego          # Rego file
+    .json          # JSON data
+    .yaml or .yml  # YAML data
+    .rego          # Rego file
 
 Non-bundle data file and directory paths can be prefixed with the desired
 destination in the data document with the following syntax:
 
-	<dotted-path>:<file-path>
+    <dotted-path>:<file-path>
 
 To set a data file as the input document in the interactive shell use the
 "repl.input" path prefix with the input file:
 
-	repl.input:<file-path>
+    repl.input:<file-path>
 
 Example:
 
-	opa run repl.input:input.json
+    $ opa run repl.input:input.json
 
 Which will load the "input.json" file at path "data.repl.input".
 
@@ -116,7 +116,7 @@ Use the "help input" command in the interactive shell to see more options.
 
 File paths can be specified as URLs to resolve ambiguity in paths containing colons:
 
-	$ opa run file:///c:/path/to/data.json
+    $ opa run file:///c:/path/to/data.json
 
 The 'run' command can also verify the signature of a signed bundle.
 A signed bundle is a normal OPA bundle that includes a file
@@ -140,7 +140,7 @@ bundle signature verification.
 
 Example:
 
-	$ opa run --verification-key secret --signing-alg HS256 --bundle bundle.tar.gz
+    $ opa run --verification-key secret --signing-alg HS256 --bundle bundle.tar.gz
 
 The 'run' command will read the bundle "bundle.tar.gz", check the
 ".signatures.json" file and perform verification using the provided key.

--- a/docs/content/schemas.md
+++ b/docs/content/schemas.md
@@ -621,8 +621,8 @@ It is valid for JSON schemas to reference other JSON schemas via URLs, like this
 }
 ```
 
-OPA's type checker will **not** fetch remote references by default.
-To opt-in to this behaviour, pass `--fetch-remote-schemas` to your OPA command.
+OPA's type checker will fetch these remote references by default.
+To disable this, pass `--disable-remote-schemas` to your OPA command.
 
 ## Limitations
 

--- a/docs/content/schemas.md
+++ b/docs/content/schemas.md
@@ -622,7 +622,34 @@ It is valid for JSON schemas to reference other JSON schemas via URLs, like this
 ```
 
 OPA's type checker will fetch these remote references by default.
-To disable this, pass `--disable-remote-schemas` to your OPA command.
+To control the remote hosts schemas will be fetched from, pass a capabilities
+file to your `opa eval` or `opa check` call.
+
+Starting from the capabilities.json of your OPA version (which can be found [in the
+repository](https://github.com/open-policy-agent/opa/tree/main/capabilities)), add
+an `allow_net` key to it: its values are the IP addresses or host names that OPA is
+supposed to connect to for retrieving remote schemas.
+
+```json
+{
+  "builtins": [ ... ],
+  "allow_net": [ "kubernetesjsonschema.dev" ]
+}
+```
+
+#### Note
+
+- To forbid all network access in schema checking, set `allow_net` to `[]`
+- Host names are checked against the list as-is, so adding `127.0.0.1` to `allow_net`,
+  and referencing a schema from `http://localhost/` will _fail_.
+- Metaschemas for different JSON Schema draft versions are not subject to this
+  constraint, as they are already provided by OPA's schema checker without requiring
+  network access. These are:
+
+  - `http://json-schema.org/draft-04/schema`
+  - `http://json-schema.org/draft-06/schema`
+  - `http://json-schema.org/draft-07/schema`
+
 
 ## Limitations
 

--- a/docs/content/schemas.md
+++ b/docs/content/schemas.md
@@ -605,6 +605,25 @@ Once this is fixed, the second typo is highlighted, informing the user that `ver
 ```
 Because the properties `kind`, `version`, and `accessNum` are all under the `allOf` keyword, the resulting schema that the given data must be validated against will contain the types contained in these properties children (string and integer). 
 
+### Remote references in JSON schemas
+
+It is valid for JSON schemas to reference other JSON schemas via URLs, like this:
+```json
+{
+  "description": "Pod is a collection of containers that can run on a host.",
+	"type": "object",
+	"properties": {
+    "metadata": {
+      "$ref": "https://kubernetesjsonschema.dev/v1.14.0/_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+      "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+	  }
+	}
+}
+```
+
+OPA's type checker will **not** fetch remote references by default.
+To opt-in to this behaviour, pass `--fetch-remote-schemas` to your OPA command.
+
 ## Limitations
 
 Currently this feature admits schemas written in JSON Schema but does not support every feature available in this format.

--- a/internal/gojsonschema/jsonLoader.go
+++ b/internal/gojsonschema/jsonLoader.go
@@ -43,14 +43,29 @@ import (
 	"github.com/xeipuuv/gojsonreference"
 )
 
-// NOTE(sr): We need to control whether remote references are resolved
-// via HTTP requests. It's quite cumbersome to add extra parameters to
-// all calls and interfaces involved, so we're using a global variable
-// insead:
-var fetchRemoteRefs bool
+// NOTE(sr): We need to control from which hosts remote references are
+// allowed to be resolved via HTTP requests. It's quite cumbersome to
+// add extra parameters to all calls and interfaces involved, so we're
+// using a global variable instead:
+var allowNet map[string]struct{}
 
-func SetFetchRemoteRefs(yes bool) {
-	fetchRemoteRefs = yes
+func SetAllowNet(hosts []string) {
+	if hosts == nil {
+		allowNet = nil // resetting the global
+		return
+	}
+	allowNet = make(map[string]struct{}, len(hosts))
+	for _, host := range hosts {
+		allowNet[host] = struct{}{}
+	}
+}
+
+func isAllowed(ref *url.URL) bool {
+	if allowNet == nil {
+		return true
+	}
+	_, ok := allowNet[ref.Hostname()]
+	return ok
 }
 
 var osFS = osFileSystem(os.Open)
@@ -171,7 +186,16 @@ func (l *jsonReferenceLoader) LoadJSON() (interface{}, error) {
 		return l.loadFromFile(filename)
 	}
 
-	if fetchRemoteRefs {
+	// NOTE(sr): hardcoded metaschema references are not subject to allow_net
+	// checking; their contents are hardcoded in the library!
+	//
+	// returned cached versions for metaschemas for drafts 4, 6 and 7
+	// for performance and allow for easier offline use
+	if metaSchema := drafts.GetMetaSchema(refToURL.String()); metaSchema != "" {
+		return decodeJSONUsingNumber(strings.NewReader(metaSchema))
+	}
+
+	if isAllowed(refToURL.GetUrl()) {
 		return l.loadFromHTTP(refToURL.String())
 	}
 
@@ -179,12 +203,6 @@ func (l *jsonReferenceLoader) LoadJSON() (interface{}, error) {
 }
 
 func (l *jsonReferenceLoader) loadFromHTTP(address string) (interface{}, error) {
-
-	// returned cached versions for metaschemas for drafts 4, 6 and 7
-	// for performance and allow for easier offline use
-	if metaSchema := drafts.GetMetaSchema(address); metaSchema != "" {
-		return decodeJSONUsingNumber(strings.NewReader(metaSchema))
-	}
 
 	resp, err := http.Get(address)
 	if err != nil {

--- a/internal/gojsonschema/jsonschema_test.go
+++ b/internal/gojsonschema/jsonschema_test.go
@@ -134,7 +134,7 @@ func TestSuite(t *testing.T) {
 		}
 	}()
 
-	SetFetchRemoteRefs(true)
+	SetAllowNet(nil)
 
 	err = filepath.Walk(wd, func(path string, fileInfo os.FileInfo, err error) error {
 		if fileInfo.IsDir() && path != wd && !testDirectories.MatchString(fileInfo.Name()) {

--- a/internal/gojsonschema/jsonschema_test.go
+++ b/internal/gojsonschema/jsonschema_test.go
@@ -134,6 +134,8 @@ func TestSuite(t *testing.T) {
 		}
 	}()
 
+	SetFetchRemoteRefs(true)
+
 	err = filepath.Walk(wd, func(path string, fileInfo os.FileInfo, err error) error {
 		if fileInfo.IsDir() && path != wd && !testDirectories.MatchString(fileInfo.Name()) {
 			return filepath.SkipDir

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -15,14 +15,12 @@ import (
 	"strings"
 
 	"github.com/ghodss/yaml"
-	"github.com/pkg/errors"
-
-	"github.com/open-policy-agent/opa/metrics"
 
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/bundle"
 	fileurl "github.com/open-policy-agent/opa/internal/file/url"
 	"github.com/open-policy-agent/opa/internal/merge"
+	"github.com/open-policy-agent/opa/metrics"
 	"github.com/open-policy-agent/opa/storage"
 	"github.com/open-policy-agent/opa/storage/inmem"
 	"github.com/open-policy-agent/opa/util"
@@ -193,7 +191,7 @@ func (fl fileLoader) AsBundle(path string) (*bundle.Bundle, error) {
 
 	b, err := br.Read()
 	if err != nil {
-		err = errors.Wrap(err, fmt.Sprintf("bundle %s", path))
+		err = fmt.Errorf("bundle %s: %w", path, err)
 	}
 
 	return &b, err
@@ -345,9 +343,8 @@ func loadOneSchema(path string) (interface{}, error) {
 	}
 
 	var schema interface{}
-	err = util.Unmarshal(bs, &schema)
-	if err != nil {
-		return nil, errors.Wrap(err, path)
+	if err := util.Unmarshal(bs, &schema); err != nil {
+		return nil, fmt.Errorf("%s: %w", path, err)
 	}
 
 	return schema, nil
@@ -591,7 +588,7 @@ func loadKnownTypes(path string, bs []byte, m metrics.Metrics, opts ast.ParserOp
 		if strings.HasSuffix(path, ".tar.gz") {
 			r, err := loadBundleFile(path, bs, m)
 			if err != nil {
-				err = errors.Wrap(err, fmt.Sprintf("bundle %s", path))
+				err = fmt.Errorf("bundle %s: %w", path, err)
 			}
 			return r, err
 		}
@@ -646,7 +643,7 @@ func loadJSON(path string, bs []byte, m metrics.Metrics) (interface{}, error) {
 	err := decoder.Decode(&x)
 	m.Timer(metrics.RegoDataParse).Stop()
 	if err != nil {
-		return nil, errors.Wrap(err, path)
+		return nil, fmt.Errorf("%s: %w", path, err)
 	}
 	return x, nil
 }

--- a/rego/rego.go
+++ b/rego/rego.go
@@ -475,6 +475,7 @@ type Rego struct {
 	runtime                *ast.Term
 	time                   time.Time
 	seed                   io.Reader
+	capabilities           *ast.Capabilities
 	builtinDecls           map[string]*ast.Builtin
 	builtinFuncs           map[string]*topdown.Builtin
 	unsafeBuiltins         map[string]struct{}
@@ -486,7 +487,6 @@ type Rego struct {
 	strictBuiltinErrors    bool
 	resolvers              []refResolver
 	schemaSet              *ast.SchemaSet
-	fetchRemoteSchemas     bool
 	target                 string // target type (wasm, rego, etc.)
 	opa                    opa.EvalEngine
 	generateJSON           func(*ast.Term, *EvalContext) (interface{}, error)
@@ -1009,10 +1009,12 @@ func Schemas(x *ast.SchemaSet) func(r *Rego) {
 	}
 }
 
-// FetchRemoteSchemas enables that remote refs will be fetched for schemas
-func FetchRemoteSchemas(yes bool) func(r *Rego) {
+// Capabilities configures the underlying compiler's capabilities.
+// This option is ignored for module compilation if the caller supplies the
+// compiler.
+func Capabilities(c *ast.Capabilities) func(r *Rego) {
 	return func(r *Rego) {
-		r.fetchRemoteSchemas = yes
+		r.capabilities = c
 	}
 }
 
@@ -1052,7 +1054,7 @@ func New(options ...func(r *Rego)) *Rego {
 			WithBuiltins(r.builtinDecls).
 			WithDebug(r.dump).
 			WithSchemas(r.schemaSet).
-			WithFetchRemoteSchemas(r.fetchRemoteSchemas)
+			WithCapabilities(r.capabilities)
 	}
 
 	if r.store == nil {


### PR DESCRIPTION
Introducing a package-level var to gojsonschema isn't the prettiest solution,
but since we want this in an all-or-nothing way right now anyways, it does
the trick. And it's more ergonomic than adding extra parameters all over the
place.

Fixes #3746.

Also:

* move some profiling-related default params into newEvalCommandParams
* replace some errors.Wrap by fmt.Errorf in loader pkg
* remove some != nil handling where it didn't make a difference when working on the schema set
* reduces indentation in code examples in `opa eval -h` and `opa check -h` by replacing tabs by four spaces.

-----

It feels to me like the addition to capabilities is a bit dangling right now. We should perhaps tackle #3665 soon.
