### PR TITLE
Fix: add missing `BuildAnnotationSet` to `ast` v0

### DIFF
--- a/ast/annotations.go
+++ b/ast/annotations.go
@@ -31,3 +31,7 @@ type (
 func NewAnnotationsRef(a *Annotations) *AnnotationsRef {
 	return v1.NewAnnotationsRef(a)
 }
+
+func BuildAnnotationSet(modules []*Module) (*AnnotationSet, Errors) {
+	return v1.BuildAnnotationSet(modules)
+}


### PR DESCRIPTION
Fixes #7347