### PR TITLE
Docs: Explain %T behavior of sprintf

### DIFF
--- a/docs/content/policy-reference.md
+++ b/docs/content/policy-reference.md
@@ -371,6 +371,13 @@ complex types.
 
 
 {{< builtin-table strings >}}
+
+{{< info >}}
+When using `sprintf`, values are pre-processed and may have an unexpected type. For example,
+`%T` evaluates to `string` for both `string` and `boolean` types. In such cases, use `type_name` to
+accurately evaluate the underlying type.
+{{< /info >}}
+
 {{< builtin-table regex >}}
 
 {{< builtin-table glob >}}


### PR DESCRIPTION
### Why the changes in this PR are needed?

Using the `sprintf` function to evaluate the type of a certain value, the current implementation is likely to cause confusion.

### What are the changes in this PR?

Clarify some of the intricacies when using `sprintf`.

### Notes to assist PR review:

See additional context in #6487

