### PR TITLE
fix InterQueryCache Insert only drop one when size over limit

### DIFF
--- a/topdown/cache/cache.go
+++ b/topdown/cache/cache.go
@@ -130,7 +130,7 @@ func (c *cache) unsafeInsert(k ast.Value, v InterQueryCacheValue) (dropped int) 
 			return dropped
 		}
 
-		for key := c.l.Front(); key != nil && (c.usage+size > limit); key = key.Next() {
+		for key := c.l.Front(); key != nil && (c.usage+size > limit); key = c.l.Front() {
 			dropKey := key.Value.(ast.Value)
 			c.unsafeDelete(dropKey)
 			c.l.Remove(key)

--- a/topdown/cache/cache_test.go
+++ b/topdown/cache/cache_test.go
@@ -118,6 +118,27 @@ func TestInsert(t *testing.T) {
 	if found {
 		t.Fatal("Unexpected key \"foo\" in cache")
 	}
+	cacheValue3 := newInterQueryCacheValue(ast.StringTerm("bar3").Value, 10)
+	cache.Insert(ast.StringTerm("foo3").Value, cacheValue3)
+	cacheValue4 := newInterQueryCacheValue(ast.StringTerm("bar4").Value, 10)
+	cache.Insert(ast.StringTerm("foo4").Value, cacheValue4)
+	cacheValue5 := newInterQueryCacheValue(ast.StringTerm("bar5").Value, 20)
+	dropped = cache.Insert(ast.StringTerm("foo5").Value, cacheValue5)
+	if dropped != 2 {
+		t.Fatal("Expected dropped to be two")
+	}
+	_, found = cache.Get(ast.StringTerm("foo3").Value)
+	if found {
+		t.Fatal("Unexpected key \"foo3\" in cache")
+	}
+	_, found = cache.Get(ast.StringTerm("foo4").Value)
+	if found {
+		t.Fatal("Unexpected key \"foo4\" in cache")
+	}
+	_, found = cache.Get(ast.StringTerm("foo5").Value)
+	if !found {
+		t.Fatal("Expected key \"foo5\" in cache")
+	}
 }
 
 func TestDelete(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: vinhph0906 <vinhph0906@gmail.com>

I have found an issue in the [inter-query cache](https://github.com/open-policy-agent/opa/blob/main/topdown/cache/cache.go) package. Specifically, [this loop](https://github.com/open-policy-agent/opa/blob/main/topdown/cache/cache.go#L133) will drop items in the cache until the cache's size is smaller than the limits. But this loop run exactly once. This is because [removing the key](https://github.com/open-policy-agent/opa/blob/main/topdown/cache/cache.go#L136) will be set `key.Next()=nil`, then the loop break with `key == nil`. So I added code and a test case to fix this issue. 