### PR TITLE
internal/merge: remove InterfaceMaps benchmark

### DIFF
--- a/internal/merge/merge_test.go
+++ b/internal/merge/merge_test.go
@@ -5,50 +5,11 @@
 package merge
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
 
 	"github.com/open-policy-agent/opa/util"
 )
-
-func BenchmarkInterfaceMaps(b *testing.B) {
-
-	for _, size := range []int{100, 1000, 10000} {
-
-		b.Run(fmt.Sprintf("store size %v", size), func(b *testing.B) {
-			aRaw := "{"
-			for i := 0; i < size; i++ {
-				if i != 0 {
-					aRaw += ","
-				}
-				aRaw += fmt.Sprintf(`"%v":{"a":{"b":"c","d":"e"}}`, i)
-			}
-			aRaw += "}"
-
-			aVals := map[string]interface{}{}
-			if err := util.UnmarshalJSON([]byte(aRaw), &aVals); err != nil {
-				panic(err)
-			}
-			for i := 0; i < b.N; i++ {
-				bRaw := fmt.Sprintf(`{"a%v":{"b":"c","d":"e"}}`, i)
-				bVals := map[string]interface{}{}
-				if err := util.UnmarshalJSON([]byte(bRaw), &bVals); err != nil {
-					panic(err)
-				}
-
-				b.StartTimer()
-				_, ok := InterfaceMaps(aVals, bVals)
-				b.StopTimer()
-
-				if !ok {
-					b.Fatal("merging interfaces failed")
-				}
-			}
-		})
-
-	}
-}
 
 func TestMergeDocs(t *testing.T) {
 


### PR DESCRIPTION
Due to the fiddling with StartTimer/StopTimer in the inner loop, this
test ended up taking 5 minutes, even though the time per store size was
not that bad.

After playing with [righting the wrong](https://github.com/srenatus/opa/commit/3d1d5ae5c08868b9f5bb42252bb25874d89c30a4), I've concluded that we don't
gain too much from accurate numbers here -- less so than we did when
this change was introduced originally.
