### PR TITLE
server: Add missing handling for `explain=fails` to the REST API.

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -2737,6 +2737,8 @@ func getExplain(p []string, zero types.ExplainModeV1) types.ExplainModeV1 {
 		switch x {
 		case string(types.ExplainNotesV1):
 			return types.ExplainNotesV1
+		case string(types.ExplainFailsV1):
+			return types.ExplainFailsV1
 		case string(types.ExplainFullV1):
 			return types.ExplainFullV1
 		case string(types.ExplainDebugV1):


### PR DESCRIPTION
### Why the changes in this PR are needed?

To enable missing functionality referenced by the REST API docs.

### What are the changes in this PR?

Add handling for the `types.ExplainFailsV1` type to the server code.