### PR TITLE
providers/aws: Refactor + fix 2x Authorization header append issue.

### DIFF
--- a/plugins/rest/aws.go
+++ b/plugins/rest/aws.go
@@ -507,11 +507,11 @@ func signV4(req *http.Request, service string, credService awsCredentialService,
 
 	now := theTime.UTC()
 
-	signedHeaders := providers.AWSSignV4(req.Header, req.Method, req.URL, body, service, creds, now)
+	authHeader, awsHeaders := providers.AWSSignV4(req.Header, req.Method, req.URL, body, service, creds, now)
 
-	req.Header.Set("Authorization", strings.Join(signedHeaders["Authorization"], ""))
-	for k, v := range signedHeaders {
-		req.Header.Add(k, strings.Join(v, ","))
+	req.Header.Set("Authorization", authHeader)
+	for k, v := range awsHeaders {
+		req.Header.Add(k, v)
 	}
 
 	return nil

--- a/plugins/rest/aws_test.go
+++ b/plugins/rest/aws_test.go
@@ -717,6 +717,10 @@ func TestV4SigningWithMultiValueHeaders(t *testing.T) {
 		"AWS4-HMAC-SHA256 Credential=MYAWSACCESSKEYGOESHERE/20190424/us-east-1/execute-api/aws4_request,"+
 			"SignedHeaders=accept;host;x-amz-date;x-amz-security-token,"+
 			"Signature=0237b0c789cad36212f0efba70c02549e1f659ab9caaca16423930cc7236c046", t)
+	// Ensure 'authorization' is not multi-valued.
+	if len(req.Header.Values("Authorization")) != 1 {
+		t.Fatal("Authorization header is multi-valued. This will break AWS v4 signing.")
+	}
 	// The multi-value headers are preserved
 	assertEq(req.Header.Values("Accept")[0], "text/plain", t)
 	assertEq(req.Header.Values("Accept")[1], "text/html", t)

--- a/topdown/providers.go
+++ b/topdown/providers.go
@@ -7,7 +7,6 @@ package topdown
 import (
 	"encoding/json"
 	"net/url"
-	"strings"
 	"time"
 
 	"github.com/open-policy-agent/opa/ast"
@@ -173,10 +172,11 @@ func builtinAWSSigV4SignReq(ctx BuiltinContext, operands []*ast.Term, iter func(
 	}
 
 	// Sign the request object's headers, and reconstruct the headers map.
-	signedHeadersMap := providers.AWSSignV4(objectToMap(headers), method, theURL, body, service, awsCreds, signingTimestamp)
+	authHeader, signedHeadersMap := providers.AWSSignV4(objectToMap(headers), method, theURL, body, service, awsCreds, signingTimestamp)
 	signedHeadersObj := ast.NewObject()
+	signedHeadersObj.Insert(ast.StringTerm("Authorization"), ast.StringTerm(authHeader))
 	for k, v := range signedHeadersMap {
-		signedHeadersObj.Insert(ast.StringTerm(k), ast.StringTerm(strings.Join(v, ",")))
+		signedHeadersObj.Insert(ast.StringTerm(k), ast.StringTerm(v))
 	}
 
 	// Create new request object with updated headers.


### PR DESCRIPTION
This commit refactors the shared AWS Sig v4 signing code, specifically to prevent the issue behind #5472. The underlying problem for #5472 was that the `"Authorization"` header was being appended *twice* to the request, but only for the AWS REST plugin, because the value was pulled twice from the signed headers map.

This was not caught by the unit tests, because the REST plugin's unit tests all assumed the header was single-valued and canonicalized.

We now test for this exact condition in the unit tests, and the signing code now returns the AWS headers map separately from the value for the `"Authorization"` header, reducing the potential for this mistake to happen in the future.

Fixes: #5472 