### PR TITLE
Adds runtime() to Go SDK

### DIFF
--- a/sdk/opa.go
+++ b/sdk/opa.go
@@ -16,6 +16,7 @@ import (
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/bundle"
 	"github.com/open-policy-agent/opa/internal/ref"
+	"github.com/open-policy-agent/opa/internal/runtime"
 	"github.com/open-policy-agent/opa/internal/uuid"
 	"github.com/open-policy-agent/opa/logging"
 	"github.com/open-policy-agent/opa/metrics"
@@ -100,11 +101,16 @@ func (opa *OPA) Configure(ctx context.Context, opts ConfigOptions) error {
 }
 
 func (opa *OPA) configure(ctx context.Context, bs []byte, ready chan struct{}, block bool) error {
+	info, err := runtime.Term(runtime.Params{})
+	if err != nil {
+		return err
+	}
 
 	manager, err := plugins.New(
 		bs,
 		opa.id,
 		inmem.New(),
+		plugins.Info(info),
 		plugins.Logger(opa.logger),
 		plugins.ConsoleLogger(opa.console))
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: orenzohar <oren.zohar@elastic.co>

Adds Runtime(Context) function to Go SDK.
Fixes #4050 

