### PR TITLE
builtin_metadata: add v0.41.0 manually

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -272,6 +272,7 @@ jobs:
         with:
           repository: open-policy-agent/npm-opa-wasm
           path: npm-opa-wasm
+          ref: '1.7.0'
 
       - name: Run npm-opa-wasm nodejs-app examples
         run: |

--- a/build/check-working-copy.sh
+++ b/build/check-working-copy.sh
@@ -4,7 +4,6 @@ EXCEPTIONS=(
   "internal/compiler/wasm/opa/opa.go"
   "internal/compiler/wasm/opa/opa.wasm"
   "internal/compiler/wasm/opa/callgraph.csv"
-  "builtin_metadata.json"
 )
 
 STATUS=$(git status --porcelain)

--- a/builtin_metadata.json
+++ b/builtin_metadata.json
@@ -291,6 +291,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns the number without its sign.",
@@ -368,6 +369,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "introduced": "v0.17.0",
@@ -449,6 +451,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns the intersection of two sets.",
@@ -527,6 +530,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "introduced": "v0.17.0",
@@ -608,6 +612,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Concatenates two arrays.",
@@ -637,6 +642,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns the reverse of a given array.",
@@ -726,6 +732,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns a slice of a given array. If `start` is greater or equal than `stop`, `slice` is `[]`.",
@@ -806,6 +813,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "infix": ":=",
@@ -883,6 +891,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Deserializes the base64 encoded input string.",
@@ -962,6 +971,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Serializes the input string into base64 encoding.",
@@ -1020,6 +1030,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Verifies the input string is base64 encoded.",
@@ -1099,6 +1110,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Deserializes the base64url encoded input string.",
@@ -1178,6 +1190,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Serializes the input string into base64url encoding.",
@@ -1234,6 +1247,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Serializes the input string into base64url encoding without padding.",
@@ -1314,6 +1328,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns the bitwise \"AND\" of two integers.",
@@ -1393,6 +1408,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns a new integer with its bits shifted `s` bits to the left.",
@@ -1467,6 +1483,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns the bitwise negation (flip) of an integer.",
@@ -1546,6 +1563,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns the bitwise \"OR\" of two integers.",
@@ -1625,6 +1643,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns a new integer with its bits shifted `s` bits to the right.",
@@ -1704,6 +1723,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns the bitwise \"XOR\" (exclusive-or) of two integers.",
@@ -1780,6 +1800,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "introduced": "v0.17.0",
@@ -1854,6 +1875,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "introduced": "v0.17.0",
@@ -1928,6 +1950,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "introduced": "v0.17.0",
@@ -2002,6 +2025,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "introduced": "v0.17.0",
@@ -2076,6 +2100,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "introduced": "v0.17.0",
@@ -2150,6 +2175,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "introduced": "v0.17.0",
@@ -2197,6 +2223,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Rounds the number _up_ to the nearest integer.",
@@ -2281,6 +2308,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Joins a set or array of strings with a delimiter.",
@@ -2364,6 +2392,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns `true` if the search string is included in the base string",
@@ -2443,6 +2472,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": " Count takes a collection or string and returns the number of elements (or characters) in it.",
@@ -2477,6 +2507,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns a string representing the MD5 HMAC of the input message using the input key.",
@@ -2511,6 +2542,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns a string representing the SHA1 HMAC of the input message using the input key.",
@@ -2545,6 +2577,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns a string representing the SHA256 HMAC of the input message using the input key.",
@@ -2579,6 +2612,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns a string representing the SHA512 HMAC of the input message using the input key.",
@@ -2658,6 +2692,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns a string representing the input string hashed with the MD5 function",
@@ -2737,6 +2772,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns a string representing the input string hashed with the SHA1 function",
@@ -2816,6 +2852,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns a string representing the input string hashed with the SHA256 function",
@@ -2854,6 +2891,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns one or more certificates from the given string containing PEM\nor base64 encoded DER certificates after verifying the supplied certificates form a complete\ncertificate chain back to a trusted root.\n\nThe first certificate is treated as the root and the last is treated as the leaf,\nwith all others being treated as intermediates.",
@@ -2918,6 +2956,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns a PKCS #10 certificate signing request from the given PEM-encoded PKCS#10 certificate signing request.",
@@ -2997,6 +3036,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns one or more certificates from the given base64 encoded string containing DER encoded certificates that have been concatenated.",
@@ -3032,6 +3072,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns a JWK for signing a JWT from the given PEM-encoded RSA private key.",
@@ -3116,6 +3157,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Divides the first number by the second number.",
@@ -3201,6 +3243,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns true if the search string begins with the base string.",
@@ -3281,6 +3324,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "infix": "=",
@@ -3363,6 +3407,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "infix": "==",
@@ -3413,6 +3458,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Rounds the number _down_ to the nearest integer.",
@@ -3497,6 +3543,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns the string representation of the number in the given base after converting it to an integer value.",
@@ -3586,6 +3633,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Parses and matches strings against the glob notation. Not to be confused with `regex.globs_match`.",
@@ -3665,6 +3713,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns a string which represents a version of the pattern where all asterisks have been escaped.",
@@ -3740,6 +3789,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Computes the set of reachable nodes in the graph from a set of starting nodes.",
@@ -3772,6 +3822,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Computes the set of reachable paths in the graph from a set of starting nodes.",
@@ -3797,10 +3848,11 @@
       }
     ],
     "available": [
+      "v0.41.0",
       "edge"
     ],
     "description": "Checks that a GraphQL query is valid against a given schema.",
-    "introduced": "edge",
+    "introduced": "v0.41.0",
     "result": {
       "description": "`true` if the query is valid under the given schema. `false` otherwise.",
       "name": "output",
@@ -3822,10 +3874,11 @@
       }
     ],
     "available": [
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns AST objects for a given GraphQL query and schema after validating the query against the schema. Returns undefined if errors were encountered during parsing or validation.",
-    "introduced": "edge",
+    "introduced": "v0.41.0",
     "result": {
       "description": "`output` is of the form `[query_ast, schema_ast]`. If the GraphQL query is valid given the provided schema, then `query_ast` and `schema_ast` are objects describing the ASTs for the query and schema.",
       "name": "output",
@@ -3847,10 +3900,11 @@
       }
     ],
     "available": [
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns a boolean indicating success or failure alongside the parsed ASTs for a given GraphQL query and schema after validating the query against the schema.",
-    "introduced": "edge",
+    "introduced": "v0.41.0",
     "result": {
       "description": " `output` is of the form `[valid, query_ast, schema_ast]`. If the query is valid given the provided schema, then `valid` is `true`, and `query_ast` and `schema_ast` are objects describing the ASTs for the GraphQL query and schema. Otherwise, `valid` is `false` and `query_ast` and `schema_ast` are `{}`.",
       "name": "output",
@@ -3867,10 +3921,11 @@
       }
     ],
     "available": [
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns an AST object for a GraphQL query.",
-    "introduced": "edge",
+    "introduced": "v0.41.0",
     "result": {
       "description": "AST object for the GraphQL query.",
       "name": "output",
@@ -3887,10 +3942,11 @@
       }
     ],
     "available": [
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns an AST object for a GraphQL schema.",
-    "introduced": "edge",
+    "introduced": "v0.41.0",
     "result": {
       "description": "AST object for the GraphQL schema.",
       "name": "output",
@@ -3971,6 +4027,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "infix": "\u003e",
@@ -4055,6 +4112,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "infix": "\u003e=",
@@ -4111,6 +4169,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Deserializes the hex-encoded input string.",
@@ -4167,6 +4226,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Serializes the input string using hex-encoding.",
@@ -4246,6 +4306,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns a HTTP response to the given HTTP request.",
@@ -4329,6 +4390,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns the index of a substring contained inside a string.",
@@ -4361,6 +4423,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns a list of all the indexes of a substring contained inside a string.",
@@ -4395,6 +4458,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "infix": "in",
@@ -4430,6 +4494,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "infix": "in",
@@ -4459,6 +4524,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "introduced": "v0.34.0",
@@ -4533,6 +4599,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns the intersection of the given input sets.",
@@ -4612,6 +4679,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Decodes a JSON Web Token and outputs it as an object.",
@@ -4696,6 +4764,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Verifies a JWT signature under parameterized constraints and decodes the claims if it is valid.\nSupports the following algorithms: HS256, HS384, HS512, RS256, RS384, RS512, ES256, ES384, ES512, PS256, PS384 and PS512.",
@@ -4785,6 +4854,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Encodes and optionally signs a JSON Web Token. Inputs are taken as objects, not encoded strings (see `io.jwt.encode_sign_raw`).",
@@ -4874,6 +4944,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Encodes and optionally signs a JSON Web Token.",
@@ -4958,6 +5029,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Verifies if a ES256 JWT signature is valid.",
@@ -5033,6 +5105,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Verifies if a ES384 JWT signature is valid.",
@@ -5108,6 +5181,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Verifies if a ES512 JWT signature is valid.",
@@ -5192,6 +5266,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Verifies if a HS256 (secret) JWT signature is valid.",
@@ -5267,6 +5342,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Verifies if a HS384 (secret) JWT signature is valid.",
@@ -5342,6 +5418,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Verifies if a HS512 (secret) JWT signature is valid.",
@@ -5426,6 +5503,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Verifies if a PS256 JWT signature is valid.",
@@ -5501,6 +5579,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Verifies if a PS384 JWT signature is valid.",
@@ -5576,6 +5655,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Verifies if a PS512 JWT signature is valid.",
@@ -5660,6 +5740,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Verifies if a RS256 JWT signature is valid.",
@@ -5735,6 +5816,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Verifies if a RS384 JWT signature is valid.",
@@ -5810,6 +5892,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Verifies if a RS512 JWT signature is valid.",
@@ -5889,6 +5972,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns `true` if the input value is an array.",
@@ -5968,6 +6052,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns `true` if the input value is a boolean.",
@@ -6047,6 +6132,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns `true` if the input value is null.",
@@ -6126,6 +6212,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns `true` if the input value is a number.",
@@ -6205,6 +6292,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns true if the input value is an object",
@@ -6284,6 +6372,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns `true` if the input value is a set.",
@@ -6363,6 +6452,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns `true` if the input value is a string.",
@@ -6447,6 +6537,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Filters the object. For example: `json.filter({\"a\": {\"b\": \"x\", \"c\": \"y\"}}, [\"a/b\"])` will result in `{\"a\": {\"b\": \"x\"}}`). Paths are not filtered in-order and are deduplicated before being evaluated.",
@@ -6504,6 +6595,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Verifies the input string is a valid JSON document.",
@@ -6583,6 +6675,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Serializes the input term to JSON.",
@@ -6641,6 +6734,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Patches an object according to RFC6902. For example: `json.patch({\"a\": {\"foo\": 1}}, [{\"op\": \"add\", \"path\": \"/a/bar\", \"value\": 2}])` results in `{\"a\": {\"foo\": 1, \"bar\": 2}`.  The patches are applied atomically: if any of them fails, the result will be undefined.",
@@ -6721,6 +6815,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Removes paths from an object. For example: `json.remove({\"a\": {\"b\": \"x\", \"c\": \"y\"}}, [\"a/b\"])` will result in `{\"a\": {\"c\": \"y\"}}`. Paths are not removed in-order and are deduplicated before being evaluated.",
@@ -6800,6 +6895,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Deserializes the input string.",
@@ -6879,6 +6975,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns the input string but with all characters in lower-case.",
@@ -6963,6 +7060,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "infix": "\u003c",
@@ -7047,6 +7145,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "infix": "\u003c=",
@@ -7126,6 +7225,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns the maximum value in a collection.",
@@ -7205,6 +7305,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns the minimum value in a collection.",
@@ -7289,6 +7390,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Minus subtracts the second number from the first number or computes the difference between two sets.",
@@ -7374,6 +7476,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Multiplies two numbers.",
@@ -7459,6 +7562,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "infix": "!=",
@@ -7543,6 +7647,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Checks if a CIDR or IP is contained within another CIDR. `output` is `true` if `cidr_or_ip` (e.g. `127.0.0.64/26` or `127.0.0.1`) is contained within `cidr` (e.g. `127.0.0.1/24`) and `false` otherwise. Supports both IPv4 and IPv6 notations.",
@@ -7621,6 +7726,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Checks if collections of cidrs or ips are contained within another collection of cidrs and returns matches. This function is similar to `net.cidr_contains` except it allows callers to pass collections of CIDRs or IPs as arguments and returns the matches (as opposed to a boolean result indicating a match between two CIDRs/IPs).",
@@ -7700,6 +7806,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Expands CIDR to set of hosts  (e.g., `net.cidr_expand(\"192.168.0.0/30\")` generates 4 hosts: `{\"192.168.0.0\", \"192.168.0.1\", \"192.168.0.2\", \"192.168.0.3\"}`).",
@@ -7784,6 +7891,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Checks if a CIDR intersects with another CIDR (e.g. `192.168.0.0/16` overlaps with `192.168.1.0/24`). Supports both IPv4 and IPv6 notations.",
@@ -7841,6 +7949,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Merges IP addresses and subnets into the smallest possible list of CIDRs (e.g., `net.cidr_merge([\"192.0.128.0/24\", \"192.0.129.0/24\"])` generates `{\"192.0.128.0/23\"}`.This function merges adjacent subnets where possible, those contained within others and also removes any duplicates.\nSupports both IPv4 and IPv6 notations. IPv6 inputs need a prefix length (e.g. \"/128\").",
@@ -7921,6 +8030,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "introduced": "v0.17.0",
@@ -7948,6 +8058,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns the set of IP addresses (both v4 and v6) that the passed-in `name` resolves to using the standard name resolution mechanisms available.",
@@ -8015,6 +8126,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns an array of numbers in the given (inclusive) range. If `a==b`, then `range == [a]`; if `a \u003e b`, then `range` is in descending order.",
@@ -8097,6 +8209,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Filters the object by keeping only specified keys. For example: `object.filter({\"a\": {\"b\": \"x\", \"c\": \"y\"}, \"d\": \"z\"}, [\"a\"])` will result in `{\"a\": {\"b\": \"x\", \"c\": \"y\"}}`).",
@@ -8186,6 +8299,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns value of an object's key if present, otherwise a default. If the supplied `key` is an `array`, then `object.get` will search through a nested object or array using each key in turn. For example: `object.get({\"a\": [{ \"b\": true }]}, [\"a\", 0, \"b\"], false)` results in `true`.",
@@ -8268,6 +8382,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Removes specified keys from an object.",
@@ -8350,6 +8465,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Creates a new object of the asymmetric union of two objects. For example: `object.union({\"a\": 1, \"b\": 2, \"c\": {\"d\": 3}}, {\"a\": 7, \"c\": {\"d\": 4, \"e\": 5}})` will result in `{\"a\": 7, \"b\": 2, \"c\": {\"d\": 4, \"e\": 5}}`.",
@@ -8377,6 +8493,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Creates a new object that is the asymmetric union of all objects merged from left to right. For example: `object.union_n([{\"a\": 1}, {\"b\": 2}, {\"a\": 3}])` will result in `{\"b\": 2, \"a\": 3}`.",
@@ -8450,6 +8567,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns an object that describes the runtime environment where OPA is deployed.",
@@ -8534,6 +8652,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns the union of two sets.",
@@ -8619,6 +8738,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Plus adds two numbers together.",
@@ -8647,6 +8767,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "introduced": "v0.34.0",
@@ -8721,6 +8842,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Muliplies elements of an array or set of numbers",
@@ -8764,6 +8886,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns a random integer between `0` and `n` (`n` exlusive). If `n` is `0`, then `y` is always `0`. For any given argument pair (`str`, `n`), the output will be consistent throughout a query evaluation.",
@@ -8844,6 +8967,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "introduced": "v0.17.0",
@@ -8930,6 +9054,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns all successive matches of the expression.",
@@ -9018,6 +9143,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns the specified number of matches when matching the input against the pattern.",
@@ -9102,6 +9228,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Checks if the intersection of two glob-style regular expressions matches a non-empty set of non-empty strings.\nThe set of regex symbols is limited for this builtin: only `.`, `*`, `+`, `[`, `-`, `]` and `\\` are treated as special symbols.",
@@ -9162,6 +9289,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Checks if a string is a valid regular expression: the detailed syntax for patterns is defined by https://github.com/google/re2/wiki/Syntax.",
@@ -9227,6 +9355,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Matches a string against a regular expression.",
@@ -9310,6 +9439,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Splits the input string by the occurrences of the given pattern.",
@@ -9404,6 +9534,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Matches a string against a pattern, where there pattern may be glob-like",
@@ -9418,6 +9549,7 @@
     "args": [],
     "available": [
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns the chain of metadata for the active rule.\nOrdered starting at the active rule, going outward to the most distant node in its package ancestry.\nA chain entry is a JSON document with two members: \"path\", an array representing the path of the node; and \"annotations\", a JSON document containing the annotations declared for the node.\nThe first entry in the chain always points to the active rule, even if it has no declared annotations (in which case the \"annotations\" member is not present).",
@@ -9433,6 +9565,7 @@
     "args": [],
     "available": [
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns annotations declared for the active rule and using the _rule_ scope.",
@@ -9517,6 +9650,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Parses the input Rego string and returns an object representation of the AST.",
@@ -9600,6 +9734,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns the remainder for of `x` divided by `y`, for `y != 0`.",
@@ -9690,6 +9825,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Replace replaces all instances of a sub-string.",
@@ -9769,6 +9905,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Rounds the number to the nearest integer.",
@@ -9836,6 +9973,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Compares valid SemVer formatted version strings.",
@@ -9898,6 +10036,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Validates that the input is a valid SemVer string.",
@@ -9978,6 +10117,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "introduced": "v0.17.0",
@@ -10054,6 +10194,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns a sorted array.",
@@ -10138,6 +10279,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Split returns an array containing elements of the input string split on a delimiter.",
@@ -10222,6 +10364,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns the given string, formatted.",
@@ -10306,6 +10449,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns true if the search string begins with the base string.",
@@ -10390,6 +10534,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Replaces a string from a list of old, new string pairs.\nReplacements are performed in the order they appear in the target string, without overlapping matches.\nThe old string comparisons are done in argument order.",
@@ -10418,6 +10563,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Reverses a given string.",
@@ -10506,6 +10652,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns the  portion of a string for a given `offset` and a `length`.  If `length \u003c 0`, `output` is the remainder of the string.",
@@ -10585,6 +10732,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Sums elements of an array or set of numbers.",
@@ -10673,6 +10821,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns the nanoseconds since epoch after adding years, months and days to nanoseconds. `undefined` if the result would be outside the valid time range that can fit within an `int64`.",
@@ -10752,6 +10901,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns the `[hour, minute, second]` of the day for the nanoseconds since epoch.",
@@ -10831,6 +10981,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns the `[year, month, day]` for the nanoseconds since epoch.",
@@ -10883,6 +11034,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns the difference between two unix timestamps in nanoseconds (with optional timezone strings).",
@@ -10956,6 +11108,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns the current time since epoch in nanoseconds.",
@@ -11035,6 +11188,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns the duration in nanoseconds represented by a string.",
@@ -11119,6 +11273,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns the time in nanoseconds parsed from the string in the given format. `undefined` if the result would be outside the valid time range that can fit within an `int64`.",
@@ -11198,6 +11353,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns the time in nanoseconds parsed from the string in RFC3339 format. `undefined` if the result would be outside the valid time range that can fit within an `int64`.",
@@ -11277,6 +11433,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns the day of the week (Monday, Tuesday, ...) for the nanoseconds since epoch.",
@@ -11356,6 +11513,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Converts a string, bool, or number value to a number: Strings are converted to numbers using `strconv.Atoi`, Boolean `false` is converted to 0 and `true` is converted to 1.",
@@ -11434,6 +11592,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Emits `note` as a `Note` event in the query explanation. Query explanations show the exact expressions evaluated by OPA during policy execution. For example, `trace(\"Hello There!\")` includes `Note \"Hello There!\"` in the query explanation. To include variables in the message, use `sprintf`. For example, `person := \"Bob\"; trace(sprintf(\"Hello There! %v\", [person]))` will emit `Note \"Hello There! Bob\"` inside of the explanation.",
@@ -11518,6 +11677,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns `value` with all leading or trailing instances of the `cutset` characters removed.",
@@ -11602,6 +11762,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns `value` with all leading instances of the `cutset` chartacters removed.",
@@ -11686,6 +11847,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns `value` without the prefix. If `value` doesn't start with `prefix`, it is returned unchanged.",
@@ -11770,6 +11932,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns `value` with all trailing instances of the `cutset` chartacters removed.",
@@ -11849,6 +12012,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Return the given string with all leading and trailing white space removed.",
@@ -11933,6 +12097,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns `value` without the suffix. If `value` doesn't end with `suffix`, it is returned unchanged.",
@@ -12010,6 +12175,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "introduced": "v0.17.0",
@@ -12086,6 +12252,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns the union of the given input sets.",
@@ -12106,10 +12273,11 @@
       }
     ],
     "available": [
+      "v0.41.0",
       "edge"
     ],
     "description": "Converts strings like \"10G\", \"5K\", \"4M\", \"1500m\" and the like into a number.\nThis number can be a non-integer, such as 1.5, 0.22, etc. Supports standard metric decimal and\nbinary SI units (e.g., K, Ki, M, Mi, G, Gi etc.) m, K, M, G, T, P, and E are treated as decimal\nunits and Ki, Mi, Gi, Ti, Pi, and Ei are treated as binary units.\n\nNote that 'm' and 'M' are case-sensitive, to allow distinguishing between \"milli\" and \"mega\" units respectively. Other units are case-insensitive.",
-    "introduced": "edge",
+    "introduced": "v0.41.0",
     "result": {
       "description": "the parsed number",
       "name": "y",
@@ -12185,6 +12353,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Converts strings like \"10GB\", \"5K\", \"4mb\" into an integer number of bytes.\nSupports standard byte units (e.g., KB, KiB, etc.) KB, MB, GB, and TB are treated as decimal\nunits and KiB, MiB, GiB, and TiB are treated as binary units. The bytes symbol (b/B) in the\nunit is optional and omitting it wil give the same result (e.g. Mi and MiB).",
@@ -12264,6 +12433,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns the input string but with all characters in upper-case.",
@@ -12343,6 +12513,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Decodes a URL-encoded input string.",
@@ -12401,6 +12572,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Decodes the given URL query string into an object.",
@@ -12480,6 +12652,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Encodes the input string into a URL-encoded string.",
@@ -12559,6 +12732,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Encodes the given object into a URL encoded query string.",
@@ -12629,6 +12803,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Returns a new UUIDv4.",
@@ -12708,6 +12883,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Generates `[path, value]` tuples for all nested documents of `x` (recursively).  Queries can use `walk` to traverse documents nested under `x`.",
@@ -12766,6 +12942,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Verifies the input string is a valid YAML document.",
@@ -12845,6 +13022,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Serializes the input term to YAML.",
@@ -12924,6 +13102,7 @@
       "v0.38.1",
       "v0.39.0",
       "v0.40.0",
+      "v0.41.0",
       "edge"
     ],
     "description": "Deserializes the input string.",


### PR DESCRIPTION
We'll figure out how to do this in the release process, but for now, this
is enough to not have the builtin_metadata.json change appear in each PR.
