### PR TITLE
format,eval: don't use source locations when formatting PE output

### DIFF
--- a/format/format.go
+++ b/format/format.go
@@ -14,6 +14,15 @@ import (
 	"github.com/open-policy-agent/opa/ast"
 )
 
+// Opts lets you control the code formatting via `AstWithOpts()`.
+type Opts struct {
+	// IgnoreLocations instructs the formatter not to use the AST nodes' locations
+	// into account when laying out the code: notably, when the input is the result
+	// of partial evaluation, arguments maybe have been shuffled around, but still
+	// carry along their original source locations.
+	IgnoreLocations bool
+}
+
 // defaultLocationFile is the file name used in `Ast()` for terms
 // without a location, as could happen when pretty-printing the
 // results of partial eval.
@@ -48,7 +57,10 @@ func MustAst(x interface{}) []byte {
 // element, Ast returns nil and an error. If AST nodes are missing locations
 // an arbitrary location will be used.
 func Ast(x interface{}) ([]byte, error) {
+	return AstWithOpts(x, Opts{})
+}
 
+func AstWithOpts(x interface{}, opts Opts) ([]byte, error) {
 	// The node has to be deep copied because it may be mutated below. Alternatively,
 	// we could avoid the copy by checking if mutation will occur first. For now,
 	// since format is not latency sensitive, just deep copy in all cases.
@@ -81,7 +93,8 @@ func Ast(x interface{}) ([]byte, error) {
 				extraFutureKeywordImports["every"] = struct{}{}
 			}
 		}
-		if x.Loc() == nil {
+
+		if opts.IgnoreLocations || x.Loc() == nil {
 			x.SetLoc(defaultLocation(x))
 		}
 		return false

--- a/format/format_test.go
+++ b/format/format_test.go
@@ -457,6 +457,17 @@ a[_x[y][[z, w]]]`,
 				t.Fatalf("Expected:\n\n%q\n\nGot:\n\n%q\n\n", expected, actual)
 			}
 		})
+
+		// consistency check: disregarding source locations, it shouldn't panic
+		t.Run("no_loc/"+tc.note, func(t *testing.T) {
+			_, err := AstWithOpts(tc.toFmt, Opts{IgnoreLocations: true})
+			if err != nil {
+				t.Fatalf("Unexpected error: %s", err)
+			}
+			if err != nil {
+				t.Fatalf("Unexpected error: %s", err)
+			}
+		})
 	}
 }
 

--- a/internal/presentation/presentation.go
+++ b/internal/presentation/presentation.go
@@ -346,7 +346,7 @@ func Source(w io.Writer, r Output) error {
 
 	for i := range r.Partial.Queries {
 		fmt.Fprintf(w, "# Query %d\n", i+1)
-		bs, err := format.Ast(r.Partial.Queries[i])
+		bs, err := format.AstWithOpts(r.Partial.Queries[i], format.Opts{IgnoreLocations: true})
 		if err != nil {
 			return err
 		}
@@ -355,7 +355,7 @@ func Source(w io.Writer, r Output) error {
 
 	for i := range r.Partial.Support {
 		fmt.Fprintf(w, "# Module %d\n", i+1)
-		bs, err := format.Ast(r.Partial.Support[i])
+		bs, err := format.AstWithOpts(r.Partial.Support[i], format.Opts{IgnoreLocations: true})
 		if err != nil {
 			return err
 		}
@@ -455,10 +455,11 @@ func prettyPartial(w io.Writer, pq *rego.PartialQueries) error {
 	return nil
 }
 
+// prettyASTNode is used for pretty-printing the result of partial eval
 func prettyASTNode(x interface{}) (string, int, error) {
-	bs, err := format.Ast(x)
+	bs, err := format.AstWithOpts(x, format.Opts{IgnoreLocations: true})
 	if err != nil {
-		return "", 0, fmt.Errorf("format error: %v", err)
+		return "", 0, fmt.Errorf("format error: %w", err)
 	}
 	var maxLineWidth int
 	s := strings.Trim(strings.Replace(string(bs), "\t", "  ", -1), "\n")


### PR DESCRIPTION
The presence of location-less nodes in the AST has been a problem before.

Most recently, it showed up here:
```
$ opa eval -p -fsource 'time.clock(input.x)==time.clock(input.y)'
# Query 1
time.clock(time.clock(input.x), input.y)
```

Fixes #4609.

What's intentionally left out for now is the bundle optimization path. While I still maintain that it's the proper thing to do; there may be more edge cases to consider, and I'd really like to fix the `opa eval -p` bug quickly.