### PR TITLE
docs: Updating kubescape repo links

### DIFF
--- a/docs/website/data/integrations.yaml
+++ b/docs/website/data/integrations.yaml
@@ -1266,12 +1266,12 @@ integrations:
     software:
       - kubescape
     code:
-      - https://github.com/armosec/kubescape
-      - https://github.com/armosec/regolibrary
+      - https://github.com/kubescape/kubescape
+      - https://github.com/kubescape/regolibrary
     inventors:
-      - armo
+      - ARMO
     tutorials:
-      - https://hub.armo.cloud
+      - https://hub.armosec.io/docs
 
   i2scim:
     title: i2scim.io SCIM Restful User/Group Provisioning API
@@ -1903,7 +1903,7 @@ software:
     link: https://apisix.apache.org/
   kubescape:
     name: Kubescape
-    link: https://github.com/armosec/kubescape
+    link: https://github.com/kubescape/kubescape
   i2scim:
     name: i2 SCIM Server
     link: https://i2scim.io

--- a/docs/website/data/integrations.yaml
+++ b/docs/website/data/integrations.yaml
@@ -1269,7 +1269,7 @@ integrations:
       - https://github.com/kubescape/kubescape
       - https://github.com/kubescape/regolibrary
     inventors:
-      - ARMO
+      - armo
     tutorials:
       - https://hub.armosec.io/docs
 

--- a/vendor/github.com/spf13/cobra/projects_using_cobra.md
+++ b/vendor/github.com/spf13/cobra/projects_using_cobra.md
@@ -25,7 +25,7 @@
 - [Istio](https://istio.io)
 - [Kool](https://github.com/kool-dev/kool)
 - [Kubernetes](https://kubernetes.io/)
-- [Kubescape](https://github.com/kubescape/kubescape)
+- [Kubescape](https://github.com/armosec/kubescape)
 - [KubeVirt](https://github.com/kubevirt/kubevirt)
 - [Linkerd](https://linkerd.io/)
 - [Mattermost-server](https://github.com/mattermost/mattermost-server)

--- a/vendor/github.com/spf13/cobra/projects_using_cobra.md
+++ b/vendor/github.com/spf13/cobra/projects_using_cobra.md
@@ -25,7 +25,7 @@
 - [Istio](https://istio.io)
 - [Kool](https://github.com/kool-dev/kool)
 - [Kubernetes](https://kubernetes.io/)
-- [Kubescape](https://github.com/armosec/kubescape)
+- [Kubescape](https://github.com/kubescape/kubescape)
 - [KubeVirt](https://github.com/kubevirt/kubevirt)
 - [Linkerd](https://linkerd.io/)
 - [Mattermost-server](https://github.com/mattermost/mattermost-server)


### PR DESCRIPTION
Signed-off-by: David Wertenteil <dwertent@armosec.io>

The Kubscape project has been moved from the [armosec](https://github.com/armosec) org to the [kubescape](https://github.com/kubescape) org.

In this PR I updated the relevant URLs.   
<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->
