### PR TITLE
Fix for the issue when OPA doesnot load tarball on cmd line as a bundle.

### DIFF
--- a/internal/runtime/init/init.go
+++ b/internal/runtime/init/init.go
@@ -127,10 +127,16 @@ func LoadPaths(paths []string,
 		caps = ast.CapabilitiesForThisVersion()
 	}
 
+	// tar.gz files are automatically loaded as bundles
+	var likelyBundles, nonBundlePaths []string
+	if !asBundle {
+		likelyBundles, nonBundlePaths = splitByTarGzExt(paths)
+		paths = likelyBundles
+	}
+
 	var result LoadPathsResult
 	var err error
-
-	if asBundle {
+	if asBundle || len(likelyBundles) > 0 {
 		result.Bundles = make(map[string]*bundle.Bundle, len(paths))
 		for _, path := range paths {
 			result.Bundles[path], err = loader.NewFileLoader().
@@ -145,6 +151,9 @@ func LoadPaths(paths []string,
 				return nil, err
 			}
 		}
+	}
+
+	if len(nonBundlePaths) == 0 {
 		return &result, nil
 	}
 
@@ -152,7 +161,8 @@ func LoadPaths(paths []string,
 		WithFS(fsys).
 		WithProcessAnnotation(processAnnotations).
 		WithCapabilities(caps).
-		Filtered(paths, filter)
+		Filtered(nonBundlePaths, filter)
+
 	if err != nil {
 		return nil, err
 	}
@@ -160,6 +170,19 @@ func LoadPaths(paths []string,
 	result.Files = *files
 
 	return &result, nil
+}
+
+// splitByTarGzExt splits the paths in 2 groups. Ones with .tar.gz and another with
+// non .tar.gz extensions.
+func splitByTarGzExt(paths []string) (targzs []string, nonTargzs []string) {
+	for _, path := range paths {
+		if strings.HasSuffix(path, ".tar.gz") {
+			targzs = append(targzs, path)
+		} else {
+			nonTargzs = append(nonTargzs, path)
+		}
+	}
+	return
 }
 
 // WalkPaths reads data and policy from the given paths and returns a set of bundle directory loaders


### PR DESCRIPTION
Fixes #5879



### Why the changes in this PR are needed?
This is fix to read tarball provided on cmd line as a bundle. It will be applied when OPA started with -s flag


### What are the changes in this PR?
ServerMode bool field is added to runtime parameters
This and BundleMode value is used to pass true value of BundleMode in LoadPaths method in init package. 


### Test cases I ran and all was successful. 
After running each command, I checked the value at http://localhost:8181/v1/data and they were correct after each run.

go run main.go run  -s -b bundle2.tar.gz bundle3.tar.gz  pass
go run main.go run  -s bundle2.tar.gz bundle3.tar.gz         pass
go run main.go run  -s bundle2.tar.gz bundle3.tar.gz bundle4.tar.gz  pass
go run main.go run  -s -b bundle2.tar.gz bundle3.tar.gz -b bundle_test pass
go run main.go run  -s bundle2.tar.gz bundle3.tar.gz -b bundle_test pass
go run main.go run  -s -b bundle2.tar.gz bundle3.tar.gz http://localhost:8080/bundle4.tar.gz pass
go run main.go run  -s bundle2.tar.gz bundle3.tar.gz http://localhost:8080/bundle4.tar.gz pass
go run main.go run  -s --config-file=config.yaml -b bundle2.tar.gz -b bundle_test http://localhost:8080/bundle4.tar.gz pass
go run main.go run  -s --config-file=config.yaml bundle2.tar.gz -b bundle_test http://localhost:8080/bundle4.tar.gz pass
go run main.go run  -s --config-file=config.yaml bundle2.tar.gz bundle_test http://localhost:8080/bundle4.tar.gz pass


### Notes to assist PR review:

<!--
Here you can add information you think will help the reviewer(s).
-->

### Further comments:

<!--
Here you can include links to additional resources related to the changes, discuss your solution, other approaches you considered etc.
-->
