### PR TITLE
docs: fixing broken links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1485,7 +1485,7 @@ more information see https://openpolicyagent.org/docs/latest/privacy/.
 #### New `opa build` command
 
 The `opa build` command can now be used to package OPA policy and data files
-into [bundles](https://www.openpolicyagent.org/docs/latest/management/#bundles)
+into [bundles](https://www.openpolicyagent.org/docs/latest/management-bundles)
 that can be easily distributed via HTTP. See `opa build --help` for details.
 This change is backwards incompatible. If you were previously relying on `opa
 build` to compile policies to wasm, you can still do so:
@@ -2420,7 +2420,7 @@ pass `"force_json_decode": true` as in the `http.send` parameters.
 * This release adds support for scoping bundles to specific roots
   under `data`. This allows bundles to be used in conjunction with
   sidecars like `kube-mgmt` that load local data and policy into
-  OPA. See the [Bundles](https://www.openpolicyagent.org/docs/bundles.html)
+  OPA. See the [Bundles](https://www.openpolicyagent.org/docs/latest/management-bundles)
   page for more details.
 
 * This release includes a small but backwards incompatible change to

--- a/docs/README.md
+++ b/docs/README.md
@@ -96,7 +96,7 @@ This option provides the best preview of the site content, using the exact same 
    user account (which should have been configured in the previous step).
    
 1) Netlify will then upload the built content and serve it via their CDN. A URL to the preview will be given in the
-   CLI console output.
+   CLI console output. Be sure to select the `edge` version within the Documentation pages to see your reflected changes in the remote site.
 
 
 #### Local Preview via `netlify dev`

--- a/docs/content/contrib-adding-builtin-functions.md
+++ b/docs/content/contrib-adding-builtin-functions.md
@@ -98,7 +98,7 @@ func init() {
 ```
 
 In the above code, `builtinRepeat` implements the `topdown.BuiltinFunc` function type. 
-The call to `RegisterBuiltinFunc(...)` in `init()` adds the built-in function to the evaluation engine; binding the implementation to `ast.Repeat` that was registered in [an earlier step](#register-the-function).
+The call to `RegisterBuiltinFunc(...)` in `init()` adds the built-in function to the evaluation engine; binding the implementation to `ast.Repeat` that was registered in [an earlier step](#declare-and-register).
 
 ### Test
 

--- a/docs/content/contrib-development.md
+++ b/docs/content/contrib-development.md
@@ -81,7 +81,7 @@ git commit -s
 git push origin somefeature
 ```
 
-> Make sure to use a [good commit message](../contributing/#commit-messages).
+> Make sure to use a [good commit message](../contrib-code/#commit-messages).
 
 Now, submit a Pull Request from your fork.
 See the official [GitHub Documentation](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request-from-a-fork)
@@ -111,17 +111,17 @@ the results are posted and can be viewed
 ## Dependencies
 
 OPA is a Go module [https://github.com/golang/go/wiki/Modules](https://github.com/golang/go/wiki/Modules)
-and dependencies are tracked with the standard [go.mod](../../go.mod) file.
+and dependencies are tracked with the standard [go.mod](https://github.com/open-policy-agent/opa/blob/main/go.mod) file.
 
-We also keep a full copy of the dependencies in the [vendor](../../vendor)
-directory. All `go` commands from the [Makefile](../../Makefile) will enable
+We also keep a full copy of the dependencies in the [vendor](https://github.com/open-policy-agent/opa/tree/main/vendor)
+directory. All `go` commands from the [Makefile](https://github.com/open-policy-agent/opa/blob/main/Makefile) will enable
 module mode by setting `GO111MODULE=on GOFLAGS=-mod=vendor` which will also
 force using the `vendor` directory.
 
 To update a dependency ensure that `GO111MODULE` is either on, or the repository
 qualifies for `auto` to enable module mode. Then simply use `go get ..` to get
-the version desired. This should update the [go.mod](../../go.mod) and (potentially)
-[go.sum](../../go.sum) files. After this you *MUST* run `go mod vendor` to ensure
+the version desired. This should update the [go.mod](https://github.com/open-policy-agent/opa/blob/main/go.mod) and (potentially)
+[go.sum](https://github.com/open-policy-agent/opa/blob/main/go.sum) files. After this you *MUST* run `go mod vendor` to ensure
 that the `vendor` directory is in sync.
 
 Example workflow for updating a dependency:
@@ -138,7 +138,7 @@ If dependencies have been removed ensure to run `go mod tidy` to clean them up.
 
 Sometimes we use some tools which are versioned and vendored
 with OPA as dependencies. For now, we have none, but any we use in the future
-should go in [tools.go](../../tools.go).
+should go in [tools.go](https://github.com/open-policy-agent/opa/blob/main/tools.go).
 
 More details on the pattern: [https://github.com/go-modules-by-example/index/blob/master/010_tools/README.md](https://github.com/go-modules-by-example/index/blob/master/010_tools/README.md)
 
@@ -155,7 +155,7 @@ files in the root of this repository:
 
 ## CI Configuration
 
-OPA uses Github Actions defined in the [.github/workflows](../../.github/workflows)
+OPA uses Github Actions defined in the [.github/workflows](https://github.com/open-policy-agent/opa/tree/main/.github/workflows)
 directory.
 
 ### Github Action Secrets

--- a/docs/content/contrib-docs.md
+++ b/docs/content/contrib-docs.md
@@ -37,7 +37,7 @@ After the Frontmatter block, each page uses standard markdown formatting. For a 
 
 ## Create a local branch
 
-To get started, fork the OPA repository and create a local branch for your Docs changes. Check out the [Development Guide](../development/#fork-clone-create-a-branch) if you need some help setting this up. 
+To get started, fork the OPA repository and create a local branch for your Docs changes. Check out the [Development Guide](../contrib-development/#fork-clone-create-a-branch) if you need some help setting this up. 
 
 ## Update Existing Docs
 
@@ -52,7 +52,7 @@ In the case where you want to add a topic that doesn't fit nicely into any of th
 Once you have made your updates, the next step is to test that they look as expected. To test your changes, generate a local preview with your updated files and preview them with Netlify.
 
 Summary of steps:
-1. Install dependencies: [Hugo](#installing-hugo), [NodeJS](https://nodejs.org), and [Netlify CLI](https://www.netlify.com/products/dev/)
+1. Install dependencies: [Hugo](https://github.com/open-policy-agent/opa/tree/main/docs#installing-hugo), [NodeJS](https://nodejs.org), and [Netlify CLI](https://www.netlify.com/products/dev/)
 1. Build artifacts: `make build`
 1. Generate HTML files: `make docs-serve-local` (*This can take up to 5 min*)
 1. Start preview server: `netlify dev`

--- a/docs/content/deployments.md
+++ b/docs/content/deployments.md
@@ -443,7 +443,7 @@ When passing a capabilities definition file via `--capabilities`, one can restri
 
 Not providing a capabilities file, or providing a file without an `allow_net` key, will permit fetching remote schemas from any host.
 
-Note that the metaschemas http://json-schema.org/draft-04/schema, http://json-schema.org/draft-06/schema, and http://json-schema.org/draft-07/schema, are always available, even without network access.
+Note that the metaschemas [http://json-schema.org/draft-04/schema](http://json-schema.org/draft-04/schema), [http://json-schema.org/draft-06/schema](http://json-schema.org/draft-06/schema), and [http://json-schema.org/draft-07/schema](http://json-schema.org/draft-07/schema), are always available, even without network access.
 
 Similarly, the `allow_net` capability restricts what hosts the `http.send` built-in function may send requests to, and what hosts the `net.lookup_ip_addr` built-in function may resolve IP addresses for.
 

--- a/docs/content/docker-authorization.md
+++ b/docs/content/docker-authorization.md
@@ -174,7 +174,7 @@ The output should be:
 Error response from daemon: authorization denied by plugin opa-docker-authz: request rejected by administrative policy
 ```
 
-To learn more about how rules define the content of documents, see: [How Does OPA Work?](../#how-does-opa-work)
+To learn more about how rules define the content of documents, see: [How Does OPA Work?](../#overview)
 
 With this policy in place, users will not be able to run any Docker commands. Go
 ahead and try other commands such as `docker run` or `docker pull`. They will

--- a/docs/content/kubernetes-introduction.md
+++ b/docs/content/kubernetes-introduction.md
@@ -46,7 +46,7 @@ OPA Gatekeeper adds the following on top of plain OPA:
 If you want to kick the tires:
 
 * See the [Installation
-  Instructions](https://github.com/open-policy-agent/gatekeeper#installation-instructions)
+  Instructions](https://open-policy-agent.github.io/gatekeeper/website/docs/install/)
   in the README.
 * See the
   [demo/basic](https://github.com/open-policy-agent/gatekeeper/tree/master/demo/basic)

--- a/docs/content/management-bundles.md
+++ b/docs/content/management-bundles.md
@@ -111,7 +111,7 @@ files in the bundle must be organized hierarchically into directories inside
 the tarball.
 
 > The hierarchical organization indicates to OPA where to load the data files
-> into the [the `data` Document](../#the-data-document).
+> into the [the `data` Document](../philosophy/#the-opa-document-model).
 
 You can list the content of a bundle with `tar`.
 
@@ -495,7 +495,7 @@ Both methods are going to need a policy for either the service account or the IA
 
 ##### Testing Authentication
 
-Use the [AWS CLI tools]([command line tools](https://aws.amazon.com/cli/)) (see "Upload Bundle" below).
+Use the [AWS CLI tools](https://aws.amazon.com/cli/) (see ["Upload Bundle"](#upload-bundle) below).
 
 #### Upload Bundle
 

--- a/docs/content/management-status.md
+++ b/docs/content/management-status.md
@@ -6,7 +6,7 @@ weight: 4
 
 OPA can periodically report status updates to remote HTTP servers. The
 updates contain status information for OPA itself as well as the
-[Bundles](#bundles) that have been downloaded and activated.
+[Bundles](../management-bundles) that have been downloaded and activated.
 
 OPA sends status reports whenever one of the following happens:
 

--- a/docs/content/policy-language.md
+++ b/docs/content/policy-language.md
@@ -867,7 +867,7 @@ pi := 3.14156   # Redeclaration error because 'pi' already declared above.
 
 ### Functions
 
-Rego supports user-defined functions that can be called with the same semantics as [Built-in Functions](#built-in-functions). They have access to both the [the data Document](../#the-data-document) and [the input Document](../#the-input-document).
+Rego supports user-defined functions that can be called with the same semantics as [Built-in Functions](#built-in-functions). They have access to both the [the data Document](../philosophy/#the-opa-document-model) and [the input Document](../philosophy/#the-opa-document-model).
 
 For example, the following function will return the result of trimming the spaces from a string and then splitting it by periods.
 
@@ -1306,8 +1306,7 @@ For using the `some` keyword with iteration, see
 ## With Keyword
 
 The `with` keyword allows queries to programmatically specify values nested
-under the [input Document](../##the-input-document) and the [data Document](../#the-data-document).
-
+under the [input Document](../philosophy/#the-opa-document-model) and the [data Document](../philosophy/#the-opa-document-model).
 For example, given the simple authorization policy in the [Imports](#imports)
 section, we can write a query that checks whether a particular request would be
 allowed:

--- a/docs/content/rest-api.md
+++ b/docs/content/rest-api.md
@@ -818,7 +818,7 @@ Get a document that requires input.
 
 The path separator is used to access values inside object and array documents. If the path indexes into an array, the server will attempt to convert the array index to an integer. If the path element cannot be converted to an integer, the server will respond with 404.
 
-The request body contains an object that specifies a value for [The input Document](../#the-input-document).
+The request body contains an object that specifies a value for [The input Document](../philosophy/#the-opa-document-model).
 
 #### Request Headers
 
@@ -938,7 +938,7 @@ Use this API if you are enforcing policy decisions via webhooks that have pre-de
 request/response formats. Note, the API path prefix is `/v0` instead of `/v1`.
 
 The request message body defines the content of the [The input
-Document](../#the-input-document). The request message body
+Document](../philosophy/#the-opa-document-model). The request message body
 may be empty. The path separator is used to access values inside object and
 array documents.
 
@@ -1157,7 +1157,7 @@ produce a value for the `/data/system/main` document. You can configure OPA
 to use a different URL path to serve these queries. See the [Configuration Reference](../configuration)
 for more information.
 
-The request message body is mapped to the [Input Document](../#the-input-document).
+The request message body is mapped to the [Input Document](../philosophy/#the-opa-document-model).
 
 ```http
 PUT /v1/policies/example1 HTTP/1.1

--- a/docs/content/security.md
+++ b/docs/content/security.md
@@ -14,7 +14,7 @@ authorization so that:
 - Traffic between OPA and clients is encrypted.
 - Clients verify the OPA API endpoint identity.
 - OPA verifies client identities.
-- Clients are only granted access to specific APIs or sections of [The `data` Document](../#the-data-document).
+- Clients are only granted access to specific APIs or sections of [The `data` Document](../philosophy/#the-opa-document-model).
 
 ## TLS and HTTPS
 

--- a/docs/content/ssh-and-sudo-authorization.md
+++ b/docs/content/ssh-and-sudo-authorization.md
@@ -110,7 +110,7 @@ In another terminal, load the policies and data into OPA that will control acces
 
 First, create a policy that will tell the PAM module to collect context that is required for authorization.
 For more details on what this policy should look like, see
-[this documentation](https://github.com/open-policy-agent/contrib/tree/main/pam_authz/pam#pull).
+[this documentation](https://github.com/open-policy-agent/contrib/tree/main/pam_opa/pam#pull).
 
 **pull.rego**:
 
@@ -133,7 +133,7 @@ curl -X PUT --data-binary @pull.rego \
 Next, create the policies that will authorize SSH and sudo requests.
 The `input` which makes up the authorization context in the policy below will also
 include some default values, such as the username making the request. See
-[this documentation](https://github.com/open-policy-agent/contrib/tree/main/pam_authz/pam#authz)
+[this documentation](https://github.com/open-policy-agent/contrib/tree/main/pam_opa/pam#authz)
 to get a better understanding of what the `input` to the authorization policy will look like.
 
 Unlike the *pull* policy, we'll create separate *authz* policies
@@ -259,7 +259,7 @@ You will see a lot of verbose logs from `sudo` as the PAM module goes through th
 This is intended so you can study how the PAM module works.
 You can disable verbose logging by changing the `log_level` argument in the PAM
 configuration. For more details see
-[this documentation](https://github.com/open-policy-agent/contrib/tree/main/pam_authz/pam#configuration).
+[this documentation](https://github.com/open-policy-agent/contrib/tree/main/pam_opa/pam#configuration).
 
 ### 4. SSH as a user without the `admin` role.
 

--- a/docs/content/terraform.md
+++ b/docs/content/terraform.md
@@ -654,7 +654,7 @@ opa exec --decision terraform/analysis/score --bundle policy/ tfplan_large.json
 
 ### 6. (Optional) Run OPA using a remote policy bundle
 
-In addition to loading policies from the local filesystem, `opa exec` can fetch policies from remote locations via [Bundles](). To see this in action, first build the policies into a bundle:
+In addition to loading policies from the local filesystem, `opa exec` can fetch policies from remote locations via [Bundles](../management-bundles). To see this in action, first build the policies into a bundle:
 
 ```shell
 opa build policy/


### PR DESCRIPTION
This updates the linking for several items in the documentation. I noticed that several links pointed to non-existent items or 404s. I've gone through the pages on the left hand side panel and adjusted all that I could find. I did test this with the remote netlify site.
