### PR TITLE
Update base images for non debug builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -332,10 +332,11 @@ image-quick-%: ensure-executable-bin
 ifneq ($(GOARCH),arm64) # build only static images for arm64
 	$(DOCKER) build \
 		-t $(DOCKER_IMAGE):$(VERSION) \
-		--build-arg BASE=gcr.io/distroless/cc \
+		--build-arg BASE=cgr.dev/chainguard/cc-dynamic \
 		--build-arg BIN_DIR=$(RELEASE_DIR) \
 		--platform linux/$* \
 		.
+	# TODO: update busybox shell debug images to image without openssl
 	$(DOCKER) build \
 		-t $(DOCKER_IMAGE):$(VERSION)-debug \
 		--build-arg BASE=gcr.io/distroless/cc:debug \
@@ -345,14 +346,14 @@ ifneq ($(GOARCH),arm64) # build only static images for arm64
 	$(DOCKER) build \
 		-t $(DOCKER_IMAGE):$(VERSION)-rootless \
 		--build-arg USER=1000:1000 \
-		--build-arg BASE=gcr.io/distroless/cc \
+		--build-arg BASE=cgr.dev/chainguard/cc-dynamic \
 		--build-arg BIN_DIR=$(RELEASE_DIR) \
 		--platform linux/$* \
 		.
 endif
 	$(DOCKER) build \
 		-t $(DOCKER_IMAGE):$(VERSION)-static \
-		--build-arg BASE=gcr.io/distroless/static \
+		--build-arg BASE=cgr.dev/chainguard/static \
 		--build-arg BIN_DIR=$(RELEASE_DIR) \
 		--build-arg BIN_SUFFIX=_static \
 		--platform linux/$* \
@@ -363,11 +364,12 @@ endif
 push-manifest-list-%: ensure-executable-bin
 	$(DOCKER) buildx build \
 		--tag $(DOCKER_IMAGE):$* \
-		--build-arg BASE=gcr.io/distroless/cc \
+		--build-arg BASE=cgr.dev/chainguard/cc-dynamic \
 		--build-arg BIN_DIR=$(RELEASE_DIR) \
 		--platform $(DOCKER_PLATFORMS) \
 		--push \
 		.
+	# TODO: update busybox shell debug images to image without openssl
 	$(DOCKER) buildx build \
 		--tag $(DOCKER_IMAGE):$*-debug \
 		--build-arg BASE=gcr.io/distroless/cc:debug \
@@ -378,14 +380,14 @@ push-manifest-list-%: ensure-executable-bin
 	$(DOCKER) buildx build \
 		--tag $(DOCKER_IMAGE):$*-rootless \
 		--build-arg USER=1000:1000 \
-		--build-arg BASE=gcr.io/distroless/cc \
+		--build-arg BASE=cgr.dev/chainguard/cc-dynamic \
 		--build-arg BIN_DIR=$(RELEASE_DIR) \
 		--platform $(DOCKER_PLATFORMS) \
 		--push \
 		.
 	$(DOCKER) buildx build \
 		--tag $(DOCKER_IMAGE):$*-static \
-		--build-arg BASE=gcr.io/distroless/static \
+		--build-arg BASE=cgr.dev/chainguard/static \
 		--build-arg BIN_DIR=$(RELEASE_DIR) \
 		--build-arg BIN_SUFFIX=_static \
 		--platform $(DOCKER_PLATFORMS_STATIC) \


### PR DESCRIPTION
New base images don't contain openssl and are sourced from https://github.com/chainguard-images/images#chainguard-images.

I have also updated the static images to use their static base, though it is not impacted by the openssl issue.

Remaining to do, perhaps as part of this PR is to update the debug base images to something that doesn't contain openssl too. Currently there is no cc image in the chainguard collection that contains a busybox shell.

Signed-off-by: Charlie Egan <charlie@styra.com>