### PR TITLE
Add a new inter-query value cache to cache data across queries

### DIFF
--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -856,11 +856,15 @@ Caching represents the configuration of the inter-query cache that built-in func
 functions provided by OPA, `http.send` is currently the only one to utilize the inter-query cache. See the documentation
 on the [http.send built-in function](../policy-reference/#http) for information about the available caching options.
 
-| Field | Type | Required | Description |
-| --- | --- | --- | --- |
-| `caching.inter_query_builtin_cache.max_size_bytes` | `int64` | No | Inter-query cache size limit in bytes. OPA will drop old items from the cache if this limit is exceeded. By default, no limit is set. |
-| `caching.inter_query_builtin_cache.forced_eviction_threshold_percentage` | `int64` | No | Threshold limit configured as percentage of `caching.inter_query_builtin_cache.max_size_bytes`, when exceeded OPA will start dropping old items permaturely. By default, set to `100`. |
-| `caching.inter_query_builtin_cache.stale_entry_eviction_period_seconds` | `int64` | No | Stale entry eviction period in seconds. OPA will drop expired items from the cache every `stale_entry_eviction_period_seconds`. By default, set to `0` indicating stale entry eviction is disabled. |
+It also represents the configuration of the inter-query value cache that built-in functions can utilize. Currently, this
+cache is utilized by the `regex` and `glob` built-in functions for compiled regex and glob match patterns respectively.
+
+| Field                                                                    | Type | Required | Description                                                                                                                                                                                         |
+|--------------------------------------------------------------------------| --- | --- |-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `caching.inter_query_builtin_cache.max_size_bytes`                       | `int64` | No | Inter-query cache size limit in bytes. OPA will drop old items from the cache if this limit is exceeded. By default, no limit is set.                                                               |
+| `caching.inter_query_builtin_cache.forced_eviction_threshold_percentage` | `int64` | No | Threshold limit configured as percentage of `caching.inter_query_builtin_cache.max_size_bytes`, when exceeded OPA will start dropping old items permaturely. By default, set to `100`.              |
+| `caching.inter_query_builtin_cache.stale_entry_eviction_period_seconds`  | `int64` | No | Stale entry eviction period in seconds. OPA will drop expired items from the cache every `stale_entry_eviction_period_seconds`. By default, set to `0` indicating stale entry eviction is disabled. |
+| `caching.inter_query_builtin_value_cache.max_num_entries`                | `int` | No | Maximum number of entries in the Inter-query value cache. OPA will drop random items from the cache if this limit is exceeded. By default, set to `0` indicating unlimited size.                    |
 
 ## Distributed tracing
 

--- a/internal/rego/opa/options.go
+++ b/internal/rego/opa/options.go
@@ -18,13 +18,14 @@ type Result struct {
 
 // EvalOpts define options for performing an evaluation.
 type EvalOpts struct {
-	Input                  *interface{}
-	Metrics                metrics.Metrics
-	Entrypoint             int32
-	Time                   time.Time
-	Seed                   io.Reader
-	InterQueryBuiltinCache cache.InterQueryCache
-	NDBuiltinCache         builtins.NDBCache
-	PrintHook              print.Hook
-	Capabilities           *ast.Capabilities
+	Input                       *interface{}
+	Metrics                     metrics.Metrics
+	Entrypoint                  int32
+	Time                        time.Time
+	Seed                        io.Reader
+	InterQueryBuiltinCache      cache.InterQueryCache
+	InterQueryBuiltinValueCache cache.InterQueryValueCache
+	NDBuiltinCache              builtins.NDBCache
+	PrintHook                   print.Hook
+	Capabilities                *ast.Capabilities
 }

--- a/plugins/discovery/discovery_test.go
+++ b/plugins/discovery/discovery_test.go
@@ -1905,7 +1905,11 @@ func TestReconfigureWithLocalOverride(t *testing.T) {
 	*period = 10
 	threshold := new(int64)
 	*threshold = 90
-	expectedCacheConf := &cache.Config{InterQueryBuiltinCache: cache.InterQueryBuiltinCacheConfig{MaxSizeBytes: maxSize, StaleEntryEvictionPeriodSeconds: period, ForcedEvictionThresholdPercentage: threshold}}
+	maxNumEntriesInterQueryValueCache := new(int)
+	*maxNumEntriesInterQueryValueCache = 0
+
+	expectedCacheConf := &cache.Config{InterQueryBuiltinCache: cache.InterQueryBuiltinCacheConfig{MaxSizeBytes: maxSize, StaleEntryEvictionPeriodSeconds: period, ForcedEvictionThresholdPercentage: threshold},
+		InterQueryBuiltinValueCache: cache.InterQueryBuiltinValueCacheConfig{MaxNumEntries: maxNumEntriesInterQueryValueCache}}
 
 	if !reflect.DeepEqual(cacheConf, expectedCacheConf) {
 		t.Fatalf("want %v got %v", expectedCacheConf, cacheConf)

--- a/plugins/plugins.go
+++ b/plugins/plugins.go
@@ -576,7 +576,7 @@ func (m *Manager) Labels() map[string]string {
 	return m.Config.Labels
 }
 
-// InterQueryBuiltinCacheConfig returns the configuration for the inter-query cache.
+// InterQueryBuiltinCacheConfig returns the configuration for the inter-query caches.
 func (m *Manager) InterQueryBuiltinCacheConfig() *cache.Config {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()

--- a/plugins/plugins_test.go
+++ b/plugins/plugins_test.go
@@ -396,7 +396,7 @@ func TestPluginManagerInitIdempotence(t *testing.T) {
 }
 
 func TestManagerWithCachingConfig(t *testing.T) {
-	m, err := New([]byte(`{"caching": {"inter_query_builtin_cache": {"max_size_bytes": 100}}}`), "test", inmem.New())
+	m, err := New([]byte(`{"caching": {"inter_query_builtin_cache": {"max_size_bytes": 100}, "inter_query_builtin_value_cache": {"max_num_entries": 100}}}`), "test", inmem.New())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -404,6 +404,8 @@ func TestManagerWithCachingConfig(t *testing.T) {
 	expected, _ := cache.ParseCachingConfig(nil)
 	limit := int64(100)
 	expected.InterQueryBuiltinCache.MaxSizeBytes = &limit
+	maxNumEntriesInterQueryValueCache := int(100)
+	expected.InterQueryBuiltinValueCache.MaxNumEntries = &maxNumEntriesInterQueryValueCache
 
 	if !reflect.DeepEqual(m.InterQueryBuiltinCacheConfig(), expected) {
 		t.Fatalf("want %+v got %+v", expected, m.interQueryBuiltinCacheConfig)
@@ -411,6 +413,12 @@ func TestManagerWithCachingConfig(t *testing.T) {
 
 	// config error
 	_, err = New([]byte(`{"caching": {"inter_query_builtin_cache": {"max_size_bytes": "100"}}}`), "test", inmem.New())
+	if err == nil {
+		t.Fatal("expected error but got nil")
+	}
+
+	// config error
+	_, err = New([]byte(`{"caching": {"inter_query_builtin_value_cache": {"max_num_entries": "100"}}}`), "test", inmem.New())
 	if err == nil {
 		t.Fatal("expected error but got nil")
 	}

--- a/rego/rego.go
+++ b/rego/rego.go
@@ -99,32 +99,33 @@ type preparedQuery struct {
 // EvalContext defines the set of options allowed to be set at evaluation
 // time. Any other options will need to be set on a new Rego object.
 type EvalContext struct {
-	hasInput               bool
-	time                   time.Time
-	seed                   io.Reader
-	rawInput               *interface{}
-	parsedInput            ast.Value
-	metrics                metrics.Metrics
-	txn                    storage.Transaction
-	instrument             bool
-	instrumentation        *topdown.Instrumentation
-	partialNamespace       string
-	queryTracers           []topdown.QueryTracer
-	compiledQuery          compiledQuery
-	unknowns               []string
-	disableInlining        []ast.Ref
-	parsedUnknowns         []*ast.Term
-	indexing               bool
-	earlyExit              bool
-	interQueryBuiltinCache cache.InterQueryCache
-	ndBuiltinCache         builtins.NDBCache
-	resolvers              []refResolver
-	sortSets               bool
-	copyMaps               bool
-	printHook              print.Hook
-	capabilities           *ast.Capabilities
-	strictBuiltinErrors    bool
-	virtualCache           topdown.VirtualCache
+	hasInput                    bool
+	time                        time.Time
+	seed                        io.Reader
+	rawInput                    *interface{}
+	parsedInput                 ast.Value
+	metrics                     metrics.Metrics
+	txn                         storage.Transaction
+	instrument                  bool
+	instrumentation             *topdown.Instrumentation
+	partialNamespace            string
+	queryTracers                []topdown.QueryTracer
+	compiledQuery               compiledQuery
+	unknowns                    []string
+	disableInlining             []ast.Ref
+	parsedUnknowns              []*ast.Term
+	indexing                    bool
+	earlyExit                   bool
+	interQueryBuiltinCache      cache.InterQueryCache
+	interQueryBuiltinValueCache cache.InterQueryValueCache
+	ndBuiltinCache              builtins.NDBCache
+	resolvers                   []refResolver
+	sortSets                    bool
+	copyMaps                    bool
+	printHook                   print.Hook
+	capabilities                *ast.Capabilities
+	strictBuiltinErrors         bool
+	virtualCache                topdown.VirtualCache
 }
 
 func (e *EvalContext) RawInput() *interface{} {
@@ -145,6 +146,10 @@ func (e *EvalContext) Seed() io.Reader {
 
 func (e *EvalContext) InterQueryBuiltinCache() cache.InterQueryCache {
 	return e.interQueryBuiltinCache
+}
+
+func (e *EvalContext) InterQueryBuiltinValueCache() cache.InterQueryValueCache {
+	return e.interQueryBuiltinValueCache
 }
 
 func (e *EvalContext) PrintHook() print.Hook {
@@ -304,6 +309,14 @@ func EvalSeed(r io.Reader) EvalOption {
 func EvalInterQueryBuiltinCache(c cache.InterQueryCache) EvalOption {
 	return func(e *EvalContext) {
 		e.interQueryBuiltinCache = c
+	}
+}
+
+// EvalInterQueryBuiltinValueCache sets the inter-query value cache that built-in functions can utilize
+// during evaluation.
+func EvalInterQueryBuiltinValueCache(c cache.InterQueryValueCache) EvalOption {
+	return func(e *EvalContext) {
+		e.interQueryBuiltinValueCache = c
 	}
 }
 
@@ -546,64 +559,65 @@ type loadPaths struct {
 
 // Rego constructs a query and can be evaluated to obtain results.
 type Rego struct {
-	query                  string
-	parsedQuery            ast.Body
-	compiledQueries        map[queryType]compiledQuery
-	pkg                    string
-	parsedPackage          *ast.Package
-	imports                []string
-	parsedImports          []*ast.Import
-	rawInput               *interface{}
-	parsedInput            ast.Value
-	unknowns               []string
-	parsedUnknowns         []*ast.Term
-	disableInlining        []string
-	shallowInlining        bool
-	skipPartialNamespace   bool
-	partialNamespace       string
-	modules                []rawModule
-	parsedModules          map[string]*ast.Module
-	compiler               *ast.Compiler
-	store                  storage.Store
-	ownStore               bool
-	txn                    storage.Transaction
-	metrics                metrics.Metrics
-	queryTracers           []topdown.QueryTracer
-	tracebuf               *topdown.BufferTracer
-	trace                  bool
-	instrumentation        *topdown.Instrumentation
-	instrument             bool
-	capture                map[*ast.Expr]ast.Var // map exprs to generated capture vars
-	termVarID              int
-	dump                   io.Writer
-	runtime                *ast.Term
-	time                   time.Time
-	seed                   io.Reader
-	capabilities           *ast.Capabilities
-	builtinDecls           map[string]*ast.Builtin
-	builtinFuncs           map[string]*topdown.Builtin
-	unsafeBuiltins         map[string]struct{}
-	loadPaths              loadPaths
-	bundlePaths            []string
-	bundles                map[string]*bundle.Bundle
-	skipBundleVerification bool
-	interQueryBuiltinCache cache.InterQueryCache
-	ndBuiltinCache         builtins.NDBCache
-	strictBuiltinErrors    bool
-	builtinErrorList       *[]topdown.Error
-	resolvers              []refResolver
-	schemaSet              *ast.SchemaSet
-	target                 string // target type (wasm, rego, etc.)
-	opa                    opa.EvalEngine
-	generateJSON           func(*ast.Term, *EvalContext) (interface{}, error)
-	printHook              print.Hook
-	enablePrintStatements  bool
-	distributedTacingOpts  tracing.Options
-	strict                 bool
-	pluginMgr              *plugins.Manager
-	plugins                []TargetPlugin
-	targetPrepState        TargetPluginEval
-	regoVersion            ast.RegoVersion
+	query                       string
+	parsedQuery                 ast.Body
+	compiledQueries             map[queryType]compiledQuery
+	pkg                         string
+	parsedPackage               *ast.Package
+	imports                     []string
+	parsedImports               []*ast.Import
+	rawInput                    *interface{}
+	parsedInput                 ast.Value
+	unknowns                    []string
+	parsedUnknowns              []*ast.Term
+	disableInlining             []string
+	shallowInlining             bool
+	skipPartialNamespace        bool
+	partialNamespace            string
+	modules                     []rawModule
+	parsedModules               map[string]*ast.Module
+	compiler                    *ast.Compiler
+	store                       storage.Store
+	ownStore                    bool
+	txn                         storage.Transaction
+	metrics                     metrics.Metrics
+	queryTracers                []topdown.QueryTracer
+	tracebuf                    *topdown.BufferTracer
+	trace                       bool
+	instrumentation             *topdown.Instrumentation
+	instrument                  bool
+	capture                     map[*ast.Expr]ast.Var // map exprs to generated capture vars
+	termVarID                   int
+	dump                        io.Writer
+	runtime                     *ast.Term
+	time                        time.Time
+	seed                        io.Reader
+	capabilities                *ast.Capabilities
+	builtinDecls                map[string]*ast.Builtin
+	builtinFuncs                map[string]*topdown.Builtin
+	unsafeBuiltins              map[string]struct{}
+	loadPaths                   loadPaths
+	bundlePaths                 []string
+	bundles                     map[string]*bundle.Bundle
+	skipBundleVerification      bool
+	interQueryBuiltinCache      cache.InterQueryCache
+	interQueryBuiltinValueCache cache.InterQueryValueCache
+	ndBuiltinCache              builtins.NDBCache
+	strictBuiltinErrors         bool
+	builtinErrorList            *[]topdown.Error
+	resolvers                   []refResolver
+	schemaSet                   *ast.SchemaSet
+	target                      string // target type (wasm, rego, etc.)
+	opa                         opa.EvalEngine
+	generateJSON                func(*ast.Term, *EvalContext) (interface{}, error)
+	printHook                   print.Hook
+	enablePrintStatements       bool
+	distributedTacingOpts       tracing.Options
+	strict                      bool
+	pluginMgr                   *plugins.Manager
+	plugins                     []TargetPlugin
+	targetPrepState             TargetPluginEval
+	regoVersion                 ast.RegoVersion
 }
 
 // Function represents a built-in function that is callable in Rego.
@@ -1114,6 +1128,14 @@ func InterQueryBuiltinCache(c cache.InterQueryCache) func(r *Rego) {
 	}
 }
 
+// InterQueryBuiltinValueCache sets the inter-query value cache that built-in functions can utilize
+// during evaluation.
+func InterQueryBuiltinValueCache(c cache.InterQueryValueCache) func(r *Rego) {
+	return func(r *Rego) {
+		r.interQueryBuiltinValueCache = c
+	}
+}
+
 // NDBuiltinCache sets the non-deterministic builtins cache.
 func NDBuiltinCache(c builtins.NDBCache) func(r *Rego) {
 	return func(r *Rego) {
@@ -1309,6 +1331,7 @@ func (r *Rego) Eval(ctx context.Context) (ResultSet, error) {
 		EvalInstrument(r.instrument),
 		EvalTime(r.time),
 		EvalInterQueryBuiltinCache(r.interQueryBuiltinCache),
+		EvalInterQueryBuiltinValueCache(r.interQueryBuiltinValueCache),
 		EvalSeed(r.seed),
 	}
 
@@ -1386,6 +1409,7 @@ func (r *Rego) Partial(ctx context.Context) (*PartialQueries, error) {
 		EvalMetrics(r.metrics),
 		EvalInstrument(r.instrument),
 		EvalInterQueryBuiltinCache(r.interQueryBuiltinCache),
+		EvalInterQueryBuiltinValueCache(r.interQueryBuiltinValueCache),
 	}
 
 	if r.ndBuiltinCache != nil {
@@ -2106,6 +2130,7 @@ func (r *Rego) eval(ctx context.Context, ectx *EvalContext) (ResultSet, error) {
 		WithIndexing(ectx.indexing).
 		WithEarlyExit(ectx.earlyExit).
 		WithInterQueryBuiltinCache(ectx.interQueryBuiltinCache).
+		WithInterQueryBuiltinValueCache(ectx.interQueryBuiltinValueCache).
 		WithStrictBuiltinErrors(r.strictBuiltinErrors).
 		WithBuiltinErrorList(r.builtinErrorList).
 		WithSeed(ectx.seed).
@@ -2164,7 +2189,6 @@ func (r *Rego) eval(ctx context.Context, ectx *EvalContext) (ResultSet, error) {
 }
 
 func (r *Rego) evalWasm(ctx context.Context, ectx *EvalContext) (ResultSet, error) {
-
 	input := ectx.rawInput
 	if ectx.parsedInput != nil {
 		i := interface{}(ectx.parsedInput)
@@ -2393,6 +2417,7 @@ func (r *Rego) partial(ctx context.Context, ectx *EvalContext) (*PartialQueries,
 		WithSkipPartialNamespace(r.skipPartialNamespace).
 		WithShallowInlining(r.shallowInlining).
 		WithInterQueryBuiltinCache(ectx.interQueryBuiltinCache).
+		WithInterQueryBuiltinValueCache(ectx.interQueryBuiltinValueCache).
 		WithStrictBuiltinErrors(ectx.strictBuiltinErrors).
 		WithSeed(ectx.seed).
 		WithPrintHook(ectx.printHook)

--- a/sdk/opa.go
+++ b/sdk/opa.go
@@ -53,9 +53,10 @@ type OPA struct {
 }
 
 type state struct {
-	manager                *plugins.Manager
-	interQueryBuiltinCache cache.InterQueryCache
-	queryCache             *queryCache
+	manager                     *plugins.Manager
+	interQueryBuiltinCache      cache.InterQueryCache
+	interQueryBuiltinValueCache cache.InterQueryValueCache
+	queryCache                  *queryCache
 }
 
 // New returns a new OPA object. This function should minimally be called with
@@ -235,6 +236,7 @@ func (opa *OPA) configure(ctx context.Context, bs []byte, ready chan struct{}, b
 	opa.state.manager = manager
 	opa.state.queryCache.Clear()
 	opa.state.interQueryBuiltinCache = cache.NewInterQueryCacheWithContext(ctx, manager.InterQueryBuiltinCacheConfig())
+	opa.state.interQueryBuiltinValueCache = cache.NewInterQueryValueCache(ctx, manager.InterQueryBuiltinCacheConfig())
 	opa.config = bs
 
 	return nil
@@ -277,22 +279,23 @@ func (opa *OPA) Decision(ctx context.Context, options DecisionOptions) (*Decisio
 		&record,
 		func(s state, result *DecisionResult) {
 			result.Result, result.Provenance, record.InputAST, record.Bundles, record.Error = evaluate(ctx, evalArgs{
-				runtime:             s.manager.Info,
-				printHook:           s.manager.PrintHook(),
-				compiler:            s.manager.GetCompiler(),
-				store:               s.manager.Store,
-				queryCache:          s.queryCache,
-				interQueryCache:     s.interQueryBuiltinCache,
-				ndbcache:            ndbc,
-				txn:                 record.Txn,
-				now:                 record.Timestamp,
-				path:                record.Path,
-				input:               *record.Input,
-				m:                   record.Metrics,
-				strictBuiltinErrors: options.StrictBuiltinErrors,
-				tracer:              options.Tracer,
-				profiler:            options.Profiler,
-				instrument:          options.Instrument,
+				runtime:                     s.manager.Info,
+				printHook:                   s.manager.PrintHook(),
+				compiler:                    s.manager.GetCompiler(),
+				store:                       s.manager.Store,
+				queryCache:                  s.queryCache,
+				interQueryCache:             s.interQueryBuiltinCache,
+				interQueryBuiltinValueCache: s.interQueryBuiltinValueCache,
+				ndbcache:                    ndbc,
+				txn:                         record.Txn,
+				now:                         record.Timestamp,
+				path:                        record.Path,
+				input:                       *record.Input,
+				m:                           record.Metrics,
+				strictBuiltinErrors:         options.StrictBuiltinErrors,
+				tracer:                      options.Tracer,
+				profiler:                    options.Profiler,
+				instrument:                  options.Instrument,
 			})
 			if record.Error == nil {
 				record.Results = &result.Result
@@ -506,22 +509,23 @@ func IsUndefinedErr(err error) bool {
 }
 
 type evalArgs struct {
-	runtime             *ast.Term
-	printHook           print.Hook
-	compiler            *ast.Compiler
-	store               storage.Store
-	txn                 storage.Transaction
-	queryCache          *queryCache
-	interQueryCache     cache.InterQueryCache
-	now                 time.Time
-	path                string
-	input               interface{}
-	ndbcache            builtins.NDBCache
-	m                   metrics.Metrics
-	strictBuiltinErrors bool
-	tracer              topdown.QueryTracer
-	profiler            topdown.QueryTracer
-	instrument          bool
+	runtime                     *ast.Term
+	printHook                   print.Hook
+	compiler                    *ast.Compiler
+	store                       storage.Store
+	txn                         storage.Transaction
+	queryCache                  *queryCache
+	interQueryCache             cache.InterQueryCache
+	interQueryBuiltinValueCache cache.InterQueryValueCache
+	now                         time.Time
+	path                        string
+	input                       interface{}
+	ndbcache                    builtins.NDBCache
+	m                           metrics.Metrics
+	strictBuiltinErrors         bool
+	tracer                      topdown.QueryTracer
+	profiler                    topdown.QueryTracer
+	instrument                  bool
 }
 
 func evaluate(ctx context.Context, args evalArgs) (interface{}, types.ProvenanceV1, ast.Value, map[string]server.BundleInfo, error) {
@@ -581,6 +585,7 @@ func evaluate(ctx context.Context, args evalArgs) (interface{}, types.Provenance
 		rego.EvalTransaction(args.txn),
 		rego.EvalMetrics(args.m),
 		rego.EvalInterQueryBuiltinCache(args.interQueryCache),
+		rego.EvalInterQueryBuiltinValueCache(args.interQueryBuiltinValueCache),
 		rego.EvalNDBuiltinCache(args.ndbcache),
 		rego.EvalQueryTracer(args.tracer),
 		rego.EvalMetrics(args.m),

--- a/server/authorizer/authorizer.go
+++ b/server/authorizer/authorizer.go
@@ -32,6 +32,7 @@ type Basic struct {
 	printHook             print.Hook
 	enablePrintStatements bool
 	interQueryCache       cache.InterQueryCache
+	interQueryValueCache  cache.InterQueryValueCache
 }
 
 // Runtime returns an argument that sets the runtime on the authorizer.
@@ -73,6 +74,13 @@ func InterQueryCache(interQueryCache cache.InterQueryCache) func(*Basic) {
 	}
 }
 
+// InterQueryValueCache enables the inter-query value cache on the authorizer
+func InterQueryValueCache(interQueryValueCache cache.InterQueryValueCache) func(*Basic) {
+	return func(b *Basic) {
+		b.interQueryValueCache = interQueryValueCache
+	}
+}
+
 // NewBasic returns a new Basic object.
 func NewBasic(inner http.Handler, compiler func() *ast.Compiler, store storage.Store, opts ...func(*Basic)) http.Handler {
 	b := &Basic{
@@ -107,6 +115,7 @@ func (h *Basic) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		rego.EnablePrintStatements(h.enablePrintStatements),
 		rego.PrintHook(h.printHook),
 		rego.InterQueryBuiltinCache(h.interQueryCache),
+		rego.InterQueryBuiltinValueCache(h.interQueryValueCache),
 	)
 
 	rs, err := rego.Eval(r.Context())

--- a/topdown/builtins.go
+++ b/topdown/builtins.go
@@ -35,25 +35,26 @@ type (
 	// BuiltinContext contains context from the evaluator that may be used by
 	// built-in functions.
 	BuiltinContext struct {
-		Context                context.Context       // request context that was passed when query started
-		Metrics                metrics.Metrics       // metrics registry for recording built-in specific metrics
-		Seed                   io.Reader             // randomization source
-		Time                   *ast.Term             // wall clock time
-		Cancel                 Cancel                // atomic value that signals evaluation to halt
-		Runtime                *ast.Term             // runtime information on the OPA instance
-		Cache                  builtins.Cache        // built-in function state cache
-		InterQueryBuiltinCache cache.InterQueryCache // cross-query built-in function state cache
-		NDBuiltinCache         builtins.NDBCache     // cache for non-deterministic built-in state
-		Location               *ast.Location         // location of built-in call
-		Tracers                []Tracer              // Deprecated: Use QueryTracers instead
-		QueryTracers           []QueryTracer         // tracer objects for trace() built-in function
-		TraceEnabled           bool                  // indicates whether tracing is enabled for the evaluation
-		QueryID                uint64                // identifies query being evaluated
-		ParentID               uint64                // identifies parent of query being evaluated
-		PrintHook              print.Hook            // provides callback function to use for printing
-		DistributedTracingOpts tracing.Options       // options to be used by distributed tracing.
-		rand                   *rand.Rand            // randomization source for non-security-sensitive operations
-		Capabilities           *ast.Capabilities
+		Context                     context.Context            // request context that was passed when query started
+		Metrics                     metrics.Metrics            // metrics registry for recording built-in specific metrics
+		Seed                        io.Reader                  // randomization source
+		Time                        *ast.Term                  // wall clock time
+		Cancel                      Cancel                     // atomic value that signals evaluation to halt
+		Runtime                     *ast.Term                  // runtime information on the OPA instance
+		Cache                       builtins.Cache             // built-in function state cache
+		InterQueryBuiltinCache      cache.InterQueryCache      // cross-query built-in function state cache
+		InterQueryBuiltinValueCache cache.InterQueryValueCache // cross-query built-in function state value cache. this cache is useful for scenarios where the entry size cannot be calculated
+		NDBuiltinCache              builtins.NDBCache          // cache for non-deterministic built-in state
+		Location                    *ast.Location              // location of built-in call
+		Tracers                     []Tracer                   // Deprecated: Use QueryTracers instead
+		QueryTracers                []QueryTracer              // tracer objects for trace() built-in function
+		TraceEnabled                bool                       // indicates whether tracing is enabled for the evaluation
+		QueryID                     uint64                     // identifies query being evaluated
+		ParentID                    uint64                     // identifies parent of query being evaluated
+		PrintHook                   print.Hook                 // provides callback function to use for printing
+		DistributedTracingOpts      tracing.Options            // options to be used by distributed tracing.
+		rand                        *rand.Rand                 // randomization source for non-security-sensitive operations
+		Capabilities                *ast.Capabilities
 	}
 
 	// BuiltinFunc defines an interface for implementing built-in functions.

--- a/topdown/eval.go
+++ b/topdown/eval.go
@@ -58,55 +58,56 @@ func (ee deferredEarlyExitError) Error() string {
 }
 
 type eval struct {
-	ctx                    context.Context
-	metrics                metrics.Metrics
-	seed                   io.Reader
-	time                   *ast.Term
-	queryID                uint64
-	queryIDFact            *queryIDFactory
-	parent                 *eval
-	caller                 *eval
-	cancel                 Cancel
-	query                  ast.Body
-	queryCompiler          ast.QueryCompiler
-	index                  int
-	indexing               bool
-	earlyExit              bool
-	bindings               *bindings
-	store                  storage.Store
-	baseCache              *baseCache
-	txn                    storage.Transaction
-	compiler               *ast.Compiler
-	input                  *ast.Term
-	data                   *ast.Term
-	external               *resolverTrie
-	targetStack            *refStack
-	tracers                []QueryTracer
-	traceEnabled           bool
-	traceLastLocation      *ast.Location // Last location of a trace event.
-	plugTraceVars          bool
-	instr                  *Instrumentation
-	builtins               map[string]*Builtin
-	builtinCache           builtins.Cache
-	ndBuiltinCache         builtins.NDBCache
-	functionMocks          *functionMocksStack
-	virtualCache           VirtualCache
-	comprehensionCache     *comprehensionCache
-	interQueryBuiltinCache cache.InterQueryCache
-	saveSet                *saveSet
-	saveStack              *saveStack
-	saveSupport            *saveSupport
-	saveNamespace          *ast.Term
-	skipSaveNamespace      bool
-	inliningControl        *inliningControl
-	genvarprefix           string
-	genvarid               int
-	runtime                *ast.Term
-	builtinErrors          *builtinErrors
-	printHook              print.Hook
-	tracingOpts            tracing.Options
-	findOne                bool
-	strictObjects          bool
+	ctx                         context.Context
+	metrics                     metrics.Metrics
+	seed                        io.Reader
+	time                        *ast.Term
+	queryID                     uint64
+	queryIDFact                 *queryIDFactory
+	parent                      *eval
+	caller                      *eval
+	cancel                      Cancel
+	query                       ast.Body
+	queryCompiler               ast.QueryCompiler
+	index                       int
+	indexing                    bool
+	earlyExit                   bool
+	bindings                    *bindings
+	store                       storage.Store
+	baseCache                   *baseCache
+	txn                         storage.Transaction
+	compiler                    *ast.Compiler
+	input                       *ast.Term
+	data                        *ast.Term
+	external                    *resolverTrie
+	targetStack                 *refStack
+	tracers                     []QueryTracer
+	traceEnabled                bool
+	traceLastLocation           *ast.Location // Last location of a trace event.
+	plugTraceVars               bool
+	instr                       *Instrumentation
+	builtins                    map[string]*Builtin
+	builtinCache                builtins.Cache
+	ndBuiltinCache              builtins.NDBCache
+	functionMocks               *functionMocksStack
+	virtualCache                VirtualCache
+	comprehensionCache          *comprehensionCache
+	interQueryBuiltinCache      cache.InterQueryCache
+	interQueryBuiltinValueCache cache.InterQueryValueCache
+	saveSet                     *saveSet
+	saveStack                   *saveStack
+	saveSupport                 *saveSupport
+	saveNamespace               *ast.Term
+	skipSaveNamespace           bool
+	inliningControl             *inliningControl
+	genvarprefix                string
+	genvarid                    int
+	runtime                     *ast.Term
+	builtinErrors               *builtinErrors
+	printHook                   print.Hook
+	tracingOpts                 tracing.Options
+	findOne                     bool
+	strictObjects               bool
 }
 
 func (e *eval) Run(iter evalIterator) error {
@@ -817,23 +818,24 @@ func (e *eval) evalCall(terms []*ast.Term, iter unifyIterator) error {
 	}
 
 	bctx := BuiltinContext{
-		Context:                e.ctx,
-		Metrics:                e.metrics,
-		Seed:                   e.seed,
-		Time:                   e.time,
-		Cancel:                 e.cancel,
-		Runtime:                e.runtime,
-		Cache:                  e.builtinCache,
-		InterQueryBuiltinCache: e.interQueryBuiltinCache,
-		NDBuiltinCache:         e.ndBuiltinCache,
-		Location:               e.query[e.index].Location,
-		QueryTracers:           e.tracers,
-		TraceEnabled:           e.traceEnabled,
-		QueryID:                e.queryID,
-		ParentID:               parentID,
-		PrintHook:              e.printHook,
-		DistributedTracingOpts: e.tracingOpts,
-		Capabilities:           capabilities,
+		Context:                     e.ctx,
+		Metrics:                     e.metrics,
+		Seed:                        e.seed,
+		Time:                        e.time,
+		Cancel:                      e.cancel,
+		Runtime:                     e.runtime,
+		Cache:                       e.builtinCache,
+		InterQueryBuiltinCache:      e.interQueryBuiltinCache,
+		InterQueryBuiltinValueCache: e.interQueryBuiltinValueCache,
+		NDBuiltinCache:              e.ndBuiltinCache,
+		Location:                    e.query[e.index].Location,
+		QueryTracers:                e.tracers,
+		TraceEnabled:                e.traceEnabled,
+		QueryID:                     e.queryID,
+		ParentID:                    parentID,
+		PrintHook:                   e.printHook,
+		DistributedTracingOpts:      e.tracingOpts,
+		Capabilities:                capabilities,
 	}
 
 	eval := evalBuiltin{

--- a/topdown/glob_test.go
+++ b/topdown/glob_test.go
@@ -5,10 +5,12 @@
 package topdown
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
 	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/topdown/cache"
 )
 
 func TestGlobBuiltinCache(t *testing.T) {
@@ -67,5 +69,110 @@ func TestGlobBuiltinCache(t *testing.T) {
 
 	if _, ok := globCache[fmt.Sprintf("%s-", glob2)]; !ok {
 		t.Fatalf("Expected glob to be cached: %v", glob2)
+	}
+}
+
+func TestGlobBuiltinInterQueryValueCache(t *testing.T) {
+	ip := []byte(`{"inter_query_builtin_value_cache": {"max_num_entries": "10"},}`)
+	config, _ := cache.ParseCachingConfig(ip)
+	interQueryValueCache := cache.NewInterQueryValueCache(context.Background(), config)
+
+	ctx := BuiltinContext{InterQueryBuiltinValueCache: interQueryValueCache}
+	iter := func(*ast.Term) error { return nil }
+
+	// A novel glob pattern is cached.
+	glob1 := "foo/*"
+	operands := []*ast.Term{
+		ast.NewTerm(ast.String(glob1)),
+		ast.NullTerm(),
+		ast.NewTerm(ast.String("foo/bar")),
+	}
+	err := builtinGlobMatch(ctx, operands, iter)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// the glob id will have a trailing '-' rune.
+	if _, ok := ctx.InterQueryBuiltinValueCache.Get(ast.StringTerm(fmt.Sprintf("%s-", glob1)).Value); !ok {
+		t.Fatalf("Expected glob to be cached: %v", glob1)
+	}
+
+	// Fill up the cache.
+	for i := 0; i < 9; i++ {
+		operands := []*ast.Term{
+			ast.NewTerm(ast.String(fmt.Sprintf("foo/%d/*", i))),
+			ast.NullTerm(),
+			ast.NewTerm(ast.String(fmt.Sprintf("foo/%d/bar", i))),
+		}
+		err := builtinGlobMatch(ctx, operands, iter)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+	}
+
+	// A new glob pattern is cached and a random pattern is evicted.
+	glob2 := "bar/*"
+	operands = []*ast.Term{
+		ast.NewTerm(ast.String(glob2)),
+		ast.NullTerm(),
+		ast.NewTerm(ast.String("bar/baz")),
+	}
+	err = builtinGlobMatch(ctx, operands, iter)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if _, ok := ctx.InterQueryBuiltinValueCache.Get(ast.StringTerm(fmt.Sprintf("%s-", glob2)).Value); !ok {
+		t.Fatalf("Expected glob to be cached: %v", glob2)
+	}
+}
+
+func TestGlobBuiltinInterQueryValueCacheTypeMismatch(t *testing.T) {
+
+	ip := []byte(`{"inter_query_builtin_value_cache": {"max_num_entries": "10"},}`)
+	config, _ := cache.ParseCachingConfig(ip)
+	interQueryValueCache := cache.NewInterQueryValueCache(context.Background(), config)
+
+	ctx := BuiltinContext{InterQueryBuiltinValueCache: interQueryValueCache}
+	iter := func(*ast.Term) error { return nil }
+
+	key := "foo.*"
+
+	operands := []*ast.Term{
+		ast.NewTerm(ast.String(key)),
+		ast.NullTerm(),
+		ast.NewTerm(ast.String("foo/bar")),
+	}
+	err := builtinGlobMatch(ctx, operands, iter)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// the glob id will have a trailing '-' rune.
+	if _, ok := ctx.InterQueryBuiltinValueCache.Get(ast.StringTerm(fmt.Sprintf("%s-", key)).Value); !ok {
+		t.Fatalf("Expected glob to be cached: %v", key)
+	}
+
+	// update the cache entry
+	ctx.InterQueryBuiltinValueCache.Insert(ast.StringTerm(fmt.Sprintf("%s-", key)).Value, "bar")
+
+	err = builtinGlobMatch(ctx, operands, iter)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// verify the cache entry is unchanged
+	value, ok := ctx.InterQueryBuiltinValueCache.Get(ast.StringTerm(fmt.Sprintf("%s-", key)).Value)
+	if !ok {
+		t.Fatal("Expected key \"foo.*-\" in cache")
+	}
+
+	actual, ok := value.(string)
+	if !ok {
+		t.Fatal("Expected string value")
+	}
+
+	if actual != "bar" {
+		t.Fatalf("Expected value \"bar\" but got %v", actual)
 	}
 }

--- a/topdown/regex_test.go
+++ b/topdown/regex_test.go
@@ -5,10 +5,12 @@
 package topdown
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
 	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/topdown/cache"
 )
 
 func TestRegexBuiltinCache(t *testing.T) {
@@ -63,5 +65,95 @@ func TestRegexBuiltinCache(t *testing.T) {
 
 	if _, ok := regexpCache[regex2]; !ok {
 		t.Fatalf("Expected regex to be cached: %v", regex2)
+	}
+}
+
+func TestRegexBuiltinInterQueryValueCache(t *testing.T) {
+
+	ip := []byte(`{"inter_query_builtin_value_cache": {"max_num_entries": "10"},}`)
+	config, _ := cache.ParseCachingConfig(ip)
+	interQueryValueCache := cache.NewInterQueryValueCache(context.Background(), config)
+
+	ctx := BuiltinContext{InterQueryBuiltinValueCache: interQueryValueCache}
+	iter := func(*ast.Term) error { return nil }
+
+	// A novel regex pattern is cached.
+	regex1 := "foo.*"
+	operands := []*ast.Term{
+		ast.NewTerm(ast.String(regex1)),
+		ast.NewTerm(ast.String("foobar")),
+	}
+	err := builtinRegexMatch(ctx, operands, iter)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if _, ok := ctx.InterQueryBuiltinValueCache.Get(ast.StringTerm(regex1).Value); !ok {
+		t.Fatalf("Expected regex to be cached: %v", regex1)
+	}
+
+	// Fill up the cache.
+	for i := 0; i < 9; i++ {
+		operands := []*ast.Term{
+			ast.NewTerm(ast.String(fmt.Sprintf("foo%d.*", i))),
+			ast.NewTerm(ast.String(fmt.Sprintf("foo%dbar", i))),
+		}
+		err := builtinRegexMatch(ctx, operands, iter)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+	}
+
+	// A new regex pattern is cached and a random pattern is evicted.
+	regex2 := "bar.*"
+	operands = []*ast.Term{
+		ast.NewTerm(ast.String(regex2)),
+		ast.NewTerm(ast.String("barbaz")),
+	}
+	err = builtinRegexMatch(ctx, operands, iter)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if _, ok := ctx.InterQueryBuiltinValueCache.Get(ast.StringTerm(regex2).Value); !ok {
+		t.Fatalf("Expected regex to be cached: %v", regex2)
+	}
+}
+
+func TestRegexBuiltinInterQueryValueCacheTypeMismatch(t *testing.T) {
+
+	ip := []byte(`{"inter_query_builtin_value_cache": {"max_num_entries": "10"},}`)
+	config, _ := cache.ParseCachingConfig(ip)
+	interQueryValueCache := cache.NewInterQueryValueCache(context.Background(), config)
+
+	ctx := BuiltinContext{InterQueryBuiltinValueCache: interQueryValueCache}
+	iter := func(*ast.Term) error { return nil }
+
+	key := "foo.*"
+
+	ctx.InterQueryBuiltinValueCache.Insert(ast.StringTerm(key).Value, "bar")
+
+	operands := []*ast.Term{
+		ast.NewTerm(ast.String(key)),
+		ast.NewTerm(ast.String("foobar")),
+	}
+	err := builtinRegexMatch(ctx, operands, iter)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// verify the original cache entry is unchanged
+	value, ok := ctx.InterQueryBuiltinValueCache.Get(ast.StringTerm(key).Value)
+	if !ok {
+		t.Fatal("Expected key \"foo.*\" in cache")
+	}
+
+	actual, ok := value.(string)
+	if !ok {
+		t.Fatal("Expected string value")
+	}
+
+	if actual != "bar" {
+		t.Fatalf("Expected value \"bar\" but got %v", actual)
 	}
 }

--- a/topdown/topdown_test.go
+++ b/topdown/topdown_test.go
@@ -2119,6 +2119,7 @@ func assertTopDownWithPathAndContext(ctx context.Context, t *testing.T, compiler
 	// add an inter-query cache
 	config, _ := iCache.ParseCachingConfig(nil)
 	interQueryCache := iCache.NewInterQueryCache(config)
+	interQueryValueCache := iCache.NewInterQueryValueCache(ctx, config)
 
 	var strictBuiltinErrors bool
 
@@ -2133,6 +2134,7 @@ func assertTopDownWithPathAndContext(ctx context.Context, t *testing.T, compiler
 		WithTransaction(txn).
 		WithInput(inputTerm).
 		WithInterQueryBuiltinCache(interQueryCache).
+		WithInterQueryBuiltinValueCache(interQueryValueCache).
 		WithStrictBuiltinErrors(strictBuiltinErrors)
 
 	var tracer BufferTracer
@@ -2212,13 +2214,15 @@ func runTopDownPartialTestCase(ctx context.Context, t *testing.T, compiler *ast.
 	// add an inter-query cache
 	config, _ := iCache.ParseCachingConfig(nil)
 	interQueryCache := iCache.NewInterQueryCache(config)
+	interQueryValueCache := iCache.NewInterQueryValueCache(ctx, config)
 
 	partialQuery := NewQuery(body).
 		WithCompiler(compiler).
 		WithStore(store).
 		WithUnknowns([]*ast.Term{ast.MustParseTerm("input")}).
 		WithTransaction(txn).
-		WithInterQueryBuiltinCache(interQueryCache)
+		WithInterQueryBuiltinCache(interQueryCache).
+		WithInterQueryBuiltinValueCache(interQueryValueCache)
 
 	partials, support, err := partialQuery.PartialRun(ctx)
 
@@ -2251,7 +2255,8 @@ func runTopDownPartialTestCase(ctx context.Context, t *testing.T, compiler *ast.
 		WithStore(store).
 		WithTransaction(txn).
 		WithInput(input).
-		WithInterQueryBuiltinCache(interQueryCache)
+		WithInterQueryBuiltinCache(interQueryCache).
+		WithInterQueryBuiltinValueCache(interQueryValueCache)
 
 	qrs, err := query.Run(ctx)
 	if err != nil {


### PR DESCRIPTION
This commit adds a new inter-query value cache that built-in
functions can use to cache information across queries.
For example, the `regex` and `glob` builtins can use this
to cache compiled regex and glob match patterns respectively.

The number of entries in the cache can be configured via the OPA
config. By default there is no limit.

Fixes: https://github.com/open-policy-agent/opa/issues/6908