### PR TITLE
[ast/inspect] Fix issue with unset annotation data

### DIFF
--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -391,6 +391,7 @@ type Reader struct {
 	verificationConfig    *VerificationConfig
 	skipVerify            bool
 	processAnnotations    bool
+	jsonOptions           *ast.JSONOptions
 	capabilities          *ast.Capabilities
 	files                 map[string]FileInfo // files in the bundle signature payload
 	sizeLimitBytes        int64
@@ -460,6 +461,12 @@ func (r *Reader) WithCapabilities(caps *ast.Capabilities) *Reader {
 	return r
 }
 
+// WithJSONOptions sets the JSONOptions to use when parsing policy files
+func (r *Reader) WithJSONOptions(opts *ast.JSONOptions) *Reader {
+	r.jsonOptions = opts
+	return r
+}
+
 // WithSizeLimitBytes sets the size limit to apply to files in the bundle. If files are larger
 // than this, an error will be returned by the reader.
 func (r *Reader) WithSizeLimitBytes(n int64) *Reader {
@@ -492,6 +499,7 @@ func (r *Reader) ParserOptions() ast.ParserOptions {
 	return ast.ParserOptions{
 		ProcessAnnotation: r.processAnnotations,
 		Capabilities:      r.capabilities,
+		JSONOptions:       r.jsonOptions,
 	}
 }
 

--- a/internal/bundle/inspect/inspect.go
+++ b/internal/bundle/inspect/inspect.go
@@ -32,6 +32,14 @@ func File(path string, includeAnnotations bool) (*Info, error) {
 	b, err := loader.NewFileLoader().
 		WithSkipBundleVerification(true).
 		WithProcessAnnotation(true). // Always process annotations, for enriching namespace listing
+		WithJSONOptions(&ast.JSONOptions{
+			MarshalOptions: ast.JSONMarshalOptions{
+				IncludeLocation: ast.NodeToggle{
+					// Annotation location data is only included if includeAnnotations is set
+					AnnotationsRef: includeAnnotations,
+				},
+			},
+		}).
 		AsBundle(path)
 	if err != nil {
 		return nil, err

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -98,6 +98,7 @@ type FileLoader interface {
 	WithSkipBundleVerification(bool) FileLoader
 	WithProcessAnnotation(bool) FileLoader
 	WithCapabilities(*ast.Capabilities) FileLoader
+	WithJSONOptions(*ast.JSONOptions) FileLoader
 }
 
 // NewFileLoader returns a new FileLoader instance.
@@ -162,6 +163,12 @@ func (fl *fileLoader) WithCapabilities(caps *ast.Capabilities) FileLoader {
 	return fl
 }
 
+// WithJSONOptions sets the JSONOptions for use when parsing files
+func (fl *fileLoader) WithJSONOptions(opts *ast.JSONOptions) FileLoader {
+	fl.opts.JSONOptions = opts
+	return fl
+}
+
 // All returns a Result object loaded (recursively) from the specified paths.
 func (fl fileLoader) All(paths []string) (*Result, error) {
 	return fl.Filtered(paths, nil)
@@ -222,7 +229,8 @@ func (fl fileLoader) AsBundle(path string) (*bundle.Bundle, error) {
 		WithBundleVerificationConfig(fl.bvc).
 		WithSkipBundleVerification(fl.skipVerify).
 		WithProcessAnnotations(fl.opts.ProcessAnnotation).
-		WithCapabilities(fl.opts.Capabilities)
+		WithCapabilities(fl.opts.Capabilities).
+		WithJSONOptions(fl.opts.JSONOptions)
 
 	// For bundle directories add the full path in front of module file names
 	// to simplify debugging.


### PR DESCRIPTION
Fixes https://github.com/open-policy-agent/opa/issues/5826

```
# before, location data is missing
opa $ opa inspect bundle.tar.gz -f json -a
{
  "manifest": {
    "revision": "",
    "roots": [
      ""
    ]
  },
  "signatures_config": {},
  "namespaces": {
    "data": [
      "/data.json"
    ],
    "data.example": [
      "/example/policy.rego"
    ]
  },
  "annotations": [
    {
      "annotations": {
        "scope": "package",
        "title": "Example Package"
      },
      "path": [
        {
          "type": "var",
          "value": "data"
        },
        {
          "type": "string",
          "value": "example"
        }
      ]
    },
    {
      "annotations": {
        "scope": "rule",
        "title": "Example Rule"
      },
      "path": [
        {
          "type": "var",
          "value": "data"
        },
        {
          "type": "string",
          "value": "example"
        },
        {
          "type": "string",
          "value": "allow"
        }
      ]
    }
  ]
}

# after, location data is set
opa $ go run main.go inspect bundle.tar.gz -f json -a
{
  "manifest": {
    "revision": "",
    "roots": [
      ""
    ]
  },
  "signatures_config": {},
  "namespaces": {
    "data": [
      "/data.json"
    ],
    "data.example": [
      "/example/policy.rego"
    ]
  },
  "annotations": [
    {
      "annotations": {
        "scope": "package",
        "title": "Example Package"
      },
      "location": {
        "file": "/example/policy.rego",
        "row": 3,
        "col": 1
      },
      "path": [
        {
          "type": "var",
          "value": "data"
        },
        {
          "type": "string",
          "value": "example"
        }
      ]
    },
    {
      "annotations": {
        "scope": "rule",
        "title": "Example Rule"
      },
      "location": {
        "file": "/example/policy.rego",
        "row": 7,
        "col": 1
      },
      "path": [
        {
          "type": "var",
          "value": "data"
        },
        {
          "type": "string",
          "value": "example"
        },
        {
          "type": "string",
          "value": "allow"
        }
      ]
    }
  ]
}

```


