### PR TITLE
fix: parse bytes of millibytes

### DIFF
--- a/test/cases/testdata/units/test-parse-bytes.yaml
+++ b/test/cases/testdata/units/test-parse-bytes.yaml
@@ -219,9 +219,9 @@ cases:
   - |
     package test
     p {
-        units.parse_bytes("100m") == 100000000
+        units.parse_bytes("1000m") == 1
     }
-  note: units_parse_bytes/100 megabytes as m
+  note: units_parse_bytes/1000 millibytes as m
   query: data.test.p = x
   want_result:
   - x: true

--- a/topdown/parse_bytes.go
+++ b/topdown/parse_bytes.go
@@ -23,12 +23,13 @@ const (
 	pi
 	ei
 
-	kb uint64 = 1000
-	mb        = kb * 1000
-	gb        = mb * 1000
-	tb        = gb * 1000
-	pb        = tb * 1000
-	eb        = pb * 1000
+	m  float64 = (1 / 1000.0)
+	kb uint64  = 1000
+	mb         = kb * 1000
+	gb         = mb * 1000
+	tb         = gb * 1000
+	pb         = tb * 1000
+	eb         = pb * 1000
 )
 
 func parseNumBytesError(msg string) error {
@@ -46,7 +47,7 @@ var (
 )
 
 func builtinNumBytes(bctx BuiltinContext, operands []*ast.Term, iter func(*ast.Term) error) error {
-	var m big.Float
+	var numBytes big.Float
 
 	raw, err := builtins.StringOperand(operands[0].Value, 1)
 	if err != nil {
@@ -66,31 +67,33 @@ func builtinNumBytes(bctx BuiltinContext, operands []*ast.Term, iter func(*ast.T
 
 	switch unit {
 	case "":
-		m.SetUint64(none)
+		numBytes.SetUint64(none)
+	case "m":
+		numBytes.SetFloat64(m)
 	case "kb", "k":
-		m.SetUint64(kb)
+		numBytes.SetUint64(kb)
 	case "kib", "ki":
-		m.SetUint64(ki)
-	case "mb", "m":
-		m.SetUint64(mb)
+		numBytes.SetUint64(ki)
+	case "mb":
+		numBytes.SetUint64(mb)
 	case "mib", "mi":
-		m.SetUint64(mi)
+		numBytes.SetUint64(mi)
 	case "gb", "g":
-		m.SetUint64(gb)
+		numBytes.SetUint64(gb)
 	case "gib", "gi":
-		m.SetUint64(gi)
+		numBytes.SetUint64(gi)
 	case "tb", "t":
-		m.SetUint64(tb)
+		numBytes.SetUint64(tb)
 	case "tib", "ti":
-		m.SetUint64(ti)
+		numBytes.SetUint64(ti)
 	case "pb", "p":
-		m.SetUint64(pb)
+		numBytes.SetUint64(pb)
 	case "pib", "pi":
-		m.SetUint64(pi)
+		numBytes.SetUint64(pi)
 	case "eb", "e":
-		m.SetUint64(eb)
+		numBytes.SetUint64(eb)
 	case "eib", "ei":
-		m.SetUint64(ei)
+		numBytes.SetUint64(ei)
 	default:
 		return errBytesUnitNotRecognized(unit)
 	}
@@ -101,7 +104,7 @@ func builtinNumBytes(bctx BuiltinContext, operands []*ast.Term, iter func(*ast.T
 	}
 
 	var total big.Int
-	numFloat.Mul(numFloat, &m).Int(&total)
+	numFloat.Mul(numFloat, &numBytes).Int(&total)
 	return iter(ast.NewTerm(builtins.IntToNumber(&total)))
 }
 


### PR DESCRIPTION
<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->

### Why the changes in this PR are needed?

<!--
Include a short description of WHY the changes were made.
-->

In [SI Prefixes](https://www.nist.gov/pml/owm/metric-si-prefixes), millibytes is defined one-thousandth of a byte

>In the SI, designations of multiples and subdivision of any unit may be arrived at by combining with the name of the unit the prefixes deka, hecto, and kilo meaning, respectively, 10, 100, and 1000, and deci, centi, and milli, meaning, respectively, one-tenth, one-hundredth, and one-thousandth. 

### What are the changes in this PR?

<!--
Include a short description of WHAT changes were made.
-->
Fixes the unit for millibyte `m`

### Notes to assist PR review:

<!--
Here you can add information you think will help the reviewer(s).
-->

### Further comments:

<!--
Here you can include links to additional resources related to the changes, discuss your solution, other approaches you considered etc.
-->
