### PR TITLE
ast+cmd: Allowing bundle to contain calls to unknown Rego functions when inspected

### DIFF
--- a/ast/check.go
+++ b/ast/check.go
@@ -93,6 +93,8 @@ func (tc *typeChecker) WithInputType(tpe types.Type) *typeChecker {
 	return tc
 }
 
+// WithAllowUndefinedFunctionCalls sets the type checker to allow references to undefined functions.
+// Additionally, the 'CheckUndefinedFuncs' and 'CheckSafetyRuleBodies' compiler stages are skipped.
 func (tc *typeChecker) WithAllowUndefinedFunctionCalls(allow bool) *typeChecker {
 	tc.allowUndefinedFuncs = allow
 	return tc

--- a/ast/compile.go
+++ b/ast/compile.go
@@ -1585,7 +1585,7 @@ func (c *Compiler) compile() {
 			}
 		}
 
-		if c.allowUndefinedFuncCalls && s.name == "CheckUndefinedFuncs" {
+		if c.allowUndefinedFuncCalls && (s.name == "CheckUndefinedFuncs" || s.name == "CheckSafetyRuleBodies") {
 			continue
 		}
 


### PR DESCRIPTION
Fixes: #6591