### PR TITLE
plugins/discovery: fix persistance of discovery bundle

### DIFF
--- a/plugins/discovery/discovery.go
+++ b/plugins/discovery/discovery.go
@@ -109,11 +109,15 @@ func New(manager *plugins.Manager, opts ...func(*Discovery)) (*Discovery, error)
 		if manager.Config.PersistenceDirectory != nil {
 			ociStorePath = filepath.Join(*manager.Config.PersistenceDirectory, "oci")
 		}
-		result.downloader = download.NewOCI(config.Config, restClient, config.path, ociStorePath).WithCallback(result.oneShot).
-			WithBundleVerificationConfig(config.Signing)
+		result.downloader = download.NewOCI(config.Config, restClient, config.path, ociStorePath).
+			WithCallback(result.oneShot).
+			WithBundleVerificationConfig(config.Signing).
+			WithBundlePersistence(config.Persist)
 	} else {
-		result.downloader = download.New(config.Config, restClient, config.path).WithCallback(result.oneShot).
-			WithBundleVerificationConfig(config.Signing)
+		result.downloader = download.New(config.Config, restClient, config.path).
+			WithCallback(result.oneShot).
+			WithBundleVerificationConfig(config.Signing).
+			WithBundlePersistence(config.Persist)
 	}
 	result.status = &bundle.Status{
 		Name: Name,


### PR DESCRIPTION
### Why the changes in this PR are needed?
Currently discovery bundle tar balls are empty.

### What are the changes in this PR?
Add missing option `WithBundlePersistence` to the discovery plugin's downloader, so that the downloaded raw buffer gets populated. Before this change the `buf` (https://github.com/open-policy-agent/opa/blob/main/download/download.go#L366) would be empty when downloading the discovery bundle. This resulted in an empty bundle.tar.gz file produced here: https://github.com/open-policy-agent/opa/blob/main/plugins/discovery/discovery.go#L325


### Further comments:
I have not added any tests due to contructor logic not being very testable. Currently it is only possible to access the downloader through the interface which makes it not possible to check if the "WithBundlePersistence" is set.

To test it, it would require a mock discovery server where the discovery plugin could try and download a discovery bundle from.

