### PR TITLE
Support for adding custom parameters and headers for OAuth2 Client Credentials Token request

### DIFF
--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -293,6 +293,8 @@ Following successful authentication at the token endpoint the returned token wil
 | `services[_].credentials.oauth2.client_id` | `string` | Yes | The client ID to use for authentication. |
 | `services[_].credentials.oauth2.client_secret` | `string` | Yes | The client secret to use for authentication. |
 | `services[_].credentials.oauth2.scopes` | `[]string` | No | Optional list of scopes to request for the token. |
+| `services[_].credentials.oauth2.additional_headers` | `map` | No | Map of additional headers to send to token endpoint at the OAuth2 authorization server |
+| `services[_].credentials.oauth2.additional_parameters` | `map` | No | Map of additional body parameters to send token endpoint at the OAuth2 authorization server |
 
 #### OAuth2 Client Credentials JWT authentication
 


### PR DESCRIPTION
This change enables to add custom body parameters and headers to OAuth2 Client Credentials token request for non-standard authorization servers.

We use such auth-server which we would need to create a custom plug-in. The target is to help integration with similar systems out of the box without creating a custom plug-in.


Signed-off-by: skosunda <skosunda@adobe.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->
