### PR TITLE
topdown: Make *.is_valid function behavior more consistent

### DIFF
--- a/test/cases/testdata/jsonbuiltins/test-is-valid.yaml
+++ b/test/cases/testdata/jsonbuiltins/test-is-valid.yaml
@@ -12,6 +12,7 @@ cases:
     ]
 
     p = [x | doc = documents[_]; json.is_valid(doc, x)]
+  strict_error: true
   want_result:
   - x:
     - false
@@ -28,9 +29,9 @@ cases:
     }
   query: data.generated.p = x
   input: {"foo": 1}
-  want_error: operand 1 must be string but got number
-  want_error_code: eval_type_error
   strict_error: true
+  want_result:
+  - x: false
 
 - note: jsonbuiltins/yaml is_valid
   query: data.generated.p = x
@@ -49,6 +50,7 @@ cases:
     ]
 
     p = [x | doc = documents[_]; yaml.is_valid(doc, x)]
+  strict_error: true
   want_result:
   - x:
     - true
@@ -65,6 +67,6 @@ cases:
     }
   query: data.generated.p = x
   input: {"foo": 1}
-  want_error: operand 1 must be string but got number
-  want_error_code: eval_type_error
   strict_error: true
+  want_result:
+  - x: false

--- a/topdown/encoding.go
+++ b/topdown/encoding.go
@@ -55,7 +55,7 @@ func builtinJSONIsValid(a ast.Value) (ast.Value, error) {
 
 	str, err := builtins.StringOperand(a, 1)
 	if err != nil {
-		return nil, err
+		return ast.Boolean(false), nil
 	}
 
 	return ast.Boolean(json.Valid([]byte(str))), nil
@@ -83,7 +83,7 @@ func builtinBase64Decode(a ast.Value) (ast.Value, error) {
 func builtinBase64IsValid(a ast.Value) (ast.Value, error) {
 	str, err := builtins.StringOperand(a, 1)
 	if err != nil {
-		return nil, err
+		return ast.Boolean(false), nil
 	}
 
 	_, err = base64.StdEncoding.DecodeString(string(str))
@@ -257,7 +257,7 @@ func builtinYAMLUnmarshal(a ast.Value) (ast.Value, error) {
 func builtinYAMLIsValid(a ast.Value) (ast.Value, error) {
 	str, err := builtins.StringOperand(a, 1)
 	if err != nil {
-		return nil, err
+		return ast.Boolean(false), nil
 	}
 
 	var x interface{}

--- a/topdown/graphql.go
+++ b/topdown/graphql.go
@@ -343,11 +343,11 @@ func builtinGraphQLIsValid(_ BuiltinContext, operands []*ast.Term, iter func(*as
 	// feed them to the GraphQL parser functions.
 	rawQuery, err := builtins.StringOperand(operands[0].Value, 1)
 	if err != nil {
-		return err
+		return iter(ast.BooleanTerm(false))
 	}
 	rawSchema, err := builtins.StringOperand(operands[1].Value, 1)
 	if err != nil {
-		return err
+		return iter(ast.BooleanTerm(false))
 	}
 
 	// Generate ASTs/errors for the GraphQL schema and query.

--- a/topdown/semver.go
+++ b/topdown/semver.go
@@ -40,8 +40,7 @@ func builtinSemVerCompare(bctx BuiltinContext, args []*ast.Term, iter func(*ast.
 func builtinSemVerIsValid(bctx BuiltinContext, args []*ast.Term, iter func(*ast.Term) error) error {
 	versionString, err := builtins.StringOperand(args[0].Value, 1)
 	if err != nil {
-		result := ast.BooleanTerm(false)
-		return iter(result)
+		return iter(ast.BooleanTerm(false))
 	}
 
 	result := true

--- a/wasm/src/encoding.c
+++ b/wasm/src/encoding.c
@@ -223,7 +223,7 @@ opa_value *opa_base64_is_valid(opa_value *a)
 {
     if (opa_value_type(a) != OPA_STRING)
     {
-        return NULL;
+        return opa_boolean(false);
     }
 
     opa_string_t *s = opa_cast_string(a);
@@ -323,7 +323,7 @@ opa_value *opa_json_is_valid(opa_value *a)
 {
     if (opa_value_type(a) != OPA_STRING)
     {
-        return NULL;
+        return opa_boolean(false);
     }
 
 


### PR DESCRIPTION
This PR changes the behavior of the `*.is_valid` builtins to consistently return **only** true/false values, with no runtime/builtin errors. No docs changes should be required, since this is the documented behavior of these functions.

The affected list of builtins:

Encoding:
 - `base64.is_valid`
 - `json.is_valid`
 - `yaml.is_valid`

 GraphQL:
  - `graphql.is_valid`

Regex:
 - `regex.is_valid` (already implements behavior)

Semver:
 - `semver.is_valid`

Questionable additions to the list:
 - `io.jwt.verifyX` functions?

Fixes #4760.