### PR TITLE
build: integrate builtin_metadata.json handling in release process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,6 +168,15 @@ clean: wasm-lib-clean
 fuzz:
 	go test ./ast -fuzz FuzzParseStatementsAndCompileModules -fuzztime ${FUZZ_TIME} -v -run '^$$'
 
+.PHONY: update-builtin-metadata-release
+update-builtin-metadata-release:
+	build/update-version.sh "$(VERSION)"
+	make generate
+
+.PHONY: update-builtin-metadata-dev
+update-builtin-metadata-dev:
+	build/update-version.sh "$(VERSION)-dev"
+	make generate
 
 ######################################################
 #
@@ -479,7 +488,7 @@ check-go-module:
 ######################################################
 
 .PHONY: release-patch
-release-patch:
+release-patch: update-builtin-metadata-release
 ifeq ($(GITHUB_TOKEN),)
 	@echo "\033[0;31mGITHUB_TOKEN environment variable missing.\033[33m Provide a GitHub Personal Access Token (PAT) with the 'read:org' scope.\033[0m"
 endif
@@ -491,7 +500,7 @@ endif
 		/_src/build/gen-release-patch.sh --version=$(VERSION) --source-url=/_src
 
 .PHONY: dev-patch
-dev-patch:
+dev-patch: update-builtin-metadata-dev
 	@$(DOCKER) run $(DOCKER_FLAGS) \
 		-v $(PWD):/_src \
 		python:2.7 \

--- a/build/gen-dev-patch.sh
+++ b/build/gen-dev-patch.sh
@@ -39,8 +39,8 @@ cd $OPA_DIR
 
 LAST_VERSION=$(git describe --abbrev=0 --tags | cut -c 2-)
 
-update_makefile() {
-    sed -i='' -e "s/Version\s\+=\s\+\".\+\"$/Version = \"$VERSION-dev\"/" version/version.go
+update_version() {
+    ./build/update-version.sh "$VERSION-dev"
 }
 
 update_changelog() {
@@ -57,7 +57,7 @@ EOF
 }
 
 main() {
-    update_makefile
+    update_version
     update_changelog
     git --no-pager diff --no-color
 }

--- a/build/gen-release-patch.sh
+++ b/build/gen-release-patch.sh
@@ -41,8 +41,8 @@ if [ -z "$LAST_VERSION" ]; then
     LAST_VERSION=$(git describe --abbrev=0 --tags)
 fi
 
-update_makefile() {
-    sed -i='' -e "s/Version\s\+=\s\+\".\+\"$/Version = \"$VERSION\"/" version/version.go
+update_version() {
+    ./build/update-version.sh "$VERSION"
 }
 
 update_changelog() {
@@ -76,10 +76,16 @@ update_capabilities() {
     git add --intent-to-add capabilities/v$VERSION.json
 }
 
+update_metadata() {
+    cp $SOURCE_URL/builtin_metadata.json $OPA_DIR
+    git add --intent-to-add builtin_metadata.json
+}
+
 main() {
-    update_makefile
+    update_version
     update_changelog
     update_capabilities
+    update_metadata
     git --no-pager diff --no-color
 }
 

--- a/build/get-build-version.sh
+++ b/build/get-build-version.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-grep '^var Version' version/version.go | awk '{print $4}' | tr -d '"'
+awk -F'"' '/^var Version/{print $2}' version/version.go

--- a/build/update-version.sh
+++ b/build/update-version.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -e
+# NOTE(sr): This was the only way I've found to replace the string
+# reliably on OSX and Linux.
+perl -pi -e "s/Version = \".*\"$/Version = \"$1\"/" version/version.go

--- a/docs/devel/RELEASE.md
+++ b/docs/devel/RELEASE.md
@@ -185,6 +185,7 @@ Once the Pull Request has merged fetch the latest changes and tag the commit to
 prepare for publishing. Use the same instructions as defined above in normal
 release [publishing](#publishing) guide (being careful to tag the appropriate commit).
 
-Last step is to copy the CHANGELOG snippet and capabilities.json for the version to `main`. Create
-a new PR with the version information added below the `Unreleased` section. Remove
-any `Unreleased` notes if they were included in the bugfix release.
+Last step is to copy the CHANGELOG snippet and generated files
+(builtin_metadata.json and capabilities.json) for the version to `main`. Create
+a new PR with the version information added below the `Unreleased` section.
+Remove any `Unreleased` notes if they were included in the bugfix release.

--- a/internal/cmd/genbuiltinmetadata/main.go
+++ b/internal/cmd/genbuiltinmetadata/main.go
@@ -13,11 +13,16 @@ import (
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/internal/compiler/wasm"
 	"github.com/open-policy-agent/opa/types"
+	"github.com/open-policy-agent/opa/version"
 )
 
 func main() {
 	f := ast.CapabilitiesForThisVersion()
-	sorted := append(sortedCaps(), versionedCaps{version: "edge", caps: f})
+	sorted := sortedCaps()
+	if !strings.HasSuffix(version.Version, "-dev") {
+		sorted = append(sorted, versionedCaps{version: "v" + version.Version, caps: f})
+	}
+	sorted = append(sorted, versionedCaps{version: "edge", caps: f})
 
 	mdata := make(map[string]interface{})
 	categories := make(map[string][]string)


### PR DESCRIPTION
Fixes #4754.

Rule number one of release-script changes: it'll break the next release. 🤞 

This is more convoluted than it has to be, but it's because of this outline of our release process:

- A clean checkout is used to generate the release patch,
  1. it'll update the version/version.go file
  2. it'll copy the capabilities files
- go isn't available in the docker container running that script (we're using python there)
- the golang script generate builtin_metadata.json consumes the capabilities files

So now, we'll bump the version in version/version.go and run `make generate` before handing stuff off to the python container with its release patch generation. With an extra conditional in the script generating the builtin_metadata.json when its version doesn't end in `-dev`, we'll add the currently-to-be-released version to each builtin's "available_versions".

This is a bit of a mess. If anyone has a better idea, I'm all ears. I'd eventually love to drop all our custom code in favor of something like ko, but that's for another day.