### PR TITLE
fix: Fixing the issue of the object.subset method failing to correctly compare array relationships

### DIFF
--- a/test/cases/testdata/subset/test-subset.yaml
+++ b/test/cases/testdata/subset/test-subset.yaml
@@ -418,7 +418,7 @@ cases:
         package test
 
         A := [1,2,3,4,5,6]
-        B := [8]
+        B := [8,9]
 
         AsubB := object.subset(A, B)
         BsubA := object.subset(B, A)

--- a/test/cases/testdata/subset/test-subset.yaml
+++ b/test/cases/testdata/subset/test-subset.yaml
@@ -386,3 +386,53 @@ cases:
     query: data.test.test_result = x
     want_result:
       - x: true
+  
+  - data:
+    modules:
+      - |
+        package test
+
+        A := [1,2,3,4,5,6]
+        B := [4,5,6,8]
+
+        AsubB := object.subset(A, B)
+        BsubA := object.subset(B, A)
+
+        # Notice that there isn't really a well-defined way to "match" the two
+        # nested sets to one another, so we B is not a subset of A in this
+        # case.
+
+        test_result {
+          not AsubB     # B is not a subset of A
+          not BsubA     # A is not a subset of B
+        }
+
+    note: subset/arrays 5
+    query: data.test.test_result = x
+    want_result:
+      - x: true
+
+  - data:
+    modules:
+      - |
+        package test
+
+        A := [1,2,3,4,5,6]
+        B := [8]
+
+        AsubB := object.subset(A, B)
+        BsubA := object.subset(B, A)
+
+        # Notice that there isn't really a well-defined way to "match" the two
+        # nested sets to one another, so we B is not a subset of A in this
+        # case.
+
+        test_result {
+          not AsubB     # B is not a subset of A
+          not BsubA     # A is not a subset of B
+        }
+
+    note: subset/arrays 6
+    query: data.test.test_result = x
+    want_result:
+      - x: true

--- a/test/cases/testdata/subset/test-subset.yaml
+++ b/test/cases/testdata/subset/test-subset.yaml
@@ -418,7 +418,7 @@ cases:
         package test
 
         A := [1,2,3,4,5,6]
-        B := [8,9]
+        B := [8,9,10]
 
         AsubB := object.subset(A, B)
         BsubA := object.subset(B, A)

--- a/topdown/subset.go
+++ b/topdown/subset.go
@@ -193,12 +193,12 @@ func arraySubset(super, sub *ast.Array) bool {
 			return true
 		}
 
-		if superCursor == super.Len() {
+		if superCursor+subCursor == super.Len() {
 			return false
 		}
 
 		subElem := sub.Elem(subCursor)
-		superElem := sub.Elem(superCursor + subCursor)
+		superElem := super.Elem(superCursor + subCursor)
 		if superElem == nil {
 			return false
 		}


### PR DESCRIPTION
fix: Fixing the issue of the object.subset method failing to correctly compare array relationships

relative issue：[#5968](https://github.com/open-policy-agent/opa/issues/5968)

1. modify arraySubset method，fixing the incorrect assignment of `superElem` and adding array boundary checks
2. add testcases for the code change

--bug=[#5968](https://github.com/open-policy-agent/opa/issues/5968)

PTAL