### PR TITLE
fix: remove resource.syso after building windows binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -315,6 +315,7 @@ ci-build-windows: ensure-release-dir
 	@$(MAKE) build GOOS=windows CC=x86_64-w64-mingw32-gcc
 	mv opa_windows_$(GOARCH) $(RELEASE_DIR)/opa_windows_$(GOARCH).exe
 	cd $(RELEASE_DIR)/ && shasum -a 256 opa_windows_$(GOARCH).exe > opa_windows_$(GOARCH).exe.sha256
+	rm resource.syso
 
 .PHONY: ensure-release-dir
 ensure-release-dir:
@@ -548,6 +549,7 @@ depr-build-darwin: ensure-release-dir
 depr-build-windows: ensure-release-dir
 	@$(MAKE) build GOOS=windows CGO_ENABLED=0 WASM_ENABLED=0
 	mv opa_windows_$(GOARCH) $(RELEASE_DIR)/opa_windows_$(GOARCH).exe
+	rm resource.syso
 
 depr-release:
 	$(DOCKER) run $(DOCKER_FLAGS) \


### PR DESCRIPTION
After merging: https://github.com/open-policy-agent/opa/pull/7501

Main failed: https://github.com/open-policy-agent/opa/actions/runs/14380716317/job/40323708024
with the error `$WORK/b001/_pkg_.a(resource.syso): 765938: unknown ARM64 relocation type 3`

This happens because windows is built and then `ci-go-ci-build-linux-static` which doesn't like that `resource.syso` exists in the directory. `resource.syso` gets generated each time anyway so safe to clean it up after a windows build.
