### PR TITLE
docs: Add current ecosystem contribution docs

### DIFF
--- a/docs/docs/contrib-docs.md
+++ b/docs/docs/contrib-docs.md
@@ -127,6 +127,22 @@ Reach out in the
 [#contributors](https://openpolicyagent.slack.com/archives/C02L1TLPN59)
 channel on the [OPA Slack](https://slack.openpolicyagent.org/) to ask for help.
 
+## OPA Ecosystem Additions
+
+The [OPA Ecosystem](/ecosystem/) is a showcase of projects that are built with
+or integrated with OPA. If you have a project that you would like to showcase,
+please open a PR with two files:
+
+- A markdown file in [docs/src/data/ecosystem/entries](https://github.com/open-policy-agent/opa/blob/main/docs/src/data/ecosystem/entries)
+- An icon file in [docs/static/img/ecosystem-entry-logos](https://github.com/open-policy-agent/opa/blob/main/docs/static/img/ecosystem-entry-logos)
+
+Both files should have the same 'id', e.g. if your project is called `foobar`,
+then the markdown file should be named `foobar.md` and the icon file
+is named `foobar.{png|svg}`.
+
+You will need to restart the Docusaurus dev server to see the changes if
+previewing locally.
+
 ## Sub-project Documentation
 
 Documentation for the OPA sub-projects each have their own home. Check out their

--- a/docs/docs/editor-and-ide-support.md
+++ b/docs/docs/editor-and-ide-support.md
@@ -24,7 +24,7 @@ evaluation, policy coverage, and more.
 message on [Slack](https://slack.openpolicyagent.org)
 We also have our [Ecosystem page](/ecosystem/). This is a great place to
 showcase your project. See
-[these instructions](https://github.com/open-policy-agent/opa/tree/main/docs#opa-ecosystem)
+[these instructions](./contrib-docs#opa-ecosystem-additions)
 to get it listed.
 :::
 

--- a/docs/src/pages/ecosystem/index.js
+++ b/docs/src/pages/ecosystem/index.js
@@ -1,6 +1,8 @@
+import React, { useState } from "react";
+
+import Link from "@docusaurus/Link";
 import Heading from "@theme/Heading";
 import Layout from "@theme/Layout";
-import React, { useState } from "react";
 
 import Card from "../../components/Card";
 import CardGrid from "../../components/CardGrid";
@@ -178,7 +180,8 @@ const EcosystemIndex = (props) => {
             }}
           />
           <p style={{ fontSize: "0.8rem", marginTop: "0.5rem" }}>
-            All integrations are ordered by the number of linked resources.
+            All integrations are ordered by the number of linked resources.{" "}
+            <Link to="/docs/contrib-docs#opa-ecosystem-additions">Add yours!</Link>
           </p>
         </div>
 


### PR DESCRIPTION
These had been removed as the process had changed in the move to the new site.

Following some feedback referencing the editor-support page.