### PR TITLE
ast/parser: add hint to future-proof imports

### DIFF
--- a/ast/parser.go
+++ b/ast/parser.go
@@ -609,7 +609,12 @@ func (p *Parser) parseImport() *Import {
 
 	path := imp.Path.Value.(Ref)
 
-	if !RootDocumentNames.Contains(path[0]) && !FutureRootDocument.Equal(path[0]) && !RegoRootDocument.Equal(path[0]) {
+	switch {
+	case RootDocumentNames.Contains(path[0]):
+	case FutureRootDocument.Equal(path[0]):
+	case RegoRootDocument.Equal(path[0]):
+	default:
+		p.hint("if this is unexpected, try updating OPA")
 		p.errorf(imp.Path.Location, "unexpected import path, must begin with one of: %v, got: %v",
 			RootDocumentNames.Union(NewSet(FutureRootDocument, RegoRootDocument)),
 			path[0])

--- a/ast/parser_test.go
+++ b/ast/parser_test.go
@@ -1336,6 +1336,11 @@ func TestFutureAndRegoV1ImportsExtraction(t *testing.T) {
 	}
 }
 
+func TestHintsOnUnknownImport(t *testing.T) {
+	assertParseErrorContains(t, "unknown", "import unknown",
+		"unexpected import path, must begin with one of: {data, future, input, rego}, got: unknown (hint: if this is unexpected, try updating OPA)")
+}
+
 func TestRegoV1Import(t *testing.T) {
 	assertParseErrorContains(t, "rego", "import rego", "invalid import `rego`, must be `rego.v1`")
 	assertParseErrorContains(t, "rego.foo", "import rego.foo", "invalid import `rego.foo`, must be `rego.v1`")


### PR DESCRIPTION
Just an idea, if we ever introduce an

    import awesome

and people start receiving "unknown import" errors on outdated OPA versions, they'll at least give a hint.

This could be extended to cover the other synthetic imports, like `rego.*` and `future.*`, but it's a start...
