### PR TITLE
ci(nightly): various trivy-related tweaks

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -77,8 +77,29 @@ jobs:
           status: ${{ job.status }}
           fields: repo,workflow
 
-  trivy-scan:
-    name: Trivy security scan
+  trivy-scan-image:
+    name: Trivy security scan image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code # needed for .trivyignore file
+        uses: actions/checkout@v3
+
+      - run: "docker pull openpolicyagent/opa:edge-static"
+
+      # Equivalent to:
+      # $ trivy image openpolicyagent/opa:edge-static
+      - name: Run Trivy scan on image
+        uses: aquasecurity/trivy-action@0.6.0
+        with:
+          image-ref: 'openpolicyagent/opa:edge-static'
+          format: table
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: os,library
+          severity: CRITICAL,HIGH
+
+  trivy-scan-repo:
+    name: Trivy security scan repo
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -93,16 +114,5 @@ jobs:
           format: table
           exit-code: '1'
           ignore-unfixed: true
-          severity: CRITICAL,HIGH
-
-      # Equivalent to:
-      # $ trivy image openpolicyagent/opa:edge
-      - name: Run Trivy scan on image
-        uses: aquasecurity/trivy-action@0.6.0
-        with:
-          image-ref: 'openpolicyagent/opa:edge'
-          format: table
-          exit-code: '1'
-          ignore-unfixed: true
-          vuln-type: os,library
+          skip-dirs: vendor/ # don't check go deps' go.mod files
           severity: CRITICAL,HIGH

--- a/.trivyignore
+++ b/.trivyignore
@@ -6,11 +6,33 @@ CVE-2021-3538
 
 # * go.etcd.io/etcd - we don't run etcd as part of the OPA deployment
 CVE-2018-1098
+CVE-2018-1099
 
 # * k8s.io/kubernetes - we don't run kubernetes as part of the OPA deployment
+CVE-2019-1002101
+CVE-2019-11250
 CVE-2019-11253
+CVE-2019-11254
+CVE-2020-8552
+CVE-2020-8554
+CVE-2020-8555
+CVE-2020-8557
 CVE-2020-8558
+CVE-2020-8559
+CVE-2020-8561
+CVE-2020-8562
+CVE-2020-8563
+CVE-2020-8564
+CVE-2020-8565
+CVE-2021-25735
+CVE-2021-25740
 CVE-2021-25741
 
 # * github.com/emicklei/go-restful - we don't use its code in our handlers
 CVE-2022-1996
+
+# * github.com/docker/distribution - OCI manifest code isn't used
+GHSA-qq97-vm5h-rrhg
+
+# github.com/dgrijalva/jwt-go -- vulnerable version used by docker/distribution above
+CVE-2020-26160


### PR DESCRIPTION
1. only check the edge-static image

   There are a bunch of libc-related findings that are hard to address, and
   likely not relevant for us: for example, Go will not use glibc's regexp
   engine, even if linked against libc.

2. pull the image before checking it

   I've noticed locally that `trivy image` will just use whatever image it
   finds under the mentioned tag. So we pull first to ensure that we actually
   scan the right 'edge' image.

3. split jobs

   Before, the scan-repo step wouldn't ever happen if scan-image failed. Let's
   do them both all the time instead.

4. for the repo scan, ignore go.mod files of the dependencies -- there's little
   we can do about, say, grpc referencing a vulnerable yaml.v2 dep in its
   go.mod. And there should also be little harm in it, since we're using a more
   recent version in our go.mod.

5. Updated .trivyignore with recent, new, findings.
