### PR TITLE
ast: Removing parser built-in fn conflict error

### DIFF
--- a/ast/parser_ext.go
+++ b/ast/parser_ext.go
@@ -187,10 +187,6 @@ func ParseRuleFromExpr(module *Module, expr *Expr) (*Rule, error) {
 		return parseCompleteRuleFromEq(module, expr)
 	}
 
-	if _, ok := BuiltinMap[expr.Operator().String()]; ok {
-		return nil, fmt.Errorf("rule name conflicts with built-in function")
-	}
-
 	return ParseRuleFromCallExpr(module, expr.Terms.([]*Term))
 }
 


### PR DESCRIPTION
A sole document level expression, like "a > 1", will generate a parse error
stating "rule name conflicts with built-in function". This is a misleading
error, as the issue - if any - is not a built-in function being overridden.
This change removes this parse check; not generating an error for such
expressions.

Signed-off-by: Johan Fylling <johan.dev@fylling.se>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->
