### PR TITLE
Drop Google Universal Analytics (UA) code

### DIFF
--- a/docs/website/config.toml
+++ b/docs/website/config.toml
@@ -2,7 +2,6 @@ title = "Open Policy Agent"
 baseURL = "https://openpolicyagent.org"
 languageCode = "en"
 disableKinds = ["taxonomy", "taxonomyTerm"]
-googleAnalytics = "UA-84550302-1"
 
 pygmentsCodeFences = true
 pygmentsUseClasses = false
@@ -37,7 +36,7 @@ navbar = "/img/logos/opa-icon-white.png"
 
 [params.ui]
 [params.ui.feedback]
-# Requires googleAnalytics to be set to track feedback events
+# Requires Google Analytics to be enabled for the site.
 # Set hide_feedback: true in a page's front matter to disable feedback for that page
 enable = true
 

--- a/docs/website/layouts/partials/docs/article.html
+++ b/docs/website/layouts/partials/docs/article.html
@@ -6,7 +6,7 @@
       <div class="content">
         {{ .Content }}
       </div>
-      {{ if (and (not .Params.hide_feedback) (site.Params.ui.feedback.enable) (site.GoogleAnalytics)) }}
+      {{ if (and (not .Params.hide_feedback) (site.Params.ui.feedback.enable)) }}
         {{ partial "feedback.html" site.Params.ui.feedback }}
       {{ end }}
       <div class="toc-padding"></div>

--- a/docs/website/layouts/partials/google-analytics.html
+++ b/docs/website/layouts/partials/google-analytics.html
@@ -1,4 +1,10 @@
-{{ $id := site.GoogleAnalytics }}
+{{ with site.GoogleAnalytics -}}
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ . }}"></script>
 <script>
-(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');ga('create', '{{ $id }}', 'auto');ga('send', 'pageview');
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', '{{ . }}');
 </script>
+{{ end -}}


### PR DESCRIPTION
- Closes #5384
- I've kept the `docs/website/layouts/partials/google-analytics.html` shortcode and updated it in case you ever decide to opt out of Netlify snippet injection. If you prefer, I can drop the shortcode too.
- Note that the UA ID is connected from the GA4 ID, so it will _continue to receive events_, until Google terminates support for UA

/cc @srenatus 