### PR TITLE
ast: Compiling annotations also for modules with solo package definition

### DIFF
--- a/ast/annotations.go
+++ b/ast/annotations.go
@@ -344,17 +344,11 @@ func newAnnotationSet() *annotationSet {
 	}
 }
 
-func buildAnnotationSet(rules []util.T) (*annotationSet, Errors) {
+func buildAnnotationSet(modules []*Module) (*annotationSet, Errors) {
 	as := newAnnotationSet()
-	processed := map[*Module]struct{}{}
 	var errs Errors
-	for _, x := range rules {
-		module := x.(*Rule).Module
-		if _, ok := processed[module]; ok {
-			continue
-		}
-		processed[module] = struct{}{}
-		for _, a := range module.Annotations {
+	for _, m := range modules {
+		for _, a := range m.Annotations {
 			if err := as.add(a); err != nil {
 				errs = append(errs, err)
 			}

--- a/ast/annotations_test.go
+++ b/ast/annotations_test.go
@@ -27,8 +27,8 @@ func TestGetAnnotations(t *testing.T) {
 				`package test
 
 # METADATA
-# title: doc
 # scope: document
+# title: doc
 # description: doc
 # organizations:
 # - doc
@@ -77,8 +77,8 @@ p = 1`,
 				`package test
 
 # METADATA
-# title: doc
 # scope: document
+# title: doc
 # description: doc
 # organizations:
 # - doc
@@ -138,8 +138,8 @@ p = 1`,
 			note: "document inherits package",
 			modules: []string{
 				`# METADATA
-# title: package
 # scope: subpackages
+# title: package
 # description: package
 # organizations:
 # - package
@@ -187,8 +187,8 @@ p = 1`,
 			note: "document overrides package",
 			modules: []string{
 				`# METADATA
-# title: package
 # scope: subpackages
+# title: package
 # description: package
 # organizations:
 # - package
@@ -250,8 +250,8 @@ p = 1`,
 			note: "package inherits super-package",
 			modules: []string{
 				`# METADATA
-# title: root
 # scope: subpackages
+# title: root
 # description: root
 # organizations:
 # - root
@@ -263,12 +263,8 @@ p = 1`,
 # - input: {"type": "string"}
 # custom:
 #  root: root
-package root
-
-p = 1`,
-				`package root.leaf
-
-p = 1`,
+package root`,
+				`package root.leaf`,
 			},
 			expected: map[expectedKey]Annotations{
 				{path: "data.root.leaf", isPackage: true}: {
@@ -302,8 +298,8 @@ p = 1`,
 			note: "package overrides super-package",
 			modules: []string{
 				`# METADATA
-# title: root
 # scope: subpackages
+# title: root
 # description: root
 # organizations:
 # - root
@@ -315,9 +311,7 @@ p = 1`,
 # - input: {"type": "string"}
 # custom:
 #  root: root
-package root
-
-p = 1`,
+package root`,
 				`# METADATA
 # title: leaf
 # description: leaf
@@ -331,9 +325,7 @@ p = 1`,
 # - input: {"type": "integer"}
 # custom:
 #  leaf: leaf
-package root.leaf
-
-p = 1`,
+package root.leaf`,
 			},
 			expected: map[expectedKey]Annotations{
 				{path: "data.root.leaf", isPackage: true}: {
@@ -373,9 +365,7 @@ p = 1`,
 # authors: 
 # - John Doe
 # scope: subpackages
-package root
-
-p = 1`, // FIXME: If this rule isn't included, annotations from this module aren't included in compilation (#4369)
+package root`,
 				`# METADATA
 # title: a package
 # description: the foo package

--- a/ast/check_test.go
+++ b/ast/check_test.go
@@ -489,8 +489,7 @@ func TestCheckInferenceRules(t *testing.T) {
 
 			ref := MustParseRef(tc.ref)
 			checker := newTypeChecker()
-			as, _ := buildAnnotationSet(elems)
-			env, err := checker.CheckTypes(nil, elems, as)
+			env, err := checker.CheckTypes(nil, elems, nil)
 
 			if err != nil {
 				t.Fatalf("Unexpected error %v:", err)
@@ -1025,8 +1024,7 @@ func TestFunctionTypeInferenceUnappliedWithObjectVarKey(t *testing.T) {
 		module.Rules[0],
 	}
 
-	as, _ := buildAnnotationSet(elems)
-	env, err := newTypeChecker().CheckTypes(newTypeChecker().Env(BuiltinMap), elems, as)
+	env, err := newTypeChecker().CheckTypes(newTypeChecker().Env(BuiltinMap), elems, nil)
 
 	if len(err) > 0 {
 		t.Fatal(err)
@@ -1222,10 +1220,8 @@ func TestCheckErrorOrdering(t *testing.T) {
 	inputReversed[1] = inputReversed[2]
 	inputReversed[2] = tmp
 
-	as, _ := buildAnnotationSet(input)
-	_, errs1 := newTypeChecker().CheckTypes(nil, input, as)
-	asReversed, _ := buildAnnotationSet(inputReversed)
-	_, errs2 := newTypeChecker().CheckTypes(nil, inputReversed, asReversed)
+	_, errs1 := newTypeChecker().CheckTypes(nil, input, nil)
+	_, errs2 := newTypeChecker().CheckTypes(nil, inputReversed, nil)
 
 	if errs1.Error() != errs2.Error() {
 		t.Fatalf("Expected error slices to be equal. errs1:\n\n%v\n\nerrs2:\n\n%v\n\n", errs1, errs2)
@@ -1271,8 +1267,7 @@ func newTestEnv(rs []string) *TypeEnv {
 		}
 	}
 
-	as, _ := buildAnnotationSet(elems)
-	env, err := newTypeChecker().CheckTypes(newTypeChecker().Env(BuiltinMap), elems, as)
+	env, err := newTypeChecker().CheckTypes(newTypeChecker().Env(BuiltinMap), elems, nil)
 	if len(err) > 0 {
 		panic(err)
 	}
@@ -1990,7 +1985,7 @@ p { input = "foo" }`},
 			}
 
 			oldTypeEnv := newTypeChecker().WithSchemaSet(schemaSet).Env(BuiltinMap)
-			as, errors := buildAnnotationSet(elems)
+			as, errors := buildAnnotationSet(asModuleSlice(mod))
 			typeenv, checkErrors := newTypeChecker().WithSchemaSet(schemaSet).CheckTypes(oldTypeEnv, elems, as)
 			errors = append(errors, checkErrors...)
 			if len(errors) > 0 {
@@ -2010,6 +2005,10 @@ p { input = "foo" }`},
 
 		})
 	}
+}
+
+func asModuleSlice(modules ...*Module) []*Module {
+	return modules
 }
 
 func TestCheckAnnotationInference(t *testing.T) {

--- a/ast/compile.go
+++ b/ast/compile.go
@@ -285,8 +285,8 @@ func NewCompiler() *Compiler {
 		{"RewriteEquals", "compile_stage_rewrite_equals", c.rewriteEquals},
 		{"RewriteDynamicTerms", "compile_stage_rewrite_dynamic_terms", c.rewriteDynamicTerms},
 		{"CheckRecursion", "compile_stage_check_recursion", c.checkRecursion},
-		{"SetAnnotationSet", "compile_stage_set_annotationset", c.setAnnotationSet}, // must be run after CheckRecursion
-		{"CheckTypes", "compile_stage_check_types", c.checkTypes},                   // must be run after CheckRecursion
+		{"SetAnnotationSet", "compile_stage_set_annotationset", c.setAnnotationSet},
+		{"CheckTypes", "compile_stage_check_types", c.checkTypes}, // must be run after CheckRecursion
 		{"CheckUnsafeBuiltins", "compile_state_check_unsafe_builtins", c.checkUnsafeBuiltins},
 		{"CheckDeprecatedBuiltins", "compile_state_check_deprecated_builtins", c.checkDeprecatedBuiltins},
 		{"BuildRuleIndices", "compile_stage_rebuild_indices", c.buildRuleIndices},
@@ -1190,8 +1190,12 @@ func parseSchema(schema interface{}) (types.Type, error) {
 }
 
 func (c *Compiler) setAnnotationSet() {
-	// Recursion is caught in earlier step, so this cannot fail.
-	sorted, _ := c.Graph.Sort()
+	// Sorting modules by name for stable error reporting
+	sorted := make([]*Module, 0, len(c.Modules))
+	for _, mName := range c.sorted {
+		sorted = append(sorted, c.Modules[mName])
+	}
+
 	as, errs := buildAnnotationSet(sorted)
 	for _, err := range errs {
 		c.err(err)


### PR DESCRIPTION
Basing compiled annotation set on module set, and not rule graph,
as that caused annotations in modules with only package and no rules
to not get picked up.

Fixes: #4369
Signed-off-by: Johan Fylling <johan.dev@fylling.se>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->
