### PR TITLE
sdk: Allow use of metrics, profilers, and instrumentation

### DIFF
--- a/sdk/opa.go
+++ b/sdk/opa.go
@@ -23,7 +23,6 @@ import (
 	"github.com/open-policy-agent/opa/plugins"
 	"github.com/open-policy-agent/opa/plugins/discovery"
 	"github.com/open-policy-agent/opa/plugins/logs"
-	"github.com/open-policy-agent/opa/profiler"
 	"github.com/open-policy-agent/opa/rego"
 	"github.com/open-policy-agent/opa/server"
 	"github.com/open-policy-agent/opa/storage"
@@ -239,11 +238,6 @@ func (opa *OPA) Decision(ctx context.Context, options DecisionOptions) (*Decisio
 		}
 	}
 
-	var p topdown.QueryTracer
-	if options.Profiler != nil {
-		p = options.Profiler
-	}
-
 	result, err := opa.executeTransaction(
 		ctx,
 		&record,
@@ -263,7 +257,7 @@ func (opa *OPA) Decision(ctx context.Context, options DecisionOptions) (*Decisio
 				m:                   record.Metrics,
 				strictBuiltinErrors: options.StrictBuiltinErrors,
 				tracer:              options.Tracer,
-				profiler:            p,
+				profiler:            options.Profiler,
 				instrument:          options.Instrument,
 			})
 			if record.Error == nil {
@@ -287,7 +281,7 @@ type DecisionOptions struct {
 	StrictBuiltinErrors bool                // treat built-in function errors as fatal
 	Tracer              topdown.QueryTracer // specifies the tracer to use for evaluation, optional
 	Metrics             metrics.Metrics     // specifies the metrics to use for preparing and evaluation, optional
-	Profiler            *profiler.Profiler  // specifies the profiler to use, optional
+	Profiler            topdown.QueryTracer // specifies the profiler to use, optional
 	Instrument          bool                // if true, instrumentation will be enabled
 }
 
@@ -364,11 +358,6 @@ func (opa *OPA) Partial(ctx context.Context, options PartialOptions) (*PartialRe
 		Metrics:   options.Metrics,
 	}
 
-	var p topdown.QueryTracer
-	if options.Profiler != nil {
-		p = options.Profiler
-	}
-
 	var pq *rego.PartialQueries
 	decision, err := opa.executeTransaction(
 		ctx,
@@ -387,7 +376,7 @@ func (opa *OPA) Partial(ctx context.Context, options PartialOptions) (*PartialRe
 				m:                   record.Metrics,
 				strictBuiltinErrors: options.StrictBuiltinErrors,
 				tracer:              options.Tracer,
-				profiler:            p,
+				profiler:            options.Profiler,
 				instrument:          options.Instrument,
 			})
 			if record.Error == nil {
@@ -431,7 +420,7 @@ type PartialOptions struct {
 	StrictBuiltinErrors bool                // treat built-in function errors as fatal
 	Tracer              topdown.QueryTracer // specifies the tracer to use for evaluation, optional
 	Metrics             metrics.Metrics     // specifies the metrics to use for preparing and evaluation, optional
-	Profiler            *profiler.Profiler  // specifies the profiler to use, optional
+	Profiler            topdown.QueryTracer // specifies the profiler to use, optional
 	Instrument          bool                // if true, instrumentation will be enabled
 }
 

--- a/sdk/opa_test.go
+++ b/sdk/opa_test.go
@@ -410,15 +410,23 @@ main = true
 		t.Fatalf("expected %d metrics, got %d", exp, act)
 	}
 
-	expectedRecordedMetrics := map[string]bool{
-		"timer_rego_query_compile_ns": true,
-		"timer_rego_query_eval_ns":    true,
-		"timer_rego_query_parse_ns":   true,
-		"timer_sdk_decision_eval_ns":  true,
+	expectedRecordedMetricGroups := map[string]bool{
+		"timer_rego": false,
+		"timer_sdk":  false,
 	}
 	for k := range m.All() {
-		if ok := expectedRecordedMetrics[k]; !ok {
-			t.Errorf("unexpected metric %s recorded", k)
+		for group, found := range expectedRecordedMetricGroups {
+			if found {
+				continue
+			}
+			if strings.HasPrefix(k, group) {
+				expectedRecordedMetricGroups[group] = true
+			}
+		}
+	}
+	for group, found := range expectedRecordedMetricGroups {
+		if !found {
+			t.Errorf("expected metric group %s not recorded", group)
 		}
 	}
 
@@ -478,36 +486,27 @@ main = true
 		t.Fatalf("expected %d metrics, got %d", exp, act)
 	}
 
-	expectedRecordedMetrics := map[string]bool{
-		"counter_eval_op_virtual_cache_miss":                       true,
-		"histogram_eval_op_plug":                                   true,
-		"histogram_eval_op_rule_index":                             true,
-		"timer_eval_op_plug_ns":                                    true,
-		"timer_eval_op_rule_index_ns":                              true,
-		"timer_query_compile_stage_build_comprehension_index_ns":   true,
-		"timer_query_compile_stage_check_deprecated_builtins_ns":   true,
-		"timer_query_compile_stage_check_keyword_overrides_ns":     true,
-		"timer_query_compile_stage_check_safety_ns":                true,
-		"timer_query_compile_stage_check_types_ns":                 true,
-		"timer_query_compile_stage_check_undefined_funcs_ns":       true,
-		"timer_query_compile_stage_check_unsafe_builtins_ns":       true,
-		"timer_query_compile_stage_check_void_calls_ns":            true,
-		"timer_query_compile_stage_resolve_refs_ns":                true,
-		"timer_query_compile_stage_rewrite_comprehension_terms_ns": true,
-		"timer_query_compile_stage_rewrite_dynamic_terms_ns":       true,
-		"timer_query_compile_stage_rewrite_expr_terms_ns":          true,
-		"timer_query_compile_stage_rewrite_local_vars_ns":          true,
-		"timer_query_compile_stage_rewrite_print_calls_ns":         true,
-		"timer_query_compile_stage_rewrite_to_capture_value_ns":    true,
-		"timer_query_compile_stage_rewrite_with_values_ns":         true,
-		"timer_rego_query_compile_ns":                              true,
-		"timer_rego_query_eval_ns":                                 true,
-		"timer_rego_query_parse_ns":                                true,
-		"timer_sdk_decision_eval_ns":                               true,
+	expectedRecordedMetricGroups := map[string]bool{
+		"counter_eval":        false,
+		"histogram_eval":      false,
+		"timer_query_compile": false,
+		"timer_eval":          false,
+		"timer_rego":          false,
+		"timer_sdk":           false,
 	}
 	for k := range m.All() {
-		if ok := expectedRecordedMetrics[k]; !ok {
-			t.Errorf("unexpected metric %s recorded", k)
+		for group, found := range expectedRecordedMetricGroups {
+			if found {
+				continue
+			}
+			if strings.HasPrefix(k, group) {
+				expectedRecordedMetricGroups[group] = true
+			}
+		}
+	}
+	for group, found := range expectedRecordedMetricGroups {
+		if !found {
+			t.Errorf("expected metric group %s not recorded", group)
 		}
 	}
 
@@ -818,16 +817,23 @@ allow {
 		t.Fatalf("expected %d metrics, got %d", exp, act)
 	}
 
-	expectedRecordedMetrics := map[string]bool{
-		"timer_rego_input_parse_ns":   true,
-		"timer_rego_partial_eval_ns":  true,
-		"timer_rego_query_compile_ns": true,
-		"timer_rego_query_parse_ns":   true,
-		"timer_sdk_decision_eval_ns":  true,
+	expectedRecordedMetricGroups := map[string]bool{
+		"timer_rego": false,
+		"timer_sdk":  false,
 	}
 	for k := range m.All() {
-		if ok := expectedRecordedMetrics[k]; !ok {
-			t.Errorf("unexpected metric %s recorded", k)
+		for group, found := range expectedRecordedMetricGroups {
+			if found {
+				continue
+			}
+			if strings.HasPrefix(k, group) {
+				expectedRecordedMetricGroups[group] = true
+			}
+		}
+	}
+	for group, found := range expectedRecordedMetricGroups {
+		if !found {
+			t.Errorf("expected metric group %s not recorded", group)
 		}
 	}
 
@@ -898,45 +904,29 @@ allow {
 		t.Fatalf("expected %d metrics, got %d", exp, act)
 	}
 
-	expectedRecordedMetrics := map[string]bool{
-		"counter_eval_op_virtual_cache_miss":                       true,
-		"histogram_eval_op_plug":                                   true,
-		"histogram_eval_op_rule_index":                             true,
-		"histogram_partial_op_copy_propagation":                    true,
-		"histogram_partial_op_save_set_contains":                   true,
-		"histogram_partial_op_save_unify":                          true,
-		"timer_eval_op_plug_ns":                                    true,
-		"timer_eval_op_rule_index_ns":                              true,
-		"timer_partial_op_copy_propagation_ns":                     true,
-		"timer_partial_op_save_set_contains_ns":                    true,
-		"timer_partial_op_save_unify_ns":                           true,
-		"timer_query_compile_stage_build_comprehension_index_ns":   true,
-		"timer_query_compile_stage_check_deprecated_builtins_ns":   true,
-		"timer_query_compile_stage_check_keyword_overrides_ns":     true,
-		"timer_query_compile_stage_check_safety_ns":                true,
-		"timer_query_compile_stage_check_types_ns":                 true,
-		"timer_query_compile_stage_check_undefined_funcs_ns":       true,
-		"timer_query_compile_stage_check_unsafe_builtins_ns":       true,
-		"timer_query_compile_stage_check_void_calls_ns":            true,
-		"timer_query_compile_stage_resolve_refs_ns":                true,
-		"timer_query_compile_stage_rewrite_comprehension_terms_ns": true,
-		"timer_query_compile_stage_rewrite_dynamic_terms_ns":       true,
-		"timer_query_compile_stage_rewrite_equals_ns":              true,
-		"timer_query_compile_stage_rewrite_expr_terms_ns":          true,
-		"timer_query_compile_stage_rewrite_local_vars_ns":          true,
-		"timer_query_compile_stage_rewrite_print_calls_ns":         true,
-		"timer_query_compile_stage_rewrite_to_capture_value_ns":    true,
-		"timer_query_compile_stage_rewrite_with_values_ns":         true,
-		"timer_rego_input_parse_ns":                                true,
-		"timer_rego_partial_eval_ns":                               true,
-		"timer_rego_query_compile_ns":                              true,
-		"timer_rego_query_eval_ns":                                 true,
-		"timer_rego_query_parse_ns":                                true,
-		"timer_sdk_decision_eval_ns":                               true,
+	expectedRecordedMetricGroups := map[string]bool{
+		"histogram_eval":      false,
+		"histogram_partial":   false,
+		"timer_query_compile": false,
+		"timer_eval":          false,
+		"timer_partial":       false,
+		"timer_rego":          false,
+		"timer_sdk":           false,
 	}
+
 	for k := range m.All() {
-		if ok := expectedRecordedMetrics[k]; !ok {
-			t.Errorf("unexpected metric %s recorded", k)
+		for group, found := range expectedRecordedMetricGroups {
+			if found {
+				continue
+			}
+			if strings.HasPrefix(k, group) {
+				expectedRecordedMetricGroups[group] = true
+			}
+		}
+	}
+	for group, found := range expectedRecordedMetricGroups {
+		if !found {
+			t.Errorf("expected metric group %s not recorded", group)
 		}
 	}
 

--- a/sdk/opa_test.go
+++ b/sdk/opa_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/logging"
+	"github.com/open-policy-agent/opa/metrics"
 	"github.com/open-policy-agent/opa/rego"
 	"github.com/open-policy-agent/opa/topdown"
 	"github.com/open-policy-agent/opa/topdown/builtins"
@@ -357,6 +358,71 @@ main {
 	}
 }
 
+func TestDecisionWithMetrics(t *testing.T) {
+
+	ctx := context.Background()
+
+	server := sdktest.MustNewServer(
+		sdktest.MockBundle("/bundles/bundle.tar.gz", map[string]string{
+			"main.rego": `
+package system
+
+main = true
+`,
+		}),
+	)
+
+	defer server.Stop()
+
+	config := fmt.Sprintf(`{
+		"services": {
+			"test": {
+				"url": %q
+			}
+		},
+		"bundles": {
+			"test": {
+				"resource": "/bundles/bundle.tar.gz"
+			}
+		}
+	}`, server.URL())
+
+	opa, err := sdk.New(ctx, sdk.Options{
+		Config: strings.NewReader(config),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer opa.Stop(ctx)
+
+	m := metrics.New()
+	if result, err := opa.Decision(ctx, sdk.DecisionOptions{
+		Metrics: m,
+	}); err != nil {
+		t.Fatal(err)
+	} else if decision, ok := result.Result.(bool); !ok || !decision {
+		t.Fatal("expected true but got:", decision, ok)
+	}
+
+	if exp, act := 4, len(m.All()); exp != act {
+		t.Fatalf("expected %d metrics, got %d", exp, act)
+	}
+
+	expectedRecordedMetrics := map[string]bool{
+		"timer_rego_query_compile_ns": true,
+		"timer_rego_query_eval_ns":    true,
+		"timer_rego_query_parse_ns":   true,
+		"timer_sdk_decision_eval_ns":  true,
+	}
+	for k := range m.All() {
+		if ok := expectedRecordedMetrics[k]; !ok {
+			t.Errorf("unexpected metric %s recorded", k)
+		}
+	}
+
+}
+
 func TestPartial(t *testing.T) {
 
 	ctx := context.Background()
@@ -588,6 +654,83 @@ main {
 	}
 }
 
+func TestPartialWithMetrics(t *testing.T) {
+
+	ctx := context.Background()
+
+	server := sdktest.MustNewServer(
+		sdktest.MockBundle("/bundles/bundle.tar.gz", map[string]string{
+			"main.rego": `
+package test
+
+allow {
+	data.junk.x = input.y
+}
+`,
+		}),
+	)
+
+	defer server.Stop()
+
+	config := fmt.Sprintf(`{
+		"services": {
+			"test": {
+				"url": %q
+			}
+		},
+		"bundles": {
+			"test": {
+				"resource": "/bundles/bundle.tar.gz"
+			}
+		},
+		"decision_logs": {
+			"console": true
+		}
+	}`, server.URL())
+
+	opa, err := sdk.New(ctx, sdk.Options{
+		Config: strings.NewReader(config),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer opa.Stop(ctx)
+
+	m := metrics.New()
+	var result *sdk.PartialResult
+	if result, err = opa.Partial(ctx, sdk.PartialOptions{
+		Input:    map[string]int{"y": 2},
+		Query:    "data.test.allow = true",
+		Unknowns: []string{"data.junk.x"},
+		Mapper:   &sdk.RawMapper{},
+		Now:      time.Unix(0, 1619868194450288000).UTC(),
+		Metrics:  m,
+	}); err != nil {
+		t.Fatal(err)
+	} else if decision, ok := result.Result.(*rego.PartialQueries); !ok || decision.Queries[0].String() != "2 = data.junk.x" {
+		t.Fatal("expected &{[2 = data.junk.x] []} true but got:", decision, ok)
+	}
+
+	if exp, act := 5, len(m.All()); exp != act {
+		t.Fatalf("expected %d metrics, got %d", exp, act)
+	}
+
+	expectedRecordedMetrics := map[string]bool{
+		"timer_rego_input_parse_ns":   true,
+		"timer_rego_partial_eval_ns":  true,
+		"timer_rego_query_compile_ns": true,
+		"timer_rego_query_parse_ns":   true,
+		"timer_sdk_decision_eval_ns":  true,
+	}
+	for k := range m.All() {
+		if ok := expectedRecordedMetrics[k]; !ok {
+			t.Errorf("unexpected metric %s recorded", k)
+		}
+	}
+
+}
+
 func TestUndefinedError(t *testing.T) {
 
 	ctx := context.Background()
@@ -805,10 +948,8 @@ main = 7
 		}
 	}`, server.URL())
 
-	testLogger := loggingtest.New()
 	opa, err := sdk.New(ctx, sdk.Options{
-		Config:        strings.NewReader(config),
-		ConsoleLogger: testLogger,
+		Config: strings.NewReader(config),
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -816,27 +957,27 @@ main = 7
 
 	defer opa.Stop(ctx)
 
-	// Execute two queries.
-	if _, err := opa.Decision(ctx, sdk.DecisionOptions{}); err != nil {
+	// Execute two queries with metrics
+	m1 := metrics.New()
+	if _, err := opa.Decision(ctx, sdk.DecisionOptions{
+		Metrics: m1,
+	}); err != nil {
 		t.Fatal(err)
 	}
 
-	if _, err := opa.Decision(ctx, sdk.DecisionOptions{}); err != nil {
+	m2 := metrics.New()
+	if _, err := opa.Decision(ctx, sdk.DecisionOptions{
+		Metrics: m2,
+	}); err != nil {
 		t.Fatal(err)
 	}
 
-	// Expect two log entries, one with timers for query preparation and the other without.
-	entries := testLogger.Entries()
-
-	if len(entries) != 2 {
-		t.Fatal("expected two log entries but got:", entries)
+	// Expect only the metrics from the first query to contain preparation metrics
+	if _, ok := m1.All()["timer_rego_query_parse_ns"]; !ok {
+		t.Fatal("first query should have preparation metrics")
 	}
-
-	_, ok1 := entries[0].Fields["metrics"].(map[string]interface{})["timer_rego_query_parse_ns"]
-	_, ok2 := entries[1].Fields["metrics"].(map[string]interface{})["timer_rego_query_parse_ns"]
-
-	if !ok1 || ok2 {
-		t.Fatal("expected first query to require preparation but not the second")
+	if _, ok := m2.All()["timer_rego_query_parse_ns"]; ok {
+		t.Fatal("second query should not have preparation metrics")
 	}
 
 }


### PR DESCRIPTION
This brings the sdk closer to feature parity with `opa eval` for metrics related functionality. Users can now set a `metrics.Metrics`, `profiler.Profiler` and enable instrumentation in `DecisionOptions` and `PartialOptions` alike.

Related to https://github.com/open-policy-agent/opa/issues/5176