### PR TITLE
cmd/exec: Add timeout flag to help prevent infinite hangs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### `opa exec` now supports a timeout flag
+
+Previously, `opa exec` could end up in situations [where it might hang forever](https://github.com/open-policy-agent/opa/issues/6613).
+This can be very undesirable behavior in build pipelines and CI systems!
+
+`opa exec` now supports a timeout flag, identically to how `opa eval` does. Example:
+
+    opa exec --decision /test/p --timeout 10s /dev/null
+
 ## 0.62.1
 
 This is a security fix release for the fixes published in [Golang 1.22.1](https://groups.google.com/g/golang-announce/c/5pwGVUPoMbg).

--- a/cmd/internal/exec/exec.go
+++ b/cmd/internal/exec/exec.go
@@ -31,6 +31,7 @@ type Params struct {
 	Fail                bool           // exits with non-zero exit code on undefined policy decision or empty policy decision result or other errors
 	FailDefined         bool           // exits with non-zero exit code on 'not undefined policy decisiondefined' or 'not empty policy decision result' or other errors
 	FailNonEmpty        bool           // exits with non-zero exit code on non-empty set (array) results
+	Timeout             time.Duration  // timeout to prevent infinite hangs. If set to 0, the command will never time out
 	V1Compatible        bool           // use OPA 1.0 compatibility mode
 	Logger              logging.Logger // Logger override. If set to nil, the default logger is used.
 }

--- a/docs/content/cli.md
+++ b/docs/content/cli.md
@@ -618,6 +618,7 @@ opa exec <path> [<path> [...]] [flags]
       --log-timestamp-format string          set log timestamp format (OPA_LOG_TIMESTAMP_FORMAT environment variable)
       --set stringArray                      override config values on the command line (use commas to specify multiple values)
       --set-file stringArray                 override config values with files on the command line (use commas to specify multiple values)
+      --timeout duration                     set exec timeout with a Go-style duration, such as '5m 30s'. (default unlimited)
       --v1-compatible                        opt-in to OPA features and behaviors that will be enabled by default in a future OPA v1.0 release
 ```
 


### PR DESCRIPTION
This PR adds a `--timeout` duration flag to the `opa exec` CLI command. This flag helps out in use cases such as CI, where stalling indefinitely is undesirable behavior.

Fixes: #6613

Also included:
 - Unit test under `cmd/exec_test.go`
 - Release notes section under the `## Unreleased` banner (so the CHANGELOG automation *should* hide it by default, until someone moves the text under the next release header).
 - CLI docs updated.