### PR TITLE
cmd/inspect: Add namespace for data file at root

### DIFF
--- a/cmd/inspect_test.go
+++ b/cmd/inspect_test.go
@@ -51,7 +51,7 @@ func TestDoInspect(t *testing.T) {
 		res := `{
     "manifest": {"revision": "rev", "roots": ["foo", "bar", "fuz", "baz", "a", "x"]},
     "signatures_config": {},
-    "namespaces": {"": ["/data.json"], "data.foo": ["/example/foo.rego"]}
+    "namespaces": {"data": ["/data.json"], "data.foo": ["/example/foo.rego"]}
   }`
 
 		exp := util.MustUnmarshalJSON([]byte(res))
@@ -131,7 +131,7 @@ NAMESPACES:
 +-----------------------------+----------------------------------------------------+
 |          NAMESPACE          |                        FILE                        |
 +-----------------------------+----------------------------------------------------+
-|                             | /data.json                                         |
+| data                        | /data.json                                         |
 | data.a.b.y                  | /a/b/y/foo.rego                                    |
 |                             | /a/...xxxxxxxxxxxxxx/yyyyyyyyyyyyyyyyyyyy/foo.rego |
 | data.foo                    | /example/foo.rego                                  |

--- a/internal/bundle/inspect/inspect.go
+++ b/internal/bundle/inspect/inspect.go
@@ -126,7 +126,7 @@ func (bi *Info) getBundleDataWasmAndSignatures(name string) error {
 			path := fmt.Sprintf("%v.%v", ast.DefaultRootDocument, strings.Join(key, "."))
 			bi.Namespaces[path] = append(bi.Namespaces[path], value)
 		} else {
-			bi.Namespaces[""] = append(bi.Namespaces[""], value) // data file at bundle root
+			bi.Namespaces[ast.DefaultRootDocument.String()] = append(bi.Namespaces[ast.DefaultRootDocument.String()], value) // data file at bundle root
 		}
 	}
 

--- a/internal/bundle/inspect/inspect_test.go
+++ b/internal/bundle/inspect/inspect_test.go
@@ -48,7 +48,7 @@ func TestGenerateBundleInfoWithFileDir(t *testing.T) {
 		}
 
 		expectedNamespaces := map[string][]string{
-			"":         {filepath.Join(rootDir, "data.json")},
+			"data":     {filepath.Join(rootDir, "data.json")},
 			"data.bar": {filepath.Join(rootDir, "base.rego")},
 			"data.foo": {filepath.Join(rootDir, "baz/authz.rego"), filepath.Join(rootDir, "foo/policy.rego")},
 			"data.fuz": {filepath.Join(rootDir, "fuz/fuz.rego"), filepath.Join(rootDir, "fuz/data.json")},
@@ -114,7 +114,7 @@ func TestGenerateBundleInfoWithFile(t *testing.T) {
 		}
 
 		expectedNamespaces := map[string][]string{
-			"":         {"/data.json"},
+			"data":     {"/data.json"},
 			"data.b.c": {"/policy.rego"},
 		}
 
@@ -181,7 +181,7 @@ func TestGenerateBundleInfoWithBundleTarGz(t *testing.T) {
 
 		expectedNamespaces := map[string][]string{
 			"data.example":                  {"/example/example.rego"},
-			"":                              {"/data.json"},
+			"data":                          {"/data.json"},
 			"data.a.b.c":                    {"/a/b/c/data.json"},
 			"data.a.b.d":                    {"/a/b/d/data.json"},
 			"data.a.b.y":                    {"/a/b/y/foo.rego", "/a/b/y/data.yaml"},


### PR DESCRIPTION
Earlier we used an empty namespace for data file located
at bundle root. This change now uses "data" as the
namespace for a data file at root.

Fixes: #4022

Signed-off-by: Ashutosh Narkar <anarkar4387@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->
