### PR TITLE
Fix: Deprecate or promote WARN level in logging package

### DIFF
--- a/logging/logging.go
+++ b/logging/logging.go
@@ -87,8 +87,8 @@ func (l *StandardLogger) getFields() map[string]interface{} {
 func (l *StandardLogger) SetLevel(level Level) {
 	var logrusLevel logrus.Level
 	switch level {
-	case Error:
-		logrusLevel = logrus.ErrorLevel
+	case Error: // set logging level report Warn or higher (includes Error)
+		logrusLevel = logrus.WarnLevel
 	case Warn:
 		logrusLevel = logrus.WarnLevel
 	case Info:
@@ -109,10 +109,8 @@ func (l *StandardLogger) GetLevel() Level {
 
 	var level Level
 	switch logrusLevel {
-	case logrus.ErrorLevel:
-		level = Error
 	case logrus.WarnLevel:
-		level = Warn
+		level = Error
 	case logrus.InfoLevel:
 		level = Info
 	case logrus.DebugLevel:
@@ -142,7 +140,7 @@ func (l *StandardLogger) Error(fmt string, a ...interface{}) {
 
 // Warn logs at warn level
 func (l *StandardLogger) Warn(fmt string, a ...interface{}) {
-	l.logger.WithFields(l.getFields()).Errorf(fmt, a...)
+	l.logger.WithFields(l.getFields()).Warnf(fmt, a...)
 }
 
 // NoOpLogger logging implementation that does nothing

--- a/logging/logging_test.go
+++ b/logging/logging_test.go
@@ -1,6 +1,8 @@
 package logging
 
 import (
+	"bytes"
+	"strings"
 	"testing"
 )
 
@@ -16,6 +18,26 @@ func TestWithFields(t *testing.T) {
 
 	if fieldvalue.(string) != "contextvalue" {
 		t.Fatal("Logger did not contain configured field value")
+	}
+}
+
+func TestCaptureWarningWithErrorSet(t *testing.T) {
+	buf := bytes.Buffer{}
+	logger := New()
+	logger.SetOutput(&buf)
+	logger.SetLevel(Error)
+
+	logger.Warn("This is a warning. Next time, I won't compile.")
+	logger.Error("Fix your issues. I'm not compiling.")
+
+	expected := []string{
+		`level=warning msg="This is a warning. Next time, I won't compile."`,
+		`level=error msg="Fix your issues. I'm not compiling."`,
+	}
+	for _, exp := range expected {
+		if !strings.Contains(buf.String(), exp) {
+			t.Errorf("expected string %q not found in logs", exp)
+		}
 	}
 }
 

--- a/storage/disk/disk_test.go
+++ b/storage/disk/disk_test.go
@@ -1398,7 +1398,7 @@ func TestDiskDiagnostics(t *testing.T) {
 			}
 
 			expected := []string{
-				`level=error msg="no partitions configured"`,
+				`level=warning msg="no partitions configured"`,
 				`level=debug msg="partition /: key count: 0 (estimated size 0 bytes)"`,
 			}
 			for _, exp := range expected {
@@ -1407,7 +1407,7 @@ func TestDiskDiagnostics(t *testing.T) {
 				}
 			}
 			if t.Failed() {
-				t.Log("log oputput: ", buf.String())
+				t.Log("log output: ", buf.String())
 			}
 
 			// re-open


### PR DESCRIPTION
Fixes #4373 

This is a new PR that was raised. The last PR was closed because of merging issues.
Old PR: #4507 