### PR TITLE
planner: fix ref heads processing

### DIFF
--- a/compile/compile.go
+++ b/compile/compile.go
@@ -562,7 +562,7 @@ func (c *Compiler) compilePlan(context.Context) error {
 	}
 
 	// Prepare modules and builtins for the planner.
-	modules := []*ast.Module{}
+	modules := make([]*ast.Module, 0, len(c.compiler.Modules))
 	for _, module := range c.compiler.Modules {
 		modules = append(modules, module)
 	}

--- a/internal/compiler/wasm/wasm.go
+++ b/internal/compiler/wasm/wasm.go
@@ -887,12 +887,9 @@ func (c *Compiler) compileFunc(fn *ir.Func) error {
 }
 
 func mapFunc(mapping ast.Object, fn *ir.Func, index int) (ast.Object, bool) {
-	curr := ast.NewObject()
-	curr.Insert(ast.StringTerm(fn.Path[len(fn.Path)-1]), ast.IntNumberTerm(index))
+	curr := ast.NewObject(ast.Item(ast.StringTerm(fn.Path[len(fn.Path)-1]), ast.IntNumberTerm(index)))
 	for i := len(fn.Path) - 2; i >= 0; i-- {
-		o := ast.NewObject()
-		o.Insert(ast.StringTerm(fn.Path[i]), ast.NewTerm(curr))
-		curr = o
+		curr = ast.NewObject(ast.Item(ast.StringTerm(fn.Path[i]), ast.NewTerm(curr)))
 	}
 	return mapping.Merge(curr)
 }

--- a/internal/planner/planner_test.go
+++ b/internal/planner/planner_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/open-policy-agent/opa/ast"
@@ -433,7 +434,7 @@ func findInPolicy(needle interface{}, loc string, p interface{}) error {
 }
 
 // Assert some selected statements' location mappings. Note that for debugging,
-// it's worthwhile to no use tabs in the multi-line strings, as they may be
+// it's worthwhile to not use tabs in the multi-line strings, as they may be
 // counted differently in the editor vs. in code.
 func TestPlannerLocations(t *testing.T) {
 
@@ -730,14 +731,20 @@ func ref(r string) ast.Ref {
 }
 
 func TestOptimizeLookup(t *testing.T) {
-	r0, r1, r2 := ast.Rule{}, ast.Rule{}, ast.Rule{}
+	r0, r1, r2 := ast.MustParseRule("p = 0 { true }"), ast.MustParseRule("p = 1 { true }"), ast.MustParseRule("p = 2 { true }")
+	planner := func() *Planner {
+		if testing.Verbose() {
+			return New().WithDebug(os.Stderr)
+		}
+		return New()
+	}
 
 	t.Run("seen variable (last), one ruleset", func(t *testing.T) {
 		r := newRuletrie()
 		val := r.LookupOrInsert(ref("foo.bar"))
-		val.rules = append(val.rules, &r0, &r1, &r2)
+		val.rules = append(val.rules, r0, r1, r2)
 
-		p := New()
+		p := planner()
 		l := p.newLocal()
 		p.vars.Put(ast.Var("x"), l)
 
@@ -770,9 +777,9 @@ func TestOptimizeLookup(t *testing.T) {
 	t.Run("ref shorter than ruletrie depth", func(t *testing.T) {
 		r := newRuletrie()
 		val := r.LookupOrInsert(ref("foo.bar.baz"))
-		val.rules = append(val.rules, &r0, &r1, &r2)
+		val.rules = append(val.rules, r0, r1, r2)
 
-		p := New()
+		p := planner().WithDebug(os.Stderr)
 		l := p.newLocal()
 		p.vars.Put(ast.Var("x"), l)
 
@@ -785,11 +792,11 @@ func TestOptimizeLookup(t *testing.T) {
 	t.Run("seen variable (last), multiple rulesets", func(t *testing.T) {
 		r := newRuletrie()
 		val := r.LookupOrInsert(ref("foo.bar"))
-		val.rules = append(val.rules, &r0, &r1)
+		val.rules = append(val.rules, r0, r1)
 		val = r.LookupOrInsert(ref("foo.baz"))
-		val.rules = append(val.rules, &r2)
+		val.rules = append(val.rules, r2)
 
-		p := New()
+		p := planner()
 		p.vars.Put(ast.Var("x"), p.newLocal())
 
 		rulesets, _, _, opt := p.optimizeLookup(r, ast.MustParseRef("data.foo[x]"))
@@ -810,9 +817,9 @@ func TestOptimizeLookup(t *testing.T) {
 	t.Run("unseen variable (last)", func(t *testing.T) {
 		r := newRuletrie()
 		val := r.LookupOrInsert(ref("foo.bar"))
-		val.rules = append(val.rules, &r0, &r1, &r2)
+		val.rules = append(val.rules, r0, r1, r2)
 
-		p := New()
+		p := planner()
 
 		_, _, _, opt := p.optimizeLookup(r, ast.MustParseRef("data.foo[x]"))
 		if exp, act := false, opt; exp != act {
@@ -823,9 +830,9 @@ func TestOptimizeLookup(t *testing.T) {
 	t.Run("all ground refs", func(t *testing.T) {
 		r := newRuletrie()
 		val := r.LookupOrInsert(ref("foo.bar.baz"))
-		val.rules = append(val.rules, &r0, &r1, &r2)
+		val.rules = append(val.rules, r0, r1, r2)
 
-		p := New()
+		p := planner()
 
 		_, _, _, opt := p.optimizeLookup(r, ast.MustParseRef("data.foo.bar.baz"))
 		if exp, act := false, opt; exp != act {
@@ -836,9 +843,9 @@ func TestOptimizeLookup(t *testing.T) {
 	t.Run("multiple seen vars, one rule set", func(t *testing.T) {
 		r := newRuletrie()
 		val := r.LookupOrInsert(ref("foo.aaa.bar.bbb.q"))
-		val.rules = append(val.rules, &r0, &r1, &r2)
+		val.rules = append(val.rules, r0, r1, r2)
 
-		p := New()
+		p := planner()
 		lx, ly := p.newLocal(), p.newLocal()
 		p.vars.Put(ast.Var("x"), lx)
 		p.vars.Put(ast.Var("y"), ly)
@@ -865,9 +872,9 @@ func TestOptimizeLookup(t *testing.T) {
 	t.Run("one seen var, one unseen, one rule set", func(t *testing.T) {
 		r := newRuletrie()
 		val := r.LookupOrInsert(ref("foo.aaa.bar.bbb.q"))
-		val.rules = append(val.rules, &r0, &r1, &r2)
+		val.rules = append(val.rules, r0, r1, r2)
 
-		p := New()
+		p := planner()
 		p.vars.Put(ast.Var("x"), p.newLocal())
 
 		_, _, _, opt := p.optimizeLookup(r, ast.MustParseRef("data.foo[x].bar[y].q"))
@@ -879,11 +886,11 @@ func TestOptimizeLookup(t *testing.T) {
 	t.Run("one seen var, one rule set and children left", func(t *testing.T) {
 		r := newRuletrie()
 		val := r.LookupOrInsert(ref("foo.aaa.bar.bbb.q"))
-		val.rules = append(val.rules, &r0)
+		val.rules = append(val.rules, r0)
 		val = r.LookupOrInsert(ref("foo.ccc.bar"))
-		val.rules = append(val.rules, &r1, &r2)
+		val.rules = append(val.rules, r1, r2)
 
-		p := New()
+		p := planner()
 		p.vars.Put(ast.Var("x"), p.newLocal())
 
 		_, _, _, opt := p.optimizeLookup(r, ast.MustParseRef("data.foo[x].bar"))
@@ -895,9 +902,9 @@ func TestOptimizeLookup(t *testing.T) {
 	t.Run("ref goes into the rules' result", func(t *testing.T) {
 		r := newRuletrie()
 		val := r.LookupOrInsert(ref("foo.aaa.bar.q"))
-		val.rules = append(val.rules, &r0, &r1, &r2)
+		val.rules = append(val.rules, r0, r1, r2)
 
-		p := New()
+		p := planner()
 		p.vars.Put(ast.Var("x"), p.newLocal())
 
 		rulesets, path, index, opt := p.optimizeLookup(r, ast.MustParseRef("data.foo[x].bar.q.p.r"))
@@ -922,10 +929,10 @@ func TestOptimizeLookup(t *testing.T) {
 	t.Run("one leaf without rules", func(t *testing.T) {
 		r := newRuletrie()
 		val := r.LookupOrInsert(ref("foo.aaa.bar.q"))
-		val.rules = append(val.rules, &r0, &r1)
+		val.rules = append(val.rules, r0, r1)
 		r.LookupOrInsert(ref("foo.bbb.bar.q"))
 
-		p := New()
+		p := planner()
 		p.vars.Put(ast.Var("x"), p.newLocal())
 
 		rulesets, _, index, opt := p.optimizeLookup(r, ast.MustParseRef("data.foo[x].bar.q"))
@@ -948,7 +955,7 @@ func TestOptimizeLookup(t *testing.T) {
 		r.LookupOrInsert(ref("foo.aaa.bar.q"))
 		r.LookupOrInsert(ref("foo.bbb.bar.q"))
 
-		p := New()
+		p := planner()
 		p.vars.Put(ast.Var("x"), p.newLocal())
 
 		rulesets, _, _, opt := p.optimizeLookup(r, ast.MustParseRef("data.foo[x].bar.q"))
@@ -959,4 +966,252 @@ func TestOptimizeLookup(t *testing.T) {
 			t.Fatalf("expected %d rulesets, got %d\n", exp, act)
 		}
 	})
+
+	t.Run("ref heads, mixed case: string and var last term", func(t *testing.T) {
+		r0, r1 := ast.MustParseRule("b.q.s = 1 { true }"), ast.MustParseRule(`b.q[x] = 2 { x = "t" }`)
+		r := newRuletrie()
+		val := r.LookupOrInsert(ref("a.b.q.s")) // b.q.s = 1 (package a)
+		val.rules = append(val.rules, r0)
+		val = r.LookupOrInsert(ref("a.b.q")) // b.q[x] = 2
+		val.rules = append(val.rules, r1)
+
+		rules := r.Lookup(ref("a.b.q")).Rules()
+		if exp, act := 2, len(rules); exp != act {
+			t.Fatalf("ruletrie: expected %d rules, got %d", exp, act)
+		}
+		if testing.Verbose() {
+			t.Logf("rules: %v", r)
+		}
+
+		p := planner()
+		p.vars.Put(ast.Var("x"), p.newLocal())
+		rulesets, _, _, opt := p.optimizeLookup(r, ast.MustParseRef("data.a[x].q"))
+
+		if exp, act := true, opt; exp != act {
+			t.Errorf("expected 'optimize' %v, got %v\n", exp, act)
+		}
+		if exp, act := 1, len(rulesets); exp != act {
+			t.Fatalf("expected %d rulesets, got %d\n", exp, act)
+		}
+
+		if exp, act := 2, len(rulesets[0]); exp != act {
+			t.Fatalf("expected %d rules in ruleset[0], got %d\n", exp, act)
+		}
+	})
+
+	t.Run("ref heads, mixed case: string and number last term", func(t *testing.T) {
+		r0, r1 := ast.MustParseRule("b.q[1] = 1 { true }"), ast.MustParseRule(`b.q[x] = 2 { x = "t" }`)
+		r := newRuletrie()
+		val := r.LookupOrInsert(ref("a.b.q")) // b.q[1] = 1 (package a)
+		val.rules = append(val.rules, r0)
+		val = r.LookupOrInsert(ref("a.b.q")) // b.q[x] = 2
+		val.rules = append(val.rules, r1)
+
+		rules := r.Lookup(ref("a.b.q")).Rules()
+		if exp, act := 2, len(rules); exp != act {
+			t.Fatalf("ruletrie: expected %d rules, got %d", exp, act)
+		}
+		if testing.Verbose() {
+			t.Logf("rules: %v", r)
+		}
+
+		p := planner()
+		p.vars.Put(ast.Var("x"), p.newLocal())
+		rulesets, _, _, opt := p.optimizeLookup(r, ast.MustParseRef("data.a[x].q"))
+
+		if exp, act := true, opt; exp != act {
+			t.Errorf("expected 'optimize' %v, got %v\n", exp, act)
+		}
+		if exp, act := 1, len(rulesets); exp != act {
+			t.Fatalf("expected %d rulesets, got %d\n", exp, act)
+		}
+
+		if exp, act := 2, len(rulesets[0]); exp != act {
+			t.Fatalf("expected %d rules in ruleset[0], got %d\n", exp, act)
+		}
+	})
+}
+
+func TestPlannerCallDynamic(t *testing.T) {
+	tests := []struct {
+		note    string
+		queries []string
+		modules []string
+		path    []interface{}                // path expected on irCallDynamicStmt, string => string const, int => local
+		where   func(*ir.Policy) interface{} // where to start walking search for `exps`
+		extras  []func(interface{}) error
+	}{
+		{
+			note:    "CallDynamicStmt optimization",
+			queries: []string{`x := "a"; data.test[x] = y`},
+			modules: []string{`package test
+a { true }`},
+			path: []interface{}{"g0", "test", 2},
+			extras: []func(interface{}) error{
+				findFunc("g0.data.test.a", "g0.test.a"),
+			},
+		},
+		{
+			note:    "simple single-val ref head",
+			queries: []string{`x := "a"; data.test.a[x].c = y`},
+			modules: []string{`package test
+a.b.c = 1 { true }`},
+			path: []interface{}{"g0", "test", "a", 2, "c"},
+			extras: []func(interface{}) error{
+				findFunc("g0.data.test.a.b.c", "g0.test.a.b.c"),
+			},
+		},
+		{
+			note:    "two single-val ref heads, string+var",
+			queries: []string{`x := "a"; data.test.a[x] = y`},
+			modules: []string{`package test
+a.b.c = 1 { true }
+a.b[t] = 2 { t := input }`},
+			path: []interface{}{"g0", "test", "a", 2},
+			extras: []func(interface{}) error{
+				findFunc("g0.data.test.a.b", "g0.test.a.b"),
+			},
+		},
+		{
+			note:    "two single-val ref heads, number+var",
+			queries: []string{`x := "a"; data.test.a[x] = y`},
+			modules: []string{`package test
+a.b[1] = 1 { true }
+a.b[t] = 2 { t := input }`},
+			path: []interface{}{"g0", "test", "a", 2},
+			extras: []func(interface{}) error{
+				findFunc("g0.data.test.a.b", "g0.test.a.b"),
+			},
+		},
+		{
+			note:    "one single-val ref head, number",
+			queries: []string{`x := "a"; data.test.a[x] = y`},
+			modules: []string{`package test
+a.b[1] = 1 { true }`},
+			path: []interface{}{"g0", "test", "a", 2},
+			extras: []func(interface{}) error{
+				findFunc("g0.data.test.a.b", "g0.test.a.b"),
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.note, func(t *testing.T) {
+			queries := make([]ast.Body, len(tc.queries))
+			for i := range queries {
+				queries[i] = ast.MustParseBody(tc.queries[i])
+			}
+			modules := make([]*ast.Module, len(tc.modules))
+			for i := range modules {
+				file := fmt.Sprintf("module-%d.rego", i)
+				m, err := ast.ParseModule(file, tc.modules[i])
+				if err != nil {
+					t.Fatal(err)
+				}
+				modules[i] = m
+			}
+			planner := New().WithQueries([]QuerySet{
+				{
+					Name:    "test",
+					Queries: queries,
+				},
+			}).WithModules(modules).WithBuiltinDecls(ast.BuiltinMap)
+			if testing.Verbose() {
+				planner = planner.WithDebug(os.Stderr)
+			}
+			policy, err := planner.Plan()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if testing.Verbose() {
+				err = ir.Pretty(os.Stderr, policy)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			start := interface{}(policy)
+			if tc.where != nil {
+				start = tc.where(policy)
+			}
+
+			if tc.path != nil {
+				exp := make([]ir.Operand, len(tc.path))
+				for i := range tc.path {
+					switch x := tc.path[i].(type) {
+					case string:
+						exp[i] = op(ir.StringIndex(planner.getStringConst(x)))
+					case int:
+						exp[i] = op(ir.Local(x))
+					}
+				}
+				if err := findCallDynamic(exp, start); err != nil {
+					t.Error(err)
+				}
+			}
+
+			if tc.extras == nil {
+				return
+			}
+			for _, e := range tc.extras {
+				if err := e(start); err != nil {
+					t.Error(err)
+				}
+			}
+		})
+	}
+}
+
+type stmtCmpWalker struct {
+	stmt  interface{}
+	found bool // stop comparing after first found needle
+}
+
+func (*stmtCmpWalker) Before(interface{}) {}
+func (*stmtCmpWalker) After(interface{})  {}
+func (w *stmtCmpWalker) Visit(x interface{}) (ir.Visitor, error) {
+	if !w.found {
+		switch s := w.stmt.(type) {
+		case *ir.CallDynamicStmt:
+			c, ok := x.(*ir.CallDynamicStmt)
+			if ok {
+				w.found = true
+				if !reflect.DeepEqual(s.Path, c.Path) {
+					return nil, fmt.Errorf("call dynamic %v: expected path %v, got %v", c, s.Path, c.Path)
+				}
+			}
+		case *ir.Func:
+			f, ok := x.(*ir.Func)
+			if ok && s.Name == f.Name {
+				w.found = true
+				if !reflect.DeepEqual(s.Path, f.Path) {
+					return nil, fmt.Errorf("func %v: expected path %v, got %v", f, s.Path, f.Path)
+				}
+			}
+		}
+	}
+	return w, nil
+}
+
+func findCallDynamic(path []ir.Operand, p interface{}) error {
+	w := &stmtCmpWalker{stmt: &ir.CallDynamicStmt{Path: path}}
+	if err := ir.Walk(w, p); err != nil {
+		return err
+	}
+	if !w.found {
+		return fmt.Errorf("not found")
+	}
+	return nil
+}
+
+func findFunc(name, path string) func(interface{}) error {
+	return func(p interface{}) error {
+		w := &stmtCmpWalker{stmt: &ir.Func{Name: name, Path: strings.Split(path, ".")}}
+		if err := ir.Walk(w, p); err != nil {
+			return err
+		}
+		if !w.found {
+			return fmt.Errorf("not found")
+		}
+		return nil
+	}
 }

--- a/internal/planner/rules.go
+++ b/internal/planner/rules.go
@@ -1,6 +1,7 @@
 package planner
 
 import (
+	"fmt"
 	"sort"
 
 	"github.com/open-policy-agent/opa/ast"
@@ -82,7 +83,27 @@ func (t *ruletrie) Arity() int {
 
 func (t *ruletrie) Rules() []*ast.Rule {
 	if t != nil {
-		return t.rules
+		if t.rules == nil {
+			return nil
+		}
+		rules := make([]*ast.Rule, len(t.rules), len(t.rules)+len(t.children)) // could be too little
+		copy(rules, t.rules)
+
+		// NOTE(sr): We pull in one layer of children: the compiler ensures
+		// that these are the only possible, relevant rule sources for a given
+		// ref: If the trie is what we get for
+		//
+		//     a.b.c  = 1 { ... }
+		//     a.b[x] = 2 { ... }
+		//
+		// and we're retrieving a.b, we want Rules() to include the rule body
+		// of a.b.c.
+		for _, rs := range t.children {
+			if r := rs[len(rs)-1].rules; r != nil {
+				rules = append(rules, r...)
+			}
+		}
+		return rules
 	}
 	return nil
 }
@@ -168,6 +189,38 @@ func (t *ruletrie) Get(k ast.Value) *ruletrie {
 		return nil
 	}
 	return nodes[len(nodes)-1]
+}
+
+func (t *ruletrie) DepthFirst(f func(*ruletrie) bool) {
+	if f(t) {
+		return
+	}
+	for _, rules := range t.children {
+		for i := range rules {
+			rules[i].DepthFirst(f)
+		}
+	}
+}
+
+func (t *ruletrie) Depth() int {
+	if len(t.Children()) == 0 {
+		return 0
+	}
+	c := make([]int, 0, len(t.Children()))
+	for _, nodes := range t.children {
+		c = append(c, nodes[len(nodes)-1].Depth())
+	}
+	max := 0
+	for i := range c {
+		if max < c[i] {
+			max = c[i]
+		}
+	}
+	return max + 1
+}
+
+func (t *ruletrie) String() string {
+	return fmt.Sprintf("<ruletrie rules:%v children:%v>", t.rules, t.children)
 }
 
 type functionMocksStack struct {

--- a/rego/rego.go
+++ b/rego/rego.go
@@ -1328,7 +1328,7 @@ func (r *Rego) Compile(ctx context.Context, opts ...CompileOption) (*CompileResu
 	}
 
 	var queries []ast.Body
-	var modules []*ast.Module
+	modules := make([]*ast.Module, 0, len(r.compiler.Modules))
 
 	if cfg.partial {
 


### PR DESCRIPTION
With the introduction of ref heads in #4660, the planned IR still mostly worked, but it was bypassing the CallDynamic optimization when it shouldn't have.

This commit re-works some of the rule planning to more robustly handle ref heads.

Also adds a few test cases to get a grip on what should and should not happen.
