### PR TITLE
cmd: removes hidden dependency on diff command

### DIFF
--- a/cmd/fmt.go
+++ b/cmd/fmt.go
@@ -7,9 +7,9 @@ package cmd
 import (
 	"bytes"
 	"fmt"
+	"github.com/sergi/go-diff/diffmatchpatch"
 	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 
 	"github.com/spf13/cobra"
@@ -135,14 +135,10 @@ func formatFile(params *fmtCommandParams, out io.Writer, filename string, info o
 
 	if params.diff {
 		if changed {
-			stdout, stderr, err := doDiff(contents, formatted)
-			if err != nil && stdout.Len() == 0 {
-				fmt.Fprintln(os.Stderr, stderr.String())
-				return newError("failed to diff formatting: %v", err)
+			diffString := doDiff(contents, formatted)
+			if _, err := fmt.Fprintln(out, diffString); err != nil {
+				return newError("failed to print contents: %v", err)
 			}
-
-			fmt.Fprintln(out, stdout.String())
-
 			if params.fail {
 				return newError("unexpected diff")
 			}
@@ -183,34 +179,10 @@ func formatStdin(params *fmtCommandParams, r io.Reader, w io.Writer) error {
 	return err
 }
 
-func doDiff(old, new []byte) (stdout, stderr bytes.Buffer, err error) {
-	o, err := os.CreateTemp("", ".opafmt")
-	if err != nil {
-		return stdout, stderr, err
-	}
-	defer os.Remove(o.Name())
-	defer o.Close()
-
-	n, err := os.CreateTemp("", ".opafmt")
-	if err != nil {
-		return stdout, stderr, err
-	}
-	defer os.Remove(n.Name())
-	defer n.Close()
-
-	_, err = o.Write(old)
-	if err != nil {
-		return stdout, stderr, err
-	}
-	_, err = n.Write(new)
-	if err != nil {
-		return stdout, stderr, err
-	}
-
-	cmd := exec.Command("diff", "-u", o.Name(), n.Name())
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	return stdout, stderr, cmd.Run()
+func doDiff(old, new []byte) (diffString string) {
+	dmp := diffmatchpatch.New()
+	diffs := dmp.DiffMain(string(old), string(new), false)
+	return dmp.DiffPrettyText(diffs)
 }
 
 type fmtError struct {

--- a/cmd/fmt.go
+++ b/cmd/fmt.go
@@ -7,11 +7,11 @@ package cmd
 import (
 	"bytes"
 	"fmt"
-	"github.com/sergi/go-diff/diffmatchpatch"
 	"io"
 	"os"
 	"path/filepath"
 
+	"github.com/sergi/go-diff/diffmatchpatch"
 	"github.com/spf13/cobra"
 
 	"github.com/open-policy-agent/opa/format"

--- a/cmd/fmt_test.go
+++ b/cmd/fmt_test.go
@@ -97,20 +97,20 @@ func TestFmtFormatFileFailToReadFile(t *testing.T) {
 		"policy.rego": unformatted,
 	}
 
-	not_there := "not_there.rego"
+	notThere := "notThere.rego"
 
 	test.WithTempFS(files, func(path string) {
 		policyFile := filepath.Join(path, "policy.rego")
 		info, err := os.Stat(policyFile)
-		err = formatFile(&params, &stdout, not_there, info, err)
+		err = formatFile(&params, &stdout, notThere, info, err)
 		if err == nil {
 			t.Fatalf("Expected error, found none")
 		}
 
 		actual := err.Error()
 
-		if !strings.Contains(actual, not_there) {
-			t.Fatalf("Expected error message to include %s, got:\n%s\n\n", not_there, actual)
+		if !strings.Contains(actual, notThere) {
+			t.Fatalf("Expected error message to include %s, got:\n%s\n\n", notThere, actual)
 		}
 	})
 }


### PR DESCRIPTION
### Why the changes in this PR are needed?

There's a hidden dependency on the `diff` command, which can fail if there is no diff tool installed. 

### What are the changes in this PR?

- Replaces the call to `diff` with a call to the go-diff library, which is already installed
- Adds tests to the modified `formatFile` function to improve coverage

### Further comments:

I wanted to add more tests to continue to improve coverage, specifically for the `-w` flag, but that's beyond the scope of this issue and would have taken some lengthy digging into the `util/test` package. Is there a general coverage improvement issue that can be used for things like that?

Fixes #6284 