### PR TITLE
cmd: Copy the loop variable into a new variable

### DIFF
--- a/cmd/eval.go
+++ b/cmd/eval.go
@@ -449,6 +449,7 @@ func evalOnce(ctx context.Context, ectx *evalContext) pr.Output {
 	result.Errors = pr.NewOutputErrors(resultErr)
 	if ectx.builtInErrorList != nil {
 		for _, err := range *(ectx.builtInErrorList) {
+			err := err
 			result.Errors = append(result.Errors, pr.NewOutputErrors(&err)...)
 		}
 	}


### PR DESCRIPTION
Earlier we were appending the address of the iterator variable to the slice. This results in unintended behavior of appending the same address to the slice. We fix this by copying the loop variable into a new variable and then appending.

Ref: https://github.com/golang/go/wiki/CommonMistakes#using-reference-to-loop-iterator-variable

Signed-off-by: Ashutosh Narkar <anarkar4387@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->
