### PR TITLE
format: Preserve brackets around set union operation

### DIFF
--- a/format/testfiles/test.rego
+++ b/format/testfiles/test.rego
@@ -195,6 +195,28 @@ declare1 := 1
 
 declare2 := 2 { false }
 
+declare3 := {1,2,3}
+declare4 := {4,5,6}
+
+union_object := {"response": (declare3|declare4)}
+
+union_set := {(declare3|declare4)}
+
+union_list := [(declare3|declare4)]
+
+union_set_2 := {(((declare3|declare4)))}
+
+union_object_multi_line := {"response": (
+  declare3 | declare4
+)}
+
+union_object_key := {(declare3|declare4): "foo"}
+
+union_object_key_multi_line := {(declare3|
+declare4):
+"foo"
+}
+
 # more comments!
 # more comments!
 # more comments!

--- a/format/testfiles/test.rego.formatted
+++ b/format/testfiles/test.rego.formatted
@@ -219,6 +219,24 @@ declare2 := 2 {
 	false
 }
 
+declare3 := {1, 2, 3}
+
+declare4 := {4, 5, 6}
+
+union_object := {"response": (declare3 | declare4)}
+
+union_set := {(declare3 | declare4)}
+
+union_list := [(declare3 | declare4)]
+
+union_set_2 := {(declare3 | declare4)}
+
+union_object_multi_line := {"response": (declare3 | declare4)}
+
+union_object_key := {(declare3 | declare4): "foo"}
+
+union_object_key_multi_line := {(declare3 | declare4): "foo"}
+
 # more comments!
 # more comments!
 # more comments!


### PR DESCRIPTION
This fix preserves the brackets around set union operations when the inflix operator (`|`) is used. Previously the formatter would remove the brackets around the union operation, interpreting the expression as a comprehesion which would yeild unexpected results.

Fixes: #6588