### PR TITLE
Import `time/tzdata` for use when filesystem tzdata is missing

### DIFF
--- a/docs/content/policy-reference.md
+++ b/docs/content/policy-reference.md
@@ -701,7 +701,8 @@ Timezones can be specified as
 * "UTC" or "", which are equivalent to not passing a timezone (i.e. will return as UTC)
 * "Local", which will use the local timezone.
 
-Note that the opa executable will need access to the timezone files in the environment it is running in (see the [Go `time.LoadLocation()`](https://pkg.go.dev/time#LoadLocation) documentation for more information).
+Note that OPA will use the `time/tzdata` data if none is present on the runtime filesystem (see the
+[Go `time.LoadLocation()`](https://pkg.go.dev/time#LoadLocation) documentation for more information).
 
 #### Timestamp Parsing
 

--- a/topdown/time.go
+++ b/topdown/time.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"sync"
 	"time"
+	_ "time/tzdata" // this is needed to have LoadLocation when no filesystem tzdata is available
 
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/topdown/builtins"


### PR DESCRIPTION
Standard OPA images are based on cc-dynamic from Chainguard Images:

https://github.com/chainguard-images/images/blob/main/images/cc-dynamic/README.md

(now deprecated, see: https://github.com/open-policy-agent/opa/issues/6037)

This image doesn't include tzdata.

Our static images however are based on static.

https://github.com/chainguard-images/images/blob/main/images/static/README.md

This build includes tzdata:

https://github.com/chainguard-images/images/blob/main/images/static/configs/latest.apko.yaml#L8

How to see this:

```
$ docker run -it openpolicyagent/opa:0.53.1-static eval 'time.clock([time.now_ns(), "Asia/Shanghai"])'
{
  "result": [
    {
      "expressions": [
        {
          "value": [
            17,
            54,
            3
          ],
          "text": "time.clock([time.now_ns(), \"Asia/Shanghai\"])",
          "location": {
            "row": 1,
            "col": 1
          }
        }
      ]
    }
  ]
}

$ docker run -it openpolicyagent/opa:0.53.1 eval 'time.clock([time.now_ns(), "Asia/Shanghai"])'
{}
```

How to test this change:

```
make ci-build-linux ci-build-linux-static
make image-quick-amd64
docker run -it openpolicyagent/opa:0.54.0-dev eval 'time.clock([time.now_ns(), "Asia/Shanghai"])'
docker run -it openpolicyagent/opa:0.54.0-dev-static eval 'time.clock([time.now_ns(), "Asia/Shanghai"])'
```

You should see that both images provide the expected output. This shows that `time/tzdata` is being used in the non-static image as expected. These steps will not work as expected on main.

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->

### Why the changes in this PR are needed?

Without these changes, OPA images without tzdata on their filesystem will be unable to use some functions of the Rego language.

### Further comments:

Via: https://github.com/orgs/open-policy-agent/discussions/425
