### PR TITLE
Add a default filter to `opa check` to only load and check `.rego` files

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -77,7 +77,8 @@ func checkModules(params checkParams, args []string) error {
 		}
 	} else {
 		f := loaderFilter{
-			Ignore: params.ignore,
+			Ignore:   params.ignore,
+			OnlyRego: true,
 		}
 
 		result, err := loader.NewFileLoader().

--- a/cmd/filters.go
+++ b/cmd/filters.go
@@ -6,15 +6,22 @@ package cmd
 
 import (
 	"os"
+	"path/filepath"
 
+	"github.com/open-policy-agent/opa/bundle"
 	"github.com/open-policy-agent/opa/loader"
 )
 
 type loaderFilter struct {
-	Ignore []string
+	Ignore   []string
+	OnlyRego bool
 }
 
 func (f loaderFilter) Apply(abspath string, info os.FileInfo, depth int) bool {
+	// if set to only load rego files, skip all non-rego files
+	if f.OnlyRego && !info.IsDir() && filepath.Ext(info.Name()) != bundle.RegoExt {
+		return true
+	}
 	for _, s := range f.Ignore {
 		if loader.GlobExcludeName(s, 1)(abspath, info, depth) {
 			return true


### PR DESCRIPTION
### Why the changes in this PR are needed?

When non-rego files are included in a directory passed to `opa check`, the command fails with an error like this: 
```1 error occurred during loading: check-tests/test.json: merge error```. See https://github.com/open-policy-agent/opa/issues/6317 for more details.

### What are the changes in this PR?

This PR adds an option to the `loaderFilter` used by the `opa check` command that will exclude all files not ending in `*.rego`. This filter is optional but can be reused by other commands as necessary.

