### PR TITLE
Fix documentation of startswith and endswith builtins

### DIFF
--- a/ast/builtins.go
+++ b/ast/builtins.go
@@ -1046,8 +1046,8 @@ var StartsWith = &Builtin{
 	Description: "Returns true if the search string begins with the base string.",
 	Decl: types.NewFunction(
 		types.Args(
-			types.Named("base", types.S).Description("base string"),
 			types.Named("search", types.S).Description("search string"),
+			types.Named("base", types.S).Description("base string"),
 		),
 		types.Named("result", types.B).Description("result of the prefix check"),
 	),
@@ -1056,11 +1056,11 @@ var StartsWith = &Builtin{
 
 var EndsWith = &Builtin{
 	Name:        "endswith",
-	Description: "Returns true if the search string begins with the base string.",
+	Description: "Returns true if the search string ends with the base string.",
 	Decl: types.NewFunction(
 		types.Args(
-			types.Named("base", types.S).Description("base string"),
 			types.Named("search", types.S).Description("search string"),
+			types.Named("base", types.S).Description("base string"),
 		),
 		types.Named("result", types.B).Description("result of the suffix check"),
 	),

--- a/ast/compile_test.go
+++ b/ast/compile_test.go
@@ -6574,7 +6574,7 @@ func TestQueryCompiler(t *testing.T) {
 			q:        `startswith("x")`,
 			pkg:      "",
 			imports:  nil,
-			expected: fmt.Errorf("1 error occurred: 1:1: rego_type_error: startswith: arity mismatch\n\thave: (string)\n\twant: (base: string, search: string)"),
+			expected: fmt.Errorf("1 error occurred: 1:1: rego_type_error: startswith: arity mismatch\n\thave: (string)\n\twant: (search: string, base: string)"),
 		},
 		{
 			note:     "built-in function arity mismatch (arity 0)",

--- a/builtin_metadata.json
+++ b/builtin_metadata.json
@@ -3174,13 +3174,13 @@
   "endswith": {
     "args": [
       {
-        "description": "base string",
-        "name": "base",
+        "description": "search string",
+        "name": "search",
         "type": "string"
       },
       {
-        "description": "search string",
-        "name": "search",
+        "description": "base string",
+        "name": "base",
         "type": "string"
       }
     ],
@@ -3247,7 +3247,7 @@
       "v0.41.0",
       "edge"
     ],
-    "description": "Returns true if the search string begins with the base string.",
+    "description": "Returns true if the search string ends with the base string.",
     "introduced": "v0.17.0",
     "result": {
       "description": "result of the suffix check",
@@ -10405,13 +10405,13 @@
   "startswith": {
     "args": [
       {
-        "description": "base string",
-        "name": "base",
+        "description": "search string",
+        "name": "search",
         "type": "string"
       },
       {
-        "description": "search string",
-        "name": "search",
+        "description": "base string",
+        "name": "base",
         "type": "string"
       }
     ],


### PR DESCRIPTION
The names of function arguments have been mixed up:
the second argument is the string that will be searched for in the
string provided as first argument.
Additionally the documentation of the endswith function had a copy paste
mistake from the starswith documentation.

Signed-off-by: Max Hoehl <m.hoehl@sap.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->
