### PR TITLE
storage/inmem: allow opt out of object roundtrip

### DIFF
--- a/bundle/store_test.go
+++ b/bundle/store_test.go
@@ -12,19 +12,17 @@ import (
 	"testing"
 
 	"github.com/open-policy-agent/opa/internal/file/archive"
-	"github.com/open-policy-agent/opa/logging"
-	"github.com/open-policy-agent/opa/util/test"
-
-	"github.com/open-policy-agent/opa/util"
+	"github.com/open-policy-agent/opa/internal/storage/mock"
 
 	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/logging"
 	"github.com/open-policy-agent/opa/metrics"
-
-	"github.com/open-policy-agent/opa/internal/storage/mock"
+	"github.com/open-policy-agent/opa/util"
+	"github.com/open-policy-agent/opa/util/test"
 
 	"github.com/open-policy-agent/opa/storage"
 	"github.com/open-policy-agent/opa/storage/disk"
-	"github.com/open-policy-agent/opa/storage/inmem"
+	inmem "github.com/open-policy-agent/opa/storage/inmem/test"
 )
 
 func TestManifestStoreLifecycleSingleBundle(t *testing.T) {

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -163,7 +163,7 @@ func opaTest(args []string) int {
 
 	if testParams.bundleMode {
 		bundles, err = tester.LoadBundles(args, filter.Apply)
-		store = inmem.New()
+		store = inmem.NewWithOpts(inmem.OptRoundTripOnWrite(false))
 	} else {
 		modules, store, err = tester.Load(args, filter.Apply)
 	}

--- a/compile/compile.go
+++ b/compile/compile.go
@@ -686,7 +686,7 @@ func (o *optimizer) Do(ctx context.Context) error {
 		data = map[string]interface{}{}
 	}
 
-	store := inmem.NewFromObject(data)
+	store := inmem.NewFromObjectWithOpts(data, inmem.OptRoundTripOnWrite(false))
 	resultsym := ast.VarTerm(o.resultsymprefix + "__result__")
 	usedFilenames := map[string]int{}
 	var unknowns []*ast.Term

--- a/internal/presentation/presentation_test.go
+++ b/internal/presentation/presentation_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/open-policy-agent/opa/loader"
 	"github.com/open-policy-agent/opa/rego"
 	"github.com/open-policy-agent/opa/storage"
-	"github.com/open-policy-agent/opa/storage/inmem"
+	inmem "github.com/open-policy-agent/opa/storage/inmem/test"
 	"github.com/open-policy-agent/opa/util"
 	"github.com/open-policy-agent/opa/util/test"
 )

--- a/internal/runtime/init/init_test.go
+++ b/internal/runtime/init/init_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 
 	"github.com/open-policy-agent/opa/storage"
-	"github.com/open-policy-agent/opa/storage/inmem"
+	inmem "github.com/open-policy-agent/opa/storage/inmem/test"
 	"github.com/open-policy-agent/opa/util"
 	"github.com/open-policy-agent/opa/util/test"
 	"github.com/open-policy-agent/opa/version"

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -55,7 +55,13 @@ func (l *Result) Compiler() (*ast.Compiler, error) {
 
 // Store returns a Store object with the documents from this loader result.
 func (l *Result) Store() (storage.Store, error) {
-	return inmem.NewFromObject(l.Documents), nil
+	return l.StoreWithOpts()
+}
+
+// StoreWithOpts returns a Store object with the documents from this loader result,
+// instantiated with the passed options.
+func (l *Result) StoreWithOpts(opts ...inmem.Opt) (storage.Store, error) {
+	return inmem.NewFromObjectWithOpts(l.Documents, opts...), nil
 }
 
 // RegoFile represents the result of loading a single Rego source file.

--- a/plugins/discovery/discovery.go
+++ b/plugins/discovery/discovery.go
@@ -318,7 +318,7 @@ func evaluateBundle(ctx context.Context, id string, info *ast.Term, b *bundleApi
 		return nil, compiler.Errors
 	}
 
-	store := inmem.NewFromObject(b.Data)
+	store := inmem.NewFromObjectWithOpts(b.Data, inmem.OptRoundTripOnWrite(false))
 
 	rego := rego.New(
 		rego.Query(query),

--- a/plugins/discovery/discovery_test.go
+++ b/plugins/discovery/discovery_test.go
@@ -34,7 +34,7 @@ import (
 	"github.com/open-policy-agent/opa/plugins/logs"
 	"github.com/open-policy-agent/opa/plugins/status"
 	"github.com/open-policy-agent/opa/server"
-	"github.com/open-policy-agent/opa/storage/inmem"
+	inmem "github.com/open-policy-agent/opa/storage/inmem/test"
 	"github.com/open-policy-agent/opa/topdown/cache"
 	"github.com/open-policy-agent/opa/util"
 	"github.com/open-policy-agent/opa/version"

--- a/plugins/logs/plugin_benchmark_test.go
+++ b/plugins/logs/plugin_benchmark_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/open-policy-agent/opa/plugins"
 	"github.com/open-policy-agent/opa/storage"
-	"github.com/open-policy-agent/opa/storage/inmem"
+	inmem "github.com/open-policy-agent/opa/storage/inmem/test"
 	"github.com/open-policy-agent/opa/util"
 )
 

--- a/plugins/logs/plugin_test.go
+++ b/plugins/logs/plugin_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/open-policy-agent/opa/rego"
 	"github.com/open-policy-agent/opa/server"
 	"github.com/open-policy-agent/opa/storage"
-	"github.com/open-policy-agent/opa/storage/inmem"
+	inmem "github.com/open-policy-agent/opa/storage/inmem/test"
 	"github.com/open-policy-agent/opa/topdown"
 	"github.com/open-policy-agent/opa/topdown/print"
 	"github.com/open-policy-agent/opa/util"

--- a/plugins/plugins_test.go
+++ b/plugins/plugins_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/open-policy-agent/opa/logging"
 	"github.com/open-policy-agent/opa/logging/test"
 	"github.com/open-policy-agent/opa/plugins/rest"
-	"github.com/open-policy-agent/opa/storage/inmem"
+	inmem "github.com/open-policy-agent/opa/storage/inmem/test"
 	"github.com/open-policy-agent/opa/topdown/cache"
 )
 

--- a/plugins/status/plugin_test.go
+++ b/plugins/status/plugin_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/open-policy-agent/opa/metrics"
 	"github.com/open-policy-agent/opa/plugins"
 	"github.com/open-policy-agent/opa/plugins/bundle"
-	"github.com/open-policy-agent/opa/storage/inmem"
+	inmem "github.com/open-policy-agent/opa/storage/inmem/test"
 	"github.com/open-policy-agent/opa/util"
 	"github.com/open-policy-agent/opa/version"
 )

--- a/repl/repl_test.go
+++ b/repl/repl_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/internal/presentation"
 	"github.com/open-policy-agent/opa/storage"
-	"github.com/open-policy-agent/opa/storage/inmem"
+	inmem "github.com/open-policy-agent/opa/storage/inmem/test"
 	"github.com/open-policy-agent/opa/util"
 )
 

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -332,7 +332,7 @@ func NewRuntime(ctx context.Context, params Params) (*Runtime, error) {
 			return nil, fmt.Errorf("initialize disk store: %w", err)
 		}
 	} else {
-		store = inmem.New()
+		store = inmem.NewWithOpts(inmem.OptRoundTripOnWrite(false))
 	}
 
 	manager, err := plugins.New(config,

--- a/storage/inmem/inmem_test.go
+++ b/storage/inmem/inmem_test.go
@@ -12,10 +12,8 @@ import (
 	"testing"
 
 	"github.com/open-policy-agent/opa/bundle"
-
 	"github.com/open-policy-agent/opa/internal/file/archive"
-
-	"github.com/open-policy-agent/opa/storage/internal/errors"
+	storageerrors "github.com/open-policy-agent/opa/storage/internal/errors"
 
 	"github.com/open-policy-agent/opa/storage"
 	"github.com/open-policy-agent/opa/util"
@@ -39,12 +37,12 @@ func TestInMemoryRead(t *testing.T) {
 		{"/d/e/1", "baz"},
 		{"/d/e", []interface{}{"bar", "baz"}},
 		{"/c/0/z", map[string]interface{}{"p": true, "q": false}},
-		{"/a/0/beef", errors.NewNotFoundError(storage.MustParsePath("/a/0/beef"))},
-		{"/d/100", errors.NewNotFoundError(storage.MustParsePath("/d/100"))},
-		{"/dead/beef", errors.NewNotFoundError(storage.MustParsePath("/dead/beef"))},
-		{"/a/str", errors.NewNotFoundErrorWithHint(storage.MustParsePath("/a/str"), errors.ArrayIndexTypeMsg)},
-		{"/a/100", errors.NewNotFoundErrorWithHint(storage.MustParsePath("/a/100"), errors.OutOfRangeMsg)},
-		{"/a/-1", errors.NewNotFoundErrorWithHint(storage.MustParsePath("/a/-1"), errors.OutOfRangeMsg)},
+		{"/a/0/beef", storageerrors.NewNotFoundError(storage.MustParsePath("/a/0/beef"))},
+		{"/d/100", storageerrors.NewNotFoundError(storage.MustParsePath("/d/100"))},
+		{"/dead/beef", storageerrors.NewNotFoundError(storage.MustParsePath("/dead/beef"))},
+		{"/a/str", storageerrors.NewNotFoundErrorWithHint(storage.MustParsePath("/a/str"), storageerrors.ArrayIndexTypeMsg)},
+		{"/a/100", storageerrors.NewNotFoundErrorWithHint(storage.MustParsePath("/a/100"), storageerrors.OutOfRangeMsg)},
+		{"/a/-1", storageerrors.NewNotFoundErrorWithHint(storage.MustParsePath("/a/-1"), storageerrors.OutOfRangeMsg)},
 	}
 
 	store := NewFromObject(data)
@@ -99,7 +97,7 @@ func TestInMemoryWrite(t *testing.T) {
 		{"append err", "remove", "/c/0/x/-", "", invalidPatchError("/c/0/x/-: invalid patch path"), "", nil},
 		{"append err-2", "replace", "/c/0/x/-", "", invalidPatchError("/c/0/x/-: invalid patch path"), "", nil},
 
-		{"remove", "remove", "/a", "", nil, "/a", errors.NewNotFoundError(storage.MustParsePath("/a"))},
+		{"remove", "remove", "/a", "", nil, "/a", storageerrors.NewNotFoundError(storage.MustParsePath("/a"))},
 		{"remove arr", "remove", "/a/1", "", nil, "/a", "[1,3,4]"},
 		{"remove obj/arr", "remove", "/c/0/x/1", "", nil, "/c/0/x", `[true,"foo"]`},
 		{"remove arr/arr", "remove", "/h/0/1", "", nil, "/h/0", "[1,3]"},
@@ -112,21 +110,21 @@ func TestInMemoryWrite(t *testing.T) {
 
 		{"err: bad root type", "add", "/", "[1,2,3]", invalidPatchError(rootMustBeObjectMsg), "", nil},
 		{"err: remove root", "remove", "/", "", invalidPatchError(rootCannotBeRemovedMsg), "", nil},
-		{"err: add arr (non-integer)", "add", "/a/foo", "1", errors.NewNotFoundErrorWithHint(storage.MustParsePath("/a/foo"), errors.ArrayIndexTypeMsg), "", nil},
-		{"err: add arr (non-integer)", "add", "/a/3.14", "1", errors.NewNotFoundErrorWithHint(storage.MustParsePath("/a/3.14"), errors.ArrayIndexTypeMsg), "", nil},
-		{"err: add arr (out of range)", "add", "/a/5", "1", errors.NewNotFoundErrorWithHint(storage.MustParsePath("/a/5"), errors.OutOfRangeMsg), "", nil},
-		{"err: add arr (out of range)", "add", "/a/-1", "1", errors.NewNotFoundErrorWithHint(storage.MustParsePath("/a/-1"), errors.OutOfRangeMsg), "", nil},
-		{"err: add arr (missing root)", "add", "/dead/beef/0", "1", errors.NewNotFoundError(storage.MustParsePath("/dead/beef/0")), "", nil},
-		{"err: add non-coll", "add", "/a/1/2", "1", errors.NewNotFoundError(storage.MustParsePath("/a/1/2")), "", nil},
-		{"err: append (missing)", "add", `/dead/beef/-`, "1", errors.NewNotFoundError(storage.MustParsePath("/dead/beef/-")), "", nil},
-		{"err: append obj/arr", "add", `/c/0/deadbeef/-`, `"x"`, errors.NewNotFoundError(storage.MustParsePath("/c/0/deadbeef/-")), "", nil},
-		{"err: append arr/arr (out of range)", "add", `/h/9999/-`, `"x"`, errors.NewNotFoundErrorWithHint(storage.MustParsePath("/h/9999/-"), errors.OutOfRangeMsg), "", nil},
-		{"err: append append+add", "add", `/a/-/b/-`, `"x"`, errors.NewNotFoundErrorWithHint(storage.MustParsePath(`/a/-/b/-`), errors.ArrayIndexTypeMsg), "", nil},
-		{"err: append arr/arr (non-array)", "add", `/b/v1/-`, "1", errors.NewNotFoundError(storage.MustParsePath("/b/v1/-")), "", nil},
-		{"err: remove missing", "remove", "/dead/beef/0", "", errors.NewNotFoundError(storage.MustParsePath("/dead/beef/0")), "", nil},
-		{"err: remove obj (missing)", "remove", "/b/deadbeef", "", errors.NewNotFoundError(storage.MustParsePath("/b/deadbeef")), "", nil},
-		{"err: replace root (missing)", "replace", "/deadbeef", "1", errors.NewNotFoundError(storage.MustParsePath("/deadbeef")), "", nil},
-		{"err: replace missing", "replace", "/dead/beef/1", "1", errors.NewNotFoundError(storage.MustParsePath("/dead/beef/1")), "", nil},
+		{"err: add arr (non-integer)", "add", "/a/foo", "1", storageerrors.NewNotFoundErrorWithHint(storage.MustParsePath("/a/foo"), storageerrors.ArrayIndexTypeMsg), "", nil},
+		{"err: add arr (non-integer)", "add", "/a/3.14", "1", storageerrors.NewNotFoundErrorWithHint(storage.MustParsePath("/a/3.14"), storageerrors.ArrayIndexTypeMsg), "", nil},
+		{"err: add arr (out of range)", "add", "/a/5", "1", storageerrors.NewNotFoundErrorWithHint(storage.MustParsePath("/a/5"), storageerrors.OutOfRangeMsg), "", nil},
+		{"err: add arr (out of range)", "add", "/a/-1", "1", storageerrors.NewNotFoundErrorWithHint(storage.MustParsePath("/a/-1"), storageerrors.OutOfRangeMsg), "", nil},
+		{"err: add arr (missing root)", "add", "/dead/beef/0", "1", storageerrors.NewNotFoundError(storage.MustParsePath("/dead/beef/0")), "", nil},
+		{"err: add non-coll", "add", "/a/1/2", "1", storageerrors.NewNotFoundError(storage.MustParsePath("/a/1/2")), "", nil},
+		{"err: append (missing)", "add", `/dead/beef/-`, "1", storageerrors.NewNotFoundError(storage.MustParsePath("/dead/beef/-")), "", nil},
+		{"err: append obj/arr", "add", `/c/0/deadbeef/-`, `"x"`, storageerrors.NewNotFoundError(storage.MustParsePath("/c/0/deadbeef/-")), "", nil},
+		{"err: append arr/arr (out of range)", "add", `/h/9999/-`, `"x"`, storageerrors.NewNotFoundErrorWithHint(storage.MustParsePath("/h/9999/-"), storageerrors.OutOfRangeMsg), "", nil},
+		{"err: append append+add", "add", `/a/-/b/-`, `"x"`, storageerrors.NewNotFoundErrorWithHint(storage.MustParsePath(`/a/-/b/-`), storageerrors.ArrayIndexTypeMsg), "", nil},
+		{"err: append arr/arr (non-array)", "add", `/b/v1/-`, "1", storageerrors.NewNotFoundError(storage.MustParsePath("/b/v1/-")), "", nil},
+		{"err: remove missing", "remove", "/dead/beef/0", "", storageerrors.NewNotFoundError(storage.MustParsePath("/dead/beef/0")), "", nil},
+		{"err: remove obj (missing)", "remove", "/b/deadbeef", "", storageerrors.NewNotFoundError(storage.MustParsePath("/b/deadbeef")), "", nil},
+		{"err: replace root (missing)", "replace", "/deadbeef", "1", storageerrors.NewNotFoundError(storage.MustParsePath("/deadbeef")), "", nil},
+		{"err: replace missing", "replace", "/dead/beef/1", "1", storageerrors.NewNotFoundError(storage.MustParsePath("/dead/beef/1")), "", nil},
 	}
 
 	ctx := context.Background()
@@ -907,4 +905,71 @@ func loadSmallTestData() map[string]interface{} {
 		panic(err)
 	}
 	return data
+}
+
+func TestOptRoundTripOnWrite(t *testing.T) {
+	validObject := map[string]string{"foo": "bar"}
+
+	// self-referential objects are not serializable to JSON.
+	invalidObject := map[string]interface{}{}
+	invalidObject["foo"] = invalidObject
+
+	tests := []struct {
+		name    string
+		opts    []Opt
+		obj     interface{}
+		wantErr bool
+	}{{
+		name:    "success on valid object no Opts",
+		opts:    nil,
+		obj:     validObject,
+		wantErr: false,
+	}, {
+		name:    "success on valid object round trip enabled",
+		opts:    []Opt{OptRoundTripOnWrite(true)},
+		obj:     validObject,
+		wantErr: false,
+	}, {
+		name:    "success on valid object round trip disabled",
+		opts:    []Opt{OptRoundTripOnWrite(false)},
+		obj:     validObject,
+		wantErr: false,
+	}, {
+		// Ensure the setting defaults to "true".
+		name:    "failure on invalid object no Opts",
+		opts:    nil,
+		obj:     invalidObject,
+		wantErr: true,
+	}, {
+		name:    "failure on invalid object round trip enabled",
+		opts:    []Opt{OptRoundTripOnWrite(true)},
+		obj:     invalidObject,
+		wantErr: true,
+	}, {
+		// While this represents a bad use case, it's how we know the round-tripping
+		// has been disabled.
+		name:    "success on invalid object round trip disabled",
+		opts:    []Opt{OptRoundTripOnWrite(false)},
+		obj:     invalidObject,
+		wantErr: false,
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db := NewWithOpts(tt.opts...)
+			ctx := context.Background()
+
+			txn, err := db.NewTransaction(ctx, storage.WriteParams)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			err = db.Write(ctx, txn, storage.AddOp, []string{"data"}, tt.obj)
+			if tt.wantErr && err == nil {
+				t.Fatal("got Write error = nil, want error")
+			} else if !tt.wantErr && err != nil {
+				t.Fatalf("got Write error, want nil")
+			}
+		})
+	}
 }

--- a/storage/inmem/opts.go
+++ b/storage/inmem/opts.go
@@ -1,0 +1,25 @@
+package inmem
+
+// An Opt modifies store at instantiation.
+type Opt func(*store)
+
+// OptRoundTripOnWrite sets whether incoming objects written to store are
+// round-tripped through JSON to ensure they are serializable to JSON.
+//
+// Callers should disable this if they can guarantee all objects passed to
+// Write() are serializable to JSON. Failing to do so may result in undefined
+// behavior, including panics.
+//
+// Usually, when only storing objects in the inmem store that have been read
+// via encoding/json, this is safe to disable, and comes with an improvement
+// in performance and memory use.
+//
+// If setting to false, callers should deep-copy any objects passed to Write()
+// unless they can guarantee the objects will not be mutated after being written,
+// and that mutations happening to the objects after they have been passed into
+// Write() don't affect their logic.
+func OptRoundTripOnWrite(enabled bool) Opt {
+	return func(s *store) {
+		s.roundTripOnWrite = enabled
+	}
+}

--- a/storage/inmem/test/testutil.go
+++ b/storage/inmem/test/testutil.go
@@ -1,0 +1,22 @@
+// Copyright 2022 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package test
+
+import (
+	"github.com/open-policy-agent/opa/storage"
+	"github.com/open-policy-agent/opa/storage/inmem"
+)
+
+// New returns an inmem store with some common options set: opt-out of write
+// roundtripping.
+func New() storage.Store {
+	return inmem.NewWithOpts(inmem.OptRoundTripOnWrite(false))
+}
+
+// NewFromObject returns an inmem store from the passed object, with some
+// common options set: opt-out of write roundtripping.
+func NewFromObject(x map[string]interface{}) storage.Store {
+	return inmem.NewFromObjectWithOpts(x, inmem.OptRoundTripOnWrite(false))
+}

--- a/storage/inmem/txn.go
+++ b/storage/inmem/txn.go
@@ -375,6 +375,9 @@ func (u *update) Apply(data interface{}) interface{} {
 	}
 	switch parent := parent.(type) {
 	case map[string]interface{}:
+		if parent == nil {
+			parent = make(map[string]interface{}, 1)
+		}
 		parent[key] = u.value
 	case []interface{}:
 		idx, err := strconv.Atoi(key)

--- a/tester/runner.go
+++ b/tester/runner.go
@@ -306,7 +306,7 @@ func (r *Runner) runTests(ctx context.Context, txn storage.Transaction, enablePr
 	})
 
 	if r.store == nil {
-		r.store = inmem.New()
+		r.store = inmem.NewWithOpts(inmem.OptRoundTripOnWrite(false))
 	}
 
 	if r.bundles != nil && len(r.bundles) > 0 {

--- a/topdown/cidr_test.go
+++ b/topdown/cidr_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/storage"
-	"github.com/open-policy-agent/opa/storage/inmem"
+	inmem "github.com/open-policy-agent/opa/storage/inmem/test"
 )
 
 func TestNetCIDRExpandCancellation(t *testing.T) {
@@ -22,7 +22,7 @@ func TestNetCIDRExpandCancellation(t *testing.T) {
 		`,
 	})
 
-	store := inmem.NewFromObject(map[string]interface{}{})
+	store := inmem.New()
 	txn := storage.NewTransactionOrDie(ctx, store)
 	cancel := NewCancel()
 

--- a/topdown/eval_test.go
+++ b/topdown/eval_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/metrics"
 	"github.com/open-policy-agent/opa/storage"
-	"github.com/open-policy-agent/opa/storage/inmem"
+	inmem "github.com/open-policy-agent/opa/storage/inmem/test"
 )
 
 func TestQueryIDFactory(t *testing.T) {

--- a/topdown/exported_test.go
+++ b/topdown/exported_test.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/storage"
-	"github.com/open-policy-agent/opa/storage/inmem"
+	inmem "github.com/open-policy-agent/opa/storage/inmem/test"
 	"github.com/open-policy-agent/opa/test/cases"
 )
 

--- a/topdown/query_test.go
+++ b/topdown/query_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/storage"
-	"github.com/open-policy-agent/opa/storage/inmem"
+	inmem "github.com/open-policy-agent/opa/storage/inmem/test"
 )
 
 func TestQueryTracerDontPlugLocalVars(t *testing.T) {

--- a/topdown/sets_bench_test.go
+++ b/topdown/sets_bench_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/storage"
-	"github.com/open-policy-agent/opa/storage/inmem"
+	inmem "github.com/open-policy-agent/opa/storage/inmem/test"
 )
 
 func BenchmarkSetUnion(b *testing.B) {

--- a/topdown/tokens_test.go
+++ b/topdown/tokens_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/open-policy-agent/opa/internal/jwx/jwk"
 	"github.com/open-policy-agent/opa/internal/jwx/jws"
 	"github.com/open-policy-agent/opa/storage"
-	"github.com/open-policy-agent/opa/storage/inmem"
+	inmem "github.com/open-policy-agent/opa/storage/inmem/test"
 )
 
 func TestParseTokenConstraints(t *testing.T) {

--- a/topdown/topdown_bench_test.go
+++ b/topdown/topdown_bench_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/metrics"
 	"github.com/open-policy-agent/opa/storage"
-	"github.com/open-policy-agent/opa/storage/inmem"
+	inmem "github.com/open-policy-agent/opa/storage/inmem/test"
 	"github.com/open-policy-agent/opa/util/test"
 )
 

--- a/topdown/topdown_partial_bench_test.go
+++ b/topdown/topdown_partial_bench_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/storage"
-	"github.com/open-policy-agent/opa/storage/inmem"
+	inmem "github.com/open-policy-agent/opa/storage/inmem/test"
 )
 
 func BenchmarkInliningFullScan(b *testing.B) {

--- a/topdown/topdown_partial_test.go
+++ b/topdown/topdown_partial_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/storage"
-	"github.com/open-policy-agent/opa/storage/inmem"
+	inmem "github.com/open-policy-agent/opa/storage/inmem/test"
 	"github.com/open-policy-agent/opa/util"
 )
 

--- a/topdown/topdown_test.go
+++ b/topdown/topdown_test.go
@@ -29,7 +29,7 @@ import (
 
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/storage"
-	"github.com/open-policy-agent/opa/storage/inmem"
+	inmem "github.com/open-policy-agent/opa/storage/inmem/test"
 	"github.com/open-policy-agent/opa/types"
 	"github.com/open-policy-agent/opa/util"
 )

--- a/topdown/trace_test.go
+++ b/topdown/trace_test.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/storage"
-	"github.com/open-policy-agent/opa/storage/inmem"
+	inmem "github.com/open-policy-agent/opa/storage/inmem/test"
 	"github.com/open-policy-agent/opa/util"
 )
 


### PR DESCRIPTION
This is a continuance of @willbeason's work in https://github.com/open-policy-agent/opa/pull/4709. 

It will allow everyone to use an in-memory store _without roundtripping_. Before, we had been roundtripping every object written to that store through json, to canonicalize its data type. However, for many code paths, this isn't necessary. Notably, when our own http handlers take in JSON through encoding/json and unmarshal it, it'll always be in the right format, and the extra roundtrip can be avoided.

This roundtrip would also create a deep copy of the object, and with the opt-out, that no longer happens.

Fixes #4708.