### PR TITLE
website/edge: fix badge function schemaVersion

### DIFF
--- a/docs/website/edge/badge.ts
+++ b/docs/website/edge/badge.ts
@@ -1,6 +1,6 @@
 import { Context } from "netlify:edge";
 
-const schemaVersion = "1";
+const schemaVersion = 1;
 const label = "OPA";
 const releases = "https://api.github.com/repos/open-policy-agent/opa/releases/latest";
 const endpoint = "/badge-endpoint/";


### PR DESCRIPTION
Who would have thought that this would work on the first try? 😅 

👉  ![here it is](https://img.shields.io/endpoint?url=https://openpolicyagent.org/badge-endpoint/v0.46.1) 🤦 