### PR TITLE
Improve log output for binary response when debug logging or pprof enabled

### DIFF
--- a/runtime/logging_test.go
+++ b/runtime/logging_test.go
@@ -7,6 +7,7 @@ package runtime
 
 import (
 	"fmt"
+	"net/http"
 	"net/url"
 	"testing"
 )
@@ -45,4 +46,63 @@ func TestDropInputParam(t *testing.T) {
 		t.Errorf("Expected %v but got: %v", expected, result)
 	}
 
+}
+
+func TestValidateGzipHeader(t *testing.T) {
+
+	httpHeader := http.Header{}
+
+	httpHeader.Add("Accept", "*/*")
+	result := gzipAccepted(httpHeader)
+	expected := false
+
+	if result != expected {
+		t.Errorf("Expected %v but got: %v", expected, result)
+	}
+
+	httpHeader.Add("Accept-Encoding", "gzip")
+
+	result = gzipAccepted(httpHeader)
+	expected = true
+
+	if result != expected {
+		t.Errorf("Expected %v but got: %v", expected, result)
+	}
+
+	httpHeader.Set("Accept-Encoding", "gzip, deflate, br")
+	result = gzipAccepted(httpHeader)
+	expected = true
+
+	if result != expected {
+		t.Errorf("Expected %v but got: %v", expected, result)
+	}
+
+	httpHeader.Set("Accept-Encoding", "br;q=1.0, gzip;q=0.8, *;q=0.1")
+	result = gzipAccepted(httpHeader)
+	expected = true
+
+	if result != expected {
+		t.Errorf("Expected %v but got: %v", expected, result)
+	}
+}
+
+func TestValidatePprofUrl(t *testing.T) {
+
+	req := http.Request{}
+
+	req.URL = &url.URL{Path: "/metrics"}
+	result := isPprofEndpoint(&req)
+	expected := false
+
+	if result != expected {
+		t.Errorf("Expected %v but got: %v", expected, result)
+	}
+
+	req.URL = &url.URL{Path: "/debug/pprof/"}
+	result = isPprofEndpoint(&req)
+	expected = true
+
+	if result != expected {
+		t.Errorf("Expected %v but got: %v", expected, result)
+	}
 }


### PR DESCRIPTION
This change omits the response body when using compression on metrics endpoint and when pprof is enabled.

Signed-off-by: Christian Altamirano <christian.altamirano.ayala@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->
