### PR TITLE
build: Migrate to GitHub CLI tool

### DIFF
--- a/.github/workflows/post-tag.yaml
+++ b/.github/workflows/post-tag.yaml
@@ -109,6 +109,6 @@ jobs:
 
       - name: Create or Update Release
         env:
-          # Required for the `hub` CLI
+          # Required for the GitHub CLI
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./build/github-release.sh --asset-dir=$(make release-dir) --tag=${TAG_NAME}

--- a/build/github-release.sh
+++ b/build/github-release.sh
@@ -31,7 +31,7 @@ done
 # Collect a list of opa binaries (expect binaries in the form: opa_<platform>_<arch>[extension])
 ASSETS=()
 for asset in "${ASSET_DIR}"/opa_*_*; do
-    ASSETS+=("-a" "$asset")
+    ASSETS+=("$asset")
 done
 
 # Gather the release notes from the CHANGELOG for the latest version
@@ -44,11 +44,10 @@ echo -e "${TAG_NAME}\n" > "${RELEASE_NOTES}"
 ./build/latest-release-notes.sh --output="${RELEASE_NOTES}"
 
 # Update or create a release on github
-if hub release show "${TAG_NAME}" > /dev/null; then
+if gh release view "${TAG_NAME}" --repo open-policy-agent/opa > /dev/null; then
     # Occurs when the tag is created via GitHub UI w/ a release
-    # Use -m "" to preserve the existing text.
-    hub release edit "${ASSETS[@]}" -m "" "${TAG_NAME}"
+    gh release upload "${TAG_NAME}" "${ASSETS[@]}" --repo open-policy-agent/opa
 else
     # Create a draft release
-    hub release create "${ASSETS[@]}" -F ${RELEASE_NOTES} --draft "${TAG_NAME}"
+    gh release create "${TAG_NAME}" "${ASSETS[@]}" -F ${RELEASE_NOTES} --draft --title "${TAG_NAME}" --repo open-policy-agent/opa
 fi


### PR DESCRIPTION
The `hub` tool is deprecated in favor of the GitHub CLI and is removed from GitHub's action runner images.

Fixes: #6326

### Notes to assist PR review:

<!--
Here you can add information you think will help the reviewer(s).
-->

[OPA-Envoy plugin's](https://github.com/open-policy-agent/opa-envoy-plugin) `Post Tag` workflow had the same issue. We fixed it there first and tested it with [this](https://github.com/open-policy-agent/opa-envoy-plugin/releases/tag/v0.57.1-envoy-3) release. Also manually tested the create and update of the release scenarios.