### PR TITLE
docs: Updating `--v1-compatible` mentions

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -182,9 +182,10 @@ OPA will automatically perform type checking based on a schema inferred from kno
 resulting from the schema check. Currently this check is performed on OPA's Authorization Policy Input document and will
 be expanded in the future. To disable this, use the --skip-known-schema-check flag.
 
-The --v1-compatible flag can be used to opt-in to OPA features and behaviors that will be enabled by default in a future OPA v1.0 release.
-Current behaviors enabled by this flag include:
-- setting OPA's listening address to "localhost:8181" by default.
+The --v0-compatible flag can be used to opt-in to OPA features and behaviors that were the default in OPA v0.x.
+Behaviors enabled by this flag include:
+- setting OPA's listening address to ":8181" by default, corresponding to listening on every network interface.
+- expecting v0 Rego syntax in policy modules instead of the default v1 Rego syntax.
 
 The --tls-cipher-suites flag can be used to specify the list of enabled TLS 1.0–1.2 cipher suites. Note that TLS 1.3
 cipher suites are not configurable. Following are the supported TLS 1.0 - 1.2 cipher suites (IANA):

--- a/docs/content/cli.md
+++ b/docs/content/cli.md
@@ -887,9 +887,10 @@ OPA will automatically perform type checking based on a schema inferred from kno
 resulting from the schema check. Currently this check is performed on OPA's Authorization Policy Input document and will
 be expanded in the future. To disable this, use the --skip-known-schema-check flag.
 
-The --v1-compatible flag can be used to opt-in to OPA features and behaviors that will be enabled by default in a future OPA v1.0 release.
-Current behaviors enabled by this flag include:
-- setting OPA's listening address to "localhost:8181" by default.
+The --v0-compatible flag can be used to opt-in to OPA features and behaviors that were the default in OPA v0.x.
+Behaviors enabled by this flag include:
+- setting OPA's listening address to ":8181" by default, corresponding to listening on every network interface.
+- expecting v0 Rego syntax in policy modules instead of the default v1 Rego syntax.
 
 The --tls-cipher-suites flag can be used to specify the list of enabled TLS 1.0–1.2 cipher suites. Note that TLS 1.3
 cipher suites are not configurable. Following are the supported TLS 1.0 - 1.2 cipher suites (IANA):

--- a/docs/content/management-bundles.md
+++ b/docs/content/management-bundles.md
@@ -214,18 +214,18 @@ fields:
   `string` value that identifies the bundle revision.
 
 * `rego_version` - An optional field that specifies the rego-version of the Rego source files
-  in the bundle. The value of this field is an `integer`; where `0` corresponds to v0 Rego (current OPA v0.x syntax), 
-  and `1` corresponds to v1 Rego ([OPA v1.0](../opa-1/) syntax).
-  If the field is not included in the manifest, OPA will enforce v0 syntax, or v1 if executed with
-  the `--v1-compatible` flag.
-  An existing bundle `rego_version` field takes precedence to the `--v1-compatible` flag.
+  in the bundle. The value of this field is an `integer`; where `0` corresponds to v0 Rego ([OPA v0.x](../v0-compatibility/) syntax), 
+  and `1` corresponds to v1 Rego (current OPA v1.x syntax).
+  If the field is not included in the manifest, OPA will enforce v1 syntax, or v0 if executed with
+  the `--v0-compatible` flag.
+  An existing bundle `rego_version` field takes precedence to the `--v0-compatible` flag.
 
 * `file_rego_versions` - An optional field that specifies per-file rego-version overrides to the 
   `rego_version` field. The value of this field is a `map` where the keys are file paths relative to the
   bundle root directory (paths are absolute and start with `/`) and the values are `integer` rego-versions.
   Glob patterns are accepted, to allow for a single entry to apply to multiple files. The behaviour is undefined 
   for overlapping patterns. If a file is not matched by any pattern, the `rego_version` field is used.
-  Existing bundle `rego_version` and `file_rego_versions` fields takes precedence to the `--v1-compatible` flag.
+  Existing bundle `rego_version` and `file_rego_versions` fields takes precedence to the `--v0-compatible` flag.
 
 * `roots` - If you expect to load additional data into OPA from outside the
   bundle (e.g., via OPA's HTTP API) you should include a top-level


### PR DESCRIPTION
outside the v1 upgrade guide and v0 compatibility docs to describe `--v0-compatible` behaviour instead.

