### PR TITLE
Removing deprecated fields and functions related to rego-v1 compatibility

### DIFF
--- a/ast/parser.go
+++ b/ast/parser.go
@@ -122,19 +122,14 @@ type ParserOptions struct {
 	SkipRules         bool
 	JSONOptions       *astJSON.Options
 	// RegoVersion is the version of Rego to parse for.
-	// RegoV1Compatible additionally affects the Rego version. Use EffectiveRegoVersion to get the effective Rego version.
-	RegoVersion RegoVersion
-	// RegoV1Compatible is equivalent to setting RegoVersion to RegoV0CompatV1.
-	// RegoV1Compatible takes precedence, and if set to true, RegoVersion is ignored.
-	// Deprecated: use RegoVersion instead. Will be removed in a future version of OPA.
-	RegoV1Compatible   bool
+	// RegoV1Compatible additionally affects the Rego version.
+	RegoVersion        RegoVersion
 	unreleasedKeywords bool // TODO(sr): cleanup
 }
 
+// EffectiveRegoVersion returns the effective RegoVersion to use for parsing.
+// Deprecated: Use RegoVersion instead.
 func (po *ParserOptions) EffectiveRegoVersion() RegoVersion {
-	if po.RegoV1Compatible {
-		return RegoV0CompatV1
-	}
 	return po.RegoVersion
 }
 
@@ -291,7 +286,7 @@ func (p *Parser) Parse() ([]Statement, []*Comment, Errors) {
 
 	allowedFutureKeywords := map[string]tokens.Token{}
 
-	if p.po.EffectiveRegoVersion() == RegoV1 {
+	if p.po.RegoVersion == RegoV1 {
 		// RegoV1 includes all future keywords in the default language definition
 		for k, v := range futureKeywords {
 			allowedFutureKeywords[k] = v
@@ -325,7 +320,7 @@ func (p *Parser) Parse() ([]Statement, []*Comment, Errors) {
 	}
 
 	selected := map[string]tokens.Token{}
-	if p.po.AllFutureKeywords || p.po.EffectiveRegoVersion() == RegoV1 {
+	if p.po.AllFutureKeywords || p.po.RegoVersion == RegoV1 {
 		for kw, tok := range allowedFutureKeywords {
 			selected[kw] = tok
 		}
@@ -346,7 +341,7 @@ func (p *Parser) Parse() ([]Statement, []*Comment, Errors) {
 	}
 	p.s.s = p.s.s.WithKeywords(selected)
 
-	if p.po.EffectiveRegoVersion() == RegoV1 {
+	if p.po.RegoVersion == RegoV1 {
 		for kw, tok := range allowedFutureKeywords {
 			p.s.s.AddKeyword(kw, tok)
 		}
@@ -2614,7 +2609,7 @@ func (p *Parser) regoV1Import(imp *Import) {
 		return
 	}
 
-	if p.po.EffectiveRegoVersion() == RegoV1 {
+	if p.po.RegoVersion == RegoV1 {
 		// We're parsing for Rego v1, where the 'rego.v1' import is a no-op.
 		return
 	}

--- a/ast/parser.go
+++ b/ast/parser.go
@@ -122,7 +122,6 @@ type ParserOptions struct {
 	SkipRules         bool
 	JSONOptions       *astJSON.Options
 	// RegoVersion is the version of Rego to parse for.
-	// RegoV1Compatible additionally affects the Rego version.
 	RegoVersion        RegoVersion
 	unreleasedKeywords bool // TODO(sr): cleanup
 }

--- a/ast/parser_ext.go
+++ b/ast/parser_ext.go
@@ -477,7 +477,7 @@ func ParseModuleWithOpts(filename, input string, popts ParserOptions) (*Module, 
 	if err != nil {
 		return nil, err
 	}
-	return parseModule(filename, stmts, comments, popts.EffectiveRegoVersion())
+	return parseModule(filename, stmts, comments, popts.RegoVersion)
 }
 
 // ParseBody returns exactly one body.
@@ -626,7 +626,7 @@ func ParseStatementsWithOpts(filename, input string, popts ParserOptions) ([]Sta
 		WithCapabilities(popts.Capabilities).
 		WithSkipRules(popts.SkipRules).
 		WithJSONOptions(popts.JSONOptions).
-		WithRegoVersion(popts.EffectiveRegoVersion()).
+		WithRegoVersion(popts.RegoVersion).
 		withUnreleasedKeywords(popts.unreleasedKeywords)
 
 	stmts, comments, errs := parser.Parse()

--- a/format/format.go
+++ b/format/format.go
@@ -26,18 +26,8 @@ type Opts struct {
 	// carry along their original source locations.
 	IgnoreLocations bool
 
-	// RegoV1 is equivalent to setting RegoVersion to ast.RegoV0Compat1.
-	// RegoV1 takes precedence over RegoVersion.
-	// Deprecated: use RegoVersion instead.
-	RegoV1      bool
+	// RegoVersion is the version of Rego to format code for.
 	RegoVersion ast.RegoVersion
-}
-
-func (o *Opts) effectiveRegoVersion() ast.RegoVersion {
-	if o.RegoV1 {
-		return ast.RegoV0CompatV1
-	}
-	return o.RegoVersion
 }
 
 // defaultLocationFile is the file name used in `Ast()` for terms
@@ -54,7 +44,7 @@ func Source(filename string, src []byte) ([]byte, error) {
 
 func SourceWithOpts(filename string, src []byte, opts Opts) ([]byte, error) {
 	parserOpts := ast.ParserOptions{}
-	if opts.effectiveRegoVersion() == ast.RegoV1 {
+	if opts.RegoVersion == ast.RegoV1 {
 		// If the rego version is V1, wee need to parse it as such, to allow for future keywords not being imported.
 		// Otherwise, we'll default to RegoV0
 		parserOpts.RegoVersion = ast.RegoV1
@@ -65,7 +55,7 @@ func SourceWithOpts(filename string, src []byte, opts Opts) ([]byte, error) {
 		return nil, err
 	}
 
-	if opts.effectiveRegoVersion() == ast.RegoV0CompatV1 || opts.effectiveRegoVersion() == ast.RegoV1 {
+	if opts.RegoVersion == ast.RegoV0CompatV1 || opts.RegoVersion == ast.RegoV1 {
 		errors := ast.CheckRegoV1(module)
 		if len(errors) > 0 {
 			return nil, errors
@@ -133,7 +123,7 @@ func AstWithOpts(x interface{}, opts Opts) ([]byte, error) {
 
 	o := fmtOpts{}
 
-	if opts.effectiveRegoVersion() == ast.RegoV0CompatV1 || opts.effectiveRegoVersion() == ast.RegoV1 {
+	if opts.RegoVersion == ast.RegoV0CompatV1 || opts.RegoVersion == ast.RegoV1 {
 		o.regoV1 = true
 		o.ifs = true
 		o.contains = true
@@ -194,13 +184,13 @@ func AstWithOpts(x interface{}, opts Opts) ([]byte, error) {
 
 	switch x := x.(type) {
 	case *ast.Module:
-		if opts.effectiveRegoVersion() == ast.RegoV1 {
+		if opts.RegoVersion == ast.RegoV1 {
 			x.Imports = filterRegoV1Import(x.Imports)
-		} else if opts.effectiveRegoVersion() == ast.RegoV0CompatV1 {
+		} else if opts.RegoVersion == ast.RegoV0CompatV1 {
 			x.Imports = ensureRegoV1Import(x.Imports)
 		}
 
-		if opts.effectiveRegoVersion() == ast.RegoV0CompatV1 || opts.effectiveRegoVersion() == ast.RegoV1 || moduleIsRegoV1Compatible(x) {
+		if opts.RegoVersion == ast.RegoV0CompatV1 || opts.RegoVersion == ast.RegoV1 || moduleIsRegoV1Compatible(x) {
 			x.Imports = future.FilterFutureImports(x.Imports)
 		} else {
 			for kw := range extraFutureKeywordImports {

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -102,11 +102,6 @@ type FileLoader interface {
 	WithProcessAnnotation(bool) FileLoader
 	WithCapabilities(*ast.Capabilities) FileLoader
 	WithJSONOptions(*astJSON.Options) FileLoader
-
-	// WithRegoV1Compatible
-	// Deprecated: use WithRegoVersion instead
-	WithRegoV1Compatible(bool) FileLoader
-
 	WithRegoVersion(ast.RegoVersion) FileLoader
 }
 
@@ -187,15 +182,6 @@ func (fl *fileLoader) WithJSONOptions(opts *astJSON.Options) FileLoader {
 	return fl
 }
 
-// WithRegoV1Compatible enforces Rego v0 with Rego v1 compatibility.
-// See ParserOptions.RegoV1Compatible for more details.
-// Deprecated: use WithRegoVersion instead
-// TODO: Remove, this is an internal type, so won't be a breaking change.
-func (fl *fileLoader) WithRegoV1Compatible(compatible bool) FileLoader {
-	fl.opts.RegoV1Compatible = compatible
-	return fl
-}
-
 // WithRegoVersion sets the ast.RegoVersion to use when parsing and compiling modules.
 func (fl *fileLoader) WithRegoVersion(version ast.RegoVersion) FileLoader {
 	fl.opts.RegoVersion = version
@@ -271,7 +257,7 @@ func (fl fileLoader) AsBundle(path string) (*bundle.Bundle, error) {
 		WithProcessAnnotations(fl.opts.ProcessAnnotation).
 		WithCapabilities(fl.opts.Capabilities).
 		WithJSONOptions(fl.opts.JSONOptions).
-		WithRegoVersion(fl.opts.EffectiveRegoVersion())
+		WithRegoVersion(fl.opts.RegoVersion)
 
 	// For bundle directories add the full path in front of module file names
 	// to simplify debugging.


### PR DESCRIPTION
to remove API ambiguity.

Also deprecating `ParserOptions.EffectiveRegoVersion()`, which will be removed in a future release.
