### PR TITLE
ast: Set result of groundness check on indexer's AllRules func

### DIFF
--- a/ast/index.go
+++ b/ast/index.go
@@ -173,6 +173,7 @@ func (i *baseDocEqIndex) AllRules(resolver ValueResolver) (*IndexResult, error) 
 
 	result := NewIndexResult(i.kind)
 	result.Default = i.defaultRule
+	result.OnlyGroundRefs = i.onlyGroundRefs
 	result.Rules = make([]*Rule, 0, len(tr.ordering))
 
 	for _, pos := range tr.ordering {


### PR DESCRIPTION
We perform groundness checks at index creation time and then include result of that in the indexer's result. Previously we did not set this value on the indexer's AllRules call as a result of which rule evaluation for complete rules would get skipped. This change updates the indexer's AllRules call to include the result of the groundness checks.

Fixes: #5857


