### PR TITLE
format: Not outputting any `future.keywords.*` imports when `rego.v1` import in policy

### DIFF
--- a/format/testfiles/test_rego_v1.rego
+++ b/format/testfiles/test_rego_v1.rego
@@ -20,3 +20,7 @@ d contains x if {
 e.f[x] if {
 	x := "g"
 }
+
+f if true in [true, false]
+
+g if every x in [1, 2, 3] { x < 4 }

--- a/format/testfiles/test_rego_v1.rego.formatted
+++ b/format/testfiles/test_rego_v1.rego.formatted
@@ -20,3 +20,7 @@ d contains x if {
 e.f[x] if {
 	x := "g"
 }
+
+f if true in [true, false]
+
+g if every x in [1, 2, 3] { x < 4 }


### PR DESCRIPTION
Fixes: #6359