### PR TITLE
docs: Redirect to search for ecosystem pages

### DIFF
--- a/docs/src/pages/ecosystem/index.js
+++ b/docs/src/pages/ecosystem/index.js
@@ -15,7 +15,18 @@ const EcosystemIndex = (props) => {
   const title = "OPA Ecosystem";
   const sortedPages = sortPagesByRank(entries);
 
-  const [searchQuery, setSearchQuery] = useState("");
+  const initialQuery = React.useMemo(() => {
+    if (typeof window === "undefined") return "";
+    return new URLSearchParams(window.location.search).get("q") || "";
+  }, []);
+
+  const [searchQuery, setSearchQuery] = useState(initialQuery);
+
+  React.useEffect(() => {
+    if (initialQuery) {
+      window.location.hash = "#all-entries";
+    }
+  }, [initialQuery]);
 
   const filteredPages = sortedPages.filter((id) => {
     const page = entries[id];
@@ -147,7 +158,7 @@ const EcosystemIndex = (props) => {
           </div>
         </div>
 
-        <Heading as="h2" style={{ margin: 0 }}>
+        <Heading as="h2" id="all-entries" style={{ margin: 0 }}>
           All Entries & Integrations
         </Heading>
 

--- a/docs/static/_redirects
+++ b/docs/static/_redirects
@@ -14,6 +14,11 @@
 /docs/envoy-tutorial-standalone-envoy/ /docs/envoy/tutorial-standalone-envoy/
 /docs/envoy-tutorial-gloo-edge/ /docs/envoy/tutorial-gloo-edge/
 
+# point to search for old ecosystem pages
+/integrations/:entry/*  /ecosystem?q=:entry 301!
+/softwares/:entry/*  /ecosystem?q=:entry 301!
+/organizations/:entry/* /ecosystem?q=:entry 301!
+
 # -----------------------------------------------------------------------------
 # Redirects for legacy usage external resources
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Some pages have been removed from the ecosystem section in the new site and we need to redirect them to somewhere more helpful.

Fixes https://github.com/open-policy-agent/opa/issues/7604

Fixes https://github.com/open-policy-agent/opa/issues/7605
