### PR TITLE
docs: make it clear dropped decisions aren't logged

### DIFF
--- a/docs/content/management-decision-logs.md
+++ b/docs/content/management-decision-logs.md
@@ -258,34 +258,40 @@ to track **remove** vs **upsert** mask operations.
 
 ### Drop Decision Logs
 
-Drop rules filters all decisions, which evaluate to `true`, before logging them.
+Drop rules filters all decisions from logging where the rule evaluates to `true`. 
 
 This rule will drop all requests to the _allow_ rule in the _kafka_ package, that returned _true_:
 ```live:drop_rule_example/kafka_allow_rule:module:read_only
 package system.log
 
-drop {
-  input.path == "kafka/allow"
-  input.result == true
+import future.keywords.if
+
+drop if {
+    input.path == "kafka/allow"
+    input.result == true
 }
 ```
 
-Log only requests for _delete_ and _alter_ operations (Kafka with opa-kafka-authorizer):
+Log only requests for _delete_ and _alter_ operations
+(Kafka with the [opa-kafka-plugin](https://github.com/StyraInc/opa-kafka-plugin)):
 
 ```live:drop_rule_example/log_only_delete_alter_operations:module:read_only
 package system.log
 
+import future.keywords.if
 import future.keywords.in
 
-drop {
-  input.path == "kafka/allow"
-  not input.input.action.operation in {"DELETE", "ALTER"}
+drop if {
+    input.path == "kafka/allow"
+    not input.input.action.operation in {"DELETE", "ALTER"}
+}
 ```
 
-The name of the drop rules by default is `drop` in the package `system.log`. It can be changed with the configuration property `decision_logs.drop_decision`.
+The name of the drop rules by default is `drop` in the package `system.log`. It can be changed with the configuration
+property `decision_logs.drop_decision`.
 ```yaml
 decision_logs:
-    drop_decision: /system/log/drop
+  drop_decision: /system/log/drop
 ```
 
 ### Rate Limiting Decision Logs


### PR DESCRIPTION
Make it clear that dropped decisions are *not* logged, and modernize the Rego examples.