### PR TITLE
build: Improve CHANGELOG mentions and token usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -429,7 +429,11 @@ check-go-module:
 
 .PHONY: release-patch
 release-patch:
+ifeq ($(GITHUB_TOKEN),)
+	@echo "\033[0;31mGITHUB_TOKEN environment variable missing.\033[33m Provide a GitHub Personal Access Token (PAT) with the 'read:org' scope.\033[0m"
+endif
 	@$(DOCKER) run $(DOCKER_FLAGS) \
+		-e GITHUB_TOKEN=$(GITHUB_TOKEN) \
 		-e LAST_VERSION=$(LAST_VERSION) \
 		-v $(PWD):/_src \
 		python:2.7 \

--- a/build/changelog.py
+++ b/build/changelog.py
@@ -1,9 +1,10 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 """
 changelog.py helps generate the CHANGELOG.md message for a particular release.
 """
 
 import argparse
+import os
 import subprocess
 import shlex
 import re
@@ -122,14 +123,16 @@ def get_subject(commit_message):
     return commit_message.splitlines()[0]
 
 def get_changelog_message(commit_message, issue_id, mention, reporter, repo_url):
+    subject = get_subject(commit_message)
     if issue_id:
-        subject = get_subject(commit_message)
         if mention:
             mention = " "+mention
         if reporter:
             reporter = " "+reporter
         return "Fixes", "{subject} ([#{issue_id}]({repo_url}/issues/{issue_id})){mention}{reporter}".format(subject=subject, issue_id=issue_id, repo_url=repo_url, mention=mention, reporter=reporter)
-    return None, get_subject(commit_message)
+    if mention:
+        mention = " (" + mention + ")"
+    return None, "{subject}{mention}".format(subject=subject, mention=mention)
 
 
 def get_latest_tag():
@@ -138,10 +141,12 @@ def get_latest_tag():
 
 
 def parse_args():
+    if "GITHUB_TOKEN" in os.environ:
+        default_token = os.environ["GITHUB_TOKEN"]
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--repo_url", default="https://github.com/open-policy-agent/opa")
-    parser.add_argument("--token", default="", help="GitHub API token")
+    parser.add_argument("--token", default=default_token, help="GitHub API token")
     parser.add_argument("from_version", nargs="?",
                         default=get_latest_tag(), help="start of changes")
     parser.add_argument("to_commit", nargs="?",

--- a/build/gen-release-patch.sh
+++ b/build/gen-release-patch.sh
@@ -66,7 +66,6 @@ $(./build/changelog.py $LAST_VERSION HEAD)
 $(awk '/^##/{f=1}f' CHANGELOG.md)
 EOF
     fi
-   
     mv _CHANGELOG.md CHANGELOG.md
 }
 


### PR DESCRIPTION
This commit improves the release-patch target to mention users in the
Miscellaneous section and warn if a GitHub token is not provided.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->
