### PR TITLE
corrected OCI config section docs

### DIFF
--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -727,7 +727,7 @@ For *GHCR* (Github Container Registry) you can use a developer PAT (personal acc
 ```
  credentials:
       bearer:
-        schema: "Bearer"
+        scheme: "Bearer"
         token: "<PAT>"
 ```
 

--- a/docs/content/management-bundles.md
+++ b/docs/content/management-bundles.md
@@ -1154,7 +1154,7 @@ services:
     type: oci
     credentials:
       bearer:
-        schema: "Bearer"
+        scheme: "Bearer"
         token: "<mytoken>"
 
 bundles:


### PR DESCRIPTION
Signed-off-by: Omri Gazitt <ogazitt@gmail.com>

This PR corrects a couple of docs pages where the config for an OCI service used "schema" instead of "scheme" as a key.
