### PR TITLE
docs: Add link to inline schema annotations

### DIFF
--- a/docs/content/policy-language.md
+++ b/docs/content/policy-language.md
@@ -2992,6 +2992,8 @@ for _, link := range chain {
 
 You can provide one or more input schema files and/or data schema files to `opa eval` to improve static type checking and get more precise error reports as you develop Rego code.
 
+Schemas can be provided to OPA in two main ways: by supplying external JSON Schema files using the `-s` command-line flag (explained below), or by embedding schema definitions directly within your Rego files using [schema annotations](#schema-annotations) (detailed further down in this document). Both methods help improve static type checking.
+
 The `-s` flag can be used to upload schemas for input and data documents in JSON Schema format. You can either load a single JSON schema file for the input document or directory of schema files.
 
 ```


### PR DESCRIPTION
<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.
  (See the [Developer Certificate of Origin](https://www.openpolicyagent.org/docs/latest/contrib-code/#developer-certificate-of-origin)
  section for specifics on signing off a commit.)

-->

### Why the changes in this PR are needed?

This change addresses issue #5744. The documentation for using schemas with the Rego type checker primarily focused on providing schemas via external files (`-s` flag). This made the alternative method of using inline `@schema` annotations less discoverable for users. Adding an explicit mention and link near the start of the relevant section improves visibility.

### What are the changes in this PR?

This PR modifies `docs/content/policy-language.md` by adding a single sentence to the "Using schemas to enhance the Rego type checker" section. This sentence explicitly mentions both methods (external file and inline annotation) for providing schemas and includes a link to the existing detailed section on inline annotations.

### Notes to assist PR review:

This is a documentation-only change. No code modifications were made, and therefore no tests are required or affected. The commit `d9fd12e60` has been signed off.

### Further comments:

N/A