### PR TITLE
Add schema flag to test

### DIFF
--- a/cmd/eval_test.go
+++ b/cmd/eval_test.go
@@ -514,8 +514,7 @@ package test
 # METADATA
 # schemas:
 #   - input: schema["input"]
-p { 
-	rego.metadata.rule() # presence of rego.metadata.* calls must not trigger unwanted schema evaluation 
+p { 	
 	input.foo == 42 # type mismatch with schema that should be ignored
 }`
 
@@ -530,8 +529,7 @@ package test
 # schemas:
 #   - input.foo: {"type": "boolean"}
 p { 
-	rego.metadata.rule() # presence of rego.metadata.* calls must not trigger unwanted schema evaluation 
-	input.foo == 42 # type mismatch with schema that should be ignored
+	input.foo == 42 # type mismatch with schema that should NOT be ignored since it is an inlined schema format
 }`
 
 	err = testEvalWithSchemasAnnotationButNoSchemaFlag(policyWithInlinedSchema)

--- a/cmd/eval_test.go
+++ b/cmd/eval_test.go
@@ -515,6 +515,7 @@ package test
 # schemas:
 #   - input: schema["input"]
 p { 	
+	rego.metadata.rule() # presence of rego.metadata.* calls must not trigger unwanted schema evaluation
 	input.foo == 42 # type mismatch with schema that should be ignored
 }`
 
@@ -528,7 +529,8 @@ package test
 # METADATA
 # schemas:
 #   - input.foo: {"type": "boolean"}
-p { 
+p {
+	rego.metadata.rule() # presence of rego.metadata.* calls must not trigger unwanted schema evaluation	 
 	input.foo == 42 # type mismatch with schema that should NOT be ignored since it is an inlined schema format
 }`
 

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -51,8 +51,8 @@ type testCommandParams struct {
 	schema       *schemaFlags
 }
 
-func newTestCommandParams() *testCommandParams {
-	return &testCommandParams{
+func newTestCommandParams() testCommandParams {
+	return testCommandParams{
 		outputFormat: util.NewEnumFlag(testPrettyOutput, []string{testPrettyOutput, testJSONOutput, benchmarkGoBenchOutput}),
 		explain:      newExplainFlag([]string{explainModeFails, explainModeFull, explainModeNotes, explainModeDebug}),
 		target:       util.NewEnumFlag(compile.TargetRego, []string{compile.TargetRego, compile.TargetWasm}),
@@ -61,97 +61,7 @@ func newTestCommandParams() *testCommandParams {
 	}
 }
 
-var testParams = newTestCommandParams()
-
-var testCommand = &cobra.Command{
-	Use:   "test <path> [path [...]]",
-	Short: "Execute Rego test cases",
-	Long: `Execute Rego test cases.
-
-The 'test' command takes a file or directory path as input and executes all
-test cases discovered in matching files. Test cases are rules whose names have the prefix "test_".
-
-If the '--bundle' option is specified the paths will be treated as policy bundles
-and loaded following standard bundle conventions. The path can be a compressed archive
-file or a directory which will be treated as a bundle. Without the '--bundle' flag OPA
-will recursively load ALL *.rego, *.json, and *.yaml files for evaluating the test cases.
-
-Test cases under development may be prefixed "todo_" in order to skip their execution,
-while still getting marked as skipped in the test results.
-
-Example policy (example/authz.rego):
-
-	package authz
-
-	import future.keywords.if
-
-	allow if {
-		input.path == ["users"]
-		input.method == "POST"
-	}
-
-	allow if {
-		input.path == ["users", input.user_id]
-		input.method == "GET"
-	}
-
-Example test (example/authz_test.rego):
-
-	package authz_test
-
-	import data.authz.allow
-
-	test_post_allowed {
-		allow with input as {"path": ["users"], "method": "POST"}
-	}
-
-	test_get_denied {
-		not allow with input as {"path": ["users"], "method": "GET"}
-	}
-
-	test_get_user_allowed {
-		allow with input as {"path": ["users", "bob"], "method": "GET", "user_id": "bob"}
-	}
-
-	test_get_another_user_denied {
-		not allow with input as {"path": ["users", "bob"], "method": "GET", "user_id": "alice"}
-	}
-
-	todo_test_user_allowed_http_client_data {
-		false # Remember to test this later!
-	}
-
-Example test run:
-
-	$ opa test ./example/
-
-If used with the '--bench' option then tests will be benchmarked.
-
-Example benchmark run:
-
-	$ opa test --bench ./example/
-
-The optional "gobench" output format conforms to the Go Benchmark Data Format.
-`,
-	PreRunE: func(Cmd *cobra.Command, args []string) error {
-		if len(args) == 0 {
-			return fmt.Errorf("specify at least one file")
-		}
-
-		// If an --explain flag was set, turn on verbose output
-		if testParams.explain.IsSet() {
-			testParams.verbose = true
-		}
-
-		return nil
-	},
-
-	Run: func(cmd *cobra.Command, args []string) {
-		os.Exit(opaTest(args))
-	},
-}
-
-func opaTest(args []string) int {
+func opaTest(args []string, testParams testCommandParams) int {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -296,7 +206,7 @@ func opaTest(args []string) int {
 	}
 
 	for i := 0; i < testParams.count; i++ {
-		exitCode := runTests(ctx, txn, runner, reporter)
+		exitCode := runTests(ctx, txn, runner, reporter, testParams)
 		if exitCode != 0 {
 			return exitCode
 		}
@@ -305,7 +215,7 @@ func opaTest(args []string) int {
 	return 0
 }
 
-func runTests(ctx context.Context, txn storage.Transaction, runner *tester.Runner, reporter tester.Reporter) int {
+func runTests(ctx context.Context, txn storage.Transaction, runner *tester.Runner, reporter tester.Reporter, testParams testCommandParams) int {
 	var err error
 	var ch chan *tester.Result
 	if testParams.benchmark {
@@ -335,7 +245,7 @@ func runTests(ctx context.Context, txn storage.Transaction, runner *tester.Runne
 				// there is a skipped test, adding the flag -z exits 0 if there are no failures
 				exitCode = 0
 			}
-			tr.Trace = filterTrace(testParams, tr.Trace)
+			tr.Trace = filterTrace(&testParams, tr.Trace)
 			dup <- tr
 		}
 	}()
@@ -384,6 +294,96 @@ func isThresholdValid(t float64) bool {
 }
 
 func init() {
+	var testParams = newTestCommandParams()
+
+	var testCommand = &cobra.Command{
+		Use:   "test <path> [path [...]]",
+		Short: "Execute Rego test cases",
+		Long: `Execute Rego test cases.
+	
+	The 'test' command takes a file or directory path as input and executes all
+	test cases discovered in matching files. Test cases are rules whose names have the prefix "test_".
+	
+	If the '--bundle' option is specified the paths will be treated as policy bundles
+	and loaded following standard bundle conventions. The path can be a compressed archive
+	file or a directory which will be treated as a bundle. Without the '--bundle' flag OPA
+	will recursively load ALL *.rego, *.json, and *.yaml files for evaluating the test cases.
+	
+	Test cases under development may be prefixed "todo_" in order to skip their execution,
+	while still getting marked as skipped in the test results.
+	
+	Example policy (example/authz.rego):
+	
+		package authz
+	
+		import future.keywords.if
+	
+		allow if {
+			input.path == ["users"]
+			input.method == "POST"
+		}
+	
+		allow if {
+			input.path == ["users", input.user_id]
+			input.method == "GET"
+		}
+	
+	Example test (example/authz_test.rego):
+	
+		package authz_test
+	
+		import data.authz.allow
+	
+		test_post_allowed {
+			allow with input as {"path": ["users"], "method": "POST"}
+		}
+	
+		test_get_denied {
+			not allow with input as {"path": ["users"], "method": "GET"}
+		}
+	
+		test_get_user_allowed {
+			allow with input as {"path": ["users", "bob"], "method": "GET", "user_id": "bob"}
+		}
+	
+		test_get_another_user_denied {
+			not allow with input as {"path": ["users", "bob"], "method": "GET", "user_id": "alice"}
+		}
+	
+		todo_test_user_allowed_http_client_data {
+			false # Remember to test this later!
+		}
+	
+	Example test run:
+	
+		$ opa test ./example/
+	
+	If used with the '--bench' option then tests will be benchmarked.
+	
+	Example benchmark run:
+	
+		$ opa test --bench ./example/
+	
+	The optional "gobench" output format conforms to the Go Benchmark Data Format.
+	`,
+		PreRunE: func(Cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return fmt.Errorf("specify at least one file")
+			}
+
+			// If an --explain flag was set, turn on verbose output
+			if testParams.explain.IsSet() {
+				testParams.verbose = true
+			}
+
+			return nil
+		},
+
+		Run: func(cmd *cobra.Command, args []string) {
+			os.Exit(opaTest(args, testParams))
+		},
+	}
+
 	// Test specific flags
 	testCommand.Flags().BoolVarP(&testParams.skipExitZero, "exit-zero-on-skipped", "z", false, "skipped tests return status 0")
 	testCommand.Flags().BoolVarP(&testParams.verbose, "verbose", "v", false, "set verbose reporting mode")

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -305,71 +305,71 @@ func init() {
 		Short: "Execute Rego test cases",
 		Long: `Execute Rego test cases.
 	
-	The 'test' command takes a file or directory path as input and executes all
-	test cases discovered in matching files. Test cases are rules whose names have the prefix "test_".
-	
-	If the '--bundle' option is specified the paths will be treated as policy bundles
-	and loaded following standard bundle conventions. The path can be a compressed archive
-	file or a directory which will be treated as a bundle. Without the '--bundle' flag OPA
-	will recursively load ALL *.rego, *.json, and *.yaml files for evaluating the test cases.
-	
-	Test cases under development may be prefixed "todo_" in order to skip their execution,
-	while still getting marked as skipped in the test results.
-	
-	Example policy (example/authz.rego):
-	
-		package authz
-	
-		import future.keywords.if
-	
-		allow if {
-			input.path == ["users"]
-			input.method == "POST"
-		}
-	
-		allow if {
-			input.path == ["users", input.user_id]
-			input.method == "GET"
-		}
-	
-	Example test (example/authz_test.rego):
-	
-		package authz_test
-	
-		import data.authz.allow
-	
-		test_post_allowed {
-			allow with input as {"path": ["users"], "method": "POST"}
-		}
-	
-		test_get_denied {
-			not allow with input as {"path": ["users"], "method": "GET"}
-		}
-	
-		test_get_user_allowed {
-			allow with input as {"path": ["users", "bob"], "method": "GET", "user_id": "bob"}
-		}
-	
-		test_get_another_user_denied {
-			not allow with input as {"path": ["users", "bob"], "method": "GET", "user_id": "alice"}
-		}
-	
-		todo_test_user_allowed_http_client_data {
-			false # Remember to test this later!
-		}
-	
-	Example test run:
-	
-		$ opa test ./example/
-	
-	If used with the '--bench' option then tests will be benchmarked.
-	
-	Example benchmark run:
-	
-		$ opa test --bench ./example/
-	
-	The optional "gobench" output format conforms to the Go Benchmark Data Format.
-	`,
+The 'test' command takes a file or directory path as input and executes all
+test cases discovered in matching files. Test cases are rules whose names have the prefix "test_".
+
+If the '--bundle' option is specified the paths will be treated as policy bundles
+and loaded following standard bundle conventions. The path can be a compressed archive
+file or a directory which will be treated as a bundle. Without the '--bundle' flag OPA
+will recursively load ALL *.rego, *.json, and *.yaml files for evaluating the test cases.
+
+Test cases under development may be prefixed "todo_" in order to skip their execution,
+while still getting marked as skipped in the test results.
+
+Example policy (example/authz.rego):
+
+	package authz
+
+	import future.keywords.if
+
+	allow if {
+		input.path == ["users"]
+		input.method == "POST"
+	}
+
+	allow if {
+		input.path == ["users", input.user_id]
+		input.method == "GET"
+	}
+
+Example test (example/authz_test.rego):
+
+	package authz_test
+
+	import data.authz.allow
+
+	test_post_allowed {
+		allow with input as {"path": ["users"], "method": "POST"}
+	}
+
+	test_get_denied {
+		not allow with input as {"path": ["users"], "method": "GET"}
+	}
+
+	test_get_user_allowed {
+		allow with input as {"path": ["users", "bob"], "method": "GET", "user_id": "bob"}
+	}
+
+	test_get_another_user_denied {
+		not allow with input as {"path": ["users", "bob"], "method": "GET", "user_id": "alice"}
+	}
+
+	todo_test_user_allowed_http_client_data {
+		false # Remember to test this later!
+	}
+
+Example test run:
+
+	$ opa test ./example/
+
+If used with the '--bench' option then tests will be benchmarked.
+
+Example benchmark run:
+
+	$ opa test --bench ./example/
+
+The optional "gobench" output format conforms to the Go Benchmark Data Format.
+`,
 		PreRunE: func(Cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				return fmt.Errorf("specify at least one file")

--- a/cmd/test_test.go
+++ b/cmd/test_test.go
@@ -26,7 +26,7 @@ func TestFilterTraceDefault(t *testing.T) {
 | | Fail data.testing.p with data.x as "bar"
 | Fail data.testing.test_p = _
 `
-	verifyFilteredTrace(t, p, expected)
+	verifyFilteredTrace(t, &p, expected)
 }
 
 func TestFilterTraceVerbose(t *testing.T) {
@@ -46,7 +46,7 @@ func TestFilterTraceVerbose(t *testing.T) {
 | | Fail data.testing.p with data.x as "bar"
 | Fail data.testing.test_p = _
 `
-	verifyFilteredTrace(t, p, expected)
+	verifyFilteredTrace(t, &p, expected)
 }
 
 func TestFilterTraceExplainFails(t *testing.T) {
@@ -66,7 +66,7 @@ func TestFilterTraceExplainFails(t *testing.T) {
 | | Fail data.testing.p with data.x as "bar"
 | Fail data.testing.test_p = _
 `
-	verifyFilteredTrace(t, p, expected)
+	verifyFilteredTrace(t, &p, expected)
 }
 
 func TestFilterTraceExplainNotes(t *testing.T) {
@@ -84,7 +84,7 @@ func TestFilterTraceExplainNotes(t *testing.T) {
 | | | | Enter data.testing.r
 | | | | | Note "got this far2"
 `
-	verifyFilteredTrace(t, p, expected)
+	verifyFilteredTrace(t, &p, expected)
 }
 
 func TestFilterTraceExplainFull(t *testing.T) {
@@ -135,7 +135,7 @@ func TestFilterTraceExplainFull(t *testing.T) {
 | | Fail data.testing.p with data.x as "bar"
 | Fail data.testing.test_p = _
 `
-	verifyFilteredTrace(t, p, expected)
+	verifyFilteredTrace(t, &p, expected)
 }
 
 func TestThresholdRange(t *testing.T) {

--- a/cmd/test_test.go
+++ b/cmd/test_test.go
@@ -335,7 +335,7 @@ p with input.foo as 42
 
 func TestJSONSchemaFail(t *testing.T) {
 
-	rego := `package test
+	regoContents := `package test
 # METADATA
 # schemas:
 #   - input: schema.demo_schema
@@ -348,24 +348,24 @@ p with input.foo as 42
 }`
 
 	schema := `{
-		"$schema": "http://json-schema.org/draft-07/schema",
-		"$id": "schema",
-		"type": "object",
-		"description": "The root schema comprises the entire JSON document.",
-		"required": [
-			"foo"
-		],
-		"properties": {
-			"foo": {
-				"$id": "#/properties/foo",
-				"type": "boolean",
-				"description": "foo"
-			}         
-		},
-		"additionalProperties": false
-   }`
+"$schema": "http://json-schema.org/draft-07/schema",
+"$id": "schema",
+"type": "object",
+"description": "The root schema comprises the entire JSON document.",
+"required": [
+	"foo"
+],
+"properties": {
+	"foo": {
+		"$id": "#/properties/foo",
+		"type": "boolean",
+		"description": "foo"
+	}         
+},
+"additionalProperties": false
+}`
 
-	exitCode, err := testSchemasAnnotationWithJSONFile(rego, schema)
+	exitCode, err := testSchemasAnnotationWithJSONFile(regoContents, schema)
 	if exitCode == 0 {
 		t.Fatalf("didn't get expected error when schema is present and is defining a different type than being used.")
 	} else if !strings.Contains(err.Error(), "rego_type_error: match error") {

--- a/cmd/test_test.go
+++ b/cmd/test_test.go
@@ -239,6 +239,7 @@ package test
 # schemas:
 #   - input: schema["input"]
 p { 
+	rego.metadata.rule() # presence of rego.metadata.* calls must not trigger unwanted schema evaluation
 	input.foo == 42 # type mismatch with schema that should be ignored
 }
 
@@ -297,7 +298,7 @@ func testSchemasAnnotationWithJSONFile(rego string, schema string) (int, error) 
 }
 func TestJSONSchemaSuccess(t *testing.T) {
 
-	rego := `package test
+	regoContents := `package test
 # METADATA
 # schemas:
 #   - input: schema.demo_schema
@@ -327,7 +328,7 @@ p with input.foo as 42
 		"additionalProperties": false
    }`
 
-	_, err := testSchemasAnnotationWithJSONFile(rego, schema)
+	_, err := testSchemasAnnotationWithJSONFile(regoContents, schema)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}

--- a/tester/runner.go
+++ b/tester/runner.go
@@ -588,7 +588,9 @@ func (r *Runner) runBenchmark(ctx context.Context, txn storage.Transaction, mod 
 
 // Load returns modules and an in-memory store for running tests.
 func Load(args []string, filter loader.Filter) (map[string]*ast.Module, storage.Store, error) {
-	loaded, err := loader.NewFileLoader().Filtered(args, filter)
+	loaded, err := loader.NewFileLoader().
+		WithProcessAnnotation(true).
+		Filtered(args, filter)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -616,7 +618,10 @@ func Load(args []string, filter loader.Filter) (map[string]*ast.Module, storage.
 func LoadBundles(args []string, filter loader.Filter) (map[string]*bundle.Bundle, error) {
 	bundles := map[string]*bundle.Bundle{}
 	for _, bundleDir := range args {
-		b, err := loader.NewFileLoader().WithSkipBundleVerification(true).AsBundle(bundleDir)
+		b, err := loader.NewFileLoader().
+			WithProcessAnnotation(true).
+			WithSkipBundleVerification(true).
+			AsBundle(bundleDir)
 		if err != nil {
 			return nil, fmt.Errorf("unable to load bundle %s: %s", bundleDir, err)
 		}


### PR DESCRIPTION
### Why the changes in this PR are needed?
To enable schema validation on `opa test` the same way that is supported today by `opa eval`

### What are the changes in this PR?

On `test.go`:
- added schema flag usage
- refactored `opaTest()` to allow it to be used by `tests_test.go`, which included the following changes:
    - added **testCommandParams** to be a parameter
    - added **error** to be returned in addition to the **exit code**
- moved **testParams** and **testCommand** initialization to be inside the init method (similar to how is in `eval` today)

On `tests_test.go`:
- fixed existing InlineSchema test to use `opaTest()` instead of the SDK (as requested by @johanfylling)
- added 2 new Json Schema test

On `runner.go`
- added annotation reading

On `eval_test.go`
- removed unnecessary `rego.metadata.rule()` line from rego contents to test inline schema to avoid confusion

### Notes to assist PR review:

Fixes: #5923

This PR replaces the abandoned [PR 5951](https://github.com/open-policy-agent/opa/pull/5951) where most of the changes here were discussed/requested there.

Signed-off-by: Renato Cordeiro <renato@renatocordeiro.com>

