### PR TITLE
Expose manager options

### DIFF
--- a/sdk/opa.go
+++ b/sdk/opa.go
@@ -48,6 +48,7 @@ type OPA struct {
 	hooks        hooks.Hooks
 	config       []byte
 	v1Compatible bool
+	managerOpts  []func(*plugins.Manager)
 }
 
 type state struct {
@@ -88,6 +89,7 @@ func New(ctx context.Context, opts Options) (*OPA, error) {
 	opa.console = opts.ConsoleLogger
 	opa.plugins = opts.Plugins
 	opa.v1Compatible = opts.V1Compatible
+	opa.managerOpts = opts.ManagerOpts
 
 	return opa, opa.configure(ctx, opa.config, opts.Ready, opts.block)
 }
@@ -141,6 +143,7 @@ func (opa *OPA) configure(ctx context.Context, bs []byte, ready chan struct{}, b
 	if opa.v1Compatible {
 		opts = append(opts, plugins.WithParserOptions(ast.ParserOptions{RegoVersion: ast.RegoV1}))
 	}
+	opts = append(opts, opa.managerOpts...)
 	manager, err := plugins.New(
 		bs,
 		opa.id,

--- a/sdk/options.go
+++ b/sdk/options.go
@@ -57,6 +57,11 @@ type Options struct {
 
 	V1Compatible bool
 
+	// ManagerOpts allows customization of the plugin manager.
+	// The given options get appended to the list of options already provided by the SDK and eventually
+	// overriding them.
+	ManagerOpts []func(manager *plugins.Manager)
+
 	config []byte
 	block  bool
 }


### PR DESCRIPTION
This commit adds the possibility to configure the plugin manager with custom options.

It will allow SDK users to override the options already provided by the SDK and to futher customize it with configurations that were not previously available. This is an advanced feature as it requires some knowledge about the inner workings of OPA.

One use case for this is to provide a prometheus registerer and have the status plugin metrics available for the client to use it in a /metrics endpoint, for example.

resolves #6662

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->

### Why the changes in this PR are needed?

Currently there is no way to customize the options of the plugin manager. As an example, if I use the OPA SDK in a golang 
http server, I cannot export the prometheus metrics provided by the status plugin in a `/metrics` endpoint.

### What are the changes in this PR?

I have exposed the manager options in the SDK Options struct and used it during initialization of the SDK.

### Notes to assist PR review:


### Further comments:

