### PR TITLE
test/e2e: silence logs by default with test params

### DIFF
--- a/test/e2e/testing.go
+++ b/test/e2e/testing.go
@@ -45,6 +45,9 @@ func NewAPIServerTestParams() runtime.Params {
 		Format: "json-pretty",
 	}
 
+	// unless overridden, don't log from tests
+	params.Logger = logging.NewNoOpLogger()
+
 	params.GracefulShutdownPeriod = 10 // seconds
 
 	return params
@@ -78,7 +81,7 @@ func NewTestRuntimeWithOpts(opts TestRuntimeOpts, params runtime.Params) (*TestR
 	rt, err := runtime.NewRuntime(ctx, params)
 	if err != nil {
 		cancel()
-		return nil, fmt.Errorf("unable to create new runtime: %s", err)
+		return nil, fmt.Errorf("create new runtime: %w", err)
 	}
 
 	return &TestRuntime{


### PR DESCRIPTION
Some random benchmark test went down from 6s to 2s, so I have some hope that this will also reduce the time our _Go Perf_ check takes.