### PR TITLE
server+util: Limit max request sizes, prealloc request buffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Request Body Size Limits
+
+OPA now rejects requests with request bodies larger than a preset maximum size. To control this behavior, two new configuration keys are available: `server.decoding.max_length` and `server.decoding.gzip.max_length`. These control the max size in bytes to allow for an incoming request payload, and the maximum size in bytes to allow for a decompressed gzip request payload, respectively.
+
+Here's an example OPA configuration using the new keys:
+
+```yaml
+# Set max request size to 64 MB and max gzip size (decompressed) to be 128 MB.
+server:
+  decoding:
+    max_length: 67108864
+    gzip:
+      max_length: 134217728
+```
+
+These changes allow improvements in memory usage for the OPA HTTP server, and help OPA deployments avoid some accidental out-of-memory situations.
+
+### Breaking Changes
+
+OPA now automatically rejects very large requests. Requests with a `Content-Length` larger than 128 MB uncompressed, and gzipped requests with payloads that decompress to larger than 256 MB will be rejected, as part of hardening OPA against denial-of-service attacks. Previously, a large enough request could cause an OPA instance to run out of memory in low-memory sidecar deployment scenarios, just from attempting to read the request body into memory.
+
+For most users, no changes will be needed to continue using OPA. However, for those who need to override the default limits, the new `server.decoding.max_length` and `server.decoding.gzip.max_length` configuration fields allow setting higher request size limits.
+
 ## 0.66.0
 
 This release contains a mix of features, performance improvements, and bugfixes.

--- a/config/config.go
+++ b/config/config.go
@@ -39,6 +39,7 @@ type Config struct {
 	DistributedTracing           json.RawMessage            `json:"distributed_tracing,omitempty"`
 	Server                       *struct {
 		Encoding json.RawMessage `json:"encoding,omitempty"`
+		Decoding json.RawMessage `json:"decoding,omitempty"`
 		Metrics  json.RawMessage `json:"metrics,omitempty"`
 	} `json:"server,omitempty"`
 	Storage *struct {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -197,6 +197,12 @@ func TestActiveConfig(t *testing.T) {
 			"some-plugin": {}
 		},
 		"server": {
+			"decoding": {
+				"max_length": 134217728,
+				"gzip": {
+					"max_length": 268435456
+				}
+			},
 			"encoding": {
 				"gzip": {
 					"min_length": 1024,
@@ -265,6 +271,12 @@ func TestActiveConfig(t *testing.T) {
 			"some-plugin": {}
 		},
 		"server": {
+			"decoding": {
+				"max_length": 134217728,
+				"gzip": {
+					"max_length": 268435456
+				}
+			},
 			"encoding": {
 				"gzip": {
 					"min_length": 1024,

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -78,9 +78,13 @@ distributed_tracing:
   encryption: "off"
 
 server:
+  decoding:
+    max_length: 134217728
+    gzip:
+      max_length: 268435456
   encoding:
     gzip:
-        min_length: 1024,
+        min_length: 1024
         compression_level: 9
 ```
 
@@ -886,14 +890,19 @@ See [the docs on disk storage](../storage/) for details about the settings.
 ## Server
 
 The `server` configuration sets:
-- the gzip compression settings for `/v0/data`, `/v1/data` and `/v1/compile` HTTP `POST` endpoints
+- for all incoming requests:
+  - maximum allowed request size
+  - maximum decompressed gzip payload size
+- the gzip compression settings for responses from the `/v0/data`, `/v1/data` and `/v1/compile` HTTP `POST` endpoints
 The gzip compression settings are used when the client sends `Accept-Encoding: gzip`
 - buckets for `http_request_duration_seconds` histogram
 
-| Field                                                       | Type        | Required                                                                  | Description                                                                                                                                                                                                               |
-|-------------------------------------------------------------|-------------|---------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `server.encoding.gzip.min_length`                           | `int`       | No, (default: 1024)                                                       | Specifies the minimum length of the response to compress                                                                                                                                                                  |
-| `server.encoding.gzip.compression_level`                    | `int`       | No, (default: 9)                                                          | Specifies the compression level. Accepted values: a value of either 0 (no compression), 1 (best speed, lowest compression) or 9 (slowest, best compression). See https://pkg.go.dev/compress/flate#pkg-constants          |
+| Field | Type| Required | Description |
+| --- | --- | --- | --- |
+| `server.decoding.max_length` | `int` | No, (default: 268435456) | Specifies the maximum allowed number of bytes to read from a request body. |
+| `server.decoding.gzip.max_length` | `int` | No, (default: 536870912) | Specifies the maximum allowed number of bytes to read from the gzip decompressor for gzip-encoded requests. |
+| `server.encoding.gzip.min_length` | `int` | No, (default: 1024) | Specifies the minimum length of the response to compress. |
+| `server.encoding.gzip.compression_level` | `int` | No, (default: 9) | Specifies the compression level. Accepted values: a value of either 0 (no compression), 1 (best speed, lowest compression) or 9 (slowest, best compression). See https://pkg.go.dev/compress/flate#pkg-constants |
 | `server.metrics.prom.http_request_duration_seconds.buckets` | `[]float64` | No, (default: [1e-6, 5e-6, 1e-5, 5e-5, 1e-4, 5e-4, 1e-3, 0.01, 0.1, 1  ]) | Specifies the buckets for the `http_request_duration_seconds` metric. Each value is a float, it is expressed in seconds and subdivisions of it. E.g `1e-6` is 1 microsecond, `1e-3` 1 millisecond, `0.01` 10 milliseconds |
 
 ## Miscellaneous

--- a/plugins/server/decoding/config.go
+++ b/plugins/server/decoding/config.go
@@ -1,0 +1,102 @@
+// Package decoding implements the configuration side of the upgraded gzip
+// decompression framework. The original work only enabled gzip decoding for
+// a few endpoints-- here we enable if for all of OPA. Additionally, we provide
+// some new defensive configuration options: max_length, and gzip.max_length.
+// These allow rejecting requests that indicate their contents are larger than
+// the size limits.
+//
+// The request handling pipeline now looks roughly like this:
+//
+// Request -> MaxBytesReader(Config.MaxLength) -> ir.CopyN(dest, req, Gzip.MaxLength)
+//
+// The intent behind this design is to improve how OPA handles large and/or
+// malicious requests, compressed or otherwise. The benefit of being a little
+// more strict in what we allow is that we can now use "riskier", but
+// dramatically more performant techniques, like preallocating content buffers
+// for gzipped data. This also should help OPAs in limited memory situations.
+package decoding
+
+import (
+	"fmt"
+
+	"github.com/open-policy-agent/opa/util"
+)
+
+var (
+	defaultMaxRequestLength     = int64(268435456) // 256 MB
+	defaultGzipMaxContentLength = int64(536870912) // 512 MB
+)
+
+// Config represents the configuration for the Server.Decoding settings
+type Config struct {
+	MaxLength *int64 `json:"max_length,omitempty"` // maximum request size that will be read, regardless of compression.
+	Gzip      *Gzip  `json:"gzip,omitempty"`
+}
+
+// Gzip represents the configuration for the Server.Decoding.Gzip settings
+type Gzip struct {
+	MaxLength *int64 `json:"max_length,omitempty"` // Max number of bytes allowed to be read from the decompressor.
+}
+
+// ConfigBuilder assists in the construction of the plugin configuration.
+type ConfigBuilder struct {
+	raw []byte
+}
+
+// NewConfigBuilder returns a new ConfigBuilder to build and parse the server config
+func NewConfigBuilder() *ConfigBuilder {
+	return &ConfigBuilder{}
+}
+
+// WithBytes sets the raw server config
+func (b *ConfigBuilder) WithBytes(config []byte) *ConfigBuilder {
+	b.raw = config
+	return b
+}
+
+// Parse returns a valid Config object with defaults injected.
+func (b *ConfigBuilder) Parse() (*Config, error) {
+	if b.raw == nil {
+		defaultConfig := &Config{
+			MaxLength: &defaultMaxRequestLength,
+			Gzip: &Gzip{
+				MaxLength: &defaultGzipMaxContentLength,
+			},
+		}
+		return defaultConfig, nil
+	}
+
+	var result Config
+
+	if err := util.Unmarshal(b.raw, &result); err != nil {
+		return nil, err
+	}
+
+	return &result, result.validateAndInjectDefaults()
+}
+
+// validateAndInjectDefaults populates defaults if the fields are nil, then
+// validates the config values.
+func (c *Config) validateAndInjectDefaults() error {
+	if c.MaxLength == nil {
+		c.MaxLength = &defaultMaxRequestLength
+	}
+
+	if c.Gzip == nil {
+		c.Gzip = &Gzip{
+			MaxLength: &defaultGzipMaxContentLength,
+		}
+	}
+	if c.Gzip.MaxLength == nil {
+		c.Gzip.MaxLength = &defaultGzipMaxContentLength
+	}
+
+	if *c.MaxLength <= 0 {
+		return fmt.Errorf("invalid value for server.decoding.max_length field, should be a positive number")
+	}
+	if *c.Gzip.MaxLength <= 0 {
+		return fmt.Errorf("invalid value for server.decoding.gzip.max_length field, should be a positive number")
+	}
+
+	return nil
+}

--- a/plugins/server/decoding/config_test.go
+++ b/plugins/server/decoding/config_test.go
@@ -1,0 +1,108 @@
+package decoding
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestConfigValidation(t *testing.T) {
+	tests := []struct {
+		input   string
+		wantErr bool
+	}{
+		{
+			input:   `{}`,
+			wantErr: false,
+		},
+		{
+			input:   `{"gzip": {"max_length": "not-a-number"}}`,
+			wantErr: true,
+		},
+		{
+			input:   `{"gzip": {max_length": 42}}`,
+			wantErr: false,
+		},
+		{
+			input:   `{"gzip":{"max_length": "42"}}`,
+			wantErr: true,
+		},
+		{
+			input:   `{"gzip":{"max_length": 0}}`,
+			wantErr: true,
+		},
+		{
+			input:   `{"gzip":{"max_length": -10}}`,
+			wantErr: true,
+		},
+		{
+			input:   `{"gzip":{"random_key": 0}}`,
+			wantErr: false,
+		},
+		{
+			input:   `{"gzip": {"max_length": -10}}`,
+			wantErr: true,
+		},
+		{
+			input:   `{"max_length": "not-a-number"}`,
+			wantErr: true,
+		},
+		{
+			input:   `{"gzip":{}}`,
+			wantErr: false,
+		},
+		{
+			input:   `{"max_length": "not-a-number", "gzip":{}}`,
+			wantErr: true,
+		},
+		{
+			input:   `{"max_length": 42, "gzip":{"max_length": 42}}`,
+			wantErr: false,
+		},
+	}
+
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("TestConfigValidation_case_%d", i), func(t *testing.T) {
+			_, err := NewConfigBuilder().WithBytes([]byte(test.input)).Parse()
+			if err != nil && !test.wantErr {
+				t.Fatalf("Unexpected error: %s", err.Error())
+			}
+			if err == nil && test.wantErr {
+				t.Fail()
+			}
+		})
+	}
+}
+
+func TestConfigValue(t *testing.T) {
+	tests := []struct {
+		input                      string
+		maxLengthExpectedValue     int64
+		gzipMaxLengthExpectedValue int64
+	}{
+		{
+			input:                      `{}`,
+			maxLengthExpectedValue:     268435456,
+			gzipMaxLengthExpectedValue: 536870912,
+		},
+		{
+			input:                      `{"max_length": 5, "gzip":{"max_length": 42}}`,
+			maxLengthExpectedValue:     5,
+			gzipMaxLengthExpectedValue: 42,
+		},
+	}
+
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("TestConfigValue_case_%d", i), func(t *testing.T) {
+			config, err := NewConfigBuilder().WithBytes([]byte(test.input)).Parse()
+			if err != nil {
+				t.Fatalf("Error building configuration: %s", err.Error())
+			}
+			if *config.MaxLength != test.maxLengthExpectedValue {
+				t.Fatalf("Unexpected config value for max_length (exp/actual): %d, %d", test.maxLengthExpectedValue, *config.MaxLength)
+			}
+			if *config.Gzip.MaxLength != test.gzipMaxLengthExpectedValue {
+				t.Fatalf("Unexpected config value for gzip.max_length (exp/actual): %d, %d", test.gzipMaxLengthExpectedValue, *config.Gzip.MaxLength)
+			}
+		})
+	}
+}

--- a/server/authorizer/authorizer.go
+++ b/server/authorizer/authorizer.go
@@ -7,7 +7,6 @@ package authorizer
 
 import (
 	"context"
-	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -163,11 +162,7 @@ func makeInput(r *http.Request) (*http.Request, interface{}, error) {
 
 	if expectBody(r.Method, path) {
 		var err error
-		plaintextBody, err := util.ReadMaybeCompressedBody(r)
-		if err != nil {
-			return r, nil, err
-		}
-		rawBody, err = io.ReadAll(plaintextBody)
+		rawBody, err = util.ReadMaybeCompressedBody(r)
 		if err != nil {
 			return r, nil, err
 		}

--- a/server/handlers/decoding.go
+++ b/server/handlers/decoding.go
@@ -1,0 +1,40 @@
+package handlers
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/open-policy-agent/opa/server/types"
+	"github.com/open-policy-agent/opa/server/writer"
+	util_decoding "github.com/open-policy-agent/opa/util/decoding"
+)
+
+// This handler provides hard limits on the size of the request body, for both
+// the raw body content, and also for the decompressed size when gzip
+// compression is used.
+//
+// The Content-Length restriction happens here in the handler, but the
+// decompressed size limit is enforced later, in `util.ReadMaybeCompressedBody`.
+// The handler passes the gzip size limits down to that function through the
+// request context whenever gzip encoding is present.
+func DecodingLimitsHandler(handler http.Handler, maxLength, gzipMaxLength int64) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Reject too-large requests before doing any further processing.
+		// Note(philipc): This likely does nothing in the case of "chunked"
+		// requests, since those should report a ContentLength of -1.
+		if r.ContentLength > maxLength {
+			writer.Error(w, http.StatusBadRequest, types.NewErrorV1(types.CodeInvalidParameter, types.MsgDecodingLimitError))
+			return
+		}
+		// Pass server.decoding.gzip.max_length down, using the request context.
+		if strings.Contains(r.Header.Get("Content-Encoding"), "gzip") {
+			ctx := util_decoding.AddServerDecodingGzipMaxLen(r.Context(), gzipMaxLength)
+			r = r.WithContext(ctx)
+		}
+
+		// Copied over from the net/http package; enforces max body read limits.
+		r2 := *r
+		r2.Body = http.MaxBytesReader(w, r.Body, maxLength)
+		handler.ServeHTTP(w, &r2)
+	})
+}

--- a/server/server.go
+++ b/server/server.go
@@ -24,6 +24,7 @@ import (
 	"sync"
 	"time"
 
+	serverDecodingPlugin "github.com/open-policy-agent/opa/plugins/server/decoding"
 	serverEncodingPlugin "github.com/open-policy-agent/opa/plugins/server/encoding"
 
 	"github.com/gorilla/mux"
@@ -214,6 +215,11 @@ func (s *Server) Init(ctx context.Context) (*Server, error) {
 		return nil, err
 	}
 	s.DiagnosticHandler = s.initHandlerAuthn(s.DiagnosticHandler)
+
+	s.Handler, err = s.initHandlerDecodingLimits(s.Handler)
+	if err != nil {
+		return nil, err
+	}
 
 	return s, s.store.Commit(ctx, txn)
 }
@@ -750,6 +756,24 @@ func (s *Server) initHandlerAuthz(handler http.Handler) http.Handler {
 	}
 
 	return handler
+}
+
+// Enforces request body size limits on incoming requests. For gzipped requests,
+// it passes the size limit down the body-reading method via the request
+// context.
+func (s *Server) initHandlerDecodingLimits(handler http.Handler) (http.Handler, error) {
+	var decodingRawConfig json.RawMessage
+	serverConfig := s.manager.Config.Server
+	if serverConfig != nil {
+		decodingRawConfig = serverConfig.Decoding
+	}
+	decodingConfig, err := serverDecodingPlugin.NewConfigBuilder().WithBytes(decodingRawConfig).Parse()
+	if err != nil {
+		return nil, err
+	}
+	decodingHandler := handlers.DecodingLimitsHandler(handler, *decodingConfig.MaxLength, *decodingConfig.Gzip.MaxLength)
+
+	return decodingHandler, nil
 }
 
 func (s *Server) initHandlerCompression(handler http.Handler) (http.Handler, error) {
@@ -2731,7 +2755,7 @@ func readInputV0(r *http.Request) (ast.Value, *interface{}, error) {
 	}
 
 	// decompress the input if sent as zip
-	body, err := util.ReadMaybeCompressedBody(r)
+	bodyBytes, err := util.ReadMaybeCompressedBody(r)
 	if err != nil {
 		return nil, nil, fmt.Errorf("could not decompress the body: %w", err)
 	}
@@ -2739,17 +2763,13 @@ func readInputV0(r *http.Request) (ast.Value, *interface{}, error) {
 	var x interface{}
 
 	if strings.Contains(r.Header.Get("Content-Type"), "yaml") {
-		bs, err := io.ReadAll(body)
-		if err != nil {
-			return nil, nil, err
-		}
-		if len(bs) > 0 {
-			if err = util.Unmarshal(bs, &x); err != nil {
+		if len(bodyBytes) > 0 {
+			if err = util.Unmarshal(bodyBytes, &x); err != nil {
 				return nil, nil, fmt.Errorf("body contains malformed input document: %w", err)
 			}
 		}
 	} else {
-		dec := util.NewJSONDecoder(body)
+		dec := util.NewJSONDecoder(bytes.NewBuffer(bodyBytes))
 		if err := dec.Decode(&x); err != nil && err != io.EOF {
 			return nil, nil, fmt.Errorf("body contains malformed input document: %w", err)
 		}
@@ -2784,7 +2804,7 @@ func readInputPostV1(r *http.Request) (ast.Value, *interface{}, error) {
 	var request types.DataRequestV1
 
 	// decompress the input if sent as zip
-	body, err := util.ReadMaybeCompressedBody(r)
+	bodyBytes, err := util.ReadMaybeCompressedBody(r)
 	if err != nil {
 		return nil, nil, fmt.Errorf("could not decompress the body: %w", err)
 	}
@@ -2793,17 +2813,13 @@ func readInputPostV1(r *http.Request) (ast.Value, *interface{}, error) {
 	// There is no standard for yaml mime-type so we just look for
 	// anything related
 	if strings.Contains(ct, "yaml") {
-		bs, err := io.ReadAll(body)
-		if err != nil {
-			return nil, nil, err
-		}
-		if len(bs) > 0 {
-			if err = util.Unmarshal(bs, &request); err != nil {
+		if len(bodyBytes) > 0 {
+			if err = util.Unmarshal(bodyBytes, &request); err != nil {
 				return nil, nil, fmt.Errorf("body contains malformed input document: %w", err)
 			}
 		}
 	} else {
-		dec := util.NewJSONDecoder(body)
+		dec := util.NewJSONDecoder(bytes.NewBuffer(bodyBytes))
 		if err := dec.Decode(&request); err != nil && err != io.EOF {
 			return nil, nil, fmt.Errorf("body contains malformed input document: %w", err)
 		}
@@ -2828,11 +2844,10 @@ type compileRequestOptions struct {
 	DisableInlining []string
 }
 
-func readInputCompilePostV1(r io.ReadCloser) (*compileRequest, *types.ErrorV1) {
-
+func readInputCompilePostV1(reqBytes []byte) (*compileRequest, *types.ErrorV1) {
 	var request types.CompileRequestV1
 
-	err := util.NewJSONDecoder(r).Decode(&request)
+	err := util.NewJSONDecoder(bytes.NewBuffer(reqBytes)).Decode(&request)
 	if err != nil {
 		return nil, types.NewErrorV1(types.CodeInvalidParameter, "error(s) occurred while decoding request: %v", err.Error())
 	}

--- a/server/types/types.go
+++ b/server/types/types.go
@@ -81,6 +81,8 @@ const (
 	MsgMissingError               = "document missing"
 	MsgFoundUndefinedError        = "document undefined"
 	MsgPluginConfigError          = "error(s) occurred while configuring plugin(s)"
+	MsgDecodingLimitError         = "request body too large"
+	MsgDecodingGzipLimitError     = "compressed request body too large"
 )
 
 // PatchV1 models a single patch operation against a document.

--- a/util/decoding/context.go
+++ b/util/decoding/context.go
@@ -1,0 +1,21 @@
+package decoding
+
+import "context"
+
+type requestContextKey string
+
+// Note(philipc): We can add functions later to add the max request body length
+// to contexts, if we ever need to.
+const (
+	reqCtxKeyMaxLen     = requestContextKey("server-decoding-plugin-context-max-length")
+	reqCtxKeyGzipMaxLen = requestContextKey("server-decoding-plugin-context-gzip-max-length")
+)
+
+func AddServerDecodingGzipMaxLen(ctx context.Context, maxLen int64) context.Context {
+	return context.WithValue(ctx, reqCtxKeyGzipMaxLen, maxLen)
+}
+
+func GetServerDecodingGzipMaxLen(ctx context.Context) (int64, bool) {
+	gzipMaxLength, ok := ctx.Value(reqCtxKeyGzipMaxLen).(int64)
+	return gzipMaxLength, ok
+}


### PR DESCRIPTION
### Why the changes in this PR are needed?
In a [recent bugfix PR][opa-pr-6825], I discovered some performance issues around how request bodies are handled in OPA, particularly when the request is gzipped. This PR is a follow-up to that one, and changes how OPA reads request bodies.

The main performance benefits of this PR come from reducing the workload of the Golang GC, and also by removing redundant `Read` operations on the request body.

### What are the changes in this PR?

This PR preallocates the entire buffer for a request body (and also for its decompressed payload) when possible. This reduces max [RSS][wikipedia-rss] for large requests by around 5-10%, and reduces GC overhead by 33-66% for large requests, while not penalizing small (<1kb) requests.

The changes are structured as follows:
 - `docs/`: Updated for the new config options.
 - `plugins/server/decoding`: New always-on plugin, modeled after the `server/encoding` plugin.
   - Includes new handler type for the OPA HTTP server.
 - `server/server.go`: Integrates the new request handler + uses the request body reading function.
 - `util/read_gzip_body.go`: Allocs whole buffers up-front now, and checks gzip blob sizes before decompressing.

Other small changes were needed in a variety of spots to account for new method signatures, and so on.

#### New configuration options: `server.decoding`
This PR introduces two new server config fields under `server.decoding`. Here's an example configuration file:

```yaml
# Only allow up to 128 MB request bodies, and up to 256 MB decompressed gzip payloads.
server:
  decoding:
    max_length: 134217728
    gzip:
      max_length: 268435456
```

These fields keep in line with the naming scheme from `server.encoding`, but I'm open to other ideas! :sweat_smile: 

#### Defending against huge requests
On `main` currently, an attacker can tie up a huge amount of resources for an OPA instance with a large, malicious request. Gzipped payloads amplify the resources that can ultimately be tied up. (Example: a 1 GB JSON object with repetitive values can compress down to 5 MB or smaller with gzip.)

In this PR, buffers are allocated all-at-once, which is hazardous-- an attacker could submit a huge request, and cause OPA to experience an out of memory (OOM) error just from allocating the buffers for the request.

In the case of gzip payloads, the raw payload size may be small, but with a forged [gzip size trailer field][wikipedia-gzip-format], the attack could cause the buffer allocation logic to believe that the gzip blob will expand to up to 4 GB in size when decompressed! This makes preallocating the decompression buffer a dangerous thing to do without some sort of validation beforehand.

In this PR, the proposed solution is validating the size of incoming request bodies against server-configured limits before allocating any buffers. That forces attackers in both scenarios to have to work a bit harder to do anything nefarious.

#### Where are the new validation checks?

The defenses against huge requests happen in 2x places:
 - For large request payloads, these are checked in the new `DecodingLimits` handler in the OPA HTTP server. This allows us to reject those requests before they can significantly tie up an OPA server's resources.
 - For large gzip payloads, these are checked in the `util.ReadMaybeCompressedBody` function (used whenever we want to read the request body contents), which checks the gzip blob's 4-byte size trailer field against the server's configured size limits.

### Notes to assist PR review:

I've moved benchmark sets into comments in the PR discussion thread, since this top PR description was getting a bit crowded. :sweat_smile: 

#### Scripts used:

<details>
<summary><b><code>summarize-gctrace.awk</code></b></summary>

```awk
# AWK script for summarizing GODEBUG=gctrace=1 logs.
# Known to work for Go 1.22, but the log format is subject to change.
# The format is the following (pulled from the Go `runtime` package docs):
#   gc # @#s #%: #+#+# ms clock, #+#/#/#+# ms cpu, #->#-># MB, # MB goal, # MB stacks, #MB globals, # P
#                ^$5             ^$10                                                               ^$28
# Example:
#   gc 11 @3.169s 1%: 0.025+509+0.017 ms clock, 0.10+0/261/0.81+0.068 ms cpu, 3585->3585->2561 MB, 3585 MB goal, 0 MB stacks, 0 MB globals, 4 P

BEGIN {
    FS = "[\t +/]+"
}

# Some simple assertions to prevent matching non-gctrace logs.
$1 != "gc" { non_matching_rows++; next; }
$9 == "cpu" { non_matching_rows++; next; }

# The main pattern-action block:
{
    num_threads = $28

    clock_stw_sweep_term += $5
    clock_conc_mark_scan += $6
    clock_stw_mark_term += $7

    cur_clock = $5 + $6 + $7
    total_clock += cur_clock
    max_pause_clock = (max_pause_clock > cur_clock) ? max_pause_clock : cur_clock

    cpu_ms_stw_sweep_term += $10
    cpu_ms_assist_gc += $11
    cpu_ms_background_gc += $12
    cpu_ms_idle_gc += $13
    cpu_ms_stw_mark_term += $14
    total_cpu += $11 + $12 + $13
}

END {
    print  "--- Wall clock time summary -------------------"
    printf "  STW sweep termination ......... %10.3f ms\n", clock_stw_sweep_term
    printf "  Concurrent mark and scan ...... %10.3f ms\n", clock_conc_mark_scan
    printf "  STW mark termination .......... %10.3f ms\n", clock_stw_mark_term
    printf "                          Total = %10.3f ms (%.3f s)\n", total_clock, total_clock / 1000
    printf "               Longest GC Pause = %10.3f ms\n", max_pause_clock
    print  ""
    print  "--- CPU time breakdown ------------------------"
    printf "  STW sweep termination ......... %10.3f ms\n", cpu_ms_stw_sweep_term
    printf "    Mark/Scan assist time ....... %10.3f ms\n", cpu_ms_assist_gc
    printf "    Mark/Scan background GC time  %10.3f ms\n", cpu_ms_background_gc
    printf "    Mark/Scan idle GC time ...... %10.3f ms\n", cpu_ms_idle_gc
    printf "  STW mark termination .......... %10.3f ms\n", cpu_ms_stw_mark_term
    printf "                          Total = %10.3f ms (%.3f s) (Does not include STW phases)\n", total_cpu, total_cpu / 1000
    print  ""
    print  "Num threads:", num_threads
    print  "Non-matching rows:", non_matching_rows
}
```

</details>

<details>
<summary><b><code>geninput.py</code></b></summary>

```python3
N = 1024 * 1024
oneKBString = "A" * 1024

if __name__ == "__main__":
    print('{"input":{')
    for i in range(0, N):
        print('"{}": "{}",'.format(i, oneKBString))
    print('"{}": "{}"'.format(N, oneKBString))
    print("}}")
```

</details>


### Further comments:

Remaining TODO items:

 - [x] Add draft release notes
 - Add more tests?
 - Add Go benchmark?

Things I'd love reviewer comments/opinions on:

 - How big should our default max request size be? How about the max gzip payload size?
 - Could the error messages be improved?
 - Could the config keys have better names?

   [opa-pr-6825]: https://github.com/open-policy-agent/opa/pull/6825
   [wikipedia-rss]: https://en.wikipedia.org/wiki/Resident_set_size
   [wikipedia-gzip-format]: https://en.wikipedia.org/wiki/Gzip#File_format