### PR TITLE
aws: util always read resp.body

### DIFF
--- a/internal/providers/aws/util.go
+++ b/internal/providers/aws/util.go
@@ -8,7 +8,7 @@ import (
 	"github.com/open-policy-agent/opa/logging"
 )
 
-// DoRequestWithClient is a convenience function to get the body of an http response with
+// DoRequestWithClient is a convenience function to get the body of a http response with
 // appropriate error-handling boilerplate and logging.
 func DoRequestWithClient(req *http.Request, client *http.Client, desc string, logger logging.Logger) ([]byte, error) {
 	resp, err := client.Do(req)
@@ -24,22 +24,18 @@ func DoRequestWithClient(req *http.Request, client *http.Client, desc string, lo
 		"headers": resp.Header,
 	}).Debug("Received response from " + desc + " service.")
 
-	if resp.StatusCode != 200 {
-		if logger.GetLevel() == logging.Debug {
-			body, err := io.ReadAll(resp.Body)
-			if err == nil {
-				logger.Debug("Error response with response body: %s", body)
-			}
-		}
-		// could be 404 for role that's not available, but cover all the bases
-		return nil, errors.New(desc + " HTTP request returned unexpected status: " + resp.Status)
-	}
-
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		// deal with problems reading the body, whatever those might be
 		return nil, errors.New(desc + " HTTP response body could not be read: " + err.Error())
 	}
 
+	if resp.StatusCode != 200 {
+		if logger.GetLevel() == logging.Debug {
+			logger.Debug("Error response with response body: %s", body)
+		}
+		// could be 404 for role that's not available, but cover all the bases
+		return nil, errors.New(desc + " HTTP request returned unexpected status: " + resp.Status)
+	}
 	return body, nil
 }


### PR DESCRIPTION
### Why the changes in this PR are needed?

Currently we only read response body if the response is 200 or if we have debug flag enabled.

As the go package documentation states
```
If the Body is not both read to EOF and closed, the [Client](https://pkg.go.dev/net/http#Client)'s underlying [RoundTripper](https://pkg.go.dev/net/http#RoundTripper) (typically [Transport](https://pkg.go.dev/net/http#Transport)) may not be able to re-use a persistent TCP connection to the server for a subsequent "keep-alive" request.
```
A typical production server that receive errors responses from AWS will be less efficient. 


### What are the changes in this PR?

Always read the response. 

