### PR TITLE
ci: move performance to nightly tests

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -57,6 +57,34 @@ jobs:
           status: ${{ job.status }}
           fields: repo,workflow
 
+  go-perf:
+    name: Go Perf
+    runs-on: ubuntu-22.04
+    needs: generate
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Download generated artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: generated
+
+      - name: Benchmark Test Golang
+        run: make ci-go-perf
+        timeout-minutes: 30
+        env:
+          DOCKER_RUNNING: 0
+
+      - name: Slack Notification
+        uses: 8398a7/action-slack@v3
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_NOTIFICATION_WEBHOOK }}
+        if: ${{ failure() && env.SLACK_WEBHOOK_URL }}
+        with:
+          status: ${{ job.status }}
+          fields: repo,workflow
+
   go-proxy-check:
     name: Go mod check
     runs-on: ubuntu-22.04

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -117,25 +117,6 @@ jobs:
         run: make test-coverage
         timeout-minutes: 30
 
-  go-perf:
-    name: Go Perf
-    runs-on: ubuntu-22.04
-    needs: generate
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v3
-
-      - name: Download generated artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: generated
-
-      - name: Benchmark Test Golang
-        run: make ci-go-perf
-        timeout-minutes: 30
-        env:
-          DOCKER_RUNNING: 0
-
   go-lint:
     name: Go Lint
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Few people ever look at the output of this, and yet everyone has to wait for it. Let's change that.
