### PR TITLE
distributedtracing: adding distributed tracing resource attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+- allow OpenTelemetry resource attributes to be configured under distributed_tracing config
+
 ### CLI
 
 - `opa exec`: This command never supported "pretty" formatting (`--format=pretty` or `-f pretty`), only `json`. Passing `pretty` is now invalid.

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -76,6 +76,10 @@ distributed_tracing:
   service_name: opa
   sample_percentage: 50
   encryption: "off"
+  resource:
+    service_namespace: "my-namespace"
+    service_version: "1.1"
+    service_instance_id: "1"
 
 server:
   decoding:
@@ -854,17 +858,20 @@ on the [http.send built-in function](../policy-reference/#http) for information 
 
 Distributed tracing represents the configuration of the OpenTelemetry Tracing.
 
-| Field | Type | Required | Description |
-| --- | --- | --- | --- |
-| `distributed_tracing.type` | `string` | No | Setting this to "grpc" enables distributed tracing with an collector gRPC endpoint |
-| `distributed_tracing.address` | `string` | No (default: `localhost:4317`) | Address of the OpenTelemetry Collector gRPC endpoint. |
-| `distributed_tracing.service_name` | `string` | No (default: `opa`) | Logical name of the service. |
-| `distributed_tracing.sample_percentage` | `int` | No (default: `100`) | Percentage of traces that are sampled and exported. |
-| `distributed_tracing.encryption` | `string` | No (default: `off`) | Configures TLS. |
-| `distributed_tracing.allow_insecure_tls` | `bool` | No (default: `false`) | Allow insecure TLS. |
-| `distributed_tracing.tls_ca_cert_file` | `string` | No | The path to the root CA certificate. |
-| `distributed_tracing.tls_cert_file` | `string` | No (unless `encryption` equals `mtls`) | The path to the client certificate to authenticate with. |
-| `distributed_tracing.tls_private_key_file` | `string` | No (unless `tls_cert_file` provided)  | The path to the private key of the client certificate. |
+| Field                                              | Type     | Required | Description                                                                        |
+|----------------------------------------------------|----------| --- |------------------------------------------------------------------------------------|
+| `distributed_tracing.type`                         | `string` | No | Setting this to "grpc" enables distributed tracing with an collector gRPC endpoint |
+| `distributed_tracing.address`                      | `string` | No (default: `localhost:4317`) | Address of the OpenTelemetry Collector gRPC endpoint.                              |
+| `distributed_tracing.service_name`                 | `string` | No (default: `opa`) | Logical name of the service.                                                       |
+| `distributed_tracing.sample_percentage`            | `int`    | No (default: `100`) | Percentage of traces that are sampled and exported.                                |
+| `distributed_tracing.encryption`                   | `string` | No (default: `off`) | Configures TLS.                                                                    |
+| `distributed_tracing.allow_insecure_tls`           | `bool`   | No (default: `false`) | Allow insecure TLS.                                                                |
+| `distributed_tracing.tls_ca_cert_file`             | `string` | No | The path to the root CA certificate.                                               |
+| `distributed_tracing.tls_cert_file`                | `string` | No (unless `encryption` equals `mtls`) | The path to the client certificate to authenticate with.                           |
+| `distributed_tracing.tls_private_key_file`         | `string` | No (unless `tls_cert_file` provided)  | The path to the private key of the client certificate.                             |
+| `distributed_tracing.resource.service_version`     | `string` | No | Service version                                                                    |
+| `distributed_tracing.resource.service_instance_id` | `string` | No | Service instance id                                                                |
+| `distributed_tracing.resource.service_namespace`   | `string` | No | Service namespace                                                                  |
 
 The following encryption methods are supported:
 

--- a/internal/distributedtracing/distributedtracing.go
+++ b/internal/distributedtracing/distributedtracing.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	"go.opentelemetry.io/otel/sdk/resource"
@@ -52,16 +53,23 @@ func isSupportedSampleRatePercentage(sampleRate int) bool {
 	return sampleRate >= 0 && sampleRate <= 100
 }
 
+type resourceConfig struct {
+	ServiceVersion    string `json:"service_version,omitempty"`
+	ServiceInstanceID string `json:"service_instance_id,omitempty"`
+	ServiceNamespace  string `json:"service_namespace,omitempty"`
+}
+
 type distributedTracingConfig struct {
-	Type                  string `json:"type,omitempty"`
-	Address               string `json:"address,omitempty"`
-	ServiceName           string `json:"service_name,omitempty"`
-	SampleRatePercentage  *int   `json:"sample_percentage,omitempty"`
-	EncryptionScheme      string `json:"encryption,omitempty"`
-	EncryptionSkipVerify  *bool  `json:"allow_insecure_tls,omitempty"`
-	TLSCertFile           string `json:"tls_cert_file,omitempty"`
-	TLSCertPrivateKeyFile string `json:"tls_private_key_file,omitempty"`
-	TLSCACertFile         string `json:"tls_ca_cert_file,omitempty"`
+	Type                  string         `json:"type,omitempty"`
+	Address               string         `json:"address,omitempty"`
+	ServiceName           string         `json:"service_name,omitempty"`
+	SampleRatePercentage  *int           `json:"sample_percentage,omitempty"`
+	EncryptionScheme      string         `json:"encryption,omitempty"`
+	EncryptionSkipVerify  *bool          `json:"allow_insecure_tls,omitempty"`
+	TLSCertFile           string         `json:"tls_cert_file,omitempty"`
+	TLSCertPrivateKeyFile string         `json:"tls_private_key_file,omitempty"`
+	TLSCACertFile         string         `json:"tls_ca_cert_file,omitempty"`
+	Resource              resourceConfig `json:"resource,omitempty"`
 }
 
 func Init(ctx context.Context, raw []byte, id string) (*otlptrace.Exporter, *trace.TracerProvider, error) {
@@ -98,11 +106,21 @@ func Init(ctx context.Context, raw []byte, id string) (*otlptrace.Exporter, *tra
 		otlptracegrpc.WithEndpoint(distributedTracingConfig.Address),
 		tlsOption,
 	)
-
+	var resourceAttributes []attribute.KeyValue
+	if distributedTracingConfig.Resource.ServiceVersion != "" {
+		resourceAttributes = append(resourceAttributes, semconv.ServiceVersionKey.String(distributedTracingConfig.Resource.ServiceVersion))
+	}
+	if distributedTracingConfig.Resource.ServiceInstanceID != "" {
+		resourceAttributes = append(resourceAttributes, semconv.ServiceInstanceIDKey.String(distributedTracingConfig.Resource.ServiceInstanceID))
+	}
+	if distributedTracingConfig.Resource.ServiceNamespace != "" {
+		resourceAttributes = append(resourceAttributes, semconv.ServiceNamespaceKey.String(distributedTracingConfig.Resource.ServiceNamespace))
+	}
 	res, err := resource.New(ctx,
 		resource.WithAttributes(
 			semconv.ServiceNameKey.String(distributedTracingConfig.ServiceName),
 		),
+		resource.WithAttributes(resourceAttributes...),
 	)
 	if err != nil {
 		return nil, nil, err

--- a/plugins/plugins_test.go
+++ b/plugins/plugins_test.go
@@ -536,7 +536,7 @@ func TestPluginManagerPrometheusRegister(t *testing.T) {
 }
 
 func TestPluginManagerTracerProvider(t *testing.T) {
-	_, tracerProvider, err := internal_tracing.Init(context.TODO(), []byte(`{ "distributed_tracing": { "type": "grpc" } }`), "test")
+	_, tracerProvider, _, err := internal_tracing.Init(context.TODO(), []byte(`{ "distributed_tracing": { "type": "grpc" } }`), "test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -391,7 +391,7 @@ func NewRuntime(ctx context.Context, params Params) (*Runtime, error) {
 		store = inmem.NewWithOpts(inmem.OptRoundTripOnWrite(false))
 	}
 
-	traceExporter, tracerProvider, err := internal_tracing.Init(ctx, config, params.ID)
+	traceExporter, tracerProvider, _, err := internal_tracing.Init(ctx, config, params.ID)
 	if err != nil {
 		return nil, fmt.Errorf("config error: %w", err)
 	}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -5297,6 +5297,7 @@ func TestDistributedTracingEnabled(t *testing.T) {
 
 func TestDistributedTracingResourceAttributes(t *testing.T) {
 	c := []byte(`{"distributed_tracing": {
+		"type": "grpc",
 		"service_name": "my-service",
 		"resource": {
 			"service_namespace": "my-namespace",

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -5295,6 +5295,23 @@ func TestDistributedTracingEnabled(t *testing.T) {
 	}
 }
 
+func TestDistributedTracingResourceAttributes(t *testing.T) {
+	c := []byte(`{"distributed_tracing": {
+		"service_name": "my-service",
+		"resource": {
+			"service_namespace": "my-namespace",
+			"service_version": "1.0",
+			"service_instance_id": "1"
+		}
+		}}`)
+
+	ctx := context.Background()
+	_, _, err := distributedtracing.Init(ctx, c, "foo")
+	if err != nil {
+		t.Fatalf("Unexpected error initializing trace exporter %v", err)
+	}
+}
+
 func TestCertPoolReloading(t *testing.T) {
 
 	ctx := context.Background()

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -5289,7 +5289,7 @@ func TestDistributedTracingEnabled(t *testing.T) {
 		}}`)
 
 	ctx := context.Background()
-	_, _, err := distributedtracing.Init(ctx, c, "foo")
+	_, _, _, err := distributedtracing.Init(ctx, c, "foo")
 	if err != nil {
 		t.Fatalf("Unexpected error initializing trace exporter %v", err)
 	}
@@ -5307,9 +5307,18 @@ func TestDistributedTracingResourceAttributes(t *testing.T) {
 		}}`)
 
 	ctx := context.Background()
-	_, _, err := distributedtracing.Init(ctx, c, "foo")
+	_, traceProvider, resource, err := distributedtracing.Init(ctx, c, "foo")
 	if err != nil {
 		t.Fatalf("Unexpected error initializing trace exporter %v", err)
+	}
+	if traceProvider == nil {
+		t.Fatalf("Tracer provider was not initialized")
+	}
+	if resource == nil {
+		t.Fatalf("Resource was not initialized")
+	}
+	if len(resource.Attributes()) != 4 {
+		t.Fatalf("Unexpected resource attributes count. Expected: %v, Got: %v", 4, len(resource.Attributes()))
 	}
 }
 


### PR DESCRIPTION
Adding a resource_attributes map to the distributed_tracing config. Entries in this map will be passed through to the OpenTelemetry SDK where they will be added as resource attributes. Resource attributes are typically service.namespace, service.version, service.name and service.instance.id, see https://opentelemetry.io/docs/specs/semconv/resource/

Fixes: #6942 

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.
  (See the [Developer Certificate of Origin](https://www.openpolicyagent.org/docs/latest/contrib-code/#developer-certificate-of-origin)
  section for specifics on signing off a commit.)

-->

### Why the changes in this PR are needed?

Allows extra OpenTelemetry resource attributes to be added to a trace, such as service.namespace
<!--
Include a short description of WHY the changes were made.
-->

### What are the changes in this PR?
Adds an optional config `distributed_tracing.resource_attributes`, which is map of strings. Values here are
added via the opentelemetry SDK as resource attributes.
<!--
Include a short description of WHAT changes were made.
-->

### Notes to assist PR review:

<!--
Here you can add information you think will help the reviewer(s).
-->

I didn't find any tests which verify the telemetry (trace) output, but I did apply the following config and observe this output:

<details>
<summary>config:</summary>

```yaml
distributed_tracing:
  type: grpc
  address: localhost:4317
  service_name: opa
  resource_attributes:
    service.name: foobar
    service.namespace: foo
    service.version: "1"
  sample_percentage: 50
  encryption: "off"
```
</details>
<details>
<summary>output in opentelemetry collector:</summary>
NB resource attributes, and that service_name takes precedence over resource_attributes."service.name"

```
2024-08-21T05:54:36.603Z	info	ResourceSpans #0
Resource SchemaURL: 
Resource attributes:
     -> service.name: Str(opa)
     -> service.namespace: Str(foo)
     -> service.version: Str(1)
ScopeSpans #0
ScopeSpans SchemaURL: 
InstrumentationScope go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp 0.53.0
Span #0
    Trace ID       : 947eef4950fa437411a025bc499e6530
    Parent ID      : 
    ID             : 539d178e352cfac6
    Name           : v1/data
    Kind           : Server
    Start time     : 2024-08-21 05:54:32.602923136 +0000 UTC
    End time       : 2024-08-21 05:54:32.602987413 +0000 UTC
    Status code    : Unset
    Status message : 
Attributes:
     -> http.method: Str(POST)
     -> http.scheme: Str(http)
     -> net.host.name: Str(localhost)
     -> net.host.port: Int(8181)
     -> net.sock.peer.addr: Str(127.0.0.1)
     -> net.sock.peer.port: Int(55730)
     -> user_agent.original: Str(curl/7.81.0)
     -> http.target: Str(/v1/data/my_policy)
     -> net.protocol.version: Str(1.1)
     -> http.request_content_length: Int(28)
     -> http.response_content_length: Int(3)
     -> http.status_code: Int(200)
```
</details>
### Further comments:

<!--
Here you can include links to additional resources related to the changes, discuss your solution, other approaches you considered etc.
-->
