### PR TITLE
testdata/units/test-parse-bytes.yaml: fix indentation

### DIFF
--- a/test/cases/testdata/units/test-parse-bytes.yaml
+++ b/test/cases/testdata/units/test-parse-bytes.yaml
@@ -358,7 +358,7 @@ cases:
   want_result:
   - x: true
 
-  - data:
+- data:
   modules:
   - |
     package test


### PR DESCRIPTION
Trivial, but it had tripped up my WIP in npm-opa-wasm: https://github.com/open-policy-agent/npm-opa-wasm/runs/3584873349?check_suite_focus=true#step:11:2483