### PR TITLE
plugins: Surface more decision log errors via status API

### DIFF
--- a/plugins/discovery/discovery_test.go
+++ b/plugins/discovery/discovery_test.go
@@ -1710,7 +1710,7 @@ func TestStatusMetricsForLogDrops(t *testing.T) {
 	}
 
 	builtInMet := e.Fields["metrics"].(map[string]interface{})["<built-in>"]
-	dropCount := builtInMet.(map[string]interface{})["counter_decision_logs_dropped"]
+	dropCount := builtInMet.(map[string]interface{})["counter_decision_logs_dropped_rate_limit_exceeded"]
 
 	actual, err := dropCount.(json.Number).Int64()
 	if err != nil {

--- a/plugins/logs/encoder.go
+++ b/plugins/logs/encoder.go
@@ -15,12 +15,13 @@ import (
 )
 
 const (
-	encHardLimitThreshold            = 0.9
-	softLimitBaseFactor              = 2
-	softLimitExponentScaleFactor     = 0.2
-	encSoftLimitScaleUpCounterName   = "enc_soft_limit_scale_up"
-	encSoftLimitScaleDownCounterName = "enc_soft_limit_scale_down"
-	encSoftLimitStableCounterName    = "enc_soft_limit_stable"
+	encHardLimitThreshold              = 0.9
+	softLimitBaseFactor                = 2
+	softLimitExponentScaleFactor       = 0.2
+	encLogExUploadSizeLimitCounterName = "enc_log_exceeded_upload_size_limit_bytes"
+	encSoftLimitScaleUpCounterName     = "enc_soft_limit_scale_up"
+	encSoftLimitScaleDownCounterName   = "enc_soft_limit_scale_down"
+	encSoftLimitStableCounterName      = "enc_soft_limit_stable"
 )
 
 // chunkEncoder implements log buffer chunking and compression. Log events are
@@ -65,6 +66,9 @@ func (enc *chunkEncoder) Write(event EventV1) (result [][]byte, err error) {
 	if len(bs) == 0 {
 		return nil, nil
 	} else if int64(len(bs)+2) > enc.limit {
+		if enc.metrics != nil {
+			enc.metrics.Counter(encLogExUploadSizeLimitCounterName).Incr()
+		}
 		return nil, fmt.Errorf("upload chunk size (%d) exceeds upload_size_limit_bytes (%d)",
 			int64(len(bs)+2), enc.limit)
 	}


### PR DESCRIPTION
Previously in #5732 we updated the decision log plugin to surface errors via the Status API. However in that change certain events like encoder errors and log drops due to buffer size limits had no metrics associated with them. This change adds more metrics for these events so that they can be surfaced via the Status API.

Fixes: #5637

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->
