### PR TITLE
website: add playground button to navbar

### DIFF
--- a/docs/website/layouts/partials/docs/navbar.html
+++ b/docs/website/layouts/partials/docs/navbar.html
@@ -120,6 +120,12 @@
         </p>
       </div>
 
+      <div class="navbar-item">
+        <a class="button is-success has-text-weight-semibold" href="https://play.openpolicyagent.org/" target="_blank" title="Playground">
+          Playground
+        </a>
+      </div>
+
       <a class="navbar-item" href="{{ $github }}" target="_blank" title="GitHub">
         <span class="icon has-text-white-bis">
           <i class="fab fa-github"></i>


### PR DESCRIPTION
Addressing one tiny bit of #4614.

<img width="621" alt="image" src="https://user-images.githubusercontent.com/870638/165302319-568d84ef-0487-40c0-a303-527bc63c6b85.png">
