### PR TITLE
format: keep new lines in between function arguments

### DIFF
--- a/format/format.go
+++ b/format/format.go
@@ -490,15 +490,13 @@ func (w *writer) writeFunctionCall(expr *ast.Expr, comments []*ast.Comment) []*a
 
 func (w *writer) writeFunctionCallPlain(terms []*ast.Term, comments []*ast.Comment) []*ast.Comment {
 	w.write(terms[0].String() + "(")
-	if len(terms) > 1 {
-		for _, v := range terms[1 : len(terms)-1] {
-			comments = w.writeTerm(v, comments)
-			w.write(", ")
-		}
-		comments = w.writeTerm(terms[len(terms)-1], comments)
+	defer w.write(")")
+	args := make([]interface{}, len(terms)-1)
+	for i, t := range terms[1:] {
+		args[i] = t
 	}
-	w.write(")")
-	return comments
+	loc := terms[0].Location
+	return w.writeIterable(args, loc, closingLoc(0, 0, '(', ')', loc), comments, w.listWriter())
 }
 
 func (w *writer) writeWith(with *ast.With, comments []*ast.Comment) []*ast.Comment {

--- a/format/testfiles/test.rego.formatted
+++ b/format/testfiles/test.rego.formatted
@@ -98,7 +98,10 @@ fn2(
 	split(x, y, c)
 	trim(a, z, d) # function comment 1
 	split(c[0], d, b)
-	x = sprintf("hello %v", ["world"])
+	x = sprintf(
+		"hello %v",
+		["world"],
+	)
 	#function comment 2
 } # function comment 3
 

--- a/format/testfiles/test_fun_args_with_linebreaks.rego
+++ b/format/testfiles/test_fun_args_with_linebreaks.rego
@@ -1,0 +1,16 @@
+package test
+
+p {
+    x := count(
+        [1, 2, 3] # four
+    )
+    y := concat(
+        "/",
+        ["foo", "bar"],
+    )
+    z := concat("/",
+        [
+            "foo",
+            "bar",
+        ])
+}

--- a/format/testfiles/test_fun_args_with_linebreaks.rego.formatted
+++ b/format/testfiles/test_fun_args_with_linebreaks.rego.formatted
@@ -1,0 +1,18 @@
+package test
+
+p {
+	x := count([1, 2, 3]) # four
+
+	y := concat(
+		"/",
+		["foo", "bar"],
+	)
+
+	z := concat(
+		"/",
+		[
+			"foo",
+			"bar",
+		],
+	)
+}

--- a/format/testfiles/test_issue_3836.rego
+++ b/format/testfiles/test_issue_3836.rego
@@ -1,0 +1,6 @@
+package testcase
+
+rule1 = contains(
+    "", # first comment
+    "", # second comment
+)

--- a/format/testfiles/test_issue_3836.rego.formatted
+++ b/format/testfiles/test_issue_3836.rego.formatted
@@ -1,0 +1,6 @@
+package testcase
+
+rule1 = contains(
+	"", # first comment
+	"", # second comment
+)


### PR DESCRIPTION
This snippet,

    r = contains(
        input.x,
        "y",
    )

would have been formatted as

    r = contains(input.x, "y")

before. Now, any new lines added between function arguments will be kept, and
the snippet will not be reformatted.

As a consequence, comments on the separate arguments we OK:

    r = contains(
        input.x, # haystack
        "y",     # needle
    )

and don't freak out the formatter.

Fixes #3836.

-------

Changes to the formatter often have the potential to be annoying, but with this, anything that had been formatted with a previous version _should_ still be formatted the same way. I.e., there would not be any breakage in people's CI running `opa fmt` on committed files.

It does, however, broaden the domain of accepted inputs, by not forcing all function arguments to be on one line.