### PR TITLE
rego: add EvalPrintHook() EvalOption

### DIFF
--- a/rego/rego.go
+++ b/rego/rego.go
@@ -265,6 +265,13 @@ func EvalSortSets(yes bool) EvalOption {
 	}
 }
 
+// EvalPrintHook sets the object to use for handling print statement outputs.
+func EvalPrintHook(ph print.Hook) EvalOption {
+	return func(e *EvalContext) {
+		e.printHook = ph
+	}
+}
+
 func (pq preparedQuery) Modules() map[string]*ast.Module {
 	mods := make(map[string]*ast.Module)
 


### PR DESCRIPTION
When using print() and PrepareForEval, subsequent Eval calls are now
able to supply their own `print.Hook`.

Since the result of PrepareForEval may be used by multiple concurrent goroutines, sharing one print hook (backed by one buffer) isn't going to work. Instead, every call to Eval can now provide its own buffer.