### PR TITLE
Remove extra quote in policy-reference.md

### DIFF
--- a/docs/content/policy-reference.md
+++ b/docs/content/policy-reference.md
@@ -1110,7 +1110,7 @@ import          = "import" ref [ "as" var ]
 policy          = { rule }
 rule            = [ "default" ] rule-head { rule-body }
 rule-head       = var ( rule-head-set | rule-head-obj | rule-head-func | rule-head-comp )
-rule-head-comp  = [ ( ":=" | "=" ) term ]") [ "if" ]
+rule-head-comp  = [ ( ":=" | "=" ) term ]) [ "if" ]
 rule-head-obj   = [ "[" term "]" ] [ ( ":=" | "=" ) term ]) [ "if" ]
 rule-head-func  = [ "(" rule-args ")" ] [ ( ":=" | "=" ) term ]) [ "if" ]
 rule-head-set   = "contains" term [ "if" ] | "[" term "]"


### PR DESCRIPTION
The `Grammar` section of the markdown document had an extra double-quote
that was throwing off the syntax highlighting. I removed it.

Fixes: #4915
Signed-off-by: Matt F <15720856+friedrichsenm@users.noreply.github.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->
