### PR TITLE
Change maintainers for Gatekeeper

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -5,6 +5,7 @@ The following table lists OPA project maintainers and areas of expertise in alph
 | Name | GitHub | Email | Organization | Repositories/Area of Expertise | Added/Renewed On |
 | --- | --- | --- | --- | --- | --- |
 | Ash Narkar | @ashutosh-narkar | anarkar4387@gmail.com | Styra | opa, opa-envoy-plugin | 2022-03-24 |
+| Ernest Wong | @chewong | chwong719@gmail.com | Microsoft | frameworks/constraints, gatekeeper, gatekeeper-library, cert-controller | 2022-07-13 |
 | Max Smythe | @maxsmythe | smythe@google.com | Google | frameworks/constraints, gatekeeper, gatekeeper-library, cert-controller | 2022-03-24 |
 | Oren Shomron | @shomron | shomron@gmail.com | VMware | frameworks/constraints, gatekeeper, gatekeeper-library, cert-controller | 2020-11-13 |
 | Rita Zhang | @ritazh | rita.z.zhang@gmail.com | Microsoft | frameworks/constraints, gatekeeper, gatekeeper-library, cert-controller | 2022-03-24 |
@@ -12,9 +13,9 @@ The following table lists OPA project maintainers and areas of expertise in alph
 | Stephan Renatus | @srenatus | stephan@styra.com | Styra | opa | 2022-04-04 |
 | Tim Hinrichs | @timothyhinrichs | timothy.l.hinrichs@gmail.com | Styra | all repositories | 2022-03-24 |
 | Torin Sandall | @tsandall | torinsandall@gmail.com | Styra | all repositories | 2022-03-24 |
-| Will Beason | @willbeason | willbeason@google.com | Google | gatekeeper, gatekeeper-library, cert-controller  | 2022-03-24 |
 
 ## Emeritus
 
 * [Craig Tabita](https://github.com/ctab)
 * [Patrick East](https://github.com/patrick-east)
+* [Will Beason](https://github.com/willbeason)


### PR DESCRIPTION
Move Will Beason to emeritus status, add Ernest as a maintainer.

Looks like this needs a 2/3 vote at the organization level.

https://github.com/open-policy-agent/opa/blob/main/GOVERNANCE.md#changes-in-maintainership


<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->
