### PR TITLE
Dockerfile: add source annotation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ ARG BASE
 FROM ${BASE}
 
 LABEL org.opencontainers.image.authors="Torin Sandall <torinsandall@gmail.com>"
+LABEL org.opencontainers.image.source="https://github.com/open-policy-agent/opa"
 
 # Temporarily allow us to identify whether running from within an offical
 # Docker image, so that we may print a warning when uid or gid == 0 (root)


### PR DESCRIPTION
Small fry. Playing with github's registry made me aware of this:

<img width="738" alt="image" src="https://user-images.githubusercontent.com/870638/165472817-548128a7-f816-4678-a509-0ee3f0372a4f.png">
