### PR TITLE
dependabot: let it update all go + GHA dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: /
     schedule:
       interval: daily
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,5 @@ version: 2
 updates:
   - package-ecosystem: gomod
     directory: /
-    allow:
-      - dependency-name: github.com/bytecodealliance/wasmtime-go
     schedule:
       interval: daily


### PR DESCRIPTION
This lets dependabot update all golang dependencies, not just wasmtime-go as we had before.

I think we could give this a try. If it becomes too annoying or doesn't work for us, it's easy to turn off again.