### PR TITLE
cmd,storage: fix int conversion type errors

### DIFF
--- a/ast/term.go
+++ b/ast/term.go
@@ -843,7 +843,7 @@ func PtrRef(head *Term, s string) (Ref, error) {
 		return Ref{head}, nil
 	}
 	parts := strings.Split(s, "/")
-	ref := make(Ref, len(parts)+1)
+	ref := make(Ref, uint(len(parts))+1)
 	ref[0] = head
 	for i := 0; i < len(parts); i++ {
 		var err error

--- a/cmd/eval.go
+++ b/cmd/eval.go
@@ -689,7 +689,7 @@ func (f *intFlag) String() string {
 }
 
 func (f *intFlag) Set(s string) error {
-	v, err := strconv.ParseInt(s, 0, 64)
+	v, err := strconv.ParseInt(s, 0, 32)
 	f.v = int(v)
 	f.isSet = true
 	return err

--- a/cmd/oracle.go
+++ b/cmd/oracle.go
@@ -147,9 +147,7 @@ func dofindDefinition(params findDefinitionParams, stdin io.Reader, stdout io.Wr
 }
 
 func parseFilenameOffset(s string) (string, int, error) {
-	if strings.HasPrefix(s, "file://") {
-		s = strings.TrimPrefix(s, "file://")
-	}
+	s = strings.TrimPrefix(s, "file://")
 
 	parts := strings.Split(s, ":")
 	if len(parts) != 2 {
@@ -163,7 +161,7 @@ func parseFilenameOffset(s string) (string, int, error) {
 		str = parts[1][2:]
 	}
 
-	offset, err := strconv.ParseInt(str, base, 64)
+	offset, err := strconv.ParseInt(str, base, 32)
 	if err != nil {
 		return "", 0, err
 	}

--- a/internal/oracle/oracle.go
+++ b/internal/oracle/oracle.go
@@ -56,8 +56,11 @@ func (o *Oracle) FindDefinition(q DefinitionQuery) (*DefinitionQueryResult, erro
 	if err != nil {
 		return nil, err
 	}
-
-	stack := findContainingNodeStack(compiler.Modules[q.Filename], q.Pos)
+	mod, ok := compiler.Modules[q.Filename]
+	if !ok {
+		return nil, ErrNoMatchFound
+	}
+	stack := findContainingNodeStack(mod, q.Pos)
 	if len(stack) == 0 {
 		return nil, ErrNoMatchFound
 	}

--- a/storage/path.go
+++ b/storage/path.go
@@ -125,7 +125,7 @@ func (p Path) Ref(head *ast.Term) (ref ast.Ref) {
 	ref = make(ast.Ref, len(p)+1)
 	ref[0] = head
 	for i := range p {
-		idx, err := strconv.ParseInt(p[i], 10, 64)
+		idx, err := strconv.ParseInt(p[i], 10, 32)
 		if err == nil {
 			ref[i+1] = ast.IntNumberTerm(int(idx))
 		} else {


### PR DESCRIPTION
Also fixes a panic in `opa oracle find-definition file:12` is file
didn't exit.
