### PR TITLE
topdown/eval: special-case 'in' calls to avoid plugging args

### DIFF
--- a/ast/term.go
+++ b/ast/term.go
@@ -1489,10 +1489,7 @@ func (s *set) Reduce(i *Term, f func(*Term, *Term) (*Term, error)) (*Term, error
 	err := s.Iter(func(x *Term) error {
 		var err error
 		i, err = f(i, x)
-		if err != nil {
-			return err
-		}
-		return nil
+		return err
 	})
 	return i, err
 }


### PR DESCRIPTION
The way this was done before, the evaluator had to plug the function
arguments, including the collection, in full, to evaluate them as is
usually done with other functions.

Introducing the special case, and the thunk-y plugNamespaced-variant,
we can avoid that: when evaluating the `x in xs` and `x, y in xs`
calls, the evaluator will plug and compare the collection element
(pairs) one-by-one.

One optimization still left open is that the keys are plugged for
objects, even if the call is for `x in obj` and it could thus be
avoided.

-------

Half of #3948.