### PR TITLE
Update OPA images to use non-root uid/gid by default 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Breaking changes
 
+All published OPA images now run with a non-root uid/gid. The `uid:gid` is set to `1000:1000` for all images. As a result
+there is no longer a need for the `-rootless` image variant and hence it will be not be published after the current release.
+This change is in line with container security best practices. OPA can still be run with root privileges by explicitly setting the user,
+either with the `--user` argument for `docker run`, or by specifying the `securityContext` in the Kubernetes Pod specification.
+
 The change to the `package` scope in [#5251](https://github.com/open-policy-agent/opa/issues/5251) may cause compile-time errors and behavioural changes to type checking when the `schemas` annotation is used, and to rules calling the `rego.metadata.chain()` built-in function:
 
 - Existing projects with the same package declared in multiple files will trigger a `rego_type_error: package annotation redeclared` error _if_ two or more of these are annotated with the `package` scope.

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,16 +9,17 @@ FROM ${BASE}
 LABEL org.opencontainers.image.authors="Torin Sandall <torinsandall@gmail.com>"
 LABEL org.opencontainers.image.source="https://github.com/open-policy-agent/opa"
 
+
 # Temporarily allow us to identify whether running from within an offical
-# Docker image, so that we may print a warning when uid or gid == 0 (root)
-# Remove once https://github.com/open-policy-agent/opa/issues/4295 is done
-ENV OPA_DOCKER_IMAGE="official"
+# Docker image with a "rootless" tag, so that we may print a warning that this image tag
+# will not be published after 0.50.0. Remove after 0.50.0 release.
+ARG OPA_DOCKER_IMAGE_TAG
+ENV OPA_DOCKER_IMAGE_TAG=${OPA_DOCKER_IMAGE_TAG}
 
 # Any non-zero number will do, and unfortunately a named user will not, as k8s
 # pod securityContext runAsNonRoot can't resolve the user ID:
-# https://github.com/kubernetes/kubernetes/issues/40958. Make root (uid 0) when
-# not specified.
-ARG USER=0
+# https://github.com/kubernetes/kubernetes/issues/40958.
+ARG USER=1000:1000
 USER ${USER}
 
 # TARGETOS and TARGETARCH are automatic platform args injected by BuildKit

--- a/docs/content/graphql-api-authorization.md
+++ b/docs/content/graphql-api-authorization.md
@@ -170,7 +170,7 @@ Next, create a `docker-compose.yml` file that runs OPA, a bundle server and the 
 ```yaml
 services:
   opa:
-    image: openpolicyagent/opa:{{< current_docker_version >}}-rootless
+    image: openpolicyagent/opa:{{< current_docker_version >}}
     ports:
       - "8181:8181"
     command:

--- a/docs/content/http-api-authorization.md
+++ b/docs/content/http-api-authorization.md
@@ -78,7 +78,7 @@ Next, create a `docker-compose.yml` file that runs OPA, a bundle server and the 
 version: '2'
 services:
   opa:
-    image: openpolicyagent/opa:{{< current_docker_version >}}-rootless
+    image: openpolicyagent/opa:{{< current_docker_version >}}
     ports:
     - 8181:8181
     # WARNING: OPA is NOT running with an authorization policy configured. This

--- a/docs/content/kafka-authorization.md
+++ b/docs/content/kafka-authorization.md
@@ -82,7 +82,7 @@ services:
     ports:
       - "80:80"
   opa:
-    image: openpolicyagent/opa:{{< current_docker_version >}}-rootless
+    image: openpolicyagent/opa:{{< current_docker_version >}}
     ports:
       - "8181:8181"
     command:

--- a/docs/content/kubernetes-tutorial.md
+++ b/docs/content/kubernetes-tutorial.md
@@ -335,7 +335,7 @@ spec:
         # authentication and authorization on the daemon. See the Security page for
         # details: https://www.openpolicyagent.org/docs/security.html.
         - name: opa
-          image: openpolicyagent/opa:{{< current_docker_version >}}-rootless
+          image: openpolicyagent/opa:{{< current_docker_version >}}
           args:
             - "run"
             - "--server"

--- a/runtime/check_user_linux.go
+++ b/runtime/check_user_linux.go
@@ -14,14 +14,20 @@ import (
 // checkUserPrivileges on Linux could be running in Docker, so we check if
 // we're running in the official container image.
 func checkUserPrivileges(logger logging.Logger) {
+	var message string
+
 	usr, err := user.Current()
 	if err != nil {
 		logger.Debug("Failed to determine uid/gid of process owner")
 	} else if usr.Uid == "0" || usr.Gid == "0" {
-		message := "OPA running with uid or gid 0. Running OPA with root privileges is not recommended."
-		if os.Getenv("OPA_DOCKER_IMAGE") == "official" {
-			message += " Use the -rootless image to avoid running with root privileges. This will be made the default in later OPA releases."
-		}
+		message = "OPA running with uid or gid 0. Running OPA with root privileges is not recommended."
+	}
+
+	if os.Getenv("OPA_DOCKER_IMAGE_TAG") == "rootless" {
+		message += " The -rootless image tag will not be published after OPA v0.50.0."
+	}
+
+	if message != "" {
 		logger.Warn(message)
 	}
 }


### PR DESCRIPTION
Currently all OPA image variants except "rootless" use
uid/gid 0 (i.e. root). Per container security best
practices it is better to run as non-root. So now OPA
defaults to non-root uid/gid in images. If root user
if needed, it can be explicitly set.

The "rootless" image variant is no longer needed and
will be not published in future releases.

Also currently the debug variant is published
for `linux/amd64` platform. For `linux/arm64` only static
images are generated. The debug variant can be useful
for debugging purposes and hence this change adds that
to the static image which can then be used on amd64 and arm64 arch.
<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->
