### PR TITLE
netlify: fix build

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -28,7 +28,7 @@ install-deps: live-blocks-install-deps
 # npm scripts in ./website/scripts/live-blocks
 .PHONY: live-blocks-%
 live-blocks-%:
-	cd $(CURDIR)/website/scripts/live-blocks && npm run --silent $*
+	cd $(CURDIR)/website/scripts/live-blocks && npm run $*
 
 .PHONY: serve-local
 serve-local: production-build

--- a/docs/website/scripts/live-blocks/scripts/inject
+++ b/docs/website/scripts/live-blocks/scripts/inject
@@ -18,6 +18,4 @@ mkdir -p ../../public/live-blocks # Other assets
 cp -r static/* ../../public/live-blocks/
 
 # Preprocess the docs
-npm run --silent preprocess ../../public/index.html
-npm run --silent preprocess ../../public/docs/*/*.html
-npm run --silent preprocess ../../public/docs/*/*/*.html
+find ../../public/ -name '*.html' -print0 | xargs -0 -n200 npm run preprocess


### PR DESCRIPTION
With more and more version appearing, the argument count passed to the
`npm run` call through the shell glob had increased, too -- to a point
where execution was impossible because it had reached a hard limit.

The obvious fix would have been to use `find [...] -exec cmd {} +` or
`find [...] -print0 | xargs -0 cmd`, however, since the npm call builds
another command line that's executed, we'd step over that limit again.

So instead, we'll now run the npm script on batches of 200 files. It's
below the maximum (unclear what it is, I haven't dug that deep), and
still fast enough (running it file-by-file takes 15+minutes).