### PR TITLE
fix: Fix race condition in gojsonschema

### DIFF
--- a/internal/gojsonschema/jsonLoader.go
+++ b/internal/gojsonschema/jsonLoader.go
@@ -39,6 +39,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 
 	"github.com/xeipuuv/gojsonreference"
 )
@@ -48,8 +49,11 @@ import (
 // add extra parameters to all calls and interfaces involved, so we're
 // using a global variable instead:
 var allowNet map[string]struct{}
+var netMut sync.RWMutex
 
 func SetAllowNet(hosts []string) {
+	netMut.Lock()
+	defer netMut.Unlock()
 	if hosts == nil {
 		allowNet = nil // resetting the global
 		return
@@ -61,6 +65,8 @@ func SetAllowNet(hosts []string) {
 }
 
 func isAllowed(ref *url.URL) bool {
+	netMut.RLock()
+	defer netMut.RUnlock()
 	if allowNet == nil {
 		return true
 	}

--- a/internal/gojsonschema/jsonschema_test.go
+++ b/internal/gojsonschema/jsonschema_test.go
@@ -190,3 +190,10 @@ func TestFormats(t *testing.T) {
 		}
 	}
 }
+
+func Test_ConcurrentNetAccessModification(t *testing.T) {
+	go func() {
+		SetAllowNet([]string{"something"})
+	}()
+	SetAllowNet(nil)
+}


### PR DESCRIPTION
Fixes a simple race condition in `gojsonschema`.

Note: the test is kind of weird-looking but it's just designed to fail when run with `-race` if concurrent writes aren't protected.

Resolves #5187 

Signed-off-by: Liam Galvin <liam.galvin@aquasec.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->
