### PR TITLE
perf: slightly more efficient policy scanning

### DIFF
--- a/v1/ast/internal/scanner/scanner.go
+++ b/v1/ast/internal/scanner/scanner.go
@@ -9,9 +9,9 @@ import (
 	"io"
 	"unicode"
 	"unicode/utf8"
-	"unsafe"
 
 	"github.com/open-policy-agent/opa/v1/ast/internal/tokens"
+	"github.com/open-policy-agent/opa/v1/util"
 )
 
 const bom = 0xFEFF
@@ -165,7 +165,21 @@ func (s *Scanner) Scan() (tokens.Token, Position, string, []Error) {
 	var lit string
 
 	if s.isWhitespace() {
-		lit = string(s.curr)
+		// string(rune) is an unnecessary heap allocation in this case as we know all
+		// the possible whitespace values, and can simply translate to string ourselves
+		switch s.curr {
+		case ' ':
+			lit = " "
+		case '\t':
+			lit = "\t"
+		case '\n':
+			lit = "\n"
+		case '\r':
+			lit = "\r"
+		default:
+			// unreachable unless isWhitespace changes
+			lit = string(s.curr)
+		}
 		s.next()
 		tok = tokens.Whitespace
 	} else if isLetter(s.curr) {
@@ -272,7 +286,7 @@ func (s *Scanner) scanIdentifier() string {
 		s.next()
 	}
 
-	return byteSliceToString(s.bs[start : s.offset-1])
+	return util.ByteSliceToString(s.bs[start : s.offset-1])
 }
 
 func (s *Scanner) scanNumber() string {
@@ -323,7 +337,7 @@ func (s *Scanner) scanNumber() string {
 		}
 	}
 
-	return byteSliceToString(s.bs[start : s.offset-1])
+	return util.ByteSliceToString(s.bs[start : s.offset-1])
 }
 
 func (s *Scanner) scanString() string {
@@ -357,7 +371,7 @@ func (s *Scanner) scanString() string {
 		}
 	}
 
-	return byteSliceToString(s.bs[start : s.offset-1])
+	return util.ByteSliceToString(s.bs[start : s.offset-1])
 }
 
 func (s *Scanner) scanRawString() string {
@@ -373,7 +387,7 @@ func (s *Scanner) scanRawString() string {
 		}
 	}
 
-	return byteSliceToString(s.bs[start : s.offset-1])
+	return util.ByteSliceToString(s.bs[start : s.offset-1])
 }
 
 func (s *Scanner) scanComment() string {
@@ -387,7 +401,7 @@ func (s *Scanner) scanComment() string {
 		end = end - 1
 	}
 
-	return byteSliceToString(s.bs[start:end])
+	return util.ByteSliceToString(s.bs[start:end])
 }
 
 func (s *Scanner) next() {
@@ -456,8 +470,4 @@ func (s *Scanner) error(reason string) {
 		Row:    s.row,
 		Col:    s.col,
 	}, Message: reason})
-}
-
-func byteSliceToString(bs []byte) string {
-	return unsafe.String(unsafe.SliceData(bs), len(bs))
 }

--- a/v1/ast/internal/tokens/tokens.go
+++ b/v1/ast/internal/tokens/tokens.go
@@ -4,12 +4,14 @@
 
 package tokens
 
+import "maps"
+
 // Token represents a single Rego source code token
 // for use by the Parser.
-type Token int
+type Token uint8
 
 func (t Token) String() string {
-	if t < 0 || int(t) >= len(strings) {
+	if int(t) >= len(strings) {
 		return "unknown"
 	}
 	return strings[t]
@@ -137,11 +139,7 @@ var keywords = map[string]Token{
 
 // Keywords returns a copy of the default string -> Token keyword map.
 func Keywords() map[string]Token {
-	cpy := make(map[string]Token, len(keywords))
-	for k, v := range keywords {
-		cpy[k] = v
-	}
-	return cpy
+	return maps.Clone(keywords)
 }
 
 // IsKeyword returns if a token is a keyword


### PR DESCRIPTION
A couple of micro-optimizations, really. But when applied together makes enough of a difference to be taken seriously.

Benchmark showing the difference in the `BenchmarkRegalNoEnabledRules` test in Regal, which was used here simply because the change has no impact outside of parsing.

```
499003281 B/op	 9746024 allocs/op // before
496497404 B/op	 9677104 allocs/op // after
```

A modest improvement, but an improvement nonetheless.
