### PR TITLE
Fix multiple-reader race condition for Sets/Objects

### DIFF
--- a/ast/term.go
+++ b/ast/term.go
@@ -1589,6 +1589,8 @@ func (s *set) Slice() []*Term {
 	return s.sortedKeys()
 }
 
+// NOTE(philipc): We assume a many-readers, single-writer model here.
+// This method should NOT be used concurrently, or else we risk data races.
 func (s *set) insert(x *Term) {
 	hash := x.Hash()
 	insertHash := hash
@@ -2223,6 +2225,8 @@ func (obj *object) get(k *Term) *objectElem {
 	return nil
 }
 
+// NOTE(philipc): We assume a many-readers, single-writer model here.
+// This method should NOT be used concurrently, or else we risk data races.
 func (obj *object) insert(k, v *Term) {
 	hash := k.Hash()
 	head := obj.elems[hash]

--- a/ast/term_test.go
+++ b/ast/term_test.go
@@ -7,8 +7,12 @@ package ast
 import (
 	"encoding/json"
 	"fmt"
+	"math/rand"
 	"reflect"
+	"runtime"
+	"sort"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/open-policy-agent/opa/util"
@@ -867,6 +871,52 @@ func TestSetCopy(t *testing.T) {
 	if !expCpy.Equal(cpy) {
 		t.Errorf("Expected %v but got %v", expCpy, cpy)
 	}
+}
+
+// Constructs a set, and then has several reader goroutines attempt to
+// concurrently iterate across it. This should pretty consistently
+// hit a race condition around sorting the underlying key slice if
+// the sorting isn't guarded properly.
+func TestSetConcurrentReads(t *testing.T) {
+	// Create array of numbers.
+	numbers := make([]*Term, 10000)
+	for i := 0; i < 10000; i++ {
+		numbers[i] = IntNumberTerm(i)
+	}
+	// Shuffle numbers array for random insertion order.
+	rand.Seed(10000)
+	rand.Shuffle(len(numbers), func(i, j int) {
+		numbers[i], numbers[j] = numbers[j], numbers[i]
+	})
+	// Build set with numbers in unsorted order.
+	s := NewSet()
+	for i := 0; i < len(numbers); i++ {
+		s.Add(numbers[i])
+	}
+	// In-place sort on numbers.
+	sort.Sort(termSlice(numbers))
+
+	// Check if race condition on key sorting is present.
+	var wg sync.WaitGroup
+	num := runtime.NumCPU()
+	wg.Add(num)
+	for i := 0; i < num; i++ {
+		go func() {
+			defer wg.Done()
+			var retrieved []*Term
+			s.Foreach(func(v *Term) {
+				retrieved = append(retrieved, v)
+			})
+			// Check for sortedness of retrieved results.
+			// This will hit a race condition around `s.sortedKeys`.
+			for n := 0; n < len(retrieved); n++ {
+				if retrieved[n] != numbers[n] {
+					t.Errorf("Expected: %v at iteration %d but got %v instead", numbers[n], n, retrieved[n])
+				}
+			}
+		}()
+	}
+	wg.Wait()
 }
 
 func TestArrayOperations(t *testing.T) {


### PR DESCRIPTION
This PR fixes a race condition around keys slice sorting for Sets and Objects, using a `sync.Once` to ensure that the sorting operation only occurs _at most once_ between successive insertion operations.

The race condition could be readily triggered by using iteration methods, such as `.Iter()` or `.Foreach()`, on a Set/Object across multiple goroutines. The goroutines would race one another to sort the keys slice before iterating, with unfortunate results. Tests are included with this PR to exercise these problematic cases.

Benchmarks are encouraging, and suggest that the `sync.Once` guards have minimal effects on performance; mostly increasing variance in ns / op statistics by a few ns between runs.