### PR TITLE
ast: Improving error information when metadata yaml fails to compile

### DIFF
--- a/ast/parser.go
+++ b/ast/parser.go
@@ -15,6 +15,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"unicode/utf8"
 
 	"gopkg.in/yaml.v2"
 
@@ -2158,7 +2159,7 @@ func (b *metadataParser) Append(c *Comment) {
 	b.comments = append(b.comments, c)
 }
 
-var yamlLineErrRegex = regexp.MustCompile(`^yaml: line ([[:digit:]]+):`)
+var yamlLineErrRegex = regexp.MustCompile(`^yaml:(?: unmarshal errors:[\n\s]*)? line ([[:digit:]]+):`)
 
 func (b *metadataParser) Parse() (*Annotations, error) {
 
@@ -2169,19 +2170,21 @@ func (b *metadataParser) Parse() (*Annotations, error) {
 	}
 
 	if err := yaml.Unmarshal(b.buf.Bytes(), &raw); err != nil {
+		var comment *Comment
 		match := yamlLineErrRegex.FindStringSubmatch(err.Error())
 		if len(match) == 2 {
 			n, err2 := strconv.Atoi(match[1])
 			if err2 == nil {
 				index := n - 1 // line numbering is 1-based so subtract one from row
 				if index >= len(b.comments) {
-					b.loc = b.comments[len(b.comments)-1].Location
+					comment = b.comments[len(b.comments)-1]
 				} else {
-					b.loc = b.comments[index].Location
+					comment = b.comments[index]
 				}
+				b.loc = comment.Location
 			}
 		}
-		return nil, err
+		return nil, augmentYamlError(err, b.comments)
 	}
 
 	var result Annotations
@@ -2248,6 +2251,37 @@ func (b *metadataParser) Parse() (*Annotations, error) {
 
 	result.Location = b.loc
 	return &result, nil
+}
+
+func augmentYamlError(err error, comments []*Comment) error {
+	for _, comment := range comments {
+		txt := string(comment.Text)
+		parts := strings.Split(txt, ":")
+		if len(parts) > 1 {
+			parts = parts[1:]
+			var invalidSpaces []string
+			for partIndex, part := range parts {
+				if len(part) == 0 && partIndex == len(parts)-1 {
+					invalidSpaces = []string{}
+					break
+				}
+
+				r, _ := utf8.DecodeRuneInString(part)
+				if r == ' ' || r == '\t' {
+					invalidSpaces = []string{}
+					break
+				}
+
+				invalidSpaces = append(invalidSpaces, fmt.Sprintf("%+q", r))
+			}
+			if len(invalidSpaces) > 0 {
+				err = fmt.Errorf(
+					"%s\n  Hint: on line %d, symbol(s) %v immediately following a key/value separator ':' is not a legal yaml space character",
+					err.Error(), comment.Location.Row, invalidSpaces)
+			}
+		}
+	}
+	return err
 }
 
 func unwrapPair(pair map[string]interface{}) (k string, v interface{}) {

--- a/ast/parser.go
+++ b/ast/parser.go
@@ -2253,7 +2253,10 @@ func (b *metadataParser) Parse() (*Annotations, error) {
 	return &result, nil
 }
 
+// augmentYamlError augments a YAML error with hints intended to help the user figure out the cause of an otherwise cryptic error.
+// These are hints, instead of proper errors, because they are educated guesses, and aren't guaranteed to be correct.
 func augmentYamlError(err error, comments []*Comment) error {
+	// Adding hints for when key/value ':' separator isn't suffixed with a legal YAML space symbol
 	for _, comment := range comments {
 		txt := string(comment.Text)
 		parts := strings.Split(txt, ":")

--- a/ast/parser_test.go
+++ b/ast/parser_test.go
@@ -3987,6 +3987,7 @@ func TestAnnotations(t *testing.T) {
 		expNumComments int
 		expAnnotations []*Annotations
 		expError       string
+		expErrorRow    int
 	}{
 		{
 			note: "Single valid annotation",
@@ -4200,6 +4201,14 @@ public_servers[server] {
 }`,
 			expNumComments: 5,
 			expError:       "rego_parse_error: yaml: unmarshal errors:\n  line 3: cannot unmarshal !!str",
+			expErrorRow:    11,
+		},
+		{
+			note: "Ill-structured (invalid) annotation with control character (vertical tab)",
+			module: "# METADATA\n" +
+				"# title: foo\vbar\n" +
+				"package opa.examples\n",
+			expError: "rego_parse_error: yaml: control characters are not allowed",
 		},
 		{
 			note: "Indentation error in yaml",
@@ -4550,6 +4559,15 @@ p { input = "str" }`,
 				if tc.expError == "" || !strings.Contains(err.Error(), tc.expError) {
 					t.Fatalf("Unexpected parse error when getting annotations: %v", err)
 				}
+				if tc.expErrorRow != 0 {
+					if errs, ok := err.(Errors); !ok {
+						t.Fatalf("expected ast.Errors, got %v", err)
+					} else if len(errs) != 1 {
+						t.Fatalf("expected exactly one ast.Error, got %v: %v", len(errs), errs)
+					} else if loc := errs[0].Location; tc.expErrorRow != loc.Row {
+						t.Fatalf("expected error location row %v, got %v", tc.expErrorRow, loc.Row)
+					}
+				}
 				return
 			} else if tc.expError != "" {
 				t.Fatalf("Expected err: %v but no error from parse module", tc.expError)
@@ -4561,6 +4579,141 @@ p { input = "str" }`,
 
 			if annotationsCompare(tc.expAnnotations, mod.Annotations) != 0 {
 				t.Fatalf("expected %v but got %v", tc.expAnnotations, mod.Annotations)
+			}
+		})
+	}
+}
+
+func TestAnnotationsAugmentedError(t *testing.T) {
+	tests := []struct {
+		note           string
+		module         string
+		expAnnotations []*Annotations
+		expErrorHint   string
+		expErrorRow    int
+	}{
+		{
+			note: "no whitespace after key/value separator",
+			module: "package opa.examples\n" +
+				"\n" +
+				"# METADATA\n" +
+				"# description:p is true\n" +
+				"p := true\n",
+			expErrorHint: "Hint: on line 4, symbol(s) ['p'] immediately following a key/value separator ':' is not a legal yaml space character",
+			expErrorRow:  4,
+		},
+		{
+			note: "non-breaking whitespace (\\u00A0) after key/value separator",
+			module: "package opa.examples\n" +
+				"\n" +
+				"# METADATA\n" +
+				"# description:\u00A0p is true\n" +
+				"p := true\n",
+			expErrorHint: "Hint: on line 4, symbol(s) ['\\u00a0'] immediately following a key/value separator ':' is not a legal yaml space character",
+			expErrorRow:  4,
+		},
+		{
+			note: "non-breaking whitespace (\\u00A0) after key/value separator (different line)",
+			module: "package opa.examples\n" +
+				"\n" +
+				"# METADATA\n" +
+				"# title: P\n" +
+				"# description:\u00A0p is true\n" +
+				"p := true\n",
+			expErrorHint: "Hint: on line 5, symbol(s) ['\\u00a0'] immediately following a key/value separator ':' is not a legal yaml space character",
+			expErrorRow:  5,
+		},
+		{
+			note: "non-breaking whitespace (\\u00A0) after key/value separator (different line)",
+			module: "package opa.examples\n" +
+				"\n" +
+				"# METADATA\n" +
+				"# title:\n" +
+				"#   P\n" +
+				"# description:\u00A0p is true\n" +
+				"p := true\n",
+			expErrorHint: "Hint: on line 6, symbol(s) ['\\u00a0'] immediately following a key/value separator ':' is not a legal yaml space character",
+			expErrorRow:  6,
+		},
+		{
+			note: "non-breaking whitespace (\\u00A0) after key/value separator (different line)",
+			module: "package opa.examples\n" +
+				"\n" +
+				"# METADATA\n" +
+				"# title:\u00A0P\n" +
+				"# description: p is true\n" +
+				"# scope: rule\n" +
+				"p := true\n",
+			expErrorHint: "Hint: on line 4, symbol(s) ['\\u00a0'] immediately following a key/value separator ':' is not a legal yaml space character",
+			expErrorRow:  5,
+		},
+		{
+			note: "thin whitespace (\\u2009) after key/value separator",
+			module: "package opa.examples\n" +
+				"\n" +
+				"# METADATA\n" +
+				"# description:\u2009p is true\n" +
+				"p := true\n",
+			expErrorHint: "Hint: on line 4, symbol(s) ['\\u2009'] immediately following a key/value separator ':' is not a legal yaml space character",
+			expErrorRow:  4,
+		},
+		{
+			note: "ideographic whitespace (\\u3000) after key/value separator",
+			module: "package opa.examples\n" +
+				"\n" +
+				"# METADATA\n" +
+				"# description:\u3000p is true\n" +
+				"p := true\n",
+			expErrorHint: "Hint: on line 4, symbol(s) ['\\u3000'] immediately following a key/value separator ':' is not a legal yaml space character",
+			expErrorRow:  4,
+		},
+		{
+			note: "several offending runes after key/value separator on single line",
+			module: "package opa.examples\n" +
+				"\n" +
+				"# METADATA\n" +
+				"# descr:iption:\u3000p is true\n" +
+				"p := true\n",
+			expErrorHint: "Hint: on line 4, symbol(s) ['i' '\\u3000'] immediately following a key/value separator ':' is not a legal yaml space character",
+			expErrorRow:  4,
+		},
+		{
+			note: "several offending runes after key/value separator on single line",
+			module: "package opa.examples\n" +
+				"\n" +
+				"# METADATA\n" +
+				"# title:\u3000p\n" +
+				"# scope: rule\n" +
+				"# description:\u2009p is true\n" +
+				"p := true\n",
+			expErrorHint: "Hint: on line 4, symbol(s) ['\\u3000'] immediately following a key/value separator ':' is not a legal yaml space character\n" +
+				"  Hint: on line 6, symbol(s) ['\\u2009'] immediately following a key/value separator ':' is not a legal yaml space character",
+			expErrorRow: 5,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.note, func(t *testing.T) {
+			_, err := ParseModuleWithOpts("test.rego", tc.module, ParserOptions{
+				ProcessAnnotation: true,
+			})
+
+			if err == nil {
+				t.Fatalf("Expected err with hint: %v but no error from parse module", tc.expErrorHint)
+			}
+
+			msg := err.Error()
+			fmt.Println(msg)
+			if !strings.Contains(msg, tc.expErrorHint) {
+				t.Fatalf("Unexpected parse error when getting annotations: %v", err)
+			}
+
+			if errs, ok := err.(Errors); !ok {
+				t.Fatalf("expected ast.Errors, got %v", err)
+			} else if len(errs) != 1 {
+				t.Fatalf("expected exactly one ast.Error, got %v: %v", len(errs), errs)
+			} else if loc := errs[0].Location; tc.expErrorRow != loc.Row {
+				t.Fatalf("expected error location row %v, got %v", tc.expErrorRow, loc.Row)
 			}
 		})
 	}

--- a/ast/parser_test.go
+++ b/ast/parser_test.go
@@ -4702,9 +4702,7 @@ func TestAnnotationsAugmentedError(t *testing.T) {
 				t.Fatalf("Expected err with hint: %v but no error from parse module", tc.expErrorHint)
 			}
 
-			msg := err.Error()
-			fmt.Println(msg)
-			if !strings.Contains(msg, tc.expErrorHint) {
+			if !strings.Contains(err.Error(), tc.expErrorHint) {
 				t.Fatalf("Unexpected parse error when getting annotations: %v", err)
 			}
 


### PR DESCRIPTION
* Properly divine Rego location for yaml unmarshal errors
* Error hint for cases where non-legal space is used with yaml key/value separator `:`

Error message is augmented with a hint if the problem _could_ be a whitespace issue.

E.g. executing the following policy with `opa eval -f pretty -d policy.rego 'data.test'`
```rego
package test

# METADATA
# title: Foo
# description:Bar
p := rego.metadata.rule()
```
will spawn the following error message:
```
1 error occurred: /Users/johan/tmp/non-breaking_whitespace/policy.rego:5: rego_parse_error: yaml: line 3: could not find expected ':'
  Hint: on line 5, symbol(s) ['B'] immediately following a key/value separator ':' is not a legal yaml space character.
```

Fixes: #4475
Signed-off-by: Johan Fylling <johan.dev@fylling.se>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->
