### PR TITLE
ast: skip rules when parsing a body (or query)

### DIFF
--- a/ast/parser.go
+++ b/ast/parser.go
@@ -99,6 +99,7 @@ type ParserOptions struct {
 	ProcessAnnotation  bool
 	AllFutureKeywords  bool
 	FutureKeywords     []string
+	SkipRules          bool
 	unreleasedKeywords bool // TODO(sr): cleanup
 }
 
@@ -135,12 +136,12 @@ func (p *Parser) WithProcessAnnotation(processAnnotation bool) *Parser {
 // WithFutureKeywords enables "future" keywords, i.e., keywords that can
 // be imported via
 //
-//     import future.keywords.kw
-//     import future.keywords.other
+//	import future.keywords.kw
+//	import future.keywords.other
 //
 // but in a more direct way. The equivalent of this import would be
 //
-//     WithFutureKeywords("kw", "other")
+//	WithFutureKeywords("kw", "other")
 func (p *Parser) WithFutureKeywords(kws ...string) *Parser {
 	p.po.FutureKeywords = kws
 	return p
@@ -149,7 +150,7 @@ func (p *Parser) WithFutureKeywords(kws ...string) *Parser {
 // WithAllFutureKeywords enables all "future" keywords, i.e., the
 // ParserOption equivalent of
 //
-//     import future.keywords
+//	import future.keywords
 func (p *Parser) WithAllFutureKeywords(yes bool) *Parser {
 	p.po.AllFutureKeywords = yes
 	return p
@@ -166,6 +167,12 @@ func (p *Parser) withUnreleasedKeywords(yes bool) *Parser {
 // WithCapabilities sets the capabilities structure on the parser.
 func (p *Parser) WithCapabilities(c *Capabilities) *Parser {
 	p.po.Capabilities = c
+	return p
+}
+
+// WithSkipRules instructs the parser not to attempt to parse Rule statements.
+func (p *Parser) WithSkipRules(skip bool) *Parser {
+	p.po.SkipRules = skip
 	return p
 }
 
@@ -212,7 +219,7 @@ func (p *Parser) futureParser() *Parser {
 // cache, and a scanner that knows none of the future keywords.
 // It is used to successfully parse keyword imports, like
 //
-//  import future.keywords.in
+//	import future.keywords.in
 //
 // even when the parser has already been informed about the
 // future keyword "in". This parser won't error out because
@@ -321,18 +328,21 @@ func (p *Parser) Parse() ([]Statement, []*Comment, Errors) {
 		}
 
 		p.restore(s)
-		s = p.save()
 
-		if rules := p.parseRules(); rules != nil {
-			for i := range rules {
-				stmts = append(stmts, rules[i])
+		if !p.po.SkipRules {
+			s = p.save()
+
+			if rules := p.parseRules(); rules != nil {
+				for i := range rules {
+					stmts = append(stmts, rules[i])
+				}
+				continue
+			} else if len(p.s.errors) > 0 {
+				break
 			}
-			continue
-		} else if len(p.s.errors) > 0 {
-			break
-		}
 
-		p.restore(s)
+			p.restore(s)
+		}
 
 		if body := p.parseQuery(true, tokens.EOF); body != nil {
 			stmts = append(stmts, body)

--- a/ast/parser_ext.go
+++ b/ast/parser_ext.go
@@ -435,6 +435,9 @@ func ParseBody(input string) (Body, error) {
 }
 
 func ParseBodyWithOpts(input string, popts ParserOptions) (Body, error) {
+	// We want to parse a body, so we skip all else
+	popts.SkipRules = true
+
 	stmts, _, err := ParseStatementsWithOpts("", input, popts)
 	if err != nil {
 		return nil, err
@@ -563,6 +566,7 @@ func ParseStatementsWithOpts(filename, input string, popts ParserOptions) ([]Sta
 		WithFutureKeywords(popts.FutureKeywords...).
 		WithAllFutureKeywords(popts.AllFutureKeywords).
 		WithCapabilities(popts.Capabilities).
+		WithSkipRules(popts.SkipRules).
 		withUnreleasedKeywords(popts.unreleasedKeywords)
 
 	stmts, comments, errs := parser.Parse()
@@ -582,14 +586,14 @@ func parseModule(filename string, stmts []Statement, comments []*Comment) (*Modu
 
 	var errs Errors
 
-	_package, ok := stmts[0].(*Package)
+	pkg, ok := stmts[0].(*Package)
 	if !ok {
 		loc := stmts[0].Loc()
 		errs = append(errs, NewError(ParseErr, loc, "package expected"))
 	}
 
 	mod := &Module{
-		Package: _package,
+		Package: pkg,
 		stmts:   stmts,
 	}
 

--- a/ast/parser_ext.go
+++ b/ast/parser_ext.go
@@ -431,12 +431,12 @@ func ParseModuleWithOpts(filename, input string, popts ParserOptions) (*Module, 
 // ParseBody returns exactly one body.
 // If multiple bodies are parsed, an error is returned.
 func ParseBody(input string) (Body, error) {
-	return ParseBodyWithOpts(input, ParserOptions{})
+	return ParseBodyWithOpts(input, ParserOptions{SkipRules: true})
 }
 
+// ParseBodyWithOpts returns exactly one body. It does _not_ set SkipRules: true on its own,
+// but respects whatever ParserOptions it's been given.
 func ParseBodyWithOpts(input string, popts ParserOptions) (Body, error) {
-	// We want to parse a body, so we skip all else
-	popts.SkipRules = true
 
 	stmts, _, err := ParseStatementsWithOpts("", input, popts)
 	if err != nil {

--- a/ast/parser_test.go
+++ b/ast/parser_test.go
@@ -1032,27 +1032,67 @@ z = [ i | [x,y] = arr  # comment in comprehension
 			exp: MustParseBody(`x = 1; y = 2; z = [i | [x,y] = arr; arr[_] = i]`),
 		},
 		{
-			note:  "whitespace following call",
-			input: "f(x)\t\n [1]",
+			note:  "array following call w/ whitespace",
+			input: "f(x)\n [1]",
 			exp: NewBody(
 				NewExpr([]*Term{RefTerm(VarTerm("f")), VarTerm("x")}),
 				NewExpr(ArrayTerm(IntNumberTerm(1))),
 			),
 		},
 		{
-			note:  "whitespace following array",
-			input: "[1]\t\n [2]",
+			note:  "set following call w/ semicolon",
+			input: "f(x);{1}",
+			exp: NewBody(
+				NewExpr([]*Term{RefTerm(VarTerm("f")), VarTerm("x")}),
+				NewExpr(SetTerm(IntNumberTerm(1))),
+			),
+		},
+		{
+			note:  "array following array w/ whitespace",
+			input: "[1]\n [2]",
 			exp: NewBody(
 				NewExpr(ArrayTerm(IntNumberTerm(1))),
 				NewExpr(ArrayTerm(IntNumberTerm(2))),
 			),
 		},
 		{
-			note:  "whitespace following set",
-			input: "{1}\t\n [2]",
+			note:  "array following set w/ whitespace",
+			input: "{1}\n [2]",
 			exp: NewBody(
 				NewExpr(SetTerm(IntNumberTerm(1))),
 				NewExpr(ArrayTerm(IntNumberTerm(2))),
+			),
+		},
+		{
+			note:  "set following call w/ whitespace",
+			input: "f(x)\n {1}",
+			exp: NewBody(
+				NewExpr([]*Term{RefTerm(VarTerm("f")), VarTerm("x")}),
+				NewExpr(SetTerm(IntNumberTerm(1))),
+			),
+		},
+		{
+			note:  "set following ref w/ whitespace",
+			input: "data.p.q\n {1}",
+			exp: NewBody(
+				NewExpr(&Term{Value: MustParseRef("data.p.q")}),
+				NewExpr(SetTerm(IntNumberTerm(1))),
+			),
+		},
+		{
+			note:  "set following variable w/ whitespace",
+			input: "input\n {1}",
+			exp: NewBody(
+				NewExpr(&Term{Value: MustParseRef("input")}),
+				NewExpr(SetTerm(IntNumberTerm(1))),
+			),
+		},
+		{
+			note:  "set following equality w/ whitespace",
+			input: "input = 2 \n {1}",
+			exp: NewBody(
+				Equality.Expr(&Term{Value: MustParseRef("input")}, IntNumberTerm(2)),
+				NewExpr(SetTerm(IntNumberTerm(1))),
 			),
 		},
 	}

--- a/ast/policy.go
+++ b/ast/policy.go
@@ -948,6 +948,11 @@ func (body Body) Vars(params VarVisitorParams) VarSet {
 
 // NewExpr returns a new Expr object.
 func NewExpr(terms interface{}) *Expr {
+	switch terms.(type) {
+	case *SomeDecl, *Every, *Term, []*Term: // ok
+	default:
+		panic("unreachable")
+	}
 	return &Expr{
 		Negated: false,
 		Terms:   terms,

--- a/rego/rego.go
+++ b/rego/rego.go
@@ -1793,6 +1793,7 @@ func (r *Rego) parseQuery(futureImports []*ast.Import, m metrics.Metrics) (ast.B
 	if err != nil {
 		return nil, err
 	}
+	popts.SkipRules = true
 	return ast.ParseBodyWithOpts(r.query, popts)
 }
 


### PR DESCRIPTION
It's used from ParseBody() (and some of its sibling functions with opts) to
instruct the parser to NOT attempt to parse the token stream as ast.Rule.

Using this, we gain more leeway in dealing with tricky ambiguous cases.
Previously, the queries

    set(); {1}

and

    set()
    {1}

haven't been equivalent, because the latter ended up being parsed as a rule.
Now, we can follow the caller intent: if that input string was parsed with
ParseBody(), we'll return the two expressions, same as is the case when parsing
with the (disambiguating) semicolon. If we have not been given ParserOptions
with SkipRules: true -- i.e., the default behaviour -- then it will be just
like before.

Also adds a panic to NewExpr to ensure we never construct anything unexpected
using it.