### PR TITLE
Add `prealloc` linter check + linter fixes

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -25,4 +25,5 @@ linters:
     - structcheck
     - staticcheck
     - gosimple
+    - prealloc
     # - gosec # too many false positives

--- a/ast/annotations.go
+++ b/ast/annotations.go
@@ -639,7 +639,8 @@ func (as *AnnotationSet) GetPackageScope(pkg *Package) *Annotations {
 // Flatten returns a flattened list view of this AnnotationSet.
 // The returned slice is sorted, first by the annotations' target path, then by their target location
 func (as *AnnotationSet) Flatten() []*AnnotationsRef {
-	var refs []*AnnotationsRef
+	// This preallocation often won't be optimal, but it's superior to starting with a nil slice.
+	var refs = make([]*AnnotationsRef, 0, len(as.byPath.Children)+len(as.byRule)+len(as.byPackage))
 
 	refs = as.byPath.flatten(refs)
 

--- a/ast/annotations.go
+++ b/ast/annotations.go
@@ -640,7 +640,7 @@ func (as *AnnotationSet) GetPackageScope(pkg *Package) *Annotations {
 // The returned slice is sorted, first by the annotations' target path, then by their target location
 func (as *AnnotationSet) Flatten() []*AnnotationsRef {
 	// This preallocation often won't be optimal, but it's superior to starting with a nil slice.
-	var refs = make([]*AnnotationsRef, 0, len(as.byPath.Children)+len(as.byRule)+len(as.byPackage))
+	refs := make([]*AnnotationsRef, 0, len(as.byPath.Children)+len(as.byRule)+len(as.byPackage))
 
 	refs = as.byPath.flatten(refs)
 

--- a/ast/check_test.go
+++ b/ast/check_test.go
@@ -1255,7 +1255,9 @@ func newTestEnv(rs []string) *TypeEnv {
 		package test
 	`)
 
-	var elems []util.T
+	// We preallocate enough for at least the base rules.
+	// Else cases will cause reallocs, but that's okay.
+	var elems = make([]util.T, 0, len(rs))
 
 	for i := range rs {
 		rule := MustParseRule(rs[i])

--- a/ast/check_test.go
+++ b/ast/check_test.go
@@ -1257,7 +1257,7 @@ func newTestEnv(rs []string) *TypeEnv {
 
 	// We preallocate enough for at least the base rules.
 	// Else cases will cause reallocs, but that's okay.
-	var elems = make([]util.T, 0, len(rs))
+	elems := make([]util.T, 0, len(rs))
 
 	for i := range rs {
 		rule := MustParseRule(rs[i])

--- a/ast/compile_test.go
+++ b/ast/compile_test.go
@@ -676,7 +676,7 @@ func TestCompilerErrorLimit(t *testing.T) {
 		"rego_compile_error: error limit reached",
 	}
 
-	var result = make([]string, 0, len(errs))
+	result := make([]string, 0, len(errs))
 	for _, err := range errs {
 		result = append(result, err.Error())
 	}

--- a/ast/compile_test.go
+++ b/ast/compile_test.go
@@ -676,7 +676,7 @@ func TestCompilerErrorLimit(t *testing.T) {
 		"rego_compile_error: error limit reached",
 	}
 
-	var result []string
+	var result = make([]string, 0, len(errs))
 	for _, err := range errs {
 		result = append(result, err.Error())
 	}

--- a/ast/policy.go
+++ b/ast/policy.go
@@ -787,7 +787,7 @@ func (a Args) Copy() Args {
 }
 
 func (a Args) String() string {
-	var buf = make([]string, 0, len(a))
+	buf := make([]string, 0, len(a))
 	for _, t := range a {
 		buf = append(buf, t.String())
 	}
@@ -931,7 +931,7 @@ func (body Body) SetLoc(loc *Location) {
 }
 
 func (body Body) String() string {
-	var buf = make([]string, 0, len(body))
+	buf := make([]string, 0, len(body))
 	for _, v := range body {
 		buf = append(buf, v.String())
 	}
@@ -1238,7 +1238,7 @@ func (expr *Expr) SetLoc(loc *Location) {
 }
 
 func (expr *Expr) String() string {
-	var buf = make([]string, 0, 2+len(expr.With))
+	buf := make([]string, 0, 2+len(expr.With))
 	if expr.Negated {
 		buf = append(buf, "not")
 	}

--- a/ast/policy.go
+++ b/ast/policy.go
@@ -787,7 +787,7 @@ func (a Args) Copy() Args {
 }
 
 func (a Args) String() string {
-	var buf []string
+	var buf = make([]string, 0, len(a))
 	for _, t := range a {
 		buf = append(buf, t.String())
 	}
@@ -931,7 +931,7 @@ func (body Body) SetLoc(loc *Location) {
 }
 
 func (body Body) String() string {
-	var buf []string
+	var buf = make([]string, 0, len(body))
 	for _, v := range body {
 		buf = append(buf, v.String())
 	}
@@ -1238,7 +1238,7 @@ func (expr *Expr) SetLoc(loc *Location) {
 }
 
 func (expr *Expr) String() string {
-	var buf []string
+	var buf = make([]string, 0, 2+len(expr.With))
 	if expr.Negated {
 		buf = append(buf, "not")
 	}

--- a/build/generate-cli-docs/generate.go
+++ b/build/generate-cli-docs/generate.go
@@ -73,7 +73,7 @@ func main() {
 
 	heading := regexp.MustCompile(`^[\\-]+$`)
 	lines := strings.Split(builder.String(), "\n")
-	var document = make([]string, 0, len(lines))
+	document := make([]string, 0, len(lines))
 	removed := 0
 
 	// The document may contain "----" for headings, which will be converted to h1

--- a/build/generate-cli-docs/generate.go
+++ b/build/generate-cli-docs/generate.go
@@ -72,13 +72,14 @@ func main() {
 	}
 
 	heading := regexp.MustCompile(`^[\\-]+$`)
-	var document []string
+	lines := strings.Split(builder.String(), "\n")
+	var document = make([]string, 0, len(lines))
 	removed := 0
 
 	// The document may contain "----" for headings, which will be converted to h1
 	// elements in markdown. This is undesirable, so let's remove them and prepend
 	// the line before that with ### to instead create a h3
-	for line, str := range strings.Split(builder.String(), "\n") {
+	for line, str := range lines {
 		if heading.Match([]byte(str)) {
 			document[line-1-removed] = fmt.Sprintf("### %s\n", document[line-1-removed])
 			removed++

--- a/bundle/file_test.go
+++ b/bundle/file_test.go
@@ -49,7 +49,7 @@ func TestTarballLoader(t *testing.T) {
 
 func TestIterator(t *testing.T) {
 
-	var files [][2]string
+	var files = make([][2]string, 0, len(archiveFiles))
 	for name, content := range archiveFiles {
 		files = append(files, [2]string{name, content})
 	}
@@ -91,7 +91,7 @@ func TestIteratorOrder(t *testing.T) {
 		"/roles/policy.rego":   "package bar\n p = 1",
 	}
 
-	var files [][2]string
+	var files = make([][2]string, 0, len(archFiles))
 	for name, content := range archFiles {
 		files = append(files, [2]string{name, content})
 	}
@@ -170,7 +170,7 @@ func TestTarballLoaderWithFilter(t *testing.T) {
 			t.Fatalf("Unexpected error: %s", err)
 		}
 
-		var gzFiles [][2]string
+		var gzFiles = make([][2]string, 0, len(files))
 		for name, content := range files {
 			gzFiles = append(gzFiles, [2]string{name, content})
 		}
@@ -222,7 +222,7 @@ func TestTarballLoaderWithFilterDir(t *testing.T) {
 			t.Fatalf("Unexpected error: %s", err)
 		}
 
-		var gzFiles [][2]string
+		var gzFiles = make([][2]string, 0, len(files))
 		for name, content := range files {
 			gzFiles = append(gzFiles, [2]string{name, content})
 		}
@@ -389,7 +389,7 @@ func testGetTarballFile(t *testing.T, root string) *os.File {
 		t.Fatalf("Unexpected error: %s", err)
 	}
 
-	var gzFiles [][2]string
+	var gzFiles = make([][2]string, 0, len(archiveFiles))
 	for name, content := range archiveFiles {
 		gzFiles = append(gzFiles, [2]string{name, content})
 	}

--- a/bundle/file_test.go
+++ b/bundle/file_test.go
@@ -49,7 +49,7 @@ func TestTarballLoader(t *testing.T) {
 
 func TestIterator(t *testing.T) {
 
-	var files = make([][2]string, 0, len(archiveFiles))
+	files := make([][2]string, 0, len(archiveFiles))
 	for name, content := range archiveFiles {
 		files = append(files, [2]string{name, content})
 	}
@@ -91,7 +91,7 @@ func TestIteratorOrder(t *testing.T) {
 		"/roles/policy.rego":   "package bar\n p = 1",
 	}
 
-	var files = make([][2]string, 0, len(archFiles))
+	files := make([][2]string, 0, len(archFiles))
 	for name, content := range archFiles {
 		files = append(files, [2]string{name, content})
 	}
@@ -170,7 +170,7 @@ func TestTarballLoaderWithFilter(t *testing.T) {
 			t.Fatalf("Unexpected error: %s", err)
 		}
 
-		var gzFiles = make([][2]string, 0, len(files))
+		gzFiles := make([][2]string, 0, len(files))
 		for name, content := range files {
 			gzFiles = append(gzFiles, [2]string{name, content})
 		}
@@ -222,7 +222,7 @@ func TestTarballLoaderWithFilterDir(t *testing.T) {
 			t.Fatalf("Unexpected error: %s", err)
 		}
 
-		var gzFiles = make([][2]string, 0, len(files))
+		gzFiles := make([][2]string, 0, len(files))
 		for name, content := range files {
 			gzFiles = append(gzFiles, [2]string{name, content})
 		}
@@ -389,7 +389,7 @@ func testGetTarballFile(t *testing.T, root string) *os.File {
 		t.Fatalf("Unexpected error: %s", err)
 	}
 
-	var gzFiles = make([][2]string, 0, len(archiveFiles))
+	gzFiles := make([][2]string, 0, len(archiveFiles))
 	for name, content := range archiveFiles {
 		gzFiles = append(gzFiles, [2]string{name, content})
 	}

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -177,7 +177,7 @@ func populateNamespaces(out io.Writer, n map[string][]string) error {
 	t.SetAutoMergeCellsByColumnIndex([]int{0})
 	var lines [][]string
 
-	var keys = make([]string, 0, len(n))
+	keys := make([]string, 0, len(n))
 	for k := range n {
 		keys = append(keys, k)
 	}
@@ -334,7 +334,7 @@ func printTitle(out io.Writer, ref *ast.AnnotationsRef) {
 func generateTableWithKeys(writer io.Writer, keys ...string) *tablewriter.Table {
 	table := tablewriter.NewWriter(writer)
 	aligns := []int{}
-	var hdrs = make([]string, 0, len(keys))
+	hdrs := make([]string, 0, len(keys))
 	for _, k := range keys {
 		hdrs = append(hdrs, strings.Title(k)) //nolint:staticcheck // SA1019, no unicode
 		aligns = append(aligns, tablewriter.ALIGN_LEFT)

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -177,7 +177,7 @@ func populateNamespaces(out io.Writer, n map[string][]string) error {
 	t.SetAutoMergeCellsByColumnIndex([]int{0})
 	var lines [][]string
 
-	var keys []string
+	var keys = make([]string, 0, len(n))
 	for k := range n {
 		keys = append(keys, k)
 	}
@@ -334,7 +334,7 @@ func printTitle(out io.Writer, ref *ast.AnnotationsRef) {
 func generateTableWithKeys(writer io.Writer, keys ...string) *tablewriter.Table {
 	table := tablewriter.NewWriter(writer)
 	aligns := []int{}
-	var hdrs []string
+	var hdrs = make([]string, 0, len(keys))
 	for _, k := range keys {
 		hdrs = append(hdrs, strings.Title(k)) //nolint:staticcheck // SA1019, no unicode
 		aligns = append(aligns, tablewriter.ALIGN_LEFT)

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -78,7 +78,7 @@ func expectOutputKeys(t *testing.T, stdout string, expectedKeys []string) {
 	t.Helper()
 
 	lines := strings.Split(strings.Trim(stdout, "\n"), "\n")
-	var gotKeys = make([]string, 0, len(lines))
+	gotKeys := make([]string, 0, len(lines))
 
 	for _, line := range lines {
 		gotKeys = append(gotKeys, strings.Split(line, ":")[0])

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -77,9 +77,10 @@ func TestCheckOPAUpdateBadURL(t *testing.T) {
 func expectOutputKeys(t *testing.T, stdout string, expectedKeys []string) {
 	t.Helper()
 
-	var gotKeys []string
+	lines := strings.Split(strings.Trim(stdout, "\n"), "\n")
+	var gotKeys = make([]string, 0, len(lines))
 
-	for _, line := range strings.Split(strings.Trim(stdout, "\n"), "\n") {
+	for _, line := range lines {
 		gotKeys = append(gotKeys, strings.Split(line, ":")[0])
 	}
 

--- a/compile/compile.go
+++ b/compile/compile.go
@@ -372,7 +372,7 @@ func (c *Compiler) initBundle() error {
 	result.Manifest.Init()
 	result.Data = load.Files.Documents
 
-	var modules = make([]string, 0, len(load.Files.Modules))
+	modules := make([]string, 0, len(load.Files.Modules))
 
 	for k := range load.Files.Modules {
 		modules = append(modules, k)
@@ -824,7 +824,7 @@ func (o *optimizer) findRequiredDocuments(ref *ast.Term) []string {
 		})
 	}
 
-	var result = make([]string, 0, len(keep))
+	result := make([]string, 0, len(keep))
 
 	for k := range keep {
 		result = append(result, k)

--- a/compile/compile.go
+++ b/compile/compile.go
@@ -372,7 +372,7 @@ func (c *Compiler) initBundle() error {
 	result.Manifest.Init()
 	result.Data = load.Files.Documents
 
-	var modules []string
+	var modules = make([]string, 0, len(load.Files.Modules))
 
 	for k := range load.Files.Modules {
 		modules = append(modules, k)
@@ -824,7 +824,7 @@ func (o *optimizer) findRequiredDocuments(ref *ast.Term) []string {
 		})
 	}
 
-	var result []string
+	var result = make([]string, 0, len(keep))
 
 	for k := range keep {
 		result = append(result, k)

--- a/compile/compile_test.go
+++ b/compile/compile_test.go
@@ -1525,14 +1525,14 @@ func getOptimizer(modules map[string]string, data string, entries []string, root
 
 func getModuleFiles(src map[string]string, includeRaw bool) []bundle.ModuleFile {
 
-	var keys = make([]string, 0, len(src))
+	keys := make([]string, 0, len(src))
 
 	for k := range src {
 		keys = append(keys, k)
 	}
 
 	sort.Strings(keys)
-	var modules = make([]bundle.ModuleFile, 0, len(keys))
+	modules := make([]bundle.ModuleFile, 0, len(keys))
 
 	for _, k := range keys {
 		module, err := ast.ParseModule(k, src[k])

--- a/compile/compile_test.go
+++ b/compile/compile_test.go
@@ -1525,14 +1525,14 @@ func getOptimizer(modules map[string]string, data string, entries []string, root
 
 func getModuleFiles(src map[string]string, includeRaw bool) []bundle.ModuleFile {
 
-	var keys []string
+	var keys = make([]string, 0, len(src))
 
 	for k := range src {
 		keys = append(keys, k)
 	}
 
 	sort.Strings(keys)
-	var modules []bundle.ModuleFile
+	var modules = make([]bundle.ModuleFile, 0, len(keys))
 
 	for _, k := range keys {
 		module, err := ast.ParseModule(k, src[k])

--- a/format/format.go
+++ b/format/format.go
@@ -854,7 +854,7 @@ func (w *writer) writeComprehension(open, close byte, term *ast.Term, body ast.B
 }
 
 func (w *writer) writeComprehensionBody(open, close byte, body ast.Body, term, compr *ast.Location, comments []*ast.Comment) []*ast.Comment {
-	var exprs = make([]interface{}, 0, len(body))
+	exprs := make([]interface{}, 0, len(body))
 	for _, expr := range body {
 		exprs = append(exprs, expr)
 	}
@@ -1004,7 +1004,7 @@ func groupIterable(elements []interface{}, last *ast.Location) [][]interface{} {
 	})
 
 	var lines [][]interface{}
-	var cur = make([]interface{}, 0, len(elements))
+	cur := make([]interface{}, 0, len(elements))
 	for i, t := range elements {
 		elem := t
 		loc := getLoc(elem)

--- a/format/format.go
+++ b/format/format.go
@@ -854,7 +854,7 @@ func (w *writer) writeComprehension(open, close byte, term *ast.Term, body ast.B
 }
 
 func (w *writer) writeComprehensionBody(open, close byte, body ast.Body, term, compr *ast.Location, comments []*ast.Comment) []*ast.Comment {
-	var exprs []interface{}
+	var exprs = make([]interface{}, 0, len(body))
 	for _, expr := range body {
 		exprs = append(exprs, expr)
 	}
@@ -1004,7 +1004,7 @@ func groupIterable(elements []interface{}, last *ast.Location) [][]interface{} {
 	})
 
 	var lines [][]interface{}
-	var cur []interface{}
+	var cur = make([]interface{}, 0, len(elements))
 	for i, t := range elements {
 		elem := t
 		loc := getLoc(elem)

--- a/internal/bundle/inspect/inspect.go
+++ b/internal/bundle/inspect/inspect.go
@@ -39,7 +39,7 @@ func File(path string, includeAnnotations bool) (*Info, error) {
 	bi := &Info{Manifest: b.Manifest}
 
 	namespaces := make(map[string][]string, len(b.Modules))
-	var modules = make([]*ast.Module, 0, len(b.Modules))
+	modules := make([]*ast.Module, 0, len(b.Modules))
 	for _, m := range b.Modules {
 		namespaces[m.Parsed.Package.Path.String()] = append(namespaces[m.Parsed.Package.Path.String()], filepath.Clean(m.Path))
 		modules = append(modules, m.Parsed)

--- a/internal/bundle/inspect/inspect.go
+++ b/internal/bundle/inspect/inspect.go
@@ -39,7 +39,7 @@ func File(path string, includeAnnotations bool) (*Info, error) {
 	bi := &Info{Manifest: b.Manifest}
 
 	namespaces := make(map[string][]string, len(b.Modules))
-	var modules []*ast.Module
+	var modules = make([]*ast.Module, 0, len(b.Modules))
 	for _, m := range b.Modules {
 		namespaces[m.Parsed.Package.Path.String()] = append(namespaces[m.Parsed.Package.Path.String()], filepath.Clean(m.Path))
 		modules = append(modules, m.Parsed)

--- a/internal/compiler/wasm/wasm.go
+++ b/internal/compiler/wasm/wasm.go
@@ -897,7 +897,7 @@ func mapFunc(mapping ast.Object, fn *ir.Func, index int) (ast.Object, bool) {
 }
 
 func (c *Compiler) emitMappingAndStartFunc() error {
-	var indices = make([]uint32, 0, len(c.policy.Funcs.Funcs))
+	indices := make([]uint32, 0, len(c.policy.Funcs.Funcs))
 	var ok bool
 	mapping := ast.NewObject()
 

--- a/internal/compiler/wasm/wasm.go
+++ b/internal/compiler/wasm/wasm.go
@@ -897,7 +897,7 @@ func mapFunc(mapping ast.Object, fn *ir.Func, index int) (ast.Object, bool) {
 }
 
 func (c *Compiler) emitMappingAndStartFunc() error {
-	var indices []uint32
+	var indices = make([]uint32, 0, len(c.policy.Funcs.Funcs))
 	var ok bool
 	mapping := ast.NewObject()
 

--- a/internal/gqlparser/validator/imported_test.go
+++ b/internal/gqlparser/validator/imported_test.go
@@ -43,7 +43,7 @@ func TestValidation(t *testing.T) {
 		d.pattern = regexp.MustCompile("^" + d.Rule + "$")
 	}
 
-	var schemas []*ast.Schema
+	var schemas = make([]*ast.Schema, 0, len(rawSchemas))
 	for i, schema := range rawSchemas {
 		schema, err := gqlparser.LoadSchema(&ast.Source{Input: schema, Name: fmt.Sprintf("schemas.yml[%d]", i)})
 		if err != nil {

--- a/internal/gqlparser/validator/imported_test.go
+++ b/internal/gqlparser/validator/imported_test.go
@@ -43,7 +43,7 @@ func TestValidation(t *testing.T) {
 		d.pattern = regexp.MustCompile("^" + d.Rule + "$")
 	}
 
-	var schemas = make([]*ast.Schema, 0, len(rawSchemas))
+	schemas := make([]*ast.Schema, 0, len(rawSchemas))
 	for i, schema := range rawSchemas {
 		schema, err := gqlparser.LoadSchema(&ast.Source{Input: schema, Name: fmt.Sprintf("schemas.yml[%d]", i)})
 		if err != nil {

--- a/internal/gqlparser/validator/rules/fields_on_correct_type.go
+++ b/internal/gqlparser/validator/rules/fields_on_correct_type.go
@@ -43,11 +43,12 @@ func getSuggestedTypeNames(walker *Walker, parent *ast.Definition, name string) 
 		return nil
 	}
 
-	var suggestedObjectTypes []string
+	possibleTypes := walker.Schema.GetPossibleTypes(parent)
+	var suggestedObjectTypes = make([]string, 0, len(possibleTypes))
 	var suggestedInterfaceTypes []string
 	interfaceUsageCount := map[string]int{}
 
-	for _, possibleType := range walker.Schema.GetPossibleTypes(parent) {
+	for _, possibleType := range possibleTypes {
 		field := possibleType.Fields.ForName(name)
 		if field == nil {
 			continue
@@ -87,7 +88,7 @@ func getSuggestedFieldNames(parent *ast.Definition, name string) []string {
 		return nil
 	}
 
-	var possibleFieldNames []string
+	var possibleFieldNames = make([]string, 0, len(parent.Fields))
 	for _, field := range parent.Fields {
 		possibleFieldNames = append(possibleFieldNames, field.Name)
 	}

--- a/internal/gqlparser/validator/rules/fields_on_correct_type.go
+++ b/internal/gqlparser/validator/rules/fields_on_correct_type.go
@@ -44,7 +44,7 @@ func getSuggestedTypeNames(walker *Walker, parent *ast.Definition, name string) 
 	}
 
 	possibleTypes := walker.Schema.GetPossibleTypes(parent)
-	var suggestedObjectTypes = make([]string, 0, len(possibleTypes))
+	suggestedObjectTypes := make([]string, 0, len(possibleTypes))
 	var suggestedInterfaceTypes []string
 	interfaceUsageCount := map[string]int{}
 
@@ -88,7 +88,7 @@ func getSuggestedFieldNames(parent *ast.Definition, name string) []string {
 		return nil
 	}
 
-	var possibleFieldNames = make([]string, 0, len(parent.Fields))
+	possibleFieldNames := make([]string, 0, len(parent.Fields))
 	for _, field := range parent.Fields {
 		possibleFieldNames = append(possibleFieldNames, field.Name)
 	}

--- a/internal/presentation/presentation.go
+++ b/internal/presentation/presentation.go
@@ -224,7 +224,7 @@ func (e OutputErrors) Error() string {
 	}
 
 	// We preallocate for at least the minimum number of strings.
-	var s = make([]string, 0, len(e))
+	s := make([]string, 0, len(e))
 	for _, err := range e {
 		s = append(s, err.Error())
 		if l, ok := err.Details.(string); ok {
@@ -599,7 +599,7 @@ func generateTableMetrics(writer io.Writer) *tablewriter.Table {
 func generateTableWithKeys(writer io.Writer, keys ...string) *tablewriter.Table {
 	table := tablewriter.NewWriter(writer)
 	aligns := make([]int, 0, len(keys))
-	var hdrs = make([]string, 0, len(keys))
+	hdrs := make([]string, 0, len(keys))
 	for _, k := range keys {
 		hdrs = append(hdrs, strings.Title(k)) //nolint:staticcheck // SA1019, no unicode here
 		aligns = append(aligns, tablewriter.ALIGN_LEFT)

--- a/internal/presentation/presentation.go
+++ b/internal/presentation/presentation.go
@@ -223,7 +223,8 @@ func (e OutputErrors) Error() string {
 		prefix = fmt.Sprintf("%d errors occurred:\n", len(e))
 	}
 
-	var s []string
+	// We preallocate for at least the minimum number of strings.
+	var s = make([]string, 0, len(e))
 	for _, err := range e {
 		s = append(s, err.Error())
 		if l, ok := err.Details.(string); ok {
@@ -597,8 +598,8 @@ func generateTableMetrics(writer io.Writer) *tablewriter.Table {
 
 func generateTableWithKeys(writer io.Writer, keys ...string) *tablewriter.Table {
 	table := tablewriter.NewWriter(writer)
-	aligns := []int{}
-	var hdrs []string
+	aligns := make([]int, 0, len(keys))
+	var hdrs = make([]string, 0, len(keys))
 	for _, k := range keys {
 		hdrs = append(hdrs, strings.Title(k)) //nolint:staticcheck // SA1019, no unicode here
 		aligns = append(aligns, tablewriter.ALIGN_LEFT)

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -137,9 +137,10 @@ func (dr *DataResponse) Pretty() string {
 		return ""
 	}
 
-	var lines []string
+	pairs := dr.Slice()
+	var lines = make([]string, 0, len(pairs))
 
-	for _, pair := range dr.Slice() {
+	for _, pair := range pairs {
 		lines = append(lines, fmt.Sprintf("%v: %v", pair[0], pair[1]))
 	}
 

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -138,7 +138,7 @@ func (dr *DataResponse) Pretty() string {
 	}
 
 	pairs := dr.Slice()
-	var lines = make([]string, 0, len(pairs))
+	lines := make([]string, 0, len(pairs))
 
 	for _, pair := range pairs {
 		lines = append(lines, fmt.Sprintf("%v: %v", pair[0], pair[1]))

--- a/internal/strings/strings.go
+++ b/internal/strings/strings.go
@@ -16,7 +16,7 @@ import (
 // "ideal" width and returns the shortened paths by replacing the middle parts of paths
 // with "...", ex: bundle1/.../a/b/policy.rego
 func TruncateFilePaths(maxIdealWidth, maxWidth int, path ...string) (map[string]string, int) {
-	var canShorten [][]byte
+	canShorten := make([][]byte, 0, len(path))
 
 	for _, p := range path {
 		canShorten = append(canShorten, []byte(getPathFromFirstSeparator(p)))

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -501,7 +501,7 @@ func Dirs(paths []string) []string {
 		unique[dir] = struct{}{}
 	}
 
-	var u = make([]string, 0, len(unique))
+	u := make([]string, 0, len(unique))
 	for k := range unique {
 		u = append(u, k)
 	}

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -501,7 +501,7 @@ func Dirs(paths []string) []string {
 		unique[dir] = struct{}{}
 	}
 
-	var u []string
+	var u = make([]string, 0, len(unique))
 	for k := range unique {
 		u = append(u, k)
 	}

--- a/profiler/profiler.go
+++ b/profiler/profiler.go
@@ -240,7 +240,7 @@ func aggregate(stats ...ExprStats) ExprStatsAggregated {
 		NumRedo:  stats[0].NumRedo,
 		Location: stats[0].Location,
 	}
-	var timeNs = make([]int64, 0, len(stats))
+	timeNs := make([]int64, 0, len(stats))
 	for _, s := range stats {
 		timeNs = append(timeNs, s.ExprTimeNs)
 	}

--- a/profiler/profiler.go
+++ b/profiler/profiler.go
@@ -240,7 +240,7 @@ func aggregate(stats ...ExprStats) ExprStatsAggregated {
 		NumRedo:  stats[0].NumRedo,
 		Location: stats[0].Location,
 	}
-	var timeNs []int64
+	var timeNs = make([]int64, 0, len(stats))
 	for _, s := range stats {
 		timeNs = append(timeNs, s.ExprTimeNs)
 	}

--- a/rego/rego_test.go
+++ b/rego/rego_test.go
@@ -1571,7 +1571,7 @@ func TestPreparedQueryGetModules(t *testing.T) {
 		"c.rego": "package c\nr = 1",
 	}
 
-	var regoArgs = make([]func(r *Rego), 0, len(mods)+1)
+	regoArgs := make([]func(r *Rego), 0, len(mods)+1)
 
 	for name, mod := range mods {
 		regoArgs = append(regoArgs, Module(name, mod))

--- a/rego/rego_test.go
+++ b/rego/rego_test.go
@@ -1571,7 +1571,7 @@ func TestPreparedQueryGetModules(t *testing.T) {
 		"c.rego": "package c\nr = 1",
 	}
 
-	var regoArgs []func(r *Rego)
+	var regoArgs = make([]func(r *Rego), 0, len(mods)+1)
 
 	for name, mod := range mods {
 		regoArgs = append(regoArgs, Module(name, mod))

--- a/sdk/test/test.go
+++ b/sdk/test/test.go
@@ -111,7 +111,7 @@ func (s *Server) URL() string {
 // Builds the tarball from the supplied policies and prepares the layers in a temporary directory
 func (s *Server) buildBundles(ref string, policies map[string]string) error {
 	// Prepare the modules to include in the bundle. Sort them so bundles are deterministic.
-	var modules = make([]bundle.ModuleFile, 0, len(policies))
+	modules := make([]bundle.ModuleFile, 0, len(policies))
 	for url, str := range policies {
 		module, err := ast.ParseModule(url, str)
 		if err != nil {
@@ -364,7 +364,7 @@ func (s *Server) handleBundles(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Prepare the modules to include in the bundle. Sort them so bundles are deterministic.
-	var modules = make([]bundle.ModuleFile, 0, len(b))
+	modules := make([]bundle.ModuleFile, 0, len(b))
 	for url, str := range b {
 		module, err := ast.ParseModule(url, str)
 		if err != nil {

--- a/sdk/test/test.go
+++ b/sdk/test/test.go
@@ -111,7 +111,7 @@ func (s *Server) URL() string {
 // Builds the tarball from the supplied policies and prepares the layers in a temporary directory
 func (s *Server) buildBundles(ref string, policies map[string]string) error {
 	// Prepare the modules to include in the bundle. Sort them so bundles are deterministic.
-	var modules []bundle.ModuleFile
+	var modules = make([]bundle.ModuleFile, 0, len(policies))
 	for url, str := range policies {
 		module, err := ast.ParseModule(url, str)
 		if err != nil {
@@ -364,7 +364,7 @@ func (s *Server) handleBundles(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Prepare the modules to include in the bundle. Sort them so bundles are deterministic.
-	var modules []bundle.ModuleFile
+	var modules = make([]bundle.ModuleFile, 0, len(b))
 	for url, str := range b {
 		module, err := ast.ParseModule(url, str)
 		if err != nil {

--- a/storage/disk/disk_test.go
+++ b/storage/disk/disk_test.go
@@ -202,7 +202,7 @@ func runTruncateTest(t *testing.T, dir string) {
 		"/roles/policy.rego": "package bar\n p = 1",
 	}
 
-	var files [][2]string
+	var files = make([][2]string, 0, len(archiveFiles))
 	for name, content := range archiveFiles {
 		files = append(files, [2]string{name, content})
 	}
@@ -334,7 +334,7 @@ func TestTruncateMultipleTxn(t *testing.T) {
 		// additional data file at root
 		archiveFiles["/data.json"] = `{"a": {"b": {"z": true}}}}`
 
-		var files [][2]string
+		var files = make([][2]string, 0, len(archiveFiles))
 		for name, content := range archiveFiles {
 			files = append(files, [2]string{name, content})
 		}

--- a/storage/disk/disk_test.go
+++ b/storage/disk/disk_test.go
@@ -202,7 +202,7 @@ func runTruncateTest(t *testing.T, dir string) {
 		"/roles/policy.rego": "package bar\n p = 1",
 	}
 
-	var files = make([][2]string, 0, len(archiveFiles))
+	files := make([][2]string, 0, len(archiveFiles))
 	for name, content := range archiveFiles {
 		files = append(files, [2]string{name, content})
 	}
@@ -334,7 +334,7 @@ func TestTruncateMultipleTxn(t *testing.T) {
 		// additional data file at root
 		archiveFiles["/data.json"] = `{"a": {"b": {"z": true}}}}`
 
-		var files = make([][2]string, 0, len(archiveFiles))
+		files := make([][2]string, 0, len(archiveFiles))
 		for name, content := range archiveFiles {
 			files = append(files, [2]string{name, content})
 		}

--- a/storage/inmem/inmem_test.go
+++ b/storage/inmem/inmem_test.go
@@ -334,7 +334,7 @@ func TestTruncateNoExistingPath(t *testing.T) {
 		"/a/b/c/data.json": "[1,2,3]",
 	}
 
-	var files [][2]string
+	var files = make([][2]string, 0, len(archiveFiles))
 	for name, content := range archiveFiles {
 		files = append(files, [2]string{name, content})
 	}
@@ -396,7 +396,7 @@ func TestTruncate(t *testing.T) {
 		"/roles/policy.rego": "package bar\n p = 1",
 	}
 
-	var files [][2]string
+	var files = make([][2]string, 0, len(archiveFiles))
 	for name, content := range archiveFiles {
 		files = append(files, [2]string{name, content})
 	}
@@ -490,7 +490,7 @@ func TestTruncateDataMergeError(t *testing.T) {
 		"/data.json":     `{"a": {"b": {"c": "bar"}}}`,
 	}
 
-	var files [][2]string
+	var files = make([][2]string, 0, len(archiveFiles))
 	for name, content := range archiveFiles {
 		files = append(files, [2]string{name, content})
 	}
@@ -525,7 +525,7 @@ func TestTruncateBadRootWrite(t *testing.T) {
 		"/roles/policy.rego": "package bar\n p = 1",
 	}
 
-	var files [][2]string
+	var files = make([][2]string, 0, len(archiveFiles))
 	for name, content := range archiveFiles {
 		files = append(files, [2]string{name, content})
 	}

--- a/storage/inmem/inmem_test.go
+++ b/storage/inmem/inmem_test.go
@@ -334,7 +334,7 @@ func TestTruncateNoExistingPath(t *testing.T) {
 		"/a/b/c/data.json": "[1,2,3]",
 	}
 
-	var files = make([][2]string, 0, len(archiveFiles))
+	files := make([][2]string, 0, len(archiveFiles))
 	for name, content := range archiveFiles {
 		files = append(files, [2]string{name, content})
 	}
@@ -396,7 +396,7 @@ func TestTruncate(t *testing.T) {
 		"/roles/policy.rego": "package bar\n p = 1",
 	}
 
-	var files = make([][2]string, 0, len(archiveFiles))
+	files := make([][2]string, 0, len(archiveFiles))
 	for name, content := range archiveFiles {
 		files = append(files, [2]string{name, content})
 	}
@@ -490,7 +490,7 @@ func TestTruncateDataMergeError(t *testing.T) {
 		"/data.json":     `{"a": {"b": {"c": "bar"}}}`,
 	}
 
-	var files = make([][2]string, 0, len(archiveFiles))
+	files := make([][2]string, 0, len(archiveFiles))
 	for name, content := range archiveFiles {
 		files = append(files, [2]string{name, content})
 	}
@@ -525,7 +525,7 @@ func TestTruncateBadRootWrite(t *testing.T) {
 		"/roles/policy.rego": "package bar\n p = 1",
 	}
 
-	var files = make([][2]string, 0, len(archiveFiles))
+	files := make([][2]string, 0, len(archiveFiles))
 	for name, content := range archiveFiles {
 		files = append(files, [2]string{name, content})
 	}

--- a/test/wasm/cmd/wasm-rego-testgen/main.go
+++ b/test/wasm/cmd/wasm-rego-testgen/main.go
@@ -42,7 +42,7 @@ type compiledTestCase struct {
 }
 
 func compileTestCases(ctx context.Context, tests cases.Set) (*compiledTestCaseSet, error) {
-	var result []compiledTestCase
+	var result = make([]compiledTestCase, 0, len(tests.Cases))
 	for _, tc := range tests.Cases {
 
 		var numExpects int

--- a/test/wasm/cmd/wasm-rego-testgen/main.go
+++ b/test/wasm/cmd/wasm-rego-testgen/main.go
@@ -42,7 +42,7 @@ type compiledTestCase struct {
 }
 
 func compileTestCases(ctx context.Context, tests cases.Set) (*compiledTestCaseSet, error) {
-	var result = make([]compiledTestCase, 0, len(tests.Cases))
+	result := make([]compiledTestCase, 0, len(tests.Cases))
 	for _, tc := range tests.Cases {
 
 		var numExpects int

--- a/tester/reporter.go
+++ b/tester/reporter.go
@@ -38,7 +38,8 @@ func (r PrettyReporter) Report(ch chan *Result) error {
 
 	dirty := false
 	var pass, fail, skip, errs int
-	var results, failures []*Result
+	var results = make([]*Result, 0, len(ch))
+	var failures []*Result
 
 	for tr := range ch {
 		if tr.Pass() {
@@ -161,7 +162,7 @@ type JSONReporter struct {
 
 // Report prints the test report to the reporter's output.
 func (r JSONReporter) Report(ch chan *Result) error {
-	var report []*Result
+	var report = make([]*Result, 0, len(ch))
 	for tr := range ch {
 		report = append(report, tr)
 	}

--- a/tester/reporter.go
+++ b/tester/reporter.go
@@ -38,7 +38,7 @@ func (r PrettyReporter) Report(ch chan *Result) error {
 
 	dirty := false
 	var pass, fail, skip, errs int
-	var results = make([]*Result, 0, len(ch))
+	results := make([]*Result, 0, len(ch))
 	var failures []*Result
 
 	for tr := range ch {
@@ -162,7 +162,7 @@ type JSONReporter struct {
 
 // Report prints the test report to the reporter's output.
 func (r JSONReporter) Report(ch chan *Result) error {
-	var report = make([]*Result, 0, len(ch))
+	report := make([]*Result, 0, len(ch))
 	for tr := range ch {
 		report = append(report, tr)
 	}

--- a/topdown/cidr.go
+++ b/topdown/cidr.go
@@ -300,7 +300,7 @@ func evalNetCIDRMerge(networks []*net.IPNet) []*net.IPNet {
 		return nil
 	}
 
-	var ranges cidrBlockRanges
+	var ranges = make(cidrBlockRanges, 0, len(networks))
 
 	// For each CIDR, create an IP range. Sort them and merge when possible.
 	for _, network := range networks {

--- a/topdown/cidr.go
+++ b/topdown/cidr.go
@@ -300,7 +300,7 @@ func evalNetCIDRMerge(networks []*net.IPNet) []*net.IPNet {
 		return nil
 	}
 
-	var ranges = make(cidrBlockRanges, 0, len(networks))
+	ranges := make(cidrBlockRanges, 0, len(networks))
 
 	// For each CIDR, create an IP range. Sort them and merge when possible.
 	for _, network := range networks {

--- a/topdown/strings.go
+++ b/topdown/strings.go
@@ -405,7 +405,7 @@ func builtinReplaceN(a, b ast.Value) (ast.Value, error) {
 		return nil, err
 	}
 
-	var oldnewArr = make([]string, 0, len(keys)*2)
+	oldnewArr := make([]string, 0, len(keys)*2)
 	for _, k := range keys {
 		keyVal, ok := k.Value.(ast.String)
 		if !ok {

--- a/topdown/strings.go
+++ b/topdown/strings.go
@@ -405,7 +405,7 @@ func builtinReplaceN(a, b ast.Value) (ast.Value, error) {
 		return nil, err
 	}
 
-	var oldnewArr []string
+	var oldnewArr = make([]string, 0, len(keys)*2)
 	for _, k := range keys {
 		keyVal, ok := k.Value.(ast.String)
 		if !ok {

--- a/topdown/tokens.go
+++ b/topdown/tokens.go
@@ -309,7 +309,7 @@ func getKeysFromCertOrJWK(certificate string) ([]verificationKey, error) {
 		return nil, fmt.Errorf("failed to parse a JWK key (set): %w", err)
 	}
 
-	var keys = make([]verificationKey, 0, len(jwks.Keys))
+	keys := make([]verificationKey, 0, len(jwks.Keys))
 	for _, k := range jwks.Keys {
 		key, err := k.Materialize()
 		if err != nil {

--- a/topdown/tokens.go
+++ b/topdown/tokens.go
@@ -309,7 +309,7 @@ func getKeysFromCertOrJWK(certificate string) ([]verificationKey, error) {
 		return nil, fmt.Errorf("failed to parse a JWK key (set): %w", err)
 	}
 
-	var keys []verificationKey
+	var keys = make([]verificationKey, 0, len(jwks.Keys))
 	for _, k := range jwks.Keys {
 		key, err := k.Materialize()
 		if err != nil {

--- a/types/types.go
+++ b/types/types.go
@@ -684,7 +684,7 @@ type FuncArgs struct {
 }
 
 func (a FuncArgs) String() string {
-	var buf []string
+	var buf = make([]string, 0, len(a.Args)+1)
 	for i := range a.Args {
 		buf = append(buf, Sprint(a.Args[i]))
 	}

--- a/types/types.go
+++ b/types/types.go
@@ -684,7 +684,7 @@ type FuncArgs struct {
 }
 
 func (a FuncArgs) String() string {
-	var buf = make([]string, 0, len(a.Args)+1)
+	buf := make([]string, 0, len(a.Args)+1)
 	for i := range a.Args {
 		buf = append(buf, Sprint(a.Args[i]))
 	}


### PR DESCRIPTION
This PR adds the `prealloc` linter to the golangci-lint set of linters we use for OPA, and makes the numerous small refactors around slice preallocation required to pass the linting check.