### PR TITLE
test/e2e: Fix missing import in benchmark.

### DIFF
--- a/test/e2e/logs/remote/remote_decision_logger_benchmark_test.go
+++ b/test/e2e/logs/remote/remote_decision_logger_benchmark_test.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"testing"


### PR DESCRIPTION
This PR fixes a tiny issue: a missing import in `test/e2e/logs/remote/remote_decision_logger_benchmark_test.go`, which comes up as part of the `make perf-noisy` makefile target.

The missing import shows up in VS Code like this:

![image](https://github.com/open-policy-agent/opa/assets/1906841/75b9c281-2197-4235-834d-8ed37688d709)

And appears in the makefile run like so:
```sh-session
$ make perf-noisy 
make[1]: Entering directory '/home/.../opa-conradp/wasm'
make: '_obj/opa.wasm' is up to date.
make: '_obj/callgraph.csv' is up to date.
make[1]: Leaving directory '/home/.../opa-conradp/wasm'
cp wasm/_obj/opa.wasm internal/compiler/wasm/opa/opa.wasm
cp wasm/_obj/callgraph.csv internal/compiler/wasm/opa/callgraph.csv
CGO_ENABLED=1 GOFLAGS=""-buildmode=exe"" go generate
CGO_ENABLED=1 GOFLAGS=""-buildmode=exe"" go test -tags=opa_wasm,slow,noisy -timeout 30m -run=- -bench=. -benchmem ./...
# github.com/open-policy-agent/opa/test/e2e/logs/remote [github.com/open-policy-agent/opa/test/e2e/logs/remote.test]
test/e2e/logs/remote/remote_decision_logger_benchmark_test.go:116:16: undefined: io
goos: linux
goarch: amd64
pkg: github.com/open-policy-agent/opa/ast
cpu: Intel(R) Core(TM) i7-8650U CPU @ 1.90GHz
BenchmarkRewriteDynamics/1-8                   	 4596518	       255.7 ns/op	      24 B/op	       1 allocs/op
BenchmarkRewriteDynamics/10-8                  	  478528	      2531 ns/op	     240 B/op	      10 allocs/op
BenchmarkRewriteDynamics/100-8                 	   39615	     28185 ns/op	    2400 B/op	     100 allocs/op
BenchmarkRewriteDynamics/1000-8                	    3434	    327735 ns/op	   24000 B/op	    1000 allocs/op
...
```