### PR TITLE
planner: shadow rule funcs if mocking functions

### DIFF
--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -615,10 +615,11 @@ func (p *Planner) planWith(e *ast.Expr, iter planiter) error {
 		}
 
 		// If any of the `with` statements targeted the data document, overwriting
-		// parts of the ruletrie, we shadow the existing planned functions during
-		// expression planning. This causes the planner to re-plan any rules that
-		// may be required during planning of this expression (transitively).
-		shadowing := p.dataRefsShadowRuletrie(dataRefs)
+		// parts of the ruletrie; or if a function has been mocked, we shadow the
+		// existing planned functions during expression planning.
+		// This causes the planner to re-plan any rules that may be required during
+		// planning of this expression (transitively).
+		shadowing := p.dataRefsShadowRuletrie(dataRefs) || len(mocks) > 0
 		if shadowing {
 			p.funcs.Push(map[string]string{})
 			for _, ref := range dataRefs {

--- a/test/cases/testdata/withkeyword/test-with-builtin-mock.yaml
+++ b/test/cases/testdata/withkeyword/test-with-builtin-mock.yaml
@@ -61,6 +61,23 @@ cases:
   modules:
   - |
     package test
+
+    f() = 1
+    p {
+      q with time.now_ns as f
+      not q
+    }
+    q {
+      time.now_ns() == 1
+    }
+  note: 'withkeyword/builtin: indirect call, arity 0, rule queried with and without mock'
+  query: data.test.p = x
+  want_result:
+  - x: true
+- data:
+  modules:
+  - |
+    package test
     import future.keywords.in
 
     pass_resp = {"body": {"roles": ["admin"]}}
@@ -132,6 +149,24 @@ cases:
     }
     valid_time(x) { time.now_ns() == x }
   note: 'withkeyword/builtin: indirect call through function'
+  query: data.test.p = x
+  want_result:
+  - x: true
+- data:
+  modules:
+  - |
+    package test
+
+    f() = 1
+    p {
+      q with time.now_ns as f
+      not q
+    }
+    q {
+      valid_time(1)
+    }
+    valid_time(x) { time.now_ns() == x }
+  note: 'withkeyword/builtin: indirect call through function, rule with and without mock'
   query: data.test.p = x
   want_result:
   - x: true


### PR DESCRIPTION
Before, we'd only plan a single rule functions when a function used
in that rule's body was mocked, instead of planning one rule function
for the mocked, and one for the un-mocked function.

This only affects uses where both the mocked and the un-mocked version
of the rule are queried, like

    p {
      q with time.now_ns as 1 # (1)
      not q                   # (2)
    }

Now, we plan g1.data.pkg.q for (1), and g0.data.pkg.q for (2), where
g1's plan uses the mocked function result, and g0's plan uses the
builtin.

