### PR TITLE
opa build: provide an option to preserve print statements (#7194)

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -47,6 +47,7 @@ type buildParams struct {
 	v0Compatible       bool
 	v1Compatible       bool
 	followSymlinks     bool
+	enablePrints       bool
 }
 
 func newBuildParams() buildParams {
@@ -241,6 +242,7 @@ against OPA v0.22.0:
 	buildCommand.Flags().StringVarP(&buildParams.outputFile, "output", "o", "bundle.tar.gz", "set the output filename")
 	buildCommand.Flags().StringVar(&buildParams.ns, "partial-namespace", "partial", "set the namespace to use for partially evaluated files in an optimized bundle")
 	buildCommand.Flags().BoolVar(&buildParams.followSymlinks, "follow-symlinks", false, "follow symlinks in the input set of paths when building the bundle")
+	buildCommand.Flags().BoolVar(&buildParams.enablePrints, "enable-print-statements", false, "enable print statements inside of modules compiled by the compiler")
 
 	addBundleModeFlag(buildCommand.Flags(), &buildParams.bundleMode, false)
 	addIgnoreFlag(buildCommand.Flags(), &buildParams.ignore)
@@ -307,7 +309,8 @@ func dobuild(params buildParams, args []string) error {
 		WithBundleVerificationConfig(bvc).
 		WithBundleSigningConfig(bsc).
 		WithPartialNamespace(params.ns).
-		WithFollowSymlinks(params.followSymlinks)
+		WithFollowSymlinks(params.followSymlinks).
+		WithEnablePrintStatements(params.enablePrints)
 
 	regoVersion := ast.DefaultRegoVersion
 	if params.v0Compatible {

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -47,7 +47,7 @@ type buildParams struct {
 	v0Compatible       bool
 	v1Compatible       bool
 	followSymlinks     bool
-	enablePrints       bool
+	wasmIncludePrint   bool
 }
 
 func newBuildParams() buildParams {
@@ -242,7 +242,7 @@ against OPA v0.22.0:
 	buildCommand.Flags().StringVarP(&buildParams.outputFile, "output", "o", "bundle.tar.gz", "set the output filename")
 	buildCommand.Flags().StringVar(&buildParams.ns, "partial-namespace", "partial", "set the namespace to use for partially evaluated files in an optimized bundle")
 	buildCommand.Flags().BoolVar(&buildParams.followSymlinks, "follow-symlinks", false, "follow symlinks in the input set of paths when building the bundle")
-	buildCommand.Flags().BoolVar(&buildParams.enablePrints, "enable-print-statements", false, "enable print statements inside of modules compiled by the compiler")
+	buildCommand.Flags().BoolVar(&buildParams.wasmIncludePrint, "wasm-include-print", false, "enable print statements inside of WebAssembly modules compiled by the compiler")
 
 	addBundleModeFlag(buildCommand.Flags(), &buildParams.bundleMode, false)
 	addIgnoreFlag(buildCommand.Flags(), &buildParams.ignore)
@@ -309,8 +309,7 @@ func dobuild(params buildParams, args []string) error {
 		WithBundleVerificationConfig(bvc).
 		WithBundleSigningConfig(bsc).
 		WithPartialNamespace(params.ns).
-		WithFollowSymlinks(params.followSymlinks).
-		WithEnablePrintStatements(params.enablePrints)
+		WithFollowSymlinks(params.followSymlinks)
 
 	regoVersion := ast.DefaultRegoVersion
 	if params.v0Compatible {
@@ -335,6 +334,10 @@ func dobuild(params buildParams, args []string) error {
 
 	if params.target.String() == compile.TargetPlan {
 		compiler = compiler.WithEnablePrintStatements(true)
+	}
+
+	if params.target.String() == compile.TargetWasm {
+		compiler = compiler.WithEnablePrintStatements(params.wasmIncludePrint)
 	}
 
 	err = compiler.Build(context.Background())


### PR DESCRIPTION
<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.
  (See the [Developer Certificate of Origin](https://www.openpolicyagent.org/docs/latest/contrib-code/#developer-certificate-of-origin)
  section for specifics on signing off a commit.)

-->

### Why the changes in this PR are needed?

PR adds an option for `opa build` to preserve print statements (#7194)

### What are the changes in this PR?

New argument `--enable-print-statements` added

### Notes to assist PR review:

N/A

### Further comments:

N/A