### PR TITLE
topdown/eval: conflict errors in functions when output not captured

### DIFF
--- a/test/cases/testdata/functionerrors/test-functionerrors-1012.yaml
+++ b/test/cases/testdata/functionerrors/test-functionerrors-1012.yaml
@@ -15,3 +15,18 @@ cases:
   query: data.test1.r = x
   want_error: functions must not produce multiple outputs for same inputs
   want_error_code: eval_conflict_error
+- data:
+  modules:
+  - |
+    package test
+
+    f(_) = true
+    f(_) = false
+
+    r {
+      data.test.f(1)
+    }
+  note: functionerrors/function output conflict, used as boolean
+  query: data.test.r = x
+  want_error: functions must not produce multiple outputs for same inputs
+  want_error_code: eval_conflict_error

--- a/topdown/eval.go
+++ b/topdown/eval.go
@@ -1701,6 +1701,9 @@ func (e evalFunc) evalOneRule(iter unifyIterator, rule *ast.Rule, cacheKey ast.R
 
 			if len(rule.Head.Args) == len(e.terms)-1 {
 				if result.Value.Compare(ast.Boolean(false)) == 0 {
+					if prev != nil && ast.Compare(prev, result) != 0 {
+						return functionConflictErr(rule.Location)
+					}
 					return nil
 				}
 			}


### PR DESCRIPTION
With func1.rego as

    package test
    r(x) {
      data.test.q(x)
    }
    q(_) = true
    q(_) = false

Before:

    $ opa eval -fpretty -d func1.rego 'data.test.r(1)'
    true

After:

    $ opa eval -fpretty -d func1.rego 'data.test.r(1)'
    1 error occurred: func1.rego:12: eval_conflict_error: functions must not produce multiple outputs for same inputs

Fixes #3912.

Signed-off-by: Stephan Renatus <stephan.renatus@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/main/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/main/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
