### PR TITLE
internal/ir: Remove unused MakeNumberFloatStmt

### DIFF
--- a/internal/compiler/wasm/wasm.go
+++ b/internal/compiler/wasm/wasm.go
@@ -52,7 +52,6 @@ const (
 	opaNull              = "opa_null"
 	opaBoolean           = "opa_boolean"
 	opaNumberInt         = "opa_number_int"
-	opaNumberFloat       = "opa_number_float"
 	opaNumberRef         = "opa_number_ref"
 	opaNumberSize        = "opa_number_size"
 	opaArrayWithCap      = "opa_array_with_cap"
@@ -1111,10 +1110,6 @@ func (c *Compiler) compileBlock(block *ir.Block) ([]instruction.Instruction, err
 			instrs = append(instrs, instruction.BrIf{Index: 0})
 		case *ir.MakeNullStmt:
 			instrs = append(instrs, instruction.Call{Index: c.function(opaNull)})
-			instrs = append(instrs, instruction.SetLocal{Index: c.local(stmt.Target)})
-		case *ir.MakeNumberFloatStmt:
-			instrs = append(instrs, instruction.F64Const{Value: stmt.Value})
-			instrs = append(instrs, instruction.Call{Index: c.function(opaNumberFloat)})
 			instrs = append(instrs, instruction.SetLocal{Index: c.local(stmt.Target)})
 		case *ir.MakeNumberIntStmt:
 			instrs = append(instrs, instruction.I64Const{Value: stmt.Value})

--- a/internal/ir/ir.go
+++ b/internal/ir/ir.go
@@ -315,15 +315,6 @@ type MakeNullStmt struct {
 	Location
 }
 
-// MakeNumberFloatStmt constructs a local variable that refers to a
-// floating-point number value.
-type MakeNumberFloatStmt struct {
-	Value  float64
-	Target Local
-
-	Location
-}
-
 // MakeNumberIntStmt constructs a local variable that refers to an integer value.
 type MakeNumberIntStmt struct {
 	Value  int64


### PR DESCRIPTION
I was reviewing the IR statements and noticed this one is no longer in use so we can remove it.

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/main/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/main/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
