### PR TITLE
topdown: Add built-in HMAC compare function

### DIFF
--- a/ast/builtins.go
+++ b/ast/builtins.go
@@ -214,6 +214,7 @@ var DefaultBuiltins = [...]*Builtin{
 	CryptoHmacSha1,
 	CryptoHmacSha256,
 	CryptoHmacSha512,
+	CryptoHmacEqual,
 
 	// Graphs
 	WalkBuiltin,
@@ -2377,6 +2378,18 @@ var CryptoHmacSha512 = &Builtin{
 			types.Named("key", types.S).Description("key to use"),
 		),
 		types.Named("y", types.S).Description("SHA512-HMAC of `x`"),
+	),
+}
+
+var CryptoHmacEqual = &Builtin{
+	Name:        "crypto.hmac.equal",
+	Description: "Returns a boolean representing the result of comparing two MACs for equality without leaking timing information.",
+	Decl: types.NewFunction(
+		types.Args(
+			types.Named("mac1", types.S).Description("mac1 to compare"),
+			types.Named("mac2", types.S).Description("mac2 to compare"),
+		),
+		types.Named("result", types.B).Description("`true` if the MACs are equals, `false` otherwise"),
 	),
 }
 

--- a/builtin_metadata.json
+++ b/builtin_metadata.json
@@ -33,6 +33,7 @@
       "to_number"
     ],
     "crypto": [
+      "crypto.hmac.equal",
       "crypto.hmac.md5",
       "crypto.hmac.sha1",
       "crypto.hmac.sha256",
@@ -3201,6 +3202,31 @@
       "type": "number"
     },
     "wasm": true
+  },
+  "crypto.hmac.equal": {
+    "args": [
+      {
+        "description": "mac1 to compare",
+        "name": "mac1",
+        "type": "string"
+      },
+      {
+        "description": "mac2 to compare",
+        "name": "mac2",
+        "type": "string"
+      }
+    ],
+    "available": [
+      "edge"
+    ],
+    "description": "Returns a boolean representing the result of comparing two MACs for equality without leaking timing information.",
+    "introduced": "edge",
+    "result": {
+      "description": "`true` if the MACs are equals, `false` otherwise",
+      "name": "result",
+      "type": "boolean"
+    },
+    "wasm": false
   },
   "crypto.hmac.md5": {
     "args": [

--- a/capabilities.json
+++ b/capabilities.json
@@ -573,6 +573,23 @@
       }
     },
     {
+      "name": "crypto.hmac.equal",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "boolean"
+        },
+        "type": "function"
+      }
+    },
+    {
       "name": "crypto.hmac.md5",
       "decl": {
         "args": [

--- a/test/cases/testdata/cryptohmacequal/test-cryptohmacequal.yaml
+++ b/test/cases/testdata/cryptohmacequal/test-cryptohmacequal.yaml
@@ -1,0 +1,66 @@
+cases:
+  - note: cryptohmacequal/crypto.hmac.equal_md5
+    query: data.test.p = x
+    modules:
+    - |
+      package test
+      
+      p[res] {
+        res := crypto.hmac.equal(input.mac1, input.mac2)
+      }
+    input: {"mac1": "31b6db9e5eb4addb42f1a6ca07367adc", "mac2": "31b6db9e5eb4addb42f1a6ca07367adc"}
+    want_result:
+    - x:
+      - true
+  - note: cryptohmacequal/crypto.hmac.equal_sha1
+    query: data.test.p = x
+    modules:
+    - |
+      package test
+      
+      p[res] {
+        res := crypto.hmac.equal(input.mac1, input.mac2)
+      }
+    input: {"mac1": "85d155c55ed286a300bd1cf124de08d87e914f3a", "mac2": "85d155c55ed286a300bd1cf124de08d87e914f3a"}
+    want_result:
+    - x:
+      - true
+  - note: cryptohmacequal/crypto.hmac.equal_sha256
+    query: data.test.p = x
+    modules:
+    - |
+      package test
+      
+      p[res] {
+        res := crypto.hmac.equal(input.mac1, input.mac2)
+      }
+    input: {"mac1": "147933218aaabc0b8b10a2b3a5c34684c8d94341bcf10a4736dc7270f7741851", "mac2": "147933218aaabc0b8b10a2b3a5c34684c8d94341bcf10a4736dc7270f7741851"}
+    want_result:
+    - x:
+      - true
+  - note: cryptohmacequal/crypto.hmac.equal_sha512
+    query: data.test.p = x
+    modules:
+    - |
+      package test
+      
+      p[res] {
+        res := crypto.hmac.equal(input.mac1, input.mac2)
+      }
+    input: {"mac1": "24257d7210582a65c731ec55159c8184cc24c02489453e58587f71f44c23a2d61b4b72154a89d17b2d49448a8452ea066f4fc56a2bcead45c088572ffccdb3d8", "mac2": "24257d7210582a65c731ec55159c8184cc24c02489453e58587f71f44c23a2d61b4b72154a89d17b2d49448a8452ea066f4fc56a2bcead45c088572ffccdb3d8"}
+    want_result:
+    - x:
+      - true  
+  - note: cryptohmacequal/crypto.hmac.equal_false
+    query: data.test.p = x
+    modules:
+    - |
+      package test
+      
+      p[res] {
+        res := crypto.hmac.equal(input.mac1, input.mac2)
+      }
+    input: {"mac1": "31b6db9e5eb4addb42f1a6ca07367adc", "mac2": "31b6db9e5eb4addb"}
+    want_result:
+    - x:
+      - false

--- a/topdown/crypto.go
+++ b/topdown/crypto.go
@@ -249,6 +249,24 @@ func builtinCryptoHmacSha512(_ BuiltinContext, operands []*ast.Term, iter func(*
 	return hmacHelper(operands, iter, sha512.New)
 }
 
+func builtinCryptoHmacEqual(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term) error) error {
+	a1 := operands[0].Value
+	mac1, err := builtins.StringOperand(a1, 1)
+	if err != nil {
+		return err
+	}
+
+	a2 := operands[1].Value
+	mac2, err := builtins.StringOperand(a2, 2)
+	if err != nil {
+		return err
+	}
+
+	res := hmac.Equal([]byte(mac1), []byte(mac2))
+
+	return iter(ast.BooleanTerm(res))
+}
+
 func init() {
 	RegisterBuiltinFunc(ast.CryptoX509ParseCertificates.Name, builtinCryptoX509ParseCertificates)
 	RegisterBuiltinFunc(ast.CryptoX509ParseAndVerifyCertificates.Name, builtinCryptoX509ParseAndVerifyCertificates)
@@ -261,6 +279,7 @@ func init() {
 	RegisterBuiltinFunc(ast.CryptoHmacSha1.Name, builtinCryptoHmacSha1)
 	RegisterBuiltinFunc(ast.CryptoHmacSha256.Name, builtinCryptoHmacSha256)
 	RegisterBuiltinFunc(ast.CryptoHmacSha512.Name, builtinCryptoHmacSha512)
+	RegisterBuiltinFunc(ast.CryptoHmacEqual.Name, builtinCryptoHmacEqual)
 }
 
 func verifyX509CertificateChain(certs []*x509.Certificate) ([]*x509.Certificate, error) {


### PR DESCRIPTION
Add crypto.hmac.equal built-in function to safelly comparing hashes generated by MD5, SHA-1, SHA-256 and SHA-512 hashing algorithms.

The built-in function is a wrapped for the function Equal of package crypto/hmac.

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->

### Why the changes in this PR are needed?

<!--
Include a short description of WHY the changes were made.
-->
PR to complement [topdown: Add built-in HMAC functions](https://github.com/open-policy-agent/opa/pull/4100)

### What are the changes in this PR?

<!--
Include a short description of WHAT changes were made.
-->
Add support to compare hashes generated by built-in functions from crypto.hmac.*

### Notes to assist PR review:

<!--
Here you can add information you think will help the reviewer(s).
-->
- crypto.hmac.* built-in functions doesn't have a function to apply constant-time comparison.
- crypto.hmac.equal wraps [go hmac.Equal](https://cs.opensource.google/go/go/+/refs/tags/go1.20.3:src/crypto/hmac/hmac.go;drc=ea5d7cbc2644643331bd675b1ebdf0aaac7419f1;l=175)

### Further comments:

<!--
Here you can include links to additional resources related to the changes, discuss your solution, other approaches you considered etc.
-->
- There are scenarios where a secret-key can be used to validate request information instead of a jwt token.

e.g.:

```rego
import input.attributes.request.http as http_request

allow if {
	http_request.method == "POST"
	input.parsed_path = ["workflows", "github", "webhooks"]
	check_signature
}


check_signature {
	secret_key := opa.runtime().env.GITHUB_SECRET_KEY
	header_signature = http_request.headers["X-Hub-Signature-256"]
	raw_body := http_request.raw_body
        hash_body := crypto.hmac.sha256(raw_body, secret_key)
        expected_signature := concat("", ["sha256=", hash_body])
        # Using a plain == operator is not advised
	crypto.hmac.equal(header_signature, expected_signature)
}
```