### PR TITLE
Document that function overloading is unsupported

### DIFF
--- a/docs/content/policy-language.md
+++ b/docs/content/policy-language.md
@@ -975,6 +975,65 @@ s(5, 3)
 ```live:eg/double_function_define_undefined/2:output:expect_undefined
 ```
 
+#### Function overloading
+Rego does not currently support the overloading of functions by the number of parameters. If two function definitions are given with the same function name but different numbers of parameters, a compile-time type error is generated.
+
+```live:eg/function_overloading_error:module
+r(x) := result if {
+    result := 2*x
+}
+
+r(x, y) := result if {
+    result := 2*x + 3*y
+}
+```
+
+```live:eg/function_overloading_error:output:expect_rego_type_error
+```
+
+The error can be avoided by using different function names.
+```live:eg/function_overloading_naming:module
+r_1(x) := result if {
+    result := 2*x
+}
+
+r_2(x, y) := result if {
+    result := 2*x + 3*y
+}
+```
+
+```live:eg/function_overloading_naming:query:merge_down
+[
+  r_1(10),
+  r_2(10, 1)
+]
+```
+```live:eg/function_overloading_naming:output
+```
+
+In the unusual case that it is critical to use the same name, the function could be made to take the list of parameters as a single array. However, this approach is not generally recommended because it sacrifices some helpful compile-time checking and can be quite error-prone.
+
+```live:eg/function_overloading_array:module
+r(params) := result if {
+    count(params) == 1
+    result := 2*params[0]
+}
+
+r(params) := result if {
+    count(params) == 2
+    result := 2*params[0] + 3*params[1]
+}
+```
+
+```live:eg/function_overloading_array:query:merge_down
+[
+  r([10]),
+  r([10, 1])
+]
+```
+```live:eg/function_overloading_array:output
+```
+
 ## Negation
 
 To generate the content of a [Virtual Document](../philosophy#how-does-opa-work), OPA attempts to bind variables in the body of the rule such that all expressions in the rule evaluate to True.


### PR DESCRIPTION
Explicitly document and show that function overloading is unsupported
in order to reduce user confusion.
PR created in response to user feedback that is confusing to search
for Rego function overloading and find only a github issue discussing
obscure OPA internals.

Signed-off-by: Eric Kao <eric@styra.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->
