### PR TITLE
perf: avoid unnecessary byte/string conversion

### DIFF
--- a/build/generate-cli-docs/generate.go
+++ b/build/generate-cli-docs/generate.go
@@ -79,7 +79,7 @@ func main() {
 	// elements in markdown. This is undesirable, so let's remove them and prepend
 	// the line before that with ### to instead create a h3
 	for line, str := range lines {
-		if heading.Match([]byte(str)) {
+		if heading.MatchString(str) {
 			document[line-1-removed] = fmt.Sprintf("### %s\n", document[line-1-removed])
 			removed++
 			continue

--- a/internal/gojsonschema/validation.go
+++ b/internal/gojsonschema/validation.go
@@ -716,7 +716,7 @@ func (v *SubSchema) validateString(currentSubSchema *SubSchema, value interface{
 
 	// minLength & maxLength:
 	if currentSubSchema.minLength != nil {
-		if utf8.RuneCount([]byte(stringValue)) < *currentSubSchema.minLength {
+		if utf8.RuneCountInString(stringValue) < *currentSubSchema.minLength {
 			result.addInternalError(
 				new(StringLengthGTEError),
 				context,
@@ -726,7 +726,7 @@ func (v *SubSchema) validateString(currentSubSchema *SubSchema, value interface{
 		}
 	}
 	if currentSubSchema.maxLength != nil {
-		if utf8.RuneCount([]byte(stringValue)) > *currentSubSchema.maxLength {
+		if utf8.RuneCountInString(stringValue) > *currentSubSchema.maxLength {
 			result.addInternalError(
 				new(StringLengthLTEError),
 				context,

--- a/sdk/test/test.go
+++ b/sdk/test/test.go
@@ -310,7 +310,7 @@ func (s *Server) handleOCIBundles(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusNotFound)
 			return
 		}
-		buf.WriteString(string(bs))
+		buf.Write(bs)
 		_, err = w.Write(buf.Bytes())
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
@@ -327,7 +327,7 @@ func (s *Server) handleOCIBundles(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusNotFound)
 			return
 		}
-		buf.WriteString(string(bs))
+		buf.Write(bs)
 		_, err = w.Write(buf.Bytes())
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
@@ -344,7 +344,7 @@ func (s *Server) handleOCIBundles(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusNotFound)
 			return
 		}
-		buf.WriteString(string(bs))
+		buf.Write(bs)
 		_, err = w.Write(buf.Bytes())
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)

--- a/topdown/regex.go
+++ b/topdown/regex.go
@@ -46,7 +46,7 @@ func builtinRegexMatch(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Te
 	if err != nil {
 		return err
 	}
-	return iter(ast.BooleanTerm(re.Match([]byte(s2))))
+	return iter(ast.BooleanTerm(re.MatchString(string(s2))))
 }
 
 func builtinRegexMatchTemplate(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term) error) error {


### PR DESCRIPTION
<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->

### Why the changes in this PR are needed?

We can use alternative functions/methods to avoid unnecessary byte/string conversion calls.

### What are the changes in this PR?

<!--
Include a short description of WHAT changes were made.
-->

1. `(*regexp.Regexp).Match([]byte(<a string>))` -> `(*regexp.Regexp).MatchString(<a string>)` [^1]
2. `utf8.RuneCount([]byte(<a string>))` -> `utf8.RuneCountInString(<a string>)` [^2]:
3. `(*bytes.Buffer).WriteString(string(<a []byte>))` -> `(*bytes.Buffer).Write(<a []byte>)` [^3]

[^1]: https://pkg.go.dev/regexp#Regexp.MatchString
[^2]: https://pkg.go.dev/unicode/utf8#RuneCountInString
[^3]: https://pkg.go.dev/bytes#Buffer.Write

### Notes to assist PR review:

<!--
Here you can add information you think will help the reviewer(s).
-->

### Further comments:

<!--
Here you can include links to additional resources related to the changes, discuss your solution, other approaches you considered etc.
-->
