### PR TITLE
sdk/opa_test: increase max delta (0.5s)

### DIFF
--- a/sdk/opa_test.go
+++ b/sdk/opa_test.go
@@ -570,11 +570,11 @@ func TestStopWithDeadline(t *testing.T) {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	before := time.Now()
-	opa.Stop(ctx) // 1m timeout is ignored
+	opa.Stop(ctx) // 1s timeout is ignored
 
 	dur := time.Since(before)
 	diff := dur - timeout
-	maxDelta := 10 * time.Millisecond
+	maxDelta := 500 * time.Millisecond
 	if diff > maxDelta || diff < -maxDelta {
 		t.Errorf("expected shutdown to have %v grace period, measured shutdown in %v (max delta %v)", timeout, dur, maxDelta)
 	}


### PR DESCRIPTION
When running on GHA, we've found this test to often fail on macos-latest:
It would not functionally be wrong, but it also wasn't able to finish in
the alloted time. Now, the maximum delta has been increased a lot (10ms to
500ms). It's much, but it's still good enough to ensure that the context
passed to Stop() is the one that matters for shutdown.
