### PR TITLE
docs: Use colors on built in table

### DIFF
--- a/docs/src/components/BuiltinTable.js
+++ b/docs/src/components/BuiltinTable.js
@@ -110,10 +110,36 @@ export default function BuiltinTable({
                         <span>{fn.introduced}</span>
                       </a>
                     )}
-                    {fn.introduced === "edge" && <span>edge</span>}
-                    {fn.wasm
-                      ? <span>Wasm</span>
-                      : <span>SDK-dependent</span>}
+                    {fn.introduced === "edge" && <span>edge</span>} {fn.wasm
+                      ? (
+                        <span
+                          style={{
+                            backgroundColor: "yellowgreen",
+                            color: "white",
+                            fontWeight: "bold",
+                            fontSize: "0.8rem",
+                            padding: "0.1rem 0.2rem",
+                            borderRadius: "0.2rem",
+                          }}
+                        >
+                          Wasm
+                        </span>
+                      )
+                      : (
+                        <span
+                          style={{
+                            backgroundColor: "gold",
+                            color: "white",
+                            fontWeight: "bold",
+                            fontSize: "0.8rem",
+                            padding: "0.1rem 0.2rem",
+                            borderRadius: "0.2rem",
+                            whiteSpace: "nowrap",
+                          }}
+                        >
+                          SDK-dependent
+                        </span>
+                      )}
                   </div>
                 </td>
               </tr>

--- a/docs/src/components/BuiltinTable.js
+++ b/docs/src/components/BuiltinTable.js
@@ -114,7 +114,7 @@ export default function BuiltinTable({
                       ? (
                         <span
                           style={{
-                            backgroundColor: "yellowgreen",
+                            backgroundColor: "seagreen",
                             color: "white",
                             fontWeight: "bold",
                             fontSize: "0.8rem",
@@ -128,7 +128,7 @@ export default function BuiltinTable({
                       : (
                         <span
                           style={{
-                            backgroundColor: "gold",
+                            backgroundColor: "darkgoldenrod",
                             color: "white",
                             fontWeight: "bold",
                             fontSize: "0.8rem",


### PR DESCRIPTION
This was missed in the redesign of the built in table.
<img width="750" alt="Screenshot 2025-05-19 at 15 03 22" src="https://github.com/user-attachments/assets/7ab1a1ad-7d15-47e3-9f4d-38f47d03c01b" />
