### PR TITLE
runtime: Fix logging configuration

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -68,7 +68,7 @@ func checkOPAUpdate(out io.Writer) error {
 		return err
 	}
 
-	reporter, err := report.New(id)
+	reporter, err := report.New(id, report.Options{})
 	if err != nil {
 		return err
 	}

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/open-policy-agent/opa/keys"
+	"github.com/open-policy-agent/opa/logging"
 
 	"os"
 	"time"
@@ -52,8 +53,13 @@ type ReleaseDetails struct {
 	OPAUpToDate   bool   `json:"opa_up_to_date,omitempty"` // is running OPA version greater than or equal to the latest released
 }
 
+// Options supplies parameters to the reporter.
+type Options struct {
+	Logger logging.Logger
+}
+
 // New returns an instance of the Reporter
-func New(id string) (*Reporter, error) {
+func New(id string, opts Options) (*Reporter, error) {
 	r := Reporter{}
 	r.body = map[string]string{
 		"id":      id,
@@ -69,7 +75,7 @@ func New(id string) (*Reporter, error) {
 		"url": %q,
 	}`, url))
 
-	client, err := rest.New(restConfig, map[string]*keys.Config{})
+	client, err := rest.New(restConfig, map[string]*keys.Config{}, rest.Logger(opts.Logger))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -18,7 +18,7 @@ import (
 func TestNewReportDefaultURL(t *testing.T) {
 	os.Unsetenv("OPA_TELEMETRY_SERVICE_URL")
 
-	reporter, err := New("")
+	reporter, err := New("", Options{})
 	if err != nil {
 		t.Fatalf("Unexpected error %v", err)
 	}
@@ -37,7 +37,7 @@ func TestSendReportBadRespStatus(t *testing.T) {
 
 	os.Setenv("OPA_TELEMETRY_SERVICE_URL", baseURL)
 
-	reporter, err := New("")
+	reporter, err := New("", Options{})
 	if err != nil {
 		t.Fatalf("Unexpected error %v", err)
 	}
@@ -62,7 +62,7 @@ func TestSendReportDecodeError(t *testing.T) {
 
 	os.Setenv("OPA_TELEMETRY_SERVICE_URL", baseURL)
 
-	reporter, err := New("")
+	reporter, err := New("", Options{})
 	if err != nil {
 		t.Fatalf("Unexpected error %v", err)
 	}
@@ -88,7 +88,7 @@ func TestSendReportWithOPAUpdate(t *testing.T) {
 
 	os.Setenv("OPA_TELEMETRY_SERVICE_URL", baseURL)
 
-	reporter, err := New("")
+	reporter, err := New("", Options{})
 	if err != nil {
 		t.Fatalf("Unexpected error %v", err)
 	}


### PR DESCRIPTION
This commit updates the runtime to pass the logger to the plugin
manager and the reporter. In addition, the reporter is updated to pass
the logger into the rest client that it creates. With this change, we
no longer rely on the global logger and the logging configuration is
applied correctly.

To verify that this change is going to fix the problem, I have
searched for references to logrus and the logging package.

Grepping for references to logrus reveals that outside of the logging
package, we only refer to formatters and fields (never the global
logrus logger directly).

Grepping for references to logging.{New, Get, NewStandardLogger}
shows that we only create new loggers if one has not been injected
into the manager or rest client. Since we are passing/injecting the
logger from the runtime, I am fairly confident this will fix the
underlying issue.

Fixes #3958

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/main/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/main/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
