### PR TITLE
ast/compile: don't lookup Call TreeNode children

### DIFF
--- a/ast/compile.go
+++ b/ast/compile.go
@@ -3106,7 +3106,7 @@ func (n *TreeNode) Size() int {
 // Child returns n's child with key k.
 func (n *TreeNode) Child(k Value) *TreeNode {
 	switch k.(type) {
-	case Ref:
+	case Ref, Call:
 		return nil
 	default:
 		return n.Children[k]


### PR DESCRIPTION
This fixes this crasher, identified by the nightly fuzz run:

    package A
    A0 {
      A(0).A(0)
    }

👉 https://github.com/open-policy-agent/opa/actions/runs/3258760618/jobs/5351087330#step:6:7