### PR TITLE
plugins/discovery: Fix discovery erasing `persistence_directory` configuration

### DIFF
--- a/docs/content/management-discovery.md
+++ b/docs/content/management-discovery.md
@@ -300,5 +300,10 @@ the discovery bundle itself is persisted. The discovered configuration that is g
 policies contained in the discovery bundle will **NOT** be persisted.
 
 {{< info >}}
-By default, the discovery bundle is persisted under the current working directory of the OPA process (e.g., `./.opa/bundles/<discovery.name>/bundle.tar.gz`).
+The discovery bundle is persisted at
+`<persistence_directory>/bundles/<discovery.name>/bundle.tar.gz`. By default
+`persistence_directory` is `.opa` in the working directory of the OPA process.
+If `persistence_directory` is changed through discovery this will not affect
+where the discovery plugin will store the discovery bundles, the boot
+configuration will always be used.
 {{< /info >}}

--- a/plugins/plugins.go
+++ b/plugins/plugins.go
@@ -691,6 +691,11 @@ func (m *Manager) Reconfigure(config *config.Config) error {
 		}
 	}
 
+	// don't erase persistence directory
+	if config.PersistenceDirectory == nil {
+		config.PersistenceDirectory = m.Config.PersistenceDirectory
+	}
+
 	m.Config = config
 	m.interQueryBuiltinCacheConfig = interQueryBuiltinCacheConfig
 	for name, client := range services {


### PR DESCRIPTION
Before this change, if a discovery bundle didn't contain configuration
for `persistence_directory`, this would be deleted from the manager's
configuration. When enabling persistence of the discovery bundle this
doesn't make much sense, as the first discovery bundle would erase the
persistence settings.

This change ensures that discovery never erases `persistence_directory`.

Signed-off-by: Benjamin Nørgaard <mail@blacksails.dev>