### PR TITLE
testing: replace reflect.DeepEqual where possible

### DIFF
--- a/cmd/capabilities_test.go
+++ b/cmd/capabilities_test.go
@@ -7,7 +7,7 @@ package cmd
 import (
 	"bytes"
 	"path"
-	"reflect"
+	"slices"
 	"sort"
 	"testing"
 
@@ -129,11 +129,11 @@ func TestCapabilitiesCurrent(t *testing.T) {
 				t.Fatal("expected success", err)
 			}
 
-			if !reflect.DeepEqual(caps.Features, tc.expFeatures) {
+			if !slices.Equal(caps.Features, tc.expFeatures) {
 				t.Errorf("expected features:\n\n%v\n\nbut got:\n\n%v", tc.expFeatures, caps.Features)
 			}
 
-			if !reflect.DeepEqual(caps.FutureKeywords, tc.expFutureKeywords) {
+			if !slices.Equal(caps.FutureKeywords, tc.expFutureKeywords) {
 				t.Errorf("expected future keywords:\n\n%v\n\nbut got:\n\n%v", tc.expFutureKeywords, caps.FutureKeywords)
 			}
 		})

--- a/cmd/eval_test.go
+++ b/cmd/eval_test.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -320,7 +321,7 @@ func TestEvalWithOptimize(t *testing.T) {
 	files := map[string]string{
 		"test.rego": `
 			package test
-			
+
 			default p = false
 			p if { q }
 			q if { input.x = data.foo }`,
@@ -389,7 +390,7 @@ func TestEvalWithOptimizeBundleData(t *testing.T) {
 	files := map[string]string{
 		"test.rego": `
 			package test
-			
+
 			default p = false
 			p if { q }
 			q if { input.x = data.foo }`,
@@ -1303,7 +1304,7 @@ func TestEvalDebugTraceJSONOutput(t *testing.T) {
 		for _, actual := range evals {
 			if expected.location.Compare(actual.location) == 0 {
 				found = true
-				if !reflect.DeepEqual(expected.varBindings, actual.varBindings) {
+				if !maps.Equal(expected.varBindings, actual.varBindings) {
 					t.Errorf("Expected var bindings:\n\n\t%+v\n\nGot\n\n\t%+v\n\n", expected.varBindings, actual.varBindings)
 				}
 			}
@@ -2482,7 +2483,7 @@ func TestBundleWithStrictFlag(t *testing.T) {
 func TestIfElseIfElseNoBrace(t *testing.T) {
 	files := map[string]string{
 		"bug.rego": `package bug
-			
+
 			p if false
 			else := 1 if false
 			else := 2`,
@@ -2507,7 +2508,7 @@ func TestIfElseIfElseNoBrace(t *testing.T) {
 func TestIfElseIfElseBrace(t *testing.T) {
 	files := map[string]string{
 		"bug.rego": `package bug
-			
+
 			p if false
 			else := 1 if { false }
 			else := 2`,
@@ -2532,7 +2533,7 @@ func TestIfElseIfElseBrace(t *testing.T) {
 func TestIfElse(t *testing.T) {
 	files := map[string]string{
 		"bug.rego": `package bug
-			
+
 			p if false
 			else := 1 `,
 	}
@@ -2584,7 +2585,7 @@ func TestElseNoIfV0(t *testing.T) {
 func TestElseIf(t *testing.T) {
 	files := map[string]string{
 		"bug.rego": `package bug
-			
+
 			p if false
 			else := x if {
 				x=2
@@ -2641,7 +2642,7 @@ func TestElseIfElseV0(t *testing.T) {
 func TestUnexpectedElseIfElseErr(t *testing.T) {
 	files := map[string]string{
 		"bug.rego": `package bug
-			
+
 			p if false
 			else := x if {
 				x=2
@@ -2679,7 +2680,7 @@ func TestUnexpectedElseIfElseErr(t *testing.T) {
 func TestUnexpectedElseIfErr(t *testing.T) {
 	files := map[string]string{
 		"bug.rego": `package bug
-			
+
 			q := 1 if false
 			else := 2 if
 			`,

--- a/cmd/refactor_test.go
+++ b/cmd/refactor_test.go
@@ -2,9 +2,9 @@ package cmd
 
 import (
 	"bytes"
+	"maps"
 	"os"
 	"path/filepath"
-	"reflect"
 	"testing"
 
 	"github.com/open-policy-agent/opa/v1/ast"
@@ -23,10 +23,10 @@ func TestDoMoveRenamePackage(t *testing.T) {
 			note:         "v0",
 			v0Compatible: true,
 			module: `package lib.foo
-			
+
 				# this is a comment
 				default allow = false
-				
+
 				allow {
 					input.message == "hello"    # this is a comment too
 				}`,
@@ -34,7 +34,7 @@ func TestDoMoveRenamePackage(t *testing.T) {
 
 				# this is a comment
 				default allow = false
-				
+
 				allow {
 					input.message == "hello"    # this is a comment too
 				}`, ast.ParserOptions{RegoVersion: ast.RegoV0}),
@@ -42,10 +42,10 @@ func TestDoMoveRenamePackage(t *testing.T) {
 		{
 			note: "v1",
 			module: `package lib.foo
-			
+
 				# this is a comment
 				default allow = false
-				
+
 				allow if {
 					input.message == "hello"    # this is a comment too
 				}`,
@@ -53,7 +53,7 @@ func TestDoMoveRenamePackage(t *testing.T) {
 
 				# this is a comment
 				default allow = false
-				
+
 				allow if {
 					input.message == "hello"    # this is a comment too
 				}`, ast.ParserOptions{RegoVersion: ast.RegoV1}),
@@ -89,7 +89,7 @@ func TestDoMoveRenamePackage(t *testing.T) {
 					formatted = format.MustAstWithOpts(tc.expected, format.Opts{RegoVersion: ast.RegoV1})
 				}
 
-				if !reflect.DeepEqual(formatted, buf.Bytes()) {
+				if !bytes.Equal(formatted, buf.Bytes()) {
 					t.Fatalf("Expected module:\n%v\n\nGot:\n%v\n", string(formatted), buf.String())
 				}
 			})
@@ -110,7 +110,7 @@ func TestDoMoveOverwriteFile(t *testing.T) {
 			module: `package lib.foo
 
 				import data.x.q
-				
+
 				default allow := false
 
 				allow {
@@ -118,9 +118,9 @@ func TestDoMoveOverwriteFile(t *testing.T) {
 				}
 				`,
 			expected: ast.MustParseModuleWithOpts(`package baz.bar
-	
+
 				import data.hidden.q
-			
+
 				default allow := false
 
 				allow {
@@ -132,7 +132,7 @@ func TestDoMoveOverwriteFile(t *testing.T) {
 			module: `package lib.foo
 
 				import data.x.q
-				
+
 				default allow := false
 
 				allow if {
@@ -140,9 +140,9 @@ func TestDoMoveOverwriteFile(t *testing.T) {
 				}
 				`,
 			expected: ast.MustParseModuleWithOpts(`package baz.bar
-	
+
 				import data.hidden.q
-			
+
 				default allow := false
 
 				allow if {
@@ -202,7 +202,7 @@ func TestParseSrcDstMap(t *testing.T) {
 
 	expected := map[string]string{"data.lib.foo": "data.baz.bar", "data": "data.acme"}
 
-	if !reflect.DeepEqual(actual, expected) {
+	if !maps.Equal(actual, expected) {
 		t.Fatalf("Expected mapping %v but got %v", expected, actual)
 	}
 

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -11,7 +11,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
-	"reflect"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -184,7 +184,7 @@ func TestInitRuntimeCipherSuites(t *testing.T) {
 				t.Fatal("Expected error but got nil")
 			} else if err == nil {
 				if len(tc.expCipherSuites) > 0 {
-					if !reflect.DeepEqual(*rt.Params.CipherSuites, tc.expCipherSuites) {
+					if !slices.Equal(*rt.Params.CipherSuites, tc.expCipherSuites) {
 						t.Fatalf("expected cipher suites %v but got %v", tc.expCipherSuites, *rt.Params.CipherSuites)
 					}
 				} else {

--- a/compile/compile_test.go
+++ b/compile/compile_test.go
@@ -8,9 +8,9 @@ import (
 	"context"
 	"fmt"
 	"io/fs"
+	"maps"
 	"os"
 	"path/filepath"
-	"reflect"
 	"strings"
 	"testing"
 
@@ -755,7 +755,7 @@ func TestCompilerBundleMergeWithBundleRegoVersion(t *testing.T) {
 
 			compareRegoVersions(t, tc.expGlobalRegoVersion, result.Manifest.RegoVersion)
 
-			if !reflect.DeepEqual(tc.expFileRegoVersions, result.Manifest.FileRegoVersions) {
+			if !maps.Equal(tc.expFileRegoVersions, result.Manifest.FileRegoVersions) {
 				t.Fatalf("expected file rego versions to be:\n\n%v\n\nbut got:\n\n%v", tc.expFileRegoVersions, result.Manifest.FileRegoVersions)
 			}
 		})

--- a/internal/bundle/inspect/inspect_test.go
+++ b/internal/bundle/inspect/inspect_test.go
@@ -11,6 +11,7 @@ import (
 	"path"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 
@@ -67,7 +68,7 @@ func TestGenerateBundleInfoWithFileDir(t *testing.T) {
 
 		expBuiltinNames := []string{"eq", "gt"}
 
-		if !reflect.DeepEqual(expBuiltinNames, builtinNames) {
+		if !slices.Equal(expBuiltinNames, builtinNames) {
 			t.Fatalf("expected builtin names to be %v but got %v", expBuiltinNames, builtinNames)
 		}
 	})

--- a/internal/json/patch/patch_test.go
+++ b/internal/json/patch/patch_test.go
@@ -1,7 +1,7 @@
 package patch
 
 import (
-	"reflect"
+	"slices"
 	"testing"
 
 	"github.com/open-policy-agent/opa/v1/storage"
@@ -79,7 +79,7 @@ func TestParsePatchPathEscaped(t *testing.T) {
 				t.Fatalf("Expected ok to be %v but was %v", tc.expectedOK, actualOK)
 			}
 
-			if !reflect.DeepEqual(tc.expectedPath, actualPath) {
+			if !slices.Equal(tc.expectedPath, actualPath) {
 				t.Fatalf("Expected path to be %v but was %v", tc.expectedPath, actualPath)
 			}
 		})

--- a/internal/pathwatcher/utils_test.go
+++ b/internal/pathwatcher/utils_test.go
@@ -6,7 +6,7 @@ package pathwatcher
 
 import (
 	"path/filepath"
-	"reflect"
+	"slices"
 	"strings"
 	"testing"
 
@@ -34,7 +34,7 @@ func TestWatchPaths(t *testing.T) {
 		for _, p := range paths {
 			result = append(result, filepath.Clean(strings.TrimPrefix(p, rootDir)))
 		}
-		if !reflect.DeepEqual(expected, result) {
+		if !slices.Equal(expected, result) {
 			t.Fatalf("Expected %q but got: %q", expected, result)
 		}
 	})

--- a/internal/planner/planner_test.go
+++ b/internal/planner/planner_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 
@@ -1222,7 +1223,7 @@ func (w *stmtCmpWalker) Visit(x interface{}) (ir.Visitor, error) {
 			f, ok := x.(*ir.Func)
 			if ok && s.Name == f.Name {
 				w.found = true
-				if !reflect.DeepEqual(s.Path, f.Path) {
+				if !slices.Equal(s.Path, f.Path) {
 					return nil, fmt.Errorf("func %v: expected path %v, got %v", f, s.Path, f.Path)
 				}
 			}

--- a/v1/ast/check_test.go
+++ b/v1/ast/check_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 
@@ -1502,7 +1503,7 @@ func TestCheckErrorDetails(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		if !reflect.DeepEqual(tc.detail.Lines(), tc.expected) {
+		if !slices.Equal(tc.detail.Lines(), tc.expected) {
 			t.Errorf("Expected %v for %v but got: %v", tc.expected, tc.detail, tc.detail.Lines())
 		}
 	}

--- a/v1/ast/policy_test.go
+++ b/v1/ast/policy_test.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
-	"reflect"
 	"testing"
 
 	"github.com/open-policy-agent/opa/v1/ast/location"
@@ -332,7 +331,7 @@ func TestExprBadJSON(t *testing.T) {
 	assert := func(js string, exp error) {
 		expr := Expr{}
 		err := util.UnmarshalJSON([]byte(js), &expr)
-		if !reflect.DeepEqual(exp, err) {
+		if exp.Error() != err.Error() {
 			t.Errorf("For %v Expected %v but got: %v", js, exp, err)
 		}
 	}
@@ -898,7 +897,7 @@ func mustParseURL(str string) url.URL {
 
 func TestModuleStringAnnotations(t *testing.T) {
 	module, err := ParseModuleWithOpts("test.rego", `package test
-import rego.v1 
+import rego.v1
 
 # METADATA
 # scope: rule
@@ -939,8 +938,8 @@ d.e.f := 3
 e.f.g[1]
 f.g.h[1] := 4
 
-g := 5 { 
-	false 
+g := 5 {
+	false
 } else := 6 {
 	false
 } else := 7`,
@@ -968,8 +967,8 @@ d.e.f := 3
 e.f.g contains 1
 f.g.h[1] := 4
 
-g := 5 if { 
-	false 
+g := 5 if {
+	false
 } else := 6 if {
 	false
 } else := 7`,
@@ -997,8 +996,8 @@ d.e.f := 3
 e.f.g contains 1
 f.g.h[1] := 4
 
-g := 5 if { 
-	false 
+g := 5 if {
+	false
 } else := 6 if {
 	false
 } else := 7`,

--- a/v1/bundle/file_test.go
+++ b/v1/bundle/file_test.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"reflect"
+	"slices"
 	"strings"
 	"testing"
 
@@ -128,7 +128,7 @@ func TestIteratorOrder(t *testing.T) {
 
 	expDataFiles := []string{"/", "/a", "/a/b", "/a/b/c", "/a/b/d/e", "/a/b/y/x/z"}
 
-	if !reflect.DeepEqual(expDataFiles, actualDataFiles) {
+	if !slices.Equal(expDataFiles, actualDataFiles) {
 		t.Fatalf("Expected data files %v but got %v", expDataFiles, actualDataFiles)
 	}
 }

--- a/v1/compile/compile_test.go
+++ b/v1/compile/compile_test.go
@@ -7,11 +7,11 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"maps"
 	"os"
 	"path"
 	"path/filepath"
-	"reflect"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -71,7 +71,7 @@ func TestCompilerV1Module(t *testing.T) {
 func TestOrderedStringSet(t *testing.T) {
 	var ss orderedStringSet
 	result := ss.Append("a", "b", "b", "a", "e", "c", "e")
-	if !reflect.DeepEqual(result, orderedStringSet{"a", "b", "e", "c"}) {
+	if !slices.Equal(result, orderedStringSet{"a", "b", "e", "c"}) {
 		t.Fatal(result)
 	}
 }
@@ -850,7 +850,7 @@ func TestCompilerBundleMergeWithBundleRegoVersion(t *testing.T) {
 
 			compareRegoVersions(t, tc.expGlobalRegoVersion, result.Manifest.RegoVersion)
 
-			if !reflect.DeepEqual(tc.expFileRegoVersions, result.Manifest.FileRegoVersions) {
+			if !maps.Equal(tc.expFileRegoVersions, result.Manifest.FileRegoVersions) {
 				t.Fatalf("expected file rego versions to be:\n\n%v\n\nbut got:\n\n%v", tc.expFileRegoVersions, result.Manifest.FileRegoVersions)
 			}
 		})
@@ -1137,7 +1137,7 @@ func TestCompilerOptimizationL1(t *testing.T) {
 	files := map[string]string{
 		"test.rego": `
 			package test
-			
+
 			default p := false
 			p if { q }
 			q if { input.x = data.foo }`,
@@ -1524,8 +1524,8 @@ foo[__local1__1] = true {
 			files: map[string]string{
 				"test.rego": `package test
 
-p { 
-	q[input.x][input.y] 
+p {
+	q[input.x][input.y]
 }
 
 q["foo/bar"][x] {
@@ -1844,7 +1844,7 @@ p {
 			files: map[string]string{
 				"test.rego": `package test
 
-import rego.v1 
+import rego.v1
 
 p if {
     input.x == 1
@@ -2193,7 +2193,7 @@ func TestCompilerWasmTargetEntrypointDependents(t *testing.T) {
 	files := map[string]string{
 		"test.rego": `package test
 			import rego.v1
-	
+
 			p if { q }
 			q if { r }
 			r := 1
@@ -3588,12 +3588,7 @@ func getOptimizer(modules map[string]string, data string, entries []string, root
 
 func getModuleFiles(src map[string]string, includeRaw bool, popts ast.ParserOptions) []bundle.ModuleFile {
 
-	keys := make([]string, 0, len(src))
-	for k := range src {
-		keys = append(keys, k)
-	}
-
-	sort.Strings(keys)
+	keys := util.KeysSorted(src)
 	modules := make([]bundle.ModuleFile, 0, len(keys))
 
 	for _, k := range keys {

--- a/v1/config/config_test.go
+++ b/v1/config/config_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"testing"
 
 	"github.com/open-policy-agent/opa/v1/util"
@@ -77,7 +78,7 @@ func TestConfigPluginNames(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			actual := test.conf.PluginNames()
-			if !reflect.DeepEqual(actual, test.expected) {
+			if !slices.Equal(actual, test.expected) {
 				t.Errorf("Expected %v but got %v", test.expected, actual)
 			}
 		})

--- a/v1/debug/debugger_test.go
+++ b/v1/debug/debugger_test.go
@@ -9,7 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"path"
-	"reflect"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -57,7 +57,7 @@ q := y if {
 import rego.v1
 
 p contains 1 if { # breakpoint
-	true    
+	true
 }
 
 p contains 2 if { # step-over to here, the next partial rule 'p'
@@ -73,7 +73,7 @@ p contains 2 if { # step-over to here, the next partial rule 'p'
 			module: `package test
 import rego.v1
 
-p contains 1 if { 
+p contains 1 if {
 	false         # breakpoint
 }
 
@@ -109,7 +109,7 @@ import rego.v1
 
 p if {
 	every x in [1, 2, 3] { # breakpoint
-		f(x) 
+		f(x)
 	}
 	true                   # step-over to here
 }
@@ -369,11 +369,11 @@ func TestDebuggerEvalStepOut(t *testing.T) {
 import rego.v1
 
 p if {
-	q       
+	q
 	true       # step-out to here
 }
 
-q := y if { 
+q := y if {
 	true       # breakpoint
 	y := 2 * 2
 }
@@ -387,11 +387,11 @@ q := y if {
 import rego.v1
 
 p if {
-	f(1)       
+	f(1)
 	true       # step-out to here
 }
 
-f(x) := y if { 
+f(x) := y if {
 	true       # breakpoint
 	y := x * 2
 }
@@ -980,7 +980,7 @@ func TestDebuggerStopOnBreakpoint(t *testing.T) {
 				}
 			})
 
-			if !reflect.DeepEqual(stoppedAt, tc.expEventIndices) {
+			if !slices.Equal(stoppedAt, tc.expEventIndices) {
 				t.Errorf("Expected to stop at event indices %v, got %v", tc.expEventIndices, stoppedAt)
 			}
 		})
@@ -1123,7 +1123,7 @@ func TestDebuggerStepIn(t *testing.T) {
 			case <-doneCh:
 			}
 
-			if !reflect.DeepEqual(stoppedAt, tc.expEventIndices) {
+			if !slices.Equal(stoppedAt, tc.expEventIndices) {
 				t.Errorf("Expected to stop at event indices %v, got %v", tc.expEventIndices, stoppedAt)
 			}
 		})
@@ -1300,7 +1300,7 @@ func TestDebuggerStepOver(t *testing.T) {
 			case <-doneCh:
 			}
 
-			if !reflect.DeepEqual(stoppedAt, tc.expEventIndices) {
+			if !slices.Equal(stoppedAt, tc.expEventIndices) {
 				t.Errorf("Expected to stop at event indices %v, got %v", tc.expEventIndices, stoppedAt)
 			}
 		})
@@ -1461,7 +1461,7 @@ func TestDebuggerStepOut(t *testing.T) {
 			case <-doneCh:
 			}
 
-			if !reflect.DeepEqual(stoppedAt, tc.expEventIndices) {
+			if !slices.Equal(stoppedAt, tc.expEventIndices) {
 				t.Errorf("Expected to stop at event indices %v, got %v", tc.expEventIndices, stoppedAt)
 			}
 		})

--- a/v1/loader/loader_test.go
+++ b/v1/loader/loader_test.go
@@ -15,6 +15,7 @@ import (
 	"path"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"sort"
 	"strings"
 	"testing"
@@ -821,7 +822,7 @@ func TestAsBundleWithDir(t *testing.T) {
 		}
 
 		expectedRoots := []string{"foo", "bar", "baz"}
-		if !reflect.DeepEqual(*b.Manifest.Roots, expectedRoots) {
+		if !slices.Equal(*b.Manifest.Roots, expectedRoots) {
 			t.Fatalf("expected roots %s, got: %s", expectedRoots, *b.Manifest.Roots)
 		}
 	})
@@ -862,7 +863,7 @@ func TestAsBundleWithFileURLDir(t *testing.T) {
 		}
 
 		expectedRoots := []string{"foo"}
-		if !reflect.DeepEqual(*b.Manifest.Roots, expectedRoots) {
+		if !slices.Equal(*b.Manifest.Roots, expectedRoots) {
 			t.Fatalf("expected roots %s, got: %s", expectedRoots, *b.Manifest.Roots)
 		}
 	})
@@ -1239,7 +1240,7 @@ func TestSplitPrefix(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.input, func(t *testing.T) {
 			parts, gotPath := SplitPrefix(tc.input)
-			if !reflect.DeepEqual(parts, tc.wantParts) {
+			if !slices.Equal(parts, tc.wantParts) {
 				t.Errorf("wanted parts %v but got %v", tc.wantParts, parts)
 			}
 			if gotPath != tc.wantPath {
@@ -1297,7 +1298,7 @@ func TestDirs(t *testing.T) {
 
 	e := []string{"/", "/foo", "/foo/bar"}
 	sorted := Dirs(paths)
-	if !reflect.DeepEqual(sorted, e) {
+	if !slices.Equal(sorted, e) {
 		t.Errorf("got: %q wanted: %q", sorted, e)
 	}
 }

--- a/v1/plugins/bundle/plugin_test.go
+++ b/v1/plugins/bundle/plugin_test.go
@@ -17,6 +17,7 @@ import (
 	"path"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"sort"
 	"strings"
 	"testing"
@@ -3052,7 +3053,7 @@ func TestPluginOneShotActivationRemovesOld(t *testing.T) {
 		ids, err := manager.Store.ListPolicies(ctx, txn)
 		if err != nil {
 			return err
-		} else if !reflect.DeepEqual([]string{filepath.Join(bundleName, "/example2.rego")}, ids) {
+		} else if !slices.Equal([]string{filepath.Join(bundleName, "/example2.rego")}, ids) {
 			return fmt.Errorf("expected updated policy ids")
 		}
 		data, err := manager.Store.Read(ctx, txn, storage.Path{})
@@ -7007,7 +7008,7 @@ func validateStoreState(ctx context.Context, t *testing.T, store storage.Store, 
 		sort.Strings(ids)
 		sort.Strings(expIDs)
 
-		if !reflect.DeepEqual(ids, expIDs) {
+		if !slices.Equal(ids, expIDs) {
 			return fmt.Errorf("expected ids %v but got %v", expIDs, ids)
 		}
 

--- a/v1/plugins/discovery/discovery_test.go
+++ b/v1/plugins/discovery/discovery_test.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -955,7 +956,7 @@ import future.keywords
 labels.x := "label value changed"
 default_decision := "bar/baz"
 default_authorization_decision := "baz/qux"
-plugins.test_plugin := v if { 
+plugins.test_plugin := v if {
 	v := {"a": "b"}
 }
 services.acmecorp.url := v if {
@@ -974,7 +975,7 @@ bundles.authz.service := v if {
 labels.x := "label value changed"
 default_decision := "bar/baz"
 default_authorization_decision := "baz/qux"
-plugins.test_plugin := v if { 
+plugins.test_plugin := v if {
 	v := {"a": "b"}
 }
 services.acmecorp.url := v if {
@@ -1082,7 +1083,7 @@ func TestLoadAndActivateBundleFromDiskWithBundleRegoVersion(t *testing.T) {
 labels.x := "label value changed"
 default_decision := "bar/baz"
 default_authorization_decision := "baz/qux"
-plugins.test_plugin := v { 
+plugins.test_plugin := v {
 	v := {"a": "b"}
 }
 
@@ -1104,7 +1105,7 @@ bundles.authz.service := v {
 labels.x := "label value changed"
 default_decision := "bar/baz"
 default_authorization_decision := "baz/qux"
-plugins.test_plugin := v { 
+plugins.test_plugin := v {
 	v := {"a": "b"}
 }`},
 				"policy2.rego": {1, `package config
@@ -1127,7 +1128,7 @@ bundles.authz.service := v if {
 labels.x := "label value changed"
 default_decision := "bar/baz"
 default_authorization_decision := "baz/qux"
-plugins.test_plugin := v if { 
+plugins.test_plugin := v if {
 	v := {"a": "b"}
 }
 services.acmecorp.url := v if {
@@ -1147,7 +1148,7 @@ bundles.authz.service := v if {
 labels.x := "label value changed"
 default_decision := "bar/baz"
 default_authorization_decision := "baz/qux"
-plugins.test_plugin := v { 
+plugins.test_plugin := v {
 	v := {"a": "b"}
 }`},
 				"policy2.rego": {-1, `package config
@@ -1403,7 +1404,7 @@ func TestReconfigure(t *testing.T) {
 
 	// Verify labels are unchanged but allow additions
 	exp := map[string]string{"x": "y", "y": "new label", "id": "test-id", "version": version.Version}
-	if !reflect.DeepEqual(manager.Labels(), exp) {
+	if !maps.Equal(manager.Labels(), exp) {
 		t.Errorf("Expected labels to be unchanged (%v) but got %v", exp, manager.Labels())
 	}
 
@@ -1418,7 +1419,7 @@ func TestReconfigure(t *testing.T) {
 	}
 
 	// Verify plugins started
-	if !reflect.DeepEqual(testPlugin.counts, map[string]int{"start": 1}) {
+	if !maps.Equal(testPlugin.counts, map[string]int{"start": 1}) {
 		t.Errorf("Expected exactly one plugin start but got %v", testPlugin)
 	}
 
@@ -1440,7 +1441,7 @@ func TestReconfigure(t *testing.T) {
 
 	// Verify label additions are always on top of bootstrap config with multiple discovery documents
 	exp = map[string]string{"x": "y", "z": "another added label", "id": "test-id", "version": version.Version}
-	if !reflect.DeepEqual(manager.Labels(), exp) {
+	if !maps.Equal(manager.Labels(), exp) {
 		t.Errorf("Expected labels to be unchanged (%v) but got %v", exp, manager.Labels())
 	}
 
@@ -1450,7 +1451,7 @@ func TestReconfigure(t *testing.T) {
 		t.Fatalf("expected snapshot bundle but got %v", disco.status.Type)
 	}
 
-	if !reflect.DeepEqual(testPlugin.counts, map[string]int{"start": 1, "reconfig": 1}) {
+	if !maps.Equal(testPlugin.counts, map[string]int{"start": 1, "reconfig": 1}) {
 		t.Errorf("Expected one plugin start and one reconfig but got %v", testPlugin)
 	}
 }
@@ -1505,7 +1506,7 @@ plugins.test_plugin := v if {
 
 	// Verify labels are unchanged but allow additions
 	exp := map[string]string{"x": "y", "y": "new label", "id": "test-id", "version": version.Version}
-	if !reflect.DeepEqual(manager.Labels(), exp) {
+	if !maps.Equal(manager.Labels(), exp) {
 		t.Errorf("Expected labels to be unchanged (%v) but got %v", exp, manager.Labels())
 	}
 
@@ -1520,7 +1521,7 @@ plugins.test_plugin := v if {
 	}
 
 	// Verify plugins started
-	if !reflect.DeepEqual(testPlugin.counts, map[string]int{"start": 1}) {
+	if !maps.Equal(testPlugin.counts, map[string]int{"start": 1}) {
 		t.Errorf("Expected exactly one plugin start but got %v", testPlugin)
 	}
 
@@ -1539,7 +1540,7 @@ plugins.test_plugin := v if {
 
 	// Verify label additions are always on top of bootstrap config with multiple discovery documents
 	exp = map[string]string{"x": "y", "z": "another added label", "id": "test-id", "version": version.Version}
-	if !reflect.DeepEqual(manager.Labels(), exp) {
+	if !maps.Equal(manager.Labels(), exp) {
 		t.Errorf("Expected labels to be unchanged (%v) but got %v", exp, manager.Labels())
 	}
 
@@ -1549,7 +1550,7 @@ plugins.test_plugin := v if {
 		t.Fatalf("expected snapshot bundle but got %v", disco.status.Type)
 	}
 
-	if !reflect.DeepEqual(testPlugin.counts, map[string]int{"start": 1, "reconfig": 1}) {
+	if !maps.Equal(testPlugin.counts, map[string]int{"start": 1, "reconfig": 1}) {
 		t.Errorf("Expected one plugin start and one reconfig but got %v", testPlugin)
 	}
 
@@ -1646,7 +1647,7 @@ plugins.test_plugin := v if {
 
 	// Verify labels are unchanged but allow additions
 	exp := map[string]string{"x": "y", "y": "new label", "id": "test-id", "version": version.Version}
-	if !reflect.DeepEqual(manager.Labels(), exp) {
+	if !maps.Equal(manager.Labels(), exp) {
 		t.Errorf("Expected labels to be unchanged (%v) but got %v", exp, manager.Labels())
 	}
 
@@ -1661,7 +1662,7 @@ plugins.test_plugin := v if {
 	}
 
 	// Verify plugins started
-	if !reflect.DeepEqual(testPlugin.counts, map[string]int{"start": 1}) {
+	if !maps.Equal(testPlugin.counts, map[string]int{"start": 1}) {
 		t.Errorf("Expected exactly one plugin start but got %v", testPlugin)
 	}
 
@@ -1680,7 +1681,7 @@ plugins.test_plugin := v if {
 
 	// Verify label additions are always on top of bootstrap config with multiple discovery documents
 	exp = map[string]string{"x": "y", "z": "another added label", "id": "test-id", "version": version.Version}
-	if !reflect.DeepEqual(manager.Labels(), exp) {
+	if !maps.Equal(manager.Labels(), exp) {
 		t.Errorf("Expected labels to be unchanged (%v) but got %v", exp, manager.Labels())
 	}
 
@@ -1690,7 +1691,7 @@ plugins.test_plugin := v if {
 		t.Fatalf("expected snapshot bundle but got %v", disco.status.Type)
 	}
 
-	if !reflect.DeepEqual(testPlugin.counts, map[string]int{"start": 1, "reconfig": 1}) {
+	if !maps.Equal(testPlugin.counts, map[string]int{"start": 1, "reconfig": 1}) {
 		t.Errorf("Expected one plugin start and one reconfig but got %v", testPlugin)
 	}
 }
@@ -1753,7 +1754,7 @@ func TestReconfigureWithLocalOverride(t *testing.T) {
 	}
 
 	exp := map[string]string{"x": "y", "y": "new label", "id": "test-id", "version": version.Version}
-	if !reflect.DeepEqual(manager.Labels(), exp) {
+	if !maps.Equal(manager.Labels(), exp) {
 		t.Errorf("Expected labels (%v) but got %v", exp, manager.Labels())
 	}
 
@@ -2851,7 +2852,7 @@ func TestStatusUpdatesFromPersistedBundlesDontDelayBoot(t *testing.T) {
 	defer listener.Close()
 
 	manager, err := plugins.New([]byte(fmt.Sprintf(`{
-            "persistence_directory": %q, 
+            "persistence_directory": %q,
 			"services": {
 				"localhost": {
 					"url": "http://%s"

--- a/v1/plugins/plugins_test.go
+++ b/v1/plugins/plugins_test.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"slices"
 	"testing"
 	"time"
 
@@ -326,7 +327,7 @@ func TestManagerWithOPATelemetryUpdateLoop(t *testing.T) {
 				t.Fatalf("Expected number of server calls: %+v but got: %+v", exp, len(versions))
 			}
 
-			if !reflect.DeepEqual(tc.exp, versions) {
+			if !slices.Equal(tc.exp, versions) {
 				t.Fatalf("Expected OPA versions: %+v but got: %+v", tc.exp, versions)
 			}
 		})

--- a/v1/plugins/rest/rest_test.go
+++ b/v1/plugins/rest/rest_test.go
@@ -27,6 +27,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -2298,7 +2299,7 @@ func (t *oauth2TestServer) handle(w http.ResponseWriter, r *http.Request) {
 
 	if len(r.Form["scope"]) > 0 {
 		scope := strings.Split(r.Form["scope"][0], " ")
-		if !reflect.DeepEqual(*t.expScope, scope) {
+		if !slices.Equal(*t.expScope, scope) {
 			t.t.Fatalf("Expected scope %v, got %v", *t.expScope, scope)
 		}
 	} else if t.expScope != nil && len(*t.expScope) > 0 {

--- a/v1/plugins/status/plugin_test.go
+++ b/v1/plugins/status/plugin_test.go
@@ -7,6 +7,7 @@ package status
 import (
 	"context"
 	"fmt"
+	"maps"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -416,7 +417,7 @@ func TestPluginStartTriggerManual(t *testing.T) {
 		},
 	}
 
-	if !reflect.DeepEqual(result.Labels, exp.Labels) {
+	if !maps.Equal(result.Labels, exp.Labels) {
 		t.Fatalf("Expected: %v but got: %v", exp, result)
 	}
 
@@ -675,7 +676,7 @@ func TestPluginStartBulkUpdateMultiple(t *testing.T) {
 		"version": version.Version,
 	}
 
-	if !reflect.DeepEqual(result.Labels, expLabels) {
+	if !maps.Equal(result.Labels, expLabels) {
 		t.Fatalf("Unexpected status labels: %+v", result.Labels)
 	}
 

--- a/v1/server/authorizer/authorizer_test.go
+++ b/v1/server/authorizer/authorizer_test.go
@@ -332,7 +332,7 @@ func TestMakeInput(t *testing.T) {
 		}
 	`))
 
-	if !reflect.DeepEqual(util.MustMarshalJSON(expectedResult), util.MustMarshalJSON(result)) {
+	if !bytes.Equal(util.MustMarshalJSON(expectedResult), util.MustMarshalJSON(result)) {
 		t.Fatalf("Expected %+v but got %+v", expectedResult, result)
 	}
 

--- a/v1/storage/disk/disk_test.go
+++ b/v1/storage/disk/disk_test.go
@@ -290,13 +290,13 @@ func runTruncateTest(t *testing.T, dir string) {
 
 	bs, err := s.GetPolicy(ctx, txn, "policy.rego")
 	expectedBytes := []byte("package foo\n p = 1")
-	if err != nil || !reflect.DeepEqual(expectedBytes, bs) {
+	if err != nil || !bytes.Equal(expectedBytes, bs) {
 		t.Fatalf("Expected get policy to return %v but got: %v (err: %v)", expectedBytes, bs, err)
 	}
 
 	bs, err = s.GetPolicy(ctx, txn, "roles/policy.rego")
 	expectedBytes = []byte("package bar\n p = 1")
-	if err != nil || !reflect.DeepEqual(expectedBytes, bs) {
+	if err != nil || !bytes.Equal(expectedBytes, bs) {
 		t.Fatalf("Expected get policy to return %v but got: %v (err: %v)", expectedBytes, bs, err)
 	}
 

--- a/v1/storage/inmem/inmem_test.go
+++ b/v1/storage/inmem/inmem_test.go
@@ -5,10 +5,12 @@
 package inmem
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"slices"
 	"testing"
 
 	"github.com/open-policy-agent/opa/internal/file/archive"
@@ -685,13 +687,13 @@ func TestTruncate(t *testing.T) {
 
 	bs, err := store.GetPolicy(ctx, txn, "policy.rego")
 	expectedBytes := []byte("package foo\n p = 1")
-	if err != nil || !reflect.DeepEqual(expectedBytes, bs) {
+	if err != nil || !bytes.Equal(expectedBytes, bs) {
 		t.Fatalf("Expected get policy to return %v but got: %v (err: %v)", expectedBytes, bs, err)
 	}
 
 	bs, err = store.GetPolicy(ctx, txn, "roles/policy.rego")
 	expectedBytes = []byte("package bar\n p = 1")
-	if err != nil || !reflect.DeepEqual(expectedBytes, bs) {
+	if err != nil || !bytes.Equal(expectedBytes, bs) {
 		t.Fatalf("Expected get policy to return %v but got: %v (err: %v)", expectedBytes, bs, err)
 	}
 }
@@ -783,13 +785,13 @@ func TestTruncateAst(t *testing.T) {
 
 	bs, err := store.GetPolicy(ctx, txn, "policy.rego")
 	expectedBytes := []byte("package foo\n p = 1")
-	if err != nil || !reflect.DeepEqual(expectedBytes, bs) {
+	if err != nil || !bytes.Equal(expectedBytes, bs) {
 		t.Fatalf("Expected get policy to return %v but got: %v (err: %v)", expectedBytes, bs, err)
 	}
 
 	bs, err = store.GetPolicy(ctx, txn, "roles/policy.rego")
 	expectedBytes = []byte("package bar\n p = 1")
-	if err != nil || !reflect.DeepEqual(expectedBytes, bs) {
+	if err != nil || !bytes.Equal(expectedBytes, bs) {
 		t.Fatalf("Expected get policy to return %v but got: %v (err: %v)", expectedBytes, bs, err)
 	}
 }
@@ -998,13 +1000,13 @@ func TestInMemoryTxnPolicies(t *testing.T) {
 
 	ids, err := store.ListPolicies(ctx, txn)
 	expectedIDs := []string{"test"}
-	if err != nil || !reflect.DeepEqual(expectedIDs, ids) {
+	if err != nil || !slices.Equal(expectedIDs, ids) {
 		t.Fatalf("Expected list policies to return %v but got: %v (err: %v)", expectedIDs, ids, err)
 	}
 
 	bs, err := store.GetPolicy(ctx, txn, "test")
 	expectedBytes := []byte("package test\nimport data.foo")
-	if err != nil || !reflect.DeepEqual(expectedBytes, bs) {
+	if err != nil || !bytes.Equal(expectedBytes, bs) {
 		t.Fatalf("Expected get policy to return %v but got: %v (err: %v)", expectedBytes, bs, err)
 	}
 
@@ -1018,13 +1020,13 @@ func TestInMemoryTxnPolicies(t *testing.T) {
 
 	ids, err = store.ListPolicies(ctx, txn)
 	expectedIDs = []string{"test2"}
-	if err != nil || !reflect.DeepEqual(expectedIDs, ids) {
+	if err != nil || !slices.Equal(expectedIDs, ids) {
 		t.Fatalf("Expected list policies to return %v but got: %v (err: %v)", expectedIDs, ids, err)
 	}
 
 	bs, err = store.GetPolicy(ctx, txn, "test2")
 	expectedBytes = []byte("package test2")
-	if err != nil || !reflect.DeepEqual(expectedBytes, bs) {
+	if err != nil || !bytes.Equal(expectedBytes, bs) {
 		t.Fatalf("Expected get policy to return %v but got: %v (err: %v)", expectedBytes, bs, err)
 	}
 
@@ -1037,7 +1039,7 @@ func TestInMemoryTxnPolicies(t *testing.T) {
 	txn = storage.NewTransactionOrDie(ctx, store)
 	ids, err = store.ListPolicies(ctx, txn)
 	expectedIDs = []string{"test"}
-	if err != nil || !reflect.DeepEqual(expectedIDs, ids) {
+	if err != nil || !slices.Equal(expectedIDs, ids) {
 		t.Fatalf("Expected list policies to return %v but got: %v (err: %v)", expectedIDs, ids, err)
 	}
 

--- a/v1/storage/path_test.go
+++ b/v1/storage/path_test.go
@@ -6,7 +6,6 @@ package storage
 
 import (
 	"math"
-	"reflect"
 	"testing"
 
 	"fmt"
@@ -61,7 +60,7 @@ func TestNewPathForRef(t *testing.T) {
 
 	for _, tc := range tests {
 		result, err := NewPathForRef(tc.input)
-		if tc.err != nil && !reflect.DeepEqual(tc.err, err) {
+		if tc.err != nil && tc.err.Error() != err.Error() {
 			t.Errorf("For %v expected %v but got %v", tc.input, tc.err, err)
 		} else if !result.Equal(tc.result) {
 			t.Errorf("For %v expected %v but got %v", tc.input, tc.result, result)

--- a/v1/test/e2e/http/http_test.go
+++ b/v1/test/e2e/http/http_test.go
@@ -5,10 +5,10 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"maps"
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"reflect"
 	"strings"
 	"testing"
 
@@ -87,7 +87,7 @@ func TestHttpSendInterQueryForceCache(t *testing.T) {
 			if tc.noForce {
 				module = `
 				package test
-			
+
 				response := http.send({
 					"method": "get",
 					"url": "%s"
@@ -96,7 +96,7 @@ func TestHttpSendInterQueryForceCache(t *testing.T) {
 			} else {
 				module = `
 				package test
-			
+
 				response := http.send({
 					"method": "get",
 					"url": "%s",
@@ -127,7 +127,7 @@ func TestHttpSendInterQueryForceCache(t *testing.T) {
 			if err = json.Unmarshal(resultJSON, &parsedBody); err != nil {
 				t.Fatal(err)
 			}
-			if !reflect.DeepEqual(parsedBody.Result, expect) {
+			if !maps.Equal(parsedBody.Result, expect) {
 				t.Errorf("Expected response %v, got %v", expect, parsedBody.Result)
 			}
 
@@ -144,7 +144,7 @@ func TestHttpSendInterQueryForceCache(t *testing.T) {
 			if err = json.Unmarshal(resultJSON, &parsedBody); err != nil {
 				t.Fatal(err)
 			}
-			if !reflect.DeepEqual(parsedBody.Result, expect) {
+			if !maps.Equal(parsedBody.Result, expect) {
 				t.Errorf("Expected response %v, got %v", expect, parsedBody.Result)
 			}
 

--- a/v1/tester/runner_test.go
+++ b/v1/tester/runner_test.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"reflect"
+	"maps"
 	"strings"
 	"testing"
 	"time"
@@ -63,12 +63,12 @@ func testRun(t *testing.T, conf testRunConfig) map[string]*ast.Module {
 	files := map[string]string{
 		"/a.rego": `package foo
 			import rego.v1
-			
+
 			allow if { true }
 			`,
 		"/a_test.rego": `package foo
 			import rego.v1
-			
+
 			test_pass if { allow }
 			non_test if { true }
 			test_fail if { not allow }
@@ -83,7 +83,7 @@ func testRun(t *testing.T, conf testRunConfig) map[string]*ast.Module {
 			`,
 		"/b_test.rego": `package bar
 			import rego.v1
-			
+
 			test_duplicate if { true }`,
 		"/c_test.rego": `package baz
 			import rego.v1
@@ -193,12 +193,12 @@ func TestRunWithFilterRegex(t *testing.T) {
 	files := map[string]string{
 		"/a.rego": `package foo
 			import rego.v1
-			
+
 			allow if { true }
 			`,
 		"/a_test.rego": `package foo
 			import rego.v1
-			
+
 			test_pass if { allow }
 			non_test if { true }
 			test_fail if { not allow }
@@ -214,11 +214,11 @@ func TestRunWithFilterRegex(t *testing.T) {
 			`,
 		"/b_test.rego": `package bar
 			import rego.v1
-			
+
 			test_duplicate if { true }`,
 		"/c_test.rego": `package baz
 			import rego.v1
-			
+
 			a.b.test_duplicate if { false }
 			a.b.test_duplicate if { true }
 			a.b.test_duplicate if { true }`,
@@ -536,7 +536,7 @@ func TestRunnerPrintOutput(t *testing.T) {
 			got[tr.Name] = string(tr.Output)
 		}
 
-		if !reflect.DeepEqual(exp, got) {
+		if !maps.Equal(exp, got) {
 			t.Fatal("expected:", exp, "got:", got)
 		}
 	})
@@ -633,7 +633,7 @@ func TestRunnerWithCustomBuiltin(t *testing.T) {
 			got[tr.Name] = tr.Pass()
 		}
 
-		if !reflect.DeepEqual(exp, got) {
+		if !maps.Equal(exp, got) {
 			t.Fatal("expected:", exp, "got:", got)
 		}
 	})
@@ -642,7 +642,7 @@ func TestRunnerWithCustomBuiltin(t *testing.T) {
 func TestRunnerWithBuiltinErrors(t *testing.T) {
 	const ruleTemplate = `package test
 	import rego.v1
-	
+
 	test_json_parsing if {
       x := json.unmarshal("%s")
 	  x.test == 123
@@ -716,8 +716,8 @@ func TestLoad_DefaultRegoVersion(t *testing.T) {
 			note: "v0 module", // NOT default rego-version
 			module: `package test
 
-p[x] { 
-	x = "a" 
+p[x] {
+	x = "a"
 }
 
 test_p {
@@ -734,8 +734,8 @@ test_p {
 			module: `package test
 import rego.v1
 
-p contains x if { 
-	x := "a" 
+p contains x if {
+	x := "a"
 }
 
 test_p if {
@@ -746,8 +746,8 @@ test_p if {
 			note: "v1 module", // default rego-version
 			module: `package test
 
-p contains x if { 
-	x := "a" 
+p contains x if {
+	x := "a"
 }
 
 test_p if {

--- a/v1/topdown/bindings_test.go
+++ b/v1/topdown/bindings_test.go
@@ -57,6 +57,8 @@ func TestBindingsArrayHashmap(t *testing.T) {
 }
 
 func testBindingKeys(t *testing.T, bindings *bindings, b *bindingsArrayHashmap, keys map[int]ast.Var) {
+	t.Helper()
+
 	for k := range keys {
 		value := testBindingValue(bindings, k)
 		if v, ok := b.Get(testBindingKey(k)); !ok {

--- a/v1/topdown/strings_bench_test.go
+++ b/v1/topdown/strings_bench_test.go
@@ -138,11 +138,91 @@ func BenchmarkSplit(b *testing.B) {
 	}
 }
 
+// Now down to 2 allocations per iteration for ASCII strings, more for non-ASCII as that requires
+// string/rune conversion. 2 allocations unavoidable - 1 for the new Term and 1 for its Value.
+func BenchmarkSubstring(b *testing.B) {
+	operands := []*ast.Term{
+		// insert any non-asci character to see the difference of that optimization
+		ast.StringTerm("The quick brown fox jumps over the lazy dog"),
+		ast.InternedIntNumberTerm(6),
+		ast.InternedIntNumberTerm(10),
+	}
+
+	iter := eqIter(ast.StringTerm("ick brown "))
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		if err := builtinSubstring(BuiltinContext{}, operands, iter); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// Unicode
+// BenchmarkIndexOf-10    	10498884	       114.0 ns/op	     176 B/op	       1 allocs/op
+//
+// ASCII
+// BenchmarkIndexOf-10    	36625468	        31.57 ns/op	       0 B/op	       0 allocs/op
+func BenchmarkIndexOf(b *testing.B) {
+	operands := []*ast.Term{
+		ast.StringTerm("The quick brown fox jumps over the lazy dog"),
+		ast.StringTerm("dog"),
+	}
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		if err := builtinIndexOf(BuiltinContext{}, operands, eqIter(ast.InternedIntNumberTerm(40))); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func eqIter(a *ast.Term) func(*ast.Term) error {
 	return func(b *ast.Term) error {
 		if !a.Equal(b) {
 			return fmt.Errorf("expected %v equal to %v", a, b)
 		}
 		return nil
+	}
+}
+
+// This benchmark is not so much about trimming space, but the optimization of returning
+// the operand as provided for string operations that don't change the string provided as
+// input, like when trimming space around a string that doesn't have any, or replacing a
+// substring that doesn't exist. Since string operations are often called in batch, this
+// win can be significant.
+//
+// BenchmarkTrimSpace/trimmable-10        14425539        85.10 ns/op      64 B/op       2 allocs/op
+// BenchmarkTrimSpace/not_trimmable-10    87051141        14.47 ns/op       0 B/op       0 allocs/op
+func BenchmarkTrimSpace(b *testing.B) {
+	bctx := BuiltinContext{}
+
+	cases := []struct {
+		input    string
+		operands []*ast.Term
+	}{
+		{
+			input:    "trimmable",
+			operands: []*ast.Term{ast.StringTerm("  The quick brown fox jumps over the lazy dog  ")},
+		},
+		{
+			input:    "not trimmable",
+			operands: []*ast.Term{ast.StringTerm("The quick brown fox jumps over the lazy dog")},
+		},
+	}
+
+	iter := eqIter(ast.StringTerm("The quick brown fox jumps over the lazy dog"))
+
+	for _, c := range cases {
+		b.Run(c.input, func(b *testing.B) {
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if err := builtinTrimSpace(bctx, c.operands, iter); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
 	}
 }

--- a/v1/topdown/topdown_test.go
+++ b/v1/topdown/topdown_test.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -181,7 +182,7 @@ func TestTopDownUnsupportedBuiltin(t *testing.T) {
 
 	expected := unsupportedBuiltinErr(body[0].Location)
 
-	if !reflect.DeepEqual(err, expected) {
+	if err.Error() != expected.Error() {
 		t.Fatalf("Expected %v but got: %v", expected, err)
 	}
 }
@@ -1552,7 +1553,7 @@ arr := [1, 2, 3, 4, 5]
 			}
 			sort.Strings(notes)
 			sort.Strings(tc.notes)
-			if !reflect.DeepEqual(notes, tc.notes) {
+			if !slices.Equal(notes, tc.notes) {
 				t.Errorf("unexpected note traces, expected %v, got %v", tc.notes, notes)
 			}
 			if exp, act := countExit, exits["early"]; exp != act {
@@ -1715,7 +1716,7 @@ func TestTopDownEvery(t *testing.T) {
 			notes := strings.Split(buf.String(), "\n")
 			notes = notes[:len(notes)-1] // last one is empty-string because each line ends in "\n"
 			if len(tc.notes) != 0 || len(tc.notes) == 0 && len(notes) != 0 {
-				if !reflect.DeepEqual(notes, tc.notes) {
+				if !slices.Equal(notes, tc.notes) {
 					t.Errorf("unexpected prints, expected %q, got %q", tc.notes, notes)
 				}
 			}

--- a/v1/topdown/trace_test.go
+++ b/v1/topdown/trace_test.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"maps"
 	"reflect"
 	"strings"
 	"testing"
@@ -1036,7 +1037,7 @@ func TestShortTraceFileNames(t *testing.T) {
 				t.Errorf("Expected longest location to be %d, got %d", tc.expectedLongest, actualLongest)
 			}
 
-			if !reflect.DeepEqual(actualNames, tc.expectedNames) {
+			if !maps.Equal(actualNames, tc.expectedNames) {
 				t.Errorf("Expected %+v got %+v", tc.expectedNames, actualNames)
 			}
 		})

--- a/v1/util/graph_test.go
+++ b/v1/util/graph_test.go
@@ -6,6 +6,7 @@ package util
 
 import (
 	"reflect"
+	"slices"
 	"testing"
 )
 
@@ -68,7 +69,7 @@ func TestDFSStop(t *testing.T) {
 
 	expected := []int{1, 3, 7, 6}
 
-	if !reflect.DeepEqual(expected, t1.ordered) {
+	if !slices.Equal(expected, t1.ordered) {
 		t.Fatalf("Expected DFS ordering %v but got: %v", expected, t1.ordered)
 	}
 }
@@ -93,7 +94,7 @@ func TestBFSStop(t *testing.T) {
 
 	expected := []int{1, 2, 3, 4}
 
-	if !reflect.DeepEqual(expected, t1.ordered) {
+	if !slices.Equal(expected, t1.ordered) {
 		t.Fatalf("Expected DFS ordering %v but got: %v", expected, t1.ordered)
 	}
 }
@@ -115,7 +116,7 @@ func TestDFS(t *testing.T) {
 
 	expected := []int{1, 3, 7, 6, 2, 5, 4}
 
-	if !reflect.DeepEqual(expected, t1.ordered) {
+	if !slices.Equal(expected, t1.ordered) {
 		t.Fatalf("Expected DFS ordering %v but got: %v", expected, t1.ordered)
 	}
 }
@@ -137,7 +138,7 @@ func TestBFS(t *testing.T) {
 
 	expected := []int{1, 2, 3, 4, 5, 6, 7}
 
-	if !reflect.DeepEqual(expected, t1.ordered) {
+	if !slices.Equal(expected, t1.ordered) {
 		t.Fatalf("Expected DFS ordering %v but got: %v", expected, t1.ordered)
 	}
 


### PR DESCRIPTION
And a few other small fixes in tests. This i not so much about performance but about choosing the best tool for a given task :) But that the alternatives are also faster doesn't hurt either.

Also a few benchmarks I forgot to include in the last PR.