### PR TITLE
config: add extensible "Extra" field, use it ActiveConfig

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -10,7 +10,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"sort"
+	"strings"
 
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/internal/ref"
@@ -41,14 +43,32 @@ type Config struct {
 	Storage *struct {
 		Disk json.RawMessage `json:"disk,omitempty"`
 	} `json:"storage,omitempty"`
+	Extra map[string]json.RawMessage `json:"-"`
 }
 
 // ParseConfig returns a valid Config object with defaults injected. The id
 // and version parameters will be set in the labels map.
 func ParseConfig(raw []byte, id string) (*Config, error) {
+	// NOTE(sr): based on https://stackoverflow.com/a/33499066/993018
 	var result Config
-	if err := util.Unmarshal(raw, &result); err != nil {
+	objValue := reflect.ValueOf(&result).Elem()
+	knownFields := map[string]reflect.Value{}
+	for i := 0; i != objValue.NumField(); i++ {
+		jsonName := strings.Split(objValue.Type().Field(i).Tag.Get("json"), ",")[0]
+		knownFields[jsonName] = objValue.Field(i)
+	}
+
+	if err := util.Unmarshal(raw, &result.Extra); err != nil {
 		return nil, err
+	}
+
+	for key, chunk := range result.Extra {
+		if field, found := knownFields[key]; found {
+			if err := util.Unmarshal(chunk, field.Addr().Interface()); err != nil {
+				return nil, err
+			}
+			delete(result.Extra, key)
+		}
 	}
 	return &result, result.validateAndInjectDefaults(id)
 }
@@ -149,30 +169,32 @@ func (c *Config) ActiveConfig() (interface{}, error) {
 	}
 
 	var result map[string]interface{}
-	if err := util.Unmarshal(bs, &result); err != nil {
+	if err := util.UnmarshalJSON(bs, &result); err != nil {
+		return nil, err
+	}
+	for k, e := range c.Extra {
+		var v any
+		if err := util.UnmarshalJSON(e, &v); err != nil {
+			return nil, err
+		}
+		result[k] = v
+	}
+
+	if err := removeServiceCredentials(result["services"]); err != nil {
 		return nil, err
 	}
 
-	if result["services"] != nil {
-		err = removeServiceCredentials(result["services"])
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	if result["keys"] != nil {
-		err = removeCryptoKeys(result["keys"])
-		if err != nil {
-			return nil, err
-		}
+	if err := removeCryptoKeys(result["keys"]); err != nil {
+		return nil, err
 	}
 
 	return result, nil
 }
 
 func removeServiceCredentials(x interface{}) error {
-
 	switch x := x.(type) {
+	case nil:
+		return nil
 	case []interface{}:
 		for _, v := range x {
 			err := removeKey(v, "credentials")
@@ -196,8 +218,9 @@ func removeServiceCredentials(x interface{}) error {
 }
 
 func removeCryptoKeys(x interface{}) error {
-
 	switch x := x.(type) {
+	case nil:
+		return nil
 	case map[string]interface{}:
 		for _, v := range x {
 			err := removeKey(v, "key", "private_key")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -377,3 +377,36 @@ func TestActiveConfig(t *testing.T) {
 	}
 
 }
+
+func TestExtraConfigFieldsRoundtrip(t *testing.T) {
+	raw := []byte(`
+decision_logger:
+  console: true
+foo: baz
+bar:
+  really: yes!`)
+	conf, err := ParseConfig(raw, "id")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	actual, err := conf.ActiveConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := map[string]any{
+		"foo":                            "baz",
+		"bar":                            map[string]any{"really": "yes!"},
+		"decision_logger":                map[string]any{"console": true},
+		"default_authorization_decision": "/system/authz/allow",
+		"default_decision":               "/system/main",
+		"labels": map[string]any{
+			"id":      "id",
+			"version": version.Version,
+		},
+	}
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("want %v got %v", expected, actual)
+	}
+}


### PR DESCRIPTION
Previously, extra keys in the OPA config file would be ignored in the /v1/config API, but included when evaluating `opa.runtime().config`.

With this change, they'll be collected into the Extra field, and included in the response of an API call to `/v1/config`, too.

## 👣 Trying out the change

Put this file on disk,
```yaml
# foo.yml
foo: bar
baz:
  quz: 100
decision_logger:
  console: true
```
and start OPA via `opa run -a 127.0.0.1:8181 -c foo.yml -s`.

### OPA 0.53.1

```interactive
$ curl "http://127.0.0.1:8181/v1/config?pretty"            
{
  "result": {
    "default_authorization_decision": "/system/authz/allow",
    "default_decision": "/system/main",
    "labels": {
      "id": "617ef51a-5f78-42ec-ba04-d7ca758c307f",
      "version": "0.53.1"
    }
  }
}
$ curl "http://127.0.0.1:8181/v1/query?pretty" -d '{"query": "x = opa.runtime().config"}'
{
  "result": [
    {
      "x": {
        "baz": {
          "quz": 100
        },
        "decision_logger": {
          "console": true
        },
        "foo": "bar"
      }
    }
  ]
}
```

### This PR

```interactive
$ curl "http://127.0.0.1:8181/v1/config?pretty"
{
  "result": {
    "baz": {
      "quz": 100
    },
    "decision_logger": {
      "console": true
    },
    "default_authorization_decision": "/system/authz/allow",
    "default_decision": "/system/main",
    "foo": "bar",
    "labels": {
      "id": "4f8394a8-2157-4d5e-a000-07eb6b7abe19",
      "version": "0.54.0-dev"
    }
  }
}
$ curl "http://127.0.0.1:8181/v1/query?pretty" -d '{"query": "x = opa.runtime().config"}'
{
  "result": [
    {
      "x": {
        "baz": {
          "quz": 100
        },
        "decision_logger": {
          "console": true
        },
        "foo": "bar"
      }
    }
  ]
}
```