### PR TITLE
Explicitly fetching fetching git tags for CI builds

### DIFF
--- a/.github/workflows/post-merge.yaml
+++ b/.github/workflows/post-merge.yaml
@@ -20,9 +20,6 @@ jobs:
         with:
           token: ${{ secrets.GH_PUSH_TOKEN }} # required to push to protected branch below
 
-      - name: Get tags
-        run: git fetch --tags origin
-
       - name: Generate
         run: make clean generate docs-generate-cli-docs
 
@@ -94,6 +91,9 @@ jobs:
       - name: Check out code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
+      - name: Get tags
+        run: git fetch --tags origin
+
       - name: Build Linux and Windows
         run: make ci-go-ci-build-linux ci-go-ci-build-linux-static ci-go-ci-build-windows
         timeout-minutes: 30
@@ -121,6 +121,9 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Get tags
+        run: git fetch --tags origin
 
       - id: go_version
         name: Read go version
@@ -153,6 +156,9 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Get tags
+        run: git fetch --tags origin
 
       - name: Test
         run: make ci-release-test

--- a/.github/workflows/post-merge.yaml
+++ b/.github/workflows/post-merge.yaml
@@ -20,6 +20,9 @@ jobs:
         with:
           token: ${{ secrets.GH_PUSH_TOKEN }} # required to push to protected branch below
 
+      - name: Get tags
+        run: git fetch --tags origin
+
       - name: Generate
         run: make clean generate docs-generate-cli-docs
 

--- a/.github/workflows/post-merge.yaml
+++ b/.github/workflows/post-merge.yaml
@@ -90,9 +90,7 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - name: Get tags
-        run: git fetch --tags origin
+        fetch-tags: true
 
       - name: Build Linux and Windows
         run: make ci-go-ci-build-linux ci-go-ci-build-linux-static ci-go-ci-build-windows
@@ -121,9 +119,7 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - name: Get tags
-        run: git fetch --tags origin
+        fetch-tags: true
 
       - id: go_version
         name: Read go version
@@ -156,9 +152,7 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - name: Get tags
-        run: git fetch --tags origin
+        fetch-tags: true
 
       - name: Test
         run: make ci-release-test

--- a/.github/workflows/post-tag.yaml
+++ b/.github/workflows/post-tag.yaml
@@ -29,6 +29,9 @@ jobs:
       - name: Check out code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
+      - name: Get tags
+        run: git fetch --tags origin
+
       - name: Build Linux and Windows
         run: make ci-go-ci-build-linux ci-go-ci-build-linux-static ci-go-ci-build-windows
         timeout-minutes: 30
@@ -56,6 +59,9 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Get tags
+        run: git fetch --tags origin
 
       - id: go_version
         name: Read go version

--- a/.github/workflows/post-tag.yaml
+++ b/.github/workflows/post-tag.yaml
@@ -12,11 +12,9 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        fetch-tags: true
         with:
           token: ${{ secrets.GH_PUSH_TOKEN }}
-
-      - name: Get tags
-        run: git fetch --tags origin
 
       - name: Generate
         run: make clean generate
@@ -28,9 +26,7 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - name: Get tags
-        run: git fetch --tags origin
+        fetch-tags: true
 
       - name: Build Linux and Windows
         run: make ci-go-ci-build-linux ci-go-ci-build-linux-static ci-go-ci-build-windows
@@ -59,9 +55,7 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - name: Get tags
-        run: git fetch --tags origin
+        fetch-tags: true
 
       - id: go_version
         name: Read go version

--- a/.github/workflows/post-tag.yaml
+++ b/.github/workflows/post-tag.yaml
@@ -15,6 +15,9 @@ jobs:
         with:
           token: ${{ secrets.GH_PUSH_TOKEN }}
 
+      - name: Get tags
+        run: git fetch --tags origin
+
       - name: Generate
         run: make clean generate
 


### PR DESCRIPTION
An attempt to deal with [failing](https://github.com/open-policy-agent/opa/actions/runs/13561553364/job/37905498515) nightly Trivy scans.