### PR TITLE
perf: faster object.get

### DIFF
--- a/internal/ref/ref.go
+++ b/internal/ref/ref.go
@@ -16,10 +16,7 @@ import (
 // ParseDataPath returns a ref from the slash separated path s rooted at data.
 // All path segments are treated as identifier strings.
 func ParseDataPath(s string) (ast.Ref, error) {
-
-	s = "/" + strings.TrimPrefix(s, "/")
-
-	path, ok := storage.ParsePath(s)
+	path, ok := storage.ParsePath("/" + strings.TrimPrefix(s, "/"))
 	if !ok {
 		return nil, errors.New("invalid path")
 	}
@@ -29,7 +26,7 @@ func ParseDataPath(s string) (ast.Ref, error) {
 
 // ArrayPath will take an ast.Array and build an ast.Ref using the ast.Terms in the Array
 func ArrayPath(a *ast.Array) ast.Ref {
-	var ref ast.Ref
+	ref := make(ast.Ref, 0, a.Len())
 
 	a.Foreach(func(term *ast.Term) {
 		ref = append(ref, term)

--- a/v1/topdown/object.go
+++ b/v1/topdown/object.go
@@ -121,8 +121,8 @@ func builtinObjectGet(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Ter
 	}
 
 	// if the get key is not an array, attempt to get the top level key for the operand value in the object
-	path, err := builtins.ArrayOperand(operands[1].Value, 2)
-	if err != nil {
+	path, ok := operands[1].Value.(*ast.Array)
+	if !ok {
 		if ret := object.Get(operands[1]); ret != nil {
 			return iter(ret)
 		}


### PR DESCRIPTION
- Check for array without allocating error
- Pre-allocate array path for given length