### PR TITLE
JSON schema: skip pattern attribute compilation

### DIFF
--- a/ast/compile_test.go
+++ b/ast/compile_test.go
@@ -909,6 +909,30 @@ func TestCompilerCheckTypesWithSchema(t *testing.T) {
 	assertNotFailed(t, c)
 }
 
+func TestCompilerCheckTypesWithRegexPatternInSchema(t *testing.T) {
+	c := NewCompiler()
+	var schema interface{}
+	// Negative lookahead is not supported in the Go regex dialect, but this is still a valid
+	// JSON schema. Since we don't rely on the "pattern" attribute for type checking, ensure
+	// that this still works (by being ignored)
+	err := util.Unmarshal([]byte(`{
+		"properties": {
+			"name": {
+				"pattern": "^(?!testing:.*)[a-z]+$",
+				"type": "string"
+			}
+		}
+	}`), &schema)
+	if err != nil {
+		t.Fatal("Unexpected error:", err)
+	}
+	schemaSet := NewSchemaSet()
+	schemaSet.Put(SchemaRootRef, schema)
+	c.WithSchemas(schemaSet)
+	compileStages(c, c.checkTypes)
+	assertNotFailed(t, c)
+}
+
 func TestCompilerCheckTypesWithAllOfSchema(t *testing.T) {
 
 	tests := []struct {

--- a/internal/gojsonschema/schema.go
+++ b/internal/gojsonschema/schema.go
@@ -517,17 +517,12 @@ func (d *Schema) parseSchema(documentNode interface{}, currentSchema *SubSchema)
 		}
 	}
 
-	if pattern, err := getString(m, KeyPattern); err != nil {
+	// NOTE: Regex compilation step removed as we don't use "pattern" attribute for
+	// type checking, and this would cause schemas to fail if they included patterns
+	// that were valid ECMA regex dialect but not known to Go (i.e. the regexp.Compile
+	// function), such as patterns with negative lookahead
+	if _, err := getString(m, KeyPattern); err != nil {
 		return err
-	} else if pattern != nil {
-		regexpObject, err := regexp.Compile(*pattern)
-		if err != nil {
-			return errors.New(formatErrorDescription(
-				Locale.MustBeValidRegex(),
-				ErrorDetails{"key": KeyPattern},
-			))
-		}
-		currentSchema.pattern = regexpObject
 	}
 
 	if format, err := getString(m, KeyFormat); err != nil {

--- a/internal/gojsonschema/testdata/draft4/pattern.json
+++ b/internal/gojsonschema/testdata/draft4/pattern.json
@@ -9,9 +9,9 @@
                 "valid": true
             },
             {
-                "description": "a non-matching pattern is invalid",
+                "description": "a non-matching pattern is invalid (but ignored)",
                 "data": "abc",
-                "valid": false
+                "valid": true
             },
             {
                 "description": "ignores non-strings",

--- a/internal/gojsonschema/testdata/draft6/pattern.json
+++ b/internal/gojsonschema/testdata/draft6/pattern.json
@@ -9,9 +9,9 @@
                 "valid": true
             },
             {
-                "description": "a non-matching pattern is invalid",
+                "description": "a non-matching pattern is invalid (but ignored)",
                 "data": "abc",
-                "valid": false
+                "valid": true
             },
             {
                 "description": "ignores non-strings",

--- a/internal/gojsonschema/testdata/draft7/pattern.json
+++ b/internal/gojsonschema/testdata/draft7/pattern.json
@@ -9,9 +9,9 @@
                 "valid": true
             },
             {
-                "description": "a non-matching pattern is invalid",
+                "description": "a non-matching pattern is invalid (but ignored)",
                 "data": "abc",
-                "valid": false
+                "valid": true
             },
             {
                 "description": "ignores non-strings",


### PR DESCRIPTION
We don't use the regex "pattern" attribute for type checking,
but this still caused problems parsing schemas where the pattern
specified contained things that the Go regex dialect did not
support, such as negative lookahead. Solved for now by simply
removing the regex compilation of pattern properties.

Fixes #4426

Signed-off-by: Anders Eknert <anders@eknert.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->
