### PR TITLE
ci: skip flakey darwin tests on PR runs

### DIFF
--- a/rego/rego_wasmtarget_test.go
+++ b/rego/rego_wasmtarget_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/open-policy-agent/opa/storage/inmem"
 	"github.com/open-policy-agent/opa/topdown"
 	"github.com/open-policy-agent/opa/topdown/cache"
+	"github.com/open-policy-agent/opa/util/test"
 
 	_ "github.com/open-policy-agent/opa/features/wasm"
 )
@@ -130,6 +131,8 @@ func TestWasmTimeOfDay(t *testing.T) {
 }
 
 func TestEvalWithContextTimeout(t *testing.T) {
+	test.Skip(t)
+
 	ts := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 		select {
 		case <-r.Context().Done():

--- a/tester/runner_test.go
+++ b/tester/runner_test.go
@@ -363,6 +363,7 @@ func testCancel(t *testing.T, bench bool) {
 }
 
 func TestRunnerTimeout(t *testing.T) {
+	test.Skip(t)
 	testTimeout(t, false)
 }
 

--- a/util/test/ci_skip.go
+++ b/util/test/ci_skip.go
@@ -1,0 +1,10 @@
+//go:build !darwin
+// +build !darwin
+
+package test
+
+import "testing"
+
+// Skip will skip this test on pull request CI runs.
+// Used for slow test runners on GHA's darwin machines.
+func Skip(*testing.T) {}

--- a/util/test/ci_skip_darwin.go
+++ b/util/test/ci_skip_darwin.go
@@ -1,0 +1,15 @@
+package test
+
+import (
+	"os"
+	"testing"
+)
+
+// Skip will skip this test on pull request CI runs.
+// Used for slow test runners on GHA's darwin machines.
+func Skip(t *testing.T) {
+	if os.Getenv("GITHUB_ACTIONS") == "" {
+		return
+	}
+	t.Skip("skipped on Darwin, test runner is slow")
+}


### PR DESCRIPTION
Some care has been taken that these tests still run on development
machines. They'll only be skipped if the following is true:

1. the os is darwin
2. the CI env var is set to something

This approach, adding the skip calls manually on a case-by-case basis,
should allow us some fine-grained control. If we had used build tags,
we'd only be able to skip all the tests in one file together.
