### PR TITLE
bundle/status: Include bundle size in status information

### DIFF
--- a/docs/content/management-status.md
+++ b/docs/content/management-status.md
@@ -55,6 +55,9 @@ on the agent, updates will be sent to `/status`.
         "timer_rego_module_compile_ns": 12345,
         "timer_rego_module_parse_ns": 12345
       }
+      "name": "http/example/authz",
+      "size": 1048576,
+      "type": "snapshot",
     }
   },
   "plugins": {
@@ -233,6 +236,8 @@ Status updates contain the following fields:
 | `bundles[_].message` | `string` | Human readable messages describing the error(s). |
 | `bundles[_].http_code` | `number` | If present, indicates an erroneous HTTP status code that OPA received downloading this bundle. |
 | `bundles[_].errors` | `array` | Collection of detailed parse or compile errors that occurred during activation of this bundle. |
+| `bundles[_].size` | `number` | Bundle size, in bytes |
+| `bundles[_].type` | `string` | Bundle type, either `snapshot` or `delta` |
 | `discovery.name` | `string` | Name of discovery bundle that the OPA instance is configured to download. |
 | `discovery.active_revision` | `string` | Opaque revision identifier of the last successful discovery activation. |
 | `discovery.last_request` | `string` | RFC3339 timestamp of last discovery bundle request. This timestamp should be >= to the successful request timestamp in normal operation. |

--- a/download/download_test.go
+++ b/download/download_test.go
@@ -53,6 +53,10 @@ func TestStartStop(t *testing.T) {
 		t.Fatalf("expected URL to have path as suffix but got %v and %v", u1.Bundle.Modules[0].URL, u1.Bundle.Modules[0].Path)
 	}
 
+	if u1.Size == 0 {
+		t.Fatal("expected non-0 size")
+	}
+
 	d.Stop(ctx)
 }
 
@@ -88,6 +92,10 @@ func TestStartStopWithBundlePersistence(t *testing.T) {
 
 	if u1.Raw == nil {
 		t.Fatal("expected bundle reader to be non-nil")
+	}
+
+	if u1.Size == 0 {
+		t.Fatal("expected non-0 size")
 	}
 
 	r := bundle.NewReader(u1.Raw)
@@ -215,6 +223,10 @@ func TestStartStopWithDeltaBundleMode(t *testing.T) {
 
 	if u1.Bundle == nil || u1.Bundle.Manifest.Revision != deltaBundleMode {
 		t.Fatal("expected delta bundle but got:", u1)
+	}
+
+	if u1.Size == 0 {
+		t.Fatal("expected non-0 size")
 	}
 
 	d.Stop(ctx)

--- a/plugins/bundle/plugin.go
+++ b/plugins/bundle/plugin.go
@@ -522,6 +522,7 @@ func (p *Plugin) process(ctx context.Context, name string, u download.Update) {
 
 		p.status[name].SetError(nil)
 		p.status[name].SetActivateSuccess(u.Bundle.Manifest.Revision)
+		p.status[name].SetBundleSize(u.Size)
 
 		if u.ETag != "" {
 			p.log(name).Info("Bundle loaded and activated successfully. Etag updated to %v.", u.ETag)

--- a/plugins/bundle/status.go
+++ b/plugins/bundle/status.go
@@ -27,6 +27,7 @@ type Status struct {
 	ActiveRevision           string          `json:"active_revision,omitempty"`
 	LastSuccessfulActivation time.Time       `json:"last_successful_activation,omitempty"`
 	Type                     string          `json:"type,omitempty"`
+	Size                     int             `json:"size,omitempty"`
 	LastSuccessfulDownload   time.Time       `json:"last_successful_download,omitempty"`
 	LastSuccessfulRequest    time.Time       `json:"last_successful_request,omitempty"`
 	LastRequest              time.Time       `json:"last_request,omitempty"`
@@ -53,6 +54,10 @@ func (s *Status) SetDownloadSuccess() {
 // SetRequest updates the status object to reflect a download attempt.
 func (s *Status) SetRequest() {
 	s.LastRequest = time.Now().UTC()
+}
+
+func (s *Status) SetBundleSize(size int) {
+	s.Size = size
 }
 
 // SetError updates the status object to reflect a failure to download or

--- a/plugins/discovery/discovery.go
+++ b/plugins/discovery/discovery.go
@@ -202,6 +202,7 @@ func (c *Discovery) processUpdate(ctx context.Context, u download.Update) {
 	if u.Bundle != nil {
 		c.status.Type = u.Bundle.Type()
 		c.status.LastSuccessfulDownload = c.status.LastSuccessfulRequest
+		c.status.SetBundleSize(u.Size)
 
 		if err := c.reconfigure(ctx, u); err != nil {
 			c.logger.Error("Discovery reconfiguration error occurred: %v", err)

--- a/plugins/discovery/discovery_test.go
+++ b/plugins/discovery/discovery_test.go
@@ -40,6 +40,10 @@ import (
 	"github.com/open-policy-agent/opa/version"
 )
 
+const (
+	snapshotBundleSize = 1024
+)
+
 func TestMain(m *testing.M) {
 	if version.Version == "" {
 		version.Version = "unit-test"
@@ -415,12 +419,14 @@ func TestReconfigure(t *testing.T) {
 		}
 	`)
 
-	disco.oneShot(ctx, download.Update{Bundle: initialBundle})
+	disco.oneShot(ctx, download.Update{Bundle: initialBundle, Size: snapshotBundleSize})
 
 	if disco.status == nil {
 		t.Fatal("Expected to find status, found nil")
 	} else if disco.status.Type != bundle.SnapshotBundleType {
 		t.Fatalf("expected snapshot bundle but got %v", disco.status.Type)
+	} else if disco.status.Size != snapshotBundleSize {
+		t.Fatalf("expected snapshot bundle size %d but got %d", snapshotBundleSize, disco.status.Size)
 	}
 
 	// Verify labels are unchanged


### PR DESCRIPTION
OPA has support for Delta Bundles. The status object already
contains valuable information such as last activation timestamp
and the type e.g., snapshot vs delta.

This change updates the bundle.Status object to include the
bundle size. This can be useful for status endpoints to differentiate
between the sizes of snapshot vs delta bundles.

Issue: 4477

Signed-off-by: Bryan Fulton <bryan@styra.com>