### PR TITLE
docs/graphql: non-nullable id argument and typo fix.

### DIFF
--- a/docs/content/graphql-api-authorization.md
+++ b/docs/content/graphql-api-authorization.md
@@ -41,14 +41,14 @@ schema {
 }
 
 type Query {
-  employeeByID(id: String): Employee
+  employeeByID(id: String!): Employee
 }
 ```
 
 Every GraphQL service has a `query` type, and may or may not have a `mutation` type.
 These types are special because they define the entry points of *every* GraphQL query for the API covered by that schema.
 
-For our example above, we've defined exactly one query entry point, the parameterized query `user(id: Int)`.
+For our example above, we've defined exactly one query entry point, the parameterized query `employeeByID(id: String!)`.
 
 ### 2. Create a policy bundle.
 


### PR DESCRIPTION
Note: This PR is a resubmission of the content of #5528, since the original author could not be reached for DCO signoff.

-----

This commit fixes a typo in the GraphQL tutorial, and changes the `optional` ID field to `required`, to better mimic real world usage.

Corresponding PR in the tutorial code repo: StyraInc/graphql-apollo-example#2

Original author: @dreglad (in PR #5528)