### PR TITLE
fix(cli): make `opa test --exit-zero-on-skipped` fail with failing test rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Breaking changes
+
+Since its introduction in 0.34.0, the `--exit-zero-on-skipped` option always made the `opa test` command return an exit code 0. When used, it now returns the exit code 0 only if no failed tests were found.
+
+Test runs on existing projects using `--exit-zero-on-skipped` will fail if any failed tests were inhibited by this behavior.
+
+### Tooling, SDK, and Runtime
+
+- `opa test`: Fix `--exit-zero-on-skipped` behavior to make test runs fail with failing test rules ([#6126](https://github.com/open-policy-agent/opa/issues/6126)) reported and authored by @fdaguin
+
 ## 0.55.0
 
 > **_NOTES:_**

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -179,12 +179,10 @@ func runTests(ctx context.Context, txn storage.Transaction, runner *tester.Runne
 	go func() {
 		defer close(dup)
 		for tr := range ch {
-			if !tr.Pass() && !testParams.skipExitZero {
-				exitCode = 2
-			}
-			if tr.Skip && exitCode == 0 && testParams.skipExitZero {
-				// there is a skipped test, adding the flag -z exits 0 if there are no failures
-				exitCode = 0
+			if !tr.Pass() {
+				if !(tr.Skip && testParams.skipExitZero) {
+					exitCode = 2
+				}
 			}
 			tr.Trace = filterTrace(&testParams, tr.Trace)
 			dup <- tr


### PR DESCRIPTION
<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->

### Why the changes in this PR are needed?

<!--
Include a short description of WHY the changes were made.
-->

Closes #6126.

### What are the changes in this PR?

<!--
Include a short description of WHAT changes were made.
-->

- Fixes the failed logic introduced in https://github.com/open-policy-agent/opa/commit/54f203c3843b23474afd9990787a1affdcaa40c5 to compute the exit code of a test run
- Adds unit tests to cover this area

### Further comments:

<!--
Here you can include links to additional resources related to the changes, discuss your solution, other approaches you considered etc.
-->

I consider this is a BREAKING-CHANGE: all passing CIs that were launching `opa test --exit-zero-on-skipped` including both skipped and failed test rules will now break.
