### PR TITLE
ast/compile: also replace declared vars in with's target

### DIFF
--- a/ast/compile.go
+++ b/ast/compile.go
@@ -5465,15 +5465,9 @@ func rewriteDeclaredVarsInTerm(g *localVarGenerator, stack *localDeclaredVars, t
 }
 
 func rewriteDeclaredVarsInTermRecursive(g *localVarGenerator, stack *localDeclaredVars, term *Term, errs Errors, strict bool) Errors {
-	WalkNodes(term, func(n Node) bool {
+	WalkTerms(term, func(t *Term) bool {
 		var stop bool
-		switch n := n.(type) {
-		case *With:
-			// TODO(sr): add test exercising this, just added it because it felt right
-			stop, errs = true, rewriteDeclaredVarsInWithRecursive(g, stack, n, errs, strict)
-		case *Term:
-			stop, errs = rewriteDeclaredVarsInTerm(g, stack, n, errs, strict)
-		}
+		stop, errs = rewriteDeclaredVarsInTerm(g, stack, t, errs, strict)
 		return stop
 	})
 	return errs

--- a/ast/compile.go
+++ b/ast/compile.go
@@ -5332,7 +5332,25 @@ func rewriteDeclaredVarsInExpr(g *localVarGenerator, stack *localDeclaredVars, e
 		case *Term:
 			stop, errs = rewriteDeclaredVarsInTerm(g, stack, x, errs, strict)
 		case *With:
+			// NOTE(sr): `with input as` and `with input.a.b.c as` are deliberately skipped here: `input` could
+			// have been shadowed by a local variable/argument but should NOT be replaced in the `with` target.
+			//
+			// We cannot drop `input` from the stack since it's conceivable to do `with input[input] as` where
+			// the second input is meant to be the local var. It's a terrible idea, but when you're shadowing
+			// `input` those might be your thing.
 			errs = rewriteDeclaredVarsInTermRecursive(g, stack, x.Target, errs, strict)
+			if sdwInput, ok := stack.Declared(InputRootDocument.Value.(Var)); ok {
+				switch value := x.Target.Value.(type) {
+				case Var:
+					if sdwInput.Equal(value) {
+						x.Target.Value = InputRootRef
+					}
+				case Ref:
+					if sdwInput.Equal(value[0].Value.(Var)) {
+						x.Target.Value.(Ref)[0].Value = InputRootDocument.Value
+					}
+				}
+			}
 			errs = rewriteDeclaredVarsInTermRecursive(g, stack, x.Value, errs, strict)
 			stop = true
 		}
@@ -5471,6 +5489,8 @@ func rewriteDeclaredVarsInTermRecursive(g *localVarGenerator, stack *localDeclar
 		var stop bool
 		switch n := n.(type) {
 		case *With:
+			// TODO(sr): add test exercising this, just added it because it felt right
+			errs = rewriteDeclaredVarsInTermRecursive(g, stack, n.Target, errs, strict)
 			errs = rewriteDeclaredVarsInTermRecursive(g, stack, n.Value, errs, strict)
 			stop = true
 		case *Term:

--- a/ast/compile.go
+++ b/ast/compile.go
@@ -5332,6 +5332,7 @@ func rewriteDeclaredVarsInExpr(g *localVarGenerator, stack *localDeclaredVars, e
 		case *Term:
 			stop, errs = rewriteDeclaredVarsInTerm(g, stack, x, errs, strict)
 		case *With:
+			errs = rewriteDeclaredVarsInTermRecursive(g, stack, x.Target, errs, strict)
 			errs = rewriteDeclaredVarsInTermRecursive(g, stack, x.Value, errs, strict)
 			stop = true
 		}

--- a/ast/compile_test.go
+++ b/ast/compile_test.go
@@ -5114,11 +5114,16 @@ func TestCompilerRewriteLocalAssignments(t *testing.T) {
 		{
 			module: `
 				package test
-				skip_with_target { a := 1; input := 2; data.p with input as a }
+				skip_with_target {
+					a := 1
+					input := 2
+					data.p with input as a
+					data.p with input.foo as a
+				}
 			`,
 			exp: `
 				package test
-				skip_with_target = true { __local0__ = 1; __local1__ = 2; data.p with input as __local0__ }
+				skip_with_target = true { __local0__ = 1; __local1__ = 2; data.p with input as __local0__; data.p with input.foo as __local0__ }
 			`,
 			expRewrittenMap: map[Var]Var{
 				Var("__local0__"): Var("a"),
@@ -5249,12 +5254,12 @@ func TestCompilerRewriteLocalAssignments(t *testing.T) {
 				package test
 				skip_with_target_in_assignment {
 					input := 1
-					a := [true | true with input as 2; true with input as 3]
+					a := [true | true with input as 2; true with input.foo as 3]
 				}
 			`,
 			exp: `
 				package test
-				skip_with_target_in_assignment = true { __local0__ = 1; __local1__ = [true | true with input as 2; true with input as 3] }
+				skip_with_target_in_assignment = true { __local0__ = 1; __local1__ = [true | true with input as 2; true with input.foo as 3] }
 			`,
 			expRewrittenMap: map[Var]Var{
 				Var("__local0__"): Var("input"),

--- a/ast/compile_test.go
+++ b/ast/compile_test.go
@@ -5674,6 +5674,23 @@ func TestRewriteDeclaredVars(t *testing.T) {
 			`,
 		},
 		{
+			note: "with: rewrite target",
+			module: `
+				package test
+				p {
+					x := "foo"
+					true with input[x] as 1
+				}
+			`,
+			exp: `
+				package test
+				p {
+					__local0__ = "foo";
+					true with input[__local0__] as 1
+				}
+			`,
+		},
+		{
 			note: "single-value rule with ref head",
 			module: `
 				package test
@@ -6035,6 +6052,26 @@ func TestRewriteDeclaredVars(t *testing.T) {
 					every __local0__, __local1__ in __local2__ {
 						__local1__ = input
 					} with input as 2
+				}
+			`,
+		},
+		{
+			note: "rewrite every: with modifier on body, using every's key+value",
+			module: `
+				package test
+				# import future.keywords.in
+				# import future.keywords.every
+				p {
+					every x, y in input { true with data.test.q[x][y] as 100 }
+				}
+			`,
+			exp: `
+				package test
+				p {
+				    __local2__ = input
+					every __local0__, __local1__ in __local2__ {
+						true with data.test.q[__local0__][__local1__] as 100
+					}
 				}
 			`,
 		},

--- a/ast/compile_test.go
+++ b/ast/compile_test.go
@@ -5696,6 +5696,23 @@ func TestRewriteDeclaredVars(t *testing.T) {
 			`,
 		},
 		{
+			note: "with: rewrite target in comprehension term",
+			module: `
+				package test
+				p {
+					input := "bar"
+					{ { 2 | true with input[input] as 1} | true }
+				}
+			`,
+			exp: `
+				package test
+				p {
+					__local0__ = "bar"
+					{__local1__ | true; __local1__ = { 2 | true with input[__local0__] as 1 }}
+				}
+			`,
+		},
+		{
 			note: "single-value rule with ref head",
 			module: `
 				package test


### PR DESCRIPTION
It might be uncommon to do this, but it's not wrong to expect this to work.

Fixes #6979.
