### PR TITLE
docs: Revert badge endpoint to old path

### DIFF
--- a/docs/functions/badge-endpoint.ts
+++ b/docs/functions/badge-endpoint.ts
@@ -10,11 +10,12 @@ const logoSvg =
 
 export default async (req: Request, context: Context) => {
   const url = new URL(req.url);
+
   const pathParts = url.pathname.split("/").filter(Boolean); // remove empty parts
   const query = url.searchParams;
 
-  // Handle /badge/config/:tag
-  if (pathParts.length === 3 && pathParts[0] === "badge" && pathParts[1] === "config") {
+  // Handle /badge-endpoint/config/:tag
+  if (pathParts.length === 3 && pathParts[0] === "badge-endpoint" && pathParts[1] === "config") {
     const tag = pathParts[2];
 
     const latest = await fetch(releases)
@@ -33,12 +34,12 @@ export default async (req: Request, context: Context) => {
     return context.json(res);
   }
 
-  // Handle /badge/:tag
-  if (pathParts.length === 2 && pathParts[0] === "badge") {
+  // Handle /badge-endpoint/:tag
+  if (pathParts.length === 2 && pathParts[0] === "badge-endpoint") {
     const tag = pathParts[1];
     const style = query.get("style");
 
-    let redirectUrl = `https://img.shields.io/endpoint?url=https://openpolicyagent.org/badge/config/${tag}`;
+    let redirectUrl = `https://img.shields.io/endpoint?url=https://openpolicyagent.org/badge-endpoint/config/${tag}`;
     if (style) {
       redirectUrl += `?style=${encodeURIComponent(style)}`;
     }

--- a/netlify.toml
+++ b/netlify.toml
@@ -8,8 +8,10 @@ edge_functions = "docs/functions"
 NODE_VERSION = "22.15.0"
 
 [[edge_functions]]
-path = "/badge/*"
-function = "badge"
+# this path should not be changed as various external sites depend on it for OPA
+# badges.
+path = "/badge-endpoint/*"
+function = "badge-endpoint"
 
 # Redirect all path based versioned requests to their new archived sites.
 # https://github.com/open-policy-agent/opa/issues/7037


### PR DESCRIPTION
This retains the badge behaviour from the old site and still uses a function for all badge related requests.

Test like this: https://img.shields.io/endpoint?url=https://deploy-preview-7618--openpolicyagent.netlify.app/badge-endpoint/config/v1.3.1
