### PR TITLE
eval: don't build trace message when tracing disabled

### DIFF
--- a/topdown/eval.go
+++ b/topdown/eval.go
@@ -1461,20 +1461,23 @@ func (e *eval) getRules(ref ast.Ref, args []*ast.Term) (*ast.IndexResult, error)
 
 	result.EarlyExit = result.EarlyExit && e.earlyExit
 
-	var msg strings.Builder
-	if len(result.Rules) == 1 {
-		msg.WriteString("(matched 1 rule")
-	} else {
-		msg.Grow(len("(matched NNNN rules)"))
-		msg.WriteString("(matched ")
-		msg.WriteString(strconv.Itoa(len(result.Rules)))
-		msg.WriteString(" rules")
+	if e.traceEnabled {
+		var msg strings.Builder
+		if len(result.Rules) == 1 {
+			msg.WriteString("(matched 1 rule")
+		} else {
+			msg.Grow(len("(matched NNNN rules)"))
+			msg.WriteString("(matched ")
+			msg.WriteString(strconv.Itoa(len(result.Rules)))
+			msg.WriteString(" rules")
+		}
+		if result.EarlyExit {
+			msg.WriteString(", early exit")
+		}
+		msg.WriteRune(')')
+		e.traceIndex(e.query[e.index], msg.String(), &ref)
 	}
-	if result.EarlyExit {
-		msg.WriteString(", early exit")
-	}
-	msg.WriteRune(')')
-	e.traceIndex(e.query[e.index], msg.String(), &ref)
+
 	return result, err
 }
 


### PR DESCRIPTION
Running `regal lint` on Regal's own policies, this accounts for ~1.4 million allocations 😵

**Before**
```
BenchmarkRegalLintingItself-10    1	3314104416 ns/op	6720813824 B/op	128361292 allocs/op
```

**After**
```
BenchmarkRegalLintingItself-10    1	3185755333 ns/op	6684952216 B/op	126912887 allocs/op
```