### PR TITLE
topdown: http.send to cache responses based on status code

### DIFF
--- a/docs/content/policy-reference.md
+++ b/docs/content/policy-reference.md
@@ -902,7 +902,8 @@ instead of halting evaluation, if `http.send` encounters an error, it can return
 set to `0` and `error` describing the actual error. This can be activated by setting the `raise_error` field
 in the `request` object to `false`.
 
-If the `cache` field in the `request` object is `true`, `http.send` will return a cached response after it checks its freshness and validity.
+If the `cache` field in the `request` object is `true`, `http.send` will return a cached response after it checks its
+freshness and validity.
 
 `http.send` uses the `Cache-Control` and `Expires` response headers to check the freshness of the cached response.
 Specifically if the [max-age](https://tools.ietf.org/html/rfc7234#section-5.2.2.8) `Cache-Control` directive is set, `http.send`
@@ -918,6 +919,10 @@ conjunction with the `force_cache_duration_seconds` field. If `force_cache` is `
 **must** be specified and `http.send` will use this value to check the freshness of the cached response.
 
 Also, if `force_cache` is `true`, it overrides the `cache` field.
+
+`http.send` only caches responses with the following HTTP status codes: `200`, `203`, `204`, `206`, `300`, `301`,
+`404`, `405`, `410`, `414`, and `501`. This is behavior is as per https://www.rfc-editor.org/rfc/rfc7231#section-6.1 and
+is enforced when caching responses within a single query or across queries via the `cache` and `force_cache` request fields.
 
 {{< info >}}
 `http.send` uses the `Date` response header to calculate the current age of the response by comparing it with the current time.


### PR DESCRIPTION
Currently http.send caches all responses. Now if the response had a status code of `500`(Internal Server Error ) for example, it's possible OPA will return a reponse from the cache for the next query. This can have unintened consequences as OPA will keep serving the cached response till it's fresh while at the same time it's possible the server has a proper response available. To avoid such as scenario this change updates the caching behavior to take into account the status code of the HTTP response before inserting a value into the cache. The list of status codes that can be cached is per https://www.rfc-editor.org/rfc/rfc7231#section-6.1.

Fixes: #5617

Signed-off-by: Ashutosh Narkar <anarkar4387@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->
