### PR TITLE
docs: Better link language SDKs

### DIFF
--- a/docs/content/http-api-authorization.md
+++ b/docs/content/http-api-authorization.md
@@ -123,6 +123,12 @@ Then run `docker-compose` to pull and run the containers.
 docker-compose -f docker-compose.yml up
 ```
 
+{{< info >}}
+This example shows conceptually a 'manual' REST API integration with OPA.
+You might find it easier to build your OPA integration using one of the
+[language SDKs](/ecosystem/#languages) than working with the REST API directly.
+{{< /info >}}
+
 Every time the demo web server receives an HTTP request, it
 asks OPA to decide whether an HTTP API is authorized or not
 using a single RESTful API call.  An example code is [here](https://github.com/open-policy-agent/contrib/blob/main/api_authz/docker/echo_server.py),

--- a/docs/content/integration.md
+++ b/docs/content/integration.md
@@ -47,7 +47,7 @@ application or service helps ensure policy decisions are fast and highly-availab
 When your application or service needs to make policy decisions it can query OPA
 locally via HTTP. While it's possible to call OPA's [REST API](../rest-api) directly,
 you can also find a number of [native language REST SDKs](/ecosystem/#languages)
-eoo which make the integration easier.
+which make the integration easier.
 
 #### Named Policy Decisions
 

--- a/docs/content/integration.md
+++ b/docs/content/integration.md
@@ -28,6 +28,7 @@ This page focuses predominantly on different ways to integrate with OPA's policy
 OPA supports different ways to evaluate policies.
 
 * The [REST API](../rest-api) returns decisions as JSON over HTTP.
+  * Also see the [Language SDKs](/ecosystem/#languages) for working with the REST API in different languages.
 * The [Go API (GoDoc)](https://pkg.go.dev/github.com/open-policy-agent/opa/rego) returns
   decisions as simple Go types (`bool`, `string`, `map[string]interface{}`,
   etc.)
@@ -37,14 +38,16 @@ OPA supports different ways to evaluate policies.
 * The [SDK](https://pkg.go.dev/github.com/open-policy-agent/opa/sdk) provides high-level APIs for obtaining the output
   of query evaluation as simple Go types (`bool`, `string`, `map[string]interface{}`, etc.)
 
-
 ### Integrating with the REST API
 
 To integrate with OPA outside of Go, we recommend you deploy OPA as a host-level
-daemon or sidecar container. When your application or service needs to make
-policy decisions it can query OPA locally via HTTP. Running OPA locally on the
-same host as your application or service helps ensure policy decisions are fast
-and highly-available.
+daemon or sidecar container. Running OPA locally on the same host as your
+application or service helps ensure policy decisions are fast and highly-available.
+
+When your application or service needs to make policy decisions it can query OPA
+locally via HTTP. While it's possible to call OPA's [REST API](../rest-api) directly,
+you can also find a number of [native language REST SDKs](/ecosystem/#languages)
+eoo which make the integration easier.
 
 #### Named Policy Decisions
 

--- a/docs/content/rest-api.md
+++ b/docs/content/rest-api.md
@@ -5,6 +5,12 @@ weight: 80
 restrictedtoc: true
 ---
 
+{{< info >}}
+Integrating with OPA from a programming language? You might find it easier to build your
+OPA integration using one of the [language SDKs](/ecosystem/#languages) than working
+with the REST API directly.
+{{< /info >}}
+
 This document is the authoritative specification of the OPA REST API. The API can be broken down into the following
 groups:
 
@@ -1316,9 +1322,9 @@ Partially evaluate a query.
 The [Compile API](#compile-api) allows you to partially evaluate Rego queries
 and obtain a simplified version of the policy. This is most useful when building
 integrations where policy logic is to be translated and evaluated in another
-environment. For example, 
+environment. For example,
 [this post](https://blog.openpolicyagent.org/write-policy-in-opa-enforce-policy-in-sql-d9d24db93bf4)
-on the OPA blog shows how SQL can be generated based on Compile API output. 
+on the OPA blog shows how SQL can be generated based on Compile API output.
 For more details on Partial Evaluation in OPA, please refer to
 [this blog post](https://blog.openpolicyagent.org/partial-evaluation-162750eaf422).
 
@@ -2178,6 +2184,6 @@ OPA currently supports the following query provenance information:
 
 ## Ecosystem Projects
 
-OPA's REST API has already been used by many projects in the OPA Ecosystem to support a variety of use cases. 
+OPA's REST API has already been used by many projects in the OPA Ecosystem to support a variety of use cases.
 
-{{< ecosystem_feature_embed key="rest-api-integration" topic="built on the OPA REST API" >}} 
+{{< ecosystem_feature_embed key="rest-api-integration" topic="built on the OPA REST API" >}}

--- a/docs/content/rest-api.md
+++ b/docs/content/rest-api.md
@@ -5,12 +5,6 @@ weight: 80
 restrictedtoc: true
 ---
 
-{{< info >}}
-Integrating with OPA from a programming language? You might find it easier to build your
-OPA integration using one of the [language SDKs](/ecosystem/#languages) than working
-with the REST API directly.
-{{< /info >}}
-
 This document is the authoritative specification of the OPA REST API. The API can be broken down into the following
 groups:
 
@@ -22,7 +16,7 @@ groups:
 * [Config API](#config-api) - view instance configuration.
 * [Status API](#status-api) - view instance [status](../management-status) state.
 
-The REST API is a very common way to integrate with OPA.
+The REST API is a common way to integrate with OPA.
 {{<
   ecosystem_feature_link
   key="rest-api-integration"
@@ -35,6 +29,12 @@ The REST API is a very common way to integrate with OPA.
 >}}
 You may also want to review the [integration documentation](../integration) for other options
 to build on OPA by embedding functionality directly into your application.
+
+{{< info >}}
+Integrating with OPA from a programming language? You might find it easier to build your
+OPA integration using one of the [language SDKs](/ecosystem/#languages) than working
+with the REST API directly.
+{{< /info >}}
 
 ##  Policy API
 


### PR DESCRIPTION
The SDK support is there for many languages now and these are likely a preferred way to use OPA's REST API for many application developers.

This PR adds some links to make sure these are featured in suitable locations so they are not missed as people browse the docs.
