### PR TITLE
ast/term: sort set's keys slice on insert

### DIFF
--- a/ast/compile_test.go
+++ b/ast/compile_test.go
@@ -1233,9 +1233,9 @@ func TestCompilerExprExpansion(t *testing.T) {
 			note:  "sets",
 			input: `{f(x), {g(x)}}`,
 			expected: []*Expr{
-				MustParseExpr("f(x, __local0__)"),
-				MustParseExpr("g(x, __local1__)"),
-				MustParseExpr("{__local0__, {__local1__,}}"),
+				MustParseExpr("g(x, __local0__)"),
+				MustParseExpr("f(x, __local1__)"),
+				MustParseExpr("{__local1__, {__local0__,}}"),
 			},
 		},
 		{

--- a/ast/pretty_test.go
+++ b/ast/pretty_test.go
@@ -62,8 +62,8 @@ func TestPretty(t *testing.T) {
      "foo"
      array
       set
-       1
        null
+       1
       true
  rule
   head

--- a/compile/compile_test.go
+++ b/compile/compile_test.go
@@ -1072,8 +1072,8 @@ func TestOptimizerOutput(t *testing.T) {
 				"optimized/test.rego": `
 					package test
 
-					p = __result__ { data.external.users.foo = input.user; __result__ = true }
 					p = __result__ { data.external.users.bar = input.user; __result__ = true }
+					p = __result__ { data.external.users.foo = input.user; __result__ = true }
 				`,
 				"test.rego": `
 					package test


### PR DESCRIPTION
Before, we'd sort a set's `keys` slice in-place, and only when it
was actually compared to another set. This side-effect of a comparison
can be unexpected.

Now, we'll keep the `keys` slice sorted by inserting every new element
into its sorted position.

Note that we still sort in-place on Compare, because its possible the
sets values have been altered in different ways (e.g. test TestSetCopy).

Analogous to #3823, where we did this with objects' `keys` slices.

------

Also noticed a problem of #3823: the ordering could me messed up in ways different from inserting key/val pairs, e.g. by changing key names in Iter(), so we'll need to care about our invariant after the Iter() call.

------
🚧 Some discussion items below 👇 