### PR TITLE
opa check --bundle report virtual/base doc conflicts

### DIFF
--- a/cmd/bench.go
+++ b/cmd/bench.go
@@ -29,6 +29,7 @@ import (
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
 
+	"github.com/open-policy-agent/opa/cmd/formats"
 	"github.com/open-policy-agent/opa/cmd/internal/env"
 	"github.com/open-policy-agent/opa/internal/presentation"
 	"github.com/open-policy-agent/opa/v1/compile"
@@ -50,18 +51,10 @@ type benchmarkCommandParams struct {
 	configFile             string
 }
 
-const (
-	benchmarkGoBenchOutput = "gobench"
-)
-
 func newBenchmarkEvalParams() benchmarkCommandParams {
 	return benchmarkCommandParams{
 		evalCommandParams: evalCommandParams{
-			outputFormat: util.NewEnumFlag(evalPrettyOutput, []string{
-				evalJSONOutput,
-				evalPrettyOutput,
-				benchmarkGoBenchOutput,
-			}),
+			outputFormat: formats.Flag(formats.Pretty, formats.JSON, formats.GoBench),
 			target:       util.NewEnumFlag(compile.TargetRego, []string{compile.TargetRego, compile.TargetWasm}),
 			schema:       &schemaFlags{},
 			capabilities: newcapabilitiesFlag(),
@@ -597,9 +590,9 @@ func readQuery(params benchmarkCommandParams, args []string) (string, error) {
 
 func renderBenchmarkResult(params benchmarkCommandParams, br testing.BenchmarkResult, w io.Writer) {
 	switch params.outputFormat.String() {
-	case evalJSONOutput:
+	case formats.JSON:
 		_ = presentation.JSON(w, br)
-	case benchmarkGoBenchOutput:
+	case formats.GoBench:
 		fmt.Fprintf(w, "BenchmarkOPAEval\t%s", br.String())
 		if params.benchMem {
 			fmt.Fprintf(w, "\t%s", br.MemString())
@@ -634,7 +627,7 @@ func renderBenchmarkError(params benchmarkCommandParams, err error, w io.Writer)
 	}
 
 	switch params.outputFormat.String() {
-	case evalJSONOutput:
+	case formats.JSON:
 		return presentation.JSON(w, o)
 	default:
 		return presentation.Pretty(w, o)

--- a/cmd/bench_test.go
+++ b/cmd/bench_test.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/open-policy-agent/opa/cmd/formats"
 	"github.com/open-policy-agent/opa/internal/presentation"
 	"github.com/open-policy-agent/opa/v1/ast"
 	"github.com/open-policy-agent/opa/v1/bundle"
@@ -886,7 +887,7 @@ a contains x if {
 
 				test.WithTempFS(files, func(path string) {
 					params := testBenchParams()
-					_ = params.outputFormat.Set(evalPrettyOutput)
+					_ = params.outputFormat.Set(formats.Pretty)
 					params.e2e = mode.e2e
 
 					for n := range files {
@@ -1022,7 +1023,7 @@ a[4] {
 
 				test.WithTempFS(files, func(path string) {
 					params := testBenchParams()
-					_ = params.outputFormat.Set(evalPrettyOutput)
+					_ = params.outputFormat.Set(formats.Pretty)
 					params.v0Compatible = tc.v0Compatible
 					params.v1Compatible = tc.v1Compatible
 					params.e2e = mode.e2e
@@ -1230,7 +1231,7 @@ a contains 4 if {
 						}
 
 						params := testBenchParams()
-						_ = params.outputFormat.Set(evalPrettyOutput)
+						_ = params.outputFormat.Set(formats.Pretty)
 
 						params.e2e = mode.e2e
 						err := params.bundlePaths.Set(p)
@@ -1273,7 +1274,7 @@ func TestRenderBenchmarkResultJSONOutput(t *testing.T) {
 	t.Parallel()
 
 	params := testBenchParams()
-	err := params.outputFormat.Set(evalJSONOutput)
+	err := params.outputFormat.Set(formats.JSON)
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}
@@ -1317,7 +1318,7 @@ func TestRenderBenchmarkResultPrettyOutput(t *testing.T) {
 
 	params := testBenchParams()
 	params.benchMem = false
-	err := params.outputFormat.Set(evalPrettyOutput)
+	err := params.outputFormat.Set(formats.Pretty)
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}
@@ -1356,7 +1357,7 @@ func TestRenderBenchmarkResultPrettyOutputShowAllocs(t *testing.T) {
 
 	params := testBenchParams()
 	params.benchMem = true
-	err := params.outputFormat.Set(evalPrettyOutput)
+	err := params.outputFormat.Set(formats.Pretty)
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}
@@ -1397,7 +1398,7 @@ func TestRenderBenchmarkResultGoBenchOutputShowAllocs(t *testing.T) {
 
 	params := testBenchParams()
 	params.benchMem = true
-	err := params.outputFormat.Set(benchmarkGoBenchOutput)
+	err := params.outputFormat.Set(formats.GoBench)
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}
@@ -1422,7 +1423,7 @@ func TestRenderBenchmarkErrorJSONOutput(t *testing.T) {
 	t.Parallel()
 
 	params := testBenchParams()
-	err := params.outputFormat.Set(evalJSONOutput)
+	err := params.outputFormat.Set(formats.JSON)
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}
@@ -1465,7 +1466,7 @@ func TestRenderBenchmarkErrorPrettyOutput(t *testing.T) {
 	t.Parallel()
 
 	params := testBenchParams()
-	err := params.outputFormat.Set(evalPrettyOutput)
+	err := params.outputFormat.Set(formats.Pretty)
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}
@@ -1477,7 +1478,7 @@ func TestRenderBenchmarkErrorGoBenchOutput(t *testing.T) {
 	t.Parallel()
 
 	params := testBenchParams()
-	err := params.outputFormat.Set(benchmarkGoBenchOutput)
+	err := params.outputFormat.Set(formats.GoBench)
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}
@@ -1509,7 +1510,7 @@ func testBenchParams() benchmarkCommandParams {
 	params := newBenchmarkEvalParams()
 	params.benchMem = true
 	params.metrics = true
-	_ = params.outputFormat.Set(evalJSONOutput)
+	_ = params.outputFormat.Set(formats.JSON)
 	params.count = 1
 	return params
 }

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -297,13 +297,9 @@ func dobuild(params buildParams, args []string) error {
 		return errors.New("enable bundle mode (ie. --bundle) to verify or sign bundle files or directories")
 	}
 
-	var capabilities *ast.Capabilities
-	// if capabilities are not provided as a cmd flag,
-	// then ast.CapabilitiesForThisVersion must be called
-	// within dobuild to ensure custom builtins are properly captured
-	if params.capabilities.C != nil {
-		capabilities = params.capabilities.C
-	} else {
+	capabilities := params.capabilities.C
+	if capabilities == nil {
+		// ensure custom builtins are properly captured
 		capabilities = ast.CapabilitiesForThisVersion(ast.CapabilitiesRegoVersion(params.regoVersion()))
 	}
 
@@ -370,7 +366,7 @@ func buildCommandLoaderFilter(bundleMode bool, ignore []string) func(string, os.
 				return true
 			}
 		}
-		return loaderFilter{Ignore: ignore}.Apply(abspath, info, depth)
+		return ignored(ignore).Apply(abspath, info, depth)
 	}
 }
 

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -7,16 +7,17 @@ package cmd
 import (
 	"errors"
 	"fmt"
-	"io"
 	"io/fs"
 	"maps"
 	"os"
 
 	"github.com/spf13/cobra"
 
+	"github.com/open-policy-agent/opa/cmd/formats"
 	"github.com/open-policy-agent/opa/cmd/internal/env"
 	pr "github.com/open-policy-agent/opa/internal/presentation"
 	"github.com/open-policy-agent/opa/v1/ast"
+	"github.com/open-policy-agent/opa/v1/bundle"
 	"github.com/open-policy-agent/opa/v1/loader"
 	"github.com/open-policy-agent/opa/v1/util"
 )
@@ -36,9 +37,7 @@ type checkParams struct {
 
 func newCheckParams() checkParams {
 	return checkParams{
-		format: util.NewEnumFlag(checkFormatPretty, []string{
-			checkFormatPretty, checkFormatJSON,
-		}),
+		format:       formats.Flag(formats.Pretty, formats.JSON),
 		capabilities: newcapabilitiesFlag(),
 		schema:       &schemaFlags{},
 	}
@@ -59,62 +58,21 @@ func (p *checkParams) regoVersion() ast.RegoVersion {
 	return ast.DefaultRegoVersion
 }
 
-const (
-	checkFormatPretty = "pretty"
-	checkFormatJSON   = "json"
-)
-
 func checkModules(params checkParams, args []string) error {
-
-	modules := map[string]*ast.Module{}
-
-	var capabilities *ast.Capabilities
-	// if capabilities are not provided as a cmd flag,
-	// then ast.CapabilitiesForThisVersion must be called
-	// within checkModules to ensure custom builtins are properly captured
-	if params.capabilities.C != nil {
-		capabilities = params.capabilities.C
-	} else {
+	// ensure custom builtins are properly captured
+	capabilities := params.capabilities.C
+	if capabilities == nil {
 		capabilities = ast.CapabilitiesForThisVersion(ast.CapabilitiesRegoVersion(params.regoVersion()))
 	}
+
+	l := loader.NewFileLoader().
+		WithRegoVersion(params.regoVersion()).
+		WithProcessAnnotation(true).
+		WithCapabilities(capabilities)
 
 	ss, err := loader.Schemas(params.schema.path)
 	if err != nil {
 		return err
-	}
-
-	if params.bundleMode {
-		for _, path := range args {
-			b, err := loader.NewFileLoader().
-				WithRegoVersion(params.regoVersion()).
-				WithSkipBundleVerification(true).
-				WithProcessAnnotation(true).
-				WithCapabilities(capabilities).
-				WithFilter(filterFromPaths(params.ignore)).
-				AsBundle(path)
-			if err != nil {
-				return err
-			}
-			maps.Copy(modules, b.ParsedModules(path))
-		}
-	} else {
-		f := loaderFilter{
-			Ignore:   params.ignore,
-			OnlyRego: true,
-		}
-
-		result, err := loader.NewFileLoader().
-			WithRegoVersion(params.regoVersion()).
-			WithProcessAnnotation(true).
-			WithCapabilities(capabilities).
-			Filtered(args, f.Apply)
-		if err != nil {
-			return err
-		}
-
-		for _, m := range result.Modules {
-			modules[m.Name] = m.Parsed
-		}
 	}
 
 	compiler := ast.NewCompiler().
@@ -125,34 +83,88 @@ func checkModules(params checkParams, args []string) error {
 		WithStrict(params.strict).
 		WithUseTypeCheckAnnotations(true)
 
-	compiler.Compile(modules)
-	if compiler.Failed() {
+	var modules map[string]*ast.Module
+
+	if params.bundleMode {
+		bundles := make([]*bundle.Bundle, 0, len(args))
+		for _, path := range args {
+			b, err := l.WithSkipBundleVerification(true).WithFilter(filterFromPaths(params.ignore)).AsBundle(path)
+			if err != nil {
+				return err
+			}
+			bundles = append(bundles, b)
+		}
+		b, err := bundle.Merge(bundles)
+		if err != nil {
+			return err
+		}
+
+		modules = maps.Clone(b.ParsedModules(""))
+		if len(b.Data) > 0 {
+			compiler = compiler.WithPathConflictsCheck(mapFinder(b.Data))
+		}
+	} else {
+		result, err := l.Filtered(args, ignoredOnlyRego(params.ignore).Apply)
+		if err != nil {
+			return err
+		}
+
+		modules = result.ParsedModules()
+	}
+
+	if compiler.Compile(modules); compiler.Failed() {
 		return compiler.Errors
 	}
+
 	return nil
+}
+
+// emulate storage.NonEmpty without having to create storage / transaction
+// returned function returns false, nil when m or path is empty
+func mapFinder(m map[string]any) func(path []string) (bool, error) {
+	if len(m) == 0 {
+		return emptyMapFinder
+	}
+	return func(path []string) (bool, error) {
+		if len(path) == 0 {
+			return false, nil
+		}
+
+		node := m
+		for _, key := range path {
+			if val, ok := node[key]; ok {
+				if subMap, ok := val.(map[string]any); ok {
+					node = subMap
+				} else {
+					return true, nil
+				}
+			} else {
+				return false, nil
+			}
+		}
+		return true, nil
+	}
+}
+
+func emptyMapFinder(path []string) (bool, error) {
+	return false, nil
 }
 
 func filterFromPaths(paths []string) loader.Filter {
 	return func(abspath string, info fs.FileInfo, depth int) bool {
-		return loaderFilter{Ignore: paths}.Apply(abspath, info, depth)
+		return ignored(paths).Apply(abspath, info, depth)
 	}
 }
 
 func outputErrors(format string, err error) {
-	var out io.Writer
+	out := os.Stdout
 	if err != nil {
 		out = os.Stderr
-	} else {
-		out = os.Stdout
 	}
 
 	switch format {
-	case checkFormatJSON:
-		result := pr.Output{
-			Errors: pr.NewOutputErrors(err),
-		}
-		err := pr.JSON(out, result)
-		if err != nil {
+	case formats.JSON:
+		if err := pr.JSON(out, pr.Output{Errors: pr.NewOutputErrors(err)}); err != nil {
 			fmt.Fprintln(os.Stderr, err.Error())
 		}
 	default:
@@ -189,7 +201,7 @@ and exit with a non-zero exit code.`,
 
 	addMaxErrorsFlag(checkCommand.Flags(), &checkParams.errLimit)
 	addIgnoreFlag(checkCommand.Flags(), &checkParams.ignore)
-	checkCommand.Flags().VarP(checkParams.format, "format", "f", "set output format")
+	addOutputFormat(checkCommand.Flags(), checkParams.format)
 	addBundleModeFlag(checkCommand.Flags(), &checkParams.bundleMode, false)
 	addCapabilitiesFlag(checkCommand.Flags(), checkParams.capabilities)
 	addSchemaFlags(checkCommand.Flags(), checkParams.schema)

--- a/cmd/check_test.go
+++ b/cmd/check_test.go
@@ -242,6 +242,34 @@ func TestCheckIgnoreBundleMode(t *testing.T) {
 	})
 }
 
+func TestCheckBundleReportsPolicyVsDataConflict(t *testing.T) {
+	t.Parallel()
+
+	files := map[string]string{
+		"policy.rego": "package p\nallow := false\n",
+		"data.json":   `{"p":{"allow":false}}`,
+	}
+
+	test.WithTempFS(files, func(root string) {
+		params := newCheckParams()
+		// Bundle mode required as the check command *should* ignore data entirely otherwise
+		params.bundleMode = true
+
+		err := checkModules(params, []string{root})
+		if err == nil {
+			t.Fatal("expected error but received none")
+		}
+
+		exp := fmt.Sprintf(
+			"1 error occurred: %s:2: rego_compile_error: conflicting rule for data path p/allow found",
+			filepath.Join(root, "policy.rego"),
+		)
+		if err.Error() != exp {
+			t.Fatalf("expected error %q, got %q", exp, err.Error())
+		}
+	})
+}
+
 func TestCheckFailsOnInvalidRego(t *testing.T) {
 	files := map[string]string{
 		"test.rego": `package test

--- a/cmd/deps_test.go
+++ b/cmd/deps_test.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/open-policy-agent/opa/cmd/formats"
 	"github.com/open-policy-agent/opa/internal/file/archive"
 	"github.com/open-policy-agent/opa/v1/util/test"
 )
@@ -54,7 +55,7 @@ a contains x if {
 
 			test.WithTempFS(files, func(rootPath string) {
 				params := newDepsCommandParams()
-				_ = params.outputFormat.Set(depsFormatPretty)
+				_ = params.outputFormat.Set(formats.Pretty)
 
 				for f := range files {
 					_ = params.dataPaths.Set(filepath.Join(rootPath, f))
@@ -231,7 +232,7 @@ p contains 3 if {
 				params := newDepsCommandParams()
 				params.v0Compatible = tc.v0Compatible
 				params.v1Compatible = tc.v1Compatible
-				_ = params.outputFormat.Set(depsFormatPretty)
+				_ = params.outputFormat.Set(formats.Pretty)
 
 				for f := range files {
 					_ = params.dataPaths.Set(filepath.Join(rootPath, f))
@@ -548,7 +549,7 @@ p contains 4 if {
 						}
 
 						params.v1Compatible = v1CompatibleFlag.used
-						_ = params.outputFormat.Set(depsFormatPretty)
+						_ = params.outputFormat.Set(formats.Pretty)
 
 						err := deps([]string{tc.query}, params, io.Discard)
 

--- a/cmd/eval.go
+++ b/cmd/eval.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/open-policy-agent/opa/cmd/formats"
 	"github.com/open-policy-agent/opa/cmd/internal/env"
 	fileurl "github.com/open-policy-agent/opa/internal/file/url"
 	pr "github.com/open-policy-agent/opa/internal/presentation"
@@ -92,15 +93,15 @@ func (p *evalCommandParams) regoVersion() ast.RegoVersion {
 func newEvalCommandParams() evalCommandParams {
 	return evalCommandParams{
 		capabilities: newcapabilitiesFlag(),
-		outputFormat: util.NewEnumFlag(evalJSONOutput, []string{
-			evalJSONOutput,
-			evalValuesOutput,
-			evalBindingsOutput,
-			evalPrettyOutput,
-			evalSourceOutput,
-			evalRawOutput,
-			evalDiscardOutput,
-		}),
+		outputFormat: formats.Flag(
+			formats.JSON,
+			formats.Values,
+			formats.Bindings,
+			formats.Pretty,
+			formats.Source,
+			formats.Raw,
+			formats.Discard,
+		),
 		explain:         newExplainFlag([]string{explainModeOff, explainModeFull, explainModeNotes, explainModeFails, explainModeDebug}),
 		target:          util.NewEnumFlag(compile.TargetRego, []string{compile.TargetRego, compile.TargetWasm}),
 		count:           1,
@@ -129,9 +130,9 @@ func validateEvalParams(p *evalCommandParams, cmdArgs []string) error {
 		return errors.New("specify --fail or --fail-defined but not both")
 	}
 	of := p.outputFormat.String()
-	if p.partial && of != evalPrettyOutput && of != evalJSONOutput && of != evalSourceOutput {
+	if p.partial && of != formats.Pretty && of != formats.JSON && of != formats.Source {
 		return errors.New("invalid output format for partial evaluation")
-	} else if !p.partial && of == evalSourceOutput {
+	} else if !p.partial && of == formats.Source {
 		return errors.New("invalid output format for evaluation")
 	}
 
@@ -169,18 +170,9 @@ func validateEvalParams(p *evalCommandParams, cmdArgs []string) error {
 }
 
 const (
-	evalJSONOutput     = "json"
-	evalValuesOutput   = "values"
-	evalBindingsOutput = "bindings"
-	evalPrettyOutput   = "pretty"
-	evalSourceOutput   = "source"
-	evalRawOutput      = "raw"
-	evalDiscardOutput  = "discard"
-
 	// number of profile results to return by default
 	defaultProfileLimit = 10
-
-	defaultPrettyLimit = 80
+	defaultPrettyLimit  = 80
 )
 
 type regoError struct{}
@@ -421,22 +413,22 @@ func eval(args []string, params evalCommandParams, w io.Writer) (bool, error) {
 	}
 
 	switch ectx.params.outputFormat.String() {
-	case evalBindingsOutput:
+	case formats.Bindings:
 		err = pr.Bindings(w, result)
-	case evalValuesOutput:
+	case formats.Values:
 		err = pr.Values(w, result)
-	case evalPrettyOutput:
+	case formats.Pretty:
 		err = pr.PrettyWithOptions(w, result, pr.PrettyOptions{
 			TraceOpts: topdown.PrettyTraceOptions{
 				Locations:     true,
 				ExprVariables: ectx.params.traceVarValues,
 			},
 		})
-	case evalSourceOutput:
+	case formats.Source:
 		err = pr.Source(w, result)
-	case evalRawOutput:
+	case formats.Raw:
 		err = pr.Raw(w, result)
-	case evalDiscardOutput:
+	case formats.Discard:
 		err = pr.Discard(w, result)
 	default:
 		err = pr.JSON(w, result)
@@ -583,14 +575,10 @@ func setupEval(args []string, params evalCommandParams) (*evalContext, error) {
 	}
 
 	if len(params.dataPaths.v) > 0 {
-		f := loaderFilter{
-			Ignore: params.ignore,
-		}
-
 		if params.optimizationLevel <= 0 {
-			regoArgs = append(regoArgs, rego.Load(params.dataPaths.v, f.Apply))
+			regoArgs = append(regoArgs, rego.Load(params.dataPaths.v, ignored(params.ignore).Apply))
 		} else {
-			b, err := generateOptimizedBundle(params, false, f.Apply, params.dataPaths.v)
+			b, err := generateOptimizedBundle(params, false, ignored(params.ignore).Apply, params.dataPaths.v)
 			if err != nil {
 				return nil, err
 			}
@@ -614,10 +602,7 @@ func setupEval(args []string, params evalCommandParams) (*evalContext, error) {
 		}
 	}
 
-	// skip bundle verification
-	regoArgs = append(regoArgs, rego.SkipBundleVerification(true))
-
-	regoArgs = append(regoArgs, rego.Target(params.target.String()))
+	regoArgs = append(regoArgs, rego.SkipBundleVerification(true), rego.Target(params.target.String()))
 
 	inputBytes, err := readInputBytes(params)
 	if err != nil {
@@ -625,8 +610,7 @@ func setupEval(args []string, params evalCommandParams) (*evalContext, error) {
 	}
 	if inputBytes != nil {
 		var input any
-		err := util.Unmarshal(inputBytes, &input)
-		if err != nil {
+		if err := util.Unmarshal(inputBytes, &input); err != nil {
 			return nil, fmt.Errorf("unable to parse input: %s", err.Error())
 		}
 		inputValue, err := ast.InterfaceToValue(input)
@@ -738,7 +722,7 @@ func (r *resettableProfiler) Config() topdown.TraceConfig { return r.p.Config() 
 
 func getProfileSortOrder(sortOrder []string) []string {
 	// convert the sort order slice to a map for faster lookups
-	sortOrderMap := make(map[string]bool)
+	sortOrderMap := make(map[string]bool, len(sortOrder))
 	for _, cr := range sortOrder {
 		sortOrderMap[cr] = true
 	}
@@ -764,8 +748,6 @@ func readInputBytes(params evalCommandParams) ([]byte, error) {
 	}
 	return nil, nil
 }
-
-const stringType = "string"
 
 type repeatedStringFlag struct {
 	v     []string
@@ -868,12 +850,8 @@ func (vis *astLocationResetVisitor) visit(x any) bool {
 }
 
 func generateOptimizedBundle(params evalCommandParams, asBundle bool, filter loader.Filter, paths []string) (*bundle.Bundle, error) {
-	buf := bytes.NewBuffer(nil)
-
-	var capabilities *ast.Capabilities
-	if params.capabilities.C != nil {
-		capabilities = params.capabilities.C
-	} else {
+	capabilities := params.capabilities.C
+	if capabilities == nil {
 		capabilities = ast.CapabilitiesForThisVersion(ast.CapabilitiesRegoVersion(params.regoVersion()))
 	}
 
@@ -882,15 +860,14 @@ func generateOptimizedBundle(params evalCommandParams, asBundle bool, filter loa
 		WithTarget(params.target.String()).
 		WithAsBundle(asBundle).
 		WithOptimizationLevel(params.optimizationLevel).
-		WithOutput(buf).
+		WithOutput(bytes.NewBuffer(nil)).
 		WithEntrypoints(params.entrypoints.v...).
 		WithRegoAnnotationEntrypoints(true).
 		WithPaths(paths...).
 		WithFilter(filter).
 		WithRegoVersion(params.regoVersion())
 
-	err := compiler.Build(context.Background())
-	if err != nil {
+	if err := compiler.Build(context.Background()); err != nil {
 		return nil, err
 	}
 

--- a/cmd/eval_test.go
+++ b/cmd/eval_test.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/open-policy-agent/opa/cmd/formats"
 	"github.com/open-policy-agent/opa/internal/file/archive"
 	"github.com/open-policy-agent/opa/internal/presentation"
 	"github.com/open-policy-agent/opa/v1/ast"
@@ -1172,7 +1173,7 @@ func assertResultSet(t *testing.T, rs rego.ResultSet, expected string) {
 
 func TestEvalErrorJSONOutput(t *testing.T) {
 	params := newEvalCommandParams()
-	err := params.outputFormat.Set(evalJSONOutput)
+	err := params.outputFormat.Set(formats.JSON)
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}
@@ -1199,7 +1200,7 @@ func TestEvalErrorJSONOutput(t *testing.T) {
 
 func TestEvalDebugTraceJSONOutput(t *testing.T) {
 	params := newEvalCommandParams()
-	err := params.outputFormat.Set(evalJSONOutput)
+	err := params.outputFormat.Set(formats.JSON)
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}
@@ -1708,7 +1709,7 @@ true
 				if _, err := os.Stat(inputFile); err == nil {
 					params.inputPath = inputFile
 				}
-				_ = params.outputFormat.Set(evalPrettyOutput)
+				_ = params.outputFormat.Set(formats.Pretty)
 				_ = params.explain.Set(explainModeFull)
 				params.traceVarValues = tc.includeVars
 				params.disableIndexing = true
@@ -1843,13 +1844,13 @@ func TestEvalPartialFormattedOutput(t *testing.T) {
 		format, expected string
 	}{
 		{
-			format: evalPrettyOutput,
+			format: formats.Pretty,
 			expected: `+---------+------------------------------------------+
 | Query 1 | time.clock(input.y, time.clock(input.x)) |
 +---------+------------------------------------------+
 `},
 		{
-			format: evalSourceOutput,
+			format: formats.Source,
 			expected: `# Query 1
 time.clock(input.y, time.clock(input.x))
 
@@ -1894,7 +1895,7 @@ p[v] {
 }
 `,
 			expected: map[string]string{
-				evalSourceOutput: `# Query 1
+				formats.Source: `# Query 1
 data.partial.test.p
 
 # Module 1
@@ -1904,7 +1905,7 @@ import rego.v1
 
 p contains __local0__1 if __local0__1 = input.v
 `,
-				evalPrettyOutput: `+-----------+-------------------------------------------------+
+				formats.Pretty: `+-----------+-------------------------------------------------+
 | Query 1   | data.partial.test.p                             |
 +-----------+-------------------------------------------------+
 | Support 1 | package partial.test                            |
@@ -1928,7 +1929,7 @@ p[v] {
 }
 `,
 			expected: map[string]string{
-				evalSourceOutput: `# Query 1
+				formats.Source: `# Query 1
 data.partial.test.p
 
 # Module 1
@@ -1938,7 +1939,7 @@ p[__local0__1] {
 	__local0__1 = input.v
 }
 `,
-				evalPrettyOutput: `+-----------+-------------------------+
+				formats.Pretty: `+-----------+-------------------------+
 | Query 1   | data.partial.test.p     |
 +-----------+-------------------------+
 | Support 1 | package partial.test    |
@@ -1964,7 +1965,7 @@ p contains v if {
 }
 `,
 			expected: map[string]string{
-				evalSourceOutput: `# Query 1
+				formats.Source: `# Query 1
 data.partial.test.p
 
 # Module 1
@@ -1974,7 +1975,7 @@ import rego.v1
 
 p contains __local0__1 if __local0__1 = input.v
 `,
-				evalPrettyOutput: `+-----------+-------------------------------------------------+
+				formats.Pretty: `+-----------+-------------------------------------------------+
 | Query 1   | data.partial.test.p                             |
 +-----------+-------------------------------------------------+
 | Support 1 | package partial.test                            |
@@ -1998,7 +1999,7 @@ p contains v if {
 }
 `,
 			expected: map[string]string{
-				evalSourceOutput: `# Query 1
+				formats.Source: `# Query 1
 data.partial.test.p
 
 # Module 1
@@ -2006,7 +2007,7 @@ package partial.test
 
 p contains __local0__1 if __local0__1 = input.v
 `,
-				evalPrettyOutput: `+-----------+-------------------------------------------------+
+				formats.Pretty: `+-----------+-------------------------------------------------+
 | Query 1   | data.partial.test.p                             |
 +-----------+-------------------------------------------------+
 | Support 1 | package partial.test                            |
@@ -2030,7 +2031,7 @@ p contains v if {
 }
 `,
 			expected: map[string]string{
-				evalSourceOutput: `# Query 1
+				formats.Source: `# Query 1
 data.partial.test.p
 
 # Module 1
@@ -2038,7 +2039,7 @@ package partial.test
 
 p contains __local0__1 if __local0__1 = input.v
 `,
-				evalPrettyOutput: `+-----------+-------------------------------------------------+
+				formats.Pretty: `+-----------+-------------------------------------------------+
 | Query 1   | data.partial.test.p                             |
 +-----------+-------------------------------------------------+
 | Support 1 | package partial.test                            |
@@ -2099,7 +2100,7 @@ func TestEvalDiscardOutput(t *testing.T) {
 			query: "1*2+3",
 			params: func() evalCommandParams {
 				params := newEvalCommandParams()
-				err := params.outputFormat.Set(evalDiscardOutput)
+				err := params.outputFormat.Set(formats.Discard)
 				if err != nil {
 					t.Fatalf("unexpected error: %s", err)
 				}
@@ -2113,7 +2114,7 @@ func TestEvalDiscardOutput(t *testing.T) {
 			query: "1/0",
 			params: func() evalCommandParams {
 				params := newEvalCommandParams()
-				err := params.outputFormat.Set(evalDiscardOutput)
+				err := params.outputFormat.Set(formats.Discard)
 				if err != nil {
 					t.Fatalf("unexpected error: %s", err)
 				}
@@ -2125,7 +2126,7 @@ func TestEvalDiscardOutput(t *testing.T) {
 			query: "1/0",
 			params: func() evalCommandParams {
 				params := newEvalCommandParams()
-				err := params.outputFormat.Set(evalDiscardOutput)
+				err := params.outputFormat.Set(formats.Discard)
 				if err != nil {
 					t.Fatalf("unexpected error: %s", err)
 				}
@@ -2164,7 +2165,7 @@ func TestEvalDiscardOutput(t *testing.T) {
 
 func TestEvalDiscardProfilerOutput(t *testing.T) {
 	params := newEvalCommandParams()
-	err := params.outputFormat.Set(evalDiscardOutput)
+	err := params.outputFormat.Set(formats.Discard)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -2769,7 +2770,7 @@ a contains x if {
 			t.Run(fmt.Sprintf("%s: %s", s.name, tc.note), func(t *testing.T) {
 				test.WithTempFS(tc.modules, func(path string) {
 					params := newEvalCommandParams()
-					_ = params.outputFormat.Set(evalPrettyOutput)
+					_ = params.outputFormat.Set(formats.Pretty)
 					s.commandParams(&params, path)
 
 					var buf bytes.Buffer
@@ -3198,7 +3199,7 @@ func TestEvalPolicyWithRegoV1Capability(t *testing.T) {
 				test.WithTempFS(tc.modules, func(path string) {
 					params := newEvalCommandParams()
 					s.commandParams(&params, path)
-					_ = params.outputFormat.Set(evalPrettyOutput)
+					_ = params.outputFormat.Set(formats.Pretty)
 					params.v0Compatible = tc.v0Compatible
 					params.capabilities.C = tc.capabilities
 
@@ -3586,7 +3587,7 @@ func TestWithQueryImports(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.note, func(t *testing.T) {
 			params := newEvalCommandParams()
-			_ = params.outputFormat.Set(evalPrettyOutput)
+			_ = params.outputFormat.Set(formats.Pretty)
 			params.imports = newrepeatedStringFlag(tc.imports)
 			params.v0Compatible = tc.v0Compatible
 			params.v1Compatible = tc.v1Compatible

--- a/cmd/filters.go
+++ b/cmd/filters.go
@@ -29,3 +29,11 @@ func (f loaderFilter) Apply(abspath string, info os.FileInfo, depth int) bool {
 	}
 	return false
 }
+
+func ignored(ignore []string) loaderFilter {
+	return loaderFilter{Ignore: ignore}
+}
+
+func ignoredOnlyRego(ignore []string) loaderFilter {
+	return loaderFilter{Ignore: ignore, OnlyRego: true}
+}

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -13,6 +13,16 @@ import (
 	"github.com/open-policy-agent/opa/v1/util"
 )
 
+const (
+	explainModeOff   = "off"
+	explainModeFull  = "full"
+	explainModeNotes = "notes"
+	explainModeFails = "fails"
+	explainModeDebug = "debug"
+
+	stringType = "string"
+)
+
 func addConfigFileFlag(fs *pflag.FlagSet, file *string) {
 	fs.StringVarP(file, "config-file", "c", "", "set path of configuration file")
 }
@@ -177,14 +187,6 @@ func addReadAstValuesFromStoreFlag(fs *pflag.FlagSet, readAstValuesFromStore *bo
 func addE2EFlag(fs *pflag.FlagSet, e2e *bool, value bool) {
 	fs.BoolVar(e2e, "e2e", value, "run benchmarks against a running OPA server")
 }
-
-const (
-	explainModeOff   = "off"
-	explainModeFull  = "full"
-	explainModeNotes = "notes"
-	explainModeFails = "fails"
-	explainModeDebug = "debug"
-)
 
 func newExplainFlag(modes []string) *util.EnumFlag {
 	return util.NewEnumFlag(modes[0], modes)

--- a/cmd/formats/formats.go
+++ b/cmd/formats/formats.go
@@ -1,0 +1,28 @@
+// Copyright 2025 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package formats
+
+import (
+	"github.com/open-policy-agent/opa/v1/util"
+)
+
+type option = string
+
+const (
+	Pretty   option = "pretty"
+	JSON     option = "json"
+	GoBench  option = "gobench"
+	Values   option = "values"
+	Bindings option = "bindings"
+	Source   option = "source"
+	Raw      option = "raw"
+	Discard  option = "discard"
+)
+
+// Returns an enum flag for the given formats, where the first provided format
+// will be used as the default format.
+func Flag(formats ...option) *util.EnumFlag {
+	return util.NewEnumFlag(formats[0], formats)
+}

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/open-policy-agent/opa/cmd/formats"
 	"github.com/open-policy-agent/opa/cmd/internal/env"
 	ib "github.com/open-policy-agent/opa/internal/bundle/inspect"
 	pr "github.com/open-policy-agent/opa/internal/presentation"
@@ -26,8 +27,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const maxTableFieldLen = 50
-const pageWidth = 80
+const (
+	maxTableFieldLen = 50
+	pageWidth        = 80
+)
 
 type inspectCommandParams struct {
 	outputFormat    *util.EnumFlag
@@ -48,10 +51,7 @@ func (p *inspectCommandParams) regoVersion() ast.RegoVersion {
 
 func newInspectCommandParams() inspectCommandParams {
 	return inspectCommandParams{
-		outputFormat: util.NewEnumFlag(evalPrettyOutput, []string{
-			evalJSONOutput,
-			evalPrettyOutput,
-		}),
+		outputFormat:    formats.Flag(formats.Pretty, formats.JSON),
 		listAnnotations: false,
 	}
 }
@@ -115,7 +115,7 @@ func doInspect(params inspectCommandParams, path string, out io.Writer) error {
 	}
 
 	switch params.outputFormat.String() {
-	case evalJSONOutput:
+	case formats.JSON:
 		return pr.JSON(out, info)
 
 	default:
@@ -155,7 +155,7 @@ func validateInspectParams(p *inspectCommandParams, args []string) error {
 	}
 
 	of := p.outputFormat.String()
-	if of == evalJSONOutput || of == evalPrettyOutput {
+	if of == formats.JSON || of == formats.Pretty {
 		return nil
 	}
 	return errors.New("invalid output format for inspect command")
@@ -365,13 +365,7 @@ func printTitle(out io.Writer, ref *ast.AnnotationsRef) {
 		title = dropDataPrefix(ref.Path).String()
 	}
 
-	fmt.Fprintf(out, "%s\n", title)
-
-	var underline []byte
-	for i := 0; i < len(title) && i < pageWidth; i++ {
-		underline = append(underline, '=')
-	}
-	fmt.Fprintln(out, string(underline))
+	fmt.Fprintf(out, "%s\n%s\n", title, strings.Repeat("=", min(len(title), pageWidth)))
 }
 
 func generateTableWithKeys(writer io.Writer, keys ...string) *tablewriter.Table {

--- a/cmd/inspect_test.go
+++ b/cmd/inspect_test.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/open-policy-agent/opa/cmd/formats"
 	"github.com/open-policy-agent/opa/internal/file/archive"
 	"github.com/open-policy-agent/opa/v1/util"
 
@@ -44,7 +45,7 @@ func TestDoInspect(t *testing.T) {
 
 		var out bytes.Buffer
 		params := newInspectCommandParams()
-		err = params.outputFormat.Set(evalJSONOutput)
+		err = params.outputFormat.Set(formats.JSON)
 		if err != nil {
 			t.Fatalf("Unexpected error: %s", err)
 		}
@@ -664,7 +665,7 @@ p contains v if {
 				var out bytes.Buffer
 				params := newInspectCommandParams()
 				params.v0Compatible = tc.v0Compatible
-				err = params.outputFormat.Set(evalJSONOutput)
+				err = params.outputFormat.Set(formats.JSON)
 				if err != nil {
 					t.Fatalf("Unexpected error: %s", err)
 				}
@@ -982,7 +983,7 @@ p contains 2 if {
 						var out bytes.Buffer
 						params := newInspectCommandParams()
 						params.v1Compatible = v1CompatibleFlag.used
-						err := params.outputFormat.Set(evalPrettyOutput)
+						err := params.outputFormat.Set(formats.Pretty)
 						if err != nil {
 							t.Fatalf("Unexpected error: %s", err)
 						}
@@ -1390,7 +1391,7 @@ test_p if {
 
 				var out bytes.Buffer
 				params := newInspectCommandParams()
-				err = params.outputFormat.Set(evalJSONOutput)
+				err = params.outputFormat.Set(formats.JSON)
 				if err != nil {
 					t.Fatalf("Unexpected error: %s", err)
 				}
@@ -1438,7 +1439,7 @@ p if {
 
 		var out bytes.Buffer
 		params := newInspectCommandParams()
-		err = params.outputFormat.Set(evalJSONOutput)
+		err = params.outputFormat.Set(formats.JSON)
 		if err != nil {
 			t.Fatalf("Unexpected error: %s", err)
 		}

--- a/cmd/internal/exec/params.go
+++ b/cmd/internal/exec/params.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"time"
 
+	"github.com/open-policy-agent/opa/cmd/formats"
 	"github.com/open-policy-agent/opa/v1/logging"
 	"github.com/open-policy-agent/opa/v1/util"
 )
@@ -34,7 +35,7 @@ type Params struct {
 func NewParams(w io.Writer) *Params {
 	return &Params{
 		Output:       w,
-		OutputFormat: util.NewEnumFlag("json", []string{"json"}),
+		OutputFormat: formats.Flag(formats.JSON),
 		LogLevel:     util.NewEnumFlag("error", []string{"debug", "info", "error"}),
 		LogFormat:    util.NewEnumFlag("json", []string{"text", "json", "json-pretty"}),
 	}

--- a/cmd/parse.go
+++ b/cmd/parse.go
@@ -14,17 +14,13 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/open-policy-agent/opa/cmd/formats"
 	"github.com/open-policy-agent/opa/cmd/internal/env"
 	pr "github.com/open-policy-agent/opa/internal/presentation"
 	"github.com/open-policy-agent/opa/v1/ast"
 	astJSON "github.com/open-policy-agent/opa/v1/ast/json"
 	"github.com/open-policy-agent/opa/v1/loader"
 	"github.com/open-policy-agent/opa/v1/util"
-)
-
-const (
-	parseFormatPretty = "pretty"
-	parseFormatJSON   = "json"
 )
 
 type parseParams struct {
@@ -46,7 +42,7 @@ func (p *parseParams) regoVersion() ast.RegoVersion {
 }
 
 var configuredParseParams = parseParams{
-	format:      util.NewEnumFlag(parseFormatPretty, []string{parseFormatPretty, parseFormatJSON}),
+	format:      formats.Flag(formats.Pretty, formats.JSON),
 	jsonInclude: "",
 }
 
@@ -124,7 +120,7 @@ func parse(args []string, params *parseParams, stdout io.Writer, stderr io.Write
 	}
 
 	switch params.format.String() {
-	case parseFormatJSON:
+	case formats.JSON:
 		bs, err := json.MarshalIndent(result.Parsed, "", "  ")
 		if err != nil {
 			_ = pr.JSON(stderr, pr.Output{Errors: pr.NewOutputErrors(err)})
@@ -140,7 +136,7 @@ func parse(args []string, params *parseParams, stdout io.Writer, stderr io.Write
 }
 
 func init() {
-	parseCommand.Flags().VarP(configuredParseParams.format, "format", "f", "set output format")
+	addOutputFormat(parseCommand.Flags(), configuredParseParams.format)
 	parseCommand.Flags().StringVarP(&configuredParseParams.jsonInclude, "json-include", "", "", "include or exclude optional elements. By default comments are included. Current options: locations, comments. E.g. --json-include locations,-comments will include locations and exclude comments.")
 	addV1CompatibleFlag(parseCommand.Flags(), &configuredParseParams.v1Compatible, false)
 	addV0CompatibleFlag(parseCommand.Flags(), &configuredParseParams.v0Compatible, false)

--- a/cmd/parse_test.go
+++ b/cmd/parse_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/open-policy-agent/opa/v1/util"
+	"github.com/open-policy-agent/opa/cmd/formats"
 	"github.com/open-policy-agent/opa/v1/util/test"
 )
 
@@ -69,7 +69,7 @@ func TestParseJSONOutput(t *testing.T) {
 		`,
 	}
 	errc, stdout, stderr, _ := testParse(t, files, &parseParams{
-		format: util.NewEnumFlag(parseFormatJSON, []string{parseFormatPretty, parseFormatJSON}),
+		format: formats.Flag(formats.JSON, formats.Pretty),
 	})
 	if errc != 0 {
 		t.Fatalf("Expected exit code 0, got %v", errc)
@@ -134,7 +134,7 @@ p = 1
 `,
 	}
 	errc, stdout, stderr, tempDirPath := testParse(t, files, &parseParams{
-		format:      util.NewEnumFlag(parseFormatJSON, []string{parseFormatPretty, parseFormatJSON}),
+		format:      formats.Flag(formats.JSON, formats.Pretty),
 		jsonInclude: "locations",
 	})
 	if errc != 0 {
@@ -267,7 +267,7 @@ func TestParseRefsJSONOutput(t *testing.T) {
 		`,
 	}
 	errc, stdout, stderr, _ := testParse(t, files, &parseParams{
-		format: util.NewEnumFlag(parseFormatJSON, []string{parseFormatPretty, parseFormatJSON}),
+		format: formats.Flag(formats.JSON, formats.Pretty),
 	})
 	if errc != 0 {
 		t.Fatalf("Expected exit code 0, got %v", errc)
@@ -340,7 +340,7 @@ a.b.c := true
 `,
 	}
 	errc, stdout, stderr, tempDirPath := testParse(t, files, &parseParams{
-		format:      util.NewEnumFlag(parseFormatJSON, []string{parseFormatPretty, parseFormatJSON}),
+		format:      formats.Flag(formats.JSON, formats.Pretty),
 		jsonInclude: "locations",
 	})
 	if errc != 0 {
@@ -498,7 +498,7 @@ allow = true if {
 `,
 	}
 	errc, stdout, stderr, tempDirPath := testParse(t, files, &parseParams{
-		format:      util.NewEnumFlag(parseFormatJSON, []string{parseFormatPretty, parseFormatJSON}),
+		format:      formats.Flag(formats.JSON, formats.Pretty),
 		jsonInclude: "locations",
 	})
 	if errc != 0 {
@@ -955,7 +955,7 @@ func TestParseJSONOutputComments(t *testing.T) {
 		`,
 	}
 	errc, stdout, stderr, _ := testParse(t, files, &parseParams{
-		format:      util.NewEnumFlag(parseFormatJSON, []string{parseFormatPretty, parseFormatJSON}),
+		format:      formats.Flag(formats.JSON, formats.Pretty),
 		jsonInclude: "comments",
 	})
 	if errc != 0 {
@@ -1005,7 +1005,7 @@ a contains x if {
 			}
 
 			_, _, stderr, _ := testParse(t, files, &parseParams{
-				format: util.NewEnumFlag(parseFormatPretty, []string{parseFormatPretty, parseFormatJSON}),
+				format: formats.Flag(formats.Pretty, formats.JSON),
 			})
 
 			if len(tc.expErrs) > 0 {
@@ -1158,7 +1158,7 @@ p contains v if {
 			}
 
 			_, _, stderr, _ := testParse(t, files, &parseParams{
-				format:       util.NewEnumFlag(parseFormatPretty, []string{parseFormatPretty, parseFormatJSON}),
+				format:       formats.Flag(formats.Pretty, formats.JSON),
 				v0Compatible: tc.v0Compatible,
 				v1Compatible: tc.v1Compatible,
 			})

--- a/cmd/refactor.go
+++ b/cmd/refactor.go
@@ -115,25 +115,15 @@ func doMove(params moveCommandParams, args []string, out io.Writer) error {
 		return err
 	}
 
-	modules := map[string]*ast.Module{}
-
-	f := loaderFilter{
-		Ignore: params.ignore,
-	}
-
 	result, err := loader.NewFileLoader().
 		WithRegoVersion(params.regoVersion()).
-		Filtered(args, f.Apply)
+		Filtered(args, ignored(params.ignore).Apply)
 	if err != nil {
 		return err
 	}
 
-	for _, m := range result.Modules {
-		modules[m.Name] = m.Parsed
-	}
-
 	mq := refactor.MoveQuery{
-		Modules:       modules,
+		Modules:       result.ParsedModules(),
 		SrcDstMapping: srcDstMap,
 	}.WithValidation(true)
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -342,10 +342,7 @@ func initRuntime(ctx context.Context, params runCmdParams, args []string, addrSe
 		TimestampFormat: timestampFormat,
 	}
 	params.rt.Paths = args
-	params.rt.Filter = loaderFilter{
-		Ignore: params.ignore,
-	}.Apply
-
+	params.rt.Filter = ignored(params.ignore).Apply
 	params.rt.EnableVersionCheck = !params.disableTelemetry
 
 	// For backwards compatibility, check if `--skip-version-check` flag set.

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -22,6 +22,7 @@ import (
 	initload "github.com/open-policy-agent/opa/internal/runtime/init"
 	"github.com/spf13/cobra"
 
+	"github.com/open-policy-agent/opa/cmd/formats"
 	"github.com/open-policy-agent/opa/cmd/internal/env"
 	"github.com/open-policy-agent/opa/internal/runtime"
 	"github.com/open-policy-agent/opa/v1/ast"
@@ -35,11 +36,6 @@ import (
 	"github.com/open-policy-agent/opa/v1/topdown"
 	"github.com/open-policy-agent/opa/v1/topdown/lineage"
 	"github.com/open-policy-agent/opa/v1/util"
-)
-
-const (
-	testPrettyOutput = "pretty"
-	testJSONOutput   = "json"
 )
 
 type testCommandParams struct {
@@ -72,7 +68,7 @@ type testCommandParams struct {
 
 func newTestCommandParams() testCommandParams {
 	return testCommandParams{
-		outputFormat: util.NewEnumFlag(testPrettyOutput, []string{testPrettyOutput, testJSONOutput, benchmarkGoBenchOutput}),
+		outputFormat: formats.Flag(formats.Pretty, formats.JSON, formats.GoBench),
 		explain:      newExplainFlag([]string{explainModeFails, explainModeFull, explainModeNotes, explainModeDebug}),
 		target:       util.NewEnumFlag(compile.TargetRego, []string{compile.TargetRego, compile.TargetWasm}),
 		capabilities: newcapabilitiesFlag(),
@@ -99,19 +95,15 @@ func opaTest(args []string, testParams testCommandParams) int {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	if testParams.outputFormat.String() == benchmarkGoBenchOutput && !testParams.benchmark {
+	if testParams.outputFormat.String() == formats.GoBench && !testParams.benchmark {
 		errMsg := "cannot use output format %s without running benchmarks (--bench)\n"
-		_, _ = fmt.Fprintf(testParams.errOutput, errMsg, benchmarkGoBenchOutput)
+		_, _ = fmt.Fprintf(testParams.errOutput, errMsg, formats.GoBench)
 		return 0
 	}
 
 	if !isThresholdValid(testParams.threshold) {
 		_, _ = fmt.Fprintln(testParams.errOutput, "Code coverage threshold must be between 0 and 100")
 		return 1
-	}
-
-	filter := loaderFilter{
-		Ignore: testParams.ignore,
 	}
 
 	var modules map[string]*ast.Module
@@ -126,10 +118,10 @@ func opaTest(args []string, testParams testCommandParams) int {
 
 	var err error
 	if testParams.bundleMode {
-		bundles, err = tester.LoadBundlesWithParserOptions(args, filter.Apply, popts)
+		bundles, err = tester.LoadBundlesWithParserOptions(args, ignored(testParams.ignore).Apply, popts)
 		store = inmem.NewWithOpts(inmem.OptRoundTripOnWrite(false))
 	} else {
-		modules, store, err = tester.LoadWithParserOptions(args, filter.Apply, popts)
+		modules, store, err = tester.LoadWithParserOptions(args, ignored(testParams.ignore).Apply, popts)
 	}
 	if err != nil {
 		_, _ = fmt.Fprintln(testParams.errOutput, err)
@@ -294,13 +286,11 @@ func readWatcher(ctx context.Context, testParams testCommandParams, watcher *fsn
 }
 
 func processWatcherUpdate(ctx context.Context, testParams testCommandParams, paths []string, removed string, store storage.Store) {
-	filter := loaderFilter{
-		Ignore: testParams.ignore,
-	}
+	filter := ignored(testParams.ignore).Apply
 
 	var loadResult *initload.LoadPathsResult
 
-	err := pathwatcher.ProcessWatcherUpdateForRegoVersion(ctx, testParams.RegoVersion(), paths, removed, store, filter.Apply, testParams.bundleMode,
+	err := pathwatcher.ProcessWatcherUpdateForRegoVersion(ctx, testParams.RegoVersion(), paths, removed, store, filter, testParams.bundleMode,
 		func(ctx context.Context, txn storage.Transaction, loaded *initload.LoadPathsResult) error {
 			if len(loaded.Files.Documents) > 0 || removed != "" {
 				if err := store.Write(ctx, txn, storage.AddOp, storage.Path{}, loaded.Files.Documents); err != nil {
@@ -421,11 +411,11 @@ func compileAndSetupTests(ctx context.Context, testParams testCommandParams, sto
 
 	if !testParams.coverage {
 		switch testParams.outputFormat.String() {
-		case testJSONOutput:
+		case formats.JSON:
 			reporter = tester.JSONReporter{
 				Output: testParams.output,
 			}
-		case benchmarkGoBenchOutput:
+		case formats.GoBench:
 			goBench = true
 			fallthrough
 		default:
@@ -549,7 +539,6 @@ recommended as some updates might cause them to be dropped by OPA.
 	testCommand.Flags().BoolVarP(&testParams.skipExitZero, "exit-zero-on-skipped", "z", false, "skipped tests return status 0")
 	testCommand.Flags().BoolVarP(&testParams.verbose, "verbose", "v", false, "set verbose reporting mode")
 	testCommand.Flags().DurationVar(&testParams.timeout, "timeout", 0, "set test timeout (default 5s, 30s when benchmarking)")
-	testCommand.Flags().VarP(testParams.outputFormat, "format", "f", "set output format")
 	testCommand.Flags().BoolVarP(&testParams.coverage, "coverage", "c", false, "report coverage (overrides debug tracing)")
 	testCommand.Flags().Float64VarP(&testParams.threshold, "threshold", "", 0, "set coverage threshold and exit with non-zero status if coverage is less than threshold %")
 	testCommand.Flags().BoolVar(&testParams.benchmark, "bench", false, "benchmark the unit tests")
@@ -559,6 +548,7 @@ recommended as some updates might cause them to be dropped by OPA.
 	testCommand.Flags().IntVarP(&testParams.parallel, "parallel", "p", goRuntime.NumCPU(), "the number of tests that can run in parallel, defaulting to the number of CPUs (explicitly set with 0). Benchmarks are always run sequentially.")
 
 	// Shared flags
+	addOutputFormat(testCommand.Flags(), testParams.outputFormat)
 	addBundleModeFlag(testCommand.Flags(), &testParams.bundleMode, false)
 	addBenchmemFlag(testCommand.Flags(), &testParams.benchMem, true)
 	addCountFlag(testCommand.Flags(), &testParams.count, "test")


### PR DESCRIPTION
A tiny first step to have more tooling correctly report virtual and base document conflicts, as detailed in #7694.

This PR fixes the `opa check` command to report conflicts of this type when the `-b`/`--bundle` flag is provided. The bundle flag is required as without that, `opa check` should only verify policies and not load data at all.

While I was in the `cmd` directory, I got annoyed with how many of these commands store the same constants for their `--format` flag, so I decided to fix that too, even if it wasn't related to what I originally planned to do. I hope it's not too distracting.