### PR TITLE
ast/term: don't sort an object's keys slice in-place

### DIFF
--- a/ast/compile_test.go
+++ b/ast/compile_test.go
@@ -1907,11 +1907,11 @@ func TestCompilerRewriteLocalAssignments(t *testing.T) {
 			`,
 			exp: `
 				package test
-				object_keys = true { {k: __local0__, "k2": __local1__} = {"foo": 1, "k2": 2} }
+				object_keys = true { {"k2": __local0__, k: __local1__} = {"foo": 1, "k2": 2} }
 			`,
 			expRewrittenMap: map[Var]Var{
-				Var("__local0__"): Var("v1"),
-				Var("__local1__"): Var("v2"),
+				Var("__local0__"): Var("v2"),
+				Var("__local1__"): Var("v1"),
 			},
 		},
 		{

--- a/ast/term.go
+++ b/ast/term.go
@@ -1800,23 +1800,22 @@ func (obj *object) Compare(other Value) int {
 	}
 	a := obj
 	b := other.(*object)
-	// TODO: Ideally Compare would be immutable; the following sorts happen in place.
-	sort.Sort(a.keys)
-	sort.Sort(b.keys)
+	akeys := objectElemSliceSorted(a.keys)
+	bkeys := objectElemSliceSorted(b.keys)
 	minLen := len(a.keys)
 	if len(b.keys) < len(a.keys) {
 		minLen = len(b.keys)
 	}
 	for i := 0; i < minLen; i++ {
-		keysCmp := Compare(a.keys[i].key, b.keys[i].key)
+		keysCmp := Compare(akeys[i].key, bkeys[i].key)
 		if keysCmp < 0 {
 			return -1
 		}
 		if keysCmp > 0 {
 			return 1
 		}
-		valA := a.keys[i].value
-		valB := b.keys[i].value
+		valA := akeys[i].value
+		valB := bkeys[i].value
 		valCmp := Compare(valA, valB)
 		if valCmp != 0 {
 			return valCmp

--- a/ast/term_bench_test.go
+++ b/ast/term_bench_test.go
@@ -6,6 +6,7 @@ package ast
 import (
 	"encoding/json"
 	"fmt"
+	"math/rand"
 	"strings"
 	"testing"
 )
@@ -149,6 +150,45 @@ func BenchmarkObjectString(b *testing.B) {
 				}
 			})
 		})
+	}
+}
+
+func BenchmarkObjectConstruction(b *testing.B) {
+	sizes := []int{5, 50, 500, 5000, 50000}
+
+	b.Run("random keys", func(b *testing.B) {
+		for _, n := range sizes {
+			b.Run(fmt.Sprint(n), func(b *testing.B) {
+				obj := map[string]int{}
+				for i := 0; i < n; i++ {
+					j := rand.Intn(n)
+					obj[fmt.Sprint(j)] = i
+				}
+				benchObjectConstruction(b, obj)
+			})
+		}
+	})
+	b.Run("increasing keys", func(b *testing.B) {
+		for _, n := range sizes {
+			b.Run(fmt.Sprint(n), func(b *testing.B) {
+				obj := map[string]int{}
+				for i := 0; i < n; i++ {
+					obj[fmt.Sprint(i)] = i
+				}
+				benchObjectConstruction(b, obj)
+			})
+		}
+	})
+}
+
+func benchObjectConstruction(b *testing.B, obj map[string]int) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		val := MustInterfaceToValue(obj)
+		_, ok := val.(Object)
+		if !ok {
+			b.Fail()
+		}
 	}
 }
 

--- a/ast/term_test.go
+++ b/ast/term_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"sort"
 	"strings"
 	"testing"
 
@@ -259,6 +260,37 @@ func TestObjectFilter(t *testing.T) {
 				t.Errorf("Expected:\n\n\t%s\n\nGot:\n\n\t%s\n\n", expected, actual)
 			}
 		})
+	}
+}
+
+func TestObjectInsertKeepsSorting(t *testing.T) {
+	keysSorted := func(o *object) func(int, int) bool {
+		return func(i, j int) bool {
+			return Compare(o.keys[i].key, o.keys[j].key) < 0
+		}
+	}
+
+	obj := NewObject(
+		[2]*Term{StringTerm("d"), IntNumberTerm(4)},
+		[2]*Term{StringTerm("b"), IntNumberTerm(2)},
+		[2]*Term{StringTerm("a"), IntNumberTerm(1)},
+	)
+	o := obj.(*object)
+	act := sort.SliceIsSorted(o.keys, keysSorted(o))
+	if exp := true; act != exp {
+		t.Errorf("SliceIsSorted: expected %v, got %v", exp, act)
+		for i := range o.keys {
+			t.Logf("elem[%d]: %v", i, o.keys[i].key)
+		}
+	}
+
+	obj.Insert(StringTerm("c"), IntNumberTerm(3))
+	act = sort.SliceIsSorted(o.keys, keysSorted(o))
+	if exp := true; act != exp {
+		t.Errorf("SliceIsSorted: expected %v, got %v", exp, act)
+		for i := range o.keys {
+			t.Logf("elem[%d]: %v", i, o.keys[i].key)
+		}
 	}
 }
 

--- a/format/testfiles/test.rego.formatted
+++ b/format/testfiles/test.rego.formatted
@@ -19,10 +19,7 @@ foo[x] {
 	g(x, "foo") = z
 }
 
-globals = {
-	"foo": "bar",
-	"fizz": "buzz",
-}
+globals = {"fizz": "buzz", "foo": "bar"}
 
 partial_obj["x"] = 1
 

--- a/rego/example_test.go
+++ b/rego/example_test.go
@@ -206,10 +206,10 @@ p = {"hello": "alice", "goodbye": "bob"} { true }`,
 	//
 	// len: 2
 	// err: <nil>
-	// bindings["x"]: hello (i=0)
-	// value: alice (i=0)
-	// bindings["x"]: goodbye (i=1)
-	// value: bob (i=1)
+	// bindings["x"]: goodbye (i=0)
+	// value: bob (i=0)
+	// bindings["x"]: hello (i=1)
+	// value: alice (i=1)
 }
 
 func ExampleRego_Eval_compiler() {

--- a/test/cases/testdata/partialsetdoc/test-issue-3819.yaml
+++ b/test/cases/testdata/partialsetdoc/test-issue-3819.yaml
@@ -1,0 +1,24 @@
+cases:
+- data:
+    a:
+      bananas: 1
+      apples: 2
+      clementines: 3
+  modules:
+  - |
+    package foo
+    p[x] {
+        data.a[x] # iterates data.a
+        q[_]
+    }
+    q[x] {
+        x = data.a # inserts data.a into a set, sorts the object keys
+    }
+  note: 'partialsetdoc: object sort while iter'
+  query: data.foo.p = x
+  sort_bindings: true
+  want_result:
+  - x:
+    - apples
+    - bananas
+    - clementines


### PR DESCRIPTION
Two different commits, two different approaches to fix the underlying problem that during evaluation, we may sort an object's key slice; and that could happen within the function passed to the object's `Iter()` method, causing the weird situation that on subsequent invocations of the passed function, the *same key* would be presented.

This example shows how it's possible, and I believe that this is what happened in #3819.

The partial set memo work that seemed to be the cause of the problem must have changed one thing: before, the document under `data.external["test.target"]` would _not_ have been Compare'd to anything, and afterwards, it would. (I haven't uncovered the complete code flow yet...)

----

This was introduced in https://github.com/open-policy-agent/opa/commit/2381824b168f0d776ec3fc9454e9b002b97fc036, and there's a TODO comment hinting at this being not ideal. I suppose we want to contemplate which way to go here (squash and merge, or drop the second commit doing the sort at insertion-time).

----

Fixes #3819.

