### PR TITLE
ast: disallowing unknown metadata annotations for rego-v1

### DIFF
--- a/ast/annotations.go
+++ b/ast/annotations.go
@@ -27,16 +27,17 @@ const (
 type (
 	// Annotations represents metadata attached to other AST nodes such as rules.
 	Annotations struct {
-		Scope            string                       `json:"scope"`
-		Title            string                       `json:"title,omitempty"`
-		Entrypoint       bool                         `json:"entrypoint,omitempty"`
-		Description      string                       `json:"description,omitempty"`
-		Organizations    []string                     `json:"organizations,omitempty"`
-		RelatedResources []*RelatedResourceAnnotation `json:"related_resources,omitempty"`
-		Authors          []*AuthorAnnotation          `json:"authors,omitempty"`
-		Schemas          []*SchemaAnnotation          `json:"schemas,omitempty"`
-		Custom           map[string]interface{}       `json:"custom,omitempty"`
-		Location         *Location                    `json:"location,omitempty"`
+		Scope                   string                       `json:"scope"`
+		Title                   string                       `json:"title,omitempty"`
+		Entrypoint              bool                         `json:"entrypoint,omitempty"`
+		Description             string                       `json:"description,omitempty"`
+		Organizations           []string                     `json:"organizations,omitempty"`
+		RelatedResources        []*RelatedResourceAnnotation `json:"related_resources,omitempty"`
+		Authors                 []*AuthorAnnotation          `json:"authors,omitempty"`
+		Schemas                 []*SchemaAnnotation          `json:"schemas,omitempty"`
+		Custom                  map[string]interface{}       `json:"custom,omitempty"`
+		Location                *Location                    `json:"location,omitempty"`
+		AllowUnknownAnnotations bool                         `json:"allow_unknown_annotations"`
 
 		comments    []*Comment
 		node        Node
@@ -166,6 +167,13 @@ func (a *Annotations) Compare(other *Annotations) int {
 		return cmp
 	}
 
+	if a.AllowUnknownAnnotations != other.AllowUnknownAnnotations {
+		if a.AllowUnknownAnnotations {
+			return 1
+		}
+		return -1
+	}
+
 	return 0
 }
 
@@ -227,6 +235,10 @@ func (a *Annotations) MarshalJSON() ([]byte, error) {
 
 	if len(a.Custom) > 0 {
 		data["custom"] = a.Custom
+	}
+
+	if a.AllowUnknownAnnotations {
+		data["allow_unknown_annotations"] = a.AllowUnknownAnnotations
 	}
 
 	if a.jsonOptions.MarshalOptions.IncludeLocation.Annotations {
@@ -504,6 +516,10 @@ func (a *Annotations) toObject() (*Object, *Error) {
 			return nil, NewError(CompileErr, a.Location, "invalid custom annotation %s", err.Error())
 		}
 		obj.Insert(StringTerm("custom"), NewTerm(c))
+	}
+
+	if a.AllowUnknownAnnotations {
+		obj.Insert(StringTerm("allow_unknown_annotations"), BooleanTerm(true))
 	}
 
 	return &obj, nil

--- a/ast/annotations.go
+++ b/ast/annotations.go
@@ -27,17 +27,17 @@ const (
 type (
 	// Annotations represents metadata attached to other AST nodes such as rules.
 	Annotations struct {
-		Scope                   string                       `json:"scope"`
-		Title                   string                       `json:"title,omitempty"`
-		Entrypoint              bool                         `json:"entrypoint,omitempty"`
-		Description             string                       `json:"description,omitempty"`
-		Organizations           []string                     `json:"organizations,omitempty"`
-		RelatedResources        []*RelatedResourceAnnotation `json:"related_resources,omitempty"`
-		Authors                 []*AuthorAnnotation          `json:"authors,omitempty"`
-		Schemas                 []*SchemaAnnotation          `json:"schemas,omitempty"`
-		Custom                  map[string]interface{}       `json:"custom,omitempty"`
-		Location                *Location                    `json:"location,omitempty"`
-		AllowUnknownAnnotations bool                         `json:"allow_unknown_annotations"`
+		Scope                 string                       `json:"scope"`
+		Title                 string                       `json:"title,omitempty"`
+		Entrypoint            bool                         `json:"entrypoint,omitempty"`
+		Description           string                       `json:"description,omitempty"`
+		Organizations         []string                     `json:"organizations,omitempty"`
+		RelatedResources      []*RelatedResourceAnnotation `json:"related_resources,omitempty"`
+		Authors               []*AuthorAnnotation          `json:"authors,omitempty"`
+		Schemas               []*SchemaAnnotation          `json:"schemas,omitempty"`
+		Custom                map[string]interface{}       `json:"custom,omitempty"`
+		Location              *Location                    `json:"location,omitempty"`
+		AdditionalAnnotations bool                         `json:"additional_annotations"`
 
 		comments    []*Comment
 		node        Node
@@ -167,8 +167,8 @@ func (a *Annotations) Compare(other *Annotations) int {
 		return cmp
 	}
 
-	if a.AllowUnknownAnnotations != other.AllowUnknownAnnotations {
-		if a.AllowUnknownAnnotations {
+	if a.AdditionalAnnotations != other.AdditionalAnnotations {
+		if a.AdditionalAnnotations {
 			return 1
 		}
 		return -1
@@ -237,8 +237,8 @@ func (a *Annotations) MarshalJSON() ([]byte, error) {
 		data["custom"] = a.Custom
 	}
 
-	if a.AllowUnknownAnnotations {
-		data["allow_unknown_annotations"] = a.AllowUnknownAnnotations
+	if a.AdditionalAnnotations {
+		data["additional_annotations"] = a.AdditionalAnnotations
 	}
 
 	if a.jsonOptions.MarshalOptions.IncludeLocation.Annotations {
@@ -518,8 +518,8 @@ func (a *Annotations) toObject() (*Object, *Error) {
 		obj.Insert(StringTerm("custom"), NewTerm(c))
 	}
 
-	if a.AllowUnknownAnnotations {
-		obj.Insert(StringTerm("allow_unknown_annotations"), BooleanTerm(true))
+	if a.AdditionalAnnotations {
+		obj.Insert(StringTerm("additional_annotations"), BooleanTerm(true))
 	}
 
 	return &obj, nil

--- a/ast/compile.go
+++ b/ast/compile.go
@@ -2214,7 +2214,7 @@ func (c *Compiler) parseMetadataBlocks() {
 
 			if len(mod.Annotations) == 0 {
 				var errs Errors
-				mod.Annotations, errs = parseAnnotations(mod.Comments)
+				mod.Annotations, errs = parseAnnotations(mod.Comments, mod.regoV1Compatible)
 				errs = append(errs, attachAnnotationsNodes(mod)...)
 				for _, err := range errs {
 					c.err(err)

--- a/ast/parser.go
+++ b/ast/parser.go
@@ -2198,16 +2198,16 @@ func (p *Parser) validateDefaultRuleArgs(rule *Rule) bool {
 // We explicitly use yaml unmarshalling, to accommodate for the '_' in 'related_resources',
 // which isn't handled properly by json for some reason.
 type rawAnnotation struct {
-	Scope                   string                 `yaml:"scope"`
-	Title                   string                 `yaml:"title"`
-	Entrypoint              bool                   `yaml:"entrypoint"`
-	Description             string                 `yaml:"description"`
-	Organizations           []string               `yaml:"organizations"`
-	RelatedResources        []interface{}          `yaml:"related_resources"`
-	Authors                 []interface{}          `yaml:"authors"`
-	Schemas                 []rawSchemaAnnotation  `yaml:"schemas"`
-	Custom                  map[string]interface{} `yaml:"custom"`
-	AllowUnknownAnnotations bool                   `yaml:"allow_unknown_annotations"`
+	Scope                 string                 `yaml:"scope"`
+	Title                 string                 `yaml:"title"`
+	Entrypoint            bool                   `yaml:"entrypoint"`
+	Description           string                 `yaml:"description"`
+	Organizations         []string               `yaml:"organizations"`
+	RelatedResources      []interface{}          `yaml:"related_resources"`
+	Authors               []interface{}          `yaml:"authors"`
+	Schemas               []rawSchemaAnnotation  `yaml:"schemas"`
+	Custom                map[string]interface{} `yaml:"custom"`
+	AdditionalAnnotations bool                   `yaml:"additional_annotations"`
 }
 
 type rawSchemaAnnotation map[string]interface{}
@@ -2257,7 +2257,7 @@ func (b *metadataParser) Parse() (*Annotations, error) {
 		return nil, augmentYamlError(err, b.comments)
 	}
 
-	if b.regoV1Compatible && !raw.AllowUnknownAnnotations {
+	if b.regoV1Compatible && !raw.AdditionalAnnotations {
 		var allAnnotations map[string]interface{}
 		if err := yaml.Unmarshal(b.buf.Bytes(), &allAnnotations); err == nil {
 			// we passed unmarshalling once, so we should never have an error
@@ -2270,7 +2270,7 @@ func (b *metadataParser) Parse() (*Annotations, error) {
 			delete(allAnnotations, "authors")
 			delete(allAnnotations, "schemas")
 			delete(allAnnotations, "custom")
-			delete(allAnnotations, "allow_unknown_annotations")
+			delete(allAnnotations, "additional_annotations")
 
 			if len(allAnnotations) > 0 {
 				unknownAnnotations := make([]string, 0, len(allAnnotations))
@@ -2289,7 +2289,7 @@ func (b *metadataParser) Parse() (*Annotations, error) {
 	result.Title = raw.Title
 	result.Description = raw.Description
 	result.Organizations = raw.Organizations
-	result.AllowUnknownAnnotations = raw.AllowUnknownAnnotations
+	result.AdditionalAnnotations = raw.AdditionalAnnotations
 
 	for _, v := range raw.RelatedResources {
 		rr, err := parseRelatedResource(v)

--- a/ast/parser_test.go
+++ b/ast/parser_test.go
@@ -5179,6 +5179,66 @@ p { input = "str" }`,
 				},
 			},
 		},
+		// unknown annotations
+		{
+			note: "Unknown annotation (rego v0)",
+			module: `package test
+# METADATA
+# title: P
+# foo: bar
+p := 1`,
+			expNumComments: 3,
+			expAnnotations: []*Annotations{
+				{
+					Title: "P",
+					Scope: annotationScopeRule,
+				},
+			},
+		},
+		{
+			note: "Unknown annotation (rego v1)",
+			module: `package test
+import rego.v1
+
+# METADATA
+# title: P
+# foo: bar
+p := 1`,
+			expNumComments: 3,
+			expError:       "test.rego:4: rego_parse_error: unknown annotation(s): [foo]",
+		},
+		{
+			note: "Unknown annotation, allowed (rego v1)",
+			module: `package test
+import rego.v1
+
+# METADATA
+# title: P
+# allow_unknown_annotations: true
+# foo: bar
+p := 1`,
+			expNumComments: 4,
+			expAnnotations: []*Annotations{
+				{
+					Title:                   "P",
+					Scope:                   annotationScopeRule,
+					AllowUnknownAnnotations: true,
+				},
+			},
+		},
+		{
+			note: "Unknown annotation, explicitly disallowed (rego v1)",
+			module: `package test
+import rego.v1
+
+# METADATA
+# title: P
+# allow_unknown_annotations: false
+# foo: bar
+p := 1`,
+			expNumComments: 4,
+			expError:       "test.rego:4: rego_parse_error: unknown annotation(s): [foo]",
+		},
 		{
 			note: "Rich meta",
 			module: `package test

--- a/ast/parser_test.go
+++ b/ast/parser_test.go
@@ -5214,15 +5214,15 @@ import rego.v1
 
 # METADATA
 # title: P
-# allow_unknown_annotations: true
+# additional_annotations: true
 # foo: bar
 p := 1`,
 			expNumComments: 4,
 			expAnnotations: []*Annotations{
 				{
-					Title:                   "P",
-					Scope:                   annotationScopeRule,
-					AllowUnknownAnnotations: true,
+					Title:                 "P",
+					Scope:                 annotationScopeRule,
+					AdditionalAnnotations: true,
 				},
 			},
 		},
@@ -5233,7 +5233,7 @@ import rego.v1
 
 # METADATA
 # title: P
-# allow_unknown_annotations: false
+# additional_annotations: false
 # foo: bar
 p := 1`,
 			expNumComments: 4,

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -279,6 +279,11 @@ func populateAnnotations(out io.Writer, refs []*ast.AnnotationsRef) error {
 					printList(out, l, " ")
 					fmt.Fprintln(out)
 				}
+
+				if a.AllowUnknownAnnotations {
+					fmt.Fprintln(out, "Allow Unknown Annotations:", a.AllowUnknownAnnotations)
+				}
+
 				if len(a.Custom) > 0 {
 					fmt.Fprintln(out, "Custom:")
 					l := make([]listEntry, 0, len(a.Custom))

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -280,8 +280,8 @@ func populateAnnotations(out io.Writer, refs []*ast.AnnotationsRef) error {
 					fmt.Fprintln(out)
 				}
 
-				if a.AllowUnknownAnnotations {
-					fmt.Fprintln(out, "Allow Unknown Annotations:", a.AllowUnknownAnnotations)
+				if a.AdditionalAnnotations {
+					fmt.Fprintln(out, "Additional Annotations:", a.AdditionalAnnotations)
 				}
 
 				if len(a.Custom) > 0 {

--- a/docs/content/policy-language.md
+++ b/docs/content/policy-language.md
@@ -2710,6 +2710,7 @@ organizations | list of strings | A list of organizations related to the annotat
 schemas | list of object | A list of associations between value paths and schema definitions. Read more [here](#schemas).
 entrypoint | boolean | Whether or not the annotation target is to be used as a policy entrypoint. Read more [here](#entrypoint).
 custom | mapping of arbitrary data | A custom mapping of named parameters holding arbitrary data. Read more [here](#custom).
+additional_annotations | boolean | Don't reject unknown annotations. Read more [here](#additional-annotations).
 
 ### Scope
 
@@ -2960,6 +2961,25 @@ The `custom` annotation is a mapping of user-defined data, mapping string keys t
 #   a: 1
 #   b: 2
 allow {
+  ...
+}
+```
+
+### Additional Annotations
+
+When OPA 1.0 compatibility is enabled through `import rego.v1`, 
+OPA will reject any unknown annotations outside of the [custom](#custom) annotation. 
+This is to ensure that future versions of OPA can safely introduce new annotations without breaking existing policies.
+This behaviour can be disabled by setting the `additional_annotations` annotation to `true`, 
+whereby unknown annotations won't abort compilation with an error.
+
+#### Example
+
+```live:rego/metadata/additional_annotations:module:read_only
+# METADATA
+# additional_annotations: true
+# foo: bar
+allow if {
   ...
 }
 ```


### PR DESCRIPTION
New `allow_unknown_annotations` annotation introduced to opt-out.

Fixes: #5411