### PR TITLE
planner: adjust check in ruletree scanning

### DIFF
--- a/v1/test/cases/testdata/v1/planner-ir/test-call-dynamic.yaml
+++ b/v1/test/cases/testdata/v1/planner-ir/test-call-dynamic.yaml
@@ -117,3 +117,18 @@ cases:
         a.y := "E"
     want_result:
       - x: true
+  - note: ir/call-dynamic with ref heads and unrelated rule (issue 7399)
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+        p := data[first].allow.see.something_else if first := "primary"
+      - |
+        package primary
+        allow[action].something if  action := "show"
+        allow.see.something_else if true
+      - |
+        package unrelated
+        allow.other.stuff if true
+    want_result:
+      - x: true


### PR DESCRIPTION
We previously only checked if there were any children at all. As #7399 showed, that could have lead into a cul-de-sac.

With this change, we're attempting to look one step ahead, so situations like that one can be ruled out. That said, both the unit test and the yaml tests are _very_ close to the original issue, at risk of of overfitting the solution. But all the previous tests still pass, so this might be OK.

Fixes #7399.