### PR TITLE
Simplify 'kind' usage instruction envoy-tutorial-standalone-envoy.md

### DIFF
--- a/docs/content/envoy-tutorial-standalone-envoy.md
+++ b/docs/content/envoy-tutorial-standalone-envoy.md
@@ -26,25 +26,7 @@ are co-located in the same pod.
 ## Running a local Kubernetes cluster
 
 To start a local Kubernetes cluster to run our demo, we'll be using
-[kind](https://kind.sigs.k8s.io/). In order to use the `kind` command,
-you'll need to have Docker installed on your machine. Running
-`docker info` is the easiest way to check if Docker is installed and
-running.
-
-You should see output similar to the following, showing information about
-the Docker client **and** server on our machine:
-
-```shell
-$ docker info
-Client:
-  ...
-
-Server:
- ...
-```
-
-If the above command shows information for both the client and server,
-then Docker is installed and running.
+[kind](https://kind.sigs.k8s.io/).
 
 {{< info >}}
 If you haven't used `kind` before, you can find installation instructions


### PR DESCRIPTION
### Why the changes in this PR are needed?

Old text explaining kind and docker usage was confusing and redundant.

### What are the changes in this PR?

Remove confusing part

### Notes to assist PR review:

<!--
Here you can add information you think will help the reviewer(s).
-->

### Further comments:

For me installing docker (desktop on Mac) wasn't enough to use kind. I had to install kind. This is compatible with the kind installation instruction which specifies to install kind after installing docker. Additionally just installing docker isn't enough. It needs to be running. The docker info is a bit confusion in this regard, because if it's installed but not running, it will show output compatible with the example in the tutorial.  Since this tutorial isn't (much) about docker, and the kind installation instructions I'd suggest to strike the rest of the text and just refer to the kind usage/installation instruction, which was already there.
