### PR TITLE
repl: Fix printed represenation of ref head rules

### DIFF
--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -241,7 +241,7 @@ func populateAnnotations(out io.Writer, refs []*ast.AnnotationsRef) error {
 				fmt.Fprintln(out, "Package: ", dropDataPrefix(p.Path))
 			}
 			if r := ref.GetRule(); r != nil {
-				fmt.Fprintln(out, "Rule:    ", r.Head.Name)
+				fmt.Fprintln(out, "Rule:    ", r.Head.Ref().String())
 			}
 			if loc := ref.Location; loc != nil {
 				fmt.Fprintln(out, "Location:", loc.String())

--- a/v1/repl/repl.go
+++ b/v1/repl/repl.go
@@ -844,7 +844,7 @@ func (r *REPL) compileRule(ctx context.Context, rule *ast.Rule) error {
 		if unset {
 			msg = "re-defined"
 		}
-		fmt.Fprintf(r.output, "Rule '%v' %v in %v. Type 'show' to see rules.\n", rule.Head.Name, msg, mod.Package)
+		fmt.Fprintf(r.output, "Rule '%v' %v in %v. Type 'show' to see rules.\n", rule.Head.Ref().String(), msg, mod.Package)
 	}
 
 	return nil

--- a/v1/repl/repl_test.go
+++ b/v1/repl/repl_test.go
@@ -1029,6 +1029,19 @@ func TestOneShotEmptyBufferOneRule(t *testing.T) {
 	expectOutput(t, buffer.String(), "Rule 'p' defined in package repl. Type 'show' to see rules.\n")
 }
 
+func TestOneShotRefHeadRulePrinted(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore()
+	var buffer bytes.Buffer
+	repl := newRepl(store, &buffer)
+	repl.regoVersion = ast.RegoV1
+
+	if err := repl.OneShot(ctx, `foo.bar.baz if { true }`); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	expectOutput(t, buffer.String(), "Rule 'foo.bar.baz' defined in package repl. Type 'show' to see rules.\n")
+}
+
 func TestOneShotBufferedExpr(t *testing.T) {
 	ctx := context.Background()
 	store := newTestStore()


### PR DESCRIPTION
Also found a place in the inspect command code with the same issue, so fixed it there too.

Fixes #7301
