### PR TITLE
opa bench: don't generate JSON from result

### DIFF
--- a/cmd/bench.go
+++ b/cmd/bench.go
@@ -164,6 +164,16 @@ func benchMain(args []string, params benchmarkCommandParams, w io.Writer, r benc
 		return 1, errRender
 	}
 
+	resultHandler := rego.GenerateJSON(func(*ast.Term, *rego.EvalContext) (interface{}, error) {
+		// Do nothing with the result, as we are only interested in benchmarking evaluation —
+		// not the potentially slow process of rendering the result.
+		// Undefined / empty results will still be handled normally (fail the benchmark unless --fail
+		// is set to false).
+		return nil, nil
+	})
+
+	ectx.regoArgs = append(ectx.regoArgs, resultHandler)
+
 	var benchFunc func(context.Context, ...rego.EvalOption) error
 	rg := rego.New(ectx.regoArgs...)
 

--- a/cmd/bench_test.go
+++ b/cmd/bench_test.go
@@ -477,6 +477,7 @@ func TestBenchMainWithNegativeCount(t *testing.T) {
 }
 
 func validateBenchMainPrep(t *testing.T, args []string, params benchmarkCommandParams) {
+	t.Helper()
 
 	var buf bytes.Buffer
 
@@ -496,8 +497,8 @@ func validateBenchMainPrep(t *testing.T, args []string, params benchmarkCommandP
 			return testing.BenchmarkResult{}, err
 		}
 
-		if !rs.Allowed() {
-			t.Errorf("Unexpected results: %+v", rs)
+		if len(rs) == 0 {
+			return testing.BenchmarkResult{}, fmt.Errorf("expected result, got none")
 		}
 
 		return testing.BenchmarkResult{}, nil


### PR DESCRIPTION
The numbers reported by `opa bench` would often be misleading, as they would include the cost of generating "JSON" (interface{}) values from the result.

**Before**
```
> opa bench 'numbers.range(1, 500)'
+-------------------------------------------+------------+
| samples                                   |      19736 |
| ns/op                                     |      61062 |
| B/op                                      |      65905 |
| allocs/op                                 |       1086 |
+-------------------------------------------+------------+
```

**After**
```
> opa bench 'numbers.range(1, 500)'
+-------------------------------------------+------------+
| samples                                   |      53263 |
| ns/op                                     |      21836 |
| B/op                                      |      12057 |
| allocs/op                                 |         63 |
+-------------------------------------------+------------+
```

Fixes #7291