### PR TITLE
fmt: retain CR/LF line endings in formatted files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+format/testfiles/crlf.rego text eol=crlf
+format/testfiles/crlf.rego.formatted text eol=crlf

--- a/format/format.go
+++ b/format/format.go
@@ -57,6 +57,10 @@ func SourceWithOpts(filename string, src []byte, opts Opts) ([]byte, error) {
 		}
 	}
 
+	// if any of the lines in the source code end with "\r\n", we will use that
+	// as the line ending in the formatted code.
+	useCRLF := strings.Contains(string(src), "\r\n")
+
 	module, err := ast.ParseModuleWithOpts(filename, string(src), parserOpts)
 	if err != nil {
 		return nil, err
@@ -77,6 +81,10 @@ func SourceWithOpts(filename string, src []byte, opts Opts) ([]byte, error) {
 	formatted, err := AstWithOpts(module, opts)
 	if err != nil {
 		return nil, fmt.Errorf("%s: %v", filename, err)
+	}
+
+	if useCRLF {
+		return bytes.ReplaceAll(formatted, []byte("\n"), []byte("\r\n")), nil
 	}
 
 	return formatted, nil

--- a/format/testfiles/crlf.rego
+++ b/format/testfiles/crlf.rego
@@ -1,0 +1,3 @@
+package crlf
+
+allow := true

--- a/format/testfiles/crlf.rego.formatted
+++ b/format/testfiles/crlf.rego.formatted
@@ -1,0 +1,3 @@
+package crlf
+
+allow := true


### PR DESCRIPTION
Fixes https://github.com/open-policy-agent/opa/issues/6993

### Why the changes in this PR are needed?

These changes are needed to make opa fmt work as expected on Windows and other systems using CR/LF endings.

### What are the changes in this PR?

If OPA fmt finds a CR/LF ending, this will be used in the formatted rego output. 
### Notes to assist PR review:

I am unsure that the Github diff shows the line endings correctly.


### Further comments:

If there are mixed endings, CR/LF will be used.

