### PR TITLE
ci(nightly): remove vendor w/o modproxy check

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -81,26 +81,6 @@ jobs:
           status: ${{ job.status }}
           fields: repo,workflow
 
-  go-proxy-check:
-    name: Go mod check
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Check out code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - name: Vendor without proxy
-        run: make check-go-module
-        timeout-minutes: 30
-
-      - name: Slack Notification
-        uses: 8398a7/action-slack@28ba43ae48961b90635b50953d216767a6bea486 # v3.16.2
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_NOTIFICATION_WEBHOOK }}
-        if: ${{ failure() && env.SLACK_WEBHOOK_URL }}
-        with:
-          status: ${{ job.status }}
-          fields: repo,workflow
-
   trivy-scan-image:
     name: Trivy security scan image
     runs-on: ubuntu-22.04


### PR DESCRIPTION
The offending vanity import proxy probably won't get fixed anytime soon. Also, I kind of forgot why we had this check, so it can't be that important.
