### PR TITLE
runtime: Increase log level for rootless img msg

### DIFF
--- a/runtime/check_user_linux.go
+++ b/runtime/check_user_linux.go
@@ -14,20 +14,16 @@ import (
 // checkUserPrivileges on Linux could be running in Docker, so we check if
 // we're running in the official container image.
 func checkUserPrivileges(logger logging.Logger) {
-	var message string
-
 	usr, err := user.Current()
 	if err != nil {
 		logger.Debug("Failed to determine uid/gid of process owner")
 	} else if usr.Uid == "0" || usr.Gid == "0" {
-		message = "OPA running with uid or gid 0. Running OPA with root privileges is not recommended."
+		message := "OPA running with uid or gid 0. Running OPA with root privileges is not recommended."
+		logger.Warn(message)
 	}
 
 	if os.Getenv("OPA_DOCKER_IMAGE_TAG") == "rootless" {
-		message += " The -rootless image tag will not be published after OPA v0.50.0."
-	}
-
-	if message != "" {
-		logger.Warn(message)
+		message := "The -rootless image tag will not be published after OPA v0.52.0."
+		logger.Error(message)
 	}
 }


### PR DESCRIPTION
<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->

### Why the changes in this PR are needed?

<!--
Include a short description of WHY the changes were made.
-->

Since all published OPA images now run with a non-root uid/gid, there is no need to publish the rootless image tag. Currently if the rootless variant is run, a log message at the Warn level is printed.


### What are the changes in this PR?

<!--
Include a short description of WHAT changes were made.
-->

This change increaes the log level for that message to Error in order to make it more explict to stop using this variant in the future.
