### PR TITLE
Delete reference to license key in envoy-tutorial-standalone-envoy.md

### DIFF
--- a/docs/content/envoy-tutorial-standalone-envoy.md
+++ b/docs/content/envoy-tutorial-standalone-envoy.md
@@ -336,7 +336,6 @@ There are a few things to note:
   created earlier.
 * The OPA container is configured to download policy bundles from
   the in-cluster bundle server (`bundle-server.default.svc.cluster.local`).
-* The OPA license key must be set. We show how to do this in the next step.
 
 ```yaml
 # app.yaml


### PR DESCRIPTION
### Why the changes in this PR are needed?

Statement on license key was confusing and redundant.

### What are the changes in this PR?

Delete the line from the documentation

### Notes to assist PR review:

Please check the license is indeed unneeded.

### Further comments:
Apparently setting a license key is not (longer?) needed. The tutorial doesn't mention it in the rest of the text as the deleted line promises. I couldn't find a hidden statement about a license key in the config files. Not does the page on installing opa using docker mention a license key. https://www.openpolicyagent.org/docs/latest/deployments/