### PR TITLE
docs: Add simple post-merge smoke test website

### DIFF
--- a/.github/workflows/post-merge.yaml
+++ b/.github/workflows/post-merge.yaml
@@ -205,3 +205,12 @@ jobs:
         # Only run if required secrets are provided
         if: ${{ env.DOCKER_USER && env.DOCKER_PASSWORD }}
         run: make push-wasm-builder-image
+
+  website-smoke-test:
+    name : Website Smoke Test
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Run Smoke Test
+        run: make -C docs smoke-test

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -21,3 +21,7 @@ clean:
 .PHONY: generate-cli-docs
 generate-cli-docs:
 	$(CURDIR)/../build/gen-cli-docs.sh > $(CURDIR)/src/data/cli.json
+
+.PHONY: smoke-test
+smoke-test:
+	./bin/smoke-test.sh

--- a/docs/bin/smoke-test.sh
+++ b/docs/bin/smoke-test.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# this script contains a number of automated tests for website URLs that are
+# depended on externally. During the rollout of the new website, we hit some
+# issues with these URLs not being available so this script is here to be run
+# in post merge to ensure we don't break them again.
+
+urls=(
+  "https://www.openpolicyagent.org/downloads/v1.4.2/opa_darwin_arm64_static"
+  "https://www.openpolicyagent.org/bundles/helm-kubernetes-quickstart"
+  "https://www.openpolicyagent.org/img/logos/opa-horizontal-color.png"
+  "https://www.openpolicyagent.org/img/logos/opa-no-text-color.png" 
+)
+
+exit_code=0
+
+for url in "${urls[@]}"; do
+  echo -n "Testing $url ... "
+
+  status=$(curl -s -o /dev/null -w "%{http_code}" -I "$url")
+
+  if [[ "$status" =~ ^2|^3 ]]; then
+    echo "PASS ($status)"
+  else
+    echo "FAIL ($status)"
+    exit_code=1
+  fi
+done
+
+exit $exit_code


### PR DESCRIPTION
This is easier to test in post merge, then we don't need to work out the preview URL of the netlify deployment.