### PR TITLE
Fixes incorrect indentation in v0/test-reachable-paths-0422.yaml.

### DIFF
--- a/test/cases/testdata/v0/reachable/test-reachable-paths-0422.yaml
+++ b/test/cases/testdata/v0/reachable/test-reachable-paths-0422.yaml
@@ -37,19 +37,19 @@ cases:
             - c
   - data: {}
     input_term: '{
-      "graph": {
-        "a": {"b", "c"},
-        "b": {"d"},
-        "c": {"d"},
-        "d": set(),
-        "e": {"f"},
-        "f": {"e"},
-        "x": {"x"},
-      },
-      "initial": {
-        "b", "e"
-      }
-    }'
+        "graph": {
+          "a": {"b", "c"},
+          "b": {"d"},
+          "c": {"d"},
+          "d": set(),
+          "e": {"f"},
+          "f": {"e"},
+          "x": {"x"},
+        },
+        "initial": {
+          "b", "e"
+        }
+      }'
     modules:
       - |
         package reachable
@@ -67,13 +67,13 @@ cases:
             - f
   - data: {}
     input_term: '{
-      "graph": {
-        "a": ["b"],
-        "b": ["c"],
-        "c": ["a"],
-      },
-      "initial": ["a"]
-    }'
+        "graph": {
+          "a": ["b"],
+          "b": ["c"],
+          "c": ["a"],
+        },
+        "initial": ["a"]
+      }'
     modules:
       - |
         package reachable
@@ -90,9 +90,9 @@ cases:
             - c
   - data: {}
     input_term: '{
-      "graph": 1,
-      "initial": [1]
-    }'
+        "graph": 1,
+        "initial": [1]
+      }'
     modules:
       - |
         package reachable
@@ -106,11 +106,11 @@ cases:
     strict_error: true
   - data: {}
     input_term: '{
-      "graph": {
-        "a": null
-      },
-      "initial": ["a"]
-    }'
+        "graph": {
+          "a": null
+        },
+        "initial": ["a"]
+      }'
     modules:
       - |
         package reachable
@@ -125,11 +125,11 @@ cases:
           - - a
   - data: {}
     input_term: '{
-      "graph": {
-        "a": []
-      },
-      "initial": "a"
-    }'
+        "graph": {
+          "a": []
+        },
+        "initial": "a"
+      }'
     modules:
       - |
         package reachable
@@ -143,13 +143,13 @@ cases:
     strict_error: true
   - data: {}
     input_term: '{
-      "graph": {
-        "a": ["b", "c"],
-        "b": ["c"],
-        "c": [],
-      },
-      "initial": {"a"}
-    }'
+        "graph": {
+          "a": ["b", "c"],
+          "b": ["c"],
+          "c": [],
+        },
+        "initial": {"a"}
+      }'
     modules:
       - |
         package reachable
@@ -169,12 +169,12 @@ cases:
 
   - data: {}
     input_term: '{
-      "graph": {
-        "a": ["b"],
-        "b": ["nonexistent"],
-      },
-      "initial": {"a", "b"}
-    }'
+        "graph": {
+          "a": ["b"],
+          "b": ["nonexistent"],
+        },
+        "initial": {"a", "b"}
+      }'
     modules:
       - |
         package reachable


### PR DESCRIPTION
### Why the changes in this PR are needed?

Due to insufficient indentation, this file would be rejected by compliant YAML parsers. This small fix resolves the issue.

### What are the changes in this PR?

Some blocks in this file are indented such that they are YAML compliant.

### Notes to assist PR review:

There are no code changes in this PR, just a whitespace change to a test file.

### Further comments:

If you copy the file as-is into a YAML checker (e.g. https://yamlchecker.com/) it will highlight the issue I've fixed here.
