### PR TITLE
[website/bugfix] Fix docs scrollbar issue

### DIFF
--- a/docs/website/assets/sass/custom.sass
+++ b/docs/website/assets/sass/custom.sass
@@ -61,8 +61,9 @@
   padding-bottom: 5rem
 
   &:not(.wide)
-    +widescreen
-      width: 75%
+    .hero, .content
+      +widescreen
+        max-width: 60rem
 
   .hero
     +touch


### PR DESCRIPTION
In #6029 I introduced a bug which caused scrollbars to show on some browsers in some viewports.



https://github.com/open-policy-agent/opa/pull/6029/files#diff-3707717b9bfb9dd7c7ac1dddba9600c1798ebc1528b2539eeca40e034a824f8fR65

This addresses the issues with a fix using a more conventional `max-width` value, though the result in this case is much the same.

<img width="1904" alt="Screenshot 2023-06-21 at 09 50 36" src="https://github.com/open-policy-agent/opa/assets/1774239/da226fa1-0fc2-4d38-a6c7-0f6cd906ad48">
