### PR TITLE
exposing disableInlining option via Compile API

### DIFF
--- a/docs/content/rest-api.md
+++ b/docs/content/rest-api.md
@@ -1281,10 +1281,11 @@ Evaluation in OPA, see [this post on blog.openpolicyagent.org](https://blog.open
 
 Compile API requests contain the following fields:
 
-| Field | Type | Requried | Description |
+| Field | Type | Required | Description |
 | --- | --- | --- | --- |
 | `query` | `string` | Yes | The query to partially evaluate and compile. |
 | `input` | `any` | No | The input document to use during partial evaluation (default: undefined). |
+| `options`  | `object[string, any]`           | No | Additional options to use during partial evaluation. Only `disableInlining` option is supported. (default: undefined). |
 | `unknowns` | `array[string]` | No | The terms to treat as unknown during partial evaluation (default: `["input"]`]). |
 
 #### Query Parameters
@@ -1324,6 +1325,9 @@ Content-Type: application/json
     "subject": {
       "clearance_level": 4
     }
+  },
+  "options": {
+    "disableInlining": []
   },
   "unknowns": [
     "data.reports"

--- a/server/server.go
+++ b/server/server.go
@@ -1242,6 +1242,7 @@ func (s *Server) v1CompilePost(w http.ResponseWriter, r *http.Request) {
 		rego.ParsedQuery(request.Query),
 		rego.ParsedInput(request.Input),
 		rego.ParsedUnknowns(request.Unknowns),
+		rego.DisableInlining(request.Options.DisableInlining),
 		rego.QueryTracer(buf),
 		rego.Instrument(includeInstrumentation),
 		rego.Metrics(m),
@@ -2670,6 +2671,11 @@ type compileRequest struct {
 	Query    ast.Body
 	Input    ast.Value
 	Unknowns []*ast.Term
+	Options  compileRequestOptions
+}
+
+type compileRequestOptions struct {
+	DisableInlining []string
 }
 
 func readInputCompilePostV1(r io.ReadCloser) (*compileRequest, *types.ErrorV1) {
@@ -2716,6 +2722,9 @@ func readInputCompilePostV1(r io.ReadCloser) (*compileRequest, *types.ErrorV1) {
 		Query:    query,
 		Input:    input,
 		Unknowns: unknowns,
+		Options: compileRequestOptions{
+			DisableInlining: request.Options.DisableInlining,
+		},
 	}
 
 	return result, nil

--- a/server/types/types.go
+++ b/server/types/types.go
@@ -352,6 +352,9 @@ type CompileRequestV1 struct {
 	Input    *interface{} `json:"input"`
 	Query    string       `json:"query"`
 	Unknowns *[]string    `json:"unknowns"`
+	Options  struct {
+		DisableInlining []string `json:"disableInlining,omitempty"`
+	} `json:"options,omitempty"`
 }
 
 // CompileResponseV1 models the response message for Compile API operations.


### PR DESCRIPTION
This change enables consumers of Compile API to specify packages those should not be inlined in partial evaluation response.

Fixes: #4357
Signed-off-by: Serol Kosunda <skosunda@adobe.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->
