### PR TITLE
Add http_code to status API

### DIFF
--- a/docs/content/management-status.md
+++ b/docs/content/management-status.md
@@ -199,6 +199,7 @@ Status updates contain the following fields:
 | `bundles[_].metrics` | `object` | Metrics from the last update of the bundle. |
 | `bundles[_].code` | `string` | If present, indicates error(s) occurred activating this bundle. |
 | `bundles[_].message` | `string` | Human readable messages describing the error(s). |
+| `bundles[_].http_code` | `number` | If present, indicates an erroneous HTTP status code that OPA received downloading this bundle. |
 | `bundles[_].errors` | `array` | Collection of detailed parse or compile errors that occurred during activation of this bundle. |
 | `discovery.name` | `string` | Name of discovery bundle that the OPA instance is configured to download. |
 | `discovery.active_revision` | `string` | Opaque revision identifier of the last successful discovery activation. |

--- a/download/download.go
+++ b/download/download.go
@@ -342,15 +342,19 @@ func (d *Downloader) download(ctx context.Context, m metrics.Metrics) (*download
 			etag:     etag,
 			longPoll: d.longPollingEnabled,
 		}, nil
-	case http.StatusNotFound:
-		return nil, fmt.Errorf("server replied with not found")
-	case http.StatusUnauthorized:
-		return nil, fmt.Errorf("server replied with not authorized")
 	default:
-		return nil, fmt.Errorf("server replied with HTTP %v", resp.StatusCode)
+		return nil, HTTPError{StatusCode: resp.StatusCode}
 	}
 }
 
 func isLongPollSupported(header http.Header) bool {
 	return header.Get("Content-Type") == "application/vnd.openpolicyagent.bundles"
+}
+
+type HTTPError struct {
+	StatusCode int
+}
+
+func (e HTTPError) Error() string {
+	return fmt.Sprintf("server replied with %s", http.StatusText(e.StatusCode))
 }

--- a/download/download_test.go
+++ b/download/download_test.go
@@ -11,6 +11,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -20,11 +21,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/open-policy-agent/opa/metrics"
-	"github.com/open-policy-agent/opa/plugins"
-
 	"github.com/open-policy-agent/opa/bundle"
 	"github.com/open-policy-agent/opa/keys"
+	"github.com/open-policy-agent/opa/metrics"
+	"github.com/open-policy-agent/opa/plugins"
 	"github.com/open-policy-agent/opa/plugins/rest"
 )
 
@@ -412,6 +412,13 @@ func TestFailureUnexpected(t *testing.T) {
 	err := d.oneShot(ctx)
 	if err == nil {
 		t.Fatal("expected error")
+	}
+	var hErr HTTPError
+	if !errors.As(err, &hErr) {
+		t.Fatal("expected HTTPError")
+	}
+	if hErr.StatusCode != 500 {
+		t.Fatal("expected status code 500")
 	}
 }
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -2713,7 +2713,8 @@ func TestStatusV1(t *testing.T) {
 	// Expect HTTP 200 and updated status after bundle update occurs
 	bs.BulkUpdateBundleStatus(map[string]*pluginBundle.Status{
 		"test": {
-			Name: "test",
+			Name:     "test",
+			HTTPCode: "403",
 		},
 	})
 
@@ -2729,7 +2730,8 @@ func TestStatusV1(t *testing.T) {
 		Result struct {
 			Bundles struct {
 				Test struct {
-					Name string
+					Name     string
+					HTTPCode json.Number `json:"http_code"`
 				}
 			}
 		}
@@ -2737,8 +2739,12 @@ func TestStatusV1(t *testing.T) {
 
 	if err := util.NewJSONDecoder(f.recorder.Body).Decode(&resp2); err != nil {
 		t.Fatal(err)
-	} else if resp2.Result.Bundles.Test.Name != "test" {
+	}
+	if resp2.Result.Bundles.Test.Name != "test" {
 		t.Fatal("expected bundle to exist in status response but got:", resp2)
+	}
+	if resp2.Result.Bundles.Test.HTTPCode != "403" {
+		t.Fatal("expected HTTPCode to equal 403 but got:", resp2)
 	}
 }
 


### PR DESCRIPTION
Hi everyone,

this change adds `http_code` field to the status API.
The field is populated,  if the downloader's last request returned an erroneous HTTP status code.
Fixes https://github.com/open-policy-agent/opa/issues/4259.
Let me know what you think.

Cheers and thank you!
