### PR TITLE
golangci: fix invalid `linter-settings` configuration name

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -141,9 +141,6 @@ linters-settings:
   lll:
     line-length: 200
 
-  misspell:
-    locale: US
-
 linters:
   disable-all: true
   enable:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -137,7 +137,7 @@ issues:
         - staticcheck
       text: "SA1019"
 
-linter-settings:
+linters-settings:
   lll:
     line-length: 200
 


### PR DESCRIPTION
### Why the changes in this PR are needed?

We started using `golangci-lint` in PR https://github.com/open-policy-agent/opa/pull/3465. However, the configuration name `linter-settings` is incorrect, which caused the configuration for the `lll` and `misspell` linters to not be applied.

https://github.com/open-policy-agent/opa/blob/3568eab2f4f12d70b9e056346466d6c8611ec14d/.golangci.yaml#L140-L145

![2025-01-05_01-51](https://github.com/user-attachments/assets/1e175111-ac98-42a4-b476-2bb05a3b087d)

The correct configuration name is `linters-settings`, as noted in https://golangci-lint.run/usage/configuration/#linters-settings-configuration

Due to this configuration error, we have accumulated many US spelling errors in the codebase. Some of these would cause breaking changes for existing users because they require renaming functions and error strings.

> [!tip]
> Hyrum's law 
> https://github.com/golang/go/blob/go1.23.4/src/net/http/request.go#L1208

```
v1/topdown/cancel.go:15:2: `Cancelled` is a misspelling of `Canceled` (misspell)
	Cancelled() bool
	^
v1/topdown/cancel.go:31:18: `Cancelled` is a misspelling of `Canceled` (misspell)
func (c *cancel) Cancelled() bool {
                 ^
v1/topdown/tokens.go:957:56: `marshalling` is a misspelling of `marshaling` (misspell)
		return fmt.Errorf("failed to prepare JWT headers for marshalling: %v", err)
		                                                     ^
v1/topdown/tokens.go:967:56: `marshalling` is a misspelling of `marshaling` (misspell)
		return fmt.Errorf("failed to prepare JWT payload for marshalling: %v", err)
		                                                     ^
v1/topdown/tokens.go:977:58: `marshalling` is a misspelling of `marshaling` (misspell)
		return fmt.Errorf("failed to prepare JWT signature for marshalling: %v", err)
		                                                       ^
```

### What are the changes in this PR?

- Rename `linter-settings` to `linters-settings` in `.golangci.yaml`
- Remove the US locale restriction from the `misspell` linter. This is because renaming functions and error strings are considered breaking changes

### Notes to assist PR review:

<!--
Here you can add information you think will help the reviewer(s).
-->

### Further comments:

<!--
Here you can include links to additional resources related to the changes, discuss your solution, other approaches you considered etc.
-->
