### PR TITLE
website/frontpage: update Learn More links

### DIFF
--- a/docs/website/layouts/index.html
+++ b/docs/website/layouts/index.html
@@ -1612,9 +1612,10 @@ allowed_pets contains pet if {
         <div class="col-12 mt-2">
           <div class="mt-4" style="font-weight:600"><label>Learn More</label></div>
           <div class="mt-2">
-            <a href="https://marketplace.visualstudio.com/items?itemName=tsandall.opa" class="btn btn-primary more-link" target="_blank">VScode</a>
-              <a href="https://play.openpolicyagent.org/" class="btn btn-primary more-link" target="_blank">Rego Playground</a>
-              <a href="./docs/{{ $latest }}/#running-opa" class="btn btn-primary more-link" target="_blank">General Tooling</a>
+            <a href="https://marketplace.visualstudio.com/items?itemName=tsandall.opa" class="btn btn-primary more-link" target="_blank">VS Code</a>
+            <a href="https://play.openpolicyagent.org/" class="btn btn-primary more-link" target="_blank">Rego Playground</a>
+            <a href="./docs/{{ $latest }}/#running-opa" class="btn btn-primary more-link" target="_blank">General Tooling</a>
+            <a href="https://github.com/open-policy-agent" class="btn btn-primary more-link" target="_blank">OPA GitHub</a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Small updates to the Learn More links section on the OPA website front page:

Additions:
* Add OPA GitHub button
  * The only GitHub link on the front page is currently in the non-sticky top nav bar. If a visitor reads through the entire page and wants to visit the OPA GitHub org, they would need to remember to scroll up to the top to find the link. Adding a link toward the bottom of the page makes is easier for the user to get to the OPA GitHub org, and the Learn More links section seemed to be a good spot for this.
  * Additionally, some ad blockers (such as uBlock Origin with cosmetic filters enabled) block/remove any elements identified as "social links", which blocks the OPA Twitter, Slack, and GitHub icon links in the nav bar. Adding an additional, non-social GitHub link on the page ensures the OPA front page always has an OPA GitHub org link somewhere on the page.

Updates:
* Fix VS Code button text
* Fix HTML alignment of button elements
