### PR TITLE
replaces os.Open with a lazy file reader for bundles

### DIFF
--- a/bundle/file.go
+++ b/bundle/file.go
@@ -24,6 +24,42 @@ type Descriptor struct {
 	closeOnce *sync.Once
 }
 
+// LazyFile defers reading the file until the first call of Read
+type LazyFile struct {
+	path string
+	file *os.File
+}
+
+// NewLazyFile creates a new instance of LazyFile
+func NewLazyFile(path string) *LazyFile {
+	return &LazyFile{path: path}
+}
+
+// Read implements io.Reader. It will check if the file has been opened
+// and open it if it has not before attempting to read using the file's
+// read method
+func (f *LazyFile) Read(b []byte) (int, error) {
+	var err error
+
+	if f.file == nil {
+		if f.file, err = os.Open(f.path); err != nil {
+			return 0, errors.Wrapf(err, "failed to open file %s", f.path)
+		}
+	}
+
+	return f.file.Read(b)
+}
+
+// Close closes the lazy file if it has been opened using the file's
+// close method
+func (f *LazyFile) Close() error {
+	if f.file != nil {
+		return f.file.Close()
+	}
+
+	return nil
+}
+
 func newDescriptor(url, path string, reader io.Reader) *Descriptor {
 	return &Descriptor{
 		url:    url,
@@ -130,10 +166,7 @@ func (d *dirLoader) NextFile() (*Descriptor, error) {
 
 	fileName := d.files[d.idx]
 	d.idx++
-	fh, err := os.Open(fileName)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to open file %s", fileName)
-	}
+	fh := NewLazyFile(fileName)
 
 	// Trim off the root directory and return path as if chrooted
 	cleanedPath := strings.TrimPrefix(fileName, d.root)


### PR DESCRIPTION
bundle: The directory bundle loader currently opens all files before reading them. This causes issues on systems with a file descriptor limit lower than the number of files in the bundle. This PR implements a LazyFile type which will only open the file on first call to the Read method. The Read itself is still performed by the *os.File's Read method. In summary the LazyFile type implements a deferred io.Reader and io.Closer

Existing testing should be adequate as the mechanics are still the same. The new code only defers opening files until they are need to be Read

Signed-off-by: Branden Horiuchi <bhoriuchi@gmail.com>

Fixes #3777 
<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/main/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/main/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
