### PR TITLE
trivyignore: add wasmtime-go CVE-2022-31169

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -36,3 +36,6 @@ GHSA-qq97-vm5h-rrhg
 
 # github.com/dgrijalva/jwt-go -- vulnerable version used by docker/distribution above
 CVE-2020-26160
+
+# github.com/bytecodealliance/wasmtime-go - we don't enable wasm on arm64 builds
+CVE-2022-31169


### PR DESCRIPTION
```
$ trivy fs  --format table --exit-code  1 --ignore-unfixed --vuln-type  os,library --severity  CRITICAL,HIGH --skip-dirs vendor/ . --security-checks vuln
2022-09-09T14:13:05.483+0200	INFO	Vulnerability scanning is enabled
2022-09-09T14:13:05.598+0200	INFO	Number of language-specific files: 5
2022-09-09T14:13:05.598+0200	INFO	Detecting npm vulnerabilities...
2022-09-09T14:13:05.602+0200	INFO	Detecting gomod vulnerabilities...
$
```

We should still update, but we shouldn't be rushed by this CVE.