### PR TITLE
logs: add ability to enrich decision logs

### DIFF
--- a/plugins/logs/ctx.go
+++ b/plugins/logs/ctx.go
@@ -1,0 +1,61 @@
+package logs
+
+import (
+	"context"
+	"sync"
+)
+
+type ctxKey struct{}
+
+type extra struct {
+	mu sync.RWMutex
+	m  map[string]interface{}
+}
+
+func (e *extra) Set(key string, val interface{}) {
+	e.mu.Lock()
+	e.m[key] = val
+	e.mu.Unlock()
+}
+
+func (e *extra) extra() map[string]interface{} {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	if len(e.m) == 0 {
+		return nil
+	}
+
+	c := make(map[string]interface{}, len(e.m))
+	for k, v := range e.m {
+		c[k] = v
+	}
+
+	return c
+}
+
+func WithContext(ctx context.Context) context.Context {
+	if _, ok := ctx.Value(ctxKey{}).(*extra); ok {
+		return ctx
+	}
+
+	return context.WithValue(ctx, ctxKey{}, &extra{
+		m: make(map[string]interface{}),
+	})
+}
+
+func SetExtra(ctx context.Context, key string, val interface{}) {
+	e, ok := ctx.Value(ctxKey{}).(*extra)
+	if !ok {
+		return
+	}
+
+	e.Set(key, val)
+}
+
+func getExtra(ctx context.Context) map[string]interface{} {
+	e, ok := ctx.Value(ctxKey{}).(*extra)
+	if !ok {
+		return nil
+	}
+	return e.extra()
+}

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"io"
 	mr "math/rand"
+	"net/http"
 	"net/url"
 	"os"
 	"os/signal"
@@ -364,6 +365,11 @@ func NewRuntime(ctx context.Context, params Params) (*Runtime, error) {
 
 	if params.Router == nil {
 		params.Router = mux.NewRouter()
+		params.Router.Use(func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+				next.ServeHTTP(rw, r.WithContext(logs.WithContext(r.Context())))
+			})
+		})
 	}
 
 	metricsConfig, parseConfigErr := extractMetricsConfig(config, params)


### PR DESCRIPTION
With the ability to add arbitrary data to decision logs, we give OPA users opportunity to enrich logs with any context or dynamic data fetched from custom built-ins.

Also, we provide a building block to make it easier for internal built-ins to communicate with the decision log plugin.

This data gets appended to an `extra` key in the decision log, that may contain any json data.

### Why the changes in this PR are needed?

In some situations it is desired to enrich decision logs with dynamic external data, without bloating policies with virtual documents only to get them appended to the logs.

### What are the changes in this PR?

I am providing an API to append extra arbitrary data to decision logs, which may be used from built-in implementations or from any internal code of OPA.

### Notes to assist PR review:

This PR is not totally ready, there still a need to add docs and integrate the solution into the SDK. I am openning the PR so that we may further discuss the implementation and come to a common understanding if this behavior is really desired to be in the OPA public go API.

### Further comments:

Nothing to add.
