### PR TITLE
.trivyignore: drop wasmtime-go

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -36,6 +36,3 @@ GHSA-qq97-vm5h-rrhg
 
 # github.com/dgrijalva/jwt-go -- vulnerable version used by docker/distribution above
 CVE-2020-26160
-
-# github.com/bytecodealliance/wasmtime-go - we don't enable wasm on arm64 builds
-CVE-2022-31169


### PR DESCRIPTION
It's been updated to 1.0.0.
