### PR TITLE
planner: when planning a ref's extent, plan the keys as values

### DIFF
--- a/test/cases/testdata/refheads/test-regressions.yaml
+++ b/test/cases/testdata/refheads/test-regressions.yaml
@@ -114,3 +114,41 @@ cases:
   query: data.test.p[{"a":"b"}] = x
   want_result:
   - x: true
+- note: regression/full extent with non-string (number) last term
+  modules:
+  - |
+    package test
+    p[0] = true
+  query: data.test = x
+  want_result:
+  - x:
+     p:
+       "0": true # stringified key
+- note: regression/full extent with non-string last term, comparison
+  modules:
+  - |
+    package test
+    p[0] = 1
+    q { p[0] == 1 }
+  query: data.test.q = x
+  want_result:
+  - x: true
+- note: regression/full extent with non-string (boolean) last term
+  modules:
+  - |
+    package test
+    p[true] = true
+  query: data.test = x
+  want_result:
+  - x:
+     p:
+       "true": true # stringified key
+- note: regression/full extent with non-string last term, comparison
+  modules:
+  - |
+    package test
+    p[true] = false
+    q { p[true] == false }
+  query: data.test.q = x
+  want_result:
+  - x: true


### PR DESCRIPTION
The compiler ensures that all the keys we see there are scalars. For strings, nothing changes -- they're handled just like before -- but this now also allows numbers and booleans.

An example policy that exploded with a panic before is

    package p
    a[0] = true

when querying the full extent of `data.p` or `data.p.a`.

Fixes #5252.
