### PR TITLE
Eliminate allocation in Value.Find

### DIFF
--- a/v1/ast/interning.go
+++ b/v1/ast/interning.go
@@ -17,6 +17,9 @@ var (
 	minusOneTerm = &Term{Value: Number("-1")}
 
 	InternedNullTerm = &Term{Value: Null{}}
+
+	InternedEmptyString = StringTerm("")
+	InternedEmptyObject = ObjectTerm()
 )
 
 // InternedBooleanTerm returns an interned term with the given boolean value.
@@ -1092,7 +1095,3 @@ var intNumberTerms = [...]*Term{
 	{Value: Number("511")},
 	{Value: Number("512")},
 }
-
-var InternedEmptyString = StringTerm("")
-
-var InternedEmptyObject = ObjectTerm()

--- a/v1/ast/syncpools.go
+++ b/v1/ast/syncpools.go
@@ -1,0 +1,47 @@
+package ast
+
+import (
+	"strings"
+	"sync"
+)
+
+type termPtrPool struct {
+	pool sync.Pool
+}
+
+type stringBuilderPool struct {
+	pool sync.Pool
+}
+
+func (p *termPtrPool) Get() *Term {
+	return p.pool.Get().(*Term)
+}
+
+func (p *termPtrPool) Put(t *Term) {
+	p.pool.Put(t)
+}
+
+func (p *stringBuilderPool) Get() *strings.Builder {
+	return p.pool.Get().(*strings.Builder)
+}
+
+func (p *stringBuilderPool) Put(sb *strings.Builder) {
+	sb.Reset()
+	p.pool.Put(sb)
+}
+
+var TermPtrPool = &termPtrPool{
+	pool: sync.Pool{
+		New: func() any {
+			return &Term{}
+		},
+	},
+}
+
+var sbPool = &stringBuilderPool{
+	pool: sync.Pool{
+		New: func() any {
+			return &strings.Builder{}
+		},
+	},
+}

--- a/v1/storage/internal/ptr/ptr.go
+++ b/v1/storage/internal/ptr/ptr.go
@@ -43,8 +43,15 @@ func ValuePtr(data ast.Value, path storage.Path) (ast.Value, error) {
 		key := path[i]
 		switch curr := node.(type) {
 		case ast.Object:
-			keyTerm := ast.StringTerm(key)
+			// This term is only created for the lookup, which is not.. ideal.
+			// By using the pool, we can at least avoid allocating the term itself,
+			// while still having to pay 1 allocation for the value. A better solution
+			// would be dynamically interned string terms.
+			keyTerm := ast.TermPtrPool.Get()
+			keyTerm.Value = ast.String(key)
+
 			val := curr.Get(keyTerm)
+			ast.TermPtrPool.Put(keyTerm)
 			if val == nil {
 				return nil, errors.NewNotFoundError(path)
 			}

--- a/v1/topdown/cache.go
+++ b/v1/topdown/cache.go
@@ -153,6 +153,12 @@ func (c *baseCache) Get(ref ast.Ref) ast.Value {
 		if node == nil {
 			return nil
 		} else if node.value != nil {
+			if len(ref) == 1 && ast.IsScalar(node.value) {
+				// If the node is a scalar, return the value directly
+				// and avoid an allocation when calling Find.
+				return node.value
+			}
+
 			result, err := node.value.Find(ref[i+1:])
 			if err != nil {
 				return nil


### PR DESCRIPTION
Mostly just some things I improved as I learnt more about how the storage system works. Reducing some allocations, and just general improvements.

- Move some sync.Pool's to a common location
- Allow object.Map to skip items when mapper returns nil key
- Eliminate allocation in object.Find and array.Find when a scalar is encountered.
- Use term pointer pool for temporary terms created only for the sake of calling object.Get in ptr.go