### PR TITLE
Insert URL links for names in the support block

### DIFF
--- a/docs/website/layouts/support/section.html.html
+++ b/docs/website/layouts/support/section.html.html
@@ -17,12 +17,12 @@
       </div>
 
       <div class="grid-container page-content">
-        <div class="card" onclick="window.open('https://www.styra.com/styra-opa-support?utm_medium=partner&utm_source=opa&utm_campaign=dmge&utm_content=opa-support')">
+        <div class="card">
           <div class="card-body">
             <div class="d-flex flex-row align-items-center flex-wrap-sm">
               <img class="card-img align-middle" src="/img/logos/styra-logo.png"/>
               <div class="card-text">
-                    <span class="align-middle">Styra is the original creator of Open Policy
+                    <span class="align-middle"><a href="https://www.styra.com/styra-opa-support?utm_medium=partner&utm_source=opa&utm_campaign=dmge&utm_content=opa-support">Styra</a> is the original creator of Open Policy
                       Agent and provides support, professional services, training, and
                       enterprise products.
                     </span>
@@ -30,12 +30,12 @@
             </div>
           </div>
         </div>
-        <div class="card" onclick="window.open('https://paclabs.io/opa_support.html?utm_source=opa&utm_content=opa-support')">
+        <div class="card">
           <div class="card-body">
             <div class="d-flex flex-row align-items-center flex-wrap-sm">
               <img class="card-img align-middle" src="/img/logos/paclabs-logo.png"/>
               <div class="card-text">
-                    <span class="align-middle"> Policy-as-Code Laboratories provides strategic planning
+                    <span class="align-middle"> <a href="https://paclabs.io/opa_support.html?utm_source=opa&utm_content=opa-support">Policy-as-Code Laboratories</a> provides strategic planning
                         and integration consulting for OPA and Rego across the PaC ecosystem
                         (Cloud, Kubernetes, Open Shift and legacy platforms)
                     </span>


### PR DESCRIPTION
The card block being clickable is not clear. This
change updates the card content to include a clickable
company name.