### PR TITLE
format: ensure future keyword import with `in`

### DIFF
--- a/format/testfiles/test_in_operator_with_all_keywords_import.rego
+++ b/format/testfiles/test_in_operator_with_all_keywords_import.rego
@@ -1,0 +1,9 @@
+package p
+
+import input.foo
+import future.keywords
+
+r {
+	internal.member_2(1, [1])
+	internal.member_3(0, 1, [1])
+}

--- a/format/testfiles/test_in_operator_with_all_keywords_import.rego.formatted
+++ b/format/testfiles/test_in_operator_with_all_keywords_import.rego.formatted
@@ -1,0 +1,9 @@
+package p
+
+import future.keywords
+import input.foo
+
+r {
+	1 in [1]
+	0, 1 in [1]
+}

--- a/format/testfiles/test_in_operator_without_import.rego
+++ b/format/testfiles/test_in_operator_without_import.rego
@@ -1,0 +1,8 @@
+package p
+
+import input.foo
+
+r {
+	internal.member_2(1, [1])
+	internal.member_3(0, 1, [1])
+}

--- a/format/testfiles/test_in_operator_without_import.rego.formatted
+++ b/format/testfiles/test_in_operator_without_import.rego.formatted
@@ -1,0 +1,9 @@
+package p
+
+import future.keywords.in
+import input.foo
+
+r {
+	1 in [1]
+	0, 1 in [1]
+}


### PR DESCRIPTION
When a module is formatted that has calls to `internal.member_2` or
`internal.member_3`, which get pretty-printed as infix `in` operator
calls, the formatter now ensures that the corresponding future keyword
import is present.

---

Fixes #4111.