### PR TITLE
Fix for the issue when OPA throws misleading error (storage_not_found_error)

### DIFF
--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -399,6 +399,7 @@ type Reader struct {
 	etag                  string
 	lazyLoadingMode       bool
 	name                  string
+	persist               bool
 }
 
 // NewReader is deprecated. Use NewCustomReader instead.
@@ -493,6 +494,12 @@ func (r *Reader) WithBundleName(name string) *Reader {
 // outside the bundle's roots will not be performed while reading the bundle.
 func (r *Reader) WithLazyLoadingMode(yes bool) *Reader {
 	r.lazyLoadingMode = yes
+	return r
+}
+
+// WithBundlePersistence specifies if the downloaded bundle will eventually be persisted to disk.
+func (r *Reader) WithBundlePersistence(persist bool) *Reader {
+	r.persist = persist
 	return r
 }
 
@@ -658,6 +665,10 @@ func (r *Reader) Read() (Bundle, error) {
 
 		if len(bundle.WasmModules) != 0 {
 			return bundle, fmt.Errorf("delta bundle expected to contain only patch file but wasm files found")
+		}
+
+		if r.persist {
+			return bundle, fmt.Errorf("'persist' property is true in config. persisting delta bundle to disk is not supported")
 		}
 	}
 

--- a/download/download.go
+++ b/download/download.go
@@ -333,7 +333,8 @@ func (d *Downloader) download(ctx context.Context, m metrics.Metrics) (*download
 				WithBundleVerificationConfig(d.bvc).
 				WithBundleEtag(etag).
 				WithLazyLoadingMode(d.lazyLoadingMode).
-				WithBundleName(d.bundleName)
+				WithBundleName(d.bundleName).
+				WithBundlePersistence(d.persist)
 			if d.sizeLimitBytes != nil {
 				reader = reader.WithSizeLimitBytes(*d.sizeLimitBytes)
 			}


### PR DESCRIPTION
Fix for the issue when OPA throws misleading error (storage_not_found_error) message while loading the delta bundle when persist property in config is true.

The fix is to prevent the loading of delta bundle when persist is true and give a more clear error message.

One Test function included TestReadWithPatchPersistProperty

Fixes #5959

### Why the changes in this PR are needed?
a new persist property is created in Reader struct in bundle.go
WithBundlePersistence method is created on Reader
from download , this property is set in Reader
persist property is checked in Read() method to throw the error for delta bundles.


