### PR TITLE
Prepare v0.44.0 release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -487,14 +487,14 @@ endif
 		-e GITHUB_TOKEN=$(GITHUB_TOKEN) \
 		-e LAST_VERSION=$(LAST_VERSION) \
 		-v $(PWD):/_src \
-		cmd.cat/make/git/go/python2/perl \
+		cmd.cat/make/git/go/python3/perl \
 		/_src/build/gen-release-patch.sh --version=$(VERSION) --source-url=/_src
 
 .PHONY: dev-patch
 dev-patch:
 	@$(DOCKER) run $(DOCKER_FLAGS) \
 		-v $(PWD):/_src \
-		cmd.cat/make/git/go/python2/perl \
+		cmd.cat/make/git/go/python3/perl \
 		/_src/build/gen-dev-patch.sh --version=$(VERSION) --source-url=/_src
 
 # Deprecated targets. To be removed.

--- a/build/changelog.py
+++ b/build/changelog.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 """
 changelog.py helps generate the CHANGELOG.md message for a particular release.
 """
@@ -8,7 +8,7 @@ import os
 import subprocess
 import shlex
 import re
-import urllib2
+import urllib.request, urllib.error, urllib.parse
 import sys
 import json
 
@@ -31,17 +31,17 @@ def get_commit_message(commit_id):
 
 
 def fetch(url, token):
-    req = urllib2.Request(url)
+    req = urllib.request.Request(url)
     if token:
         req.add_header('Authorization', "token {}".format(token))
     try:
-        rsp = urllib2.urlopen(req)
+        rsp = urllib.request.urlopen(req)
         result = json.loads(rsp.read())
     except Exception as e:
         if hasattr(e, 'reason'):
-            print >> sys.stderr, 'Failed to fetch URL {}: {}'.format(url, e.reason)
+            print('Failed to fetch URL {}: {}'.format(url, e.reason), file=sys.stderr)
         elif hasattr(e, 'code'):
-            print >> sys.stderr, 'Failed to fetch URL {}: Code {}'.format(url, e.code)
+            print('Failed to fetch URL {}: Code {}'.format(url, e.code), file=sys.stderr)
         return {}
     else:
         return result

--- a/builtin_metadata.json
+++ b/builtin_metadata.json
@@ -300,6 +300,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns the number without its sign.",
@@ -383,6 +384,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "deprecated": true,
@@ -469,6 +471,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns the intersection of two sets.",
@@ -553,6 +556,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "deprecated": true,
@@ -639,6 +643,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Concatenates two arrays.",
@@ -674,6 +679,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns the reverse of a given array.",
@@ -769,6 +775,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns a slice of a given array. If `start` is greater or equal than `stop`, `slice` is `[]`.",
@@ -855,6 +862,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "infix": ":=",
@@ -937,6 +945,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Deserializes the base64 encoded input string.",
@@ -1021,6 +1030,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Serializes the input string into base64 encoding.",
@@ -1084,6 +1094,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Verifies the input string is base64 encoded.",
@@ -1168,6 +1179,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Deserializes the base64url encoded input string.",
@@ -1252,6 +1264,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Serializes the input string into base64url encoding.",
@@ -1313,6 +1326,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Serializes the input string into base64url encoding without padding.",
@@ -1397,6 +1411,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns the bitwise \"AND\" of two integers.",
@@ -1480,6 +1495,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns a new integer with its bits shifted `s` bits to the left.",
@@ -1559,6 +1575,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns the bitwise negation (flip) of an integer.",
@@ -1642,6 +1659,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns the bitwise \"OR\" of two integers.",
@@ -1725,6 +1743,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns a new integer with its bits shifted `s` bits to the right.",
@@ -1808,6 +1827,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns the bitwise \"XOR\" (exclusive-or) of two integers.",
@@ -1890,6 +1910,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "deprecated": true,
@@ -1971,6 +1992,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "deprecated": true,
@@ -2052,6 +2074,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "deprecated": true,
@@ -2133,6 +2156,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "deprecated": true,
@@ -2214,6 +2238,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "deprecated": true,
@@ -2295,6 +2320,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "deprecated": true,
@@ -2349,6 +2375,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Rounds the number _up_ to the nearest integer.",
@@ -2438,6 +2465,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Joins a set or array of strings with a delimiter.",
@@ -2527,6 +2555,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns `true` if the search string is included in the base string",
@@ -2612,6 +2641,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": " Count takes a collection or string and returns the number of elements (or characters) in it.",
@@ -2652,6 +2682,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns a string representing the MD5 HMAC of the input message using the input key.",
@@ -2692,6 +2723,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns a string representing the SHA1 HMAC of the input message using the input key.",
@@ -2732,6 +2764,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns a string representing the SHA256 HMAC of the input message using the input key.",
@@ -2772,6 +2805,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns a string representing the SHA512 HMAC of the input message using the input key.",
@@ -2856,6 +2890,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns a string representing the input string hashed with the MD5 function",
@@ -2940,6 +2975,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns a string representing the input string hashed with the SHA1 function",
@@ -3024,6 +3060,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns a string representing the input string hashed with the SHA256 function",
@@ -3068,6 +3105,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns one or more certificates from the given string containing PEM\nor base64 encoded DER certificates after verifying the supplied certificates form a complete\ncertificate chain back to a trusted root.\n\nThe first certificate is treated as the root and the last is treated as the leaf,\nwith all others being treated as intermediates.",
@@ -3138,6 +3176,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns a PKCS #10 certificate signing request from the given PEM-encoded PKCS#10 certificate signing request.",
@@ -3223,6 +3262,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns one or more certificates from the given base64 encoded string containing DER encoded certificates that have been concatenated.",
@@ -3264,6 +3304,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns a JWK for signing a JWT from the given PEM-encoded RSA private key.",
@@ -3354,6 +3395,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Divides the first number by the second number.",
@@ -3445,6 +3487,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns true if the search string ends with the base string.",
@@ -3531,6 +3574,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "infix": "=",
@@ -3617,6 +3661,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "infix": "==",
@@ -3673,6 +3718,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Rounds the number _down_ to the nearest integer.",
@@ -3763,6 +3809,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns the string representation of the number in the given base after rounding it down to an integer value.",
@@ -3856,6 +3903,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Parses and matches strings against the glob notation. Not to be confused with `regex.globs_match`.",
@@ -3940,6 +3988,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns a string which represents a version of the pattern where all asterisks have been escaped.",
@@ -4021,6 +4070,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Computes the set of reachable nodes in the graph from a set of starting nodes.",
@@ -4059,6 +4109,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Computes the set of reachable paths in the graph from a set of starting nodes.",
@@ -4088,6 +4139,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Checks that a GraphQL query is valid against a given schema.",
@@ -4117,6 +4169,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns AST objects for a given GraphQL query and schema after validating the query against the schema. Returns undefined if errors were encountered during parsing or validation.",
@@ -4146,6 +4199,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns a boolean indicating success or failure alongside the parsed ASTs for a given GraphQL query and schema after validating the query against the schema.",
@@ -4171,6 +4225,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns an AST object for a GraphQL query.",
@@ -4196,6 +4251,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns an AST object for a GraphQL schema.",
@@ -4284,6 +4340,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "infix": "\u003e",
@@ -4372,6 +4429,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "infix": "\u003e=",
@@ -4434,6 +4492,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Deserializes the hex-encoded input string.",
@@ -4495,6 +4554,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Serializes the input string using hex-encoding.",
@@ -4579,6 +4639,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns a HTTP response to the given HTTP request.",
@@ -4668,6 +4729,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns the index of a substring contained inside a string.",
@@ -4706,6 +4768,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns a list of all the indexes of a substring contained inside a string.",
@@ -4746,6 +4809,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "infix": "in",
@@ -4787,6 +4851,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "infix": "in",
@@ -4822,6 +4887,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "introduced": "v0.34.0",
@@ -4902,6 +4968,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns the intersection of the given input sets.",
@@ -4987,6 +5054,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Decodes a JSON Web Token and outputs it as an object.",
@@ -5077,6 +5145,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Verifies a JWT signature under parameterized constraints and decodes the claims if it is valid.\nSupports the following algorithms: HS256, HS384, HS512, RS256, RS384, RS512, ES256, ES384, ES512, PS256, PS384 and PS512.",
@@ -5172,6 +5241,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Encodes and optionally signs a JSON Web Token. Inputs are taken as objects, not encoded strings (see `io.jwt.encode_sign_raw`).",
@@ -5267,6 +5337,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Encodes and optionally signs a JSON Web Token.",
@@ -5357,6 +5428,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Verifies if a ES256 JWT signature is valid.",
@@ -5438,6 +5510,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Verifies if a ES384 JWT signature is valid.",
@@ -5519,6 +5592,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Verifies if a ES512 JWT signature is valid.",
@@ -5609,6 +5683,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Verifies if a HS256 (secret) JWT signature is valid.",
@@ -5690,6 +5765,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Verifies if a HS384 (secret) JWT signature is valid.",
@@ -5771,6 +5847,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Verifies if a HS512 (secret) JWT signature is valid.",
@@ -5861,6 +5938,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Verifies if a PS256 JWT signature is valid.",
@@ -5942,6 +6020,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Verifies if a PS384 JWT signature is valid.",
@@ -6023,6 +6102,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Verifies if a PS512 JWT signature is valid.",
@@ -6113,6 +6193,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Verifies if a RS256 JWT signature is valid.",
@@ -6194,6 +6275,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Verifies if a RS384 JWT signature is valid.",
@@ -6275,6 +6357,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Verifies if a RS512 JWT signature is valid.",
@@ -6359,6 +6442,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns `true` if the input value is an array.",
@@ -6443,6 +6527,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns `true` if the input value is a boolean.",
@@ -6527,6 +6612,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns `true` if the input value is null.",
@@ -6611,6 +6697,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns `true` if the input value is a number.",
@@ -6695,6 +6782,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns true if the input value is an object",
@@ -6779,6 +6867,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns `true` if the input value is a set.",
@@ -6863,6 +6952,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns `true` if the input value is a string.",
@@ -6952,6 +7042,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Filters the object. For example: `json.filter({\"a\": {\"b\": \"x\", \"c\": \"y\"}}, [\"a/b\"])` will result in `{\"a\": {\"b\": \"x\"}}`). Paths are not filtered in-order and are deduplicated before being evaluated.",
@@ -7015,6 +7106,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Verifies the input string is a valid JSON document.",
@@ -7100,6 +7192,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Serializes the input term to JSON.",
@@ -7162,6 +7255,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Patches an object according to RFC6902. For example: `json.patch({\"a\": {\"foo\": 1}}, [{\"op\": \"add\", \"path\": \"/a/bar\", \"value\": 2}])` results in `{\"a\": {\"foo\": 1, \"bar\": 2}`.  The patches are applied atomically: if any of them fails, the result will be undefined.",
@@ -7247,6 +7341,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Removes paths from an object. For example: `json.remove({\"a\": {\"b\": \"x\", \"c\": \"y\"}}, [\"a/b\"])` will result in `{\"a\": {\"c\": \"y\"}}`. Paths are not removed in-order and are deduplicated before being evaluated.",
@@ -7332,6 +7427,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Deserializes the input string.",
@@ -7417,6 +7513,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns the input string but with all characters in lower-case.",
@@ -7505,6 +7602,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "infix": "\u003c",
@@ -7593,6 +7691,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "infix": "\u003c=",
@@ -7677,6 +7776,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns the maximum value in a collection.",
@@ -7761,6 +7861,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns the minimum value in a collection.",
@@ -7849,6 +7950,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Minus subtracts the second number from the first number or computes the difference between two sets.",
@@ -7938,6 +8040,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Multiplies two numbers.",
@@ -8027,6 +8130,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "infix": "!=",
@@ -8115,6 +8219,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Checks if a CIDR or IP is contained within another CIDR. `output` is `true` if `cidr_or_ip` (e.g. `127.0.0.64/26` or `127.0.0.1`) is contained within `cidr` (e.g. `127.0.0.1/24`) and `false` otherwise. Supports both IPv4 and IPv6 notations.",
@@ -8197,6 +8302,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Checks if collections of cidrs or ips are contained within another collection of cidrs and returns matches. This function is similar to `net.cidr_contains` except it allows callers to pass collections of CIDRs or IPs as arguments and returns the matches (as opposed to a boolean result indicating a match between two CIDRs/IPs).",
@@ -8281,6 +8387,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Expands CIDR to set of hosts  (e.g., `net.cidr_expand(\"192.168.0.0/30\")` generates 4 hosts: `{\"192.168.0.0\", \"192.168.0.1\", \"192.168.0.2\", \"192.168.0.3\"}`).",
@@ -8369,6 +8476,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Checks if a CIDR intersects with another CIDR (e.g. `192.168.0.0/16` overlaps with `192.168.1.0/24`). Supports both IPv4 and IPv6 notations.",
@@ -8432,6 +8540,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Merges IP addresses and subnets into the smallest possible list of CIDRs (e.g., `net.cidr_merge([\"192.0.128.0/24\", \"192.0.129.0/24\"])` generates `{\"192.0.128.0/23\"}`.This function merges adjacent subnets where possible, those contained within others and also removes any duplicates.\nSupports both IPv4 and IPv6 notations. IPv6 inputs need a prefix length (e.g. \"/128\").",
@@ -8518,6 +8627,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "deprecated": true,
@@ -8552,6 +8662,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns the set of IP addresses (both v4 and v6) that the passed-in `name` resolves to using the standard name resolution mechanisms available.",
@@ -8623,6 +8734,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns an array of numbers in the given (inclusive) range. If `a==b`, then `range == [a]`; if `a \u003e b`, then `range` is in descending order.",
@@ -8710,6 +8822,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Filters the object by keeping only specified keys. For example: `object.filter({\"a\": {\"b\": \"x\", \"c\": \"y\"}, \"d\": \"z\"}, [\"a\"])` will result in `{\"a\": {\"b\": \"x\", \"c\": \"y\"}}`).",
@@ -8805,6 +8918,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns value of an object's key if present, otherwise a default. If the supplied `key` is an `array`, then `object.get` will search through a nested object or array using each key in turn. For example: `object.get({\"a\": [{ \"b\": true }]}, [\"a\", 0, \"b\"], false)` results in `true`.",
@@ -8893,6 +9007,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Removes specified keys from an object.",
@@ -8923,6 +9038,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Determines if an object `sub` is a subset of another object `super`.Object `sub` is a subset of object `super` if and only if every key in `sub` is also in `super`, **and** for all keys which `sub` and `super` share, they have the same value. This function works with objects, sets, arrays and a set of array and set.If both arguments are objects, then the operation is recursive, e.g. `{\"c\": {\"x\": {10, 15, 20}}` is a subset of `{\"a\": \"b\", \"c\": {\"x\": {10, 15, 20, 25}, \"y\": \"z\"}`. If both arguments are sets, then this function checks if every element of `sub` is a member of `super`, but does not attempt to recurse. If both arguments are arrays, then this function checks if `sub` appears contiguously in order within `super`, and also does not attempt to recurse. If `super` is array and `sub` is set, then this function checks if `super` contains every element of `sub` with no consideration of ordering, and also does not attempt to recurse.",
@@ -9009,6 +9125,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Creates a new object of the asymmetric union of two objects. For example: `object.union({\"a\": 1, \"b\": 2, \"c\": {\"d\": 3}}, {\"a\": 7, \"c\": {\"d\": 4, \"e\": 5}})` will result in `{\"a\": 7, \"b\": 2, \"c\": {\"d\": 4, \"e\": 5}}`.",
@@ -9041,6 +9158,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Creates a new object that is the asymmetric union of all objects merged from left to right. For example: `object.union_n([{\"a\": 1}, {\"b\": 2}, {\"a\": 3}])` will result in `{\"b\": 2, \"a\": 3}`.",
@@ -9120,6 +9238,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns an object that describes the runtime environment where OPA is deployed.",
@@ -9208,6 +9327,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns the union of two sets.",
@@ -9297,6 +9417,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Plus adds two numbers together.",
@@ -9331,6 +9452,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "introduced": "v0.34.0",
@@ -9410,6 +9532,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Muliplies elements of an array or set of numbers",
@@ -9457,6 +9580,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns a random integer between `0` and `n` (`n` exlusive). If `n` is `0`, then `y` is always `0`. For any given argument pair (`str`, `n`), the output will be consistent throughout a query evaluation.",
@@ -9543,6 +9667,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "deprecated": true,
@@ -9636,6 +9761,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns all successive matches of the expression.",
@@ -9730,6 +9856,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns the specified number of matches when matching the input against the pattern.",
@@ -9818,6 +9945,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Checks if the intersection of two glob-style regular expressions matches a non-empty set of non-empty strings.\nThe set of regex symbols is limited for this builtin: only `.`, `*`, `+`, `[`, `-`, `]` and `\\` are treated as special symbols.",
@@ -9884,6 +10012,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Checks if a string is a valid regular expression: the detailed syntax for patterns is defined by https://github.com/google/re2/wiki/Syntax.",
@@ -9955,6 +10084,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Matches a string against a regular expression.",
@@ -10044,6 +10174,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Splits the input string by the occurrences of the given pattern.",
@@ -10144,6 +10275,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Matches a string against a pattern, where there pattern may be glob-like",
@@ -10164,6 +10296,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns the chain of metadata for the active rule.\nOrdered starting at the active rule, going outward to the most distant node in its package ancestry.\nA chain entry is a JSON document with two members: \"path\", an array representing the path of the node; and \"annotations\", a JSON document containing the annotations declared for the node.\nThe first entry in the chain always points to the active rule, even if it has no declared annotations (in which case the \"annotations\" member is not present).",
@@ -10185,6 +10318,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns annotations declared for the active rule and using the _rule_ scope.",
@@ -10275,6 +10409,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Parses the input Rego string and returns an object representation of the AST.",
@@ -10362,6 +10497,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns the remainder for of `x` divided by `y`, for `y != 0`.",
@@ -10458,6 +10594,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Replace replaces all instances of a sub-string.",
@@ -10543,6 +10680,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Rounds the number to the nearest integer.",
@@ -10614,6 +10752,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Compares valid SemVer formatted version strings.",
@@ -10681,6 +10820,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Validates that the input is a valid SemVer string.",
@@ -10767,6 +10907,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "deprecated": true,
@@ -10850,6 +10991,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns a sorted array.",
@@ -10940,6 +11082,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Split returns an array containing elements of the input string split on a delimiter.",
@@ -11030,6 +11173,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns the given string, formatted.",
@@ -11120,6 +11264,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns true if the search string begins with the base string.",
@@ -11145,10 +11290,11 @@
       }
     ],
     "available": [
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns true if any of the search strings begins with any of the base strings.",
-    "introduced": "edge",
+    "introduced": "v0.44.0",
     "result": {
       "description": "result of the prefix check",
       "name": "result",
@@ -11170,10 +11316,11 @@
       }
     ],
     "available": [
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns true if any of the search strings ends with any of the base strings.",
-    "introduced": "edge",
+    "introduced": "v0.44.0",
     "result": {
       "description": "result of the suffix check",
       "name": "result",
@@ -11260,6 +11407,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Replaces a string from a list of old, new string pairs.\nReplacements are performed in the order they appear in the target string, without overlapping matches.\nThe old string comparisons are done in argument order.",
@@ -11293,6 +11441,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Reverses a given string.",
@@ -11386,6 +11535,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns the  portion of a string for a given `offset` and a `length`.  If `length \u003c 0`, `output` is the remainder of the string.",
@@ -11470,6 +11620,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Sums elements of an array or set of numbers.",
@@ -11561,6 +11712,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns the nanoseconds since epoch after adding years, months and days to nanoseconds. `undefined` if the result would be outside the valid time range that can fit within an `int64`.",
@@ -11646,6 +11798,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns the `[hour, minute, second]` of the day for the nanoseconds since epoch.",
@@ -11731,6 +11884,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns the `[year, month, day]` for the nanoseconds since epoch.",
@@ -11787,6 +11941,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns the difference between two unix timestamps in nanoseconds (with optional timezone strings).",
@@ -11866,6 +12021,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns the current time since epoch in nanoseconds.",
@@ -11951,6 +12107,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns the duration in nanoseconds represented by a string.",
@@ -12041,6 +12198,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns the time in nanoseconds parsed from the string in the given format. `undefined` if the result would be outside the valid time range that can fit within an `int64`.",
@@ -12125,6 +12283,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns the time in nanoseconds parsed from the string in RFC3339 format. `undefined` if the result would be outside the valid time range that can fit within an `int64`.",
@@ -12210,6 +12369,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns the day of the week (Monday, Tuesday, ...) for the nanoseconds since epoch.",
@@ -12294,6 +12454,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Converts a string, bool, or number value to a number: Strings are converted to numbers using `strconv.Atoi`, Boolean `false` is converted to 0 and `true` is converted to 1.",
@@ -12378,6 +12539,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Emits `note` as a `Note` event in the query explanation. Query explanations show the exact expressions evaluated by OPA during policy execution. For example, `trace(\"Hello There!\")` includes `Note \"Hello There!\"` in the query explanation. To include variables in the message, use `sprintf`. For example, `person := \"Bob\"; trace(sprintf(\"Hello There! %v\", [person]))` will emit `Note \"Hello There! Bob\"` inside of the explanation.",
@@ -12468,6 +12630,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns `value` with all leading or trailing instances of the `cutset` characters removed.",
@@ -12558,6 +12721,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns `value` with all leading instances of the `cutset` chartacters removed.",
@@ -12648,6 +12812,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns `value` without the prefix. If `value` doesn't start with `prefix`, it is returned unchanged.",
@@ -12738,6 +12903,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns `value` with all trailing instances of the `cutset` chartacters removed.",
@@ -12823,6 +12989,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Return the given string with all leading and trailing white space removed.",
@@ -12913,6 +13080,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns `value` without the suffix. If `value` doesn't end with `suffix`, it is returned unchanged.",
@@ -12997,6 +13165,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns the type of its input value.",
@@ -13082,6 +13251,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns the union of the given input sets.",
@@ -13108,6 +13278,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Converts strings like \"10G\", \"5K\", \"4M\", \"1500m\" and the like into a number.\nThis number can be a non-integer, such as 1.5, 0.22, etc. Supports standard metric decimal and\nbinary SI units (e.g., K, Ki, M, Mi, G, Gi etc.) m, K, M, G, T, P, and E are treated as decimal\nunits and Ki, Mi, Gi, Ti, Pi, and Ei are treated as binary units.\n\nNote that 'm' and 'M' are case-sensitive, to allow distinguishing between \"milli\" and \"mega\" units respectively. Other units are case-insensitive.",
@@ -13193,6 +13364,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Converts strings like \"10GB\", \"5K\", \"4mb\" into an integer number of bytes.\nSupports standard byte units (e.g., KB, KiB, etc.) KB, MB, GB, and TB are treated as decimal\nunits and KiB, MiB, GiB, and TiB are treated as binary units. The bytes symbol (b/B) in the\nunit is optional and omitting it wil give the same result (e.g. Mi and MiB).",
@@ -13278,6 +13450,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns the input string but with all characters in upper-case.",
@@ -13362,6 +13535,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Decodes a URL-encoded input string.",
@@ -13426,6 +13600,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Decodes the given URL query string into an object.",
@@ -13510,6 +13685,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Encodes the input string into a URL-encoded string.",
@@ -13594,6 +13770,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Encodes the given object into a URL encoded query string.",
@@ -13669,6 +13846,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Returns a new UUIDv4.",
@@ -13753,6 +13931,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Generates `[path, value]` tuples for all nested documents of `x` (recursively).  Queries can use `walk` to traverse documents nested under `x`.",
@@ -13817,6 +13996,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Verifies the input string is a valid YAML document.",
@@ -13902,6 +14082,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Serializes the input term to YAML.",
@@ -13987,6 +14168,7 @@
       "v0.42.2",
       "v0.43.0",
       "v0.43.1",
+      "v0.44.0",
       "edge"
     ],
     "description": "Deserializes the input string.",

--- a/capabilities/v0.44.0.json
+++ b/capabilities/v0.44.0.json
@@ -1,0 +1,4190 @@
+{
+  "builtins": [
+    {
+      "name": "abs",
+      "decl": {
+        "args": [
+          {
+            "type": "number"
+          }
+        ],
+        "result": {
+          "type": "number"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "all",
+      "decl": {
+        "args": [
+          {
+            "of": [
+              {
+                "dynamic": {
+                  "type": "any"
+                },
+                "type": "array"
+              },
+              {
+                "of": {
+                  "type": "any"
+                },
+                "type": "set"
+              }
+            ],
+            "type": "any"
+          }
+        ],
+        "result": {
+          "type": "boolean"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "and",
+      "decl": {
+        "args": [
+          {
+            "of": {
+              "type": "any"
+            },
+            "type": "set"
+          },
+          {
+            "of": {
+              "type": "any"
+            },
+            "type": "set"
+          }
+        ],
+        "result": {
+          "of": {
+            "type": "any"
+          },
+          "type": "set"
+        },
+        "type": "function"
+      },
+      "infix": "\u0026"
+    },
+    {
+      "name": "any",
+      "decl": {
+        "args": [
+          {
+            "of": [
+              {
+                "dynamic": {
+                  "type": "any"
+                },
+                "type": "array"
+              },
+              {
+                "of": {
+                  "type": "any"
+                },
+                "type": "set"
+              }
+            ],
+            "type": "any"
+          }
+        ],
+        "result": {
+          "type": "boolean"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "array.concat",
+      "decl": {
+        "args": [
+          {
+            "dynamic": {
+              "type": "any"
+            },
+            "type": "array"
+          },
+          {
+            "dynamic": {
+              "type": "any"
+            },
+            "type": "array"
+          }
+        ],
+        "result": {
+          "dynamic": {
+            "type": "any"
+          },
+          "type": "array"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "array.reverse",
+      "decl": {
+        "args": [
+          {
+            "dynamic": {
+              "type": "any"
+            },
+            "type": "array"
+          }
+        ],
+        "result": {
+          "dynamic": {
+            "type": "any"
+          },
+          "type": "array"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "array.slice",
+      "decl": {
+        "args": [
+          {
+            "dynamic": {
+              "type": "any"
+            },
+            "type": "array"
+          },
+          {
+            "type": "number"
+          },
+          {
+            "type": "number"
+          }
+        ],
+        "result": {
+          "dynamic": {
+            "type": "any"
+          },
+          "type": "array"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "assign",
+      "decl": {
+        "args": [
+          {
+            "type": "any"
+          },
+          {
+            "type": "any"
+          }
+        ],
+        "result": {
+          "type": "boolean"
+        },
+        "type": "function"
+      },
+      "infix": ":="
+    },
+    {
+      "name": "base64.decode",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "string"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "base64.encode",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "string"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "base64.is_valid",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "boolean"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "base64url.decode",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "string"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "base64url.encode",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "string"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "base64url.encode_no_pad",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "string"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "bits.and",
+      "decl": {
+        "args": [
+          {
+            "type": "number"
+          },
+          {
+            "type": "number"
+          }
+        ],
+        "result": {
+          "type": "number"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "bits.lsh",
+      "decl": {
+        "args": [
+          {
+            "type": "number"
+          },
+          {
+            "type": "number"
+          }
+        ],
+        "result": {
+          "type": "number"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "bits.negate",
+      "decl": {
+        "args": [
+          {
+            "type": "number"
+          }
+        ],
+        "result": {
+          "type": "number"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "bits.or",
+      "decl": {
+        "args": [
+          {
+            "type": "number"
+          },
+          {
+            "type": "number"
+          }
+        ],
+        "result": {
+          "type": "number"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "bits.rsh",
+      "decl": {
+        "args": [
+          {
+            "type": "number"
+          },
+          {
+            "type": "number"
+          }
+        ],
+        "result": {
+          "type": "number"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "bits.xor",
+      "decl": {
+        "args": [
+          {
+            "type": "number"
+          },
+          {
+            "type": "number"
+          }
+        ],
+        "result": {
+          "type": "number"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "cast_array",
+      "decl": {
+        "args": [
+          {
+            "type": "any"
+          }
+        ],
+        "result": {
+          "dynamic": {
+            "type": "any"
+          },
+          "type": "array"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "cast_boolean",
+      "decl": {
+        "args": [
+          {
+            "type": "any"
+          }
+        ],
+        "result": {
+          "type": "boolean"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "cast_null",
+      "decl": {
+        "args": [
+          {
+            "type": "any"
+          }
+        ],
+        "result": {
+          "type": "null"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "cast_object",
+      "decl": {
+        "args": [
+          {
+            "type": "any"
+          }
+        ],
+        "result": {
+          "dynamic": {
+            "key": {
+              "type": "any"
+            },
+            "value": {
+              "type": "any"
+            }
+          },
+          "type": "object"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "cast_set",
+      "decl": {
+        "args": [
+          {
+            "type": "any"
+          }
+        ],
+        "result": {
+          "of": {
+            "type": "any"
+          },
+          "type": "set"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "cast_string",
+      "decl": {
+        "args": [
+          {
+            "type": "any"
+          }
+        ],
+        "result": {
+          "type": "string"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "ceil",
+      "decl": {
+        "args": [
+          {
+            "type": "number"
+          }
+        ],
+        "result": {
+          "type": "number"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "concat",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          },
+          {
+            "of": [
+              {
+                "dynamic": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "of": {
+                  "type": "string"
+                },
+                "type": "set"
+              }
+            ],
+            "type": "any"
+          }
+        ],
+        "result": {
+          "type": "string"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "contains",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "boolean"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "count",
+      "decl": {
+        "args": [
+          {
+            "of": [
+              {
+                "type": "string"
+              },
+              {
+                "dynamic": {
+                  "type": "any"
+                },
+                "type": "array"
+              },
+              {
+                "dynamic": {
+                  "key": {
+                    "type": "any"
+                  },
+                  "value": {
+                    "type": "any"
+                  }
+                },
+                "type": "object"
+              },
+              {
+                "of": {
+                  "type": "any"
+                },
+                "type": "set"
+              }
+            ],
+            "type": "any"
+          }
+        ],
+        "result": {
+          "type": "number"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "crypto.hmac.md5",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "string"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "crypto.hmac.sha1",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "string"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "crypto.hmac.sha256",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "string"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "crypto.hmac.sha512",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "string"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "crypto.md5",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "string"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "crypto.sha1",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "string"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "crypto.sha256",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "string"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "crypto.x509.parse_and_verify_certificates",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "static": [
+            {
+              "type": "boolean"
+            },
+            {
+              "dynamic": {
+                "dynamic": {
+                  "key": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "any"
+                  }
+                },
+                "type": "object"
+              },
+              "type": "array"
+            }
+          ],
+          "type": "array"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "crypto.x509.parse_certificate_request",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "dynamic": {
+            "key": {
+              "type": "string"
+            },
+            "value": {
+              "type": "any"
+            }
+          },
+          "type": "object"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "crypto.x509.parse_certificates",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "dynamic": {
+            "dynamic": {
+              "key": {
+                "type": "string"
+              },
+              "value": {
+                "type": "any"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "crypto.x509.parse_rsa_private_key",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "dynamic": {
+            "key": {
+              "type": "string"
+            },
+            "value": {
+              "type": "any"
+            }
+          },
+          "type": "object"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "div",
+      "decl": {
+        "args": [
+          {
+            "type": "number"
+          },
+          {
+            "type": "number"
+          }
+        ],
+        "result": {
+          "type": "number"
+        },
+        "type": "function"
+      },
+      "infix": "/"
+    },
+    {
+      "name": "endswith",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "boolean"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "eq",
+      "decl": {
+        "args": [
+          {
+            "type": "any"
+          },
+          {
+            "type": "any"
+          }
+        ],
+        "result": {
+          "type": "boolean"
+        },
+        "type": "function"
+      },
+      "infix": "="
+    },
+    {
+      "name": "equal",
+      "decl": {
+        "args": [
+          {
+            "type": "any"
+          },
+          {
+            "type": "any"
+          }
+        ],
+        "result": {
+          "type": "boolean"
+        },
+        "type": "function"
+      },
+      "infix": "=="
+    },
+    {
+      "name": "floor",
+      "decl": {
+        "args": [
+          {
+            "type": "number"
+          }
+        ],
+        "result": {
+          "type": "number"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "format_int",
+      "decl": {
+        "args": [
+          {
+            "type": "number"
+          },
+          {
+            "type": "number"
+          }
+        ],
+        "result": {
+          "type": "string"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "glob.match",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          },
+          {
+            "of": [
+              {
+                "type": "null"
+              },
+              {
+                "dynamic": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            ],
+            "type": "any"
+          },
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "boolean"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "glob.quote_meta",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "string"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "graph.reachable",
+      "decl": {
+        "args": [
+          {
+            "dynamic": {
+              "key": {
+                "type": "any"
+              },
+              "value": {
+                "of": [
+                  {
+                    "dynamic": {
+                      "type": "any"
+                    },
+                    "type": "array"
+                  },
+                  {
+                    "of": {
+                      "type": "any"
+                    },
+                    "type": "set"
+                  }
+                ],
+                "type": "any"
+              }
+            },
+            "type": "object"
+          },
+          {
+            "of": [
+              {
+                "dynamic": {
+                  "type": "any"
+                },
+                "type": "array"
+              },
+              {
+                "of": {
+                  "type": "any"
+                },
+                "type": "set"
+              }
+            ],
+            "type": "any"
+          }
+        ],
+        "result": {
+          "of": {
+            "type": "any"
+          },
+          "type": "set"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "graph.reachable_paths",
+      "decl": {
+        "args": [
+          {
+            "dynamic": {
+              "key": {
+                "type": "any"
+              },
+              "value": {
+                "of": [
+                  {
+                    "dynamic": {
+                      "type": "any"
+                    },
+                    "type": "array"
+                  },
+                  {
+                    "of": {
+                      "type": "any"
+                    },
+                    "type": "set"
+                  }
+                ],
+                "type": "any"
+              }
+            },
+            "type": "object"
+          },
+          {
+            "of": [
+              {
+                "dynamic": {
+                  "type": "any"
+                },
+                "type": "array"
+              },
+              {
+                "of": {
+                  "type": "any"
+                },
+                "type": "set"
+              }
+            ],
+            "type": "any"
+          }
+        ],
+        "result": {
+          "of": {
+            "dynamic": {
+              "type": "any"
+            },
+            "type": "array"
+          },
+          "type": "set"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "graphql.is_valid",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "boolean"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "graphql.parse",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "static": [
+            {
+              "dynamic": {
+                "key": {
+                  "type": "any"
+                },
+                "value": {
+                  "type": "any"
+                }
+              },
+              "type": "object"
+            },
+            {
+              "dynamic": {
+                "key": {
+                  "type": "any"
+                },
+                "value": {
+                  "type": "any"
+                }
+              },
+              "type": "object"
+            }
+          ],
+          "type": "array"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "graphql.parse_and_verify",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "static": [
+            {
+              "type": "boolean"
+            },
+            {
+              "dynamic": {
+                "key": {
+                  "type": "any"
+                },
+                "value": {
+                  "type": "any"
+                }
+              },
+              "type": "object"
+            },
+            {
+              "dynamic": {
+                "key": {
+                  "type": "any"
+                },
+                "value": {
+                  "type": "any"
+                }
+              },
+              "type": "object"
+            }
+          ],
+          "type": "array"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "graphql.parse_query",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "dynamic": {
+            "key": {
+              "type": "any"
+            },
+            "value": {
+              "type": "any"
+            }
+          },
+          "type": "object"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "graphql.parse_schema",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "dynamic": {
+            "key": {
+              "type": "any"
+            },
+            "value": {
+              "type": "any"
+            }
+          },
+          "type": "object"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "gt",
+      "decl": {
+        "args": [
+          {
+            "type": "any"
+          },
+          {
+            "type": "any"
+          }
+        ],
+        "result": {
+          "type": "boolean"
+        },
+        "type": "function"
+      },
+      "infix": "\u003e"
+    },
+    {
+      "name": "gte",
+      "decl": {
+        "args": [
+          {
+            "type": "any"
+          },
+          {
+            "type": "any"
+          }
+        ],
+        "result": {
+          "type": "boolean"
+        },
+        "type": "function"
+      },
+      "infix": "\u003e="
+    },
+    {
+      "name": "hex.decode",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "string"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "hex.encode",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "string"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "http.send",
+      "decl": {
+        "args": [
+          {
+            "dynamic": {
+              "key": {
+                "type": "string"
+              },
+              "value": {
+                "type": "any"
+              }
+            },
+            "type": "object"
+          }
+        ],
+        "result": {
+          "dynamic": {
+            "key": {
+              "type": "any"
+            },
+            "value": {
+              "type": "any"
+            }
+          },
+          "type": "object"
+        },
+        "type": "function"
+      },
+      "nondeterministic": true
+    },
+    {
+      "name": "indexof",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "number"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "indexof_n",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "dynamic": {
+            "type": "number"
+          },
+          "type": "array"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "internal.member_2",
+      "decl": {
+        "args": [
+          {
+            "type": "any"
+          },
+          {
+            "type": "any"
+          }
+        ],
+        "result": {
+          "type": "boolean"
+        },
+        "type": "function"
+      },
+      "infix": "in"
+    },
+    {
+      "name": "internal.member_3",
+      "decl": {
+        "args": [
+          {
+            "type": "any"
+          },
+          {
+            "type": "any"
+          },
+          {
+            "type": "any"
+          }
+        ],
+        "result": {
+          "type": "boolean"
+        },
+        "type": "function"
+      },
+      "infix": "in"
+    },
+    {
+      "name": "internal.print",
+      "decl": {
+        "args": [
+          {
+            "dynamic": {
+              "of": {
+                "type": "any"
+              },
+              "type": "set"
+            },
+            "type": "array"
+          }
+        ],
+        "type": "function"
+      }
+    },
+    {
+      "name": "intersection",
+      "decl": {
+        "args": [
+          {
+            "of": {
+              "of": {
+                "type": "any"
+              },
+              "type": "set"
+            },
+            "type": "set"
+          }
+        ],
+        "result": {
+          "of": {
+            "type": "any"
+          },
+          "type": "set"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "io.jwt.decode",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "static": [
+            {
+              "dynamic": {
+                "key": {
+                  "type": "any"
+                },
+                "value": {
+                  "type": "any"
+                }
+              },
+              "type": "object"
+            },
+            {
+              "dynamic": {
+                "key": {
+                  "type": "any"
+                },
+                "value": {
+                  "type": "any"
+                }
+              },
+              "type": "object"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "type": "array"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "io.jwt.decode_verify",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          },
+          {
+            "dynamic": {
+              "key": {
+                "type": "string"
+              },
+              "value": {
+                "type": "any"
+              }
+            },
+            "type": "object"
+          }
+        ],
+        "result": {
+          "static": [
+            {
+              "type": "boolean"
+            },
+            {
+              "dynamic": {
+                "key": {
+                  "type": "any"
+                },
+                "value": {
+                  "type": "any"
+                }
+              },
+              "type": "object"
+            },
+            {
+              "dynamic": {
+                "key": {
+                  "type": "any"
+                },
+                "value": {
+                  "type": "any"
+                }
+              },
+              "type": "object"
+            }
+          ],
+          "type": "array"
+        },
+        "type": "function"
+      },
+      "nondeterministic": true
+    },
+    {
+      "name": "io.jwt.encode_sign",
+      "decl": {
+        "args": [
+          {
+            "dynamic": {
+              "key": {
+                "type": "string"
+              },
+              "value": {
+                "type": "any"
+              }
+            },
+            "type": "object"
+          },
+          {
+            "dynamic": {
+              "key": {
+                "type": "string"
+              },
+              "value": {
+                "type": "any"
+              }
+            },
+            "type": "object"
+          },
+          {
+            "dynamic": {
+              "key": {
+                "type": "string"
+              },
+              "value": {
+                "type": "any"
+              }
+            },
+            "type": "object"
+          }
+        ],
+        "result": {
+          "type": "string"
+        },
+        "type": "function"
+      },
+      "nondeterministic": true
+    },
+    {
+      "name": "io.jwt.encode_sign_raw",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "string"
+        },
+        "type": "function"
+      },
+      "nondeterministic": true
+    },
+    {
+      "name": "io.jwt.verify_es256",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "boolean"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "io.jwt.verify_es384",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "boolean"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "io.jwt.verify_es512",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "boolean"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "io.jwt.verify_hs256",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "boolean"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "io.jwt.verify_hs384",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "boolean"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "io.jwt.verify_hs512",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "boolean"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "io.jwt.verify_ps256",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "boolean"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "io.jwt.verify_ps384",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "boolean"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "io.jwt.verify_ps512",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "boolean"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "io.jwt.verify_rs256",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "boolean"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "io.jwt.verify_rs384",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "boolean"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "io.jwt.verify_rs512",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "boolean"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "is_array",
+      "decl": {
+        "args": [
+          {
+            "type": "any"
+          }
+        ],
+        "result": {
+          "type": "boolean"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "is_boolean",
+      "decl": {
+        "args": [
+          {
+            "type": "any"
+          }
+        ],
+        "result": {
+          "type": "boolean"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "is_null",
+      "decl": {
+        "args": [
+          {
+            "type": "any"
+          }
+        ],
+        "result": {
+          "type": "boolean"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "is_number",
+      "decl": {
+        "args": [
+          {
+            "type": "any"
+          }
+        ],
+        "result": {
+          "type": "boolean"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "is_object",
+      "decl": {
+        "args": [
+          {
+            "type": "any"
+          }
+        ],
+        "result": {
+          "type": "boolean"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "is_set",
+      "decl": {
+        "args": [
+          {
+            "type": "any"
+          }
+        ],
+        "result": {
+          "type": "boolean"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "is_string",
+      "decl": {
+        "args": [
+          {
+            "type": "any"
+          }
+        ],
+        "result": {
+          "type": "boolean"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "json.filter",
+      "decl": {
+        "args": [
+          {
+            "dynamic": {
+              "key": {
+                "type": "any"
+              },
+              "value": {
+                "type": "any"
+              }
+            },
+            "type": "object"
+          },
+          {
+            "of": [
+              {
+                "dynamic": {
+                  "of": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "dynamic": {
+                        "type": "any"
+                      },
+                      "type": "array"
+                    }
+                  ],
+                  "type": "any"
+                },
+                "type": "array"
+              },
+              {
+                "of": {
+                  "of": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "dynamic": {
+                        "type": "any"
+                      },
+                      "type": "array"
+                    }
+                  ],
+                  "type": "any"
+                },
+                "type": "set"
+              }
+            ],
+            "type": "any"
+          }
+        ],
+        "result": {
+          "type": "any"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "json.is_valid",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "boolean"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "json.marshal",
+      "decl": {
+        "args": [
+          {
+            "type": "any"
+          }
+        ],
+        "result": {
+          "type": "string"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "json.patch",
+      "decl": {
+        "args": [
+          {
+            "type": "any"
+          },
+          {
+            "dynamic": {
+              "dynamic": {
+                "key": {
+                  "type": "any"
+                },
+                "value": {
+                  "type": "any"
+                }
+              },
+              "static": [
+                {
+                  "key": "op",
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "key": "path",
+                  "value": {
+                    "type": "any"
+                  }
+                }
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          }
+        ],
+        "result": {
+          "type": "any"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "json.remove",
+      "decl": {
+        "args": [
+          {
+            "dynamic": {
+              "key": {
+                "type": "any"
+              },
+              "value": {
+                "type": "any"
+              }
+            },
+            "type": "object"
+          },
+          {
+            "of": [
+              {
+                "dynamic": {
+                  "of": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "dynamic": {
+                        "type": "any"
+                      },
+                      "type": "array"
+                    }
+                  ],
+                  "type": "any"
+                },
+                "type": "array"
+              },
+              {
+                "of": {
+                  "of": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "dynamic": {
+                        "type": "any"
+                      },
+                      "type": "array"
+                    }
+                  ],
+                  "type": "any"
+                },
+                "type": "set"
+              }
+            ],
+            "type": "any"
+          }
+        ],
+        "result": {
+          "type": "any"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "json.unmarshal",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "any"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "lower",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "string"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "lt",
+      "decl": {
+        "args": [
+          {
+            "type": "any"
+          },
+          {
+            "type": "any"
+          }
+        ],
+        "result": {
+          "type": "boolean"
+        },
+        "type": "function"
+      },
+      "infix": "\u003c"
+    },
+    {
+      "name": "lte",
+      "decl": {
+        "args": [
+          {
+            "type": "any"
+          },
+          {
+            "type": "any"
+          }
+        ],
+        "result": {
+          "type": "boolean"
+        },
+        "type": "function"
+      },
+      "infix": "\u003c="
+    },
+    {
+      "name": "max",
+      "decl": {
+        "args": [
+          {
+            "of": [
+              {
+                "dynamic": {
+                  "type": "any"
+                },
+                "type": "array"
+              },
+              {
+                "of": {
+                  "type": "any"
+                },
+                "type": "set"
+              }
+            ],
+            "type": "any"
+          }
+        ],
+        "result": {
+          "type": "any"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "min",
+      "decl": {
+        "args": [
+          {
+            "of": [
+              {
+                "dynamic": {
+                  "type": "any"
+                },
+                "type": "array"
+              },
+              {
+                "of": {
+                  "type": "any"
+                },
+                "type": "set"
+              }
+            ],
+            "type": "any"
+          }
+        ],
+        "result": {
+          "type": "any"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "minus",
+      "decl": {
+        "args": [
+          {
+            "of": [
+              {
+                "type": "number"
+              },
+              {
+                "of": {
+                  "type": "any"
+                },
+                "type": "set"
+              }
+            ],
+            "type": "any"
+          },
+          {
+            "of": [
+              {
+                "type": "number"
+              },
+              {
+                "of": {
+                  "type": "any"
+                },
+                "type": "set"
+              }
+            ],
+            "type": "any"
+          }
+        ],
+        "result": {
+          "of": [
+            {
+              "type": "number"
+            },
+            {
+              "of": {
+                "type": "any"
+              },
+              "type": "set"
+            }
+          ],
+          "type": "any"
+        },
+        "type": "function"
+      },
+      "infix": "-"
+    },
+    {
+      "name": "mul",
+      "decl": {
+        "args": [
+          {
+            "type": "number"
+          },
+          {
+            "type": "number"
+          }
+        ],
+        "result": {
+          "type": "number"
+        },
+        "type": "function"
+      },
+      "infix": "*"
+    },
+    {
+      "name": "neq",
+      "decl": {
+        "args": [
+          {
+            "type": "any"
+          },
+          {
+            "type": "any"
+          }
+        ],
+        "result": {
+          "type": "boolean"
+        },
+        "type": "function"
+      },
+      "infix": "!="
+    },
+    {
+      "name": "net.cidr_contains",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "boolean"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "net.cidr_contains_matches",
+      "decl": {
+        "args": [
+          {
+            "of": [
+              {
+                "type": "string"
+              },
+              {
+                "dynamic": {
+                  "of": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "dynamic": {
+                        "type": "any"
+                      },
+                      "type": "array"
+                    }
+                  ],
+                  "type": "any"
+                },
+                "type": "array"
+              },
+              {
+                "dynamic": {
+                  "key": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "of": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "dynamic": {
+                          "type": "any"
+                        },
+                        "type": "array"
+                      }
+                    ],
+                    "type": "any"
+                  }
+                },
+                "type": "object"
+              },
+              {
+                "of": {
+                  "of": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "dynamic": {
+                        "type": "any"
+                      },
+                      "type": "array"
+                    }
+                  ],
+                  "type": "any"
+                },
+                "type": "set"
+              }
+            ],
+            "type": "any"
+          },
+          {
+            "of": [
+              {
+                "type": "string"
+              },
+              {
+                "dynamic": {
+                  "of": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "dynamic": {
+                        "type": "any"
+                      },
+                      "type": "array"
+                    }
+                  ],
+                  "type": "any"
+                },
+                "type": "array"
+              },
+              {
+                "dynamic": {
+                  "key": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "of": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "dynamic": {
+                          "type": "any"
+                        },
+                        "type": "array"
+                      }
+                    ],
+                    "type": "any"
+                  }
+                },
+                "type": "object"
+              },
+              {
+                "of": {
+                  "of": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "dynamic": {
+                        "type": "any"
+                      },
+                      "type": "array"
+                    }
+                  ],
+                  "type": "any"
+                },
+                "type": "set"
+              }
+            ],
+            "type": "any"
+          }
+        ],
+        "result": {
+          "of": {
+            "static": [
+              {
+                "type": "any"
+              },
+              {
+                "type": "any"
+              }
+            ],
+            "type": "array"
+          },
+          "type": "set"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "net.cidr_expand",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "of": {
+            "type": "string"
+          },
+          "type": "set"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "net.cidr_intersects",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "boolean"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "net.cidr_merge",
+      "decl": {
+        "args": [
+          {
+            "of": [
+              {
+                "dynamic": {
+                  "of": [
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "type": "any"
+                },
+                "type": "array"
+              },
+              {
+                "of": {
+                  "type": "string"
+                },
+                "type": "set"
+              }
+            ],
+            "type": "any"
+          }
+        ],
+        "result": {
+          "of": {
+            "type": "string"
+          },
+          "type": "set"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "net.cidr_overlap",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "boolean"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "net.lookup_ip_addr",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "of": {
+            "type": "string"
+          },
+          "type": "set"
+        },
+        "type": "function"
+      },
+      "nondeterministic": true
+    },
+    {
+      "name": "numbers.range",
+      "decl": {
+        "args": [
+          {
+            "type": "number"
+          },
+          {
+            "type": "number"
+          }
+        ],
+        "result": {
+          "dynamic": {
+            "type": "number"
+          },
+          "type": "array"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "object.filter",
+      "decl": {
+        "args": [
+          {
+            "dynamic": {
+              "key": {
+                "type": "any"
+              },
+              "value": {
+                "type": "any"
+              }
+            },
+            "type": "object"
+          },
+          {
+            "of": [
+              {
+                "dynamic": {
+                  "type": "any"
+                },
+                "type": "array"
+              },
+              {
+                "dynamic": {
+                  "key": {
+                    "type": "any"
+                  },
+                  "value": {
+                    "type": "any"
+                  }
+                },
+                "type": "object"
+              },
+              {
+                "of": {
+                  "type": "any"
+                },
+                "type": "set"
+              }
+            ],
+            "type": "any"
+          }
+        ],
+        "result": {
+          "type": "any"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "object.get",
+      "decl": {
+        "args": [
+          {
+            "dynamic": {
+              "key": {
+                "type": "any"
+              },
+              "value": {
+                "type": "any"
+              }
+            },
+            "type": "object"
+          },
+          {
+            "type": "any"
+          },
+          {
+            "type": "any"
+          }
+        ],
+        "result": {
+          "type": "any"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "object.remove",
+      "decl": {
+        "args": [
+          {
+            "dynamic": {
+              "key": {
+                "type": "any"
+              },
+              "value": {
+                "type": "any"
+              }
+            },
+            "type": "object"
+          },
+          {
+            "of": [
+              {
+                "dynamic": {
+                  "type": "any"
+                },
+                "type": "array"
+              },
+              {
+                "dynamic": {
+                  "key": {
+                    "type": "any"
+                  },
+                  "value": {
+                    "type": "any"
+                  }
+                },
+                "type": "object"
+              },
+              {
+                "of": {
+                  "type": "any"
+                },
+                "type": "set"
+              }
+            ],
+            "type": "any"
+          }
+        ],
+        "result": {
+          "type": "any"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "object.subset",
+      "decl": {
+        "args": [
+          {
+            "of": [
+              {
+                "dynamic": {
+                  "type": "any"
+                },
+                "type": "array"
+              },
+              {
+                "dynamic": {
+                  "key": {
+                    "type": "any"
+                  },
+                  "value": {
+                    "type": "any"
+                  }
+                },
+                "type": "object"
+              },
+              {
+                "of": {
+                  "type": "any"
+                },
+                "type": "set"
+              }
+            ],
+            "type": "any"
+          },
+          {
+            "of": [
+              {
+                "dynamic": {
+                  "type": "any"
+                },
+                "type": "array"
+              },
+              {
+                "dynamic": {
+                  "key": {
+                    "type": "any"
+                  },
+                  "value": {
+                    "type": "any"
+                  }
+                },
+                "type": "object"
+              },
+              {
+                "of": {
+                  "type": "any"
+                },
+                "type": "set"
+              }
+            ],
+            "type": "any"
+          }
+        ],
+        "result": {
+          "type": "any"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "object.union",
+      "decl": {
+        "args": [
+          {
+            "dynamic": {
+              "key": {
+                "type": "any"
+              },
+              "value": {
+                "type": "any"
+              }
+            },
+            "type": "object"
+          },
+          {
+            "dynamic": {
+              "key": {
+                "type": "any"
+              },
+              "value": {
+                "type": "any"
+              }
+            },
+            "type": "object"
+          }
+        ],
+        "result": {
+          "type": "any"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "object.union_n",
+      "decl": {
+        "args": [
+          {
+            "dynamic": {
+              "dynamic": {
+                "key": {
+                  "type": "any"
+                },
+                "value": {
+                  "type": "any"
+                }
+              },
+              "type": "object"
+            },
+            "type": "array"
+          }
+        ],
+        "result": {
+          "type": "any"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "opa.runtime",
+      "decl": {
+        "result": {
+          "dynamic": {
+            "key": {
+              "type": "string"
+            },
+            "value": {
+              "type": "any"
+            }
+          },
+          "type": "object"
+        },
+        "type": "function"
+      },
+      "nondeterministic": true
+    },
+    {
+      "name": "or",
+      "decl": {
+        "args": [
+          {
+            "of": {
+              "type": "any"
+            },
+            "type": "set"
+          },
+          {
+            "of": {
+              "type": "any"
+            },
+            "type": "set"
+          }
+        ],
+        "result": {
+          "of": {
+            "type": "any"
+          },
+          "type": "set"
+        },
+        "type": "function"
+      },
+      "infix": "|"
+    },
+    {
+      "name": "plus",
+      "decl": {
+        "args": [
+          {
+            "type": "number"
+          },
+          {
+            "type": "number"
+          }
+        ],
+        "result": {
+          "type": "number"
+        },
+        "type": "function"
+      },
+      "infix": "+"
+    },
+    {
+      "name": "print",
+      "decl": {
+        "type": "function",
+        "variadic": {
+          "type": "any"
+        }
+      }
+    },
+    {
+      "name": "product",
+      "decl": {
+        "args": [
+          {
+            "of": [
+              {
+                "dynamic": {
+                  "type": "number"
+                },
+                "type": "array"
+              },
+              {
+                "of": {
+                  "type": "number"
+                },
+                "type": "set"
+              }
+            ],
+            "type": "any"
+          }
+        ],
+        "result": {
+          "type": "number"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "rand.intn",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "number"
+          }
+        ],
+        "result": {
+          "type": "number"
+        },
+        "type": "function"
+      },
+      "nondeterministic": true
+    },
+    {
+      "name": "re_match",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "boolean"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "regex.find_all_string_submatch_n",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string"
+          },
+          {
+            "type": "number"
+          }
+        ],
+        "result": {
+          "dynamic": {
+            "dynamic": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "type": "array"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "regex.find_n",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string"
+          },
+          {
+            "type": "number"
+          }
+        ],
+        "result": {
+          "dynamic": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "regex.globs_match",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "boolean"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "regex.is_valid",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "boolean"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "regex.match",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "boolean"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "regex.split",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "dynamic": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "regex.template_match",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string"
+          },
+          {
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "boolean"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "rego.metadata.chain",
+      "decl": {
+        "result": {
+          "dynamic": {
+            "type": "any"
+          },
+          "type": "array"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "rego.metadata.rule",
+      "decl": {
+        "result": {
+          "type": "any"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "rego.parse_module",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "dynamic": {
+            "key": {
+              "type": "string"
+            },
+            "value": {
+              "type": "any"
+            }
+          },
+          "type": "object"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "rem",
+      "decl": {
+        "args": [
+          {
+            "type": "number"
+          },
+          {
+            "type": "number"
+          }
+        ],
+        "result": {
+          "type": "number"
+        },
+        "type": "function"
+      },
+      "infix": "%"
+    },
+    {
+      "name": "replace",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "string"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "round",
+      "decl": {
+        "args": [
+          {
+            "type": "number"
+          }
+        ],
+        "result": {
+          "type": "number"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "semver.compare",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "number"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "semver.is_valid",
+      "decl": {
+        "args": [
+          {
+            "type": "any"
+          }
+        ],
+        "result": {
+          "type": "boolean"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "set_diff",
+      "decl": {
+        "args": [
+          {
+            "of": {
+              "type": "any"
+            },
+            "type": "set"
+          },
+          {
+            "of": {
+              "type": "any"
+            },
+            "type": "set"
+          }
+        ],
+        "result": {
+          "of": {
+            "type": "any"
+          },
+          "type": "set"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "sort",
+      "decl": {
+        "args": [
+          {
+            "of": [
+              {
+                "dynamic": {
+                  "type": "any"
+                },
+                "type": "array"
+              },
+              {
+                "of": {
+                  "type": "any"
+                },
+                "type": "set"
+              }
+            ],
+            "type": "any"
+          }
+        ],
+        "result": {
+          "dynamic": {
+            "type": "any"
+          },
+          "type": "array"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "split",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "dynamic": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "sprintf",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          },
+          {
+            "dynamic": {
+              "type": "any"
+            },
+            "type": "array"
+          }
+        ],
+        "result": {
+          "type": "string"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "startswith",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "boolean"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "strings.any_prefix_match",
+      "decl": {
+        "args": [
+          {
+            "of": [
+              {
+                "type": "string"
+              },
+              {
+                "dynamic": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "of": {
+                  "type": "string"
+                },
+                "type": "set"
+              }
+            ],
+            "type": "any"
+          },
+          {
+            "of": [
+              {
+                "type": "string"
+              },
+              {
+                "dynamic": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "of": {
+                  "type": "string"
+                },
+                "type": "set"
+              }
+            ],
+            "type": "any"
+          }
+        ],
+        "result": {
+          "type": "boolean"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "strings.any_suffix_match",
+      "decl": {
+        "args": [
+          {
+            "of": [
+              {
+                "type": "string"
+              },
+              {
+                "dynamic": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "of": {
+                  "type": "string"
+                },
+                "type": "set"
+              }
+            ],
+            "type": "any"
+          },
+          {
+            "of": [
+              {
+                "type": "string"
+              },
+              {
+                "dynamic": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "of": {
+                  "type": "string"
+                },
+                "type": "set"
+              }
+            ],
+            "type": "any"
+          }
+        ],
+        "result": {
+          "type": "boolean"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "strings.replace_n",
+      "decl": {
+        "args": [
+          {
+            "dynamic": {
+              "key": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "string"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "strings.reverse",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "string"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "substring",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "number"
+          },
+          {
+            "type": "number"
+          }
+        ],
+        "result": {
+          "type": "string"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "sum",
+      "decl": {
+        "args": [
+          {
+            "of": [
+              {
+                "dynamic": {
+                  "type": "number"
+                },
+                "type": "array"
+              },
+              {
+                "of": {
+                  "type": "number"
+                },
+                "type": "set"
+              }
+            ],
+            "type": "any"
+          }
+        ],
+        "result": {
+          "type": "number"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "time.add_date",
+      "decl": {
+        "args": [
+          {
+            "type": "number"
+          },
+          {
+            "type": "number"
+          },
+          {
+            "type": "number"
+          },
+          {
+            "type": "number"
+          }
+        ],
+        "result": {
+          "type": "number"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "time.clock",
+      "decl": {
+        "args": [
+          {
+            "of": [
+              {
+                "type": "number"
+              },
+              {
+                "static": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "type": "array"
+              }
+            ],
+            "type": "any"
+          }
+        ],
+        "result": {
+          "static": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "type": "array"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "time.date",
+      "decl": {
+        "args": [
+          {
+            "of": [
+              {
+                "type": "number"
+              },
+              {
+                "static": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "type": "array"
+              }
+            ],
+            "type": "any"
+          }
+        ],
+        "result": {
+          "static": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "type": "array"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "time.diff",
+      "decl": {
+        "args": [
+          {
+            "of": [
+              {
+                "type": "number"
+              },
+              {
+                "static": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "type": "array"
+              }
+            ],
+            "type": "any"
+          },
+          {
+            "of": [
+              {
+                "type": "number"
+              },
+              {
+                "static": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "type": "array"
+              }
+            ],
+            "type": "any"
+          }
+        ],
+        "result": {
+          "static": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "type": "array"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "time.now_ns",
+      "decl": {
+        "result": {
+          "type": "number"
+        },
+        "type": "function"
+      },
+      "nondeterministic": true
+    },
+    {
+      "name": "time.parse_duration_ns",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "number"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "time.parse_ns",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "number"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "time.parse_rfc3339_ns",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "number"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "time.weekday",
+      "decl": {
+        "args": [
+          {
+            "of": [
+              {
+                "type": "number"
+              },
+              {
+                "static": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "type": "array"
+              }
+            ],
+            "type": "any"
+          }
+        ],
+        "result": {
+          "type": "string"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "to_number",
+      "decl": {
+        "args": [
+          {
+            "of": [
+              {
+                "type": "null"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "type": "any"
+          }
+        ],
+        "result": {
+          "type": "number"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "trace",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "boolean"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "trim",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "string"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "trim_left",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "string"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "trim_prefix",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "string"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "trim_right",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "string"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "trim_space",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "string"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "trim_suffix",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "string"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "type_name",
+      "decl": {
+        "args": [
+          {
+            "type": "any"
+          }
+        ],
+        "result": {
+          "type": "string"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "union",
+      "decl": {
+        "args": [
+          {
+            "of": {
+              "of": {
+                "type": "any"
+              },
+              "type": "set"
+            },
+            "type": "set"
+          }
+        ],
+        "result": {
+          "of": {
+            "type": "any"
+          },
+          "type": "set"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "units.parse",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "number"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "units.parse_bytes",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "number"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "upper",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "string"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "urlquery.decode",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "string"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "urlquery.decode_object",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "dynamic": {
+            "key": {
+              "type": "string"
+            },
+            "value": {
+              "dynamic": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "urlquery.encode",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "string"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "urlquery.encode_object",
+      "decl": {
+        "args": [
+          {
+            "dynamic": {
+              "key": {
+                "type": "string"
+              },
+              "value": {
+                "of": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "dynamic": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  {
+                    "of": {
+                      "type": "string"
+                    },
+                    "type": "set"
+                  }
+                ],
+                "type": "any"
+              }
+            },
+            "type": "object"
+          }
+        ],
+        "result": {
+          "type": "string"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "uuid.rfc4122",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "string"
+        },
+        "type": "function"
+      },
+      "nondeterministic": true
+    },
+    {
+      "name": "walk",
+      "decl": {
+        "args": [
+          {
+            "type": "any"
+          }
+        ],
+        "result": {
+          "static": [
+            {
+              "dynamic": {
+                "type": "any"
+              },
+              "type": "array"
+            },
+            {
+              "type": "any"
+            }
+          ],
+          "type": "array"
+        },
+        "type": "function"
+      },
+      "relation": true
+    },
+    {
+      "name": "yaml.is_valid",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "boolean"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "yaml.marshal",
+      "decl": {
+        "args": [
+          {
+            "type": "any"
+          }
+        ],
+        "result": {
+          "type": "string"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "yaml.unmarshal",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "any"
+        },
+        "type": "function"
+      }
+    }
+  ],
+  "future_keywords": [
+    "contains",
+    "every",
+    "if",
+    "in"
+  ],
+  "wasm_abi_versions": [
+    {
+      "version": 1,
+      "minor_version": 1
+    },
+    {
+      "version": 1,
+      "minor_version": 2
+    }
+  ]
+}

--- a/version/version.go
+++ b/version/version.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Version is the canonical version of OPA.
-var Version = "0.44.0-dev"
+var Version = "0.44.0"
 
 // GoVersion is the version of Go this was built with
 var GoVersion = runtime.Version()


### PR DESCRIPTION
Note: This release commit rolls in a small fix for the build/release tooling: an upgrade for the changelog-generator script from Python 2 -> Python 3. The script can now handle unicode in commit messages without breaking.