### PR TITLE
version: use runtime/debug.BuildInfo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,8 +60,6 @@ S3_RELEASE_BUCKET ?= opa-releases
 FUZZ_TIME ?= 1h
 TELEMETRY_URL ?= #Default empty
 
-BUILD_COMMIT := $(shell ./build/get-build-commit.sh)
-BUILD_TIMESTAMP := $(shell ./build/get-build-timestamp.sh)
 BUILD_HOSTNAME := $(shell ./build/get-build-hostname.sh)
 
 RELEASE_BUILD_IMAGE := golang:$(GOVERSION)
@@ -73,9 +71,6 @@ TELEMETRY_FLAG := -X github.com/open-policy-agent/opa/internal/report.ExternalSe
 endif
 
 LDFLAGS := "$(TELEMETRY_FLAG) \
-	-X github.com/open-policy-agent/opa/version.Version=$(VERSION) \
-	-X github.com/open-policy-agent/opa/version.Vcs=$(BUILD_COMMIT) \
-	-X github.com/open-policy-agent/opa/version.Timestamp=$(BUILD_TIMESTAMP) \
 	-X github.com/open-policy-agent/opa/version.Hostname=$(BUILD_HOSTNAME)"
 
 

--- a/build/get-build-commit.sh
+++ b/build/get-build-commit.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-GIT_SHA=$(git rev-parse --short HEAD)
-
-if [ -z "$(git status --porcelain 2>/dev/null)" ]; then
-    echo $GIT_SHA
-else
-    echo "$GIT_SHA-dirty"
-fi

--- a/build/get-build-timestamp.sh
+++ b/build/get-build-timestamp.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-date -u +"%Y-%m-%dT%H:%M:%SZ"

--- a/version/version_go1.18.go
+++ b/version/version_go1.18.go
@@ -1,0 +1,33 @@
+// Copyright 2022 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+//go:build go1.18
+// +build go1.18
+
+package version
+
+import (
+	"runtime/debug"
+)
+
+func init() {
+	bi, ok := debug.ReadBuildInfo()
+	if !ok {
+		return
+	}
+	dirty := false
+	for _, s := range bi.Settings {
+		switch s.Key {
+		case "vcs.time":
+			Timestamp = s.Value
+		case "vcs.revision":
+			Vcs = s.Value
+		case "vcs.modified":
+			dirty = s.Value == "true"
+		}
+	}
+	if dirty {
+		Vcs = Vcs + "-dirty"
+	}
+}


### PR DESCRIPTION
Two small moving parts less. The commit will now be included unabbreviated, but I think that's OK.

Edit: I had been misreading the stdlib docs, the VCS-related info is only available with go 1.18+. So, put that logic into a build-flag-file.

ℹ️ We're still running `make build` in Go 1.17 and 1.18 to ensure compatibility, but those binaries are not published. It is thus not that important that they have the correct VCS info in them.