### PR TITLE
Bump website to hugo 0.88.1

### DIFF
--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -387,12 +387,12 @@ keys:
     private_key: ${BUNDLE_SERVICE_SIGNING_KEY}
 ```
 
-{{% danger %}}
-OPA masks services authentication secrets which make use of the <code>credentials</code> field, in order to prevent the exposure of sensitive tokens.
-It is important to note that the <a href="../rest-api/#config-api">/v1/config API</a> allows clients to read the runtime configuration of OPA. As such, any credentials used by
+{{< danger >}}
+OPA masks services authentication secrets which make use of the `credentials` field, in order to prevent the exposure of sensitive tokens.
+It is important to note that the [/v1/config API](../rest-api/#config-api) allows clients to read the runtime configuration of OPA. As such, any credentials used by
 custom configurations not utilizing the credentials field will be exposed to the caller.
 Consider requiring authentication in order to prevent unauthorized read access to OPA's runtime configuration.
-{{% /danger %}}
+{{< /danger >}}
 
 #### AWS Signature
 

--- a/docs/content/extensions.md
+++ b/docs/content/extensions.md
@@ -12,14 +12,14 @@ to customize and extend OPA in different ways.
 
 Read this section if you want to extend OPA with custom built-in functions.
 
-{{% info %}}
+{{< info >}}
 This section assumes you are embedding OPA as a library and executing policies
-via the <code>github.com/open-policy-agent/opa/rego</code> package. If you are NOT embedding OPA
+via the `github.com/open-policy-agent/opa/rego` package. If you are NOT embedding OPA
 as a library and instead want to customize the OPA runtime, read this section
 anyway because it provides useful information on implementing built-in functions.
 For a complete example that shows how to add custom built-in functions to the
-OPA runtime, see the <a href="#adding-built-in-functions-to-the-opa-runtime">Adding Built-in Functions to the OPA Runtime</a> appendix.
-{{% /info %}}
+OPA runtime, see the [Adding Built-in Functions to the OPA Runtime](#adding-built-in-functions-to-the-opa-runtime) appendix.
+{{< /info >}}
 
 OPA supports built-in functions for simple operations like string manipulation
 and arithmetic as well as more complex operations like JWT verification and
@@ -120,12 +120,12 @@ built-in functions to avoid collisions. This declaration indicates the function
 accepts two strings and returns a value of type `any`. The `any` type is the
 union of all types in Rego.
 
-{{% info %}}
-<code>types.S</code> and <code>types.A</code> are shortcuts for constructing Rego types. If you need
+{{< info >}}
+`types.S` and `types.A` are shortcuts for constructing Rego types. If you need
 to define use-case specific types (e.g., a list of objects that have fields
-<code>foo</code>, <code>bar</code>, and <code>baz</code>, you will need to construct them using the <code>types</code>
+`foo`, `bar`, and `baz`, you will need to construct them using the `types`
 packages APIs.)
-{{% /info %}}
+{{< /info >}}
 
 The declaration also sets `rego.Function#Memoize` to true to enable memoization
 across multiple calls in the same query. If your built-in function performs I/O,
@@ -174,11 +174,11 @@ The implementation is careful to use the context passed to the built-in function
 when executing the HTTP request. See the appendix at the end of this page for
 the complete example.
 
-{{% danger %}}
-Custom built-in functions <strong>must not</strong> be used for effecting changes in
+{{< danger >}}
+Custom built-in functions **must not** be used for effecting changes in
 external systems as OPA does not guarantee that the statement will be executed due
 to automatic performance optimizations that are applied during policy evaluation.
-{{% /danger %}}
+{{< /danger >}}
 
 ## Custom Plugins for OPA Runtime
 
@@ -202,9 +202,9 @@ inside your main function.
 The plugin may (optionally) report its current status to the plugin Manager via the `plugins.Manager#UpdatePluginStatus`
 API.
 
-{{% info %}}
+{{< info >}}
 If no status is provided the plugin is assumed to be working OK.
-{{% /info %}}
+{{< /info >}}
 
 Typically the plugin should report `StatusNotReady` at creation time and update to `StatusOK` (or `StatusErr`) when
 appropriate.
@@ -352,11 +352,11 @@ log event written to stdout.
 The source code for this example can be found
 [here](https://github.com/open-policy-agent/contrib/tree/main/decision_logger_plugin_example).
 
-{{% info %}}
-If there is a mask policy set (see <a href="../management-decision-logs">Decision Logger</a>
-for details) the <code>Event</code> received by the
-demo plugin will potentially be different than the example documented.
-{{% /info %}}
+{{< info >}}
+If there is a mask policy set (see [Decision Logger](../management-decision-logs)
+for details) the `Event` received by the demo plugin will potentially be different
+than the example documented.
+{{< /info >}}
 
 ## Setting the OPA Runtime Version
 

--- a/docs/content/policy-reference.md
+++ b/docs/content/policy-reference.md
@@ -877,11 +877,11 @@ org_chart_permissions[entity_name]
 | ------- |-------------|---------------|
 | <span class="opa-keep-it-together">``response := http.send(request)``</span> | ``http.send`` executes an HTTP `request` and returns a `response`. | ``SDK-dependent`` |
 
-{{% danger %}}
-This built-in function <strong>must not</strong> be used for effecting changes in
+{{< danger >}}
+This built-in function **must not** be used for effecting changes in
 external systems as OPA does not guarantee that the statement will be executed due
 to automatic performance optimizations that are applied during policy evaluation.
-{{% /danger %}}
+{{< /danger >}}
 
 The `request` object parameter may contain the following fields:
 

--- a/docs/website/config.toml
+++ b/docs/website/config.toml
@@ -13,6 +13,11 @@ pygmentsGuessSyntax = true
 # the are loaded via shortcode helpers.
 ignorefiles = [ "/docs/v.*/code/.*" ]
 
+[markup]
+[markup.goldmark]
+[markup.goldmark.renderer]
+unsafe = true
+
 [params]
 description = "Policy-based control for cloud native environments"
 tagline = "Empower your administrators with flexible, fine-grained control across your entire stack."

--- a/docs/website/layouts/partials/docs/navbar-section.html
+++ b/docs/website/layouts/partials/docs/navbar-section.html
@@ -11,7 +11,8 @@
 
 {{ end }}
 
-{{ if (ne ($scratch.Get "sectionsForVersion") nil) and (gt (len ($scratch.Get "sectionsForVersion")) 0) }}
+{{ if ne ($scratch.Get "sectionsForVersion") nil }}
+{{ if gt (len ($scratch.Get "sectionsForVersion")) 0 }}
 
 <br />
 
@@ -23,4 +24,5 @@
 {{ partial "docs/navbar-link.html" (dict "ctx" . "pageUrl" $pageUrl "version" $version) }}
 {{ end }}
 
+{{ end }}
 {{ end }}

--- a/docs/website/layouts/partials/docs/sidenav-section.html
+++ b/docs/website/layouts/partials/docs/sidenav-section.html
@@ -11,7 +11,8 @@
 
 {{ end }}
 
-{{ if (ne ($scratch.Get "sectionsForVersion") nil) and (gt (len ($scratch.Get "sectionsForVersion")) 0) }}
+{{ if ne ($scratch.Get "sectionsForVersion") nil }}
+{{ if gt (len ($scratch.Get "sectionsForVersion")) 0 }}
 
 <hr class="docs-nav-hr" />
 
@@ -23,4 +24,5 @@
 {{ partial "docs/sidenav-link.html" (dict "ctx" . "pageUrl" $pageUrl "version" $version) }}
 {{ end }}
 
+{{ end }}
 {{ end }}

--- a/docs/website/layouts/shortcodes/danger.html
+++ b/docs/website/layouts/shortcodes/danger.html
@@ -1,10 +1,5 @@
 <article class="message is-danger">
-    {{ if .Get 0 }}
-    <div class="message-header">
-        <p>{{ .Get 0 }}</p>
-    </div>
-    {{ end }}
-    <div class="message-body">
-        {{ .Inner }}
-    </div>
+<div class="message-body">
+{{ .Inner | markdownify }}
+</div>
 </article>

--- a/docs/website/layouts/shortcodes/info.html
+++ b/docs/website/layouts/shortcodes/info.html
@@ -1,10 +1,5 @@
 <article class="message is-info">
-    {{ if .Get 0 }}
-    <div class="message-header">
-        <p>{{ .Get 0 }}</p>
-    </div>
-    {{ end }}
-    <div class="message-body">
-        {{ .Inner }}
-    </div>
+<div class="message-body">
+{{ .Inner | markdownify }}
+</div>
 </article>

--- a/docs/website/scripts/live-blocks/src/preprocess/index.js
+++ b/docs/website/scripts/live-blocks/src/preprocess/index.js
@@ -103,7 +103,12 @@ function constructGroups($, codeElts) {
   codeElts.each(function () { // Cheerio's `each` method (codeElts is not iterable).
     try {
       const codeElt = $(this)
-      const container = codeElt.parent().parent()
+      // remove trailing newline
+      codeElt.text(codeElt.text().trim())
+
+      // wrap in div
+      const container = $('<div></div>').addClass(CLASSES.BLOCK_CONTAINER)
+      codeElt.parent().wrap(container)
 
       const label = codeElt.data('lang')
       let info = infoFromLabel(label)
@@ -154,10 +159,6 @@ function constructGroups($, codeElts) {
 function styleBlocks(groups) {
   for (let group of Object.values(groups)) {
     for (let [type, block] of Object.entries(group)) {
-      // Add container class, remove hugo highlight class
-      block.container.addClass(CLASSES.BLOCK_CONTAINER)
-      block.container.removeClass(CLASSES.HUGO_BLOCK_CONTAINER)
-
       // Reset highlighting
       const content = block.get()
       block.codeElt.empty()

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@ publish = "docs/website/public"
 command = "make netlify-prod WASM_ENABLED=0 CGO_ENABLED=0"
 
 [build.environment]
-HUGO_VERSION = "0.55.5"
+HUGO_VERSION = "0.88.1"
 
 [context.deploy-preview]
 command = "make netlify-preview WASM_ENABLED=0 CGO_ENABLED=0"


### PR DESCRIPTION
For some reason, the "and" trick to step around undefined values no longer
worked. So now, we're wrapping {{ if }} conditionals instead: the outer one
checks that the value is defined, the inner one asserts something on its
value.

Somewhere between 0.55 and the most recent version, Hugo stopped emitting
that div on purpose for languages it didn't know.

Since we depend on it for further processing, we're adding it back.

Also, a trailing newline for code elements was introduced, and that broke
our codemirrors integration -- every code entry would be folllowed by an
empty line. Now, we're removing that in the same preprocess step.

Fixes #3787.