### PR TITLE
to_number : built-in function now rejects "Inf", "Infinity" and "NaN" values

### DIFF
--- a/test/cases/testdata/v1/casts/test-casts-0828.yml
+++ b/test/cases/testdata/v1/casts/test-casts-0828.yml
@@ -1,0 +1,90 @@
+---
+cases:
+  - note: "casts/to_number: nan input"
+    query: data.generated.p = b
+    modules:
+      - |
+        package generated
+
+        p if {
+          to_number("nan", b)
+        }
+    want_error_code: eval_type_error
+    strict_error: true
+  - note: "casts/to_number: inf input"
+    query: data.generated.p = b
+    modules:
+      - |
+        package generated
+
+        p if {
+          to_number("inf", b)
+        }
+    want_error_code: eval_type_error
+    strict_error: true
+  - note: "casts/to_number: -inf input"
+    query: data.generated.p = b
+    modules:
+      - |
+        package generated
+
+        p if {
+          to_number("-inf", b)
+        }
+    want_error_code: eval_type_error
+    strict_error: true
+  - note: "casts/to_number: Infinity input"
+    query: data.generated.p = b
+    modules:
+      - |
+        package generated
+
+        p if {
+          to_number("Infinity", b)
+        }
+    want_error_code: eval_type_error
+    strict_error: true
+  - note: "casts/to_number: -Infinity input"
+    query: data.generated.p = b
+    modules:
+      - |
+        package generated
+
+        p if {
+          to_number("-Infinity", b)
+        }
+    want_error_code: eval_type_error
+    strict_error: true
+  - note: "casts/to_number: -nan input"
+    query: data.generated.p = b
+    modules:
+      - |
+        package generated
+
+        p if {
+          to_number("-nan", b)
+        }
+    want_error_code: eval_type_error
+    strict_error: true
+  - note: "casts/to_number: -NaN input"
+    query: data.generated.p = b
+    modules:
+      - |
+        package generated
+
+        p if {
+          to_number("-NaN", b)
+        }
+    want_error_code: eval_type_error
+    strict_error: true
+  - note: "casts/to_number: iNf input"
+    query: data.generated.p = b
+    modules:
+      - |
+        package generated
+
+        p if {
+          to_number("iNf", b)
+        }
+    want_error_code: eval_type_error
+    strict_error: true

--- a/topdown/casts.go
+++ b/topdown/casts.go
@@ -6,6 +6,7 @@ package topdown
 
 import (
 	"strconv"
+	"strings"
 
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/topdown/builtins"
@@ -23,7 +24,16 @@ func builtinToNumber(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term
 	case ast.Number:
 		return iter(ast.NewTerm(a))
 	case ast.String:
-		_, err := strconv.ParseFloat(string(a), 64)
+		strValue := string(a)
+
+		trimmedVal := strings.TrimLeft(strValue, "+-")
+		lowerCaseVal := strings.ToLower(trimmedVal)
+
+		if lowerCaseVal == "inf" || lowerCaseVal == "infinity" || lowerCaseVal == "nan" {
+			return builtins.NewOperandTypeErr(1, operands[0].Value, "valid number string")
+		}
+
+		_, err := strconv.ParseFloat(strValue, 64)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
closes #7200 

### Why the changes in this PR are needed?

The `to_number` built-in function in OPA currently allows inputs such as `"Inf"`, `"Infinity"`, and `"NaN"` because these are accepted by Go's `strconv.ParseFloat` function. However, these values are not valid JSON numbers and can cause errors during JSON marshaling or undefined behavior. This change ensures that `to_number` explicitly rejects these inputs, aligning with OPA's expected behavior for numeric conversions.

### What are the changes in this PR?

- Added validation to the `to_number` function to explicitly reject string inputs `"Inf"`, `"Infinity"`, and `"NaN"`.
- Updated the logic to raise a clear `NewOperandTypeErr` when these invalid strings are encountered.
