### PR TITLE
docs: Make Playground the first link in docs sidemenu

### DIFF
--- a/docs/website/layouts/partials/docs/sidenav.html
+++ b/docs/website/layouts/partials/docs/sidenav.html
@@ -13,6 +13,12 @@
 {{ $version    := index (split .File.Path "/") 1 }}
 {{ $latest     := index site.Data.releases 1 }}
 
+<span class="docs-nav-title">Online Editor</span>
+<a class="docs-nav-title" href="https://play.openpolicyagent.org/">
+  Rego Playground
+</a>
+<hr class="docs-nav-hr" />
+
 <span class="docs-nav-title">
   Core Docs
 </span>
@@ -48,10 +54,6 @@
 {{ partial "docs/sidenav-section.html" ( dict "ctx" . "sectionTitle" "Contributing" "section" $contrib "pageUrl" $pageUrl "version" $version ) }}
 
 {{ partial "docs/sidenav-section.html" ( dict "ctx" . "sectionTitle" "Miscellaneous" "section" $misc "pageUrl" $pageUrl "version" $version ) }}
-
-<a class="docs-nav-item" href="https://play.openpolicyagent.org/">
-  Rego Playground
-</a>
 
 <hr class="docs-nav-hr" />
 


### PR DESCRIPTION
The current location for rego playground is very hard to find. It's almost the last item in a huge list.

It should be one of the most important links. The online playground is how people can _try_ Rego and get instant feedback. We should encourage people to use it as a first port of call when learning.

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/main/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/main/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
