### PR TITLE
ci: re-enable wasm lib tests

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -177,8 +177,6 @@ jobs:
         run: make ci-wasm
         timeout-minutes: 15
         if: steps.changed-files.outputs.any_changed == 'true'
-        env:
-          DOCKER_RUNNING: 0
 
       - name: Build and Test Wasm SDK
         run: make ci-go-wasm-sdk-e2e-test

--- a/wasm/Makefile
+++ b/wasm/Makefile
@@ -1,8 +1,6 @@
 DOCKER := docker
-
-DEBUG ?= 0
-
 DOCKER_FLAGS := --rm -e DEBUG
+DEBUG ?= 0
 
 ifeq ($(shell tty > /dev/null && echo 1 || echo 0), 1)
 DOCKER_FLAGS += -it


### PR DESCRIPTION
It had slipped my mind that those need docker, too. Previously, I've disabled
docker for those tests to avoid having them rebuild their wasm artifacts.
