### PR TITLE
cmd/{build,check}: respect capabilities for parsing

### DIFF
--- a/cmd/build_test.go
+++ b/cmd/build_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"archive/tar"
 	"compress/gzip"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -11,6 +12,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/loader"
 
 	"github.com/open-policy-agent/opa/util/test"
@@ -69,52 +71,117 @@ func TestBuildProducesBundle(t *testing.T) {
 }
 
 func TestBuildRespectsCapabilities(t *testing.T) {
-	capabilitiesJSON := `{
-    "builtins": [
-      {
-        "name": "is_foo",
-        "decl": {
-          "args": [
-            {
-              "type": "string"
-            }
-          ],
-          "result": {
-            "type": "boolean"
-          },
-          "type": "function"
-        }
-      }
-    ]
-  }`
-
-	files := map[string]string{
-		"capabilities.json": capabilitiesJSON,
-		"test.rego": `
-			package test
-			p { is_foo("bar") }
-		`,
+	tests := []struct {
+		note       string
+		caps       string
+		policy     string
+		err        string
+		bundleMode bool // build with "-b" flag
+	}{
+		{
+			note: "builtin defined in caps",
+			caps: `{
+			"builtins": [
+				{
+					"name": "is_foo",
+					"decl": {
+						"args": [
+							{
+								"type": "string"
+							}
+						],
+						"result": {
+							"type": "boolean"
+						},
+						"type": "function"
+					}
+				}
+			]
+		}`,
+			policy: `package test
+p { is_foo("bar") }`,
+		},
+		{
+			note: "future kw NOT defined in caps",
+			caps: func() string {
+				c := ast.CapabilitiesForThisVersion()
+				c.FutureKeywords = []string{"in"}
+				j, err := json.Marshal(c)
+				if err != nil {
+					panic(err)
+				}
+				return string(j)
+			}(),
+			policy: `package test
+import future.keywords.if
+import future.keywords.in
+p if "opa" in input.tools`,
+			err: "rego_parse_error: unexpected keyword, must be one of [in]",
+		},
+		{
+			note: "future kw are defined in caps",
+			caps: func() string {
+				c := ast.CapabilitiesForThisVersion()
+				c.FutureKeywords = []string{"in", "if"}
+				j, err := json.Marshal(c)
+				if err != nil {
+					panic(err)
+				}
+				return string(j)
+			}(),
+			policy: `package test
+import future.keywords.if
+import future.keywords.in
+p if "opa" in input.tools`,
+		},
 	}
 
-	test.WithTempFS(files, func(root string) {
-		caps := newcapabilitiesFlag()
-		if err := caps.Set(path.Join(root, "capabilities.json")); err != nil {
-			t.Fatal(err)
-		}
-		params := newBuildParams()
-		params.outputFile = path.Join(root, "bundle.tar.gz")
-		params.capabilities = caps
+	// add same tests for bundle-mode == true:
+	for i := range tests {
+		tc := tests[i]
+		tc.bundleMode = true
+		tc.note = tc.note + " (as bundle)"
+		tests = append(tests, tc)
+	}
 
-		err := dobuild(params, []string{root})
-		if err != nil {
-			t.Fatal(err)
-		}
+	for _, tc := range tests {
+		t.Run(tc.note, func(t *testing.T) {
+			files := map[string]string{
+				"capabilities.json": tc.caps,
+				"test.rego":         tc.policy,
+			}
 
-		_, err = loader.NewFileLoader().AsBundle(params.outputFile)
-		if err != nil {
-			t.Fatal(err)
-		}
-	})
+			test.WithTempFS(files, func(root string) {
+				caps := newcapabilitiesFlag()
+				if err := caps.Set(path.Join(root, "capabilities.json")); err != nil {
+					t.Fatal(err)
+				}
+				params := newBuildParams()
+				params.outputFile = path.Join(root, "bundle.tar.gz")
+				params.capabilities = caps
+				params.bundleMode = tc.bundleMode
+
+				err := dobuild(params, []string{root})
+				switch {
+				case err != nil && tc.err != "":
+					if !strings.Contains(err.Error(), tc.err) {
+						t.Fatalf("expected err %v, got %v", tc.err, err)
+					}
+					return // don't read back bundle below
+				case err != nil && tc.err == "":
+					t.Fatalf("unexpected error: %v", err)
+				case err == nil && tc.err != "":
+					t.Fatalf("expected error %v, got nil", tc.err)
+				}
+
+				// check that the resulting bundle is readable
+				_, err = loader.NewFileLoader().AsBundle(params.outputFile)
+				if err != nil {
+					t.Fatal(err)
+				}
+			})
+		})
+	}
 }
 
 func TestBuildFilesystemModeIgnoresTarGz(t *testing.T) {

--- a/cmd/check_test.go
+++ b/cmd/check_test.go
@@ -1,0 +1,122 @@
+// Copyright 2022 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package cmd
+
+import (
+	"encoding/json"
+	"path"
+	"strings"
+	"testing"
+
+	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/util/test"
+)
+
+func TestCheckRespectsCapabilities(t *testing.T) {
+	tests := []struct {
+		note       string
+		caps       string
+		policy     string
+		err        string
+		bundleMode bool // check with "-b" flag
+	}{
+		{
+			note: "builtin defined in caps",
+			caps: `{
+			"builtins": [
+				{
+					"name": "is_foo",
+					"decl": {
+						"args": [
+							{
+								"type": "string"
+							}
+						],
+						"result": {
+							"type": "boolean"
+						},
+						"type": "function"
+					}
+				}
+			]
+		}`,
+			policy: `package test
+p { is_foo("bar") }`,
+		},
+		{
+			note: "future kw NOT defined in caps",
+			caps: func() string {
+				c := ast.CapabilitiesForThisVersion()
+				c.FutureKeywords = []string{"in"}
+				j, err := json.Marshal(c)
+				if err != nil {
+					panic(err)
+				}
+				return string(j)
+			}(),
+			policy: `package test
+import future.keywords.if
+import future.keywords.in
+p if "opa" in input.tools`,
+			err: "rego_parse_error: unexpected keyword, must be one of [in]",
+		},
+		{
+			note: "future kw are defined in caps",
+			caps: func() string {
+				c := ast.CapabilitiesForThisVersion()
+				c.FutureKeywords = []string{"in", "if"}
+				j, err := json.Marshal(c)
+				if err != nil {
+					panic(err)
+				}
+				return string(j)
+			}(),
+			policy: `package test
+import future.keywords.if
+import future.keywords.in
+p if "opa" in input.tools`,
+		},
+	}
+
+	// add same tests for bundle-mode == true:
+	for i := range tests {
+		tc := tests[i]
+		tc.bundleMode = true
+		tc.note = tc.note + " (as bundle)"
+		tests = append(tests, tc)
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.note, func(t *testing.T) {
+			files := map[string]string{
+				"capabilities.json": tc.caps,
+				"test.rego":         tc.policy,
+			}
+
+			test.WithTempFS(files, func(root string) {
+				caps := newcapabilitiesFlag()
+				if err := caps.Set(path.Join(root, "capabilities.json")); err != nil {
+					t.Fatal(err)
+				}
+				params := newCheckParams()
+				params.capabilities = caps
+				params.bundleMode = tc.bundleMode
+
+				err := checkModules(params, []string{root})
+				switch {
+				case err != nil && tc.err != "":
+					if !strings.Contains(err.Error(), tc.err) {
+						t.Fatalf("expected err %v, got %v", tc.err, err)
+					}
+					return // don't read back bundle below
+				case err != nil && tc.err == "":
+					t.Fatalf("unexpected error: %v", err)
+				case err == nil && tc.err != "":
+					t.Fatalf("expected error %v, got nil", tc.err)
+				}
+			})
+		})
+	}
+}

--- a/cmd/parse.go
+++ b/cmd/parse.go
@@ -39,7 +39,7 @@ var parseCommand = &cobra.Command{
 		}
 		return nil
 	},
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		os.Exit(parse(args, os.Stdout, os.Stderr))
 	},
 }

--- a/compile/compile.go
+++ b/compile/compile.go
@@ -409,7 +409,7 @@ func (c *Compiler) initBundle() error {
 	// TODO(tsandall): the metrics object should passed through here so we that
 	// we can track read and parse times.
 
-	load, err := initload.LoadPaths(c.paths, c.filter, c.asBundle, c.bvc, false, c.useRegoAnnotationEntrypoints)
+	load, err := initload.LoadPaths(c.paths, c.filter, c.asBundle, c.bvc, false, c.useRegoAnnotationEntrypoints, c.capabilities)
 	if err != nil {
 		return fmt.Errorf("load error: %w", err)
 	}

--- a/internal/runtime/init/init.go
+++ b/internal/runtime/init/init.go
@@ -113,7 +113,17 @@ type Descriptor struct {
 
 // LoadPaths reads data and policy from the given paths and returns a set of bundles or
 // raw loader file results.
-func LoadPaths(paths []string, filter loader.Filter, asBundle bool, bvc *bundle.VerificationConfig, skipVerify bool, processAnnotations bool) (*LoadPathsResult, error) {
+func LoadPaths(paths []string,
+	filter loader.Filter,
+	asBundle bool,
+	bvc *bundle.VerificationConfig,
+	skipVerify bool,
+	processAnnotations bool,
+	caps *ast.Capabilities) (*LoadPathsResult, error) {
+
+	if caps == nil {
+		caps = ast.CapabilitiesForThisVersion()
+	}
 
 	var result LoadPathsResult
 	var err error
@@ -126,6 +136,7 @@ func LoadPaths(paths []string, filter loader.Filter, asBundle bool, bvc *bundle.
 				WithSkipBundleVerification(skipVerify).
 				WithFilter(filter).
 				WithProcessAnnotation(processAnnotations).
+				WithCapabilities(caps).
 				AsBundle(path)
 			if err != nil {
 				return nil, err
@@ -136,6 +147,7 @@ func LoadPaths(paths []string, filter loader.Filter, asBundle bool, bvc *bundle.
 
 	files, err := loader.NewFileLoader().
 		WithProcessAnnotation(processAnnotations).
+		WithCapabilities(caps).
 		Filtered(paths, filter)
 	if err != nil {
 		return nil, err

--- a/internal/runtime/init/init_test.go
+++ b/internal/runtime/init/init_test.go
@@ -14,7 +14,6 @@ import (
 	"testing"
 
 	"github.com/open-policy-agent/opa/loader"
-
 	"github.com/open-policy-agent/opa/storage"
 	inmem "github.com/open-policy-agent/opa/storage/inmem/test"
 	"github.com/open-policy-agent/opa/util"
@@ -121,7 +120,7 @@ p = true { 1 = 2 }`
 
 				err := storage.Txn(ctx, store, storage.WriteParams, func(txn storage.Transaction) error {
 
-					loaded, err := LoadPaths(paths, nil, tc.asBundle, nil, true, false)
+					loaded, err := LoadPaths(paths, nil, tc.asBundle, nil, true, false, nil)
 					if err != nil {
 						return err
 					}
@@ -270,7 +269,7 @@ func TestLoadPathsBundleModeWithFilter(t *testing.T) {
 		// bundle mode
 		loaded, err := LoadPaths(paths, func(abspath string, info os.FileInfo, depth int) bool {
 			return loader.GlobExcludeName("*_test.rego", 1)(abspath, info, depth)
-		}, true, nil, true, false)
+		}, true, nil, true, false, nil)
 		if err != nil {
 			t.Fatalf("Unexpected error: %s", err)
 		}

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -91,12 +91,13 @@ type FileLoader interface {
 	All(paths []string) (*Result, error)
 	Filtered(paths []string, filter Filter) (*Result, error)
 	AsBundle(path string) (*bundle.Bundle, error)
-	WithFS(fsys fs.FS) FileLoader
-	WithMetrics(m metrics.Metrics) FileLoader
-	WithFilter(filter Filter) FileLoader
+	WithFS(fs.FS) FileLoader
+	WithMetrics(metrics.Metrics) FileLoader
+	WithFilter(Filter) FileLoader
 	WithBundleVerificationConfig(*bundle.VerificationConfig) FileLoader
-	WithSkipBundleVerification(skipVerify bool) FileLoader
-	WithProcessAnnotation(processAnnotation bool) FileLoader
+	WithSkipBundleVerification(bool) FileLoader
+	WithProcessAnnotation(bool) FileLoader
+	WithCapabilities(*ast.Capabilities) FileLoader
 }
 
 // NewFileLoader returns a new FileLoader instance.
@@ -152,6 +153,12 @@ func (fl *fileLoader) WithSkipBundleVerification(skipVerify bool) FileLoader {
 // WithProcessAnnotation enables or disables processing of schema annotations on rules
 func (fl *fileLoader) WithProcessAnnotation(processAnnotation bool) FileLoader {
 	fl.opts.ProcessAnnotation = processAnnotation
+	return fl
+}
+
+// WithCapabilities sets the supported capabilities when loading the files
+func (fl *fileLoader) WithCapabilities(caps *ast.Capabilities) FileLoader {
+	fl.opts.Capabilities = caps
 	return fl
 }
 
@@ -214,7 +221,8 @@ func (fl fileLoader) AsBundle(path string) (*bundle.Bundle, error) {
 		WithMetrics(fl.metrics).
 		WithBundleVerificationConfig(fl.bvc).
 		WithSkipBundleVerification(fl.skipVerify).
-		WithProcessAnnotations(fl.opts.ProcessAnnotation)
+		WithProcessAnnotations(fl.opts.ProcessAnnotation).
+		WithCapabilities(fl.opts.Capabilities)
 
 	// For bundle directories add the full path in front of module file names
 	// to simplify debugging.

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -298,7 +298,7 @@ func NewRuntime(ctx context.Context, params Params) (*Runtime, error) {
 		}
 	}
 
-	loaded, err := initload.LoadPaths(params.Paths, params.Filter, params.BundleMode, params.BundleVerificationConfig, params.SkipBundleVerification, false)
+	loaded, err := initload.LoadPaths(params.Paths, params.Filter, params.BundleMode, params.BundleVerificationConfig, params.SkipBundleVerification, false, nil)
 	if err != nil {
 		return nil, fmt.Errorf("load error: %w", err)
 	}
@@ -716,7 +716,7 @@ func (rt *Runtime) readWatcher(ctx context.Context, watcher *fsnotify.Watcher, p
 
 func (rt *Runtime) processWatcherUpdate(ctx context.Context, paths []string, removed string) error {
 
-	loaded, err := initload.LoadPaths(paths, rt.Params.Filter, rt.Params.BundleMode, nil, true, false)
+	loaded, err := initload.LoadPaths(paths, rt.Params.Filter, rt.Params.BundleMode, nil, true, false, nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Before, the capabilities were plumbled through in most places:

1. checking which builtins exist
2. passed along to the optimizer
3. passed along to the planner

But they hadn't been passed along to the file loader. As such, it could not pass the caps along to the parser either. This is now done, but adding a new method to the FileLoader interface.

Fixes #5323.