### PR TITLE
nightly: skip Fri/Sat night

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -2,7 +2,7 @@ name: Nightly
 on:
   workflow_dispatch: {}   # Allow for manual triggers
   schedule:
-    - cron:  '0 8 * * *'  # Daily, at 8:00 UTC
+    - cron:  '0 8 * * 0-4' # Sun-Thu, at 8:00 UTC
 
 
 jobs:


### PR DESCRIPTION
It's unlikely that anyone is looking at the results when there's a fresh run's results (of Sunday) awaiting you on Monday.
