### PR TITLE
Revert "ast/compile: fix print rewriting for arrays in := and head vars"

### DIFF
--- a/ast/compile.go
+++ b/ast/compile.go
@@ -1371,7 +1371,7 @@ func (c *Compiler) rewritePrintCalls() {
 	for _, name := range c.sorted {
 		mod := c.Modules[name]
 		WalkRules(mod, func(r *Rule) bool {
-			safe := r.Head.Vars()
+			safe := r.Head.Args.Vars()
 			safe.Update(ReservedVars)
 			WalkBodies(r, func(b Body) bool {
 				for _, err := range rewritePrintCalls(c.localvargen, c.GetArity, safe, b) {

--- a/ast/compile_test.go
+++ b/ast/compile_test.go
@@ -3169,36 +3169,6 @@ func TestCompilerRewritePrintCalls(t *testing.T) {
 			f(__local0__) = __local2__ { true; __local2__ = {1 | __local0__[x]; __local3__ = {__local1__ | __local1__ = x}; internal.print([__local3__])} }
 			`,
 		},
-		{
-			note: "print call of var in head key",
-			module: `package test
-			f(_) = [1, 2, 3]
-			p[x] { [_, x, _] := f(true); print(x) }`,
-			exp: `package test
-			f(__local0__) = [1, 2, 3] { true }
-			p[__local2__] { data.test.f(true, __local5__); [__local1__, __local2__, __local3__] = __local5__; __local6__ = {__local4__ | __local4__ = __local2__}; internal.print([__local6__]) }
-			`,
-		},
-		{
-			note: "print call of var in head value",
-			module: `package test
-			f(_) = [1, 2, 3]
-			p = x { [_, x, _] := f(true); print(x) }`,
-			exp: `package test
-			f(__local0__) = [1, 2, 3] { true }
-			p = __local2__ { data.test.f(true, __local5__); [__local1__, __local2__, __local3__] = __local5__; __local6__ = {__local4__ | __local4__ = __local2__}; internal.print([__local6__]) }
-			`,
-		},
-		{
-			note: "print call of vars in head key and value",
-			module: `package test
-			f(_) = [1, 2, 3]
-			p[x] = y { [_, x, y] := f(true); print(x) }`,
-			exp: `package test
-			f(__local0__) = [1, 2, 3] { true }
-			p[__local2__] = __local3__ { data.test.f(true, __local5__); [__local1__, __local2__, __local3__] = __local5__; __local6__ = {__local4__ | __local4__ = __local2__}; internal.print([__local6__]) }
-			`,
-		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
This reverts commit d1525c126c6c4c9f8b16898f3a92c2a997afdd9b.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->
