### PR TITLE
ast/compile: check arity in undefined function stage

### DIFF
--- a/ast/compile_test.go
+++ b/ast/compile_test.go
@@ -4399,12 +4399,12 @@ func TestQueryCompiler(t *testing.T) {
 		{
 			note:     "invalid eq",
 			q:        "eq()",
-			expected: fmt.Errorf("1 error occurred: 1:1: rego_type_error: built-in function eq: expected (any, any), got ()"),
+			expected: fmt.Errorf("1 error occurred: 1:1: rego_type_error: eq: arity mismatch\n\thave: ()\n\twant: (any, any)"),
 		},
 		{
 			note:     "invalid eq",
 			q:        "eq(1)",
-			expected: fmt.Errorf("1 error occurred: 1:1: rego_type_error: built-in function eq: expected (any, any), got (number)"),
+			expected: fmt.Errorf("1 error occurred: 1:1: rego_type_error: eq: arity mismatch\n\thave: (number)\n\twant: (any, any)"),
 		},
 		{
 			note:     "rewrite assignment",
@@ -4486,21 +4486,21 @@ func TestQueryCompiler(t *testing.T) {
 			q:        `startswith("x")`,
 			pkg:      "",
 			imports:  nil,
-			expected: fmt.Errorf("1 error occurred: 1:1: rego_type_error: built-in function startswith: expected (string, string), got (string)"),
+			expected: fmt.Errorf("1 error occurred: 1:1: rego_type_error: startswith: arity mismatch\n\thave: (string)\n\twant: (string, string)"),
 		},
 		{
 			note:     "built-in function arity mismatch (arity 0)",
 			q:        `x := opa.runtime("foo")`,
 			pkg:      "",
 			imports:  nil,
-			expected: fmt.Errorf("1 error occurred: 1:6: rego_type_error: built-in function opa.runtime: expected (), got (string)"),
+			expected: fmt.Errorf("1 error occurred: 1:6: rego_type_error: opa.runtime: arity mismatch\n\thave: (string, ???)\n\twant: ()"),
 		},
 		{
 			note:     "built-in function arity mismatch, nested",
 			q:        "count(sum())",
 			pkg:      "",
 			imports:  nil,
-			expected: fmt.Errorf("1 error occurred: 1:7: rego_type_error: built-in function sum: expected (any<array[number], set[number]>), got ()"),
+			expected: fmt.Errorf("1 error occurred: 1:7: rego_type_error: sum: arity mismatch\n\thave: (???)\n\twant: (any<array[number], set[number]>)"),
 		},
 		{
 			note:     "check types",

--- a/ast/compile_test.go
+++ b/ast/compile_test.go
@@ -4533,7 +4533,7 @@ func TestQueryCompiler(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		runQueryCompilerTest(t, tc.note, tc.q, tc.pkg, tc.imports, tc.expected)
+		t.Run(tc.note, runQueryCompilerTest(tc.q, tc.pkg, tc.imports, tc.expected))
 	}
 }
 
@@ -4829,8 +4829,9 @@ func compilerErrsToStringSlice(errors []*Error) []string {
 	return result
 }
 
-func runQueryCompilerTest(t *testing.T, note, q, pkg string, imports []string, expected interface{}) {
-	t.Run(note, func(t *testing.T) {
+func runQueryCompilerTest(q, pkg string, imports []string, expected interface{}) func(*testing.T) {
+	return func(t *testing.T) {
+		t.Helper()
 		c := NewCompiler().WithEnablePrintStatements(false)
 		c.Compile(getCompilerTestModules())
 		assertNotFailed(t, c)
@@ -4868,7 +4869,7 @@ func runQueryCompilerTest(t *testing.T, note, q, pkg string, imports []string, e
 				t.Fatalf("Expected error %v but got: %v", expected, err)
 			}
 		}
-	})
+	}
 }
 
 func TestCompilerCapabilitiesExtendedWithCustomBuiltins(t *testing.T) {

--- a/repl/repl_test.go
+++ b/repl/repl_test.go
@@ -1255,7 +1255,7 @@ x := 2
 
 	buffer.Reset()
 	err := repl.OneShot(ctx, "assign()")
-	if err == nil || !strings.Contains(err.Error(), "rego_type_error: built-in function assign: expected (any, any), got ()") {
+	if err == nil || !strings.Contains(err.Error(), "rego_type_error: assign: arity mismatch\n\thave: ()\n\twant: (any, any)") {
 		t.Fatal("Expected type check error but got:", err)
 	}
 }

--- a/repl/repl_test.go
+++ b/repl/repl_test.go
@@ -1255,7 +1255,7 @@ x := 2
 
 	buffer.Reset()
 	err := repl.OneShot(ctx, "assign()")
-	if err == nil || !strings.Contains(err.Error(), "too few arguments") {
+	if err == nil || !strings.Contains(err.Error(), "rego_type_error: built-in function assign: expected (any, any), got ()") {
 		t.Fatal("Expected type check error but got:", err)
 	}
 }


### PR DESCRIPTION
Before, the "undefined function" check stage in the compiler (and query
compiler) only asserted that the function was known.

Now, we'll also check that the number of arguments _could be_ valid. If
it really is valid will be determined by the type checker at a later
stage.

However, asserting the arity early allows us to give more on-the-spot
error messages.

Fixes #4054.