### PR TITLE
inspect: Fixing issue where some inspect errors aren't reported

### DIFF
--- a/internal/bundle/inspect/inspect.go
+++ b/internal/bundle/inspect/inspect.go
@@ -47,10 +47,9 @@ func File(path string, includeAnnotations bool) (*Info, error) {
 	bi.Namespaces = namespaces
 
 	if includeAnnotations {
-		var errs ast.Errors
-		as, err := ast.BuildAnnotationSet(modules)
+		as, errs := ast.BuildAnnotationSet(modules)
 		if len(errs) > 0 {
-			return nil, err
+			return nil, errs
 		}
 		bi.Annotations = as.Flatten()
 	}


### PR DESCRIPTION
Errors encountered during `inspect` command execution, when building the annotation-set are swallowed.

Signed-off-by: Johan Fylling <johan.dev@fylling.se>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->
