### PR TITLE
Run containers as user 1000:1000

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,16 +9,7 @@ FROM ${BASE}
 LABEL org.opencontainers.image.authors="Torin Sandall <torinsandall@gmail.com>"
 LABEL org.opencontainers.image.source="https://github.com/open-policy-agent/opa"
 
-# Temporarily allow us to identify whether running from within an offical
-# Docker image, so that we may print a warning when uid or gid == 0 (root)
-# Remove once https://github.com/open-policy-agent/opa/issues/4295 is done
-ENV OPA_DOCKER_IMAGE="official"
-
-# Any non-zero number will do, and unfortunately a named user will not, as k8s
-# pod securityContext runAsNonRoot can't resolve the user ID:
-# https://github.com/kubernetes/kubernetes/issues/40958. Make root (uid 0) when
-# not specified.
-ARG USER=0
+ARG USER=1000:1000
 USER ${USER}
 
 # TARGETOS and TARGETARCH are automatic platform args injected by BuildKit

--- a/Makefile
+++ b/Makefile
@@ -342,13 +342,6 @@ ifneq ($(GOARCH),arm64) # build only static images for arm64
 		--build-arg BIN_DIR=$(RELEASE_DIR) \
 		--platform linux/$* \
 		.
-	$(DOCKER) build \
-		-t $(DOCKER_IMAGE):$(VERSION)-rootless \
-		--build-arg USER=1000:1000 \
-		--build-arg BASE=gcr.io/distroless/cc \
-		--build-arg BIN_DIR=$(RELEASE_DIR) \
-		--platform linux/$* \
-		.
 endif
 	$(DOCKER) build \
 		-t $(DOCKER_IMAGE):$(VERSION)-static \
@@ -376,14 +369,6 @@ push-manifest-list-%: ensure-executable-bin
 		--push \
 		.
 	$(DOCKER) buildx build \
-		--tag $(DOCKER_IMAGE):$*-rootless \
-		--build-arg USER=1000:1000 \
-		--build-arg BASE=gcr.io/distroless/cc \
-		--build-arg BIN_DIR=$(RELEASE_DIR) \
-		--platform $(DOCKER_PLATFORMS) \
-		--push \
-		.
-	$(DOCKER) buildx build \
 		--tag $(DOCKER_IMAGE):$*-static \
 		--build-arg BASE=gcr.io/distroless/static \
 		--build-arg BIN_DIR=$(RELEASE_DIR) \
@@ -401,10 +386,9 @@ ci-image-smoke-test-%: image-quick-%
 ifneq ($(GOARCH),arm64) # we build only static images for arm64
 	$(DOCKER) run --platform linux/$* $(DOCKER_IMAGE):$(VERSION) version
 	$(DOCKER) run --platform linux/$* $(DOCKER_IMAGE):$(VERSION)-debug version
-	$(DOCKER) run --platform linux/$* $(DOCKER_IMAGE):$(VERSION)-rootless version
 
-	$(DOCKER) image inspect $(DOCKER_IMAGE):$(VERSION)-rootless |\
-	  $(DOCKER) run --interactive --platform linux/$* $(DOCKER_IMAGE):$(VERSION)-rootless \
+	$(DOCKER) image inspect $(DOCKER_IMAGE):$(VERSION) |\
+	  $(DOCKER) run --interactive --platform linux/$* $(DOCKER_IMAGE):$(VERSION) \
 	  eval --fail --format raw --stdin-input 'input[0].Config.User = "1000:1000"'
 endif
 	$(DOCKER) run --platform linux/$* $(DOCKER_IMAGE):$(VERSION)-static version

--- a/docs/content/graphql-api-authorization.md
+++ b/docs/content/graphql-api-authorization.md
@@ -168,7 +168,7 @@ Next, create a `docker-compose.yml` file that runs OPA, a bundle server and the 
 ```yaml
 services:
   opa:
-    image: openpolicyagent/opa:{{< current_docker_version >}}-rootless
+    image: openpolicyagent/opa:{{< current_docker_version >}}
     ports:
       - "8181:8181"
     command:

--- a/docs/content/http-api-authorization.md
+++ b/docs/content/http-api-authorization.md
@@ -71,7 +71,7 @@ Next, create a `docker-compose.yml` file that runs OPA, a bundle server and the 
 version: '2'
 services:
   opa:
-    image: openpolicyagent/opa:{{< current_docker_version >}}-rootless
+    image: openpolicyagent/opa:{{< current_docker_version >}}
     ports:
     - 8181:8181
     # WARNING: OPA is NOT running with an authorization policy configured. This

--- a/docs/content/kafka-authorization.md
+++ b/docs/content/kafka-authorization.md
@@ -82,7 +82,7 @@ services:
     ports:
       - "80:80"
   opa:
-    image: openpolicyagent/opa:{{< current_docker_version >}}-rootless
+    image: openpolicyagent/opa:{{< current_docker_version >}}
     ports:
       - "8181:8181"
     command:

--- a/docs/content/kubernetes-tutorial.md
+++ b/docs/content/kubernetes-tutorial.md
@@ -335,7 +335,7 @@ spec:
         # authentication and authorization on the daemon. See the Security page for
         # details: https://www.openpolicyagent.org/docs/security.html.
         - name: opa
-          image: openpolicyagent/opa:{{< current_docker_version >}}-rootless
+          image: openpolicyagent/opa:{{< current_docker_version >}}
           args:
             - "run"
             - "--server"

--- a/runtime/check_user_linux.go
+++ b/runtime/check_user_linux.go
@@ -5,23 +5,16 @@
 package runtime
 
 import (
-	"os"
 	"os/user"
 
 	"github.com/open-policy-agent/opa/logging"
 )
 
-// checkUserPrivileges on Linux could be running in Docker, so we check if
-// we're running in the official container image.
 func checkUserPrivileges(logger logging.Logger) {
 	usr, err := user.Current()
 	if err != nil {
 		logger.Debug("Failed to determine uid/gid of process owner")
 	} else if usr.Uid == "0" || usr.Gid == "0" {
-		message := "OPA running with uid or gid 0. Running OPA with root privileges is not recommended."
-		if os.Getenv("OPA_DOCKER_IMAGE") == "official" {
-			message += " Use the -rootless image to avoid running with root privileges. This will be made the default in later OPA releases."
-		}
-		logger.Warn(message)
+		logger.Warn("OPA running with uid or gid 0. Running OPA with root privileges is not recommended.")
 	}
 }


### PR DESCRIPTION
For the changelog:

Breaking change: all OPA images now run with a non-root uid/gid. This means there is no longer a need for the -rootless image variant, and it has thus been decomissioned. If you were using the -rootless images before, you'll need to change your configuration to use the regular image (i.e. without the -rootless suffix).

While the OPA images contain no other software (like a shell), running as root is still a bad practice. If you for some reason **must** run OPA with root privileges, this can still be achieved by explicitly setting the user, either with the `--user` argument for `docker run`, or in the `securityContext` of your Kubernetes pod spec.

Fixes #4295

Signed-off-by: Anders Eknert <anders@eknert.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->
