### PR TITLE
Clean old bundle data before new activation

### DIFF
--- a/bundle/store.go
+++ b/bundle/store.go
@@ -727,6 +727,16 @@ func writeDataAndModules(ctx context.Context, store storage.Store, txn storage.T
 				}
 			}
 		} else {
+			var rootOverwrite bool
+			for _, root := range *b.Manifest.Roots {
+				if root == "" {
+					rootOverwrite = true
+					break
+				}
+			}
+
+			params.RootOverwrite = rootOverwrite
+
 			err := store.Truncate(ctx, txn, params, NewIterator(b.Raw))
 			if err != nil {
 				return fmt.Errorf("store truncate failed for bundle '%s': %v", name, err)

--- a/storage/disk/txn.go
+++ b/storage/disk/txn.go
@@ -329,6 +329,12 @@ func (txn *transaction) partitionWriteMultiple(node *partitionTrie, path storage
 			return nil, err
 		}
 		return txn.doPartitionWriteMultiple(node, path, bs, result)
+	case map[string]json.RawMessage:
+		bs, err := serialize(v)
+		if err != nil {
+			return nil, err
+		}
+		return txn.doPartitionWriteMultiple(node, path, bs, result)
 	case json.RawMessage:
 		return txn.doPartitionWriteMultiple(node, path, v, result)
 	case []uint8:

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -52,6 +52,9 @@ type MakeDirer interface {
 // TransactionParams describes a new transaction.
 type TransactionParams struct {
 
+	// RootOverwrite indicates if this transaction will overwrite data at root.
+	RootOverwrite bool
+
 	// Write indicates if this transaction will perform any write operations.
 	Write bool
 


### PR DESCRIPTION
If OPA has an activated bundle that owns all roots
and a new bundle with empty roots is to be activated, the
old bundle's data should first be erased from the store.
Currently both the old and new data is kept in the store.

This commit attempts to fix this by providing an indication to
the truncate call about the scenario in which the root is to be
overwritten.

Fixes: #4940

Signed-off-by: Ashutosh Narkar <anarkar4387@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->
