### PR TITLE
Adding `--v1-compatible` flag to `opa build` and `opa eval`

### DIFF
--- a/ast/compile.go
+++ b/ast/compile.go
@@ -1537,7 +1537,7 @@ func (c *Compiler) checkUnsafeBuiltins() {
 func (c *Compiler) checkDeprecatedBuiltins() {
 	for _, name := range c.sorted {
 		mod := c.Modules[name]
-		if c.strict || mod.regoV1Compatible {
+		if c.strict || mod.regoV1Compatible() {
 			errs := checkDeprecatedBuiltins(c.deprecatedBuiltinsMap, mod)
 			for _, err := range errs {
 				c.err(err)
@@ -1683,7 +1683,7 @@ func (c *Compiler) checkDuplicateImports() {
 
 	for _, name := range c.sorted {
 		mod := c.Modules[name]
-		if c.strict || mod.regoV1Compatible {
+		if c.strict || mod.regoV1Compatible() {
 			modules = append(modules, mod)
 		}
 	}
@@ -1697,7 +1697,7 @@ func (c *Compiler) checkDuplicateImports() {
 func (c *Compiler) checkKeywordOverrides() {
 	for _, name := range c.sorted {
 		mod := c.Modules[name]
-		if c.strict || mod.regoV1Compatible {
+		if c.strict || mod.regoV1Compatible() {
 			errs := checkRootDocumentOverrides(mod)
 			for _, err := range errs {
 				c.err(err)

--- a/ast/parser.go
+++ b/ast/parser.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"maps"
 	"math/big"
 	"net/url"
 	"regexp"
@@ -273,7 +272,9 @@ func (p *Parser) Parse() ([]Statement, []*Comment, Errors) {
 
 	if p.po.RegoVersion == RegoV1 {
 		// RegoV1 includes all future keywords in the default language definition
-		allowedFutureKeywords = maps.Clone(futureKeywords)
+		for k, v := range futureKeywords {
+			allowedFutureKeywords[k] = v
+		}
 	} else {
 		for _, kw := range p.po.Capabilities.FutureKeywords {
 			var ok bool

--- a/ast/parser.go
+++ b/ast/parser.go
@@ -125,14 +125,14 @@ type ParserOptions struct {
 	// RegoV1Compatible additionally affects the Rego version. Use EffectiveRegoVersion to get the effective Rego version.
 	RegoVersion RegoVersion
 	// RegoV1Compatible is equivalent to setting RegoVersion to RegoV0CompatV1.
-	// Setting RegoV1Compatible only has effect if RegoVersion is RegoV0.
+	// RegoV1Compatible takes precedence, and if set to true, RegoVersion is ignored.
 	// Deprecated: use RegoVersion instead. Will be removed in a future version of OPA.
 	RegoV1Compatible   bool
 	unreleasedKeywords bool // TODO(sr): cleanup
 }
 
 func (po *ParserOptions) EffectiveRegoVersion() RegoVersion {
-	if po.RegoVersion == RegoV0 && po.RegoV1Compatible {
+	if po.RegoV1Compatible {
 		return RegoV0CompatV1
 	}
 	return po.RegoVersion

--- a/ast/parser.go
+++ b/ast/parser.go
@@ -27,11 +27,19 @@ import (
 
 var RegoV1CompatibleRef = Ref{VarTerm("rego"), StringTerm("v1")}
 
+// RegoVersion defines the Rego syntax requirements for a module.
 type RegoVersion int
 
 const (
+	// RegoV0 is the default, original Rego syntax.
 	RegoV0 RegoVersion = iota
+	// RegoV0CompatV1 requires modules to comply with both the RegoV0 and RegoV1 syntax (as when 'rego.v1' is imported in a module).
+	// Shortly, RegoV1 compatibility is required, but 'rego.v1' or 'future.keywords' must also be imported.
 	RegoV0CompatV1
+	// RegoV1 is the Rego syntax enforced by OPA 1.0; e.g.:
+	// future.keywords part of default keyword set, and don't require imports;
+	// 'if' and 'contains' required in rule heads;
+	// (some) strict checks on by default.
 	RegoV1
 )
 

--- a/ast/parser_ext.go
+++ b/ast/parser_ext.go
@@ -659,14 +659,14 @@ func parseModule(filename string, stmts []Statement, comments []*Comment, regoCo
 
 	// The comments slice only holds comments that were not their own statements.
 	mod.Comments = append(mod.Comments, comments...)
-	mod.regoV1Compatible = regoCompatibilityMode == RegoV1 || regoCompatibilityMode == RegoV0CompatV1
+	mod.regoVersion = regoCompatibilityMode
 
 	for i, stmt := range stmts[1:] {
 		switch stmt := stmt.(type) {
 		case *Import:
 			mod.Imports = append(mod.Imports, stmt)
-			if Compare(stmt.Path.Value, RegoV1CompatibleRef) == 0 {
-				mod.regoV1Compatible = true
+			if mod.regoVersion == RegoV0 && Compare(stmt.Path.Value, RegoV1CompatibleRef) == 0 {
+				mod.regoVersion = RegoV0CompatV1
 			}
 		case *Rule:
 			setRuleModule(stmt, mod)
@@ -695,7 +695,7 @@ func parseModule(filename string, stmts []Statement, comments []*Comment, regoCo
 		}
 	}
 
-	if mod.regoV1Compatible {
+	if mod.regoVersion == RegoV0CompatV1 || mod.regoVersion == RegoV1 {
 		for _, rule := range mod.Rules {
 			for r := rule; r != nil; r = r.Else {
 				var t string

--- a/ast/parser_ext.go
+++ b/ast/parser_ext.go
@@ -477,7 +477,7 @@ func ParseModuleWithOpts(filename, input string, popts ParserOptions) (*Module, 
 	if err != nil {
 		return nil, err
 	}
-	return parseModule(filename, stmts, comments, popts.RegoV1Compatible)
+	return parseModule(filename, stmts, comments, popts.RegoVersion)
 }
 
 // ParseBody returns exactly one body.
@@ -626,6 +626,7 @@ func ParseStatementsWithOpts(filename, input string, popts ParserOptions) ([]Sta
 		WithCapabilities(popts.Capabilities).
 		WithSkipRules(popts.SkipRules).
 		WithJSONOptions(popts.JSONOptions).
+		WithRegoVersion(popts.RegoVersion).
 		withUnreleasedKeywords(popts.unreleasedKeywords)
 
 	stmts, comments, errs := parser.Parse()
@@ -637,7 +638,7 @@ func ParseStatementsWithOpts(filename, input string, popts ParserOptions) ([]Sta
 	return stmts, comments, nil
 }
 
-func parseModule(filename string, stmts []Statement, comments []*Comment, regoV1Compatible bool) (*Module, error) {
+func parseModule(filename string, stmts []Statement, comments []*Comment, regoCompatibilityMode RegoVersion) (*Module, error) {
 
 	if len(stmts) == 0 {
 		return nil, NewError(ParseErr, &Location{File: filename}, "empty module")
@@ -658,7 +659,7 @@ func parseModule(filename string, stmts []Statement, comments []*Comment, regoV1
 
 	// The comments slice only holds comments that were not their own statements.
 	mod.Comments = append(mod.Comments, comments...)
-	mod.regoV1Compatible = regoV1Compatible
+	mod.regoV1Compatible = regoCompatibilityMode == RegoV1 || regoCompatibilityMode == RegoV0CompatV1
 
 	for i, stmt := range stmts[1:] {
 		switch stmt := stmt.(type) {

--- a/ast/parser_ext.go
+++ b/ast/parser_ext.go
@@ -477,7 +477,7 @@ func ParseModuleWithOpts(filename, input string, popts ParserOptions) (*Module, 
 	if err != nil {
 		return nil, err
 	}
-	return parseModule(filename, stmts, comments, popts.RegoVersion)
+	return parseModule(filename, stmts, comments, popts.EffectiveRegoVersion())
 }
 
 // ParseBody returns exactly one body.
@@ -626,7 +626,7 @@ func ParseStatementsWithOpts(filename, input string, popts ParserOptions) ([]Sta
 		WithCapabilities(popts.Capabilities).
 		WithSkipRules(popts.SkipRules).
 		WithJSONOptions(popts.JSONOptions).
-		WithRegoVersion(popts.RegoVersion).
+		WithRegoVersion(popts.EffectiveRegoVersion()).
 		withUnreleasedKeywords(popts.unreleasedKeywords)
 
 	stmts, comments, errs := parser.Parse()

--- a/ast/policy.go
+++ b/ast/policy.go
@@ -145,13 +145,13 @@ type (
 	// within a namespace (defined by the package) and optional
 	// dependencies on external documents (defined by imports).
 	Module struct {
-		Package          *Package       `json:"package"`
-		Imports          []*Import      `json:"imports,omitempty"`
-		Annotations      []*Annotations `json:"annotations,omitempty"`
-		Rules            []*Rule        `json:"rules,omitempty"`
-		Comments         []*Comment     `json:"comments,omitempty"`
-		stmts            []Statement
-		regoV1Compatible bool
+		Package     *Package       `json:"package"`
+		Imports     []*Import      `json:"imports,omitempty"`
+		Annotations []*Annotations `json:"annotations,omitempty"`
+		Rules       []*Rule        `json:"rules,omitempty"`
+		Comments    []*Comment     `json:"comments,omitempty"`
+		stmts       []Statement
+		regoVersion RegoVersion
 	}
 
 	// Comment contains the raw text from the comment in the definition.
@@ -397,6 +397,14 @@ func (mod *Module) UnmarshalJSON(bs []byte) error {
 	})
 
 	return nil
+}
+
+func (mod *Module) regoV1Compatible() bool {
+	return mod.regoVersion == RegoV1 || mod.regoVersion == RegoV0CompatV1
+}
+
+func (mod *Module) RegoVersion() RegoVersion {
+	return mod.regoVersion
 }
 
 // NewComment returns a new Comment object.

--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -1012,34 +1012,13 @@ func hashBundleFiles(hash SignatureHasher, b *Bundle) ([]FileInfo, error) {
 }
 
 // FormatModules formats Rego modules
+// Modules will be formatted to comply with rego-v1, but Rego compatibility of individual parsed modules will be respected (e.g. if 'rego.v1' is imported).
 func (b *Bundle) FormatModules(useModulePath bool) error {
-	var err error
-
-	for i, module := range b.Modules {
-		if module.Raw == nil {
-			module.Raw, err = format.Ast(module.Parsed)
-			if err != nil {
-				return err
-			}
-		} else {
-			path := module.URL
-			if useModulePath {
-				path = module.Path
-			}
-
-			// Preserve Rego version of parsed module
-			module.Raw, err = format.SourceWithOpts(path, module.Raw, format.Opts{RegoVersion: module.Parsed.RegoVersion()})
-			if err != nil {
-				return err
-			}
-		}
-		b.Modules[i].Raw = module.Raw
-	}
-	return nil
+	return b.FormatModulesForRegoVersion(ast.RegoV0, true, useModulePath)
 }
 
 // FormatModulesForRegoVersion formats Rego modules to comply with a given Rego version
-func (b *Bundle) FormatModulesForRegoVersion(version ast.RegoVersion, useModulePath bool) error {
+func (b *Bundle) FormatModulesForRegoVersion(version ast.RegoVersion, preserveModuleRegoVersion bool, useModulePath bool) error {
 	var err error
 
 	for i, module := range b.Modules {
@@ -1054,7 +1033,14 @@ func (b *Bundle) FormatModulesForRegoVersion(version ast.RegoVersion, useModuleP
 				path = module.Path
 			}
 
-			module.Raw, err = format.SourceWithOpts(path, module.Raw, format.Opts{RegoVersion: version})
+			opts := format.Opts{}
+			if preserveModuleRegoVersion {
+				opts.RegoVersion = module.Parsed.RegoVersion()
+			} else {
+				opts.RegoVersion = version
+			}
+
+			module.Raw, err = format.SourceWithOpts(path, module.Raw, opts)
 			if err != nil {
 				return err
 			}

--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -1027,7 +1027,7 @@ func (b *Bundle) FormatModules(useModulePath bool) error {
 				path = module.Path
 			}
 
-			module.Raw, err = format.Source(path, module.Raw)
+			module.Raw, err = format.SourceWithOpts(path, module.Raw, format.Opts{RegoVersion: module.Parsed.RegoVersion()})
 			if err != nil {
 				return err
 			}

--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -1037,6 +1037,32 @@ func (b *Bundle) FormatModules(useModulePath bool) error {
 	return nil
 }
 
+// FormatModulesForRegoVersion formats Rego modules to comply with a given Rego version
+func (b *Bundle) FormatModulesForRegoVersion(version ast.RegoVersion, useModulePath bool) error {
+	var err error
+
+	for i, module := range b.Modules {
+		if module.Raw == nil {
+			module.Raw, err = format.AstWithOpts(module.Parsed, format.Opts{RegoVersion: version})
+			if err != nil {
+				return err
+			}
+		} else {
+			path := module.URL
+			if useModulePath {
+				path = module.Path
+			}
+
+			module.Raw, err = format.SourceWithOpts(path, module.Raw, format.Opts{RegoVersion: version})
+			if err != nil {
+				return err
+			}
+		}
+		b.Modules[i].Raw = module.Raw
+	}
+	return nil
+}
+
 // GenerateSignature generates the signature for the given bundle.
 func (b *Bundle) GenerateSignature(signingConfig *SigningConfig, keyID string, useModulePath bool) error {
 

--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -400,6 +400,7 @@ type Reader struct {
 	lazyLoadingMode       bool
 	name                  string
 	persist               bool
+	regoVersion           ast.RegoVersion
 }
 
 // NewReader is deprecated. Use NewCustomReader instead.
@@ -503,11 +504,17 @@ func (r *Reader) WithBundlePersistence(persist bool) *Reader {
 	return r
 }
 
+func (r *Reader) WithRegoVersion(version ast.RegoVersion) *Reader {
+	r.regoVersion = version
+	return r
+}
+
 func (r *Reader) ParserOptions() ast.ParserOptions {
 	return ast.ParserOptions{
 		ProcessAnnotation: r.processAnnotations,
 		Capabilities:      r.capabilities,
 		JSONOptions:       r.jsonOptions,
+		RegoVersion:       r.regoVersion,
 	}
 }
 

--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -1027,6 +1027,7 @@ func (b *Bundle) FormatModules(useModulePath bool) error {
 				path = module.Path
 			}
 
+			// Preserve Rego version of parsed module
 			module.Raw, err = format.SourceWithOpts(path, module.Raw, format.Opts{RegoVersion: module.Parsed.RegoVersion()})
 			if err != nil {
 				return err

--- a/bundle/store_test.go
+++ b/bundle/store_test.go
@@ -4294,7 +4294,7 @@ func TestErasePolicies(t *testing.T) {
 			for _, root := range tc.roots {
 				roots[root] = struct{}{}
 			}
-			remaining, err := erasePolicies(ctx, mockStore, txn, roots)
+			remaining, err := erasePolicies(ctx, mockStore, txn, ast.ParserOptions{}, roots)
 			if !tc.expectErr && err != nil {
 				t.Fatalf("unepected error: %s", err)
 			} else if tc.expectErr && err == nil {

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -43,7 +43,7 @@ type buildParams struct {
 	excludeVerifyFiles []string
 	plugin             string
 	ns                 string
-	regoV1             bool
+	v1Compatible       bool
 }
 
 func newBuildParams() buildParams {
@@ -254,7 +254,7 @@ against OPA v0.22.0:
 	addSigningPluginFlag(buildCommand.Flags(), &buildParams.plugin)
 	addClaimsFileFlag(buildCommand.Flags(), &buildParams.claimsFile)
 
-	addRegoV1Flag(buildCommand.Flags(), &buildParams.regoV1, false)
+	addV1CompatibleFlag(buildCommand.Flags(), &buildParams.v1Compatible, false)
 
 	RootCommand.AddCommand(buildCommand)
 }
@@ -303,7 +303,7 @@ func dobuild(params buildParams, args []string) error {
 		WithBundleSigningConfig(bsc).
 		WithPartialNamespace(params.ns)
 
-	if params.regoV1 {
+	if params.v1Compatible {
 		compiler = compiler.WithRegoVersion(ast.RegoV1)
 	}
 

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -43,6 +43,7 @@ type buildParams struct {
 	excludeVerifyFiles []string
 	plugin             string
 	ns                 string
+	regoV1             bool
 }
 
 func newBuildParams() buildParams {
@@ -253,6 +254,8 @@ against OPA v0.22.0:
 	addSigningPluginFlag(buildCommand.Flags(), &buildParams.plugin)
 	addClaimsFileFlag(buildCommand.Flags(), &buildParams.claimsFile)
 
+	addRegoV1Flag(buildCommand.Flags(), &buildParams.regoV1, false)
+
 	RootCommand.AddCommand(buildCommand)
 }
 
@@ -299,6 +302,10 @@ func dobuild(params buildParams, args []string) error {
 		WithBundleVerificationConfig(bvc).
 		WithBundleSigningConfig(bsc).
 		WithPartialNamespace(params.ns)
+
+	if params.regoV1 {
+		compiler = compiler.WithRegoVersion(ast.RegoV1)
+	}
 
 	if params.revision.isSet {
 		compiler = compiler.WithRevision(*params.revision.v)

--- a/cmd/build_test.go
+++ b/cmd/build_test.go
@@ -1208,7 +1208,7 @@ p[k] contains v if {
 `,
 			},
 			// Note: the rego.v1 import isn't added to the optimized module.
-			// This is ok, as the bundle was built with the --rego-v1 flag,
+			// This is ok, as the bundle was built with the --v1-compatible flag,
 			// and is therefore only guaranteed to work with OPA 1.0 or when
 			// OPA 0.x is run with the --rego-v1 flag.
 			// TODO: add rego-v1 flag to bundle, so `opa run` etc. doesn't need the --rego-v1 flag to consume it.

--- a/cmd/build_test.go
+++ b/cmd/build_test.go
@@ -977,16 +977,16 @@ func TestBuildBundleModeIgnoreFlag(t *testing.T) {
 	})
 }
 
-func TestBuildWithRegoV1Flag(t *testing.T) {
+func TestBuildWithV1CompatibleFlag(t *testing.T) {
 	tests := []struct {
 		note          string
-		regoV1        bool
+		v1Compatible  bool
 		files         map[string]string
 		expectedFiles map[string]string
 		expectedErr   string
 	}{
 		{
-			note: "rego-v0 mode: policy with no rego.v1 or future.keywords imports",
+			note: "default compatibility: policy with no rego.v1 or future.keywords imports",
 			files: map[string]string{
 				"test.rego": `package test
 				allow if {
@@ -996,7 +996,7 @@ func TestBuildWithRegoV1Flag(t *testing.T) {
 			expectedErr: "rego_parse_error",
 		},
 		{
-			note: "rego-v0 mode: policy with rego.v1 imports",
+			note: "default compatibility: policy with rego.v1 imports",
 			files: map[string]string{
 				"test.rego": `package test
 				import rego.v1
@@ -1017,7 +1017,7 @@ allow if {
 			},
 		},
 		{
-			note: "rego-v0 mode: policy with future.keywords imports",
+			note: "default compatibility: policy with future.keywords imports",
 			files: map[string]string{
 				"test.rego": `package test
 				import future.keywords.if
@@ -1038,8 +1038,8 @@ allow if {
 			},
 		},
 		{
-			note:   "rego-v1 mode: policy with no rego.v1 or future.keywords imports",
-			regoV1: true,
+			note:         "1.0 compatibility: policy with no rego.v1 or future.keywords imports",
+			v1Compatible: true,
 			files: map[string]string{
 				"test.rego": `package test
 				allow if {
@@ -1057,8 +1057,8 @@ allow if {
 			},
 		},
 		{
-			note:   "rego-v1 mode: policy with rego.v1 import",
-			regoV1: true,
+			note:         "1.0 compatibility: policy with rego.v1 import",
+			v1Compatible: true,
 			files: map[string]string{
 				"test.rego": `package test
 				import rego.v1
@@ -1077,8 +1077,8 @@ allow if {
 			},
 		},
 		{
-			note:   "rego-v1 mode: policy with future.keywords import",
-			regoV1: true,
+			note:         "1.0 compatibility: policy with future.keywords import",
+			v1Compatible: true,
 			files: map[string]string{
 				"test.rego": `package test
 				import future.keywords.if
@@ -1103,7 +1103,7 @@ allow if {
 			test.WithTempFS(tc.files, func(root string) {
 				params := newBuildParams()
 				params.outputFile = path.Join(root, "bundle.tar.gz")
-				params.regoV1 = tc.regoV1
+				params.v1Compatible = tc.v1Compatible
 
 				err := dobuild(params, []string{root})
 
@@ -1120,7 +1120,7 @@ allow if {
 					}
 
 					fl := loader.NewFileLoader()
-					if tc.regoV1 {
+					if tc.v1Compatible {
 						fl = fl.WithRegoVersion(ast.RegoV1)
 					}
 					_, err = fl.AsBundle(params.outputFile)
@@ -1167,7 +1167,7 @@ allow if {
 	}
 }
 
-func TestBuildWithRegoV1FlagOptimized(t *testing.T) {
+func TestBuildWithV1CompatibleFlagOptimized(t *testing.T) {
 	tests := []struct {
 		note          string
 		files         map[string]string
@@ -1250,7 +1250,7 @@ foo contains __local1__1 if {
 			test.WithTempFS(tc.files, func(root string) {
 				params := newBuildParams()
 				params.outputFile = path.Join(root, "bundle.tar.gz")
-				params.regoV1 = true
+				params.v1Compatible = true
 				params.optimizationLevel = 1
 
 				err := dobuild(params, []string{root})

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -26,6 +26,7 @@ type checkParams struct {
 	schema       *schemaFlags
 	strict       bool
 	regoV1       bool
+	v1Compatible bool
 }
 
 func newCheckParams() checkParams {
@@ -39,8 +40,12 @@ func newCheckParams() checkParams {
 }
 
 func (p *checkParams) regoVersion() ast.RegoVersion {
+	// The '--rego-v1' flag takes precedence over the '--v1-compatible' flag.
 	if p.regoV1 {
 		return ast.RegoV0CompatV1
+	}
+	if p.v1Compatible {
+		return ast.RegoV1
 	}
 	return ast.RegoV0
 }
@@ -177,5 +182,6 @@ func init() {
 	addStrictFlag(checkCommand.Flags(), &checkParams.strict, false)
 	addRegoV1FlagWithDescription(checkCommand.Flags(), &checkParams.regoV1, false,
 		"check for Rego v1 compatibility (policies must also be compatible with current OPA version)")
+	addV1CompatibleFlag(checkCommand.Flags(), &checkParams.v1Compatible, false)
 	RootCommand.AddCommand(checkCommand)
 }

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -38,6 +38,13 @@ func newCheckParams() checkParams {
 	}
 }
 
+func (p *checkParams) regoVersion() ast.RegoVersion {
+	if p.regoV1 {
+		return ast.RegoV0CompatV1
+	}
+	return ast.RegoV0
+}
+
 const (
 	checkFormatPretty = "pretty"
 	checkFormatJSON   = "json"
@@ -65,7 +72,7 @@ func checkModules(params checkParams, args []string) error {
 	if params.bundleMode {
 		for _, path := range args {
 			b, err := loader.NewFileLoader().
-				WithRegoV1Compatible(params.regoV1).
+				WithRegoVersion(params.regoVersion()).
 				WithSkipBundleVerification(true).
 				WithProcessAnnotation(true).
 				WithCapabilities(capabilities).
@@ -84,7 +91,7 @@ func checkModules(params checkParams, args []string) error {
 		}
 
 		result, err := loader.NewFileLoader().
-			WithRegoV1Compatible(params.regoV1).
+			WithRegoVersion(params.regoVersion()).
 			WithProcessAnnotation(true).
 			WithCapabilities(capabilities).
 			Filtered(args, f.Apply)

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -168,6 +168,7 @@ func init() {
 	addCapabilitiesFlag(checkCommand.Flags(), checkParams.capabilities)
 	addSchemaFlags(checkCommand.Flags(), checkParams.schema)
 	addStrictFlag(checkCommand.Flags(), &checkParams.strict, false)
-	checkCommand.Flags().BoolVar(&checkParams.regoV1, "rego-v1", false, "check for Rego v1 compatibility (policies must also be compatible with current OPA version)")
+	addRegoV1FlagWithDescription(checkCommand.Flags(), &checkParams.regoV1, false,
+		"check for Rego v1 compatibility (policies must also be compatible with current OPA version)")
 	RootCommand.AddCommand(checkCommand)
 }

--- a/cmd/check_test.go
+++ b/cmd/check_test.go
@@ -367,3 +367,130 @@ p contains x if {
 		})
 	}
 }
+
+func TestCheckV1Compatible(t *testing.T) {
+	cases := []struct {
+		note    string
+		policy  string
+		expErrs []string
+	}{
+		{
+			note: "rego.v1 imported, v1 compliant",
+			policy: `package test
+import rego.v1
+p contains x if {
+	x := [1,2,3]
+}`,
+		},
+		{
+			note: "rego.v1 imported, NOT v1 compliant (parser)",
+			policy: `package test
+import rego.v1
+p contains x {
+	x := [1,2,3]
+}
+
+q.r`,
+			expErrs: []string{
+				"test.rego:3: rego_parse_error: `if` keyword is required before rule body",
+				"test.rego:7: rego_parse_error: `contains` keyword is required for partial set rules",
+			},
+		},
+		{
+			note: "rego.v1 imported, NOT v1 compliant (compiler)",
+			policy: `package test
+import rego.v1
+
+import data.foo
+import data.bar as foo
+`,
+			expErrs: []string{
+				"test.rego:5: rego_compile_error: import must not shadow import data.foo",
+			},
+		},
+		{
+			note: "keywords imported, v1 compliant",
+			policy: `package test
+import future.keywords.if
+import future.keywords.contains
+p contains x if {
+	x := [1,2,3]
+}`,
+		},
+		{
+			note: "keywords imported, NOT v1 compliant",
+			policy: `package test
+import future.keywords.contains
+p contains x {
+	x := [1,2,3]
+}
+
+q.r`,
+			expErrs: []string{
+				"test.rego:3: rego_parse_error: `if` keyword is required before rule body",
+				"test.rego:7: rego_parse_error: `contains` keyword is required for partial set rules",
+			},
+		},
+		{
+			note: "keywords imported, NOT v1 compliant (compiler)",
+			policy: `package test
+import future.keywords.if
+
+input := 1 if {
+	1 == 2
+}`,
+			expErrs: []string{
+				"test.rego:4: rego_compile_error: rules must not shadow input (use a different rule name)",
+			},
+		},
+		{
+			note: "no imports, v1 compliant",
+			policy: `package test
+p := 1
+`,
+		},
+		{
+			note: "no imports, NOT v1 compliant but v0 compliant (compiler)",
+			policy: `package test
+p.x`,
+			expErrs: []string{
+				"test.rego:2: rego_parse_error: `contains` keyword is required for partial set rules",
+			},
+		},
+		{
+			note: "no imports, v1 compliant but NOT v0 compliant",
+			policy: `package test
+p contains x if {
+	x := [1,2,3]
+}`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.note, func(t *testing.T) {
+			files := map[string]string{
+				"test.rego": tc.policy,
+			}
+
+			test.WithTempFS(files, func(root string) {
+				params := newCheckParams()
+				params.v1Compatible = true
+
+				err := checkModules(params, []string{root})
+				switch {
+				case err != nil && len(tc.expErrs) > 0:
+					for _, expErr := range tc.expErrs {
+						if !strings.Contains(err.Error(), expErr) {
+							t.Fatalf("expected err:\n\n%v\n\ngot:\n\n%v", expErr, err)
+						}
+					}
+					return // don't read back bundle below
+				case err != nil && len(tc.expErrs) == 0:
+					t.Fatalf("unexpected error: %v", err)
+				case err == nil && len(tc.expErrs) > 0:
+					t.Fatalf("expected error:\n\n%v\n\ngot: none", tc.expErrs)
+				}
+			})
+		})
+	}
+}

--- a/cmd/eval.go
+++ b/cmd/eval.go
@@ -70,6 +70,7 @@ type evalCommandParams struct {
 	optimizationLevel   int
 	entrypoints         repeatedStringFlag
 	strict              bool
+	regoV1              bool
 }
 
 func newEvalCommandParams() evalCommandParams {
@@ -326,6 +327,7 @@ access.
 	addTargetFlag(evalCommand.Flags(), params.target)
 	addCountFlag(evalCommand.Flags(), &params.count, "benchmark")
 	addStrictFlag(evalCommand.Flags(), &params.strict, false)
+	addRegoV1Flag(evalCommand.Flags(), &params.regoV1, false)
 
 	RootCommand.AddCommand(evalCommand)
 }
@@ -661,6 +663,10 @@ func setupEval(args []string, params evalCommandParams) (*evalContext, error) {
 
 	if params.strict {
 		regoArgs = append(regoArgs, rego.Strict(params.strict))
+	}
+
+	if params.regoV1 {
+		regoArgs = append(regoArgs, rego.RegoVersion(ast.RegoV1))
 	}
 
 	evalCtx := &evalContext{

--- a/cmd/eval.go
+++ b/cmd/eval.go
@@ -70,7 +70,7 @@ type evalCommandParams struct {
 	optimizationLevel   int
 	entrypoints         repeatedStringFlag
 	strict              bool
-	regoV1              bool
+	v1Compatible        bool
 }
 
 func newEvalCommandParams() evalCommandParams {
@@ -327,7 +327,7 @@ access.
 	addTargetFlag(evalCommand.Flags(), params.target)
 	addCountFlag(evalCommand.Flags(), &params.count, "benchmark")
 	addStrictFlag(evalCommand.Flags(), &params.strict, false)
-	addRegoV1Flag(evalCommand.Flags(), &params.regoV1, false)
+	addV1CompatibleFlag(evalCommand.Flags(), &params.v1Compatible, false)
 
 	RootCommand.AddCommand(evalCommand)
 }
@@ -665,7 +665,7 @@ func setupEval(args []string, params evalCommandParams) (*evalContext, error) {
 		regoArgs = append(regoArgs, rego.Strict(params.strict))
 	}
 
-	if params.regoV1 {
+	if params.v1Compatible {
 		regoArgs = append(regoArgs, rego.SetRegoVersion(ast.RegoV1))
 	}
 

--- a/cmd/eval.go
+++ b/cmd/eval.go
@@ -666,7 +666,7 @@ func setupEval(args []string, params evalCommandParams) (*evalContext, error) {
 	}
 
 	if params.regoV1 {
-		regoArgs = append(regoArgs, rego.RegoVersion(ast.RegoV1))
+		regoArgs = append(regoArgs, rego.SetRegoVersion(ast.RegoV1))
 	}
 
 	evalCtx := &evalContext{

--- a/cmd/eval_test.go
+++ b/cmd/eval_test.go
@@ -1972,7 +1972,7 @@ func TestEvalPolicyWithRegoV1Flag(t *testing.T) {
 
 					if tc.expectedErr == "" {
 						if err != nil {
-							t.Fatalf("Unexpected error: %v, buf: %s", err, string(buf.Bytes()))
+							t.Fatalf("Unexpected error: %v, buf: %s", err, buf.String())
 						} else if !defined {
 							t.Fatal("expected result to be defined")
 						}
@@ -1981,7 +1981,7 @@ func TestEvalPolicyWithRegoV1Flag(t *testing.T) {
 							t.Fatal("expected error, got none")
 						}
 
-						actual := string(buf.Bytes())
+						actual := buf.String()
 						if !strings.Contains(actual, tc.expectedErr) {
 							t.Fatalf("expected error:\n\n%v\n\ngot\n\n%v", tc.expectedErr, actual)
 						}

--- a/cmd/eval_test.go
+++ b/cmd/eval_test.go
@@ -1881,16 +1881,16 @@ func TestUnexpectedElseIfErr(t *testing.T) {
 	})
 }
 
-func TestEvalPolicyWithRegoV1Flag(t *testing.T) {
+func TestEvalPolicyWithV1CompatibleFlag(t *testing.T) {
 	tests := []struct {
-		note        string
-		regoV1      bool
-		modules     map[string]string
-		query       string
-		expectedErr string
+		note         string
+		v1Compatible bool
+		modules      map[string]string
+		query        string
+		expectedErr  string
 	}{
 		{
-			note: "rego-v0 mode: policy with no rego.v1 or future.keywords imports",
+			note: "default compatibility: policy with no rego.v1 or future.keywords imports",
 			modules: map[string]string{
 				"test.rego": `package test
 				allow if {
@@ -1901,8 +1901,8 @@ func TestEvalPolicyWithRegoV1Flag(t *testing.T) {
 			expectedErr: "rego_parse_error",
 		},
 		{
-			note:   "rego-v1 mode: policy with no rego.v1 or future.keywords imports",
-			regoV1: true,
+			note:         "1.0 compatibility: policy with no rego.v1 or future.keywords imports",
+			v1Compatible: true,
 			modules: map[string]string{
 				"test.rego": `package test
 				allow if {
@@ -1912,8 +1912,8 @@ func TestEvalPolicyWithRegoV1Flag(t *testing.T) {
 			query: "data.test.allow",
 		},
 		{
-			note:   "rego-v1 mode: policy with rego.v1 import",
-			regoV1: true,
+			note:         "1.0 compatibility: policy with rego.v1 import",
+			v1Compatible: true,
 			modules: map[string]string{
 				"test.rego": `package test
 				import rego.v1
@@ -1924,8 +1924,8 @@ func TestEvalPolicyWithRegoV1Flag(t *testing.T) {
 			query: "data.test.allow",
 		},
 		{
-			note:   "rego-v1 mode: policy with future.keywords import",
-			regoV1: true,
+			note:         "1.0 compatibility: policy with future.keywords import",
+			v1Compatible: true,
 			modules: map[string]string{
 				"test.rego": `package test
 				import future.keywords.if
@@ -1963,8 +1963,7 @@ func TestEvalPolicyWithRegoV1Flag(t *testing.T) {
 				test.WithTempFS(tc.modules, func(path string) {
 					params := newEvalCommandParams()
 					s.commandParams(&params, path)
-					//params.dataPaths = newrepeatedStringFlag([]string{path})
-					params.regoV1 = tc.regoV1
+					params.v1Compatible = tc.v1Compatible
 
 					var buf bytes.Buffer
 

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -153,6 +153,14 @@ func addStrictFlag(fs *pflag.FlagSet, strict *bool, value bool) {
 	fs.BoolVarP(strict, "strict", "S", value, "enable compiler strict mode")
 }
 
+func addRegoV1Flag(fs *pflag.FlagSet, regoV1 *bool, value bool) {
+	addRegoV1FlagWithDescription(fs, regoV1, value, "enforce Rego v1 compatibility")
+}
+
+func addRegoV1FlagWithDescription(fs *pflag.FlagSet, regoV1 *bool, value bool, description string) {
+	fs.BoolVar(regoV1, "rego-v1", value, description)
+}
+
 func addE2EFlag(fs *pflag.FlagSet, e2e *bool, value bool) {
 	fs.BoolVar(e2e, "e2e", value, "run benchmarks against a running OPA server")
 }

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -153,12 +153,12 @@ func addStrictFlag(fs *pflag.FlagSet, strict *bool, value bool) {
 	fs.BoolVarP(strict, "strict", "S", value, "enable compiler strict mode")
 }
 
-func addRegoV1Flag(fs *pflag.FlagSet, regoV1 *bool, value bool) {
-	addRegoV1FlagWithDescription(fs, regoV1, value, "enforce Rego v1 compatibility")
-}
-
 func addRegoV1FlagWithDescription(fs *pflag.FlagSet, regoV1 *bool, value bool, description string) {
 	fs.BoolVar(regoV1, "rego-v1", value, description)
+}
+
+func addV1CompatibleFlag(fs *pflag.FlagSet, v1Compatible *bool, value bool) {
+	fs.BoolVar(v1Compatible, "v1-compatible", value, "opt-in to OPA features and behaviors that will be enabled by default in a future OPA v1.0 release")
 }
 
 func addE2EFlag(fs *pflag.FlagSet, e2e *bool, value bool) {

--- a/cmd/fmt.go
+++ b/cmd/fmt.go
@@ -20,18 +20,23 @@ import (
 )
 
 type fmtCommandParams struct {
-	overwrite bool
-	list      bool
-	diff      bool
-	fail      bool
-	regoV1    bool
+	overwrite    bool
+	list         bool
+	diff         bool
+	fail         bool
+	regoV1       bool
+	v1Compatible bool
 }
 
 var fmtParams = fmtCommandParams{}
 
 func (p *fmtCommandParams) regoVersion() ast.RegoVersion {
+	// The '--rego-v1' flag takes precedence over the '--v1-compatible' flag.
 	if p.regoV1 {
 		return ast.RegoV0CompatV1
+	}
+	if p.v1Compatible {
+		return ast.RegoV1
 	}
 	return ast.RegoV0
 }
@@ -219,6 +224,7 @@ func init() {
 	formatCommand.Flags().BoolVarP(&fmtParams.diff, "diff", "d", false, "only display a diff of the changes")
 	formatCommand.Flags().BoolVar(&fmtParams.fail, "fail", false, "non zero exit code on reformat")
 	addRegoV1FlagWithDescription(formatCommand.Flags(), &fmtParams.regoV1, false, "format as Rego v1")
+	addV1CompatibleFlag(formatCommand.Flags(), &fmtParams.v1Compatible, false)
 
 	RootCommand.AddCommand(formatCommand)
 }

--- a/cmd/fmt.go
+++ b/cmd/fmt.go
@@ -206,6 +206,7 @@ func init() {
 	formatCommand.Flags().BoolVarP(&fmtParams.list, "list", "l", false, "list all files who would change when formatted")
 	formatCommand.Flags().BoolVarP(&fmtParams.diff, "diff", "d", false, "only display a diff of the changes")
 	formatCommand.Flags().BoolVar(&fmtParams.fail, "fail", false, "non zero exit code on reformat")
-	formatCommand.Flags().BoolVar(&fmtParams.regoV1, "rego-v1", false, "format as Rego v1")
+	addRegoV1FlagWithDescription(formatCommand.Flags(), &fmtParams.regoV1, false, "format as Rego v1")
+
 	RootCommand.AddCommand(formatCommand)
 }

--- a/cmd/fmt.go
+++ b/cmd/fmt.go
@@ -7,6 +7,7 @@ package cmd
 import (
 	"bytes"
 	"fmt"
+	"github.com/open-policy-agent/opa/ast"
 	"io"
 	"os"
 	"path/filepath"
@@ -109,7 +110,11 @@ func formatFile(params *fmtCommandParams, out io.Writer, filename string, info o
 		return newError("failed to open file: %v", err)
 	}
 
-	formatted, err := format.SourceWithOpts(filename, contents, format.Opts{RegoV1: params.regoV1})
+	opts := format.Opts{}
+	if params.regoV1 {
+		opts.RegoVersion = ast.RegoV0CompatV1
+	}
+	formatted, err := format.SourceWithOpts(filename, contents, opts)
 	if err != nil {
 		return newError("failed to format Rego source file: %v", err)
 	}
@@ -170,7 +175,11 @@ func formatStdin(params *fmtCommandParams, r io.Reader, w io.Writer) error {
 		return err
 	}
 
-	formatted, err := format.SourceWithOpts("stdin", contents, format.Opts{RegoV1: params.regoV1})
+	opts := format.Opts{}
+	if params.regoV1 {
+		opts.RegoVersion = ast.RegoV0CompatV1
+	}
+	formatted, err := format.SourceWithOpts("stdin", contents, opts)
 	if err != nil {
 		return err
 	}

--- a/cmd/fmt.go
+++ b/cmd/fmt.go
@@ -223,7 +223,7 @@ func init() {
 	formatCommand.Flags().BoolVarP(&fmtParams.list, "list", "l", false, "list all files who would change when formatted")
 	formatCommand.Flags().BoolVarP(&fmtParams.diff, "diff", "d", false, "only display a diff of the changes")
 	formatCommand.Flags().BoolVar(&fmtParams.fail, "fail", false, "non zero exit code on reformat")
-	addRegoV1FlagWithDescription(formatCommand.Flags(), &fmtParams.regoV1, false, "format as Rego v1")
+	addRegoV1FlagWithDescription(formatCommand.Flags(), &fmtParams.regoV1, false, "format module(s) to be compatible with both Rego v1 and current OPA version)")
 	addV1CompatibleFlag(formatCommand.Flags(), &fmtParams.v1Compatible, false)
 
 	RootCommand.AddCommand(formatCommand)

--- a/cmd/fmt.go
+++ b/cmd/fmt.go
@@ -29,6 +29,13 @@ type fmtCommandParams struct {
 
 var fmtParams = fmtCommandParams{}
 
+func (p *fmtCommandParams) regoVersion() ast.RegoVersion {
+	if p.regoV1 {
+		return ast.RegoV0CompatV1
+	}
+	return ast.RegoV0
+}
+
 var formatCommand = &cobra.Command{
 	Use:   "fmt [path [...]]",
 	Short: "Format Rego source files",
@@ -111,9 +118,7 @@ func formatFile(params *fmtCommandParams, out io.Writer, filename string, info o
 	}
 
 	opts := format.Opts{}
-	if params.regoV1 {
-		opts.RegoVersion = ast.RegoV0CompatV1
-	}
+	opts.RegoVersion = params.regoVersion()
 	formatted, err := format.SourceWithOpts(filename, contents, opts)
 	if err != nil {
 		return newError("failed to format Rego source file: %v", err)
@@ -176,9 +181,7 @@ func formatStdin(params *fmtCommandParams, r io.Reader, w io.Writer) error {
 	}
 
 	opts := format.Opts{}
-	if params.regoV1 {
-		opts.RegoVersion = ast.RegoV0CompatV1
-	}
+	opts.RegoVersion = params.regoVersion()
 	formatted, err := format.SourceWithOpts("stdin", contents, opts)
 	if err != nil {
 		return err

--- a/cmd/fmt.go
+++ b/cmd/fmt.go
@@ -7,7 +7,6 @@ package cmd
 import (
 	"bytes"
 	"fmt"
-	"github.com/open-policy-agent/opa/ast"
 	"io"
 	"os"
 	"path/filepath"
@@ -15,6 +14,7 @@ import (
 	"github.com/sergi/go-diff/diffmatchpatch"
 	"github.com/spf13/cobra"
 
+	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/format"
 	fileurl "github.com/open-policy-agent/opa/internal/file/url"
 )

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -205,7 +205,7 @@ Current behaviors enabled by this flag include:
 	runCommand.Flags().BoolVar(&cmdParams.rt.H2CEnabled, "h2c", false, "enable H2C for HTTP listeners")
 	runCommand.Flags().StringVarP(&cmdParams.rt.OutputFormat, "format", "f", "pretty", "set shell output format, i.e, pretty, json")
 	runCommand.Flags().BoolVarP(&cmdParams.rt.Watch, "watch", "w", false, "watch command line files for changes")
-	runCommand.Flags().BoolVar(&cmdParams.rt.V1Compatible, "v1-compatible", false, "opt-in to OPA features and behaviors that will be enabled by default in a future OPA v1.0 release")
+	addV1CompatibleFlag(runCommand.Flags(), &cmdParams.rt.V1Compatible, false)
 	addMaxErrorsFlag(runCommand.Flags(), &cmdParams.rt.ErrorLimit)
 	runCommand.Flags().BoolVar(&cmdParams.rt.PprofEnabled, "pprof", false, "enables pprof endpoints")
 	runCommand.Flags().StringVar(&cmdParams.tlsCertFile, "tls-cert-file", "", "set path of TLS certificate file")

--- a/cmd/test_test.go
+++ b/cmd/test_test.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"bytes"
 	"context"
+	"fmt"
+	"github.com/open-policy-agent/opa/bundle"
 	"io"
 	"os"
 	"path"
@@ -1009,6 +1011,207 @@ Lines not covered:
 				}
 			})
 		})
+	}
+}
+
+type loadType int
+
+const (
+	loadFile loadType = iota
+	loadBundle
+	loadTarball
+)
+
+func (t loadType) String() string {
+	return [...]string{"file", "bundle", "bundle tarball"}[t]
+}
+
+func TestWithV1CompatibleFlag(t *testing.T) {
+	tests := []struct {
+		note         string
+		v1Compatible bool
+		files        map[string]string
+		expErr       string
+	}{
+		{
+			note: "0.x module, no imports",
+			files: map[string]string{
+				"/test.rego": `package test
+
+l1 := {1, 3, 5}
+l2 contains v if {
+	v := l1[_]
+}
+
+test_l if {
+	l1 == l2
+}`,
+			},
+			expErr: "rego_parse_error",
+		},
+		{
+			note: "0.x module, rego.v1 imported",
+			files: map[string]string{
+				"/test.rego": `package test
+
+import rego.v1
+
+l1 := {1, 3, 5}
+l2 contains v if {
+	v := l1[_]
+}
+
+test_l if {
+	l1 == l2
+}`,
+			},
+		},
+		{
+			note: "0.x module, future.keywords imported",
+			files: map[string]string{
+				"/test.rego": `package test
+
+import future.keywords
+
+l1 := {1, 3, 5}
+l2 contains v if {
+	v := l1[_]
+}
+
+test_l if {
+	l1 == l2
+}`,
+			},
+		},
+
+		{
+			note:         "1.0 compatible module, no imports",
+			v1Compatible: true,
+			files: map[string]string{
+				"/test.rego": `package test
+
+l1 := {1, 3, 5}
+l2 contains v if {
+	v := l1[_]
+}
+
+test_l if {
+	l1 == l2
+}`,
+			},
+		},
+		{
+			note:         "1.0 compatible module, rego.v1 imported",
+			v1Compatible: true,
+			files: map[string]string{
+				"/test.rego": `package test
+
+import rego.v1
+
+l1 := {1, 3, 5}
+l2 contains v if {
+	v := l1[_]
+}
+
+test_l if {
+	l1 == l2
+}`,
+			},
+		},
+		{
+			note:         "1.0 compatible module, future.keywords imported",
+			v1Compatible: true,
+			files: map[string]string{
+				"/test.rego": `package test
+
+import future.keywords
+
+l1 := {1, 3, 5}
+l2 contains v if {
+	v := l1[_]
+}
+
+test_l if {
+	l1 == l2
+}`,
+			},
+		},
+	}
+
+	loadTypes := []loadType{loadFile, loadBundle, loadTarball}
+
+	for _, tc := range tests {
+		for _, loadType := range loadTypes {
+			t.Run(fmt.Sprintf("%s (%s)", tc.note, loadType), func(t *testing.T) {
+				var files map[string]string
+				if loadType != loadTarball {
+					files = tc.files
+				}
+				test.WithTempFS(files, func(root string) {
+					if loadType == loadTarball {
+						f, err := os.Create(filepath.Join(root, "bundle.tar.gz"))
+						if err != nil {
+							t.Fatal(err)
+						}
+
+						testBundle := bundle.Bundle{
+							Data: map[string]interface{}{},
+						}
+						for k, v := range tc.files {
+							testBundle.Modules = append(testBundle.Modules, bundle.ModuleFile{
+								Path: k,
+								Raw:  []byte(v),
+							})
+						}
+
+						if err := bundle.Write(f, testBundle); err != nil {
+							t.Fatal(err)
+						}
+					}
+
+					var buf bytes.Buffer
+					var errBuf bytes.Buffer
+
+					testParams := newTestCommandParams()
+					testParams.v1Compatible = tc.v1Compatible
+					testParams.bundleMode = loadType == loadBundle
+					testParams.count = 1
+					testParams.output = &buf
+					testParams.errOutput = &errBuf
+
+					var paths []string
+					if loadType == loadTarball {
+						paths = []string{filepath.Join(root, "bundle.tar.gz")}
+					} else {
+						paths = []string{root}
+					}
+
+					exitCode, _ := opaTest(paths, testParams)
+					if tc.expErr != "" {
+						if exitCode == 0 {
+							t.Fatalf("expected non-zero exit code")
+						}
+
+						if actual := errBuf.String(); !strings.Contains(actual, tc.expErr) {
+							t.Fatalf("expected error output to contain:\n\n%q\n\nbut got:\n\n%q", tc.expErr, actual)
+						}
+					} else {
+						if exitCode != 0 {
+							t.Fatalf("unexpected exit code: %d", exitCode)
+						}
+
+						if errBuf.Len() > 0 {
+							t.Fatalf("expected no error output but got:\n\n%q", buf.String())
+						}
+
+						expected := "PASS: 1/1"
+						if actual := buf.String(); !strings.Contains(actual, expected) {
+							t.Fatalf("expected output to contain:\n\n%s\n\nbut got:\n\n%q", expected, actual)
+						}
+					}
+				})
+			})
+		}
 	}
 }
 

--- a/cmd/test_test.go
+++ b/cmd/test_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/open-policy-agent/opa/bundle"
 	"io"
 	"os"
 	"path"
@@ -17,6 +16,7 @@ import (
 	"time"
 
 	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/bundle"
 	"github.com/open-policy-agent/opa/rego"
 	"github.com/open-policy-agent/opa/topdown"
 	"github.com/open-policy-agent/opa/util/test"

--- a/compile/compile.go
+++ b/compile/compile.go
@@ -83,6 +83,7 @@ type Compiler struct {
 	metadata                     *map[string]interface{}    // represents additional data included in .manifest file
 	fsys                         fs.FS                      // file system to use when loading paths
 	ns                           string
+	regoVersion                  ast.RegoVersion
 }
 
 // New returns a new compiler instance that can be invoked.
@@ -239,6 +240,11 @@ func (c *Compiler) WithFS(fsys fs.FS) *Compiler {
 // WithPartialNamespace sets the namespace to use for partial evaluation results
 func (c *Compiler) WithPartialNamespace(ns string) *Compiler {
 	c.ns = ns
+	return c
+}
+
+func (c *Compiler) WithRegoVersion(v ast.RegoVersion) *Compiler {
+	c.regoVersion = v
 	return c
 }
 
@@ -432,7 +438,7 @@ func (c *Compiler) initBundle() error {
 	// TODO(tsandall): the metrics object should passed through here so we that
 	// we can track read and parse times.
 
-	load, err := initload.LoadPaths(c.paths, c.filter, c.asBundle, c.bvc, false, c.useRegoAnnotationEntrypoints, c.capabilities, c.fsys)
+	load, err := initload.LoadPathsForRegoVersion(c.regoVersion, c.paths, c.filter, c.asBundle, c.bvc, false, c.useRegoAnnotationEntrypoints, c.capabilities, c.fsys)
 	if err != nil {
 		return fmt.Errorf("load error: %w", err)
 	}

--- a/compile/compile.go
+++ b/compile/compile.go
@@ -363,7 +363,7 @@ func (c *Compiler) Build(ctx context.Context) error {
 	}
 
 	if c.regoVersion == ast.RegoV1 {
-		if err := c.bundle.FormatModulesForRegoVersion(c.regoVersion, false); err != nil {
+		if err := c.bundle.FormatModulesForRegoVersion(c.regoVersion, false, false); err != nil {
 			return err
 		}
 	} else {

--- a/compile/compile.go
+++ b/compile/compile.go
@@ -362,8 +362,14 @@ func (c *Compiler) Build(ctx context.Context) error {
 		c.bundle.Manifest.Metadata = *c.metadata
 	}
 
-	if err := c.bundle.FormatModules(false); err != nil {
-		return err
+	if c.regoVersion == ast.RegoV1 {
+		if err := c.bundle.FormatModulesForRegoVersion(c.regoVersion, false); err != nil {
+			return err
+		}
+	} else {
+		if err := c.bundle.FormatModules(false); err != nil {
+			return err
+		}
 	}
 
 	if c.bsc != nil {

--- a/docs/content/cli.md
+++ b/docs/content/cli.md
@@ -249,6 +249,7 @@ opa build <path> [<path> [...]] [flags]
       --signing-key string             set the secret (HMAC) or path of the PEM file containing the private key (RSA and ECDSA)
       --signing-plugin string          name of the plugin to use for signing/verification (see https://www.openpolicyagent.org/docs/latest/management-bundles/#signature-plugin
   -t, --target {rego,wasm,plan}        set the output bundle target type (default rego)
+      --v1-compatible                  opt-in to OPA features and behaviors that will be enabled by default in a future OPA v1.0 release
       --verification-key string        set the secret (HMAC) or path of the PEM file containing the public key (RSA and ECDSA)
       --verification-key-id string     name assigned to the verification key used for bundle verification (default "default")
 ```
@@ -348,6 +349,7 @@ opa check <path> [path [...]] [flags]
       --rego-v1                check for Rego v1 compatibility (policies must also be compatible with current OPA version)
   -s, --schema string          set schema file path or directory path
   -S, --strict                 enable compiler strict mode
+      --v1-compatible          opt-in to OPA features and behaviors that will be enabled by default in a future OPA v1.0 release
 ```
 
 ____
@@ -560,6 +562,7 @@ opa eval <query> [flags]
   -t, --target {rego,wasm}                                        set the runtime to exercise (default rego)
       --timeout duration                                          set eval timeout (default unlimited)
   -u, --unknowns stringArray                                      set paths to treat as unknown during partial evaluation (default [input])
+      --v1-compatible                                             opt-in to OPA features and behaviors that will be enabled by default in a future OPA v1.0 release
 ```
 
 ____
@@ -646,12 +649,13 @@ opa fmt [path [...]] [flags]
 ### Options
 
 ```
-  -d, --diff      only display a diff of the changes
-      --fail      non zero exit code on reformat
-  -h, --help      help for fmt
-  -l, --list      list all files who would change when formatted
-      --rego-v1   format as Rego v1
-  -w, --write     overwrite the original source file
+  -d, --diff            only display a diff of the changes
+      --fail            non zero exit code on reformat
+  -h, --help            help for fmt
+  -l, --list            list all files who would change when formatted
+      --rego-v1         format as Rego v1
+      --v1-compatible   opt-in to OPA features and behaviors that will be enabled by default in a future OPA v1.0 release
+  -w, --write           overwrite the original source file
 ```
 
 ____
@@ -1102,6 +1106,7 @@ opa test <path> [path [...]] [flags]
   -t, --target {rego,wasm}                 set the runtime to exercise (default rego)
       --threshold float                    set coverage threshold and exit with non-zero status if coverage is less than threshold %
       --timeout duration                   set test timeout (default 5s, 30s when benchmarking)
+      --v1-compatible                      opt-in to OPA features and behaviors that will be enabled by default in a future OPA v1.0 release
   -v, --verbose                            set verbose reporting mode
   -w, --watch                              watch command line files for changes
 ```

--- a/docs/content/opa-1.md
+++ b/docs/content/opa-1.md
@@ -13,7 +13,9 @@ The full set of breaking changes in OPA v1.0 is not yet finalized.
 The tools mentioned in the below sections - such as the `rego.v1` import and the `--rego-v1` command flag - may change over time, so it's good practice to regularly employ them to ensure your policies are compatible with the future release of OPA v1.0.
 {{< /info >}}
 
-## The `future.keywords` imports
+## What's changing in OPA 1.0
+
+### The `future.keywords` imports
 
 The `in`, `every`, `if` and `contains` keywords have been introduced over time, and currently require opt-in to prevent them from breaking policies that existed before their introduction. 
 The `future.keywords` imports facilitate this opt-in mechanism.
@@ -23,14 +25,14 @@ There is growing adoption of these keywords and their usage is prevalent in the 
 In OPA v1.0 the `in`, `every`, `if` and `contains` keywords will be part of the language by default and the `future.keywords` imports will become a no-op.
 A policy that makes use of these keywords, but doesn't import `future.keywords` is valid in OPA v1.0 but not in older versions of OPA.
 
-### Making new and existing policies compatible with OPA v1.0
+#### Making new and existing policies compatible with OPA v1.0
 
 1. A new [rego.v1](../policy-language/#the-regov1-import) import has been introduced that, when used, makes OPA apply all restrictions that will eventually be enforced by default in OPA v1.0. 
    If a Rego module imports `rego.v1`, it means applicable `future.keywords` imports are implied. It is illegal to import both `rego.v1` and `future.keywords` in the same module.
 2. The `--rego-v1` flag on the `opa fmt` command will rewrite existing modules to use the `rego.v1` import instead of `future.keywords` imports.
 3. The `--rego-v1` flag on the `opa check` command will check that either the `rego.v1` import or applicable `future.keywords` imports are present if any of the `in`, `every`, `if` and `contains` keywords are used in a module.
 
-### Backwards compatibility in OPA v1.0
+#### Backwards compatibility in OPA v1.0
 
 To avoid breaking existing policies and give users a chance to update them such that these future keywords don’t clash with, for example, existing variable names, a new flag called `--v0-compatible` will be added to OPA commands such as `opa run` to maintain backward compatibility. 
 OPA’s Go SDK and Go API will be equipped with similar functionality, as well. 
@@ -38,7 +40,7 @@ In addition to this, the bundle manifest will also be updated to include a bit t
 This should be useful for cases when pre-OPA v1.0 functionality is desired but the users themselves have no control over the OPA deployment and hence cannot set the CLI flag.
 OPA tooling such as the `opa build` command will be equipped with a new flag that will allow users to control the relevant bit in the manifest. 
 
-## Enforce use of `if` and `contains` keywords in rule head declarations
+### Enforce use of `if` and `contains` keywords in rule head declarations
 
 Currently, there is semantic ambiguity between rules like `a.b {true}` and `a.b.c {true}`. Although syntactically similar, the former generates a set with the entry `b` at path `data.a`, while the latter generates an object with the attribute `"c": true` at path `data.a.b`. 
 This inconsistency makes it difficult for new users to understand how Rego works. 
@@ -132,38 +134,38 @@ When the above rule is evaluated the output is:
 The requirement of `if` and `contains` keywords will remove the ambiguity between single-value and multi-value rule declaration.
 This will make Rego code easier to author and read; thereby making it simpler for users to author their policies.
 
-### Making new and existing policies compatible with OPA v1.0
+#### Making new and existing policies compatible with OPA v1.0
 
 1. A new [rego.v1](../policy-language/#the-regov1-import) import has been introduced that, when used, makes OPA apply all restrictions that will eventually be enforced by default in OPA v1.0.
    If a Rego module imports `rego.v1`, it means the `if` and `contains` keywords are required when declaring rules. Constants, rules that only consist of a value assignment, are exempted.
 2. The `--rego-v1` flag on the `opa fmt` command will rewrite existing modules to use the `if` and `contains` keywords where applicable.
 3. The `--rego-v1` flag on the `opa check` command will check that the `if` and `contains` keywords are used where applicable in a module.
 
-### Backwards compatibility in OPA v1.0
+#### Backwards compatibility in OPA v1.0
 
 By default, OPA v1.0 will require the usage of `if` and `contains` as described above, but to maintain backward compatibility for policies written pre-OPA v1.0, a new flag called `--v0-compatible` will be added to OPA commands such as `opa run`, to avoid breaking existing policies and give users time to update them. 
 Similar functionality will be added to OPA’s Go SDK and Go API to assist users that embed OPA as a library in their Go services and also to OPA’s build command.
 
-## Prohibit duplicate imports
+### Prohibit duplicate imports
 
 The Rego compiler supports [strict mode](../policy-language/#strict-mode) which enforces additional constraints and safety checks during compilation. 
 One of these checks is to prohibit duplicate imports where one import shadows another. OPA v1.0 will enforce this check by default.
 
 An import shadowing another is most likely an authoring error and probably unintentional. OPA checking this by default will help to avoid policy evaluations resulting in error-prone decisions.
 
-### Making new and existing policies compatible with OPA v1.0
+#### Making new and existing policies compatible with OPA v1.0
 
 1. A new [rego.v1](../policy-language/#the-regov1-import) import has been introduced that, when used, makes OPA apply all restrictions that will eventually be enforced by default in OPA v1.0.
    If a Rego module imports `rego.v1`, duplicate imports are prohibited.
 2. The `--rego-v1` flag on the `opa fmt` command will reject modules with duplicate imports.
 3. The `--rego-v1` flag on the `opa check` command will check that duplicate imports are not present in a module.
 
-### Backwards compatibility in OPA v1.0
+#### Backwards compatibility in OPA v1.0
 
 If pre-OPA v1.0 behavior is desired where this check is only enforced when `strict mode` is enabled, a new `--v0-compatible` flag will be added to the OPA CLI to achieve that.
 Similar functionality will be added to OPA’s Go SDK, Go API and build command.
 
-## `input` and `data` keywords are reserved
+### `input` and `data` keywords are reserved
 
 The Rego compiler supports [strict mode](../policy-language/#strict-mode), which enforces additional constraints and safety checks during compilation. 
 One of these checks is to ensure that `input` and `data` are reserved keywords and may not be used as names for rules and variable assignments.
@@ -173,7 +175,7 @@ Hence, if a rule or variable shadows `input` or `data` you have the unintended c
 
 Note, using the [with](../policy-language/#with-keyword) keyword to insert values into - or to fully replace - the `input` or `data` documents, as in `my_func(x) with input as {...}` does not constitute shadowing and is therefore allowed in OPA v1.0.
 
-### Making new and existing policies compatible with OPA v1.0
+#### Making new and existing policies compatible with OPA v1.0
 
 1. A new [rego.v1](../policy-language/#the-regov1-import) import has been introduced that, when used, makes OPA apply all restrictions that will eventually be enforced by default in OPA v1.0.
    If a Rego module imports `rego.v1`, it means `input` and `data` are reserved keywords and may not be used as names for rules and variable assignments.
@@ -181,12 +183,12 @@ Note, using the [with](../policy-language/#with-keyword) keyword to insert value
    In a future release, a `--refactor-local-variables` flag will be added to `opa fmt` to refactor local variable assignments.
 3. The `--rego-v1` flag on the `opa check` command will check that `input` and `data` are not used as names for rules and local variable assignments in a module.
 
-### Backwards compatibility in OPA v1.0
+#### Backwards compatibility in OPA v1.0
 
 OPA v1.0 will enforce this check by default. If pre-OPA v1.0 behavior is desired where this check is only enforced when `strict mode` is enabled, a new flag `--v0-compatible` will be added to the OPA CLI to achieve that.
 Similar functionality will be added to OPA’s Go SDK, Go API and build command.
 
-## Prohibit use of deprecated builtins
+### Prohibit use of deprecated builtins
 
 The Rego compiler supports [strict mode](../policy-language/#strict-mode), which enforces additional constraints and safety checks during compilation. 
 One of these checks is to prohibit use of deprecated built-in functions. In OPA v1.0, these built-ins will be removed.
@@ -194,7 +196,7 @@ One of these checks is to prohibit use of deprecated built-in functions. In OPA 
 The following built-in functions are deprecated: `any`, `all`, `re_match`, `net.cidr_overlap`, `set_diff`, `cast_array`, `cast_set`, `cast_string`, `cast_boolean`, `cast_null`, `cast_object`.
 In some cases, new built-in functions have been added that provide functionality at least similar to a deprecated built-in.
 
-### Making new and existing policies compatible with OPA v1.0
+#### Making new and existing policies compatible with OPA v1.0
 
 1. A new [rego.v1](../policy-language/#the-regov1-import) import has been introduced that, when used, makes OPA apply all restrictions that will eventually be enforced by default in OPA v1.0.
    If a Rego module imports `rego.v1`, it means deprecated built-in functions are prohibited.
@@ -203,12 +205,12 @@ In some cases, new built-in functions have been added that provide functionality
    An FAQ section will be published that explains why each built-in function is deprecated and why it should be removed or replaced in the policy.
 3. The `--rego-v1` flag on the `opa check` command will check that deprecated built-in functions are not used in a module.
 
-### Backwards compatibility in OPA v1.0
+#### Backwards compatibility in OPA v1.0
 
 If pre-OPA v1.0 behavior is desired, where this check is only enforced when `strict` mode is enabled, a new flag `--v0-compatible` will be added to the OPA CLI to achieve that. 
 Similar functionality will be added to OPA’s Go SDK, Go API and build command.
 
-## Binding the OPA server to the `localhost` interface by default
+### Binding the OPA server to the `localhost` interface by default
 
 By default, OPA binds to the `0.0.0.0` interface, which allows the OPA server to be exposed to services running outside of the local machine. 
 Though not inherently insecure in a trusted environment, it's good practice to bind OPA to the `localhost` interface by default if OPA is not intended to be exposed to remote services.
@@ -217,3 +219,16 @@ In OPA v1.0, the OPA server will bind to the `localhost` interface by default.
 
 The `--v1-compatible` flag on the `opa run` command makes OPA employ configuration defaults that will eventually be used in OPA v1.0. 
 Binding to the `localhost` interface is one such default.
+
+## Running OPA in 1.0 compatibility mode
+
+OPA can be run in 1.0 compatibility mode by using the `--v1-compatible` flag. When this mode is enabled, the current release of OPA will behave as OPA v1.0 will eventually behave by default when it comes to the changes described [here](#whats-changing-in-opa-10).
+
+The `--v1-compatible` flag is currently supported on the following commands:
+
+* `build`
+* `eval`
+
+{{< info >}}
+Support for more commands will be added in the future.
+{{< /info >}}

--- a/docs/content/opa-1.md
+++ b/docs/content/opa-1.md
@@ -227,10 +227,13 @@ OPA can be run in 1.0 compatibility mode by using the `--v1-compatible` flag. Wh
 The `--v1-compatible` flag is currently supported on the following commands:
 
 * `build`
-* `fmt` Note that this command also supports the `--rego-v1` flag, which will format the Rego modules to be compatible with the Rego syntax of _both_ the current 0.x OPA version and OPA v1.0.
-  If both are used, `--rego-v1` takes precedence.
+* `check`*
+* `fmt`*
 * `eval`
 * `test`
+
+Note: the `check` and `fmt` commands also support the `--rego-v1` flag, which will check/format Rego modules as if compatible with the Rego syntax of _both_ the current 0.x OPA version and OPA v1.0.
+If both flags are used at the same time, `--rego-v1` takes precedence over `--v1-compatible`.
 
 {{< info >}}
 Support for more commands will be added over time, leading up to the release of OPA 1.0.

--- a/docs/content/opa-1.md
+++ b/docs/content/opa-1.md
@@ -226,11 +226,11 @@ OPA can be run in 1.0 compatibility mode by using the `--v1-compatible` flag. Wh
 
 The `--v1-compatible` flag is currently supported on the following commands:
 
-* `build`
-* `check`*
-* `fmt`*
-* `eval`
-* `test`
+* `build`: requires modules to be compatible with OPA v1.0 syntax
+* `check`*: requires modules to be compatible with OPA v1.0 syntax
+* `fmt`*: formats modules to be compatible with OPA v1.0 syntax, but not the current 0.x syntax.
+* `eval`: requires modules to be compatible with OPA v1.0 syntax
+* `test`: requires modules to be compatible with OPA v1.0 syntax
 
 Note: the `check` and `fmt` commands also support the `--rego-v1` flag, which will check/format Rego modules as if compatible with the Rego syntax of _both_ the current 0.x OPA version and OPA v1.0.
 If both flags are used at the same time, `--rego-v1` takes precedence over `--v1-compatible`.

--- a/docs/content/opa-1.md
+++ b/docs/content/opa-1.md
@@ -228,7 +228,8 @@ The `--v1-compatible` flag is currently supported on the following commands:
 
 * `build`
 * `eval`
+* `test`
 
 {{< info >}}
-Support for more commands will be added in the future.
+Support for more commands will be added over time, leading up to the release of OPA 1.0.
 {{< /info >}}

--- a/docs/content/opa-1.md
+++ b/docs/content/opa-1.md
@@ -227,6 +227,8 @@ OPA can be run in 1.0 compatibility mode by using the `--v1-compatible` flag. Wh
 The `--v1-compatible` flag is currently supported on the following commands:
 
 * `build`
+* `fmt` Note that this command also supports the `--rego-v1` flag, which will format the Rego modules to be compatible with the Rego syntax of _both_ the current 0.x OPA version and OPA v1.0.
+  If both are used, `--rego-v1` takes precedence.
 * `eval`
 * `test`
 

--- a/format/format.go
+++ b/format/format.go
@@ -122,13 +122,10 @@ func AstWithOpts(x interface{}, opts Opts) ([]byte, error) {
 
 	o := fmtOpts{}
 
-	switch opts.RegoVersion {
-	case ast.RegoV0CompatV1:
+	if opts.RegoVersion == ast.RegoV0CompatV1 || opts.RegoVersion == ast.RegoV1 {
 		o.regoV1 = true
 		o.ifs = true
 		o.contains = true
-	case ast.RegoV1:
-		o.regoV1 = true
 	}
 
 	// Preprocess the AST. Set any required defaults and calculate

--- a/format/format.go
+++ b/format/format.go
@@ -26,7 +26,18 @@ type Opts struct {
 	// carry along their original source locations.
 	IgnoreLocations bool
 
+	// RegoV1 is equivalent to setting RegoVersion to ast.RegoV0Compat1.
+	// RegoV1 takes precedence over RegoVersion.
+	// Deprecated: use RegoVersion instead.
+	RegoV1      bool
 	RegoVersion ast.RegoVersion
+}
+
+func (o *Opts) effectiveRegoVersion() ast.RegoVersion {
+	if o.RegoV1 {
+		return ast.RegoV0CompatV1
+	}
+	return o.RegoVersion
 }
 
 // defaultLocationFile is the file name used in `Ast()` for terms
@@ -43,7 +54,7 @@ func Source(filename string, src []byte) ([]byte, error) {
 
 func SourceWithOpts(filename string, src []byte, opts Opts) ([]byte, error) {
 	parserOpts := ast.ParserOptions{}
-	if opts.RegoVersion == ast.RegoV1 {
+	if opts.effectiveRegoVersion() == ast.RegoV1 {
 		// If the rego version is V1, wee need to parse it as such, to allow for future keywords not being imported.
 		// Otherwise, we'll default to RegoV0
 		parserOpts.RegoVersion = ast.RegoV1
@@ -54,7 +65,7 @@ func SourceWithOpts(filename string, src []byte, opts Opts) ([]byte, error) {
 		return nil, err
 	}
 
-	if opts.RegoVersion == ast.RegoV0CompatV1 || opts.RegoVersion == ast.RegoV1 {
+	if opts.effectiveRegoVersion() == ast.RegoV0CompatV1 || opts.effectiveRegoVersion() == ast.RegoV1 {
 		errors := ast.CheckRegoV1(module)
 		if len(errors) > 0 {
 			return nil, errors
@@ -122,7 +133,7 @@ func AstWithOpts(x interface{}, opts Opts) ([]byte, error) {
 
 	o := fmtOpts{}
 
-	if opts.RegoVersion == ast.RegoV0CompatV1 || opts.RegoVersion == ast.RegoV1 {
+	if opts.effectiveRegoVersion() == ast.RegoV0CompatV1 || opts.effectiveRegoVersion() == ast.RegoV1 {
 		o.regoV1 = true
 		o.ifs = true
 		o.contains = true
@@ -183,13 +194,13 @@ func AstWithOpts(x interface{}, opts Opts) ([]byte, error) {
 
 	switch x := x.(type) {
 	case *ast.Module:
-		if opts.RegoVersion == ast.RegoV1 {
+		if opts.effectiveRegoVersion() == ast.RegoV1 {
 			x.Imports = filterRegoV1Import(x.Imports)
-		} else if opts.RegoVersion == ast.RegoV0CompatV1 {
+		} else if opts.effectiveRegoVersion() == ast.RegoV0CompatV1 {
 			x.Imports = ensureRegoV1Import(x.Imports)
 		}
 
-		if opts.RegoVersion == ast.RegoV0CompatV1 || opts.RegoVersion == ast.RegoV1 || moduleIsRegoV1Compatible(x) {
+		if opts.effectiveRegoVersion() == ast.RegoV0CompatV1 || opts.effectiveRegoVersion() == ast.RegoV1 || moduleIsRegoV1Compatible(x) {
 			x.Imports = future.FilterFutureImports(x.Imports)
 		} else {
 			for kw := range extraFutureKeywordImports {

--- a/format/format_test.go
+++ b/format/format_test.go
@@ -150,7 +150,7 @@ func TestFormatSourceToRegoV1(t *testing.T) {
 			}
 
 			if errorExpected {
-				formatted, err := SourceWithOpts(rego, contents, Opts{RegoV1: true})
+				formatted, err := SourceWithOpts(rego, contents, Opts{RegoVersion: ast.RegoV0CompatV1})
 				if err == nil {
 					t.Fatalf("Expected error, got: %s", formatted)
 				}
@@ -158,7 +158,7 @@ func TestFormatSourceToRegoV1(t *testing.T) {
 					t.Fatalf("Expected error:\n\n'%s'\n\ngot:\n\n'%s'", expected, err.Error())
 				}
 			} else {
-				formatted, err := SourceWithOpts(rego, contents, Opts{RegoV1: true})
+				formatted, err := SourceWithOpts(rego, contents, Opts{RegoVersion: ast.RegoV0CompatV1})
 				if err != nil {
 					t.Fatalf("Failed to format file: %v", err)
 				}
@@ -171,7 +171,7 @@ func TestFormatSourceToRegoV1(t *testing.T) {
 					t.Fatalf("Failed to parse formatted bytes: %v", err)
 				}
 
-				formatted, err = SourceWithOpts(rego, formatted, Opts{RegoV1: true})
+				formatted, err = SourceWithOpts(rego, formatted, Opts{RegoVersion: ast.RegoV0CompatV1})
 				if err != nil {
 					t.Fatalf("Failed to double format file")
 				}

--- a/internal/runtime/init/init.go
+++ b/internal/runtime/init/init.go
@@ -122,6 +122,18 @@ func LoadPaths(paths []string,
 	processAnnotations bool,
 	caps *ast.Capabilities,
 	fsys fs.FS) (*LoadPathsResult, error) {
+	return LoadPathsForRegoVersion(ast.RegoV0, paths, filter, asBundle, bvc, skipVerify, processAnnotations, caps, fsys)
+}
+
+func LoadPathsForRegoVersion(regoVersion ast.RegoVersion,
+	paths []string,
+	filter loader.Filter,
+	asBundle bool,
+	bvc *bundle.VerificationConfig,
+	skipVerify bool,
+	processAnnotations bool,
+	caps *ast.Capabilities,
+	fsys fs.FS) (*LoadPathsResult, error) {
 
 	if caps == nil {
 		caps = ast.CapabilitiesForThisVersion()
@@ -146,6 +158,7 @@ func LoadPaths(paths []string,
 				WithFilter(filter).
 				WithProcessAnnotation(processAnnotations).
 				WithCapabilities(caps).
+				WithRegoVersion(regoVersion).
 				AsBundle(path)
 			if err != nil {
 				return nil, err
@@ -161,6 +174,7 @@ func LoadPaths(paths []string,
 		WithFS(fsys).
 		WithProcessAnnotation(processAnnotations).
 		WithCapabilities(caps).
+		WithRegoVersion(regoVersion).
 		Filtered(nonBundlePaths, filter)
 
 	if err != nil {

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -103,6 +103,8 @@ type FileLoader interface {
 	WithCapabilities(*ast.Capabilities) FileLoader
 	WithJSONOptions(*astJSON.Options) FileLoader
 
+	// WithRegoV1Compatible
+	// Deprecated: use WithRegoVersion instead
 	WithRegoV1Compatible(bool) FileLoader
 
 	WithRegoVersion(ast.RegoVersion) FileLoader

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -273,7 +273,7 @@ func (fl fileLoader) AsBundle(path string) (*bundle.Bundle, error) {
 		WithProcessAnnotations(fl.opts.ProcessAnnotation).
 		WithCapabilities(fl.opts.Capabilities).
 		WithJSONOptions(fl.opts.JSONOptions).
-		WithRegoVersion(fl.opts.RegoVersion)
+		WithRegoVersion(fl.opts.EffectiveRegoVersion())
 
 	// For bundle directories add the full path in front of module file names
 	// to simplify debugging.

--- a/rego/rego.go
+++ b/rego/rego.go
@@ -1194,7 +1194,7 @@ func Strict(yes bool) func(r *Rego) {
 	}
 }
 
-func RegoVersion(version ast.RegoVersion) func(r *Rego) {
+func SetRegoVersion(version ast.RegoVersion) func(r *Rego) {
 	return func(r *Rego) {
 		r.regoVersion = version
 	}

--- a/rego/rego.go
+++ b/rego/rego.go
@@ -594,6 +594,7 @@ type Rego struct {
 	pluginMgr              *plugins.Manager
 	plugins                []TargetPlugin
 	targetPrepState        TargetPluginEval
+	regoVersion            ast.RegoVersion
 }
 
 // Function represents a built-in function that is callable in Rego.
@@ -1190,6 +1191,12 @@ func EnablePrintStatements(yes bool) func(r *Rego) {
 func Strict(yes bool) func(r *Rego) {
 	return func(r *Rego) {
 		r.strict = yes
+	}
+}
+
+func RegoVersion(version ast.RegoVersion) func(r *Rego) {
+	return func(r *Rego) {
+		r.regoVersion = version
 	}
 }
 
@@ -1803,7 +1810,7 @@ func (r *Rego) parseModules(ctx context.Context, txn storage.Transaction, m metr
 			return err
 		}
 
-		parsed, err := ast.ParseModule(id, string(bs))
+		parsed, err := ast.ParseModuleWithOpts(id, string(bs), ast.ParserOptions{RegoVersion: r.regoVersion})
 		if err != nil {
 			errs = append(errs, err)
 		}
@@ -1813,7 +1820,7 @@ func (r *Rego) parseModules(ctx context.Context, txn storage.Transaction, m metr
 
 	// Parse any passed in as arguments to the Rego object
 	for _, module := range r.modules {
-		p, err := module.Parse()
+		p, err := module.ParseWithOpts(ast.ParserOptions{RegoVersion: r.regoVersion})
 		if err != nil {
 			switch errorWithType := err.(type) {
 			case ast.Errors:
@@ -1845,6 +1852,7 @@ func (r *Rego) loadFiles(ctx context.Context, txn storage.Transaction, m metrics
 	result, err := loader.NewFileLoader().
 		WithMetrics(m).
 		WithProcessAnnotation(true).
+		WithRegoVersion(r.regoVersion).
 		Filtered(r.loadPaths.paths, r.loadPaths.filter)
 	if err != nil {
 		return err
@@ -1875,6 +1883,7 @@ func (r *Rego) loadBundles(ctx context.Context, txn storage.Transaction, m metri
 			WithMetrics(m).
 			WithProcessAnnotation(true).
 			WithSkipBundleVerification(r.skipBundleVerification).
+			WithRegoVersion(r.regoVersion).
 			AsBundle(path)
 		if err != nil {
 			return fmt.Errorf("loading error: %s", err)
@@ -1940,13 +1949,14 @@ func (r *Rego) compileModules(ctx context.Context, txn storage.Transaction, m me
 		// Use this as the single-point of compiling everything only a
 		// single time.
 		opts := &bundle.ActivateOpts{
-			Ctx:          ctx,
-			Store:        r.store,
-			Txn:          txn,
-			Compiler:     r.compilerForTxn(ctx, r.store, txn),
-			Metrics:      m,
-			Bundles:      r.bundles,
-			ExtraModules: r.parsedModules,
+			Ctx:           ctx,
+			Store:         r.store,
+			Txn:           txn,
+			Compiler:      r.compilerForTxn(ctx, r.store, txn),
+			Metrics:       m,
+			Bundles:       r.bundles,
+			ExtraModules:  r.parsedModules,
+			ParserOptions: ast.ParserOptions{RegoVersion: r.regoVersion},
 		}
 		err := bundle.Activate(opts)
 		if err != nil {
@@ -2612,6 +2622,10 @@ type rawModule struct {
 
 func (m rawModule) Parse() (*ast.Module, error) {
 	return ast.ParseModule(m.filename, m.module)
+}
+
+func (m rawModule) ParseWithOpts(opts ast.ParserOptions) (*ast.Module, error) {
+	return ast.ParseModuleWithOpts(m.filename, m.module, opts)
 }
 
 type extraStage struct {

--- a/rego/rego_test.go
+++ b/rego/rego_test.go
@@ -1229,8 +1229,6 @@ foo[__local1__1] { __local1__1 = input.v }`,
 				t.Fatal(err)
 			}
 
-			fmt.Println(partialQuery)
-
 			actualQuery := partialQuery.Queries[0].String()
 			if tc.expQuery != actualQuery {
 				t.Fatalf("Expected partial query to be:\n\n%s\n\nbut got:\n\n%s", tc.expQuery, actualQuery)

--- a/rego/rego_test.go
+++ b/rego/rego_test.go
@@ -1167,7 +1167,7 @@ func TestPrepareAndPartial(t *testing.T) {
 	}
 }
 
-func TestPartialWitRegoV1(t *testing.T) {
+func TestPartialWithRegoV1(t *testing.T) {
 	tests := []struct {
 		note       string
 		module     string

--- a/rego/rego_test.go
+++ b/rego/rego_test.go
@@ -1219,7 +1219,7 @@ foo[__local1__1] { __local1__1 = input.v }`,
 			r := New(
 				Query("data.test.p = x"),
 				Module("test.rego", tc.module),
-				RegoVersion(ast.RegoV1),
+				SetRegoVersion(ast.RegoV1),
 			)
 
 			ctx := context.Background()
@@ -2064,7 +2064,7 @@ func TestRegoEvalWithRegoV1(t *testing.T) {
 						Query("data.test"),
 						func(r *Rego) {
 							if tc.regoVersion != ast.RegoV0 {
-								RegoVersion(tc.regoVersion)(r)
+								SetRegoVersion(tc.regoVersion)(r)
 							}
 						},
 					)
@@ -2720,7 +2720,7 @@ x contains v if {
 	r := New(
 		Query("data.test.x"),
 		Module("", module),
-		RegoVersion(ast.RegoV1),
+		SetRegoVersion(ast.RegoV1),
 	)
 
 	ctx := context.Background()

--- a/tester/runner.go
+++ b/tester/runner.go
@@ -606,7 +606,14 @@ func (r *Runner) runBenchmark(ctx context.Context, txn storage.Transaction, mod 
 
 // Load returns modules and an in-memory store for running tests.
 func Load(args []string, filter loader.Filter) (map[string]*ast.Module, storage.Store, error) {
+	return LoadWithRegoVersion(args, filter, ast.RegoV0)
+}
+
+// LoadWithRegoVersion returns modules and an in-memory store for running tests.
+// Modules are parsed in accordance with the given RegoVersion.
+func LoadWithRegoVersion(args []string, filter loader.Filter, regoVersion ast.RegoVersion) (map[string]*ast.Module, storage.Store, error) {
 	loaded, err := loader.NewFileLoader().
+		WithRegoVersion(regoVersion).
 		WithProcessAnnotation(true).
 		Filtered(args, filter)
 	if err != nil {
@@ -634,9 +641,16 @@ func Load(args []string, filter loader.Filter) (map[string]*ast.Module, storage.
 
 // LoadBundles will load the given args as bundles, either tarball or directory is OK.
 func LoadBundles(args []string, filter loader.Filter) (map[string]*bundle.Bundle, error) {
+	return LoadBundlesWithRegoVersion(args, filter, ast.RegoV0)
+}
+
+// LoadBundlesWithRegoVersion will load the given args as bundles, either tarball or directory is OK.
+// Bundles are parsed in accordance with the given RegoVersion.
+func LoadBundlesWithRegoVersion(args []string, filter loader.Filter, regoVersion ast.RegoVersion) (map[string]*bundle.Bundle, error) {
 	bundles := map[string]*bundle.Bundle{}
 	for _, bundleDir := range args {
 		b, err := loader.NewFileLoader().
+			WithRegoVersion(regoVersion).
 			WithProcessAnnotation(true).
 			WithSkipBundleVerification(true).
 			WithFilter(filter).


### PR DESCRIPTION
This PR implements a small subset of the commands in #6463; namely `build` and `eval`. I'm not including more commands here to keep the scope of the PR tight, in part to make it easier to review, but also so that implementation of the remaining commands can be parallelized between multiple developers.

When applied, the `--rego-v1` flag will cause `opa build` and `opa eval` to behave strictly as they would in OPA 1.0 in regards to module parsing, compilation, and PE. The difference to the behavior of e.g. `opa fmt --rego-v1` is that this strict 1.0 behavior allows for policies using the `future` keywords without first importing `future.keywords` or `rego.v1`. E.g.:

```rego
package example

allow if {
  input.x == 42
}
```

An open question is what this flag should be named. A couple of options:

* `--rego-v1`: The current naming in this PR. This was selected because this flag already exists on the `fmt` and `check` commands. I'm now reevaluating this choice, as `--rego-v1` on e.g. `fmt` means the policy will be formatted to be compatible with _both_ Rego in OPA 0.x and 1.0, whereas for `eval` it enforces compatibility with _only_ 1.0. In addition to this behavioral difference, reusing the `--rego.v1` flag means that we can't provide _exactly_ OPA 1.0 behavior for `fmt` and `check` in addition to this current v0/v1 compatibility.
* `--v1-compatible`: This flag already exists in `opa run`, and will apply configuration default values as if OPA 1.0. E.g., the server defaults to listen to `localhost` instead of `0.0.0.0` (currently the only change). It could be argued that module processing is part of this "OPA 1.0 compatibility mode".
* `--rego-version=<version>`: Allow the user to explicitly select what version/flavor of Rego to use. In this PR, we have internally have three flavors of Rego (we could allow the user to either select between no1 and no3; or all three, but that might become confusing): 
    1. `rego-v0`: The current, default Rego version.
    2. `rego-v0-compat-v1`: A flavor of Rego compatible with both v0 and v1. What is currently enforced in `opa check --rego-v1` and `opa fmt --rego-v1`.
    3. `rego-v1`: The future Rego version of OPA 1.0.