### PR TITLE
Add WASM support for json.is_valid built-in.

### DIFF
--- a/docs/content/policy-reference.md
+++ b/docs/content/policy-reference.md
@@ -488,7 +488,7 @@ The following table shows examples of how ``glob.match`` works:
 | <span class="opa-keep-it-together">``output := urlquery.decode_object(string)``</span> | ``output`` is URL query parameter decoded ``string`` represented as an ``object`` | ``SDK-dependent`` |
 | <span class="opa-keep-it-together">``output := json.marshal(x)``</span> | ``output`` is ``x`` serialized to a JSON string | ✅ |
 | <span class="opa-keep-it-together">``output := json.unmarshal(string)``</span> | ``output`` is ``string`` deserialized to a term from a JSON encoded string | ✅ |
-| <span class="opa-keep-it-together">``output := json.is_valid(string)``</span> | ``output`` is a ``boolean`` that indicated whether ``string`` is a valid JSON document | ``SDK-dependent`` |
+| <span class="opa-keep-it-together">``output := json.is_valid(string)``</span> | ``output`` is a ``boolean`` that indicated whether ``string`` is a valid JSON document | ✅ |
 | <span class="opa-keep-it-together">``output := yaml.marshal(x)``</span> | ``output`` is ``x`` serialized to a YAML string | ``SDK-dependent`` |
 | <span class="opa-keep-it-together">``output := yaml.unmarshal(string)``</span> | ``output`` is ``string`` deserialized to a term from YAML encoded string | ``SDK-dependent`` |
 | <span class="opa-keep-it-together">``output := yaml.is_valid(string)``</span> | ``output`` is a ``boolean`` that indicated whether ``string`` is a valid YAML document that can be decoded by `yaml.unmarshal` | ``SDK-dependent`` |

--- a/internal/compiler/wasm/wasm.go
+++ b/internal/compiler/wasm/wasm.go
@@ -137,6 +137,7 @@ var builtinsFunctions = map[string]string{
 	ast.GlobMatch.Name:                  "opa_glob_match",
 	ast.JSONMarshal.Name:                "opa_json_marshal",
 	ast.JSONUnmarshal.Name:              "opa_json_unmarshal",
+	ast.JSONIsValid.Name:                "opa_json_is_valid",
 	ast.ObjectFilter.Name:               "builtin_object_filter",
 	ast.ObjectGet.Name:                  "builtin_object_get",
 	ast.ObjectRemove.Name:               "builtin_object_remove",

--- a/wasm/src/encoding.c
+++ b/wasm/src/encoding.c
@@ -316,3 +316,23 @@ opa_value *opa_json_marshal(opa_value *a)
 
     return opa_string_allocated(v, strlen(v));
 }
+
+OPA_BUILTIN
+opa_value *opa_json_is_valid(opa_value *a)
+{
+    if (opa_value_type(a) != OPA_STRING)
+    {
+        return NULL;
+    }
+
+
+    opa_string_t *s = opa_cast_string(a);
+    opa_value *r = opa_json_parse(s->v, s->len);
+
+	if (r == NULL)
+	{
+		return opa_boolean(false);
+	}
+
+	return opa_boolean(true);
+}

--- a/wasm/src/encoding.c
+++ b/wasm/src/encoding.c
@@ -39,6 +39,7 @@
 #include <limits.h>
 
 #include "json.h"
+#include "malloc.h"
 #include "value.h"
 
 static const unsigned char base64_table[65] =
@@ -334,5 +335,6 @@ opa_value *opa_json_is_valid(opa_value *a)
 		return opa_boolean(false);
 	}
 
+	opa_free(r);
 	return opa_boolean(true);
 }

--- a/wasm/src/encoding.h
+++ b/wasm/src/encoding.h
@@ -10,5 +10,6 @@ opa_value *opa_base64_url_decode(opa_value *a);
 opa_value *opa_base64_url_encode(opa_value *a);
 opa_value *opa_json_unmarshal(opa_value *a);
 opa_value *opa_json_marshal(opa_value *a);
+opa_value *opa_json_is_valid(opa_value *a);
 
 #endif

--- a/wasm/tests/test.c
+++ b/wasm/tests/test.c
@@ -1790,6 +1790,8 @@ void test_json(void)
 {
     test("json/marshal", opa_value_compare(opa_json_marshal(opa_string_terminated("string")), opa_string_terminated("\"string\"")) == 0);
     test("json/unmarshal", opa_value_compare(opa_json_unmarshal(opa_string_terminated("\"string\"")), opa_string_terminated("string")) == 0);
+    test("json/is_valid_true", opa_value_compare(opa_json_is_valid(opa_string_terminated("\"string\"")), opa_boolean(true)) == 0);
+    test("json/is_valid_false", opa_value_compare(opa_json_is_valid(opa_string_terminated("\"string")), opa_boolean(false)) == 0);
 }
 
 WASM_EXPORT(test_object)

--- a/wasm/tests/test.c
+++ b/wasm/tests/test.c
@@ -1790,8 +1790,8 @@ void test_json(void)
 {
     test("json/marshal", opa_value_compare(opa_json_marshal(opa_string_terminated("string")), opa_string_terminated("\"string\"")) == 0);
     test("json/unmarshal", opa_value_compare(opa_json_unmarshal(opa_string_terminated("\"string\"")), opa_string_terminated("string")) == 0);
-    test("json/is_valid_true", opa_value_compare(opa_json_is_valid(opa_string_terminated("\"string\"")), opa_boolean(true)) == 0);
-    test("json/is_valid_false", opa_value_compare(opa_json_is_valid(opa_string_terminated("\"string")), opa_boolean(false)) == 0);
+    test("json/is_valid_true", opa_cast_boolean(opa_json_is_valid(opa_string_terminated("\"string\"")))->v);
+    test("json/is_valid_false", !opa_cast_boolean(opa_json_is_valid(opa_string_terminated("\"string")))->v);
 }
 
 WASM_EXPORT(test_object)


### PR DESCRIPTION
wasm: Add support for WASM and simple tests.
internal: Add opa_json_is_valid to map of wasm built-ins.
docs: Indicate that WASM support is now available for json.is_valid.

This code could also benefit from an allocation-less implementation as the change in #4203 was motivated by, but since that is not readily available I opted for this low-hanging version which I still think improves the codebase, and that can be changed to an allocation-less implementation at a later time by someone with capacity and know-how.

Fixes #4140