### PR TITLE
docs/website: make "outdated version" banner red if ancient

### DIFF
--- a/docs/website/layouts/partials/docs/article.html
+++ b/docs/website/layouts/partials/docs/article.html
@@ -1,9 +1,18 @@
 {{ $releases   := site.Data.releases }}
+{{ $version    := index (split .File.Path "/") 1 }}
 {{ $latest     := printf "%s" (index $releases 1) }}
-{{- if eq (len site.Data.releases) 1 -}}
+{{- if eq (len $releases) 1 -}}
 {{- $latest = "(dev preview)" -}}
 {{- end -}}
-{{ $version    := index (split .File.Path "/") 1 }}
+
+{{ $rank := 1 }}
+{{- range $index, $ver := $releases -}}
+  {{- if eq $ver $version -}}
+    {{ $rank = $index }}
+  {{- end -}}
+{{- end -}}
+{{ $ancient := gt $rank 5 }}
+
 <article class="article">
   {{- if (eq $version "edge") }}
   <div class="message is-danger">
@@ -12,7 +21,7 @@
     </div>
   </div>
   {{- else if (and (ne $version "latest") (ne $version $latest)) }}
-  <div class="message is-warning">
+  <div class="message {{ cond $ancient "is-danger" "is-warning"}}">
     <div class="message-body">
       These are the docs for an older version of OPA. Latest stable release is <a href="/docs/latest">{{ $latest }}</a>
     </div>

--- a/docs/website/layouts/partials/docs/dashboard-panel.html
+++ b/docs/website/layouts/partials/docs/dashboard-panel.html
@@ -5,6 +5,14 @@
 {{ $version    := index (split .File.Path "/") 1 }}
 {{ $page       := trim .RelPermalink "/" }}
 {{ $isLatest   := or (eq $version $latest) (eq $version "latest") }}
+
+{{ $rank := 1 }}
+{{- range $index, $ver := $releases -}}
+  {{- if eq $ver $version -}}
+    {{ $rank = $index }}
+  {{- end -}}
+{{- end -}}
+{{ $ancient := gt $rank 5 }}
 <div class="dashboard-panel left has-background-white-bis is-hidden-touch">
   <div class="dashboard-panel-header has-text-centered">
     <div class="dashboard-panel-header-logo">
@@ -27,16 +35,16 @@
           </span>
             {{ if $isLatest }}
               <span class="tag latest-tag is-success is-small has-text-weight-bold">
-            latest
-          </span>
+                latest
+              </span>
             {{ else if (eq $version "edge") }}
               <span class="tag latest-tag is-danger is-small has-text-weight-bold">
-            pre-release
-          </span>
+                pre-release
+              </span>
             {{ else }}
-              <span class="tag latest-tag is-warning is-small has-text-weight-bold">
-            older
-          </span>
+              <span class="tag latest-tag {{ cond $ancient "is-danger" "is-warning"}} is-small has-text-weight-bold">
+                older
+              </span>
             {{ end }}
           <span class="icon is-small">
             <i class="fas fa-angle-down" aria-hidden="true"></i>

--- a/netlify.toml
+++ b/netlify.toml
@@ -17,6 +17,7 @@ command = "make netlify-preview WASM_ENABLED=0 CGO_ENABLED=0"
 # "netlify dev" will serve the static content using netlify locally
 # with all the redirects and other netlify specific rules in place.
 publish = "docs/website/public"
+framework = "#static"
 
 # To run the netlify dev service with hugo dev server "live" behind
 # it uncomment these lines:


### PR DESCRIPTION
If a release is not among the last five releases, the "you're using an outdated version" banner will turn red.

You cannot see the effect in the deploy preview, but I've verified it locally:

<img width="1089" alt="image" src="https://user-images.githubusercontent.com/870638/199462415-f106bff4-b2a1-49a2-b2f8-967aaa6c802d.png">

-------

<img width="1102" alt="image" src="https://user-images.githubusercontent.com/870638/199462499-ee91939f-4a6f-40cc-a229-d654c26d4490.png">
