### PR TITLE
format: don't add 'in' keyword import when 'every' is there

### DIFF
--- a/format/testfiles/test_in_operator_without_import.rego.formatted
+++ b/format/testfiles/test_in_operator_without_import.rego.formatted
@@ -1,6 +1,7 @@
 package p
 
 import future.keywords.in
+
 import input.foo
 
 r {

--- a/format/testfiles/test_issue_4606.rego
+++ b/format/testfiles/test_issue_4606.rego
@@ -1,0 +1,6 @@
+package p
+
+#
+import future.keywords.every
+
+r { 1 in [] }

--- a/format/testfiles/test_issue_4606.rego.formatted
+++ b/format/testfiles/test_issue_4606.rego.formatted
@@ -1,0 +1,8 @@
+package p
+
+#
+import future.keywords.every
+
+r {
+	1 in []
+}


### PR DESCRIPTION
Also ensure that added imports have a location set.

Previously, `opa fmt` on the added test file would have panicked
because the import hadn't had a location.

Fixes #4606.