### PR TITLE
bundle: Normalize paths before bundle root check

### DIFF
--- a/bundle/store.go
+++ b/bundle/store.go
@@ -493,6 +493,10 @@ func doDFS(obj map[string]json.RawMessage, path string, roots []string) error {
 
 		newPath := filepath.Join(strings.Trim(path, "/"), key)
 
+		// Note: filepath.Join can return paths with '\' separators, always use
+		// filepath.ToSlash to keep them normalized.
+		newPath = strings.TrimLeft(filepath.ToSlash(newPath), "/.")
+
 		contains := false
 		prefix := false
 		if RootPathsContain(roots, newPath) {


### PR DESCRIPTION
filepath.Join can return paths with \ separators. So
when this command is run on Windows the paths are joined
using \ separator. But the bundle root check logic assumes the paths
are '/' separated. This change processes the result of filepath.Join
is ensure the path has '/' separators.

Signed-off-by: Ashutosh Narkar <anarkar4387@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->
