### PR TITLE
cicd: dump response on http.send failure

### DIFF
--- a/build/policy/files_test.rego
+++ b/build/policy/files_test.rego
@@ -143,7 +143,7 @@ test_allow_listed_software {
 }
 
 test_deny_invalid_yaml_file {
-	expected := "invalid.yaml is an invalid YAML file"
+	expected := "invalid.yaml is an invalid YAML file: {null{}}"
 	deny[expected] with data.files.yaml_file_contents as {"invalid.yaml": "{null{}}"}
 		with data.files.changes as {"invalid.yaml": {"status": "modified"}}
 }
@@ -154,7 +154,7 @@ test_allow_valid_yaml_file {
 }
 
 test_deny_invalid_json_file {
-	expected := "invalid.json is an invalid JSON file"
+	expected := "invalid.json is an invalid JSON file: }}}"
 	deny[expected] with data.files.json_file_contents as {"invalid.json": "}}}"}
 		with data.files.changes as {"invalid.json": {"status": "modified"}}
 }


### PR DESCRIPTION
Something to hopefully help understand what goes wrong in https://github.com/open-policy-agent/opa/pull/5069

Signed-off-by: Anders Eknert <anders@eknert.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->
