### PR TITLE
Avoid possible race condition using locks

### DIFF
--- a/plugins/bundle/plugin.go
+++ b/plugins/bundle/plugin.go
@@ -157,7 +157,10 @@ func (p *Plugin) Reconfigure(ctx context.Context, config interface{}) {
 	// Look for any bundles that have had their config changed, are new, or have been removed
 	newConfig := config.(*Config)
 	newBundles, updatedBundles, deletedBundles := p.configDelta(newConfig)
+
+	p.mtx.Lock()
 	p.config = *newConfig
+	p.mtx.Unlock()
 
 	if len(updatedBundles) == 0 && len(newBundles) == 0 && len(deletedBundles) == 0 {
 		// no relevant config changes
@@ -643,6 +646,8 @@ func (p *Plugin) activate(ctx context.Context, name string, b *bundle.Bundle) er
 }
 
 func (p *Plugin) persistBundle(name string) bool {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
 	bundleSrc := p.config.Bundles[name]
 
 	if bundleSrc == nil {

--- a/plugins/bundle/plugin.go
+++ b/plugins/bundle/plugin.go
@@ -317,7 +317,7 @@ func (p *Plugin) Config() *Config {
 
 func (p *Plugin) initDownloaders(ctx context.Context) {
 	p.cfgMtx.RLock()
-	p.cfgMtx.RUnlock()
+	defer p.cfgMtx.RUnlock()
 
 	// Initialize a downloader for each bundle configured.
 	for name, source := range p.config.Bundles {
@@ -353,7 +353,7 @@ func (p *Plugin) readBundleEtagFromStore(ctx context.Context, name string) strin
 
 func (p *Plugin) loadAndActivateBundlesFromDisk(ctx context.Context) {
 	p.cfgMtx.RLock()
-	p.cfgMtx.RUnlock()
+	defer p.cfgMtx.RUnlock()
 
 	persistedBundles := map[string]*bundle.Bundle{}
 

--- a/plugins/bundle/plugin.go
+++ b/plugins/bundle/plugin.go
@@ -313,8 +313,6 @@ func (p *Plugin) UnregisterBulkListener(name interface{}) {
 
 // Config returns the plugins current configuration
 func (p *Plugin) Config() *Config {
-	p.cfgMtx.RLock()
-	defer p.cfgMtx.RUnlock()
 	return &p.config
 }
 

--- a/plugins/bundle/plugin.go
+++ b/plugins/bundle/plugin.go
@@ -643,6 +643,8 @@ func (p *Plugin) activate(ctx context.Context, name string, b *bundle.Bundle) er
 }
 
 func (p *Plugin) persistBundle(name string) bool {
+	p.cfgMtx.RLock()
+	defer p.cfgMtx.RUnlock()
 	bundleSrc := p.config.Bundles[name]
 
 	if bundleSrc == nil {

--- a/plugins/bundle/plugin.go
+++ b/plugins/bundle/plugin.go
@@ -643,8 +643,6 @@ func (p *Plugin) activate(ctx context.Context, name string, b *bundle.Bundle) er
 }
 
 func (p *Plugin) persistBundle(name string) bool {
-	p.cfgMtx.RLock()
-	defer p.cfgMtx.RUnlock()
 	bundleSrc := p.config.Bundles[name]
 
 	if bundleSrc == nil {

--- a/plugins/bundle/plugin.go
+++ b/plugins/bundle/plugin.go
@@ -663,8 +663,6 @@ func (p *Plugin) persistBundle(name string) bool {
 
 // configDelta will return a map of new bundle sources, updated bundle sources, and a set of deleted bundle names
 func (p *Plugin) configDelta(newConfig *Config) (map[string]*Source, map[string]*Source, map[string]struct{}) {
-	p.cfgMtx.RLock()
-	defer p.cfgMtx.RUnlock()
 	deletedBundles := map[string]struct{}{}
 	for name := range p.config.Bundles {
 		deletedBundles[name] = struct{}{}

--- a/plugins/bundle/plugin.go
+++ b/plugins/bundle/plugin.go
@@ -151,8 +151,8 @@ func (p *Plugin) Reconfigure(ctx context.Context, config interface{}) {
 	// nothing swaps underneath us with the current p.config and the updated one.
 	// Use p.cfgMtx instead of p.mtx so as to not block any bundle downloads/activations
 	// that are in progress. We upgrade to p.mtx locking after stopping downloaders.
-	p.cfgMtx.Lock()
-	defer p.cfgMtx.Unlock()
+	p.cfgMtx.RLock()
+	defer p.cfgMtx.RUnlock()
 
 	// Look for any bundles that have had their config changed, are new, or have been removed
 	newConfig := config.(*Config)

--- a/plugins/bundle/plugin.go
+++ b/plugins/bundle/plugin.go
@@ -151,8 +151,8 @@ func (p *Plugin) Reconfigure(ctx context.Context, config interface{}) {
 	// nothing swaps underneath us with the current p.config and the updated one.
 	// Use p.cfgMtx instead of p.mtx so as to not block any bundle downloads/activations
 	// that are in progress. We upgrade to p.mtx locking after stopping downloaders.
-	p.cfgMtx.RLock()
-	defer p.cfgMtx.RUnlock()
+	p.cfgMtx.Lock()
+	defer p.cfgMtx.Unlock()
 
 	// Look for any bundles that have had their config changed, are new, or have been removed
 	newConfig := config.(*Config)


### PR DESCRIPTION
### Why the changes in this PR are needed?
to address https://github.com/open-policy-agent/opa/issues/6849

### What are the changes in this PR?
Add locks when reading and writing the bundle plugin configuration.

No tests are added, as not sure exactly on how to write a test for this. The issue is experienced when checking for race conditions while using bundle plugin status listeners while using OPA as a library.