### PR TITLE
server: Support fsnotify reloading of certs

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -282,6 +282,7 @@ func initRuntime(ctx context.Context, params runCmdParams, args []string, addrSe
 	params.rt.CertificateFile = params.tlsCertFile
 	params.rt.CertificateKeyFile = params.tlsPrivateKeyFile
 	params.rt.CertificateRefresh = params.tlsCertRefresh
+	params.rt.CertPoolFile = params.tlsCACertFile
 
 	if params.tlsCACertFile != "" {
 		pool, err := loadCertPool(params.tlsCACertFile)

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -564,9 +564,15 @@ func (rt *Runtime) Serve(ctx context.Context) error {
 		rt.server = rt.server.WithUnixSocketPermission(rt.Params.UnixSocketPerm)
 	}
 
+	// If a refresh period is set, then we will periodically reload the certificate and ca pool. Otherwise, we will only
+	// reload cert, key and ca pool files when they change on disk.
 	if rt.Params.CertificateRefresh > 0 {
-		rt.server = rt.server.WithCertificatePaths(rt.Params.CertificateFile, rt.Params.CertificateKeyFile, rt.Params.CertificateRefresh)
-	} else if rt.Params.Certificate != nil {
+		rt.server = rt.server.WithCertRefresh(rt.Params.CertificateRefresh)
+	}
+
+	// if either the cert or the ca pool file is set then these fields will be set on the server and reloaded when they
+	// change on disk.
+	if rt.Params.CertificateFile != "" || rt.Params.CertPoolFile != "" {
 		rt.server = rt.server.WithTLSConfig(&server.TLSConfig{
 			CertFile:     rt.Params.CertificateFile,
 			KeyFile:      rt.Params.CertificateKeyFile,

--- a/server/certs.go
+++ b/server/certs.go
@@ -27,54 +27,56 @@ func (s *Server) getCertificate(h *tls.ClientHelloInfo) (*tls.Certificate, error
 }
 
 func (s *Server) reloadTLSConfig(logger logging.Logger) error {
-	certHash, err := hash(s.certFile)
-	if err != nil {
-		return fmt.Errorf("failed to refresh server certificate: %w", err)
-	}
-	certKeyHash, err := hash(s.certKeyFile)
-	if err != nil {
-		return fmt.Errorf("failed to refresh server key: %w", err)
-	}
-
 	s.tlsConfigMtx.Lock()
 	defer s.tlsConfigMtx.Unlock()
 
-	different := !bytes.Equal(s.certFileHash, certHash) ||
-		!bytes.Equal(s.certKeyFileHash, certKeyHash)
-
-	if different { // load and store
-		newCert, err := tls.LoadX509KeyPair(s.certFile, s.certKeyFile)
+	// if the server has a cert configured, then we need to check the cert and key for changes.
+	if s.certFile != "" {
+		certHash, err := hash(s.certFile)
 		if err != nil {
-			return fmt.Errorf("failed to refresh server certificate: %w", err)
+			return fmt.Errorf("failed to check server certificate: %w", err)
 		}
-		s.cert = &newCert
-		s.certFileHash = certHash
-		s.certKeyFileHash = certKeyHash
-		logger.Debug("Refreshed server certificate.")
-	}
 
-	// do not attempt to reload the ca cert pool if it has not been configured
-	if s.certPoolFile == "" {
-		return nil
-	}
-
-	certPoolHash, err := hash(s.certPoolFile)
-	if err != nil {
-		return fmt.Errorf("failed to refresh CA cert pool: %w", err)
-	}
-
-	if !bytes.Equal(s.certPoolFileHash, certPoolHash) {
-		caCertPEM, err := os.ReadFile(s.certPoolFile)
+		certKeyHash, err := hash(s.certKeyFile)
 		if err != nil {
-			return fmt.Errorf("failed to read CA cert pool file: %w", err)
+			return fmt.Errorf("failed to check server key: %w", err)
 		}
 
-		pool := x509.NewCertPool()
-		if ok := pool.AppendCertsFromPEM(caCertPEM); !ok {
-			return fmt.Errorf("failed to parse CA cert pool file %q", s.certPoolFile)
+		different := !bytes.Equal(s.certFileHash, certHash) ||
+			!bytes.Equal(s.certKeyFileHash, certKeyHash)
+
+		if different { // load and store
+			newCert, err := tls.LoadX509KeyPair(s.certFile, s.certKeyFile)
+			if err != nil {
+				return fmt.Errorf("failed to refresh server certificate: %w", err)
+			}
+			s.cert = &newCert
+			s.certFileHash = certHash
+			s.certKeyFileHash = certKeyHash
+			logger.Debug("Refreshed server certificate.")
+		}
+	}
+
+	// do not attempt to reload the ca cert pool if it has not been configured.
+	if s.certPoolFile != "" {
+		certPoolHash, err := hash(s.certPoolFile)
+		if err != nil {
+			return fmt.Errorf("failed to refresh CA cert pool: %w", err)
 		}
 
-		s.certPool = pool
+		if !bytes.Equal(s.certPoolFileHash, certPoolHash) {
+			caCertPEM, err := os.ReadFile(s.certPoolFile)
+			if err != nil {
+				return fmt.Errorf("failed to read CA cert pool file: %w", err)
+			}
+
+			pool := x509.NewCertPool()
+			if ok := pool.AppendCertsFromPEM(caCertPEM); !ok {
+				return fmt.Errorf("failed to parse CA cert pool file %q", s.certPoolFile)
+			}
+
+			s.certPool = pool
+		}
 	}
 
 	return nil
@@ -95,9 +97,21 @@ func (s *Server) certLoopPolling(logger logging.Logger) Loop {
 
 func (s *Server) certLoopNotify(logger logging.Logger) Loop {
 	return func() error {
-		watcher, err := pathwatcher.CreatePathWatcher([]string{
-			s.certFile, s.certKeyFile, s.certPoolFile,
-		})
+
+		var paths []string
+
+		// if a cert file is set, then we want to watch the cert and key
+		if s.certFile != "" {
+			paths = append(paths, s.certFile, s.certKeyFile)
+		}
+
+		// if a cert pool file is set, then we want to watch the cert pool. This might be set without the cert and key
+		// being set too.
+		if s.certPoolFile != "" {
+			paths = append(paths, s.certPoolFile)
+		}
+
+		watcher, err := pathwatcher.CreatePathWatcher(paths)
 		if err != nil {
 			return fmt.Errorf("failed to create tls path watcher: %w", err)
 		}

--- a/server/certs.go
+++ b/server/certs.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/fsnotify/fsnotify"
 
+	"github.com/open-policy-agent/opa/internal/errors"
 	"github.com/open-policy-agent/opa/internal/pathwatcher"
 	"github.com/open-policy-agent/opa/logging"
 )
@@ -26,60 +27,109 @@ func (s *Server) getCertificate(h *tls.ClientHelloInfo) (*tls.Certificate, error
 	return s.cert, nil
 }
 
+// reloadTLSConfig reloads the TLS config if the cert, key files or cert pool contents have changed.
 func (s *Server) reloadTLSConfig(logger logging.Logger) error {
 	s.tlsConfigMtx.Lock()
 	defer s.tlsConfigMtx.Unlock()
 
+	// reloading of the certificate key pair and the CA pool are independent operations,
+	// though errors from either operation are aggregated.
+	var errs error
+
 	// if the server has a cert configured, then we need to check the cert and key for changes.
 	if s.certFile != "" {
-		certHash, err := hash(s.certFile)
+		newCert, certFileHash, certKeyFileHash, updated, err := reloadCertificateKeyPair(
+			s.certFile,
+			s.certKeyFile,
+			s.certFileHash,
+			s.certKeyFileHash,
+			logger,
+		)
 		if err != nil {
-			return fmt.Errorf("failed to check server certificate: %w", err)
-		}
+			errs = errors.Join(errs, err)
+		} else if updated {
+			s.cert = newCert
+			s.certFileHash = certFileHash
+			s.certKeyFileHash = certKeyFileHash
 
-		certKeyHash, err := hash(s.certKeyFile)
-		if err != nil {
-			return fmt.Errorf("failed to check server key: %w", err)
-		}
-
-		different := !bytes.Equal(s.certFileHash, certHash) ||
-			!bytes.Equal(s.certKeyFileHash, certKeyHash)
-
-		if different { // load and store
-			newCert, err := tls.LoadX509KeyPair(s.certFile, s.certKeyFile)
-			if err != nil {
-				return fmt.Errorf("failed to refresh server certificate: %w", err)
-			}
-			s.cert = &newCert
-			s.certFileHash = certHash
-			s.certKeyFileHash = certKeyHash
 			logger.Debug("Refreshed server certificate.")
 		}
 	}
 
-	// do not attempt to reload the ca cert pool if it has not been configured.
+	// if the server has a cert pool configured, also attempt to reload this
 	if s.certPoolFile != "" {
-		certPoolHash, err := hash(s.certPoolFile)
+		pool, updated, err := reloadCertificatePool(s.certPoolFile, s.certPoolFileHash, logger)
 		if err != nil {
-			return fmt.Errorf("failed to refresh CA cert pool: %w", err)
-		}
-
-		if !bytes.Equal(s.certPoolFileHash, certPoolHash) {
-			caCertPEM, err := os.ReadFile(s.certPoolFile)
-			if err != nil {
-				return fmt.Errorf("failed to read CA cert pool file: %w", err)
-			}
-
-			pool := x509.NewCertPool()
-			if ok := pool.AppendCertsFromPEM(caCertPEM); !ok {
-				return fmt.Errorf("failed to parse CA cert pool file %q", s.certPoolFile)
-			}
-
+			errs = errors.Join(errs, err)
+		} else if updated {
 			s.certPool = pool
+			logger.Debug("Refreshed server CA certificate pool.")
 		}
 	}
 
-	return nil
+	return errs
+}
+
+// reloadCertificatePool loads the CA cert pool from the given file and returns a new pool if the file has changed.
+func reloadCertificatePool(certPoolFile string, certPoolFileHash []byte, logger logging.Logger) (*x509.CertPool, bool, error) {
+	certPoolHash, err := hash(certPoolFile)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to hash CA cert pool file: %w", err)
+	}
+
+	if bytes.Equal(certPoolFileHash, certPoolHash) {
+		return nil, false, nil
+	}
+	caCertPEM, err := os.ReadFile(certPoolFile)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to read CA cert pool file %q: %w", certPoolFile, err)
+	}
+
+	pool := x509.NewCertPool()
+	if ok := pool.AppendCertsFromPEM(caCertPEM); !ok {
+		return nil, false, fmt.Errorf("failed to load CA cert pool file %q", certPoolFile)
+	}
+
+	return pool, true, nil
+}
+
+// reloadCertificateKeyPair loads the certificate and key from the given files and returns a new certificate if either
+// file has changed.
+func reloadCertificateKeyPair(
+	certFile, certKeyFile string,
+	certFileHash, certKeyFileHash []byte,
+	logger logging.Logger,
+) (*tls.Certificate, []byte, []byte, bool, error) {
+	certHash, err := hash(certFile)
+	if err != nil {
+		return nil, nil, nil, false, fmt.Errorf("failed to hash server certificate file: %w", err)
+	}
+
+	certKeyHash, err := hash(certKeyFile)
+	if err != nil {
+		return nil, nil, nil, false, fmt.Errorf("failed to hash server key file: %w", err)
+	}
+
+	differentCert := !bytes.Equal(certFileHash, certHash)
+	differentKey := !bytes.Equal(certKeyFileHash, certKeyHash)
+
+	if differentCert && !differentKey {
+		logger.Warn("Server certificate file changed but server key file did not change.")
+	}
+	if !differentCert && differentKey {
+		logger.Warn("Server key file changed but server certificate file did not change.")
+	}
+
+	if !differentCert && !differentKey {
+		return nil, nil, nil, false, nil
+	}
+
+	newCert, err := tls.LoadX509KeyPair(certFile, certKeyFile)
+	if err != nil {
+		return nil, nil, nil, false, fmt.Errorf("server certificate key pair was not updated, update failed: %w", err)
+	}
+
+	return &newCert, certHash, certKeyHash, true, nil
 }
 
 func (s *Server) certLoopPolling(logger logging.Logger) Loop {

--- a/server/certs.go
+++ b/server/certs.go
@@ -8,52 +8,110 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"crypto/tls"
+	"crypto/x509"
+	"fmt"
 	"io"
 	"os"
 	"time"
 
+	"github.com/fsnotify/fsnotify"
+
+	"github.com/open-policy-agent/opa/internal/pathwatcher"
 	"github.com/open-policy-agent/opa/logging"
 )
 
 func (s *Server) getCertificate(h *tls.ClientHelloInfo) (*tls.Certificate, error) {
-	s.certMtx.RLock()
-	defer s.certMtx.RUnlock()
+	s.tlsConfigMtx.RLock()
+	defer s.tlsConfigMtx.RUnlock()
 	return s.cert, nil
 }
 
-func (s *Server) certLoop(logger logging.Logger) Loop {
+func (s *Server) reloadTLSConfig(logger logging.Logger) error {
+	certHash, err := hash(s.certFile)
+	if err != nil {
+		return fmt.Errorf("failed to refresh server certificate: %w", err)
+	}
+	certKeyHash, err := hash(s.certKeyFile)
+	if err != nil {
+		return fmt.Errorf("failed to refresh server key: %w", err)
+	}
+
+	s.tlsConfigMtx.Lock()
+	defer s.tlsConfigMtx.Unlock()
+
+	different := !bytes.Equal(s.certFileHash, certHash) ||
+		!bytes.Equal(s.certKeyFileHash, certKeyHash)
+
+	if different { // load and store
+		newCert, err := tls.LoadX509KeyPair(s.certFile, s.certKeyFile)
+		if err != nil {
+			return fmt.Errorf("failed to refresh server certificate: %w", err)
+		}
+		s.cert = &newCert
+		s.certFileHash = certHash
+		s.certKeyFileHash = certKeyHash
+		logger.Debug("Refreshed server certificate.")
+	}
+
+	// do not attempt to reload the ca cert pool if it has not been configured
+	if s.certPoolFile == "" {
+		return nil
+	}
+
+	certPoolHash, err := hash(s.certPoolFile)
+	if err != nil {
+		return fmt.Errorf("failed to refresh CA cert pool: %w", err)
+	}
+
+	if !bytes.Equal(s.certPoolFileHash, certPoolHash) {
+		caCertPEM, err := os.ReadFile(s.certPoolFile)
+		if err != nil {
+			return fmt.Errorf("failed to read CA cert pool file: %w", err)
+		}
+
+		pool := x509.NewCertPool()
+		if ok := pool.AppendCertsFromPEM(caCertPEM); !ok {
+			return fmt.Errorf("failed to parse CA cert pool file %q", s.certPoolFile)
+		}
+
+		s.certPool = pool
+	}
+
+	return nil
+}
+
+func (s *Server) certLoopPolling(logger logging.Logger) Loop {
 	return func() error {
 		for range time.NewTicker(s.certRefresh).C {
-			certHash, err := hash(s.certFile)
+			err := s.reloadTLSConfig(logger)
 			if err != nil {
-				logger.Info("Failed to refresh server certificate: %s.", err.Error())
-				continue
+				logger.Error(fmt.Sprintf("Failed to reload TLS config: %s", err))
 			}
-			certKeyHash, err := hash(s.certKeyFile)
-			if err != nil {
-				logger.Info("Failed to refresh server certificate: %s.", err.Error())
-				continue
-			}
+		}
 
-			s.certMtx.Lock()
+		return nil
+	}
+}
 
-			different := !bytes.Equal(s.certFileHash, certHash) ||
-				!bytes.Equal(s.certKeyFileHash, certKeyHash)
+func (s *Server) certLoopNotify(logger logging.Logger) Loop {
+	return func() error {
+		watcher, err := pathwatcher.CreatePathWatcher([]string{
+			s.certFile, s.certKeyFile, s.certPoolFile,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to create tls path watcher: %w", err)
+		}
 
-			if different { // load and store
-				newCert, err := tls.LoadX509KeyPair(s.certFile, s.certKeyFile)
+		for evt := range watcher.Events {
+			removalMask := fsnotify.Remove | fsnotify.Rename
+			mask := fsnotify.Create | fsnotify.Write | removalMask
+			if (evt.Op & mask) != 0 {
+				err = s.reloadTLSConfig(s.manager.Logger())
 				if err != nil {
-					logger.Info("Failed to refresh server certificate: %s.", err.Error())
-					s.certMtx.Unlock()
-					continue
+					logger.Error("failed to reload TLS config: %s", err)
 				}
-				s.cert = &newCert
-				s.certFileHash = certHash
-				s.certKeyFileHash = certKeyHash
-				logger.Debug("Refreshed server certificate.")
+				logger.Info("TLS config reloaded")
 			}
-
-			s.certMtx.Unlock()
 		}
 
 		return nil

--- a/server/server.go
+++ b/server/server.go
@@ -298,6 +298,12 @@ func (s *Server) WithTLSConfig(tlsConfig *TLSConfig) *Server {
 	return s
 }
 
+// WithCertRefresh sets the period on which certs, keys and cert pools are reloaded from disk.
+func (s *Server) WithCertRefresh(refresh time.Duration) *Server {
+	s.certRefresh = refresh
+	return s
+}
+
 // WithStore sets the storage used by the server.
 func (s *Server) WithStore(store storage.Store) *Server {
 	s.store = store
@@ -595,7 +601,7 @@ func (s *Server) getListener(addr string, h http.Handler, t httpListenerType) ([
 		// otherwise use the fsnotify default behavior
 		if s.certRefresh > 0 {
 			loops = []Loop{loop, s.certLoopPolling(logger)}
-		} else if s.certFile != "" {
+		} else if s.certFile != "" || s.certPoolFile != "" {
 			loops = []Loop{loop, s.certLoopNotify(logger)}
 		}
 	default:

--- a/server/server.go
+++ b/server/server.go
@@ -159,13 +159,16 @@ type Metrics interface {
 // This configuration is used to configure file watchers to reload each file as it
 // changes on disk.
 type TLSConfig struct {
-	// CertFile is the path to the certificate file.
+	// CertFile is the path to the server's serving certificate file.
 	CertFile string
 
-	// KeyFile is the path to the key file.
+	// KeyFile is the path to the server's key file, completing the key pair for the
+	// CertFile certificate.
 	KeyFile string
 
-	// CertPoolFile is the path to the CA cert pool file.
+	// CertPoolFile is the path to the CA cert pool file. The contents of this file will be
+	// reloaded when the file changes on disk and used in as trusted client CAs in the TLS config
+	// for new connections to the server.
 	CertPoolFile string
 }
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -5144,8 +5144,8 @@ func TestCertPoolReloading(t *testing.T) {
 	}
 
 	_, err = client.Do(req)
-	if !strings.Contains(err.Error(), "bad certificate") {
-		t.Fatalf("expected bad certificate error, got %s", err.Error())
+	if !strings.Contains(err.Error(), "remote error: tls") {
+		t.Fatalf("expected unknown certificate authority error but got: %s", err)
 	}
 
 	// update the cert pool file to include the CA cert
@@ -5167,7 +5167,6 @@ func TestCertPoolReloading(t *testing.T) {
 		}
 
 		_, err = client.Do(req)
-		t.Log(err)
 		if err != nil {
 			t.Log("server still doesn't trust client cert")
 			retries--


### PR DESCRIPTION
Fixes https://github.com/open-policy-agent/opa/issues/5788

This PR makes the following changes:

* Adds a new `WithTLSConfig` option on the server to support the setting of a cert, key and ca cert at the same time. Previously, it was only possible to set the cert and key, in addition to a polling duration with `WithCertificatePaths`.
* Adds a test for this in `TestFSNotifyCertReloading` and the interval reloading in `TestIntervalCertReloading`. These tests are really verbose, and the cert fixture creation might be best if DRYed up some.
* Makes it possible to reload the CA certs when the pool file changes on disk. Previously, this was static post init.
* Retains the `WithCertificate` and `WithCertPool` runtime options as well as the polling behaviour if the interval is set in `certLoopPolling`