### PR TITLE
Update documentation on GCS bundles

### DIFF
--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -631,7 +631,7 @@ services:
 bundles:
   authz:
     service: gcs
-    resource: 'bundles%2fhttp%2fexampl%2fbundle.tar.gz?alt=media'
+    resource: 'bundles%2fhttp%2fexample%2fbundle.tar.gz?alt=media'
     persist: true
     polling:
       min_delay_seconds: 60

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -497,7 +497,7 @@ services:
 bundles:
   authz:
     service: gcp
-    resource: 'bundles/http/example/authz.tar.gz?alt=media'
+    resource: 'bundles%2fhttp%2fexample%2fauthz.tar.gz?alt=media'
 
 keys:
   jwt_signing_key:
@@ -631,12 +631,14 @@ services:
 bundles:
   authz:
     service: gcs
-    resource: 'bundle.tar.gz?alt=media'
+    resource: 'bundles%2fhttp%2fexampl%2fbundle.tar.gz?alt=media'
     persist: true
     polling:
       min_delay_seconds: 60
       max_delay_seconds: 120
 ```
+
+When the given resource (the object in the GCS bucket) contains slashes (/) or other special characters, these need to be url-encoded here.
 
 #### Azure Managed Identities Token
 

--- a/docs/content/management-bundles.md
+++ b/docs/content/management-bundles.md
@@ -941,6 +941,9 @@ bundles:
     resource: 'bundle.tar.gz?alt=media'
 ```
 
+If the resource (the object in the gcs bucket) contains slashes (/) or other special characters, these need to be url-encoded here, e.g.
+`bundles/bundle.tar.gz?alt=media` should be entered as `bundles%2fbundle.tar.gz?alt=media`.
+
 ##### Google Cloud Storage Bundle and JWT Bearer Authentication
 
 ```yaml

--- a/docs/content/management-bundles.md
+++ b/docs/content/management-bundles.md
@@ -942,7 +942,7 @@ bundles:
 ```
 
 If the resource (the object in the gcs bucket) contains slashes (/) or other special characters, these need to be url-encoded here, e.g.
-`bundles/bundle.tar.gz?alt=media` should be entered as `bundles%2fbundle.tar.gz?alt=media`.
+`bundles/bundle.tar.gz?alt=media` should be entered as `bundles%2fbundle.tar.gz?alt=media`. Please refer to the [official documentation](https://cloud.google.com/storage/docs/request-endpoints#encoding) for more information.
 
 ##### Google Cloud Storage Bundle and JWT Bearer Authentication
 


### PR DESCRIPTION
When an object in GCS contains special characters such as slashes (/) these need to be url-encoded in the configuration. If not, the bundle will not be found.

e.g. `bundles/bundle.tar.gz` should be entered as `bundles%2fbundle.tar.gz`

This PR adds notes to help the reader know about this and corrects some existing (IMHO incorrect) documentation.

### Why the changes in this PR are needed?

I tried to add a bundle using GCS (with a bundle in a subfolder) and stumbled upon the fact myself. Took me some time
to figure it out. I hope this helps the next reader of this part of the documentation.

### What are the changes in this PR?

Just some notes were added to the documentation regarding GCS bundles, some other parts were corrected.

### Notes to assist PR review:

Personally, I think this is enough. If preferred, though, we could elaborate a little more on it and e.g. link to
the GCS documentation page.

### Further comments:

relevant GCS docs: https://cloud.google.com/storage/docs/request-endpoints#encoding