### PR TITLE
fix: aws util remove if debug clause

### DIFF
--- a/internal/providers/aws/util.go
+++ b/internal/providers/aws/util.go
@@ -31,9 +31,7 @@ func DoRequestWithClient(req *http.Request, client *http.Client, desc string, lo
 	}
 
 	if resp.StatusCode != 200 {
-		if logger.GetLevel() == logging.Debug {
-			logger.Debug("Error response with response body: %s", body)
-		}
+		logger.Debug("Error response with response body: %s", body)
 		// could be 404 for role that's not available, but cover all the bases
 		return nil, errors.New(desc + " HTTP request returned unexpected status: " + resp.Status)
 	}


### PR DESCRIPTION
### Why the changes in this PR are needed?

We don't need to check if debug is enabled, before using logger.debug, its already explicit.

Should have caught this in, https://github.com/open-policy-agent/opa/commit/7c0278eebd2030a334750e29aade091ef9e56cb0


### What are the changes in this PR?

Remove if logger level is debug


