### PR TITLE
docs: update edge links to use /docs/edge/ path

### DIFF
--- a/docs/website/layouts/partials/docs/dashboard-panel.html
+++ b/docs/website/layouts/partials/docs/dashboard-panel.html
@@ -55,7 +55,7 @@
       <div class="dropdown-menu">
         <div class="dropdown-content has-text-left">
           {{ range $releases }}
-            {{ if ne . "latest" }}
+            {{ if and (ne . "latest") (ne . "edge") }}
               {{ $isLatest := eq . (index site.Data.releases 1) }}
                 {{ $verRef := . }}
                 {{ if $isLatest }}
@@ -73,6 +73,10 @@
                 </a>
             {{ end }}
           {{ end }}
+          <!-- edge is handled specially since we do not have a archive site for it-->
+          <a href="https://www.openpolicyagent.org/docs/edge/" class="dropdown-item">
+            edge
+          </a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
No versioned archive deploy is available/maintained for this tag.
