### PR TITLE
types: Add GoDoc about name types

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -48,6 +48,8 @@ func NewNull() Null {
 	return Null{}
 }
 
+// NamedType represents a type alias with an arbitrary name and description.
+// This is useful for generating documentation for built-in functions.
 type NamedType struct {
 	Name, Descr string
 	Type        Type
@@ -77,6 +79,9 @@ func (n *NamedType) Description(d string) *NamedType {
 	return n
 }
 
+// Named returns the passed type as a named type.
+// Named types are only valid at the top level of built-in functions.
+// Note that nested named types cause panic.
 func Named(name string, t Type) *NamedType {
 	return &NamedType{
 		Type: t,


### PR DESCRIPTION
<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->

Fixes https://github.com/open-policy-agent/opa/issues/5582

It is the intended behavior that nested named types are not allowed.

This PR adds GoDoc to `types.Named` and `types.NamedType` to avoid confusion.