### PR TITLE
website/load-docs: skip first, check later

### DIFF
--- a/docs/website/scripts/load-docs.sh
+++ b/docs/website/scripts/load-docs.sh
@@ -27,15 +27,6 @@ PREV_MINOR_VER="-1"
 for release in ${ALL_RELEASES}; do
     CUR_SEM_VER=${release#"v"}
 
-    # ignore if the tag if there is no corresponding OPA binary available on the GitHub Release page
-    BINARY_URL=https://github.com/open-policy-agent/opa/releases/download/${release}/opa_linux_amd64
-    curl_exit_code=0
-    curl --silent --location --head --fail $BINARY_URL >/dev/null || curl_exit_code=$?
-    if [[ $curl_exit_code -ne 0 ]]; then
-        echo "WARNING: skipping $release because $BINARY_URL does not exist (or GET failed...)"
-        continue
-    fi
-
     # ignore any release candidate versions, for now if they
     # are the "latest" they'll be documented under "edge"
     if [[ "${CUR_SEM_VER}" == *"rc"* ]]; then
@@ -51,6 +42,15 @@ for release in ${ALL_RELEASES}; do
     if [[ (${CUR_MAJOR_VER} -lt 0) || \
             (${CUR_MAJOR_VER} -le 0 && ${CUR_MINOR_VER} -lt 11) || \
             (${CUR_MAJOR_VER} -le 0 && ${CUR_MINOR_VER} -le 10 && ${CUR_PATCH_VER} -le 7) ]]; then
+        continue
+    fi
+
+    # ignore the tag if there is no corresponding OPA binary available on the GitHub Release page
+    BINARY_URL=https://github.com/open-policy-agent/opa/releases/download/${release}/opa_linux_amd64
+    curl_exit_code=0
+    curl --silent --location --head --fail $BINARY_URL >/dev/null || curl_exit_code=$?
+    if [[ $curl_exit_code -ne 0 ]]; then
+        echo "WARNING: skipping $release because $BINARY_URL does not exist (or GET failed...)"
         continue
     fi
 


### PR DESCRIPTION
The website deployment takes longer than it has to because we're
checking for binaries we don't really care about: those predating
the website, and those of release candidates.

Now, we'll only curl for those we don't skip.
