### PR TITLE
ast/compile: 'every' rewriting steps

### DIFF
--- a/ast/compile.go
+++ b/ast/compile.go
@@ -3048,16 +3048,7 @@ func outputVarsForExpr(expr *Expr, arity func(Ref) int, safe VarSet) VarSet {
 
 		return outputVarsForExprCall(expr, ar, safe, terms)
 	case *Every:
-		s := outputVarsForTerms(terms.Domain, safe)
-
-		cpy := safe.Copy()
-		if terms.Key != nil {
-			cpy.Add(terms.Key.Value.(Var))
-		}
-		cpy.Add(terms.Value.Value.(Var))
-
-		s.Update(outputVarsForBody(terms.Body, arity, cpy))
-		return s
+		return outputVarsForTerms(terms.Domain, safe)
 	default:
 		panic("illegal expression")
 	}

--- a/ast/compile.go
+++ b/ast/compile.go
@@ -4127,6 +4127,7 @@ func rewriteEveryStatement(g *localVarGenerator, stack *localDeclaredVars, expr 
 	errs = rewriteDeclaredVarsInTermRecursive(g, stack, every.Domain, errs, strict)
 
 	stack.Push()
+	defer stack.Pop()
 
 	// optionally rewrite the key
 	if every.Key != nil {

--- a/ast/compile.go
+++ b/ast/compile.go
@@ -1464,7 +1464,7 @@ func rewritePrintCalls(gen *localVarGenerator, getArity func(Ref) int, globals V
 				case *ObjectComprehension:
 					errs = rewritePrintCalls(gen, getArity, safe, x.Body)
 				case *Every:
-					safe.Update(x.Vars())
+					safe.Update(x.KeyValueVars())
 					errs = rewritePrintCalls(gen, getArity, safe, x.Body)
 				}
 				return true
@@ -2902,7 +2902,7 @@ func (xform *bodySafetyTransformer) Visit(x interface{}) bool {
 		}
 	case *Expr:
 		if ev, ok := term.Terms.(*Every); ok {
-			xform.globals.Update(ev.Vars())
+			xform.globals.Update(ev.KeyValueVars())
 			ev.Body = xform.reorderComprehensionSafety(NewVarSet(), ev.Body)
 			return true
 		}

--- a/ast/compile.go
+++ b/ast/compile.go
@@ -3776,7 +3776,16 @@ func expandExpr(gen *localVarGenerator, expr *Expr) (result []*Expr) {
 		result = append(result, expr)
 	case *Every:
 		var extras []*Expr
-		extras, terms.Domain = expandExprTerm(gen, terms.Domain)
+		if _, ok := terms.Domain.Value.(Call); ok {
+			extras, terms.Domain = expandExprTerm(gen, terms.Domain)
+		} else {
+			term := NewTerm(gen.Generate()).SetLocation(terms.Domain.Location)
+			eq := Equality.Expr(term, terms.Domain)
+			eq.Generated = true
+			eq.Location = terms.Domain.Location
+			extras = append(extras, eq)
+			terms.Domain = term
+		}
 		terms.Body = rewriteExprTermsInBody(gen, terms.Body)
 		result = append(result, extras...)
 		result = append(result, expr)

--- a/ast/compile.go
+++ b/ast/compile.go
@@ -1452,7 +1452,7 @@ func rewritePrintCalls(gen *localVarGenerator, getArity func(Ref) int, globals V
 	// Visit comprehension bodies recursively to ensure print statements inside
 	// those bodies only close over variables that are safe.
 	for i := range body {
-		if ContainsComprehensions(body[i]) || body[i].IsEvery() {
+		if ContainsClosures(body[i]) {
 			safe := outputVarsForBody(body[:i], getArity, globals)
 			safe.Update(globals)
 			WalkClosures(body[i], func(x interface{}) bool {

--- a/ast/compile.go
+++ b/ast/compile.go
@@ -2962,6 +2962,10 @@ func reorderBodyForClosures(arity func(Ref) int, globals VarSet, body Body) (Bod
 			vs := VarSet{}
 			WalkClosures(e, func(x interface{}) bool {
 				vis := &VarVisitor{vars: vs}
+				if ev, ok := x.(*Every); ok {
+					vis.Walk(ev.Body)
+					return true
+				}
 				vis.Walk(x)
 				return true
 			})

--- a/ast/compile.go
+++ b/ast/compile.go
@@ -3284,7 +3284,7 @@ func resolveRefsInRule(globals map[Var]Ref, rule *Rule) error {
 }
 
 func resolveRefsInBody(globals map[Var]Ref, ignore *declaredVarStack, body Body) Body {
-	r := Body{}
+	r := make([]*Expr, 0, len(body))
 	for _, expr := range body {
 		r = append(r, resolveRefsInExpr(globals, ignore, expr))
 	}

--- a/ast/compile.go
+++ b/ast/compile.go
@@ -4130,19 +4130,23 @@ func rewriteEveryStatement(g *localVarGenerator, stack *localDeclaredVars, expr 
 
 	// optionally rewrite the key
 	if every.Key != nil {
-		gv, err := rewriteDeclaredVar(g, stack, every.Key.Value.(Var), declaredVar)
-		if err != nil {
-			return nil, append(errs, NewError(CompileErr, every.Loc(), err.Error()))
+		if v := every.Key.Value.(Var); !v.IsWildcard() { // TODO
+			gv, err := rewriteDeclaredVar(g, stack, v, declaredVar)
+			if err != nil {
+				return nil, append(errs, NewError(CompileErr, every.Loc(), err.Error()))
+			}
+			every.Key.Value = gv
 		}
-		every.Key.Value = gv
 	}
 
 	// value is always present
-	gv, err := rewriteDeclaredVar(g, stack, every.Value.Value.(Var), declaredVar)
-	if err != nil {
-		return nil, append(errs, NewError(CompileErr, every.Loc(), err.Error()))
+	if v := every.Value.Value.(Var); !v.IsWildcard() {
+		gv, err := rewriteDeclaredVar(g, stack, v, declaredVar)
+		if err != nil {
+			return nil, append(errs, NewError(CompileErr, every.Loc(), err.Error()))
+		}
+		every.Value.Value = gv
 	}
-	every.Value.Value = gv
 
 	used := NewVarSet()
 	every.Body, errs = rewriteDeclaredVarsInBody(g, stack, used, every.Body, errs, strict)

--- a/ast/compile_test.go
+++ b/ast/compile_test.go
@@ -693,7 +693,7 @@ func TestCompilerCheckSafetyBodyReordering(t *testing.T) {
 	`},
 		{"userfunc", `split(y, ".", z); data.a.b.funcs.fn("...foo.bar..", y)`, `data.a.b.funcs.fn("...foo.bar..", y); split(y, ".", z)`},
 		{"every", `every _ in [] { x != 1 }; x = 1`, `__local3__ = []; x = 1; every _ in __local3__ { x != 1}`},
-		{"every-domain", `every _ in xs { true }; xs = [1]`, `xs = [1]; every _ in xs { true }`},
+		{"every-domain", `every _ in xs { true }; xs = [1]`, `xs = [1]; __local3__ = xs; every _ in __local3__ { true }`},
 	}
 
 	for i, tc := range tests {

--- a/ast/compile_test.go
+++ b/ast/compile_test.go
@@ -2848,7 +2848,7 @@ func TestRewriteDeclaredVars(t *testing.T) {
 					data.test.f(__local2__, "bar")
 				}
 
-				 f(__local0__, __local1__) = true {
+				f(__local0__, __local1__) = true {
 					__local0__[__local1__]
 				}
 			`,

--- a/ast/compile_test.go
+++ b/ast/compile_test.go
@@ -2791,6 +2791,33 @@ func TestRewriteDeclaredVars(t *testing.T) {
 			`,
 		},
 		{
+			note: "rewrite every: nested",
+			module: `
+				package test
+				# import future.keywords.in
+				# import future.keywords.every
+				p {
+					xs := [[1], [2]]
+					every v in [1] {
+						every w in xs[v] {
+							w == 2
+						}
+					}
+				}
+			`,
+			exp: `
+				package test
+				p = true {
+					__local0__ = [[1], [2]]
+					every __local1__ in [1] {
+						__local3__ = __local0__[__local1__]
+						every __local2__ in __local3__ {
+							equal(__local2__, 2)
+						}
+					}
+				}
+			`},
+		{
 			note: "rewrite closures",
 			module: `
 				package test

--- a/ast/compile_test.go
+++ b/ast/compile_test.go
@@ -2764,6 +2764,23 @@ func TestRewriteDeclaredVars(t *testing.T) {
 			`,
 		},
 		{
+			note: "rewrite every: pops declared var stack",
+			module: `
+				package test
+				# import future.keywords.in
+				# import future.keywords.every
+				p[x] {
+					some x
+					x = 10
+					every _ in [1] { true }
+				}
+			`,
+			exp: `
+				package test
+				p[__local0__] { __local0__ = 10;  every _ in [1] { true } }
+			`,
+		},
+		{
 			note: "rewrite closures",
 			module: `
 				package test

--- a/ast/compile_test.go
+++ b/ast/compile_test.go
@@ -213,6 +213,11 @@ func TestOutputVarsForNode(t *testing.T) {
 			query: `xs = []; every k, v in xs[i] { k < v }`,
 			exp:   `{xs, i}`,
 		},
+		{
+			note:  "every: output vars in body",
+			query: `every k, v in [] { k < v; i = 1 }`,
+			exp:   `{i}`,
+		},
 	}
 
 	for _, tc := range tests {

--- a/ast/compile_test.go
+++ b/ast/compile_test.go
@@ -216,7 +216,7 @@ func TestOutputVarsForNode(t *testing.T) {
 		{
 			note:  "every: output vars in body",
 			query: `every k, v in [] { k < v; i = 1 }`,
-			exp:   `{i}`,
+			exp:   `set()`,
 		},
 	}
 

--- a/ast/compilehelper.go
+++ b/ast/compilehelper.go
@@ -13,6 +13,7 @@ func CompileModules(modules map[string]string) (*Compiler, error) {
 // CompileOpts defines a set of options for the compiler.
 type CompileOpts struct {
 	EnablePrintStatements bool
+	ParserOptions         ParserOptions
 }
 
 // CompileModulesWithOpt takes a set of Rego modules represented as strings and
@@ -24,7 +25,7 @@ func CompileModulesWithOpt(modules map[string]string, opts CompileOpts) (*Compil
 	for f, module := range modules {
 		var pm *Module
 		var err error
-		if pm, err = ParseModule(f, module); err != nil {
+		if pm, err = ParseModuleWithOpts(f, module, opts.ParserOptions); err != nil {
 			return nil, err
 		}
 		parsed[f] = pm

--- a/ast/parser_ext.go
+++ b/ast/parser_ext.go
@@ -22,7 +22,13 @@ import (
 // MustParseBody returns a parsed body.
 // If an error occurs during parsing, panic.
 func MustParseBody(input string) Body {
-	parsed, err := ParseBody(input)
+	return MustParseBodyWithOpts(input, ParserOptions{})
+}
+
+// MustParseBodyWithOpts returns a parsed body.
+// If an error occurs during parsing, panic.
+func MustParseBodyWithOpts(input string, opts ParserOptions) Body {
+	parsed, err := ParseBodyWithOpts(input, opts)
 	if err != nil {
 		panic(err)
 	}
@@ -52,7 +58,13 @@ func MustParseImports(input string) []*Import {
 // MustParseModule returns a parsed module.
 // If an error occurs during parsing, panic.
 func MustParseModule(input string) *Module {
-	parsed, err := ParseModule("", input)
+	return MustParseModuleWithOpts(input, ParserOptions{})
+}
+
+// MustParseModuleWithOpts returns a parsed module.
+// If an error occurs during parsing, panic.
+func MustParseModuleWithOpts(input string, opts ParserOptions) *Module {
+	parsed, err := ParseModuleWithOpts("", input, opts)
 	if err != nil {
 		panic(err)
 	}

--- a/ast/policy.go
+++ b/ast/policy.go
@@ -1491,6 +1491,21 @@ func (q *Every) Compare(other *Every) int {
 	return q.Body.Compare(other.Body)
 }
 
+// Vars returns the key and val arguments of an every expression,
+// if they are non-nil and not wildcards.
+func (q *Every) Vars() VarSet {
+	r := NewVarSet()
+	if v := q.Value.Value.(Var); !v.IsWildcard() {
+		r.Add(v)
+	}
+	if q.Key != nil {
+		if v := q.Key.Value.(Var); !v.IsWildcard() {
+			r.Add(v)
+		}
+	}
+	return r
+}
+
 func (w *With) String() string {
 	return "with " + w.Target.String() + " as " + w.Value.String()
 }

--- a/ast/policy.go
+++ b/ast/policy.go
@@ -1491,9 +1491,9 @@ func (q *Every) Compare(other *Every) int {
 	return q.Body.Compare(other.Body)
 }
 
-// Vars returns the key and val arguments of an every expression,
-// if they are non-nil and not wildcards.
-func (q *Every) Vars() VarSet {
+// KeyValueVars returns the key and val arguments of an `every`
+// expression, if they are non-nil and not wildcards.
+func (q *Every) KeyValueVars() VarSet {
 	r := NewVarSet()
 	if v := q.Value.Value.(Var); !v.IsWildcard() {
 		r.Add(v)

--- a/ast/policy.go
+++ b/ast/policy.go
@@ -1494,16 +1494,12 @@ func (q *Every) Compare(other *Every) int {
 // KeyValueVars returns the key and val arguments of an `every`
 // expression, if they are non-nil and not wildcards.
 func (q *Every) KeyValueVars() VarSet {
-	r := NewVarSet()
-	if v := q.Value.Value.(Var); !v.IsWildcard() {
-		r.Add(v)
-	}
+	vis := &VarVisitor{vars: VarSet{}}
 	if q.Key != nil {
-		if v := q.Key.Value.(Var); !v.IsWildcard() {
-			r.Add(v)
-		}
+		vis.Walk(q.Key)
 	}
-	return r
+	vis.Walk(q.Value)
+	return vis.vars
 }
 
 func (w *With) String() string {

--- a/ast/policy.go
+++ b/ast/policy.go
@@ -1262,6 +1262,18 @@ func (expr *Expr) IsCall() bool {
 	return ok
 }
 
+// IsEvery returns true if this expression is an 'every' expression.
+func (expr *Expr) IsEvery() bool {
+	_, ok := expr.Terms.(*Every)
+	return ok
+}
+
+// IsSome returns true if this expression is a 'some' expression.
+func (expr *Expr) IsSome() bool {
+	_, ok := expr.Terms.(*SomeDecl)
+	return ok
+}
+
 // Operator returns the name of the function or built-in this expression refers
 // to. If this expression is not a function call, returns nil.
 func (expr *Expr) Operator() Ref {

--- a/ast/term.go
+++ b/ast/term.go
@@ -493,6 +493,20 @@ func ContainsComprehensions(v interface{}) bool {
 	return found
 }
 
+// ContainsClosures returns true if the Value v contains closures.
+func ContainsClosures(v interface{}) bool {
+	found := false
+	WalkClosures(v, func(x interface{}) bool {
+		switch x.(type) {
+		case *ArrayComprehension, *ObjectComprehension, *SetComprehension, *Every:
+			found = true
+			return found
+		}
+		return found
+	})
+	return found
+}
+
 // IsScalar returns true if the AST value is a scalar.
 func IsScalar(v Value) bool {
 	switch v.(type) {

--- a/ast/visit.go
+++ b/ast/visit.go
@@ -542,6 +542,8 @@ func (vis *VarVisitor) Vars() VarSet {
 	return vis.vars
 }
 
+// visit determines if the VarVisitor will recurse into x: if it returns `true`,
+// the visitor will _skip_ that branch of the AST
 func (vis *VarVisitor) visit(v interface{}) bool {
 	if vis.params.SkipObjectKeys {
 		if o, ok := v.(Object); ok {
@@ -560,9 +562,13 @@ func (vis *VarVisitor) visit(v interface{}) bool {
 		}
 	}
 	if vis.params.SkipClosures {
-		switch v.(type) {
-		case *ArrayComprehension, *ObjectComprehension, *SetComprehension, *Every:
+		switch v := v.(type) {
+		case *ArrayComprehension, *ObjectComprehension, *SetComprehension:
 			return true
+		case *Expr:
+			if _, ok := v.Terms.(*Every); ok {
+				return true
+			}
 		}
 	}
 	if vis.params.SkipWithTarget {

--- a/ast/visit.go
+++ b/ast/visit.go
@@ -161,10 +161,8 @@ func WalkVars(x interface{}, f func(Var) bool) {
 func WalkClosures(x interface{}, f func(interface{}) bool) {
 	vis := &GenericVisitor{func(x interface{}) bool {
 		switch x := x.(type) {
-		case *ArrayComprehension, *ObjectComprehension, *SetComprehension:
+		case *ArrayComprehension, *ObjectComprehension, *SetComprehension, *Every:
 			return f(x)
-		case *Every:
-			return f(x.Body)
 		}
 		return false
 	}}

--- a/ast/visit.go
+++ b/ast/visit.go
@@ -160,9 +160,11 @@ func WalkVars(x interface{}, f func(Var) bool) {
 // returns true, AST nodes under the last node will not be visited.
 func WalkClosures(x interface{}, f func(interface{}) bool) {
 	vis := &GenericVisitor{func(x interface{}) bool {
-		switch x.(type) {
+		switch x := x.(type) {
 		case *ArrayComprehension, *ObjectComprehension, *SetComprehension:
 			return f(x)
+		case *Every:
+			return f(x.Body)
 		}
 		return false
 	}}
@@ -566,7 +568,9 @@ func (vis *VarVisitor) visit(v interface{}) bool {
 		case *ArrayComprehension, *ObjectComprehension, *SetComprehension:
 			return true
 		case *Expr:
-			if _, ok := v.Terms.(*Every); ok {
+			if ev, ok := v.Terms.(*Every); ok {
+				vis.Walk(ev.Domain)
+				// We're _not_ walking ev.Body -- that's the closure here
 				return true
 			}
 		}


### PR DESCRIPTION
This PR covers the compiler doing it's job on `every`:

- resolve refs
- rewriting other declared vars in _domain_
- rewriting _its declared vars_ and others in _its body_
- rewriting dynamics in the body
- expanding expressions
- safety body reordering and var checking