### PR TITLE
Add ability for opa inspect to inspect a single file outside of any bundle

### DIFF
--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -57,10 +57,10 @@ func init() {
 
 	var inspectCommand = &cobra.Command{
 		Use:   "inspect <path> [<path> [...]]",
-		Short: "Inspect OPA bundle(s)",
-		Long: `Inspect OPA bundle(s).
+		Short: "Inspect OPA bundle(s) or Rego files.",
+		Long: `Inspect OPA bundle(s) or Rego files.
 
-The 'inspect' command provides a summary of the contents in OPA bundle(s). Bundles are
+The 'inspect' command provides a summary of the contents in OPA bundle(s) or a single Rego file. Bundles are
 gzipped tarballs containing policies and data. The 'inspect' command reads bundle(s) and lists
 the following:
 
@@ -77,8 +77,10 @@ Example:
     bundle.tar.gz
     $ opa inspect bundle.tar.gz
 
-You can provide exactly one OPA bundle or path to the 'inspect' command on the command-line. If you provide a path
-referring to a directory, the 'inspect' command will load that path as a bundle and summarize its structure and contents.
+You can provide exactly one OPA bundle, path to a bundle directory, or direct path to a Rego file to the 'inspect' command 
+on the command-line. If you provide a path referring to a directory, the 'inspect' command will load that path as a bundle
+and summarize its structure and contents. If you provide a path referring to a Rego file, the 'inspect' command will load
+that file and summarize its structure and contents.
 `,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if err := validateInspectParams(&params, args); err != nil {
@@ -111,8 +113,7 @@ func doInspect(params inspectCommandParams, path string, out io.Writer) error {
 		return pr.JSON(out, info)
 
 	default:
-		if info.Manifest.Revision != "" || len(*info.Manifest.Roots) != 0 || len(info.Manifest.Metadata) != 0 ||
-			info.Manifest.RegoVersion != nil {
+		if hasManifest(info) {
 			if err := populateManifest(out, info.Manifest); err != nil {
 				return err
 			}
@@ -134,6 +135,14 @@ func doInspect(params inspectCommandParams, path string, out io.Writer) error {
 	}
 }
 
+func hasManifest(info *ib.Info) bool {
+	if info.Manifest == nil {
+		return false
+	}
+	return info.Manifest.Revision != "" || len(*info.Manifest.Roots) != 0 || len(info.Manifest.Metadata) != 0 ||
+		info.Manifest.RegoVersion != nil
+}
+
 func validateInspectParams(p *inspectCommandParams, args []string) error {
 	if len(args) != 1 {
 		return fmt.Errorf("specify exactly one OPA bundle or path")
@@ -146,7 +155,7 @@ func validateInspectParams(p *inspectCommandParams, args []string) error {
 	return fmt.Errorf("invalid output format for inspect command")
 }
 
-func populateManifest(out io.Writer, m bundle.Manifest) error {
+func populateManifest(out io.Writer, m *bundle.Manifest) error {
 	t := generateTableWithKeys(out, "field", "value")
 	var lines [][]string
 

--- a/internal/bundle/inspect/inspect.go
+++ b/internal/bundle/inspect/inspect.go
@@ -22,7 +22,7 @@ import (
 
 // Info represents information about a bundle.
 type Info struct {
-	Manifest    bundle.Manifest          `json:"manifest,omitempty"`
+	Manifest    *bundle.Manifest         `json:"manifest,omitempty"`
 	Signatures  bundle.SignaturesConfig  `json:"signatures_config,omitempty"`
 	WasmModules []map[string]interface{} `json:"wasm_modules,omitempty"`
 	Namespaces  map[string][]string      `json:"namespaces,omitempty"`
@@ -35,6 +35,14 @@ func File(path string, includeAnnotations bool) (*Info, error) {
 }
 
 func FileForRegoVersion(regoVersion ast.RegoVersion, path string, includeAnnotations bool) (*Info, error) {
+	if strings.HasSuffix(path, bundle.RegoExt) {
+		return fileInfoForRegoVersion(regoVersion, path, includeAnnotations)
+	}
+
+	return bundleOrDirInfoForRegoVersion(regoVersion, path, includeAnnotations)
+}
+
+func bundleOrDirInfoForRegoVersion(regoVersion ast.RegoVersion, path string, includeAnnotations bool) (*Info, error) {
 	b, err := loader.NewFileLoader().
 		WithRegoVersion(regoVersion).
 		WithSkipBundleVerification(true).
@@ -52,7 +60,7 @@ func FileForRegoVersion(regoVersion ast.RegoVersion, path string, includeAnnotat
 		return nil, err
 	}
 
-	bi := &Info{Manifest: b.Manifest}
+	bi := &Info{Manifest: &b.Manifest}
 
 	namespaces := make(map[string][]string, len(b.Modules))
 	modules := make([]*ast.Module, 0, len(b.Modules))
@@ -198,4 +206,56 @@ func (bi *Info) getBundleDataWasmAndSignatures(name string) error {
 	}
 
 	return nil
+}
+
+func fileInfoForRegoVersion(regoVersion ast.RegoVersion, path string, includeAnnotations bool) (*Info, error) {
+	res, err := loader.NewFileLoader().
+		WithRegoVersion(regoVersion).
+		WithSkipBundleVerification(true).
+		WithProcessAnnotation(true). // Always process annotations, for enriching namespace listing
+		WithJSONOptions(&json.Options{
+			MarshalOptions: json.MarshalOptions{
+				IncludeLocation: json.NodeToggle{
+					// Annotation location data is only included if includeAnnotations is set
+					AnnotationsRef: includeAnnotations,
+				},
+			},
+		}).
+		All([]string{path})
+	if err != nil {
+		return nil, err
+	}
+	bi := &Info{
+		Namespaces: make(map[string][]string, len(res.Modules)),
+	}
+
+	moduleMap := make(map[string]*ast.Module, len(res.Modules))
+
+	for _, m := range res.Modules {
+		bi.Namespaces[m.Parsed.Package.Path.String()] = append(
+			bi.Namespaces[m.Parsed.Package.Path.String()],
+			filepath.Clean(m.Name),
+		)
+		moduleMap[m.Name] = m.Parsed
+	}
+
+	if includeAnnotations {
+		as, errs := ast.BuildAnnotationSet(util.Values(moduleMap))
+		if len(errs) > 0 {
+			return nil, errs
+		}
+
+		bi.Annotations = as.Flatten()
+	}
+
+	c := ast.NewCompiler().
+		WithAllowUndefinedFunctionCalls(true)
+	c.Compile(moduleMap)
+	if c.Failed() {
+		return bi, c.Errors
+	}
+
+	bi.Required = c.Required
+
+	return bi, nil
 }

--- a/util/maps.go
+++ b/util/maps.go
@@ -1,0 +1,10 @@
+package util
+
+// Values returns a slice of values from any map. Copied from golang.org/x/exp/maps.
+func Values[M ~map[K]V, K comparable, V any](m M) []V {
+	r := make([]V, 0, len(m))
+	for _, v := range m {
+		r = append(r, v)
+	}
+	return r
+}

--- a/util/maps_test.go
+++ b/util/maps_test.go
@@ -1,0 +1,18 @@
+package util
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestValues(t *testing.T) {
+	testMap := map[string]int{"a": 1, "b": 2, "c": 3}
+	values := Values(testMap)
+	if len(values) != 3 {
+		t.Errorf("Expected 3 values, got %d", len(values))
+	}
+	slices.Sort(values)
+	if values[0] != 1 || values[1] != 2 || values[2] != 3 {
+		t.Errorf("Expected [1, 2, 3], got %v", values)
+	}
+}


### PR DESCRIPTION
<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->

### Why the changes in this PR are needed?

Resolves https://github.com/open-policy-agent/opa/issues/6799 by adding the ability for the `opa inspect` command to handle single files in addition to the currently supported bundle directory and tarball options. This PR is necessary to improve the UX of inspecting annotations in a single file.

<!--
Include a short description of WHY the changes were made.
-->

### What are the changes in this PR?

Adds a new method and decision tree to the `opa inspect` command that will process a single file if the argument passed to the command ends with `.rego`. Will follow other `opa inspect` processing semantics and behavior - changes are constrained to loading the single file and processing it as its own entity outside of the scope of a bundle.

<!--
Include a short description of WHAT changes were made.
-->

### Notes to assist PR review:

I'm not terribly familiar with OPA's WASM capabilities yet - @anderseknert is there anything in this issue you were thinking would extend to WASM as well that I could add?

I also updated vendored deps as part of this PR - let me know if I should back those changes out.

<!--
Here you can add information you think will help the reviewer(s).
-->

### Further comments:

<!--
Here you can include links to additional resources related to the changes, discuss your solution, other approaches you considered etc.
-->
