### PR TITLE
ci: publish multi-arch image manifest lists

### DIFF
--- a/.github/workflows/post-merge.yaml
+++ b/.github/workflows/post-merge.yaml
@@ -90,6 +90,13 @@ jobs:
         env:
           TELEMETRY_URL: ${{ secrets.TELEMETRY_URL }}
 
+      - name: Build Linux arm64
+        run: make ci-go-ci-build-linux ci-go-ci-build-linux-static
+        timeout-minutes: 30
+        env:
+          GOARCH: arm64
+          TELEMETRY_URL: ${{ secrets.TELEMETRY_URL }}
+
       - name: Upload binaries
         uses: actions/upload-artifact@v2
         if: always()
@@ -144,6 +151,9 @@ jobs:
         with:
           name: binaries
           path: _release
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
 
       - name: Deploy OPA Edge
         env:

--- a/.github/workflows/post-tag.yaml
+++ b/.github/workflows/post-tag.yaml
@@ -32,6 +32,13 @@ jobs:
         env:
           TELEMETRY_URL: ${{ secrets.TELEMETRY_URL }}
 
+      - name: Build Linux arm64
+        run: make ci-go-ci-build-linux ci-go-ci-build-linux-static
+        timeout-minutes: 30
+        env:
+          GOARCH: arm64
+          TELEMETRY_URL: ${{ secrets.TELEMETRY_URL }}
+
       - name: Upload binaries
         uses: actions/upload-artifact@v2
         if: always()
@@ -86,6 +93,9 @@ jobs:
         with:
           name: binaries
           path: _release
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
 
       - name: Build and Deploy OPA Docker Images
         id: build-and-deploy

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -24,7 +24,7 @@ jobs:
             capabilities.json
 
   go-build:
-    name: Go Build (${{ matrix.os }})
+    name: Go Build (${{ matrix.os }}${{ matrix.arch && format(' {0}', matrix.arch) || '' }})
     runs-on: ${{ matrix.run }}
     needs: generate
     strategy:
@@ -34,6 +34,11 @@ jobs:
           - os: linux
             run: ubuntu-18.04
             targets: ci-go-ci-build-linux ci-go-ci-build-linux-static
+            arch: amd64
+          - os: linux
+            run: ubuntu-18.04
+            targets: ci-go-ci-build-linux ci-go-ci-build-linux-static
+            arch: arm64
           - os: windows
             run: ubuntu-18.04
             targets: ci-go-ci-build-windows
@@ -61,6 +66,8 @@ jobs:
 
       - name: Build
         run: make ${{ matrix.targets }}
+        env:
+          GOARCH: ${{ matrix.arch }}
         timeout-minutes: 30
 
       - name: Upload binaries
@@ -188,14 +195,24 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: arm64
+
       - name: Download release binaries
         uses: actions/download-artifact@v2
         with:
           name: binaries
           path: _release
 
-      - name: Test images
+      - name: Test amd64 images
         run: make ci-image-smoke-test
+
+      - name: Test arm64 images
+        run: make ci-image-smoke-test
+        env:
+          GOARCH: arm64
 
   smoke-test-binaries:
     runs-on: ${{ matrix.os }}
@@ -296,4 +313,3 @@ jobs:
           | opa eval --bundle build/policy/ --format values --stdin-input --fail-defined 'data.files.deny[message]'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,20 +6,22 @@ ARG BASE
 
 FROM ${BASE}
 
+LABEL org.opencontainers.image.authors="Torin Sandall <torinsandall@gmail.com>"
+
 # Any non-zero number will do, and unfortunately a named user will not, as k8s
 # pod securityContext runAsNonRoot can't resolve the user ID:
 # https://github.com/kubernetes/kubernetes/issues/40958. Make root (uid 0) when
 # not specified.
 ARG USER=0
-
-MAINTAINER Torin Sandall <torinsandall@gmail.com>
-
-# Hack.. https://github.com/moby/moby/issues/37965
-# _Something_ needs to be between the two COPY steps.
 USER ${USER}
 
-ARG BIN=./opa_linux_amd64
-COPY ${BIN} /opa
+# TARGETOS and TARGETARCH are automatic platform args injected by BuildKit
+# https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope
+ARG TARGETOS
+ARG TARGETARCH
+ARG BIN_DIR=.
+ARG BIN_SUFFIX=
+COPY ${BIN_DIR}/opa_${TARGETOS}_${TARGETARCH}${BIN_SUFFIX} /opa
 
 ENTRYPOINT ["/opa"]
 CMD ["run"]

--- a/build/ensure-linux-toolchain.sh
+++ b/build/ensure-linux-toolchain.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+case "$(uname -m | tr '[:upper:]' '[:lower:]')" in
+  amd64 | x86_64 | x64)
+    HOST_ARCH=amd64
+    ;;
+  arm64 | aarch64)
+    HOST_ARCH=arm64
+    ;;
+  *)
+    echo "Error: Host architecture not supported." >&2
+    exit 1
+    ;;
+esac
+
+# Native build
+if [ "${GOARCH}" = "${HOST_ARCH}" ]; then
+  if ! [ -x "$(command -v gcc)" ]; then
+    echo "Error: gcc not found." >&2
+    exit 1
+  fi
+  exit 0
+fi
+
+# Cross-compile
+case "${GOARCH}" in
+  amd64)
+    PKG=gcc-x86-64-linux-gnu
+    CC=x86_64-linux-gnu-gcc
+    ;;
+  arm64)
+    PKG=gcc-aarch64-linux-gnu
+    CC=aarch64-linux-gnu-gcc
+    ;;
+  *)
+    echo "Error: Target architecture ${GOARCH} not supported." >&2
+    exit 1
+    ;;
+esac
+
+type -f ${CC} 2>/dev/null && exit 0
+
+if ! [ -x "$(command -v apt-get)" ]; then
+  echo "Error: apt-get not found. Could not install missing toolchain." >&2
+  exit 1
+fi
+
+apt-get update >/dev/null && \
+  apt-get install -y ${PKG} >/dev/null
+
+echo ${CC}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -42,6 +42,7 @@ func generateCmdOutput(out io.Writer, check bool) {
 	fmt.Fprintln(out, "Build Timestamp: "+version.Timestamp)
 	fmt.Fprintln(out, "Build Hostname: "+version.Hostname)
 	fmt.Fprintln(out, "Go Version: "+version.GoVersion)
+	fmt.Fprintln(out, "Platform: "+version.Platform)
 
 	var wasmAvailable string
 

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -28,6 +28,7 @@ func TestGenerateCmdOutputDisableCheckFlag(t *testing.T) {
 		"Build Timestamp",
 		"Build Hostname",
 		"Go Version",
+		"Platform",
 		"WebAssembly",
 	})
 }
@@ -55,6 +56,7 @@ func TestGenerateCmdOutputWithCheckFlagNoError(t *testing.T) {
 		"Build Timestamp",
 		"Build Hostname",
 		"Go Version",
+		"Platform",
 		"WebAssembly",
 		"Latest Upstream Version",
 		"Release Notes",

--- a/version/version.go
+++ b/version/version.go
@@ -15,6 +15,9 @@ var Version = "0.37.0-dev"
 // GoVersion is the version of Go this was built with
 var GoVersion = runtime.Version()
 
+// Platform is the runtime OS and architecture of this OPA binary
+var Platform = runtime.GOOS + "/" + runtime.GOARCH
+
 // Additional version information that is displayed by the "version" command and used to
 // identify the version of running instances of OPA.
 var (


### PR DESCRIPTION
This change adds linux/arm64 binaries to the release. It also publishes an arm64 container image for all variants (standard, debug, rootless, static) and releases (dev, edge, latest).

The build and push process uses buildx to push the individual images by digest (i.e. untagged) and reference them in a single, tagged manifest list. This avoids cluttering Docker Hub's tag list with `<tag>-<arch>` tags.

Fixes #2233