### PR TITLE
ast: add `every` future keyword

### DIFF
--- a/ast/capabilities.go
+++ b/ast/capabilities.go
@@ -50,6 +50,9 @@ func CapabilitiesForThisVersion() *Capabilities {
 	})
 
 	for kw := range futureKeywords {
+		if kw == "every" { // TODO(sr): drop when ready
+			continue
+		}
 		f.FutureKeywords = append(f.FutureKeywords, kw)
 	}
 	sort.Strings(f.FutureKeywords)

--- a/ast/compare.go
+++ b/ast/compare.go
@@ -201,6 +201,9 @@ func Compare(a, b interface{}) int {
 	case *SomeDecl:
 		b := b.(*SomeDecl)
 		return a.Compare(b)
+	case *Every:
+		b := b.(*Every)
+		return a.Compare(b)
 	case *With:
 		b := b.(*With)
 		return a.Compare(b)
@@ -272,6 +275,8 @@ func sortOrder(x interface{}) int {
 		return 100
 	case *SomeDecl:
 		return 101
+	case *Every:
+		return 102
 	case *With:
 		return 110
 	case *Head:

--- a/ast/internal/tokens/tokens.go
+++ b/ast/internal/tokens/tokens.go
@@ -65,6 +65,8 @@ const (
 	Lte
 	Dot
 	Semicolon
+
+	Every
 )
 
 var strings = [...]string{
@@ -112,6 +114,7 @@ var strings = [...]string{
 	Lte:        "lte",
 	Dot:        ".",
 	Semicolon:  ";",
+	Every:      "every",
 }
 
 var keywords = map[string]Token{

--- a/ast/parser.go
+++ b/ast/parser.go
@@ -2062,12 +2062,8 @@ var futureKeywords = map[string]tokens.Token{
 
 func (p *Parser) futureImport(imp *Import, allowedFutureKeywords map[string]tokens.Token) {
 	path := imp.Path.Value.(Ref)
-	if len(path) == 1 {
-		p.errorf(imp.Path.Location, "invalid import, use `import future.keywords` or `import.future.keywords.in`")
-		return
-	}
 
-	if !path[1].Equal(StringTerm("keywords")) {
+	if len(path) == 1 || !path[1].Equal(StringTerm("keywords")) {
 		p.errorf(imp.Path.Location, "invalid import, must be `future.keywords`")
 		return
 	}

--- a/ast/parser.go
+++ b/ast/parser.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"math/big"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -2080,6 +2081,7 @@ func (p *Parser) futureImport(imp *Import, allowedFutureKeywords map[string]toke
 	for k := range allowedFutureKeywords {
 		kwds = append(kwds, k)
 	}
+
 	switch len(path) {
 	case 2: // all keywords imported, nothing to do
 	case 3: // one keyword imported
@@ -2091,6 +2093,7 @@ func (p *Parser) futureImport(imp *Import, allowedFutureKeywords map[string]toke
 		keyword := string(kw)
 		_, ok = allowedFutureKeywords[keyword]
 		if !ok {
+			sort.Strings(kwds) // so the error message is stable
 			p.errorf(imp.Path.Location, "unexpected keyword, must be one of %v", kwds)
 			return
 		}

--- a/ast/parser.go
+++ b/ast/parser.go
@@ -933,6 +933,7 @@ func (p *Parser) parseEvery() *Expr {
 	}
 	call, ok := term.Value.(Call)
 	if !ok {
+		p.illegal("expected `x[, y] in xs { ... }` expression")
 		return nil
 	}
 	switch call[0].String() {
@@ -944,7 +945,7 @@ func (p *Parser) parseEvery() *Expr {
 		qb.Value = call[2]
 		qb.Domain = call[3]
 	default:
-		p.illegal("expected `x in xs` or `x, y in xs` expression")
+		p.illegal("expected `x[, y] in xs { ... }` expression")
 		return nil
 	}
 	if p.s.tok == tokens.LBrace { // every x in xs { ... }
@@ -958,6 +959,7 @@ func (p *Parser) parseEvery() *Expr {
 		return NewExpr(qb).SetLocation(qb.Location)
 	}
 
+	p.illegal("missing body")
 	return nil
 }
 

--- a/ast/parser_ext.go
+++ b/ast/parser_ext.go
@@ -566,7 +566,8 @@ func ParseStatementsWithOpts(filename, input string, popts ParserOptions) ([]Sta
 		WithProcessAnnotation(popts.ProcessAnnotation).
 		WithFutureKeywords(popts.FutureKeywords...).
 		WithAllFutureKeywords(popts.AllFutureKeywords).
-		WithCapabilities(popts.Capabilities)
+		WithCapabilities(popts.Capabilities).
+		withUnreleasedKeywords(popts.unreleasedKeywords)
 
 	stmts, comments, errs := parser.Parse()
 

--- a/ast/parser_test.go
+++ b/ast/parser_test.go
@@ -1135,7 +1135,7 @@ func TestImport(t *testing.T) {
 }
 
 func TestFutureImports(t *testing.T) {
-	assertParseErrorContains(t, "future", "import future", "invalid import, use `import future.keywords` or `import.future.keywords.in`")
+	assertParseErrorContains(t, "future", "import future", "invalid import, must be `future.keywords`")
 	assertParseErrorContains(t, "future.a", "import future.a", "invalid import, must be `future.keywords`")
 	assertParseErrorContains(t, "unknown keyword", "import future.keywords.xyz", "unexpected keyword, must be one of [every in]")
 	assertParseErrorContains(t, "all keyword import + alias", "import future.keywords as xyz", "future keyword imports cannot be aliased")

--- a/ast/parser_test.go
+++ b/ast/parser_test.go
@@ -796,6 +796,8 @@ func TestEvery(t *testing.T) {
 		}, opts)
 
 	assertParseErrorContains(t, "arbitrary term", "every 10", "expected `x[, y] in xs { ... }` expression", opts)
+	assertParseErrorContains(t, "non-var value", "every 10 in xs { true }", "unexpected { token: expected value to be a variable", opts)
+	assertParseErrorContains(t, "non-var key", "every 10, x in xs { true }", "unexpected { token: expected key to be a variable", opts)
 	assertParseErrorContains(t, "arbitrary call", "every f(10)", "expected `x[, y] in xs { ... }` expression", opts)
 	assertParseErrorContains(t, "no body", "every x in xs", "missing body", opts)
 	assertParseErrorContains(t, "invalid body", "every x in xs { + }", "unexpected plus token", opts)

--- a/ast/parser_test.go
+++ b/ast/parser_test.go
@@ -782,10 +782,13 @@ func TestEvery(t *testing.T) {
 			},
 		},
 		opts)
-	assertParseOneExpr(t, "with key", "every k, v in xs { true }",
+
+	assertParseOneExpr(t, "with key", "every k, v in [1,2] { true }",
 		&Expr{
 			Terms: &Every{
-				Domain: Call([]*Term{NewTerm(MemberWithKey.Ref()), VarTerm("k"), VarTerm("v"), VarTerm("xs")}),
+				Key:    VarTerm("k"),
+				Value:  VarTerm("v"),
+				Domain: ArrayTerm(IntNumberTerm(1), IntNumberTerm(2)),
 				Body: []*Expr{
 					NewExpr(BooleanTerm(true)),
 				},

--- a/ast/parser_test.go
+++ b/ast/parser_test.go
@@ -769,6 +769,30 @@ func TestSomeDeclExpr(t *testing.T) {
 	})
 }
 
+func TestEvery(t *testing.T) {
+	opts := ParserOptions{FutureKeywords: []string{"in", "every"}} // TODO: "every" should imply "in"? it can't be used without it
+	assertParseOneExpr(t, "simple", "every x in xs { true }",
+		&Expr{
+			Terms: &Every{
+				Value:  VarTerm("x"),
+				Domain: VarTerm("xs"),
+				Body: []*Expr{
+					NewExpr(BooleanTerm(true)),
+				},
+			},
+		},
+		opts)
+	assertParseOneExpr(t, "with key", "every k, v in xs { true }",
+		&Expr{
+			Terms: &Every{
+				Domain: Call([]*Term{NewTerm(MemberWithKey.Ref()), VarTerm("k"), VarTerm("v"), VarTerm("xs")}),
+				Body: []*Expr{
+					NewExpr(BooleanTerm(true)),
+				},
+			},
+		}, opts)
+}
+
 func TestNestedExpressions(t *testing.T) {
 
 	n1 := IntNumberTerm(1)
@@ -1110,7 +1134,7 @@ func TestImport(t *testing.T) {
 func TestFutureImports(t *testing.T) {
 	assertParseErrorContains(t, "future", "import future", "invalid import, use `import future.keywords` or `import.future.keywords.in`")
 	assertParseErrorContains(t, "future.a", "import future.a", "invalid import, must be `future.keywords`")
-	assertParseErrorContains(t, "unknown keyword", "import future.keywords.xyz", "unexpected keyword, must be one of [in]")
+	assertParseErrorContains(t, "unknown keyword", "import future.keywords.xyz", "unexpected keyword, must be one of [every in]")
 	assertParseErrorContains(t, "all keyword import + alias", "import future.keywords as xyz", "future keyword imports cannot be aliased")
 	assertParseErrorContains(t, "keyword import + alias", "import future.keywords.in as xyz", "future keyword imports cannot be aliased")
 

--- a/ast/parser_test.go
+++ b/ast/parser_test.go
@@ -770,7 +770,7 @@ func TestSomeDeclExpr(t *testing.T) {
 }
 
 func TestEvery(t *testing.T) {
-	opts := ParserOptions{FutureKeywords: []string{"in", "every"}} // TODO: "every" should imply "in"? it can't be used without it
+	opts := ParserOptions{unreleasedKeywords: true, FutureKeywords: []string{"in", "every"}} // TODO: "every" should imply "in"? it can't be used without it
 	assertParseOneExpr(t, "simple", "every x in xs { true }",
 		&Expr{
 			Terms: &Every{
@@ -1144,7 +1144,7 @@ func TestImport(t *testing.T) {
 func TestFutureImports(t *testing.T) {
 	assertParseErrorContains(t, "future", "import future", "invalid import, must be `future.keywords`")
 	assertParseErrorContains(t, "future.a", "import future.a", "invalid import, must be `future.keywords`")
-	assertParseErrorContains(t, "unknown keyword", "import future.keywords.xyz", "unexpected keyword, must be one of [every in]")
+	assertParseErrorContains(t, "unknown keyword", "import future.keywords.xyz", "unexpected keyword, must be one of [in]")
 	assertParseErrorContains(t, "all keyword import + alias", "import future.keywords as xyz", "future keyword imports cannot be aliased")
 	assertParseErrorContains(t, "keyword import + alias", "import future.keywords.in as xyz", "future keyword imports cannot be aliased")
 

--- a/ast/policy.go
+++ b/ast/policy.go
@@ -1172,12 +1172,14 @@ func (expr *Expr) Compare(other *Expr) int {
 
 func (expr *Expr) sortOrder() int {
 	switch expr.Terms.(type) {
-	case *SomeDecl, *Every: // TODO(sr): think about this more
+	case *SomeDecl:
 		return 0
 	case *Term:
 		return 1
 	case []*Term:
 		return 2
+	case *Every:
+		return 3
 	}
 	return -1
 }

--- a/ast/policy.go
+++ b/ast/policy.go
@@ -1161,6 +1161,10 @@ func (expr *Expr) Compare(other *Expr) int {
 		if cmp := Compare(t, other.Terms.(*SomeDecl)); cmp != 0 {
 			return cmp
 		}
+	case *Every:
+		if cmp := Compare(t, other.Terms.(*Every)); cmp != 0 {
+			return cmp
+		}
 	}
 
 	return withSliceCompare(expr.With, other.With)
@@ -1168,7 +1172,7 @@ func (expr *Expr) Compare(other *Expr) int {
 
 func (expr *Expr) sortOrder() int {
 	switch expr.Terms.(type) {
-	case *SomeDecl:
+	case *SomeDecl, *Every: // TODO(sr): think about this more
 		return 0
 	case *Term:
 		return 1

--- a/ast/policy.go
+++ b/ast/policy.go
@@ -231,6 +231,14 @@ type (
 		Symbols  []*Term   `json:"symbols"`
 	}
 
+	Every struct {
+		Location *Location `json:"-"`
+		Key      *Term     `json:"key"`
+		Value    *Term     `json:"value"`
+		Domain   *Term     `json:"domain"`
+		Body     Body      `json:"body"`
+	}
+
 	// With represents a modifier on an expression.
 	With struct {
 		Location *Location `json:"-"`
@@ -1344,9 +1352,7 @@ func (expr *Expr) String() string {
 		} else {
 			buf = append(buf, Call(t).String())
 		}
-	case *Term:
-		buf = append(buf, t.String())
-	case *SomeDecl:
+	case fmt.Stringer:
 		buf = append(buf, t.String())
 	}
 
@@ -1420,6 +1426,51 @@ func (d *SomeDecl) Compare(other *SomeDecl) int {
 // Hash returns a hash code of d.
 func (d *SomeDecl) Hash() int {
 	return termSliceHash(d.Symbols)
+}
+
+func (q *Every) String() string {
+	if q.Key != nil {
+		return fmt.Sprintf("every %s, %s in %s { %s }",
+			q.Key,
+			q.Value,
+			q.Domain,
+			q.Body)
+	}
+	return fmt.Sprintf("every %s in %s { %s }",
+		q.Value,
+		q.Domain,
+		q.Body)
+}
+
+func (q *Every) Loc() *Location {
+	return q.Location
+}
+
+func (q *Every) SetLoc(l *Location) {
+	q.Location = l
+}
+
+// Copy returns a deep copy of d.
+func (q *Every) Copy() *Every {
+	cpy := *q
+	cpy.Key = q.Key.Copy()
+	cpy.Value = q.Value.Copy()
+	cpy.Domain = q.Domain.Copy()
+	cpy.Body = q.Body.Copy()
+	return &cpy
+}
+
+func (q *Every) Compare(other *Every) int {
+	for _, terms := range [][2]*Term{
+		{q.Key, other.Key},
+		{q.Value, other.Value},
+		{q.Domain, other.Domain},
+	} {
+		if d := Compare(terms[0], terms[1]); d != 0 {
+			return d
+		}
+	}
+	return q.Body.Compare(other.Body)
 }
 
 func (w *With) String() string {
@@ -1502,6 +1553,8 @@ func Copy(x interface{}) interface{} {
 	case *With:
 		return x.Copy()
 	case *SomeDecl:
+		return x.Copy()
+	case *Every:
 		return x.Copy()
 	case *Term:
 		return x.Copy()

--- a/ast/policy_test.go
+++ b/ast/policy_test.go
@@ -562,6 +562,50 @@ func TestSomeDeclString(t *testing.T) {
 	}
 }
 
+func TestEveryString(t *testing.T) {
+	tests := []struct {
+		every Every
+		exp   string
+	}{
+		{
+			exp: `every x in ["foo", "bar"] { true; true }`,
+			every: Every{
+				Value:  VarTerm("x"),
+				Domain: ArrayTerm(StringTerm("foo"), StringTerm("bar")),
+				Body: []*Expr{
+					{
+						Terms: BooleanTerm(true),
+					},
+					{
+						Terms: BooleanTerm(true),
+					},
+				},
+			},
+		},
+		{
+			exp: `every k, v in ["foo", "bar"] { true; true }`,
+			every: Every{
+				Key:    VarTerm("k"),
+				Value:  VarTerm("v"),
+				Domain: ArrayTerm(StringTerm("foo"), StringTerm("bar")),
+				Body: []*Expr{
+					{
+						Terms: BooleanTerm(true),
+					},
+					{
+						Terms: BooleanTerm(true),
+					},
+				},
+			},
+		},
+	}
+	for _, tc := range tests {
+		if act := tc.every.String(); act != tc.exp {
+			t.Errorf("expected %q, got %q", tc.exp, act)
+		}
+	}
+}
+
 func TestAnnotationsString(t *testing.T) {
 	a := &Annotations{
 		Scope: "foo",

--- a/ast/visit.go
+++ b/ast/visit.go
@@ -136,6 +136,13 @@ func walk(v Visitor, x interface{}) {
 		for _, t := range x {
 			Walk(w, t)
 		}
+	case *Every:
+		if x.Key != nil {
+			Walk(w, x.Key)
+		}
+		Walk(w, x.Value)
+		Walk(w, x.Domain)
+		Walk(w, x.Body)
 	}
 }
 
@@ -367,6 +374,13 @@ func (vis *GenericVisitor) Walk(x interface{}) {
 		for _, t := range x {
 			vis.Walk(t)
 		}
+	case *Every:
+		if x.Key != nil {
+			vis.Walk(x.Key)
+		}
+		vis.Walk(x.Value)
+		vis.Walk(x.Domain)
+		vis.Walk(x.Body)
 	}
 }
 
@@ -546,7 +560,7 @@ func (vis *VarVisitor) visit(v interface{}) bool {
 	}
 	if vis.params.SkipClosures {
 		switch v.(type) {
-		case *ArrayComprehension, *ObjectComprehension, *SetComprehension:
+		case *ArrayComprehension, *ObjectComprehension, *SetComprehension, *Every:
 			return true
 		}
 	}
@@ -691,5 +705,12 @@ func (vis *VarVisitor) Walk(x interface{}) {
 		for _, t := range x {
 			vis.Walk(t)
 		}
+	case *Every:
+		if x.Key != nil {
+			vis.Walk(x.Key)
+		}
+		vis.Walk(x.Value)
+		vis.Walk(x.Domain)
+		vis.Walk(x.Body)
 	}
 }

--- a/ast/visit.go
+++ b/ast/visit.go
@@ -96,6 +96,13 @@ func walk(v Visitor, x interface{}) {
 			}
 		case *Term:
 			Walk(w, ts)
+		case *Every:
+			if ts.Key != nil {
+				Walk(w, ts.Key)
+			}
+			Walk(w, ts.Value)
+			Walk(w, ts.Domain)
+			Walk(w, ts.Body)
 		}
 		for i := range x.With {
 			Walk(w, x.With[i])
@@ -334,6 +341,13 @@ func (vis *GenericVisitor) Walk(x interface{}) {
 			}
 		case *Term:
 			vis.Walk(ts)
+		case *Every:
+			if ts.Key != nil {
+				vis.Walk(ts.Key)
+			}
+			vis.Walk(ts.Value)
+			vis.Walk(ts.Domain)
+			vis.Walk(ts.Body)
 		}
 		for i := range x.With {
 			vis.Walk(x.With[i])
@@ -462,6 +476,13 @@ func (vis *BeforeAfterVisitor) Walk(x interface{}) {
 			}
 		case *Term:
 			vis.Walk(ts)
+		case *Every:
+			if ts.Key != nil {
+				vis.Walk(ts.Key)
+			}
+			vis.Walk(ts.Value)
+			vis.Walk(ts.Domain)
+			vis.Walk(ts.Body)
 		}
 		for i := range x.With {
 			vis.Walk(x.With[i])
@@ -502,6 +523,13 @@ func (vis *BeforeAfterVisitor) Walk(x interface{}) {
 		for _, t := range x {
 			vis.Walk(t)
 		}
+	case *Every:
+		if x.Key != nil {
+			vis.Walk(x.Key)
+		}
+		vis.Walk(x.Value)
+		vis.Walk(x.Domain)
+		vis.Walk(x.Body)
 	}
 }
 
@@ -665,6 +693,13 @@ func (vis *VarVisitor) Walk(x interface{}) {
 			}
 		case *Term:
 			vis.Walk(ts)
+		case *Every:
+			if ts.Key != nil {
+				vis.Walk(ts.Key)
+			}
+			vis.Walk(ts.Value)
+			vis.Walk(ts.Domain)
+			vis.Walk(ts.Body)
 		}
 		for i := range x.With {
 			vis.Walk(x.With[i])

--- a/ast/visit.go
+++ b/ast/visit.go
@@ -88,21 +88,12 @@ func walk(v Visitor, x interface{}) {
 		}
 	case *Expr:
 		switch ts := x.Terms.(type) {
-		case *SomeDecl:
+		case *Term, *SomeDecl, *Every:
 			Walk(w, ts)
 		case []*Term:
 			for _, t := range ts {
 				Walk(w, t)
 			}
-		case *Term:
-			Walk(w, ts)
-		case *Every:
-			if ts.Key != nil {
-				Walk(w, ts.Key)
-			}
-			Walk(w, ts.Value)
-			Walk(w, ts.Domain)
-			Walk(w, ts.Body)
 		}
 		for i := range x.With {
 			Walk(w, x.With[i])
@@ -333,21 +324,12 @@ func (vis *GenericVisitor) Walk(x interface{}) {
 		}
 	case *Expr:
 		switch ts := x.Terms.(type) {
-		case *SomeDecl:
+		case *Term, *SomeDecl, *Every:
 			vis.Walk(ts)
 		case []*Term:
 			for _, t := range ts {
 				vis.Walk(t)
 			}
-		case *Term:
-			vis.Walk(ts)
-		case *Every:
-			if ts.Key != nil {
-				vis.Walk(ts.Key)
-			}
-			vis.Walk(ts.Value)
-			vis.Walk(ts.Domain)
-			vis.Walk(ts.Body)
 		}
 		for i := range x.With {
 			vis.Walk(x.With[i])
@@ -468,21 +450,12 @@ func (vis *BeforeAfterVisitor) Walk(x interface{}) {
 		}
 	case *Expr:
 		switch ts := x.Terms.(type) {
-		case *SomeDecl:
+		case *Term, *SomeDecl, *Every:
 			vis.Walk(ts)
 		case []*Term:
 			for _, t := range ts {
 				vis.Walk(t)
 			}
-		case *Term:
-			vis.Walk(ts)
-		case *Every:
-			if ts.Key != nil {
-				vis.Walk(ts.Key)
-			}
-			vis.Walk(ts.Value)
-			vis.Walk(ts.Domain)
-			vis.Walk(ts.Body)
 		}
 		for i := range x.With {
 			vis.Walk(x.With[i])
@@ -685,21 +658,12 @@ func (vis *VarVisitor) Walk(x interface{}) {
 		}
 	case *Expr:
 		switch ts := x.Terms.(type) {
-		case *SomeDecl:
+		case *Term, *SomeDecl, *Every:
 			vis.Walk(ts)
 		case []*Term:
 			for _, t := range ts {
 				vis.Walk(t)
 			}
-		case *Term:
-			vis.Walk(ts)
-		case *Every:
-			if ts.Key != nil {
-				vis.Walk(ts.Key)
-			}
-			vis.Walk(ts.Value)
-			vis.Walk(ts.Domain)
-			vis.Walk(ts.Body)
 		}
 		for i := range x.With {
 			vis.Walk(x.With[i])

--- a/capabilities.json
+++ b/capabilities.json
@@ -3785,6 +3785,7 @@
     }
   ],
   "future_keywords": [
+    "every",
     "in"
   ],
   "wasm_abi_versions": [

--- a/capabilities.json
+++ b/capabilities.json
@@ -3785,7 +3785,6 @@
     }
   ],
   "future_keywords": [
-    "every",
     "in"
   ],
   "wasm_abi_versions": [

--- a/format/format.go
+++ b/format/format.go
@@ -426,6 +426,8 @@ func (w *writer) writeExpr(expr *ast.Expr, comments []*ast.Comment) []*ast.Comme
 	switch t := expr.Terms.(type) {
 	case *ast.SomeDecl:
 		comments = w.writeSomeDecl(t, comments)
+	case *ast.Every:
+		comments = w.writeEvery(t, comments)
 	case []*ast.Term:
 		comments = w.writeFunctionCall(expr, comments)
 	case *ast.Term:
@@ -478,6 +480,27 @@ func (w *writer) writeSomeDecl(decl *ast.SomeDecl, comments []*ast.Comment) []*a
 		}
 	}
 
+	return comments
+}
+
+func (w *writer) writeEvery(every *ast.Every, comments []*ast.Comment) []*ast.Comment {
+	comments = w.insertComments(comments, every.Location)
+	w.write("every ")
+	if every.Key != nil {
+		comments = w.writeTerm(every.Key, comments)
+		w.write(", ")
+	}
+	comments = w.writeTerm(every.Value, comments)
+	w.write(" in ")
+	comments = w.writeTerm(every.Domain, comments)
+	w.write(" {")
+	comments = w.writeComprehensionBody('{', '}', every.Body, every.Loc(), every.Loc(), comments)
+
+	if len(every.Body) == 1 &&
+		every.Body[0].Location.Row == every.Location.Row {
+		w.write(" ")
+	}
+	w.write("}")
 	return comments
 }
 

--- a/format/format_test.go
+++ b/format/format_test.go
@@ -89,6 +89,9 @@ func TestFormatSource(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to read rego source: %v", err)
 			}
+			if bytes.Contains(contents, []byte(`import future.keywords.every`)) {
+				t.Skip("TODO: uncomment 'every' tests")
+			}
 
 			expected, err := ioutil.ReadFile(rego + ".formatted")
 			if err != nil {

--- a/format/testfiles/test_every.rego
+++ b/format/testfiles/test_every.rego
@@ -1,0 +1,20 @@
+package p
+
+import future.keywords.every
+import future.keywords.in
+
+r {
+	every x in [1,3,5] {
+        is_odd(x)
+    }
+
+	every x in [1,3,5] { is_odd(x); true }
+
+	every x in [1,3,5] {
+        is_odd(x)
+        true
+        x < 10
+    }
+}
+
+is_odd(x) = x % 2 == 0

--- a/format/testfiles/test_every.rego.formatted
+++ b/format/testfiles/test_every.rego.formatted
@@ -1,0 +1,20 @@
+package p
+
+import future.keywords.every
+import future.keywords.in
+
+r {
+	every x in [1, 3, 5] {
+		is_odd(x)
+	}
+
+	every x in [1, 3, 5] { is_odd(x); true}
+
+	every x in [1, 3, 5] {
+		is_odd(x)
+		true
+		x < 10
+	}
+}
+
+is_odd(x) = (x % 2) == 0

--- a/format/testfiles/test_every_with_key.rego
+++ b/format/testfiles/test_every_with_key.rego
@@ -1,0 +1,22 @@
+package p
+
+import future.keywords.every
+import future.keywords.in
+
+r {
+	every i, x in [1,3,5] {
+        is_odd(x)
+        i < 10
+    }
+
+	every i, x in {"foo": 1, "bar": 3, "baz": 5} { is_odd(x); i != 20 }
+
+	every i, x in [1,3,5] {
+        is_odd(x)
+        true
+        x < 10
+        x > i
+    }
+}
+
+is_odd(x) = x % 2 == 0

--- a/format/testfiles/test_every_with_key.rego.formatted
+++ b/format/testfiles/test_every_with_key.rego.formatted
@@ -1,0 +1,22 @@
+package p
+
+import future.keywords.every
+import future.keywords.in
+
+r {
+	every i, x in [1, 3, 5] {
+		is_odd(x)
+		i < 10
+	}
+
+	every i, x in {"foo": 1, "bar": 3, "baz": 5} { is_odd(x); i != 20}
+
+	every i, x in [1, 3, 5] {
+		is_odd(x)
+		true
+		x < 10
+		x > i
+	}
+}
+
+is_odd(x) = (x % 2) == 0


### PR DESCRIPTION
This is the first slice of #2090. It will _parse_ and _format_ policies like

```rego
package p

import future.keywords.every
import future.keywords.in

r {
  every x in [1,2,3] {
    x > 0
  }

  every i, x in [1,2,3] {
    x > i
  }
}
```

In follow-up PRs (or piling into this one 🙈), the term rewriting, and the actual evaluation will be added.

(Technically, the visitor changes here wouldn't have been necessary, I think... but anyways it's here now. Rewriting will show if it's the right thing.)

-------

🚧 Open questions:

- [ ] should importing `future.keywords.every` imply importing `future.keywords.in`? Right now, if you only import `every`, it just won't work. I suppose we could also _warn_... 🤔 