### PR TITLE
ast: Making partial object key rules contribute to dynamic portion of object type

### DIFF
--- a/ast/check.go
+++ b/ast/check.go
@@ -268,7 +268,7 @@ func (tc *typeChecker) checkRule(env *TypeEnv, as *AnnotationSet, rule *Rule) {
 	}
 
 	if tpe != nil {
-		env.tree.Insert(path, tpe)
+		env.tree.Insert(path, tpe, env)
 	}
 }
 

--- a/ast/check_test.go
+++ b/ast/check_test.go
@@ -355,8 +355,8 @@ func TestCheckInferenceRules(t *testing.T) {
 		{`overlap`, `p.q.r = false { true }`},
 		{`overlap`, `p.q.r = "false" { true }`},
 		{`overlap`, `p.q[42] = 1337 { true }`},
-		{`overlap`, `p.q.a = input.a { true }`},
-		{`overlap`, `p.q[56] = input.a { true }`},
+		{`overlap`, `p.q2.a = input.a { true }`},
+		{`overlap`, `p.q2[56] = input.a { true }`},
 	}
 
 	tests := []struct {
@@ -525,33 +525,28 @@ func TestCheckInferenceRules(t *testing.T) {
 		{
 			note:     "ref-rules single value, full ref to known leaf (any type)",
 			rules:    ruleset2,
-			ref:      "data.overlap.p.q.a",
+			ref:      "data.overlap.p.q2.a",
 			expected: types.A,
 		},
 		{
 			note:     "ref-rules single value, full ref to known leaf (same key type as dynamic, any type)",
 			rules:    ruleset2,
-			ref:      "data.overlap.p.q[56]",
+			ref:      "data.overlap.p.q2[56]",
 			expected: types.A,
 		},
 		{
 			note:     "ref-rules single value, full ref to dynamic leaf",
 			rules:    ruleset2,
 			ref:      "data.overlap.p.q[1]",
-			expected: types.S,
+			expected: types.Any{types.B, types.N, types.S}, // key type cannot be tied to specific dynamic value type, so we get all of them
 		},
 		{
 			note:  "ref-rules single value, prefix ref to partial object root",
 			rules: ruleset2,
 			ref:   "data.overlap.p.q",
 			expected: types.NewObject(
-				[]*types.StaticProperty{
-					types.NewStaticProperty(json.Number("42"), types.N),
-					types.NewStaticProperty(json.Number("56"), types.A),
-					types.NewStaticProperty("a", types.A),
-					types.NewStaticProperty("r", types.Or(types.B, types.S)),
-				},
-				types.NewDynamicProperty(types.N, types.S),
+				nil,
+				types.NewDynamicProperty(types.Any{types.N, types.S}, types.Any{types.B, types.N, types.S}),
 			),
 		},
 	}

--- a/ast/env.go
+++ b/ast/env.go
@@ -6,9 +6,10 @@ package ast
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/open-policy-agent/opa/types"
 	"github.com/open-policy-agent/opa/util"
-	"strings"
 )
 
 // TypeEnv contains type info for static analysis such as type checking.

--- a/ast/env.go
+++ b/ast/env.go
@@ -6,9 +6,9 @@ package ast
 
 import (
 	"fmt"
-
 	"github.com/open-policy-agent/opa/types"
 	"github.com/open-policy-agent/opa/util"
+	"strings"
 )
 
 // TypeEnv contains type info for static analysis such as type checking.
@@ -171,6 +171,11 @@ func (env *TypeEnv) getRefRec(node *typeTreeNode, ref, tail Ref) types.Type {
 	}
 
 	if node.Leaf() {
+		if node.children.Len() > 0 {
+			if child := node.Child(tail[0].Value); child != nil {
+				return env.getRefRec(child, ref, tail[1:])
+			}
+		}
 		return selectRef(node.Value(), tail)
 	}
 
@@ -305,9 +310,9 @@ func (n *typeTreeNode) Put(path Ref, tpe types.Type) {
 }
 
 // Insert inserts tpe at path in the tree, but also merges the value into any types.Object present along that path.
-// If an types.Object is inserted, any leafs already present further down the tree are merged into the inserted object.
+// If a types.Object is inserted, any leafs already present further down the tree are merged into the inserted object.
 // path must be ground.
-func (n *typeTreeNode) Insert(path Ref, tpe types.Type) {
+func (n *typeTreeNode) Insert(path Ref, tpe types.Type, env *TypeEnv) {
 	curr := n
 	for i, term := range path {
 		c, ok := curr.children.Get(term.Value)
@@ -324,7 +329,7 @@ func (n *typeTreeNode) Insert(path Ref, tpe types.Type) {
 				// If child has an object value, merge the new value into it.
 				if o, ok := child.value.(*types.Object); ok {
 					var err error
-					child.value, err = insertIntoObject(o, path[i+1:], tpe)
+					child.value, err = insertIntoObject(o, path[i+1:], tpe, env)
 					if err != nil {
 						panic(fmt.Errorf("unreachable, insertIntoObject: %w", err))
 					}
@@ -342,7 +347,7 @@ func (n *typeTreeNode) Insert(path Ref, tpe types.Type) {
 		leafs := curr.Leafs()
 		for p, t := range leafs {
 			var err error
-			curr.value, err = insertIntoObject(curr.value.(*types.Object), *p, t)
+			curr.value, err = insertIntoObject(curr.value.(*types.Object), *p, t, env)
 			if err != nil {
 				panic(fmt.Errorf("unreachable, insertIntoObject: %w", err))
 			}
@@ -350,47 +355,62 @@ func (n *typeTreeNode) Insert(path Ref, tpe types.Type) {
 	}
 }
 
-func insertIntoObject(o *types.Object, path Ref, tpe types.Type) (*types.Object, error) {
+func (n *typeTreeNode) String() string {
+	b := strings.Builder{}
+
+	if k := n.key; k != nil {
+		b.WriteString(k.String())
+	} else {
+		b.WriteString("-")
+	}
+
+	if v := n.value; v != nil {
+		b.WriteString(": ")
+		b.WriteString(v.String())
+	}
+
+	n.children.Iter(func(_, v util.T) bool {
+		if child, ok := v.(*typeTreeNode); ok {
+			b.WriteString("\n\t+ ")
+			s := child.String()
+			s = strings.ReplaceAll(s, "\n", "\n\t")
+			b.WriteString(s)
+		}
+		return false
+	})
+
+	return b.String()
+}
+
+func insertIntoObject(o *types.Object, path Ref, tpe types.Type, env *TypeEnv) (*types.Object, error) {
 	if len(path) == 0 {
 		return o, nil
 	}
 
-	key, err := JSON(path[0].Value)
-	if err != nil {
-		return nil, fmt.Errorf("invalid path term %v: %w", path[0], err)
-	}
+	key := env.Get(path[0].Value)
 
 	if len(path) == 1 {
-		for _, prop := range o.StaticProperties() {
-			if util.Compare(prop.Key, key) == 0 {
-				prop.Value = types.Or(prop.Value, tpe)
-				return o, nil
-			}
+		var dynamicProps *types.DynamicProperty
+		if dp := o.DynamicProperties(); dp != nil {
+			dynamicProps = types.NewDynamicProperty(types.Or(o.DynamicProperties().Key, key), types.Or(o.DynamicProperties().Value, tpe))
+		} else {
+			dynamicProps = types.NewDynamicProperty(key, tpe)
 		}
-		staticProps := append(o.StaticProperties(), types.NewStaticProperty(key, tpe))
-		return types.NewObject(staticProps, o.DynamicProperties()), nil
+		return types.NewObject(o.StaticProperties(), dynamicProps), nil
 	}
 
-	for _, prop := range o.StaticProperties() {
-		if util.Compare(prop.Key, key) == 0 {
-			if propO := prop.Value.(*types.Object); propO != nil {
-				prop.Value, err = insertIntoObject(propO, path[1:], tpe)
-				if err != nil {
-					return nil, err
-				}
-			} else {
-				return nil, fmt.Errorf("cannot insert into non-object type %v", prop.Value)
-			}
-			return o, nil
-		}
-	}
-
-	child, err := insertIntoObject(types.NewObject(nil, nil), path[1:], tpe)
+	child, err := insertIntoObject(types.NewObject(nil, nil), path[1:], tpe, env)
 	if err != nil {
 		return nil, err
 	}
-	staticProps := append(o.StaticProperties(), types.NewStaticProperty(key, child))
-	return types.NewObject(staticProps, o.DynamicProperties()), nil
+
+	var dynamicProps *types.DynamicProperty
+	if dp := o.DynamicProperties(); dp != nil {
+		dynamicProps = types.NewDynamicProperty(types.Or(o.DynamicProperties().Key, key), types.Or(o.DynamicProperties().Value, child))
+	} else {
+		dynamicProps = types.NewDynamicProperty(key, child)
+	}
+	return types.NewObject(o.StaticProperties(), dynamicProps), nil
 }
 
 func (n *typeTreeNode) Leafs() map[*Ref]types.Type {

--- a/test/cases/testdata/type/test-regressions.yaml
+++ b/test/cases/testdata/type/test-regressions.yaml
@@ -30,3 +30,28 @@ cases:
   query: data.test.q = x
   want_result:
     - x: ["bar"]
+- note: regression/dynamic object to static object comparison (https://github.com/open-policy-agent/opa/issues/6138)
+  modules:
+    - |
+      package test
+      
+      obj[k] := v {
+        v := ["a", "b", "c"][k]
+      }
+
+      obj.foo := "bar"
+      
+      obj.baz := true { false }
+      
+      compare {
+        # Comparison with static object that doesn't contain "optional" key.
+        obj == {
+          0: "a",
+          1: "b",
+          2: "c",
+          "foo": "bar"
+        }
+      }
+  query: data.test.compare = x
+  want_result:
+    - x: true


### PR DESCRIPTION
instead of static portion.

This change allows object unification/comparison between an object composed at eval-time (i.e. constructed by rules) and a static object that doesn't contain all keys declared by rules, as those might not be defined at eval-time.

e.g.:

```rego
package test
      
obj[k] := v {
  v := ["a", "b", "c"][k]
}

obj.foo := "bar"

obj.baz := true { false }

compare {
  # Comparison with static object that doesn't contain "optional" key.
  obj == {
    0: "a",
    1: "b",
    2: "c",
    "foo": "bar"
  }
}
```

Fixes: #6138