### PR TITLE
ast: Add JSON filter option to specify all array indices (#3131)

### DIFF
--- a/ast/term.go
+++ b/ast/term.go
@@ -2043,7 +2043,7 @@ func (obj object) MergeWith(other Object, conflictResolver func(v1, v2 *Term) (*
 
 // Filter returns a new object from values in obj where the keys are
 // found in filter. Array indices for values can be specified as
-// number strings.
+// number strings or all array values can be specified using "_"
 func (obj *object) Filter(filter Object) (Object, error) {
 	filtered, err := filterObject(obj, filter)
 	if err != nil {
@@ -2301,6 +2301,9 @@ func filterObject(o Value, filter Value) (Value, error) {
 		values := NewArray()
 		for i := 0; i < v.Len(); i++ {
 			subFilter := filteredObj.Get(StringTerm(strconv.Itoa(i)))
+			if subFilter == nil {
+				subFilter = filteredObj.Get(StringTerm("_"))
+			}
 			if subFilter != nil {
 				filteredValue, err := filterObject(v.Elem(i).Value, subFilter.Value)
 				if err != nil {

--- a/ast/term_test.go
+++ b/ast/term_test.go
@@ -234,6 +234,12 @@ func TestObjectFilter(t *testing.T) {
 			expected: `{"a": [{"b": 7}, {"d": 9}]}`,
 		},
 		{
+			note:     "all array elements",
+			object:   `{"a": [{"b": 7, "c": 8}, {"d": 9}]}`,
+			filter:   `{"a": {"_": null}}`,
+			expected: `{"a": [{"b": 7, "c": 8}, {"d": 9}]}`,
+		},
+		{
 			note:     "object with number keys",
 			object:   `{"a": [{"1":["b", "c", "d"]}, {"x": "y"}]}`,
 			filter:   `{"a": {"0": {"1": {"2": null}}}}`,

--- a/docs/content/policy-reference.md
+++ b/docs/content/policy-reference.md
@@ -354,9 +354,10 @@ complex types.
   `object.remove({"a": {"b": {"c": 2}}, "x": 123}, {"a": {"b": {"foo": "bar"}}}) == {"x": 123}`.
 
 
-* The `json` string `paths` may reference into array values by using index numbers. For example with the object
-  `{"a": ["x", "y", "z"]}` the path `a/1` references `y`. Nested structures are supported as well, for example:
-  `{"a": ["x", {"y": {"y1": {"y2": ["foo", "bar"]}}}, "z"]}` the path `a/1/y1/y2/0` references `"foo"`.
+* The `json` string `paths` may reference into specific array values by using index numbers or reference into 
+  the entire array by using the character `_`. For example with the object `{"a": ["x", "y", "z"]}` the path 
+  `a/1` references `y`, while the path `a/_` references `x`, `y`, and `z`. Nested structures are supported as well, 
+  for example: `{"a": ["x", {"y": {"y1": {"y2": ["foo", "bar"]}}}, "z"]}` the path `a/1/y1/y2/0` references `"foo"`.
 
 
 * The `json` string `paths` support `~0`, or `~1` characters for `~` and `/` characters in key names.


### PR DESCRIPTION
JSON filter previously required an index when using json.filter on an array object.
This change allows users to specify the whole array by using the index "_".

Fixes: #3131

Signed-off-by: Emily Tao <tao.emily@yahoo.ca>
