### PR TITLE
Fix a bug with object.union_n in which the nested objects would be mutated

### DIFF
--- a/topdown/object.go
+++ b/topdown/object.go
@@ -200,7 +200,16 @@ func mergewithOverwriteInPlace(obj, other ast.Object, frozenKeys map[*ast.Term]s
 		v2 := obj.Get(k)
 		// The key didn't exist in other, keep the original value.
 		if v2 == nil {
-			obj.Insert(k, v)
+			nestedObj, ok := v.Value.(ast.Object)
+			if !ok {
+				// v is not an object
+				obj.Insert(k, v)
+			} else {
+				// Copy the nested object so the original object would not be modified
+				nestedObjCopy := nestedObj.Copy()
+				obj.Insert(k, ast.NewTerm(nestedObjCopy))
+			}
+
 			return
 		}
 		// The key exists in both. Merge or reject change.

--- a/topdown/object_test.go
+++ b/topdown/object_test.go
@@ -50,6 +50,11 @@ func TestObjectUnionNBuiltin(t *testing.T) {
 			expected: `{"A": 1, "B": 200, "C": 3,}`,
 		},
 		{
+			note:     "2x objects, with simple merge on nested objects with different keys",
+			input:    `[{"X": {"A": "a"}}, {"X": {"B": "b"}}]`,
+			expected: `{"X": {"A": "a", "B": "b"}}`,
+		},
+		{
 			note:     "2x objects, with complex merge on nested object",
 			input:    `[{"A": 1, "B": {"N1": {"X": true, "Z": false}}, "C": 3},  {"B": {"N1": {"X": 49, "Z": 50}}}]`,
 			expected: `{"A": 1, "B": {"N1": {"X": 49, "Z": 50}}, "C": 3}`,
@@ -68,9 +73,14 @@ func TestObjectUnionNBuiltin(t *testing.T) {
 
 	for _, tc := range tests {
 		inputs := ast.MustParseTerm(tc.input)
+		inputsCopy := inputs.Copy()
 		result, err := getResult(builtinObjectUnionN, inputs)
 		if err != nil {
 			t.Fatal(err)
+		}
+
+		if !inputsCopy.Equal(inputs) {
+			t.Fatal("Inputs were mutated")
 		}
 
 		expected := ast.MustParseTerm(tc.expected)


### PR DESCRIPTION
<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->

### Why the changes in this PR are needed?

<!--
Include a short description of WHY the changes were made.
-->
To fix a bug with `object.union_n` in which the nested objects would be mutated. Related issue: https://github.com/open-policy-agent/opa/pull/5975


### What are the changes in this PR?

<!--
Include a short description of WHAT changes were made.
-->
When inserting a nested object from `other` to `obj`, instead of inserting the original object, make a copy and insert the copy instead to make sure the original nested object is not copied, and thus prevent the objects passed in from being mutated


### Notes to assist PR review:

<!--
Here you can add information you think will help the reviewer(s).
-->

### Further comments:

<!--
Here you can include links to additional resources related to the changes, discuss your solution, other approaches you considered etc.
-->
