### PR TITLE
topdown/copypropagation: skip comprehensions when checking eqs

### DIFF
--- a/topdown/topdown_partial_test.go
+++ b/topdown/topdown_partial_test.go
@@ -3288,6 +3288,28 @@ func TestTopDownPartialEval(t *testing.T) {
 					a2 = input; __local4__2 > __local2__2 }
 				}`},
 		},
+		{ // https://github.com/open-policy-agent/opa/issues/5367
+			note:  "copypropagation: keep equations that are only found in comprehensions, inlined function call",
+			query: "data.test.p",
+			modules: []string{`package test
+			key_exists(obj, k) { x = obj[k] }
+			
+			p {
+				key_exists(input, "foo")
+				{ true | input.foo }
+			}`},
+			wantQueries: []string{`{true | input.foo} = x_term_1_21; x_term_1_21; x2 = input.foo`},
+		},
+		{ // condensed form of the test above
+			note:  "copypropagation: keep equations that are only found in comprehensions",
+			query: "data.test.p",
+			modules: []string{`package test
+			p {
+				x = input.foo
+				{ true | input.foo }
+			}`},
+			wantQueries: []string{`{true | input.foo} = x_term_1_11; x_term_1_11; x1 = input.foo`},
+		},
 	}
 
 	ctx := context.Background()


### PR DESCRIPTION
CP works as follows, it removes a bunch of questions (details omitted), and then re-adds them if they provide safety for some variable, or if they introduce refs and values that aren't "contained" in the existing body.

For that second part, checking containment, the code looked at all refs (all terms), regardless of whether they're in comprehensions or not.

Now, in the specific case,

    p {
       { 1 | input.foo} # <-- present already
       _ = input.foo    # <-- required?
    }

the fact that `input.foo` is in the body already doesn't make the second expression any less meaningful: if `input.foo` is undefined, the comprehension would just be empty. For `p`, however, adding the second line makes a big difference.

Now, we'll skip comprehensions when checking if a previously-removed equation should be re-introduced.

I've thrown in another small check to rule out some simple cases that have popped up when changing the previous containment-check.

Fixes #5367.

