### PR TITLE
cidr_is_valid: add function to validate network cidr

### DIFF
--- a/ast/builtins.go
+++ b/ast/builtins.go
@@ -260,6 +260,7 @@ var DefaultBuiltins = [...]*Builtin{
 	NetCIDRExpand,
 	NetCIDRMerge,
 	NetLookupIPAddr,
+	NetCIDRParse,
 
 	// Glob
 	GlobMatch,
@@ -2768,6 +2769,17 @@ Supports both IPv4 and IPv6 notations. IPv6 inputs need a prefix length (e.g. "/
 			)).Description("CIDRs or IP addresses"),
 		),
 		types.Named("output", types.NewSet(types.S)).Description("smallest possible set of CIDRs obtained after merging the provided list of IP addresses and subnets in `addrs`"),
+	),
+}
+
+var NetCIDRParse = &Builtin{
+	Name:        "net.cidr_parse",
+	Description: "Parses IPv4/IPv6 CIDRs. Returns a boolean indicating if the provided CIDR is valid.",
+	Decl: types.NewFunction(
+		types.Args(
+			types.Named("cidr", types.S),
+		),
+		types.Named("result", types.B),
 	),
 }
 

--- a/ast/builtins.go
+++ b/ast/builtins.go
@@ -260,7 +260,7 @@ var DefaultBuiltins = [...]*Builtin{
 	NetCIDRExpand,
 	NetCIDRMerge,
 	NetLookupIPAddr,
-	NetCIDRParse,
+	NetCIDRIsValid,
 
 	// Glob
 	GlobMatch,
@@ -2772,9 +2772,9 @@ Supports both IPv4 and IPv6 notations. IPv6 inputs need a prefix length (e.g. "/
 	),
 }
 
-var NetCIDRParse = &Builtin{
-	Name:        "net.cidr_parse",
-	Description: "Parses IPv4/IPv6 CIDRs. Returns a boolean indicating if the provided CIDR is valid.",
+var NetCIDRIsValid = &Builtin{
+	Name:        "net.cidr_is_valid",
+	Description: "Parses an IPv4/IPv6 CIDR and returns a boolean indicating if the provided CIDR is valid.",
 	Decl: types.NewFunction(
 		types.Args(
 			types.Named("cidr", types.S),

--- a/builtin_metadata.json
+++ b/builtin_metadata.json
@@ -94,9 +94,9 @@
       "net.cidr_contains_matches",
       "net.cidr_expand",
       "net.cidr_intersects",
+      "net.cidr_is_valid",
       "net.cidr_merge",
       "net.cidr_overlap",
-      "net.cidr_parse",
       "net.lookup_ip_addr"
     ],
     "numbers": [
@@ -8597,6 +8597,24 @@
     },
     "wasm": true
   },
+  "net.cidr_is_valid": {
+    "args": [
+      {
+        "name": "cidr",
+        "type": "string"
+      }
+    ],
+    "available": [
+      "edge"
+    ],
+    "description": "Parses an IPv4/IPv6 CIDR and returns a boolean indicating if the provided CIDR is valid.",
+    "introduced": "edge",
+    "result": {
+      "name": "result",
+      "type": "boolean"
+    },
+    "wasm": false
+  },
   "net.cidr_merge": {
     "args": [
       {
@@ -8748,24 +8766,6 @@
       "type": "boolean"
     },
     "wasm": true
-  },
-  "net.cidr_parse": {
-    "args": [
-      {
-        "name": "cidr",
-        "type": "string"
-      }
-    ],
-    "available": [
-      "edge"
-    ],
-    "description": "Parses IPv4/IPv6 CIDRs. Returns a boolean indicating if the provided CIDR is valid.",
-    "introduced": "edge",
-    "result": {
-      "name": "result",
-      "type": "boolean"
-    },
-    "wasm": false
   },
   "net.lookup_ip_addr": {
     "args": [

--- a/builtin_metadata.json
+++ b/builtin_metadata.json
@@ -96,6 +96,7 @@
       "net.cidr_intersects",
       "net.cidr_merge",
       "net.cidr_overlap",
+      "net.cidr_parse",
       "net.lookup_ip_addr"
     ],
     "numbers": [
@@ -8747,6 +8748,24 @@
       "type": "boolean"
     },
     "wasm": true
+  },
+  "net.cidr_parse": {
+    "args": [
+      {
+        "name": "cidr",
+        "type": "string"
+      }
+    ],
+    "available": [
+      "edge"
+    ],
+    "description": "Parses IPv4/IPv6 CIDRs. Returns a boolean indicating if the provided CIDR is valid.",
+    "introduced": "edge",
+    "result": {
+      "name": "result",
+      "type": "boolean"
+    },
+    "wasm": false
   },
   "net.lookup_ip_addr": {
     "args": [

--- a/capabilities.json
+++ b/capabilities.json
@@ -2562,6 +2562,20 @@
       }
     },
     {
+      "name": "net.cidr_is_valid",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "boolean"
+        },
+        "type": "function"
+      }
+    },
+    {
       "name": "net.cidr_merge",
       "decl": {
         "args": [
@@ -2604,20 +2618,6 @@
           {
             "type": "string"
           },
-          {
-            "type": "string"
-          }
-        ],
-        "result": {
-          "type": "boolean"
-        },
-        "type": "function"
-      }
-    },
-    {
-      "name": "net.cidr_parse",
-      "decl": {
-        "args": [
           {
             "type": "string"
           }

--- a/capabilities.json
+++ b/capabilities.json
@@ -2615,6 +2615,20 @@
       }
     },
     {
+      "name": "net.cidr_parse",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "boolean"
+        },
+        "type": "function"
+      }
+    },
+    {
       "name": "net.lookup_ip_addr",
       "decl": {
         "args": [

--- a/test/cases/testdata/netcidrisvalid/test_netcidrisvalid-0001.yaml
+++ b/test/cases/testdata/netcidrisvalid/test_netcidrisvalid-0001.yaml
@@ -1,0 +1,66 @@
+cases:
+- data: {}
+  modules:
+  - |
+    package generated
+
+    p = x {
+      net.cidr_is_valid("192.168.1.0/24", __local0__)
+      x = __local0__
+    }
+  note: valid ipv4 cidr
+  query: data.generated.p = x
+  want_result:
+  - x: true
+- data: {}
+  modules:
+  - |
+    package generated
+
+    p = x {
+      net.cidr_is_valid("", __local0__)
+      x = __local0__
+    }
+  note: empty cidr
+  query: data.generated.p = x
+  want_result:
+  - x: false
+- data: {}
+  modules:
+  - |
+    package generated
+
+    p = x {
+      net.cidr_is_valid("there goes a string", __local0__)
+      x = __local0__
+    }
+  note: random string
+  query: data.generated.p = x
+  want_result:
+  - x: false
+- data: {}
+  modules:
+  - |
+    package generated
+
+    p = x {
+      net.cidr_is_valid("192.168.1.2", __local0__)
+      x = __local0__
+    }
+  note: valid ipv4 address
+  query: data.generated.p = x
+  want_result:
+  - x: false
+- data: {}
+  modules:
+  - |
+    package generated
+
+    p = x {
+      net.cidr_is_valid("2002::1234:abcd:ffff:c0a8:101/64", __local0__)
+      x = __local0__
+    }
+  note: valid ipv6 cidr
+  query: data.generated.p = x
+  want_result:
+  - x: true

--- a/topdown/cidr.go
+++ b/topdown/cidr.go
@@ -216,6 +216,18 @@ func builtinNetCIDRExpand(bctx BuiltinContext, operands []*ast.Term, iter func(*
 	return iter(ast.NewTerm(result))
 }
 
+func builtinNetCIDRParse(bctx BuiltinContext, operands []*ast.Term, iter func(*ast.Term) error) error {
+	cidr, err := builtins.StringOperand(operands[0].Value, 1)
+	if err != nil {
+		return iter(ast.BooleanTerm(false))
+	}
+
+	if _, _, err := net.ParseCIDR(string(cidr)); err != nil {
+		return iter(ast.BooleanTerm(false))
+	}
+	return iter(ast.BooleanTerm(true))
+}
+
 type cidrBlockRange struct {
 	First   *net.IP
 	Last    *net.IP
@@ -402,4 +414,5 @@ func init() {
 	RegisterBuiltinFunc(ast.NetCIDRContainsMatches.Name, builtinNetCIDRContainsMatches)
 	RegisterBuiltinFunc(ast.NetCIDRExpand.Name, builtinNetCIDRExpand)
 	RegisterBuiltinFunc(ast.NetCIDRMerge.Name, builtinNetCIDRMerge)
+	RegisterBuiltinFunc(ast.NetCIDRParse.Name, builtinNetCIDRParse)
 }

--- a/topdown/cidr.go
+++ b/topdown/cidr.go
@@ -216,7 +216,7 @@ func builtinNetCIDRExpand(bctx BuiltinContext, operands []*ast.Term, iter func(*
 	return iter(ast.NewTerm(result))
 }
 
-func builtinNetCIDRParse(bctx BuiltinContext, operands []*ast.Term, iter func(*ast.Term) error) error {
+func builtinNetCIDRIsValid(bctx BuiltinContext, operands []*ast.Term, iter func(*ast.Term) error) error {
 	cidr, err := builtins.StringOperand(operands[0].Value, 1)
 	if err != nil {
 		return iter(ast.BooleanTerm(false))
@@ -414,5 +414,5 @@ func init() {
 	RegisterBuiltinFunc(ast.NetCIDRContainsMatches.Name, builtinNetCIDRContainsMatches)
 	RegisterBuiltinFunc(ast.NetCIDRExpand.Name, builtinNetCIDRExpand)
 	RegisterBuiltinFunc(ast.NetCIDRMerge.Name, builtinNetCIDRMerge)
-	RegisterBuiltinFunc(ast.NetCIDRParse.Name, builtinNetCIDRParse)
+	RegisterBuiltinFunc(ast.NetCIDRIsValid.Name, builtinNetCIDRIsValid)
 }

--- a/topdown/cidr.go
+++ b/topdown/cidr.go
@@ -216,7 +216,7 @@ func builtinNetCIDRExpand(bctx BuiltinContext, operands []*ast.Term, iter func(*
 	return iter(ast.NewTerm(result))
 }
 
-func builtinNetCIDRIsValid(bctx BuiltinContext, operands []*ast.Term, iter func(*ast.Term) error) error {
+func builtinNetCIDRIsValid(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term) error) error {
 	cidr, err := builtins.StringOperand(operands[0].Value, 1)
 	if err != nil {
 		return iter(ast.BooleanTerm(false))

--- a/topdown/cidr_test.go
+++ b/topdown/cidr_test.go
@@ -2,7 +2,6 @@ package topdown
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -44,76 +43,4 @@ func TestNetCIDRExpandCancellation(t *testing.T) {
 		t.Fatalf("Expected cancel error but got: %v (err: %v)", qrs, err)
 	}
 
-}
-
-func TestNetCIDRIsValid(t *testing.T) {
-	ctx := context.Background()
-	store := inmem.New()
-	txn := storage.NewTransactionOrDie(ctx, store)
-
-	for _, tt := range []struct {
-		name     string
-		cidr     string
-		expected bool
-	}{
-		{
-			name:     "valid ipv4 cidr",
-			cidr:     `192.168.1.0/24`,
-			expected: true,
-		},
-		{
-			name:     "empty cidr",
-			cidr:     "",
-			expected: false,
-		},
-		{
-			name:     "string",
-			cidr:     "there goes a string",
-			expected: false,
-		},
-		{
-			name:     "valid ipv4 address",
-			cidr:     `192.168.1.2`,
-			expected: false,
-		},
-		{
-			name:     "valid ipv6 cidr",
-			cidr:     `2002::1234:abcd:ffff:c0a8:101/64`,
-			expected: true,
-		},
-	} {
-		t.Run(tt.name, func(t *testing.T) {
-			module := fmt.Sprintf(
-				`
-				package test
-				default valid = false
-				valid { net.cidr_is_valid(%q) }
-				`,
-				tt.cidr,
-			)
-
-			compiler := compileModules([]string{module})
-
-			query := NewQuery(ast.MustParseBody("data.test.valid = x")).
-				WithCompiler(compiler).
-				WithStore(store).
-				WithTransaction(txn)
-
-			qrs, err := query.Run(ctx)
-			if err != nil {
-				t.Fatalf("unexpected error: %s", err)
-				return
-			}
-
-			if len(qrs) != 1 {
-				t.Fatalf("unexpected query result set size: %+v", qrs)
-				return
-			}
-
-			val := qrs[0][ast.Var("x")].String()
-			if fmt.Sprintf("%v", tt.expected) != val {
-				t.Errorf("expected %v, received %v", tt.expected, val)
-			}
-		})
-	}
 }

--- a/topdown/cidr_test.go
+++ b/topdown/cidr_test.go
@@ -2,6 +2,7 @@ package topdown
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -43,4 +44,76 @@ func TestNetCIDRExpandCancellation(t *testing.T) {
 		t.Fatalf("Expected cancel error but got: %v (err: %v)", qrs, err)
 	}
 
+}
+
+func TestNetCIDRParse(t *testing.T) {
+	ctx := context.Background()
+	store := inmem.New()
+	txn := storage.NewTransactionOrDie(ctx, store)
+
+	for _, tt := range []struct {
+		name     string
+		cidr     string
+		expected bool
+	}{
+		{
+			name:     "valid ipv4 cidr",
+			cidr:     `192.168.1.0/24`,
+			expected: true,
+		},
+		{
+			name:     "empty cidr",
+			cidr:     "",
+			expected: false,
+		},
+		{
+			name:     "string",
+			cidr:     "there goes a string",
+			expected: false,
+		},
+		{
+			name:     "valid ipv4 address",
+			cidr:     `192.168.1.2`,
+			expected: false,
+		},
+		{
+			name:     "valid ipv6 cidr",
+			cidr:     `2002::1234:abcd:ffff:c0a8:101/64`,
+			expected: true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			module := fmt.Sprintf(
+				`
+				package test
+				default valid = false
+				valid { net.cidr_parse(%q) }
+				`,
+				tt.cidr,
+			)
+
+			compiler := compileModules([]string{module})
+
+			query := NewQuery(ast.MustParseBody("data.test.valid = x")).
+				WithCompiler(compiler).
+				WithStore(store).
+				WithTransaction(txn)
+
+			qrs, err := query.Run(ctx)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+				return
+			}
+
+			if len(qrs) != 1 {
+				t.Fatalf("unexpected query result set size: %+v", qrs)
+				return
+			}
+
+			val := qrs[0][ast.Var("x")].String()
+			if fmt.Sprintf("%v", tt.expected) != val {
+				t.Errorf("expected %v, received %v", tt.expected, val)
+			}
+		})
+	}
 }

--- a/topdown/cidr_test.go
+++ b/topdown/cidr_test.go
@@ -46,7 +46,7 @@ func TestNetCIDRExpandCancellation(t *testing.T) {
 
 }
 
-func TestNetCIDRParse(t *testing.T) {
+func TestNetCIDRIsValid(t *testing.T) {
 	ctx := context.Background()
 	store := inmem.New()
 	txn := storage.NewTransactionOrDie(ctx, store)
@@ -87,7 +87,7 @@ func TestNetCIDRParse(t *testing.T) {
 				`
 				package test
 				default valid = false
-				valid { net.cidr_parse(%q) }
+				valid { net.cidr_is_valid(%q) }
 				`,
 				tt.cidr,
 			)


### PR DESCRIPTION
Allows for users to verify if a given string represents a valid network CIDR. To do the same thing through `regex` can get very complex to maintain over time and to use `net.cidr_expand` for the same purpose can take a lot of time.

The function works as follow: 

```
valid {
	net.cidr_is_valid("192.168.0.0/24")
}
```

To parse IPv6 CIDRs is also supported.