### PR TITLE
Show prominent warning when viewing old docs

### DIFF
--- a/docs/website/assets/sass/docs.sass
+++ b/docs/website/assets/sass/docs.sass
@@ -134,27 +134,32 @@ $panel-header-logo-width: 85%
   padding: 0 2rem 0 0
 
 .banner-version-warning
-  margin-bottom: 0 !important // override bulma default
+  // override bulma defaults for messages
+  margin-bottom: 0 !important
   border-radius: 0
   font-size: 1.2rem
   font-weight: bold
   border-top: 1rem solid transparent
   border-bottom: 1rem solid transparent
+  .message-body
+    border: none
+    border-radius: 0
 
+  // this is used to make the banner appear in the same position as the page
+  // scrolls
   position: fixed
   width: 100%
   z-index: 100
 
-
+  // different types of message should have different colors. The colors are
+  // duplicated from the bulma since we're not using variables
   &.is-danger
     border-image: 50 repeating-linear-gradient(75deg, #cc0f35 0, #cc0f35 1rem, transparent 0, transparent 2rem);
   &.is-warning
     border-image: 50 repeating-linear-gradient(75deg, #946c00 0, #946c00 1rem, transparent 0, transparent 2rem);
 
+  // the hidden clone of the message is used to 'push down' the dashboard
+  // when a message is being displayed by the correct amount
   &.hidden
     visibility: hidden
     position: relative
-
-  .message-body
-    border: none
-    border-radius: 0

--- a/docs/website/assets/sass/docs.sass
+++ b/docs/website/assets/sass/docs.sass
@@ -15,7 +15,6 @@ $panel-header-logo-width: 85%
   +row
   position: relative
   overflow: hidden
-  height: 100vh
 
   .is-scrollable
     overflow-y: auto
@@ -133,3 +132,29 @@ $panel-header-logo-width: 85%
 .dashboard-panel-content
   margin: 0 0 0 2rem
   padding: 0 2rem 0 0
+
+.banner-version-warning
+  margin-bottom: 0 !important // override bulma default
+  border-radius: 0
+  font-size: 1.2rem
+  font-weight: bold
+  border-top: 1rem solid transparent
+  border-bottom: 1rem solid transparent
+
+  position: fixed
+  width: 100%
+  z-index: 100
+
+
+  &.is-danger
+    border-image: 50 repeating-linear-gradient(75deg, #cc0f35 0, #cc0f35 1rem, transparent 0, transparent 2rem);
+  &.is-warning
+    border-image: 50 repeating-linear-gradient(75deg, #946c00 0, #946c00 1rem, transparent 0, transparent 2rem);
+
+  &.hidden
+    visibility: hidden
+    position: relative
+
+  .message-body
+    border: none
+    border-radius: 0

--- a/docs/website/layouts/partials/docs/article.html
+++ b/docs/website/layouts/partials/docs/article.html
@@ -1,32 +1,4 @@
-{{ $releases   := site.Data.releases }}
-{{ $version    := index (split .File.Path "/") 1 }}
-{{ $latest     := printf "%s" (index $releases 1) }}
-{{- if eq (len $releases) 1 -}}
-{{- $latest = "(dev preview)" -}}
-{{- end -}}
-
-{{ $rank := 1 }}
-{{- range $index, $ver := $releases -}}
-  {{- if eq $ver $version -}}
-    {{ $rank = $index }}
-  {{- end -}}
-{{- end -}}
-{{ $ancient := gt $rank 5 }}
-
 <article class="article">
-  {{- if (eq $version "edge") }}
-  <div class="message is-danger">
-    <div class="message-body">
-      This version is still under development! Latest stable release is <a href="/docs/latest">{{ $latest }}</a>
-    </div>
-  </div>
-  {{- else if (and (ne $version "latest") (ne $version $latest)) }}
-  <div class="message {{ cond $ancient "is-danger" "is-warning"}}">
-    <div class="message-body">
-      These are the docs for an older version of OPA. Latest stable release is <a href="/docs/latest">{{ $latest }}</a>
-    </div>
-  </div>
-  {{- end }}
   <div class="container">
     {{ partial "docs/hero.html" . }}
 

--- a/docs/website/layouts/partials/docs/banner-version-warning.html
+++ b/docs/website/layouts/partials/docs/banner-version-warning.html
@@ -1,0 +1,47 @@
+{{- $latest := "latest" -}}
+{{- if eq (len site.Data.releases) 1 -}}
+{{- $latest = "edge" -}}
+{{- end -}}
+
+{{ $releases            := site.Data.releases }}
+
+{{ $version             := index (split .File.Path "/") 1 }}
+
+{{ $latestVersionString := printf "%s" (index $releases 1) }}
+{{- if eq (len $releases) 1 -}}
+{{- $latestVersionString = "(dev preview)" -}}
+{{- end -}}
+
+{{ $rank := 1 }}
+{{- range $index, $ver := site.Data.releases -}}
+{{- if eq $ver $version -}}
+{{ $rank = $index }}
+{{- end -}}
+{{- end -}}
+{{ $ancient := gt $rank 5 }}
+
+{{- if (eq $version "edge") }}
+  <div class="message is-danger banner-version-warning">
+    <div class="message-body">
+      This version is still under development! Latest stable release is <a href="/docs/latest">{{ $latestVersionString }}</a>
+    </div>
+  </div>
+  <!-- this is here to add make sure the space in the dom is retained and pushes down the dashboard the correct amount-->
+  <div class="message is-danger banner-version-warning hidden">
+    <div class="message-body">
+      This version is still under development! Latest stable release is <a href="/docs/latest">{{ $latestVersionString }}</a>
+    </div>
+  </div>
+{{- else if (and (ne $version "latest") (ne $version $latest)) }}
+  <div class="message {{ cond $ancient "is-danger" "is-warning"}} banner-version-warning">
+    <div class="message-body">
+      These are the docs for an older version of OPA ({{ $version }}). Latest stable release is <a href="/docs/latest">{{ $latestVersionString }}</a>
+    </div>
+  </div>
+  <!-- this is here to add make sure the space in the dom is retained and pushes down the dashboard the correct amount-->
+  <div class="message {{ cond $ancient "is-danger" "is-warning"}} banner-version-warning hidden ">
+    <div class="message-body">
+      These are the docs for an older version of OPA ({{ $version }}). Latest stable release is <a href="/docs/latest">{{ $latestVersionString }}</a>
+    </div>
+  </div>
+{{- end }}

--- a/docs/website/layouts/partials/docs/dashboard.html
+++ b/docs/website/layouts/partials/docs/dashboard.html
@@ -1,3 +1,5 @@
+{{ partial "docs/banner-version-warning.html" . }}
+
 <div class="dashboard">
   {{ partial "docs/dashboard-panel.html" . }}
 


### PR DESCRIPTION
We have issues were some old pages still rank in search engines. This change is intended to make it clearer to users who land on the docs from such results that they are viewing outdated version of the docs.

https://user-images.githubusercontent.com/1774239/214556730-58a56ea8-108f-43c6-874a-4afe35a1ef80.mov

