### PR TITLE
Tweak the ident token string representation

### DIFF
--- a/ast/capabilities_test.go
+++ b/ast/capabilities_test.go
@@ -82,7 +82,7 @@ func TestParserCapabilitiesWithWildcardOptInAndOlderOPA(t *testing.T) {
 		t.Fatal("expected error")
 	} else if errs, ok := err.(Errors); !ok || len(errs) != 1 {
 		t.Fatal("expected exactly one error but got:", err)
-	} else if errs[0].Code != ParseErr || errs[0].Location.Row != 7 || errs[0].Message != "unexpected ident token: expected \\n or ; or }" {
+	} else if errs[0].Code != ParseErr || errs[0].Location.Row != 7 || errs[0].Message != "unexpected identifier token: expected \\n or ; or }" {
 		t.Fatal("unexpected error:", err)
 	}
 }

--- a/ast/internal/tokens/tokens.go
+++ b/ast/internal/tokens/tokens.go
@@ -76,7 +76,7 @@ var strings = [...]string{
 	EOF:        "eof",
 	Whitespace: "whitespace",
 	Comment:    "comment",
-	Ident:      "ident",
+	Ident:      "identifier",
 	Package:    "package",
 	Import:     "import",
 	As:         "as",

--- a/ast/parser_test.go
+++ b/ast/parser_test.go
@@ -752,13 +752,13 @@ func TestSomeDeclExpr(t *testing.T) {
 	p[x] {
 		some x in {"foo": "bar"}
 	}`,
-		"unexpected ident token: expected \\n or ; or } (hint: `import future.keywords.in` for `some x in xs` expressions)")
+		"unexpected identifier token: expected \\n or ; or } (hint: `import future.keywords.in` for `some x in xs` expressions)")
 
 	assertParseErrorContains(t, "some x, y in ... usage is hinted properly", `
 	p[y] = x {
 		some x, y in {"foo": "bar"}
 	}`,
-		"unexpected ident token: expected \\n or ; or } (hint: `import future.keywords.in` for `some x in xs` expressions)")
+		"unexpected identifier token: expected \\n or ; or } (hint: `import future.keywords.in` for `some x in xs` expressions)")
 
 	assertParseRule(t, "whitespace terminated", `
 
@@ -848,13 +848,13 @@ func TestEvery(t *testing.T) {
 	p {
 		every x, y in {"foo": "bar"} { is_string(x); is_string(y) }
 	}`,
-		"unexpected ident token: expected \\n or ; or } (hint: `import future.keywords.every` for `every x in xs { ... }` expressions)")
+		"unexpected identifier token: expected \\n or ; or } (hint: `import future.keywords.every` for `every x in xs { ... }` expressions)")
 
 	assertParseErrorContains(t, "not every 'every' gets a hint", `
 	p {
 		every x
 	}`,
-		"unexpected ident token: expected \\n or ; or }\n\tevery x\n", // this asserts that the tail of the error message doesn't contain a hint
+		"unexpected identifier token: expected \\n or ; or }\n\tevery x\n", // this asserts that the tail of the error message doesn't contain a hint
 	)
 
 	assertParseErrorContains(t, "invalid domain (internal.member_2)", "every internal.member_2()", "illegal domain", opts)
@@ -5194,7 +5194,7 @@ p { input = "str" }`,
 # - Tyrell Corp.
 # related_resources:
 # - https://example.com
-# - 
+# -
 #  ref: http://john:123@do.re/mi?foo=bar#baz
 #  description: foo bar
 # authors:

--- a/cmd/eval_test.go
+++ b/cmd/eval_test.go
@@ -514,7 +514,7 @@ package test
 # METADATA
 # schemas:
 #   - input: schema["input"]
-p { 	
+p {
 	rego.metadata.rule() # presence of rego.metadata.* calls must not trigger unwanted schema evaluation
 	input.foo == 42 # type mismatch with schema that should be ignored
 }`
@@ -530,7 +530,7 @@ package test
 # schemas:
 #   - input.foo: {"type": "boolean"}
 p {
-	rego.metadata.rule() # presence of rego.metadata.* calls must not trigger unwanted schema evaluation	 
+	rego.metadata.rule() # presence of rego.metadata.* calls must not trigger unwanted schema evaluation
 	input.foo == 42 # type mismatch with schema that should NOT be ignored since it is an inlined schema format
 }`
 
@@ -1432,9 +1432,9 @@ func TestPolicyWithStrictFlag(t *testing.T) {
 	}{
 		{
 			note: "strict mode should error on duplicate imports",
-			policy: `package x 
-			import future.keywords.if 
-			import future.keywords.if 
+			policy: `package x
+			import future.keywords.if
+			import future.keywords.if
 			foo = 2`,
 			query:           "data.foo",
 			expectedCode:    "rego_compile_error",
@@ -1444,7 +1444,7 @@ func TestPolicyWithStrictFlag(t *testing.T) {
 			note: "strict mode should error on unused imports",
 			policy: `package x
 			import future.keywords.if
-			import data.foo 
+			import data.foo
 			foo = 2`,
 			query:           "data.foo",
 			expectedCode:    "rego_compile_error",
@@ -1501,15 +1501,15 @@ func TestPolicyWithStrictFlag(t *testing.T) {
 	}{
 		{
 			note: "This should not error as it is valid",
-			policy: `package x 
+			policy: `package x
 			import future.keywords.if
 			foo = 2`,
 			query: "data.foo",
 		},
 		{
 			note: "Strict mode should not validate the query, only the policy, this should not error",
-			policy: `package x 
-			import future.keywords.if 
+			policy: `package x
+			import future.keywords.if
 			foo = 2`,
 			query: "x := data.x.foo",
 		},
@@ -1546,9 +1546,9 @@ func TestBundleWithStrictFlag(t *testing.T) {
 	}{
 		{
 			note: "strict mode should error on duplicate imports in this bundle",
-			policy: `package x 
-			import future.keywords.if 
-			import future.keywords.if 
+			policy: `package x
+			import future.keywords.if
+			import future.keywords.if
 			foo = 2`,
 			query:           "data.foo",
 			expectedCode:    "rego_compile_error",
@@ -1557,8 +1557,8 @@ func TestBundleWithStrictFlag(t *testing.T) {
 		{
 			note: "strict mode should error on unused imports in this bundle",
 			policy: `package x
-			import future.keywords.if 
-			import data.foo 
+			import future.keywords.if
+			import data.foo
 			foo = 2`,
 			query:           "data.foo",
 			expectedCode:    "rego_compile_error",
@@ -1567,7 +1567,7 @@ func TestBundleWithStrictFlag(t *testing.T) {
 		{
 			note: "strict mode should error when reserved vars data or input is used in this bundle",
 			policy: `package x
-			import future.keywords.if 
+			import future.keywords.if
 			data if { x = 1}`,
 			query:           "data.foo",
 			expectedCode:    "rego_compile_error",
@@ -1616,15 +1616,15 @@ func TestBundleWithStrictFlag(t *testing.T) {
 	}{
 		{
 			note: "This bundle should not error as it is valid",
-			policy: `package x 
-			import future.keywords.if 
+			policy: `package x
+			import future.keywords.if
 			foo = 2`,
 			query: "data.foo",
 		},
 		{
 			note: "Strict mode should not validate the query, only the policy, this bundle should not error",
-			policy: `package x 
-			import future.keywords.if 
+			policy: `package x
+			import future.keywords.if
 			foo = 2`,
 			query: "x := data.x.foo",
 		},
@@ -1817,7 +1817,7 @@ func TestUnexpectedElseIfElseErr(t *testing.T) {
 			else := x if {
 				x=2
 				1==2
-			} else 
+			} else
 				x=3
 			`,
 	}
@@ -1840,7 +1840,7 @@ func TestUnexpectedElseIfElseErr(t *testing.T) {
 
 		// Check the error message
 		errorMessage := err.Error()
-		expectedErrorMessage := "rego_parse_error: unexpected ident token: expected else value term or rule body"
+		expectedErrorMessage := "rego_parse_error: unexpected identifier token: expected else value term or rule body"
 		if !strings.Contains(errorMessage, expectedErrorMessage) {
 			t.Fatalf("expected error message to contain '%s', but got '%s'", expectedErrorMessage, errorMessage)
 		}


### PR DESCRIPTION
In https://github.com/open-policy-agent/opa/issues/6432 @anderseknert pointed out that the ident string representation is not ideal. This PR just changes it to "identifier" so that it's a bit clearer.