### PR TITLE
fixes #6206; using cuboid rather than cube

### DIFF
--- a/docs/content/policy-language.md
+++ b/docs/content/policy-language.md
@@ -311,17 +311,17 @@ A simple example is a regex to match a valid Rego variable. With a regular strin
 
 Composite values define collections. In simple cases, composite values can be treated as constants like [Scalar Values](#scalar-values):
 
-```live:eg/cube:module
-cube := {"width": 3, "height": 4, "depth": 5}
+```live:eg/cuboid:module
+cuboid := {"width": 3, "height": 4, "depth": 5}
 ```
 
 The result:
 
-```live:eg/cube:query:merge_down
-cube.width
+```live:eg/cuboid:query:merge_down
+cuboid.width
 ```
 
-```live:eg/cube:output
+```live:eg/cuboid:output
 ```
 
 Composite values can also be defined in terms of [Variables](#variables) or [References](#references). For example:
@@ -382,11 +382,11 @@ collections of unique values. Just like other composite values, sets can be
 defined in terms of scalars, variables, references, and other composite values.
 For example:
 
-```live:eg/cube/sets:query:merge_down
-s := {cube.width, cube.height, cube.depth}
+```live:eg/cuboid/sets:query:merge_down
+s := {cuboid.width, cuboid.height, cuboid.depth}
 ```
 
-```live:eg/cube/sets:output
+```live:eg/cuboid/sets:output
 ```
 
 > Set documents are collections of values without keys. OPA represents set


### PR DESCRIPTION
<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->

### Why the changes in this PR are needed?

<!--
Include a short description of WHY the changes were made.
-->
The change involves using a cuboid rather than a cube to explain concepts of sets and composite values in policy-language section of documentation.

### What are the changes in this PR?

<!--
Include a short description of WHAT changes were made.
-->
The changes are in a single file i.e. policy-language.md

### Notes to assist PR review:

<!--
Here you can add information you think will help the reviewer(s).
—>
NA

### Further comments:

<!--
Here you can include links to additional resources related to the changes, discuss your solution, other approaches you considered etc.
-->
