### PR TITLE
Add hint to docs to clarify that the S3 regional endpoint should be used

### DIFF
--- a/docs/content/management-bundles.md
+++ b/docs/content/management-bundles.md
@@ -525,6 +525,8 @@ bundles:
     resource: bundle.tar.gz
 ```
 
+**NOTE:** the S3 `url` is the bucket's regional endpoint.
+
 ##### Metadata Credentials
 
 In order for this to work it is required that the permissions you created in the "Authentication" steps above are embedded in an IAM Role, which is then assigned to the EC2 instance hosting OPA.
@@ -544,6 +546,8 @@ bundles:
     service: s3
     resource: bundle.tar.gz
 ```
+
+**NOTE:** the S3 `url` is the bucket's regional endpoint.
 
 ### Google Cloud Storage
 


### PR DESCRIPTION
Doc change to clarify that the S3 regional endpoint should be used when loading bundles from Amazon S3.

Using the global S3 endpoint can cause `Bundle load failed: server replied with HTTP 403` due to slow [DNS propagation]( https://aws.amazon.com/premiumsupport/knowledge-center/s3-http-307-response/) after creating a bucket.

When Amazon S3 responds to a "download bundle" request with a redirect, the follow up request from OPA doesn't have an `Authorization` header. This appears to be a deliberate design choice in the go http client:

```
When following redirects, the Client will forward all headers set on the initial Request except:
• when forwarding sensitive headers like “Authorization”, “WWW-Authenticate”, and “Cookie” to untrusted targets. These headers will be ignored when following a redirect to a domain that is not a subdomain match or exact match of the initial domain. For example, a redirect from “foo.com” to either “foo.com” or “sub.foo.com” will forward the sensitive headers, but a redirect to “bar.com” will not.
```
https://pkg.go.dev/net/http#Client

Using the regional endpoint prevents the 307 redirect.