### PR TITLE
topdown: fix wall clock time init for PartialRun()

### DIFF
--- a/v1/topdown/query.go
+++ b/v1/topdown/query.go
@@ -344,7 +344,7 @@ func (q *Query) PartialRun(ctx context.Context) (partials []ast.Body, support []
 	if q.seed == nil {
 		q.seed = rand.Reader
 	}
-	if !q.time.IsZero() {
+	if q.time.IsZero() {
 		q.time = time.Now()
 	}
 	if q.metrics == nil {

--- a/v1/topdown/topdown_partial_test.go
+++ b/v1/topdown/topdown_partial_test.go
@@ -4059,6 +4059,15 @@ func TestTopDownPartialEval(t *testing.T) {
 			},
 			wantQueries: []string{`"x" = input.x`},
 		},
+		{
+			note:                     "nondeterministic builtin time.now_ns() properly initiated",
+			query:                    "data.test.p",
+			nondeterministicBuiltins: true,
+			modules: []string{`package test
+			p if time.now_ns() > 0`,
+			},
+			wantQueries: []string{""}, // unconditional true
+		},
 	}
 
 	ctx := context.Background()


### PR DESCRIPTION
Turns out it wasn't an overflow.

This wrong `!` never mattered because without evaluation of nondeterministic builtins (as it was done for ages, the configurable is rather new), time.now_ns() always remained in the PE results, it wasn't evaluated.

Fixes #7490.