### PR TITLE
planner: fix p.curr <-> prev handling in CallDynamic optimization case

### DIFF
--- a/test/cases/testdata/planner-ir/test-call-dynamic.yaml
+++ b/test/cases/testdata/planner-ir/test-call-dynamic.yaml
@@ -1,0 +1,22 @@
+cases:
+- note: ir/call_dynamic in comprehension
+  modules:
+  - |
+    package test
+    p := x {
+      b := input
+      x := { y | y := data.a[b][_] }
+    }
+  - |
+    package a
+    b := {"foo", "bar"}
+  - |
+    package a
+    c := {"x", "y" }
+  query: data.test.p = x
+  sort_bindings: true
+  input: "b"
+  want_result:
+  - x:
+    - bar
+    - foo


### PR DESCRIPTION
For the added test case,

    x := { y | y := data.a[b][_] }

the IR that was previously emitted was out of whack:

```
| | | | | | *ir.ScanStmt &{Source:Local<6> Key:Local<9> Value:Local<10> Block:Block (1 statements) Location:{File:0 Col:14 Row:4 file:module-0.rego text:y := data.a[b][_]}} | | | | | | | *ir.Block Block (1 statements)
| | | | | | | | *ir.AssignVarStmt &{Source:{Value:Local<9>} Target:Local<11> Location:{File:0 Col:14 Row:4 file:module-0.rego text:y := data.a[b][_]}} | | | | *ir.AssignVarStmt &{Source:{Value:Local<5>} Target:Local<13> Location:{File:0 Col:8 Row:4 file:module-0.rego text:{ y | y := data.a[b][_] }}} | | | | *ir.AssignVarOnceStmt &{Source:{Value:Local<13>} Target:Local<3> Location:{File:0 Col:1 Row:2 file:module-0.rego text:p := x}}
```

Now, we get the right statements: the Value of ScanStmt is what we're interested in, and what needs to be added to the result set:

```
| | | | | | | | *ir.ScanStmt &{Source:Local<6> Key:Local<9> Value:Local<10> Block:Block (3 statements) Location:{File:0 Col:14 Row:4 file:module-0.rego text:y := data.a[b][_]}} | | | | | | | | | *ir.Block Block (3 statements)
| | | | | | | | | | *ir.AssignVarStmt &{Source:{Value:Local<9>} Target:Local<11> Location:{File:0 Col:14 Row:4 file:module-0.rego text:y := data.a[b][_]}} | | | | | | | | | | *ir.AssignVarStmt &{Source:{Value:Local<10>} Target:Local<12> Location:{File:0 Col:14 Row:4 file:module-0.rego text:y := data.a[b][_]}} | | | | | | | | | | *ir.SetAddStmt &{Value:{Value:Local<12>} Set:Local<5> Location:{File:0 Col:8 Row:4 file:module-0.rego text:{ y | y := data.a[b][_] }}}
```