### PR TITLE
decision log format configurable. ingest directly to ELK

### DIFF
--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -833,6 +833,8 @@ included in the actual bundle gzipped tarball.
 | `decision_logs.mask_decision` | `string` | No (default: `system/log/mask`) | Set path of masking decision. |
 | `decision_logs.plugin` | `string` | No | Use the named plugin for decision logging. If this field exists, the other configuration fields are not required. |
 | `decision_logs.console` | `boolean` | No (default: `false`) | Log the decisions locally to the console. When enabled alongside a remote decision logging API the `service` must be configured, the default `service` selection will be disabled. |
+| `decision_logs.format` | `string` | No (default: `json`) | Format of the decision logs: `json`, `ndjson` or `elastic` |
+| `decision_logs.elastic_index` | `string` | Only for format=`elastic`) | Name of the index to add the logs to. |
 
 ### Discovery
 

--- a/docs/content/management-decision-logs.md
+++ b/docs/content/management-decision-logs.md
@@ -108,6 +108,18 @@ decision_logs:
 This will dump all decisions to the console. See
 [Configuration Reference](../configuration) for more details.
 
+### Logging to ELK
+
+To log directly to your ELK cluster use:
+```yaml
+decision_logs:
+    format: elastic
+    elastic_index: myindex_name
+    resource: my_index_name/_bulk
+```
+
+Authorization is configured in the referenced service's config. For basic auth add an `Authorization` header there.
+
 ### Masking Sensitive Data
 
 Policy queries may contain sensitive information in the `input` document that

--- a/plugins/logs/encoder.go
+++ b/plugins/logs/encoder.go
@@ -55,7 +55,7 @@ func newChunkEncoder(limit int64, format *string, elasticIndex *string) *chunkEn
 	var postfixFunction func() []byte
 
 	switch *format {
-	case formatJson:
+	case formatJSON:
 		prefixFunction = func(first bool, event EventV1) []byte {
 			if first {
 				return []byte("[")
@@ -72,9 +72,8 @@ func newChunkEncoder(limit int64, format *string, elasticIndex *string) *chunkEn
 		prefixFunction = func(first bool, event EventV1) []byte {
 			if first {
 				return []byte("")
-			} else {
-				return []byte("")
 			}
+			return []byte("")
 		}
 
 		postfixFunction = func() []byte {

--- a/plugins/logs/encoder.go
+++ b/plugins/logs/encoder.go
@@ -59,9 +59,8 @@ func newChunkEncoder(limit int64, format *string, elasticIndex *string) *chunkEn
 		prefixFunction = func(first bool, event EventV1) []byte {
 			if first {
 				return []byte("[")
-			} else {
-				return []byte(",")
 			}
+			return []byte(",")
 		}
 
 		postfixFunction = func() []byte {

--- a/plugins/logs/encoder_test.go
+++ b/plugins/logs/encoder_test.go
@@ -14,7 +14,9 @@ import (
 
 func TestChunkEncoder(t *testing.T) {
 
-	enc := newChunkEncoder(1000)
+	format := "json"
+
+	enc := newChunkEncoder(1000, &format, nil)
 	var result interface{} = false
 	var expInput interface{} = map[string]interface{}{"method": "GET"}
 	ts, err := time.Parse(time.RFC3339Nano, "2018-01-01T12:00:00.123456Z")
@@ -55,7 +57,8 @@ func TestChunkEncoder(t *testing.T) {
 
 func TestChunkEncoderAdaptive(t *testing.T) {
 
-	enc := newChunkEncoder(1000).WithMetrics(metrics.New())
+	format := "json"
+	enc := newChunkEncoder(1000, &format, nil).WithMetrics(metrics.New())
 	var result interface{} = false
 	var expInput interface{} = map[string]interface{}{"method": "GET"}
 	ts, err := time.Parse(time.RFC3339Nano, "2018-01-01T12:00:00.123456Z")

--- a/plugins/logs/plugin.go
+++ b/plugins/logs/plugin.go
@@ -228,7 +228,7 @@ const (
 	logDropCounterName          = "decision_logs_dropped"
 	defaultResourcePath         = "/logs"
 	defaultFormat               = "json"
-	formatJson                  = "json"
+	formatJSON                  = "json"
 	formatNdjson                = "ndjson"
 	formatElastic               = "elastic"
 )
@@ -367,8 +367,8 @@ func (c *Config) validateAndInjectDefaults(services []string, pluginsList []stri
 		c.Format = &format
 	}
 
-	if *c.Format != formatJson && *c.Format != formatNdjson && *c.Format != formatElastic {
-		return fmt.Errorf("invalid format in decision_logs: %s", c.Format)
+	if *c.Format != formatJSON && *c.Format != formatNdjson && *c.Format != formatElastic {
+		return fmt.Errorf("invalid format in decision_logs: %s", *c.Format)
 	}
 
 	if *c.Format == formatElastic && c.ElasticIndex == nil {


### PR DESCRIPTION
I've split #5043 up.

This gives 3 options for the decision log's format. 
* `json`  default like it used to be. array of json objects `[ ]`
* `ndjson` newline separated json objects `\n` after each object
* `elastic` like ndjson with a metadata json to write directly to an ELK cluster's bulk API
```json
{"index":{"_index":"opa_decisions_alias","_type":"_doc","_id":"abc6c2a7-f614-489f-9e4e-d934e3c802c5"}}
{"actual":"log entry"}
```

```yaml
decision_logs:
  service: decisionlogger
  format: elastic
  elastic_index: my_index
  resource: my_index/_bulk
```

I implemented that by replacing the hard-coded [ ] in logs.encoder with functions, that are set according to the configuration when creating a new instance.

prefix function is called before each log entry. For json returns , or [ , if it is the first entry in the buffer.
Nothing or newline for ndjson.
Bulk-API statement with the decision_id as key (and newline) for format elastic.

postfix function is called before sending the buffer to the log-system. (] for format json, newline for ndjson and elastic).

I think the reset mechanism for the buffer works, because the Bulk-API-lines are ignored during deserialization, but I lack the Go-skills to judge that.