### PR TITLE
ast/visit: include LazyObject in walks

### DIFF
--- a/ast/visit.go
+++ b/ast/visit.go
@@ -348,6 +348,11 @@ func (vis *GenericVisitor) Walk(x interface{}) {
 			vis.Walk(k)
 			vis.Walk(x.Get(k))
 		})
+	case Object:
+		x.Foreach(func(k, v *Term) {
+			vis.Walk(k)
+			vis.Walk(x.Get(k))
+		})
 	case *Array:
 		x.Foreach(func(t *Term) {
 			vis.Walk(t)
@@ -475,6 +480,11 @@ func (vis *BeforeAfterVisitor) Walk(x interface{}) {
 			vis.Walk(x[i])
 		}
 	case *object:
+		x.Foreach(func(k, v *Term) {
+			vis.Walk(k)
+			vis.Walk(x.Get(k))
+		})
+	case Object:
 		x.Foreach(func(k, v *Term) {
 			vis.Walk(k)
 			vis.Walk(x.Get(k))

--- a/ast/visit_test.go
+++ b/ast/visit_test.go
@@ -432,3 +432,45 @@ func TestVarVisitor(t *testing.T) {
 		}
 	}
 }
+
+func TestGenericVisitorLazyObject(t *testing.T) {
+	o := LazyObject(map[string]interface{}{"foo": 3})
+	act := 0
+	WalkTerms(o, func(n *Term) bool {
+		switch n.Value {
+		case String("foo"):
+			act++
+		case Number("3"):
+			act++
+		}
+
+		return false
+	})
+	if exp := 2; exp != act {
+		t.Errorf("expected %v, got %v", exp, act)
+	}
+}
+
+func TestGenericBeforeAfterVisitorLazyObject(t *testing.T) {
+	o := LazyObject(map[string]interface{}{"foo": 3})
+	act := 0
+	vis := NewBeforeAfterVisitor(func(x interface{}) bool {
+		t, ok := x.(*Term)
+		if !ok {
+			return false
+		}
+		switch t.Value {
+		case String("foo"):
+			act++
+		case Number("3"):
+			act++
+		}
+
+		return false
+	},
+		func(interface{}) {})
+	vis.Walk(o)
+	if exp := 2; exp != act {
+		t.Errorf("expected %v, got %v", exp, act)
+	}
+}


### PR DESCRIPTION
In situations involving PE, it's possible that we walk over an AST that contains objects taken from the store. With the lazy-objects optimization, those objects had been neglected: the walker code only cared for `*object`, not the `Object` interface, for performance reasons.

Now, we'll include the `Object` interface, which covers our lazy objects, and thus include them in AST walks.

Fixes #5479.
