### PR TITLE
server: Retry cert reloading & test case step

### DIFF
--- a/server/certs.go
+++ b/server/certs.go
@@ -170,12 +170,26 @@ func (s *Server) certLoopNotify(logger logging.Logger) Loop {
 		for evt := range watcher.Events {
 			removalMask := fsnotify.Remove | fsnotify.Rename
 			mask := fsnotify.Create | fsnotify.Write | removalMask
-			if (evt.Op & mask) != 0 {
+			if (evt.Op & mask) == 0 {
+				continue
+			}
+
+			// retry logic here handles cases where the files are still being written to as events are triggered.
+			retries := 0
+			for {
 				err = s.reloadTLSConfig(s.manager.Logger())
-				if err != nil {
-					logger.Error("failed to reload TLS config: %s", err)
+				if err == nil {
+					logger.Info("TLS config reloaded after retrying", retries)
+					break
 				}
-				logger.Info("TLS config reloaded")
+
+				retries++
+				if retries >= 5 {
+					logger.Error("Failed to reload TLS config after retrying: %s", err)
+					break
+				}
+
+				time.Sleep(100 * time.Millisecond)
 			}
 		}
 

--- a/server/certs.go
+++ b/server/certs.go
@@ -179,7 +179,7 @@ func (s *Server) certLoopNotify(logger logging.Logger) Loop {
 			for {
 				err = s.reloadTLSConfig(s.manager.Logger())
 				if err == nil {
-					logger.Info("TLS config reloaded after retrying", retries)
+					logger.Info("TLS config reloaded")
 					break
 				}
 


### PR DESCRIPTION


### Why the changes in this PR are needed?

In workflow runs like this:
https://github.com/open-policy-agent/opa/actions/runs/7803493290/job/21283458848#step:3:317

We can see two problems, the test flakes and there is a lot of output. This PR is meant to address them.

### What are the changes in this PR?

**First**, the test failed with this message:

```
expected unknown certificate authority error but got: Get "https://127.0.0.1:38699/v1/data": write tcp 127.0.0.1:52786->127.0.0.1:38699: write: connection reset by peer
```

Now this step in the test is retried like the other steps in the test since it can fail too.

**Second**, the error `failed to reload TLS config` appears many times in the logs for that test. This issue is caused by the server attempting to read the new cert, key, and CA contents from disk while they are still being written to. This PR also introduces a 100ms pause between upto 5 attempts to reload the config for any given change to the state on disk. This should mean that the error is seen only when is is actually an issue and the reload has failed after a reasonable time. In most cases, running locally, the reload happens without error on the first run.

