### PR TITLE
website/live-blocks: update codemirror-rego to 1.3.0

### DIFF
--- a/docs/website/scripts/live-blocks/package-lock.json
+++ b/docs/website/scripts/live-blocks/package-lock.json
@@ -1625,9 +1625,9 @@
       "integrity": "sha512-+D1NZjAucuzE93vJGbAaXzvoBHwp9nJZWWWF9utjv25+5AZUiah6CIlfb4ikG4MoDsFsCG8niiJH5++OO2LgIQ=="
     },
     "codemirror-rego": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/codemirror-rego/-/codemirror-rego-1.1.0.tgz",
-      "integrity": "sha512-knGIT7jLKVLljy+ABDetmqeinqBefF5rvjNNm7LH7zHz0dbw+1P5UxdocXi/LTCXss9XHBxWE1DSx2e/CsXNJw=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/codemirror-rego/-/codemirror-rego-1.3.0.tgz",
+      "integrity": "sha512-5GI/UCJZbOiPuwDE9UMh3k5aPWAtNOJzblx8loHdbNBz/3MJeOmjHXnhxq0ibNSIArLedvVv2neITcWhm6x+ew=="
     },
     "color-convert": {
       "version": "1.9.3",

--- a/docs/website/scripts/live-blocks/package.json
+++ b/docs/website/scripts/live-blocks/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "cheerio": "^1.0.0-rc.3",
     "codemirror": "^5.58.2",
-    "codemirror-rego": "^1.1.0",
+    "codemirror-rego": "^1.3.0",
     "esm": "^3.2.25",
     "node-fetch": "^2.6.7",
     "tmp": "^0.2.1"


### PR DESCRIPTION
...for proper highlighting of "contains" and "if":

Before

<img width="534" alt="image" src="https://user-images.githubusercontent.com/870638/177971605-75816b2b-3385-40d5-9b2f-d9943a2dbf3a.png">


After

<img width="573" alt="image" src="https://user-images.githubusercontent.com/870638/177971083-6d21eb76-a20b-4aa7-ae1f-2ad781ec6016.png">
