### PR TITLE
types: Sort any elements during construction

### DIFF
--- a/capabilities.json
+++ b/capabilities.json
@@ -21,16 +21,16 @@
           {
             "of": [
               {
-                "of": {
-                  "type": "any"
-                },
-                "type": "set"
-              },
-              {
                 "dynamic": {
                   "type": "any"
                 },
                 "type": "array"
+              },
+              {
+                "of": {
+                  "type": "any"
+                },
+                "type": "set"
               }
             ],
             "type": "any"
@@ -76,16 +76,16 @@
           {
             "of": [
               {
-                "of": {
-                  "type": "any"
-                },
-                "type": "set"
-              },
-              {
                 "dynamic": {
                   "type": "any"
                 },
                 "type": "array"
+              },
+              {
+                "of": {
+                  "type": "any"
+                },
+                "type": "set"
               }
             ],
             "type": "any"
@@ -472,16 +472,16 @@
           {
             "of": [
               {
-                "of": {
-                  "type": "string"
-                },
-                "type": "set"
-              },
-              {
                 "dynamic": {
                   "type": "string"
                 },
                 "type": "array"
+              },
+              {
+                "of": {
+                  "type": "string"
+                },
+                "type": "set"
               }
             ],
             "type": "any"
@@ -517,10 +517,7 @@
           {
             "of": [
               {
-                "of": {
-                  "type": "any"
-                },
-                "type": "set"
+                "type": "string"
               },
               {
                 "dynamic": {
@@ -540,7 +537,10 @@
                 "type": "object"
               },
               {
-                "type": "string"
+                "of": {
+                  "type": "any"
+                },
+                "type": "set"
               }
             ],
             "type": "any"
@@ -847,16 +847,16 @@
               "value": {
                 "of": [
                   {
-                    "of": {
-                      "type": "any"
-                    },
-                    "type": "set"
-                  },
-                  {
                     "dynamic": {
                       "type": "any"
                     },
                     "type": "array"
+                  },
+                  {
+                    "of": {
+                      "type": "any"
+                    },
+                    "type": "set"
                   }
                 ],
                 "type": "any"
@@ -867,16 +867,16 @@
           {
             "of": [
               {
-                "of": {
-                  "type": "any"
-                },
-                "type": "set"
-              },
-              {
                 "dynamic": {
                   "type": "any"
                 },
                 "type": "array"
+              },
+              {
+                "of": {
+                  "type": "any"
+                },
+                "type": "set"
               }
             ],
             "type": "any"
@@ -1747,16 +1747,16 @@
           {
             "of": [
               {
-                "of": {
-                  "type": "any"
-                },
-                "type": "set"
-              },
-              {
                 "dynamic": {
                   "type": "any"
                 },
                 "type": "array"
+              },
+              {
+                "of": {
+                  "type": "any"
+                },
+                "type": "set"
               }
             ],
             "type": "any"
@@ -1775,16 +1775,16 @@
           {
             "of": [
               {
-                "of": {
-                  "type": "any"
-                },
-                "type": "set"
-              },
-              {
                 "dynamic": {
                   "type": "any"
                 },
                 "type": "array"
+              },
+              {
+                "of": {
+                  "type": "any"
+                },
+                "type": "set"
               }
             ],
             "type": "any"
@@ -1927,23 +1927,6 @@
                 "type": "array"
               },
               {
-                "of": {
-                  "of": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "dynamic": {
-                        "type": "any"
-                      },
-                      "type": "array"
-                    }
-                  ],
-                  "type": "any"
-                },
-                "type": "set"
-              },
-              {
                 "dynamic": {
                   "key": {
                     "type": "string"
@@ -1964,6 +1947,23 @@
                   }
                 },
                 "type": "object"
+              },
+              {
+                "of": {
+                  "of": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "dynamic": {
+                        "type": "any"
+                      },
+                      "type": "array"
+                    }
+                  ],
+                  "type": "any"
+                },
+                "type": "set"
               }
             ],
             "type": "any"
@@ -1991,23 +1991,6 @@
                 "type": "array"
               },
               {
-                "of": {
-                  "of": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "dynamic": {
-                        "type": "any"
-                      },
-                      "type": "array"
-                    }
-                  ],
-                  "type": "any"
-                },
-                "type": "set"
-              },
-              {
                 "dynamic": {
                   "key": {
                     "type": "string"
@@ -2028,6 +2011,23 @@
                   }
                 },
                 "type": "object"
+              },
+              {
+                "of": {
+                  "of": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "dynamic": {
+                        "type": "any"
+                      },
+                      "type": "array"
+                    }
+                  ],
+                  "type": "any"
+                },
+                "type": "set"
               }
             ],
             "type": "any"
@@ -2181,12 +2181,6 @@
                 "type": "array"
               },
               {
-                "of": {
-                  "type": "any"
-                },
-                "type": "set"
-              },
-              {
                 "dynamic": {
                   "key": {
                     "type": "any"
@@ -2196,6 +2190,12 @@
                   }
                 },
                 "type": "object"
+              },
+              {
+                "of": {
+                  "type": "any"
+                },
+                "type": "set"
               }
             ],
             "type": "any"
@@ -2259,12 +2259,6 @@
                 "type": "array"
               },
               {
-                "of": {
-                  "type": "any"
-                },
-                "type": "set"
-              },
-              {
                 "dynamic": {
                   "key": {
                     "type": "any"
@@ -2274,6 +2268,12 @@
                   }
                 },
                 "type": "object"
+              },
+              {
+                "of": {
+                  "type": "any"
+                },
+                "type": "set"
               }
             ],
             "type": "any"
@@ -2387,16 +2387,16 @@
           {
             "of": [
               {
-                "of": {
-                  "type": "number"
-                },
-                "type": "set"
-              },
-              {
                 "dynamic": {
                   "type": "number"
                 },
                 "type": "array"
+              },
+              {
+                "of": {
+                  "type": "number"
+                },
+                "type": "set"
               }
             ],
             "type": "any"
@@ -2856,16 +2856,16 @@
           {
             "of": [
               {
-                "of": {
-                  "type": "number"
-                },
-                "type": "set"
-              },
-              {
                 "dynamic": {
                   "type": "number"
                 },
                 "type": "array"
+              },
+              {
+                "of": {
+                  "type": "number"
+                },
+                "type": "set"
               }
             ],
             "type": "any"
@@ -3142,16 +3142,16 @@
           {
             "of": [
               {
-                "type": "number"
-              },
-              {
-                "type": "string"
+                "type": "null"
               },
               {
                 "type": "boolean"
               },
               {
-                "type": "null"
+                "type": "number"
+              },
+              {
+                "type": "string"
               }
             ],
             "type": "any"

--- a/internal/presentation/presentation_test.go
+++ b/internal/presentation/presentation_test.go
@@ -193,10 +193,7 @@ func TestOutputJSONErrorStructuredAstErr(t *testing.T) {
           {
             "of": [
               {
-                "of": {
-                  "type": "any"
-                },
-                "type": "set"
+                "type": "string"
               },
               {
                 "dynamic": {
@@ -216,7 +213,10 @@ func TestOutputJSONErrorStructuredAstErr(t *testing.T) {
                 "type": "object"
               },
               {
-                "type": "string"
+                "of": {
+                  "type": "any"
+                },
+                "type": "set"
               }
             ],
             "type": "any"

--- a/types/types.go
+++ b/types/types.go
@@ -376,6 +376,7 @@ func NewAny(of ...Type) Any {
 	for i := range sl {
 		sl[i] = of[i]
 	}
+	sort.Sort(typeSlice(sl))
 	return sl
 }
 
@@ -411,7 +412,14 @@ func (t Any) Merge(other Type) Any {
 	if t.Contains(other) {
 		return t
 	}
-	return append(t, other)
+	cpy := make(Any, len(t)+1)
+	idx := sort.Search(len(t), func(i int) bool {
+		return Compare(t[i], other) >= 0
+	})
+	copy(cpy, t[:idx])
+	cpy[idx] = other
+	copy(cpy[idx+1:], t[idx:])
+	return cpy
 }
 
 // Union returns a new Any type that is the union of the two Any types.
@@ -431,6 +439,7 @@ func (t Any) Union(other Any) Any {
 			cpy = append(cpy, other[i])
 		}
 	}
+	sort.Sort(typeSlice(cpy))
 	return cpy
 }
 
@@ -625,8 +634,6 @@ func Compare(a, b Type) int {
 	case Any:
 		sl1 := typeSlice(a.(Any))
 		sl2 := typeSlice(b.(Any))
-		sort.Sort(sl1)
-		sort.Sort(sl2)
 		return typeSliceCompare(sl1, sl2)
 	case *Function:
 		fA := a.(*Function)

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -14,6 +14,44 @@ import (
 
 var dynamicPropertyAnyAny = NewDynamicProperty(A, A)
 
+func TestAnySorted(t *testing.T) {
+	a := NewAny(S, N)
+	if Compare(a[0], N) != 0 {
+		t.Fatal("expected any type to be sorted")
+	}
+}
+
+func TestAnyMerge(t *testing.T) {
+	x := NewAny(S, B)
+
+	if Compare(x.Merge(N)[1], N) != 0 {
+		t.Fatal("expected number to be inserted into middle")
+	}
+
+	if Compare(x.Merge(NewNull())[0], NewNull()) != 0 {
+		t.Fatal("expected null to be inserted at front")
+	}
+
+	if Compare(x.Merge(NewArray(nil, A))[2], NewArray(nil, A)) != 0 {
+		t.Fatal("expected array to be inserted at back")
+	}
+}
+
+func TestAnyUnion(t *testing.T) {
+	x := NewAny(NewNull(), N)
+	y := NewAny(S, B)
+	z := x.Union(y)
+	exp := []Type{NewNull(), B, N, S}
+	if len(z) != len(exp) {
+		t.Fatalf("expected %v elements in result of union", len(exp))
+	}
+	for i := range z {
+		if Compare(z[i], exp[i]) != 0 {
+			t.Fatal("expected", exp[i], "but got", z[i])
+		}
+	}
+}
+
 func TestStrings(t *testing.T) {
 
 	tpe := NewObject([]*StaticProperty{


### PR DESCRIPTION
This changes updates the implementation of the any type to sort
elements during construction. This way the Compare() function does not
have to sort elements before recursing (which can result in data races
if global type instances from the built-in function declarations or
elsewhere are compared.)

Fixes #3793

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/main/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/main/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
