### PR TITLE
topdown: ability to retrieve input and plug bindings in the Event

### DIFF
--- a/topdown/eval.go
+++ b/topdown/eval.go
@@ -242,6 +242,8 @@ func (e *eval) traceEvent(op Op, x ast.Node, msg string, target *ast.Ref) {
 		Location: x.Loc(),
 		Message:  msg,
 		Ref:      target,
+		input:    e.input,
+		bindings: e.bindings,
 	}
 
 	// Skip plugging the local variables, unless any of the tracers

--- a/topdown/trace.go
+++ b/topdown/trace.go
@@ -78,6 +78,9 @@ type Event struct {
 	LocalMetadata map[ast.Var]VarMetadata // Contains metadata for the local variable bindings. Nil if variables were not included in the trace event.
 	Message       string                  // Contains message for Note events.
 	Ref           *ast.Ref                // Identifies the subject ref for the event. Only applies to Index and Wasm operations.
+
+	input    *ast.Term
+	bindings *bindings
 }
 
 // HasRule returns true if the Event contains an ast.Rule.
@@ -117,6 +120,17 @@ func (evt *Event) Equal(other *Event) bool {
 
 func (evt *Event) String() string {
 	return fmt.Sprintf("%v %v %v (qid=%v, pqid=%v)", evt.Op, evt.Node, evt.Locals, evt.QueryID, evt.ParentID)
+}
+
+// Input returns the input object as it was at the event.
+func (evt *Event) Input() *ast.Term {
+	return evt.input
+}
+
+// Plug plugs event bindings into the provided ast.Term. Because bindings are mutable, this only makes sense to do when
+// the event is emitted rather than on recorded trace events as the bindings are going to be different by then.
+func (evt *Event) Plug(term *ast.Term) *ast.Term {
+	return evt.bindings.Plug(term)
 }
 
 func (evt *Event) equalNodes(other *Event) bool {


### PR DESCRIPTION
2 new methods of the Event structure:
* Input() to retrieve input document upon event
* Plug(Term) => Term to plug event bindings into Term. This works even if `PlugLocalVars` is false

Signed-off-by: Stan Lagun <stan@styra.com>
