### PR TITLE
planner: don't plan superfluous Equal/NotEqualStmts

### DIFF
--- a/internal/compiler/wasm/wasm.go
+++ b/internal/compiler/wasm/wasm.go
@@ -1085,27 +1085,11 @@ func (c *Compiler) compileBlock(block *ir.Block) ([]instruction.Instruction, err
 			instrs = append(instrs, instruction.Call{Index: c.function(opaNumberSize)})
 			instrs = append(instrs, instruction.SetLocal{Index: c.local(stmt.Target)})
 		case *ir.EqualStmt:
-			if stmt.A != stmt.B { // constants, or locals, being equal here can skip the check
-				instrs = append(instrs, c.instrRead(stmt.A))
-				instrs = append(instrs, c.instrRead(stmt.B))
-				instrs = append(instrs, instruction.Call{Index: c.function(opaValueCompare)})
-				instrs = append(instrs, instruction.BrIf{Index: 0})
-			}
+			instrs = append(instrs, c.instrRead(stmt.A))
+			instrs = append(instrs, c.instrRead(stmt.B))
+			instrs = append(instrs, instruction.Call{Index: c.function(opaValueCompare)})
+			instrs = append(instrs, instruction.BrIf{Index: 0})
 		case *ir.NotEqualStmt:
-			if stmt.A == stmt.B { // same local, same bool constant, or same string constant
-				instrs = append(instrs, instruction.Br{Index: 0})
-				continue
-			}
-			_, okA := stmt.A.Value.(ir.Bool)
-			if _, okB := stmt.B.Value.(ir.Bool); okA && okB {
-				// not equal (checked above), but both booleans => not equal
-				continue
-			}
-			_, okA = stmt.A.Value.(ir.StringIndex)
-			if _, okB := stmt.B.Value.(ir.StringIndex); okA && okB {
-				// not equal (checked above), but both strings => not equal
-				continue
-			}
 			instrs = append(instrs, c.instrRead(stmt.A))
 			instrs = append(instrs, c.instrRead(stmt.B))
 			instrs = append(instrs, instruction.Call{Index: c.function(opaValueCompare)})

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -841,13 +841,29 @@ func (p *Planner) dataRefsShadowRuletrie(refs []ast.Ref) bool {
 }
 
 func (p *Planner) planExprTerm(e *ast.Expr, iter planiter) error {
-	return p.planTerm(e.Terms.(*ast.Term), func() error {
-		p.appendStmt(&ir.NotEqualStmt{
-			A: p.ltarget,
-			B: op(ir.Bool(false)),
+	// NOTE(sr): There are only three cases to deal with when we see a naked term
+	// in a rule body:
+	//  1. it's `false` -- so we can stop, emit a break stmt
+	//  2. it's a var or a ref, like `input` or `data.foo.bar`, where we need to
+	//     check what it ends up being (at run time) to determine if it's not false
+	//  3. it's any other term -- `true`, a string, a number, whatever. We can skip
+	//     that, since it's true-ish enough for evaluating the rule body.
+	switch t := e.Terms.(*ast.Term).Value.(type) {
+	case ast.Boolean:
+		if !bool(t) { // We know this cannot hold, break unconditionally
+			p.appendStmt(&ir.BreakStmt{})
+			return iter()
+		}
+	case ast.Ref, ast.Var: // We don't know these at plan-time
+		return p.planTerm(e.Terms.(*ast.Term), func() error {
+			p.appendStmt(&ir.NotEqualStmt{
+				A: p.ltarget,
+				B: op(ir.Bool(false)),
+			})
+			return iter()
 		})
-		return iter()
-	})
+	}
+	return iter()
 }
 
 func (p *Planner) planExprEvery(e *ast.Expr, iter planiter) error {


### PR DESCRIPTION
Basically lifting [this compiler optiimization for the Wasm compiler](https://github.com/open-policy-agent/opa/blob/main/internal/compiler/wasm/wasm.go#L1094-L1113) into the planning stage: If we already know at plan time that a certain (in)equality check fails/succeeds, we don't need to do it. The less work, the better.

We should have our bases covered by the existing yaml tests 🤞 