### PR TITLE
Update rule index's trie node scalars to use custom map

### DIFF
--- a/test/cases/testdata/eqexpr/test-eqexpr-0599.yaml
+++ b/test/cases/testdata/eqexpr/test-eqexpr-0599.yaml
@@ -1,0 +1,19 @@
+cases:
+  - input_term: "1.0"
+    modules:
+      - |
+        package test
+        p { input == 1.0 }
+    note: "eqexpr/indexing: input is 1.0"
+    query: data.test.p = x
+    want_result:
+      - x: true
+  - input_term: "1"
+    modules:
+      - |
+        package test
+        p { input == 1.0 }
+    note: "eqexpr/indexing: input is 1"
+    query: data.test.p = x
+    want_result:
+      - x: true


### PR DESCRIPTION
Earlier the trie's scalar used map[ast.Value]trieNode. This resulted in unexpected key comparison results such as 1 != 1.0 when key types were ast.Number for example. This change updates the scalar to use a util.HashMap instead that will utilize ast.Compare to perfom key comparisons.

Fixes: #5585

Signed-off-by: Ashutosh Narkar <anarkar4387@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->
