### PR TITLE
ast: improve String() performance for arrays, sets, objects

### DIFF
--- a/ast/term.go
+++ b/ast/term.go
@@ -544,7 +544,7 @@ func (null Null) Hash() int {
 }
 
 // IsGround always returns true.
-func (null Null) IsGround() bool {
+func (Null) IsGround() bool {
 	return true
 }
 
@@ -593,7 +593,7 @@ func (bol Boolean) Hash() int {
 }
 
 // IsGround always returns true.
-func (bol Boolean) IsGround() bool {
+func (Boolean) IsGround() bool {
 	return true
 }
 
@@ -685,7 +685,7 @@ func (num Number) Float64() (float64, bool) {
 }
 
 // IsGround always returns true.
-func (num Number) IsGround() bool {
+func (Number) IsGround() bool {
 	return true
 }
 
@@ -747,7 +747,7 @@ func (str String) Find(path Ref) (Value, error) {
 }
 
 // IsGround always returns true.
-func (str String) IsGround() bool {
+func (String) IsGround() bool {
 	return true
 }
 
@@ -801,7 +801,7 @@ func (v Var) Hash() int {
 }
 
 // IsGround always returns false.
-func (v Var) IsGround() bool {
+func (Var) IsGround() bool {
 	return false
 }
 
@@ -1177,11 +1177,16 @@ func (arr *Array) MarshalJSON() ([]byte, error) {
 }
 
 func (arr *Array) String() string {
-	var buf []string
-	for _, e := range arr.elems {
-		buf = append(buf, e.String())
+	var b strings.Builder
+	b.WriteRune('[')
+	for i, e := range arr.elems {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString(e.String())
 	}
-	return "[" + strings.Join(buf, ", ") + "]"
+	b.WriteRune(']')
+	return b.String()
 }
 
 // Len returns the number of elements in the array.
@@ -1336,12 +1341,19 @@ func (s *set) String() string {
 	if s.Len() == 0 {
 		return "set()"
 	}
-	buf := []string{}
+	var b strings.Builder
+	b.WriteRune('{')
 	sorted := s.Sorted()
+	first := true
 	sorted.Foreach(func(x *Term) {
-		buf = append(buf, fmt.Sprint(x))
+		if !first {
+			b.WriteString(", ")
+		}
+		first = false
+		b.WriteString(x.Value.String())
 	})
-	return "{" + strings.Join(buf, ", ") + "}"
+	b.WriteRune('}')
+	return b.String()
 }
 
 // Compare compares s to other, return <0, 0, or >0 if it is less than, equal to,
@@ -2040,12 +2052,20 @@ func (obj object) Len() int {
 }
 
 func (obj object) String() string {
-	var buf []string
+	var b strings.Builder
+	b.WriteRune('{')
+
 	sorted := objectElemSliceSorted(obj.keys)
-	for _, elem := range sorted {
-		buf = append(buf, fmt.Sprintf("%s: %s", elem.key, elem.value))
+	for i, elem := range sorted {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString(elem.key.String())
+		b.WriteString(": ")
+		b.WriteString(elem.value.String())
 	}
-	return "{" + strings.Join(buf, ", ") + "}"
+	b.WriteRune('}')
+	return b.String()
 }
 
 func (obj *object) get(k *Term) *objectElem {

--- a/ast/term_bench_test.go
+++ b/ast/term_bench_test.go
@@ -4,6 +4,7 @@
 package ast
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
@@ -102,6 +103,107 @@ func BenchmarkTermHashing(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				_ = s.Hash()
 			}
+		})
+	}
+}
+
+var str string
+var bs []byte
+
+// BenchmarkObjectString generates several objects of different sizes, and
+// marshals them to JSON via two ways:
+//   map[string]int -> ast.Value -> .String()
+// and
+//   map[string]int -> json.Marshal()
+//
+// The difference between these two is relevant for feeding input into the
+// wasm vm: when calling rego.New(...) with rego.Target("wasm"), it's up to
+// the caller to provide the input in parsed form (ast.Value), or
+// raw (interface{}).
+func BenchmarkObjectString(b *testing.B) {
+	var err error
+	sizes := []int{5, 50, 500, 5000}
+
+	for _, n := range sizes {
+		b.Run(fmt.Sprint(n), func(b *testing.B) {
+
+			obj := map[string]int{}
+			for i := 0; i < n; i++ {
+				obj[fmt.Sprint(i)] = i
+			}
+			val := MustInterfaceToValue(obj)
+
+			b.Run("String()", func(b *testing.B) {
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					str = val.String()
+				}
+			})
+			b.Run("json.Marshal", func(b *testing.B) {
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					bs, err = json.Marshal(obj)
+					if err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		})
+	}
+}
+
+// BenchmarkArrayString compares the performance characteristics of
+// (ast.Value).String() with the stdlib-native json.Marshal. See
+// BenchmarkObjectString above for details.
+func BenchmarkArrayString(b *testing.B) {
+	var err error
+	sizes := []int{5, 50, 500, 5000}
+
+	for _, n := range sizes {
+		b.Run(fmt.Sprint(n), func(b *testing.B) {
+
+			obj := make([]string, n)
+			for i := 0; i < n; i++ {
+				obj[i] = fmt.Sprint(i)
+			}
+			val := MustInterfaceToValue(obj)
+
+			b.Run("String()", func(b *testing.B) {
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					str = val.String()
+				}
+			})
+			b.Run("json.Marshal", func(b *testing.B) {
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					bs, err = json.Marshal(obj)
+					if err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		})
+	}
+}
+
+func BenchmarkSetString(b *testing.B) {
+	sizes := []int{5, 50, 500, 5000}
+
+	for _, n := range sizes {
+		b.Run(fmt.Sprint(n), func(b *testing.B) {
+
+			val := NewSet()
+			for i := 0; i < n; i++ {
+				val.Add(IntNumberTerm(i))
+			}
+
+			b.Run("String()", func(b *testing.B) {
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					str = val.String()
+				}
+			})
 		})
 	}
 }


### PR DESCRIPTION
Before had been creating slices of strings and passed them to
strings.Join. Now, we're directly making use of a strings.Builder.

The added benchmarks include comparisons to the stdlib json.Marshal
method. Only looking at the String() method's performance, we find
this benchstat output:

```
name                               old time/op    new time/op    delta
ObjectString/5/String()-16           2.47µs ± 3%    0.82µs ± 3%  -66.64%  (p=0.008 n=5+5)
ObjectString/50/String()-16          26.1µs ± 3%    10.4µs ± 3%  -60.37%  (p=0.008 n=5+5)
ObjectString/500/String()-16          307µs ± 4%     173µs ± 4%  -43.61%  (p=0.008 n=5+5)
ObjectString/5000/String()-16        3.81ms ± 4%    2.33ms ± 1%  -38.84%  (p=0.008 n=5+5)
ArrayString/5/String()-16             801ns ± 7%     456ns ± 3%  -43.09%  (p=0.008 n=5+5)
ArrayString/50/String()-16           5.28µs ± 1%    3.94µs ± 4%  -25.32%  (p=0.008 n=5+5)
ArrayString/500/String()-16          53.9µs ± 2%    45.9µs ± 2%  -14.72%  (p=0.016 n=5+4)
ArrayString/5000/String()-16          555µs ± 1%     429µs ± 3%  -22.72%  (p=0.016 n=4+5)
SetString/5/String()-16              1.69µs ± 4%    0.44µs ± 3%  -73.71%  (p=0.008 n=5+5)
SetString/50/String()-16             17.3µs ± 4%     7.2µs ± 3%  -58.27%  (p=0.008 n=5+5)
SetString/500/String()-16             244µs ± 7%     154µs ± 7%  -37.08%  (p=0.008 n=5+5)
SetString/5000/String()-16           3.32ms ± 9%    2.21ms ± 2%  -33.50%  (p=0.008 n=5+5)

name                               old alloc/op   new alloc/op   delta
ObjectString/5/String()-16             528B ± 0%      280B ± 0%  -46.97%  (p=0.008 n=5+5)
ObjectString/50/String()-16          4.99kB ± 0%    2.26kB ± 0%  -54.60%  (p=0.008 n=5+5)
ObjectString/500/String()-16         48.8kB ± 0%    41.8kB ± 0%  -14.42%  (p=0.029 n=4+4)
ObjectString/5000/String()-16         700kB ± 0%     409kB ± 0%  -41.52%  (p=0.008 n=5+5)
ArrayString/5/String()-16              376B ± 0%      144B ± 0%  -61.70%  (p=0.008 n=5+5)
ArrayString/50/String()-16           3.44kB ± 0%    1.82kB ± 0%  -46.98%  (p=0.008 n=5+5)
ArrayString/500/String()-16          34.5kB ± 0%    25.8kB ± 0%  -25.20%  (p=0.008 n=5+5)
ArrayString/5000/String()-16          520kB ± 0%     241kB ± 0%  -53.69%  (p=0.029 n=4+4)
SetString/5/String()-16                376B ± 0%      128B ± 0%  -65.96%  (p=0.008 n=5+5)
SetString/50/String()-16             2.97kB ± 0%    0.98kB ± 0%  -67.13%  (p=0.008 n=5+5)
SetString/500/String()-16            27.4kB ± 0%    14.6kB ± 0%  -46.52%  (p=0.008 n=5+5)
SetString/5000/String()-16            477kB ± 0%     195kB ± 0%  -59.18%  (p=0.016 n=5+4)

name                               old allocs/op  new allocs/op  delta
ObjectString/5/String()-16             28.0 ± 0%      21.0 ± 0%  -25.00%  (p=0.008 n=5+5)
ObjectString/50/String()-16             211 ± 0%       159 ± 0%  -24.64%  (p=0.008 n=5+5)
ObjectString/500/String()-16          2.01k ± 0%     1.52k ± 0%  -24.68%  (p=0.008 n=5+5)
ObjectString/5000/String()-16         16.0k ± 0%     11.0k ± 0%     ~     (p=0.079 n=4+5)
ArrayString/5/String()-16              21.0 ± 0%      18.0 ± 0%  -14.29%  (p=0.008 n=5+5)
ArrayString/50/String()-16              159 ± 0%       157 ± 0%   -1.26%  (p=0.008 n=5+5)
ArrayString/500/String()-16           1.51k ± 0%     1.51k ± 0%   +0.07%  (p=0.008 n=5+5)
ArrayString/5000/String()-16          11.0k ± 0%     11.0k ± 0%   +0.02%  (p=0.008 n=5+5)
SetString/5/String()-16                9.00 ± 0%      5.00 ± 0%  -44.44%  (p=0.008 n=5+5)
SetString/50/String()-16               52.0 ± 0%       9.0 ± 0%  -82.69%  (p=0.008 n=5+5)
SetString/500/String()-16               505 ± 0%        15 ± 0%  -97.03%  (p=0.008 n=5+5)
SetString/5000/String()-16            5.01k ± 0%     0.02k ± 0%  -99.52%  (p=0.008 n=5+5)
```