### PR TITLE
Add tracing to bundle/discovery download

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,15 +18,17 @@ import (
 	"github.com/open-policy-agent/opa/keys"
 	"github.com/open-policy-agent/opa/logging"
 	"github.com/open-policy-agent/opa/plugins/rest"
+	"github.com/open-policy-agent/opa/tracing"
 	"github.com/open-policy-agent/opa/util"
 )
 
 // ServiceOptions stores the options passed to ParseServicesConfig
 type ServiceOptions struct {
-	Raw        json.RawMessage
-	AuthPlugin rest.AuthPluginLookupFunc
-	Keys       map[string]*keys.Config
-	Logger     logging.Logger
+	Raw                   json.RawMessage
+	AuthPlugin            rest.AuthPluginLookupFunc
+	Keys                  map[string]*keys.Config
+	Logger                logging.Logger
+	DistributedTacingOpts tracing.Options
 }
 
 // ParseServicesConfig returns a set of named service clients. The service
@@ -42,7 +44,7 @@ func ParseServicesConfig(opts ServiceOptions) (map[string]rest.Client, error) {
 
 	if err := util.Unmarshal(opts.Raw, &arr); err == nil {
 		for _, s := range arr {
-			client, err := rest.New(s, opts.Keys, rest.AuthPluginLookup(opts.AuthPlugin), rest.Logger(opts.Logger))
+			client, err := rest.New(s, opts.Keys, rest.AuthPluginLookup(opts.AuthPlugin), rest.Logger(opts.Logger), rest.DistributedTracingOpts(opts.DistributedTacingOpts))
 			if err != nil {
 				return nil, err
 			}
@@ -50,7 +52,7 @@ func ParseServicesConfig(opts ServiceOptions) (map[string]rest.Client, error) {
 		}
 	} else if util.Unmarshal(opts.Raw, &obj) == nil {
 		for k := range obj {
-			client, err := rest.New(obj[k], opts.Keys, rest.Name(k), rest.AuthPluginLookup(opts.AuthPlugin), rest.Logger(opts.Logger))
+			client, err := rest.New(obj[k], opts.Keys, rest.Name(k), rest.AuthPluginLookup(opts.AuthPlugin), rest.Logger(opts.Logger), rest.DistributedTracingOpts(opts.DistributedTacingOpts))
 			if err != nil {
 				return nil, err
 			}

--- a/topdown/http_test.go
+++ b/topdown/http_test.go
@@ -3217,7 +3217,7 @@ func TestDistributedTracingEnabled(t *testing.T) {
 	}
 
 	if exp, act := 1, mock.called; exp != act {
-		t.Errorf("calls to NewTransported: expected %d, got %d", exp, act)
+		t.Errorf("calls to NewTransport: expected %d, got %d", exp, act)
 	}
 }
 


### PR DESCRIPTION
### Why the changes in this PR are needed?

Addresses #5967, adds the ability to configure distributed tracing options to plugin manager and rest client. 

This allows using an existing distributed tracing infrastructure that is used for the http built-in for bundle downloads without relying in OpenTelemetry. 

### What are the changes in this PR?

* Adds `tracing.Options` to the relevant places to configure bundle download tracing


