### PR TITLE
Make type checker `copy` method copy all values

### DIFF
--- a/ast/check.go
+++ b/ast/check.go
@@ -60,7 +60,10 @@ func (tc *typeChecker) copy() *typeChecker {
 		WithVarRewriter(tc.varRewriter).
 		WithSchemaSet(tc.ss).
 		WithAllowNet(tc.allowNet).
-		WithInputType(tc.input)
+		WithInputType(tc.input).
+		WithAllowUndefinedFunctionCalls(tc.allowUndefinedFuncs).
+		WithBuiltins(tc.builtins).
+		WithRequiredCapabilities(tc.required)
 }
 
 func (tc *typeChecker) WithRequiredCapabilities(c *Capabilities) *typeChecker {


### PR DESCRIPTION
Just a small improvement from looking into #6946

This doesn't necessarily solve all issues reported there, but I figured I might as well commit this anyway.