### PR TITLE
build: Make summary failure source clearer

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -494,18 +494,28 @@ jobs:
     ]
     if: always()
     steps:
+    - name: Check out code
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - name: Download OPA
+      uses: open-policy-agent/setup-opa@34a30e8a924d1b03ce2cf7abe97250bbb1f332b5 # v2.2.0
+      with:
+        version: edge
     - name: Check job results
       run: |
-        # Check if any required job failed (not skipped)
-        if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
-          echo "One or more required jobs failed"
+        # Create the input file with all job results
+        echo '${{ toJSON(needs) }}' > input.json
+        
+        # Find failed or cancelled jobs using OPA
+        opa eval -d .github/workflows/pull-request.yaml \
+        --input=input.json \
+        '{job|some _, job in data.jobs["pr-check-summary"].needs} & {job | input[job].result in {"failure", "cancelled"}}' \
+        --format=raw > failed_jobs.json
+        
+        # Check for failures and display a nice message
+        if [ "$(cat failed_jobs.json)" != "[]" ]; then
+          echo "The following required jobs did not complete successfully:"
+          jq -r '.[]' failed_jobs.json | sed 's/^/- /'
           exit 1
         fi
-
-        # Check if any required job was cancelled
-        if [[ "${{ contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
-          echo "One or more required jobs were cancelled"
-          exit 1
-        fi
-
+        
         echo "All jobs completed successfully or were skipped"


### PR DESCRIPTION
In: https://github.com/open-policy-agent/opa/actions/runs/15607457047/job/43960850907?pr=7693

The output is really unclear that it's the race job that failed.

Since it's the summary that is the required check, it should be give the author some hint about what to do next to fix the issue rather than just saying "one of the required checks failed".
