### PR TITLE
test: fix "too many open files" issue on Mac OS

### DIFF
--- a/plugins/logs/plugin.go
+++ b/plugins/logs/plugin.go
@@ -18,7 +18,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/pkg/errors"
 	"golang.org/x/time/rate"
 
 	"github.com/open-policy-agent/opa/ast"
@@ -282,7 +281,7 @@ func (c *Config) validateAndInjectDefaults(services []string, pluginsList []stri
 
 	t, err := plugins.ValidateAndInjectDefaultsForTriggerMode(trigger, c.Reporting.Trigger)
 	if err != nil {
-		return errors.Wrap(err, "invalid decision_log config")
+		return fmt.Errorf("invalid decision_log config: %w", err)
 	}
 	c.Reporting.Trigger = t
 
@@ -336,7 +335,7 @@ func (c *Config) validateAndInjectDefaults(services []string, pluginsList []stri
 
 	c.maskDecisionRef, err = ref.ParseDataPath(*c.MaskDecision)
 	if err != nil {
-		return errors.Wrap(err, "invalid mask_decision in decision_logs")
+		return fmt.Errorf("invalid mask_decision in decision_logs: %w", err)
 	}
 
 	if c.PartitionName != "" {
@@ -891,7 +890,7 @@ func uploadChunk(ctx context.Context, client rest.Client, uploadPath string, dat
 		Do(ctx, "POST", uploadPath)
 
 	if err != nil {
-		return errors.Wrap(err, "Log upload failed")
+		return fmt.Errorf("log upload failed: %w", err)
 	}
 
 	defer util.Close(resp)
@@ -900,11 +899,11 @@ func uploadChunk(ctx context.Context, client rest.Client, uploadPath string, dat
 	case http.StatusOK:
 		return nil
 	case http.StatusNotFound:
-		return fmt.Errorf("Log upload failed, server replied with not found")
+		return fmt.Errorf("log upload failed, server replied with not found")
 	case http.StatusUnauthorized:
-		return fmt.Errorf("Log upload failed, server replied with not authorized")
+		return fmt.Errorf("log upload failed, server replied with not authorized")
 	default:
-		return fmt.Errorf("Log upload failed, server replied with HTTP %v", resp.StatusCode)
+		return fmt.Errorf("log upload failed, server replied with HTTP %v", resp.StatusCode)
 	}
 }
 

--- a/plugins/logs/plugin_test.go
+++ b/plugins/logs/plugin_test.go
@@ -942,6 +942,8 @@ func TestPluginTriggerManual(t *testing.T) {
 	fixture := newTestFixture(t)
 	defer fixture.server.stop()
 
+	fixture.server.server.Config.SetKeepAlivesEnabled(false)
+
 	fixture.server.ch = make(chan []EventV1, 4)
 	tr := plugins.TriggerManual
 	fixture.plugin.config.Reporting.Trigger = &tr

--- a/storage/disk/disk_test.go
+++ b/storage/disk/disk_test.go
@@ -40,6 +40,7 @@ func TestPolicies(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		defer s.Close(ctx)
 
 		err = storage.Txn(ctx, s, storage.WriteParams, func(txn storage.Transaction) error {
 			ids, err := s.ListPolicies(ctx, txn)
@@ -604,10 +605,10 @@ func TestDataPartitioningReadsAndWrites(t *testing.T) {
 
 				ctx := context.Background()
 				s, err := New(ctx, Options{Dir: dir, Partitions: partitions})
-
 				if err != nil {
 					t.Fatal(err)
 				}
+				defer s.Close(ctx)
 
 				for _, x := range tc.sequence {
 					switch x := x.(type) {
@@ -752,10 +753,10 @@ func TestDataPartitioningReadNotFoundErrors(t *testing.T) {
 
 				ctx := context.Background()
 				s, err := New(ctx, Options{Dir: dir, Partitions: partitions})
-
 				if err != nil {
 					t.Fatal(err)
 				}
+				defer s.Close(ctx)
 
 				for _, x := range tc.sequence {
 					switch x := x.(type) {
@@ -962,6 +963,7 @@ func TestDataPartitioningWriteNotFoundErrors(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
+				defer s.Close(ctx)
 
 				for _, x := range tc.sequence {
 					switch x := x.(type) {
@@ -998,6 +1000,7 @@ func TestDataPartitioningWriteInvalidPatchError(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		defer s.Close(ctx)
 
 		err = storage.WriteOne(ctx, s, storage.AddOp, storage.MustParsePath("/foo"), util.MustUnmarshalJSON([]byte(`[1,2,3]`)))
 		if err == nil {

--- a/storage/disk/example_test.go
+++ b/storage/disk/example_test.go
@@ -75,6 +75,9 @@ func Example_store() {
 	value, err := storage.ReadOne(ctx, store2, storage.MustParsePath("/authz/tenants/acmecorp.openpolicyagent.org"))
 	check(err)
 
+	err = store2.Close(ctx)
+	check(err)
+
 	fmt.Println(value)
 
 	// Output:


### PR DESCRIPTION
`make test` was crashing on Mac OS due to "too many open files",
which could be traced to two different issues.

The first one was the disk based storage being opened but not closed
in some cases. This change takes the number of open file pointers
from >300 to ~30 after the disk based tests have run.

The second issue was a fixture HTTP server allowing keep-alive
connections, and since each test would call the server on a
random port, no connection reuse was possible. Since the test
ran over 400 iterations, and the max open file handles on Mac
OS by default is 256, things broke.

Signed-off-by: Anders Eknert <anders@eknert.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->
