### PR TITLE
topdown: Honor default keyword on functions

### DIFF
--- a/ast/parser_test.go
+++ b/ast/parser_test.go
@@ -1611,6 +1611,14 @@ func TestRule(t *testing.T) {
 	assertParseErrorContains(t, "default invalid rule head builtin call", `default a = upper("foo")`, "illegal default rule (value cannot contain call)")
 	assertParseErrorContains(t, "default invalid rule head call", `default a = b`, "illegal default rule (value cannot contain var)")
 
+	assertParseErrorContains(t, "default invalid function head ref", `default f(x) = b.c.d`, "illegal default rule (value cannot contain ref)")
+	assertParseErrorContains(t, "default invalid function head call", `default f(x) = g(x)`, "illegal default rule (value cannot contain call)")
+	assertParseErrorContains(t, "default invalid function head builtin call", `default f(x) = upper("foo")`, "illegal default rule (value cannot contain call)")
+	assertParseErrorContains(t, "default invalid function head call", `default f(x) = b`, "illegal default rule (value cannot contain var)")
+	assertParseErrorContains(t, "default invalid function composite argument", `default f([x]) = 1`, "illegal default rule (arguments cannot contain array)")
+	assertParseErrorContains(t, "default invalid function number argument", `default f(1) = 1`, "illegal default rule (arguments cannot contain number)")
+	assertParseErrorContains(t, "default invalid function repeated vars", `default f(x, x) = 1`, "illegal default rule (arguments cannot be repeated x)")
+
 	assertParseError(t, "extra braces", `{ a := 1 }`)
 	assertParseError(t, "invalid rule name hyphen", `a-b = x { x := 1 }`)
 

--- a/internal/wasm/sdk/test/e2e/exceptions.yaml
+++ b/internal/wasm/sdk/test/e2e/exceptions.yaml
@@ -1,5 +1,4 @@
 # Exception Format is <test name>: <reason>
-"functions/default": "not supported in topdown, https://github.com/open-policy-agent/opa/issues/2445"
 "data/toplevel integer": "https://github.com/open-policy-agent/opa/issues/3711"
 "data/nested integer": "https://github.com/open-policy-agent/opa/issues/3711"
 "withkeyword/function: indirect call, arity 1, replacement is value that needs eval (array comprehension)": "https://github.com/open-policy-agent/opa/issues/5311"

--- a/test/cases/testdata/defaultkeyword/test-default-functions.yaml
+++ b/test/cases/testdata/defaultkeyword/test-default-functions.yaml
@@ -1,5 +1,3 @@
-# NOTE(sr): default functions are not supported, but they had sneaked into
-# the full extent of a package. These cases assert that this won't happen.
 cases:
 - note: defaultkeyword/function with var arg
   modules:
@@ -10,24 +8,32 @@ cases:
   query: data.test = x
   want_result:
   - x: {}
-- note: defaultkeyword/function with ground arg
+- note: defaultkeyword/function with var arg, ref head
   modules:
   - |
     package test
 
-    default f(10) := 100
-  query: data.test = x
-  want_result:
-  - x: {}
-- note: defaultkeyword/function with ground arg, ref head
-  modules:
-  - |
-    package test
-
-    default p.q.r.f(10) := 100
+    default p.q.r.f(x) := 100
   query: data.test = x
   want_result:
   - x:
       p:
         q:
           r: {}
+- note: defaultkeyword/function with var arg, ref head query
+  modules:
+    - |
+      package test
+
+      default p.q.r.f(x) := 100
+
+      p.q.r.f(x) = x {
+        x == 2
+      }
+
+      foo {
+        p.q.r.f(3) == 100
+      }
+  query: data.test.foo = x
+  want_result:
+    - x: true

--- a/test/cases/testdata/functions/test-functions-default.yaml
+++ b/test/cases/testdata/functions/test-functions-default.yaml
@@ -1,21 +1,99 @@
 cases:
 - data:
   modules:
-  - |
-    package p.m
+    - |
+      package test
 
-    default hello = false
+      default f(x) = 1
 
-    hello() = m {
-      m = input.message
-      1 == 2
-      m = "world"
-    }
-    h = m {
-      m = hello()
-    }
-  note: functions/default # not supported but shouldn't panic
-  query: data.p.m = x
+      f(x) = x {
+        x > 0
+      }
+
+      p {
+        f(-1) == 1
+      }
+
+  note: functions/default
+  query: data.test.p = x
   want_result:
-  - x:
-      hello: false
+    - x: true
+
+- data:
+  modules:
+    - |
+      package test
+
+      default f(x) = 1
+
+      f(x) = x {
+        x > 0
+      }
+
+      p {
+        f(2) == 2
+      }
+
+  note: functions/non default
+  query: data.test.p = x
+  want_result:
+    - x: true
+
+- data:
+  modules:
+    - |
+      package test
+
+      default f(x) = 1
+
+      p {
+        f(2) == 1
+      }
+
+  note: functions/only default
+  query: data.test.p = x
+  want_result:
+    - x: true
+
+- data:
+  modules:
+    - |
+      package test
+
+      default f(_, _) = 1
+
+      f(x, y) = x {
+        x == y
+      }
+
+      p {
+        f(2, 2) == 2
+      }
+
+  note: functions/wildcard args
+  query: data.test.p = x
+  want_result:
+    - x: true
+
+- data:
+  modules:
+    - |
+      package test
+
+      default f(x) = 1000
+
+      f(x) = x {
+        x > 0
+      }
+
+      p = xs {
+        xs := [y | x = [1, -2, 3][_]; y := f(x)]
+      }
+
+  note: functions/comprehensions
+  query: data.test.p = x
+  want_result:
+    - x:
+        - 1
+        - 1000
+        - 3


### PR DESCRIPTION
Default functions satisfy the following properties:

* Same arity as other functions with the same name
* Arguments should only be plain variables ie. no composite values. For ex, default f([x]) = 1 is an invalid default function
* Variable names should not be repeated ie. default f(x, x) = 1 is an invalid default function

Fixes: https://github.com/open-policy-agent/opa/issues/2445

