### PR TITLE
feature(builtins): add a new builtin function to render templated strings

### DIFF
--- a/ast/builtins.go
+++ b/ast/builtins.go
@@ -133,6 +133,7 @@ var DefaultBuiltins = [...]*Builtin{
 	TrimSpace,
 	Sprintf,
 	StringReverse,
+	RenderTemplate,
 
 	// Numbers
 	NumbersRange,
@@ -1313,6 +1314,20 @@ var StringReverse = &Builtin{
 			types.Named("x", types.S),
 		),
 		types.Named("y", types.S),
+	),
+	Categories: stringsCat,
+}
+
+var RenderTemplate = &Builtin{
+	Name: "strings.render_template",
+	Description: `Renders a templated string with given template variables injected. For a given templated string and key/value mapping, values will be injected into the template where they are referenced by key.
+	For examples of templating syntax, see https://pkg.go.dev/text/template`,
+	Decl: types.NewFunction(
+		types.Args(
+			types.Named("value", types.S).Description("a templated string"),
+			types.Named("vars", types.NewObject(nil, types.NewDynamicProperty(types.S, types.A))).Description("a mapping of template variable keys to values"),
+		),
+		types.Named("result", types.S).Description("rendered template with template variables injected"),
 	),
 	Categories: stringsCat,
 }

--- a/builtin_metadata.json
+++ b/builtin_metadata.json
@@ -176,6 +176,7 @@
       "startswith",
       "strings.any_prefix_match",
       "strings.any_suffix_match",
+      "strings.render_template",
       "strings.replace_n",
       "strings.reverse",
       "substring",
@@ -15895,6 +15896,31 @@
       "description": "result of the suffix check",
       "name": "result",
       "type": "boolean"
+    },
+    "wasm": false
+  },
+  "strings.render_template": {
+    "args": [
+      {
+        "description": "a templated string",
+        "name": "value",
+        "type": "string"
+      },
+      {
+        "description": "a mapping of template variable keys to values",
+        "name": "vars",
+        "type": "object[string: any]"
+      }
+    ],
+    "available": [
+      "edge"
+    ],
+    "description": "Renders a templated string with given template variables injected. For a given templated string and key/value mapping, values will be injected into the template where they are referenced by key.\n\tFor examples of templating syntax, see https://pkg.go.dev/text/template",
+    "introduced": "edge",
+    "result": {
+      "description": "rendered template with template variables injected",
+      "name": "result",
+      "type": "string"
     },
     "wasm": false
   },

--- a/capabilities.json
+++ b/capabilities.json
@@ -3881,6 +3881,31 @@
       }
     },
     {
+      "name": "strings.render_template",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          },
+          {
+            "dynamic": {
+              "key": {
+                "type": "string"
+              },
+              "value": {
+                "type": "any"
+              }
+            },
+            "type": "object"
+          }
+        ],
+        "result": {
+          "type": "string"
+        },
+        "type": "function"
+      }
+    },
+    {
       "name": "strings.replace_n",
       "decl": {
         "args": [

--- a/test/cases/testdata/rendertemplate/rendertemplate.yaml
+++ b/test/cases/testdata/rendertemplate/rendertemplate.yaml
@@ -1,0 +1,49 @@
+cases:
+- note: rendertemplate/simple
+  query: data.test.p = x
+  modules:
+  - |
+    package test
+
+    template_string = `{{.test}}`
+    template_vars = {`test`: `hello world`}
+    p = strings.render_template(template_string, template_vars)
+  want_result:
+  - x: 'hello world'
+
+- note: rendertemplate/simpleint
+  query: data.test.p = x
+  modules:
+  - |
+    package test
+
+    template_string = `{{.test}}`
+    template_vars = {`test`: 2023}
+    p = strings.render_template(template_string, template_vars)
+  want_result:
+  - x: '2023'
+
+- note: rendertemplate/complex
+  query: data.test.p = x
+  modules:
+  - |
+    package test
+
+    template_string = `{{range $i, $name := .hellonames}}{{if $i}},{{end}}hello {{$name}}{{end}}`
+    template_vars = {`hellonames`: [`rohan`, `john doe`]}
+    p = strings.render_template(template_string, template_vars)
+  want_result:
+  - x: 'hello rohan,hello john doe'
+
+- note: rendertemplate/missingkey
+  query: data.test.p = x
+  modules:
+    - |
+      package test
+
+      template_string = `{{.testvarnotprovided}}`
+      template_vars = {`test`: `hello world`}
+      p = strings.render_template(template_string, template_vars)
+  want_error_code: eval_builtin_error
+  strict_error: true
+

--- a/topdown/template.go
+++ b/topdown/template.go
@@ -1,0 +1,45 @@
+package topdown
+
+import (
+	"bytes"
+	"text/template"
+
+	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/topdown/builtins"
+)
+
+func renderTemplate(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term) error) error {
+	preContentTerm, err := builtins.StringOperand(operands[0].Value, 1)
+	if err != nil {
+		return err
+	}
+
+	templateVariablesTerm, err := builtins.ObjectOperand(operands[1].Value, 2)
+	if err != nil {
+		return err
+	}
+
+	var templateVariables map[string]interface{}
+
+	if err := ast.As(templateVariablesTerm, &templateVariables); err != nil {
+		return err
+	}
+
+	tmpl, err := template.New("template").Parse(string(preContentTerm))
+	if err != nil {
+		return err
+	}
+
+	// Do not attempt to render if template variable keys are missing
+	tmpl.Option("missingkey=error")
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, templateVariables); err != nil {
+		return err
+	}
+
+	return iter(ast.StringTerm(buf.String()))
+}
+
+func init() {
+	RegisterBuiltinFunc(ast.RenderTemplate.Name, renderTemplate)
+}


### PR DESCRIPTION
<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->

### Why the changes in this PR are needed?
closes: #6371 

Adds a builtin function for template rendering.
<!--
Include a short description of WHY the changes were made.
-->

### What are the changes in this PR?
Adds a new builtin function that accepts a templated string and a mapping of vars to inject, and returns the rendered string with the vars injected.

<!--
Include a short description of WHAT changes were made.
-->

### Notes to assist PR review:
For this builtin function, I've set the `missingkey` option to `error`, so that if the template contains a variable that is not present in the given variable mapping, the function will not attempt to render the template and return an error. This was done to prevent silent failures from occurring. 
  

<!--
Here you can add information you think will help the reviewer(s).
-->


<!--
Here you can include links to additional resources related to the changes, discuss your solution, other approaches you considered etc.
-->
