### PR TITLE
feat: support []string and ast.Value in ast.InterfaceToValue

### DIFF
--- a/v1/ast/term.go
+++ b/v1/ast/term.go
@@ -56,13 +56,12 @@ type Value interface {
 // InterfaceToValue converts a native Go value x to a Value.
 func InterfaceToValue(x interface{}) (Value, error) {
 	switch x := x.(type) {
+	case Value:
+		return x, nil
 	case nil:
 		return NullValue, nil
 	case bool:
-		if x {
-			return InternedBooleanTerm(true).Value, nil
-		}
-		return InternedBooleanTerm(false).Value, nil
+		return InternedBooleanTerm(x).Value, nil
 	case json.Number:
 		if interned := InternedIntNumberTermFromString(string(x)); interned != nil {
 			return interned.Value, nil
@@ -86,6 +85,12 @@ func InterfaceToValue(x interface{}) (Value, error) {
 				return nil, err
 			}
 			r[i].Value = e
+		}
+		return NewArray(r...), nil
+	case []string:
+		r := util.NewPtrSlice[Term](len(x))
+		for i, e := range x {
+			r[i].Value = String(e)
 		}
 		return NewArray(r...), nil
 	case map[string]any:

--- a/v1/ast/term_test.go
+++ b/v1/ast/term_test.go
@@ -29,6 +29,7 @@ func TestInterfaceToValue(t *testing.T) {
 			null,
 			"hello",
 			["goodbye", 1],
+			["dummy", "tummy"],
 			{"y": 3.1}
 		]
 	}
@@ -73,6 +74,8 @@ func TestInterfaceToValue(t *testing.T) {
 		{int(100), "100"},
 		{map[string]string{"foo": "bar"}, `{"foo": "bar"}`},
 		{uint64(100), "100"},
+		{[]string{"dummy", "tummy"}, `["dummy", "tummy"]`},
+		{String("bob"), `"bob"`},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.
  (See the [Developer Certificate of Origin](https://www.openpolicyagent.org/docs/latest/contrib-code/#developer-certificate-of-origin)
  section for specifics on signing off a commit.)

-->

### Why the changes in this PR are needed?

1. `ast.InterfaceToValue` walks through json encode/decode for the native `ast.Value` type. It doesn't make sense as far as the function returns `ast.Value`.
2. Regarding `[]string` case, it reduces the number of iterations

### What are the changes in this PR?

<!--
Include a short description of WHAT changes were made.
-->
Updates in `ast.InterfaceToValue` function.

### Notes to assist PR review:

<!--
Here you can add information you think will help the reviewer(s).
-->

### Further comments:

<!--
Here you can include links to additional resources related to the changes, discuss your solution, other approaches you considered etc.
-->
