### PR TITLE
Fix error when initializing empty logging plugin

### DIFF
--- a/plugins/logs/plugin.go
+++ b/plugins/logs/plugin.go
@@ -275,10 +275,6 @@ func (c *Config) validateAndInjectDefaults(services []string, pluginsList []stri
 		}
 	}
 
-	if c.Plugin == nil && c.Service == "" && !c.ConsoleLogs {
-		return fmt.Errorf("invalid decision_log config, must have a `service`, `plugin`, or `console` logging enabled")
-	}
-
 	t, err := plugins.ValidateAndInjectDefaultsForTriggerMode(trigger, c.Reporting.Trigger)
 	if err != nil {
 		return fmt.Errorf("invalid decision_log config: %w", err)
@@ -432,6 +428,11 @@ func (b *ConfigBuilder) Parse() (*Config, error) {
 
 	if err := util.Unmarshal(b.raw, &parsedConfig); err != nil {
 		return nil, err
+	}
+
+	if parsedConfig.Plugin == nil && parsedConfig.Service == "" && len(b.services) == 0 && !parsedConfig.ConsoleLogs {
+		// Nothing to validate or inject
+		return nil, nil
 	}
 
 	if err := parsedConfig.validateAndInjectDefaults(b.services, b.plugins, b.trigger); err != nil {

--- a/plugins/logs/plugin_test.go
+++ b/plugins/logs/plugin_test.go
@@ -936,6 +936,40 @@ func TestPluginRateLimitBadConfig(t *testing.T) {
 	}
 }
 
+func TestPluginNoLogging(t *testing.T) {
+	// Given no custom plugin, no service(s) and no console logging configured,
+	// this should not be an error, but neither do we need to initiate the plugin
+	cases := []struct {
+		note   string
+		config []byte
+	}{
+		{
+			note:   "no plugin attributes",
+			config: []byte(`{}`),
+		},
+		{
+			note:   "empty plugin configuration",
+			config: []byte(`{"decision_logs": {}}`),
+		},
+		{
+			note:   "only disabled console logger",
+			config: []byte(`{"decision_logs": {"console": "false"}}`),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.note, func(t *testing.T) {
+			config, err := ParseConfig(tc.config, []string{}, nil)
+			if err != nil {
+				t.Errorf("expected no error: %v", err)
+			}
+			if config != nil {
+				t.Errorf("excected no config for a no-op logging plugin")
+			}
+		})
+	}
+}
+
 func TestPluginTriggerManual(t *testing.T) {
 	ctx := context.Background()
 
@@ -1806,16 +1840,6 @@ func TestParseConfigDefaultServiceWithConsole(t *testing.T) {
 
 	if config.Service != "" {
 		t.Errorf("Expected no service in config, actual = '%s'", config.Service)
-	}
-}
-
-func TestParseConfigDefaultServiceWithNoServiceOrConsole(t *testing.T) {
-	loggerConfig := []byte(`{}`)
-
-	_, err := ParseConfig([]byte(loggerConfig), []string{}, nil)
-
-	if err == nil {
-		t.Errorf("Expected an error but err==nil")
 	}
 }
 

--- a/plugins/status/plugin.go
+++ b/plugins/status/plugin.go
@@ -107,11 +107,6 @@ func (c *Config) validateAndInjectDefaults(services []string, pluginsList []stri
 		}
 	}
 
-	// If a plugin or service wasn't found, and console logging isn't enabled.
-	if c.Plugin == nil && c.Service == "" && !c.ConsoleLogs {
-		return fmt.Errorf("invalid status config, must have a `service`, `plugin`, or `console` logging specified")
-	}
-
 	t, err := plugins.ValidateAndInjectDefaultsForTriggerMode(trigger, c.Trigger)
 	if err != nil {
 		return errors.Wrap(err, "invalid status config")
@@ -174,6 +169,11 @@ func (b *ConfigBuilder) Parse() (*Config, error) {
 
 	if err := util.Unmarshal(b.raw, &parsedConfig); err != nil {
 		return nil, err
+	}
+
+	if parsedConfig.Plugin == nil && parsedConfig.Service == "" && len(b.services) == 0 && !parsedConfig.ConsoleLogs {
+		// Nothing to validate or inject
+		return nil, nil
 	}
 
 	if err := parsedConfig.validateAndInjectDefaults(b.services, b.plugins, b.trigger); err != nil {

--- a/plugins/status/plugin_test.go
+++ b/plugins/status/plugin_test.go
@@ -75,6 +75,40 @@ func TestPluginStart(t *testing.T) {
 	}
 }
 
+func TestPluginNoLogging(t *testing.T) {
+	// Given no custom plugin, no service(s) and no console logging configured,
+	// this should not be an error, but neither do we need to initiate the plugin
+	cases := []struct {
+		note   string
+		config []byte
+	}{
+		{
+			note:   "no plugin attributes",
+			config: []byte(`{}`),
+		},
+		{
+			note:   "empty plugin configuration",
+			config: []byte(`{"status": {}}`),
+		},
+		{
+			note:   "only disabled console logger",
+			config: []byte(`{"status": {"console": "false"}}`),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.note, func(t *testing.T) {
+			config, err := ParseConfig(tc.config, []string{}, nil)
+			if err != nil {
+				t.Errorf("expected no error: %v", err)
+			}
+			if config != nil {
+				t.Errorf("excected no config for a no-op logging plugin")
+			}
+		})
+	}
+}
+
 func TestPluginStartTriggerManual(t *testing.T) {
 
 	fixture := newTestFixture(t, nil)
@@ -557,16 +591,6 @@ func TestParseConfigDefaultServiceWithConsole(t *testing.T) {
 
 	if config.Service != "" {
 		t.Errorf("Expected no service in config, actual = '%s'", config.Service)
-	}
-}
-
-func TestParseConfigDefaultServiceWithNoServiceOrConsole(t *testing.T) {
-	loggerConfig := []byte(`{}`)
-
-	_, err := ParseConfig(loggerConfig, []string{}, nil)
-
-	if err == nil {
-		t.Error("Expected an error but err==nil")
 	}
 }
 


### PR DESCRIPTION
Move the check for "emptiness" before validation and
injection of defaults, as there isn't a whole lot we
can do with a logging plugin that doesn't actually
log anything. Rather than error though, just return
nil to skip initialization of the plugin.

Fixes #4291

Signed-off-by: Anders Eknert <anders@eknert.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->
