### PR TITLE
builtins: `json.patch` benchmark + rework

### DIFF
--- a/topdown/json.go
+++ b/topdown/json.go
@@ -10,12 +10,12 @@ import (
 	"strings"
 
 	"github.com/open-policy-agent/opa/ast"
-	"github.com/open-policy-agent/opa/internal/edittree"
 	"github.com/open-policy-agent/opa/topdown/builtins"
+
+	"github.com/open-policy-agent/opa/internal/edittree"
 )
 
 func builtinJSONRemove(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term) error) error {
-
 	// Expect an object and a string or array/set of strings
 	_, err := builtins.ObjectOperand(operands[0].Value, 1)
 	if err != nil {
@@ -117,7 +117,6 @@ func jsonRemove(a *ast.Term, b *ast.Term) (*ast.Term, error) {
 }
 
 func builtinJSONFilter(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term) error) error {
-
 	// Ensure we have the right parameters, expect an object and a string or array/set of strings
 	obj, err := builtins.ObjectOperand(operands[0].Value, 1)
 	if err != nil {
@@ -131,10 +130,13 @@ func builtinJSONFilter(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Te
 	}
 
 	// Actually do the filtering
-	et := edittree.NewEditTree(ast.NewTerm(obj))
-	r := et.Filter(filters)
+	filterObj := pathsToObject(filters)
+	r, err := obj.Filter(filterObj)
+	if err != nil {
+		return err
+	}
 
-	return iter(r)
+	return iter(ast.NewTerm(r))
 }
 
 func getJSONPaths(operand ast.Value) ([]ast.Ref, error) {
@@ -194,7 +196,6 @@ func parsePath(path *ast.Term) (ast.Ref, error) {
 }
 
 func pathsToObject(paths []ast.Ref) ast.Object {
-
 	root := ast.NewObject()
 
 	for _, path := range paths {
@@ -237,288 +238,147 @@ func pathsToObject(paths []ast.Ref) ast.Object {
 	return root
 }
 
-// toIndex tries to convert path elements (that may be strings) into indices into
-// an array.
-func toIndex(arr *ast.Array, term *ast.Term) (int, error) {
-	i := 0
+type jsonPatch struct {
+	op    string
+	path  *ast.Term
+	from  *ast.Term
+	value *ast.Term
+}
+
+func getPatch(o ast.Object) (jsonPatch, error) {
+	validOps := map[string]struct{}{"add": {}, "remove": {}, "replace": {}, "move": {}, "copy": {}, "test": {}}
+	var out jsonPatch
 	var ok bool
-	switch v := term.Value.(type) {
-	case ast.Number:
-		if i, ok = v.Int(); !ok {
-			return 0, fmt.Errorf("Invalid number type for indexing")
+	getAttribute := func(attr string) (*ast.Term, error) {
+		if term := o.Get(ast.StringTerm(attr)); term != nil {
+			return term, nil
 		}
-	case ast.String:
-		if v == "-" {
-			return arr.Len(), nil
-		}
-		num := ast.Number(v)
-		if i, ok = num.Int(); !ok {
-			return 0, fmt.Errorf("Invalid string for indexing")
-		}
-		if v != "0" && strings.HasPrefix(string(v), "0") {
-			return 0, fmt.Errorf("Leading zeros are not allowed in JSON paths")
-		}
-	default:
-		return 0, fmt.Errorf("Invalid type for indexing")
+
+		return nil, fmt.Errorf("missing '%s' attribute", attr)
 	}
 
-	return i, nil
-}
-
-// patchWorkerris a worker that modifies a direct child of a term located
-// at the given key.  It returns the new term, and optionally a result that
-// is passed back to the caller.
-type patchWorker = func(parent, key *ast.Term) (updated, result *ast.Term)
-
-func jsonPatchTraverse(
-	target *ast.Term,
-	path ast.Ref,
-	worker patchWorker,
-) (*ast.Term, *ast.Term) {
-	if len(path) < 1 {
-		return nil, nil
+	opTerm, err := getAttribute("op")
+	if err != nil {
+		return out, err
+	}
+	op, ok := opTerm.Value.(ast.String)
+	if !ok {
+		return out, fmt.Errorf("attribute 'op' must be a string")
+	}
+	out.op = string(op)
+	if _, found := validOps[out.op]; !found {
+		out.op = ""
+		return out, fmt.Errorf("unrecognized op '%s'", string(op))
 	}
 
-	key := path[0]
-	if len(path) == 1 {
-		return worker(target, key)
+	pathTerm, err := getAttribute("path")
+	if err != nil {
+		return out, err
 	}
+	out.path = pathTerm
 
-	success := false
-	var updated, result *ast.Term
-	switch parent := target.Value.(type) {
-	case ast.Object:
-		obj := ast.NewObject()
-		parent.Foreach(func(k, v *ast.Term) {
-			if k.Equal(key) {
-				if v, result = jsonPatchTraverse(v, path[1:], worker); v != nil {
-					obj.Insert(k, v)
-					success = true
-				}
-			} else {
-				obj.Insert(k, v)
-			}
-		})
-		updated = ast.NewTerm(obj)
-
-	case *ast.Array:
-		idx, err := toIndex(parent, key)
+	// Only fetch the "from" parameter for move/copy ops.
+	switch out.op {
+	case "move", "copy":
+		fromTerm, err := getAttribute("from")
 		if err != nil {
-			return nil, nil
+			return out, err
 		}
-		arr := ast.NewArray()
-		for i := 0; i < parent.Len(); i++ {
-			v := parent.Elem(i)
-			if idx == i {
-				if v, result = jsonPatchTraverse(v, path[1:], worker); v != nil {
-					arr = arr.Append(v)
-					success = true
-				}
-			} else {
-				arr = arr.Append(v)
+		out.from = fromTerm
+	}
+
+	// Only fetch the "value" parameter for add/replace/test ops.
+	switch out.op {
+	case "add", "replace", "test":
+		valueTerm, err := getAttribute("value")
+		if err != nil {
+			return out, err
+		}
+		out.value = valueTerm
+	}
+
+	return out, nil
+}
+
+func applyPatches(source *ast.Term, operations *ast.Array) (*ast.Term, error) {
+	et := edittree.NewEditTree(source)
+	for i := 0; i < operations.Len(); i++ {
+		object, ok := operations.Elem(i).Value.(ast.Object)
+		if !ok {
+			return nil, fmt.Errorf("must be an array of JSON-Patch objects, but at least one element is not an object")
+		}
+		patch, err := getPatch(object)
+		if err != nil {
+			return nil, err
+		}
+		path, err := parsePath(patch.path)
+		if err != nil {
+			return nil, err
+		}
+
+		switch patch.op {
+		case "add":
+			_, err = et.InsertAtPath(path, patch.value)
+			if err != nil {
+				return nil, err
+			}
+		case "remove":
+			_, err = et.DeleteAtPath(path)
+			if err != nil {
+				return nil, err
+			}
+		case "replace":
+			_, err = et.DeleteAtPath(path)
+			if err != nil {
+				return nil, err
+			}
+			_, err = et.InsertAtPath(path, patch.value)
+			if err != nil {
+				return nil, err
+			}
+		case "move":
+			from, err := parsePath(patch.from)
+			if err != nil {
+				return nil, err
+			}
+			chunk, err := et.RenderAtPath(from)
+			if err != nil {
+				return nil, err
+			}
+			_, err = et.DeleteAtPath(from)
+			if err != nil {
+				return nil, err
+			}
+			_, err = et.InsertAtPath(path, chunk)
+			if err != nil {
+				return nil, err
+			}
+		case "copy":
+			from, err := parsePath(patch.from)
+			if err != nil {
+				return nil, err
+			}
+			chunk, err := et.RenderAtPath(from)
+			if err != nil {
+				return nil, err
+			}
+			_, err = et.InsertAtPath(path, chunk)
+			if err != nil {
+				return nil, err
+			}
+		case "test":
+			chunk, err := et.RenderAtPath(path)
+			if err != nil {
+				return nil, err
+			}
+			if !chunk.Equal(patch.value) {
+				return nil, fmt.Errorf("value from EditTree != patch value.\n\nExpected: %v\n\nFound: %v", patch.value, chunk)
 			}
 		}
-		updated = ast.NewTerm(arr)
-
-	case ast.Set:
-		set := ast.NewSet()
-		parent.Foreach(func(k *ast.Term) {
-			if k.Equal(key) {
-				if k, result = jsonPatchTraverse(k, path[1:], worker); k != nil {
-					set.Add(k)
-					success = true
-				}
-			} else {
-				set.Add(k)
-			}
-		})
-		updated = ast.NewTerm(set)
 	}
-
-	if success {
-		return updated, result
-	}
-
-	return nil, nil
-}
-
-// jsonPatchGet goes one step further than jsonPatchTraverse and returns the
-// term at the location specified by the path.  It is used in functions
-// where we want to read a value but not manipulate its parent: for example
-// jsonPatchTest and jsonPatchCopy.
-//
-// Because it uses jsonPatchTraverse, it makes shallow copies of the objects
-// along the path.  We could possibly add a signaling mechanism that we didn't
-// make any changes to avoid this.
-func jsonPatchGet(target *ast.Term, path ast.Ref) *ast.Term {
-	// Special case: get entire document.
-	if len(path) == 0 {
-		return target
-	}
-
-	_, result := jsonPatchTraverse(target, path, func(parent, key *ast.Term) (*ast.Term, *ast.Term) {
-		switch v := parent.Value.(type) {
-		case ast.Object:
-			return parent, v.Get(key)
-		case *ast.Array:
-			i, err := toIndex(v, key)
-			if err == nil {
-				return parent, v.Elem(i)
-			}
-		case ast.Set:
-			if v.Contains(key) {
-				return parent, key
-			}
-		}
-		return nil, nil
-	})
-	return result
-}
-
-func jsonPatchAdd(target *ast.Term, path ast.Ref, value *ast.Term) *ast.Term {
-	// Special case: replacing root document.
-	if len(path) == 0 {
-		return value
-	}
-
-	target, _ = jsonPatchTraverse(target, path, func(parent *ast.Term, key *ast.Term) (*ast.Term, *ast.Term) {
-		switch original := parent.Value.(type) {
-		case ast.Object:
-			obj := ast.NewObject()
-			original.Foreach(func(k, v *ast.Term) {
-				obj.Insert(k, v)
-			})
-			obj.Insert(key, value)
-			return ast.NewTerm(obj), nil
-		case *ast.Array:
-			idx, err := toIndex(original, key)
-			if err != nil || idx < 0 || idx > original.Len() {
-				return nil, nil
-			}
-			arr := ast.NewArray()
-			for i := 0; i < idx; i++ {
-				arr = arr.Append(original.Elem(i))
-			}
-			arr = arr.Append(value)
-			for i := idx; i < original.Len(); i++ {
-				arr = arr.Append(original.Elem(i))
-			}
-			return ast.NewTerm(arr), nil
-		case ast.Set:
-			if !key.Equal(value) {
-				return nil, nil
-			}
-			set := ast.NewSet()
-			original.Foreach(func(k *ast.Term) {
-				set.Add(k)
-			})
-			set.Add(key)
-			return ast.NewTerm(set), nil
-		}
-		return nil, nil
-	})
-
-	return target
-}
-
-func jsonPatchRemove(target *ast.Term, path ast.Ref) (*ast.Term, *ast.Term) {
-	// Special case: replacing root document.
-	if len(path) == 0 {
-		return nil, nil
-	}
-
-	target, removed := jsonPatchTraverse(target, path, func(parent *ast.Term, key *ast.Term) (*ast.Term, *ast.Term) {
-		var removed *ast.Term
-		switch original := parent.Value.(type) {
-		case ast.Object:
-			obj := ast.NewObject()
-			original.Foreach(func(k, v *ast.Term) {
-				if k.Equal(key) {
-					removed = v
-				} else {
-					obj.Insert(k, v)
-				}
-			})
-			return ast.NewTerm(obj), removed
-		case *ast.Array:
-			idx, err := toIndex(original, key)
-			if err != nil || idx < 0 || idx >= original.Len() {
-				return nil, nil
-			}
-			arr := ast.NewArray()
-			for i := 0; i < idx; i++ {
-				arr = arr.Append(original.Elem(i))
-			}
-			removed = original.Elem(idx)
-			for i := idx + 1; i < original.Len(); i++ {
-				arr = arr.Append(original.Elem(i))
-			}
-			return ast.NewTerm(arr), removed
-		case ast.Set:
-			set := ast.NewSet()
-			original.Foreach(func(k *ast.Term) {
-				if k.Equal(key) {
-					removed = k
-				} else {
-					set.Add(k)
-				}
-			})
-			return ast.NewTerm(set), removed
-		}
-		return nil, nil
-	})
-
-	if target != nil && removed != nil {
-		return target, removed
-	}
-
-	return nil, nil
-}
-
-func jsonPatchReplace(target *ast.Term, path ast.Ref, value *ast.Term) *ast.Term {
-	// Special case: replacing the whole document.
-	if len(path) == 0 {
-		return value
-	}
-
-	// Replace is specified as `remove` followed by `add`.
-	if target, _ = jsonPatchRemove(target, path); target == nil {
-		return nil
-	}
-
-	return jsonPatchAdd(target, path, value)
-}
-
-func jsonPatchMove(target *ast.Term, path ast.Ref, from ast.Ref) *ast.Term {
-	// Move is specified as `remove` followed by `add`.
-	target, removed := jsonPatchRemove(target, from)
-	if target == nil || removed == nil {
-		return nil
-	}
-
-	return jsonPatchAdd(target, path, removed)
-}
-
-func jsonPatchCopy(target *ast.Term, path ast.Ref, from ast.Ref) *ast.Term {
-	value := jsonPatchGet(target, from)
-	if value == nil {
-		return nil
-	}
-
-	return jsonPatchAdd(target, path, value)
-}
-
-func jsonPatchTest(target *ast.Term, path ast.Ref, value *ast.Term) *ast.Term {
-	actual := jsonPatchGet(target, path)
-	if actual == nil {
-		return nil
-	}
-
-	if actual.Equal(value) {
-		return target
-	}
-
-	return nil
+	final := et.Render()
+	// TODO: Nil check here?
+	return final, nil
 }
 
 func builtinJSONPatch(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term) error) error {
@@ -531,93 +391,11 @@ func builtinJSONPatch(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Ter
 		return err
 	}
 
-	// Apply operations one by one.
-	for i := 0; i < operations.Len(); i++ {
-		if object, ok := operations.Elem(i).Value.(ast.Object); ok {
-			getAttribute := func(attr string) (*ast.Term, error) {
-				if term := object.Get(ast.StringTerm(attr)); term != nil {
-					return term, nil
-				}
-
-				return nil, builtins.NewOperandErr(2, fmt.Sprintf("patch is missing '%s' attribute", attr))
-			}
-
-			getPathAttribute := func(attr string) (ast.Ref, error) {
-				term, err := getAttribute(attr)
-				if err != nil {
-					return ast.Ref{}, err
-				}
-				path, err := parsePath(term)
-				if err != nil {
-					return ast.Ref{}, err
-				}
-				return path, nil
-			}
-
-			// Parse operation.
-			opTerm, err := getAttribute("op")
-			if err != nil {
-				return err
-			}
-			op, ok := opTerm.Value.(ast.String)
-			if !ok {
-				return builtins.NewOperandErr(2, "patch attribute 'op' must be a string")
-			}
-
-			// Parse path.
-			path, err := getPathAttribute("path")
-			if err != nil {
-				return err
-			}
-
-			switch op {
-			case "add":
-				value, err := getAttribute("value")
-				if err != nil {
-					return err
-				}
-				target = jsonPatchAdd(target, path, value)
-			case "remove":
-				target, _ = jsonPatchRemove(target, path)
-			case "replace":
-				value, err := getAttribute("value")
-				if err != nil {
-					return err
-				}
-				target = jsonPatchReplace(target, path, value)
-			case "move":
-				from, err := getPathAttribute("from")
-				if err != nil {
-					return err
-				}
-				target = jsonPatchMove(target, path, from)
-			case "copy":
-				from, err := getPathAttribute("from")
-				if err != nil {
-					return err
-				}
-				target = jsonPatchCopy(target, path, from)
-			case "test":
-				value, err := getAttribute("value")
-				if err != nil {
-					return err
-				}
-				target = jsonPatchTest(target, path, value)
-			default:
-				return builtins.NewOperandErr(2, "must be an array of JSON-Patch objects")
-			}
-		} else {
-			return builtins.NewOperandErr(2, "must be an array of JSON-Patch objects")
-		}
-
-		// JSON patches should work atomically; and if one of them fails,
-		// we should not try to continue.
-		if target == nil {
-			return nil
-		}
+	patched, err := applyPatches(target, operations)
+	if err != nil {
+		return nil
 	}
-
-	return iter(target)
+	return iter(patched)
 }
 
 func init() {

--- a/topdown/json_bench_test.go
+++ b/topdown/json_bench_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 The OPA Authors.  All rights reserved.
+// Copyright 2022 The OPA Authors.  All rights reserved.
 // Use of this source code is governed by an Apache2
 // license that can be found in the LICENSE file.
 
@@ -7,7 +7,9 @@ package topdown
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/open-policy-agent/opa/ast"
@@ -15,70 +17,493 @@ import (
 	inmem "github.com/open-policy-agent/opa/storage/inmem/test"
 )
 
-func BenchmarkJSONFilterShallow(b *testing.B) {
+// Tests on only single-layer composite data types.
+// func BenchmarkJSONPatchAdd(b *testing.B) {
+// 	ctx := context.Background()
+
+// 	sizes := []int{10, 100, 1000, 1000}
+// }
+
+// func BenchmarkJSONPatchRemove(b *testing.B) {
+// 	ctx := context.Background()
+
+// 	sizes := []int{10, 100, 1000, 1000}
+// }
+
+// func BenchmarkJSONPatchReplace(b *testing.B) {
+// 	ctx := context.Background()
+
+// 	sizes := []int{10, 100, 1000, 1000}
+
+// }
+func BenchmarkJSONPatchAddShallowScalar(b *testing.B) {
 	ctx := context.Background()
 
 	sizes := []int{10, 100, 1000, 10000}
 
+	// Object case
 	for _, n := range sizes {
 		source := genTestObject(n)
 		for _, m := range sizes {
-			if m > n {
-				continue // skip tests where too many paths would be removed. (error case)
-			}
 			testName := fmt.Sprintf("object-%d-%d", n, m)
 			// Build dataset right before use:
-			paths := make([]*ast.Term, 0, m)
-			// paths to remove
+			plArrayObj := make([]*ast.Term, 0, m*2)
+			// add ops
 			for i := 0; i < m; i++ {
-				paths = append(paths, ast.StringTerm("/"+strconv.FormatInt(int64(i), 10)))
+				plArrayObj = append(plArrayObj, genTestJSONPatchObject("add", ast.StringTerm("/"+strconv.FormatInt(int64(i+n), 10)), nil, ast.IntNumberTerm(i+n)))
 			}
+			patchList := ast.NewArray(plArrayObj...)
 
 			b.ResetTimer()
 			b.Run(testName, func(b *testing.B) {
-				runJSONFilterBenchmarkTest(ctx, b, source, paths)
+				runJSONPatchBenchmarkTest(ctx, b, source, patchList)
+			})
+		}
+	}
+
+	// Array case
+	for _, n := range sizes {
+		source := genTestArray(n)
+		for _, m := range sizes {
+			testName := fmt.Sprintf("array-%d-%d", n, m)
+			// Build dataset right before use:
+			plArrayObj := make([]*ast.Term, 0, m*2)
+			// add ops
+			for i := 0; i < m; i++ {
+				plArrayObj = append(plArrayObj, genTestJSONPatchObject("add", ast.StringTerm("/"+strconv.FormatInt(int64(i+n), 10)), nil, ast.IntNumberTerm(i+n)))
+			}
+			patchList := ast.NewArray(plArrayObj...)
+
+			b.ResetTimer()
+			b.Run(testName, func(b *testing.B) {
+				runJSONPatchBenchmarkTest(ctx, b, source, patchList)
+			})
+		}
+	}
+	// Set case
+	for _, n := range sizes {
+		source := genTestSet(n)
+		for _, m := range sizes {
+			testName := fmt.Sprintf("set-%d-%d", n, m)
+			// Build dataset right before use:
+			plSet := make([]*ast.Term, 0, m*2)
+			// add ops
+			for i := 0; i < m; i++ {
+				plSet = append(plSet, genTestJSONPatchObject("add", ast.ArrayTerm(ast.IntNumberTerm(i+n)), nil, ast.IntNumberTerm(i+n)))
+			}
+			patchList := ast.NewArray(plSet...)
+
+			b.ResetTimer()
+			b.Run(testName, func(b *testing.B) {
+				runJSONPatchBenchmarkTest(ctx, b, source, patchList)
 			})
 		}
 	}
 }
 
-func BenchmarkJSONFilterNested(b *testing.B) {
+func BenchmarkJSONPatchAddShallowComposite(b *testing.B) {
 	ctx := context.Background()
 
 	sizes := []int{10, 100, 1000, 10000}
 
+	// Object case
 	for _, n := range sizes {
-		source := genNestedTestObject(n, 3)
+		source := genTestObject(n)
 		for _, m := range sizes {
-			if m > n {
-				continue // skip tests where too many paths would be removed. (error case)
-			}
 			testName := fmt.Sprintf("object-%d-%d", n, m)
 			// Build dataset right before use:
-			paths := make([]*ast.Term, 0, m)
-			// paths to remove
+			plArrayObj := make([]*ast.Term, 0, m*2)
+			// add ops
 			for i := 0; i < m; i++ {
-				idx := strconv.FormatInt(int64(i), 10)
-				paths = append(paths, ast.StringTerm("/"+idx+"/"+idx+"/"+idx))
+				plArrayObj = append(plArrayObj, genTestJSONPatchObject("add", ast.StringTerm("/"+strconv.FormatInt(int64(i+n), 10)), nil, ast.ArrayTerm(ast.IntNumberTerm(i+n))))
 			}
+			patchList := ast.NewArray(plArrayObj...)
 
 			b.ResetTimer()
 			b.Run(testName, func(b *testing.B) {
-				runJSONFilterBenchmarkTest(ctx, b, source, paths)
+				runJSONPatchBenchmarkTest(ctx, b, source, patchList)
+			})
+		}
+	}
+
+	// Array case
+	for _, n := range sizes {
+		source := genTestArray(n)
+		for _, m := range sizes {
+			testName := fmt.Sprintf("array-%d-%d", n, m)
+			// Build dataset right before use:
+			plArrayObj := make([]*ast.Term, 0, m*2)
+			// add ops
+			for i := 0; i < m; i++ {
+				plArrayObj = append(plArrayObj, genTestJSONPatchObject("add", ast.StringTerm("/"+strconv.FormatInt(int64(i+n), 10)), nil, ast.ArrayTerm(ast.IntNumberTerm(i+n))))
+			}
+			patchList := ast.NewArray(plArrayObj...)
+
+			b.ResetTimer()
+			b.Run(testName, func(b *testing.B) {
+				runJSONPatchBenchmarkTest(ctx, b, source, patchList)
+			})
+		}
+	}
+	// Set case
+	for _, n := range sizes {
+		source := genTestSet(n)
+		for _, m := range sizes {
+			testName := fmt.Sprintf("set-%d-%d", n, m)
+			// Build dataset right before use:
+			plSet := make([]*ast.Term, 0, m*2)
+			// add ops
+			for i := 0; i < m; i++ {
+				plSet = append(plSet, genTestJSONPatchObject("add", ast.ArrayTerm(ast.ArrayTerm(ast.IntNumberTerm(i+n))), nil, ast.ArrayTerm(ast.IntNumberTerm(i+n))))
+			}
+			patchList := ast.NewArray(plSet...)
+
+			b.ResetTimer()
+			b.Run(testName, func(b *testing.B) {
+				runJSONPatchBenchmarkTest(ctx, b, source, patchList)
 			})
 		}
 	}
 }
 
-func runJSONFilterBenchmarkTest(ctx context.Context, b *testing.B, source ast.Value, paths []*ast.Term) {
+func BenchmarkJSONPatchAddRemove(b *testing.B) {
+	ctx := context.Background()
+
+	sizes := []int{10, 100, 1000, 10000}
+
+	// Object case
+	for _, n := range sizes {
+		source := genTestObject(n)
+		for _, m := range sizes {
+			testName := fmt.Sprintf("object-%d-%d", n, m)
+			// Build dataset right before use:
+			plArrayObj := make([]*ast.Term, 0, m*2)
+			// add ops
+			for i := 0; i < m; i++ {
+				plArrayObj = append(plArrayObj, genTestJSONPatchObject("add", ast.StringTerm("/"+strconv.FormatInt(int64(i+n), 10)), nil, ast.IntNumberTerm(i+n)))
+			}
+			// remove ops
+			for i := m - 1; i >= 0; i-- {
+				plArrayObj = append(plArrayObj, genTestJSONPatchObject("remove", ast.StringTerm("/"+strconv.FormatInt(int64(i+n), 10)), nil, nil))
+			}
+			patchList := ast.NewArray(plArrayObj...)
+
+			b.ResetTimer()
+			b.Run(testName, func(b *testing.B) {
+				runJSONPatchBenchmarkTest(ctx, b, source, patchList)
+			})
+		}
+	}
+
+	// Array case
+	for _, n := range sizes {
+		source := genTestArray(n)
+		for _, m := range sizes {
+			testName := fmt.Sprintf("array-%d-%d", n, m)
+			// Build dataset right before use:
+			plArrayObj := make([]*ast.Term, 0, m*2)
+			// add ops
+			for i := 0; i < m; i++ {
+				plArrayObj = append(plArrayObj, genTestJSONPatchObject("add", ast.StringTerm("/"+strconv.FormatInt(int64(i+n), 10)), nil, ast.IntNumberTerm(i+n)))
+			}
+			// remove ops
+			for i := m - 1; i >= 0; i-- {
+				plArrayObj = append(plArrayObj, genTestJSONPatchObject("remove", ast.StringTerm("/"+strconv.FormatInt(int64(i+n), 10)), nil, nil))
+			}
+			patchList := ast.NewArray(plArrayObj...)
+
+			b.ResetTimer()
+			b.Run(testName, func(b *testing.B) {
+				runJSONPatchBenchmarkTest(ctx, b, source, patchList)
+			})
+		}
+	}
+
+	// Set case
+	for _, n := range sizes {
+		source := genTestSet(n)
+		for _, m := range sizes {
+			testName := fmt.Sprintf("set-%d-%d", n, m)
+			// Build dataset right before use:
+			plSet := make([]*ast.Term, 0, m*2)
+			// add ops
+			for i := 0; i < m; i++ {
+				plSet = append(plSet, genTestJSONPatchObject("add", ast.ArrayTerm(ast.IntNumberTerm(i+n)), nil, ast.IntNumberTerm(i+n)))
+			}
+			// remove ops
+			for i := m - 1; i >= 0; i-- {
+				plSet = append(plSet, genTestJSONPatchObject("remove", ast.ArrayTerm(ast.IntNumberTerm(i+n)), nil, nil))
+			}
+			patchList := ast.NewArray(plSet...)
+
+			b.ResetTimer()
+			b.Run(testName, func(b *testing.B) {
+				runJSONPatchBenchmarkTest(ctx, b, source, patchList)
+			})
+		}
+	}
+}
+
+func genTestJSONPatchObject(op string, path, from, value *ast.Term) *ast.Term {
+	patchObj := ast.NewObject(
+		[2]*ast.Term{ast.StringTerm("op"), ast.StringTerm(op)},
+		[2]*ast.Term{ast.StringTerm("path"), path},
+	)
+	if from != nil {
+		patchObj.Insert(ast.StringTerm("from"), from)
+	}
+	if value != nil {
+		patchObj.Insert(ast.StringTerm("value"), value)
+	}
+	return ast.NewTerm(patchObj)
+}
+
+func genTestObject(width int) ast.Value {
+	out := ast.NewObject()
+	for i := 0; i < width; i++ {
+		out.Insert(ast.IntNumberTerm(i), ast.IntNumberTerm(i))
+	}
+	return out
+}
+
+func genTestArray(width int) ast.Value {
+	out := ast.NewArray()
+	for i := 0; i < width; i++ {
+		out = out.Append(ast.IntNumberTerm(i))
+	}
+	return out
+}
+
+func genTestSet(width int) ast.Value {
+	out := ast.NewSet()
+	for i := 0; i < width; i++ {
+		out.Add(ast.IntNumberTerm(i))
+	}
+	return out
+}
+
+// For the purposes of addressing the original Github issue (#4409), a
+// fairly shallow object with many keys ought to do the trick.
+func gen3LayerObject(l1Keys, l2Keys, l3Keys int) ast.Value {
+	obj := ast.NewObject()
+	for i := 0; i < l1Keys; i++ {
+		l2Obj := ast.NewObject()
+		for j := 0; j < l2Keys; j++ {
+			l3Obj := ast.NewObject()
+			for k := 0; k < l3Keys; k++ {
+				l3Obj.Insert(ast.StringTerm(fmt.Sprintf("%d", k)), ast.BooleanTerm(true))
+			}
+			l2Obj.Insert(ast.StringTerm(fmt.Sprintf("%d", j)), ast.NewTerm(l3Obj))
+		}
+		obj.Insert(ast.StringTerm(fmt.Sprintf("%d", i)), ast.NewTerm(l2Obj))
+	}
+	return obj
+}
+
+// Generates a list of paths for JSON operations. N keys per level, M levels. P patches.
+// TODO: Generate non-conflicting paths.
+func genRandom3LayerObjectJSONPatchListData(l1Keys, l2Keys, l3Keys, p int) ast.Value {
+	patchList := make([]*ast.Term, p)
+	numKeys := []int{l1Keys, l2Keys, l3Keys}
+	for i := 0; i < p; i++ {
+		patchObj := ast.NewObject(
+			[2]*ast.Term{ast.StringTerm("op"), ast.StringTerm("replace")},
+			[2]*ast.Term{ast.StringTerm("value"), ast.IntNumberTerm(2)},
+		)
+		// Random path depth.
+		depth := rand.Intn(3) + 1 // (max - min) + min method of getting a random range.
+
+		// Random values for each path segment.
+		segments := []string{}
+		for j := 0; j < depth; j++ {
+			pathSegment := strconv.FormatInt(int64(rand.Intn(numKeys[j])), 10)
+			segments = append(segments, "/", pathSegment)
+		}
+		path := strings.Join(segments, "")
+		patchObj.Insert(ast.StringTerm("path"), ast.StringTerm(path))
+		patchList[i] = ast.NewTerm(patchObj)
+	}
+	return ast.NewArray(patchList...)
+}
+
+func BenchmarkJSONPatchReplace(b *testing.B) {
+	ctx := context.Background()
+
+	sizes := []int{10, 100, 1000}
+
+	// Pre-generate the test datasets/patches.
+	testdata := map[string][2]ast.Value{}
+	for _, n := range sizes {
+		for _, m := range sizes {
+			testObj := gen3LayerObject(n, m, 10)
+			for _, p := range sizes {
+				testdata[fmt.Sprintf("%dx%dx10-%dp", n, m, p)] = [2]ast.Value{testObj, genRandom3LayerObjectJSONPatchListData(n, m, 10, p)}
+			}
+		}
+	}
+
+	for _, n := range sizes {
+		for _, m := range sizes {
+			for _, p := range sizes {
+				testName := fmt.Sprintf("%dx%dx10-%dp", n, m, p)
+				b.Run(testName, func(b *testing.B) {
+					store := inmem.NewFromObject(map[string]interface{}{
+						"obj":     testdata[testName][0],
+						"patches": testdata[testName][1],
+					})
+
+					module := `package test
+
+					result := json.patch(data.obj, data.patches)`
+
+					query := ast.MustParseBody("data.test.result")
+					compiler := ast.MustCompileModules(map[string]string{
+						"test.rego": module,
+					})
+
+					b.ResetTimer()
+
+					for i := 0; i < b.N; i++ {
+
+						err := storage.Txn(ctx, store, storage.TransactionParams{}, func(txn storage.Transaction) error {
+
+							q := NewQuery(query).
+								WithCompiler(compiler).
+								WithStore(store).
+								WithTransaction(txn)
+
+							_, err := q.Run(ctx)
+							if err != nil {
+								return err
+							}
+
+							return nil
+						})
+
+						if err != nil {
+							b.Fatal(err)
+						}
+					}
+				})
+			}
+		}
+	}
+}
+
+func BenchmarkJSONPatchPathologicalNestedAddChainObject(b *testing.B) {
+	ctx := context.Background()
+
+	sizes := []int{10, 100, 500, 1000, 5000, 10000}
+	// Pre-generate the test datasets/patches.
+	testdata := map[string]ast.Value{}
+	for _, n := range sizes {
+		patchList := make([]*ast.Term, n)
+		path := ""
+		for i := 0; i < n; i++ {
+			patchObj := ast.NewObject(
+				[2]*ast.Term{ast.StringTerm("op"), ast.StringTerm("add")},
+				[2]*ast.Term{ast.StringTerm("value"), ast.ObjectTerm()},
+			)
+
+			path = path + "/a"
+
+			patchObj.Insert(ast.StringTerm("path"), ast.StringTerm(path))
+			patchList[i] = ast.NewTerm(patchObj)
+		}
+		testdata[fmt.Sprintf("%d", n)] = ast.NewArray(patchList...)
+	}
+
+	for _, n := range sizes {
+		testName := fmt.Sprintf("%d", n)
+		b.Run(testName, func(b *testing.B) {
+			runJSONPatchBenchmarkTest(ctx, b, ast.NewObject(), testdata[testName])
+		})
+	}
+}
+
+func BenchmarkJSONPatchPathologicalNestedAddChainArray(b *testing.B) {
+	ctx := context.Background()
+
+	sizes := []int{10, 100, 500, 1000, 5000, 10000}
+	// Pre-generate the test datasets/patches.
+	testdata := map[string]ast.Value{}
+	for _, n := range sizes {
+		patchList := make([]*ast.Term, n)
+		path := ""
+		for i := 0; i < n; i++ {
+			patchObj := ast.NewObject(
+				[2]*ast.Term{ast.StringTerm("op"), ast.StringTerm("add")},
+				[2]*ast.Term{ast.StringTerm("value"), ast.ArrayTerm()},
+			)
+
+			path = path + "/0"
+
+			patchObj.Insert(ast.StringTerm("path"), ast.StringTerm(path))
+			patchList[i] = ast.NewTerm(patchObj)
+		}
+		testdata[fmt.Sprintf("%d", n)] = ast.NewArray(patchList...)
+	}
+
+	for _, n := range sizes {
+		testName := fmt.Sprintf("%d", n)
+		b.Run(testName, func(b *testing.B) {
+			runJSONPatchBenchmarkTest(ctx, b, ast.NewArray(), testdata[testName])
+		})
+	}
+}
+
+// This one is tricky, because sets used content-based addressing.
+// That means our sets for the path have to be recursively constructed!
+func BenchmarkJSONPatchPathologicalNestedAddChainSet(b *testing.B) {
+	ctx := context.Background()
+	sizes := []int{10, 100, 500, 1000}
+
+	// Pre-generate the test datasets/patches.
+	testdata := map[string]ast.Value{}
+	for _, n := range sizes {
+		patchList := make([]*ast.Term, n)
+		for i := 0; i < n; i++ {
+			patchObj := ast.NewObject(
+				[2]*ast.Term{ast.StringTerm("op"), ast.StringTerm("add")},
+			)
+			value := ast.SetTerm(ast.StringTerm("a"))
+			constructedPath := ast.NewArray(ast.SetTerm(ast.StringTerm("a")))
+			for j := 0; j < i; j++ {
+				constructedPath = constructedPath.Append(value)
+				value = ast.SetTerm(ast.StringTerm("a"), value)
+			}
+
+			// Reverse the ast.Array slice.
+			path := ast.NewArray()
+			pathLength := constructedPath.Len() - 1
+			for j := 0; j < constructedPath.Len(); j++ {
+				path = path.Append(constructedPath.Elem(pathLength - j))
+			}
+
+			patchObj.Insert(ast.StringTerm("value"), ast.SetTerm(ast.StringTerm("a")))
+			patchObj.Insert(ast.StringTerm("path"), ast.NewTerm(path))
+			patchList[i] = ast.NewTerm(patchObj)
+		}
+		testdata[fmt.Sprintf("%d", n)] = ast.NewArray(patchList...)
+	}
+
+	for _, n := range sizes {
+		testName := fmt.Sprintf("%d", n)
+		b.Run(testName, func(b *testing.B) {
+			runJSONPatchBenchmarkTest(ctx, b, ast.NewSet(ast.StringTerm("a")), testdata[testName])
+		})
+	}
+}
+
+func runJSONPatchBenchmarkTest(ctx context.Context, b *testing.B, source ast.Value, patches ast.Value) {
 	store := inmem.NewFromObject(map[string]interface{}{
-		"source": source,
-		"paths":  ast.NewArray(paths...),
+		"source":  source,
+		"patches": patches,
 	})
 
 	module := `package test
 
-			result := json.filter(data.source, data.paths)`
+			result := json.patch(data.source, data.patches)`
 
 	query := ast.MustParseBody("data.test.result")
 	compiler := ast.MustCompileModules(map[string]string{
@@ -108,25 +533,5 @@ func runJSONFilterBenchmarkTest(ctx context.Context, b *testing.B, source ast.Va
 			b.Fatal(err)
 		}
 	}
-}
 
-func genTestObject(width int) ast.Value {
-	out := ast.NewObject()
-	for i := 0; i < width; i++ {
-		out.Insert(ast.IntNumberTerm(i), ast.IntNumberTerm(i))
-	}
-	return out
-}
-
-func genNestedTestObject(width, levels int) ast.Value {
-	if levels == 1 {
-		return genTestObject(width)
-	} else if levels > 1 {
-		out := ast.NewObject()
-		childValue := genNestedTestObject(width, levels-1)
-		for i := 0; i < width; i++ {
-			out.Insert(ast.IntNumberTerm(i), ast.NewTerm(childValue))
-		}
-	}
-	return ast.NewObject()
 }


### PR DESCRIPTION
Now that #5494 has landed, this PR should be ready-for-merge! :smile: 

What follows below is the original PR text:

-----

This PR is an investigation (and hopefully remediation!) of performance issues around [`json.patch`](https://www.openpolicyagent.org/docs/latest/policy-reference/#builtin-object-jsonpatch), triggered by the report in #4409, which actually is for a different subsystem. Based on preliminary findings, and a simple benchmark, the performance is not great, and has room to improve. Algorithmic improvements here *may* be useful as a blueprint for improving `PATCH` operations in the server as well.

## Early Benchmark Design
To be able to dig into the performance issue here, I first constructed a Golang benchmark test that ensures `json.patch` is run in a very simple policy.

The patch list and source object are pre-generated outside of the testing loop, before the tests are run. (This improved runtimes by over 10+ seconds on my machine.)

Source object:
 - Based on the report in #4409, shallow-depth objects with many keys seemed like a good target.
 - Objects are generated to have 3x levels, with the deepest-nested level always having 10x elements. The other two levels are parameterized in the benchmark.

Patch list:
 - Only `"replace"` ops, for now.
 - `"path"` values are randomly constructed right now, but later may need more advanced logic to avoid conflict cases.
 
At the start of each test, the appropriate object+patch list combo are inserted into the `data.` document store for use in the policy, so as to reduce Rego eval times down to just the builtin + some minimal overheads.

### Results
Raw benchmark stats:
```
$ go test -cpuprofile cpu-jsonpatch-1.prof -memprofile mem-jsonpatch-1.prof -benchmem -run=^$ -tags opa_wasm,slow -bench ^BenchmarkJSONPatchReplace$ github.com/open-policy-agent/opa/topdown
goos: linux
goarch: amd64
pkg: github.com/open-policy-agent/opa/topdown
cpu: Intel(R) Core(TM) i7-8650U CPU @ 1.90GHz
BenchmarkJSONPatchReplace/10x10x10-10p-8         	   10000	    101703 ns/op	   46441 B/op	    1204 allocs/op
BenchmarkJSONPatchReplace/10x10x10-100p-8        	   15049	     81726 ns/op	   42330 B/op	    1103 allocs/op
BenchmarkJSONPatchReplace/10x10x10-1000p-8       	    9276	    128922 ns/op	   63121 B/op	    1670 allocs/op
BenchmarkJSONPatchReplace/10x100x10-10p-8        	   47305	     26871 ns/op	   13418 B/op	     334 allocs/op
BenchmarkJSONPatchReplace/10x100x10-100p-8       	    1712	    701998 ns/op	  349436 B/op	    7273 allocs/op
BenchmarkJSONPatchReplace/10x100x10-1000p-8      	    3733	    320407 ns/op	  155194 B/op	    3275 allocs/op
BenchmarkJSONPatchReplace/10x1000x10-10p-8       	     894	   1564078 ns/op	  927401 B/op	   12894 allocs/op
BenchmarkJSONPatchReplace/10x1000x10-100p-8      	     429	   3158324 ns/op	 1844231 B/op	   25532 allocs/op
BenchmarkJSONPatchReplace/10x1000x10-1000p-8     	     100	  10617619 ns/op	 5838210 B/op	   80839 allocs/op
BenchmarkJSONPatchReplace/100x10x10-10p-8        	    2179	    540448 ns/op	  261160 B/op	    5228 allocs/op
BenchmarkJSONPatchReplace/100x10x10-100p-8       	    1317	    930041 ns/op	  445025 B/op	    9053 allocs/op
BenchmarkJSONPatchReplace/100x10x10-1000p-8      	     537	   2344290 ns/op	 1141634 B/op	   23241 allocs/op
BenchmarkJSONPatchReplace/100x100x10-10p-8       	    1719	    798749 ns/op	  367190 B/op	    7205 allocs/op
BenchmarkJSONPatchReplace/100x100x10-100p-8      	     832	   1552204 ns/op	  757433 B/op	   14848 allocs/op
BenchmarkJSONPatchReplace/100x100x10-1000p-8     	     481	   2609749 ns/op	 1274929 B/op	   24935 allocs/op
BenchmarkJSONPatchReplace/100x1000x10-10p-8      	     256	   5374676 ns/op	 2674055 B/op	   38046 allocs/op
BenchmarkJSONPatchReplace/100x1000x10-100p-8     	      61	  18289825 ns/op	 8608514 B/op	  123659 allocs/op
BenchmarkJSONPatchReplace/100x1000x10-1000p-8    	     141	   8167262 ns/op	 3896869 B/op	   56604 allocs/op
BenchmarkJSONPatchReplace/1000x10x10-10p-8       	     226	   5652384 ns/op	 3046484 B/op	   41810 allocs/op
BenchmarkJSONPatchReplace/1000x10x10-100p-8      	      52	  24835330 ns/op	12966910 B/op	  178414 allocs/op
BenchmarkJSONPatchReplace/1000x10x10-1000p-8     	      27	  42939638 ns/op	23308201 B/op	  320330 allocs/op
BenchmarkJSONPatchReplace/1000x100x10-10p-8      	     187	   6695119 ns/op	 3243178 B/op	   45524 allocs/op
BenchmarkJSONPatchReplace/1000x100x10-100p-8     	      16	  67282293 ns/op	32013615 B/op	  447507 allocs/op
BenchmarkJSONPatchReplace/1000x100x10-1000p-8    	      30	  40890195 ns/op	19214344 B/op	  267676 allocs/op
BenchmarkJSONPatchReplace/1000x1000x10-10p-8     	     104	  11540075 ns/op	 5456755 B/op	   74556 allocs/op
BenchmarkJSONPatchReplace/1000x1000x10-100p-8    	      30	  35105130 ns/op	16186964 B/op	  220930 allocs/op
BenchmarkJSONPatchReplace/1000x1000x10-1000p-8   	      14	  74157119 ns/op	34644164 B/op	  472921 allocs/op
PASS
ok  	github.com/open-policy-agent/opa/topdown	93.668s
```


The CPU profiling graph is *dominated* by the Golang GC, which usually only happens when we're placing high load on the GC from lots of dead objects. Current theory: `json.patch` is throwing away a *lot* of intermediate copies of the object's parts along the way.

The memory profiling graph is dominated by eval-related calls (expected) and `object.insert` calls. This backs up the above theory fairly strongly, and would be expected if we're building a ton of objects that get thrown out shortly after construction.

<details>
  <summary><b><u>CPU Profiling Graph</u></b></summary>
  <img src="https://user-images.githubusercontent.com/1906841/202249179-83bcb4ba-e0c5-493b-8628-fa6be58ac658.png" />
</details>
<details>
  <summary><b><u>Memory Profiling Graph</u></b></summary>
  <img src="https://user-images.githubusercontent.com/1906841/202249298-62402c43-94d8-41f7-8f83-3d3520cf3483.png" />
</details>