### PR TITLE
v1/topdown/graphql: Cache GraphQL schema parse results (#5377)

### DIFF
--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -863,17 +863,19 @@ Caching represents the configuration of the inter-query cache that built-in func
 functions provided by OPA, `http.send` is currently the only one to utilize the inter-query cache. See the documentation
 on the [http.send built-in function](../policy-reference/#http) for information about the available caching options.
 
-It also represents the configuration of the inter-query _value_ cache that built-in functions can utilize. Currently, 
+It also represents the configuration of the inter-query _value_ cache that built-in functions can utilize. Currently,
 this cache is utilized by the `regex` and `glob` built-in functions for compiled regex and glob match patterns
-respectively, and the `json.schema_match` built-in function for compiled JSON schemas.
+respectively, the `json.schema_match` built-in function for compiled JSON schemas, and any `graphql` built-in function
+that requires GraphQL schemas.
 
 | Field                                                                    | Type    | Required | Description                                                                                                                                                                                                                                          |
 |--------------------------------------------------------------------------|---------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `caching.inter_query_builtin_cache.max_size_bytes`                       | `int64` | No       | Inter-query cache size limit in bytes. OPA will drop old items from the cache if this limit is exceeded. By default, no limit is set.                                                                                                                |
-| `caching.inter_query_builtin_cache.forced_eviction_threshold_percentage` | `int64` | No       | Threshold limit configured as percentage of `caching.inter_query_builtin_cache.max_size_bytes`, when exceeded OPA will start dropping old items permaturely. By default, set to `100`.                                                               |
+| `caching.inter_query_builtin_cache.forced_eviction_threshold_percentage` | `int64` | No       | Threshold limit configured as percentage of `caching.inter_query_builtin_cache.max_size_bytes`, when exceeded OPA will start dropping old items prematurely. By default, set to `100`.                                                               |
 | `caching.inter_query_builtin_cache.stale_entry_eviction_period_seconds`  | `int64` | No       | Stale entry eviction period in seconds. OPA will drop expired items from the cache every `stale_entry_eviction_period_seconds`. By default, set to `0` indicating stale entry eviction is disabled.                                                  |
 | `caching.inter_query_builtin_value_cache.max_num_entries`                | `int`   | No       | Maximum number of entries in the Inter-query value cache. OPA will drop random items from the cache if this limit is exceeded. By default, set to `0` indicating unlimited size.                                                                     |
 | `caching.inter_query_builtin_value_cache.named.io_jwt.max_num_entries`   | `int`   | No       | Maximum number of entries in the `io_jwt` cache, used by the [`io.jwt` token verification](../policy-reference/#tokens) built-in functions. OPA will drop random items from the cache if this limit is exceeded. By default, this cache is disabled. |
+| `caching.inter_query_builtin_value_cache.named.graphql.max_num_entries`  | `int`   | No       | Maximum number of entries in the `graphql` cache, used by the [`graphql` builtins](../policy-reference/#graphql) built-in functions to cache parsed schemas. OPA will drop random items from the cache if this limit is exceeded. By default, this cache is set to a maximum of 10 entries. |
 
 ## Distributed tracing
 

--- a/v1/plugins/discovery/discovery_test.go
+++ b/v1/plugins/discovery/discovery_test.go
@@ -1721,8 +1721,9 @@ func TestReconfigureWithLocalOverride(t *testing.T) {
 			"inter_query_builtin_cache": {"max_size_bytes": 10000000, "forced_eviction_threshold_percentage": 90},
 			"inter_query_builtin_value_cache": {
 				"named": {
-					"io_jwt": {"max_num_entries": 55}
-				} 
+					"io_jwt": {"max_num_entries": 55},
+					"graphql": {"max_num_entries": 10}
+				}
 			}
 		}
 	}`)
@@ -1888,8 +1889,9 @@ func TestReconfigureWithLocalOverride(t *testing.T) {
 					"inter_query_builtin_cache": {"max_size_bytes": 200, "stale_entry_eviction_period_seconds": 10, "forced_eviction_threshold_percentage": 200},
 					"inter_query_builtin_value_cache": {
 						"named": {
-							"io_jwt": {"max_num_entries": 10}
-						} 
+							"io_jwt": {"max_num_entries": 10},
+							"graphql": {"max_num_entries": 11}
+						}
 					}
 				}
 			}
@@ -1906,6 +1908,7 @@ func TestReconfigureWithLocalOverride(t *testing.T) {
 		"caching.inter_query_builtin_cache.max_size_bytes",
 		"caching.inter_query_builtin_cache.forced_eviction_threshold_percentage",
 		"caching.inter_query_builtin_value_cache.named.io_jwt.max_num_entries",
+		"caching.inter_query_builtin_value_cache.named.graphql.max_num_entries",
 	}
 	for _, k := range expectedOverriddenKeys {
 		if !strings.Contains(disco.status.Message, k) {
@@ -1928,6 +1931,8 @@ func TestReconfigureWithLocalOverride(t *testing.T) {
 	*maxNumEntriesInterQueryValueCache = 0
 	maxNumEntriesJWTValueCache := new(int)
 	*maxNumEntriesJWTValueCache = 55
+	maxNumEntriesGraphQLValueCache := new(int)
+	*maxNumEntriesGraphQLValueCache = 10
 
 	expectedCacheConf := &cache.Config{
 		InterQueryBuiltinCache: cache.InterQueryBuiltinCacheConfig{
@@ -1940,6 +1945,9 @@ func TestReconfigureWithLocalOverride(t *testing.T) {
 			NamedCacheConfigs: map[string]*cache.NamedValueCacheConfig{
 				"io_jwt": {
 					MaxNumEntries: maxNumEntriesJWTValueCache,
+				},
+				"graphql": {
+					MaxNumEntries: maxNumEntriesGraphQLValueCache,
 				},
 			},
 		},

--- a/v1/topdown/graphql_bench_test.go
+++ b/v1/topdown/graphql_bench_test.go
@@ -1,0 +1,408 @@
+// Copyright 2025 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package topdown
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+	"testing"
+
+	"github.com/open-policy-agent/opa/v1/ast"
+	"github.com/open-policy-agent/opa/v1/topdown/cache"
+)
+
+// The MaxNumEntries value for the named caches
+const defaultCacheEntries = 10
+
+// The number of types to add to the existing schema which already has one type definition
+const extraTypes = 999
+
+func BenchmarkGraphQLSchemaIsValid(b *testing.B) {
+	benches := []struct {
+		desc   string
+		schema *ast.Term
+		cache  cache.InterQueryValueCache
+		result *ast.Term
+	}{
+		{
+			desc:   "Trivial Schema - string",
+			schema: ast.NewTerm(ast.String(employeeGQLSchema)),
+			cache:  nil,
+			result: ast.BooleanTerm(true),
+		},
+		{
+			desc:   "Trivial Schema with cache - string",
+			schema: ast.NewTerm(ast.String(employeeGQLSchema)),
+			cache:  valueCacheFactory(gqlCacheName, defaultCacheEntries),
+			result: ast.BooleanTerm(true),
+		},
+		{
+			desc:   fmt.Sprintf("Schema w/ %d types - string", extraTypes+1),
+			schema: ast.NewTerm(ast.String(schemaWithExtraEmployeeTypes(extraTypes))),
+			cache:  nil,
+			result: ast.BooleanTerm(true),
+		},
+		{
+			desc:   fmt.Sprintf("Schema w/ %d types with cache - string", extraTypes+1),
+			schema: ast.NewTerm(ast.String(schemaWithExtraEmployeeTypes(extraTypes))),
+			cache:  valueCacheFactory(gqlCacheName, defaultCacheEntries),
+			result: ast.BooleanTerm(true),
+		},
+		{
+			desc:   "Trivial Schema - AST object",
+			schema: ast.NewTerm(ast.MustParseTerm(employeeGQLSchemaAST).Value.(ast.Object)),
+			cache:  nil,
+			result: ast.BooleanTerm(true),
+		},
+		{
+			desc:   "Trivial Schema with cache - AST object",
+			schema: ast.NewTerm(ast.MustParseTerm(employeeGQLSchemaAST).Value.(ast.Object)),
+			cache:  valueCacheFactory(gqlCacheName, defaultCacheEntries),
+			result: ast.BooleanTerm(true),
+		},
+	}
+
+	for _, bench := range benches {
+		b.Run(bench.desc, func(b *testing.B) {
+			for range b.N {
+				var result *ast.Term
+				b.StartTimer()
+				err := builtinGraphQLSchemaIsValid(
+					BuiltinContext{
+						InterQueryBuiltinValueCache: bench.cache,
+					},
+					[]*ast.Term{bench.schema},
+					func(term *ast.Term) error {
+						result = term
+						return nil
+					},
+				)
+				b.StopTimer()
+				if err != nil {
+					b.Fatalf("unexpected error: %s", err)
+				}
+				if !bench.result.Equal(result) {
+					b.Fatalf("unexpected result: wanted: %#v got: %#v", bench.result, result)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkGraphQLParseSchema(b *testing.B) {
+	benches := []struct {
+		desc   string
+		schema *ast.Term
+		cache  cache.InterQueryValueCache
+		result *ast.Term
+	}{
+		{
+			desc:   "Trivial Schema - string",
+			schema: ast.NewTerm(ast.String(employeeGQLSchema)),
+			cache:  nil,
+			result: ast.NewTerm(employeeGQLSchemaASTObj),
+		},
+		{
+			desc:   "Trivial Schema with cache - string",
+			schema: ast.NewTerm(ast.String(employeeGQLSchema)),
+			cache:  valueCacheFactory(gqlCacheName, defaultCacheEntries),
+			result: ast.NewTerm(employeeGQLSchemaASTObj),
+		},
+	}
+	for _, bench := range benches {
+		b.Run(bench.desc, func(b *testing.B) {
+			for range b.N {
+				var result *ast.Term
+				b.StartTimer()
+				err := builtinGraphQLParseSchema(
+					BuiltinContext{
+						InterQueryBuiltinValueCache: bench.cache,
+					},
+					[]*ast.Term{bench.schema},
+					func(term *ast.Term) error {
+						result = term
+						return nil
+					},
+				)
+				b.StopTimer()
+				if err != nil {
+					b.Fatalf("unexpected error: %s", err)
+				}
+				if !bench.result.Equal(result) {
+					b.Errorf("Unexpected result, expected %#v, got %#v", bench.result, result)
+					return
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkGraphQLParseQuery(b *testing.B) {
+	benches := []struct {
+		desc   string
+		query  *ast.Term
+		cache  cache.InterQueryValueCache
+		result *ast.Term
+	}{
+		{
+			desc:   "Trivial Query - string",
+			query:  ast.NewTerm(ast.String(`{ employeeByID(id: "alice") { salary } }`)),
+			cache:  nil,
+			result: ast.NewTerm(employeeGQLQueryASTObj),
+		},
+		{
+			desc:   "Trivial Query with cache - string",
+			query:  ast.NewTerm(ast.String(`{ employeeByID(id: "alice") { salary } }`)),
+			cache:  valueCacheFactory(gqlCacheName, defaultCacheEntries),
+			result: ast.NewTerm(employeeGQLQueryASTObj),
+		},
+	}
+	for _, bench := range benches {
+		b.Run(bench.desc, func(b *testing.B) {
+			for range b.N {
+				var result *ast.Term
+				b.StartTimer()
+				err := builtinGraphQLParseQuery(
+					BuiltinContext{
+						InterQueryBuiltinValueCache: bench.cache,
+					},
+					[]*ast.Term{bench.query},
+					func(term *ast.Term) error {
+						result = term
+						return nil
+					},
+				)
+				b.StopTimer()
+				if err != nil {
+					b.Fatalf("unexpected error: %s", err)
+				}
+				if !bench.result.Equal(result) {
+					b.Errorf("Unexpected result, expected %#v, got %#v", bench.result, result)
+					return
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkGraphQLIsValid(b *testing.B) {
+	benches := []struct {
+		desc   string
+		schema *ast.Term
+		cache  cache.InterQueryValueCache
+		query  *ast.Term
+		result *ast.Term
+	}{
+		{
+			desc:   "Trivial Schema - string",
+			cache:  nil,
+			query:  ast.NewTerm(ast.String(`{ employeeByID(id: "alice") { salary } }`)),
+			schema: ast.NewTerm(ast.String(employeeGQLSchema)),
+			result: ast.BooleanTerm(true),
+		},
+		{
+			desc:   "Trivial Schema with cache - string",
+			cache:  valueCacheFactory(gqlCacheName, defaultCacheEntries),
+			query:  ast.NewTerm(ast.String(`{ employeeByID(id: "alice") { salary } }`)),
+			schema: ast.NewTerm(ast.String(employeeGQLSchema)),
+			result: ast.BooleanTerm(true),
+		},
+		{
+			desc:   fmt.Sprintf("Schema w/ %d types - string", extraTypes+1),
+			cache:  nil,
+			query:  ast.NewTerm(ast.String(`{ employeeByID(id: "alice") { salary } }`)),
+			schema: ast.NewTerm(ast.String(schemaWithExtraEmployeeTypes(extraTypes))),
+			result: ast.BooleanTerm(true),
+		},
+		{
+			desc:   fmt.Sprintf("Schema w/ %d types with cache - string", extraTypes+1),
+			cache:  valueCacheFactory(gqlCacheName, defaultCacheEntries),
+			query:  ast.NewTerm(ast.String(`{ employeeByID(id: "alice") { salary } }`)),
+			schema: ast.NewTerm(ast.String(schemaWithExtraEmployeeTypes(extraTypes))),
+			result: ast.BooleanTerm(true),
+		},
+	}
+	for _, bench := range benches {
+		b.Run(bench.desc, func(b *testing.B) {
+			for range b.N {
+				var result *ast.Term
+				b.StartTimer()
+				err := builtinGraphQLIsValid(
+					BuiltinContext{
+						InterQueryBuiltinValueCache: bench.cache,
+					},
+					[]*ast.Term{bench.query, bench.schema},
+					func(term *ast.Term) error {
+						result = term
+						return nil
+					},
+				)
+				b.StopTimer()
+				if err != nil {
+					b.Fatalf("unexpected error: %s", err)
+				}
+				if !bench.result.Equal(result) {
+					b.Errorf("Unexpected result, expected %#v, got %#v", bench.result, result)
+					return
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkGraphQLParse(b *testing.B) {
+	// Use this to map result item position to purpose for better error messages
+	resultItemDescription := []string{"query_ast", "schema_ast"}
+
+	benches := []struct {
+		desc   string
+		schema *ast.Term
+		cache  cache.InterQueryValueCache
+		query  *ast.Term
+		result *ast.Term
+	}{
+		{
+			desc:   "Trivial Schema - string",
+			cache:  nil,
+			query:  ast.NewTerm(ast.String(`{ employeeByID(id: "alice") { salary } }`)),
+			schema: ast.NewTerm(ast.String(employeeGQLSchema)),
+			result: ast.ArrayTerm(
+				ast.NewTerm(employeeGQLQueryASTObj),
+				ast.NewTerm(employeeGQLSchemaASTObj),
+			),
+		},
+		{
+			desc:   "Trivial Schema with cache - string",
+			cache:  valueCacheFactory(gqlCacheName, defaultCacheEntries),
+			query:  ast.NewTerm(ast.String(`{ employeeByID(id: "alice") { salary } }`)),
+			schema: ast.NewTerm(ast.String(employeeGQLSchema)),
+			result: ast.ArrayTerm(
+				ast.NewTerm(employeeGQLQueryASTObj),
+				ast.NewTerm(employeeGQLSchemaASTObj),
+			),
+		},
+	}
+	for _, bench := range benches {
+		b.Run(bench.desc, func(b *testing.B) {
+			for range b.N {
+				var result *ast.Term
+				b.StartTimer()
+				err := builtinGraphQLParse(
+					BuiltinContext{
+						InterQueryBuiltinValueCache: bench.cache,
+					},
+					[]*ast.Term{bench.query, bench.schema},
+					func(term *ast.Term) error {
+						result = term
+						return nil
+					},
+				)
+				b.StopTimer()
+				if err != nil {
+					b.Fatalf("unexpected error: %s", err)
+				}
+				if !bench.result.Equal(result) {
+					b.Errorf("Unexpected result, expected %#v, got %#v", bench.result, result)
+					return
+				}
+				// Check each item in array result
+				for i := range bench.result.Value.(*ast.Array).Len() {
+					expected := bench.result.Value.(*ast.Array).Elem(i)
+					actual := result.Value.(*ast.Array).Elem(i)
+					if !expected.Equal(actual) {
+						b.Errorf("Unexpected value at result[%d] (%s), expected %#v, got %#v", i, resultItemDescription[i], expected, actual)
+						return
+					}
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkGraphQLParseAndVerify(b *testing.B) {
+	// Use this to map result item position to purpose for better error messages
+	resultItemDescription := []string{"is_valid", "query_ast", "schema_ast"}
+
+	benches := []struct {
+		desc   string
+		schema *ast.Term
+		cache  cache.InterQueryValueCache
+		query  *ast.Term
+		result *ast.Term
+	}{
+		{
+			desc:   "Trivial Schema - string",
+			cache:  nil,
+			query:  ast.NewTerm(ast.String(`{ employeeByID(id: "alice") { salary } }`)),
+			schema: ast.NewTerm(ast.String(employeeGQLSchema)),
+			result: ast.ArrayTerm(
+				ast.BooleanTerm(true),
+				ast.NewTerm(employeeGQLQueryASTObj),
+				ast.NewTerm(employeeGQLSchemaASTObj),
+			),
+		},
+		{
+			desc:   "Trivial Schema with cache - string",
+			cache:  valueCacheFactory(gqlCacheName, defaultCacheEntries),
+			query:  ast.NewTerm(ast.String(`{ employeeByID(id: "alice") { salary } }`)),
+			schema: ast.NewTerm(ast.String(employeeGQLSchema)),
+			result: ast.ArrayTerm(
+				ast.BooleanTerm(true),
+				ast.NewTerm(employeeGQLQueryASTObj),
+				ast.NewTerm(employeeGQLSchemaASTObj),
+			),
+		},
+	}
+	for _, bench := range benches {
+		b.Run(bench.desc, func(b *testing.B) {
+			for range b.N {
+				var result *ast.Term
+				b.StartTimer()
+				err := builtinGraphQLParseAndVerify(
+					BuiltinContext{
+						InterQueryBuiltinValueCache: bench.cache,
+					},
+					[]*ast.Term{bench.query, bench.schema},
+					func(term *ast.Term) error {
+						result = term
+						return nil
+					},
+				)
+				b.StopTimer()
+				if err != nil {
+					b.Fatalf("unexpected error: %s", err)
+				}
+				if !bench.result.Equal(result) {
+					b.Errorf("Unexpected result, expected %#v, got %#v", bench.result, result)
+					return
+				}
+				// Check each item in array result
+				for i := range bench.result.Value.(*ast.Array).Len() {
+					expected := bench.result.Value.(*ast.Array).Elem(i)
+					actual := result.Value.(*ast.Array).Elem(i)
+					if !expected.Equal(actual) {
+						b.Errorf("Unexpected value at result[%d] (%s), expected %#v, got %#v", i, resultItemDescription[i], expected, actual)
+						return
+					}
+				}
+			}
+		})
+	}
+}
+
+func valueCacheFactory(name string, maxEntries int) cache.InterQueryValueCache {
+	return cache.NewInterQueryValueCache(
+		context.Background(),
+		&cache.Config{
+			InterQueryBuiltinValueCache: cache.InterQueryBuiltinValueCacheConfig{
+				NamedCacheConfigs: map[string]*cache.NamedValueCacheConfig{
+					name: {
+						MaxNumEntries: &[]int{maxEntries}[0],
+					},
+				},
+			},
+		})
+}

--- a/v1/topdown/graphql_test.go
+++ b/v1/topdown/graphql_test.go
@@ -1,0 +1,924 @@
+// Copyright 2025 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package topdown
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/open-policy-agent/opa/v1/ast"
+	"github.com/open-policy-agent/opa/v1/topdown/cache"
+)
+
+const employeeGQLSchema = `
+       type Employee {
+               id: String!
+               salary: Int!
+       }
+
+       schema {
+               query: Query
+       }
+
+       type Query {
+               employeeByID(id: String!): Employee
+       }`
+
+const invalidEmployeeGQLSchema = `
+	type Employee {
+		id: String!
+		salary: Int!
+	}
+
+	schema {
+		query: Query
+	}
+
+	type Broken {
+		fixme
+
+	type Query {
+		employeeByID(id: String!): Employee
+	}`
+
+const employeeGQLQueryAST = `{"Operations":[{"Name":"","Operation":"query","SelectionSet":[{"Alias":"employeeByID","Arguments":[{"Name":"id","Value":{"Kind":3,"Raw":"alice"}}],"Name":"employeeByID","SelectionSet":[{"Alias":"salary","Name":"salary"}]}]}]}`
+
+const employeeGQLSchemaAST = `{"Definitions":[{"BuiltIn":false,"Description":"","Fields":[{"Description":"","Name":"id","Type":{"NamedType":"String","NonNull":true}},{"Description":"","Name":"salary","Type":{"NamedType":"Int","NonNull":true}}],"Kind":"OBJECT","Name":"Employee"},{"BuiltIn":false,"Description":"","Fields":[{"Arguments":[{"Description":"","Name":"id","Type":{"NamedType":"String","NonNull":true}}],"Description":"","Name":"employeeByID","Type":{"NamedType":"Employee","NonNull":false}}],"Kind":"OBJECT","Name":"Query"}],"Schema":[{"Description":"","OperationTypes":[{"Operation":"query","Type":"Query"}]}]}`
+
+var employeeGQLQueryASTObj = ast.MustParseTerm(employeeGQLQueryAST).Value.(ast.Object)
+var employeeGQLSchemaASTObj = ast.MustParseTerm(employeeGQLSchemaAST).Value.(ast.Object)
+
+func TestGraphQLParseString(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		note    string
+		schema  string
+		query   string
+		result  string
+		wantErr bool
+	}{
+		{
+			note:    "valid employee query and GQL schema",
+			schema:  employeeGQLSchema,
+			query:   `{ employeeByID(id: "alice") { salary } }`,
+			result:  `[{"Operations": [{"Name": "", "Operation": "query", "SelectionSet": [{"Alias": "employeeByID", "Arguments": [{"Name": "id", "Value": {"Kind": 3, "Raw": "alice"}}], "Name": "employeeByID", "SelectionSet": [{"Alias": "salary", "Name": "salary"}]}]}]}, {"Definitions": [{"BuiltIn": false, "Description": "", "Fields": [{"Description": "", "Name": "id", "Type": {"NamedType": "String", "NonNull": true}}, {"Description": "", "Name": "salary", "Type": {"NamedType": "Int", "NonNull": true}}], "Kind": "OBJECT", "Name": "Employee"}, {"BuiltIn": false, "Description": "", "Fields": [{"Arguments": [{"Description": "", "Name": "id", "Type": {"NamedType": "String", "NonNull": true}}], "Description": "", "Name": "employeeByID", "Type": {"NamedType": "Employee", "NonNull": false}}], "Kind": "OBJECT", "Name": "Query"}], "Schema": [{"Description": "", "OperationTypes": [{"Operation": "query", "Type": "Query"}]}]}]`,
+			wantErr: false,
+		},
+		{
+			note:    "valid employee schema, invalid query",
+			schema:  employeeGQLSchema,
+			query:   `{employeeByID("alice"`,
+			result:  "",
+			wantErr: true,
+		},
+		{
+			note:    "invalid",
+			schema:  invalidEmployeeGQLSchema,
+			query:   `{ employeeByID(id:"bob") } `, // missing fields
+			result:  "",
+			wantErr: true,
+		},
+		{
+			note:    "empty",
+			schema:  ``,
+			query:   `{ employeeByID(id: "charlie") { id salary } }`,
+			result:  "",
+			wantErr: true,
+		},
+	}
+
+	valueCache := cache.NewInterQueryValueCache(
+		context.Background(),
+		&cache.Config{
+			InterQueryBuiltinValueCache: cache.InterQueryBuiltinValueCacheConfig{
+				NamedCacheConfigs: map[string]*cache.NamedValueCacheConfig{
+					gqlCacheName: {
+						MaxNumEntries: &[]int{10}[0],
+					},
+				},
+			},
+		})
+
+	for _, tc := range cases {
+
+		t.Run(tc.note, func(t *testing.T) {
+			t.Parallel()
+
+			var result *ast.Term
+			var err error
+			// Call function multiple times to hit the cache
+			for i := 1; i <= 3; i++ {
+
+				err = builtinGraphQLParse(
+					BuiltinContext{
+						InterQueryBuiltinValueCache: valueCache,
+					},
+					[]*ast.Term{ast.NewTerm(ast.String(tc.query)), ast.NewTerm(ast.String(tc.schema))},
+					func(term *ast.Term) error {
+						result = term
+						return nil
+					},
+				)
+				if tc.wantErr && err == nil {
+					t.Errorf("Unexpected return value, expected error, got nil")
+					return
+				}
+				if !tc.wantErr && err != nil {
+					t.Errorf("Unexpected return value, expected nil, got error: %s", err)
+					return
+				}
+				if (result != nil) && (tc.result != result.String()) {
+					t.Errorf("Unexpected result, expected %#v, got %s", tc.result, result.String())
+					return
+				}
+			}
+			// Without the cache
+			err = builtinGraphQLParse(
+				BuiltinContext{
+					InterQueryBuiltinValueCache: nil,
+				},
+				[]*ast.Term{ast.NewTerm(ast.String(tc.query)), ast.NewTerm(ast.String(tc.schema))},
+				func(term *ast.Term) error {
+					result = term
+					return nil
+				},
+			)
+			if tc.wantErr && err == nil {
+				t.Errorf("Unexpected return value, expected error, got nil")
+				return
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("Unexpected return value, expected nil, got error: %s", err)
+				return
+			}
+			if (result != nil) && (tc.result != result.String()) {
+				t.Errorf("Unexpected result, expected %#v, got %s", tc.result, result.String())
+				return
+			}
+		})
+	}
+}
+
+func TestGraphQLParseObject(t *testing.T) {
+	t.Parallel()
+
+	// Create a default Term with the expected result for the happy path here
+	// so we can include it in the test case table
+	defaultExpectedResult := ast.ArrayTerm(
+		ast.NewTerm(employeeGQLQueryASTObj),
+		ast.NewTerm(employeeGQLSchemaASTObj),
+	)
+
+	cases := []struct {
+		note    string
+		schema  string
+		query   string
+		result  *ast.Term
+		wantErr bool
+	}{
+		{
+			note:    "valid employee schema, valid query",
+			schema:  employeeGQLSchemaAST,
+			query:   `{ employeeByID(id: "alice") { salary } }`,
+			result:  defaultExpectedResult,
+			wantErr: false,
+		},
+		{
+			note:    "valid employee schema, invalid query",
+			schema:  employeeGQLSchemaAST,
+			query:   `{employeeByID("alice"`,
+			result:  defaultExpectedResult,
+			wantErr: true,
+		},
+	}
+
+	valueCache := cache.NewInterQueryValueCache(
+		context.Background(),
+		&cache.Config{
+			InterQueryBuiltinValueCache: cache.InterQueryBuiltinValueCacheConfig{
+				NamedCacheConfigs: map[string]*cache.NamedValueCacheConfig{
+					gqlCacheName: {
+						MaxNumEntries: &[]int{10}[0],
+					},
+				},
+			},
+		})
+
+	for _, tc := range cases {
+
+		t.Run(tc.note, func(t *testing.T) {
+			t.Parallel()
+
+			var result *ast.Term
+			var err error
+			inputTerm := ast.NewTerm(ast.MustParseTerm(tc.schema).Value.(ast.Object))
+
+			// Call function multiple times to hit the cache
+			for i := 1; i <= 3; i++ {
+
+				err = builtinGraphQLParse(
+					BuiltinContext{
+						InterQueryBuiltinValueCache: valueCache,
+					},
+					[]*ast.Term{ast.NewTerm(ast.String(tc.query)), inputTerm},
+					func(term *ast.Term) error {
+						result = term
+						return nil
+					},
+				)
+				if tc.wantErr && err == nil {
+					t.Errorf("Unexpected return value, expected error, got nil")
+					return
+				}
+				if !tc.wantErr && err != nil {
+					t.Errorf("Unexpected return value, expected nil, got error: %s", err)
+					return
+				}
+				if result != nil && !tc.wantErr {
+					if !tc.result.Equal(result) {
+						t.Errorf("Unexpected result, expected\n%s\ngot\n%s\n", tc.result.String(), result.String())
+						return
+					}
+				}
+				result = nil
+			}
+			// Without the cache
+			err = builtinGraphQLParse(
+				BuiltinContext{
+					InterQueryBuiltinValueCache: nil,
+				},
+				[]*ast.Term{ast.NewTerm(ast.String(tc.query)), inputTerm},
+				func(term *ast.Term) error {
+					result = term
+					return nil
+				},
+			)
+			if tc.wantErr && err == nil {
+				t.Errorf("Unexpected return value, expected error, got nil")
+				return
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("Unexpected return value, expected nil, got error: %s", err)
+				return
+			}
+			if result != nil && !tc.wantErr {
+				if !tc.result.Equal(result) {
+					t.Errorf("Unexpected result, expected\n%s\ngot\n%s\n", tc.result.String(), result.String())
+					return
+				}
+			}
+			result = nil
+		})
+	}
+}
+
+func TestGraphQLSchemaIsValid(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		note    string
+		schema  *ast.Term
+		result  ast.Value
+		wantErr bool
+	}{
+		{
+			note:    "valid employee",
+			schema:  ast.NewTerm(ast.String(employeeGQLSchema)),
+			result:  ast.Boolean(true),
+			wantErr: false,
+		},
+		{
+			note:    "invalid",
+			schema:  ast.NewTerm(ast.String(invalidEmployeeGQLSchema)),
+			result:  ast.Boolean(false),
+			wantErr: false,
+		},
+		{
+			note:    "empty",
+			schema:  ast.NewTerm(ast.String(``)),
+			result:  ast.Boolean(true), // An empty schema is valid because it is merged with the base schema
+			wantErr: false,
+		},
+		{
+			note:    "valid employee schema as object",
+			schema:  ast.NewTerm(ast.MustParseTerm(employeeGQLSchemaAST).Value.(ast.Object)),
+			result:  ast.Boolean(true),
+			wantErr: false,
+		},
+	}
+
+	valueCache := cache.NewInterQueryValueCache(
+		context.Background(),
+		&cache.Config{
+			InterQueryBuiltinValueCache: cache.InterQueryBuiltinValueCacheConfig{
+				NamedCacheConfigs: map[string]*cache.NamedValueCacheConfig{
+					gqlCacheName: {
+						MaxNumEntries: &[]int{10}[0],
+					},
+				},
+			},
+		})
+
+	for _, tc := range cases {
+
+		t.Run(tc.note, func(t *testing.T) {
+			t.Parallel()
+
+			var result ast.Value
+			var err error
+			// Call function multiple times to hit the cache
+			for i := 1; i <= 3; i++ {
+				err = builtinGraphQLSchemaIsValid(
+					BuiltinContext{
+						InterQueryBuiltinValueCache: valueCache,
+					},
+					[]*ast.Term{tc.schema},
+					func(term *ast.Term) error {
+						result = term.Value
+						return nil
+					},
+				)
+				if tc.wantErr && err == nil {
+					t.Errorf("Unexpected return value, expected error, got nil")
+					return
+				}
+				if !tc.wantErr && err != nil {
+					t.Errorf("Unexpected return value, expected nil, got error: %s", err)
+					return
+				}
+				if tc.result != result {
+					t.Errorf("Unexpected result, expected %#v, got %#v", tc.result, result)
+					return
+				}
+			}
+			// Without the cache
+			err = builtinGraphQLSchemaIsValid(
+				BuiltinContext{
+					InterQueryBuiltinValueCache: nil,
+				},
+				[]*ast.Term{tc.schema},
+				func(term *ast.Term) error {
+					result = term.Value
+					return nil
+				},
+			)
+			if tc.wantErr && err == nil {
+				t.Errorf("Unexpected return value, expected error, got nil")
+				return
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("Unexpected return value, expected nil, got error: %s", err)
+				return
+			}
+			if tc.result != result {
+				t.Errorf("Unexpected result, expected %#v, got %#v", tc.result, result)
+				return
+			}
+		})
+	}
+}
+
+func TestGraphQLParseAndVerify(t *testing.T) {
+	t.Parallel()
+
+	// Use this to map result item position to purpose for better error messages
+	resultItemDescription := []string{"is_valid", "query_ast", "schema_ast"}
+
+	failureResult := ast.ArrayTerm(
+		ast.BooleanTerm(false),
+		ast.MustParseTerm("{}"),
+		ast.MustParseTerm("{}"),
+	)
+
+	cases := []struct {
+		note    string
+		schema  string
+		query   string
+		result  *ast.Term
+		wantErr bool
+	}{
+		{
+			note:   "valid employee query and GQL schema",
+			schema: employeeGQLSchema,
+			query:  `{ employeeByID(id: "alice") { salary } }`,
+			result: ast.ArrayTerm(
+				ast.BooleanTerm(true),
+				ast.NewTerm(employeeGQLQueryASTObj),
+				ast.NewTerm(employeeGQLSchemaASTObj),
+			),
+			wantErr: false,
+		},
+		{
+			note:    "valid employee schema, invalid query",
+			schema:  employeeGQLSchema,
+			query:   `{employeeByID("alice"`,
+			result:  failureResult,
+			wantErr: false,
+		},
+		{
+			note:    "invalid schema",
+			schema:  invalidEmployeeGQLSchema,
+			query:   `{ employeeByID(id: "alice") { salary } }`,
+			result:  failureResult,
+			wantErr: false,
+		},
+		{
+			note:    "invalid query",
+			schema:  employeeGQLSchema,
+			query:   `{ employeeByID(id:"bob") } `, // missing fields
+			result:  failureResult,
+			wantErr: false,
+		},
+		{
+			note:    "empty schema is not ok",
+			schema:  ``,
+			query:   `{ employeeByID(id: "charlie") { id salary } }`,
+			result:  failureResult,
+			wantErr: false,
+		},
+		{
+			note:   "empty query is ok",
+			schema: employeeGQLSchema,
+			query:  ``,
+			result: ast.ArrayTerm(
+				ast.BooleanTerm(true),
+				ast.MustParseTerm("{}"),
+				ast.NewTerm(employeeGQLSchemaASTObj),
+			),
+			wantErr: false,
+		},
+	}
+
+	valueCache := cache.NewInterQueryValueCache(
+		context.Background(),
+		&cache.Config{
+			InterQueryBuiltinValueCache: cache.InterQueryBuiltinValueCacheConfig{
+				NamedCacheConfigs: map[string]*cache.NamedValueCacheConfig{
+					gqlCacheName: {
+						MaxNumEntries: &[]int{10}[0],
+					},
+				},
+			},
+		})
+
+	for _, tc := range cases {
+
+		t.Run(tc.note, func(t *testing.T) {
+			t.Parallel()
+
+			var result *ast.Term
+			var err error
+			// Call function multiple times to hit the cache
+			for i := 1; i <= 3; i++ {
+
+				err = builtinGraphQLParseAndVerify(
+					BuiltinContext{
+						InterQueryBuiltinValueCache: valueCache,
+					},
+					[]*ast.Term{ast.NewTerm(ast.String(tc.query)), ast.NewTerm(ast.String(tc.schema))},
+					func(term *ast.Term) error {
+						result = term
+						return nil
+					},
+				)
+				if tc.wantErr && err == nil {
+					t.Errorf("Unexpected return value, expected error, got nil")
+					return
+				}
+				if !tc.wantErr && err != nil {
+					t.Errorf("Unexpected return value, expected nil, got error: %s", err)
+					return
+				}
+				// Check each item in array result
+				for i := range tc.result.Value.(*ast.Array).Len() {
+					expected := tc.result.Value.(*ast.Array).Elem(i)
+					actual := result.Value.(*ast.Array).Elem(i)
+					if !expected.Equal(actual) {
+						fmt.Fprintf(os.Stderr, "DEBUG: expected:\n%s\ngot:\n%s\n", expected.String(), actual.String())
+						t.Errorf("Unexpected value at result[%d] (%s), expected %#v, got %#v", i, resultItemDescription[i], expected, actual)
+						return
+					}
+				}
+			}
+			// Without the cache
+			err = builtinGraphQLParseAndVerify(
+				BuiltinContext{
+					InterQueryBuiltinValueCache: nil,
+				},
+				[]*ast.Term{ast.NewTerm(ast.String(tc.query)), ast.NewTerm(ast.String(tc.schema))},
+				func(term *ast.Term) error {
+					result = term
+					return nil
+				},
+			)
+			if tc.wantErr && err == nil {
+				t.Errorf("Unexpected return value, expected error, got nil")
+				return
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("Unexpected return value, expected nil, got error: %s", err)
+				return
+			}
+			// Check each item in array result
+			for i := range tc.result.Value.(*ast.Array).Len() {
+				expected := tc.result.Value.(*ast.Array).Elem(i)
+				actual := result.Value.(*ast.Array).Elem(i)
+				if !expected.Equal(actual) {
+					t.Errorf("Unexpected value at result[%d] (%s), expected %#v, got %#v", i, resultItemDescription[i], expected, actual)
+					return
+				}
+			}
+		})
+	}
+}
+
+func TestGraphQLIsValid(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		note    string
+		query   *ast.Term
+		schema  *ast.Term
+		result  ast.Value
+		wantErr bool
+	}{
+		{
+			note:    "valid employee - query as string",
+			query:   ast.NewTerm(ast.String(`{ employeeByID(id: "alice") { salary } }`)),
+			schema:  ast.NewTerm(ast.String(employeeGQLSchema)),
+			result:  ast.Boolean(true),
+			wantErr: false,
+		},
+		{
+			note:    "valid employee - query as object",
+			query:   ast.NewTerm(ast.MustParseTerm(employeeGQLQueryAST).Value.(ast.Object)),
+			schema:  ast.NewTerm(ast.String(employeeGQLSchema)),
+			result:  ast.Boolean(true),
+			wantErr: false,
+		},
+		{
+			note:    "invalid schema",
+			query:   ast.NewTerm(ast.String(`{ employeeByID(id: "alice") { salary } }`)),
+			schema:  ast.NewTerm(ast.String(invalidEmployeeGQLSchema)),
+			result:  ast.Boolean(false),
+			wantErr: false,
+		},
+		{
+			note:    "invalid query",
+			query:   ast.NewTerm(ast.String(`{ employeeByID(id: "bob") }`)),
+			schema:  ast.NewTerm(ast.String(employeeGQLSchema)),
+			result:  ast.Boolean(false),
+			wantErr: false,
+		},
+	}
+
+	valueCache := cache.NewInterQueryValueCache(
+		context.Background(),
+		&cache.Config{
+			InterQueryBuiltinValueCache: cache.InterQueryBuiltinValueCacheConfig{
+				NamedCacheConfigs: map[string]*cache.NamedValueCacheConfig{
+					gqlCacheName: {
+						MaxNumEntries: &[]int{10}[0],
+					},
+				},
+			},
+		})
+
+	for _, tc := range cases {
+
+		t.Run(tc.note, func(t *testing.T) {
+			t.Parallel()
+
+			var result ast.Value
+			var err error
+			// Call function multiple times to hit the cache
+			for i := 1; i <= 3; i++ {
+				err = builtinGraphQLIsValid(
+					BuiltinContext{
+						InterQueryBuiltinValueCache: valueCache,
+					},
+					[]*ast.Term{tc.query, tc.schema},
+					func(term *ast.Term) error {
+						result = term.Value
+						return nil
+					},
+				)
+				if tc.wantErr && err == nil {
+					t.Errorf("Unexpected return value, expected error, got nil")
+					return
+				}
+				if !tc.wantErr && err != nil {
+					t.Errorf("Unexpected return value, expected nil, got error: %s", err)
+					return
+				}
+				if tc.result != result {
+					t.Errorf("Unexpected result, expected %#v, got %#v", tc.result, result)
+					return
+				}
+			}
+			// Without the cache
+			err = builtinGraphQLIsValid(
+				BuiltinContext{
+					InterQueryBuiltinValueCache: nil,
+				},
+				[]*ast.Term{tc.query, tc.schema},
+				func(term *ast.Term) error {
+					result = term.Value
+					return nil
+				},
+			)
+			if tc.wantErr && err == nil {
+				t.Errorf("Unexpected return value, expected error, got nil")
+				return
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("Unexpected return value, expected nil, got error: %s", err)
+				return
+			}
+			if tc.result != result {
+				t.Errorf("Unexpected result, expected %#v, got %#v", tc.result, result)
+				return
+			}
+		})
+	}
+}
+
+func TestGraphQLParseQuery(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		note    string
+		query   *ast.Term
+		result  *ast.Term
+		wantErr bool
+	}{
+		{
+			note:    "valid employee - query as string",
+			query:   ast.NewTerm(ast.String(`{ employeeByID(id: "alice") { salary } }`)),
+			result:  ast.NewTerm(employeeGQLQueryASTObj),
+			wantErr: false,
+		},
+		{
+			note:    "invalid query",
+			query:   ast.NewTerm(ast.String(`{ employeeByID("id: bob") }`)),
+			result:  nil,
+			wantErr: true,
+		},
+		{
+			note:    "empty query is valid",
+			query:   ast.NewTerm(ast.String(``)),
+			result:  ast.MustParseTerm("{}"),
+			wantErr: false,
+		},
+	}
+
+	valueCache := cache.NewInterQueryValueCache(
+		context.Background(),
+		&cache.Config{
+			InterQueryBuiltinValueCache: cache.InterQueryBuiltinValueCacheConfig{
+				NamedCacheConfigs: map[string]*cache.NamedValueCacheConfig{
+					gqlCacheName: {
+						MaxNumEntries: &[]int{10}[0],
+					},
+				},
+			},
+		})
+
+	for _, tc := range cases {
+
+		t.Run(tc.note, func(t *testing.T) {
+			t.Parallel()
+
+			var result *ast.Term
+			var err error
+			// Call function multiple times to hit the cache
+			for i := 1; i <= 3; i++ {
+				err = builtinGraphQLParseQuery(
+					BuiltinContext{
+						InterQueryBuiltinValueCache: valueCache,
+					},
+					[]*ast.Term{tc.query},
+					func(term *ast.Term) error {
+						result = term
+						return nil
+					},
+				)
+				if tc.wantErr && err == nil {
+					t.Errorf("Unexpected return value, expected error, got nil")
+					return
+				}
+				if !tc.wantErr && err != nil {
+					t.Errorf("Unexpected return value, expected nil, got error: %s", err)
+					return
+				}
+				if !tc.result.Equal(result) {
+					t.Errorf("Unexpected result, expected %#v, got %#v", tc.result, result)
+					return
+				}
+			}
+			// Without the cache
+			err = builtinGraphQLParseQuery(
+				BuiltinContext{
+					InterQueryBuiltinValueCache: nil,
+				},
+				[]*ast.Term{tc.query},
+				func(term *ast.Term) error {
+					result = term
+					return nil
+				},
+			)
+			if tc.wantErr && err == nil {
+				t.Errorf("Unexpected return value, expected error, got nil")
+				return
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("Unexpected return value, expected nil, got error: %s", err)
+				return
+			}
+			if !tc.result.Equal(result) {
+				t.Errorf("Unexpected result, expected %#v, got %#v", tc.result, result)
+				return
+			}
+		})
+	}
+}
+
+func TestGraphQLParseSchema(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		note    string
+		schema  *ast.Term
+		result  *ast.Term
+		wantErr bool
+	}{
+		{
+			note:    "valid schema as string",
+			schema:  ast.NewTerm(ast.String(employeeGQLSchema)),
+			result:  ast.NewTerm(employeeGQLSchemaASTObj),
+			wantErr: false,
+		},
+		{
+			note:    "invalid schema as string",
+			schema:  ast.NewTerm(ast.String(invalidEmployeeGQLSchema)),
+			result:  nil,
+			wantErr: true,
+		},
+		{
+			note:    "empty schema is valid",
+			schema:  ast.NewTerm(ast.String(``)),
+			result:  ast.MustParseTerm("{}"),
+			wantErr: false,
+		},
+	}
+
+	valueCache := cache.NewInterQueryValueCache(
+		context.Background(),
+		&cache.Config{
+			InterQueryBuiltinValueCache: cache.InterQueryBuiltinValueCacheConfig{
+				NamedCacheConfigs: map[string]*cache.NamedValueCacheConfig{
+					gqlCacheName: {
+						MaxNumEntries: &[]int{10}[0],
+					},
+				},
+			},
+		})
+
+	for _, tc := range cases {
+
+		t.Run(tc.note, func(t *testing.T) {
+			t.Parallel()
+
+			var result *ast.Term
+			var err error
+			// Call function multiple times to hit the cache
+			for i := 1; i <= 3; i++ {
+				err = builtinGraphQLParseSchema(
+					BuiltinContext{
+						InterQueryBuiltinValueCache: valueCache,
+					},
+					[]*ast.Term{tc.schema},
+					func(term *ast.Term) error {
+						result = term
+						return nil
+					},
+				)
+				if tc.wantErr && err == nil {
+					t.Errorf("Unexpected return value, expected error, got nil")
+					return
+				}
+				if !tc.wantErr && err != nil {
+					t.Errorf("Unexpected return value, expected nil, got error: %s", err)
+					return
+				}
+				if !tc.result.Equal(result) {
+					t.Errorf("Unexpected result, expected %#v, got %#v", tc.result, result)
+					return
+				}
+			}
+			// Without the cache
+			err = builtinGraphQLParseSchema(
+				BuiltinContext{
+					InterQueryBuiltinValueCache: nil,
+				},
+				[]*ast.Term{tc.schema},
+				func(term *ast.Term) error {
+					result = term
+					return nil
+				},
+			)
+			if tc.wantErr && err == nil {
+				t.Errorf("Unexpected return value, expected error, got nil")
+				return
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("Unexpected return value, expected nil, got error: %s", err)
+				return
+			}
+			if !tc.result.Equal(result) {
+				t.Errorf("Unexpected result, expected %#v, got %#v", tc.result, result)
+				return
+			}
+		})
+	}
+}
+
+func TestGraphQLParseSchemaAlloc(t *testing.T) {
+	cases := []struct {
+		note     string
+		schema   *ast.Term
+		maxAlloc uint64
+	}{
+		{
+			note:     "default schema",
+			schema:   ast.NewTerm(ast.String(schemaWithExtraEmployeeTypes(0))),
+			maxAlloc: 1 * 1024 * 1024,
+		},
+		// Uncomment when https://github.com/open-policy-agent/opa/pull/7509 is merged
+		// {
+		// 	note:     "default schema plus 100 additional types",
+		// 	schema:   ast.NewTerm(ast.String(schemaWithExtraEmployeeTypes(100))),
+		// 	maxAlloc: 10 * 1024 * 1024,
+		// },
+		// {
+		// 	note:     "default schema plus 1,000 additional types",
+		// 	schema:   ast.NewTerm(ast.String(schemaWithExtraEmployeeTypes(1000))),
+		// 	maxAlloc: 50 * 1024 * 1024,
+		// },
+		// {
+		// 	note:     "default schema plus 10,000 additional types",
+		// 	schema:   ast.NewTerm(ast.String(schemaWithExtraEmployeeTypes(10000))),
+		// 	maxAlloc: 100 * 1024 * 1024,
+		// },
+	}
+
+	for _, tc := range cases {
+
+		t.Run(tc.note, func(t *testing.T) {
+
+			var startMemStats runtime.MemStats
+			runtime.ReadMemStats(&startMemStats)
+
+			_ = builtinGraphQLParseSchema(
+				BuiltinContext{
+					InterQueryBuiltinValueCache: nil,
+				},
+				[]*ast.Term{tc.schema},
+				func(term *ast.Term) error {
+					return nil
+				},
+			)
+
+			var finishMemStats runtime.MemStats
+			runtime.ReadMemStats(&finishMemStats)
+			allocDifference := finishMemStats.Alloc - startMemStats.Alloc
+			runtime.GC()
+
+			if allocDifference > tc.maxAlloc {
+				t.Errorf("Parsing schema '%s' expected alloc < %d, got %d", tc.note, tc.maxAlloc, allocDifference)
+				return
+			}
+		})
+	}
+}
+
+// Inflate GraphQL schema size with `count` extra types
+func schemaWithExtraEmployeeTypes(count int) string {
+
+	// build up `count` more types on basic schema
+	var builder strings.Builder
+	builder.WriteString(employeeGQLSchema)
+
+	for i := range count {
+		fmt.Fprintf(&builder, "\ntype Employee%d {\n    id: String!\n    salary: Int!\n}\n", i)
+	}
+
+	return builder.String()
+}


### PR DESCRIPTION
This commit stores parsed GraphQL schemas to the cache, which improves the performance of GraphQL operations that parse the schema more than once.

Queries are not cached.

```
pkg: github.com/open-policy-agent/opa/v1/topdown
cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
BenchmarkGraphQLSchemaIsValid/Trivial_Schema_-_string-16	                   15519            100178 ns/op
BenchmarkGraphQLSchemaIsValid/Trivial_Schema_with_cache_-_string-16               371311              3383 ns/op
BenchmarkGraphQLSchemaIsValid/Trivial_Schema_-_object-16                            2133            542355 ns/op
BenchmarkGraphQLSchemaIsValid/Trivial_Schema_with_cache_-_object-16                 3471            528579 ns/op
BenchmarkGraphQLSchemaIsValid/Trivial_Schema_-_AST_object-16                        7105            193325 ns/op
BenchmarkGraphQLSchemaIsValid/Trivial_Schema_with_cache_-_AST_object-16            66594             18093 ns/op
BenchmarkGraphQLParseSchema/Trivial_Schema_-_string-16                              6429            173773 ns/op
BenchmarkGraphQLParseSchema/Trivial_Schema_with_cache_-_string-16                   6523            170819 ns/op
BenchmarkGraphQLParseQuery/Trivial_Query_-_string-16                               16352             72777 ns/op
BenchmarkGraphQLParseQuery/Trivial_Query_with_cache_-_string-16                    16083             73548 ns/op
BenchmarkGraphQLIsValid/Trivial_Schema_-_string-16                                 14320             83589 ns/op
BenchmarkGraphQLIsValid/Trivial_Schema_with_cache_-_string-16                      71486             15463 ns/op
BenchmarkGraphQLParse/Trivial_Schema_-_string-16                                    3380            321490 ns/op
BenchmarkGraphQLParse/Trivial_Schema_with_cache_-_string-16                        13909             87633 ns/op
BenchmarkGraphQLParseAndVerify/Trivial_Schema_-_string-16                           3435            327646 ns/op
BenchmarkGraphQLParseAndVerify/Trivial_Schema_with_cache_-_string-16               13844             85213 ns/op
PASS
ok      github.com/open-policy-agent/opa/v1/topdown     112.465s
```

Resolves: #5377

### Why the changes in this PR are needed?

GraphQL schema parsing can be an expensive operation, so caching can help speed things up.

### What are the changes in this PR?

This PR leverages the [InterQueryBuiltinValueCache](https://pkg.go.dev/github.com/open-policy-agent/opa/v1/topdown/cache#InterQueryValueCache) to store parsed GraphQL schema data.

### Notes to assist PR review:

The performance improvements are more dramatic on more complex schemas, but the complex schemas were omitted from the included test cases because they are quite large.  Those numbers are captured in the [issue thread](https://github.com/open-policy-agent/opa/issues/5377#issuecomment-2740925058).

### Further comments:

The GraphQL builtin code has some repeated patterns which could probably be cleaned up, but I felt that was out of scope for adding a caching layer.
