### PR TITLE
linters: add unconvert

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -26,4 +26,5 @@ linters:
     - staticcheck
     - gosimple
     - prealloc
+    - unconvert
     # - gosec # too many false positives

--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -1003,7 +1003,7 @@ func (b *Bundle) GenerateSignature(signingConfig *SigningConfig, keyID string, u
 		b.Signatures.Plugin = signingConfig.Plugin
 	}
 
-	b.Signatures.Signatures = []string{string(token)}
+	b.Signatures.Signatures = []string{token}
 
 	return nil
 }

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -226,9 +226,9 @@ func opaTest(args []string) int {
 
 	timeout := testParams.timeout
 	if timeout == 0 { // unset
-		timeout = time.Duration(5 * time.Second)
+		timeout = 5 * time.Second
 		if testParams.benchmark {
-			timeout = time.Duration(30 * time.Second)
+			timeout = 30 * time.Second
 		}
 	}
 

--- a/download/oci_dowload.go
+++ b/download/oci_dowload.go
@@ -251,7 +251,7 @@ func (d *OCIDownloader) download(ctx context.Context, m metrics.Metrics) (*downl
 	if tarballDescriptor.MediaType == "" {
 		return nil, fmt.Errorf("no tarball descriptor found in the layers")
 	}
-	etag := string(tarballDescriptor.Digest.Hex())
+	etag := tarballDescriptor.Digest.Hex()
 	bundleFilePath := filepath.Join(d.localStorePath, "blobs", "sha256", etag)
 	// if the downloader etag sha is the same with digest of the tarball it was already loaded
 	if d.etag == etag {

--- a/internal/compiler/wasm/wasm.go
+++ b/internal/compiler/wasm/wasm.go
@@ -603,7 +603,7 @@ func (c *Compiler) writeExternalFuncNames(buf *bytes.Buffer) {
 
 	for _, decl := range c.policy.Static.BuiltinFuncs {
 		if _, ok := builtinsFunctions[decl.Name]; !ok {
-			addr := int32(buf.Len()) + int32(c.stringOffset)
+			addr := int32(buf.Len()) + c.stringOffset
 			buf.WriteString(decl.Name)
 			buf.WriteByte(0)
 			c.externalFuncNameAddrs[decl.Name] = addr
@@ -615,7 +615,7 @@ func (c *Compiler) writeEntrypointNames(buf *bytes.Buffer) {
 	c.entrypointNameAddrs = make(map[string]int32)
 
 	for _, plan := range c.policy.Plans.Plans {
-		addr := int32(buf.Len()) + int32(c.stringOffset)
+		addr := int32(buf.Len()) + c.stringOffset
 		buf.WriteString(plan.Name)
 		buf.WriteByte(0)
 		c.entrypointNameAddrs[plan.Name] = addr

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -65,7 +65,7 @@ func TestSubEnvVarsVarsSubMulti(t *testing.T) {
 
 	actual := subEnvVars(configYaml)
 
-	if string(actual) != expected {
+	if actual != expected {
 		t.Errorf("\nExpected: '%s'\nActual: '%s'", expected, actual)
 	}
 }
@@ -76,7 +76,7 @@ func TestSubEnvVarsVarsNoVars(t *testing.T) {
 
 	actual := subEnvVars(configYaml)
 
-	if string(actual) != expected {
+	if actual != expected {
 		t.Errorf("Expected: '%s'\nActual: '%s'", expected, actual)
 	}
 }
@@ -87,7 +87,7 @@ func TestSubEnvVarsVarsEmptyString(t *testing.T) {
 
 	actual := subEnvVars(configYaml)
 
-	if string(actual) != expected {
+	if actual != expected {
 		t.Errorf("Expected: '%s'\nActual: '%s'", expected, actual)
 	}
 }
@@ -102,7 +102,7 @@ func TestSubEnvVarsVarsSubMissingEnvVar(t *testing.T) {
 
 	actual := subEnvVars(configYaml)
 
-	if string(actual) != expected {
+	if actual != expected {
 		t.Errorf("Expected: '%s'\nActual: '%s'", expected, actual)
 	}
 }
@@ -113,7 +113,7 @@ func TestSubEnvVarsVarsSubEmptyVarName(t *testing.T) {
 
 	actual := subEnvVars(configYaml)
 
-	if string(actual) != expected {
+	if actual != expected {
 		t.Errorf("Expected: '%s'\nActual: '%s'", expected, actual)
 	}
 }

--- a/internal/gojsonschema/validation.go
+++ b/internal/gojsonschema/validation.go
@@ -503,7 +503,7 @@ func (v *SubSchema) validateArray(currentSubSchema *SubSchema, value []interface
 
 	// minItems & maxItems
 	if currentSubSchema.minItems != nil {
-		if nbValues < int(*currentSubSchema.minItems) {
+		if nbValues < *currentSubSchema.minItems {
 			result.addInternalError(
 				new(ArrayMinItemsError),
 				context,
@@ -513,7 +513,7 @@ func (v *SubSchema) validateArray(currentSubSchema *SubSchema, value []interface
 		}
 	}
 	if currentSubSchema.maxItems != nil {
-		if nbValues > int(*currentSubSchema.maxItems) {
+		if nbValues > *currentSubSchema.maxItems {
 			result.addInternalError(
 				new(ArrayMaxItemsError),
 				context,
@@ -587,7 +587,7 @@ func (v *SubSchema) validateObject(currentSubSchema *SubSchema, value map[string
 
 	// minProperties & maxProperties:
 	if currentSubSchema.minProperties != nil {
-		if len(value) < int(*currentSubSchema.minProperties) {
+		if len(value) < *currentSubSchema.minProperties {
 			result.addInternalError(
 				new(ArrayMinPropertiesError),
 				context,
@@ -597,7 +597,7 @@ func (v *SubSchema) validateObject(currentSubSchema *SubSchema, value map[string
 		}
 	}
 	if currentSubSchema.maxProperties != nil {
-		if len(value) > int(*currentSubSchema.maxProperties) {
+		if len(value) > *currentSubSchema.maxProperties {
 			result.addInternalError(
 				new(ArrayMaxPropertiesError),
 				context,
@@ -716,7 +716,7 @@ func (v *SubSchema) validateString(currentSubSchema *SubSchema, value interface{
 
 	// minLength & maxLength:
 	if currentSubSchema.minLength != nil {
-		if utf8.RuneCount([]byte(stringValue)) < int(*currentSubSchema.minLength) {
+		if utf8.RuneCount([]byte(stringValue)) < *currentSubSchema.minLength {
 			result.addInternalError(
 				new(StringLengthGTEError),
 				context,
@@ -726,7 +726,7 @@ func (v *SubSchema) validateString(currentSubSchema *SubSchema, value interface{
 		}
 	}
 	if currentSubSchema.maxLength != nil {
-		if utf8.RuneCount([]byte(stringValue)) > int(*currentSubSchema.maxLength) {
+		if utf8.RuneCount([]byte(stringValue)) > *currentSubSchema.maxLength {
 			result.addInternalError(
 				new(StringLengthLTEError),
 				context,

--- a/internal/jwx/jwk/symmetric_test.go
+++ b/internal/jwx/jwk/symmetric_test.go
@@ -45,7 +45,7 @@ func TestSymmetric(t *testing.T) {
 }`)
 		var jwkKey jwk.Key
 		rawKeySetJSON := &jwk.RawKeySetJSON{}
-		err = json.Unmarshal([]byte(jwkSrc), rawKeySetJSON)
+		err = json.Unmarshal(jwkSrc, rawKeySetJSON)
 		if err != nil {
 			t.Fatalf("Failed to unmarshal JWK Set: %s", err.Error())
 		}
@@ -96,7 +96,7 @@ func TestSymmetric(t *testing.T) {
   ]
 }`)
 		rawKeySetJSON := &jwk.RawKeySetJSON{}
-		err := json.Unmarshal([]byte(jwkSrc), rawKeySetJSON)
+		err := json.Unmarshal(jwkSrc, rawKeySetJSON)
 		if err != nil {
 			t.Fatalf("Failed to unmarshal JWK Set: %s", err.Error())
 		}

--- a/internal/oracle/oracle_test.go
+++ b/internal/oracle/oracle_test.go
@@ -392,7 +392,7 @@ q[x.y] = 10 {
 			if after > len(buffer) {
 				after = len(buffer)
 			}
-			t.Logf("pos is %d: \"%s<%s>%s\"", tc.pos, string(buffer[before:tc.pos]), string(buffer[tc.pos]), string(buffer[tc.pos+1:after]))
+			t.Logf("pos is %d: \"%s<%s>%s\"", tc.pos, buffer[before:tc.pos], string(buffer[tc.pos]), buffer[tc.pos+1:after])
 			o := New()
 			result, err := o.FindDefinition(DefinitionQuery{
 				Modules:  modules,

--- a/internal/prometheus/prometheus_test.go
+++ b/internal/prometheus/prometheus_test.go
@@ -21,7 +21,7 @@ func TestJSONSerialization(t *testing.T) {
 	inner := metrics.New()
 	logger := func(logger logging.Logger) loggerFunc {
 		return func(attrs map[string]interface{}, f string, a ...interface{}) {
-			logger.WithFields(map[string]interface{}(attrs)).Error(f, a...)
+			logger.WithFields(attrs).Error(f, a...)
 		}
 	}(logging.NewNoOpLogger())
 

--- a/internal/wasm/encoding/writer.go
+++ b/internal/wasm/encoding/writer.go
@@ -229,7 +229,7 @@ func writeFunctionSection(w io.Writer, s module.FunctionSection) error {
 	}
 
 	for _, idx := range s.TypeIndices {
-		if err := leb128.WriteVarUint32(&buf, uint32(idx)); err != nil {
+		if err := leb128.WriteVarUint32(&buf, idx); err != nil {
 			return err
 		}
 	}

--- a/internal/wasm/sdk/internal/wasm/vm.go
+++ b/internal/wasm/sdk/internal/wasm/vm.go
@@ -330,7 +330,7 @@ func (i *VM) Eval(ctx context.Context,
 	i.dispatcher.Reset(ctx, seed, ns, iqbCache, ndbCache, ph, capabilities)
 
 	metrics.Timer("wasm_vm_eval_call").Start()
-	resultAddr, err := i.evalOneOff(ctx, int32(entrypoint), i.dataAddr, inputAddr, inputLen, heapPtr)
+	resultAddr, err := i.evalOneOff(ctx, entrypoint, i.dataAddr, inputAddr, inputLen, heapPtr)
 	if err != nil {
 		return nil, err
 	}
@@ -387,7 +387,7 @@ func (i *VM) evalCompat(ctx context.Context,
 		}
 	}
 
-	if err := i.evalCtxSetEntrypoint(ctx, ctxAddr, int32(entrypoint)); err != nil {
+	if err := i.evalCtxSetEntrypoint(ctx, ctxAddr, entrypoint); err != nil {
 		return nil, err
 	}
 
@@ -470,7 +470,7 @@ func (i *VM) SetPolicyData(ctx context.Context, opts vmOpts) error {
 		copy(mem[i.baseHeapPtr:i.baseHeapPtr+len], opts.parsedData)
 		i.dataAddr = opts.parsedDataAddr
 
-		i.evalHeapPtr = i.baseHeapPtr + int32(len)
+		i.evalHeapPtr = i.baseHeapPtr + len
 		err := i.setHeapState(ctx, i.evalHeapPtr)
 		if err != nil {
 			return err

--- a/internal/wasm/sdk/opa/loader/http/util.go
+++ b/internal/wasm/sdk/opa/loader/http/util.go
@@ -22,6 +22,7 @@ func backoff(base, max, jitter, factor float64, retries int) time.Duration {
 		return 0
 	}
 
+	//nolint:unconvert
 	backoff, max := float64(base), float64(max)
 	for backoff < max && retries > 0 {
 		backoff *= factor

--- a/plugins/logs/encoder.go
+++ b/plugins/logs/encoder.go
@@ -120,6 +120,7 @@ func (enc *chunkEncoder) Flush() ([][]byte, error) {
 	return enc.reset()
 }
 
+//nolint:unconvert
 func (enc *chunkEncoder) reset() ([][]byte, error) {
 
 	// Adjust the encoder's soft limit based on the current amount of

--- a/profiler/profiler_test.go
+++ b/profiler/profiler_test.go
@@ -151,7 +151,7 @@ func TestProfileCheckExprDuration(t *testing.T) {
 		t.Fatalf("Expected text is test.sleep(\"100ms\") but got %v", string(fr.Result[0].Location.Text))
 	}
 
-	if fr.Result[0].ExprTimeNs <= time.Duration(50*time.Millisecond).Nanoseconds() {
+	if fr.Result[0].ExprTimeNs <= 50*time.Millisecond.Nanoseconds() {
 		t.Fatalf("Expected eval time is at least 100 msec but got %v", fr.Result[0].ExprTimeNs)
 	}
 

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -844,7 +844,7 @@ func (rt *Runtime) getWatcher(rootPaths []string) (*fsnotify.Watcher, error) {
 
 func errorLogger(logger logging.Logger) func(attrs map[string]interface{}, f string, a ...interface{}) {
 	return func(attrs map[string]interface{}, f string, a ...interface{}) {
-		logger.WithFields(map[string]interface{}(attrs)).Error(f, a...)
+		logger.WithFields(attrs).Error(f, a...)
 	}
 }
 

--- a/storage/errors.go
+++ b/storage/errors.go
@@ -51,7 +51,7 @@ func (err *Error) Error() string {
 	if err.Message != "" {
 		return fmt.Sprintf("%v: %v", err.Code, err.Message)
 	}
-	return string(err.Code)
+	return err.Code
 }
 
 // IsNotFound returns true if this error is a NotFoundErr.

--- a/test/e2e/certrefresh/certrefresh_test.go
+++ b/test/e2e/certrefresh/certrefresh_test.go
@@ -98,7 +98,7 @@ func TestCertificateRotation(t *testing.T) {
 
 	// before rotation
 	cert := getCert(t)
-	if exp, act := serial0, string(cert.SerialNumber.String()); exp != act {
+	if exp, act := serial0, cert.SerialNumber.String(); exp != act {
 		t.Fatalf("expected signature %s, got %s", exp, act)
 	}
 
@@ -108,7 +108,7 @@ func TestCertificateRotation(t *testing.T) {
 
 	// after rotation
 	cert = getCert(t)
-	if exp, act := serial1, string(cert.SerialNumber.String()); exp != act {
+	if exp, act := serial1, cert.SerialNumber.String(); exp != act {
 		t.Fatalf("expected signature %s, got %s", exp, act)
 	}
 
@@ -118,7 +118,7 @@ func TestCertificateRotation(t *testing.T) {
 
 	// second cert still used
 	cert = getCert(t)
-	if exp, act := serial1, string(cert.SerialNumber.String()); exp != act {
+	if exp, act := serial1, cert.SerialNumber.String(); exp != act {
 		t.Fatalf("expected signature %s, got %s", exp, act)
 	}
 
@@ -126,7 +126,7 @@ func TestCertificateRotation(t *testing.T) {
 	replaceCerts(t, certFile0, certKeyFile0)
 	time.Sleep(wait)
 	cert = getCert(t)
-	if exp, act := serial0, string(cert.SerialNumber.String()); exp != act {
+	if exp, act := serial0, cert.SerialNumber.String(); exp != act {
 		t.Fatalf("expected signature %s, got %s", exp, act)
 	}
 }

--- a/topdown/builtins.go
+++ b/topdown/builtins.go
@@ -184,13 +184,13 @@ func handleBuiltinErr(name string, loc *ast.Location, err error) error {
 	case builtins.ErrOperand:
 		return &Error{
 			Code:     TypeErr,
-			Message:  fmt.Sprintf("%v: %v", string(name), err.Error()),
+			Message:  fmt.Sprintf("%v: %v", name, err.Error()),
 			Location: loc,
 		}
 	default:
 		return &Error{
 			Code:     BuiltinErr,
-			Message:  fmt.Sprintf("%v: %v", string(name), err.Error()),
+			Message:  fmt.Sprintf("%v: %v", name, err.Error()),
 			Location: loc,
 		}
 	}

--- a/topdown/cache/cache.go
+++ b/topdown/cache/cache.go
@@ -155,7 +155,7 @@ func (c *cache) unsafeDelete(k ast.Value) {
 		return
 	}
 
-	c.usage -= int64(value.SizeInBytes())
+	c.usage -= value.SizeInBytes()
 	delete(c.items, k.String())
 }
 

--- a/topdown/regex.go
+++ b/topdown/regex.go
@@ -107,7 +107,7 @@ func getRegexp(pat string) (*regexp.Regexp, error) {
 	re, ok := regexpCache[pat]
 	if !ok {
 		var err error
-		re, err = regexp.Compile(string(pat))
+		re, err = regexp.Compile(pat)
 		if err != nil {
 			return nil, err
 		}
@@ -122,7 +122,7 @@ func getRegexpTemplate(pat string, delimStart, delimEnd byte) (*regexp.Regexp, e
 	re, ok := regexpCache[pat]
 	if !ok {
 		var err error
-		re, err = compileRegexTemplate(string(pat), delimStart, delimEnd)
+		re, err = compileRegexTemplate(pat, delimStart, delimEnd)
 		if err != nil {
 			return nil, err
 		}

--- a/topdown/strings.go
+++ b/topdown/strings.go
@@ -552,7 +552,7 @@ func builtinReverse(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term)
 }
 
 func reverseString(str string) string {
-	sRunes := []rune(string(str))
+	sRunes := []rune(str)
 	length := len(sRunes)
 	reversedRunes := make([]rune, length)
 

--- a/topdown/tokens.go
+++ b/topdown/tokens.go
@@ -42,7 +42,8 @@ const (
 )
 
 // JSONWebToken represent the 3 parts (header, payload & signature) of
-//              a JWT in Base64.
+//
+//	a JWT in Base64.
 type JSONWebToken struct {
 	header        string
 	payload       string
@@ -753,7 +754,7 @@ func verifyHMAC(key interface{}, hash crypto.Hash, payload []byte, signature []b
 		return fmt.Errorf("incorrect symmetric key type")
 	}
 	mac := hmac.New(hash.New, macKey)
-	if _, err := mac.Write([]byte(payload)); err != nil {
+	if _, err := mac.Write(payload); err != nil {
 		return err
 	}
 	if !hmac.Equal(signature, mac.Sum([]byte{})) {
@@ -1081,7 +1082,7 @@ func builtinJWTDecodeVerify(bctx BuiltinContext, operands []*ast.Term, iter func
 		switch exp.Value.(type) {
 		case ast.Number:
 			// constraints.time is in nanoseconds but exp Value is in seconds
-			compareTime := ast.FloatNumberTerm(float64(constraints.time) / 1000000000)
+			compareTime := ast.FloatNumberTerm(constraints.time / 1000000000)
 			if ast.Compare(compareTime, exp.Value.(ast.Number)) != -1 {
 				return iter(unverified)
 			}
@@ -1094,7 +1095,7 @@ func builtinJWTDecodeVerify(bctx BuiltinContext, operands []*ast.Term, iter func
 		switch nbf.Value.(type) {
 		case ast.Number:
 			// constraints.time is in nanoseconds but nbf Value is in seconds
-			compareTime := ast.FloatNumberTerm(float64(constraints.time) / 1000000000)
+			compareTime := ast.FloatNumberTerm(constraints.time / 1000000000)
 			if ast.Compare(compareTime, nbf.Value.(ast.Number)) == -1 {
 				return iter(unverified)
 			}


### PR DESCRIPTION
Got a few warnings from my IDE about redundant type conversions, so I decided to look into it. Added the unconvert linter to our checks, and fixed the violations. Added two ignore comments as I wasn't sure about whether they'd change the semantics of the code.

Signed-off-by: Anders Eknert <anders@eknert.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->
