### PR TITLE
repl: only use ToLower on the input command

### DIFF
--- a/repl/repl.go
+++ b/repl/repl.go
@@ -1354,12 +1354,13 @@ type command struct {
 }
 
 func newCommand(line string) *command {
-	p := strings.Fields(strings.TrimSpace(strings.ToLower(line)))
+	p := strings.Fields(strings.TrimSpace(line))
 	if len(p) == 0 {
 		return nil
 	}
+	inputCommand := strings.ToLower(p[0])
 	for _, c := range builtin {
-		if c.name == p[0] {
+		if c.name == inputCommand {
 			return &command{
 				op:   c.name,
 				args: p[1:],


### PR DESCRIPTION
This PR fixes #5229. As noted by @burnerlee, to fix the issue it is necessary to avoid that arguments of command processed by [this line of code](https://github.com/open-policy-agent/opa/blob/50d4e31d6b41382f8fa4d29f8be30b6974e4da74/repl/repl.go#L1357) are converted to lower case.

@srenatus suggested an approach in which only the actual command is converted to lower case, while the arguments (in the case of the issue a file path) are not touched.

This PR realizes the proposed fix. In addition to that, the comment mentioning the fixed issue in the test [TestDumpPath](https://github.com/Trolloldem/opa/blob/9f700a7651e6a6c2c992ee9d743d3b5dd37c01bb/repl/repl_test.go#L277) has been removed and a new test called [TestDumpPathCaseSensitive](https://github.com/Trolloldem/opa/blob/9f700a7651e6a6c2c992ee9d743d3b5dd37c01bb/repl/repl_test.go#L324) to check that CamelCase file paths are correctly processed.
