### PR TITLE
ast+compile: Support entrypoint annotations

### DIFF
--- a/ast/parser.go
+++ b/ast/parser.go
@@ -2111,6 +2111,7 @@ func (p *Parser) validateDefaultRuleValue(rule *Rule) bool {
 type rawAnnotation struct {
 	Scope            string                 `yaml:"scope"`
 	Title            string                 `yaml:"title"`
+	Entrypoint       bool                   `yaml:"entrypoint"`
 	Description      string                 `yaml:"description"`
 	Organizations    []string               `yaml:"organizations"`
 	RelatedResources []interface{}          `yaml:"related_resources"`
@@ -2165,6 +2166,7 @@ func (b *metadataParser) Parse() (*Annotations, error) {
 
 	var result Annotations
 	result.Scope = raw.Scope
+	result.Entrypoint = raw.Entrypoint
 	result.Title = raw.Title
 	result.Description = raw.Description
 	result.Organizations = raw.Organizations

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -109,7 +109,8 @@ The 'build' command supports targets (specified by -t):
     rego    The default target emits a bundle containing a set of policy and data files
             that are semantically equivalent to the input files. If optimizations are
             disabled the output may simply contain a copy of the input policy and data
-            files. If optimization is enabled at least one entrypoint (-e) must be supplied.
+            files. If optimization is enabled at least one entrypoint must be supplied,
+            either via the -e option, or via entrypoint metadata annotations.
 
     wasm    The wasm target emits a bundle containing a WebAssembly module compiled from
             the input files for each specified entrypoint. The bundle may contain the
@@ -267,6 +268,7 @@ func dobuild(params buildParams, args []string) error {
 			return fmt.Errorf("enable bundle mode (ie. --bundle) to verify or sign bundle files or directories")
 		}
 	}
+
 	var capabilities *ast.Capabilities
 	// if capabilities are not provided as a cmd flag,
 	// then ast.CapabilitiesForThisVersion must be called
@@ -276,6 +278,7 @@ func dobuild(params buildParams, args []string) error {
 	} else {
 		capabilities = ast.CapabilitiesForThisVersion()
 	}
+
 	compiler := compile.New().
 		WithCapabilities(capabilities).
 		WithTarget(params.target.String()).
@@ -284,6 +287,7 @@ func dobuild(params buildParams, args []string) error {
 		WithOptimizationLevel(params.optimizationLevel).
 		WithOutput(buf).
 		WithEntrypoints(params.entrypoints.v...).
+		WithRegoAnnotationEntrypoints(true).
 		WithPaths(args...).
 		WithFilter(buildCommandLoaderFilter(params.bundleMode, params.ignore)).
 		WithBundleVerificationConfig(bvc).

--- a/cmd/eval.go
+++ b/cmd/eval.go
@@ -216,8 +216,9 @@ The -O flag controls the optimization level. By default, optimization is disable
 When optimization is enabled the 'eval' command generates a bundle from the files provided
 with either the --bundle or --data flag. This bundle is semantically equivalent to the input
 files however the structure of the files in the bundle may have been changed by rewriting, inlining,
-pruning, etc. This resulting optimized bundle is used to evaluate the query. If optimization is enabled
-at least one entrypoint (-e) must be supplied.
+pruning, etc. This resulting optimized bundle is used to evaluate the query. If optimization is
+enabled at least one entrypoint must be supplied, either via the -e option, or via entrypoint
+metadata annotations.
 
 Output Formats
 --------------
@@ -800,6 +801,7 @@ func generateOptimizedBundle(params evalCommandParams, asBundle bool, filter loa
 		WithOptimizationLevel(params.optimizationLevel).
 		WithOutput(buf).
 		WithEntrypoints(params.entrypoints.v...).
+		WithRegoAnnotationEntrypoints(true).
 		WithPaths(paths...).
 		WithFilter(filter)
 

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -217,6 +217,9 @@ func populateAnnotations(out io.Writer, refs []*ast.AnnotationsRef) error {
 				fmt.Fprintln(out, "Rule:    ", r.Head.Name)
 			}
 			fmt.Fprintln(out, "Location:", ref.Location.String())
+			if a := ref.Annotations; a != nil && a.Entrypoint {
+				fmt.Fprintln(out, "Entrypoint:", a.Entrypoint)
+			}
 			fmt.Fprintln(out)
 
 			if a := ref.Annotations; a != nil {

--- a/docs/content/annotations.md
+++ b/docs/content/annotations.md
@@ -12,6 +12,7 @@ The package and individual rules in a module can be annotated with a rich set of
 # description: A rule that determines if x is allowed.
 # authors:
 # - John Doe <john@example.com>
+# entrypoint: true
 allow {
   ...
 }
@@ -40,6 +41,7 @@ related_resources | list of URLs | A list of URLs pointing to related resources/
 authors | list of strings | A list of authors for the annotation target. Read more [here](#authors).
 organizations | list of strings | A list of organizations related to the annotation target. Read more [here](#organizations).
 schemas | list of object | A list of associations between value paths and schema definitions. Read more [here](#schemas).
+entrypoint | boolean | Whether or not the annotation target is to be used as a policy entrypoint. Read more [here](#entrypoint).
 custom | mapping of arbitrary data | A custom mapping of named parameters holding arbitrary data. Read more [here](#custom).
 
 ### Scope
@@ -235,6 +237,14 @@ allow {
     access[_] == input.operation
 }
 ```
+
+### Entrypoint
+
+The `entrypoint` annotation is a boolean used to mark rules and packages that should be used as entrypoints for a policy.
+This value is false by default, and can only be used at `rule` or `package` scope.
+
+The `build` and `eval` CLI commands will automatically pick up annotated entrypoints; you do not have to specify them with `-e`.
+
 
 ### Custom
 

--- a/docs/content/cli.md
+++ b/docs/content/cli.md
@@ -118,7 +118,8 @@ The 'build' command supports targets (specified by -t):
     rego    The default target emits a bundle containing a set of policy and data files
             that are semantically equivalent to the input files. If optimizations are
             disabled the output may simply contain a copy of the input policy and data
-            files. If optimization is enabled at least one entrypoint (-e) must be supplied.
+            files. If optimization is enabled at least one entrypoint must be supplied,
+            either via the -e option, or via entrypoint metadata annotations.
 
     wasm    The wasm target emits a bundle containing a WebAssembly module compiled from
             the input files for each specified entrypoint. The bundle may contain the
@@ -463,7 +464,7 @@ When optimization is enabled the 'eval' command generates a bundle from the file
 with either the --bundle or --data flag. This bundle is semantically equivalent to the input
 files however the structure of the files in the bundle may have been changed by rewriting, inlining,
 pruning, etc. This resulting optimized bundle is used to evaluate the query. If optimization is enabled
-at least one entrypoint (-e) must be supplied.
+at least one entrypoint must be supplied, either via the -e option, or via entrypoint metadata annotations.
 
 ### Output Formats
 

--- a/docs/content/wasm.md
+++ b/docs/content/wasm.md
@@ -33,7 +33,7 @@ You can compile Rego policies into Wasm modules using the `opa build` subcommand
 
 For example, the `opa build` command below compiles the `example.rego` file into a
 Wasm module and packages it into an OPA bundle. The `wasm` target requires at least
-one entrypoint rule (specified by `-e`).
+one entrypoint rule (specified by `-e`, or a metadata `entrypoint` annotation).
 
 ```bash
 opa build -t wasm -e example/allow example.rego

--- a/internal/runtime/init/init.go
+++ b/internal/runtime/init/init.go
@@ -113,7 +113,7 @@ type Descriptor struct {
 
 // LoadPaths reads data and policy from the given paths and returns a set of bundles or
 // raw loader file results.
-func LoadPaths(paths []string, filter loader.Filter, asBundle bool, bvc *bundle.VerificationConfig, skipVerify bool) (*LoadPathsResult, error) {
+func LoadPaths(paths []string, filter loader.Filter, asBundle bool, bvc *bundle.VerificationConfig, skipVerify bool, processAnnotations bool) (*LoadPathsResult, error) {
 
 	var result LoadPathsResult
 	var err error
@@ -121,8 +121,12 @@ func LoadPaths(paths []string, filter loader.Filter, asBundle bool, bvc *bundle.
 	if asBundle {
 		result.Bundles = make(map[string]*bundle.Bundle, len(paths))
 		for _, path := range paths {
-			result.Bundles[path], err = loader.NewFileLoader().WithBundleVerificationConfig(bvc).
-				WithSkipBundleVerification(skipVerify).WithFilter(filter).AsBundle(path)
+			result.Bundles[path], err = loader.NewFileLoader().
+				WithBundleVerificationConfig(bvc).
+				WithSkipBundleVerification(skipVerify).
+				WithFilter(filter).
+				WithProcessAnnotation(processAnnotations).
+				AsBundle(path)
 			if err != nil {
 				return nil, err
 			}
@@ -130,7 +134,9 @@ func LoadPaths(paths []string, filter loader.Filter, asBundle bool, bvc *bundle.
 		return &result, nil
 	}
 
-	files, err := loader.NewFileLoader().Filtered(paths, filter)
+	files, err := loader.NewFileLoader().
+		WithProcessAnnotation(processAnnotations).
+		Filtered(paths, filter)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/runtime/init/init_test.go
+++ b/internal/runtime/init/init_test.go
@@ -121,7 +121,7 @@ p = true { 1 = 2 }`
 
 				err := storage.Txn(ctx, store, storage.WriteParams, func(txn storage.Transaction) error {
 
-					loaded, err := LoadPaths(paths, nil, tc.asBundle, nil, true)
+					loaded, err := LoadPaths(paths, nil, tc.asBundle, nil, true, false)
 					if err != nil {
 						return err
 					}
@@ -270,7 +270,7 @@ func TestLoadPathsBundleModeWithFilter(t *testing.T) {
 		// bundle mode
 		loaded, err := LoadPaths(paths, func(abspath string, info os.FileInfo, depth int) bool {
 			return loader.GlobExcludeName("*_test.rego", 1)(abspath, info, depth)
-		}, true, nil, true)
+		}, true, nil, true, false)
 		if err != nil {
 			t.Fatalf("Unexpected error: %s", err)
 		}

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -296,7 +296,7 @@ func NewRuntime(ctx context.Context, params Params) (*Runtime, error) {
 		}
 	}
 
-	loaded, err := initload.LoadPaths(params.Paths, params.Filter, params.BundleMode, params.BundleVerificationConfig, params.SkipBundleVerification)
+	loaded, err := initload.LoadPaths(params.Paths, params.Filter, params.BundleMode, params.BundleVerificationConfig, params.SkipBundleVerification, false)
 	if err != nil {
 		return nil, fmt.Errorf("load error: %w", err)
 	}
@@ -710,7 +710,7 @@ func (rt *Runtime) readWatcher(ctx context.Context, watcher *fsnotify.Watcher, p
 
 func (rt *Runtime) processWatcherUpdate(ctx context.Context, paths []string, removed string) error {
 
-	loaded, err := initload.LoadPaths(paths, rt.Params.Filter, rt.Params.BundleMode, nil, true)
+	loaded, err := initload.LoadPaths(paths, rt.Params.Filter, rt.Params.BundleMode, nil, true, false)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR implements basic support for entrypoint rule/package annotations in Rego. This feature means that optimized bundle builds, WASM, and Plan target compilation all no longer require a CLI argument for the entrypoint, so long as at least one rule was annotated as an entrypoint in the policies provided.

Fixes: #3459

-----

Remaining Work:

 - [x] New annotation struct field + helpers/validation.
 - [x] Entrypoint extraction in `compile`.
 - [x] Re-plumb CLI commands to use the extraction utility, or extract the entrypoints during parsing.
 - [x] Update relevant tests + add new testcases for CLI commands.