### PR TITLE
[docs] Address issues with Ecosystem links in navs

### DIFF
--- a/docs/website/layouts/partials/docs/navbar.html
+++ b/docs/website/layouts/partials/docs/navbar.html
@@ -16,7 +16,7 @@
 {{ $operations  := where $allDocs ".Params.kind" "eq" "operations" }}
 {{ $management  := where $allDocs ".Params.kind" "eq" "management" }}
 {{ $contrib     := where $allDocs ".Params.kind" "eq" "contrib" }}
-{{ $misc        := where $allDocs ".Params.kind" "eq" "misc" }}
+{{ $misc       := where (where $allDocs ".Params.kind" "eq" "misc") ".Title" "ne" "Ecosystem" }}
 {{ $version     := index (split .File.Path "/") 1 }}
 {{ $pageUrl     := .Permalink }}
 <nav class="navbar is-primary">
@@ -66,10 +66,13 @@
         Support
       </span>
       <a class="navbar-item" href="/support">
-        Enterprise and Commercial
+        Enterprise
       </a>
       <a class="navbar-item" href="/community">
         Community
+      </a>
+      <a class="navbar-item" href="/ecosystem">
+        OPA Ecosystem
       </a>
     </div>
 

--- a/docs/website/layouts/partials/docs/sidenav.html
+++ b/docs/website/layouts/partials/docs/sidenav.html
@@ -8,8 +8,9 @@
 {{ $operations := where $allDocs ".Params.kind" "eq" "operations" }}
 {{ $management := where $allDocs ".Params.kind" "eq" "management" }}
 {{ $contrib    := where $allDocs ".Params.kind" "eq" "contrib" }}
-{{ $misc       := where $allDocs ".Params.kind" "eq" "misc" }}
-{{ $support    := where $allDocs ".Params.kind" "eq" "support" }}
+{{/* Drop all ecosystem pages in historic versions in favor of hard coded link below */}}
+{{ $misc       := where (where $allDocs ".Params.kind" "eq" "misc") ".Title" "ne" "Ecosystem" }}
+{{ $support    := where (where (where $allDocs ".Params.kind" "eq" "support") ".Title" "ne" "Ecosystem") ".Title" "ne" "OPA Ecosystem" }}
 {{ $pageUrl    := .Permalink }}
 {{ $isDocsHome := eq .Permalink $docsHome.Permalink }}
 {{ $version    := index (split .File.Path "/") 1 }}
@@ -53,10 +54,5 @@
 
 {{ partial "docs/sidenav-section.html" ( dict "ctx" . "sectionTitle" "Support" "section" $support "pageUrl" $pageUrl "version" $version ) }}
 
-<a class="docs-nav-item" href="/ecosystem">
-  OPA Ecosystem
-</a>
-
-<a class="docs-nav-item" href="/support">
-  Enterprise
-</a>
+<a class="docs-nav-item" href="/ecosystem">OPA Ecosystem</a>
+<a class="docs-nav-item" href="/support">Enterprise</a>


### PR DESCRIPTION
There are the following issues with the docs menus at the moment:

* OPA ecosystem is shown 2x for some versions
* OPA ecosystem is not linked from the mobile nav in the latest version
* OPA ecosystem still appears under misc in earlier versions

<img width="275" alt="Screenshot 2023-08-31 at 10 32 26" src="https://github.com/open-policy-agent/opa/assets/1774239/da635e2e-bf57-4722-a2e9-1d0cd36fa37f">
<img width="180" alt="Screenshot 2023-08-31 at 10 25 57" src="https://github.com/open-policy-agent/opa/assets/1774239/0d7273e2-2d7c-4d26-9a01-d2896268aa64">

In order to make changes based on page structure in earlier versions, I've had to filter how the pages are selected. I've opted to exclude all content based linking to the opa ecosystem and replace it with the hardcoded link to the now unversioned page /ecosystem.

The mobile enterprise support link has also been renamed to match the link text used on the desktop sidenav