### PR TITLE
ci: Using `fetch-depth` when fetching tags

### DIFF
--- a/.github/workflows/post-merge.yaml
+++ b/.github/workflows/post-merge.yaml
@@ -91,6 +91,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
+          fetch-depth: 0
           fetch-tags: true
 
       - name: Build Linux and Windows
@@ -121,6 +122,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
+          fetch-depth: 0
           fetch-tags: true
 
       - id: go_version
@@ -155,6 +157,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
+          fetch-depth: 0
           fetch-tags: true
 
       - name: Test

--- a/.github/workflows/post-merge.yaml
+++ b/.github/workflows/post-merge.yaml
@@ -156,9 +156,6 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-          fetch-tags: true
 
       - name: Test
         run: make ci-release-test

--- a/.github/workflows/post-merge.yaml
+++ b/.github/workflows/post-merge.yaml
@@ -94,6 +94,9 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
+      - name: Git Describe
+        run: git describe --tags
+
       - name: Build Linux and Windows
         run: make ci-go-ci-build-linux ci-go-ci-build-linux-static ci-go-ci-build-windows
         timeout-minutes: 30
@@ -124,6 +127,9 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+
+      - name: Git Describe
+        run: git describe --tags
 
       - id: go_version
         name: Read go version

--- a/.github/workflows/post-tag.yaml
+++ b/.github/workflows/post-tag.yaml
@@ -14,6 +14,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           token: ${{ secrets.GH_PUSH_TOKEN }}
+          fetch-depth: 0
           fetch-tags: true
 
       - name: Generate
@@ -27,6 +28,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
+          fetch-depth: 0
           fetch-tags: true
 
       - name: Build Linux and Windows
@@ -57,6 +59,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
+          fetch-depth: 0
           fetch-tags: true
 
       - id: go_version

--- a/.github/workflows/post-tag.yaml
+++ b/.github/workflows/post-tag.yaml
@@ -14,8 +14,6 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           token: ${{ secrets.GH_PUSH_TOKEN }}
-          fetch-depth: 0
-          fetch-tags: true
 
       - name: Generate
         run: make clean generate

--- a/.github/workflows/post-tag.yaml
+++ b/.github/workflows/post-tag.yaml
@@ -29,6 +29,9 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
+      - name: Git Describe
+        run: git describe --tags
+
       - name: Build Linux and Windows
         run: make ci-go-ci-build-linux ci-go-ci-build-linux-static ci-go-ci-build-windows
         timeout-minutes: 30
@@ -59,6 +62,9 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+
+      - name: Git Describe
+        run: git describe --tags
 
       - id: go_version
         name: Read go version

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -17,6 +17,12 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Git Describe
+        run: git describe --tags
 
       - name: Generate
         run: make clean generate

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -17,12 +17,6 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-          fetch-tags: true
-
-      - name: Git Describe
-        run: git describe --tags
 
       - name: Generate
         run: make clean generate


### PR DESCRIPTION
Tags aren't fetched unless complete git history is pulled with `fetch-depth: 0`