### PR TITLE
[ast/opa parse] Support marshalling of all ast location data

### DIFF
--- a/ast/annotations.go
+++ b/ast/annotations.go
@@ -37,9 +37,9 @@ type (
 		Custom           map[string]interface{}       `json:"custom,omitempty"`
 		Location         *Location                    `json:"location,omitempty"`
 
-		comments   []*Comment
-		node       Node
-		jsonFields map[string]bool
+		comments    []*Comment
+		node        Node
+		jsonOptions JSONOptions
 	}
 
 	// SchemaAnnotation contains a schema declaration for the document identified by the path.
@@ -76,7 +76,7 @@ type (
 		Annotations *Annotations `json:"annotations,omitempty"`
 		Location    *Location    `json:"location,omitempty"` // The location of the node the annotations are applied to
 
-		jsonFields map[string]bool
+		jsonOptions JSONOptions
 
 		node Node // The node the annotations are applied to
 	}
@@ -180,8 +180,8 @@ func (a *Annotations) GetTargetPath() Ref {
 	}
 }
 
-func (a *Annotations) exposeJSONFields(jsonFields map[string]bool) {
-	a.jsonFields = jsonFields
+func (a *Annotations) setJSONOptions(opts JSONOptions) {
+	a.jsonOptions = opts
 }
 
 func (a *Annotations) MarshalJSON() ([]byte, error) {
@@ -225,7 +225,7 @@ func (a *Annotations) MarshalJSON() ([]byte, error) {
 		data["custom"] = a.Custom
 	}
 
-	if showLocation, ok := a.jsonFields["location"]; ok && showLocation {
+	if a.jsonOptions.MarshalOptions.IncludeLocation.Annotations {
 		if a.Location != nil {
 			data["location"] = a.Location
 		}
@@ -277,7 +277,7 @@ func (ar *AnnotationsRef) MarshalJSON() ([]byte, error) {
 		data["annotations"] = ar.Annotations
 	}
 
-	if showLocation, ok := ar.jsonFields["location"]; ok && showLocation {
+	if ar.jsonOptions.MarshalOptions.IncludeLocation.AnnotationsRef {
 		if ar.Location != nil {
 			data["location"] = ar.Location
 		}

--- a/ast/annotations.go
+++ b/ast/annotations.go
@@ -26,7 +26,6 @@ const (
 type (
 	// Annotations represents metadata attached to other AST nodes such as rules.
 	Annotations struct {
-		Location         *Location                    `json:"-"`
 		Scope            string                       `json:"scope"`
 		Title            string                       `json:"title,omitempty"`
 		Entrypoint       bool                         `json:"entrypoint,omitempty"`
@@ -36,8 +35,11 @@ type (
 		Authors          []*AuthorAnnotation          `json:"authors,omitempty"`
 		Schemas          []*SchemaAnnotation          `json:"schemas,omitempty"`
 		Custom           map[string]interface{}       `json:"custom,omitempty"`
-		node             Node
-		comments         []*Comment
+		Location         *Location                    `json:"location,omitempty"`
+
+		comments   []*Comment
+		node       Node
+		jsonFields map[string]bool
 	}
 
 	// SchemaAnnotation contains a schema declaration for the document identified by the path.
@@ -70,10 +72,13 @@ type (
 	}
 
 	AnnotationsRef struct {
-		Location    *Location    `json:"location"` // The location of the node the annotations are applied to
-		Path        Ref          `json:"path"`     // The path of the node the annotations are applied to
+		Path        Ref          `json:"path"` // The path of the node the annotations are applied to
 		Annotations *Annotations `json:"annotations,omitempty"`
-		node        Node         // The node the annotations are applied to
+		Location    *Location    `json:"location,omitempty"` // The location of the node the annotations are applied to
+
+		jsonFields map[string]bool
+
+		node Node // The node the annotations are applied to
 	}
 
 	AnnotationsRefSet []*AnnotationsRef
@@ -82,7 +87,7 @@ type (
 )
 
 func (a *Annotations) String() string {
-	bs, _ := json.Marshal(a)
+	bs, _ := a.MarshalJSON()
 	return string(bs)
 }
 
@@ -175,6 +180,60 @@ func (a *Annotations) GetTargetPath() Ref {
 	}
 }
 
+func (a *Annotations) exposeJSONFields(jsonFields map[string]bool) {
+	a.jsonFields = jsonFields
+}
+
+func (a *Annotations) MarshalJSON() ([]byte, error) {
+	if a == nil {
+		return []byte(`{"scope":""}`), nil
+	}
+
+	data := map[string]interface{}{
+		"scope": a.Scope,
+	}
+
+	if a.Title != "" {
+		data["title"] = a.Title
+	}
+
+	if a.Description != "" {
+		data["description"] = a.Description
+	}
+
+	if a.Entrypoint {
+		data["entrypoint"] = a.Entrypoint
+	}
+
+	if len(a.Organizations) > 0 {
+		data["organizations"] = a.Organizations
+	}
+
+	if len(a.RelatedResources) > 0 {
+		data["related_resources"] = a.RelatedResources
+	}
+
+	if len(a.Authors) > 0 {
+		data["authors"] = a.Authors
+	}
+
+	if len(a.Schemas) > 0 {
+		data["schemas"] = a.Schemas
+	}
+
+	if len(a.Custom) > 0 {
+		data["custom"] = a.Custom
+	}
+
+	if showLocation, ok := a.jsonFields["location"]; ok && showLocation {
+		if a.Location != nil {
+			data["location"] = a.Location
+		}
+	}
+
+	return json.Marshal(data)
+}
+
 func NewAnnotationsRef(a *Annotations) *AnnotationsRef {
 	var loc *Location
 	if a.node != nil {
@@ -207,6 +266,24 @@ func (ar *AnnotationsRef) GetRule() *Rule {
 	default:
 		return nil
 	}
+}
+
+func (ar *AnnotationsRef) MarshalJSON() ([]byte, error) {
+	data := map[string]interface{}{
+		"path": ar.Path,
+	}
+
+	if ar.Annotations != nil {
+		data["annotations"] = ar.Annotations
+	}
+
+	if showLocation, ok := ar.jsonFields["location"]; ok && showLocation {
+		if ar.Location != nil {
+			data["location"] = ar.Location
+		}
+	}
+
+	return json.Marshal(data)
 }
 
 func scopeCompare(s1, s2 string) int {

--- a/ast/annotations_test.go
+++ b/ast/annotations_test.go
@@ -52,8 +52,8 @@ p := 7`},
 	}
 
 	// Output:
-	// data.foo at foo.rego:5 has annotations {"scope":"subpackages","organizations":["Acme Corp."]}
-	// data.foo.bar at mod:3 has annotations {"scope":"package","description":"A couple of useful rules"}
+	// data.foo at foo.rego:5 has annotations {"organizations":["Acme Corp."],"scope":"subpackages"}
+	// data.foo.bar at mod:3 has annotations {"description":"A couple of useful rules","scope":"package"}
 	// data.foo.bar.p at mod:7 has annotations {"scope":"rule","title":"My Rule P"}
 }
 
@@ -102,8 +102,8 @@ p := 7`},
 
 	// Output:
 	// data.foo.bar.p at mod:7 has annotations {"scope":"rule","title":"My Rule P"}
-	// data.foo.bar at mod:3 has annotations {"scope":"package","description":"A couple of useful rules"}
-	// data.foo at foo.rego:5 has annotations {"scope":"subpackages","organizations":["Acme Corp."]}
+	// data.foo.bar at mod:3 has annotations {"description":"A couple of useful rules","scope":"package"}
+	// data.foo at foo.rego:5 has annotations {"organizations":["Acme Corp."],"scope":"subpackages"}
 }
 
 func TestAnnotationSet_Flatten(t *testing.T) {

--- a/ast/marshal.go
+++ b/ast/marshal.go
@@ -1,0 +1,8 @@
+package ast
+
+// customJSON is an interface that can be implemented by AST nodes that
+// allows the parser to set a list of fields and if the field is to be
+// included in the JSON output.
+type customJSON interface {
+	exposeJSONFields(map[string]bool)
+}

--- a/ast/marshal.go
+++ b/ast/marshal.go
@@ -1,8 +1,7 @@
 package ast
 
 // customJSON is an interface that can be implemented by AST nodes that
-// allows the parser to set a list of fields and if the field is to be
-// included in the JSON output.
+// allows the parser to set options for JSON operations on that node.
 type customJSON interface {
-	exposeJSONFields(map[string]bool)
+	setJSONOptions(JSONOptions)
 }

--- a/ast/marshal_test.go
+++ b/ast/marshal_test.go
@@ -1,7 +1,6 @@
 package ast
 
 import (
-	"bytes"
 	"encoding/json"
 	"testing"
 
@@ -172,46 +171,6 @@ func TestPackage_MarshalJSON(t *testing.T) {
 	}
 }
 
-func TestPackage_UnmarshalJSON(t *testing.T) {
-	testCases := map[string]struct {
-		JSON            string
-		ExpectedPackage *Package
-	}{
-		"base case": {
-			JSON: `{"path":[]}`,
-			ExpectedPackage: &Package{
-				Path: EmptyRef(),
-			},
-		},
-		"location case": {
-			JSON: `{"location":{"file":"example.rego","row":1,"col":2},"path":[]}`,
-			ExpectedPackage: &Package{
-				Path:     EmptyRef(),
-				Location: NewLocation([]byte{}, "example.rego", 1, 2),
-			},
-		},
-	}
-
-	for name, data := range testCases {
-		t.Run(name, func(t *testing.T) {
-			var pkg Package
-			err := json.Unmarshal([]byte(data.JSON), &pkg)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			if !pkg.Equal(data.ExpectedPackage) {
-				t.Fatalf("expected:\n%#v got\n%#v", data.ExpectedPackage, pkg)
-			}
-			if data.ExpectedPackage.Location != nil {
-				if !pkg.Location.Equal(data.ExpectedPackage.Location) {
-					t.Fatalf("expected location:\n%#v got\n%#v", data.ExpectedPackage, pkg)
-				}
-			}
-		})
-	}
-}
-
 // TODO: Comment has inconsistent JSON field names starting with an upper case letter. Comment Location is
 // also always included for legacy reasons
 func TestComment_MarshalJSON(t *testing.T) {
@@ -263,58 +222,6 @@ func TestComment_MarshalJSON(t *testing.T) {
 
 			if got != exp {
 				t.Fatalf("expected:\n%s got\n%s", exp, got)
-			}
-		})
-	}
-}
-
-// TODO: Comment has inconsistent JSON field names starting with an upper case letter. Comment Location is
-// also always included for legacy reasons
-func TestComment_UnmarshalJSON(t *testing.T) {
-	testCases := map[string]struct {
-		JSON            string
-		ExpectedComment *Comment
-	}{
-		"base case": {
-			JSON: `{"Text":"Y29tbWVudA=="}`,
-			ExpectedComment: &Comment{
-				Text: []byte("comment"),
-			},
-		},
-		"location case": {
-			JSON: `{"Location":{"file":"example.rego","row":1,"col":2},"Text":"Y29tbWVudA=="}`,
-			ExpectedComment: &Comment{
-				Text:     []byte("comment"),
-				Location: NewLocation([]byte{}, "example.rego", 1, 2),
-			},
-		},
-	}
-
-	for name, data := range testCases {
-		t.Run(name, func(t *testing.T) {
-			var comment Comment
-			err := json.Unmarshal([]byte(data.JSON), &comment)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			equal := true
-			if data.ExpectedComment.Location != nil {
-				if comment.Location == nil {
-					t.Fatal("expected location to be non-nil")
-				}
-
-				// comment.Equal will check the location too
-				if !comment.Equal(data.ExpectedComment) {
-					equal = false
-				}
-			} else {
-				if !bytes.Equal(comment.Text, data.ExpectedComment.Text) {
-					equal = false
-				}
-			}
-			if !equal {
-				t.Fatalf("expected:\n%#v got\n%#v", data.ExpectedComment, comment)
 			}
 		})
 	}
@@ -393,57 +300,6 @@ func TestImport_MarshalJSON(t *testing.T) {
 	}
 }
 
-func TestImport_UnmarshalJSON(t *testing.T) {
-	testCases := map[string]struct {
-		JSON           string
-		ExpectedImport *Import
-	}{
-		"base case": {
-			JSON: `{"path":{"type":"string","value":"example"}}`,
-			ExpectedImport: func() *Import {
-				v, _ := InterfaceToValue("example")
-				term := Term{
-					Value: v,
-				}
-				return &Import{Path: &term}
-			}(),
-		},
-		"location case": {
-			JSON: `{"location":{"file":"example.rego","row":1,"col":2},"path":{"type":"string","value":"example"}}`,
-			ExpectedImport: func() *Import {
-				v, _ := InterfaceToValue("example")
-				term := Term{
-					Value:    v,
-					Location: NewLocation([]byte{}, "example.rego", 1, 2),
-				}
-				return &Import{
-					Path:     &term,
-					Location: NewLocation([]byte{}, "example.rego", 1, 2),
-				}
-			}(),
-		},
-	}
-
-	for name, data := range testCases {
-		t.Run(name, func(t *testing.T) {
-			var imp Import
-			err := json.Unmarshal([]byte(data.JSON), &imp)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			if !imp.Equal(data.ExpectedImport) {
-				t.Fatalf("expected:\n%#v got\n%#v", data.ExpectedImport, imp)
-			}
-			if data.ExpectedImport.Location != nil {
-				if !imp.Location.Equal(data.ExpectedImport.Location) {
-					t.Fatalf("expected location:\n%#v got\n%#v", data.ExpectedImport, imp)
-				}
-			}
-		})
-	}
-}
-
 func TestRule_MarshalJSON(t *testing.T) {
 	rawModule := `
 	package foo
@@ -506,62 +362,6 @@ func TestRule_MarshalJSON(t *testing.T) {
 
 			if got != exp {
 				t.Fatalf("expected:\n%s got\n%s", exp, got)
-			}
-		})
-	}
-}
-
-func TestRule_UnmarshalJSON(t *testing.T) {
-	rawModule := `
-	package foo
-	
-	# comment
-	
-	allow { true }
-	`
-
-	module, err := ParseModuleWithOpts("example.rego", rawModule, ParserOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	rule := module.Rules[0]
-	// text is not marshalled to JSON so we just drop it in our examples
-	rule.Location.Text = nil
-
-	testCases := map[string]struct {
-		JSON         string
-		ExpectedRule *Rule
-	}{
-		"base case": {
-			JSON: `{"body":[{"terms":{"type":"boolean","value":true},"location":{"file":"example.rego","row":6,"col":10},"index":0}],"head":{"name":"allow","value":{"type":"boolean","value":true},"location":{"file":"example.rego","row":6,"col":2},"ref":[{"type":"var","value":"allow"}]}}`,
-			ExpectedRule: func() *Rule {
-				r := rule.Copy()
-				r.Location = nil
-				return r
-			}(),
-		},
-		"location case": {
-			JSON:         `{"body":[{"terms":{"type":"boolean","value":true},"location":{"file":"example.rego","row":6,"col":10},"index":0}],"head":{"name":"allow","value":{"type":"boolean","value":true},"location":{"file":"example.rego","row":6,"col":2},"ref":[{"type":"var","value":"allow"}]},"location":{"file":"example.rego","row":6,"col":2}}`,
-			ExpectedRule: rule,
-		},
-	}
-
-	for name, data := range testCases {
-		t.Run(name, func(t *testing.T) {
-			var rule Rule
-			err := json.Unmarshal([]byte(data.JSON), &rule)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			if !rule.Equal(data.ExpectedRule) {
-				t.Fatalf("expected:\n%#v got\n%#v", data.ExpectedRule, rule)
-			}
-			if data.ExpectedRule.Location != nil {
-				if !rule.Location.Equal(data.ExpectedRule.Location) {
-					t.Fatalf("expected location:\n%#v got\n%#v", data.ExpectedRule.Location, rule.Location)
-				}
 			}
 		})
 	}
@@ -630,62 +430,6 @@ func TestHead_MarshalJSON(t *testing.T) {
 
 			if got != exp {
 				t.Fatalf("expected:\n%s got\n%s", exp, got)
-			}
-		})
-	}
-}
-
-func TestHead_UnmarshalJSON(t *testing.T) {
-	rawModule := `
-	package foo
-
-	# comment
-
-	allow { true }
-	`
-
-	module, err := ParseModuleWithOpts("example.rego", rawModule, ParserOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	head := module.Rules[0].Head
-	// text is not marshalled to JSON so we just drop it in our examples
-	head.Location.Text = nil
-
-	testCases := map[string]struct {
-		JSON         string
-		ExpectedHead *Head
-	}{
-		"base case": {
-			JSON: `{"name":"allow","value":{"type":"boolean","value":true},"ref":[{"type":"var","value":"allow"}]}`,
-			ExpectedHead: func() *Head {
-				h := head.Copy()
-				h.Location = nil
-				return h
-			}(),
-		},
-		"location case": {
-			JSON:         `{"name":"allow","value":{"type":"boolean","value":true},"ref":[{"type":"var","value":"allow"}],"location":{"file":"example.rego","row":6,"col":2}}`,
-			ExpectedHead: head,
-		},
-	}
-
-	for name, data := range testCases {
-		t.Run(name, func(t *testing.T) {
-			var head Head
-			err := json.Unmarshal([]byte(data.JSON), &head)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			if !head.Equal(data.ExpectedHead) {
-				t.Fatalf("expected:\n%#v got\n%#v", data.ExpectedHead, head)
-			}
-			if data.ExpectedHead.Location != nil {
-				if !head.Location.Equal(data.ExpectedHead.Location) {
-					t.Fatalf("expected location:\n%#v got\n%#v", data.ExpectedHead.Location, head.Location)
-				}
 			}
 		})
 	}
@@ -864,53 +608,6 @@ func TestSomeDecl_MarshalJSON(t *testing.T) {
 	}
 }
 
-func TestSomeDecl_UnmarshalJSON(t *testing.T) {
-	v, _ := InterfaceToValue("example")
-	term := &Term{
-		Value:    v,
-		Location: NewLocation([]byte{}, "example.rego", 1, 2),
-	}
-
-	testCases := map[string]struct {
-		JSON             string
-		ExpectedSomeDecl *SomeDecl
-	}{
-		"base case": {
-			JSON: `{"symbols":[{"type":"string","value":"example"}]}`,
-			ExpectedSomeDecl: &SomeDecl{
-				Symbols: []*Term{term},
-			},
-		},
-		"location case": {
-			JSON: `{"location":{"file":"example.rego","row":1,"col":2},"symbols":[{"type":"string","value":"example"}]}`,
-			ExpectedSomeDecl: &SomeDecl{
-				Symbols:  []*Term{term},
-				Location: NewLocation([]byte{}, "example.rego", 1, 2),
-			},
-		},
-	}
-
-	for name, data := range testCases {
-		t.Run(name, func(t *testing.T) {
-			var d SomeDecl
-			err := json.Unmarshal([]byte(data.JSON), &d)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			if len(d.Symbols) != len(data.ExpectedSomeDecl.Symbols) {
-				t.Fatalf("expected:\n%#v got\n%#v", data.ExpectedSomeDecl.Symbols, d.Symbols)
-			}
-
-			if data.ExpectedSomeDecl.Location != nil {
-				if !d.Location.Equal(data.ExpectedSomeDecl.Location) {
-					t.Fatalf("expected location:\n%#v got\n%#v", data.ExpectedSomeDecl.Location, d.Location)
-				}
-			}
-		})
-	}
-}
-
 func TestEvery_MarshalJSON(t *testing.T) {
 
 	rawModule := `
@@ -974,73 +671,6 @@ allow {
 	}
 }
 
-func TestEvery_UnmarshalJSON(t *testing.T) {
-	rawModule := `
-package foo
-
-import future.keywords.every
-	
-allow { 
-	every e in [1,2,3] {
-		e == 1
-    }
-}
-`
-
-	module, err := ParseModuleWithOpts("example.rego", rawModule, ParserOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	every, ok := module.Rules[0].Body[0].Terms.(*Every)
-	if !ok {
-		t.Fatal("expected every term")
-	}
-
-	testCases := map[string]struct {
-		JSON          string
-		ExpectedEvery *Every
-	}{
-		"base case": {
-			JSON: `{"body":[{"index":0,"terms":[{"type":"ref","value":[{"type":"var","value":"equal"}]},{"type":"var","value":"e"},{"type":"number","value":1}]}],"domain":{"type":"array","value":[{"type":"number","value":1},{"type":"number","value":2},{"type":"number","value":3}]},"key":null,"value":{"type":"var","value":"e"}}`,
-			ExpectedEvery: func() *Every {
-				e := every.Copy()
-				e.Location = nil
-				return e
-			}(),
-		},
-		"location case": {
-			JSON: `{"body":[{"index":0,"terms":[{"type":"ref","value":[{"type":"var","value":"equal"}]},{"type":"var","value":"e"},{"type":"number","value":1}]}],"domain":{"type":"array","value":[{"type":"number","value":1},{"type":"number","value":2},{"type":"number","value":3}]},"key":null,"location":{"file":"example.rego","row":7,"col":2},"value":{"type":"var","value":"e"}}`,
-			ExpectedEvery: func() *Every {
-				e := every.Copy()
-				// text is not marshalled to JSON so we just drop it in our examples
-				e.Location.Text = []byte{}
-				return e
-			}(),
-		},
-	}
-
-	for name, data := range testCases {
-		t.Run(name, func(t *testing.T) {
-			var e Every
-			err := json.Unmarshal([]byte(data.JSON), &e)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			if e.String() != data.ExpectedEvery.String() {
-				t.Fatalf("expected:\n%#v got\n%#v", data.ExpectedEvery.String(), e.String())
-			}
-
-			if data.ExpectedEvery.Location != nil {
-				if !e.Location.Equal(data.ExpectedEvery.Location) {
-					t.Fatalf("expected location:\n%#v got\n%#v", data.ExpectedEvery.Location, e.Location)
-				}
-			}
-		})
-	}
-}
-
 func TestWith_MarshalJSON(t *testing.T) {
 
 	rawModule := `
@@ -1094,69 +724,6 @@ b {
 
 			if got != exp {
 				t.Fatalf("expected:\n%s got\n%s", exp, got)
-			}
-		})
-	}
-}
-
-func TestWith_UnmarshalJSON(t *testing.T) {
-
-	rawModule := `
-package foo
-
-a {input}
-
-b {
-	a with input as 1
-}
-`
-
-	module, err := ParseModuleWithOpts("example.rego", rawModule, ParserOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	with := module.Rules[1].Body[0].With[0]
-
-	testCases := map[string]struct {
-		JSON         string
-		ExpectedWith *With
-	}{
-		"base case": {
-			JSON: `{"target":{"type":"ref","value":[{"type":"var","value":"input"}]},"value":{"type":"number","value":1}}`,
-			ExpectedWith: func() *With {
-				w := with.Copy()
-				w.Location = nil
-				return w
-			}(),
-		},
-		"location case": {
-			JSON: `{"location":{"file":"example.rego","row":7,"col":4},"target":{"type":"ref","value":[{"type":"var","value":"input"}]},"value":{"type":"number","value":1}}`,
-			ExpectedWith: func() *With {
-				e := with.Copy()
-				// text is not marshalled to JSON so we just drop it in our examples
-				e.Location.Text = []byte{}
-				return e
-			}(),
-		},
-	}
-
-	for name, data := range testCases {
-		t.Run(name, func(t *testing.T) {
-			var w With
-			err := json.Unmarshal([]byte(data.JSON), &w)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			if w.String() != data.ExpectedWith.String() {
-				t.Fatalf("expected:\n%#v got\n%#v", data.ExpectedWith.String(), w.String())
-			}
-
-			if data.ExpectedWith.Location != nil {
-				if !w.Location.Equal(data.ExpectedWith.Location) {
-					t.Fatalf("expected location:\n%#v got\n%#v", data.ExpectedWith.Location, w.Location)
-				}
 			}
 		})
 	}
@@ -1237,62 +804,6 @@ func TestAnnotations_MarshalJSON(t *testing.T) {
 	}
 }
 
-func TestAnnotations_UnmarshalJSON(t *testing.T) {
-
-	testCases := map[string]struct {
-		JSON                string
-		ExpectedAnnotations *Annotations
-	}{
-		"base case": {
-			JSON: `{"custom":{"foo":"bar"},"description":"My desc","entrypoint":true,"organizations":["org1"],"scope":"rule","title":"My rule"}`,
-			ExpectedAnnotations: &Annotations{
-				Scope:         "rule",
-				Title:         "My rule",
-				Entrypoint:    true,
-				Organizations: []string{"org1"},
-				Description:   "My desc",
-				Custom: map[string]interface{}{
-					"foo": "bar",
-				},
-			},
-		},
-		"location case": {
-			JSON: `{"custom":{"foo":"bar"},"description":"My desc","entrypoint":true,"location":{"file":"example.rego","row":1,"col":4},"organizations":["org1"],"scope":"rule","title":"My rule"}`,
-			ExpectedAnnotations: &Annotations{
-				Scope:         "rule",
-				Title:         "My rule",
-				Entrypoint:    true,
-				Organizations: []string{"org1"},
-				Description:   "My desc",
-				Custom: map[string]interface{}{
-					"foo": "bar",
-				},
-				Location: NewLocation([]byte{}, "example.rego", 1, 4),
-			},
-		},
-	}
-
-	for name, data := range testCases {
-		t.Run(name, func(t *testing.T) {
-			var a Annotations
-			err := json.Unmarshal([]byte(data.JSON), &a)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			if a.String() != data.ExpectedAnnotations.String() {
-				t.Fatalf("expected:\n%#v got\n%#v", data.ExpectedAnnotations.String(), a.String())
-			}
-
-			if data.ExpectedAnnotations.Location != nil {
-				if !a.Location.Equal(data.ExpectedAnnotations.Location) {
-					t.Fatalf("expected location:\n%#v got\n%#v", data.ExpectedAnnotations.Location, a.Location)
-				}
-			}
-		})
-	}
-}
-
 func TestAnnotationsRef_MarshalJSON(t *testing.T) {
 
 	testCases := map[string]struct {
@@ -1345,54 +856,6 @@ func TestAnnotationsRef_MarshalJSON(t *testing.T) {
 
 			if got != exp {
 				t.Fatalf("expected:\n%s got\n%s", exp, got)
-			}
-		})
-	}
-}
-
-func TestAnnotationsRef_UnmarshalJSON(t *testing.T) {
-
-	testCases := map[string]struct {
-		JSON                   string
-		ExpectedAnnotationsRef *AnnotationsRef
-	}{
-		"base case": {
-			JSON: `{"annotations":{"scope":""},"path":[]}`,
-			ExpectedAnnotationsRef: &AnnotationsRef{
-				Path:        []*Term{},
-				Annotations: &Annotations{},
-			},
-		},
-		"location case": {
-			JSON: `{"custom":{"foo":"bar"},"description":"My desc","entrypoint":true,"location":{"file":"example.rego","row":1,"col":4},"organizations":["org1"],"scope":"rule","title":"My rule"}`,
-			ExpectedAnnotationsRef: &AnnotationsRef{
-				Path:        []*Term{},
-				Annotations: &Annotations{},
-				Location:    NewLocation([]byte{}, "example.rego", 1, 4),
-			},
-		},
-	}
-
-	for name, data := range testCases {
-		t.Run(name, func(t *testing.T) {
-			var a AnnotationsRef
-			err := json.Unmarshal([]byte(data.JSON), &a)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			if got, exp := len(a.Path), len(data.ExpectedAnnotationsRef.Path); exp != got {
-				t.Fatalf("expected:\n%#v got\n%#v", exp, got)
-			}
-
-			if got, exp := a.Annotations.String(), data.ExpectedAnnotationsRef.Annotations.String(); exp != got {
-				t.Fatalf("expected:\n%#v got\n%#v", exp, got)
-			}
-
-			if data.ExpectedAnnotationsRef.Location != nil {
-				if !a.Location.Equal(data.ExpectedAnnotationsRef.Location) {
-					t.Fatalf("expected location:\n%#v got\n%#v", data.ExpectedAnnotationsRef.Location, a.Location)
-				}
 			}
 		})
 	}

--- a/ast/marshal_test.go
+++ b/ast/marshal_test.go
@@ -1,0 +1,1329 @@
+package ast
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/open-policy-agent/opa/util"
+)
+
+func TestTerm_MarshalJSON(t *testing.T) {
+	testCases := map[string]struct {
+		Term         *Term
+		ExpectedJSON string
+	}{
+		"base case": {
+			Term: func() *Term {
+				v, _ := InterfaceToValue("example")
+				return &Term{
+					Value:    v,
+					Location: NewLocation([]byte{}, "example.rego", 1, 2),
+				}
+			}(),
+			ExpectedJSON: `{"type":"string","value":"example"}`,
+		},
+		"location excluded": {
+			Term: func() *Term {
+				v, _ := InterfaceToValue("example")
+				return &Term{
+					Value:    v,
+					Location: NewLocation([]byte{}, "example.rego", 1, 2),
+					jsonFields: map[string]bool{
+						"location": false,
+					},
+				}
+			}(),
+			ExpectedJSON: `{"type":"string","value":"example"}`,
+		},
+		"location included": {
+			Term: func() *Term {
+				v, _ := InterfaceToValue("example")
+				return &Term{
+					Value:    v,
+					Location: NewLocation([]byte{}, "example.rego", 1, 2),
+					jsonFields: map[string]bool{
+						"location": true,
+					},
+				}
+			}(),
+			ExpectedJSON: `{"location":{"file":"example.rego","row":1,"col":2},"type":"string","value":"example"}`,
+		},
+	}
+
+	for name, data := range testCases {
+		t.Run(name, func(t *testing.T) {
+			bs := util.MustMarshalJSON(data.Term)
+			got := string(bs)
+			exp := data.ExpectedJSON
+
+			if got != exp {
+				t.Fatalf("expected:\n%s got\n%s", exp, got)
+			}
+		})
+	}
+}
+
+func TestTerm_UnmarshalJSON(t *testing.T) {
+	testCases := map[string]struct {
+		JSON         string
+		ExpectedTerm *Term
+	}{
+		"base case": {
+			JSON: `{"type":"string","value":"example"}`,
+			ExpectedTerm: func() *Term {
+				v, _ := InterfaceToValue("example")
+				return &Term{
+					Value: v,
+				}
+			}(),
+		},
+		"location case": {
+			JSON: `{"location":{"file":"example.rego","row":1,"col":2},"type":"string","value":"example"}`,
+			ExpectedTerm: func() *Term {
+				v, _ := InterfaceToValue("example")
+				return &Term{
+					Value:    v,
+					Location: NewLocation([]byte{}, "example.rego", 1, 2),
+				}
+			}(),
+		},
+	}
+
+	for name, data := range testCases {
+		t.Run(name, func(t *testing.T) {
+			var term Term
+			err := json.Unmarshal([]byte(data.JSON), &term)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !term.Equal(data.ExpectedTerm) {
+				t.Fatalf("expected:\n%#v got\n%#v", data.ExpectedTerm, term)
+			}
+			if data.ExpectedTerm.Location != nil {
+				if !term.Location.Equal(data.ExpectedTerm.Location) {
+					t.Fatalf("expected location:\n%#v got\n%#v", data.ExpectedTerm, term)
+				}
+			}
+		})
+	}
+}
+
+func TestPackage_MarshalJSON(t *testing.T) {
+	testCases := map[string]struct {
+		Package      *Package
+		ExpectedJSON string
+	}{
+		"base case": {
+			Package: &Package{
+				Path: EmptyRef(),
+			},
+			ExpectedJSON: `{"path":[]}`,
+		},
+		"location excluded": {
+			Package: &Package{
+				Path:     EmptyRef(),
+				Location: NewLocation([]byte{}, "example.rego", 1, 2),
+				jsonFields: map[string]bool{
+					"location": false,
+				},
+			},
+			ExpectedJSON: `{"path":[]}`,
+		},
+		"location included": {
+			Package: &Package{
+				Path:     EmptyRef(),
+				Location: NewLocation([]byte{}, "example.rego", 1, 2),
+				jsonFields: map[string]bool{
+					"location": true,
+				},
+			},
+			ExpectedJSON: `{"location":{"file":"example.rego","row":1,"col":2},"path":[]}`,
+		},
+	}
+
+	for name, data := range testCases {
+		t.Run(name, func(t *testing.T) {
+			bs := util.MustMarshalJSON(data.Package)
+			got := string(bs)
+			exp := data.ExpectedJSON
+
+			if got != exp {
+				t.Fatalf("expected:\n%s got\n%s", exp, got)
+			}
+		})
+	}
+}
+
+func TestPackage_UnmarshalJSON(t *testing.T) {
+	testCases := map[string]struct {
+		JSON            string
+		ExpectedPackage *Package
+	}{
+		"base case": {
+			JSON: `{"path":[]}`,
+			ExpectedPackage: &Package{
+				Path: EmptyRef(),
+			},
+		},
+		"location case": {
+			JSON: `{"location":{"file":"example.rego","row":1,"col":2},"path":[]}`,
+			ExpectedPackage: &Package{
+				Path:     EmptyRef(),
+				Location: NewLocation([]byte{}, "example.rego", 1, 2),
+			},
+		},
+	}
+
+	for name, data := range testCases {
+		t.Run(name, func(t *testing.T) {
+			var pkg Package
+			err := json.Unmarshal([]byte(data.JSON), &pkg)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !pkg.Equal(data.ExpectedPackage) {
+				t.Fatalf("expected:\n%#v got\n%#v", data.ExpectedPackage, pkg)
+			}
+			if data.ExpectedPackage.Location != nil {
+				if !pkg.Location.Equal(data.ExpectedPackage.Location) {
+					t.Fatalf("expected location:\n%#v got\n%#v", data.ExpectedPackage, pkg)
+				}
+			}
+		})
+	}
+}
+
+// TODO: Comment has inconsistent JSON field names starting with an upper case letter. Comment Location is
+// also always included for legacy reasons
+func TestComment_MarshalJSON(t *testing.T) {
+	testCases := map[string]struct {
+		Comment      *Comment
+		ExpectedJSON string
+	}{
+		"base case": {
+			Comment: &Comment{
+				Text: []byte("comment"),
+			},
+			ExpectedJSON: `{"Text":"Y29tbWVudA=="}`,
+		},
+		"location excluded, still included for legacy reasons": {
+			Comment: &Comment{
+				Text:     []byte("comment"),
+				Location: NewLocation([]byte{}, "example.rego", 1, 2),
+				jsonFields: map[string]bool{
+					"location": false, // ignored
+				},
+			},
+			ExpectedJSON: `{"Location":{"file":"example.rego","row":1,"col":2},"Text":"Y29tbWVudA=="}`,
+		},
+		"location included": {
+			Comment: &Comment{
+				Text:     []byte("comment"),
+				Location: NewLocation([]byte{}, "example.rego", 1, 2),
+				jsonFields: map[string]bool{
+					"location": true, // ignored
+				},
+			},
+			ExpectedJSON: `{"Location":{"file":"example.rego","row":1,"col":2},"Text":"Y29tbWVudA=="}`,
+		},
+	}
+
+	for name, data := range testCases {
+		t.Run(name, func(t *testing.T) {
+			bs := util.MustMarshalJSON(data.Comment)
+			got := string(bs)
+			exp := data.ExpectedJSON
+
+			if got != exp {
+				t.Fatalf("expected:\n%s got\n%s", exp, got)
+			}
+		})
+	}
+}
+
+// TODO: Comment has inconsistent JSON field names starting with an upper case letter. Comment Location is
+// also always included for legacy reasons
+func TestComment_UnmarshalJSON(t *testing.T) {
+	testCases := map[string]struct {
+		JSON            string
+		ExpectedComment *Comment
+	}{
+		"base case": {
+			JSON: `{"Text":"Y29tbWVudA=="}`,
+			ExpectedComment: &Comment{
+				Text: []byte("comment"),
+			},
+		},
+		"location case": {
+			JSON: `{"Location":{"file":"example.rego","row":1,"col":2},"Text":"Y29tbWVudA=="}`,
+			ExpectedComment: &Comment{
+				Text:     []byte("comment"),
+				Location: NewLocation([]byte{}, "example.rego", 1, 2),
+			},
+		},
+	}
+
+	for name, data := range testCases {
+		t.Run(name, func(t *testing.T) {
+			var comment Comment
+			err := json.Unmarshal([]byte(data.JSON), &comment)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			equal := true
+			if data.ExpectedComment.Location != nil {
+				if comment.Location == nil {
+					t.Fatal("expected location to be non-nil")
+				}
+
+				// comment.Equal will check the location too
+				if !comment.Equal(data.ExpectedComment) {
+					equal = false
+				}
+			} else {
+				if !bytes.Equal(comment.Text, data.ExpectedComment.Text) {
+					equal = false
+				}
+			}
+			if !equal {
+				t.Fatalf("expected:\n%#v got\n%#v", data.ExpectedComment, comment)
+			}
+		})
+	}
+}
+
+func TestImport_MarshalJSON(t *testing.T) {
+	testCases := map[string]struct {
+		Import       *Import
+		ExpectedJSON string
+	}{
+		"base case": {
+			Import: func() *Import {
+				v, _ := InterfaceToValue("example")
+				term := Term{
+					Value:    v,
+					Location: NewLocation([]byte{}, "example.rego", 1, 2),
+				}
+				return &Import{Path: &term}
+			}(),
+			ExpectedJSON: `{"path":{"type":"string","value":"example"}}`,
+		},
+		"location excluded": {
+			Import: func() *Import {
+				v, _ := InterfaceToValue("example")
+				term := Term{
+					Value:    v,
+					Location: NewLocation([]byte{}, "example.rego", 1, 2),
+				}
+				return &Import{
+					Path:     &term,
+					Location: NewLocation([]byte{}, "example.rego", 1, 2),
+					jsonFields: map[string]bool{
+						"location": false,
+					},
+				}
+			}(),
+			ExpectedJSON: `{"path":{"type":"string","value":"example"}}`,
+		},
+		"location included": {
+			Import: func() *Import {
+				v, _ := InterfaceToValue("example")
+				term := Term{
+					Value:    v,
+					Location: NewLocation([]byte{}, "example.rego", 1, 2),
+				}
+				return &Import{
+					Path:     &term,
+					Location: NewLocation([]byte{}, "example.rego", 1, 2),
+					jsonFields: map[string]bool{
+						"location": true,
+					},
+				}
+			}(),
+			ExpectedJSON: `{"location":{"file":"example.rego","row":1,"col":2},"path":{"type":"string","value":"example"}}`,
+		},
+	}
+
+	for name, data := range testCases {
+		t.Run(name, func(t *testing.T) {
+			bs := util.MustMarshalJSON(data.Import)
+			got := string(bs)
+			exp := data.ExpectedJSON
+
+			if got != exp {
+				t.Fatalf("expected:\n%s got\n%s", exp, got)
+			}
+		})
+	}
+}
+
+func TestImport_UnmarshalJSON(t *testing.T) {
+	testCases := map[string]struct {
+		JSON           string
+		ExpectedImport *Import
+	}{
+		"base case": {
+			JSON: `{"path":{"type":"string","value":"example"}}`,
+			ExpectedImport: func() *Import {
+				v, _ := InterfaceToValue("example")
+				term := Term{
+					Value: v,
+				}
+				return &Import{Path: &term}
+			}(),
+		},
+		"location case": {
+			JSON: `{"location":{"file":"example.rego","row":1,"col":2},"path":{"type":"string","value":"example"}}`,
+			ExpectedImport: func() *Import {
+				v, _ := InterfaceToValue("example")
+				term := Term{
+					Value:    v,
+					Location: NewLocation([]byte{}, "example.rego", 1, 2),
+				}
+				return &Import{
+					Path:     &term,
+					Location: NewLocation([]byte{}, "example.rego", 1, 2),
+					jsonFields: map[string]bool{
+						"location": false,
+					},
+				}
+			}(),
+		},
+	}
+
+	for name, data := range testCases {
+		t.Run(name, func(t *testing.T) {
+			var imp Import
+			err := json.Unmarshal([]byte(data.JSON), &imp)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !imp.Equal(data.ExpectedImport) {
+				t.Fatalf("expected:\n%#v got\n%#v", data.ExpectedImport, imp)
+			}
+			if data.ExpectedImport.Location != nil {
+				if !imp.Location.Equal(data.ExpectedImport.Location) {
+					t.Fatalf("expected location:\n%#v got\n%#v", data.ExpectedImport, imp)
+				}
+			}
+		})
+	}
+}
+
+func TestRule_MarshalJSON(t *testing.T) {
+	rawModule := `
+	package foo
+	
+	# comment
+	
+	allow { true }
+	`
+
+	module, err := ParseModuleWithOpts("example.rego", rawModule, ParserOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rule := module.Rules[0]
+
+	testCases := map[string]struct {
+		Rule         *Rule
+		ExpectedJSON string
+	}{
+		"base case": {
+			Rule:         rule.Copy(),
+			ExpectedJSON: `{"body":[{"index":0,"terms":{"type":"boolean","value":true}}],"head":{"name":"allow","value":{"type":"boolean","value":true},"ref":[{"type":"var","value":"allow"}]}}`,
+		},
+		"location excluded": {
+			Rule: func() *Rule {
+				r := rule.Copy()
+				r.jsonFields = map[string]bool{
+					"location": false,
+				}
+				return r
+			}(),
+			ExpectedJSON: `{"body":[{"index":0,"terms":{"type":"boolean","value":true}}],"head":{"name":"allow","value":{"type":"boolean","value":true},"ref":[{"type":"var","value":"allow"}]}}`,
+		},
+		"location included": {
+			Rule: func() *Rule {
+				r := rule.Copy()
+				r.jsonFields = map[string]bool{
+					"location": true,
+				}
+				return r
+			}(),
+			ExpectedJSON: `{"body":[{"index":0,"terms":{"type":"boolean","value":true}}],"head":{"name":"allow","value":{"type":"boolean","value":true},"ref":[{"type":"var","value":"allow"}]},"location":{"file":"example.rego","row":6,"col":2}}`,
+		},
+	}
+
+	for name, data := range testCases {
+		t.Run(name, func(t *testing.T) {
+			bs := util.MustMarshalJSON(data.Rule)
+			got := string(bs)
+			exp := data.ExpectedJSON
+
+			if got != exp {
+				t.Fatalf("expected:\n%s got\n%s", exp, got)
+			}
+		})
+	}
+}
+
+func TestRule_UnmarshalJSON(t *testing.T) {
+	rawModule := `
+	package foo
+	
+	# comment
+	
+	allow { true }
+	`
+
+	module, err := ParseModuleWithOpts("example.rego", rawModule, ParserOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rule := module.Rules[0]
+	// text is not marshalled to JSON so we just drop it in our examples
+	rule.Location.Text = nil
+
+	testCases := map[string]struct {
+		JSON         string
+		ExpectedRule *Rule
+	}{
+		"base case": {
+			JSON: `{"body":[{"terms":{"type":"boolean","value":true},"location":{"file":"example.rego","row":6,"col":10},"index":0}],"head":{"name":"allow","value":{"type":"boolean","value":true},"location":{"file":"example.rego","row":6,"col":2},"ref":[{"type":"var","value":"allow"}]}}`,
+			ExpectedRule: func() *Rule {
+				r := rule.Copy()
+				r.Location = nil
+				return r
+			}(),
+		},
+		"location case": {
+			JSON:         `{"body":[{"terms":{"type":"boolean","value":true},"location":{"file":"example.rego","row":6,"col":10},"index":0}],"head":{"name":"allow","value":{"type":"boolean","value":true},"location":{"file":"example.rego","row":6,"col":2},"ref":[{"type":"var","value":"allow"}]},"location":{"file":"example.rego","row":6,"col":2}}`,
+			ExpectedRule: rule,
+		},
+	}
+
+	for name, data := range testCases {
+		t.Run(name, func(t *testing.T) {
+			var rule Rule
+			err := json.Unmarshal([]byte(data.JSON), &rule)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !rule.Equal(data.ExpectedRule) {
+				t.Fatalf("expected:\n%#v got\n%#v", data.ExpectedRule, rule)
+			}
+			if data.ExpectedRule.Location != nil {
+				if !rule.Location.Equal(data.ExpectedRule.Location) {
+					t.Fatalf("expected location:\n%#v got\n%#v", data.ExpectedRule.Location, rule.Location)
+				}
+			}
+		})
+	}
+}
+
+func TestHead_MarshalJSON(t *testing.T) {
+	rawModule := `
+	package foo
+	
+	# comment
+	
+	allow { true }
+	`
+
+	module, err := ParseModuleWithOpts("example.rego", rawModule, ParserOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	head := module.Rules[0].Head
+
+	testCases := map[string]struct {
+		Head         *Head
+		ExpectedJSON string
+	}{
+		"base case": {
+			Head:         head.Copy(),
+			ExpectedJSON: `{"name":"allow","value":{"type":"boolean","value":true},"ref":[{"type":"var","value":"allow"}]}`,
+		},
+		"location excluded": {
+			Head: func() *Head {
+				h := head.Copy()
+				h.jsonFields = map[string]bool{
+					"location": false,
+				}
+				return h
+			}(),
+			ExpectedJSON: `{"name":"allow","value":{"type":"boolean","value":true},"ref":[{"type":"var","value":"allow"}]}`,
+		},
+		"location included": {
+			Head: func() *Head {
+				h := head.Copy()
+				h.jsonFields = map[string]bool{
+					"location": true,
+				}
+				return h
+			}(),
+			ExpectedJSON: `{"name":"allow","value":{"type":"boolean","value":true},"ref":[{"type":"var","value":"allow"}],"location":{"file":"example.rego","row":6,"col":2}}`,
+		},
+	}
+
+	for name, data := range testCases {
+		t.Run(name, func(t *testing.T) {
+			bs := util.MustMarshalJSON(data.Head)
+			got := string(bs)
+			exp := data.ExpectedJSON
+
+			if got != exp {
+				t.Fatalf("expected:\n%s got\n%s", exp, got)
+			}
+		})
+	}
+}
+
+func TestHead_UnmarshalJSON(t *testing.T) {
+	rawModule := `
+	package foo
+
+	# comment
+
+	allow { true }
+	`
+
+	module, err := ParseModuleWithOpts("example.rego", rawModule, ParserOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	head := module.Rules[0].Head
+	// text is not marshalled to JSON so we just drop it in our examples
+	head.Location.Text = nil
+
+	testCases := map[string]struct {
+		JSON         string
+		ExpectedHead *Head
+	}{
+		"base case": {
+			JSON: `{"name":"allow","value":{"type":"boolean","value":true},"ref":[{"type":"var","value":"allow"}]}`,
+			ExpectedHead: func() *Head {
+				h := head.Copy()
+				h.Location = nil
+				return h
+			}(),
+		},
+		"location case": {
+			JSON:         `{"name":"allow","value":{"type":"boolean","value":true},"ref":[{"type":"var","value":"allow"}],"location":{"file":"example.rego","row":6,"col":2}}`,
+			ExpectedHead: head,
+		},
+	}
+
+	for name, data := range testCases {
+		t.Run(name, func(t *testing.T) {
+			var head Head
+			err := json.Unmarshal([]byte(data.JSON), &head)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !head.Equal(data.ExpectedHead) {
+				t.Fatalf("expected:\n%#v got\n%#v", data.ExpectedHead, head)
+			}
+			if data.ExpectedHead.Location != nil {
+				if !head.Location.Equal(data.ExpectedHead.Location) {
+					t.Fatalf("expected location:\n%#v got\n%#v", data.ExpectedHead.Location, head.Location)
+				}
+			}
+		})
+	}
+}
+
+func TestExpr_MarshalJSON(t *testing.T) {
+	rawModule := `
+	package foo
+	
+	# comment
+	
+	allow { true }
+	`
+
+	module, err := ParseModuleWithOpts("example.rego", rawModule, ParserOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expr := module.Rules[0].Body[0]
+
+	testCases := map[string]struct {
+		Expr         *Expr
+		ExpectedJSON string
+	}{
+		"base case": {
+			Expr:         expr.Copy(),
+			ExpectedJSON: `{"index":0,"terms":{"type":"boolean","value":true}}`,
+		},
+		"location excluded": {
+			Expr: func() *Expr {
+				e := expr.Copy()
+				e.jsonFields = map[string]bool{
+					"location": false,
+				}
+				return e
+			}(),
+			ExpectedJSON: `{"index":0,"terms":{"type":"boolean","value":true}}`,
+		},
+		"location included": {
+			Expr: func() *Expr {
+				e := expr.Copy()
+				e.jsonFields = map[string]bool{
+					"location": true,
+				}
+				return e
+			}(),
+			ExpectedJSON: `{"index":0,"location":{"file":"example.rego","row":6,"col":10},"terms":{"type":"boolean","value":true}}`,
+		},
+	}
+
+	for name, data := range testCases {
+		t.Run(name, func(t *testing.T) {
+			bs := util.MustMarshalJSON(data.Expr)
+			got := string(bs)
+			exp := data.ExpectedJSON
+
+			if got != exp {
+				t.Fatalf("expected:\n%s got\n%s", exp, got)
+			}
+		})
+	}
+}
+
+func TestExpr_UnmarshalJSON(t *testing.T) {
+	rawModule := `
+	package foo
+
+	# comment
+
+	allow { true }
+	`
+
+	module, err := ParseModuleWithOpts("example.rego", rawModule, ParserOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expr := module.Rules[0].Body[0]
+	// text is not marshalled to JSON so we just drop it in our examples
+	expr.Location.Text = nil
+
+	testCases := map[string]struct {
+		JSON         string
+		ExpectedExpr *Expr
+	}{
+		"base case": {
+			JSON: `{"index":0,"terms":{"type":"boolean","value":true}}`,
+			ExpectedExpr: func() *Expr {
+				e := expr.Copy()
+				e.Location = nil
+				return e
+			}(),
+		},
+		"location case": {
+			JSON:         `{"index":0,"location":{"file":"example.rego","row":6,"col":10},"terms":{"type":"boolean","value":true}}`,
+			ExpectedExpr: expr,
+		},
+	}
+
+	for name, data := range testCases {
+		t.Run(name, func(t *testing.T) {
+			var expr Expr
+			err := json.Unmarshal([]byte(data.JSON), &expr)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !expr.Equal(data.ExpectedExpr) {
+				t.Fatalf("expected:\n%#v got\n%#v", data.ExpectedExpr, expr)
+			}
+			if data.ExpectedExpr.Location != nil {
+				if !expr.Location.Equal(data.ExpectedExpr.Location) {
+					t.Fatalf("expected location:\n%#v got\n%#v", data.ExpectedExpr.Location, expr.Location)
+				}
+			}
+		})
+	}
+}
+
+func TestSomeDecl_MarshalJSON(t *testing.T) {
+	v, _ := InterfaceToValue("example")
+	term := &Term{
+		Value:    v,
+		Location: NewLocation([]byte{}, "example.rego", 1, 2),
+	}
+
+	testCases := map[string]struct {
+		SomeDecl     *SomeDecl
+		ExpectedJSON string
+	}{
+		"base case": {
+			SomeDecl: &SomeDecl{
+				Symbols:  []*Term{term},
+				Location: NewLocation([]byte{}, "example.rego", 1, 2),
+			},
+			ExpectedJSON: `{"symbols":[{"type":"string","value":"example"}]}`,
+		},
+		"location excluded": {
+			SomeDecl: &SomeDecl{
+				Symbols:    []*Term{term},
+				Location:   NewLocation([]byte{}, "example.rego", 1, 2),
+				jsonFields: map[string]bool{"location": false},
+			},
+			ExpectedJSON: `{"symbols":[{"type":"string","value":"example"}]}`,
+		},
+		"location included": {
+			SomeDecl: &SomeDecl{
+				Symbols:    []*Term{term},
+				Location:   NewLocation([]byte{}, "example.rego", 1, 2),
+				jsonFields: map[string]bool{"location": true},
+			},
+			ExpectedJSON: `{"location":{"file":"example.rego","row":1,"col":2},"symbols":[{"type":"string","value":"example"}]}`,
+		},
+	}
+
+	for name, data := range testCases {
+		t.Run(name, func(t *testing.T) {
+			bs := util.MustMarshalJSON(data.SomeDecl)
+			got := string(bs)
+			exp := data.ExpectedJSON
+
+			if got != exp {
+				t.Fatalf("expected:\n%s got\n%s", exp, got)
+			}
+		})
+	}
+}
+
+func TestSomeDecl_UnmarshalJSON(t *testing.T) {
+	v, _ := InterfaceToValue("example")
+	term := &Term{
+		Value:    v,
+		Location: NewLocation([]byte{}, "example.rego", 1, 2),
+	}
+
+	testCases := map[string]struct {
+		JSON             string
+		ExpectedSomeDecl *SomeDecl
+	}{
+		"base case": {
+			JSON: `{"symbols":[{"type":"string","value":"example"}]}`,
+			ExpectedSomeDecl: &SomeDecl{
+				Symbols: []*Term{term},
+			},
+		},
+		"location case": {
+			JSON: `{"location":{"file":"example.rego","row":1,"col":2},"symbols":[{"type":"string","value":"example"}]}`,
+			ExpectedSomeDecl: &SomeDecl{
+				Symbols:  []*Term{term},
+				Location: NewLocation([]byte{}, "example.rego", 1, 2),
+			},
+		},
+	}
+
+	for name, data := range testCases {
+		t.Run(name, func(t *testing.T) {
+			var d SomeDecl
+			err := json.Unmarshal([]byte(data.JSON), &d)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if len(d.Symbols) != len(data.ExpectedSomeDecl.Symbols) {
+				t.Fatalf("expected:\n%#v got\n%#v", data.ExpectedSomeDecl.Symbols, d.Symbols)
+			}
+
+			if data.ExpectedSomeDecl.Location != nil {
+				if !d.Location.Equal(data.ExpectedSomeDecl.Location) {
+					t.Fatalf("expected location:\n%#v got\n%#v", data.ExpectedSomeDecl.Location, d.Location)
+				}
+			}
+		})
+	}
+}
+
+func TestEvery_MarshalJSON(t *testing.T) {
+
+	rawModule := `
+package foo
+
+import future.keywords.every
+	
+allow { 
+	every e in [1,2,3] {
+		e == 1
+    }
+}
+`
+
+	module, err := ParseModuleWithOpts("example.rego", rawModule, ParserOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	every, ok := module.Rules[0].Body[0].Terms.(*Every)
+	if !ok {
+		t.Fatal("expected every term")
+	}
+
+	testCases := map[string]struct {
+		Every        *Every
+		ExpectedJSON string
+	}{
+		"base case": {
+			Every:        every,
+			ExpectedJSON: `{"body":[{"index":0,"terms":[{"type":"ref","value":[{"type":"var","value":"equal"}]},{"type":"var","value":"e"},{"type":"number","value":1}]}],"domain":{"type":"array","value":[{"type":"number","value":1},{"type":"number","value":2},{"type":"number","value":3}]},"key":null,"value":{"type":"var","value":"e"}}`,
+		},
+		"location excluded": {
+			Every: func() *Every {
+				e := every.Copy()
+				e.jsonFields = map[string]bool{"location": false}
+				return e
+			}(),
+			ExpectedJSON: `{"body":[{"index":0,"terms":[{"type":"ref","value":[{"type":"var","value":"equal"}]},{"type":"var","value":"e"},{"type":"number","value":1}]}],"domain":{"type":"array","value":[{"type":"number","value":1},{"type":"number","value":2},{"type":"number","value":3}]},"key":null,"value":{"type":"var","value":"e"}}`,
+		},
+		"location included": {
+			Every: func() *Every {
+				e := every.Copy()
+				e.jsonFields = map[string]bool{"location": true}
+				return e
+			}(),
+			ExpectedJSON: `{"body":[{"index":0,"terms":[{"type":"ref","value":[{"type":"var","value":"equal"}]},{"type":"var","value":"e"},{"type":"number","value":1}]}],"domain":{"type":"array","value":[{"type":"number","value":1},{"type":"number","value":2},{"type":"number","value":3}]},"key":null,"location":{"file":"example.rego","row":7,"col":2},"value":{"type":"var","value":"e"}}`,
+		},
+	}
+
+	for name, data := range testCases {
+		t.Run(name, func(t *testing.T) {
+			bs := util.MustMarshalJSON(data.Every)
+			got := string(bs)
+			exp := data.ExpectedJSON
+
+			if got != exp {
+				t.Fatalf("expected:\n%s got\n%s", exp, got)
+			}
+		})
+	}
+}
+
+func TestEvery_UnmarshalJSON(t *testing.T) {
+	rawModule := `
+package foo
+
+import future.keywords.every
+	
+allow { 
+	every e in [1,2,3] {
+		e == 1
+    }
+}
+`
+
+	module, err := ParseModuleWithOpts("example.rego", rawModule, ParserOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	every, ok := module.Rules[0].Body[0].Terms.(*Every)
+	if !ok {
+		t.Fatal("expected every term")
+	}
+
+	testCases := map[string]struct {
+		JSON          string
+		ExpectedEvery *Every
+	}{
+		"base case": {
+			JSON: `{"body":[{"index":0,"terms":[{"type":"ref","value":[{"type":"var","value":"equal"}]},{"type":"var","value":"e"},{"type":"number","value":1}]}],"domain":{"type":"array","value":[{"type":"number","value":1},{"type":"number","value":2},{"type":"number","value":3}]},"key":null,"value":{"type":"var","value":"e"}}`,
+			ExpectedEvery: func() *Every {
+				e := every.Copy()
+				e.Location = nil
+				return e
+			}(),
+		},
+		"location case": {
+			JSON: `{"body":[{"index":0,"terms":[{"type":"ref","value":[{"type":"var","value":"equal"}]},{"type":"var","value":"e"},{"type":"number","value":1}]}],"domain":{"type":"array","value":[{"type":"number","value":1},{"type":"number","value":2},{"type":"number","value":3}]},"key":null,"location":{"file":"example.rego","row":7,"col":2},"value":{"type":"var","value":"e"}}`,
+			ExpectedEvery: func() *Every {
+				e := every.Copy()
+				// text is not marshalled to JSON so we just drop it in our examples
+				e.Location.Text = []byte{}
+				return e
+			}(),
+		},
+	}
+
+	for name, data := range testCases {
+		t.Run(name, func(t *testing.T) {
+			var e Every
+			err := json.Unmarshal([]byte(data.JSON), &e)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if e.String() != data.ExpectedEvery.String() {
+				t.Fatalf("expected:\n%#v got\n%#v", data.ExpectedEvery.String(), e.String())
+			}
+
+			if data.ExpectedEvery.Location != nil {
+				if !e.Location.Equal(data.ExpectedEvery.Location) {
+					t.Fatalf("expected location:\n%#v got\n%#v", data.ExpectedEvery.Location, e.Location)
+				}
+			}
+		})
+	}
+}
+
+func TestWith_MarshalJSON(t *testing.T) {
+
+	rawModule := `
+package foo
+
+a {input}
+
+b {
+	a with input as 1
+}
+`
+
+	module, err := ParseModuleWithOpts("example.rego", rawModule, ParserOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	with := module.Rules[1].Body[0].With[0]
+
+	testCases := map[string]struct {
+		With         *With
+		ExpectedJSON string
+	}{
+		"base case": {
+			With:         with,
+			ExpectedJSON: `{"target":{"type":"ref","value":[{"type":"var","value":"input"}]},"value":{"type":"number","value":1}}`,
+		},
+		"location excluded": {
+			With: func() *With {
+				w := with.Copy()
+				w.jsonFields = map[string]bool{"location": false}
+				return w
+			}(),
+			ExpectedJSON: `{"target":{"type":"ref","value":[{"type":"var","value":"input"}]},"value":{"type":"number","value":1}}`,
+		},
+		"location included": {
+			With: func() *With {
+				w := with.Copy()
+				w.jsonFields = map[string]bool{"location": true}
+				return w
+			}(),
+			ExpectedJSON: `{"location":{"file":"example.rego","row":7,"col":4},"target":{"type":"ref","value":[{"type":"var","value":"input"}]},"value":{"type":"number","value":1}}`,
+		},
+	}
+
+	for name, data := range testCases {
+		t.Run(name, func(t *testing.T) {
+			bs := util.MustMarshalJSON(data.With)
+			got := string(bs)
+			exp := data.ExpectedJSON
+
+			if got != exp {
+				t.Fatalf("expected:\n%s got\n%s", exp, got)
+			}
+		})
+	}
+}
+
+func TestWith_UnmarshalJSON(t *testing.T) {
+
+	rawModule := `
+package foo
+
+a {input}
+
+b {
+	a with input as 1
+}
+`
+
+	module, err := ParseModuleWithOpts("example.rego", rawModule, ParserOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	with := module.Rules[1].Body[0].With[0]
+
+	testCases := map[string]struct {
+		JSON         string
+		ExpectedWith *With
+	}{
+		"base case": {
+			JSON: `{"target":{"type":"ref","value":[{"type":"var","value":"input"}]},"value":{"type":"number","value":1}}`,
+			ExpectedWith: func() *With {
+				w := with.Copy()
+				w.Location = nil
+				return w
+			}(),
+		},
+		"location case": {
+			JSON: `{"location":{"file":"example.rego","row":7,"col":4},"target":{"type":"ref","value":[{"type":"var","value":"input"}]},"value":{"type":"number","value":1}}`,
+			ExpectedWith: func() *With {
+				e := with.Copy()
+				// text is not marshalled to JSON so we just drop it in our examples
+				e.Location.Text = []byte{}
+				return e
+			}(),
+		},
+	}
+
+	for name, data := range testCases {
+		t.Run(name, func(t *testing.T) {
+			var w With
+			err := json.Unmarshal([]byte(data.JSON), &w)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if w.String() != data.ExpectedWith.String() {
+				t.Fatalf("expected:\n%#v got\n%#v", data.ExpectedWith.String(), w.String())
+			}
+
+			if data.ExpectedWith.Location != nil {
+				if !w.Location.Equal(data.ExpectedWith.Location) {
+					t.Fatalf("expected location:\n%#v got\n%#v", data.ExpectedWith.Location, w.Location)
+				}
+			}
+		})
+	}
+}
+
+func TestAnnotations_MarshalJSON(t *testing.T) {
+
+	testCases := map[string]struct {
+		Annotations  *Annotations
+		ExpectedJSON string
+	}{
+		"base case": {
+			Annotations: &Annotations{
+				Scope:         "rule",
+				Title:         "My rule",
+				Entrypoint:    true,
+				Organizations: []string{"org1"},
+				Description:   "My desc",
+				Custom: map[string]interface{}{
+					"foo": "bar",
+				},
+				Location: NewLocation([]byte{}, "example.rego", 1, 4),
+			},
+			ExpectedJSON: `{"custom":{"foo":"bar"},"description":"My desc","entrypoint":true,"organizations":["org1"],"scope":"rule","title":"My rule"}`,
+		},
+		"location excluded": {
+			Annotations: &Annotations{
+				Scope:         "rule",
+				Title:         "My rule",
+				Entrypoint:    true,
+				Organizations: []string{"org1"},
+				Description:   "My desc",
+				Custom: map[string]interface{}{
+					"foo": "bar",
+				},
+				Location: NewLocation([]byte{}, "example.rego", 1, 4),
+
+				jsonFields: map[string]bool{"location": false},
+			},
+			ExpectedJSON: `{"custom":{"foo":"bar"},"description":"My desc","entrypoint":true,"organizations":["org1"],"scope":"rule","title":"My rule"}`,
+		},
+		"location included": {
+			Annotations: &Annotations{
+				Scope:         "rule",
+				Title:         "My rule",
+				Entrypoint:    true,
+				Organizations: []string{"org1"},
+				Description:   "My desc",
+				Custom: map[string]interface{}{
+					"foo": "bar",
+				},
+				Location: NewLocation([]byte{}, "example.rego", 1, 4),
+
+				jsonFields: map[string]bool{"location": true},
+			},
+			ExpectedJSON: `{"custom":{"foo":"bar"},"description":"My desc","entrypoint":true,"location":{"file":"example.rego","row":1,"col":4},"organizations":["org1"],"scope":"rule","title":"My rule"}`,
+		},
+	}
+
+	for name, data := range testCases {
+		t.Run(name, func(t *testing.T) {
+			bs := util.MustMarshalJSON(data.Annotations)
+			got := string(bs)
+			exp := data.ExpectedJSON
+
+			if got != exp {
+				t.Fatalf("expected:\n%s got\n%s", exp, got)
+			}
+		})
+	}
+}
+
+func TestAnnotations_UnmarshalJSON(t *testing.T) {
+
+	testCases := map[string]struct {
+		JSON                string
+		ExpectedAnnotations *Annotations
+	}{
+		"base case": {
+			JSON: `{"custom":{"foo":"bar"},"description":"My desc","entrypoint":true,"organizations":["org1"],"scope":"rule","title":"My rule"}`,
+			ExpectedAnnotations: &Annotations{
+				Scope:         "rule",
+				Title:         "My rule",
+				Entrypoint:    true,
+				Organizations: []string{"org1"},
+				Description:   "My desc",
+				Custom: map[string]interface{}{
+					"foo": "bar",
+				},
+			},
+		},
+		"location case": {
+			JSON: `{"custom":{"foo":"bar"},"description":"My desc","entrypoint":true,"location":{"file":"example.rego","row":1,"col":4},"organizations":["org1"],"scope":"rule","title":"My rule"}`,
+			ExpectedAnnotations: &Annotations{
+				Scope:         "rule",
+				Title:         "My rule",
+				Entrypoint:    true,
+				Organizations: []string{"org1"},
+				Description:   "My desc",
+				Custom: map[string]interface{}{
+					"foo": "bar",
+				},
+				Location: NewLocation([]byte{}, "example.rego", 1, 4),
+			},
+		},
+	}
+
+	for name, data := range testCases {
+		t.Run(name, func(t *testing.T) {
+			var a Annotations
+			err := json.Unmarshal([]byte(data.JSON), &a)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if a.String() != data.ExpectedAnnotations.String() {
+				t.Fatalf("expected:\n%#v got\n%#v", data.ExpectedAnnotations.String(), a.String())
+			}
+
+			if data.ExpectedAnnotations.Location != nil {
+				if !a.Location.Equal(data.ExpectedAnnotations.Location) {
+					t.Fatalf("expected location:\n%#v got\n%#v", data.ExpectedAnnotations.Location, a.Location)
+				}
+			}
+		})
+	}
+}
+
+func TestAnnotationsRef_MarshalJSON(t *testing.T) {
+
+	testCases := map[string]struct {
+		AnnotationsRef *AnnotationsRef
+		ExpectedJSON   string
+	}{
+		"base case": {
+			AnnotationsRef: &AnnotationsRef{
+				Path: []*Term{},
+				// using an empty annotations object here since Annotations marshalling is tested separately
+				Annotations: &Annotations{},
+				Location:    NewLocation([]byte{}, "example.rego", 1, 4),
+			},
+			ExpectedJSON: `{"annotations":{"scope":""},"path":[]}`,
+		},
+		"location excluded": {
+			AnnotationsRef: &AnnotationsRef{
+				Path:        []*Term{},
+				Annotations: &Annotations{},
+				Location:    NewLocation([]byte{}, "example.rego", 1, 4),
+
+				jsonFields: map[string]bool{"location": false},
+			},
+			ExpectedJSON: `{"annotations":{"scope":""},"path":[]}`,
+		},
+		"location included": {
+			AnnotationsRef: &AnnotationsRef{
+				Path:        []*Term{},
+				Annotations: &Annotations{},
+				Location:    NewLocation([]byte{}, "example.rego", 1, 4),
+
+				jsonFields: map[string]bool{"location": true},
+			},
+			ExpectedJSON: `{"annotations":{"scope":""},"location":{"file":"example.rego","row":1,"col":4},"path":[]}`,
+		},
+	}
+
+	for name, data := range testCases {
+		t.Run(name, func(t *testing.T) {
+			bs := util.MustMarshalJSON(data.AnnotationsRef)
+			got := string(bs)
+			exp := data.ExpectedJSON
+
+			if got != exp {
+				t.Fatalf("expected:\n%s got\n%s", exp, got)
+			}
+		})
+	}
+}
+
+func TestAnnotationsRef_UnmarshalJSON(t *testing.T) {
+
+	testCases := map[string]struct {
+		JSON                   string
+		ExpectedAnnotationsRef *AnnotationsRef
+	}{
+		"base case": {
+			JSON: `{"annotations":{"scope":""},"path":[]}`,
+			ExpectedAnnotationsRef: &AnnotationsRef{
+				Path:        []*Term{},
+				Annotations: &Annotations{},
+			},
+		},
+		"location case": {
+			JSON: `{"custom":{"foo":"bar"},"description":"My desc","entrypoint":true,"location":{"file":"example.rego","row":1,"col":4},"organizations":["org1"],"scope":"rule","title":"My rule"}`,
+			ExpectedAnnotationsRef: &AnnotationsRef{
+				Path:        []*Term{},
+				Annotations: &Annotations{},
+				Location:    NewLocation([]byte{}, "example.rego", 1, 4),
+			},
+		},
+	}
+
+	for name, data := range testCases {
+		t.Run(name, func(t *testing.T) {
+			var a AnnotationsRef
+			err := json.Unmarshal([]byte(data.JSON), &a)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if got, exp := len(a.Path), len(data.ExpectedAnnotationsRef.Path); exp != got {
+				t.Fatalf("expected:\n%#v got\n%#v", exp, got)
+			}
+
+			if got, exp := a.Annotations.String(), data.ExpectedAnnotationsRef.Annotations.String(); exp != got {
+				t.Fatalf("expected:\n%#v got\n%#v", exp, got)
+			}
+
+			if data.ExpectedAnnotationsRef.Location != nil {
+				if !a.Location.Equal(data.ExpectedAnnotationsRef.Location) {
+					t.Fatalf("expected location:\n%#v got\n%#v", data.ExpectedAnnotationsRef.Location, a.Location)
+				}
+			}
+		})
+	}
+}

--- a/ast/marshal_test.go
+++ b/ast/marshal_test.go
@@ -29,8 +29,12 @@ func TestTerm_MarshalJSON(t *testing.T) {
 				return &Term{
 					Value:    v,
 					Location: NewLocation([]byte{}, "example.rego", 1, 2),
-					jsonFields: map[string]bool{
-						"location": false,
+					jsonOptions: JSONOptions{
+						MarshalOptions: JSONMarshalOptions{
+							IncludeLocation: NodeToggle{
+								Term: false,
+							},
+						},
 					},
 				}
 			}(),
@@ -42,8 +46,12 @@ func TestTerm_MarshalJSON(t *testing.T) {
 				return &Term{
 					Value:    v,
 					Location: NewLocation([]byte{}, "example.rego", 1, 2),
-					jsonFields: map[string]bool{
-						"location": true,
+					jsonOptions: JSONOptions{
+						MarshalOptions: JSONMarshalOptions{
+							IncludeLocation: NodeToggle{
+								Term: true,
+							},
+						},
 					},
 				}
 			}(),
@@ -125,8 +133,12 @@ func TestPackage_MarshalJSON(t *testing.T) {
 			Package: &Package{
 				Path:     EmptyRef(),
 				Location: NewLocation([]byte{}, "example.rego", 1, 2),
-				jsonFields: map[string]bool{
-					"location": false,
+				jsonOptions: JSONOptions{
+					MarshalOptions: JSONMarshalOptions{
+						IncludeLocation: NodeToggle{
+							Package: false,
+						},
+					},
 				},
 			},
 			ExpectedJSON: `{"path":[]}`,
@@ -135,8 +147,12 @@ func TestPackage_MarshalJSON(t *testing.T) {
 			Package: &Package{
 				Path:     EmptyRef(),
 				Location: NewLocation([]byte{}, "example.rego", 1, 2),
-				jsonFields: map[string]bool{
-					"location": true,
+				jsonOptions: JSONOptions{
+					MarshalOptions: JSONMarshalOptions{
+						IncludeLocation: NodeToggle{
+							Package: true,
+						},
+					},
 				},
 			},
 			ExpectedJSON: `{"location":{"file":"example.rego","row":1,"col":2},"path":[]}`,
@@ -213,8 +229,12 @@ func TestComment_MarshalJSON(t *testing.T) {
 			Comment: &Comment{
 				Text:     []byte("comment"),
 				Location: NewLocation([]byte{}, "example.rego", 1, 2),
-				jsonFields: map[string]bool{
-					"location": false, // ignored
+				jsonOptions: JSONOptions{
+					MarshalOptions: JSONMarshalOptions{
+						IncludeLocation: NodeToggle{
+							Comment: false, // ignored
+						},
+					},
 				},
 			},
 			ExpectedJSON: `{"Text":"Y29tbWVudA==","Location":{"file":"example.rego","row":1,"col":2}}`,
@@ -223,8 +243,12 @@ func TestComment_MarshalJSON(t *testing.T) {
 			Comment: &Comment{
 				Text:     []byte("comment"),
 				Location: NewLocation([]byte{}, "example.rego", 1, 2),
-				jsonFields: map[string]bool{
-					"location": true, // ignored
+				jsonOptions: JSONOptions{
+					MarshalOptions: JSONMarshalOptions{
+						IncludeLocation: NodeToggle{
+							Comment: true, // ignored
+						},
+					},
 				},
 			},
 			ExpectedJSON: `{"Text":"Y29tbWVudA==","Location":{"file":"example.rego","row":1,"col":2}}`,
@@ -322,8 +346,12 @@ func TestImport_MarshalJSON(t *testing.T) {
 				return &Import{
 					Path:     &term,
 					Location: NewLocation([]byte{}, "example.rego", 1, 2),
-					jsonFields: map[string]bool{
-						"location": false,
+					jsonOptions: JSONOptions{
+						MarshalOptions: JSONMarshalOptions{
+							IncludeLocation: NodeToggle{
+								Import: false,
+							},
+						},
 					},
 				}
 			}(),
@@ -339,8 +367,12 @@ func TestImport_MarshalJSON(t *testing.T) {
 				return &Import{
 					Path:     &term,
 					Location: NewLocation([]byte{}, "example.rego", 1, 2),
-					jsonFields: map[string]bool{
-						"location": true,
+					jsonOptions: JSONOptions{
+						MarshalOptions: JSONMarshalOptions{
+							IncludeLocation: NodeToggle{
+								Import: true,
+							},
+						},
 					},
 				}
 			}(),
@@ -439,8 +471,12 @@ func TestRule_MarshalJSON(t *testing.T) {
 		"location excluded": {
 			Rule: func() *Rule {
 				r := rule.Copy()
-				r.jsonFields = map[string]bool{
-					"location": false,
+				r.jsonOptions = JSONOptions{
+					MarshalOptions: JSONMarshalOptions{
+						IncludeLocation: NodeToggle{
+							Rule: false,
+						},
+					},
 				}
 				return r
 			}(),
@@ -449,8 +485,12 @@ func TestRule_MarshalJSON(t *testing.T) {
 		"location included": {
 			Rule: func() *Rule {
 				r := rule.Copy()
-				r.jsonFields = map[string]bool{
-					"location": true,
+				r.jsonOptions = JSONOptions{
+					MarshalOptions: JSONMarshalOptions{
+						IncludeLocation: NodeToggle{
+							Rule: true,
+						},
+					},
 				}
 				return r
 			}(),
@@ -554,9 +594,14 @@ func TestHead_MarshalJSON(t *testing.T) {
 		"location excluded": {
 			Head: func() *Head {
 				h := head.Copy()
-				h.jsonFields = map[string]bool{
-					"location": false,
+				h.jsonOptions = JSONOptions{
+					MarshalOptions: JSONMarshalOptions{
+						IncludeLocation: NodeToggle{
+							Head: false,
+						},
+					},
 				}
+
 				return h
 			}(),
 			ExpectedJSON: `{"name":"allow","value":{"type":"boolean","value":true},"ref":[{"type":"var","value":"allow"}]}`,
@@ -564,8 +609,12 @@ func TestHead_MarshalJSON(t *testing.T) {
 		"location included": {
 			Head: func() *Head {
 				h := head.Copy()
-				h.jsonFields = map[string]bool{
-					"location": true,
+				h.jsonOptions = JSONOptions{
+					MarshalOptions: JSONMarshalOptions{
+						IncludeLocation: NodeToggle{
+							Head: true,
+						},
+					},
 				}
 				return h
 			}(),
@@ -669,9 +718,14 @@ func TestExpr_MarshalJSON(t *testing.T) {
 		"location excluded": {
 			Expr: func() *Expr {
 				e := expr.Copy()
-				e.jsonFields = map[string]bool{
-					"location": false,
+				e.jsonOptions = JSONOptions{
+					MarshalOptions: JSONMarshalOptions{
+						IncludeLocation: NodeToggle{
+							Expr: false,
+						},
+					},
 				}
+
 				return e
 			}(),
 			ExpectedJSON: `{"index":0,"terms":{"type":"boolean","value":true}}`,
@@ -679,8 +733,12 @@ func TestExpr_MarshalJSON(t *testing.T) {
 		"location included": {
 			Expr: func() *Expr {
 				e := expr.Copy()
-				e.jsonFields = map[string]bool{
-					"location": true,
+				e.jsonOptions = JSONOptions{
+					MarshalOptions: JSONMarshalOptions{
+						IncludeLocation: NodeToggle{
+							Expr: true,
+						},
+					},
 				}
 				return e
 			}(),
@@ -777,17 +835,17 @@ func TestSomeDecl_MarshalJSON(t *testing.T) {
 		},
 		"location excluded": {
 			SomeDecl: &SomeDecl{
-				Symbols:    []*Term{term},
-				Location:   NewLocation([]byte{}, "example.rego", 1, 2),
-				jsonFields: map[string]bool{"location": false},
+				Symbols:     []*Term{term},
+				Location:    NewLocation([]byte{}, "example.rego", 1, 2),
+				jsonOptions: JSONOptions{MarshalOptions: JSONMarshalOptions{IncludeLocation: NodeToggle{SomeDecl: false}}},
 			},
 			ExpectedJSON: `{"symbols":[{"type":"string","value":"example"}]}`,
 		},
 		"location included": {
 			SomeDecl: &SomeDecl{
-				Symbols:    []*Term{term},
-				Location:   NewLocation([]byte{}, "example.rego", 1, 2),
-				jsonFields: map[string]bool{"location": true},
+				Symbols:     []*Term{term},
+				Location:    NewLocation([]byte{}, "example.rego", 1, 2),
+				jsonOptions: JSONOptions{MarshalOptions: JSONMarshalOptions{IncludeLocation: NodeToggle{SomeDecl: true}}},
 			},
 			ExpectedJSON: `{"location":{"file":"example.rego","row":1,"col":2},"symbols":[{"type":"string","value":"example"}]}`,
 		},
@@ -888,7 +946,7 @@ allow {
 		"location excluded": {
 			Every: func() *Every {
 				e := every.Copy()
-				e.jsonFields = map[string]bool{"location": false}
+				e.jsonOptions = JSONOptions{MarshalOptions: JSONMarshalOptions{IncludeLocation: NodeToggle{Every: false}}}
 				return e
 			}(),
 			ExpectedJSON: `{"body":[{"index":0,"terms":[{"type":"ref","value":[{"type":"var","value":"equal"}]},{"type":"var","value":"e"},{"type":"number","value":1}]}],"domain":{"type":"array","value":[{"type":"number","value":1},{"type":"number","value":2},{"type":"number","value":3}]},"key":null,"value":{"type":"var","value":"e"}}`,
@@ -896,7 +954,7 @@ allow {
 		"location included": {
 			Every: func() *Every {
 				e := every.Copy()
-				e.jsonFields = map[string]bool{"location": true}
+				e.jsonOptions = JSONOptions{MarshalOptions: JSONMarshalOptions{IncludeLocation: NodeToggle{Every: true}}}
 				return e
 			}(),
 			ExpectedJSON: `{"body":[{"index":0,"terms":[{"type":"ref","value":[{"type":"var","value":"equal"}]},{"type":"var","value":"e"},{"type":"number","value":1}]}],"domain":{"type":"array","value":[{"type":"number","value":1},{"type":"number","value":2},{"type":"number","value":3}]},"key":null,"location":{"file":"example.rego","row":7,"col":2},"value":{"type":"var","value":"e"}}`,
@@ -1013,7 +1071,7 @@ b {
 		"location excluded": {
 			With: func() *With {
 				w := with.Copy()
-				w.jsonFields = map[string]bool{"location": false}
+				w.jsonOptions = JSONOptions{MarshalOptions: JSONMarshalOptions{IncludeLocation: NodeToggle{With: false}}}
 				return w
 			}(),
 			ExpectedJSON: `{"target":{"type":"ref","value":[{"type":"var","value":"input"}]},"value":{"type":"number","value":1}}`,
@@ -1021,7 +1079,7 @@ b {
 		"location included": {
 			With: func() *With {
 				w := with.Copy()
-				w.jsonFields = map[string]bool{"location": true}
+				w.jsonOptions = JSONOptions{MarshalOptions: JSONMarshalOptions{IncludeLocation: NodeToggle{With: true}}}
 				return w
 			}(),
 			ExpectedJSON: `{"location":{"file":"example.rego","row":7,"col":4},"target":{"type":"ref","value":[{"type":"var","value":"input"}]},"value":{"type":"number","value":1}}`,
@@ -1136,7 +1194,11 @@ func TestAnnotations_MarshalJSON(t *testing.T) {
 				},
 				Location: NewLocation([]byte{}, "example.rego", 1, 4),
 
-				jsonFields: map[string]bool{"location": false},
+				jsonOptions: JSONOptions{
+					MarshalOptions: JSONMarshalOptions{
+						IncludeLocation: NodeToggle{Annotations: false},
+					},
+				},
 			},
 			ExpectedJSON: `{"custom":{"foo":"bar"},"description":"My desc","entrypoint":true,"organizations":["org1"],"scope":"rule","title":"My rule"}`,
 		},
@@ -1152,7 +1214,11 @@ func TestAnnotations_MarshalJSON(t *testing.T) {
 				},
 				Location: NewLocation([]byte{}, "example.rego", 1, 4),
 
-				jsonFields: map[string]bool{"location": true},
+				jsonOptions: JSONOptions{
+					MarshalOptions: JSONMarshalOptions{
+						IncludeLocation: NodeToggle{Annotations: true},
+					},
+				},
 			},
 			ExpectedJSON: `{"custom":{"foo":"bar"},"description":"My desc","entrypoint":true,"location":{"file":"example.rego","row":1,"col":4},"organizations":["org1"],"scope":"rule","title":"My rule"}`,
 		},
@@ -1247,8 +1313,11 @@ func TestAnnotationsRef_MarshalJSON(t *testing.T) {
 				Path:        []*Term{},
 				Annotations: &Annotations{},
 				Location:    NewLocation([]byte{}, "example.rego", 1, 4),
-
-				jsonFields: map[string]bool{"location": false},
+				jsonOptions: JSONOptions{
+					MarshalOptions: JSONMarshalOptions{
+						IncludeLocation: NodeToggle{AnnotationsRef: false},
+					},
+				},
 			},
 			ExpectedJSON: `{"annotations":{"scope":""},"path":[]}`,
 		},
@@ -1258,7 +1327,11 @@ func TestAnnotationsRef_MarshalJSON(t *testing.T) {
 				Annotations: &Annotations{},
 				Location:    NewLocation([]byte{}, "example.rego", 1, 4),
 
-				jsonFields: map[string]bool{"location": true},
+				jsonOptions: JSONOptions{
+					MarshalOptions: JSONMarshalOptions{
+						IncludeLocation: NodeToggle{AnnotationsRef: true},
+					},
+				},
 			},
 			ExpectedJSON: `{"annotations":{"scope":""},"location":{"file":"example.rego","row":1,"col":4},"path":[]}`,
 		},

--- a/ast/marshal_test.go
+++ b/ast/marshal_test.go
@@ -387,9 +387,6 @@ func TestImport_UnmarshalJSON(t *testing.T) {
 				return &Import{
 					Path:     &term,
 					Location: NewLocation([]byte{}, "example.rego", 1, 2),
-					jsonFields: map[string]bool{
-						"location": false,
-					},
 				}
 			}(),
 		},

--- a/ast/marshal_test.go
+++ b/ast/marshal_test.go
@@ -207,7 +207,7 @@ func TestComment_MarshalJSON(t *testing.T) {
 			Comment: &Comment{
 				Text: []byte("comment"),
 			},
-			ExpectedJSON: `{"Text":"Y29tbWVudA=="}`,
+			ExpectedJSON: `{"Text":"Y29tbWVudA==","Location":null}`,
 		},
 		"location excluded, still included for legacy reasons": {
 			Comment: &Comment{
@@ -217,7 +217,7 @@ func TestComment_MarshalJSON(t *testing.T) {
 					"location": false, // ignored
 				},
 			},
-			ExpectedJSON: `{"Location":{"file":"example.rego","row":1,"col":2},"Text":"Y29tbWVudA=="}`,
+			ExpectedJSON: `{"Text":"Y29tbWVudA==","Location":{"file":"example.rego","row":1,"col":2}}`,
 		},
 		"location included": {
 			Comment: &Comment{
@@ -227,7 +227,7 @@ func TestComment_MarshalJSON(t *testing.T) {
 					"location": true, // ignored
 				},
 			},
-			ExpectedJSON: `{"Location":{"file":"example.rego","row":1,"col":2},"Text":"Y29tbWVudA=="}`,
+			ExpectedJSON: `{"Text":"Y29tbWVudA==","Location":{"file":"example.rego","row":1,"col":2}}`,
 		},
 	}
 

--- a/ast/parser.go
+++ b/ast/parser.go
@@ -101,8 +101,37 @@ type ParserOptions struct {
 	AllFutureKeywords  bool
 	FutureKeywords     []string
 	SkipRules          bool
-	JSONFields         map[string]bool
+	JSONOptions        *JSONOptions
 	unreleasedKeywords bool // TODO(sr): cleanup
+}
+
+// JSONOptions defines the options for JSON operations,
+// currently only marshaling can be configured
+type JSONOptions struct {
+	MarshalOptions JSONMarshalOptions
+}
+
+// JSONMarshalOptions defines the options for JSON marshaling,
+// currently only toggling the marshaling of location information is supported
+type JSONMarshalOptions struct {
+	IncludeLocation NodeToggle
+}
+
+// NodeToggle is a generic struct to allow the toggling of
+// settings for different ast node types
+type NodeToggle struct {
+	Term           bool
+	Package        bool
+	Comment        bool
+	Import         bool
+	Rule           bool
+	Head           bool
+	Expr           bool
+	SomeDecl       bool
+	Every          bool
+	With           bool
+	Annotations    bool
+	AnnotationsRef bool
 }
 
 // NewParser creates and initializes a Parser.
@@ -178,9 +207,10 @@ func (p *Parser) WithSkipRules(skip bool) *Parser {
 	return p
 }
 
-// WithJSONFields sets the JSON fields that should be exposed in the JSON
-func (p *Parser) WithJSONFields(jsonFields map[string]bool) *Parser {
-	p.po.JSONFields = jsonFields
+// WithJSONOptions sets the JSONOptions which will be set on nodes to configure
+// their JSON marshaling behavior.
+func (p *Parser) WithJSONOptions(jsonOptions *JSONOptions) *Parser {
+	p.po.JSONOptions = jsonOptions
 	return p
 }
 
@@ -364,15 +394,17 @@ func (p *Parser) Parse() ([]Statement, []*Comment, Errors) {
 		stmts = p.parseAnnotations(stmts)
 	}
 
-	for i := range stmts {
-		vis := NewGenericVisitor(func(x interface{}) bool {
-			if x, ok := x.(customJSON); ok {
-				x.exposeJSONFields(p.po.JSONFields)
-			}
-			return false
-		})
+	if p.po.JSONOptions != nil {
+		for i := range stmts {
+			vis := NewGenericVisitor(func(x interface{}) bool {
+				if x, ok := x.(customJSON); ok {
+					x.setJSONOptions(*p.po.JSONOptions)
+				}
+				return false
+			})
 
-		vis.Walk(stmts[i])
+			vis.Walk(stmts[i])
+		}
 	}
 
 	return stmts, p.s.comments, p.s.errors

--- a/ast/parser_ext.go
+++ b/ast/parser_ext.go
@@ -594,7 +594,7 @@ func ParseStatementsWithOpts(filename, input string, popts ParserOptions) ([]Sta
 		WithAllFutureKeywords(popts.AllFutureKeywords).
 		WithCapabilities(popts.Capabilities).
 		WithSkipRules(popts.SkipRules).
-		WithJSONFields(popts.JSONFields).
+		WithJSONOptions(popts.JSONOptions).
 		withUnreleasedKeywords(popts.unreleasedKeywords)
 
 	stmts, comments, errs := parser.Parse()

--- a/ast/parser_ext.go
+++ b/ast/parser_ext.go
@@ -594,6 +594,7 @@ func ParseStatementsWithOpts(filename, input string, popts ParserOptions) ([]Sta
 		WithAllFutureKeywords(popts.AllFutureKeywords).
 		WithCapabilities(popts.Capabilities).
 		WithSkipRules(popts.SkipRules).
+		WithJSONFields(popts.JSONFields).
 		withUnreleasedKeywords(popts.unreleasedKeywords)
 
 	stmts, comments, errs := parser.Parse()

--- a/ast/policy.go
+++ b/ast/policy.go
@@ -433,20 +433,6 @@ func (c *Comment) exposeJSONFields(fields map[string]bool) {
 	c.jsonFields = fields
 }
 
-func (c *Comment) MarshalJSON() ([]byte, error) {
-	// TODO: Comment has inconsistent JSON field names starting with an upper case letter.
-	data := map[string]interface{}{
-		"Text": c.Text,
-	}
-
-	// TODO: Comment Location is also always included for legacy reasons. jsonFields data is ignored.
-	if c.Location != nil {
-		data["Location"] = c.Location
-	}
-
-	return json.Marshal(data)
-}
-
 // Compare returns an integer indicating whether pkg is less than, equal to,
 // or greater than other.
 func (pkg *Package) Compare(other *Package) int {

--- a/ast/policy_test.go
+++ b/ast/policy_test.go
@@ -408,7 +408,7 @@ func TestRuleHeadJSON(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if exp, act := `{"head":{"name":"allow","ref":[{"type":"var","value":"allow"}]},"body":[]}`, string(bs); act != exp {
+	if exp, act := `{"body":[],"head":{"name":"allow","ref":[{"type":"var","value":"allow"}]}}`, string(bs); act != exp {
 		t.Errorf("expected %q, got %q", exp, act)
 	}
 
@@ -805,17 +805,10 @@ func TestAnnotationsString(t *testing.T) {
 
 	// NOTE(tsandall): for now, annotations are represented as JSON objects
 	// which are a subset of YAML. We could improve this in the future.
-	exp := `{"scope":"foo",` +
-		`"title":"bar",` +
-		`"description":"baz",` +
-		`"organizations":["mi","fa"],` +
-		`"related_resources":[{"ref":"https://example.com"},{"description":"Some resource","ref":"https://example.com/2"}],` +
-		`"authors":[{"name":"John Doe","email":"john@example.com"},{"name":"Jane Doe"}],` +
-		`"schemas":[{"path":[{"type":"var","value":"data"},{"type":"string","value":"bar"}],"schema":[{"type":"var","value":"schema"},{"type":"string","value":"baz"}]}],` +
-		`"custom":{"flag":true,"list":[1,2,3],"map":{"one":1,"two":{"3":"three"}}}}`
+	exp := `{"authors":[{"name":"John Doe","email":"john@example.com"},{"name":"Jane Doe"}],"custom":{"flag":true,"list":[1,2,3],"map":{"one":1,"two":{"3":"three"}}},"description":"baz","organizations":["mi","fa"],"related_resources":[{"ref":"https://example.com"},{"description":"Some resource","ref":"https://example.com/2"}],"schemas":[{"path":[{"type":"var","value":"data"},{"type":"string","value":"bar"}],"schema":[{"type":"var","value":"schema"},{"type":"string","value":"baz"}]}],"scope":"foo","title":"bar"}`
 
-	if exp != a.String() {
-		t.Fatalf("expected %q but got %q", exp, a.String())
+	if got := a.String(); exp != got {
+		t.Fatalf("expected\n%s\nbut got\n%s", exp, got)
 	}
 }
 

--- a/ast/term.go
+++ b/ast/term.go
@@ -444,7 +444,7 @@ func (term *Term) String() string {
 }
 
 // UnmarshalJSON parses the byte array and stores the result in term.
-// Specialized unmarshalling is required to handle Value.
+// Specialized unmarshalling is required to handle Value and Location.
 func (term *Term) UnmarshalJSON(bs []byte) error {
 	v := map[string]interface{}{}
 	if err := util.UnmarshalJSON(bs, &v); err != nil {

--- a/ast/term.go
+++ b/ast/term.go
@@ -294,7 +294,7 @@ type Term struct {
 	Value    Value     `json:"value"`              // the value of the Term as represented in Go
 	Location *Location `json:"location,omitempty"` // the location of the Term in the source
 
-	jsonFields map[string]bool
+	jsonOptions JSONOptions
 }
 
 // NewTerm returns a new Term object.
@@ -419,8 +419,8 @@ func (term *Term) IsGround() bool {
 	return term.Value.IsGround()
 }
 
-func (term *Term) exposeJSONFields(fields map[string]bool) {
-	term.jsonFields = fields
+func (term *Term) setJSONOptions(opts JSONOptions) {
+	term.jsonOptions = opts
 }
 
 // MarshalJSON returns the JSON encoding of the term.
@@ -431,7 +431,7 @@ func (term *Term) MarshalJSON() ([]byte, error) {
 		"type":  TypeName(term.Value),
 		"value": term.Value,
 	}
-	if showLocation, ok := term.jsonFields["location"]; ok && showLocation {
+	if term.jsonOptions.MarshalOptions.IncludeLocation.Term {
 		if term.Location != nil {
 			d["location"] = term.Location
 		}

--- a/ast/term.go
+++ b/ast/term.go
@@ -291,8 +291,10 @@ func MustInterfaceToValue(x interface{}) Value {
 
 // Term is an argument to a function.
 type Term struct {
-	Value    Value     `json:"value"` // the value of the Term as represented in Go
-	Location *Location `json:"-"`     // the location of the Term in the source
+	Value    Value     `json:"value"`              // the value of the Term as represented in Go
+	Location *Location `json:"location,omitempty"` // the location of the Term in the source
+
+	jsonFields map[string]bool
 }
 
 // NewTerm returns a new Term object.
@@ -417,6 +419,10 @@ func (term *Term) IsGround() bool {
 	return term.Value.IsGround()
 }
 
+func (term *Term) exposeJSONFields(fields map[string]bool) {
+	term.jsonFields = fields
+}
+
 // MarshalJSON returns the JSON encoding of the term.
 //
 // Specialized marshalling logic is required to include a type hint for Value.
@@ -424,6 +430,11 @@ func (term *Term) MarshalJSON() ([]byte, error) {
 	d := map[string]interface{}{
 		"type":  TypeName(term.Value),
 		"value": term.Value,
+	}
+	if showLocation, ok := term.jsonFields["location"]; ok && showLocation {
+		if term.Location != nil {
+			d["location"] = term.Location
+		}
 	}
 	return json.Marshal(d)
 }
@@ -444,6 +455,14 @@ func (term *Term) UnmarshalJSON(bs []byte) error {
 		return err
 	}
 	term.Value = val
+
+	if loc, ok := v["location"].(map[string]interface{}); ok {
+		term.Location = &Location{}
+		err := unmarshalLocation(term.Location, loc)
+		if err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -2897,6 +2916,14 @@ func unmarshalExpr(expr *Expr, v map[string]interface{}) error {
 			return fmt.Errorf("ast: unable to unmarshal negated field with type: %T (expected true or false)", v["negated"])
 		}
 	}
+	if generatedRaw, ok := v["generated"]; ok {
+		if b, ok := generatedRaw.(bool); ok {
+			expr.Generated = b
+		} else {
+			return fmt.Errorf("ast: unable to unmarshal generated field with type: %T (expected true or false)", v["generated"])
+		}
+	}
+
 	if err := unmarshalExprIndex(expr, v); err != nil {
 		return err
 	}
@@ -2929,6 +2956,46 @@ func unmarshalExpr(expr *Expr, v map[string]interface{}) error {
 			expr.With = ws
 		}
 	}
+	if loc, ok := v["location"].(map[string]interface{}); ok {
+		expr.Location = &Location{}
+		if err := unmarshalLocation(expr.Location, loc); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func unmarshalLocation(loc *Location, v map[string]interface{}) error {
+	if x, ok := v["file"]; ok {
+		if s, ok := x.(string); ok {
+			loc.File = s
+		} else {
+			return fmt.Errorf("ast: unable to unmarshal file field with type: %T (expected string)", v["file"])
+		}
+	}
+	if x, ok := v["row"]; ok {
+		if n, ok := x.(json.Number); ok {
+			i64, err := n.Int64()
+			if err != nil {
+				return err
+			}
+			loc.Row = int(i64)
+		} else {
+			return fmt.Errorf("ast: unable to unmarshal row field with type: %T (expected number)", v["row"])
+		}
+	}
+	if x, ok := v["col"]; ok {
+		if n, ok := x.(json.Number); ok {
+			i64, err := n.Int64()
+			if err != nil {
+				return err
+			}
+			loc.Col = int(i64)
+		} else {
+			return fmt.Errorf("ast: unable to unmarshal col field with type: %T (expected number)", v["col"])
+		}
+	}
+
 	return nil
 }
 
@@ -2946,11 +3013,22 @@ func unmarshalExprIndex(expr *Expr, v map[string]interface{}) error {
 }
 
 func unmarshalTerm(m map[string]interface{}) (*Term, error) {
+	var term Term
+
 	v, err := unmarshalValue(m)
 	if err != nil {
 		return nil, err
 	}
-	return &Term{Value: v}, nil
+	term.Value = v
+
+	if loc, ok := m["location"].(map[string]interface{}); ok {
+		term.Location = &Location{}
+		if err := unmarshalLocation(term.Location, loc); err != nil {
+			return nil, err
+		}
+	}
+
+	return &term, nil
 }
 
 func unmarshalTermSlice(s []interface{}) ([]*Term, error) {

--- a/cmd/parse.go
+++ b/cmd/parse.go
@@ -124,7 +124,7 @@ func parse(args []string, params *parseParams, stdout io.Writer, stderr io.Write
 
 func init() {
 	parseCommand.Flags().VarP(configuredParseParams.format, "format", "f", "set output format")
-	parseCommand.Flags().StringVarP(&configuredParseParams.jsonInclude, "json-include", "", "", "select optional elements, current options: locations, comments. E.g. --json-include locations,-comments will include locations and exclude comments.")
+	parseCommand.Flags().StringVarP(&configuredParseParams.jsonInclude, "json-include", "", "", "include or exclude optional elements. By default comments are included. Current options: locations, comments. E.g. --json-include locations,-comments will include locations and exclude comments.")
 
 	RootCommand.AddCommand(parseCommand)
 }

--- a/cmd/parse.go
+++ b/cmd/parse.go
@@ -68,12 +68,29 @@ func parse(args []string, stdout io.Writer, stderr io.Writer) int {
 		}
 	}
 
-	result, err := loader.RegoWithOpts(args[0], ast.ParserOptions{
-		ProcessAnnotation: true,
-		JSONFields: map[string]bool{
-			"location": exposeLocation,
-		},
-	})
+	parserOpts := ast.ParserOptions{ProcessAnnotation: true}
+	if exposeLocation {
+		parserOpts.JSONOptions = &ast.JSONOptions{
+			MarshalOptions: ast.JSONMarshalOptions{
+				IncludeLocation: ast.NodeToggle{
+					Term:           true,
+					Package:        true,
+					Comment:        true,
+					Import:         true,
+					Rule:           true,
+					Head:           true,
+					Expr:           true,
+					SomeDecl:       true,
+					Every:          true,
+					With:           true,
+					Annotations:    true,
+					AnnotationsRef: true,
+				},
+			},
+		}
+	}
+
+	result, err := loader.RegoWithOpts(args[0], parserOpts)
 	if err != nil {
 		_ = pr.JSON(stderr, pr.Output{Errors: pr.NewOutputErrors(err)})
 		return 1

--- a/cmd/parse_test.go
+++ b/cmd/parse_test.go
@@ -3,8 +3,10 @@ package cmd
 import (
 	"bytes"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/open-policy-agent/opa/util"
 	"github.com/open-policy-agent/opa/util/test"
 )
 
@@ -16,12 +18,31 @@ func TestParseExit0(t *testing.T) {
 		p = 1
 		`,
 	}
-	errc, _, stderr := testParse(t, files)
+	errc, stdout, stderr, _ := testParse(t, files, &configuredParseParams)
 	if errc != 0 {
 		t.Fatalf("Expected exit code 0, got %v", errc)
 	}
 	if len(stderr) > 0 {
 		t.Fatalf("Expected no stderr output, got:\n%s\n", string(stderr))
+	}
+
+	expectedOutput := `module
+ package
+  ref
+   data
+   "x"
+ rule
+  head
+   ref
+    p
+   1
+  body
+   expr index=0
+    true
+`
+
+	if got, want := string(stdout), expectedOutput; got != want {
+		t.Fatalf("Expected output\n%v\n, got\n%v", want, got)
 	}
 }
 
@@ -30,7 +51,7 @@ func TestParseExit1(t *testing.T) {
 	files := map[string]string{
 		"x.rego": `???`,
 	}
-	errc, _, stderr := testParse(t, files)
+	errc, _, stderr, _ := testParse(t, files, &configuredParseParams)
 	if errc != 1 {
 		t.Fatalf("Expected exit code 1, got %v", errc)
 	}
@@ -39,21 +60,202 @@ func TestParseExit1(t *testing.T) {
 	}
 }
 
+func TestParseJSONOutput(t *testing.T) {
+
+	files := map[string]string{
+		"x.rego": `package x
+		
+		p = 1
+		`,
+	}
+	errc, stdout, stderr, _ := testParse(t, files, &parseParams{
+		format: util.NewEnumFlag(parseFormatJSON, []string{parseFormatPretty, parseFormatJSON}),
+	})
+	if errc != 0 {
+		t.Fatalf("Expected exit code 0, got %v", errc)
+	}
+	if len(stderr) > 0 {
+		t.Fatalf("Expected no stderr output, got:\n%s\n", string(stderr))
+	}
+
+	expectedOutput := `{
+  "package": {
+    "path": [
+      {
+        "type": "var",
+        "value": "data"
+      },
+      {
+        "type": "string",
+        "value": "x"
+      }
+    ]
+  },
+  "rules": [
+    {
+      "body": [
+        {
+          "index": 0,
+          "terms": {
+            "type": "boolean",
+            "value": true
+          }
+        }
+      ],
+      "head": {
+        "name": "p",
+        "value": {
+          "type": "number",
+          "value": 1
+        },
+        "ref": [
+          {
+            "type": "var",
+            "value": "p"
+          }
+        ]
+      }
+    }
+  ]
+}
+`
+
+	if got, want := string(stdout), expectedOutput; got != want {
+		t.Fatalf("Expected output\n%v\n, got\n%v", want, got)
+	}
+}
+
+func TestParseJSONOutputWithLocations(t *testing.T) {
+
+	files := map[string]string{
+		"x.rego": `package x
+		
+		p = 1
+		`,
+	}
+	errc, stdout, stderr, tempDirPath := testParse(t, files, &parseParams{
+		format:      util.NewEnumFlag(parseFormatJSON, []string{parseFormatPretty, parseFormatJSON}),
+		jsonInclude: "locations",
+	})
+	if errc != 0 {
+		t.Fatalf("Expected exit code 0, got %v", errc)
+	}
+	if len(stderr) > 0 {
+		t.Fatalf("Expected no stderr output, got:\n%s\n", string(stderr))
+	}
+
+	expectedOutput := strings.Replace(`{
+  "package": {
+    "location": {
+      "file": "TEMPDIR/x.rego",
+      "row": 1,
+      "col": 1
+    },
+    "path": [
+      {
+        "location": {
+          "file": "TEMPDIR/x.rego",
+          "row": 1,
+          "col": 9
+        },
+        "type": "var",
+        "value": "data"
+      },
+      {
+        "location": {
+          "file": "TEMPDIR/x.rego",
+          "row": 1,
+          "col": 9
+        },
+        "type": "string",
+        "value": "x"
+      }
+    ]
+  },
+  "rules": [
+    {
+      "body": [
+        {
+          "index": 0,
+          "terms": {
+            "type": "boolean",
+            "value": true
+          }
+        }
+      ],
+      "head": {
+        "name": "p",
+        "value": {
+          "location": {
+            "file": "TEMPDIR/x.rego",
+            "row": 3,
+            "col": 7
+          },
+          "type": "number",
+          "value": 1
+        },
+        "ref": [
+          {
+            "type": "var",
+            "value": "p"
+          }
+        ]
+      }
+    }
+  ]
+}
+`, "TEMPDIR", tempDirPath, -1)
+
+	if got, want := string(stdout), expectedOutput; got != want {
+		t.Fatalf("Expected output\n%v\n, got\n%v", want, got)
+	}
+}
+
+func TestParseJSONOutputComments(t *testing.T) {
+
+	files := map[string]string{
+		"x.rego": `package x
+		
+		# comment
+		p = 1
+		`,
+	}
+	errc, stdout, stderr, _ := testParse(t, files, &parseParams{
+		format:      util.NewEnumFlag(parseFormatJSON, []string{parseFormatPretty, parseFormatJSON}),
+		jsonInclude: "comments",
+	})
+	if errc != 0 {
+		t.Fatalf("Expected exit code 0, got %v", errc)
+	}
+	if len(stderr) > 0 {
+		t.Fatalf("Expected no stderr output, got:\n%s\n", string(stderr))
+	}
+
+	expectedCommentTextValue := "IGNvbW1lbnQ="
+
+	if !strings.Contains(string(stdout), expectedCommentTextValue) {
+		t.Fatalf("Comment text value %q missing in output: %s", expectedCommentTextValue, string(stdout))
+	}
+}
+
 // Runs parse and returns the exit code, stdout, and stderr contents
-func testParse(t *testing.T, files map[string]string) (int, []byte, []byte) {
+func testParse(t *testing.T, files map[string]string, params *parseParams) (int, []byte, []byte, string) {
 	t.Helper()
 
 	stdout := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)
 	var errc int
 
+	var tempDirUsed string
 	test.WithTempFS(files, func(path string) {
 		var args []string
 		for file := range files {
 			args = append(args, filepath.Join(path, file))
 		}
-		errc = parse(args, stdout, stderr)
+		errc = parse(args, params, stdout, stderr)
+
+		tempDirUsed = path
 	})
 
-	return errc, stdout.Bytes(), stderr.Bytes()
+	return errc, stdout.Bytes(), stderr.Bytes(), tempDirUsed
 }


### PR DESCRIPTION
Fixes https://github.com/open-policy-agent/opa/issues/3143

This is being done so that the json representation of an ast parse can
be used more easily by automated tools which need the location
information. This location information is verbose for human users of the
data and has until now been excluded from JSON representation.

This PR makes it possible to configure the JSON marshalling with some
options. However, the functionality of the OPA parse command has been
left mostly unchanged.

The only with the json output is that the fields are in a different
order:

```
diff --git a/new.json b/old.json
index 5b9504fa..0fb9d4f2 100644
--- a/new.json
+++ b/old.json
@@ -13,15 +13,6 @@
   },
   "rules": [
     {
-      "body": [
-        {
-          "index": 0,
-          "terms": {
-            "type": "boolean",
-            "value": true
-          }
-        }
-      ],
       "head": {
         "name": "allow",
         "value": {
@@ -34,17 +25,26 @@
             "value": "allow"
           }
         ]
-      }
+      },
+      "body": [
+        {
+          "terms": {
+            "type": "boolean",
+            "value": true
+          },
+          "index": 0
+        }
+      ]
     }
   ],
   "comments": [
     {
+      "Text": "IGNvbW1lbnQ=",
       "Location": {
         "file": "main.rego",
         "row": 3,
         "col": 1
-      },
-      "Text": "IGNvbW1lbnQ="
+      }
     }
   ]
 }
```

It's also possible to now show locations for all terms with another flag
option.

```
$ go run main.go parse main.rego --format=json --json-include=locations
{
  "package": {
    "location": {
      "file": "main.rego",
      "row": 1,
      "col": 1
    },
    "path": [
      {
        "location": {
          "file": "main.rego",
          "row": 1,
          "col": 9
        },
        "type": "var",
        "value": "data"
      },
...
}
```

Reviewer Notes:

* Following https://github.com/open-policy-agent/opa/pull/5576#discussion_r1081425623, I've left the comment json formatting as is. This can be picked up another time.
* Following https://github.com/open-policy-agent/opa/pull/5576#discussion_r1084081224, I've renamed the flag to `json-include`
* Following, https://github.com/open-policy-agent/opa/pull/5576#discussion_r1081717004, I've adjusted the implementation to use an option passed at compile time to control the JSON marshalling behaviour. This means that modules parsed with different options could have different JSONs.