### PR TITLE
Allow adding labels via discovery

### DIFF
--- a/docs/content/management-discovery.md
+++ b/docs/content/management-discovery.md
@@ -271,9 +271,10 @@ configuration labels or environment variables.
 
 In practice, discovery services do not change frequently. These configuration sections are treated as
 immutable to avoid accidental configuration errors rendering OPA unable to discover a new configuration.
-If the discovered configuration changes the `discovery` or `labels` sections,
+If the discovered configuration changes the `discovery` section,
 those changes are ignored. If the discovered configuration changes the discovery service,
 an error will be logged.
+If the discovered configuration changes the `labels` section, only labels that are additional compared to the bootstrap configuration are used, all other changes are ignored. If the discovery document changes its `labels` section over time, the effective set of labels is always the bootstrap configuration plus added labels from the latest discovery document. 
 
 ### Discovery Bundle Signature
 


### PR DESCRIPTION
### Why the changes in this PR are needed?

This PR addresses issue #5832 and allows to add labels to the OPA configuration via discovery. This unlocks use cases where labels that are irrelevant for discovery but useful either in policies, status updates or decision logs.  

### What are the changes in this PR?

The current silent dropping of labels from discovery is changed to only drop changes. Additional labels are accepted and added to the runtime configuration. Additions are always based on the bootstrap configuration, i.e. multiple discovery updates behave as if just the last has happened. 

