### PR TITLE
document for `all` and `any` aggregate builtins

### DIFF
--- a/docs/content/policy-reference.md
+++ b/docs/content/policy-reference.md
@@ -319,7 +319,9 @@ complex types.
 | <span class="opa-keep-it-together">``output := max(array_or_set)``</span> | ``output`` is the maximum value in ``array_or_set`` | ✅ |
 | <span class="opa-keep-it-together">``output := min(array_or_set)``</span> | ``output`` is the minimum value in ``array_or_set`` | ✅ |
 | <span class="opa-keep-it-together">``output := sort(array_or_set)``</span> | ``output`` is the sorted ``array`` containing elements from ``array_or_set``. | ✅ |
-
+| <span class="opa-keep-it-together">``all(array_or_set, output)``</span> | 1 | ``output`` is ``true`` if all of the values in ``array_or_set`` are ``true``. A collection of length 0 returns ``true``.| ✅ |
+| <span class="opa-keep-it-together">``any(array_or_set, output)``</span> | 1 | ``output`` is ``true`` if any of the values in ``array_or_set`` is ``true``. A collection of length 0 returns ``false``.| ✅ |
+	
 ### Arrays
 | Built-in | Description | Wasm Support |
 | ------- |-------------|---------------|


### PR DESCRIPTION
These functions exist but aren't currently mentioned in the documentation.  It looks like these lines were at one point in the policy-reference, but were lost in commit bb0d4e271b9adfbbfed174ae097a45174c7cb4a9. 

I also wonder if it would be worth mentioning using `all` in the section on [Universal Quantification](https://www.openpolicyagent.org/docs/v0.27.1/policy-language/#universal-quantification-for-all), something like:

```opa
no_bitcoin_miners_using_all :=  all([(app.name != "bitcoin-miner") | app := apps[_]])
```

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->
