### PR TITLE
Go API: Allow providing custom base cache

### DIFF
--- a/v1/topdown/cache.go
+++ b/v1/topdown/cache.go
@@ -32,6 +32,12 @@ type VirtualCache interface {
 	Keys() []ast.Ref
 }
 
+// BaseCache defines the interface for a cache that stores cached base documents, i.e. data.
+type BaseCache interface {
+	Get(ast.Ref) ast.Value
+	Put(ast.Ref, ast.Value)
+}
+
 type virtualCache struct {
 	stack []*virtualCacheElem
 }

--- a/v1/topdown/eval.go
+++ b/v1/topdown/eval.go
@@ -72,6 +72,7 @@ type eval struct {
 	store                       storage.Store
 	txn                         storage.Transaction
 	virtualCache                VirtualCache
+	baseCache                   BaseCache
 	interQueryBuiltinCache      cache.InterQueryCache
 	interQueryBuiltinValueCache cache.InterQueryValueCache
 	printHook                   print.Hook
@@ -80,7 +81,6 @@ type eval struct {
 	parent                      *eval
 	caller                      *eval
 	bindings                    *bindings
-	baseCache                   *baseCache
 	compiler                    *ast.Compiler
 	input                       *ast.Term
 	data                        *ast.Term

--- a/v1/topdown/resolver.go
+++ b/v1/topdown/resolver.go
@@ -48,7 +48,11 @@ func (t *resolverTrie) Resolve(e *eval, ref ast.Ref) (ast.Value, error) {
 				Input:   e.input,
 				Metrics: e.metrics,
 			}
-			e.traceWasm(e.query[e.index], &in.Ref)
+			if e.traceEnabled {
+				// avoid leaking pointer if trace is disabled
+				cpy := in.Ref
+				e.traceWasm(e.query[e.index], &cpy)
+			}
 			if e.data != nil {
 				return nil, errInScopeWithStmt
 			}
@@ -75,7 +79,10 @@ func (t *resolverTrie) Resolve(e *eval, ref ast.Ref) (ast.Value, error) {
 
 func (t *resolverTrie) mktree(e *eval, in resolver.Input) (ast.Value, error) {
 	if t.r != nil {
-		e.traceWasm(e.query[e.index], &in.Ref)
+		if e.traceEnabled {
+			cpy := in.Ref
+			e.traceWasm(e.query[e.index], &cpy)
+		}
 		if e.data != nil {
 			return nil, errInScopeWithStmt
 		}


### PR DESCRIPTION
The same way it's possible to provide a VirtualCache, it should be possible to bring your own BaseCache. In clients like Regal (when invoked via `regal lint`), the base data is only ever loaded once and doesn't change later. Yet currently, each evaluation (of which there are hundreds) will have a new cache instantiated, leading to unnecessary cache misses.

Since our inmem-store is AST-based, we could also try to have the base cache tap directly into the store for a 100% hit ratio, avoiding the more costly storage queries. But that's still untested this point 🤓
 
(The tiny changes in resolver.go are unrelated to this feature but fix a perf issue I noticed last night as I was testing that functionality. Too small fix to warrant a PR of its own.)