### PR TITLE
Relax configuration check when Discovery is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ The `go` stanza of OPA's `go.mod` had become out of sync: Projects importing OPA
 This was introduced with v0.63.0, but the main branch's `go.mod` still claimed to be a `go 1.20` compatible.
 Now, it states the true state of affairs: OPA, used as Go dependency, requires at least Go 1.21, and thus works with all officially supported Go versions (1.21.x and 1.22.x).
 
+#### Breaking Change
+
+##### Bootstrap configuration overrides Discovered configuration
+
+Previously if Discovery was enabled, other features like bundle downloading and status reporting could not be configured manually.
+The reason for this was to prevent OPAs being deployed that could not be controlled through discovery. It's possible that
+the system serving the discovered config is unaware of all options locally available in OPA. Hence, we relax the configuration
+check when discovery is enabled so that the bootstrap configuration can contain plugin configurations. In case of conflicts,
+the bootstrap configuration for plugins wins. These local configuration overrides from the bootstrap configuration are included
+in the Status API messages so that management systems can get visibility into the local overrides.
+
+**In general, the bootstrap configuration overrides the discovered configuration.** Previously this was not the case for all
+configuration fields. For example, if the discovered configuration changes the `labels` section, only labels that are
+additional compared to the bootstrap configuration are used, all other changes are ignored. This implies labels in the
+bootstrap configuration override those in the discovered configuration. But for fields such as `default_decision`, `default_authorization_decision`,
+`nd_builtin_cache`, the discovered configuration would override the bootstrap configuration. Now the behavior is more consistent
+for the entire configuration and helps to avoid accidental configuration errors.
+
 ## 0.63.0
 
 This release contains a mix of features, performance improvements, and bugfixes.

--- a/docs/content/management-discovery.md
+++ b/docs/content/management-discovery.md
@@ -24,9 +24,9 @@ ways to structure the discovery bundle:
 > option.
 
 If discovery is enabled, other features like bundle downloading and status
-reporting **cannot** be configured manually. Similarly, discovered configuration
-cannot override the original discovery settings in the configuration file that
-OPA was booted with.
+reporting **can** be configured manually. In case of conflicts, the bootstrap configuration
+for plugins would override the discovered configuration. **In general, the bootstrap configuration
+overrides the discovered configuration.**
 
 See the [Configuration Reference](../configuration) for configuration details.
 

--- a/plugins/logs/plugin.go
+++ b/plugins/logs/plugin.go
@@ -559,6 +559,11 @@ func (p *Plugin) Stop(ctx context.Context) {
 	p.manager.UpdatePluginStatus(Name, &plugins.Status{State: plugins.StateNotReady})
 }
 
+// Config returns the plugin's current configuration
+func (p *Plugin) Config() *Config {
+	return &p.config
+}
+
 func (p *Plugin) flushDecisions(ctx context.Context) {
 	p.logger.Info("Flushing decision logs.")
 

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -431,7 +431,13 @@ func NewRuntime(ctx context.Context, params Params) (*Runtime, error) {
 		}
 	}
 
-	disco, err := discovery.New(manager, discovery.Factories(registeredPlugins), discovery.Metrics(metrics))
+	var bootConfig map[string]interface{}
+	err = util.Unmarshal(config, &bootConfig)
+	if err != nil {
+		return nil, fmt.Errorf("config error: %w", err)
+	}
+
+	disco, err := discovery.New(manager, discovery.Factories(registeredPlugins), discovery.Metrics(metrics), discovery.BootConfig(bootConfig))
 	if err != nil {
 		return nil, fmt.Errorf("config error: %w", err)
 	}

--- a/sdk/opa.go
+++ b/sdk/opa.go
@@ -32,6 +32,7 @@ import (
 	"github.com/open-policy-agent/opa/topdown/builtins"
 	"github.com/open-policy-agent/opa/topdown/cache"
 	"github.com/open-policy-agent/opa/topdown/print"
+	"github.com/open-policy-agent/opa/util"
 	"github.com/open-policy-agent/opa/version"
 )
 
@@ -183,9 +184,16 @@ func (opa *OPA) configure(ctx context.Context, bs []byte, ready chan struct{}, b
 		close(ready)
 	})
 
+	var bootConfig map[string]interface{}
+	err = util.Unmarshal(opa.config, &bootConfig)
+	if err != nil {
+		return err
+	}
+
 	d, err := discovery.New(manager,
 		discovery.Factories(opa.plugins),
 		discovery.Hooks(opa.hooks),
+		discovery.BootConfig(bootConfig),
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
Previously if Discovery was enabled, other features like bundle downloading and status reporting could not be configured manually. The reason for this was to prevent OPAs being deployed that could not be controlled through discovery. It's possible that the system serving the discovered config is unaware of all options locally available in OPA. Hence, we relax the configuration check when discovery is enabled so that the bootstrap configuration can contain plugin configurations. In case of conflicts, the bootstrap configuration for plugins wins. These local configuration overrides from the bootstrap configuration are included in the Status API messages so that management systems can get visibility into the local overrides.

**In general, the bootstrap configuration overrides the discovered configuration.** Previously this was not the case for all configuration fields. For example, if the discovered configuration changes the `labels` section, only labels that are additional compared to the bootstrap configuration are used, all other changes are ignored. This implies labels in the bootstrap configuration override those in the discovered configuration. But for fields such as `default_decision`, `default_authorization_decision`, `nd_builtin_cache`, the discovered configuration would override the bootstrap configuration. Now the behavior is more consistent for the entire configuration and helps to avoid accidental configuration errors.

Fixes: #5722