### PR TITLE
add readfile built-in function  @rafaelreinert

### DIFF
--- a/ast/builtins.go
+++ b/ast/builtins.go
@@ -249,13 +249,16 @@ var DefaultBuiltins = [...]*Builtin{
 	// UUIDs
 	UUIDRFC4122,
 
-	//SemVers
+	// SemVers
 	SemVerIsValid,
 	SemVerCompare,
 
 	// Printing
 	Print,
 	InternalPrint,
+
+	// File System
+	ReadFile,
 }
 
 // BuiltinMap provides a convenient mapping of built-in names to
@@ -2384,6 +2387,15 @@ var RegexMatchDeprecated = &Builtin{
 			types.S,
 		),
 		types.B,
+	),
+}
+
+// ReadFile read a file and returns the content as string; throws an error otherwise
+var ReadFile = &Builtin{
+	Name: "fs.readfile",
+	Decl: types.NewFunction(
+		types.Args(types.S),
+		types.S,
 	),
 }
 

--- a/capabilities.json
+++ b/capabilities.json
@@ -799,6 +799,20 @@
       }
     },
     {
+      "name": "fs.readfile",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "string"
+        },
+        "type": "function"
+      }
+    },
+    {
       "name": "glob.match",
       "decl": {
         "args": [

--- a/docs/content/policy-reference.md
+++ b/docs/content/policy-reference.md
@@ -1096,6 +1096,20 @@ CLI | `--explain` | `opa eval --explain=notes --format=pretty 'trace("hello worl
 HTTP | `explain=notes` | `curl localhost:8181/v1/data/example/allow?explain=notes&pretty` |
 REPL | `notes` | n/a | The "notes" command enables trace explanations. See `help` for more details.
 
+### File System
+
+| Built-in | Description | Wasm Support |
+| ------- |-------------|---------------|
+| <span class="opa-keep-it-together">``fs.readfile(file_path)``</span> | ``fs.readfile`` opens ``file_path`` as a ``Note`` event in the query explanation. Query explanations show the exact expressions evaluated by OPA during policy execution. For example, ``trace("Hello There!")`` includes ``Note "Hello There!"`` in the query explanation. To include variables in the message, use ``sprintf``. For example, ``person := "Bob"; trace(sprintf("Hello There! %v", [person]))`` will emit ``Note "Hello There! Bob"`` inside of the explanation. | ``SDK-dependent`` |
+
+By default, explanations are disabled. The following table summarizes how you can enable tracing:
+
+API | Parameter | Example | Memo
+--- | --- | --- | ---
+CLI | `--explain` | `opa eval --explain=notes --format=pretty 'trace("hello world")'` |
+HTTP | `explain=notes` | `curl localhost:8181/v1/data/example/allow?explain=notes&pretty` |
+REPL | `notes` | n/a | The "notes" command enables trace explanations. See `help` for more details.
+
 ## Reserved Names
 
 The following words are reserved and cannot be used as variable names, rule

--- a/docs/content/policy-reference.md
+++ b/docs/content/policy-reference.md
@@ -1100,15 +1100,7 @@ REPL | `notes` | n/a | The "notes" command enables trace explanations. See `help
 
 | Built-in | Description | Wasm Support |
 | ------- |-------------|---------------|
-| <span class="opa-keep-it-together">``fs.readfile(file_path)``</span> | ``fs.readfile`` opens ``file_path`` as a ``Note`` event in the query explanation. Query explanations show the exact expressions evaluated by OPA during policy execution. For example, ``trace("Hello There!")`` includes ``Note "Hello There!"`` in the query explanation. To include variables in the message, use ``sprintf``. For example, ``person := "Bob"; trace(sprintf("Hello There! %v", [person]))`` will emit ``Note "Hello There! Bob"`` inside of the explanation. | ``SDK-dependent`` |
-
-By default, explanations are disabled. The following table summarizes how you can enable tracing:
-
-API | Parameter | Example | Memo
---- | --- | --- | ---
-CLI | `--explain` | `opa eval --explain=notes --format=pretty 'trace("hello world")'` |
-HTTP | `explain=notes` | `curl localhost:8181/v1/data/example/allow?explain=notes&pretty` |
-REPL | `notes` | n/a | The "notes" command enables trace explanations. See `help` for more details.
+| <span class="opa-keep-it-together">``fs.readfile(file_path)``</span> | ``output := fs.readfile`` opens the ``file_path`` file and returns all the content to ``output``  | ``SDK-dependent`` |
 
 ## Reserved Names
 

--- a/test/cases/testdata/fs/test-fs-1070.yaml
+++ b/test/cases/testdata/fs/test-fs-1070.yaml
@@ -1,0 +1,14 @@
+cases:
+- note: fs/read_file
+  query: data.test.p = x
+  modules:
+  - |
+    package test
+    p = fs.readfile(input.file)
+  input: {"file": "../topdown/testdata/ca.pem"}
+  want_result: [{x: "-----BEGIN CERTIFICATE-----\nMIIDATCCAemgAwIBAgIUZh0dmUOZ+xR/WnyK+APueJFe6OgwDQYJKoZIhvcNAQEL\nBQAwEDEOMAwGA1UEAwwFbXktY2EwHhcNMjExMDI0MDgyNzIxWhcNMzExMDIyMDgy\nNzIxWjAQMQ4wDAYDVQQDDAVteS1jYTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCC\nAQoCggEBAMb8vC9kCTMQ3JTiHuCJjf1IPuqNPWX+j9PbeSmVibb5xdoo7ZEcxKsP\nBB5GmiqwfiqWi85jWXONn314sEdn2QCUn7sLVjPI5udpBBqBLH9v80vUi/yRwfVR\nEdVayPktHUR4tlrO1WD14H545Pk42ayrB7cCbZxj/VdO95VmIuJlB+kFWab5bepL\nAEcV0GvnMkDaJhWc0IYHc9Rl9zv/EdoLVmCGqBtpzF7vt1mu6XeChG5zLRw9Grvr\nZLwouu8ahMXnLWG5hDuxF67rjniqmAdfNm3lYsJHJ8duNRtUST3HZpmGr77vh+aH\nYn5H1HepLsT1gdyaDESeq8QABd50Y/8CAwEAAaNTMFEwHQYDVR0OBBYEFL1uOISV\n+Bcay1Ik3PhLsPERcxtoMB8GA1UdIwQYMBaAFL1uOISV+Bcay1Ik3PhLsPERcxto\nMA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBABzNhRXqhHn3s2O8\nzrgWUD0w/i13KlnWFsno2g8Zxxi/kK5HHyUR8roBKyGShZHiYB8pUdbZXXtzwzed\nYBjDqndhu6mhxwEeaKlVG6Yi8sNPfUKUVBBQ9KvA473geNBgfT0FapyaFHcvtvAT\nTPVLdKSqSi8QDaGywFpuce81b9yZMxDYgU3ICktpLq3qn79s5UPMyyS89LMUeQt2\nmdvSx/s9xVfB7whzciLea9nubZDRsSgxKDoGoKnv58fpjSeXEgZzqAM6hc5Ys3tj\nKkJIvfs0g/ijAfKcBkIBPazqxDZK7zHwmSramHsMnWc+l/7JkfDjB8SFghtliy8V\nBnahd2k=\n-----END CERTIFICATE-----\n"}]
+- note: fs/read_file_when_file_does_not_exists
+  query: fs.readfile("/it_does_not_exists.txt")
+  want_error_code: eval_builtin_error
+  want_error: 'fs.readfile("/it_does_not_exists.txt"): eval_builtin_error: fs.readfile: open /it_does_not_exists.txt: no such file or directory'
+  strict_error: true

--- a/topdown/fs.go
+++ b/topdown/fs.go
@@ -1,0 +1,33 @@
+// Copyright 2021 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package topdown
+
+import (
+	"io/ioutil"
+	"path/filepath"
+
+	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/topdown/builtins"
+)
+
+func builtinReadFile(a ast.Value) (ast.Value, error) {
+	s, err := builtins.StringOperand(a, 1)
+	if err != nil {
+		return nil, err
+	}
+	path, err := filepath.Abs(string(s))
+	if err != nil {
+		return nil, err
+	}
+	content, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return ast.String(string(content[:])), nil
+}
+
+func init() {
+	RegisterFunctionalBuiltin1(ast.ReadFile.Name, builtinReadFile)
+}

--- a/topdown/fs_test.go
+++ b/topdown/fs_test.go
@@ -1,0 +1,68 @@
+// Copyright 2021 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package topdown_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/storage/inmem"
+	"github.com/open-policy-agent/opa/topdown"
+	"github.com/open-policy-agent/opa/util/test"
+)
+
+func TestReadAValidFile(t *testing.T) {
+	files := map[string]string{
+		"token": `ZXlKaGJHY2lPaUpTV`,
+	}
+	test.WithTempFS(files, func(root string) {
+		ctx := context.Background()
+		compiler := ast.NewCompiler()
+		query, err := compiler.QueryCompiler().Compile(ast.MustParseBody(`x = fs.readfile(data.file)`))
+		if err != nil {
+			panic(err)
+		}
+		var data map[string]interface{}
+		decoder := json.NewDecoder(bytes.NewBufferString(fmt.Sprintf(`{"file": "%s/token"}`, root)))
+
+		if err := decoder.Decode(&data); err != nil {
+			panic(err)
+		}
+		store := inmem.NewFromObject(data)
+		txn, err := store.NewTransaction(ctx)
+		if err != nil {
+			panic(err)
+		}
+		defer store.Abort(ctx, txn)
+		q := topdown.NewQuery(query).
+			WithCompiler(compiler).
+			WithStore(store).
+			WithTransaction(txn)
+
+		result := []interface{}{}
+
+		err = q.Iter(ctx, func(qr topdown.QueryResult) error {
+			x := qr[ast.Var("x")]
+			v, err := ast.JSON(x.Value)
+			if err != nil {
+				panic(err)
+			}
+
+			result = append(result, v)
+			return nil
+		})
+		if err != nil {
+			panic(err)
+		}
+
+		if result[0].(string) != files["token"] {
+			t.Errorf("Variable x should be the file content %s", files["token"])
+		}
+	})
+}


### PR DESCRIPTION
<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->

This pr is adding a new built-in to read all content from a single file on the filesystem . My current user case is read a token volume projection from Kubernetes https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-token-volume-projection
