### PR TITLE
docs: mention `http.send` in inter-query cache config docs

### DIFF
--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -840,7 +840,9 @@ The following signing algorithms are supported:
 
 ## Caching
 
-Caching represents the configuration of the inter-query cache that built-in functions can utilize.
+Caching represents the configuration of the inter-query cache that built-in functions can utilize. Of the built-in
+functions provided by OPA, `http.send` is currently the only one to utilize the inter-query cache. See the documentation
+on the [http.send built-in function](../policy-reference/#http) for information about the available caching options.
 
 | Field | Type | Required | Description |
 | --- | --- | --- | --- |

--- a/docs/content/policy-language.md
+++ b/docs/content/policy-language.md
@@ -2660,7 +2660,7 @@ comment block containing the YAML document is finished
 
 Name | Type | Description
 --- | --- | ---
-scope | string; one of `package`, `rule`, `document`, `subpackages` | The scope on which the `schemas` annotation is applied. Read more [here](./#scope).
+scope | string; one of `package`, `rule`, `document`, `subpackages` | The scope for which the metadata applies. Read more [here](./#scope).
 title | string | A human-readable name for the annotation target. Read more [here](#title).
 description | string | A description of the annotation target. Read more [here](#description).
 related_resources | list of URLs | A list of URLs pointing to related resources/documentation. Read more [here](#related-resources).


### PR DESCRIPTION
It wasn't obvious when configuring the inter-query cache might be needed, as it wasn't mentioned which built-in made use of it.

Also fixed the docs on annotations where it said `scope` only applies to `schemas`.