### PR TITLE
Use new value cache for `json.match_schema`

### DIFF
--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -856,8 +856,9 @@ Caching represents the configuration of the inter-query cache that built-in func
 functions provided by OPA, `http.send` is currently the only one to utilize the inter-query cache. See the documentation
 on the [http.send built-in function](../policy-reference/#http) for information about the available caching options.
 
-It also represents the configuration of the inter-query value cache that built-in functions can utilize. Currently, this
-cache is utilized by the `regex` and `glob` built-in functions for compiled regex and glob match patterns respectively.
+It also represents the configuration of the inter-query _value_ cache that built-in functions can utilize. Currently, 
+this cache is utilized by the `regex` and `glob` built-in functions for compiled regex and glob match patterns
+respectively, and the `json.schema_match` built-in function for compiled JSON schemas.
 
 | Field                                                                    | Type | Required | Description                                                                                                                                                                                         |
 |--------------------------------------------------------------------------| --- | --- |-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|


### PR DESCRIPTION
I figured I'd test this out anyway, and this seemed like a good case given that there was an actual issue on this.

Testing response times with OPA running as a server, and the first request is ~800 ms while the following ones are ~10 ms.

Fixes #7011

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.
  (See the [Developer Certificate of Origin](https://www.openpolicyagent.org/docs/latest/contrib-code/#developer-certificate-of-origin)
  section for specifics on signing off a commit.)

-->

### Why the changes in this PR are needed?

<!--
Include a short description of WHY the changes were made.
-->

### What are the changes in this PR?

<!--
Include a short description of WHAT changes were made.
-->

### Notes to assist PR review:

<!--
Here you can add information you think will help the reviewer(s).
-->

### Further comments:

<!--
Here you can include links to additional resources related to the changes, discuss your solution, other approaches you considered etc.
-->
