### PR TITLE
General refs/docs

### DIFF
--- a/docs/content/policy-language.md
+++ b/docs/content/policy-language.md
@@ -1082,7 +1082,7 @@ Error:
 ```
 
 In the above example, rule `R2` overlaps with the dynamic portion of rule `R1`'s reference (`[x].r`), which is allowed at compile-time, as these rules aren't guaranteed to produce conflicting output.
-However, if `R1` defines `x` as `"q"` and `y` as, e.g. `0`, a conflict will be reported at evaluation-time.
+However, as `R1` defines `x` as `"q"` and `y` as `1`, a conflict will be reported at evaluation-time.
 
 Conflicts are detected at compile-time, where possible, between rules even if they are within the dynamic extent of another rule.
 


### PR DESCRIPTION
Fixes: #5996

Updating documentation with information about general refs in rule heads.

~🚧 ⚠️  These changes are contingent on #6235 getting merged; and should not be merged before those changes.~

Note: we use live code blocks to demonstrate general ref rule heads, and these will be broken until the Rego Playground is updated to use the latest OPA version.

To build the docs, and view the live code blocks, build the playground with `main`-branch OPA and run it locally; then point the docs to that instance by updating `PLAYGROUND` in `docs/website/scripts/live-blocks/src/constants.js`.