### PR TITLE
Renaming `--rego-v1` cmd flag to `--v0-v1`

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -194,9 +194,8 @@ func init() {
 	addCapabilitiesFlag(checkCommand.Flags(), checkParams.capabilities)
 	addSchemaFlags(checkCommand.Flags(), checkParams.schema)
 	addStrictFlag(checkCommand.Flags(), &checkParams.strict, false)
-	// FIXME: Rename or add new flag with same effect? '--rego-v1' will become even more confusing in 1.0, as what it actually means is check that module is compatible with BOTH v0 and v1.
-	addRegoV1FlagWithDescription(checkCommand.Flags(), &checkParams.regoV1, false,
-		"check for Rego v1 compatibility (policies must also be compatible with current OPA version)")
+	addRegoV0V1FlagWithDescription(checkCommand.Flags(), &checkParams.regoV1, false,
+		"check for Rego v0 and v1 compatibility (policies must be compatible with both Rego versions)")
 	addV0CompatibleFlag(checkCommand.Flags(), &checkParams.v0Compatible, false)
 	addV1CompatibleFlag(checkCommand.Flags(), &checkParams.v1Compatible, false)
 	RootCommand.AddCommand(checkCommand)

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -153,8 +153,12 @@ func addStrictFlag(fs *pflag.FlagSet, strict *bool, value bool) {
 	fs.BoolVarP(strict, "strict", "S", value, "enable compiler strict mode")
 }
 
-func addRegoV1FlagWithDescription(fs *pflag.FlagSet, regoV1 *bool, value bool, description string) {
+func addRegoV0V1FlagWithDescription(fs *pflag.FlagSet, regoV1 *bool, value bool, description string) {
+	fs.BoolVar(regoV1, "v0-v1", value, description)
+
+	// For backwards compatibility
 	fs.BoolVar(regoV1, "rego-v1", value, description)
+	_ = fs.MarkHidden("rego-v1")
 }
 
 func addV0CompatibleFlag(fs *pflag.FlagSet, v1Compatible *bool, value bool) {

--- a/cmd/fmt.go
+++ b/cmd/fmt.go
@@ -138,6 +138,10 @@ func formatFile(params *fmtCommandParams, out io.Writer, filename string, info o
 		DropV0Imports: params.dropV0Imports,
 	}
 
+	if params.regoV1 {
+		opts.ParserOptions = &ast.ParserOptions{RegoVersion: ast.RegoV0}
+	}
+
 	if params.v0Compatible {
 		// v0 takes precedence over v1
 		opts.ParserOptions = &ast.ParserOptions{RegoVersion: ast.RegoV0}
@@ -216,6 +220,11 @@ func formatStdin(params *fmtCommandParams, r io.Reader, w io.Writer) error {
 
 	opts := format.Opts{}
 	opts.RegoVersion = params.regoVersion()
+
+	if params.regoV1 {
+		opts.ParserOptions = &ast.ParserOptions{RegoVersion: ast.RegoV0}
+	}
+
 	formatted, err := format.SourceWithOpts("stdin", contents, opts)
 	if err != nil {
 		return err
@@ -252,7 +261,7 @@ func init() {
 	formatCommand.Flags().BoolVarP(&fmtParams.list, "list", "l", false, "list all files who would change when formatted")
 	formatCommand.Flags().BoolVarP(&fmtParams.diff, "diff", "d", false, "only display a diff of the changes")
 	formatCommand.Flags().BoolVar(&fmtParams.fail, "fail", false, "non zero exit code on reformat")
-	addRegoV1FlagWithDescription(formatCommand.Flags(), &fmtParams.regoV1, false, "format module(s) to be compatible with both Rego v1 and current OPA version)")
+	addRegoV0V1FlagWithDescription(formatCommand.Flags(), &fmtParams.regoV1, false, "format module(s) to be compatible with both Rego v0 and v1")
 	addV0CompatibleFlag(formatCommand.Flags(), &fmtParams.v0Compatible, false)
 	addV1CompatibleFlag(formatCommand.Flags(), &fmtParams.v1Compatible, false)
 	formatCommand.Flags().BoolVar(&fmtParams.checkResult, "check-result", true, "assert that the formatted code is valid and can be successfully parsed (default true)")

--- a/cmd/fmt_test.go
+++ b/cmd/fmt_test.go
@@ -840,9 +840,7 @@ q := all([true, false])
 	for _, tc := range tests {
 		t.Run(tc.note, func(t *testing.T) {
 			params := fmtCommandParams{
-				// Locking rego-version to v0, as it's only then the --rego-v1 flag is relevant
-				v0Compatible: true,
-				regoV1:       true,
+				regoV1: true,
 			}
 
 			files := map[string]string{


### PR DESCRIPTION
Affects `opa fmt` and `opa check`.

`opa fmt` command is updated to expect incoming rego to be v0.
