### PR TITLE
plugins/logs: Update mechanism to escape field paths

### DIFF
--- a/plugins/logs/mask.go
+++ b/plugins/logs/mask.go
@@ -70,12 +70,12 @@ func newMaskRule(path string, opts ...maskRuleOption) (*maskRule, error) {
 
 	escapedParts := make([]string, len(parts))
 	for i := range parts {
-		_, err := url.QueryUnescape(parts[i])
+		_, err := url.PathUnescape(parts[i])
 		if err != nil {
 			return nil, err
 		}
 
-		escapedParts[i] = url.QueryEscape(parts[i])
+		escapedParts[i] = url.PathEscape(parts[i])
 	}
 
 	modifyFullObj := false

--- a/plugins/logs/mask_test.go
+++ b/plugins/logs/mask_test.go
@@ -541,6 +541,25 @@ func TestMaskRuleMask(t *testing.T) {
 			event: `{"input": {"foo": [{"bar": 1, "baz": 2}]}}`,
 			exp:   `{"input": {"foo": [{"baz": 2}]}, "erased": ["/input/foo/0/bar"]}`,
 		},
+		{
+			note: "erase input: special character in path",
+			ptr: &maskRule{
+				OP:   maskOPRemove,
+				Path: "/input/:path",
+			},
+			event: `{"input": {"bar": 1, ":path": "token"}}`,
+			exp:   `{"input": {"bar": 1}, "erased": ["/input/:path"]}`,
+		},
+		{
+			note: "upsert input: special character in path",
+			ptr: &maskRule{
+				OP:    maskOPUpsert,
+				Path:  "/input/:path",
+				Value: "upserted",
+			},
+			event: `{"input": {"bar": 1, ":path": "token"}}`,
+			exp:   `{"input": {"bar": 1, ":path": "upserted"}, "masked": ["/input/:path"]}`,
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
Earlier the paths to the field to perform an upsert or
remove operation on were escaped using Go's url.QueryEscape
method. This results in incorrect behavior when the paths contain
a reserved character like ":". This change updates to using
url.PathEscape instead to escape the input and result paths.

Fixes: #4717

Signed-off-by: Ashutosh Narkar <anarkar4387@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->
