### PR TITLE
ci: Tweak the post-tag workflow

### DIFF
--- a/.github/workflows/post-tag.yaml
+++ b/.github/workflows/post-tag.yaml
@@ -81,10 +81,6 @@ jobs:
         # Subsequent jobs will be have the computed tag name
         run: echo "TAG_NAME=${GITHUB_REF##*/}" >> $GITHUB_ENV
 
-      - name: Test
-        run: make ci-release-test
-        timeout-minutes: 60
-
       - name: Download release binaries
         uses: actions/download-artifact@v2
         with:
@@ -105,4 +101,4 @@ jobs:
         env:
           # Required for the `hub` CLI
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./build/github-release.sh --asset-dir=./_release/${TAG_NAME#v}/ --tag=${TAG_NAME}
+        run: ./build/github-release.sh --asset-dir=$(make release-dir) --tag=${TAG_NAME}

--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,10 @@ all: build test perf wasm-sdk-e2e-test check
 version:
 	@echo $(VERSION)
 
+.PHONY: release-dir
+release-dir:
+	@echo $(RELEASE_DIR)
+
 .PHONY: generate
 generate: wasm-lib-build
 	$(GO) generate


### PR DESCRIPTION
* Do not run ci-release-tag target--the tests have already been run
  pre-merge and post-merge so there is little reason to run them again
  post-tag. The only thing this would do is find non-deterministic
  test failures--which begs the question: what do we do with the
  release? We already run tests pre-merge, post-merge, and nightly so
  it's unlikely that post-tag will help improve quality.

* Use the RELEASE_DIR from the makefile for the `hub release` asset
  parameter rather than assuming the TAG <=> RELEASE_DIR (this is not
  always true if tagging an arbitrary commit.) This enables us to cut
  release candidates without commiting changes to the repo.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/main/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/main/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
