### PR TITLE
wasm: opa_abort if memory grow fails

### DIFF
--- a/internal/compiler/wasm/opa/callgraph.csv
+++ b/internal/compiler/wasm/opa/callgraph.csv
@@ -337,6 +337,7 @@ opa_json_writer_write,opa_json_writer_emit_value
 opa_json_writer_write,opa_free
 opa_json_dump,opa_json_writer_write
 opa_value_dump,opa_json_writer_write
+opa_malloc,opa_abort
 opa_realloc,opa_malloc
 opa_realloc,memcpy
 opa_realloc,opa_free

--- a/internal/wasm/sdk/internal/wasm/vm.go
+++ b/internal/wasm/sdk/internal/wasm/vm.go
@@ -465,11 +465,11 @@ func (i *VM) SetPolicyData(ctx context.Context, opts vmOpts) error {
 			}
 		}
 		mem := i.memory.UnsafeData(i.store)
-		for src, dest := 0, i.baseHeapPtr; src < len(opts.parsedData); src, dest = src+1, dest+1 {
-			mem[dest] = opts.parsedData[src]
-		}
+		len := int32(len(opts.parsedData))
+		copy(mem[i.baseHeapPtr:i.baseHeapPtr+len], opts.parsedData)
 		i.dataAddr = opts.parsedDataAddr
-		i.evalHeapPtr = i.baseHeapPtr + int32(len(opts.parsedData))
+
+		i.evalHeapPtr = i.baseHeapPtr + int32(len)
 		err := i.setHeapState(ctx, i.evalHeapPtr)
 		if err != nil {
 			return err

--- a/wasm/src/malloc.c
+++ b/wasm/src/malloc.c
@@ -173,7 +173,10 @@ static void *__opa_malloc_new_allocation(size_t size)
     if (heap_ptr >= heap_top)
     {
         unsigned int pages = (block_size / WASM_PAGE_SIZE) + 1;
-        __builtin_wasm_memory_grow(0, pages);
+        if (__builtin_wasm_memory_grow(0, pages) == -1 )
+        {
+            opa_abort("opa_malloc: failed");
+        };
         heap_top += (pages * WASM_PAGE_SIZE);
     }
 


### PR DESCRIPTION
Before, we'd either trap with out-of-bounds memory access, or other weird
behaviour.

Included some code cosmetics in pool.go, replacing `for` loop with a `copy`.

Added tests to opa_test.go.
