### PR TITLE
[discovery] Catch missing discovery bundle name

### DIFF
--- a/plugins/discovery/config.go
+++ b/plugins/discovery/config.go
@@ -20,7 +20,7 @@ import (
 // Config represents the configuration for the discovery feature.
 type Config struct {
 	download.Config                            // bundle downloader configuration
-	Name            *string                    `json:"name"`               // name of the discovery bundle
+	Name            *string                    `json:"name"`               // Deprecated: name of the discovery bundle, use `Resource` instead.
 	Prefix          *string                    `json:"prefix,omitempty"`   // Deprecated: use `Resource` instead.
 	Decision        *string                    `json:"decision"`           // the name of the query to run on the bundle to get the config
 	Service         string                     `json:"service"`            // the name of the service used to download discovery bundle from
@@ -98,7 +98,7 @@ func (c *Config) validateAndInjectDefaults(services []string, confKeys map[strin
 	if c.Signing != nil {
 		err := c.Signing.ValidateAndInjectDefaults(copy)
 		if err != nil {
-			return fmt.Errorf("invalid configuration for discovery service %q: %s", *c.Name, err.Error())
+			return fmt.Errorf("invalid configuration for discovery service: %s", err.Error())
 		}
 	} else {
 		if len(confKeys) > 0 {

--- a/plugins/discovery/config_test.go
+++ b/plugins/discovery/config_test.go
@@ -69,10 +69,10 @@ func TestConfigValidation(t *testing.T) {
 		t.Run(fmt.Sprintf("TestConfigValidation_case_%d", i), func(t *testing.T) {
 			_, err := NewConfigBuilder().WithBytes([]byte(test.input)).WithServices(test.services).WithKeyConfigs(keys).Parse()
 			if err != nil && !test.wantErr {
-				t.Fail()
+				t.Fatalf("unexpected error while parsing config: %s", err.Error())
 			}
 			if err == nil && test.wantErr {
-				t.Fail()
+				t.Fatal("expected error while parsing config, but got none")
 			}
 		})
 	}
@@ -137,7 +137,7 @@ func TestConfigService(t *testing.T) {
 		t.Run(fmt.Sprintf("TestConfigService_case_%d", i), func(t *testing.T) {
 			c, err := NewConfigBuilder().WithBytes([]byte(test.input)).WithServices(test.services).Parse()
 			if err != nil {
-				t.Fatal("unexpected error while parsing config")
+				t.Fatalf("unexpected error while parsing config: %s", err)
 			}
 
 			if c.service != test.service {
@@ -174,7 +174,7 @@ func TestConfigPath(t *testing.T) {
 		t.Run(fmt.Sprintf("TestConfigDecision_case_%d", i), func(t *testing.T) {
 			c, err := NewConfigBuilder().WithBytes([]byte(test.input)).WithServices([]string{"service1"}).Parse()
 			if err != nil {
-				t.Fatal("unexpected error while parsing config")
+				t.Fatalf("unexpected error while parsing config: %s", err.Error())
 			}
 
 			if c.path != test.path {

--- a/plugins/discovery/discovery.go
+++ b/plugins/discovery/discovery.go
@@ -249,12 +249,12 @@ func (c *Discovery) loadAndActivateBundleFromDisk(ctx context.Context) {
 }
 
 func (c *Discovery) loadBundleFromDisk() (*bundleApi.Bundle, error) {
-	return bundleUtils.LoadBundleFromDisk(c.bundlePersistPath, *c.config.Name, c.config.Signing)
+	return bundleUtils.LoadBundleFromDisk(c.bundlePersistPath, c.discoveryBundleDirName(), c.config.Signing)
 }
 
 func (c *Discovery) saveBundleToDisk(raw io.Reader) error {
 
-	bundleDir := filepath.Join(c.bundlePersistPath, *c.config.Name)
+	bundleDir := filepath.Join(c.bundlePersistPath, c.discoveryBundleDirName())
 	bundleFile := filepath.Join(bundleDir, "bundle.tar.gz")
 
 	tmpFile, saveErr := saveCurrentBundleToDisk(bundleDir, raw)
@@ -329,7 +329,7 @@ func (c *Discovery) processUpdate(ctx context.Context, u download.Update) {
 				c.downloader.SetCache("")
 				return
 			}
-			c.logger.Debug("Discovery bundle persisted to disk successfully at path %v.", filepath.Join(c.bundlePersistPath, *c.config.Name))
+			c.logger.Debug("Discovery bundle persisted to disk successfully at path %v.", filepath.Join(c.bundlePersistPath, c.discoveryBundleDirName()))
 		}
 
 		c.status.SetError(nil)
@@ -427,6 +427,15 @@ func (c *Discovery) processBundle(ctx context.Context, b *bundleApi.Bundle) (*pl
 	}
 
 	return getPluginSet(c.factories, c.manager, config, c.metrics, c.config.Trigger)
+}
+
+// discoveryBundleDirName returns the name of the directory where the discovery bundle will be persisted.
+// It wraps the deprecated config.Name and uses Name as a default.
+func (c *Discovery) discoveryBundleDirName() string {
+	if c.config.Name != nil {
+		return *c.config.Name
+	}
+	return Name
 }
 
 func evaluateBundle(ctx context.Context, id string, info *ast.Term, b *bundleApi.Bundle, query string) (*config.Config, error) {

--- a/plugins/discovery/discovery_test.go
+++ b/plugins/discovery/discovery_test.go
@@ -20,22 +20,19 @@ import (
 	"testing"
 	"time"
 
-	"github.com/open-policy-agent/opa/storage"
-
-	"github.com/open-policy-agent/opa/rego"
-
-	"github.com/open-policy-agent/opa/logging/test"
-
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/bundle"
 	bundleApi "github.com/open-policy-agent/opa/bundle"
 	"github.com/open-policy-agent/opa/download"
+	"github.com/open-policy-agent/opa/logging/test"
 	"github.com/open-policy-agent/opa/metrics"
 	"github.com/open-policy-agent/opa/plugins"
 	bundlePlugin "github.com/open-policy-agent/opa/plugins/bundle"
 	"github.com/open-policy-agent/opa/plugins/logs"
 	"github.com/open-policy-agent/opa/plugins/status"
+	"github.com/open-policy-agent/opa/rego"
 	"github.com/open-policy-agent/opa/server"
+	"github.com/open-policy-agent/opa/storage"
 	inmem "github.com/open-policy-agent/opa/storage/inmem/test"
 	"github.com/open-policy-agent/opa/topdown/cache"
 	"github.com/open-policy-agent/opa/util"


### PR DESCRIPTION
I ran into this error while working on https://github.com/open-policy-agent/opa/pull/5687

```
$ opa run -s --config-file=config.yaml
{"addrs":[":8181"],"diagnostic-addrs":[],"level":"info","msg":"Initializing server.","time":"2023-03-01T16:25:09Z"}
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x101614e50]

goroutine 1 [running]:
github.com/open-policy-agent/opa/plugins/discovery.(*Discovery).loadBundleFromDisk(...)
        /Users/charlieegan3/Code/opa/plugins/discovery/discovery.go:252
```

When using this config:

```
services:
  example:
    url: http://localhost:8080

discovery:
  service: example
  resource: /configuration/example/discovery.tar.gz
  persist: true
```

To address this I have wrapped the problematic uses of the deprecated Name field in a function which provides a default. I had hoped to do more, but the use of these deprecated fields is prevalent in the package tests and I thought I'd share this fix as is before spending longer on it.
