### PR TITLE
website/load-docs.sh: add versioned docs for latest version

### DIFF
--- a/docs/website/scripts/load-docs.sh
+++ b/docs/website/scripts/load-docs.sh
@@ -111,4 +111,4 @@ echo "- edge" >> ${RELEASES_YAML_FILE}
 ln -s ../../../content ${ROOT_DIR}/docs/website/generated/docs/edge
 
 # Create a "latest" version from the latest semver found
-ln -s ${RELEASES[0]} ${ROOT_DIR}/docs/website/generated/docs/latest
+cp -r ${ROOT_DIR}/docs/website/generated/docs/${RELEASES[0]} ${ROOT_DIR}/docs/website/generated/docs/latest


### PR DESCRIPTION
With this change, we should get both a /docs/v0.36.1 and a /docs/latest
in our deployed docs.

Before, the symlink would have made hugo only build a /docs/latest,
but not the other link.

