### PR TITLE
internal/pathwatcher: Fix how paths to watch are determined

### DIFF
--- a/internal/pathwatcher/utils_test.go
+++ b/internal/pathwatcher/utils_test.go
@@ -17,10 +17,12 @@ func TestWatchPaths(t *testing.T) {
 
 	fs := map[string]string{
 		"/foo/bar/baz.json": "true",
+		"/foo/faz/baz.json": "true",
+		"/foo/baz.json":     "true",
 	}
 
 	expected := []string{
-		".", "/foo", "/foo/bar",
+		"/foo", "/foo/bar", "/foo/faz",
 	}
 
 	test.WithTempFS(fs, func(rootDir string) {


### PR DESCRIPTION
Currently if a fsnotify watcher is specified for a particular directory, we incorrectly also add it's parent directory to be monitored. This happens because the function that determines which paths are to be watched calls `filepath.Dir` on each of them to get their directory. This is the right thing to do for files as their parent directory gets watched, but when done on a directory especially for the top-level directory adds an incorrect directory to be watched. This changes attempts to fix that.