### PR TITLE
testdata/units/test-parse-bytes.yaml: fix indentation

### DIFF
--- a/test/cases/testdata/units/test-parse-bytes.yaml
+++ b/test/cases/testdata/units/test-parse-bytes.yaml
@@ -406,7 +406,7 @@ cases:
   want_result:
   - x: true
 
-  - data:
+- data:
   modules:
   - |
     package test


### PR DESCRIPTION
Fixing another wrong indentation in testdata that would trip up some YAML readers.