### PR TITLE
topdown/parse_units: Use big.Rat for units parsing.

### DIFF
--- a/test/cases/testdata/units/test-issue-4856.yaml
+++ b/test/cases/testdata/units/test-issue-4856.yaml
@@ -1,0 +1,30 @@
+cases:
+- data:
+  modules:
+  - |
+    package test
+    p {
+        units.parse("500m") == 0.5
+    }
+  note: units_parse/exact comparison - regression case 1
+  query: data.test.p = x
+  want_result:
+  - x: true
+  - |
+    package test
+    p {
+        units.parse("0.0005K") == 0.5
+    }
+  note: units_parse/exact comparison - regression case 2
+  query: data.test.p = x
+  want_result:
+  - x: true
+  - |
+    package test
+    p {
+        units.parse("0.0000005M") == 0.5
+    }
+  note: units_parse/exact comparison - regression case 3
+  query: data.test.p = x
+  want_result:
+  - x: true


### PR DESCRIPTION
Previously, we used `big.Float` for units parsing, but this resulted in occasional rounding issues, due to values like `0.001` not being perfectly representable in floating-point format.

This issue was fixed by switching units parsing to use `big.Rat`, since Rationals can generally handle such quantities with perfect precision.

A few new regression test cases have been added to the test suite, lifted almost verbatim from the original issue.

Fixes #4856.