### PR TITLE
cmd: adds a discard subcommand for format to discard the result Fixes…

### DIFF
--- a/cmd/eval.go
+++ b/cmd/eval.go
@@ -82,6 +82,7 @@ func newEvalCommandParams() evalCommandParams {
 			evalPrettyOutput,
 			evalSourceOutput,
 			evalRawOutput,
+			evalDiscardOutput,
 		}),
 		explain:         newExplainFlag([]string{explainModeOff, explainModeFull, explainModeNotes, explainModeFails, explainModeDebug}),
 		target:          util.NewEnumFlag(compile.TargetRego, []string{compile.TargetRego, compile.TargetWasm}),
@@ -142,6 +143,7 @@ const (
 	evalPrettyOutput   = "pretty"
 	evalSourceOutput   = "source"
 	evalRawOutput      = "raw"
+	evalDiscardOutput  = "discard"
 
 	// number of profile results to return by default
 	defaultProfileLimit = 10
@@ -232,6 +234,7 @@ Set the output format with the --format flag.
     --format=pretty    : output query results in a human-readable format
     --format=source    : output partial evaluation results in a source format
     --format=raw       : output the values from query results in a scripting friendly format
+	--format=discard   : output the result field as "discarded" when non-nil
 
 Schema
 ------
@@ -394,6 +397,8 @@ func eval(args []string, params evalCommandParams, w io.Writer) (bool, error) {
 		err = pr.Source(w, result)
 	case evalRawOutput:
 		err = pr.Raw(w, result)
+	case evalDiscardOutput:
+		err = pr.Discard(w, result)
 	default:
 		err = pr.JSON(w, result)
 	}

--- a/cmd/eval_test.go
+++ b/cmd/eval_test.go
@@ -1312,6 +1312,116 @@ time.clock(input.y, time.clock(input.x))
 	}
 }
 
+func TestEvalDiscardOutput(t *testing.T) {
+	tests := map[string]struct {
+		query, format, expected string
+		params                  evalCommandParams
+	}{
+		"success example": {
+			query: "1*2+3",
+			params: func() evalCommandParams {
+				params := newEvalCommandParams()
+				err := params.outputFormat.Set(evalDiscardOutput)
+				if err != nil {
+					t.Fatalf("unexpected error: %s", err)
+				}
+				return params
+			}(),
+			expected: `{
+  "result": "discarded"
+}
+`},
+		"error example": {
+			query: "1/0",
+			params: func() evalCommandParams {
+				params := newEvalCommandParams()
+				err := params.outputFormat.Set(evalDiscardOutput)
+				if err != nil {
+					t.Fatalf("unexpected error: %s", err)
+				}
+				return params
+			}(),
+			expected: `{}
+`},
+		"error example show built-in-errors": {
+			query: "1/0",
+			params: func() evalCommandParams {
+				params := newEvalCommandParams()
+				err := params.outputFormat.Set(evalDiscardOutput)
+				if err != nil {
+					t.Fatalf("unexpected error: %s", err)
+				}
+				params.showBuiltinErrors = true
+				return params
+			}(),
+			expected: `{
+  "errors": [
+    {
+      "code": "eval_builtin_error",
+      "location": {
+        "col": 1,
+        "file": "",
+        "row": 1
+      },
+      "message": "div: divide by zero"
+    }
+  ]
+}
+`},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			var buf bytes.Buffer
+			_, err := eval([]string{tc.query}, tc.params, &buf)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			if actual := buf.String(); actual != tc.expected {
+				t.Errorf("expected output %q\ngot %q", tc.expected, actual)
+			}
+		})
+	}
+}
+
+func TestEvalDiscardProfilerOutput(t *testing.T) {
+	params := newEvalCommandParams()
+	err := params.outputFormat.Set(evalDiscardOutput)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	params.profile = true
+
+	query := "1*2+3"
+
+	var buf bytes.Buffer
+	_, err = eval([]string{query}, params, &buf)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	var output map[string]interface{}
+	if err := util.NewJSONDecoder(&buf).Decode(&output); err != nil {
+		t.Fatal(err)
+	}
+
+	// assert that the result is set to discarded
+	result, ok := output["result"].(string)
+	if !ok {
+		t.Fatal("error extracting result as string from output")
+	}
+
+	if result != "discarded" {
+		t.Fatal("Expected result field to be set to 'discarded'")
+	}
+
+	// assert that profile is still set
+	_, ok = output["profile"]
+	if !ok {
+		t.Fatal("error in parsing profile output")
+	}
+}
+
 func TestPolicyWithStrictFlag(t *testing.T) {
 	testsShouldError := []struct {
 		note            string

--- a/internal/presentation/presentation.go
+++ b/internal/presentation/presentation.go
@@ -399,6 +399,28 @@ func Raw(w io.Writer, r Output) error {
 	return nil
 }
 
+func Discard(w io.Writer, x interface{}) error {
+	encoder := json.NewEncoder(w)
+	encoder.SetIndent("", "  ")
+	field, ok := x.(Output)
+	if !ok {
+		return fmt.Errorf("error in converting interface to type Output")
+	}
+	bs, err := json.Marshal(field)
+	if err != nil {
+		return err
+	}
+	var rawData map[string]interface{}
+	err = json.Unmarshal(bs, &rawData)
+	if err != nil {
+		return err
+	}
+	if rawData["result"] != nil {
+		rawData["result"] = "discarded"
+	}
+	return encoder.Encode(rawData)
+}
+
 func prettyError(w io.Writer, errs OutputErrors) error {
 	_, err := fmt.Fprintln(w, errs)
 	return err


### PR DESCRIPTION
<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->

### Why the changes in this PR are needed?
fixes #5863 
<!--
Include a short description of WHY the changes were made.
-->

### What are the changes in this PR?
adds a subcommand for `format` which will discard the result
<!--
Include a short description of WHAT changes were made.
-->

### Notes to assist PR review:

<!--
Here you can add information you think will help the reviewer(s).
-->

### Further comments:

<!--
Here you can include links to additional resources related to the changes, discuss your solution, other approaches you considered etc.
-->
