### PR TITLE
fix(test): re-evaluate storage when remove is detected

### DIFF
--- a/cmd/test.go
+++ b/cmd/test.go
@@ -273,7 +273,7 @@ func processWatcherUpdate(ctx context.Context, testParams testCommandParams, pat
 
 	err := pathwatcher.ProcessWatcherUpdate(ctx, paths, removed, store, filter.Apply, testParams.bundleMode,
 		func(ctx context.Context, txn storage.Transaction, loaded *initload.LoadPathsResult) error {
-			if len(loaded.Files.Documents) > 0 {
+			if len(loaded.Files.Documents) > 0 || removed != "" {
 				if err := store.Write(ctx, txn, storage.AddOp, storage.Path{}, loaded.Files.Documents); err != nil {
 					return fmt.Errorf("storage error: %w", err)
 				}


### PR DESCRIPTION
### Why the changes in this PR are needed?

Fix: https://github.com/open-policy-agent/opa/issues/5986

### What are the changes in this PR?

This is to make `storage.Write` responsive when `removed` is detected
I came across the issue, as @ashutosh-narkar well-described,  while including some data.json into the folder using `mv`
```
./opa_darwin_arm64 test smoketest -w
```
then
```
mv smoketest/check_data.json ./
mv check_data.json smoketest
```
