### PR TITLE
ci: pass --region to 'aws s3 sync' command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -430,7 +430,7 @@ ci-binary-smoke-test-%:
 
 .PHONY: push-binary-edge
 push-binary-edge:
-	aws s3 sync $(RELEASE_DIR) s3://$(S3_RELEASE_BUCKET)/edge/ --no-progress
+	aws s3 sync $(RELEASE_DIR) s3://$(S3_RELEASE_BUCKET)/edge/ --no-progress --region us-west-1
 
 .PHONY: docker-login
 docker-login:


### PR DESCRIPTION
This is an attempt to fix an obscure condition that started last week:
the `aws s3 sync` command in our `deploy-ci` make target started failing,
with only this output:

    <botocore.awsrequest.AWSRequest object at 0x7f3198832f70>

A promising google hit suggests that it's got to do with "what's the best
region for me?" auto-discovery failing. Passing any region should then do
the trick.

Ref: https://florian.ec/blog/github-actions-awscli-errors/

