### PR TITLE
ast: Fix deep copy on Module to include comments

### DIFF
--- a/ast/policy.go
+++ b/ast/policy.go
@@ -411,6 +411,11 @@ func (mod *Module) Copy() *Module {
 		cpy.Annotations[i] = mod.Annotations[i].Copy(nodes[mod.Annotations[i].node])
 	}
 
+	cpy.Comments = make([]*Comment, len(mod.Comments))
+	for i := range mod.Comments {
+		cpy.Comments[i] = mod.Comments[i].Copy()
+	}
+
 	return &cpy
 }
 

--- a/ast/policy_test.go
+++ b/ast/policy_test.go
@@ -5,6 +5,7 @@
 package ast
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -481,6 +482,22 @@ wildcard = true { bar[_] = 1 }`
 
 	if !roundtrip.Equal(mod) {
 		t.Fatalf("Expected roundtripped to equal original but:\n\nExpected:\n\n%v\n\nDoes not equal result:\n\n%v", mod, roundtrip)
+	}
+}
+
+func TestModuleCopy(t *testing.T) {
+
+	input := `package foo
+
+	# comment
+	p := 7`
+
+	mod := MustParseModule(input)
+	cpy := mod.Copy()
+	cpy.Comments[0].Text[0] = 'X'
+
+	if !bytes.Equal(mod.Comments[0].Text, []byte(" comment")) {
+		t.Fatal("expected comment text to be unchanged")
 	}
 }
 


### PR DESCRIPTION
Previously comments were not being deep copied which could lead to
data races from the transfomer and other places.

Fixes #3793

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/main/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/main/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
