### PR TITLE
fix: plugin reconfigure state when downloaded bundle is Not Modified

### DIFF
--- a/plugins/bundle/plugin.go
+++ b/plugins/bundle/plugin.go
@@ -540,8 +540,9 @@ func (p *Plugin) process(ctx context.Context, name string, u download.Update) {
 	if etag, ok := p.etags[name]; ok && u.ETag == etag {
 		p.log(name).Debug("Bundle load skipped, server replied with not modified.")
 		p.status[name].SetError(nil)
-		// proposed fix to check plugin readiness on 304
-		// p.checkPluginReadiness()
+
+		// The downloader received a 304 (same etag as saved in local state), update plugin readiness
+		p.checkPluginReadiness()
 		return
 	}
 }

--- a/plugins/bundle/plugin.go
+++ b/plugins/bundle/plugin.go
@@ -540,6 +540,8 @@ func (p *Plugin) process(ctx context.Context, name string, u download.Update) {
 	if etag, ok := p.etags[name]; ok && u.ETag == etag {
 		p.log(name).Debug("Bundle load skipped, server replied with not modified.")
 		p.status[name].SetError(nil)
+		// proposed fix to check plugin readiness on 304
+		// p.checkPluginReadiness()
 		return
 	}
 }

--- a/plugins/bundle/plugin_test.go
+++ b/plugins/bundle/plugin_test.go
@@ -3308,15 +3308,19 @@ func TestPluginStateReconciliationOnReconfigure(t *testing.T) {
 				return
 			}
 
+			// if there is a change in config
+			// Reconfigure sets the plugin state as StateNotReady
 			ensurePluginState(t, plugin, plugins.StateNotReady)
 
 			for name := range stage.cfg.Bundles {
-				go func() {
+				go func(name string) {
 					_ = plugin.Loaders()[name].Trigger(ctx)
-				}()
+				}(name)
 				<-statusCh
 			}
 
+			// after all downloaders are processed the state should
+			// reconcile to StateOK, if there are no errors
 			ensurePluginState(t, plugin, plugins.StateOK)
 		})
 	}

--- a/plugins/bundle/plugin_test.go
+++ b/plugins/bundle/plugin_test.go
@@ -3107,12 +3107,18 @@ func TestPluginReadBundleEtagFromDiskStore(t *testing.T) {
 
 		plugin.Reconfigure(ctx, cfg)
 
+		// Reconfigure should mark the state as not ready
+		ensurePluginState(t, plugin, plugins.StateNotReady)
+
 		// manually trigger bundle download
 		go func() {
 			_ = plugin.Loaders()["test"].Trigger(ctx)
 		}()
 
 		<-statusCh
+
+		// on bundle download with 304 the state should be OK
+		ensurePluginState(t, plugin, plugins.StateOK)
 
 		if notModifiedCount != 2 {
 			t.Fatalf("Expected two bundle responses with HTTP status 304 but got %v", notModifiedCount)


### PR DESCRIPTION
<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->

### Why the changes in this PR are needed?

This PR tries to represent a bug in the code which causes the OPA container to become unhealthy and propose a fix for the same.


### What are the changes in this PR?

The bug happens on plugin readiness,  when `Reconfigure` is called the plugin state it NotReady and waits for all downloaders to be triggered again and reconcile the state to OK. However if all bundles received a 304 from the backend server the plugin state remains NotReady and causes the `/health?bundles=true` to start failing

The PR adds `checkPluginReadiness` an existing method in the branch where the downloaded bundle is Not Modified instructing the plugin to reconcile plugin readiness.

Adding tests around plugin state reconciliation on `Reconfigure` when one or all of the downloaded bundles can be Not Modified.


