### PR TITLE
bundle: Setting default rego-version in bundle API

### DIFF
--- a/bundle/store.go
+++ b/bundle/store.go
@@ -7,6 +7,7 @@ package bundle
 import (
 	"context"
 
+	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/storage"
 	v1 "github.com/open-policy-agent/opa/v1/bundle"
 )
@@ -87,7 +88,7 @@ type ActivateOpts = v1.ActivateOpts
 // Activate the bundle(s) by loading into the given Store. This will load policies, data, and record
 // the manifest in storage. The compiler provided will have had the polices compiled on it.
 func Activate(opts *ActivateOpts) error {
-	return v1.Activate(opts)
+	return v1.Activate(setActivateDefaultRegoVersion(opts))
 }
 
 // DeactivateOpts defines options for the Deactivate API call
@@ -95,7 +96,7 @@ type DeactivateOpts = v1.DeactivateOpts
 
 // Deactivate the bundle(s). This will erase associated data, policies, and the manifest entry from the store.
 func Deactivate(opts *DeactivateOpts) error {
-	return v1.Deactivate(opts)
+	return v1.Deactivate(setDeactivateDefaultRegoVersion(opts))
 }
 
 // LegacyWriteManifestToStore will write the bundle manifest to the older single (unnamed) bundle manifest location.
@@ -120,4 +121,32 @@ func LegacyReadRevisionFromStore(ctx context.Context, store storage.Store, txn s
 // Deprecated: Use Activate with named bundles instead.
 func ActivateLegacy(opts *ActivateOpts) error {
 	return v1.ActivateLegacy(opts)
+}
+
+func setActivateDefaultRegoVersion(opts *ActivateOpts) *ActivateOpts {
+	if opts == nil {
+		return nil
+	}
+
+	if opts.ParserOptions.RegoVersion == ast.RegoUndefined {
+		cpy := *opts
+		cpy.ParserOptions.RegoVersion = ast.DefaultRegoVersion
+		return &cpy
+	}
+
+	return opts
+}
+
+func setDeactivateDefaultRegoVersion(opts *DeactivateOpts) *DeactivateOpts {
+	if opts == nil {
+		return nil
+	}
+
+	if opts.ParserOptions.RegoVersion == ast.RegoUndefined {
+		cpy := *opts
+		cpy.ParserOptions.RegoVersion = ast.DefaultRegoVersion
+		return &cpy
+	}
+
+	return opts
 }

--- a/bundle/store_test.go
+++ b/bundle/store_test.go
@@ -6,9 +6,13 @@ package bundle
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"testing"
 
+	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/internal/storage/mock"
+	"github.com/open-policy-agent/opa/metrics"
 	"github.com/open-policy-agent/opa/storage"
 )
 
@@ -87,6 +91,284 @@ func TestHasRootsOverlap(t *testing.T) {
 			}
 
 			mockStore.AssertValid(t)
+		})
+	}
+}
+
+func TestActivate_DefaultRegoVersion(t *testing.T) {
+	tests := []struct {
+		note              string
+		module            string
+		customRegoVersion ast.RegoVersion
+		expErrs           []string
+	}{
+		// default rego-version
+		{
+			note: "v0 module, no v1 parse-time violations",
+			module: `package test
+					p[x] { 
+						x = "a" 
+					}`,
+		},
+		{
+			note: "v0 module, v1 parse-time violations",
+			module: `package test
+
+					contains[x] { 
+						x = "a" 
+					}`,
+		},
+
+		// cross-rego-version
+		{
+			note: "rego.v1 import, no v1 parse-time violations",
+			module: `package test
+					import rego.v1
+
+					p contains x if { 
+						x = "a" 
+					}`,
+		},
+		{
+			note: "rego.v1 import, v1 parse-time violations",
+			module: `package test
+					import rego.v1
+
+					p contains x { 
+						x = "a" 
+					}`,
+			expErrs: []string{
+				"rego_parse_error: `if` keyword is required before rule body",
+			},
+		},
+
+		// NOT default rego-version
+		{
+			note: "v1 module",
+			module: `package test
+
+					p contains x if { 
+						x = "a" 
+					}`,
+			expErrs: []string{
+				"rego_parse_error: var cannot be used for rule name",
+			},
+		},
+
+		// custom rego-version
+		{
+			note: "v1 module, v1 custom rego-version",
+			module: `package test
+
+					p contains x if { 
+						x = "a" 
+					}`,
+			customRegoVersion: ast.RegoV1,
+		},
+		{
+			note: "v1 module, v1 custom rego-version, v1 parse-time violations",
+			module: `package test
+
+					p contains x { 
+						x = "a" 
+					}`,
+			customRegoVersion: ast.RegoV1,
+			expErrs: []string{
+				"rego_parse_error: `if` keyword is required before rule body",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.note, func(t *testing.T) {
+			ctx := context.Background()
+			store := mock.New()
+			txn := storage.NewTransactionOrDie(ctx, store, storage.WriteParams)
+			compiler := ast.NewCompiler().WithDefaultRegoVersion(ast.RegoV0CompatV1)
+			m := metrics.New()
+
+			bundleName := "bundle1"
+			modulePath := "test/policy.rego"
+
+			// We want to make assert that the default rego-version is used, which it is when a module is erased from storage and we don't know what version it has.
+			// Therefore, we add a module to the store, which is the replaced by the Activate() call, causing an erase.
+			if err := store.UpsertPolicy(ctx, txn, fmt.Sprintf("%s/%s", bundleName, modulePath), []byte(tc.module)); err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+
+			newModule := `package test`
+			bundles := map[string]*Bundle{
+				bundleName: {
+					Manifest: Manifest{
+						Roots: &[]string{"test"},
+					},
+					Modules: []ModuleFile{
+						{
+							Path:   modulePath,
+							Raw:    []byte(newModule),
+							Parsed: ast.MustParseModule(newModule),
+						},
+					},
+				},
+			}
+
+			opts := ActivateOpts{
+				Ctx:      ctx,
+				Txn:      txn,
+				Store:    store,
+				Compiler: compiler,
+				Metrics:  m,
+				Bundles:  bundles,
+			}
+
+			if tc.customRegoVersion != ast.RegoUndefined {
+				opts.ParserOptions.RegoVersion = tc.customRegoVersion
+			}
+
+			err := Activate(&opts)
+
+			if len(tc.expErrs) > 0 {
+				if err == nil {
+					t.Fatalf("Expected error but got nil for test: %s", tc.note)
+				}
+				for _, expErr := range tc.expErrs {
+					if err := err.Error(); !strings.Contains(err, expErr) {
+						t.Fatalf("Expected error to contain:\n\n%s\n\nbut got:\n\n%s", expErr, err)
+					}
+				}
+			} else if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestDeactivate_DefaultRegoVersion(t *testing.T) {
+	tests := []struct {
+		note              string
+		module            string
+		customRegoVersion ast.RegoVersion
+		expErrs           []string
+	}{
+		// default rego-version
+		{
+			note: "v0 module, no v1 parse-time violations",
+			module: `package test
+					p[x] { 
+						x = "a" 
+					}`,
+		},
+		{
+			note: "v0 module, v1 parse-time violations",
+			module: `package test
+
+					contains[x] { 
+						x = "a" 
+					}`,
+		},
+
+		// cross-rego-version
+		{
+			note: "rego.v1 import, no v1 parse-time violations",
+			module: `package test
+					import rego.v1
+
+					p contains x if { 
+						x = "a" 
+					}`,
+		},
+		{
+			note: "rego.v1 import, v1 parse-time violations",
+			module: `package test
+					import rego.v1
+
+					p contains x { 
+						x = "a" 
+					}`,
+			expErrs: []string{
+				"rego_parse_error: `if` keyword is required before rule body",
+			},
+		},
+
+		// NOT default rego-version
+		{
+			note: "v1 module",
+			module: `package test
+
+					p contains x if { 
+						x = "a" 
+					}`,
+			expErrs: []string{
+				"rego_parse_error: var cannot be used for rule name",
+			},
+		},
+
+		// custom rego-version
+		{
+			note: "v1 module, v1 custom rego-version",
+			module: `package test
+
+					p contains x if { 
+						x = "a" 
+					}`,
+			customRegoVersion: ast.RegoV1,
+		},
+		{
+			note: "v1 module, v1 custom rego-version, v1 parse-time violations",
+			module: `package test
+
+					p contains x { 
+						x = "a" 
+					}`,
+			customRegoVersion: ast.RegoV1,
+			expErrs: []string{
+				"rego_parse_error: `if` keyword is required before rule body",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.note, func(t *testing.T) {
+			ctx := context.Background()
+			store := mock.New()
+			txn := storage.NewTransactionOrDie(ctx, store, storage.WriteParams)
+
+			bundleName := "bundle1"
+			modulePath := "test/policy.rego"
+
+			// We want to make assert that the default rego-version is used, which it is when a module is erased from storage and we don't know what version it has.
+			// Therefore, we add a module to the store, which is the replaced by the Activate() call, causing an erase.
+			if err := store.UpsertPolicy(ctx, txn, fmt.Sprintf("%s/%s", bundleName, modulePath), []byte(tc.module)); err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+
+			opts := DeactivateOpts{
+				Ctx:   ctx,
+				Txn:   txn,
+				Store: store,
+				BundleNames: map[string]struct{}{
+					fmt.Sprintf("%s/%s", bundleName, modulePath): {},
+				},
+			}
+
+			if tc.customRegoVersion != ast.RegoUndefined {
+				opts.ParserOptions.RegoVersion = tc.customRegoVersion
+			}
+
+			err := Deactivate(&opts)
+
+			if len(tc.expErrs) > 0 {
+				if err == nil {
+					t.Fatalf("Expected error but got nil for test: %s", tc.note)
+				}
+				for _, expErr := range tc.expErrs {
+					if err := err.Error(); !strings.Contains(err, expErr) {
+						t.Fatalf("Expected error to contain:\n\n%s\n\nbut got:\n\n%s", expErr, err)
+					}
+				}
+			} else if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
 		})
 	}
 }

--- a/v1/bundle/store_test.go
+++ b/v1/bundle/store_test.go
@@ -6886,3 +6886,263 @@ func TestBundleStoreHelpers(t *testing.T) {
 		})
 	}
 }
+
+func TestActivate_DefaultRegoVersion(t *testing.T) {
+	tests := []struct {
+		note              string
+		module            string
+		customRegoVersion ast.RegoVersion
+		expErrs           []string
+	}{
+		// NOT default rego-version
+		{
+			note: "v0 module",
+			module: `package test
+					p[x] { 
+						x = "a" 
+					}`,
+			expErrs: []string{
+				"rego_parse_error: `if` keyword is required before rule body",
+				"rego_parse_error: `contains` keyword is required for partial set rules",
+			},
+		},
+
+		// cross-rego-version
+		{
+			note: "rego.v1 import, no v1 parse-time violations",
+			module: `package test
+					import rego.v1
+
+					p contains x if { 
+						x = "a" 
+					}`,
+		},
+		{
+			note: "rego.v1 import, v1 parse-time violations",
+			module: `package test
+					import rego.v1
+
+					p contains x { 
+						x = "a" 
+					}`,
+			expErrs: []string{
+				"rego_parse_error: `if` keyword is required before rule body",
+			},
+		},
+
+		// default rego-version
+		{
+			note: "v1 module, no v1 parse-time violations",
+			module: `package test
+
+					p contains x if { 
+						x = "a" 
+					}`,
+		},
+		{
+			note: "v1 module, v1 parse-time violations",
+			module: `package test
+
+					p contains x { 
+						x = "a" 
+					}`,
+			expErrs: []string{
+				"rego_parse_error: `if` keyword is required before rule body",
+			},
+		},
+
+		// custom rego-version
+		{
+			note: "v0 module, v0 custom rego-version",
+			module: `package test
+					p[x] { 
+						x = "a" 
+					}`,
+			customRegoVersion: ast.RegoV0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.note, func(t *testing.T) {
+			ctx := context.Background()
+			store := mock.New()
+			txn := storage.NewTransactionOrDie(ctx, store, storage.WriteParams)
+			compiler := ast.NewCompiler().WithDefaultRegoVersion(ast.RegoV0CompatV1)
+			m := metrics.New()
+
+			bundleName := "bundle1"
+			modulePath := "test/policy.rego"
+
+			// We want to make assert that the default rego-version is used, which it is when a module is erased from storage and we don't know what version it has.
+			// Therefore, we add a module to the store, which is the replaced by the Activate() call, causing an erase.
+			if err := store.UpsertPolicy(ctx, txn, modulePathWithPrefix(bundleName, modulePath), []byte(tc.module)); err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+
+			newModule := `package test`
+			bundles := map[string]*Bundle{
+				bundleName: {
+					Manifest: Manifest{
+						Roots: &[]string{"test"},
+					},
+					Modules: []ModuleFile{
+						{
+							Path:   modulePath,
+							Raw:    []byte(newModule),
+							Parsed: ast.MustParseModule(newModule),
+						},
+					},
+				},
+			}
+
+			opts := ActivateOpts{
+				Ctx:      ctx,
+				Txn:      txn,
+				Store:    store,
+				Compiler: compiler,
+				Metrics:  m,
+				Bundles:  bundles,
+			}
+
+			if tc.customRegoVersion != ast.RegoUndefined {
+				opts.ParserOptions.RegoVersion = tc.customRegoVersion
+			}
+
+			err := Activate(&opts)
+
+			if len(tc.expErrs) > 0 {
+				if err == nil {
+					t.Fatalf("Expected error but got nil for test: %s", tc.note)
+				}
+				for _, expErr := range tc.expErrs {
+					if err := err.Error(); !strings.Contains(err, expErr) {
+						t.Fatalf("Expected error to contain:\n\n%s\n\nbut got:\n\n%s", expErr, err)
+					}
+				}
+			} else if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestDeactivate_DefaultRegoVersion(t *testing.T) {
+	tests := []struct {
+		note              string
+		module            string
+		customRegoVersion ast.RegoVersion
+		expErrs           []string
+	}{
+		// NOT default rego-version
+		{
+			note: "v0 module",
+			module: `package test
+					p[x] { 
+						x = "a" 
+					}`,
+			expErrs: []string{
+				"rego_parse_error: `if` keyword is required before rule body",
+				"rego_parse_error: `contains` keyword is required for partial set rules",
+			},
+		},
+
+		// cross-rego-version
+		{
+			note: "rego.v1 import, no v1 parse-time violations",
+			module: `package test
+					import rego.v1
+
+					p contains x if { 
+						x = "a" 
+					}`,
+		},
+		{
+			note: "rego.v1 import, v1 parse-time violations",
+			module: `package test
+					import rego.v1
+
+					p contains x { 
+						x = "a" 
+					}`,
+			expErrs: []string{
+				"rego_parse_error: `if` keyword is required before rule body",
+			},
+		},
+
+		// default rego-version
+		{
+			note: "v1 module, no v1 parse-time violations",
+			module: `package test
+
+					p contains x if { 
+						x = "a" 
+					}`,
+		},
+		{
+			note: "v1 module, v1 parse-time violations",
+			module: `package test
+
+					p contains x { 
+						x = "a" 
+					}`,
+			expErrs: []string{
+				"rego_parse_error: `if` keyword is required before rule body",
+			},
+		},
+
+		// custom rego-version
+		{
+			note: "v0 module, v0 custom rego-version",
+			module: `package test
+					p[x] { 
+						x = "a" 
+					}`,
+			customRegoVersion: ast.RegoV0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.note, func(t *testing.T) {
+			ctx := context.Background()
+			store := mock.New()
+			txn := storage.NewTransactionOrDie(ctx, store, storage.WriteParams)
+
+			bundleName := "bundle1"
+			modulePath := "test/policy.rego"
+
+			// We want to make assert that the default rego-version is used, which it is when a module is erased from storage and we don't know what version it has.
+			// Therefore, we add a module to the store, which is the replaced by the Activate() call, causing an erase.
+			if err := store.UpsertPolicy(ctx, txn, modulePathWithPrefix(bundleName, modulePath), []byte(tc.module)); err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+
+			opts := DeactivateOpts{
+				Ctx:   ctx,
+				Txn:   txn,
+				Store: store,
+				BundleNames: map[string]struct{}{
+					modulePathWithPrefix(bundleName, modulePath): {},
+				},
+			}
+
+			if tc.customRegoVersion != ast.RegoUndefined {
+				opts.ParserOptions.RegoVersion = tc.customRegoVersion
+			}
+
+			err := Deactivate(&opts)
+
+			if len(tc.expErrs) > 0 {
+				if err == nil {
+					t.Fatalf("Expected error but got nil for test: %s", tc.note)
+				}
+				for _, expErr := range tc.expErrs {
+					if err := err.Error(); !strings.Contains(err, expErr) {
+						t.Fatalf("Expected error to contain:\n\n%s\n\nbut got:\n\n%s", expErr, err)
+					}
+				}
+			} else if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Applying default rego-version for `bundle.Activate()` and `bundle.Deactivate()`.

Fixes: #7588