### PR TITLE
aws: support for Unsigned Payload or provided content sha256 in AWS signing (#6581)

### DIFF
--- a/internal/providers/aws/signing_v4a.go
+++ b/internal/providers/aws/signing_v4a.go
@@ -32,6 +32,7 @@ const (
 	amzSecurityTokenKey = v4Internal.AmzSecurityTokenKey
 	amzDateKey          = v4Internal.AmzDateKey
 	authorizationHeader = "Authorization"
+	amzContentSha256Key = "x-amz-content-sha256"
 
 	signingAlgorithm = "AWS4-ECDSA-P256-SHA256"
 
@@ -192,7 +193,7 @@ func (s *httpSigner) Build() (signedRequest, error) {
 
 	// seemingly required by S3/MRAP -- 403 Forbidden otherwise
 	headers.Set("host", req.URL.Host)
-	headers.Set("x-amz-content-sha256", s.PayloadHash)
+	headers.Set(amzContentSha256Key, s.PayloadHash)
 
 	s.setRequiredSigningFields(headers, query)
 
@@ -381,8 +382,7 @@ type signedRequest struct {
 
 // SignV4a returns a map[string][]string of headers, including an added AWS V4a signature based on the config/credentials provided.
 func SignV4a(headers map[string][]string, method string, theURL *url.URL, body []byte, service string, awsCreds Credentials, theTime time.Time) map[string][]string {
-	bodyHexHash := fmt.Sprintf("%x", sha256.Sum256(body))
-
+	contentSha256 := getContentHash(false, body)
 	key, err := retrievePrivateKey(awsCreds)
 	if err != nil {
 		return map[string][]string{}
@@ -394,7 +394,7 @@ func SignV4a(headers map[string][]string, method string, theURL *url.URL, body [
 
 	signer := &httpSigner{
 		Request:     req,
-		PayloadHash: bodyHexHash,
+		PayloadHash: contentSha256,
 		ServiceName: service,
 		RegionSet:   []string{"*"},
 		Credentials: key,

--- a/test/cases/testdata/providers-aws/aws-sign_req-errors.yaml
+++ b/test/cases/testdata/providers-aws/aws-sign_req-errors.yaml
@@ -147,3 +147,29 @@ cases:
     want_error_code: eval_type_error
     want_error: "providers.aws.sign_req: operand 3 could not convert time_ns value into a unix timestamp"
     strict_error: true
+  # boolean type error for disable_payload_signing key
+  - data:
+    modules:
+      - |
+        package test
+        req := {"method": "get", "url": "https://example.com", "headers": {"foo": "bar"}}
+        aws_config := {"aws_access_key": "MYAWSACCESSKEYGOESHERE", "aws_secret_access_key": "MYAWSSECRETACCESSKEYGOESHERE", "aws_service": "s3", "aws_region": "us-east-1", "disable_payload_signing": "false"}
+        expected := {
+          "headers": {
+            "Authorization": "AWS4-HMAC-SHA256 Credential=MYAWSACCESSKEYGOESHERE/20151228/us-east-1/s3/aws4_request,SignedHeaders=foo;host;x-amz-content-sha256;x-amz-date,Signature=8f1dc7c9b9978356a0d0989fd26a95307f4f8a4aa264d8220647b7097d839952",
+            "foo": "bar",
+            "host": "example.com",
+            "x-amz-content-sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            "x-amz-date": "20151228T140825Z"
+          },
+          "method": "get",
+          "url": "https://example.com"
+        }
+        p {
+            providers.aws.sign_req(req, aws_config, 1451311705000000000) == expected
+        }
+    note: providers-aws-sign_req/failure-simple-bad-type-payload-signing-config
+    query: data.test.p = x
+    want_error_code: eval_type_error
+    want_error: "providers.aws.sign_req: operand 2 invalid value for 'disable_payload_signing' in AWS config"
+    strict_error: true

--- a/test/cases/testdata/providers-aws/aws-sign_req.yaml
+++ b/test/cases/testdata/providers-aws/aws-sign_req.yaml
@@ -160,3 +160,151 @@ cases:
     query: data.test.p = x
     want_result:
       - x: true
+  - data:
+    modules:
+      - |
+        package test
+        req := {"method": "get", "url": "https://example.com", "headers": {"foo": "bar"}}
+        aws_config := {"aws_access_key": "MYAWSACCESSKEYGOESHERE", "aws_secret_access_key": "MYAWSSECRETACCESSKEYGOESHERE", "aws_service": "s3", "aws_region": "us-east-1", "disable_payload_signing": false}
+        expected := {
+          "headers": {
+            "Authorization": "AWS4-HMAC-SHA256 Credential=MYAWSACCESSKEYGOESHERE/20151228/us-east-1/s3/aws4_request,SignedHeaders=foo;host;x-amz-content-sha256;x-amz-date,Signature=8f1dc7c9b9978356a0d0989fd26a95307f4f8a4aa264d8220647b7097d839952",
+            "foo": "bar",
+            "host": "example.com",
+            "x-amz-content-sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            "x-amz-date": "20151228T140825Z"
+          },
+          "method": "get",
+          "url": "https://example.com"
+        }
+        p {
+            providers.aws.sign_req(req, aws_config, 1451311705000000000) == expected
+        }
+    note: providers-aws-sign_req/success-simple-with-headers-no-body-with-payload-signing
+    query: data.test.p = x
+    want_result:
+      - x: true
+  - data:
+    modules:
+      - |
+        package test
+        req := {"method": "get", "url": "https://example.com", "headers": {"foo": "bar"}}
+        aws_config := {"aws_access_key": "MYAWSACCESSKEYGOESHERE", "aws_secret_access_key": "MYAWSSECRETACCESSKEYGOESHERE", "aws_service": "s3", "aws_region": "us-east-1", "disable_payload_signing": true}
+        expected := {
+          "headers": {
+            "Authorization": "AWS4-HMAC-SHA256 Credential=MYAWSACCESSKEYGOESHERE/20151228/us-east-1/s3/aws4_request,SignedHeaders=foo;host;x-amz-content-sha256;x-amz-date,Signature=c6e6db654e92172f71e18c714c123711de069ac6fd7df1348e5b28fd05532028",
+            "foo": "bar",
+            "host": "example.com",
+            "x-amz-content-sha256": "UNSIGNED-PAYLOAD",
+            "x-amz-date": "20151228T140825Z"
+          },
+          "method": "get",
+          "url": "https://example.com"
+        }
+        p {
+            providers.aws.sign_req(req, aws_config, 1451311705000000000) == expected
+        }
+    note: providers-aws-sign_req/success-simple-with-headers-no-body-no-payload-signing
+    query: data.test.p = x
+    want_result:
+      - x: true
+  - data:
+    modules:
+      - |
+        package test
+        req := {"method": "get", "url": "https://example.com", "headers": {"foo": "bar"}, "body": {"example": {1, 2, 3, 4}}}
+        aws_config := {"aws_access_key": "MYAWSACCESSKEYGOESHERE", "aws_secret_access_key": "MYAWSSECRETACCESSKEYGOESHERE", "aws_service": "s3", "aws_region": "us-east-1", "disable_payload_signing": false}
+        expected := {
+          "body": {"example": {1, 2, 3, 4}},
+          "headers": {
+            "Authorization": "AWS4-HMAC-SHA256 Credential=MYAWSACCESSKEYGOESHERE/20151228/us-east-1/s3/aws4_request,SignedHeaders=foo;host;x-amz-content-sha256;x-amz-date,Signature=f6703a8727ec0a32f81b225a002f622e511e8a7d2ca8914894fcbb7a71d8d9d8",
+            "foo": "bar",
+            "host": "example.com",
+            "x-amz-content-sha256": "bacff6243c850423883052ac3c336fd645994442933408dfd3f9e858e69bda07",
+            "x-amz-date": "20151228T140825Z"
+          },
+          "method": "get",
+          "url": "https://example.com"
+        }
+        p {
+            providers.aws.sign_req(req, aws_config, 1451311705000000000) == expected
+        }
+    note: providers-aws-sign_req/success-simple-with-headers-with-body-with-payload-signing
+    query: data.test.p = x
+    want_result:
+      - x: true
+  - data:
+    modules:
+      - |
+        package test
+        req := {"method": "get", "url": "https://example.com", "headers": {"foo": "bar"}, "body": {"example": {1, 2, 3, 4}}}
+        aws_config := {"aws_access_key": "MYAWSACCESSKEYGOESHERE", "aws_secret_access_key": "MYAWSSECRETACCESSKEYGOESHERE", "aws_service": "s3", "aws_region": "us-east-1", "disable_payload_signing": true}
+        expected := {
+          "body": {"example": {1, 2, 3, 4}},
+          "headers": {
+            "Authorization": "AWS4-HMAC-SHA256 Credential=MYAWSACCESSKEYGOESHERE/20151228/us-east-1/s3/aws4_request,SignedHeaders=foo;host;x-amz-content-sha256;x-amz-date,Signature=c6e6db654e92172f71e18c714c123711de069ac6fd7df1348e5b28fd05532028",
+            "foo": "bar",
+            "host": "example.com",
+            "x-amz-content-sha256": "UNSIGNED-PAYLOAD",
+            "x-amz-date": "20151228T140825Z"
+          },
+          "method": "get",
+          "url": "https://example.com"
+        }
+        p {
+            providers.aws.sign_req(req, aws_config, 1451311705000000000) == expected
+        }
+    note: providers-aws-sign_req/success-simple-with-headers-with-body-no-payload-signing
+    query: data.test.p = x
+    want_result:
+      - x: true
+  - data:
+    modules:
+      - |
+        package test
+        req := {"method": "get", "url": "https://example.com", "headers": {"foo": "bar", "x-amz-content-sha256": "existing-value"}, "body": {"example": {1, 2, 3, 4}}}
+        aws_config := {"aws_access_key": "MYAWSACCESSKEYGOESHERE", "aws_secret_access_key": "MYAWSSECRETACCESSKEYGOESHERE", "aws_service": "s3", "aws_region": "us-east-1", "disable_payload_signing": false}
+        expected := {
+          "body": {"example": {1, 2, 3, 4}},
+          "headers": {
+            "Authorization": "AWS4-HMAC-SHA256 Credential=MYAWSACCESSKEYGOESHERE/20151228/us-east-1/s3/aws4_request,SignedHeaders=foo;host;x-amz-content-sha256;x-amz-date,Signature=42bcac7fc6d170e09be72fdf38b62e59361265bc59d5f9156f0d6faf889e98ba",
+            "foo": "bar",
+            "host": "example.com",
+            "x-amz-content-sha256": "bacff6243c850423883052ac3c336fd645994442933408dfd3f9e858e69bda07",
+            "x-amz-date": "20151228T140825Z"
+          },
+          "method": "get",
+          "url": "https://example.com"
+        }
+        p {
+            providers.aws.sign_req(req, aws_config, 1451311705000000000) == expected
+        }
+    note: providers-aws-sign_req/success-simple-with-existing-sha-header-with-body-with-payload-signing
+    query: data.test.p = x
+    want_result:
+      - x: true
+  - data:
+    modules:
+      - |
+        package test
+        req := {"method": "get", "url": "https://example.com", "headers": {"foo": "bar", "x-amz-content-sha256": "existing-value"}, "body": {"example": {1, 2, 3, 4}}}
+        aws_config := {"aws_access_key": "MYAWSACCESSKEYGOESHERE", "aws_secret_access_key": "MYAWSSECRETACCESSKEYGOESHERE", "aws_service": "s3", "aws_region": "us-east-1", "disable_payload_signing": true}
+        expected := {
+          "body": {"example": {1, 2, 3, 4}},
+          "headers": {
+            "Authorization": "AWS4-HMAC-SHA256 Credential=MYAWSACCESSKEYGOESHERE/20151228/us-east-1/s3/aws4_request,SignedHeaders=foo;host;x-amz-content-sha256;x-amz-date,Signature=edcd3ca3fd3acdfbcecad1a1d8062dbc6562d90352e294c336f9727397f9c383",
+            "foo": "bar",
+            "host": "example.com",
+            "x-amz-content-sha256": "UNSIGNED-PAYLOAD",
+            "x-amz-date": "20151228T140825Z"
+          },
+          "method": "get",
+          "url": "https://example.com"
+        }
+        p {
+            providers.aws.sign_req(req, aws_config, 1451311705000000000) == expected
+        }
+    note: providers-aws-sign_req/success-simple-with-existing-sha-header-with-body-no-payload-signing
+    query: data.test.p = x
+    want_result:
+      - x: true

--- a/topdown/providers.go
+++ b/topdown/providers.go
@@ -173,7 +173,19 @@ func builtinAWSSigV4SignReq(ctx BuiltinContext, operands []*ast.Term, iter func(
 
 	// Sign the request object's headers, and reconstruct the headers map.
 	headersMap := objectToMap(headers)
-	authHeader, awsHeadersMap := aws.SignV4(headersMap, method, theURL, body, service, awsCreds, signingTimestamp)
+
+	// if payload signing config is set, pass it down to the signing method
+	disablePayloadSigning := false
+	t := awsConfigObj.Get(ast.StringTerm("disable_payload_signing"))
+	if t != nil {
+		if v, ok := t.Value.(ast.Boolean); ok {
+			disablePayloadSigning = bool(v)
+		} else {
+			return builtins.NewOperandErr(2, "invalid value for 'disable_payload_signing' in AWS config")
+		}
+	}
+
+	authHeader, awsHeadersMap := aws.SignV4(headersMap, method, theURL, body, service, awsCreds, signingTimestamp, disablePayloadSigning)
 	signedHeadersObj := ast.NewObject()
 	// Restore original headers
 	for k, v := range headersMap {


### PR DESCRIPTION
To support uses cases where OPA is used for signing s3 requests whose payload is not known upfront or payload is big enough (big file upload) to be sent over wire, this PR adds support for unsigned payloads.

AWS signer has configurable option to use unsigned payload where the x-amz-content-sha256 is set to "UNSIGNED-PAYLOAD" and is included as part of signing process. This PR provides an option for unsigned payload if aws_config.disable_payload_signing is set to true. If payload signing is disabled, SignV4 method will not compute the content sha from the request body but instead use "UNSIGNED-PAYLOAD" string literal for x-amz-content-sha256 header during signature computation.

References:
https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-auth-using-authorization-header.html

Solves #6581 