### PR TITLE
cmd: Respect `--v0-compatible` for `opa eval` support modules

### DIFF
--- a/internal/presentation/presentation.go
+++ b/internal/presentation/presentation.go
@@ -457,25 +457,25 @@ func prettyPartial(w io.Writer, pq *rego.PartialQueries) error {
 	var maxWidth int
 
 	for i := range pq.Queries {
-		s, width, err := prettyASTNode(pq.Queries[i])
+		f, width, err := prettyASTNode(pq.Queries[i], ast.DefaultRegoVersion)
 		if err != nil {
 			return err
 		}
 		if width > maxWidth {
 			maxWidth = width
 		}
-		table.Append([]string{fmt.Sprintf("Query %d", i+1), s})
+		table.Append([]string{fmt.Sprintf("Query %d", i+1), f})
 	}
 
-	for i := range pq.Support {
-		s, width, err := prettyASTNode(pq.Support[i])
+	for i, s := range pq.Support {
+		f, width, err := prettyASTNode(s, s.RegoVersion())
 		if err != nil {
 			return err
 		}
 		if width > maxWidth {
 			maxWidth = width
 		}
-		table.Append([]string{fmt.Sprintf("Support %d", i+1), s})
+		table.Append([]string{fmt.Sprintf("Support %d", i+1), f})
 	}
 
 	table.SetColMinWidth(1, maxWidth)
@@ -485,8 +485,8 @@ func prettyPartial(w io.Writer, pq *rego.PartialQueries) error {
 }
 
 // prettyASTNode is used for pretty-printing the result of partial eval
-func prettyASTNode(x interface{}) (string, int, error) {
-	bs, err := format.AstWithOpts(x, format.Opts{IgnoreLocations: true})
+func prettyASTNode(x interface{}, regoVersion ast.RegoVersion) (string, int, error) {
+	bs, err := format.AstWithOpts(x, format.Opts{IgnoreLocations: true, RegoVersion: regoVersion})
 	if err != nil {
 		return "", 0, fmt.Errorf("format error: %w", err)
 	}


### PR DESCRIPTION
Fixing issue in the `opa eval` command where `--v0-compatible` was ignored for PE support modules when used in combination with the `pretty` output format; producing v1 support modules instead of v0.

Fixing: #7248
