### PR TITLE
ast: check caps for ref rules

### DIFF
--- a/ast/capabilities.go
+++ b/ast/capabilities.go
@@ -17,12 +17,23 @@ import (
 	"github.com/open-policy-agent/opa/util"
 )
 
+// In the compiler, we used this to check that we're OK working with ref heads.
+// If this isn't present, we'll fail. This is to ensure that older versions of
+// OPA can work with policies that we're compiling -- if they don't know ref
+// heads, they wouldn't be able to parse them.
+const FeatureRefHeadStringPrefixes = "rule_head_ref_string_prefixes"
+
 // Capabilities defines a structure containing data that describes the capabilities
 // or features supported by a particular version of OPA.
 type Capabilities struct {
 	Builtins        []*Builtin       `json:"builtins"`
 	FutureKeywords  []string         `json:"future_keywords"`
 	WasmABIVersions []WasmABIVersion `json:"wasm_abi_versions"`
+
+	// Features is a bit of a mixed bag for checking that an older version of OPA
+	// is able to do what needs to be done.
+	// TODO(sr): find better words ^^
+	Features []string `json:"features"`
 
 	// allow_net is an array of hostnames or IP addresses, that an OPA instance is
 	// allowed to connect to.
@@ -59,6 +70,10 @@ func CapabilitiesForThisVersion() *Capabilities {
 		f.FutureKeywords = append(f.FutureKeywords, kw)
 	}
 	sort.Strings(f.FutureKeywords)
+
+	f.Features = []string{
+		FeatureRefHeadStringPrefixes,
+	}
 
 	return f
 }

--- a/ast/compile.go
+++ b/ast/compile.go
@@ -1635,6 +1635,19 @@ func (c *Compiler) rewriteRuleHeadRefs() {
 				rule.Head.Reference = ref
 			}
 
+			cannotSpeakRefs := true
+			for _, f := range c.capabilities.Features {
+				if f == FeatureRefHeadStringPrefixes {
+					cannotSpeakRefs = false
+					break
+				}
+			}
+
+			if cannotSpeakRefs && rule.Head.Name == "" {
+				c.err(NewError(CompileErr, rule.Loc(), "rule heads with refs are not supported: %v", rule.Head.Reference))
+				return true
+			}
+
 			for i := 1; i < len(ref); i++ {
 				// NOTE(sr): In the first iteration, non-string values in the refs are forbidden
 				// except for the last position, e.g.

--- a/capabilities.json
+++ b/capabilities.json
@@ -4302,5 +4302,8 @@
       "version": 1,
       "minor_version": 2
     }
+  ],
+  "features": [
+    "rule_head_ref_string_prefixes"
   ]
 }


### PR DESCRIPTION
This allows us to guard the use of ref heads through capabilities. If we're given a caps file without
the proper feature enabled, and a policy file with ref head rules, this check will fail.

We can thereby ensure that a policy (bundle) works with a certain older version of  OPA that does
not know ref heads.

Similar features would be added for the follow-up steps: general refs `p[x].q[y].r = ...`; or package-less rego files.