### PR TITLE
ast: Add future keywords to capabilities

### DIFF
--- a/ast/capabilities.go
+++ b/ast/capabilities.go
@@ -15,8 +15,8 @@ import (
 // Capabilities defines a structure containing data that describes the capablilities
 // or features supported by a particular version of OPA.
 type Capabilities struct {
-	// builtins is a set of built-in functions that are supported.
 	Builtins        []*Builtin       `json:"builtins"`
+	FutureKeywords  []string         `json:"future_keywords"`
 	WasmABIVersions []WasmABIVersion `json:"wasm_abi_versions"`
 
 	// allow_net is an array of hostnames or IP addresses, that an OPA instance is
@@ -48,6 +48,11 @@ func CapabilitiesForThisVersion() *Capabilities {
 	sort.Slice(f.Builtins, func(i, j int) bool {
 		return f.Builtins[i].Name < f.Builtins[j].Name
 	})
+
+	for kw := range futureKeywords {
+		f.FutureKeywords = append(f.FutureKeywords, kw)
+	}
+	sort.Strings(f.FutureKeywords)
 
 	return f
 }

--- a/ast/capabilities_test.go
+++ b/ast/capabilities_test.go
@@ -1,0 +1,85 @@
+package ast
+
+import (
+	"testing"
+)
+
+func TestParserCatchesIllegalCapabilities(t *testing.T) {
+	var opts ParserOptions
+	opts.Capabilities = &Capabilities{
+		FutureKeywords: []string{"deadbeef"},
+	}
+
+	_, _, err := ParseStatementsWithOpts("test.rego", "true", opts)
+	if err == nil {
+		t.Fatal("expected error")
+	} else if errs, ok := err.(Errors); !ok || len(errs) != 1 {
+		t.Fatal("expected exactly one error but got:", err)
+	} else if errs[0].Code != ParseErr || errs[0].Message != "illegal capabilities: unknown keyword: deadbeef" {
+		t.Fatal("unexpected error:", err)
+	}
+}
+
+func TestParserCatchesIllegalFutureKeywordsBasedOnCapabilities(t *testing.T) {
+	var opts ParserOptions
+	opts.Capabilities = CapabilitiesForThisVersion()
+	opts.FutureKeywords = []string{"deadbeef"}
+
+	_, _, err := ParseStatementsWithOpts("test.rego", "true", opts)
+	if err == nil {
+		t.Fatal("expected error")
+	} else if errs, ok := err.(Errors); !ok || len(errs) != 1 {
+		t.Fatal("expected exactly one error but got:", err)
+	} else if errs[0].Code != ParseErr || errs[0].Message != "unknown future keyword: deadbeef" {
+		t.Fatal("unexpected error:", err)
+	}
+}
+
+func TestParserCapabilitiesWithSpecificOptInAndOlderOPA(t *testing.T) {
+
+	src := `
+		package test
+
+		import future.keywords.in
+
+		p {
+			1 in [3,2,1]
+		}
+	`
+
+	var opts ParserOptions
+	opts.Capabilities = &Capabilities{}
+
+	_, err := ParseModuleWithOpts("test.rego", src, opts)
+	if err == nil {
+		t.Fatal("expected error")
+	} else if errs, ok := err.(Errors); !ok || len(errs) != 1 {
+		t.Fatal("expected exactly one error but got:", err)
+	} else if errs[0].Code != ParseErr || errs[0].Location.Row != 4 || errs[0].Message != "unexpected keyword, must be one of []" {
+		t.Fatal("unexpected error:", err)
+	}
+}
+
+func TestParserCapabilitiesWithWildcardOptInAndOlderOPA(t *testing.T) {
+
+	src := `
+		package test
+
+		import future.keywords
+
+		p {
+			1 in [3,2,1]
+		}
+	`
+	var opts ParserOptions
+	opts.Capabilities = &Capabilities{}
+
+	_, err := ParseModuleWithOpts("test.rego", src, opts)
+	if err == nil {
+		t.Fatal("expected error")
+	} else if errs, ok := err.(Errors); !ok || len(errs) != 1 {
+		t.Fatal("expected exactly one error but got:", err)
+	} else if errs[0].Code != ParseErr || errs[0].Location.Row != 7 || errs[0].Message != "unexpected ident token: expected \\n or ; or }" {
+		t.Fatal("unexpected error:", err)
+	}
+}

--- a/ast/parser_ext.go
+++ b/ast/parser_ext.go
@@ -563,12 +563,11 @@ func ParseStatementsWithOpts(filename, input string, popts ParserOptions) ([]Sta
 	parser := NewParser().
 		WithFilename(filename).
 		WithReader(bytes.NewBufferString(input)).
+		WithProcessAnnotation(popts.ProcessAnnotation).
 		WithFutureKeywords(popts.FutureKeywords...).
-		WithAllFutureKeywords(popts.AllFutureKeywords)
+		WithAllFutureKeywords(popts.AllFutureKeywords).
+		WithCapabilities(popts.Capabilities)
 
-	if popts.ProcessAnnotation {
-		parser.WithProcessAnnotation(popts.ProcessAnnotation)
-	}
 	stmts, comments, errs := parser.Parse()
 
 	if len(errs) > 0 {

--- a/capabilities.json
+++ b/capabilities.json
@@ -3586,6 +3586,9 @@
       }
     }
   ],
+  "future_keywords": [
+    "in"
+  ],
   "wasm_abi_versions": [
     {
       "version": 1,


### PR DESCRIPTION
This commit updates the capabilities structure to include the set of
supported future keywords and enhances the parser to accept the
capabilities structure so that callers can restrict what keywords can
be opted into in the first place. This ensures that callers can verify
that policies will parse for a particular version of OPA.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/main/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/main/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
