### PR TITLE
docs/website: Add feedback buttons to docs

### DIFF
--- a/docs/content/kubernetes-primer.md
+++ b/docs/content/kubernetes-primer.md
@@ -358,9 +358,7 @@ request:
                 port:
                   number: 443
 </code></pre></div>
-
-
-<br>
+</div>
 
 ## Detailed Admission Control Flow
 

--- a/docs/website/assets/js/app.js
+++ b/docs/website/assets/js/app.js
@@ -31,7 +31,7 @@ document.addEventListener("DOMContentLoaded", function(event) {
   var fullHeight = content.outerHeight(true) + content.offset().top
   var delta = fullHeight - lastHeading.offsetTop
   var padding = window.innerHeight - delta
-  content.css('paddingBottom', padding + 'px');
+  $('.toc-padding').css('paddingBottom', padding + 'px');
 
   tocbot.init({
     tocSelector: '.toc',

--- a/docs/website/config.toml
+++ b/docs/website/config.toml
@@ -33,6 +33,12 @@ github = "https://github.com/open-policy-agent/opa"
 sidebar = "/img/logos/opa-horizontal-color.png"
 navbar = "/img/logos/opa-icon-white.png"
 
+[params.ui]
+[params.ui.feedback]
+# Requires googleAnalytics to be set to track feedback events
+# Set hide_feedback: true in a page's front matter to disable feedback for that page
+enable = true
+
 [menu]
 [[menu.social]]
 name = "Medium"

--- a/docs/website/layouts/partials/docs/article.html
+++ b/docs/website/layouts/partials/docs/article.html
@@ -19,6 +19,7 @@
       {{ if (and (not .Params.hide_feedback) (site.Params.ui.feedback.enable) (site.GoogleAnalytics)) }}
         {{ partial "feedback.html" site.Params.ui.feedback }}
       {{ end }}
+      <div class="toc-padding"></div>
     </section>
   </div>
 </article>

--- a/docs/website/layouts/partials/docs/article.html
+++ b/docs/website/layouts/partials/docs/article.html
@@ -16,6 +16,9 @@
       <div class="content">
         {{ .Content }}
       </div>
+      {{ if (and (not .Params.hide_feedback) (site.Params.ui.feedback.enable) (site.GoogleAnalytics)) }}
+        {{ partial "feedback.html" site.Params.ui.feedback }}
+      {{ end }}
     </section>
   </div>
 </article>

--- a/docs/website/layouts/partials/feedback.html
+++ b/docs/website/layouts/partials/feedback.html
@@ -1,0 +1,65 @@
+<style>
+  .feedback--answer {
+    display: inline-block;
+  }
+  .feedback--answer-no {
+    margin-left: 1em;
+  }
+  .feedback--response {
+    display: none;
+    margin-top: 1em;
+  }
+  .feedback--response__visible {
+    display: block;
+  }
+  .feedback--question {
+    margin-bottom: 1em;
+  }
+  .feedback--title {
+    font-size: 1.75em;
+  }
+</style>
+<div class="d-print-none">
+  <h2 class="feedback--title">Feedback</h2>
+  <p class="feedback--question">Was this page helpful?</p>
+  <button class="button feedback--answer feedback--answer-yes">Yes</button>
+  <button class="button feedback--answer feedback--answer-no">No</button>
+  <p class="feedback--response feedback--response-yes">
+    Glad to hear it! Please <a href="https://github.com/open-policy-agent/opa/issues/new">tell us how we can improve</a>.
+  </p>
+  <p class="feedback--response feedback--response-no">
+    Sorry to hear that. Please <a href="https://github.com/open-policy-agent/opa/issues/new">tell us how we can improve</a>.
+  </p>
+</div>
+<script>
+  const yesButton = document.querySelector('.feedback--answer-yes');
+  const noButton = document.querySelector('.feedback--answer-no');
+  const yesResponse = document.querySelector('.feedback--response-yes');
+  const noResponse = document.querySelector('.feedback--response-no');
+  const disableButtons = () => {
+    yesButton.disabled = true;
+    noButton.disabled = true;
+  };
+  const sendFeedback = (value) => {
+    if (typeof ga !== 'function') return;
+    const args = {
+      command: 'send',
+      hitType: 'event',
+      category: 'Helpful',
+      action: 'click',
+      label: window.location.pathname,
+      value: value
+    };
+    ga(args.command, args.hitType, args.category, args.action, args.label, args.value);
+  };
+  yesButton.addEventListener('click', () => {
+    yesResponse.classList.add('feedback--response__visible');
+    disableButtons();
+    sendFeedback(1);
+  });
+  noButton.addEventListener('click', () => {
+    noResponse.classList.add('feedback--response__visible');
+    disableButtons();
+    sendFeedback(0);
+  });
+</script>


### PR DESCRIPTION
Add an option for users to provide feedback on documentation. Feedback events are logged to Google Analytics.
Based on a Hugo template called Docsy https://www.docsy.dev/docs/adding-content/feedback/).

Changes:
- Add params.ui.feedback parameter to config.toml
- Add feedback.html partial template (based on https://github.com/google/docsy/blob/master/layouts/partials/feedback.html)
- Update article.html partial to include feedback
- Clicking "tell us how we can improve" links the user to create a new issue at https://github.com/open-policy-agent/opa/issues/new
- Add missing </div> to kubernetes-primer.md
- Change app.js to add padding to a separate div

Note: Add `hide_feedback: true` to a page's front matter to disable feedback for that page, for example:

**`docs/content/faq.md`**
```
---
title: Frequently Asked Questions
navtitle: FAQ
kind: misc
weight: 17
hide_feedback: true
---
```


### Accessing feedback data (taken from https://www.docsy.dev/docs/adding-content/feedback/):
1. Open Google Analytics.
2. Open Behavior > Events > Overview.
3. In the Event Category table click the Helpful row. Click view full report if you don’t see the Helpful row.
4. Click Event Label. You now have a page-by-page breakdown of ratings.
5. Note that results may only be available 24 hours after logging - to see real-time events, go to Realtime > Events.

Here’s what the 4 columns represent:
- Total Events is the total number of times that users clicked either Yes or No.
- Unique Events provides a rough indication of how frequently users are rating your pages per session. For example, suppose your Total Events is 5000, and Unique Events is 2500. This means that you have 2500 users who are rating 2 pages per session.
- Event Value isn’t that useful.
- Avg. Value is the aggregated rating for that page. The value is always between 0 and 1. When users click No a value of 0 is sent to Google Analytics. When users click Yes a value of 1 is sent. You can think of it as a percentage. If a page has an Avg. Value of 0.67, it means that 67% of users clicked Yes and 33% clicked No.

### Screenshots:
Tested locally with my personal Googly Analytics tracking ID (note that this is from real-time events, which only shows the count of events, and not the Yes/No values):
![docs_metrics](https://user-images.githubusercontent.com/19272628/144728152-57f76cf8-4cca-4302-958b-11ede09756e6.png)

Feedback data report after 24 hours:
![image](https://user-images.githubusercontent.com/19272628/144802100-c7cd4492-e174-4724-a8ca-0487c5470ded.png)

Feedback buttons:
![opa_feedback_1](https://user-images.githubusercontent.com/19272628/144728166-aced5088-422d-4ce0-a456-1a46126205fb.png)

Clicking "Yes":
![opa_feedback_2](https://user-images.githubusercontent.com/19272628/144728175-76ce19cf-d53c-4a89-8e62-2a8253ca57c3.png)

Clicking "No":
![opa_feedback_3](https://user-images.githubusercontent.com/19272628/144728186-ddac855e-ffaf-443c-acaf-567a392c02f6.png)



Fixes #3664
Signed-off-by: Alan Ma <alan_ma@live.ca>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->
