### PR TITLE
fix: repeat args from sub-func call

### DIFF
--- a/v1/sdk/opa.go
+++ b/v1/sdk/opa.go
@@ -580,7 +580,6 @@ func evaluate(ctx context.Context, args evalArgs) (interface{}, types.Provenance
 		rego.EvalTime(args.now),
 		rego.EvalParsedInput(inputAST),
 		rego.EvalTransaction(args.txn),
-		rego.EvalMetrics(args.m),
 		rego.EvalInterQueryBuiltinCache(args.interQueryCache),
 		rego.EvalInterQueryBuiltinValueCache(args.interQueryBuiltinValueCache),
 		rego.EvalNDBuiltinCache(args.ndbcache),


### PR DESCRIPTION

### Why the changes in this PR are needed?

I am verifying some lint idea in my project see https://github.com/alingse/sundrylint/pull/10
it report the function call with repeat args from a sub-function call.

we think the sub-function call is heavy, so the repeat args probably a copy-and-paste mistake.

I check the top 4000 github repos, and found this repo has this case.

### What are the changes in this PR?

remove duplicate code

### Notes to assist PR review:


### Further comments:


