### PR TITLE
Use available auth plugins in OCIDownloader

### DIFF
--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -739,24 +739,38 @@ func init() {
 
 ### Using private image from OCI repositories
 
-When using a private image from an OCI registry the credentials are mandatory as the OCI downloader needs the credentials for the pull operation.
+When using a private image from an OCI registry you need to specify an authentication method. Supported authentication methods are listed in the [Services](#services) section. The Azure managed identity plugin
+is not supported at this point in time.
 
-Examples of setting credetials for pulling private images:
-*AWS ECR* private image usually requires at least basic authentication. The credentials to authenticate can be obtained using the AWS CLI command `aws ecr get-login` and those can be passed to the service configuration as basic bearer credentials as follows:
+Examples of setting credentials for pulling private images:
+*AWS ECR* private images usually require at least basic authentication. The credentials to authenticate can be obtained using the AWS CLI command `aws ecr get-login` and those can be passed to the service configuration as basic bearer credentials as follows:
+```yaml
+credentials:
+  bearer:
+    scheme: "Basic"
+    token: "<username>:<password>"
 ```
- credentials:
-      bearer:
-        scheme: "Basic"
-        token: "<username>:<password>"
+
+Other AWS authentication methods also work:
+```yaml
+credentials:
+  s3_signing:
+    service: "ecr"
+    metadata_credentials:
+      aws_region: us-east-1
 ```
-The OCI downloader includes a base64 encoder for these credentials so they can be supplied as shown above.
+
+Note, that the authentication method `s3_signing` does work for
+signing requests to other AWS services.
+
+A special case is that bearer authentication works differently to normal service authentication. The OCI downloader base64-encodes the credentials for you so that they need to be supplied in plain text.
 
 For *GHCR* (Github Container Registry) you can use a developer PAT (personal access token) when downloading a private image. These can be supplied as:
-```
- credentials:
-      bearer:
-        scheme: "Bearer"
-        token: "<PAT>"
+```yaml
+credentials:
+  bearer:
+    scheme: "Bearer"
+    token: "<PAT>"
 ```
 
 ### Miscellaneous

--- a/download/oci_download_test.go
+++ b/download/oci_download_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"net/http"
 	"strings"
 	"testing"
 	"time"
@@ -50,12 +51,30 @@ func TestOCIStartStop(t *testing.T) {
 	d.Stop(ctx)
 }
 
-func TestOCIAuth(t *testing.T) {
+func TestOCIBearerAuthPlugin(t *testing.T) {
 	ctx := context.Background()
 	fixture := newTestFixture(t)
-	token := base64.StdEncoding.EncodeToString([]byte("secret")) // token should be base64 encoded
-	fixture.server.expAuth = fmt.Sprintf("Bearer %s", token)     // test on private repository
+	plainToken := "secret"
+	token := base64.StdEncoding.EncodeToString([]byte(plainToken)) // token should be base64 encoded
+	fixture.server.expAuth = fmt.Sprintf("Bearer %s", token)       // test on private repository
 	fixture.server.expEtag = "sha256:c5834dbce332cabe6ae68a364de171a50bf5b08024c27d7c08cc72878b4df7ff"
+
+	restConf := fmt.Sprintf(`{
+		"url": %q,
+		"type": "oci",
+		"credentials": {
+			"bearer": {
+				"token": %q
+			}
+		}
+	}`, fixture.server.server.URL, plainToken)
+
+	client, err := rest.New([]byte(restConf), map[string]*keys.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fixture.setClient(client)
 
 	config := Config{}
 	if err := config.ValidateAndInjectDefaults(); err != nil {
@@ -64,9 +83,8 @@ func TestOCIAuth(t *testing.T) {
 
 	d := NewOCI(config, fixture.client, "ghcr.io/org/repo:latest", "/tmp/oci")
 
-	err := d.oneShot(ctx)
-	if err != nil {
-		t.Fatal("unexpected error")
+	if err := d.oneShot(ctx); err != nil {
+		t.Fatal(err)
 	}
 }
 
@@ -89,15 +107,33 @@ func TestOCIFailureAuthn(t *testing.T) {
 }
 
 func TestOCIEtag(t *testing.T) {
-	ctx := context.Background()
 	fixture := newTestFixture(t)
 	token := base64.StdEncoding.EncodeToString([]byte("secret")) // token should be base64 encoded
 	fixture.server.expAuth = fmt.Sprintf("Bearer %s", token)     // test on private repository
 	fixture.server.expEtag = "sha256:c5834dbce332cabe6ae68a364de171a50bf5b08024c27d7c08cc72878b4df7ff"
+
+	restConfig := []byte(fmt.Sprintf(`{
+		"url": %q,
+		"type": "oci",
+		"credentials": {
+			"bearer": {
+				"token": "secret"
+			}
+		}
+	}`, fixture.server.server.URL))
+
+	client, err := rest.New(restConfig, map[string]*keys.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fixture.setClient(client)
+
 	config := Config{}
 	if err := config.ValidateAndInjectDefaults(); err != nil {
 		t.Fatal(err)
 	}
+
 	firstResponse := Update{ETag: ""}
 	d := NewOCI(config, fixture.client, "ghcr.io/org/repo:latest", "/tmp/oci").WithCallback(func(_ context.Context, u Update) {
 		if firstResponse.ETag == "" {
@@ -111,17 +147,16 @@ func TestOCIEtag(t *testing.T) {
 	})
 
 	// fill firstResponse
-	err := d.oneShot(ctx)
-	if err != nil {
-		t.Fatal("unexpected error")
+	if err := d.oneShot(context.Background()); err != nil {
+		t.Fatal(err)
 	}
 	// Give time for some download events to occur
 	time.Sleep(1 * time.Second)
 
 	// second call to verify if nil bundle is returned and same etag
-	err = d.oneShot(ctx)
+	err = d.oneShot(context.Background())
 	if err != nil {
-		t.Fatal("unexpected error")
+		t.Fatal(err)
 	}
 }
 
@@ -151,4 +186,67 @@ func TestOCIPublicRegistry(t *testing.T) {
 	if err != nil {
 		t.Fatal("unexpected error")
 	}
+}
+
+func TestOCICustomAuthPlugin(t *testing.T) {
+	fixture := newTestFixture(t)
+	defer fixture.server.stop()
+
+	restConfig := []byte(fmt.Sprintf(`{
+		"url": %q,
+		"credentials": {
+			"plugin": "my_plugin"
+		}
+	}`, fixture.server.server.URL))
+
+	client, err := rest.New(
+		restConfig,
+		map[string]*keys.Config{},
+		rest.AuthPluginLookup(mockAuthPluginLookup),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fixture.setClient(client)
+
+	config := Config{}
+	if err := config.ValidateAndInjectDefaults(); err != nil {
+		t.Fatal(err)
+	}
+
+	tmpDir := t.TempDir()
+
+	d := NewOCI(config, fixture.client, "ghcr.io/org/repo:latest", tmpDir)
+
+	if err := d.oneShot(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func mockAuthPluginLookup(string) rest.HTTPAuthPlugin {
+	return &mockAuthPlugin{}
+}
+
+type mockAuthPlugin struct{}
+
+func (p *mockAuthPlugin) NewClient(c rest.Config) (*http.Client, error) {
+	tlsConfig, err := rest.DefaultTLSConfig(c)
+	if err != nil {
+		return nil, err
+	}
+
+	timeoutSec := 10
+
+	client := rest.DefaultRoundTripperClient(
+		tlsConfig,
+		int64(timeoutSec),
+	)
+
+	return client, nil
+}
+
+func (*mockAuthPlugin) Prepare(r *http.Request) error {
+	r.Header.Set("Authorization", "Bearer secret")
+	return nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,7 +24,7 @@ import (
 // ServiceOptions stores the options passed to ParseServicesConfig
 type ServiceOptions struct {
 	Raw        json.RawMessage
-	AuthPlugin func(string) rest.HTTPAuthPlugin
+	AuthPlugin rest.AuthPluginLookupFunc
 	Keys       map[string]*keys.Config
 	Logger     logging.Logger
 }

--- a/internal/providers/aws/ecr.go
+++ b/internal/providers/aws/ecr.go
@@ -1,0 +1,148 @@
+package aws
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/big"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/open-policy-agent/opa/internal/version"
+	"github.com/open-policy-agent/opa/logging"
+)
+
+// Values taken from
+// https://docs.aws.amazon.com/AmazonECR/latest/APIReference/API_GetAuthorizationToken.html
+const (
+	ecrGetAuthorizationTokenTarget = "AmazonEC2ContainerRegistry_V20150921.GetAuthorizationToken"
+	ecrEndpointFmt                 = "https://ecr.%s.amazonaws.com/"
+)
+
+// ECR is used to request tokens from Elastic Container Registry.
+type ECR struct {
+	// endpoint returns the region-specifc ECR endpoint.
+	// It can be overridden by tests.
+	endpoint func(region string) string
+
+	// client is used to send authorization tokens requests.
+	client *http.Client
+
+	logger logging.Logger
+}
+
+func NewECR(logger logging.Logger) *ECR {
+	return &ECR{
+		endpoint: func(region string) string {
+			return fmt.Sprintf(ecrEndpointFmt, region)
+		},
+		client: &http.Client{},
+		logger: logger,
+	}
+}
+
+// GetAuthorizationToken requests a token that can be used to authenticate image pull requests.
+func (e *ECR) GetAuthorizationToken(ctx context.Context, creds Credentials, signatureVersion string) (ECRAuthorizationToken, error) {
+	endpoint := e.endpoint(creds.RegionName)
+	body := strings.NewReader("{}")
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, body)
+	if err != nil {
+		return ECRAuthorizationToken{}, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("X-Amz-Target", ecrGetAuthorizationTokenTarget)
+	req.Header.Set("Accept-Encoding", "identity")
+	req.Header.Set("Content-Type", "application/x-amz-json-1.1")
+	req.Header.Set("User-Agent", version.UserAgent)
+
+	e.logger.Debug("Signing ECR authorization token request")
+
+	if err := SignRequest(req, "ecr", creds, time.Now(), signatureVersion); err != nil {
+		return ECRAuthorizationToken{}, fmt.Errorf("failed to sign request: %w", err)
+	}
+
+	resp, err := DoRequestWithClient(req, e.client, "ecr get authorization token", e.logger)
+	if err != nil {
+		return ECRAuthorizationToken{}, err
+	}
+
+	var data struct {
+		AuthorizationData []struct {
+			AuthorizationToken string      `json:"authorizationToken"`
+			ExpiresAt          json.Number `json:"expiresAt"`
+		} `json:"authorizationData"`
+	}
+	if err := json.Unmarshal(resp, &data); err != nil {
+		return ECRAuthorizationToken{}, fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+
+	if len(data.AuthorizationData) < 1 {
+		return ECRAuthorizationToken{}, errors.New("empty authorization data")
+	}
+
+	// The GetAuthorizationToken request returns a list of tokens for
+	// backwards compatibility reasons. We should only ever get one token back
+	// because we don't define any registryIDs in the request.
+	// See https://docs.aws.amazon.com/AmazonECR/latest/APIReference/API_GetAuthorizationToken.html#API_GetAuthorizationToken_ResponseSyntax
+	resultToken := data.AuthorizationData[0]
+
+	expiresAt, err := parseTimestamp(resultToken.ExpiresAt)
+	if err != nil {
+		return ECRAuthorizationToken{}, fmt.Errorf("failed to parse expiresAt: %w", err)
+	}
+
+	return ECRAuthorizationToken{
+		AuthorizationToken: resultToken.AuthorizationToken,
+		ExpiresAt:          expiresAt,
+	}, nil
+}
+
+// ECRAuthorizationToken can sign requests to AWS ECR.
+//
+// It corresponds to data returned by the AWS GetAuthorizationToken API.
+// See https://docs.aws.amazon.com/AmazonECR/latest/APIReference/API_AuthorizationData.html
+type ECRAuthorizationToken struct {
+	AuthorizationToken string
+	ExpiresAt          time.Time
+}
+
+// IsValid returns true if the token is set and not expired.
+// It respects a margin of error for time handling and will mark it as expired early.
+func (t *ECRAuthorizationToken) IsValid() bool {
+	const tokenExpirationMargin = 5 * time.Minute
+
+	expired := time.Now().Add(tokenExpirationMargin).After(t.ExpiresAt)
+	return t.AuthorizationToken != "" && !expired
+}
+
+var millisecondsFloat = new(big.Float).SetInt64(1e3)
+
+// parseTimestamp parses the AWS format for timestamps.
+// The time precision is in milliseconds.
+//
+// The logic is taken from
+// https://github.com/aws/aws-sdk-go/blob/41717ba2c04d3fd03f94d09ea984a10899574935/private/protocol/json/jsonutil/unmarshal.go#L294-L302
+func parseTimestamp(raw json.Number) (time.Time, error) {
+	s := raw.String()
+
+	float, ok := new(big.Float).SetString(s)
+	if !ok {
+		return time.Time{}, fmt.Errorf("not a float: %q", raw)
+	}
+
+	// The float is expected to be in second resolution with millisecond
+	// decimal places.
+	// Multiply by millisecondsFloat to obtain an integer in millisecond
+	// resolution
+	ms, _ := float.Mul(float, millisecondsFloat).Int64()
+
+	// Multiply again to obtain nanosecond resolution for time.Unix
+	ns := ms * 1e6
+
+	t := time.Unix(0, ns).UTC()
+
+	return t, nil
+}

--- a/internal/providers/aws/ecr_test.go
+++ b/internal/providers/aws/ecr_test.go
@@ -1,0 +1,118 @@
+package aws
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/open-policy-agent/opa/logging"
+)
+
+func TestECR(t *testing.T) {
+	payload := `{
+		"authorizationData": [
+			{
+				"authorizationToken": "secret",
+				"expiresAt": 1.676258918209E9
+			}
+		]
+	}`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if _, err := io.WriteString(w, payload); err != nil {
+			t.Fatalf("io.WriteString(w, payload) = %v", err)
+		}
+	}))
+	defer server.Close()
+
+	logger := logging.New()
+	logger.SetLevel(logging.Debug)
+
+	ecr := ECR{
+		endpoint: func(string) string { return server.URL },
+		client:   server.Client(),
+		logger:   logger,
+	}
+
+	creds := Credentials{}
+	token, err := ecr.GetAuthorizationToken(context.Background(), creds, "v4")
+	if err != nil {
+		t.Errorf("ecrServer.getAuthorizationToken = %v", err)
+	}
+
+	if token.AuthorizationToken != "secret" {
+		t.Errorf("token.AuthorizationToken = %q, want = %q", token.AuthorizationToken, "secret")
+	}
+
+	got := token.ExpiresAt
+	want := time.Date(2023, 02, 13, 03, 28, 38, 209*1000*1000, time.UTC)
+	if !got.Equal(want) {
+		t.Errorf("token.ExpiresAt = %v, want = %v", got, want)
+	}
+
+}
+
+func TestParseAWSTimestamp(t *testing.T) {
+	type testCase struct {
+		name       string
+		raw        json.Number
+		wantParsed time.Time
+		wantErr    bool
+	}
+
+	run := func(t *testing.T, tc testCase) {
+		got, err := parseTimestamp(tc.raw)
+		if err != nil && tc.wantErr == false {
+			t.Fatalf("expected no error, got: %s", err)
+		}
+
+		if err == nil && tc.wantErr {
+			t.Fatal("expected error")
+		}
+
+		if !tc.wantParsed.Equal(got) {
+			t.Fatalf("expected %s, got %s", tc.wantParsed, got)
+		}
+	}
+
+	testCases := []testCase{
+		{
+			name:    "empty raw value",
+			wantErr: true,
+		},
+		{
+			name:    "no number",
+			raw:     "no-number",
+			wantErr: true,
+		},
+		{
+			name:       "float in e notation",
+			raw:        "1.676258918209E9", // actual timestamp returned from the API
+			wantParsed: time.Date(2023, 02, 13, 03, 28, 38, 209*1000*1000, time.UTC),
+		},
+		{
+			name:       "raw float",
+			raw:        "1676258918.209",
+			wantParsed: time.Date(2023, 02, 13, 03, 28, 38, 209*1000*1000, time.UTC),
+		},
+		{
+			name:       "cuts down to ms resolution",
+			raw:        "1676258918.209123",
+			wantParsed: time.Date(2023, 02, 13, 03, 28, 38, 209*1000*1000, time.UTC),
+		},
+		{
+			name:       "integer without ms",
+			raw:        "1676258918",
+			wantParsed: time.Date(2023, 02, 13, 03, 28, 38, 0, time.UTC),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			run(t, tc)
+		})
+	}
+}

--- a/internal/providers/aws/signing_v4.go
+++ b/internal/providers/aws/signing_v4.go
@@ -5,9 +5,13 @@
 package aws
 
 import (
+	"bytes"
 	"crypto/hmac"
 	"crypto/sha256"
+	"errors"
 	"fmt"
+	"io"
+	"net/http"
 	"net/url"
 	"sort"
 	"strings"
@@ -74,6 +78,42 @@ func sortKeys(strMap map[string][]string) []string {
 	return keys
 }
 
+// SignRequest modifies an http.Request to include an AWS V4 signature based on the provided credentials.
+func SignRequest(req *http.Request, service string, creds Credentials, theTime time.Time, sigVersion string) error {
+	// General ref. https://docs.aws.amazon.com/general/latest/gr/sigv4_signing.html
+	// S3 ref. https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-auth-using-authorization-header.html
+	// APIGateway ref. https://docs.aws.amazon.com/apigateway/api-reference/signing-requests/
+
+	var body []byte
+	if req.Body == nil {
+		body = []byte("")
+	} else {
+		var err error
+		body, err = io.ReadAll(req.Body)
+		if err != nil {
+			return errors.New("error getting request body: " + err.Error())
+		}
+		// Since ReadAll consumed the body ReadCloser, we must create a new ReadCloser for the request so that the
+		// subsequent read starts from the beginning
+		req.Body = io.NopCloser(bytes.NewReader(body))
+	}
+
+	now := theTime.UTC()
+
+	if sigVersion == "4a" {
+		signedHeaders := SignV4a(req.Header, req.Method, req.URL, body, service, creds, now)
+		req.Header = signedHeaders
+	} else {
+		authHeader, awsHeaders := SignV4(req.Header, req.Method, req.URL, body, service, creds, now)
+		req.Header.Set("Authorization", authHeader)
+		for k, v := range awsHeaders {
+			req.Header.Add(k, v)
+		}
+	}
+
+	return nil
+}
+
 // SignV4 modifies a map[string][]string of headers to generate an AWS V4 signature + headers based on the config/credentials provided.
 func SignV4(headers map[string][]string, method string, theURL *url.URL, body []byte, service string, awsCreds Credentials, theTime time.Time) (string, map[string]string) {
 	// General ref. https://docs.aws.amazon.com/general/latest/gr/sigv4_signing.html
@@ -118,7 +158,7 @@ func SignV4(headers map[string][]string, method string, theURL *url.URL, body []
 	}
 
 	// the "canonical request" is the normalized version of the AWS service access
-	// that we're attempting to perform; in this case, a GET from an S3 bucket
+	// that we're attempting to perform
 	canonicalReq := method + "\n"               // HTTP method
 	canonicalReq += theURL.EscapedPath() + "\n" // URI-escaped path
 	canonicalReq += theURL.RawQuery + "\n"      // RAW Query String

--- a/internal/providers/aws/util.go
+++ b/internal/providers/aws/util.go
@@ -1,0 +1,45 @@
+package aws
+
+import (
+	"errors"
+	"io"
+	"net/http"
+
+	"github.com/open-policy-agent/opa/logging"
+)
+
+// DoRequestWithClient is a convenience function to get the body of an http response with
+// appropriate error-handling boilerplate and logging.
+func DoRequestWithClient(req *http.Request, client *http.Client, desc string, logger logging.Logger) ([]byte, error) {
+	resp, err := client.Do(req)
+	if err != nil {
+		// some kind of catastrophe talking to the service
+		return nil, errors.New(desc + " HTTP request failed: " + err.Error())
+	}
+	defer resp.Body.Close()
+
+	logger.WithFields(map[string]interface{}{
+		"url":     req.URL.String(),
+		"status":  resp.Status,
+		"headers": resp.Header,
+	}).Debug("Received response from " + desc + " service.")
+
+	if resp.StatusCode != 200 {
+		if logger.GetLevel() == logging.Debug {
+			body, err := io.ReadAll(resp.Body)
+			if err == nil {
+				logger.Debug("Error response with response body: %s", body)
+			}
+		}
+		// could be 404 for role that's not available, but cover all the bases
+		return nil, errors.New(desc + " HTTP request returned unexpected status: " + resp.Status)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		// deal with problems reading the body, whatever those might be
+		return nil, errors.New(desc + " HTTP response body could not be read: " + err.Error())
+	}
+
+	return body, nil
+}

--- a/plugins/rest/auth_test.go
+++ b/plugins/rest/auth_test.go
@@ -1,0 +1,93 @@
+package rest
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/open-policy-agent/opa/keys"
+)
+
+func TestOCIWithAWSAuthSetsUpECRAuthPlugin(t *testing.T) {
+	conf := `{
+		"type": "oci",
+		"credentials": {
+			"s3_signing": {
+				"environment_credentials": {}
+			}
+		}
+	}`
+
+	client, err := New([]byte(conf), map[string]*keys.Config{})
+	if err != nil {
+		t.Fatalf("New() = %v", err)
+	}
+
+	if _, err := client.config.Credentials.S3Signing.NewClient(client.config); err != nil {
+		t.Fatalf("S3Signing.NewClient() = %q", err)
+	}
+
+	if client.config.Credentials.S3Signing.AWSService != "ecr" {
+		t.Errorf("S3Signing.AWSService = %v, want = %v", client.config.Credentials.S3Signing.AWSService, "ecr")
+	}
+
+	if client.config.Credentials.S3Signing.ecrAuthPlugin == nil {
+		t.Errorf("S3Signing.ecrAuthPlugin isn't setup")
+	}
+}
+
+func TestOCIWithAWSWrongService(t *testing.T) {
+	conf := `{
+		"type": "oci",
+		"credentials": {
+			"s3_signing": {
+				"service": "ec2",
+				"environment_credentials": {}
+			}
+		}
+	}`
+
+	client, err := New([]byte(conf), map[string]*keys.Config{})
+	if err != nil {
+		t.Fatalf("New() = %q", err)
+	}
+
+	{
+		_, err := client.config.Credentials.S3Signing.NewClient(client.config)
+		if err == nil {
+			t.Fatalf("S3Signing.NewClient(): expected error")
+		}
+
+		wantContains := "ec2"
+		if !strings.Contains(err.Error(), wantContains) {
+			t.Errorf("got: %q, should contain: %q", err.Error(), wantContains)
+		}
+	}
+}
+
+func TestECRWithoutOCIFails(t *testing.T) {
+	conf := `{
+		"credentials": {
+			"s3_signing": {
+				"service": "ecr",
+				"environment_credentials": {}
+			}
+		}
+	}`
+
+	client, err := New([]byte(conf), map[string]*keys.Config{})
+	if err != nil {
+		t.Fatalf("New() = %q", err)
+	}
+
+	{
+		_, err := client.config.Credentials.S3Signing.NewClient(client.config)
+		if err == nil {
+			t.Fatal("S3Signing.NewClient(): expected error")
+		}
+
+		wantContains := "oci"
+		if !strings.Contains(err.Error(), wantContains) {
+			t.Fatalf("S3Signing.NewClient() = %q, should contain = %q", err, wantContains)
+		}
+	}
+}

--- a/plugins/rest/azure.go
+++ b/plugins/rest/azure.go
@@ -2,6 +2,7 @@ package rest
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -49,6 +50,10 @@ type azureManagedIdentitiesAuthPlugin struct {
 }
 
 func (ap *azureManagedIdentitiesAuthPlugin) NewClient(c Config) (*http.Client, error) {
+	if c.Type == "oci" {
+		return nil, errors.New("azure managed identities auth: OCI service not supported")
+	}
+
 	if ap.Endpoint == "" {
 		ap.Endpoint = azureIMDSEndpoint
 	}

--- a/plugins/rest/rest.go
+++ b/plugins/rest/rest.go
@@ -67,15 +67,19 @@ func (c *Config) Equal(other *Config) bool {
 	return reflect.DeepEqual(c, &otherWithoutLogger)
 }
 
-func (c *Config) authPlugin(authPluginLookup func(string) HTTPAuthPlugin) (HTTPAuthPlugin, error) {
+// An AuthPluginLookupFunc can lookup auth plugins by their name.
+type AuthPluginLookupFunc func(name string) HTTPAuthPlugin
+
+// AuthPlugin should be used to get an authentication method from the config.
+func (c *Config) AuthPlugin(lookup AuthPluginLookupFunc) (HTTPAuthPlugin, error) {
 	var candidate HTTPAuthPlugin
 	if c.Credentials.Plugin != nil {
-		if authPluginLookup == nil {
+		if lookup == nil {
 			// if no authPluginLookup function is passed we can't resolve the plugin
 			return nil, errors.New("missing auth plugin lookup function")
 		}
 
-		candidate := authPluginLookup(*c.Credentials.Plugin)
+		candidate := lookup(*c.Credentials.Plugin)
 		if candidate == nil {
 			return nil, fmt.Errorf("auth plugin %q not found", *c.Credentials.Plugin)
 		}
@@ -102,16 +106,16 @@ func (c *Config) authPlugin(authPluginLookup func(string) HTTPAuthPlugin) (HTTPA
 	return candidate, nil
 }
 
-func (c *Config) authHTTPClient(authPluginLookup func(string) HTTPAuthPlugin) (*http.Client, error) {
-	plugin, err := c.authPlugin(authPluginLookup)
+func (c *Config) authHTTPClient(lookup AuthPluginLookupFunc) (*http.Client, error) {
+	plugin, err := c.AuthPlugin(lookup)
 	if err != nil {
 		return nil, err
 	}
 	return plugin.NewClient(*c)
 }
 
-func (c *Config) authPrepare(req *http.Request, authPluginLookup func(string) HTTPAuthPlugin) error {
-	plugin, err := c.authPlugin(authPluginLookup)
+func (c *Config) authPrepare(req *http.Request, lookup AuthPluginLookupFunc) error {
+	plugin, err := c.AuthPlugin(lookup)
 	if err != nil {
 		return err
 	}
@@ -125,7 +129,7 @@ type Client struct {
 	json             *interface{}
 	config           Config
 	headers          map[string]string
-	authPluginLookup func(string) HTTPAuthPlugin
+	authPluginLookup AuthPluginLookupFunc
 	logger           logging.Logger
 	loggerFields     map[string]interface{}
 }
@@ -141,7 +145,7 @@ func Name(s string) func(*Client) {
 // It's intended to be used when creating a Client using New(). Usually this is passed
 // the plugins.AuthPlugin func, which retrieves a registered HTTPAuthPlugin from the
 // plugin manager.
-func AuthPluginLookup(l func(string) HTTPAuthPlugin) func(*Client) {
+func AuthPluginLookup(l AuthPluginLookupFunc) func(*Client) {
 	return func(c *Client) {
 		c.authPluginLookup = l
 	}
@@ -157,7 +161,6 @@ func Logger(l logging.Logger) func(*Client) {
 // New returns a new Client for config.
 func New(config []byte, keys map[string]*keys.Config, opts ...func(*Client)) (Client, error) {
 	var parsedConfig Config
-
 	if err := util.Unmarshal(config, &parsedConfig); err != nil {
 		return Client{}, err
 	}
@@ -165,9 +168,8 @@ func New(config []byte, keys map[string]*keys.Config, opts ...func(*Client)) (Cl
 	parsedConfig.URL = strings.TrimRight(parsedConfig.URL, "/")
 
 	if parsedConfig.ResponseHeaderTimeoutSeconds == nil {
-		timeout := new(int64)
-		*timeout = defaultResponseHeaderTimeoutSeconds
-		parsedConfig.ResponseHeaderTimeoutSeconds = timeout
+		timeout := defaultResponseHeaderTimeoutSeconds
+		parsedConfig.ResponseHeaderTimeoutSeconds = &timeout
 	}
 
 	parsedConfig.keys = keys
@@ -183,9 +185,16 @@ func New(config []byte, keys map[string]*keys.Config, opts ...func(*Client)) (Cl
 	if client.logger == nil {
 		client.logger = logging.Get()
 	}
+
 	client.config.logger = client.logger
 
 	return client, nil
+}
+
+// AuthPluginLookup returns the lookup function to find a custom registered
+// auth plugin by its name.
+func (c Client) AuthPluginLookup() AuthPluginLookupFunc {
+	return c.authPluginLookup
 }
 
 // Service returns the name of the service this Client is configured for.


### PR DESCRIPTION
This PR is an attempt to address solutions 2) and 3) of https://github.com/open-policy-agent/opa/issues/5553.
It mainly starts using the (now exposed) `Config.AuthPlugin()` function of the `rest` package in the [`download.OCIDownloader`](https://pkg.go.dev/github.com/open-policy-agent/opa@v0.48.0/download#OCIDownloader). This allows it to use any [`HTTPAuthPlugin`](https://pkg.go.dev/github.com/open-policy-agent/opa@v0.48.0/plugins/rest#HTTPAuthPlugin) that is defined in the `Config.Credentials` section and makes it much more consistent with behavior of the `download.Downloader` and potential other uses of the `rest` package.

`Config.AuthPlugin()` was only used internally in the [`Client.Do()`](https://pkg.go.dev/github.com/open-policy-agent/opa@v0.48.0/plugins/rest#Client.Do) function to authenticate requests. The OCIDownloader however, doesn't make use of the `rest.Client` directly but relies on a client from the external [containerd](https://pkg.go.dev/github.com/containerd/containerd@v1.6.15/remotes/docker) package. To make use of existing auth plugins, I decided to expose the function, then use it to get access to auth plugins to authenticate requests with them.

## Changes to the public API
```go
func (*Config) AuthPlugin(func(string) HTTPAuthPlugin) (HTTPAuthPlugin, error)
```
and
```go
func (Client) AuthPluginLookup() func(string) HTTPAuthPlugin
```
now become part of the public API.

The `OCIDownloader` should now support all previously available auth plugins. This still needs to be documented.

## Decision log
The `OCIDownloader` uses the `bearerAuthPlugin` differently than the `Downloader`/ `rest.Client` do. Specifically, it does not use tokens defined in the configuration as they are but encodes them to base64 before use. Bearer tokens read from a file path were not supported with the OCIDownloader until now. To make their use consistent with tokens passed via the config, those tokens are now also encoded to base64 for the user.

The `Config.AuthPlugin()` func returns a `rest.defaultAuthPlugin` when no authentication method is defined. This default plugin still defines a fairly advanced http client. The OCIDownloader on the other hand used to use a very simple client in those cases:
```go
http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: clientConfig.AllowInsecureTLS}}}
```
I've compared the resulting client implementations (see below https://github.com/open-policy-agent/opa/pull/5560#issuecomment-1384371608) and decided that it is fine (better) to use the client defined by the `rest.defaultAuthPlugin`.

EDIT: reflect current status
