### PR TITLE
ast: Consistent casing in AST comments

### DIFF
--- a/ast/policy.go
+++ b/ast/policy.go
@@ -148,8 +148,8 @@ type (
 
 	// Comment contains the raw text from the comment in the definition.
 	Comment struct {
-		Text     []byte
-		Location *Location
+		Text     []byte    `json:"text"`
+		Location *Location `json:"location,omitempty"`
 	}
 
 	// Annotations represents metadata attached to other AST nodes such as rules.


### PR DESCRIPTION
Playing around with `opa parse --format json`
I noticed that the comments all had a different,
capitalized, casing from any of the other attributes.
Obviously annoyed by this, I went straight here to fix it.

Signed-off-by: Anders Eknert <anders@eknert.com>

<img width="366" alt="Screenshot 2022-01-30 at 22 08 07" src="https://user-images.githubusercontent.com/510711/151717930-4bd1f9b8-c6cf-429f-bb48-0a217efa6c09.png">


