### PR TITLE
Old Search Box still appearing in UI (After Algolia Upgrade)

### DIFF
--- a/docs/website/layouts/partials/docs/navbar.html
+++ b/docs/website/layouts/partials/docs/navbar.html
@@ -114,7 +114,6 @@
       <div class="navbar-item">
         <p class="control has-icons-right">
           <div id="docsearch">
-          <input class="input" type="search" id="search-bar" placeholder="Search...">
           </div>
           <span class="icon is-small is-right">
             <icon />

--- a/docs/website/layouts/partials/javascript.html
+++ b/docs/website/layouts/partials/javascript.html
@@ -18,12 +18,6 @@
 {{ $apiKey  := site.Params.algolia_api_key }}
 <script>
   console.log("You are reading the docs for version {{ $version }} of Open Policy Agent");
-
-  window.onload = function() {
-    // Log a message to the console if the #search-bar element does not exist on the page
-    if (!document.getElementById('search-bar')) {
-      console.error('#search-bar element not found on the page')
-    }
     docsearch({
       container: '#docsearch',
       appId: 'P4N61UNFMP',
@@ -31,6 +25,5 @@
       apiKey: '{{ $apiKey }}',
       searchParameters: { 'facetFilters': ["version:{{ $version }}"] }
     });
-  }
 </script>
 {{ end }}


### PR DESCRIPTION
Hey Team :wave: 

I noticed after #5706 that the old search bar still appears in the Nav-bar.

This PR should hopefully address this issue, I also removed the `window.onload` function because I don't think it's needed, it should just load Algolia and not wait for the window to load.. but open to discussing this!

Thank you!