### PR TITLE
add test for []byte

### DIFF
--- a/v1/ast/term_test.go
+++ b/v1/ast/term_test.go
@@ -76,7 +76,7 @@ func TestInterfaceToValue(t *testing.T) {
 		{uint64(100), "100"},
 		{[]string{"dummy", "tummy"}, `["dummy", "tummy"]`},
 		{String("bob"), `"bob"`},
-				{[]byte("base64ed"), `"YmFzZTY0ZWQ="`}, // []byte is base64 encoded.
+		{[]byte("base64ed"), `"YmFzZTY0ZWQ="`}, // []byte is base64 encoded.
 	}
 
 	for _, tc := range tests {

--- a/v1/ast/term_test.go
+++ b/v1/ast/term_test.go
@@ -76,6 +76,7 @@ func TestInterfaceToValue(t *testing.T) {
 		{uint64(100), "100"},
 		{[]string{"dummy", "tummy"}, `["dummy", "tummy"]`},
 		{String("bob"), `"bob"`},
+				{[]byte("base64ed"), `"YmFzZTY0ZWQ="`}, // []byte is base64 encoded.
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
### Why the changes in this PR are needed?
I was confused when InterfaceToValue base64-ed the byte array, and decided to explicitly add a test for it.

### What are the changes in this PR?
Just a test case