### PR TITLE
docs: update version for non docs pages

### DIFF
--- a/docs/website/layouts/partials/meta.html
+++ b/docs/website/layouts/partials/meta.html
@@ -5,7 +5,10 @@
 {{ $pageType    := cond $isHome "website" "article" }}
 {{ $imageUrl    := "/img/logos/opa-horizontal-color.png" | absURL }}
 {{ $twitter     := site.Params.social.twitter }}
-{{ $version     := index (split .File.Path "/") 1 }}
+{{ $version := "latest" }}
+{{ if strings.HasPrefix .Permalink "/docs/" }}
+{{ $version := index (split .File.Path "/") 1 }}
+{{ end }}
 {{ $page       := trim .RelPermalink "/" }}
 {{ $releases   := site.Data.releases }}
 {{ $latest     := index $releases 1 }}


### PR DESCRIPTION
This sets the default version for all non docs pages to latest.

We have recently started to list some pages in the search index from non docs pages, when a user makes a search, they search within the current version. This will make pages from the rest of the site available in the index when searching from 'latest'.

