### PR TITLE
Bug fix for issue 7550, only use JSON-escaped literal when needed in Ref.String()

### DIFF
--- a/v1/ast/term.go
+++ b/v1/ast/term.go
@@ -1195,9 +1195,12 @@ func (ref Ref) String() string {
 				sb.WriteByte('.')
 				sb.WriteString(str)
 			} else {
+				// Determine whether we need the full JSON-escaped form
 				if strings.IndexFunc(str, isControlOrBackslash) >= 0 {
+					sb.WriteByte('[')
 					// only now pay the cost of expensive JSON-escaped form
-					sb.WriteString("[" + p.String() + "]")
+					sb.WriteString(p.String())
+					sb.WriteByte(']')
 				} else {
 					sb.WriteString(`["`)
 					sb.WriteString(str)

--- a/v1/ast/term.go
+++ b/v1/ast/term.go
@@ -1196,7 +1196,7 @@ func (ref Ref) String() string {
 				sb.WriteString(str)
 			} else {
 				// Determine whether we need the full JSON-escaped form
-				if strings.IndexFunc(str, isControlOrBackslash) >= 0 {
+				if strings.ContainsFunc(str, isControlOrBackslash) {
 					sb.WriteByte('[')
 					// only now pay the cost of expensive JSON-escaped form
 					sb.WriteString(p.String())

--- a/v1/ast/term.go
+++ b/v1/ast/term.go
@@ -19,9 +19,9 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"unicode"
 
 	"github.com/cespare/xxhash/v2"
-
 	astJSON "github.com/open-policy-agent/opa/v1/ast/json"
 	"github.com/open-policy-agent/opa/v1/ast/location"
 	"github.com/open-policy-agent/opa/v1/util"
@@ -1195,9 +1195,14 @@ func (ref Ref) String() string {
 				sb.WriteByte('.')
 				sb.WriteString(str)
 			} else {
-				sb.WriteString(`["`)
-				sb.WriteString(str)
-				sb.WriteString(`"]`)
+				if strings.IndexFunc(str, isControlOrBackslash) >= 0 {
+					// only now pay the cost of expensive JSON-escaped form
+					sb.WriteString("[" + p.String() + "]")
+				} else {
+					sb.WriteString(`["`)
+					sb.WriteString(str)
+					sb.WriteString(`"]`)
+				}
 			}
 		default:
 			sb.WriteByte('[')
@@ -3099,6 +3104,11 @@ func termSliceIsGround(a []*Term) bool {
 		}
 	}
 	return true
+}
+
+// Detect when String() need to use expensive JSON‐escaped form
+func isControlOrBackslash(r rune) bool {
+	return r == '\\' || unicode.IsControl(r)
 }
 
 // NOTE(tsandall): The unmarshalling errors in these functions are not

--- a/v1/ast/term_bench_test.go
+++ b/v1/ast/term_bench_test.go
@@ -461,26 +461,34 @@ func BenchmarkSetMarshalJSON(b *testing.B) {
 	}
 }
 
-// BenchmarkRefString benchmarks the performance of parsing references from strings.
+// BenchmarkRefString benchmarks the performance of Ref.String().
 func BenchmarkRefString(b *testing.B) {
+	// prepare all the refs before timing
+	simpleRef := MustParseRef(`data.policy["main"]`)
+	controlRef := MustParseRef(`data.policy["ma\tin"]`)
+	longInputRef := MustParseRef(
+		`data.policy.test1.test2.test3.test4` +
+			`["main1"]["main2"]["main3"]["main4"]`,
+	)
+
 	b.Run("Simple", func(b *testing.B) {
 		b.ReportAllocs()
 		for range b.N {
-			_ = MustParseRef(`data.policy["main"]`)
+			_ = simpleRef.String()
 		}
 	})
 
 	b.Run("WithControl", func(b *testing.B) {
 		b.ReportAllocs()
 		for range b.N {
-			_ = MustParseRef(`data.policy["ma\tin"]`)
+			_ = controlRef.String()
 		}
 	})
 
 	b.Run("LongInput", func(b *testing.B) {
 		b.ReportAllocs()
 		for range b.N {
-			_ = MustParseRef(`data.policy.test1.test2.test3.test4["main1"]["main2"]["main3"]["main4"]`)
+			_ = longInputRef.String()
 		}
 	})
 }

--- a/v1/ast/term_bench_test.go
+++ b/v1/ast/term_bench_test.go
@@ -461,6 +461,7 @@ func BenchmarkSetMarshalJSON(b *testing.B) {
 	}
 }
 
+// BenchmarkRefString benchmarks the performance of parsing references from strings.
 func BenchmarkRefString(b *testing.B) {
 	b.Run("Simple", func(b *testing.B) {
 		b.ReportAllocs()

--- a/v1/ast/term_bench_test.go
+++ b/v1/ast/term_bench_test.go
@@ -460,3 +460,26 @@ func BenchmarkSetMarshalJSON(b *testing.B) {
 		})
 	}
 }
+
+func BenchmarkRefString(b *testing.B) {
+	b.Run("Simple", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			_ = MustParseRef(`data.policy["main"]`)
+		}
+	})
+
+	b.Run("WithControl", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			_ = MustParseRef(`data.policy["ma\tin"]`)
+		}
+	})
+
+	b.Run("LongInput", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			_ = MustParseRef(`data.policy.test1.test2.test3.test4["main1"]["main2"]["main3"]["main4"]`)
+		}
+	})
+}

--- a/v1/ast/term_bench_test.go
+++ b/v1/ast/term_bench_test.go
@@ -464,21 +464,21 @@ func BenchmarkSetMarshalJSON(b *testing.B) {
 func BenchmarkRefString(b *testing.B) {
 	b.Run("Simple", func(b *testing.B) {
 		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			_ = MustParseRef(`data.policy["main"]`)
 		}
 	})
 
 	b.Run("WithControl", func(b *testing.B) {
 		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			_ = MustParseRef(`data.policy["ma\tin"]`)
 		}
 	})
 
 	b.Run("LongInput", func(b *testing.B) {
 		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			_ = MustParseRef(`data.policy.test1.test2.test3.test4["main1"]["main2"]["main3"]["main4"]`)
 		}
 	})


### PR DESCRIPTION
Fix issue - https://github.com/open-policy-agent/opa/issues/7550

### Why the changes in this PR are needed?
After some investigation, it looks like after https://github.com/open-policy-agent/opa/pull/7172, Ref.String() in ast/term.go (around line 1124) stopped using p.String() (which produces a JSON-escaped literal, it uses strconv.Quote(string(str)) under the covers) and instead writes the raw contents of the String term. As a result, sequences like "\t" in a reference key now become an actual tab (ASCII 9) instead of the two‐byte escape (\ + t, ASCII 92,116).

Hence have this PR to address the regression.


### What are the changes in this PR?
Per the discussion in https://github.com/open-policy-agent/opa/issues/7550, this function is called a lot, so avoiding strconv.Quote is desirable if possible as it allocates. So I add a simply check for \ in the string and use it only when that's present.


### Notes to assist PR review:
New unit tests
![image](https://github.com/user-attachments/assets/59563cdf-125d-4668-a66e-cab554fc727f)


Existing unit tests
![image](https://github.com/user-attachments/assets/10366aff-90c7-4b2a-b508-582e35b1b2a9)

New benchmark before any code change
<img width="953" alt="Pasted Graphic 37" src="https://github.com/user-attachments/assets/b849556a-96e2-44e4-af3c-a785902bb3d3" />


New benchmark with this change
<img width="923" alt="Pasted Graphic 36" src="https://github.com/user-attachments/assets/a662fa8d-c115-4b21-9540-f39344096ed7" />

