### PR TITLE
cmd/build: don't expect key if alg is non-empty

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -266,10 +266,8 @@ func dobuild(params buildParams, args []string) error {
 		return err
 	}
 
-	if bvc != nil || bsc != nil {
-		if !params.bundleMode {
-			return fmt.Errorf("enable bundle mode (ie. --bundle) to verify or sign bundle files or directories")
-		}
+	if (bvc != nil || bsc != nil) && !params.bundleMode {
+		return fmt.Errorf("enable bundle mode (ie. --bundle) to verify or sign bundle files or directories")
 	}
 
 	var capabilities *ast.Capabilities
@@ -350,8 +348,8 @@ func buildVerificationConfig(pubKey, pubKeyID, alg, scope string, excludeFiles [
 }
 
 func buildSigningConfig(key, alg, claimsFile, plugin string) (*bundle.SigningConfig, error) {
-	if key == "" && (plugin != "" || claimsFile != "" || alg != "") {
-		return nil, fmt.Errorf("specify the secret (HMAC) or path of the PEM file containing the private key (RSA and ECDSA)")
+	if key == "" && (plugin != "" || claimsFile != "") {
+		return nil, errSigningConfigIncomplete
 	}
 	if key == "" {
 		return nil, nil

--- a/cmd/build_test.go
+++ b/cmd/build_test.go
@@ -291,6 +291,39 @@ func TestBuildVerificationConfigError(t *testing.T) {
 	})
 }
 
+func TestBuildSigningConfigError(t *testing.T) {
+	tests := []struct {
+		note                    string
+		key, plugin, claimsFile string
+		expErr                  bool
+	}{
+		{
+			note: "key+plugin+claimsFile unset",
+		},
+		{
+			note:   "key+claimsFile unset",
+			plugin: "plugin",
+			expErr: true,
+		},
+		{
+			note:       "key+plugin unset",
+			claimsFile: "claims",
+			expErr:     true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.note, func(t *testing.T) {
+			_, err := buildSigningConfig(tc.key, defaultTokenSigningAlg, tc.claimsFile, tc.plugin)
+			switch {
+			case tc.expErr && err == nil:
+				t.Fatal("Expected error but got nil")
+			case !tc.expErr && err != nil:
+				t.Fatalf("Expected no error but got %v", err)
+			}
+		})
+	}
+}
+
 func TestBuildPlanWithPruneUnused(t *testing.T) {
 
 	files := map[string]string{

--- a/cmd/sign.go
+++ b/cmd/sign.go
@@ -36,6 +36,8 @@ const (
 	signaturesFile         = ".signatures.json"
 )
 
+var errSigningConfigIncomplete = fmt.Errorf("specify the secret (HMAC) or path of the PEM file containing the private key (RSA and ECDSA)")
+
 func newSignCmdParams() signCmdParams {
 	return signCmdParams{}
 }
@@ -271,7 +273,7 @@ func validateSignParams(args []string, params signCmdParams) error {
 	}
 
 	if params.key == "" {
-		return fmt.Errorf("specify the secret (HMAC) or path of the PEM file containing the private key (RSA and ECDSA)")
+		return errSigningConfigIncomplete
 	}
 
 	if !params.bundleMode {


### PR DESCRIPTION
Since `alg` has a default setting, we've gotten that error too often.

Follow-up to #5297 and #4972.
