### PR TITLE
ast: Fix print call rewriting for calls in head

### DIFF
--- a/ast/compile.go
+++ b/ast/compile.go
@@ -1341,8 +1341,8 @@ func (c *Compiler) rewritePrintCalls() {
 	}
 	for _, name := range c.sorted {
 		mod := c.Modules[name]
-		WalkRules(mod, func(rule *Rule) bool {
-			for _, err := range rewritePrintCalls(c.localvargen, c.GetArity, ReservedVars, rule.Body) {
+		WalkBodies(mod, func(b Body) bool {
+			for _, err := range rewritePrintCalls(c.localvargen, c.GetArity, ReservedVars, b) {
 				c.err(err)
 			}
 			return false

--- a/ast/compile_test.go
+++ b/ast/compile_test.go
@@ -2964,6 +2964,15 @@ func TestCompilerRewritePrintCallsErasure(t *testing.T) {
 
 			p { {"x": 1 | false} } `,
 		},
+		{
+			note: "in head",
+			module: `package test
+
+			p = {1 | print("x")}`,
+			exp: `package test
+
+			p = __local0__ { true; __local0__ = {1 | true} }`,
+		},
 	}
 
 	for _, tc := range cases {
@@ -3090,6 +3099,18 @@ func TestCompilerRewritePrintCalls(t *testing.T) {
 			exp: `package test
 
 			p = true { split("abc", "", __local3__); __local0__ = __local3__[y]; __local4__ = {__local1__ | __local1__ = __local0__}; __local5__ = {__local2__ | __local2__ = y}; internal.print([__local4__, __local5__]) }`,
+		},
+		{
+			note: "print call in head",
+			module: `package test
+
+			p = {1 | print("x") }`,
+			exp: `package test
+
+			p = __local1__ {
+				true
+				__local1__ = {1 | __local2__ = { __local0__ | __local0__ = "x"}; internal.print([__local2__])}
+			}`,
 		},
 	}
 


### PR DESCRIPTION
The print call rewriting only worked for calls in the body of the
rule. If a call was embedded inside of a comprehension in the head of
the rule, it would not get rewritten. This change just updates the
compiler to use WalkBodies instead of WalkRules which ensures that all
ast.Body structures in the module get visited regardless of where they
are contained.

Fixes #3967

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/main/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/main/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
