### PR TITLE
built-ins: use strings.Builder in glob.match()

### DIFF
--- a/topdown/glob.go
+++ b/topdown/glob.go
@@ -1,7 +1,7 @@
 package topdown
 
 import (
-	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/gobwas/glob"
@@ -33,7 +33,13 @@ func builtinGlobMatch(a, b, c ast.Value) (ast.Value, error) {
 		return nil, err
 	}
 
-	id := fmt.Sprintf("%s-%v", pattern, delimiters)
+	builder := strings.Builder{}
+	builder.WriteString(string(pattern))
+	builder.WriteRune('-')
+	for _, v := range delimiters {
+		builder.WriteRune(v)
+	}
+	id := builder.String()
 
 	globCacheLock.Lock()
 	defer globCacheLock.Unlock()
@@ -46,7 +52,8 @@ func builtinGlobMatch(a, b, c ast.Value) (ast.Value, error) {
 		globCache[id] = p
 	}
 
-	return ast.Boolean(p.Match(string(match))), nil
+	m := p.Match(string(match))
+	return ast.Boolean(m), nil
 }
 
 func builtinGlobQuoteMeta(a ast.Value) (ast.Value, error) {


### PR DESCRIPTION
Use strings.Builder to construct the ID for use in glob.match(). This
offers a slight performance improvement.

This also adds a benchmark to the glob.match() builtin.

Signed-off-by: Charles Daniels <charles@styra.com>


---

Before I made this optimization, this is what I got on the new benchmark:

```plain
pkg: github.com/open-policy-agent/opa/topdown
BenchmarkGlob/10-8         	   15644	     76413 ns/op
BenchmarkGlob/100-8        	    1770	    656534 ns/op
BenchmarkGlob/1000-8       	     178	   6645135 ns/op
BenchmarkGlob/10000-8      	      16	  69947432 ns/op
PASS
ok  	github.com/open-policy-agent/opa/topdown	9.025s
```

And after:

```plain
pkg: github.com/open-policy-agent/opa/topdown
BenchmarkGlob/10-8         	   19495	     61227 ns/op
BenchmarkGlob/100-8        	    2337	    511508 ns/op
BenchmarkGlob/1000-8       	     231	   5206028 ns/op
BenchmarkGlob/10000-8      	      20	  54776096 ns/op
PASS
ok  	github.com/open-policy-agent/opa/topdown	8.682s
```

Both tests were run on a 2021 14-inch Macbook Pro with an M1 Pro, 32GB of RAM, and running macOS Monterey 12.4.

I was hoping to achieve a much better speedup here, as `glob.match()` is a big performance hotspot for one of my use cases. However since I already did the work to try this patch out and analyze the performance, and it _is_ a marginal performance uplift...