### PR TITLE
Fix: attach annotation to static part of rule ref

### DIFF
--- a/ast/annotations.go
+++ b/ast/annotations.go
@@ -520,7 +520,7 @@ func attachRuleAnnotations(mod *Module) {
 		var j int
 		var found bool
 		for i, a := range cpy {
-			if rule.Ref().Equal(a.GetTargetPath()) {
+			if rule.Ref().GroundPrefix().Equal(a.GetTargetPath()) {
 				if a.Scope == annotationScopeDocument {
 					rule.Annotations = append(rule.Annotations, a)
 				} else if a.Scope == annotationScopeRule && rule.Loc().Row > a.Location.Row {

--- a/ast/parser_test.go
+++ b/ast/parser_test.go
@@ -5785,6 +5785,23 @@ p contains 2
 				},
 			},
 		},
+		{
+			note: "rule with variable in ref head",
+			module: `package test
+
+# METADATA
+# title: foo
+rule[x] := true if x := 1
+			`,
+			expAnnotations: map[int][]*Annotations{
+				5: {
+					{
+						Scope: "rule",
+						Title: "foo",
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
Previously, annotations were missing on rules that had variable components in the ref head. Now we annotate the rule using the path up to the first var.

Fixes #7050