### PR TITLE
bundle: dont sign manifest when empty

### DIFF
--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -851,25 +851,29 @@ func hashBundleFiles(hash SignatureHasher, b *Bundle) ([]FileInfo, error) {
 		files = append(files, NewFile(strings.TrimPrefix(planmodule.Path, "/"), hex.EncodeToString(bs), defaultHashingAlg))
 	}
 
-	// Parse the manifest into a JSON structure;
+	// If the manifest is essentially empty, don't add it to the signatures since it
+	// won't be written to the bundle. Otherwise:
+	// parse the manifest into a JSON structure;
 	// then recursively order the fields of all objects alphabetically and then apply
 	// the hash function to result to compute the hash.
-	mbs, err := json.Marshal(b.Manifest)
-	if err != nil {
-		return files, err
-	}
+	if !b.Manifest.Equal(Manifest{}) {
+		mbs, err := json.Marshal(b.Manifest)
+		if err != nil {
+			return files, err
+		}
 
-	var result map[string]interface{}
-	if err := util.Unmarshal(mbs, &result); err != nil {
-		return files, err
-	}
+		var result map[string]interface{}
+		if err := util.Unmarshal(mbs, &result); err != nil {
+			return files, err
+		}
 
-	bs, err = hash.HashFile(result)
-	if err != nil {
-		return files, err
-	}
+		bs, err = hash.HashFile(result)
+		if err != nil {
+			return files, err
+		}
 
-	files = append(files, NewFile(strings.TrimPrefix(ManifestExt, "/"), hex.EncodeToString(bs), defaultHashingAlg))
+		files = append(files, NewFile(strings.TrimPrefix(ManifestExt, "/"), hex.EncodeToString(bs), defaultHashingAlg))
+	}
 
 	return files, err
 }

--- a/bundle/bundle_test.go
+++ b/bundle/bundle_test.go
@@ -1338,8 +1338,8 @@ func TestHashBundleFiles(t *testing.T) {
 		plan     []byte
 		exp      int
 	}{
-		"no_content":                 {map[string]interface{}{}, Manifest{}, nil, nil, 2},
-		"data":                       {map[string]interface{}{"foo": "bar"}, Manifest{}, nil, nil, 2},
+		"no_content":                 {map[string]interface{}{}, Manifest{}, nil, nil, 1},
+		"data":                       {map[string]interface{}{"foo": "bar"}, Manifest{}, nil, nil, 1},
 		"data_and_manifest":          {map[string]interface{}{"foo": "bar"}, Manifest{Revision: "quickbrownfaux"}, []byte{}, nil, 2},
 		"data_and_manifest_and_wasm": {map[string]interface{}{"foo": "bar"}, Manifest{Revision: "quickbrownfaux"}, []byte("modules-compiled-as-wasm-binary"), nil, 3},
 		"data_and_plan":              {map[string]interface{}{"foo": "bar"}, Manifest{Revision: "quickbrownfaux"}, nil, []byte("not a plan but good enough"), 3},


### PR DESCRIPTION
Previously, when creating a signed bundle and either no `.manifest`
file is present or when the contents are the defaults, no `.manifest`
file would get written to the `.tar.gz` output but there would be an
entry for the manifest in the `.signatures.json` file when trying to
verify the bundle. I modified the signature process to skip hashing
the manifest when it is empty for whatever reason.

Fixes #4712

Signed-off-by: Matt F <15720856+friedrichsenm@users.noreply.github.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->
