### PR TITLE
Add detail-tab for collapsable markdown

### DIFF
--- a/docs/content/envoy-primer.md
+++ b/docs/content/envoy-primer.md
@@ -233,7 +233,7 @@ http_filters:
 
 #### Example Input
 
-<details><summary>Example v3 Input</summary>
+{{<detail-tag "Example v3 Input">}}
 ```json
 {
   "attributes": {
@@ -289,9 +289,9 @@ http_filters:
   }
 }
 ```
-</details>
+{{</detail-tag>}}
 
-<details><summary>Example v2 Input</summary>
+{{<detail-tag "Example v2 Input">}}
 ```json
 {
   "attributes":{
@@ -353,7 +353,7 @@ http_filters:
   }
 }
 ```
-</details>
+{{</detail-tag>}}
 
 The `parsed_path` field in the input is generated from the `path` field in the HTTP request which is included in the
 Envoy External Authorization `CheckRequest` message type. This field provides the request path as a string array which

--- a/docs/website/layouts/shortcodes/detail-tag.html
+++ b/docs/website/layouts/shortcodes/detail-tag.html
@@ -1,0 +1,4 @@
+<details>
+  <summary>{{ (.Get 0) | markdownify }}</summary>
+  {{ .Inner | markdownify }}
+</details>


### PR DESCRIPTION
This is for issue #4186 . The problem was the default renderer for Hugo doesn't consider these blocks to be safe so chose not to render them. This workaround was taken from [Hugo's discourse](https://discourse.gohugo.io/t/unable-to-use-collapsible-expand-markdown/32810). There is a secondary option of enabling `unsafe=true` for the Goldberg renderer that is detailed on that page.