### PR TITLE
cmd/build+compile: allow opt-out of dependents gathering

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -27,6 +27,7 @@ type buildParams struct {
 	capabilities       *capabilitiesFlag
 	target             *util.EnumFlag
 	bundleMode         bool
+	pruneUnused        bool
 	optimizationLevel  int
 	entrypoints        repeatedStringFlag
 	outputFile         string
@@ -113,6 +114,11 @@ The 'build' command supports targets (specified by -t):
     wasm    The wasm target emits a bundle containing a WebAssembly module compiled from
             the input files for each specified entrypoint. The bundle may contain the
             original policy or data files.
+
+    plan    The plan target emits a bundle containing a plan, i.e., an intermediate
+			representation compiled from the input files for each specified entrypoint.
+			This is for further processing, OPA cannot evaluate a "plan bundle" like it
+			can evaluate a wasm or rego bundle.
 
 The -e flag tells the 'build' command which documents will be queried by the software
 asking for policy decisions, so that it can focus optimization efforts and ensure
@@ -218,7 +224,8 @@ against OPA v0.22.0:
 	}
 
 	buildCommand.Flags().VarP(buildParams.target, "target", "t", "set the output bundle target type")
-	buildCommand.Flags().BoolVarP(&buildParams.debug, "debug", "", false, "enable debug output")
+	buildCommand.Flags().BoolVar(&buildParams.pruneUnused, "prune-unused", false, "exclude dependents of entrypoints")
+	buildCommand.Flags().BoolVar(&buildParams.debug, "debug", false, "enable debug output")
 	buildCommand.Flags().IntVarP(&buildParams.optimizationLevel, "optimize", "O", 0, "set optimization level")
 	buildCommand.Flags().VarP(&buildParams.entrypoints, "entrypoint", "e", "set slash separated entrypoint path")
 	buildCommand.Flags().VarP(&buildParams.revision, "revision", "r", "set output bundle revision")
@@ -273,6 +280,7 @@ func dobuild(params buildParams, args []string) error {
 		WithCapabilities(capabilities).
 		WithTarget(params.target.String()).
 		WithAsBundle(params.bundleMode).
+		WithPruneUnused(params.pruneUnused).
 		WithOptimizationLevel(params.optimizationLevel).
 		WithOutput(buf).
 		WithEntrypoints(params.entrypoints.v...).


### PR DESCRIPTION
With `.WithPruneUnused(true)`, the compiler (of the compile package) no longer
collects dependents of its entrypoints.

The resulting bundle, if used with the wasm target, will no longer be
semantically equivalent to the bundle built with the rego target.

Since we're unable to have entrypoints for functions, this allows building
modules that we couldn't build before.

Fixes #5035.