### PR TITLE
perf: improve performance when referencing "global" in loop

### DIFF
--- a/v1/ast/term.go
+++ b/v1/ast/term.go
@@ -676,8 +676,8 @@ func (num Number) Equal(other Value) bool {
 	case Number:
 		if n1, ok1 := num.Int64(); ok1 {
 			n2, ok2 := other.Int64()
-			if ok1 && ok2 && n1 == n2 {
-				return true
+			if ok1 && ok2 {
+				return n1 == n2
 			}
 		}
 

--- a/v1/topdown/numbers.go
+++ b/v1/topdown/numbers.go
@@ -20,7 +20,7 @@ var one = big.NewInt(1)
 
 func builtinNumbersRange(bctx BuiltinContext, operands []*ast.Term, iter func(*ast.Term) error) error {
 	if canGenerateCheapRange(operands) {
-		return generateCheapRange(operands, iter)
+		return generateCheapRange(operands, 1, iter)
 	}
 
 	x, err := builtins.BigIntOperand(operands[0].Value, 1)
@@ -42,6 +42,13 @@ func builtinNumbersRange(bctx BuiltinContext, operands []*ast.Term, iter func(*a
 }
 
 func builtinNumbersRangeStep(bctx BuiltinContext, operands []*ast.Term, iter func(*ast.Term) error) error {
+	if canGenerateCheapRangeStep(operands) {
+		step, _ := builtins.IntOperand(operands[2].Value, 3)
+		if step <= 0 {
+			return errors.New("numbers.range_step: step must be a positive number above zero")
+		}
+		return generateCheapRange(operands, step, iter)
+	}
 
 	x, err := builtins.BigIntOperand(operands[0].Value, 1)
 	if err != nil {
@@ -84,7 +91,18 @@ func canGenerateCheapRange(operands []*ast.Term) bool {
 	return true
 }
 
-func generateCheapRange(operands []*ast.Term, iter func(*ast.Term) error) error {
+func canGenerateCheapRangeStep(operands []*ast.Term) bool {
+	if canGenerateCheapRange(operands) {
+		step, err := builtins.IntOperand(operands[1].Value, 3)
+		if err == nil && ast.HasInternedIntNumberTerm(step) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func generateCheapRange(operands []*ast.Term, step int, iter func(*ast.Term) error) error {
 	x, err := builtins.IntOperand(operands[0].Value, 1)
 	if err != nil {
 		return err
@@ -93,19 +111,6 @@ func generateCheapRange(operands []*ast.Term, iter func(*ast.Term) error) error 
 	y, err := builtins.IntOperand(operands[1].Value, 2)
 	if err != nil {
 		return err
-	}
-
-	step := 1
-
-	if len(operands) > 2 {
-		stepOp, err := builtins.IntOperand(operands[2].Value, 3)
-		if err == nil {
-			step = stepOp
-		}
-	}
-
-	if step <= 0 {
-		return errors.New("numbers.range_step: step must be a positive number above zero")
 	}
 
 	terms := make([]*ast.Term, 0, y+1)
@@ -124,7 +129,6 @@ func generateCheapRange(operands []*ast.Term, iter func(*ast.Term) error) error 
 }
 
 func generateRange(bctx BuiltinContext, x *big.Int, y *big.Int, step *big.Int, funcName string) (*ast.Term, error) {
-
 	cmp := x.Cmp(y)
 
 	comp := func(i *big.Int, y *big.Int) bool { return i.Cmp(y) <= 0 }

--- a/v1/topdown/numbers_bench_test.go
+++ b/v1/topdown/numbers_bench_test.go
@@ -1,0 +1,78 @@
+package topdown
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/open-policy-agent/opa/v1/ast"
+)
+
+// BenchmarkNumbersRange/interned-12         	  824348	      1443 ns/op	    1880 B/op	       4 allocs/op
+// BenchmarkNumbersRange/not_interned-12     	   99547	     12052 ns/op	   15968 B/op	     533 allocs/op
+func BenchmarkNumbersRange(b *testing.B) {
+	bctx := BuiltinContext{}
+	expect100Items := expectCountIter(b, 100)
+	tests := []struct {
+		name     string
+		operands []*ast.Term
+	}{
+		{
+			name:     "interned",
+			operands: []*ast.Term{ast.InternedIntNumberTerm(0), ast.InternedIntNumberTerm(99)},
+		},
+		{
+			name:     "not interned",
+			operands: []*ast.Term{ast.IntNumberTerm(1000), ast.IntNumberTerm(1099)},
+		},
+	}
+
+	for _, test := range tests {
+		b.Run(test.name, func(b *testing.B) {
+			for range b.N {
+				if err := builtinNumbersRange(bctx, test.operands, expect100Items); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// Performs and should perform identically to BenchmarkNumbersRange
+func BenchmarkNumbersRangeStep(b *testing.B) {
+	bctx := BuiltinContext{}
+	expect100Items := expectCountIter(b, 100)
+	step := ast.InternedIntNumberTerm(2)
+	tests := []struct {
+		name     string
+		operands []*ast.Term
+	}{
+		{
+			name:     "interned",
+			operands: []*ast.Term{ast.InternedIntNumberTerm(0), ast.InternedIntNumberTerm(199), step},
+		},
+		{
+			name:     "not interned",
+			operands: []*ast.Term{ast.IntNumberTerm(1000), ast.IntNumberTerm(1199), step},
+		},
+	}
+
+	for _, test := range tests {
+		b.Run(test.name, func(b *testing.B) {
+			for range b.N {
+				if err := builtinNumbersRangeStep(bctx, test.operands, expect100Items); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func expectCountIter(b *testing.B, expected int) func(*ast.Term) error {
+	b.Helper()
+	return func(term *ast.Term) error {
+		if a, ok := term.Value.(*ast.Array); ok && a.Len() == expected {
+			return nil
+		}
+		return fmt.Errorf("expected an array of %d items, got %v", expected, term.Value)
+	}
+}


### PR DESCRIPTION
And as a pleasant side-effect, somewhat improved performance when referencing local vars as well :)

- Make integer equality check of `Number`s cheaper by not delegating to Compare unless required
- Fix mistake where IndexResult structs never got put back into the `sync.Pool` they came from. Oops!
- Slightly cheaper `numbers.range` by avoiding allocating an error
- Add `*eval.unknownRef` method to avoid allocations from `any` boxing of refs

I've also added a benchmark to easily try compare the costs of these two lookup types, and I'm pretty happy with the results:

**main**
```
global_ref-12         	   20461	     57639 ns/op	   24473 B/op	     903 allocs/op
local_var-12          	   42226	     28495 ns/op	   13363 B/op	     410 allocs/op
```

**change**
```
global_ref-12         	   25377	     46168 ns/op	   14627 B/op	     496 allocs/op
local_var-12          	   46336	     25671 ns/op	   11488 B/op	     300 allocs/op
```

Fixes #7654

While there are still potential improvements to be made, and referencing a global rule is still more expensive than a local var, the difference is now small enough that the global -> local doesn't feel warranted for anything but the most demanding requirements. For that reason, I consider this fixed. The benchmarks are great for anyone looking to improve this further :)
