### PR TITLE
chore: Remove dedup comment function in opa fmt

### DIFF
--- a/format/format.go
+++ b/format/format.go
@@ -264,9 +264,6 @@ func (w *writer) writeModule(module *ast.Module, o fmtOpts) {
 		return locLess(comments[i], comments[j])
 	})
 
-	// XXX: The parser currently duplicates comments for some reason, so we need
-	// to remove duplicates here.
-	comments = dedupComments(comments)
 	sort.Slice(others, func(i, j int) bool {
 		return locLess(others[i], others[j])
 	})
@@ -1299,21 +1296,6 @@ func skipPast(open, close byte, loc *ast.Location) (int, int) {
 	}
 
 	return i, offset
-}
-
-func dedupComments(comments []*ast.Comment) []*ast.Comment {
-	if len(comments) == 0 {
-		return nil
-	}
-
-	filtered := []*ast.Comment{comments[0]}
-	for i := 1; i < len(comments); i++ {
-		if comments[i].Location.Equal(comments[i-1].Location) {
-			continue
-		}
-		filtered = append(filtered, comments[i])
-	}
-	return filtered
 }
 
 // startLine begins a line with the current indentation level.


### PR DESCRIPTION
The comment said the parser duplicated comments, but that does no longer seem to be the case. All tests pass without this and I was not able to reproduce it any other way.