### PR TITLE
types: Fix Arity function to return zero when type is known

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -468,18 +468,21 @@ func Args(x ...Type) []Type {
 }
 
 // Void returns true if the function has no return value. This function returns
-// false if tpe is not a function.
+// false if x is not a function.
 func Void(x Type) bool {
 	f, ok := x.(*Function)
 	return ok && f.Result() == nil
 }
 
-// Arity returns the number of arguments in the function signature. This
-// function returns -1 if tpe is not a function.
+// Arity returns the number of arguments in the function signature or zero if x
+// is not a function. If the type is unknown, this function returns -1.
 func Arity(x Type) int {
+	if x == nil {
+		return -1
+	}
 	f, ok := x.(*Function)
 	if !ok {
-		return -1
+		return 0
 	}
 	return len(f.FuncArgs().Args)
 }


### PR DESCRIPTION
This commit updates the Arity function to return zero if the type is
known and -1 if the type is unknown. This makes the Arity function
behave the same as the GetArity function on the compiler which was
used for similar purposes.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/main/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/main/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
