### PR TITLE
Make warning banner closeable, edge banner is more understated

### DIFF
--- a/docs/website/assets/js/app.js
+++ b/docs/website/assets/js/app.js
@@ -1,3 +1,9 @@
+function initBannerVersionWarningCloseButton() {
+  $(".banner-version-warning").find(".delete").click(function() {
+    $(".banner-version-warning").remove();
+  });
+}
+
 function navbarBurger() {
   $(".navbar-burger").click(function() {
     $(".navbar-burger").toggleClass("is-active");
@@ -18,6 +24,8 @@ $(function() {
 
 document.addEventListener("DOMContentLoaded", function(event) {
   anchors.add();
+
+  initBannerVersionWarningCloseButton();
 
   // TODO: We should probably look into updating the tocbot library
   // but for now we can pad the bottom of the content to make

--- a/docs/website/assets/sass/docs.sass
+++ b/docs/website/assets/sass/docs.sass
@@ -144,6 +144,9 @@ $panel-header-logo-width: 85%
   .message-body
     border: none
     border-radius: 0
+    button.delete
+      float: right
+      margin-top: 0.25rem
 
   // this is used to make the banner appear in the same position as the page
   // scrolls
@@ -154,9 +157,11 @@ $panel-header-logo-width: 85%
   // different types of message should have different colors. The colors are
   // duplicated from the bulma since we're not using variables
   &.is-danger
-    border-image: 50 repeating-linear-gradient(75deg, #cc0f35 0, #cc0f35 1rem, transparent 0, transparent 2rem);
+    border-image: 50 repeating-linear-gradient(75deg, #cc0f35 0, #cc0f35 1rem, transparent 0, transparent 2rem)
   &.is-warning
-    border-image: 50 repeating-linear-gradient(75deg, #946c00 0, #946c00 1rem, transparent 0, transparent 2rem);
+    border-image: 50 repeating-linear-gradient(75deg, #946c00 0, #946c00 1rem, transparent 0, transparent 2rem)
+  &.is-info
+    border-image: 50 repeating-linear-gradient(75deg, #296fa8 0, #296fa8 1rem, transparent 0, transparent 2rem)
 
   // the hidden clone of the message is used to 'push down' the dashboard
   // when a message is being displayed by the correct amount

--- a/docs/website/layouts/partials/docs/banner-version-warning.html
+++ b/docs/website/layouts/partials/docs/banner-version-warning.html
@@ -21,9 +21,10 @@
 {{ $ancient := gt $rank 5 }}
 
 {{- if (eq $version "edge") }}
-  <div class="message is-danger banner-version-warning">
+  <div class="message is-info banner-version-warning">
     <div class="message-body">
       This version is still under development! Latest stable release is <a href="/docs/latest">{{ $latestVersionString }}</a>
+      <button class="delete" aria-label="delete"></button>
     </div>
   </div>
   <!-- this is here to add make sure the space in the dom is retained and pushes down the dashboard the correct amount-->
@@ -36,6 +37,9 @@
   <div class="message {{ cond $ancient "is-danger" "is-warning"}} banner-version-warning">
     <div class="message-body">
       These are the docs for an older version of OPA ({{ $version }}). Latest stable release is <a href="/docs/latest">{{ $latestVersionString }}</a>
+      {{ if not $ancient }}
+        <button class="delete" aria-label="delete"></button>
+      {{ end }}
     </div>
   </div>
   <!-- this is here to add make sure the space in the dom is retained and pushes down the dashboard the correct amount-->


### PR DESCRIPTION
Responding to feedback on https://github.com/open-policy-agent/opa/pull/5592 in the OPA slack. https://openpolicyagent.slack.com/archives/C02L1TLPN59/p1674674181401449

https://user-images.githubusercontent.com/1774239/214808668-39fa6fc2-790e-49e4-bedd-54e55dd56f7a.mov



'ancient' version banners cannot be dismissed.

Signed-off-by: Charlie Egan <charlie@styra.com>
