### PR TITLE
ast: skip if keyword requirement for default rule

### DIFF
--- a/ast/parser_ext.go
+++ b/ast/parser_ext.go
@@ -699,7 +699,7 @@ func parseModule(filename string, stmts []Statement, comments []*Comment) (*Modu
 				if r.generatedBody && r.Head.generatedValue {
 					errs = append(errs, NewError(ParseErr, r.Location, "rule must have value assignment and/or body declaration"))
 				}
-				if r.Body != nil && !r.generatedBody && !ruleDeclarationHasKeyword(r, tokens.If) {
+				if r.Body != nil && !r.generatedBody && !ruleDeclarationHasKeyword(r, tokens.If) && !r.Default {
 					errs = append(errs, NewError(ParseErr, r.Location, "`if` keyword is required before rule body"))
 				}
 				if r.Head.RuleKind() == MultiValue && !ruleDeclarationHasKeyword(r, tokens.Contains) {

--- a/ast/parser_test.go
+++ b/ast/parser_test.go
@@ -1511,6 +1511,12 @@ p.q[x] { x = input.x}`,
 				"rego_parse_error: `if` keyword is required before rule body",
 			},
 		},
+		{
+			note: "`if` keyword not used on default rule",
+			module: `package test
+import rego.v1
+default allow := false`,
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
The `rego.v1` import requires the `if` keyword before the rule body. We should make an exception for default rules.

