### PR TITLE
docs: Added quotes so both examples are consistent.

### DIFF
--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -88,7 +88,7 @@ Example using `BASE_URL` and `BEARER_TOKEN` environment variables:
 ```yaml
 services:
   acmecorp:
-    url: ${BASE_URL}
+    url: "${BASE_URL}"
     credentials:
       bearer:
         token: "${BEARER_TOKEN}"

--- a/docs/content/contrib-adding-builtin-functions.md
+++ b/docs/content/contrib-adding-builtin-functions.md
@@ -81,7 +81,7 @@ func builtinRepeat(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term) 
         return err
     }
 
-    // Get the first argument as an int, returning an error if it's not the correct type or not a positive value.
+    // Get the second argument as an int, returning an error if it's not the correct type or not a positive value.
     count, err := builtins.IntOperand(operands[1].Value, 2)
     if err != nil {
         return err


### PR DESCRIPTION
No quotes can give wrong values. Also fixed minor typo.

Signed-off-by: Anders Holmefjord <andersholmefjord@gmail.com>

