### PR TITLE
Disable provenance attestations in buildx

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -373,6 +373,7 @@ push-manifest-list-%: ensure-executable-bin
 		--build-arg BASE=cgr.dev/chainguard/glibc-dynamic:latest \
 		--build-arg BIN_DIR=$(RELEASE_DIR) \
 		--platform $(DOCKER_PLATFORMS) \
+		--provenance=false \
 		--push \
 		.
 	$(DOCKER) buildx build \
@@ -380,6 +381,7 @@ push-manifest-list-%: ensure-executable-bin
 		--build-arg BASE=cgr.dev/chainguard/glibc-dynamic:latest-dev \
 		--build-arg BIN_DIR=$(RELEASE_DIR) \
 		--platform $(DOCKER_PLATFORMS) \
+		--provenance=false \
 		--push \
 		.
 	$(DOCKER) buildx build \
@@ -388,6 +390,7 @@ push-manifest-list-%: ensure-executable-bin
 		--build-arg BASE=cgr.dev/chainguard/glibc-dynamic:latest \
 		--build-arg BIN_DIR=$(RELEASE_DIR) \
 		--platform $(DOCKER_PLATFORMS) \
+		--provenance=false \
 		--push \
 		.
 
@@ -397,6 +400,7 @@ push-manifest-list-%: ensure-executable-bin
 		--build-arg BIN_DIR=$(RELEASE_DIR) \
 		--build-arg BIN_SUFFIX=_static \
 		--platform $(DOCKER_PLATFORMS_STATIC) \
+		--provenance=false \
 		--push \
 		.
 
@@ -406,6 +410,7 @@ push-manifest-list-%: ensure-executable-bin
 		--build-arg BIN_DIR=$(RELEASE_DIR) \
 		--build-arg BIN_SUFFIX=_static \
 		--platform $(DOCKER_PLATFORMS_STATIC) \
+		--provenance=false \
 		--push \
 		.
 


### PR DESCRIPTION
Buildx version >=0.10 generates a new OCI format
with support for provenance. As a result the
following error is generated on M1/M2 while inspecting the manifest

> OCI manifest found, but accept header does not support OCI manifests

The suggested fix is to temporarily disable provenance.

Fixes: #5877

### Further comments:

<!--
Here you can include links to additional resources related to the changes, discuss your solution, other approaches you considered etc.
-->

Related: https://github.com/docker/buildx/issues/1533.

The other workaround is to pin `buildx` version to `v0.9.1`. If this fix does not work as intended we can pin the version.
