### PR TITLE
sdk: allow use of StrictBuiltinErrors

### DIFF
--- a/sdk/opa_test.go
+++ b/sdk/opa_test.go
@@ -370,8 +370,7 @@ erroring_function(number) = output {
 }
 
 allow {
-	data.unknown.x 
-	erroring_function(input.x) 
+	erroring_function(1)
 }`,
 		}),
 	)
@@ -406,9 +405,9 @@ allow {
 	defer opa.Stop(ctx)
 
 	_, err = opa.Partial(ctx, sdk.PartialOptions{
-		Input:               map[string]int{"x": 1},
+		Input:               map[string]interface{}{},
 		Query:               "data.example.allow",
-		Unknowns:            []string{"data.unknown.x"},
+		Unknowns:            []string{},
 		Mapper:              &sdk.RawMapper{},
 		Now:                 time.Unix(0, 1619868194450288000).UTC(),
 		StrictBuiltinErrors: true,

--- a/sdk/opa_test.go
+++ b/sdk/opa_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/logging"
 	"github.com/open-policy-agent/opa/rego"
+	"github.com/open-policy-agent/opa/topdown"
 	"github.com/open-policy-agent/opa/topdown/builtins"
 
 	"github.com/fortytw2/leaktest"
@@ -212,6 +213,62 @@ func TestDecision(t *testing.T) {
 		t.Fatal(err)
 	} else if !reflect.DeepEqual(result.Result, exp) {
 		t.Fatalf("expected %v but got %v", exp, result.Result)
+	}
+}
+
+func TestDecisionWithStrictBuiltinErrors(t *testing.T) {
+
+	ctx := context.Background()
+
+	server := sdktest.MustNewServer(
+		sdktest.MockBundle("/bundles/bundle.tar.gz", map[string]string{
+			"main.rego": `
+				package example
+
+erroring_function(number) = output {
+	output := number / 0
+}
+
+allow {
+	erroring_function(1)
+}`,
+		}),
+	)
+
+	defer server.Stop()
+
+	config := fmt.Sprintf(`{
+		"services": {
+			"test": {
+				"url": %q
+			}
+		},
+		"bundles": {
+			"test": {
+				"resource": "/bundles/bundle.tar.gz"
+			}
+		}
+	}`, server.URL())
+
+	opa, err := sdk.New(ctx, sdk.Options{
+		Config: strings.NewReader(config),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer opa.Stop(ctx)
+
+	_, err = opa.Decision(ctx, sdk.DecisionOptions{
+		StrictBuiltinErrors: true,
+		Path:                "/example/allow",
+	})
+	if err == nil {
+		t.Fatal("expected error but got nil")
+	}
+
+	if actual, ok := err.(*topdown.Error); !ok || actual.Code != "eval_builtin_error" {
+		t.Fatalf("expected eval_builtin_error but got %v", actual)
 	}
 }
 

--- a/sdk/opa_test.go
+++ b/sdk/opa_test.go
@@ -267,8 +267,14 @@ allow {
 		t.Fatal("expected error but got nil")
 	}
 
-	if actual, ok := err.(*topdown.Error); !ok || actual.Code != "eval_builtin_error" {
+	actual, ok := err.(*topdown.Error)
+	if !ok || actual.Code != "eval_builtin_error" {
 		t.Fatalf("expected eval_builtin_error but got %v", actual)
+	}
+
+	expectedMessage := "div: divide by zero"
+	if actual.Message != expectedMessage {
+		t.Fatalf("expected %v but got %v", expectedMessage, actual.Message)
 	}
 }
 


### PR DESCRIPTION
This allows the struct builtin errors functionality to be used in the SDK by passing the value in DecisionOptions & PartialOptions.

Related to https://github.com/open-policy-agent/opa/issues/5176
