### PR TITLE
Fix opa fmt location for non-key rules

### DIFF
--- a/format/format.go
+++ b/format/format.go
@@ -300,8 +300,10 @@ func (w *writer) writeRule(rule *ast.Rule, isElse bool, comments []*ast.Comment)
 
 	if len(rule.Head.Args) > 0 {
 		closeLoc = closingLoc('(', ')', '{', '}', rule.Location)
-	} else {
+	} else if rule.Head.Key != nil {
 		closeLoc = closingLoc('[', ']', '{', '}', rule.Location)
+	} else {
+		closeLoc = closingLoc(0, 0, '{', '}', rule.Location)
 	}
 
 	comments = w.insertComments(comments, closeLoc)

--- a/format/testfiles/test_end_of_rule_comment.rego
+++ b/format/testfiles/test_end_of_rule_comment.rego
@@ -1,0 +1,7 @@
+package foo
+
+bar {
+	# before
+	input.bar
+	# after
+}

--- a/format/testfiles/test_end_of_rule_comment.rego.formatted
+++ b/format/testfiles/test_end_of_rule_comment.rego.formatted
@@ -1,0 +1,7 @@
+package foo
+
+bar {
+	# before
+	input.bar
+	# after
+}

--- a/format/testfiles/test_issue_2299.rego
+++ b/format/testfiles/test_issue_2299.rego
@@ -25,7 +25,8 @@ else = z {
 # Mixed compact and newline separated
 p = x {
     foo == "bar"
-} # some special case
+}
+# some special case
 # with lots of comments
 # describing it
 else = y {


### PR DESCRIPTION
Running the following through `opa fmt`:

    package foo

    bar {
    	# before
    	input.bar
    	# after
    }

Causes the `after` comment to be moved outside of the rule:

    package foo

    bar {
    	# before
    	input.bar
    }

    # after

This was caused by `skipPast` in `closingLoc` being called even when there is no
`[key]` part in the rule head.  Adding a third clause fixed this; it seems
like `closingLoc` is designed to take `0` in this case because of the
`skipOpen > 0`.

This did affect one other test case, where I had to add an extra newline
to separate the comment from the rule head.  Without that, `insertComments`
(correctly, I guess) inserts:

    } # some special case

Signed-off-by: Jasper Van der Jeugt <m@jaspervdj.be>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->
