### PR TITLE
fix: Add support for recursive json schema elements to prevent fatal error

### DIFF
--- a/ast/compile.go
+++ b/ast/compile.go
@@ -475,16 +475,16 @@ func (c *Compiler) GetArity(ref Ref) int {
 //
 // E.g., given the following module:
 //
-//	package a.b.c
+//		package a.b.c
 //
-//	p[k] = v { ... }    # rule1
-//  p[k1] = v1 { ... }  # rule2
+//		p[k] = v { ... }    # rule1
+//	 p[k1] = v1 { ... }  # rule2
 //
 // The following calls yield the rules on the right.
 //
-//  GetRulesExact("data.a.b.c.p")   => [rule1, rule2]
-//  GetRulesExact("data.a.b.c.p.x") => nil
-//  GetRulesExact("data.a.b.c")     => nil
+//	GetRulesExact("data.a.b.c.p")   => [rule1, rule2]
+//	GetRulesExact("data.a.b.c.p.x") => nil
+//	GetRulesExact("data.a.b.c")     => nil
 func (c *Compiler) GetRulesExact(ref Ref) (rules []*Rule) {
 	node := c.RuleTree
 
@@ -502,16 +502,16 @@ func (c *Compiler) GetRulesExact(ref Ref) (rules []*Rule) {
 //
 // E.g., given the following module:
 //
-//	package a.b.c
+//		package a.b.c
 //
-//	p[k] = v { ... }    # rule1
-//  p[k1] = v1 { ... }  # rule2
+//		p[k] = v { ... }    # rule1
+//	 p[k1] = v1 { ... }  # rule2
 //
 // The following calls yield the rules on the right.
 //
-//  GetRulesForVirtualDocument("data.a.b.c.p")   => [rule1, rule2]
-//  GetRulesForVirtualDocument("data.a.b.c.p.x") => [rule1, rule2]
-//  GetRulesForVirtualDocument("data.a.b.c")     => nil
+//	GetRulesForVirtualDocument("data.a.b.c.p")   => [rule1, rule2]
+//	GetRulesForVirtualDocument("data.a.b.c.p.x") => [rule1, rule2]
+//	GetRulesForVirtualDocument("data.a.b.c")     => nil
 func (c *Compiler) GetRulesForVirtualDocument(ref Ref) (rules []*Rule) {
 
 	node := c.RuleTree
@@ -532,17 +532,17 @@ func (c *Compiler) GetRulesForVirtualDocument(ref Ref) (rules []*Rule) {
 //
 // E.g., given the following module:
 //
-//  package a.b.c
+//	package a.b.c
 //
-//  p[x] = y { ... }  # rule1
-//  p[k] = v { ... }  # rule2
-//  q { ... }         # rule3
+//	p[x] = y { ... }  # rule1
+//	p[k] = v { ... }  # rule2
+//	q { ... }         # rule3
 //
 // The following calls yield the rules on the right.
 //
-//  GetRulesWithPrefix("data.a.b.c.p")   => [rule1, rule2]
-//  GetRulesWithPrefix("data.a.b.c.p.a") => nil
-//  GetRulesWithPrefix("data.a.b.c")     => [rule1, rule2, rule3]
+//	GetRulesWithPrefix("data.a.b.c.p")   => [rule1, rule2]
+//	GetRulesWithPrefix("data.a.b.c.p.a") => nil
+//	GetRulesWithPrefix("data.a.b.c")     => [rule1, rule2, rule3]
 func (c *Compiler) GetRulesWithPrefix(ref Ref) (rules []*Rule) {
 
 	node := c.RuleTree
@@ -581,18 +581,18 @@ func extractRules(s []util.T) (rules []*Rule) {
 //
 // E.g., given the following module:
 //
-//  package a.b.c
+//	package a.b.c
 //
-//  p[x] = y { q[x] = y; ... } # rule1
-//  q[x] = y { ... }           # rule2
+//	p[x] = y { q[x] = y; ... } # rule1
+//	q[x] = y { ... }           # rule2
 //
 // The following calls yield the rules on the right.
 //
-//  GetRules("data.a.b.c.p")	=> [rule1]
-//  GetRules("data.a.b.c.p.x")	=> [rule1]
-//  GetRules("data.a.b.c.q")	=> [rule2]
-//  GetRules("data.a.b.c")		=> [rule1, rule2]
-//  GetRules("data.a.b.d")		=> nil
+//	GetRules("data.a.b.c.p")	=> [rule1]
+//	GetRules("data.a.b.c.p.x")	=> [rule1]
+//	GetRules("data.a.b.c.q")	=> [rule2]
+//	GetRules("data.a.b.c")		=> [rule1, rule2]
+//	GetRules("data.a.b.d")		=> nil
 func (c *Compiler) GetRules(ref Ref) (rules []*Rule) {
 
 	set := map[*Rule]struct{}{}
@@ -627,34 +627,34 @@ func (c *Compiler) GetRulesDynamic(ref Ref) []*Rule {
 //
 // E.g., given the following modules:
 //
-//  package a.b.c
+//	package a.b.c
 //
-//  r1 = 1  # rule1
+//	r1 = 1  # rule1
 //
 // and:
 //
-//  package a.d.c
+//	package a.d.c
 //
-//  r2 = 2  # rule2
+//	r2 = 2  # rule2
 //
 // The following calls yield the rules on the right.
 //
-//  GetRulesDynamicWithOpts("data.a[x].c[y]", opts) => [rule1, rule2]
-//  GetRulesDynamicWithOpts("data.a[x].c.r2", opts) => [rule2]
-//  GetRulesDynamicWithOpts("data.a.b[x][y]", opts) => [rule1]
+//	GetRulesDynamicWithOpts("data.a[x].c[y]", opts) => [rule1, rule2]
+//	GetRulesDynamicWithOpts("data.a[x].c.r2", opts) => [rule2]
+//	GetRulesDynamicWithOpts("data.a.b[x][y]", opts) => [rule1]
 //
 // Using the RulesOptions parameter, the inclusion of hidden modules can be
 // controlled:
 //
 // With
 //
-//  package system.main
+//	package system.main
 //
-//  r3 = 3 # rule3
+//	r3 = 3 # rule3
 //
 // We'd get this result:
 //
-//  GetRulesDynamicWithOpts("data[x]", RulesOptions{IncludeHiddenModules: true}) => [rule1, rule2, rule3]
+//	GetRulesDynamicWithOpts("data[x]", RulesOptions{IncludeHiddenModules: true}) => [rule1, rule2, rule3]
 //
 // Without the options, it would be excluded.
 func (c *Compiler) GetRulesDynamicWithOpts(ref Ref, opts RulesOptions) []*Rule {
@@ -1053,7 +1053,21 @@ func mergeSchemas(schemas ...*gojsonschema.SubSchema) (*gojsonschema.SubSchema, 
 	return result, nil
 }
 
-func parseSchema(schema interface{}) (types.Type, error) {
+type schemaParser struct {
+	definitionCache map[string]*cachedDef
+}
+
+type cachedDef struct {
+	properties []*types.StaticProperty
+}
+
+func newSchemaParser() *schemaParser {
+	return &schemaParser{
+		definitionCache: map[string]*cachedDef{},
+	}
+}
+
+func (parser *schemaParser) parseSchema(schema interface{}) (types.Type, error) {
 	subSchema, ok := schema.(*gojsonschema.SubSchema)
 	if !ok {
 		return nil, fmt.Errorf("unexpected schema type %v", subSchema)
@@ -1061,7 +1075,10 @@ func parseSchema(schema interface{}) (types.Type, error) {
 
 	// Handle referenced schemas, returns directly when a $ref is found
 	if subSchema.RefSchema != nil {
-		return parseSchema(subSchema.RefSchema)
+		if existing, ok := parser.definitionCache[subSchema.RefSchema.ID.String()]; ok {
+			return types.NewObject(existing.properties, nil), nil
+		}
+		return parser.parseSchema(subSchema.RefSchema)
 	}
 
 	// Handle anyOf
@@ -1073,7 +1090,7 @@ func parseSchema(schema interface{}) (types.Type, error) {
 			copySchema := *subSchema
 			copySchemaRef := &copySchema
 			copySchemaRef.AnyOf = nil
-			coreType, err := parseSchema(copySchemaRef)
+			coreType, err := parser.parseSchema(copySchemaRef)
 			if err != nil {
 				return nil, fmt.Errorf("unexpected schema type %v: %w", subSchema, err)
 			}
@@ -1088,7 +1105,7 @@ func parseSchema(schema interface{}) (types.Type, error) {
 
 		// Iterate through every property of AnyOf and add it to orType
 		for _, pSchema := range subSchema.AnyOf {
-			newtype, err := parseSchema(pSchema)
+			newtype, err := parser.parseSchema(pSchema)
 			if err != nil {
 				return nil, fmt.Errorf("unexpected schema type %v: %w", pSchema, err)
 			}
@@ -1111,12 +1128,12 @@ func parseSchema(schema interface{}) (types.Type, error) {
 				if err != nil {
 					return nil, err
 				}
-				return parseSchema(objectOrArrayResult)
+				return parser.parseSchema(objectOrArrayResult)
 			} else if subSchema.Types.String() != allOfResult.Types.String() {
 				return nil, fmt.Errorf("unable to merge these schemas")
 			}
 		}
-		return parseSchema(allOfResult)
+		return parser.parseSchema(allOfResult)
 	}
 
 	if subSchema.Types.IsTyped() {
@@ -1131,15 +1148,28 @@ func parseSchema(schema interface{}) (types.Type, error) {
 
 		} else if subSchema.Types.Contains("object") {
 			if len(subSchema.PropertiesChildren) > 0 {
-				staticProps := make([]*types.StaticProperty, 0, len(subSchema.PropertiesChildren))
+				def := &cachedDef{
+					properties: make([]*types.StaticProperty, 0, len(subSchema.PropertiesChildren)),
+				}
 				for _, pSchema := range subSchema.PropertiesChildren {
-					newtype, err := parseSchema(pSchema)
+					def.properties = append(def.properties, types.NewStaticProperty(pSchema.Property, nil))
+				}
+				if subSchema.Parent != nil {
+					parser.definitionCache[subSchema.ID.String()] = def
+				}
+				for _, pSchema := range subSchema.PropertiesChildren {
+					newtype, err := parser.parseSchema(pSchema)
 					if err != nil {
 						return nil, fmt.Errorf("unexpected schema type %v: %w", pSchema, err)
 					}
-					staticProps = append(staticProps, types.NewStaticProperty(pSchema.Property, newtype))
+					for i, prop := range def.properties {
+						if prop.Key == pSchema.Property {
+							def.properties[i].Value = newtype
+							break
+						}
+					}
 				}
-				return types.NewObject(staticProps, nil), nil
+				return types.NewObject(def.properties, nil), nil
 			}
 			return types.NewObject(nil, types.NewDynamicProperty(types.A, types.A)), nil
 
@@ -1147,7 +1177,7 @@ func parseSchema(schema interface{}) (types.Type, error) {
 			if len(subSchema.ItemsChildren) > 0 {
 				if subSchema.ItemsChildrenIsSingleSchema {
 					iSchema := subSchema.ItemsChildren[0]
-					newtype, err := parseSchema(iSchema)
+					newtype, err := parser.parseSchema(iSchema)
 					if err != nil {
 						return nil, fmt.Errorf("unexpected schema type %v", iSchema)
 					}
@@ -1156,7 +1186,7 @@ func parseSchema(schema interface{}) (types.Type, error) {
 				newTypes := make([]types.Type, 0, len(subSchema.ItemsChildren))
 				for i := 0; i != len(subSchema.ItemsChildren); i++ {
 					iSchema := subSchema.ItemsChildren[i]
-					newtype, err := parseSchema(iSchema)
+					newtype, err := parser.parseSchema(iSchema)
 					if err != nil {
 						return nil, fmt.Errorf("unexpected schema type %v", iSchema)
 					}
@@ -1171,11 +1201,11 @@ func parseSchema(schema interface{}) (types.Type, error) {
 	// Assume types if not specified in schema
 	if len(subSchema.PropertiesChildren) > 0 {
 		if err := subSchema.Types.Add("object"); err == nil {
-			return parseSchema(subSchema)
+			return parser.parseSchema(subSchema)
 		}
 	} else if len(subSchema.ItemsChildren) > 0 {
 		if err := subSchema.Types.Add("array"); err == nil {
-			return parseSchema(subSchema)
+			return parser.parseSchema(subSchema)
 		}
 	}
 
@@ -1565,11 +1595,11 @@ func checkVoidCalls(env *TypeEnv, x interface{}) Errors {
 //
 // For example, given the following print statement:
 //
-//   print("the value of x is:", input.x)
+//	print("the value of x is:", input.x)
 //
 // The expression would be rewritten to:
 //
-//   print({__local0__ | __local0__ = "the value of x is:"}, {__local1__ | __local1__ = input.x})
+//	print({__local0__ | __local0__ = "the value of x is:"}, {__local1__ | __local1__ = input.x})
 func rewritePrintCalls(gen *localVarGenerator, getArity func(Ref) int, globals VarSet, body Body) Errors {
 
 	var errs Errors

--- a/ast/schema.go
+++ b/ast/schema.go
@@ -54,7 +54,7 @@ func loadSchema(raw interface{}, allowNet []string) (types.Type, error) {
 		return nil, err
 	}
 
-	tpe, err := parseSchema(jsonSchema.RootSchema)
+	tpe, err := newSchemaParser().parseSchema(jsonSchema.RootSchema)
 	if err != nil {
 		return nil, fmt.Errorf("type checking: %w", err)
 	}

--- a/ast/schema_test.go
+++ b/ast/schema_test.go
@@ -460,7 +460,7 @@ func TestParseSchemaWithSchemaBadSchema(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to compile schema: %v", err)
 	}
-	newtype, err := parseSchema(jsonSchema) // Did not pass the subschema
+	newtype, err := newSchemaParser().parseSchema(jsonSchema) // Did not pass the subschema
 	if err == nil {
 		t.Fatalf("Expected parseSchema() = error, got nil")
 	}
@@ -811,6 +811,16 @@ func TestAnyOfArrayMissing(t *testing.T) {
 	c.WithSchemas(schemaSet)
 	if c.schemaSet == nil {
 		t.Fatalf("Did not correctly compile an array type schema with anyOf where items are inside anyOf")
+	}
+}
+
+func TestRecursiveSchema(t *testing.T) {
+	c := NewCompiler()
+	schemaSet := NewSchemaSet()
+	schemaSet.Put(SchemaRootRef, recursiveElements)
+	c.WithSchemas(schemaSet)
+	if c.schemaSet == nil {
+		t.Fatalf("Did not correctly compile an object schema with recursive elements")
 	}
 }
 
@@ -1620,3 +1630,31 @@ const allOfSchemaWithUnevenArray = `{
 		}
 	]
 }`
+
+const recursiveElements = `{
+  "type": "object",
+  "properties": {
+    "Something": {
+      "$ref": "#/$defs/X"
+    }
+  },
+  "$defs": {
+    "X": {
+      "type": "object",
+      "properties": {
+        "Y": {
+          "$ref": "#/$defs/Y"
+        }
+      }
+    },
+    "Y": {
+      "type": "object",
+      "properties": {
+        "X": {
+          "$ref": "#/$defs/X"
+        }
+      }
+    }
+  }
+}
+`


### PR DESCRIPTION
This adds support for recursive json schemas, such as:

```json
{
  "$schema": "https://json-schema.org/draft/2020-12/schema",
  "$id": "https://github.com/open-policy-agent/opa/issues/5166",
  "type": "object",
  "properties": {
    "Something": {
      "$ref": "#/$defs/X"
    }
  },
  "$defs": {
    "X": {
      "type": "object",
      "properties": {
        "Y": {
          "$ref": "#/$defs/Y"
        }
      }
    },
    "Y": {
      "type": "object",
      "properties": {
        "X": {
          "$ref": "#/$defs/X"
        }
      }
    }
  }
}
```

The `parseSchema` method now hangs from a `schemaParser` struct. This allows the use of a cache that can be populated with definitions as they are seen, to prevent them being reparsed later. They are added to cache _*before*_ they are completely parsed, otherwise the recursive crash would still occur. Thus they are added to the cache with all properties without values, then the values are added in by reference after the subsequent child tree parse.

I've added a couple of tests that cover my use case, as well as a schema parsing test (this already passed before my changes - the compile time analysis of the schema is the problem) for good measure.

Happy to change whatever or discuss an alternative approach, just shout (I'm on the OPA slack)

Resolves #5166

Signed-off-by: Liam Galvin <liam.galvin@aquasec.com>