### PR TITLE
Updating kubescape repo links

### DIFF
--- a/docs/website/data/integrations.yaml
+++ b/docs/website/data/integrations.yaml
@@ -1269,7 +1269,7 @@ integrations:
       - https://github.com/kubescape/kubescape
       - https://github.com/kubescape/regolibrary
     inventors:
-      - armo
+      - ARMO
     tutorials:
       - https://hub.armosec.io/docs
 

--- a/docs/website/data/integrations.yaml
+++ b/docs/website/data/integrations.yaml
@@ -1272,7 +1272,7 @@ integrations:
       - armo
     tutorials:
       - https://hub.armosec.io/docs
-      
+
   i2scim:
     title: i2scim.io SCIM Restful User/Group Provisioning API
     description: |

--- a/docs/website/data/integrations.yaml
+++ b/docs/website/data/integrations.yaml
@@ -1266,13 +1266,13 @@ integrations:
     software:
       - kubescape
     code:
-      - https://github.com/armosec/kubescape
-      - https://github.com/armosec/regolibrary
+      - https://github.com/kubescape/kubescape
+      - https://github.com/kubescape/regolibrary
     inventors:
       - armo
     tutorials:
-      - https://hub.armo.cloud
-
+      - https://hub.armosec.io/docs
+      
   i2scim:
     title: i2scim.io SCIM Restful User/Group Provisioning API
     description: |
@@ -1903,7 +1903,7 @@ software:
     link: https://apisix.apache.org/
   kubescape:
     name: Kubescape
-    link: https://github.com/armosec/kubescape
+    link: https://github.com/kubescape/kubescape
   i2scim:
     name: i2 SCIM Server
     link: https://i2scim.io

--- a/vendor/github.com/spf13/cobra/projects_using_cobra.md
+++ b/vendor/github.com/spf13/cobra/projects_using_cobra.md
@@ -25,7 +25,7 @@
 - [Istio](https://istio.io)
 - [Kool](https://github.com/kool-dev/kool)
 - [Kubernetes](https://kubernetes.io/)
-- [Kubescape](https://github.com/armosec/kubescape)
+- [Kubescape](https://github.com/kubescape/kubescape)
 - [KubeVirt](https://github.com/kubevirt/kubevirt)
 - [Linkerd](https://linkerd.io/)
 - [Mattermost-server](https://github.com/mattermost/mattermost-server)


### PR DESCRIPTION
The Kubscape project has been moved from the [armosec](https://github.com/armosec) org to the [kubescape](https://github.com/kubescape) org.

In this PR I updated the relevant URLs.   