### PR TITLE
compiler, topdown, planner: special-case `internal.member_3`

### DIFF
--- a/ast/compile.go
+++ b/ast/compile.go
@@ -866,7 +866,7 @@ func condenseBody(b Body) Body {
 			if v, ok := arg.Value.(Var); ok {
 				if pr, ok := refs[v]; ok {
 					b[i].Terms.([]*Term)[lazyIdx+1].Value = pr.ref
-					b.Remove(pr.idx)
+					b.remove(pr.idx)
 				}
 			}
 		}

--- a/ast/compile.go
+++ b/ast/compile.go
@@ -839,6 +839,7 @@ func condenseBody(b Body) Body {
 		return false
 	})
 
+	var rem []int // indexes to remove
 	for i := range b {
 		switch {
 		case b[i].IsEquality():
@@ -866,10 +867,14 @@ func condenseBody(b Body) Body {
 			if v, ok := arg.Value.(Var); ok {
 				if pr, ok := refs[v]; ok {
 					b[i].Terms.([]*Term)[lazyIdx+1].Value = pr.ref
-					b.remove(pr.idx)
+					rem = append(rem, pr.idx)
 				}
 			}
 		}
+	}
+	// remove back-to-front, since we'd otherwise mess up indices
+	for i := len(rem) - 1; i >= 0; i-- {
+		b.remove(rem[i])
 	}
 	return b
 }

--- a/ast/compile_test.go
+++ b/ast/compile_test.go
@@ -8790,7 +8790,7 @@ p if "a", 1 in http.send({"method": "GET", "url": "url"}).body.nums
 				}`),
 		},
 		{
-			note: "rule body, declared variable",
+			note: "not modified: declared variable",
 			mod: MustParseModuleWithOpts(`package p
 
 p {
@@ -8798,7 +8798,7 @@ p {
 	1, "a" in v
 }
 `, popts),
-			exp: MustParseRule(`p { internal.member_3(1, "a", input.foo) }`),
+			exp: MustParseRule(`p { __local0__ = input.foo; internal.member_3(1, "a", input.foo) }`),
 		},
 		{
 			note: "every body",

--- a/ast/compile_test.go
+++ b/ast/compile_test.go
@@ -8767,9 +8767,25 @@ func TestCompilerCondenseRefs(t *testing.T) {
 		{
 			note: "rule body, simple",
 			mod: MustParseModuleWithOpts(`package p
-p { 1, "a" in input.foo }
+p {
+	1, "a" in input.foo
+}
 `, popts),
 			exp: MustParseRule(`p { internal.member_3(1, "a", input.foo) }`),
+		},
+		{
+			note: "rule body, multiple simple",
+			mod: MustParseModuleWithOpts(`package p
+p {
+	1, "a" in input.foo
+	2, "b" in input.baz
+}
+`, popts),
+			exp: MustParseRule(
+				`p {
+					internal.member_3(1, "a", input.foo)
+					internal.member_3(2, "b", input.baz)
+				}`),
 		},
 		{
 			note: "rule body, nested",

--- a/ast/policy.go
+++ b/ast/policy.go
@@ -934,11 +934,15 @@ func (body *Body) Append(expr *Expr) {
 	*body = append(*body, expr)
 }
 
-// Remove deletes the expr at index `i` frmo the body and updates other exprs'
-// indexes accordingly.
-func (body *Body) Remove(i int) {
+// remove deletes the generated expr at index `i` from the body and updates other
+// exprs' indexes accordingly. If the expression at index `i` was not generated,
+// it does nothing
+func (body *Body) remove(i int) {
 	if i < 0 || i >= len(*body) {
 		panic("index out of range")
+	}
+	if !(*body)[i].Generated {
+		return
 	}
 	var s []*Expr = *body
 	s = append(s[:i], s[i+1:]...)

--- a/ast/policy.go
+++ b/ast/policy.go
@@ -934,6 +934,20 @@ func (body *Body) Append(expr *Expr) {
 	*body = append(*body, expr)
 }
 
+// Remove deletes the expr at index `i` frmo the body and updates other exprs'
+// indexes accordingly.
+func (body *Body) Remove(i int) {
+	if i < 0 || i >= len(*body) {
+		panic("index out of range")
+	}
+	var s []*Expr = *body
+	s = append(s[:i], s[i+1:]...)
+	for j := range s {
+		s[j].Index = j
+	}
+	*body = s
+}
+
 // Set sets the expr in the body at the specified position and updates the
 // expr's index accordingly.
 func (body Body) Set(expr *Expr, pos int) {

--- a/internal/wasm/sdk/test/e2e/exceptions.yaml
+++ b/internal/wasm/sdk/test/e2e/exceptions.yaml
@@ -4,3 +4,4 @@
 "data/nested integer": "https://github.com/open-policy-agent/opa/issues/3711"
 "withkeyword/function: indirect call, arity 1, replacement is value that needs eval (array comprehension)": "https://github.com/open-policy-agent/opa/issues/5311"
 "withkeyword/builtin: indirect call, arity 1, replacement is value that needs eval (array comprehension)": "https://github.com/open-policy-agent/opa/issues/5311"
+"aggregates/member+key+ref+input+other rule (conflict)": "planner doesn't implement the special-casing of internal.member_3 yet"

--- a/test/cases/testdata/aggregates/test-membership-in-refs.yaml
+++ b/test/cases/testdata/aggregates/test-membership-in-refs.yaml
@@ -58,6 +58,24 @@ cases:
     other.ref.b = 3
 
     p if "a", 1 in other.ref
+  note: aggregates/member+key+ref+input+other rule (conflict)
+  query: data.test.p = x
+  want_result:
+  - x: true
+- modules:
+  # NOTE(sr): This is the same as the case above, but without the conflict.
+  # It's added because the planner does the correct thing already to cope with
+  # the change to the compiler; but it doesn't do the same optimizations yet.
+  # When it does, the two cases can be combined.
+  - |
+    package test
+    import future.keywords.in
+    import future.keywords.if
+
+    other.ref.a = 1
+    other.ref.b = 2
+
+    p if "a", 1 in other.ref
   note: aggregates/member+key+ref+input+other rule
   query: data.test.p = x
   want_result:

--- a/test/cases/testdata/aggregates/test-membership-in-refs.yaml
+++ b/test/cases/testdata/aggregates/test-membership-in-refs.yaml
@@ -75,8 +75,29 @@ cases:
     other.ref.a = 1
     other.ref.b = 2
 
-    p if "a", 1 in other.ref
+    p if "a", 1 in {"a": 1} #other.ref
   note: aggregates/member+key+ref+input+other rule
   query: data.test.p = x
   want_result:
   - x: true
+- modules:
+  # NOTE(sr): This is the same as the case above, but without the conflict.
+  # It's added because the planner does the correct thing already to cope with
+  # the change to the compiler; but it doesn't do the same optimizations yet.
+  # When it does, the two cases can be combined.
+  - |
+    package test
+    import future.keywords.in
+    import future.keywords.if
+
+    other.ref.a = 1
+    other.ref.b = 2
+
+    p if x := "a", 2 in other.ref
+  note: aggregates/member+key+ref+input+other rule, value used
+  query: data.test.p = x
+  want_result:
+  - x: true
+
+  ## NB   p := "a", 1 in other.ref
+  ## NB   p if internal.member_3("a", 2, other.ref, true)

--- a/test/cases/testdata/aggregates/test-membership-in-refs.yaml
+++ b/test/cases/testdata/aggregates/test-membership-in-refs.yaml
@@ -1,0 +1,64 @@
+cases:
+- data:
+    object:
+      a: 1
+      b: 2
+      c: 3
+  modules:
+  - |
+    package test
+    import future.keywords.in
+    import future.keywords.if
+    p if "a", 1 in data.object
+  note: aggregates/member+key+ref+data
+  query: data.test.p = x
+  want_result:
+  - x: true
+- input:
+    a: 1
+    b: 2
+    c: 3
+  modules:
+  - |
+    package test
+    import future.keywords.in
+    import future.keywords.if
+    p if "a", 1 in input
+  note: aggregates/member+key+ref+input
+  query: data.test.p = x
+  want_result:
+  - x: true
+- input:
+    z:
+      a: 1
+      b: 2
+      c: 3
+  modules:
+  - |
+    package test
+    import future.keywords.in
+    import future.keywords.if
+
+    p if {
+      some x in {"x", "y", "z"}
+      "a", 1 in input[x]
+    }
+  note: aggregates/member+key+ref+input+other var
+  query: data.test.p = x
+  want_result:
+  - x: true
+- modules:
+  - |
+    package test
+    import future.keywords.in
+    import future.keywords.if
+
+    other.ref.a = 1
+    other.ref.b = 2 # eval conflict if `other.ref.b` is evaluated
+    other.ref.b = 3
+
+    p if "a", 1 in other.ref
+  note: aggregates/member+key+ref+input+other rule
+  query: data.test.p = x
+  want_result:
+  - x: true


### PR DESCRIPTION
First parts of #5325: It occurred to me this morning that instead of changing all the rewriting logic, and dealing with all the ripple effects, we could perhaps just dial back that one thing we need -- at the end of the compiler stages.

I've been going back and forth with myself while trying this, not sure if I've forgotten any side effect that hinders us here... but it seems to work 😅 

- [x] compiler: added a new stage that'll pluck the expanded refs back in -- and also declared vars, because why not, if it helps performance?
- [x] topdown: adapt the evaluator code to special-case `"k", "v" in collection`
- [x] planner: at least undo the condensed format
- [ ] determine if the improvements are significant enough to push this further