### PR TITLE
plugins: accept any HTTP 2xx for status and logs

### DIFF
--- a/docs/content/management-decision-logs.md
+++ b/docs/content/management-decision-logs.md
@@ -76,10 +76,10 @@ Decision log updates contain the following fields:
 | `[_].erased` | `array[string]` | Set of JSON Pointers specifying fields in the event that were erased. |
 | `[_].masked` | `array[string]` | Set of JSON Pointers specifying fields in the event that were masked. |
 
-If the decision log was successfully uploaded to the remote service, it should respond with an HTTP 200 OK status. If the
-service responds with a non-200 OK status, OPA will requeue the last chunk containing decision log events and upload it
+If the decision log was successfully uploaded to the remote service, it should respond with an HTTP 2xx status. If the
+service responds with a non-2xx status, OPA will requeue the last chunk containing decision log events and upload it
 during the next upload event. OPA also performs an exponential backoff to calculate the delay in uploading the next chunk
-when the remote service responds with a non-200 OK status.
+when the remote service responds with a non-2xx status.
 
 OPA periodically uploads decision logs to the remote service. In order to conserve network and memory resources, OPA
 attempts to fill up each upload chunk with as many events as possible while respecting the user-specified

--- a/docs/content/management-status.md
+++ b/docs/content/management-status.md
@@ -252,7 +252,7 @@ the following additional fields.
 | `discovery.message` | `string` | Human readable messages describing the error(s). |
 | `discovery.errors` | `array` | Collection of detailed parse or compile errors that occurred during activation. |
 
-Services should reply with HTTP status `200 OK` if the status update is
+Services should reply with a `2xx` HTTP status if the status update is
 processed successfully.
 
 ### Local Status Logs

--- a/plugins/logs/plugin.go
+++ b/plugins/logs/plugin.go
@@ -908,16 +908,11 @@ func uploadChunk(ctx context.Context, client rest.Client, uploadPath string, dat
 
 	defer util.Close(resp)
 
-	switch resp.StatusCode {
-	case http.StatusOK:
-		return nil
-	case http.StatusNotFound:
-		return fmt.Errorf("log upload failed, server replied with not found")
-	case http.StatusUnauthorized:
-		return fmt.Errorf("log upload failed, server replied with not authorized")
-	default:
-		return fmt.Errorf("log upload failed, server replied with HTTP %v", resp.StatusCode)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("log upload failed, server replied with HTTP %v %v", resp.StatusCode, http.StatusText(resp.StatusCode))
 	}
+
+	return nil
 }
 
 func (p *Plugin) logEvent(event EventV1) error {

--- a/plugins/status/plugin.go
+++ b/plugins/status/plugin.go
@@ -415,15 +415,8 @@ func (p *Plugin) oneShot(ctx context.Context) error {
 
 		defer util.Close(resp)
 
-		switch resp.StatusCode {
-		case http.StatusOK:
-			return nil
-		case http.StatusNotFound:
-			return fmt.Errorf("status update failed, server replied with not found")
-		case http.StatusUnauthorized:
-			return fmt.Errorf("status update failed, server replied with not authorized")
-		default:
-			return fmt.Errorf("status update failed, server replied with HTTP %v", resp.StatusCode)
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			return fmt.Errorf("status update failed, server replied with HTTP %v %v", resp.StatusCode, http.StatusText(resp.StatusCode))
 		}
 	}
 	return nil

--- a/plugins/status/plugin_test.go
+++ b/plugins/status/plugin_test.go
@@ -500,6 +500,18 @@ func TestPluginBadStatus(t *testing.T) {
 	}
 }
 
+func TestPlugin2xxStatus(t *testing.T) {
+	fixture := newTestFixture(t, nil)
+	ctx := context.Background()
+	fixture.server.expCode = 204
+	defer fixture.server.stop()
+	fixture.plugin.lastBundleStatuses = map[string]*bundle.Status{}
+	err := fixture.plugin.oneShot(ctx)
+	if err != nil {
+		t.Fatal("Expected no error")
+	}
+}
+
 func TestPluginReconfigure(t *testing.T) {
 	ctx := context.Background()
 	fixture := newTestFixture(t, nil)


### PR DESCRIPTION
Implementations of the Status and Decision Log API may return
response codes that indicate success but are not 200,
for example 204 No Content.

OPA should treat those statuses as successful instead of errors.

Ref: https://datatracker.ietf.org/doc/html/rfc7231#section-6

> a client MUST understand the class of any status code, as indicated by the first digit, and treat an unrecognized status code as being equivalent to the x00 status code of that class

Signed-off-by: Lander Visterin <lander.visterin@klarrio.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->
