### PR TITLE
ast: Assigning rule key also for `if`-rules with 2-part non-ground refs

### DIFF
--- a/ast/parser.go
+++ b/ast/parser.go
@@ -688,6 +688,10 @@ func (p *Parser) parseRules() []*Rule {
 
 	// p[x] if ...  becomes a single-value rule p[x]
 	if hasIf && !usesContains && len(rule.Head.Ref()) == 2 {
+		if !rule.Head.Ref()[1].IsGround() && len(rule.Head.Args) == 0 {
+			rule.Head.Key = rule.Head.Ref()[1]
+		}
+
 		if rule.Head.Value == nil {
 			rule.Head.generatedValue = true
 			rule.Head.Value = BooleanTerm(true).SetLocation(rule.Head.Location)

--- a/ast/parser_test.go
+++ b/ast/parser_test.go
@@ -2652,6 +2652,7 @@ func TestRuleIf(t *testing.T) {
 				Head: &Head{
 					Name:      Var("p"),
 					Reference: MustParseRef("p[x]"),
+					Key:       VarTerm("x"),
 					Value:     VarTerm("y"),
 				},
 				Body: MustParseBody(`x := "foo"; y := "bar"`),
@@ -2687,6 +2688,7 @@ func TestRuleIf(t *testing.T) {
 			exp: &Rule{
 				Head: &Head{
 					Reference: MustParseRef("p[x]"),
+					Key:       VarTerm("x"),
 					Value:     BooleanTerm(true),
 				},
 				Body: MustParseBody(`x := 1`),
@@ -2698,6 +2700,7 @@ func TestRuleIf(t *testing.T) {
 			exp: &Rule{
 				Head: &Head{
 					Reference: MustParseRef("p[x]"),
+					Key:       VarTerm("x"),
 					Value:     BooleanTerm(true),
 				},
 				Body: MustParseBody(`x := 1`),
@@ -2783,6 +2786,7 @@ func TestRuleRefHeads(t *testing.T) {
 				Head: &Head{
 					Name:      Var("p"),
 					Reference: MustParseRef("p[x]"),
+					Key:       VarTerm("x"),
 					Value:     IntNumberTerm(1),
 				},
 				Body: MustParseBody("x := 2"),

--- a/format/format.go
+++ b/format/format.go
@@ -568,8 +568,7 @@ func (w *writer) writeHead(head *ast.Head, isDefault, isExpandedConst bool, o fm
 		// * a.b.c.d -> a.b.c.d := true
 		isRegoV1RefConst := o.regoV1 && isExpandedConst && head.Key == nil && len(head.Args) == 0
 
-		if len(head.Args) > 0 &&
-			head.Location == head.Value.Location &&
+		if head.Location == head.Value.Location &&
 			head.Name != "else" &&
 			ast.Compare(head.Value, ast.BooleanTerm(true)) == 0 &&
 			!isRegoV1RefConst {


### PR DESCRIPTION
This fix prepares for the switch to Rego v1 by default in OPA 1.0.