### PR TITLE
Fix Timer stopping in http.send

### DIFF
--- a/topdown/http.go
+++ b/topdown/http.go
@@ -168,6 +168,7 @@ func generateRaiseErrorResult(err error) *ast.Term {
 func getHTTPResponse(bctx BuiltinContext, req ast.Object) (*ast.Term, error) {
 
 	bctx.Metrics.Timer(httpSendLatencyMetricKey).Start()
+	defer bctx.Metrics.Timer(httpSendLatencyMetricKey).Stop()
 
 	key, err := getKeyFromRequest(req)
 	if err != nil {
@@ -199,7 +200,6 @@ func getHTTPResponse(bctx BuiltinContext, req ast.Object) (*ast.Term, error) {
 		}
 	}
 
-	bctx.Metrics.Timer(httpSendLatencyMetricKey).Stop()
 
 	return ast.NewTerm(resp), nil
 }

--- a/topdown/http.go
+++ b/topdown/http.go
@@ -200,7 +200,6 @@ func getHTTPResponse(bctx BuiltinContext, req ast.Object) (*ast.Term, error) {
 		}
 	}
 
-
 	return ast.NewTerm(resp), nil
 }
 


### PR DESCRIPTION
Fixes incorrect `Timer` measuring in case of error. Without calling `Stop()` method when e.g. `eval_cancel_error` happens the last delta is not added to the accumulated `Timer` value.

I discovered it by investigating `eval_cancel_error` when the caller gave up but according to OPA metrics it looked like `http.send` did not cause it (I would expect near 10s value in `timer_rego_builtin_http_send_ns` too):
```
{"counter_rego_builtin_http_send_interquery_cache_hits":1,
"counter_server_query_cache_hit":1,
"timer_rego_builtin_http_send_ns":124580,
"timer_rego_input_parse_ns":4771,
"timer_rego_query_eval_ns":9770617400,
"timer_server_handler_ns":9770659804} 
```
