### PR TITLE
topdown: evaluate "every"

### DIFF
--- a/ast/capabilities.go
+++ b/ast/capabilities.go
@@ -50,9 +50,6 @@ func CapabilitiesForThisVersion() *Capabilities {
 	})
 
 	for kw := range futureKeywords {
-		if kw == "every" { // TODO(sr): drop when ready
-			continue
-		}
 		f.FutureKeywords = append(f.FutureKeywords, kw)
 	}
 	sort.Strings(f.FutureKeywords)

--- a/ast/compile.go
+++ b/ast/compile.go
@@ -3846,9 +3846,8 @@ func expandExpr(gen *localVarGenerator, expr *Expr) (result []*Expr) {
 			extras, terms.Domain = expandExprTerm(gen, terms.Domain)
 		} else {
 			term := NewTerm(gen.Generate()).SetLocation(terms.Domain.Location)
-			eq := Equality.Expr(term, terms.Domain)
+			eq := Equality.Expr(term, terms.Domain).SetLocation(terms.Domain.Location)
 			eq.Generated = true
-			eq.Location = terms.Domain.Location
 			eq.With = expr.With
 			extras = append(extras, eq)
 			terms.Domain = term

--- a/ast/internal/scanner/scanner.go
+++ b/ast/internal/scanner/scanner.go
@@ -96,6 +96,11 @@ func (s *Scanner) Keyword(lit string) tokens.Token {
 // AddKeyword adds a string -> token mapping to this Scanner instance.
 func (s *Scanner) AddKeyword(kw string, tok tokens.Token) {
 	s.keywords[kw] = tok
+
+	switch tok {
+	case tokens.Every: // importing 'every' means also importing 'in'
+		s.keywords["in"] = tokens.In
+	}
 }
 
 // WithKeywords returns a new copy of the Scanner struct `s`, with the set

--- a/ast/parser.go
+++ b/ast/parser.go
@@ -99,7 +99,7 @@ type ParserOptions struct {
 	ProcessAnnotation  bool
 	AllFutureKeywords  bool
 	FutureKeywords     []string
-	unreleasedKeywords bool
+	unreleasedKeywords bool // TODO(sr): cleanup
 }
 
 // NewParser creates and initializes a Parser.
@@ -257,10 +257,6 @@ func (p *Parser) Parse() ([]Statement, []*Comment, Errors) {
 				},
 			}
 		}
-	}
-
-	if p.po.unreleasedKeywords { // TODO(sr): remove when capabilities include "every"
-		allowedFutureKeywords["every"] = tokens.Every
 	}
 
 	var err error
@@ -806,13 +802,13 @@ func (p *Parser) parseLiteral() (expr *Expr) {
 	switch p.s.tok {
 	case tokens.Some:
 		if negated {
-			p.illegal("not is invalid")
+			p.illegal("illegal negation of 'some'")
 			return nil
 		}
 		return p.parseSome()
 	case tokens.Every:
 		if negated {
-			p.illegal("not is invalid")
+			p.illegal("illegal negation of 'every'")
 			return nil
 		}
 		return p.parseEvery()
@@ -2124,12 +2120,6 @@ func (p *Parser) futureImport(imp *Import, allowedFutureKeywords map[string]toke
 
 	switch len(path) {
 	case 2: // all keywords imported, nothing to do
-		// TODO(sr): remove when ready
-		for i, kw := range kwds {
-			if kw == "every" {
-				kwds = append(kwds[:i], kwds[i+1:]...)
-			}
-		}
 	case 3: // one keyword imported
 		kw, ok := path[2].Value.(String)
 		if !ok {

--- a/ast/parser_test.go
+++ b/ast/parser_test.go
@@ -693,7 +693,7 @@ func TestSomeDeclExpr(t *testing.T) {
 	}, opts)
 
 	assertParseErrorContains(t, "not some", "not some x, y in xs",
-		"unexpected some keyword: not is invalid",
+		"unexpected some keyword: illegal negation of 'some'",
 		opts)
 
 	assertParseErrorContains(t, "some + function call", "some f(x)",
@@ -805,7 +805,12 @@ func TestEvery(t *testing.T) {
 	assertParseErrorContains(t, "arbitrary call", "every f(10)", "expected `x[, y] in xs { ... }` expression", opts)
 	assertParseErrorContains(t, "no body", "every x in xs", "missing body", opts)
 	assertParseErrorContains(t, "invalid body", "every x in xs { + }", "unexpected plus token", opts)
-	assertParseErrorContains(t, "not every", "not every x in xs { true }", "unexpected every keyword: not is invalid", opts)
+	assertParseErrorContains(t, "not every", "not every x in xs { true }", "unexpected every keyword: illegal negation of 'every'", opts)
+
+	assertParseOneExpr(t, `"every" kw implies "in" kw`, "x in xs", Member.Expr(
+		VarTerm("x"),
+		VarTerm("xs"),
+	), opts)
 }
 
 func TestNestedExpressions(t *testing.T) {
@@ -1149,7 +1154,7 @@ func TestImport(t *testing.T) {
 func TestFutureImports(t *testing.T) {
 	assertParseErrorContains(t, "future", "import future", "invalid import, must be `future.keywords`")
 	assertParseErrorContains(t, "future.a", "import future.a", "invalid import, must be `future.keywords`")
-	assertParseErrorContains(t, "unknown keyword", "import future.keywords.xyz", "unexpected keyword, must be one of [in]")
+	assertParseErrorContains(t, "unknown keyword", "import future.keywords.xyz", "unexpected keyword, must be one of [every in]")
 	assertParseErrorContains(t, "all keyword import + alias", "import future.keywords as xyz", "future keyword imports cannot be aliased")
 	assertParseErrorContains(t, "keyword import + alias", "import future.keywords.in as xyz", "future keyword imports cannot be aliased")
 

--- a/ast/parser_test.go
+++ b/ast/parser_test.go
@@ -774,7 +774,7 @@ func TestSomeDeclExpr(t *testing.T) {
 }
 
 func TestEvery(t *testing.T) {
-	opts := ParserOptions{unreleasedKeywords: true, FutureKeywords: []string{"in", "every"}} // TODO: "every" should imply "in"? it can't be used without it
+	opts := ParserOptions{unreleasedKeywords: true, FutureKeywords: []string{"every"}}
 	assertParseOneExpr(t, "simple", "every x in xs { true }",
 		&Expr{
 			Terms: &Every{

--- a/ast/policy.go
+++ b/ast/policy.go
@@ -1200,6 +1200,8 @@ func (expr *Expr) Copy() *Expr {
 		cpy.Terms = cpyTs
 	case *Term:
 		cpy.Terms = ts.Copy()
+	case *Every:
+		cpy.Terms = ts.Copy()
 	}
 
 	cpy.With = make([]*With, len(expr.With))

--- a/ast/policy_test.go
+++ b/ast/policy_test.go
@@ -376,6 +376,21 @@ func TestExprBadJSON(t *testing.T) {
 	assert(js, exp)
 }
 
+func TestExprEveryCopy(t *testing.T) {
+	opts := ParserOptions{AllFutureKeywords: true}
+	newEvery := func() *Expr {
+		return MustParseBodyWithOpts(
+			`every k, v in [1,2,3] { true }`, opts,
+		)[0]
+	}
+	e0 := newEvery()
+	e1 := e0.Copy()
+	e1.Terms.(*Every).Body = NewBody(NewExpr(BooleanTerm(false)))
+	if exp := newEvery(); exp.Compare(e0) != 0 {
+		t.Errorf("expected e0 unchanged (%v), found %v", exp, e0)
+	}
+}
+
 func TestRuleHeadEquals(t *testing.T) {
 	assertHeadsEqual(t, &Head{}, &Head{})
 

--- a/capabilities.json
+++ b/capabilities.json
@@ -3810,6 +3810,7 @@
     }
   ],
   "future_keywords": [
+    "every",
     "in"
   ],
   "wasm_abi_versions": [

--- a/format/format.go
+++ b/format/format.go
@@ -74,10 +74,11 @@ func Ast(x interface{}) ([]byte, error) {
 			unmangleWildcardVar(wildcards, n)
 
 		case *ast.Expr:
-			if n.IsCall() &&
-				ast.Member.Ref().Equal(n.Operator()) ||
-				ast.MemberWithKey.Ref().Equal(n.Operator()) {
+			switch {
+			case n.IsCall() && ast.Member.Ref().Equal(n.Operator()) || ast.MemberWithKey.Ref().Equal(n.Operator()):
 				extraFutureKeywordImports["in"] = true
+			case n.IsEvery():
+				extraFutureKeywordImports["every"] = true
 			}
 		}
 		if x.Loc() == nil {

--- a/format/testfiles/test_every.rego
+++ b/format/testfiles/test_every.rego
@@ -1,7 +1,6 @@
 package p
 
 import future.keywords.every
-import future.keywords.in
 
 r {
 	every x in [1,3,5] {

--- a/format/testfiles/test_every.rego.formatted
+++ b/format/testfiles/test_every.rego.formatted
@@ -1,7 +1,6 @@
 package p
 
 import future.keywords.every
-import future.keywords.in
 
 r {
 	every x in [1, 3, 5] {

--- a/format/testfiles/test_every_with_key.rego
+++ b/format/testfiles/test_every_with_key.rego
@@ -1,7 +1,6 @@
 package p
 
 import future.keywords.every
-import future.keywords.in
 
 r {
 	every i, x in [1,3,5] {

--- a/format/testfiles/test_every_with_key.rego.formatted
+++ b/format/testfiles/test_every_with_key.rego.formatted
@@ -1,7 +1,6 @@
 package p
 
 import future.keywords.every
-import future.keywords.in
 
 r {
 	every i, x in [1, 3, 5] {

--- a/internal/planner/planner_test.go
+++ b/internal/planner/planner_test.go
@@ -142,6 +142,14 @@ func TestPlannerHelloWorld(t *testing.T) {
 			`},
 		},
 		{
+			note:    "every",
+			queries: []string{`data.test.p`},
+			modules: []string{`
+				package test
+				p { xs = [1]; every k, v in xs { k < v } }
+			`},
+		},
+		{
 			note:    "virtual extent",
 			queries: []string{`data`},
 			modules: []string{`
@@ -337,7 +345,8 @@ q = 2`,
 			modules := make([]*ast.Module, len(tc.modules))
 			for i := range modules {
 				file := fmt.Sprintf("module-%d.rego", i)
-				m, err := ast.ParseModule(file, tc.modules[i])
+				opts := ast.ParserOptions{AllFutureKeywords: true}
+				m, err := ast.ParseModuleWithOpts(file, tc.modules[i], opts)
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/internal/wasm/sdk/test/e2e/exceptions.yaml
+++ b/internal/wasm/sdk/test/e2e/exceptions.yaml
@@ -1,2 +1,3 @@
 # Exception Format is <test name>: <reason>
 "functions/default": "not supported in topdown, https://github.com/open-policy-agent/opa/issues/2445"
+"every/example every/some": "WIP"

--- a/internal/wasm/sdk/test/e2e/external_test.go
+++ b/internal/wasm/sdk/test/e2e/external_test.go
@@ -72,6 +72,9 @@ func TestWasmE2E(t *testing.T) {
 			for i := range tc.Modules {
 				opts = append(opts, rego.Module(fmt.Sprintf("module-%d.rego", i), tc.Modules[i]))
 			}
+			if testing.Verbose() {
+				opts = append(opts, rego.Dump(os.Stderr))
+			}
 			cr, err := rego.New(opts...).Compile(ctx)
 			if err != nil {
 				t.Fatal(err)

--- a/test/cases/testdata/every/every.yaml
+++ b/test/cases/testdata/every/every.yaml
@@ -1,0 +1,116 @@
+cases:
+- data:
+  modules:
+  - |
+    package test
+    import future.keywords.every
+
+    p {
+      every x in [] { x != x }
+    }
+  note: every/empty domain
+  query: data.test.p = x
+  want_result:
+  - x: true
+- data:
+  modules:
+  - |
+    package test
+    import future.keywords.every
+
+    p {
+      every _ in input { true }
+    }
+  note: every/domain undefined
+  query: data.test.p = x
+  want_result: []
+- data:
+  modules:
+  - |
+    package test
+    import future.keywords.every
+
+    p {
+      every x in numbers.range(1, 10) { x >= 1 }
+    }
+  note: every/domain is call
+  query: data.test.p = x
+  want_result:
+  - x: true
+- data:
+  modules:
+  - |
+    package test
+    import future.keywords.every
+
+    p {
+      every k, v in [1, 2] { k+1 == v }
+    }
+  note: every/simple key/val
+  query: data.test.p = x
+  want_result:
+  - x: true
+- data:
+  modules:
+  - |
+    package test
+    import future.keywords.every
+
+    p {
+      i := 10
+      every k, v in [1, 2] { k+v != i }
+    }
+  note: every/outer bindings
+  query: data.test.p = x
+  want_result:
+  - x: true
+- data:
+  modules:
+  - |
+    package test
+    import future.keywords.every
+
+    p {
+      every v in [1, 2] { v != 1 }
+    }
+  note: every/simple failure, first
+  query: data.test.p = x
+  want_result: []
+- data:
+  modules:
+  - |
+    package test
+    import future.keywords.every
+
+    p {
+      every v in [1, 2] { v != 2 }
+    }
+  note: every/simple failure, last
+  query: data.test.p = x
+  want_result: []
+- data:
+  modules:
+  - |
+    package test
+    import future.keywords.every
+
+    p {
+      every v in input { v == 1 } with input as [1, 1, 1]
+    }
+  note: 'every/with: domain'
+  query: data.test.p = x
+  want_result:
+  - x: true
+- data:
+  modules:
+  - |
+    package test
+    import future.keywords.every
+
+    p {
+      every v in [1, 2] { v in input } with input as [1, 2, 1, 0]
+    }
+  note: 'every/with: body'
+  query: data.test.p = x
+  want_result:
+  - x: true

--- a/test/cases/testdata/every/textbook.yaml
+++ b/test/cases/testdata/every/textbook.yaml
@@ -1,0 +1,100 @@
+cases:
+- data:
+  input:
+    containers:
+    - image: bitcoin-miner
+    - image: acmecorp.com/webapp
+  modules:
+  - |
+    package test
+    import future.keywords.every
+
+    p {
+      every x in input.containers {
+        startswith(x.image, "acmecorp.com/")
+      }
+    }
+  note: every/example, fail
+  query: data.test.p = x
+  want_result: []
+- data:
+  input:
+    containers:
+    - image: acmecorp.com/bitcoin-miner
+    - image: acmecorp.com/webapp
+  modules:
+  - |
+    package test
+    import future.keywords.every
+
+    p {
+      every x in input.containers {
+        startswith(x.image, "acmecorp.com/")
+      }
+    }
+  note: every/example, success
+  query: data.test.p = x
+  want_result:
+  - x: true
+- data:
+  input:
+    containers:
+    - image: acmecorp.com/bitcoin-miner
+    - image: acmecorp.com/webapp
+    init_containers:
+    - image: another/bitcoin-miner
+  modules:
+  - |
+    package test
+    import future.keywords.every
+
+    p {
+      every x in input.containers | input.init_containers {
+        startswith(x.image, "acmecorp.com/")
+      }
+    }
+  note: every/example with init_container
+  query: data.test.p = x
+  want_result: []
+- data:
+  input:
+    containers:
+    - image: hooli.com/bitcoin-miner
+    - image: acmecorp.net/webapp
+    - image: nginx
+  modules:
+  - |
+    package test
+    import future.keywords.every
+
+    allowed_repos := {"hooli.com/", "acmecorp.net/"}
+
+    p {
+      every c in input.containers {
+        some repo in allowed_repos
+        startswith(c.image, repo)
+      }
+    }
+  note: every/example every/some
+  query: data.test.p = x
+  want_result: []
+- data:
+  input:
+    servers:
+    - ports: [80, 443]
+    - ports: [80]
+  modules:
+  - |
+    package test
+    import future.keywords.every
+
+    deny {
+      some s in input.servers
+      every port in s.ports {
+        port != 443
+      }
+    }
+  note: every/example some/every
+  query: data.test.deny = x
+  want_result:
+  - x: true

--- a/topdown/copypropagation/copypropagation.go
+++ b/topdown/copypropagation/copypropagation.go
@@ -422,7 +422,7 @@ func makeDisjointSets(livevars ast.VarSet, query ast.Body) (*unionFind, bool) {
 
 func isNoop(expr *ast.Expr) bool {
 
-	if !expr.IsCall() {
+	if !expr.IsCall() && !expr.IsEvery() {
 		term := expr.Terms.(*ast.Term)
 		if !ast.IsConstant(term.Value) {
 			return false


### PR DESCRIPTION
This is another iteration on the "every" work. It includes:

- [X] simple eval
- [x] partial eval
- [x] "unveiling" the every keyword via "import future.keywords" and "import future.keywords.every" 

TODOs for follow-ups:
- [ ] Tracing: We're not emitting traces in an organized manner yet.
- [ ] IR/Wasm: there are known bugs in this code path
- [ ] Documentation!
