### PR TITLE
Updating formatter to not drop `rego.v1` and `future.keywords` imports for v1

### DIFF
--- a/cmd/build_test.go
+++ b/cmd/build_test.go
@@ -2393,11 +2393,13 @@ allow if {
 					1 < 2
 				}`,
 			},
-			// the rego.v1 import is obsolete in rego-v1, and is removed
+			// the rego.v1 import is kept to maximize compatibility surface
 			expectedFiles: map[string]string{
 				".manifest": `{"revision":"","roots":[""],"rego_version":1}
 `,
 				"test.rego": `package test
+
+import rego.v1
 
 allow if {
 	1 < 2
@@ -2415,11 +2417,38 @@ allow if {
 					1 < 2
 				}`,
 			},
-			// future.keywords imports are obsolete in rego-v1, and are removed
+			// future.keywords imports are kept to maximize compatibility surface
 			expectedFiles: map[string]string{
 				".manifest": `{"revision":"","roots":[""],"rego_version":1}
 `,
 				"test.rego": `package test
+
+import future.keywords.if
+
+allow if {
+	1 < 2
+}
+`,
+			},
+		},
+		{
+			note:         "v1 compatibility: policy with rego.v1 and future.keywords imports",
+			v1Compatible: true,
+			files: map[string]string{
+				"test.rego": `package test
+				import rego.v1
+				import future.keywords.if
+				allow if {
+					1 < 2
+				}`,
+			},
+			// future.keywords are dropped as these are covered by rego.v1
+			expectedFiles: map[string]string{
+				".manifest": `{"revision":"","roots":[""],"rego_version":1}
+`,
+				"test.rego": `package test
+
+import rego.v1
 
 allow if {
 	1 < 2

--- a/cmd/fmt.go
+++ b/cmd/fmt.go
@@ -21,14 +21,15 @@ import (
 )
 
 type fmtCommandParams struct {
-	overwrite    bool
-	list         bool
-	diff         bool
-	fail         bool
-	regoV1       bool
-	v0Compatible bool
-	v1Compatible bool
-	checkResult  bool
+	overwrite     bool
+	list          bool
+	diff          bool
+	fail          bool
+	regoV1        bool
+	v0Compatible  bool
+	v1Compatible  bool
+	checkResult   bool
+	dropV0Imports bool
 }
 
 var fmtParams = fmtCommandParams{}
@@ -133,7 +134,8 @@ func formatFile(params *fmtCommandParams, out io.Writer, filename string, info o
 	}
 
 	opts := format.Opts{
-		RegoVersion: params.regoVersion(),
+		RegoVersion:   params.regoVersion(),
+		DropV0Imports: params.dropV0Imports,
 	}
 
 	if params.v0Compatible {
@@ -254,6 +256,7 @@ func init() {
 	addV0CompatibleFlag(formatCommand.Flags(), &fmtParams.v0Compatible, false)
 	addV1CompatibleFlag(formatCommand.Flags(), &fmtParams.v1Compatible, false)
 	formatCommand.Flags().BoolVar(&fmtParams.checkResult, "check-result", true, "assert that the formatted code is valid and can be successfully parsed (default true)")
+	formatCommand.Flags().BoolVar(&fmtParams.dropV0Imports, "drop-v0-imports", false, "drop v0 imports from the formatted code, such as 'rego.v1' and 'future.keywords'")
 
 	RootCommand.AddCommand(formatCommand)
 }

--- a/cmd/fmt_test.go
+++ b/cmd/fmt_test.go
@@ -887,10 +887,11 @@ q := all([true, false])
 
 func TestFmt_DefaultRegoVersion(t *testing.T) {
 	tests := []struct {
-		note         string
-		input        string
-		expected     string
-		expectedErrs []string
+		note          string
+		dropV0Imports bool
+		input         string
+		expected      string
+		expectedErrs  []string
 	}{
 		{
 			note: "no keywords used",
@@ -935,6 +936,86 @@ q contains "foo" if {
 			note: "future imports",
 			input: `package test
 import future.keywords
+p if {
+	input.x == 1
+}
+
+q contains "foo" if {
+	input.x == 2
+}
+`,
+			// NOTE: We keep the future imports to create the broadest possible compatibility surface
+			expected: `package test
+
+import future.keywords
+
+p if {
+	input.x == 1
+}
+
+q contains "foo" if {
+	input.x == 2
+}
+`,
+		},
+		{
+			note: "future imports, drop v0 imports",
+			input: `package test
+import future.keywords.if
+import future.keywords.contains
+p if {
+	input.x == 1
+}
+
+q contains "foo" if {
+	input.x == 2
+}
+`,
+			expected: `package test
+
+import future.keywords.contains
+import future.keywords.if
+
+p if {
+	input.x == 1
+}
+
+q contains "foo" if {
+	input.x == 2
+}
+`,
+		},
+		{
+			note: "rego.v1 import",
+			input: `package test
+import rego.v1
+p if {
+	input.x == 1
+}
+
+q contains "foo" if {
+	input.x == 2
+}
+`,
+			// NOTE: We keep the rego.v1 import to create the broadest possible compatibility surface
+			expected: `package test
+
+import rego.v1
+
+p if {
+	input.x == 1
+}
+
+q contains "foo" if {
+	input.x == 2
+}
+`,
+		},
+		{
+			note:          "rego.v1 import, drop v0 imports",
+			dropV0Imports: true,
+			input: `package test
+import rego.v1
 p if {
 	input.x == 1
 }
@@ -998,6 +1079,7 @@ q := all([true, false])
 	for _, tc := range tests {
 		t.Run(tc.note, func(t *testing.T) {
 			params := fmtCommandParams{}
+			params.dropV0Imports = tc.dropV0Imports
 
 			files := map[string]string{
 				"policy.rego": tc.input,

--- a/v1/format/testfiles/v1/test_future_kw_import.rego
+++ b/v1/format/testfiles/v1/test_future_kw_import.rego
@@ -1,0 +1,21 @@
+package p
+
+# existing future.keywords imports kept for broadest compatibility surface
+import future.keywords.every
+import future.keywords.if
+
+r if {
+	every x in [1,3,5] {
+        is_odd(x)
+    }
+
+	every x in [1,3,5] { is_odd(x); true }
+
+	every x in [1,3,5] {
+        is_odd(x)
+        true
+        x < 10
+    }
+}
+
+is_odd(x) = x % 2 == 0

--- a/v1/format/testfiles/v1/test_future_kw_import.rego.formatted
+++ b/v1/format/testfiles/v1/test_future_kw_import.rego.formatted
@@ -1,0 +1,21 @@
+package p
+
+# existing future.keywords imports kept for broadest compatibility surface
+import future.keywords.every
+import future.keywords.if
+
+r if {
+	every x in [1, 3, 5] {
+		is_odd(x)
+	}
+
+	every x in [1, 3, 5] { is_odd(x); true}
+
+	every x in [1, 3, 5] {
+		is_odd(x)
+		true
+		x < 10
+	}
+}
+
+is_odd(x) := (x % 2) == 0

--- a/v1/format/testfiles/v1/test_rego_v1.rego
+++ b/v1/format/testfiles/v1/test_rego_v1.rego
@@ -1,6 +1,7 @@
 package example
 
-import rego.v1 # import will be dropped
+import rego.v1 # rego.v1 import kept for broadest compatibility surface
+import future.keywords.if # future.keywords imports are dropped, as they're covered by rego.v1
 
 # R1: constant
 a := 1

--- a/v1/format/testfiles/v1/test_rego_v1.rego.formatted
+++ b/v1/format/testfiles/v1/test_rego_v1.rego.formatted
@@ -1,6 +1,8 @@
 package example
 
-# import will be dropped
+import rego.v1 # rego.v1 import kept for broadest compatibility surface
+
+# future.keywords imports are dropped, as they're covered by rego.v1
 
 # R1: constant
 a := 1


### PR DESCRIPTION
to maximize compatibility surface across OPA versions.

Adding `--drop-v0-imports` flag to `opa fmt` for opting in to dropping redundant v0 imports.