### PR TITLE
ast/parser: fix else handling with ref heads

### DIFF
--- a/ast/parser.go
+++ b/ast/parser.go
@@ -644,9 +644,12 @@ func (p *Parser) parseRules() []*Rule {
 	}
 
 	if p.s.tok == tokens.Else {
-
+		if r := rule.Head.Ref(); len(r) > 1 && !r[len(r)-1].Value.IsGround() {
+			p.error(p.s.Loc(), "else keyword cannot be used on rules with variables in head")
+			return nil
+		}
 		if rule.Head.Key != nil {
-			p.error(p.s.Loc(), "else keyword cannot be used on partial rules")
+			p.error(p.s.Loc(), "else keyword cannot be used on multi-value rules")
 			return nil
 		}
 


### PR DESCRIPTION
There was a case that slipped through the parser, but failed at a later stage. It's now caught early.

<img width="658" alt="image" src="https://user-images.githubusercontent.com/870638/204514651-814ba39a-35f0-4268-b312-342b8b75cafe.png">
