### PR TITLE
Update term_test.go

### DIFF
--- a/v1/ast/term_test.go
+++ b/v1/ast/term_test.go
@@ -76,6 +76,7 @@ func TestInterfaceToValue(t *testing.T) {
 		{uint64(100), "100"},
 		{[]string{"dummy", "tummy"}, `["dummy", "tummy"]`},
 		{String("bob"), `"bob"`},
+		{[]byte("base64ed"), `"YmFzZTY0ZWQ="`},  // byte array is base64 encoded.
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
add a test for []byte

### Why the changes in this PR are needed?
I was surprised to see that []byte isn't serialized as string value and wanted to capture that in the test.

### What are the changes in this PR?
Just adding a test.