### PR TITLE
bundle: Roundtrip manifest before hashing

### DIFF
--- a/bundle/bundle_test.go
+++ b/bundle/bundle_test.go
@@ -851,7 +851,9 @@ func TestRoundtrip(t *testing.T) {
 			},
 		},
 		Manifest: Manifest{
+			Roots:    &[]string{""},
 			Revision: "quickbrownfaux",
+			Metadata: map[string]interface{}{"version": "v1", "hello": "world"},
 		},
 	}
 


### PR DESCRIPTION
When OPA verifies the content of the manifest file,
it first parses it into a JSON structure and then recursively orders
the fields of all objects alphabetically and then applies the
hash function. The same process was not followed while generating
the hash for the manifest content which would result in a digest
mismatch during verification. This can be observed with a manifest
that contains metadata.

Fixes: #4233

Signed-off-by: Ashutosh Narkar <anarkar4387@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->
