### PR TITLE
Retract pre go module OPA versions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -96,3 +96,7 @@ require (
 // at a cost, its init function will lookup the current user, and on Windows, that's much
 // work.
 replace github.com/golang/glog => ./build/replacements/github.com/golang/glog
+
+// Before 0.15.0 OPA was not using go modules. We must retract these releases in order to have pkg.go.dev
+// show the latest versions. See: https://github.com/golang/go/issues/58925
+retract [v0.1.0-rc1, v0.14.2]


### PR DESCRIPTION
We have two versions of our go package docs showing in https://pkg.go.dev/.

A) open-policy-agent/OPA &
B) https://pkg.go.dev/github.com/open-policy-agent/opa

A appears to contain only versions up to 0.15.0 where we started using go modules. B is the correct one we want to keep using.

According to advice here: https://github.com/golang/go/issues/58925, we need to retract the old versions to have this page disappear. Given the time that has passed since the 0.15.0 release I hope we can make this change now.


https://user-images.githubusercontent.com/1774239/223995554-dfb3310a-8e23-48e3-b73f-0f7e60ee056c.mov

