### PR TITLE
website: Hide feedback pop-up forever if dismissed

### DIFF
--- a/docs/src/components/FeedbackForm/index.js
+++ b/docs/src/components/FeedbackForm/index.js
@@ -39,6 +39,12 @@ export default function FeedbackForm({ enablePopup = false }) {
     if (typeof window !== "undefined") {
       setUrl(window.location);
       setPath(window.location.pathname);
+
+      // Check if popup has been globally dismissed
+      const popupDismissed = localStorage.getItem("documentation-feedback-popup-dismissed");
+      if (popupDismissed) {
+        setPopupEnabled(false);
+      }
     }
   }, []);
 
@@ -200,36 +206,51 @@ export default function FeedbackForm({ enablePopup = false }) {
  * the feedback form and pre-select their feedback type. The popup is automatically
  * hidden when the feedback form comes into view.
  */
-const FloatingPopup = ({ onClose, onFeedbackSelect }) => (
-  <div className={styles.popup}>
-    <button
-      className={styles.closeButton}
-      onClick={onClose}
-      aria-label="Close feedback popup"
-    >
-      <Icon icon="mdi:close" size="24px" />
-    </button>
-    <div className={styles["popup-content"]}>
-      <p>How's this page?</p>
-      <div className={styles["popup-buttons"]}>
-        <button
-          type="button"
-          onClick={() => onFeedbackSelect("positive")}
-          className={`${styles.button} ${styles.positive}`}
-        >
-          <Icon icon="mdi:thumbs-up" size="24px" />
-        </button>
-        <button
-          type="button"
-          onClick={() => onFeedbackSelect("negative")}
-          className={`${styles.button} ${styles.negative}`}
-        >
-          <Icon icon="mdi:thumbs-down" size="24px" />
-        </button>
+const FloatingPopup = ({ onClose, onFeedbackSelect }) => {
+  const handleClose = () => {
+    // Set global flag to never show popup again
+    localStorage.setItem("documentation-feedback-popup-dismissed", "true");
+    onClose();
+  };
+
+  const handleFeedbackSelect = (type) => {
+    if (type === "negative") {
+      localStorage.setItem("documentation-feedback-popup-dismissed", "true");
+    }
+    onFeedbackSelect(type);
+  };
+
+  return (
+    <div className={styles.popup}>
+      <button
+        className={styles.closeButton}
+        onClick={handleClose}
+        aria-label="Close feedback popup"
+      >
+        <Icon icon="mdi:close" size="24px" />
+      </button>
+      <div className={styles["popup-content"]}>
+        <p>How's this page?</p>
+        <div className={styles["popup-buttons"]}>
+          <button
+            type="button"
+            onClick={() => handleFeedbackSelect("positive")}
+            className={`${styles.button} ${styles.positive}`}
+          >
+            <Icon icon="mdi:thumbs-up" size="24px" />
+          </button>
+          <button
+            type="button"
+            onClick={() => handleFeedbackSelect("negative")}
+            className={`${styles.button} ${styles.negative}`}
+          >
+            <Icon icon="mdi:thumbs-down" size="24px" />
+          </button>
+        </div>
       </div>
     </div>
-  </div>
-);
+  );
+};
 
 const Form = ({
   formName,


### PR DESCRIPTION
In response to feedback, the feedback pop-up will now be hidden indefinitely if the user chooses to dismiss it. This change is intended to improve user experience by preventing the pop-up from reappearing after being dismissed on one page and then re-appearing on another.

<img width="405" alt="Screenshot 2025-06-09 at 10 50 06" src="https://github.com/user-attachments/assets/cad8cd9a-3645-4c9f-a3d6-a4ba0ad71577" />

