### PR TITLE
Add util.HasherMap

### DIFF
--- a/v1/ast/check.go
+++ b/v1/ast/check.go
@@ -781,8 +781,8 @@ func (rc *refChecker) checkRef(curr *TypeEnv, node *typeTreeNode, ref Ref, idx i
 
 		case RootDocumentNames.Contains(ref[0]):
 			if idx != 0 {
-				node.Children().Iter(func(_, child util.T) bool {
-					_ = rc.checkRef(curr, child.(*typeTreeNode), ref, idx+1) // ignore error
+				node.Children().Iter(func(_ Value, child *typeTreeNode) bool {
+					_ = rc.checkRef(curr, child, ref, idx+1) // ignore error
 					return false
 				})
 				return nil
@@ -1127,8 +1127,8 @@ func newArgError(loc *Location, builtinName Ref, msg string, have []types.Type, 
 }
 
 func getOneOfForNode(node *typeTreeNode) (result []Value) {
-	node.Children().Iter(func(k, _ util.T) bool {
-		result = append(result, k.(Value))
+	node.Children().Iter(func(k Value, _ *typeTreeNode) bool {
+		result = append(result, k)
 		return false
 	})
 

--- a/v1/ast/compare.go
+++ b/v1/ast/compare.go
@@ -402,6 +402,10 @@ func TermValueCompare(a, b *Term) int {
 	return a.Value.Compare(b.Value)
 }
 
+func TermValueEqual(a, b *Term) bool {
+	return ValueEqual(a.Value, b.Value)
+}
+
 func ValueEqual(a, b Value) bool {
 	// TODO(ae): why doesn't this work the same?
 	//

--- a/v1/ast/compile.go
+++ b/v1/ast/compile.go
@@ -124,7 +124,7 @@ type Compiler struct {
 
 	localvargen                *localVarGenerator
 	moduleLoader               ModuleLoader
-	ruleIndices                *util.HashMap
+	ruleIndices                *util.HasherMap[Ref, RuleIndex]
 	stages                     []stage
 	maxErrs                    int
 	sorted                     []string // list of sorted module names
@@ -303,15 +303,10 @@ type stage struct {
 func NewCompiler() *Compiler {
 
 	c := &Compiler{
-		Modules:       map[string]*Module{},
-		RewrittenVars: map[Var]Var{},
-		Required:      &Capabilities{},
-		ruleIndices: util.NewHashMap(func(a, b util.T) bool {
-			r1, r2 := a.(Ref), b.(Ref)
-			return r1.Equal(r2)
-		}, func(x util.T) int {
-			return x.(Ref).Hash()
-		}),
+		Modules:               map[string]*Module{},
+		RewrittenVars:         map[Var]Var{},
+		Required:              &Capabilities{},
+		ruleIndices:           util.NewHasherMap[Ref, RuleIndex](RefEqual),
 		maxErrs:               CompileErrorLimitDefault,
 		after:                 map[string][]CompilerStageDefinition{},
 		unsafeBuiltinsMap:     map[string]struct{}{},
@@ -825,7 +820,7 @@ func (c *Compiler) RuleIndex(path Ref) RuleIndex {
 	if !ok {
 		return nil
 	}
-	return r.(RuleIndex)
+	return r
 }
 
 // PassesTypeCheck determines whether the given body passes type checking
@@ -1738,13 +1733,9 @@ func (c *Compiler) err(err *Error) {
 	c.Errors = append(c.Errors, err)
 }
 
-func (c *Compiler) getExports() *util.HashMap {
+func (c *Compiler) getExports() *util.HasherMap[Ref, []Ref] {
 
-	rules := util.NewHashMap(func(a, b util.T) bool {
-		return a.(Ref).Equal(b.(Ref))
-	}, func(v util.T) int {
-		return v.(Ref).Hash()
-	})
+	rules := util.NewHasherMap[Ref, []Ref](RefEqual)
 
 	for _, name := range c.sorted {
 		mod := c.Modules[name]
@@ -1757,18 +1748,30 @@ func (c *Compiler) getExports() *util.HashMap {
 	return rules
 }
 
-func hashMapAdd(rules *util.HashMap, pkg, rule Ref) {
+func refSliceEqual(a, b []Ref) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if !a[i].Equal(b[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func hashMapAdd(rules *util.HasherMap[Ref, []Ref], pkg, rule Ref) {
 	prev, ok := rules.Get(pkg)
 	if !ok {
 		rules.Put(pkg, []Ref{rule})
 		return
 	}
-	for _, p := range prev.([]Ref) {
+	for _, p := range prev {
 		if p.Equal(rule) {
 			return
 		}
 	}
-	rules.Put(pkg, append(prev.([]Ref), rule))
+	rules.Put(pkg, append(prev, rule))
 }
 
 func (c *Compiler) GetAnnotationSet() *AnnotationSet {
@@ -1867,7 +1870,7 @@ func (c *Compiler) resolveAllRefs() {
 
 		var ruleExports []Ref
 		if x, ok := rules.Get(mod.Package.Path); ok {
-			ruleExports = x.([]Ref)
+			ruleExports = x
 		}
 
 		globals := getGlobals(mod.Package, ruleExports, mod.Imports)
@@ -3014,7 +3017,7 @@ func (qc *queryCompiler) resolveRefs(qctx *QueryContext, body Body) (Body, error
 			var ruleExports []Ref
 			rules := qc.compiler.getExports()
 			if exist, ok := rules.Get(pkg.Path); ok {
-				ruleExports = exist.([]Ref)
+				ruleExports = exist
 			}
 
 			globals = getGlobals(qctx.Package, ruleExports, qctx.Imports)

--- a/v1/ast/compile_test.go
+++ b/v1/ast/compile_test.go
@@ -410,28 +410,8 @@ func TestCompilerGetExports(t *testing.T) {
 		// TODO(sr): add multi-val rule, and ref-with-var single-value rule.
 	}
 
-	hashMap := func(ms map[string][]string) *util.HashMap {
-		rules := util.NewHashMap(func(a, b util.T) bool {
-			switch a := a.(type) {
-			case Ref:
-				return a.Equal(b.(Ref))
-			case []Ref:
-				b := b.([]Ref)
-				if len(b) != len(a) {
-					return false
-				}
-				for i := range a {
-					if !a[i].Equal(b[i]) {
-						return false
-					}
-				}
-				return true
-			default:
-				panic("unreachable")
-			}
-		}, func(v util.T) int {
-			return v.(Ref).Hash()
-		})
+	hashMap := func(ms map[string][]string) *util.HasherMap[Ref, []Ref] {
+		rules := util.NewHasherMap[Ref, []Ref](RefEqual)
 		for r, rs := range ms {
 			refs := make([]Ref, len(rs))
 			for i := range rs {
@@ -449,11 +429,27 @@ func TestCompilerGetExports(t *testing.T) {
 				c.Modules[strconv.Itoa(i)] = m
 				c.sorted = append(c.sorted, strconv.Itoa(i))
 			}
-			if exp, act := hashMap(tc.exports), c.getExports(); !exp.Equal(act) {
+			if exp, act := hashMap(tc.exports), c.getExports(); !refMapEqual(exp, act) {
 				t.Errorf("expected %v, got %v", exp, act)
 			}
 		})
 	}
+}
+
+func refMapEqual(a, b *util.HasherMap[Ref, []Ref]) bool {
+	if a.Len() != b.Len() {
+		return false
+	}
+	return !a.Iter(func(k Ref, v []Ref) bool {
+		v2, ok := b.Get(k)
+		if !ok {
+			return true
+		}
+		if !refSliceEqual(v, v2) {
+			return true
+		}
+		return false
+	})
 }
 
 func toRef(s string) Ref {

--- a/v1/ast/env.go
+++ b/v1/ast/env.go
@@ -200,10 +200,7 @@ func (env *TypeEnv) getRefRecExtent(node *typeTreeNode) types.Type {
 
 	children := []*types.StaticProperty{}
 
-	node.Children().Iter(func(k, v util.T) bool {
-		key := k.(Value)
-		child := v.(*typeTreeNode)
-
+	node.Children().Iter(func(key Value, child *typeTreeNode) bool {
 		tpe := env.getRefRecExtent(child)
 
 		// NOTE(sr): Converting to Golang-native types here is an extension of what we did
@@ -237,14 +234,14 @@ func (env *TypeEnv) wrap() *TypeEnv {
 type typeTreeNode struct {
 	key      Value
 	value    types.Type
-	children *util.HashMap
+	children *util.HasherMap[Value, *typeTreeNode]
 }
 
 func newTypeTree() *typeTreeNode {
 	return &typeTreeNode{
 		key:      nil,
 		value:    nil,
-		children: util.NewHashMap(valueEq, valueHash),
+		children: util.NewHasherMap[Value, *typeTreeNode](ValueEqual),
 	}
 }
 
@@ -253,10 +250,10 @@ func (n *typeTreeNode) Child(key Value) *typeTreeNode {
 	if !ok {
 		return nil
 	}
-	return value.(*typeTreeNode)
+	return value
 }
 
-func (n *typeTreeNode) Children() *util.HashMap {
+func (n *typeTreeNode) Children() *util.HasherMap[Value, *typeTreeNode] {
 	return n.children
 }
 
@@ -267,7 +264,7 @@ func (n *typeTreeNode) Get(path Ref) types.Type {
 		if !ok {
 			return nil
 		}
-		curr = child.(*typeTreeNode)
+		curr = child
 	}
 	return curr.Value()
 }
@@ -285,7 +282,7 @@ func (n *typeTreeNode) PutOne(key Value, tpe types.Type) {
 		child.key = key
 		n.children.Put(key, child)
 	} else {
-		child = c.(*typeTreeNode)
+		child = c
 	}
 
 	child.value = tpe
@@ -302,7 +299,7 @@ func (n *typeTreeNode) Put(path Ref, tpe types.Type) {
 			child.key = term.Value
 			curr.children.Put(child.key, child)
 		} else {
-			child = c.(*typeTreeNode)
+			child = c
 		}
 
 		curr = child
@@ -324,8 +321,7 @@ func (n *typeTreeNode) Insert(path Ref, tpe types.Type, env *TypeEnv) {
 			child.key = term.Value
 			curr.children.Put(child.key, child)
 		} else {
-			child = c.(*typeTreeNode)
-
+			child = c
 			if child.value != nil && i+1 < len(path) {
 				// If child has an object value, merge the new value into it.
 				if o, ok := child.value.(*types.Object); ok {
@@ -426,13 +422,12 @@ func (n *typeTreeNode) String() string {
 		b.WriteString(v.String())
 	}
 
-	n.children.Iter(func(_, v util.T) bool {
-		if child, ok := v.(*typeTreeNode); ok {
-			b.WriteString("\n\t+ ")
-			s := child.String()
-			s = strings.ReplaceAll(s, "\n", "\n\t")
-			b.WriteString(s)
-		}
+	n.children.Iter(func(_ Value, child *typeTreeNode) bool {
+		b.WriteString("\n\t+ ")
+		s := child.String()
+		s = strings.ReplaceAll(s, "\n", "\n\t")
+		b.WriteString(s)
+
 		return false
 	})
 
@@ -472,8 +467,8 @@ func insertIntoObject(o *types.Object, path Ref, tpe types.Type, env *TypeEnv) (
 
 func (n *typeTreeNode) Leafs() map[*Ref]types.Type {
 	leafs := map[*Ref]types.Type{}
-	n.children.Iter(func(_, v util.T) bool {
-		collectLeafs(v.(*typeTreeNode), nil, leafs)
+	n.children.Iter(func(_ Value, v *typeTreeNode) bool {
+		collectLeafs(v, nil, leafs)
 		return false
 	})
 	return leafs
@@ -485,8 +480,8 @@ func collectLeafs(n *typeTreeNode, path Ref, leafs map[*Ref]types.Type) {
 		leafs[&nPath] = n.Value()
 		return
 	}
-	n.children.Iter(func(_, v util.T) bool {
-		collectLeafs(v.(*typeTreeNode), nPath, leafs)
+	n.children.Iter(func(_ Value, v *typeTreeNode) bool {
+		collectLeafs(v, nPath, leafs)
 		return false
 	})
 }

--- a/v1/ast/map_test.go
+++ b/v1/ast/map_test.go
@@ -38,22 +38,15 @@ func TestValueMapIter(t *testing.T) {
 	}
 }
 
-func TestValueMapCopy(t *testing.T) {
-	a := NewValueMap()
-	a.Put(String("x"), String("foo"))
-	a.Put(String("y"), String("bar"))
-	b := a.Copy()
-	b.Delete(String("y"))
-	if a.Get(String("y")) != String("bar") {
-		t.Fatalf("Unexpected a['y'] value: %v", a.Get(String("y")))
-	}
-}
-
 func TestValueMapEqual(t *testing.T) {
 	a := NewValueMap()
 	a.Put(String("x"), String("foo"))
 	a.Put(String("y"), String("bar"))
-	b := a.Copy()
+
+	b := NewValueMap()
+	b.Put(String("x"), String("foo"))
+	b.Put(String("y"), String("bar"))
+
 	if !a.Equal(b) {
 		t.Fatalf("Expected a == b but not for: %v / %v", a, b)
 	}
@@ -89,9 +82,6 @@ func TestValueMapString(t *testing.T) {
 
 func TestValueMapNil(t *testing.T) {
 	var a *ValueMap
-	if a.Copy() != nil {
-		t.Fatalf("Expected nil map copy to be nil")
-	}
 	a.Delete(String("foo"))
 	var b *ValueMap
 	if !a.Equal(b) {

--- a/v1/ast/schema.go
+++ b/v1/ast/schema.go
@@ -13,41 +13,32 @@ import (
 
 // SchemaSet holds a map from a path to a schema.
 type SchemaSet struct {
-	m *util.HashMap
+	m *util.HasherMap[Ref, any]
 }
 
 // NewSchemaSet returns an empty SchemaSet.
 func NewSchemaSet() *SchemaSet {
-
-	eqFunc := func(a, b util.T) bool {
-		return a.(Ref).Equal(b.(Ref))
-	}
-
-	hashFunc := func(x util.T) int { return x.(Ref).Hash() }
-
 	return &SchemaSet{
-		m: util.NewHashMap(eqFunc, hashFunc),
+		m: util.NewHasherMap[Ref, any](RefEqual),
 	}
 }
 
 // Put inserts a raw schema into the set.
-func (ss *SchemaSet) Put(path Ref, raw interface{}) {
+func (ss *SchemaSet) Put(path Ref, raw any) {
 	ss.m.Put(path, raw)
 }
 
 // Get returns the raw schema identified by the path.
-func (ss *SchemaSet) Get(path Ref) interface{} {
-	if ss == nil {
-		return nil
+func (ss *SchemaSet) Get(path Ref) any {
+	if ss != nil {
+		if x, ok := ss.m.Get(path); ok {
+			return x
+		}
 	}
-	x, ok := ss.m.Get(path)
-	if !ok {
-		return nil
-	}
-	return x
+	return nil
 }
 
-func loadSchema(raw interface{}, allowNet []string) (types.Type, error) {
+func loadSchema(raw any, allowNet []string) (types.Type, error) {
 
 	jsonSchema, err := compileSchema(raw, allowNet)
 	if err != nil {

--- a/v1/rego/rego.go
+++ b/v1/rego/rego.go
@@ -2855,17 +2855,26 @@ func parseStringsToRefs(s []string) ([]ast.Ref, error) {
 func finishFunction(name string, bctx topdown.BuiltinContext, result *ast.Term, err error, iter func(*ast.Term) error) error {
 	if err != nil {
 		var e *HaltError
+		sb := strings.Builder{}
 		if errors.As(err, &e) {
+			sb.Grow(len(name) + len(e.Error()) + 2)
+			sb.WriteString(name)
+			sb.WriteString(": ")
+			sb.WriteString(e.Error())
 			tdErr := &topdown.Error{
 				Code:     topdown.BuiltinErr,
-				Message:  fmt.Sprintf("%v: %v", name, e.Error()),
+				Message:  sb.String(),
 				Location: bctx.Location,
 			}
 			return topdown.Halt{Err: tdErr.Wrap(e)}
 		}
+		sb.Grow(len(name) + len(err.Error()) + 2)
+		sb.WriteString(name)
+		sb.WriteString(": ")
+		sb.WriteString(err.Error())
 		tdErr := &topdown.Error{
 			Code:     topdown.BuiltinErr,
-			Message:  fmt.Sprintf("%v: %v", name, err.Error()),
+			Message:  sb.String(),
 			Location: bctx.Location,
 		}
 		return tdErr.Wrap(err)

--- a/v1/topdown/cache/cache.go
+++ b/v1/topdown/cache/cache.go
@@ -372,19 +372,13 @@ type InterQueryValueCacheBucket interface {
 }
 
 type interQueryValueCacheBucket struct {
-	items  util.TypedHashMap[ast.Value, any]
+	items  util.HasherMap[ast.Value, any]
 	config *NamedValueCacheConfig
 	mtx    sync.RWMutex
 }
 
-func newItemsMap() *util.TypedHashMap[ast.Value, any] {
-	return util.NewTypedHashMap[ast.Value, any](
-		func(a, b ast.Value) bool { return a.Compare(b) == 0 },
-		func(any, any) bool { return false }, // map equality not supported
-		func(a ast.Value) int { return a.Hash() },
-		func(any) int { return 0 }, // map equality not supported
-		nil,
-	)
+func newItemsMap() *util.HasherMap[ast.Value, any] {
+	return util.NewHasherMap[ast.Value, any](ast.ValueEqual)
 }
 
 func (c *interQueryValueCacheBucket) Get(k ast.Value) (any, bool) {

--- a/v1/topdown/copypropagation/unionfind.go
+++ b/v1/topdown/copypropagation/unionfind.go
@@ -14,18 +14,14 @@ import (
 type rankFunc func(*unionFindRoot, *unionFindRoot) (*unionFindRoot, *unionFindRoot)
 
 type unionFind struct {
-	roots   *util.HashMap
+	roots   *util.HasherMap[ast.Value, *unionFindRoot]
 	parents *ast.ValueMap
 	rank    rankFunc
 }
 
 func newUnionFind(rank rankFunc) *unionFind {
 	return &unionFind{
-		roots: util.NewHashMap(func(a util.T, b util.T) bool {
-			return a.(ast.Value).Compare(b.(ast.Value)) == 0
-		}, func(v util.T) int {
-			return v.(ast.Value).Hash()
-		}),
+		roots:   util.NewHasherMap[ast.Value, *unionFindRoot](ast.ValueEqual),
 		parents: ast.NewValueMap(),
 		rank:    rank,
 	}
@@ -53,7 +49,7 @@ func (uf *unionFind) Find(v ast.Value) (*unionFindRoot, bool) {
 
 	if parent.Compare(v) == 0 {
 		r, ok := uf.roots.Get(v)
-		return r.(*unionFindRoot), ok
+		return r, ok
 	}
 
 	return uf.Find(parent)
@@ -93,13 +89,13 @@ func (uf *unionFind) String() string {
 		map[string]ast.Value{},
 	}
 
-	uf.roots.Iter(func(k util.T, v util.T) bool {
-		o.Roots[k.(ast.Value).String()] = struct {
+	uf.roots.Iter(func(k ast.Value, v *unionFindRoot) bool {
+		o.Roots[k.String()] = struct {
 			Constant *ast.Term
 			Key      ast.Value
 		}{
-			v.(*unionFindRoot).constant,
-			v.(*unionFindRoot).key,
+			v.constant,
+			v.key,
 		}
 		return true
 	})

--- a/v1/topdown/http.go
+++ b/v1/topdown/http.go
@@ -781,28 +781,17 @@ type httpSendCacheEntry struct {
 
 // The httpSendCache is used for intra-query caching of http.send results.
 type httpSendCache struct {
-	entries *util.HashMap
+	entries *util.HasherMap[ast.Value, httpSendCacheEntry]
 }
 
 func newHTTPSendCache() *httpSendCache {
 	return &httpSendCache{
-		entries: util.NewHashMap(valueEq, valueHash),
+		entries: util.NewHasherMap[ast.Value, httpSendCacheEntry](ast.ValueEqual),
 	}
-}
-
-func valueHash(v util.T) int {
-	return ast.StringTerm(v.(ast.Value).String()).Hash()
-}
-
-func valueEq(a, b util.T) bool {
-	av := a.(ast.Value)
-	bv := b.(ast.Value)
-	return av.String() == bv.String()
 }
 
 func (cache *httpSendCache) get(k ast.Value) *httpSendCacheEntry {
 	if v, ok := cache.entries.Get(k); ok {
-		v := v.(httpSendCacheEntry)
 		return &v
 	}
 	return nil


### PR DESCRIPTION
This is a simpler version of util.TypedHashMap where the keys implement a `.Hash()` method and as such won't need one to be passed in, and where the values are largely ignored by the map. These maps are smaller / more performant, but most importantly, they are nicer to work with.

Perf wise, this saves about 600k+ allocs and 40 MB allocated memory in `regal lint bundle`:
```
1207614875 ns/op	3293454016 B/op	64802095 allocs/op
1197978125 ns/op	3256960504 B/op	64164871 allocs/op
```

Also:
- Use `strings.Builder` instead of `fmt.Sprintf` in one location
- Remove `ValueMap.Copy` as it was only used in a test
