### PR TITLE
workflow: move go-mod-proxy check into nightly tests

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -93,3 +93,22 @@ jobs:
           status: ${{ job.status }}
           fields: repo,workflow
 
+  go-proxy-check:
+    name: Go mod check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Vendor without proxy
+        run: make check-go-module
+        timeout-minutes: 30
+
+      - name: Slack Notification
+        uses: 8398a7/action-slack@v3
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_NOTIFICATION_WEBHOOK }}
+        if: ${{ failure() && env.SLACK_WEBHOOK_URL }}
+        with:
+          status: ${{ job.status }}
+          fields: repo,workflow

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -274,14 +274,3 @@ jobs:
       - name: Build
         run: make ci-go-ci-build-linux GOVERSION=${{ matrix.version }}
         timeout-minutes: 30
-
-  go-proxy-check:
-    name: Go mod check
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v2
-
-      - name: Vendor without proxy
-        run: make check-go-module
-        timeout-minutes: 30


### PR DESCRIPTION
It seldomly matters for PRs, since only a tiny subset of them alters
dependencies. Having the check run in nightlies, where a failure does
not block a PR, but we still notice it through the notifications,
seems like a good trade-off.
