### PR TITLE
opa check: only check schema types when user provides schemas

### DIFF
--- a/ast/check.go
+++ b/ast/check.go
@@ -231,7 +231,8 @@ func (tc *typeChecker) checkRule(env *TypeEnv, as *AnnotationSet, rule *Rule) {
 		}
 
 		ref := schemaAnnot.Path
-		if ref == nil && refType == nil {
+		// if we do not have a ref or a reftype, we should not evaluate this rule.
+		if ref == nil || refType == nil {
 			continue
 		}
 


### PR DESCRIPTION
<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.
  (See the [Developer Certificate of Origin](https://www.openpolicyagent.org/docs/latest/contrib-code/#developer-certificate-of-origin)
  section for specifics on signing off a commit.)

-->

### Why the changes in this PR are needed?

`v0.69.0` caused a regression in `opa check` where a file that referenced non-provided schemas now fails validation. This PR fixes the regression and restores the behavior from `v0.68.0`.

<!--
Include a short description of WHY the changes were made.
-->

### What are the changes in this PR?

Resolves https://github.com/open-policy-agent/opa/issues/7116 by only adding the `useTypeCheckAnnotations` option if the user has provided a path to schemas to validate. 

This regression was introduced in https://github.com/open-policy-agent/opa/commit/76f7038ea2d18f7d543950847260e61e6a80faaf. In that commit, the signature of the `processAnnotations` method changed: https://github.com/open-policy-agent/opa/commit/76f7038ea2d18f7d543950847260e61e6a80faaf#diff-d23ff3bfce1aa610d34183f8ccab5ecfd112e19dd9ebca55d69f231a29b62337R227. The annotation's `path` will nearly always exist, causing the checker to attempt to validate it and error because its schema is not found.

An alternate approach would be to return early if the type of the `annotation` is `nil`, similar to how the `path` was handled in `v0.68.0`.

### Notes to assist PR review:

<!--
Here you can add information you think will help the reviewer(s).
-->

### Further comments:

<!--
Here you can include links to additional resources related to the changes, discuss your solution, other approaches you considered etc.
-->
