### PR TITLE
Add JSON Schema validation built-ins

### DIFF
--- a/ast/builtins.go
+++ b/ast/builtins.go
@@ -172,6 +172,10 @@ var DefaultBuiltins = [...]*Builtin{
 	JSONRemove,
 	JSONPatch,
 
+	// JSON Schema
+	JSONSchemaIsValid,
+	JSONSchemaValidate,
+
 	// Tokens
 	JWTDecode,
 	JWTVerifyRS256,
@@ -2911,6 +2915,50 @@ var SemVerCompare = &Builtin{
 		),
 		types.Named("result", types.N).Description("`-1` if `a < b`; `1` if `a > b`; `0` if `a == b`"),
 	),
+}
+
+/**
+ * JSON Schema
+ */
+
+var jsonschema = category("jsonschema")
+
+var JSONSchemaIsValid = &Builtin{
+	Name:        "jsonschema.is_valid",
+	Description: "Validates that the input is valid according to the passed JSON schema.",
+	Decl: types.NewFunction(
+		types.Args(
+			types.Named("schema", types.S),
+			types.Named("doc", types.A),
+		),
+		types.Named("result", types.B).Description("`true` if `doc` is a valid instance of the json schema passed in `schema`"),
+	),
+	Categories: jsonschema,
+}
+
+var JSONSchemaValidate = &Builtin{
+	Name:        "jsonschema.validate",
+	Description: "Validates against a passed JSON Schema and returns a set of validation errors.",
+	Decl: types.NewFunction(
+		types.Args(
+			types.Named("schema", types.S),
+			types.Named("doc", types.A),
+		),
+		types.Named("result",
+			types.NewSet(
+				types.NewObject(
+					[]*types.StaticProperty{
+						{Key: "error", Value: types.S},
+						{Key: "type", Value: types.S},
+						{Key: "field", Value: types.S},
+						{Key: "desc", Value: types.S},
+					},
+					nil,
+				),
+			),
+		).Description("A set of validation errors if `doc` is invalid against `schema`"),
+	),
+	Categories: jsonschema,
 }
 
 /**

--- a/test/cases/testdata/jsonschemabuiltins/test-is-valid.yaml
+++ b/test/cases/testdata/jsonschemabuiltins/test-is-valid.yaml
@@ -1,0 +1,47 @@
+cases:
+- note: jsonschemabuiltins/is_valid
+  query: data.test.p = x
+  modules:
+  - |
+    package test
+
+    documents = [
+      "plainstring",
+      {},
+      false
+    ]
+
+    schema := "{ \"type\": \"string\" }"
+
+    p = [x | doc = documents[_]; jsonschema.is_valid(schema, doc, x)]
+  strict_error: true
+  want_result:
+  - x:
+    - true
+    - false
+    - false
+
+- note: jsonschemabuiltins/validate
+  query: data.test.p = x
+  modules:
+  - |
+    package test
+
+    documents = [
+      "plainstring",
+      {},
+      false
+    ]
+
+    schema := "{ \"type\": \"string\" }"
+
+    p = [x | doc = documents[_]; jsonschema.validate(schema, doc, x)]
+  strict_error: true
+  want_result:
+  - x:
+    - []
+    - [{"description": "Invalid type. Expected: string, given: object", "error": "(Root): Invalid type. Expected: string, given: object", "field": "(Root)", "type": "invalid_type"}]
+    - [{"description": "Invalid type. Expected: string, given: boolean", "error": "(Root): Invalid type. Expected: string, given: boolean", "field": "(Root)", "type": "invalid_type"}]
+
+    
+

--- a/topdown/jsonschema.go
+++ b/topdown/jsonschema.go
@@ -1,0 +1,65 @@
+package topdown
+
+import (
+	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/internal/gojsonschema"
+	"github.com/open-policy-agent/opa/topdown/builtins"
+)
+
+// implements topdown.BuiltinFunc
+func builtinJSONSchemaIsValid(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term) error) error {
+	result, err := validateSchema(operands)
+	if err != nil {
+		return err
+	}
+
+	return iter(ast.BooleanTerm(result.Valid()))
+}
+
+// implements topdown.BuiltinFunc
+func builtinJSONSchemaValidate(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term) error) error {
+	result, err := validateSchema(operands)
+	if err != nil {
+		return err
+	}
+
+	var validationErrorTerms []*ast.Term
+	for _, err := range result.Errors() {
+		term := ast.ObjectTerm(
+			[2]*ast.Term{ast.StringTerm("error"), ast.StringTerm(err.String())},
+			[2]*ast.Term{ast.StringTerm("type"), ast.StringTerm(err.Type())},
+			[2]*ast.Term{ast.StringTerm("field"), ast.StringTerm(err.Field())},
+			[2]*ast.Term{ast.StringTerm("description"), ast.StringTerm(err.Description())},
+		)
+		validationErrorTerms = append(validationErrorTerms, term)
+	}
+
+	return iter(ast.SetTerm(validationErrorTerms...))
+}
+
+func validateSchema(operands []*ast.Term) (*gojsonschema.Result, error) {
+	schema, err := builtins.StringOperand(operands[0].Value, 1)
+	if err != nil {
+		return nil, err
+	}
+
+	schemaLoader := gojsonschema.NewStringLoader(string(schema))
+
+	document, err := ast.JSON(operands[1].Value)
+	if err != nil {
+		return nil, err
+	}
+	documentLoader := gojsonschema.NewGoLoader(document)
+
+	result, err := gojsonschema.Validate(schemaLoader, documentLoader)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func init() {
+	RegisterBuiltinFunc(ast.JSONSchemaIsValid.Name, builtinJSONSchemaIsValid)
+	RegisterBuiltinFunc(ast.JSONSchemaValidate.Name, builtinJSONSchemaValidate)
+}

--- a/topdown/jsonschema.go
+++ b/topdown/jsonschema.go
@@ -23,15 +23,16 @@ func builtinJSONSchemaValidate(_ BuiltinContext, operands []*ast.Term, iter func
 		return err
 	}
 
-	var validationErrorTerms []*ast.Term
-	for _, err := range result.Errors() {
+	var validationErrorTerms []*ast.Term = make([]*ast.Term, len(result.Errors()))
+	for i, err := range result.Errors() {
 		term := ast.ObjectTerm(
 			[2]*ast.Term{ast.StringTerm("error"), ast.StringTerm(err.String())},
 			[2]*ast.Term{ast.StringTerm("type"), ast.StringTerm(err.Type())},
 			[2]*ast.Term{ast.StringTerm("field"), ast.StringTerm(err.Field())},
 			[2]*ast.Term{ast.StringTerm("description"), ast.StringTerm(err.Description())},
 		)
-		validationErrorTerms = append(validationErrorTerms, term)
+
+		validationErrorTerms[i] = term
 	}
 
 	return iter(ast.SetTerm(validationErrorTerms...))


### PR DESCRIPTION
Implements #1449 by adding two new built-ins:

* `jsonschema.is_valid(schema, doc)` which is just `true|false`
* `jsonschema.validate(schema, doc)` which returns a set of validation errors

Both built-ins expect the schema encoded as a string and the document as any value. The expectation is that this is mostly useful to validate structures of existing rego objects vs. existing JSON structures. 
