### PR TITLE
topdown: fix TestRego

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -298,7 +298,12 @@ jobs:
         with:
           go-version: ${{ matrix.version }}
       - run: make build
+        env:
+          DOCKER_RUNNING: 0
       - run: make go-test
+        env:
+          DOCKER_RUNNING: 0
+
 
   # Run PR metadata against Rego policies
   rego-check-pr:

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ endif
 
 GOLANGCI_LINT_VERSION := v1.43.0
 
-DOCKER_RUNNING := $(shell docker ps >/dev/null 2>&1 && echo 1 || echo 0)
+DOCKER_RUNNING ?= $(shell docker ps >/dev/null 2>&1 && echo 1 || echo 0)
 
 # We use root because the windows build, invoked through the ci-go-build-windows
 # target, installs the gcc mingw32 cross-compiler.

--- a/topdown/exported_test.go
+++ b/topdown/exported_test.go
@@ -2,19 +2,13 @@
 // Use of this source code is governed by an Apache2
 // license that can be found in the LICENSE file.
 
-// NOTE(sr): x509-related errors that we assert in the exported tests looked different
-// before go1.17. Since they are still (non-strict) errors in both cases, we'll skip
-// running the exported tests on go1.16.
-// This can be removed when we drop support for go 1.16.
-//go:build !go1.16
-// +build !go1.16
-
 package topdown
 
 import (
 	"context"
 	"fmt"
 	"os"
+	"runtime"
 	"sort"
 	"strings"
 	"testing"
@@ -25,8 +19,27 @@ import (
 	"github.com/open-policy-agent/opa/test/cases"
 )
 
+var x508Exceptions = []string{
+	"cryptox509parsecertificates/invalid DER or PEM data, b64",
+}
+
+func isException(note string) bool {
+	for _, exc := range x508Exceptions {
+		if note == exc {
+			return true
+		}
+	}
+	return false
+}
+
 func TestRego(t *testing.T) {
 	for _, tc := range cases.MustLoad("../test/cases/testdata").Sorted().Cases {
+		if strings.HasPrefix(runtime.Version(), "go1.16") && isException(tc.Note) {
+			t.Run(tc.Note, func(t *testing.T) {
+				t.Skip("skipped for go1.16, x509 errors differ")
+			})
+			continue
+		}
 		t.Run(tc.Note, func(t *testing.T) {
 			testRun(t, tc)
 		})

--- a/topdown/topdown_test.go
+++ b/topdown/topdown_test.go
@@ -295,7 +295,7 @@ func TestTopDownQueryCancellationEvery(t *testing.T) {
 
 			done := make(chan struct{})
 			go func() {
-				time.Sleep(time.Millisecond * 50)
+				time.Sleep(time.Millisecond * 500)
 				cancel.Cancel()
 				close(done)
 			}()


### PR DESCRIPTION
Inadvertently stopped running these in CI when going to go1.18 and expanding our tests base. 😅 

Also turns the timeout higher for a cancellation tests that was flakey on macos in CI.

Also avoid building wasm for the compat builds.