### PR TITLE
[rego] Check store modules before skipping parsing

### DIFF
--- a/plugins/logs/plugin_test.go
+++ b/plugins/logs/plugin_test.go
@@ -1705,6 +1705,7 @@ func TestPluginMasking(t *testing.T) {
 					if tc.errManager.Error() != err.Error() {
 						t.Fatalf("expected error %s, but got %s", tc.errManager.Error(), err.Error())
 					}
+					return
 				}
 			}
 

--- a/rego/rego.go
+++ b/rego/rego.go
@@ -1689,7 +1689,14 @@ func (r *Rego) prepare(ctx context.Context, qType queryType, extras []extraStage
 }
 
 func (r *Rego) parseModules(ctx context.Context, txn storage.Transaction, m metrics.Metrics) error {
-	if len(r.modules) == 0 {
+	ids, err := r.store.ListPolicies(ctx, txn)
+	if err != nil {
+		return err
+	}
+
+	// if there are no raw modules, nor modules in the store, then there
+	// is nothing to do.
+	if len(r.modules) == 0 && len(ids) == 0 {
 		return nil
 	}
 
@@ -1700,11 +1707,6 @@ func (r *Rego) parseModules(ctx context.Context, txn storage.Transaction, m metr
 	// Parse any modules in the are saved to the store, but only if
 	// another compile step is going to occur (ie. we have parsed modules
 	// that need to be compiled).
-	ids, err := r.store.ListPolicies(ctx, txn)
-	if err != nil {
-		return err
-	}
-
 	for _, id := range ids {
 		// if it is already on the compiler we're using
 		// then don't bother to re-parse it from source

--- a/sdk/opa_test.go
+++ b/sdk/opa_test.go
@@ -408,7 +408,7 @@ main = true
 		t.Fatal("expected true but got:", decision, ok)
 	}
 
-	if exp, act := 4, len(m.All()); exp != act {
+	if exp, act := 5, len(m.All()); exp != act {
 		t.Fatalf("expected %d metrics, got %d", exp, act)
 	}
 
@@ -484,7 +484,7 @@ main = true
 		t.Fatal("expected true but got:", decision, ok)
 	}
 
-	if exp, act := 25, len(m.All()); exp != act {
+	if exp, act := 26, len(m.All()); exp != act {
 		t.Fatalf("expected %d metrics, got %d", exp, act)
 	}
 
@@ -932,7 +932,7 @@ allow {
 		t.Fatal("expected &{[2 = data.junk.x] []} true but got:", decision, ok)
 	}
 
-	if exp, act := 5, len(m.All()); exp != act {
+	if exp, act := 6, len(m.All()); exp != act {
 		t.Fatalf("expected %d metrics, got %d", exp, act)
 	}
 
@@ -1019,7 +1019,7 @@ allow {
 		t.Fatal("expected &{[2 = data.junk.x] []} true but got:", decision, ok)
 	}
 
-	if exp, act := 32, len(m.All()); exp != act {
+	if exp, act := 33, len(m.All()); exp != act {
 		t.Fatalf("expected %d metrics, got %d", exp, act)
 	}
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1034,6 +1034,7 @@ func TestCompileV1Observability(t *testing.T) {
 			"timer_rego_partial_eval_ns",
 			"timer_rego_query_compile_ns",
 			"timer_rego_query_parse_ns",
+			"timer_rego_module_parse_ns",
 			"timer_server_handler_ns",
 			"counter_disk_read_keys",
 			"timer_disk_read_ns",


### PR DESCRIPTION
Fixes https://github.com/open-policy-agent/opa/issues/5511

This change will cause the operation to be timed if the store modules have already all been compiled and there are no rawModules. This might be undesirable. Updates to metric counts show the impact this has in our tested examples.

Signed-off-by: Charlie Egan <charlieegan3@users.noreply.github.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->
