### PR TITLE
nolint:staticcheck, ignoring tlsCert.RootCAs.Subjects is deprecated .

### DIFF
--- a/topdown/http_test.go
+++ b/topdown/http_test.go
@@ -2430,6 +2430,7 @@ func TestHTTPSNoClientCerts(t *testing.T) {
 	})
 }
 
+// nolint:staticcheck // ignoring tlsCert.RootCAs.Subjects is deprecated ERR because cert does not come from SystemCertPool.
 func TestCertSelectionLogic(t *testing.T) {
 	const (
 		localCaFile = "testdata/ca.pem"


### PR DESCRIPTION
Signed-off-by: yanggang <gang.yang@daocloud.io>

As [lint err](https://github.com/open-telemetry/opentelemetry-go/issues/2667) and [lint ignore](https://github.com/open-telemetry/opentelemetry-go/pull/2674/files).
We can handle the err ``` ignoring tlsCert.RootCAs.Subjects is deprecated ERR because cert does not come from SystemCertPool```.