### PR TITLE
Don't generate JSON values for wildcard/generated keys in result set

### DIFF
--- a/v1/rego/rego.go
+++ b/v1/rego/rego.go
@@ -2311,17 +2311,18 @@ func (r *Rego) generateResult(qr topdown.QueryResult, ectx *EvalContext) (Result
 
 	result := newResult()
 	for k, term := range qr {
-		v, err := r.generateJSON(term, ectx)
-		if err != nil {
-			return result, err
-		}
-
 		if rw, ok := rewritten[k]; ok {
 			k = rw
 		}
 		if isTermVar(k) || isTermWasmVar(k) || k.IsGenerated() || k.IsWildcard() {
 			continue
 		}
+
+		v, err := r.generateJSON(term, ectx)
+		if err != nil {
+			return result, err
+		}
+
 		result.Bindings[string(k)] = v
 	}
 


### PR DESCRIPTION
Saw this by accident, and while I'm not sure how common this is, there's really never any point in serializing a JSON value unless it is known to be used later.