### PR TITLE
ci: temporary workaround for golang proxy/sumdb bug

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -172,6 +172,9 @@ jobs:
           go-version: ${{ steps.go_version.outputs.go_version }}
 
       - run: go install golang.org/x/vuln/cmd/govulncheck@latest
+        env:
+          GOPROXY: direct
+          GOSUMDB: off 
       - run: govulncheck ./...
 
       - name: Slack Notification


### PR DESCRIPTION
As of last night, we see this error -- reproducible locally:

```
$ go install golang.org/x/vuln/cmd/govulncheck@latest
go: golang.org/x/vuln/cmd/govulncheck@latest: no matching versions for query "latest"
```

with the env vars set to bypass the infrastructure, it'll work:
```
$ GOPROXY=direct GOSUMDB=off go install golang.org/x/vuln/cmd/govulncheck@latest
go: downloading golang.org/x/vuln v0.0.0-20221208180742-f2dca5ff4cc3
go: downloading golang.org/x/tools v0.4.0
```

So let's do that for now.