### PR TITLE
website: Only show latest patch in archive

### DIFF
--- a/docs/src/Archive.js
+++ b/docs/src/Archive.js
@@ -123,7 +123,10 @@ const Archive = (props) => {
       <div className="container margin-vert--lg">
         <Heading as="h1">{title}</Heading>
 
-        <p>Please find a list of archived OPA docs versions here:</p>
+        <p>
+          Please find links to past versions of the OPA Documentation here. Note that only the latest patch within a
+          minor release is shown.
+        </p>
 
         <div style={{ marginTop: "1rem" }}>
           <ul


### PR DESCRIPTION
This updates the archive list to only show the latest patch release for each minor version. This is to reduce the total number of entries on the archive page. (and it is what we used to do with the old site too!)
