### PR TITLE
ast/compile: fix local var rewriting for 'some ... in ...'

### DIFF
--- a/ast/compile_test.go
+++ b/ast/compile_test.go
@@ -2480,7 +2480,7 @@ func TestRewriteDeclaredVars(t *testing.T) {
 			exp: `
 				package test
 				xs = ["a", "b", "c"]
-				p { __local2__ = data.test.xs[__local1__]; __local2__ = "a" }
+				p { __local1__ = data.test.xs[__local0__]; __local1__ = "a" }
 			`,
 		},
 		{


### PR DESCRIPTION
It wasn't _broken_ before, but I've thought a bit more about it and I believe it's _more correct_ now. Does anyone see a test case that would have failed before? 🤔 🔍 