### PR TITLE
Use byte for RuleKind and DocKind

### DIFF
--- a/ast/policy.go
+++ b/ast/policy.go
@@ -184,7 +184,7 @@ func RefHead(ref Ref, args ...*Term) *Head {
 }
 
 // DocKind represents the collection of document types that can be produced by rules.
-type DocKind int
+type DocKind = v1.DocKind
 
 const (
 	// CompleteDoc represents a document that is completely defined by the rule.

--- a/v1/ast/index.go
+++ b/v1/ast/index.go
@@ -33,10 +33,10 @@ type RuleIndex interface {
 
 // IndexResult contains the result of an index lookup.
 type IndexResult struct {
-	Kind           RuleKind
 	Rules          []*Rule
 	Else           map[*Rule][]*Rule
 	Default        *Rule
+	Kind           RuleKind
 	EarlyExit      bool
 	OnlyGroundRefs bool
 }

--- a/v1/ast/policy.go
+++ b/v1/ast/policy.go
@@ -892,7 +892,7 @@ func RefHead(ref Ref, args ...*Term) *Head {
 }
 
 // DocKind represents the collection of document types that can be produced by rules.
-type DocKind int
+type DocKind byte
 
 const (
 	// CompleteDoc represents a document that is completely defined by the rule.
@@ -916,7 +916,7 @@ func (head *Head) DocKind() DocKind {
 	return CompleteDoc
 }
 
-type RuleKind int
+type RuleKind byte
 
 const (
 	SingleValue = iota


### PR DESCRIPTION
Saving 7 bytes per index result. Not much, but adds up to ~10Mb in the `regal lint` benchmark. Changing the underlying type is technically a breaking change I suppose, but in the unlikely case anyone used this outside of OPA (we barely use it ourselves!), they'd still have to do and int() conversion to work with it as an int, which will still work.