### PR TITLE
perf: ref.String() shortcut on single var term ref

### DIFF
--- a/v1/ast/term.go
+++ b/v1/ast/term.go
@@ -1180,11 +1180,17 @@ func (ref Ref) String() string {
 		return ""
 	}
 
+	if len(ref) == 1 {
+		switch p := ref[0].Value.(type) {
+		case Var:
+			return p.String()
+		}
+	}
+
 	sb := sbPool.Get()
 	defer sbPool.Put(sb)
 
 	sb.Grow(10 * len(ref))
-
 	sb.WriteString(ref[0].Value.String())
 
 	for _, p := range ref[1:] {
@@ -1195,17 +1201,17 @@ func (ref Ref) String() string {
 				sb.WriteByte('.')
 				sb.WriteString(str)
 			} else {
+				sb.WriteByte('[')
 				// Determine whether we need the full JSON-escaped form
 				if strings.ContainsFunc(str, isControlOrBackslash) {
-					sb.WriteByte('[')
 					// only now pay the cost of expensive JSON-escaped form
 					sb.WriteString(p.String())
-					sb.WriteByte(']')
 				} else {
-					sb.WriteString(`["`)
+					sb.WriteByte('"')
 					sb.WriteString(str)
-					sb.WriteString(`"]`)
+					sb.WriteByte('"')
 				}
+				sb.WriteByte(']')
 			}
 		default:
 			sb.WriteByte('[')

--- a/v1/ast/term_bench_test.go
+++ b/v1/ast/term_bench_test.go
@@ -470,25 +470,29 @@ func BenchmarkRefString(b *testing.B) {
 		`data.policy.test1.test2.test3.test4` +
 			`["main1"]["main2"]["main3"]["main4"]`,
 	)
+	singleTerm := Ref{VarTerm("is_object")}
 
 	b.Run("Simple", func(b *testing.B) {
-		b.ReportAllocs()
 		for range b.N {
 			_ = simpleRef.String()
 		}
 	})
 
 	b.Run("WithControl", func(b *testing.B) {
-		b.ReportAllocs()
 		for range b.N {
 			_ = controlRef.String()
 		}
 	})
 
 	b.Run("LongInput", func(b *testing.B) {
-		b.ReportAllocs()
 		for range b.N {
 			_ = longInputRef.String()
+		}
+	})
+
+	b.Run("SingleTerm", func(b *testing.B) {
+		for range b.N {
+			_ = singleTerm.String()
 		}
 	})
 }


### PR DESCRIPTION
This is a marginal improvement, but considering this is one of the most called functions in OPA, the overall impact is still substantial. Concretely, this simple change reduces the number of allocations done in the `regal lint bundle` benchmark by about 655K(!)

**main vs. change**
```
BenchmarkRefString/SingleTerm-12     56586423      20.70 ns/op       16 B/op      1 allocs/op
BenchmarkRefString/SingleTerm-12     581425396      2.07 ns/op        0 B/op      0 allocs/op
```