### PR TITLE
Object Insertion Rework

### DIFF
--- a/ast/term_test.go
+++ b/ast/term_test.go
@@ -263,37 +263,6 @@ func TestObjectFilter(t *testing.T) {
 	}
 }
 
-func TestObjectInsertKeepsSorting(t *testing.T) {
-	keysSorted := func(o *object) func(int, int) bool {
-		return func(i, j int) bool {
-			return Compare(o.keys[i].key, o.keys[j].key) < 0
-		}
-	}
-
-	obj := NewObject(
-		[2]*Term{StringTerm("d"), IntNumberTerm(4)},
-		[2]*Term{StringTerm("b"), IntNumberTerm(2)},
-		[2]*Term{StringTerm("a"), IntNumberTerm(1)},
-	)
-	o := obj.(*object)
-	act := sort.SliceIsSorted(o.keys, keysSorted(o))
-	if exp := true; act != exp {
-		t.Errorf("SliceIsSorted: expected %v, got %v", exp, act)
-		for i := range o.keys {
-			t.Logf("elem[%d]: %v", i, o.keys[i].key)
-		}
-	}
-
-	obj.Insert(StringTerm("c"), IntNumberTerm(3))
-	act = sort.SliceIsSorted(o.keys, keysSorted(o))
-	if exp := true; act != exp {
-		t.Errorf("SliceIsSorted: expected %v, got %v", exp, act)
-		for i := range o.keys {
-			t.Logf("elem[%d]: %v", i, o.keys[i].key)
-		}
-	}
-}
-
 func TestSetInsertKeepsKeysSorting(t *testing.T) {
 	keysSorted := func(s *set) func(int, int) bool {
 		return func(i, j int) bool {

--- a/topdown/eval.go
+++ b/topdown/eval.go
@@ -909,20 +909,20 @@ func (e *eval) biunifyObjects(a, b ast.Object, b1, b2 *bindings, iter unifyItera
 		b = plugKeys(b, b2)
 	}
 
-	return e.biunifyObjectsRec(a, b, b1, b2, iter, a, 0)
+	return e.biunifyObjectsRec(a, b, b1, b2, iter, a, a.KeysIterator())
 }
 
-func (e *eval) biunifyObjectsRec(a, b ast.Object, b1, b2 *bindings, iter unifyIterator, keys ast.Object, idx int) error {
-	if idx == keys.Len() {
+func (e *eval) biunifyObjectsRec(a, b ast.Object, b1, b2 *bindings, iter unifyIterator, keys ast.Object, oki ast.ObjectKeysIterator) error {
+	key, more := oki.Next() // Get next key from iterator.
+	if !more {
 		return iter()
 	}
-	key, _ := keys.Elem(idx)
 	v2 := b.Get(key)
 	if v2 == nil {
 		return nil
 	}
 	return e.biunify(a.Get(key), v2, b1, b2, func() error {
-		return e.biunifyObjectsRec(a, b, b1, b2, iter, keys, idx+1)
+		return e.biunifyObjectsRec(a, b, b1, b2, iter, keys, oki)
 	})
 }
 


### PR DESCRIPTION
## Planned Changes

This PR changes the sorting behavior of the `ast.Object` type, from sorting on each insertion, to sorting only when a canonical key ordering is required, and the keys are not already in sorted order. This dramatically changes the asymptotics of several operations for `ast.Object`, and requires that all future users of `obj.keys` use `obj.keysSorted()` instead.

Externally (at the language level) no key ordering is guaranteed, but internally, we need a canonical key ordering-- which sorted keys provide.

**Historical Context**: Originally, an object's keys were assumed to be in *unsorted order*, and required sorting at each use site that needed a canonical key order. In the changes of #3823, we enforced *keys always being in sorted order* by sorting them at insertion time, and this provided implementation complexity and performance benefits across the compiler, while correcting a few subtle bugs that were affecting downstream users, like Gatekeeper.

**Proposed Behavior**: The key difference between this PR's behavior and prior behaviors for `ast.Object` is that the keys are *supposed* to be in sorted order *by default* now, but might be temporarily not in sorted order. We lazily correct the sorting at usage sites where an `ast.Object` might produce keys for external consumption. This should keep the correctness and implementation complexity benefits from #3823, but allow for improved asymptotic behavior overall, and especially for insertions.

~~This PR will swap out the current implementation of `ast.Object` to use a linked-list, or other data structure for storing keys. This is expected to dramatically improve insertion performance as objects are constructed, since it will cut out the existing realloc overheads of the current slice-based implementation.~~

~~To preserve ordering requirements, I intend to implement [Insertion Sorting](https://en.wikipedia.org/wiki/Insertion_sort) during `Object.Insert` operations, since this can be done online at little additional cost over simply appending to the linked list.~~ (See comment thread below for how this naive approach didn't work out too well. :sweat_smile: )

## Task List

 - [X] Find or build a performance benchmark. ([`BenchmarkObjectConstruction`](https://github.com/open-policy-agent/opa/blob/main/ast/term_bench_test.go#L157-L197) is perfect for the job, and already exists!)
 - [X] Remove all `Object.Elem` uses in the OPA codebase to see what breaks.
   - [x] Patch evaluator's Object biunification to not need `Object.Elem` anymore.
     - :x: Naive implementation with `Object.Iter` didn't work out, may need to construct some kind of iterator for keys to keep original continuation-passing callback style)
     - :heavy_check_mark:  The `ObjectKeysIterator` approach *does* seem to work!
 - [x] Rework key storage for Objects.
   - [X] Change implementation and propagate changes to all relevant sites in `term.go`
   - [X] InsertionSort implementation in `Object.Insert`, or underlying helper functions.
     - :x: This wound up being a terrible idea, since InsertionSort can have an *O(N)* cost in the worst case. (Reverted these changes)
   - [X] :heavy_check_mark: Made key sorting lazy.
     - Object construction benchmark now shows nearly linear scaling for `Object.Insert`
 - [x] Performance/memory evaluation.
   - [x] New representative benchmark tests
     - Ensures that we see the true costs around lazy key sorting, and can see improvements over time.
     - Existing `BenchmarkObjectConstruction` may need minor revisions, but covers the "all inserts, no reads" case nicely.
     - :heavy_check_mark: `BenchmarkObjectStringInterfaces` benchmark. (Covers the "many Insert() + Get()" case)
     - :heavy_check_mark: `BenchmarkObjectCreationAndLookup` benchmark. (Forces key sorting overheads.)
 - Document the key sortedness change for library users of OPA?

Fixes #4625.