### PR TITLE
docs/website: Fix ecosystem tile size and alignment

### DIFF
--- a/docs/website/static/css/support.css
+++ b/docs/website/static/css/support.css
@@ -2,6 +2,8 @@
     border-radius: 20px;
     box-shadow: 2px 3px 6px rgba(51, 51, 51, 0.25);
     cursor: pointer;
+    min-width: inherit;
+    text-align: center;
 }
 
 .card-body {


### PR DESCRIPTION
The boxes on the ecosystem page were different sizes. To fix this
I set the min-wdith to inherit which should make it flexible for
future re-designs. I also fixed the text alignment issue.

This work was done in conjunction with @anderseknert via slack.

Testing was manual as there are no site tests that I could find. 

Fixes #3875

Signed-off-by: Derek Murawsky <dmurawsky@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/main/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/main/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
