### PR TITLE
ast+format: introduce "contains" + "if" keywords

### DIFF
--- a/ast/compile.go
+++ b/ast/compile.go
@@ -3518,8 +3518,12 @@ func getGlobals(pkg *Package, rules []Var, imports []*Import) map[Var]*usedRef {
 	}
 
 	// Populate globals with imports.
-	for _, i := range imports {
-		globals[i.Name()] = &usedRef{ref: i.Path.Value.(Ref)}
+	for _, imp := range imports {
+		path := imp.Path.Value.(Ref)
+		if FutureRootDocument.Equal(path[0]) {
+			continue // ignore future imports
+		}
+		globals[imp.Name()] = &usedRef{ref: path}
 	}
 
 	return globals

--- a/ast/internal/tokens/tokens.go
+++ b/ast/internal/tokens/tokens.go
@@ -67,6 +67,8 @@ const (
 	Semicolon
 
 	Every
+	Contains
+	If
 )
 
 var strings = [...]string{
@@ -115,6 +117,8 @@ var strings = [...]string{
 	Dot:        ".",
 	Semicolon:  ";",
 	Every:      "every",
+	Contains:   "contains",
+	If:         "if",
 }
 
 var keywords = map[string]Token{

--- a/capabilities.json
+++ b/capabilities.json
@@ -4058,7 +4058,9 @@
     }
   ],
   "future_keywords": [
+    "contains",
     "every",
+    "if",
     "in"
   ],
   "wasm_abi_versions": [

--- a/docs/content/envoy-tutorial-istio.md
+++ b/docs/content/envoy-tutorial-istio.md
@@ -45,50 +45,50 @@ The `quick_start.yaml` manifest defines the following resources:
 
     ```live:example:module:openable
     package istio.authz
-
+    
+    import future.keywords
+    
     import input.attributes.request.http as http_request
     import input.parsed_path
-
+    
     default allow := false
-
-    allow {
-        parsed_path[0] == "health"
-        http_request.method == "GET"
+    
+    allow if {
+    	parsed_path[0] == "health"
+    	http_request.method == "GET"
     }
-
-    allow {
-        roles_for_user[r]
-        required_roles[r]
+    
+    allow if {
+    	some r in roles_for_user
+    	r in required_roles
     }
-
-    roles_for_user[r] {
-        r := user_roles[user_name][_]
+    
+    roles_for_user contains r if {
+    	some r in user_roles[user_name]
     }
-
-    required_roles[r] {
-        perm := role_perms[r][_]
-        perm.method == http_request.method
-        perm.path == http_request.path
+    
+    required_roles contains r if {
+    	some perm in role_perms[r]
+    	perm.method == http_request.method
+    	perm.path == http_request.path
     }
-
-    user_name := parsed {
-        [_, encoded] := split(http_request.headers.authorization, " ")
-        [parsed, _] := split(base64url.decode(encoded), ":")
+    
+    user_name := parsed if {
+    	[_, encoded] := split(http_request.headers.authorization, " ")
+    	[parsed, _] := split(base64url.decode(encoded), ":")
     }
-
+    
     user_roles := {
-        "alice": ["guest"],
-        "bob": ["admin"]
+    	"alice": ["guest"],
+    	"bob": ["admin"],
     }
-
+    
     role_perms := {
-        "guest": [
-            {"method": "GET",  "path": "/productpage"},
-        ],
-        "admin": [
-            {"method": "GET",  "path": "/productpage"},
-            {"method": "GET",  "path": "/api/v1/products"},
-        ],
+    	"guest": [{"method": "GET", "path": "/productpage"}],
+    	"admin": [
+    		{"method": "GET", "path": "/productpage"},
+    		{"method": "GET", "path": "/api/v1/products"},
+    	],
     }
     ```
 

--- a/docs/content/envoy-tutorial-standalone-envoy.md
+++ b/docs/content/envoy-tutorial-standalone-envoy.md
@@ -125,44 +125,46 @@ employee with the same `firstname` as himself.
 ```live:example:module:openable
 package envoy.authz
 
+import future.keywords
+
 import input.attributes.request.http as http_request
 
 default allow := false
 
-allow {
-    is_token_valid
-    action_allowed
+allow if {
+	is_token_valid
+	action_allowed
 }
 
-is_token_valid {
-    token.valid
-    now := time.now_ns() / 1000000000
-    token.payload.nbf <= now
-    now < token.payload.exp
+is_token_valid if {
+	token.valid
+	now := time.now_ns() / 1000000000
+	token.payload.nbf <= now
+	now < token.payload.exp
 }
 
-action_allowed {
-    http_request.method == "GET"
-    token.payload.role == "guest"
-    glob.match("/people", ["/"], http_request.path)
+action_allowed if {
+	http_request.method == "GET"
+	token.payload.role == "guest"
+	glob.match("/people", ["/"], http_request.path)
 }
 
-action_allowed {
-    http_request.method == "GET"
-    token.payload.role == "admin"
-    glob.match("/people", ["/"], http_request.path)
+action_allowed if {
+	http_request.method == "GET"
+	token.payload.role == "admin"
+	glob.match("/people", ["/"], http_request.path)
 }
 
-action_allowed {
-    http_request.method == "POST"
-    token.payload.role == "admin"
-    glob.match("/people", ["/"], http_request.path)
-    lower(input.parsed_body.firstname) != base64url.decode(token.payload.sub)
+action_allowed if {
+	http_request.method == "POST"
+	token.payload.role == "admin"
+	glob.match("/people", ["/"], http_request.path)
+	lower(input.parsed_body.firstname) != base64url.decode(token.payload.sub)
 }
 
-token := {"valid": valid, "payload": payload} {
-    [_, encoded] := split(http_request.headers.authorization, " ")
-    [valid, _, payload] := io.jwt.decode_verify(encoded, {"secret": "secret"})
+token := {"valid": valid, "payload": payload} if {
+	[_, encoded] := split(http_request.headers.authorization, " ")
+	[valid, _, payload] := io.jwt.decode_verify(encoded, {"secret": "secret"})
 }
 ```
 

--- a/docs/content/policy-reference.md
+++ b/docs/content/policy-reference.md
@@ -103,6 +103,11 @@ some [x, "b", z] in a_set
 
 ## Iteration
 
+```live:iteration:module:hidden
+package example
+import future.keywords
+```
+
 ### Arrays
 
 ```live:iteration/arrays:query:read_only
@@ -182,13 +187,13 @@ not any_not_match
 ```
 
 ```live:iteration/forall:module:read_only
-any_match {
-    set[x]
+any_match if {
+    some x in set
     f(x)
 }
 
-any_not_match {
-    set[x]
+any_not_match if {
+    some x in set
     not f(x)
 }
 ```
@@ -196,6 +201,11 @@ any_not_match {
 ## Rules
 
 In the examples below `...` represents one or more conditions.
+
+```live:rules:module:hidden
+package example
+import future.keywords
+```
 
 ### Constants
 
@@ -212,7 +222,9 @@ c := a | b
 p := true { ... }
 
 # OR
+p if { ... }
 
+# OR
 p { ... }
 ```
 
@@ -220,8 +232,8 @@ p { ... }
 
 ```live:rules/cond:module:read_only
 default a := 1
-a := 5 { ... }
-a := 100 { ... }
+a := 5   if { ... }
+a := 100 if { ... }
 ```
 
 ### Incremental
@@ -231,29 +243,33 @@ a := 100 { ... }
 a_set[x] { ... }
 a_set[y] { ... }
 
+# alternatively, with future.keywords
+a_set contains x if { ... }
+a_set contains y if { ... }
+
 # a_map will contain key->value pairs x->y and w->z
-a_map[x] := y { ... }
-a_map[w] := z { ... }
+a_map[x] := y if { ... }
+a_map[w] := z if { ... }
 ```
 
 ### Ordered (Else)
 
 ```live:rules/ordered:module:read_only
 default a := 1
-a := 5 { ... }
+a := 5 if { ... }
 else := 10 { ... }
 ```
 
 ### Functions (Boolean)
 
 ```live:rules/funcs:module:read_only
-f(x, y) {
+f(x, y) if {
     ...
 }
 
 # OR
 
-f(x, y) := true {
+f(x, y) := true if {
     ...
 }
 ```
@@ -261,9 +277,9 @@ f(x, y) := true {
 ### Functions (Conditionals)
 
 ```live:rules/condfuncs:module:read_only
-f(x) := "A" { x >= 90 }
-f(x) := "B" { x >= 80; x < 90 }
-f(x) := "C" { x >= 70; x < 80 }
+f(x) := "A" if { x >= 90 }
+f(x) := "B" if { x >= 80; x < 90 }
+f(x) := "C" if { x >= 70; x < 80 }
 ```
 
 ## Tests
@@ -1055,7 +1071,11 @@ package         = "package" ref
 import          = "import" ref [ "as" var ]
 policy          = { rule }
 rule            = [ "default" ] rule-head { rule-body }
-rule-head       = var [ "(" rule-args ")" ] [ "[" term "]" ] [ ( ":=" | "=" ) term ]
+rule-head       = var ( rule-head-set | rule-head-obj | rule-head-func | rule-head-comp )
+rule-head-comp  = [ ( ":=" | "=" ) term ]") [ "if" ]
+rule-head-obj   = [ "[" term "]" ] [ ( ":=" | "=" ) term ]) [ "if" ]
+rule-head-func  = [ "(" rule-args ")" ] [ ( ":=" | "=" ) term ]) [ "if" ]
+rule-head-set   = "contains" term [ "if" ] | "[" term "]"
 rule-args       = term { "," term }
 rule-body       = [ "else" [ ( ":=" | "=" ) term ] ] "{" query "}"
 query           = literal { ( ";" | ( [CR] LF ) ) literal }
@@ -1089,6 +1109,8 @@ set             = empty-set | non-empty-set
 non-empty-set   = "{" term { "," term } "}"
 empty-set       = "set(" ")"
 ```
+
+Note that the grammar corresponds to Rego with all future keywords enabled.
 
 The grammar defined above makes use of the following syntax. See [the Wikipedia page on EBNF](https://en.wikipedia.org/wiki/Extended_Backus–Naur_Form) for more details:
 

--- a/docs/website/scripts/live-blocks/src/preprocess/localEval.js
+++ b/docs/website/scripts/live-blocks/src/preprocess/localEval.js
@@ -91,6 +91,7 @@ async function prepEval(groups, groupName) {
     }
 
     if (query) {
+      rest.push('--import', 'future.keywords') // queries may contain them
       rest.push(query)
     } else { // Simulate playground default behavior
       if (included) {

--- a/format/format_test.go
+++ b/format/format_test.go
@@ -274,7 +274,7 @@ p {
 
 import future.keywords
 
-p {
+p if {
 	every k, v in [1, 2] { k != v }
 }`,
 		},
@@ -290,7 +290,7 @@ p {
 
 import future.keywords
 
-p {
+p if {
 	every k, v in [1, 2] { k != v }
 }`,
 		},

--- a/format/testfiles/test_contains.rego
+++ b/format/testfiles/test_contains.rego
@@ -1,0 +1,12 @@
+package test.contains
+import future.keywords.contains
+
+p contains "foo" { true }
+
+deny contains msg {
+  msg := "foo"
+}
+deny[msg] {msg := "bar" }
+
+# partial objects unchanged
+o[k] = v { k := "ok"; v := "nok" }

--- a/format/testfiles/test_contains.rego.formatted
+++ b/format/testfiles/test_contains.rego.formatted
@@ -1,0 +1,19 @@
+package test.contains
+
+import future.keywords.contains
+
+p contains "foo"
+
+deny contains msg {
+	msg := "foo"
+}
+
+deny contains msg {
+	msg := "bar"
+}
+
+# partial objects unchanged
+o[k] = v {
+	k := "ok"
+	v := "nok"
+}

--- a/format/testfiles/test_contains_if.rego
+++ b/format/testfiles/test_contains_if.rego
@@ -1,0 +1,17 @@
+package test.if
+
+import future.keywords
+
+q[x] = y if {
+	y := 10
+	x := "ten"
+}
+
+q[x] = y { # not using if
+	y := 11
+	x := "eleven"
+}
+
+r[x] { # no if here before
+	x := "set"
+}

--- a/format/testfiles/test_contains_if.rego.formatted
+++ b/format/testfiles/test_contains_if.rego.formatted
@@ -1,0 +1,17 @@
+package test.if
+
+import future.keywords
+
+q[x] = y if {
+	y := 10
+	x := "ten"
+}
+
+q[x] = y if { # not using if
+	y := 11
+	x := "eleven"
+}
+
+r contains x if { # no if here before
+	x := "set"
+}

--- a/format/testfiles/test_if.rego
+++ b/format/testfiles/test_if.rego
@@ -1,0 +1,32 @@
+package test.if
+
+import future.keywords.if
+
+p if 1 > 0 # shorthand
+
+p if { 1 > 0 } # longhand one line
+
+p if {
+  1 > 0 # longhand two lines
+}
+
+# same without the comment
+p if {
+  1 > 0
+}
+
+p if { # comment one
+  1 > 0 # comment two
+}
+
+q[x] = y if {
+    y := 10
+    x := "ten"
+}
+
+q[x] = y { # not using if
+    y := 11
+    x := "eleven"
+}
+
+r[x] { x := "set" } # no if here before

--- a/format/testfiles/test_if.rego.formatted
+++ b/format/testfiles/test_if.rego.formatted
@@ -1,0 +1,34 @@
+package test.if
+
+import future.keywords.if
+
+p if 1 > 0 # shorthand
+
+p if 1 > 0 # longhand one line
+
+p if {
+	1 > 0 # longhand two lines
+}
+
+# same without the comment
+p if {
+	1 > 0
+}
+
+p if { # comment one
+	1 > 0 # comment two
+}
+
+q[x] = y if {
+	y := 10
+	x := "ten"
+}
+
+q[x] = y if { # not using if
+	y := 11
+	x := "eleven"
+}
+
+r[x] { # no if here before
+	x := "set"
+}

--- a/format/testfiles/test_if_else.rego
+++ b/format/testfiles/test_if_else.rego
@@ -1,0 +1,13 @@
+package test.if
+
+import future.keywords.if
+
+p := 1 if { 1 > 0 }
+else := 2
+
+q := 1 if { 1 > 0 } else := 2 { 2 > 1 }
+
+q := 1 if {
+  1 > 0
+  2 > 1
+} else := 2 { 2 > 1 }

--- a/format/testfiles/test_if_else.rego.formatted
+++ b/format/testfiles/test_if_else.rego.formatted
@@ -1,0 +1,22 @@
+package test.if
+
+import future.keywords.if
+
+p := 1 if 1 > 0
+
+else := 2 {
+	true
+}
+
+q := 1 if 1 > 0
+
+else := 2 {
+	2 > 1
+}
+
+q := 1 if {
+	1 > 0
+	2 > 1
+} else := 2 {
+	2 > 1
+}

--- a/format/testfiles/test_in_operator_with_all_keywords_import.rego.formatted
+++ b/format/testfiles/test_in_operator_with_all_keywords_import.rego.formatted
@@ -3,7 +3,7 @@ package p
 import future.keywords
 import input.foo
 
-r {
+r if {
 	1 in [1]
 	0, 1 in [1]
 }

--- a/internal/future/filter_imports.go
+++ b/internal/future/filter_imports.go
@@ -18,3 +18,20 @@ func FilterFutureImports(imps []*ast.Import) []*ast.Import {
 	}
 	return ret
 }
+
+// IsAllFutureKeywords returns true if the passed *ast.Import is `future.keywords`
+func IsAllFutureKeywords(imp *ast.Import) bool {
+	path := imp.Path.Value.(ast.Ref)
+	return len(path) == 2 &&
+		ast.FutureRootDocument.Equal(path[0]) &&
+		path[1].Equal(ast.StringTerm("keywords"))
+}
+
+// IsFutureKeyword returns true if the passed *ast.Import is `future.keywords.{kw}`
+func IsFutureKeyword(imp *ast.Import, kw string) bool {
+	path := imp.Path.Value.(ast.Ref)
+	return len(path) == 3 &&
+		ast.FutureRootDocument.Equal(path[0]) &&
+		path[1].Equal(ast.StringTerm("keywords")) &&
+		path[2].Equal(ast.StringTerm(kw))
+}

--- a/test/cases/testdata/containskeyword/test-contains-future-keyword.yaml
+++ b/test/cases/testdata/containskeyword/test-contains-future-keyword.yaml
@@ -1,0 +1,67 @@
+cases:
+- data:
+  modules:
+  - |
+    package test
+    p {
+      contains("fireplace", "repl")
+    }
+  note: containskeyword/base case
+  query: data.test.p = x
+  want_result:
+  - x: true
+- data:
+  modules:
+  - |
+    package test
+    import future.keywords.contains
+
+    p {
+      contains("fireplace", "repl")
+    }
+  note: containskeyword/with unused kw import
+  query: data.test.p = x
+  want_result:
+  - x: true
+- data:
+  modules:
+  - |
+    package test
+    import future.keywords.contains
+
+    p contains "x" {
+      contains("fireplace", "repl")
+    }
+  note: containskeyword/with kw and builtin used
+  query: data.test.p = x
+  want_result:
+  - x: [x]
+- data:
+  modules:
+  - |
+    package test
+    import future.keywords.contains
+
+    p contains "x"
+  note: containskeyword/empty body
+  query: data.test.p = x
+  want_result:
+  - x: [x]
+- data:
+  modules:
+  - |
+    package test
+    import future.keywords.contains
+
+    p contains msg {
+      msg := "nono"
+    }
+    p contains msg {
+      msg := "nonono"
+    }
+  note: containskeyword/ordinary deny rule
+  query: data.test.p = x
+  want_result:
+  - x:
+    - nono
+    - nonono


### PR DESCRIPTION
### contains

This introduces another keyword to Rego: "contains"

It provides an alternative way to declare partial sets:

    p contains x {
      x := { "foo": "bar"
    }

which is the same as

    p[x] {
      x := { "foo": "bar"
    }

The keyword is enabled by importing `future.keywords.contains`, and
when it _is enabled_, the format will be used for all partial sets in
that file for pretty-printing.

### if

With this change, we can use `if`, and an optional shorthand for
rule definitions:

The syntax is

    NAME [if] { EXPR [EXPR...] }

and the shorthand allows dropping the braces around the expression
if there is only one:

    NAME if EXPR

For example, this allows expressions like

    allow if not deny
    f(xs) if every x in xs { x != "foo" }

The one exception here are partial sets: they cannot use `if` UNLESS
they use `contains`:

    p[x] { x := "foo" }            # valid
    p contains x { x := "bar" }    # valid
    p contains x if { x := "bar" } # valid
    p[x] if { x := "foo" }         # invalid

This is because we want to interpret that differently (as an object
rule defining `p.foo = true`) in the near future.

-------

🚧 TODO:
- [x] docs
  - [x] contains
  - [x] if
- [x] update grammar
  - [x] contains
  - [x] if