### PR TITLE
ast: Make `Module.String()` include `if`/`contains` for v1 modules

### DIFF
--- a/ast/policy.go
+++ b/ast/policy.go
@@ -1023,6 +1023,7 @@ func (head *Head) String() string {
 func (head *Head) stringWithOpts(opts toStringOpts) string {
 	buf := strings.Builder{}
 	buf.WriteString(head.Ref().String())
+	containsAdded := false
 
 	switch {
 	case len(head.Args) != 0:
@@ -1034,6 +1035,7 @@ func (head *Head) stringWithOpts(opts toStringOpts) string {
 			buf.WriteString(head.Key.String())
 			buf.WriteRune(']')
 		default:
+			containsAdded = true
 			buf.WriteString(" contains ")
 			buf.WriteString(head.Key.String())
 		}
@@ -1045,7 +1047,7 @@ func (head *Head) stringWithOpts(opts toStringOpts) string {
 			buf.WriteString(" = ")
 		}
 		buf.WriteString(head.Value.String())
-	} else if head.Name == "" && head.Key != nil {
+	} else if !containsAdded && head.Name == "" && head.Key != nil {
 		buf.WriteString(" contains ")
 		buf.WriteString(head.Key.String())
 	}

--- a/ast/policy.go
+++ b/ast/policy.go
@@ -405,7 +405,7 @@ func (mod *Module) String() string {
 		buf = append(buf, "")
 		for _, rule := range mod.Rules {
 			buf = appendAnnotationStrings(buf, rule)
-			buf = append(buf, rule.String())
+			buf = append(buf, rule.stringWithOpts(toStringOpts{regoVersion: mod.regoVersion}))
 		}
 	}
 	return strings.Join(buf, "\n")
@@ -770,18 +770,30 @@ func (rule *Rule) Ref() Ref {
 }
 
 func (rule *Rule) String() string {
+	return rule.stringWithOpts(toStringOpts{})
+}
+
+type toStringOpts struct {
+	regoVersion RegoVersion
+}
+
+func (rule *Rule) stringWithOpts(opts toStringOpts) string {
 	buf := []string{}
 	if rule.Default {
 		buf = append(buf, "default")
 	}
-	buf = append(buf, rule.Head.String())
+	buf = append(buf, rule.Head.stringWithOpts(opts))
 	if !rule.Default {
+		switch opts.regoVersion {
+		case RegoV1, RegoV0CompatV1:
+			buf = append(buf, "if")
+		}
 		buf = append(buf, "{")
 		buf = append(buf, rule.Body.String())
 		buf = append(buf, "}")
 	}
 	if rule.Else != nil {
-		buf = append(buf, rule.Else.elseString())
+		buf = append(buf, rule.Else.elseString(opts))
 	}
 	return strings.Join(buf, " ")
 }
@@ -824,7 +836,7 @@ func (rule *Rule) MarshalJSON() ([]byte, error) {
 	return json.Marshal(data)
 }
 
-func (rule *Rule) elseString() string {
+func (rule *Rule) elseString(opts toStringOpts) string {
 	var buf []string
 
 	buf = append(buf, "else")
@@ -835,12 +847,17 @@ func (rule *Rule) elseString() string {
 		buf = append(buf, value.String())
 	}
 
+	switch opts.regoVersion {
+	case RegoV1, RegoV0CompatV1:
+		buf = append(buf, "if")
+	}
+
 	buf = append(buf, "{")
 	buf = append(buf, rule.Body.String())
 	buf = append(buf, "}")
 
 	if rule.Else != nil {
-		buf = append(buf, rule.Else.elseString())
+		buf = append(buf, rule.Else.elseString(opts))
 	}
 
 	return strings.Join(buf, " ")
@@ -1000,6 +1017,10 @@ func (head *Head) Equal(other *Head) bool {
 }
 
 func (head *Head) String() string {
+	return head.stringWithOpts(toStringOpts{})
+}
+
+func (head *Head) stringWithOpts(opts toStringOpts) string {
 	buf := strings.Builder{}
 	buf.WriteString(head.Ref().String())
 
@@ -1007,9 +1028,15 @@ func (head *Head) String() string {
 	case len(head.Args) != 0:
 		buf.WriteString(head.Args.String())
 	case len(head.Reference) == 1 && head.Key != nil:
-		buf.WriteRune('[')
-		buf.WriteString(head.Key.String())
-		buf.WriteRune(']')
+		switch opts.regoVersion {
+		case RegoV0:
+			buf.WriteRune('[')
+			buf.WriteString(head.Key.String())
+			buf.WriteRune(']')
+		default:
+			buf.WriteString(" contains ")
+			buf.WriteString(head.Key.String())
+		}
 	}
 	if head.Value != nil {
 		if head.Assign {

--- a/compile/compile_test.go
+++ b/compile/compile_test.go
@@ -1246,9 +1246,11 @@ func TestCompilerOptimizationWithConfiguredNamespace(t *testing.T) {
 				t.Fatalf("expected two modules but got: %v", len(compiler.bundle.Modules))
 			}
 
+			// The compiler will strip the rego.v1 import from the module, so we need to compare it
+			// to a pure v1 module that doesn't require the import.
 			optimizedExp := ast.MustParseModuleWithOpts(`package custom
 				__not1_0_2__ = true if { data.test.q = _; _ }`,
-				ast.ParserOptions{AllFutureKeywords: true})
+				ast.ParserOptions{RegoVersion: ast.RegoV1})
 
 			if optimizedExp.String() != compiler.bundle.Modules[0].Parsed.String() {
 				t.Fatalf("expected optimized module to be:\n\n%v\n\ngot:\n\n%v", optimizedExp, compiler.bundle.Modules[0])
@@ -1258,7 +1260,7 @@ func TestCompilerOptimizationWithConfiguredNamespace(t *testing.T) {
 				k = {1, 2, 3} if { true }
 				p = true if { not data.custom.__not1_0_2__ }
 				q = true if { __local0__3 = input.a; data.test.k[__local0__3] = _; _; __local1__3 = input.b; data.test.k[__local1__3] = _; _ }`,
-				ast.ParserOptions{AllFutureKeywords: true})
+				ast.ParserOptions{RegoVersion: ast.RegoV1})
 
 			if expected.String() != compiler.bundle.Modules[1].Parsed.String() {
 				t.Fatalf("expected module to be:\n\n%v\n\ngot:\n\n%v", expected, compiler.bundle.Modules[1])

--- a/rego/rego_test.go
+++ b/rego/rego_test.go
@@ -1184,7 +1184,7 @@ func TestPartialWithRegoV1(t *testing.T) {
 			expQuery: `data.partial.test.p = x`,
 			expSupport: `package partial.test.p
 
-foo[__local1__1] { __local1__1 = input.v }`,
+foo contains __local1__1 if { __local1__1 = input.v }`,
 		},
 		{
 			note: "rego.v1 imported",
@@ -1197,7 +1197,7 @@ foo[__local1__1] { __local1__1 = input.v }`,
 			expQuery: `data.partial.test.p = x`,
 			expSupport: `package partial.test.p
 
-foo[__local1__1] { __local1__1 = input.v }`,
+foo contains __local1__1 if { __local1__1 = input.v }`,
 		},
 		{
 			note: "future.keywords imported",
@@ -1210,7 +1210,7 @@ foo[__local1__1] { __local1__1 = input.v }`,
 			expQuery: `data.partial.test.p = x`,
 			expSupport: `package partial.test.p
 
-foo[__local1__1] { __local1__1 = input.v }`,
+foo contains __local1__1 if { __local1__1 = input.v }`,
 		},
 	}
 


### PR DESCRIPTION
Fixes: #6973

This is also helpful for the v1 refactoring of tests we're currently doing.