### PR TITLE
ast/index: skip indexing if glob.match output is captured

### DIFF
--- a/ast/index.go
+++ b/ast/index.go
@@ -246,15 +246,20 @@ func (i *refindices) Update(rule *Rule, expr *Expr) {
 
 	op := expr.Operator()
 
-	if op.Equal(Equality.Ref()) {
+	switch {
+	case op.Equal(Equality.Ref()):
 		i.updateEq(rule, expr)
-	} else if op.Equal(Equal.Ref()) && len(expr.Operands()) == 2 {
+
+	case op.Equal(Equal.Ref()) && len(expr.Operands()) == 2:
 		// NOTE(tsandall): if equal() is called with more than two arguments the
 		// output value is being captured in which case the indexer cannot
 		// exclude the rule if the equal() call would return false (because the
 		// false value must still be produced.)
 		i.updateEq(rule, expr)
-	} else if op.Equal(GlobMatch.Ref()) {
+
+	case op.Equal(GlobMatch.Ref()) && len(expr.Operands()) == 3:
+		// NOTE(sr): Same as with equal() above -- 4 operands means the output
+		// of `glob.match` is captured and the rule can thus not be excluded.
 		i.updateGlobMatch(rule, expr)
 	}
 }

--- a/ast/index_test.go
+++ b/ast/index_test.go
@@ -496,6 +496,17 @@ func TestBaseDocEqIndexing(t *testing.T) {
 			expectedRS: []string{},
 		},
 		{
+			note: "glob.match: do not index captured output",
+			module: MustParseModule(`package test
+				p { x = input.x; glob.match("/a/*/c", ["/"], x, false) }
+			`),
+			ruleset: "p",
+			input:   `{"x": "wrong"}`,
+			expectedRS: []string{
+				`p { x = input.x; glob.match("/a/*/c", ["/"], x, false) }`,
+			},
+		},
+		{
 			note: "functions: args match",
 			module: MustParseModule(`package test
 			f(x) = y {

--- a/test/cases/testdata/globmatch/test-globmatch-issue-5273.yaml
+++ b/test/cases/testdata/globmatch/test-globmatch-issue-5273.yaml
@@ -1,8 +1,7 @@
 cases:
-- data: {}
-  modules:
+- modules:
   - |
-    package generated
+    package test
 
     p[x] {
       glob.match("*.github.com", ["."], "api.github.com", x)
@@ -10,8 +9,7 @@ cases:
     }
   # See: https://github.com/open-policy-agent/opa/issues/5273
   note: globmatch/no deadlocks for glob match
-  query: data.generated.p = x
-  sort_bindings: true
+  query: data.test.p = x
   want_result:
   - x:
     - true

--- a/test/cases/testdata/globmatch/test-globmatch-issue-5283.yaml
+++ b/test/cases/testdata/globmatch/test-globmatch-issue-5283.yaml
@@ -1,0 +1,24 @@
+# See https://github.com/open-policy-agent/opa/issues/528
+cases:
+- modules:
+  - |
+    package test
+    p = x {
+      x := glob.match("*.github.com", ["."], input)
+    }
+  input: api.example.com
+  note: globmatch/captured negative results, variable
+  query: data.test.p = x
+  want_result:
+  - x: false
+- modules:
+  - |
+    package test
+    p {
+      glob.match("*.github.com", ["."], input, false)
+    }
+  input: api.example.com
+  note: globmatch/captured negative result, constant
+  query: data.test.p = x
+  want_result:
+  - x: true


### PR DESCRIPTION
We had been taking care of this case for equal(), but not for glob.match.

Now, we'll get the correct results for this policy, with and without indexing:

     package play

     p = x {
      	x := glob.match("/a/*/c", ["/"], input.path)
     }

Fixes #5283.