### PR TITLE
topdown/json: Fix panic in json.filter on empty JSON paths.

### DIFF
--- a/topdown/json.go
+++ b/topdown/json.go
@@ -203,11 +203,12 @@ func pathsToObject(paths []ast.Ref) ast.Object {
 		node := root
 		var done bool
 
-		// If it's a null JSON path, skip all further processing.
+		// If the path is an empty JSON path, skip all further processing.
 		if len(path) == 0 {
 			done = true
 		}
 
+		// Otherwise, we should have 1+ path segments to work with.
 		for i := 0; i < len(path)-1 && !done; i++ {
 
 			k := path[i]

--- a/topdown/json.go
+++ b/topdown/json.go
@@ -203,6 +203,11 @@ func pathsToObject(paths []ast.Ref) ast.Object {
 		node := root
 		var done bool
 
+		// If it's a null JSON path, skip all further processing.
+		if len(path) == 0 {
+			done = true
+		}
+
 		for i := 0; i < len(path)-1 && !done; i++ {
 
 			k := path[i]

--- a/topdown/json_test.go
+++ b/topdown/json_test.go
@@ -17,6 +17,11 @@ func TestFiltersToObject(t *testing.T) {
 		expected string
 	}{
 		{
+			note:     "empty path",
+			filters:  []string{`""`},
+			expected: `{}`,
+		},
+		{
 			note:     "base",
 			filters:  []string{`"a/b/c"`},
 			expected: `{"a": {"b": {"c": null}}}`,
@@ -80,6 +85,11 @@ func TestFiltersToObject(t *testing.T) {
 			note:     "mixed escapes",
 			filters:  []string{`"a/~0b~1c/d~1~0"`},
 			expected: `{"a": {"~b/c": {"d/~": null}}}`,
+		},
+		{
+			note:     "empty strings mixed with normal paths",
+			filters:  []string{`"a/b/c"`, `""`, `"a/b/d"`, `"a/e/f"`, `""`},
+			expected: `{"a": {"b": {"c": null, "d": null}, "e": {"f": null}}}`,
 		},
 	}
 


### PR DESCRIPTION
This commit fixes a panic discovered in the `json.filter` builtin that could be triggered with an empty JSON path parameter, such as `""`. This panic was caused by indexing logic in a helper function always assuming it had at least one path segment to work with, and thus indexing out-of-bounds when no path segment was present.

The issue was fixed by adding an extra check to the helper function for the null path case, and adding new unit tests to check for the issue.

Fixes: #5199