### PR TITLE
eval: reduce allocations in hot path

### DIFF
--- a/v1/topdown/eval_test.go
+++ b/v1/topdown/eval_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -1648,5 +1649,43 @@ func TestContextErrorHandling(t *testing.T) {
 				t.Fatalf("Expected error to be of type %#v, but got %#v", et, err)
 			}
 		})
+	}
+}
+
+func TestFmtVarTerm(t *testing.T) {
+	e := &eval{
+		genvarprefix: "foobar",
+		queryID:      12345,
+		index:        54321,
+	}
+
+	res := e.fmtVarTerm()
+
+	if res != "foobar_term_12345_54321" {
+		t.Fatalf("Expected foobar_term_12345_54321 but got %s", res)
+	}
+
+	res = fmt.Sprintf("%s_term_%d_%d", e.genvarprefix, e.queryID, e.index)
+
+	if res != "foobar_term_12345_54321" {
+		t.Fatalf("Expected foobar_term_12345_54321 but got %s", res)
+	}
+}
+
+// Comparison with fmt.Sprintf:
+// fmt.sprintf        8093799   159.41 ns/op      56 B/op       4 allocs/op
+// formatVarTerm     20424126    50.95 ns/op      24 B/op       1 allocs/op
+func BenchmarkFormatVarTerm(b *testing.B) {
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	e := &eval{
+		genvarprefix: "foobar",
+		queryID:      12345,
+		index:        54321,
+	}
+
+	for i := 0; i < b.N; i++ {
+		_ = e.fmtVarTerm()
 	}
 }

--- a/v1/util/performance.go
+++ b/v1/util/performance.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"math"
 	"slices"
 	"unsafe"
 )
@@ -36,4 +37,28 @@ func ByteSliceToString(bs []byte) string {
 // Note that the byte slice must not be modified after conversion
 func StringToByteSlice[T ~string](s T) []byte {
 	return unsafe.Slice(unsafe.StringData(string(s)), len(s))
+}
+
+// NumDigitsInt returns the number of digits in n.
+// This is useful for pre-allocating buffers for string conversion.
+func NumDigitsInt(n int) int {
+	if n == 0 {
+		return 1
+	}
+
+	if n < 0 {
+		n = -n
+	}
+
+	return int(math.Log10(float64(n))) + 1
+}
+
+// NumDigitsUint returns the number of digits in n.
+// This is useful for pre-allocating buffers for string conversion.
+func NumDigitsUint(n uint64) int {
+	if n == 0 {
+		return 1
+	}
+
+	return int(math.Log10(float64(n))) + 1
 }


### PR DESCRIPTION
Another PR to reduce allocations, split up from my rather huge local changeset. Here are a few tricks to avoid heap allocations in the eval hotpath, mainly by not letting variables escape their scope, and to make sure we don't evaluate code for partial evaluation when that's not the mode we're running with.

About 3.3 million allocations less reported by the `regal lint bundle` benchmark.

**BenchmarkRegalLintingItself-10 before / after**
```
1822641834 ns/op    3464916080 B/op    66300871 allocs/op
1762596000 ns/op    3380345056 B/op    62983984 allocs/op
```