### PR TITLE
perf: more efficient data/v1 POST handler

### DIFF
--- a/internal/prometheus/prometheus.go
+++ b/internal/prometheus/prometheus.go
@@ -204,7 +204,7 @@ func allocHandler(rsp http.ResponseWriter, req *http.Request) {
 	total := m.HeapInuse + m.StackInuse + m.MCacheInuse + m.MSpanInuse
 
 	var alloc string
-	if req.URL.Query().Get("pretty") == "true" {
+	if req.URL.RawQuery != "" && req.URL.Query().Get("pretty") == "true" {
 		alloc = prettyByteSize(total)
 	} else {
 		alloc = strconv.FormatUint(total, 10)

--- a/v1/plugins/logs/plugin.go
+++ b/v1/plugins/logs/plugin.go
@@ -99,7 +99,9 @@ func (b *BundleInfoV1) AST() ast.Value {
 // mask policy to the event.
 func (e *EventV1) AST() (ast.Value, error) {
 	var err error
-	event := ast.NewObject()
+	event := ast.NewObject(
+		ast.Item(ast.InternedStringTerm("decision_id"), ast.StringTerm(e.DecisionID)),
+	)
 
 	if e.Labels != nil {
 		labelsObj := ast.NewObject()
@@ -110,8 +112,6 @@ func (e *EventV1) AST() (ast.Value, error) {
 	} else {
 		event.Insert(ast.InternedStringTerm("labels"), ast.NullTerm())
 	}
-
-	event.Insert(ast.InternedStringTerm("decision_id"), ast.StringTerm(e.DecisionID))
 
 	if len(e.Revision) > 0 {
 		event.Insert(ast.InternedStringTerm("revision"), ast.StringTerm(e.Revision))
@@ -133,12 +133,12 @@ func (e *EventV1) AST() (ast.Value, error) {
 		event.Insert(ast.InternedStringTerm("query"), ast.StringTerm(e.Query))
 	}
 
-	if e.Input != nil {
-		if e.inputAST == nil {
-			e.inputAST, err = roundtripJSONToAST(e.Input)
-			if err != nil {
-				return nil, err
-			}
+	if e.inputAST != nil {
+		event.Insert(ast.InternedStringTerm("input"), ast.NewTerm(e.inputAST))
+	} else if e.Input != nil {
+		e.inputAST, err = roundtripJSONToAST(e.Input)
+		if err != nil {
+			return nil, err
 		}
 		event.Insert(ast.InternedStringTerm("input"), ast.NewTerm(e.inputAST))
 	}

--- a/v1/server/authorizer/authorizer.go
+++ b/v1/server/authorizer/authorizer.go
@@ -158,6 +158,8 @@ func (h *Basic) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	writer.Error(w, http.StatusUnauthorized, types.NewErrorV1(types.CodeUnauthorized, types.MsgUnauthorizedError))
 }
 
+var emptyQuery = url.Values{}
+
 func makeInput(r *http.Request) (*http.Request, any, error) {
 	path, err := parsePath(r.URL.Path)
 	if err != nil {
@@ -165,7 +167,11 @@ func makeInput(r *http.Request) (*http.Request, any, error) {
 	}
 
 	method := strings.ToUpper(r.Method)
-	query := r.URL.Query()
+
+	var query = emptyQuery
+	if r.URL.RawQuery != "" {
+		query = r.URL.Query()
+	}
 
 	var rawBody []byte
 

--- a/v1/server/server.go
+++ b/v1/server/server.go
@@ -70,8 +70,6 @@ const (
 	AuthenticationTLS
 )
 
-var supportedTLSVersions = []uint16{tls.VersionTLS10, tls.VersionTLS11, tls.VersionTLS12, tls.VersionTLS13}
-
 // AuthorizationScheme enumerates the supported authorization schemes. The authorization
 // scheme determines how access to OPA is controlled.
 type AuthorizationScheme int
@@ -82,10 +80,10 @@ const (
 	AuthorizationBasic
 )
 
-const defaultMinTLSVersion = tls.VersionTLS12
-
-// Set of handlers for use in the "handler" dimension of the duration metric.
 const (
+	defaultMinTLSVersion = tls.VersionTLS12
+
+	// Set of handlers for use in the "handler" dimension of the duration metric.
 	PromHandlerV0Data     = "v0/data"
 	PromHandlerV1Data     = "v1/data"
 	PromHandlerV1Query    = "v1/query"
@@ -97,15 +95,17 @@ const (
 	PromHandlerCatch      = "catchall"
 	PromHandlerHealth     = "health"
 	PromHandlerAPIAuthz   = "authz"
+
+	pqMaxCacheSize = 100
+
+	// OpenTelemetry attributes
+	otelDecisionIDAttr = "opa.decision_id"
 )
 
-const pqMaxCacheSize = 100
-
-// OpenTelemetry attributes
-const otelDecisionIDAttr = "opa.decision_id"
-
-// map of unsafe builtins
-var unsafeBuiltinsMap = map[string]struct{}{ast.HTTPSend.Name: {}}
+var (
+	supportedTLSVersions = []uint16{tls.VersionTLS10, tls.VersionTLS11, tls.VersionTLS12, tls.VersionTLS13}
+	unsafeBuiltinsMap    = map[string]struct{}{ast.HTTPSend.Name: {}}
+)
 
 // Server represents an instance of OPA running in server mode.
 type Server struct {
@@ -1170,9 +1170,9 @@ func (s *Server) v0QueryPath(w http.ResponseWriter, r *http.Request, urlPath str
 
 func (s *Server) getCachedPreparedEvalQuery(key string, m metrics.Metrics) (*rego.PreparedEvalQuery, bool) {
 	pq, ok := s.preparedEvalQueries.Get(key)
-	m.Counter(metrics.ServerQueryCacheHit) // Creates the counter on the metrics if it doesn't exist, starts at 0
+	counter := m.Counter(metrics.ServerQueryCacheHit) // Creates the counter on m if it doesn't exist, starts at 0
 	if ok {
-		m.Counter(metrics.ServerQueryCacheHit).Incr() // Increment counter on hit
+		counter.Incr() // Increment counter on hit
 		return pq.(*rego.PreparedEvalQuery), true
 	}
 	return nil, false
@@ -1362,7 +1362,7 @@ func writeHealthResponse(w http.ResponseWriter, err error) {
 
 func (s *Server) v1CompilePost(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	explainMode := getExplain(r.URL.Query()[types.ParamExplainV1], types.ExplainOffV1)
+	explainMode := getExplain(r.URL, types.ExplainOffV1)
 	includeInstrumentation := getBoolParam(r.URL, types.ParamInstrumentV1, true)
 
 	m := metrics.New()
@@ -1461,7 +1461,7 @@ func (s *Server) v1DataGet(w http.ResponseWriter, r *http.Request) {
 
 	vars := mux.Vars(r)
 	urlPath := vars["path"]
-	explainMode := getExplain(r.URL.Query()["explain"], types.ExplainOffV1)
+	explainMode := getExplain(r.URL, types.ExplainOffV1)
 	includeInstrumentation := getBoolParam(r.URL, types.ParamInstrumentV1, true)
 	provenance := getBoolParam(r.URL, types.ParamProvenanceV1, true)
 	strictBuiltinErrors := getBoolParam(r.URL, types.ParamStrictBuiltinErrors, true)
@@ -1679,19 +1679,12 @@ func (s *Server) v1DataPatch(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) v1DataPost(w http.ResponseWriter, r *http.Request) {
-	m := metrics.New()
+	m := s.getMetrics(r)
 	m.Timer(metrics.ServerHandler).Start()
 
 	decisionID := s.generateDecisionID()
 	ctx := logging.WithDecisionID(r.Context(), decisionID)
 	annotateSpan(ctx, decisionID)
-
-	vars := mux.Vars(r)
-	urlPath := vars["path"]
-	explainMode := getExplain(r.URL.Query()[types.ParamExplainV1], types.ExplainOffV1)
-	includeInstrumentation := getBoolParam(r.URL, types.ParamInstrumentV1, true)
-	provenance := getBoolParam(r.URL, types.ParamProvenanceV1, true)
-	strictBuiltinErrors := getBoolParam(r.URL, types.ParamStrictBuiltinErrors, true)
 
 	m.Timer(metrics.RegoInputParse).Start()
 
@@ -1711,28 +1704,41 @@ func (s *Server) v1DataPost(w http.ResponseWriter, r *http.Request) {
 
 	defer s.store.Abort(ctx, txn)
 
-	br, err := getRevisions(ctx, s.store, txn)
-	if err != nil {
-		writer.ErrorAuto(w, err)
-		return
+	provenance := getBoolParam(r.URL, types.ParamProvenanceV1, true)
+
+	var logger decisionLogger
+	var br bundleRevisions
+
+	if s.logger != nil || provenance {
+		br, err = getRevisions(ctx, s.store, txn)
+		if err != nil {
+			writer.ErrorAuto(w, err)
+			return
+		}
+		if s.logger != nil {
+			logger = s.getDecisionLogger(br)
+		}
 	}
 
-	logger := s.getDecisionLogger(br)
+	var buf *topdown.BufferTracer
+
+	explainMode := getExplain(r.URL, types.ExplainOffV1)
+	if explainMode != types.ExplainOffV1 {
+		buf = topdown.NewBufferTracer()
+	}
 
 	var ndbCache builtins.NDBCache
 	if s.ndbCacheEnabled {
 		ndbCache = builtins.NDBCache{}
 	}
 
-	var buf *topdown.BufferTracer
-
-	if explainMode != types.ExplainOffV1 {
-		buf = topdown.NewBufferTracer()
-	}
+	urlPath := mux.Vars(r)["path"]
+	strictBuiltinErrors := getBoolParam(r.URL, types.ParamStrictBuiltinErrors, true)
+	includeInstrumentation := getBoolParam(r.URL, types.ParamInstrumentV1, true)
 
 	pqID := "v1DataPost::"
 	if strictBuiltinErrors {
-		pqID += "strict-builtin-errors::"
+		pqID = "v1DataPost::strict-builtin-errors::"
 	}
 	pqID += urlPath
 	preparedQuery, ok := s.getCachedPreparedEvalQuery(pqID, m)
@@ -1767,7 +1773,7 @@ func (s *Server) v1DataPost(w http.ResponseWriter, r *http.Request) {
 		s.preparedEvalQueries.Insert(pqID, preparedQuery)
 	}
 
-	evalOpts := []rego.EvalOption{
+	rs, err := preparedQuery.Eval(ctx,
 		rego.EvalTransaction(txn),
 		rego.EvalParsedInput(input),
 		rego.EvalMetrics(m),
@@ -1776,11 +1782,6 @@ func (s *Server) v1DataPost(w http.ResponseWriter, r *http.Request) {
 		rego.EvalInterQueryBuiltinValueCache(s.interQueryBuiltinValueCache),
 		rego.EvalInstrument(includeInstrumentation),
 		rego.EvalNDBuiltinCache(ndbCache),
-	}
-
-	rs, err := preparedQuery.Eval(
-		ctx,
-		evalOpts...,
 	)
 
 	m.Timer(metrics.ServerHandler).Stop()
@@ -1800,7 +1801,8 @@ func (s *Server) v1DataPost(w http.ResponseWriter, r *http.Request) {
 		result.Warning = types.NewWarning(types.CodeAPIUsageWarn, types.MsgInputKeyMissing)
 	}
 
-	if includeMetrics(r) || includeInstrumentation {
+	includeMetrics := getBoolParam(r.URL, types.ParamMetricsV1, true)
+	if includeMetrics || includeInstrumentation {
 		result.Metrics = m.All()
 	}
 
@@ -1810,14 +1812,12 @@ func (s *Server) v1DataPost(w http.ResponseWriter, r *http.Request) {
 
 	if len(rs) == 0 {
 		if explainMode == types.ExplainFullV1 {
-			result.Explanation, err = types.NewTraceV1(lineage.Full(*buf), pretty(r))
-			if err != nil {
+			if result.Explanation, err = types.NewTraceV1(lineage.Full(*buf), pretty(r)); err != nil {
 				writer.ErrorAuto(w, err)
 				return
 			}
 		}
-		err = logger.Log(ctx, txn, urlPath, "", goInput, input, nil, ndbCache, nil, m)
-		if err != nil {
+		if err = logger.Log(ctx, txn, urlPath, "", goInput, input, nil, ndbCache, nil, m); err != nil {
 			writer.ErrorAuto(w, err)
 			return
 		}
@@ -2258,7 +2258,7 @@ func (s *Server) v1QueryGet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	explainMode := getExplain(r.URL.Query()["explain"], types.ExplainOffV1)
+	explainMode := getExplain(r.URL, types.ExplainOffV1)
 	includeInstrumentation := getBoolParam(r.URL, types.ParamInstrumentV1, true)
 
 	params := storage.TransactionParams{Context: storage.NewContext().WithMetrics(m)}
@@ -2317,7 +2317,7 @@ func (s *Server) v1QueryPost(w http.ResponseWriter, r *http.Request) {
 	}
 
 	pretty := pretty(r)
-	explainMode := getExplain(r.URL.Query()["explain"], types.ExplainOffV1)
+	explainMode := getExplain(r.URL, types.ExplainOffV1)
 	includeMetrics := includeMetrics(r)
 	includeInstrumentation := getBoolParam(r.URL, types.ParamInstrumentV1, true)
 
@@ -2414,6 +2414,17 @@ func (s *Server) checkPolicyPackageScope(ctx context.Context, txn storage.Transa
 	}
 
 	return s.checkPathScope(ctx, txn, spath)
+}
+
+func (s *Server) getMetrics(r *http.Request) metrics.Metrics {
+	metricsInQuery := getBoolParam(r.URL, types.ParamMetricsV1, true)
+	instrumentationInQuery := getBoolParam(r.URL, types.ParamInstrumentV1, true)
+
+	if s.logger == nil && !metricsInQuery && !instrumentationInQuery {
+		return metrics.NoOp()
+	}
+
+	return metrics.New()
 }
 
 func (s *Server) checkPathScope(ctx context.Context, txn storage.Transaction, path storage.Path) error {
@@ -2763,6 +2774,9 @@ func validateQuery(query string, opts ast.ParserOptions) (ast.Body, error) {
 }
 
 func getBoolParam(url *url.URL, name string, ifEmpty bool) bool {
+	if url.RawQuery == "" {
+		return false
+	}
 
 	p, ok := url.Query()[name]
 	if !ok {
@@ -2800,8 +2814,12 @@ func getStringSliceParam(url *url.URL, name string) []string {
 	return p
 }
 
-func getExplain(p []string, zero types.ExplainModeV1) types.ExplainModeV1 {
-	for _, x := range p {
+func getExplain(url *url.URL, zero types.ExplainModeV1) types.ExplainModeV1 {
+	if url.RawQuery == "" {
+		return zero
+	}
+
+	for _, x := range url.Query()[types.ParamExplainV1] {
 		switch x {
 		case string(types.ExplainNotesV1):
 			return types.ExplainNotesV1
@@ -3028,7 +3046,21 @@ type decisionLogger struct {
 	logger    func(context.Context, *Info) error
 }
 
-func (l decisionLogger) Log(ctx context.Context, txn storage.Transaction, path string, query string, goInput *any, astInput ast.Value, goResults *any, ndbCache builtins.NDBCache, err error, m metrics.Metrics) error {
+func (l decisionLogger) Log(
+	ctx context.Context,
+	txn storage.Transaction,
+	path string,
+	query string,
+	goInput *any,
+	astInput ast.Value,
+	goResults *any,
+	ndbCache builtins.NDBCache,
+	err error,
+	m metrics.Metrics,
+) error {
+	if l.logger == nil {
+		return nil
+	}
 
 	bundles := map[string]BundleInfo{}
 	for name, rev := range l.revisions {
@@ -3080,10 +3112,8 @@ func (l decisionLogger) Log(ctx context.Context, txn storage.Transaction, path s
 		info.SpanID = sctx.SpanID().String()
 	}
 
-	if l.logger != nil {
-		if err := l.logger(ctx, info); err != nil {
-			return fmt.Errorf("decision_logs: %w", err)
-		}
+	if err := l.logger(ctx, info); err != nil {
+		return fmt.Errorf("decision_logs: %w", err)
 	}
 
 	return nil
@@ -3107,11 +3137,9 @@ func parseURL(s string, useHTTPSByDefault bool) (*url.URL, error) {
 }
 
 func annotateSpan(ctx context.Context, decisionID string) {
-	if decisionID == "" {
-		return
+	if decisionID != "" {
+		trace.SpanFromContext(ctx).SetAttributes(attribute.String(otelDecisionIDAttr, decisionID))
 	}
-	trace.SpanFromContext(ctx).
-		SetAttributes(attribute.String(otelDecisionIDAttr, decisionID))
 }
 
 func pretty(r *http.Request) bool {

--- a/v1/server/server_bench_test.go
+++ b/v1/server/server_bench_test.go
@@ -1,0 +1,72 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/open-policy-agent/opa/v1/plugins"
+	"github.com/open-policy-agent/opa/v1/storage/inmem"
+)
+
+func BenchmarkDataPostV1Request(b *testing.B) {
+	f := newBenchFixture(b)
+	err := f.v1(http.MethodPut, "/policies/test", `package test
+
+default hello := false
+
+hello if input.message == "world"
+`, 200, "")
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	for i := range b.N {
+		req := newReqV1("POST", "/data/test", `{"input": {"message": "world"}}`)
+
+		err := f.executeRequest(req, 200, "{\"result\":{\"hello\":true}}\n")
+		if err != nil {
+			b.Fatalf("Unexpected error from POST /data/test: %v, iteration: %d", err, i)
+		}
+	}
+}
+
+func newBenchFixture(b *testing.B, opts ...any) *fixture {
+	ctx := context.Background()
+	server := New().
+		WithAddresses([]string{"localhost:8182"}).
+		WithStore(inmem.New()) // potentially overridden via opts
+
+	for _, opt := range opts {
+		if opt, ok := opt.(func(*Server)); ok {
+			opt(server)
+		}
+	}
+
+	var mOpts []func(*plugins.Manager)
+	for _, opt := range opts {
+		if opt, ok := opt.(func(*plugins.Manager)); ok {
+			mOpts = append(mOpts, opt)
+		}
+	}
+
+	m, err := plugins.New([]byte{}, "test", server.store, mOpts...)
+	if err != nil {
+		b.Fatal(err)
+	}
+	server = server.WithManager(m)
+	if err := m.Start(ctx); err != nil {
+		b.Fatal(err)
+	}
+	server, err = server.Init(ctx)
+	if err != nil {
+		b.Fatal(err)
+	}
+	recorder := httptest.NewRecorder()
+
+	return &fixture{
+		server:   server,
+		recorder: recorder,
+	}
+}

--- a/v1/server/server_test.go
+++ b/v1/server/server_test.go
@@ -5381,6 +5381,14 @@ func (f *fixture) executeRequestForHandler(h http.Handler, req *http.Request, co
 		return fmt.Errorf("Expected code %v from %v %v but got: %+v", code, req.Method, req.URL, f.recorder)
 	}
 	if resp != "" {
+		body := f.recorder.Body.String()
+		if resp == body {
+			// Early return on exact match as we can avoid the cost of uunmarshalling
+			// both the expected and actual response in that case. This is particularly
+			// useful for benchmarks where you only want to measure server-sider handling.
+			return nil
+		}
+
 		var result any
 		if err := util.UnmarshalJSON(f.recorder.Body.Bytes(), &result); err != nil {
 			return fmt.Errorf("Expected JSON response from %v %v but got: %v", req.Method, req.URL, f.recorder)


### PR DESCRIPTION
Since we don't use OPA's HTTP API in Regal, I hadn't looked at this from a performance POV before, but it was a fun side quest :)

A pretty decent reduction of the baseline cost for the most common request type, v1/data POST. Changes:

- Add NoOp implementation of `Metrics` for when metrics aren't needed
- Cheaper `metrics.New` instantiation avoiding unnecessary lock
- Avoid cost of decision logging if decision logging isn't enabled
- Only call request.URL.Query() if URL.RawQuery isn't empty, avoiding allocating an empty map with each request

While the target was v1/data POST handling, some of the changes above have a positive impact on all or most handlers. All changes have been run through the existing tests, and a new benchmark to measure the impact of the fixes have been added, showing:

```
13063 ns/op	   15162 B/op	     195 allocs/op - main
12796 ns/op	   14856 B/op	     189 allocs/op - avoid r.URL.Query() when no query provided
12541 ns/op	   14483 B/op	     187 allocs/op - decisionLogger.Log early exit if not enabled
12133 ns/op	   14235 B/op	     180 allocs/op - get revisions and init logger only if needed
11098 ns/op	   14207 B/op	     180 allocs/op - more efficient metrics.New() (without locking)
10683 ns/op	   13171 B/op	     169 allocs/op - use no-op metrics implementation when metrics aren't requested
```

Even if the impact is pretty good, it's worth noting that most of the improvements above are only seen when decision logging is turned off. While this is the common case for development, it's not in production. Getting the baseline cost down is important still as there should be no cost paid for features unused.