### PR TITLE
Persist activated bundle etag to store

### DIFF
--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -54,6 +54,7 @@ type Bundle struct {
 	WasmModules []WasmModuleFile
 	PlanModules []PlanModuleFile
 	Patch       Patch
+	Etag        string
 }
 
 // Patch contains an array of objects wherein each object represents the patch operation to be
@@ -342,6 +343,7 @@ type Reader struct {
 	processAnnotations    bool
 	files                 map[string]FileInfo // files in the bundle signature payload
 	sizeLimitBytes        int64
+	etag                  string
 }
 
 // NewReader is deprecated. Use NewCustomReader instead.
@@ -403,6 +405,12 @@ func (r *Reader) WithProcessAnnotations(yes bool) *Reader {
 // than this, an error will be returned by the reader.
 func (r *Reader) WithSizeLimitBytes(n int64) *Reader {
 	r.sizeLimitBytes = n + 1
+	return r
+}
+
+// WithBundleEtag sets the given etag value on the bundle
+func (r *Reader) WithBundleEtag(etag string) *Reader {
+	r.etag = etag
 	return r
 }
 
@@ -583,6 +591,8 @@ func (r *Reader) Read() (Bundle, error) {
 			return bundle, errors.Wrapf(err, "bundle load failed on %v", legacyRevisionStoragePath)
 		}
 	}
+
+	bundle.Etag = r.etag
 
 	return bundle, nil
 }

--- a/bundle/bundle_test.go
+++ b/bundle/bundle_test.go
@@ -118,6 +118,23 @@ func TestReadWithSizeLimit(t *testing.T) {
 	}
 }
 
+func TestReadWithBundleEtag(t *testing.T) {
+
+	files := [][2]string{
+		{"/.manifest", `{"revision": "quickbrownfaux"}`},
+	}
+
+	buf := archive.MustWriteTarGz(files)
+	bundle, err := NewReader(buf).WithBundleEtag("foo").Read()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if bundle.Etag != "foo" {
+		t.Fatalf("Expected bundle etag foo but got %v\n", bundle.Etag)
+	}
+}
+
 func testReadBundle(t *testing.T, baseDir string) {
 	module := `package example`
 

--- a/bundle/store_test.go
+++ b/bundle/store_test.go
@@ -243,6 +243,7 @@ func TestBundleLifecycle(t *testing.T) {
 					Parsed: ast.MustParseModule(mod2),
 				},
 			},
+			Etag: "foo",
 		},
 		"bundle2": {
 			Manifest: Manifest{
@@ -318,13 +319,15 @@ func TestBundleLifecycle(t *testing.T) {
 				"manifest": {
 					"revision": "",
 					"roots": ["a"]
-				}
+				},
+				"etag": "foo"
 			},
 			"bundle2": {
 				"manifest": {
 					"revision": "",
 					"roots": ["b", "c"]
-				}
+				},
+				"etag": ""
 			}
 		}
 	}
@@ -415,6 +418,7 @@ func TestDeltaBundleLifecycle(t *testing.T) {
 					Parsed: ast.MustParseModule(mod1),
 				},
 			},
+			Etag: "foo",
 		},
 		"bundle2": {
 			Manifest: Manifest{
@@ -534,6 +538,7 @@ func TestDeltaBundleLifecycle(t *testing.T) {
 				Roots:    &[]string{"a"},
 			},
 			Patch: Patch{Data: []PatchOperation{p1, p2, p3, p4, p5, p6}},
+			Etag:  "bar",
 		},
 		"bundle2": {
 			Manifest: Manifest{
@@ -541,6 +546,7 @@ func TestDeltaBundleLifecycle(t *testing.T) {
 				Roots:    &[]string{"b", "c"},
 			},
 			Patch: Patch{Data: []PatchOperation{p7}},
+			Etag:  "baz",
 		},
 		"bundle3": {
 			Manifest: Manifest{
@@ -608,19 +614,22 @@ func TestDeltaBundleLifecycle(t *testing.T) {
 					"manifest": {
 						"revision": "delta-1",
 						"roots": ["a"]
-					}
+					},
+					"etag": "bar"
 				},
 				"bundle2": {
 					"manifest": {
 						"revision": "delta-2",
 						"roots": ["b", "c"]
-					}
+					},
+					"etag": "baz"
 				},
 				"bundle3": {
 					"manifest": {
 						"revision": "",
 						"roots": ["d"]
-					}
+					},
+					"etag": ""
 				}
 			}
 		}
@@ -659,6 +668,7 @@ func TestDeltaBundleActivate(t *testing.T) {
 				Roots:    &[]string{"a"},
 			},
 			Patch: Patch{Data: []PatchOperation{p1}},
+			Etag:  "foo",
 		},
 	}
 
@@ -722,7 +732,8 @@ func TestDeltaBundleActivate(t *testing.T) {
 					"manifest": {
 						"revision": "delta",
 						"roots": ["a"]
-					}
+					},
+					"etag": "foo"
 				}
 			}
 		}

--- a/download/download.go
+++ b/download/download.go
@@ -307,7 +307,9 @@ func (d *Downloader) download(ctx context.Context, m metrics.Metrics) (*download
 				loader = bundle.NewTarballLoaderWithBaseURL(resp.Body, baseURL)
 			}
 
-			reader := bundle.NewCustomReader(loader).WithMetrics(m).WithBundleVerificationConfig(d.bvc)
+			etag := resp.Header.Get("ETag")
+			reader := bundle.NewCustomReader(loader).WithMetrics(m).WithBundleVerificationConfig(d.bvc).
+				WithBundleEtag(etag)
 			if d.sizeLimitBytes != nil {
 				reader = reader.WithSizeLimitBytes(*d.sizeLimitBytes)
 			}
@@ -337,7 +339,7 @@ func (d *Downloader) download(ctx context.Context, m metrics.Metrics) (*download
 			return &downloaderResponse{
 				b:        &b,
 				raw:      &buf,
-				etag:     resp.Header.Get("ETag"),
+				etag:     etag,
 				longPoll: isLongPollSupported(resp.Header),
 			}, nil
 		}


### PR DESCRIPTION
Currently etag from the HTTP response of activated bundles is not
persisted to store. Hence if OPA restarts and an activated bundle
loaded from the disk store is up-to-date, OPA may still download
the same version of the bundle and activate it. With this change,
OPA should include the right etag in the bundle download request
thereby avoiding unnecessary bundle download and activation.

Fixes: #4544

Signed-off-by: Ashutosh Narkar <anarkar4387@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->
