### PR TITLE
release process: fix metadata logic

### DIFF
--- a/build/check-working-copy.sh
+++ b/build/check-working-copy.sh
@@ -26,5 +26,7 @@ if [[ "${HAS_CHANGES}" == "1" ]]; then
   echo ""
   echo "git status"
   git status
+  echo "git diff"
+  git diff
   exit 1
 fi

--- a/internal/cmd/genbuiltinmetadata/main.go
+++ b/internal/cmd/genbuiltinmetadata/main.go
@@ -13,15 +13,11 @@ import (
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/internal/compiler/wasm"
 	"github.com/open-policy-agent/opa/types"
-	"github.com/open-policy-agent/opa/version"
 )
 
 func main() {
 	f := ast.CapabilitiesForThisVersion()
 	sorted := sortedCaps()
-	if !strings.HasSuffix(version.Version, "-dev") {
-		sorted = append(sorted, versionedCaps{version: "v" + version.Version, caps: f})
-	}
 	sorted = append(sorted, versionedCaps{version: "edge", caps: f})
 
 	mdata := make(map[string]interface{})


### PR DESCRIPTION
#4763 had overcompensated. Now we're not adding the latest version twice.