### PR TITLE
docs: fix typo in k8s primer

### DIFF
--- a/docs/content/kubernetes-primer.md
+++ b/docs/content/kubernetes-primer.md
@@ -50,7 +50,7 @@ spec:
     name: mysql-backend
 ```
 
-The admission review request to sent to OPA would look like this:
+The admission review request to be sent to OPA would look like this:
 
 ```live:container_images:input
 {


### PR DESCRIPTION
### Why the changes in this PR are needed?

There is a small typo in the documentation page of Kubernetes primer (https://www.openpolicyagent.org/docs/latest/kubernetes-primer/) at line 53 of the Markdown file.

### What are the changes in this PR?

The original phrase is: "The admission review request to sent to OPA would look like this:" which have a grammatical error with "to sent".
The PR change the phrase adding "be" to adhere to a future/passive form ("to be sent").