### PR TITLE
plugins/rest/aws: debug log metadata error

### DIFF
--- a/plugins/rest/aws.go
+++ b/plugins/rest/aws.go
@@ -378,6 +378,12 @@ func doMetaDataRequestWithClient(req *http.Request, client *http.Client, desc st
 	}).Debug("Received response from " + desc + " service.")
 
 	if resp.StatusCode != 200 {
+		if logger.GetLevel() == logging.Debug {
+			body, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				logger.Debug("Error response with response body: %v", body)
+			}
+		}
 		// could be 404 for role that's not available, but cover all the bases
 		return nil, errors.New(desc + " HTTP request returned unexpected status: " + resp.Status)
 	}


### PR DESCRIPTION
A user on Slack is getting 500 responses from the AWS metadata API
using a configuration like the below:

```yaml
 services:
  - name: svc-bundle
    url: https://opa-policies-dev.s3.amazonaws.com
    credentials:
      s3_signing:
        metadata_credentials:
          aws_region: us-east-1
          iam_role: arn:aws:iam::1234:role/opa-bundles
```
It's really hard to know why this might be given how we currently
only log the HTTP status code under this error condition.

This tries to print the response body on debug level (if set).

Signed-off-by: Anders Eknert <anders@eknert.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->
