### PR TITLE
Support Caching Output of Non-Deterministic Builtins

### DIFF
--- a/ast/builtins.go
+++ b/ast/builtins.go
@@ -1288,6 +1288,7 @@ var StringReverse = &Builtin{
  */
 
 // RandIntn returns a random number 0 - n
+// Marked non-deterministic because it relies on RNG internally.
 var RandIntn = &Builtin{
 	Name:        "rand.intn",
 	Description: "Returns a random integer between `0` and `n` (`n` exlusive). If `n` is `0`, then `y` is always `0`. For any given argument pair (`str`, `n`), the output will be consistent throughout a query evaluation.",
@@ -1298,7 +1299,8 @@ var RandIntn = &Builtin{
 		),
 		types.Named("y", types.N).Description("random integer in the range `[0, abs(n))`"),
 	),
-	Categories: number,
+	Categories:       number,
+	Nondeterministic: true,
 }
 
 var NumbersRange = &Builtin{
@@ -1353,6 +1355,7 @@ unit is optional and omitting it wil give the same result (e.g. Mi and MiB).`,
  */
 
 // UUIDRFC4122 returns a version 4 UUID string.
+// Marked non-deterministic because it relies on RNG internally.
 var UUIDRFC4122 = &Builtin{
 	Name:        "uuid.rfc4122",
 	Description: "Returns a new UUIDv4.",
@@ -1362,6 +1365,7 @@ var UUIDRFC4122 = &Builtin{
 		),
 		types.Named("output", types.S).Description("a version 4 UUID; for any given `k`, the output will be consistent throughout a query evaluation"),
 	),
+	Nondeterministic: true,
 }
 
 /**
@@ -1999,6 +2003,7 @@ var JWTVerifyHS512 = &Builtin{
 	Categories: tokensCat,
 }
 
+// Marked non-deterministic because it relies on time internally.
 var JWTDecodeVerify = &Builtin{
 	Name: "io.jwt.decode_verify",
 	Description: `Verifies a JWT signature under parameterized constraints and decodes the claims if it is valid.
@@ -2014,11 +2019,13 @@ Supports the following algorithms: HS256, HS384, HS512, RS256, RS384, RS512, ES2
 			types.NewObject(nil, types.NewDynamicProperty(types.A, types.A)),
 		}, nil)).Description("`[valid, header, payload]`:  if the input token is verified and meets the requirements of `constraints` then `valid` is `true`; `header` and `payload` are objects containing the JOSE header and the JWT claim set; otherwise, `valid` is `false`, `header` and `payload` are `{}`"),
 	),
-	Categories: tokensCat,
+	Categories:       tokensCat,
+	Nondeterministic: true,
 }
 
 var tokenSign = category("tokensign")
 
+// Marked non-deterministic because it relies on RNG internally.
 var JWTEncodeSignRaw = &Builtin{
 	Name:        "io.jwt.encode_sign_raw",
 	Description: "Encodes and optionally signs a JSON Web Token.",
@@ -2030,9 +2037,11 @@ var JWTEncodeSignRaw = &Builtin{
 		),
 		types.Named("output", types.S).Description("signed JWT"),
 	),
-	Categories: tokenSign,
+	Categories:       tokenSign,
+	Nondeterministic: true,
 }
 
+// Marked non-deterministic because it relies on RNG internally.
 var JWTEncodeSign = &Builtin{
 	Name:        "io.jwt.encode_sign",
 	Description: "Encodes and optionally signs a JSON Web Token. Inputs are taken as objects, not encoded strings (see `io.jwt.encode_sign_raw`).",
@@ -2044,13 +2053,15 @@ var JWTEncodeSign = &Builtin{
 		),
 		types.Named("output", types.S).Description("signed JWT"),
 	),
-	Categories: tokenSign,
+	Categories:       tokenSign,
+	Nondeterministic: true,
 }
 
 /**
  * Time
  */
 
+// Marked non-deterministic because it relies on time directly.
 var NowNanos = &Builtin{
 	Name:        "time.now_ns",
 	Description: "Returns the current time since epoch in nanoseconds.",
@@ -2058,6 +2069,7 @@ var NowNanos = &Builtin{
 		nil,
 		types.Named("now", types.N).Description("nanoseconds since epoch"),
 	),
+	Nondeterministic: true,
 }
 
 var ParseNanos = &Builtin{
@@ -2480,6 +2492,7 @@ var TypeNameBuiltin = &Builtin{
  * HTTP Request
  */
 
+// Marked non-deterministic because HTTP request results can be non-deterministic.
 var HTTPSend = &Builtin{
 	Name:        "http.send",
 	Description: "Returns a HTTP response to the given HTTP request.",
@@ -2489,6 +2502,7 @@ var HTTPSend = &Builtin{
 		),
 		types.Named("response", types.NewObject(nil, types.NewDynamicProperty(types.A, types.A))),
 	),
+	Nondeterministic: true,
 }
 
 /**
@@ -2610,6 +2624,7 @@ var RegoMetadataRule = &Builtin{
  * OPA
  */
 
+// Marked non-deterministic because of unpredictable config/environment-dependent results.
 var OPARuntime = &Builtin{
 	Name:        "opa.runtime",
 	Description: "Returns an object that describes the runtime environment where OPA is deployed.",
@@ -2618,6 +2633,7 @@ var OPARuntime = &Builtin{
 		types.Named("output", types.NewObject(nil, types.NewDynamicProperty(types.S, types.A))).
 			Description("includes a `config` key if OPA was started with a configuration file; an `env` key containing the environment variables that the OPA process was started with; includes `version` and `commit` keys containing the version and build commit of OPA."),
 	),
+	Nondeterministic: true,
 }
 
 /**
@@ -2756,6 +2772,7 @@ var netCidrContainsMatchesOperandType = types.NewAny(
 	)),
 )
 
+// Marked non-deterministic because DNS resolution results can be non-deterministic.
 var NetLookupIPAddr = &Builtin{
 	Name:        "net.lookup_ip_addr",
 	Description: "Returns the set of IP addresses (both v4 and v6) that the passed-in `name` resolves to using the standard name resolution mechanisms available.",
@@ -2765,6 +2782,7 @@ var NetLookupIPAddr = &Builtin{
 		),
 		types.Named("addrs", types.NewSet(types.S)).Description("IP addresses (v4 and v6) that `name` resolves to"),
 	),
+	Nondeterministic: true,
 }
 
 /**
@@ -2966,10 +2984,11 @@ type Builtin struct {
 	// "minus" for example, is part of two categories: numbers and sets. (NOTE(sr): aspirational)
 	Categories []string `json:"categories,omitempty"`
 
-	Decl       *types.Function `json:"decl"`               // Built-in function type declaration.
-	Infix      string          `json:"infix,omitempty"`    // Unique name of infix operator. Default should be unset.
-	Relation   bool            `json:"relation,omitempty"` // Indicates if the built-in acts as a relation.
-	deprecated bool            // Indicates if the built-in has been deprecated.
+	Decl             *types.Function `json:"decl"`               // Built-in function type declaration.
+	Infix            string          `json:"infix,omitempty"`    // Unique name of infix operator. Default should be unset.
+	Relation         bool            `json:"relation,omitempty"` // Indicates if the built-in acts as a relation.
+	deprecated       bool            // Indicates if the built-in has been deprecated.
+	Nondeterministic bool            `json:"nondeterministic,omitempty"` // Indicates if the built-in returns non-deterministic results.
 }
 
 // category is a helper for specifying a Builtin's Categories
@@ -2980,6 +2999,11 @@ func category(cs ...string) []string {
 // IsDeprecated returns true if the Builtin function is deprecated and will be removed in a future release.
 func (b *Builtin) IsDeprecated() bool {
 	return b.deprecated
+}
+
+// IsDeterministic returns true if the Builtin function returns non-deterministic results.
+func (b *Builtin) IsNondeterministic() bool {
+	return b.Nondeterministic
 }
 
 // Expr creates a new expression for the built-in with the given operands.

--- a/capabilities.json
+++ b/capabilities.json
@@ -1284,7 +1284,8 @@
           "type": "object"
         },
         "type": "function"
-      }
+      },
+      "nondeterministic": true
     },
     {
       "name": "indexof",
@@ -1493,7 +1494,8 @@
           "type": "array"
         },
         "type": "function"
-      }
+      },
+      "nondeterministic": true
     },
     {
       "name": "io.jwt.encode_sign",
@@ -1537,7 +1539,8 @@
           "type": "string"
         },
         "type": "function"
-      }
+      },
+      "nondeterministic": true
     },
     {
       "name": "io.jwt.encode_sign_raw",
@@ -1557,7 +1560,8 @@
           "type": "string"
         },
         "type": "function"
-      }
+      },
+      "nondeterministic": true
     },
     {
       "name": "io.jwt.verify_es256",
@@ -2529,7 +2533,8 @@
           "type": "set"
         },
         "type": "function"
-      }
+      },
+      "nondeterministic": true
     },
     {
       "name": "numbers.range",
@@ -2819,7 +2824,8 @@
           "type": "object"
         },
         "type": "function"
-      }
+      },
+      "nondeterministic": true
     },
     {
       "name": "or",
@@ -2918,7 +2924,8 @@
           "type": "number"
         },
         "type": "function"
-      }
+      },
+      "nondeterministic": true
     },
     {
       "name": "re_match",
@@ -3690,7 +3697,8 @@
           "type": "number"
         },
         "type": "function"
-      }
+      },
+      "nondeterministic": true
     },
     {
       "name": "time.parse_duration_ns",
@@ -4091,7 +4099,8 @@
           "type": "string"
         },
         "type": "function"
-      }
+      },
+      "nondeterministic": true
     },
     {
       "name": "walk",

--- a/features/wasm/wasm.go
+++ b/features/wasm/wasm.go
@@ -64,6 +64,7 @@ func (o *OPA) Eval(ctx context.Context, opts opa.EvalOpts) (*opa.Result, error) 
 		Time:                   opts.Time,
 		Seed:                   opts.Seed,
 		InterQueryBuiltinCache: opts.InterQueryBuiltinCache,
+		NDBuiltinCache:         opts.NDBuiltinCache,
 		PrintHook:              opts.PrintHook,
 		Capabilities:           opts.Capabilities,
 	}

--- a/internal/rego/opa/options.go
+++ b/internal/rego/opa/options.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/metrics"
+	"github.com/open-policy-agent/opa/topdown/builtins"
 	"github.com/open-policy-agent/opa/topdown/cache"
 	"github.com/open-policy-agent/opa/topdown/print"
 )
@@ -23,6 +24,7 @@ type EvalOpts struct {
 	Time                   time.Time
 	Seed                   io.Reader
 	InterQueryBuiltinCache cache.InterQueryCache
+	NDBuiltinCache         builtins.NDBCache
 	PrintHook              print.Hook
 	Capabilities           *ast.Capabilities
 }

--- a/internal/wasm/sdk/internal/wasm/bindings.go
+++ b/internal/wasm/sdk/internal/wasm/bindings.go
@@ -85,6 +85,7 @@ func (d *builtinDispatcher) Reset(ctx context.Context,
 	seed io.Reader,
 	ns time.Time,
 	iqbCache cache.InterQueryCache,
+	ndbCache builtins.NDBCache,
 	ph print.Hook,
 	capabilities *ast.Capabilities) {
 	if ns.IsZero() {
@@ -107,6 +108,7 @@ func (d *builtinDispatcher) Reset(ctx context.Context,
 		QueryID:                0,
 		ParentID:               0,
 		InterQueryBuiltinCache: iqbCache,
+		NDBuiltinCache:         ndbCache,
 		PrintHook:              ph,
 		Capabilities:           capabilities,
 	}

--- a/internal/wasm/sdk/internal/wasm/pool_test.go
+++ b/internal/wasm/sdk/internal/wasm/pool_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/open-policy-agent/opa/internal/wasm/sdk/internal/wasm"
 	wasm_util "github.com/open-policy-agent/opa/internal/wasm/util"
 	"github.com/open-policy-agent/opa/metrics"
+	"github.com/open-policy-agent/opa/topdown/builtins"
 	"github.com/open-policy-agent/opa/topdown/cache"
 	"github.com/open-policy-agent/opa/util"
 )
@@ -176,7 +177,7 @@ func ensurePoolResults(t *testing.T, ctx context.Context, testPool *wasm.Pool, p
 		toRelease = append(toRelease, vm)
 
 		cfg, _ := cache.ParseCachingConfig(nil)
-		result, err := vm.Eval(ctx, 0, input, metrics.New(), rand.New(rand.NewSource(0)), time.Now(), cache.NewInterQueryCache(cfg), nil, nil)
+		result, err := vm.Eval(ctx, 0, input, metrics.New(), rand.New(rand.NewSource(0)), time.Now(), cache.NewInterQueryCache(cfg), builtins.NDBCache{}, nil, nil)
 		if err != nil {
 			t.Fatalf("Unexpected error: %s", err)
 		}

--- a/internal/wasm/sdk/opa/opa.go
+++ b/internal/wasm/sdk/opa/opa.go
@@ -17,6 +17,7 @@ import (
 	"github.com/open-policy-agent/opa/internal/wasm/sdk/opa/errors"
 	sdk_errors "github.com/open-policy-agent/opa/internal/wasm/sdk/opa/errors"
 	"github.com/open-policy-agent/opa/metrics"
+	"github.com/open-policy-agent/opa/topdown/builtins"
 	"github.com/open-policy-agent/opa/topdown/cache"
 	"github.com/open-policy-agent/opa/topdown/print"
 )
@@ -165,6 +166,7 @@ type EvalOpts struct {
 	Time                   time.Time
 	Seed                   io.Reader
 	InterQueryBuiltinCache cache.InterQueryCache
+	NDBuiltinCache         builtins.NDBCache
 	PrintHook              print.Hook
 	Capabilities           *ast.Capabilities
 }
@@ -190,8 +192,7 @@ func (o *OPA) Eval(ctx context.Context, opts EvalOpts) (*Result, error) {
 
 	defer o.pool.Release(instance, m)
 
-	result, err := instance.Eval(ctx, opts.Entrypoint, opts.Input, m, opts.Seed, opts.Time, opts.InterQueryBuiltinCache,
-		opts.PrintHook, opts.Capabilities)
+	result, err := instance.Eval(ctx, opts.Entrypoint, opts.Input, m, opts.Seed, opts.Time, opts.InterQueryBuiltinCache, opts.NDBuiltinCache, opts.PrintHook, opts.Capabilities)
 	if err != nil {
 		return nil, err
 	}

--- a/rego/rego.go
+++ b/rego/rego.go
@@ -29,6 +29,7 @@ import (
 	"github.com/open-policy-agent/opa/storage"
 	"github.com/open-policy-agent/opa/storage/inmem"
 	"github.com/open-policy-agent/opa/topdown"
+	"github.com/open-policy-agent/opa/topdown/builtins"
 	"github.com/open-policy-agent/opa/topdown/cache"
 	"github.com/open-policy-agent/opa/topdown/print"
 	"github.com/open-policy-agent/opa/tracing"
@@ -115,6 +116,7 @@ type EvalContext struct {
 	indexing               bool
 	earlyExit              bool
 	interQueryBuiltinCache cache.InterQueryCache
+	ndBuiltinCache         builtins.NDBCache
 	resolvers              []refResolver
 	sortSets               bool
 	printHook              print.Hook
@@ -253,6 +255,14 @@ func EvalInterQueryBuiltinCache(c cache.InterQueryCache) EvalOption {
 	}
 }
 
+// EvalNDBuiltinCache sets the non-deterministic builtin cache that built-in functions can
+// use during evaluation.
+func EvalNDBuiltinCache(c builtins.NDBCache) EvalOption {
+	return func(e *EvalContext) {
+		e.ndBuiltinCache = c
+	}
+}
+
 // EvalResolver sets a Resolver for a specified ref path for this evaluation.
 func EvalResolver(ref ast.Ref, r resolver.Resolver) EvalOption {
 	return func(e *EvalContext) {
@@ -310,6 +320,7 @@ func (pq preparedQuery) newEvalContext(ctx context.Context, options []EvalOption
 		compiledQuery:    compiledQuery{},
 		indexing:         true,
 		earlyExit:        true,
+		ndBuiltinCache:   builtins.NDBCache{},
 		resolvers:        pq.r.resolvers,
 		printHook:        pq.r.printHook,
 		capabilities:     pq.r.capabilities,
@@ -508,6 +519,7 @@ type Rego struct {
 	bundles                map[string]*bundle.Bundle
 	skipBundleVerification bool
 	interQueryBuiltinCache cache.InterQueryCache
+	ndBuiltinCache         builtins.NDBCache
 	strictBuiltinErrors    bool
 	resolvers              []refResolver
 	schemaSet              *ast.SchemaSet
@@ -1015,6 +1027,13 @@ func InterQueryBuiltinCache(c cache.InterQueryCache) func(r *Rego) {
 	}
 }
 
+// NDBuiltinCache sets the non-deterministic builtins cache.
+func NDBuiltinCache(c builtins.NDBCache) func(r *Rego) {
+	return func(r *Rego) {
+		r.ndBuiltinCache = c
+	}
+}
+
 // StrictBuiltinErrors tells the evaluator to treat all built-in function errors as fatal errors.
 func StrictBuiltinErrors(yes bool) func(r *Rego) {
 	return func(r *Rego) {
@@ -1093,6 +1112,7 @@ func New(options ...func(r *Rego)) *Rego {
 		builtinDecls:    map[string]*ast.Builtin{},
 		builtinFuncs:    map[string]*topdown.Builtin{},
 		bundles:         map[string]*bundle.Bundle{},
+		ndBuiltinCache:  builtins.NDBCache{},
 	}
 
 	for _, option := range options {
@@ -1162,6 +1182,7 @@ func (r *Rego) Eval(ctx context.Context) (ResultSet, error) {
 		EvalInstrument(r.instrument),
 		EvalTime(r.time),
 		EvalInterQueryBuiltinCache(r.interQueryBuiltinCache),
+		EvalNDBuiltinCache(r.ndBuiltinCache),
 		EvalSeed(r.seed),
 	}
 
@@ -1235,6 +1256,7 @@ func (r *Rego) Partial(ctx context.Context) (*PartialQueries, error) {
 		EvalMetrics(r.metrics),
 		EvalInstrument(r.instrument),
 		EvalInterQueryBuiltinCache(r.interQueryBuiltinCache),
+		EvalNDBuiltinCache(r.ndBuiltinCache),
 	}
 
 	for _, t := range r.queryTracers {
@@ -1906,6 +1928,7 @@ func (r *Rego) eval(ctx context.Context, ectx *EvalContext) (ResultSet, error) {
 		WithIndexing(ectx.indexing).
 		WithEarlyExit(ectx.earlyExit).
 		WithInterQueryBuiltinCache(ectx.interQueryBuiltinCache).
+		WithNDBuiltinCache(ectx.ndBuiltinCache).
 		WithStrictBuiltinErrors(r.strictBuiltinErrors).
 		WithSeed(ectx.seed).
 		WithPrintHook(ectx.printHook).
@@ -1970,6 +1993,7 @@ func (r *Rego) evalWasm(ctx context.Context, ectx *EvalContext) (ResultSet, erro
 		Time:                   ectx.time,
 		Seed:                   ectx.seed,
 		InterQueryBuiltinCache: ectx.interQueryBuiltinCache,
+		NDBuiltinCache:         ectx.ndBuiltinCache,
 		PrintHook:              ectx.printHook,
 		Capabilities:           ectx.capabilities,
 	})
@@ -2181,6 +2205,7 @@ func (r *Rego) partial(ctx context.Context, ectx *EvalContext) (*PartialQueries,
 		WithSkipPartialNamespace(r.skipPartialNamespace).
 		WithShallowInlining(r.shallowInlining).
 		WithInterQueryBuiltinCache(ectx.interQueryBuiltinCache).
+		WithNDBuiltinCache(ectx.ndBuiltinCache).
 		WithStrictBuiltinErrors(r.strictBuiltinErrors).
 		WithSeed(ectx.seed).
 		WithPrintHook(ectx.printHook)

--- a/topdown/builtins.go
+++ b/topdown/builtins.go
@@ -43,6 +43,7 @@ type (
 		Runtime                *ast.Term             // runtime information on the OPA instance
 		Cache                  builtins.Cache        // built-in function state cache
 		InterQueryBuiltinCache cache.InterQueryCache // cross-query built-in function state cache
+		NDBuiltinCache         builtins.NDBCache     // cache for non-deterministic built-in state
 		Location               *ast.Location         // location of built-in call
 		Tracers                []Tracer              // Deprecated: Use QueryTracers instead
 		QueryTracers           []QueryTracer         // tracer objects for trace() built-in function

--- a/topdown/http.go
+++ b/topdown/http.go
@@ -136,7 +136,7 @@ func getHTTPResponse(bctx BuiltinContext, req ast.Object) (*ast.Term, error) {
 		return nil, err
 	}
 
-	// check if cache already has a response for this query
+	// Check if cache already has a response for this query
 	resp, err := reqExecutor.CheckCache()
 	if err != nil {
 		return nil, err
@@ -148,7 +148,7 @@ func getHTTPResponse(bctx BuiltinContext, req ast.Object) (*ast.Term, error) {
 			return nil, err
 		}
 		defer util.Close(httpResp)
-		// add result to cache
+		// Add result to intra/inter-query cache.
 		resp, err = reqExecutor.InsertIntoCache(httpResp)
 		if err != nil {
 			return nil, err

--- a/topdown/query.go
+++ b/topdown/query.go
@@ -52,6 +52,7 @@ type Query struct {
 	indexing               bool
 	earlyExit              bool
 	interQueryBuiltinCache cache.InterQueryCache
+	ndBuiltinCache         builtins.NDBCache
 	strictBuiltinErrors    bool
 	printHook              print.Hook
 	tracingOpts            tracing.Options
@@ -242,6 +243,12 @@ func (q *Query) WithInterQueryBuiltinCache(c cache.InterQueryCache) *Query {
 	return q
 }
 
+// WithNDBuiltinCache sets the non-deterministic builtin cache.
+func (q *Query) WithNDBuiltinCache(c builtins.NDBCache) *Query {
+	q.ndBuiltinCache = c
+	return q
+}
+
 // WithStrictBuiltinErrors tells the evaluator to treat all built-in function errors as fatal errors.
 func (q *Query) WithStrictBuiltinErrors(yes bool) *Query {
 	q.strictBuiltinErrors = yes
@@ -313,6 +320,7 @@ func (q *Query) PartialRun(ctx context.Context) (partials []ast.Body, support []
 		builtinCache:           builtins.Cache{},
 		functionMocks:          newFunctionMocksStack(),
 		interQueryBuiltinCache: q.interQueryBuiltinCache,
+		ndBuiltinCache:         q.ndBuiltinCache,
 		virtualCache:           newVirtualCache(),
 		comprehensionCache:     newComprehensionCache(),
 		saveSet:                newSaveSet(q.unknowns, b, q.instr),
@@ -462,6 +470,7 @@ func (q *Query) Iter(ctx context.Context, iter func(QueryResult) error) error {
 		builtinCache:           builtins.Cache{},
 		functionMocks:          newFunctionMocksStack(),
 		interQueryBuiltinCache: q.interQueryBuiltinCache,
+		ndBuiltinCache:         q.ndBuiltinCache,
 		virtualCache:           newVirtualCache(),
 		comprehensionCache:     newComprehensionCache(),
 		genvarprefix:           q.genvarprefix,


### PR DESCRIPTION
This PR implements support for caching the results of non-deterministic builtins for more complete Decision Logging support. Currently, only the `rego` module and its direct dependents have received the plumbing work this feature requires.

The NDBuiltinCache is ~just a `builtins.Cache`~ a custom 2-level map, modeled off of `builtins.Cache`, which is carefully propagated downwards into the `topdown.BuiltinContext` from the query/eval context. This allows non-deterministic builtins to trivially add cache entries during evaluation, which can later be recovered by higher-level library users.

Rough Usage Example (derived from the tests):
```go
// Set up the NDBuiltinCache, and insert some arbitrary data.
ndBC := builtins.NDBCache{}
ndBC.Put("experiment", 5, 3)

// Run a Rego query.
ctx := context.Background()
_, err := rego.New(rego.Query(query), NDBuiltinCache(ndBC)).Eval(ctx)
if err != nil {
	t.Fatal(err)
}

// Get the arbitrary data back out later.
if v, ok := ndBC.Get("experiment", 5); ok {
	fmt.Println("k:", 5, "v:", v)
}
// ndBC will have additional cache entries from any non-deterministic builtins
// that ran during the query's evaluation.
```

## Task List

 - [x] Extend evaluator to support non-deterministic builtin result caching
 - [x] Cache insertion logic for non-deterministic builtins
   - :heavy_check_mark: [`rand.intn`](https://www.openpolicyagent.org/docs/latest/policy-reference/#builtin-numbers-randintn) (relies on RNG)
   - :heavy_check_mark: [`io.jwt.encode_sign`, `io.jwt.encode_sign_raw`](https://www.openpolicyagent.org/docs/latest/policy-reference/#tokensign) (relies on RNG internally) (Will require careful masking when exposed in the server later.)
   - :heavy_check_mark: [`io.jwt.decode_verify`](https://www.openpolicyagent.org/docs/latest/policy-reference/#tokens) (relies on time internally) (Will require careful masking when exposed in the server later.)
   - :heavy_check_mark: [`time.now_ns`](https://www.openpolicyagent.org/docs/latest/policy-reference/#builtin-time-timenow_ns) (relies on time directly)
   - :heavy_check_mark: [`http.send`](https://www.openpolicyagent.org/docs/latest/policy-reference/#builtin-http-httpsend) (unpredictable HTTP request results)
   - :heavy_check_mark: [`net.lookup_ip_addr`](https://www.openpolicyagent.org/docs/latest/policy-reference/#builtin-net-netlookup_ip_addr) (unpredictable DNS resolution results)
   - :heavy_check_mark: [`opa.runtime`](https://www.openpolicyagent.org/docs/latest/policy-reference/#builtin-opa-oparuntime) (unpredictable config/environment-dependent results)
   - :heavy_check_mark: [`uuid.rfc4122`](https://www.openpolicyagent.org/docs/latest/policy-reference/#builtin-uuid-uuidrfc4122) (relies on RNG)
 - [x] Test cases

Fixes #1514 