### PR TITLE
docs: Use Example field for alternative commands

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -52,9 +52,11 @@ By default, the 'exec' command executes the "default decision" (specified in
 the OPA configuration) against each input file. This can be overridden by
 specifying the --decision argument and pointing at a specific policy decision,
 e.g., opa exec --decision /foo/bar/baz ...
+`,
 
-Alternative Usage:
-  ` + RootCommand.Use + ` exec [<path> [...]] --stdin-input [flags]`,
+		Example: fmt.Sprintf(`  Loading input from stdin:
+    %s exec [<path> [...]] --stdin-input [flags]
+`, RootCommand.Use),
 
 		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return env.CmdFlags.CheckEnvironmentVariables(cmd)

--- a/docs/content/cli.md
+++ b/docs/content/cli.md
@@ -599,11 +599,17 @@ the OPA configuration) against each input file. This can be overridden by
 specifying the --decision argument and pointing at a specific policy decision,
 e.g., opa exec --decision /foo/bar/baz ...
 
-Alternative Usage:
-  generate exec [<path> [...]] --stdin-input [flags]
 
 ```
 opa exec <path> [<path> [...]] [flags]
+```
+
+### Examples
+
+```
+  Loading input from stdin:
+    generate exec [<path> [...]] --stdin-input [flags]
+
 ```
 
 ### Options


### PR DESCRIPTION
This makes it safer to process this text into markdown and other formats. (`<path>` is tricky as it looks like an HTML tag.

CLI output would look like this:

```
$ go run main.go exec --help
...
e.g., opa exec --decision /foo/bar/baz ...

Usage:
  main exec <path> [<path> [...]] [flags]

Examples:
  Loading input from stdin:
    main exec [<path> [...]] --stdin-input [flags]
```