### PR TITLE
topdown/object: Rework `object.union_n` to use in-place merge algorithm.

### DIFF
--- a/topdown/object_bench_test.go
+++ b/topdown/object_bench_test.go
@@ -1,0 +1,122 @@
+// Copyright 2022 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package topdown
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/storage"
+	inmem "github.com/open-policy-agent/opa/storage/inmem/test"
+)
+
+func genNxMObjectBenchmarkData(n, m int) ast.Value {
+	objList := make([]*ast.Term, n)
+	for i := 0; i < n; i++ {
+		v := ast.NewObject()
+		for j := 0; j < m; j++ {
+			v.Insert(ast.StringTerm(fmt.Sprintf("%d,%d", i, j)), ast.BooleanTerm(true))
+		}
+		objList[i] = ast.NewTerm(v)
+	}
+	return ast.NewArray(objList...)
+}
+
+func BenchmarkObjectUnionN(b *testing.B) {
+	ctx := context.Background()
+
+	sizes := []int{10, 100, 250}
+
+	for _, n := range sizes {
+		for _, m := range sizes {
+			b.Run(fmt.Sprintf("%dx%d", n, m), func(b *testing.B) {
+				store := inmem.NewFromObject(map[string]interface{}{"objs": genNxMObjectBenchmarkData(n, m)})
+				module := `package test
+
+				combined := object.union_n(data.objs)`
+
+				query := ast.MustParseBody("data.test.combined")
+				compiler := ast.MustCompileModules(map[string]string{
+					"test.rego": module,
+				})
+
+				b.ResetTimer()
+
+				for i := 0; i < b.N; i++ {
+
+					err := storage.Txn(ctx, store, storage.TransactionParams{}, func(txn storage.Transaction) error {
+
+						q := NewQuery(query).
+							WithCompiler(compiler).
+							WithStore(store).
+							WithTransaction(txn)
+
+						_, err := q.Run(ctx)
+						if err != nil {
+							return err
+						}
+
+						return nil
+					})
+
+					if err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		}
+	}
+}
+
+func BenchmarkObjectUnionNSlow(b *testing.B) {
+	// This benchmarks the suggested means to implement union
+	// without using the builtin, to give us an idea of whether or not
+	// the builtin is actually making things any faster.
+	ctx := context.Background()
+
+	sizes := []int{10, 100, 250}
+
+	for _, n := range sizes {
+		for _, m := range sizes {
+			b.Run(fmt.Sprintf("%dx%d", n, m), func(b *testing.B) {
+				store := inmem.NewFromObject(map[string]interface{}{"objs": genNxMObjectBenchmarkData(n, m)})
+				module := `package test
+
+				combined := {k: true | s := data.objs[_]; s[k]}`
+
+				query := ast.MustParseBody("data.test.combined")
+				compiler := ast.MustCompileModules(map[string]string{
+					"test.rego": module,
+				})
+
+				b.ResetTimer()
+
+				for i := 0; i < b.N; i++ {
+
+					err := storage.Txn(ctx, store, storage.TransactionParams{}, func(txn storage.Transaction) error {
+
+						q := NewQuery(query).
+							WithCompiler(compiler).
+							WithStore(store).
+							WithTransaction(txn)
+
+						_, err := q.Run(ctx)
+						if err != nil {
+							return err
+						}
+
+						return nil
+					})
+
+					if err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		}
+	}
+}

--- a/topdown/object_test.go
+++ b/topdown/object_test.go
@@ -1,0 +1,81 @@
+// Copyright 2022 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package topdown
+
+import (
+	"testing"
+
+	"github.com/open-policy-agent/opa/ast"
+)
+
+func TestObjectUnionNBuiltin(t *testing.T) {
+	tests := []struct {
+		note     string
+		query    string
+		input    string
+		expected string
+	}{
+		// NOTE(philipc): These tests assume that erroneous types are
+		// checked elsewhere, and focus only on functional correctness.
+		{
+			note:     "Empty",
+			input:    `[]`,
+			expected: `{}`,
+		},
+		{
+			note:     "Singletons",
+			input:    `[{1: true}, {2: true}, {3: true}]`,
+			expected: `{1: true, 2: true, 3: true}`,
+		},
+		{
+			note:     "One object",
+			input:    `[{1: true, 2: true, 3: true}]`,
+			expected: `{1: true, 2: true, 3: true}`,
+		},
+		{
+			note:     "One object + empty",
+			input:    `[{1: true, 2: true, 3: true}, {}]`,
+			expected: `{1: true, 2: true, 3: true}`,
+		},
+		{
+			note:     "Multiple objects, with scalar duplicates",
+			input:    `[{"A": 1, "B": 2, "C": 3}, {"A": 1, "B": 2}, {"C": 3}, {"D": 4, "E": 5}]`,
+			expected: `{"A": 1, "B": 2, "C": 3, "D": 4, "E": 5}`,
+		},
+		{
+			note:     "2x objects, with simple merge on key",
+			input:    `[{"A": 1, "B": {"D": 4}, "C": 3},  {"B": 200}]`,
+			expected: `{"A": 1, "B": 200, "C": 3,}`,
+		},
+		{
+			note:     "2x objects, with complex merge on nested object",
+			input:    `[{"A": 1, "B": {"N1": {"X": true, "Z": false}}, "C": 3},  {"B": {"N1": {"X": 49, "Z": 50}}}]`,
+			expected: `{"A": 1, "B": {"N1": {"X": 49, "Z": 50}}, "C": 3}`,
+		},
+		{
+			note:     "Multiple objects, with scalar, then object, overwrite on nested key",
+			input:    `[{"A": 1, "B": {"N1": {"X": true, "Z": false}}, "C": 3}, {"B": {"N1": 23}}, {"B": {"N1": {"Z": 50}}}]`,
+			expected: `{"A": 1, "B": {"N1": {"Z": 50}}, "C": 3}`,
+		},
+		{
+			note:     "Multiple objects, with complex overwrite on nested key",
+			input:    `[{"A": 1, "B": {"N1": {"X": true, "Z": false}}, "C": 3}, {"B": {"N1": 23}}, {"B": {"N1": {"Z": 50}}}, {"B": {"N1": {"Z": 35}}}]`,
+			expected: `{"A": 1, "B": {"N1": {"Z": 35}}, "C": 3}`,
+		},
+	}
+
+	for _, tc := range tests {
+		inputs := ast.MustParseTerm(tc.input)
+		result, err := getResult(builtinObjectUnionN, inputs)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		expected := ast.MustParseTerm(tc.expected)
+		if !result.Equal(expected) {
+			t.Fatalf("Expected %v but got %v", expected, result)
+		}
+	}
+}


### PR DESCRIPTION
This PR fixes a performance regression for the `object.union_n` builtin, discovered in issue #4985.

The original logic for the builtin did pairwise `mergeWithOverwrite` calls between the input Objects, resulting in many wasted intermediate result Objects that were almost immediately discarded. The updated builtin uses a new algorithm to do a single pass across the input Objects, respecting the "last assignment wins, with merges" semantics of the original builtin implementation.

In the included benchmarks, this provides a 2x speed and 2-3x memory efficiency improvement over using a pure-Rego comprehension to do the same job, and a 6-30x improvement over the original implementation on all metrics as input Object arrays grow larger.

Fixes #4985

The 3x relevant benchmarks are shown below:

 - `object.union_n` on `main` branch
 - Pure Rego implementation (Object comprehension)
 - `object.union_n` on this PR

## Benchmarks

Benchmark of `object.union_n` on `main` branch:
```
Running tool: /usr/local/go/bin/go test -benchmem -run=^$ -bench ^BenchmarkObjectUnionN$ github.com/open-policy-agent/opa/topdown

goos: linux
goarch: amd64
pkg: github.com/open-policy-agent/opa/topdown
cpu: Intel(R) Core(TM) i7-8650U CPU @ 1.90GHz
BenchmarkObjectUnionN/10x10-8         	    4965	    236921 ns/op	   79700 B/op	    1441 allocs/op
BenchmarkObjectUnionN/10x100-8        	     526	   2305226 ns/op	  759100 B/op	   11524 allocs/op
BenchmarkObjectUnionN/10x250-8        	     128	  11340810 ns/op	 1946964 B/op	   28243 allocs/op
BenchmarkObjectUnionN/100x10-8        	      34	  32815013 ns/op	 7083399 B/op	  104789 allocs/op
BenchmarkObjectUnionN/100x100-8       	       4	 267571459 ns/op	74272772 B/op	 1025478 allocs/op
BenchmarkObjectUnionN/100x250-8       	       2	 778593630 ns/op	182422912 B/op	 2562647 allocs/op
BenchmarkObjectUnionN/250x10-8        	       7	 171022894 ns/op	44684044 B/op	  641897 allocs/op
BenchmarkObjectUnionN/250x100-8       	       1	1771797807 ns/op	453937248 B/op	 6368408 allocs/op
BenchmarkObjectUnionN/250x250-8       	       1	4780766324 ns/op	1205083376 B/op	15958999 allocs/op
PASS
ok  	github.com/open-policy-agent/opa/topdown	20.584s
```

Benchmark of Pure Rego implementation:
```
Running tool: /usr/local/go/bin/go test -benchmem -run=^$ -bench ^BenchmarkObjectUnionNSlow$ github.com/open-policy-agent/opa/topdown

goos: linux
goarch: amd64
pkg: github.com/open-policy-agent/opa/topdown
cpu: Intel(R) Core(TM) i7-8650U CPU @ 1.90GHz
BenchmarkObjectUnionNSlow/10x10-8         	    9382	    130836 ns/op	   40207 B/op	     818 allocs/op
BenchmarkObjectUnionNSlow/10x100-8        	    1122	   1202061 ns/op	  323580 B/op	    5348 allocs/op
BenchmarkObjectUnionNSlow/10x250-8        	     535	   2209046 ns/op	  744128 B/op	   12876 allocs/op
BenchmarkObjectUnionNSlow/100x10-8        	    1210	   1025966 ns/op	  368944 B/op	    6788 allocs/op
BenchmarkObjectUnionNSlow/100x100-8       	     100	  10117234 ns/op	 3093754 B/op	   51983 allocs/op
BenchmarkObjectUnionNSlow/100x250-8       	      42	  26226170 ns/op	 7340888 B/op	  127626 allocs/op
BenchmarkObjectUnionNSlow/250x10-8        	     452	   2805731 ns/op	  865134 B/op	   16867 allocs/op
BenchmarkObjectUnionNSlow/250x100-8       	      46	  25466460 ns/op	 7417977 B/op	  130189 allocs/op
BenchmarkObjectUnionNSlow/250x250-8       	      18	  69078588 ns/op	20508967 B/op	  319094 allocs/op
PASS
ok  	github.com/open-policy-agent/opa/topdown	15.404s
```

Benchmark of `object.union_n` on this PR:
```
Running tool: /usr/local/go/bin/go test -benchmem -run=^$ -bench ^BenchmarkObjectUnionN$ github.com/open-policy-agent/opa/topdown

goos: linux
goarch: amd64
pkg: github.com/open-policy-agent/opa/topdown
cpu: Intel(R) Core(TM) i7-8650U CPU @ 1.90GHz
BenchmarkObjectUnionN/10x10-8         	   25534	     44702 ns/op	   19468 B/op	     374 allocs/op
BenchmarkObjectUnionN/10x100-8        	    4594	    458595 ns/op	  158814 B/op	    2203 allocs/op
BenchmarkObjectUnionN/10x250-8        	    1677	    848999 ns/op	  339319 B/op	    5232 allocs/op
BenchmarkObjectUnionN/100x10-8        	    2611	    570072 ns/op	  161686 B/op	    2293 allocs/op
BenchmarkObjectUnionN/100x100-8       	     340	   3914881 ns/op	 1446257 B/op	   20485 allocs/op
BenchmarkObjectUnionN/100x250-8       	     153	   7588882 ns/op	 3294123 B/op	   51133 allocs/op
BenchmarkObjectUnionN/250x10-8        	    1686	    636962 ns/op	  347029 B/op	    5472 allocs/op
BenchmarkObjectUnionN/250x100-8       	     163	   7328428 ns/op	 3298907 B/op	   51283 allocs/op
BenchmarkObjectUnionN/250x250-8       	      57	  20065940 ns/op	10388723 B/op	  127676 allocs/op
PASS
ok  	github.com/open-policy-agent/opa/topdown	17.998s
```

## Summary of Results

As mentioned above, and as shown in the benchmark results, this PR's changes provide dramatic performance improvements on all metrics, and result in the builtin having around 2-3x better performance overall than a pure Rego equivalent.

![2022-09-12_object-union-n-optimization-v2](https://user-images.githubusercontent.com/1906841/189769989-d93b0a00-5539-44b7-9819-01d620465491.png)
