### PR TITLE
fix: Forward SDK config to runtime config

### DIFF
--- a/sdk/opa.go
+++ b/sdk/opa.go
@@ -101,7 +101,7 @@ func (opa *OPA) Configure(ctx context.Context, opts ConfigOptions) error {
 }
 
 func (opa *OPA) configure(ctx context.Context, bs []byte, ready chan struct{}, block bool) error {
-	info, err := runtime.Term(runtime.Params{})
+	info, err := runtime.Term(runtime.Params{Config: opa.config})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Updates runtime generation to include the `opa.config`.  @oren-zohar added this functionality yesterday (thank you!), but when I was playing around with it, I noticed the provided config wasn't honored when initializing the SDK. This should take care of it.

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->
