### PR TITLE
sdk: allow passing in a separate store implementation

### DIFF
--- a/sdk/opa.go
+++ b/sdk/opa.go
@@ -27,7 +27,6 @@ import (
 	"github.com/open-policy-agent/opa/server"
 	"github.com/open-policy-agent/opa/server/types"
 	"github.com/open-policy-agent/opa/storage"
-	"github.com/open-policy-agent/opa/storage/inmem"
 	"github.com/open-policy-agent/opa/topdown"
 	"github.com/open-policy-agent/opa/topdown/builtins"
 	"github.com/open-policy-agent/opa/topdown/cache"
@@ -44,6 +43,7 @@ type OPA struct {
 	logger  logging.Logger
 	console logging.Logger
 	plugins map[string]plugins.Factory
+	store   storage.Store
 	config  []byte
 }
 
@@ -72,7 +72,8 @@ func New(ctx context.Context, opts Options) (*OPA, error) {
 	}
 
 	opa := &OPA{
-		id: id,
+		id:    id,
+		store: opts.Store,
 		state: &state{
 			queryCache: newQueryCache(),
 		},
@@ -127,7 +128,7 @@ func (opa *OPA) configure(ctx context.Context, bs []byte, ready chan struct{}, b
 	manager, err := plugins.New(
 		bs,
 		opa.id,
-		inmem.New(),
+		opa.store,
 		plugins.Info(info),
 		plugins.Logger(opa.logger),
 		plugins.ConsoleLogger(opa.console),

--- a/sdk/options.go
+++ b/sdk/options.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/open-policy-agent/opa/logging"
 	"github.com/open-policy-agent/opa/plugins"
+	"github.com/open-policy-agent/opa/storage"
+	"github.com/open-policy-agent/opa/storage/inmem"
 )
 
 // Options contains parameters to setup and configure OPA.
@@ -44,6 +46,10 @@ type Options struct {
 	// is recommended, as it makes it easier to track the system over time.
 	ID string
 
+	// Store sets the store to be used by the SDK instance. If nil, it'll use OPA's
+	// inmem store.
+	Store storage.Store
+
 	config []byte
 	block  bool
 }
@@ -73,6 +79,10 @@ func (o *Options) init() error {
 			return err
 		}
 		o.config = bs
+	}
+
+	if o.Store == nil {
+		o.Store = inmem.New()
 	}
 
 	return nil


### PR DESCRIPTION
The store to use in the SDK is currently hard-coded to be `inmem`. This change allows providing new implementations.