### PR TITLE
capabilities: add package-level embed.FS (go 1.16+)

### DIFF
--- a/capabilities/capabilities.go
+++ b/capabilities/capabilities.go
@@ -1,0 +1,18 @@
+// Copyright 2021 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+//go:build go1.16
+// +build go1.16
+
+package capabilities
+
+import (
+	"embed"
+)
+
+// FS contains the embedded capabilities/ directory of the built version,
+// which has all the capabilities of previous versions:
+// "v0.18.0.json" contains the capabilities JSON of version v0.18.0, etc
+//go:embed *.json
+var FS embed.FS

--- a/capabilities/capabilities_test.go
+++ b/capabilities/capabilities_test.go
@@ -1,0 +1,36 @@
+// Copyright 2021 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+//go:build go1.16
+// +build go1.16
+
+package capabilities_test
+
+import (
+	"testing"
+
+	"github.com/open-policy-agent/opa/capabilities"
+	"github.com/open-policy-agent/opa/util"
+)
+
+func TestCapabilitiesEmbedded(t *testing.T) {
+	ents, err := capabilities.FS.ReadDir(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ents) == 0 {
+		t.Error("expected capabilities to be present")
+	}
+	for _, ent := range ents {
+		cont, err := capabilities.FS.ReadFile(ent.Name())
+		if err != nil {
+			t.Errorf("file %v: %v", ent.Name(), err)
+		}
+		var x interface{}
+		err = util.UnmarshalJSON(cont, &x)
+		if err != nil {
+			t.Errorf("file %v: %v", ent.Name(), err)
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-policy-agent/opa
 
-go 1.15
+go 1.16
 
 require (
 	github.com/OneOfOne/xxhash v1.2.8


### PR DESCRIPTION
Had to bump the lang directive for this, but our CI should ensure we'll
still be buildable for Go 1.15.

Fixes #3961.
