### PR TITLE
Fix for the issue when OPA doesnot load tarball on cmd line as a bundle

### DIFF
--- a/plugins/plugins.go
+++ b/plugins/plugins.go
@@ -199,6 +199,7 @@ type Manager struct {
 	registeredNDCacheTriggers    []func(bool)
 	bootstrapConfigLabels        map[string]string
 	hooks                        hooks.Hooks
+	bundleLocationLocal          bool
 }
 
 type managerContextKey string
@@ -381,6 +382,14 @@ func WithDistributedTracingOpts(tr tracing.Options) func(*Manager) {
 func WithHooks(hs hooks.Hooks) func(*Manager) {
 	return func(m *Manager) {
 		m.hooks = hs
+	}
+}
+
+// WithBundleLocationLocal sets the property whether the bundle tar ball is locally loaded or not.
+// Will be true in command like opa run -s bundle.tar.gz where tarball is local on user machine
+func WithBundleLocationLocal(local bool) func(*Manager) {
+	return func(m *Manager) {
+		m.bundleLocationLocal = local
 	}
 }
 
@@ -980,4 +989,8 @@ func (m *Manager) RegisterNDCacheTrigger(trigger func(bool)) {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
 	m.registeredNDCacheTriggers = append(m.registeredNDCacheTriggers, trigger)
+}
+
+func (m *Manager) BundleLocationLocal() bool {
+	return m.bundleLocationLocal
 }


### PR DESCRIPTION
Fix for the issue so that when a tar ball is provided in the list of files in the args, it is always read as a bundle.

Fixes #5879

### What are the changes in this PR?
local property is set in Manager to expose whether the bundle is loaded locally
This is used in while loading the bundle

Output of run after the change. bundle.tar.gz is in my opa directory.

> go run main.go run -s bundle.tar.gz

{"addrs":[":8181"],"diagnostic-addrs":[],"level":"info","msg":"Initializing server. OPA is running on a public (0.0.0.0) network interface. Unless you intend to expose OPA outside of the host, binding to the localhost interface (--addr localhost:8181) is recommended. See https://www.openpolicyagent.org/docs/latest/security/#interface-binding","time":"2023-07-01T12:23:46-04:00"}
{"level":"info","msg":"Bundle loaded from disk and activated successfully.","name":"cli1","plugin":"bundle","time":"2023-07-01T12:23:46-04:00"}

last line was set Debug level, I just turned it to Info to get this output. I left it as Debug.

