### PR TITLE
server: Update eval options for simple health query

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1114,19 +1114,8 @@ func (s *Server) getCachedPreparedEvalQuery(key string, m metrics.Metrics) (*reg
 
 func (s *Server) canEval(ctx context.Context) bool {
 	// Create very simple query that binds a single variable.
-	opts := []func(*rego.Rego){
-		rego.Compiler(s.getCompiler()),
-		rego.Store(s.store),
-		rego.Query("x = 1"),
-	}
+	eval := rego.New(rego.Query("x = 1"))
 
-	for _, r := range s.manager.GetWasmResolvers() {
-		for _, ep := range r.Entrypoints() {
-			opts = append(opts, rego.Resolver(ep, r))
-		}
-	}
-
-	eval := rego.New(opts...)
 	// Run evaluation.
 	rs, err := eval.Eval(ctx)
 	if err != nil {


### PR DESCRIPTION


<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->


### What are the changes in this PR?

<!--
Include a short description of WHAT changes were made.
-->

The /health API endpoint executes a simple built-in policy query that binds a single variable. The Rego object created for this query sets the compiler, store and resolvers which seem unnecessary for the simple query.



### Further comments:

<!--
Here you can include links to additional resources related to the changes, discuss your solution, other approaches you considered etc.
-->

As discussed in [this](https://github.com/open-policy-agent/opa/issues/5868#issuecomment-1581583426) issue, concurrent access to the health API can result in a panic due to routines trying to access the modules on the compiler. Although this scenario can affect other endpoints too and the fix would be to synchronize access to the compiler's modules, this fix attempts to make a small fix that would help resolve the issue for the health API.