### PR TITLE
runtime: Treat other Unix-es like macos

### DIFF
--- a/runtime/check_user_unix.go
+++ b/runtime/check_user_unix.go
@@ -1,3 +1,5 @@
+// +build !linux,!windows
+
 // Copyright 2022 The OPA Authors.  All rights reserved.
 // Use of this source code is governed by an Apache2
 // license that can be found in the LICENSE file.
@@ -10,7 +12,7 @@ import (
 	"github.com/open-policy-agent/opa/logging"
 )
 
-// checkUserPrivileges on macos could not be running in Docker, so we only warn
+// checkUserPrivileges could not be running in Docker, so we only warn
 // if run as uid/gid 0.
 func checkUserPrivileges(logger logging.Logger) {
 	usr, err := user.Current()


### PR DESCRIPTION
The check specific to macos is also valid on most other Unix-es.

Should fix the build on most other Unix-es.

This was noticed while building `opa` on NetBSD (but probably all non-Linux, non-macos or non-Windows platform are no longer okay since commit 9d4fc06f4d80224ccdab674e37161f46aa4917b7).
