### PR TITLE
ast+topdown+planner: non-built-in function mocking

### DIFF
--- a/docs/content/policy-language.md
+++ b/docs/content/policy-language.md
@@ -1487,7 +1487,7 @@ following syntax:
 ```
 
 The `<target>`s must be references to values in the input document (or the input
-document itself) or data document, or references to built-in functions.
+document itself) or data document, or references to functions (built-in or not).
 
 {{< info >}}
 When applied to the `data` document, the `<target>` must not attempt to
@@ -1516,7 +1516,7 @@ outer := result {
 }
 ```
 
-When `<target>` is a reference to a built-in function, like `http.send`, then
+When `<target>` is a reference to a function, like `http.send`, then
 its `<value>` can be any of the following:
 1. a value: `with http.send as {"body": {"success": true }}`
 2. a reference to another function: `with http.send as mock_http_send`
@@ -1533,10 +1533,10 @@ See the following example:
 package opa.examples
 import future.keywords.in
 
-f(x) = count(x)
+f(x) := count(x)
 
-mock_count(x) = 0 { "x" in x }
-mock_count(x) = count(x) { not "x" in x }
+mock_count(x) := 0 { "x" in x }
+mock_count(x) := count(x) { not "x" in x }
 ```
 
 ```live:with_builtins/1:query:merge_down
@@ -1558,12 +1558,12 @@ Each replacement function evaluation will start a new scope: it's valid to use
 package opa.examples
 import future.keywords.in
 
-f(x) = count(x) {
+f(x) := count(x) {
     rule_using_concat with concat as "foo,bar"
 }
 
-mock_count(x) = 0 { "x" in x }
-mock_count(x) = count(x) { not "x" in x }
+mock_count(x) := 0 { "x" in x }
+mock_count(x) := count(x) { not "x" in x }
 
 rule_using_concat {
     concat(",", input.x) == "foo,bar"

--- a/format/testfiles/test_with.rego
+++ b/format/testfiles/test_with.rego
@@ -23,3 +23,10 @@ func_replacements {
     with array.concat as true
     with count as mock_f
 }
+
+original(x) = x+1
+
+more_func_replacements {
+    original(1) with original as mock_f
+    original(1) with original as 1234
+}

--- a/format/testfiles/test_with.rego.formatted
+++ b/format/testfiles/test_with.rego.formatted
@@ -22,3 +22,10 @@ func_replacements {
 		with array.concat as true
 		with count as mock_f
 }
+
+original(x) = x + 1
+
+more_func_replacements {
+	original(1) with original as mock_f
+	original(1) with original as 1234
+}

--- a/internal/planner/rules.go
+++ b/internal/planner/rules.go
@@ -203,10 +203,10 @@ func (s *functionMocksStack) PopFrame() {
 	*current = (*current)[:len(*current)-1]
 }
 
-func (s *functionMocksStack) Lookup(builtinName string) *ast.Term {
+func (s *functionMocksStack) Lookup(f string) *ast.Term {
 	current := *s.stack[len(s.stack)-1]
 	for i := len(current) - 1; i >= 0; i-- {
-		if t, ok := current[i][builtinName]; ok {
+		if t, ok := current[i][f]; ok {
 			return t
 		}
 	}

--- a/test/cases/testdata/withkeyword/test-with-function-mock.yaml
+++ b/test/cases/testdata/withkeyword/test-with-function-mock.yaml
@@ -1,0 +1,110 @@
+cases:
+- data:
+  modules:
+  - |
+    package test
+    f(_) = 2
+    p = y {
+      y = f(true) with f as 1
+    }
+  note: 'withkeyword/function: direct call, value replacement, arity 1' # NOTE(sr): arity-0 functions fail typechecking
+  query: data.test.p = x
+  want_result:
+  - x: 1
+- data:
+  modules:
+  - |
+    package test
+    f(_) = 2
+    g(_) = 1
+    p = y {
+      y = f(true) with f as g
+    }
+  note: 'withkeyword/function: direct call, function replacement, arity 1'
+  query: data.test.p = x
+  want_result:
+  - x: 1
+- data:
+  modules:
+  - |
+    package test
+    f(_) = 2
+    g(_) = 1
+    p {
+      f(true, 1) with f as g
+    }
+  note: 'withkeyword/function: direct call, function replacement, arity 1, result captured'
+  query: data.test.p = x
+  want_result:
+  - x: true
+- data:
+  modules:
+  - |
+    package test
+    f(_) = 2
+    p = y {
+      y = f([1]) with f as count
+    }
+  note: 'withkeyword/function: direct call, built-in replacement, arity 1'
+  query: data.test.p = x
+  want_result:
+  - x: 1
+- data:
+  modules:
+  - |
+    package test
+    f(_) = 2
+    p {
+      f([1], 1) with f as count
+    }
+  note: 'withkeyword/function: direct call, built-in replacement, arity 1, result captured'
+  query: data.test.p = x
+  want_result:
+  - x: true
+- data:
+  modules:
+  - |
+    package test
+
+    f1(x) = object.union_n(x)
+    f2(x) = count(x)
+    f3(x) = array.reverse(x)
+    f(x) = f1(x)
+    g(x) = 123 {
+      f2(x)
+      s with f3 as h
+    }
+    h(_) = ["replaced"]
+    p { q with f1 as f }
+    q { r with f2 as g }
+    r { x := [{"foo": 4}, {"baz": 5}]; f2(x) == 123; f1(x) == {"foo": 4, "baz": 5} }
+    s { x := [{}]; f3(x) == ["replaced"] }
+  note: 'withkeyword/function: nested scope handling'
+  query: data.test.p = x
+  want_result:
+  - x: true
+- data:
+  modules:
+  - |
+    package test
+
+    f(x) = 2
+    g(x) = f(x)
+    p = y { y := f(1) with f as g }
+  note: 'withkeyword/function: simple scope handling (no recursion here)'
+  query: data.test.p = x
+  want_result:
+  - x: 2
+- data:
+  modules:
+  - |
+    package test
+
+    f(_) = 1 {
+      input.x = "x"
+    }
+    p = y { y := f(1) with f as 2 }
+  note: 'withkeyword/function: rule indexing irrelevant'
+  query: data.test.p = x
+  want_result:
+  - x: 2

--- a/topdown/cache.go
+++ b/topdown/cache.go
@@ -280,10 +280,10 @@ func (s *functionMocksStack) Put(el frame) {
 	*current = append(*current, el)
 }
 
-func (s *functionMocksStack) Get(builtinName string) (*ast.Term, bool) {
+func (s *functionMocksStack) Get(f ast.Ref) (*ast.Term, bool) {
 	current := *s.stack[len(s.stack)-1]
 	for i := len(current) - 1; i >= 0; i-- {
-		if r, ok := current[i][builtinName]; ok {
+		if r, ok := current[i][f.String()]; ok {
 			return r, true
 		}
 	}


### PR DESCRIPTION
Follow-up to https://github.com/open-policy-agent/opa/pull/4540

We can now mock functions that are user-defined:

    package test

    f(_) = 1 {
        input.x = "x"
    }
    p = y {
        y := f(1) with f as 2
    }

...following the same scoping rules as laid out for built-in mocks.
The replacement can be a value (replacing all calls), or a built-in,
or another non-built-in function.

Also addresses bugs in the previous slice:
* topdown/evalCall: account for empty rules result from indexer
* topdown/eval: capture value replacement in PE could panic

Note: in PE, we now drop 'with' for function mocks of any kind:

These are always fully replaced in the saved support modules, so
this should be OK.

When keeping them, we'd also have to either copy the existing definitions
into the support module; or create a function stub in it.

Fixes https://github.com/open-policy-agent/opa/issues/4449.