### PR TITLE
docs: Point path versioned requests to new sites

### DIFF
--- a/docs/website/edge/version-redirect.ts
+++ b/docs/website/edge/version-redirect.ts
@@ -1,0 +1,37 @@
+// Redirect path versioned requests to archived versions of the OPA
+// documentation.
+// Context: https://github.com/open-policy-agent/opa/issues/7037
+import { Context } from "@netlify/edge-functions";
+
+export default async (
+  request: Request,
+  context: Context
+): Promise<Response | undefined> => {
+  const url: URL = new URL(request.url);
+  const pathname: string = url.pathname;
+
+  // this is the name of the archived site project and forms the base of all
+  // archived sites.
+  const siteName: string = "opa-docs";
+
+  const versionRegex: RegExp = /^\/docs\/v(\d+\.\d+\.\d+)(\/.*)?$/;
+  const match: RegExpMatchArray | null = pathname.match(versionRegex);
+
+  if (match) {
+    const version: string = match[1]; // e.g., "0.65.0"
+    const restOfPath: string = match[2] || "/"; // e.g., "/introduction" or defaults to "/"
+
+    // Format version for the Netlify subdomain: replace dots with dashes
+    const formattedVersion: string = version.replace(/\./g, "-"); // e.g., "0-65-0"
+
+    // Construct the target archive URL
+    const targetDomain: string = `v${formattedVersion}--${siteName}.netlify.app`;
+    const targetUrl: string = `https://${targetDomain}${restOfPath}`;
+
+    console.log(`Edge Function: Redirecting ${pathname} to ${targetUrl}`);
+
+    return Response.redirect(targetUrl, 301);
+  }
+
+  return undefined;
+};

--- a/netlify.toml
+++ b/netlify.toml
@@ -8,6 +8,12 @@ edge_functions = "docs/website/edge"
 path = "/badge-endpoint/*"
 function = "badge"
 
+# Redirect all path based versioned requests to their new archived sites.
+# https://github.com/open-policy-agent/opa/issues/7037
+[[edge_functions]]
+path = "/docs/*"
+function = "version-redirect"
+
 [build.environment]
 # keep this version in sync with the version in .github/workflows/pull-request.yml
 # Note, that upgrading Hugo is tricky as all versions of the OPA docs need to work


### PR DESCRIPTION
Following #7528, we also need to route any requests using the old versioned paths to the correct location.

Related to https://github.com/open-policy-agent/opa/issues/7037

Pages like https://www.openpolicyagent.org/docs/v1.0.1/ still exist and while they are not in the version nav, they still serve the page. These pages are not going to be there in future so I am creating these redirects.