### PR TITLE
ci/perf: don't run tests in 'perf' target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,11 +119,11 @@ test-coverage: generate
 
 .PHONY: perf
 perf: generate
-	$(GO) test $(GO_TAGS),slow $(GO_TEST_TIMEOUT) -run=- -bench=. -benchmem ./...
+	$(GO) test $(GO_TAGS),slow $(GO_TEST_TIMEOUT) -run=^$$ -bench=. -benchmem ./...
 
 .PHONY: perf-noisy
 perf-noisy: generate
-	$(GO) test $(GO_TAGS),slow,noisy $(GO_TEST_TIMEOUT) -run=- -bench=. -benchmem ./...
+	$(GO) test $(GO_TAGS),slow,noisy $(GO_TEST_TIMEOUT) -run=^$$ -bench=. -benchmem ./...
 
 .PHONY: wasm-sdk-e2e-test
 wasm-sdk-e2e-test: generate


### PR DESCRIPTION
#3872 has shown that we're running "ordinary" tests in the perf tests. We're running the ordinary tests, too, for the race detector, and once for linux and macos.... So, we're still running them often enough when we take them out of the longest-running CI job we have.