### PR TITLE
Fix opa fmt issue on refs containing operators

### DIFF
--- a/format/format.go
+++ b/format/format.go
@@ -570,14 +570,16 @@ func (w *writer) writeRef(x ast.Ref) {
 	if len(x) > 0 {
 		w.writeTerm(x[0], nil)
 		path := x[1:]
-		for _, p := range path {
-			switch p := p.Value.(type) {
+		for _, t := range path {
+			switch p := t.Value.(type) {
 			case ast.String:
 				w.writeRefStringPath(p)
 			case ast.Var:
 				w.writeBracketed(w.formatVar(p))
 			default:
-				w.writeBracketed(p.String())
+				w.write("[")
+				w.writeTerm(t, nil)
+				w.write("]")
 			}
 		}
 	}

--- a/format/format_test.go
+++ b/format/format_test.go
@@ -219,6 +219,11 @@ func TestFormatAST(t *testing.T) {
 			expected: ``,
 		},
 		{
+			note:     "ref operator",
+			toFmt:    ast.MustParseRef(`foo[count(foo) - 1]`),
+			expected: `foo[count(foo) - 1]`,
+		},
+		{
 			note:     "x in xs",
 			toFmt:    ast.Member.Call(ast.VarTerm("x"), ast.VarTerm("xs")),
 			expected: `x in xs`,


### PR DESCRIPTION
The current version of OPA shows unexpected behavior when formatting files that
contain operators in refs.  This is commonly used to get e.g. the last item out
of an array:

    $ cat test.rego
    package test

    foo = x {
    	arr = [1, 2, 3]
    	x = arr[count(arr) - 1]
    }
    $ opa fmt test.rego
    package test

    foo = x {
    	arr = [1, 2, 3]
    	x = arr[minus(count(arr), 1)]
    }

This fixes that issue by using `writeTerm()` rather than `String()` for the ref.
Another approach could be to change this in `String()`; I wasn't sure which one
was better.