### PR TITLE
storage/inmem: Move shareable code into internal package

### DIFF
--- a/storage/inmem/inmem.go
+++ b/storage/inmem/inmem.go
@@ -239,31 +239,12 @@ func (db *store) underlying(txn storage.Transaction) (*transaction, error) {
 	return underlying, nil
 }
 
-var doesNotExistMsg = "document does not exist"
 var rootMustBeObjectMsg = "root must be object"
 var rootCannotBeRemovedMsg = "root cannot be removed"
-var outOfRangeMsg = "array index out of range"
-var arrayIndexTypeMsg = "array index must be integer"
 
 func invalidPatchError(f string, a ...interface{}) *storage.Error {
 	return &storage.Error{
 		Code:    storage.InvalidPatchErr,
 		Message: fmt.Sprintf(f, a...),
-	}
-}
-
-func notFoundError(path storage.Path) *storage.Error {
-	return notFoundErrorHint(path, doesNotExistMsg)
-}
-
-func notFoundErrorHint(path storage.Path, hint string) *storage.Error {
-	return notFoundErrorf("%v: %v", path.String(), hint)
-}
-
-func notFoundErrorf(f string, a ...interface{}) *storage.Error {
-	msg := fmt.Sprintf(f, a...)
-	return &storage.Error{
-		Code:    storage.NotFoundErr,
-		Message: msg,
 	}
 }

--- a/storage/internal/errors/errors.go
+++ b/storage/internal/errors/errors.go
@@ -1,0 +1,32 @@
+// Copyright 2021 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+// Package errors contains reusable error-related code for the storage layer.
+package errors
+
+import (
+	"fmt"
+
+	"github.com/open-policy-agent/opa/storage"
+)
+
+const ArrayIndexTypeMsg = "array index must be integer"
+const DoesNotExistMsg = "document does not exist"
+const OutOfRangeMsg = "array index out of range"
+
+func NewNotFoundError(path storage.Path) *storage.Error {
+	return NewNotFoundErrorWithHint(path, DoesNotExistMsg)
+}
+
+func NewNotFoundErrorWithHint(path storage.Path, hint string) *storage.Error {
+	return NewNotFoundErrorf("%v: %v", path.String(), hint)
+}
+
+func NewNotFoundErrorf(f string, a ...interface{}) *storage.Error {
+	msg := fmt.Sprintf(f, a...)
+	return &storage.Error{
+		Code:    storage.NotFoundErr,
+		Message: msg,
+	}
+}

--- a/storage/internal/ptr/ptr.go
+++ b/storage/internal/ptr/ptr.go
@@ -1,0 +1,48 @@
+// Copyright 2021 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+// Package ptr provides utilities for pointer operations using storage layer paths.
+package ptr
+
+import (
+	"strconv"
+
+	"github.com/open-policy-agent/opa/storage"
+	"github.com/open-policy-agent/opa/storage/internal/errors"
+)
+
+func Ptr(data interface{}, path storage.Path) (interface{}, error) {
+	node := data
+	for i := range path {
+		key := path[i]
+		switch curr := node.(type) {
+		case map[string]interface{}:
+			var ok bool
+			if node, ok = curr[key]; !ok {
+				return nil, errors.NewNotFoundError(path)
+			}
+		case []interface{}:
+			pos, err := ValidateArrayIndex(curr, key, path)
+			if err != nil {
+				return nil, err
+			}
+			node = curr[pos]
+		default:
+			return nil, errors.NewNotFoundError(path)
+		}
+	}
+
+	return node, nil
+}
+
+func ValidateArrayIndex(arr []interface{}, s string, path storage.Path) (int, error) {
+	idx, err := strconv.Atoi(s)
+	if err != nil {
+		return 0, errors.NewNotFoundErrorWithHint(path, errors.ArrayIndexTypeMsg)
+	}
+	if idx < 0 || idx >= len(arr) {
+		return 0, errors.NewNotFoundErrorWithHint(path, errors.OutOfRangeMsg)
+	}
+	return idx, nil
+}


### PR DESCRIPTION
This commit just moves some shareable error helpers and the ptr()
function into an internal package so that we can reuse it with the
disk-based store implementation. This commit doesn't change any
existing functionality and no new public APIs are exposed.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/main/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/main/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
