### PR TITLE
build: add CHANGELOG.md to website build triggers

### DIFF
--- a/build/docs-build-needed.sh
+++ b/build/docs-build-needed.sh
@@ -5,4 +5,4 @@ set -exo pipefail
 # NOTE(sr): we include version because that's what drives releases
 # Makefile and netlify.toml capture when the build infrastructure changes
 # ast/builtins.go and capabilities.json are driving the builtins_metadata.
-git diff --name-only --exit-code $CACHED_COMMIT_REF $COMMIT_REF docs/ Makefile build/ netlify.toml ast/builtins.go capabilities.json version/
+git diff --name-only --exit-code $CACHED_COMMIT_REF $COMMIT_REF docs/ Makefile build/ netlify.toml ast/builtins.go capabilities.json version/ CHANGELOG.md


### PR DESCRIPTION
this change itself will also trigger the website build, since it contains a change in `build/`.