### PR TITLE
fix: Disk storage broken link

### DIFF
--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -987,7 +987,7 @@ with data put into the configured `directory`.
 | `storage.disk.partitions` | `array[string]` | No | Non-overlapping `data` prefixes used for partitioning the data on disk. |
 | `storage.disk.badger` | `string` | No (default: empty) | "Superflags" passed to Badger allowing to modify advanced options. |
 
-See [the docs on disk storage](../misc-disk/) for details about the settings.
+See [the docs on disk storage](../storage/) for details about the settings.
 
 ### Server
 


### PR DESCRIPTION

### Why the changes in this PR are needed?
Broken link for disk storage page on configuration page

### What are the changes in this PR?
Replaced broken link with current storage link
