### PR TITLE
[website] Include static hugo pages in prod build

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -20,17 +20,21 @@ generate-cli-docs:
 	$(CURDIR)/../build/gen-cli-docs.sh "$(CURDIR)/content"
 
 .PHONY: generate
-generate: generate-cli-docs copy-builtin-metadata
+generate: generate-cli-docs copy-builtin-metadata copy-hugo-static-content
 	$(CURDIR)/website/scripts/load-docs.sh
 
 .PHONY: copy-builtin-metadata
 copy-builtin-metadata:
 	cp -v $(CURDIR)/../builtin_metadata.json $(CURDIR)/website/data/builtin_metadata.json
 
-.PHONY: dev-generate
-dev-generate: generate-cli-docs copy-builtin-metadata
-	DEV=true $(CURDIR)/website/scripts/load-docs.sh
+.PHONY: copy-hugo-static-content
+copy-hugo-static-content:
+	mkdir -p $(CURDIR)/website/generated/
 	cp -r $(CURDIR)/website/content/* $(CURDIR)/website/generated/
+
+.PHONY: dev-generate
+dev-generate: generate-cli-docs copy-builtin-metadata copy-hugo-static-content
+	DEV=true $(CURDIR)/website/scripts/load-docs.sh
 
 # The website has some npm dependencies saved in ./website/node_modules
 # As well as dependencies required for the "live-blocks".

--- a/docs/website/scripts/load-docs.sh
+++ b/docs/website/scripts/load-docs.sh
@@ -74,7 +74,7 @@ echo "Git version: ${GIT_VERSION}"
 echo "Releases to consider: ${RELEASES[*]}"
 
 echo "Cleaning generated folder"
-rm -rf ${ROOT_DIR}/docs/website/generated/*
+rm -rf ${ROOT_DIR}/docs/website/generated/docs/*
 
 echo "Removing data/releases.yaml file"
 rm -f ${RELEASES_YAML_FILE}


### PR DESCRIPTION
This was only added for dev in https://github.com/open-policy-agent/opa/pull/5984/files#diff-cdec797dddf8fc387304501d6bd4f318e1e9067c6fae012dfa8b69fd85fd3248R33

I missed this as I thought the preview would run the prod commands

