### PR TITLE
vektah/gqlparser dep updated, and graphql.is_valid_schema & validate_schema implemented

### DIFF
--- a/ast/builtins.go
+++ b/ast/builtins.go
@@ -239,6 +239,8 @@ var DefaultBuiltins = [...]*Builtin{
 	GraphQLParseQuery,
 	GraphQLParseSchema,
 	GraphQLIsValid,
+	GraphQLIsValidSchema,
+	GraphQLValidateSchema,
 
 	// Rego
 	RegoParseModule,
@@ -2579,6 +2581,36 @@ var GraphQLIsValid = &Builtin{
 			types.Named("schema", types.S),
 		),
 		types.Named("output", types.B).Description("`true` if the query is valid under the given schema. `false` otherwise."),
+	),
+}
+
+// GraphQLIsValidSchema returns true if a GraphQL schema is valid.
+var GraphQLIsValidSchema = &Builtin{
+	Name:        "graphql.is_valid_schema",
+	Description: "Checks that a GraphQL schema is valid.",
+	Decl: types.NewFunction(
+		types.Args(
+			types.Named("schema", types.S),
+		),
+		types.Named("output", types.B).Description("`true` if the schema is valid. `false` otherwise."),
+	),
+}
+
+// GraphQLValidateSchema returns object with validation flag and error representation for GraphQL schema.
+var GraphQLValidateSchema = &Builtin{
+	Name:        "graphql.validate_schema",
+	Description: "Checks that a GraphQL schema is valid with error.",
+	Decl: types.NewFunction(
+		types.Args(
+			types.Named("schema", types.S),
+		),
+		types.Named("output", types.NewObject(
+			[]*types.StaticProperty{
+				types.NewStaticProperty("error", types.S),
+				types.NewStaticProperty("is_valid", types.B),
+			},
+			types.NewDynamicProperty(types.A, types.A),
+		)).Description(" `output` is of the form `{error: string, is_valid: bool}`. If the schema is valid given the provided schema, then `valid` is `true` and `error` is empty string. If `false` then `error` contains error specific message."),
 	),
 }
 

--- a/internal/gqlparser/.gitignore
+++ b/internal/gqlparser/.gitignore
@@ -1,0 +1,5 @@
+/vendor
+/validator/imported/node_modules
+/validator/imported/graphql-js
+
+.idea/

--- a/internal/gqlparser/README.md
+++ b/internal/gqlparser/README.md
@@ -1,20 +1,5 @@
-# gqlparser (Details of library residing in OPA's internal)
-
-## Description
-
-https://github.com/vektah/gqlparser was duplicated into `internal/gqlparser` folder, so that we no longer have to track the external library 1-to-1, and so that OPA library users who want to use newer/older gqlparser versions won't have to match our GraphQL parser's version.
-
-The current version we have forked from is the [`v2.4.8`](https://github.com/vektah/gqlparser/releases/tag/v2.4.8) release. (Commit: `6d97050` on `master`)
-
-## Rewriter script
-
-The `rewrite-deps.sh` can be run from this directory, and it will do the grunt work of rewriting all import path prefixes for `gqlparser` sub-packages, so that they import this package.
-It also will add some linter ignore annotations on the validator rules, since those are tedious to do by hand.
-
-The script thus should alleviate around 40-60% of the linter-fixup work required during a version bump.
-
-
-## Original README
+gqlparser [![CircleCI](https://badgen.net/circleci/github/vektah/gqlparser/master)](https://circleci.com/gh/vektah/gqlparser) [![Go Report Card](https://goreportcard.com/badge/github.com/vektah/gqlparser/v2)](https://goreportcard.com/report/github.com/vektah/gqlparser/v2) [![Coverage Status](https://badgen.net/coveralls/c/github/vektah/gqlparser)](https://coveralls.io/github/vektah/gqlparser?branch=master)
+===
 
 This is a parser for graphql, written to mirror the graphql-js reference implementation as closely while remaining idiomatic and easy to use.
 

--- a/internal/gqlparser/ast/path.go
+++ b/internal/gqlparser/ast/path.go
@@ -60,8 +60,8 @@ func (path *Path) UnmarshalJSON(b []byte) error {
 
 type PathIndex int
 
-func (PathIndex) isPathElement() {}
+func (_ PathIndex) isPathElement() {}
 
 type PathName string
 
-func (PathName) isPathElement() {}
+func (_ PathName) isPathElement() {}

--- a/internal/gqlparser/ast/selection.go
+++ b/internal/gqlparser/ast/selection.go
@@ -34,6 +34,6 @@ type Argument struct {
 	Position *Position `dump:"-"`
 }
 
-func (s *Field) ArgumentMap(vars map[string]interface{}) map[string]interface{} {
-	return arg2map(s.Definition.Arguments, s.Arguments, vars)
+func (f *Field) ArgumentMap(vars map[string]interface{}) map[string]interface{} {
+	return arg2map(f.Definition.Arguments, f.Arguments, vars)
 }

--- a/internal/gqlparser/ast/type.go
+++ b/internal/gqlparser/ast/type.go
@@ -63,6 +63,6 @@ func (t *Type) IsCompatible(other *Type) bool {
 	return true
 }
 
-func (t *Type) Dump() string {
-	return t.String()
+func (v *Type) Dump() string {
+	return v.String()
 }

--- a/internal/gqlparser/formatter/formatter.go
+++ b/internal/gqlparser/formatter/formatter.go
@@ -15,7 +15,6 @@ type Formatter interface {
 	FormatQueryDocument(doc *ast.QueryDocument)
 }
 
-//nolint:revive // Revive is being too aggressive here.
 type FormatterOption func(*formatter)
 
 func WithIndent(indent string) FormatterOption {

--- a/internal/gqlparser/formatter/formatter_test.go
+++ b/internal/gqlparser/formatter/formatter_test.go
@@ -8,11 +8,11 @@ import (
 	"testing"
 	"unicode/utf8"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/open-policy-agent/opa/internal/gqlparser"
 	"github.com/open-policy-agent/opa/internal/gqlparser/ast"
 	"github.com/open-policy-agent/opa/internal/gqlparser/formatter"
 	"github.com/open-policy-agent/opa/internal/gqlparser/parser"
-	"github.com/stretchr/testify/assert"
 )
 
 var update = flag.Bool("u", false, "update golden files")

--- a/internal/gqlparser/gqlerror/error_test.go
+++ b/internal/gqlparser/gqlerror/error_test.go
@@ -3,8 +3,8 @@ package gqlerror
 import (
 	"testing"
 
-	"github.com/open-policy-agent/opa/internal/gqlparser/ast"
 	"github.com/stretchr/testify/require"
+	"github.com/open-policy-agent/opa/internal/gqlparser/ast"
 )
 
 func TestErrorFormatting(t *testing.T) {

--- a/internal/gqlparser/gqlparser.go
+++ b/internal/gqlparser/gqlparser.go
@@ -5,12 +5,10 @@ import (
 	"github.com/open-policy-agent/opa/internal/gqlparser/gqlerror"
 	"github.com/open-policy-agent/opa/internal/gqlparser/parser"
 	"github.com/open-policy-agent/opa/internal/gqlparser/validator"
-
-	// Side-effecting import. Triggers validation rule init() functions.
 	_ "github.com/open-policy-agent/opa/internal/gqlparser/validator/rules"
 )
 
-func LoadSchema(str ...*ast.Source) (*ast.Schema, *gqlerror.Error) {
+func LoadSchema(str ...*ast.Source) (*ast.Schema, error) {
 	return validator.LoadSchema(append([]*ast.Source{validator.Prelude}, str...)...)
 }
 
@@ -25,7 +23,8 @@ func MustLoadSchema(str ...*ast.Source) *ast.Schema {
 func LoadQuery(schema *ast.Schema, str string) (*ast.QueryDocument, gqlerror.List) {
 	query, err := parser.ParseQuery(&ast.Source{Input: str})
 	if err != nil {
-		return nil, gqlerror.List{err}
+		gqlErr := err.(*gqlerror.Error)
+		return nil, gqlerror.List{gqlErr}
 	}
 	errs := validator.Validate(schema, query)
 	if errs != nil {

--- a/internal/gqlparser/lexer/lexer.go
+++ b/internal/gqlparser/lexer/lexer.go
@@ -37,11 +37,11 @@ func (s *Lexer) peek() (rune, int) {
 	return utf8.DecodeRuneInString(s.Input[s.end:])
 }
 
-func (s *Lexer) makeToken(kind Type) (Token, *gqlerror.Error) {
+func (s *Lexer) makeToken(kind Type) (Token, error) {
 	return s.makeValueToken(kind, s.Input[s.start:s.end])
 }
 
-func (s *Lexer) makeValueToken(kind Type, value string) (Token, *gqlerror.Error) {
+func (s *Lexer) makeValueToken(kind Type, value string) (Token, error) {
 	return Token{
 		Kind:  kind,
 		Value: value,
@@ -55,7 +55,7 @@ func (s *Lexer) makeValueToken(kind Type, value string) (Token, *gqlerror.Error)
 	}, nil
 }
 
-func (s *Lexer) makeError(format string, args ...interface{}) (Token, *gqlerror.Error) {
+func (s *Lexer) makeError(format string, args ...interface{}) (Token, error) {
 	column := s.endRunes - s.lineStartRunes + 1
 	return Token{
 		Kind: Invalid,
@@ -74,7 +74,7 @@ func (s *Lexer) makeError(format string, args ...interface{}) (Token, *gqlerror.
 // This skips over whitespace and comments until it finds the next lexable
 // token, then lexes punctuators immediately or calls the appropriate helper
 // function for more complicated tokens.
-func (s *Lexer) ReadToken() (token Token, err *gqlerror.Error) {
+func (s *Lexer) ReadToken() (token Token, err error) {
 
 	s.ws()
 	s.start = s.end
@@ -121,10 +121,7 @@ func (s *Lexer) ReadToken() (token Token, err *gqlerror.Error) {
 	case '|':
 		return s.makeValueToken(Pipe, "")
 	case '#':
-		comment, err := s.readComment()
-		if err != nil {
-			return comment, err
-		}
+		s.readComment()
 		return s.ReadToken()
 
 	case '_', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z':
@@ -195,7 +192,7 @@ func (s *Lexer) ws() {
 // readComment from the input
 //
 // #[\u0009\u0020-\uFFFF]*
-func (s *Lexer) readComment() (Token, *gqlerror.Error) {
+func (s *Lexer) readComment() (Token, error) {
 	for s.end < len(s.Input) {
 		r, w := s.peek()
 
@@ -216,7 +213,7 @@ func (s *Lexer) readComment() (Token, *gqlerror.Error) {
 //
 // Int:   -?(0|[1-9][0-9]*)
 // Float: -?(0|[1-9][0-9]*)(\.[0-9]+)?((E|e)(+|-)?[0-9]+)?
-func (s *Lexer) readNumber() (Token, *gqlerror.Error) {
+func (s *Lexer) readNumber() (Token, error) {
 	float := false
 
 	// backup to the first digit
@@ -257,8 +254,9 @@ func (s *Lexer) readNumber() (Token, *gqlerror.Error) {
 
 	if float {
 		return s.makeToken(Float)
+	} else {
+		return s.makeToken(Int)
 	}
-	return s.makeToken(Int)
 }
 
 // acceptByte if it matches any of given bytes, returning true if it found anything
@@ -301,7 +299,7 @@ func (s *Lexer) describeNext() string {
 // readString from the input
 //
 // "([^"\\\u000A\u000D]|(\\(u[0-9a-fA-F]{4}|["\\/bfnrt])))*"
-func (s *Lexer) readString() (Token, *gqlerror.Error) {
+func (s *Lexer) readString() (Token, error) {
 	inputLen := len(s.Input)
 
 	// this buffer is lazily created only if there are escape characters.
@@ -395,8 +393,8 @@ func (s *Lexer) readString() (Token, *gqlerror.Error) {
 				case 't':
 					buf.WriteByte('\t')
 				default:
-					s.end++
-					s.endRunes++
+					s.end += 1
+					s.endRunes += 1
 					return s.makeError("Invalid character escape sequence: \\%s.", string(escape))
 				}
 				s.end += 2
@@ -411,7 +409,7 @@ func (s *Lexer) readString() (Token, *gqlerror.Error) {
 // readBlockString from the input
 //
 // """("?"?(\\"""|\\(?!=""")|[^"\\]))*"""
-func (s *Lexer) readBlockString() (Token, *gqlerror.Error) {
+func (s *Lexer) readBlockString() (Token, error) {
 	inputLen := len(s.Input)
 
 	var buf bytes.Buffer
@@ -501,7 +499,7 @@ func unhex(b string) (v rune, ok bool) {
 // readName from the input
 //
 // [_A-Za-z][_0-9A-Za-z]*
-func (s *Lexer) readName() (Token, *gqlerror.Error) {
+func (s *Lexer) readName() (Token, error) {
 	for s.end < len(s.Input) {
 		r, w := s.peek()
 

--- a/internal/gqlparser/lexer/lexer_test.go
+++ b/internal/gqlparser/lexer/lexer_test.go
@@ -1,6 +1,7 @@
 package lexer
 
 import (
+	"github.com/open-policy-agent/opa/internal/gqlparser/gqlerror"
 	"testing"
 
 	"github.com/open-policy-agent/opa/internal/gqlparser/ast"
@@ -16,7 +17,7 @@ func TestLexer(t *testing.T) {
 			tok, err := l.ReadToken()
 
 			if err != nil {
-				ret.Error = err
+				ret.Error = err.(*gqlerror.Error)
 				break
 			}
 

--- a/internal/gqlparser/parser/parser.go
+++ b/internal/gqlparser/parser/parser.go
@@ -10,11 +10,11 @@ import (
 
 type parser struct {
 	lexer lexer.Lexer
-	err   *gqlerror.Error
+	err   error
 
 	peeked    bool
 	peekToken lexer.Token
-	peekError *gqlerror.Error
+	peekError error
 
 	prev lexer.Token
 }

--- a/internal/gqlparser/parser/parser_test.go
+++ b/internal/gqlparser/parser/parser_test.go
@@ -3,9 +3,9 @@ package parser
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"github.com/open-policy-agent/opa/internal/gqlparser/ast"
 	"github.com/open-policy-agent/opa/internal/gqlparser/lexer"
-	"github.com/stretchr/testify/require"
 )
 
 func TestParserUtils(t *testing.T) {

--- a/internal/gqlparser/parser/query.go
+++ b/internal/gqlparser/parser/query.go
@@ -1,14 +1,12 @@
 package parser
 
 import (
-	"github.com/open-policy-agent/opa/internal/gqlparser/gqlerror"
 	"github.com/open-policy-agent/opa/internal/gqlparser/lexer"
 
-	//nolint:revive // Original library used dot imports for convenience.
 	. "github.com/open-policy-agent/opa/internal/gqlparser/ast"
 )
 
-func ParseQuery(source *Source) (*QueryDocument, *gqlerror.Error) {
+func ParseQuery(source *Source) (*QueryDocument, error) {
 	p := parser{
 		lexer: lexer.New(source),
 	}
@@ -338,7 +336,6 @@ func (p *parser) parseTypeReference() *Type {
 	}
 
 	if p.skip(lexer.Bang) {
-		typ.Position = p.peekPos()
 		typ.NonNull = true
 	}
 	return &typ

--- a/internal/gqlparser/parser/query_test.go
+++ b/internal/gqlparser/parser/query_test.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"github.com/open-policy-agent/opa/internal/gqlparser/gqlerror"
 	"testing"
 
 	"github.com/open-policy-agent/opa/internal/gqlparser/ast"
@@ -10,8 +11,14 @@ import (
 func TestQueryDocument(t *testing.T) {
 	testrunner.Test(t, "query_test.yml", func(t *testing.T, input string) testrunner.Spec {
 		doc, err := ParseQuery(&ast.Source{Input: input, Name: "spec"})
+		if err != nil {
+			gqlErr := err.(*gqlerror.Error)
+			return testrunner.Spec{
+				Error: gqlErr,
+				AST:   ast.Dump(doc),
+			}
+		}
 		return testrunner.Spec{
-			Error: err,
 			AST:   ast.Dump(doc),
 		}
 	})

--- a/internal/gqlparser/parser/schema.go
+++ b/internal/gqlparser/parser/schema.go
@@ -1,13 +1,11 @@
 package parser
 
 import (
-	//nolint:revive // Original library used dot imports for convenience.
 	. "github.com/open-policy-agent/opa/internal/gqlparser/ast"
-	"github.com/open-policy-agent/opa/internal/gqlparser/gqlerror"
 	"github.com/open-policy-agent/opa/internal/gqlparser/lexer"
 )
 
-func ParseSchema(source *Source) (*SchemaDocument, *gqlerror.Error) {
+func ParseSchema(source *Source) (*SchemaDocument, error) {
 	p := parser{
 		lexer: lexer.New(source),
 	}
@@ -26,7 +24,7 @@ func ParseSchema(source *Source) (*SchemaDocument, *gqlerror.Error) {
 	return ast, nil
 }
 
-func ParseSchemas(inputs ...*Source) (*SchemaDocument, *gqlerror.Error) {
+func ParseSchemas(inputs ...*Source) (*SchemaDocument, error) {
 	ast := &SchemaDocument{}
 	for _, input := range inputs {
 		inputAst, err := ParseSchema(input)

--- a/internal/gqlparser/parser/schema_test.go
+++ b/internal/gqlparser/parser/schema_test.go
@@ -1,6 +1,8 @@
 package parser
 
 import (
+	"github.com/stretchr/testify/assert"
+	"github.com/open-policy-agent/opa/internal/gqlparser/gqlerror"
 	"testing"
 
 	"github.com/open-policy-agent/opa/internal/gqlparser/ast"
@@ -10,9 +12,37 @@ import (
 func TestSchemaDocument(t *testing.T) {
 	testrunner.Test(t, "schema_test.yml", func(t *testing.T, input string) testrunner.Spec {
 		doc, err := ParseSchema(&ast.Source{Input: input, Name: "spec"})
-		return testrunner.Spec{
-			Error: err,
-			AST:   ast.Dump(doc),
+		if err != nil {
+			return testrunner.Spec{
+				Error: err.(*gqlerror.Error),
+				AST:   ast.Dump(doc),
+			}
 		}
+		return testrunner.Spec{
+			AST: ast.Dump(doc),
+		}
+	})
+}
+
+func TestTypePosition(t *testing.T) {
+	t.Run("type line number with no bang", func(t *testing.T) {
+		schema, parseErr := ParseSchema(&ast.Source{
+			Input: `type query {
+						me: User
+					}
+			`,
+		})
+		assert.Nil(t, parseErr)
+		assert.Equal(t, 2, schema.Definitions.ForName("query").Fields.ForName("me").Type.Position.Line)
+	})
+	t.Run("type line number with bang", func(t *testing.T) {
+		schema, parseErr := ParseSchema(&ast.Source{
+			Input: `type query {
+						me: User!
+					}
+			`,
+		})
+		assert.Nil(t, parseErr)
+		assert.Equal(t, 2, schema.Definitions.ForName("query").Fields.ForName("me").Type.Position.Line)
 	})
 }

--- a/internal/gqlparser/parser/testrunner/runner.go
+++ b/internal/gqlparser/parser/testrunner/runner.go
@@ -55,7 +55,8 @@ func Test(t *testing.T, filename string, f func(t *testing.T, input string) Spec
 
 					if spec.Error == nil {
 						if result.Error != nil {
-							t.Errorf("unexpected error %s", result.Error.Message)
+							gqlErr := err.(*gqlerror.Error)
+							t.Errorf("unexpected error %s", gqlErr.Message)
 						}
 					} else if result.Error == nil {
 						t.Errorf("expected error but got none")

--- a/internal/gqlparser/validator/imported_test.go
+++ b/internal/gqlparser/validator/imported_test.go
@@ -10,10 +10,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"github.com/open-policy-agent/opa/internal/gqlparser"
 	"github.com/open-policy-agent/opa/internal/gqlparser/ast"
 	"github.com/open-policy-agent/opa/internal/gqlparser/gqlerror"
-	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
 )
 
@@ -88,7 +88,7 @@ func runSpec(t *testing.T, schemas []*ast.Schema, deviations []*Deviation, filen
 				// idx := spec.Schema
 				var schema *ast.Schema
 				if idx, err := strconv.Atoi(spec.Schema); err != nil {
-					var gqlErr *gqlerror.Error
+					var gqlErr error
 					schema, gqlErr = gqlparser.LoadSchema(&ast.Source{Input: spec.Schema, Name: spec.Name})
 					if gqlErr != nil {
 						t.Fatal(err)
@@ -96,9 +96,9 @@ func runSpec(t *testing.T, schemas []*ast.Schema, deviations []*Deviation, filen
 				} else {
 					schema = schemas[idx]
 				}
-				_, err := gqlparser.LoadQuery(schema, spec.Query)
+				_, errList := gqlparser.LoadQuery(schema, spec.Query)
 				var finalErrors gqlerror.List
-				for _, err := range err {
+				for _, err := range errList {
 					// ignore errors from other rules
 					if spec.Rule != "" && err.Rule != spec.Rule {
 						continue

--- a/internal/gqlparser/validator/prelude.go
+++ b/internal/gqlparser/validator/prelude.go
@@ -2,7 +2,6 @@ package validator
 
 import (
 	_ "embed"
-
 	"github.com/open-policy-agent/opa/internal/gqlparser/ast"
 )
 

--- a/internal/gqlparser/validator/rules/known_directives.go
+++ b/internal/gqlparser/validator/rules/known_directives.go
@@ -14,7 +14,7 @@ func init() {
 			Line   int
 			Column int
 		}
-		var seen = map[mayNotBeUsedDirective]bool{}
+		var seen map[mayNotBeUsedDirective]bool = map[mayNotBeUsedDirective]bool{}
 		observers.OnDirective(func(walker *Walker, directive *ast.Directive) {
 			if directive.Definition == nil {
 				addError(

--- a/internal/gqlparser/validator/schema.go
+++ b/internal/gqlparser/validator/schema.go
@@ -5,13 +5,12 @@ import (
 	"strconv"
 	"strings"
 
-	//nolint:revive // Original library used dot imports for convenience.
 	. "github.com/open-policy-agent/opa/internal/gqlparser/ast"
 	"github.com/open-policy-agent/opa/internal/gqlparser/gqlerror"
 	"github.com/open-policy-agent/opa/internal/gqlparser/parser"
 )
 
-func LoadSchema(inputs ...*Source) (*Schema, *gqlerror.Error) {
+func LoadSchema(inputs ...*Source) (*Schema, error) {
 	ast, err := parser.ParseSchemas(inputs...)
 	if err != nil {
 		return nil, err
@@ -19,7 +18,7 @@ func LoadSchema(inputs ...*Source) (*Schema, *gqlerror.Error) {
 	return ValidateSchemaDocument(ast)
 }
 
-func ValidateSchemaDocument(ast *SchemaDocument) (*Schema, *gqlerror.Error) {
+func ValidateSchemaDocument(ast *SchemaDocument) (*Schema, error) {
 	schema := Schema{
 		Types:         map[string]*Definition{},
 		Directives:    map[string]*DirectiveDefinition{},

--- a/internal/gqlparser/validator/schema_test.go
+++ b/internal/gqlparser/validator/schema_test.go
@@ -1,12 +1,13 @@
 package validator
 
 import (
+	"github.com/open-policy-agent/opa/internal/gqlparser/gqlerror"
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"github.com/open-policy-agent/opa/internal/gqlparser/ast"
 	"github.com/open-policy-agent/opa/internal/gqlparser/parser/testrunner"
-	"github.com/stretchr/testify/require"
 )
 
 func TestLoadSchema(t *testing.T) {
@@ -97,9 +98,12 @@ func TestLoadSchema(t *testing.T) {
 
 	testrunner.Test(t, "./schema_test.yml", func(t *testing.T, input string) testrunner.Spec {
 		_, err := LoadSchema(Prelude, &ast.Source{Input: input})
-		return testrunner.Spec{
-			Error: err,
+		if err != nil {
+			return testrunner.Spec{
+				Error: err.(*gqlerror.Error),
+			}
 		}
+		return testrunner.Spec{}
 	})
 }
 

--- a/internal/gqlparser/validator/validator.go
+++ b/internal/gqlparser/validator/validator.go
@@ -1,7 +1,6 @@
 package validator
 
 import (
-	//nolint:revive // Original library used dot imports for convenience.
 	. "github.com/open-policy-agent/opa/internal/gqlparser/ast"
 	"github.com/open-policy-agent/opa/internal/gqlparser/gqlerror"
 )

--- a/internal/gqlparser/validator/validator_test.go
+++ b/internal/gqlparser/validator/validator_test.go
@@ -3,11 +3,11 @@ package validator_test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"github.com/open-policy-agent/opa/internal/gqlparser"
 	"github.com/open-policy-agent/opa/internal/gqlparser/ast"
 	"github.com/open-policy-agent/opa/internal/gqlparser/parser"
 	"github.com/open-policy-agent/opa/internal/gqlparser/validator"
-	"github.com/stretchr/testify/require"
 )
 
 func TestExtendingNonExistantTypes(t *testing.T) {

--- a/internal/gqlparser/validator/vars.go
+++ b/internal/gqlparser/validator/vars.go
@@ -11,10 +11,10 @@ import (
 	"github.com/open-policy-agent/opa/internal/gqlparser/gqlerror"
 )
 
-var ErrorUnexpectedType = fmt.Errorf("Unexpected Type")
+var UnexpectedType = fmt.Errorf("Unexpected Type")
 
 // VariableValues coerces and validates variable values
-func VariableValues(schema *ast.Schema, op *ast.OperationDefinition, variables map[string]interface{}) (map[string]interface{}, *gqlerror.Error) {
+func VariableValues(schema *ast.Schema, op *ast.OperationDefinition, variables map[string]interface{}) (map[string]interface{}, error) {
 	coercedVars := map[string]interface{}{}
 
 	validator := varValidator{
@@ -53,8 +53,8 @@ func VariableValues(schema *ast.Schema, op *ast.OperationDefinition, variables m
 			} else {
 				rv := reflect.ValueOf(val)
 
-				jsonNumber, isJSONumber := val.(json.Number)
-				if isJSONumber {
+				jsonNumber, isJsonNumber := val.(json.Number)
+				if isJsonNumber {
 					if v.Type.NamedType == "Int" {
 						n, err := jsonNumber.Int64()
 						if err != nil {

--- a/internal/gqlparser/validator/walk_test.go
+++ b/internal/gqlparser/validator/walk_test.go
@@ -3,9 +3,9 @@ package validator
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"github.com/open-policy-agent/opa/internal/gqlparser/ast"
 	"github.com/open-policy-agent/opa/internal/gqlparser/parser"
-	"github.com/stretchr/testify/require"
 )
 
 func TestWalker(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Yuri Kulagin <jkulvichi@gmail.com>

Added 2 methods:
graphql.is_valid_schema(string): bool
graphql.validate_schema(string): {error: string, is_valid: bool}


<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->
