### PR TITLE
docs/website: add warning to 'http.send' docs

### DIFF
--- a/docs/content/extensions.md
+++ b/docs/content/extensions.md
@@ -170,6 +170,12 @@ The implementation is careful to use the context passed to the built-in function
 when executing the HTTP request. See the appendix at the end of this page for
 the complete example.
 
+{{% danger %}}
+Custom built-in functions <strong>must not</strong> be used for effecting changes in
+external systems as OPA does not guarantee that the statement will be executed due
+to automatic performance optimizations that are applied during policy evaluation.
+{{% /danger %}}
+
 ## Custom Plugins for OPA Runtime
 
 Read this section if you want to customize or extend the OPA runtime/executable

--- a/docs/content/policy-reference.md
+++ b/docs/content/policy-reference.md
@@ -877,6 +877,12 @@ org_chart_permissions[entity_name]
 | ------- |-------------|---------------|
 | <span class="opa-keep-it-together">``response := http.send(request)``</span> | ``http.send`` executes an HTTP `request` and returns a `response`. | ``SDK-dependent`` |
 
+{{% danger %}}
+This built-in function <strong>must not</strong> be used for effecting changes in
+external systems as OPA does not guarantee that the statement will be executed due
+to automatic performance optimizations that are applied during policy evaluation.
+{{% /danger %}}
+
 The `request` object parameter may contain the following fields:
 
 | Field | Required | Type | Description |

--- a/docs/website/layouts/shortcodes/danger.html
+++ b/docs/website/layouts/shortcodes/danger.html
@@ -1,0 +1,10 @@
+<article class="message is-danger">
+    {{ if .Get 0 }}
+    <div class="message-header">
+        <p>{{ .Get 0 }}</p>
+    </div>
+    {{ end }}
+    <div class="message-body">
+        {{ .Inner }}
+    </div>
+</article>


### PR DESCRIPTION
Fixes #3893.
![image](https://user-images.githubusercontent.com/870638/138695807-3b2dd6bf-602e-4462-9cae-7419cc446c20.png)