### PR TITLE
testdata: add cases for peculiar data deref of integer keys

### DIFF
--- a/internal/wasm/sdk/test/e2e/exceptions.yaml
+++ b/internal/wasm/sdk/test/e2e/exceptions.yaml
@@ -1,2 +1,4 @@
 # Exception Format is <test name>: <reason>
 "functions/default": "not supported in topdown, https://github.com/open-policy-agent/opa/issues/2445"
+"data/toplevel integer": "https://github.com/open-policy-agent/opa/issues/3711"
+"data/nested integer": "https://github.com/open-policy-agent/opa/issues/3711"

--- a/test/cases/testdata/dataderef/test-data-derefs.yaml
+++ b/test/cases/testdata/dataderef/test-data-derefs.yaml
@@ -1,0 +1,34 @@
+cases:
+- data:
+    "2": bar
+  modules:
+  - |
+    package test
+    p := data[2]
+  note: data/toplevel integer
+  query: data.test.p = x
+  want_result:
+  - x: bar
+- data:
+    nested:
+      "2": bar
+  modules:
+  - |
+    package test
+    p := data.nested[2]
+  note: data/nested integer
+  query: data.test.p = x
+  want_result:
+  - x: bar
+- data:
+    nested:
+      "2": bar
+  modules:
+  - |
+    package test
+    p := obj[2] {
+      obj := data.nested
+    }
+  note: "data/negative case: nested integer"
+  query: data.test.p = x
+  want_result: []


### PR DESCRIPTION
See https://github.com/open-policy-agent/opa/issues/3711.
