### PR TITLE
ci: remove quick-fuzz, guard wasm tests on changed files, limit concurrency

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -122,17 +122,6 @@ jobs:
         run: make ci-go-perf
         timeout-minutes: 30
 
-  go-quick-fuzz:
-    name: Go quick fuzz
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v3
-
-      - name: Run fuzz check (3m)
-        run: make ci-go-fuzz FUZZ_TIME=180s
-        timeout-minutes: 30
-
   go-lint:
     name: Go Lint
     runs-on: ubuntu-22.04
@@ -151,9 +140,28 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3
 
-      - name: Build and Test WASM
+      - id: changed-files
+        uses: tj-actions/changed-files@v28.0.0
+        with:
+          files: |
+            Makefile
+            wasm/
+            ast/
+            internal/compiler/
+            internal/planner/
+            internal/wasm/
+            test/wasm/
+            test/cases/
+
+      - name: Build and Test Wasm
         run: make ci-wasm
         timeout-minutes: 15
+        if: steps.changed-files.outputs.any_changed == 'true'
+
+      - name: Build and Test Wasm SDK
+        run: make ci-go-wasm-sdk-e2e-test
+        timeout-minutes: 30
+        if: steps.changed-files.outputs.any_changed == 'true'
 
   check-generated:
     name: Check Generated
@@ -165,17 +173,6 @@ jobs:
       - name: Check Working Copy
         run: make ci-check-working-copy
         timeout-minutes: 15
-
-  wasm-go-sdk-e2e:
-    name: OPA Wasm SDK e2e
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v3
-
-      - name: Build and Test Wasm SDK
-        run: make ci-go-wasm-sdk-e2e-test
-        timeout-minutes: 30
 
   race-detector:
     name: Go Race Detector

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -120,13 +120,21 @@ jobs:
   go-perf:
     name: Go Perf
     runs-on: ubuntu-22.04
+    needs: generate
     steps:
       - name: Check out code
         uses: actions/checkout@v3
 
+      - name: Download generated artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: generated
+
       - name: Benchmark Test Golang
         run: make ci-go-perf
         timeout-minutes: 30
+        env:
+          DOCKER_RUNNING: 0
 
   go-lint:
     name: Go Lint
@@ -142,6 +150,7 @@ jobs:
   wasm:
     name: WASM
     runs-on: ubuntu-22.04
+    needs: generate
     steps:
       - name: Check out code
         uses: actions/checkout@v3
@@ -159,36 +168,61 @@ jobs:
             test/wasm/
             test/cases/
 
+      - name: Download generated artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: generated
+
       - name: Build and Test Wasm
         run: make ci-wasm
         timeout-minutes: 15
         if: steps.changed-files.outputs.any_changed == 'true'
+        env:
+          DOCKER_RUNNING: 0
 
       - name: Build and Test Wasm SDK
         run: make ci-go-wasm-sdk-e2e-test
         timeout-minutes: 30
         if: steps.changed-files.outputs.any_changed == 'true'
+        env:
+          DOCKER_RUNNING: 0
 
   check-generated:
     name: Check Generated
     runs-on: ubuntu-22.04
+    needs: generate
     steps:
       - name: Check out code
         uses: actions/checkout@v3
+
+      - name: Download generated artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: generated
 
       - name: Check Working Copy
         run: make ci-check-working-copy
         timeout-minutes: 15
+        env:
+          DOCKER_RUNNING: 0
 
   race-detector:
     name: Go Race Detector
     runs-on: ubuntu-22.04
+    needs: generate
     steps:
       - name: Check out code
         uses: actions/checkout@v3
 
+      - name: Download generated artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: generated
+
       - name: Test with Race Detector
         run: make ci-go-race-detector
+        env:
+          DOCKER_RUNNING: 0
 
   smoke-test-docker-images:
     name: docker image smoke test

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -2,6 +2,12 @@ name: PR Check
 
 on: [pull_request]
 
+# When a new revision is pushed to a PR, cancel all in-progress CI runs for that
+# PR. See https://docs.github.com/en/actions/using-jobs/using-concurrency
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # All jobs essentially re-create the `ci-release-test` make target, but are split
   # up for parallel runners for faster PR feedback and a nicer UX.


### PR DESCRIPTION
This is a first step into running less things all the time that don't need to
be run all the time.

It's a heuristic, and as such fallible: there could always be changes that
break something in the wasm code path, because I have forgotten that there's a
dependency of some sort.

Removing the quick-fuzz target, it's never brought any issues up; and still
runs in nightly tests.

Signed-off-by: Stephan Renatus <stephan.renatus@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->
