### PR TITLE
nightly: dump fuzzer's crashers to stdout

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -35,6 +35,10 @@ jobs:
       - name: Run go-fuzz
         run: make ci-go-check-fuzz
 
+      - name: Dump crashers
+        if: ${{ failure() }}
+        run: find build/fuzzer/workdir/crashers -name '*.quoted' -print -exec cat {} \;
+
       - name: Upload Workdir
         if: ${{ failure() }}
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
For a week or so, we haven't been able to inspect nightly fuzzer failures because the upload-artifact had failed.

This change is trying to get another look at the output: just dump the crashers in quoted form to stdout.

Not solving the root issue yet, but at least we perhaps get a look at the failures. They're somewhat spurious, so I want to avoid loosing more of them.