### PR TITLE
Expose router in plugin manager

### DIFF
--- a/plugins/plugins.go
+++ b/plugins/plugins.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/gorilla/mux"
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/bundle"
 	"github.com/open-policy-agent/opa/config"
@@ -185,6 +186,7 @@ type Manager struct {
 	serverInitializedOnce        sync.Once
 	printHook                    print.Hook
 	enablePrintStatements        bool
+	router                       *mux.Router
 }
 
 type managerContextKey string
@@ -333,6 +335,12 @@ func EnablePrintStatements(yes bool) func(*Manager) {
 func PrintHook(h print.Hook) func(*Manager) {
 	return func(m *Manager) {
 		m.printHook = h
+	}
+}
+
+func WithRouter(r *mux.Router) func(*Manager) {
+	return func(m *Manager) {
+		m.router = r
 	}
 }
 
@@ -516,6 +524,13 @@ func (m *Manager) setCompiler(compiler *ast.Compiler) {
 	m.compilerMux.Lock()
 	defer m.compilerMux.Unlock()
 	m.compiler = compiler
+}
+
+// GetRouter returns the managers router if set
+func (m *Manager) GetRouter() *mux.Router {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+	return m.router
 }
 
 // RegisterCompilerTrigger registers for change notifications when the compiler

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -299,6 +299,10 @@ func NewRuntime(ctx context.Context, params Params) (*Runtime, error) {
 		consoleLogger = params.ConsoleLogger
 	}
 
+	if params.Router == nil {
+		params.Router = mux.NewRouter()
+	}
+
 	manager, err := plugins.New(config,
 		params.ID,
 		inmem.New(),
@@ -310,7 +314,8 @@ func NewRuntime(ctx context.Context, params Params) (*Runtime, error) {
 		plugins.ConsoleLogger(consoleLogger),
 		plugins.Logger(logger),
 		plugins.EnablePrintStatements(logger.GetLevel() >= logging.Info),
-		plugins.PrintHook(loggingPrintHook{logger: logger}))
+		plugins.PrintHook(loggingPrintHook{logger: logger}),
+		plugins.WithRouter(params.Router))
 	if err != nil {
 		return nil, errors.Wrap(err, "config error")
 	}


### PR DESCRIPTION
Addresses #2777 by

* adding a private router property to the plugin manager along with get and set accessor methods
* adding a conditional override of the runtime param router value if set on the plugin manager

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/main/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/main/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
