### PR TITLE
Fix interquery cache memory leak

### DIFF
--- a/topdown/cache/cache.go
+++ b/topdown/cache/cache.go
@@ -75,15 +75,20 @@ type InterQueryCache interface {
 // NewInterQueryCache returns a new inter-query cache.
 func NewInterQueryCache(config *Config) InterQueryCache {
 	return &cache{
-		items:  map[string]InterQueryCacheValue{},
+		items:  map[string]cacheItem{},
 		usage:  0,
 		config: config,
 		l:      list.New(),
 	}
 }
 
+type cacheItem struct {
+	value      InterQueryCacheValue
+	keyElement *list.Element
+}
+
 type cache struct {
-	items  map[string]InterQueryCacheValue
+	items  map[string]cacheItem
 	usage  int64
 	config *Config
 	l      *list.List
@@ -101,7 +106,12 @@ func (c *cache) Insert(k ast.Value, v InterQueryCacheValue) (dropped int) {
 func (c *cache) Get(k ast.Value) (InterQueryCacheValue, bool) {
 	c.mtx.Lock()
 	defer c.mtx.Unlock()
-	return c.unsafeGet(k)
+	cacheItem, ok := c.unsafeGet(k)
+
+	if ok {
+		return cacheItem.value, true
+	}
+	return nil, false
 }
 
 // Delete deletes the value in the cache for k.
@@ -133,7 +143,6 @@ func (c *cache) unsafeInsert(k ast.Value, v InterQueryCacheValue) (dropped int) 
 		for key := c.l.Front(); key != nil && (c.usage+size > limit); key = c.l.Front() {
 			dropKey := key.Value.(ast.Value)
 			c.unsafeDelete(dropKey)
-			c.l.Remove(key)
 			dropped++
 		}
 	}
@@ -141,25 +150,28 @@ func (c *cache) unsafeInsert(k ast.Value, v InterQueryCacheValue) (dropped int) 
 	// By deleting the old value, if it exists, we ensure the usage variable stays correct
 	c.unsafeDelete(k)
 
-	c.items[k.String()] = v
-	c.l.PushBack(k)
+	c.items[k.String()] = cacheItem{
+		value:      v,
+		keyElement: c.l.PushBack(k),
+	}
 	c.usage += size
 	return dropped
 }
 
-func (c *cache) unsafeGet(k ast.Value) (InterQueryCacheValue, bool) {
+func (c *cache) unsafeGet(k ast.Value) (cacheItem, bool) {
 	value, ok := c.items[k.String()]
 	return value, ok
 }
 
 func (c *cache) unsafeDelete(k ast.Value) {
-	value, ok := c.unsafeGet(k)
+	cacheItem, ok := c.unsafeGet(k)
 	if !ok {
 		return
 	}
 
-	c.usage -= value.SizeInBytes()
+	c.usage -= cacheItem.value.SizeInBytes()
 	delete(c.items, k.String())
+	c.l.Remove(cacheItem.keyElement)
 }
 
 func (c *cache) maxSizeBytes() int64 {


### PR DESCRIPTION
I thought we could fix the leak in #5381 by keeping track of the elements in `c.l` and remove them from the list whenever the corresponding cache values are removed. Since `c.l` is already a doubly linked list it's possible to add this with very little 
changes and with O(1) complexity

I can add some tests if this looks otherwise OK