### PR TITLE
Fix Bug Preventing 3 or More Optimization Entrypoints in a Single File

### DIFF
--- a/compile/compile.go
+++ b/compile/compile.go
@@ -862,12 +862,13 @@ func (o *optimizer) getSupportModuleFilename(used map[string]int, module *ast.Mo
 
 	if err == nil && safePathPattern.MatchString(fileName) {
 		fileName = o.outputprefix + "/" + fileName
+		uniqueFileName := fileName
 		if c, ok := used[fileName]; ok {
-			fileName += fmt.Sprintf(".%d", c)
+			uniqueFileName += fmt.Sprintf(".%d", c)
 		}
 		used[fileName]++
-		fileName += ".rego"
-		return fileName
+		uniqueFileName += ".rego"
+		return uniqueFileName
 	}
 
 	return fmt.Sprintf("%v/%v/%v/%v.rego", o.outputprefix, o.nsprefix, entrypointIndex, supportIndex)

--- a/compile/compile_test.go
+++ b/compile/compile_test.go
@@ -891,7 +891,7 @@ func TestOptimizerOutput(t *testing.T) {
 		},
 		{
 			note:        "multiple entrypoints",
-			entrypoints: []string{"data.test.p", "data.test.r"},
+			entrypoints: []string{"data.test.p", "data.test.r", "data.test.s"},
 			modules: map[string]string{
 				"test.rego": `
 					package test
@@ -901,6 +901,10 @@ func TestOptimizerOutput(t *testing.T) {
 					}
 
 					r {
+						q[input.x]
+					}
+
+					s {
 						q[input.x]
 					}
 
@@ -917,6 +921,11 @@ func TestOptimizerOutput(t *testing.T) {
 					package test
 
 					r = __result__ { 1 = input.x; __result__ = true }
+				`,
+				"optimized/test.2.rego": `
+					package test
+
+					s = __result__ { 1 = input.x; __result__ = true }
 				`,
 				"test.rego": `
 					package test


### PR DESCRIPTION
Currently, when setting three or more entrypoints from the same file to `opa build` / `compiler.Build`, only two artifacts get generated.

This appears to be due to a bug in  `compile.optimizer.getSupportModuleFilename`. The current logic  attempts to count the number of times a given filename has been used my bumping a count in a map, however, the key to that map is the mutated file name not the original file name.

Example:
consider three rules in the same policy file `my/policy`
`my/policy/entry_one`
`my/policy/entry_two`
`my/policy/entry_three`


* First rule `getSupportModuleFilename` is called for: 
  * `used[my/policy]` gets set to 1 [here](https://github.com/open-policy-agent/opa/blob/main/compile/compile.go#L868)
* Second rule `getSupportModuleFilename` is called for 
  * `used[my/policy.1]` gets set to 1 [here](https://github.com/open-policy-agent/opa/blob/main/compile/compile.go#L868)
  * `used[my/policy]` is still 1
* Third rule (and all proceeding rules) `getSupportModuleFilename` is called for 
  * `used[my/policy]` is still 1, so filename gets set to my/policy.1 again [here](https://github.com/open-policy-agent/opa/blob/main/compile/compile.go#L866)
  * `used[my/policy.1]` gets set to 2 [here](https://github.com/open-policy-agent/opa/blob/main/compile/compile.go#L868)
