### PR TITLE
Add v1/status endpoint

### DIFF
--- a/docs/content/rest-api.md
+++ b/docs/content/rest-api.md
@@ -1521,13 +1521,9 @@ that the server is operational. Optionally it can account for bundle activation 
 (useful for "ready" checks at startup).
 
 #### Query Parameters
-`bundles` - Boolean parameter to account for bundle activation status in response. This includes
-            any discovery bundles or bundles defined in the loaded discovery configuration.
-`plugins` - Boolean parameter to account for plugin status in response.
-`exclude-plugin` - String parameter to exclude a plugin from status checks. Can be added multiple
-            times. Does nothing if `plugins` is not true. This parameter is useful for special use cases
-            where a plugin depends on the server being fully initialized before it can fully intialize
-            itself.
+* `bundles` - Boolean parameter to account for bundle activation status in response. This includes any discovery bundles or bundles defined in the loaded discovery configuration.
+* `plugins` - Boolean parameter to account for plugin status in response.
+* `exclude-plugin` - String parameter to exclude a plugin from status checks. Can be added multiple times. Does nothing if `plugins` is not true. This parameter is useful for special use cases where a plugin depends on the server being fully initialized before it can fully intialize itself.
 
 #### Status Codes
 - **200** - OPA service is healthy. If the `bundles` option is specified then all configured bundles have
@@ -1536,9 +1532,11 @@ that the server is operational. Optionally it can account for bundle activation 
             bundles have not yet been activated. If the `plugins` option is specified then at least one
             plugin is in a non-OK state.
 
-> *Note*: The bundle activation check is only for initial bundle activation. Subsequent downloads
-  will not affect the health check. The [Status](../management-status)
-  API should be used for more fine-grained bundle status monitoring.
+{{< info >}}
+The bundle activation check is only for initial bundle activation. Subsequent
+downloads will not affect the health check. The [Status](../management-status)
+API should be used for more fine-grained bundle status monitoring.
+{{< /info >}}
 
 #### Example Request
 ```http
@@ -1609,16 +1607,16 @@ is defined under package `system.health`.
 Here is a basic health policy for liveness and readiness. In this example, OPA is live once it is
 able to process the `live` rule. OPA is ready once all plugins have entered the OK state at least once.
 
-```rego
+```live:health_policy_example:module:read_only
 package system.health
 
-// opa is live if it can process this rule
+# opa is live if it can process this rule
 default live = true
 
-// by default, opa is not ready
+# by default, opa is not ready
 default ready = false
 
-// opa is ready once all plugins have reported OK at least once
+# opa is ready once all plugins have reported OK at least once
 ready {
   input.plugins_ready
 }
@@ -1627,15 +1625,15 @@ ready {
 Note that once `input.plugins_ready` is true, it stays true. If you want to fail the ready check when
 specific a plugin leaves the OK state, try this:
 
-```rego
+```live:health_policy_example_2:module:read_only
 package system.health
 
 default live = true
 
 default ready = false
 
-// opa is ready once all plugins have reported OK at least once AND
-// the bundle plugin is currently in an OK state
+# opa is ready once all plugins have reported OK at least once AND
+# the bundle plugin is currently in an OK state
 ready {
   input.plugins_ready
   input.plugin_state.bundle == "OK"

--- a/download/download.go
+++ b/download/download.go
@@ -278,7 +278,9 @@ func (d *Downloader) download(ctx context.Context, m metrics.Metrics) (*download
 		}
 	}
 
+	m.Timer(metrics.BundleRequest).Start()
 	resp, err := d.client.Do(ctx, "GET", d.path)
+	m.Timer(metrics.BundleRequest).Stop()
 	if err != nil {
 		return nil, errors.Wrap(err, "request failed")
 	}

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -19,6 +19,7 @@ import (
 
 // Well-known metric names.
 const (
+	BundleRequest       = "bundle_request"
 	ServerHandler       = "server_handler"
 	ServerQueryCacheHit = "server_query_cache_hit"
 	SDKDecisionEval     = "sdk_decision_eval"

--- a/plugins/status/plugin.go
+++ b/plugins/status/plugin.go
@@ -41,25 +41,22 @@ type UpdateRequestV1 struct {
 
 // Plugin implements status reporting. Updates can be triggered by the caller.
 type Plugin struct {
-	manager          *plugins.Manager
-	config           Config
-	bundleCh         chan bundle.Status // Deprecated: Use bulk bundle status updates instead
-	lastBundleStatus *bundle.Status     // Deprecated: Use bulk bundle status updates instead
-
+	manager            *plugins.Manager
+	config             Config
+	bundleCh           chan bundle.Status // Deprecated: Use bulk bundle status updates instead
+	lastBundleStatus   *bundle.Status     // Deprecated: Use bulk bundle status updates instead
 	bulkBundleCh       chan map[string]*bundle.Status
 	lastBundleStatuses map[string]*bundle.Status
-
-	discoCh         chan bundle.Status
-	lastDiscoStatus *bundle.Status
-
+	discoCh            chan bundle.Status
+	lastDiscoStatus    *bundle.Status
 	pluginStatusCh     chan map[string]*plugins.Status
 	lastPluginStatuses map[string]*plugins.Status
-
-	stop     chan chan struct{}
-	reconfig chan interface{}
-	metrics  metrics.Metrics
-	logger   logging.Logger
-	trigger  chan trigger
+	queryCh            chan chan *UpdateRequestV1
+	stop               chan chan struct{}
+	reconfig           chan interface{}
+	metrics            metrics.Metrics
+	logger             logging.Logger
+	trigger            chan trigger
 }
 
 // Config contains configuration for the plugin.
@@ -197,6 +194,7 @@ func New(parsedConfig *Config, manager *plugins.Manager) *Plugin {
 		stop:           make(chan chan struct{}),
 		reconfig:       make(chan interface{}),
 		pluginStatusCh: make(chan map[string]*plugins.Status),
+		queryCh:        make(chan chan *UpdateRequestV1),
 		logger:         manager.Logger().WithFields(map[string]interface{}{"plugin": Name}),
 		trigger:        make(chan trigger),
 	}
@@ -276,6 +274,14 @@ func (p *Plugin) Reconfigure(_ context.Context, config interface{}) {
 	p.reconfig <- config
 }
 
+// Snapshot returns the current status.
+func (p *Plugin) Snapshot() *UpdateRequestV1 {
+	ch := make(chan *UpdateRequestV1)
+	p.queryCh <- ch
+	s := <-ch
+	return s
+}
+
 // Trigger can be used to control when the plugin attempts to upload
 //status in manual triggering mode.
 func (p *Plugin) Trigger(ctx context.Context) error {
@@ -339,6 +345,8 @@ func (p *Plugin) loop() {
 			}
 		case newConfig := <-p.reconfig:
 			p.reconfigure(newConfig)
+		case respCh := <-p.queryCh:
+			respCh <- p.snapshot()
 		case update := <-p.trigger:
 			err := p.oneShot(update.ctx)
 			if err != nil {
@@ -360,17 +368,7 @@ func (p *Plugin) loop() {
 
 func (p *Plugin) oneShot(ctx context.Context) error {
 
-	req := &UpdateRequestV1{
-		Labels:    p.manager.Labels(),
-		Discovery: p.lastDiscoStatus,
-		Bundle:    p.lastBundleStatus,
-		Bundles:   p.lastBundleStatuses,
-		Plugins:   p.lastPluginStatuses,
-	}
-
-	if p.metrics != nil {
-		req.Metrics = map[string]interface{}{p.metrics.Info().Name: p.metrics.All()}
-	}
+	req := p.snapshot()
 
 	if p.config.ConsoleLogs {
 		err := p.logUpdate(req)
@@ -422,6 +420,23 @@ func (p *Plugin) reconfigure(config interface{}) {
 
 	p.logger.Info("Status reporter configuration changed.")
 	p.config = *newConfig
+}
+
+func (p *Plugin) snapshot() *UpdateRequestV1 {
+
+	s := &UpdateRequestV1{
+		Labels:    p.manager.Labels(),
+		Discovery: p.lastDiscoStatus,
+		Bundle:    p.lastBundleStatus,
+		Bundles:   p.lastBundleStatuses,
+		Plugins:   p.lastPluginStatuses,
+	}
+
+	if p.metrics != nil {
+		s.Metrics = map[string]interface{}{p.metrics.Info().Name: p.metrics.All()}
+	}
+
+	return s
 }
 
 func (p *Plugin) logUpdate(update *UpdateRequestV1) error {

--- a/server/types/types.go
+++ b/server/types/types.go
@@ -379,6 +379,11 @@ type ConfigResponseV1 struct {
 	Result *interface{} `json:"result,omitempty"`
 }
 
+// StatusResponseV1 models the response message for Status API (pull) operations.
+type StatusResponseV1 struct {
+	Result *interface{} `json:"result,omitempty"`
+}
+
 // HealthResponseV1 models the response message for Health API operations.
 type HealthResponseV1 struct {
 	Error string `json:"error,omitempty"`


### PR DESCRIPTION
This is the initial implementation of the v1/status endpoint. The server looks up the status plugin and fetches a snapshot of the status information to return the caller. If the status plugin is not enabled, the endpoint returns a 500 response. 