### PR TITLE
test/cases: add test case for rand.intn

### DIFF
--- a/test/cases/testdata/rand/test-rand.intn.yaml
+++ b/test/cases/testdata/rand/test-rand.intn.yaml
@@ -1,0 +1,13 @@
+cases:
+- data:
+  modules:
+  - |
+    package test
+
+    p = count(rands) {
+      rands := { rand.intn("key", 100) | numbers.range(1,100)[_] }
+    }
+  note: rand.intn/consistent values for same arguments
+  query: data.test.p = x
+  want_result:
+  - x: 1


### PR DESCRIPTION
It looks like we didn't have any before. While it's inherently random, we still know that for the same inputs, within a single evaluation run, we should only get one output. So let's assert that.
