### PR TITLE
Add OPA environment information Gauge to Prometheus metrics

### DIFF
--- a/docs/content/monitoring.md
+++ b/docs/content/monitoring.md
@@ -81,6 +81,7 @@ When Prometheus is enabled in the status plugin (see [Configuration](../configur
 
 | Metric name | Metric type | Description                                              | Status |
 | --- | --- |----------------------------------------------------------|--------|
+| opa_info | gauge | Information about the OPA environment.                    | EXPERIMENTAL |
 | plugin_status_gauge | gauge | Number of plugins by name and status.                    | EXPERIMENTAL |
 | bundle_loaded_counter | counter | Number of bundles loaded with success.                   | EXPERIMENTAL |
 | bundle_failed_load_counter | counter | Number of bundles that failed to load.                   | EXPERIMENTAL |

--- a/plugins/status/metrics.go
+++ b/plugins/status/metrics.go
@@ -1,10 +1,18 @@
 package status
 
 import (
+	"github.com/open-policy-agent/opa/version"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 var (
+	opaInfo = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name:        "opa_info",
+			Help:        "Information about the OPA environment.",
+			ConstLabels: map[string]string{"version": version.Version},
+		},
+	)
 	pluginStatus = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "plugin_status_gauge",
@@ -53,3 +61,7 @@ var (
 		Buckets: prometheus.ExponentialBuckets(1000, 2, 20),
 	}, []string{"name", "stage"})
 )
+
+func init() {
+	opaInfo.Set(1)
+}

--- a/plugins/status/plugin.go
+++ b/plugins/status/plugin.go
@@ -238,7 +238,7 @@ func (p *Plugin) Start(ctx context.Context) error {
 	p.manager.RegisterPluginStatusListener(Name, p.UpdatePluginStatus)
 
 	if p.config.Prometheus && p.manager.PrometheusRegister() != nil {
-		p.register(p.manager.PrometheusRegister(), pluginStatus, loaded, failLoad,
+		p.register(p.manager.PrometheusRegister(), opaInfo, pluginStatus, loaded, failLoad,
 			lastRequest, lastSuccessfulActivation, lastSuccessfulDownload,
 			lastSuccessfulRequest, bundleLoadDuration)
 	}

--- a/plugins/status/plugin_go1.17_test.go
+++ b/plugins/status/plugin_go1.17_test.go
@@ -13,10 +13,13 @@ package status
 
 import (
 	"context"
+	"reflect"
 	"testing"
 	"time"
 
 	"github.com/open-policy-agent/opa/plugins/bundle"
+	"github.com/open-policy-agent/opa/version"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 )
 
@@ -42,6 +45,9 @@ func TestPluginPrometheus(t *testing.T) {
 	<-fixture.server.ch
 
 	registerMock := fixture.manager.PrometheusRegister().(*prometheusRegisterMock)
+
+	assertOpInformationGauge(t, registerMock)
+
 	if registerMock.Collectors[pluginStatus] != true {
 		t.Fatalf("Plugin status metric was not registered on prometheus")
 	}
@@ -66,8 +72,8 @@ func TestPluginPrometheus(t *testing.T) {
 	if registerMock.Collectors[bundleLoadDuration] != true {
 		t.Fatalf("Bundle Load Duration metric was not registered on prometheus")
 	}
-	if len(registerMock.Collectors) != 8 {
-		t.Fatalf("Number of collectors expected (%v), got %v", 8, len(registerMock.Collectors))
+	if len(registerMock.Collectors) != 9 {
+		t.Fatalf("Number of collectors expected (%v), got %v", 9, len(registerMock.Collectors))
 	}
 
 	lastRequestMetricResult := time.UnixMilli(int64(testutil.ToFloat64(lastRequest) / 1e6))
@@ -104,6 +110,58 @@ func TestPluginPrometheus(t *testing.T) {
 	if pluginsStatus != 1 {
 		t.Fatalf("Unexpected number of plugins (%v), got %v", 1, pluginsStatus)
 	}
+}
+
+func assertOpInformationGauge(t *testing.T, registerMock *prometheusRegisterMock) {
+	gauges := filterGauges(registerMock)
+	if len(gauges) != 1 {
+		t.Fatalf("Expected one registered gauge on prometheus but got %v", len(gauges))
+	}
+
+	gauge := gauges[0]
+
+	fqName := getName(gauge)
+	if fqName != "opa_info" {
+		t.Fatalf("Expected gauge to have name opa_info but was %s", fqName)
+	}
+
+	labels := getConstLabels(gauge)
+	versionAct := labels["version"]
+	if versionAct != version.Version {
+		t.Fatalf("Expected gauge to have version label with value %s but was %s", version.Version, versionAct)
+	}
+}
+
+func getName(gauge prometheus.Gauge) string {
+	desc := reflect.Indirect(reflect.ValueOf(gauge.Desc()))
+	fqName := desc.FieldByName("fqName").String()
+	return fqName
+}
+
+func getConstLabels(gauge prometheus.Gauge) prometheus.Labels {
+	desc := reflect.Indirect(reflect.ValueOf(gauge.Desc()))
+	constLabelPairs := desc.FieldByName("constLabelPairs")
+
+	// put all label pairs into a map for easier comparison.
+	labels := make(prometheus.Labels, constLabelPairs.Len())
+	for i := 0; i < constLabelPairs.Len(); i++ {
+		name := constLabelPairs.Index(i).Elem().FieldByName("Name").Elem().String()
+		value := constLabelPairs.Index(i).Elem().FieldByName("Value").Elem().String()
+		labels[name] = value
+	}
+	return labels
+}
+
+func filterGauges(registerMock *prometheusRegisterMock) []prometheus.Gauge {
+	fltd := make([]prometheus.Gauge, 0)
+
+	for m := range registerMock.Collectors {
+		switch metric := m.(type) {
+		case prometheus.Gauge:
+			fltd = append(fltd, metric)
+		}
+	}
+	return fltd
 }
 
 func TestMetricsBundleWithoutRevision(t *testing.T) {


### PR DESCRIPTION
Add OPA environment information Gauge to Prometheus metrics

Closes issue https://github.com/open-policy-agent/opa/issues/5852
Provides version of OPA in a Prometheus gauge for observability

### What are the changes in this PR?

A new Prometheus metric has been added that includes a constant label for the version of OPA.