### PR TITLE
util+plugins: Fix potential memory leak with explicit timer cancellation.

### DIFF
--- a/download/download.go
+++ b/download/download.go
@@ -246,14 +246,16 @@ func (d *Downloader) loop(ctx context.Context) {
 
 		d.logger.Debug("Waiting %v before next download/retry.", delay)
 
+		timer, timerCancel := util.TimerWithCancel(delay)
 		select {
-		case <-time.After(delay):
+		case <-timer.C:
 			if err != nil {
 				retry++
 			} else {
 				retry = 0
 			}
 		case <-ctx.Done():
+			timerCancel() // explicitly cancel the timer.
 			return
 		}
 	}

--- a/download/oci_download.go
+++ b/download/oci_download.go
@@ -186,14 +186,16 @@ func (d *OCIDownloader) loop(ctx context.Context) {
 
 		d.logger.Debug("OCI - Waiting %v before next download/retry.", delay)
 
+		timer, timerCancel := util.TimerWithCancel(delay)
 		select {
-		case <-time.After(delay):
+		case <-timer.C:
 			if err != nil {
 				retry++
 			} else {
 				retry = 0
 			}
 		case <-ctx.Done():
+			timerCancel() // explicitly cancel the timer.
 			return
 		}
 	}

--- a/internal/wasm/sdk/opa/loader/file/loader.go
+++ b/internal/wasm/sdk/opa/loader/file/loader.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/open-policy-agent/opa/bundle"
 	"github.com/open-policy-agent/opa/internal/wasm/sdk/opa/errors"
+	"github.com/open-policy-agent/opa/util"
 
 	"github.com/open-policy-agent/opa/internal/wasm/sdk/opa"
 )
@@ -156,9 +157,11 @@ func (l *Loader) poller() {
 			l.logError(err)
 		}
 
+		timer, timerCancel := util.TimerWithCancel(l.interval)
 		select {
-		case <-time.After(l.interval):
+		case <-timer.C:
 		case <-l.closing:
+			timerCancel() // explicitly cancel the timer.
 			return
 		}
 	}

--- a/plugins/logs/plugin.go
+++ b/plugins/logs/plugin.go
@@ -802,8 +802,9 @@ func (p *Plugin) loop() {
 
 			waitC = make(chan struct{})
 			go func() {
+				timer, timerCancel := util.TimerWithCancel(delay)
 				select {
-				case <-time.After(delay):
+				case <-timer.C:
 					if err != nil {
 						retry++
 					} else {
@@ -811,6 +812,7 @@ func (p *Plugin) loop() {
 					}
 					close(waitC)
 				case <-ctx.Done():
+					timerCancel() // explicitly cancel the timer.
 				}
 			}()
 		}

--- a/util/time.go
+++ b/util/time.go
@@ -1,0 +1,48 @@
+package util
+
+import "time"
+
+// TimerWithCancel exists because of memory leaks when using
+// time.After in select statements. Instead, we now manually create timers,
+// wait on them, and manually free them.
+//
+// See this for more details:
+// https://www.arangodb.com/2020/09/a-story-of-a-memory-leak-in-go-how-to-properly-use-time-after/
+//
+// Note: This issue is fixed in Go 1.23, but this fix helps us until then.
+//
+// Warning: the cancel cannot be done concurrent to reading, everything should
+// work in the same goroutine.
+//
+// Example:
+//
+//	for retries := 0; true; retries++ {
+//
+//		...main logic...
+//
+//		timer, cancel := utils.TimerWithCancel(utils.Backoff(retries))
+//		select {
+//		case <-ctx.Done():
+//			cancel()
+//			return ctx.Err()
+//		case <-timer.C:
+//			continue
+//		}
+//	}
+func TimerWithCancel(delay time.Duration) (*time.Timer, func()) {
+	timer := time.NewTimer(delay)
+
+	return timer, func() {
+		// Note: The Stop function returns:
+		// - true: if the timer is active. (no draining required)
+		// - false: if the timer was already stopped or fired/expired.
+		// In this case the channel should be drained to prevent memory
+		// leaks only if it is not empty.
+		// This operation is safe only if the cancel function is
+		// used in same goroutine. Concurrent reading or canceling may
+		// cause deadlock.
+		if !timer.Stop() && len(timer.C) > 0 {
+			<-timer.C
+		}
+	}
+}


### PR DESCRIPTION
## What changed?

This commit adds a utility for explicitly creating cancelable timers, to avoid possible memory leaks caused by some `time.After` timers in `select` statements never being GC'd properly. This issue is fixed in Go 1.23, but since we're still on Go 1.21, this will resolve the possibility of leaks in the mean time.

The patch fixes every instance in OPA of `<-time.After(...)` that we have, so this *should* fix the issue until OPA eventually upgrades to Go 1.23 (which [changes the behavior of `time.After`](https://go.dev/doc/go1.23#timer-changes)).

**Note**: One of these instances occurs in `topdown/http.go`, so after this fix is integrated into an OPA release, we may want to poke some OPA memory leak reporters again, especially if they were using `http.send` extensively in their policies.

## Additional Resources

 - [Explanation](https://arangodb.com/2020/09/a-story-of-a-memory-leak-in-go-how-to-properly-use-time-after/) of the `time.After` issue
 - [Go 1.23 release notes (timer change)](https://go.dev/doc/go1.23#timer-changes)