### PR TITLE
[docs] Address issue OPA ecosystem missing items

### DIFF
--- a/docs/website/data/integrations.yaml
+++ b/docs/website/data/integrations.yaml
@@ -1,0 +1,2894 @@
+# NOTE: this file has been deprecated as of
+# https://github.com/open-policy-agent/opa/pull/6158
+# Please see the docs to learn how to add new integrations
+# https://github.com/open-policy-agent/opa/blob/1e4f120beb9777d3202bb594a2c212256549d953/docs/README.md
+
+# TODO: this file can be removed after v0.56.0 release
+integrations:
+
+  torque:
+    title: Torque
+    description: Torque by Quali is a cloud-based platform that provides infrastructure automation and orchestration solutions for digital transformation and DevOps initiatives. Troque utilizes Open Policy Agent (OPA) to enforce policy-as-code, enabling users to define and automate their own security, compliance, and governance policies across their infrastructure.
+    labels:
+      category: Environments as a Service
+      layer: Infrastructure
+      type: poweredbyopa
+    software:
+      - terraform
+      - helm
+      - cloudformation
+      - kubernetes
+      - ansible
+      - aws
+      - gcp
+      - azure
+    tutorials:
+      - https://docs.qtorque.io/governance/policies
+    code:
+      - https://github.com/QualiTorque/opa
+    inventors:
+      - quali
+    blogs:
+      - https://www.quali.com/blog/enforcing-open-policy-agent-guardrails-across-your-cloud-configurations/
+    docs_features:
+      cli-integration:
+        note: |
+          Torque policy evaluation is done using the OPA CLI. See an
+          [example command](https://github.com/QualiTorque/opa#perform-policy-evaluation)
+          in the documentation.
+      terraform:
+        note: |
+          Torque supports Terraform policy enforcement and defines some
+          [sample policies here](https://github.com/QualiTorque/opa).
+
+  styra-das:
+    title: Styra Declarative Authorization Service
+    subtitle: Policy as Code Control Plane
+    description: Styra DAS provides a single pane of glass for authorization and policy across the cloud-native ecosystem of software systems. Beyond a simple control plane, Styra DAS pushes OPA’s potential, providing powerful impact analysis, policy authoring, and decision logging.
+    software:
+      - styra-das
+      - kubernetes
+      - envoy
+      - terraform
+    labels:
+      category: authorization
+      type: poweredbyopa
+    tutorials:
+      - https://docs.styra.com/getting-started
+      - https://docs.styra.com/tutorials/kubernetes/introduction
+      - https://docs.styra.com/tutorials/envoy/introduction
+      - https://docs.styra.com/tutorials/ssh/introduction
+      - https://docs.styra.com/tutorials/terraform/introduction
+      - https://docs.styra.com/tutorials/entitlements/introduction
+      - https://academy.styra.com/courses/opa-rego
+    code:
+      - https://github.com/StyraInc/das-opa-samples
+      - https://github.com/StyraInc/example-policy-management
+      - https://github.com/StyraInc/entitlements-samples
+    inventors:
+      - styra
+    blogs:
+      - https://blog.styra.com/blog/six-of-my-favorite-styra-declarative-authorization-service-das-features
+      - https://blog.styra.com/blog/styra-declarative-authorization-service-expands-service-mesh-use-case
+      - https://blog.styra.com/blog/opa-styra-terraform-protect-your-cloud-investment
+      - https://www.styra.com/blog/how-to-write-your-first-rules-in-rego-the-policy-language-for-opa
+    videos:
+      - title: "Securing Microservices-Based Apps with Dynamic Traffic Authz"
+        speakers:
+          - name: Kurt Roekle
+            organization: styra
+        venue: online
+        link: https://www.youtube.com/watch?v=9F-Zyn9j25g
+      - title: "Policy Management Across the Cloud-Native Stack: Styra DAS for Terraform"
+        speakers:
+          - name: Kurt Roekle
+            organization: styra
+        venue: online
+        link: https://www.youtube.com/watch?v=3K0RqIvNfAc
+    docs_features:
+      status-api:
+        note: |
+          Styra DAS can receive status updates from OPA instances via the status
+          API. See the
+          [documentation here](https://docs.styra.com/das/policies/policy-organization/systems/view-opa-status)
+          for more information.
+      envoy:
+        note: |
+          Styra DAS provides an out-of-the-box integration for writing Envoy
+          authorization policies. See the
+          [tutorial](https://docs.styra.com/das/systems/envoy/tutorials)
+          here.
+      policy-testing:
+        note: |
+          DAS supports the running of tests alongside Rego policy in its UI.
+          Read documentation about
+          [testing Rego policies in DAS](https://docs.styra.com/das/policies/policy-authoring/test-policies).
+      language-tooling:
+        note: |
+          DAS supports the writing, testing and debugging of Rego policies in a UI.
+          Read about
+          [Writing Policies](https://docs.styra.com/das/policies/policy-authoring/write-policies)
+          and
+          [Testing Policies](https://docs.styra.com/das/policies/policy-authoring/test-policies)
+          in the DAS documentation.
+      external-data:
+        note: |
+          The [Bundle Registry](https://docs.styra.com/das/policies/bundles/bundle-registry)
+          feature of DAS uses OPA's Bundle API to distribute policy and data updates to
+          OPA instances.
+      opa-bundles:
+        note: |
+          Styra DAS exposes a Bundle Service compatible API to the OPA instances
+          that it manages. Delta bundles are also supported. Read the
+          [Bundle Registry Docs](https://docs.styra.com/das/policies/bundles/bundle-registry)
+          to learn more.
+      opa-bundles-discovery:
+        note: |
+          Styra DAS exposes a Bundle Service compatible API to the OPA instances
+          that it manages. Discovery bundles are also supported. Read the
+          [Bundle Registry Docs](https://docs.styra.com/das/policies/bundles/bundle-registry)
+          to learn more.
+      terraform:
+        note: |
+          Styra DAS has native support for the validation of Terraform code and
+          plans via a prebuilt 'system-type', this is
+          [documented here](https://docs.styra.com/das/systems/terraform/overview).
+      kubernetes:
+        note: |
+          Styra DAS has native support for mutating and validating Kubernetes
+          at admission time via a prebuilt 'system-type', this is
+          [documented here](https://docs.styra.com/das/systems/kubernetes/overview).
+      decision-logging:
+        note: |
+          Styra DAS can aggregate and index OPA decision logs. Exporting to
+          object storage, and Kafka is also supported. View
+          [the documentation](https://docs.styra.com/das/observability-and-audit/decision-logs/overview)
+          here.
+
+  alluxio:
+    title: Alluxio
+    description: Alluxio is an open source data orchestration technology for analytics and AI for the cloud. Alluxio can integrate with OPA and delegate all permission checks to OPA.
+    software:
+      - alluxio
+    labels:
+      category: authorization
+      type: poweredbyopa
+    tutorials:
+      - https://docs.alluxio.io/ee/user/2.10.0/en/security/OpenPolicyAgent-Integration.html
+    inventors:
+      - alluxio
+
+  circleci:
+    title: CircleCI
+    description: Use config policy management to create organization-level policies to impose rules and scopes around which configuration elements are required, allowed, not allowed etc.
+    software:
+      - circleci
+    labels:
+      category: tooling
+      layer: cicd
+      type: poweredbyopa
+    tutorials:
+      - https://circleci.com/docs/config-policy-management-overview/
+    inventors:
+      - circleci
+
+  awesome-opa:
+    title: Awesome OPA List
+    description: A curated list of awesome OPA related tools, frameworks and articles.
+    software: []
+    labels:
+      category: learning
+      type: poweredbyopa
+    code:
+      - https://github.com/StyraInc/awesome-opa
+    inventors:
+      - styra
+    docs_features:
+      learning-rego:
+        note: |
+          The Awesome OPA project maintains a list of
+          [policy packages](https://github.com/StyraInc/awesome-opa#policy-packages),
+          and [editor integrations](https://github.com/StyraInc/awesome-opa#ide-and-editor-integrations)
+          which can be helpful references for learning Rego.
+
+  aws-cloudformation-hook:
+    title: AWS CloudFormation Hook
+    description: AWS CloudFormation Hook that uses OPA to make policy decisions on infrastructure provisioned via AWS CloudFormation
+    software:
+      - aws
+      - cloudformation
+    labels:
+      type: poweredbyopa
+    tutorials:
+      - https://www.openpolicyagent.org/docs/latest/aws-cloudformation-hooks/
+    code:
+      - https://github.com/StyraInc/opa-aws-cloudformation-hook
+    blogs:
+      - https://blog.styra.com/blog/the-opa-aws-cloudformation-hook
+    inventors:
+      - styra
+    docs_features:
+      rest-api-integration:
+        note: |
+          The OPA CloudFormation Hook uses AWS Lambda to consult an OPA instance
+          using the REST API before allowing a CloudFormation stack to be created.
+
+          Read [the tutorial](https://www.openpolicyagent.org/docs/latest/aws-cloudformation-hooks/)
+          here in the OPA documentation.
+
+  oauth2:
+    title: OAuth2
+    description: Integrating OAuth2 with Open Policy Agent
+    software:
+      - oauth
+    labels:
+      category: security
+    tutorials:
+      - https://www.openpolicyagent.org/docs/latest/oauth-oidc/
+    blogs:
+      - https://blog.styra.com/blog/integrating-identity-oauth2-and-openid-connect-in-open-policy-agent
+
+  oidc:
+    title: OpenID Connect (OIDC)
+    description: Integrating OpenID Connect (OIDC) with Open Policy Agent
+    software:
+      - oauth
+      - oidc
+    labels:
+      category: security
+    tutorials:
+      - https://www.openpolicyagent.org/docs/latest/oauth-oidc/
+    blogs:
+      - https://blog.styra.com/blog/integrating-identity-oauth2-and-openid-connect-in-open-policy-agent
+
+  google-kubernetes-engine:
+    title: GKE Policy Automation
+    description: Tool and policy library for reviewing Google Kubernetes Engine clusters against best practices
+    software:
+      - kubernetes
+      - google-kubernetes-engine
+    labels:
+      category: containers
+      layer: orchestration
+    code:
+      - https://github.com/google/gke-policy-automation
+    tutorials:
+      - https://github.com/google/gke-policy-automation/tree/main/gke-policies
+    inventors:
+      - google
+    docs_features:
+      kubernetes:
+        note: |
+          The GKE Policy Automation project provides a set of policies for
+          validating Kubernetes clusters running on GKE. Review the
+          [policy library here](https://github.com/google/gke-policy-automation/tree/main/gke-policies-v2)
+
+  apache-apisix:
+    title: Authorization Integration with Apache APISIX
+    description: Apache APISIX provides a plugin for delegating fine-grained authorization decisions to OPA.
+    software:
+      - apache-apisix
+    labels:
+      category: gateway
+      layer: network
+    code:
+      - https://github.com/apache/apisix
+    inventors:
+      - apache-apisix
+    blogs:
+      - https://apisix.apache.org/blog/2021/12/24/open-policy-agent
+      - https://medium.com/@ApacheAPISIX/apache-apisix-integrates-with-open-policy-agent-to-enrich-its-ecosystem-15569fe3ab9c
+    docs_features:
+      rest-api-integration:
+        note: |
+          Apache APISIX routes can be configured to call an OPA instance over
+          the REST API.
+          [This blog post](https://apisix.apache.org/blog/2021/12/24/open-policy-agent/)
+          explains how such a configuration can be achieved.
+
+  dapr:
+    title: Dapr
+    description: Middleware to apply Open Policy Agent policies on incoming requests
+    software:
+      - dapr
+    labels:
+      category: application
+      layer: network
+    tutorials:
+      - https://docs.dapr.io/reference/components-reference/supported-middleware/middleware-opa/
+    code:
+      - https://github.com/dapr/dapr
+      - https://github.com/dapr/components-contrib/blob/master/middleware/http/opa/middleware.go
+    docs_features:
+      go-integration:
+        note: |
+          Dapr's contrib middleware include an OPA integration built on the Go
+          API.
+          [This tutorial](https://docs.dapr.io/reference/components-reference/supported-middleware/middleware-opa/)
+          explains how to configure it.
+
+  fig:
+    title: fig
+    description: Beautiful shell autocompletion for OPA and many other commands, for Mac OS
+    software:
+      - fig
+    labels:
+      category: utilities
+      layer: shell
+    code:
+      - https://github.com/open-policy-agent/contrib/tree/main/opa_fig_autocomplete
+      - https://github.com/withfig/autocomplete/blob/master/src/opa.ts
+    inventors:
+      - fig
+
+  fiber:
+    title: fiber
+    description: |
+      Fiber is an Express inspired web framework built on top of Fasthttp, the fastest HTTP engine for Go.
+      Designed to ease things up for fast development with zero memory allocation and performance in mind.
+      With Open Policy Agent integration, you can run your Rego policies as part of the request lifecycle in the middleware.
+    labels:
+      category: application
+      layer: library
+    software:
+      - golang
+      - fiber
+    code:
+      - https://github.com/gofiber/contrib/tree/main/opafiber
+
+  sphinx-rego:
+    title: Automatically document Rego policies
+    description: Sphinx extension that automatically documents Open Policy Agent Rego policies using meta properties.
+    software:
+      - sphinx-doc
+    code:
+      - https://github.com/zenitysec/sphinx-rego
+    inventors:
+      - zenity
+    labels:
+      category: tooling
+      layer: cicd
+
+  opa-playground:
+    title: OPA Playground
+    subtitle: Online Rego Playground
+    description: Interactive online Rego playground for writing and sharing policies
+    software: []
+    inventors:
+      - styra
+    labels:
+      category: tooling
+      layer: rego
+    code:
+      - https://play.openpolicyagent.org/
+    blogs:
+      - https://blog.openpolicyagent.org/the-rego-playground-977566855cec
+      - https://blog.openpolicyagent.org/rego-playground-new-features-ec0345a73b9e
+    docs_features:
+      learning-rego:
+        note: |
+          Sometimes if you're working on a Rego policy in an integrated system
+          it can help to debug it in isolation first. The playground is a great
+          place to do that. Get started with a [hello world example](https://play.openpolicyagent.org/).
+      language-tooling:
+        note: |
+          The playground is a great place to get started with writing and testing
+          your first policies. You can also share links if you're asking for
+          help in the community Slack. Get started with a simple
+          [RBAC example](https://play.openpolicyagent.org/p/Bb9FqBvauC).
+
+  kubernetes-validating-admission:
+    title: Kubernetes Admission Control
+    description: Kubernetes automates deployment, scaling, and management of containerized applications.  OPA provides fine-grained, context-aware authorization for which application component configuration.
+    software:
+      - kubernetes
+    labels:
+      category: containers
+      layer: orchestration
+    tutorials:
+      - https://www.openpolicyagent.org/docs/kubernetes-admission-control.html
+      - https://katacoda.com/austinheiman/scenarios/open-policy-agent-gatekeeper
+    code:
+      - https://github.com/open-policy-agent/kube-mgmt
+      - https://github.com/open-policy-agent/gatekeeper
+    inventors:
+      - styra
+      - microsoft
+      - google
+    videos:
+      - title: Securing Kubernetes With Admission Controllers
+        speakers:
+          - name: Dave Strebel
+            organization: microsoft
+        venue: Kubecon Seattle 2018
+        link: https://sched.co/GrZQ
+      - title: Using OPA for Admission Control in Production
+        speakers:
+          - name: Zach Abrahamson
+            organization: Capital One
+          - name: Todd Ekenstam
+            organization: Intuit
+        venue: Kubecon Seattle 2018
+        link: https://sched.co/Grbn
+      - title: Liz Rice Keynote
+        speakers:
+          - name: Liz Rice
+            organization: AquaSecurity
+        venue: Kubecon Seattle 2018
+        link: https://youtu.be/McDzaTnUVWs?t=418
+      - title: Intro to Open Policy Agent Gatekeeper
+        speakers:
+          - name: Rita Zhang
+            organization: microsoft
+          - name: Max Smythe
+            organization: google
+        venue: Kubecon Barcelona 2019
+        link: https://kccnceu19.sched.com/event/MPiM/intro-open-policy-agent-rita-zhang-microsoft-max-smythe-google
+      - title: Policy Enabled Kubernetes and CICD
+        speakers:
+          - name: Jimmy Ray
+            organization: capitalone
+        venue: OPA Summit at Kubecon San Diego 2019
+        link: https://www.youtube.com/watch?v=vkvWZuqSk5M
+      - title: "TripAdvisor: Building a Testing Framework for Integrating OPA into K8s"
+        speakers:
+          - name: Luke Massa
+            organization: tripadvisor
+        venue: OPA Summit at Kubecon San Diego 2019
+        link: https://www.youtube.com/watch?v=X09c1eXvCFM
+      - title: Enforcing automatic mTLS with Linkerd and OPA Gatekeeper
+        speakers:
+          - name: Ivan Sim
+            organization: buoyant
+          - name: Rita Zhang
+            organization: microsoft
+        venue: Kubecon San Diego 2019
+        link: https://www.youtube.com/watch?v=gMaGVHnvNfs
+      - title: Enforcing Service Mesh Structure using OPA Gatekeeper
+        speakers:
+          - name: Sandeep Parikh
+            organization: google
+        venue: Kubecon San Diego 2019
+        link: https://www.youtube.com/watch?v=90RHTBinAFU
+      - title: "TGIK: Exploring the Open Policy Agent"
+        speakers:
+          - name: Joe Beda
+            organization: VMware
+        link: https://www.youtube.com/watch?v=QU9BGPf0hBw
+    blogs:
+      - https://medium.com/@sbueringer/kubernetes-authorization-via-open-policy-agent-a9455d9d5ceb
+      - https://medium.com/@jimmy.ray/policy-enabled-kubernetes-with-open-policy-agent-3b612b3f0203
+      - https://blog.openpolicyagent.org/securing-the-kubernetes-api-with-open-policy-agent-ce93af0552c3
+      - https://itnext.io/kubernetes-authorization-via-open-policy-agent-a9455d9d5ceb
+      - https://medium.com/capital-one-tech/policy-enabled-kubernetes-with-open-policy-agent-3b612b3f0203
+      - https://blog.openshift.com/fine-grained-policy-enforcement-in-openshift-with-open-policy-agent/
+    docs_features:
+      rest-api-integration:
+        note: |
+          The Kubernetes API server can be configured to use OPA as an
+          admission controller. Creating a
+          [ValidatingWebhookConfiguration](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#validatingwebhookconfiguration)
+          resource can be used to query OPA for policy decisions.
+      kubernetes:
+        note: |
+          View a selection of projects and talks about integrating OPA with
+          Kubernetes.
+
+  kubernetes-authorization:
+    title: Kubernetes Authorization
+    description: |
+      Kubernetes Authorization is a pluggable mechanism that lets administrators control which users can run which APIs and
+      is often handled by builtin RBAC.  OPA's policy language is more flexible than the RBAC, for example,
+      writing policy using a prohibited list of APIs instead of the usual RBAC style of listing the permitted APIs.
+    code:
+      - https://github.com/open-policy-agent/contrib/tree/main/k8s_authorization
+    blogs:
+      - https://blog.styra.com/blog/kubernetes-authorization-webhook
+      - https://itnext.io/kubernetes-authorization-via-open-policy-agent-a9455d9d5ceb
+      - https://itnext.io/optimizing-open-policy-agent-based-kubernetes-authorization-via-go-execution-tracer-7b439bb5dc5b
+    inventors:
+      - styra
+    docs_features:
+      rest-api-integration:
+        note: |
+          The Kubernetes API server can be configured to use OPA as an
+          authorization webhook. Such an integration can be configured by
+          following [the documentation](https://github.com/open-policy-agent/contrib/tree/main/k8s_authorization)
+          in the contrib repo.
+      kubernetes:
+        note: |
+          View
+          [an example project](https://github.com/open-policy-agent/contrib/tree/main/k8s_authorization)
+          showing how it's possible to integrate OPA with Kubernetes User Authorization.
+
+
+  kubernetes-provisioning:
+    title: Kubernetes Provisioning
+    description: Kubernetes automates deployment, scaling, and management of containerized applications.  OPA decides which resources need to be created on k8s in response to a namespace being created.
+    software:
+      - kubernetes
+    labels:
+      category: containers
+      layer: orchestration
+    inventors:
+      - goldmansachs
+    videos:
+      - title: Kubernetes Policy Enforcement Using OPA at Goldman Sachs
+        speakers:
+          - name: Miguel Uzcategui
+            organization: goldmansachs
+          - name: Tim Hinrichs
+            organization: styra
+        venue: Kubecon San Diego 2019
+        link: https://www.youtube.com/watch?v=lYHr_UaHsYQ&list=PLj6h78yzYM2NDs-iu8WU5fMxINxHXlien&index=140&t=0s
+
+  google-calendar:
+    title: Google Calendar
+    description: Using the Google Calendar API with OPA for calendar powered policy decisions
+    labels:
+      category: data
+      layer: rego
+    software:
+      - google-calendar
+    inventors:
+      - styra
+    code:
+      - https://github.com/anderseknert/opa-google-calendar
+    blogs:
+      - https://blog.styra.com/blog/the-power-of-data-calendar-based-policy-enforcement
+
+  gcp-forseti:
+    title: GCP audit with Forseti
+    description: |
+      Google cloud provides a plethora of software as a service.
+      Forseti, built using OPA, lets you run policy checks against the software resources on Google cloud and remediate violations.
+    labels:
+      category: publiccloud
+    inventors:
+      - google
+    code:
+      - https://forsetisecurity.org
+    videos:
+      - title: Repeatable GCP Environments at Scale with Cloud Build Infra-as-Code Pipelines
+        speakers:
+          - name: Morgante Pell
+            organization: google
+          - name: Andrew Phillips
+            organization: google
+        venue: Cloud Next 2019
+        link: https://www.youtube.com/watch?v=3vfXQxWJazM&feature=youtu.be&t=2054
+
+  aws-api-gateway:
+    title: AWS API Gateway
+    description: The AWS API Gateway controls API traffic for your application running on AWS.  OPA can be configured as an external authorizer for that Gateway to implement authorization policies on APIs.
+    labels:
+      category: servicemesh
+      layer: gateway
+    code:
+      - https://github.com/zotoio/sls-lambda-opa
+
+  antlr:
+    title: ANTLR Grammar
+    description: ANTLR4 grammar for Rego.
+    labels:
+      category: utilities
+      layer: rego
+    code:
+      - https://github.com/antlr/grammars-v4
+    inventors:
+      - independent
+
+  traefik-api-gateway:
+    title: Traefik API Gateway
+    description: |
+      The Traefik API Gateway is open-source software that controls API traffic into your application.
+      OPA can be configured as a plugin to implement authorization policies for those APIs.
+    labels:
+      category: servicemesh
+      layer: gateway
+    blogs:
+      - https://medium.com/etermax-technology/api-authorization-with-kubernetes-traefik-and-open-policy-agent-23647fc384a1
+    code:
+      - https://github.com/edgeflare/traefik-opa-proxy
+
+  nodejs-express:
+    title: NodeJS express
+    description: |
+      Express is a minimal and flexible Node.js web application framework that provides a robust set of features for web and mobile applications.
+      OPA can be used to implement authorization policies for APIs used in the express framework.
+    labels:
+      category: application
+      layer: network
+    code:
+      - https://github.com/build-security/opa-express-middleware
+    inventors:
+      - build.security
+    docs_features:
+      rest-api-integration:
+        note: |
+          This project provides a middleware that can query an OPA server for
+          policy decisions. See the project's
+          [README](https://github.com/build-security/opa-express-middleware#simple-usage)
+          for a js simple example.
+
+  nginx:
+    title: Nginx
+    description: OPA Authorization for Nginx
+    labels:
+      category: gateway
+      layer: network
+    software:
+      - nginx
+    code:
+      - https://github.com/summerwind/opa-nginx-rbac
+
+  asp-dotnet-core:
+    title: ASP.NET Core
+    description: |
+      Use ASP.NET Core to create web apps and services that are fast, secure, cross-platform, and cloud-based.
+      OPA can be used to implement authorization policies for APIs used in the ASP.NET Core framework.
+    labels:
+      category: application
+      layer: network
+    code:
+      - https://github.com/build-security/OPA-AspDotNetCore-Middleware
+    inventors:
+      - build.security
+
+  gloo-api-gateway:
+    title: Gloo API Gateway
+    description: |
+      Gloo is an open-source Kubernetes-native ingress controller, and next-generation API gateway.
+      OPA can be used to implement authorization policies for those APIs.
+    labels:
+      category: servicemesh
+      layer: gateway
+    blogs:
+      - https://medium.com/solo-io/5-min-with-gloo-api-gateway-configuration-with-open-policy-agent-53da276a6534
+      - https://docs.solo.io/gloo/latest/security/auth/opa/
+
+  envoy-authorization:
+    title: Container Network Authorization with Envoy
+    subtitle: Official OPA Envoy Integration
+    description: Envoy is a networking abstraction for cloud-native applications. OPA hooks into Envoy’s external authorization filter to provide fine-grained, context-aware authorization for network or HTTP requests.
+    labels:
+      category: servicemesh
+      layer: network
+    software:
+      - envoy
+    tutorials:
+      - https://github.com/tsandall/minimal-opa-envoy-example/blob/master/README.md
+      - https://www.openpolicyagent.org/docs/latest/envoy-introduction/
+    code:
+      - https://github.com/open-policy-agent/opa-envoy-plugin
+      - https://github.com/tsandall/minimal-opa-envoy-example
+    inventors:
+      - styra
+    blogs:
+      - https://blog.openpolicyagent.org/envoy-external-authorization-with-opa-578213ed567c
+    videos:
+      - title: "OPA at Scale: How Pinterest Manages Policy Distribution"
+        speakers:
+          - name: Will Fu
+            organization: pinterest
+          - name: Jeremy Krach
+            organization: pinterest
+        venue: OPA Summit at Kubecon San Diego 2019
+        link: https://www.youtube.com/watch?v=LhgxFICWsA8
+      - title: "Deploying Open Policy Agent at Atlassian"
+        speakers:
+          - name: Chris Stivers
+            organization: atlassian
+          - name: Nicholas Higgins
+            organization: atlassian
+        venue: OPA Summit at Kubecon San Diego 2019
+        link: https://www.youtube.com/watch?v=nvRTO8xjmrg
+      - title: How Yelp Moved Security From the App to the Mesh with Envoy and OPA
+        speakers:
+          - name: Daniel Popescu
+            organization: yelp
+          - name: Ben Plotnick
+            organization: yelp
+        venue: Kubecon San Diego 2019
+        link: https://www.youtube.com/watch?v=Z6aN3Smt-9M
+    docs_features:
+      envoy:
+        note: |
+          The
+          [opa-envoy-plugin](https://github.com/open-policy-agent/opa-envoy-plugin)
+          project is the official integration for OPA and Envoy.
+      rest-api-integration:
+        note: |
+          The [opa-envoy-plugin](https://github.com/open-policy-agent/opa-envoy-plugin)
+          project uses the REST API to allow and deny requests routed via an Envoy proxy.
+
+          Read about this integration in the
+          [OPA Docs](https://www.openpolicyagent.org/docs/latest/envoy-introduction/).
+
+  custom-library-microservice-authorization:
+    title: Library-based Microservice Authorization
+    description: Microservice authorization can be enforced through a network proxy like Envoy/Istio/Linkerd/...
+      or can be enforced by modifying the microservice code to use a common library.  In both cases
+      OPA makes the authorization decision that the network proxy or the library enforce.
+    labels:
+      category: servicemesh
+      layer: library
+    videos:
+      - title: How Netflix is Solving Authorization Across Their Cloud
+        speakers:
+          - name: Manish Mehta
+            organization: netflix
+          - name: Torin Sandall
+            organization: styra
+        venue: Kubecon Austin 2017
+        link: https://www.youtube.com/watch?v=R6tUNpRpdnY
+
+  istio-authorization-mixer:
+    title: Container Network Authorization with Istio (as part of Mixer)
+    description: Istio is a networking abstraction for cloud-native applications. In this Istio integration OPA hooks into the centralized Mixer component of Istio, to provide fine-grained, context-aware authorization for network or HTTP requests.
+    labels:
+      category: servicemesh
+      layer: network
+    software:
+      - istio
+    tutorials:
+      - https://istio.io/docs/reference/config/policy-and-telemetry/adapters/opa/
+    code:
+      - https://github.com/istio/istio/tree/master/mixer/adapter/opa
+    inventors:
+      - google
+
+  openfaas-function-authorization:
+    title: OpenFaaS Serverless Function Authorization
+    description: OpenFaaS is a serverless function framework that runs on Docker Swarm and Kubernetes. OPA makes it possible to provide fine-grained context-aware authorization on a per-function basis.
+    labels:
+      layer: application
+      category: serverless
+    software:
+      - openfaas
+    code:
+      - https://github.com/adaptant-labs/openfaas-function-auth-opa
+    tutorials:
+      - https://github.com/adaptant-labs/openfaas-function-auth-opa/blob/master/README.md
+    inventors:
+      - adaptant
+
+  kong-authorization:
+    title: API Gateway Authorization with Kong
+    description: Kong is a microservice API Gateway.  OPA provides fine-grained, context-aware control over the requests that Kong receives.
+    labels:
+      layer: network
+      category: gateway
+    software:
+      - kong
+    code:
+      - https://github.com/TravelNest/kong-authorization-opa
+      - https://github.com/open-policy-agent/contrib/tree/master/kong_api_authz
+    inventors:
+      - travelnest
+      - wada-ama
+
+  linux-pam:
+    title: SSH and Sudo Authorization with Linux
+    description: Host-level access controls are an important part of every organization's security strategy. OPA provides fine-grained, context-aware controls for SSH and sudo using Linux-PAM.
+    software:
+      - linuxpam
+    labels:
+      layer: server
+    tutorials:
+      - https://www.openpolicyagent.org/docs/ssh-and-sudo-authorization.html
+    code:
+      - https://github.com/open-policy-agent/contrib/tree/master/pam_opa
+    inventors:
+      - styra
+
+  kafka-authorization:
+    title: Kafka Topic Authorization
+    description: Apache Kafka is a high-performance distributed streaming platform deployed by thousands of companies.  OPA provides fine-grained, context-aware access control of which users can read/write which Kafka topics to enforce important requirements around confidentiality and integrity.
+    software:
+      - kafka
+    labels:
+      category: streaming
+      layer: data
+    blogs:
+      - https://opencredo.com/blogs/controlling-kafka-data-flows-using-open-policy-agent/
+    tutorials:
+      - https://www.openpolicyagent.org/docs/latest/kafka-authorization/
+    code:
+      - https://github.com/StyraInc/opa-kafka-plugin
+      - https://github.com/llofberg/kafka-authorizer-opa
+      - https://github.com/opencredo/opa-single-message-transformer
+    inventors:
+      - ticketmaster
+      - styra
+    videos:
+      - title: "OPA at Scale: How Pinterest Manages Policy Distribution"
+        speakers:
+          - name: Will Fu
+            organization: pinterest
+          - name: Jeremy Krach
+            organization: pinterest
+        venue: OPA Summit at Kubecon San Diego 2019
+        link: https://www.youtube.com/watch?v=LhgxFICWsA8
+    docs_features:
+      rest-api-integration:
+        note: |
+          This project implements a custom
+          [Kafka authorizer](https://docs.confluent.io/platform/current/kafka/authorization.html#authorizer)
+          that uses OPA to make authorization decisions by calling the REST API.
+
+          Installation and configuration instructions are available in the
+          project's [README](https://github.com/StyraInc/opa-kafka-plugin#installation).
+
+  strimzi:
+    title: Strimzi (Apache Kafka on Kubernetes)
+    description: Strimzi provides a way to run an Apache Kafka cluster on Kubernetes in various deployment configurations. Strimzi ships with the OPA authorizer plugin right out of the box, and supports OPA as an option for Kafka authorization.
+    software:
+      - kafka
+      - strimzi
+    labels:
+      category: streaming
+      layer: data
+    blogs:
+      - https://strimzi.io/blog/2020/08/05/using-open-policy-agent-with-strimzi-and-apache-kafka/
+      - https://strimzi.io/blog/2020/09/01/enforce-custom-resource-policies-with-opa-gatekeeper/
+    code:
+      - https://github.com/strimzi/strimzi-kafka-operator
+      - https://github.com/scholzj/demo-opa-kafka-authorization
+      - https://github.com/StyraInc/opa-kafka-plugin
+    inventors:
+      - redhat
+    docs_features:
+      rest-api-integration:
+        note: |
+          Strimzi can be configured to use OPA via the REST API as the Kafka
+          authorizer using [this project](https://github.com/scholzj/demo-opa-kafka-authorization).
+
+  ceph:
+    title: Ceph Object Storage Authorization
+    description: Ceph is a highly scalable distributed storage solution that uniquely delivers object, block, and file storage in one unified system.  OPA provides fine-grained, context-aware authorization of the information stored within Ceph.
+    software:
+      - ceph
+    labels:
+      category: object
+      layer: data
+    tutorials:
+      - https://docs.ceph.com/docs/master/radosgw/opa/
+      - https://www.katacoda.com/styra/scenarios/opa-ceph
+    inventors:
+      - styra
+      - redhat
+    videos:
+      - https://www.youtube.com/watch?v=9m4FymEvOqM&feature=share
+    docs_feature:
+      rest-api-integration:
+        note: |
+          The Ceph Object Gateway implements a native integration with OPA using
+          the REST API.
+          The [integration is documented](https://docs.ceph.com/en/latest/radosgw/opa/)
+          in the Ceph docs.
+
+  clojure:
+    title: App authorization for Clojure
+    description: Authorization middleware for Ring based apps and other utilities for working with OPA in Clojure.
+    software:
+      - clojure
+    labels:
+      layer: network
+      category: application
+    code:
+      - https://github.com/anderseknert/clj-opa
+    inventors:
+      - styra
+
+  open-service-mesh:
+    title: Open Service Mesh (OSM)
+    description: Open Service Mesh is a lightweight and extensible cloud native service mesh.
+    software:
+      - osm
+    labels:
+      category: servicemesh
+      layer: network
+    tutorials:
+      - https://release-v1-2.docs.openservicemesh.io/docs/guides/integrations/external_auth_opa/
+    docs_features:
+      envoy:
+        note: |
+          External Authorization supports OPA and is documented
+          [here](https://release-v1-2.docs.openservicemesh.io/docs/guides/integrations/external_auth_opa/)
+
+  minio:
+    title: Minio API Authorization
+    description: Minio is an open source, on-premise object database compatible with the Amazon S3 API.  This integration lets OPA enforce policies on Minio's API.
+    software:
+      - minio
+    labels:
+      layer: data
+      category: authorization
+    tutorials:
+      - https://github.com/minio/minio/blob/master/docs/iam/opa.md
+    inventors:
+      - minio
+      - styra
+    docs_features:
+      rest-api-integration:
+        note: |
+          Minio implements a native integration with OPA using the REST API.
+          The [integration is documented](https://github.com/minio/minio/blob/master/docs/iam/opa.md)
+          in the Minio docs.
+
+  terraform:
+    title: Terraform Policy
+    description: Terraform lets you describe the infrastructure you want and automatically creates, deletes, and modifies your existing infrastructure to match. OPA makes it possible to write policies that test the changes Terraform is about to make before it makes them.
+    software:
+      - terraform
+      - aws
+      - gcp
+      - azure
+    labels:
+      category: publiccloud
+      layer: orchestration
+    tutorials:
+      - https://www.openpolicyagent.org/docs/terraform.html
+      - https://github.com/instrumenta/conftest/blob/master/README.md
+    code:
+      - https://github.com/instrumenta/conftest
+      - https://github.com/fugue/regula
+      - https://github.com/accurics/terrascan
+      - https://github.com/Checkmarx/kics
+      - https://github.com/open-policy-agent/library/tree/master/terraform
+      - https://github.com/accurics/terrascan/tree/master/pkg/policies/opa/rego
+      - https://github.com/Checkmarx/kics/tree/master/assets/queries/terraform
+    blogs:
+      - https://blog.styra.com/blog/policy-based-infrastructure-guardrails-with-terraform-and-opa
+    inventors:
+      - fugue
+      - accurics
+      - checkmarx
+      - medallia
+      - styra
+      - docker
+      - snyk
+
+  terraform-cloud:
+    title: Terraform Cloud
+    description: |
+      Policies are rules that Terraform Cloud enforces on runs.
+      You use the Rego policy language to write policies for the
+      Open Policy Agent (OPA) framework.
+    software:
+      - terraform
+      - terraform-cloud
+      - aws
+      - gcp
+      - azure
+    labels:
+      category: publiccloud
+      layer: orchestration
+    tutorials:
+      - https://developer.hashicorp.com/terraform/cloud-docs/policy-enforcement/opa
+      - https://developer.hashicorp.com/terraform/tutorials/cloud/drift-and-opa
+      - https://developer.hashicorp.com/terraform/cloud-docs/policy-enforcement/opa/vcs
+    videos:
+      - title: "Terraform Cloud Learn Lab: Validate Infrastructure and Enforce OPA Policies"
+        speakers:
+          - name: Rita Sokolova
+            organization: HashiCorp
+          - name: Cole Morrison
+            organization: HashiCorp
+        venue: HashiConf Europe 2022
+        link: https://www.youtube.com/watch?v=jO2CiYMPxFE
+    inventors:
+      - hashicorp
+    docs_features:
+      terraform:
+        note: |
+          Terraform cloud has native support for enforcing Rego policy on plans.
+          The feature is [documented here](https://developer.hashicorp.com/terraform/cloud-docs/policy-enforcement/opa).
+
+  pulumi:
+    title: Pulumi
+    description: Build infrastructure as code in familiar languages. CrossGuard is Pulumi's policy as code offering, providing OPA as one of the options to use for defining policy.
+    software:
+      - pulumi
+      - aws
+      - gcp
+      - azure
+    labels:
+      category: publiccloud
+      layer: orchestration
+    code:
+      - https://github.com/pulumi/pulumi-policy-opa
+    blogs:
+      - https://www.pulumi.com/blog/opa-support-for-crossguard/
+    videos:
+      - title: "Testing Configuration with Open Policy Agent"
+        speakers:
+          - name: Gareth Rushgrove
+            organization: snyk
+        venue: Cloud Engineering Summit 2020
+        link: https://www.pulumi.com/resources/testing-configuration-with-open-policy-agent/
+    inventors:
+      - pulumi
+    docs_features:
+      go-integration:
+        note: |
+          The Pulumi OPA bridge uses the Rego API to evaluate policies in a
+          policy pack. View the [docs and code](https://github.com/pulumi/pulumi-policy-opa).
+
+  iptables:
+    title: IPTables
+    description: IPTables is a useful tool available to Linux kernel for filtering network packets. OPA makes it possible to manage IPTables rules using context-aware policy.
+    labels:
+      layer: network
+      category: linux
+    software:
+      - linux
+    tutorials:
+      - https://github.com/open-policy-agent/contrib/blob/master/opa-iptables/docs/tutorial.md
+    code:
+      - https://github.com/open-policy-agent/contrib/tree/master/opa-iptables
+    inventors:
+      - gsoc
+      - cisco
+      - styra
+
+  dart-authorization:
+    title: HTTP API Authorization in Dart
+    description: This integration demonstrates how to leverage OPA to perform basic HTTP API authorization in a simple Dart microservice. OPA makes it possible to provide fine-grained context-aware authorization for each REST endpoint and access method.
+    labels:
+      layer: network
+      category: application
+    software:
+      - dart
+    tutorials:
+      - https://github.com/adaptant-labs/opa-api-authz-dart/README.md
+    code:
+      - https://github.com/adaptant-labs/opa-api-authz-dart
+    inventors:
+      - adaptant
+
+  springsecurity-api:
+    title: Authorization for Java Spring Security
+    description: Spring Security provides a framework for securing Java applications.  These integrations provide simple implementations for Spring Security that use OPA for making API authorization decisions.  They provide support for both traditional Spring Security (MVC), as well as an implementation for Spring Reactive (Web Flux).
+    labels:
+      layer: network
+      category: application
+    software:
+      - javaspringsecurity
+    code:
+      - https://github.com/open-policy-agent/contrib/tree/master/spring_authz
+      - https://github.com/Bisnode/opa-spring-security
+      - https://github.com/build-security/opa-java-spring-client
+      - https://github.com/massenz/jwt-opa
+      - https://github.com/eugenp/tutorials/tree/master/spring-security-modules/spring-security-opa
+
+    tutorials:
+      - https://github.com/open-policy-agent/contrib/blob/master/spring_authz/README.md
+      - https://github.com/massenz/jwt-opa#web-server-demo-app
+      - https://www.baeldung.com/spring-security-authorization-opa
+    inventors:
+      - styra
+      - build.security
+      - bisnode
+      - alertavert
+    docs_features:
+      rest-api-integration:
+        note: |
+          OPA Spring Security uses the REST API to query OPA about authz decisions.
+          See an example application in OPA's
+          [contrib repo](https://github.com/open-policy-agent/contrib/tree/main/spring_authz).
+
+  spinnaker-pipeline:
+    title: Spinnaker Pipeline Policy Enforcment
+    description: Spinnaker is a  Continuous Delivery and Deployment tool started by Netflix.  OPA lets you configure policies that dictate what kinds of Spinnaker pipelines developers can create.
+    labels:
+      layer: cicd
+    software:
+      - spinnaker
+    blogs:
+      - https://blog.armory.io/deployment-policies-with-spinnaker/
+    tutorials:
+      - https://docs.armory.io/spinnaker/policy_engine/
+    inventors:
+      - armory
+
+  java:
+    title: Authorization for Java
+    description: Integrations for interacting with OPA from Java
+    labels:
+      layer: network
+      category: application
+    software:
+      - java
+    code:
+      - https://github.com/Bisnode/opa-java-client
+    inventors:
+      - bisnode
+
+  jenkins-job-authorization:
+    title: Jenkins Job Trigger Policy Enforcement
+    description: Jenkins automates software development processes.  OPA lets you control which people and which machines can run which Jenkins jobs.
+    labels:
+      layer: cicd
+    software:
+      - jenkins
+    inventors:
+      - pinterest
+    videos:
+      - title: "OPA at Scale: How Pinterest Manages Policy Distribution"
+        speakers:
+          - name: Will Fu
+            organization: pinterest
+          - name: Jeremy Krach
+            organization: pinterest
+        venue: OPA Summit at Kubecon San Diego 2019
+        link: https://www.youtube.com/watch?v=LhgxFICWsA8
+
+
+  elasticsearch-datafiltering:
+    title: Elasticsearch Data Filtering
+    description: Elasticsearch is a distributed, open source search and analytics engine.  This OPA integration lets an elasticsearch client construct queries so that the data returned by elasticsearch obeys OPA-defined policies.
+    labels:
+      layer: data
+      category: filtering
+    software:
+      - elasticsearch
+    code:
+      - https://github.com/open-policy-agent/contrib/tree/master/data_filter_elasticsearch
+    tutorials:
+      - https://github.com/open-policy-agent/contrib/blob/master/data_filter_elasticsearch/README.md
+    inventors:
+      - styra
+
+  sql-datafiltering:
+    title: SQL Database Data Filtering
+    description: This integration enables the client of a SQL database to enhance a SQL query so that the results obey an OPA-defined policy.
+    labels:
+      layer: data
+      category: filtering
+    software:
+      - sqlite
+    code:
+      - https://github.com/open-policy-agent/contrib/tree/master/data_filter_example
+    blogs:
+      - https://blog.openpolicyagent.org/write-policy-in-opa-enforce-policy-in-sql-d9d24db93bf4
+    inventors:
+      - styra
+
+  clair-datasource:
+    title: Kubernetes Admission Control using Vulnerability Scanning
+    description: |
+      Admission control policies in Kubernetes can be augmented with
+      vulnerability scanning results to make more informed decisions.
+      This integration demonstrates how to integrate CoreOS Clair with OPA and
+      run it as an admission controller.
+    software:
+      - kubernetes
+      - clair
+    labels:
+      layer: orchestration
+      category: containers
+      datasource: clair
+    code:
+      - https://github.com/open-policy-agent/contrib/tree/master/image_enforcer
+    tutorials:
+      - https://github.com/open-policy-agent/contrib/blob/master/image_enforcer/README.md
+    docs_features:
+      rest-api-integration:
+        note: |
+          This example project in
+          [OPA contrib](https://github.com/open-policy-agent/contrib/tree/main/image_enforcer)
+          uses OPA over the REST API to enforce admission policy based on
+          vulnerability scanning results.
+      kubernetes:
+        note: |
+          This example project in
+          [OPA contrib](https://github.com/open-policy-agent/contrib/tree/main/image_enforcer)
+          uses OPA to enforce admission policy in Kubernetes.
+
+  cloudflare-worker:
+    title: Cloudflare Worker Enforcement of OPA Policies Using Wasm
+    description: |
+      Cloudflare Workers are a serverless platform that supports Wasm.
+      This integration uses OPA's Wasm compiler to generate code enforced at the edge of Cloudflare's network.
+    software:
+      - cloudflare
+    labels:
+      layer: application
+      category: serverless
+    code:
+      - https://github.com/open-policy-agent/contrib/tree/master/wasm/cloudflare-worker
+    tutorials:
+      - https://github.com/open-policy-agent/contrib/blob/master/wasm/cloudflare-worker/README.md
+    docs_features:
+      wasm-integration:
+        note: |
+          This example project in
+          [OPA contrib](https://github.com/open-policy-agent/contrib/tree/main/wasm/cloudflare-worker)
+          uses the
+          [NodeJS OPA Wasm Module](https://github.com/open-policy-agent/npm-opa-wasm)
+          to enforce policy at the edge of Cloudflare's network.
+
+  docker-machine:
+    title: Docker controls via OPA Policies
+    description: Docker's out of the box authorization model is all or nothing.  This integration demonstrates how to use OPA's context-aware policies to exert fine-grained control over Docker.
+    software:
+      - docker
+    labels:
+      layer: server
+      category: container
+    code:
+      - https://github.com/open-policy-agent/opa-docker-authz
+    tutorials:
+      - https://www.openpolicyagent.org/docs/latest/docker-authorization/
+    inventors:
+      - styra
+
+  gatekeeper:
+    title: OPA Gatekeeper
+    subtitle: Rego Policy Controller for Kubernetes
+    description: Manage Rego Kubernetes admission policies using Custom Resources.
+    labels:
+      type: poweredbyopa
+      layer: configuration
+    code:
+      - https://github.com/open-policy-agent/gatekeeper
+    software:
+      - kubernetes
+    tutorials:
+      - https://open-policy-agent.github.io/gatekeeper/website/docs/howto
+    videos:
+      - https://youtu.be/RMiovzGGCfI?t=1049
+      - https://youtu.be/6RNp3m_THw4?t=864
+    docs_features:
+      go-integration:
+        note: |
+          OPA Gatekeeper is written in Go and uses the
+          [Rego Go API](https://www.openpolicyagent.org/docs/latest/integration/#integrating-with-the-go-api)
+          to evaluate policies loaded from Custom Resources.
+      kubernetes:
+        note: |
+          OPA Gatekeeper integrates with
+          [Kubernetes Admission](https://open-policy-agent.github.io/gatekeeper/website/docs/customize-admission/)
+          and also uses Custom Resources and the Kubernetes API server to
+          store policy state.
+
+  conftest:
+    title: Conftest
+    subtitle: Rego policy for configuration files
+    description: Conftest is a utility built on top of OPA to help you write tests against structured configuration data.
+    labels:
+      type: poweredbyopa
+      layer: configuration
+    code:
+      - https://github.com/open-policy-agent/conftest
+    software:
+      - kustomize
+      - terraform
+      - aws
+      - toml
+      - docker
+    tutorials:
+      - https://www.conftest.dev
+      - https://www.conftest.dev/examples/
+    videos:
+      - title: "Applying Policy Throughout the Application Lifecycle with Open Policy Agent"
+        speakers:
+          - name: Gareth Rushgrove
+            organization: snyk
+        venue: Kubecon San Diego 2019
+        link: https://www.youtube.com/watch?v=cXfsaE6RKfc
+      - title: "Terraform Code Reviews: Supercharged with Conftest"
+        speakers:
+          - name: Jay Wallace
+            organization: doordash
+        venue: Hashitalks 2020
+        link: https://www.youtube.com/watch?v=ziKT-ZjZ7mM
+    docs_features:
+      policy-testing:
+        note: |
+          Conftest supports unit testing of policy and has a number of extra language
+          features for working with configuration files. The functionality is
+          [documented here](https://www.conftest.dev/#testingverifying-policies).
+      go-integration:
+        note: |
+          Conftest is written in Go and uses the
+          [Rego Go API](https://www.openpolicyagent.org/docs/latest/integration/#integrating-with-the-go-api).
+      opa-bundles:
+        note: |
+          Conftest supports the loading of policy in a bundle format. The feature
+          is [documented here](https://www.conftest.dev/sharing/).
+      terraform:
+        note: |
+          Conftest has generic support for Terraform source files defined in HCL.
+          There is an example provided here on
+          [GitHub](https://github.com/open-policy-agent/conftest/tree/master/examples/hcl2).
+
+  boomerang-bosun:
+    title: Boomerang Bosun Policy Gating
+    description: Boomerang Bosun is a policy-based gating system that combines Policy Templates with Rules and data to validate Gates.
+    labels:
+      type: poweredbyopa
+      layer: application
+    code:
+      - https://www.useboomerang.io/
+      - https://github.com/boomerang-io
+    inventors:
+      - ibm
+      - boomerang
+    software:
+      - bosun
+    docs_features:
+      rest-api-integration:
+        note: |
+          The
+          [Boomerang Bosun Service](https://github.com/boomerang-io/bosun.service.policy)
+          component interacts with an OPA instance over the REST API to evaluate
+          policy during CICD runs.
+
+
+  kubeshield:
+    title: KubeShield
+    subtitle: Secure Kubernetes using eBPF & Open Policy Agent
+    description: Ensure runtime security in any linux machine by combining Extended Berkeley Packet Filter(eBPF) and Open Policy Agent.
+    software:
+      - linux
+      - kubernetes
+      - ebpf
+    labels:
+      layer: application
+      category: filtering
+    code:
+      - https://github.com/kubeshield/bpf-opa-demo
+    blogs:
+      - https://blog.byte.builders/post/bpf-opa/
+    docs_features:
+      kubernetes:
+        note: |
+          KubeShield implements runtime policy for containers in a Kubernetes
+          cluster using eBPF. Follow the
+          [tutorial here](https://github.com/kubeshield/bpf-opa-demo#usage)
+          to get up and running.
+
+
+  php-authorization:
+    title: PHP OPA Library
+    description: These integrations demonstrate using OPA to perform API authorization in PSR-15 and Symfony compliant frameworks.
+    labels:
+      layer: network
+      category: application
+    software:
+      - php
+    tutorials:
+      - https://coil.com/p/segra/OPA-for-API-Authorization-with-Slim-PHP/H-7YsQL2m
+    code:
+      - https://github.com/segrax/opa-php-examples
+      - https://github.com/segrax/openpolicyagent
+      - https://github.com/build-security/opa-symfony-middleware
+    inventors:
+      - build.security
+    docs_features:
+      rest-api-integration:
+        note: |
+          This library provides a PHP wrapper around the OPA REST API. It can
+          update policies and query for decisions. See the
+          [project README](https://github.com/segrax/openpolicyagent)
+          for various examples.
+
+  gradle-plugin:
+    title: Gradle Build Plugin
+    description: Build plugin adding various tasks to support using OPA as part of Gradle builds
+    labels:
+      layer: cicd
+      category: cicdplugin
+      type: poweredbyopa
+    software:
+      - gradle
+      - java
+      - groovy
+      - kotlin
+    code:
+      - https://github.com/Bisnode/opa-gradle-plugin
+      - https://plugins.gradle.org/plugin/com.bisnode.opa
+    inventors:
+      - bisnode
+
+  chef-automate:
+    title: Chef Automate
+    subtitle: Operational Visibility Dashboard
+    description: |
+      Application require authorization decisions made at the API gateway, frontend, backend, and database.
+      OPA helps developers decouple authorization logic from application code, define a custom authorization model
+      that enables end-users to control tenant permissions, and enforce that policy across the different components of the
+      application (gateway, frontend, backend, database).
+    tutorials:
+      - https://github.com/chef/automate/tree/master/components/authz-service#authz-with-opa
+    blogs:
+      - https://blog.verygoodsecurity.com/posts/building-a-fine-grained-permission-system-in-a-distributed-environment/
+      - https://choria.io/blog/post/2020/02/14/rego_policies_opa/
+    videos:
+      - title: "OPA in Practice: From Angular to OPA in Chef Automate"
+        speakers:
+          - name: Michael Sorens
+            organization: chef
+        venue: OPA Summit at Kubecon San Diego 2019
+        link: https://www.youtube.com/watch?v=jrrW855xL3s
+    docs_features:
+      go-integration:
+        note: |
+          Chef Automate uses the Go Rego API to evaluate authorization policies
+          controlling access to its own API endpoints. The feature is
+          [documented here](https://github.com/chef/automate/tree/master/components/authz-service#authz-with-opa).
+
+  sysdig-image-scanner:
+    title: Sysdig Image Scanner Admission Controller
+    description: Sysdig’s OPA Image Scanner combines Sysdig Secure image scanner with OPA policy-based rego language to evaluate the scan results and the admission context, providing great flexibility on the admission decision.
+    software:
+      - kubernetes
+      - sysdigsecure
+    labels:
+      category: containers
+      layer: orchestration
+    code:
+      - https://github.com/sysdiglabs/opa-image-scanner
+    inventors:
+      - sysdig
+    docs_feature:
+      kubernetes:
+        note: |
+          Integrates image scanning results with Kubernetes admission checks
+          using Rego to make pod admission decisions. See the
+          [README](https://github.com/sysdiglabs/opa-image-scanner#overview)
+          for more details.
+
+  pomerium-authz:
+    title: Pomerium Access Proxy
+    description: Pomerium is an identity-aware proxy that enables secure access to internal applications.  OPA implements authorization under the hood.
+    labels:
+      layer: network
+      category: proxy
+    software:
+      - pomerium
+    blogs:
+      - https://www.pomerium.io/posts/2020/04/16/release-0-7/
+    code:
+      - https://github.com/pomerium/pomerium
+
+  coredns-authz:
+    title: CoreDNS Authorization
+    description: CoreDNS is a cloud-native DNS server written in Go.  OPA can be used as a plugin to filter queries and responses.
+    labels:
+      layer: network
+      category: dns
+    software:
+      - coredns
+    code:
+      - https://github.com/coredns/policy
+    inventors:
+      - infoblox
+
+  gluu-gateway-authz:
+    title: Gluu Gateway Authorization
+    description: Gluu Gateway provides API authentication and authorization for websites built on Kong.  Gluu provides an OPA plugin to handle API authorization.
+    labels:
+      layer: network
+      category: gateway
+    software:
+      - gluu
+      - kong
+    code:
+      - https://github.com/GluuFederation/gluu-gateway
+
+  pre-commit-hooks:
+    title: Pre-commit hooks
+    description: Pre-commit git hooks for OPA and Rego development
+    labels:
+      category: tooling
+      layer: cicd
+    software:
+      - git
+      - pre-commit
+    code:
+      - https://github.com/anderseknert/pre-commit-opa
+    blogs:
+      - https://www.eknert.com/tech/2020/08/31/pre-commit-hooks-for-opa
+    inventors:
+      - independent
+
+  scalr-iacp:
+    title: Scalr
+    subtitle: Policy enforcement for Terraform
+    description: Scalr allows teams to easily collaborate on Terraform through its pipeline that runs all Terraform operations, policy checks, and stores state. Scalr uses OPA to check the auto-generated Terraform JSON plan to ensure that it meets your organization standards prior to an apply.
+    labels:
+      category: Infrastructure as Code
+      layer: cicd
+    software:
+      - terraform
+    tutorials:
+      - https://iacp.docs.scalr.com/en/latest/working-with-iacp/opa.html#creating-the-opa-policy
+    code:
+      - https://github.com/Scalr/sample-tf-opa-policies
+    inventors:
+      - scalr
+    blogs:
+      - https://www.scalr.com/blog/opa-is-to-policy-automation-as-terraform-is-to-iac/
+    docs_features:
+      cli-integration:
+        note: |
+          These policies can be run using OPA at the command line against a
+          Terraform plan JSON. See
+          [the example](https://github.com/Scalr/sample-tf-opa-policies#policy-evaluation)
+          in the README.
+      terraform:
+        note: |
+          These policies can be run using OPA at the command line against a
+          Terraform plan JSON. See
+          [the example](https://github.com/Scalr/sample-tf-opa-policies#policy-evaluation)
+          in the README.
+
+  spire:
+    title: SPIRE
+    description: SPIRE is a production-ready implementation of the SPIFFE APIs that performs node and workload attestation in order to securely issue SPIFFE Verifiable Identity Documents (SVIDs) to workloads, and verify the SVIDs of other workloads, based on a predefined set of conditions.
+    labels:
+      layer: network
+      category: application
+    software:
+      - spiffe
+      - spire
+    blogs:
+      - https://www.styra.com/blog/zero-trust-with-envoy-spire-and-open-policy-agent-opa/
+    code:
+      - https://github.com/spiffe/spire/blob/v1.0.2/doc/authorization_policy_engine.md
+    tutorials:
+      - https://spiffe.io/docs/latest/microservices/envoy-opa/readme/
+      - https://spiffe.io/docs/latest/microservices/envoy-jwt-opa/readme/
+    docs_features:
+      envoy:
+        note: |
+          SPIRE can be used to integrate with Envoy and OPA. See a
+          [blog here](https://www.styra.com/blog/zero-trust-with-envoy-spire-and-open-policy-agent-opa/)
+          to learn more.
+      rest-api-integration:
+        note: |
+          SPIRE can work in tandem with the Envoy proxy to integrate with the OPA
+          REST API. See the
+          [tutorial here](https://spiffe.io/docs/latest/microservices/envoy-jwt-opa/readme/).
+
+  fairwinds-insights:
+    title: Fairwinds Insights Configuration Validation Software
+    description: Automate, monitor and enforce OPA policies with visibility across multiple clusters and multiple teams. It ensures the same policies are applied across all your clusters and gives some flexibility if you want certain policies to apply to only certain workloads. Run the same policies in CI/CD, Admission Control, and In-cluster scanning to apply policy consistently throughout the development and deployment process.
+    labels:
+      category: kubernetes
+      layer: cicd
+    inventors:
+      - fairwinds
+    software:
+      - kubernetes
+      - docker
+      - helm
+    tutorials:
+      - https://insights.docs.fairwinds.com/features/policy/
+      - https://insights.docs.fairwinds.com/reports/opa/
+      - https://insights.docs.fairwinds.com/features/admission-controller/
+      - https://insights.docs.fairwinds.com/features/continuous-integration/
+    videos:
+      - https://youtu.be/kmvPYjx1bpU
+      - https://youtu.be/gxE_Tkj6d40
+    blogs:
+      - https://www.fairwinds.com/blog/managing-opa-policies-with-fairwinds-insights
+      - https://www.fairwinds.com/blog/manage-open-policy-agent-opa-consistently
+      - https://www.fairwinds.com/blog/kubernetes-multi-cluster-visibility-why-how-to-get-it
+      - https://www.fairwinds.com/blog/what-is-kubernetes-policy-as-code
+      - https://www.fairwinds.com/blog/why-kubernetes-policy-enforcement
+      - https://www.fairwinds.com/blog/an-interview-with-flatfile-on-why-fairwinds-insights-kubernetes-configuration-validation
+    docs_features:
+      kubernetes:
+        note: |
+          Implements auditing and admission checking of Kubernetes resources
+          using Rego policy using
+          [Polaris](https://github.com/FairwindsOps/Polaris).
+
+  flask-opa:
+    title: Flask-OPA
+    description: Simple to use Flask extension that lets you secure your projects with OPA. It allows HTTP API Authorization and Policy Enforcement Point (AOP using decorators on methods).
+    labels:
+      category: flask
+      layer: library
+    code:
+      - https://github.com/EliuX/flask-opa
+    blogs:
+      - https://github.com/EliuX/flask-opa/tree/master/examples
+
+  permit:
+    title: Permit.io
+    description:  |
+      Permit.io empowers developers to bake in permissions and access-control into any product in minutes and takes away the pain of constantly rebuilding them.
+      Permit is based on OPA.
+    labels:
+      category: authorization
+      layer: application
+    inventors:
+      - permitio
+    code:
+      - https://github.com/permitio
+    tutorials:
+      - https://docs.permit.io/
+    videos:
+      - https://docs.permit.io/tutorials/onboarding_demo
+    blogs:
+      - https://www.permit.io/blog/introduction-to-opa
+      - https://www.permit.io/blog/implement-abac-using-opa
+      - https://www.permit.io/blog/implement-rbac-using-opa
+
+  opal:
+    title: OPAL
+    subtitle: Open Policy Administration Layer
+    description:  |
+      OPAL is an administration layer for Open Policy Agent (OPA), detecting changes in realtime to both policy and policy data and pushing live updates to your agents.
+      OPAL brings open-policy up to the speed needed by live applications. As your application state changes (whether it's via your APIs, DBs, git, S3 or 3rd-party SaaS services), OPAL will make sure your services are always in sync with the authorization data and policy they need (and only those they need).
+    labels:
+      category: updates
+      layer: application
+    inventors:
+      - permitio
+    software:
+      - opal
+    code:
+      - https://github.com/permitio/opal
+    tutorials:
+      - https://github.com/permitio/opal/tree/master/documentation/docs/tutorials
+    videos:
+      - https://www.youtube.com/watch?v=K1Zm2FPfrh8
+    docs_features:
+      rest-api-integration:
+        note: |
+          OPAL uses the OPA REST API to update the policy and data pushed down
+          from the OPAL server.
+          See [how this works](https://docs.opal.ac/overview/architecture).
+      external-data:
+        note: |
+          The OPAL Client uses the OPA REST API to update the state pushed down
+          from the OPAL server.
+          See [how this works](https://docs.opal.ac/overview/architecture).
+      external-data-realtime-push:
+        note: |
+          OPAL is able to deliver real-time data updates to OPA instances.
+          See
+          [how this works](https://docs.opal.ac/getting-started/quickstart/opal-playground/publishing-data-update)
+          in the OPAL docs.
+
+  optoggles:
+    title: OPToggles (Open Policy Toggles)
+    description:  |
+      OPToggles uses OPA and OPAL to sync open-policy to your frontend with the help of feature flag solutions.
+      OPToggles creates user-targeted feature flags based on the policy rules you defined in OPA and keeps the users updated in real-time with OPAL's real-time policy and policy-data change detection.
+      OPToggles already supports launchdarkly.com and a generic REST API.
+    labels:
+      category: updates
+      layer: application
+    inventors:
+      - permitio
+    code:
+      - https://github.com/permitio/OPToggles
+    tutorials:
+      - https://optoggles.opal.ac/tutorials/demo
+
+  bottle:
+    title: Bottle Application Authorization
+    description:  |
+      This integration demonstrates using Open Policy Agent to perform API authorization for a Python application backed by Bottle.
+      Bottle is a fast, simple and lightweight WSGI micro web-framework for Python.
+    labels:
+      layer: network
+      category: application
+    inventors:
+      - dolevf
+    software:
+      - bottle
+    code:
+      - https://github.com/dolevf/bottle-acl-openpolicyagent
+    blogs:
+      - https://blog.lethalbit.com/open-policy-agent-for-bottle-web-framework/
+    docs_features:
+      rest-api-integration:
+        note: |
+          This sample python application calls has a middleware to call OPA
+          before processing each request. See the
+          [example code](https://github.com/dolevf/bottle-acl-openpolicyagent/blob/00a4336/main.py#L37).
+
+  kubescape:
+    title: Kubescape
+    subtitle: Kubernetes security posture scanner
+    description: |
+      This integration uses OPA for defining security controls over Kubernetes clusters. Kubescape is a simple extensible tool
+      finding security problems in your environment. OPA enables Kubescape to implement and extend very fast to answer new problems.
+    labels:
+      category: security
+      layer: application
+    software:
+      - kubescape
+    code:
+      - https://github.com/kubescape/kubescape
+      - https://github.com/kubescape/regolibrary
+    inventors:
+      - armo
+    tutorials:
+      - https://hub.armosec.io/docs
+    docs_features:
+      go-integration:
+        note: |
+          Kubescape uses the Go Repo API to test Kubernetes objects against
+          a range of posture controls.
+
+  i2scim:
+    title: i2scim.io SCIM Restful User/Group Provisioning API
+    description: |
+      i2scim.io is an open source, Apache 2 Licensed, implementation of SCIM (System for Cross-domain Identity Management RFC7643/7644) for use
+      cloud-native kubernetes platforms. i2scim supports externalized access control decisions through OPA. SCIM is a RESTful HTTP API that can be
+      used to provide a standardized way to provision accounts from Azure, Okta, PingIdentity and other providers and tools. SCIM can also be used
+      as a backing identity store for OAuth and other authentication services.
+    labels:
+      category: security
+      layer: application
+    software:
+      - i2scim
+    code:
+      - https://github.com/i2-open/i2scim
+      - https://i2scim.io
+    inventors:
+      - i2
+    tutorials:
+      - https://i2scim.io/OPA_AccessControl.html
+    docs_features:
+      rest-api-integration:
+        note: |
+          i2scim supports externalized access control decisions using OPA's REST API.
+          The integration is described in the [i2scim documentation](https://i2scim.io/OPA_AccessControl.html).
+
+  graphene-graphql:
+    title: Custom Application with Field-level Authorization in Graphene GraphQL
+    description:  |
+      This integration demonstrates using Open Policy Agent to perform field-level Authorization with GraphQL for a custom Python application backed by Graphene.
+    labels:
+      layer: network
+      category: application
+    software:
+      - graphene-graphql
+    code:
+      - https://github.com/dolevf/graphql-open-policy-agent
+
+  regal:
+    title: Regal
+    subtitle: The Linter of Rego Language
+    description: |
+      Regal is a linter for Rego, with the goal of making your Rego magnificent!
+
+      Regal can:
+      * Identify common mistakes, bugs and inefficiencies in Rego policies, and suggest better approaches
+      * Provide advice on best practices, coding style, and tooling
+      * Allow users, teams and organizations to enforce custom rules on their policy code
+    labels:
+      category: tooling
+      layer: shell
+    software:
+      - regal
+    inventors:
+      - styra
+    blogs:
+      - https://www.styra.com/blog/guarding-the-guardrails-introducing-regal-the-rego-linter/
+    code:
+      - https://github.com/StyraInc/regal
+    videos:
+      - https://www.youtube.com/live/Xx8npd2TQJ0?feature=share&t=2567
+    tutorials:
+      - https://github.com/StyraInc/regal#try-it-out
+    docs_features:
+      learning-rego:
+        note: |
+          Regal can automatically check for common Rego mistakes as you code.
+          Each violation is accompanied by a detailed explanation which can be a
+          great learning tool for new Rego users. See the
+          [Supported Rules](https://github.com/StyraInc/regal/tree/main#rules).
+      go-integration:
+        note: |
+          Regal is built using the Go Rego API. Regal evaluates linting rules
+          defined in Rego against the Rego AST of policy files. The
+          [linter package](https://github.com/StyraInc/regal/blob/main/pkg/linter/linter.go)
+          is a good place to see how OPA is used in the project.
+      policy-testing:
+        note: |
+          Regal is a useful step to use when testing Rego policies to ensure
+          code is correct and free of common errors. See
+          [the README](https://github.com/StyraInc/regal#try-it-out)
+          to get started.
+
+  rekor:
+    title: Rekor transparency log monitoring and alerting
+    description: |
+      Rekor Sidekick monitors a Rekor signature transparency log and forwards events of interest where ever you like.
+      Alert policies written in Rego determine if an event is of interest.
+    labels:
+      category: security
+      layer: application
+    software:
+      - rekor
+    inventors:
+      - sigstore
+    code:
+      - https://github.com/nsmith5/rekor-sidekick
+    videos:
+      - https://www.youtube.com/watch?v=lHSLPIo1pz8
+
+  cosign:
+    title: Container Signing, Verification and Storage in an OCI registry
+    description: |
+      Cosign is a tool for container image signing and verifying maintained under the Project Sigstore
+      in collaboration with the Linux Foundation. Among other features, Cosign supports KMS signing,
+      built-in binary transparency, and timestamping service with Rekor and Kubernetes policy enforcement.
+    labels:
+      category: security
+      layer: application
+    software:
+      - cosign
+    inventors:
+      - sigstore
+    code:
+      - https://docs.sigstore.dev/cosign/attestation#validate-in-toto-attestations
+      - https://github.com/sigstore/cosign-gatekeeper-provider
+    vides:
+      - https://www.youtube.com/watch?v=gCi9_4NYyR0
+    docs_features:
+      go-integration:
+        note: |
+          Cosign In-Toto attestations can be
+          [written in Rego](https://docs.sigstore.dev/cosign/attestation/#cosign-custom-predicate-type-and-rego-policy),
+          these are evaluated in the Cosign binary using the Go API.
+
+  alfred:
+    title: "Alfred"
+    subtitle: "Self-hosted OPA playground"
+    description:  |
+      Alfred introduces a local graphical user interface to interact with Open Policy Agent and acts as an alternative to OPA's playground, allowing the user to keep information related to policy testing locally.
+    labels:
+      layer: network
+      category: application
+    software:
+      - alfred
+    inventors:
+      - dolevf
+    code:
+      - https://github.com/dolevf/Open-Policy-Agent-Alfred
+    docs_features:
+      learning-rego:
+        note: |
+          Similar to the public [OPA Playground](https://play.openpolicyagent.org/),
+          Alfred can be used to learn Rego interactively in an environment that
+          can't use the public playground. Read about
+          [installation](https://github.com/dolevf/Open-Policy-Agent-Alfred#how-to-install).
+
+  open-policy-registry:
+    title: Open Policy Registry
+    subtitle: A Docker-inspired workflow for OPA policies
+    description:  |
+      The Open Policy Registry project provides a docker-style workflow for OPA policies.
+      The policy CLI can be used to build, tag, sign, push, and pull OPA policies as OCIv2 container images,
+      in conjunction with any container registry.
+      The Open Policy Registry (OPCR) is a reference implementation of a policy registry, built and hosted on GCP.
+    labels:
+      category: containers
+      layer: application
+    inventors:
+      - aserto
+    software:
+      - open-policy-registry
+    code:
+      - https://github.com/opcr-io/policy
+    tutorials:
+      - https://www.openpolicyregistry.io/docs/tutorial
+    blogs:
+      - https://www.openpolicyregistry.io/blog/docker-workflow-for-opa
+    docs_features:
+      go-integration:
+        note: |
+          Makes use of the
+          [OPA Repl package](https://pkg.go.dev/github.com/open-policy-agent/opa/repl)
+          to interact with an OPA instance.
+      opa-bundles:
+        note: |
+          OPCR policy images can be loaded in over the Bundle API. The feature
+          it documented in the
+          [OPCR docs](https://openpolicycontainers.com/docs/opa).
+      opa-bundles-discovery:
+        note: |
+          OPCR images can be loaded in over the Bundle API and contain
+          discovery bundles. The feature it documented in the
+          [OPCR docs](https://openpolicycontainers.com/docs/opa).
+      external-data:
+        note: |
+          OPCR policy images can contain data as well as policy. If you need to
+          distribute data to OPA from an OCI registry, OPCR can build and push
+          such images. See the docs for
+          [building images here](https://openpolicycontainers.com/docs/cli/build).
+
+  aserto:
+    title: Aserto
+    description:  |
+      Aserto is a cloud-native authorization service that makes it easy to add permissions and RBAC to your SaaS applications and APIs.
+      Aserto is based on the Open Policy Agent.
+    labels:
+      category: authorization
+      layer: application
+      type: poweredbyopa
+    inventors:
+      - aserto
+    software:
+      - aserto
+    code:
+      - https://github.com/aserto-dev
+      - https://github.com/opcr-io
+    tutorials:
+      - https://docs.aserto.com/docs
+    blogs:
+      - https://www.aserto.com/blog/how-do-aserto-rego-policies-work
+      - https://www.aserto.com/blog/testing-rego-policies
+      - https://www.aserto.com/blog/aserto-on-aserto-an-opa-authorization-policy-for-aserto-tenants
+      - https://www.aserto.com/blog/rego-getting-started
+    videos:
+      - https://www.youtube.com/watch?v=RJkgmdjJn_w
+
+  topaz:
+    title: Topaz
+    description:  |
+      Topaz is an open source authorization service providing fine grained, real-time, policy based access control for applications and APIs.
+      Topaz uses OPA as its decision engine, and includes an embedded database that stores subjects, relations, and objects, inspired by the Google Zanzibar data model.
+      Topaz can be deployed as a sidecar or microservice in your cloud.
+    labels:
+      category: authorization
+      layer: application
+      type: poweredbyopa
+    inventors:
+      - aserto
+    software:
+      - topaz
+    code:
+      - https://github.com/aserto-dev/topaz
+    tutorials:
+      - https://www.topaz.sh
+      - https://github.com/aserto-dev/topaz#quickstart
+    blogs:
+      - https://www.aserto.com/blog/topaz-oss-cloud-native-authorization-combines-opa-zanzibar
+    docs_features:
+      go-integration:
+        note: |
+          Topaz's Authorizer component makes use of the Rego API to evaluate
+          policies to make authorization decisions for connected applications.
+
+  emissary-ingress:
+    title: Emissary-Ingress
+    description:  |
+      Emissary-Ingress is an open-source Kubernetes-native API Gateway, Layer 7 load balancer and Kubernetes Ingress built on Envoy Proxy.
+      OPA can be integrated with Emissary as an external authorization service to enforce authorization policies over APIs.
+    labels:
+      category: network
+      layer: gateway
+    software:
+      - emissary-ingress
+    blogs:
+      - https://www.infracloud.io/blogs/emissary-ingress-opa-integration/
+
+  magda:
+    title: Magda
+    description:  |
+      Magda is a federated, Kubernetes-based, open-source data catalog system.
+      Working as Magda's central authorisation policy engine, OPA helps not only the API endpoint authorisation.
+      Magda also uses its partial evaluation feature to translate datasets authorisation decisions to other database-specific DSLs (e.g. SQL or Elasticsearch DSL) and use them for dataset authorisation enforcement in different databases.
+    labels:
+      type: poweredbyopa
+      category: application
+      layer: application
+    software:
+      - magda
+    code:
+      - https://github.com/magda-io/magda
+    blogs:
+      - https://github.com/magda-io/magda/blob/master/docs/docs/architecture/Guide%20to%20Magda%20Internals.md#authorization-authz
+
+  sansshell:
+    title: Sansshell
+    description: A non-interactive daemon for host management
+    software:
+      - sansshell
+    labels:
+      category: management
+      layer: server
+      type: poweredbyopa
+    code:
+      - https://github.com/Snowflake-Labs/sansshell
+    blogs:
+      - https://www.snowflake.com/blog/sansshell-local-host-agent/
+    inventors:
+      - snowflake
+
+  rond:
+    title: Rönd
+    description: |
+      Rönd is a lightweight container that distributes security policy enforcement throughout your application.
+    software:
+      - rond
+    labels:
+      category: authorization
+      layer: application
+    code:
+      - https://github.com/rond-authz/rond
+    tutorials:
+      - https://github.com/rond-authz/example
+    videos:
+      - title: "Rönd - The Open Source K8s sidecar that defines security policies over your APIs"
+        speakers:
+          - name: Federico Maggi
+            organization: mia-platform
+        link: https://youtu.be/ubT31NtHV8w
+    inventors:
+      - mia-platform
+    blogs:
+      - https://blog.mia-platform.eu/en/announcing-rond-new-open-source-security-enforcement-over-your-apis
+      - https://blog.mia-platform.eu/en/how-why-adopted-role-based-access-control-rbac
+    docs_features:
+      go-integration:
+        note: |
+          The Rönd sidecar uses the OPA Rego API to make API-access
+          authorization decisions. See the
+          [OPA evaluator](https://github.com/rond-authz/rond/blob/4c27fa6a127f68b8670a39c792b0e40dac52dafa/core/opaevaluator.go#L173)
+          code.
+
+  waltid:
+    title: walt.id SSI Kit
+    subtitle: Self-Sovereign Identity toolkit with OPA policy support
+    description:  |
+      Verifying W3C Verifiable Credentials for building SSI (Self-Sovereign Identity) use cases.
+    labels:
+      category: authorization
+      layer: application
+      type: poweredbyopa
+    inventors:
+      - waltid
+      - blockchainlabum
+      - netis
+    software:
+      - ssikit
+    code:
+      - https://github.com/walt-id/waltid-ssikit
+    tutorials:
+      - https://docs.walt.id/v/ssikit/ssi-kit/open-policy-agent
+      - https://docs.walt.id/v/ssikit/concepts/verification-policies/dynamic-policies
+    videos:
+      - title: "Verifying W3C Verifiable Credentials with the SSI Kit using OPA (Open Policy Agent)"
+        speakers:
+          - name: Severin Stampler
+            organization: waltid
+        link: https://youtu.be/mue4UjzOZ3Q
+    docs_features:
+      rest-api-integration:
+        note: |
+          SSI Kit's CLI exposes policy management commands which update a local
+          OPA instance. The feature is
+          [documented in the walt.id docs](https://docs.walt.id/v/ssikit/concepts/open-policy-agent).
+
+  graphql:
+    title: GraphQL
+    description:  |
+      GraphQL is a query language for APIs and a runtime for fulfilling those queries with your existing data.
+    labels:
+      category: network
+      layer: application
+    software:
+      - graphql
+    code:
+      - https://github.com/StyraInc/graphql-apollo-example
+    tutorials:
+      - https://www.openpolicyagent.org/docs/graphql-api-authorization/
+
+  wirelesssecuritylab:
+    title: ccbr
+    description:  |
+      CCBR is a policy management system project. It uses the policy language
+      Rego to implement the CIS benchmark test of cloud native kubernetes.
+      In addition, it integrates gatekeeper, manages its constraint templates,
+      constraints and policies, and supports policy deployment and audit inspection.
+    labels:
+      category: network
+      layer: application
+    software:
+      - ccbr
+    code:
+      - https://github.com/wirelesssecuritylab/ccbr
+    inventors:
+      - wirelesssecuritylab
+    docs_features:
+      kubernetes:
+        note: |
+          Implements the CIS benchmark using Rego for Kubernetes workloads.
+
+  spacelift:
+    title: Spacelift
+    description: Spacelift is a sophisticated CI/CD platform for Infrastructure as Code including Terraform, Pulumi, CloudFormation, Kubernetes, and Ansible. Spacelift utilizes Open Policy Agent to support a variety of policy types within the platform and Policy as Code for secure and compliance Infrastructure as Code.
+    labels:
+      category: Infrastructure as Code
+      layer: cicd
+    software:
+      - terraform
+      - pulumi
+      - cloudformation
+      - kubernetes
+      - ansible
+      - aws
+      - gcp
+      - azure
+    tutorials:
+      - https://docs.spacelift.io/concepts/policy
+    code:
+      - https://github.com/spacelift-io/spacelift-policies-example-library
+    inventors:
+      - spacelift
+    blogs:
+      - https://spacelift.io/blog/what-is-open-policy-agent-and-how-it-works
+    docs_features:
+      rego-language-embedding:
+        note: |
+          Spacelift supports Rego as a language to describe policies for IaC
+          resources. View the docs on
+          [creating Rego policies](https://docs.spacelift.io/concepts/policy/).
+      terraform:
+        note: |
+          Spacelift supports Rego as a language to describe policies for Terraform
+          JSON plans.
+          [This blog](https://spacelift.io/blog/what-is-open-policy-agent-and-how-it-works)
+          outlines how the integration works.
+      kubernetes:
+        note: |
+          Spacelift supports Rego as a language to describe policies for various
+          resource types, including Kubernetes. View the
+          [policy documentation](https://docs.spacelift.io/concepts/policy/) for
+          more information.
+
+  easegress:
+    title: Easegress
+    description: |
+      Easegress is a Cloud Native API orchestration system.
+      OPA can be configured as a filter(plugin) to implement authorization policies for the APIs.
+    labels:
+      category: gateway
+      layer: network
+    code:
+      - https://github.com/megaease/easegress
+    inventors:
+      - megaease
+
+  enterprise-opa:
+    title: Styra Enterprise OPA
+    description: An enterprise-grade drop-in replacement for the Open Policy Agent with improved performance and out of the box enterprise integrations
+    software:
+      - enterprise-opa
+    labels:
+      category: authorization
+      type: poweredbyopa
+    tutorials:
+      - https://docs.styra.com/enterprise-opa/tutorials
+      - https://docs.styra.com/enterprise-opa/tutorials/performance-testing
+      - https://docs.styra.com/enterprise-opa/tutorials/grpc-basic-tutorial
+      - https://docs.styra.com/enterprise-opa/tutorials/grpc-go-tutorial
+      - https://docs.styra.com/enterprise-opa/tutorials/lia
+      - https://docs.styra.com/enterprise-opa/tutorials/decision-logs/
+      - https://docs.styra.com/enterprise-opa/tutorials/kafka
+      - https://docs.styra.com/enterprise-opa/tutorials/abac-with-sql
+    code:
+      - https://github.com/StyraInc/enterprise-opa
+    inventors:
+      - styra
+    blogs:
+      - https://www.styra.com/blog/introducing-styra-load-enterprise-opa-distribution-for-data-heavy-authorization/
+    videos:
+      - title: "Start Loving Your Data-heavy Authorization"
+        speakers:
+          - name: Torin Sandall
+            organization: styra
+          - name: Chris Hendrix
+            organization: styra
+        venue: online
+        link: https://www.youtube.com/watch?v=Is1iBPr1YVs
+    docs_features:
+      opa-bundles:
+        note: |
+          Its possible to configure bundles for both
+          [policy](https://docs.styra.com/enterprise-opa/reference/configuration/policy/bundle-api)
+          and
+          [data](https://docs.styra.com/enterprise-opa/reference/configuration/data/bundle-api)
+          in Enterprise OPA.
+      external-data:
+        note: |
+          [Enterprise OPA](https://docs.styra.com/enterprise-opa/)
+          supports various external data sources, including:
+          [Kafka](https://docs.styra.com/enterprise-opa/reference/configuration/data/kafka),
+          [Okta](https://docs.styra.com/enterprise-opa/reference/configuration/data/okta),
+          [LDAP](https://docs.styra.com/enterprise-opa/reference/configuration/data/ldap),
+          [HTTP](https://docs.styra.com/enterprise-opa/reference/configuration/data/http),
+          [Git](https://docs.styra.com/enterprise-opa/reference/configuration/data/git)
+          and
+          [S3](https://docs.styra.com/enterprise-opa/reference/configuration/data/s3).
+          Runtime support for
+          [SQL](https://docs.styra.com/enterprise-opa/tutorials/abac-with-sql)
+          is also available.
+      external-data-runtime:
+        note: |
+          [Enterprise OPA](https://docs.styra.com/enterprise-opa/)
+          can load data from SQL sources at runtime. The feature
+          [is documented](https://docs.styra.com/enterprise-opa/tutorials/abac-with-sql)
+          here with an ABAC example.
+      external-data-realtime-push:
+        note: |
+          It's possible to steam data updates to
+          [Enterprise OPA](https://docs.styra.com/enterprise-opa/)
+          using Kafka. The Kafka integration is
+          [documented](https://docs.styra.com/enterprise-opa/tutorials/kafka)
+          here.
+      policy-testing:
+        note: |
+          [Enterprise OPA's](https://docs.styra.com/enterprise-opa/)
+          [Live Impact Analysis (LIA) feature](https://docs.styra.com/enterprise-opa/tutorials/lia)
+          allows you to test changes to Rego policy on running instances.
+      decision-logging:
+        note: |
+          It's possible to send decision logs to a enterprise tools like Splunk,
+          and Kafka. This enhanced decision logging functionality is
+          [documented here](https://docs.styra.com/enterprise-opa/tutorials/decision-logs/).
+
+  reposaur:
+    title: Reposaur
+    description: Audit, verify and report on development platforms (GitHub and others) easily with pre-defined and/or custom policies.
+    software:
+      - github
+    labels:
+      category: security
+      type: poweredbyopa
+    tutorials:
+      - https://docs.reposaur.com/guides/writing-your-first-policy
+    code:
+      - https://github.com/reposaur/reposaur
+    inventors:
+      - reposaur
+
+  carbonetes:
+    title: Carbonetes - BrainIAC
+    description: BrainIAC uses static code analysis to analyze IAC code to detect security issues before deployment. This tool can scan for issues like security policy misconfigurations, insecure cloud-based services, and compliance issues. The BrainIAC tool performs a comprehensive code scan and generates reports containing detailed insights into the identified issues..
+    software:
+      - github
+      - brainiac
+    labels:
+      layer: Infrastructure
+      category: security
+      type: poweredbyopa
+    code:
+      - https://github.com/carbonetes/brainiac
+    inventors:
+      - carbonetes
+
+  atmos:
+    title: Atmos
+    description: Workflow automation tool for DevOps. Keep configuration DRY with hierarchical imports of configurations, inheritance, and WAY more.
+    software:
+      - aws
+      - gcp
+      - terraform
+      - helm
+    inventors:
+      - cloudposse
+    labels:
+      category: Infrastructure as Code
+      type: poweredbyopa
+    tutorials:
+      - https://atmos.tools/core-concepts/components/validation/#open-policy-agent-opa
+    code:
+      - https://github.com/cloudposse/atmos
+    docs_features:
+      terraform:
+        note: |
+          Atmos can validate Terraform stack before applying them. This is done
+          using the `validate component` command
+          [documented here](https://atmos.tools/cli/commands/validate/component).
+
+  opa-wasm-js:
+    title: OPA Wasm Javascript Module
+    description: |
+      A small SDK for using WebAssembly (Wasm) compiled Rego policies
+    software:
+      - javascript
+    inventors:
+      - styra
+    labels:
+      category: wasm
+      type: poweredbyopa
+    tutorials:
+      - https://github.com/open-policy-agent/npm-opa-wasm/blob/main/README.md
+    code:
+      - https://github.com/open-policy-agent/npm-opa-wasm/
+      - https://www.npmjs.com/package/@open-policy-agent/opa-wasm?activeTab=readme
+    videos:
+      - title: "Scratching an Itch: Running Policy in Hard to Reach Places with Wasm & OPA"
+        speakers:
+          - name: Charlie Egan
+            organization: styra
+        link: https://www.youtube.com/watch?v=BdeBhukLwt4
+    docs_features:
+      wasm-integration:
+        note: |
+          This project implements the OPA Wasm module interface in JavaScript.
+
+  opa-wasm-dotnet:
+    title: OPA Wasm .NET package
+    description: |
+      Call Rego policies in Wasm from C# .NET Core
+    software:
+      - csharp
+    inventors:
+      - christophwille
+    labels:
+      category: wasm
+      type: poweredbyopa
+    tutorials:
+      - https://github.com/christophwille/dotnet-opa-wasm
+    code:
+      - https://github.com/christophwille/dotnet-opa-wasm
+      - https://www.nuget.org/packages/Opa.Wasm/
+    docs_features:
+      wasm-integration:
+        note: |
+          This project implements the OPA Wasm module interface in C#.
+
+  opa-wasm-java:
+    title: OPA Wasm Java Gradle SDK
+    description: |
+      SDK to illustrate how to use Wasm compiled Rego policies from a Java application
+    software:
+      - java
+    inventors:
+      - sangkeon
+    labels:
+      category: wasm
+      type: poweredbyopa
+    tutorials:
+      - https://github.com/sangkeon/java-opa-wasm#usage
+    code:
+      - https://github.com/sangkeon/java-opa-wasm
+    docs_features:
+      wasm-integration:
+        note: |
+          This project implements the OPA Wasm module interface in Java.
+
+  opa-wasm-rust:
+    title: OPA Wasm Rust Crate
+    description: |
+      A crate to use OPA policies compiled to WASM.
+    software:
+      - rust
+    inventors:
+      - matrix
+    labels:
+      category: wasm
+      type: poweredbyopa
+    tutorials:
+      - https://github.com/matrix-org/rust-opa-wasm#try-it-out
+      - https://docs.rs/opa/latest/opa/wasm/index.html
+    code:
+      - https://github.com/matrix-org/rust-opa-wasm
+    docs_features:
+      wasm-integration:
+        note: |
+          This project implements the OPA Wasm module interface in Rust.
+
+  styra-academy:
+    title: Styra Academy
+    subtitle: OPA Learning Portal
+    description: |
+      Styra Academy is a free, self-paced learning portal for OPA and Styra Products.
+      It includes a series of courses on a range of topics from beginner to advanced.
+    software: []
+    inventors:
+      - styra
+    labels:
+      category: learning
+      type: poweredbyopa
+    tutorials:
+      - https://academy.styra.com
+      - https://academy.styra.com/courses/opa-by-example
+      - https://academy.styra.com/courses/opa-rego
+      - https://academy.styra.com/courses/opa-k8s-admission-control
+      - https://academy.styra.com/courses/opa-performance
+    code:
+      - https://github.com/StyraInc/academy-samples
+    docs_features:
+      learning-rego:
+        note: |
+          ['OPA Policy Authoring'](https://academy.styra.com/courses/opa-rego)
+          is a free course that teaches the fundamentals of writing Rego policies.
+
+organizations:
+  quali:
+    name: Quali
+    link: https://www.quali.com/
+  styra:
+    name: Styra
+    link: https://styra.com
+  microsoft:
+    name: Microsoft
+    link: https://microsoft.com
+  google:
+    name: Google
+    link: https://google.com
+  travelnest:
+    name: TravelNest
+    link: https://travelnest.com
+  ticketmaster:
+    name: TicketMaster
+    link: https://www.ticketmaster.com/
+  docker:
+    name: Docker
+    link: https://www.docker.com/
+  snyk:
+    name: Snyk
+    link: https://snyk.io/
+  ceph:
+    name: Ceph
+    link: https://ceph.io/
+  fig:
+    name: fig
+    link: https://fig.io
+  redhat:
+    name: RedHat
+    link: https://www.redhat.com
+  medallia:
+    name: Medallia
+    link: https://www.medallia.com/
+  gsoc:
+    name: Google Summer of Code
+    link: https://summerofcode.withgoogle.com/
+  cisco:
+    name: Cisco
+    link: https://www.cisco.com/
+  adaptant:
+    name: Adaptant
+    link: https://www.adaptant.io/
+  armory:
+    name: Armory
+    link: https://www.armory.io/
+  minio:
+    name: Minio
+    link: https://min.io/
+  ibm:
+    name: IBM
+    link: https://developer.ibm.com/open
+  boomerang:
+    name: Boomerang
+    link: https://www.useboomerang.io/
+  bisnode:
+    name: Bisnode
+    link: https://www.bisnode.com
+  goldmansachs:
+    name: Goldman Sachs
+    link: https://www.goldmansachs.com/
+  pinterest:
+    name: Pinterest
+    link: https://www.pinterest.com/
+  atlassian:
+    name: Atlassian
+    link: https://www.atlassian.com/
+  tripadvisor:
+    name: TripAdvisor
+    link: https://www.tripadvisor.com/
+  chef:
+    name: Chef
+    link: https://www.chef.io/
+  buoyant:
+    name: Buoyant
+    link: https://buoyant.io/
+  netflix:
+    name: Netflix
+    link: https://www.netflix.com/
+  capitalone:
+    name: CapitalOne
+    link: https://www.capitalone.com/
+  yelp:
+    name: Yelp
+    link: https://www.yelp.com/
+  sysdig:
+    name: Sysdig
+    link: https://sysdig.com/
+  wada-ama:
+    name: World Anti-Doping Agency
+    link: https://www.wada-ama.org
+  infoblox:
+    name: InfoBlox
+    link: https://www.infoblox.com/
+  independent:
+    name: Independent developer
+    link: https://www.openpolicyagent.org
+  scalr:
+    name: Scalr
+    link: https://www.scalr.com/
+  sigstore:
+    name: Sigstore
+    link: https://sigstore.dev/
+  build.security:
+    name: build.security
+    link: https://www.elastic.co/blog/elastic-and-build-security-shifting-left-together-to-secure-the-cloud
+  fugue:
+    name: Fugue
+    link: https://www.fugue.co
+  accurics:
+    name: Accurics
+    link: https://www.accurics.com/
+  checkmarx:
+    name: Checkmarx
+    link: https://www.checkmarx.com
+  fairwinds:
+    name: Fairwinds
+    link: https://fairwinds.com
+  permitio:
+    name: Permit.io
+    link: https://permit.io
+  alertavert:
+    name: AlertAVert.com
+    link: https://www.alertavert.com/
+  zenity:
+    name: Zenity
+    link: https://www.zenity.io
+  apache-apisix:
+    name: Apache APISIX
+    link: https://apisix.apache.org/
+  armo:
+    name: ARMO
+    link: https://armosec.io
+  i2:
+    name: Independent Identity
+    link: https://www.independentid.com
+  aserto:
+    name: Aserto
+    link: https://www.aserto.com
+  snowflake:
+    name: Snowflake
+    link: https://www.snowflake.com/
+  pulumi:
+    name: Pulumi
+    link: https://www.pulumi.com/
+  mia-platform:
+    name: Mia-Platform
+    link: https://mia-platform.eu/
+  waltid:
+    name: walt.id
+    link: https://walt.id
+  blockchainlabum:
+    name: Blockchain Lab:UM
+    link: https://blockchain-lab.um.si
+  netis:
+    name: Netis
+    link:  http://netis.si/en/
+  spacelift:
+    name: Spacelift
+    link: https://spacelift.io
+  circleci:
+    name: CircleCI
+    link: https://circleci.com
+  hashicorp:
+    name: HashiCorp
+    link: https://www.hashicorp.com/
+  wirelesssecuritylab:
+    name: WirelessSecurityLab
+    link: https://github.com/wirelesssecuritylab/
+  megaease:
+    name: MegaEase
+    link: https://www.megaease.com/
+  reposaur:
+    name: Reposaur
+    link: https://reposaur.com/
+  alluxio:
+    name: Alluxio
+    link: https://www.alluxio.io
+  carbonetes:
+    name: Carbonetes
+    link: https://www.carbonetes.com/
+  cloudposse:
+    name: Cloud Posse
+    link: https://cloudposse.com
+  dolevf:
+    name: Dolev Farhi
+    link: https://github.com/dolevf
+  christophwille:
+    name: Christoph Wille
+    link: https://github.com/christophwille
+  a2d24:
+    name: a2d24
+    link: https://github.com/a2d24
+  sangkeon:
+    name: Sangkeon Nam
+    link: https://github.com/sangkeon
+  matrix:
+    name: matrix.org
+    link: https://matrix.org
+
+software:
+  oauth:
+    name: OAuth
+    link: https://oauth.net/
+  oidc:
+    name: OpenID Connect (OIDC)
+    link: https://openid.net/connect/
+  dapr:
+    name: Dapr
+    link: https://dapr.io/
+  fig:
+    name: fig
+    link: https://fig.io
+  kubernetes:
+    name: Kubernetes
+    link: https://kubernetes.io
+  envoy:
+    name: Envoy
+    link: https://envoyproxy.io
+  istio:
+    name: Istio
+    link: https://istio.io
+  kong:
+    name: Kong
+    link: https://konghq.com/
+  linuxpam:
+    name: Linux PAM
+    link: http://www.linux-pam.org/
+  terraform:
+    name: Terraform
+    link: https://www.terraform.io/
+  kafka:
+    name: Kafka
+    link: https://kafka.apache.org/
+  ceph:
+    name: Ceph
+    link: https://ceph.io/
+  clojure:
+    name: Clojure
+    link: https://clojure.org
+  cosign:
+    name: Cosign
+    link: https://github.com/sigstore/cosign
+  aws:
+    name: Amazon Public Cloud
+    link: https://aws.com
+  gcp:
+    name: Google Public Cloud
+    link: https://cloud.google.com/
+  azure:
+    name: Microsoft Public Cloud
+    link: https://azure.microsoft.com/
+  cloudformation:
+    name: AWS CloudFormation
+    link: https://aws.amazon.com/cloudformation/
+  fiber:
+    name: Fiber
+    link: https://docs.gofiber.io
+  golang:
+    name: golang
+    link: https://golang.org/
+  java:
+    name: Java
+    link: https://www.java.com/
+  javaspringsecurity:
+    name: Spring Security
+    link: https://spring.io/projects/spring-security
+  osm:
+    name: Open Service Mesh
+    link: https://openservicemesh.io/
+  spinnaker:
+    name: Spinnaker
+    link: https://www.spinnaker.io/
+  strimzi:
+    name: Strimzi
+    link: https://strimzi.io/
+  elasticsearch:
+    name: Elastic Search
+    link: https://www.elastic.co/
+  azurecosmos:
+    name: Azure Cosmos
+    link: https://docs.microsoft.com/en-us/azure/cosmos-db/introduction
+  azuretablestorage:
+    name: Azure Table Storage
+    link: https://docs.microsoft.com/en-us/azure/cosmos-db/table-storage-overview
+  sqlite:
+    name: SQLite
+    link: https://www.sqlite.org/index.html
+  clair:
+    name: Clair
+    link: https://github.com/coreos/clair
+  cloudflare:
+    name: Cloudflare
+    link: https://www.cloudflare.com
+  openfaas:
+    name: OpenFaaS
+    link: https://www.openfaas.com/
+  minio:
+    name: Minio
+    link: https://min.io/
+  dart:
+    name: dart
+    link: https://dart.dev/
+  docker:
+    name: Docker
+    link: https://www.docker.com/
+  bosun:
+    name: Boomerang Bosun
+    link: https://www.useboomerang.io/
+  php:
+    name: PHP
+    link: https://www.php.net/
+  gradle:
+    name: Gradle
+    link: https://gradle.org/
+  jenkins:
+    name: Jenkins
+    link: https://jenkins.io/
+  sysdigsecure:
+    name: Sysdig Secure
+    link: https://sysdig.com/products/kubernetes-security/
+  pomerium:
+    name: Pomerium
+    link: https://www.pomerium.io/
+  coredns:
+    name: CoreDNS
+    link: https://coredns.io/
+  gluu:
+    name: Gluu Gateway
+    link: https://www.gluu.org/
+  nodejsexpress:
+    name: Node.JS express
+    link: https://expressjs.com/
+  aspdotnetcore:
+    name: ASP .NET core
+    link: https://docs.microsoft.com/en-us/aspnet/core/
+  helm:
+    name: Helm
+    link: https://helm.sh/
+  flask:
+    name: Flask
+    link: https://flask.palletsprojects.com/
+  opal:
+    name: OPAL
+    link: https://opal.ac
+  sphinx-doc:
+    name: Sphinx
+    link: https://www.sphinx-doc.org
+  bottle:
+    name: Bottle
+    link: https://bottlepy.org
+  spiffe:
+    name: SPIFFE
+    link: https://spiffe.io
+  spire:
+    name: SPIRE
+    link: https://spiffe.io
+  google-calendar:
+    name: Google Calendar
+    link: https://calendar.google.com/
+  apache-apisix:
+    name: Apache APISIX
+    link: https://apisix.apache.org/
+  kubescape:
+    name: Kubescape
+    link: https://github.com/kubescape/kubescape
+  i2scim:
+    name: i2 SCIM Server
+    link: https://i2scim.io
+  graphene-graphql:
+    name: Graphene GraphQL
+    link: https://graphene-python.org
+  styra-das:
+    name: Styra DAS
+    link: https://www.styra.com/styra-das/
+  enterprise-opa:
+    name: Enterprise OPA
+    link: https://www.styra.com/enterprise-opa/
+  kustomize:
+    name: Kustomize
+    link: https://kustomize.io
+  toml:
+    name: TOML
+    link: https://toml.io
+  groovy:
+    name: Groovy
+    link: https://groovy-lang.org
+  kotlin:
+    name: Kotlin
+    link: https://kotlinlang.org
+  linux:
+    name: Linux
+    link: https://www.kernel.org
+  ebpf:
+    name: eBPF
+    link: https://ebpf.io
+  git:
+    name: Git
+    link: https://git-scm.com
+  pre-commit:
+    name: pre-commit
+    link: https://pre-commit.com
+  rekor:
+    name: rekor
+    link: https://github.com/sigstore/rekor
+  open-policy-registry:
+    name: Open Policy Registry
+    link: https://www.openpolicyregistry.io
+  aserto:
+    name: Aserto
+    link: https://www.aserto.com
+  topaz:
+    name: Topaz
+    link: https://www.topaz.sh
+  emissary-ingress:
+    name: Emissary-Ingress
+    link: https://github.com/emissary-ingress/emissary
+  magda:
+    name: Magda
+    link: https://github.com/magda-io/magda
+  google-kubernetes-engine:
+    name: Google Kubernetes Engine
+    link: https://cloud.google.com/kubernetes-engine/
+  sansshell:
+    name: Sansshell
+    link: https://github.com/Snowflake-Labs/sansshell
+  nginx:
+    name: Nginx
+    link: https://nginx.org/
+  pulumi:
+    name: Pulumi
+    link: https://www.pulumi.com/
+  alfred:
+    name: alfred
+    link: https://github.com/dolevf/Open-Policy-Agent-Alfred
+  rond:
+    name: Rönd
+    link: https://rond-authz.io/
+  regal:
+    name: Regal
+    link: https://github.com/StyraInc/regal
+  ssikit:
+    name: ssikit
+    link: https://walt.id/ssi-kit
+  graphql:
+    name: graphql
+    link: https://graphql.org/
+  ccbr:
+    name: ccbr
+    link: https://github.com/wirelesssecuritylab/ccbr
+  ansible:
+    name: Ansible
+    link: https://www.ansible.com
+  circleci:
+    name: CircleCI
+    link: https://circleci.com
+  terraform-cloud:
+    name: Terraform Cloud
+    link: https://cloud.hashicorp.com/products/terraform
+  github:
+    name: GitHub
+    link: https://github.com
+  alluxio:
+    name: Alluxio
+    link: https://www.alluxio.io
+  brainiac:
+    name: BrainIAC
+    link: https://github.com/carbonetes/brainiac
+  csharp:
+    name: "C#"
+    link: https://docs.microsoft.com/en-us/dotnet/csharp/
+  javascript:
+    name: JavaScript
+    link: https://developer.mozilla.org/en-US/docs/Web/JavaScript
+  rust:
+    name: Rust
+    link: https://www.rust-lang.org/


### PR DESCRIPTION
We got this wrong again: https://github.com/open-policy-agent/opa/pull/6158#issuecomment-1680505381

The data used for the website is always using edge, not the latest release.

https://www.openpolicyagent.org/docs/latest/ecosystem/ is broken at the moment because of this.
