### PR TITLE
Drop EXPERIMENTAL status of reported prom metrics

### DIFF
--- a/docs/content/monitoring.md
+++ b/docs/content/monitoring.md
@@ -81,15 +81,15 @@ When Prometheus is enabled in the status plugin (see [Configuration](../configur
 
 | Metric name | Metric type | Description                                              | Status |
 | --- | --- |----------------------------------------------------------|--------|
-| opa_info | gauge | Information about the OPA environment.                    | EXPERIMENTAL |
-| plugin_status_gauge | gauge | Number of plugins by name and status.                    | EXPERIMENTAL |
-| bundle_loaded_counter | counter | Number of bundles loaded with success.                   | EXPERIMENTAL |
-| bundle_failed_load_counter | counter | Number of bundles that failed to load.                   | EXPERIMENTAL |
-| last_bundle_request | gauge | Last bundle request in UNIX nanoseconds.                 | EXPERIMENTAL |
-| last_success_bundle_activation | gauge | Last successful bundle activation in UNIX nanoseconds. | EXPERIMENTAL |
-| last_success_bundle_download | gauge | Last successful bundle download in UNIX nanoseconds.   | EXPERIMENTAL |
-| last_success_bundle_request | gauge | Last successful bundle request in UNIX nanoseconds.    | EXPERIMENTAL |
-| bundle_loading_duration_ns | histogram | A histogram of duration for bundle loading.              | EXPERIMENTAL |
+| opa_info | gauge | Information about the OPA environment.                    | STABLE |
+| plugin_status_gauge | gauge | Number of plugins by name and status.                    | STABLE |
+| bundle_loaded_counter | counter | Number of bundles loaded with success.                   | STABLE |
+| bundle_failed_load_counter | counter | Number of bundles that failed to load.                   | STABLE |
+| last_bundle_request | gauge | Last bundle request in UNIX nanoseconds.                 | STABLE |
+| last_success_bundle_activation | gauge | Last successful bundle activation in UNIX nanoseconds. | STABLE |
+| last_success_bundle_download | gauge | Last successful bundle download in UNIX nanoseconds.   | STABLE |
+| last_success_bundle_request | gauge | Last successful bundle request in UNIX nanoseconds.    | STABLE |
+| bundle_loading_duration_ns | histogram | A histogram of duration for bundle loading.              | STABLE |
 
 
 ## Health Checks


### PR DESCRIPTION
Drop `EXPERIMENTAL` status of metrics reported via Prometheus in Status API. OPA's maintained these for a while now and there's no 3rd party dependency required to support these.

Fixes: #6298

