### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/plugins/bundle/plugin_test.go
+++ b/plugins/bundle/plugin_test.go
@@ -536,12 +536,7 @@ func TestPluginOneShotBundlePersistence(t *testing.T) {
 	ctx := context.Background()
 	manager := getTestManager()
 
-	dir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("unexpected error %v", err)
-	}
-
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	bundleName := "test-bundle"
 	bundleSource := Source{
@@ -642,12 +637,7 @@ func TestPluginOneShotSignedBundlePersistence(t *testing.T) {
 	ctx := context.Background()
 	manager := getTestManager()
 
-	dir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("unexpected error %v", err)
-	}
-
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	bundleName := "test-bundle"
 	vc := bundle.NewVerificationConfig(map[string]*bundle.KeyConfig{"foo": {Key: "secret", Algorithm: "HS256"}}, "foo", "", nil)
@@ -743,12 +733,7 @@ func TestLoadAndActivateBundlesFromDisk(t *testing.T) {
 	ctx := context.Background()
 	manager := getTestManager()
 
-	dir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("unexpected error %v", err)
-	}
-
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	bundleName := "test-bundle"
 	bundleSource := Source{
@@ -790,7 +775,7 @@ func TestLoadAndActivateBundlesFromDisk(t *testing.T) {
 		t.Fatal("unexpected error:", err)
 	}
 
-	err = plugin.saveBundleToDisk(bundleName, &buf)
+	err := plugin.saveBundleToDisk(bundleName, &buf)
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}
@@ -828,12 +813,7 @@ func TestLoadAndActivateDepBundlesFromDisk(t *testing.T) {
 	ctx := context.Background()
 	manager := getTestManager()
 
-	dir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("unexpected error %v", err)
-	}
-
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	bundleName := "test-bundle-main"
 	bundleSource := Source{
@@ -905,7 +885,7 @@ is_one(x) {
 		t.Fatal("unexpected error:", err)
 	}
 
-	err = plugin.saveBundleToDisk(bundleName, &buf1)
+	err := plugin.saveBundleToDisk(bundleName, &buf1)
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}
@@ -937,12 +917,7 @@ func TestLoadAndActivateDepBundlesFromDiskMaxAttempts(t *testing.T) {
 	ctx := context.Background()
 	manager := getTestManager()
 
-	dir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("unexpected error %v", err)
-	}
-
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	bundleName := "test-bundle-main"
 	bundleSource := Source{
@@ -986,7 +961,7 @@ allow {
 		t.Fatal("unexpected error:", err)
 	}
 
-	err = plugin.saveBundleToDisk(bundleName, &buf)
+	err := plugin.saveBundleToDisk(bundleName, &buf)
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}
@@ -2424,36 +2399,27 @@ func TestSaveBundleToDiskNew(t *testing.T) {
 
 	manager := getTestManager()
 
-	dir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("unexpected error %v", err)
-	}
-
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	bundles := map[string]*Source{}
 	plugin := New(&Config{Bundles: bundles}, manager)
 	plugin.bundlePersistPath = filepath.Join(dir, ".opa")
 
-	err = plugin.saveBundleToDisk("foo", getTestRawBundle(t))
+	err := plugin.saveBundleToDisk("foo", getTestRawBundle(t))
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}
 }
 
 func TestSaveBundleToDiskNewConfiguredPersistDir(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("unexpected error %v", err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	manager := getTestManager()
 	manager.Config.PersistenceDirectory = &dir
 	bundles := map[string]*Source{}
 	plugin := New(&Config{Bundles: bundles}, manager)
 
-	err = plugin.Start(context.Background())
+	err := plugin.Start(context.Background())
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}
@@ -2475,12 +2441,7 @@ func TestSaveBundleToDiskOverWrite(t *testing.T) {
 	manager := getTestManager()
 
 	// test to check existing bundle is replaced
-	dir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("unexpected error %v", err)
-	}
-
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	bundles := map[string]*Source{}
 	plugin := New(&Config{Bundles: bundles}, manager)
@@ -2489,7 +2450,7 @@ func TestSaveBundleToDiskOverWrite(t *testing.T) {
 	bundleName := "foo"
 	bundleDir := filepath.Join(plugin.bundlePersistPath, bundleName)
 
-	err = os.MkdirAll(bundleDir, os.ModePerm)
+	err := os.MkdirAll(bundleDir, os.ModePerm)
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}
@@ -2536,12 +2497,7 @@ func TestSaveBundleToDiskOverWrite(t *testing.T) {
 }
 
 func TestSaveCurrentBundleToDisk(t *testing.T) {
-	srcDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("unexpected error %v", err)
-	}
-
-	defer os.RemoveAll(srcDir)
+	srcDir := t.TempDir()
 
 	bundlePath, err := saveCurrentBundleToDisk(srcDir, getTestRawBundle(t))
 	if err != nil {
@@ -2572,12 +2528,7 @@ func TestLoadBundleFromDisk(t *testing.T) {
 	}
 
 	// create a test bundle and load it from disk
-	dir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("unexpected error %v", err)
-	}
-
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	bundleName := "foo"
 	bundleDir := filepath.Join(dir, bundleName)
@@ -2608,12 +2559,7 @@ func TestLoadSignedBundleFromDisk(t *testing.T) {
 	}
 
 	// create a test signed bundle and load it from disk
-	dir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("unexpected error %v", err)
-	}
-
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	bundleName := "foo"
 	bundleDir := filepath.Join(dir, bundleName)

--- a/repl/repl_test.go
+++ b/repl/repl_test.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"reflect"
 	"sort"
@@ -287,17 +286,7 @@ func TestDumpPath(t *testing.T) {
 	var buffer bytes.Buffer
 	repl := newRepl(store, &buffer)
 
-	dir, err := ioutil.TempDir("", "dump-path-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	t.Cleanup(func() {
-		err := os.RemoveAll(dir)
-		if err != nil {
-			t.Errorf("error cleaning up with RemoveAll(): %v", err)
-		}
-	})
+	dir := t.TempDir()
 	file := filepath.Join(dir, "tmpfile")
 	if err := repl.OneShot(ctx, fmt.Sprintf("dump %s", file)); err != nil {
 		t.Fatalf("Unexpected error: %v", err)

--- a/storage/disk/config_test.go
+++ b/storage/disk/config_test.go
@@ -7,7 +7,6 @@ package disk
 import (
 	"context"
 	"errors"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -17,11 +16,7 @@ import (
 )
 
 func TestNewFromConfig(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "disk_test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { os.RemoveAll(tmpdir) })
+	tmpdir := t.TempDir()
 
 	for _, tc := range []struct {
 		note    string
@@ -107,11 +102,7 @@ storage:
 
 func TestDataDirPrefix(t *testing.T) {
 	ctx := context.Background()
-	tmpdir, err := ioutil.TempDir("", "disk_test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { os.RemoveAll(tmpdir) })
+	tmpdir := t.TempDir()
 
 	d, err := New(ctx, logging.NewNoOpLogger(), nil, Options{
 		Dir: tmpdir,

--- a/test/authz/authz_bench_test.go
+++ b/test/authz/authz_bench_test.go
@@ -6,8 +6,6 @@ package authz
 
 import (
 	"context"
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/open-policy-agent/opa/ast"
@@ -63,13 +61,9 @@ func runAuthzBenchmark(b *testing.B, mode InputMode, numPaths int, extras ...boo
 	}
 
 	var store storage.Store
+	var err error
 	if useDisk {
-		rootDir, err := ioutil.TempDir("", "test-e2e-bench-disk")
-		if err != nil {
-			panic(err)
-		}
-
-		defer os.RemoveAll(rootDir)
+		rootDir := b.TempDir()
 		store, err = disk.New(ctx, logging.NewNoOpLogger(), nil, disk.Options{
 			Dir:        rootDir,
 			Partitions: nil,


### PR DESCRIPTION
<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->


A testing cleanup. 

This pull request replaces `ioutil.TempDir` with `t.TempDir`. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

Reference: https://pkg.go.dev/testing#T.TempDir

```go
func TestFoo(t *testing.T) {
	// before
	tmpDir, err := ioutil.TempDir("", "")
	if err != nil {
		t.Fatalf("unexpected error %v", err)
	}
	defer os.RemoveAll(tmpDir)

	// now
	tmpDir := t.TempDir()
}
```