### PR TITLE
docs: Port c50c7e CLI docs update to new docs site

### DIFF
--- a/docs/new/docs/cli.md
+++ b/docs/new/docs/cli.md
@@ -24,8 +24,6 @@ Example with bundle and input data:
 
     opa bench -b ./policy-bundle -i input.json 'data.authz.allow'
 
-To enable more detailed analysis use the --metrics and --benchmem flags.
-
 To run benchmarks against a running OPA server to evaluate server overhead use the --e2e flag.
 
 The optional "gobench" output format conforms to the Go Benchmark Data Format.


### PR DESCRIPTION
The contents of the CLI documentation is being manually updated while we prepare the new site.

original change: c50c7eedcc5c2db625687967fc8bc38aa24bd1f8
