### PR TITLE
perf: use json.Encode to avoid extra allocation

### DIFF
--- a/server/server_test.go
+++ b/server/server_test.go
@@ -3431,7 +3431,7 @@ func TestUnversionedPost(t *testing.T) {
 	f.reset()
 	f.server.Handler.ServeHTTP(f.recorder, post())
 
-	expected := `{"agg":6}`
+	expected := "{\"agg\":6}\n"
 	if f.recorder.Code != 200 || f.recorder.Body.String() != expected {
 		t.Fatalf(`Expected HTTP 200 / %v but got: %v`, expected, f.recorder)
 	}

--- a/server/writer/writer.go
+++ b/server/writer/writer.go
@@ -58,26 +58,17 @@ func Error(w http.ResponseWriter, status int, err *types.ErrorV1) {
 // JSON writes a response with the specified status code and object. The object
 // will be JSON serialized.
 func JSON(w http.ResponseWriter, code int, v interface{}, pretty bool) {
-
-	var bs []byte
-	var err error
-
+	enc := json.NewEncoder(w)
 	if pretty {
-		bs, err = json.MarshalIndent(v, "", "  ")
-	} else {
-		bs, err = json.Marshal(v)
+		enc.SetIndent("", "  ")
 	}
 
-	if err != nil {
+	w.Header().Add("Content-Type", "application/json")
+	w.WriteHeader(code)
+
+	if err := enc.Encode(v); err != nil {
 		ErrorAuto(w, err)
 		return
-	}
-	headers := w.Header()
-	headers.Add("Content-Type", "application/json")
-	Bytes(w, code, bs)
-
-	if pretty {
-		_, _ = w.Write([]byte("\n"))
 	}
 }
 

--- a/test/e2e/distributedtracing/distributedtracing_test.go
+++ b/test/e2e/distributedtracing/distributedtracing_test.go
@@ -77,7 +77,7 @@ func TestServerSpan(t *testing.T) {
 			attribute.Int("http.status_code", 200),
 			attribute.String("http.target", "/v0/data"),
 			attribute.String("http.user_agent", "Go-http-client/1.1"),
-			attribute.Int("http.wrote_bytes", 2),
+			attribute.Int("http.wrote_bytes", 3),
 			attribute.String("net.transport", "ip_tcp"),
 		}
 		compareSpanAttributes(t, expected, attribute.NewSet(spans[0].Attributes...))
@@ -111,7 +111,7 @@ func TestServerSpan(t *testing.T) {
 			attribute.Int("http.status_code", 200),
 			attribute.String("http.target", "/v1/data"),
 			attribute.String("http.user_agent", "Go-http-client/1.1"),
-			attribute.Int("http.wrote_bytes", 66),
+			attribute.Int("http.wrote_bytes", 67),
 			attribute.String("net.transport", "ip_tcp"),
 		}
 		compareSpanAttributes(t, expected, attribute.NewSet(spans[0].Attributes...))


### PR DESCRIPTION
When sending JSON back to the client — and we do a lot of that, use the streaming implementation of json.Encode rather than marshalling the data into an intermediate byte array.

One curious detail here is that the streaming implementation uses newlines to mark the end of the stream, so a few unit tests had to be updated to expect this. Previously we would only emit a trailing newline if "pretty" was configured.

Signed-off-by: Anders Eknert <anders@styra.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->
