### PR TITLE
topdown/tokens_test: adjust expected signature for go1.18.1

### DIFF
--- a/topdown/tokens_test.go
+++ b/topdown/tokens_test.go
@@ -471,7 +471,7 @@ func TestTopdownJWTEncodeSignECWithSeedReturnsSameSignature(t *testing.T) {
 	   "d":"jpsQnnGQmL-YBIffH1136cspYG6-0iY7X1fCE9-E9LI"
 	  }, x)`
 	encodedSigned := "eyJhbGciOiAiRVMyNTYifQ.eyJwYXkiOiAibG9hZCJ9.05wmHY3NomU1jr7yvusBvKwhthRklPuJhUPOkoeIn5e5n_GXvE25EfRs9AJK2wOy6NoY2ljhj07M9BMtV0dfyA"
-	if runtime.Version() != "go1.18" {
+	if !strings.HasPrefix(runtime.Version(), "go1.18") {
 		encodedSigned = "eyJhbGciOiAiRVMyNTYifQ.eyJwYXkiOiAibG9hZCJ9.-LoHxtbT8t_TnqlLyONI4BtjvfkySO8TcoCFENqTTH2AKxvn29nAjxOdlbY-0EKVM2nJ4ukCx4IGtZtuwXr0VQ"
 	}
 


### PR DESCRIPTION
[Go 1.18.1](https://groups.google.com/g/golang-announce/c/oecdBNLOml8) was released last night -- and while it doesn't change
the signatures, it changes what `runtime.Version()` returns.

Our test expectation didn't account for that.

We've been pulling in go1.18.1 because our .go-version has 1.18 in it,
and the docker image ref built from that for the `ci-go-*` make targets
will use golang:1.18, which refers to the latest patch release.