### PR TITLE
ast/compile: fix print rewriting for arrays in unification

### DIFF
--- a/ast/compile_test.go
+++ b/ast/compile_test.go
@@ -3169,6 +3169,36 @@ func TestCompilerRewritePrintCalls(t *testing.T) {
 			f(__local0__) = __local2__ { true; __local2__ = {1 | __local0__[x]; __local3__ = {__local1__ | __local1__ = x}; internal.print([__local3__])} }
 			`,
 		},
+		{
+			note: "print call of var in head key",
+			module: `package test
+			f(_) = [1, 2, 3]
+			p[x] { [_, x, _] := f(true); print(x) }`,
+			exp: `package test
+			f(__local0__) = [1, 2, 3] { true }
+			p[__local2__] { data.test.f(true, __local5__); [__local1__, __local2__, __local3__] = __local5__; __local6__ = {__local4__ | __local4__ = __local2__}; internal.print([__local6__]) }
+			`,
+		},
+		{
+			note: "print call of var in head value",
+			module: `package test
+			f(_) = [1, 2, 3]
+			p = x { [_, x, _] := f(true); print(x) }`,
+			exp: `package test
+			f(__local0__) = [1, 2, 3] { true }
+			p = __local2__ { data.test.f(true, __local5__); [__local1__, __local2__, __local3__] = __local5__; __local6__ = {__local4__ | __local4__ = __local2__}; internal.print([__local6__]) }
+			`,
+		},
+		{
+			note: "print call of vars in head key and value",
+			module: `package test
+			f(_) = [1, 2, 3]
+			p[x] = y { [_, x, y] := f(true); print(x) }`,
+			exp: `package test
+			f(__local0__) = [1, 2, 3] { true }
+			p[__local2__] = __local3__ { data.test.f(true, __local5__); [__local1__, __local2__, __local3__] = __local5__; __local6__ = {__local4__ | __local4__ = __local2__}; internal.print([__local6__]) }
+			`,
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
outputVarsForExprEq, which is used in the rewriting of `print()` calls,
wasn't able to find `x` in

    [_, x, _] = f(1)

and thus certain print expressions failed during the rewriting stage of
print() calls in the compiler.

Now, the "collection (array/object) = func call" is handled.

Furthermore, this adds calls to isRefSafe in a few places: as it turned
out, the test cases

    {"array/ref", "[1,2,x] = a[_]", "[a]", "[x]"},
    {"object/ref", `{"x": x} = a[_]`, "[a]", "[x]"},

would have, without the check, passed without "a" in "safe" (3rd field).
The fact that these cases are including "a" is evidence for this being
the correct behaviour.

Fixes #4078.
