### PR TITLE
feat: handle Infinite and Infinity strings in number parsing #7200

### DIFF
--- a/test/cases/infinity_test.rego
+++ b/test/cases/infinity_test.rego
@@ -1,0 +1,35 @@
+package infinity_test
+
+test_infinity {
+    # Test Infinity string
+    inf1 := to_number("Infinity")
+    inf1 > 1e308  # Larger than max float64
+    
+    # Test Infinite string
+    inf2 := to_number("Infinite")
+    inf2 > 1e308  # Larger than max float64
+    
+    # Test that regular numbers still work
+    to_number("123") == 123
+    to_number("123.456") == 123.456
+    
+    # Test that invalid strings still return errors
+    not to_number("not a number")
+    not to_number("InfinityX")
+    not to_number("Infinit")  # Missing 'e' or 'y'
+}
+
+test_infinity_operations {
+    # Test arithmetic operations with infinity
+    inf := to_number("Infinity")
+    
+    # Infinity should be greater than any finite number
+    inf > 1e308
+    inf > 1e100
+    
+    # Infinity should equal itself
+    inf == inf
+    
+    # Test that infinity from both strings produces equal values
+    to_number("Infinite") == to_number("Infinity")
+}

--- a/topdown/casts.go
+++ b/topdown/casts.go
@@ -23,7 +23,12 @@ func builtinToNumber(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term
 	case ast.Number:
 		return iter(ast.NewTerm(a))
 	case ast.String:
-		_, err := strconv.ParseFloat(string(a), 64)
+		// Handle special cases first
+		str := string(a)
+		if str == "Infinite" || str == "Infinity" {
+			return iter(ast.NewTerm(ast.Number("1e999"))) // A very large number to represent infinity
+		}
+		_, err := strconv.ParseFloat(str, 64)
 		if err != nil {
 			return err
 		}

--- a/wasm/src/conversions.c
+++ b/wasm/src/conversions.c
@@ -20,10 +20,17 @@ opa_value *opa_to_number(opa_value *v)
     {
         opa_string_t *a = opa_cast_string(v);
         double n;
-        // NOTE: we're only using opa_atof64 for validation here
-        if (opa_atof64(a->v, a->len, &n) != 0)
+        // Check for special values and convert them using opa_atof64
+        int result = opa_atof64(a->v, a->len, &n);
+        if (result != 0)
         {
             return NULL;
+        }
+
+        // If it's a special value (Infinity), create a number with that value
+        if (isinf(n))
+        {
+            return opa_number_float(n);
         }
 
         return opa_number_ref(a->v, a->len);

--- a/wasm/src/str.c
+++ b/wasm/src/str.c
@@ -1,5 +1,6 @@
 #include "string.h"
 #include "limits.h"
+#include "math.h"
 
 size_t opa_strlen(const char *s)
 {
@@ -188,6 +189,18 @@ int opa_atof64(const char *str, int len, double *result)
     if (len <= 0)
     {
         return -1;
+    }
+
+    // Check for special values
+    if (len == 8 && opa_strncmp(str, "Infinite", 8) == 0)
+    {
+        *result = INFINITY;
+        return 0;
+    }
+    if (len == 8 && opa_strncmp(str, "Infinity", 8) == 0)
+    {
+        *result = INFINITY;
+        return 0;
     }
 
     // Handle sign.


### PR DESCRIPTION
# Description

This change allows OPA's number parsing to handle 'Infinite' and 'Infinity' strings by converting them to a representation of infinity. This is useful when parsing JSON data that contains these special values.

## Changes
- Modified `opa_atof64` to recognize Infinite/Infinity strings
- Updated `builtinToNumber` to handle these special cases
- Added comprehensive tests for infinity handling

## Example Usage
```rego
# Both forms work
inf1 := to_number("Infinite")
inf2 := to_number("Infinity")

# Infinity comparisons work as expected
inf1 > 1e308  # true
inf2 > 1e100  # true
inf1 == inf2  # true
