### PR TITLE
mask: don't rely on JSON roundtrip to convert structs

### DIFF
--- a/plugins/logs/mask_test.go
+++ b/plugins/logs/mask_test.go
@@ -607,37 +607,34 @@ func TestMaskRuleMask(t *testing.T) {
 
 func TestNewMaskRuleSet(t *testing.T) {
 	tests := []struct {
-		onRuleError func(*maskRule, error)
-		note        string
-		value       interface{}
-		exp         *maskRuleSet
-		err         error
+		note  string
+		value interface{}
+		exp   *maskRuleSet
+		err   error
 	}{
 		{
-			onRuleError: func(mRule *maskRule, err error) {},
-			note:        "invalid format: not []interface{}",
-			value:       map[string]int{"invalid": 1},
-			err:         fmt.Errorf("json: cannot unmarshal object into Go value of type []interface {}"),
+			note:  "invalid format: not []interface{}",
+			value: map[string]int{"invalid": 1},
+			err:   fmt.Errorf("unexpected rule format map[invalid:1] (map[string]int)"),
 		},
 		{
-			onRuleError: func(mRule *maskRule, err error) {},
-			note:        "invalid format: nested type not string or map[string]interface{}",
+			note: "invalid format: nested type not string or map[string]interface{}",
 			value: []interface{}{
 				[]int{1, 2},
 			},
-			err: fmt.Errorf("invalid mask rule format encountered: []interface {}"),
+			err: fmt.Errorf("invalid mask rule format encountered: []int"),
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.note, func(t *testing.T) {
-
 			_, err := newMaskRuleSet(tc.value, func(mRule *maskRule, err error) {})
-
 			if err != nil {
-				if tc.err.Error() != err.Error() {
-					t.Fatalf("Expected: %s\nGot: %s", tc.err.Error(), err.Error())
+				if exp, act := tc.err.Error(), err.Error(); exp != act {
+					t.Fatalf("Expected: %s\nGot: %s", exp, act)
 				}
+			} else if tc.err != nil {
+				t.Errorf("expected error %v, got nil", tc.err)
 			}
 		})
 	}


### PR DESCRIPTION
Reading the code, I couldn't bear the use of a JSON roundtrip to convert from one kind of struct to another.

```
$ benchstat main.out pr.out
goos: darwin
goarch: amd64
pkg: github.com/open-policy-agent/opa/plugins/logs cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
                                  │  main.out   │               pr.out                │
                                  │   sec/op    │   sec/op     vs base                │
MaskingNop-16                       4.779µ ± 2%   4.892µ ± 1%   +2.38% (p=0.009 n=10)
MaskingRuleCountsNop/1Rules-16      4.859µ ± 3%   4.868µ ± 1%        ~ (p=0.754 n=10)
MaskingRuleCountsNop/10Rules-16     5.047µ ± 3%   4.872µ ± 0%   -3.47% (p=0.000 n=10)
MaskingRuleCountsNop/100Rules-16    5.089µ ± 4%   4.846µ ± 1%   -4.78% (p=0.000 n=10)
MaskingRuleCountsNop/1000Rules-16   4.894µ ± 4%   4.905µ ± 3%        ~ (p=0.684 n=10)
MaskingErase-16                     14.66µ ± 2%   11.77µ ± 3%  -19.72% (p=0.000 n=10)
geomean                             5.914µ        5.648µ        -4.50%

                                  │   main.out   │                 pr.out                 │
                                  │     B/op     │     B/op      vs base                  │
MaskingNop-16                       3.136Ki ± 0%   3.136Ki ± 0%        ~ (p=1.000 n=10)
MaskingRuleCountsNop/1Rules-16      3.136Ki ± 0%   3.136Ki ± 0%        ~ (p=1.000 n=10) ¹
MaskingRuleCountsNop/10Rules-16     3.136Ki ± 0%   3.136Ki ± 0%        ~ (p=1.000 n=10) ¹
MaskingRuleCountsNop/100Rules-16    3.136Ki ± 0%   3.136Ki ± 0%        ~ (p=1.000 n=10) ¹
MaskingRuleCountsNop/1000Rules-16   3.136Ki ± 0%   3.136Ki ± 0%        ~ (p=1.000 n=10) ¹
MaskingErase-16                     8.328Ki ± 0%   7.281Ki ± 0%  -12.57% (p=0.000 n=10)
geomean                             3.690Ki        3.608Ki        -2.21%
¹ all samples are equal

                                  │  main.out  │               pr.out                │
                                  │ allocs/op  │ allocs/op   vs base                 │
MaskingNop-16                       65.00 ± 0%   65.00 ± 0%       ~ (p=1.000 n=10) ¹
MaskingRuleCountsNop/1Rules-16      65.00 ± 0%   65.00 ± 0%       ~ (p=1.000 n=10) ¹
MaskingRuleCountsNop/10Rules-16     65.00 ± 0%   65.00 ± 0%       ~ (p=1.000 n=10) ¹
MaskingRuleCountsNop/100Rules-16    65.00 ± 0%   65.00 ± 0%       ~ (p=1.000 n=10) ¹
MaskingRuleCountsNop/1000Rules-16   65.00 ± 0%   65.00 ± 0%       ~ (p=1.000 n=10) ¹
MaskingErase-16                     149.0 ± 0%   138.0 ± 0%  -7.38% (p=0.000 n=10)
geomean                             74.64        73.69       -1.27%
¹ all samples are equal
```