### PR TITLE
v1/server: Fix deferred metrics timers for `/v1/data` PUT, PATCH, and DELETE.

### DIFF
--- a/v1/server/server.go
+++ b/v1/server/server.go
@@ -1617,7 +1617,6 @@ func (s *Server) v1DataGet(w http.ResponseWriter, r *http.Request) {
 func (s *Server) v1DataPatch(w http.ResponseWriter, r *http.Request) {
 	m := metrics.New()
 	m.Timer(metrics.ServerHandler).Start()
-	defer m.Timer(metrics.ServerHandler).Stop()
 
 	ctx := r.Context()
 	vars := mux.Vars(r)
@@ -1666,6 +1665,8 @@ func (s *Server) v1DataPatch(w http.ResponseWriter, r *http.Request) {
 		writer.ErrorAuto(w, err)
 		return
 	}
+
+	m.Timer(metrics.ServerHandler).Stop()
 
 	if includeMetrics(r) {
 		result := types.DataResponseV1{
@@ -1841,7 +1842,6 @@ func (s *Server) v1DataPost(w http.ResponseWriter, r *http.Request) {
 func (s *Server) v1DataPut(w http.ResponseWriter, r *http.Request) {
 	m := metrics.New()
 	m.Timer(metrics.ServerHandler).Start()
-	defer m.Timer(metrics.ServerHandler).Stop()
 
 	ctx := r.Context()
 	vars := mux.Vars(r)
@@ -1907,6 +1907,8 @@ func (s *Server) v1DataPut(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	m.Timer(metrics.ServerHandler).Stop()
+
 	if includeMetrics(r) {
 		result := types.DataResponseV1{
 			Metrics: m.All(),
@@ -1921,7 +1923,6 @@ func (s *Server) v1DataPut(w http.ResponseWriter, r *http.Request) {
 func (s *Server) v1DataDelete(w http.ResponseWriter, r *http.Request) {
 	m := metrics.New()
 	m.Timer(metrics.ServerHandler).Start()
-	defer m.Timer(metrics.ServerHandler).Stop()
 
 	ctx := r.Context()
 	vars := mux.Vars(r)
@@ -1960,6 +1961,8 @@ func (s *Server) v1DataDelete(w http.ResponseWriter, r *http.Request) {
 		writer.ErrorAuto(w, err)
 		return
 	}
+
+	m.Timer(metrics.ServerHandler).Stop()
 
 	if includeMetrics(r) {
 		result := types.DataResponseV1{


### PR DESCRIPTION
## What changed?

The `/v1/data` endpoint's PUT, PATCH, and DELETE methods all report incorrect timer information (zeroed out timers). This is caused by the `Timer.Stop()` calls being `defer`'d in those method handlers. The problem is that the timers don't record a time value until you `Stop` them, and so when the metrics are reported, all of those timers are still storing their initial zero values.

I fixed this issue by manually calling `Timer.Stop()` right before metrics collection on each endpoint, similar to how we handle many other endpoints in the server.

## How to test (Manual)?

Fire up an OPA with `opa run -s`, then:

```shell
curl -X PUT -H "Content-Type: application/json" --data '{"x": 1}' 'localhost:8181/v1/data?metrics'
```

On `main` right now, you should see something like this returned:

```json
{"metrics":{"timer_rego_input_parse_ns":11043,"timer_server_handler_ns":0}}
```

After the fix:

```json
{"metrics":{"timer_rego_input_parse_ns":16511,"timer_server_handler_ns":38674}}
```

## How to test (Golang)?

Try running the following on the CLI:

    go test -timeout 30s -run ^TestDataMetricsEval$ github.com/open-policy-agent/opa/v1/server -count=1
    