### PR TITLE
topdown: Update cache interface with Clone method

### DIFF
--- a/topdown/cache/cache.go
+++ b/topdown/cache/cache.go
@@ -7,10 +7,9 @@ package cache
 
 import (
 	"container/list"
+	"sync"
 
 	"github.com/open-policy-agent/opa/ast"
-
-	"sync"
 
 	"github.com/open-policy-agent/opa/util"
 )
@@ -62,6 +61,7 @@ func (c *Config) validateAndInjectDefaults() error {
 // InterQueryCacheValue defines the interface for the data that the inter-query cache holds.
 type InterQueryCacheValue interface {
 	SizeInBytes() int64
+	Clone() (InterQueryCacheValue, error)
 }
 
 // InterQueryCache defines the interface for the inter-query cache.
@@ -70,6 +70,7 @@ type InterQueryCache interface {
 	Insert(key ast.Value, value InterQueryCacheValue) int
 	Delete(key ast.Value)
 	UpdateConfig(config *Config)
+	Clone(value InterQueryCacheValue) (InterQueryCacheValue, error)
 }
 
 // NewInterQueryCache returns a new inter-query cache.
@@ -130,6 +131,12 @@ func (c *cache) UpdateConfig(config *Config) {
 	c.config = config
 }
 
+func (c *cache) Clone(value InterQueryCacheValue) (InterQueryCacheValue, error) {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+	return c.unsafeClone(value)
+}
+
 func (c *cache) unsafeInsert(k ast.Value, v InterQueryCacheValue) (dropped int) {
 	size := v.SizeInBytes()
 	limit := c.maxSizeBytes()
@@ -172,6 +179,10 @@ func (c *cache) unsafeDelete(k ast.Value) {
 	c.usage -= cacheItem.value.SizeInBytes()
 	delete(c.items, k.String())
 	c.l.Remove(cacheItem.keyElement)
+}
+
+func (c *cache) unsafeClone(value InterQueryCacheValue) (InterQueryCacheValue, error) {
+	return value.Clone()
 }
 
 func (c *cache) maxSizeBytes() int64 {


### PR DESCRIPTION
Concurrent evaluation of the http.send builtin for the
same object can sometimes result in the HTTP headers
map being concurrently accessed. This can happen for
example when a key already present in the inter-query
cache needs to be revalidated and multiple routines
may access the HTTP headers at the same time resulting
in a race.

This change adds a new Clone method to cache interface.
The idea is to give each routine its own copy of the cached object
which would mean it has a copy of the headers map and
thus should be able to avoid any sync issues.

Signed-off-by: Ashutosh Narkar <anarkar4387@gmail.com>