### PR TITLE
:bug: fix: oras cli changed to --config

### DIFF
--- a/docs/content/management-bundles.md
+++ b/docs/content/management-bundles.md
@@ -1309,7 +1309,7 @@ To push the build image to an upstream registry we first need to login using:
 
 And now we can push our policy using:
 ```bash
-oras push ghcr.io/someorg/policy-hello:1.0.0 --manifest-config config.json:application/vnd.oci.image.config.v1+json bundle.tar.gz:application/vnd.oci.image.layer.v1.tar+gzip
+oras push ghcr.io/someorg/policy-hello:1.0.0 --config config.json:application/vnd.oci.image.config.v1+json bundle.tar.gz:application/vnd.oci.image.layer.v1.tar+gzip
 ```
 
 ###### Spin up the policy with OPA CLI


### PR DESCRIPTION
ORAS CLI has changed. Therefore the tutorial breaks as the --manifest-config option is not available in the most recent version of ORAS v1.2

### Why the changes in this PR are needed?

The current tutorial is broken. This changes fixes this.

### What are the changes in this PR?

Docs change to fix the issue with a deprecated argument

