### PR TITLE
refactor: Change most maps to be preallocated.

### DIFF
--- a/ast/check.go
+++ b/ast/check.go
@@ -95,12 +95,10 @@ func (tc *typeChecker) Env(builtins map[string]*Builtin) *TypeEnv {
 // are found. The resulting TypeEnv wraps the provided one. The resulting
 // TypeEnv will be able to resolve types of vars contained in the body.
 func (tc *typeChecker) CheckBody(env *TypeEnv, body Body) (*TypeEnv, Errors) {
-
 	errors := []*Error{}
 	env = tc.newEnv(env)
 
 	WalkExprs(body, func(expr *Expr) bool {
-
 		closureErrs := tc.checkClosures(env, expr)
 		for _, err := range closureErrs {
 			errors = append(errors, err)
@@ -174,7 +172,6 @@ func (tc *typeChecker) checkClosures(env *TypeEnv, expr *Expr) Errors {
 }
 
 func (tc *typeChecker) checkRule(env *TypeEnv, as *AnnotationSet, rule *Rule) {
-
 	env = env.wrap()
 
 	if schemaAnnots := getRuleAnnotation(as, rule); schemaAnnots != nil {
@@ -290,7 +287,6 @@ func (tc *typeChecker) checkExpr(env *TypeEnv, expr *Expr) *Error {
 }
 
 func (tc *typeChecker) checkExprBuiltin(env *TypeEnv, expr *Expr) *Error {
-
 	args := expr.Operands()
 	pre := getArgTypes(env, args)
 
@@ -350,7 +346,6 @@ func (tc *typeChecker) checkExprBuiltin(env *TypeEnv, expr *Expr) *Error {
 }
 
 func (tc *typeChecker) checkExprEq(env *TypeEnv, expr *Expr) *Error {
-
 	pre := getArgTypes(env, expr.Operands())
 	exp := Equality.Decl.FuncArgs()
 
@@ -399,7 +394,6 @@ func (tc *typeChecker) checkExprWith(env *TypeEnv, expr *Expr, i int) *Error {
 }
 
 func unify2(env *TypeEnv, a *Term, typeA types.Type, b *Term, typeB types.Type) bool {
-
 	nilA := types.Nil(typeA)
 	nilB := types.Nil(typeB)
 
@@ -603,7 +597,6 @@ func rewriteVarsNop(node Ref) Ref {
 }
 
 func newRefChecker(env *TypeEnv, f varRewriter) *refChecker {
-
 	if f == nil {
 		f = rewriteVarsNop
 	}
@@ -652,7 +645,6 @@ func (rc *refChecker) checkApply(curr *TypeEnv, ref Ref) *Error {
 }
 
 func (rc *refChecker) checkRef(curr *TypeEnv, node *typeTreeNode, ref Ref, idx int) *Error {
-
 	if idx == len(ref) {
 		return nil
 	}
@@ -713,7 +705,6 @@ func (rc *refChecker) checkRef(curr *TypeEnv, node *typeTreeNode, ref Ref, idx i
 }
 
 func (rc *refChecker) checkRefLeaf(tpe types.Type, ref Ref, idx int) *Error {
-
 	if idx == len(ref) {
 		return nil
 	}
@@ -760,7 +751,6 @@ func (rc *refChecker) checkRefLeaf(tpe types.Type, ref Ref, idx int) *Error {
 }
 
 func unifies(a, b types.Type) bool {
-
 	if a == nil || b == nil {
 		return false
 	}
@@ -845,7 +835,6 @@ func unifiesAny(a types.Any, b types.Type) bool {
 }
 
 func unifiesArrays(a, b *types.Array) bool {
-
 	if !unifiesArraysStatic(a, b) {
 		return false
 	}
@@ -1077,7 +1066,7 @@ func sortValueSlice(sl []Value) {
 }
 
 func removeDuplicate(list []Value) []Value {
-	seen := make(map[Value]bool)
+	seen := make(map[Value]bool, len(list))
 	var newResult []Value
 	for _, item := range list {
 		if !seen[item] {
@@ -1191,7 +1180,6 @@ func getObjectType(ref Ref, o types.Type, rule *Rule, d *types.DynamicProperty) 
 }
 
 func getRuleAnnotation(as *AnnotationSet, rule *Rule) (result []*SchemaAnnotation) {
-
 	for _, x := range as.GetSubpackagesScope(rule.Module.Package.Path) {
 		result = append(result, x.Schemas...)
 	}
@@ -1212,7 +1200,6 @@ func getRuleAnnotation(as *AnnotationSet, rule *Rule) (result []*SchemaAnnotatio
 }
 
 func processAnnotation(ss *SchemaSet, annot *SchemaAnnotation, rule *Rule, allowNet []string) (Ref, types.Type, *Error) {
-
 	var schema interface{}
 
 	if annot.Schema != nil {

--- a/ast/parser.go
+++ b/ast/parser.go
@@ -275,7 +275,6 @@ func (p *Parser) presentParser() (*Parser, map[string]tokens.Token) {
 // comments as they are found. Any errors encountered while
 // parsing will be accumulated and returned as a list of Errors.
 func (p *Parser) Parse() ([]Statement, []*Comment, Errors) {
-
 	if p.po.Capabilities == nil {
 		p.po.Capabilities = CapabilitiesForThisVersion()
 	}
@@ -411,7 +410,6 @@ func (p *Parser) Parse() ([]Statement, []*Comment, Errors) {
 }
 
 func (p *Parser) parseAnnotations(stmts []Statement) []Statement {
-
 	annotStmts, errs := parseAnnotations(p.s.comments)
 	for _, err := range errs {
 		p.error(err.Location, err.Message)
@@ -425,8 +423,7 @@ func (p *Parser) parseAnnotations(stmts []Statement) []Statement {
 }
 
 func parseAnnotations(comments []*Comment) ([]*Annotations, Errors) {
-
-	var hint = []byte("METADATA")
+	hint := []byte("METADATA")
 	var curr *metadataParser
 	var blocks []*metadataParser
 
@@ -463,7 +460,6 @@ func parseAnnotations(comments []*Comment) ([]*Annotations, Errors) {
 }
 
 func (p *Parser) parsePackage() *Package {
-
 	var pkg Package
 	pkg.SetLoc(p.s.Loc())
 
@@ -521,7 +517,6 @@ func (p *Parser) parsePackage() *Package {
 }
 
 func (p *Parser) parseImport() *Import {
-
 	var imp Import
 	imp.SetLoc(p.s.Loc())
 
@@ -591,7 +586,6 @@ func (p *Parser) parseImport() *Import {
 }
 
 func (p *Parser) parseRules() []*Rule {
-
 	var rule Rule
 	rule.SetLoc(p.s.Loc())
 
@@ -751,7 +745,6 @@ func (p *Parser) parseRules() []*Rule {
 }
 
 func (p *Parser) parseElse(head *Head) *Rule {
-
 	var rule Rule
 	rule.SetLoc(p.s.Loc())
 
@@ -832,7 +825,6 @@ func (p *Parser) parseElse(head *Head) *Rule {
 }
 
 func (p *Parser) parseHead(defaultRule bool) (*Head, bool) {
-
 	head := &Head{}
 	loc := p.s.Loc()
 	defer func() {
@@ -968,7 +960,6 @@ func (p *Parser) parseQuery(requireSemi bool, end tokens.Token) Body {
 }
 
 func (p *Parser) parseLiteral() (expr *Expr) {
-
 	offset := p.s.loc.Offset
 	loc := p.s.Loc()
 
@@ -1029,7 +1020,6 @@ func (p *Parser) parseLiteral() (expr *Expr) {
 }
 
 func (p *Parser) parseWith() []*With {
-
 	withs := []*With{}
 
 	for {
@@ -1080,7 +1070,6 @@ func (p *Parser) parseWith() []*With {
 }
 
 func (p *Parser) parseSome() *Expr {
-
 	decl := &SomeDecl{}
 	decl.SetLoc(p.s.Loc())
 
@@ -1224,7 +1213,6 @@ func (p *Parser) parseEvery() *Expr {
 }
 
 func (p *Parser) parseExpr() *Expr {
-
 	lhs := p.parseTermInfixCall()
 	if lhs == nil {
 		return nil
@@ -1554,7 +1542,6 @@ func (p *Parser) parseRawString() *Term {
 var setConstructor = RefTerm(VarTerm("set"))
 
 func (p *Parser) parseCall(operator *Term, offset int) (term *Term) {
-
 	loc := operator.Location
 	var end int
 
@@ -1583,7 +1570,6 @@ func (p *Parser) parseCall(operator *Term, offset int) (term *Term) {
 }
 
 func (p *Parser) parseRef(head *Term, offset int) (term *Term) {
-
 	loc := head.Location
 	var end int
 
@@ -1648,7 +1634,6 @@ func (p *Parser) parseRef(head *Term, offset int) (term *Term) {
 }
 
 func (p *Parser) parseArray() (term *Term) {
-
 	loc := p.s.Loc()
 	offset := p.s.loc.Offset
 
@@ -1976,7 +1961,6 @@ func (p *Parser) parseTermOpName(ref Ref, values ...tokens.Token) *Term {
 }
 
 func (p *Parser) parseVar() *Term {
-
 	s := p.s.lit
 
 	term := VarTerm(s).SetLocation(p.s.Loc())
@@ -2070,7 +2054,6 @@ func (p *Parser) scanWS() {
 }
 
 func (p *Parser) doScan(skipws bool) {
-
 	// NOTE(tsandall): the last position is used to compute the "text" field for
 	// complex AST nodes. Whitespace never affects the last position of an AST
 	// node so do not update it when scanning.
@@ -2211,7 +2194,6 @@ func (b *metadataParser) Append(c *Comment) {
 var yamlLineErrRegex = regexp.MustCompile(`^yaml:(?: unmarshal errors:[\n\s]*)? line ([[:digit:]]+):`)
 
 func (b *metadataParser) Parse() (*Annotations, error) {
-
 	var raw rawAnnotation
 
 	if len(bytes.TrimSpace(b.buf.Bytes())) == 0 {
@@ -2290,7 +2272,7 @@ func (b *metadataParser) Parse() (*Annotations, error) {
 		result.Authors = append(result.Authors, author)
 	}
 
-	result.Custom = make(map[string]interface{})
+	result.Custom = make(map[string]interface{}, len(raw.Custom))
 	for k, v := range raw.Custom {
 		val, err := convertYAMLMapKeyTypes(v, nil)
 		if err != nil {
@@ -2349,7 +2331,6 @@ var errInvalidSchemaRef = fmt.Errorf("invalid schema reference")
 // supported by the compiler or evaluator today. Once we fix that, we can remove
 // this function.
 func parseSchemaRef(s string) (Ref, error) {
-
 	term, err := ParseTerm(s)
 	if err == nil {
 		switch v := term.Value.(type) {
@@ -2429,8 +2410,10 @@ func getSafeString(m map[string]interface{}, k string) string {
 	return ""
 }
 
-const emailPrefix = "<"
-const emailSuffix = ">"
+const (
+	emailPrefix = "<"
+	emailSuffix = ">"
+)
 
 // parseAuthor parses a string into an AuthorAnnotation. If the last word of the input string is enclosed within <>,
 // it is extracted as the author's email. The email may not contain whitelines, as it then will be interpreted as

--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -151,7 +151,6 @@ func (m *Manifest) AddRoot(r string) {
 
 // Equal returns true if m is semantically equivalent to other.
 func (m Manifest) Equal(other Manifest) bool {
-
 	// This is safe since both are passed by value.
 	m.Init()
 	other.Init()
@@ -185,7 +184,7 @@ func (m Manifest) Copy() Manifest {
 	metadata := m.Metadata
 
 	if metadata != nil {
-		m.Metadata = make(map[string]interface{})
+		m.Metadata = make(map[string]interface{}, len(metadata))
 		for k, v := range metadata {
 			m.Metadata[k] = v
 		}
@@ -269,7 +268,6 @@ func (ss stringSet) Equal(other stringSet) bool {
 }
 
 func (m *Manifest) validateAndInjectDefaults(b Bundle) error {
-
 	m.Init()
 
 	// Validate roots in bundle.
@@ -497,7 +495,6 @@ func (r *Reader) ParserOptions() ast.ParserOptions {
 
 // Read returns a new Bundle loaded from the reader.
 func (r *Reader) Read() (Bundle, error) {
-
 	var bundle Bundle
 	var descriptors []*Descriptor
 	var err error
@@ -884,7 +881,6 @@ func (w *Writer) writePlan(tw *tar.Writer, bundle Bundle) error {
 }
 
 func writeManifest(tw *tar.Writer, bundle Bundle) error {
-
 	if bundle.Manifest.Empty() {
 		return nil
 	}
@@ -899,7 +895,6 @@ func writeManifest(tw *tar.Writer, bundle Bundle) error {
 }
 
 func writePatch(tw *tar.Writer, bundle Bundle) error {
-
 	var buf bytes.Buffer
 
 	if err := json.NewEncoder(&buf).Encode(bundle.Patch); err != nil {
@@ -910,7 +905,6 @@ func writePatch(tw *tar.Writer, bundle Bundle) error {
 }
 
 func writeSignatures(tw *tar.Writer, bundle Bundle) error {
-
 	if bundle.Signatures.isEmpty() {
 		return nil
 	}
@@ -924,7 +918,6 @@ func writeSignatures(tw *tar.Writer, bundle Bundle) error {
 }
 
 func hashBundleFiles(hash SignatureHasher, b *Bundle) ([]FileInfo, error) {
-
 	files := []FileInfo{}
 
 	bs, err := hash.HashFile(b.Data)
@@ -1012,7 +1005,6 @@ func (b *Bundle) FormatModules(useModulePath bool) error {
 
 // GenerateSignature generates the signature for the given bundle.
 func (b *Bundle) GenerateSignature(signingConfig *SigningConfig, keyID string, useModulePath bool) error {
-
 	hash, err := NewSignatureHasher(HashingAlgorithm(defaultHashingAlg))
 	if err != nil {
 		return err
@@ -1061,7 +1053,6 @@ func (b *Bundle) GenerateSignature(signingConfig *SigningConfig, keyID string, u
 // ParsedModules returns a map of parsed modules with names that are
 // unique and human readable for the given a bundle name.
 func (b *Bundle) ParsedModules(bundleName string) map[string]*ast.Module {
-
 	mods := make(map[string]*ast.Module, len(b.Modules))
 
 	for _, mf := range b.Modules {
@@ -1104,7 +1095,6 @@ func (b Bundle) Equal(other Bundle) bool {
 
 // Copy returns a deep copy of the bundle.
 func (b Bundle) Copy() Bundle {
-
 	// Copy data.
 	var x interface{} = b.Data
 
@@ -1149,7 +1139,6 @@ func (b *Bundle) insertData(key []string, value interface{}) error {
 }
 
 func (b *Bundle) readData(key []string) *interface{} {
-
 	if len(key) == 0 {
 		if len(b.Data) == 0 {
 			return nil
@@ -1217,7 +1206,6 @@ func mktree(path []string, value interface{}) (map[string]interface{}, error) {
 // will have an empty revision except in the special case where a single bundle is provided
 // (and in that case the bundle is just returned unmodified.)
 func Merge(bundles []*Bundle) (*Bundle, error) {
-
 	if len(bundles) == 0 {
 		return nil, errors.New("expected at least one bundle")
 	}
@@ -1290,7 +1278,6 @@ func rootPathSegments(path string) []string {
 }
 
 func rootContains(root []string, other []string) bool {
-
 	// A single segment, empty string root always contains the other.
 	if len(root) == 1 && root[0] == "" {
 		return true

--- a/bundle/sign.go
+++ b/bundle/sign.go
@@ -89,24 +89,27 @@ func (*DefaultSigner) GenerateSignedToken(files []FileInfo, sc *SigningConfig, k
 }
 
 func generatePayload(files []FileInfo, sc *SigningConfig, keyID string) ([]byte, error) {
-	payload := make(map[string]interface{})
-	payload["files"] = files
+	var payload map[string]interface{}
 
 	if sc.ClaimsPath != "" {
 		claims, err := sc.GetClaims()
 		if err != nil {
 			return nil, err
 		}
+		// Delay initialization of payload, so that we can prealloc.
+		payload = make(map[string]interface{}, len(claims)+1)
 
 		for claim, value := range claims {
 			payload[claim] = value
 		}
 	} else {
+		payload = make(map[string]interface{})
 		if keyID != "" {
 			// keyid claim is deprecated but include it for backwards compatibility.
 			payload["keyid"] = keyID
 		}
 	}
+	payload["files"] = files
 	return json.Marshal(payload)
 }
 

--- a/bundle/sign_test.go
+++ b/bundle/sign_test.go
@@ -19,7 +19,6 @@ import (
 )
 
 func TestGenerateSignedToken(t *testing.T) {
-
 	files := [][2]string{
 		{"/.manifest", `{"revision": "quickbrownfaux"}`},
 		{"/a/b/c/data.json", "[1,2,3]"},
@@ -70,7 +69,6 @@ func TestGenerateSignedToken(t *testing.T) {
 }
 
 func TestGenerateSignedTokenWithClaims(t *testing.T) {
-
 	files := [][2]string{
 		{"/.manifest", `{"revision": "quickbrownfaux"}`},
 		{"/a/b/d/data.json", "true"},
@@ -96,8 +94,7 @@ func TestGenerateSignedTokenWithClaims(t *testing.T) {
 	}
 
 	test.WithTempFS(map[string]string{}, func(rootDir string) {
-		claims := make(map[string]interface{})
-		claims["scope"] = "read"
+		claims := map[string]interface{}{"scope": "read"}
 
 		claimBytes, err := json.Marshal(claims)
 		if err != nil {
@@ -106,7 +103,7 @@ func TestGenerateSignedTokenWithClaims(t *testing.T) {
 
 		// create claims file
 		claimsFile := filepath.Join(rootDir, "claims.json")
-		if err := os.WriteFile(claimsFile, claimBytes, 0644); err != nil {
+		if err := os.WriteFile(claimsFile, claimBytes, 0o644); err != nil {
 			t.Fatalf("Unexpected error: %s", err)
 		}
 
@@ -138,7 +135,6 @@ func TestGenerateSignedTokenWithClaims(t *testing.T) {
 }
 
 func TestGeneratePayload(t *testing.T) {
-
 	files := [][2]string{
 		{"/.manifest", `{"revision": "quickbrownfaux"}`},
 	}

--- a/bundle/store.go
+++ b/bundle/store.go
@@ -335,7 +335,6 @@ func Deactivate(opts *DeactivateOpts) error {
 }
 
 func activateBundles(opts *ActivateOpts) error {
-
 	// Build collections of bundle names, modules, and roots to erase
 	erase := map[string]struct{}{}
 	names := map[string]struct{}{}
@@ -387,9 +386,7 @@ func activateBundles(opts *ActivateOpts) error {
 
 	// Validate data in bundle does not contain paths outside the bundle's roots.
 	for _, b := range snapshotBundles {
-
 		if b.lazyLoadingMode {
-
 			for _, item := range b.Raw {
 				path := filepath.ToSlash(item.Path)
 
@@ -442,7 +439,7 @@ func activateBundles(opts *ActivateOpts) error {
 	}
 
 	// Compile the modules all at once to avoid having to re-do work.
-	remainingAndExtra := make(map[string]*ast.Module)
+	remainingAndExtra := make(map[string]*ast.Module, len(remaining)+len(opts.ExtraModules))
 	for name, mod := range remaining {
 		remainingAndExtra[name] = mod
 	}
@@ -528,7 +525,6 @@ func doDFS(obj map[string]json.RawMessage, path string, roots []string) error {
 }
 
 func activateDeltaBundles(opts *ActivateOpts, bundles map[string]*Bundle) error {
-
 	// Check that the manifest roots and wasm resolvers in the delta bundle
 	// match with those currently in the store
 	for name, b := range bundles {
@@ -584,7 +580,6 @@ func activateDeltaBundles(opts *ActivateOpts, bundles map[string]*Bundle) error 
 // erase bundles by name and roots. This will clear all policies and data at its roots and remove its
 // manifest from storage.
 func eraseBundles(ctx context.Context, store storage.Store, txn storage.Transaction, names map[string]struct{}, roots map[string]struct{}) (map[string]*ast.Module, error) {
-
 	if err := eraseData(ctx, store, txn, roots); err != nil {
 		return nil, err
 	}
@@ -632,7 +627,6 @@ func eraseData(ctx context.Context, store storage.Store, txn storage.Transaction
 }
 
 func erasePolicies(ctx context.Context, store storage.Store, txn storage.Transaction, roots map[string]struct{}) (map[string]*ast.Module, error) {
-
 	ids, err := store.ListPolicies(ctx, txn)
 	if err != nil {
 		return nil, err
@@ -756,7 +750,6 @@ func writeData(ctx context.Context, store storage.Store, txn storage.Transaction
 }
 
 func compileModules(compiler *ast.Compiler, m metrics.Metrics, bundles map[string]*Bundle, extraModules map[string]*ast.Module, legacy bool) error {
-
 	m.Timer(metrics.RegoModuleCompile).Start()
 	defer m.Timer(metrics.RegoModuleCompile).Stop()
 
@@ -793,7 +786,6 @@ func compileModules(compiler *ast.Compiler, m metrics.Metrics, bundles map[strin
 }
 
 func writeModules(ctx context.Context, store storage.Store, txn storage.Transaction, compiler *ast.Compiler, m metrics.Metrics, bundles map[string]*Bundle, extraModules map[string]*ast.Module, legacy bool) error {
-
 	m.Timer(metrics.RegoModuleCompile).Start()
 	defer m.Timer(metrics.RegoModuleCompile).Stop()
 
@@ -962,8 +954,10 @@ func applyPatches(ctx context.Context, store storage.Store, txn storage.Transact
 
 // LegacyManifestStoragePath is the older unnamed bundle path for manifests to be stored.
 // Deprecated: Use ManifestStoragePath and named bundles instead.
-var legacyManifestStoragePath = storage.MustParsePath("/system/bundle/manifest")
-var legacyRevisionStoragePath = append(legacyManifestStoragePath, "revision")
+var (
+	legacyManifestStoragePath = storage.MustParsePath("/system/bundle/manifest")
+	legacyRevisionStoragePath = append(legacyManifestStoragePath, "revision")
+)
 
 // LegacyWriteManifestToStore will write the bundle manifest to the older single (unnamed) bundle manifest location.
 // Deprecated: Use WriteManifestToStore and named bundles instead.

--- a/bundle/verify.go
+++ b/bundle/verify.go
@@ -35,7 +35,7 @@ type Verifier interface {
 func VerifyBundleSignature(sc SignaturesConfig, bvc *VerificationConfig) (map[string]FileInfo, error) {
 	// default implementation does not return a nil for map, so don't
 	// do it here either
-	files := make(map[string]FileInfo)
+	files := map[string]FileInfo{}
 	var plugin string
 	// for backwards compatibility, check if there is no plugin specified, and use default
 	if sc.Plugin == "" {
@@ -57,7 +57,7 @@ type DefaultVerifier struct{}
 // VerifyBundleSignature verifies the bundle signature using the given public keys or secret.
 // If a signature is verified, it keeps track of the files specified in the JWT payload
 func (*DefaultVerifier) VerifyBundleSignature(sc SignaturesConfig, bvc *VerificationConfig) (map[string]FileInfo, error) {
-	files := make(map[string]FileInfo)
+	files := map[string]FileInfo{}
 
 	if len(sc.Signatures) == 0 {
 		return files, fmt.Errorf(".signatures.json: missing JWT (expected exactly one)")
@@ -73,6 +73,8 @@ func (*DefaultVerifier) VerifyBundleSignature(sc SignaturesConfig, bvc *Verifica
 			return files, err
 		}
 
+		// Prealloc map for FileInfo structs.
+		files = make(map[string]FileInfo, len(payload.Files))
 		for _, file := range payload.Files {
 			files[file.Name] = file
 		}

--- a/cmd/bench.go
+++ b/cmd/bench.go
@@ -139,7 +139,6 @@ type benchRunner interface {
 }
 
 func benchMain(args []string, params benchmarkCommandParams, w io.Writer, r benchRunner) (int, error) {
-
 	ctx := context.Background()
 
 	if params.e2e {
@@ -209,11 +208,9 @@ func benchMain(args []string, params benchmarkCommandParams, w io.Writer, r benc
 	return 0, nil
 }
 
-type goBenchRunner struct {
-}
+type goBenchRunner struct{}
 
 func (r *goBenchRunner) run(ctx context.Context, ectx *evalContext, params benchmarkCommandParams, f func(context.Context, ...rego.EvalOption) error) (testing.BenchmarkResult, error) {
-
 	var hist, m metrics.Metrics
 	if params.metrics {
 		hist = metrics.New()
@@ -225,7 +222,6 @@ func (r *goBenchRunner) run(ctx context.Context, ectx *evalContext, params bench
 	var benchErr error
 
 	br := testing.Benchmark(func(b *testing.B) {
-
 		// Track memory allocations, if enabled
 		if params.benchMem {
 			b.ReportAllocs()
@@ -412,7 +408,6 @@ func runE2E(params benchmarkCommandParams, url string, input map[string]interfac
 	var benchErr error
 
 	br := testing.Benchmark(func(b *testing.B) {
-
 		// Track memory allocations, if enabled
 		if params.benchMem {
 			b.ReportAllocs()
@@ -448,7 +443,6 @@ func runE2E(params benchmarkCommandParams, url string, input map[string]interfac
 							b.FailNow()
 						}
 						hist.Histogram(name).Update(num)
-
 					}
 				}
 			}
@@ -463,7 +457,6 @@ func runE2E(params benchmarkCommandParams, url string, input map[string]interfac
 }
 
 func e2eQuery(params benchmarkCommandParams, url string, input map[string]interface{}) (types.MetricsV1, error) {
-
 	reqBody, err := json.Marshal(input)
 	if err != nil {
 		return nil, err

--- a/cmd/eval.go
+++ b/cmd/eval.go
@@ -156,7 +156,6 @@ func (regoError) Error() string {
 }
 
 func init() {
-
 	params := newEvalCommandParams()
 
 	evalCommand := &cobra.Command{
@@ -269,7 +268,6 @@ access.
 			return validateEvalParams(&params, args)
 		},
 		Run: func(cmd *cobra.Command, args []string) {
-
 			defined, err := eval(args, params, os.Stdout)
 			if err != nil {
 				if _, ok := err.(regoError); !ok {
@@ -328,7 +326,6 @@ access.
 }
 
 func eval(args []string, params evalCommandParams, w io.Writer) (bool, error) {
-
 	ctx := context.Background()
 	if params.timeout != 0 {
 		var cancel func()
@@ -472,7 +469,7 @@ func evalOnce(ctx context.Context, ectx *evalContext) pr.Output {
 	}
 
 	if ectx.params.profile {
-		var sortOrder = pr.DefaultProfileSortOrder
+		sortOrder := pr.DefaultProfileSortOrder
 
 		if len(ectx.params.profileCriteria.v) != 0 {
 			sortOrder = getProfileSortOrder(strings.Split(ectx.params.profileCriteria.String(), ","))
@@ -685,9 +682,8 @@ func (r *resettableProfiler) TraceEvent(ev topdown.Event) { r.p.TraceEvent(ev) }
 func (r *resettableProfiler) Config() topdown.TraceConfig { return r.p.Config() }
 
 func getProfileSortOrder(sortOrder []string) []string {
-
 	// convert the sort order slice to a map for faster lookups
-	sortOrderMap := make(map[string]bool)
+	sortOrderMap := make(map[string]bool, len(sortOrder))
 	for _, cr := range sortOrder {
 		sortOrderMap[cr] = true
 	}

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -36,7 +36,7 @@ type Result struct {
 
 // ParsedModules returns the parsed modules stored on the result.
 func (l *Result) ParsedModules() map[string]*ast.Module {
-	modules := make(map[string]*ast.Module)
+	modules := make(map[string]*ast.Module, len(l.Modules))
 	for _, module := range l.Modules {
 		modules[module.Name] = module.Parsed
 	}
@@ -172,7 +172,6 @@ func (fl fileLoader) All(paths []string) (*Result, error) {
 // file/directory is excluded.
 func (fl fileLoader) Filtered(paths []string, filter Filter) (*Result, error) {
 	return all(fl.fsys, paths, filter, func(curr *Result, path string, depth int) error {
-
 		var (
 			bs  []byte
 			err error
@@ -316,7 +315,6 @@ func FilteredPathsFS(fsys fs.FS, paths []string, filter Filter) ([]string, error
 
 // Schemas loads a schema set from the specified file path.
 func Schemas(schemaPath string) (*ast.SchemaSet, error) {
-
 	var errs Errors
 	ss, err := loadSchemas(schemaPath)
 	if err != nil {
@@ -328,7 +326,6 @@ func Schemas(schemaPath string) (*ast.SchemaSet, error) {
 }
 
 func loadSchemas(schemaPath string) (*ast.SchemaSet, error) {
-
 	if schemaPath == "" {
 		return nil, nil
 	}
@@ -389,7 +386,6 @@ func loadSchemas(schemaPath string) (*ast.SchemaSet, error) {
 }
 
 func getSchemaSetByPathKey(path string) ast.Ref {
-
 	front := filepath.Dir(path)
 	last := strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
 
@@ -609,7 +605,6 @@ func all(fsys fs.FS, paths []string, filter Filter, f func(*Result, string, int)
 }
 
 func allRec(fsys fs.FS, path string, filter Filter, errors *Errors, loaded *Result, depth int, f func(*Result, string, int) error) {
-
 	path, err := fileurl.Clean(path)
 	if err != nil {
 		errors.add(err)

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -69,7 +69,9 @@ func (l *StandardLogger) SetFormatter(formatter logrus.Formatter) {
 // WithFields provides additional fields to include in log output
 func (l *StandardLogger) WithFields(fields map[string]interface{}) Logger {
 	cp := *l
-	cp.fields = make(map[string]interface{})
+	// We attempt to prealloc fields here. In the event that the two maps
+	// contain identical keys, we won't have oversized the map.
+	cp.fields = make(map[string]interface{}, max(len(cp.fields), len(fields)))
 	for k, v := range l.fields {
 		cp.fields[k] = v
 	}
@@ -77,6 +79,14 @@ func (l *StandardLogger) WithFields(fields map[string]interface{}) Logger {
 		cp.fields[k] = v
 	}
 	return &cp
+}
+
+// Utility function.
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
 }
 
 // getFields returns additional fields of this logger

--- a/logging/test/test.go
+++ b/logging/test/test.go
@@ -40,7 +40,7 @@ func (l *Logger) WithFields(fields map[string]interface{}) logging.Logger {
 		entries: l.entries,
 		fields:  l.fields,
 	}
-	flds := make(map[string]interface{})
+	flds := make(map[string]interface{}, max(len(cp.fields), len(fields)))
 	for k, v := range cp.fields {
 		flds[k] = v
 	}
@@ -49,6 +49,14 @@ func (l *Logger) WithFields(fields map[string]interface{}) logging.Logger {
 	}
 	cp.fields = flds
 	return &cp
+}
+
+// Utility function.
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
 }
 
 // Debug buffers a log message.

--- a/plugins/logs/plugin_test.go
+++ b/plugins/logs/plugin_test.go
@@ -91,7 +91,6 @@ func TestPluginCustomBackend(t *testing.T) {
 }
 
 func TestPluginCustomBackendAndHTTPServiceAndConsole(t *testing.T) {
-
 	ctx := context.Background()
 	backend := testPlugin{}
 	testLogger := test.New()
@@ -250,7 +249,6 @@ func TestPluginQueriesAndPaths(t *testing.T) {
 }
 
 func TestPluginStartSameInput(t *testing.T) {
-
 	ctx := context.Background()
 
 	fixture := newTestFixture(t)
@@ -330,7 +328,6 @@ func TestPluginStartSameInput(t *testing.T) {
 }
 
 func TestPluginStartChangingInputValues(t *testing.T) {
-
 	ctx := context.Background()
 
 	fixture := newTestFixture(t)
@@ -399,7 +396,6 @@ func TestPluginStartChangingInputValues(t *testing.T) {
 }
 
 func TestPluginStartChangingInputKeysAndValues(t *testing.T) {
-
 	ctx := context.Background()
 
 	fixture := newTestFixture(t)
@@ -460,7 +456,6 @@ func TestPluginStartChangingInputKeysAndValues(t *testing.T) {
 }
 
 func TestPluginRequeue(t *testing.T) {
-
 	ctx := context.Background()
 
 	fixture := newTestFixture(t)
@@ -1439,7 +1434,6 @@ func TestPluginTerminatesAfterGracefulShutdownPeriodWithoutLogs(t *testing.T) {
 }
 
 func TestPluginReconfigure(t *testing.T) {
-
 	ctx := context.Background()
 	fixture := newTestFixture(t)
 	defer fixture.server.stop()
@@ -1485,7 +1479,6 @@ func TestPluginReconfigure(t *testing.T) {
 }
 
 func TestPluginReconfigureUploadSizeLimit(t *testing.T) {
-
 	ctx := context.Background()
 	limit := int64(300)
 
@@ -1930,7 +1923,6 @@ func TestPluginMasking(t *testing.T) {
 				}
 
 			}
-
 		})
 	}
 }
@@ -1972,7 +1964,7 @@ func TestPluginDrop(t *testing.T) {
 			ctx := context.Background()
 			store := inmem.New()
 
-			//checks if raw policy is valid and stores policy in store
+			// checks if raw policy is valid and stores policy in store
 			err := storage.Txn(ctx, store, storage.WriteParams, func(txn storage.Transaction) error {
 				if err := store.UpsertPolicy(ctx, txn, "test.rego", tc.rawPolicy); err != nil {
 					return err
@@ -2044,7 +2036,6 @@ type testFixture struct {
 }
 
 func newTestFixture(t *testing.T, opts ...testFixtureOptions) testFixture {
-
 	var options testFixtureOptions
 	if len(opts) > 0 {
 		options = opts[0]
@@ -2152,7 +2143,6 @@ func newTestFixture(t *testing.T, opts ...testFixtureOptions) testFixture {
 		plugin:        p,
 		server:        &ts,
 	}
-
 }
 
 func TestParseConfigUseDefaultServiceNoConsole(t *testing.T) {
@@ -2167,7 +2157,6 @@ func TestParseConfigUseDefaultServiceNoConsole(t *testing.T) {
 	}`)
 
 	config, err := ParseConfig([]byte(loggerConfig), services, nil)
-
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}
@@ -2189,7 +2178,6 @@ func TestParseConfigDefaultServiceWithConsole(t *testing.T) {
 	}`)
 
 	config, err := ParseConfig([]byte(loggerConfig), services, nil)
-
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}
@@ -2235,7 +2223,6 @@ func TestParseConfigTriggerMode(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.note, func(t *testing.T) {
-
 			c, err := NewConfigBuilder().WithBytes(tc.config).WithServices([]string{"s0"}).WithTriggerMode(&tc.expected).Parse()
 
 			if tc.wantErr {
@@ -2443,7 +2430,6 @@ func TestEventV1ToAST(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.note, func(t *testing.T) {
-
 			// Ensure that the custom AST() function gives the same
 			// result as round tripping through JSON
 
@@ -2459,13 +2445,11 @@ func TestEventV1ToAST(t *testing.T) {
 			if expected.Compare(actual) != 0 {
 				t.Fatalf("\nExpected:\n%s\n\nGot:\n%s\n\n", expected, actual)
 			}
-
 		})
 	}
 }
 
 func TestPluginDefaultResourcePath(t *testing.T) {
-
 	ctx := context.Background()
 
 	testServerPath := "/logs"
@@ -2502,7 +2486,6 @@ func TestPluginDefaultResourcePath(t *testing.T) {
 }
 
 func TestPluginResourcePathAndPartitionName(t *testing.T) {
-
 	ctx := context.Background()
 
 	resourcePath := "/resource/path"
@@ -2543,7 +2526,6 @@ func TestPluginResourcePathAndPartitionName(t *testing.T) {
 }
 
 func TestPluginResourcePath(t *testing.T) {
-
 	ctx := context.Background()
 
 	resourcePath := "/plugin/log/path"
@@ -2639,8 +2621,8 @@ func getValueForUser(idx int) string {
 }
 
 func generateInputMap(idx int) map[string]interface{} {
-	var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
-	result := make(map[string]interface{})
+	letters := []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+	result := make(map[string]interface{}, 20)
 
 	for i := 0; i < 20; i++ {
 		n := idx % len(letters)
@@ -2648,7 +2630,6 @@ func generateInputMap(idx int) map[string]interface{} {
 		result[key] = fmt.Sprint(idx)
 	}
 	return result
-
 }
 
 func getWellKnownMetrics() metrics.Metrics {
@@ -2699,7 +2680,6 @@ func compareLogEvent(t *testing.T, actual []byte, exp EventV1) {
 }
 
 func testStatus() *bundle.Status {
-
 	tDownload, _ := time.Parse(time.RFC3339Nano, "2018-01-01T00:00:00.0000000Z")
 	tActivate, _ := time.Parse(time.RFC3339Nano, "2018-01-01T00:00:01.0000000Z")
 

--- a/plugins/rest/rest_auth.go
+++ b/plugins/rest/rest_auth.go
@@ -189,7 +189,7 @@ func (ap *oauth2ClientCredentialsAuthPlugin) createAuthJWT(claims map[string]int
 		"exp": now.Add(10 * time.Minute).Unix(),
 	}
 	if claims == nil {
-		claims = make(map[string]interface{})
+		claims = make(map[string]interface{}, len(baseClaims))
 	}
 	for k, v := range baseClaims {
 		claims[k] = v

--- a/rego/rego.go
+++ b/rego/rego.go
@@ -698,7 +698,6 @@ type memo struct {
 type memokey string
 
 func memoize(decl *Function, bctx BuiltinContext, terms []*ast.Term, ifEmpty func() (*ast.Term, error)) (*ast.Term, error) {
-
 	if !decl.Memoize {
 		return ifEmpty()
 	}
@@ -1133,7 +1132,6 @@ func Strict(yes bool) func(r *Rego) {
 
 // New returns a new Rego object.
 func New(options ...func(r *Rego)) *Rego {
-
 	r := &Rego{
 		parsedModules:   map[string]*ast.Module{},
 		capture:         map[*ast.Expr]ast.Var{},
@@ -1329,7 +1327,6 @@ func CompilePartial(yes bool) CompileOption {
 
 // Compile returns a compiled policy query.
 func (r *Rego) Compile(ctx context.Context, opts ...CompileOption) (*CompileResult, error) {
-
 	var cfg CompileContext
 
 	for _, opt := range opts {
@@ -1838,7 +1835,6 @@ func (r *Rego) parseQuery(futureImports []*ast.Import, m metrics.Metrics) (ast.B
 }
 
 func (r *Rego) compileModules(ctx context.Context, txn storage.Transaction, m metrics.Metrics) error {
-
 	// Only compile again if there are new modules.
 	if len(r.bundles) > 0 || len(r.parsedModules) > 0 {
 
@@ -1948,7 +1944,6 @@ func (r *Rego) compileQuery(query ast.Body, imports []*ast.Import, m metrics.Met
 	compiled, err := qc.Compile(query)
 
 	return qc, compiled, err
-
 }
 
 func (r *Rego) eval(ctx context.Context, ectx *EvalContext) (ResultSet, error) {
@@ -2012,7 +2007,6 @@ func (r *Rego) eval(ctx context.Context, ectx *EvalContext) (ResultSet, error) {
 		rs = append(rs, result)
 		return nil
 	})
-
 	if err != nil {
 		return nil, err
 	}
@@ -2025,7 +2019,6 @@ func (r *Rego) eval(ctx context.Context, ectx *EvalContext) (ResultSet, error) {
 }
 
 func (r *Rego) evalWasm(ctx context.Context, ectx *EvalContext) (ResultSet, error) {
-
 	input := ectx.rawInput
 	if ectx.parsedInput != nil {
 		i := interface{}(ectx.parsedInput)
@@ -2082,7 +2075,6 @@ func (r *Rego) evalWasm(ctx context.Context, ectx *EvalContext) (ResultSet, erro
 }
 
 func (r *Rego) generateResult(qr topdown.QueryResult, ectx *EvalContext) (Result, error) {
-
 	rewritten := ectx.compiledQuery.compiler.RewrittenVars()
 
 	result := newResult()
@@ -2121,7 +2113,6 @@ func (r *Rego) generateResult(qr topdown.QueryResult, ectx *EvalContext) (Result
 }
 
 func (r *Rego) partialResult(ctx context.Context, pCfg *PrepareConfig) (PartialResult, error) {
-
 	err := r.prepare(ctx, partialResultQueryType, []extraStage{
 		{
 			after: "ResolveRefs",
@@ -2212,7 +2203,6 @@ func (r *Rego) partialResult(ctx context.Context, pCfg *PrepareConfig) (PartialR
 }
 
 func (r *Rego) partial(ctx context.Context, ectx *EvalContext) (*PartialQueries, error) {
-
 	var unknowns []*ast.Term
 
 	switch {
@@ -2296,7 +2286,6 @@ func (r *Rego) partial(ctx context.Context, ectx *EvalContext) (*PartialQueries,
 }
 
 func (r *Rego) rewriteQueryToCaptureValue(qc ast.QueryCompiler, query ast.Body) (ast.Body, error) {
-
 	checkCapture := iteration(query) || len(query) > 1
 
 	for _, expr := range query {
@@ -2409,7 +2398,6 @@ type transactionCloser func(ctx context.Context, err error) error
 // the configured Rego object. The returned function should be used to close the txn
 // regardless of status.
 func (r *Rego) getTxn(ctx context.Context) (storage.Transaction, transactionCloser, error) {
-
 	noopCloser := func(ctx context.Context, err error) error {
 		return nil // no-op default
 	}
@@ -2515,7 +2503,6 @@ type refResolver struct {
 }
 
 func iteration(x interface{}) bool {
-
 	var stopped bool
 
 	vis := ast.NewGenericVisitor(func(x interface{}) bool {
@@ -2550,7 +2537,6 @@ func iteration(x interface{}) bool {
 }
 
 func parseStringsToRefs(s []string) ([]ast.Ref, error) {
-
 	refs := make([]ast.Ref, len(s))
 	for i := range refs {
 		var err error

--- a/rego/rego_bench_test.go
+++ b/rego/rego_bench_test.go
@@ -21,7 +21,7 @@ func BenchmarkPartialObjectRuleCrossModule(b *testing.B) {
 			mods := test.PartialObjectBenchmarkCrossModule(n)
 			query := "data.test.foo"
 
-			input := make(map[string]interface{})
+			input := make(map[string]interface{}, 4)
 			for idx := 0; idx <= 3; idx++ {
 				input[fmt.Sprintf("test_input_%d", idx)] = "test_input_10"
 			}
@@ -46,7 +46,6 @@ func BenchmarkPartialObjectRuleCrossModule(b *testing.B) {
 				Store(store),
 				Runtime(info),
 			).PrepareForEval(ctx)
-
 			if err != nil {
 				b.Fatal(err)
 			}

--- a/sdk/opa.go
+++ b/sdk/opa.go
@@ -56,7 +56,6 @@ type state struct {
 // New returns a new OPA object. This function should minimally be called with
 // options that specify an OPA configuration file.
 func New(ctx context.Context, opts Options) (*OPA, error) {
-
 	var err error
 
 	id := opts.ID
@@ -99,7 +98,6 @@ func (opa *OPA) Plugin(name string) plugins.Plugin {
 // function is atomic. If the configuration update cannot be successfully
 // applied, the old configuration will remain intact.
 func (opa *OPA) Configure(ctx context.Context, opts ConfigOptions) error {
-
 	if err := opts.init(); err != nil {
 		return err
 	}
@@ -144,7 +142,6 @@ func (opa *OPA) configure(ctx context.Context, bs []byte, ready chan struct{}, b
 	})
 
 	manager.RegisterPluginStatusListener("sdk", func(status map[string]*plugins.Status) {
-
 		select {
 		case <-ready:
 			return
@@ -211,7 +208,6 @@ func (opa *OPA) configure(ctx context.Context, bs []byte, ready chan struct{}, b
 
 // Stop closes the OPA. The OPA cannot be restarted.
 func (opa *OPA) Stop(ctx context.Context) {
-
 	opa.mtx.Lock()
 	mgr := opa.state.manager
 	opa.mtx.Unlock()
@@ -223,7 +219,6 @@ func (opa *OPA) Stop(ctx context.Context) {
 
 // Decision returns a named decision. This function is threadsafe.
 func (opa *OPA) Decision(ctx context.Context, options DecisionOptions) (*DecisionResult, error) {
-
 	record := server.Info{
 		Timestamp:      options.Now,
 		Path:           options.Path,
@@ -349,7 +344,6 @@ func (opa *OPA) executeTransaction(ctx context.Context, record *server.Info, wor
 // Note(philipc): The NDBCache is unused here, because non-deterministic
 // builtins are not run during partial evaluation.
 func (opa *OPA) Partial(ctx context.Context, options PartialOptions) (*PartialResult, error) {
-
 	if options.Mapper == nil {
 		options.Mapper = &RawMapper{}
 	}
@@ -485,7 +479,6 @@ type evalArgs struct {
 }
 
 func evaluate(ctx context.Context, args evalArgs) (interface{}, types.ProvenanceV1, ast.Value, map[string]server.BundleInfo, error) {
-
 	provenance := types.ProvenanceV1{
 		Version:   version.Version,
 		Vcs:       version.Vcs,
@@ -497,6 +490,7 @@ func evaluate(ctx context.Context, args evalArgs) (interface{}, types.Provenance
 	if err != nil {
 		return nil, provenance, nil, nil, err
 	}
+	provenance.Bundles = make(map[string]types.ProvenanceBundleV1, len(bundles))
 	for b, info := range bundles {
 		provenance.Bundles[b] = types.ProvenanceBundleV1{
 			Revision: info.Revision,
@@ -574,7 +568,6 @@ type partialEvalArgs struct {
 }
 
 func partial(ctx context.Context, args partialEvalArgs) (*rego.PartialQueries, types.ProvenanceV1, ast.Value, map[string]server.BundleInfo, error) {
-
 	provenance := types.ProvenanceV1{
 		Version: version.Version,
 		Bundles: make(map[string]types.ProvenanceBundleV1),

--- a/topdown/bindings_test.go
+++ b/topdown/bindings_test.go
@@ -35,7 +35,7 @@ func term(s string) *ast.Term {
 func TestBindingsArrayHashmap(t *testing.T) {
 	var bindings bindings
 	b := newBindingsArrayHashmap()
-	keys := make(map[int]ast.Var)
+	keys := make(map[int]ast.Var, maxLinearScan+1)
 
 	for i := 0; i < maxLinearScan+1; i++ {
 		b.Put(testBindingKey(i), testBindingValue(&bindings, i))

--- a/topdown/eval.go
+++ b/topdown/eval.go
@@ -229,7 +229,6 @@ func (e *eval) traceWasm(x ast.Node, target *ast.Ref) {
 }
 
 func (e *eval) traceEvent(op Op, x ast.Node, msg string, target *ast.Ref) {
-
 	if !e.traceEnabled {
 		return
 	}
@@ -305,7 +304,6 @@ func (e *eval) eval(iter evalIterator) error {
 }
 
 func (e *eval) evalExpr(iter evalIterator) error {
-
 	if e.cancel != nil && e.cancel.Cancelled() {
 		return &Error{
 			Code:    CancelErr,
@@ -344,7 +342,6 @@ func (e *eval) evalExpr(iter evalIterator) error {
 }
 
 func (e *eval) evalStep(iter evalIterator) error {
-
 	expr := e.query[e.index]
 
 	if expr.Negated {
@@ -422,7 +419,6 @@ func (e *eval) evalStep(iter evalIterator) error {
 }
 
 func (e *eval) evalNot(iter evalIterator) error {
-
 	expr := e.query[e.index]
 
 	if e.unknown(expr, e.bindings) {
@@ -441,7 +437,6 @@ func (e *eval) evalNot(iter evalIterator) error {
 		child.traceRedo(negation)
 		return nil
 	})
-
 	if err != nil {
 		return err
 	}
@@ -455,7 +450,6 @@ func (e *eval) evalNot(iter evalIterator) error {
 }
 
 func (e *eval) evalWith(iter evalIterator) error {
-
 	expr := e.query[e.index]
 
 	// Disable inlining on all references in the expression so the result of
@@ -589,7 +583,6 @@ func (e *eval) evalWithPop(input, data *ast.Term) {
 }
 
 func (e *eval) evalNotPartial(iter evalIterator) error {
-
 	// Prepare query normally.
 	expr := e.query[e.index]
 	negation := expr.Complement().NoWith()
@@ -664,7 +657,6 @@ func (e *eval) evalNotPartial(iter evalIterator) error {
 }
 
 func (e *eval) evalNotPartialSupport(negationID uint64, expr *ast.Expr, unknowns ast.VarSet, queries []ast.Body, iter evalIterator) error {
-
 	// Prepare support rule head.
 	supportName := fmt.Sprintf("__not%d_%d_%d__", e.queryID, e.index, negationID)
 	term := ast.RefTerm(ast.DefaultRootDocument, e.saveNamespace, ast.StringTerm(supportName))
@@ -720,7 +712,6 @@ func (e *eval) evalNotPartialSupport(negationID uint64, expr *ast.Expr, unknowns
 }
 
 func (e *eval) evalCall(terms []*ast.Term, iter unifyIterator) error {
-
 	ref := terms[0].Value.(ast.Ref)
 
 	var mocked bool
@@ -1023,7 +1014,6 @@ func (e *eval) biunifyValues(a, b *ast.Term, b1, b2 *bindings, iter unifyIterato
 }
 
 func (e *eval) biunifyRef(a, b *ast.Term, b1, b2 *bindings, iter unifyIterator) error {
-
 	ref := a.Value.(ast.Ref)
 
 	if ref[0].Equal(ast.DefaultRootDocument) {
@@ -1073,7 +1063,6 @@ func (e *eval) biunifyRef(a, b *ast.Term, b1, b2 *bindings, iter unifyIterator) 
 }
 
 func (e *eval) biunifyComprehension(a, b *ast.Term, b1, b2 *bindings, swap bool, iter unifyIterator) error {
-
 	if e.unknown(a, b1) {
 		return e.biunifyComprehensionPartial(a, b, b1, b2, swap, iter)
 	}
@@ -1101,7 +1090,6 @@ func (e *eval) biunifyComprehension(a, b *ast.Term, b1, b2 *bindings, swap bool,
 }
 
 func (e *eval) buildComprehensionCache(a *ast.Term) (*ast.Term, error) {
-
 	index := e.comprehensionIndex(a)
 	if index == nil {
 		e.instr.counterIncr(evalOpComprehensionCacheSkip)
@@ -1393,7 +1381,6 @@ func (e *eval) saveCall(declArgsLen int, terms []*ast.Term, iter unifyIterator) 
 }
 
 func (e *eval) saveInlinedNegatedExprs(exprs []*ast.Expr, iter unifyIterator) error {
-
 	with := make([]*ast.With, len(e.query[e.index].With))
 
 	for i := range e.query[e.index].With {
@@ -1576,7 +1563,7 @@ func (e *eval) resolveReadFromStorage(ref ast.Ref, a ast.Value) (ast.Value, erro
 			switch obj := blob.(type) {
 			case map[string]interface{}:
 				if len(obj) > 0 {
-					cpy := make(map[string]interface{}, len(obj)-1)
+					cpy := make(map[string]interface{}, len(obj))
 					for k, v := range obj {
 						if string(ast.SystemDocumentKey) != k {
 							cpy[k] = v
@@ -1647,7 +1634,6 @@ func (e *eval) rewrittenVar(v ast.Var) (ast.Var, bool) {
 }
 
 func (e *eval) getDeclArgsLen(x *ast.Expr) (int, error) {
-
 	if !x.IsCall() {
 		return -1, nil
 	}
@@ -1692,7 +1678,6 @@ func (e *evalBuiltin) canUseNDBCache(bi *ast.Builtin) bool {
 }
 
 func (e evalBuiltin) eval(iter unifyIterator) error {
-
 	operands := make([]*ast.Term, len(e.terms))
 
 	for i := range e.terms {
@@ -1739,7 +1724,6 @@ func (e evalBuiltin) eval(iter unifyIterator) error {
 
 	// Normal unification flow for builtins:
 	err = e.f(e.bctx, operands, func(output *ast.Term) error {
-
 		e.e.instr.stopTimer(evalOpBuiltinCall)
 
 		var err error
@@ -1794,7 +1778,6 @@ type evalFunc struct {
 }
 
 func (e evalFunc) eval(iter unifyIterator) error {
-
 	// default functions aren't supported:
 	// https://github.com/open-policy-agent/opa/issues/2445
 	if len(e.ir.Rules) == 0 {
@@ -1891,7 +1874,6 @@ func (e evalFunc) evalCache(argCount int, iter unifyIterator) (ast.Ref, bool, er
 }
 
 func (e evalFunc) evalOneRule(iter unifyIterator, rule *ast.Rule, cacheKey ast.Ref, prev *ast.Term, findOne bool) (*ast.Term, error) {
-
 	child := e.e.child(rule.Body)
 	child.findOne = findOne
 
@@ -1962,7 +1944,6 @@ func (e evalFunc) evalOneRule(iter unifyIterator, rule *ast.Rule, cacheKey ast.R
 }
 
 func (e evalFunc) partialEvalSupport(declArgsLen int, iter unifyIterator) error {
-
 	path := e.e.namespaceRef(e.ref)
 	term := ast.NewTerm(path)
 
@@ -1983,7 +1964,6 @@ func (e evalFunc) partialEvalSupport(declArgsLen int, iter unifyIterator) error 
 }
 
 func (e evalFunc) partialEvalSupportRule(rule *ast.Rule, path ast.Ref) error {
-
 	child := e.e.child(rule.Body)
 	child.traceEnter(rule)
 
@@ -2043,7 +2023,6 @@ type evalTree struct {
 }
 
 func (e evalTree) eval(iter unifyIterator) error {
-
 	if len(e.ref) == e.pos {
 		return e.finish(iter)
 	}
@@ -2058,7 +2037,6 @@ func (e evalTree) eval(iter unifyIterator) error {
 }
 
 func (e evalTree) finish(iter unifyIterator) error {
-
 	// In some cases, it may not be possible to PE the ref. If the path refers
 	// to virtual docs that PE does not support or base documents where inlining
 	// has been disabled, then we have to save.
@@ -2077,7 +2055,6 @@ func (e evalTree) finish(iter unifyIterator) error {
 }
 
 func (e evalTree) next(iter unifyIterator, plugged *ast.Term) error {
-
 	var node *ast.TreeNode
 
 	cpy := e
@@ -2108,7 +2085,6 @@ func (e evalTree) next(iter unifyIterator, plugged *ast.Term) error {
 }
 
 func (e evalTree) enumerate(iter unifyIterator) error {
-
 	if e.e.inliningControl.Disabled(e.plugged[:e.pos], true) {
 		return e.e.saveUnify(ast.NewTerm(e.plugged), e.rterm, e.bindings, e.rbindings, iter)
 	}
@@ -2199,7 +2175,6 @@ func (e evalTree) extent() (*ast.Term, error) {
 // leaves builds a tree from evaluating the full rule tree extent, by recursing into all
 // branches, and building up objects as it goes.
 func (e evalTree) leaves(plugged ast.Ref, node *ast.TreeNode) (ast.Object, error) {
-
 	if e.node == nil {
 		return nil, nil
 	}
@@ -2255,7 +2230,6 @@ type evalVirtual struct {
 }
 
 func (e evalVirtual) eval(iter unifyIterator) error {
-
 	ir, err := e.e.getRules(e.plugged[:e.pos+1], nil)
 	if err != nil {
 		return err
@@ -2333,7 +2307,6 @@ type evalVirtualPartialCacheHint struct {
 }
 
 func (e evalVirtualPartial) eval(iter unifyIterator) error {
-
 	unknown := e.e.unknown(e.ref[:e.pos+1], e.bindings)
 
 	if len(e.ref) == e.pos+1 {
@@ -2351,7 +2324,6 @@ func (e evalVirtualPartial) eval(iter unifyIterator) error {
 }
 
 func (e evalVirtualPartial) evalEachRule(iter unifyIterator, unknown bool) error {
-
 	if e.e.unknown(e.ref[e.pos+1], e.bindings) {
 		for _, rule := range e.ir.Rules {
 			if err := e.evalOneRulePostUnify(iter, rule); err != nil {
@@ -2388,7 +2360,6 @@ func (e evalVirtualPartial) evalEachRule(iter unifyIterator, unknown bool) error
 }
 
 func (e evalVirtualPartial) evalAllRules(iter unifyIterator, rules []*ast.Rule) error {
-
 	cacheKey := e.plugged[:e.pos+1]
 	result, _ := e.e.virtualCache.Get(cacheKey)
 	if result != nil {
@@ -2427,7 +2398,6 @@ func (e evalVirtualPartial) evalAllRulesNoCache(rules []*ast.Rule) (*ast.Term, e
 			child.traceRedo(rule)
 			return nil
 		})
-
 		if err != nil {
 			return nil, err
 		}
@@ -2437,7 +2407,6 @@ func (e evalVirtualPartial) evalAllRulesNoCache(rules []*ast.Rule) (*ast.Term, e
 }
 
 func (e evalVirtualPartial) evalOneRulePreUnify(iter unifyIterator, rule *ast.Rule, hint evalVirtualPartialCacheHint, result *ast.Term, unknown bool) error {
-
 	key := e.ref[e.pos+1]
 	child := e.e.child(rule.Body)
 
@@ -2451,7 +2420,6 @@ func (e evalVirtualPartial) evalOneRulePreUnify(iter unifyIterator, rule *ast.Ru
 	err := child.biunify(headKey, key, child.bindings, e.bindings, func() error {
 		defined = true
 		return child.eval(func(child *eval) error {
-
 			term := rule.Head.Value
 			if term == nil {
 				term = headKey
@@ -2489,7 +2457,6 @@ func (e evalVirtualPartial) evalOneRulePreUnify(iter unifyIterator, rule *ast.Ru
 			return nil
 		})
 	})
-
 	if err != nil {
 		return err
 	}
@@ -2503,7 +2470,6 @@ func (e evalVirtualPartial) evalOneRulePreUnify(iter unifyIterator, rule *ast.Ru
 }
 
 func (e evalVirtualPartial) evalOneRulePostUnify(iter unifyIterator, rule *ast.Rule) error {
-
 	key := e.ref[e.pos+1]
 	child := e.e.child(rule.Body)
 
@@ -2516,7 +2482,6 @@ func (e evalVirtualPartial) evalOneRulePostUnify(iter unifyIterator, rule *ast.R
 			return e.evalOneRuleContinue(iter, rule, child)
 		})
 	})
-
 	if err != nil {
 		return err
 	}
@@ -2529,7 +2494,6 @@ func (e evalVirtualPartial) evalOneRulePostUnify(iter unifyIterator, rule *ast.R
 }
 
 func (e evalVirtualPartial) evalOneRuleContinue(iter unifyIterator, rule *ast.Rule, child *eval) error {
-
 	child.traceExit(rule)
 
 	term := rule.Head.Value
@@ -2548,7 +2512,6 @@ func (e evalVirtualPartial) evalOneRuleContinue(iter unifyIterator, rule *ast.Ru
 }
 
 func (e evalVirtualPartial) partialEvalSupport(iter unifyIterator) error {
-
 	path := e.e.namespaceRef(e.plugged[:e.pos+1])
 	term := ast.NewTerm(e.e.namespaceRef(e.ref))
 
@@ -2581,7 +2544,6 @@ func (e evalVirtualPartial) partialEvalSupport(iter unifyIterator) error {
 }
 
 func (e evalVirtualPartial) partialEvalSupportRule(rule *ast.Rule, path ast.Ref) (bool, error) {
-
 	child := e.e.child(rule.Body)
 	child.traceEnter(rule)
 
@@ -2645,7 +2607,6 @@ func (e evalVirtualPartial) evalTerm(iter unifyIterator, pos int, term *ast.Term
 }
 
 func (e evalVirtualPartial) evalCache(iter unifyIterator) (evalVirtualPartialCacheHint, error) {
-
 	var hint evalVirtualPartialCacheHint
 
 	if e.e.unknown(e.ref[:e.pos+1], e.bindings) {
@@ -2679,7 +2640,6 @@ func (e evalVirtualPartial) evalCache(iter unifyIterator) (evalVirtualPartialCac
 }
 
 func (e evalVirtualPartial) reduce(head *ast.Head, b *bindings, result *ast.Term) (*ast.Term, bool, error) {
-
 	var exists bool
 
 	switch v := result.Value.(type) {
@@ -2716,7 +2676,6 @@ type evalVirtualComplete struct {
 }
 
 func (e evalVirtualComplete) eval(iter unifyIterator) error {
-
 	if e.ir.Empty() {
 		return nil
 	}
@@ -2800,7 +2759,6 @@ func (e evalVirtualComplete) evalValue(iter unifyIterator, findOne bool) error {
 }
 
 func (e evalVirtualComplete) evalValueRule(iter unifyIterator, rule *ast.Rule, prev *ast.Term, findOne bool) (*ast.Term, error) {
-
 	child := e.e.child(rule.Body)
 	child.findOne = findOne
 	child.traceEnter(rule)
@@ -2835,7 +2793,6 @@ func (e evalVirtualComplete) evalValueRule(iter unifyIterator, rule *ast.Rule, p
 }
 
 func (e evalVirtualComplete) partialEval(iter unifyIterator) error {
-
 	for _, rule := range e.ir.Rules {
 		child := e.e.child(rule.Body)
 		child.traceEnter(rule)
@@ -2852,7 +2809,6 @@ func (e evalVirtualComplete) partialEval(iter unifyIterator) error {
 			child.traceRedo(rule)
 			return nil
 		})
-
 		if err != nil {
 			return err
 		}
@@ -2862,7 +2818,6 @@ func (e evalVirtualComplete) partialEval(iter unifyIterator) error {
 }
 
 func (e evalVirtualComplete) partialEvalSupport(iter unifyIterator) error {
-
 	path := e.e.namespaceRef(e.plugged[:e.pos+1])
 	term := ast.NewTerm(e.e.namespaceRef(e.ref))
 
@@ -2900,7 +2855,6 @@ func (e evalVirtualComplete) partialEvalSupport(iter unifyIterator) error {
 }
 
 func (e evalVirtualComplete) partialEvalSupportRule(rule *ast.Rule, path ast.Ref) (bool, error) {
-
 	child := e.e.child(rule.Body)
 	child.traceEnter(rule)
 
@@ -2973,7 +2927,6 @@ type evalTerm struct {
 }
 
 func (e evalTerm) eval(iter unifyIterator) error {
-
 	if len(e.ref) == e.pos {
 		return e.e.biunify(e.term, e.rterm, e.termbindings, e.rbindings, iter)
 	}
@@ -2992,7 +2945,6 @@ func (e evalTerm) eval(iter unifyIterator) error {
 }
 
 func (e evalTerm) next(iter unifyIterator, plugged *ast.Term) error {
-
 	term, bindings := e.get(plugged)
 	if term == nil {
 		return nil
@@ -3006,7 +2958,6 @@ func (e evalTerm) next(iter unifyIterator, plugged *ast.Term) error {
 }
 
 func (e evalTerm) enumerate(iter unifyIterator) error {
-
 	switch v := e.term.Value.(type) {
 	case *ast.Array:
 		for i := 0; i < v.Len(); i++ {
@@ -3086,12 +3037,10 @@ func (e evalTerm) get(plugged *ast.Term) (*ast.Term, *bindings) {
 }
 
 func (e evalTerm) save(iter unifyIterator) error {
-
 	v := e.e.generateVar(fmt.Sprintf("ref_%d", e.e.genvarid))
 	e.e.genvarid++
 
 	return e.e.biunify(e.term, v, e.termbindings, e.bindings, func() error {
-
 		suffix := e.ref[e.pos:]
 		ref := make(ast.Ref, len(suffix)+1)
 		ref[0] = v
@@ -3099,7 +3048,6 @@ func (e evalTerm) save(iter unifyIterator) error {
 
 		return e.e.biunify(ast.NewTerm(ref), e.rterm, e.bindings, e.rbindings, iter)
 	})
-
 }
 
 type evalEvery struct {
@@ -3254,7 +3202,6 @@ func plugKeys(a ast.Object, b *bindings) ast.Object {
 }
 
 func canInlineNegation(safe ast.VarSet, queries []ast.Body) bool {
-
 	size := 1
 	vis := newNestedCheckVisitor()
 
@@ -3314,7 +3261,6 @@ func (v *nestedCheckVisitor) visit(x interface{}) bool {
 }
 
 func containsNestedRefOrCall(vis *nestedCheckVisitor, expr *ast.Expr) bool {
-
 	if expr.IsEquality() {
 		for _, term := range expr.Operands() {
 			if containsNestedRefOrCallInTerm(vis, term) {

--- a/topdown/http.go
+++ b/topdown/http.go
@@ -144,7 +144,6 @@ func builtinHTTPSend(bctx BuiltinContext, operands []*ast.Term, iter func(*ast.T
 }
 
 func getHTTPResponse(bctx BuiltinContext, req ast.Object) (*ast.Term, error) {
-
 	bctx.Metrics.Timer(httpSendLatencyMetricKey).Start()
 
 	reqExecutor, err := newHTTPRequestExecutor(bctx, req)
@@ -217,7 +216,6 @@ func initDefaults() {
 }
 
 func validateHTTPRequestOperand(term *ast.Term, pos int) (ast.Object, error) {
-
 	obj, err := builtins.ObjectOperand(term.Value, pos)
 	if err != nil {
 		return nil, err
@@ -236,7 +234,6 @@ func validateHTTPRequestOperand(term *ast.Term, pos int) (ast.Object, error) {
 	}
 
 	return obj, nil
-
 }
 
 // canonicalizeHeaders returns a copy of the headers where the keys are in
@@ -348,7 +345,7 @@ func createHTTPRequest(bctx BuiltinContext, obj ast.Object) (*http.Request, *htt
 	var tlsConfig tls.Config
 	var customHeaders map[string]interface{}
 	var tlsInsecureSkipVerify bool
-	var timeout = defaultHTTPRequestTimeout
+	timeout := defaultHTTPRequestTimeout
 
 	for _, val := range obj.Keys() {
 		key, err := ast.JSON(val.Value)
@@ -977,7 +974,8 @@ func newInterQueryCacheData(bctx BuiltinContext, resp *http.Response, respBody [
 		RespBody:   respBody,
 		Status:     resp.Status,
 		StatusCode: resp.StatusCode,
-		Headers:    resp.Header}
+		Headers:    resp.Header,
+	}
 
 	return &cv, nil
 }
@@ -1175,7 +1173,6 @@ func parseMaxAgeCacheDirective(cc map[string]string) (deltaSeconds, error) {
 }
 
 func formatHTTPResponseToAST(resp *http.Response, forceJSONDecode, forceYAMLDecode bool) (ast.Value, []byte, error) {
-
 	resultRawBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, nil, err
@@ -1202,7 +1199,7 @@ func prepareASTResult(headers http.Header, forceJSONDecode, forceYAMLDecode bool
 		_ = util.Unmarshal(body, &resultBody)
 	}
 
-	result := make(map[string]interface{})
+	result := make(map[string]interface{}, 5)
 	result["status"] = status
 	result["status_code"] = statusCode
 	result["body"] = resultBody

--- a/topdown/topdown_bench_test.go
+++ b/topdown/topdown_bench_test.go
@@ -56,7 +56,6 @@ func BenchmarkArrayPlugging(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 
 				err := storage.Txn(ctx, store, storage.TransactionParams{}, func(txn storage.Transaction) error {
-
 					q := NewQuery(query).
 						WithCompiler(compiler).
 						WithStore(store).
@@ -69,7 +68,6 @@ func BenchmarkArrayPlugging(b *testing.B) {
 
 					return nil
 				})
-
 				if err != nil {
 					b.Fatal(err)
 				}
@@ -133,7 +131,6 @@ func BenchmarkLargeJSON(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 
 		err := storage.Txn(ctx, store, storage.TransactionParams{}, func(txn storage.Transaction) error {
-
 			q := NewQuery(query).
 				WithCompiler(compiler).
 				WithStore(store).
@@ -146,7 +143,6 @@ func BenchmarkLargeJSON(b *testing.B) {
 
 			return nil
 		})
-
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -179,7 +175,6 @@ func BenchmarkConcurrency8Writers(b *testing.B) {
 }
 
 func benchmarkConcurrency(b *testing.B, params []storage.TransactionParams) {
-
 	mod, data := test.GenerateConcurrencyBenchmarkData()
 	ctx := context.Background()
 	store := inmem.NewFromObject(data)
@@ -275,7 +270,6 @@ func BenchmarkVirtualDocs1000x1000(b *testing.B) {
 }
 
 func runVirtualDocsBenchmark(b *testing.B, numTotalRules, numHitRules int) {
-
 	mod, inp := test.GenerateVirtualDocsBenchmarkData(numTotalRules, numHitRules)
 	ctx := context.Background()
 	compiler := ast.NewCompiler()
@@ -331,7 +325,6 @@ func BenchmarkPartialEvalCompile(b *testing.B) {
 }
 
 func runPartialEvalBenchmark(b *testing.B, numRoles int) {
-
 	ctx := context.Background()
 	compiler := ast.NewCompiler()
 	compiler.Compile(map[string]*ast.Module{
@@ -409,13 +402,11 @@ func runPartialEvalBenchmark(b *testing.B, numRoles int) {
 }
 
 func runPartialEvalCompileBenchmark(b *testing.B, numRoles int) {
-
 	ctx := context.Background()
 	data := generatePartialEvalBenchmarkData(numRoles)
 	store := inmem.NewFromObject(data)
 
 	err := storage.Txn(ctx, store, storage.TransactionParams{}, func(txn storage.Transaction) error {
-
 		b.ResetTimer()
 
 		for i := 0; i < b.N; i++ {
@@ -472,7 +463,6 @@ func runPartialEvalCompileBenchmark(b *testing.B, numRoles int) {
 
 		return nil
 	})
-
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -527,7 +517,6 @@ func generatePartialEvalBenchmarkData(numRoles int) map[string]interface{} {
 }
 
 func generatePartialEvalBenchmarkInput(numRoles int) *ast.Term {
-
 	tmpl, err := template.New("Test").Parse(`{
 		"operation": "operation-{{ . }}",
 		"resource": "resource-{{ . }}",
@@ -549,7 +538,6 @@ func generatePartialEvalBenchmarkInput(numRoles int) *ast.Term {
 }
 
 func BenchmarkWalk(b *testing.B) {
-
 	ctx := context.Background()
 	sizes := []int{100, 1000, 2000, 3000}
 
@@ -582,7 +570,6 @@ func BenchmarkWalk(b *testing.B) {
 			}
 		})
 	}
-
 }
 
 func genWalkBenchmarkData(n int) map[string]interface{} {
@@ -738,8 +725,8 @@ func BenchmarkObjectSubset(b *testing.B) {
 
 	for _, n := range sizes {
 		b.Run(fmt.Sprint(n), func(b *testing.B) {
-			all := make(map[string]string)
-			evens := make(map[string]string)
+			all := make(map[string]string, n)
+			evens := make(map[string]string, n/2)
 
 			for i := 0; i < n; i++ {
 				all[fmt.Sprint(i)] = fmt.Sprint(i * 2)
@@ -763,7 +750,6 @@ func BenchmarkObjectSubset(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 
 				err := storage.Txn(ctx, store, storage.TransactionParams{}, func(txn storage.Transaction) error {
-
 					q := NewQuery(query).
 						WithCompiler(compiler).
 						WithStore(store).
@@ -776,7 +762,6 @@ func BenchmarkObjectSubset(b *testing.B) {
 
 					return nil
 				})
-
 				if err != nil {
 					b.Fatal(err)
 				}
@@ -795,8 +780,8 @@ func BenchmarkObjectSubsetSlow(b *testing.B) {
 
 	for _, n := range sizes {
 		b.Run(fmt.Sprint(n), func(b *testing.B) {
-			all := make(map[string]string)
-			evens := make(map[string]string)
+			all := make(map[string]string, n)
+			evens := make(map[string]string, n/2)
 
 			for i := 0; i < n; i++ {
 				all[fmt.Sprint(i)] = fmt.Sprint(i * 2)
@@ -830,7 +815,6 @@ func BenchmarkObjectSubsetSlow(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 
 				err := storage.Txn(ctx, store, storage.TransactionParams{}, func(txn storage.Transaction) error {
-
 					q := NewQuery(query).
 						WithCompiler(compiler).
 						WithStore(store).
@@ -843,7 +827,6 @@ func BenchmarkObjectSubsetSlow(b *testing.B) {
 
 					return nil
 				})
-
 				if err != nil {
 					b.Fatal(err)
 				}
@@ -920,7 +903,6 @@ func BenchmarkGlob(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 
 				err := storage.Txn(ctx, store, storage.TransactionParams{}, func(txn storage.Transaction) error {
-
 					q := NewQuery(query).
 						WithCompiler(compiler).
 						WithStore(store).
@@ -933,7 +915,6 @@ func BenchmarkGlob(b *testing.B) {
 
 					return nil
 				})
-
 				if err != nil {
 					b.Fatal(err)
 				}

--- a/util/hashmap.go
+++ b/util/hashmap.go
@@ -39,6 +39,8 @@ func NewHashMap(eq func(T, T) bool, hash func(T) int) *HashMap {
 // Copy returns a shallow copy of this HashMap.
 func (h *HashMap) Copy() *HashMap {
 	cpy := NewHashMap(h.eq, h.hash)
+	// Prealloc the map used to store the hashed entries.
+	cpy.table = make(map[int]*hashEntry, h.Len())
 	h.Iter(func(k, v T) bool {
 		cpy.Put(k, v)
 		return false


### PR DESCRIPTION
This PR changes most instances of `map` instantiations in OPA to be preallocated when possible.

The `prealloc` linter we've been using only checks for opportunities to preallocate *slice* types, meaning that we have no checka in place to see if our maps can be preallocated too.

Before this PR is ready for merge, some performance benchmarking will need to be done to make sure that it doesn't cause a performance regression. :sweat_smile: 