### PR TITLE
enable direct error handling for bundle plugin trigger method

### DIFF
--- a/plugins/bundle/errors.go
+++ b/plugins/bundle/errors.go
@@ -1,0 +1,53 @@
+package bundle
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/open-policy-agent/opa/download"
+)
+
+// Errors represents a list of errors that occurred during a bundle load enriched by the bundle name.
+type Errors []Error
+
+func (e Errors) Unwrap() []error {
+	output := make([]error, len(e))
+	for i := range e {
+		output[i] = e[i]
+	}
+	return output
+}
+func (e Errors) Error() string {
+	err := errors.Join(e.Unwrap()...)
+	return err.Error()
+}
+
+type Error struct {
+	BundleName string
+	Code       string
+	HTTPCode   int
+	Message    string
+	Err        error
+}
+
+func NewBundleError(bundleName string, cause error) Error {
+	var (
+		httpError download.HTTPError
+	)
+	switch {
+	case cause == nil:
+		return Error{BundleName: bundleName, Code: "", HTTPCode: -1, Message: "", Err: nil}
+	case errors.As(cause, &httpError):
+		return Error{BundleName: bundleName, Code: errCode, HTTPCode: httpError.StatusCode, Message: httpError.Error(), Err: cause}
+	default:
+		return Error{BundleName: bundleName, Code: errCode, HTTPCode: -1, Message: cause.Error(), Err: cause}
+	}
+}
+
+func (e Error) Error() string {
+	return fmt.Sprintf("Bundle name: %s, Code: %s, HTTPCode: %d, Message: %s", e.BundleName, errCode, e.HTTPCode, e.Message)
+}
+
+func (e Error) Unwrap() error {
+	return e.Err
+}

--- a/plugins/bundle/errors_test.go
+++ b/plugins/bundle/errors_test.go
@@ -1,0 +1,145 @@
+package bundle
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/download"
+)
+
+func TestErrors(t *testing.T) {
+	errs := Errors{
+		NewBundleError("foo", fmt.Errorf("foo error")),
+		NewBundleError("bar", fmt.Errorf("bar error")),
+	}
+
+	expected := "Bundle name: foo, Code: bundle_error, HTTPCode: -1, Message: foo error\nBundle name: bar, Code: bundle_error, HTTPCode: -1, Message: bar error"
+	result := errs.Error()
+
+	if result != expected {
+		t.Errorf("Expected: %v \nbut got: %v", expected, result)
+	}
+}
+
+func TestUnwrapSlice(t *testing.T) {
+	fooErr := NewBundleError("foo", fmt.Errorf("foo error"))
+	barErr := NewBundleError("bar", fmt.Errorf("bar error"))
+
+	errs := Errors{fooErr, barErr}
+
+	result := errs.Unwrap()
+
+	if result[0].Error() != fooErr.Error() {
+		t.Fatalf("expected %v \nbut got: %v", fooErr, result[0])
+	}
+	if result[1].Error() != barErr.Error() {
+		t.Fatalf("expected %v \nbut got: %v", barErr, result[1])
+	}
+}
+
+func TestUnwrap(t *testing.T) {
+	serverHTTPError := NewBundleError("server", download.HTTPError{StatusCode: 500})
+	clientHTTPError := NewBundleError("client", download.HTTPError{StatusCode: 400})
+	astErrors := ast.Errors{ast.NewError(ast.ParseErr, ast.NewLocation(nil, "foo.rego", 100, 2), "blarg")}
+
+	errs := Errors{serverHTTPError, clientHTTPError, NewBundleError("ast", astErrors)}
+
+	// unwrap first bundle.Error
+	var bundleError Error
+	if !errors.As(errs, &bundleError) {
+		t.Fatal("failed to unwrap Error")
+	}
+	if bundleError.Error() != serverHTTPError.Error() {
+		t.Fatalf("expected: %v \ngot: %v", serverHTTPError, bundleError)
+	}
+
+	// unwrap first HTTPError
+	var httpError download.HTTPError
+	if !errors.As(errs, &httpError) {
+		t.Fatal("failed to unwrap Error")
+	}
+	if httpError.Error() != serverHTTPError.Err.Error() {
+		t.Fatalf("expected: %v \ngot: %v", serverHTTPError.Err, httpError)
+	}
+
+	// unwrap HTTPError from bundle.Error
+	if !errors.As(bundleError, &httpError) {
+		t.Fatal("failed to unwrap HTTPError")
+	}
+	if httpError.Error() != serverHTTPError.Err.Error() {
+		t.Fatalf("expected: %v \nbgot: %v", serverHTTPError.Err, httpError)
+	}
+
+	var unwrappedAstErrors ast.Errors
+	if !errors.As(errs, &unwrappedAstErrors) {
+		t.Fatal("failed to unwrap ast.Errors")
+	}
+	if unwrappedAstErrors.Error() != astErrors.Error() {
+		t.Fatalf("expected: %v \ngot: %v", astErrors, unwrappedAstErrors)
+	}
+}
+
+func TestHTTPErrorWrapping(t *testing.T) {
+	err := download.HTTPError{StatusCode: 500}
+	bundleErr := NewBundleError("foo", err)
+
+	if bundleErr.BundleName != "foo" {
+		t.Fatalf("BundleName: expected: %v \ngot: %v", "foo", bundleErr.BundleName)
+	}
+	if bundleErr.HTTPCode != err.StatusCode {
+		t.Fatalf("HTTPCode: expected: %v \ngot: %v", err.StatusCode, bundleErr.HTTPCode)
+	}
+	if bundleErr.Message != err.Error() {
+		t.Fatalf("Message: expected: %v \ngot: %v", err.Error(), bundleErr.Message)
+	}
+	if bundleErr.Code != errCode {
+		t.Fatalf("Code: expected: %v \ngot: %v", errCode, bundleErr.Code)
+	}
+	if bundleErr.Err != err {
+		t.Fatalf("Err: expected: %v \ngot: %v", err, bundleErr.Err)
+	}
+}
+
+func TestASTErrorsWrapping(t *testing.T) {
+	err := ast.Errors{ast.NewError(ast.ParseErr, ast.NewLocation(nil, "foo.rego", 100, 2), "blarg")}
+	bundleErr := NewBundleError("foo", err)
+
+	if bundleErr.BundleName != "foo" {
+		t.Fatalf("BundleName: expected: %v \ngot: %v", "foo", bundleErr.BundleName)
+	}
+	if bundleErr.HTTPCode != -1 {
+		t.Fatalf("HTTPCode: expected: %v \ngot: %v", -1, bundleErr.HTTPCode)
+	}
+	if bundleErr.Message != err.Error() {
+		t.Fatalf("Message: expected: %v \ngot: %v", err.Error(), bundleErr.Message)
+	}
+	if bundleErr.Code != errCode {
+		t.Fatalf("Code: expected: %v \ngot: %v", errCode, bundleErr.Code)
+	}
+	if bundleErr.Err.Error() != err.Error() {
+		t.Fatalf("Err: expected: %v \ngot: %v", err.Error(), bundleErr.Err.Error())
+	}
+}
+
+func TestGenericErrorWrapping(t *testing.T) {
+	err := fmt.Errorf("foo error")
+	bundleErr := NewBundleError("foo", err)
+
+	if bundleErr.BundleName != "foo" {
+		t.Fatalf("BundleName: expected: %v \ngot: %v", "foo", bundleErr.BundleName)
+	}
+	if bundleErr.HTTPCode != -1 {
+		t.Fatalf("HTTPCode: expected: %v \ngot: %v", -1, bundleErr.HTTPCode)
+	}
+	if bundleErr.Message != err.Error() {
+		t.Fatalf("Message: expected: %v \ngot: %v", err.Error(), bundleErr.Message)
+	}
+	if bundleErr.Code != errCode {
+		t.Fatalf("Code: expected: %v \ngot: %v", errCode, bundleErr.Code)
+	}
+	if bundleErr.Err.Error() != err.Error() {
+		t.Fatalf("Err: expected: %v \ngot: %v", err.Error(), bundleErr.Err.Error())
+	}
+}


### PR DESCRIPTION

### Why the changes in this PR are needed?

When using opa as a library you may want to directly control when and how opa interacts with the bundle registry.
When switching to manual trigger mode and triggering the the bundle plugin directly you may want to react to errors that occurred when downloading the bundles. 
The current capability of using the bundle status requires configuring a listener and wait for it to be triggered which differs from the approach taken f.ex. in the discovery plugin.
By returning the downloader errors directly in the bundle plugin trigger method you can f.ex. check for HTTPError and its status code so to determine if a retry can be successful (status code 5xx) or will yield the same result (4xx).


### What are the changes in this PR?

- creating an error type for the bundle plugin similar to ast.Errors that will collect the different errors and wrap them in a detailed error type carrying the bundle name
- collecting all downloader errors for bundles in **manual** trigger mode. 
- return errors in bundle plugin trigger mode or nil if no errors occurred
- changed the exec_test to also verify the returned errors and not expect zero errors 

### Notes to assist PR review:



### Further comments:

- the different behaviour of the exec method might be undesired but would IMO be helpful
- in case the behaviour change is undesired this functionality could be made configurable
- also the downloader errors for bundles in periodic trigger mode could be returned
