### PR TITLE
Add unwrap functionality to topdown.Error

### DIFF
--- a/rego/rego.go
+++ b/rego/rego.go
@@ -2647,12 +2647,14 @@ func finishFunction(name string, bctx topdown.BuiltinContext, result *ast.Term, 
 				Code:     topdown.BuiltinErr,
 				Message:  fmt.Sprintf("%v: %v", name, e.Error()),
 				Location: bctx.Location,
+				Err:      e,
 			}}
 		}
 		return &topdown.Error{
 			Code:     topdown.BuiltinErr,
 			Message:  fmt.Sprintf("%v: %v", name, err.Error()),
 			Location: bctx.Location,
+			Err:      err,
 		}
 	}
 	if result == nil {

--- a/rego/rego.go
+++ b/rego/rego.go
@@ -2643,19 +2643,19 @@ func finishFunction(name string, bctx topdown.BuiltinContext, result *ast.Term, 
 	if err != nil {
 		var e *HaltError
 		if errors.As(err, &e) {
-			return topdown.Halt{Err: &topdown.Error{
+			tdErr := &topdown.Error{
 				Code:     topdown.BuiltinErr,
 				Message:  fmt.Sprintf("%v: %v", name, e.Error()),
 				Location: bctx.Location,
-				Err:      e,
-			}}
+			}
+			return topdown.Halt{Err: tdErr.Wrap(e)}
 		}
-		return &topdown.Error{
+		tdErr := &topdown.Error{
 			Code:     topdown.BuiltinErr,
 			Message:  fmt.Sprintf("%v: %v", name, err.Error()),
 			Location: bctx.Location,
-			Err:      err,
 		}
+		return tdErr.Wrap(err)
 	}
 	if result == nil {
 		return nil

--- a/topdown/builtins.go
+++ b/topdown/builtins.go
@@ -182,19 +182,19 @@ func handleBuiltinErr(name string, loc *ast.Location, err error) error {
 	case *Error, Halt:
 		return err
 	case builtins.ErrOperand:
-		return &Error{
+		e := &Error{
 			Code:     TypeErr,
 			Message:  fmt.Sprintf("%v: %v", name, err.Error()),
 			Location: loc,
-			Err:      err,
 		}
+		return e.Wrap(err)
 	default:
-		return &Error{
+		e := &Error{
 			Code:     BuiltinErr,
 			Message:  fmt.Sprintf("%v: %v", name, err.Error()),
 			Location: loc,
-			Err:      err,
 		}
+		return e.Wrap(err)
 	}
 }
 

--- a/topdown/builtins.go
+++ b/topdown/builtins.go
@@ -186,12 +186,14 @@ func handleBuiltinErr(name string, loc *ast.Location, err error) error {
 			Code:     TypeErr,
 			Message:  fmt.Sprintf("%v: %v", name, err.Error()),
 			Location: loc,
+			Err:      err,
 		}
 	default:
 		return &Error{
 			Code:     BuiltinErr,
 			Message:  fmt.Sprintf("%v: %v", name, err.Error()),
 			Location: loc,
+			Err:      err,
 		}
 	}
 }

--- a/topdown/errors.go
+++ b/topdown/errors.go
@@ -29,6 +29,7 @@ type Error struct {
 	Code     string        `json:"code"`
 	Message  string        `json:"message"`
 	Location *ast.Location `json:"location,omitempty"`
+	Err      error         `json:"-"`
 }
 
 const (
@@ -88,6 +89,10 @@ func (e *Error) Error() string {
 	}
 
 	return msg
+}
+
+func (e *Error) Unwrap() error {
+	return e.Err
 }
 
 func functionConflictErr(loc *ast.Location) error {

--- a/topdown/errors.go
+++ b/topdown/errors.go
@@ -29,7 +29,7 @@ type Error struct {
 	Code     string        `json:"code"`
 	Message  string        `json:"message"`
 	Location *ast.Location `json:"location,omitempty"`
-	Err      error         `json:"-"`
+	err      error         `json:"-"`
 }
 
 const (
@@ -91,8 +91,13 @@ func (e *Error) Error() string {
 	return msg
 }
 
+func (e *Error) Wrap(err error) *Error {
+	e.err = err
+	return e
+}
+
 func (e *Error) Unwrap() error {
-	return e.Err
+	return e.err
 }
 
 func functionConflictErr(loc *ast.Location) error {

--- a/topdown/errors_test.go
+++ b/topdown/errors_test.go
@@ -14,13 +14,17 @@ func TestErrorWrapping(t *testing.T) {
 		return errors.As(err, &topdown.Halt{})
 	}
 
+	builtinErr := errors.New("builtin error")
+	loc := location.Location{
+		File: "b.rego",
+		Col:  10,
+		Row:  12,
+	}
+
 	e0 := topdown.Error{Code: topdown.BuiltinErr,
-		Message: "builtin error",
-		Location: &location.Location{
-			File: "b.rego",
-			Col:  10,
-			Row:  12,
-		},
+		Message:  "builtin error",
+		Location: &loc,
+		Err:      builtinErr,
 	}
 
 	tests := []struct {
@@ -64,6 +68,13 @@ func TestErrorWrapping(t *testing.T) {
 			check: topdown.IsCancel,
 		},
 		{
+			note: "wrapped builtin error",
+			err:  &e0,
+			check: func(err error) bool {
+				return errors.Is(err, builtinErr)
+			},
+		},
+		{
 			note: "matching errors, code",
 			err:  &e0,
 			check: func(err error) bool {
@@ -78,7 +89,14 @@ func TestErrorWrapping(t *testing.T) {
 			},
 		},
 		{
-			note: "matching errors, code and message and location",
+			note: "matching errors, code, message and location",
+			err:  &e0,
+			check: func(err error) bool {
+				return errors.Is(err, &topdown.Error{Code: topdown.BuiltinErr, Message: "builtin error", Location: &loc})
+			},
+		},
+		{
+			note: "matching errors, code, message, location and builtin error",
 			err:  &e0,
 			check: func(err error) bool {
 				return errors.Is(err, &e0)

--- a/topdown/errors_test.go
+++ b/topdown/errors_test.go
@@ -21,11 +21,10 @@ func TestErrorWrapping(t *testing.T) {
 		Row:  12,
 	}
 
-	e0 := topdown.Error{Code: topdown.BuiltinErr,
+	e0 := (&topdown.Error{Code: topdown.BuiltinErr,
 		Message:  "builtin error",
 		Location: &loc,
-		Err:      builtinErr,
-	}
+	}).Wrap(builtinErr)
 
 	tests := []struct {
 		note  string
@@ -69,37 +68,37 @@ func TestErrorWrapping(t *testing.T) {
 		},
 		{
 			note: "wrapped builtin error",
-			err:  &e0,
+			err:  e0,
 			check: func(err error) bool {
 				return errors.Is(err, builtinErr)
 			},
 		},
 		{
 			note: "matching errors, code",
-			err:  &e0,
+			err:  e0,
 			check: func(err error) bool {
 				return errors.Is(err, &topdown.Error{Code: topdown.BuiltinErr})
 			},
 		},
 		{
 			note: "matching errors, code and message",
-			err:  &e0,
+			err:  e0,
 			check: func(err error) bool {
 				return errors.Is(err, &topdown.Error{Code: topdown.BuiltinErr, Message: "builtin error"})
 			},
 		},
 		{
 			note: "matching errors, code, message and location",
-			err:  &e0,
+			err:  e0,
 			check: func(err error) bool {
 				return errors.Is(err, &topdown.Error{Code: topdown.BuiltinErr, Message: "builtin error", Location: &loc})
 			},
 		},
 		{
 			note: "matching errors, code, message, location and builtin error",
-			err:  &e0,
+			err:  e0,
 			check: func(err error) bool {
-				return errors.Is(err, &e0)
+				return errors.Is(err, e0)
 			},
 		},
 	}


### PR DESCRIPTION
### Why the changes in this PR are needed?

OPA currently doesn't support wrapping errors returned by builtin functions from the higher-level evaluation methods like `(*rego.Rego).Eval` or `(*opa.SDK).Decision`. Retrieving a specific error from a builtin would give more context to users of these higher-level APIs to handle errors related to custom builtin functions.

An example use case that this PR allows:

```go
result, err := opa.Decision(ctx, sdk.DecisionOptions{Input: input, Path: path})
var customErr mybuiltins.BuiltinError
if err != nil && errors.As(err, &customErr) {
    // Get additional error information from customErr
}
```

### What are the changes in this PR?

This PR introduces unwrap functionality for `topdown.Error` and modifies error handling for builtins to return a `topdown.Error` that wraps the error returned by a builtin implementation.