### PR TITLE
cmd/inspect: Update inspect to pretty print by default (#4021)

### DIFF
--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -30,7 +30,7 @@ type inspectCommandParams struct {
 
 func newInspectCommandParams() inspectCommandParams {
 	return inspectCommandParams{
-		outputFormat: util.NewEnumFlag(evalJSONOutput, []string{
+		outputFormat: util.NewEnumFlag(evalPrettyOutput, []string{
 			evalJSONOutput,
 			evalPrettyOutput,
 		}),
@@ -89,7 +89,10 @@ func doInspect(params inspectCommandParams, path string, out io.Writer) error {
 	}
 
 	switch params.outputFormat.String() {
-	case evalPrettyOutput:
+	case evalJSONOutput:
+		return pr.JSON(out, info)
+
+	default:
 		if info.Manifest.Revision != "" || len(*info.Manifest.Roots) != 0 || len(info.Manifest.Metadata) != 0 {
 			if err := populateManifest(out, info.Manifest); err != nil {
 				return err
@@ -102,9 +105,6 @@ func doInspect(params inspectCommandParams, path string, out io.Writer) error {
 			}
 		}
 		return nil
-
-	default:
-		return pr.JSON(out, info)
 	}
 }
 

--- a/cmd/inspect_test.go
+++ b/cmd/inspect_test.go
@@ -43,7 +43,13 @@ func TestDoInspect(t *testing.T) {
 		}
 
 		var out bytes.Buffer
-		err = doInspect(newInspectCommandParams(), bundleFile, &out)
+		params := newInspectCommandParams()
+		err = params.outputFormat.Set(evalJSONOutput)
+		if err != nil {
+			t.Fatalf("Unexpected error: %s", err)
+		}
+
+		err = doInspect(params, bundleFile, &out)
 		if err != nil {
 			t.Fatalf("Unexpected error %v", err)
 		}
@@ -100,13 +106,7 @@ func TestDoInspectPretty(t *testing.T) {
 		}
 
 		var out bytes.Buffer
-		params := newInspectCommandParams()
-		err = params.outputFormat.Set(evalPrettyOutput)
-		if err != nil {
-			t.Fatalf("Unexpected error: %s", err)
-		}
-
-		err = doInspect(params, bundleFile, &out)
+		err = doInspect(newInspectCommandParams(), bundleFile, &out)
 		if err != nil {
 			t.Fatalf("Unexpected error %v", err)
 		}
@@ -176,13 +176,7 @@ func TestDoInspectPrettyManifestOnlySingleRoot(t *testing.T) {
 		}
 
 		var out bytes.Buffer
-		params := newInspectCommandParams()
-		err = params.outputFormat.Set(evalPrettyOutput)
-		if err != nil {
-			t.Fatalf("Unexpected error: %s", err)
-		}
-
-		err = doInspect(params, bundleFile, &out)
+		err = doInspect(newInspectCommandParams(), bundleFile, &out)
 		if err != nil {
 			t.Fatalf("Unexpected error %v", err)
 		}


### PR DESCRIPTION
Inspect previously pretty printed only when -f pretty was specified. This change 
ensures that inspect pretty prints by default, and a user can specify --format=json
to avoid relying on implicit default behaviour.  

Fixes: #4021

Signed-off-by: Emily Tao
<tao.emily@yahoo.ca>
