### PR TITLE
cmd: Fix opa test --ignore when used together with --bundle

### DIFF
--- a/tester/runner.go
+++ b/tester/runner.go
@@ -621,6 +621,7 @@ func LoadBundles(args []string, filter loader.Filter) (map[string]*bundle.Bundle
 		b, err := loader.NewFileLoader().
 			WithProcessAnnotation(true).
 			WithSkipBundleVerification(true).
+			WithFilter(filter).
 			AsBundle(bundleDir)
 		if err != nil {
 			return nil, fmt.Errorf("unable to load bundle %s: %s", bundleDir, err)


### PR DESCRIPTION
### Why the changes in this PR are needed?

When used `opa test --bundle` the flags `--ignore` were not used to filter the files.

### What are the changes in this PR?

Change the function `LoadBundles` to use the parameter `filter` received.

### Notes to assist PR review:

None.

### Further comments:

None.