### PR TITLE
Add the ability to wrap the http.RoundTripper from Go code

### DIFF
--- a/topdown/builtins.go
+++ b/topdown/builtins.go
@@ -52,6 +52,7 @@ type (
 		QueryID                     uint64                     // identifies query being evaluated
 		ParentID                    uint64                     // identifies parent of query being evaluated
 		PrintHook                   print.Hook                 // provides callback function to use for printing
+		RoundTripper                CustomizeRoundTripper      // customize transport to use for HTTP requests
 		DistributedTracingOpts      tracing.Options            // options to be used by distributed tracing.
 		rand                        *rand.Rand                 // randomization source for non-security-sensitive operations
 		Capabilities                *ast.Capabilities

--- a/topdown/eval.go
+++ b/topdown/eval.go
@@ -108,6 +108,7 @@ type eval struct {
 	tracingOpts                 tracing.Options
 	findOne                     bool
 	strictObjects               bool
+	roundTripper                CustomizeRoundTripper
 }
 
 func (e *eval) Run(iter evalIterator) error {
@@ -836,6 +837,7 @@ func (e *eval) evalCall(terms []*ast.Term, iter unifyIterator) error {
 		PrintHook:                   e.printHook,
 		DistributedTracingOpts:      e.tracingOpts,
 		Capabilities:                capabilities,
+		RoundTripper:                e.roundTripper,
 	}
 
 	eval := evalBuiltin{

--- a/topdown/query.go
+++ b/topdown/query.go
@@ -57,6 +57,7 @@ type Query struct {
 	strictBuiltinErrors         bool
 	builtinErrorList            *[]Error
 	strictObjects               bool
+	roundTripper                CustomizeRoundTripper
 	printHook                   print.Hook
 	tracingOpts                 tracing.Options
 	virtualCache                VirtualCache
@@ -276,6 +277,12 @@ func (q *Query) WithBuiltinErrorList(list *[]Error) *Query {
 // WithResolver configures an external resolver to use for the given ref.
 func (q *Query) WithResolver(ref ast.Ref, r resolver.Resolver) *Query {
 	q.external.Put(ref, r)
+	return q
+}
+
+// WithHTTPRoundTripper configures a custom HTTP transport for built-in functions that make HTTP requests.
+func (q *Query) WithHTTPRoundTripper(t CustomizeRoundTripper) *Query {
+	q.roundTripper = t
 	return q
 }
 
@@ -561,6 +568,7 @@ func (q *Query) Iter(ctx context.Context, iter func(QueryResult) error) error {
 		printHook:                   q.printHook,
 		tracingOpts:                 q.tracingOpts,
 		strictObjects:               q.strictObjects,
+		roundTripper:                q.roundTripper,
 	}
 	e.caller = e
 	q.metrics.Timer(metrics.RegoQueryEval).Start()


### PR DESCRIPTION
<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.
  (See the [Developer Certificate of Origin](https://www.openpolicyagent.org/docs/latest/contrib-code/#developer-certificate-of-origin)
  section for specifics on signing off a commit.)

-->

### Why the changes in this PR are needed?

We use Rego (via `topdown`) in [Minder](https://github.com/mindersec/minder), an OpenSSF project.  We'd like to be able to customize the `http.send` for a number of use cases, such as automatically adding service-managed credentials (JWTs represent a specific project in a multi-tenant system, similar to GitHub Actions IDs) to outgoing requests.  To do this, we'd need to inject our own `http.RoundTripper`, while respecting the existing flags and arguments to make it easier to transfer Rego knowledge from one environment to another (and to avoid rewriting the builtin `http.send`, which does a lot of useful stuff).

### What are the changes in this PR?

Adds an `EvalHTTPRoundTrip` EvalOption and query-level `WithHTTPRoundTrip` option.  Both use a new function type which converts an `http.Transport` configured by `topdown` to an `http.RoundTripper`, presumably by wrapping the underlying `http.Transport`.

### Notes to assist PR review:

I ended up needing to adjust some of the tests; in particular, I discovered that `assertTopDownWithPathAndContext` was creating _two_ `query` objects, but only using the supplied `options` for the full-eval version, and not the partial-eval version.  In turn, this caused me to discover some other HTTP tests which were relying on the `Query` objects between the two tests having different options, and fixing them.

### Further comments:

I'm not sure if there's further documentation beyond the Go docs via comments that need to be added; if so, I'm happy to add them.
