### PR TITLE
Warn when .manifest detected in non --bundle build

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -317,6 +317,9 @@ func buildCommandLoaderFilter(bundleMode bool, ignore []string) func(string, os.
 			if !info.IsDir() && strings.HasSuffix(abspath, ".tar.gz") {
 				return true
 			}
+			if info.Name() == ".manifest" {
+				fmt.Println("warn: detected .manifest file will be ignored unless --bundle flag is provided.")
+			}
 		}
 		return loaderFilter{Ignore: ignore}.Apply(abspath, info, depth)
 	}


### PR DESCRIPTION
Following a reappearing confusion around `opa build` and
.manifest files, print a warning if a .manifest file is
detected when building a "non-bundle bundle" to let the
user know it's getting ignored.

Signed-off-by: Anders Eknert <anders@eknert.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->
