### PR TITLE
test/e2e/wasm: Unblock benchmarks

### DIFF
--- a/test/e2e/wasm/authz/authz_bench_integration_test.go
+++ b/test/e2e/wasm/authz/authz_bench_integration_test.go
@@ -119,11 +119,11 @@ func BenchmarkRESTAuthzAllow10Paths(b *testing.B) {
 	runAuthzBenchmark(b, testAuthz.Allow, 10)
 }
 
-func BenchmarkRESTAuthzAllow100Paths(b *testing.B) {
-	runAuthzBenchmark(b, testAuthz.Allow, 100)
-}
-
 // TODO: Re-enable when performance issues have been addressed.
+//func BenchmarkRESTAuthzAllow100Paths(b *testing.B) {
+//	runAuthzBenchmark(b, testAuthz.Allow, 100)
+//}
+
 // func BenchmarkRESTAuthzAllow1000Paths(b *testing.B) {
 // 	runAuthzBenchmark(b, testAuthz.Allow, 1000)
 // }


### PR DESCRIPTION
Unblocking the post-merge workflow. We still need to fix the underlying issue.