### PR TITLE
netlify: add debug output from 'ignore' script, simplify diff logic, include output

### DIFF
--- a/build/docs-build-needed.sh
+++ b/build/docs-build-needed.sh
@@ -1,16 +1,8 @@
 #!/bin/bash
 
-set -eo pipefail
-
-# Inspired by https://github.com/aptos-labs/aptos-core/pull/1324
-# Docs: https://docs.netlify.com/configure-builds/ignore-builds/
-if [ "$PULL_REQUEST" == "true" ]; then
-  BASE=main
-else
-  BASE=$CACHED_COMMIT_REF
-fi
+set -exo pipefail
 
 # NOTE(sr): we include version because that's what drives releases
 # Makefile and netlify.toml capture when the build infrastructure changes
 # ast/builtins.go and capabilities.json are driving the builtins_metadata.
-git diff --quiet $BASE $COMMIT_REF docs/ Makefile netlify.toml ast/builtins.go capabilities.json version/
+git diff --exit-code $CACHED_COMMIT_REF $COMMIT_REF docs/ Makefile build/ netlify.toml ast/builtins.go capabilities.json version/


### PR DESCRIPTION
`main` on netlify is a really old branch, and we have no way to update it.

So instead, we'll use what netlify intended: cached vs latest ref. Let's see
if we run into problems.

Concretely, it'll mean that if a PR updates parts of the website in one commit,
netlify will build the PR branch. If a subsequent commit to that PR branch does
not change anything in the website as it was in the previously built commit, no
build will happen. This could be confusing, it also makes sense: it was already
built, why build it again?

Also adds the build/ folder to the list of watched files: much of the docs
generation logic lives there.

---

ℹ️ Nothing should change for merged commits: they had been using this ref before, successfully. Only PR branch builds are different now: they should rebuild everything less often.