### PR TITLE
Fix improper formatter behavior when comprehension contains comment

### DIFF
--- a/cmd/fmt_test.go
+++ b/cmd/fmt_test.go
@@ -75,6 +75,25 @@ p if {
 }
 `
 
+const ComprehensionCommentShouldNotMoveFormatted = `package test
+
+f(x) := [x |
+	some v in x
+
+	# regal ignore:external-reference
+	x in data.foo
+][0]
+`
+
+const ComprehensionCommentShouldNotMoveUnformatted = `package test
+
+f(x) := [x |
+	some v in x
+	# regal ignore:external-reference
+	x in data.foo
+][0]
+`
+
 type errorWriter struct {
 	ErrMsg string
 }
@@ -102,6 +121,12 @@ func TestFmtFormatFile(t *testing.T) {
 			unformatted: unformattedV1,
 			formatted:   formattedV1,
 		},
+		{
+			note:        "comment in comprehension",
+			params:      fmtCommandParams{v1Compatible: true},
+			unformatted: ComprehensionCommentShouldNotMoveUnformatted,
+			formatted:   ComprehensionCommentShouldNotMoveFormatted,
+		},
 	}
 
 	for _, tc := range cases {
@@ -122,7 +147,7 @@ func TestFmtFormatFile(t *testing.T) {
 
 				actual := stdout.String()
 				if actual != tc.formatted {
-					t.Fatalf("Expected:%s\n\nGot:\n%s\n\n", tc.formatted, actual)
+					t.Fatalf("Expected:\n%s\n\nGot:\n%s\n\n", tc.formatted, actual)
 				}
 			})
 		})


### PR DESCRIPTION
<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.
  (See the [Developer Certificate of Origin](https://www.openpolicyagent.org/docs/latest/contrib-code/#developer-certificate-of-origin)
  section for specifics on signing off a commit.)

-->

### Why the changes in this PR are needed?

Resolves https://github.com/open-policy-agent/opa/issues/6999.

### What are the changes in this PR?

When a comprehension is followed by a index retrieving a value from the comprehension, the OPA AST treats that as a `ref`. `ref`s of this sort may contain comments, but the formatter did not write them inline. Since the formatter did not write them inside the comprehension body, the comments were left over and written at the end of the document.

### Notes to assist PR review:

The `else` handling for the formatter is getting a bit gnarly. Constructing a fake ref for the `else` feels like something that can be handled better, but is not in scope for this PR imo.

### Further comments:

<!--
Here you can include links to additional resources related to the changes, discuss your solution, other approaches you considered etc.
-->
