### PR TITLE
server/writer: properly handle result encoding errors

### DIFF
--- a/server/writer/writer.go
+++ b/server/writer/writer.go
@@ -49,8 +49,7 @@ func ErrorString(w http.ResponseWriter, status int, code string, err error) {
 
 // Error writes a response with specified status and error response.
 func Error(w http.ResponseWriter, status int, err *types.ErrorV1) {
-	headers := w.Header()
-	headers.Add("Content-Type", "application/json")
+	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
 	_, _ = w.Write(append(err.Bytes(), byte('\n')))
 }
@@ -66,7 +65,7 @@ func JSON(w http.ResponseWriter, code int, v interface{}, pretty bool) {
 		enc.SetIndent("", "  ")
 	}
 
-	w.Header().Add("Content-Type", "application/json")
+	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(code)
 
 	if err := enc.Encode(v); err != nil {


### PR DESCRIPTION
If the encoding of a result of some sort -- any payload passed to `writer.JSON()` or `writer.JSONOK()` -- failed, we'd emit a log line like 

```
2024/10/11 12:30:21 http: superfluous response.WriteHeader call from github.com/open-policy-agent/opa/runtime.(*recorder).WriteHeader (logging.go:254)
```

and nobody likes these. Also, the encoding error would be the response payload, but the status code had still been 200.

Now, errors encoding the payload properly lead to 500 statuses, without extra logs.

Also headers should be set using Set(), not Add(), to avoid response headers like

```
< HTTP/1.1 500 Internal Server Error
< Content-Type: application/json
< Content-Type: application/json
< Date: Fri, 11 Oct 2024 11:52:22 GMT
< Content-Length: 120
```