### PR TITLE
Clarify Unreleased changelog section

### DIFF
--- a/build/gen-dev-patch.sh
+++ b/build/gen-dev-patch.sh
@@ -49,6 +49,8 @@ $(awk "1;/## $LAST_VERSION/{exit}" CHANGELOG.md | sed '$d')
 
 ## Unreleased
 
+[empty, no unreleased changes have been noted in the changelog]
+
 ## $LAST_VERSION
 $(sed "1,/## $LAST_VERSION/d" CHANGELOG.md)
 EOF


### PR DESCRIPTION
I hope that this comment will make it clearer that there are no unreleased changes, rather than that the following release is unreleased.

Addresses: https://github.com/open-policy-agent/opa/pull/5554#discussion_r1064832893

<img width="927" alt="Screenshot 2023-01-09 at 16 26 23" src="https://user-images.githubusercontent.com/1774239/211359046-69d5158e-0b39-41d8-a0b9-33589b5b2567.png">


Signed-off-by: Charlie Egan <charlie@styra.com>
