### PR TITLE
server+plugins: Integrate server + NDBCache in decision logs.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -32,6 +32,7 @@ type Config struct {
 	DefaultDecision              *string                    `json:"default_decision,omitempty"`
 	DefaultAuthorizationDecision *string                    `json:"default_authorization_decision,omitempty"`
 	Caching                      json.RawMessage            `json:"caching,omitempty"`
+	NDBuiltinCache               bool                       `json:"nd_builtin_cache,omitempty"`
 	PersistenceDirectory         *string                    `json:"persistence_directory,omitempty"`
 	DistributedTracing           json.RawMessage            `json:"distributed_tracing,omitempty"`
 	Storage                      *struct {
@@ -85,6 +86,11 @@ func (c Config) DefaultDecisionRef() ast.Ref {
 func (c Config) DefaultAuthorizationDecisionRef() ast.Ref {
 	r, _ := ref.ParseDataPath(*c.DefaultAuthorizationDecision)
 	return r
+}
+
+// NDBuiltinCacheEnabled returns if the ND builtins cache should be used.
+func (c Config) NDBuiltinCacheEnabled() bool {
+	return c.NDBuiltinCache
 }
 
 func (c *Config) validateAndInjectDefaults(id string) error {

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -740,6 +740,7 @@ For *GHCR* (Github Container Registry) you can use a developer PAT (personal acc
 | `default_authorization_decision` | `string` | No (default: `/system/authz/allow`) | Set path of default authorization decision for OPA's API. |
 | `persistence_directory` | `string` | No (default `$PWD/.opa`) | Set directory to use for persistence with options like `bundles[_].persist`. |
 | `plugins` | `object` | No (default: `{}`) | Location for custom plugin configuration. See [Plugins](../plugins) for details. |
+| `nd_builtin_cache` | `boolean` | No (default: `false`) | Enable the non-deterministic builtins caching system during policy evaluation, and include the contents of the cache in decision logs. Note that decision logs that are larger than `upload_size_limit_bytes` will drop the `nd_builtin_cache` key from the log entry before uploading. |
 
 ### Keys
 

--- a/plugins/logs/mask.go
+++ b/plugins/logs/mask.go
@@ -21,8 +21,9 @@ const (
 	maskOPRemove maskOP = "remove"
 	maskOPUpsert maskOP = "upsert"
 
-	partInput  = "input"
-	partResult = "result"
+	partInput    = "input"
+	partResult   = "result"
+	partNDBCache = "nd_builtin_cache"
 )
 
 var (
@@ -64,7 +65,9 @@ func newMaskRule(path string, opts ...maskRuleOption) (*maskRule, error) {
 
 	parts := strings.Split(path[1:], "/")
 
-	if parts[0] != partInput && parts[0] != partResult {
+	switch parts[0] {
+	case partInput, partResult, partNDBCache: // OK
+	default:
 		return nil, fmt.Errorf("mask prefix not allowed: %v", parts[0])
 	}
 
@@ -130,8 +133,8 @@ func withFailUndefinedPath() maskRuleOption {
 
 func (r maskRule) Mask(event *EventV1) error {
 
-	var maskObj *interface{}     // pointer to event Input|Result object
-	var maskObjPtr **interface{} // pointer to the event Input|Result pointer itself
+	var maskObj *interface{}     // pointer to event Input|Result|NDBCache object
+	var maskObjPtr **interface{} // pointer to the event Input|Result|NDBCache pointer itself
 
 	switch p := r.escapedParts[0]; p {
 	case partInput:
@@ -143,7 +146,6 @@ func (r maskRule) Mask(event *EventV1) error {
 		}
 		maskObj = event.Input
 		maskObjPtr = &event.Input
-
 	case partResult:
 		if event.Result == nil {
 			if r.failUndefinedPath {
@@ -153,6 +155,15 @@ func (r maskRule) Mask(event *EventV1) error {
 		}
 		maskObj = event.Result
 		maskObjPtr = &event.Result
+	case partNDBCache:
+		if event.NDBuiltinCache == nil {
+			if r.failUndefinedPath {
+				return errMaskInvalidObject
+			}
+			return nil
+		}
+		maskObj = event.NDBuiltinCache
+		maskObjPtr = &event.NDBuiltinCache
 	default:
 		return fmt.Errorf("illegal path value: %s", p)
 	}

--- a/rego/rego.go
+++ b/rego/rego.go
@@ -1186,8 +1186,11 @@ func (r *Rego) Eval(ctx context.Context) (ResultSet, error) {
 		EvalInstrument(r.instrument),
 		EvalTime(r.time),
 		EvalInterQueryBuiltinCache(r.interQueryBuiltinCache),
-		EvalNDBuiltinCache(r.ndBuiltinCache),
 		EvalSeed(r.seed),
+	}
+
+	if r.ndBuiltinCache != nil {
+		evalArgs = append(evalArgs, EvalNDBuiltinCache(r.ndBuiltinCache))
 	}
 
 	for _, qt := range r.queryTracers {
@@ -1260,7 +1263,10 @@ func (r *Rego) Partial(ctx context.Context) (*PartialQueries, error) {
 		EvalMetrics(r.metrics),
 		EvalInstrument(r.instrument),
 		EvalInterQueryBuiltinCache(r.interQueryBuiltinCache),
-		EvalNDBuiltinCache(r.ndBuiltinCache),
+	}
+
+	if r.ndBuiltinCache != nil {
+		evalArgs = append(evalArgs, EvalNDBuiltinCache(r.ndBuiltinCache))
 	}
 
 	for _, t := range r.queryTracers {
@@ -1933,7 +1939,6 @@ func (r *Rego) eval(ctx context.Context, ectx *EvalContext) (ResultSet, error) {
 		WithIndexing(ectx.indexing).
 		WithEarlyExit(ectx.earlyExit).
 		WithInterQueryBuiltinCache(ectx.interQueryBuiltinCache).
-		WithNDBuiltinCache(ectx.ndBuiltinCache).
 		WithStrictBuiltinErrors(r.strictBuiltinErrors).
 		WithSeed(ectx.seed).
 		WithPrintHook(ectx.printHook).
@@ -1941,6 +1946,10 @@ func (r *Rego) eval(ctx context.Context, ectx *EvalContext) (ResultSet, error) {
 
 	if !ectx.time.IsZero() {
 		q = q.WithTime(ectx.time)
+	}
+
+	if ectx.ndBuiltinCache != nil {
+		q = q.WithNDBuiltinCache(ectx.ndBuiltinCache)
 	}
 
 	for i := range ectx.queryTracers {
@@ -2210,13 +2219,16 @@ func (r *Rego) partial(ctx context.Context, ectx *EvalContext) (*PartialQueries,
 		WithSkipPartialNamespace(r.skipPartialNamespace).
 		WithShallowInlining(r.shallowInlining).
 		WithInterQueryBuiltinCache(ectx.interQueryBuiltinCache).
-		WithNDBuiltinCache(ectx.ndBuiltinCache).
 		WithStrictBuiltinErrors(r.strictBuiltinErrors).
 		WithSeed(ectx.seed).
 		WithPrintHook(ectx.printHook)
 
 	if !ectx.time.IsZero() {
 		q = q.WithTime(ectx.time)
+	}
+
+	if ectx.ndBuiltinCache != nil {
+		q = q.WithNDBuiltinCache(ectx.ndBuiltinCache)
 	}
 
 	for i := range ectx.queryTracers {

--- a/rego/rego_test.go
+++ b/rego/rego_test.go
@@ -2086,7 +2086,7 @@ func TestEvalWithNDCache(t *testing.T) {
 	}
 
 	// Check and make sure we got exactly 2x items back in the ND builtin cache.
-	// NDBuiltinsCache always has the structure: map[ast.String]map[ast.Array]ast.Value
+	// NDBuiltinCache always has the structure: map[ast.String]map[ast.Array]ast.Value
 	if len(ndBC) != 2 {
 		t.Fatalf("Expected exactly 2 items in non-deterministic builtin cache. Found %d items.\n", len(ndBC))
 	}

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -474,6 +474,11 @@ func (rt *Runtime) Serve(ctx context.Context) error {
 		WithMinTLSVersion(rt.Params.MinTLSVersion).
 		WithDistributedTracingOpts(rt.Params.DistributedTracingOpts)
 
+	// If decision_logging plugin enabled, check to see if we opted in to the ND builtins cache.
+	if lp := logs.Lookup(rt.Manager); lp != nil {
+		rt.server = rt.server.WithNDBCacheEnabled(rt.Manager.Config.NDBuiltinCacheEnabled())
+	}
+
 	if rt.Params.DiagnosticAddrs != nil {
 		rt.server = rt.server.WithDiagnosticAddresses(*rt.Params.DiagnosticAddrs)
 	}

--- a/server/buffer.go
+++ b/server/buffer.go
@@ -15,21 +15,22 @@ import (
 
 // Info contains information describing a policy decision.
 type Info struct {
-	Txn           storage.Transaction
-	Revision      string // Deprecated: Use `Bundles` instead
-	Bundles       map[string]BundleInfo
-	DecisionID    string
-	RemoteAddr    string
-	Query         string
-	Path          string
-	Timestamp     time.Time
-	Input         *interface{}
-	InputAST      ast.Value
-	Results       *interface{}
-	MappedResults *interface{}
-	Error         error
-	Metrics       metrics.Metrics
-	Trace         []*topdown.Event
+	Txn            storage.Transaction
+	Revision       string // Deprecated: Use `Bundles` instead
+	Bundles        map[string]BundleInfo
+	DecisionID     string
+	RemoteAddr     string
+	Query          string
+	Path           string
+	Timestamp      time.Time
+	Input          *interface{}
+	InputAST       ast.Value
+	Results        *interface{}
+	MappedResults  *interface{}
+	NDBuiltinCache *interface{}
+	Error          error
+	Metrics        metrics.Metrics
+	Trace          []*topdown.Event
 }
 
 // BundleInfo contains information describing a bundle.


### PR DESCRIPTION
This PR integrates the non-deterministic builtins cache (introduced in #4926) into the OPA server and SDK, ensuring that the cache's contents are added to the decision logs generated by the decision logging plugin when the `nd_builtin_cache` key is set to `true`.
 
Fixes: #1514

## Task List

 - [x] Remove the "always true" setting in the server for enabling the ND builtins cache.
    - [x] Plumb in a config file setting for enabling the ND builtins cache.
 - [x] Add tests for the server/plugin to test out the new field addition. (A few more tests may be possible to add here, but the current ones exercise the most important functionality in the plugin and server.)
 - [x] Integrate the ND builtins cache into the SDK package. (See Caveats below.)
 - [x] Add tests for the SDK integration.
 - [x] Update decision logging docs.
   - [x] Specifically call out how this feature affects decision log sizes when using builtins like `http.send`.

## Known Caveats / Questions for Code Review

-  ~~Should we be silently dropping the `nd_builtins_cache` key from DL entries when they are too large? Could we use the `Error` field to perhaps signal that all is not well? Is there maybe an out-of-band logging system that could be used?~~
(EDIT: @ashutosh-narkar suggested logging + a metrics counter, and I have implemented this in my latest changeset.)
- `sdk.Opa.Partial` has no support for the ND builtins cache, because partial evaluation will not run the ND builtins, as of #5172, and #5175 merging. I am fairly sure this is correct, but would appreciate a second opinion from a reviewer. :sweat_smile: 