### PR TITLE
parse: include rule head location when requested

### DIFF
--- a/cmd/parse_test.go
+++ b/cmd/parse_test.go
@@ -177,7 +177,17 @@ func TestParseJSONOutputWithLocations(t *testing.T) {
       "body": [
         {
           "index": 0,
+          "location": {
+            "file": "TEMPDIR/x.rego",
+            "row": 3,
+            "col": 7
+          },
           "terms": {
+            "location": {
+              "file": "TEMPDIR/x.rego",
+              "row": 3,
+              "col": 7
+            },
             "type": "boolean",
             "value": true
           }
@@ -199,7 +209,378 @@ func TestParseJSONOutputWithLocations(t *testing.T) {
             "type": "var",
             "value": "p"
           }
-        ]
+        ],
+        "location": {
+          "file": "TEMPDIR/x.rego",
+          "row": 3,
+          "col": 3
+        }
+      },
+      "location": {
+        "file": "TEMPDIR/x.rego",
+        "row": 3,
+        "col": 3
+      }
+    }
+  ]
+}
+`, "TEMPDIR", tempDirPath, -1)
+
+	if got, want := string(stdout), expectedOutput; got != want {
+		t.Fatalf("Expected output\n%v\n, got\n%v", want, got)
+	}
+}
+
+func TestParseRulesBlockJSONOutputWithLocations(t *testing.T) {
+
+	files := map[string]string{
+		"x.rego": `package x
+
+		default allow = false
+    allow = true {
+      input.method == "GET"
+      input.path = ["getUser", user]
+      input.user == user
+    }
+		`,
+	}
+	errc, stdout, stderr, tempDirPath := testParse(t, files, &parseParams{
+		format:      util.NewEnumFlag(parseFormatJSON, []string{parseFormatPretty, parseFormatJSON}),
+		jsonInclude: "locations",
+	})
+	if errc != 0 {
+		t.Fatalf("Expected exit code 0, got %v", errc)
+	}
+	if len(stderr) > 0 {
+		t.Fatalf("Expected no stderr output, got:\n%s\n", string(stderr))
+	}
+
+	expectedOutput := strings.Replace(`{
+  "package": {
+    "location": {
+      "file": "TEMPDIR/x.rego",
+      "row": 1,
+      "col": 1
+    },
+    "path": [
+      {
+        "location": {
+          "file": "TEMPDIR/x.rego",
+          "row": 1,
+          "col": 9
+        },
+        "type": "var",
+        "value": "data"
+      },
+      {
+        "location": {
+          "file": "TEMPDIR/x.rego",
+          "row": 1,
+          "col": 9
+        },
+        "type": "string",
+        "value": "x"
+      }
+    ]
+  },
+  "rules": [
+    {
+      "body": [
+        {
+          "index": 0,
+          "location": {
+            "file": "TEMPDIR/x.rego",
+            "row": 3,
+            "col": 3
+          },
+          "terms": {
+            "location": {
+              "file": "TEMPDIR/x.rego",
+              "row": 3,
+              "col": 3
+            },
+            "type": "boolean",
+            "value": true
+          }
+        }
+      ],
+      "default": true,
+      "head": {
+        "name": "allow",
+        "value": {
+          "location": {
+            "file": "TEMPDIR/x.rego",
+            "row": 3,
+            "col": 19
+          },
+          "type": "boolean",
+          "value": false
+        },
+        "ref": [
+          {
+            "type": "var",
+            "value": "allow"
+          }
+        ],
+        "location": {
+          "file": "TEMPDIR/x.rego",
+          "row": 3,
+          "col": 11
+        }
+      },
+      "location": {
+        "file": "TEMPDIR/x.rego",
+        "row": 3,
+        "col": 3
+      }
+    },
+    {
+      "body": [
+        {
+          "index": 0,
+          "location": {
+            "file": "TEMPDIR/x.rego",
+            "row": 5,
+            "col": 7
+          },
+          "terms": [
+            {
+              "location": {
+                "file": "TEMPDIR/x.rego",
+                "row": 5,
+                "col": 20
+              },
+              "type": "ref",
+              "value": [
+                {
+                  "location": {
+                    "file": "TEMPDIR/x.rego",
+                    "row": 5,
+                    "col": 20
+                  },
+                  "type": "var",
+                  "value": "equal"
+                }
+              ]
+            },
+            {
+              "location": {
+                "file": "TEMPDIR/x.rego",
+                "row": 5,
+                "col": 7
+              },
+              "type": "ref",
+              "value": [
+                {
+                  "location": {
+                    "file": "TEMPDIR/x.rego",
+                    "row": 5,
+                    "col": 7
+                  },
+                  "type": "var",
+                  "value": "input"
+                },
+                {
+                  "location": {
+                    "file": "TEMPDIR/x.rego",
+                    "row": 5,
+                    "col": 13
+                  },
+                  "type": "string",
+                  "value": "method"
+                }
+              ]
+            },
+            {
+              "location": {
+                "file": "TEMPDIR/x.rego",
+                "row": 5,
+                "col": 23
+              },
+              "type": "string",
+              "value": "GET"
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "location": {
+            "file": "TEMPDIR/x.rego",
+            "row": 6,
+            "col": 7
+          },
+          "terms": [
+            {
+              "location": {
+                "file": "TEMPDIR/x.rego",
+                "row": 6,
+                "col": 18
+              },
+              "type": "ref",
+              "value": [
+                {
+                  "location": {
+                    "file": "TEMPDIR/x.rego",
+                    "row": 6,
+                    "col": 18
+                  },
+                  "type": "var",
+                  "value": "eq"
+                }
+              ]
+            },
+            {
+              "location": {
+                "file": "TEMPDIR/x.rego",
+                "row": 6,
+                "col": 7
+              },
+              "type": "ref",
+              "value": [
+                {
+                  "location": {
+                    "file": "TEMPDIR/x.rego",
+                    "row": 6,
+                    "col": 7
+                  },
+                  "type": "var",
+                  "value": "input"
+                },
+                {
+                  "location": {
+                    "file": "TEMPDIR/x.rego",
+                    "row": 6,
+                    "col": 13
+                  },
+                  "type": "string",
+                  "value": "path"
+                }
+              ]
+            },
+            {
+              "location": {
+                "file": "TEMPDIR/x.rego",
+                "row": 6,
+                "col": 20
+              },
+              "type": "array",
+              "value": [
+                {
+                  "location": {
+                    "file": "TEMPDIR/x.rego",
+                    "row": 6,
+                    "col": 21
+                  },
+                  "type": "string",
+                  "value": "getUser"
+                },
+                {
+                  "location": {
+                    "file": "TEMPDIR/x.rego",
+                    "row": 6,
+                    "col": 32
+                  },
+                  "type": "var",
+                  "value": "user"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "location": {
+            "file": "TEMPDIR/x.rego",
+            "row": 7,
+            "col": 7
+          },
+          "terms": [
+            {
+              "location": {
+                "file": "TEMPDIR/x.rego",
+                "row": 7,
+                "col": 18
+              },
+              "type": "ref",
+              "value": [
+                {
+                  "location": {
+                    "file": "TEMPDIR/x.rego",
+                    "row": 7,
+                    "col": 18
+                  },
+                  "type": "var",
+                  "value": "equal"
+                }
+              ]
+            },
+            {
+              "location": {
+                "file": "TEMPDIR/x.rego",
+                "row": 7,
+                "col": 7
+              },
+              "type": "ref",
+              "value": [
+                {
+                  "location": {
+                    "file": "TEMPDIR/x.rego",
+                    "row": 7,
+                    "col": 7
+                  },
+                  "type": "var",
+                  "value": "input"
+                },
+                {
+                  "location": {
+                    "file": "TEMPDIR/x.rego",
+                    "row": 7,
+                    "col": 13
+                  },
+                  "type": "string",
+                  "value": "user"
+                }
+              ]
+            },
+            {
+              "location": {
+                "file": "TEMPDIR/x.rego",
+                "row": 7,
+                "col": 21
+              },
+              "type": "var",
+              "value": "user"
+            }
+          ]
+        }
+      ],
+      "head": {
+        "name": "allow",
+        "value": {
+          "location": {
+            "file": "TEMPDIR/x.rego",
+            "row": 4,
+            "col": 13
+          },
+          "type": "boolean",
+          "value": true
+        },
+        "ref": [
+          {
+            "type": "var",
+            "value": "allow"
+          }
+        ],
+        "location": {
+          "file": "TEMPDIR/x.rego",
+          "row": 4,
+          "col": 5
+        }
+      },
+      "location": {
+        "file": "TEMPDIR/x.rego",
+        "row": 4,
+        "col": 5
       }
     }
   ]


### PR DESCRIPTION
<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->

### Why the changes in this PR are needed?
Prior to this PR, when the AST information were serialized to JSON, rules expressed as discussed in #5790 included only the location of their value and not the one of the rule ref var itself. This was due to the fact that these type of rule is processed by the function [ParseRuleFromBody](https://github.com/open-policy-agent/opa/blob/main/ast/parser_ext.go#L135), which does not set the value of the [jsonOptions](https://github.com/open-policy-agent/opa/blob/main/ast/policy.go#L193) field of the `Rule` struct created.
<!--
Include a short description of WHY the changes were made.
-->

### What are the changes in this PR?
This PR adds the code necessary to set the correct value of the `jsonOptions` field in the function [parseModule](https://github.com/Trolloldem/opa/blob/138687d635e84f97a5fa213201aa558014fca802/ast/parser_ext.go#L609) using the same approach employed for the `Rule` structs created in [Parse](https://github.com/open-policy-agent/opa/blob/main/ast/parser.go#L399) method.

In addition to that, the test [TestParseJSONOutputWithLocations](https://github.com/Trolloldem/opa/blob/138687d635e84f97a5fa213201aa558014fca802/cmd/parse_test.go#L128) has been modified accordingly with the expected output, which is a JSON including the information about the rule head location. A new test [TestParseRulesBlockJSONOutputWithLocations](https://github.com/Trolloldem/opa/blob/138687d635e84f97a5fa213201aa558014fca802/cmd/parse_test.go#L234) has been added to check both branches of the [switch statement](https://github.com/Trolloldem/opa/blob/138687d635e84f97a5fa213201aa558014fca802/ast/parser_ext.go#L632) that populates the slice of `Rule` structs in the [Module](https://github.com/open-policy-agent/opa/blob/main/ast/policy.go#L141) struct
<!--
Include a short description of WHAT changes were made.
-->

### Notes to assist PR review:
This PR changes only the [parseModule](https://github.com/Trolloldem/opa/blob/138687d635e84f97a5fa213201aa558014fca802/ast/parser_ext.go#L609) using the same logic found in the [Parse](https://github.com/open-policy-agent/opa/blob/main/ast/parser.go#L399) method to set the correct `JSONOptions`.

The other changes are the test found in [cmd/parse_test.go](https://github.com/Trolloldem/opa/blob/138687d635e84f97a5fa213201aa558014fca802/cmd/parse_test.go).
<!--
Here you can add information you think will help the reviewer(s).
-->
