### PR TITLE
docs: Use Node 22 for all contexts

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -20,9 +20,10 @@ function = "version-redirect"
 # with the Hugo version used.
 # see: https://github.com/open-policy-agent/opa/pull/7034
 HUGO_VERSION = "0.113.0"
+# A modern node version is required to build the docusaurus site.
+NODE_VERSION = "22.15.0"
 
 [context.deploy-preview]
-environment = { NODE_VERSION = "22.15.0" }
 command = "make netlify-preview WASM_ENABLED=0 CGO_ENABLED=0"
 
 [context.branch-deploy]


### PR DESCRIPTION
This had been set only for previews before when testing #7534.

This is needed to use docusaurus, the framework used to build the new site.

10.x as used before is eol too and was only needed for live block injection. Live blocks have been removed as we transition to the new site. Live blocks which need Node 10 and cannot work with newer versions.

