### PR TITLE
Fix location for multivalue rules with generated bodies

### DIFF
--- a/ast/parser.go
+++ b/ast/parser.go
@@ -780,6 +780,8 @@ func (p *Parser) parseRules() []*Rule {
 	case usesContains:
 		rule.Body = NewBody(NewExpr(BooleanTerm(true).SetLocation(rule.Location)).SetLocation(rule.Location))
 		rule.generatedBody = true
+		rule.Location = rule.Head.Location
+
 		return []*Rule{&rule}
 
 	default:

--- a/ast/parser_test.go
+++ b/ast/parser_test.go
@@ -4112,6 +4112,29 @@ func TestWildcards(t *testing.T) {
 	})
 }
 
+// https://github.com/open-policy-agent/opa/issues/7128
+func TestParseMultiValueRuleGeneratedBodyLocationText(t *testing.T) {
+	t.Parallel()
+
+	mod := `package test
+	
+	import rego.v1
+	
+	foo contains "bar"
+	`
+
+	parsed, err := ParseModule("test.rego", mod)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	text := string(parsed.Rules[0].Location.Text)
+
+	if text != `foo contains "bar"` {
+		t.Errorf("Expected rule location text to be %q but got %q", `foo contains "bar"`, text)
+	}
+}
+
 func TestRuleFromBodyJSONOptions(t *testing.T) {
 	tests := []string{
 		`pi = 3.14159`,


### PR DESCRIPTION
Since there is no body, the location of the head is a better option than simply using the fist scanned token for location.

Fixes #7128