### PR TITLE
docs: Fix issue in versioning docs for search

### DIFF
--- a/docs/website/layouts/partials/meta.html
+++ b/docs/website/layouts/partials/meta.html
@@ -1,3 +1,7 @@
+{{ $version := "latest" }}
+{{ if strings.HasPrefix .RelPermalink "/docs/" }}
+  {{ $version = index (split .File.Path "/") 1 -}}
+{{ end -}}
 {{ $isHome      := .IsHome }}
 {{ $isDoc       := eq .Section "docs" }}
 {{ $title       := cond $isHome site.Title .Title }}
@@ -5,14 +9,10 @@
 {{ $pageType    := cond $isHome "website" "article" }}
 {{ $imageUrl    := "/img/logos/opa-horizontal-color.png" | absURL }}
 {{ $twitter     := site.Params.social.twitter }}
-{{ $version := "latest" }}
-{{ if strings.HasPrefix .Permalink "/docs/" }}
-{{ $version := index (split .File.Path "/") 1 }}
-{{ end }}
-{{ $page       := trim .RelPermalink "/" }}
-{{ $releases   := site.Data.releases }}
-{{ $latest     := index $releases 1 }}
-{{ $isLatest   := or (eq $version $latest) (eq $version "latest") }}
+{{ $page        := trim .RelPermalink "/" }}
+{{ $releases    := site.Data.releases }}
+{{ $latest      := index $releases 1 }}
+{{ $isLatest    := or (eq $version $latest) (eq $version "latest") }}
 
 
 <!-- Basic metadata -->


### PR DESCRIPTION
https://github.com/open-policy-agent/opa/pull/6526 contained two errors, that I can see. First, it used `Permalink` rather than `RelPermalink`, this contains the host and scheme on build and so the older versions of pages were all getting version set to the latest.

Even if that had worked, the setting of version was incorrect and set a locally scoped var instead of the variable for the whole file.

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->

### Why the changes in this PR are needed?

<!--
Include a short description of WHY the changes were made.
-->

### What are the changes in this PR?

<!--
Include a short description of WHAT changes were made.
-->

### Notes to assist PR review:

<!--
Here you can add information you think will help the reviewer(s).
-->

### Further comments:

<!--
Here you can include links to additional resources related to the changes, discuss your solution, other approaches you considered etc.
-->
