### PR TITLE
fix opt SkipPartialNamespace

### DIFF
--- a/rego/rego.go
+++ b/rego/rego.go
@@ -787,7 +787,7 @@ func ShallowInlining(yes bool) func(r *Rego) {
 // rules generated from policy. Synthetic support rules are still namespaced.
 func SkipPartialNamespace(yes bool) func(r *Rego) {
 	return func(r *Rego) {
-		r.skipPartialNamespace = true
+		r.skipPartialNamespace = yes
 	}
 }
 


### PR DESCRIPTION
Fix typo in rego option `SkipPartialNamespace` reported in https://github.com/open-policy-agent/opa/issues/3996