### PR TITLE
planner: fix with replacement with local-var values

### DIFF
--- a/internal/planner/rules.go
+++ b/internal/planner/rules.go
@@ -306,3 +306,16 @@ func (s *functionMocksStack) Lookup(f string) *ast.Term {
 	}
 	return nil
 }
+
+func (s *functionMocksStack) ExtraVars() []*ast.Term {
+	exs := make([]*ast.Term, 0)
+	current := *s.stack[len(s.stack)-1]
+	for i := len(current) - 1; i >= 0; i-- {
+		for _, t := range current[i] {
+			if _, ok := t.Value.(ast.Var); ok {
+				exs = append(exs, t)
+			}
+		}
+	}
+	return exs
+}

--- a/test/cases/testdata/v0/withkeyword/test-with-builtin-mock.yaml
+++ b/test/cases/testdata/v0/withkeyword/test-with-builtin-mock.yaml
@@ -450,3 +450,38 @@ cases:
     query: data.test.p = x
     want_result:
       - x: true
+  - modules:
+      - |
+        package test
+        p {
+          my_var := 1
+          q with count as my_var
+        }
+        q {
+          r
+        }
+        r {
+          count([1,2,3]) == 1
+        }
+    note: "withkeyword/builtin: indirect call, arity 1, replacement is local variable"
+    query: data.test.p = x
+    want_result:
+      - x: true
+  - modules:
+      - |
+        package test
+        f(1) = 2
+        p {
+          my_var := 1
+          q with f as my_var
+        }
+        q {
+          r
+        }
+        r {
+          f(1) == 1
+        }
+    note: "withkeyword/function: indirect call, arity 1, replacement is local variable"
+    query: data.test.p = x
+    want_result:
+      - x: true


### PR DESCRIPTION
Every function down the call stacks of a with-replacement that does this will now get extra variables added to its args to carry along the local variables that will eventually be needed to replace the with-mocked func call.

TODOs:
- [ ] think hard about variable name clashes (do we need a factory func for this? OTOH I think local vars are safe...)
- [ ] more test cases

Fixes #5311.
