### PR TITLE
topdown: fix re-wrapping of ndb_cache errors

### DIFF
--- a/test/cases/testdata/withkeyword/test-with-and-ndbcache-issue.yaml
+++ b/test/cases/testdata/withkeyword/test-with-and-ndbcache-issue.yaml
@@ -1,0 +1,16 @@
+cases:
+- modules:
+  - |
+    package rules
+
+    p {
+      time.now_ns(now)
+    }
+
+    q { p with data.x as 7 }
+  note: "with: ndb_cache-issue"
+  query: data.rules = x
+  want_result:
+  - x:
+      p: true
+      q: true

--- a/topdown/exported_test.go
+++ b/topdown/exported_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/open-policy-agent/opa/storage"
 	inmem "github.com/open-policy-agent/opa/storage/inmem/test"
 	"github.com/open-policy-agent/opa/test/cases"
+	"github.com/open-policy-agent/opa/topdown/builtins"
 )
 
 func TestRego(t *testing.T) {
@@ -34,7 +35,19 @@ func TestOPARego(t *testing.T) {
 	}
 }
 
-func testRun(t *testing.T, tc cases.TestCase) {
+func TestRegoWithNDBCache(t *testing.T) {
+	for _, tc := range cases.MustLoad("../test/cases/testdata").Sorted().Cases {
+		t.Run(tc.Note, func(t *testing.T) {
+			testRun(t, tc, func(q *Query) *Query {
+				return q.WithNDBuiltinCache(builtins.NDBCache{})
+			})
+		})
+	}
+}
+
+type opt func(*Query) *Query
+
+func testRun(t *testing.T, tc cases.TestCase, opts ...opt) {
 
 	ctx := context.Background()
 
@@ -69,14 +82,19 @@ func testRun(t *testing.T, tc cases.TestCase) {
 	}
 
 	buf := NewBufferTracer()
-	rs, err := NewQuery(query).
+	q := NewQuery(query).
 		WithCompiler(compiler).
 		WithStore(store).
 		WithTransaction(txn).
 		WithInput(input).
 		WithStrictBuiltinErrors(tc.StrictError).
-		WithTracer(buf).
-		Run(ctx)
+		WithTracer(buf)
+
+	for _, o := range opts {
+		q = o(q)
+	}
+
+	rs, err := q.Run(ctx)
 
 	if tc.WantError != nil {
 		testAssertErrorText(t, *tc.WantError, err)


### PR DESCRIPTION
Errors happening in the "cache hit" code path for NDBCache calls would come from the iterators called with the function call results retrieved from the cache. Now, these errors include the sentinel "early exit" errors, which would ordinarily be suppressed further up the call stack.

However, since the iter()-returned errors had been wrapped into topdown.Halt{}, they were not picked up by the suppression mechanisms.

Now, those iter-derived errors are no longer wrapped into Halt, and the code section that suggests that they should be has gotten a new comment explaining what's going on there.

To improve our blinds spots in testing, the Rego Yaml tests are now also run with NDBCache enabled. No further assertions are added, those are tested elsewhere, but it would have caught this problem. Hence it seems worthwhile to spend the extra 3s in tests.
