### PR TITLE
topdown: In builtin jwt_decode_verify, assert that exp and nbf are number

### DIFF
--- a/test/cases/testdata/jwtdecodeverify/test-jwtdecodeverify-invalid-exp-type.yaml
+++ b/test/cases/testdata/jwtdecodeverify/test-jwtdecodeverify-invalid-exp-type.yaml
@@ -1,0 +1,15 @@
+cases:
+  - data:
+    modules:
+      - |
+        package generated
+        
+        token := io.jwt.encode_sign({"alg": "HS256"}, {"exp": null}, {"kty": "oct", "k": base64url.encode_no_pad("42")})
+        
+        decoded := io.jwt.decode_verify(token, {"secret": "42"})
+
+    note: jwtdecodeverify/invalid-exp
+    query: data.generated.decoded = x
+    strict_error: true
+    want_error: exp value must be a number
+    want_error_code: eval_builtin_error

--- a/test/cases/testdata/jwtdecodeverify/test-jwtdecodeverify-invalid-nbf-type.yaml
+++ b/test/cases/testdata/jwtdecodeverify/test-jwtdecodeverify-invalid-nbf-type.yaml
@@ -4,7 +4,7 @@ cases:
       - |
         package generated
         
-        token := io.jwt.encode_sign({"alg": "HS256"}, {"nbf": null}, {"kty": "oct", "k": base64url.encode_no_pad("42")})
+        token := io.jwt.encode_sign({"alg": "HS256"}, {"nbf": "string is not valid here"}, {"kty": "oct", "k": base64url.encode_no_pad("42")})
         
         decoded := io.jwt.decode_verify(token, {"secret": "42"})
 

--- a/test/cases/testdata/jwtdecodeverify/test-jwtdecodeverify-invalid-nbf-type.yaml
+++ b/test/cases/testdata/jwtdecodeverify/test-jwtdecodeverify-invalid-nbf-type.yaml
@@ -1,0 +1,15 @@
+cases:
+  - data:
+    modules:
+      - |
+        package generated
+        
+        token := io.jwt.encode_sign({"alg": "HS256"}, {"nbf": null}, {"kty": "oct", "k": base64url.encode_no_pad("42")})
+        
+        decoded := io.jwt.decode_verify(token, {"secret": "42"})
+
+    note: jwtdecodeverify/invalid-nbf
+    query: data.generated.decoded = x
+    strict_error: true
+    want_error: nbf value must be a number
+    want_error_code: eval_builtin_error

--- a/topdown/tokens.go
+++ b/topdown/tokens.go
@@ -1064,18 +1064,28 @@ func builtinJWTDecodeVerify(bctx BuiltinContext, args []*ast.Term, iter func(*as
 	}
 	// RFC7159 4.1.4 exp
 	if exp := payload.Get(jwtExpKey); exp != nil {
-		// constraints.time is in nanoseconds but exp Value is in seconds
-		compareTime := ast.FloatNumberTerm(float64(constraints.time) / 1000000000)
-		if ast.Compare(compareTime, exp.Value.(ast.Number)) != -1 {
-			return iter(unverified)
+		switch exp.Value.(type) {
+		case ast.Number:
+			// constraints.time is in nanoseconds but exp Value is in seconds
+			compareTime := ast.FloatNumberTerm(float64(constraints.time) / 1000000000)
+			if ast.Compare(compareTime, exp.Value.(ast.Number)) != -1 {
+				return iter(unverified)
+			}
+		default:
+			return fmt.Errorf("exp value must be a number")
 		}
 	}
 	// RFC7159 4.1.5 nbf
 	if nbf := payload.Get(jwtNbfKey); nbf != nil {
-		// constraints.time is in nanoseconds but nbf Value is in seconds
-		compareTime := ast.FloatNumberTerm(float64(constraints.time) / 1000000000)
-		if ast.Compare(compareTime, nbf.Value.(ast.Number)) == -1 {
-			return iter(unverified)
+		switch nbf.Value.(type) {
+		case ast.Number:
+			// constraints.time is in nanoseconds but nbf Value is in seconds
+			compareTime := ast.FloatNumberTerm(float64(constraints.time) / 1000000000)
+			if ast.Compare(compareTime, nbf.Value.(ast.Number)) == -1 {
+				return iter(unverified)
+			}
+		default:
+			return fmt.Errorf("nbf value must be a number")
 		}
 	}
 


### PR DESCRIPTION
topdown: In builtin jwt_decode_verify, assert that exp and nbf are number if present

Spec allows exp and nbf to be missing, but if they are present, they must be of type "number." Before this change, JWTs that violated this would result in OPA panic. Added assertion on expected type. Added test case for each.

Signed-off-by: Charlie Flowers <cflowers@gmail.com>
