### PR TITLE
cmd: Add support for watch mode in opa test

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -167,6 +167,10 @@ The 'run' command can ONLY be used with the --bundle flag to verify signatures
 for existing bundle files or directories following the bundle structure.
 
 To skip bundle verification, use the --skip-verify flag.
+
+The --watch flag can be used to monitor policy and data file-system changes. When a change is detected, the updated policy
+and data is reloaded into OPA. Watching individual files (rather than directories) is generally not recommended as some
+updates might cause them to be dropped by OPA.
 `,
 
 		Run: func(cmd *cobra.Command, args []string) {

--- a/internal/pathwatcher/utils.go
+++ b/internal/pathwatcher/utils.go
@@ -1,0 +1,102 @@
+// Copyright 2023 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+// Package pathwatcher provides helper functions for creating file and directory watchers
+package pathwatcher
+
+import (
+	"context"
+
+	"github.com/fsnotify/fsnotify"
+	"github.com/open-policy-agent/opa/ast"
+	initload "github.com/open-policy-agent/opa/internal/runtime/init"
+	"github.com/open-policy-agent/opa/loader"
+	"github.com/open-policy-agent/opa/storage"
+)
+
+// CreatePathWatcher creates watchers to monitor for path changes
+func CreatePathWatcher(rootPaths []string) (*fsnotify.Watcher, error) {
+	watchPaths, err := getWatchPaths(rootPaths)
+	if err != nil {
+		return nil, err
+	}
+
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, path := range watchPaths {
+		if err := watcher.Add(path); err != nil {
+			return nil, err
+		}
+	}
+
+	return watcher, nil
+}
+
+// ProcessWatcherUpdate handles an occurrence of a watcher event
+func ProcessWatcherUpdate(ctx context.Context, paths []string, removed string, store storage.Store, filter loader.Filter, asBundle bool,
+	f func(context.Context, storage.Transaction, *initload.LoadPathsResult) error) error {
+	loaded, err := initload.LoadPaths(paths, filter, asBundle, nil, true, false, nil, nil)
+	if err != nil {
+		return err
+	}
+
+	removed = loader.CleanPath(removed)
+
+	return storage.Txn(ctx, store, storage.WriteParams, func(txn storage.Transaction) error {
+		if !asBundle {
+			ids, err := store.ListPolicies(ctx, txn)
+			if err != nil {
+				return err
+			}
+			for _, id := range ids {
+				if id == removed {
+					if err := store.DeletePolicy(ctx, txn, id); err != nil {
+						return err
+					}
+				} else if _, exists := loaded.Files.Modules[id]; !exists {
+					// This branch get hit in two cases.
+					// 1. Another piece of code has access to the store and inserts
+					//    a policy out-of-band.
+					// 2. In between FS notification and loader.Filtered() call above, a
+					//    policy is removed from disk.
+					bs, err := store.GetPolicy(ctx, txn, id)
+					if err != nil {
+						return err
+					}
+					module, err := ast.ParseModule(id, string(bs))
+					if err != nil {
+						return err
+					}
+					loaded.Files.Modules[id] = &loader.RegoFile{
+						Name:   id,
+						Raw:    bs,
+						Parsed: module,
+					}
+				}
+			}
+		}
+
+		return f(ctx, txn, loaded)
+	})
+}
+
+func getWatchPaths(rootPaths []string) ([]string, error) {
+	paths := []string{}
+
+	for _, path := range rootPaths {
+
+		_, path = loader.SplitPrefix(path)
+		result, err := loader.Paths(path, true)
+		if err != nil {
+			return nil, err
+		}
+
+		paths = append(paths, loader.Dirs(result)...)
+	}
+
+	return paths, nil
+}

--- a/internal/pathwatcher/utils_test.go
+++ b/internal/pathwatcher/utils_test.go
@@ -1,0 +1,39 @@
+// Copyright 2023 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package pathwatcher
+
+import (
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/open-policy-agent/opa/util/test"
+)
+
+func TestWatchPaths(t *testing.T) {
+
+	fs := map[string]string{
+		"/foo/bar/baz.json": "true",
+	}
+
+	expected := []string{
+		".", "/foo", "/foo/bar",
+	}
+
+	test.WithTempFS(fs, func(rootDir string) {
+		paths, err := getWatchPaths([]string{"prefix:" + rootDir + "/foo"})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		result := []string{}
+		for _, p := range paths {
+			result = append(result, filepath.Clean(strings.TrimPrefix(p, rootDir)))
+		}
+		if !reflect.DeepEqual(expected, result) {
+			t.Fatalf("Expected %q but got: %q", expected, result)
+		}
+	})
+}

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -29,31 +29,6 @@ import (
 	"github.com/open-policy-agent/opa/util/test"
 )
 
-func TestWatchPaths(t *testing.T) {
-
-	fs := map[string]string{
-		"/foo/bar/baz.json": "true",
-	}
-
-	expected := []string{
-		".", "/foo", "/foo/bar",
-	}
-
-	test.WithTempFS(fs, func(rootDir string) {
-		paths, err := getWatchPaths([]string{"prefix:" + rootDir + "/foo"})
-		if err != nil {
-			t.Fatalf("Unexpected error: %v", err)
-		}
-		result := []string{}
-		for _, p := range paths {
-			result = append(result, filepath.Clean(strings.TrimPrefix(p, rootDir)))
-		}
-		if !reflect.DeepEqual(expected, result) {
-			t.Fatalf("Expected %q but got: %q", expected, result)
-		}
-	})
-}
-
 func TestRuntimeProcessWatchEvents(t *testing.T) {
 	testRuntimeProcessWatchEvents(t, false)
 }


### PR DESCRIPTION
### What are the changes in this PR?

Similar to the watch mode available in OPA when run as a server, this change adds a watch mode in OPA test which
reloads the policy on file-system changes and re-runs the tests. The watch mode in OPA test could be useful for example in TDD of policies.

### Notes to assist PR review:

Some of the watch/fsnotify code has been pulled out in a new `internal` package and is now shared with the `runtime`.