### PR TITLE
bundle/status: Include bundle type in status information

### DIFF
--- a/plugins/bundle/plugin.go
+++ b/plugins/bundle/plugin.go
@@ -375,6 +375,7 @@ func (p *Plugin) loadAndActivateBundlesFromDisk(ctx context.Context) {
 		numActivatedBundles := 0
 		for name, b := range persistedBundles {
 			p.status[name].Metrics = metrics.New()
+			p.status[name].Type = b.Type()
 
 			err := p.activate(ctx, name, b)
 			if err != nil {
@@ -474,6 +475,7 @@ func (p *Plugin) process(ctx context.Context, name string, u download.Update) {
 	p.status[name].LastSuccessfulRequest = p.status[name].LastRequest
 
 	if u.Bundle != nil {
+		p.status[name].Type = u.Bundle.Type()
 		p.status[name].LastSuccessfulDownload = p.status[name].LastSuccessfulRequest
 
 		p.status[name].Metrics.Timer(metrics.RegoLoadBundles).Start()

--- a/plugins/bundle/plugin_test.go
+++ b/plugins/bundle/plugin_test.go
@@ -71,6 +71,12 @@ func TestPluginOneShot(t *testing.T) {
 
 	ensurePluginState(t, plugin, plugins.StateOK)
 
+	if status, ok := plugin.status[bundleName]; !ok {
+		t.Fatalf("Expected to find status for %s, found nil", bundleName)
+	} else if status.Type != bundle.SnapshotBundleType {
+		t.Fatalf("expected snapshot bundle but got %v", status.Type)
+	}
+
 	txn := storage.NewTransactionOrDie(ctx, manager.Store)
 	defer manager.Store.Abort(ctx, txn)
 
@@ -261,6 +267,12 @@ func TestPluginOneShotDeltaBundle(t *testing.T) {
 	plugin.process(ctx, bundleName, download.Update{Bundle: &b2, Metrics: metrics.New()})
 
 	ensurePluginState(t, plugin, plugins.StateOK)
+
+	if status, ok := plugin.status[bundleName]; !ok {
+		t.Fatalf("Expected to find status for %s, found nil", bundleName)
+	} else if status.Type != bundle.DeltaBundleType {
+		t.Fatalf("expected delta bundle but got %v", status.Type)
+	}
 
 	txn := storage.NewTransactionOrDie(ctx, manager.Store)
 	defer manager.Store.Abort(ctx, txn)

--- a/plugins/bundle/status.go
+++ b/plugins/bundle/status.go
@@ -26,6 +26,7 @@ type Status struct {
 	Name                     string          `json:"name"`
 	ActiveRevision           string          `json:"active_revision,omitempty"`
 	LastSuccessfulActivation time.Time       `json:"last_successful_activation,omitempty"`
+	Type                     string          `json:"type,omitempty"`
 	LastSuccessfulDownload   time.Time       `json:"last_successful_download,omitempty"`
 	LastSuccessfulRequest    time.Time       `json:"last_successful_request,omitempty"`
 	LastRequest              time.Time       `json:"last_request,omitempty"`

--- a/plugins/discovery/discovery.go
+++ b/plugins/discovery/discovery.go
@@ -188,6 +188,7 @@ func (c *Discovery) processUpdate(ctx context.Context, u download.Update) {
 	c.status.LastSuccessfulRequest = c.status.LastRequest
 
 	if u.Bundle != nil {
+		c.status.Type = u.Bundle.Type()
 		c.status.LastSuccessfulDownload = c.status.LastSuccessfulRequest
 
 		if err := c.reconfigure(ctx, u); err != nil {


### PR DESCRIPTION
OPA has support for Delta Bundles. The status object already
contains valuable information such as last activation timestamp but
does not specify if the bundle was a canonical snapshot or delta.

This change updates the bundle.Status object to include the
bundle type string: either "snapshot" or "delta". This can be useful
for status endpoints to differentiate between the bundle types.

Issue: 4477

Signed-off-by: Bryan Fulton <bryan@styra.com>