### PR TITLE
Even less allocs

### DIFF
--- a/ast/builtins.go
+++ b/ast/builtins.go
@@ -1404,7 +1404,7 @@ var NumbersRangeStep = &Builtin{
 var UnitsParse = &Builtin{
 	Name: "units.parse",
 	Description: `Converts strings like "10G", "5K", "4M", "1500m", and the like into a number.
-This number can be a non-integer, such as 1.5, 0.22, etc. Scientific notation is supported, 
+This number can be a non-integer, such as 1.5, 0.22, etc. Scientific notation is supported,
 allowing values such as "1e-3K" (1) or "2.5e6M" (2.5 million M).
 
 Supports standard metric decimal and binary SI units (e.g., K, Ki, M, Mi, G, Gi, etc.) where
@@ -1425,11 +1425,11 @@ var UnitsParseBytes = &Builtin{
 	Name: "units.parse_bytes",
 	Description: `Converts strings like "10GB", "5K", "4mb", or "1e6KB" into an integer number of bytes.
 
-Supports standard byte units (e.g., KB, KiB, etc.) where KB, MB, GB, and TB are treated as decimal 
-units, and KiB, MiB, GiB, and TiB are treated as binary units. Scientific notation is supported, 
+Supports standard byte units (e.g., KB, KiB, etc.) where KB, MB, GB, and TB are treated as decimal
+units, and KiB, MiB, GiB, and TiB are treated as binary units. Scientific notation is supported,
 enabling values like "1.5e3MB" (1500MB) or "2e6GiB" (2 million GiB).
 
-The bytes symbol (b/B) in the unit is optional; omitting it will yield the same result (e.g., "Mi" 
+The bytes symbol (b/B) in the unit is optional; omitting it will yield the same result (e.g., "Mi"
 and "MiB" are equivalent).`,
 	Decl: types.NewFunction(
 		types.Args(
@@ -3387,7 +3387,7 @@ func (b *Builtin) Ref() Ref {
 // IsTargetPos returns true if a variable in the i-th position will be bound by
 // evaluating the call expression.
 func (b *Builtin) IsTargetPos(i int) bool {
-	return len(b.Decl.FuncArgs().Args) == i
+	return b.Decl.Arity() == i
 }
 
 func init() {

--- a/ast/map.go
+++ b/ast/map.go
@@ -55,7 +55,7 @@ func (vs *ValueMap) Equal(other *ValueMap) bool {
 		return other == nil || other.Len() == 0
 	}
 	if other == nil {
-		return vs == nil || vs.Len() == 0
+		return vs.Len() == 0
 	}
 	return vs.hashMap.Equal(other.hashMap)
 }

--- a/ast/term.go
+++ b/ast/term.go
@@ -385,6 +385,8 @@ func (term *Term) Equal(other *Term) bool {
 		return v.Equal(other.Value)
 	case Var:
 		return v.Equal(other.Value)
+	case Ref:
+		return v.Equal(other.Value)
 	}
 
 	return term.Value.Compare(other.Value) == 0
@@ -992,7 +994,20 @@ func (ref Ref) Copy() Ref {
 
 // Equal returns true if ref is equal to other.
 func (ref Ref) Equal(other Value) bool {
-	return Compare(ref, other) == 0
+	switch o := other.(type) {
+	case Ref:
+		if len(ref) == len(o) {
+			for i := range ref {
+				if !ref[i].Equal(o[i]) {
+					return false
+				}
+			}
+
+			return true
+		}
+	}
+
+	return false
 }
 
 // Compare compares ref to other, return <0, 0, or >0 if it is less than, equal to,
@@ -1578,12 +1593,8 @@ func (s *set) Intersect(other Set) Set {
 // Union returns the set containing all elements of s and other.
 func (s *set) Union(other Set) Set {
 	r := NewSet()
-	s.Foreach(func(x *Term) {
-		r.Add(x)
-	})
-	other.Foreach(func(x *Term) {
-		r.Add(x)
-	})
+	s.Foreach(r.Add)
+	other.Foreach(r.Add)
 	return r
 }
 

--- a/builtin_metadata.json
+++ b/builtin_metadata.json
@@ -21380,7 +21380,7 @@
       "v0.70.0",
       "edge"
     ],
-    "description": "Converts strings like \"10G\", \"5K\", \"4M\", \"1500m\", and the like into a number.\nThis number can be a non-integer, such as 1.5, 0.22, etc. Scientific notation is supported, \nallowing values such as \"1e-3K\" (1) or \"2.5e6M\" (2.5 million M).\n\nSupports standard metric decimal and binary SI units (e.g., K, Ki, M, Mi, G, Gi, etc.) where\nm, K, M, G, T, P, and E are treated as decimal units and Ki, Mi, Gi, Ti, Pi, and Ei are treated as\nbinary units.\n\nNote that 'm' and 'M' are case-sensitive to allow distinguishing between \"milli\" and \"mega\" units\nrespectively. Other units are case-insensitive.",
+    "description": "Converts strings like \"10G\", \"5K\", \"4M\", \"1500m\", and the like into a number.\nThis number can be a non-integer, such as 1.5, 0.22, etc. Scientific notation is supported,\nallowing values such as \"1e-3K\" (1) or \"2.5e6M\" (2.5 million M).\n\nSupports standard metric decimal and binary SI units (e.g., K, Ki, M, Mi, G, Gi, etc.) where\nm, K, M, G, T, P, and E are treated as decimal units and Ki, Mi, Gi, Ti, Pi, and Ei are treated as\nbinary units.\n\nNote that 'm' and 'M' are case-sensitive to allow distinguishing between \"milli\" and \"mega\" units\nrespectively. Other units are case-insensitive.",
     "introduced": "v0.41.0",
     "result": {
       "description": "the parsed number",
@@ -21508,7 +21508,7 @@
       "v0.70.0",
       "edge"
     ],
-    "description": "Converts strings like \"10GB\", \"5K\", \"4mb\", or \"1e6KB\" into an integer number of bytes.\n\nSupports standard byte units (e.g., KB, KiB, etc.) where KB, MB, GB, and TB are treated as decimal \nunits, and KiB, MiB, GiB, and TiB are treated as binary units. Scientific notation is supported, \nenabling values like \"1.5e3MB\" (1500MB) or \"2e6GiB\" (2 million GiB).\n\nThe bytes symbol (b/B) in the unit is optional; omitting it will yield the same result (e.g., \"Mi\" \nand \"MiB\" are equivalent).",
+    "description": "Converts strings like \"10GB\", \"5K\", \"4mb\", or \"1e6KB\" into an integer number of bytes.\n\nSupports standard byte units (e.g., KB, KiB, etc.) where KB, MB, GB, and TB are treated as decimal\nunits, and KiB, MiB, GiB, and TiB are treated as binary units. Scientific notation is supported,\nenabling values like \"1.5e3MB\" (1500MB) or \"2e6GiB\" (2 million GiB).\n\nThe bytes symbol (b/B) in the unit is optional; omitting it will yield the same result (e.g., \"Mi\"\nand \"MiB\" are equivalent).",
     "introduced": "v0.17.0",
     "result": {
       "description": "the parsed number",

--- a/format/format.go
+++ b/format/format.go
@@ -758,7 +758,7 @@ func (w *writer) writeFunctionCall(expr *ast.Expr, comments []*ast.Comment) []*a
 		return w.writeFunctionCallPlain(terms, comments)
 	}
 
-	numDeclArgs := len(bi.Decl.Args())
+	numDeclArgs := bi.Decl.Arity()
 	numCallArgs := len(terms) - 1
 
 	switch numCallArgs {
@@ -918,7 +918,7 @@ func (w *writer) writeCall(parens bool, x ast.Call, loc *ast.Location, comments 
 	// NOTE(Trolloldem): writeCall is only invoked when the function call is a term
 	// of another function. The only valid arity is the one of the
 	// built-in function
-	if len(bi.Decl.Args()) != len(x)-1 {
+	if bi.Decl.Arity() != len(x)-1 {
 		w.errs = append(w.errs, ArityFormatMismatchError(x[1:], x[0].String(), loc, bi.Decl))
 		return comments
 	}
@@ -935,10 +935,10 @@ func (w *writer) writeCall(parens bool, x ast.Call, loc *ast.Location, comments 
 
 func (w *writer) writeInOperator(parens bool, operands []*ast.Term, comments []*ast.Comment, loc *ast.Location, f *types.Function) []*ast.Comment {
 
-	if len(operands) != len(f.Args()) {
+	if len(operands) != f.Arity() {
 		// The number of operands does not math the arity of the `in` operator
 		operator := ast.Member.Name
-		if len(f.Args()) == 3 {
+		if f.Arity() == 3 {
 			operator = ast.MemberWithKey.Name
 		}
 		w.errs = append(w.errs, ArityFormatMismatchError(operands, operator, loc, f))
@@ -1603,9 +1603,9 @@ type ArityFormatErrDetail struct {
 
 // arityMismatchError but for `fmt` checks since the compiler has not run yet.
 func ArityFormatMismatchError(operands []*ast.Term, operator string, loc *ast.Location, f *types.Function) *ast.Error {
-	want := make([]string, len(f.Args()))
-	for i := range f.Args() {
-		want[i] = types.Sprint(f.Args()[i])
+	want := make([]string, f.Arity())
+	for i, arg := range f.Args() {
+		want[i] = types.Sprint(arg)
 	}
 
 	have := make([]string, len(operands))

--- a/internal/edittree/edittree.go
+++ b/internal/edittree/edittree.go
@@ -727,7 +727,7 @@ func (e *EditTree) Unfold(path ast.Ref) (*EditTree, error) {
 		// Extend the tree if key is present. Error otherwise.
 		if v, err := x.Find(ast.Ref{ast.InternedIntNumberTerm(idx)}); err == nil {
 			// TODO: Consider a more efficient "Replace" function that special-cases this for arrays instead?
-			_, err := e.Delete(ast.IntNumberTerm(idx))
+			_, err := e.Delete(ast.InternedIntNumberTerm(idx))
 			if err != nil {
 				return nil, err
 			}

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -1037,7 +1037,7 @@ func (p *Planner) planExprCall(e *ast.Expr, iter planiter) error {
 			args = p.defaultOperands()
 		} else if decl, ok := p.decls[operator]; ok {
 			relation = decl.Relation
-			arity = len(decl.Decl.Args())
+			arity = decl.Decl.Arity()
 			void = decl.Decl.Result() == nil
 			name = operator
 			p.externs[operator] = decl

--- a/internal/strvals/parser.go
+++ b/internal/strvals/parser.go
@@ -31,7 +31,7 @@ var ErrNotList = errors.New("not a list")
 
 // MaxIndex is the maximum index that will be allowed by setIndex.
 // The default value 65536 = 1024 * 64
-var MaxIndex = 65536
+const MaxIndex = 65536
 
 // ToYAML takes a string of arguments and converts to a YAML document.
 func ToYAML(s string) (string, error) {

--- a/rego/rego.go
+++ b/rego/rego.go
@@ -809,7 +809,7 @@ func memoize(decl *Function, bctx BuiltinContext, terms []*ast.Term, ifEmpty fun
 	// The term slice _may_ include an output term depending on how the caller
 	// referred to the built-in function. Only use the arguments as the cache
 	// key. Unification ensures we don't get false positive matches.
-	for i := 0; i < len(decl.Decl.Args()); i++ {
+	for i := 0; i < decl.Decl.Arity(); i++ {
 		if _, err := b.WriteString(terms[i].String()); err != nil {
 			return nil, err
 		}

--- a/topdown/graphql.go
+++ b/topdown/graphql.go
@@ -174,7 +174,7 @@ func pruneIrrelevantGraphQLASTNodes(value ast.Value) ast.Value {
 			case ast.Object:
 				// Safe, because we knew the type before going to prune it.
 				vo := pruneIrrelevantGraphQLASTNodes(v).(ast.Object)
-				if len(vo.Keys()) > 0 {
+				if vo.Len() > 0 {
 					result = result.Append(ast.NewTerm(vo))
 				}
 			default:
@@ -209,7 +209,7 @@ func pruneIrrelevantGraphQLASTNodes(value ast.Value) ast.Value {
 			case ast.Object:
 				// Safe, because we knew the type before going to prune it.
 				vo := pruneIrrelevantGraphQLASTNodes(v).(ast.Object)
-				if len(vo.Keys()) > 0 {
+				if vo.Len() > 0 {
 					result.Insert(k, ast.NewTerm(vo))
 				}
 			default:

--- a/topdown/object.go
+++ b/topdown/object.go
@@ -144,9 +144,7 @@ func builtinObjectKeys(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Te
 		return err
 	}
 
-	keys := ast.SetTerm(object.Keys()...)
-
-	return iter(keys)
+	return iter(ast.SetTerm(object.Keys()...))
 }
 
 // getObjectKeysParam returns a set of key values

--- a/types/types.go
+++ b/types/types.go
@@ -675,7 +675,7 @@ func Arity(x Type) int {
 	if !ok {
 		return 0
 	}
-	return len(f.FuncArgs().Args)
+	return f.Arity()
 }
 
 // NewFunction returns a new Function object of the given argument and result types.
@@ -721,6 +721,11 @@ func (t *Function) Args() []Type {
 		cpy[i] = unwrap(t.args[i])
 	}
 	return cpy
+}
+
+// Arity returns the number of arguments in the function signature.
+func (t *Function) Arity() int {
+	return len(t.args)
 }
 
 // Result returns the function's result type.
@@ -780,14 +785,15 @@ func (t *Function) Union(other *Function) *Function {
 		return other
 	}
 
-	a := t.Args()
-	b := other.Args()
-	if len(a) != len(b) {
+	if t.Arity() != other.Arity() {
 		return nil
 	}
 
-	aIsVariadic := t.FuncArgs().Variadic != nil
-	bIsVariadic := other.FuncArgs().Variadic != nil
+	tfa := t.FuncArgs()
+	ofa := other.FuncArgs()
+
+	aIsVariadic := tfa.Variadic != nil
+	bIsVariadic := ofa.Variadic != nil
 
 	if aIsVariadic && !bIsVariadic {
 		return nil
@@ -795,13 +801,16 @@ func (t *Function) Union(other *Function) *Function {
 		return nil
 	}
 
+	a := t.Args()
+	b := other.Args()
+
 	args := make([]Type, len(a))
 	for i := range a {
 		args[i] = Or(a[i], b[i])
 	}
 
 	result := NewFunction(args, Or(t.Result(), other.Result()))
-	result.variadic = Or(t.FuncArgs().Variadic, other.FuncArgs().Variadic)
+	result.variadic = Or(tfa.Variadic, ofa.Variadic)
 
 	return result
 }


### PR DESCRIPTION
**main**
```
BenchmarkLintAllEnabled-10    1	2640715625 ns/op	6385110200 B/op	116296633 allocs/op
```

**pr**
```
BenchmarkLintAllEnabled-10    1	2597179708 ns/op	6183614112 B/op	108421141 allocs/op
```

(I renamed the benchmark, but this is the same as "regal linting itself" used in the past)

Another 8 million allocations cut off from `regal lint bundle`, and a whopping 10% improvements to wall clock time!

The most significant improvement is the Equal implementation for refs, since that is called all over the place. But there are many other fixes here, and they all contribute something substantial (and fixes that only have had marginal impact have been left out).
