### PR TITLE
website: Fix badge endpoint

### DIFF
--- a/docs/functions/badge.ts
+++ b/docs/functions/badge.ts
@@ -34,8 +34,8 @@ export default async (req: Request, context: Context) => {
     return context.json(res);
   }
 
-  // Handle /badge-endpoint/:tag
-  if (pathParts.length === 2 && pathParts[0] === "badge-endpoint") {
+  // Handle /badge/:tag
+  if (pathParts.length === 2 && pathParts[0] === "badge") {
     const tag = pathParts[1];
     const style = query.get("style");
 

--- a/docs/functions/badge.ts
+++ b/docs/functions/badge.ts
@@ -10,6 +10,7 @@ const logoSvg =
 
 export default async (req: Request, context: Context) => {
   const url = new URL(req.url);
+  const host = req.headers.get("host");
 
   const pathParts = url.pathname.split("/").filter(Boolean); // remove empty parts
   const query = url.searchParams;
@@ -39,9 +40,13 @@ export default async (req: Request, context: Context) => {
     const tag = pathParts[1];
     const style = query.get("style");
 
-    let redirectUrl = `https://img.shields.io/endpoint?url=https://openpolicyagent.org/badge-endpoint/config/${tag}`;
+    // Build dynamic badge endpoint URL using current host
+    const base = `https://${host}/badge-endpoint/config/${tag}`;
+    const encodedUrl = encodeURIComponent(base);
+
+    let redirectUrl = `https://img.shields.io/endpoint?url=${encodedUrl}`;
     if (style) {
-      redirectUrl += `?style=${encodeURIComponent(style)}`;
+      redirectUrl += `&style=${encodeURIComponent(style)}`;
     }
 
     return Response.redirect(redirectUrl, 302);

--- a/netlify.toml
+++ b/netlify.toml
@@ -11,7 +11,13 @@ NODE_VERSION = "22.15.0"
 # this path should not be changed as various external sites depend on it for OPA
 # badges.
 path = "/badge-endpoint/*"
-function = "badge-endpoint"
+function = "badge"
+
+[[edge_functions]]
+# this path should not be changed as various external sites depend on it for OPA
+# badges.
+path = "/badge/*"
+function = "badge"
 
 # Redirect all path based versioned requests to their new archived sites.
 # https://github.com/open-policy-agent/opa/issues/7037


### PR DESCRIPTION
We have callers using /badge and /badge-endpoint

https://github.com/StyraInc/regal/blob/main/README.md?plain=1#L4

https://github.com/StyraInc/enterprise-opa/blob/main/README.md?plain=1#L1C15-L1C100

There are likely others mixing the use so I think we should continue to support both.
