### PR TITLE
Improve error handling for bundle status errors

### DIFF
--- a/plugins/bundle/status.go
+++ b/plugins/bundle/status.go
@@ -86,12 +86,12 @@ func (s *Status) SetError(err error) {
 		s.Code = errCode
 		s.HTTPCode = json.Number(strconv.Itoa(httpError.StatusCode))
 		s.Message = err.Error()
-		s.Errors = nil
+		s.Errors = []error{}
 
 	default:
 		s.Code = errCode
 		s.HTTPCode = ""
 		s.Message = err.Error()
-		s.Errors = nil
+		s.Errors = []error{}
 	}
 }


### PR DESCRIPTION
### Why the changes in this PR are needed?
We are using OPA as a library inside a HTTP router similar to Envoy(for Reference - [the integration code](https://github.com/zalando/skipper/blob/47d31f21b7f957d59226ca571363754d2eef7780/filters/openpolicyagent/openpolicyagent.go#L842-L868))

Here it was difficult to reliably identify the error scenarios except for relying on s.Code == errCode which is a constant `bundle_error`. Since constant is not public we have the concern of relying on exact text as if it ever change, the code will be broken.

Relying of s.Errors was also not reliable as in some error cases it was `nil`.

### What are the changes in this PR?
Mark the error scenario and populate Errors.
Hoping `s.Errors != nil` is a reliable way to detect errors.

### Notes to assist PR review:
Looking for more ideas to better handle errors in this code without breaking existing functionality.

### Further comments:
Considering,
- The error code been a public constant
- A better option to indicate the error scenario reliably.
