### PR TITLE
Kafka tutorial: new plugin + management APIs

### DIFF
--- a/docs/content/kafka-authorization.md
+++ b/docs/content/kafka-authorization.md
@@ -15,8 +15,8 @@ This tutorial shows how to enforce fine-grained access control over Kafka
 topics. In this tutorial you will use OPA to define and enforce an
 authorization policy stating:
 
-* Consumers of topics containing Personally Identifiable Information (PII) must be whitelisted.
-* Producers to topics with _high fanout_ must be whitelisted.
+* Consumers of topics containing Personally Identifiable Information (PII) must be on allow list.
+* Producers to topics with _high fanout_ must be on allow list.
 
 In addition, this tutorial shows how to break up a policy with small helper
 rules to reuse logic and improve overall readability.
@@ -25,86 +25,114 @@ rules to reuse logic and improve overall readability.
 
 This tutorial requires [Docker Compose](https://docs.docker.com/compose/install/) to run Kafka, ZooKeeper, and OPA.
 
+Additionally, we'll use Nginx for serving policy and data bundles to OPA. This component is however easily replaceable
+by any other bundle server [implementation](../management-bundles/#implementations).
+
 ## Steps
 
 ### 1. Bootstrap the tutorial environment using Docker Compose.
 
-First, create an OPA policy that allows all requests. You will update this policy later in the tutorial.
+First, let's create some directories. We'll create one for our policy files, a second one for built bundles, and a third
+one or the OPA authorizer plugin.
 
 ```bash
-mkdir -p policies
+mkdir policies bundles plugin
 ```
+
+Next, create an OPA policy that allows all requests. You will update this policy later in the tutorial.
 
 **policies/tutorial.rego**:
 
 ```live:start:module:read_only
 package kafka.authz
 
-allow = true
+allow := true
 ```
 
-Next, create a `docker-compose.yaml` file that runs OPA, ZooKeeper, and Kafka.
+With the policy in place, build a bundle from the contents of the `policies` directory and place it in the `bundles`
+directory. The `bundles` directory will later be mounted into the Nginx container in order to distribute policy updates
+to OPA.
+
+```shell
+opa build --bundle policies/ --output bundles/bundle.tar.gz
+```
+
+#### Kafka Authorizer JAR File
+
+Next, download the latest version of the [Open Policy Agent plugin for Kafka authorization](https://github.com/anderseknert/opa-kafka-plugin)
+plugin from the projects [release pages](https://github.com/anderseknert/opa-kafka-plugin/releases).
+
+Store the plugin in the `plugin` directory (replace `${version}` with the version number of the plugin just downloaded):
+```bash
+mv opa-authorizer-${version}-all.jar plugin/
+```
+
+For more information on how to configure the OPA plugin for Kafka, see the plugin [repository](https://github.com/anderseknert/opa-kafka-plugin).
+
+Next, create a `docker-compose.yaml` file that runs OPA, Nginx, ZooKeeper, and Kafka.
 
 **docker-compose.yaml**:
 
 ```yaml
-version: "2"
 services:
-  opa:
-    hostname: opa
-    image: openpolicyagent/opa:{{< current_docker_version >}}
-    ports:
-      - 8181:8181
-    # WARNING: OPA is NOT running with an authorization policy configured. This
-    # means that clients can read and write policies in OPA. If you are deploying
-    # OPA in an insecure environment, you should configure authentication and
-    # authorization on the daemon. See the Security page for details:
-    # https://www.openpolicyagent.org/docs/security.html.
-    command: "run --server --watch /policies"
+  nginx:
+    image: nginx:1.21.4
     volumes:
-      - ./policies:/policies
-  zookeeper:
-    image: confluentinc/cp-zookeeper:4.0.0-3
-    environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
-      zk_id: "1"
-  kafka:
-    hostname: kafka
-    image: openpolicyagent/demo-kafka:1.0
-    links:
-      - zookeeper
-      - opa
+      - "./bundles:/usr/share/nginx/html"
     ports:
-      - "9092:9092"
+      - "80:80"
+  opa:
+    image: openpolicyagent/opa:{{< current_docker_version >}}-rootless
+    ports:
+      - "8181:8181"
+    command:
+      - "run"
+      - "--server"
+      - "--set=decision_logs.console=true"
+      - "--set=services.authz.url=http://nginx"
+      - "--set=bundles.authz.service=authz"
+      - "--set=bundles.authz.resource=bundle.tar.gz"
+    depends_on:
+      - nginx
+  zookeeper:
+    image: confluentinc/cp-zookeeper:6.2.1
+    ports:
+      - "2181:2181"
     environment:
-      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: "1"
+      - ALLOW_ANONYMOUS_LOGIN=yes
+      - ZOOKEEPER_CLIENT_PORT=2181
+  broker:
+    image: confluentinc/cp-kafka:6.2.1
+    ports:
+      - "9093:9093"
+    environment:
+      # Set cache expiry to low value for development in order to see decisions
+      KAFKA_OPA_AUTHORIZER_CACHE_EXPIRE_AFTER_SECONDS: 10
+      KAFKA_OPA_AUTHORIZER_URL: http://opa:8181/v1/data/kafka/authz/allow
+      KAFKA_AUTHORIZER_CLASS_NAME: org.openpolicyagent.kafka.OpaAuthorizer
+      KAFKA_BROKER_ID: 1
       KAFKA_ZOOKEEPER_CONNECT: "zookeeper:2181"
-      KAFKA_ADVERTISED_LISTENERS: "SSL://:9093"
+      KAFKA_ADVERTISED_LISTENERS: SSL://localhost:9093
       KAFKA_SECURITY_INTER_BROKER_PROTOCOL: SSL
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
+      KAFKA_SSL_KEYSTORE_FILENAME: server.keystore
+      KAFKA_SSL_KEYSTORE_CREDENTIALS: credentials.txt
+      KAFKA_SSL_KEY_CREDENTIALS: credentials.txt
+      KAFKA_SSL_TRUSTSTORE_FILENAME: server.truststore
+      KAFKA_SSL_TRUSTSTORE_CREDENTIALS: credentials.txt
       KAFKA_SSL_CLIENT_AUTH: required
-      KAFKA_SSL_KEYSTORE_FILENAME: kafka.broker.keystore.jks
-      KAFKA_SSL_KEYSTORE_CREDENTIALS: broker_keystore_creds
-      KAFKA_SSL_KEY_CREDENTIALS: broker_sslkey_creds
-      KAFKA_SSL_TRUSTSTORE_FILENAME: kafka.broker.truststore.jks
-      KAFKA_SSL_TRUSTSTORE_CREDENTIALS: broker_truststore_creds
-      KAFKA_AUTHORIZER_CLASS_NAME: com.lbg.kafka.opa.OpaAuthorizer
-      KAFKA_OPA_AUTHORIZER_URL: "http://opa:8181/v1/data/kafka/authz/allow"
-      KAFKA_OPA_AUTHORIZER_ALLOW_ON_ERROR: "false"
-      KAFKA_OPA_AUTHORIZER_CACHE_INITIAL_CAPACITY: 100
-      KAFKA_OPA_AUTHORIZER_CACHE_MAXIMUM_SIZE: 100
-      KAFKA_OPA_AUTHORIZER_CACHE_EXPIRE_AFTER_MS: 600000
+      CLASSPATH: "/plugin/*"
+    volumes:
+      - "./plugin:/plugin"
+      - "./cert/server:/etc/kafka/secrets"
+    depends_on:
+      - opa
+      - zookeeper
 ```
-
-For more information on how to configure the OPA plugin for Kafka, see the [github.com/open-policy-agent/contrib](https://github.com/open-policy-agent/contrib)
-repository.
-
-Once you have created the file, launch the containers for this tutorial.
-
-```bash
-docker-compose --project-name opa-kafka-tutorial up
-```
-
-Now that the tutorial environment is running, we can define an authorization policy using OPA and test it.
 
 #### Authentication
 
@@ -115,43 +143,89 @@ example below shows the input structure.
 
 ```json
 {
-  "operation": {
-    "name": "Write"
-  },
-  "resource": {
-    "resourceType": {
-      "name": "Topic"
+  "action": {
+    "logIfAllowed": true,
+    "logIfDenied": true,
+    "operation": "WRITE",
+    "resourcePattern": {
+      "name": "credit-scores",
+      "patternType": "LITERAL",
+      "resourceType": "TOPIC",
+      "unknown": false
     },
-    "name": "credit-scores"
+    "resourceReferenceCount": 1
   },
-  "session": {
+  "requestContext": {
+    "clientAddress": "/172.22.0.1",
+    "clientInformation": {
+      "softwareName": "apache-kafka-java",
+      "softwareVersion": "2.8.1"
+    },
+    "connectionId": "172.22.0.5:9093-172.22.0.1:62744-2",
+    "header": {
+      "headerVersion": 2,
+      "name": {
+        "clientId": "consumer-console-producer-63933-1",
+        "correlationId": 10,
+        "requestApiKey": 1,
+        "requestApiVersion": 12
+      }
+    },
+    "listenerName": "SSL",
     "principal": {
+      "name": "CN=anon_producer,OU=Developers",
       "principalType": "User"
     },
-    "clientAddress": "172.21.0.5",
-    "sanitizedUser": "CN%3Danon_producer.tutorial.openpolicyagent.org%2COU%3DTUTORIAL%2CO%3DOPA%2CL%3DSF%2CST%3DCA%2CC%3DUS"
+    "securityProtocol": "SSL"
   }
 }
 ```
 
 The client identity is extracted from the SSL certificates that clients
-present when they connect to the broker. The client identity information is
-encoded in the `input.session.sanitizedUser` field. This field can be decoded
-inside the policy.
+present when they connect to the broker. The user identity information is
+encoded in the `input.requestContext.principal.name` field.
+This field can be used inside the policy.
 
-Generating SSL certificates and JKS files required for SSL client
-authentication is outside the scope of this tutorial. To simplify the steps
-below, the Docker Compose file uses an extended version of the
-[confluentinc/cp-kafka](https://hub.docker.com/r/confluentinc/cp-kafka/)
-image from Docker Hub. The extended image includes **pre-generated SSL
-certificates** that the broker and clients use to identify themselves.
+A detailed rundown of generating SSL certificates and JKS files required
+for SSL client authentication is outside the scope of this tutorial, but the plugin
+repository provides an [example script](https://github.com/anderseknert/opa-kafka-plugin/tree/main/example/opa_tutorial/create_cert.sh)
+that demonstrates the creation of client certificates for the four different
+users used in this tutorial:
 
-Do not rely on these pre-generated SSL certificates in real-world scenarios.
+* `anon_producer`
+* `anon_consumer`
+* `pii_consumer`
+* `fanout_producer`
+
+Lets' download the script and run it:
+
+```shell
+curl -O https://raw.githubusercontent.com/anderseknert/opa-kafka-plugin/main/example/opa_tutorial/create_cert.sh
+chmod +x create_cert.sh
+./create_cert.sh
+```
+
+We should now find a new `cert` directory created by the script,
+containing the server and client certificates we'll need for TLS
+authentication.
+
+Note: Do not rely on these SSL certificates in real-world scenarios.
 They are only provided for convenience/test purposes.
 
-#### Kafka Authorizer JAR File
+If you'd rather set up these users by other means, like one
+of the available SASL mechanisms Kafka provides, that should work
+just as well. Just make sure to update the Docker compose file
+accordingly.
 
-The Kafka image used in this tutorial includes a pre-installed JAR file that implements the [Kafka Authorizer](https://kafka.apache.org/documentation/#security_authz) interface. For more information on the authorizer see [open-policy-agent/contrib/kafka_authorizer](https://github.com/open-policy-agent/contrib/tree/main/kafka_authorizer).
+Once you have created the files needed for authentication,
+you may launch the containers for this tutorial.
+
+```bash
+docker-compose --project-name opa-kafka-tutorial up
+```
+
+Now that the tutorial environment is running, we can define an authorization policy using OPA and test it.
+
 
 ### 2. Define a policy to restrict consumer access to topics containing Personally Identifiable Information (PII).
 
@@ -170,6 +244,8 @@ Update the `policies/tutorial.rego` with the following content.
 #-----------------------------------------------------------------------------
 package kafka.authz
 
+import future.keywords.in
+
 default allow = false
 
 allow {
@@ -179,7 +255,7 @@ allow {
 deny {
 	is_read_operation
 	topic_contains_pii
-	not consumer_is_whitelisted_for_pii
+	not consumer_is_allowlisted_for_pii
 }
 
 #-----------------------------------------------------------------------------
@@ -188,7 +264,7 @@ deny {
 # data could be pulled from external sources like AD, Git, etc.
 #-----------------------------------------------------------------------------
 
-consumer_whitelist = {"pii": {"pii_consumer"}}
+consumer_allowlist = {"pii": {"pii_consumer"}}
 
 topic_metadata = {"credit-scores": {"tags": ["pii"]}}
 
@@ -197,11 +273,11 @@ topic_metadata = {"credit-scores": {"tags": ["pii"]}}
 #-----------------------------------
 
 topic_contains_pii {
-	topic_metadata[topic_name].tags[_] == "pii"
+	"pii" in topic_metadata[topic_name].tags
 }
 
-consumer_is_whitelisted_for_pii {
-	consumer_whitelist.pii[_] == principal.name
+consumer_is_allowlisted_for_pii {
+	principal.name in consumer_allowlist.pii
 }
 
 #-----------------------------------------------------------------------------
@@ -211,25 +287,27 @@ consumer_is_whitelisted_for_pii {
 #-----------------------------------------------------------------------------
 
 is_write_operation {
-    input.operation.name == "Write"
+    input.action.operation == "WRITE"
 }
 
 is_read_operation {
-	input.operation.name == "Read"
+	input.action.operation == "READ"
 }
 
 is_topic_resource {
-	input.resource.resourceType.name == "Topic"
+	input.action.resourcePattern.resourceType == "TOPIC"
 }
 
-topic_name = input.resource.name {
+topic_name = input.action.resourcePattern.name {
 	is_topic_resource
 }
 
 principal = {"fqn": parsed.CN, "name": cn_parts[0]} {
-	parsed := parse_user(urlquery.decode(input.session.sanitizedUser))
+	parsed := parse_user(input.requestContext.principal.name)
 	cn_parts := split(parsed.CN, ".")
-}
+} 
+# If client certificates aren't used for authentication
+else = {"fqn": "", "name": input.requestContext.principal.name}
 
 parse_user(user) = {key: value |
 	parts := split(user, ",")
@@ -240,7 +318,7 @@ parse_user(user) = {key: value |
 The Kafka authorization plugin is configured to query for the
 `data.kafka.authz.allow` decision. If the response is `true` the operation is
 allowed, otherwise the operation is denied. When the integration queries OPA it
-supplies a JSON representation of the operation, resource, and principal.
+supplies a JSON representation of the operation, resource, client, and principal.
 
 ```live:example:query:hidden
 data.kafka.authz.allow
@@ -248,21 +326,40 @@ data.kafka.authz.allow
 
 ```live:example:input
 {
-  "operation": {
-    "name": "Write"
-  },
-  "resource": {
-    "resourceType": {
-      "name": "Topic"
+  "action": {
+    "logIfAllowed": true,
+    "logIfDenied": true,
+    "operation": "READ",
+    "resourcePattern": {
+      "name": "credit-scores",
+      "patternType": "LITERAL",
+      "resourceType": "TOPIC",
+      "unknown": false
     },
-    "name": "credit-scores"
+    "resourceReferenceCount": 1
   },
-  "session": {
+  "requestContext": {
+    "clientAddress": "/172.22.0.1",
+    "clientInformation": {
+      "softwareName": "apache-kafka-java",
+      "softwareVersion": "2.8.1"
+    },
+    "connectionId": "172.22.0.5:9093-172.22.0.1:62744-2",
+    "header": {
+      "headerVersion": 2,
+      "name": {
+        "clientId": "consumer-console-producer-63933-1",
+        "correlationId": 10,
+        "requestApiKey": 1,
+        "requestApiVersion": 12
+      }
+    },
+    "listenerName": "SSL",
     "principal": {
+      "name": "CN=pii_consumer,OU=developers",
       "principalType": "User"
     },
-    "clientAddress": "172.21.0.5",
-    "sanitizedUser": "CN%3Danon_producer.tutorial.openpolicyagent.org%2COU%3DTUTORIAL%2CO%3DOPA%2CL%3DSF%2CST%3DCA%2CC%3DUS"
+    "securityProtocol": "SSL"
   }
 }
 ```
@@ -272,9 +369,14 @@ With the input value above, the answer is:
 ```live:example:output
 ```
 
-The `./policies` directory is mounted into the Docker container running OPA.
-When the files under this directory change, OPA is notified and the policies
-are automatically reloaded.
+The `./bundles` directory is mounted into the Docker container running Nginx.
+When the bundle under this directory change, OPA is notified via the bundle API,
+and the policies are automatically reloaded.
+
+You can update the bundle at any time by rebuilding it.
+```shell
+opa build --bundle policies/ --output bundles/bundle.tar.gz
+```
 
 At this point, you can exercise the policy.
 
@@ -287,13 +389,13 @@ others are not.
 First, run `kafka-console-producer` to generate some data on the
 `credit-scores` topic.
 
-> This tutorial uses the `kafka-console-producer` and `kafka-console-consumer` scripts to generate and display Kafka messages. These scripts read from STDIN and write to STDOUT and are frequently used to send and receive data via Kafka over the command line. If you are not familiar with these scripts you can learn more in Kafka's [Quick Start](https://kafka.apache.org/documentation/#quickstart) documentation.
+> This tutorial uses the `kafka-console-producer` and `kafka-console-consumer` scripts provided by Kafka to generate and display Kafka messages. These scripts read from STDIN and write to STDOUT and are frequently used to send and receive data via Kafka over the command line. If you are not familiar with these scripts you can learn more in Kafka's [Quick Start](https://kafka.apache.org/documentation/#quickstart) documentation.
 
 
 ```bash
-docker run --rm --network opakafkatutorial_default \
-    openpolicyagent/demo-kafka:1.0 \
-    bash -c 'for i in {1..10}; do echo "{\"user\": \"bob\", \"score\": $i}"; done | kafka-console-producer --topic credit-scores --broker-list kafka:9093 -producer.config /etc/kafka/secrets/anon_producer.ssl.config'
+docker run -v $(pwd)/cert/client:/tmp/client --rm --network opa-kafka-tutorial_default \
+    confluentinc/cp-kafka:6.2.1 \
+    bash -c 'for i in {1..10}; do echo "{\"user\": \"bob\", \"score\": $i}"; done | kafka-console-producer --topic credit-scores --broker-list broker:9093 -producer.config /tmp/client/anon_producer.properties'
 ```
 
 This command will send 10 messages to the `credit-scores` topic. Bob's credit
@@ -304,9 +406,9 @@ the `pii_consumer` credentials to simulate a service that is allowed to read
 PII data.
 
 ```bash
-docker run --rm --network opakafkatutorial_default \
-    openpolicyagent/demo-kafka:1.0 \
-    kafka-console-consumer --bootstrap-server kafka:9093 --topic credit-scores --from-beginning --consumer.config /etc/kafka/secrets/pii_consumer.ssl.config
+docker run -v $(pwd)/cert/client:/tmp/client --rm --network opa-kafka-tutorial_default \
+    confluentinc/cp-kafka:6.2.1 \
+    kafka-console-consumer --bootstrap-server broker:9093 --topic credit-scores --from-beginning --consumer.config /tmp/client/pii_consumer.properties
 ```
 
 This command will output the 10 messages sent to the topic in the first part
@@ -318,9 +420,9 @@ Finally, run `kafka-console-consumer` again but this time try to use the
 service that has **not** been explicitly granted access to PII data.
 
 ```bash
-docker run --rm --network opakafkatutorial_default \
-    openpolicyagent/demo-kafka:1.0 \
-    kafka-console-consumer --bootstrap-server kafka:9093 --topic credit-scores --from-beginning --consumer.config /etc/kafka/secrets/anon_consumer.ssl.config
+docker run -v $(pwd)/cert/client:/tmp/client --rm --network opa-kafka-tutorial_default \
+    confluentinc/cp-kafka:6.2.1 \
+    kafka-console-consumer --bootstrap-server broker:9093 --topic credit-scores --from-beginning --consumer.config /tmp/client/anon_consumer.properties
 ```
 
 Because the `anon_consumer` is not allowed to read PII data, the request will
@@ -338,23 +440,23 @@ First, add the following content to the policy file (`./policies/tutorial.rego`)
 
 ```live:example/deny:module:openable
 deny {
-  is_write_operation
-  topic_has_large_fanout
-  not producer_is_whitelisted_for_large_fanout
+    is_write_operation
+    topic_has_large_fanout
+    not producer_is_allowlisted_for_large_fanout
 }
 
-producer_whitelist = {
-  "large-fanout": {
-    "fanout_producer",
-  }
+producer_allowlist = {
+    "large-fanout": {
+        "fanout_producer",
+    }
 }
 
 topic_has_large_fanout {
-  topic_metadata[topic_name].tags[_] == "large-fanout"
+    topic_metadata[topic_name].tags[_] == "large-fanout"
 }
 
-producer_is_whitelisted_for_large_fanout {
-  producer_whitelist["large-fanout"][_] == principal.name
+producer_is_allowlisted_for_large_fanout {
+    producer_allowlist["large-fanout"][_] == principal.name
 }
 ```
 
@@ -363,13 +465,18 @@ that the `click-stream` topic has a high fanout.
 
 ```live:updated_metadata:module:read_only
 topic_metadata = {
-  "click-stream": {
-    "tags": ["large-fanout"],
-  },
-  "credit-scores": {
-    "tags": ["pii"],
-  }
+    "click-stream": {
+        "tags": ["large-fanout"],
+    },
+    "credit-scores": {
+        "tags": ["pii"],
+    }
 }
+```
+
+Last, build a bundle from the updated policy.
+```shell
+opa build --bundle policies/ --output bundles/bundle.tar.gz
 ```
 
 ### 5. Exercise the policy that restricts producer access to topics with high fanout.
@@ -378,17 +485,17 @@ First, run `kafka-console-producer` and simulate a service with access to the
 `click-stream` topic.
 
 ```bash
-docker run --rm --network opakafkatutorial_default \
-    openpolicyagent/demo-kafka:1.0 \
-    bash -c 'for i in {1..10}; do echo "{\"user\": \"alice\", \"button\": $i}"; done | kafka-console-producer --topic click-stream --broker-list kafka:9093 -producer.config /etc/kafka/secrets/fanout_producer.ssl.config'
+docker run -v $(pwd)/cert/client:/tmp/client --rm --network opa-kafka-tutorial_default \
+    confluentinc/cp-kafka:6.2.1 \
+    bash -c 'for i in {1..10}; do echo "{\"user\": \"alice\", \"button\": $i}"; done | kafka-console-producer --topic click-stream --broker-list broker:9093 -producer.config /tmp/client/fanout_producer.properties'
 ```
 
 Next, run the `kafka-console-consumer` to confirm that the messages were published.
 
 ```bash
-docker run --rm --network opakafkatutorial_default \
-    openpolicyagent/demo-kafka:1.0 \
-    kafka-console-consumer --bootstrap-server kafka:9093 --topic click-stream --from-beginning --consumer.config /etc/kafka/secrets/anon_consumer.ssl.config
+docker run -v $(pwd)/cert/client:/tmp/client --rm --network opa-kafka-tutorial_default \
+    confluentinc/cp-kafka:6.2.1 \
+    kafka-console-consumer --bootstrap-server broker:9093 --topic click-stream --from-beginning --consumer.config /tmp/client/anon_consumer.properties
 ```
 
 Once you see the 10 messages produced by the first part of this step, exit the console consumer (^C).
@@ -397,9 +504,9 @@ Lastly, run `kafka-console-producer` to simulate a service that should **not**
 have access to _high fanout_ topics.
 
 ```bash
-docker run --rm --network opakafkatutorial_default \
-    openpolicyagent/demo-kafka:1.0 \
-    bash -c 'echo "{\"user\": \"alice\", \"button\": \"bogus\"}" | kafka-console-producer --topic click-stream --broker-list kafka:9093 -producer.config /etc/kafka/secrets/anon_producer.ssl.config'
+docker run -v $(pwd)/cert/client:/tmp/client --rm --network opa-kafka-tutorial_default \
+    confluentinc/cp-kafka:6.2.1 \
+    bash -c 'echo "{\"user\": \"alice\", \"button\": \"bogus\"}" | kafka-console-producer --topic click-stream --broker-list broker:9093 -producer.config /tmp/client/anon_producer.properties'
 ```
 
 Because `anon_producer` is not authorized to write to high fanout topics, the
@@ -411,7 +518,7 @@ Not authorized to access topics: [click-stream]
 
 ## Wrap Up
 
-Congratulations for finishing the tutorial!
+Congratulations on finishing the tutorial!
 
 At this point you have learned how to enforce fine-grained access control
 over Kafka topics. In addition, you have seen how to break down policies into
@@ -420,5 +527,5 @@ policy.
 
 If you want to use the Kafka Authorizer plugin that integrates Kafka with
 OPA, see the build and install instructions in the
-[github.com/open-policy-agent/contrib](https://github.com/open-policy-agent/contrib)
+[opa-kafka-plugin](https://github.com/anderseknert/opa-kafka-plugin)
 repository.


### PR DESCRIPTION
Rewrite the Kafka tutorial to use the new authorizer plugin,
and use the management APIs rather than reading policy from
disk.

One decision I made here was to no longer build a special
docker image of Kafka with client certificates bundled, but
rather have a separate script for creating these. This may
add a bit of complexity, but it also makes the process more
transparent to the reader, and they are free to use other
authentication mechanisms should they want to.

A big benefit of this approach is that we don't need to
build new Kafka images whenever Kafka is updated, and
readers can just use the images provided by Confluent.

Finally, the policy examples have been reworked to use
the new authorization input format used by later versions
of Kafka.

Signed-off-by: Anders Eknert <anders@eknert.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->
