### PR TITLE
test/units: Add "units_" prefix to units-related tests.

### DIFF
--- a/test/cases/testdata/units/test-parse-bytes-comparisons.yaml
+++ b/test/cases/testdata/units/test-parse-bytes-comparisons.yaml
@@ -6,7 +6,7 @@ cases:
     p {
         units.parse_bytes("8kb") > units.parse_bytes("7kb")
     }
-  note: parse_bytes/comparison
+  note: units_parse_bytes/comparison
   query: data.test.p = x
   want_result:
   - x: true
@@ -17,7 +17,7 @@ cases:
     p {
         units.parse_bytes("8gb") > units.parse_bytes("8mb")
     }
-  note: parse_bytes/comparison
+  note: units_parse_bytes/comparison
   query: data.test.p = x
   want_result:
   - x: true
@@ -28,7 +28,7 @@ cases:
     p {
         units.parse_bytes("1234kb") < units.parse_bytes("1gb")
     }
-  note: parse_bytes/comparison
+  note: units_parse_bytes/comparison
   query: data.test.p = x
   want_result:
   - x: true
@@ -39,7 +39,7 @@ cases:
     p {
         units.parse_bytes("1024") == units.parse_bytes("1KiB")
     }
-  note: parse_bytes/comparison
+  note: units_parse_bytes/comparison
   query: data.test.p = x
   want_result:
   - x: true
@@ -50,7 +50,7 @@ cases:
     p {
         units.parse_bytes("2MiB") == units.parse_bytes("2097152")
     }
-  note: parse_bytes/comparison
+  note: units_parse_bytes/comparison
   query: data.test.p = x
   want_result:
   - x: true
@@ -61,7 +61,7 @@ cases:
     p {
         units.parse_bytes("3MiB") > units.parse_bytes("3MB")
     }
-  note: parse_bytes/comparison
+  note: units_parse_bytes/comparison
   query: data.test.p = x
   want_result:
   - x: true
@@ -72,7 +72,7 @@ cases:
     p {
         units.parse_bytes("2MiB") == units.parse_bytes("2Mi")
     }
-  note: parse_bytes/comparison
+  note: units_parse_bytes/comparison
   query: data.test.p = x
   want_result:
   - x: true
@@ -83,7 +83,7 @@ cases:
     p {
         units.parse_bytes("4Mi") > units.parse_bytes("4M")
     }
-  note: parse_bytes/comparison
+  note: units_parse_bytes/comparison
   query: data.test.p = x
   want_result:
   - x: true
@@ -94,7 +94,7 @@ cases:
     p {
         units.parse_bytes("4.1Mi") > units.parse_bytes("4Mi")
     }
-  note: parse_bytes/comparison
+  note: units_parse_bytes/comparison
   query: data.test.p = x
   want_result:
   - x: true
@@ -105,7 +105,7 @@ cases:
     p {
         units.parse_bytes("128Gi") == units.parse_bytes("137438953472")
     }
-  note: parse_bytes/comparison
+  note: units_parse_bytes/comparison
   query: data.test.p = x
   want_result:
   - x: true

--- a/test/cases/testdata/units/test-parse-bytes-errors.yaml
+++ b/test/cases/testdata/units/test-parse-bytes-errors.yaml
@@ -6,7 +6,7 @@ cases:
     p {
         units.parse_bytes("")
     }
-  note: parse_bytes/failure
+  note: units_parse_bytes/failure
   query: data.test.p = x
   want_error: "units.parse_bytes error: no byte amount provided"
   strict_error: true
@@ -17,7 +17,7 @@ cases:
     p {
         units.parse_bytes("GB")
     }
-  note: parse_bytes/failure
+  note: units_parse_bytes/failure
   query: data.test.p = x
   want_error: "units.parse_bytes error: no byte amount provided"
   strict_error: true
@@ -28,7 +28,7 @@ cases:
     p {
         units.parse_bytes("foo")
     }
-  note: parse_bytes/failure
+  note: units_parse_bytes/failure
   query: data.test.p = x
   want_error: "units.parse_bytes error: no byte amount provided"
   strict_error: true
@@ -39,7 +39,7 @@ cases:
     p {
         units.parse_bytes("0.0.0")
     }
-  note: parse_bytes/failure
+  note: units_parse_bytes/failure
   query: data.test.p = x
   want_error: "units.parse_bytes error: could not parse byte amount to a number"
   strict_error: true
@@ -50,7 +50,7 @@ cases:
     p {
         units.parse_bytes(".5.2")
     }
-  note: parse_bytes/failure
+  note: units_parse_bytes/failure
   query: data.test.p = x
   want_error: "units.parse_bytes error: could not parse byte amount to a number"
   strict_error: true
@@ -61,7 +61,7 @@ cases:
     p {
         units.parse_bytes("100 kb")
     }
-  note: parse_bytes/failure
+  note: units_parse_bytes/failure
   query: data.test.p = x
   want_error: "units.parse_bytes error: spaces not allowed in resource strings"
   strict_error: true
@@ -72,7 +72,7 @@ cases:
     p {
         units.parse_bytes(" 327MiB ")
     }
-  note: parse_bytes/failure
+  note: units_parse_bytes/failure
   query: data.test.p = x
   want_error: "units.parse_bytes error: spaces not allowed in resource strings"
   strict_error: true

--- a/test/cases/testdata/units/test-parse-bytes.yaml
+++ b/test/cases/testdata/units/test-parse-bytes.yaml
@@ -6,7 +6,7 @@ cases:
     p {
         units.parse_bytes("\"100TIB\"") == 109951162777600
     }
-  note: parse_bytes/removes quotes and lowercases string
+  note: units_parse_bytes/removes quotes and lowercases string
   query: data.test.p = x
   want_result:
   - x: true
@@ -17,7 +17,7 @@ cases:
     p {
         units.parse_bytes("0") == 0
     }
-  note: parse_bytes/zero
+  note: units_parse_bytes/zero
   query: data.test.p = x
   want_result:
   - x: true
@@ -29,7 +29,7 @@ cases:
     p {
         units.parse_bytes("0.0") == 0
     }
-  note: parse_bytes/zero float
+  note: units_parse_bytes/zero float
   query: data.test.p = x
   want_result:
   - x: true
@@ -41,7 +41,7 @@ cases:
     p {
         units.parse_bytes(".0") == 0
     }
-  note: parse_bytes/zero bare float
+  note: units_parse_bytes/zero bare float
   query: data.test.p = x
   want_result:
   - x: true
@@ -53,7 +53,7 @@ cases:
     p {
         units.parse_bytes("12345") == 12345
     }
-  note: parse_bytes/raw number
+  note: units_parse_bytes/raw number
   query: data.test.p = x
   want_result:
   - x: true
@@ -65,7 +65,7 @@ cases:
     p {
         units.parse_bytes("10KB") == 10000
     }
-  note: parse_bytes/10 kilobytes uppercase
+  note: units_parse_bytes/10 kilobytes uppercase
   query: data.test.p = x
   want_result:
   - x: true
@@ -77,7 +77,7 @@ cases:
     p {
         units.parse_bytes("10KIB") == 10240
     }
-  note: parse_bytes/10 KiB uppercase
+  note: units_parse_bytes/10 KiB uppercase
   query: data.test.p = x
   want_result:
   - x: true
@@ -89,7 +89,7 @@ cases:
     p {
         units.parse_bytes("10kb") == 10000
     }
-  note: parse_bytes/10 KB lowercase
+  note: units_parse_bytes/10 KB lowercase
   query: data.test.p = x
   want_result:
   - x: true
@@ -101,7 +101,7 @@ cases:
     p {
         units.parse_bytes("10Kib") == 10240
     }
-  note: parse_bytes/10 KiB mixed case
+  note: units_parse_bytes/10 KiB mixed case
   query: data.test.p = x
   want_result:
   - x: true
@@ -113,7 +113,7 @@ cases:
     p {
         units.parse_bytes("200mb") == 200000000
     }
-  note: parse_bytes/200 megabytes as mb
+  note: units_parse_bytes/200 megabytes as mb
   query: data.test.p = x
   want_result:
   - x: true
@@ -125,7 +125,7 @@ cases:
     p {
         units.parse_bytes("300GiB") == 322122547200
     }
-  note: parse_bytes/300 GiB
+  note: units_parse_bytes/300 GiB
   query: data.test.p = x
   want_result:
   - x: true
@@ -137,7 +137,7 @@ cases:
     p {
         units.parse_bytes("1.1KB") == 1100
     }
-  note: parse_bytes/1.1 KB floating point
+  note: units_parse_bytes/1.1 KB floating point
   query: data.test.p = x
   want_result:
   - x: true
@@ -149,7 +149,7 @@ cases:
     p {
         units.parse_bytes("1.1KiB") == 1126
     }
-  note: parse_bytes/1.1 KiB floating point rounded
+  note: units_parse_bytes/1.1 KiB floating point rounded
   query: data.test.p = x
   want_result:
   - x: true
@@ -161,7 +161,7 @@ cases:
     p {
         units.parse_bytes(".5KB") == 500
     }
-  note: parse_bytes/.5 KB bare floating point
+  note: units_parse_bytes/.5 KB bare floating point
   query: data.test.p = x
   want_result:
   - x: true
@@ -173,7 +173,7 @@ cases:
     p {
         units.parse_bytes("100k") == 100000
     }
-  note: parse_bytes/100 kilobytes as k
+  note: units_parse_bytes/100 kilobytes as k
   query: data.test.p = x
   want_result:
   - x: true
@@ -185,7 +185,7 @@ cases:
     p {
         units.parse_bytes("100kb") == 100000
     }
-  note: parse_bytes/100 kilobytes as kb
+  note: units_parse_bytes/100 kilobytes as kb
   query: data.test.p = x
   want_result:
   - x: true
@@ -197,7 +197,7 @@ cases:
     p {
         units.parse_bytes("100ki") == 102400
     }
-  note: parse_bytes/100 kibibytes as ki
+  note: units_parse_bytes/100 kibibytes as ki
   query: data.test.p = x
   want_result:
   - x: true
@@ -209,7 +209,7 @@ cases:
     p {
         units.parse_bytes("100kib") == 102400
     }
-  note: parse_bytes/100 kibibytes as kib
+  note: units_parse_bytes/100 kibibytes as kib
   query: data.test.p = x
   want_result:
   - x: true
@@ -221,7 +221,7 @@ cases:
     p {
         units.parse_bytes("100m") == 100000000
     }
-  note: parse_bytes/100 megabytes as m
+  note: units_parse_bytes/100 megabytes as m
   query: data.test.p = x
   want_result:
   - x: true
@@ -233,7 +233,7 @@ cases:
     p {
         units.parse_bytes("100mb") == 100000000
     }
-  note: parse_bytes/100 megabytes as mb
+  note: units_parse_bytes/100 megabytes as mb
   query: data.test.p = x
   want_result:
   - x: true
@@ -245,7 +245,7 @@ cases:
     p {
         units.parse_bytes("100mi") == 104857600
     }
-  note: parse_bytes/100 mebibytes as mi
+  note: units_parse_bytes/100 mebibytes as mi
   query: data.test.p = x
   want_result:
   - x: true
@@ -257,7 +257,7 @@ cases:
     p {
         units.parse_bytes("100mib") == 104857600
     }
-  note: parse_bytes/100 mebibytes as mib
+  note: units_parse_bytes/100 mebibytes as mib
   query: data.test.p = x
   want_result:
   - x: true
@@ -269,7 +269,7 @@ cases:
     p {
         units.parse_bytes("100g") == 100000000000
     }
-  note: parse_bytes/100 gigabytes as g
+  note: units_parse_bytes/100 gigabytes as g
   query: data.test.p = x
   want_result:
   - x: true
@@ -281,7 +281,7 @@ cases:
     p {
         units.parse_bytes("100gb") == 100000000000
     }
-  note: parse_bytes/100 gigabytes as gb
+  note: units_parse_bytes/100 gigabytes as gb
   query: data.test.p = x
   want_result:
   - x: true
@@ -293,7 +293,7 @@ cases:
     p {
         units.parse_bytes("100gi") == 107374182400
     }
-  note: parse_bytes/100 gibibytes as gi
+  note: units_parse_bytes/100 gibibytes as gi
   query: data.test.p = x
   want_result:
   - x: true
@@ -305,7 +305,7 @@ cases:
     p {
         units.parse_bytes("100gib") == 107374182400
     }
-  note: parse_bytes/100 gibibytes as gib
+  note: units_parse_bytes/100 gibibytes as gib
   query: data.test.p = x
   want_result:
   - x: true
@@ -317,7 +317,7 @@ cases:
     p {
         units.parse_bytes("100t") == 100000000000000
     }
-  note: parse_bytes/100 terabytes as t
+  note: units_parse_bytes/100 terabytes as t
   query: data.test.p = x
   want_result:
   - x: true
@@ -329,7 +329,7 @@ cases:
     p {
         units.parse_bytes("100tb") == 100000000000000
     }
-  note: parse_bytes/100 terabytes as tb
+  note: units_parse_bytes/100 terabytes as tb
   query: data.test.p = x
   want_result:
   - x: true
@@ -341,7 +341,7 @@ cases:
     p {
         units.parse_bytes("100ti") == 109951162777600
     }
-  note: parse_bytes/100 tebibytes as ti
+  note: units_parse_bytes/100 tebibytes as ti
   query: data.test.p = x
   want_result:
   - x: true
@@ -353,7 +353,7 @@ cases:
     p {
         units.parse_bytes("100tib") == 109951162777600
     }
-  note: parse_bytes/100 tebibytes as tib
+  note: units_parse_bytes/100 tebibytes as tib
   query: data.test.p = x
   want_result:
   - x: true
@@ -365,7 +365,7 @@ cases:
     p {
         units.parse_bytes("100p") == 100000000000000000
     }
-  note: parse_bytes/100 petabytes as p
+  note: units_parse_bytes/100 petabytes as p
   query: data.test.p = x
   want_result:
   - x: true
@@ -377,7 +377,7 @@ cases:
     p {
         units.parse_bytes("100pb") == 100000000000000000
     }
-  note: parse_bytes/100 petabytes as pb
+  note: units_parse_bytes/100 petabytes as pb
   query: data.test.p = x
   want_result:
   - x: true
@@ -389,7 +389,7 @@ cases:
     p {
         units.parse_bytes("100pi") == 112589990684262400
     }
-  note: parse_bytes/100 pebibytes as pi
+  note: units_parse_bytes/100 pebibytes as pi
   query: data.test.p = x
   want_result:
   - x: true
@@ -401,7 +401,7 @@ cases:
     p {
         units.parse_bytes("100pib") == 112589990684262400
     }
-  note: parse_bytes/100 pebibytes as pib
+  note: units_parse_bytes/100 pebibytes as pib
   query: data.test.p = x
   want_result:
   - x: true
@@ -413,7 +413,7 @@ cases:
     p {
         units.parse_bytes("10e") == 10000000000000000000
     }
-  note: parse_bytes/10 etabytes as e
+  note: units_parse_bytes/10 etabytes as e
   query: data.test.p = x
   want_result:
   - x: true
@@ -425,7 +425,7 @@ cases:
     p {
         units.parse_bytes("10eb") == 10000000000000000000
     }
-  note: parse_bytes/10 etabytes as eb
+  note: units_parse_bytes/10 etabytes as eb
   query: data.test.p = x
   want_result:
   - x: true
@@ -437,7 +437,7 @@ cases:
     p {
         units.parse_bytes("10ei") == 11529215046068469760
     }
-  note: parse_bytes/10 ebibytes as ei
+  note: units_parse_bytes/10 ebibytes as ei
   query: data.test.p = x
   want_result:
   - x: true
@@ -449,7 +449,7 @@ cases:
     p {
         units.parse_bytes("10eib") == 11529215046068469760
     }
-  note: parse_bytes/10 ebibytes as eib
+  note: units_parse_bytes/10 ebibytes as eib
   query: data.test.p = x
   want_result:
   - x: true

--- a/test/cases/testdata/units/test-parse-units-comparisons.yaml
+++ b/test/cases/testdata/units/test-parse-units-comparisons.yaml
@@ -6,7 +6,7 @@ cases:
     p {
         units.parse("8k") > units.parse("7k")
     }
-  note: parse/comparison
+  note: units_parse/comparison
   query: data.test.p = x
   want_result:
   - x: true
@@ -17,7 +17,7 @@ cases:
     p {
         units.parse("8g") > units.parse("8m")
     }
-  note: parse/comparison
+  note: units_parse/comparison
   query: data.test.p = x
   want_result:
   - x: true
@@ -28,7 +28,7 @@ cases:
     p {
         units.parse("1234k") < units.parse("1g")
     }
-  note: parse/comparison
+  note: units_parse/comparison
   query: data.test.p = x
   want_result:
   - x: true
@@ -39,7 +39,7 @@ cases:
     p {
         units.parse("1024") == units.parse("1Ki")
     }
-  note: parse/comparison
+  note: units_parse/comparison
   query: data.test.p = x
   want_result:
   - x: true
@@ -50,7 +50,7 @@ cases:
     p {
         units.parse("2Mi") == units.parse("2097152")
     }
-  note: parse/comparison
+  note: units_parse/comparison
   query: data.test.p = x
   want_result:
   - x: true
@@ -61,7 +61,7 @@ cases:
     p {
         units.parse("3Mi") > units.parse("3M")
     }
-  note: parse/comparison
+  note: units_parse/comparison
   query: data.test.p = x
   want_result:
   - x: true
@@ -72,7 +72,7 @@ cases:
     p {
         units.parse("2Mi") == units.parse("2Mi")
     }
-  note: parse/comparison
+  note: units_parse/comparison
   query: data.test.p = x
   want_result:
   - x: true
@@ -83,7 +83,7 @@ cases:
     p {
         units.parse("4Mi") > units.parse("4M")
     }
-  note: parse/comparison
+  note: units_parse/comparison
   query: data.test.p = x
   want_result:
   - x: true
@@ -94,7 +94,7 @@ cases:
     p {
         units.parse("4.1Mi") > units.parse("4Mi")
     }
-  note: parse/comparison
+  note: units_parse/comparison
   query: data.test.p = x
   want_result:
   - x: true
@@ -105,7 +105,7 @@ cases:
     p {
         units.parse("128Gi") == units.parse("137438953472")
     }
-  note: parse/comparison
+  note: units_parse/comparison
   query: data.test.p = x
   want_result:
   - x: true

--- a/test/cases/testdata/units/test-parse-units-errors.yaml
+++ b/test/cases/testdata/units/test-parse-units-errors.yaml
@@ -6,7 +6,7 @@ cases:
     p {
         units.parse("")
     }
-  note: parse/failure
+  note: units_parse/failure
   query: data.test.p = x
   want_error: "units.parse error: no amount provided"
   strict_error: true
@@ -17,7 +17,7 @@ cases:
     p {
         units.parse("G")
     }
-  note: parse/failure
+  note: units_parse/failure
   query: data.test.p = x
   want_error: "units.parse error: no amount provided"
   strict_error: true
@@ -28,7 +28,7 @@ cases:
     p {
         units.parse("foo")
     }
-  note: parse/failure
+  note: units_parse/failure
   query: data.test.p = x
   want_error: "units.parse error: no amount provided"
   strict_error: true
@@ -39,7 +39,7 @@ cases:
     p {
         units.parse("0.0.0")
     }
-  note: parse/failure
+  note: units_parse/failure
   query: data.test.p = x
   want_error: "units.parse error: could not parse amount to a number"
   strict_error: true
@@ -50,7 +50,7 @@ cases:
     p {
         units.parse(".5.2")
     }
-  note: parse/failure
+  note: units_parse/failure
   query: data.test.p = x
   want_error: "units.parse error: could not parse amount to a number"
   strict_error: true
@@ -61,7 +61,7 @@ cases:
     p {
         units.parse("100 k")
     }
-  note: parse/failure
+  note: units_parse/failure
   query: data.test.p = x
   want_error: "units.parse error: spaces not allowed in resource strings"
   strict_error: true
@@ -72,7 +72,7 @@ cases:
     p {
         units.parse(" 327Mi ")
     }
-  note: parse/failure
+  note: units_parse/failure
   query: data.test.p = x
   want_error: "units.parse error: spaces not allowed in resource strings"
   strict_error: true

--- a/test/cases/testdata/units/test-parse-units.yaml
+++ b/test/cases/testdata/units/test-parse-units.yaml
@@ -6,7 +6,7 @@ cases:
     p {
         units.parse("\"100TI\"") == 109951162777600
     }
-  note: parse/removes quotes and lowercases string
+  note: units_parse/removes quotes and lowercases string
   query: data.test.p = x
   want_result:
   - x: true
@@ -17,7 +17,7 @@ cases:
     p {
         units.parse("0") == 0
     }
-  note: parse/zero
+  note: units_parse/zero
   query: data.test.p = x
   want_result:
   - x: true
@@ -29,7 +29,7 @@ cases:
     p {
         units.parse("0.0") == 0
     }
-  note: parse/zero float
+  note: units_parse/zero float
   query: data.test.p = x
   want_result:
   - x: true
@@ -41,7 +41,7 @@ cases:
     p {
         units.parse(".0") == 0
     }
-  note: parse/zero bare float
+  note: units_parse/zero bare float
   query: data.test.p = x
   want_result:
   - x: true
@@ -53,7 +53,7 @@ cases:
     p {
         units.parse("12345") == 12345
     }
-  note: parse/raw number
+  note: units_parse/raw number
   query: data.test.p = x
   want_result:
   - x: true
@@ -65,7 +65,7 @@ cases:
     p {
         units.parse("10K") == 10000
     }
-  note: parse/10 kilo uppercase
+  note: units_parse/10 kilo uppercase
   query: data.test.p = x
   want_result:
   - x: true
@@ -77,7 +77,7 @@ cases:
     p {
         units.parse("10KI") == 10240
     }
-  note: parse/10 Ki uppercase
+  note: units_parse/10 Ki uppercase
   query: data.test.p = x
   want_result:
   - x: true
@@ -89,7 +89,7 @@ cases:
     p {
         units.parse("10k") == 10000
     }
-  note: parse/10 K lowercase
+  note: units_parse/10 K lowercase
   query: data.test.p = x
   want_result:
   - x: true
@@ -101,7 +101,7 @@ cases:
     p {
         units.parse("10Ki") == 10240
     }
-  note: parse/10 Ki mixed case
+  note: units_parse/10 Ki mixed case
   query: data.test.p = x
   want_result:
   - x: true
@@ -113,7 +113,7 @@ cases:
     p {
         units.parse("200M") == 200000000
     }
-  note: parse/200 mega
+  note: units_parse/200 mega
   query: data.test.p = x
   want_result:
   - x: true
@@ -125,7 +125,7 @@ cases:
     p {
         units.parse("300Gi") == 322122547200
     }
-  note: parse/300 Gi
+  note: units_parse/300 Gi
   query: data.test.p = x
   want_result:
   - x: true
@@ -137,7 +137,7 @@ cases:
     p {
         units.parse("1.1K") == 1100
     }
-  note: parse/1.1 K floating point
+  note: units_parse/1.1 K floating point
   query: data.test.p = x
   want_result:
   - x: true
@@ -149,7 +149,7 @@ cases:
     p {
         units.parse("1.1Ki") == 1126.4
     }
-  note: parse/1.1 Ki floating point, not rounded
+  note: units_parse/1.1 Ki floating point, not rounded
   query: data.test.p = x
   want_result:
   - x: true
@@ -161,7 +161,7 @@ cases:
     p {
         units.parse(".5K") == 500
     }
-  note: parse/.5 K bare floating point
+  note: units_parse/.5 K bare floating point
   query: data.test.p = x
   want_result:
   - x: true
@@ -173,7 +173,7 @@ cases:
     p {
         units.parse("100k") == 100000
     }
-  note: parse/100 kilo as k
+  note: units_parse/100 kilo as k
   query: data.test.p = x
   want_result:
   - x: true
@@ -185,7 +185,7 @@ cases:
     p {
         units.parse("100K") == 100000
     }
-  note: parse/100 kilo as K
+  note: units_parse/100 kilo as K
   query: data.test.p = x
   want_result:
   - x: true
@@ -197,7 +197,7 @@ cases:
     p {
         units.parse("100ki") == 102400
     }
-  note: parse/100 kibi as ki
+  note: units_parse/100 kibi as ki
   query: data.test.p = x
   want_result:
   - x: true
@@ -209,7 +209,7 @@ cases:
     p {
         units.parse("100Ki") == 102400
     }
-  note: parse/100 kibi as Ki
+  note: units_parse/100 kibi as Ki
   query: data.test.p = x
   want_result:
   - x: true
@@ -221,7 +221,7 @@ cases:
     p {
         round(units.parse("100m") * 1000) == 100
     }
-  note: parse/100 milli as m
+  note: units_parse/100 milli as m
   query: data.test.p = x
   want_result:
   - x: true
@@ -233,7 +233,7 @@ cases:
     p {
         units.parse("100M") == 100000000
     }
-  note: parse/100 mega as M
+  note: units_parse/100 mega as M
   query: data.test.p = x
   want_result:
   - x: true
@@ -245,7 +245,7 @@ cases:
     p {
         units.parse("100mi") == 104857600
     }
-  note: parse/100 mebi as mi
+  note: units_parse/100 mebi as mi
   query: data.test.p = x
   want_result:
   - x: true
@@ -257,7 +257,7 @@ cases:
     p {
         units.parse("100Mi") == 104857600
     }
-  note: parse/100 mebi as Mi
+  note: units_parse/100 mebi as Mi
   query: data.test.p = x
   want_result:
   - x: true
@@ -269,7 +269,7 @@ cases:
     p {
         units.parse("100g") == 100000000000
     }
-  note: parse/100 giga as g
+  note: units_parse/100 giga as g
   query: data.test.p = x
   want_result:
   - x: true
@@ -281,7 +281,7 @@ cases:
     p {
         units.parse("100gi") == 107374182400
     }
-  note: parse/100 gibi as gi
+  note: units_parse/100 gibi as gi
   query: data.test.p = x
   want_result:
   - x: true
@@ -293,7 +293,7 @@ cases:
     p {
         units.parse("100t") == 100000000000000
     }
-  note: parse/100 tera as t
+  note: units_parse/100 tera as t
   query: data.test.p = x
   want_result:
   - x: true
@@ -305,7 +305,7 @@ cases:
     p {
         units.parse("100T") == 100000000000000
     }
-  note: parse/100 tera as T
+  note: units_parse/100 tera as T
   query: data.test.p = x
   want_result:
   - x: true
@@ -317,7 +317,7 @@ cases:
     p {
         units.parse("100ti") == 109951162777600
     }
-  note: parse/100 tebi as ti
+  note: units_parse/100 tebi as ti
   query: data.test.p = x
   want_result:
   - x: true
@@ -329,7 +329,7 @@ cases:
     p {
         units.parse("100Ti") == 109951162777600
     }
-  note: parse/100 tebi as Ti
+  note: units_parse/100 tebi as Ti
   query: data.test.p = x
   want_result:
   - x: true
@@ -341,7 +341,7 @@ cases:
     p {
         units.parse("100p") == 100000000000000000
     }
-  note: parse/100 peta as p
+  note: units_parse/100 peta as p
   query: data.test.p = x
   want_result:
   - x: true
@@ -353,7 +353,7 @@ cases:
     p {
         units.parse("100P") == 100000000000000000
     }
-  note: parse/100 peta as P
+  note: units_parse/100 peta as P
   query: data.test.p = x
   want_result:
   - x: true
@@ -365,7 +365,7 @@ cases:
     p {
         units.parse("100pi") == 112589990684262400
     }
-  note: parse/100 pebi as pi
+  note: units_parse/100 pebi as pi
   query: data.test.p = x
   want_result:
   - x: true
@@ -377,7 +377,7 @@ cases:
     p {
         units.parse("100Pi") == 112589990684262400
     }
-  note: parse/100 pebi as Pi
+  note: units_parse/100 pebi as Pi
   query: data.test.p = x
   want_result:
   - x: true
@@ -389,7 +389,7 @@ cases:
     p {
         units.parse("10e") == 10000000000000000000
     }
-  note: parse/10 eta as e
+  note: units_parse/10 eta as e
   query: data.test.p = x
   want_result:
   - x: true
@@ -401,7 +401,7 @@ cases:
     p {
         units.parse("10E") == 10000000000000000000
     }
-  note: parse/10 eta as E
+  note: units_parse/10 eta as E
   query: data.test.p = x
   want_result:
   - x: true
@@ -413,7 +413,7 @@ cases:
     p {
         units.parse("10ei") == 11529215046068469760
     }
-  note: parse/10 ebi as ei
+  note: units_parse/10 ebi as ei
   query: data.test.p = x
   want_result:
   - x: true
@@ -425,7 +425,7 @@ cases:
     p {
         units.parse("10Ei") == 11529215046068469760
     }
-  note: parse/10 ebi as Ei
+  note: units_parse/10 ebi as Ei
   query: data.test.p = x
   want_result:
   - x: true


### PR DESCRIPTION
Add "units_" prefix to all units-related test cases, so that they are
easier to find and run manually.

Signed-off-by: Philip Conrad <philipaconrad@gmail.com>
