### PR TITLE
ast+rego: disable compiler stages for IR-based eval paths

### DIFF
--- a/rego/rego.go
+++ b/rego/rego.go
@@ -1213,6 +1213,12 @@ func New(options ...func(r *Rego)) *Rego {
 			WithEnablePrintStatements(r.enablePrintStatements).
 			WithStrict(r.strict).
 			WithUseTypeCheckAnnotations(true)
+
+		// topdown could be target "" or "rego", but both could be overridden by
+		// a target plugin (checked below)
+		if r.target == targetWasm {
+			r.compiler = r.compiler.WithEvalMode(ast.EvalModeIR)
+		}
 	}
 
 	if r.store == nil {
@@ -1252,6 +1258,11 @@ func New(options ...func(r *Rego)) *Rego {
 			}
 		}
 	}
+
+	if t := r.targetPlugin(r.target); t != nil {
+		r.compiler = r.compiler.WithEvalMode(ast.EvalModeIR)
+	}
+
 	return r
 }
 


### PR DESCRIPTION
Only topdown can make sense of rules and comprehension indices, so Wasm and any eval plugins should instruct the compiler to avoid that work.

Instrumentation metrics for a wasm-eval before:

```
+----------------------------------------------------------+--------+
|                          METRIC                          | VALUE  |
+----------------------------------------------------------+--------+
| counter_compile_stage_comprehension_index_build          | 0      |
| timer_compile_stage_check_duplicate_imports_ns           | 218    |
| timer_compile_stage_check_keyword_overrides_ns           | 337    |
| timer_compile_stage_check_recursion_ns                   | 3306   |
| timer_compile_stage_check_rule_conflicts_ns              | 20497  |
| timer_compile_stage_check_safety_rule_bodies_ns          | 18710  |
| timer_compile_stage_check_safety_rule_heads_ns           | 5688   |
| timer_compile_stage_check_types_ns                       | 25696  |
| timer_compile_stage_check_undefined_funcs_ns             | 3412   |
| timer_compile_stage_check_void_calls_ns                  | 3473   |
| timer_compile_stage_init_local_var_gen_ns                | 4683   |
| timer_compile_stage_parse_metadata_blocks_ns             | 9285   |
| timer_compile_stage_rebuild_comprehension_indices_ns     | 5623   |
| timer_compile_stage_rebuild_indices_ns                   | 9695   |
| timer_compile_stage_remove_imports_ns                    | 402    |
| timer_compile_stage_resolve_refs_ns                      | 32749  |
| timer_compile_stage_rewrite_comprehension_terms_ns       | 3387   |
| timer_compile_stage_rewrite_dynamic_terms_ns             | 2551   |
| timer_compile_stage_rewrite_equals_ns                    | 5086   |
| timer_compile_stage_rewrite_expr_terms_ns                | 5237   |
| timer_compile_stage_rewrite_local_vars_ns                | 35814  |
| timer_compile_stage_rewrite_print_calls_ns               | 4950   |
| timer_compile_stage_rewrite_refs_in_head_ns              | 3220   |
| timer_compile_stage_rewrite_rego_metadata_calls_ns       | 2799   |
| timer_compile_stage_rewrite_rule_head_refs_ns            | 2819   |
| timer_compile_stage_rewrite_with_values_ns               | 5978   |
| timer_compile_stage_set_annotationset_ns                 | 4145   |
| timer_compile_stage_set_graph_ns                         | 6652   |
| timer_compile_stage_set_module_tree_ns                   | 2026   |
| timer_compile_stage_set_rule_tree_ns                     | 3661   |
| timer_compile_state_check_deprecated_builtins_ns         | 268    |
| timer_compile_state_check_unsafe_builtins_ns             | 1349   |
| timer_query_compile_stage_build_comprehension_index_ns   | 2358   |
| timer_query_compile_stage_check_deprecated_builtins_ns   | 229    |
| timer_query_compile_stage_check_keyword_overrides_ns     | 318    |
| timer_query_compile_stage_check_safety_ns                | 11951  |
| timer_query_compile_stage_check_types_ns                 | 22022  |
| timer_query_compile_stage_check_undefined_funcs_ns       | 1475   |
| timer_query_compile_stage_check_unsafe_builtins_ns       | 994    |
| timer_query_compile_stage_check_void_calls_ns            | 1033   |
| timer_query_compile_stage_resolve_refs_ns                | 1925   |
| timer_query_compile_stage_rewrite_comprehension_terms_ns | 2017   |
| timer_query_compile_stage_rewrite_dynamic_terms_ns       | 1588   |
| timer_query_compile_stage_rewrite_expr_terms_ns          | 1514   |
| timer_query_compile_stage_rewrite_local_vars_ns          | 9646   |
| timer_query_compile_stage_rewrite_print_calls_ns         | 2369   |
| timer_query_compile_stage_rewrite_to_capture_value_ns    | 8641   |
| timer_query_compile_stage_rewrite_with_values_ns         | 1010   |
| timer_rego_load_files_ns                                 | 203476 |
| timer_rego_module_compile_ns                             | 501892 |
| timer_rego_module_parse_ns                               | 128785 |
| timer_rego_query_compile_ns                              | 86464  |
| timer_rego_query_parse_ns                                | 52628  |
| timer_wasm_pool_acquire_ns                               | 755    |
| timer_wasm_pool_release_ns                               | 472    |
| timer_wasm_vm_eval_call_ns                               | 20882  |
| timer_wasm_vm_eval_ns                                    | 25382  |
+----------------------------------------------------------+--------+
```

and after:

```
+----------------------------------------------------------+--------+
|                          METRIC                          | VALUE  |
+----------------------------------------------------------+--------+
| timer_compile_stage_check_duplicate_imports_ns           | 225    |
| timer_compile_stage_check_keyword_overrides_ns           | 605    |
| timer_compile_stage_check_recursion_ns                   | 1491   |
| timer_compile_stage_check_rule_conflicts_ns              | 19705  |
| timer_compile_stage_check_safety_rule_bodies_ns          | 16846  |
| timer_compile_stage_check_safety_rule_heads_ns           | 5904   |
| timer_compile_stage_check_types_ns                       | 30401  |
| timer_compile_stage_check_undefined_funcs_ns             | 3797   |
| timer_compile_stage_check_void_calls_ns                  | 3667   |
| timer_compile_stage_init_local_var_gen_ns                | 6856   |
| timer_compile_stage_parse_metadata_blocks_ns             | 4526   |
| timer_compile_stage_remove_imports_ns                    | 447    |
| timer_compile_stage_resolve_refs_ns                      | 31314  |
| timer_compile_stage_rewrite_comprehension_terms_ns       | 3129   |
| timer_compile_stage_rewrite_dynamic_terms_ns             | 4851   |
| timer_compile_stage_rewrite_equals_ns                    | 4594   |
| timer_compile_stage_rewrite_expr_terms_ns                | 4940   |
| timer_compile_stage_rewrite_local_vars_ns                | 31923  |
| timer_compile_stage_rewrite_print_calls_ns               | 5107   |
| timer_compile_stage_rewrite_refs_in_head_ns              | 1429   |
| timer_compile_stage_rewrite_rego_metadata_calls_ns       | 4890   |
| timer_compile_stage_rewrite_rule_head_refs_ns            | 2890   |
| timer_compile_stage_rewrite_with_values_ns               | 6000   |
| timer_compile_stage_set_annotationset_ns                 | 4199   |
| timer_compile_stage_set_graph_ns                         | 6935   |
| timer_compile_stage_set_module_tree_ns                   | 1744   |
| timer_compile_stage_set_rule_tree_ns                     | 3744   |
| timer_compile_state_check_deprecated_builtins_ns         | 226    |
| timer_compile_state_check_unsafe_builtins_ns             | 1437   |
| timer_query_compile_stage_check_deprecated_builtins_ns   | 292    |
| timer_query_compile_stage_check_keyword_overrides_ns     | 333    |
| timer_query_compile_stage_check_safety_ns                | 12422  |
| timer_query_compile_stage_check_types_ns                 | 18762  |
| timer_query_compile_stage_check_undefined_funcs_ns       | 1490   |
| timer_query_compile_stage_check_unsafe_builtins_ns       | 976    |
| timer_query_compile_stage_check_void_calls_ns            | 988    |
| timer_query_compile_stage_resolve_refs_ns                | 1977   |
| timer_query_compile_stage_rewrite_comprehension_terms_ns | 2223   |
| timer_query_compile_stage_rewrite_dynamic_terms_ns       | 1295   |
| timer_query_compile_stage_rewrite_expr_terms_ns          | 1467   |
| timer_query_compile_stage_rewrite_local_vars_ns          | 6749   |
| timer_query_compile_stage_rewrite_print_calls_ns         | 4241   |
| timer_query_compile_stage_rewrite_to_capture_value_ns    | 8548   |
| timer_query_compile_stage_rewrite_with_values_ns         | 1008   |
| timer_rego_load_files_ns                                 | 216676 |
| timer_rego_module_compile_ns                             | 511394 |
| timer_rego_module_parse_ns                               | 139088 |
| timer_rego_query_compile_ns                              | 79783  |
| timer_rego_query_parse_ns                                | 50614  |
| timer_wasm_pool_acquire_ns                               | 1266   |
| timer_wasm_pool_release_ns                               | 482    |
| timer_wasm_vm_eval_call_ns                               | 23161  |
| timer_wasm_vm_eval_ns                                    | 36042  |
+----------------------------------------------------------+--------+
```

Absent, as desired, we find:

- counter_compile_stage_comprehension_index_build          
- timer_compile_stage_rebuild_comprehension_indices_ns    
- timer_compile_stage_rebuild_indices_ns                
- timer_query_compile_stage_build_comprehension_index_ns  