### PR TITLE
.github/workflows: Update name of the checkout action token

### DIFF
--- a/.github/workflows/post-merge.yaml
+++ b/.github/workflows/post-merge.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GH_PUSH_TOKEN_2 }} # required to push to protected branch below
+          token: ${{ secrets.GH_PUSH_TOKEN }} # required to push to protected branch below
 
       - name: Generate
         run: make clean generate docs-generate-cli-docs


### PR DESCRIPTION
This PR attempts to fix the failures seen in the Post Merge workflow. Previously the token used in the checkout action had probably expired and a new token was generated to test out this hypothesis. Now that the Post Merge workflow [succeeds](https://github.com/open-policy-agent/opa/actions/runs/7254582557), we're renaming the token as before and updating the token value in the repo.
