### PR TITLE
runtime: don't lookup current user on windows

### DIFF
--- a/runtime/check_user_darwin.go
+++ b/runtime/check_user_darwin.go
@@ -1,0 +1,22 @@
+// Copyright 2022 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package runtime
+
+import (
+	"os/user"
+
+	"github.com/open-policy-agent/opa/logging"
+)
+
+// checkUserPrivileges on macos could not be running in Docker, so we only warn
+// if run as uid/gid 0.
+func checkUserPrivileges(logger logging.Logger) {
+	usr, err := user.Current()
+	if err != nil {
+		logger.Debug("Failed to determine uid/gid of process owner")
+	} else if usr.Uid == "0" || usr.Gid == "0" {
+		logger.Warn("OPA running with uid or gid 0. Running OPA with root privileges is not recommended.")
+	}
+}

--- a/runtime/check_user_linux.go
+++ b/runtime/check_user_linux.go
@@ -1,0 +1,27 @@
+// Copyright 2022 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package runtime
+
+import (
+	"os"
+	"os/user"
+
+	"github.com/open-policy-agent/opa/logging"
+)
+
+// checkUserPrivileges on Linux could be running in Docker, so we check if
+// we're running in the official container image.
+func checkUserPrivileges(logger logging.Logger) {
+	usr, err := user.Current()
+	if err != nil {
+		logger.Debug("Failed to determine uid/gid of process owner")
+	} else if usr.Uid == "0" || usr.Gid == "0" {
+		message := "OPA running with uid or gid 0. Running OPA with root privileges is not recommended."
+		if os.Getenv("OPA_DOCKER_IMAGE") == "official" {
+			message += " Use the -rootless image to avoid running with root privileges. This will be made the default in later OPA releases."
+		}
+		logger.Warn(message)
+	}
+}

--- a/runtime/check_user_windows.go
+++ b/runtime/check_user_windows.go
@@ -1,0 +1,14 @@
+// Copyright 2022 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package runtime
+
+import (
+	"github.com/open-policy-agent/opa/logging"
+)
+
+// checkUserPrivileges is a no-op in Windows to avoid lookups with
+// Active Directory and the like, when we don't care for the output
+// anyways.
+func checkUserPrivileges(logging.Logger) {}

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -15,7 +15,6 @@ import (
 	mr "math/rand"
 	"os"
 	"os/signal"
-	"os/user"
 	"strings"
 	"sync"
 	"syscall"
@@ -418,16 +417,7 @@ func (rt *Runtime) Serve(ctx context.Context) error {
 		rt.logger.Error("Token authentication enabled without authorization. Authentication will be ineffective. See https://www.openpolicyagent.org/docs/latest/security/#authentication-and-authorization for more information.")
 	}
 
-	usr, err := user.Current()
-	if err != nil {
-		rt.logger.Debug("Failed to determine uid/gid of process owner")
-	} else if usr.Uid == "0" || usr.Gid == "0" {
-		message := "OPA running with uid or gid 0. Running OPA with root privileges is not recommended."
-		if os.Getenv("OPA_DOCKER_IMAGE") == "official" {
-			message += " Use the -rootless image to avoid running with root privileges. This will be made the default in later OPA releases."
-		}
-		rt.logger.Warn(message)
-	}
+	checkUserPrivileges(rt.logger)
 
 	// NOTE(tsandall): at some point, hopefully we can remove this because the
 	// Go runtime will just do the right thing. Until then, try to set


### PR DESCRIPTION
We don't need it, and it can cause issues and delays we could avoid.
