### PR TITLE
rego: expose PrepareOption, add BuiltinFuncs

### DIFF
--- a/rego/prepare_test.go
+++ b/rego/prepare_test.go
@@ -1,0 +1,39 @@
+// Copyright 2023 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package rego_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
+	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/rego"
+	"github.com/open-policy-agent/opa/topdown"
+	"github.com/open-policy-agent/opa/types"
+)
+
+// NOTE(sr): These test are here because the only cases where PrepareOption are
+// used is outside of the rego package. Testing them within the rego package
+// would be less realistic.
+func TestPrepareOption(t *testing.T) {
+	t.Run("BuiltinFuncs", func(t *testing.T) {
+		bi := map[string]*topdown.Builtin{
+			"count": {
+				Decl: ast.BuiltinMap["count"],
+				Func: topdown.GetBuiltin("count"),
+			},
+		}
+		pc := &rego.PrepareConfig{}
+		rego.WithBuiltinFuncs(bi)(pc)
+		act, exp := pc.BuiltinFuncs(), bi
+		if diff := cmp.Diff(exp, act,
+			cmpopts.IgnoreUnexported(ast.Builtin{}, types.Function{}),
+			cmpopts.IgnoreFields(topdown.Builtin{}, "Func")); diff != "" {
+			t.Errorf("unexpected result (-want, +got):\n%s", diff)
+		}
+	})
+}

--- a/rego/rego.go
+++ b/rego/rego.go
@@ -1502,6 +1502,7 @@ type PrepareOption func(*PrepareConfig)
 type PrepareConfig struct {
 	doPartialEval   bool
 	disableInlining *[]string
+	builtinFuncs    map[string]*topdown.Builtin
 }
 
 // WithPartialEval configures an option for PrepareForEval
@@ -1518,6 +1519,25 @@ func WithNoInline(paths []string) PrepareOption {
 	return func(p *PrepareConfig) {
 		p.disableInlining = &paths
 	}
+}
+
+// WithBuiltinFuncs carries the rego.Function{1,2,3} per-query function definitions
+// to the target plugins.
+func WithBuiltinFuncs(bis map[string]*topdown.Builtin) PrepareOption {
+	return func(p *PrepareConfig) {
+		if p.builtinFuncs == nil {
+			p.builtinFuncs = make(map[string]*topdown.Builtin, len(bis))
+		}
+		for k, v := range bis {
+			p.builtinFuncs[k] = v
+		}
+	}
+}
+
+// BuiltinFuncs allows retrieving the builtin funcs set via PrepareOption
+// WithBuiltinFuncs.
+func (p *PrepareConfig) BuiltinFuncs() map[string]*topdown.Builtin {
+	return p.builtinFuncs
 }
 
 // PrepareForEval will parse inputs, modules, and query arguments in preparation
@@ -1622,6 +1642,8 @@ func (r *Rego) PrepareForEval(ctx context.Context, opts ...PrepareOption) (Prepa
 			if err != nil {
 				return PreparedEvalQuery{}, err
 			}
+			// always add the builtins provided via rego.FunctionN options
+			opts = append(opts, WithBuiltinFuncs(r.builtinFuncs))
 			r.targetPrepState, err = tgt.PrepareForEval(ctx, pol, opts...)
 			if err != nil {
 				return PreparedEvalQuery{}, err


### PR DESCRIPTION
This is used as a mechanism to inform custom rego target plugins about builtins that have been defined ad-hoc, via rego.Function1, rego.Function2, etc.

Before, in a setup like this:

```go
	regoArgs = append(regoArgs,
		rego.Target("my_custom_evaluator"),
		// ...
		rego.Function2(builtins.RegalParseModuleMeta, builtins.RegalParseModule),
		rego.Function1(builtins.RegalJSONPrettyMeta, builtins.RegalJSONPretty),
		rego.Function1(builtins.RegalLastMeta, builtins.RegalLast),
	)
```
...the prepared eval state for the custom rego target would not be informed about the functions defined there ☝️ 

Now, the PrepareOptions that are passed to the target plugins are used to carry the information along. To do that, a new field was added, and an accessor function.

In the working stages of this, I had also added accessors for NoInline and PartialEval, but since the target plugin mechanism explicitly does not support anything PE-related (yet), I've rolled those changes back.