### PR TITLE
Fix spelling and grammar of an HTTP

### DIFF
--- a/internal/providers/aws/util.go
+++ b/internal/providers/aws/util.go
@@ -8,7 +8,7 @@ import (
 	"github.com/open-policy-agent/opa/logging"
 )
 
-// DoRequestWithClient is a convenience function to get the body of a http response with
+// DoRequestWithClient is a convenience function to get the body of an HTTP response with
 // appropriate error-handling boilerplate and logging.
 func DoRequestWithClient(req *http.Request, client *http.Client, desc string, logger logging.Logger) ([]byte, error) {
 	resp, err := client.Do(req)


### PR DESCRIPTION
- To decide whether to use an or a: https://www.merriam-webster.com/grammar/is-it-a-or-an
- Spelling of HTTP: https://en.wikipedia.org/wiki/HTTP