### PR TITLE
docs: Downgrade Hugo

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -375,7 +375,7 @@ jobs:
         uses: peaceiris/actions-hugo@75d2e84710de30f6ff7268e08f310b60ef14033f # v3.0.0
         with:
           # keep this version in sync with the version in netlify.toml
-          hugo-version: "0.129.0"
+          hugo-version: "0.113.0"
           extended: true
 
       - name: Build docs site and test integrations data

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -375,6 +375,9 @@ jobs:
         uses: peaceiris/actions-hugo@75d2e84710de30f6ff7268e08f310b60ef14033f # v3.0.0
         with:
           # keep this version in sync with the version in netlify.toml
+          # Note, that upgrading Hugo is tricky as all versions of the OPA docs need to work
+          # with the Hugo version used.
+          # see: https://github.com/open-policy-agent/opa/pull/7034
           hugo-version: "0.113.0"
           extended: true
 

--- a/docs/website/layouts/partials/css.html
+++ b/docs/website/layouts/partials/css.html
@@ -1,4 +1,4 @@
-{{ $inServerMode := hugo.IsServer }}
+{{ $inServerMode := site.IsServer }}
 {{ $sass         := "sass/style.sass" }}
 {{ $cssOutput    := "css/style.css" }}
 {{ $includePaths := (slice "node_modules") }}

--- a/netlify.toml
+++ b/netlify.toml
@@ -10,7 +10,7 @@ function = "badge"
 
 [build.environment]
 # keep this version in sync with the version in .github/workflows/pull-request.yml
-HUGO_VERSION = "0.129.0"
+HUGO_VERSION = "0.113.0"
 
 [context.deploy-preview]
 command = "make netlify-preview WASM_ENABLED=0 CGO_ENABLED=0"

--- a/netlify.toml
+++ b/netlify.toml
@@ -10,6 +10,9 @@ function = "badge"
 
 [build.environment]
 # keep this version in sync with the version in .github/workflows/pull-request.yml
+# Note, that upgrading Hugo is tricky as all versions of the OPA docs need to work
+# with the Hugo version used.
+# see: https://github.com/open-policy-agent/opa/pull/7034
 HUGO_VERSION = "0.113.0"
 
 [context.deploy-preview]


### PR DESCRIPTION
In https://github.com/open-policy-agent/opa/pull/7033, I hoped to upgrade the Hugo version used to build the site. However, this was not as simple as it seemed...

While the site preview built ok, it was actually missing the docs content. When running on main, this broken the netlify build.

Issues I encountered while attempting to update:

- .File.Path was nil
- `kind` in YAML frontmatter is not allowed, but we use it to structure the site's navbars

I have added a note next to the Hugo versions that upgrading the site's version is challenging for these reasons as the new Hugo version also needs to work with all the old versions of the content. We'd got away with this in recent updates, but it seems now we need to do a lot of work before we can consider upgrading again.