### PR TITLE
docs+build: Restore diff-against-main behavior for PRs.

### DIFF
--- a/build/docs-build-needed.sh
+++ b/build/docs-build-needed.sh
@@ -2,7 +2,13 @@
 
 set -exo pipefail
 
+if [ "$PULL_REQUEST" == "true" ]; then
+  BASE=main
+else
+  BASE=$CACHED_COMMIT_REF
+fi
+
 # NOTE(sr): we include version because that's what drives releases
 # Makefile and netlify.toml capture when the build infrastructure changes
 # ast/builtins.go and capabilities.json are driving the builtins_metadata.
-git diff --exit-code $CACHED_COMMIT_REF $COMMIT_REF docs/ Makefile build/ netlify.toml ast/builtins.go capabilities.json version/
+git diff --exit-code $BASE $COMMIT_REF docs/ Makefile build/ netlify.toml ast/builtins.go capabilities.json version/


### PR DESCRIPTION
This commit partially reverts #5045, allowing us to correctly diff against `main` during PRs, and against cached builds the rest of the time.