### PR TITLE
fix prefix error in `opa inspect` for bundle from root

### DIFF
--- a/build/binary-smoke-test.sh
+++ b/build/binary-smoke-test.sh
@@ -4,8 +4,13 @@ OPA_EXEC="$1"
 TARGET="$2"
 
 PATH_SEPARATOR="/"
+BASE_PATH=$(pwd)
+TEST_PATH="${BASE_PATH}/test/cli/smoke/namespace/data.json"
 if [[ $OPA_EXEC == *".exe" ]]; then
     PATH_SEPARATOR="\\"
+    BASE_PATH=$(pwd -W)
+    TEST_PATH="$(echo ${BASE_PATH}/test/cli/smoke/namespace/data.json | sed 's/^\///' | sed 's/\//\\\\/g')"
+    BASE_PATH=$(echo ${BASE_PATH} | sed 's/^\///' | sed 's/\//\\/g')
 fi
 
 github_actions_group() {
@@ -30,6 +35,16 @@ assert_contains() {
     fi
 }
 
+# assert_not_contains checks if the actual string does not contain the expected string.
+assert_not_contains() {
+    local expected="$1"
+    local actual="$2"
+    if [[ "$actual" == *"$expected"* ]]; then
+        echo "Didn't expect '$expected' in '$actual'"
+        exit 0
+    fi
+}
+
 opa version
 opa eval -t $TARGET 'time.now_ns()'
 opa eval --format pretty --bundle test/cli/smoke/golden-bundle.tar.gz --input test/cli/smoke/input.json data.test.result --fail
@@ -48,4 +63,10 @@ github_actions_group assert_contains '/test/cli/smoke/test.rego' "$(tar -tf o3.t
 # Data files - correct namespaces
 echo "::group:: Data files - correct namespaces"
 assert_contains "data.namespace | test${PATH_SEPARATOR}cli${PATH_SEPARATOR}smoke${PATH_SEPARATOR}namespace${PATH_SEPARATOR}data.json" "$(opa inspect test/cli/smoke)"
+echo "::endgroup::"
+
+# Data files - correct root path
+echo "::group:: Data files - correct root path"
+assert_contains "${TEST_PATH}" "$(opa inspect ${BASE_PATH}/test/cli/smoke -f json)"
+assert_not_contains "\\\\${TEST_PATH}" "$(opa inspect ${BASE_PATH}/test/cli/smoke -f json)"
 echo "::endgroup::"

--- a/bundle/file.go
+++ b/bundle/file.go
@@ -164,7 +164,7 @@ func (d *dirLoader) NextFile() (*Descriptor, error) {
 				if d.filter != nil && d.filter(filepath.ToSlash(path), info, getdepth(path, false)) {
 					return nil
 				}
-				d.files = append(d.files, filepath.ToSlash(path))
+				d.files = append(d.files, path)
 			} else if info != nil && info.Mode().IsDir() {
 				if d.filter != nil && d.filter(filepath.ToSlash(path), info, getdepth(path, true)) {
 					return filepath.SkipDir
@@ -188,13 +188,13 @@ func (d *dirLoader) NextFile() (*Descriptor, error) {
 	fh := newLazyFile(fileName)
 
 	// Trim off the root directory and return path as if chrooted
-	cleanedPath := strings.TrimPrefix(fileName, d.root)
+	cleanedPath := strings.TrimPrefix(fileName, filepath.FromSlash(d.root))
 	if d.root == "." && filepath.Base(fileName) == ManifestExt {
 		cleanedPath = fileName
 	}
 
-	if !strings.HasPrefix(cleanedPath, "/") {
-		cleanedPath = "/" + cleanedPath
+	if !strings.HasPrefix(cleanedPath, string(os.PathSeparator)) {
+		cleanedPath = string(os.PathSeparator) + cleanedPath
 	}
 
 	f := newDescriptor(path.Join(d.root, cleanedPath), cleanedPath, fh).withCloser(fh)

--- a/test/cli/smoke/.manifest
+++ b/test/cli/smoke/.manifest
@@ -1,0 +1,3 @@
+{
+    "roots": ["test", "namespace", "x"]
+}


### PR DESCRIPTION
Signed-off-by: harikannan512 [harikannan512@gmail.com](mailto:harikannan512@gmail.com)

New PR opened to undo signed commit errors in the preovious PR


Command used:

Win: ./opa.exe inspect C:\sample_opa\opa_inspect\ -f json
Mac: ./opa inspect ~/Downloads/opa_inspect/ -f json

Resolves:
https://github.com/open-policy-agent/opa/issues/5503

Before:

`error: bundle Z:\sample_inspect_bundle: manifest roots [a/b/c a/b/d play play2] do not permit data at path '/Z:' (hint: check bundle directory structure)`
After:
```
{
  "manifest": {
    "revision": "",
    "roots": [
      "a/b/c",
      "a/b/d",
      "play",
      "play2"
    ]
  },
  "signatures_config": {},
  "namespaces": {
    "data.a.b.c": [
      "C:\\sample_opa\\opa_inspect\\authz.rego",
      "C:\\sample_opa\\opa_inspect\\authz3.rego"
    ],
    "data.a.b.d": [
      "C:\\sample_opa\\opa_inspect\\authz2.rego"
    ],
    "data.play": [
      "C:\\sample_opa\\opa_inspect\\authz4.rego",
      "C:\\sample_opa\\opa_inspect\\/play\\data.json"
    ],
    "data.play2": [
      "C:\\sample_opa\\opa_inspect\\/play2\\data.json"
    ]
  }
}
```