### PR TITLE
cmd: Extend e2e benchmarking mode to include OPA config

### DIFF
--- a/cmd/bench.go
+++ b/cmd/bench.go
@@ -46,6 +46,7 @@ type benchmarkCommandParams struct {
 	e2e                    bool
 	gracefulShutdownPeriod int
 	shutdownWaitPeriod     int
+	configFile             string
 }
 
 const (
@@ -125,6 +126,7 @@ The optional "gobench" output format conforms to the Go Benchmark Data Format.
 	addBenchmemFlag(benchCommand.Flags(), &params.benchMem, true)
 
 	addE2EFlag(benchCommand.Flags(), &params.e2e, false)
+	addConfigFileFlag(benchCommand.Flags(), &params.configFile)
 
 	benchCommand.Flags().IntVar(&params.gracefulShutdownPeriod, "shutdown-grace-period", 10, "set the time (in seconds) that the server will wait to gracefully shut down. This flag is valid in 'e2e' mode only.")
 	benchCommand.Flags().IntVar(&params.shutdownWaitPeriod, "shutdown-wait-period", 0, "set the time (in seconds) that the server will wait before initiating shutdown. This flag is valid in 'e2e' mode only.")
@@ -296,6 +298,7 @@ func benchE2E(ctx context.Context, args []string, params benchmarkCommandParams,
 		EnableVersionCheck:     false,
 		GracefulShutdownPeriod: params.gracefulShutdownPeriod,
 		ShutdownWaitPeriod:     params.shutdownWaitPeriod,
+		ConfigFile:             params.configFile,
 	}
 
 	rt, err := runtime.NewRuntime(ctx, rtParams)

--- a/cmd/bench_test.go
+++ b/cmd/bench_test.go
@@ -102,6 +102,59 @@ func TestRunBenchmarkE2E(t *testing.T) {
 	}
 }
 
+func TestRunBenchmarkE2EWithOPAConfigFile(t *testing.T) {
+
+	fs := map[string]string{
+		"/config.yaml": `{"decision_logs": {"console": true}}`,
+	}
+
+	test.WithTempFS(fs, func(testDirRoot string) {
+
+		params := testBenchParams()
+		params.e2e = true
+		params.configFile = filepath.Join(testDirRoot, "/config.yaml")
+
+		args := []string{"1 + 1"}
+		var buf bytes.Buffer
+
+		rc, err := benchMain(args, params, &buf, &goBenchRunner{})
+		if err != nil {
+			t.Fatalf("Unexpected error: %s", err)
+		}
+
+		if rc != 0 {
+			t.Fatalf("Unexpected return code %d, expected 0", rc)
+		}
+
+		// Expect a json serialized benchmark result with histogram fields
+		var br testing.BenchmarkResult
+		err = util.UnmarshalJSON(buf.Bytes(), &br)
+		if err != nil {
+			t.Fatalf("Unexpected error unmarshalling output: %s", err)
+		}
+
+		if br.N == 0 || br.T == 0 || br.MemAllocs == 0 || br.MemBytes == 0 {
+			t.Fatalf("Expected benchmark results to be non-zero, got: %+v", br)
+		}
+
+		if _, ok := br.Extra["histogram_timer_rego_query_eval_ns_count"]; !ok {
+			t.Fatalf("Expected benchmark results to contain 'histogram_timer_rego_query_eval_ns_count', got: %+v", br)
+		}
+
+		if float64(br.N) != br.Extra["histogram_timer_rego_query_eval_ns_count"] {
+			t.Fatalf("Expected 'histogram_timer_rego_query_eval_ns_count' to be equal to N")
+		}
+
+		if _, ok := br.Extra["histogram_timer_server_handler_ns_count"]; !ok {
+			t.Fatalf("Expected benchmark results to contain 'histogram_timer_server_handler_ns_count', got: %+v", br)
+		}
+
+		if float64(br.N) != br.Extra["histogram_timer_server_handler_ns_count"] {
+			t.Fatalf("Expected 'histogram_timer_server_handler_ns_count' to be equal to N")
+		}
+	})
+}
+
 func TestRunBenchmarkFailFastE2E(t *testing.T) {
 	params := testBenchParams()
 	params.fail = true // configured to fail on undefined results


### PR DESCRIPTION
Currently the e2e bench mode doesn't support providing an OPA configuration to enable features like decision logging that can have an impact on the server overhead. This change adds a new flag to the bench cmd to specify the OPA configuration.

Fixes: #4899

Signed-off-by: Ashutosh Narkar <anarkar4387@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->
