### PR TITLE
docs: Use ABAC example on new OPA homepage

### DIFF
--- a/docs/new/src/pages/_examples/admin/config.json
+++ b/docs/new/src/pages/_examples/admin/config.json
@@ -2,5 +2,5 @@
   "showInput": false,
   "showData": false,
   "showTitles": false,
-  "command": "data.rbac"
+  "command": "data.payments"
 }

--- a/docs/new/src/pages/_examples/admin/input.json
+++ b/docs/new/src/pages/_examples/admin/input.json
@@ -1,6 +1,11 @@
 {
-  "method": "DELETE",
-  "email": "alice@example.com",
-  "role": "staff",
-  "path": "/users/42"
+  "account": {
+    "state": "open"
+  },
+  "user": {
+    "risk_score": "low"
+  },
+  "transaction": {
+    "amount": 950
+  }
 }

--- a/docs/new/src/pages/_examples/admin/policy.rego
+++ b/docs/new/src/pages/_examples/admin/policy.rego
@@ -1,10 +1,12 @@
 # Run your first Rego policy!
-package rbac
+package payments
 
-deny contains sprintf("%s cannot delete users", [input.role]) if {
-	input.method == "DELETE"
-	startswith(input.path, "/users/")
-	input.role != "admin"
+default allow := false
+
+allow if {
+	input.account.state == "open"
+	input.user.risk_score in ["low", "medium"]
+	input.transaction.amount <= 1000
 }
 
 # Open in the Rego Playground to see the full example.


### PR DESCRIPTION
This showcases Rego nicely with an ABAC example instead.

This is intended to be clearer to understand and is based on some feedback I've had on the new site.
