### PR TITLE
internal/presentation: cleanup location handling

### DIFF
--- a/cmd/eval_test.go
+++ b/cmd/eval_test.go
@@ -111,17 +111,17 @@ q {
 			t.Fatalf("expected message '%v', got '%v'", expectedMessage, msg)
 		}
 
-		loc1, ok1 := output.Errors[0].Location.(map[string]interface{})
-		if !ok1 {
-			t.Fatal("unexpected location type")
+		loc1 := output.Errors[0].Location
+		if loc1 == nil {
+			t.Fatal("unexpected nil location")
 		}
 
-		loc2, ok2 := output.Errors[1].Location.(map[string]interface{})
-		if !ok2 {
-			t.Fatal("unexpected location type")
+		loc2 := output.Errors[1].Location
+		if loc2 == nil {
+			t.Fatal("unexpected nil location")
 		}
 
-		if loc1["row"] == loc2["row"] {
+		if loc1.Row == loc2.Row {
 			t.Fatal("expected 2 distinct error occurrences in policy")
 		}
 	})

--- a/internal/presentation/presentation.go
+++ b/internal/presentation/presentation.go
@@ -142,19 +142,14 @@ func NewOutputErrors(err error) []OutputError {
 
 		switch typedErr := err.(type) {
 		case *ast.Error:
-			oe := OutputError{
-				Code:    typedErr.Code,
-				Message: typedErr.Message,
-				Details: typedErr.Details,
-				err:     typedErr,
-			}
+			errs = []OutputError{{
+				Code:     typedErr.Code,
+				Message:  typedErr.Message,
+				Details:  typedErr.Details,
+				Location: typedErr.Location,
+				err:      typedErr,
+			}}
 
-			// TODO(patrick-east): Why does the JSON marshaller marshal
-			// location as `null` when err.location == nil?!
-			if typedErr.Location != nil {
-				oe.Location = typedErr.Location
-			}
-			errs = []OutputError{oe}
 		case *topdown.Error:
 			errs = []OutputError{{
 				Code:     typedErr.Code,
@@ -184,11 +179,9 @@ func NewOutputErrors(err error) []OutputError {
 				}
 			}
 		case loader.Errors:
-			{
-				for _, e := range typedErr {
-					if e != nil {
-						errs = append(errs, NewOutputErrors(e)...)
-					}
+			for _, e := range typedErr {
+				if e != nil {
+					errs = append(errs, NewOutputErrors(e)...)
 				}
 			}
 		default:
@@ -239,10 +232,10 @@ func (e OutputErrors) Error() string {
 // library errors so that the JSON output given by the
 // presentation package is consistent and parsable.
 type OutputError struct {
-	Message  string      `json:"message"`
-	Code     string      `json:"code,omitempty"`
-	Location interface{} `json:"location,omitempty"`
-	Details  interface{} `json:"details,omitempty"`
+	Message  string        `json:"message"`
+	Code     string        `json:"code,omitempty"`
+	Location *ast.Location `json:"location,omitempty"`
+	Details  interface{}   `json:"details,omitempty"`
 	err      error
 }
 


### PR DESCRIPTION
`nil` values for `any` are always rendered. I don't think there's a need to have `Location` be `interface{}` here, so I've changed it, cleaning up the output formatting without extra hurdles.

Random stackoverflow answer: https://stackoverflow.com/a/44321451/993018