### PR TITLE
Fix: Correct the spelling of forbidden on the Policy Language documentation page.

### DIFF
--- a/docs/content/policy-language.md
+++ b/docs/content/policy-language.md
@@ -1506,7 +1506,7 @@ deny if input.token != "secret"
 This keyword allows more expressive rule heads for partial set rules:
 
 ```live:eg/kws/contains:module:read_only
-deny contains msg { msg := "forbdiden" }
+deny contains msg { msg := "forbidden" }
 ```
 
 `contains` was introduced in [v0.42.0](https://github.com/open-policy-agent/opa/releases/tag/v0.42.0).


### PR DESCRIPTION
This change fixes the spelling of a misspelled word found in the `Policy Language` documentation.

In `docs/content/policy-language.md`, a misspelled word forbdiden has been corrected to forbidden, [following Merriam-Webster's spelling of the word](https://www.merriam-webster.com/dictionary/forbidden).

Attached below is a screenshot of the word's location in the `future.keywords.contains` section on the `Policy Language` docs page.
<img width="813" alt="Screen Shot 2023-01-08 at 3 09 56 PM" src="https://user-images.githubusercontent.com/20607878/211216809-cc18a24b-e161-4c2d-aeb8-e39f15718c64.png">