### PR TITLE
chore: Disable verbose output in wasm-sdk-e2e-test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ perf-noisy: generate
 
 .PHONY: wasm-sdk-e2e-test
 wasm-sdk-e2e-test: generate
-	$(GO) test $(GO_TAGS),slow,wasm_sdk_e2e $(GO_TEST_TIMEOUT) -v ./internal/wasm/sdk/test/e2e
+	$(GO) test $(GO_TAGS),slow,wasm_sdk_e2e $(GO_TEST_TIMEOUT) ./internal/wasm/sdk/test/e2e
 
 .PHONY: check
 check:


### PR DESCRIPTION
The output is extremely noisy and there does not seem to be a good reason for it to be enabled all of the time.