### PR TITLE
fmt:fix `fmt` panic in comprehension with comments

### DIFF
--- a/format/format.go
+++ b/format/format.go
@@ -914,7 +914,7 @@ func (w *writer) writeObjectComprehension(object *ast.ObjectComprehension, loc *
 }
 
 func (w *writer) writeComprehension(open, close byte, term *ast.Term, body ast.Body, loc *ast.Location, comments []*ast.Comment) []*ast.Comment {
-	if term.Location.Row-loc.Row > 1 {
+	if term.Location.Row-loc.Row >= 1 {
 		w.endLine()
 		w.startLine()
 	}

--- a/format/testfiles/test_issue_5798.rego
+++ b/format/testfiles/test_issue_5798.rego
@@ -1,0 +1,9 @@
+package test
+
+rule01 = fail
+{
+    fail = {                # this
+        x |                 # panics
+            set[x]; f(x)
+    }
+}

--- a/format/testfiles/test_issue_5798.rego.formatted
+++ b/format/testfiles/test_issue_5798.rego.formatted
@@ -1,0 +1,9 @@
+package test
+
+rule01 = fail {
+	fail = { # this
+	x | # panics
+		set[x]
+		f(x)
+	}
+}


### PR DESCRIPTION
### Why the changes in this PR are needed?

As noted in #5798, the `fmt` command panicked when rego files processed contained a comprehension written on multiple lines with comments in these lines. The issue contains an example of such comprehension.

This allows to handle such cases.

### What are the changes in this PR?
The only part of the code that is changed by this PR is the first check 
performed in [writeComprehension](https://github.com/open-policy-agent/opa/blob/main/format/format.go#L917).  Instead of starting a new line only when the comprehension and the first term processed are separated by at least two rows, now only one row is necessary to start a new line. This avoids that the [insertComments](https://github.com/open-policy-agent/opa/blob/main/format/format.go#L498) panics when writing the second comment.

In addition to this, a test case for this issue has been added.

### Notes to assist PR review:
The method followed to solve this issue is the same adopted in #3864, which solves a similar problem.
