### PR TITLE
.github/workflows: Update CodeQL workflow contents perm

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -16,7 +16,7 @@ on:
     branches: [ main, release-* ]
 
 permissions: 
-  contents: read
+  contents: write
 
 jobs:
   analyze:


### PR DESCRIPTION
The CodeQL workflow uploads the results to GitHub so it needs a write value on the contents permission.

