### PR TITLE
ci: only run code build/test when not docs-only PR

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -1,6 +1,9 @@
 name: PR Check
 
-on: [pull_request]
+on:
+  pull_request:
+    paths-ignore:
+    - "docs/**"
 
 jobs:
   # All jobs essentially re-create the `ci-release-test` make target, but are split


### PR DESCRIPTION
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-excluding-paths

Another experiment in improving developer experience when it comes
to docs changes. The contributor shouldn't have to wait 10 minutes
for the golang benchmarks, or be confused by flakey macos tests if
the contribution is for docs.

Since the docs build still _builds_ the golang binary (for live-blocks)
we're not depending the GHA in the netlify job.
