### PR TITLE
build: use -bullseye golang image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ TELEMETRY_URL ?= #Default empty
 
 BUILD_HOSTNAME := $(shell ./build/get-build-hostname.sh)
 
-RELEASE_BUILD_IMAGE := golang:$(GOVERSION)
+RELEASE_BUILD_IMAGE := golang:$(GOVERSION)-bullseye
 
 RELEASE_DIR ?= _release/$(VERSION)
 
@@ -249,7 +249,7 @@ CI_GOLANG_DOCKER_MAKE := $(DOCKER) run \
 	-e WASM_ENABLED=$(WASM_ENABLED) \
 	-e FUZZ_TIME=$(FUZZ_TIME) \
 	-e TELEMETRY_URL=$(TELEMETRY_URL) \
-	golang:$(GOVERSION)
+	$(RELEASE_BUILD_IMAGE)
 
 .PHONY: ci-go-%
 ci-go-%: generate
@@ -486,7 +486,7 @@ check-go-module:
 	  -v $(PWD):/src:Z \
 	  -e 'GOPRIVATE=*' \
 	  --tmpfs /src/.go \
-	  golang:$(GOVERSION) \
+	  $(RELEASE_BUILD_IMAGE) \
 	  /bin/bash -c "git config --system --add safe.directory /src && go mod vendor -v"
 
 ######################################################


### PR DESCRIPTION
[See this](https://github.com/docker-library/golang/issues/466), bumping the golang image used for building our release binaries changed our glibc lowest-possible-version inadvertently. This will turn that back.

At some point in the future, when a new debian release is out, the support for bullseye is going to be dropped, but we'll notice when trying to update Golang.