### PR TITLE
cmd/exec: remove "pretty" format

### DIFF
--- a/cmd/internal/exec/params.go
+++ b/cmd/internal/exec/params.go
@@ -33,7 +33,7 @@ type Params struct {
 func NewParams(w io.Writer) *Params {
 	return &Params{
 		Output:       w,
-		OutputFormat: util.NewEnumFlag("pretty", []string{"pretty", "json"}),
+		OutputFormat: util.NewEnumFlag("json", []string{"json"}),
 		LogLevel:     util.NewEnumFlag("error", []string{"debug", "info", "error"}),
 		LogFormat:    util.NewEnumFlag("json", []string{"text", "json", "json-pretty"}),
 	}


### PR DESCRIPTION
This was never supported, and the flag is thus confusing. Since the only supported format is "json" (the default), the flag is redundant now. However, I've kept it so if someone uses `opa exec --format=json` somewhere, their calls won't become invalid.

If someone had been using `opa exec --format=pretty`, they will now see an error, but I think that's less confusing: pretty formatting is just not supported for 'opa exec'.

