### PR TITLE
tester: Only including failed sub-test cases in report summary when non-verbose

### DIFF
--- a/v1/tester/reporter.go
+++ b/v1/tester/reporter.go
@@ -146,8 +146,15 @@ func (r PrettyReporter) Report(ch chan *Result) error {
 			r.println(tr.string(false))
 
 			w := newIndentingWriter(r.Output)
-			if sr := tr.SubResults; len(sr) > 0 {
-				_, _ = fmt.Fprint(w, sr.string("  "))
+			if srs := tr.SubResults; len(srs) > 0 {
+				for fullName, sr := range srs.Iter {
+					if sr.Fail || r.Verbose {
+						_, _ = fmt.Fprint(w, fmt.Sprintf("%s%s\n",
+							strings.Repeat("  ", len(fullName)-1),
+							sr.String(),
+						))
+					}
+				}
 			}
 
 			if len(tr.Output) > 0 {

--- a/v1/tester/reporter.go
+++ b/v1/tester/reporter.go
@@ -149,10 +149,10 @@ func (r PrettyReporter) Report(ch chan *Result) error {
 			if srs := tr.SubResults; len(srs) > 0 {
 				for fullName, sr := range srs.Iter {
 					if sr.Fail || r.Verbose {
-						_, _ = fmt.Fprint(w, fmt.Sprintf("%s%s\n",
+						_, _ = fmt.Fprintf(w, "%s%s\n",
 							strings.Repeat("  ", len(fullName)-1),
 							sr.String(),
-						))
+						)
 					}
 				}
 			}

--- a/v1/tester/reporter_test.go
+++ b/v1/tester/reporter_test.go
@@ -444,11 +444,7 @@ data.foo.baz.p.q.r.test_quz: FAIL (0s)
 
 policy5.rego:
 data.foo.qux.test_cases_nested: FAIL (0s)
-  one: PASS
-    bar: PASS
-    foo: PASS
   two: FAIL
-    bar: PASS
     foo: FAIL
 --------------------------------------------------------------------------------
 PASS: 5/11
@@ -621,14 +617,8 @@ data.foo.baz.p.q.r.test_quz: FAIL (0s)
 policy4.rego:
 data.foo.qux.test_cases: FAIL (0s)
   bar: FAIL
-  baz: PASS
-  foo: PASS
 data.foo.qux.test_cases_nested: FAIL (0s)
-  one: PASS
-    bar: PASS
-    foo: PASS
   two: FAIL
-    bar: PASS
     foo: FAIL
 --------------------------------------------------------------------------------
 PASS: 7/14


### PR DESCRIPTION
This aligns with not including PASS:ing non-parameterized tests in non-verbose test report summary.

verbose:

```
data.foo.qux.test_cases: FAIL (0s)
  bar: FAIL
  baz: PASS
  foo: PASS
```

non-verbose:

```
data.foo.qux.test_cases: FAIL (0s)
  bar: FAIL
```