### PR TITLE
server: Remove remaining code from the diagnostics buffer

### DIFF
--- a/server/buffer.go
+++ b/server/buffer.go
@@ -13,17 +13,6 @@ import (
 	"github.com/open-policy-agent/opa/topdown"
 )
 
-// Buffer defines an interface for recording decisions.
-// DEPRECATED. Use Decision Logging instead.
-type Buffer interface {
-	// Push adds the given Info into the buffer.
-	Push(*Info)
-
-	// Iter iterates over the buffer, from oldest present Info to newest. It should
-	// call fn on each Info.
-	Iter(fn func(*Info))
-}
-
 // Info contains information describing a policy decision.
 type Info struct {
 	Txn        storage.Transaction

--- a/server/server.go
+++ b/server/server.go
@@ -111,7 +111,6 @@ type Server struct {
 	store                  storage.Store
 	manager                *plugins.Manager
 	decisionIDFactory      func() string
-	buffer                 Buffer
 	logger                 func(context.Context, *Info) error
 	errLimit               int
 	pprofEnabled           bool
@@ -2204,7 +2203,6 @@ func (s *Server) getDecisionLogger(br bundleRevisions) (logger decisionLogger) {
 		logger.revisions = br.Revisions
 	}
 	logger.logger = s.logger
-	logger.buffer = s.buffer
 	return logger
 }
 
@@ -2733,7 +2731,6 @@ type decisionLogger struct {
 	revisions map[string]string
 	revision  string // Deprecated: Use `revisions` instead.
 	logger    func(context.Context, *Info) error
-	buffer    Buffer
 }
 
 func (l decisionLogger) Log(ctx context.Context, txn storage.Transaction, decisionID, remoteAddr, path string, query string, goInput *interface{}, astInput ast.Value, goResults *interface{}, err error, m metrics.Metrics) error {
@@ -2763,10 +2760,6 @@ func (l decisionLogger) Log(ctx context.Context, txn storage.Transaction, decisi
 		if err := l.logger(ctx, info); err != nil {
 			return errors.Wrap(err, "decision_logs")
 		}
-	}
-
-	if l.buffer != nil {
-		l.buffer.Push(info)
 	}
 
 	return nil


### PR DESCRIPTION
In 6b3c99f1141107e7d4ff21e9113ec1810c887288 the diagnostics buffer
was removed from the runtime params but we forgot to remove the
associated unused code from the server package. This commit completes that.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->
