### PR TITLE
Avoid copying loop vars (Go 1.22+)

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -29,4 +29,5 @@ linters:
     - gosimple
     - prealloc
     - unconvert
+    - copyloopvar
     # - gosec # too many false positives

--- a/cmd/bench_test.go
+++ b/cmd/bench_test.go
@@ -859,7 +859,6 @@ a[4] {
 
 	for _, mode := range modes {
 		for _, tc := range tests {
-			tc := tc // Reassignment prevents loop var scoping issue. (See: https://go.dev/blog/loopvar-preview)
 			t.Run(fmt.Sprintf("%s, %s", tc.note, mode.name), func(t *testing.T) {
 				t.Parallel()
 
@@ -1023,7 +1022,6 @@ a contains 4 if {
 	for _, bundleType := range bundleTypeCases {
 		for _, mode := range modes {
 			for _, tc := range tests {
-				tc := tc // Reassignment prevents loop var scoping issue. (See: https://go.dev/blog/loopvar-preview)
 				t.Run(fmt.Sprintf("%s, %s, %s", bundleType.note, tc.note, mode.name), func(t *testing.T) {
 					t.Parallel()
 

--- a/cmd/eval.go
+++ b/cmd/eval.go
@@ -499,7 +499,6 @@ func evalOnce(ctx context.Context, ectx *evalContext) pr.Output {
 	result.Errors = pr.NewOutputErrors(resultErr)
 	if ectx.builtInErrorList != nil {
 		for _, err := range *(ectx.builtInErrorList) {
-			err := err
 			result.Errors = append(result.Errors, pr.NewOutputErrors(&err)...)
 		}
 	}

--- a/debug/debugger.go
+++ b/debug/debugger.go
@@ -413,7 +413,6 @@ func (s *session) start() error {
 	defer s.mtx.Unlock()
 
 	for _, t := range s.threads {
-		t := t
 		go func() {
 			s.d.logger.Debug("Thread %d started", t.id)
 			s.d.sendEvent(Event{Type: ThreadEventType, Thread: t.id, Message: "started"})

--- a/storage/disk/config_test.go
+++ b/storage/disk/config_test.go
@@ -225,7 +225,6 @@ func TestBadgerConfigFromOptions(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc // copy for capturing loop variable (not needed in Go 1.22+)
 		t.Run(tc.note, func(t *testing.T) {
 			t.Parallel()
 

--- a/storage/disk/disk_test.go
+++ b/storage/disk/disk_test.go
@@ -1144,7 +1144,6 @@ func TestDataPartitioningReadsAndWrites(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc // copy for capturing loop variable (not needed in Go 1.22+)
 		t.Run(tc.note, func(t *testing.T) {
 			t.Parallel()
 
@@ -1301,7 +1300,6 @@ func TestDataPartitioningReadNotFoundErrors(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc // copy for capturing loop variable (not needed in Go 1.22+)
 		t.Run(tc.note, func(t *testing.T) {
 			t.Parallel()
 
@@ -1458,7 +1456,6 @@ func TestDataPartitioningWriteNotFoundErrors(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc // copy for capturing loop variable (not needed in Go 1.22+)
 		t.Run(tc.note, func(t *testing.T) {
 			t.Parallel()
 
@@ -1507,7 +1504,6 @@ func TestDataPartitioningWriteInvalidPatchError(t *testing.T) {
 	t.Parallel()
 
 	for _, pt := range []string{"/*", "/foo"} {
-		pt := pt // copy for capturing loop variable (not needed in Go 1.22+)
 		t.Run(pt, func(t *testing.T) {
 			t.Parallel()
 
@@ -1672,7 +1668,6 @@ func TestLookup(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc // copy for capturing loop variable (not needed in Go 1.22+)
 		t.Run(tc.note, func(t *testing.T) {
 			t.Parallel()
 

--- a/storage/disk/partition_test.go
+++ b/storage/disk/partition_test.go
@@ -105,7 +105,6 @@ func TestPartitionTrie(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc // copy for capturing loop variable (not needed in Go 1.22+)
 		t.Run(strings.TrimPrefix(tc.path, "/"), func(t *testing.T) {
 			t.Parallel()
 

--- a/storage/disk/paths_test.go
+++ b/storage/disk/paths_test.go
@@ -51,7 +51,6 @@ func TestIsDisjoint(t *testing.T) {
 			overlapped: true,
 		},
 	} {
-		tc := tc // copy for capturing loop variable (not needed in Go 1.22+)
 		t.Run(tc.note, func(t *testing.T) {
 			t.Parallel()
 

--- a/topdown/crypto_test.go
+++ b/topdown/crypto_test.go
@@ -667,7 +667,6 @@ xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 		},
 	}
 	for name, testData := range tests {
-		testData := testData // copy for capturing loop variable (not needed in Go 1.22+)
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -829,9 +828,9 @@ func TestExtractX509VerifyOptions(t *testing.T) {
 			},
 		},
 		{ // KeyUsages as an array
-			jsonOption: ast.MustParseTerm(`{"DNSName": "test.com", "CurrentTime": 1708447636000000000, 
-				"MaxConstraintComparisons": 5, 				
-				"KeyUsages" : ["KeyUsageAny", "KeyUsageAny", 1, 2,   
+			jsonOption: ast.MustParseTerm(`{"DNSName": "test.com", "CurrentTime": 1708447636000000000,
+				"MaxConstraintComparisons": 5,
+				"KeyUsages" : ["KeyUsageAny", "KeyUsageAny", 1, 2,
 				"KeyUsageServerAuth","KeyUsageClientAuth"]}`),
 			expectVerifyOpt: x509.VerifyOptions{
 				DNSName:                   "test.com",

--- a/topdown/errors_test.go
+++ b/topdown/errors_test.go
@@ -106,7 +106,6 @@ func TestErrorWrapping(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc // copy for capturing loop variable (not needed in Go 1.22+)
 		t.Run(tc.note, func(t *testing.T) {
 			t.Parallel()
 

--- a/topdown/eval_test.go
+++ b/topdown/eval_test.go
@@ -116,7 +116,6 @@ func TestMergeWhenHittingNonObject(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc // copy for capturing loop variable (not needed in Go 1.22+)
 		t.Run(tc.note, func(t *testing.T) {
 			t.Parallel()
 
@@ -172,7 +171,6 @@ func TestRefContainsNonScalar(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc // copy for capturing loop variable (not needed in Go 1.22+)
 		t.Run(tc.note, func(t *testing.T) {
 			t.Parallel()
 
@@ -252,7 +250,6 @@ func TestContainsNestedRefOrCall(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc // copy for capturing loop variable (not needed in Go 1.22+)
 		t.Run(tc.note, func(t *testing.T) {
 			t.Parallel()
 
@@ -586,13 +583,13 @@ func TestTopdownVirtualCache(t *testing.T) {
 		{
 			note: "partial object, ref-head, ref with unification scope",
 			module: `package test
-			
+
 			a[x][y][z] := x + y + z if {
 				some x in [1, 2]
 				some y in [3, 4]
 				some z in [5, 6]
 			}
-			
+
 			p if {
 				x := a[1][_][5]   # miss, cache key: data.test.a[1][<_,5>]
 				some foo
@@ -606,14 +603,14 @@ func TestTopdownVirtualCache(t *testing.T) {
 		{
 			note: "partial object, ref-head, ref with unification scope, component order",
 			module: `package test
-			
+
 			a[x][y][a][b] := i if {
 				some x in [1, 2]
 				some y in [3, 4]
 				some a in ["foo", "bar"]
 				some i, b in ["foo", "bar"]
 			}
-			
+
 			p if {
 				x := a[1][_]["foo"]["bar"] # miss, cache key: data.test.a[1][<_,foo,bar>]
 				y := a[1][_]["bar"]["foo"] # miss, cache key: data.test.a[1][<_,bar,foo>]
@@ -626,13 +623,13 @@ func TestTopdownVirtualCache(t *testing.T) {
 		{
 			note: "partial object, ref-head, ref with unification scope, diverging key scope",
 			module: `package test
-			
+
 			a[x][y][z] := x + y + z if {
 				some x in [1, 2]
 				some y in [3, 4]
 				some z in [5, 6]
 			}
-			
+
 			p if {
 				x := a[1][_][5] # miss, cache key: data.test.a[1][<_,5>]
 				y := a[1][_][6] # miss, cache key: data.test.a[1][<_,6>]
@@ -647,13 +644,13 @@ func TestTopdownVirtualCache(t *testing.T) {
 		{
 			note: "partial object, ref-head, ref with unification scope, trailing vars don't contribute to key scope",
 			module: `package test
-				
+
 				a[x][y][z][x] := x + y + z if {
 					some x in [1, 2]
 					some y in [3, 4]
 					some z in [5, 6]
 				}
-				
+
 				p if {
 					x := a[1][_][5][_] # miss, cache key: data.test.a[1][<_,5>]
 					y := a[1][_][5]    # hit, cache key: data.test.a[1][<_,5>]
@@ -667,11 +664,11 @@ func TestTopdownVirtualCache(t *testing.T) {
 			// Regression test for https://github.com/open-policy-agent/opa/issues/6926
 			note: "partial object, ref-head, leaf set, ref with unification scope",
 			module: `package p
-				
+
 				obj.sub[x][x] contains x if some x in ["one", "two"]
-				
+
 				obj[x][x] contains x if x := "whatever"
-				
+
 				main contains x if {
 					[1 | obj.sub[_].one[_]] # miss, cache key: data.p.obj.sub[<_,one>]
 					x := obj.sub[_][_][_]   # miss, cache key: data.p.obj.sub
@@ -683,7 +680,6 @@ func TestTopdownVirtualCache(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc // copy for capturing loop variable (not needed in Go 1.22+)
 		t.Run(tc.note, func(t *testing.T) {
 			t.Parallel()
 
@@ -988,9 +984,9 @@ func TestPartialRule(t *testing.T) {
 			`,
 			query: `data = x`,
 			exp: `[{"x": {"test": {"p": {"foo": {
-						"0": {"bar": "a"}, 
-						"1": {"bar": "b"}, 
-						"2": {"bar": "c"}, 
+						"0": {"bar": "a"},
+						"1": {"bar": "b"},
+						"2": {"bar": "c"},
 						"bar": {"0": "a", "1": "b", "2": "c"}}}}}}]`,
 		},
 		// Intersections with object values
@@ -1131,8 +1127,8 @@ func TestPartialRule(t *testing.T) {
 		{
 			note: "deep query into partial object (ref head) and object value",
 			module: `package test
-				p.q[r] := x if { 
-					r := "foo" 
+				p.q[r] := x if {
+					r := "foo"
 					x := {"bar": {"baz": 1}}
 				}
 			`,
@@ -1258,7 +1254,7 @@ func TestPartialRule(t *testing.T) {
 		{ // enumeration
 			note: "deep query into partial object and object value, full depth, enumeration on object value",
 			module: `package test
-				p.q[r] := x if { 
+				p.q[r] := x if {
 					r := ["foo", "bar"][_]
 					x := {"s": {"do": 0, "re": 1, "mi": 2}}
 				}
@@ -1269,7 +1265,7 @@ func TestPartialRule(t *testing.T) {
 		{ // enumeration
 			note: "deep query into partial object and object value, full depth, enumeration on rule path and object value",
 			module: `package test
-				p.q[r] := x if { 
+				p.q[r] := x if {
 					r := ["foo", "bar"][_]
 					x := {"s": {"do": 0, "re": 1, "mi": 2}}
 				}
@@ -1292,8 +1288,8 @@ func TestPartialRule(t *testing.T) {
 			note: "deep query into partial object (general ref head) and set value",
 			module: `package test
 				import future.keywords
-				p.q[r] contains t if { 
-					r := ["foo", "bar"][_] 
+				p.q[r] contains t if {
+					r := ["foo", "bar"][_]
 					{"do", "re", "mi"}[t]
 				}
 			`,
@@ -1304,8 +1300,8 @@ func TestPartialRule(t *testing.T) {
 			note: "deep query into partial object (general ref head, static tail) and set value",
 			module: `package test
 				import future.keywords
-				p.q[r].s contains t if { 
-					r := ["foo", "bar"][_] 
+				p.q[r].s contains t if {
+					r := ["foo", "bar"][_]
 					{"do", "re", "mi"}[t]
 				}
 			`,
@@ -1316,8 +1312,8 @@ func TestPartialRule(t *testing.T) {
 			note: "deep query into general ref to set value",
 			module: `package test
 				import future.keywords
-				p.q[r].s contains t if { 
-					r := ["foo", "bar"][_] 
+				p.q[r].s contains t if {
+					r := ["foo", "bar"][_]
 					t := ["do", "re", "mi"][_]
 				}
 			`,
@@ -1327,8 +1323,8 @@ func TestPartialRule(t *testing.T) {
 		{
 			note: "deep query into general ref to object value",
 			module: `package test
-				p.q[r].s[t] := u if { 
-					r := ["foo", "bar"][_] 
+				p.q[r].s[t] := u if {
+					r := ["foo", "bar"][_]
 					t := ["do", "re", "mi"][u]
 				}
 			`,
@@ -1339,8 +1335,8 @@ func TestPartialRule(t *testing.T) {
 			note: "deep query into general ref enumerating set values",
 			module: `package test
 				import future.keywords
-				p.q[r].s contains t if { 
-					r := ["foo", "bar"][_] 
+				p.q[r].s contains t if {
+					r := ["foo", "bar"][_]
 					{"do", "re", "mi"}[t]
 				}
 			`,
@@ -1351,8 +1347,8 @@ func TestPartialRule(t *testing.T) {
 		{
 			note: "deep query into partial object and object value, non-tail var",
 			module: `package test
-				p.q[r].s := x if { 
-					r := "foo" 
+				p.q[r].s := x if {
+					r := "foo"
 					x := {"bar": {"baz": 1}}
 				}
 			`,
@@ -1470,7 +1466,7 @@ func TestPartialRule(t *testing.T) {
 					t := ["d", "e", "f"][u]
 				}`,
 			query: `data.test.p.q[x] = y`,
-			exp: `[{"x": "a", "y": {"s": {"d": 0, "e": 1, "f": 2}}}, 
+			exp: `[{"x": "a", "y": {"s": {"d": 0, "e": 1, "f": 2}}},
 					{"x": "b", "y": {"s": {"d": 0, "e": 1, "f": 2}}},
 					{"x": "c", "y": {"s": {"d": 0, "e": 1, "f": 2}}}]`,
 		},
@@ -1535,7 +1531,6 @@ func TestPartialRule(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc // copy for capturing loop variable (not needed in Go 1.22+)
 		t.Run(tc.note, func(t *testing.T) {
 			t.Parallel()
 

--- a/topdown/exported_test.go
+++ b/topdown/exported_test.go
@@ -23,7 +23,6 @@ func TestRego(t *testing.T) {
 	t.Parallel()
 
 	for _, tc := range cases.MustLoad("../test/cases/testdata/v0").Sorted().Cases {
-		tc := tc // copy for capturing loop variable (not needed in Go 1.22+)
 		t.Run(fmt.Sprintf("v0/%s", tc.Note), func(t *testing.T) {
 			t.Parallel()
 
@@ -31,7 +30,6 @@ func TestRego(t *testing.T) {
 		})
 	}
 	for _, tc := range cases.MustLoad("../test/cases/testdata/v1").Sorted().Cases {
-		tc := tc // copy for capturing loop variable (not needed in Go 1.22+)
 		t.Run(fmt.Sprintf("v1/%s", tc.Note), func(t *testing.T) {
 			t.Parallel()
 
@@ -44,7 +42,6 @@ func TestOPARego(t *testing.T) {
 	t.Parallel()
 
 	for _, tc := range cases.MustLoad("testdata/cases").Sorted().Cases {
-		tc := tc // copy for capturing loop variable (not needed in Go 1.22+)
 		t.Run(tc.Note, func(t *testing.T) {
 			t.Parallel()
 
@@ -57,7 +54,6 @@ func TestRegoWithNDBCache(t *testing.T) {
 	t.Parallel()
 
 	for _, tc := range cases.MustLoad("../test/cases/testdata/v0").Sorted().Cases {
-		tc := tc // copy for capturing loop variable (not needed in Go 1.22+)
 		t.Run(fmt.Sprintf("v0/%s", tc.Note), func(t *testing.T) {
 			t.Parallel()
 
@@ -67,7 +63,6 @@ func TestRegoWithNDBCache(t *testing.T) {
 		})
 	}
 	for _, tc := range cases.MustLoad("../test/cases/testdata/v1").Sorted().Cases {
-		tc := tc // copy for capturing loop variable (not needed in Go 1.22+)
 		t.Run(fmt.Sprintf("v1/%s", tc.Note), func(t *testing.T) {
 			t.Parallel()
 

--- a/topdown/http_test.go
+++ b/topdown/http_test.go
@@ -707,7 +707,6 @@ func TestParseTimeout(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc // copy for capturing loop variable (not needed in Go 1.22+)
 		t.Run(tc.note, func(t *testing.T) {
 			t.Parallel()
 
@@ -959,7 +958,6 @@ func TestHTTPSendRaiseError(t *testing.T) {
 	data := loadSmallTestData()
 
 	for _, tc := range tests {
-		tc := tc // copy for capturing loop variable (not needed in Go 1.22+)
 		t.Run(tc.note, func(t *testing.T) {
 			t.Parallel()
 
@@ -1135,7 +1133,6 @@ func TestHTTPSendCaching(t *testing.T) {
 	data := loadSmallTestData()
 
 	for _, tc := range tests {
-		tc := tc // copy for capturing loop variable (not needed in Go 1.22+)
 		t.Run(tc.note, func(t *testing.T) {
 			t.Parallel()
 
@@ -1239,7 +1236,6 @@ func TestHTTPSendIntraQueryCaching(t *testing.T) {
 	t0 := time.Now()
 
 	for _, tc := range tests {
-		tc := tc // copy for capturing loop variable (not needed in Go 1.22+)
 		t.Run(tc.note, func(t *testing.T) {
 			t.Parallel()
 
@@ -1400,7 +1396,6 @@ func TestHTTPSendInterQueryCaching(t *testing.T) {
 	t0 := time.Now()
 
 	for _, tc := range tests {
-		tc := tc // copy for capturing loop variable (not needed in Go 1.22+)
 		t.Run(tc.note, func(t *testing.T) {
 			t.Parallel()
 
@@ -1570,7 +1565,6 @@ func TestHTTPSendInterQueryForceCaching(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc // copy for capturing loop variable (not needed in Go 1.22+)
 		t.Run(tc.note, func(t *testing.T) {
 			t.Parallel()
 
@@ -1657,7 +1651,6 @@ func TestHTTPSendInterQueryForceCachingRefresh(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc // copy for capturing loop variable (not needed in Go 1.22+)
 		t.Run(tc.note, func(t *testing.T) {
 			t.Parallel()
 
@@ -1808,7 +1801,6 @@ func TestHTTPSendInterQueryCachingModifiedResp(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc // copy for capturing loop variable (not needed in Go 1.22+)
 		t.Run(tc.note, func(t *testing.T) {
 			t.Parallel()
 
@@ -1887,7 +1879,6 @@ func TestHTTPSendInterQueryCachingNewResp(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc // copy for capturing loop variable (not needed in Go 1.22+)
 		t.Run(tc.note, func(t *testing.T) {
 			t.Parallel()
 
@@ -1985,7 +1976,6 @@ func TestInsertIntoHTTPSendInterQueryCacheError(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc // copy for capturing loop variable (not needed in Go 1.22+)
 		t0 := time.Now().UTC()
 
 		t.Run(tc.note, func(t *testing.T) {
@@ -2074,7 +2064,6 @@ func TestGetCachingMode(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc // copy for capturing loop variable (not needed in Go 1.22+)
 		t.Run(tc.note, func(t *testing.T) {
 			t.Parallel()
 
@@ -2162,7 +2151,6 @@ func TestParseMaxAgeCacheDirective(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc // copy for capturing loop variable (not needed in Go 1.22+)
 		t.Run(tc.note, func(t *testing.T) {
 			t.Parallel()
 
@@ -2229,7 +2217,6 @@ func TestNewForceCacheParams(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc // copy for capturing loop variable (not needed in Go 1.22+)
 		t.Run(tc.note, func(t *testing.T) {
 			t.Parallel()
 
@@ -2299,7 +2286,6 @@ func TestGetBoolValFromReqObj(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc // copy for capturing loop variable (not needed in Go 1.22+)
 		t.Run(tc.note, func(t *testing.T) {
 			t.Parallel()
 
@@ -3342,21 +3328,21 @@ func TestIntraQueryCache_ClientError(t *testing.T) {
 	}{
 		{
 			note: "raised errors",
-			rules: []string{`p["one"] { 
-	not http.send({"method": "GET", "url": "%URL%", "timeout": "10ms"}) 
+			rules: []string{`p["one"] {
+	not http.send({"method": "GET", "url": "%URL%", "timeout": "10ms"})
 }`,
-				`p["two"] { 
+				`p["two"] {
 	not http.send({"method": "GET", "url": "%URL%", "timeout": "10ms"})
 }`},
 			expected: `["one", "two"]`,
 		},
 		{
 			note: "no raised errors",
-			rules: []string{`p["one"] { 
-	r := http.send({"method": "GET", "url": "%URL%", "timeout": "10ms", "raise_error": false}) 
+			rules: []string{`p["one"] {
+	r := http.send({"method": "GET", "url": "%URL%", "timeout": "10ms", "raise_error": false})
 	r.error.code == "eval_http_send_network_error"
 }`,
-				`p["two"] { 
+				`p["two"] {
 	r := http.send({"method": "GET", "url": "%URL%", "timeout": "10ms", "raise_error": false})
 	r.error.code == "eval_http_send_network_error"
 }`},
@@ -3365,7 +3351,6 @@ func TestIntraQueryCache_ClientError(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc // copy for capturing loop variable (not needed in Go 1.22+)
 		t.Run(tc.note, func(t *testing.T) {
 			t.Parallel()
 
@@ -3409,21 +3394,21 @@ func TestInterQueryCache_ClientError(t *testing.T) {
 	}{
 		{
 			note: "raised errors",
-			rules: []string{`p["one"] { 
-	not http.send({"method": "GET", "url": "%URL%", "timeout": "10ms", "cache": true}) 
+			rules: []string{`p["one"] {
+	not http.send({"method": "GET", "url": "%URL%", "timeout": "10ms", "cache": true})
 }`,
-				`p["two"] { 
+				`p["two"] {
 	not http.send({"method": "GET", "url": "%URL%", "timeout": "10ms", "cache": true})
 }`},
 			expected: `["one", "two"]`,
 		},
 		{
 			note: "no raised errors",
-			rules: []string{`p["one"] { 
-	r := http.send({"method": "GET", "url": "%URL%", "timeout": "10ms", "cache": true, "raise_error": false}) 
+			rules: []string{`p["one"] {
+	r := http.send({"method": "GET", "url": "%URL%", "timeout": "10ms", "cache": true, "raise_error": false})
 	r.error.code == "eval_http_send_network_error"
 }`,
-				`p["two"] { 
+				`p["two"] {
 	r := http.send({"method": "GET", "url": "%URL%", "timeout": "10ms", "cache": true, "raise_error": false})
 	r.error.code == "eval_http_send_network_error"
 }`},
@@ -3432,7 +3417,6 @@ func TestInterQueryCache_ClientError(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc // copy for capturing loop variable (not needed in Go 1.22+)
 		t.Run(tc.note, func(t *testing.T) {
 			t.Parallel()
 

--- a/topdown/input_test.go
+++ b/topdown/input_test.go
@@ -84,8 +84,6 @@ func TestMergeTermWithValues(t *testing.T) {
 	}
 
 	for i, tc := range tests {
-		i := i
-		tc := tc // copy for capturing loop variable (not needed in Go 1.22+)
 		t.Run(tc.note, func(t *testing.T) {
 			t.Parallel()
 

--- a/topdown/json_test.go
+++ b/topdown/json_test.go
@@ -96,7 +96,6 @@ func TestFiltersToObject(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc // copy for capturing loop variable (not needed in Go 1.22+)
 		t.Run(tc.note, func(t *testing.T) {
 			t.Parallel()
 

--- a/topdown/jsonschema_test.go
+++ b/topdown/jsonschema_test.go
@@ -73,7 +73,6 @@ func TestAstValueToJSONSchemaLoader(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc // copy for capturing loop variable (not needed in Go 1.22+)
 		t.Run(tc.note, func(t *testing.T) {
 			t.Parallel()
 
@@ -144,7 +143,6 @@ func TestBuiltinJSONSchemaVerify(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc // copy for capturing loop variable (not needed in Go 1.22+)
 		t.Run(tc.note, func(t *testing.T) {
 			t.Parallel()
 
@@ -262,7 +260,6 @@ func TestBuiltinJSONMatchSchema(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc // copy for capturing loop variable (not needed in Go 1.22+)
 		t.Run(tc.note, func(t *testing.T) {
 			t.Parallel()
 

--- a/topdown/lineage/lineage_test.go
+++ b/topdown/lineage/lineage_test.go
@@ -106,7 +106,7 @@ Redo data.test.p = x
 			note: "disjunction (iteration)",
 			module: `package test
 			import rego.v1
-			
+
 			q contains 1
 			q contains 2
 			p if { q[x]; trace(sprintf("x=%d", [x])) }`,
@@ -173,7 +173,6 @@ Enter data.test.p = x
 	}
 
 	for _, tc := range tests {
-		tc := tc // copy for capturing loop variable (not needed in Go 1.22+)
 		t.Run(tc.note, func(t *testing.T) {
 			t.Parallel()
 

--- a/topdown/print_test.go
+++ b/topdown/print_test.go
@@ -107,7 +107,6 @@ func TestTopDownPrint(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc // copy for capturing loop variable (not needed in Go 1.22+)
 		t.Run(tc.note, func(t *testing.T) {
 			t.Parallel()
 

--- a/topdown/query_test.go
+++ b/topdown/query_test.go
@@ -67,7 +67,6 @@ func TestQueryTracerDontPlugLocalVars(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc // copy for capturing loop variable (not needed in Go 1.22+)
 		t.Run(tc.note, func(t *testing.T) {
 			t.Parallel()
 
@@ -207,7 +206,6 @@ func TestRegoMetadataBuiltinCall(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc // copy for capturing loop variable (not needed in Go 1.22+)
 		t.Run(tc.note, func(t *testing.T) {
 			t.Parallel()
 
@@ -267,16 +265,16 @@ func initTracerTestQuery() *Query {
 
 	compiler := compileModules([]string{
 		`package x
-	
+
 	p if {
 		a := [1, 2, 3]
 		f(a[_])
 	}
-	
+
 	f(x) if {
 		x == 3
 	}
-	
+
 	`})
 
 	return NewQuery(ast.MustParseBody("data.x.p")).

--- a/topdown/regex_template_test.go
+++ b/topdown/regex_template_test.go
@@ -25,7 +25,6 @@ func TestRegexCompiler(t *testing.T) {
 		{"urn:foo.bar.com:{.*{}", '{', '}', true, "", true},
 		{"urn:foo:<.*>", '<', '>', false, "urn:foo:bar:baz", false},
 	} {
-		tc := tc // copy for capturing loop variable (not needed in Go 1.22+)
 		t.Run(fmt.Sprintf("template=%s", tc.template), func(t *testing.T) {
 			t.Parallel()
 

--- a/topdown/tokens_test.go
+++ b/topdown/tokens_test.go
@@ -635,7 +635,6 @@ func TestTopdownJWTVerifyOnlyVerifiesUsingApplicableKeys(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc // copy for capturing loop variable (not needed in Go 1.22+)
 		t.Run(tc.note, func(t *testing.T) {
 			t.Parallel()
 

--- a/topdown/topdown_test.go
+++ b/topdown/topdown_test.go
@@ -272,7 +272,6 @@ func TestTopDownQueryCancellationEvery(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc // copy for capturing loop variable (not needed in Go 1.22+)
 		t.Run(tc.note, func(t *testing.T) {
 			t.Parallel()
 
@@ -431,7 +430,7 @@ func TestTopDownEarlyExit(t *testing.T) {
 				package test
 				p if { q }
 
-				q contains x if { 
+				q contains x if {
 					x := [1, 2, 3][_]; trace("a")
 				}`,
 			notes: n("a", "a", "a"),
@@ -440,12 +439,12 @@ func TestTopDownEarlyExit(t *testing.T) {
 			note: "complete doc, iteration: other partial doc that cannot exit early",
 			module: `
 				package test
-				p if { 
-					data.arr[_] = x; trace("x") 
-					q 
+				p if {
+					data.arr[_] = x; trace("x")
+					q
 				}
 
-				q contains x if { 
+				q contains x if {
 					x := [1, 2, 3][_]; trace("a")
 				}`,
 			notes: n("x", "a", "a", "a"),
@@ -458,11 +457,11 @@ func TestTopDownEarlyExit(t *testing.T) {
 					data.arr[_] = x; trace("x")
 					q
 				}
-		
+
 				q contains x if {
 					x := [1, 2, 3][_]; trace("a")
 				}
-		
+
 				q contains x if {
 					x := [4, 5, 6][_]; trace("b")
 				}`,
@@ -558,8 +557,8 @@ func TestTopDownEarlyExit(t *testing.T) {
 			note: "complete doc, multiple array iteration",
 			module: `
 				package test
-				p if { 
-					data.arr[_] = x; trace("x") 
+				p if {
+					data.arr[_] = x; trace("x")
 					data.arr[_] = y; trace("y")
 					data.arr[_] = z; trace("z")
 				}
@@ -571,12 +570,12 @@ func TestTopDownEarlyExit(t *testing.T) {
 			module: `
 				package test
 				p if {
-					data.arr[_] = x; trace("x") 
+					data.arr[_] = x; trace("x")
 					data.arr[_] = y; trace("y")
 					q; trace("q")
 				}
 
-				q if { 
+				q if {
 					data.arr[_] = a; trace("a")
 					data.arr[_] = b; trace("b")
 				}
@@ -589,18 +588,18 @@ func TestTopDownEarlyExit(t *testing.T) {
 			module: `
 				package test
 				p if {
-					data.arr[_] = x; trace("x") 
+					data.arr[_] = x; trace("x")
 					data.arr[_] = y; trace("y")
 					q; trace("q")
 				}
 
-				q if { 
+				q if {
 					data.arr[_] = a; trace("a")
 					data.arr[_] = b; trace("b")
 				}
 
 				# Not called because of EE
-				q if { 
+				q if {
 					data.arr[_] = a; trace("c")
 					data.arr[_] = b; trace("d")
 				}
@@ -613,13 +612,13 @@ func TestTopDownEarlyExit(t *testing.T) {
 			module: `
 				package test
 				p if {
-					data.arr[_] = x; trace("x") 
+					data.arr[_] = x; trace("x")
 					data.arr[_] = y; trace("y")
 					q; trace("q1")
 					q; trace("q2") # result of q in cache
 				}
 
-				q if { 
+				q if {
 					data.arr[_] = a; trace("a")
 					data.arr[_] = b; trace("b")
 				}
@@ -632,19 +631,19 @@ func TestTopDownEarlyExit(t *testing.T) {
 			module: `
 				package test
 				p if {
-					data.arr[_] = x; trace("x") 
+					data.arr[_] = x; trace("x")
 					data.arr[_] = y; trace("y")
 					q; trace("q1")
 					q; trace("q2") # result of q in cache
 				}
 
-				q if { 
+				q if {
 					data.arr[_] = a; trace("a")
 					data.arr[_] = b; trace("b")
 				}
 
 				# Not called because of EE
-				q if { 
+				q if {
 					data.arr[_] = a; trace("c")
 					data.arr[_] = b; trace("d")
 				}
@@ -657,18 +656,18 @@ func TestTopDownEarlyExit(t *testing.T) {
 			module: `
 				package test
 				p if {
-					data.arr[_] = x; trace("x") 
+					data.arr[_] = x; trace("x")
 					data.arr[_] = y; trace("y")
 					q; trace("q")
 					r; trace("r")
 				}
 
-				q if { 
+				q if {
 					data.arr[_] = a; trace("a")
 					data.arr[_] = b; trace("b")
 				}
 
-				r if { 
+				r if {
 					data.arr[_] = c; trace("c")
 					data.arr[_] = d; trace("d")
 				}
@@ -681,7 +680,7 @@ func TestTopDownEarlyExit(t *testing.T) {
 			module: `
 				package test
 				arr := ["a", "b", "c"]
-				p if { 
+				p if {
 					arr[_] = x; trace("x")
 				}
 			`,
@@ -693,8 +692,8 @@ func TestTopDownEarlyExit(t *testing.T) {
 			module: `
 				package test
 				arr := ["a", "b", "c"]
-				p if { 
-					arr[_] = x; trace("x") 
+				p if {
+					arr[_] = x; trace("x")
 					arr[_] = y; trace("y") # arr in cache
 				}
 			`,
@@ -753,11 +752,11 @@ func TestTopDownEarlyExit(t *testing.T) {
 			note: "complete doc, array iteration, func call with early exit",
 			module: `
 				package test
-				p if { 
+				p if {
 					data.arr[_] = x; trace("x")
 					f(1) == 1
 				}
-				
+
 				f(x) := 1 if {
 					trace("a")
 				}
@@ -769,15 +768,15 @@ func TestTopDownEarlyExit(t *testing.T) {
 			note: "complete doc, multiple array iterations, func call multiple early exit",
 			module: `
 				package test
-				p if { 
+				p if {
 					data.arr[_] = x; trace("x")
 					f(1) == 1
 				}
-				
+
 				f(x) := 1 if {
 					trace("a")
 				}
-				
+
 				f(x) := 1 if {
 					trace("b")
 				}
@@ -789,15 +788,15 @@ func TestTopDownEarlyExit(t *testing.T) {
 			note: "complete doc, multiple array iterations, func call without early exit",
 			module: `
 				package test
-				p if { 
+				p if {
 					data.arr[_] = x; trace("x")
 					f(1) == 1
 				}
-				
+
 				f(x) := 1 if {
 					trace("a")
 				}
-				
+
 				f(x) := 1 if {
 					trace("b")
 				}
@@ -813,11 +812,11 @@ func TestTopDownEarlyExit(t *testing.T) {
 			note: "complete doc, multiple array iterations, func call with early exit and iteration",
 			module: `
 				package test
-				p if { 
+				p if {
 					data.arr[_] = x; trace("x")
 					f(1) == 1
 				}
-				
+
 				f(x) := 1 if {
 					data.arr[_] = a; trace("a")
 				}
@@ -829,11 +828,11 @@ func TestTopDownEarlyExit(t *testing.T) {
 			note: "complete doc, array iteration, func call without early exit, static arg",
 			module: `
 				package test
-				p if { 
+				p if {
 					data.arr[_] = x; trace("x")
 					f(1) == 1
 				}
-				
+
 				f(x) := x if {
 					trace("a")
 				}
@@ -844,11 +843,11 @@ func TestTopDownEarlyExit(t *testing.T) {
 			note: "complete doc, array iteration -> func call without early exit, dynamic arg",
 			module: `
 				package test
-				p if { 
+				p if {
 					data.arr[_] = x; trace("x")
 					f(x) == x
 				}
-				
+
 				f(x) := x if {
 					trace("a")
 				}
@@ -861,11 +860,11 @@ func TestTopDownEarlyExit(t *testing.T) {
 				package test
 				s := { 1, 2, 3 }
 
-				p if { 
+				p if {
 					s[_] = x; trace("x")
 					f(x) == x
 				}
-				
+
 				f(x) := x if {
 					trace("a")
 				}
@@ -883,11 +882,11 @@ func TestTopDownEarlyExit(t *testing.T) {
 					"c": 3,
 				}
 
-				p if { 
+				p if {
 					o[_] = x; trace("x")
 					f(x) == x
 				}
-				
+
 				f(x) := x if {
 					trace("a")
 				}
@@ -899,13 +898,13 @@ func TestTopDownEarlyExit(t *testing.T) {
 			note: "complete doc, array iteration -> func call without early exit, array iteration, dynamic arg",
 			module: `
 				package test
-				p if { 
+				p if {
 					arr[_] = x; trace("x")
 					f(x) == x
 				}
 
 				arr := [1, 2, 3, 4, 2]
-				
+
 				f(x) := x if {
 					arr[_] = y; trace("a")
 					y == 2; trace("b") # y will have exactly two matches, so we expect two "b" notes, and an exhaustive number of "a" notes
@@ -921,7 +920,7 @@ func TestTopDownEarlyExit(t *testing.T) {
 
 				s := { 1, 2, 3, 4, 5 }
 
-				p if { 
+				p if {
 					s[_] = x; trace("x")
 					f(x) == x
 				}
@@ -939,14 +938,14 @@ func TestTopDownEarlyExit(t *testing.T) {
 			module: `
 				package test
 
-				o := { 
+				o := {
 					"a": 1,
 					"b": 2,
 					"c": 3,
 					"d": 2,
 				}
 
-				p if { 
+				p if {
 					o[_] = x; trace("x")
 					f(x) == x
 				}
@@ -963,13 +962,13 @@ func TestTopDownEarlyExit(t *testing.T) {
 			note: "complete doc, array iteration -> func call without early exit, virtual doc array iteration, dynamic arg",
 			module: `
 				package test
-				p if { 
+				p if {
 					data.arr[_] = x; trace("x")
 					f(x) == x
 				}
 
 arr := [1, 2, 3, 4, 5]
-				
+
 				f(x) := x if {
 					arr[_] = y; trace("a")
 					y == 3; trace("b")
@@ -982,11 +981,11 @@ arr := [1, 2, 3, 4, 5]
 			note: "complete doc, array iteration -> func (multi) call without early exit, static arg",
 			module: `
 				package test
-				p if { 
+				p if {
 					data.arr[_] = x; trace("x")
 					f(1) == 1
 				}
-				
+
 				f(x) := x if {
 					trace("a")
 				}
@@ -1151,9 +1150,9 @@ arr := [1, 2, 3, 4, 5]
 				import future.keywords
 				p if {
 					data.arr[_] = x; trace("x")
-					every x in [1, 2, 3] { 
+					every x in [1, 2, 3] {
 						data.arr[_] = y; trace("a")
-						x; trace("b") 
+						x; trace("b")
 					}
 				}
 			`,
@@ -1166,7 +1165,7 @@ arr := [1, 2, 3, 4, 5]
 				import future.keywords
 				p if {
 					data.arr_small[_] = x; trace("x")
-					every x in [1, 2, 3] { 
+					every x in [1, 2, 3] {
 						data.arr_small[_] = y; trace("e1")
 						x
 						q; trace("e2")
@@ -1192,7 +1191,7 @@ arr := [1, 2, 3, 4, 5]
 				import future.keywords
 				p if {
 					data.arr[_] = x; trace("x")
-					every x in [1, 2, 3] { 
+					every x in [1, 2, 3] {
 						data.arr_small[_] = y; trace("e1")
 						x
 						q; trace("e2")
@@ -1222,11 +1221,11 @@ arr := [1, 2, 3, 4, 5]
 				}
 
 				arr := [1, 2]
-		
+
 				q := x if {
 					x := 1
 					arr[_] = y; trace("a")
-					every v in [1, 2, 3] { 
+					every v in [1, 2, 3] {
 						v; trace("b") # we expect 3*len(arr)==6 "b" notes
 					}
 				}
@@ -1244,15 +1243,15 @@ arr := [1, 2, 3, 4, 5]
 				}
 
 				arr := [1, 2]
-		
+
 				q := x if {
 					x := 1
 					arr[_] = y; trace("a")
-					every v in [1, 2, 3] { 
+					every v in [1, 2, 3] {
 						v; r; trace("b") # we expect 3*len(arr)==6 "b" notes
 					}
 				}
-	
+
 				r if {
 					data.arr[_] = x; trace("c")
 				}
@@ -1269,7 +1268,7 @@ arr := [1, 2, 3, 4, 5]
 					data.arr[_] = x; trace("p1")
 					y := [v | v = data.arr[_]; q]; trace("p2")
 				}
-		
+
 				q if {
 					data.arr[_] = x; trace("q")
 				}
@@ -1285,7 +1284,7 @@ arr := [1, 2, 3, 4, 5]
 					data.arr[_] = x; trace("p1")
 					y := [v | v = data.arr[_]; q]; trace("p2")
 				}
-		
+
 				q if {
 					data.arr[_] = x; trace("q")
 					r
@@ -1308,7 +1307,7 @@ arr := [1, 2, 3, 4, 5]
 					data.arr[_] = x; trace("p1")
 					y := {v | v = data.arr[_]; q}; trace("p2")
 				}
-		
+
 				q if {
 					data.arr[_] = x; trace("q")
 				}
@@ -1324,7 +1323,7 @@ arr := [1, 2, 3, 4, 5]
 					data.arr[_] = x; trace("p1")
 					y := {v | v = data.arr[_]; q}; trace("p2")
 				}
-		
+
 				q if {
 					data.arr[_] = x; trace("q")
 					r
@@ -1347,7 +1346,7 @@ arr := [1, 2, 3, 4, 5]
 					data.arr[_] = x; trace("p1")
 					y := {k: v | v = data.arr[k]; q}; trace("p2")
 				}
-		
+
 				q if {
 					data.arr[_] = x; trace("q")
 				}
@@ -1363,7 +1362,7 @@ arr := [1, 2, 3, 4, 5]
 					data.arr[_] = x; trace("p1")
 					y := {k: v | v = data.arr[k]; q}; trace("p2")
 				}
-		
+
 				q if {
 					data.arr[_] = x; trace("q")
 					r
@@ -1465,7 +1464,7 @@ arr := [1, 2, 3, 4, 5]
 					data.arr[_] = x; trace("p1")
 					not q; trace("p2")
 				}
-		
+
 				q := false if {
 					data.arr[_] = x; trace("q")
 				}
@@ -1481,7 +1480,7 @@ arr := [1, 2, 3, 4, 5]
 					data.arr[_] = x; trace("p1")
 					not q; trace("p2")
 				}
-		
+
 				q := x if {
 					x := false
 					data.arr_small[_] = y; trace("q")
@@ -1497,7 +1496,7 @@ arr := [1, 2, 3, 4, 5]
 					data.arr[_] = x; trace("p1")
 					not q; trace("p2")
 				}
-		
+
 				q if {
 					data.arr_small[_] = x; trace("q")
 					false
@@ -1507,7 +1506,6 @@ arr := [1, 2, 3, 4, 5]
 		},
 	}
 	for _, tc := range tests {
-		tc := tc // copy for capturing loop variable (not needed in Go 1.22+)
 		t.Run(tc.note, func(t *testing.T) {
 			t.Parallel()
 
@@ -1680,7 +1678,6 @@ func TestTopDownEvery(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		tc := tc // copy for capturing loop variable (not needed in Go 1.22+)
 		t.Run(tc.note, func(t *testing.T) {
 			t.Parallel()
 

--- a/topdown/trace_test.go
+++ b/topdown/trace_test.go
@@ -762,7 +762,6 @@ func TestTraceRewrittenVars(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc // copy for capturing loop variable (not needed in Go 1.22+)
 		t.Run(tc.note, func(t *testing.T) {
 			t.Parallel()
 
@@ -1029,7 +1028,6 @@ func TestShortTraceFileNames(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc // copy for capturing loop variable (not needed in Go 1.22+)
 		t.Run(tc.note, func(t *testing.T) {
 			t.Parallel()
 


### PR DESCRIPTION
This isn't needed anymore, so now we don't. Also enabled the copyloopvar linter in case we accidentally do this in the future.