### PR TITLE
build: work around issues

### DIFF
--- a/.github/workflows/post-merge.yaml
+++ b/.github/workflows/post-merge.yaml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN_ACTION }} # required to push to protected branch below
 
       - name: Generate
         run: make clean generate docs-generate-cli-docs

--- a/Makefile
+++ b/Makefile
@@ -414,7 +414,7 @@ ci-binary-smoke-test-%:
 
 .PHONY: push-binary-edge
 push-binary-edge:
-	aws s3 sync $(RELEASE_DIR) s3://$(S3_RELEASE_BUCKET)/edge/ --delete --no-progress
+	aws s3 sync $(RELEASE_DIR) s3://$(S3_RELEASE_BUCKET)/edge/ --no-progress
 
 .PHONY: docker-login
 docker-login:


### PR DESCRIPTION
1. The `aws s3 sync` change is a band-aid, we should fix the IAM policy eventually. We'll keep the stale files around, it should be OK as it doesn't affect the (next) release.
2. If the change to the workflow is what we need is a test; I believe it would make sense if it was the case, but we'll see.