### PR TITLE
docs: update traefik integration link

### DIFF
--- a/docs/website/data/integrations.yaml
+++ b/docs/website/data/integrations.yaml
@@ -582,8 +582,8 @@ integrations:
     labels:
       category: servicemesh
       layer: gateway
-    blogs:
-      - https://engineering.etermax.com/api-authorization-with-kubernetes-traefik-and-open-policy-agent-23647fc384a1
+    code:
+      - https://github.com/edgeflare/traefik-opa-proxy
 
   nodejs-express:
     title: NodeJS express


### PR DESCRIPTION
### Why the changes in this PR are needed?
https://engineering.etermax.com/api-authorization-with-kubernetes-traefik-and-open-policy-agent-23647fc384a1 is broken.

### What are the changes in this PR?
Replaced the broken blog link with https://github.com/edgeflare/traefik-opa-proxy.

### Notes to assist PR review:
The proxy sits between Traefik and OPA, and translates OPA's decisions (allow: true/false) into HTTP status codes (200, 403) for [Traefik forwardauth middleware](https://doc.traefik.io/traefik/master/middlewares/http/forwardauth/). See repo's README for more.
