### PR TITLE
perf: eval optimizations

### DIFF
--- a/v1/storage/inmem/ast.go
+++ b/v1/storage/inmem/ast.go
@@ -101,8 +101,7 @@ func newUpdateArrayAST(data *ast.Array, op storage.PatchOp, path storage.Path, i
 				return nil, invalidPatchError("%v: invalid patch path", path)
 			}
 
-			cpy := data.Copy()
-			cpy = cpy.Append(ast.NewTerm(value))
+			cpy := data.Append(ast.NewTerm(value))
 			return &updateAST{path[:len(path)-1], false, cpy}, nil
 		}
 


### PR DESCRIPTION
Another changeset I've kept around without pushing. Nothing *that* exciting here, but still significant enough to want to keep, I think.

Most notable improvement is in evalValue, where we now reuse the same term slice for args across all evalOneRule calls. These are always invoked in sequence over the same args (for any given incremental rule/function), so allocating a new slice for them each time isn't needed.

The result is approximatelu 300k less allocations needed in `regal lint bundle`.

**main**
```
1239432250 ns/op	3254824064 B/op	64160920 allocs/op
```

**change**
```
1195618209 ns/op	3249758040 B/op	63847644 allocs/op
```