### PR TITLE
plugins/discovery: Check for empty key config

### DIFF
--- a/plugins/discovery/discovery.go
+++ b/plugins/discovery/discovery.go
@@ -290,10 +290,12 @@ func (c *Discovery) processBundle(ctx context.Context, b *bundleApi.Bundle) (*pl
 		return nil, err
 	}
 
-	for key, kc := range keys {
-		if curr, ok := c.config.Signing.PublicKeys[key]; ok {
-			if !curr.Equal(kc) {
-				return nil, fmt.Errorf("updates to keys specified in the boot configuration are not allowed")
+	if c.config.Signing != nil {
+		for key, kc := range keys {
+			if curr, ok := c.config.Signing.PublicKeys[key]; ok {
+				if !curr.Equal(kc) {
+					return nil, fmt.Errorf("updates to keys specified in the boot configuration are not allowed")
+				}
 			}
 		}
 	}

--- a/plugins/discovery/discovery_test.go
+++ b/plugins/discovery/discovery_test.go
@@ -827,7 +827,42 @@ func TestProcessBundleWithSigning(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error %v", err)
 	}
+}
 
+func TestProcessBundleWithNoSigningConfig(t *testing.T) {
+	ctx := context.Background()
+
+	manager, err := plugins.New([]byte(`{
+		"labels": {"x": "y"},
+		"services": {
+			"localhost": {
+				"url": "http://localhost:9999"
+			}
+		},
+		"discovery": {"name": "config"}
+	}`), "test-id", inmem.New())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	disco, err := New(manager)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	initialBundle := makeDataBundle(1, `
+		{
+			"config": {
+				"bundles": {"test1": {"service": "localhost"}},
+				"keys": {"my_local_key": {"algorithm": "HS256", "key": "new_secret"}}
+			}
+		}
+	`)
+
+	_, err = disco.processBundle(ctx, initialBundle)
+	if err != nil {
+		t.Fatalf("Unexpected error %v", err)
+	}
 }
 
 type testServer struct {


### PR DESCRIPTION
Currently OPA allows users to use unsigned discovery
bundles that themselves point to signed service bundles.
The discovery plugin checks if the keys in the service bundle
do not update those in the boot config. It's possible that
the signing config in the discovery object be a nil pointer.
This is change adds a check for that.

Fixes: #4656

Signed-off-by: Ashutosh Narkar <anarkar4387@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->
