### PR TITLE
chore: improves auth plugin resolution.

### DIFF
--- a/plugins/rest/rest.go
+++ b/plugins/rest/rest.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"reflect"
@@ -65,26 +66,22 @@ func (c *Config) Equal(other *Config) bool {
 
 func (c *Config) authPlugin(authPluginLookup func(string) HTTPAuthPlugin) (HTTPAuthPlugin, error) {
 	var candidate HTTPAuthPlugin
-	if c.Credentials.Plugin != nil && authPluginLookup != nil {
+	if c.Credentials.Plugin != nil {
+		if authPluginLookup == nil {
+			// if no authPluginLookup function is passed we can't resolve the plugin
+			return nil, errors.New("missing auth plugin lookup function")
+		}
+
 		candidate := authPluginLookup(*c.Credentials.Plugin)
 		if candidate == nil {
-			c.logger.WithFields(map[string]interface{}{
-				"plugin": *c.Credentials.Plugin,
-			}).Warn("Could not resolve candidate auth plugin")
-		} else {
-			return candidate, nil
+			return nil, fmt.Errorf("auth plugin %q not found", *c.Credentials.Plugin)
 		}
+
+		return candidate, nil
 	}
 	// reflection avoids need for this code to change as auth plugins are added
 	s := reflect.ValueOf(c.Credentials)
 	for i := 0; i < s.NumField(); i++ {
-		if s.Field(i).Type().String() == "*string" {
-			// if the field is `Plugin` we should have resolved that above, if we didn't
-			// we won't do it here, hence we avoid this check (which will fail anyways in casting)
-			// and let the rest of the code below handle it
-			continue
-		}
-
 		if s.Field(i).IsNil() {
 			continue
 		}

--- a/plugins/rest/rest.go
+++ b/plugins/rest/rest.go
@@ -79,6 +79,9 @@ func (c *Config) authPlugin(authPluginLookup func(string) HTTPAuthPlugin) (HTTPA
 	s := reflect.ValueOf(c.Credentials)
 	for i := 0; i < s.NumField(); i++ {
 		if s.Field(i).Type().String() == "*string" {
+			// if the field is `Plugin` we should have resolved that above, if we didn't
+			// we won't do it here, hence we avoid this check (which will fail anyways in casting)
+			// and let the rest of the code below handle it
 			continue
 		}
 
@@ -92,6 +95,7 @@ func (c *Config) authPlugin(authPluginLookup func(string) HTTPAuthPlugin) (HTTPA
 
 		candidate = s.Field(i).Interface().(HTTPAuthPlugin)
 	}
+
 	if candidate == nil {
 		return &defaultAuthPlugin{}, nil
 	}

--- a/plugins/rest/rest_test.go
+++ b/plugins/rest/rest_test.go
@@ -623,6 +623,16 @@ func TestNew(t *testing.T) {
         }
 			}`,
 		},
+		{
+			name: "Unknown plugin",
+			input: `{
+				"name": "foo",
+				"url": "http://localhost",
+				"credentials": {
+					"plugin": "my_other_plugin"
+        }
+			}`,
+		},
 	}
 
 	var results []Client

--- a/plugins/rest/rest_test.go
+++ b/plugins/rest/rest_test.go
@@ -41,8 +41,31 @@ import (
 
 const keyID = "key1"
 
-func TestNew(t *testing.T) {
+func TestAuthPluginWithNoAuthPluginLookup(t *testing.T) {
+	authPlugin := "anything"
+	cfg := Config{
+		Credentials: struct {
+			Bearer               *bearerAuthPlugin                  `json:"bearer,omitempty"`
+			OAuth2               *oauth2ClientCredentialsAuthPlugin `json:"oauth2,omitempty"`
+			ClientTLS            *clientTLSAuthPlugin               `json:"client_tls,omitempty"`
+			S3Signing            *awsSigningAuthPlugin              `json:"s3_signing,omitempty"`
+			GCPMetadata          *gcpMetadataAuthPlugin             `json:"gcp_metadata,omitempty"`
+			AzureManagedIdentity *azureManagedIdentitiesAuthPlugin  `json:"azure_managed_identity,omitempty"`
+			Plugin               *string                            `json:"plugin,omitempty"`
+		}{
+			Plugin: &authPlugin,
+		},
+	}
+	_, err := cfg.authPlugin(nil)
+	if err == nil {
+		t.Error("Expected error but got nil")
+	}
+	if want, have := "missing auth plugin lookup function", err.Error(); want != have {
+		t.Errorf("Unexpected error, want %q, have %q", want, have)
+	}
+}
 
+func TestNew(t *testing.T) {
 	tests := []struct {
 		name    string
 		input   string
@@ -629,9 +652,10 @@ func TestNew(t *testing.T) {
 				"name": "foo",
 				"url": "http://localhost",
 				"credentials": {
-					"plugin": "my_other_plugin"
+					"plugin": "unknown_plugin"
         }
 			}`,
+			wantErr: true,
 		},
 	}
 


### PR DESCRIPTION
Currently when aiming to use a Plugin in credentials section, if the plugin is known then it will be resolved, if it isn't, it will be passed to the supported credentials and tried to be cast as HTTPAuthPlugin which ends up in a casting issue without further feedback on what was the plugin string.
