### PR TITLE
perf: Add ref.CopyNonGround

### DIFF
--- a/v1/ast/compile.go
+++ b/v1/ast/compile.go
@@ -1114,7 +1114,7 @@ func (c *Compiler) checkRuleConflicts() {
 		for _, rule := range node.Values {
 			r := rule.(*Rule)
 			ref := r.Ref()
-			name = rw(ref.Copy()).String() // varRewriter operates in-place
+			name = rw(ref.CopyNonGround()).String() // varRewriter operates in-place
 			kinds[r.Head.RuleKind()] = struct{}{}
 			arities[len(r.Head.Args)] = struct{}{}
 			if r.Default {
@@ -1156,7 +1156,7 @@ func (c *Compiler) checkRuleConflicts() {
 			//   data.p.q[r][s] { r := input.r; s := input.s }
 			//   data.p[q].r.s { q := input.q }
 
-			if r.Ref().IsGround() && len(node.Children) > 0 {
+			if ref.IsGround() && len(node.Children) > 0 {
 				conflicts = node.flattenChildren()
 			}
 

--- a/v1/ast/term.go
+++ b/v1/ast/term.go
@@ -1017,6 +1017,25 @@ func (ref Ref) Copy() Ref {
 	return termSliceCopy(ref)
 }
 
+// CopyNonGround returns a new ref with deep copies of the non-ground parts and shallow
+// copies of the ground parts. This is a *much* cheaper operation than Copy for operations
+// that only intend to modify (e.g. plug) the non-ground parts. The head element of the ref
+// is always shallow copied.
+func (ref Ref) CopyNonGround() Ref {
+	cpy := make(Ref, len(ref))
+	cpy[0] = ref[0]
+
+	for i := 1; i < len(ref); i++ {
+		if ref[i].Value.IsGround() {
+			cpy[i] = ref[i]
+		} else {
+			cpy[i] = ref[i].Copy()
+		}
+	}
+
+	return cpy
+}
+
 // Equal returns true if ref is equal to other.
 func (ref Ref) Equal(other Value) bool {
 	switch o := other.(type) {
@@ -3063,14 +3082,10 @@ func (c Call) String() string {
 
 func termSliceCopy(a []*Term) []*Term {
 	cpy := make([]*Term, len(a))
-	termSliceCopyTo(a, cpy)
-	return cpy
-}
-
-func termSliceCopyTo(src, dst []*Term) {
-	for i := range src {
-		dst[i] = src[i].Copy()
+	for i := range a {
+		cpy[i] = a[i].Copy()
 	}
+	return cpy
 }
 
 func termSliceEqual(a, b []*Term) bool {

--- a/v1/topdown/eval.go
+++ b/v1/topdown/eval.go
@@ -1185,7 +1185,7 @@ func (e *eval) biunifyRef(a, b *ast.Term, b1, b2 *bindings, iter unifyIterator) 
 			e:         e,
 			ref:       ref,
 			pos:       1,
-			plugged:   ref.Copy(),
+			plugged:   ref.CopyNonGround(),
 			bindings:  b1,
 			rterm:     b,
 			rbindings: b2,


### PR DESCRIPTION
Refs copied for the purpose of modification often don't need _all_ parts deep-copied, but only those to be modified. It turns out that in most cases in the context of eval, **no** parts of the ref needs copying, as those refs are static. This PR adds a simple new method to refs that allows smarter copying, saving a million and a half allocations in the `regal lint` benchmark, and hundreds to thousands of allocations in common policy evaluation.

**Before**
```
1716967000 ns/op	3125089752 B/op	62201992 allocs/op
```
**After**
```
1679479541 ns/op	3086159368 B/op	60630066 allocs/op
```