### PR TITLE
ci: bump golangci-lint to v1.46.2, fix some issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ ifeq ($(WASM_ENABLED),1)
 GO_TAGS = -tags=opa_wasm
 endif
 
-GOLANGCI_LINT_VERSION := v1.43.0
+GOLANGCI_LINT_VERSION := v1.46.2
 
 DOCKER_RUNNING ?= $(shell docker ps >/dev/null 2>&1 && echo 1 || echo 0)
 

--- a/ast/fuzz_test.go
+++ b/ast/fuzz_test.go
@@ -13,8 +13,9 @@ func FuzzParseStatementsAndCompileModules(f *testing.F) {
 	f.Fuzz(func(t *testing.T, input string) {
 		t.Parallel() // seed corpus tests can run in parallel
 		_, _, err := ParseStatements("", input)
-		if err != nil {
-			CompileModules(map[string]string{"": input})
+		if err == nil {
+			// CompileModules is expected to error, but it shouldn't panic
+			CompileModules(map[string]string{"": input}) //nolint
 		}
 	})
 }

--- a/ast/policy.go
+++ b/ast/policy.go
@@ -261,28 +261,22 @@ func (mod *Module) Copy() *Module {
 	cpy := *mod
 	cpy.Rules = make([]*Rule, len(mod.Rules))
 
-	nodes := make(map[Node]Node)
+	nodes := make(map[Node]Node, len(mod.Rules)+len(mod.Imports)+1 /* package */)
 
 	for i := range mod.Rules {
 		cpy.Rules[i] = mod.Rules[i].Copy()
 		cpy.Rules[i].Module = &cpy
-		if nodes != nil {
-			nodes[mod.Rules[i]] = cpy.Rules[i]
-		}
+		nodes[mod.Rules[i]] = cpy.Rules[i]
 	}
 
 	cpy.Imports = make([]*Import, len(mod.Imports))
 	for i := range mod.Imports {
 		cpy.Imports[i] = mod.Imports[i].Copy()
-		if nodes != nil {
-			nodes[mod.Imports[i]] = cpy.Imports[i]
-		}
+		nodes[mod.Imports[i]] = cpy.Imports[i]
 	}
 
 	cpy.Package = mod.Package.Copy()
-	if nodes != nil {
-		nodes[mod.Package] = cpy.Package
-	}
+	nodes[mod.Package] = cpy.Package
 
 	cpy.Annotations = make([]*Annotations, len(mod.Annotations))
 	for i := range mod.Annotations {

--- a/ast/term.go
+++ b/ast/term.go
@@ -1570,9 +1570,7 @@ func (s *set) MarshalJSON() ([]byte, error) {
 // Sorted returns an Array that contains the sorted elements of s.
 func (s *set) Sorted() *Array {
 	cpy := make([]*Term, len(s.keys))
-	for i := range s.keys {
-		cpy[i] = s.keys[i]
-	}
+	copy(cpy, s.keys)
 	sort.Sort(termSlice(cpy))
 	return NewArray(cpy...)
 }

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -336,7 +336,7 @@ func generateTableWithKeys(writer io.Writer, keys ...string) *tablewriter.Table 
 	aligns := []int{}
 	var hdrs []string
 	for _, k := range keys {
-		hdrs = append(hdrs, strings.Title((k)))
+		hdrs = append(hdrs, strings.Title(k)) //nolint:staticcheck // SA1019, no unicode
 		aligns = append(aligns, tablewriter.ALIGN_LEFT)
 	}
 	table.SetHeader(hdrs)

--- a/internal/presentation/presentation.go
+++ b/internal/presentation/presentation.go
@@ -600,7 +600,7 @@ func generateTableWithKeys(writer io.Writer, keys ...string) *tablewriter.Table 
 	aligns := []int{}
 	var hdrs []string
 	for _, k := range keys {
-		hdrs = append(hdrs, strings.Title((k)))
+		hdrs = append(hdrs, strings.Title(k)) //nolint:staticcheck // SA1019, no unicode here
 		aligns = append(aligns, tablewriter.ALIGN_LEFT)
 	}
 	table.SetHeader(hdrs)

--- a/tester/reporter.go
+++ b/tester/reporter.go
@@ -141,7 +141,7 @@ func (r PrettyReporter) fmtBenchmark(tr *Result) string {
 		// like BenchmarkDataFooBarTestAuth.
 		camelCaseName := ""
 		for _, part := range strings.Split(strings.Replace(name, "_", ".", -1), ".") {
-			camelCaseName += strings.Title(part)
+			camelCaseName += strings.Title(part) //nolint:staticcheck // SA1019, no unicode here
 		}
 		name = "Benchmark" + camelCaseName
 	}


### PR DESCRIPTION
Fixes #4765; at least in a way. None of the new findings were err-related.

⚠️ Note that golangci-lint tries hard to cut down the number of issues it presents the user:
```
level=info msg="[runner] Issues before processing: 429, after processing: 0"
```
which is why a plain `errcheck` run is expected to turn up more problems than a golangci-lint run of the `errcheck` linter.