### PR TITLE
Allow TLS cipher suites to be set for the OPA server

### DIFF
--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -7,8 +7,11 @@ package cmd
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"encoding/json"
+	"fmt"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -146,6 +149,51 @@ func TestInitRuntimeVerifyNonBundle(t *testing.T) {
 	exp := "enable bundle mode (ie. --bundle) to verify bundle files or directories"
 	if err.Error() != exp {
 		t.Fatalf("expected error message %v but got %v", exp, err.Error())
+	}
+}
+
+func TestInitRuntimeCipherSuites(t *testing.T) {
+	testCases := []struct {
+		name            string
+		cipherSuites    []string
+		expErr          bool
+		expCipherSuites []uint16
+	}{
+		{"no cipher suites", []string{}, false, []uint16{}},
+		{"secure and insecure cipher suites", []string{"TLS_RSA_WITH_AES_128_CBC_SHA", "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA", "TLS_RSA_WITH_RC4_128_SHA"}, false, []uint16{tls.TLS_RSA_WITH_AES_128_CBC_SHA, tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA, tls.TLS_RSA_WITH_RC4_128_SHA}},
+		{"invalid cipher suites", []string{"foo"}, true, []uint16{}},
+		{"tls 1.3 cipher suite", []string{"TLS_AES_128_GCM_SHA256"}, true, []uint16{}},
+		{"tls 1.2-1.3 cipher suite", []string{"TLS_RSA_WITH_AES_128_GCM_SHA256", "TLS_AES_128_GCM_SHA256"}, true, []uint16{}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			params := newTestRunParams()
+
+			if len(tc.cipherSuites) != 0 {
+				params.cipherSuites = tc.cipherSuites
+			}
+
+			rt, err := initRuntime(context.Background(), params, nil, false)
+			fmt.Println(err)
+
+			if !tc.expErr && err != nil {
+				t.Fatal("Unexpected error occurred:", err)
+			} else if tc.expErr && err == nil {
+				t.Fatal("Expected error but got nil")
+			} else if err == nil {
+				if len(tc.expCipherSuites) > 0 {
+					if !reflect.DeepEqual(*rt.Params.CipherSuites, tc.expCipherSuites) {
+						t.Fatalf("expected cipher suites %v but got %v", tc.expCipherSuites, *rt.Params.CipherSuites)
+					}
+				} else {
+					if rt.Params.CipherSuites != nil {
+						t.Fatal("expected no value defined for cipher suites")
+					}
+				}
+			}
+		})
 	}
 }
 

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -231,6 +231,9 @@ type Params struct {
 	// This flag allows users to opt-in to the new behavior and helps transition to the future release upon which
 	// the new behavior will be enabled by default.
 	V1Compatible bool
+
+	// CipherSuites specifies the list of enabled TLS 1.0–1.2 cipher suites
+	CipherSuites *[]uint16
 }
 
 // LoggingConfig stores the configuration for OPA's logging behaviour.
@@ -550,6 +553,7 @@ func (rt *Runtime) Serve(ctx context.Context) error {
 		WithRuntime(rt.Manager.Info).
 		WithMetrics(rt.metrics).
 		WithMinTLSVersion(rt.Params.MinTLSVersion).
+		WithCipherSuites(rt.Params.CipherSuites).
 		WithDistributedTracingOpts(rt.Params.DistributedTracingOpts)
 
 	// If decision_logging plugin enabled, check to see if we opted in to the ND builtins cache.


### PR DESCRIPTION
This change adds a new flag to `opa run` to allow users to specify a list of enabled TLS 1.0–1.2 cipher suites. This allows users to control the cipher suites the OPA server supports during a TLS handshake.

