### PR TITLE
Update philosophy.md

### DIFF
--- a/docs/content/philosophy.md
+++ b/docs/content/philosophy.md
@@ -140,7 +140,7 @@ surfaced in virtual documents. Data loaded synchronously is kept outside of `dat
 avoid naming conflicts.
 
 The following table summarizes the different models for loading base documents into OPA,
-how they can referenced inside of policies, and the actual mechanism(s) for loading.
+how they can be referenced inside of policies, and the actual mechanism(s) for loading.
 
 | Model | How to access in Rego | How to integrate with OPA |
 | --- | --- | --- |
@@ -170,7 +170,7 @@ virtual documents named `data.iam.user_has_role` and `data.acme.user_is_assigned
 {{< figure src="data-model.svg" width="65" caption="Hypothetical Policy Document Model" >}}
 
 > [1] OPA has excellent support for loading JSON and YAML because they are prevalent
-> in modern systems however OPA is not tied to any particular data format. OPA
+> in modern systems; however, OPA is not tied to any particular data format. OPA
 > uses its own internal representation for structures like maps and lists (a.k.a.,
 > objects and arrays in JSON.)
 
@@ -181,5 +181,5 @@ virtual documents named `data.iam.user_has_role` and `data.acme.user_is_assigned
 > nested, hierarchical data structures containing several levels of embedded
 > maps and lists.
 
-> [3] Internally HTTP requests like `GET /v1/data` or `GET /v1/data/foo/bar` are turned
+> [3] Internally, HTTP requests like `GET /v1/data` or `GET /v1/data/foo/bar` are turned
 > into Rego queries that are almost identical to the HTTP path (e.g., `data` or `data.foo.bar`)


### PR DESCRIPTION
This is a documentation change only so updates to tests are not needed. I am suggesting this change to fix grammatical errors which will increase readability for consumers of the OPA Philosophy document.

---

1. I noticed there is a missing word ("be") in the OPA Document Model section, just above the table that summarizes the different models for loading base documents into OPA. This change adds the omitted word.

2. I've also made a change to the first note at the bottom of the page ([1]). "However" is used as a conjunctive adverb, I've updated the sentence's punctuation to reflect this.

3. Lastly, I've made a punctuation change to note number three at the bottom of the page ([3])  to increase readability.