### PR TITLE
fix: jwt_decode_verify missing iss while required

### DIFF
--- a/test/cases/testdata/jwtdecodeverify/test-jwtdecodeverify-missing-iss-while-required.yaml
+++ b/test/cases/testdata/jwtdecodeverify/test-jwtdecodeverify-missing-iss-while-required.yaml
@@ -1,0 +1,17 @@
+cases:
+  - data:
+    modules:
+      - |
+        package generated
+        
+        token := io.jwt.encode_sign({"alg": "HS256"}, {}, {"kty": "oct", "k": base64url.encode_no_pad("42")})
+        
+        decoded := io.jwt.decode_verify(token, {"secret": "42", "iss": "xxx"})
+
+    note: jwtdecodeverify/missing-iss-while-required
+    query: data.generated.decoded = x
+    want_result:
+      - x:
+          - false
+          - { }
+          - { }

--- a/topdown/tokens.go
+++ b/topdown/tokens.go
@@ -1065,6 +1065,8 @@ func builtinJWTDecodeVerify(bctx BuiltinContext, operands []*ast.Term, iter func
 			if constraints.iss != issVal {
 				return iter(unverified)
 			}
+		} else {
+			return iter(unverified)
 		}
 	}
 	// RFC7159 4.1.3 aud


### PR DESCRIPTION
jwt_decode_verify function has a bug that permits missing "iss" property of a token even when "iss" is required. This change fixes this bug - when "iss" property is passed as a constraint, a token with missing "iss" is not allowed.

Fixes #5850

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->

### Why the changes in this PR are needed?

<!--
Include a short description of WHY the changes were made.
-->

### What are the changes in this PR?

<!--
Include a short description of WHAT changes were made.
-->

### Notes to assist PR review:

<!--
Here you can add information you think will help the reviewer(s).
-->

### Further comments:

<!--
Here you can include links to additional resources related to the changes, discuss your solution, other approaches you considered etc.
-->
