### PR TITLE
The [opa eval] command is unable to access Rego policies located on other drives on windows

### DIFF
--- a/loader/loader.go
+++ b/loader/loader.go
@@ -572,7 +572,7 @@ func SplitPrefix(path string) ([]string, string) {
 		return nil, path
 	}
 	parts := strings.SplitN(path, ":", 2)
-	if len(parts) == 2 && len(parts[0]) > 0 {
+	if len(parts) == 2 && len(parts[0]) > 1 {
 		return strings.Split(parts[0], "."), parts[1]
 	}
 	return nil, path

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -823,6 +823,10 @@ func TestSplitPrefix(t *testing.T) {
 			wantParts: []string{"x", "y"},
 			wantPath:  "file:///c:/a/b/c",
 		},
+		{
+			input:    "c:/a/b/c",
+			wantPath: "c:/a/b/c",
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
The [opa eval] command is unable to access Rego policies located on other drives in Windows. For more details, see https://github.com/open-policy-agent/opa/issues/6910 and https://github.com/open-policy-agent/conftest/issues/979.

OPA should be capable of accessing Rego policies from specified paths including drives (e.g., c:\a\b\c.rego).

The code has been updated to allow OPA to load Rego policies from paths with drives. Now, OPA can load Rego policies from paths(e.g., `/a/b/c/example.rego`), path with URLs(e.g., `file:///path/to/file.json`), and path with drives(e.g., `C:\a\b\c\example.rego`).

Fixes https://github.com/open-policy-agent/opa/issues/6910

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.

-->

### Why the changes in this PR are needed?
The `opa eval` command encountered an issue where it could not load Rego policies from different drives on Windows. The error message was:

```
CreateFile \\Users\\pck\\AppData\\Local\\Temp\\temp_dir_12342318055089\\example.rego: The system cannot find the path specified
```
It fixes: https://github.com/open-policy-agent/opa/issues/6910 and https://github.com/open-policy-agent/conftest/issues/979


<!--
Include a short description of WHY the changes were made.
-->

### What are the changes in this PR?

#### Code Update:
The code has been modified to allow OPA to load Rego policies from paths that include drive letters. Now, OPA supports loading Rego policies from:
- Paths (e.g., `/a/b/c/example.rego`)
- Paths with URLs (e.g., `file:///path/to/file.json`)
- Paths with drive letters (e.g., `C:\a\b\c\example.rego`)

#### Documentation Reference:
According to the [official documentation](https://www.openpolicyagent.org/docs/latest/cli/#examples), the expected values for the `--data` flag in the `opa eval` command are:
1. A simple path (e.g., `/a/b/c/example.rego`)
2. A path with a URL (e.g., `file:///path/to/file.json`)

Ideally, specifying a path like `C:\a\b\c\example.rego` should work, but it was failing. The code was modified to support paths with drive letters by ensuring that the prefix is only separated when its length is greater than 1.

<!--
Include a short description of WHAT changes were made.
-->

### Notes to assist PR review:

#### Steps to Reproduce the issue:
1. Place the OPA binary on the D drive.
2. Store the Rego policies on the C drive.
3. Attempt to evaluate the policies using the `opa eval` command with the policies located on the C drive. The above error will occur. For more details, refer to [this GitHub issue](https://github.com/open-policy-agent/opa/issues/6910#issuecomment-2282810960).


<!--
Here you can add information you think will help the reviewer(s).
-->

### Further comments:

#### [opa eval] command before fix. (Failed: opa in D drive and Failed to load rego policies from C drive.)
![Screenshot 2024-08-11 at 9 10 42 PM_Edited](https://github.com/user-attachments/assets/9ef23efc-032b-4a96-86d1-5885f67b3cac)


#### [opa eval] command after fix. (Success: opa in D drive and Failed to load rego policies from C drive.)
<img width="1164" alt="Screenshot 2024-08-12 at 1 50 03 PM" src="https://github.com/user-attachments/assets/9b07b095-170a-453e-b01f-9bf46ba39724">

#### Unit Testcase pass screenshot. [Function tested](https://github.com/open-policy-agent/opa/blob/main/loader/loader.go#L568)
<img width="644" alt="Screenshot 2024-08-12 at 1 50 28 PM" src="https://github.com/user-attachments/assets/4ae0a2fc-142e-4b0b-a900-b5af74e32656">

<!--
Here you can include links to additional resources related to the changes, discuss your solution, other approaches you considered etc.
-->

 @boranx Can you please review this change and share your comments? Thanks in advance
