### PR TITLE
tester/runner: Fix panic'ing case in utility function.

### DIFF
--- a/tester/runner.go
+++ b/tester/runner.go
@@ -437,7 +437,7 @@ func ruleName(h *ast.Head) string {
 	case ast.String:
 		return string(last)
 	default:
-		panic("unreachable")
+		return ""
 	}
 }
 

--- a/tester/runner_test.go
+++ b/tester/runner_test.go
@@ -81,6 +81,11 @@ func testRun(t *testing.T, conf testRunConfig) map[string]*ast.Module {
 			a.b.test_duplicate { false }
 			a.b.test_duplicate { true }
 			a.b.test_duplicate { true }`,
+		// Regression test for issue #5496.
+		"/d_test.rego": `package test
+
+		a[0] := 1
+		test_pass { true }`,
 	}
 
 	tests := expectedTestResults{
@@ -96,6 +101,7 @@ func testRun(t *testing.T, conf testRunConfig) map[string]*ast.Module {
 		{"data.baz", "a.b.test_duplicate"}:         {false, true, false},
 		{"data.baz", "a.b[\"test_duplicate#01\"]"}: {false, false, false},
 		{"data.baz", "a.b[\"test_duplicate#02\"]"}: {false, false, false},
+		{"data.test", "test_pass"}:                 {false, false, false},
 	}
 
 	var modules map[string]*ast.Module


### PR DESCRIPTION
This commit fixes a panic from a utility function in the `opa test` codepath. After the ref-heads change in #4660, this particular function could be fed a ref that it didn't know how to work with, such as the innocuous line `a[0] := 1`, and it would then panic.

This was fixed by returning a dummy value instead of panic'ing.

Fixes: #5496