### PR TITLE
Bind OPA server to localhost interface by default

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -21,8 +21,8 @@ import (
 )
 
 const (
-	defaultAddr        = ":8181"        // default listening address for server
-	defaultHistoryFile = ".opa_history" // default filename for shell history
+	defaultAddr        = "localhost:8181" // default listening address for server
+	defaultHistoryFile = ".opa_history"   // default filename for shell history
 )
 
 type runCmdParams struct {
@@ -180,8 +180,7 @@ be expanded in the future. To disable this, use the --skip-known-schema-check fl
 
 		Run: func(cmd *cobra.Command, args []string) {
 			ctx := context.Background()
-			addrSetByUser := cmd.Flags().Changed("addr")
-			rt, err := initRuntime(ctx, cmdParams, args, addrSetByUser)
+			rt, err := initRuntime(ctx, cmdParams, args)
 			if err != nil {
 				fmt.Println("error:", err)
 				os.Exit(1)
@@ -249,7 +248,8 @@ Flags:
 	RootCommand.AddCommand(runCommand)
 }
 
-func initRuntime(ctx context.Context, params runCmdParams, args []string, addrSetByUser bool) (*runtime.Runtime, error) {
+func initRuntime(ctx context.Context, params runCmdParams, args []string) (*runtime.Runtime, error) {
+
 	authenticationSchemes := map[string]server.AuthenticationScheme{
 		"token": server.AuthenticationToken,
 		"tls":   server.AuthenticationTLS,
@@ -331,7 +331,6 @@ func initRuntime(ctx context.Context, params runCmdParams, args []string, addrSe
 	}
 
 	rt.SetDistributedTracingLogging()
-	rt.Params.AddrSetByUser = addrSetByUser
 
 	return rt, nil
 }

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -16,14 +16,13 @@ import (
 	"github.com/open-policy-agent/opa/logging"
 	"github.com/open-policy-agent/opa/test/e2e"
 	"github.com/open-policy-agent/opa/util/test"
-	"github.com/spf13/cobra"
 )
 
 func TestRunServerBase(t *testing.T) {
 	params := newTestRunParams()
 	ctx, cancel := context.WithCancel(context.Background())
 
-	rt, err := initRuntime(ctx, params, nil, false)
+	rt, err := initRuntime(ctx, params, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -55,7 +54,7 @@ func TestRunServerWithDiagnosticAddr(t *testing.T) {
 	params.rt.DiagnosticAddrs = &[]string{"localhost:0"}
 	ctx, cancel := context.WithCancel(context.Background())
 
-	rt, err := initRuntime(ctx, params, nil, false)
+	rt, err := initRuntime(ctx, params, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -96,7 +95,7 @@ func TestInitRuntimeVerifyNonBundle(t *testing.T) {
 	params.pubKey = "secret"
 	params.serverMode = false
 
-	_, err := initRuntime(context.Background(), params, nil, false)
+	_, err := initRuntime(context.Background(), params, nil)
 	if err == nil {
 		t.Fatal("Expected error but got nil")
 	}
@@ -128,7 +127,7 @@ func TestInitRuntimeSkipKnownSchemaCheck(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		_, err = initRuntime(context.Background(), params, []string{rootDir}, false)
+		_, err = initRuntime(context.Background(), params, []string{rootDir})
 		if err == nil {
 			t.Fatal("Expected error but got nil")
 		}
@@ -139,7 +138,7 @@ func TestInitRuntimeSkipKnownSchemaCheck(t *testing.T) {
 
 		// skip type checking for known input schemas
 		params.skipKnownSchemaCheck = true
-		_, err = initRuntime(context.Background(), params, []string{rootDir}, false)
+		_, err = initRuntime(context.Background(), params, []string{rootDir})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -166,7 +165,7 @@ func TestRunServerCheckLogTimestampFormat(t *testing.T) {
 func checkLogTimeStampFormat(t *testing.T, params runCmdParams, format string) {
 	ctx, cancel := context.WithCancel(context.Background())
 
-	rt, err := initRuntime(ctx, params, nil, false)
+	rt, err := initRuntime(ctx, params, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -211,44 +210,6 @@ func checkLogTimeStampFormat(t *testing.T, params runCmdParams, format string) {
 		if _, err := time.Parse(format, rec.Time); err != nil {
 			t.Fatalf("incorrect timestamp format %q: %v", rec.Time, err)
 		}
-	}
-}
-
-func TestInitRuntimeAddrSetByUser(t *testing.T) {
-	testCases := []struct {
-		name        string
-		addrValue   string
-		addrFlagSet bool
-	}{
-		{"AddrSetByUser_True", "localhost:8181", true},
-		{"AddrSetByUser_False", "", false},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			cmd := &cobra.Command{}
-			cmd.Flags().String("addr", "", "set address")
-			if tc.addrFlagSet {
-				if err := cmd.Flags().Set("addr", tc.addrValue); err != nil {
-					t.Fatalf("Failed to set addr flag: %v", err)
-				}
-			}
-
-			params := newTestRunParams()
-			params.rt.Addrs = &[]string{"localhost:0"}
-			ctx, cancel := context.WithCancel(context.Background())
-
-			rt, err := initRuntime(ctx, params, []string{}, cmd.Flags().Changed("addr"))
-			if err != nil {
-				t.Fatalf("Unexpected error: %v", err)
-			}
-
-			if rt.Params.AddrSetByUser != tc.addrFlagSet {
-				t.Errorf("Expected AddrSetByUser to be %v, but got %v", tc.addrFlagSet, rt.Params.AddrSetByUser)
-			}
-
-			cancel()
-		})
 	}
 }
 

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -1020,7 +1020,7 @@ You can start OPA as a server with `-s` or `--server`:
 ./opa run --server ./example.rego
 ```
 
-By default OPA listens for HTTP connections on `0.0.0.0:8181`. See `opa run
+By default OPA listens for HTTP connections on `localhost:8181`. See `opa run
 --help` for a list of options to change the listening address, enable TLS, and
 more.
 

--- a/docs/content/deployments.md
+++ b/docs/content/deployments.md
@@ -30,11 +30,11 @@ The `run` command accepts a `--server` (or `-s`) flag that starts OPA as a
 server. See `--help` for more information on other arguments. The most important
 command line arguments for OPA's server mode are:
 
-* `--addr` to set the listening address (default: `0.0.0.0:8181`).
+* `--addr` to set the listening address (default: `localhost:8181`).
 * `--log-level` (or `-l`) to set the log level (default: `"info"`).
 * `--log-format` to set the log format (default: `"json"`).
 
-By default, OPA listens for normal HTTP connections on `0.0.0.0:8181`. To make
+By default, OPA listens for normal HTTP connections on `localhost:8181`. To make
 OPA listen for HTTPS connections, see [Security](../security).
 
 We can run OPA as a server using Docker:

--- a/docs/content/security.md
+++ b/docs/content/security.md
@@ -88,21 +88,6 @@ curl -k https://localhost:8181/v1/data
 We have to use cURL's `-k/--insecure` flag because we are using a self-signed certificate.
 {{< /info >}}
 
-## Interface Binding
-
-OPA can be configured to listen on specific interfaces using the `--addr` flag. For example:
-
-```bash
-opa run --server \
-  --log-level debug \
-  --addr localhost:8181 \
-```
-
-By default, OPA binds to the 0.0.0.0 interface, which allows the OPA server to be exposed to services running outside of the same machine. It's important to note that binding OPA to the 0.0.0.0 interface by itself is not inherently insecure in a trusted environment, exposing OPA to the outside world would also require opening ports and likely a similar procedure on a gateway layer above.
-
-In situations where OPA is not intended to be exposed to remote services, it is recommended to bind OPA to the localhost interface, which only allows connections from the same machine. If it is necessary to expose OPA to remote services, ensure to follow the security recommendations on this page, such as requiring authentication.
-
-
 ## Authentication and Authorization
 
 This section shows how to configure OPA to authenticate and authorize client

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -219,9 +219,6 @@ type Params struct {
 
 	DistributedTracingOpts tracing.Options
 
-	// Check if default Addr is set or the user has changed it.
-	AddrSetByUser bool
-
 	// UnixSocketPerm specifies the permission for the Unix domain socket if used to listen for connections
 	UnixSocketPerm *string
 }
@@ -471,11 +468,6 @@ func (rt *Runtime) Serve(ctx context.Context) error {
 		return fmt.Errorf("at least one address must be configured in runtime parameters")
 	}
 
-	serverInitializingMessage := "Initializing server."
-	if !rt.Params.AddrSetByUser {
-		serverInitializingMessage += " OPA is running on a public (0.0.0.0) network interface. Unless you intend to expose OPA outside of the host, binding to the localhost interface (--addr localhost:8181) is recommended. See https://www.openpolicyagent.org/docs/latest/security/#interface-binding"
-	}
-
 	if rt.Params.DiagnosticAddrs == nil {
 		rt.Params.DiagnosticAddrs = &[]string{}
 	}
@@ -483,7 +475,7 @@ func (rt *Runtime) Serve(ctx context.Context) error {
 	rt.logger.WithFields(map[string]interface{}{
 		"addrs":            *rt.Params.Addrs,
 		"diagnostic-addrs": *rt.Params.DiagnosticAddrs,
-	}).Info(serverInitializingMessage)
+	}).Info("Initializing server.")
 
 	if rt.Params.Authorization == server.AuthorizationOff && rt.Params.Authentication == server.AuthenticationToken {
 		rt.logger.Error("Token authentication enabled without authorization. Authentication will be ineffective. See https://www.openpolicyagent.org/docs/latest/security/#authentication-and-authorization for more information.")

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/open-policy-agent/opa/internal/report"
 	"github.com/open-policy-agent/opa/logging"
-	testLog "github.com/open-policy-agent/opa/logging/test"
 	"github.com/open-policy-agent/opa/server"
 
 	"github.com/open-policy-agent/opa/ast"
@@ -552,56 +551,6 @@ func getTestRuntime(ctx context.Context, t *testing.T, logger logging.Logger) *R
 		t.Fatalf("Unexpected error %v", err)
 	}
 	return rt
-}
-
-func TestAddrWarningMessage(t *testing.T) {
-	testCases := []struct {
-		name          string
-		addrSetByUser bool
-		containsMsg   bool
-	}{
-		{"WarningMessage", false, true},
-		{"NoWarningMessage", true, false},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Millisecond)
-			defer cancel()
-
-			params := NewParams()
-
-			logger := testLog.New()
-			logLevel := logging.Info
-
-			params.Logger = logger
-			params.Addrs = &[]string{"localhost:8181"}
-			params.AddrSetByUser = tc.addrSetByUser
-			params.GracefulShutdownPeriod = 1
-			rt, err := NewRuntime(ctx, params)
-			if err != nil {
-				t.Fatalf("Unexpected error %v", err)
-			}
-
-			done := make(chan struct{})
-			go func() {
-				rt.StartServer(ctx)
-				close(done)
-			}()
-			<-done
-
-			warning := " OPA is running on a public (0.0.0.0) network interface. Unless you intend to expose OPA outside of the host, binding to the localhost interface (--addr localhost:8181) is recommended. See https://www.openpolicyagent.org/docs/latest/security/#interface-binding"
-			containsWarning := strings.Contains(logger.Entries()[0].Message, warning)
-
-			if containsWarning != tc.containsMsg {
-				t.Fatal("Mismatch between OPA server displaying the interface warning message and user setting the server address")
-			}
-
-			if logger.GetLevel() != logLevel {
-				t.Fatalf("Expected log level to be: \"%v\" but got \"%v\"", logLevel, logger.GetLevel())
-			}
-		})
-	}
 }
 
 func TestRuntimeWithExplicitMetricConfiguration(t *testing.T) {


### PR DESCRIPTION
Currently OPA binds to the 0.0.0.0 interface by default, which allows the OPA server to be exposed to services running outside of the same machine. Though not inherently insecure in a trusted environment, it's good practice to bind OPA to the localhost interface by default if OPA is not intended to be exposed to remote services.

Fixes: #6286

### Further comments:

<!--
Here you can include links to additional resources related to the changes, discuss your solution, other approaches you considered etc.
-->

Below is a log from the OPA server which shows `localhost:8181` as the default address.

```
$ go run main.go run -s
{"addrs":["localhost:8181"],"diagnostic-addrs":[],"level":"info","msg":"Initializing server.","time":"2023-10-11T16:51:58-07:00"}
```
