### PR TITLE
Fix inconsistent error messages in units.parse*

### DIFF
--- a/test/cases/testdata/units/test-parse-bytes-errors.yaml
+++ b/test/cases/testdata/units/test-parse-bytes-errors.yaml
@@ -9,7 +9,7 @@ cases:
   note: units_parse_bytes/failure
   query: data.test.p = x
   want_error_code: eval_builtin_error
-  want_error: "units.parse_bytes error: no byte amount provided"
+  want_error: "units.parse_bytes: no byte amount provided"
   strict_error: true
 - data:
   modules:
@@ -21,7 +21,7 @@ cases:
   note: units_parse_bytes/failure
   query: data.test.p = x
   want_error_code: eval_builtin_error
-  want_error: "units.parse_bytes error: no byte amount provided"
+  want_error: "units.parse_bytes: no byte amount provided"
   strict_error: true
 - data:
   modules:
@@ -33,7 +33,7 @@ cases:
   note: units_parse_bytes/failure
   query: data.test.p = x
   want_error_code: eval_builtin_error
-  want_error: "units.parse_bytes error: no byte amount provided"
+  want_error: "units.parse_bytes: no byte amount provided"
   strict_error: true
 - data:
   modules:
@@ -45,7 +45,7 @@ cases:
   note: units_parse_bytes/failure
   query: data.test.p = x
   want_error_code: eval_builtin_error
-  want_error: "units.parse_bytes error: could not parse byte amount to a number"
+  want_error: "units.parse_bytes: could not parse byte amount to a number"
   strict_error: true
 - data:
   modules:
@@ -57,7 +57,7 @@ cases:
   note: units_parse_bytes/failure
   query: data.test.p = x
   want_error_code: eval_builtin_error
-  want_error: "units.parse_bytes error: could not parse byte amount to a number"
+  want_error: "units.parse_bytes: could not parse byte amount to a number"
   strict_error: true
 - data:
   modules:
@@ -69,7 +69,7 @@ cases:
   note: units_parse_bytes/failure
   query: data.test.p = x
   want_error_code: eval_builtin_error
-  want_error: "units.parse_bytes error: spaces not allowed in resource strings"
+  want_error: "units.parse_bytes: spaces not allowed in resource strings"
   strict_error: true
 - data:
   modules:
@@ -81,5 +81,5 @@ cases:
   note: units_parse_bytes/failure
   query: data.test.p = x
   want_error_code: eval_builtin_error
-  want_error: "units.parse_bytes error: spaces not allowed in resource strings"
+  want_error: "units.parse_bytes: spaces not allowed in resource strings"
   strict_error: true

--- a/test/cases/testdata/units/test-parse-units-errors.yaml
+++ b/test/cases/testdata/units/test-parse-units-errors.yaml
@@ -9,7 +9,7 @@ cases:
   note: units_parse/failure
   query: data.test.p = x
   want_error_code: eval_builtin_error
-  want_error: "units.parse error: no amount provided"
+  want_error: "units.parse: no amount provided"
   strict_error: true
 - data:
   modules:
@@ -21,7 +21,7 @@ cases:
   note: units_parse/failure
   query: data.test.p = x
   want_error_code: eval_builtin_error
-  want_error: "units.parse error: no amount provided"
+  want_error: "units.parse: no amount provided"
   strict_error: true
 - data:
   modules:
@@ -33,7 +33,7 @@ cases:
   note: units_parse/failure
   query: data.test.p = x
   want_error_code: eval_builtin_error
-  want_error: "units.parse error: no amount provided"
+  want_error: "units.parse: no amount provided"
   strict_error: true
 - data:
   modules:
@@ -45,7 +45,7 @@ cases:
   note: units_parse/failure
   query: data.test.p = x
   want_error_code: eval_builtin_error
-  want_error: "units.parse error: could not parse amount to a number"
+  want_error: "units.parse: could not parse amount to a number"
   strict_error: true
 - data:
   modules:
@@ -57,7 +57,7 @@ cases:
   note: units_parse/failure
   query: data.test.p = x
   want_error_code: eval_builtin_error
-  want_error: "units.parse error: could not parse amount to a number"
+  want_error: "units.parse: could not parse amount to a number"
   strict_error: true
 - data:
   modules:
@@ -69,7 +69,7 @@ cases:
   note: units_parse/failure
   query: data.test.p = x
   want_error_code: eval_builtin_error
-  want_error: "units.parse error: spaces not allowed in resource strings"
+  want_error: "units.parse: spaces not allowed in resource strings"
   strict_error: true
 - data:
   modules:
@@ -81,5 +81,5 @@ cases:
   note: units_parse/failure
   query: data.test.p = x
   want_error_code: eval_builtin_error
-  want_error: "units.parse error: spaces not allowed in resource strings"
+  want_error: "units.parse: spaces not allowed in resource strings"
   strict_error: true

--- a/topdown/parse_bytes.go
+++ b/topdown/parse_bytes.go
@@ -32,7 +32,7 @@ const (
 )
 
 func parseNumBytesError(msg string) error {
-	return fmt.Errorf("%s error: %s", ast.UnitsParseBytes.Name, msg)
+	return fmt.Errorf("%s: %s", ast.UnitsParseBytes.Name, msg)
 }
 
 func errBytesUnitNotRecognized(unit string) error {

--- a/topdown/parse_units.go
+++ b/topdown/parse_units.go
@@ -26,7 +26,7 @@ const (
 )
 
 func parseUnitsError(msg string) error {
-	return fmt.Errorf("%s error: %s", ast.UnitsParse.Name, msg)
+	return fmt.Errorf("%s: %s", ast.UnitsParse.Name, msg)
 }
 
 func errUnitNotRecognized(unit string) error {


### PR DESCRIPTION
Adding `error: ` to each message is redundant, and breaks tooling
that expects a uniform format of `<builtin-name>: message` in error
messages from OPA (i.e. Jarl 😄).

Signed-off-by: Anders Eknert <anders@eknert.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->
