### PR TITLE
rego: Fix printing duplication when parse errors length is 1

### DIFF
--- a/rego/rego.go
+++ b/rego/rego.go
@@ -1731,7 +1731,14 @@ func (r *Rego) parseModules(ctx context.Context, txn storage.Transaction, m metr
 	for _, module := range r.modules {
 		p, err := module.Parse()
 		if err != nil {
-			errs = append(errs, err)
+			switch errorWithType := err.(type) {
+			case ast.Errors:
+				for _, e := range errorWithType {
+					errs = append(errs, e)
+				}
+			default:
+				errs = append(errs, errorWithType)
+			}
 		}
 		r.parsedModules[module.filename] = p
 	}

--- a/rego/rego_test.go
+++ b/rego/rego_test.go
@@ -937,6 +937,29 @@ func TestPrepareAndEvalOriginal(t *testing.T) {
 	assertEval(t, r, "[[2]]")
 }
 
+func TestPrepareAndEvalOnlyOneErrorOccurredPrintOnce(t *testing.T) {
+	module := `
+	package test
+    package test
+	x = input.y
+	`
+
+	r := New(
+		Query("data.test.x"),
+		Module("", module),
+		Package("foo"),
+		Input(map[string]int{"y": 2}),
+	)
+
+	_, err := r.PrepareForEval(context.Background())
+	if err == nil {
+		t.Fatal("Expected error but got nil")
+	}
+	if strings.Count(err.Error(), "1 error occurred") > 1 {
+		t.Fatalf("Expected to print '1 error occurred' only once")
+	}
+}
+
 func TestPrepareAndEvalNewPrintHook(t *testing.T) {
 	module := `
 	package test


### PR DESCRIPTION
<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->

### Why the changes in this PR are needed?

When having a rego compilation error that has only 1 error element the string "1 error occurred" is printed twice. For example from real usage:
1 error occurred: 1 error occurred: main.rego:2: rego_parse_error: unexpected package

### What are the changes in this PR?

I used type conversion in the parse function in order to avoid "1 error occurred" duplication when only 1 error occured.

### Notes to assist PR review:

The test I added demonstrates how to reproduce the bug

### Further comments:

<img width="802" alt="Screen Shot 2023-04-17 at 12 44 30" src="https://user-images.githubusercontent.com/51244810/232627894-19866f2f-d364-4bdf-8b9f-0bc545aa881e.png">

the squashed commit of https://github.com/open-policy-agent/opa/pull/5834
