### PR TITLE
build: Skip jobs for non docs changes

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -459,3 +459,43 @@ jobs:
 
     - name: Build docs
       run: make docs-build
+
+  # This job is required to complete before merging, and is set as a branch
+  # protection rule:
+  # https://github.com/open-policy-agent/opa/settings/branch_protection_rules
+  pr-check-summary:
+    name: PR Check Summary
+    runs-on: ubuntu-24.04
+    needs: [
+      check-changes,
+      generate,
+      go-build,
+      go-test,
+      go-lint,
+      yaml-lint,
+      wasm,
+      check-generated,
+      race-detector,
+      smoke-test-docker-images,
+      smoke-test-binaries,
+      go-version-build,
+      rego-check-pr,
+      docs-build,
+    ]
+    if: always()
+    steps:
+    - name: Check job results
+      run: |
+        # Check if any required job failed (not skipped)
+        if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
+          echo "One or more required jobs failed"
+          exit 1
+        fi
+
+        # Check if any required job was cancelled
+        if [[ "${{ contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+          echo "One or more required jobs were cancelled"
+          exit 1
+        fi
+
+        echo "All jobs completed successfully or were skipped"


### PR DESCRIPTION
I have tried to re-write the scripts we use to toggle jobs on and off here and so have a custom script that runs checks for different types of gates (wasm and docs-only) right now.

There is a lot of docs PRs at the moment and the go checks are slowing them down and then they flake it blocks the auto merge too.

Open to feedback on if we should even skip this, or if this is something we want to add only after we have some more checks for docs PRs (e.g. spell and link checks).