### PR TITLE
wasm: deal with importing memory in the compiler

### DIFF
--- a/internal/wasm/encoding/writer.go
+++ b/internal/wasm/encoding/writer.go
@@ -50,6 +50,10 @@ func WriteModule(w io.Writer, module *module.Module) error {
 		return err
 	}
 
+	if err := writeMemorySection(w, module.Memory); err != nil {
+		return err
+	}
+
 	if err := writeGlobalSection(w, module.Global); err != nil {
 		return err
 	}
@@ -264,7 +268,31 @@ func writeTableSection(w io.Writer, s module.TableSection) error {
 	}
 
 	return writeRawSection(w, &buf)
+}
 
+func writeMemorySection(w io.Writer, s module.MemorySection) error {
+
+	if len(s.Memories) == 0 {
+		return nil
+	}
+
+	if err := writeByte(w, constant.MemorySectionID); err != nil {
+		return err
+	}
+
+	var buf bytes.Buffer
+
+	if err := leb128.WriteVarUint32(&buf, uint32(len(s.Memories))); err != nil {
+		return err
+	}
+
+	for _, mem := range s.Memories {
+		if err := writeLimits(&buf, mem.Lim); err != nil {
+			return err
+		}
+	}
+
+	return writeRawSection(w, &buf)
 }
 
 func writeExportSection(w io.Writer, s module.ExportSection) error {

--- a/internal/wasm/module/module.go
+++ b/internal/wasm/module/module.go
@@ -21,6 +21,7 @@ type (
 		Import   ImportSection
 		Function FunctionSection
 		Table    TableSection
+		Memory   MemorySection
 		Element  ElementSection
 		Global   GlobalSection
 		Export   ExportSection
@@ -53,6 +54,11 @@ type (
 	// TableSection represents a WASM table section.
 	TableSection struct {
 		Tables []Table
+	}
+
+	// MemorySection represents a Wasm memory section.
+	MemorySection struct {
+		Memories []Memory
 	}
 
 	// ElementSection represents a WASM element section.
@@ -173,6 +179,11 @@ type (
 	Table struct {
 		Type types.ElementType
 		Lim  Limit
+	}
+
+	// Memory represents a Wasm memory statement.
+	Memory struct {
+		Lim Limit
 	}
 
 	// Global represents a WASM global statement.

--- a/internal/wasm/sdk/internal/wasm/pool.go
+++ b/internal/wasm/sdk/internal/wasm/pool.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bytecodealliance/wasmtime-go"
 
 	"github.com/open-policy-agent/opa/internal/wasm/sdk/opa/errors"
+	"github.com/open-policy-agent/opa/internal/wasm/util"
 	"github.com/open-policy-agent/opa/metrics"
 )
 
@@ -180,7 +181,7 @@ func (p *Pool) SetPolicyData(ctx context.Context, policy []byte, data []byte) er
 
 		if err == nil {
 			parsedDataAddr, parsedData := vm.cloneDataSegment()
-			p.memoryMinPages = Pages(uint32(vm.memory.DataSize(vm.store)))
+			p.memoryMinPages = util.Pages(uint32(vm.memory.DataSize(vm.store)))
 			p.vms = append(p.vms, vm)
 			p.acquired = append(p.acquired, false)
 			p.initialized = true
@@ -288,7 +289,7 @@ func (p *Pool) updateVMs(update func(vm *VM, opts vmOpts) error) error {
 				activated = true
 				policy = vm.policy
 				parsedDataAddr, parsedData = vm.cloneDataSegment()
-				seedMemorySize = Pages(uint32(vm.memory.DataSize(vm.store)))
+				seedMemorySize = util.Pages(uint32(vm.memory.DataSize(vm.store)))
 				p.activate(policy, parsedData, parsedDataAddr, seedMemorySize)
 			}
 

--- a/internal/wasm/sdk/opa/config.go
+++ b/internal/wasm/sdk/opa/config.go
@@ -8,8 +8,8 @@ import (
 	"encoding/json"
 	"io/ioutil"
 
-	"github.com/open-policy-agent/opa/internal/wasm/sdk/internal/wasm"
 	"github.com/open-policy-agent/opa/internal/wasm/sdk/opa/errors"
+	"github.com/open-policy-agent/opa/internal/wasm/util"
 )
 
 // WithPolicyFile configures a policy file to load.
@@ -63,7 +63,7 @@ func (o *OPA) WithDataJSON(data interface{}) *OPA {
 // WithMemoryLimits configures the memory limits (in bytes) for a single policy
 // evaluation.
 func (o *OPA) WithMemoryLimits(min, max uint32) *OPA {
-	if min < 2*wasm.PageSize {
+	if min < 2*util.PageSize {
 		o.configErr = errors.New(errors.InvalidConfigErr, "too low minimum memory limit")
 		return o
 	}
@@ -77,7 +77,7 @@ func (o *OPA) WithMemoryLimits(min, max uint32) *OPA {
 		return o
 	}
 
-	o.memoryMinPages, o.memoryMaxPages = wasm.Pages(min), wasm.Pages(max)
+	o.memoryMinPages, o.memoryMaxPages = util.Pages(min), util.Pages(max)
 	return o
 }
 

--- a/internal/wasm/sdk/opa/opa_bench_test.go
+++ b/internal/wasm/sdk/opa/opa_bench_test.go
@@ -11,8 +11,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/open-policy-agent/opa/internal/wasm/sdk/internal/wasm"
 	"github.com/open-policy-agent/opa/internal/wasm/sdk/opa"
+	"github.com/open-policy-agent/opa/internal/wasm/util"
 	"github.com/open-policy-agent/opa/rego"
 	"github.com/open-policy-agent/opa/util/test"
 )
@@ -96,7 +96,7 @@ func benchmarkIteration(b *testing.B, module string) {
 
 	instance, err := opa.New().
 		WithPolicyBytes(policy).
-		WithMemoryLimits(2*wasm.PageSize, 47*wasm.PageSize).
+		WithMemoryLimits(2*util.PageSize, 47*util.PageSize).
 		WithPoolSize(1).
 		Init()
 	if err != nil {
@@ -138,7 +138,7 @@ func BenchmarkWASMLargeJSON(b *testing.B) {
 			instance, err := opa.New().
 				WithPolicyBytes(policy).
 				WithDataJSON(data).
-				WithMemoryLimits(200*wasm.PageSize, 600*wasm.PageSize). // This is rather much
+				WithMemoryLimits(200*util.PageSize, 600*util.PageSize). // This is rather much
 				WithPoolSize(1).
 				Init()
 			if err != nil {
@@ -186,7 +186,7 @@ func runVirtualDocsBenchmark(b *testing.B, numTotalRules, numHitRules int) {
 
 	instance, err := opa.New().
 		WithPolicyBytes(policy).
-		WithMemoryLimits(8*wasm.PageSize, 8*wasm.PageSize).
+		WithMemoryLimits(8*util.PageSize, 8*util.PageSize).
 		WithPoolSize(1).
 		Init()
 	if err != nil {

--- a/internal/wasm/util/util.go
+++ b/internal/wasm/util/util.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by an Apache2
 // license that can be found in the LICENSE file.
 
-package wasm
+package util
 
 // PageSize represents the WASM page size in bytes.
 const PageSize = 65535

--- a/wasm/Makefile
+++ b/wasm/Makefile
@@ -148,8 +148,8 @@ $(TEST_CPP_OBJS): $(WASM_OBJ_DIR)/tests/%.wasm: tests/%.cc
 $(WASM_OBJ_DIR)/opa.wasm: $(OBJS) $(CPP_OBJS) $(LIB_OBJS) $(LIB_MPDEC_OBJS) $(LIB_CPP_OBJS) $(RE2_RE2_OBJS) $(RE2_UTIL_OBJS)
 	wasm-ld-12 \
 			--allow-undefined-file=src/undefined.symbols \
-			--import-memory \
 			--no-entry \
+			--export=__heap_base \
 			--stack-first \
 			-o $@ $^
 	@wasm2wat $(WASM_OBJ_DIR)/opa.wasm > $(WASM_OBJ_DIR)/opa.wast
@@ -158,7 +158,6 @@ $(WASM_OBJ_DIR)/opa-test.wasm: $(OBJS) $(CPP_OBJS) $(LIB_OBJS) $(LIB_MPDEC_OBJS)
 	@cat src/undefined.symbols tests/undefined.symbols > _obj/undefined.symbols
 	@wasm-ld-12 \
 			--allow-undefined-file=_obj/undefined.symbols \
-			--import-memory \
 			--no-entry \
 			--stack-first \
 			-o $@ $^

--- a/wasm/test.js
+++ b/wasm/test.js
@@ -1,9 +1,8 @@
 const { readFileSync } = require('fs');
 
 function stringDecoder(mem) {
-    return function (addr) {
+    return function(addr) {
         const i8 = new Int8Array(mem.buffer);
-        const start = addr;
         var s = "";
         while (i8[addr] != 0) {
             s += String.fromCharCode(i8[addr++]);
@@ -49,21 +48,20 @@ function report(passed, error, msg) {
 
 async function test(executable) {
 
-    const mem = new WebAssembly.Memory({ initial: 3 });
-    const addr2string = stringDecoder(mem);
-
+    const memory = new WebAssembly.Memory({ initial: 3 });
+    let addr2string;
     let cache = {};
     let failedOrErrored = 0;
     let seenFuncs = {};
 
     const module = await WebAssembly.instantiate(readFileSync(executable), {
         env: {
-            memory: mem,
-            opa_builtin0: (_1, _2) => { return 0; },
-            opa_builtin1: (_1, _2, _3, _4) => { return 0; },
-            opa_builtin2: (_1, _2, _3, _4) => { return 0; },
-            opa_builtin3: (_1, _2, _3, _4, _5) => { return 0; },
-            opa_builtin4: (_1, _2, _3, _4, _5, _6) => { return 0; },
+            memory,
+            opa_builtin0: () => 0,
+            opa_builtin1: () => 0,
+            opa_builtin2: () => 0,
+            opa_builtin3: () => 0,
+            opa_builtin4: () => 0,
             opa_println: (msg) => {
                 console.log(addr2string(msg));
             },
@@ -89,6 +87,8 @@ async function test(executable) {
             },
         }
     });
+
+    addr2string = stringDecoder(module.instance.exports.memory);
 
     for (let key in module.instance.exports) {
         if (key.startsWith("test_")) {


### PR DESCRIPTION
This sets the stage for eventually allowing OPA wasm modules that do NOT
import memory.

With this change, we add the necessary segments to the wasm module that
declare that memory is to be imported, in the wasm compiler. As far as
LLVM and our C base is concerned, the memory is NOT imported.

The test runners have been adapted, `make wasm-lib-test` works without
having imported memory now. `make wasm-rego-test` can deal with both: it
will provide memory in its `imports` for instantiation, but if the wasm
module happens to not want that import, it'll be ignored. The memory used
in the other host methods is the exported one. (Whether that is exported
or re-exported imported doesn't make a difference.)

Some first steps have been included to make OPA's Wasm SDK work without
imported memory. There are a few loose ends around enforcing memory
limits, to be taken care of later.

----

This also addresses a problem we've seen in the wild before: when our
additions to the wasm modules' data segments exceed the number of pages
needed for the memory import, a "data segment overflowing memory" issue
could have happened. That was because the minimal memory size for the
imported memory was determined by LLVM, and we'd just squeeze our added
data segments in, without adjusting that limit.

Now, the limit will be set properly; and if a too small memory was
provided, a more descriptive failure will happen at instantiation time.
Wasmtime, for example, raises

    incompatible import type for `env::memory`
    Caused by:
        memory types incompatible

----

There's nothing user-visible or ABI changing in there, the emitted policy.wasm files should be pretty much the same we had before, **except** for the ordering of the exports, which should not matter. (Skimmed the code for the python SDK and the C# one, I think they work similarly to the Node SDK, where the ordering does **not** matter. It used to matter for our wasmtime SDK, but we've changed to that is called in https://github.com/open-policy-agent/opa/commit/e2af1423c712523567c568ef9f8e266479eb728d.)

🔧 If you play with this locally, ensure that `wasm/_obj/opa.wasm` is not _stale_ (delete it, or run `make clean build`).