### PR TITLE
perf: zero alloc lower/upper unless changed

### DIFF
--- a/v1/topdown/strings.go
+++ b/v1/topdown/strings.go
@@ -443,7 +443,14 @@ func builtinUpper(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term) e
 		return err
 	}
 
-	return iter(ast.StringTerm(strings.ToUpper(string(s))))
+	arg := string(s)
+	upp := strings.ToUpper(arg)
+
+	if arg == upp {
+		return iter(operands[0])
+	}
+
+	return iter(ast.StringTerm(upp))
 }
 
 func builtinSplit(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term) error) error {


### PR DESCRIPTION
Similar to how some other built-in functions have been optimized previously, the `lower` and `upper` functions now return the operand as-is when the string wasn't modified by the operation. The impact of this check is negligible when the string is modified, and as the benchmarks demonstrate, quite an improvement for the cases where it isn't. For those, we no longer need to allocate at all.