### PR TITLE
Update docs on ordering expressions

### DIFF
--- a/docs/content/policy-language.md
+++ b/docs/content/policy-language.md
@@ -147,37 +147,6 @@ t
 ```live:eg/rules:output
 ```
 
-The order of expressions in a rule does not affect the document’s content.
-
-```live:eg/expression_order:module
-s {
-    x > y
-    y = 41
-    x = 42
-}
-```
-
-The query result is the same:
-
-```live:eg/expression_order:query:hidden
-s
-```
-```live:eg/expression_order:output
-```
-
-There's one exception: if you use assignment `:=` the compiler will check
-that the variable you are assigning has not already been used.
-
-```live:eg/assignment_check:module:merge_down
-z {
-    y := 41
-    y := 42
-    43 > y
-}
-```
-```live:eg/assignment_check:output:expect_assigned_above
-```
-
 Rego [References](#references) help you refer to nested documents. For example, with:
 
 ```live:eg/references:module
@@ -1948,6 +1917,15 @@ sites[i].servers[j].name = apps[k].servers[m]
 ```live:eg/data/unification2:output
 ```
 
+As opposed to when assignment (`:=`) is used, the order of expressions in a rule does not affect the document’s content.
+
+```live:eg/expression_order:module
+s {
+    x > y
+    y = 41
+    x = 42
+}
+```
 
 #### Best Practices for Equality
 


### PR DESCRIPTION
In almost all cases now, order does matter, and using assignment
is no longer the exception but the rule. Move the "order doesn't
matter" text to the section on unification.

![Screenshot 2022-05-24 at 11 28 01](https://user-images.githubusercontent.com/510711/170841424-d713f7b7-9168-4f59-90a2-c1526d688e39.png)

Signed-off-by: Anders Eknert <anders@eknert.com>