### PR TITLE
perf: improve "baseline" metrics of opa bench for trivial queries

### DIFF
--- a/cmd/bench.go
+++ b/cmd/bench.go
@@ -85,8 +85,6 @@ Example with bundle and input data:
 
 	opa bench -b ./policy-bundle -i input.json 'data.authz.allow'
 
-To enable more detailed analysis use the --metrics and --benchmem flags.
-
 To run benchmarks against a running OPA server to evaluate server overhead use the --e2e flag.
 
 The optional "gobench" output format conforms to the Go Benchmark Data Format.
@@ -250,7 +248,9 @@ func (*goBenchRunner) run(ctx context.Context, ectx *evalContext, params benchma
 		}
 
 		// Reset the histogram for each invocation of the bench function
-		hist.Clear()
+		if params.metrics {
+			hist.Clear()
+		}
 
 		b.ResetTimer()
 		for range b.N {

--- a/v1/rego/rego.go
+++ b/v1/rego/rego.go
@@ -2832,6 +2832,9 @@ func iteration(x any) bool {
 }
 
 func parseStringsToRefs(s []string) ([]ast.Ref, error) {
+	if len(s) == 0 {
+		return nil, nil
+	}
 
 	refs := make([]ast.Ref, len(s))
 	for i := range refs {

--- a/v1/rego/rego_bench_test.go
+++ b/v1/rego/rego_bench_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/open-policy-agent/opa/internal/runtime"
 	"github.com/open-policy-agent/opa/v1/ast"
 	"github.com/open-policy-agent/opa/v1/loader"
+	"github.com/open-policy-agent/opa/v1/metrics"
 	"github.com/open-policy-agent/opa/v1/storage"
 	inmem "github.com/open-policy-agent/opa/v1/storage/inmem/test"
 	"github.com/open-policy-agent/opa/v1/util/test"
@@ -121,6 +122,7 @@ func BenchmarkCustomFunctionInHotPath(b *testing.B) {
 // https://github.com/microsoft/regorus?tab=readme-ov-file#performance
 
 // BenchmarkAciTestBuildAndEval-10    37    30700209 ns/op    16437935 B/op    384211 allocs/op
+// BenchmarkAciTestBuildAndEval-12    58    17566909 ns/op    15991409 B/op    304237 allocs/op
 func BenchmarkAciTestBuildAndEval(b *testing.B) {
 	ctx := context.Background()
 
@@ -155,6 +157,7 @@ func BenchmarkAciTestBuildAndEval(b *testing.B) {
 
 // BenchmarkAciTestOnlyEval-10    12752    92188 ns/op    50005 B/op    1062 allocs/op
 // BenchmarkAciTestOnlyEval-10    13521	   86647 ns/op	  47448 B/op	 967 allocs/op // ref.CopyNonGround
+// BenchmarkAciTestOnlyEval-12    21007	   57551 ns/op	  45323 B/op	 920 allocs/op
 func BenchmarkAciTestOnlyEval(b *testing.B) {
 	ctx := context.Background()
 
@@ -416,17 +419,16 @@ func BenchmarkStoreRead(b *testing.B) {
 	}
 }
 
-// 233337	      5730 ns/op	    5737 B/op	      93 allocs/op
-// 229280	      5222 ns/op	    5639 B/op	      89 allocs/op // ref.CopyNonGround
+// 5730 ns/op	    5737 B/op	      93 allocs/op
+// 5222 ns/op	    5639 B/op	      89 allocs/op // ref.CopyNonGround
+// 2786 ns/op	    5090 B/op	      77 allocs/op // Lazy init improvements
 func BenchmarkTrivialPolicy(b *testing.B) {
 	ctx := context.Background()
 	r := New(
 		ParsedQuery(ast.MustParseBody("data.p.r = x")),
 		ParsedModule(ast.MustParseModule(`package p
 		r := 1`)),
-		GenerateJSON(func(*ast.Term, *EvalContext) (any, error) {
-			return nil, nil
-		}),
+		GenerateJSON(noOpGenerateJSON),
 	)
 
 	pq, err := r.PrepareForEval(ctx)
@@ -444,6 +446,29 @@ func BenchmarkTrivialPolicy(b *testing.B) {
 	}
 }
 
+// 1851 ns/op       3376 B/op         53 allocs/op - main
+// 1312 ns/op	    2632 B/op	      38 allocs/op - lazy init targetStack, functionMockStack, comprehensionCache
+// ------------------------------------------------- and move newResolverTrie call from NewQuery to WithResolver
+// ...
+func BenchmarkTrivialQuery(b *testing.B) {
+	m := metrics.New()
+	r := New(ParsedQuery(ast.MustParseBody("1")), GenerateJSON(noOpGenerateJSON), Metrics(m))
+
+	ctx := context.Background()
+
+	pq, err := r.PrepareForEval(ctx)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	for range b.N {
+		_, err := pq.Eval(ctx, EvalMetrics(m))
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func mustReadFileAsString(b *testing.B, path string) string {
 	b.Helper()
 
@@ -453,4 +478,8 @@ func mustReadFileAsString(b *testing.B, path string) string {
 	}
 
 	return string(bs)
+}
+
+func noOpGenerateJSON(*ast.Term, *EvalContext) (any, error) {
+	return nil, nil
 }

--- a/v1/topdown/cache.go
+++ b/v1/topdown/cache.go
@@ -5,6 +5,8 @@
 package topdown
 
 import (
+	"slices"
+
 	"github.com/open-policy-agent/opa/v1/ast"
 	"github.com/open-policy-agent/opa/v1/util"
 )
@@ -218,16 +220,17 @@ func (s *refStack) Push(refs []ast.Ref) {
 }
 
 func (s *refStack) Pop() {
+	if s == nil {
+		return
+	}
 	s.sl = s.sl[:len(s.sl)-1]
 }
 
 func (s *refStack) Prefixed(ref ast.Ref) bool {
 	if s != nil {
 		for i := len(s.sl) - 1; i >= 0; i-- {
-			for j := range s.sl[i].refs {
-				if ref.HasPrefix(s.sl[i].refs[j]) {
-					return true
-				}
+			if slices.ContainsFunc(s.sl[i].refs, ref.HasPrefix) {
+				return true
 			}
 		}
 	}
@@ -346,6 +349,10 @@ func (s *functionMocksStack) Put(el frame) {
 }
 
 func (s *functionMocksStack) Get(f ast.Ref) (*ast.Term, bool) {
+	if s == nil {
+		return nil, false
+	}
+
 	current := *s.stack[len(s.stack)-1]
 	for i := len(current) - 1; i >= 0; i-- {
 		if r, ok := current[i][f.String()]; ok {

--- a/v1/topdown/query.go
+++ b/v1/topdown/query.go
@@ -78,7 +78,6 @@ func NewQuery(query ast.Body) *Query {
 		genvarprefix: ast.WildcardPrefix,
 		indexing:     true,
 		earlyExit:    true,
-		external:     newResolverTrie(),
 	}
 }
 
@@ -278,6 +277,9 @@ func (q *Query) WithBuiltinErrorList(list *[]Error) *Query {
 
 // WithResolver configures an external resolver to use for the given ref.
 func (q *Query) WithResolver(ref ast.Ref, r resolver.Resolver) *Query {
+	if q.external == nil {
+		q.external = newResolverTrie()
+	}
 	q.external.Put(ref, r)
 	return q
 }
@@ -382,7 +384,6 @@ func (q *Query) PartialRun(ctx context.Context) (partials []ast.Body, support []
 		compiler:                    q.compiler,
 		store:                       q.store,
 		baseCache:                   bc,
-		targetStack:                 newRefStack(),
 		txn:                         q.txn,
 		input:                       q.input,
 		external:                    q.external,
@@ -392,12 +393,10 @@ func (q *Query) PartialRun(ctx context.Context) (partials []ast.Body, support []
 		instr:                       q.instr,
 		builtins:                    q.builtins,
 		builtinCache:                builtins.Cache{},
-		functionMocks:               newFunctionMocksStack(),
 		interQueryBuiltinCache:      q.interQueryBuiltinCache,
 		interQueryBuiltinValueCache: q.interQueryBuiltinValueCache,
 		ndBuiltinCache:              q.ndBuiltinCache,
 		virtualCache:                vc,
-		comprehensionCache:          newComprehensionCache(),
 		saveSet:                     newSaveSet(q.unknowns, b, q.instr),
 		saveStack:                   newSaveStack(),
 		saveSupport:                 newSaveSupport(),
@@ -580,7 +579,6 @@ func (q *Query) Iter(ctx context.Context, iter func(QueryResult) error) error {
 		compiler:                    q.compiler,
 		store:                       q.store,
 		baseCache:                   bc,
-		targetStack:                 newRefStack(),
 		txn:                         q.txn,
 		input:                       q.input,
 		external:                    q.external,
@@ -590,12 +588,10 @@ func (q *Query) Iter(ctx context.Context, iter func(QueryResult) error) error {
 		instr:                       q.instr,
 		builtins:                    q.builtins,
 		builtinCache:                builtins.Cache{},
-		functionMocks:               newFunctionMocksStack(),
 		interQueryBuiltinCache:      q.interQueryBuiltinCache,
 		interQueryBuiltinValueCache: q.interQueryBuiltinValueCache,
 		ndBuiltinCache:              q.ndBuiltinCache,
 		virtualCache:                vc,
-		comprehensionCache:          newComprehensionCache(),
 		genvarprefix:                q.genvarprefix,
 		runtime:                     q.runtime,
 		indexing:                    q.indexing,

--- a/v1/topdown/resolver.go
+++ b/v1/topdown/resolver.go
@@ -35,6 +35,10 @@ func (t *resolverTrie) Put(ref ast.Ref, r resolver.Resolver) {
 func (t *resolverTrie) Resolve(e *eval, ref ast.Ref) (ast.Value, error) {
 	e.metrics.Timer(metrics.RegoExternalResolve).Start()
 	defer e.metrics.Timer(metrics.RegoExternalResolve).Stop()
+
+	if t == nil {
+		return nil, nil
+	}
 	node := t
 	for i, t := range ref {
 		child, ok := node.children[t.Value]


### PR DESCRIPTION
It's been irritating me for long how `opa bench` has such a high baseline metric for even the most trivial queries, as in order to know the cost of "your" Rego you'll need to first subtract the number OPA adds for just getting eval set up. This improves this somewhat by not initiating some caches until they're needed. We don't need to cache comprehensions to eval the value '1', or a functionMockStack, and so on. In fact, we may never need one. The gain here is miniscule for real policy evaluation, but helps some with making `opa bench` approach a more reasonable baseline.

We *can* have 10 allocs more removed if we initialize and reuse a base cache and a virtual cache across all runs. This works as the query is the same for all runs. However, since those are normally initialized per "run" (query), perhaps that's going too far?

```
opa bench 1
```

**Before**
```
+-------------------------------------------+------------+
| samples                                   |     398083 |
| ns/op                                     |       2978 |
| B/op                                      |       3200 |
| allocs/op                                 |         49 |
+-------------------------------------------+------------+
```

**After**
```
+-------------------------------------------+------------+
| samples                                   |     432841 |
| ns/op                                     |       2825 |
| B/op                                      |       2968 |
| allocs/op                                 |         40 |
+-------------------------------------------+------------+
```

This change also fixes a panic which happened when the `--metrics` flag was set to `false`.