### PR TITLE
decision logging: remove unused inter-query cache setup

### DIFF
--- a/plugins/logs/plugin.go
+++ b/plugins/logs/plugin.go
@@ -29,7 +29,6 @@ import (
 	"github.com/open-policy-agent/opa/rego"
 	"github.com/open-policy-agent/opa/server"
 	"github.com/open-policy-agent/opa/storage"
-	"github.com/open-policy-agent/opa/topdown/cache"
 	"github.com/open-policy-agent/opa/util"
 )
 
@@ -979,7 +978,6 @@ func (p *Plugin) dropEvent(ctx context.Context, txn storage.Transaction, event *
 
 		if p.drop == nil {
 			query := ast.NewBody(ast.NewExpr(ast.NewTerm(p.config.dropDecisionRef)))
-			interQueryCache := cache.NewInterQueryCache(p.manager.InterQueryBuiltinCacheConfig())
 			r := rego.New(
 				rego.ParsedQuery(query),
 				rego.Compiler(p.manager.GetCompiler()),
@@ -988,7 +986,6 @@ func (p *Plugin) dropEvent(ctx context.Context, txn storage.Transaction, event *
 				rego.Runtime(p.manager.Info),
 				rego.EnablePrintStatements(p.manager.EnablePrintStatements()),
 				rego.PrintHook(p.manager.PrintHook()),
-				rego.InterQueryBuiltinCache(interQueryCache),
 			)
 
 			pq, err := r.PrepareForEval(context.Background())


### PR DESCRIPTION
Since a cache was created per request, this did not work as intended. As it's unlikely that http.send is used in decision log drop/masking decisions, it should be alright to leave this out until this is requested, if ever.

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->
