### PR TITLE
workflow: use GITHUB_OUTPUT, not ::set-output

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -34,7 +34,7 @@ jobs:
 
     - id: go_version
       name: Read go version
-      run: echo "::set-output name=go_version::$(cat .go-version)"
+      run: echo "go_version=$(cat .go-version)" >> $GITHUB_OUTPUT
 
     - name: Install Go (${{ steps.go_version.outputs.go_version }})
       uses: actions/setup-go@v3

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -34,7 +34,7 @@ jobs:
 
       - id: go_version
         name: Read go version
-        run: echo "::set-output name=go_version::$(cat .go-version)"
+        run: echo "go_version=$(cat .go-version)" >> $GITHUB_OUTPUT
 
       - name: Install Go (${{ steps.go_version.outputs.go_version }})
         uses: actions/setup-go@v3
@@ -142,7 +142,7 @@ jobs:
       - uses: actions/checkout@v3
       - id: go_version
         name: Read go version
-        run: echo "::set-output name=go_version::$(cat .go-version)"
+        run: echo "go_version=$(cat .go-version)" >> $GITHUB_OUTPUT
 
       - name: Install Go (${{ steps.go_version.outputs.go_version }})
         uses: actions/setup-go@v3

--- a/.github/workflows/post-merge.yaml
+++ b/.github/workflows/post-merge.yaml
@@ -116,7 +116,7 @@ jobs:
 
       - id: go_version
         name: Read go version
-        run: echo "::set-output name=go_version::$(cat .go-version)"
+        run: echo "go_version=$(cat .go-version)" >> $GITHUB_OUTPUT
 
       - name: Install Go (${{ steps.go_version.outputs.go_version }})
         uses: actions/setup-go@v3

--- a/.github/workflows/post-tag.yaml
+++ b/.github/workflows/post-tag.yaml
@@ -56,7 +56,7 @@ jobs:
 
       - id: go_version
         name: Read go version
-        run: echo "::set-output name=go_version::$(cat .go-version)"
+        run: echo "go_version=%(cat .go-version)" >> $GITHUB_OUTPUT
 
       - name: Install Go (${{ steps.go_version.outputs.go_version }})
         uses: actions/setup-go@v3

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -57,7 +57,7 @@ jobs:
 
       - id: go_version
         name: Read go version
-        run: echo "::set-output name=go_version::$(cat .go-version)"
+        run: echo "go_version=$(cat .go-version)" >> $GITHUB_OUTPUT
 
       - name: Install Go (${{ steps.go_version.outputs.go_version }})
         uses: actions/setup-go@v3
@@ -101,7 +101,7 @@ jobs:
 
       - id: go_version
         name: Read go version
-        run: echo "::set-output name=go_version::$(cat .go-version)"
+        run: echo "go_version=$(cat .go-version)" >> $GITHUB_OUTPUT
 
       - name: Install Go (${{ steps.go_version.outputs.go_version }})
         uses: actions/setup-go@v3


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
