### PR TITLE
docs: Document reference timestamp behavior for `time.parse_ns`

### DIFF
--- a/ast/builtins.go
+++ b/ast/builtins.go
@@ -2136,7 +2136,7 @@ var ParseDurationNanos = &Builtin{
 	Description: "Returns the duration in nanoseconds represented by a string.",
 	Decl: types.NewFunction(
 		types.Args(
-			types.Named("duration", types.S).Description("a duration like \"3m\"; seethe [Go `time` package documentation](https://golang.org/pkg/time/#ParseDuration) for more details"),
+			types.Named("duration", types.S).Description("a duration like \"3m\"; see the [Go `time` package documentation](https://golang.org/pkg/time/#ParseDuration) for more details"),
 		),
 		types.Named("ns", types.N).Description("the `duration` in nanoseconds"),
 	),

--- a/builtin_metadata.json
+++ b/builtin_metadata.json
@@ -12630,7 +12630,7 @@
   "time.parse_duration_ns": {
     "args": [
       {
-        "description": "a duration like \"3m\"; seethe [Go `time` package documentation](https://golang.org/pkg/time/#ParseDuration) for more details",
+        "description": "a duration like \"3m\"; see the [Go `time` package documentation](https://golang.org/pkg/time/#ParseDuration) for more details",
         "name": "duration",
         "type": "string"
       }

--- a/docs/content/policy-reference.md
+++ b/docs/content/policy-reference.md
@@ -703,6 +703,43 @@ Timezones can be specified as
 
 Note that the opa executable will need access to the timezone files in the environment it is running in (see the [Go `time.LoadLocation()`](https://pkg.go.dev/time#LoadLocation) documentation for more information).
 
+#### Timestamp Parsing
+
+OPA can parse timestamps of nearly arbitrary formats, and currently accepts the same inputs as Go's `time.Parse()` utility.
+As a result, you **must** describe the format of your timestamps using the Reference Timestamp that Go's `time` module expects:
+
+    2006-01-02T15:04:05Z07:00
+
+In other date formats, that same value is rendered as:
+
+ - January 2, 15:04:05, 2006, in time zone seven hours west of GMT
+ - Unix time: `1136239445`
+ - Unix `date` command output: `Mon Jan 2 15:04:05 MST 2006`
+ - RFC3339 timestamp: `2006-01-02T15:04:05Z07:00`
+
+Examples of valid values for each timestamp field:
+
+ - Year: `"2006"` `"06"`
+ - Month: `"Jan"` `"January"` `"01"` `"1"`
+ - Day of the week: `"Mon"` `"Monday"`
+ - Day of the month: `"2"` `"_2"` `"02"`
+ - Day of the year: `"__2"` `"002"`
+ - Hour: `"15"` `"3"` `"03"` (PM or AM)
+ - Minute: `"4"` `"04"`
+ - Second: `"5"` `"05"`
+ - AM/PM mark: `"PM"`
+
+For formatting of nanoseconds, time zones, and other fields, see the [Go `time/format` module documentation](https://cs.opensource.google/go/go/+/master:src/time/format.go;l=9-100).
+
+#### Timestamp Parsing Example
+
+In OPA, we can parse a simple `YYYY-MM-DD` timestamp as follows:
+
+```live:time/parse_ns/example:module
+ts := "1985-10-27"
+result := time.parse_ns("2006-01-02", ts)
+```
+
 {{< builtin-table cat=crypto title=Cryptography >}}
 
 {{< builtin-table cat=graph title=Graphs >}}


### PR DESCRIPTION
This commit adds documentation and examples around one of the bigger "gotchas" in handling time values in OPA: parsing date formats.

The issue is that users of `time.parse_ns` have to use the same "reference timestamp" values as Go's `time/format` module does, which can be deeply surprising behavior to newcomers to the Go language, and to OPA users as well.

By documenting this, the hope is that we'll help users make fewer mistakes around parsing date formats in OPA.

Reference: https://cs.opensource.google/go/go/+/master:src/time/format.go;l=9-100