### PR TITLE
docs: policy-reference, update sig algs formatting

### DIFF
--- a/docs/docs/policy-reference/index.md
+++ b/docs/docs/policy-reference/index.md
@@ -474,18 +474,18 @@ JSON will match.
 
 The following algorithms are supported:
 
-    ES256       "ES256" // ECDSA using P-256 and SHA-256
-    ES384       "ES384" // ECDSA using P-384 and SHA-384
-    ES512       "ES512" // ECDSA using P-521 and SHA-512
-    HS256       "HS256" // HMAC using SHA-256
-    HS384       "HS384" // HMAC using SHA-384
-    HS512       "HS512" // HMAC using SHA-512
-    PS256       "PS256" // RSASSA-PSS using SHA256 and MGF1-SHA256
-    PS384       "PS384" // RSASSA-PSS using SHA384 and MGF1-SHA384
-    PS512       "PS512" // RSASSA-PSS using SHA512 and MGF1-SHA512
-    RS256       "RS256" // RSASSA-PKCS-v1.5 using SHA-256
-    RS384       "RS384" // RSASSA-PKCS-v1.5 using SHA-384
-    RS512       "RS512" // RSASSA-PKCS-v1.5 using SHA-512
+- `ES256`: ECDSA using P-256 and SHA-256
+- `ES384`: ECDSA using P-384 and SHA-384
+- `ES512`: ECDSA using P-521 and SHA-512
+- `HS256`: HMAC using SHA-256
+- `HS384`: HMAC using SHA-384
+- `HS512`: HMAC using SHA-512
+- `PS256`: RSASSA-PSS using SHA256 and MGF1-SHA256
+- `PS384`: RSASSA-PSS using SHA384 and MGF1-SHA384
+- `PS512`: RSASSA-PSS using SHA512 and MGF1-SHA512
+- `RS256`: RSASSA-PKCS-v1.5 using SHA-256
+- `RS384`: RSASSA-PKCS-v1.5 using SHA-384
+- `RS512`: RSASSA-PKCS-v1.5 using SHA-512
 
 :::info
 Note that the key's provided should be base64 URL encoded (without padding) as per the specification ([RFC7517](https://tools.ietf.org/html/rfc7517)).


### PR DESCRIPTION
This used to be rendered as a pre block on the old site, but it was broken as our mdx formatter does not do that now.

I have made it a nice list instead.

![image](https://github.com/user-attachments/assets/f0281287-f000-4ac6-9732-1dfed5b15463)
