### PR TITLE
server/authorizer: Fix gzip payload handling.

### DIFF
--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1682,6 +1682,112 @@ func TestDataPutV1IfNoneMatch(t *testing.T) {
 	}
 }
 
+func mustGZIPPayload(payload []byte) []byte {
+	// Compress JSON payload with gzip
+	var compressedPayload bytes.Buffer
+	gz := gzip.NewWriter(&compressedPayload)
+	if _, err := gz.Write(payload); err != nil {
+		panic(fmt.Errorf("Error closing gzip writer: %w", err))
+	}
+	if err := gz.Close(); err != nil {
+		panic(fmt.Errorf("Error closing gzip writer: %w", err))
+	}
+	return compressedPayload.Bytes()
+}
+
+// Ref: https://github.com/open-policy-agent/opa/issues/6804
+func TestDataGetV1CompressedRequestWithAuthorizer(t *testing.T) {
+	tests := []struct {
+		note                  string
+		payload               []byte
+		forcePayloadSizeField uint32 // Size to manually set the payload field for the gzip blob.
+		expRespHTTPStatus     int
+		authzEnabled          bool
+	}{
+		{
+			note:              "empty message",
+			payload:           mustGZIPPayload([]byte{}),
+			expRespHTTPStatus: 401,
+			authzEnabled:      true,
+		},
+		{
+			note:              "empty object",
+			payload:           mustGZIPPayload([]byte(`{}`)),
+			expRespHTTPStatus: 401,
+			authzEnabled:      true,
+		},
+		{
+			note:              "basic authz - fail",
+			payload:           mustGZIPPayload([]byte(`{"user": "bob"}`)),
+			expRespHTTPStatus: 401,
+			authzEnabled:      true,
+		},
+		{
+			note:              "basic authz - pass",
+			payload:           mustGZIPPayload([]byte(`{"user": "alice"}`)),
+			expRespHTTPStatus: 200,
+			authzEnabled:      true,
+		},
+		{
+			note:                  "basic authz - malicious size field",
+			payload:               mustGZIPPayload([]byte(`{"user": "alice"}`)),
+			expRespHTTPStatus:     200,
+			forcePayloadSizeField: 134217728, // 128 MB
+			authzEnabled:          true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.note, func(t *testing.T) {
+			ctx := context.Background()
+			store := inmem.New()
+			txn := storage.NewTransactionOrDie(ctx, store, storage.WriteParams)
+			authzPolicy := `package system.authz
+
+import rego.v1
+
+default allow := false # Reject requests by default.
+
+allow if {
+	# Logic to authorize request goes here.
+	input.body.user == "alice"
+}
+`
+
+			if err := store.UpsertPolicy(ctx, txn, "test", []byte(authzPolicy)); err != nil {
+				panic(err)
+			}
+
+			if err := store.Commit(ctx, txn); err != nil {
+				panic(err)
+			}
+
+			opts := [](func(*Server)){func(s *Server) {
+				s.WithStore(store)
+			}}
+			if test.authzEnabled {
+				opts = append(opts, func(s *Server) {
+					s.WithAuthorization(AuthorizationBasic)
+				})
+			}
+
+			f := newFixtureWithConfig(t, fmt.Sprintf(`{"server":{"decision_logs": %t}}`, true), opts...)
+
+			// execute the request
+			req := newReqV1(http.MethodPost, "/data/test", string(test.payload))
+			// req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Content-Encoding", "gzip")
+			f.reset()
+			f.server.Handler.ServeHTTP(f.recorder, req)
+			if f.recorder.Code != test.expRespHTTPStatus {
+				t.Fatalf("Unexpected HTTP status code, (exp,got): %d, %d", test.expRespHTTPStatus, f.recorder.Code)
+			}
+			fmt.Println(f.recorder.Body)
+			// panic("AAA")
+		})
+	}
+}
+
 func TestDataPostV0CompressedResponse(t *testing.T) {
 	tests := []struct {
 		gzipMinLength      int

--- a/util/read_gzip_body.go
+++ b/util/read_gzip_body.go
@@ -1,0 +1,26 @@
+package util
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// Note(philipc): Originally taken from server/server.go
+func ReadMaybeCompressedBody(r *http.Request) (io.ReadCloser, error) {
+	if strings.Contains(r.Header.Get("Content-Encoding"), "gzip") {
+		gzReader, err := gzip.NewReader(r.Body)
+		if err != nil {
+			return nil, err
+		}
+		defer gzReader.Close()
+		bytesBody, err := io.ReadAll(gzReader)
+		if err != nil {
+			return nil, err
+		}
+		return io.NopCloser(bytes.NewReader(bytesBody)), err
+	}
+	return r.Body, nil
+}


### PR DESCRIPTION
## What changed in this PR?

This PR fixes an issue where an OPA running authorization policies would be unable to handle gzipped request bodies.

Example OPA CLI setup:

```shell
opa run -s --authorization=basic
```

Example request:

```shell
echo -n '{}' | gzip | curl -H "Content-Encoding: gzip" --data-binary @- http://127.0.0.1:8181/v1/data
```

This would result in unhelpful error messages, like:

```json
{
  "code": "invalid_parameter",
  "message": "invalid character '\\x1f' looking for beginning of value"
}
```

The cause was that the request body handling system in the `server/authorizer` package did not take gzipped payloads into account. The fix was to borrow the gzip request body handling function from `server/server.go`, to transparently decompress the body when needed.

Fixes: #6804

## TODOs

 - [x] Add an authorizer test for the gzipped payload case (to prevent regressions!)