### PR TITLE
ci/pull-request: change action used for wasm filter

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -155,33 +155,36 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3
 
-      - id: changed-files
-        uses: tj-actions/changed-files@v32.1.0
+      - name: Check PR for changes to Wasm
+        uses: dorny/paths-filter@v2
+        id: changes
         with:
-          files: |
-            Makefile
-            wasm/
-            ast/
-            internal/compiler/
-            internal/planner/
-            internal/wasm/
-            test/wasm/
-            test/cases/
+          filters: |
+            wasm:
+              - Makefile
+              - 'wasm/**'
+              - 'ast/**'
+              - 'internal/compiler/**'
+              - 'internal/planner/**'
+              - 'internal/wasm/**'
+              - 'test/wasm/**'
+              - 'test/cases/**'
 
       - name: Download generated artifacts
         uses: actions/download-artifact@v3
         with:
           name: generated
+        if: steps.changes.outputs.wasm == 'true'
 
       - name: Build and Test Wasm
         run: make ci-wasm
         timeout-minutes: 15
-        if: steps.changed-files.outputs.any_changed == 'true'
+        if: steps.changes.outputs.wasm == 'true'
 
       - name: Build and Test Wasm SDK
         run: make ci-go-wasm-sdk-e2e-test
         timeout-minutes: 30
-        if: steps.changed-files.outputs.any_changed == 'true'
+        if: steps.changes.outputs.wasm == 'true'
         env:
           DOCKER_RUNNING: 0
 


### PR DESCRIPTION
The other one was broken; let's see what's going on here. Maybe it was related to the action used, maybe not...