### PR TITLE
Stretch background so it covers on larger screens

### DIFF
--- a/docs/website/static/css/community.css
+++ b/docs/website/static/css/community.css
@@ -27,11 +27,13 @@
 
 .support-bg {
     width: 100%;
+    height: 100%;
     background-color: #5687e5;
     background-image: url("../img/cloudAll.png"), url("../img/homebg.png");
     background-attachment: fixed, scroll;
     background-position: right top;
     background-repeat: no-repeat;
+    background-size: cover;
 }
 
 .support-content {


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

The new community page looks fine at reasonably high resolution (3456 × 2234 on my machine)...

<img width="691" alt="image" src="https://user-images.githubusercontent.com/6817500/156637423-6e7a564c-2b1a-4e40-9c67-31d16ea31659.png">

but there are yet much higher resolutions to be had out there!
If I emulate that by reducing the image (via `Cmd` + `-` several times) this artifact is revealed--notice the clouds no longer cover the full background:
<img width="691" alt="image" src="https://user-images.githubusercontent.com/6817500/156638160-d59d664e-001f-4451-baf5-c827c3eeca92.png">

And reducing even further, we get another artifact (I added a border just so you can delineate the edge of the image):
<img width="695" alt="image" src="https://user-images.githubusercontent.com/6817500/156638721-1ea00a42-5b81-4a65-b6dc-b37b9289b293.png">

### :+1: Definition of Done
Even at highest resolution, we want the background image to maintain its full cover:
<img width="691" alt="image" src="https://user-images.githubusercontent.com/6817500/156638362-fa3253fb-0f3b-4afd-873c-24b60fc65933.png">

### :athletic_shoe: How to Build and Test the Change

Visit the [netlify deploy preview](https://deploy-preview-4405--openpolicyagent.netlify.app/community)

### :chains: Related Resources
Signed-off-by: Michael Sorens <msorens@styra.com>

