### PR TITLE
Rename --future-compat CLI flag

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -178,7 +178,7 @@ OPA will automatically perform type checking based on a schema inferred from kno
 resulting from the schema check. Currently this check is performed on OPA's Authorization Policy Input document and will
 be expanded in the future. To disable this, use the --skip-known-schema-check flag.
 
-The --future-compat flag can be used to opt-in to OPA features and behaviors that will be enabled by default in future OPA releases.
+The --v1-compatible flag can be used to opt-in to OPA features and behaviors that will be enabled by default in a future OPA v1.0 release.
 Current behaviors enabled by this flag include:
 - setting OPA's listening address to "localhost:8181" by default.
 `,
@@ -205,7 +205,7 @@ Current behaviors enabled by this flag include:
 	runCommand.Flags().BoolVar(&cmdParams.rt.H2CEnabled, "h2c", false, "enable H2C for HTTP listeners")
 	runCommand.Flags().StringVarP(&cmdParams.rt.OutputFormat, "format", "f", "pretty", "set shell output format, i.e, pretty, json")
 	runCommand.Flags().BoolVarP(&cmdParams.rt.Watch, "watch", "w", false, "watch command line files for changes")
-	runCommand.Flags().BoolVar(&cmdParams.rt.FutureCompatibility, "future-compat", false, "opt-in to OPA features and behaviors that will be enabled by default in future OPA releases")
+	runCommand.Flags().BoolVar(&cmdParams.rt.V1Compatible, "v1-compatible", false, "opt-in to OPA features and behaviors that will be enabled by default in a future OPA v1.0 release")
 	addMaxErrorsFlag(runCommand.Flags(), &cmdParams.rt.ErrorLimit)
 	runCommand.Flags().BoolVar(&cmdParams.rt.PprofEnabled, "pprof", false, "enables pprof endpoints")
 	runCommand.Flags().StringVar(&cmdParams.tlsCertFile, "tls-cert-file", "", "set path of TLS certificate file")
@@ -339,7 +339,7 @@ func initRuntime(ctx context.Context, params runCmdParams, args []string, addrSe
 	rt.SetDistributedTracingLogging()
 	rt.Params.AddrSetByUser = addrSetByUser
 
-	if !addrSetByUser && rt.Params.FutureCompatibility {
+	if !addrSetByUser && rt.Params.V1Compatible {
 		rt.Params.Addrs = &[]string{defaultLocalAddr}
 	}
 

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -52,7 +52,7 @@ func TestRunServerBase(t *testing.T) {
 
 func TestRunServerBaseListenOnLocalhost(t *testing.T) {
 	params := newTestRunParams()
-	params.rt.FutureCompatibility = true
+	params.rt.V1Compatible = true
 
 	ctx, cancel := context.WithCancel(context.Background())
 

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -1022,7 +1022,7 @@ You can start OPA as a server with `-s` or `--server`:
 
 By default OPA listens for HTTP connections on `0.0.0.0:8181`. See `opa run
 --help` for a list of options to change the listening address, enable TLS, and
-more. For example, if the `--future-compat` flag is set, OPA will listen
+more. For example, if the `--v1-compatible` flag is set, OPA will listen
 for HTTP connections on `localhost:8181` by default.
 
 Inside of another terminal use `curl` (or a similar tool) to access OPA's HTTP

--- a/docs/content/cli.md
+++ b/docs/content/cli.md
@@ -836,7 +836,7 @@ OPA will automatically perform type checking based on a schema inferred from kno
 resulting from the schema check. Currently this check is performed on OPA's Authorization Policy Input document and will
 be expanded in the future. To disable this, use the --skip-known-schema-check flag.
 
-The --future-compat flag can be used to opt-in to OPA features and behaviors that will be enabled by default in future OPA releases.
+The --v1-compatible flag can be used to opt-in to OPA features and behaviors that will be enabled by default in a future OPA v1.0 release.
 Current behaviors enabled by this flag include:
 - setting OPA's listening address to "localhost:8181" by default.
 
@@ -857,7 +857,6 @@ opa run [flags]
       --disable-telemetry                    disables anonymous information reporting (see: https://www.openpolicyagent.org/docs/latest/privacy)
       --exclude-files-verify strings         set file names to exclude during bundle verification
   -f, --format string                        set shell output format, i.e, pretty, json (default "pretty")
-      --future-compat                        opt-in to OPA features and behaviors that will be enabled by default in future OPA releases
       --h2c                                  enable H2C for HTTP listeners
   -h, --help                                 help for run
   -H, --history string                       set path of history file (default "$HOME/.opa_history")
@@ -883,6 +882,7 @@ opa run [flags]
       --tls-cert-refresh-period duration     set certificate refresh period
       --tls-private-key-file string          set path of TLS private key file
       --unix-socket-perm string              specify the permissions for the Unix domain socket if used to listen for incoming connections (default "755")
+       --v1-compatible                       opt-in to OPA features and behaviors that will be enabled by default in a future OPA v1.0 release
       --verification-key string              set the secret (HMAC) or path of the PEM file containing the public key (RSA and ECDSA)
       --verification-key-id string           name assigned to the verification key used for bundle verification (default "default")
   -w, --watch                                watch command line files for changes

--- a/docs/content/deployments.md
+++ b/docs/content/deployments.md
@@ -33,7 +33,7 @@ command line arguments for OPA's server mode are:
 * `--addr` to set the listening address (default: `0.0.0.0:8181`).
 * `--log-level` (or `-l`) to set the log level (default: `"info"`).
 * `--log-format` to set the log format (default: `"json"`).
-* `--future-compat` to opt-in to OPA features and behaviors that will be enabled by default in future OPA releases. For example, setting the listening address to `localhost:8181` by default.
+* `--v1-compatible` to opt-in to OPA features and behaviors that will be enabled by default in a future OPA v1.0 release. For example, setting the listening address to `localhost:8181` by default.
 
 By default, OPA listens for normal HTTP connections on `0.0.0.0:8181`. To make
 OPA listen for HTTPS connections, see [Security](../security).

--- a/docs/content/security.md
+++ b/docs/content/security.md
@@ -103,7 +103,7 @@ By default, OPA binds to the 0.0.0.0 interface, which allows the OPA server to b
 In situations where OPA is not intended to be exposed to remote services, it is recommended to bind OPA to the localhost interface, which only allows connections from the same machine. If it is necessary to expose OPA to remote services, ensure to follow the security recommendations on this page, such as requiring authentication.
 
 {{< info >}}
-The `--future-compat` flag can be set on `opa run` to opt-in to OPA features and behaviors that will be enabled by default in future OPA releases. For example, if the `--future-compat` flag is set, OPA will listen
+The `--v1-compatible` flag can be set on `opa run` to opt-in to OPA features and behaviors that will be enabled by default in a future OPA v1.0 releases. For example, if the `--v1-compatible` flag is set, OPA will listen
 for HTTP connections on `localhost:8181` by default.
 {{< /info >}}
 

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -225,10 +225,10 @@ type Params struct {
 	// UnixSocketPerm specifies the permission for the Unix domain socket if used to listen for connections
 	UnixSocketPerm *string
 
-	// FutureCompatibility will enable OPA features and behaviors that will be enabled by default in future OPA releases.
-	// This flag allows users to opt-in to the new behavior and helps transition to a future release upon which
+	// V1Compatible will enable OPA features and behaviors that will be enabled by default in a future OPA v1.0 release.
+	// This flag allows users to opt-in to the new behavior and helps transition to the future release upon which
 	// the new behavior will be enabled by default.
-	FutureCompatibility bool
+	V1Compatible bool
 }
 
 // LoggingConfig stores the configuration for OPA's logging behaviour.
@@ -477,7 +477,7 @@ func (rt *Runtime) Serve(ctx context.Context) error {
 	}
 
 	serverInitializingMessage := "Initializing server."
-	if !rt.Params.AddrSetByUser && !rt.Params.FutureCompatibility {
+	if !rt.Params.AddrSetByUser && !rt.Params.V1Compatible {
 		serverInitializingMessage += " OPA is running on a public (0.0.0.0) network interface. Unless you intend to expose OPA outside of the host, binding to the localhost interface (--addr localhost:8181) is recommended. See https://www.openpolicyagent.org/docs/latest/security/#interface-binding"
 	}
 

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -556,15 +556,15 @@ func getTestRuntime(ctx context.Context, t *testing.T, logger logging.Logger) *R
 
 func TestAddrWarningMessage(t *testing.T) {
 	testCases := []struct {
-		name                string
-		addrSetByUser       bool
-		containsMsg         bool
-		futureCompatibility bool
+		name          string
+		addrSetByUser bool
+		containsMsg   bool
+		v1Compatible  bool
 	}{
 		{"WarningMessage", false, true, false},
 		{"NoWarningMessage", true, false, false},
-		{"FutureCompatibilityEnabled", false, false, true},
-		{"FutureCompatibilityDisabled", false, true, false},
+		{"V1Compatible", false, false, true},
+		{"V1InCompatible", false, true, false},
 	}
 
 	for _, tc := range testCases {
@@ -581,7 +581,7 @@ func TestAddrWarningMessage(t *testing.T) {
 			params.Addrs = &[]string{"localhost:8181"}
 			params.AddrSetByUser = tc.addrSetByUser
 			params.GracefulShutdownPeriod = 1
-			params.FutureCompatibility = tc.futureCompatibility
+			params.V1Compatible = tc.v1Compatible
 			rt, err := NewRuntime(ctx, params)
 			if err != nil {
 				t.Fatalf("Unexpected error %v", err)


### PR DESCRIPTION
This change renames the `--future-compat` CLI flag on `opa run` to `--rego-v1`. The latter is clear that it's a declaration that gated features are compatible with a v1 version of OPA.
