### PR TITLE
test: Not modifying global recursion depth limit in parser tests init

### DIFF
--- a/v1/ast/parser.go
+++ b/v1/ast/parser.go
@@ -32,8 +32,6 @@ import (
 // depth for the parser
 const DefaultMaxParsingRecursionDepth = 100000
 
-var maxParsingRecursionDepth = DefaultMaxParsingRecursionDepth
-
 // ErrMaxParsingRecursionDepthExceeded is returned when the parser
 // recursion exceeds the maximum allowed depth
 var ErrMaxParsingRecursionDepthExceeded = errors.New("max parsing recursion depth exceeded")
@@ -183,7 +181,7 @@ func NewParser() *Parser {
 	p := &Parser{
 		s:                 &state{},
 		po:                ParserOptions{},
-		maxRecursionDepth: maxParsingRecursionDepth,
+		maxRecursionDepth: DefaultMaxParsingRecursionDepth,
 	}
 	return p
 }

--- a/v1/ast/parser_test.go
+++ b/v1/ast/parser_test.go
@@ -6378,11 +6378,6 @@ allow if {
 	assertLocationText(t, "# METADATA\n# title: rule", m.Rules[0].Annotations[0].Location)
 }
 
-func init() {
-	// maxParsingRecursionDepth is set much lower for testing purposes.
-	maxParsingRecursionDepth = 100
-}
-
 func TestMaxParsingRecursionDepth(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -6392,7 +6387,7 @@ func TestMaxParsingRecursionDepth(t *testing.T) {
 	}{
 		{
 			name:        "deeply nested array exceeds default limit",
-			input:       generateDeeplyNestedArray(200),
+			input:       generateDeeplyNestedArray(DefaultMaxParsingRecursionDepth + 1),
 			expectError: true,
 		},
 		{


### PR DESCRIPTION
The previous `init()` func in `v1/ast/parser_test.go` would also run for `make perf`, which would cause failing benchmark tests in CI.