### PR TITLE
docs+website: two small links fixes

### DIFF
--- a/docs/content/ssh-and-sudo-authorization.md
+++ b/docs/content/ssh-and-sudo-authorization.md
@@ -389,7 +389,7 @@ You will find that running `sudo ls /` as the `frontend-dev` user is disallowed 
 It is possible to configure the *display* policy to only make the PAM module prompt for the
 elevation ticket when our mock API has a non-empty `tickets` object. So when there are no
 elevated users, there will be no prompt for a ticket. This can be done using the Rego
-[`count` aggregate](http://www.openpolicyagent.org/docs/language-reference.html#aggregates).
+[`count` aggregate](../policy-reference/#aggregates).
 
 ## Wrap Up
 

--- a/docs/website/static/community.html
+++ b/docs/website/static/community.html
@@ -356,7 +356,7 @@
             <div class="col-8">
               Sign up for the OPA newsletter!
             </div>
-            <a href="http://eepurl.com/hSFrEP"
+            <a href="https://eepurl.com/hSFrEP"
               class="btn btn-primary btn-lg col-4" role="button">Go to Newsletter Sign-up</a>
           </div>
         </section>


### PR DESCRIPTION
The docs themselves shouldn't use the full URL to reference other
pages.

Also changes http -> https for the newsletter sign-up page.
