### PR TITLE
rego-v1: Future-proofing `compiler` pkg tests

### DIFF
--- a/ast/parser.go
+++ b/ast/parser.go
@@ -30,6 +30,8 @@ var RegoV1CompatibleRef = Ref{VarTerm("rego"), StringTerm("v1")}
 // RegoVersion defines the Rego syntax requirements for a module.
 type RegoVersion int
 
+const DefaultRegoVersion = RegoVersion(0)
+
 const (
 	// RegoV0 is the default, original Rego syntax.
 	RegoV0 RegoVersion = iota

--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -200,7 +200,10 @@ func (m Manifest) Equal(other Manifest) bool {
 	if m.RegoVersion != nil && other.RegoVersion != nil && *m.RegoVersion != *other.RegoVersion {
 		return false
 	}
-	if !reflect.DeepEqual(m.FileRegoVersions, other.FileRegoVersions) {
+
+	// If both are nil, or both are empty, we consider them equal.
+	if !(len(m.FileRegoVersions) == 0 && len(other.FileRegoVersions) == 0) &&
+		!reflect.DeepEqual(m.FileRegoVersions, other.FileRegoVersions) {
 		return false
 	}
 
@@ -1092,6 +1095,9 @@ func (b *Bundle) FormatModulesForRegoVersion(version ast.RegoVersion, preserveMo
 		opts := format.Opts{}
 		if preserveModuleRegoVersion {
 			opts.RegoVersion = module.Parsed.RegoVersion()
+			opts.ParserOptions = &ast.ParserOptions{
+				RegoVersion: opts.RegoVersion,
+			}
 		} else {
 			opts.RegoVersion = version
 		}

--- a/compile/compile.go
+++ b/compile/compile.go
@@ -1107,6 +1107,7 @@ func (o *optimizer) getSupportForEntrypoint(queries []ast.Body, e *ast.Term, res
 	path := e.Value.(ast.Ref)
 	name := ast.Var(path[len(path)-1].Value.(ast.String))
 	module := &ast.Module{Package: &ast.Package{Path: path[:len(path)-1]}}
+	module.SetRegoVersion(o.regoVersion)
 
 	for _, query := range queries {
 		// NOTE(tsandall): when the query refers to the original entrypoint, throw it

--- a/compile/compile_test.go
+++ b/compile/compile_test.go
@@ -1615,6 +1615,7 @@ update {
 					}
 
 					compiler := New().
+						WithRegoVersion(ast.RegoV0).
 						WithFS(fsys).
 						WithPaths(root).
 						WithOptimizationLevel(1).

--- a/compile/compile_test.go
+++ b/compile/compile_test.go
@@ -2752,10 +2752,10 @@ func TestCompilerSetRoots(t *testing.T) {
 
 func TestCompilerOutput(t *testing.T) {
 	// NOTE(tsandall): must use format package here because the compiler formats.
+	mod := ast.MustParseModuleWithOpts(`package test
+		p { input.x = data.foo }`, ast.ParserOptions{RegoVersion: ast.RegoV0})
 	files := map[string]string{
-		"test.rego": string(format.MustAst(ast.MustParseModule(`package test
-
-		p { input.x = data.foo }`))),
+		"test.rego": string(format.MustAstWithOpts(mod, format.Opts{RegoVersion: ast.RegoV0})),
 		"data.json": `{"foo": 1}`,
 		".manifest": `{"rego_version": 0}`,
 	}
@@ -2765,6 +2765,7 @@ func TestCompilerOutput(t *testing.T) {
 
 			buf := bytes.NewBuffer(nil)
 			compiler := New().
+				WithAsBundle(true). // To respect the manifest file.
 				WithFS(fsys).
 				WithPaths(root).
 				WithOutput(buf)

--- a/compile/compile_test.go
+++ b/compile/compile_test.go
@@ -473,7 +473,6 @@ func TestCompilerBundleMergeWithBundleRegoVersion(t *testing.T) {
 					Modules: []bundle.ModuleFile{},
 				},
 			},
-			//expGlobalRegoVersion: pointTo(0),
 			expGlobalRegoVersion: pointTo(ast.DefaultRegoVersion.Int()),
 			expFileRegoVersions:  map[string]int{},
 		},
@@ -1096,7 +1095,7 @@ func TestCompilerOptimizationL1(t *testing.T) {
 	files := map[string]string{
 		"test.rego": `
 			package test
-			import rego.v1
+			
 			default p := false
 			p if { q }
 			q if { input.x = data.foo }`,
@@ -1108,6 +1107,7 @@ func TestCompilerOptimizationL1(t *testing.T) {
 		test.WithTestFS(files, useMemoryFS, func(root string, fsys fs.FS) {
 
 			compiler := New().
+				WithRegoVersion(ast.RegoV1).
 				WithFS(fsys).
 				WithPaths(root).
 				WithOptimizationLevel(1).
@@ -1999,6 +1999,7 @@ func TestCompilerWasmTargetWithCapabilitiesMismatch(t *testing.T) {
 func TestCompilerWasmTargetMultipleEntrypoints(t *testing.T) {
 	files := map[string]string{
 		"test.rego": `package test
+		import rego.v1
 
 		p := true`,
 		"policy.rego": `package policy
@@ -2013,7 +2014,6 @@ func TestCompilerWasmTargetMultipleEntrypoints(t *testing.T) {
 		test.WithTestFS(files, useMemoryFS, func(root string, fsys fs.FS) {
 
 			compiler := New().
-				WithRegoVersion(ast.RegoV1).
 				WithFS(fsys).
 				WithPaths(root).
 				WithTarget("wasm").

--- a/compile/compile_test.go
+++ b/compile/compile_test.go
@@ -1999,13 +1999,13 @@ func TestCompilerWasmTargetWithCapabilitiesMismatch(t *testing.T) {
 func TestCompilerWasmTargetMultipleEntrypoints(t *testing.T) {
 	files := map[string]string{
 		"test.rego": `package test
-		import rego.v1
 
 		p := true`,
 		"policy.rego": `package policy
 
 		authz := true`,
 		"mask.rego": `package system.log
+		import rego.v1
 
 		mask contains "/input/password"`,
 	}
@@ -2030,7 +2030,7 @@ func TestCompilerWasmTargetMultipleEntrypoints(t *testing.T) {
 
 			expManifest := bundle.Manifest{}
 			expManifest.Init()
-			expManifest.SetRegoVersion(ast.RegoV1)
+			expManifest.SetRegoVersion(ast.DefaultRegoVersion)
 			expManifest.WasmResolvers = []bundle.WasmResolver{
 				{
 					Entrypoint: "test/p",

--- a/format/format.go
+++ b/format/format.go
@@ -52,7 +52,7 @@ func SourceWithOpts(filename string, src []byte, opts Opts) ([]byte, error) {
 	} else {
 		if opts.RegoVersion == ast.RegoV1 {
 			// If the rego version is V1, we need to parse it as such, to allow for future keywords not being imported.
-			// Otherwise, we'll default to RegoV0
+			// Otherwise, we'll default to the default rego-version.
 			parserOpts.RegoVersion = ast.RegoV1
 		}
 	}
@@ -86,6 +86,16 @@ func SourceWithOpts(filename string, src []byte, opts Opts) ([]byte, error) {
 // occurs this function will panic. This is mostly used for test
 func MustAst(x interface{}) []byte {
 	bs, err := Ast(x)
+	if err != nil {
+		panic(err)
+	}
+	return bs
+}
+
+// MustAstWithOpts is a helper function to format a Rego AST element. If any errors
+// occurs this function will panic. This is mostly used for test
+func MustAstWithOpts(x interface{}, opts Opts) []byte {
+	bs, err := AstWithOpts(x, opts)
 	if err != nil {
 		panic(err)
 	}

--- a/rego/rego.go
+++ b/rego/rego.go
@@ -2431,14 +2431,10 @@ func (r *Rego) partial(ctx context.Context, ectx *EvalContext) (*PartialQueries,
 		return nil, err
 	}
 
+	// If the target rego-version is v0, and the rego.v1 import is available, then we attempt to apply it to support modules.
 	if r.regoVersion == ast.RegoV0 && (r.capabilities == nil || r.capabilities.ContainsFeature(ast.FeatureRegoV1Import)) {
-		// If the target rego-version in v0, and the rego.v1 import is available, then we attempt to apply it to support modules.
 
 		for i, mod := range support {
-			if mod.RegoVersion() != ast.RegoV0 {
-				continue
-			}
-
 			// We can't apply the RegoV0CompatV1 version to the support module if it contains rules or vars that
 			// conflict with future keywords.
 			applyRegoVersion := true


### PR DESCRIPTION
Future-proofing `compiler` package tests to continue working when we flip the default rego-version to `v1` in OPA 1.0.

Also updating a few places that depended on `v0`-by-default assumptions.