### PR TITLE
ast/parser: disallow whitespace separated statements

### DIFF
--- a/ast/parser.go
+++ b/ast/parser.go
@@ -226,6 +226,9 @@ func (p *Parser) Parse() ([]Statement, []*Comment, Errors) {
 
 		if body := p.parseQuery(true, tokens.EOF); body != nil {
 			stmts = append(stmts, body)
+			if p.s.tok != tokens.EOF && !p.s.skippedNL {
+				p.illegal(`expected \n or ;`)
+			}
 			continue
 		}
 

--- a/ast/parser_test.go
+++ b/ast/parser_test.go
@@ -128,11 +128,11 @@ func TestScalarTerms(t *testing.T) {
 	assertParseErrorContains(t, "non-string", "'a string'", "illegal token")
 	assertParseErrorContains(t, "non-number", "6zxy", "illegal number format")
 	assertParseErrorContains(t, "non-number2", "6d7", "illegal number format")
-	assertParseErrorContains(t, "non-number3", "6\"foo\"", "expected exactly one statement") // ??
+	assertParseErrorContains(t, "non-number3", "6\"foo\"", `expected \n or ;`)
 	assertParseErrorContains(t, "non-number4", "6true", "illegal number format")
 	assertParseErrorContains(t, "non-number5", "6false", "illegal number format")
 	assertParseErrorContains(t, "non-number6", "6[null, null]", "illegal ref (head cannot be number)") // ??
-	assertParseErrorContains(t, "non-number7", "6{\"foo\": \"bar\"}", "expected exactly one statement")
+	assertParseErrorContains(t, "non-number7", "6{\"foo\": \"bar\"}", `expected \n or ;`)
 	assertParseErrorContains(t, "non-number8", ".0.", "expected fraction")
 	assertParseErrorContains(t, "non-number9", "0e", "expected exponent")
 	assertParseErrorContains(t, "non-number10", "0e.", "expected exponent")
@@ -153,6 +153,8 @@ func TestScalarTerms(t *testing.T) {
 
 	// g := big.NewFloat(1); g.SetMantExp(g, 1e6); g.String() // => 9.900656229e+301029
 	assertParseErrorContains(t, "float exp > 1e5", "9.900656229e+301029", "number too big")
+
+	assertParseErrorContains(t, "many expressions in a row", "x = 1 1+1 true != false", `expected \n or ;`)
 }
 
 func TestVarTerms(t *testing.T) {
@@ -1804,7 +1806,7 @@ func TestModuleParseErrors(t *testing.T) {
 
 	errs, ok := err.(Errors)
 	if !ok {
-		panic("unexpected error value")
+		t.Fatalf("unexpected error value: %v", err)
 	}
 
 	if len(errs) != 5 {


### PR DESCRIPTION
Before, without future keywords,

    1 in [1, 2, 3]

would be parsed as follows:

- parseQuery would fetch the 1, and continue in the `Parse()` loop
- parseRules would pick up `in[1`, and then fail to make sense of the
  rule head with a comma in it.

Another oddity based on this is the evaluation of a query with spaces
separating multiple statements:

Before

    $ opa eval -fpretty 'q = 1 1+1 x = 4142'
    +---+------+-----+
    | q |  x   | 1+1 |
    +---+------+-----+
    | 1 | 4142 | 2   |
    +---+------+-----+

After

    $ opa eval -fpretty 'q = 1 1+1 x = 4142'
    1 error occurred: 1:7: rego_parse_error: unexpected number token: expected \n
            q = 1 1+1 x = 4142
                  ^

Signed-off-by: Stephan Renatus <stephan.renatus@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/main/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/main/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
