### PR TITLE
Fix tocbot 100vh issue and fix navbar

### DIFF
--- a/docs/website/assets/sass/custom.sass
+++ b/docs/website/assets/sass/custom.sass
@@ -65,7 +65,7 @@
 
     +touch
       width: 100%
-    
+
     .hero-body
       padding: 2rem 1.5rem 0 3rem
 

--- a/docs/website/assets/sass/docs.sass
+++ b/docs/website/assets/sass/docs.sass
@@ -129,6 +129,20 @@ $panel-header-logo-width: 85%
 .highlight
   margin-bottom: 1.5rem // matches what live-blocks does
 
+.dashboard-wrapper
+  display: flex
+  flex-flow: column
+  height: 100%
+  max-height: 100vh
+
+.dashboard
+  flex: 1 1 auto
+
+  .navbar
+    @media screen and (min-width: 1024px)
+      position: sticky
+      top: 0
+
 .dashboard-panel-content
   margin: 0 0 0 2rem
   padding: 0 2rem 0 0
@@ -166,5 +180,6 @@ $panel-header-logo-width: 85%
   // the hidden clone of the message is used to 'push down' the dashboard
   // when a message is being displayed by the correct amount
   &.hidden
+    flex: 0 1 auto
     visibility: hidden
     position: relative

--- a/docs/website/layouts/docs/section.en.html
+++ b/docs/website/layouts/docs/section.en.html
@@ -3,5 +3,7 @@
 {{ end }}
 
 {{ define "main" }}
-{{ partial "docs/dashboard.html" . }}
+<div class="dashboard-wrapper">
+  {{ partial "docs/dashboard.html" . }}
+</div>
 {{ end }}

--- a/docs/website/layouts/docs/single.en.html
+++ b/docs/website/layouts/docs/single.en.html
@@ -3,5 +3,7 @@
 {{ end }}
 
 {{ define "main" }}
-{{ partial "docs/dashboard.html" . }}
+<div class="dashboard-wrapper">
+  {{ partial "docs/dashboard.html" . }}
+</div>
 {{ end }}


### PR DESCRIPTION
There seems to be some feature of tocbot which changes the behavior of the menu based on its size.

I have also fixed the nav as the page scrolls so search is more readily accessible.

A horizontal scroll bar is also present to allow full built-in table contents to be viewed on narrow screen sizes. These are currently clipped.

Signed-off-by: Charlie Egan <charlie@styra.com>

Comparison showing browsable toc fix:

https://user-images.githubusercontent.com/1774239/215470841-a20c109b-24aa-4591-b457-60fad6ed9515.mov

Comparison showing fixed (sticky) nav while scrolling:

https://user-images.githubusercontent.com/1774239/215470885-f0c18cae-ef63-4e74-afc6-d0e54fbabe7c.mov

Comparison showing table clipping bug and h scrolling:

https://user-images.githubusercontent.com/1774239/215470896-ae6d896e-cc8a-410d-9164-df54b6b5466f.mov

