### PR TITLE
build: Update WASM Rego test generation setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -222,7 +222,7 @@ endif
 .PHONY: wasm-rego-test
 wasm-rego-test: generate
 ifeq ($(DOCKER_RUNNING), 1)
-	GOVERSION=$(GOVERSION) ./build/run-wasm-rego-tests.sh
+	GOVERSION=$(GOVERSION) DOCKER_UID=$(DOCKER_UID) DOCKER_GID=$(DOCKER_GID) ./build/run-wasm-rego-tests.sh
 else
 	@echo "Docker not installed or not running. Skipping Rego-WASM test."
 endif

--- a/build/run-wasm-rego-tests.sh
+++ b/build/run-wasm-rego-tests.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 # This script executes the Wasm Rego test cases. The script uses Docker to run
-# the test generation progam and then again to run the test cases inside of a
-# Node JS container. The script cachces the test generation program build
+# the test generation program and then again to run the test cases inside of a
+# Node JS container. The script caches the test generation program build
 # results in the $PWD/.go directory so that it can be re-used across runs. The
 # volumes from the test generation container are shared with the Node JS
 # container to avoid copying the generated test cases more than necessary.
@@ -10,6 +10,8 @@
 set -ex
 
 GOVERSION=${GOVERSION:?"You must set the GOVERSION environment variable."}
+DOCKER_UID=${DOCKER_UID:-$(id -u)}
+DOCKER_GID=${DOCKER_GID:-$(id -g)}
 ASSETS=${ASSETS:-"$PWD/test/wasm/assets"}
 VERBOSE=${VERBOSE:-"0"}
 TESTGEN_CONTAINER_NAME="opa-wasm-testgen-container"
@@ -44,14 +46,14 @@ function generate_testcases {
     purge_testgen_container
     docker run \
         --name $TESTGEN_CONTAINER_NAME \
-        -u $(id -u):$(id -g) \
+        -u $DOCKER_UID:$DOCKER_GID \
         -v $PWD/.go/bin:/go/bin:Z \
         -v $PWD:/src:z \
         -v $ASSETS:/assets:Z \
         -e GOCACHE=/src/.go/cache \
         -w /src \
         golang:$GOVERSION \
-        sh -c 'make wasm-rego-testgen-install \
+        sh -c 'git config --global --add safe.directory /src && make wasm-rego-testgen-install \
                 && wasm-rego-testgen \
                 --input-dir=/assets \
                 --runner=/src/test/wasm/assets/test.js \


### PR DESCRIPTION
This change updates the WASM Rego test generation docker command to address CVE-2022-24765 in Git which could cause it to execute arbitrary commands.

The error was seen when running the `make wasm-rego-test` target on darwin/arm64.

Fixes: #6703