### PR TITLE
storage/disk: make symlinks work with relative paths

### DIFF
--- a/storage/disk/disk.go
+++ b/storage/disk/disk.go
@@ -351,17 +351,20 @@ func (db *Store) Truncate(ctx context.Context, txn storage.Transaction, params s
 
 	// update symlink to point to the active db
 	symlink := filepath.Join(path.Dir(newDB.Opts().Dir), symlinkKey)
+	// "active" -> "backupXXXX" is what we want, not
+	// "active" -> "DIR/backupXXX", since that won't work when using a relative directory
+	target := filepath.Base(newDB.Opts().Dir)
 	if _, err := os.Lstat(symlink); err == nil {
 		if err := os.Remove(symlink); err != nil {
 			return wrapError(err)
 		}
 
-		err = os.Symlink(newDB.Opts().Dir, symlink)
+		err = os.Symlink(target, symlink)
 		if err != nil {
 			return wrapError(err)
 		}
 	} else if errors.Is(err, os.ErrNotExist) {
-		err = os.Symlink(newDB.Opts().Dir, symlink)
+		err = os.Symlink(target, symlink)
 		if err != nil {
 			return wrapError(err)
 		}


### PR DESCRIPTION
So for now, we'll properly create the symlinks without the wrong indirection.

Fixes #4869.

~I'm still looking into remediation logic: _if the symlink is wrong, fix it automatically_.~

Update: I think we should keep this as-is. The first is simple enough to guide the few people who could have run into it at this point to the proper steps.