### PR TITLE
Add option for specifying decision ID to SDK

### DIFF
--- a/sdk/opa.go
+++ b/sdk/opa.go
@@ -239,7 +239,7 @@ func (opa *OPA) Decision(ctx context.Context, options DecisionOptions) (*Decisio
 		Input:          &options.Input,
 		NDBuiltinCache: &options.NDBCache,
 		Metrics:        options.Metrics,
-		DecisionID:		options.DecisionID,
+		DecisionID:     options.DecisionID,
 	}
 
 	// Only use non-deterministic builtins cache if it's available.
@@ -295,7 +295,7 @@ type DecisionOptions struct {
 	Metrics             metrics.Metrics     // specifies the metrics to use for preparing and evaluation, optional
 	Profiler            topdown.QueryTracer // specifies the profiler to use, optional
 	Instrument          bool                // if true, instrumentation will be enabled
-	DecisionID			string				// the identifier for this decision; if not set, a globally unique identifier will be generated
+	DecisionID          string              // the identifier for this decision; if not set, a globally unique identifier will be generated
 }
 
 // DecisionResult contains the output of query evaluation.
@@ -371,10 +371,10 @@ func (opa *OPA) Partial(ctx context.Context, options PartialOptions) (*PartialRe
 	}
 
 	record := server.Info{
-		Timestamp: options.Now,
-		Input:     &options.Input,
-		Query:     options.Query,
-		Metrics:   options.Metrics,
+		Timestamp:  options.Now,
+		Input:      &options.Input,
+		Query:      options.Query,
+		Metrics:    options.Metrics,
 		DecisionID: options.DecisionID,
 	}
 
@@ -445,7 +445,7 @@ type PartialOptions struct {
 	Metrics             metrics.Metrics     // specifies the metrics to use for preparing and evaluation, optional
 	Profiler            topdown.QueryTracer // specifies the profiler to use, optional
 	Instrument          bool                // if true, instrumentation will be enabled
-	DecisionID			string				// the identifier for this decision; if not set, a globally unique identifier will be generated
+	DecisionID          string              // the identifier for this decision; if not set, a globally unique identifier will be generated
 }
 
 type PartialResult struct {

--- a/sdk/opa.go
+++ b/sdk/opa.go
@@ -239,6 +239,7 @@ func (opa *OPA) Decision(ctx context.Context, options DecisionOptions) (*Decisio
 		Input:          &options.Input,
 		NDBuiltinCache: &options.NDBCache,
 		Metrics:        options.Metrics,
+		DecisionID:		options.DecisionID,
 	}
 
 	// Only use non-deterministic builtins cache if it's available.
@@ -294,22 +295,14 @@ type DecisionOptions struct {
 	Metrics             metrics.Metrics     // specifies the metrics to use for preparing and evaluation, optional
 	Profiler            topdown.QueryTracer // specifies the profiler to use, optional
 	Instrument          bool                // if true, instrumentation will be enabled
+	DecisionID			string				// the identifier for this decision; if not set, a globally unique identifier will be generated
 }
 
 // DecisionResult contains the output of query evaluation.
 type DecisionResult struct {
-	ID         string             // provides a globally unique identifier for this decision (which is included in the decision log.)
+	ID         string             // provides the identifier for this decision (which is included in the decision log.)
 	Result     interface{}        // provides the output of query evaluation.
 	Provenance types.ProvenanceV1 // wraps the bundle build/version information
-}
-
-func newDecisionResult() (*DecisionResult, error) {
-	id, err := uuid.New(rand.Reader)
-	if err != nil {
-		return nil, err
-	}
-	result := &DecisionResult{ID: id}
-	return result, nil
 }
 
 func (opa *OPA) executeTransaction(ctx context.Context, record *server.Info, work func(state, *DecisionResult)) (*DecisionResult, error) {
@@ -318,16 +311,19 @@ func (opa *OPA) executeTransaction(ctx context.Context, record *server.Info, wor
 	}
 	record.Metrics.Timer(metrics.SDKDecisionEval).Start()
 
-	result, err := newDecisionResult()
-	if err != nil {
-		return nil, err
+	if record.DecisionID == "" {
+		id, err := uuid.New(rand.Reader)
+		if err != nil {
+			return nil, err
+		}
+		record.DecisionID = id
 	}
+
+	result := &DecisionResult{ID: record.DecisionID}
 
 	opa.mtx.Lock()
 	s := *opa.state
 	opa.mtx.Unlock()
-
-	record.DecisionID = result.ID
 
 	if record.Timestamp.IsZero() {
 		record.Timestamp = time.Now().UTC()
@@ -379,6 +375,7 @@ func (opa *OPA) Partial(ctx context.Context, options PartialOptions) (*PartialRe
 		Input:     &options.Input,
 		Query:     options.Query,
 		Metrics:   options.Metrics,
+		DecisionID: options.DecisionID,
 	}
 
 	var provenance types.ProvenanceV1
@@ -448,6 +445,7 @@ type PartialOptions struct {
 	Metrics             metrics.Metrics     // specifies the metrics to use for preparing and evaluation, optional
 	Profiler            topdown.QueryTracer // specifies the profiler to use, optional
 	Instrument          bool                // if true, instrumentation will be enabled
+	DecisionID			string				// the identifier for this decision; if not set, a globally unique identifier will be generated
 }
 
 type PartialResult struct {

--- a/sdk/opa_test.go
+++ b/sdk/opa_test.go
@@ -784,7 +784,7 @@ main = time.now_ns()
 	}
 
 	if _, err := opa.Decision(ctx, sdk.DecisionOptions{
-		Now: time.Unix(0, 1619868194450288000).UTC(),
+		Now:        time.Unix(0, 1619868194450288000).UTC(),
 		DecisionID: "164031de-e511-11ec-8fea-0242ac120002",
 	}); err != nil {
 		t.Fatal(err)
@@ -1358,11 +1358,11 @@ allow {
 	}
 
 	if result, err := opa.Partial(ctx, sdk.PartialOptions{
-		Input:    map[string]int{"y": 2},
-		Query:    "data.test.allow = true",
-		Unknowns: []string{"data.junk.x"},
-		Mapper:   &sdk.RawMapper{},
-		Now:      time.Unix(0, 1619868194450288000).UTC(),
+		Input:      map[string]int{"y": 2},
+		Query:      "data.test.allow = true",
+		Unknowns:   []string{"data.junk.x"},
+		Mapper:     &sdk.RawMapper{},
+		Now:        time.Unix(0, 1619868194450288000).UTC(),
 		DecisionID: "164031de-e511-11ec-8fea-0242ac120002",
 	}); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->

### Why the changes in this PR are needed?

This allows clients to specify the decision ID for the decisions
returned by the `Decision` and `Partial` functions provided by the SDK
package. If not provided, a uniquely generated identifier will be
generated for the decision, just as before.

This option can be useful for clients that have already generated a
decision ID prior to calling OPA. It would then be convenient to pass
that decision ID through to OPA so decision logs use that same ID.

### What are the changes in this PR?

The `sdk.DecisionOptions` and `sdk.PartialOptions` structs now accept a 
`DecisionID` that clients can use to specify their own decision ID.

### Notes to assist PR review:

<!--
Here you can add information you think will help the reviewer(s).
-->

### Further comments:

<!--
Here you can include links to additional resources related to the changes, discuss your solution, other approaches you considered etc.
-->
