### PR TITLE
perf: use GetByValue to avoid boxing to interface{}

### DIFF
--- a/v1/ast/builtins.go
+++ b/v1/ast/builtins.go
@@ -489,10 +489,10 @@ var Minus = &Builtin{
 	Description: "Minus subtracts the second number from the first number or computes the difference between two sets.",
 	Decl: types.NewFunction(
 		types.Args(
-			types.Named("x", types.NewAny(types.N, types.NewSet(types.A))),
-			types.Named("y", types.NewAny(types.N, types.NewSet(types.A))),
+			types.Named("x", types.NewAny(types.N, types.SetOfAny)),
+			types.Named("y", types.NewAny(types.N, types.SetOfAny)),
 		),
-		types.Named("z", types.NewAny(types.N, types.NewSet(types.A))).Description("the difference of `x` and `y`"),
+		types.Named("z", types.NewAny(types.N, types.SetOfAny)).Description("the difference of `x` and `y`"),
 	),
 	Categories: category("sets", "numbers"),
 }
@@ -674,10 +674,10 @@ var And = &Builtin{
 	Description: "Returns the intersection of two sets.",
 	Decl: types.NewFunction(
 		types.Args(
-			types.Named("x", types.NewSet(types.A)).Description("the first set"),
-			types.Named("y", types.NewSet(types.A)).Description("the second set"),
+			types.Named("x", types.SetOfAny).Description("the first set"),
+			types.Named("y", types.SetOfAny).Description("the second set"),
 		),
-		types.Named("z", types.NewSet(types.A)).Description("the intersection of `x` and `y`"),
+		types.Named("z", types.SetOfAny).Description("the intersection of `x` and `y`"),
 	),
 	Categories: sets,
 }
@@ -689,10 +689,10 @@ var Or = &Builtin{
 	Description: "Returns the union of two sets.",
 	Decl: types.NewFunction(
 		types.Args(
-			types.Named("x", types.NewSet(types.A)),
-			types.Named("y", types.NewSet(types.A)),
+			types.Named("x", types.SetOfAny),
+			types.Named("y", types.SetOfAny),
 		),
-		types.Named("z", types.NewSet(types.A)).Description("the union of `x` and `y`"),
+		types.Named("z", types.SetOfAny).Description("the union of `x` and `y`"),
 	),
 	Categories: sets,
 }
@@ -702,9 +702,9 @@ var Intersection = &Builtin{
 	Description: "Returns the intersection of the given input sets.",
 	Decl: types.NewFunction(
 		types.Args(
-			types.Named("xs", types.NewSet(types.NewSet(types.A))).Description("set of sets to intersect"),
+			types.Named("xs", types.NewSet(types.SetOfAny)).Description("set of sets to intersect"),
 		),
-		types.Named("y", types.NewSet(types.A)).Description("the intersection of all `xs` sets"),
+		types.Named("y", types.SetOfAny).Description("the intersection of all `xs` sets"),
 	),
 	Categories: sets,
 }
@@ -714,9 +714,9 @@ var Union = &Builtin{
 	Description: "Returns the union of the given input sets.",
 	Decl: types.NewFunction(
 		types.Args(
-			types.Named("xs", types.NewSet(types.NewSet(types.A))).Description("set of sets to merge"),
+			types.Named("xs", types.NewSet(types.SetOfAny)).Description("set of sets to merge"),
 		),
-		types.Named("y", types.NewSet(types.A)).Description("the union of all `xs` sets"),
+		types.Named("y", types.SetOfAny).Description("the union of all `xs` sets"),
 	),
 	Categories: sets,
 }
@@ -733,7 +733,7 @@ var Count = &Builtin{
 	Decl: types.NewFunction(
 		types.Args(
 			types.Named("collection", types.NewAny(
-				types.NewSet(types.A),
+				types.SetOfAny,
 				types.NewArray(nil, types.A),
 				types.NewObject(nil, types.NewDynamicProperty(types.A, types.A)),
 				types.S,
@@ -750,7 +750,7 @@ var Sum = &Builtin{
 	Decl: types.NewFunction(
 		types.Args(
 			types.Named("collection", types.NewAny(
-				types.NewSet(types.N),
+				types.SetOfNum,
 				types.NewArray(nil, types.N),
 			)).Description("the set or array of numbers to sum"),
 		),
@@ -765,7 +765,7 @@ var Product = &Builtin{
 	Decl: types.NewFunction(
 		types.Args(
 			types.Named("collection", types.NewAny(
-				types.NewSet(types.N),
+				types.SetOfNum,
 				types.NewArray(nil, types.N),
 			)).Description("the set or array of numbers to multiply"),
 		),
@@ -780,7 +780,7 @@ var Max = &Builtin{
 	Decl: types.NewFunction(
 		types.Args(
 			types.Named("collection", types.NewAny(
-				types.NewSet(types.A),
+				types.SetOfAny,
 				types.NewArray(nil, types.A),
 			)).Description("the set or array to be searched"),
 		),
@@ -795,7 +795,7 @@ var Min = &Builtin{
 	Decl: types.NewFunction(
 		types.Args(
 			types.Named("collection", types.NewAny(
-				types.NewSet(types.A),
+				types.SetOfAny,
 				types.NewArray(nil, types.A),
 			)).Description("the set or array to be searched"),
 		),
@@ -815,7 +815,7 @@ var Sort = &Builtin{
 		types.Args(
 			types.Named("collection", types.NewAny(
 				types.NewArray(nil, types.A),
-				types.NewSet(types.A),
+				types.SetOfAny,
 			)).Description("the array or set to be sorted"),
 		),
 		types.Named("n", types.NewArray(nil, types.A)).Description("the sorted array"),
@@ -845,8 +845,8 @@ var ArraySlice = &Builtin{
 	Decl: types.NewFunction(
 		types.Args(
 			types.Named("arr", types.NewArray(nil, types.A)).Description("the array to be sliced"),
-			types.Named("start", types.NewNumber()).Description("the start index of the returned slice; if less than zero, it's clamped to 0"),
-			types.Named("stop", types.NewNumber()).Description("the stop index of the returned slice; if larger than `count(arr)`, it's clamped to `count(arr)`"),
+			types.Named("start", types.N).Description("the start index of the returned slice; if less than zero, it's clamped to 0"),
+			types.Named("stop", types.N).Description("the stop index of the returned slice; if larger than `count(arr)`, it's clamped to `count(arr)`"),
 		),
 		types.Named("slice", types.NewArray(nil, types.A)).Description("the subslice of `array`, from `start` to `end`, including `arr[start]`, but excluding `arr[end]`"),
 	),
@@ -996,12 +996,12 @@ var AnyPrefixMatch = &Builtin{
 		types.Args(
 			types.Named("search", types.NewAny(
 				types.S,
-				types.NewSet(types.S),
+				types.SetOfStr,
 				types.NewArray(nil, types.S),
 			)).Description("search string(s)"),
 			types.Named("base", types.NewAny(
 				types.S,
-				types.NewSet(types.S),
+				types.SetOfStr,
 				types.NewArray(nil, types.S),
 			)).Description("base string(s)"),
 		),
@@ -1017,12 +1017,12 @@ var AnySuffixMatch = &Builtin{
 		types.Args(
 			types.Named("search", types.NewAny(
 				types.S,
-				types.NewSet(types.S),
+				types.SetOfStr,
 				types.NewArray(nil, types.S),
 			)).Description("search string(s)"),
 			types.Named("base", types.NewAny(
 				types.S,
-				types.NewSet(types.S),
+				types.SetOfStr,
 				types.NewArray(nil, types.S),
 			)).Description("base string(s)"),
 		),
@@ -1038,7 +1038,7 @@ var Concat = &Builtin{
 		types.Args(
 			types.Named("delimiter", types.S).Description("string to use as a delimiter"),
 			types.Named("collection", types.NewAny(
-				types.NewSet(types.S),
+				types.SetOfStr,
 				types.NewArray(nil, types.S),
 			)).Description("strings to join"),
 		),
@@ -1600,13 +1600,13 @@ var ObjectSubset = &Builtin{
 			types.Named("super", types.NewAny(types.NewObject(
 				nil,
 				types.NewDynamicProperty(types.A, types.A),
-			), types.NewSet(types.A),
+			), types.SetOfAny,
 				types.NewArray(nil, types.A),
 			)).Description("object to test if sub is a subset of"),
 			types.Named("sub", types.NewAny(types.NewObject(
 				nil,
 				types.NewDynamicProperty(types.A, types.A),
-			), types.NewSet(types.A),
+			), types.SetOfAny,
 				types.NewArray(nil, types.A),
 			)).Description("object to test if super is a superset of"),
 		),
@@ -1659,7 +1659,7 @@ var ObjectRemove = &Builtin{
 			)).Description("object to remove keys from"),
 			types.Named("keys", types.NewAny(
 				types.NewArray(nil, types.A),
-				types.NewSet(types.A),
+				types.SetOfAny,
 				types.NewObject(nil, types.NewDynamicProperty(types.A, types.A)),
 			)).Description("keys to remove from x"),
 		),
@@ -1679,7 +1679,7 @@ var ObjectFilter = &Builtin{
 			)).Description("object to filter keys"),
 			types.Named("keys", types.NewAny(
 				types.NewArray(nil, types.A),
-				types.NewSet(types.A),
+				types.SetOfAny,
 				types.NewObject(nil, types.NewDynamicProperty(types.A, types.A)),
 			)).Description("keys to keep in `object`"),
 		),
@@ -1710,7 +1710,7 @@ var ObjectKeys = &Builtin{
 		types.Args(
 			types.Named("object", types.NewObject(nil, types.NewDynamicProperty(types.A, types.A))).Description("object to get keys from"),
 		),
-		types.Named("value", types.NewSet(types.A)).Description("set of `object`'s keys"),
+		types.Named("value", types.SetOfAny).Description("set of `object`'s keys"),
 	),
 }
 
@@ -1884,7 +1884,8 @@ var URLQueryEncodeObject = &Builtin{
 					types.NewAny(
 						types.S,
 						types.NewArray(nil, types.S),
-						types.NewSet(types.S)),
+						types.SetOfStr,
+					),
 				),
 			),
 			).Description("the object to encode"),
@@ -2575,13 +2576,13 @@ var ReachableBuiltin = &Builtin{
 				types.NewDynamicProperty(
 					types.A,
 					types.NewAny(
-						types.NewSet(types.A),
+						types.SetOfAny,
 						types.NewArray(nil, types.A)),
 				)),
 			).Description("object containing a set or array of neighboring vertices"),
-			types.Named("initial", types.NewAny(types.NewSet(types.A), types.NewArray(nil, types.A))).Description("set or array of root vertices"),
+			types.Named("initial", types.NewAny(types.SetOfAny, types.NewArray(nil, types.A))).Description("set or array of root vertices"),
 		),
-		types.Named("output", types.NewSet(types.A)).Description("set of vertices reachable from the `initial` vertices in the directed `graph`"),
+		types.Named("output", types.SetOfAny).Description("set of vertices reachable from the `initial` vertices in the directed `graph`"),
 	),
 }
 
@@ -2595,11 +2596,11 @@ var ReachablePathsBuiltin = &Builtin{
 				types.NewDynamicProperty(
 					types.A,
 					types.NewAny(
-						types.NewSet(types.A),
+						types.SetOfAny,
 						types.NewArray(nil, types.A)),
 				)),
 			).Description("object containing a set or array of root vertices"),
-			types.Named("initial", types.NewAny(types.NewSet(types.A), types.NewArray(nil, types.A))).Description("initial paths"), // TODO(sr): copied. is that correct?
+			types.Named("initial", types.NewAny(types.SetOfAny, types.NewArray(nil, types.A))).Description("initial paths"), // TODO(sr): copied. is that correct?
 		),
 		types.Named("output", types.NewSet(types.NewArray(nil, types.A))).Description("paths reachable from the `initial` vertices in the directed `graph`"),
 	),
@@ -3030,7 +3031,7 @@ var NetCIDRExpand = &Builtin{
 		types.Args(
 			types.Named("cidr", types.S).Description("CIDR to expand"),
 		),
-		types.Named("hosts", types.NewSet(types.S)).Description("set of IP addresses the CIDR `cidr` expands to"),
+		types.Named("hosts", types.SetOfStr).Description("set of IP addresses the CIDR `cidr` expands to"),
 	),
 }
 
@@ -3068,10 +3069,10 @@ Supports both IPv4 and IPv6 notations. IPv6 inputs need a prefix length (e.g. "/
 		types.Args(
 			types.Named("addrs", types.NewAny(
 				types.NewArray(nil, types.NewAny(types.S)),
-				types.NewSet(types.S),
+				types.SetOfStr,
 			)).Description("CIDRs or IP addresses"),
 		),
-		types.Named("output", types.NewSet(types.S)).Description("smallest possible set of CIDRs obtained after merging the provided list of IP addresses and subnets in `addrs`"),
+		types.Named("output", types.SetOfStr).Description("smallest possible set of CIDRs obtained after merging the provided list of IP addresses and subnets in `addrs`"),
 	),
 }
 
@@ -3113,7 +3114,7 @@ var NetLookupIPAddr = &Builtin{
 		types.Args(
 			types.Named("name", types.S).Description("domain name to resolve"),
 		),
-		types.Named("addrs", types.NewSet(types.S)).Description("IP addresses (v4 and v6) that `name` resolves to"),
+		types.Named("addrs", types.SetOfStr).Description("IP addresses (v4 and v6) that `name` resolves to"),
 	),
 	Nondeterministic: true,
 }
@@ -3163,7 +3164,7 @@ var Print = &Builtin{
 // The compiler rewrites print() calls to refer to the internal implementation.
 var InternalPrint = &Builtin{
 	Name: "internal.print",
-	Decl: types.NewFunction([]types.Type{types.NewArray(nil, types.NewSet(types.A))}, nil),
+	Decl: types.NewFunction([]types.Type{types.NewArray(nil, types.SetOfAny)}, nil),
 }
 
 var InternalTestCase = &Builtin{
@@ -3180,10 +3181,10 @@ var SetDiff = &Builtin{
 	Name: "set_diff",
 	Decl: types.NewFunction(
 		types.Args(
-			types.NewSet(types.A),
-			types.NewSet(types.A),
+			types.SetOfAny,
+			types.SetOfAny,
 		),
-		types.NewSet(types.A),
+		types.SetOfAny,
 	),
 	deprecated: true,
 }
@@ -3220,7 +3221,7 @@ var CastSet = &Builtin{
 	Name: "cast_set",
 	Decl: types.NewFunction(
 		types.Args(types.A),
-		types.NewSet(types.A),
+		types.SetOfAny,
 	),
 	deprecated: true,
 }
@@ -3286,7 +3287,7 @@ var All = &Builtin{
 	Decl: types.NewFunction(
 		types.Args(
 			types.NewAny(
-				types.NewSet(types.A),
+				types.SetOfAny,
 				types.NewArray(nil, types.A),
 			),
 		),
@@ -3302,7 +3303,7 @@ var Any = &Builtin{
 	Decl: types.NewFunction(
 		types.Args(
 			types.NewAny(
-				types.NewSet(types.A),
+				types.SetOfAny,
 				types.NewArray(nil, types.A),
 			),
 		),

--- a/v1/ast/check.go
+++ b/v1/ast/check.go
@@ -276,7 +276,7 @@ func (tc *typeChecker) checkRule(env *TypeEnv, as *AnnotationSet, rule *Rule) {
 	if len(rule.Head.Args) > 0 {
 		// If args are not referred to in body, infer as any.
 		WalkVars(rule.Head.Args, func(v Var) bool {
-			if cpy.Get(v) == nil {
+			if cpy.GetByValue(v) == nil {
 				cpy.tree.PutOne(v, types.A)
 			}
 			return false
@@ -285,7 +285,7 @@ func (tc *typeChecker) checkRule(env *TypeEnv, as *AnnotationSet, rule *Rule) {
 		// Construct function type.
 		args := make([]types.Type, len(rule.Head.Args))
 		for i := range len(rule.Head.Args) {
-			args[i] = cpy.Get(rule.Head.Args[i])
+			args[i] = cpy.GetByValue(rule.Head.Args[i].Value)
 		}
 
 		f := types.NewFunction(args, cpy.Get(rule.Head.Value))
@@ -294,7 +294,7 @@ func (tc *typeChecker) checkRule(env *TypeEnv, as *AnnotationSet, rule *Rule) {
 	} else {
 		switch rule.Head.RuleKind() {
 		case SingleValue:
-			typeV := cpy.Get(rule.Head.Value)
+			typeV := cpy.GetByValue(rule.Head.Value.Value)
 			if !path.IsGround() {
 				// e.g. store object[string: whatever] at data.p.q.r, not data.p.q.r[x] or data.p.q.r[x].y[z]
 				objPath := path.DynamicSuffix()
@@ -312,7 +312,7 @@ func (tc *typeChecker) checkRule(env *TypeEnv, as *AnnotationSet, rule *Rule) {
 				}
 			}
 		case MultiValue:
-			typeK := cpy.Get(rule.Head.Key)
+			typeK := cpy.GetByValue(rule.Head.Key.Value)
 			if typeK != nil {
 				tpe = types.NewSet(typeK)
 			}
@@ -341,7 +341,7 @@ func nestedObject(env *TypeEnv, path Ref, tpe types.Type) (types.Type, error) {
 	}
 
 	var dynamicProperty *types.DynamicProperty
-	typeK := env.Get(k)
+	typeK := env.GetByValue(k.Value)
 	if typeK == nil {
 		return nil, nil
 	}
@@ -391,7 +391,7 @@ func (tc *typeChecker) checkExprBuiltin(env *TypeEnv, expr *Expr) *Error {
 	// type checker relies on reordering (in particular for references to local
 	// vars).
 	name := expr.Operator()
-	tpe := env.Get(name)
+	tpe := env.GetByRef(name)
 
 	if tpe == nil {
 		if tc.allowUndefinedFuncs {
@@ -431,7 +431,7 @@ func (tc *typeChecker) checkExprBuiltin(env *TypeEnv, expr *Expr) *Error {
 		if !unify1(env, args[i], fargs.Arg(i), false) {
 			post := make([]types.Type, len(args))
 			for i := range args {
-				post[i] = env.Get(args[i])
+				post[i] = env.GetByValue(args[i].Value)
 			}
 			return newArgError(expr.Location, name, "invalid argument(s)", post, namedFargs)
 		}
@@ -453,7 +453,7 @@ func checkExprEq(env *TypeEnv, expr *Expr) *Error {
 	}
 
 	a, b := expr.Operand(0), expr.Operand(1)
-	typeA, typeB := env.Get(a), env.Get(b)
+	typeA, typeB := env.GetByValue(a.Value), env.GetByValue(b.Value)
 
 	if !unify2(env, a, typeA, b, typeB) {
 		err := NewError(TypeErr, expr.Location, "match error")
@@ -473,7 +473,7 @@ func (tc *typeChecker) checkExprWith(env *TypeEnv, expr *Expr, i int) *Error {
 	}
 
 	target, value := expr.With[i].Target, expr.With[i].Value
-	targetType, valueType := env.Get(target), env.Get(value)
+	targetType, valueType := env.GetByValue(target.Value), env.GetByValue(value.Value)
 
 	if t, ok := targetType.(*types.Function); ok { // built-in function replacement
 		switch v := valueType.(type) {
@@ -509,7 +509,7 @@ func unify2(env *TypeEnv, a *Term, typeA types.Type, b *Term, typeB types.Type) 
 	case Var:
 		switch b.Value.(type) {
 		case Var:
-			return unify1(env, a, types.A, false) && unify1(env, b, env.Get(a), false)
+			return unify1(env, a, types.A, false) && unify1(env, b, env.GetByValue(a.Value), false)
 		case *Array:
 			return unify2Array(env, b, a)
 		case *object:
@@ -526,14 +526,14 @@ func unify2Array(env *TypeEnv, a *Term, b *Term) bool {
 	case *Array:
 		if arr.Len() == bv.Len() {
 			for i := range arr.Len() {
-				if !unify2(env, arr.Elem(i), env.Get(arr.Elem(i)), bv.Elem(i), env.Get(bv.Elem(i))) {
+				if !unify2(env, arr.Elem(i), env.GetByValue(arr.Elem(i).Value), bv.Elem(i), env.GetByValue(bv.Elem(i).Value)) {
 					return false
 				}
 			}
 			return true
 		}
 	case Var:
-		return unify1(env, a, types.A, false) && unify1(env, b, env.Get(a), false)
+		return unify1(env, a, types.A, false) && unify1(env, b, env.GetByValue(a.Value), false)
 	}
 	return false
 }
@@ -545,14 +545,14 @@ func unify2Object(env *TypeEnv, a *Term, b *Term) bool {
 		cv := obj.Intersect(bv)
 		if obj.Len() == bv.Len() && bv.Len() == len(cv) {
 			for i := range cv {
-				if !unify2(env, cv[i][1], env.Get(cv[i][1]), cv[i][2], env.Get(cv[i][2])) {
+				if !unify2(env, cv[i][1], env.GetByValue(cv[i][1].Value), cv[i][2], env.GetByValue(cv[i][2].Value)) {
 					return false
 				}
 			}
 			return true
 		}
 	case Var:
-		return unify1(env, a, types.A, false) && unify1(env, b, env.Get(a), false)
+		return unify1(env, a, types.A, false) && unify1(env, b, env.GetByValue(a.Value), false)
 	}
 	return false
 }
@@ -615,22 +615,22 @@ func unify1(env *TypeEnv, term *Term, tpe types.Type, union bool) bool {
 		}
 		return false
 	case Ref, *ArrayComprehension, *ObjectComprehension, *SetComprehension:
-		return unifies(env.Get(v), tpe)
+		return unifies(env.GetByValue(v), tpe)
 	case Var:
 		if !union {
-			if exist := env.Get(v); exist != nil {
+			if exist := env.GetByValue(v); exist != nil {
 				return unifies(exist, tpe)
 			}
 			env.tree.PutOne(term.Value, tpe)
 		} else {
-			env.tree.PutOne(term.Value, types.Or(env.Get(v), tpe))
+			env.tree.PutOne(term.Value, types.Or(env.GetByValue(v), tpe))
 		}
 		return true
 	default:
 		if !IsConstant(v) {
 			panic("unreachable")
 		}
-		return unifies(env.Get(term), tpe)
+		return unifies(env.GetByValue(term.Value), tpe)
 	}
 }
 
@@ -732,7 +732,7 @@ func (rc *refChecker) Visit(x interface{}) bool {
 }
 
 func (rc *refChecker) checkApply(curr *TypeEnv, ref Ref) *Error {
-	switch tpe := curr.Get(ref).(type) {
+	switch tpe := curr.GetByRef(ref).(type) {
 	case *types.Function: // NOTE(sr): We don't support first-class functions, except for `with`.
 		return newRefErrUnsupported(ref[0].Location, rc.varRewriter(ref), len(ref)-1, tpe)
 	}
@@ -755,19 +755,19 @@ func (rc *refChecker) checkRef(curr *TypeEnv, node *typeTreeNode, ref Ref, idx i
 		switch head.Value.(type) {
 		case Var, String: // OK
 		default:
-			have := rc.env.Get(head.Value)
+			have := rc.env.GetByValue(head.Value)
 			return newRefErrInvalid(ref[0].Location, rc.varRewriter(ref), idx, have, types.S, getOneOfForNode(node))
 		}
 	}
 
-	if v, ok := head.Value.(Var); ok && idx != 0 {
+	if _, ok := head.Value.(Var); ok && idx != 0 {
 		tpe := types.Keys(rc.env.getRefRecExtent(node))
-		if exist := rc.env.Get(v); exist != nil {
+		if exist := rc.env.GetByValue(head.Value); exist != nil {
 			if !unifies(tpe, exist) {
 				return newRefErrInvalid(ref[0].Location, rc.varRewriter(ref), idx, exist, tpe, getOneOfForNode(node))
 			}
 		} else {
-			rc.env.tree.PutOne(v, tpe)
+			rc.env.tree.PutOne(head.Value, tpe)
 		}
 	}
 
@@ -817,7 +817,7 @@ func (rc *refChecker) checkRefLeaf(tpe types.Type, ref Ref, idx int) *Error {
 	switch value := head.Value.(type) {
 
 	case Var:
-		if exist := rc.env.Get(value); exist != nil {
+		if exist := rc.env.GetByValue(value); exist != nil {
 			if !unifies(exist, keys) {
 				return newRefErrInvalid(ref[0].Location, rc.varRewriter(ref), idx, exist, keys, getOneOfForType(tpe))
 			}

--- a/v1/ast/check_test.go
+++ b/v1/ast/check_test.go
@@ -518,7 +518,7 @@ func TestCheckInferenceRules(t *testing.T) {
 		{"ref_regression_array_key", ruleset2, "data.ref_regression_array_key.walker",
 			types.NewObject(
 				nil,
-				types.NewDynamicProperty(types.NewArray([]types.Type{types.NewArray(types.A, types.A), types.A}, nil),
+				types.NewDynamicProperty(types.NewArray([]types.Type{types.NewArray(types.NewAny(), types.A), types.A}, nil),
 					types.NewObject(nil, types.NewDynamicProperty(types.A, types.A))),
 			)},
 		{

--- a/v1/ast/env.go
+++ b/v1/ast/env.go
@@ -29,29 +29,38 @@ func newTypeEnv(f func() *typeChecker) *TypeEnv {
 }
 
 // Get returns the type of x.
+// Deprecated: Use GetByValue or GetByRef instead, as they are more efficient.
 func (env *TypeEnv) Get(x interface{}) types.Type {
-
 	if term, ok := x.(*Term); ok {
 		x = term.Value
 	}
 
-	switch x := x.(type) {
+	if v, ok := x.(Value); ok {
+		return env.GetByValue(v)
+	}
+
+	panic("unreachable")
+}
+
+// GetByValue returns the type of v.
+func (env *TypeEnv) GetByValue(v Value) types.Type {
+	switch x := v.(type) {
 
 	// Scalars.
 	case Null:
-		return types.NewNull()
+		return types.Nl
 	case Boolean:
-		return types.NewBoolean()
+		return types.B
 	case Number:
-		return types.NewNumber()
+		return types.N
 	case String:
-		return types.NewString()
+		return types.S
 
 	// Composites.
 	case *Array:
 		static := make([]types.Type, x.Len())
 		for i := range static {
-			tpe := env.Get(x.Elem(i).Value)
+			tpe := env.GetByValue(x.Elem(i).Value)
 			static[i] = tpe
 		}
 
@@ -63,7 +72,7 @@ func (env *TypeEnv) Get(x interface{}) types.Type {
 		return types.NewArray(static, dynamic)
 
 	case *lazyObj:
-		return env.Get(x.force())
+		return env.GetByValue(x.force())
 	case *object:
 		static := []*types.StaticProperty{}
 		var dynamic *types.DynamicProperty
@@ -72,14 +81,14 @@ func (env *TypeEnv) Get(x interface{}) types.Type {
 			if IsConstant(k.Value) {
 				kjson, err := JSON(k.Value)
 				if err == nil {
-					tpe := env.Get(v)
+					tpe := env.GetByValue(v.Value)
 					static = append(static, types.NewStaticProperty(kjson, tpe))
 					return
 				}
 			}
 			// Can't handle it as a static property, fallback to dynamic
-			typeK := env.Get(k.Value)
-			typeV := env.Get(v.Value)
+			typeK := env.GetByValue(k.Value)
+			typeV := env.GetByValue(v.Value)
 			dynamic = types.NewDynamicProperty(typeK, typeV)
 		})
 
@@ -92,8 +101,7 @@ func (env *TypeEnv) Get(x interface{}) types.Type {
 	case Set:
 		var tpe types.Type
 		x.Foreach(func(elem *Term) {
-			other := env.Get(elem.Value)
-			tpe = types.Or(tpe, other)
+			tpe = types.Or(tpe, env.GetByValue(elem.Value))
 		})
 		if tpe == nil {
 			tpe = types.A
@@ -104,47 +112,46 @@ func (env *TypeEnv) Get(x interface{}) types.Type {
 	case *ArrayComprehension:
 		cpy, errs := env.newChecker().CheckBody(env, x.Body)
 		if len(errs) == 0 {
-			return types.NewArray(nil, cpy.Get(x.Term))
+			return types.NewArray(nil, cpy.GetByValue(x.Term.Value))
 		}
 		return nil
 	case *ObjectComprehension:
 		cpy, errs := env.newChecker().CheckBody(env, x.Body)
 		if len(errs) == 0 {
-			return types.NewObject(nil, types.NewDynamicProperty(cpy.Get(x.Key), cpy.Get(x.Value)))
+			return types.NewObject(nil, types.NewDynamicProperty(cpy.GetByValue(x.Key.Value), cpy.GetByValue(x.Value.Value)))
 		}
 		return nil
 	case *SetComprehension:
 		cpy, errs := env.newChecker().CheckBody(env, x.Body)
 		if len(errs) == 0 {
-			return types.NewSet(cpy.Get(x.Term))
+			return types.NewSet(cpy.GetByValue(x.Term.Value))
 		}
 		return nil
 
 	// Refs.
 	case Ref:
-		return env.getRef(x)
+		return env.GetByRef(x)
 
 	// Vars.
 	case Var:
-		if node := env.tree.Child(x); node != nil {
+		if node := env.tree.Child(v); node != nil {
 			return node.Value()
 		}
 		if env.next != nil {
-			return env.next.Get(x)
+			return env.next.GetByValue(v)
 		}
 		return nil
 
 	// Calls.
 	case Call:
 		return nil
-
-	default:
-		panic("unreachable")
 	}
+
+	return env.Get(v)
 }
 
-func (env *TypeEnv) getRef(ref Ref) types.Type {
-
+// GetByRef returns the type of the value referred to by ref.
+func (env *TypeEnv) GetByRef(ref Ref) types.Type {
 	node := env.tree.Child(ref[0].Value)
 	if node == nil {
 		return env.getRefFallback(ref)
@@ -156,7 +163,7 @@ func (env *TypeEnv) getRef(ref Ref) types.Type {
 func (env *TypeEnv) getRefFallback(ref Ref) types.Type {
 
 	if env.next != nil {
-		return env.next.Get(ref)
+		return env.next.GetByRef(ref)
 	}
 
 	if RootDocumentNames.Contains(ref[0]) {
@@ -439,7 +446,7 @@ func insertIntoObject(o *types.Object, path Ref, tpe types.Type, env *TypeEnv) (
 		return o, nil
 	}
 
-	key := env.Get(path[0].Value)
+	key := env.GetByValue(path[0].Value)
 
 	if len(path) == 1 {
 		var dynamicProps *types.DynamicProperty

--- a/v1/server/handlers/compress.go
+++ b/v1/server/handlers/compress.go
@@ -131,7 +131,7 @@ func (w *compressResponseWriter) doCompressedResponse() error {
 	w.Header().Del(contentLengthHeader)
 	w.writeHeader()
 	// there's nothing to write
-	if w.buffer == nil || len(w.buffer) <= 0 {
+	if len(w.buffer) <= 0 {
 		return nil
 	}
 	gzipWriter := gzipPool.Get().(*gzip.Writer)

--- a/v1/tester/runner.go
+++ b/v1/tester/runner.go
@@ -569,10 +569,7 @@ func rewriteDuplicateTestNames(compiler *ast.Compiler) *ast.Error {
 				} else {
 					ref[len(ref)-1] = ast.StringTerm(newName)
 				}
-				for i := range len(dynamicSuffix) {
-					ref = append(ref, dynamicSuffix[i])
-				}
-				rule.Head.SetRef(ref)
+				rule.Head.SetRef(append(ref, dynamicSuffix...))
 			}
 			count[key]++
 		}

--- a/v1/types/decode.go
+++ b/v1/types/decode.go
@@ -31,13 +31,13 @@ func Unmarshal(bs []byte) (result Type, err error) {
 	if err = util.UnmarshalJSON(bs, &hint); err == nil {
 		switch hint.Type {
 		case typeNull:
-			result = NewNull()
+			result = Nl
 		case typeBoolean:
-			result = NewBoolean()
+			result = B
 		case typeNumber:
-			result = NewNumber()
+			result = N
 		case typeString:
-			result = NewString()
+			result = S
 		case typeArray:
 			var arr rawarray
 			if err = util.UnmarshalJSON(bs, &arr); err == nil {

--- a/v1/types/types.go
+++ b/v1/types/types.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 
@@ -48,6 +49,8 @@ type Null struct{}
 func NewNull() Null {
 	return Null{}
 }
+
+var Nl Type = NewNull()
 
 // NamedType represents a type alias with an arbitrary name and description.
 // This is useful for generating documentation for built-in functions.
@@ -114,7 +117,7 @@ func (t Null) String() string {
 type Boolean struct{}
 
 // B represents an instance of the boolean type.
-var B = NewBoolean()
+var B Type = NewBoolean()
 
 // NewBoolean returns a new Boolean type.
 func NewBoolean() Boolean {
@@ -137,7 +140,7 @@ func (t Boolean) String() string {
 type String struct{}
 
 // S represents an instance of the string type.
-var S = NewString()
+var S Type = NewString()
 
 // NewString returns a new String type.
 func NewString() String {
@@ -159,7 +162,7 @@ func (String) String() string {
 type Number struct{}
 
 // N represents an instance of the number type.
-var N = NewNumber()
+var N Type = NewNumber()
 
 // NewNumber returns a new Number type.
 func NewNumber() Number {
@@ -253,6 +256,13 @@ type Set struct {
 	of Type
 }
 
+// Boxed set types.
+var (
+	SetOfAny Type = NewSet(A)
+	SetOfStr Type = NewSet(S)
+	SetOfNum Type = NewSet(N)
+)
+
 // NewSet returns a new Set type.
 func NewSet(of Type) *Set {
 	return &Set{
@@ -340,9 +350,8 @@ type Object struct {
 
 // NewObject returns a new Object type.
 func NewObject(static []*StaticProperty, dynamic *DynamicProperty) *Object {
-	sort.Slice(static, func(i, j int) bool {
-		cmp := util.Compare(static[i].Key, static[j].Key)
-		return cmp == -1
+	slices.SortFunc(static, func(a, b *StaticProperty) int {
+		return util.Compare(a.Key, b.Key)
 	})
 	return &Object{
 		static:  static,
@@ -505,7 +514,7 @@ func mergeObjects(a, b *Object) *Object {
 type Any []Type
 
 // A represents the superset of all types.
-var A = NewAny()
+var A Type = NewAny()
 
 // NewAny returns a new Any type.
 func NewAny(of ...Type) Any {
@@ -1130,7 +1139,7 @@ func Nil(a Type) bool {
 func TypeOf(x interface{}) Type {
 	switch x := x.(type) {
 	case nil:
-		return NewNull()
+		return Nl
 	case bool:
 		return B
 	case string:


### PR DESCRIPTION
And make shorthand types boxed types to avoid allocations at runtime.

Below stats show the difference running Regal lint with all rules disabled (to better highlight compilation costs). @srenatus will be pleased by this format, I'm sure.

```
goos: darwin
goarch: arm64
pkg: github.com/styrainc/regal/pkg/linter
cpu: Apple M4 Pro
                       │  main.txt   │              pr.txt               │
                       │   sec/op    │   sec/op     vs base              │
RegalNoEnabledRules-12   190.8m ± 2%   181.8m ± 2%  -4.72% (p=0.002 n=6)

                       │   main.txt   │               pr.txt               │
                       │     B/op     │     B/op      vs base              │
RegalNoEnabledRules-12   474.4Mi ± 0%   471.3Mi ± 0%  -0.65% (p=0.002 n=6)

                       │  main.txt   │              pr.txt               │
                       │  allocs/op  │  allocs/op   vs base              │
RegalNoEnabledRules-12   9.657M ± 0%   9.476M ± 0%  -1.88% (p=0.002 n=6)
```