### PR TITLE
ast/parser/ParseRuleFromExpr: ignore Calls

### DIFF
--- a/ast/parser_ext.go
+++ b/ast/parser_ext.go
@@ -188,7 +188,7 @@ func ParseRuleFromExpr(module *Module, expr *Expr) (*Rule, error) {
 	}
 
 	if _, ok := BuiltinMap[expr.Operator().String()]; ok {
-		return nil, fmt.Errorf("rule name conflicts with built-in function")
+		return nil, nil
 	}
 
 	return ParseRuleFromCallExpr(module, expr.Terms.([]*Term))
@@ -609,7 +609,7 @@ func parseModule(filename string, stmts []Statement, comments []*Comment) (*Modu
 			rule, err := ParseRuleFromBody(mod, stmt)
 			if err != nil {
 				errs = append(errs, NewError(ParseErr, stmt[0].Location, err.Error()))
-			} else {
+			} else if rule != nil {
 				mod.Rules = append(mod.Rules, rule)
 
 				// NOTE(tsandall): the statement should now be interpreted as a

--- a/ast/parser_test.go
+++ b/ast/parser_test.go
@@ -1871,7 +1871,6 @@ func TestModuleParseErrors(t *testing.T) {
 	x = 1			# expect package
 	package a  		# unexpected package
 	1 = 2			# non-var head
-	1 != 2			# non-equality expr
 	x = y; x = 1    # multiple exprs
 	`
 
@@ -1882,11 +1881,11 @@ func TestModuleParseErrors(t *testing.T) {
 
 	errs, ok := err.(Errors)
 	if !ok {
-		panic("unexpected error value")
+		t.Fatalf("unexpected error value: %v", err)
 	}
 
-	if len(errs) != 5 {
-		t.Fatalf("Expected exactly 5 errors but got: %v", err)
+	if exp, act := 4, len(errs); exp != act {
+		t.Errorf("Expected exactly %d errors but got %d: %v", exp, act, errs)
 	}
 }
 
@@ -2080,7 +2079,6 @@ data = {"bar": 2}`
 	eq(x)`
 
 	assertParseModuleError(t, "multiple expressions", multipleExprs)
-	assertParseModuleError(t, "non-equality", nonEquality)
 	assertParseModuleError(t, "non-var name", nonVarName)
 	assertParseModuleError(t, "with expr", withExpr)
 	assertParseModuleError(t, "bad ref (too long)", badRefLen1)
@@ -2106,6 +2104,11 @@ data = {"bar": 2}`
 	}); err == nil {
 		t.Fatal("expected error for unknown expression term type")
 	}
+
+	assertParseModule(t, "non-equality", nonEquality, &Module{
+		Package: MustParseStatement(`package a.b.c`).(*Package),
+		Rules:   []*Rule{},
+	})
 }
 
 func TestWildcards(t *testing.T) {


### PR DESCRIPTION
Consider the following example:

    package p
    in(set, elem) {
      _ = set[elem]
    }
    in({3}, 4)

Up until the latest release (inclusive), the last line would have been
parsed as a shorthand for

    in({3}, 4) = true { true }

With the introduction of the `in` operator, the naked call of line 5 started
raising an error:

    rego_parse_error: rule name conflicts with built-in function

Similar things happen to top-level calls to `print("whatever")`.

Arguably, those extra rule bodies never did what the user intended in the
first place: assert something -- they haven't been inside of a rule body.

With this change, calls like these are simply ignored, and stripped out by
calls to `opa fmt`.

Note that it only applies to calls to existing built-in functions. You are
still able to use shorthand notation for declaring facts, like

    fruit("apple")
    fruit("banana")

