### PR TITLE
topdown/reachable: Fix missing operand type checks.

### DIFF
--- a/test/cases/testdata/reachable/test-reachable-0326.yaml
+++ b/test/cases/testdata/reachable/test-reachable-0326.yaml
@@ -13,5 +13,5 @@ cases:
     }
   note: reachable/malformed 1
   query: data.generated.p = x
-  want_result:
-  - x: []
+  want_error_code: eval_type_error
+  strict_error: true

--- a/test/cases/testdata/reachable/test-reachable-0328.yaml
+++ b/test/cases/testdata/reachable/test-reachable-0328.yaml
@@ -13,5 +13,5 @@ cases:
     }
   note: reachable/malformed 3
   query: data.generated.p = x
-  want_result:
-  - x: []
+  want_error_code: eval_type_error
+  strict_error: true

--- a/test/cases/testdata/reachable/test-reachable-paths-0422.yaml
+++ b/test/cases/testdata/reachable/test-reachable-paths-0422.yaml
@@ -138,8 +138,8 @@ cases:
         }
     note: reachable_paths/malformed 3
     query: data.reachable.p = x
-    want_result:
-      - x: []
+    want_error_code: eval_type_error
+    strict_error: true
   - data: {}
     input_term: '{
       "graph": {

--- a/topdown/reachable.go
+++ b/topdown/reachable.go
@@ -38,17 +38,15 @@ func builtinReachable(bctx BuiltinContext, args []*ast.Term, iter func(*ast.Term
 		return err
 	}
 
-	initial, err := builtins.ArrayOperand(args[1].Value, 2)
-	if err != nil {
-		return err
+	var queue []*ast.Term
+	switch initial := args[1].Value.(type) {
+	case *ast.Array, ast.Set:
+		foreachVertex(ast.NewTerm(initial), func(t *ast.Term) {
+			queue = append(queue, t)
+		})
+	default:
+		return builtins.NewOperandTypeErr(2, initial, "{array, set}")
 	}
-
-	// This is a queue that holds all nodes we still need to visit.  It is
-	// initialised to the initial set of nodes we start out with.
-	queue := []*ast.Term{}
-	foreachVertex(ast.NewTerm(initial), func(t *ast.Term) {
-		queue = append(queue, t)
-	})
 
 	// This is the set of nodes we have reached.
 	reached := ast.NewSet()
@@ -107,17 +105,17 @@ func builtinReachablePaths(bctx BuiltinContext, args []*ast.Term, iter func(*ast
 		return err
 	}
 
-	initial, err := builtins.ArrayOperand(args[1].Value, 2)
-	if err != nil {
-		return err
-	}
-
 	// This is a queue that holds all nodes we still need to visit.  It is
 	// initialised to the initial set of nodes we start out with.
 	var queue []*ast.Term
-	foreachVertex(ast.NewTerm(initial), func(t *ast.Term) {
-		queue = append(queue, t)
-	})
+	switch initial := args[1].Value.(type) {
+	case *ast.Array, ast.Set:
+		foreachVertex(ast.NewTerm(initial), func(t *ast.Term) {
+			queue = append(queue, t)
+		})
+	default:
+		return builtins.NewOperandTypeErr(2, initial, "{array, set}")
+	}
 
 	results := ast.NewSet()
 

--- a/topdown/reachable.go
+++ b/topdown/reachable.go
@@ -32,16 +32,21 @@ func numberOfEdges(collection *ast.Term) int {
 }
 
 func builtinReachable(bctx BuiltinContext, args []*ast.Term, iter func(*ast.Term) error) error {
-	// Return the empty set if the first argument is not an object.
-	graph, ok := args[0].Value.(ast.Object)
-	if !ok {
-		return iter(ast.NewTerm(ast.NewSet()))
+	// Error on wrong types for args.
+	graph, err := builtins.ObjectOperand(args[0].Value, 1)
+	if err != nil {
+		return err
+	}
+
+	initial, err := builtins.ArrayOperand(args[1].Value, 2)
+	if err != nil {
+		return err
 	}
 
 	// This is a queue that holds all nodes we still need to visit.  It is
 	// initialised to the initial set of nodes we start out with.
 	queue := []*ast.Term{}
-	foreachVertex(args[1], func(t *ast.Term) {
+	foreachVertex(ast.NewTerm(initial), func(t *ast.Term) {
 		queue = append(queue, t)
 	})
 
@@ -96,8 +101,13 @@ func pathBuilder(graph ast.Object, root *ast.Term, path []*ast.Term, paths []*as
 }
 
 func builtinReachablePaths(bctx BuiltinContext, args []*ast.Term, iter func(*ast.Term) error) error {
-	// Return an error if the first argument is not an object.
+	// Error on wrong types for args.
 	graph, err := builtins.ObjectOperand(args[0].Value, 1)
+	if err != nil {
+		return err
+	}
+
+	initial, err := builtins.ArrayOperand(args[1].Value, 2)
 	if err != nil {
 		return err
 	}
@@ -105,7 +115,7 @@ func builtinReachablePaths(bctx BuiltinContext, args []*ast.Term, iter func(*ast
 	// This is a queue that holds all nodes we still need to visit.  It is
 	// initialised to the initial set of nodes we start out with.
 	var queue []*ast.Term
-	foreachVertex(args[1], func(t *ast.Term) {
+	foreachVertex(ast.NewTerm(initial), func(t *ast.Term) {
 		queue = append(queue, t)
 	})
 

--- a/wasm/src/graphs.c
+++ b/wasm/src/graphs.c
@@ -47,7 +47,11 @@ opa_value *builtin_graph_reachable(opa_value *graph, opa_value *initial)
 {
     if (opa_value_type(graph) != OPA_OBJECT)
     {
-        return opa_set();
+        return NULL;
+    }
+    if (opa_value_type(initial) != OPA_SET && opa_value_type(initial) != OPA_ARRAY)
+    {
+        return NULL;
     }
 
     // This is a queue that holds all nodes we still need to visit. It is

--- a/wasm/tests/test.c
+++ b/wasm/tests/test.c
@@ -2487,7 +2487,7 @@ WASM_EXPORT(test_builtin_graph_reachable)
 void test_builtin_graph_reachable(void)
 {
 
-    test("reachable/malformed graph", opa_value_compare(builtin_graph_reachable(opa_set(), opa_set()), opa_set()) == 0);
+    test("reachable/malformed graph", opa_value_compare(builtin_graph_reachable(opa_set(), opa_set()), NULL) == 0);
 
     opa_object_t *graph1 = opa_cast_object(opa_object());
     opa_set_t *initial1 = opa_cast_set(opa_set());
@@ -2577,7 +2577,7 @@ void test_builtin_graph_reachable(void)
 
     test("reachable/arrays", opa_value_compare(builtin_graph_reachable(&graph3->hdr, &initial3->hdr), &expected3->hdr) == 0);
 
-    test("reachable/malformed initial nodes", opa_value_compare(builtin_graph_reachable(&graph3->hdr, opa_string_terminated("foo")), opa_set()) == 0);
+    test("reachable/malformed initial nodes", opa_value_compare(builtin_graph_reachable(&graph3->hdr, opa_string_terminated("foo")), NULL) == 0);
 
     // graph -> {"a": null}
     opa_object_t *graph4 = opa_cast_object(opa_object());


### PR DESCRIPTION
This PR adds operand type checks for the `graph.reachable` and `graph.reachable_paths` builtins, so that they will consistently return builtin errors about wrong types for *both* arguments.

Previous behavior was inconsistent about when errors would be returned, if at all.

Fixes #4951.