### PR TITLE
Fix OpenTelemetry graceful shutdown.

### DIFF
--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -540,13 +540,6 @@ func (rt *Runtime) Serve(ctx context.Context) error {
 			rt.logger.WithFields(map[string]interface{}{"err": err}).Error("Failed to start OpenTelemetry trace exporter.")
 			return err
 		}
-
-		defer func() {
-			err := rt.traceExporter.Shutdown(ctx)
-			if err != nil {
-				rt.logger.WithFields(map[string]interface{}{"err": err}).Error("Failed to shutdown OpenTelemetry trace exporter gracefully.")
-			}
-		}()
 	}
 
 	rt.server = server.New().
@@ -863,6 +856,13 @@ func (rt *Runtime) gracefulServerShutdown(s *server.Server) error {
 		return err
 	}
 	rt.logger.Info("Server shutdown.")
+
+	if rt.traceExporter != nil {
+		err = rt.traceExporter.Shutdown(ctx)
+		if err != nil {
+			rt.logger.WithFields(map[string]interface{}{"err": err}).Error("Failed to shutdown OpenTelemetry trace exporter gracefully.")
+		}
+	}
 	return nil
 }
 

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -1235,6 +1235,46 @@ func TestServerInitializedWithBundleRegoVersion(t *testing.T) {
 	}
 }
 
+func TestGracefulTracerShutdown(t *testing.T) {
+	fs := map[string]string{
+		"/config.yaml": `{"distributed_tracing": {"type": "grpc"}}`,
+	}
+
+	test.WithTempFS(fs, func(testDirRoot string) {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Millisecond)
+		defer cancel() // NOTE(sr): The timeout will have been reached by the time `done` is closed.
+
+		logger := testLog.New()
+
+		params := NewParams()
+		params.ConfigFile = filepath.Join(testDirRoot, "/config.yaml")
+		params.Addrs = &[]string{"localhost:0"}
+		params.GracefulShutdownPeriod = 1
+		params.Logger = logger
+
+		rt, err := NewRuntime(ctx, params)
+		if err != nil {
+			t.Fatalf("Unexpected error %v", err)
+		}
+
+		if rt.traceExporter == nil {
+			t.Fatal("traceExporter should not be nil")
+		}
+
+		done := make(chan struct{})
+		go func() {
+			rt.StartServer(ctx)
+			close(done)
+		}()
+		<-done
+
+		expected := "Failed to shutdown OpenTelemetry trace exporter gracefully."
+		if strings.Contains(logger.Entries()[0].Message, expected) {
+			t.Fatalf("Expected no output containing: \"%v\"", expected)
+		}
+	})
+}
+
 func TestUrlPathToConfigOverride(t *testing.T) {
 	params := NewParams()
 	params.Paths = []string{"https://www.example.com/bundles/bundle.tar.gz"}


### PR DESCRIPTION
<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->

### Why the changes in this PR are needed?

When running OPA with the distributed tracing option enabled, the OpenTelemetry trace exporter is not gracefully shut down when the server is stopped.

### What are the changes in this PR?

This PR fixes that issues by moving the trace exporter shutdown in the gracefulServerShutdown function.

### Notes to assist PR review:

Picked up from https://github.com/open-policy-agent/opa/pull/6664

### Further comments:

Fixes #6651.
This bug seems to have been introduced by this [commit](https://github.com/open-policy-agent/opa/commit/f063c90275bed61c4381db771162724e191f2d3c).
