### PR TITLE
Add padding to bottom of dashboard panel content

### DIFF
--- a/docs/website/assets/sass/docs.sass
+++ b/docs/website/assets/sass/docs.sass
@@ -163,7 +163,7 @@ $panel-header-logo-width: 85%
 
 .dashboard-panel-content
   margin: 0 0 0 2rem
-  padding: 0 2rem 0 0
+  padding: 0 2rem 2rem 0
 
 .banner-version-warning
   // override bulma defaults for messages


### PR DESCRIPTION
This video shows the issue present on the current docs site in Chromium and Safari, and how it looks after this fix.

https://github.com/open-policy-agent/opa/assets/1774239/e45e818c-097e-4e97-ba65-799ff86d00ff

