### PR TITLE
plugins: Fix logger initialization on plugin manager

### DIFF
--- a/logging/logging.go
+++ b/logging/logging.go
@@ -34,7 +34,7 @@ type Logger interface {
 	SetLevel(Level)
 }
 
-// StandardLogger is the default OPA logger
+// StandardLogger is the default OPA logger implementation.
 type StandardLogger struct {
 	logger *logrus.Logger
 	fields map[string]interface{}
@@ -47,12 +47,9 @@ func New() *StandardLogger {
 	}
 }
 
-// NewStandardLogger is deprecated. Use Get instead.
-func NewStandardLogger() *StandardLogger {
-	return Get()
-}
-
 // Get returns the standard logger used throughout OPA.
+//
+// Deprecated. Do not rely on the global logger.
 func Get() *StandardLogger {
 	return &StandardLogger{
 		logger: logrus.StandardLogger(),

--- a/logging/logging_test.go
+++ b/logging/logging_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestWithFields(t *testing.T) {
-	logger := NewStandardLogger().WithFields(map[string]interface{}{"context": "contextvalue"})
+	logger := New().WithFields(map[string]interface{}{"context": "contextvalue"})
 
 	var fieldvalue interface{}
 	var ok bool
@@ -20,7 +20,7 @@ func TestWithFields(t *testing.T) {
 }
 
 func TestWithFieldsOverrides(t *testing.T) {
-	logger := NewStandardLogger().
+	logger := New().
 		WithFields(map[string]interface{}{"context": "contextvalue"}).
 		WithFields(map[string]interface{}{"context": "changedcontextvalue"})
 
@@ -37,7 +37,7 @@ func TestWithFieldsOverrides(t *testing.T) {
 }
 
 func TestWithFieldsMerges(t *testing.T) {
-	logger := NewStandardLogger().
+	logger := New().
 		WithFields(map[string]interface{}{"context": "contextvalue"}).
 		WithFields(map[string]interface{}{"anothercontext": "anothercontextvalue"})
 

--- a/plugins/plugins.go
+++ b/plugins/plugins.go
@@ -366,6 +366,10 @@ func New(raw []byte, id string, store storage.Store, opts ...func(*Manager)) (*M
 		serverInitialized:            make(chan struct{}),
 	}
 
+	for _, f := range opts {
+		f(m)
+	}
+
 	if m.logger == nil {
 		m.logger = logging.Get()
 	}
@@ -380,16 +384,13 @@ func New(raw []byte, id string, store storage.Store, opts ...func(*Manager)) (*M
 		Keys:       keys,
 		Logger:     m.logger,
 	}
+
 	services, err := cfg.ParseServicesConfig(serviceOpts)
 	if err != nil {
 		return nil, err
 	}
 
 	m.services = services
-
-	for _, f := range opts {
-		f(m)
-	}
 
 	return m, nil
 }


### PR DESCRIPTION
The plugin manager was initializing the logger _after_ creating
service clients which meant that service clients ended up relying on
the global logger. Since the runtime package did not configure the log
level on the global logger, the logs from the service clients were
missing.

This commit updates the plugin manager to initialize the logger
_before_ creating service clients and updates the runtime package to
set the log level on the global logger as a fallback.

Fixes #4071

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->
