### PR TITLE
Update eval_cancel_error logic to separate context canceled, timeout errors

### DIFF
--- a/rego/rego_test.go
+++ b/rego/rego_test.go
@@ -259,7 +259,7 @@ func TestRegoCancellation(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Expected cancellation error but got: %v", rs)
 	}
-	exp := topdown.Error{Code: topdown.CancelErr, Message: "caller cancelled query execution"}
+	exp := topdown.Error{Code: topdown.CancelErr, Message: context.DeadlineExceeded.Error()}
 	if !errors.Is(err, &exp) {
 		t.Errorf("error: expected %v, got: %v", exp, err)
 	}
@@ -1137,7 +1137,7 @@ func TestPrepareAndPartial(t *testing.T) {
 	mod := `
 	package test
 	import rego.v1
-	
+
 	default p = false
 	p if {
 		input.x = 1
@@ -1326,7 +1326,7 @@ func TestPartialResultWithInput(t *testing.T) {
 	mod := `
 	package test
 	import rego.v1
-	
+
 	default p = false
 	p if {
 		input.x == 1
@@ -1355,7 +1355,7 @@ func TestPartialResultWithNamespace(t *testing.T) {
 	mod := `
 	package test
 	import rego.v1
-	
+
 	p if {
 		true
 	}
@@ -1398,7 +1398,7 @@ func TestPreparedPartialResultWithTracer(t *testing.T) {
 	mod := `
 	package test
 	import rego.v1
-	
+
 	default p = false
 	p if {
 		input.x = 1
@@ -1440,7 +1440,7 @@ func TestPreparedPartialResultWithQueryTracer(t *testing.T) {
 	mod := `
 	package test
 	import rego.v1
-	
+
 	default p = false
 	p if {
 		input.x = 1
@@ -2174,7 +2174,7 @@ func TestRegoLoadBundleWithProvidedStore(t *testing.T) {
 func TestRegoCustomBuiltinPartialPropagate(t *testing.T) {
 	mod := `package test
 	import rego.v1
-	
+
 	p if {
 		x = trim_and_split(input.foo, "/")
 		x == ["foo", "bar", "baz"]
@@ -2279,15 +2279,15 @@ func TestShallowInliningOption(t *testing.T) {
 		SetRegoVersion(ast.RegoV1),
 		Module("example.rego", `
 			package test
-			
+
 			p if {
 				q = true
 			}
-			
+
 			q if {
 				input.x = r
 			}
-			
+
 			r = 7
 		`),
 		ShallowInlining(true))
@@ -2318,19 +2318,19 @@ func TestRegoPartialResultSortedRules(t *testing.T) {
 		SetRegoVersion(ast.RegoV1),
 		Module("example.rego", `
 			package test
-	
+
 			default p = false
-	
+
 			p if {
 				r = (input.d * input.a) + input.c
 				r < s
 			}
-	
+
 			p if {
 				r = (input.d * input.b) + input.c
 				r < s
 			}
-	
+
 			s = 100
 	`))
 

--- a/tester/runner_test.go
+++ b/tester/runner_test.go
@@ -6,6 +6,7 @@ package tester_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"testing"
@@ -408,6 +409,10 @@ func testCancel(t *testing.T, bench bool) {
 		if !topdown.IsCancel(results[0].Error) {
 			t.Fatalf("Expected cancel error for first test but got: %v", results[0].Error)
 		}
+
+		if !errors.Is(results[0].Error, context.Canceled) {
+			t.Fatalf("Expected error to be of type context.Canceled but got: %v", results[0].Error)
+		}
 	})
 }
 
@@ -475,6 +480,10 @@ func testTimeout(t *testing.T, bench bool) {
 			if topdown.IsCancel(results[1].Error) {
 				t.Fatalf("Expected no error for second test, but it timed out")
 			}
+		}
+
+		if !errors.Is(results[0].Error, context.DeadlineExceeded) {
+			t.Fatalf("Expected error to be of type context.DeadlineExceeded but got: %v", results[0].Error)
 		}
 	})
 }

--- a/topdown/eval.go
+++ b/topdown/eval.go
@@ -340,6 +340,14 @@ func (e *eval) evalExpr(iter evalIterator) error {
 		return &earlyExitError{prev: err, e: e}
 	}
 
+	if e.ctx != nil && e.ctx.Err() != nil {
+		return &Error{
+			Code:    CancelErr,
+			Message: e.ctx.Err().Error(),
+			err:     e.ctx.Err(),
+		}
+	}
+
 	if e.cancel != nil && e.cancel.Cancelled() {
 		return &Error{
 			Code:    CancelErr,


### PR DESCRIPTION
### Why the changes in this PR are needed?

While the `eval_cancel_error: caller cancelled query execution` error is useful in identifying requests that stopped, I propose that it's a little too vague because it absorbs both `context.Canceled` and `context.DeadlineExceeded` errors. It's useful to differentiate these errors as it gives a clue to whether the user intentionally stopped the request, or the request exeeded some deadline from the caller. Without a change similar to this, it's much more difficult to tell why a call to `Eval` failed.

### What are the changes in this PR?

This adds logic to `topdown/eval.go` to differentiate context errors. It has the same `eval_cancel_error` prefix as before, but can now return an error that gives more clues:

```
eval_cancel_error: context deadline exceeded
eval_cancel_error: context canceled
```

### Notes to assist PR review:

### Further comments:

An alternative here could be just to return the `e.ctx.Err()` in the [existing logic](https://github.com/open-policy-agent/opa/blob/976e2d467b6964973fda338ca1b154d09bd75dc4/topdown/eval.go#L343), but that does retain the more vague error message.