### PR TITLE
bundle: Remove raw bytes check for lazy bundle loading mode

### DIFF
--- a/bundle/store.go
+++ b/bundle/store.go
@@ -390,10 +390,6 @@ func activateBundles(opts *ActivateOpts) error {
 
 		if b.lazyLoadingMode {
 
-			if len(b.Raw) == 0 {
-				return fmt.Errorf("raw bundle bytes not set on bundle object")
-			}
-
 			for _, item := range b.Raw {
 				path := filepath.ToSlash(item.Path)
 


### PR DESCRIPTION
The raw bytes on the bundle object are only set if the bundle
contains any policy or data. So while activating a bundle w/o
policy or data in lazy mode we check if the raw bytes are set
and generate an error if not. This check would prevent valid
bundles from being activated if they contained no policy/data.

Signed-off-by: Ashutosh Narkar <anarkar4387@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->
