### PR TITLE
Expose planner/IR output via compile package and build command

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -46,7 +46,7 @@ type buildParams struct {
 func newBuildParams() buildParams {
 	return buildParams{
 		capabilities: newcapabilitiesFlag(),
-		target:       util.NewEnumFlag(compile.TargetRego, []string{compile.TargetRego, compile.TargetWasm}),
+		target:       util.NewEnumFlag(compile.TargetRego, compile.Targets),
 	}
 }
 

--- a/compile/compile_test.go
+++ b/compile/compile_test.go
@@ -660,6 +660,28 @@ func ensureEntrypointRemoved(t *testing.T, b *bundle.Bundle, e string) {
 	}
 }
 
+func TestCompilerPlanTarget(t *testing.T) {
+	files := map[string]string{
+		"test.rego": `package test
+
+		p = 7
+		q = p+1`,
+	}
+
+	test.WithTempFS(files, func(root string) {
+
+		compiler := New().WithPaths(root).WithTarget("plan").WithEntrypoints("test/p", "test/q")
+		err := compiler.Build(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(compiler.bundle.PlanModules) == 0 {
+			t.Fatal("expected to find compiled plan module")
+		}
+	})
+}
+
 func TestCompilerSetRevision(t *testing.T) {
 	files := map[string]string{
 		"test.rego": `package test

--- a/docs/content/ir.md
+++ b/docs/content/ir.md
@@ -1,0 +1,457 @@
+---
+title: Intermediate Representation (IR)
+kind: misc
+weight: 1
+---
+
+# Overview
+
+OPA can compile policy queries into planned evaluation paths suitable for
+further compilation or interpretation. This document explains the structure and
+semantics of the intermediate representation (IR) used to represent these
+planned evaluation paths. Read this document if you want to write a compiler or
+interpreter for Rego.
+
+# Structure
+
+This section explains the structure of policies compiled into the IR.
+
+## Policy
+
+The root object emitted by the compiler is a `Policy` and contains the following
+top-level keys:
+
+* `static` is an object containing static data used by the compiled plans and
+  functions.
+* `plans` is an object containing entrypoints to compiled evaluation paths.
+* `funcs` is an object containing functions supporting the compiled evaluation
+  paths.
+
+## Static
+
+The `Static` object contains static data required by the plans and functions.
+The static object also contains metadata that does not affect the semantics of
+the policy. The static object contains the following top-level keys:
+
+* `strings` is an array of string constants referenced by compiled statements in
+  the plans and functions.
+* `builtin_funcs` is an array of function declarations representing built-in
+  functions required by the compiled statements.
+* `files` is used for debugging purposes only. It is an array of filenames that
+  were used during compilation.
+
+### Strings
+
+The `Strings` array is a collection of string objects referenced by compiled
+statements in the policy. Strings are referenced by their index in the
+collection. Each string object contains the following fields:
+
+* `value` is the string constant value. The string may be any valid JSON string.
+
+### Built-in Functions
+
+The `Built-in Functions` array is a collection of built-in function
+declarations. Each declaration represents a function that must be provided by
+the environment where the policy is eventually executed. Each built-in function
+contains the following fields:
+
+* `name` is the name of the function that must be provided.
+* `decl` is the type definition of the function.
+
+### Files
+
+The `Files` array is a collection of static strings representing names of source
+files used during compilation. Filenames are referred to by their index in the
+files array.
+
+## Plans
+
+The `Plans` object contains a collection of planned evaluation paths
+representing entrypoints to the policy. When users compile policies they supply
+the queries to expose as entrypoints. Each plan contains the following fields:
+
+* `name` is the entrypoint identifier, typically set to the path of the policy
+  decision (e.g., `authz/allow`).
+* `blocks` is a collection of [`Block`](#blocks) objects representing the
+  compiled statements that define the entrypoint.
+
+## Functions
+
+The `Functions` object contains a collection of function definitions that
+represent functions supporting the plans. Functions can be invoked by name
+inside of plans and other functions. Each function contains the following
+fields:
+
+* `name` is the function identifier referenced by call statements.
+* `path` is the function identifier referenced by dynamic call statements.
+* `params` is an ordered list of local variable identifiers representing
+  function parameters. The parameters can be referenced inside of the blocks
+  that define the function.
+* `return` is the local variable containing the return value of the function.
+* `blocks` is collection of [`Block`](#blocks) objects representing the compiled
+  statements that define the function.
+
+## Blocks
+
+The `Block` object contains a sequence of [Statements](#statements) that must be
+executed in order until a statement terminating block execution is encountered
+or the end of the block is reached. Each block contains the following fields:
+
+* `stmts` is an array of `Statement` objects.
+
+## Statements
+
+The `Statement` object represents an operation performed by the policy (e.g.,
+function invocation, lookup, iteration, comparison, etc.) The structure is
+specific to each statement type but every statement contains the following
+fields:
+
+* `type` is a string value that identifies the type of the statement.
+* `stmt` is an object containing statement-specific fields.
+* `file` is the index of source filename where this statement originated.
+* `row` is the row in the source file where this statement originated.
+* `col` is the column in the source file where this statement originated.
+
+See the [Statement Definitions](#statement-definitions) section for an
+explanation of the supported statement types.
+
+# Execution
+
+This section explains the execution model for compiled policies.
+
+## Plan Execution
+
+Compiled policies consist of one or more plans. Any plan can be invoked by name.
+If no name is supplied, the first plan in the policy should be executed. Plans
+consist of one or more [Blocks](#blocks) that are executed in-order. Statements
+inside the blocks of a plan have implicit access to two local variables
+representing the `input` and `data` documents (`0` and `1` respectively.) The
+final statement in every block inside of a plan is a `ResultSetAddStmt`
+statement that adds an object to an implicit result set. The object contains the
+key-value bindings representing the values of variables in the original query.
+If no `ResultSetAddStmt` statements are executed, the implicit result set is
+empty.
+
+## Function Execution
+
+Compiled policies may contain zero or more functions. Any function can be
+invoked by name via the `CallStmt` statement or dynamically via the
+`CallDynamicStmt` statement. All functions are defined with two or more
+positional arguments. The first positional argument is a local variable
+representing the `input` document. The second positional argument is a local
+variable representing the `data` document. Function execution terminates when a
+`ReturnLocalStmt` statement is encountered. All functions include a final block
+that includes a `ReturnLocalStmt`.
+
+## Block Execution
+
+Blocks are sequences of statements that are executed in order. Statements can be
+executed if all of the input parameters are defined. If any input parameter is
+undefined then the statement is undefined. The [Statement
+Definitions](#statement-definitions) section below indicates when a statement
+may be undefined. When a statement is undefined execution breaks to the end of
+the current block and resumes execution at the statement immediately following
+the block (which may be the beginning of another block.) When a statement is
+defined, all output parameters are defined. Execution halts if a statement
+raises an exception.
+
+# Statement Definitions
+
+This section defines the statements that can be contained in plans and functions
+and explains the input and output parameters that each statement accepts. The
+set of valid parameter types are:
+
+* `local` is a 32-bit integer representing a local variable.
+* `int32` is a 32-bit integer.
+* `int64` is a 64-bit integer.
+* `uint32` is a 32-bit unsigned integer.
+* `string` is an arbitrary-length unicode string.
+* `array[...]` represents a sequence of `...` values.
+
+In addition, parameters may be of type `operand`. The `operand` type represents
+a tagged union that can refer to a local variable, boolean constant, or string
+constant index:
+
+```
+{
+    "type": "local" | "bool" | "string_index"
+    "value": number | boolean | number
+}
+```
+
+Local variables refer to values. The value types are any JSON value (i.e., `null`,
+`true`, `false`, `number`, `string`, `array`, and `object`) as well as sets
+(which are unordered value collections.)
+
+## `ArrayAppendStmt`
+
+Parameter | Input/Output | Type | Description
+--- | --- | --- | ---
+`array` | `input` | `local` | The array to append a value to.
+`value` | `input` | `operand` | The value to append to the array.
+
+## `AssignIntStmt`
+
+Parameter | Input/Output | Type | Description
+--- | --- | --- | ---
+`value` | `input` | `int64` | The integer value to assign to the target.
+`target` | `output` | `local` | The local variable to assign the integer to.
+
+## `AssignVarOnceStmt`
+
+Parameter | Input/Output | Type | Description
+--- | --- | --- | ---
+`source` | `input` | `operand` | The value ato assign to the target.
+`target` | `output` | `local` | The local variable to assign the operand to.
+
+{{< danger >}}
+This statement raises an exception if the `target` operand is already assigned.
+{{< /danger >}}
+
+## `AssignVarStmt`
+
+Parameter | Input/Output | Type | Description
+--- | --- | --- | ---
+`source` | `input` | `operand` | The value to assign to the target.
+`target` | `output` | `local` | The local variable to assign the operand to.
+
+## `BlockStmt`
+
+Parameter | Input/Output | Type | Description
+--- | --- | --- | ---
+`blocks` | `input` | [Blocks](#blocks) | The nested blocks to execute.
+
+## `BreakStmt`
+
+Parameter | Input/Output | Type | Description
+--- | --- | --- | ---
+`index` | `input` | `uint32` | The index of the block to jump out of starting with zero representing the current block and incrementing by one for each outer block.
+
+## `CallDynamicStmt`
+
+Parameter | Input/Output | Type | Description
+--- | --- | --- | ---
+`path` | `input` | `array[operand]` | The path of the function to invoke.
+`args` | `input` | `array[local]` | The positional arguments to pass to the function.
+`result` | `output` | `local` | The local variable to assign the function return value to.
+
+## `CallStmt`
+
+Parameter | Input/Output | Type | Description
+--- | --- | --- | ---
+`func` | `input` | `string` | The name of the function to invoke.
+`args` | `input` | `array[local]` | The positional arguments to pass to the function.
+`result` | `output` | `local` | The local variable to assign the function return value to.
+
+## `DotStmt`
+
+Parameter | Input/Output | Type | Description
+--- | --- | --- | ---
+`source` | `input` | `operand` | The value to perform a lookup operation on.
+`key` | `input` | `operand` | The key to lookup in the source.
+`target` | `output` | `local` | The local variable to assign the result to.
+
+This statement is **undefined** if the `key` does not exist in the `source` value.
+
+## `EqualStmt`
+
+Parameter | Input/Output | Type | Description
+--- | --- | --- | ---
+`a` | `input` | `operand` | The first value to compare.
+`b` | `input` | `operand` | The second value to compare.
+
+This statement is **undefined** if `a` does not equal `b`.
+
+## `IsArrayStmt`
+
+Parameter | Input/Output | Type | Description
+--- | --- | --- | ---
+`source` | `input` | `operand` | The value to check.
+
+This statement is **undefined** if `source` is not an array.
+
+## `IsDefinedStmt`
+
+Parameter | Input/Output | Type | Description
+--- | --- | --- | ---
+`source` | `input` | `operand` | The value to check.
+
+This statement is **undefined** if `source` is undefined.
+
+## `IsObjectStmt`
+
+Parameter | Input/Output | Type | Description
+--- | --- | --- | ---
+`source` | `input` | `operand` | The value to check.
+
+This statement is **undefined** if `source` is not an object.
+
+## `IsUndefinedStmt`
+
+Parameter | Input/Output | Type | Description
+--- | --- | --- | ---
+`source` | `input` | `operand` | The value to check.
+
+This statement is **undefined** if `source` is not undefined.
+
+## `LenStmt`
+
+Parameter | Input/Output | Type | Description
+--- | --- | --- | ---
+`source` | `input` | `operand` | The value to compute the length for.
+`target` | `output` | `local` | The local variable to assign the length to.
+
+## `MakeArrayStmt`
+
+Parameter | Input/Output | Type | Description
+--- | --- | --- | ---
+`capacity` | `input` | `int32` | The initial size of the array to pre-allocate.
+`target` | `output` | `local` | The local variable to assign the array value to.
+
+## `MakeNullStmt`
+
+Parameter | Input/Output | Type | Description
+--- | --- | --- | ---
+`target` | `output` | `local` | The local variable to assign the null value to.
+
+## `MakeNumberIntStmt`
+
+Parameter | Input/Output | Type | Description
+--- | --- | --- | ---
+`value` | `input` | `int64` | The integer value to initialize the target with.
+`target` | `output` | `local` | The local variable to assign the number to.
+
+## `MakeNumberRefStmt`
+
+Parameter | Input/Output | Type | Description
+--- | --- | --- | ---
+`index` | `input` | `int32` | The index of the string constant to construct the number with.
+`target` | `output` | `local` | The local variable to assign the number to.
+
+## `MakeObjectStmt`
+
+Parameter | Input/Output | Type | Description
+--- | --- | --- | ---
+`target` | `output` | `local` | The local variable to assign the object to.
+
+## `MakeSetStmt`
+
+Parameter | Input/Output | Type | Description
+--- | --- | --- | ---
+`target` | `output` | `local` | The local variable to assign the set to.
+
+## `NopStmt`
+
+This statement is only used for debugging purposes.
+
+## `NotEqualStmt`
+
+Parameter | Input/Output | Type | Description
+--- | --- | --- | ---
+`a` | `input` | `operand` | The first value to compare.
+`b` | `input` | `operand` | The second value to compare.
+
+This statement is **undefined** if `a` is equal to `b`.
+
+## `NotStmt`
+
+Parameter | Input/Output | Type | Description
+--- | --- | --- | ---
+`block` | `input` | [Block](#blocks) | The negated statement to execute.
+
+This statement is **undefined** if the contained block is not undefined.
+
+## `ObjectInsertOnceStmt`
+
+Parameter | Input/Output | Type | Description
+--- | --- | --- | ---
+`key` | `input` | `operand` | The key to insert into the object.
+`value` | `input` | `operand` | The value to insert into the object.
+`object` | `input` | `local` | The object to insert the key-value pair into.
+
+{{< danger >}}
+This statement raises an exception if the `object` contains an existing `key` with a different `value`.
+{{< /danger >}}
+
+## `ObjectInsertStmt`
+
+Parameter | Input/Output | Type | Description
+--- | --- | --- | ---
+`key` | `input` | `operand` | The key to insert into the object.
+`value` | `input` | `operand` | The value to insert into the object.
+`object` | `input` | `local` | The object to insert the key-value pair into.
+
+## `ObjectMergeStmt`
+
+Parameter | Input/Output | Type | Description
+--- | --- | --- | ---
+`a` | `input` | `local` | The object to merge into.
+`b` | `input` | `local` | The object to merge from.
+`target` | `output` | `local` | The local variable to assign the merged object to.
+
+## `ResetLocalStmt`
+
+Parameter | Input/Output | Type | Description
+--- | --- | --- | ---
+`target` | `output` | `local` | The local variable to reset.
+
+## `ResultSetAddStmt`
+
+Parameter | Input/Output | Type | Description
+--- | --- | --- | ---
+`value` | `input` | `local` | The value to add to the result set.
+
+## `ReturnLocalStmt`
+
+Parameter | Input/Output | Type | Description
+--- | --- | --- | ---
+`source` | `input` | `local` | The value to return from the function.
+
+## `ScanStmt`
+
+Parameter | Input/Output | Type | Description
+--- | --- | --- | ---
+`source` | `input` | `local` | The value to scan.
+`key` | `output` | `local` | The local variable to assign keys to before executing the nested block.
+`value` | `output` | `local` | The local variable to assign values to before executing the nested block.
+`block` | `input` | [Block](#blocks) | The nested block to execute repeatedly for each element in the collection.
+
+This statement is **undefined** if `source` is a scalar value or empty collection.
+
+## `SetAddStmt`
+
+Parameter | Input/Output | Type | Description
+--- | --- | --- | ---
+`value` | `input` | `operand` | The value to insert into the set.
+`set` | `input` | `local` | The set to insert the value into.
+
+## `WithStmt`
+
+Parameter | Input/Output | Type | Description
+--- | --- | --- | ---
+`local` | `input` | `local` | The value to mutate in the context of the nested block.
+`path` | `input` | `array[int32]` | The path of the nested document to replace with the `value` represented as an array of string constant indices.
+`value` | `input` | `operand` | The value to upsert.
+`block` | `input` | [Block](#blocks) | The nested block to execute in the context of the mutation.
+
+# Test Suite
+
+The OPA repository contains a [test
+suite](https://github.com/open-policy-agent/opa/tree/main/test/cases/testdata)
+that is used internally to validate both the Go interpreter and the Wasm
+compiler. If you are implementing your own compiler or interpreter we highly
+recommend integrating the test suite into your own development environment so
+that your implementation can be verified to conform with OPA's.
+
+The test suite consists of a set of YAML files that each contain a set of test
+cases. Each test cases specifies a query, set of modules, data values, and
+expected outputs or expected error conditions.
+
+To get started with the test suite, see the [Hello
+World](https://github.com/open-policy-agent/opa/blob/main/test/cases/testdata/helloworld/test-helloworld-1.yaml)
+example.
+
+The following examples show how the test suite is used internally:
+
+* [`github.com/open-policy-agent/opa/topdown#TestRego`](https://github.com/open-policy-agent/opa/blob/main/topdown/exported_test.go)
+* [`github.com/open-policy-agent/opa/test/wasm/cmd/wasm-rego-testgen`](https://github.com/open-policy-agent/opa/blob/main/test/wasm/cmd/wasm-rego-testgen/main.go)

--- a/internal/ir/encoding/encoding_test.go
+++ b/internal/ir/encoding/encoding_test.go
@@ -1,0 +1,71 @@
+package planner
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/internal/ir"
+	"github.com/open-policy-agent/opa/internal/planner"
+)
+
+func TestRoundTrip(t *testing.T) {
+
+	c, err := ast.CompileModules(map[string]string{
+		"test.rego": `
+			package test
+
+			p {
+				input.foo == 7
+			}
+		`,
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	modules := []*ast.Module{}
+
+	for _, m := range c.Modules {
+		modules = append(modules, m)
+	}
+
+	planner := planner.New().
+		WithQueries([]planner.QuerySet{
+			{
+				Name: "main",
+				Queries: []ast.Body{
+					ast.MustParseBody("data.test.p = true"),
+				},
+			},
+		}).
+		WithModules(modules).
+		WithBuiltinDecls(ast.BuiltinMap)
+
+	plan, err := planner.Plan()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	bs, err := json.MarshalIndent(plan, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var cpy ir.Policy
+	err = json.Unmarshal(bs, &cpy)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	bs2, err := json.MarshalIndent(plan, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(bs, bs2) {
+		t.Fatal("expected bytes to be equal")
+	}
+}

--- a/internal/ir/ir.go
+++ b/internal/ir/ir.go
@@ -89,32 +89,9 @@ type (
 	// TODO(tsandall): should this be int32 for safety?
 	Local int
 
-	// Const represents a constant value from the policy.
-	Const interface {
-		typeMarker()
-	}
-
-	// NullConst represents a null value.
-	NullConst struct{}
-
-	// BooleanConst represents a boolean value.
-	BooleanConst struct {
-		Value bool
-	}
-
 	// StringConst represents a string value.
 	StringConst struct {
 		Value string
-	}
-
-	// IntConst represents an integer constant.
-	IntConst struct {
-		Value int64
-	}
-
-	// FloatConst represents a floating-point constant.
-	FloatConst struct {
-		Value float64
 	}
 )
 
@@ -152,12 +129,6 @@ func (a *Plan) String() string {
 func (a *Block) String() string {
 	return fmt.Sprintf("Block (%d statements)", len(a.Stmts))
 }
-
-func (*BooleanConst) typeMarker() {}
-func (*NullConst) typeMarker()    {}
-func (*IntConst) typeMarker()     {}
-func (*FloatConst) typeMarker()   {}
-func (*StringConst) typeMarker()  {}
 
 // ReturnLocalStmt represents a return statement that yields a local value.
 type ReturnLocalStmt struct {

--- a/internal/ir/marshal.go
+++ b/internal/ir/marshal.go
@@ -1,0 +1,133 @@
+package ir
+
+import (
+	"encoding/json"
+	"reflect"
+)
+
+func (a *Block) MarshalJSON() ([]byte, error) {
+	var result typedBlock
+	result.Stmts = make([]typedStmt, len(a.Stmts))
+	for i := range a.Stmts {
+		tpe := reflect.Indirect(reflect.ValueOf(a.Stmts[i])).Type().Name()
+		result.Stmts[i] = typedStmt{
+			Type: tpe,
+			Stmt: a.Stmts[i],
+		}
+	}
+	return json.Marshal(result)
+}
+
+func (a *Block) UnmarshalJSON(bs []byte) error {
+	var typed rawTypedBlock
+	if err := json.Unmarshal(bs, &typed); err != nil {
+		return err
+	}
+	a.Stmts = make([]Stmt, len(typed.Stmts))
+	for i := range typed.Stmts {
+		var err error
+		a.Stmts[i], err = typed.Stmts[i].Unmarshal()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (a *Operand) MarshalJSON() ([]byte, error) {
+	var result typedOperand
+	result.Value = a.Value
+	result.Type = a.Value.typeHint()
+	return json.Marshal(result)
+}
+
+func (a *Operand) UnmarshalJSON(bs []byte) error {
+	var typed rawTypedOperand
+	if err := json.Unmarshal(bs, &typed); err != nil {
+		return err
+	}
+	x := valFactories[typed.Type]()
+	if err := json.Unmarshal(typed.Value, &x); err != nil {
+		return err
+	}
+	a.Value = x
+	return nil
+}
+
+type typedBlock struct {
+	Stmts []typedStmt `json:"stmts"`
+}
+
+type typedStmt struct {
+	Type string `json:"type"`
+	Stmt Stmt   `json:"stmt"`
+}
+
+type rawTypedBlock struct {
+	Stmts []rawTypedStmt `json:"stmts"`
+}
+
+type rawTypedStmt struct {
+	Type string          `json:"type"`
+	Stmt json.RawMessage `json:"stmt"`
+}
+
+func (raw rawTypedStmt) Unmarshal() (Stmt, error) {
+	x := stmtFactories[raw.Type]()
+	if err := json.Unmarshal(raw.Stmt, &x); err != nil {
+		return nil, err
+	}
+	return x, nil
+}
+
+type rawTypedOperand struct {
+	Type  string          `json:"type"`
+	Value json.RawMessage `json:"value"`
+}
+
+type typedOperand struct {
+	Type  string `json:"type"`
+	Value Val    `json:"value"`
+}
+
+var stmtFactories = map[string]func() Stmt{
+	"ReturnLocalStmt":      func() Stmt { return &ReturnLocalStmt{} },
+	"CallStmt":             func() Stmt { return &CallStmt{} },
+	"CallDynamicStmt":      func() Stmt { return &CallDynamicStmt{} },
+	"BlockStmt":            func() Stmt { return &BlockStmt{} },
+	"BreakStmt":            func() Stmt { return &BreakStmt{} },
+	"DotStmt":              func() Stmt { return &DotStmt{} },
+	"LenStmt":              func() Stmt { return &LenStmt{} },
+	"ScanStmt":             func() Stmt { return &ScanStmt{} },
+	"NotStmt":              func() Stmt { return &NotStmt{} },
+	"AssignIntStmt":        func() Stmt { return &AssignIntStmt{} },
+	"AssignVarStmt":        func() Stmt { return &AssignVarStmt{} },
+	"AssignVarOnceStmt":    func() Stmt { return &AssignVarOnceStmt{} },
+	"ResetLocalStmt":       func() Stmt { return &ResetLocalStmt{} },
+	"MakeNullStmt":         func() Stmt { return &MakeNullStmt{} },
+	"MakeNumberIntStmt":    func() Stmt { return &MakeNumberIntStmt{} },
+	"MakeNumberRefStmt":    func() Stmt { return &MakeNumberRefStmt{} },
+	"MakeArrayStmt":        func() Stmt { return &MakeArrayStmt{} },
+	"MakeObjectStmt":       func() Stmt { return &MakeObjectStmt{} },
+	"MakeSetStmt":          func() Stmt { return &MakeSetStmt{} },
+	"EqualStmt":            func() Stmt { return &EqualStmt{} },
+	"NotEqualStmt":         func() Stmt { return &NotEqualStmt{} },
+	"IsArrayStmt":          func() Stmt { return &IsArrayStmt{} },
+	"IsObjectStmt":         func() Stmt { return &IsObjectStmt{} },
+	"IsDefinedStmt":        func() Stmt { return &IsDefinedStmt{} },
+	"IsUndefinedStmt":      func() Stmt { return &IsUndefinedStmt{} },
+	"ArrayAppendStmt":      func() Stmt { return &ArrayAppendStmt{} },
+	"ObjectInsertStmt":     func() Stmt { return &ObjectInsertStmt{} },
+	"ObjectInsertOnceStmt": func() Stmt { return &ObjectInsertOnceStmt{} },
+	"ObjectMergeStmt":      func() Stmt { return &ObjectMergeStmt{} },
+	"SetAddStmt":           func() Stmt { return &SetAddStmt{} },
+	"WithStmt":             func() Stmt { return &WithStmt{} },
+	"NopStmt":              func() Stmt { return &NopStmt{} },
+	"ResultSetAddStmt":     func() Stmt { return &ResultSetAddStmt{} },
+}
+
+var valFactories = map[string]func() Val{
+	"bool":         func() Val { var x Bool; return &x },
+	"string_index": func() Val { var x StringIndex; return &x },
+	"local":        func() Val { var x Local; return &x },
+}

--- a/internal/planner/planner_test.go
+++ b/internal/planner/planner_test.go
@@ -585,7 +585,7 @@ a = true`},
 				&ir.CallStmt{}:         "<query>:1:1: data[y].a = x",
 				&ir.MakeObjectStmt{}:   "<query>:1:1: data[y].a = x",
 				&ir.ObjectInsertStmt{}: "<query>:1:1: data[y].a = x",
-				&ir.ResultSetAdd{}:     "<query>:1:1: data[y].a = x",
+				&ir.ResultSetAddStmt{}: "<query>:1:1: data[y].a = x",
 				&ir.DotStmt{}:          "<query>:1:1: data[y].a = x",
 			},
 			where: func(p *ir.Policy) interface{} {
@@ -603,7 +603,7 @@ a {
 				&ir.CallStmt{}:         "<query>:1:1: data.test.a = x",
 				&ir.MakeObjectStmt{}:   "<query>:1:1: data.test.a = x",
 				&ir.ObjectInsertStmt{}: "<query>:1:1: data.test.a = x",
-				&ir.ResultSetAdd{}:     "<query>:1:1: data.test.a = x",
+				&ir.ResultSetAddStmt{}: "<query>:1:1: data.test.a = x",
 				&ir.ScanStmt{}:         `module-0.rego:3:3: data.test1[_].y = "z"`,
 			},
 		},
@@ -738,7 +738,7 @@ func TestOptimizeLookup(t *testing.T) {
 		if exp, act := 3, len(path); exp != act {
 			t.Fatalf("expected path len %d, got %d\n", exp, act)
 		}
-		last, ok := path[len(path)-1].(ir.Local)
+		last, ok := path[len(path)-1].Value.(ir.Local)
 		if exp, act := true, ok; exp != act {
 			t.Fatalf("expected last path pieces to be local, got %T\n", last)
 		}

--- a/internal/planner/varstack.go
+++ b/internal/planner/varstack.go
@@ -42,6 +42,19 @@ func (vs varstack) Get(k ast.Var) (ir.Local, bool) {
 	return 0, false
 }
 
+func (vs varstack) GetOpOrEmpty(k ast.Var) ir.Operand {
+	l := vs.GetOrEmpty(k)
+	return ir.Operand{Value: l}
+}
+
+func (vs varstack) GetOp(k ast.Var) (ir.Operand, bool) {
+	l, ok := vs.Get(k)
+	if !ok {
+		return ir.Operand{}, false
+	}
+	return ir.Operand{Value: l}, true
+}
+
 func (vs varstack) Put(k ast.Var, v ir.Local) {
 	vs[len(vs)-1][k] = v
 }


### PR DESCRIPTION
This PR adds a new "plan" target to the compile package and `opa build` command. This lets users compile their policies into the plan IR so that they could be further transpiled or interpreted outside of OPA.

@srenatus this is still WIP but it's probably worth getting your eyes on this...

- The encoding stuff for the IR is not the prettiest but it works. Maybe there's a cleaner way of doing this? I wanted to avoid having to add marshaling logic to every single statement struct.
- I think we should rename `LocalOrConst` to something a bit less verbose. Maybe just `Operand`?
- See my comment about wrapping the old `LocalOrConst` interface (currently called `LocalOrConstInterface`) in another struct to facilitate marshaling.

Assuming this direction is good, I could imagine:

- ~Adding json tags to all of the struct fields so that we don't inherit the TitleCase convention~
- ~Writing up a short doc explaining the plans so that people could start building transpilers/interpreters for them--explain the top-level policy/plan/block structures + explain each of the statements.~
- ~Rename `Index` field on ir.Location struct to `file`~
- ~Rename `ResultSetAdd` to `ResultSetAddStmt` for consistency~
- ~Think about whether to support bare locals on statements (or make everything an operand)~ punting on this for now--see comment below.

I haven't updated all of the bundle activation logic to insert plans into the store like we do for wasm modules (because we don't have a built-in interpreter for the plans anyway.)