### PR TITLE
Add JSON annotation in internal/gqlparser/ast to Position fields

### DIFF
--- a/internal/gqlparser/README.md
+++ b/internal/gqlparser/README.md
@@ -18,6 +18,13 @@ It also will add some linter ignore annotations on the validator rules, since th
 
 The script thus should alleviate around 40-60% of the linter-fixup work required during a version bump.
 
+## JSON Position Marshal script
+
+The `remove-position-marshal.sh` script can be executed from this directory.
+This script annotates gqlparser structs to exclude the Position field during JSON marshaling.
+The Position field contains a copy of the original schema for each element, potentially causing unexpectedly large memory allocations.
+OPA subsequently prunes the Position from the AST, so it makes sense not to generate it in the first place.
+
 ## Original README
 
 This is a parser for graphql, written to mirror the graphql-js reference implementation as closely while remaining idiomatic and easy to use.

--- a/internal/gqlparser/ast/definition.go
+++ b/internal/gqlparser/ast/definition.go
@@ -29,7 +29,7 @@ type Definition struct {
 	Types       []string      // union
 	EnumValues  EnumValueList // enum
 
-	Position *Position `dump:"-"`
+	Position *Position `dump:"-" json:"-"`
 	BuiltIn  bool      `dump:"-"`
 }
 
@@ -65,7 +65,7 @@ type FieldDefinition struct {
 	DefaultValue *Value                 // only for input objects
 	Type         *Type
 	Directives   DirectiveList
-	Position     *Position `dump:"-"`
+	Position     *Position `dump:"-" json:"-"`
 }
 
 type ArgumentDefinition struct {
@@ -74,14 +74,14 @@ type ArgumentDefinition struct {
 	DefaultValue *Value
 	Type         *Type
 	Directives   DirectiveList
-	Position     *Position `dump:"-"`
+	Position     *Position `dump:"-" json:"-"`
 }
 
 type EnumValueDefinition struct {
 	Description string
 	Name        string
 	Directives  DirectiveList
-	Position    *Position `dump:"-"`
+	Position    *Position `dump:"-" json:"-"`
 }
 
 type DirectiveDefinition struct {
@@ -90,5 +90,5 @@ type DirectiveDefinition struct {
 	Arguments    ArgumentDefinitionList
 	Locations    []DirectiveLocation
 	IsRepeatable bool
-	Position     *Position `dump:"-"`
+	Position     *Position `dump:"-" json:"-"`
 }

--- a/internal/gqlparser/ast/directive.go
+++ b/internal/gqlparser/ast/directive.go
@@ -30,7 +30,7 @@ const (
 type Directive struct {
 	Name      string
 	Arguments ArgumentList
-	Position  *Position `dump:"-"`
+	Position  *Position `dump:"-" json:"-"`
 
 	// Requires validation
 	ParentDefinition *Definition

--- a/internal/gqlparser/ast/document.go
+++ b/internal/gqlparser/ast/document.go
@@ -3,7 +3,7 @@ package ast
 type QueryDocument struct {
 	Operations OperationList
 	Fragments  FragmentDefinitionList
-	Position   *Position `dump:"-"`
+	Position   *Position `dump:"-" json:"-"`
 }
 
 type SchemaDocument struct {
@@ -12,7 +12,7 @@ type SchemaDocument struct {
 	Directives      DirectiveDefinitionList
 	Definitions     DefinitionList
 	Extensions      DefinitionList
-	Position        *Position `dump:"-"`
+	Position        *Position `dump:"-" json:"-"`
 }
 
 func (d *SchemaDocument) Merge(other *SchemaDocument) {
@@ -69,11 +69,11 @@ type SchemaDefinition struct {
 	Description    string
 	Directives     DirectiveList
 	OperationTypes OperationTypeDefinitionList
-	Position       *Position `dump:"-"`
+	Position       *Position `dump:"-" json:"-"`
 }
 
 type OperationTypeDefinition struct {
 	Operation Operation
 	Type      string
-	Position  *Position `dump:"-"`
+	Position  *Position `dump:"-" json:"-"`
 }

--- a/internal/gqlparser/ast/fragment.go
+++ b/internal/gqlparser/ast/fragment.go
@@ -8,7 +8,7 @@ type FragmentSpread struct {
 	ObjectDefinition *Definition
 	Definition       *FragmentDefinition
 
-	Position *Position `dump:"-"`
+	Position *Position `dump:"-" json:"-"`
 }
 
 type InlineFragment struct {
@@ -19,7 +19,7 @@ type InlineFragment struct {
 	// Require validation
 	ObjectDefinition *Definition
 
-	Position *Position `dump:"-"`
+	Position *Position `dump:"-" json:"-"`
 }
 
 type FragmentDefinition struct {
@@ -34,5 +34,5 @@ type FragmentDefinition struct {
 	// Require validation
 	Definition *Definition
 
-	Position *Position `dump:"-"`
+	Position *Position `dump:"-" json:"-"`
 }

--- a/internal/gqlparser/ast/operation.go
+++ b/internal/gqlparser/ast/operation.go
@@ -14,7 +14,7 @@ type OperationDefinition struct {
 	VariableDefinitions VariableDefinitionList
 	Directives          DirectiveList
 	SelectionSet        SelectionSet
-	Position            *Position `dump:"-"`
+	Position            *Position `dump:"-" json:"-"`
 }
 
 type VariableDefinition struct {
@@ -22,7 +22,7 @@ type VariableDefinition struct {
 	Type         *Type
 	DefaultValue *Value
 	Directives   DirectiveList
-	Position     *Position `dump:"-"`
+	Position     *Position `dump:"-" json:"-"`
 
 	// Requires validation
 	Definition *Definition

--- a/internal/gqlparser/ast/selection.go
+++ b/internal/gqlparser/ast/selection.go
@@ -21,7 +21,7 @@ type Field struct {
 	Arguments    ArgumentList
 	Directives   DirectiveList
 	SelectionSet SelectionSet
-	Position     *Position `dump:"-"`
+	Position     *Position `dump:"-" json:"-"`
 
 	// Require validation
 	Definition       *FieldDefinition
@@ -31,7 +31,7 @@ type Field struct {
 type Argument struct {
 	Name     string
 	Value    *Value
-	Position *Position `dump:"-"`
+	Position *Position `dump:"-" json:"-"`
 }
 
 func (s *Field) ArgumentMap(vars map[string]interface{}) map[string]interface{} {

--- a/internal/gqlparser/ast/type.go
+++ b/internal/gqlparser/ast/type.go
@@ -20,7 +20,7 @@ type Type struct {
 	NamedType string
 	Elem      *Type
 	NonNull   bool
-	Position  *Position `dump:"-"`
+	Position  *Position `dump:"-" json:"-"`
 }
 
 func (t *Type) Name() string {

--- a/internal/gqlparser/ast/value.go
+++ b/internal/gqlparser/ast/value.go
@@ -25,7 +25,7 @@ type Value struct {
 	Raw      string
 	Children ChildValueList
 	Kind     ValueKind
-	Position *Position `dump:"-"`
+	Position *Position `dump:"-" json:"-"`
 
 	// Require validation
 	Definition         *Definition
@@ -36,7 +36,7 @@ type Value struct {
 type ChildValue struct {
 	Name     string
 	Value    *Value
-	Position *Position `dump:"-"`
+	Position *Position `dump:"-" json:"-"`
 }
 
 func (v *Value) Value(vars map[string]interface{}) (interface{}, error) {

--- a/internal/gqlparser/remove-position-marshal.sh
+++ b/internal/gqlparser/remove-position-marshal.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -e
+
+# Relies on perl to do in-place regex search-and-replace for the Position annotations
+# Relies on find to recursively enumerate all the Go files.
+
+# Add Position json annotation
+# Position information is pruned by pruneIrrelevantGraphQLASTNodes() later anyway
+for f in $(find . -name "*.go"); do perl -pi -e 's/\*Position \`dump:"-"\`/\*Position \`dump:"-" json:"-"\`/g' $f; done


### PR DESCRIPTION
Annotate internal/gqlparser/ast structs not to include Position when marshaled to JSON.
This makes the JSON roundtrip succeed without allocating a ton of memory for JSON fields that will be subsequently pruned.


```sh
# Without this change:
$ time ./reproducer-pre-fix
Now passing 1262568 bytes to builtinGraphQLParseSchema() to reproduce the issue in ast.InterfaceToValue()
Alloc = 4159 MiB   TotalAlloc = 5625 MiB   Sys = 5584 MiB  NumGC = 18
Alloc = 8312 MiB   TotalAlloc = 11169 MiB  Sys = 11125 MiB NumGC = 19
Alloc = 8312 MiB   TotalAlloc = 11169 MiB  Sys = 11125 MiB NumGC = 19
Alloc = 16615 MiB  TotalAlloc = 22247 MiB  Sys = 22209 MiB NumGC = 20
Alloc = 16615 MiB  TotalAlloc = 22247 MiB  Sys = 22209 MiB NumGC = 20
Alloc = 16615 MiB  TotalAlloc = 22247 MiB  Sys = 22209 MiB NumGC = 20
Alloc = 38765 MiB  TotalAlloc = 44397 MiB  Sys = 44377 MiB NumGC = 20
Alloc = 33223 MiB  TotalAlloc = 44397 MiB  Sys = 44377 MiB NumGC = 21

# With this change:
$ time ./reproducer-post-fix
Now passing 1262568 bytes to builtinGraphQLParseSchema() to reproduce the issue in ast.InterfaceToValue()

real       0m0.545s
user       0m0.201s
sys        0m0.028s
```

- This doesn't change any internal or external APIs or add any functionality, so new tests are not needed.
- A [reproducer](https://github.com/user-attachments/files/19701935/reproducer.go.txt) is attached
- Resolves issue discussed in https://github.com/open-policy-agent/opa/issues/5377#issuecomment-2739864081 with ast.InterfaceToValue never returning since it relies on a RoundTrip to JSON.

I have also [submitted this change](https://github.com/vektah/gqlparser/pull/364) for inclusion in the upstream gqlparser project.
