### PR TITLE
internal/logging: nitpicks

### DIFF
--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -44,21 +44,10 @@ func GetFormatter(format, timestampFormat string) logrus.Formatter {
 // prettyFormatter implements the Logrus Formatter interface
 // and provides a more simple, but easier to read, text formatter
 // option than the default logrus.TextFormatter.
-type prettyFormatter struct {
-}
-
-func isJSON(buf []byte) bool {
-	var tmp interface{}
-	err := json.Unmarshal(buf, &tmp)
-	return err == nil
-}
+type prettyFormatter struct{}
 
 func spaces(num int) string {
-	sb := strings.Builder{}
-	for i := 0; i < num; i++ {
-		sb.WriteByte(' ')
-	}
-	return sb.String()
+	return strings.Repeat(" ", num)
 }
 
 func (p *prettyFormatter) Format(e *logrus.Entry) ([]byte, error) {
@@ -85,7 +74,7 @@ func (p *prettyFormatter) Format(e *logrus.Entry) ([]byte, error) {
 				sb.WriteByte('\n')
 				stringVal = sb.String()
 			}
-		} else if ok && isJSON([]byte(stringVal)) {
+		} else if ok && json.Valid([]byte(stringVal)) {
 			var tmp bytes.Buffer
 			err := json.Indent(&tmp, []byte(stringVal), spaces(multiLineIndent), spaces(2))
 			if err != nil {


### PR DESCRIPTION
- There's a cheaper method to check if a byte slices is valid JSON: json.Valid.
- Also replaces spaces() by strings.Repeat().
