### PR TITLE
topdown/eval: Fix key construction for NDBCache.

### DIFF
--- a/rego/rego.go
+++ b/rego/rego.go
@@ -320,7 +320,6 @@ func (pq preparedQuery) newEvalContext(ctx context.Context, options []EvalOption
 		compiledQuery:    compiledQuery{},
 		indexing:         true,
 		earlyExit:        true,
-		ndBuiltinCache:   builtins.NDBCache{},
 		resolvers:        pq.r.resolvers,
 		printHook:        pq.r.printHook,
 		capabilities:     pq.r.capabilities,
@@ -1112,7 +1111,6 @@ func New(options ...func(r *Rego)) *Rego {
 		builtinDecls:    map[string]*ast.Builtin{},
 		builtinFuncs:    map[string]*topdown.Builtin{},
 		bundles:         map[string]*bundle.Bundle{},
-		ndBuiltinCache:  builtins.NDBCache{},
 	}
 
 	for _, option := range options {

--- a/topdown/eval.go
+++ b/topdown/eval.go
@@ -1707,7 +1707,7 @@ func (e evalBuiltin) eval(iter unifyIterator) error {
 		e.e.instr.stopTimer(evalOpBuiltinCall)
 
 		// Unify against the NDBCache result if present.
-		if v, ok := e.bctx.NDBuiltinCache.Get(e.bi.Name, ast.NewArray(e.terms[:endIndex]...)); ok {
+		if v, ok := e.bctx.NDBuiltinCache.Get(e.bi.Name, ast.NewArray(operands[:endIndex]...)); ok {
 			switch {
 			case e.bi.Decl.Result() == nil:
 				err = iter()
@@ -1753,7 +1753,7 @@ func (e evalBuiltin) eval(iter unifyIterator) error {
 		// call was not cached earlier.
 		if e.canUseNDBCache(e.bi) {
 			// Populate the NDBCache from the output term.
-			e.bctx.NDBuiltinCache.Put(e.bi.Name, ast.NewArray(e.terms[:endIndex]...), output.Value)
+			e.bctx.NDBuiltinCache.Put(e.bi.Name, ast.NewArray(operands[:endIndex]...), output.Value)
 		}
 
 		if err != nil {


### PR DESCRIPTION
This commit fixes the construction process for keys used to look up
entries in the non-deterministic builtins cache. The original cache
lookup process could use refs that were not fully-grounded, and this
meant that calling a builtin twice with differing parameters could
appear identical to the cache if they involved refs as parameters.

We now use fully-grounded terms for the cache keys during insertion/lookup,
meaning that non-deterministic builtin calls with different parameters
are now guaranteed to result in unique cache entries, even if hidden
behind a ref.

This commit also fixes a bug that prevented the NDBCache from being opt-in.