### PR TITLE
compile: bundle roots can be provided by caller

### DIFF
--- a/compile/compile.go
+++ b/compile/compile.go
@@ -67,6 +67,7 @@ type Compiler struct {
 	filter                       loader.Filter              // filter to apply to file loader
 	paths                        []string                   // file paths to load. TODO(tsandall): add support for supplying readers for embedded users.
 	entrypoints                  orderedStringSet           // policy entrypoints required for optimization and certain targets
+	roots                        []string                   // optionally, bundle roots can be provided
 	useRegoAnnotationEntrypoints bool                       // allow compiler to late-bind entrypoints from annotated rules in policies.
 	optimizationLevel            int                        // how aggressive should optimization be
 	target                       string                     // target type (wasm, rego, etc.)
@@ -220,6 +221,12 @@ func (c *Compiler) WithCapabilities(capabilities *ast.Capabilities) *Compiler {
 // WithMetadata sets the additional data to be included in .manifest
 func (c *Compiler) WithMetadata(metadata *map[string]interface{}) *Compiler {
 	c.metadata = metadata
+	return c
+}
+
+// WithRoots sets the roots to include in the output bundle manifest.
+func (c *Compiler) WithRoots(r ...string) *Compiler {
+	c.roots = append(c.roots, r...)
 	return c
 }
 
@@ -453,11 +460,14 @@ func (c *Compiler) initBundle() error {
 		return nil
 	}
 
-	// TODO(tsandall): add support for controlling roots. Either the caller could
-	// supply them or the compiler could infer them based on the packages and data
-	// contents. The latter would require changes to the loader to preserve the
+	// TODO(tsandall): roots could be automatically inferred based on the packages and data
+	// contents. That would require changes to the loader to preserve the
 	// locations where base documents were mounted under data.
 	result := &bundle.Bundle{}
+	if len(c.roots) > 0 {
+		result.Manifest.Roots = &c.roots
+	}
+
 	result.Manifest.Init()
 	result.Data = load.Files.Documents
 

--- a/compile/compile_test.go
+++ b/compile/compile_test.go
@@ -1403,6 +1403,35 @@ func TestCompilerSetMetadata(t *testing.T) {
 	}
 }
 
+func TestCompilerSetRoots(t *testing.T) {
+	files := map[string]string{
+		"test.rego": `package test
+
+		import data.common
+
+		x = true`,
+	}
+
+	for _, useMemoryFS := range []bool{false, true} {
+		test.WithTestFS(files, useMemoryFS, func(root string, fsys fs.FS) {
+
+			compiler := New().
+				WithFS(fsys).
+				WithPaths(root).
+				WithRoots("test")
+
+			err := compiler.Build(context.Background())
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if len(*compiler.bundle.Manifest.Roots) != 1 || (*compiler.bundle.Manifest.Roots)[0] != "test" {
+				t.Fatal("expected roots to be set to ['test'] but got:", compiler.bundle.Manifest.Roots)
+			}
+		})
+	}
+}
+
 func TestCompilerOutput(t *testing.T) {
 	// NOTE(tsandall): must use format package here because the compiler formats.
 	files := map[string]string{


### PR DESCRIPTION

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->

### Why the changes in this PR are needed?

Previously, bundle roots couldn't be provided and neither .manifest file couldn't be provided, because it was replaced by the .manifest generated by the compiler. This will help to build bundles from using the Go library for more advanced use cases with multiple bundles.

<!--
Include a short description of WHY the changes were made.
-->

### What are the changes in this PR?

Added `WithRoots` option so caller can provide roots.
<!--
Include a short description of WHAT changes were made.
-->

### Notes to assist PR review:

<!--
Here you can add information you think will help the reviewer(s).
-->

### Further comments:

Fixes: #6085

<!--
Here you can include links to additional resources related to the changes, discuss your solution, other approaches you considered etc.
-->
