### PR TITLE
Improve storage lookup performance

### DIFF
--- a/v1/storage/inmem/test/testutil.go
+++ b/v1/storage/inmem/test/testutil.go
@@ -20,3 +20,9 @@ func New() storage.Store {
 func NewFromObject(x map[string]interface{}) storage.Store {
 	return inmem.NewFromObjectWithOpts(x, inmem.OptRoundTripOnWrite(false))
 }
+
+// NewFromObjectWithASTRead returns an inmem store from the passed object, with
+// round-trip on write disabled and AST values returned on read.
+func NewFromObjectWithASTRead(x map[string]interface{}) storage.Store {
+	return inmem.NewFromObjectWithOpts(x, inmem.OptRoundTripOnWrite(false), inmem.OptReturnASTValuesOnRead(true))
+}

--- a/v1/storage/internal/errors/errors.go
+++ b/v1/storage/internal/errors/errors.go
@@ -20,7 +20,11 @@ func NewNotFoundError(path storage.Path) *storage.Error {
 }
 
 func NewNotFoundErrorWithHint(path storage.Path, hint string) *storage.Error {
-	return NewNotFoundErrorf("%v: %v", path.String(), hint)
+	message := path.String() + ": " + hint
+	return &storage.Error{
+		Code:    storage.NotFoundErr,
+		Message: message,
+	}
 }
 
 func NewNotFoundErrorf(f string, a ...interface{}) *storage.Error {

--- a/v1/storage/internal/errors/errors_test.go
+++ b/v1/storage/internal/errors/errors_test.go
@@ -1,0 +1,22 @@
+package errors
+
+import (
+	"testing"
+
+	"github.com/open-policy-agent/opa/v1/storage"
+)
+
+// 160.8 ns/op    96 B/op    5 allocs/op    // using fmt.Sprintf
+// 58.31 ns/op     8 B/op    1 allocs/op    // using string concatenation
+// ...
+func BenchmarkNewNotFoundErrorWithHint(b *testing.B) {
+	path := storage.Path([]string{"a", "b", "c"})
+	hint := "something something"
+
+	for range b.N {
+		err := NewNotFoundErrorWithHint(path, hint)
+		if err == nil {
+			b.Fatal("expected error")
+		}
+	}
+}

--- a/v1/storage/path.go
+++ b/v1/storage/path.go
@@ -133,11 +133,22 @@ func (p Path) Ref(head *ast.Term) (ref ast.Ref) {
 }
 
 func (p Path) String() string {
-	buf := make([]string, len(p))
-	for i := range buf {
-		buf[i] = url.PathEscape(p[i])
+	if len(p) == 0 {
+		return "/"
 	}
-	return "/" + strings.Join(buf, "/")
+
+	l := 0
+	for i := range p {
+		l += len(p[i]) + 1
+	}
+
+	sb := strings.Builder{}
+	sb.Grow(l)
+	for i := range p {
+		sb.WriteByte('/')
+		sb.WriteString(url.PathEscape(p[i]))
+	}
+	return sb.String()
 }
 
 // MustParsePath returns a new Path for s. If s cannot be parsed, this function

--- a/v1/storage/path_test.go
+++ b/v1/storage/path_test.go
@@ -192,3 +192,17 @@ func TestPathRef(t *testing.T) {
 		}
 	}
 }
+
+// 108.8 ns/op    80 B/op    3 allocs/op // original implementation concat + Join
+// 68.60 ns/op    24 B/op    2 allocs/op // strings.Builder
+// 50.28 ns/op    16 B/op    1 allocs/op // strings.Builder with pre-allocated buffer
+func BenchmarkPathString(b *testing.B) {
+	path := Path{"foo", "bar", "baz"}
+
+	for range b.N {
+		res := path.String()
+		if res != "/foo/bar/baz" {
+			b.Fatal("unexpected result:", res)
+		}
+	}
+}

--- a/v1/topdown/eval.go
+++ b/v1/topdown/eval.go
@@ -1788,16 +1788,7 @@ func (e *eval) resolveReadFromStorage(ref ast.Ref, a ast.Value) (ast.Value, erro
 				}
 			case ast.Object:
 				if obj.Len() > 0 {
-					cpy := ast.NewObject()
-					if err := obj.Iter(func(k *ast.Term, v *ast.Term) error {
-						if !ast.SystemDocumentKey.Equal(k.Value) {
-							cpy.Insert(k, v)
-						}
-						return nil
-					}); err != nil {
-						return nil, err
-					}
-					blob = cpy
+					blob, _ = obj.Map(systemDocumentKeyRemoveMapper)
 				}
 			}
 		}
@@ -1828,6 +1819,13 @@ func (e *eval) resolveReadFromStorage(ref ast.Ref, a ast.Value) (ast.Value, erro
 	}
 
 	return merged, nil
+}
+
+func systemDocumentKeyRemoveMapper(k, v *ast.Term) (*ast.Term, *ast.Term, error) {
+	if ast.SystemDocumentKey.Equal(k.Value) {
+		return nil, nil, nil
+	}
+	return k, v, nil
 }
 
 func (e *eval) generateVar(suffix string) *ast.Term {


### PR DESCRIPTION
Some code I had left from the weekend, where I looked into the cost of querying the store during eval, and if that could be improved. The code here is mostly benchmarks that I found useful for that purpose, but also includes a few optimizations of code that is on the hot path for these lookups and as such has a high impact — as the benchmarks demonstrate.

The small change in eval.go is the first use of the new feature of object.Map added some days ago, where a map function returning a nil key means skipping that key/value pair.