### PR TITLE
docs: Improve explanations for initial examples

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -320,7 +320,9 @@ output := input.networks
 <RunSnippet files="#input.json" command="data.servers.output"/>
 
 One option would be to test each network in the input (which is undefined since
-networks 1 and 2 are not public):
+networks 1 and 2 are not public). Incremental definitions of a rule are
+[OR'd together](#logical-or) so if any are true, the result of the whole rule is
+true.
 
 ```rego
 package servers


### PR DESCRIPTION
We had some feedback that the initial examples in the docs were not clear enough and needed some more explanation.
<img width="771" alt="Screenshot 2025-06-09 at 15 21 25" src="https://github.com/user-attachments/assets/defc8412-6993-447a-86c9-19fb7fa14b5b" />
