### PR TITLE
wasm/Makefile: disable builtin rules

### DIFF
--- a/wasm/Makefile
+++ b/wasm/Makefile
@@ -68,7 +68,8 @@ push-builder:
 
 .PHONY: build
 build:
-	@$(DOCKER) run $(DOCKER_FLAGS) -v $(CURDIR):/src $(WASM_BUILDER_IMAGE) make $(WASM_OBJ_DIR)/opa.wasm $(WASM_OBJ_DIR)/callgraph.csv
+	@$(DOCKER) run $(DOCKER_FLAGS) -v $(CURDIR):/src $(WASM_BUILDER_IMAGE) \
+	  make --no-builtin-rules $(WASM_OBJ_DIR)/opa.wasm $(WASM_OBJ_DIR)/callgraph.csv
 
 .PHONY: test
 test:
@@ -167,3 +168,7 @@ $(WASM_OBJ_DIR)/callgraph.csv: $(WASM_OBJ_DIR)/opa.wasm
 	# because we're not actually optimizing the wasm, but only extract
 	# information.
 	build/gen-wasm-callgraph.sh $< > $@
+
+# These are for canceling the implicit rules of GNU Make, see
+# https://www.gnu.org/software/make/manual/html_node/Canceling-Rules.html#Canceling-Rules
+src/libc++/mutex: src/libc++/mutex.cc


### PR DESCRIPTION
The builtin rules are what causes `make` to attempt to build `src/libc++/mutex`
from `src/libc++/mutex.cc`. The build call will fail like this,

    clang++-12  -std=c++17 -MD -MP -nodefaultlibs --target=wasm32-unknown-unknown-wasm -fno-exceptions -fno-rtti -I src/lib -I src/libc++ -I /usr/lib/llvm-12/include/c++/v1 -I /usr/lib/llvm-12/lib/clang/12.0.0/include -I src/re2 -D_LIBCPP_HAS_NO_THREADS -D_LIBCPP_HAS_NO_LIBRARY_ALIGNED_ALLOCATION -O3   src/libc++/mutex.cc   -o src/libc++/mutex
    clang: error: unable to execute command: Executable "wasm-ld" doesn't exist!
    clang: error: linker command failed with exit code 1 (use -v to see invocation)

and leave the working tree in a state where `src/libc++/mutex` is deleted,
since it was truncated by the `-o` argument to the cpp compiler, and an
untracked `src/libc++/mutex.d` dependency file was created, also by that
call (and its -MD -MP args).

With this change, these implicit rules are turned off: we don't want any
rules we haven't built ourselves here. `src/libc++/mutex` is a stub header
file, and has no ending.

We're also adding an extra rule to remove the pitfall for anyone calling
`make` themselves, outside of our build make targets.

-----

It's about time we fix this; while these errors have been spurious, they _do happen_ and are especially puzzling for new users working on a fresh checkout.