### PR TITLE
bug: Fix 'opa eval -b' to honor '--ignore' flag

### DIFF
--- a/cmd/eval.go
+++ b/cmd/eval.go
@@ -567,6 +567,7 @@ func setupEval(args []string, params evalCommandParams) (*evalContext, error) {
 
 			regoArgs = append(regoArgs, rego.ParsedBundle("optimized", b))
 		}
+		regoArgs = append(regoArgs, rego.WithIgnore(params.ignore))
 	}
 
 	// skip bundle verification

--- a/rego/rego.go
+++ b/rego/rego.go
@@ -1892,10 +1892,6 @@ func (r *Rego) loadBundles(ctx context.Context, txn storage.Transaction, m metri
 	}
 
 	for _, path := range r.bundlePaths {
-		// Apply the filter to skip loading if necessary
-		//if filter(path, nil, 0) {
-		//	continue
-		//}
 		bndl, err := loader.NewFileLoader().
 			WithMetrics(m).
 			WithProcessAnnotation(true).


### PR DESCRIPTION
<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->

### Why the changes in this PR are needed?

Currently, 'opa eval -b' does not honor the '--ignore' flag. This is a blocking issue for users who need to exclude a directory or file from the bundle. It is also a blocking issue for the VSCode OPA extension. We want to exclude the .git directory from the bundle by default, and we also want to provide developers with an option to exclude any directory or file.

### What are the changes in this PR?

<!--
Include a short description of WHAT changes were made.
-->
As of now, this PR is a draft. I've added a test to assist in the investigation. I'm hoping to locate the source code causing the issue.

### Notes to assist PR review:

<!--
Here you can add information you think will help the reviewer(s).
-->
This PR eventually will fix #6358

### Further comments:

<!--
Here you can include links to additional resources related to the changes, discuss your solution, other approaches you considered etc.
-->
