### PR TITLE
fix: returns error with illegal args with unknowns flag (#7127)

### DIFF
--- a/cmd/eval.go
+++ b/cmd/eval.go
@@ -137,7 +137,7 @@ func validateEvalParams(p *evalCommandParams, cmdArgs []string) error {
 		return errors.New("invalid output format for evaluation")
 	}
 
-	//* check if illegal arguments is passed with unknowns flag
+	// check if illegal arguments is passed with unknowns flag
 	for _, unknwn := range p.unknowns {
 		term, err := ast.ParseTerm(unknwn)
 		if err != nil {
@@ -148,7 +148,7 @@ func validateEvalParams(p *evalCommandParams, cmdArgs []string) error {
 		case ast.Ref:
 			return nil
 		default:
-			return errors.New(errIllegalUnknownsArg.Error())
+			return errIllegalUnknownsArg
 		}
 	}
 

--- a/cmd/eval.go
+++ b/cmd/eval.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -139,9 +138,16 @@ func validateEvalParams(p *evalCommandParams, cmdArgs []string) error {
 	}
 
 	//* check if illegal arguments is passed with unknowns flag
-	regexArr := regexp.MustCompile(`^\[.*\]$`)
 	for _, unknwn := range p.unknowns {
-		if regexArr.MatchString(unknwn) {
+		term, err := ast.ParseTerm(unknwn)
+		if err != nil {
+			return err
+		}
+
+		switch term.Value.(type) {
+		case ast.Ref:
+			return nil
+		default:
 			return errors.New(errIllegalUnknownsArg.Error())
 		}
 	}

--- a/cmd/eval.go
+++ b/cmd/eval.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -33,6 +34,10 @@ import (
 	"github.com/open-policy-agent/opa/topdown"
 	"github.com/open-policy-agent/opa/topdown/lineage"
 	"github.com/open-policy-agent/opa/util"
+)
+
+var (
+	illegalUnknownsArg = errors.New("illegal argument with --unknowns, specify string with one or more --unknowns")
 )
 
 type evalCommandParams struct {
@@ -109,6 +114,7 @@ func newEvalCommandParams() evalCommandParams {
 }
 
 func validateEvalParams(p *evalCommandParams, cmdArgs []string) error {
+
 	if len(cmdArgs) > 0 && p.stdin {
 		return errors.New("specify query argument or --stdin but not both")
 	} else if len(cmdArgs) == 0 && !p.stdin {
@@ -130,6 +136,14 @@ func validateEvalParams(p *evalCommandParams, cmdArgs []string) error {
 		return errors.New("invalid output format for partial evaluation")
 	} else if !p.partial && of == evalSourceOutput {
 		return errors.New("invalid output format for evaluation")
+	}
+
+	//* check if illegal arguments is passed with unknowns flag
+	regexArr := regexp.MustCompile(`^\[.*\]$`)
+	for _, unknwn := range p.unknowns {
+		if regexArr.MatchString(unknwn) {
+			return errors.New(illegalUnknownsArg.Error())
+		}
 	}
 
 	if p.optimizationLevel > 0 {

--- a/cmd/eval.go
+++ b/cmd/eval.go
@@ -37,7 +37,7 @@ import (
 )
 
 var (
-	illegalUnknownsArg = errors.New("illegal argument with --unknowns, specify string with one or more --unknowns")
+	errIllegalUnknownsArg = errors.New("illegal argument with --unknowns, specify string with one or more --unknowns")
 )
 
 type evalCommandParams struct {
@@ -142,7 +142,7 @@ func validateEvalParams(p *evalCommandParams, cmdArgs []string) error {
 	regexArr := regexp.MustCompile(`^\[.*\]$`)
 	for _, unknwn := range p.unknowns {
 		if regexArr.MatchString(unknwn) {
-			return errors.New(illegalUnknownsArg.Error())
+			return errors.New(errIllegalUnknownsArg.Error())
 		}
 	}
 

--- a/cmd/eval_test.go
+++ b/cmd/eval_test.go
@@ -37,14 +37,19 @@ func TestEvalWithIllegalUnknownArgs(t *testing.T) {
 		expectedErr error
 	}{
 		{
-			name:        "happy path: passing ref as unknown",
-			unknowns:    "data.posts",
+			name:        "happy path: passing input ref as unknown",
+			unknowns:    "input",
 			expectedErr: nil,
 		},
 		{
-			name:        "passing ; separated values",
-			unknowns:    "input; data.posts",
-			expectedErr: errors.New("expected exactly one term but got: input; data.posts"),
+			name:        "happy path: passing input.users ref as unknown",
+			unknowns:    "input.users",
+			expectedErr: nil,
+		},
+		{
+			name:        "passing multiple refs with ; separated",
+			unknowns:    "input;input.users",
+			expectedErr: errors.New("expected exactly one term but got: input; input.users"),
 		},
 		{
 			name:        "passing array as unknown",

--- a/cmd/eval_test.go
+++ b/cmd/eval_test.go
@@ -36,8 +36,8 @@ func TestEvalWithIllegalUnknownArgs(t *testing.T) {
 
 	err := validateEvalParams(&params, []string{"data"})
 
-	if !strings.EqualFold(err.Error(), illegalUnknownsArg.Error()) {
-		t.Errorf("expected %s; got %s", illegalUnknownsArg.Error(), err.Error())
+	if !strings.EqualFold(err.Error(), errIllegalUnknownsArg.Error()) {
+		t.Errorf("expected %s; got %s", errIllegalUnknownsArg.Error(), err.Error())
 	}
 
 }

--- a/cmd/eval_test.go
+++ b/cmd/eval_test.go
@@ -29,6 +29,19 @@ import (
 	"github.com/open-policy-agent/opa/util/test"
 )
 
+func TestEvalWithIllegalUnknownArgs(t *testing.T) {
+	params := newEvalCommandParams()
+	params.unknowns = []string{"[input, data.posts]"}
+	params.partial = true
+
+	err := validateEvalParams(&params, []string{"data"})
+
+	if !strings.EqualFold(err.Error(), illegalUnknownsArg.Error()) {
+		t.Errorf("expected %s; got %s", illegalUnknownsArg.Error(), err.Error())
+	}
+
+}
+
 func TestEvalExitCode(t *testing.T) {
 	params := newEvalCommandParams()
 	params.fail = true
@@ -764,8 +777,8 @@ func TestEvalWithSchemaFileWithRemoteRef(t *testing.T) {
 		"p.rego": `package p
 import rego.v1
 
-r if { 
-	input.metadata.clusterName == "NAME" 
+r if {
+	input.metadata.clusterName == "NAME"
 }`,
 	}
 
@@ -1296,7 +1309,7 @@ p if {
 	y := 2
 	z := 3
 	x == z - y
-} 
+}
 `,
 			},
 			expected: `%SKIP_LINE%
@@ -1335,7 +1348,7 @@ p if {
 	y := 2
 	z := 3
 	x == z - y
-} 
+}
 `,
 			},
 			expected: `%SKIP_LINE%
@@ -1380,7 +1393,7 @@ p if {
 	x := v
 
 	x.foo[_] == "a"
-} 
+}
 `,
 			},
 			expected: `%SKIP_LINE%


### PR DESCRIPTION
<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.
  (See the [Developer Certificate of Origin](https://www.openpolicyagent.org/docs/latest/contrib-code/#developer-certificate-of-origin)
  section for specifics on signing off a commit.)

-->

### Why the changes in this PR are needed?

- This fixes #7127 when multiple unknowns are passed as array to unknowns flag

### What are the changes in this PR?

- We are doing a regex match for the presence of array in the argument passed to unknowns flag. If it matches with array then we return error.

### Notes to assist PR review:

<!--
Here you can add information you think will help the reviewer(s).
-->

### Further comments:

<!--
Here you can include links to additional resources related to the changes, discuss your solution, other approaches you considered etc.
-->
