### PR TITLE
bundle: Update private key extraction mechanism from signing config

### DIFF
--- a/bundle/keys.go
+++ b/bundle/keys.go
@@ -6,6 +6,7 @@
 package bundle
 
 import (
+	"encoding/pem"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -106,6 +107,12 @@ func (s *SigningConfig) WithPlugin(plugin string) *SigningConfig {
 
 // GetPrivateKey returns the private key or secret from the signing config
 func (s *SigningConfig) GetPrivateKey() (interface{}, error) {
+
+	block, _ := pem.Decode([]byte(s.Key))
+	if block != nil {
+		return sign.GetSigningKey(s.Key, jwa.SignatureAlgorithm(s.Algorithm))
+	}
+
 	var priv string
 	if _, err := os.Stat(s.Key); err == nil {
 		bs, err := ioutil.ReadFile(s.Key)
@@ -118,6 +125,7 @@ func (s *SigningConfig) GetPrivateKey() (interface{}, error) {
 	} else {
 		return nil, err
 	}
+
 	return sign.GetSigningKey(priv, jwa.SignatureAlgorithm(s.Algorithm))
 }
 

--- a/bundle/keys_test.go
+++ b/bundle/keys_test.go
@@ -291,6 +291,37 @@ qnby6ICFV1o3cV2WFc5PVToBVoPEyUZQ7KFz/3znYQ44fbclemgU/5mf
 	})
 }
 
+func TestGetPrivateKeyNoFilePrivateKey(t *testing.T) {
+
+	privateKey := `-----BEGIN RSA PRIVATE KEY-----
+MIICXAIBAAKBgQCv9GCKxswe5axmZ0XUVoi2JB6fZWtquTMq+EwIHfqDT6Ch252W
+sJNF0XxupVdzxLlGax2enE0i4oKf8fNNylX2cRTvHJxlwdJjwZ2oARYScqacZjA5
+JRDDUsuzW9Qqru2fB6lXkgN1Aklzgnf0bkx6CoqwsHBkPVNyts2fpDLFBQIDAQAB
+AoGAK4rUIUOU28iGY0kHNMa9SiWiFlvoux5dlTKgzhltFvWrkKJiWxoTN+HhYxgz
+jgiOuOhlCg0v4YQgQyiCxytdHhgI+2fwh8upknNMLJdO485wbSe/nOaX1HO49yR/
+LAL3RX4+7pjSdlofGzu+mLaactU4M6i2QxBYj1xSfqJkyTkCQQDkFooNmHZV9cLr
+8msT3Dp2QpVJ4/hIwLCSPkPJLGfMUBpW/mBSgrBP1WkF5Us1564WEe9gsX6eZur5
+rlZewYNbAkEAxXyesM/ZYe1j3AlBOnQ69882vyeXK1oou1pHbKv7zbIgTjnusk5N
+GeqQfLvB+9MMLF2XVzqfbnBGoLYs0BMnHwJAAxVi7GghQWw/JF10oSIbEDo6NnOE
+icdBG9kHpZKaHKMAmCh8OOFXbNzfvJqq96GYMugvKkl8Arw1dQasWD+ZfQJBAMMz
+4futBxcXucwFzdbEioDl7hxWOsMcNAS0QMM24Ac62VnZQ4o1gVprk3Pndt++hVrZ
+C72p8WsNSZKTX4owVEsCQHIe9bXtAS8M02ftqHpp4Lvvu5R3WdLV2Jg/tCa/YogM
+b6giP1ZPqZArXaaZaUXZrWcsYx956X6wA4RkjrvaG40=
+-----END RSA PRIVATE KEY-----`
+
+	sc := NewSigningConfig(privateKey, "RS256", "")
+
+	result, err := sc.GetPrivateKey()
+	if err != nil {
+		t.Fatalf("Unexpected error %v", err)
+	}
+
+	_, ok := result.(*rsa.PrivateKey)
+	if !ok {
+		t.Fatalf("Expected key type *rsa.PrivateKey but got %T", result)
+	}
+}
+
 func TestGetClaimsErrors(t *testing.T) {
 	files := map[string]string{
 		"claims.json": `["foo", "read"]`,


### PR DESCRIPTION
The bundle package provides a utility to extract a private key
from a file. If the private key is not included in a file, the method
first assumes it's a file name and tries to open it. Based on the size of
the key this could result in a os.PathError such as "file name too long".

This fix changes the logic of how the private key/secret is extracted from
the signing config by first performing a PEM decode on the input and then
falling back on the exisiting mechanism.

Fixes: #3766

Signed-off-by: Ashutosh Narkar <anarkar4387@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/main/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/main/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
