### PR TITLE
Add an adaptive limit for the upload chunk size

### DIFF
--- a/plugins/logs/encoder_test.go
+++ b/plugins/logs/encoder_test.go
@@ -5,8 +5,11 @@
 package logs
 
 import (
+	"fmt"
 	"testing"
 	"time"
+
+	"github.com/open-policy-agent/opa/metrics"
 )
 
 func TestChunkEncoder(t *testing.T) {
@@ -46,6 +49,103 @@ func TestChunkEncoder(t *testing.T) {
 	bs, err = enc.Flush()
 	if bs != nil || err != nil {
 		t.Fatalf("Unexpected error chunk produced: err: %v", err)
+
+	}
+}
+
+func TestChunkEncoderAdaptive(t *testing.T) {
+
+	enc := newChunkEncoder(1000).WithMetrics(metrics.New())
+	var result interface{} = false
+	var expInput interface{} = map[string]interface{}{"method": "GET"}
+	ts, err := time.Parse(time.RFC3339Nano, "2018-01-01T12:00:00.123456Z")
+	if err != nil {
+		panic(err)
 	}
 
+	var chunks [][]byte
+	numEvents := 400
+	for i := 0; i < numEvents; i++ {
+
+		bundles := map[string]BundleInfoV1{}
+		bundles["authz"] = BundleInfoV1{Revision: fmt.Sprint(i)}
+
+		event := EventV1{
+			Labels: map[string]string{
+				"id":  "test-instance-id",
+				"app": "example-app",
+			},
+			Bundles:     bundles,
+			DecisionID:  fmt.Sprint(i),
+			Path:        "foo/bar",
+			Input:       &expInput,
+			Result:      &result,
+			RequestedBy: "test",
+			Timestamp:   ts,
+		}
+
+		chunk, err := enc.Write(event)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if chunk != nil {
+			chunks = append(chunks, chunk...)
+		}
+	}
+
+	// decode the chunks and check the number of events is equal to the encoded events
+
+	numEventsActual := decodeChunks(t, chunks)
+
+	// flush the encoder
+	for {
+		bs, err := enc.Flush()
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		if len(bs) == 0 {
+			break
+		}
+
+		numEventsActual += decodeChunks(t, bs)
+	}
+
+	if numEvents != numEventsActual {
+		t.Fatalf("Expected %v events but got %v", numEvents, numEventsActual)
+	}
+
+	actualScaleUpEvents := enc.metrics.Counter(encSoftLimitScaleUpCounterName).Value().(uint64)
+	actualScaleDownEvents := enc.metrics.Counter(encSoftLimitScaleDownCounterName).Value().(uint64)
+	actualEquiEvents := enc.metrics.Counter(encSoftLimitStableCounterName).Value().(uint64)
+
+	expectedScaleUpEvents := uint64(8)
+	expectedScaleDownEvents := uint64(3)
+	expectedEquiEvents := uint64(0)
+
+	if actualScaleUpEvents != expectedScaleUpEvents {
+		t.Fatalf("Expected scale up events %v but got %v", expectedScaleUpEvents, actualScaleUpEvents)
+	}
+
+	if actualScaleDownEvents != expectedScaleDownEvents {
+		t.Fatalf("Expected scale down events %v but got %v", expectedScaleDownEvents, actualScaleDownEvents)
+	}
+
+	if actualEquiEvents != expectedEquiEvents {
+		t.Fatalf("Expected equilibrium events %v but got %v", expectedEquiEvents, actualEquiEvents)
+	}
+}
+
+func decodeChunks(t *testing.T, bs [][]byte) int {
+	t.Helper()
+
+	numEvents := 0
+	for _, chunk := range bs {
+		events, err := newChunkDecoder(chunk).decode()
+		if err != nil {
+			t.Fatal(err)
+		}
+		numEvents += len(events)
+	}
+	return numEvents
 }


### PR DESCRIPTION
This commit adds a chunk adaptive limit that acts as a
    measure for encoding as many decisions into each chunk as possible.
    This change should help fill-up the chunks close to their allowed
    limit and thereby help reduce netwrok and memory resources.

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/main/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/main/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
