### PR TITLE
fmt: remove { true } block following else head

### DIFF
--- a/format/format.go
+++ b/format/format.go
@@ -316,7 +316,7 @@ func (w *writer) writeRule(rule *ast.Rule, isElse, useContainsKW, useIf bool, co
 	// this excludes partial sets UNLESS `contains` is used
 	partialSetException := useContainsKW || rule.Head.Value != nil
 
-	if (len(rule.Body) == 0 || isExpandedConst) && !isElse {
+	if len(rule.Body) == 0 || isExpandedConst {
 		w.endLine()
 		return comments
 	}

--- a/format/testfiles/test_assignments.rego.formatted
+++ b/format/testfiles/test_assignments.rego.formatted
@@ -9,9 +9,7 @@ b := 2
 # else keyword
 c := 3 {
 	false
-} else := 4 {
-	true
-}
+} else := 4
 
 # partial rule
 d[msg] := 5 {

--- a/format/testfiles/test_if_else.rego.formatted
+++ b/format/testfiles/test_if_else.rego.formatted
@@ -4,7 +4,7 @@ import future.keywords.if
 
 p := 1 if 1 > 0
 
-else := 2 if true
+else := 2
 
 q := 1 if 1 > 0
 

--- a/format/testfiles/test_issue_5348.rego.formatted
+++ b/format/testfiles/test_issue_5348.rego.formatted
@@ -2,6 +2,4 @@ package p
 
 f(x) {
 	true
-} else := false {
-	true
-}
+} else := false


### PR DESCRIPTION
This fixes a long-standing annoyance where:

```rego
allow {
	input.user.name == "foo"
} else := false
```
Formats into:

```rego
allow {
        input.user.name == "foo"
} else := false {
	true
}
```

Signed-off-by: Anders Eknert <anders@eknert.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->
