### PR TITLE
Update to Security Docs

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -168,9 +168,11 @@ for existing bundle files or directories following the bundle structure.
 
 To skip bundle verification, use the --skip-verify flag.
 `,
+
 		Run: func(cmd *cobra.Command, args []string) {
 			ctx := context.Background()
-			rt, err := initRuntime(ctx, cmdParams, args)
+			addrSetByUser := cmd.Flags().Changed("addr")
+			rt, err := initRuntime(ctx, cmdParams, args, addrSetByUser)
 			if err != nil {
 				fmt.Println("error:", err)
 				os.Exit(1)
@@ -236,7 +238,7 @@ Flags:
 	RootCommand.AddCommand(runCommand)
 }
 
-func initRuntime(ctx context.Context, params runCmdParams, args []string) (*runtime.Runtime, error) {
+func initRuntime(ctx context.Context, params runCmdParams, args []string, addrSetByUser bool) (*runtime.Runtime, error) {
 	authenticationSchemes := map[string]server.AuthenticationScheme{
 		"token": server.AuthenticationToken,
 		"tls":   server.AuthenticationTLS,
@@ -316,6 +318,7 @@ func initRuntime(ctx context.Context, params runCmdParams, args []string) (*runt
 	}
 
 	rt.SetDistributedTracingLogging()
+	rt.Params.AddrSetByUser = addrSetByUser
 
 	return rt, nil
 }

--- a/docs/content/security.md
+++ b/docs/content/security.md
@@ -88,6 +88,21 @@ curl -k https://localhost:8181/v1/data
 We have to use cURL's `-k/--insecure` flag because we are using a self-signed certificate.
 {{< /info >}}
 
+## Interface Binding
+
+OPA can be configured to listen on specific interfaces using the `--addr` flag. For example:
+
+```bash
+opa run --server \
+  --log-level debug \
+  --addr localhost:8181 \
+```
+
+By default, OPA binds to the 0.0.0.0 interface, which allows the OPA server to be exposed to services running outside of the same machine. It's important to note that binding OPA to the 0.0.0.0 interface by itself is not inherently insecure in a trusted environment, exposing OPA to the outside world would also require opening ports and likely a similar procedure on a gateway layer above.
+
+In situations where OPA is not intended to be exposed to remote services, it is recommended to bind OPA to the localhost interface, which only allows connections from the same machine. If it is necessary to expose OPA to remote services, ensure to follow the security recommendations on this page, such as requiring authentication.
+
+
 ## Authentication and Authorization
 
 This section shows how to configure OPA to authenticate and authorize client

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -211,6 +211,9 @@ type Params struct {
 	DiskStorage *disk.Options
 
 	DistributedTracingOpts tracing.Options
+
+	// Check if default Addr is set or the user has changed it.
+	AddrSetByUser bool
 }
 
 // LoggingConfig stores the configuration for OPA's logging behaviour.
@@ -425,6 +428,11 @@ func (rt *Runtime) Serve(ctx context.Context) error {
 		return fmt.Errorf("at least one address must be configured in runtime parameters")
 	}
 
+	serverInitializingMessage := "Initializing server."
+	if !rt.Params.AddrSetByUser {
+		serverInitializingMessage += " OPA is running on a public (0.0.0.0) network interface. Unless you intend to expose OPA outside of the host, binding to the localhost interface (--addr localhost:8181) is recommended. See https://www.openpolicyagent.org/docs/latest/security/#interface-binding"
+	}
+
 	if rt.Params.DiagnosticAddrs == nil {
 		rt.Params.DiagnosticAddrs = &[]string{}
 	}
@@ -432,7 +440,7 @@ func (rt *Runtime) Serve(ctx context.Context) error {
 	rt.logger.WithFields(map[string]interface{}{
 		"addrs":            *rt.Params.Addrs,
 		"diagnostic-addrs": *rt.Params.DiagnosticAddrs,
-	}).Info("Initializing server.")
+	}).Info(serverInitializingMessage)
 
 	if rt.Params.Authorization == server.AuthorizationOff && rt.Params.Authentication == server.AuthenticationToken {
 		rt.logger.Error("Token authentication enabled without authorization. Authentication will be ineffective. See https://www.openpolicyagent.org/docs/latest/security/#authentication-and-authorization for more information.")


### PR DESCRIPTION
Hey @anderseknert! :wave: 

This is for #5090 

It explains why you should use localhost if you do not intend to expose the opa server to services outside of the same machine.

Signed-off-by: Peter Macdonald <macdonald.peter90@gmail.com>

Still need to check about adding a message to the server but wanted to make sure the text here is okay.

Thanks a lot!