### PR TITLE
website: make local dev not build everything

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -450,7 +450,7 @@ endif
 netlify-prod: clean docs-clean build docs-generate docs-production-build
 
 .PHONY: netlify-preview
-netlify-preview: clean docs-clean build docs-live-blocks-install-deps docs-live-blocks-test docs-generate docs-preview-build
+netlify-preview: clean docs-clean build docs-live-blocks-install-deps docs-live-blocks-test docs-dev-generate docs-preview-build
 
 .PHONY: check-fuzz
 check-fuzz:

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -35,7 +35,7 @@ live-blocks-%:
 	cd $(CURDIR)/website/scripts/live-blocks && npm run $*
 
 .PHONY: serve-local
-serve-local: production-build
+serve-local: dev-build
 	# must be run from root of repo for
 	# the netlify.toml config to work
 	cd $(CURDIR)/.. && netlify dev --offline --dir $(CURDIR)/website/public
@@ -45,6 +45,10 @@ serve-remote: production-build
 	# must be run from root of repo for
 	# the netlify.toml config to work
 	cd $(CURDIR)/.. && netlify deploy
+
+.PHONY: dev-build
+dev-build:
+	make production-build DEV=true
 
 ######################################################
 #

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -12,6 +12,7 @@ clean:
 	rm -rf $(CURDIR)/website/generated
 	rm -rf $(CURDIR)/website/public
 	rm -rf $(CURDIR)/website/resources
+	rm -rf $(CURDIR)/website/scripts/live-blocks/opa_versions/latest-*
 
 .PHONY: generate-cli-docs
 generate-cli-docs:

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -21,6 +21,10 @@ generate-cli-docs:
 generate: generate-cli-docs
 	$(CURDIR)/website/scripts/load-docs.sh
 
+.PHONY: dev-generate
+dev-generate: generate-cli-docs
+	DEV=true $(CURDIR)/website/scripts/load-docs.sh
+
 # The website has some npm dependencies saved in ./website/node_modules
 # As well as dependencies required for the "live-blocks".
 # Use this target to update them as needed.
@@ -47,8 +51,7 @@ serve-remote: production-build
 	cd $(CURDIR)/.. && netlify deploy
 
 .PHONY: dev-build
-dev-build:
-	make production-build DEV=true
+dev-build: clean dev-generate hugo-production-build live-blocks-inject
 
 ######################################################
 #

--- a/docs/website/layouts/404.html
+++ b/docs/website/layouts/404.html
@@ -20,12 +20,13 @@
         color: #008a98;
       }
 
-     body,html {
-      height: 100%;
-      overflow: hidden;}
+      body,html {
+        height: 100%;
+        overflow: hidden;
+      }
 
-      .headline--wave--fg { bottom: 200px;}
-      .headline--wave--bg { bottom: 230px;}
+      .headline--wave--fg { bottom: 200px; }
+      .headline--wave--bg { bottom: 230px; }
 
       h1,p {
         text-align: center;

--- a/docs/website/layouts/index.html
+++ b/docs/website/layouts/index.html
@@ -1,4 +1,8 @@
 {{ define "main" }}
+{{- $latest := "latest" -}}
+{{- if eq (len site.Data.releases) 1 -}}
+{{- $latest = "edge" -}}
+{{- end -}}
   <!doctype html>
   <html lang="en">
 
@@ -35,13 +39,13 @@
 
           <ul class="navbar-nav">
             <li class="nav-item">
-              <a class="nav-link" href="./docs/latest/">Documentation </a>
+              <a class="nav-link" href="./docs/{{ $latest }}/">Documentation </a>
             </li>
             <li class="nav-item">
-              <a class="nav-link" href="./docs/latest/#running-opa">Download </a>
+              <a class="nav-link" href="./docs/{{ $latest }}/#running-opa">Download </a>
             </li>
             <li class="nav-item">
-              <a class="nav-link" href="./docs/latest/ecosystem/">Ecosystem </a>
+              <a class="nav-link" href="./docs/{{ $latest }}/ecosystem/">Ecosystem </a>
             </li>
             <li class="nav-item">
               <a class="nav-link" href="./support">Support</a>
@@ -1421,14 +1425,14 @@ allowed_pets[pet] {
         <div class="col-12 mt-2">
           <div class="mt-4" style="font-weight:600"><label>Learn More</label></div>
           <div class="mt-2">
-            <a href="./docs/latest/kubernetes-introduction/" class="btn more-link btn-primary"
+            <a href="./docs/{{ $latest }}/kubernetes-introduction/" class="btn more-link btn-primary"
               target="_blank">Kubernetes</a>
-            <a href="./docs/latest/envoy-introduction/" class="btn btn-primary more-link" target="_blank">Envoy</a>
-            <a href="./docs/latest/terraform/" class="btn more-link btn-primary" target="_blank">Terraform</a>
-            <a href="./docs/latest/kafka-authorization/" class="btn more-link btn-primary" target="_blank">Kafka</a>
+            <a href="./docs/{{ $latest }}/envoy-introduction/" class="btn btn-primary more-link" target="_blank">Envoy</a>
+            <a href="./docs/{{ $latest }}/terraform/" class="btn more-link btn-primary" target="_blank">Terraform</a>
+            <a href="./docs/{{ $latest }}/kafka-authorization/" class="btn more-link btn-primary" target="_blank">Kafka</a>
             <a href="https://blog.openpolicyagent.org/write-policy-in-opa-enforce-policy-in-sql-d9d24db93bf4"
               class="btn more-link btn-primary" target="_blank">SQL</a>
-            <a href="./docs/latest/ssh-and-sudo-authorization/" class="btn more-link btn-primary" target="_blank">Linux</a>
+            <a href="./docs/{{ $latest }}/ssh-and-sudo-authorization/" class="btn more-link btn-primary" target="_blank">Linux</a>
           </div>
         </div>
       </div>
@@ -1534,8 +1538,8 @@ allowed_pets[pet] {
         <div class="col-12 mt-2">
           <div class="mt-4" style="font-weight:600"><label>Learn More</label></div>
           <div class="mt-2">
-            <a href="./docs/latest/deployments/" class="btn btn-primary more-link" target="_blank">Daemon</a>
-            <a href="./docs/latest/integration/#integrating-with-the-go-api" class="btn btn-primary more-link" target="_blank">Library</a>
+            <a href="./docs/{{ $latest }}/deployments/" class="btn btn-primary more-link" target="_blank">Daemon</a>
+            <a href="./docs/{{ $latest }}/integration/#integrating-with-the-go-api" class="btn btn-primary more-link" target="_blank">Library</a>
           </div>
         </div>
       </div>
@@ -1591,7 +1595,7 @@ allowed_pets[pet] {
           <div class="mt-2">
             <a href="https://marketplace.visualstudio.com/items?itemName=tsandall.opa" class="btn btn-primary more-link" target="_blank">VScode</a>
               <a href="https://play.openpolicyagent.org/" class="btn btn-primary more-link" target="_blank">Rego Playground</a>
-              <a href="./docs/latest/#running-opa" class="btn btn-primary more-link" target="_blank">General Tooling</a>
+              <a href="./docs/{{ $latest }}/#running-opa" class="btn btn-primary more-link" target="_blank">General Tooling</a>
           </div>
         </div>
       </div>
@@ -1612,7 +1616,7 @@ allowed_pets[pet] {
           <div class="footer-bottom">
             © {{ now.Format "2006"}} Open Policy Agent contributors. Licensed under the Apache
             License, Version 2.0. For information about
-            contributing, <a href="/docs/latest/contributing/">see documentation</a>.
+            contributing, <a href="/docs/{{ $latest }}/contributing/">see documentation</a>.
           </div>
         </div>
       </div>

--- a/docs/website/layouts/index.redirects
+++ b/docs/website/layouts/index.redirects
@@ -3,7 +3,11 @@
 {{- $docRedirects := site.Data.redirects }}
 
 # Redirect to latest doc version by default
-/docs     /docs/latest      301!
+{{- $latest := "latest" -}}
+{{- if eq (len site.Data.releases) 1 -}}
+{{- $latest = "edge" -}}
+{{- end -}}
+/docs     /docs/{{ $latest }}      301!
 
 # v0.14.0 re-org redirects
 # TODO: Remove at some point in the future when its more ok to break old links en-mass

--- a/docs/website/layouts/partials/docs/article.html
+++ b/docs/website/layouts/partials/docs/article.html
@@ -1,5 +1,8 @@
 {{ $releases   := site.Data.releases }}
 {{ $latest     := printf "%s" (index $releases 1) }}
+{{- if eq (len site.Data.releases) 1 -}}
+{{- $latest = "(dev preview)" -}}
+{{- end -}}
 {{ $version    := index (split .File.Path "/") 1 }}
 <article class="article">
   {{ with (eq $version "edge") }}

--- a/docs/website/scripts/live-blocks/src/preprocess/acquireOPAVersion.js
+++ b/docs/website/scripts/live-blocks/src/preprocess/acquireOPAVersion.js
@@ -50,7 +50,7 @@ function createAcquirer(version) {
 
     const path = pathToVersion(version)
 
-    if (await needsDownloading(version, path)) { // This does not protect against run conditions within a single preprocessing script run, simply allows (long-term) caching.
+    if (await needsDownloading(path)) { // This does not protect against run conditions within a single preprocessing script run, simply allows (long-term) caching.
 
       // Edge is required to have been built from the current source tree,
       // expect the binary to be available at the normal build output location.
@@ -115,8 +115,8 @@ async function getReleaseAssetURL(version) {
   throw new Error(`unable to get the OPA release asset URL for ${version} on ${PLATFORM} from ${releaseURL}`)
 }
 
-// Determines, based on the desired version and the path to where it should be downloaded, whether it needs to be downloaded. Will not throw an error.
-async function needsDownloading(version, path) {
+// Determines, based on the path to where it should be downloaded, whether it needs to be downloaded. Will not throw an error.
+async function needsDownloading(path) {
   try {
     await promFS.access(path, fsConsts.X_OK) // X_OK verifies that permissions-wise it's executable
   } catch (e) {

--- a/docs/website/scripts/load-docs.sh
+++ b/docs/website/scripts/load-docs.sh
@@ -24,13 +24,17 @@ RELEASES=()
 PREV_MAJOR_VER="-1"
 PREV_MINOR_VER="-1"
 
+if [[ ${DEV} != "" ]]; then
+    ALL_RELEASES=()
+fi
+
 for release in ${ALL_RELEASES}; do
     CUR_SEM_VER=${release#"v"}
 
     # ignore any release candidate versions, for now if they
     # are the "latest" they'll be documented under "edge"
     if [[ "${CUR_SEM_VER}" == *"rc"* ]]; then
-      continue
+        continue
     fi
 
     SEMVER_REGEX='[^0-9]*\([0-9]*\)[.]\([0-9]*\)[.]\([0-9]*\)\([0-9A-Za-z-]*\)'
@@ -57,8 +61,8 @@ for release in ${ALL_RELEASES}; do
     # The releases are sorted in order by semver from newest to oldest, and we only want
     # the latest point release for each minor version
     if [[ "${CUR_MAJOR_VER}" != "${PREV_MAJOR_VER}" || \
-             ("${CUR_MAJOR_VER}" = "${PREV_MAJOR_VER}" && \
-                "${CUR_MINOR_VER}" != "${PREV_MINOR_VER}") ]]; then
+            ("${CUR_MAJOR_VER}" = "${PREV_MAJOR_VER}" && \
+            "${CUR_MINOR_VER}" != "${PREV_MINOR_VER}") ]]; then
         RELEASES+=(${release})
     fi
 
@@ -77,8 +81,10 @@ rm -f ${RELEASES_YAML_FILE}
 
 mkdir -p $(dirname ${RELEASES_YAML_FILE})
 
-echo 'Adding "latest" version to releases.yaml'
-echo "- latest" > ${RELEASES_YAML_FILE}
+if [[ ${DEV} == "" ]]; then
+    echo 'Adding "latest" version to releases.yaml'
+    echo "- latest" > ${RELEASES_YAML_FILE}
+fi
 
 for release in "${RELEASES[@]}"; do
     version_docs_dir=${ROOT_DIR}/docs/website/generated/docs/${release}
@@ -108,7 +114,10 @@ echo "- edge" >> ${RELEASES_YAML_FILE}
 
 # Link instead of copy so we don't need to re-generate each time.
 # Use a relative link so it works in a container more easily.
+mkdir -p ${ROOT_DIR}/docs/website/generated/docs
 ln -s ../../../content ${ROOT_DIR}/docs/website/generated/docs/edge
 
 # Create a "latest" version from the latest semver found
-cp -r ${ROOT_DIR}/docs/website/generated/docs/${RELEASES[0]} ${ROOT_DIR}/docs/website/generated/docs/latest
+if [[ ${DEV} == "" ]]; then
+    cp -r ${ROOT_DIR}/docs/website/generated/docs/${RELEASES[0]} ${ROOT_DIR}/docs/website/generated/docs/latest
+fi

--- a/docs/website/static/community.html
+++ b/docs/website/static/community.html
@@ -1,3 +1,7 @@
+{{- $latest := "latest" -}}
+{{- if eq (len site.Data.releases) 1 -}}
+{{- $latest = "edge" -}}
+{{- end -}}
 <!doctype html>
 <html lang="en">
 
@@ -38,13 +42,13 @@
 
               <ul class="navbar-nav">
                 <li class="nav-item">
-                  <a class="nav-link" href="./docs/latest/">Documentation</a>
+                  <a class="nav-link" href="./docs/{{ $latest }}/">Documentation</a>
                 </li>
                 <li class="nav-item">
-                  <a class="nav-link" href="./docs/latest/#running-opa">Download</a>
+                  <a class="nav-link" href="./docs/{{ $latest }}/#running-opa">Download</a>
                 </li>
                 <li class="nav-item">
-                  <a class="nav-link" href="./docs/latest/ecosystem/">Ecosystem</a>
+                  <a class="nav-link" href="./docs/{{ $latest }}/ecosystem/">Ecosystem</a>
                 </li>
                 <li class="nav-item">
                   <a class="nav-link" href="./support">Support</a>


### PR DESCRIPTION
With this change, the work done for local development, and the per-PR netlify preview changes:

_It will no longer include the website stuff for versions other than **edge**, the current working tree._

We thus save us the time, and the flakiness, involved with
1. checking if github has release binaries for all the versions
2. checking out their sources
3. fetching the release binaries to pre-hydrate old versions' live-blocks.

The previously-used, documented make target should still be intact. 

Fixes #4379 to some extent, I hope.