### PR TITLE
internals/strvals: port helm strvals fix

### DIFF
--- a/internal/strvals/parser_test.go
+++ b/internal/strvals/parser_test.go
@@ -28,6 +28,7 @@ func TestSetIndex(t *testing.T) {
 		expect  []interface{}
 		add     int
 		val     int
+		err     bool
 	}{
 		{
 			name:    "short",
@@ -50,16 +51,47 @@ func TestSetIndex(t *testing.T) {
 			add:     3,
 			val:     4,
 		},
+		{
+			name:    "negative",
+			initial: []interface{}{0, 1, 2, 3, 4, 5},
+			expect:  []interface{}{0, 1, 2, 3, 4, 5},
+			add:     -1,
+			val:     4,
+			err:     true,
+		},
+		{
+			name:    "large",
+			initial: []interface{}{0, 1, 2, 3, 4, 5},
+			expect:  []interface{}{0, 1, 2, 3, 4, 5},
+			add:     MaxIndex + 1,
+			val:     4,
+			err:     true,
+		},
 	}
 
 	for _, tt := range tests {
-		got := setIndex(tt.initial, tt.add, tt.val)
+		got, err := setIndex(tt.initial, tt.add, tt.val)
+
+		if err != nil && tt.err == false {
+			t.Fatalf("%s: Expected no error but error returned", tt.name)
+		} else if err == nil && tt.err == true {
+			t.Fatalf("%s: Expected error but no error returned", tt.name)
+		}
+
 		if len(got) != len(tt.expect) {
 			t.Fatalf("%s: Expected length %d, got %d", tt.name, len(tt.expect), len(got))
 		}
 
-		if gg := got[tt.add].(int); gg != tt.val {
-			t.Errorf("%s, Expected value %d, got %d", tt.name, tt.val, gg)
+		if !tt.err {
+			if gg := got[tt.add].(int); gg != tt.val {
+				t.Errorf("%s, Expected value %d, got %d", tt.name, tt.val, gg)
+			}
+		}
+
+		for k, v := range got {
+			if v != tt.expect[k] {
+				t.Errorf("%s, Expected value %d, got %d", tt.name, tt.expect[k], v)
+			}
 		}
 	}
 }


### PR DESCRIPTION
The impact of this in OPA is minimal: when passing for example

    --set "abc[9999999999999]=123"

to `opa run` or `opa exec`, it would run out of memory. With this change, it will return an error instead:

    $ opa exec --set "abc[9999999999999]=123" .
    {"err":"config error: failed parsing --set data: index of 9999999999999 is greater than maximum supported index of 65536",
     "level":"error","msg":"Unexpected error.","time":"2022-10-27T10:24:01+02:00"}

Since these parameters are never user-controlled, or accessible at runtime, any attack vector here involves having access to a machines CLI, and is thus equivalent to already having local user rights. The affected instance of OPA would be the instance that is started -- so no others would be affected.

Thanks to @pjbgf for bringing this up.

See also the issue in helm,
https://github.com/fluxcd/flux2/security/advisories/GHSA-p2g7-xwvr-rrw3.

The changes have been ported from
https://github.com/helm/helm/commit/225f8d7732aba378378e7507655157b1d26cd514.

More stuff has happened on that package in helm, and new features have been added -- but I've refrained from pulling all that in.