### PR TITLE
bundle: Replace HasPrefix in erasePolicy

### DIFF
--- a/bundle/store.go
+++ b/bundle/store.go
@@ -9,7 +9,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/metrics"
@@ -447,7 +446,7 @@ func erasePolicies(ctx context.Context, store storage.Store, txn storage.Transac
 		}
 		deleted := false
 		for root := range roots {
-			if strings.HasPrefix(path, root) {
+			if RootPathsContain([]string{root}, path) {
 				if err := store.DeletePolicy(ctx, txn, id); err != nil {
 					return nil, err
 				}

--- a/bundle/store_test.go
+++ b/bundle/store_test.go
@@ -510,6 +510,16 @@ func TestErasePolicies(t *testing.T) {
 			expectedRemaining: []string{"mod1", "mod2"},
 		},
 		{
+			note: "erase correct paths",
+			initialPolicies: map[string][]byte{
+				"mod1": []byte("package a.test\np = true"),
+				"mod2": []byte("package a.test_v2\np = true"),
+			},
+			roots:             []string{"a/test"},
+			expectErr:         false,
+			expectedRemaining: []string{"mod2"},
+		},
+		{
 			note: "erase some",
 			initialPolicies: map[string][]byte{
 				"mod1": []byte("package a\np = true"),
@@ -556,7 +566,7 @@ func TestErasePolicies(t *testing.T) {
 
 			if !tc.expectErr {
 				if len(remaining) != len(tc.expectedRemaining) {
-					t.Fatalf("expected %d modules remaining, got %d", len(remaining), len(tc.expectedRemaining))
+					t.Fatalf("expected %d modules remaining, got %d", len(tc.expectedRemaining), len(remaining))
 				}
 				for _, name := range tc.expectedRemaining {
 					if _, ok := remaining[name]; !ok {


### PR DESCRIPTION
Using HasPrefix to compare a root path to the path of policy can result
in unexpected behaviour when different bundles have similarly named
roots.

This replaces the HasPrefix comparison with a comparison that treats the
paths as directories and checks if the policy path is the same path as
the root or a subdirectory of the root path.

Signed-off-by: Edward Paget <edward.paget@chime.com>

For a full explanation of this fix, I ran into this problem with our OPA deployment where I have bundles that are related to specific events. I have two events which I'll call `event_one` and another called `event_one_for_the_books`. They have policies packaged under `com/example/event_one` and `com/example/event_one_for_the_books`. I found that -- depending on the order the bundles were initialized on my OPA node -- policies under the root `com/example/event_one_for_the_books` were not present because they were being deleted when the `event_one` bundle was initialized. 

I think there's a good case to be made for my events to not be named such that the name of one is a substring of the other, but policies being overwritten was still surprising. 

Also since bundle roots and package names seem to be generally treated as paths, it made sense to me that the comparison should look for equal paths or subdirectories instead of a string prefix. 