### PR TITLE
topdown: Specify host verification policy for http redirects

### DIFF
--- a/topdown/http.go
+++ b/topdown/http.go
@@ -452,6 +452,9 @@ func createHTTPRequest(bctx BuiltinContext, obj ast.Object) (*http.Request, *htt
 	isTLS := false
 	client := &http.Client{
 		Timeout: timeout,
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
 	}
 
 	if tlsInsecureSkipVerify {
@@ -560,9 +563,9 @@ func createHTTPRequest(bctx BuiltinContext, obj ast.Object) (*http.Request, *htt
 	}
 
 	// check if redirects are enabled
-	if !enableRedirect {
-		client.CheckRedirect = func(*http.Request, []*http.Request) error {
-			return http.ErrUseLastResponse
+	if enableRedirect {
+		client.CheckRedirect = func(req *http.Request, _ []*http.Request) error {
+			return verifyURLHost(bctx, req.URL.String())
 		}
 	}
 


### PR DESCRIPTION
Currently if http redirects are enabled, we use the client's default redirect policy. We should instead check if the hosts http.send calls as part of the redirect are explictly allowed by the policy authors. This change updates the http client's CheckRedirect policy to verify the hosts the client calls when redirects are enabled.

Fixes: #5388

Signed-off-by: Ashutosh Narkar <anarkar4387@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->
