### PR TITLE
Add ability to configure Unix socket permissions

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -187,6 +187,7 @@ To skip bundle verification, use the --skip-verify flag.
 	runCommand.Flags().StringVarP(&cmdParams.rt.HistoryPath, "history", "H", historyPath(), "set path of history file")
 	cmdParams.rt.Addrs = runCommand.Flags().StringSliceP("addr", "a", []string{defaultAddr}, "set listening address of the server (e.g., [ip]:<port> for TCP, unix://<path> for UNIX domain socket)")
 	cmdParams.rt.DiagnosticAddrs = runCommand.Flags().StringSlice("diagnostic-addr", []string{}, "set read-only diagnostic listening address of the server for /health and /metric APIs (e.g., [ip]:<port> for TCP, unix://<path> for UNIX domain socket)")
+	cmdParams.rt.UnixSocketPerm = runCommand.Flags().String("unix-socket-perm", "755", "specify the permissions for the Unix domain socket if used to listen for incoming connections")
 	runCommand.Flags().BoolVar(&cmdParams.rt.H2CEnabled, "h2c", false, "enable H2C for HTTP listeners")
 	runCommand.Flags().StringVarP(&cmdParams.rt.OutputFormat, "format", "f", "pretty", "set shell output format, i.e, pretty, json")
 	runCommand.Flags().BoolVarP(&cmdParams.rt.Watch, "watch", "w", false, "watch command line files for changes")

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -214,6 +214,9 @@ type Params struct {
 
 	// Check if default Addr is set or the user has changed it.
 	AddrSetByUser bool
+
+	// UnixSocketPerm specifies the permission for the Unix domain socket if used to listen for connections
+	UnixSocketPerm *string
 }
 
 // LoggingConfig stores the configuration for OPA's logging behaviour.
@@ -508,6 +511,10 @@ func (rt *Runtime) Serve(ctx context.Context) error {
 
 	if rt.Params.DiagnosticAddrs != nil {
 		rt.server = rt.server.WithDiagnosticAddresses(*rt.Params.DiagnosticAddrs)
+	}
+
+	if rt.Params.UnixSocketPerm != nil {
+		rt.server = rt.server.WithUnixSocketPermission(rt.Params.UnixSocketPerm)
 	}
 
 	rt.server, err = rt.server.Init(ctx)


### PR DESCRIPTION
<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->

### Why the changes in this PR are needed?

<!--
Include a short description of WHY the changes were made.
-->
Currently if OPA listens on a Unix socket, the socket file is created with 755 permissions. So if OPA is deployed on k8s for example and the socket path is shared via a volume between pods, due to the default permissions, the socket will not be reachable for the caller. One way around this is to match the user id for the OPA and caller containers but that is not always possible.


### What are the changes in this PR?

<!--
Include a short description of WHAT changes were made.
-->
This change adds a new flag to the OPA runtime that allows to configure the permission of the socket file. In the k8s scenario, if the file permission is updated to 777 for instance, the caller will be able to connect to OPA via the socket.

### Notes to assist PR review:

<!--
Here you can add information you think will help the reviewer(s).
-->

I have tested this change with OPA deployed on k8s listening on a UDS and verifying another pod cannot connect to if w/o the file permissions changed to 777. I am not sure how to unit test this.
