### PR TITLE
build: Add support for building images based on processor architecture

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -295,27 +295,27 @@ build-all-platforms: ci-build-linux ci-build-linux-static ci-build-darwin ci-bui
 
 .PHONY: image-quick
 image-quick:
-	chmod +x $(RELEASE_DIR)/opa_linux_amd64*
+	chmod +x $(RELEASE_DIR)/opa_linux_$(GOARCH)*
 	$(DOCKER) build \
 		-t $(DOCKER_IMAGE):$(VERSION) \
 		--build-arg BASE=gcr.io/distroless/cc \
-		--build-arg BIN=$(RELEASE_DIR)/opa_linux_amd64 \
+		--build-arg BIN=$(RELEASE_DIR)/opa_linux_$(GOARCH) \
 		.
 	$(DOCKER) build \
 		-t $(DOCKER_IMAGE):$(VERSION)-debug \
 		--build-arg BASE=gcr.io/distroless/cc:debug \
-		--build-arg BIN=$(RELEASE_DIR)/opa_linux_amd64 \
+		--build-arg BIN=$(RELEASE_DIR)/opa_linux_$(GOARCH) \
 		.
 	$(DOCKER) build \
 		-t $(DOCKER_IMAGE):$(VERSION)-rootless \
 		--build-arg USER=1000 \
 		--build-arg BASE=gcr.io/distroless/cc \
-		--build-arg BIN=$(RELEASE_DIR)/opa_linux_amd64 \
+		--build-arg BIN=$(RELEASE_DIR)/opa_linux_$(GOARCH) \
 		.
 	$(DOCKER) build \
 		-t $(DOCKER_IMAGE):$(VERSION)-static \
 		--build-arg BASE=gcr.io/distroless/static \
-		--build-arg BIN=$(RELEASE_DIR)/opa_linux_amd64_static \
+		--build-arg BIN=$(RELEASE_DIR)/opa_linux_$(GOARCH)_static \
 		.
 
 .PHONY: ci-image-smoke-test


### PR DESCRIPTION
Added support for building images based on ARM64 processor architecture. 
I've tested the building image process with the following command:
`make build GOARCH=arm64 GOOS=linux CGO_ENABLED=0 WASM_ENABLED=0`