### PR TITLE
fix(oci): oci downloader unavailable missing WithBundleParserOpts method

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -30,7 +30,7 @@ jobs:
             capabilities.json
 
   go-build:
-    name: Go Build (${{ matrix.os }}${{ matrix.arch && format(' {0}', matrix.arch) || '' }})
+    name: Go Build (${{ matrix.os }}${{ matrix.arch && format(' {0}', matrix.arch) || '' }}${{ matrix.go_tags }})
     runs-on: ${{ matrix.run }}
     needs: generate
     strategy:
@@ -44,6 +44,11 @@ jobs:
           - os: linux
             run: ubuntu-22.04
             targets: ci-go-ci-build-linux-static
+            arch: arm64
+          - os: linux
+            run: ubuntu-22.04
+            targets: ci-go-ci-build-linux-static
+            go_tags: GO_TAGS="-tags=opa_no_oci"
             arch: arm64
           - os: windows
             run: ubuntu-22.04
@@ -71,7 +76,7 @@ jobs:
           name: generated
 
       - name: Build
-        run: make ${{ matrix.targets }}
+        run: make ${{ matrix.go_tags }} ${{ matrix.targets }}
         env:
           GOARCH: ${{ matrix.arch }}
         timeout-minutes: 30

--- a/download/oci_download_unavailable.go
+++ b/download/oci_download_unavailable.go
@@ -4,6 +4,8 @@ package download
 
 import (
 	"context"
+
+	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/bundle"
 	"github.com/open-policy-agent/opa/plugins/rest"
 )
@@ -49,5 +51,9 @@ func (d *OCIDownloader) Start(context.Context) {
 }
 
 func (d *OCIDownloader) Stop(context.Context) {
+	panic("built without OCI support")
+}
+
+func (*OCIDownloader) WithBundleParserOpts(ast.ParserOptions) *OCIDownloader {
 	panic("built without OCI support")
 }


### PR DESCRIPTION
<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->

### Why the changes in this PR are needed?

In https://github.com/open-policy-agent/opa/pull/6159 I introduced a disabled OCI downloader to get rid of dependency on containerd to minimise the CVE surface. https://github.com/open-policy-agent/opa/pull/6521/files#diff-f808512360f39e5c4f67342ca24d84117be5403637b032d67e82df3a425cdde9R139 broke our builds adding a method only to one of the implementations. 

<!--
Include a short description of WHY the changes were made.
-->

### What are the changes in this PR?

In this PR I added an interface (should show up in IDE) and a CI check (makes sure building `make GO_TAGS="-tags=opa_no_oci" build` works) to see if everything builds with `GO_TAGS="-tags=opa_no_oci"`.

<!--
Include a short description of WHAT changes were made.
-->

### Notes to assist PR review:

There supposed to be a long term solution for (getting rid of containerd) this but it seems that it was not implemented.

<!--
Here you can add information you think will help the reviewer(s).
-->

### Further comments:

Hope you don't mind me doing a PR - if you want to move this to an issue and discuss - feel free to do so, or tell me to do it :) 

<!--
Here you can include links to additional resources related to the changes, discuss your solution, other approaches you considered etc.
-->
