### PR TITLE
Add ability to specify namespace for optimized files

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -42,6 +42,7 @@ type buildParams struct {
 	claimsFile         string
 	excludeVerifyFiles []string
 	plugin             string
+	ns                 string
 }
 
 func newBuildParams() buildParams {
@@ -102,7 +103,8 @@ The -O flag controls the optimization level. By default, optimization is disable
 When optimization is enabled the 'build' command generates a bundle that is semantically
 equivalent to the input files however the structure of the files in the bundle may have
 been changed by rewriting, inlining, pruning, etc. Higher optimization levels may result
-in longer build times.
+in longer build times. The --partial-namespace flag can used in conjunction with the -O flag
+to specify the namespace for the partially evaluated files in the optimized bundle.
 
 The 'build' command supports targets (specified by -t):
 
@@ -233,6 +235,7 @@ against OPA v0.22.0:
 	buildCommand.Flags().VarP(&buildParams.entrypoints, "entrypoint", "e", "set slash separated entrypoint path")
 	buildCommand.Flags().VarP(&buildParams.revision, "revision", "r", "set output bundle revision")
 	buildCommand.Flags().StringVarP(&buildParams.outputFile, "output", "o", "bundle.tar.gz", "set the output filename")
+	buildCommand.Flags().StringVar(&buildParams.ns, "partial-namespace", "partial", "set the namespace to use for partially evaluated files in an optimized bundle")
 
 	addBundleModeFlag(buildCommand.Flags(), &buildParams.bundleMode, false)
 	addIgnoreFlag(buildCommand.Flags(), &buildParams.ignore)
@@ -294,7 +297,8 @@ func dobuild(params buildParams, args []string) error {
 		WithPaths(args...).
 		WithFilter(buildCommandLoaderFilter(params.bundleMode, params.ignore)).
 		WithBundleVerificationConfig(bvc).
-		WithBundleSigningConfig(bsc)
+		WithBundleSigningConfig(bsc).
+		WithPartialNamespace(params.ns)
 
 	if params.revision.isSet {
 		compiler = compiler.WithRevision(*params.revision.v)

--- a/compile/compile.go
+++ b/compile/compile.go
@@ -81,6 +81,7 @@ type Compiler struct {
 	keyID                        string                     // represents the name of the default key used to verify a signed bundle
 	metadata                     *map[string]interface{}    // represents additional data included in .manifest file
 	fsys                         fs.FS                      // file system to use when loading paths
+	ns                           string
 }
 
 // New returns a new compiler instance that can be invoked.
@@ -225,6 +226,12 @@ func (c *Compiler) WithMetadata(metadata *map[string]interface{}) *Compiler {
 // WithFS sets the file system to use when loading paths
 func (c *Compiler) WithFS(fsys fs.FS) *Compiler {
 	c.fsys = fsys
+	return c
+}
+
+// WithPartialNamespace sets the namespace to use for partial evaluation results
+func (c *Compiler) WithPartialNamespace(ns string) *Compiler {
+	c.ns = ns
 	return c
 }
 
@@ -489,6 +496,10 @@ func (c *Compiler) optimize(ctx context.Context) error {
 		WithDebug(c.debug.Writer()).
 		WithShallowInlining(c.optimizationLevel <= 1).
 		WithEnablePrintStatements(c.enablePrintStatements)
+
+	if c.ns != "" {
+		o = o.WithPartialNamespace(c.ns)
+	}
 
 	err := o.Do(ctx)
 	if err != nil {
@@ -841,6 +852,11 @@ func (o *optimizer) WithEntrypoints(es []*ast.Term) *optimizer {
 
 func (o *optimizer) WithShallowInlining(yes bool) *optimizer {
 	o.shallow = yes
+	return o
+}
+
+func (o *optimizer) WithPartialNamespace(ns string) *optimizer {
+	o.nsprefix = ns
 	return o
 }
 


### PR DESCRIPTION
Currently the namespace for partially evaluated files in an optimized bundle cannot be modified. As a result if more than one optimized bundle is loaded in OPA, a root conflict error would occur as the optimized bundles have a root called "partial" automatially added to their
manifest. This change allows the namespace to be configured via the build command.

Fixes: #5933

