### PR TITLE
[Nit] Small doc fix for the RBAC example in the comparison page

### DIFF
--- a/docs/content/comparison-to-other-systems.md
+++ b/docs/content/comparison-to-other-systems.md
@@ -37,7 +37,7 @@ And the following role/permission assignments:
 | ``engineering`` | ``read`` | ``server123`` |
 | ``webdev`` | ``write`` | ``server123`` |
 | ``webdev`` | ``read`` | ``server123`` |
-| ``hr`` | ``write`` | ``database456`` |
+| ``hr`` | ``read`` | ``database456`` |
 
 In this example, RBAC makes the following authorization decisions:
 


### PR DESCRIPTION
The permissions table wasn't matching the decisions table and sample rego for the RBAC example--thanks!!