### PR TITLE
topdown+builtins: Block all ND builtins from partial eval.

### DIFF
--- a/ast/builtins.go
+++ b/ast/builtins.go
@@ -284,17 +284,6 @@ var DefaultBuiltins = [...]*Builtin{
 // built-in definitions.
 var BuiltinMap map[string]*Builtin
 
-// IgnoreDuringPartialEval is a set of built-in functions that should not be
-// evaluated during partial evaluation. These functions are not partially
-// evaluated because they are not pure.
-var IgnoreDuringPartialEval = []*Builtin{
-	NowNanos,
-	HTTPSend,
-	UUIDRFC4122,
-	RandIntn,
-	NetLookupIPAddr,
-}
-
 /**
  * Unification
  */

--- a/topdown/save.go
+++ b/topdown/save.go
@@ -375,12 +375,8 @@ func ignoreExprDuringPartial(expr *ast.Expr) bool {
 }
 
 func ignoreDuringPartial(bi *ast.Builtin) bool {
-	for _, ignore := range ast.IgnoreDuringPartialEval {
-		if bi == ignore {
-			return true
-		}
-	}
-	return false
+	// Note(philipc): For now, we throw out all non-deterministic builtins.
+	return bi.Nondeterministic
 }
 
 type inliningControl struct {


### PR DESCRIPTION
This commit removes the `IgnoreDuringPartialEval` list in `ast/builtins`, and instead changes the partial evaluator to simply ignore all non-deterministic builtins. This keeps true to the intent of the original list, and reduces the potential for human error in maintenance in the future.

Fixes: #5171