### PR TITLE
docs: Update community slack inviter link

### DIFF
--- a/docs/website/content/community/_index.md
+++ b/docs/website/content/community/_index.md
@@ -18,7 +18,7 @@ sections:
       note: |
         Primary channel for community support and OPA maintainer discussions.
         Join #help for support.
-      link: https://inviter.co/opa/
+      link: https://inviter.co/opa
       link_text: Join us on Slack
     - title: GitHub
       icon: /img/community-logos/github.png


### PR DESCRIPTION
With the trailing slash, the link is 500ing