### PR TITLE
Add flag to follow symlinks when running opa build

### DIFF
--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -450,6 +450,7 @@ type Reader struct {
 	name                  string
 	persist               bool
 	regoVersion           ast.RegoVersion
+	followSymlinks        bool
 }
 
 // NewReader is deprecated. Use NewCustomReader instead.
@@ -535,6 +536,11 @@ func (r *Reader) WithBundleEtag(etag string) *Reader {
 // WithBundleName specifies the bundle name
 func (r *Reader) WithBundleName(name string) *Reader {
 	r.name = name
+	return r
+}
+
+func (r *Reader) WithFollowSymlinks(yes bool) *Reader {
+	r.followSymlinks = yes
 	return r
 }
 

--- a/bundle/file.go
+++ b/bundle/file.go
@@ -6,6 +6,7 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"sort"
@@ -126,6 +127,7 @@ type DirectoryLoader interface {
 	WithFilter(filter filter.LoaderFilter) DirectoryLoader
 	WithPathFormat(PathFormat) DirectoryLoader
 	WithSizeLimitBytes(sizeLimitBytes int64) DirectoryLoader
+	WithFollowSymlinks(followSymlinks bool) DirectoryLoader
 }
 
 type dirLoader struct {
@@ -135,6 +137,7 @@ type dirLoader struct {
 	filter            filter.LoaderFilter
 	pathFormat        PathFormat
 	maxSizeLimitBytes int64
+	followSymlinks    bool
 }
 
 // Normalize root directory, ex "./src/bundle" -> "src/bundle"
@@ -181,6 +184,12 @@ func (d *dirLoader) WithSizeLimitBytes(sizeLimitBytes int64) DirectoryLoader {
 	return d
 }
 
+// WithFollowSymlinks specifies whether to follow symlinks when loading files from the directory
+func (d *dirLoader) WithFollowSymlinks(followSymlinks bool) DirectoryLoader {
+	d.followSymlinks = followSymlinks
+	return d
+}
+
 func formatPath(fileName string, root string, pathFormat PathFormat) string {
 	switch pathFormat {
 	case SlashRooted:
@@ -212,7 +221,11 @@ func (d *dirLoader) NextFile() (*Descriptor, error) {
 	if d.files == nil {
 		d.files = []string{}
 		err := filepath.Walk(d.root, func(path string, info os.FileInfo, _ error) error {
-			if info != nil && info.Mode().IsRegular() {
+			if info == nil {
+				return nil
+			}
+
+			if info.Mode().IsRegular() {
 				if d.filter != nil && d.filter(filepath.ToSlash(path), info, getdepth(path, false)) {
 					return nil
 				}
@@ -220,7 +233,15 @@ func (d *dirLoader) NextFile() (*Descriptor, error) {
 					return fmt.Errorf(maxSizeLimitBytesErrMsg, strings.TrimPrefix(path, "/"), info.Size(), d.maxSizeLimitBytes)
 				}
 				d.files = append(d.files, path)
-			} else if info != nil && info.Mode().IsDir() {
+			} else if d.followSymlinks && info.Mode().Type()&fs.ModeSymlink == fs.ModeSymlink {
+				if d.filter != nil && d.filter(filepath.ToSlash(path), info, getdepth(path, false)) {
+					return nil
+				}
+				if d.maxSizeLimitBytes > 0 && info.Size() > d.maxSizeLimitBytes {
+					return fmt.Errorf(maxSizeLimitBytesErrMsg, strings.TrimPrefix(path, "/"), info.Size(), d.maxSizeLimitBytes)
+				}
+				d.files = append(d.files, path)
+			} else if info.Mode().IsDir() {
 				if d.filter != nil && d.filter(filepath.ToSlash(path), info, getdepth(path, true)) {
 					return filepath.SkipDir
 				}
@@ -302,6 +323,11 @@ func (t *tarballLoader) WithPathFormat(pathFormat PathFormat) DirectoryLoader {
 // WithSizeLimitBytes specifies the maximum size of any file in the tarball to read
 func (t *tarballLoader) WithSizeLimitBytes(sizeLimitBytes int64) DirectoryLoader {
 	t.maxSizeLimitBytes = sizeLimitBytes
+	return t
+}
+
+// WithFollowSymlinks is a no-op for tarballLoader
+func (t *tarballLoader) WithFollowSymlinks(_ bool) DirectoryLoader {
 	return t
 }
 

--- a/bundle/filefs.go
+++ b/bundle/filefs.go
@@ -26,6 +26,7 @@ type dirLoaderFS struct {
 	root              string
 	pathFormat        PathFormat
 	maxSizeLimitBytes int64
+	followSymlinks    bool
 }
 
 // NewFSLoader returns a basic DirectoryLoader implementation
@@ -67,6 +68,16 @@ func (d *dirLoaderFS) walkDir(path string, dirEntry fs.DirEntry, err error) erro
 			}
 
 			d.files = append(d.files, path)
+		} else if dirEntry.Type()&fs.ModeSymlink != 0 && d.followSymlinks {
+			if d.filter != nil && d.filter(filepath.ToSlash(path), info, getdepth(path, false)) {
+				return nil
+			}
+
+			if d.maxSizeLimitBytes > 0 && info.Size() > d.maxSizeLimitBytes {
+				return fmt.Errorf("file %s size %d exceeds limit of %d", path, info.Size(), d.maxSizeLimitBytes)
+			}
+
+			d.files = append(d.files, path)
 		} else if dirEntry.Type().IsDir() {
 			if d.filter != nil && d.filter(filepath.ToSlash(path), info, getdepth(path, true)) {
 				return fs.SkipDir
@@ -91,6 +102,11 @@ func (d *dirLoaderFS) WithPathFormat(pathFormat PathFormat) DirectoryLoader {
 // WithSizeLimitBytes specifies the maximum size of any file in the filesystem directory to read
 func (d *dirLoaderFS) WithSizeLimitBytes(sizeLimitBytes int64) DirectoryLoader {
 	d.maxSizeLimitBytes = sizeLimitBytes
+	return d
+}
+
+func (d *dirLoaderFS) WithFollowSymlinks(followSymlinks bool) DirectoryLoader {
+	d.followSymlinks = followSymlinks
 	return d
 }
 

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -45,6 +45,7 @@ type buildParams struct {
 	plugin             string
 	ns                 string
 	v1Compatible       bool
+	followSymlinks     bool
 }
 
 func newBuildParams() buildParams {
@@ -238,6 +239,7 @@ against OPA v0.22.0:
 	buildCommand.Flags().VarP(&buildParams.revision, "revision", "r", "set output bundle revision")
 	buildCommand.Flags().StringVarP(&buildParams.outputFile, "output", "o", "bundle.tar.gz", "set the output filename")
 	buildCommand.Flags().StringVar(&buildParams.ns, "partial-namespace", "partial", "set the namespace to use for partially evaluated files in an optimized bundle")
+	buildCommand.Flags().BoolVar(&buildParams.followSymlinks, "follow-symlinks", false, "follow symlinks in the input set of paths when building the bundle")
 
 	addBundleModeFlag(buildCommand.Flags(), &buildParams.bundleMode, false)
 	addIgnoreFlag(buildCommand.Flags(), &buildParams.ignore)
@@ -302,7 +304,8 @@ func dobuild(params buildParams, args []string) error {
 		WithFilter(buildCommandLoaderFilter(params.bundleMode, params.ignore)).
 		WithBundleVerificationConfig(bvc).
 		WithBundleSigningConfig(bsc).
-		WithPartialNamespace(params.ns)
+		WithPartialNamespace(params.ns).
+		WithFollowSymlinks(params.followSymlinks)
 
 	if params.v1Compatible {
 		compiler = compiler.WithRegoVersion(ast.RegoV1)

--- a/compile/compile.go
+++ b/compile/compile.go
@@ -84,6 +84,7 @@ type Compiler struct {
 	fsys                         fs.FS                      // file system to use when loading paths
 	ns                           string
 	regoVersion                  ast.RegoVersion
+	followSymlinks               bool // optionally follow symlinks in the bundle directory when building the bundle
 }
 
 // New returns a new compiler instance that can be invoked.
@@ -216,6 +217,12 @@ func (c *Compiler) WithBundleVerificationKeyID(keyID string) *Compiler {
 // WithCapabilities sets the capabilities to use while checking policies.
 func (c *Compiler) WithCapabilities(capabilities *ast.Capabilities) *Compiler {
 	c.capabilities = capabilities
+	return c
+}
+
+// WithFollowSymlinks sets whether or not to follow symlinks in the bundle directory when building the bundle
+func (c *Compiler) WithFollowSymlinks(yes bool) *Compiler {
+	c.followSymlinks = yes
 	return c
 }
 
@@ -471,7 +478,17 @@ func (c *Compiler) initBundle(usePath bool) error {
 	// TODO(tsandall): the metrics object should passed through here so we that
 	// we can track read and parse times.
 
-	load, err := initload.LoadPathsForRegoVersion(c.regoVersion, c.paths, c.filter, c.asBundle, c.bvc, false, c.useRegoAnnotationEntrypoints, c.capabilities, c.fsys)
+	load, err := initload.LoadPathsForRegoVersion(
+		c.regoVersion,
+		c.paths,
+		c.filter,
+		c.asBundle,
+		c.bvc,
+		false,
+		c.useRegoAnnotationEntrypoints,
+		c.followSymlinks,
+		c.capabilities,
+		c.fsys)
 	if err != nil {
 		return fmt.Errorf("load error: %w", err)
 	}

--- a/internal/pathwatcher/utils.go
+++ b/internal/pathwatcher/utils.go
@@ -47,7 +47,7 @@ func ProcessWatcherUpdate(ctx context.Context, paths []string, removed string, s
 
 func ProcessWatcherUpdateForRegoVersion(ctx context.Context, regoVersion ast.RegoVersion, paths []string, removed string, store storage.Store, filter loader.Filter, asBundle bool,
 	f func(context.Context, storage.Transaction, *initload.LoadPathsResult) error) error {
-	loaded, err := initload.LoadPathsForRegoVersion(regoVersion, paths, filter, asBundle, nil, true, false, nil, nil)
+	loaded, err := initload.LoadPathsForRegoVersion(regoVersion, paths, filter, asBundle, nil, true, false, false, nil, nil)
 	if err != nil {
 		return err
 	}

--- a/internal/runtime/init/init.go
+++ b/internal/runtime/init/init.go
@@ -124,7 +124,7 @@ func LoadPaths(paths []string,
 	processAnnotations bool,
 	caps *ast.Capabilities,
 	fsys fs.FS) (*LoadPathsResult, error) {
-	return LoadPathsForRegoVersion(ast.RegoV0, paths, filter, asBundle, bvc, skipVerify, processAnnotations, caps, fsys)
+	return LoadPathsForRegoVersion(ast.RegoV0, paths, filter, asBundle, bvc, skipVerify, processAnnotations, false, caps, fsys)
 }
 
 func LoadPathsForRegoVersion(regoVersion ast.RegoVersion,
@@ -134,6 +134,7 @@ func LoadPathsForRegoVersion(regoVersion ast.RegoVersion,
 	bvc *bundle.VerificationConfig,
 	skipVerify bool,
 	processAnnotations bool,
+	followSymlinks bool,
 	caps *ast.Capabilities,
 	fsys fs.FS) (*LoadPathsResult, error) {
 
@@ -161,6 +162,7 @@ func LoadPathsForRegoVersion(regoVersion ast.RegoVersion,
 				WithProcessAnnotation(processAnnotations).
 				WithCapabilities(caps).
 				WithRegoVersion(regoVersion).
+				WithFollowSymlinks(followSymlinks).
 				AsBundle(path)
 			if err != nil {
 				return nil, err

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -343,7 +343,7 @@ func NewRuntime(ctx context.Context, params Params) (*Runtime, error) {
 	} else {
 		regoVersion = ast.RegoV0
 	}
-	loaded, err := initload.LoadPathsForRegoVersion(regoVersion, params.Paths, params.Filter, params.BundleMode, params.BundleVerificationConfig, params.SkipBundleVerification, false, nil, nil)
+	loaded, err := initload.LoadPathsForRegoVersion(regoVersion, params.Paths, params.Filter, params.BundleMode, params.BundleVerificationConfig, params.SkipBundleVerification, false, false, nil, nil)
 	if err != nil {
 		return nil, fmt.Errorf("load error: %w", err)
 	}


### PR DESCRIPTION
<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->

### Why the changes in this PR are needed?

Per https://github.com/open-policy-agent/opa/issues/6495, it is important to users using build systems like babel to allow `opa build` to include symlinked files in the bundle directory. Bazel and other build tools create sandboxes of symlinked files before building. As it stands today, `opa build` only includes regular files and directories by default.

### What are the changes in this PR?

<!--
Include a short description of WHAT changes were made.
-->

This PR adds a boolean flag, `--follow-symlinks` to the `opa build` command to allow users to build directories with symlinked files, and have the contents of those symlinked files included in the built bundle.

### Notes to assist PR review:

<!--
Here you can add information you think will help the reviewer(s).
-->

I've included tests for the build command but would appreciate a critical eye as to any other areas that could use testing. Also, I've kept the symlink changes as constrained to the `build` features as possible, but there are many layers of method calls to get to the core filesystem loading logic, so any ideas for cleaning up this code is welcome.

### Further comments:

<!--
Here you can include links to additional resources related to the changes, discuss your solution, other approaches you considered etc.
-->
