### PR TITLE
util+server: Fix bug around chunked request handling.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Fixes
+
+- util+server: Fix bug around chunked request handling. This PR fixes a request handling bug introduced in ([#6868](https://github.com/open-policy-agent/opa/pull/6868)), which caused OPA to treat all incoming chunked requests as if they had zero-length request bodies. ([#6906](https://github.com/open-policy-agent/opa/pull/6906)) authored by @philipaconrad
+
 ## 0.67.0
 
 This release contains a mix of features, a new builtin function (`strings.count`), performance improvements, and bugfixes.

--- a/server/handlers/decoding.go
+++ b/server/handlers/decoding.go
@@ -20,11 +20,24 @@ import (
 func DecodingLimitsHandler(handler http.Handler, maxLength, gzipMaxLength int64) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Reject too-large requests before doing any further processing.
-		// Note(philipc): This likely does nothing in the case of "chunked"
+		// Note(philipc): This does nothing in the case of "chunked"
 		// requests, since those should report a ContentLength of -1.
 		if r.ContentLength > maxLength {
 			writer.Error(w, http.StatusBadRequest, types.NewErrorV1(types.CodeInvalidParameter, types.MsgDecodingLimitError))
 			return
+		}
+		// For requests where full size is not known in advance (such as chunked
+		// requests), pass server.decoding.max_length down, using the request
+		// context.
+
+		// Note(philipc): Unknown request body size is signaled to the server
+		// handler by net/http setting the Request.ContentLength field to -1. We
+		// don't check for the `Transfer-Encoding: chunked` header explicitly,
+		// because net/http will strip it out from requests automatically.
+		// Ref: https://pkg.go.dev/net/http#Request
+		if r.ContentLength < 0 {
+			ctx := util_decoding.AddServerDecodingMaxLen(r.Context(), maxLength)
+			r = r.WithContext(ctx)
 		}
 		// Pass server.decoding.gzip.max_length down, using the request context.
 		if strings.Contains(r.Header.Get("Content-Encoding"), "gzip") {

--- a/util/decoding/context.go
+++ b/util/decoding/context.go
@@ -11,8 +11,18 @@ const (
 	reqCtxKeyGzipMaxLen = requestContextKey("server-decoding-plugin-context-gzip-max-length")
 )
 
+func AddServerDecodingMaxLen(ctx context.Context, maxLen int64) context.Context {
+	return context.WithValue(ctx, reqCtxKeyMaxLen, maxLen)
+}
+
 func AddServerDecodingGzipMaxLen(ctx context.Context, maxLen int64) context.Context {
 	return context.WithValue(ctx, reqCtxKeyGzipMaxLen, maxLen)
+}
+
+// Used for enforcing max body content limits when dealing with chunked requests.
+func GetServerDecodingMaxLen(ctx context.Context) (int64, bool) {
+	maxLength, ok := ctx.Value(reqCtxKeyMaxLen).(int64)
+	return maxLength, ok
 }
 
 func GetServerDecodingGzipMaxLen(ctx context.Context) (int64, bool) {


### PR DESCRIPTION
### What are the changes in this PR?

This PR fixes a request handling bug introduced in #6868, which caused OPA to treat all incoming chunked requests as if they had zero-length request bodies.

The fix detects cases where the request body size is unknown in the DecodingLimits handler, and propagates a request context key down to the `util.ReadMaybeCompressedBody` function, allowing it to correctly select between using the original `io.ReadAll` style for chunked requests, or the newer preallocated buffers approach (for requests of known size).

This change has a small, but barely visible performance impact for large requests (<5% increase in GC pauses for a 1GB request JSON blob), and minimal, if any, effect on RPS under load.

Fixes: #6904

### Notes to assist PR review:

 - A new context key is passed down from the `DecodingLimits` handler wrapper in `server/server.go` to the `util.ReadMaybeCompressedBody` function in `util/read_gzip_body.go`. This is used to signal cases where the request body is of indeterminate length, and the body reader should enforce the size limit itself.
 - Added back the original `io.ReadAll` code path in `util.ReadMaybeCompressedBody`, but it only triggers now on chunked requests, and is guarded both at the top-level in the DecodingLimits handler with a `MaxBytesReader`, and at the `io.ReadAll` callsite with a `LimitReader`. This prevents accidentally reading more of the request body than intended.
 - Gzip handling did not need any changes for this fix, surprisingly! It takes whatever content we pulled from the incoming request/request-stream, and processes it exactly as before.
 - Test cases were extended to throw errors on unexpected warnings, which allows us to catch the issue in #6904 that the tests didn't surface back in #6868.

### Further notes:

 - Performance impact is minimal: RPS under load seems to be unaffected, and GC overheads increased by <5% for 1GB requests in my local testing.