### PR TITLE
server: Remove partial query parameter

### DIFF
--- a/runtime/logging.go
+++ b/runtime/logging.go
@@ -107,12 +107,6 @@ func (h *LoggingHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	params := r.URL.Query()
-
-	if _, ok := params["partial"]; ok {
-		h.logger.Warn("Deprecated 'partial' parameter specified in request. See https://github.com/open-policy-agent/opa/releases/tag/v0.23.0 for details.")
-	}
-
 	h.inner.ServeHTTP(recorder, r)
 
 	dt := time.Since(t0)

--- a/server/types/types.go
+++ b/server/types/types.go
@@ -438,11 +438,6 @@ const (
 	// diagnosing performance issues.
 	ParamInstrumentV1 = "instrument"
 
-	// ParamPartialV1 defines the name of the HTTP URL parameter that indicates
-	// the client wants the partial evaluation optimization to be used during
-	// query evaluation. This parameter is DEPRECATED.
-	ParamPartialV1 = "partial"
-
 	// ParamProvenanceV1 defines the name of the HTTP URL parameter that indicates
 	// the client wants build and version information in addition to the result.
 	ParamProvenanceV1 = "provenance"


### PR DESCRIPTION
The partial query parameter has been marked as deprecated since v0.23.0. It's also removed from the docs since that time.

Fixes: #2266

