### PR TITLE
ast/parser: hint about 'every' future keyword

### DIFF
--- a/ast/parser_test.go
+++ b/ast/parser_test.go
@@ -837,6 +837,20 @@ func TestEvery(t *testing.T) {
 			},
 			With: []*With{{Value: ArrayTerm(), Target: NewTerm(MustParseRef("input"))}},
 		}, opts)
+
+	assertParseErrorContains(t, "every x, y in ... usage is hinted properly", `
+	p {
+		every x, y in {"foo": "bar"} { is_string(x); is_string(y) }
+	}`,
+		"unexpected ident token: expected \\n or ; or } (hint: `import future.keywords.every` for `every x in xs { ... }` expressions)")
+
+	assertParseErrorContains(t, "not every 'every' gets a hint", `
+	p {
+		every x
+	}`,
+		"unexpected ident token: expected \\n or ; or }\n\tevery x\n", // this asserts that the tail of the error message doesn't contain a hint
+	)
+
 }
 
 func TestNestedExpressions(t *testing.T) {


### PR DESCRIPTION
This should inject a hint for when it's likely that a parsed
identifier `every` was meant to be a keyword.

By the usual hinting mechanism in the parser, if the parser proceeds
without any errors, the hint is going to be ignored.