### PR TITLE
internal: Update the return value for typed value null

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -439,3 +439,48 @@ func TestLoadConfigWithParamOverrideNoConfigFile(t *testing.T) {
 		t.Errorf("config does not match expected:\n\nExpected: %+v\nActual: %+v", expected, config)
 	}
 }
+
+func TestLoadConfigWithParamOverrideNoConfigFileWithEmptyObject(t *testing.T) {
+	configOverrides := []string{
+		"services.acmecorp.url=https://example.com/control-plane-api/v1",
+		"services.acmecorp.headers=null",
+		"services.acmecorp.credentials.s3_signing.environment_credentials=null",
+		"decision_logs.plugin=my_plugin",
+		"plugins.my_plugin=null",
+	}
+
+	configBytes, err := Load("", configOverrides, nil)
+	if err != nil {
+		t.Errorf("unexpected error loading config: " + err.Error())
+	}
+
+	config := map[string]interface{}{}
+	err = yaml.Unmarshal(configBytes, &config)
+	if err != nil {
+		t.Errorf("unexpected error unmarshalling config")
+	}
+
+	expected := map[string]interface{}{
+		"services": map[string]interface{}{
+			"acmecorp": map[string]interface{}{
+				"url":     "https://example.com/control-plane-api/v1",
+				"headers": map[string]interface{}{},
+				"credentials": map[string]interface{}{
+					"s3_signing": map[string]interface{}{
+						"environment_credentials": map[string]interface{}{},
+					},
+				},
+			},
+		},
+		"decision_logs": map[string]interface{}{
+			"plugin": "my_plugin",
+		},
+		"plugins": map[string]interface{}{
+			"my_plugin": map[string]interface{}{},
+		},
+	}
+
+	if !reflect.DeepEqual(config, expected) {
+		t.Errorf("config does not match expected:\n\nExpected: %+v\nActual: %+v", expected, config)
+	}
+}

--- a/internal/strvals/parser.go
+++ b/internal/strvals/parser.go
@@ -382,7 +382,7 @@ func typedVal(v []rune, st bool) interface{} {
 	}
 
 	if strings.EqualFold(val, "null") {
-		return nil
+		return struct{}{}
 	}
 
 	if strings.EqualFold(val, "0") {

--- a/internal/strvals/parser_test.go
+++ b/internal/strvals/parser_test.go
@@ -98,7 +98,7 @@ func TestParseSet(t *testing.T) {
 	}{
 		{
 			"name1=null,f=false,t=true",
-			map[string]interface{}{"name1": nil, "f": false, "t": true},
+			map[string]interface{}{"name1": map[string]interface{}{}, "f": false, "t": true},
 			false,
 		},
 		{
@@ -142,7 +142,7 @@ func TestParseSet(t *testing.T) {
 		},
 		{
 			str:    "is_null=null",
-			expect: map[string]interface{}{"is_null": nil},
+			expect: map[string]interface{}{"is_null": map[string]interface{}{}},
 			err:    false,
 		},
 		{


### PR DESCRIPTION
This commit updates the parser for --set options
to return empty struct as return value when null
is specified. This is needed to set an empty object
with the CLI overrides for a null typed value.

Fixes: #3846

Signed-off-by: Ashutosh Narkar <anarkar4387@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/main/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/main/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
