### PR TITLE
topdown: Handling rego.metadata.* calls in query

### DIFF
--- a/topdown/parse.go
+++ b/topdown/parse.go
@@ -7,6 +7,7 @@ package topdown
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/topdown/builtins"
@@ -42,6 +43,17 @@ func builtinRegoParseModule(a, b ast.Value) (ast.Value, error) {
 	return term.Value, nil
 }
 
+func registerRegoMetadataBuiltinFunction(builtin *ast.Builtin) {
+	f := func(_ BuiltinContext, _ []*ast.Term, _ func(*ast.Term) error) error {
+		// The compiler should replace all usage of this function, so the only way to get here is within a query;
+		// which cannot define rules.
+		return fmt.Errorf("the %s function must only be called within the scope of a rule", builtin.Name)
+	}
+	RegisterBuiltinFunc(builtin.Name, f)
+}
+
 func init() {
 	RegisterFunctionalBuiltin2(ast.RegoParseModule.Name, builtinRegoParseModule)
+	registerRegoMetadataBuiltinFunction(ast.RegoMetadataChain)
+	registerRegoMetadataBuiltinFunction(ast.RegoMetadataRule)
 }

--- a/topdown/query_test.go
+++ b/topdown/query_test.go
@@ -178,6 +178,42 @@ func TestDisabledTracer(t *testing.T) {
 	}
 }
 
+func TestRegoMetadataBuiltinCall(t *testing.T) {
+	tests := []struct {
+		note          string
+		query         string
+		expectedError string
+	}{
+		{
+			note:          "rego.metadata.chain() call",
+			query:         "rego.metadata.chain()",
+			expectedError: "rego.metadata.chain(): eval_builtin_error: rego.metadata.chain: the rego.metadata.chain function must only be called within the scope of a rule",
+		},
+		{
+			note:          "rego.metadata.rule() call",
+			query:         "rego.metadata.rule()",
+			expectedError: "rego.metadata.rule(): eval_builtin_error: rego.metadata.rule: the rego.metadata.rule function must only be called within the scope of a rule",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.note, func(t *testing.T) {
+			c := ast.NewCompiler()
+			q := NewQuery(ast.MustParseBody(tc.query)).WithCompiler(c).
+				WithStrictBuiltinErrors(true)
+			_, err := q.Run(context.Background())
+
+			if err == nil {
+				t.Fatalf("expected error")
+			}
+
+			if tc.expectedError != err.Error() {
+				t.Fatalf("expected error:\n\n%s\n\ngot:\n\n%s", tc.expectedError, err.Error())
+			}
+		})
+	}
+}
+
 func initTracerTestQuery() *Query {
 	ctx := context.Background()
 	store := inmem.New()


### PR DESCRIPTION
Returning error if rego.metadata.* functions are actually called

Fixes: #4587
Signed-off-by: Johan Fylling <johan.dev@fylling.se>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->
