### PR TITLE
provide a more useful error message when there are conflicting default rules

### DIFF
--- a/ast/compile.go
+++ b/ast/compile.go
@@ -1056,12 +1056,12 @@ func (c *Compiler) checkRuleConflicts() {
 		}
 
 		kinds := make(map[RuleKind]struct{}, len(node.Values))
-		defaultRules := 0
 		completeRules := 0
 		partialRules := 0
 		arities := make(map[int]struct{}, len(node.Values))
 		name := ""
 		var conflicts []Ref
+		defaultRules := make([]*Rule, 0)
 
 		for _, rule := range node.Values {
 			r := rule.(*Rule)
@@ -1070,7 +1070,7 @@ func (c *Compiler) checkRuleConflicts() {
 			kinds[r.Head.RuleKind()] = struct{}{}
 			arities[len(r.Head.Args)] = struct{}{}
 			if r.Default {
-				defaultRules++
+				defaultRules = append(defaultRules, r)
 			}
 
 			// Single-value rules may not have any other rules in their extent.
@@ -1126,8 +1126,21 @@ func (c *Compiler) checkRuleConflicts() {
 		case len(kinds) > 1 || len(arities) > 1 || (completeRules >= 1 && partialRules >= 1):
 			c.err(NewError(TypeErr, node.Values[0].(*Rule).Loc(), "conflicting rules %v found", name))
 
-		case defaultRules > 1:
-			c.err(NewError(TypeErr, node.Values[0].(*Rule).Loc(), "multiple default rules %s found", name))
+		case len(defaultRules) > 1:
+
+			defaultRuleLocations := strings.Builder{}
+			defaultRuleLocations.WriteString(defaultRules[0].Loc().String())
+			for i := 1; i < len(defaultRules); i++ {
+				defaultRuleLocations.WriteString(", ")
+				defaultRuleLocations.WriteString(defaultRules[i].Loc().String())
+			}
+
+			c.err(NewError(
+				TypeErr,
+				defaultRules[0].Module.Package.Loc(),
+				"multiple default rules %s found at %s",
+				name, defaultRuleLocations.String()),
+			)
 		}
 
 		return false

--- a/ast/compile_test.go
+++ b/ast/compile_test.go
@@ -1977,8 +1977,8 @@ p[r] := 2 if { r := "foo" }`,
 		"rego_type_error: conflicting rules data.badrules.complete_partial.p[r] found",
 		"rego_type_error: conflicting rules data.badrules.p[x] found",
 		"rego_type_error: conflicting rules data.badrules.q found",
-		"rego_type_error: multiple default rules data.badrules.defkw.foo found",
-		"rego_type_error: multiple default rules data.badrules.defkw.p.q.bar found",
+		"rego_type_error: multiple default rules data.badrules.defkw.foo found at mod3.rego:3, mod3.rego:4",
+		"rego_type_error: multiple default rules data.badrules.defkw.p.q.bar found at mod3.rego:7, mod3.rego:8",
 		"rego_type_error: package badrules.s conflicts with rule s defined at mod1.rego:10",
 		"rego_type_error: package badrules.s conflicts with rule s defined at mod1.rego:9",
 		"rego_type_error: package badrules.t conflicts with rule t defined at mod1.rego:11",
@@ -2048,7 +2048,7 @@ func TestCompilerCheckRuleConflictsDotsInRuleHeads(t *testing.T) {
 				`package pkg.p.q
 				default r = 4
 				r = 2`),
-			err: "rego_type_error: multiple default rules data.pkg.p.q.r found",
+			err: "rego_type_error: multiple default rules data.pkg.p.q.r found at mod0.rego:2, mod1.rego:2",
 		},
 		{
 			note: "arity mismatch, ref and ref rule",
@@ -2068,7 +2068,7 @@ func TestCompilerCheckRuleConflictsDotsInRuleHeads(t *testing.T) {
 				`package pkg.p
 				default q.w.r = 4
 				q.w.r = 2`),
-			err: "rego_type_error: multiple default rules data.pkg.p.q.w.r found",
+			err: "rego_type_error: multiple default rules data.pkg.p.q.w.r found at mod0.rego:2, mod1.rego:2",
 		},
 		{
 			note: "multi-value + single-value rules, both with same ref prefix",


### PR DESCRIPTION
<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.
  (See the [Developer Certificate of Origin](https://www.openpolicyagent.org/docs/latest/contrib-code/#developer-certificate-of-origin)
  section for specifics on signing off a commit.)

-->

### Why the changes in this PR are needed?
Resolves https://github.com/open-policy-agent/opa/issues/6897.

When there are multiple default rules in a package, the OPA compiler will error out with an unhelpful error message only providing the location of one default rule. This is confusing for users and can be improved by adding all default rule locations to the error message.

### What are the changes in this PR?

Provide the location of all default rules in the resultant error when there are more than one default rule in the fileset compiled.

### Notes to assist PR review:

<!--
Here you can add information you think will help the reviewer(s).
-->

### Further comments:

<!--
Here you can include links to additional resources related to the changes, discuss your solution, other approaches you considered etc.
-->
