### PR TITLE
Adding lines not covered to test coverage threshold error message

### DIFF
--- a/cmd/test.go
+++ b/cmd/test.go
@@ -412,6 +412,7 @@ func compileAndSetupTests(ctx context.Context, testParams testCommandParams, sto
 			Modules:   modules,
 			Output:    testParams.output,
 			Threshold: testParams.threshold,
+			Verbose:   testParams.verbose,
 		}
 	}
 

--- a/cover/cover.go
+++ b/cover/cover.go
@@ -6,6 +6,7 @@
 package cover
 
 import (
+	"bytes"
 	"fmt"
 	"math"
 	"sort"
@@ -244,13 +245,38 @@ func (r Report) IsCovered(file string, row int) bool {
 type CoverageThresholdError struct {
 	Coverage  float64
 	Threshold float64
+	Report    *Report
 }
 
 func (e *CoverageThresholdError) Error() string {
-	return fmt.Sprintf(
+	var buffer bytes.Buffer
+	buffer.WriteString(fmt.Sprintf(
 		"Code coverage threshold not met: got %.2f instead of %.2f",
 		e.Coverage,
-		e.Threshold)
+		e.Threshold))
+
+	if e.Report != nil && len(e.Report.Files) > 0 {
+		buffer.WriteString("\nLines not covered:")
+
+		sorted := make([]string, 0, len(e.Report.Files))
+		for file := range e.Report.Files {
+			sorted = append(sorted, file)
+		}
+		sort.Strings(sorted)
+
+		for _, file := range sorted {
+			report := e.Report.Files[file]
+			for _, r := range report.NotCovered {
+				if r.Start.Row == r.End.Row {
+					buffer.WriteString(fmt.Sprintf("\n\t%s:%d", file, r.Start.Row))
+				} else {
+					buffer.WriteString(fmt.Sprintf("\n\t%s:%d-%d", file, r.Start.Row, r.End.Row))
+				}
+			}
+		}
+	}
+
+	return fmt.Sprintf(buffer.String())
 }
 
 func sortedPositionSliceToRangeSlice(sorted []Position) (result []Range) {

--- a/cover/cover.go
+++ b/cover/cover.go
@@ -276,7 +276,7 @@ func (e *CoverageThresholdError) Error() string {
 		}
 	}
 
-	return fmt.Sprintf(buffer.String())
+	return fmt.Sprint(buffer.String())
 }
 
 func sortedPositionSliceToRangeSlice(sorted []Position) (result []Range) {

--- a/tester/reporter.go
+++ b/tester/reporter.go
@@ -181,6 +181,7 @@ type JSONCoverageReporter struct {
 	Modules   map[string]*ast.Module
 	Output    io.Writer
 	Threshold float64
+	Verbose   bool
 }
 
 // Report prints the test report to the reporter's output. If any tests fail or
@@ -197,10 +198,16 @@ func (r JSONCoverageReporter) Report(ch chan *Result) error {
 	report := r.Cover.Report(r.Modules)
 
 	if report.Coverage < r.Threshold {
-		return &cover.CoverageThresholdError{
+		err := cover.CoverageThresholdError{
 			Coverage:  report.Coverage,
 			Threshold: r.Threshold,
 		}
+
+		if r.Verbose {
+			err.Report = &report
+		}
+
+		return &err
 	}
 
 	encoder := json.NewEncoder(r.Output)


### PR DESCRIPTION
when `--verbose` flag is enabled.

Fixes: #2562
