### PR TITLE
docs: de-evaluate $HOME in CLI docs

### DIFF
--- a/build/generate-cli-docs/generate.go
+++ b/build/generate-cli-docs/generate.go
@@ -105,11 +105,15 @@ func fixupSection(path string) (string, error) {
 	builder := strings.Builder{}
 
 	for scanner.Scan() {
+		line := scanner.Text()
 		// Remove "See also" section
-		if strings.Contains(scanner.Text(), "### SEE ALSO") {
+		if strings.Contains(line, "### SEE ALSO") {
 			break
 		}
-		builder.WriteString(scanner.Text())
+		if home := os.Getenv("HOME"); home != "" {
+			line = strings.ReplaceAll(line, home, "$HOME")
+		}
+		builder.WriteString(line)
 		builder.WriteString("\n")
 	}
 

--- a/docs/content/cli.md
+++ b/docs/content/cli.md
@@ -697,7 +697,7 @@ opa run [flags]
   -f, --format string                        set shell output format, i.e, pretty, json (default "pretty")
       --h2c                                  enable H2C for HTTP listeners
   -h, --help                                 help for run
-  -H, --history string                       set path of history file (default "/home/runner/.opa_history")
+  -H, --history string                       set path of history file (default "$HOME/.opa_history")
       --ignore strings                       set file and directory names to ignore during loading (e.g., '.*' excludes hidden files)
       --log-format {text,json,json-pretty}   set log format (default json)
   -l, --log-level {debug,info,error}         set log level (default info)


### PR DESCRIPTION
So we don't end up with `/opt/buildhome` in our CLI docs:

![image](https://user-images.githubusercontent.com/870638/150319317-485aad4f-c5de-4a20-a186-5eee813a440b.png)
