### PR TITLE
build: don't build and push non-static edge arm64 binaries

### DIFF
--- a/.github/workflows/post-merge.yaml
+++ b/.github/workflows/post-merge.yaml
@@ -91,7 +91,7 @@ jobs:
           TELEMETRY_URL: ${{ secrets.TELEMETRY_URL }}
 
       - name: Build Linux arm64
-        run: make ci-go-ci-build-linux ci-go-ci-build-linux-static
+        run: make ci-go-ci-build-linux-static
         timeout-minutes: 30
         env:
           GOARCH: arm64

--- a/Makefile
+++ b/Makefile
@@ -414,7 +414,7 @@ ci-binary-smoke-test-%:
 
 .PHONY: push-binary-edge
 push-binary-edge:
-	aws s3 sync $(RELEASE_DIR) s3://$(S3_RELEASE_BUCKET)/edge/ --delete
+	aws s3 sync $(RELEASE_DIR) s3://$(S3_RELEASE_BUCKET)/edge/ --delete --no-progress
 
 .PHONY: docker-login
 docker-login:


### PR DESCRIPTION
....and silence the aws CLI output a bit.