### PR TITLE
website/style: fix code block bottom margin

### DIFF
--- a/docs/website/assets/sass/docs.sass
+++ b/docs/website/assets/sass/docs.sass
@@ -126,3 +126,6 @@ $panel-header-logo-width: 85%
 .dropdown-menu .dropdown-content
   max-height: 55vh
   overflow-y: auto
+
+.highlight
+  margin-bottom: 1.5rem // matches what live-blocks does


### PR DESCRIPTION
Adds some bottom margin to regular (non-live-blocks) code blocks:

<img width="957" alt="image" src="https://user-images.githubusercontent.com/870638/161043713-78a818b9-bb30-4a1d-914b-622eba02fbe1.png">
