### PR TITLE
plugins/bundle: Update persisted bundle activation mechanism

### DIFF
--- a/docs/content/management-bundles.md
+++ b/docs/content/management-bundles.md
@@ -86,8 +86,9 @@ OPA can optionally persist activated bundles to disk for recovery purposes. To e
 persistence, set the `bundles[_].persist` field to `true`. When bundle
 persistence is enabled, OPA will attempt to read the bundle from disk on startup. This
 allows OPA to start with the most recently activated bundle in case OPA cannot communicate
-with the bundle server. When communication between OPA and the bundle server is restored,
-the latest bundle is downloaded, activated, and persisted.
+with the bundle server. OPA will try to load and activate persisted bundles on a best-effort basis. Any errors
+encountered during the process will be surfaced in the bundle's status update. When communication between OPA and
+the bundle server is restored, the latest bundle is downloaded, activated, and persisted.
 
 > By default, bundles are persisted under the current working directory of the OPA process (e.g., `./.opa/bundles/<bundle-name>/bundle.tar.gz`).
 

--- a/plugins/bundle/plugin_test.go
+++ b/plugins/bundle/plugin_test.go
@@ -406,10 +406,7 @@ func TestLoadAndActivateBundlesFromDisk(t *testing.T) {
 	plugin := New(&Config{Bundles: bundles}, manager)
 	plugin.bundlePersistPath = filepath.Join(dir, ".opa")
 
-	err = plugin.loadAndActivateBundlesFromDisk(ctx)
-	if err != nil {
-		t.Fatal("unexpected error:", err)
-	}
+	plugin.loadAndActivateBundlesFromDisk(ctx)
 
 	// persist a bundle to disk and then load it
 	module := "package foo\n\ncorge=1"
@@ -439,10 +436,7 @@ func TestLoadAndActivateBundlesFromDisk(t *testing.T) {
 		t.Fatalf("unexpected error %v", err)
 	}
 
-	err = plugin.loadAndActivateBundlesFromDisk(ctx)
-	if err != nil {
-		t.Fatal("unexpected error:", err)
-	}
+	plugin.loadAndActivateBundlesFromDisk(ctx)
 
 	txn := storage.NewTransactionOrDie(ctx, manager.Store)
 	defer manager.Store.Abort(ctx, txn)
@@ -468,6 +462,186 @@ func TestLoadAndActivateBundlesFromDisk(t *testing.T) {
 		t.Fatal(err)
 	} else if !reflect.DeepEqual(data, expData) {
 		t.Fatalf("Bad data content. Exp:\n%v\n\nGot:\n\n%v", expData, data)
+	}
+}
+
+func TestLoadAndActivateDepBundlesFromDisk(t *testing.T) {
+	ctx := context.Background()
+	manager := getTestManager()
+
+	dir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+
+	defer os.RemoveAll(dir)
+
+	bundleName := "test-bundle-main"
+	bundleSource := Source{
+		Persist: true,
+	}
+
+	bundleNameOther := "test-bundle-lib"
+	bundleSourceOther := Source{
+		Persist: true,
+	}
+
+	bundles := map[string]*Source{}
+	bundles[bundleName] = &bundleSource
+	bundles[bundleNameOther] = &bundleSourceOther
+
+	plugin := New(&Config{Bundles: bundles}, manager)
+	plugin.bundlePersistPath = filepath.Join(dir, ".opa")
+
+	module1 := `
+package bar
+
+import data.foo
+
+default allow = false
+
+allow {
+	foo.is_one(1)
+}`
+
+	module2 := `
+package foo
+
+is_one(x) {
+	x == 1
+}`
+
+	b1 := bundle.Bundle{
+		Manifest: bundle.Manifest{Revision: "quickbrownfauxbar", Roots: &[]string{"bar"}},
+		Data:     map[string]interface{}{},
+		Modules: []bundle.ModuleFile{
+			{
+				URL:    "/bar/policy.rego",
+				Path:   "/bar/policy.rego",
+				Parsed: ast.MustParseModule(module1),
+				Raw:    []byte(module1),
+			},
+		},
+	}
+
+	b1.Manifest.Init()
+
+	b2 := bundle.Bundle{
+		Manifest: bundle.Manifest{Revision: "quickbrownfauxfoo", Roots: &[]string{"foo"}},
+		Data:     map[string]interface{}{},
+		Modules: []bundle.ModuleFile{
+			{
+				URL:    "/foo/policy.rego",
+				Path:   "/foo/policy.rego",
+				Parsed: ast.MustParseModule(module2),
+				Raw:    []byte(module2),
+			},
+		},
+	}
+
+	b2.Manifest.Init()
+
+	var buf1 bytes.Buffer
+	if err := bundle.NewWriter(&buf1).UseModulePath(true).Write(b1); err != nil {
+		t.Fatal("unexpected error:", err)
+	}
+
+	err = plugin.saveBundleToDisk(bundleName, &buf1)
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+
+	var buf2 bytes.Buffer
+	if err := bundle.NewWriter(&buf2).UseModulePath(true).Write(b2); err != nil {
+		t.Fatal("unexpected error:", err)
+	}
+
+	err = plugin.saveBundleToDisk(bundleNameOther, &buf2)
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+
+	plugin.loadAndActivateBundlesFromDisk(ctx)
+
+	txn := storage.NewTransactionOrDie(ctx, manager.Store)
+	defer manager.Store.Abort(ctx, txn)
+
+	ids, err := manager.Store.ListPolicies(ctx, txn)
+	if err != nil {
+		t.Fatal(err)
+	} else if len(ids) != 2 {
+		t.Fatal("Expected 2 policies")
+	}
+}
+
+func TestLoadAndActivateDepBundlesFromDiskMaxAttempts(t *testing.T) {
+	ctx := context.Background()
+	manager := getTestManager()
+
+	dir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+
+	defer os.RemoveAll(dir)
+
+	bundleName := "test-bundle-main"
+	bundleSource := Source{
+		Persist: true,
+	}
+
+	bundles := map[string]*Source{}
+	bundles[bundleName] = &bundleSource
+
+	plugin := New(&Config{Bundles: bundles}, manager)
+	plugin.bundlePersistPath = filepath.Join(dir, ".opa")
+
+	module := `
+package bar
+
+import data.foo
+
+default allow = false
+
+allow {
+	foo.is_one(1)
+}`
+
+	b := bundle.Bundle{
+		Manifest: bundle.Manifest{Revision: "quickbrownfaux", Roots: &[]string{"bar"}},
+		Data:     map[string]interface{}{},
+		Modules: []bundle.ModuleFile{
+			{
+				URL:    "/bar/policy.rego",
+				Path:   "/bar/policy.rego",
+				Parsed: ast.MustParseModule(module),
+				Raw:    []byte(module),
+			},
+		},
+	}
+
+	b.Manifest.Init()
+
+	var buf bytes.Buffer
+	if err := bundle.NewWriter(&buf).UseModulePath(true).Write(b); err != nil {
+		t.Fatal("unexpected error:", err)
+	}
+
+	err = plugin.saveBundleToDisk(bundleName, &buf)
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+
+	plugin.loadAndActivateBundlesFromDisk(ctx)
+
+	txn := storage.NewTransactionOrDie(ctx, manager.Store)
+	defer manager.Store.Abort(ctx, txn)
+
+	ids, err := manager.Store.ListPolicies(ctx, txn)
+	if err != nil {
+		t.Fatal(err)
+	} else if len(ids) != 0 {
+		t.Fatal("Expected 0 policies")
 	}
 }
 


### PR DESCRIPTION
Earlier errors encountered during loading and activating persisted
bundles would cause the OPA runtime to exit. This behavior is different
from when OPA downloads a bundle and activation errors if any would possibly
get resolved in successive download attempts. This fix adds a retry mechanism
to activate persisted bundles in an attempt to mimic the behavior seen during
bundle downloads. Errors if any encountered during the process will be
surfaced in the bundle's status update and not result in an abrupt exit.

Fixes: #3840

Signed-off-by: Ashutosh Narkar <anarkar4387@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->
