### PR TITLE
v1/metrics: Fix restartable timer bug.

### DIFF
--- a/v1/metrics/metrics_bench_test.go
+++ b/v1/metrics/metrics_bench_test.go
@@ -49,3 +49,19 @@ func BenchmarkMetricsMarshaling(b *testing.B) {
 
 	b.StopTimer()
 }
+
+func BenchmarkMetricsTimerStartStopRestart(b *testing.B) {
+	m := metrics.New()
+
+	b.ResetTimer()
+
+	for range b.N {
+		m.Timer("foo").Start()
+		_ = m.Timer("foo").Stop()
+		_ = m.Timer("foo").Stop() // Second stop to exercise the sync guard.
+		m.Timer("foo").Start()
+		_ = m.Timer("foo").Stop()
+	}
+
+	b.StopTimer()
+}

--- a/v1/metrics/metrics_test.go
+++ b/v1/metrics/metrics_test.go
@@ -23,3 +23,39 @@ func TestMetricsTimer(t *testing.T) {
 		t.Fatalf("Expected metrics to be cleared, but found %v", m.All())
 	}
 }
+
+func TestMetricsTimerDoubleStop(t *testing.T) {
+	m := New()
+	m.Timer("foo").Start()
+
+	time.Sleep(time.Millisecond)
+	m.Timer("foo").Stop()
+	t1 := m.Timer("foo").Int64()
+
+	time.Sleep(time.Millisecond)
+	m.Timer("foo").Stop()
+	t2 := m.Timer("foo").Int64()
+
+	if t1 != t2 {
+		t.Fatalf("Unexpected difference in stopped timer values: %v, %v", t1, t2)
+	}
+}
+
+func TestMetricsTimerRestart(t *testing.T) {
+	m := New()
+	m.Timer("foo").Start()
+
+	time.Sleep(time.Millisecond)
+	m.Timer("foo").Stop()
+	t1 := m.Timer("foo").Int64()
+
+	// Restart the timer.
+	m.Timer("foo").Start()
+	time.Sleep(time.Millisecond)
+	m.Timer("foo").Stop()
+	t2 := m.Timer("foo").Int64()
+
+	if t1 >= t2 {
+		t.Fatalf("Expected restarted timer to advance, but got same value.: %v, %v", t1, t2)
+	}
+}


### PR DESCRIPTION
## What changed?

This PR fixes a potential bug that could occur with `metrics.Timer`. Whenever `timer.Stop()` was called, the timer would add the current delta from the start time to its accumulated value so far, *regardless of whether it had been restarted with `timer.Start()` or not*.

This could lead to confusing metrics in some places if `timer.Stop()` was accidentally called twice. (Value would be much larger than expected.)

The fix is to use a `sync.Once` guard around the accumulating step. This adds about 20 nanoseconds to timer start/stop in benchmarks, and 16 bytes to the underlying timer struct, but no extra allocs or other performance impacts.

## How to test?

    go test -timeout 30s github.com/open-policy-agent/opa/v1/metrics -count=1

## How to benchmark?

    go test -benchmem -run=^$ -bench ^BenchmarkMetricsTimerStartStop$ github.com/open-policy-agent/opa/v1/metrics -count=1