### PR TITLE
server: pass decision_id via ctx, cleanup RemoteAddr -> RequestContext.ClientAddr

### DIFF
--- a/logging/logging.go
+++ b/logging/logging.go
@@ -220,3 +220,14 @@ func FromContext(ctx context.Context) (*RequestContext, bool) {
 	requestContext, ok := ctx.Value(reqCtxKey).(*RequestContext)
 	return requestContext, ok
 }
+
+const decisionCtxKey = requestContextKey("decision_id")
+
+func WithDecisionID(parent context.Context, id string) context.Context {
+	return context.WithValue(parent, decisionCtxKey, id)
+}
+
+func DecisionIDFromContext(ctx context.Context) (string, bool) {
+	s, ok := ctx.Value(decisionCtxKey).(string)
+	return s, ok
+}

--- a/logging/logging_test.go
+++ b/logging/logging_test.go
@@ -2,8 +2,12 @@ package logging
 
 import (
 	"bytes"
+	"context"
+	"crypto/rand"
 	"strings"
 	"testing"
+
+	"github.com/open-policy-agent/opa/internal/uuid"
 )
 
 func TestWithFields(t *testing.T) {
@@ -124,5 +128,21 @@ func TestRequestContextFields(t *testing.T) {
 
 	if fieldvalue.(string) != "/test" {
 		t.Fatal("Fields did not contain the configured req_path value")
+	}
+}
+
+func TestDecsionIDFromContext(t *testing.T) {
+	id, err := uuid.New(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := WithDecisionID(context.Background(), id)
+
+	act, ok := DecisionIDFromContext(ctx)
+	if !ok {
+		t.Fatalf("expected 'ok' to be true")
+	}
+	if exp := id; act != exp {
+		t.Errorf("Expected %q to be %q", act, exp)
 	}
 }


### PR DESCRIPTION
Just a small cleanup in the server handler code. Ctx is for request-scoped data, so let's put the decision ID there, too.

Our Eval and Log helper methods have way too many arguments already.
