### PR TITLE
website: link ecosystem from edge

### DIFF
--- a/docs/website/layouts/docs/baseof.html
+++ b/docs/website/layouts/docs/baseof.html
@@ -37,17 +37,18 @@
     {{ $ancient := gt $rank 5 }}
 
     {{ $isEdge := (eq $version "edge") }}
+    {{ $isNotEcosystem := (ne (index (split .File.Path "/") 2) "ecosystem") }}
     {{ $isNotLatest := (and (ne $version $latest) (ne $version $latestVersionString)) }}
 
-    <div class="dashboard-wrapper {{ if (or $isEdge $isNotLatest) }}showing-banner-version-warning{{ end }}">
-      {{- if $isEdge }}
+    <div class="dashboard-wrapper {{ if (or (and $isEdge $isNotEcosystem) $isNotLatest) }}showing-banner-version-warning{{ end }}">
+    {{- if $isEdge }}
       <div class="message is-info banner-version-warning">
         <div class="message-body">
           This version is still under development! Latest stable release is <a href="/docs/latest">{{ $latestVersionString }}</a>
           <button class="delete" aria-label="delete"></button>
         </div>
       </div>
-      {{- else if $isNotLatest }}
+    {{- else if $isNotLatest }}
       <div class="message {{ cond $ancient "is-danger" "is-warning"}} banner-version-warning">
       <div class="message-body">
         These are the docs for an older version of OPA ({{ $version }}). Latest stable release is <a href="/docs/latest">{{ $latestVersionString }}</a>

--- a/docs/website/layouts/docs/ecosystem.html.html
+++ b/docs/website/layouts/docs/ecosystem.html.html
@@ -87,7 +87,7 @@
       <section class="section">
         <div class="content">
           <p>
-            Please see the latest docs for the <a href="https://www.openpolicyagent.org/docs/latest/ecosystem/">OPA Ecosytem List</a>.
+            Please see the latest docs for the <a href="https://www.openpolicyagent.org/docs/edge/ecosystem/">OPA Ecosystem List</a>.
           </p>
         </div>
         {{ if (and (not .Params.hide_feedback) (site.Params.ui.feedback.enable)) }}

--- a/docs/website/layouts/partials/nav.html
+++ b/docs/website/layouts/partials/nav.html
@@ -18,7 +18,7 @@
         <ul class="navbar-nav">
           <li class="nav-item"><a class="nav-link" href="/docs/">Docs</a></li>
           <li class="nav-item"><a class="nav-link" href="/docs/#running-opa">Download</a></li>
-          <li class="nav-item"><a class="nav-link" href="/docs/latest/ecosystem/">Ecosystem</a></li>
+          <li class="nav-item"><a class="nav-link" href="/docs/edge/ecosystem/">Ecosystem</a></li>
           <li class="nav-item"><a class="nav-link" href="/security">Security</a></li>
           <li class="nav-item"><a class="nav-link" href="/support">Support</a></li>
           <li class="nav-item"><a class="nav-link" href="/community">Community</a></li>


### PR DESCRIPTION
Edge works fine, so we'll do this:

1. link to /docs/edge/ecosystem
2. suppress the "you're viewing edge" banner from the
   ecosystem page

We can revisit this when the next release is out, but it
makes the ecosystem page _less broken_ for the time until
then.

Small bonus: you can now directly visit the Ecosystem page from the preview, since it now links to "edge" (was "latest" before, there, too).