### PR TITLE
[cmd] Implement a rootless deprecation messages

### DIFF
--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -9,6 +9,8 @@ import (
 	"path"
 
 	"github.com/spf13/cobra"
+
+	"github.com/open-policy-agent/opa/cmd/internal/deprecation"
 )
 
 // RootCommand is the base CLI command that all subcommands are added to.
@@ -16,4 +18,15 @@ var RootCommand = &cobra.Command{
 	Use:   path.Base(os.Args[0]),
 	Short: "Open Policy Agent (OPA)",
 	Long:  "An open source project to policy-enable your service.",
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+
+		message, fatal := deprecation.CheckWarnings(os.Environ(), cmd.Use)
+		if message != "" {
+			cmd.PrintErr(message)
+			if fatal {
+				os.Exit(1)
+			}
+		}
+
+	},
 }

--- a/cmd/internal/deprecation/rootless.go
+++ b/cmd/internal/deprecation/rootless.go
@@ -1,0 +1,54 @@
+package deprecation
+
+// TODO: these warnings can be removed when the rootless images are no longer published.
+
+const rootlessWarningMessage = `OPA appears to be running in a deprecated -rootless image.
+Since v0.50.0, the default OPA images have been configured to use a non-root
+user.
+
+This image will soon cease to be updated. The following images should now be
+used instead:
+
+* openpolicyagent/opa:latest and NOT (openpolicyagent/opa:latest-rootless)
+* openpolicyagent/opa:edge and NOT (openpolicyagent/opa:edge-rootless)
+* openpolicyagent/opa:X.Y.Z and NOT (openpolicyagent/opa:X.Y.Z-rootless)
+
+You can choose to acknowledge and ignore this message by unsetting:
+OPA_DOCKER_IMAGE_TAG=rootless
+`
+
+// warningRootless is a fatal warning is triggered when the user is running OPA
+// in a deprecated rootless image.
+var warningRootless = warning{
+	MatchEnv: func(env []string) bool {
+		for _, e := range env {
+			if e == "OPA_DOCKER_IMAGE_TAG=rootless" {
+				return true
+			}
+		}
+		return false
+	},
+	MatchCommand: func(name string) bool {
+		return name != "run"
+	},
+	Fatal:   true,
+	Message: rootlessWarningMessage,
+}
+
+// warningRootlessRun is a non-fatal version of the warning reserved for opa run.
+// The warning for run is non-fatal to avoid production disruption
+var warningRootlessRun = warning{
+	MatchEnv: func(env []string) bool {
+		for _, e := range env {
+			if e == "OPA_DOCKER_IMAGE_TAG=rootless" {
+				return true
+			}
+		}
+		return false
+	},
+	MatchCommand: func(name string) bool {
+		return name == "run"
+	},
+	Fatal:   false,
+	Message: rootlessWarningMessage,
+}

--- a/cmd/internal/deprecation/warning.go
+++ b/cmd/internal/deprecation/warning.go
@@ -1,0 +1,92 @@
+package deprecation
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+)
+
+const width, border = 80, 3
+const titleChar, dividerChar = "#", "-"
+
+// warning is a struct which can be used to define deprecation warnings based on
+// the environment and command being run.
+type warning struct {
+	MatchEnv     func([]string) bool
+	MatchCommand func(string) bool
+	Fatal        bool
+	Message      string
+}
+
+// CheckWarnings runs messageForWarnings with a default set of real warnings.
+func CheckWarnings(env []string, command string) (string, bool) {
+	warnings := []warning{
+		warningRootless,
+		warningRootlessRun,
+	}
+
+	return messageForWarnings(warnings, env, command)
+}
+
+// messageForWarnings returns an obnoxious banner with the contents of all firing warnings.
+// If no warnings fire, it returns an empty string.
+// If any warnings are fatal, it returns true for the second return value.
+func messageForWarnings(warnings []warning, env []string, command string) (string, bool) {
+	var messages []string
+	var fatal bool
+
+	for _, w := range warnings {
+		if w.MatchEnv(env) && w.MatchCommand(command) {
+			messages = append(messages, w.Message)
+			if w.Fatal {
+				fatal = true
+			}
+		}
+	}
+
+	buf := bytes.NewBuffer(nil)
+
+	if len(messages) == 0 {
+		return "", false
+	}
+
+	title := "Deprecation Warnings"
+	if fatal {
+		title = "Fatal Deprecation Warnings"
+	}
+
+	printFormattedTitle(buf, title)
+
+	for i, msg := range messages {
+		fmt.Fprintln(buf, strings.TrimSpace(msg))
+		if i < len(messages)-1 {
+			printFormattedDivider(buf)
+		}
+	}
+
+	printFormattedTitle(buf, "end "+title)
+
+	return string(buf.Bytes()), fatal
+}
+
+func printFormattedTitle(out io.Writer, title string) {
+	padding := (width - len(title) - border*2) / 2
+
+	fmt.Fprintln(out, strings.Repeat(titleChar, width))
+	fmt.Fprintln(out,
+		strings.Join(
+			[]string{
+				strings.Repeat(titleChar, border),
+				strings.Repeat(" ", padding), strings.ToUpper(title), strings.Repeat(" ", padding),
+				strings.Repeat(titleChar, border),
+			},
+			"",
+		),
+	)
+	fmt.Fprintln(out, strings.Repeat(titleChar, width))
+}
+
+func printFormattedDivider(out io.Writer) {
+	fmt.Fprintln(out, strings.Repeat(dividerChar, width))
+}

--- a/cmd/internal/deprecation/warning.go
+++ b/cmd/internal/deprecation/warning.go
@@ -67,7 +67,7 @@ func messageForWarnings(warnings []warning, env []string, command string) (strin
 
 	printFormattedTitle(buf, "end "+title)
 
-	return string(buf.Bytes()), fatal
+	return buf.String(), fatal
 }
 
 func printFormattedTitle(out io.Writer, title string) {

--- a/cmd/internal/deprecation/warning_test.go
+++ b/cmd/internal/deprecation/warning_test.go
@@ -1,0 +1,163 @@
+package deprecation
+
+import (
+	"testing"
+)
+
+func TestMessageForWarnings(t *testing.T) {
+	testCases := map[string]struct {
+		Env             []string
+		Command         string
+		Warnings        []warning
+		ExpectedMessage string
+		ExpectedFatal   bool
+	}{
+		"warning that does not fire": {
+			Env:     []string{"OPA_FOOBAR=1"},
+			Command: "foobar",
+			Warnings: []warning{
+				{
+					MatchEnv: func(env []string) bool {
+						return false
+					},
+					MatchCommand: func(command string) bool {
+						return false
+					},
+					Fatal:   true,
+					Message: "fatal warning",
+				},
+			},
+			ExpectedFatal:   false,
+			ExpectedMessage: "",
+		},
+		"warning that fires": {
+			Env:     []string{"OPA_FOOBAR=1"},
+			Command: "foobar",
+			Warnings: []warning{
+				{
+					MatchEnv: func(env []string) bool {
+						for _, e := range env {
+							if e == "OPA_FOOBAR=1" {
+								return true
+							}
+						}
+						return false
+					},
+					MatchCommand: func(command string) bool {
+						return command == "foobar"
+					},
+					Fatal:   true,
+					Message: "fatal warning for foobar",
+				},
+			},
+			ExpectedMessage: `################################################################################
+###                        FATAL DEPRECATION WARNINGS                        ###
+################################################################################
+fatal warning for foobar
+################################################################################
+###                      END FATAL DEPRECATION WARNINGS                      ###
+################################################################################
+`,
+			ExpectedFatal: true,
+		},
+		"two warnings that fire, one fatally": {
+			Env:     []string{"OPA_FOOBAR=1"},
+			Command: "foobar",
+			Warnings: []warning{
+				{
+					MatchEnv: func(env []string) bool {
+						for _, e := range env {
+							if e == "OPA_FOOBAR=1" {
+								return true
+							}
+						}
+						return false
+					},
+					MatchCommand: func(command string) bool {
+						return command == "foobar"
+					},
+					Fatal:   true,
+					Message: "fatal warning for foobar",
+				},
+				{
+					MatchEnv: func(env []string) bool {
+						return true
+					},
+					MatchCommand: func(command string) bool {
+						return command == "foobar"
+					},
+					Fatal:   false,
+					Message: "non fatal warning for foobar",
+				},
+			},
+			ExpectedMessage: `################################################################################
+###                        FATAL DEPRECATION WARNINGS                        ###
+################################################################################
+fatal warning for foobar
+--------------------------------------------------------------------------------
+non fatal warning for foobar
+################################################################################
+###                      END FATAL DEPRECATION WARNINGS                      ###
+################################################################################
+`,
+			ExpectedFatal: true,
+		},
+		"two warnings that fire, neither fatally": {
+			Env:     []string{"OPA_FOOBAR=1"},
+			Command: "foobar",
+			Warnings: []warning{
+				{
+					MatchEnv: func(env []string) bool {
+						for _, e := range env {
+							if e == "OPA_FOOBAR=1" {
+								return true
+							}
+						}
+						return false
+					},
+					MatchCommand: func(command string) bool {
+						return command == "foobar"
+					},
+					Fatal:   false,
+					Message: "warning for foobar",
+				},
+				{
+					MatchEnv: func(env []string) bool {
+						return true
+					},
+					MatchCommand: func(command string) bool {
+						return command == "foobar"
+					},
+					Fatal:   false,
+					Message: "another warning for foobar",
+				},
+			},
+			ExpectedMessage: `################################################################################
+###                           DEPRECATION WARNINGS                           ###
+################################################################################
+warning for foobar
+--------------------------------------------------------------------------------
+another warning for foobar
+################################################################################
+###                         END DEPRECATION WARNINGS                         ###
+################################################################################
+`,
+			ExpectedFatal: false,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			message, fatal := messageForWarnings(tc.Warnings, tc.Env, tc.Command)
+
+			if fatal != tc.ExpectedFatal {
+				t.Errorf("Expected fatal to be %v but got %v", tc.ExpectedFatal, fatal)
+			}
+
+			if message != tc.ExpectedMessage {
+				t.Errorf("Expected message\n%s\nbut got\n%s", tc.ExpectedMessage, message)
+			}
+
+		})
+	}
+}

--- a/runtime/check_user_linux.go
+++ b/runtime/check_user_linux.go
@@ -5,7 +5,6 @@
 package runtime
 
 import (
-	"os"
 	"os/user"
 
 	"github.com/open-policy-agent/opa/logging"
@@ -20,10 +19,5 @@ func checkUserPrivileges(logger logging.Logger) {
 	} else if usr.Uid == "0" || usr.Gid == "0" {
 		message := "OPA running with uid or gid 0. Running OPA with root privileges is not recommended."
 		logger.Warn(message)
-	}
-
-	if os.Getenv("OPA_DOCKER_IMAGE_TAG") == "rootless" {
-		message := "The -rootless image tag will not be published after OPA v0.52.0."
-		logger.Error(message)
 	}
 }


### PR DESCRIPTION
I have added a system for showing fatal and non-fatal deprecation warnings. It's configurable by command and environment.

If we merge this PR, running a rootless image with any OPA command other than `opa run` will result in a fatal error and exit code 1.

It's possible for users to continue to use the image by unsetting: OPA_DOCKER_IMAGE_TAG=rootless.

`opa run` will show the message, but it's not fatal for this command. This is intended to avoid production disruption.


This PR has been added to allow us to one day do https://github.com/open-policy-agent/opa/pull/6086. It is a simpler version of my earlier PR for the same task https://github.com/open-policy-agent/opa/pull/5566.

Example showing how `opa build` will fail and exit with 1:

```
opa $ OPA_DOCKER_IMAGE_TAG=rootless go run main.go build
################################################################################
###                        FATAL DEPRECATION WARNINGS                        ###
################################################################################
OPA appears to be running in a deprecated -rootless image.
Since v0.50.0, the default OPA images have been configured to use a non-root
user.

This image will soon cease to be updated. The following images should now be
used instead:

* openpolicyagent/opa:latest and NOT (openpolicyagent/opa:latest-rootless)
* openpolicyagent/opa:edge and NOT (openpolicyagent/opa:edge-rootless)
* openpolicyagent/opa:X.Y.Z and NOT (openpolicyagent/opa:X.Y.Z-rootless)

You can choose to acknowledge and ignore this message by unsetting:
OPA_DOCKER_IMAGE_TAG=rootless
################################################################################
###                      END FATAL DEPRECATION WARNINGS                      ###
################################################################################
exit status 1
```

Example showing how `opa run` will continue as normal, after showing the message.

```
$ OPA_DOCKER_IMAGE_TAG=rootless go run main.go run -s
################################################################################
###                           DEPRECATION WARNINGS                           ###
################################################################################
OPA appears to be running in a deprecated -rootless image.
Since v0.50.0, the default OPA images have been configured to use a non-root
user.

This image will soon cease to be updated. The following images should now be
used instead:

* openpolicyagent/opa:latest and NOT (openpolicyagent/opa:latest-rootless)
* openpolicyagent/opa:edge and NOT (openpolicyagent/opa:edge-rootless)
* openpolicyagent/opa:X.Y.Z and NOT (openpolicyagent/opa:X.Y.Z-rootless)

You can choose to acknowledge and ignore this message by unsetting:
OPA_DOCKER_IMAGE_TAG=rootless
################################################################################
###                         END DEPRECATION WARNINGS                         ###
################################################################################
{"addrs":[":8181"],"diagnostic-addrs":[],"level":"info","msg":"Initializing server. OPA is running on a public (0.0.0.0) network interface. Unless you intend to expose OPA outside of the host, binding to the localhost interface (--addr localhost:8181) is recommended. See https://www.openpolicyagent.org/docs/latest/security/#interface-binding","time":"2023-07-13T14:24:07+01:00"}
```