### PR TITLE
ci(pull-request): setup-opa@v1 -> setup-opa@v2

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -317,7 +317,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Download OPA
-        uses: open-policy-agent/setup-opa@v1
+        uses: open-policy-agent/setup-opa@v2
         with:
           version: edge
 


### PR DESCRIPTION
This should get us rid of the node 12 warning.