### PR TITLE
docs: Update slack inviter link

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ OPA is proud to be a graduated project in the [Cloud Native Computing Foundation
 
 ## Want to talk about OPA or get support?
 
-- Join the [OPA Slack](https://slack.openpolicyagent.org) to talk to other OPA users and maintainers. See `#help` for support.
+- Join the [OPA Slack](https://inviter.co/opa) to talk to other OPA users and maintainers. See `#help` for support.
 - Check out the [Community Discussions](https://github.com/orgs/open-policy-agent/discussions) to ask questions.
 - See the [Support](https://www.openpolicyagent.org/support/) page for commercial support options.
 

--- a/docs/content/contributing.md
+++ b/docs/content/contributing.md
@@ -8,7 +8,7 @@ Thanks for your interest in contributing to the Open Policy Agent project!
 
 {{< info >}}
 Most of the discussions about OPA take place on Slack, if you haven't already,
-you can [sign up here](https://slack.openpolicyagent.org/).
+you can [sign up here](https://inviter.co/opa/).
 {{< /info >}}
 
 ## I'd like to help OPA users
@@ -58,7 +58,7 @@ If you have a talk or blog you'd like to share please feel free to post in:
 ## I'm interested in something else...
 
 Sounds interesting, we'd love to hear all about it,
-[sign up for our Slack](https://slack.openpolicyagent.org/) and
+[sign up for our Slack](https://inviter.co/opa/) and
 drop a message in the
 [#contributors](https://openpolicyagent.slack.com/archives/C02L1TLPN59)
 channel.

--- a/docs/content/debugging.md
+++ b/docs/content/debugging.md
@@ -40,7 +40,7 @@ opa run [policy-files] [data-files]
 
 The [Rego Playground](http://play.openpolicyagent.org) is a web-based Rego development environment that can be
 used to test policies with different inputs and data. If you are interested in asking for help in the
-[OPA Slack](http://slack.openpolicyagent.org), the playground is a great way to share your policy and data with
+[OPA Slack](https://inviter.co/opa), the playground is a great way to share your policy and data with
 others.
 
 ## Using the `print` Built-in Function

--- a/docs/content/editor-and-ide-support.md
+++ b/docs/content/editor-and-ide-support.md
@@ -23,7 +23,7 @@ evaluation, policy coverage, and more.
 
 {{< info >}}
 **Your editor missing? Built a Rego integration for your editor?** Drop us a
-message on [Slack](http://slack.openpolicyagent.org)
+message on [Slack](https://inviter.co/opa)
 We also have our [Ecosystem page](/ecosystem/). This is a great place to
 showcase your project. See
 [these instructions](https://github.com/open-policy-agent/opa/tree/main/docs#opa-ecosystem)

--- a/docs/content/envoy-debugging.md
+++ b/docs/content/envoy-debugging.md
@@ -6,7 +6,7 @@ weight: 110
 
 This page provides some pointers that could assist in addressing issues encountered while using the
 OPA-Envoy plugin. If none of these tips work, feel free to join
-[slack.openpolicyagent.org](https://slack.openpolicyagent.org) and ask for help.
+[our slack](https://inviter.co/opa) and ask for help.
 
 ## Debugging Performance Issues
 

--- a/docs/content/kubernetes-debugging.md
+++ b/docs/content/kubernetes-debugging.md
@@ -7,7 +7,7 @@ weight: 100
 If you run into problems getting OPA to enforce admission control policies in
 Kubernetes there are a few things you can check to make sure everything is
 configured correctly. If none of these tips work, feel free to join
-[slack.openpolicyagent.org](https://slack.openpolicyagent.org) and ask for help.
+[our slack](https://inviter.co/opa) and ask for help.
 
 The tips below cover the OPA-Kubernetes integration that uses kube-mgmt.
 The [OPA Gatekeeper version](https://open-policy-agent.github.io/gatekeeper)

--- a/docs/content/policy-language.md
+++ b/docs/content/policy-language.md
@@ -49,7 +49,7 @@ to optimize queries to improve performance.
 In while reviewing the examples below, you might find it helpful to follow along
 using the online [OPA playground](http://play.openpolicyagent.org). The
 playground also allows sharing of examples via URL which can be helpful when
-asking questions on the [OPA Slack](https://slack.openpolicyagent.org).
+asking questions on the [OPA Slack](https://inviter.co/opa).
 In addition to these official resources, you may also be interested to check
 out the community learning materials and tools.
 {{<

--- a/docs/content/v0-upgrade.md
+++ b/docs/content/v0-upgrade.md
@@ -468,7 +468,7 @@ OPA binary of version 1.0 or later.
    unexpected behaviour.
 
 If you run into any issues while upgrading a Rego project, please drop a message
-in the #help channel on the [OPA Slack](https://slack.openpolicyagent.org/).
+in the #help channel on the [OPA Slack](https://inviter.co/opa/).
 
 ## Upgrading OPA Instances
 

--- a/docs/website/config.toml
+++ b/docs/website/config.toml
@@ -26,7 +26,7 @@ GithubEdit = "https://github.com/open-policy-agent/opa/edit/main/docs/content/"
 [params.social]
 twitter = "OpenPolicyAgent"
 medium = "https://blog.openpolicyagent.org"
-slack = "https://slack.openpolicyagent.org"
+slack = "https://inviter.co/opa"
 github = "https://github.com/open-policy-agent/opa"
 discussions = "https://github.com/open-policy-agent/feedback/discussions"
 

--- a/docs/website/content/community/_index.md
+++ b/docs/website/content/community/_index.md
@@ -18,7 +18,7 @@ sections:
       note: |
         Primary channel for community support and OPA maintainer discussions.
         Join #help for support.
-      link: https://slack.openpolicyagent.org/
+      link: https://inviter.co/opa/
       link_text: Join us on Slack
     - title: GitHub
       icon: /img/community-logos/github.png

--- a/docs/website/content/integrations/opa-errors.md
+++ b/docs/website/content/integrations/opa-errors.md
@@ -24,4 +24,4 @@ and how to fix it.
 
 If you'd like to request that a new error is listed, please drop us a message in
 the
-[Styra Slack](https://communityinviter.com/apps/styracommunity/signup).
+[Styra Slack](https://inviter.co/styra).

--- a/docs/website/layouts/partials/ecosystem-cta.html
+++ b/docs/website/layouts/partials/ecosystem-cta.html
@@ -4,7 +4,7 @@
     these instructions
   </a>
   to get it listed or go to the <code>#ecosystem</code> channel in the
-  <a target="_blank" rel="noopener noreferrer" href="https://slack.openpolicyagent.org">
+  <a target="_blank" rel="noopener noreferrer" href="https://inviter.co/opa">
     OPA Slack
   </a>
   if you have any questions.

--- a/docs/website/layouts/partials/nav.html
+++ b/docs/website/layouts/partials/nav.html
@@ -31,7 +31,7 @@
             </a>
           </li>
           <li class="nav-item social-nav-item">
-            <a class="nav-link social-icon-link" href="https://slack.openpolicyagent.org/">
+            <a class="nav-link social-icon-link" href="https://inviter.co/opa/">
               <img src="/img/slack-icon.png" alt="Slack">
               <div class="nav-link social-icon-title">Slack</div>
             </a>

--- a/docs/website/layouts/security/section.html.html
+++ b/docs/website/layouts/security/section.html.html
@@ -32,7 +32,7 @@
                     information or guidance surrounding the reported issue.</li>
 
                   <li>If you have not received a reply to your report within two days, please reach out on our
-                    <a href="https://slack.openpolicyagent.org/">Slack</a>
+                    <a href="https://inviter.co/opa/">Slack</a>
                     by posting a message in the <code>#contributors</code> channel.</li>
 
                   <li>Note that the <code>#contributors</code> channel is public, so please don't discuss details of your
@@ -92,7 +92,7 @@
                   <ul>
                     <li><a href="https://github.com/open-policy-agent/opa/security/advisories">Security Advisories for OPA</a></li>
                     <li><a href="https://github.com/orgs/open-policy-agent/discussions/categories/announcements">GitHub Discussions</a> Announcements</li>
-                    <li><a href="https://slack.openpolicyagent.org/">Slack</a> <code>#announcements</code> channel</li>
+                    <li><a href="https://inviter.co/opa/">Slack</a> <code>#announcements</code> channel</li>
                     <li><a href="https://nvd.nist.gov/vuln/search/results?form_type=Advanced&results_type=overview&search_type=all&isCpeNameSearch=false&cpe_vendor=cpe%3A%2F%3Aopenpolicyagent&cpe_product=cpe%3A%2F%3Aopenpolicyagent%3Aopen_policy_agent">NIST Vulnerability Data Base: Search Results for OPA</a></li>
                   </ul>
                 </div>


### PR DESCRIPTION
slack.openpolicyagent.org redirected to communityinviter. This service is now migrated to inviter.co and should be used instead. I have not yet updated the redirect, but when this has been done, we can revert the change to refer to slack.openpolicyagent.org.
