### PR TITLE
Fix docs banner and search configuration

### DIFF
--- a/docs/website/layouts/partials/docs/banner-version-warning.html
+++ b/docs/website/layouts/partials/docs/banner-version-warning.html
@@ -33,7 +33,7 @@
       This version is still under development! Latest stable release is <a href="/docs/latest">{{ $latestVersionString }}</a>
     </div>
   </div>
-{{- else if (and (ne $version "latest") (ne $version $latest)) }}
+{{- else if (and (ne $version $latest) (ne $version $latestVersionString)) }}
   <div class="message {{ cond $ancient "is-danger" "is-warning"}} banner-version-warning">
     <div class="message-body">
       These are the docs for an older version of OPA ({{ $version }}). Latest stable release is <a href="/docs/latest">{{ $latestVersionString }}</a>

--- a/docs/website/layouts/partials/meta.html
+++ b/docs/website/layouts/partials/meta.html
@@ -1,15 +1,15 @@
-{{ $isHome        := .IsHome }}
-{{ $isDoc         := eq .Section "docs" }}
-{{ $title         := cond $isHome site.Title .Title }}
-{{ $description   := .Param "description" }}
-{{ $pageType      := cond $isHome "website" "article" }}
-{{ $imageUrl      := "/img/logos/opa-horizontal-color.png" | absURL }}
-{{ $twitter       := site.Params.social.twitter }}
-{{ $version       := index (split .File.Path "/") 1 }}
-{{ $page          := trim .RelPermalink "/" }}
-{{ $releases      := site.Data.releases }}
-{{ $latestVersion := index $releases 1 }}
-{{ $isLatest      := or (eq $version $latestVersion) (eq $version "latest") }}
+{{ $isHome      := .IsHome }}
+{{ $isDoc       := eq .Section "docs" }}
+{{ $title       := cond $isHome site.Title .Title }}
+{{ $description := .Param "description" }}
+{{ $pageType    := cond $isHome "website" "article" }}
+{{ $imageUrl    := "/img/logos/opa-horizontal-color.png" | absURL }}
+{{ $twitter     := site.Params.social.twitter }}
+{{ $version     := index (split .File.Path "/") 1 }}
+{{ $page       := trim .RelPermalink "/" }}
+{{ $releases   := site.Data.releases }}
+{{ $latest     := index $releases 1 }}
+{{ $isLatest   := or (eq $version $latest) (eq $version "latest") }}
 
 
 <!-- Basic metadata -->
@@ -52,11 +52,7 @@
 
 <!-- Algolia metadata -->
 <meta name="docsearch:language" content="en" />
-{{- if $isLatest -}}
-<link rel="docsearch:version" href="{{ $latestVersion }}">
-{{- else -}}
-<link rel="docsearch:version" href="{{ $version }}">
-{{- end -}}
+<meta name="docsearch:version" content="{{ $version }}" />
 
 <!-- Site generator -->
 {{ hugo.Generator }}


### PR DESCRIPTION
This PR fixes two issues:

Firstly, I'm not sure when this slipped in but we see this:

<img width="874" alt="Screenshot 2023-03-07 at 14 36 49" src="https://user-images.githubusercontent.com/1774239/223453884-e5c82e8f-711f-4200-b09e-c7fe627a430a.png">

(see https://www.openpolicyagent.org/docs/v0.49.2/)

I think I have addressed this in cd5a83267ddbc27e1c14ac1c27e21f0e086b3877 by also checking the version against the latest semver from the releases data.

This also makes the following change to search. Revert https://github.com/open-policy-agent/opa/pull/5730. It was a mistake to conflate 0.49.2 and latest as being the same. I think that we want to have these as two separate facet values so they can be searched independently. Otherwise, unless we ignore latest docs urls from indexing, there will be duplicates on latest and 0.49.2 which is undesirable. We might in future want to only index the latest version of the docs, however, for now, I think it makes sense to have all the records for all versions as we had before.

In addition to this, when this merges. I'll remove:

```js
            version:
              "div.dropdown-trigger > button > span:nth-child(1) > strong",
```

From the crawler config. This will make sure that only the meta tags are used for the version and won't conflate latest and 0.49.2.