### PR TITLE
Add line count to test coverage report

### DIFF
--- a/cover/cover.go
+++ b/cover/cover.go
@@ -86,14 +86,18 @@ func (c *Cover) Report(modules map[string]*ast.Module) (report Report) {
 
 	for _, fr := range report.Files {
 		fr.Coverage = fr.computeCoveragePercentage()
-		coveredLoc += fr.locCovered()
-		notCoveredLoc += fr.locNotCovered()
+		fr.CoveredLines = fr.locCovered()
+		fr.NotCoveredLines = fr.locNotCovered()
+		coveredLoc += fr.CoveredLines
+		notCoveredLoc += fr.NotCoveredLines
 	}
 	totalLoc := coveredLoc + notCoveredLoc
 
 	if totalLoc != 0 {
 		overallCoverage = 100.0 * float64(coveredLoc) / float64(totalLoc)
 	}
+	report.CoveredLines = coveredLoc
+	report.NotCoveredLines = notCoveredLoc
 	report.Coverage = round(overallCoverage, 2)
 
 	return
@@ -158,9 +162,11 @@ func (r Range) In(row int) bool {
 
 // FileReport represents a coverage report for a single file.
 type FileReport struct {
-	Covered    []Range `json:"covered,omitempty"`
-	NotCovered []Range `json:"not_covered,omitempty"`
-	Coverage   float64 `json:"coverage,omitempty"`
+	Covered         []Range `json:"covered,omitempty"`
+	NotCovered      []Range `json:"not_covered,omitempty"`
+	CoveredLines    int     `json:"covered_lines,omitempty"`
+	NotCoveredLines int     `json:"not_covered_lines,omitempty"`
+	Coverage        float64 `json:"coverage,omitempty"`
 }
 
 // IsCovered returns true if the row is marked as covered in the report.
@@ -222,8 +228,10 @@ func (fr *FileReport) computeCoveragePercentage() float64 {
 
 // Report represents a coverage report for a set of files.
 type Report struct {
-	Files    map[string]*FileReport `json:"files"`
-	Coverage float64                `json:"coverage"`
+	Files           map[string]*FileReport `json:"files"`
+	CoveredLines    int                    `json:"covered_lines"`
+	NotCoveredLines int                    `json:"not_covered_lines"`
+	Coverage        float64                `json:"coverage"`
 }
 
 // IsCovered returns true if the row in the given file is covered.

--- a/docs/content/policy-testing.md
+++ b/docs/content/policy-testing.md
@@ -472,7 +472,10 @@ opa test --coverage --format=json example.rego example_test.rego
             "row": 8
           }
         }
-      ]
+      ],
+      "covered_lines": 6,
+      "not_covered_lines": 1,
+      "coverage": 85.7
     },
     "example_test.rego": {
       "covered": [
@@ -500,8 +503,13 @@ opa test --coverage --format=json example.rego example_test.rego
             "row": 12
           }
         }
-      ]
-    }
+      ],
+      "covered_lines": 6,
+      "coverage": 100
+    },
+    "covered_lines": 12,
+    "not_covered_lines": 1,
+    "coverage": 92.3
   }
 }
 ```


### PR DESCRIPTION
Adds `covered_lines` and `not_covered_lines` to the test coverage report for each file and the total. This allows custom scripts to more easily parse the output and calculate its own coverage numbers skipping certain files, e.g. test files or external policy dependencies.
Whilst these numbers can be calculated manually, custom scripts would be much simpler having these numbers already present and it's also more clear to readers how coverage is calculated.

No tests were added as these fields use existing methods that are already tested.