### PR TITLE
fmt: fix `fmt` producing invalid code

### DIFF
--- a/format/format.go
+++ b/format/format.go
@@ -732,7 +732,12 @@ func (w *writer) writeTermParens(parens bool, term *ast.Term, comments []*ast.Co
 
 func (w *writer) writeRef(x ast.Ref) {
 	if len(x) > 0 {
-		w.writeTerm(x[0], nil)
+		parens := false
+		_, ok := x[0].Value.(ast.Call)
+		if ok {
+			parens = x[0].Location.Text[0] == 40 // Starts with "("
+		}
+		w.writeTermParens(parens, x[0], nil)
 		path := x[1:]
 		for _, t := range path {
 			switch p := t.Value.(type) {
@@ -914,7 +919,12 @@ func (w *writer) writeComprehension(open, close byte, term *ast.Term, body ast.B
 		w.startLine()
 	}
 
-	comments = w.writeTerm(term, comments)
+	parens := false
+	_, ok := term.Value.(ast.Call)
+	if ok {
+		parens = term.Location.Text[0] == 40 // Starts with "("
+	}
+	comments = w.writeTermParens(parens, term, comments)
 	w.write(" |")
 
 	return w.writeComprehensionBody(open, close, body, term.Location, loc, comments)

--- a/format/testfiles/test_issue_5537_with_comprehension.rego
+++ b/format/testfiles/test_issue_5537_with_comprehension.rego
@@ -1,0 +1,3 @@
+package p
+
+array := [(input.thing[i] == input.other[i]) | true]

--- a/format/testfiles/test_issue_5537_with_comprehension.rego.formatted
+++ b/format/testfiles/test_issue_5537_with_comprehension.rego.formatted
@@ -1,0 +1,3 @@
+package p
+
+array := [(input.thing[i] == input.other[i]) | true]

--- a/format/testfiles/test_issue_5537_with_ref.rego
+++ b/format/testfiles/test_issue_5537_with_ref.rego
@@ -1,0 +1,8 @@
+package p
+
+first := {"one", "two"}
+second := {"two", "three"}
+
+example[msg] {
+  msg := (first | second)[_]
+}

--- a/format/testfiles/test_issue_5537_with_ref.rego.formatted
+++ b/format/testfiles/test_issue_5537_with_ref.rego.formatted
@@ -1,0 +1,9 @@
+package p
+
+first := {"one", "two"}
+
+second := {"two", "three"}
+
+example[msg] {
+	msg := (first | second)[_]
+}


### PR DESCRIPTION

### Why the changes in this PR are needed?
Prior to this change, the `fmt` command produced invalid code when applied to the rego files presented in #5537, due to the fact that parentheses are not handle correctly in these edge cases.

With the changes in this PR, the `fmt` command is now able to handle the edge cases that produce invalid code in output.

### What are the changes in this PR?
This PR adds check to the following two methods: [writeRef](https://github.com/open-policy-agent/opa/blob/main/format/format.go#L733) and [writeComprehension](https://github.com/open-policy-agent/opa/blob/main/format/format.go#L911). 

As discussed noted in #5537, these two methods are responsible of calling the [writeTerm](https://github.com/open-policy-agent/opa/blob/main/format/format.go#L686). When used, these method automatically strips parentheses from the formatted test. 

Since this behavior may produce invalid code, both methods now check the following:

1. The first term processed in the function is a function [Call](https://github.com/open-policy-agent/opa/blob/94a204478baa63fd73dcd49c84fa8eebbce3c3bd/ast/term.go#L2801)
2. The term starts with an open parentheses

If these two conditions are met, instead of calling `writeTerm`, it is called `writeTermParens(true, ...` to handle the edge cases, otherwise `writeTermParens(false, ...`  is called, to reproduce the behavior prior to this PR for all the other cases.

In order to test what has been added, two new test cases for `format` have been created: 

1.` format/testfiles/test_issue_5537_with_comprehension.rego`
2. `format/testfiles/test_issue_5537_with_ref.rego`

### Further comments:
As anticipated in #5537, this may leave some unneeded parentheses, but such cases are not present in all the test cases currently present in OPA
