### PR TITLE
Bumping GHA runner to `ubuntu-24.04`

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   race-detector:
     name: Go Race Detector
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -29,7 +29,7 @@ jobs:
 
   native-fuzzer:
     name: Go Fuzzer (native)
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -61,7 +61,7 @@ jobs:
 
   go-perf:
     name: Go Perf
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -83,7 +83,7 @@ jobs:
 
   trivy-scan-image:
     name: Trivy security scan image
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code # needed for .trivyignore file
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -115,7 +115,7 @@ jobs:
 
   trivy-scan-repo:
     name: Trivy security scan repo
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -145,7 +145,7 @@ jobs:
 
   govulncheck:
     name: Go vulnerability check
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - id: go_version

--- a/.github/workflows/post-merge.yaml
+++ b/.github/workflows/post-merge.yaml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       contents: write  # for Git to git push
     name: Sync Generated Code and Docs
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -73,7 +73,7 @@ jobs:
 
   code-coverage:
     name: Update Go Test Coverage
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: generate
     steps:
       - name: Check out code
@@ -85,7 +85,7 @@ jobs:
 
   release-build:
     name: Release Build (linux, windows)
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: generate
     steps:
       - name: Check out code
@@ -157,7 +157,7 @@ jobs:
 
   deploy-edge:
     name: Push Edge Release
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: [release-build, release-build-darwin]
     steps:
       - name: Check out code
@@ -191,7 +191,7 @@ jobs:
 
   deploy-wasm-builder:
     name: Deploy WASM Builder
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: generate
     steps:
       - name: Check out code

--- a/.github/workflows/post-release.yaml
+++ b/.github/workflows/post-release.yaml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   kick-netlify:
     name: Kick Netlify
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Trigger Netlify Deploy
         env:

--- a/.github/workflows/post-tag.yaml
+++ b/.github/workflows/post-tag.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   generate:
     name: Generate Code
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -20,7 +20,7 @@ jobs:
 
   release-build:
     name: Release Build (linux, windows)
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: generate
     steps:
       - name: Check out code
@@ -93,7 +93,7 @@ jobs:
   build:
     name: Push Latest Release
     needs: [release-build, release-build-darwin]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -13,7 +13,7 @@ jobs:
   # up for parallel runners for faster PR feedback and a nicer UX.
   generate:
     name: Generate Code
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -38,21 +38,21 @@ jobs:
       matrix:
         include:
           - os: linux
-            run: ubuntu-22.04
+            run: ubuntu-24.04
             targets: ci-go-ci-build-linux ci-go-ci-build-linux-static
             arch: amd64
           - os: linux
-            run: ubuntu-22.04
+            run: ubuntu-24.04
             targets: ci-go-ci-build-linux-static
             arch: arm64
           - os: linux
-            run: ubuntu-22.04
+            run: ubuntu-24.04
             targets: ci-go-ci-build-linux-static
             go_tags: GO_TAGS="-tags=opa_no_oci"
             variant_name: opa_no_ci
             arch: arm64
           - os: windows
-            run: ubuntu-22.04
+            run: ubuntu-24.04
             targets: ci-go-ci-build-windows
             arch: amd64
           - os: darwin
@@ -111,7 +111,7 @@ jobs:
       matrix:
         include:
           - os: linux
-            run: ubuntu-22.04
+            run: ubuntu-24.04
           - os: darwin
             run: macos-14
     steps:
@@ -138,7 +138,7 @@ jobs:
 
   go-lint:
     name: Go Lint
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -149,7 +149,7 @@ jobs:
 
   yaml-lint:
     name: YAML Lint
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -162,7 +162,7 @@ jobs:
 
   wasm:
     name: WASM
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: generate
     steps:
       - name: Check out code
@@ -203,7 +203,7 @@ jobs:
 
   check-generated:
     name: Check Generated
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: generate
     steps:
       - name: Check out code
@@ -222,7 +222,7 @@ jobs:
 
   race-detector:
     name: Go Race Detector
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: generate
     steps:
       - name: Check out code
@@ -240,7 +240,7 @@ jobs:
 
   smoke-test-docker-images:
     name: docker image smoke test
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: go-build
     steps:
       - name: Check out code
@@ -274,11 +274,11 @@ jobs:
       matrix:
         include:
           - os: linux
-            run: ubuntu-22.04
+            run: ubuntu-24.04
             exec: opa_linux_amd64
             arch: amd64
           - os: linux
-            run: ubuntu-22.04
+            run: ubuntu-24.04
             exec: opa_linux_amd64_static
             arch: amd64
             wasm: disabled
@@ -320,7 +320,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-14]
+        os: [ubuntu-24.04, macos-14]
         version: ["1.21"]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -341,7 +341,7 @@ jobs:
   # Run PR metadata against Rego policies
   rego-check-pr:
     name: Rego PR checks
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
The older `ubuntu-22.04` runner is [deprecated](https://github.com/actions/runner-images/issues/11101) and has started getting brownouts.
