### PR TITLE
ast: Fixing nil pointer dereference in compiler for partial rule edge case

### DIFF
--- a/ast/index.go
+++ b/ast/index.go
@@ -494,7 +494,7 @@ func (node *trieNode) String() string {
 func (node *trieNode) append(prio [2]int, rule *Rule) {
 	node.rules = append(node.rules, &ruleNode{prio, rule})
 
-	if node.values != nil {
+	if node.values != nil && rule.Head.Value != nil {
 		node.values.Add(rule.Head.Value)
 		return
 	}


### PR DESCRIPTION
Only appending rule to trieNode values list if it has declared value.

Fixes: #6930
