### PR TITLE
Update golangci-lint to v1.43.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ GOVERSION ?= $(shell cat ./.go-version)
 GOARCH := $(shell go env GOARCH)
 GOOS := $(shell go env GOOS)
 
-GOLANGCI_LINT_VERSION := v1.40.1
+GOLANGCI_LINT_VERSION := v1.43.0
 
 DOCKER_RUNNING := $(shell docker ps >/dev/null 2>&1 && echo 1 || echo 0)
 

--- a/bundle/filefs.go
+++ b/bundle/filefs.go
@@ -1,3 +1,4 @@
+//go:build go1.16
 // +build go1.16
 
 package bundle

--- a/bundle/filefs_test.go
+++ b/bundle/filefs_test.go
@@ -1,3 +1,4 @@
+//go:build go1.16
 // +build go1.16
 
 package bundle

--- a/internal/wasm/sdk/opa/capabilities/capabilities_nowasm.go
+++ b/internal/wasm/sdk/opa/capabilities/capabilities_nowasm.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by an Apache2
 // license that can be found in the LICENSE file.
 
+//go:build !opa_wasm && !generate
 // +build !opa_wasm,!generate
 
 package capabilities


### PR DESCRIPTION
<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->

I noticed OPA uses a relatively old golangci-lint version (v1.40.1, which was released on 14 May 2021) so I updated it to the latest v1.43.0 version (And also fixed some linter errors). Thank you for your review1
