### PR TITLE
[docs] Use www domain for site base URL

### DIFF
--- a/docs/website/config.toml
+++ b/docs/website/config.toml
@@ -1,5 +1,5 @@
 title = "Open Policy Agent"
-baseURL = "https://openpolicyagent.org"
+baseURL = "https://www.openpolicyagent.org"
 languageCode = "en"
 disableKinds = ["taxonomy", "taxonomyTerm"]
 


### PR DESCRIPTION
The base URL is used to generate Permalinks in hugo:

https://gohugo.io/content-management/urls/

We then use page permalinks to generate the canonical URL:

https://github.com/open-policy-agent/opa/blob/09f1724270abe9b17a440c035d3837303688e268/docs/website/layouts/partials/meta.html#L47

This causes issues for the algolia crawler since www.openpolicyagent.org is the domain used in there, and not openpolicyagent.org.

Given that we don't seem to use it either:

```
$ curl -I https://openpolicyagent.org/docs/v0.43.1/policy-language/
HTTP/2 301
location: https://www.openpolicyagent.org/docs/v0.43.1/policy-language/
...
```

I think it makes sense to update this to www. This is being done as follow on from: https://github.com/open-policy-agent/opa/pull/5706


