### PR TITLE
format: Output list and diff changes with --fail flag (#4508)

### DIFF
--- a/cmd/fmt.go
+++ b/cmd/fmt.go
@@ -116,7 +116,7 @@ func formatFile(params *fmtCommandParams, out io.Writer, filename string, info o
 
 	changed := !bytes.Equal(contents, formatted)
 
-	if params.fail {
+	if params.fail && !params.list && !params.diff {
 		if changed {
 			return newError("unexpected diff")
 		}
@@ -125,6 +125,10 @@ func formatFile(params *fmtCommandParams, out io.Writer, filename string, info o
 	if params.list {
 		if changed {
 			fmt.Fprintln(out, filename)
+
+			if params.fail {
+				return newError("unexpected diff")
+			}
 		}
 		return nil
 	}
@@ -138,6 +142,10 @@ func formatFile(params *fmtCommandParams, out io.Writer, filename string, info o
 			}
 
 			fmt.Fprintln(out, stdout.String())
+
+			if params.fail {
+				return newError("unexpected diff")
+			}
 		}
 		return nil
 	}


### PR DESCRIPTION
The change enables using --diff and --list together with --fail as discussed in https://github.com/open-policy-agent/opa/issues/4508, for example:

	$ opa fmt [path [...]] --list --fail; exit $?
	path/to/file-1.rego
	path/to/file-2.rego
	unexpected diff
	2

Previously, the same command returned only the error:

	$ opa fmt [path [...]] --list --fail; exit $?
	unexpected diff
	2