### PR TITLE
ast/builtins: fix 'type_name' type and docs

### DIFF
--- a/ast/builtins.go
+++ b/ast/builtins.go
@@ -2422,15 +2422,15 @@ var IsNull = &Builtin{
 
 // TypeNameBuiltin returns the type of the input.
 var TypeNameBuiltin = &Builtin{
-	Name: "type_name",
+	Name:        "type_name",
+	Description: "Returns the type of its input value.",
 	Decl: types.NewFunction(
 		types.Args(
-			types.NewAny(
-				types.A,
-			),
+			types.Named("x", types.A),
 		),
-		types.S,
+		types.Named("type", types.S).Description(`one of "null", "boolean", "number", "string", "array", "object", "set"`),
 	),
+	Categories: typesCat,
 }
 
 /**

--- a/builtin_metadata.json
+++ b/builtin_metadata.json
@@ -214,7 +214,8 @@
       "is_number",
       "is_object",
       "is_set",
-      "is_string"
+      "is_string",
+      "type_name"
     ],
     "units": [
       "units.parse",
@@ -12531,7 +12532,8 @@
   "type_name": {
     "args": [
       {
-        "type": "any\u003cany\u003e"
+        "name": "x",
+        "type": "any"
       }
     ],
     "available": [
@@ -12600,8 +12602,11 @@
       "v0.42.2",
       "edge"
     ],
+    "description": "Returns the type of its input value.",
     "introduced": "v0.17.0",
     "result": {
+      "description": "one of \"null\", \"boolean\", \"number\", \"string\", \"array\", \"object\", \"set\"",
+      "name": "type",
       "type": "string"
     },
     "wasm": true

--- a/capabilities.json
+++ b/capabilities.json
@@ -3803,11 +3803,6 @@
       "decl": {
         "args": [
           {
-            "of": [
-              {
-                "type": "any"
-              }
-            ],
             "type": "any"
           }
         ],

--- a/internal/cmd/genbuiltinmetadata/main.go
+++ b/internal/cmd/genbuiltinmetadata/main.go
@@ -157,7 +157,7 @@ func builtinCategories(b *ast.Builtin) []string {
 	if !b.IsDeprecated() {
 		switch b.Name {
 		case "assign", "cast_array", "cast_boolean", "cast_null", "cast_object", "cast_set", "cast_string",
-			"eq", "print", "re_match", "set_diff", "type_name":
+			"eq", "print", "re_match", "set_diff":
 			// Do nothing.
 		default:
 			log.Printf("WARN: not categorized: %s", b.Name)


### PR DESCRIPTION
The type was `any<any>` before which is a bit much.

Also removes the "unclassified builtin" exception for "type_name" in the genbuiltinmetadata script.