### PR TITLE
website: show yellow banner for old version

### DIFF
--- a/docs/website/layouts/partials/docs/article.html
+++ b/docs/website/layouts/partials/docs/article.html
@@ -5,13 +5,19 @@
 {{- end -}}
 {{ $version    := index (split .File.Path "/") 1 }}
 <article class="article">
-  {{ with (eq $version "edge") }}
+  {{- if (eq $version "edge") }}
   <div class="message is-danger">
     <div class="message-body">
       This version is still under development! Latest stable release is <a href="/docs/latest">{{ $latest }}</a>
     </div>
   </div>
-  {{ end }}
+  {{- else if (and (ne $version "latest") (ne $version $latest)) }}
+  <div class="message is-warning">
+    <div class="message-body">
+      These are the docs for an older version of OPA. Latest stable release is <a href="/docs/latest">{{ $latest }}</a>
+    </div>
+  </div>
+  {{- end }}
   <div class="container">
     {{ partial "docs/hero.html" . }}
 


### PR DESCRIPTION
Hopefully this is gets more attention than the yellow "older" button
in the version picker.

Tested locally, seems to be OK:

<img width="975" alt="image" src="https://user-images.githubusercontent.com/870638/161225814-0a9bdb38-375c-49d2-abb6-47a47322175c.png">

Note: this had to be tested locally since we've stopped building all the versions for a PR preview.