### PR TITLE
[docs] Fix bug for broken ecosystem links

### DIFF
--- a/docs/website/layouts/docs/ecosystem-single.html.html
+++ b/docs/website/layouts/docs/ecosystem-single.html.html
@@ -22,7 +22,8 @@
   {{ if (gt (len $selectedIntegrations) 0) }}
     <p>Integrations are ordered by the amount of linked content.</p>
     {{ $sortedIntegrations := partial "functions/sort-integrations" (dict "integrations" $selectedIntegrations) }}
-    {{ partial "ecosystem-project-list-for-feature" (dict "selectedIntegrations" $sortedIntegrations "integrationsData" $.Site.Data.integrations "feature" $feature) }}
+    {{ $base := delimit (first 3 (split .Page.RelPermalink "/")) "/" }}
+    {{ partial "ecosystem-project-list-for-feature" (dict "selectedIntegrations" $sortedIntegrations "integrationsData" $.Site.Data.integrations "feature" $feature "base" $base) }}
   {{ else }}
     <p>There are no integrations for this category.</p>
   {{ end }}

--- a/docs/website/layouts/partials/ecosystem-project-list-for-feature.html
+++ b/docs/website/layouts/partials/ecosystem-project-list-for-feature.html
@@ -1,6 +1,7 @@
 {{ $selectedIntegrations := (index . "selectedIntegrations") }}
 {{ $integrationsData := (index . "integrationsData") }}
 {{ $feature := (index . "feature") }}
+{{ $base := (index . "base") }}
 
 <div class="ecosystem-list">
 {{ range $name := $selectedIntegrations }}
@@ -34,8 +35,12 @@
   <div class="ecosystem-list-item-content">
     {{ (index (index $integration.docs_features $feature) "note") | markdownify }}
   </div>
-  <a class="ecosystem-list-item-footer" href="../#{{ $name }}-detail">
-    View on the OPA Ecosystem page
+  <a class="ecosystem-list-item-footer" href="{{ $base }}/ecosystem/#{{ $name }}-detail">
+    {{ if lt (len $integration.title) 30 }}
+      View {{ $integration.title }} in Ecosystem
+    {{ else }}
+      View in Ecosystem
+    {{ end }}
   </a>
 </div>
 {{ end }}

--- a/docs/website/layouts/shortcodes/ecosystem_feature_embed.html
+++ b/docs/website/layouts/shortcodes/ecosystem_feature_embed.html
@@ -1,8 +1,8 @@
 {{ $feature := .Get "key" }}
 {{ $selectedIntegrations := partial "functions/select-integrations-by-docs-feature" (dict "integrations" $.Site.Data.integrations.integrations "feature" $feature) }}
 
+{{ $base := delimit (first 3 (split .Page.RelPermalink "/")) "/" }}
 {{ if (gt (len $selectedIntegrations) 6) }}
-  {{ $base := delimit (first 3 (split .Page.RelPermalink "/")) "/" }}
   <p>
     The {{ len $selectedIntegrations }} ecosystem projects related to this page
     can be found in the corresponding <a href="{{ $base }}/ecosystem/{{ $feature }}">OPA Ecosystem section</a>.
@@ -14,9 +14,8 @@
   </p>
 
   {{ $sortedIntegrations := partial "functions/sort-integrations" (dict "integrations" $selectedIntegrations) }}
-  {{ partial "ecosystem-project-list-for-feature" (dict "selectedIntegrations" $sortedIntegrations "integrationsData" $.Site.Data.integrations "feature" $feature) }}
+  {{ partial "ecosystem-project-list-for-feature" (dict "selectedIntegrations" $sortedIntegrations "integrationsData" $.Site.Data.integrations "feature" $feature "base" $base) }}
 
-  {{ $base := delimit (first 3 (split .Page.RelPermalink "/")) "/" }}
   <p class="mt-4">
     View these projects in the <a href="{{ $base }}/ecosystem/{{ $feature }}">OPA Ecosystem</a>.
   </p>


### PR DESCRIPTION
Reproduce Bug:

* Visit: https://www.openpolicyagent.org/docs/edge/policy-language/#ecosystem-projects
* Click `view on the OPA ecosystem page`

I have also tried to use the titles from items in links when the titles are short enough.

Some photos to show the changed titles. Note that some show default text, and shorter titled items use the title in link. This should make the linked pages better detected in search engines.

* <img width="969" alt="Screenshot 2023-07-20 at 17 42 24" src="https://github.com/open-policy-agent/opa/assets/1774239/700c2fd8-6969-4d7a-befe-bd951204c53c">
* <img width="963" alt="Screenshot 2023-07-20 at 17 42 52" src="https://github.com/open-policy-agent/opa/assets/1774239/f571405b-0f00-477a-860c-3f203eca7d43">
