### PR TITLE
fix: Support AWS_CONTAINER_CREDENTIALS_FULL_URI metadata endpoint

### DIFF
--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -393,7 +393,9 @@ To use the EC2 metadata service, the IAM role to use and the AWS region for the 
 be specified as `iam_role` and `aws_region` respectively.
 
 To use the ECS metadata service, specify only the AWS region for the resource as `aws_region`. ECS
-containers have at most one associated IAM role.
+containers have at most one associated IAM role. As per the [AWS documentation](https://docs.aws.amazon.com/sdkref/latest/guide/feature-container-credentials.html), credentials are
+sourced from the `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` metadata environment variable or the
+`AWS_CONTAINER_CREDENTIALS_FULL_URI` metadata environment variable in order.
 
 > Providing a value for `iam_role` will cause OPA to use the EC2 metadata service even
 > if running inside an ECS container. This may result in unexpected problems if, for example,

--- a/plugins/rest/aws_test.go
+++ b/plugins/rest/aws_test.go
@@ -351,6 +351,13 @@ func TestMetadataCredentialService(t *testing.T) {
 	_, err = cs.credentials(context.Background())
 	assertErr("metadata endpoint cannot be determined from settings and environment", err, t)
 
+	// wrong path: missing token
+	t.Setenv(ecsFullPathEnvVar, "fullPath")
+	os.Unsetenv(ecsAuthorizationTokenEnvVar)
+	_, err = cs.credentials(context.Background())
+	assertErr("unable to get ECS metadata authorization token", err, t)
+	os.Unsetenv(ecsFullPathEnvVar)
+
 	// wrong path: creds not found
 	cs = awsMetadataCredentialService{
 		RoleName:        "not_my_iam_role", // not present
@@ -490,6 +497,34 @@ func TestMetadataCredentialService(t *testing.T) {
 	assertEq(creds.SecretKey, ts.payload.SecretAccessKey, t)
 	assertEq(creds.RegionName, cs.RegionName, t)
 	assertEq(creds.SessionToken, ts.payload.Token, t)
+
+	// happy path: credentials fetched from full path var
+	cs = awsMetadataCredentialService{
+		RegionName:      "us-east-1",
+		credServicePath: "", // not set as we want to test env var resolution
+		logger:          logging.Get(),
+	}
+	ts.payload = metadataPayload{
+		AccessKeyID:     "MYAWSACCESSKEYGOESHERE",
+		SecretAccessKey: "MYAWSSECRETACCESSKEYGOESHERE",
+		Code:            "Success",
+		Token:           "MYAWSSECURITYTOKENGOESHERE",
+		Expiration:      time.Now().UTC().Add(time.Minute * 2)} // short time
+	t.Setenv(ecsFullPathEnvVar, ts.server.URL+"/fullPath")
+	t.Setenv(ecsAuthorizationTokenEnvVar, "THIS_IS_A_GOOD_TOKEN")
+
+	creds, err = cs.credentials(context.Background())
+	if err != nil {
+		// Cannot proceed with test if unable to fetch credentials.
+		t.Fatal(err)
+	}
+
+	assertEq(creds.AccessKey, ts.payload.AccessKeyID, t)
+	assertEq(creds.SecretKey, ts.payload.SecretAccessKey, t)
+	assertEq(creds.RegionName, cs.RegionName, t)
+	assertEq(creds.SessionToken, ts.payload.Token, t)
+	os.Unsetenv(ecsFullPathEnvVar)
+	os.Unsetenv(ecsAuthorizationTokenEnvVar)
 }
 
 func TestMetadataServiceErrorHandled(t *testing.T) {
@@ -957,6 +992,7 @@ type ec2CredTestServer struct {
 func (t *ec2CredTestServer) handle(w http.ResponseWriter, r *http.Request) {
 	goodPath := "/latest/meta-data/iam/security-credentials/my_iam_role"
 	badPath := "/latest/meta-data/iam/security-credentials/my_bad_iam_role"
+	goodPathFull := "/fullPath"
 
 	goodTokenPath := "/latest/api/token"
 	badTokenPath := "/latest/api/bad_token"
@@ -987,6 +1023,15 @@ func (t *ec2CredTestServer) handle(w http.ResponseWriter, r *http.Request) {
 		// a metadata response that's not well-formed
 		w.WriteHeader(200)
 		_, _ = w.Write([]byte("This isn't a JSON payload"))
+	case goodPathFull:
+		// validate token...
+		if r.Header.Get("Authorization") == tokenValue {
+			w.WriteHeader(200)
+			_, _ = w.Write(jsonBytes)
+		} else {
+			// AWS returns a 404 if the token is wrong
+			w.WriteHeader(404)
+		}
 	default:
 		// something else that we won't be able to find
 		w.WriteHeader(404)


### PR DESCRIPTION
Support loading credentials from the AWS_CONTAINER_CREDENTIALS_FULL_URI metadata endpoint which is helpful for AWS SnapStart lamdbas

Fixes #6893

---

Not modifying any tests as it doesnt look like we test this url resolution anyway. 

See [AWS Docs](https://docs.aws.amazon.com/sdkref/latest/guide/feature-container-credentials.html#:~:text=Note%3A%20This%20setting%20is%20an%20alternative%20to%20AWS_CONTAINER_CREDENTIALS_RELATIVE_URI%20and%20will%20only%20be%20used%20if%20AWS_CONTAINER_CREDENTIALS_RELATIVE_URI%20is%20not%20set.) for more information on why this is needed
