### PR TITLE
feat(download): add opa_no_oci flag to build without containerd

### DIFF
--- a/download/oci_download.go
+++ b/download/oci_download.go
@@ -1,3 +1,5 @@
+//go:build !opa_no_oci
+
 package download
 
 import (
@@ -11,7 +13,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/containerd/containerd/errdefs"
@@ -29,25 +30,6 @@ import (
 	"github.com/open-policy-agent/opa/plugins/rest"
 	"github.com/open-policy-agent/opa/util"
 )
-
-type OCIDownloader struct {
-	config         Config                        // downloader configuration for tuning polling and other downloader behaviour
-	client         rest.Client                   // HTTP client to use for bundle downloading
-	path           string                        // path for OCI image as <registry>/<org>/<repo>:<tag>
-	localStorePath string                        // path for the local OCI storage
-	trigger        chan chan struct{}            // channel to signal downloads when manual triggering is enabled
-	stop           chan chan struct{}            // used to signal plugin to stop running
-	f              func(context.Context, Update) // callback function invoked when download updates occur
-	sizeLimitBytes *int64                        // max bundle file size in bytes (passed to reader)
-	bvc            *bundle.VerificationConfig
-	wg             sync.WaitGroup
-	logger         logging.Logger
-	mtx            sync.Mutex
-	stopped        bool
-	persist        bool
-	store          *oci.Store
-	etag           string
-}
 
 // NewOCI returns a new Downloader that can be started.
 func NewOCI(config Config, client rest.Client, path, storePath string) *OCIDownloader {

--- a/download/oci_download_unavailable.go
+++ b/download/oci_download_unavailable.go
@@ -1,0 +1,53 @@
+//go:build opa_no_oci
+
+package download
+
+import (
+	"context"
+	"github.com/open-policy-agent/opa/bundle"
+	"github.com/open-policy-agent/opa/plugins/rest"
+)
+
+func NewOCI(Config, rest.Client, string, string) *OCIDownloader {
+	panic("built without OCI support")
+}
+
+func (d *OCIDownloader) WithCallback(f func(context.Context, Update)) *OCIDownloader {
+	panic("built without OCI support")
+}
+
+func (d *OCIDownloader) WithLogAttrs(map[string]interface{}) *OCIDownloader {
+	panic("built without OCI support")
+}
+
+func (d *OCIDownloader) WithBundleVerificationConfig(*bundle.VerificationConfig) *OCIDownloader {
+	panic("built without OCI support")
+}
+
+func (d *OCIDownloader) WithSizeLimitBytes(int64) *OCIDownloader {
+	panic("built without OCI support")
+}
+
+func (d *OCIDownloader) WithBundlePersistence(bool) *OCIDownloader {
+	panic("built without OCI support")
+}
+
+func (d *OCIDownloader) ClearCache() {
+	panic("built without OCI support")
+}
+
+func (d *OCIDownloader) SetCache(string) {
+	panic("built without OCI support")
+}
+
+func (d *OCIDownloader) Trigger(context.Context) error {
+	panic("built without OCI support")
+}
+
+func (d *OCIDownloader) Start(context.Context) {
+	panic("built without OCI support")
+}
+
+func (d *OCIDownloader) Stop(context.Context) {
+	panic("built without OCI support")
+}

--- a/download/oci_downloader.go
+++ b/download/oci_downloader.go
@@ -1,0 +1,30 @@
+package download
+
+import (
+	"context"
+	"sync"
+
+	"github.com/open-policy-agent/opa/bundle"
+	"github.com/open-policy-agent/opa/logging"
+	"github.com/open-policy-agent/opa/plugins/rest"
+	"oras.land/oras-go/v2/content/oci"
+)
+
+type OCIDownloader struct {
+	config         Config                        // downloader configuration for tuning polling and other downloader behaviour
+	client         rest.Client                   // HTTP client to use for bundle downloading
+	path           string                        // path for OCI image as <registry>/<org>/<repo>:<tag>
+	localStorePath string                        // path for the local OCI storage
+	trigger        chan chan struct{}            // channel to signal downloads when manual triggering is enabled
+	stop           chan chan struct{}            // used to signal plugin to stop running
+	f              func(context.Context, Update) // callback function invoked when download updates occur
+	sizeLimitBytes *int64                        // max bundle file size in bytes (passed to reader)
+	bvc            *bundle.VerificationConfig
+	wg             sync.WaitGroup
+	logger         logging.Logger
+	mtx            sync.Mutex
+	stopped        bool
+	persist        bool
+	store          *oci.Store
+	etag           string
+}


### PR DESCRIPTION
xrel https://github.com/open-policy-agent/opa/issues/6160

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->

### Why the changes in this PR are needed?

I think it's best explained in the issue - https://github.com/open-policy-agent/opa/issues/6160
<!--
Include a short description of WHY the changes were made.
-->

### What are the changes in this PR?

This pr adds an `opa_no_oci` build flag to exclude containerd dependency.

<!--
Include a short description of WHAT changes were made.
-->

### Notes to assist PR review:

Look at the issue first - https://github.com/open-policy-agent/opa/issues/6160.

<!--
Here you can add information you think will help the reviewer(s).
-->

### Further comments:

Nothing.

<!--
Here you can include links to additional resources related to the changes, discuss your solution, other approaches you considered etc.
-->
