### PR TITLE
testcases: Fix duplicate yaml test keys

### DIFF
--- a/test/cases/testdata/units/test-issue-4856.yaml
+++ b/test/cases/testdata/units/test-issue-4856.yaml
@@ -10,6 +10,8 @@ cases:
   query: data.test.p = x
   want_result:
   - x: true
+- data:
+  modules:
   - |
     package test
     p {
@@ -19,6 +21,8 @@ cases:
   query: data.test.p = x
   want_result:
   - x: true
+- data:
+  modules:
   - |
     package test
     p {

--- a/test/cases/testdata/units/test-issue-4856.yaml
+++ b/test/cases/testdata/units/test-issue-4856.yaml
@@ -1,34 +1,35 @@
+---
 cases:
-- data:
-  modules:
-  - |
-    package test
-    p {
-        units.parse("500m") == 0.5
-    }
-  note: units_parse/exact comparison - regression case 1
-  query: data.test.p = x
-  want_result:
-  - x: true
-- data:
-  modules:
-  - |
-    package test
-    p {
-        units.parse("0.0005K") == 0.5
-    }
-  note: units_parse/exact comparison - regression case 2
-  query: data.test.p = x
-  want_result:
-  - x: true
-- data:
-  modules:
-  - |
-    package test
-    p {
-        units.parse("0.0000005M") == 0.5
-    }
-  note: units_parse/exact comparison - regression case 3
-  query: data.test.p = x
-  want_result:
-  - x: true
+  - data:
+    modules:
+      - |
+        package test
+        p {
+            units.parse("500m") == 0.5
+        }
+    note: units_parse/exact comparison - regression case 1
+    query: data.test.p = x
+    want_result:
+      - x: true
+  - data:
+    modules:
+      - |
+        package test
+        p {
+            units.parse("0.0005K") == 0.5
+        }
+    note: units_parse/exact comparison - regression case 2
+    query: data.test.p = x
+    want_result:
+      - x: true
+  - data:
+    modules:
+      - |
+        package test
+        p {
+            units.parse("0.0000005M") == 0.5
+        }
+    note: units_parse/exact comparison - regression case 3
+    query: data.test.p = x
+    want_result:
+      - x: true


### PR DESCRIPTION
This commit adds missing `module` keys to the `units/test-issue-4856.yaml` regression tests, and fixes several YAML formatting issues in the file.