### PR TITLE
Make it possible to only build wasm testcases

### DIFF
--- a/build/run-wasm-rego-tests.sh
+++ b/build/run-wasm-rego-tests.sh
@@ -16,13 +16,18 @@ ASSETS=${ASSETS:-"$PWD/test/wasm/assets"}
 VERBOSE=${VERBOSE:-"0"}
 TESTGEN_CONTAINER_NAME="opa-wasm-testgen-container"
 TESTRUN_CONTAINER_NAME="opa-wasm-testrun-container"
+WASM_BUILD_ONLY=${WASM_BUILD_ONLY:-"false"}
 
 function main {
     trap interrupt SIGINT SIGTERM
     mkdir -p $PWD/.go/cache/go-build
     mkdir -p $PWD/.go/bin
     generate_testcases
-    run_testcases
+    if [[ "${WASM_BUILD_ONLY}" != "true" ]]; then
+        run_testcases
+    else
+        echo "Running wasm tests disabled by environment variable."
+    fi
 }
 
 function interrupt {


### PR DESCRIPTION
### Why the changes in this PR are needed?

Tackling this "TODO":
https://github.com/open-policy-agent/npm-opa-wasm/blob/92b8aa0234a7e487f2bd335ea1544351718972f7/.github/workflows/ci.yml#L50-L52

as I'm in the same situation:
https://github.com/andreaTP/opa-chicory/blob/d37da558e054510e50da53bf7a1933e0bc19a136/.github/workflows/ci.yml#L33-L34

### What are the changes in this PR?

Add the handling for an env var `WASM_BUILD_ONLY` so that, running:

```
WASM_BUILD_ONLY=true make wasm-rego-test
```
Would not run the tests saving time and container images downloads.

### Notes to assist PR review:

Attempted to do the least intrusive possible change.

### Further comments:

An additional step would be to upload the resulting `testcases.tar.gz` to GH releases, but I'm looking for feedback before doing the changes.