### PR TITLE
Don't use rounding for coverage calculation

### DIFF
--- a/cmd/test_test.go
+++ b/cmd/test_test.go
@@ -973,7 +973,7 @@ Lines not covered:
 			threshold:        100,
 			expectedExitCode: 2,
 			verbose:          true,
-			expectedErrOutput: `Code coverage threshold not met: got 33.35 instead of 100.00
+			expectedErrOutput: `Code coverage threshold not met: got 33.33 instead of 100.00
 Lines not covered:
 	%ROOT%/policy1.rego:2-3
 	%ROOT%/policy1.rego:6

--- a/cover/cover.go
+++ b/cover/cover.go
@@ -8,7 +8,6 @@ package cover
 import (
 	"bytes"
 	"fmt"
-	"math"
 	"sort"
 
 	"github.com/open-policy-agent/opa/ast"
@@ -99,7 +98,7 @@ func (c *Cover) Report(modules map[string]*ast.Module) (report Report) {
 	}
 	report.CoveredLines = coveredLoc
 	report.NotCoveredLines = notCoveredLoc
-	report.Coverage = round(overallCoverage, 2)
+	report.Coverage = overallCoverage
 
 	return
 }
@@ -224,7 +223,7 @@ func (fr *FileReport) computeCoveragePercentage() float64 {
 		return 0.0
 	}
 
-	return round(100.0*float64(coveredLoc)/float64(totalLoc), 2)
+	return 100.0 * float64(coveredLoc) / float64(totalLoc)
 }
 
 // Report represents a coverage report for a set of files.
@@ -301,11 +300,6 @@ func sortedPositionSliceToRangeSlice(sorted []Position) (result []Range) {
 
 func hasFileLocation(loc *ast.Location) bool {
 	return loc != nil && loc.File != ""
-}
-
-// round returns the number with the specified precision.
-func round(number float64, precision int) float64 {
-	return math.Round(number*10*float64(precision)) / (10.0 * float64(precision))
 }
 
 // Check the expression and return true if it should be included in the coverage report

--- a/cover/cover_test.go
+++ b/cover/cover_test.go
@@ -117,9 +117,9 @@ p {
 			fr.locNotCovered())
 	}
 
-	expectedCoveragePercentage := round(100.0*float64(len(expectedCovered))/float64(len(expectedCovered)+len(expectedNotCovered)), 2)
+	expectedCoveragePercentage := 100.0 * float64(len(expectedCovered)) / float64(len(expectedCovered)+len(expectedNotCovered))
 	if expectedCoveragePercentage != fr.Coverage {
-		t.Errorf("Expected coverage %f != %f", expectedCoveragePercentage, fr.Coverage)
+		t.Errorf("Expected coverage %v != %v", expectedCoveragePercentage, fr.Coverage)
 	}
 
 	// there's just one file, hence the overall coverage is equal to the
@@ -212,7 +212,7 @@ allow { true }
 			fr.locNotCovered())
 	}
 
-	expectedCoveragePercentage := round(100.0*float64(len(expectedCovered))/float64(len(expectedCovered)+len(expectedNotCovered)), 2)
+	expectedCoveragePercentage := 100.0 * float64(len(expectedCovered)) / float64(len(expectedCovered)+len(expectedNotCovered))
 	if expectedCoveragePercentage != fr.Coverage {
 		t.Errorf("Expected coverage %f != %f", expectedCoveragePercentage, fr.Coverage)
 	}


### PR DESCRIPTION
Perhaps it looks prettier, but this is only reported in JSON output, so I don't think we should decide on what precision to use there.

On coverage < threshold error, we still print using 2 decimals, which is Pretty ✨

Fixes #6307