### PR TITLE
ci: fix rego check

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -310,6 +310,8 @@ jobs:
 
       - name: Download OPA
         uses: open-policy-agent/setup-opa@v1
+        with:
+          version: edge
 
       - name: Test policies
         run: opa test build/policy

--- a/build/policy/files_test.rego
+++ b/build/policy/files_test.rego
@@ -145,21 +145,21 @@ test_allow_listed_software {
 test_deny_invalid_yaml_file {
 	expected := "invalid.yaml is an invalid YAML file"
 	deny[expected] with data.files.yaml_file_contents as {"invalid.yaml": "{null{}}"}
-		 with data.files.changes as {"invalid.yaml": {"status": "modified"}}
+		with data.files.changes as {"invalid.yaml": {"status": "modified"}}
 }
 
 test_allow_valid_yaml_file {
 	count(deny) == 0 with data.files.yaml_file_contents as {"valid.yaml": "foo: bar"}
-		 with data.files.changes as {"valid.yaml": {"status": "modified"}}
+		with data.files.changes as {"valid.yaml": {"status": "modified"}}
 }
 
 test_deny_invalid_json_file {
 	expected := "invalid.json is an invalid JSON file"
 	deny[expected] with data.files.json_file_contents as {"invalid.json": "}}}"}
-		 with data.files.changes as {"invalid.json": {"status": "modified"}}
+		with data.files.changes as {"invalid.json": {"status": "modified"}}
 }
 
 test_allow_valid_json_file {
 	count(deny) == 0 with data.files.json_file_contents as {"valid.json": "{\"foo\": \"bar\"}"}
-		 with data.files.changes as {"valid.json": {"status": "modified"}}
+		with data.files.changes as {"valid.json": {"status": "modified"}}
 }


### PR DESCRIPTION
- opa 0.39.0 changed the `with` formatting
- we're using the `latest` version of OPA in there (by default) -- changed to `edge` to catch something like this earlier