### PR TITLE
types: New benchmarks + new (Any).Union algorithm

### DIFF
--- a/compile/compile_bench_test.go
+++ b/compile/compile_bench_test.go
@@ -3,6 +3,7 @@ package compile
 import (
 	"context"
 	"fmt"
+	"io/fs"
 	"strings"
 	"testing"
 
@@ -22,11 +23,11 @@ func BenchmarkCompileDynamicPolicy(b *testing.B) {
 
 	for _, n := range numPolicies {
 		testcase := generateDynamicPolicyBenchmarkData(n)
-		b.Run(fmt.Sprintf("%d", n), func(b *testing.B) {
-			test.WithTempFS(testcase, func(root string) {
-				b.ResetTimer()
-
+		test.WithTestFS(testcase, true, func(root string, fileSys fs.FS) {
+			b.ResetTimer()
+			b.Run(fmt.Sprintf("%d", n), func(b *testing.B) {
 				compiler := New().
+					WithFS(fileSys).
 					WithPaths(root)
 
 				err := compiler.Build(context.Background())

--- a/types/types_bench_test.go
+++ b/types/types_bench_test.go
@@ -38,3 +38,57 @@ func generateType(n int) Type {
 	}
 	return NewObject(static, nil)
 }
+
+func generateTypeWithPrefix(n int, prefix string) Type {
+	static := make([]*StaticProperty, n)
+	for i := 0; i < n; i++ {
+		static[i] = NewStaticProperty(prefix+fmt.Sprint(i), S)
+	}
+	return NewObject(static, nil)
+}
+
+func BenchmarkAnyMergeOne(b *testing.B) {
+	sizes := []int{100, 500, 1000, 5000, 10000}
+	for _, size := range sizes {
+		anyA := Any(make([]Type, 0, size))
+		for i := 0; i < size; i++ {
+			tpe := generateType(i)
+			anyA = append(anyA, tpe)
+		}
+		tpeB := N
+		b.ResetTimer()
+		b.Run(fmt.Sprint(size), func(b *testing.B) {
+			result := anyA.Merge(tpeB)
+			if len(result) != len(anyA)+1 {
+				b.Fatalf("Expected length of merged result to be: %d, got: %d", len(anyA)+1, len(result))
+			}
+		})
+	}
+}
+
+// Build up 2x Any type lists of unique and different types, then Union merge.
+func BenchmarkAnyUnionAllUniqueTypes(b *testing.B) {
+	sizes := []int{100, 250, 500, 1000, 2500}
+	for _, sizeA := range sizes {
+		for _, sizeB := range sizes {
+			anyA := Any(make([]Type, 0, sizeA))
+			for i := 0; i < sizeA; i++ {
+				tpe := generateType(i)
+				anyA = append(anyA, tpe)
+			}
+			anyB := Any(make([]Type, 0, sizeB))
+			for i := 0; i < sizeB; i++ {
+				tpe := generateTypeWithPrefix(i, "B-")
+				anyB = append(anyB, tpe)
+			}
+			b.ResetTimer()
+			b.Run(fmt.Sprintf("%dx%d", sizeA, sizeB), func(b *testing.B) {
+				resultA2B := anyA.Union(anyB)
+				// Expect length to be A + B - 1, because the `object` type is present in both Any type sets.
+				if len(resultA2B) != (len(anyA) + len(anyB) - 1) {
+					b.Fatalf("Expected length of unioned result to be: %d, got: %d", len(anyA)+len(anyB), len(resultA2B))
+				}
+			})
+		}
+	}
+}


### PR DESCRIPTION
### Why the changes in this PR are needed?

I noticed an optimization opportunity for the type checker's `Any` type, specifically when merging two `Any` types together with the `Union` method.

This came up as part of a continuing investigation into #5216, and I realized I could carve off a useful set of changes along the way.

*Note: This **does not** significantly change the bottom line for #5216 sadly, since the bottleneck is distributed across 2-3x other places. :slightly_frowning_face:* 

### What are the changes in this PR?

This PR extends the `types/types_bench_test.go` benchmarks with **2x new benchmarks**, one for the frequently-called `(Any).Merge` function, and another for `(Any).Union`.

It also **implements a new algorithm** for `(Any).Union` which is dramatically more efficient than the original, and scales to larger sizes without pathological allocation/thrashing behavior in the limit.

There's also a **small change to the `BenchmarkCompileDynamicPolicy` benchmark from #5216**, which reduces the impact on the host filesystem by not regenerating the entire temp directory on each benchmark iteration (reducing timing variance *a lot*), and also keeping the test filesystem in-memory for the duration of the tests (reduces file system pressure, but ups the memory pressure on the Go runtime, which only slightly changes the ranges of numbers in the results; the overall story/bad scaling remains the same).

#### Algorithm scaling changes:

For `(Any).Union(Any)`:
 - $N$ is the size of the left-side `Any`
 - $M$ is the size of the right-side `Any`

The old algorithm scaled in $O(M*log(N))$ `Compare` operations in the worst case.
The new algorithm scales in $O(N+M)$ `Compare` operations in the worst case.

On average, this tends to result in a more stable number of comparisons, and the copying loop stays on the stack, with no explosions of heap allocations, even as sizes scale up (see the benchstat plots below).

### Notes to assist PR review:

#### Plots!

![Screenshot from 2023-09-14 14-24-12](https://github.com/open-policy-agent/opa/assets/1906841/df440e3f-5503-4f5f-a355-1cfaadbeb11e)
*These plots were generated from representative runs of the `AnyUnionAllUniqueTypes` benchmark, using `main` and this PR.*

#### Benchstat data

Benchstat results between `main` and this PR:

<details>
<summary>Benchstat dump (10+ runs each)</summary>

```
name                                old time/op    new time/op    delta
AnyUnionAllUniqueTypes/100x100-8      0.00ns ±19%    0.00ns ±32%   -99.80%  (p=0.000 n=17+10)
AnyUnionAllUniqueTypes/100x250-8      0.01ns ±29%    0.00ns ±31%   -99.83%  (p=0.000 n=19+10)
AnyUnionAllUniqueTypes/100x500-8      0.02ns ±39%    0.00ns ±31%   -99.94%  (p=0.000 n=18+9)
AnyUnionAllUniqueTypes/100x1000-8     0.09ns ± 6%    0.00ns ±52%   -99.97%  (p=0.000 n=18+9)
AnyUnionAllUniqueTypes/100x2500-8     0.37ns ± 3%    0.00ns ± 4%   -99.99%  (p=0.000 n=17+8)
AnyUnionAllUniqueTypes/250x100-8      0.03ns ±13%    0.00ns ±10%   -99.92%  (p=0.000 n=19+8)
AnyUnionAllUniqueTypes/250x250-8      0.03ns ±25%    0.00ns ±11%   -99.91%  (p=0.000 n=20+8)
AnyUnionAllUniqueTypes/250x500-8      0.03ns ± 7%    0.00ns ±36%   -99.91%  (p=0.000 n=18+10)
AnyUnionAllUniqueTypes/250x1000-8     0.12ns ± 4%    0.00ns ±16%   -99.96%  (p=0.000 n=19+9)
AnyUnionAllUniqueTypes/250x2500-8     0.38ns ± 3%    0.00ns ±12%   -99.98%  (p=0.000 n=20+9)
AnyUnionAllUniqueTypes/500x100-8      0.17ns ± 8%    0.00ns ±16%   -99.98%  (p=0.000 n=19+8)
AnyUnionAllUniqueTypes/500x250-8      0.11ns ± 8%    0.00ns ±37%   -99.96%  (p=0.000 n=18+10)
AnyUnionAllUniqueTypes/500x500-8      0.11ns ± 6%    0.00ns ±43%   -99.95%  (p=0.000 n=19+10)
AnyUnionAllUniqueTypes/500x1000-8     0.15ns ± 8%    0.00ns ±20%   -99.94%  (p=0.000 n=19+8)
AnyUnionAllUniqueTypes/500x2500-8     0.16ns ± 3%    0.00ns ±10%   -99.93%  (p=0.000 n=18+10)
AnyUnionAllUniqueTypes/1000x100-8     0.79ns ± 3%    0.00ns ±15%   -99.98%  (p=0.000 n=15+10)
AnyUnionAllUniqueTypes/1000x250-8     0.76ns ± 1%    0.00ns ±23%   -99.98%  (p=0.000 n=10+10)
AnyUnionAllUniqueTypes/1000x500-8     0.42ns ± 2%    0.00ns ±30%   -99.96%  (p=0.000 n=10+10)
AnyUnionAllUniqueTypes/1000x1000-8    0.42ns ± 1%    0.00ns ±16%   -99.95%  (p=0.000 n=9+10)
AnyUnionAllUniqueTypes/1000x2500-8    0.48ns ± 2%    0.00ns ±14%   -99.95%  (p=0.000 n=10+10)
AnyUnionAllUniqueTypes/2500x100-8      5.63s ± 1%     0.00s ± 5%  -100.00%  (p=0.000 n=10+9)
AnyUnionAllUniqueTypes/2500x250-8      4.93s ± 2%     0.00s ±12%  -100.00%  (p=0.000 n=10+10)
AnyUnionAllUniqueTypes/2500x500-8      4.01s ± 3%     0.00s ± 6%  -100.00%  (p=0.000 n=10+10)
AnyUnionAllUniqueTypes/2500x1000-8     2.75s ± 1%     0.00s ± 4%  -100.00%  (p=0.000 n=10+8)
AnyUnionAllUniqueTypes/2500x2500-8     2.54s ± 1%     0.00s ±12%  -100.00%  (p=0.000 n=9+9)

name                                old alloc/op   new alloc/op   delta
AnyUnionAllUniqueTypes/100x100-8       0.00B          0.00B           ~     (all equal)
AnyUnionAllUniqueTypes/100x250-8       0.00B          0.00B           ~     (all equal)
AnyUnionAllUniqueTypes/100x500-8       0.00B          0.00B           ~     (all equal)
AnyUnionAllUniqueTypes/100x1000-8      0.00B          0.00B           ~     (all equal)
AnyUnionAllUniqueTypes/100x2500-8      0.00B          0.00B           ~     (all equal)
AnyUnionAllUniqueTypes/250x100-8       0.00B          0.00B           ~     (all equal)
AnyUnionAllUniqueTypes/250x250-8       0.00B          0.00B           ~     (all equal)
AnyUnionAllUniqueTypes/250x500-8       0.00B          0.00B           ~     (all equal)
AnyUnionAllUniqueTypes/250x1000-8      0.00B          0.00B           ~     (all equal)
AnyUnionAllUniqueTypes/250x2500-8      0.00B          0.00B           ~     (all equal)
AnyUnionAllUniqueTypes/500x100-8       0.00B          0.00B           ~     (all equal)
AnyUnionAllUniqueTypes/500x250-8       0.00B          0.00B           ~     (all equal)
AnyUnionAllUniqueTypes/500x500-8       0.00B          0.00B           ~     (all equal)
AnyUnionAllUniqueTypes/500x1000-8      0.00B          0.00B           ~     (all equal)
AnyUnionAllUniqueTypes/500x2500-8      0.00B          0.00B           ~     (all equal)
AnyUnionAllUniqueTypes/1000x100-8      0.00B          0.00B           ~     (all equal)
AnyUnionAllUniqueTypes/1000x250-8      0.00B          0.00B           ~     (all equal)
AnyUnionAllUniqueTypes/1000x500-8      0.00B          0.00B           ~     (all equal)
AnyUnionAllUniqueTypes/1000x1000-8     0.00B          0.00B           ~     (all equal)
AnyUnionAllUniqueTypes/1000x2500-8     0.00B          0.00B           ~     (all equal)
AnyUnionAllUniqueTypes/2500x100-8     1.31GB ± 0%    0.00GB       -100.00%  (p=0.000 n=9+10)
AnyUnionAllUniqueTypes/2500x250-8     1.15GB ± 0%    0.00GB       -100.00%  (p=0.000 n=9+10)
AnyUnionAllUniqueTypes/2500x500-8      923MB ± 0%       0MB       -100.00%  (p=0.000 n=10+10)
AnyUnionAllUniqueTypes/2500x1000-8     641MB ± 0%       0MB       -100.00%  (p=0.000 n=9+10)
AnyUnionAllUniqueTypes/2500x2500-8     501MB ± 0%       0MB       -100.00%  (p=0.000 n=9+10)

name                                old allocs/op  new allocs/op  delta
AnyUnionAllUniqueTypes/100x100-8        0.00           0.00           ~     (all equal)
AnyUnionAllUniqueTypes/100x250-8        0.00           0.00           ~     (all equal)
AnyUnionAllUniqueTypes/100x500-8        0.00           0.00           ~     (all equal)
AnyUnionAllUniqueTypes/100x1000-8       0.00           0.00           ~     (all equal)
AnyUnionAllUniqueTypes/100x2500-8       0.00           0.00           ~     (all equal)
AnyUnionAllUniqueTypes/250x100-8        0.00           0.00           ~     (all equal)
AnyUnionAllUniqueTypes/250x250-8        0.00           0.00           ~     (all equal)
AnyUnionAllUniqueTypes/250x500-8        0.00           0.00           ~     (all equal)
AnyUnionAllUniqueTypes/250x1000-8       0.00           0.00           ~     (all equal)
AnyUnionAllUniqueTypes/250x2500-8       0.00           0.00           ~     (all equal)
AnyUnionAllUniqueTypes/500x100-8        0.00           0.00           ~     (all equal)
AnyUnionAllUniqueTypes/500x250-8        0.00           0.00           ~     (all equal)
AnyUnionAllUniqueTypes/500x500-8        0.00           0.00           ~     (all equal)
AnyUnionAllUniqueTypes/500x1000-8       0.00           0.00           ~     (all equal)
AnyUnionAllUniqueTypes/500x2500-8       0.00           0.00           ~     (all equal)
AnyUnionAllUniqueTypes/1000x100-8       0.00           0.00           ~     (all equal)
AnyUnionAllUniqueTypes/1000x250-8       0.00           0.00           ~     (all equal)
AnyUnionAllUniqueTypes/1000x500-8       0.00           0.00           ~     (all equal)
AnyUnionAllUniqueTypes/1000x1000-8      0.00           0.00           ~     (all equal)
AnyUnionAllUniqueTypes/1000x2500-8      0.00           0.00           ~     (all equal)
AnyUnionAllUniqueTypes/2500x100-8      65.7M ± 0%      0.0M       -100.00%  (p=0.002 n=8+10)
AnyUnionAllUniqueTypes/2500x250-8      57.5M ± 0%      0.0M       -100.00%  (p=0.002 n=8+10)
AnyUnionAllUniqueTypes/2500x500-8      46.1M ± 0%      0.0M       -100.00%  (p=0.000 n=10+10)
AnyUnionAllUniqueTypes/2500x1000-8     32.0M ± 0%      0.0M       -100.00%  (p=0.000 n=9+10)
AnyUnionAllUniqueTypes/2500x2500-8     25.1M ± 0%      0.0M       -100.00%  (p=0.000 n=9+10)

```

Note: I had double the samples for lower sizes of the benchmark on `main`, because of a few earlier runs that failed due to the default 10 minute timeout for `go test`. I had to manually up the time limit for the `main` benchmarking runs to make it through the full parameter set. :sweat_smile: 

Also, because this is benchstat, and it has more than 5x sample runs to pick from for `main`/PR runs, it throws out outliers automatically, which is why you'll see notes like `n=8+10` for some runs. The `8` comes from 2x outliers being tossed out.

</details>

### Further comments:

<!--
Here you can include links to additional resources related to the changes, discuss your solution, other approaches you considered etc.
-->
