### PR TITLE
fmt: report wrong arity for built-in functions

### DIFF
--- a/cmd/fmt_test.go
+++ b/cmd/fmt_test.go
@@ -2,12 +2,15 @@ package cmd
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/format"
 	"github.com/open-policy-agent/opa/util/test"
 )
 
@@ -28,6 +31,27 @@ const unformatted = `
         }
 
 
+`
+
+const singleWrongArity = `package test
+
+p {
+	a := 1
+	b := 2
+	plus(a, b, c) == 3
+}
+`
+
+const MultipleWrongArity = `package test
+
+p {
+	x:=5
+	y:=7
+	z:=6
+	plus([x, y]) == 3
+	and(true, false, false) == false
+	plus(a, x, y, z)
+}
 `
 
 func TestFmtFormatFile(t *testing.T) {
@@ -266,6 +290,92 @@ func TestFmtFailFileChangesDiff(t *testing.T) {
 		actual := strings.TrimSpace(stdout.String())
 		if len(actual) == 0 {
 			t.Fatalf("Expected output, got:\n%v\n\n", actual)
+		}
+	})
+}
+
+func TestFmtSingleWrongArityError(t *testing.T) {
+	params := fmtCommandParams{}
+	var stdout bytes.Buffer
+
+	files := map[string]string{
+		"policy.rego": singleWrongArity,
+	}
+
+	test.WithTempFS(files, func(path string) {
+		policyFile := filepath.Join(path, "policy.rego")
+		info, err := os.Stat(policyFile)
+		err = formatFile(&params, &stdout, policyFile, info, err)
+		if err == nil {
+			t.Fatalf("Expected error but did not receive one")
+		}
+
+		loc := ast.Location{File: policyFile, Row: 6}
+		errExp := ast.NewError(ast.TypeErr, &loc, "%s: %s", "plus", "arity mismatch")
+		errExp.Details = &format.ArityFormatErrDetail{
+			Have: []string{"var", "var", "var"},
+			Want: []string{"number", "number"},
+		}
+		expectedErrs := ast.Errors(make([]*ast.Error, 1))
+		expectedErrs[0] = errExp
+		expectedSingleWrongArityErr := newError("failed to parse Rego source file: %v", fmt.Errorf("%s: %v", policyFile, expectedErrs))
+
+		if err != expectedSingleWrongArityErr {
+			t.Fatalf("Expected:%s\n\nGot:%s\n\n", expectedSingleWrongArityErr, err)
+		}
+	})
+}
+
+func TestFmtMultipleWrongArityError(t *testing.T) {
+	params := fmtCommandParams{}
+	var stdout bytes.Buffer
+
+	files := map[string]string{
+		"policy.rego": MultipleWrongArity,
+	}
+
+	test.WithTempFS(files, func(path string) {
+		policyFile := filepath.Join(path, "policy.rego")
+		info, err := os.Stat(policyFile)
+		err = formatFile(&params, &stdout, policyFile, info, err)
+		if err == nil {
+			t.Fatalf("Expected error but did not receive one")
+		}
+
+		locations := []ast.Location{
+			{File: policyFile, Row: 7},
+			{File: policyFile, Row: 8},
+			{File: policyFile, Row: 9},
+		}
+		haveStrings := [][]string{
+			{"array"},
+			{"boolean", "boolean", "boolean"},
+			{"var", "var", "var", "var"},
+		}
+		wantStrings := [][]string{
+			{"number", "number"},
+			{"set[any]", "set[any]"},
+			{"number", "number"},
+		}
+		operators := []string{
+			"plus",
+			"and",
+			"plus",
+		}
+		expectedErrs := ast.Errors(make([]*ast.Error, 3))
+		for i := 0; i < 3; i++ {
+			loc := locations[i]
+			errExp := ast.NewError(ast.TypeErr, &loc, "%s: %s", operators[i], "arity mismatch")
+			errExp.Details = &format.ArityFormatErrDetail{
+				Have: haveStrings[i],
+				Want: wantStrings[i],
+			}
+			expectedErrs[i] = errExp
+		}
+		expectedMultipleWrongArityErr := newError("failed to parse Rego source file: %v", fmt.Errorf("%s: %v", policyFile, expectedErrs))
+
+		if err != expectedMultipleWrongArityErr {
+			t.Fatalf("Expected:%s\n\nGot:%s\n\n", expectedMultipleWrongArityErr, err)
 		}
 	})
 }


### PR DESCRIPTION
This PR fixes #5646. As discussed in the issue, `opa fmt` crashes when  a built-in function with a corresponding `Infix` is processed by the [writeCall](https://github.com/open-policy-agent/opa/blob/main/format/format.go#L763) function. This is due to the fact that, previously to this PR, this function assumed that the number of arguments provided is exactly the expected number. Due to this assumption, when these functions are processed in `writeCall` with only one argument, `opa fmt` panics due to an unhandled `index out of range` error.

As noted in #5646, this is not the only issue caused by the assumption used in `writeCall`. Currently, if the number of arguments provided to built-in functions with a corresponding `Infix` is larger than the expected number, only the first two are processed, while the other are simple removed from formatted document.

This error is visible only when the function is used as a term of another function (`writeCall` is used only in [writeTermParens](https://github.com/open-policy-agent/opa/blob/main/format/format.go#L679)). 
Normally a function is processed by [writeFunctionCall](https://github.com/open-policy-agent/opa/blob/main/format/format.go#L618), which delegates the process to [writeFunctionCallPlain](https://github.com/open-policy-agent/opa/blob/main/format/format.go#L653) in case of wrong arity.

Since both the `assignment` and the `equality` operator are treated as built-in functions, the check `and([true, false]) == false` causes the call `and([true, false])` to be processed as a term. This leads to the panic noted in #5646.

To fix this behavior, this PR introduces arity checks for built-in functions and introduces error handling for panics that can be found during the execution of `opa fmt`. The changes are the following:

- [arity check](https://github.com/Trolloldem/opa/blob/5bcc2287f9b783287afe9bf6b76bbb718993c47b/format/format.go#L795) in `writeCall` for all the built-in functions with a corresponding `Infix` that are not the `in` operator
- [arity check](https://github.com/Trolloldem/opa/blob/5bcc2287f9b783287afe9bf6b76bbb718993c47b/format/format.go#L811) in `writeInOperator` for the `in` operator
- [slice of errors](https://github.com/Trolloldem/opa/blob/5bcc2287f9b783287afe9bf6b76bbb718993c47b/format/format.go#L150) declared in `AstWithOpts` to collect all the errors found during the format procedure. This behavior is similar to the one obtained through the [Scanner struct](https://github.com/open-policy-agent/opa/blob/main/ast/internal/scanner/scanner.go#L27) used during the parsing procedure
- [Error formatting](https://github.com/Trolloldem/opa/blob/5bcc2287f9b783287afe9bf6b76bbb718993c47b/format/format.go#L1391), similar to the one performed at [compile time](https://github.com/open-policy-agent/opa/blob/main/ast/compile.go#L998)
- [error handling tests](https://github.com/Trolloldem/opa/blob/5bcc2287f9b783287afe9bf6b76bbb718993c47b/cmd/fmt_test.go#L294)