### PR TITLE
server: Keep default decision path in-sync with manager's config

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1050,7 +1050,7 @@ func (s *Server) v0QueryPath(w http.ResponseWriter, r *http.Request, urlPath str
 	}
 
 	if useDefaultDecisionPath {
-		urlPath = s.defaultDecisionPath
+		urlPath = s.generateDefaultDecisionPath()
 	}
 
 	logger := s.getDecisionLogger(br)


### PR DESCRIPTION
This change attempts to keep the default decision path used by the server in sync with the one defined on the manager's config. Currently the server only updates the default decision path when it's initialized and when there is a commit on the store. The issue happens when the default decision path is updated via the discovered config. In this case, the manager's config is updated but there could be no store txn. Hence the updated value of default decision path is not taken into account by the server.

Fixes: #6697