### PR TITLE
test: mark TestCertReloading as slow

### DIFF
--- a/v1/server/server_test.go
+++ b/v1/server/server_test.go
@@ -6318,6 +6318,10 @@ func TestCertPoolReloading(t *testing.T) {
 }
 
 func TestCertReloading(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	ctx := context.Background()


### PR DESCRIPTION
Running `make test-short` is reporting long execution time for:

`ok      github.com/open-policy-agent/opa/v1/server      7.269s`

running `go test -count 1 -short -v ./v1/server/...` shows the culprit is:

```
--- PASS: TestCertReloading (12.37s)
    --- PASS: TestCertReloading/interval_reloaded_server (6.54s)
    --- PASS: TestCertReloading/fs_notified_server (5.83s)
```

`TestCertReloading` tests reloading a server certificate using both a periodic interval and fsnotify. This test can randomly take a while for the new certificate to be loaded. I couldn't find an obvious way to guarantee a short execution time, skipping the test when passing `--short` seems like the best option.

With `TestCertReloading` skipped when running `make test-short` the execution time drops:

`ok  	github.com/open-policy-agent/opa/v1/server	1.621s`