### PR TITLE
topdown: Improve arith operations by caching small numbers

### DIFF
--- a/topdown/arithmetic.go
+++ b/topdown/arithmetic.go
@@ -5,9 +5,8 @@
 package topdown
 
 import (
-	"math/big"
-
 	"fmt"
+	"math/big"
 
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/topdown/builtins"
@@ -52,6 +51,61 @@ func arithFloor(a *big.Float) (*big.Float, error) {
 	}
 
 	return new(big.Float).Sub(f, big.NewFloat(1.0)), nil
+}
+
+func builtinPlus(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term) error) error {
+	n1, err := builtins.NumberOperand(operands[0].Value, 1)
+	if err != nil {
+		return err
+	}
+	n2, err := builtins.NumberOperand(operands[1].Value, 2)
+	if err != nil {
+		return err
+	}
+
+	x, ok1 := n1.Int()
+	y, ok2 := n2.Int()
+
+	if ok1 && ok2 && x < 256 && y < 256 {
+		z := x + y
+		if z < 256 {
+			return iter(ast.IntNumberTerm(z))
+		}
+	}
+
+	f, err := arithPlus(builtins.NumberToFloat(n1), builtins.NumberToFloat(n2))
+	if err != nil {
+		return err
+	}
+	return iter(ast.NewTerm(builtins.FloatToNumber(f)))
+}
+
+func builtinMultiply(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term) error) error {
+	n1, err := builtins.NumberOperand(operands[0].Value, 1)
+	if err != nil {
+		return err
+	}
+	n2, err := builtins.NumberOperand(operands[1].Value, 2)
+	if err != nil {
+		return err
+	}
+
+	x, ok1 := n1.Int()
+	y, ok2 := n2.Int()
+
+	if ok1 && ok2 && x < 256 && y < 256 {
+		z := x * y
+		if z < 256 {
+			return iter(ast.IntNumberTerm(z))
+		}
+
+	}
+
+	f, err := arithMultiply(builtins.NumberToFloat(n1), builtins.NumberToFloat(n2))
+	if err != nil {
+		return err
+	}
+	return iter(ast.NewTerm(builtins.FloatToNumber(f)))
 }
 
 func arithPlus(a, b *big.Float) (*big.Float, error) {
@@ -119,6 +173,17 @@ func builtinMinus(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term) e
 	n2, ok2 := operands[1].Value.(ast.Number)
 
 	if ok1 && ok2 {
+
+		x, okx := n1.Int()
+		y, oky := n2.Int()
+
+		if okx && oky && x < 256 && y < 256 {
+			z := x - y
+			if z < 256 {
+				return iter(ast.IntNumberTerm(z))
+			}
+		}
+
 		f, err := arithMinus(builtins.NumberToFloat(n1), builtins.NumberToFloat(n2))
 		if err != nil {
 			return err
@@ -150,6 +215,20 @@ func builtinRem(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term) err
 
 	if ok1 && ok2 {
 
+		x, okx := n1.Int()
+		y, oky := n2.Int()
+
+		if okx && oky && x < 256 && y < 256 {
+			if y == 0 {
+				return fmt.Errorf("modulo by zero")
+			}
+
+			z := x % y
+			if z < 256 {
+				return iter(ast.IntNumberTerm(z))
+			}
+		}
+
 		op1, err1 := builtins.NumberToInt(n1)
 		op2, err2 := builtins.NumberToInt(n2)
 
@@ -176,9 +255,9 @@ func init() {
 	RegisterBuiltinFunc(ast.Round.Name, builtinArithArity1(arithRound))
 	RegisterBuiltinFunc(ast.Ceil.Name, builtinArithArity1(arithCeil))
 	RegisterBuiltinFunc(ast.Floor.Name, builtinArithArity1(arithFloor))
-	RegisterBuiltinFunc(ast.Plus.Name, builtinArithArity2(arithPlus))
+	RegisterBuiltinFunc(ast.Plus.Name, builtinPlus)
 	RegisterBuiltinFunc(ast.Minus.Name, builtinMinus)
-	RegisterBuiltinFunc(ast.Multiply.Name, builtinArithArity2(arithMultiply))
+	RegisterBuiltinFunc(ast.Multiply.Name, builtinMultiply)
 	RegisterBuiltinFunc(ast.Divide.Name, builtinArithArity2(arithDivide))
 	RegisterBuiltinFunc(ast.Rem.Name, builtinRem)
 }


### PR DESCRIPTION
<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->

### Why the changes in this PR are needed?

<!--
Include a short description of WHY the changes were made.
-->

Currently for arithmetic operations like addition, subtraction etc. the operands are first converted to the big float type before operating on them. This conversion can be avoided for small numbers w/o impacting the accuracy of the result. 

### What are the changes in this PR?

<!--
Include a short description of WHAT changes were made.
-->

This change attemtps to avoid the conversion for small numbers by caching them and thereby helping to speedup some operations.

### Notes to assist PR review:

<!--
Here you can add information you think will help the reviewer(s).
-->

The division operator (`/ `) was not changed as the result could lose precision with the mechanism used for other operators.
