### PR TITLE
Respect runtime rego-version in RESTful policy API

### DIFF
--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -259,6 +259,10 @@ func (p *Params) regoVersion() ast.RegoVersion {
 	return ast.DefaultRegoVersion
 }
 
+func (p *Params) parserOptions() ast.ParserOptions {
+	return ast.ParserOptions{RegoVersion: p.regoVersion()}
+}
+
 // LoggingConfig stores the configuration for OPA's logging behaviour.
 type LoggingConfig struct {
 	Level           string
@@ -437,7 +441,7 @@ func NewRuntime(ctx context.Context, params Params) (*Runtime, error) {
 		plugins.WithPrometheusRegister(metrics),
 		plugins.WithTracerProvider(tracerProvider),
 		plugins.WithEnableTelemetry(params.EnableVersionCheck),
-		plugins.WithParserOptions(ast.ParserOptions{RegoVersion: regoVersion}))
+		plugins.WithParserOptions(params.parserOptions()))
 	if err != nil {
 		return nil, fmt.Errorf("config error: %w", err)
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -2161,7 +2161,7 @@ func (s *Server) v1PoliciesPut(w http.ResponseWriter, r *http.Request) {
 	}
 
 	m.Timer(metrics.RegoModuleParse).Start()
-	parsedMod, err := ast.ParseModule(id, string(buf))
+	parsedMod, err := ast.ParseModuleWithOpts(id, string(buf), s.manager.ParserOptions())
 	m.Timer(metrics.RegoModuleParse).Stop()
 
 	if err != nil {
@@ -2391,7 +2391,7 @@ func (s *Server) checkPolicyIDScope(ctx context.Context, txn storage.Transaction
 		return err
 	}
 
-	module, err := ast.ParseModule(id, string(bs))
+	module, err := ast.ParseModuleWithOpts(id, string(bs), s.manager.ParserOptions())
 	if err != nil {
 		return err
 	}
@@ -2523,7 +2523,7 @@ func (s *Server) loadModules(ctx context.Context, txn storage.Transaction) (map[
 			return nil, err
 		}
 
-		parsed, err := ast.ParseModule(id, string(bs))
+		parsed, err := ast.ParseModuleWithOpts(id, string(bs), s.manager.ParserOptions())
 		if err != nil {
 			return nil, err
 		}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -3343,33 +3343,28 @@ r contains x if { z[x] = 4 }`
 	tests := []struct {
 		note        string
 		regoVersion ast.RegoVersion
-		modId       string
 		module      string
 		expErrs     []string
 	}{
 		{
 			note:        "v0 server, v0 module",
 			regoVersion: ast.RegoV0,
-			modId:       "a",
 			module:      v0Module,
 		},
 		{
 			note:        "v0 server, v1 module",
 			regoVersion: ast.RegoV0,
-			modId:       "b",
 			module:      v1Module,
 			expErrs:     []string{"var cannot be used for rule name"},
 		},
 		{
 			note:        "v1 server, v1 module",
 			regoVersion: ast.RegoV1,
-			modId:       "c",
 			module:      v1Module,
 		},
 		{
 			note:        "v1 server, v0 module",
 			regoVersion: ast.RegoV1,
-			modId:       "d",
 			module:      v0Module,
 			expErrs: []string{
 				"`if` keyword is required before rule body",
@@ -3378,12 +3373,12 @@ r contains x if { z[x] = 4 }`
 		},
 	}
 
-	for _, tc := range tests {
+	for i, tc := range tests {
 		t.Run(tc.note, func(t *testing.T) {
 			f := newFixture(t, plugins.WithParserOptions(ast.ParserOptions{
 				RegoVersion: tc.regoVersion,
 			}))
-			req := newReqV1(http.MethodPut, fmt.Sprintf("/policies/%s", tc.modId), tc.module)
+			req := newReqV1(http.MethodPut, fmt.Sprintf("/policies/%d", i), tc.module)
 
 			f.server.Handler.ServeHTTP(f.recorder, req)
 


### PR DESCRIPTION
Updating `/v1/policies` RESTful endpoint to respect the `--v0-compatible`/`--v1-compatible` flags.
