### PR TITLE
storage/inmem: Create path if does not exist during truncate

### DIFF
--- a/storage/inmem/inmem.go
+++ b/storage/inmem/inmem.go
@@ -121,6 +121,17 @@ func (db *store) Truncate(ctx context.Context, txn storage.Transaction, _ storag
 					return err
 				}
 
+				_, err := underlying.Read(update.Path[:len(update.Path)-1])
+				if err != nil {
+					if !storage.IsNotFound(err) {
+						return err
+					}
+
+					if err := storage.MakeDir(ctx, db, txn, update.Path[:len(update.Path)-1]); err != nil {
+						return err
+					}
+				}
+
 				err = underlying.Write(storage.AddOp, update.Path, obj)
 				if err != nil {
 					return err


### PR DESCRIPTION
A data write performed at a non-root nonexistent path
in the im-memory store during a trucnate op would cause a
storage not found error. This change creates a path if one
does not exist before writing data.

Signed-off-by: Ashutosh Narkar <anarkar4387@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->
