### PR TITLE
doc/envoy-standalone: added cleanup instruction

### DIFF
--- a/docs/content/envoy-tutorial-standalone-envoy.md
+++ b/docs/content/envoy-tutorial-standalone-envoy.md
@@ -400,6 +400,14 @@ Check that `Bob` **cannot** create an employee with the same firstname as himsel
 curl -i  -H "Authorization: Bearer $BOB_TOKEN" -d '{"firstname":"Bob", "lastname":"Rego"}' -H "Content-Type: application/json" -X POST http://$SERVICE_URL/people
 ```
 
+To remove the kubernetes resources created during this tutorial please use the following commands.
+```bash
+kubectl delete service example-app-service
+kubectl delete deployment example-app
+kubectl delete secret opa-policy
+kubectl delete configmap proxy-config
+```
+
 ## Wrap Up
 
 Congratulations for finishing the tutorial !


### PR DESCRIPTION
Added cleanup instructions to return Kubernetes cluster to the state it was before doing the tutorial

Signed-off-by: Anthony Barbieri <anthonyabarbieri@gmail.com>
