### PR TITLE
docs: Update docker-compose.yml to include addr

### DIFF
--- a/docs/content/http-api-authorization.md
+++ b/docs/content/http-api-authorization.md
@@ -89,6 +89,7 @@ services:
     command:
     - "run"
     - "--server"
+    - "--addr=0.0.0.0:8181"
     - "--log-format=json-pretty"
     - "--set=decision_logs.console=true"
     - "--set=services.nginx.url=http://bundle_server"


### PR DESCRIPTION
### Why the changes in this PR are needed?
Per #7264: "OPA 1.0+ server now binds only to localhost by default". Adding the --addr flag allows the container to spin up with the correct binding, allowing it to be reachable.

New results with updated docker-compose.yml:
```
$ curl --user alice:password localhost:5000/finance/salary/alice
Success: user alice is authorized 

$ curl localhost:8181
...
</pre>
Open Policy Agent - An open source project to policy-enable your service.<br>
<br>
Version: 1.0.0<br>
...
```
