### PR TITLE
Handle failing tests in `opa test --bench`

### DIFF
--- a/cmd/test.go
+++ b/cmd/test.go
@@ -13,6 +13,7 @@ import (
 	"os/signal"
 	"strings"
 	"syscall"
+	"testing"
 	"time"
 
 	"github.com/fsnotify/fsnotify"
@@ -182,6 +183,11 @@ func runTests(ctx context.Context, txn storage.Transaction, runner *tester.Runne
 	var err error
 	var ch chan *tester.Result
 	if testParams.benchmark {
+		// Initialize testing package for benchmarking. This is needed to set default values for some flags that may
+		// otherwise be dereferenced on some code paths causing panics, as reported in:
+		// https://github.com/open-policy-agent/opa/issues/7205
+		testing.Init()
+
 		benchOpts := tester.BenchmarkOptions{
 			ReportAllocations: testParams.benchMem,
 		}
@@ -451,7 +457,7 @@ func init() {
 		Use:   "test <path> [path [...]]",
 		Short: "Execute Rego test cases",
 		Long: `Execute Rego test cases.
-	
+
 The 'test' command takes a file or directory path as input and executes all
 test cases discovered in matching files. Test cases are rules whose names have the prefix "test_".
 

--- a/cmd/test_test.go
+++ b/cmd/test_test.go
@@ -3474,3 +3474,27 @@ test_l if {
 		}
 	}
 }
+
+// Assert that a failing test doesn't cause a panic.
+// https://github.com/open-policy-agent/opa/issues/7205
+func TestTestBenchFailingTest(t *testing.T) {
+	files := map[string]string{
+		"test.rego": `package test
+			test_fail if false`,
+	}
+
+	test.WithTempFS(files, func(path string) {
+		fp := filepath.Join(path, "test.rego")
+		tp := newTestCommandParams()
+		tp.benchmark = true
+		tp.count = 1
+
+		exitCode, err := opaTest([]string{fp}, tp)
+		if exitCode == 0 {
+			t.Fatalf("Expected exit code 0, got %d", exitCode)
+		}
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
Fixes #7205