### PR TITLE
[docs] Missing hint "future.keywords.if" for "Ordered (Else)"

### DIFF
--- a/docs/content/policy-reference.md
+++ b/docs/content/policy-reference.md
@@ -255,6 +255,7 @@ a_map[w] := z if { ... }
 ### Ordered (Else)
 
 ```live:rules/ordered:module:read_only
+# with `import future.keywords.if`
 default a := 1
 a := 5 if { ... }
 else := 10 if { ... }


### PR DESCRIPTION
Fixes #6134 

### What are the changes in this PR?
- Added a line to correctly run the [Ordered(Else)](https://www.openpolicyagent.org/docs/latest/policy-reference/#ordered-else) example.