### PR TITLE
ast/parser: don't error when future kw import is redundant

### DIFF
--- a/ast/internal/scanner/scanner.go
+++ b/ast/internal/scanner/scanner.go
@@ -112,6 +112,21 @@ func (s *Scanner) WithKeywords(kws map[string]tokens.Token) *Scanner {
 	return &cpy
 }
 
+// WithoutKeywords returns a new copy of the Scanner struct `s`, with the
+// set of known keywords being that of `s` with `kws` removed.
+// The previously known keywords are returned for a convenient reset.
+func (s *Scanner) WithoutKeywords(kws map[string]tokens.Token) (*Scanner, map[string]tokens.Token) {
+	cpy := *s
+	kw := s.keywords
+	cpy.keywords = make(map[string]tokens.Token, len(s.keywords)-len(kws))
+	for kw, tok := range s.keywords {
+		if _, ok := kws[kw]; !ok {
+			cpy.AddKeyword(kw, tok)
+		}
+	}
+	return &cpy, kw
+}
+
 // Scan will increment the scanners position in the source
 // code until the next token is found. The token, starting position
 // of the token, string literal, and any errors encountered are


### PR DESCRIPTION
When passing `ParserOptions{AllFutureKeywords: true}` or
`ParserOptions{FutureKeywords: []string{"in"}}` to the `ast` package's
parse methods, and when parsing a module that contains

    import future.keywords.in

then we would previously have raised an error: when the parser
encountered the `in`, it complains about not expecting an "in" token
there.

Now, parsing imports is done with a scanner copy that knows nothing
about the future keywords.
