### PR TITLE
plugins/rest: masks X-AMZ-SECURITY-TOKEN header in decision logs

### DIFF
--- a/plugins/rest/rest.go
+++ b/plugins/rest/rest.go
@@ -32,9 +32,9 @@ const (
 	grantTypeJwtBearer         = "jwt_bearer"
 )
 
-var maskedHeaderKeys = map[string]bool{
-	"Authorization":        false,
-	"X-Amz-Security-Token": false,
+var maskedHeaderKeys = map[string]struct{}{
+	"Authorization":        {},
+	"X-Amz-Security-Token": {},
 }
 
 // An HTTPAuthPlugin represents a mechanism to construct and configure HTTP authentication for a REST service
@@ -327,7 +327,7 @@ func (c Client) Do(ctx context.Context, method, path string) (*http.Response, er
 		c.loggerFields = map[string]interface{}{
 			"method":  method,
 			"url":     url,
-			"headers": withMaskedAuthorizationHeaders(req.Header),
+			"headers": withMaskedHeaders(req.Header),
 		}
 
 		c.logger.WithFields(c.loggerFields).Debug("Sending request.")
@@ -359,11 +359,11 @@ func (c Client) Do(ctx context.Context, method, path string) (*http.Response, er
 	return resp, err
 }
 
-func withMaskedAuthorizationHeaders(headers http.Header) http.Header {
+func withMaskedHeaders(headers http.Header) http.Header {
 	masked := make(http.Header)
 	for k, v := range headers {
 		if _, ok := maskedHeaderKeys[k]; ok {
-			masked.Add(k, "REDACTED")
+			masked.Set(k, "REDACTED")
 		} else {
 			masked[k] = v
 		}

--- a/plugins/rest/rest.go
+++ b/plugins/rest/rest.go
@@ -32,6 +32,11 @@ const (
 	grantTypeJwtBearer         = "jwt_bearer"
 )
 
+var maskedHeaderKeys = map[string]bool{
+	"Authorization":        false,
+	"X-Amz-Security-Token": false,
+}
+
 // An HTTPAuthPlugin represents a mechanism to construct and configure HTTP authentication for a REST service
 type HTTPAuthPlugin interface {
 	// implementations can assume NewClient will be called before Prepare
@@ -322,7 +327,7 @@ func (c Client) Do(ctx context.Context, method, path string) (*http.Response, er
 		c.loggerFields = map[string]interface{}{
 			"method":  method,
 			"url":     url,
-			"headers": withMaskedAuthorizationHeader(req.Header),
+			"headers": withMaskedAuthorizationHeaders(req.Header),
 		}
 
 		c.logger.WithFields(c.loggerFields).Debug("Sending request.")
@@ -354,15 +359,14 @@ func (c Client) Do(ctx context.Context, method, path string) (*http.Response, er
 	return resp, err
 }
 
-func withMaskedAuthorizationHeader(headers http.Header) http.Header {
-	authzHeader := headers.Get("Authorization")
-	if authzHeader != "" {
-		masked := make(http.Header)
-		for k, v := range headers {
+func withMaskedAuthorizationHeaders(headers http.Header) http.Header {
+	masked := make(http.Header)
+	for k, v := range headers {
+		if _, ok := maskedHeaderKeys[k]; ok {
+			masked.Add(k, "REDACTED")
+		} else {
 			masked[k] = v
 		}
-		masked.Set("Authorization", "REDACTED")
-		return masked
 	}
-	return headers
+	return masked
 }

--- a/plugins/rest/rest_test.go
+++ b/plugins/rest/rest_test.go
@@ -1913,25 +1913,22 @@ func TestDebugLoggingRequestMaskAuthorizationHeader(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
-	var reqLogFound bool
-	for _, entry := range logger.Entries() {
-		if entry.Fields["headers"] != nil {
-			headers := entry.Fields["headers"].(http.Header)
-			for k := range headers {
-				v := headers.Get(k)
-				if _, ok := maskedHeaderKeys[k]; ok {
-					reqLogFound = true
-					if v != "REDACTED" {
-						t.Errorf("Expected redacted %q header value, got %v", k, v)
-					}
-				} else if k == "Remains-Unmasked" && v != plaintext {
-					t.Errorf("Expected %q header to have value %q, got %v", k, plaintext, v)
-				}
-			}
-		}
+	entries := logger.Entries()
+	if len(entries) != 2 {
+		t.Fatalf("Expected 2 log entries, got %d", len(entries))
 	}
-	if !reqLogFound {
-		t.Fatalf("Expected log entry from request")
+
+	requestEntry := entries[0]
+	headers := requestEntry.Fields["headers"].(http.Header)
+	for k := range headers {
+		v := headers.Get(k)
+		if _, ok := maskedHeaderKeys[k]; ok {
+			if v != "REDACTED" {
+				t.Errorf("Expected redacted %q header value, got %v", k, v)
+			}
+		} else if k == "Remains-Unmasked" && v != plaintext {
+			t.Errorf("Expected %q header to have value %q, got %v", k, plaintext, v)
+		}
 	}
 }
 

--- a/plugins/rest/rest_test.go
+++ b/plugins/rest/rest_test.go
@@ -1881,6 +1881,7 @@ func TestAWSCredentialServiceChain(t *testing.T) {
 
 func TestDebugLoggingRequestMaskAuthorizationHeader(t *testing.T) {
 	token := "secret"
+	plaintext := "plaintext"
 	ts := testServer{t: t, expBearerToken: token}
 	ts.start()
 	defer ts.stop()
@@ -1892,8 +1893,12 @@ func TestDebugLoggingRequestMaskAuthorizationHeader(t *testing.T) {
 			"bearer": {
 				"token": %q
 			}
+		},
+		"headers": {
+			"X-AMZ-SECURITY-TOKEN": %q,
+			"remains-unmasked": %q
 		}
-	}`, ts.server.URL, token)
+	}`, ts.server.URL, token, token, plaintext)
 	client, err := New([]byte(config), map[string]*keys.Config{})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
@@ -1912,11 +1917,15 @@ func TestDebugLoggingRequestMaskAuthorizationHeader(t *testing.T) {
 	for _, entry := range logger.Entries() {
 		if entry.Fields["headers"] != nil {
 			headers := entry.Fields["headers"].(http.Header)
-			authzHeader := headers.Get("Authorization")
-			if authzHeader != "" {
-				reqLogFound = true
-				if authzHeader != "REDACTED" {
-					t.Errorf("Excpected redacted Authorization header value, got %v", authzHeader)
+			for k := range headers {
+				v := headers.Get(k)
+				if _, ok := maskedHeaderKeys[k]; ok {
+					reqLogFound = true
+					if v != "REDACTED" {
+						t.Errorf("Expected redacted %q header value, got %v", k, v)
+					}
+				} else if k == "Remains-Unmasked" && v != plaintext {
+					t.Errorf("Expected %q header to have value %q, got %v", k, plaintext, v)
 				}
 			}
 		}


### PR DESCRIPTION
### Why the changes in this PR are needed?

Decision logs had previously been configured to hide the value of the Authorization header, as that is considered sensitive information. However, there are cases when additional headers are provided that contain sensitive information, such as the X-AMZ-SECURITY-TOKEN header. These values were being logged in plaintext, despite being equally sensitive.

### What are the changes in this PR?

This PR creates an internal map of headers that should be masked, which can be expanded if additional headers are required. It then loops over the headers in a request, and performs a lookup on the internal map to see if any of them match those that should be masked. If so, it replaces their values with "REDACTED". An existing test was added to check both the header keys that should be masked, as well as a key that should not.

An existing test was modified to check both the header keys that should be masked, as well as a test key that should not.

### Notes to assist PR review:

Implementation for this change was discussed in [this comment](https://github.com/open-policy-agent/opa/issues/5848#issuecomment-1810969930).

Nothing else comes to mind. I've got the basics - tests pass, `make check` went well, etc. If I'm missing something, please let me know.

### Further comments:

Additional work, out of scope for this PR, would be to open a config setting that would allow users to pass in a list of headers that should be masked.

Fixes: #5848 

(Replaces https://github.com/open-policy-agent/opa/pull/6421)
