### PR TITLE
topdown: Use `json.Valid` instead of `util.UnmarshalJSON`

### DIFF
--- a/topdown/encoding.go
+++ b/topdown/encoding.go
@@ -58,9 +58,7 @@ func builtinJSONIsValid(a ast.Value) (ast.Value, error) {
 		return nil, err
 	}
 
-	var x interface{}
-	err = util.UnmarshalJSON([]byte(str), &x)
-	return ast.Boolean(err == nil), nil
+	return ast.Boolean(json.Valid([]byte(str))), nil
 }
 
 func builtinBase64Encode(a ast.Value) (ast.Value, error) {


### PR DESCRIPTION
While looking into #4140, I noticed that the topdown code for json.is_valid checks validity of json documents by unmarshaling them and checking if there is an error. This leads to allocations proportional to the size of the document, which could affect performance.

This change avoids unnecessary allocations and should offer improved speed and efficiency.

I do not think that changes to tests are necessary because:
- The functionality should be the same, as util.UnmarshalJSON uses the json library internally, except that
- It enables parsing numbers as `Number` instead of float, but I think that difference is only important for unmarshaling, and not validating.

Also, for reference, I wrote a simple benchmark to compare the two implementations here: https://github.com/kristiansvalland/json-valid-benchmark

For completeness of this PR, I include the results achieved on my local workstation here as well:
Hardware: cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz

| Benchmark name | Iterations | Time per operation | Bits allocated per operation | Allocations per operation |
|-----|-----|----|----|----|
| BenchmarkJsonValid-12 | 2416996 | 486.0 ns/op | 144 B/op | 1 allocs/op |
| BenchmarkJsonUnmarshalValid-12 | 645478 | 1844 ns/op | 1152 B/op | 19 allocs/op |