### PR TITLE
binary: add sha256 checksum to downloads

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -265,24 +265,28 @@ ci-build-linux: ensure-release-dir
 	@$(MAKE) build GOOS=linux
 	chmod +x opa_linux_$(GOARCH)
 	mv opa_linux_$(GOARCH) $(RELEASE_DIR)/
+	cd $(RELEASE_DIR)/ && shasum -a 256 opa_linux_$(GOARCH) > opa_linux_$(GOARCH).sha256
 
 .PHONY: ci-build-linux-static
 ci-build-linux-static: ensure-release-dir
 	@$(MAKE) build GOOS=linux WASM_ENABLED=0 CGO_ENABLED=0
 	chmod +x opa_linux_$(GOARCH)
 	mv opa_linux_$(GOARCH) $(RELEASE_DIR)/opa_linux_$(GOARCH)_static
+	cd $(RELEASE_DIR)/ && shasum -a 256 opa_linux_$(GOARCH)_static > opa_linux_$(GOARCH)_static.sha256
 
 .PHONY: ci-build-darwin
 ci-build-darwin: ensure-release-dir
 	@$(MAKE) build GOOS=darwin
 	chmod +x opa_darwin_$(GOARCH)
 	mv opa_darwin_$(GOARCH) $(RELEASE_DIR)/
+	cd $(RELEASE_DIR)/ && shasum -a 256 opa_darwin_$(GOARCH) > opa_darwin_$(GOARCH).sha256
 
 .PHONY: ci-build-darwin-arm64-static
 ci-build-darwin-arm64-static: ensure-release-dir
 	@$(MAKE) build GOOS=darwin GOARCH=arm64 WASM_ENABLED=0 CGO_ENABLED=0
 	chmod +x opa_darwin_arm64
 	mv opa_darwin_arm64 $(RELEASE_DIR)/opa_darwin_arm64_static
+	cd $(RELEASE_DIR)/ && shasum -a 256 opa_darwin_arm64_static > opa_darwin_arm64_static.sha256
 
 # NOTE: This target expects to be run as root on some debian/ubuntu variant
 # that can install the `gcc-mingw-w64-x86-64` package via apt-get.
@@ -291,6 +295,7 @@ ci-build-windows: ensure-release-dir
 	build/ensure-windows-toolchain.sh
 	@$(MAKE) build GOOS=windows CC=x86_64-w64-mingw32-gcc
 	mv opa_windows_$(GOARCH) $(RELEASE_DIR)/opa_windows_$(GOARCH).exe
+	cd $(RELEASE_DIR)/ && shasum -a 256 opa_windows_$(GOARCH).exe > opa_windows_$(GOARCH).exe.sha256
 
 .PHONY: ensure-release-dir
 ensure-release-dir:
@@ -359,11 +364,7 @@ push-latest:
 
 .PHONY: push-binary-edge
 push-binary-edge:
-	aws s3 cp $(RELEASE_DIR)/opa_darwin_$(GOARCH) s3://$(S3_RELEASE_BUCKET)/edge/opa_darwin_$(GOARCH)
-	aws s3 cp $(RELEASE_DIR)/opa_darwin_arm64_static s3://$(S3_RELEASE_BUCKET)/edge/opa_darwin_arm64_static
-	aws s3 cp $(RELEASE_DIR)/opa_windows_$(GOARCH).exe s3://$(S3_RELEASE_BUCKET)/edge/opa_windows_$(GOARCH).exe
-	aws s3 cp $(RELEASE_DIR)/opa_linux_$(GOARCH) s3://$(S3_RELEASE_BUCKET)/edge/opa_linux_$(GOARCH)
-	aws s3 cp $(RELEASE_DIR)/opa_linux_$(GOARCH)_static s3://$(S3_RELEASE_BUCKET)/edge/opa_linux_$(GOARCH)_static
+	aws s3 sync $(RELEASE_DIR) s3://$(S3_RELEASE_BUCKET)/edge/ --delete
 
 .PHONY: tag-edge
 tag-edge:

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -664,6 +664,15 @@ chmod 755 ./opa
 > You can also download and run OPA via Docker. The latest stable image tag is
 > `openpolicyagent/opa:{{< current_docker_version >}}`.
 
+#### Checksums
+Checksums for all binaries are available in the download path by appending `.sha256` to the binary filename. 
+Verify the macOS binary checksum:
+```shell
+curl -L -o opa_darwin_amd64 https://openpolicyagent.org/downloads/{{< current_version >}}/opa_darwin_amd64
+curl -L -o opa_darwin_amd64.sha256 https://openpolicyagent.org/downloads/{{< current_version >}}/opa_darwin_amd64.sha256
+shasum -c opa_darwin_amd64.sha256
+```
+
 ### 2. Try `opa eval`
 
 The simplest way to interact with OPA is via the command-line using the `opa


### PR DESCRIPTION
Adds sha256 checksum to all binaries

These checksums can be used to verify file integrity.


Fixes #3448
