### PR TITLE
Update Hugo version, update deprecated Page fields

### DIFF
--- a/docs/website/layouts/partials/docs/navbar-link.html
+++ b/docs/website/layouts/partials/docs/navbar-link.html
@@ -7,7 +7,7 @@
 {{- $title := cond (isset .ctx.Params "navtitle") (.ctx.Params.navtitle) .ctx.Title -}}
 {{- if not $isRoot -}}
 {{- if eq .version $contentVersion -}}
-{{- $linkRef := .ctx.URL -}}
+{{- $linkRef := .ctx.Permalink -}}
 <a class="navbar-item" href="{{ $linkRef }}">
   {{ $title }}
 </a>

--- a/docs/website/layouts/partials/docs/navbar.html
+++ b/docs/website/layouts/partials/docs/navbar.html
@@ -17,7 +17,7 @@
 {{ $contrib     := where $allDocs ".Params.kind" "eq" "contrib" }}
 {{ $misc        := where $allDocs ".Params.kind" "eq" "misc" }}
 {{ $version     := index (split .File.Path "/") 1 }}
-{{ $pageUrl     := .URL }}
+{{ $pageUrl     := .Permalink }}
 <nav class="navbar is-primary">
   <div class="navbar-brand is-hidden-desktop">
     <a class="navbar-item" href="{{ $home }}">
@@ -37,7 +37,7 @@
         Core Docs
       </span>
 
-      <a class="navbar-item" href="{{ $docsHome.URL }}">
+      <a class="navbar-item" href="{{ $docsHome.Permalink }}">
         {{ $docsHome.Name }}
       </a>
 

--- a/docs/website/layouts/partials/docs/sidenav-link.html
+++ b/docs/website/layouts/partials/docs/sidenav-link.html
@@ -4,11 +4,11 @@
 {{/* In the current "ctx" the file path refers to the doc we are linking to, not the page we are on */}}
 {{- $contentVersion := index (split .ctx.File.Path "/") 1 -}}
 {{- $isRoot := eq (len (split .ctx.File.Path "/")) 2 -}}
-{{- $isThisPage := eq .ctx.URL .pageUrl -}}
+{{- $isThisPage := eq .ctx.Permalink .pageUrl -}}
 {{- $title := cond (isset .ctx.Params "navtitle") (.ctx.Params.navtitle) .ctx.Title -}}
 {{- if not $isRoot -}}
 {{- if eq .version $contentVersion -}}
-{{- $linkRef := .ctx.URL -}}
+{{- $linkRef := .ctx.Permalink -}}
 <a class="docs-nav-item{{ if $isThisPage }} is-active{{ end }}" href="{{ $linkRef }}">
   {{ $title }}
 </a>

--- a/docs/website/layouts/partials/docs/sidenav.html
+++ b/docs/website/layouts/partials/docs/sidenav.html
@@ -8,8 +8,8 @@
 {{ $management := where $allDocs ".Params.kind" "eq" "management" }}
 {{ $contrib    := where $allDocs ".Params.kind" "eq" "contrib" }}
 {{ $misc       := where $allDocs ".Params.kind" "eq" "misc" }}
-{{ $pageUrl    := .URL }}
-{{ $isDocsHome := eq .URL $docsHome.URL }}
+{{ $pageUrl    := .Permalink }}
+{{ $isDocsHome := eq .Permalink $docsHome.Permalink }}
 {{ $version    := index (split .File.Path "/") 1 }}
 {{ $latest     := index site.Data.releases 1 }}
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -9,7 +9,7 @@ path = "/badge-endpoint/*"
 function = "badge"
 
 [build.environment]
-HUGO_VERSION = "0.88.1"
+HUGO_VERSION = "0.109.0"
 
 [context.deploy-preview]
 command = "make netlify-preview WASM_ENABLED=0 CGO_ENABLED=0"


### PR DESCRIPTION
In https://github.com/gohugoio/hugo/releases/tag/v0.93.0 the hugo project deprecated the .URL fields in favor of Permalink and RelPermalink fields.

In this PR I have updated the netlify hugo version and these fields.

I have done this since v0.88.1 is not available for arm Macs. I hope this will make it easier to work on the docs site.

Signed-off-by: Charlie Egan <charlieegan3@users.noreply.github.com>
