### PR TITLE
build: use proper action token secret name

### DIFF
--- a/.github/workflows/post-merge.yaml
+++ b/.github/workflows/post-merge.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
         with:
-          token: ${{ secrets.GITHUB_TOKEN_ACTION }} # required to push to protected branch below
+          token: ${{ secrets.GH_PUSH_TOKEN }} # required to push to protected branch below
 
       - name: Generate
         run: make clean generate docs-generate-cli-docs


### PR DESCRIPTION
Now it is consistent with post-tag.yaml. No idea why it was like it was before we had removed it.