### PR TITLE
plugins: Surface decision log errors via status API

### DIFF
--- a/docs/content/management-status.md
+++ b/docs/content/management-status.md
@@ -221,32 +221,36 @@ on the agent, updates will be sent to `/status`.
 
 Status updates contain the following fields:
 
-| Field | Type | Description |
-| --- | --- | --- |
-| `labels` | `object` | Set of key-value pairs that uniquely identify the OPA instance. |
-| `bundles` | `object` | Set of objects describing the status for each bundle configured with OPA. |
-| `bundles[_].name` | `string` | Name of bundle that the OPA instance is configured to download. |
-| `bundles[_].active_revision` | `string` | Opaque revision identifier of the last successful activation. |
-| `bundles[_].last_request` | `string` | RFC3339 timestamp of last bundle request. This timestamp should be >= to the successful request timestamp in normal operation. |
-| `bundles[_].last_successful_request` | `string` | RFC3339 timestamp of last successful bundle request. This timestamp should be >= to the successful download timestamp in normal operation. |
-| `bundles[_].last_successful_download` | `string` | RFC3339 timestamp of last successful bundle download. |
-| `bundles[_].last_successful_activation` | `string` | RFC3339 timestamp of last successful bundle activation. |
-| `bundles[_].metrics` | `object` | Metrics from the last update of the bundle. |
-| `bundles[_].code` | `string` | If present, indicates error(s) occurred activating this bundle. |
-| `bundles[_].message` | `string` | Human readable messages describing the error(s). |
-| `bundles[_].http_code` | `number` | If present, indicates an erroneous HTTP status code that OPA received downloading this bundle. |
-| `bundles[_].errors` | `array` | Collection of detailed parse or compile errors that occurred during activation of this bundle. |
-| `bundles[_].size` | `number` | Bundle size, in bytes |
-| `bundles[_].type` | `string` | Bundle type, either `snapshot` or `delta` |
-| `discovery.name` | `string` | Name of discovery bundle that the OPA instance is configured to download. |
-| `discovery.active_revision` | `string` | Opaque revision identifier of the last successful discovery activation. |
-| `discovery.last_request` | `string` | RFC3339 timestamp of last discovery bundle request. This timestamp should be >= to the successful request timestamp in normal operation. |
+| Field               | Type | Description                                                                                                                                          |
+|---------------------| --- |------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `labels`            | `object` | Set of key-value pairs that uniquely identify the OPA instance.                                                                                      |
+| `bundles`           | `object` | Set of objects describing the status for each bundle configured with OPA.                                                                            |
+| `bundles[_].name`   | `string` | Name of bundle that the OPA instance is configured to download.                                                                                      |
+| `bundles[_].active_revision` | `string` | Opaque revision identifier of the last successful activation.                                                                                        |
+| `bundles[_].last_request` | `string` | RFC3339 timestamp of last bundle request. This timestamp should be >= to the successful request timestamp in normal operation.                       |
+| `bundles[_].last_successful_request` | `string` | RFC3339 timestamp of last successful bundle request. This timestamp should be >= to the successful download timestamp in normal operation.           |
+| `bundles[_].last_successful_download` | `string` | RFC3339 timestamp of last successful bundle download.                                                                                                |
+| `bundles[_].last_successful_activation` | `string` | RFC3339 timestamp of last successful bundle activation.                                                                                              |
+| `bundles[_].metrics` | `object` | Metrics from the last update of the bundle.                                                                                                          |
+| `bundles[_].code`   | `string` | If present, indicates error(s) occurred activating this bundle.                                                                                      |
+| `bundles[_].message` | `string` | Human readable messages describing the error(s).                                                                                                     |
+| `bundles[_].http_code` | `number` | If present, indicates an erroneous HTTP status code that OPA received downloading this bundle.                                                       |
+| `bundles[_].errors` | `array` | Collection of detailed parse or compile errors that occurred during activation of this bundle.                                                       |
+| `bundles[_].size`   | `number` | Bundle size, in bytes                                                                                                                                |
+| `bundles[_].type`   | `string` | Bundle type, either `snapshot` or `delta`                                                                                                            |
+| `discovery.name`    | `string` | Name of discovery bundle that the OPA instance is configured to download.                                                                            |
+| `discovery.active_revision` | `string` | Opaque revision identifier of the last successful discovery activation.                                                                              |
+| `discovery.last_request` | `string` | RFC3339 timestamp of last discovery bundle request. This timestamp should be >= to the successful request timestamp in normal operation.             |
 | `discovery.last_successful_request` | `string` | RFC3339 timestamp of last successful discovery bundle request. This timestamp should be >= to the successful download timestamp in normal operation. |
-| `discovery.last_successful_download` | `string` | RFC3339 timestamp of last successful discovery bundle download. |
-| `discovery.last_successful_activation` | `string` | RFC3339 timestamp of last successful discovery bundle activation. |
-| `plugins` | `object` | A set of objects describing the state of configured plugins in OPA's runtime. |
-| `plugins[_].state` | `string` | The state of each plugin. |
-| `metrics.prometheus` | `object` | Global performance metrics for the OPA instance. |
+| `discovery.last_successful_download` | `string` | RFC3339 timestamp of last successful discovery bundle download.                                                                                      |
+| `discovery.last_successful_activation` | `string` | RFC3339 timestamp of last successful discovery bundle activation.                                                                                    |
+| `decision_logs.code` | `string` | If present, indicates error(s) occurred during decision log upload event.                                                                            |
+| `decision_logs.message` | `string` | Human readable messages describing the error(s).                                                                                                     |
+| `decision_logs.http_code` | `number` | If present, indicates an erroneous HTTP status code that OPA received during a decision log upload event.                                            |
+| `decision_logs.metrics`   | `object` | Metrics from the last decision log upload event.                                                                                                     |
+| `plugins`           | `object` | A set of objects describing the state of configured plugins in OPA's runtime.                                                                        |
+| `plugins[_].state`  | `string` | The state of each plugin.                                                                                                                            |
+| `metrics.prometheus` | `object` | Global performance metrics for the OPA instance.                                                                                                     |
 
 If the discovery bundle download or activation failed, the status update will contain
 the following additional fields.

--- a/plugins/logs/status/status.go
+++ b/plugins/logs/status/status.go
@@ -1,0 +1,58 @@
+// Copyright 2023 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package status
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/open-policy-agent/opa/metrics"
+)
+
+const (
+	errCode = "decision_log_error"
+)
+
+// Status represents the status of processing a decision log.
+type Status struct {
+	Code     string          `json:"code,omitempty"`
+	Message  string          `json:"message,omitempty"`
+	HTTPCode json.Number     `json:"http_code,omitempty"`
+	Metrics  metrics.Metrics `json:"metrics,omitempty"`
+}
+
+// SetError updates the status object to reflect a failure to upload or
+// process a log. If err is nil, the error status is cleared.
+func (s *Status) SetError(err error) {
+	var httpError HTTPError
+
+	switch {
+	case err == nil:
+		s.Code = ""
+		s.HTTPCode = ""
+		s.Message = ""
+
+	case errors.As(err, &httpError):
+		s.Code = errCode
+		s.HTTPCode = json.Number(strconv.Itoa(httpError.StatusCode))
+		s.Message = err.Error()
+
+	default:
+		s.Code = errCode
+		s.HTTPCode = ""
+		s.Message = err.Error()
+	}
+}
+
+type HTTPError struct {
+	StatusCode int
+}
+
+func (e HTTPError) Error() string {
+	return fmt.Sprintf("log upload failed, server replied with HTTP %v %v", e.StatusCode, http.StatusText(e.StatusCode))
+}


### PR DESCRIPTION
Currently errors encountered during decision log uploads are logged. This change now includes these errors as part of status updates  which can be useful for the control plane to determine if OPA is having any issues while processing, uploading logs etc.

Fixes: #5637

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->
