### PR TITLE
topdown/units_parse: Avoid extra decimal places for integers.

### DIFF
--- a/test/cases/testdata/units/test-units-precision.yaml
+++ b/test/cases/testdata/units/test-units-precision.yaml
@@ -1,0 +1,13 @@
+---
+cases:
+  - data:
+    modules:
+      - |
+        package test
+        p {
+            json.marshal(units.parse("1G")) == json.marshal(1000000000)
+        }
+    note: units_parse/no decimal places for integers
+    query: data.test.p = x
+    want_result:
+      - x: true

--- a/topdown/parse_units.go
+++ b/topdown/parse_units.go
@@ -108,6 +108,11 @@ func builtinUnits(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term) e
 
 	numRat.Mul(numRat, &x)
 
+	// Cleaner printout when we have a pure integer value.
+	if numRat.IsInt() {
+		return iter(ast.NumberTerm(json.Number(numRat.Num().String())))
+	}
+
 	// When using just big.Float, we had floating-point precision
 	// issues because quantities like 0.001 are not exactly representable.
 	// Rationals (such as big.Rat) do not suffer this problem, but are


### PR DESCRIPTION
This commit cleans up the output of `units.parse` for integer values. Previously, all of them would have 10 places past the decimal, regardless of whether that much precision was actually needed.

Example of bad behavior:
```
opa eval -f raw 'units.parse("1G")'
1000000000.0000000000
```

Behavior change from this PR:
```
opa eval -f raw 'units.parse("1G")'
1000000000
```

Thanks @anderseknert for reporting this one!