### PR TITLE
website: Fix badge endpoints

### DIFF
--- a/docs/functions/badge.ts
+++ b/docs/functions/badge.ts
@@ -15,8 +15,8 @@ export default async (req: Request, context: Context) => {
   const pathParts = url.pathname.split("/").filter(Boolean); // remove empty parts
   const query = url.searchParams;
 
-  // Handle /badge-endpoint/config/:tag
-  if (pathParts.length === 3 && pathParts[0] === "badge-endpoint" && pathParts[1] === "config") {
+  // Handle /badge/config/:tag
+  if (pathParts.length === 3 && pathParts[0] === "badge" && pathParts[1] === "config") {
     const tag = pathParts[2];
 
     const latest = await fetch(releases)
@@ -41,7 +41,7 @@ export default async (req: Request, context: Context) => {
     const style = query.get("style");
 
     // Build dynamic badge endpoint URL using current host
-    const base = `https://${host}/badge-endpoint/config/${tag}`;
+    const base = `https://${host}/badge/config/${tag}`;
     const encodedUrl = encodeURIComponent(base);
 
     let redirectUrl = `https://img.shields.io/endpoint?url=${encodedUrl}`;

--- a/netlify.toml
+++ b/netlify.toml
@@ -10,12 +10,6 @@ NODE_VERSION = "22.15.0"
 [[edge_functions]]
 # this path should not be changed as various external sites depend on it for OPA
 # badges.
-path = "/badge-endpoint/*"
-function = "badge"
-
-[[edge_functions]]
-# this path should not be changed as various external sites depend on it for OPA
-# badges.
 path = "/badge/*"
 function = "badge"
 


### PR DESCRIPTION
We have been having some issues with the badge endpoints and have opted to standardize on the `/badge` as the public API for this feature.

e.g. https://openpolicyagent.org/badge/v1.5.0
