### PR TITLE
plugins: Fix default trigger mode in the non-discovery path

### DIFF
--- a/plugins/bundle/config.go
+++ b/plugins/bundle/config.go
@@ -57,7 +57,8 @@ func ParseConfig(config []byte, services []string) (*Config, error) {
 // the defined `bundles`. This expects a map of bundle names to resource
 // configurations.
 func ParseBundlesConfig(config []byte, services []string) (*Config, error) {
-	return NewConfigBuilder().WithBytes(config).WithServices(services).WithTriggerMode(nil).Parse()
+	t := plugins.DefaultTriggerMode
+	return NewConfigBuilder().WithBytes(config).WithServices(services).WithTriggerMode(&t).Parse()
 }
 
 // NewConfigBuilder returns a new ConfigBuilder to build and parse the bundle config
@@ -85,10 +86,6 @@ func (b *ConfigBuilder) WithKeyConfigs(keys map[string]*keys.Config) *ConfigBuil
 
 // WithTriggerMode sets the plugin trigger mode
 func (b *ConfigBuilder) WithTriggerMode(trigger *plugins.TriggerMode) *ConfigBuilder {
-	if trigger == nil {
-		t := plugins.DefaultTriggerMode
-		trigger = &t
-	}
 	b.trigger = trigger
 	return b
 }
@@ -202,28 +199,11 @@ func (c *Config) validateAndInjectDefaults(services []string, keys map[string]*k
 			return fmt.Errorf("invalid configuration for bundle %q: %s", name, err.Error())
 		}
 
-		if trigger == nil {
-			t := plugins.DefaultTriggerMode
-			trigger = &t
-		} else {
-			err = validateTriggerMode(*trigger)
-			if err != nil {
-				return err
-			}
+		t, err := plugins.ValidateAndInjectDefaultsForTriggerMode(trigger, source.Trigger)
+		if err != nil {
+			return fmt.Errorf("invalid configuration for bundle %q: %w", name, err)
 		}
-
-		if source.Trigger == nil {
-			source.Trigger = trigger
-		} else {
-			err := validateTriggerMode(*source.Trigger)
-			if err != nil {
-				return err
-			}
-
-			if *source.Trigger != *trigger {
-				return fmt.Errorf("invalid configuration for bundle %q: discovery has trigger mode %s, bundle has %s", name, *trigger, *source.Trigger)
-			}
-		}
+		source.Trigger = t
 
 		if err == nil || ignoreServiceConfigErr {
 			err = source.Config.ValidateAndInjectDefaults()
@@ -280,15 +260,6 @@ func (c *Config) getServiceFromList(service string, services []string) (string, 
 func (c *Config) generateLegacyResourcePath() string {
 	joined := path.Join(*c.Prefix, c.Name)
 	return strings.TrimPrefix(joined, "/")
-}
-
-func validateTriggerMode(mode plugins.TriggerMode) error {
-	switch mode {
-	case plugins.TriggerPeriodic, plugins.TriggerManual:
-		return nil
-	default:
-		return fmt.Errorf("invalid trigger mode %q (want %q or %q)", mode, plugins.TriggerPeriodic, plugins.TriggerManual)
-	}
 }
 
 const (

--- a/plugins/discovery/discovery.go
+++ b/plugins/discovery/discovery.go
@@ -78,8 +78,7 @@ func New(manager *plugins.Manager, opts ...func(*Discovery)) (*Discovery, error)
 	if err != nil {
 		return nil, err
 	} else if config == nil {
-		t := plugins.DefaultTriggerMode
-		if _, err := getPluginSet(result.factories, manager, manager.Config, result.metrics, &t); err != nil {
+		if _, err := getPluginSet(result.factories, manager, manager.Config, result.metrics, nil); err != nil {
 			return nil, err
 		}
 		return result, nil

--- a/plugins/discovery/discovery_test.go
+++ b/plugins/discovery/discovery_test.go
@@ -1246,7 +1246,7 @@ bundles:
 			confGood, false, nil,
 		},
 		"trigger_mode_mismatch": {
-			confBad, true, fmt.Errorf("invalid configuration for bundle \"bundle-new\": discovery has trigger mode manual, bundle has periodic"),
+			confBad, true, fmt.Errorf("invalid configuration for bundle \"bundle-new\": trigger mode mismatch: manual and periodic (hint: check discovery configuration)"),
 		},
 	}
 
@@ -1313,7 +1313,7 @@ decision_logs:
 			confGood, false, nil,
 		},
 		"trigger_mode_mismatch": {
-			confBad, true, fmt.Errorf("invalid decision_log config, discovery has trigger mode manual, decision_log has periodic"),
+			confBad, true, fmt.Errorf("invalid decision_log config: trigger mode mismatch: manual and periodic (hint: check discovery configuration)"),
 		},
 	}
 
@@ -1386,7 +1386,7 @@ status:
 			confGood, false, nil,
 		},
 		"trigger_mode_mismatch": {
-			confBad, true, fmt.Errorf("invalid status config, discovery has trigger mode manual, status has periodic"),
+			confBad, true, fmt.Errorf("invalid status config: trigger mode mismatch: manual and periodic (hint: check discovery configuration)"),
 		},
 	}
 
@@ -1659,7 +1659,7 @@ func TestPluginManualTriggerLifecycle(t *testing.T) {
 	disco, _ := fixture.server.statusEvent[2].(map[string]interface{})
 	errMsg := disco["discovery"].(map[string]interface{})["message"]
 
-	expErrMsg := "invalid configuration for bundle \"authz\": discovery has trigger mode manual, bundle has periodic"
+	expErrMsg := "invalid configuration for bundle \"authz\": trigger mode mismatch: manual and periodic (hint: check discovery configuration)"
 	if errMsg != expErrMsg {
 		t.Fatalf("Expected error %v but got %v", expErrMsg, errMsg)
 	}

--- a/plugins/logs/plugin_test.go
+++ b/plugins/logs/plugin_test.go
@@ -1690,14 +1690,14 @@ func TestParseConfigTriggerMode(t *testing.T) {
 			config:   []byte(`{"reporting": {"trigger": "manual"}}`),
 			expected: plugins.TriggerPeriodic,
 			wantErr:  true,
-			err:      fmt.Errorf("invalid decision_log config, discovery has trigger mode periodic, decision_log has manual"),
+			err:      fmt.Errorf("invalid decision_log config: trigger mode mismatch: periodic and manual (hint: check discovery configuration)"),
 		},
 		{
 			note:     "bad trigger mode",
 			config:   []byte(`{"reporting": {"trigger": "foo"}}`),
 			expected: "foo",
 			wantErr:  true,
-			err:      fmt.Errorf("invalid trigger mode \"foo\" (want \"periodic\" or \"manual\")"),
+			err:      fmt.Errorf("invalid decision_log config: invalid trigger mode \"foo\" (want \"periodic\" or \"manual\")"),
 		},
 	}
 

--- a/plugins/plugins.go
+++ b/plugins/plugins.go
@@ -224,6 +224,46 @@ func getWasmResolversOnContext(context *storage.Context) []*wasm.Resolver {
 	return resolvers
 }
 
+func validateTriggerMode(mode TriggerMode) error {
+	switch mode {
+	case TriggerPeriodic, TriggerManual:
+		return nil
+	default:
+		return fmt.Errorf("invalid trigger mode %q (want %q or %q)", mode, TriggerPeriodic, TriggerManual)
+	}
+}
+
+// ValidateAndInjectDefaultsForTriggerMode validates the trigger mode and injects default values
+func ValidateAndInjectDefaultsForTriggerMode(a, b *TriggerMode) (*TriggerMode, error) {
+
+	if a == nil && b != nil {
+		err := validateTriggerMode(*b)
+		if err != nil {
+			return nil, err
+		}
+		return b, nil
+	} else if a != nil && b == nil {
+		err := validateTriggerMode(*a)
+		if err != nil {
+			return nil, err
+		}
+		return a, nil
+	} else if a != nil && b != nil {
+		if *a != *b {
+			return nil, fmt.Errorf("trigger mode mismatch: %s and %s (hint: check discovery configuration)", *a, *b)
+		}
+		err := validateTriggerMode(*a)
+		if err != nil {
+			return nil, err
+		}
+		return a, nil
+
+	} else {
+		t := DefaultTriggerMode
+		return &t, nil
+	}
+}
+
 type namedplugin struct {
 	name   string
 	plugin Plugin

--- a/plugins/status/plugin_test.go
+++ b/plugins/status/plugin_test.go
@@ -593,14 +593,14 @@ func TestParseConfigTriggerMode(t *testing.T) {
 			config:   []byte(`{"trigger": "manual"}`),
 			expected: plugins.TriggerPeriodic,
 			wantErr:  true,
-			err:      fmt.Errorf("invalid status config, discovery has trigger mode periodic, status has manual"),
+			err:      fmt.Errorf("invalid status config: trigger mode mismatch: periodic and manual (hint: check discovery configuration)"),
 		},
 		{
 			note:     "bad trigger mode",
 			config:   []byte(`{"trigger": "foo"}`),
 			expected: "foo",
 			wantErr:  true,
-			err:      fmt.Errorf("invalid trigger mode \"foo\" (want \"periodic\" or \"manual\")"),
+			err:      fmt.Errorf("invalid status config: invalid trigger mode \"foo\" (want \"periodic\" or \"manual\")"),
 		},
 	}
 


### PR DESCRIPTION
When individual plugins (except discovery) were configured, the
default trigger mode was set as periodic. So if the plugin specified
a different mode (eg. manual), the configuration check would incorrectly
fail on account of a mode mismatch. This commit fixes the issue by
updating the trigger mode check to not specify a default mode in
scenarios when only plugins (except discovery) are configured.

Fixes: #3797

Signed-off-by: Ashutosh Narkar <anarkar4387@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/main/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/main/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
