### PR TITLE
Bind OPA server to localhost interface by default

### DIFF
--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -1022,7 +1022,8 @@ You can start OPA as a server with `-s` or `--server`:
 
 By default OPA listens for HTTP connections on `0.0.0.0:8181`. See `opa run
 --help` for a list of options to change the listening address, enable TLS, and
-more.
+more. For example, if the `--future-compat` flag is set, OPA will listen
+for HTTP connections on `localhost:8181` by default.
 
 Inside of another terminal use `curl` (or a similar tool) to access OPA's HTTP
 API. When you query the `/v1/data` HTTP API you must wrap input data inside of a

--- a/docs/content/deployments.md
+++ b/docs/content/deployments.md
@@ -33,6 +33,7 @@ command line arguments for OPA's server mode are:
 * `--addr` to set the listening address (default: `0.0.0.0:8181`).
 * `--log-level` (or `-l`) to set the log level (default: `"info"`).
 * `--log-format` to set the log format (default: `"json"`).
+* `--future-compat` to opt-in to OPA features and behaviors that will be enabled by default in future OPA releases. For example, setting the listening address to `localhost:8181` by default.
 
 By default, OPA listens for normal HTTP connections on `0.0.0.0:8181`. To make
 OPA listen for HTTPS connections, see [Security](../security).

--- a/docs/content/security.md
+++ b/docs/content/security.md
@@ -102,6 +102,10 @@ By default, OPA binds to the 0.0.0.0 interface, which allows the OPA server to b
 
 In situations where OPA is not intended to be exposed to remote services, it is recommended to bind OPA to the localhost interface, which only allows connections from the same machine. If it is necessary to expose OPA to remote services, ensure to follow the security recommendations on this page, such as requiring authentication.
 
+{{< info >}}
+The `--future-compat` flag can be set on `opa run` to opt-in to OPA features and behaviors that will be enabled by default in future OPA releases. For example, if the `--future-compat` flag is set, OPA will listen
+for HTTP connections on `localhost:8181` by default.
+{{< /info >}}
 
 ## Authentication and Authorization
 

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -224,6 +224,11 @@ type Params struct {
 
 	// UnixSocketPerm specifies the permission for the Unix domain socket if used to listen for connections
 	UnixSocketPerm *string
+
+	// FutureCompatibility will enable OPA features and behaviors that will be enabled by default in future OPA releases.
+	// This flag allows users to opt-in to the new behavior and helps transition to a future release upon which
+	// the new behavior will be enabled by default.
+	FutureCompatibility bool
 }
 
 // LoggingConfig stores the configuration for OPA's logging behaviour.
@@ -472,7 +477,7 @@ func (rt *Runtime) Serve(ctx context.Context) error {
 	}
 
 	serverInitializingMessage := "Initializing server."
-	if !rt.Params.AddrSetByUser {
+	if !rt.Params.AddrSetByUser && !rt.Params.FutureCompatibility {
 		serverInitializingMessage += " OPA is running on a public (0.0.0.0) network interface. Unless you intend to expose OPA outside of the host, binding to the localhost interface (--addr localhost:8181) is recommended. See https://www.openpolicyagent.org/docs/latest/security/#interface-binding"
 	}
 

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -556,12 +556,15 @@ func getTestRuntime(ctx context.Context, t *testing.T, logger logging.Logger) *R
 
 func TestAddrWarningMessage(t *testing.T) {
 	testCases := []struct {
-		name          string
-		addrSetByUser bool
-		containsMsg   bool
+		name                string
+		addrSetByUser       bool
+		containsMsg         bool
+		futureCompatibility bool
 	}{
-		{"WarningMessage", false, true},
-		{"NoWarningMessage", true, false},
+		{"WarningMessage", false, true, false},
+		{"NoWarningMessage", true, false, false},
+		{"FutureCompatibilityEnabled", false, false, true},
+		{"FutureCompatibilityDisabled", false, true, false},
 	}
 
 	for _, tc := range testCases {
@@ -578,6 +581,7 @@ func TestAddrWarningMessage(t *testing.T) {
 			params.Addrs = &[]string{"localhost:8181"}
 			params.AddrSetByUser = tc.addrSetByUser
 			params.GracefulShutdownPeriod = 1
+			params.FutureCompatibility = tc.futureCompatibility
 			rt, err := NewRuntime(ctx, params)
 			if err != nil {
 				t.Fatalf("Unexpected error %v", err)


### PR DESCRIPTION
Currently OPA binds to the 0.0.0.0 interface by default, which allows
the OPA server to be exposed to services running outside of the same machine.
Though not inherently insecure in a trusted environment, it's good practice
to bind OPA to the localhost interface by default if OPA is not intended
to be exposed to remote services.

This change also adds a new feature flag to `opa run` to allow users to enable
future OPA compatible behavior.