### PR TITLE
Remove space from tabbed `with` indentation

### DIFF
--- a/format/format.go
+++ b/format/format.go
@@ -110,7 +110,7 @@ func Ast(x interface{}) ([]byte, error) {
 	case *ast.Expr:
 		w.writeExpr(x, nil)
 	case *ast.With:
-		w.writeWith(x, nil)
+		w.writeWith(x, nil, false)
 	case *ast.Term:
 		w.writeTerm(x, nil)
 	case ast.Value:
@@ -452,7 +452,7 @@ func (w *writer) writeExpr(expr *ast.Expr, comments []*ast.Comment) []*ast.Comme
 			w.endLine()
 			w.startLine()
 		}
-		comments = w.writeWith(with, comments)
+		comments = w.writeWith(with, comments, indented)
 	}
 
 	return comments
@@ -556,9 +556,12 @@ func (w *writer) writeFunctionCallPlain(terms []*ast.Term, comments []*ast.Comme
 	return w.writeIterable(args, loc, closingLoc(0, 0, '(', ')', loc), comments, w.listWriter())
 }
 
-func (w *writer) writeWith(with *ast.With, comments []*ast.Comment) []*ast.Comment {
+func (w *writer) writeWith(with *ast.With, comments []*ast.Comment, indented bool) []*ast.Comment {
 	comments = w.insertComments(comments, with.Location)
-	w.write(" with ")
+	if !indented {
+		w.write(" ")
+	}
+	w.write("with ")
 	comments = w.writeTerm(with.Target, comments)
 	w.write(" as ")
 	return w.writeTerm(with.Value, comments)

--- a/format/testfiles/test.rego
+++ b/format/testfiles/test.rego
@@ -195,18 +195,6 @@ declare1 := 1
 
 declare2 := 2 { false }
 
-multi_line_with {
-    fn(1) with input.a as "a"
-                with input.b as "b"
-            with input.c as {
-                "foo": "bar",
-            }
-                with input.d as [
-                    1,
-                    2,
-                    3]
-}
-
 # more comments!
 # more comments!
 # more comments!

--- a/format/testfiles/test.rego.formatted
+++ b/format/testfiles/test.rego.formatted
@@ -226,17 +226,6 @@ declare2 := 2 {
 	false
 }
 
-multi_line_with {
-	fn(1) with input.a as "a"
-		 with input.b as "b"
-		 with input.c as {"foo": "bar"}
-		 with input.d as [
-			1,
-			2,
-			3,
-		]
-}
-
 # more comments!
 # more comments!
 # more comments!

--- a/format/testfiles/test_with.rego
+++ b/format/testfiles/test_with.rego
@@ -1,0 +1,17 @@
+package p
+
+single_line_with {
+  fn(1)   with input.a as "a"
+}
+
+multi_line_with {
+    fn(1) with input.a as "a"
+                with input.b as "b"
+            with input.c as {
+                "foo": "bar",
+            }
+                with input.d as [
+                    1,
+                    2,
+                    3]
+}

--- a/format/testfiles/test_with.rego.formatted
+++ b/format/testfiles/test_with.rego.formatted
@@ -1,0 +1,16 @@
+package p
+
+single_line_with {
+	fn(1) with input.a as "a"
+}
+
+multi_line_with {
+	fn(1) with input.a as "a"
+		with input.b as "b"
+		with input.c as {"foo": "bar"}
+		with input.d as [
+			1,
+			2,
+			3,
+		]
+}


### PR DESCRIPTION
Fixes #4376

Do note though that this does not change how multiple
with statements are grouped. Although I agree with that,
it's IMHO a separate feature request, while the spacing
issue is a bug.

Signed-off-by: Anders Eknert <anders@eknert.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->
