### PR TITLE
Fix typo in documentation

### DIFF
--- a/docs/content/policy-language.md
+++ b/docs/content/policy-language.md
@@ -159,7 +159,7 @@ rule-name IS value IF body
 
 If the **value** is omitted, it defaults to **true**.
 
-When we query for the value of `t` we see the obvious result:
+When we query for the value of `t2` we see the obvious result:
 
 ```live:eg/rules:query:hidden
 t


### PR DESCRIPTION
In the policy-language guide there's an example expression assigned to the variable name `t2`.

```
t2 {
    x := 42
    y := 41
    x > y
}
```

But in the explanation for the result it is evaluated into, the variable name is shown as `t`. This change fixes it.