### PR TITLE
auth: requestToken close response body

### DIFF
--- a/plugins/rest/auth.go
+++ b/plugins/rest/auth.go
@@ -541,6 +541,7 @@ func (ap *oauth2ClientCredentialsAuthPlugin) requestToken(ctx context.Context) (
 	if err != nil {
 		return nil, err
 	}
+	defer response.Body.Close()
 
 	bodyRaw, err := io.ReadAll(response.Body)
 	if err != nil {


### PR DESCRIPTION
### Why the changes in this PR are needed?

We are currently leaking sockets. These are open unclosed sockets from 7 days ago
```
ls -l /proc/1/fd/*|grep socket
lrwx------    1 core     core            64 Apr 16 13:00 /proc/1/fd/3 -> socket:[22595818]
lrwx------    1 core     core            64 Apr 16 13:00 /proc/1/fd/7 -> socket:[94892]
lrwx------    1 core     core            64 Apr 16 13:00 /proc/1/fd/8 -> socket:[22592372]
lrwx------    1 core     core            64 Apr 16 13:00 /proc/1/fd/9 -> socket:[22589424]
```

### What are the changes in this PR?

Close the response body after requesting a token

