### PR TITLE
ast/parser: generate new wildcards for else

### DIFF
--- a/ast/parser.go
+++ b/ast/parser.go
@@ -699,6 +699,11 @@ func (p *Parser) parseElse(head *Head) *Rule {
 	rule.SetLoc(p.s.Loc())
 
 	rule.Head = head.Copy()
+	for i := range rule.Head.Args {
+		if v, ok := rule.Head.Args[i].Value.(Var); ok && v.IsWildcard() {
+			rule.Head.Args[i].Value = Var(p.genwildcard())
+		}
+	}
 	rule.Head.SetLoc(p.s.Loc())
 
 	defer func() {

--- a/ast/parser_test.go
+++ b/ast/parser_test.go
@@ -1634,6 +1634,30 @@ func TestRule(t *testing.T) {
 	})
 	assertParseError(t, "invalid rule body no separator", `p { a = "foo"bar }`)
 	assertParseError(t, "invalid rule body no newline", `p { a b c }`)
+
+	assertParseRule(t, "wildcard in else args", `f(_) { true } else := false`, &Rule{
+		Head: &Head{
+			Name:      "f",
+			Reference: Ref{VarTerm("f")},
+			Args: Args{
+				VarTerm("$0"),
+			},
+			Value: BooleanTerm(true),
+		},
+		Body: MustParseBody(`true`),
+		Else: &Rule{
+			Head: &Head{
+				Name:      "f",
+				Assign:    true,
+				Reference: Ref{VarTerm("f")},
+				Args: Args{
+					VarTerm("$1"),
+				},
+				Value: BooleanTerm(false),
+			},
+			Body: MustParseBody(`true`),
+		},
+	})
 }
 
 func TestRuleContains(t *testing.T) {
@@ -4829,6 +4853,9 @@ func assertParseRule(t *testing.T, msg string, input string, correct *Rule, opts
 		}
 		if !rule.Head.Ref().Equal(correct.Head.Ref()) {
 			t.Errorf("Error on test \"%s\": rule heads not equal: ref = %v (parsed), ref = %v (correct)", msg, rule.Head.Ref(), correct.Head.Ref())
+		}
+		if !rule.Head.Equal(correct.Head) {
+			t.Errorf("Error on test \"%s\": rule heads not equal: %v (parsed), %v (correct)", msg, rule.Head, correct.Head)
 		}
 		if !rule.Equal(correct) {
 			t.Errorf("Error on test \"%s\": rules not equal: %v (parsed), %v (correct)", msg, rule, correct)


### PR DESCRIPTION
The previous behaviour had triggered a check in the formatter for multiple use of wildcard variables:

     f(_) := true { true }
     else := false

The formatter found `$1`, the `_` argument of f, again in else, and thus changed it into `_1`:

     f(_1) := true { true }
     else := false

There's no extra meaning to the copied wildcards in `else`, they should not count as second usage.

Fixes #5347.

⚠️ It does not fix the case where a rewriting is necessary, and clashes with an existing var. But it makes the rewriting a lot less likely; and notably doesn't do it just because there is an `else` defined for a function.