### PR TITLE
wasm: fix re2 bug

### DIFF
--- a/internal/compiler/wasm/opa/callgraph.csv
+++ b/internal/compiler/wasm/opa/callgraph.csv
@@ -1068,7 +1068,6 @@ opa_regex_find_all_string_submatch,memcpy
 opa_regex_find_all_string_submatch,compile\28char\20const*\29
 opa_regex_find_all_string_submatch,opa_array
 opa_regex_find_all_string_submatch,memset
-opa_regex_find_all_string_submatch,strlen
 opa_regex_find_all_string_submatch,re2::RE2::Match\28re2::StringPiece\20const&\2c\20unsigned\20long\2c\20unsigned\20long\2c\20re2::RE2::Anchor\2c\20re2::StringPiece*\2c\20int\29\20const
 opa_regex_find_all_string_submatch,fullrune
 opa_regex_find_all_string_submatch,chartorune

--- a/test/cases/testdata/regexfindallstringsubmatch/test-regexfindallstringsubmatch-large-input.yaml
+++ b/test/cases/testdata/regexfindallstringsubmatch/test-regexfindallstringsubmatch-large-input.yaml
@@ -1,0 +1,15 @@
+cases:
+- data:
+  input:
+    long: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabc"
+  modules:
+  - |
+    package test
+    import future.keywords
+
+    p contains m if some m in regex.find_all_string_submatch_n("^.*$", input.long, -1)
+  note: regexfindallstringsubmatch/large input
+  query: data.test.p = x
+  want_result:
+  - x:
+    - ["aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabc"]

--- a/wasm/src/regex.cc
+++ b/wasm/src/regex.cc
@@ -108,20 +108,21 @@ opa_value *opa_regex_find_all_string_submatch(opa_value *pattern, opa_value *val
         return NULL;
     }
 
-    opa_string_t *s = opa_cast_string(value);
+    std::string val(opa_cast_string(value)->v, opa_cast_string(value)->len);
     opa_array_t *result = opa_cast_array(opa_array());
     int nsubmatch = re->NumberOfCapturingGroups() + 1;
     re2::StringPiece submatches[nsubmatch];
 
     // The following is effectively refactored RE2::GlobalReplace:
 
-    const char* p = s->v;
-    const char* ep = p + s->len;
+    const char* beginpos = val.c_str();
+    const char* p = beginpos;
+    const char* ep = p + val.size();
     const char* lastend = NULL;
     int pos = 0;
 
     while (p <= ep && (num_results == -1 || result->len < num_results)) {
-        if (!re->Match(s->v, static_cast<size_t>(p - s->v), s->len, re2::RE2::UNANCHORED, submatches, nsubmatch))
+        if (!re->Match(val, static_cast<size_t>(p - beginpos), val.size(), re2::RE2::UNANCHORED, submatches, nsubmatch))
         {
             break;
         }


### PR DESCRIPTION
When feeding a `char *` into `re->Match()`, it was converted to a StringPiece, taking its size as `strlen()`. For our (long) input, that wasn't resulting in the correct size, and did then freak out the re2 match input validation if the regular expression has an end anchor, but the endpos wasn't the same as its length. Since the endpos was taken from `s->len`, and the "length" taken via the mentioned StringPiece's strlen() call, they did indeed not match.

Worked around by feeding it a properly-constructed std::string instead. I'm a C++ novice at best, but it does the trick, and I'm reasonable certain it's less wrong than before.

Fixes #6376.