### PR TITLE
build: bump go to 1.23.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,8 @@
 module github.com/open-policy-agent/opa
 
-go 1.23.6
-toolchain go1.24.1
+go 1.23.8
+
+toolchain go1.24.2
 
 require (
 	github.com/agnivade/levenshtein v1.2.1


### PR DESCRIPTION
[CVE-2025-22871](https://www.cve.org/CVERecord?id=CVE-2025-22871)

https://pkg.go.dev/vuln/GO-2025-3563

