### PR TITLE
docs: non-nullable id argument and typo fix

### DIFF
--- a/docs/content/graphql-api-authorization.md
+++ b/docs/content/graphql-api-authorization.md
@@ -41,14 +41,14 @@ schema {
 }
 
 type Query {
-  employeeByID(id: String): Employee
+  employeeByID(id: String!): Employee
 }
 ```
 
 Every GraphQL service has a `query` type, and may or may not have a `mutation` type.
 These types are special because they define the entry points of *every* GraphQL query for the API covered by that schema.
 
-For our example above, we've defined exactly one query entry point, the parameterized query `user(id: Int)`.
+For our example above, we've defined exactly one query entry point, the parameterized query `employeeByID(id: String!)`.
 
 ### 2. Create a policy bundle.
 


### PR DESCRIPTION
- Changes `id` argument from optional to required, as being optional makes little sense in a real API
- Fixes typo where `Int` should be `String` to match the original argument type. Another option would have been to use the [`ID scalar type`](https://graphql.org/learn/schema/#scalar-types) instead of neither String or Int, that's definitely the best practice but might confuse newcomers and distract them from the main point.

Also made this corresponding PR into the example code:
https://github.com/StyraInc/graphql-apollo-example/pull/2

