### PR TITLE
v1/metrics: Prealloc maps + add benchmark

### DIFF
--- a/v1/metrics/metrics.go
+++ b/v1/metrics/metrics.go
@@ -83,7 +83,6 @@ func (*metrics) Info() Info {
 }
 
 func (m *metrics) String() string {
-
 	all := m.All()
 	sorted := make([]metric, 0, len(all))
 
@@ -147,7 +146,7 @@ func (m *metrics) Counter(name string) Counter {
 func (m *metrics) All() map[string]any {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
-	result := map[string]any{}
+	result := make(map[string]any, len(m.timers)+len(m.histograms)+len(m.counters))
 	for name, timer := range m.timers {
 		result[m.formatKey(name, timer)] = timer.Value()
 	}
@@ -163,7 +162,7 @@ func (m *metrics) All() map[string]any {
 func (m *metrics) Timers() map[string]any {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
-	ts := map[string]any{}
+	ts := make(map[string]any, len(m.timers))
 	for n, t := range m.timers {
 		ts[m.formatKey(n, t)] = t.Value()
 	}
@@ -254,7 +253,7 @@ func (h *histogram) Update(v int64) {
 }
 
 func (h *histogram) Value() any {
-	values := map[string]any{}
+	values := make(map[string]any, 12)
 	snap := h.hist.Snapshot()
 	percentiles := snap.Percentiles([]float64{
 		0.5,

--- a/v1/metrics/metrics_bench_test.go
+++ b/v1/metrics/metrics_bench_test.go
@@ -1,0 +1,51 @@
+// Copyright 2025 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package metrics_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/open-policy-agent/opa/v1/metrics"
+)
+
+func BenchmarkMetricsMarshaling(b *testing.B) {
+	m := metrics.New()
+
+	// Setup a handful of metrics across each type.
+	for i := range 10 {
+		m.Timer(fmt.Sprintf("rego_timer_example_%d", i)).Start()
+	}
+	time.Sleep(1 * time.Millisecond)
+	for i := range 10 {
+		m.Timer(fmt.Sprintf("rego_timer_example_%d", i)).Stop()
+	}
+
+	for i := range 10 {
+		m.Counter(fmt.Sprintf("rego_counter_example_%d", i)).Add(uint64(i))
+	}
+
+	for i := range 10 {
+		for j := range 100 {
+			m.Histogram(fmt.Sprintf("rego_histogram_example_%d", i)).Update(int64(i + j))
+		}
+	}
+
+	b.ResetTimer()
+
+	for range b.N {
+		bs, err := json.Marshal(m)
+		if err != nil {
+			b.Fatalf("Unexpected error: %v", err)
+		}
+		if len(bs) == 0 {
+			b.Fatalf("No output")
+		}
+	}
+
+	b.StopTimer()
+}


### PR DESCRIPTION
## What changed?

This PR preallocates maps where possible in the `v1/metrics` package, which we were not doing before. This provides a small, but reliable/stable boost to the performance of several operations on the hot path for serialization of metrics, mostly from reducing allocations.

## Performance Analysis / Benchmarks

I built a benchmark for the hot path that I'm the most interested in: JSON serialization when several metrics are present.
This fully exercises most of the `v1/metrics` package, and shows the full benefit of the prealloc changes.

Here's the [benchstat](https://pkg.go.dev/golang.org/x/perf/cmd/benchstat) diff of 40x runs of main (as of yesterday) versus 40x runs of this PR:

```
% benchstat main.txt pr.txt
goos: linux
goarch: amd64
pkg: github.com/open-policy-agent/opa/v1/metrics
cpu: Intel(R) Core(TM) i7-8650U CPU @ 1.90GHz
                    │  main.txt   │               pr.txt               │
                    │   sec/op    │   sec/op     vs base               │
MetricsMarshaling-8   133.3µ ± 1%   124.9µ ± 1%  -6.29% (p=0.000 n=40)

                    │   main.txt   │                pr.txt                │
                    │     B/op     │     B/op      vs base                │
MetricsMarshaling-8   42.83Ki ± 0%   37.98Ki ± 0%  -11.32% (p=0.000 n=40)

                    │  main.txt  │          pr.txt           │
                    │ allocs/op  │ allocs/op   vs base       │
MetricsMarshaling-8   562.0 ± 0%   547.0 ± 0%  -2.67% (n=40)
```

- [main.txt](https://github.com/user-attachments/files/20594462/main.txt)
- [pr.txt](https://github.com/user-attachments/files/20594463/pr.txt)

