### PR TITLE
plugins/discovery: ensure discovery doesn't erase its own config

### DIFF
--- a/plugins/discovery/discovery.go
+++ b/plugins/discovery/discovery.go
@@ -412,6 +412,7 @@ func (c *Discovery) processBundle(ctx context.Context, b *bundleApi.Bundle) (*pl
 	// Note: We don't currently support changes to the discovery
 	// configuration. These changes are risky because errors would be
 	// unrecoverable (without keeping track of changes and rolling back...)
+	config.Discovery = c.manager.Config.Discovery
 
 	// check for updates to the discovery service
 	opts := cfg.ServiceOptions{

--- a/plugins/discovery/discovery_test.go
+++ b/plugins/discovery/discovery_test.go
@@ -275,7 +275,9 @@ func TestProcessBundleWithActiveConfig(t *testing.T) {
 			}
 		},
 		"default_authorization_decision": "baz/qux",
-		"default_decision": "bar/baz"}`, version.Version)
+		"default_decision": "bar/baz",
+		"discovery": {"name": "config"}
+	}`, version.Version)
 
 	var expected map[string]interface{}
 	if err := util.Unmarshal([]byte(expectedConfig), &expected); err != nil {
@@ -340,7 +342,9 @@ func TestProcessBundleWithActiveConfig(t *testing.T) {
 			}
 		},
 		"default_authorization_decision": "/system/authz/allow",
-		"default_decision": "/system/main"}`, version.Version)
+		"default_decision": "/system/main",
+		"discovery": {"name": "config"}
+	}`, version.Version)
 
 	var expected2 map[string]interface{}
 	if err := util.Unmarshal([]byte(expectedConfig2), &expected2); err != nil {
@@ -1348,7 +1352,7 @@ func TestReconfigureWithUpdates(t *testing.T) {
 		t.Fatalf("Unexpected error %v", err)
 	}
 
-	// check that not setting persistence_directory doesn't remove boot config
+	// check that omitting persistence_directory or discovery doesn't remove boot config
 	updatedBundle = makeDataBundle(13, `
 		{
 			"config": {}
@@ -1362,6 +1366,9 @@ func TestReconfigureWithUpdates(t *testing.T) {
 
 	if manager.Config.PersistenceDirectory == nil {
 		t.Fatal("Erased persistence directory configuration")
+	}
+	if manager.Config.Discovery == nil {
+		t.Fatal("Erased discovery plugin configuration")
 	}
 
 	// update persistence directory

--- a/sdk/opa_test.go
+++ b/sdk/opa_test.go
@@ -161,7 +161,8 @@ func TestHookOnConfigDiscovery(t *testing.T) {
 			"foo":     "baz",
 			"fox":     "quz",
 		},
-		Plugins: map[string]json.RawMessage{"test_plugin": json.RawMessage("{}")},
+		Plugins:   map[string]json.RawMessage{"test_plugin": json.RawMessage("{}")},
+		Discovery: json.RawMessage(`{"service":"disco", "resource": "disco.tar.gz"}`),
 	}
 	act := th1.c // doesn't matter which hook, they only mutate the config via its pointer
 	if diff := cmp.Diff(exp, act, cmpopts.IgnoreFields(config.Config{}, "DefaultDecision", "DefaultAuthorizationDecision")); diff != "" {


### PR DESCRIPTION
When the discovery plugin receives a a discovery bundle which omits the
discovery configuration, it deletes its own configuration from the
manager. In turn this means that `GET /v1/config` doesn't show the
configuration of the discovery plugin.

This change ensures that the plugin will never overwrite the discovery
configuration on the manager.

Signed-off-by: Benjamin Nørgaard <mail@blacksails.dev>
