### PR TITLE
cmd/bench: Fix port collision in utility function.

### DIFF
--- a/cmd/bench.go
+++ b/cmd/bench.go
@@ -343,7 +343,7 @@ func benchE2E(ctx context.Context, args []string, params benchmarkCommandParams,
 		break
 	}
 	// Check for port still being unbound after retry loop.
-	if len(rt.Addrs()) == 0 {
+	if port == 0 {
 		return fmt.Errorf("unable to bind a port for bench testing")
 	}
 

--- a/cmd/bench.go
+++ b/cmd/bench.go
@@ -328,7 +328,7 @@ func benchE2E(ctx context.Context, args []string, params benchmarkCommandParams,
 	// typically comes online very quickly.
 	baseDelay := time.Duration(100) * time.Millisecond
 	maxDelay := time.Duration(60) * time.Second
-	retries := 8 // Max of around 1 minute total wait time.
+	retries := 3 // Max of around 1 minute total wait time.
 	for i := 0; i < retries; i++ {
 		if len(rt.Addrs()) == 0 {
 			delay := util.DefaultBackoff(float64(baseDelay), float64(maxDelay), i)

--- a/cmd/bench.go
+++ b/cmd/bench.go
@@ -326,7 +326,7 @@ func benchE2E(ctx context.Context, args []string, params benchmarkCommandParams,
 	// Busy loop until server has truly come online to recover the bound port.
 	// We do this with exponential backoff for wait times, since the server
 	// typically comes online very quickly.
-	baseDelay := time.Duration(10) * time.Microsecond
+	baseDelay := time.Duration(100) * time.Millisecond
 	maxDelay := time.Duration(60) * time.Second
 	retries := 8 // Max of around 1 minute total wait time.
 	for i := 0; i < retries; i++ {

--- a/cmd/bench.go
+++ b/cmd/bench.go
@@ -327,8 +327,8 @@ func benchE2E(ctx context.Context, args []string, params benchmarkCommandParams,
 	// We do this with exponential backoff for wait times, since the server
 	// typically comes online very quickly.
 	baseDelay := time.Duration(10) * time.Microsecond
-	maxDelay := time.Duration(10) * time.Second
-	retries := 7 // Max of around 10 seconds total wait time.
+	maxDelay := time.Duration(60) * time.Second
+	retries := 8 // Max of around 1 minute total wait time.
 	for i := 0; i < retries; i++ {
 		if len(rt.Addrs()) == 0 {
 			delay := util.DefaultBackoff(float64(baseDelay), float64(maxDelay), i)

--- a/cmd/bench.go
+++ b/cmd/bench.go
@@ -389,7 +389,7 @@ func benchE2E(ctx context.Context, args []string, params benchmarkCommandParams,
 		}
 	}
 
-	url := fmt.Sprintf("http://%s:%s/v1/%v", host, strconv.Itoa(port), path)
+	url := fmt.Sprintf("http://%s:%d/v1/%v", host, port, path)
 	if params.metrics {
 		url += "?metrics=true"
 	}


### PR DESCRIPTION
This PR fixes the dreaded `err="listen tcp 127.0.0.1:18181: bind: address already in use"` errors that have cropped up in the `cmd` tests from time to time. The underlying cause was a function named `benchE2E()` that created a runtime instance bound to port 18181, but had no logic to handle multiple test goroutines trying to bind that address at the same time.

This commit fixes the port collision issue by having the `benchE2E()` function attempt to naively bind a port in a loop, starting at 18181, and incrementing the port number on each " bind: address already in use" failure, until it eventually finds an open port. 

This is an admittedly ugly solution, but it should result in correct behavior: no more "bind: address already in use" errors! :sweat_smile: 