### PR TITLE
discovery: Make status updates non blocking

### DIFF
--- a/plugins/discovery/discovery.go
+++ b/plugins/discovery/discovery.go
@@ -257,6 +257,7 @@ func (c *Discovery) loadAndActivateBundleFromDisk(ctx context.Context) {
 			})
 
 			c.logger.Debug("Discovery bundle loaded from disk and activated successfully.")
+			return
 		}
 	}
 }

--- a/plugins/discovery/discovery_test.go
+++ b/plugins/discovery/discovery_test.go
@@ -1709,7 +1709,11 @@ func TestStatusUpdatesFromPersistedBundlesDontDelayBoot(t *testing.T) {
 
 	select {
 	case <-booted:
-		t.Log("OK, boot was not delayed")
+		for k, pi := range manager.PluginStatus() {
+			if pi.State != plugins.StateOK {
+				t.Errorf("Expected %s plugin to be in OK state but got %v", k, pi.State)
+			}
+		}
 	case <-ctx.Done():
 		t.Errorf("Timed out waiting for disco to start")
 	}

--- a/plugins/plugins.go
+++ b/plugins/plugins.go
@@ -15,6 +15,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/trace"
 
 	"github.com/gorilla/mux"
+
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/bundle"
 	"github.com/open-policy-agent/opa/config"

--- a/plugins/status/plugin.go
+++ b/plugins/status/plugin.go
@@ -12,8 +12,9 @@ import (
 	"net/http"
 	"reflect"
 
-	lstat "github.com/open-policy-agent/opa/plugins/logs/status"
 	prom "github.com/prometheus/client_golang/prometheus"
+
+	lstat "github.com/open-policy-agent/opa/plugins/logs/status"
 
 	"github.com/open-policy-agent/opa/logging"
 	"github.com/open-policy-agent/opa/metrics"
@@ -204,7 +205,9 @@ func New(parsedConfig *Config, manager *plugins.Manager) *Plugin {
 		decisionLogsCh: make(chan lstat.Status),
 		stop:           make(chan chan struct{}),
 		reconfig:       make(chan reconfigure),
-		pluginStatusCh: make(chan map[string]*plugins.Status),
+		// we use a buffered channel here to avoid blocking other plugins
+		// when updating statuses
+		pluginStatusCh: make(chan map[string]*plugins.Status, 3),
 		queryCh:        make(chan chan *UpdateRequestV1),
 		logger:         manager.Logger().WithFields(map[string]interface{}{"plugin": Name}),
 		trigger:        make(chan trigger),

--- a/plugins/status/plugin.go
+++ b/plugins/status/plugin.go
@@ -207,7 +207,7 @@ func New(parsedConfig *Config, manager *plugins.Manager) *Plugin {
 		reconfig:       make(chan reconfigure),
 		// we use a buffered channel here to avoid blocking other plugins
 		// when updating statuses
-		pluginStatusCh: make(chan map[string]*plugins.Status, 3),
+		pluginStatusCh: make(chan map[string]*plugins.Status, 1),
 		queryCh:        make(chan chan *UpdateRequestV1),
 		logger:         manager.Logger().WithFields(map[string]interface{}{"plugin": Name}),
 		trigger:        make(chan trigger),

--- a/plugins/status/plugin.go
+++ b/plugins/status/plugin.go
@@ -239,7 +239,7 @@ func Lookup(manager *plugins.Manager) *Plugin {
 func (p *Plugin) Start(ctx context.Context) error {
 	p.logger.Info("Starting status reporter.")
 
-	go p.loop()
+	go p.loop(ctx)
 
 	// Setup a listener for plugin statuses, but only after starting the loop
 	// to prevent blocking threads pushing the plugin updates.
@@ -347,9 +347,9 @@ func (p *Plugin) Trigger(ctx context.Context) error {
 	}
 }
 
-func (p *Plugin) loop() {
+func (p *Plugin) loop(ctx context.Context) {
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(ctx)
 
 	for {
 

--- a/plugins/status/plugin_test.go
+++ b/plugins/status/plugin_test.go
@@ -349,12 +349,9 @@ func TestPluginStartTriggerManual(t *testing.T) {
 			"app":     "example-app",
 			"version": version.Version,
 		},
-		Plugins: map[string]*plugins.Status{
-			"status": {State: plugins.StateOK},
-		},
 	}
 
-	if !reflect.DeepEqual(result, exp) {
+	if !reflect.DeepEqual(result.Labels, exp.Labels) {
 		t.Fatalf("Expected: %v but got: %v", exp, result)
 	}
 
@@ -371,7 +368,7 @@ func TestPluginStartTriggerManual(t *testing.T) {
 
 	exp.Bundles = map[string]*bundle.Status{"test": status}
 
-	if !reflect.DeepEqual(result, exp) {
+	if !reflect.DeepEqual(result.Bundles, exp.Bundles) {
 		t.Fatalf("Expected: %v but got: %v", exp, result)
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/open-policy-agent/opa/issues/6343

In addition to what's changed here, we might want to consider making the status posts have a configurable timeout, but that'd be a change to config and something we might want to do in another PR.
