### PR TITLE
Support reading AWS token from the filesystem

### DIFF
--- a/plugins/rest/aws.go
+++ b/plugins/rest/aws.go
@@ -30,10 +30,11 @@ const (
 	ec2DefaultTokenPath = "http://169.254.169.254/latest/api/token"
 
 	// ref. https://docs.aws.amazon.com/AmazonECS/latest/userguide/task-iam-roles.html
-	ecsDefaultCredServicePath   = "http://169.254.170.2"
-	ecsRelativePathEnvVar       = "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"
-	ecsFullPathEnvVar           = "AWS_CONTAINER_CREDENTIALS_FULL_URI"
-	ecsAuthorizationTokenEnvVar = "AWS_CONTAINER_AUTHORIZATION_TOKEN"
+	ecsDefaultCredServicePath       = "http://169.254.170.2"
+	ecsRelativePathEnvVar           = "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"
+	ecsFullPathEnvVar               = "AWS_CONTAINER_CREDENTIALS_FULL_URI"
+	ecsAuthorizationTokenEnvVar     = "AWS_CONTAINER_AUTHORIZATION_TOKEN"
+	ecsAuthorizationTokenFileEnvVar = "AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE"
 
 	// ref. https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html
 	stsDefaultDomain = "amazonaws.com"
@@ -278,8 +279,17 @@ func (cs *awsMetadataCredentialService) refreshFromService(ctx context.Context) 
 	// to the request
 	if _, useFullPath := os.LookupEnv(ecsFullPathEnvVar); useFullPath {
 		token, tokenExists := os.LookupEnv(ecsAuthorizationTokenEnvVar)
+		// If token doesn't exist as an env var check if it exists on the file system (e.g. for pod identities)
 		if !tokenExists {
-			return errors.New("unable to get ECS metadata authorization token")
+			tokenFilePath, tokenFilePathExists := os.LookupEnv(ecsAuthorizationTokenFileEnvVar)
+			if !tokenFilePathExists {
+				return errors.New("unable to get ECS metadata authorization token")
+			}
+			tokenBytes, err := os.ReadFile(tokenFilePath)
+			if err != nil {
+				return errors.New("failed to read ECS metadata authorization token from file: " + err.Error())
+			}
+			token = string(tokenBytes)
 		}
 		req.Header.Set("Authorization", token)
 	}


### PR DESCRIPTION
Fixes #6724 

### Why the changes in this PR are needed?

PR #6894 adds support for the [AWS container credential provider](https://docs.aws.amazon.com/sdkref/latest/guide/feature-container-credentials.html) but it is missing support for providing the token as file via the `AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE` environment variable. This mechanism is used by [EKS pod identities](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html).

### What are the changes in this PR?

When using the container credential provider we will attempt to load the token from file if `AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE` is set.  If both `AWS_CONTAINER_AUTHORIZATION_TOKEN` and `AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE` are set the former takes precedence.

### Notes to assist PR review:

The changes in this PR have been confirmed working in EKS.