### PR TITLE
compile/compile: Fix panic from CLI + metadata entrypoint overlaps.

### DIFF
--- a/compile/compile_test.go
+++ b/compile/compile_test.go
@@ -978,9 +978,7 @@ update {
 
 func modulesToString(modules []bundle.ModuleFile) string {
 	var buf bytes.Buffer
-	//result := make([]string, len(modules))
 	for i, m := range modules {
-		//result[i] = m.Parsed.String()
 		buf.WriteString(strconv.Itoa(i))
 		buf.WriteString(":\n")
 		buf.WriteString(string(m.Raw))
@@ -1621,6 +1619,28 @@ q[3]
 			wantEntrypoints: map[string]struct{}{
 				"test/nested": {},
 				"test/p":      {},
+			},
+		},
+		{
+			note:        "overlapping manual entrypoints + annotation entrypoints",
+			entrypoints: []string{"test/p"},
+			modules: map[string]string{
+				"test.rego": `
+package test
+
+# METADATA
+# entrypoint: true
+p {
+	q[input.x]
+}
+
+q[1]
+q[2]
+q[3]
+				`,
+			},
+			wantEntrypoints: map[string]struct{}{
+				"test/p": {},
 			},
 		},
 		{


### PR DESCRIPTION
This PR fixes a panic that could occur when `opa build` was provided an entrypoint from both a CLI flag, and via entrypoint metadata annotation.

The fix is simple: deduplicate the slice of entrypoint refs that the compiler uses, before compiling WASM or Plan targets.

Fixes: #6661

Thanks to @dxh9845 for reporting this one, and for putting together the initial repro test case!