### PR TITLE
rego: allow for extending the rego targets with plugins

### DIFF
--- a/rego/plugins.go
+++ b/rego/plugins.go
@@ -1,0 +1,43 @@
+// Copyright 2023 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package rego
+
+import (
+	"context"
+	"sync"
+
+	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/ir"
+)
+
+var targetPlugins = map[string]TargetPlugin{}
+var pluginMtx sync.Mutex
+
+type TargetPlugin interface {
+	IsTarget(string) bool
+	PrepareForEval(context.Context, *ir.Policy, ...PrepareOption) (TargetPluginEval, error)
+}
+
+type TargetPluginEval interface {
+	Eval(context.Context, *EvalContext, ast.Value) (ast.Value, error)
+}
+
+func (r *Rego) targetPlugin(tgt string) TargetPlugin {
+	for _, p := range targetPlugins {
+		if p.IsTarget(tgt) {
+			return p
+		}
+	}
+	return nil
+}
+
+func RegisterPlugin(name string, p TargetPlugin) {
+	pluginMtx.Lock()
+	defer pluginMtx.Unlock()
+	if _, ok := targetPlugins[name]; ok {
+		panic("plugin already registered " + name)
+	}
+	targetPlugins[name] = p
+}

--- a/rego/plugins_test.go
+++ b/rego/plugins_test.go
@@ -1,0 +1,94 @@
+// Copyright 2023 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package rego
+
+import (
+	"context"
+	"testing"
+
+	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/ir"
+)
+
+type testPlugin struct {
+	state string
+}
+
+func (*testPlugin) Start(context.Context) error {
+	return nil
+}
+
+func (*testPlugin) Stop(context.Context) {
+}
+
+func (*testPlugin) Reconfigure(context.Context, interface{}) {
+}
+
+func (*testPlugin) IsTarget(t string) bool {
+	return t == "foo"
+}
+
+func (*testPlugin) PrepareForEval(context.Context, *ir.Policy, ...PrepareOption) (TargetPluginEval, error) {
+	return &testPlugin{state: "newstate"}, nil
+}
+
+func (t *testPlugin) Eval(_ context.Context, _ *EvalContext, rt ast.Value) (ast.Value, error) {
+	if rt != nil {
+		return ast.NewSet(ast.NewTerm(ast.NewObject(
+			[2]*ast.Term{ast.StringTerm("^term1"), ast.ObjectTerm([2]*ast.Term{ast.StringTerm(t.state), ast.NewTerm(rt)})},
+		))), nil
+	}
+	return ast.NewSet(ast.NewTerm(ast.NewObject(
+		[2]*ast.Term{ast.StringTerm("^term1"), ast.StringTerm(t.state)},
+	))), nil
+}
+
+func TestTargetViaPlugin(t *testing.T) {
+	tp := testPlugin{}
+	RegisterPlugin("rego.target.foo", &tp)
+	defer resetPlugins()
+	r := New(
+		Query("input"),
+		Input("original-input"),
+		Target("foo"),
+		Runtime(ast.StringTerm("runtime")),
+	)
+	assertEval(t, r, `[[{"newstate": "runtime"}]]`)
+}
+
+type defaultPlugin struct {
+	testPlugin
+}
+
+func (*defaultPlugin) IsTarget(t string) bool { return t == "" || t == "foo" }
+
+func TestTargetViaDefaultPlugin(t *testing.T) {
+	t.Run("no target", func(t *testing.T) {
+		tp := defaultPlugin{testPlugin{}}
+		RegisterPlugin("rego.target.foo", &tp)
+		defer resetPlugins()
+		r := New(
+			Query("input"),
+			Input("original-input"),
+		)
+		assertEval(t, r, `[["newstate"]]`)
+	})
+
+	t.Run("other target NOT overridden", func(t *testing.T) {
+		tp := defaultPlugin{testPlugin{}}
+		RegisterPlugin("rego.target.foo", &tp)
+		defer resetPlugins()
+		r := New(
+			Query("input"),
+			Input("original-input"),
+			Target("rego"),
+		)
+		assertEval(t, r, `[["original-input"]]`)
+	})
+}
+
+func resetPlugins() {
+	targetPlugins = map[string]TargetPlugin{}
+}

--- a/rego/rego_test.go
+++ b/rego/rego_test.go
@@ -2455,7 +2455,7 @@ func TestGenerateJSON(t *testing.T) {
 	r := New(
 		Query("input"),
 		Input("original-input"),
-		GenerateJSON(func(t *ast.Term, ectx *EvalContext) (interface{}, error) {
+		GenerateJSON(func(*ast.Term, *EvalContext) (interface{}, error) {
 			return "converted-input", nil
 		}),
 	)


### PR DESCRIPTION
The handoff point for plugins right now is the IR: that, the store, and the open transaction is passed to `PrepareForEval`.

Rego target plugins  aren't plugged in through the plugin manager machinery, and they don't need to be enabled via configs. They are more akin to custom builtins, which also become available right away after having been registered with the ast package.

In the future, another option would be to pass the Wasm bytes: we could then have a wasmtime-based plugin, and a wazero-based one.

* rego.EvalContext: expose a few fields

* ()*Rego).Compile() is only used by our wasm tests, and doesn't even make sense for the "rego" target. Not added to the plugin interface.

* In rego.New, we now only gather plugins once, and have the plugins decide if a target is for them or not. This untangles the plugin name from the target matching; a plugin can have any name it wants now.
