### PR TITLE
perf: StringTerm interning

### DIFF
--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -21,14 +21,9 @@ type Params struct {
 	SkipKnownSchemaCheck   bool
 }
 
-var (
-	configKey               = ast.StringTerm("config")
-	envKey                  = ast.StringTerm("env")
-	versionKey              = ast.StringTerm("version")
-	commitKey               = ast.StringTerm("commit")
-	authorizationEnabledKey = ast.StringTerm("authorization_enabled")
-	skipKnownSchemaCheckKey = ast.StringTerm("skip_known_schema_check")
-)
+func init() {
+	ast.InternedStringTerm.Store("config", "env", "version", "commit", "authorization_enabled", "skip_known_schema_check")
+}
 
 // Term returns the runtime information as an ast.Term object.
 func Term(params Params) (*ast.Term, error) {
@@ -47,7 +42,7 @@ func Term(params Params) (*ast.Term, error) {
 			return nil, err
 		}
 
-		obj.Insert(configKey, ast.NewTerm(v))
+		obj.Insert(ast.InternedStringTerm.Get("config"), ast.NewTerm(v))
 	}
 
 	env := ast.NewObject()
@@ -61,11 +56,11 @@ func Term(params Params) (*ast.Term, error) {
 		}
 	}
 
-	obj.Insert(envKey, ast.NewTerm(env))
-	obj.Insert(versionKey, ast.StringTerm(version.Version))
-	obj.Insert(commitKey, ast.StringTerm(version.Vcs))
-	obj.Insert(authorizationEnabledKey, ast.InternedBooleanTerm(params.IsAuthorizationEnabled))
-	obj.Insert(skipKnownSchemaCheckKey, ast.InternedBooleanTerm(params.SkipKnownSchemaCheck))
+	obj.Insert(ast.InternedStringTerm.Get("env"), ast.NewTerm(env))
+	obj.Insert(ast.InternedStringTerm.Get("version"), ast.StringTerm(version.Version))
+	obj.Insert(ast.InternedStringTerm.Get("commit"), ast.StringTerm(version.Vcs))
+	obj.Insert(ast.InternedStringTerm.Get("authorization_enabled"), ast.InternedBooleanTerm(params.IsAuthorizationEnabled))
+	obj.Insert(ast.InternedStringTerm.Get("skip_known_schema_check"), ast.InternedBooleanTerm(params.SkipKnownSchemaCheck))
 
 	return ast.NewTerm(obj), nil
 }

--- a/v1/ast/builtins.go
+++ b/v1/ast/builtins.go
@@ -3401,7 +3401,14 @@ func (b *Builtin) IsTargetPos(i int) bool {
 
 func init() {
 	BuiltinMap = map[string]*Builtin{}
-	for _, b := range &DefaultBuiltins {
-		RegisterBuiltin(b)
+	builtinNames := make([]string, 0, len(DefaultBuiltins))
+	for i := range &DefaultBuiltins {
+		RegisterBuiltin(DefaultBuiltins[i])
+		builtinNames = append(builtinNames, DefaultBuiltins[i].Name)
+		if DefaultBuiltins[i].Infix != "" {
+			builtinNames = append(builtinNames, DefaultBuiltins[i].Infix)
+		}
 	}
+
+	InternedStringTerm.Store(builtinNames...)
 }

--- a/v1/plugins/plugins.go
+++ b/v1/plugins/plugins.go
@@ -536,6 +536,12 @@ func (m *Manager) Init(ctx context.Context) error {
 	}
 
 	err := storage.Txn(ctx, m.Store, params, func(txn storage.Transaction) error {
+		// Drop references to these once we've passed them to the compiler,
+		// as to allow garbage collection to clean them up.
+		defer func() {
+			m.initBundles = nil
+			m.initFiles = loader.Result{}
+		}()
 
 		result, err := initload.InsertAndCompile(ctx, initload.InsertAndCompileOptions{
 			Store:                 m.Store,

--- a/v1/storage/inmem/txn.go
+++ b/v1/storage/inmem/txn.go
@@ -14,6 +14,7 @@ import (
 	"github.com/open-policy-agent/opa/v1/storage"
 	"github.com/open-policy-agent/opa/v1/storage/internal/errors"
 	"github.com/open-policy-agent/opa/v1/storage/internal/ptr"
+	"github.com/open-policy-agent/opa/v1/util"
 )
 
 // transaction implements the low-level read/write operations on the in-memory
@@ -329,6 +330,11 @@ type updateRaw struct {
 
 func (db *store) newUpdate(data interface{}, op storage.PatchOp, path storage.Path, idx int, value interface{}) (dataUpdate, error) {
 	if db.returnASTValuesOnRead {
+		keys := util.KeysRecursive(value, map[string]struct{}{})
+		if len(keys) > 0 {
+			ast.InternedStringTerm.Store(util.Keys(keys)...)
+		}
+
 		astData, err := interfaceToValue(data)
 		if err != nil {
 			return nil, err

--- a/v1/topdown/http.go
+++ b/v1/topdown/http.go
@@ -1006,8 +1006,10 @@ func insertIntoHTTPSendInterQueryCache(bctx BuiltinContext, key ast.Value, resp 
 }
 
 func createKeys() {
+	ast.InternedStringTerm.Store(allowedKeyNames[:]...)
+
 	for _, element := range allowedKeyNames {
-		term := ast.StringTerm(element)
+		term := ast.InternedStringTerm.Get(element)
 
 		allowedKeys.Add(term)
 		keyCache[element] = term

--- a/v1/topdown/strings.go
+++ b/v1/topdown/strings.go
@@ -310,14 +310,14 @@ func builtinSubstring(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Ter
 
 	sbase := string(base)
 	if sbase == "" {
-		return iter(ast.InternedEmptyString)
+		return iter(ast.InternedStringTerm.Get(""))
 	}
 
 	// Optimized path for the likely common case of ASCII strings.
 	// This allocates less memory and runs in about 1/3 the time.
 	if isASCII(sbase) {
 		if startIndex >= len(sbase) {
-			return iter(ast.InternedEmptyString)
+			return iter(ast.InternedStringTerm.Get(""))
 		}
 
 		if length < 0 {
@@ -342,7 +342,7 @@ func builtinSubstring(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Ter
 	runes := []rune(base)
 
 	if startIndex >= len(runes) {
-		return iter(ast.InternedEmptyString)
+		return iter(ast.InternedStringTerm.Get(""))
 	}
 
 	var s string
@@ -649,7 +649,7 @@ func builtinSprintf(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term)
 	if s == "%d" && astArr.Len() == 1 {
 		if n, ok := astArr.Elem(0).Value.(ast.Number); ok {
 			if i, ok := n.Int(); ok {
-				return iter(ast.InternedStringTerm(strconv.Itoa(i)))
+				return iter(ast.InternedStringTerm.GetOrCreate(strconv.Itoa(i)))
 			}
 		}
 	}

--- a/v1/util/maps.go
+++ b/v1/util/maps.go
@@ -32,3 +32,25 @@ func Values[M ~map[K]V, K comparable, V any](m M) []V {
 	}
 	return r
 }
+
+// KeysRecursive returns a set of string keys from any map or slice,
+// including nested maps and slices.
+func KeysRecursive(x any, keys map[string]struct{}) map[string]struct{} {
+	switch x := x.(type) {
+	case map[string]any:
+		for k := range x {
+			keys[k] = struct{}{}
+			v := x[k]
+			keys = KeysRecursive(v, keys)
+		}
+	case []any:
+		for i := range x {
+			keys = KeysRecursive(x[i], keys)
+		}
+	case []map[string]any:
+		for i := range x {
+			keys = KeysRecursive(x[i], keys)
+		}
+	}
+	return keys
+}

--- a/v1/util/maps_test.go
+++ b/v1/util/maps_test.go
@@ -16,3 +16,20 @@ func TestValues(t *testing.T) {
 		t.Errorf("Expected [1, 2, 3], got %v", values)
 	}
 }
+
+func TestKeysRecursive(t *testing.T) {
+	testMap := map[string]any{
+		"a": 1,
+		"b": map[string]any{
+			"c": 2,
+			"d": map[string]any{
+				"e": 3,
+			},
+		},
+	}
+	keys := KeysRecursive(testMap, make(map[string]struct{}))
+	keysSlice := KeysSorted(keys)
+	if !slices.Equal(keysSlice, []string{"a", "b", "c", "d", "e"}) {
+		t.Errorf("Expected [a b c d e], got %v", keysSlice)
+	}
+}


### PR DESCRIPTION
Allow interning of String values and terms, and have functions like `ast.InterfaceToValue` leverage that capability when possible.

This first PR mainly impacts the store when configured to store AST objects, as in that case all string keys are interned. But any function calling `InterfaceToValue` will benefit, provided that the term is interned since before.

Memory consumption for the bundle I used for testing went from 800 MB to 500 MB.

Note that this is really just scratching the surface of what we can do with string interning! Most or all built-ins dealing with strings could for example make use of this... but let's not get ahead of ourselves 🙂