### PR TITLE
docs: update kube tutorial cert install procedure

### DIFF
--- a/docs/content/kubernetes-tutorial.md
+++ b/docs/content/kubernetes-tutorial.md
@@ -70,33 +70,33 @@ certificate authority (CA) and certificate/key pair for OPA:
 
 ```bash
 openssl genrsa -out ca.key 2048
-openssl req -x509 -new -nodes -key ca.key -days 100000 -out ca.crt -subj "/CN=admission_ca"
+openssl req -x509 -new -nodes -sha256 -key ca.key -days 100000 -out ca.crt -subj "/CN=admission_ca"
 ```
 
 Generate the TLS key and certificate for OPA:
 
 ```bash
 cat >server.conf <<EOF
-[req]
-req_extensions = v3_req
-distinguished_name = req_distinguished_name
+[ req ]
 prompt = no
-[req_distinguished_name]
+req_extensions = v3_ext
+distinguished_name = dn
+
+[ dn ]
 CN = opa.opa.svc
-[ v3_req ]
+
+[ v3_ext ]
 basicConstraints = CA:FALSE
 keyUsage = nonRepudiation, digitalSignature, keyEncipherment
 extendedKeyUsage = clientAuth, serverAuth
-subjectAltName = @alt_names
-[alt_names]
-DNS.1 = opa.opa.svc
+subjectAltName = DNS:opa.opa.svc,DNS:opa.opa.svc.cluster,DNS:opa.opa.svc.cluster.local
 EOF
 ```
 
 ```bash
 openssl genrsa -out server.key 2048
-openssl req -new -key server.key -out server.csr -config server.conf
-openssl x509 -req -in server.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out server.crt -days 100000 -extensions v3_req -extfile server.conf
+openssl req -new -key server.key -sha256 -out server.csr -extensions v3_ext -config server.conf
+openssl x509 -req -in server.csr -sha256 -CA ca.crt -CAkey ca.key -CAcreateserial -out server.crt -days 100000 -extensions v3_ext -extfile server.conf
 ```
 
 > Note: the Common Name value and Subject Alternative Name you give to openssl MUST match the name of the OPA service created below.


### PR DESCRIPTION
Two unrelated issues would break the Kubernetes tutorial in recent kube versions. The first one being the SHA1 hash used by default in at least older versions of OpenSSL, which is no longer accepted by Kubernetes. Easy fix.

The next one is definitely a head scratcher - for whatever reason, the `subjectAltName` previously provided in the config didn't seem to be picked up in certificate signing requests. Older versions of Kubernetes - or Go, really - would accept the common name (CN), but more recent ones require the use of `subjectAltName`, so it's possible this never "worked" as intended but was ignored as the CN was used instead.

The docs on the topic however all suggest that the previous config _should_ have worked, and after having spent a long time trying to figure out why it didn't, I've found nothing to provide any insights here. Best I have is "works on my machine", so if anyone else would want to try this out to make sure it works on theirs too, that'd be great.

* Use explicit hashing algorithm
* Specify `-extensions` as this does not seem to be picked up when provided in config only.

Fixes #4902

Signed-off-by: Anders Eknert <anders@eknert.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->
