### PR TITLE
Extend type checking for authz policies

### DIFF
--- a/bundle/store.go
+++ b/bundle/store.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/open-policy-agent/opa/ast"
+	iCompiler "github.com/open-policy-agent/opa/internal/compiler"
 	"github.com/open-policy-agent/opa/internal/json/patch"
 	"github.com/open-policy-agent/opa/metrics"
 	"github.com/open-policy-agent/opa/storage"
@@ -291,14 +292,15 @@ func readEtagFromStore(ctx context.Context, store storage.Store, txn storage.Tra
 
 // ActivateOpts defines options for the Activate API call.
 type ActivateOpts struct {
-	Ctx          context.Context
-	Store        storage.Store
-	Txn          storage.Transaction
-	TxnCtx       *storage.Context
-	Compiler     *ast.Compiler
-	Metrics      metrics.Metrics
-	Bundles      map[string]*Bundle     // Optional
-	ExtraModules map[string]*ast.Module // Optional
+	Ctx                      context.Context
+	Store                    storage.Store
+	Txn                      storage.Transaction
+	TxnCtx                   *storage.Context
+	Compiler                 *ast.Compiler
+	Metrics                  metrics.Metrics
+	Bundles                  map[string]*Bundle     // Optional
+	ExtraModules             map[string]*ast.Module // Optional
+	AuthorizationDecisionRef ast.Ref
 
 	legacy bool
 }
@@ -450,7 +452,7 @@ func activateBundles(opts *ActivateOpts) error {
 		remainingAndExtra[name] = mod
 	}
 
-	err = compileModules(opts.Compiler, opts.Metrics, snapshotBundles, remainingAndExtra, opts.legacy)
+	err = compileModules(opts.Compiler, opts.Metrics, snapshotBundles, remainingAndExtra, opts.legacy, opts.AuthorizationDecisionRef)
 	if err != nil {
 		return err
 	}
@@ -755,7 +757,7 @@ func writeData(ctx context.Context, store storage.Store, txn storage.Transaction
 	return nil
 }
 
-func compileModules(compiler *ast.Compiler, m metrics.Metrics, bundles map[string]*Bundle, extraModules map[string]*ast.Module, legacy bool) error {
+func compileModules(compiler *ast.Compiler, m metrics.Metrics, bundles map[string]*Bundle, extraModules map[string]*ast.Module, legacy bool, authorizationDecisionRef ast.Ref) error {
 
 	m.Timer(metrics.RegoModuleCompile).Start()
 	defer m.Timer(metrics.RegoModuleCompile).Stop()
@@ -789,7 +791,11 @@ func compileModules(compiler *ast.Compiler, m metrics.Metrics, bundles map[strin
 		return compiler.Errors
 	}
 
-	return nil
+	if authorizationDecisionRef.Equal(ast.EmptyRef()) {
+		return nil
+	}
+
+	return iCompiler.VerifyAuthorizationPolicySchema(compiler, authorizationDecisionRef)
 }
 
 func writeModules(ctx context.Context, store storage.Store, txn storage.Transaction, compiler *ast.Compiler, m metrics.Metrics, bundles map[string]*Bundle, extraModules map[string]*ast.Module, legacy bool) error {

--- a/docs/content/security.md
+++ b/docs/content/security.md
@@ -173,7 +173,9 @@ request is rejected immediately. The count of requests rejected by an OPA instan
 are surfaced via the performance metrics in the [Status](../management-status) information.
 
 OPA provides the following `input` document when executing the authorization
-policy:
+policy. Since the schema for the `input` document is known to OPA, it performs automatic type checking of this document
+and reports any errors resulting from the schema check. The `--skip-known-schema-check` flag can be passed to `opa run`
+to disable automatic type checking of this `input` document.
 
 <!-- TODO(sr): check if "jsonc" looks alright on netlify -->
 ```jsonc

--- a/internal/compiler/utils.go
+++ b/internal/compiler/utils.go
@@ -1,0 +1,89 @@
+// Copyright 2023 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package compiler
+
+import (
+	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/schemas"
+	"github.com/open-policy-agent/opa/util"
+)
+
+type SchemaFile string
+
+const (
+	AuthorizationPolicySchema SchemaFile = "authorizationPolicy.json"
+)
+
+var schemaDefinitions = map[SchemaFile]interface{}{}
+
+// VerifyAuthorizationPolicySchema performs type checking on rules against the schema for the Authorization Policy
+// Input document.
+// NOTE: The provided compiler should have already run the compilation process on the input modules
+func VerifyAuthorizationPolicySchema(compiler *ast.Compiler, ref ast.Ref) error {
+
+	rules := getRulesWithDependencies(compiler, ref)
+
+	if len(rules) == 0 {
+		return nil
+	}
+
+	schemaSet := ast.NewSchemaSet()
+	schemaSet.Put(ast.SchemaRootRef, schemaDefinitions[AuthorizationPolicySchema])
+
+	errs := ast.NewCompiler().WithSchemas(schemaSet).PassesTypeCheckRules(rules)
+
+	if len(errs) > 0 {
+		return errs
+	}
+
+	return nil
+}
+
+// getRulesWithDependencies returns a slice of rules that are referred to by ref along with their dependencies
+func getRulesWithDependencies(compiler *ast.Compiler, ref ast.Ref) []*ast.Rule {
+	allRules := compiler.GetRules(ref)
+
+	deps := map[*ast.Rule]struct{}{}
+	for _, rule := range allRules {
+		transitiveDependencies(compiler, rule, deps)
+	}
+
+	for dep := range deps {
+		allRules = append(allRules, dep)
+	}
+
+	return allRules
+}
+
+func transitiveDependencies(compiler *ast.Compiler, rule *ast.Rule, deps map[*ast.Rule]struct{}) {
+	for x := range compiler.Graph.Dependencies(rule) {
+		other := x.(*ast.Rule)
+		deps[other] = struct{}{}
+		transitiveDependencies(compiler, other, deps)
+	}
+}
+
+func loadAuthorizationPolicySchema() {
+
+	cont, err := schemas.FS.ReadFile(string(AuthorizationPolicySchema))
+	if err != nil {
+		panic(err)
+	}
+
+	if len(cont) == 0 {
+		panic("expected authorization policy schema file to be present")
+	}
+
+	var schema interface{}
+	if err := util.Unmarshal(cont, &schema); err != nil {
+		panic(err)
+	}
+
+	schemaDefinitions[AuthorizationPolicySchema] = schema
+}
+
+func init() {
+	loadAuthorizationPolicySchema()
+}

--- a/internal/compiler/utils_test.go
+++ b/internal/compiler/utils_test.go
@@ -1,0 +1,138 @@
+// Copyright 2023 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package compiler
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/open-policy-agent/opa/ast"
+)
+
+func TestVerifyAuthorizationPolicySchema(t *testing.T) {
+
+	module1 := `
+	package policy
+
+    import future.keywords
+
+	default allow := false
+
+	allow {
+	   input.identity = "foo"
+	}
+
+	allow {
+	   input.client_certificates[0] = {"foo": "bar"}
+	}
+
+	allow {
+	   input.method = "GET"
+	}
+
+	allow {
+	   input.path = ["foo", "bar"]
+	}
+
+    allow {
+	   "foo" in input.path
+	}
+
+	allow {
+	   input.params = {"foo": "bar"}
+	}
+
+	allow {
+	   input.headers = {"foo": "bar"}
+	}
+
+	allow {
+	   input.body.input.stock = "ACME"
+	}`
+
+	module2 := `
+	package policy
+
+	default allow := false
+
+	allow {
+	   input.identty = "foo"
+	}
+
+	allow {
+	   input.path = "foo"
+	}`
+
+	module3 := `
+	package policy
+
+	default allow := false
+
+	allow {
+	   input.path = [1, 2, 3]
+	}`
+
+	module4 := `
+    package policy
+
+    default allow := false
+
+    allow {
+       input.client_certificates[0] = "foo"
+    }`
+
+	tests := []struct {
+		note    string
+		modules []string
+		wantErr bool
+		errs    []string
+	}{
+		{note: "no rules", modules: []string{}},
+		{note: "no error", modules: []string{module1}},
+		{note: "multiple errors", modules: []string{module2}, wantErr: true, errs: []string{"match error", "undefined ref: input.identty"}},
+		{note: "wrong item type path", modules: []string{module3}, wantErr: true, errs: []string{"match error"}},
+		{note: "wrong item type certs", modules: []string{module4}, wantErr: true, errs: []string{"match error"}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.note, func(t *testing.T) {
+			modules := map[string]*ast.Module{}
+
+			for i, module := range tc.modules {
+				mod, err := ast.ParseModule(fmt.Sprintf("test%d.rego", i+1), module)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				modules[fmt.Sprintf("test%d.rego", i+1)] = mod
+			}
+
+			c := ast.NewCompiler()
+			c.Compile(modules)
+			if c.Failed() {
+				t.Fatal("unexpected error:", c.Errors)
+			}
+
+			err := VerifyAuthorizationPolicySchema(c, ast.MustParseRef("data.policy.allow"))
+
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("Expected error but got nil")
+				}
+
+				for _, e := range tc.errs {
+					if !strings.Contains(err.Error(), e) {
+						t.Errorf("Expected error %v not found", e)
+					}
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("Unexpected error %v", err)
+				}
+			}
+		})
+	}
+}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -16,7 +16,9 @@ import (
 
 // Params controls the types of runtime information to return.
 type Params struct {
-	Config []byte
+	Config                 []byte
+	IsAuthorizationEnabled bool
+	SkipKnownSchemaCheck   bool
 }
 
 // Term returns the runtime information as an ast.Term object.
@@ -53,6 +55,8 @@ func Term(params Params) (*ast.Term, error) {
 	obj.Insert(ast.StringTerm("env"), ast.NewTerm(env))
 	obj.Insert(ast.StringTerm("version"), ast.StringTerm(version.Version))
 	obj.Insert(ast.StringTerm("commit"), ast.StringTerm(version.Vcs))
+	obj.Insert(ast.StringTerm("authorization_enabled"), ast.BooleanTerm(params.IsAuthorizationEnabled))
+	obj.Insert(ast.StringTerm("skip_known_schema_check"), ast.BooleanTerm(params.SkipKnownSchemaCheck))
 
 	return ast.NewTerm(obj), nil
 }

--- a/plugins/bundle/plugin.go
+++ b/plugins/bundle/plugin.go
@@ -22,6 +22,7 @@ import (
 	"github.com/open-policy-agent/opa/bundle"
 	"github.com/open-policy-agent/opa/download"
 	bundleUtils "github.com/open-policy-agent/opa/internal/bundle"
+	"github.com/open-policy-agent/opa/internal/ref"
 	"github.com/open-policy-agent/opa/logging"
 	"github.com/open-policy-agent/opa/metrics"
 	"github.com/open-policy-agent/opa/plugins"
@@ -596,6 +597,20 @@ func (p *Plugin) activate(ctx context.Context, name string, b *bundle.Bundle) er
 			Compiler: compiler,
 			Metrics:  p.status[name].Metrics,
 			Bundles:  map[string]*bundle.Bundle{name: b},
+		}
+
+		if p.manager.Info != nil {
+
+			skipKnownSchemaCheck := p.manager.Info.Get(ast.StringTerm("skip_known_schema_check"))
+			isAuthzEnabled := p.manager.Info.Get(ast.StringTerm("authorization_enabled"))
+
+			if ast.BooleanTerm(true).Equal(isAuthzEnabled) && ast.BooleanTerm(false).Equal(skipKnownSchemaCheck) {
+				authorizationDecisionRef, err := ref.ParseDataPath(*p.manager.Config.DefaultAuthorizationDecision)
+				if err != nil {
+					return err
+				}
+				opts.AuthorizationDecisionRef = authorizationDecisionRef
+			}
 		}
 
 		if p.config.IsMultiBundle() {

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -280,6 +280,105 @@ func TestCheckOPAUpdateLoopWithNewUpdate(t *testing.T) {
 	testCheckOPAUpdateLoop(t, baseURL, "OPA is out of date.")
 }
 
+func TestRuntimeWithAuthzSchemaVerification(t *testing.T) {
+	ctx := context.Background()
+
+	fs := map[string]string{
+		"test/authz.rego": `package system.authz
+
+		default allow := false
+
+		allow {
+          input.identity = "foo"
+		}`,
+	}
+
+	test.WithTempFS(fs, func(rootDir string) {
+		rootDir = filepath.Join(rootDir, "test")
+
+		params := NewParams()
+		params.Paths = []string{rootDir}
+		params.Authorization = server.AuthorizationBasic
+
+		_, err := NewRuntime(ctx, params)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		badModule := []byte(`package system.authz
+
+		default allow := false
+
+		allow {
+           input.identty = "foo"
+		}`)
+
+		if err := os.WriteFile(path.Join(rootDir, "authz.rego"), badModule, 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		_, err = NewRuntime(ctx, params)
+		if err == nil {
+			t.Fatal("Expected error but got nil")
+		}
+
+		if !strings.Contains(err.Error(), "undefined ref: input.identty") {
+			t.Errorf("Expected error \"%v\" not found", "undefined ref: input.identty")
+		}
+
+		// no verification checks
+		params.Authorization = server.AuthorizationOff
+		_, err = NewRuntime(ctx, params)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
+func TestRuntimeWithAuthzSchemaVerificationTransitive(t *testing.T) {
+	ctx := context.Background()
+
+	fs := map[string]string{
+		"test/authz.rego": `package system.authz
+
+		default allow := false
+
+        is_secret :=  input.identty == "secret"
+
+        # even though "is_secret" is called via 2 paths, there should be only one resulting error
+        # 1-step dependency
+        allow {
+          is_secret
+        }
+
+        # 2-step dependency
+        allow {
+          allow2
+        }
+
+        allow2 {
+          is_secret
+        }`,
+	}
+
+	test.WithTempFS(fs, func(rootDir string) {
+		rootDir = filepath.Join(rootDir, "test")
+
+		params := NewParams()
+		params.Paths = []string{rootDir}
+		params.Authorization = server.AuthorizationBasic
+
+		_, err := NewRuntime(ctx, params)
+		if err == nil {
+			t.Fatal("Expected error but got nil")
+		}
+
+		if !strings.Contains(err.Error(), "undefined ref: input.identty") {
+			t.Errorf("Expected error \"%v\" not found", "undefined ref: input.identty")
+		}
+	})
+}
+
 func TestCheckAuthIneffective(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Millisecond)
 	defer cancel() // NOTE(sr): The timeout will have been reached by the time `done` is closed.

--- a/schemas/authorizationPolicy.json
+++ b/schemas/authorizationPolicy.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Schema for the OPA Authorization Policy Input document",
+  "type": "object",
+  "properties": {
+    "identity": {
+      "type": "string"
+    },
+    "client_certificates": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "method": {
+      "type": "string"
+    },
+    "path": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "params": {
+      "type": "object"
+    },
+    "headers": {
+      "type": "object"
+    },
+    "body": {
+      "type": "object"
+    }
+  },
+  "required": [
+    "identity",
+    "client_certificates",
+    "method",
+    "path",
+    "params",
+    "headers",
+    "body"
+  ]
+}

--- a/schemas/schemas.go
+++ b/schemas/schemas.go
@@ -1,0 +1,15 @@
+// Copyright 2023 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package schemas
+
+import (
+	"embed"
+)
+
+// FS contains the known schemas for OPA's Authorization Policy etc.
+// "authorizationPolicy.json" contains the input schema for OPA's Authorization Policy
+//
+//go:embed *.json
+var FS embed.FS

--- a/schemas/schemas_test.go
+++ b/schemas/schemas_test.go
@@ -1,0 +1,33 @@
+// Copyright 2023 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package schemas_test
+
+import (
+	"testing"
+
+	"github.com/open-policy-agent/opa/schemas"
+	"github.com/open-policy-agent/opa/util"
+)
+
+func TestSchemasEmbedded(t *testing.T) {
+	ents, err := schemas.FS.ReadDir(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ents) == 0 {
+		t.Error("expected schemas to be present")
+	}
+	for _, ent := range ents {
+		cont, err := schemas.FS.ReadFile(ent.Name())
+		if err != nil {
+			t.Errorf("file %v: %v", ent.Name(), err)
+		}
+		var x interface{}
+		err = util.UnmarshalJSON(cont, &x)
+		if err != nil {
+			t.Errorf("file %v: %v", ent.Name(), err)
+		}
+	}
+}


### PR DESCRIPTION
The schema of the input document for the authorization
policy is known to OPA. This feature leverages that
to perform automatic type checking on the authorization policy.
The checks happen on policies provided to OPA on start-up and
also those provided via bundles. This check is enabled by default
and can be disabled using the `--skip-known-schema-check` flag
on `opa run`. This feature will help catch errors such as
typos, mismatch types etc. in these policies and provide precise
feedback to the policy author.