### PR TITLE
ast: continue DepthFirst when building index

### DIFF
--- a/ast/compile.go
+++ b/ast/compile.go
@@ -803,7 +803,7 @@ func (c *Compiler) buildRuleIndices() {
 		if index.Build(rules) {
 			c.ruleIndices.Put(rules[0].Ref().GroundPrefix(), index)
 		}
-		return hasNonGroundKey // currently, we don't allow those branches to go deeper
+		return false
 	})
 
 }


### PR DESCRIPTION
This fixes the indexer to index Partial Object rules. There was a performance regression from 0.45 -> 0.46 and beyond on rules like:
```
rule_object[key] := value {
  value := data.some.other.module[key]
  some_conditional(key)
}
```

As far as I can tell restoring the 0.45 behaviour does not cause any regressions against the test suite.