### PR TITLE
Allow local override of operational configs

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -110,7 +110,7 @@ func Load(configFile string, overrides []string, overrideFiles []string) ([]byte
 	}
 
 	// Merge together base config file and overrides, prefer the overrides
-	conf := mergeValues(baseConf, overrideConf)
+	conf := MergeValues(baseConf, overrideConf)
 
 	// Take the patched config and marshal back to YAML
 	return yaml.Marshal(conf)
@@ -139,8 +139,8 @@ func subEnvVars(s string) string {
 	return updatedConfig
 }
 
-// mergeValues will merge source and destination map, preferring values from the source map
-func mergeValues(dest map[string]interface{}, src map[string]interface{}) map[string]interface{} {
+// MergeValues will merge source and destination map, preferring values from the source map
+func MergeValues(dest map[string]interface{}, src map[string]interface{}) map[string]interface{} {
 	for k, v := range src {
 		// If the key doesn't exist already, then just set the key to that value
 		if _, exists := dest[k]; !exists {
@@ -161,7 +161,7 @@ func mergeValues(dest map[string]interface{}, src map[string]interface{}) map[st
 			continue
 		}
 		// If we got to this point, it is a map in both, so merge them
-		dest[k] = mergeValues(destMap, nextMap)
+		dest[k] = MergeValues(destMap, nextMap)
 	}
 	return dest
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -126,7 +126,7 @@ func TestMergeValuesNoOverride(t *testing.T) {
 		},
 	}
 
-	actual := mergeValues(dest, src)
+	actual := MergeValues(dest, src)
 
 	expected := map[string]interface{}{
 		"a": map[string]interface{}{
@@ -147,7 +147,7 @@ func TestMergeValuesOverrideSingle(t *testing.T) {
 		"a": "override-value",
 	}
 
-	actual := mergeValues(dest, src)
+	actual := MergeValues(dest, src)
 
 	expected := map[string]interface{}{
 		"a": "override-value",
@@ -170,7 +170,7 @@ func TestMergeValuesOverrideSingleNested(t *testing.T) {
 		},
 	}
 
-	actual := mergeValues(dest, src)
+	actual := MergeValues(dest, src)
 
 	expected := map[string]interface{}{
 		"a": map[string]interface{}{
@@ -203,7 +203,7 @@ func TestMergeValuesOverrideMultipleNested(t *testing.T) {
 		},
 	}
 
-	actual := mergeValues(dest, src)
+	actual := MergeValues(dest, src)
 
 	expected := map[string]interface{}{
 		"a": map[string]interface{}{
@@ -242,7 +242,7 @@ func TestMergeValuesOverrideSingleList(t *testing.T) {
 		},
 	}
 
-	actual := mergeValues(dest, src)
+	actual := MergeValues(dest, src)
 
 	// The list index 0 should have been replaced instead of merging the sub objects
 	expected := map[string]interface{}{
@@ -268,7 +268,7 @@ func TestMergeValuesNoSrc(t *testing.T) {
 	}
 	src := map[string]interface{}{}
 
-	actual := mergeValues(dest, src)
+	actual := MergeValues(dest, src)
 
 	expected := map[string]interface{}{
 		"a": map[string]interface{}{
@@ -285,7 +285,7 @@ func TestMergeValuesNoSrcOrDest(t *testing.T) {
 	dest := map[string]interface{}{}
 	src := map[string]interface{}{}
 
-	actual := mergeValues(dest, src)
+	actual := MergeValues(dest, src)
 
 	expected := map[string]interface{}{}
 

--- a/plugins/discovery/discovery.go
+++ b/plugins/discovery/discovery.go
@@ -281,24 +281,32 @@ func (c *Discovery) reconfigure(ctx context.Context, u download.Update) error {
 }
 
 func (c *Discovery) applyLocalOverride(config *config.Config) error {
-	for name, rawJson := range c.localConficOverrides {
+	for name, rawJSON := range c.localConficOverrides {
 		var localOverride, target map[string]interface{}
-		util.Unmarshal(rawJson, &localOverride)
+		err := util.Unmarshal(rawJSON, &localOverride)
+		if err != nil {
+			return err
+		}
 
 		var rawTarget json.RawMessage
-		if name == "bundles" {
+		switch name {
+		case "bundles":
 			rawTarget = config.Bundles
-		} else if name == "status" {
+		case "status":
 			rawTarget = config.Status
-		} else if name == "decision_logs" {
+		case "decision_logs":
 			rawTarget = config.DecisionLogs
-		} else if name == "caching" {
+		case "caching":
 			rawTarget = config.Caching
-		} else {
+		default:
 			rawTarget = config.Plugins[name]
 		}
 
-		util.Unmarshal(rawTarget, &target)
+		err = util.Unmarshal(rawTarget, &target)
+		if err != nil {
+			return err
+		}
+
 		if target == nil {
 			target = make(map[string]interface{})
 		}
@@ -309,15 +317,20 @@ func (c *Discovery) applyLocalOverride(config *config.Config) error {
 			return err
 		}
 
-		if name == "bundles" {
+		switch name {
+		case "bundles":
 			config.Bundles = mergedPluginConfig
-		} else if name == "status" {
+
+		case "status":
 			config.Status = mergedPluginConfig
-		} else if name == "decision_logs" {
+
+		case "decision_logs":
 			config.DecisionLogs = mergedPluginConfig
-		} else if name == "caching" {
+
+		case "caching":
 			config.Caching = mergedPluginConfig
-		} else {
+
+		default:
 			config.Plugins[name] = mergedPluginConfig
 		}
 	}

--- a/plugins/discovery/discovery_test.go
+++ b/plugins/discovery/discovery_test.go
@@ -537,7 +537,7 @@ func TestReconfigureLocalOverride(t *testing.T) {
 		t.Errorf("Expected overwritten decision_logs config (%v) but got %v", exp, actual)
 	}
 
-	if exp := int64(10000000); !reflect.DeepEqual(*manager.InterQueryBuiltinCacheConfig().InterQueryBuiltinCache.MaxSizeBytes, exp) {
+	if exp := int64(10000000); *manager.InterQueryBuiltinCacheConfig().InterQueryBuiltinCache.MaxSizeBytes != exp {
 		t.Errorf("Expected cache bytes to be locally overwritten (%v) but got %v", exp, *manager.InterQueryBuiltinCacheConfig().InterQueryBuiltinCache.MaxSizeBytes)
 	}
 

--- a/plugins/discovery/discovery_test.go
+++ b/plugins/discovery/discovery_test.go
@@ -532,7 +532,11 @@ func TestReconfigureLocalOverride(t *testing.T) {
 	// Verify decision log settings are overwritten
 	exp := map[string]interface{}{"partition_name": "bar", "reporting": map[string]interface{}{"buffer_size_limit_bytes": json.Number("512")}}
 	var actual map[string]interface{}
-	util.Unmarshal(manager.Config.DecisionLogs, &actual)
+	err = util.Unmarshal(manager.Config.DecisionLogs, &actual)
+	if err != nil {
+		t.Fatalf("Failure unmarshaling decision log config: %v", err)
+	}
+
 	if !reflect.DeepEqual(actual, exp) {
 		t.Errorf("Expected overwritten decision_logs config (%v) but got %v", exp, actual)
 	}

--- a/plugins/logs/plugin.go
+++ b/plugins/logs/plugin.go
@@ -6,7 +6,6 @@
 package logs
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -431,20 +430,15 @@ func AllowConfigOverride(localConfig json.RawMessage) error {
 		return nil
 	}
 
-	type overridableConfig struct {
-		Reporting ReportingConfig `json:"reporting"`
+	m := map[string]interface{}{}
+	if err := util.Unmarshal(localConfig, &m); err != nil {
+		return err
 	}
-
-	d := json.NewDecoder(bytes.NewReader(localConfig))
-	d.DisallowUnknownFields()
-	var configStruct overridableConfig
-	err := d.Decode(&configStruct)
-
-	if err != nil {
-		return fmt.Errorf("discovery only allows manual configuration of the decision_logs plugin for the reporting.* configuration items")
+	_, ok := m["reporting"]
+	if ok && len(m) == 1 {
+		return nil
 	}
-
-	return nil
+	return fmt.Errorf("discovery only allows manual configuration of the decision_logs plugin for the reporting.* configuration items")
 }
 
 // ConfigBuilder assists in the construction of the plugin configuration.

--- a/plugins/logs/plugin.go
+++ b/plugins/logs/plugin.go
@@ -6,6 +6,7 @@
 package logs
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -423,6 +424,27 @@ func ParseConfig(config []byte, services []string, pluginList []string) (*Config
 		WithPlugins(pluginList).
 		WithTriggerMode(&t).
 		Parse()
+}
+
+func AllowConfigOverride(localConfig json.RawMessage) error {
+	if localConfig == nil {
+		return nil
+	}
+
+	type overridableConfig struct {
+		Reporting ReportingConfig `json:"reporting"`
+	}
+
+	d := json.NewDecoder(bytes.NewReader(localConfig))
+	d.DisallowUnknownFields()
+	var configStruct overridableConfig
+	err := d.Decode(&configStruct)
+
+	if err != nil {
+		return fmt.Errorf("discovery only allows manual configuration of the decision_logs plugin for the reporting.* configuration items")
+	}
+
+	return nil
 }
 
 // ConfigBuilder assists in the construction of the plugin configuration.

--- a/plugins/plugins.go
+++ b/plugins/plugins.go
@@ -82,7 +82,7 @@ type Factory interface {
 	New(manager *Manager, config interface{}) Plugin
 }
 
-// DiscoveryOverride can be implemented by Factorys to allow specific keys to be overridable locally
+// DiscoveryOverride can be implemented by a Factory to allow specific keys to be overridable locally
 type DiscoveryOverride interface {
 	AllowOverride(config interface{}) error
 }

--- a/plugins/plugins.go
+++ b/plugins/plugins.go
@@ -82,6 +82,11 @@ type Factory interface {
 	New(manager *Manager, config interface{}) Plugin
 }
 
+// DiscoveryOverride can be implemented by FactoryS to allow specific keys to be overridable locally
+type DiscoveryOverride interface {
+	AllowOverride(config interface{}) error
+}
+
 // Plugin defines the interface OPA uses to manage your plugin.
 //
 // When OPA starts it will start all of the plugins it was configured

--- a/plugins/plugins.go
+++ b/plugins/plugins.go
@@ -82,7 +82,7 @@ type Factory interface {
 	New(manager *Manager, config interface{}) Plugin
 }
 
-// DiscoveryOverride can be implemented by FactoryS to allow specific keys to be overridable locally
+// DiscoveryOverride can be implemented by Factorys to allow specific keys to be overridable locally
 type DiscoveryOverride interface {
 	AllowOverride(config interface{}) error
 }


### PR DESCRIPTION
A draft PR to address #5070

It makes specific attributes on the OPA configuration overridable if discovery is used
* It allows all `decision_logs.runtime.*` attributes
* It allows the `caching` configuration to be overridden 

It also introduces an interface for plugin factories to make their config partially overridable.

This PR is still a draft because at least one negative test and a test for the plugin factories is missing