### PR TITLE
Include original text in annotation location text attribute

### DIFF
--- a/ast/parser.go
+++ b/ast/parser.go
@@ -2373,6 +2373,21 @@ func (b *metadataParser) Parse() (*Annotations, error) {
 	}
 
 	result.Location = b.loc
+
+	// recreate original text of entire metadata block for location text attribute
+	sb := strings.Builder{}
+	sb.WriteString("# METADATA\n")
+
+	lines := bytes.Split(b.buf.Bytes(), []byte{'\n'})
+
+	for _, line := range lines[:len(lines)-1] {
+		sb.WriteString("# ")
+		sb.Write(line)
+		sb.WriteByte('\n')
+	}
+
+	result.Location.Text = []byte(strings.TrimSuffix(sb.String(), "\n"))
+
 	return &result, nil
 }
 

--- a/ast/parser_test.go
+++ b/ast/parser_test.go
@@ -6190,6 +6190,32 @@ func TestRelatedResourceAnnotation(t *testing.T) {
 	}
 }
 
+func TestAnnotationsLocationText(t *testing.T) {
+	module := `# METADATA
+# title: pkg
+# description: a package
+package pkg
+
+import rego.v1
+
+# METADATA
+# title: rule
+allow if {
+	true
+}
+`
+
+	m, err := ParseModuleWithOpts("test.rego", module, ParserOptions{ProcessAnnotation: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assertLocationText(t, "# METADATA\n# title: pkg\n# description: a package", m.Annotations[0].Location)
+	assertLocationText(t, "# METADATA\n# title: rule", m.Annotations[1].Location)
+
+	assertLocationText(t, "# METADATA\n# title: rule", m.Rules[0].Annotations[0].Location)
+}
+
 func assertLocationText(t *testing.T, expected string, actual *Location) {
 	t.Helper()
 	if actual == nil || actual.Text == nil {


### PR DESCRIPTION
Previously it would just say '# METADATA'

Fixes #6779