### PR TITLE
[6012]Update auth.go to support azure workload identity on AKS pod

### DIFF
--- a/plugins/rest/auth.go
+++ b/plugins/rest/auth.go
@@ -35,6 +35,8 @@ import (
 const (
 	// Default to s3 when the service for sigv4 signing is not specified for backwards compatibility
 	awsSigv4SigningDefaultService = "s3"
+	// Default to urn:ietf:params:oauth:client-assertion-type:jwt-bearer for ClientAssertionType
+	defaultClientAssertionType = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
 )
 
 // DefaultTLSConfig defines standard TLS configurations based on the Config
@@ -178,6 +180,9 @@ type oauth2ClientCredentialsAuthPlugin struct {
 	ClientSecret         string                 `json:"client_secret"`
 	SigningKeyID         string                 `json:"signing_key"`
 	Thumbprint           string                 `json:"thumbprint"`
+	ClientAssertionType  string                 `json:"client_assertion_type"`
+	ClientAssertion      string                 `json:"client_assertion"`
+	ClientAssertionPath  string                 `json:"client_assertion_path"`
 	Claims               map[string]interface{} `json:"additional_claims"`
 	IncludeJti           bool                   `json:"include_jti_claim"`
 	Scopes               []string               `json:"scopes,omitempty"`
@@ -302,11 +307,42 @@ func (ap *oauth2ClientCredentialsAuthPlugin) NewClient(c Config) (*http.Client, 
 		return nil, errors.New("token_url required to use https scheme")
 	}
 	if ap.GrantType == grantTypeClientCredentials {
-		if ap.ClientSecret != "" && ap.SigningKeyID != "" {
-			return nil, errors.New("can only use one of client_secret and signing_key for client_credentials")
+		var clientCredentialsVariables = [4]string{ap.ClientSecret, ap.SigningKeyID, ap.ClientAssertion, ap.ClientAssertionPath}
+
+		var notEmptyVarCount int
+
+		for i := 0; i < len(clientCredentialsVariables); i++ {
+			if clientCredentialsVariables[i] != "" {
+				notEmptyVarCount++
+			}
 		}
-		if ap.SigningKeyID == "" && (ap.ClientID == "" || ap.ClientSecret == "") {
+
+		if notEmptyVarCount == 0 {
+			return nil, errors.New("please provide use one of client_secret, signing_key, client_assertion and client_assertion_path for client_credentials")
+		}
+
+		if notEmptyVarCount > 1 {
+			return nil, errors.New("can only use one of client_secret, signing_key, client_assertion and client_assertion_path for client_credentials")
+		}
+
+		if ap.ClientSecret != "" && ap.ClientID == "" {
 			return nil, errors.New("client_id and client_secret required")
+		} else if ap.ClientAssertion != "" {
+			if ap.ClientAssertionType == "" {
+				ap.ClientAssertionType = defaultClientAssertionType
+			}
+
+			if ap.ClientID == "" {
+				return nil, errors.New("client_id and client_assertion required")
+			}
+		} else if ap.ClientAssertionPath != "" {
+			if ap.ClientAssertionType == "" {
+				ap.ClientAssertionType = defaultClientAssertionType
+			}
+
+			if ap.ClientID == "" {
+				return nil, errors.New("client_id and client_assertion_path required")
+			}
 		}
 	}
 
@@ -334,12 +370,23 @@ func (ap *oauth2ClientCredentialsAuthPlugin) requestToken(ctx context.Context) (
 			if err != nil {
 				return nil, err
 			}
-			body.Add("client_assertion_type", "urn:ietf:params:oauth:client-assertion-type:jwt-bearer")
+			body.Add("client_assertion_type", defaultClientAssertionType)
 			body.Add("client_assertion", *authJwt)
 
 			if ap.ClientID != "" {
 				body.Add("client_id", ap.ClientID)
 			}
+		} else if ap.ClientAssertion != "" {
+			body.Add("client_assertion_type", defaultClientAssertionType)
+			body.Add("client_assertion", ap.ClientAssertion)
+		} else if ap.ClientAssertionPath != "" {
+			body.Add("client_assertion_type", defaultClientAssertionType)
+			fileContent, err := os.ReadFile(ap.ClientAssertionPath)
+			if err != nil {
+				return nil, err
+			}
+			token := string(fileContent)
+			body.Add("client_assertion", token)
 		}
 	}
 

--- a/plugins/rest/rest_test.go
+++ b/plugins/rest/rest_test.go
@@ -364,6 +364,34 @@ func TestNew(t *testing.T) {
 			}`,
 		},
 		{
+			name: "Oauth2CredAssertion",
+			input: `{
+				"name": "foo",
+				"url": "http://localhost",
+				"credentials": {
+					"oauth2": {
+						"token_url": "https://localhost",
+						"client_id": "client_one",
+						"client_assertion": "assertion_token"
+					}
+				}
+			}`,
+		},
+		{
+			name: "Oauth2CredAssertionPath",
+			input: `{
+				"name": "foo",
+				"url": "http://localhost",
+				"credentials": {
+					"oauth2": {
+						"token_url": "https://localhost",
+						"client_id": "client_one",
+						"client_assertion_path": "assertion_path"
+					}
+				}
+			}`,
+		},
+		{
 			name: "Oauth2JwtBearerMissingSigningKey",
 			input: fmt.Sprintf(`{
 				"name": "foo",


### PR DESCRIPTION
<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->

### Why the changes in this PR are needed?

<!--
Include a short description of WHY the changes were made.
-->

To support Azure AD workload identity ,

in order to get a token from Azure AD with workload identity

the code needs to fetch the client_assertion token from a file generated by K8s service account



AZURE_FEDERATED_TOKEN_FILE | The path of the projected service account token file.
-- | --


https://learn.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-client-creds-grant-flow#third-case-access-token-request-with-a-federated-credential

sample token request

```sh
POST /{tenant}/oauth2/v2.0/token HTTP/1.1               // Line breaks for clarity
Host: login.microsoftonline.com:443
Content-Type: application/x-www-form-urlencoded

scope=https%3A%2F%2Fgraph.microsoft.com%2F.default
&client_id=97e0a5b7-d745-40b6-94fe-5f77d35c6e05
&client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer
&client_assertion=eyJhbGciOiJSUzI1NiIsIng1dCI6Imd4OHRHeXN5amNScUtqRlBuZDdSRnd2d1pJMCJ9.eyJ{a lot of characters here}M8U3bSUKKJDEg
&grant_type=client_credentials
```

<br style="color: rgb(188, 189, 208); font-family: &quot;Open Sans&quot;, sans-serif; font-size: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><table style="margin: 0px auto; border-collapse: collapse; color: rgb(188, 189, 208); font-family: &quot;Open Sans&quot;, sans-serif; font-size: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><thead style="background: var(--table-header-bg);"><tr style="border: 1px var(--table-header-bg) solid;">

### What are the changes in this PR?

<!--
Include a short description of WHAT changes were made.
-->

### Notes to assist PR review:

<!--
Here you can add information you think will help the reviewer(s).
-->

### Further comments:

<!--
Here you can include links to additional resources related to the changes, discuss your solution, other approaches you considered etc.
-->
