### PR TITLE
test/e2e/certrefresh: Add file.Sync() to eliminate slow write failures.

### DIFF
--- a/test/e2e/certrefresh/certrefresh_test.go
+++ b/test/e2e/certrefresh/certrefresh_test.go
@@ -155,6 +155,12 @@ func copy(from, to string) error {
 	defer dst.Close()
 
 	_, err = io.Copy(dst, src)
+	if err != nil {
+		return err
+	}
+
+	// Ensure that our writes get committed to disk, even on slower systems.
+	err = dst.Sync()
 	return err
 }
 

--- a/test/e2e/certrefresh/certrefresh_test.go
+++ b/test/e2e/certrefresh/certrefresh_test.go
@@ -160,8 +160,7 @@ func copy(from, to string) error {
 	}
 
 	// Ensure that our writes get committed to disk, even on slower systems.
-	err = dst.Sync()
-	return err
+	return dst.Sync()
 }
 
 func getCert(t *testing.T) *x509.Certificate {


### PR DESCRIPTION
This PR adds a `(*File).Sync` to the `copy()` function in the test. This *should* eliminate slow disk writes as a potential failure cause for the certificate rotation test.

The certificate rotation test has been one of the two flakiest tests in the test suite for a good while now, so if this fixes the issue, we'll have ~40-50% fewer spurious test failures in CI.
