### PR TITLE
ast/compile: rewrite ref-replacements with non-function values

### DIFF
--- a/ast/compile.go
+++ b/ast/compile.go
@@ -5151,7 +5151,7 @@ func validateWith(c *Compiler, unsafeBuiltinsMap map[string]struct{}, expr *Expr
 				for _, v := range child.Values {
 					if len(v.(*Rule).Head.Args) > 0 {
 						if ok, err := validateWithFunctionValue(c.builtins, unsafeBuiltinsMap, c.RuleTree, value); err != nil || ok {
-							return false, err // may be nil
+							return false, err // err may be nil
 						}
 					}
 				}
@@ -5173,7 +5173,7 @@ func validateWith(c *Compiler, unsafeBuiltinsMap map[string]struct{}, expr *Expr
 		}
 
 		if ok, err := validateWithFunctionValue(c.builtins, unsafeBuiltinsMap, c.RuleTree, value); err != nil || ok {
-			return false, err // may be nil
+			return false, err // err may be nil
 		}
 	default:
 		return false, NewError(TypeErr, target.Location, "with keyword target must reference existing %v, %v, or a function", InputRootDocument, DefaultRootDocument)

--- a/ast/compile_test.go
+++ b/ast/compile_test.go
@@ -5293,6 +5293,27 @@ func TestCompilerRewriteWithValue(t *testing.T) {
 			expected: `p { true with http.send as {"body": "yay"} }`,
 		},
 		{
+			note: "built-in function: replaced by var",
+			input: `
+				p {
+					resp := { "body": "yay" }
+					true with http.send as resp
+				}
+			`,
+			expected: `p { __local0__ = {"body": "yay"}; true with http.send as __local0__ }`,
+		},
+		{
+			note: "non-built-in function: replaced by var",
+			input: `
+				p {
+					resp := true
+					f(true) with f as resp
+				}
+				f(false) { true }
+			`,
+			expected: `p { __local0__ = true; data.test.f(true) with data.test.f as __local0__ }`,
+		},
+		{
 			note: "built-in function: replaced by comprehension",
 			input: `
 				p { true with http.send as { x: true | x := ["a", "b"][_] } }

--- a/docs/content/policy-language.md
+++ b/docs/content/policy-language.md
@@ -1744,7 +1744,8 @@ When `<target>` is a reference to a function, like `http.send`, then
 its `<value>` can be any of the following:
 1. a value: `with http.send as {"body": {"success": true }}`
 2. a reference to another function: `with http.send as mock_http_send`
-3. a reference to another (possibly custom) built-in function: `with custom_builtin as less_strict_custom_builtin`.
+3. a reference to another (possibly custom) built-in function: `with custom_builtin as less_strict_custom_builtin`
+4. a reference to a rule that will be used as the _value_.
 
 When the replacement value is a function, its arity needs to match the replaced
 function's arity; and the types must be compatible.

--- a/internal/wasm/sdk/test/e2e/exceptions.yaml
+++ b/internal/wasm/sdk/test/e2e/exceptions.yaml
@@ -2,3 +2,5 @@
 "functions/default": "not supported in topdown, https://github.com/open-policy-agent/opa/issues/2445"
 "data/toplevel integer": "https://github.com/open-policy-agent/opa/issues/3711"
 "data/nested integer": "https://github.com/open-policy-agent/opa/issues/3711"
+"withkeyword/function: indirect call, arity 1, replacement is value that needs eval (array comprehension)": "https://github.com/open-policy-agent/opa/issues/5311"
+"withkeyword/builtin: indirect call, arity 1, replacement is value that needs eval (array comprehension)": "https://github.com/open-policy-agent/opa/issues/5311"

--- a/test/cases/testdata/withkeyword/test-with-builtin-mock.yaml
+++ b/test/cases/testdata/withkeyword/test-with-builtin-mock.yaml
@@ -1,6 +1,5 @@
 cases:
-- data:
-  modules:
+- modules:
   - |
     package test
 
@@ -12,8 +11,7 @@ cases:
   query: data.test.p = x
   want_result:
   - x: 1
-- data:
-  modules:
+- modules:
   - |
     package test
 
@@ -25,8 +23,7 @@ cases:
   query: data.test.p = x
   want_result:
   - x: 1
-- data:
-  modules:
+- modules:
   - |
     package test
 
@@ -41,8 +38,7 @@ cases:
   query: data.test.p = x
   want_result:
   - x: true
-- data:
-  modules:
+- modules:
   - |
     package test
 
@@ -57,8 +53,7 @@ cases:
   query: data.test.p = x
   want_result:
   - x: true
-- data:
-  modules:
+- modules:
   - |
     package test
 
@@ -74,8 +69,7 @@ cases:
   query: data.test.p = x
   want_result:
   - x: true
-- data:
-  modules:
+- modules:
   - |
     package test
 
@@ -92,8 +86,7 @@ cases:
   - x:
       f: 1
       p: true
-- data:
-  modules:
+- modules:
   - |
     package test
     import future.keywords.in
@@ -115,8 +108,7 @@ cases:
   query: data.test.test_allow = x
   want_result:
   - x: true
-- data:
-  modules:
+- modules:
   - |
     package test
     import future.keywords.in
@@ -153,8 +145,7 @@ cases:
   query: data.test.test_allow = x
   want_result:
   - x: true
-- data:
-  modules:
+- modules:
   - |
     package test
 
@@ -170,8 +161,7 @@ cases:
   query: data.test.p = x
   want_result:
   - x: true
-- data:
-  modules:
+- modules:
   - |
     package test
 
@@ -188,8 +178,7 @@ cases:
   query: data.test.p = x
   want_result:
   - x: true
-- data:
-  modules:
+- modules:
   - |
     package test
 
@@ -207,8 +196,7 @@ cases:
   - x:
       f: 1
       p: true 
-- data:
-  modules:
+- modules:
   - |
     package test
     import future.keywords.in
@@ -229,8 +217,7 @@ cases:
     - 1
     - 3
     - 4
-- data:
-  modules:
+- modules:
   - |
     package test
     import future.keywords.in
@@ -246,8 +233,7 @@ cases:
   query: data.test.p = x
   want_result:
   - x: [["one"]]
-- data:
-  modules:
+- modules:
   - |
     package test
     import future.keywords.in
@@ -276,8 +262,7 @@ cases:
   query: data.test.p = x
   want_result:
   - x: [["one"]]
-- data:
-  modules:
+- modules:
   - |
     package test
 
@@ -294,8 +279,7 @@ cases:
   query: data.test.p = x
   want_result:
   - x: 1
-- data:
-  modules:
+- modules:
   - |
     package test
 
@@ -314,8 +298,7 @@ cases:
   query: data.test.p = x
   want_result:
   - x: true
-- data:
-  modules:
+- modules:
   - |
     package test
 
@@ -333,8 +316,7 @@ cases:
   query: data.test.p = x
   want_result:
   - x: true
-- data:
-  modules:
+- modules:
   - |
     package test
 
@@ -345,8 +327,7 @@ cases:
   query: data.test.p = x
   want_result:
   - x: 12300
-- data:
-  modules:
+- modules:
   - |
     package test
 
@@ -356,8 +337,7 @@ cases:
   note: 'withkeyword/builtin-value: arity-0, false'
   query: data.test.p = x
   want_result: []
-- data:
-  modules:
+- modules:
   - |
     package test
 
@@ -368,8 +348,7 @@ cases:
   query: data.test.p = x
   want_result:
   - x: true
-- data:
-  modules:
+- modules:
   - |
     package test
 
@@ -381,8 +360,7 @@ cases:
   query: data.test.p = x
   want_result:
   - x: true
-- data:
-  modules:
+- modules:
   - |
     package test
 
@@ -393,8 +371,7 @@ cases:
   query: data.test.p = x
   want_result:
   - x: true
-- data:
-  modules:
+- modules:
   - |
     package test
 
@@ -405,8 +382,7 @@ cases:
   query: data.test.p = x
   want_result:
   - x: true
-- data:
-  modules:
+- modules:
   - |
     package test
 
@@ -416,8 +392,7 @@ cases:
   note: 'withkeyword/builtin-value: arity-1, input must still be defined'
   query: data.test.p = x
   want_result: []
-- data:
-  modules:
+- modules:
   - |
     package test
 
@@ -428,8 +403,7 @@ cases:
   query: data.test.p = x
   want_result:
   - x: {}
-- data:
-  modules:
+- modules:
   - |
     package test
 
@@ -441,8 +415,7 @@ cases:
   want_result:
   - x:
       foo: 3
-- data:
-  modules:
+- modules:
   - |
     package test
 
@@ -453,3 +426,26 @@ cases:
   query: data.test.p = x
   want_result:
   - x: 2
+- modules:
+  - |
+    package test
+    p {
+      count([1,2,3]) == 1 with count as [1|true][0]
+    }
+  note: 'withkeyword/builtin: direct call, arity 1, replacement is value that needs eval (array comprehension)'
+  query: data.test.p = x
+  want_result:
+  - x: true
+- modules:
+  - |
+    package test
+    p {
+      q with count as [1|true][0]
+    }
+    q {
+      count([1,2,3]) == 1
+    }
+  note: 'withkeyword/builtin: indirect call, arity 1, replacement is value that needs eval (array comprehension)'
+  query: data.test.p = x
+  want_result:
+  - x: true

--- a/test/cases/testdata/withkeyword/test-with-function-mock.yaml
+++ b/test/cases/testdata/withkeyword/test-with-function-mock.yaml
@@ -1,6 +1,5 @@
 cases:
-- data:
-  modules:
+- modules:
   - |
     package test
     f(_) = 2
@@ -11,8 +10,7 @@ cases:
   query: data.test.p = x
   want_result:
   - x: 1
-- data:
-  modules:
+- modules:
   - |
     package test
     f(_) = 2
@@ -24,8 +22,7 @@ cases:
   query: data.test.p = x
   want_result:
   - x: 1
-- data:
-  modules:
+- modules:
   - |
     package test
     f(_) = 2
@@ -37,8 +34,7 @@ cases:
   query: data.test.p = x
   want_result:
   - x: true
-- data:
-  modules:
+- modules:
   - |
     package test
     f(_) = 2
@@ -49,8 +45,7 @@ cases:
   query: data.test.p = x
   want_result:
   - x: 1
-- data:
-  modules:
+- modules:
   - |
     package test
     f(_) = 2
@@ -61,8 +56,7 @@ cases:
   query: data.test.p = x
   want_result:
   - x: true
-- data:
-  modules:
+- modules:
   - |
     package test
 
@@ -83,8 +77,7 @@ cases:
   query: data.test.p = x
   want_result:
   - x: true
-- data:
-  modules:
+- modules:
   - |
     package test
 
@@ -95,8 +88,7 @@ cases:
   query: data.test.p = x
   want_result:
   - x: 2
-- data:
-  modules:
+- modules:
   - |
     package test
 
@@ -108,3 +100,28 @@ cases:
   query: data.test.p = x
   want_result:
   - x: 2
+- modules:
+  - |
+    package test
+    f(_) = 1
+    p {
+      f([1,2,3]) == 1 with f as [1|true][0]
+    }
+  note: 'withkeyword/function: direct call, arity 1, replacement is value that needs eval (array comprehension)'
+  query: data.test.p = x
+  want_result:
+  - x: true
+- modules:
+  - |
+    package test
+    f(_) = 1
+    p {
+      q with f as [1|true][0]
+    }
+    q {
+      f([1,2,3]) == 1
+    }
+  note: 'withkeyword/function: indirect call, arity 1, replacement is value that needs eval (array comprehension)'
+  query: data.test.p = x
+  want_result:
+  - x: true

--- a/test/cases/testdata/withkeyword/test-with-function-mocks-issue-5299.yaml
+++ b/test/cases/testdata/withkeyword/test-with-function-mocks-issue-5299.yaml
@@ -1,0 +1,59 @@
+cases:
+- modules:
+  - |
+    package test
+    f(_) = 2
+    f0 := 1 # a rule
+    p = y {
+      y = f(true) with f as f0
+    }
+  note: 'withkeyword/function: direct call, rule replacement'
+  query: data.test.p = x
+  want_result:
+  - x: 1
+- modules:
+  - |
+    package test
+    f(_) = 2
+    f0 := 1 # a rule
+    p {
+      f(true, 1) with f as f0
+    }
+  note: 'withkeyword/function: captured result, rule replacement'
+  query: data.test.p = x
+  want_result:
+  - x: true
+- modules:
+  - |
+    package test
+    f := 1 # a rule
+    p = y {
+      y = time.now_ns() with time.now_ns as f
+    }
+  note: 'withkeyword/builtin: direct call, arity 0, rule replacement'
+  query: data.test.p = x
+  want_result:
+  - x: 1
+- modules:
+  - |
+    package test
+    f := 1 # a rule
+    p = y {
+      y = count([1,2,3]) with count as f
+    }
+  note: 'withkeyword/builtin: direct call, arity 1, rule replacement'
+  query: data.test.p = x
+  want_result:
+  - x: 1
+- modules:
+  - |
+    package test
+    f := 1 # a rule
+    g(x) := count(x)
+    p = y {
+      y = g([1,2,3]) with count as f
+    }
+  note: 'withkeyword/builtin: indirect call, arity 1, rule replacement'
+  query: data.test.p = x
+  want_result:
+  - x: 1

--- a/topdown/eval.go
+++ b/topdown/eval.go
@@ -727,20 +727,18 @@ func (e *eval) evalCall(terms []*ast.Term, iter unifyIterator) error {
 	var mocked bool
 	mock, mocked := e.functionMocks.Get(ref)
 	if mocked {
-		if m, ok := mock.Value.(ast.Ref); ok { // builtin or data function
-			if _, ok := e.compiler.TypeEnv.Get(m).(*types.Function); ok {
-				mockCall := append([]*ast.Term{ast.NewTerm(m)}, terms[1:]...)
+		if m, ok := mock.Value.(ast.Ref); ok && isFunction(e.compiler.TypeEnv, m) { // builtin or data function
+			mockCall := append([]*ast.Term{ast.NewTerm(m)}, terms[1:]...)
 
-				e.functionMocks.Push()
-				err := e.evalCall(mockCall, func() error {
-					e.functionMocks.Pop()
-					err := iter()
-					e.functionMocks.Push()
-					return err
-				})
+			e.functionMocks.Push()
+			err := e.evalCall(mockCall, func() error {
 				e.functionMocks.Pop()
+				err := iter()
+				e.functionMocks.Push()
 				return err
-			}
+			})
+			e.functionMocks.Pop()
+			return err
 		}
 	}
 	// 'mocked' true now indicates that the replacement is a value: if
@@ -3404,12 +3402,19 @@ func isOtherRef(term *ast.Term) bool {
 	return !ref.HasPrefix(ast.DefaultRootRef) && !ref.HasPrefix(ast.InputRootRef)
 }
 
-func isFunction(env *ast.TypeEnv, ref *ast.Term) bool {
-	r, ok := ref.Value.(ast.Ref)
-	if !ok {
+func isFunction(env *ast.TypeEnv, ref interface{}) bool {
+	var r ast.Ref
+	switch v := ref.(type) {
+	case ast.Ref:
+		r = v
+	case *ast.Term:
+		return isFunction(env, v.Value)
+	case ast.Value:
 		return false
+	default:
+		panic("expected ast.Value or *ast.Term")
 	}
-	_, ok = env.Get(r).(*types.Function)
+	_, ok := env.Get(r).(*types.Function)
 	return ok
 }
 


### PR DESCRIPTION
Before, this was OK:

    test_a {
    . mock_f := true
      allow with f as mock_f
    }

but this had panicked:

    mock_f := true
    test_a {
      allow with f as mock_f
    }

Which, from a user perspective, is quite incomprehensible. Technically, the first snippet was a (supported) replacement-by-value, and the second was an unsupported replacement by a rule that was not a function.

Furthermore, the second case wasn't properly caught in the 'with' validations.

Now, we'll capture the situation, and start supporting it. Both snippets will now work the same, as one would expect from the language surface.

Fixes #5299.