### PR TITLE
fix issue with _ matching in rule indexing for arrays

### DIFF
--- a/ast/index.go
+++ b/ast/index.go
@@ -483,8 +483,10 @@ func (node *trieNode) String() string {
 	if len(node.mappers) > 0 {
 		flags = append(flags, fmt.Sprintf("%d mapper(s)", len(node.mappers)))
 	}
-	if l := node.values.Len(); l > 0 {
-		flags = append(flags, fmt.Sprintf("%d value(s)", l))
+	if node.values != nil {
+		if l := node.values.Len(); l > 0 {
+			flags = append(flags, fmt.Sprintf("%d value(s)", l))
+		}
 	}
 	return strings.Join(flags, " ")
 }
@@ -698,17 +700,17 @@ func (node *trieNode) traverseArray(resolver ValueResolver, tr *trieTraversalRes
 		return node.Traverse(resolver, tr)
 	}
 
-	head := arr.Elem(0).Value
-
-	if !IsScalar(head) {
-		return nil
-	}
-
 	if node.any != nil {
 		err := node.any.traverseArray(resolver, tr, arr.Slice(1, -1))
 		if err != nil {
 			return err
 		}
+	}
+
+	head := arr.Elem(0).Value
+
+	if !IsScalar(head) {
+		return nil
 	}
 
 	child, ok := node.scalars.Get(head)

--- a/test/cases/testdata/indexing/array-any.yaml
+++ b/test/cases/testdata/indexing/array-any.yaml
@@ -1,0 +1,18 @@
+cases:
+- data: {}
+  input_term: '{}'
+  modules:
+  - |
+    package indexing
+
+    f(val) {
+      [_, _] = val
+    }
+
+    p {
+      f([1, ["foo", "bar"]])
+    }
+  note: indexing on any array
+  query: data.indexing.p = x
+  want_result:
+  - x: true

--- a/test/cases/testdata/indexing/array-any.yaml
+++ b/test/cases/testdata/indexing/array-any.yaml
@@ -12,7 +12,7 @@ cases:
     p {
       f([1, ["foo", "bar"]])
     }
-  note: indexing on any array
+  note: indexing on any and arrays
   query: data.indexing.p = x
   want_result:
   - x: true


### PR DESCRIPTION
### Why the changes in this PR are needed?

I found an issue in rule indexing, and managed to reduce it to a fairly small example. The following Rego currently fails `opa test`:

```rego
package example

is_tuple(val) {
	[_, _] = val
}

test_this_works {
	is_tuple([1, 2])
}

test_this_doesnt {
	is_tuple([1, ["foo", "bar"]])
}
```

[example of a failed job](https://github.com/open-policy-agent/opa/actions/runs/4960888899/jobs/8877020568?pr=5916)

### What are the changes in this PR?

By moving the `isScalar` check down we allow `_` here to match against non-scalars as well.

### Notes to assist PR review:

N/A

### Further comments:

I added a test case in the general test cases which reproduces it.  I'm not sure if there should be a separate test in `ast/index_test.go`, and I couldn't figure out how to write a nice test for this there.