### PR TITLE
docs: Fix integration policy

### DIFF
--- a/docs/content/integration.md
+++ b/docs/content/integration.md
@@ -202,7 +202,6 @@ package example.authz
 default allow = false
 
 allow {
-    some id
     input.method == "GET"
     input.path == ["salary", input.subject.user]
 }


### PR DESCRIPTION
`some id` left after policy cleanup caused the Rego
compiler to rightfully protest when I tried integrating
OPA as a library today.

Signed-off-by: Anders Eknert <anders@eknert.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->
