### PR TITLE
status: Registering Prometheus Collectors on Status-plugin reconfigure

### DIFF
--- a/plugins/status/metrics.go
+++ b/plugins/status/metrics.go
@@ -61,6 +61,9 @@ var (
 		Buckets: prometheus.ExponentialBuckets(1000, 2, 20),
 	}, []string{"name", "stage"})
 
+	// allCollectors is a list of all collectors maintained by the status plugin.
+	// Note: when adding a new collector, make sure to also add it to this list,
+	// or it won't survive status plugin reconfigure events.
 	allCollectors = []prometheus.Collector{
 		opaInfo,
 		pluginStatus,

--- a/plugins/status/metrics.go
+++ b/plugins/status/metrics.go
@@ -60,6 +60,18 @@ var (
 		Help:    "Histogram for the bundle loading duration by stage.",
 		Buckets: prometheus.ExponentialBuckets(1000, 2, 20),
 	}, []string{"name", "stage"})
+
+	allCollectors = []prometheus.Collector{
+		opaInfo,
+		pluginStatus,
+		loaded,
+		failLoad,
+		lastRequest,
+		lastSuccessfulActivation,
+		lastSuccessfulDownload,
+		lastSuccessfulRequest,
+		bundleLoadDuration,
+	}
 )
 
 func init() {

--- a/plugins/status/plugin_test.go
+++ b/plugins/status/plugin_test.go
@@ -779,14 +779,7 @@ func newTestFixture(t *testing.T, m metrics.Metrics, options ...testPluginCustom
 		t.Fatal(err)
 	}
 
-	pluginConfig := []byte(`{
-			"service": "example",
-		}`)
-
-	config, _ := ParseConfig(pluginConfig, manager.Services(), nil)
-	for _, option := range options {
-		option(config)
-	}
+	config := newConfig(manager, options...)
 
 	p := New(config, manager).WithMetrics(m)
 
@@ -796,6 +789,19 @@ func newTestFixture(t *testing.T, m metrics.Metrics, options ...testPluginCustom
 		server:  &ts,
 	}
 
+}
+
+func newConfig(manager *plugins.Manager, options ...testPluginCustomizer) *Config {
+	pluginConfig := []byte(`{
+			"service": "example",
+		}`)
+
+	config, _ := ParseConfig(pluginConfig, manager.Services(), nil)
+	for _, option := range options {
+		option(config)
+	}
+
+	return config
 }
 
 type testServer struct {


### PR DESCRIPTION
if `Prometheus` was enabled on active config change; and unregistering collectors if disabled.

Fixes: #5918
