### PR TITLE
prometheus: bump client_golang, adjust setup and tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/opencontainers/image-spec v1.0.3-0.20211202183452-c5a74bcca799
 	github.com/peterh/liner v0.0.0-20170211195444-bf27d3ba8e1d
 	github.com/pkg/errors v0.9.1
-	github.com/prometheus/client_golang v1.12.1
+	github.com/prometheus/client_golang v1.12.2
 	github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -815,8 +815,8 @@ github.com/prometheus/client_golang v1.1.0/go.mod h1:I1FGZT9+L76gKKOs5djB6ezCbFQ
 github.com/prometheus/client_golang v1.7.1/go.mod h1:PY5Wy2awLA44sXw4AOSfFBetzPP4j5+D6mVACh+pe2M=
 github.com/prometheus/client_golang v1.11.0/go.mod h1:Z6t4BnS23TR94PD6BsDNk8yVqroYurpAkEiz0P2BEV0=
 github.com/prometheus/client_golang v1.11.1/go.mod h1:Z6t4BnS23TR94PD6BsDNk8yVqroYurpAkEiz0P2BEV0=
-github.com/prometheus/client_golang v1.12.1 h1:ZiaPsmm9uiBeaSMRznKsCDNtPCS0T3JVDGF+06gjBzk=
-github.com/prometheus/client_golang v1.12.1/go.mod h1:3Z9XVyYiZYEO+YQWt3RD2R3jrbd179Rt297l4aS6nDY=
+github.com/prometheus/client_golang v1.12.2 h1:51L9cDoUHVrXx4zWYlcLQIZ+d+VXHgqnYKkIuq4g/34=
+github.com/prometheus/client_golang v1.12.2/go.mod h1:3Z9XVyYiZYEO+YQWt3RD2R3jrbd179Rt297l4aS6nDY=
 github.com/prometheus/client_model v0.0.0-20171117100541-99fa1f4be8e5/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=

--- a/internal/prometheus/prometheus.go
+++ b/internal/prometheus/prometheus.go
@@ -16,7 +16,6 @@ import (
 	"github.com/golang/protobuf/proto"  // nolint:staticcheck
 
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
 	"github.com/open-policy-agent/opa/metrics"
@@ -37,7 +36,7 @@ type loggerFunc func(attrs map[string]interface{}, f string, a ...interface{})
 // New returns a new Provider object.
 func New(inner metrics.Metrics, logger loggerFunc) *Provider {
 	registry := prometheus.NewRegistry()
-	registry.MustRegister(collectors.NewGoCollector())
+	registry.MustRegister(collector())
 	durationHistogram := prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name: "http_request_duration_seconds",

--- a/internal/prometheus/prometheus_go1.16.go
+++ b/internal/prometheus/prometheus_go1.16.go
@@ -1,0 +1,17 @@
+// Copyright 2022 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+// NOTE(sr): Different go runtime metrics on 1.16.
+// This can be removed when we drop support for go 1.16.
+
+//go:build !go1.17
+// +build !go1.17
+
+package prometheus
+
+import "github.com/prometheus/client_golang/prometheus"
+
+func collector() prometheus.Collector {
+	return prometheus.NewGoCollector()
+}

--- a/internal/prometheus/prometheus_go1.17.go
+++ b/internal/prometheus/prometheus_go1.17.go
@@ -1,0 +1,20 @@
+// Copyright 2022 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+// NOTE(sr): Different go runtime metrics on 1.16.
+// This can be removed when we drop support for go 1.16.
+
+//go:build go1.17
+// +build go1.17
+
+package prometheus
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
+)
+
+func collector() prometheus.Collector {
+	return collectors.NewGoCollector(collectors.WithGoCollections(collectors.GoRuntimeMemStatsCollection | collectors.GoRuntimeMetricsCollection))
+}

--- a/internal/prometheus/prometheus_test.go
+++ b/internal/prometheus/prometheus_test.go
@@ -4,8 +4,8 @@
 
 // NOTE(sr): Different go runtime metrics on 1.16.
 // This can be removed when we drop support for go 1.16.
-//go:build !go1.16
-// +build !go1.16
+//go:build go1.17
+// +build go1.17
 
 package prometheus
 
@@ -62,7 +62,7 @@ func TestJSONSerialization(t *testing.T) {
 			"go_memory_classes_total_bytes",
 			"go_memstats_alloc_bytes",
 			"go_memstats_buck_hash_sys_bytes",
-			"go_memstats_gc_cpu_fraction",
+			// "go_memstats_gc_cpu_fraction", // removed: https://github.com/prometheus/client_golang/issues/842#issuecomment-861812034
 			"go_memstats_gc_sys_bytes",
 			"go_memstats_heap_alloc_bytes",
 			"go_memstats_heap_idle_bytes",
@@ -101,9 +101,9 @@ func TestJSONSerialization(t *testing.T) {
 			"go_gc_duration_seconds",
 		},
 		"HISTOGRAM": {
-			"go_gc_pauses_seconds_total",
-			"go_gc_heap_allocs_by_size_bytes_total",
-			"go_gc_heap_frees_by_size_bytes_total",
+			"go_gc_pauses_seconds",            // was: "go_gc_pauses_seconds_total"
+			"go_gc_heap_allocs_by_size_bytes", // was: "go_gc_heap_allocs_by_size_bytes_total"
+			"go_gc_heap_frees_by_size_bytes",  // was: "go_gc_heap_frees_by_size_bytes_total"
 			"go_sched_latencies_seconds",
 		},
 	}

--- a/vendor/github.com/prometheus/client_golang/prometheus/collectors/collectors.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/collectors/collectors.go
@@ -14,3 +14,27 @@
 // Package collectors provides implementations of prometheus.Collector to
 // conveniently collect process and Go-related metrics.
 package collectors
+
+import "github.com/prometheus/client_golang/prometheus"
+
+// NewBuildInfoCollector returns a collector collecting a single metric
+// "go_build_info" with the constant value 1 and three labels "path", "version",
+// and "checksum". Their label values contain the main module path, version, and
+// checksum, respectively. The labels will only have meaningful values if the
+// binary is built with Go module support and from source code retrieved from
+// the source repository (rather than the local file system). This is usually
+// accomplished by building from outside of GOPATH, specifying the full address
+// of the main package, e.g. "GO111MODULE=on go run
+// github.com/prometheus/client_golang/examples/random". If built without Go
+// module support, all label values will be "unknown". If built with Go module
+// support but using the source code from the local file system, the "path" will
+// be set appropriately, but "checksum" will be empty and "version" will be
+// "(devel)".
+//
+// This collector uses only the build information for the main module. See
+// https://github.com/povilasv/prommod for an example of a collector for the
+// module dependencies.
+func NewBuildInfoCollector() prometheus.Collector {
+	//nolint:staticcheck // Ignore SA1019 until v2.
+	return prometheus.NewBuildInfoCollector()
+}

--- a/vendor/github.com/prometheus/client_golang/prometheus/collectors/go_collector_go116.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/collectors/go_collector_go116.go
@@ -11,6 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !go1.17
+// +build !go1.17
+
 package collectors
 
 import "github.com/prometheus/client_golang/prometheus"
@@ -42,28 +45,5 @@ import "github.com/prometheus/client_golang/prometheus"
 // NOTE: The problem is solved in Go 1.15, see
 // https://github.com/golang/go/issues/19812 for the related Go issue.
 func NewGoCollector() prometheus.Collector {
-	//nolint:staticcheck // Ignore SA1019 until v2.
 	return prometheus.NewGoCollector()
-}
-
-// NewBuildInfoCollector returns a collector collecting a single metric
-// "go_build_info" with the constant value 1 and three labels "path", "version",
-// and "checksum". Their label values contain the main module path, version, and
-// checksum, respectively. The labels will only have meaningful values if the
-// binary is built with Go module support and from source code retrieved from
-// the source repository (rather than the local file system). This is usually
-// accomplished by building from outside of GOPATH, specifying the full address
-// of the main package, e.g. "GO111MODULE=on go run
-// github.com/prometheus/client_golang/examples/random". If built without Go
-// module support, all label values will be "unknown". If built with Go module
-// support but using the source code from the local file system, the "path" will
-// be set appropriately, but "checksum" will be empty and "version" will be
-// "(devel)".
-//
-// This collector uses only the build information for the main module. See
-// https://github.com/povilasv/prommod for an example of a collector for the
-// module dependencies.
-func NewBuildInfoCollector() prometheus.Collector {
-	//nolint:staticcheck // Ignore SA1019 until v2.
-	return prometheus.NewBuildInfoCollector()
 }

--- a/vendor/github.com/prometheus/client_golang/prometheus/collectors/go_collector_latest.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/collectors/go_collector_latest.go
@@ -1,0 +1,91 @@
+// Copyright 2021 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build go1.17
+// +build go1.17
+
+package collectors
+
+import "github.com/prometheus/client_golang/prometheus"
+
+//nolint:staticcheck // Ignore SA1019 until v2.
+type goOptions = prometheus.GoCollectorOptions
+type goOption func(o *goOptions)
+
+type GoCollectionOption uint32
+
+const (
+	// GoRuntimeMemStatsCollection represents the metrics represented by runtime.MemStats structure such as
+	// go_memstats_alloc_bytes
+	// go_memstats_alloc_bytes_total
+	// go_memstats_sys_bytes
+	// go_memstats_lookups_total
+	// go_memstats_mallocs_total
+	// go_memstats_frees_total
+	// go_memstats_heap_alloc_bytes
+	// go_memstats_heap_sys_bytes
+	// go_memstats_heap_idle_bytes
+	// go_memstats_heap_inuse_bytes
+	// go_memstats_heap_released_bytes
+	// go_memstats_heap_objects
+	// go_memstats_stack_inuse_bytes
+	// go_memstats_stack_sys_bytes
+	// go_memstats_mspan_inuse_bytes
+	// go_memstats_mspan_sys_bytes
+	// go_memstats_mcache_inuse_bytes
+	// go_memstats_mcache_sys_bytes
+	// go_memstats_buck_hash_sys_bytes
+	// go_memstats_gc_sys_bytes
+	// go_memstats_other_sys_bytes
+	// go_memstats_next_gc_bytes
+	// so the metrics known from pre client_golang v1.12.0, except skipped go_memstats_gc_cpu_fraction (see
+	// https://github.com/prometheus/client_golang/issues/842#issuecomment-861812034 for explanation.
+	//
+	// NOTE that this mode represents runtime.MemStats statistics, but they are
+	// actually implemented using new runtime/metrics package.
+	// Deprecated: Use GoRuntimeMetricsCollection instead going forward.
+	GoRuntimeMemStatsCollection GoCollectionOption = 1 << iota
+	// GoRuntimeMetricsCollection is the new set of metrics represented by runtime/metrics package and follows
+	// consistent naming. The exposed metric set depends on Go version, but it is controlled against
+	// unexpected cardinality. This set has overlapping information with GoRuntimeMemStatsCollection, just with
+	// new names. GoRuntimeMetricsCollection is what is recommended for using going forward.
+	GoRuntimeMetricsCollection
+)
+
+// WithGoCollections allows enabling different collections for Go collector on top of base metrics
+// like go_goroutines, go_threads, go_gc_duration_seconds, go_memstats_last_gc_time_seconds, go_info.
+//
+// Check GoRuntimeMemStatsCollection and GoRuntimeMetricsCollection for more details. You can use none,
+// one or more collections at once. For example:
+// WithGoCollections(GoRuntimeMemStatsCollection | GoRuntimeMetricsCollection) means both GoRuntimeMemStatsCollection
+// metrics and GoRuntimeMetricsCollection will be exposed.
+//
+// The current default is GoRuntimeMemStatsCollection, so the compatibility mode with
+// client_golang pre v1.12 (move to runtime/metrics).
+func WithGoCollections(flags GoCollectionOption) goOption {
+	return func(o *goOptions) {
+		o.EnabledCollections = uint32(flags)
+	}
+}
+
+// NewGoCollector returns a collector that exports metrics about the current Go
+// process using debug.GCStats using runtime/metrics.
+func NewGoCollector(opts ...goOption) prometheus.Collector {
+	//nolint:staticcheck // Ignore SA1019 until v2.
+	promPkgOpts := make([]func(o *prometheus.GoCollectorOptions), len(opts))
+	for i, opt := range opts {
+		promPkgOpts[i] = opt
+	}
+	//nolint:staticcheck // Ignore SA1019 until v2.
+	return prometheus.NewGoCollector(promPkgOpts...)
+}

--- a/vendor/github.com/prometheus/client_golang/prometheus/go_collector.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/go_collector.go
@@ -197,14 +197,6 @@ func goRuntimeMemStats() memStatsMetrics {
 			),
 			eval:    func(ms *runtime.MemStats) float64 { return float64(ms.NextGC) },
 			valType: GaugeValue,
-		}, {
-			desc: NewDesc(
-				memstatNamespace("gc_cpu_fraction"),
-				"The fraction of this program's available CPU time used by the GC since the program started.",
-				nil, nil,
-			),
-			eval:    func(ms *runtime.MemStats) float64 { return ms.GCCPUFraction },
-			valType: GaugeValue,
 		},
 	}
 }
@@ -268,7 +260,6 @@ func (c *baseGoCollector) Collect(ch chan<- Metric) {
 	quantiles[0.0] = stats.PauseQuantiles[0].Seconds()
 	ch <- MustNewConstSummary(c.gcDesc, uint64(stats.NumGC), stats.PauseTotal.Seconds(), quantiles)
 	ch <- MustNewConstMetric(c.gcLastTimeDesc, GaugeValue, float64(stats.LastGC.UnixNano())/1e9)
-
 	ch <- MustNewConstMetric(c.goInfoDesc, GaugeValue, 1)
 }
 
@@ -278,6 +269,7 @@ func memstatNamespace(s string) string {
 
 // memStatsMetrics provide description, evaluator, runtime/metrics name, and
 // value type for memstat metrics.
+// TODO(bwplotka): Remove with end Go 1.16 EOL and replace with runtime/metrics.Description
 type memStatsMetrics []struct {
 	desc    *Desc
 	eval    func(*runtime.MemStats) float64

--- a/vendor/github.com/prometheus/client_golang/prometheus/internal/go_runtime_metrics.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/internal/go_runtime_metrics.go
@@ -62,7 +62,7 @@ func RuntimeMetricsToProm(d *metrics.Description) (string, string, string, bool)
 	// other data.
 	name = strings.ReplaceAll(name, "-", "_")
 	name = name + "_" + unit
-	if d.Cumulative {
+	if d.Cumulative && d.Kind != metrics.KindFloat64Histogram {
 		name = name + "_total"
 	}
 
@@ -84,12 +84,12 @@ func RuntimeMetricsToProm(d *metrics.Description) (string, string, string, bool)
 func RuntimeMetricsBucketsForUnit(buckets []float64, unit string) []float64 {
 	switch unit {
 	case "bytes":
-		// Rebucket as powers of 2.
-		return rebucketExp(buckets, 2)
+		// Re-bucket as powers of 2.
+		return reBucketExp(buckets, 2)
 	case "seconds":
-		// Rebucket as powers of 10 and then merge all buckets greater
+		// Re-bucket as powers of 10 and then merge all buckets greater
 		// than 1 second into the +Inf bucket.
-		b := rebucketExp(buckets, 10)
+		b := reBucketExp(buckets, 10)
 		for i := range b {
 			if b[i] <= 1 {
 				continue
@@ -103,11 +103,11 @@ func RuntimeMetricsBucketsForUnit(buckets []float64, unit string) []float64 {
 	return buckets
 }
 
-// rebucketExp takes a list of bucket boundaries (lower bound inclusive) and
+// reBucketExp takes a list of bucket boundaries (lower bound inclusive) and
 // downsamples the buckets to those a multiple of base apart. The end result
 // is a roughly exponential (in many cases, perfectly exponential) bucketing
 // scheme.
-func rebucketExp(buckets []float64, base float64) []float64 {
+func reBucketExp(buckets []float64, base float64) []float64 {
 	bucket := buckets[0]
 	var newBuckets []float64
 	// We may see a -Inf here, in which case, add it and skip it

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -212,7 +212,7 @@ github.com/peterh/liner
 github.com/pkg/errors
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib
-# github.com/prometheus/client_golang v1.12.1
+# github.com/prometheus/client_golang v1.12.2
 ## explicit
 github.com/prometheus/client_golang/prometheus
 github.com/prometheus/client_golang/prometheus/collectors


### PR DESCRIPTION
Fixes #4697.

- three histograms lost their erroneous "_total" suffix
- one gc cpu fractions metrics is gone

Also, the tests now actually run on Go1.17+, I had misunderstood a build tag earlier.

We're using a deprecated option to keep all the metrics we had before.
In the future, it probably makes sense to use the advised collection only.
Alternatively, we could expose a config option.