### PR TITLE
bundle: Fixing issue where `--v0-compatible` isn't respected for custom bundles

### DIFF
--- a/v1/bundle/bundle.go
+++ b/v1/bundle/bundle.go
@@ -718,6 +718,7 @@ func (r *Reader) Read() (Bundle, error) {
 		if regoVersion, err := bundle.RegoVersionForFile(mf.RelativePath, popts.EffectiveRegoVersion()); err != nil {
 			return bundle, err
 		} else if regoVersion != ast.RegoUndefined {
+			// We don't expect ast.RegoUndefined here, but don't override configured rego-version if we do just to be extra protective
 			modulePopts.RegoVersion = regoVersion
 		}
 		r.metrics.Timer(metrics.RegoModuleParse).Start()

--- a/v1/bundle/store.go
+++ b/v1/bundle/store.go
@@ -827,7 +827,7 @@ func writeModuleRegoVersionToStore(ctx context.Context, store storage.Store, txn
 
 	if regoVersion == ast.RegoUndefined {
 		var err error
-		regoVersion, err = b.RegoVersionForFile(mf.Path, ast.RegoUndefined)
+		regoVersion, err = b.RegoVersionForFile(mf.Path, runtimeRegoVersion)
 		if err != nil {
 			return fmt.Errorf("failed to get rego version for module '%s' in bundle: %w", mf.Path, err)
 		}

--- a/v1/bundle/store_test.go
+++ b/v1/bundle/store_test.go
@@ -722,6 +722,106 @@ func TestBundleLifecycle_ModuleRegoVersions(t *testing.T) {
 								}
 							}`,
 				},
+				activation{
+					bundles: bundles{
+						"bundle1": {
+							{"/.manifest", `{"roots": ["a"]}`},
+							{"a/policy.rego", `package a
+								p contains 1337 if { true }`},
+						},
+					},
+					lazy:               true,
+					readWithBundleName: true,
+					expData: `{
+								"system":{
+									"bundles":{"bundle1":{"etag":"bar","manifest":{"revision":"","roots":["a"]}}}
+								}
+							}`,
+				},
+				deactivation{
+					bundles: map[string]struct{}{"bundle1": {}},
+					expData: `{"system":{"bundles":{}}}`,
+				},
+			},
+		},
+		{
+			note:               "custom bundle without rego-version, lazy, v1 runtime (explicit)",
+			runtimeRegoVersion: ast.RegoV1,
+			updates: []interface{}{
+				activation{
+					bundles: bundles{
+						"bundle1": {
+							{"/.manifest", `{"roots": ["a"]}`},
+							{"a/policy.rego", `package a
+								p contains 42 if { true }`},
+						},
+					},
+					lazy:               true,
+					readWithBundleName: true,
+					expData: `{
+								"system":{
+									"bundles":{"bundle1":{"etag":"bar","manifest":{"revision":"","roots":["a"]}}}
+								}
+							}`,
+				},
+				activation{
+					bundles: bundles{
+						"bundle1": {
+							{"/.manifest", `{"roots": ["a"]}`},
+							{"a/policy.rego", `package a
+								p contains 1337 if { true }`},
+						},
+					},
+					lazy:               true,
+					readWithBundleName: true,
+					expData: `{
+								"system":{
+									"bundles":{"bundle1":{"etag":"bar","manifest":{"revision":"","roots":["a"]}}}
+								}
+							}`,
+				},
+				deactivation{
+					bundles: map[string]struct{}{"bundle1": {}},
+					expData: `{"system":{"bundles":{}}}`,
+				},
+			},
+		},
+		{
+			note:               "custom bundle without rego-version, lazy, --v0-compatible",
+			runtimeRegoVersion: ast.RegoV0,
+			updates: []interface{}{
+				activation{
+					bundles: bundles{
+						"bundle1": {
+							{"/.manifest", `{"roots": ["a"]}`},
+							{"a/policy.rego", `package a
+								p[42] { true }`},
+						},
+					},
+					lazy:               true,
+					readWithBundleName: true,
+					expData: `{
+								"system":{
+									"bundles":{"bundle1":{"etag":"bar","manifest":{"revision":"","roots":["a"]}}}
+								}
+							}`,
+				},
+				activation{
+					bundles: bundles{
+						"bundle1": {
+							{"/.manifest", `{"roots": ["a"]}`},
+							{"a/policy.rego", `package a
+								p[1337] { true }`},
+						},
+					},
+					lazy:               true,
+					readWithBundleName: true,
+					expData: `{
+								"system":{
+									"bundles":{"bundle1":{"etag":"bar","manifest":{"revision":"","roots":["a"]}}}
+								}
+							}`,
+				},
 				deactivation{
 					bundles: map[string]struct{}{"bundle1": {}},
 					expData: `{"system":{"bundles":{}}}`,
@@ -2258,11 +2358,6 @@ func TestBundleLazyModeLifecycleRawNoBundleRoots(t *testing.T) {
 				},
 				"etag": "foo"
 			}
-		},
-		"modules":{
-			"example/example.rego":{
-				"rego_version":1
-			}
 		}
 	}
 }
@@ -2455,11 +2550,6 @@ func TestBundleLazyModeLifecycleRawNoBundleRootsDiskStorage(t *testing.T) {
 				},
 				"etag": "foo"
 			}
-		},
-		"modules":{
-			"example/example.rego":{
-				"rego_version":1
-			}
 		}
 	}
 }
@@ -2632,12 +2722,7 @@ func TestBundleLazyModeLifecycleNoBundleRoots(t *testing.T) {
                   },
                   "etag": ""
                }
-            },
-			"modules":{
-				"bundle1/a/policy.rego":{
-					"rego_version":1
-				}
-			}
+            }
          }
       }`
 
@@ -2847,12 +2932,7 @@ func TestBundleLazyModeLifecycleNoBundleRootsDiskStorage(t *testing.T) {
                   },
                   "etag": ""
                }
-            },
-			"modules":{
-				"bundle1/a/policy.rego":{
-					"rego_version":1
-				}
-			}
+            }
          }
       }`
 
@@ -3085,12 +3165,7 @@ func TestBundleLazyModeLifecycleMixBundleTypeActivationDiskStorage(t *testing.T)
                   },
                   "etag": ""
                }
-            },
-			"modules":{
-				"bundle1/a/policy.rego":{
-					"rego_version":1
-				}
-			}
+            }
          }
       }`
 
@@ -3222,12 +3297,7 @@ func TestBundleLazyModeLifecycleOldBundleEraseDiskStorage(t *testing.T) {
                   },
                   "etag": ""
                }
-            },
-			"modules":{
-				"bundle1/a/policy.rego":{
-					"rego_version":1
-				}
-			}
+            }
          }
       }`
 
@@ -3439,12 +3509,7 @@ func TestBundleLazyModeLifecycleRestoreBackupDB(t *testing.T) {
                   },
                   "etag": ""
                }
-            },
-			"modules":{
-				"bundle1/a/policy.rego":{
-					"rego_version":1
-				}
-			}
+            }
          }
       }`
 
@@ -3523,12 +3588,7 @@ func TestBundleLazyModeLifecycleRestoreBackupDB(t *testing.T) {
                   },
                   "etag": ""
                }
-            },
-			"modules":{
-				"bundle1/a/policy.rego":{
-					"rego_version":1
-				}
-			}
+            }
          }
       }`
 
@@ -3813,14 +3873,6 @@ func TestDeltaBundleLazyModeLifecycleDiskStorage(t *testing.T) {
 							"roots": ["d"]
 						},
 						"etag": ""
-					}
-				},
-				"modules":{
-					"bundle1/a/policy.rego":{
-						"rego_version":1
-					},
-					"bundle2/b/policy.rego":{
-						"rego_version":1
 					}
 				}
 			}
@@ -4683,14 +4735,6 @@ func TestDeltaBundleLazyModeLifecycle(t *testing.T) {
 					},
 					"etag": ""
 				}
-			},
-			"modules":{
-				"bundle1/policy.rego":{
-					"rego_version":1
-				},
-				"bundle2/policy.rego":{
-					"rego_version":1
-				}
 			}
 		}
 	}`
@@ -4980,14 +5024,6 @@ func TestDeltaBundleLazyModeWithDefaultRules(t *testing.T) {
 						"roots": ["d"]
 					},
 					"etag": ""
-				}
-			},
-			"modules":{
-				"bundle1/policy.rego":{
-					"rego_version":1
-				},
-				"bundle2/policy.rego":{
-					"rego_version":1
 				}
 			}
 		}

--- a/v1/bundle/store_test.go
+++ b/v1/bundle/store_test.go
@@ -830,6 +830,132 @@ func TestBundleLifecycle_ModuleRegoVersions(t *testing.T) {
 		},
 
 		{
+			note: "custom bundle without rego-version, not lazy",
+			updates: []interface{}{
+				activation{
+					bundles: bundles{
+						"bundle1": {
+							{"/.manifest", `{"roots": ["a"]}`},
+							{"a/policy.rego", `package a
+								p contains 42 if { true }`},
+						},
+					},
+					lazy:               false,
+					readWithBundleName: true,
+					expData: `{
+								"system":{
+									"bundles":{"bundle1":{"etag":"bar","manifest":{"revision":"","roots":["a"]}}}
+								}
+							}`,
+				},
+				activation{
+					bundles: bundles{
+						"bundle1": {
+							{"/.manifest", `{"roots": ["a"]}`},
+							{"a/policy.rego", `package a
+								p contains 1337 if { true }`},
+						},
+					},
+					lazy:               false,
+					readWithBundleName: true,
+					expData: `{
+								"system":{
+									"bundles":{"bundle1":{"etag":"bar","manifest":{"revision":"","roots":["a"]}}}
+								}
+							}`,
+				},
+				deactivation{
+					bundles: map[string]struct{}{"bundle1": {}},
+					expData: `{"system":{"bundles":{}}}`,
+				},
+			},
+		},
+		{
+			note:               "custom bundle without rego-version, not lazy, v1 runtime (explicit)",
+			runtimeRegoVersion: ast.RegoV1,
+			updates: []interface{}{
+				activation{
+					bundles: bundles{
+						"bundle1": {
+							{"/.manifest", `{"roots": ["a"]}`},
+							{"a/policy.rego", `package a
+								p contains 42 if { true }`},
+						},
+					},
+					lazy:               false,
+					readWithBundleName: true,
+					expData: `{
+								"system":{
+									"bundles":{"bundle1":{"etag":"bar","manifest":{"revision":"","roots":["a"]}}}
+								}
+							}`,
+				},
+				activation{
+					bundles: bundles{
+						"bundle1": {
+							{"/.manifest", `{"roots": ["a"]}`},
+							{"a/policy.rego", `package a
+								p contains 1337 if { true }`},
+						},
+					},
+					lazy:               false,
+					readWithBundleName: true,
+					expData: `{
+								"system":{
+									"bundles":{"bundle1":{"etag":"bar","manifest":{"revision":"","roots":["a"]}}}
+								}
+							}`,
+				},
+				deactivation{
+					bundles: map[string]struct{}{"bundle1": {}},
+					expData: `{"system":{"bundles":{}}}`,
+				},
+			},
+		},
+		{
+			note:               "custom bundle without rego-version, not lazy, --v0-compatible",
+			runtimeRegoVersion: ast.RegoV0,
+			updates: []interface{}{
+				activation{
+					bundles: bundles{
+						"bundle1": {
+							{"/.manifest", `{"roots": ["a"]}`},
+							{"a/policy.rego", `package a
+								p[42] { true }`},
+						},
+					},
+					lazy:               false,
+					readWithBundleName: true,
+					expData: `{
+								"system":{
+									"bundles":{"bundle1":{"etag":"bar","manifest":{"revision":"","roots":["a"]}}}
+								}
+							}`,
+				},
+				activation{
+					bundles: bundles{
+						"bundle1": {
+							{"/.manifest", `{"roots": ["a"]}`},
+							{"a/policy.rego", `package a
+								p[1337] { true }`},
+						},
+					},
+					lazy:               false,
+					readWithBundleName: true,
+					expData: `{
+								"system":{
+									"bundles":{"bundle1":{"etag":"bar","manifest":{"revision":"","roots":["a"]}}}
+								}
+							}`,
+				},
+				deactivation{
+					bundles: map[string]struct{}{"bundle1": {}},
+					expData: `{"system":{"bundles":{}}}`,
+				},
+			},
+		},
+
+		{
 			note: "v0, lazy replaced by non-lazy",
 			updates: []interface{}{
 				activation{

--- a/v1/plugins/bundle/plugin_test.go
+++ b/v1/plugins/bundle/plugin_test.go
@@ -109,8 +109,7 @@ func TestPluginOneShot(t *testing.T) {
 	expData := util.MustUnmarshalJSON([]byte(`{
 		"foo": {"bar": 1, "baz": "qux"},
 		"system": {
-			"bundles": {"test-bundle": {"etag": "foo", "manifest": {"revision": "quickbrownfaux", "roots": [""]}}},
-			"modules": {"test-bundle/foo/bar": {"rego_version": 1}}
+			"bundles": {"test-bundle": {"etag": "foo", "manifest": {"revision": "quickbrownfaux", "roots": [""]}}}
 		}
 	}`))
 	if err != nil {
@@ -970,8 +969,7 @@ func TestPluginStartLazyLoadInMem(t *testing.T) {
 			expected := `{
 				"p": "x1", "q": "x2",
 				"system": {
-					"bundles": {"test-1": {"etag": "", "manifest": {"revision": "", "roots": ["p", "authz"]}}, "test-2": {"etag": "", "manifest": {"revision": "", "roots": ["q"]}}},
-					"modules": {"test-1/bar/policy.rego": {"rego_version": 1}}
+					"bundles": {"test-1": {"etag": "", "manifest": {"revision": "", "roots": ["p", "authz"]}}, "test-2": {"etag": "", "manifest": {"revision": "", "roots": ["q"]}}}
 				}
 			}`
 			if rm.readAst {
@@ -1040,11 +1038,11 @@ func TestPluginOneShotDiskStorageMetrics(t *testing.T) {
 			t.Errorf("%s: expected %v, got %v", name, exp, act)
 		}
 		name = "disk_written_keys"
-		if exp, act := 7, met.Counter(name).Value(); act.(uint64) != uint64(exp) {
+		if exp, act := 6, met.Counter(name).Value(); act.(uint64) != uint64(exp) {
 			t.Errorf("%s: expected %v, got %v", name, exp, act)
 		}
 		name = "disk_read_keys"
-		if exp, act := 14, met.Counter(name).Value(); act.(uint64) != uint64(exp) {
+		if exp, act := 13, met.Counter(name).Value(); act.(uint64) != uint64(exp) {
 			t.Errorf("%s: expected %v, got %v", name, exp, act)
 		}
 		name = "disk_read_bytes"
@@ -1089,8 +1087,7 @@ func TestPluginOneShotDiskStorageMetrics(t *testing.T) {
 		expData := util.MustUnmarshalJSON([]byte(`{
 			"foo": {"bar": 1, "baz": "qux"},
 			"system": {
-				"bundles": {"test-bundle": {"etag": "", "manifest": {"revision": "quickbrownfaux", "roots": [""]}}},
-				"modules": {"test-bundle/foo/bar": {"rego_version": 1}}
+				"bundles": {"test-bundle": {"etag": "", "manifest": {"revision": "quickbrownfaux", "roots": [""]}}}
 			}
 		}`))
 		if err != nil {
@@ -1196,8 +1193,7 @@ func TestPluginOneShotDeltaBundle(t *testing.T) {
 	expData := util.MustUnmarshalJSON([]byte(`{
 		"a": {"baz": "bux", "foo": ["hello", "world"]},
 		"system": {
-			"bundles": {"test-bundle": {"etag": "foo", "manifest": {"revision": "delta", "roots": ["a"]}}},
-			"modules": {"test-bundle/a/policy.rego": {"rego_version": 1}}
+			"bundles": {"test-bundle": {"etag": "foo", "manifest": {"revision": "delta", "roots": ["a"]}}}
 		}
 	}`))
 	if !reflect.DeepEqual(data, expData) {
@@ -1301,8 +1297,7 @@ func TestPluginOneShotDeltaBundleWithAstStore(t *testing.T) {
 	expData := ast.MustParseTerm(`{
 		"a": {"baz": "bux", "foo": ["hello", "world"]},
 		"system": {
-			"bundles": {"test-bundle": {"etag": "foo", "manifest": {"revision": "delta", "roots": ["a"]}}},
-			"modules": {"test-bundle/a/policy.rego": {"rego_version": 1}}
+			"bundles": {"test-bundle": {"etag": "foo", "manifest": {"revision": "delta", "roots": ["a"]}}}
 		}
 	}`)
 	if ast.Compare(data, expData) != 0 {
@@ -1488,8 +1483,7 @@ func TestPluginOneShotBundlePersistence(t *testing.T) {
 	expData := util.MustUnmarshalJSON([]byte(`{
 		"foo": {"bar": 1, "baz": "qux"},
 		"system": {
-			"bundles": {"test-bundle": {"etag": "foo", "manifest": {"revision": "quickbrownfaux", "roots": [""]}}},
-			"modules": {"test-bundle/foo/bar.rego": {"rego_version": 1}}
+			"bundles": {"test-bundle": {"etag": "foo", "manifest": {"revision": "quickbrownfaux", "roots": [""]}}}
 		}
 	}`))
 	if err != nil {
@@ -2171,8 +2165,7 @@ func TestLoadAndActivateBundlesFromDisk(t *testing.T) {
 	expData := util.MustUnmarshalJSON([]byte(`{
 		"foo": {"bar": 1, "baz": "qux"},
 		"system": {
-			"bundles": {"test-bundle": {"etag": "", "manifest": {"revision": "quickbrownfaux", "roots": [""]}}},
-			"modules": {"test-bundle/foo/bar.rego": {"rego_version": 1}}
+			"bundles": {"test-bundle": {"etag": "", "manifest": {"revision": "quickbrownfaux", "roots": [""]}}}
 		}
 	}`))
 	if err != nil {
@@ -2257,8 +2250,7 @@ func TestLoadAndActivateBundlesFromDiskReservedChars(t *testing.T) {
 	expData := util.MustUnmarshalJSON([]byte(`{
 		"foo": {"bar": 1, "baz": "qux"},
 		"system": {
-			"bundles": {"test?bundle=opa": {"etag": "", "manifest": {"revision": "quickbrownfaux", "roots": [""]}}},
-			"modules": {"test/foo/bar.rego": {"rego_version": 1}}
+			"bundles": {"test?bundle=opa": {"etag": "", "manifest": {"revision": "quickbrownfaux", "roots": [""]}}}
 		}
 	}`))
 	if err != nil {
@@ -6860,8 +6852,7 @@ func TestPluginManualTriggerMultipleDiskStorage(t *testing.T) {
 		expData := util.MustUnmarshalJSON([]byte(`{
 			"p": "x1", "q": "x2",
 			"system": {
-				"bundles": {"test-1": {"etag": "", "manifest": {"revision": "", "roots": ["p", "authz"]}}, "test-2": {"etag": "", "manifest": {"revision": "", "roots": ["q"]}}},
-				"modules": {"test-1/bar/policy.rego": {"rego_version": 1}}
+				"bundles": {"test-1": {"etag": "", "manifest": {"revision": "", "roots": ["p", "authz"]}}, "test-2": {"etag": "", "manifest": {"revision": "", "roots": ["q"]}}}
 			}
 		}`))
 		if err != nil {

--- a/v1/plugins/plugins.go
+++ b/v1/plugins/plugins.go
@@ -449,6 +449,7 @@ func New(raw []byte, id string, store storage.Store, opts ...func(*Manager)) (*M
 	}
 
 	if m.parserOptions.RegoVersion == ast.RegoUndefined {
+		// Default to v1 if rego-version is not set through options
 		m.parserOptions.RegoVersion = ast.DefaultRegoVersion
 	}
 

--- a/v1/plugins/plugins.go
+++ b/v1/plugins/plugins.go
@@ -448,6 +448,10 @@ func New(raw []byte, id string, store storage.Store, opts ...func(*Manager)) (*M
 		f(m)
 	}
 
+	if m.parserOptions.RegoVersion == ast.RegoUndefined {
+		m.parserOptions.RegoVersion = ast.DefaultRegoVersion
+	}
+
 	if m.logger == nil {
 		m.logger = logging.Get()
 	}


### PR DESCRIPTION
where the bundle has been manually constructed containing v0 Rego modules and no `rego_version`/`file_rego_versions` fields are declared in the bundle manifest.

This affects bundle deactivation in the bundle store lifecycle used when for `opa run` in server mode (`-s`).
