### PR TITLE
ast: Fix panic when using named types

### DIFF
--- a/ast/check.go
+++ b/ast/check.go
@@ -780,6 +780,15 @@ func unifies(a, b types.Type) bool {
 		return false
 	}
 
+	named, ok := a.(*types.NamedType)
+	if ok {
+		return unifies(named.Type, b)
+	}
+	named, ok = b.(*types.NamedType)
+	if ok {
+		return unifies(a, named.Type)
+	}
+
 	switch a := a.(type) {
 	case types.Null:
 		_, ok := b.(types.Null)
@@ -825,7 +834,7 @@ func unifies(a, b types.Type) bool {
 		}
 		return false
 	default:
-		panic("unreachable")
+		panic(fmt.Sprintf("unreachable: %T", a))
 	}
 }
 

--- a/ast/check_test.go
+++ b/ast/check_test.go
@@ -747,6 +747,13 @@ func TestCheckBuiltinErrors(t *testing.T) {
 			),
 		),
 	})
+	RegisterBuiltin(&Builtin{
+		Name: "fake_named_number",
+		Decl: types.NewFunction(
+			types.Args(),
+			types.Named("number", types.N),
+		),
+	})
 
 	tests := []struct {
 		note  string
@@ -761,6 +768,7 @@ func TestCheckBuiltinErrors(t *testing.T) {
 		{"objects-bad-input", `sum({"a": 1, "b": 2}, x)`},
 		{"sets-any", `sum({1,2,"3",4}, x)`},
 		{"virtual-ref", `plus(data.test.p, data.coffee, 0)`},
+		{"named-type", `plus(1, fake_named_number())`},
 	}
 
 	env := newTestEnv([]string{


### PR DESCRIPTION
<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->

Fixes https://github.com/open-policy-agent/opa/issues/5582

After some digging into #5582, I noticed that it was missing a named type consideration. This PR restores the original type when dealing with `types.NamedType` in `unifies`.

I've tried adding a test case that reproduces this issue, but now panics in different places...

```
--- FAIL: TestCheckBuiltinErrors (0.00s)
    --- FAIL: TestCheckBuiltinErrors/named-type (0.00s)
panic: unreachable [recovered]
        panic: unreachable

goroutine 129 [running]:
testing.tRunner.func1.2({0x9d6b80, 0xddf420})
        /usr/local/go/src/testing/testing.go:1396 +0x24e
testing.tRunner.func1()
        /usr/local/go/src/testing/testing.go:1399 +0x39f
panic({0x9d6b80, 0xddf420})
        /usr/local/go/src/runtime/panic.go:884 +0x212
github.com/open-policy-agent/opa/ast.unify1(0xc000012558, 0xc0000120f0, {0xde5c88?, 0x117b4d8?}, 0x0?)
        /workspaces/opa/ast/check.go:538 +0x74a
github.com/open-policy-agent/opa/ast.(*typeChecker).checkExprBuiltin(0x9fbde0?, 0xc0000a0900?, 0xc000548100)
        /workspaces/opa/ast/check.go:337 +0xb05
github.com/open-policy-agent/opa/ast.(*typeChecker).checkExpr(0xc000690d20, 0x117b4d8?, 0xc000548100)
        /workspaces/opa/ast/check.go:286 +0x105
github.com/open-policy-agent/opa/ast.(*typeChecker).CheckBody.func1(0x0?)
        /workspaces/opa/ast/check.go:119 +0x334
github.com/open-policy-agent/opa/ast.WalkExprs.func1({0xa75e40?, 0xc000548100?})
        /workspaces/opa/ast/visit.go:217 +0x36
github.com/open-policy-agent/opa/ast.(*GenericVisitor).Walk(0xc00011d720, {0xa75e40?, 0xc000548100?})
        /workspaces/opa/ast/visit.go:282 +0x5f
github.com/open-policy-agent/opa/ast.(*GenericVisitor).Walk(0xc00011d720, {0xa61240?, 0xc000012588?})
        /workspaces/opa/ast/visit.go:323 +0xedb
github.com/open-policy-agent/opa/ast.WalkExprs({0xa61240, 0xc000012588}, 0xc0000c6ee0)
        /workspaces/opa/ast/visit.go:221 +0x9a
github.com/open-policy-agent/opa/ast.(*typeChecker).CheckBody(0xc000690d20, 0xc0000a0900?, {0xc00011d718, 0x1, 0x1})
        /workspaces/opa/ast/check.go:102 +0x107
github.com/open-policy-agent/opa/ast.TestCheckBuiltinErrors.func1(0xc000720000)
        /workspaces/opa/ast/check_test.go:783 +0x137
testing.tRunner(0xc000720000, 0xc000571ef0)
        /usr/local/go/src/testing/testing.go:1446 +0x10b
created by testing.(*T).Run
        /usr/local/go/src/testing/testing.go:1493 +0x35f
exit status 2
FAIL    github.com/open-policy-agent/opa/ast    0.648s
```

https://github.com/open-policy-agent/opa/blob/4bc74912372fd5479cb8700074582723316d3b06/ast/check.go#L538

Can someone please help me to solve this issue?