### PR TITLE
topdown: Fixing issues with optimizing rules with refs in the head

### DIFF
--- a/ast/term.go
+++ b/ast/term.go
@@ -1102,7 +1102,7 @@ func (ref Ref) Ptr() (string, error) {
 	return strings.Join(parts, "/"), nil
 }
 
-var varRegexp = regexp.MustCompile("^[[:alpha:]_][[:alpha:][:digit:]_]*$")
+var VarRegexp = regexp.MustCompile("^[[:alpha:]_][[:alpha:][:digit:]_]*$")
 
 func (ref Ref) String() string {
 	if len(ref) == 0 {
@@ -1114,7 +1114,7 @@ func (ref Ref) String() string {
 		switch p := p.Value.(type) {
 		case String:
 			str := string(p)
-			if varRegexp.MatchString(str) && len(buf) > 0 && !IsKeyword(str) {
+			if VarRegexp.MatchString(str) && len(buf) > 0 && !IsKeyword(str) {
 				buf = append(buf, "."+str)
 			} else {
 				buf = append(buf, "["+p.String()+"]")

--- a/ast/term.go
+++ b/ast/term.go
@@ -1102,7 +1102,11 @@ func (ref Ref) Ptr() (string, error) {
 	return strings.Join(parts, "/"), nil
 }
 
-var VarRegexp = regexp.MustCompile("^[[:alpha:]_][[:alpha:][:digit:]_]*$")
+var varRegexp = regexp.MustCompile("^[[:alpha:]_][[:alpha:][:digit:]_]*$")
+
+func IsVarCompatibleString(s string) bool {
+	return varRegexp.MatchString(s)
+}
 
 func (ref Ref) String() string {
 	if len(ref) == 0 {
@@ -1114,7 +1118,7 @@ func (ref Ref) String() string {
 		switch p := p.Value.(type) {
 		case String:
 			str := string(p)
-			if VarRegexp.MatchString(str) && len(buf) > 0 && !IsKeyword(str) {
+			if varRegexp.MatchString(str) && len(buf) > 0 && !IsKeyword(str) {
 				buf = append(buf, "."+str)
 			} else {
 				buf = append(buf, "["+p.String()+"]")

--- a/topdown/save.go
+++ b/topdown/save.go
@@ -287,22 +287,37 @@ func (s *saveSupport) List() []*ast.Module {
 }
 
 func (s *saveSupport) Exists(path ast.Ref) bool {
-	k := path[:len(path)-1].String()
-	module, ok := s.modules[k]
+	pkg, ruleRef := splitPackageAndRule(path)
+	module, ok := s.modules[pkg.String()]
 	if !ok {
 		return false
 	}
-	name := ast.Var(path[len(path)-1].Value.(ast.String))
+
+	if len(ruleRef) == 1 {
+		name := ruleRef[0].Value.(ast.Var)
+		for _, rule := range module.Rules {
+			if rule.Head.Name.Equal(name) {
+				return true
+			}
+		}
+		return false
+	}
+
 	for _, rule := range module.Rules {
-		if rule.Head.Name.Equal(name) {
+		if rule.Head.Ref().HasPrefix(ruleRef) {
 			return true
 		}
 	}
+
 	return false
 }
 
 func (s *saveSupport) Insert(path ast.Ref, rule *ast.Rule) {
-	pkg := path[:len(path)-1]
+	pkg, _ := splitPackageAndRule(path)
+	s.InsertByPkg(pkg, rule)
+}
+
+func (s *saveSupport) InsertByPkg(pkg ast.Ref, rule *ast.Rule) {
 	k := pkg.String()
 	module, ok := s.modules[k]
 	if !ok {
@@ -315,6 +330,25 @@ func (s *saveSupport) Insert(path ast.Ref, rule *ast.Rule) {
 	}
 	rule.Module = module
 	module.Rules = append(module.Rules, rule)
+}
+
+func splitPackageAndRule(path ast.Ref) (ast.Ref, ast.Ref) {
+	p := path.Copy()
+
+	ruleRefStart := 2 // path always contains at least 3 terms (data. + one term in package + rule name)
+	for i := ruleRefStart; i < len(p.StringPrefix()); i++ {
+		t := p[i]
+		if str, ok := t.Value.(ast.String); ok && ast.VarRegexp.MatchString(string(str)) {
+			ruleRefStart = i
+		} else {
+			break
+		}
+	}
+
+	pkg := p[:ruleRefStart]
+	rule := p[ruleRefStart:]
+	rule[0].Value = ast.Var(rule[0].Value.(ast.String))
+	return pkg, rule
 }
 
 // saveRequired returns true if the statement x will result in some expressions

--- a/topdown/save.go
+++ b/topdown/save.go
@@ -338,7 +338,7 @@ func splitPackageAndRule(path ast.Ref) (ast.Ref, ast.Ref) {
 	ruleRefStart := 2 // path always contains at least 3 terms (data. + one term in package + rule name)
 	for i := ruleRefStart; i < len(p.StringPrefix()); i++ {
 		t := p[i]
-		if str, ok := t.Value.(ast.String); ok && ast.VarRegexp.MatchString(string(str)) {
+		if str, ok := t.Value.(ast.String); ok && ast.IsVarCompatibleString(string(str)) {
 			ruleRefStart = i
 		} else {
 			break


### PR DESCRIPTION
Issues fixed:

* production of support module with forbidden characters in first var of rule ref (#6338)
* panic when policy contains rules with a general ref in the head (#6339)