### PR TITLE
ast/compile: sort modules by file name in NewModuleTree

### DIFF
--- a/ast/compile.go
+++ b/ast/compile.go
@@ -2763,7 +2763,13 @@ func NewModuleTree(mods map[string]*Module) *ModuleTreeNode {
 	root := &ModuleTreeNode{
 		Children: map[Value]*ModuleTreeNode{},
 	}
-	for _, m := range mods {
+	names := make([]string, 0, len(mods))
+	for name := range mods {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		m := mods[name]
 		node := root
 		for i, x := range m.Package.Path {
 			c, ok := node.Children[x.Value]


### PR DESCRIPTION
Previously, running

    go test ./ast -run TestModuleTreeFilenameOrder -count=100

would yield some failing runs, since the map iteration order is non-
deterministic.

Alternatively, we could have used c.sorted, but then we'd have had to make
NewModuleTree a method on the Compiler struct, kept the old version around
for API backward compatibility, etc. This seemed like an OK compromise.

Fixes #5056.
