### PR TITLE
perf: improve built-in `concat` performance

### DIFF
--- a/v1/topdown/strings.go
+++ b/v1/topdown/strings.go
@@ -152,59 +152,110 @@ func builtinFormatInt(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Ter
 }
 
 func builtinConcat(b BuiltinContext, operands []*ast.Term, iter func(*ast.Term) error) error {
-
 	join, err := builtins.StringOperand(operands[0].Value, 1)
 	if err != nil {
 		return err
 	}
 
-	var strs []string
-
-	switch b := operands[1].Value.(type) {
-	case *ast.Array:
-		var l int
-		for i := range b.Len() {
-			s, ok := b.Elem(i).Value.(ast.String)
-			if !ok {
-				return builtins.NewOperandElementErr(2, operands[1].Value, b.Elem(i).Value, "string")
-			}
-			l += len(string(s))
-		}
-
-		if b.Len() == 1 {
-			return iter(b.Elem(0))
-		}
-
-		strs = make([]string, 0, l)
-		for i := range b.Len() {
-			strs = append(strs, string(b.Elem(i).Value.(ast.String)))
-		}
-
-	case ast.Set:
-		var l int
-		terms := b.Slice()
-		for i := range terms {
-			s, ok := terms[i].Value.(ast.String)
-			if !ok {
-				return builtins.NewOperandElementErr(2, operands[1].Value, terms[i].Value, "string")
-			}
-			l += len(string(s))
-		}
-
-		if b.Len() == 1 {
-			return iter(b.Slice()[0])
-		}
-
-		strs = make([]string, 0, l)
-		for i := range b.Len() {
-			strs = append(strs, string(terms[i].Value.(ast.String)))
-		}
-
-	default:
-		return builtins.NewOperandTypeErr(2, operands[1].Value, "set", "array")
+	// fast path for empty or single string array/set, allocates no memory
+	if term, ok := zeroOrOneStringTerm(operands[1].Value); ok {
+		return iter(term)
 	}
 
-	return iter(ast.InternedStringTerm(strings.Join(strs, string(join))))
+	// NOTE(anderseknert):
+	// More or less Go's strings.Join implementation, but where we avoid
+	// creating an intermediate []string slice to pass to that function,
+	// as that's expensive (3.5x more space allocated). Instead we build
+	// the string directly using a strings.Builder to concatenate the string
+	// values from the array/set with the separator.
+	n := 0
+	switch b := operands[1].Value.(type) {
+	case *ast.Array:
+		l := b.Len()
+		for i := range l {
+			s, ok := b.Elem(i).Value.(ast.String)
+			if !ok {
+				return builtins.NewOperandElementErr(2, b, b.Elem(i).Value, "string")
+			}
+			n += len(s)
+		}
+		sep := string(join)
+		if len(sep) > 0 {
+			n += len(sep) * (l - 1)
+		}
+		var sb strings.Builder
+		sb.Grow(n)
+		sb.WriteString(string(b.Elem(0).Value.(ast.String)))
+		if sep == "" {
+			for i := 1; i < l; i++ {
+				sb.WriteString(string(b.Elem(i).Value.(ast.String)))
+			}
+		} else if len(sep) == 1 {
+			// when the separator is a single byte, sb.WriteByte is substantially faster
+			bsep := sep[0]
+			for i := 1; i < l; i++ {
+				sb.WriteByte(bsep)
+				sb.WriteString(string(b.Elem(i).Value.(ast.String)))
+			}
+		} else {
+			// for longer separators, there is no such difference between WriteString and Write
+			for i := 1; i < l; i++ {
+				sb.WriteString(sep)
+				sb.WriteString(string(b.Elem(i).Value.(ast.String)))
+			}
+		}
+		return iter(ast.InternedStringTerm(sb.String()))
+	case ast.Set:
+		for _, v := range b.Slice() {
+			s, ok := v.Value.(ast.String)
+			if !ok {
+				return builtins.NewOperandElementErr(2, b, v.Value, "string")
+			}
+			n += len(s)
+		}
+		sep := string(join)
+		l := b.Len()
+		if len(sep) > 0 {
+			n += len(sep) * (l - 1)
+		}
+		var sb strings.Builder
+		sb.Grow(n)
+		for i, v := range b.Slice() {
+			sb.WriteString(string(v.Value.(ast.String)))
+			if i < l-1 {
+				sb.WriteString(sep)
+			}
+		}
+		return iter(ast.InternedStringTerm(sb.String()))
+	}
+
+	return builtins.NewOperandTypeErr(2, operands[1].Value, "set", "array")
+}
+
+func zeroOrOneStringTerm(a ast.Value) (*ast.Term, bool) {
+	switch b := a.(type) {
+	case *ast.Array:
+		if b.Len() == 0 {
+			return ast.InternedEmptyString, true
+		}
+		if b.Len() == 1 {
+			e := b.Elem(0)
+			if _, ok := e.Value.(ast.String); ok {
+				return e, true
+			}
+		}
+	case ast.Set:
+		if b.Len() == 0 {
+			return ast.InternedEmptyString, true
+		}
+		if b.Len() == 1 {
+			e := b.Slice()[0]
+			if _, ok := e.Value.(ast.String); ok {
+				return e, true
+			}
+		}
+	}
+	return nil, false
 }
 
 func runesEqual(a, b []rune) bool {

--- a/v1/topdown/strings_bench_test.go
+++ b/v1/topdown/strings_bench_test.go
@@ -3,6 +3,7 @@ package topdown
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/open-policy-agent/opa/v1/ast"
@@ -300,4 +301,107 @@ func BenchmarkLower(b *testing.B) {
 			}
 		})
 	}
+}
+
+func BenchmarkConcat(b *testing.B) {
+	bctx := BuiltinContext{}
+	tests := []struct {
+		name     string
+		operands []*ast.Term
+		expected *ast.Term
+	}{
+		{
+			name:     "0 elements '.' sep",
+			operands: []*ast.Term{ast.InternedStringTerm("."), ast.InternedEmptyArray},
+			expected: ast.InternedEmptyString,
+		},
+		{
+			name:     "1 element '.' sep",
+			operands: []*ast.Term{ast.InternedStringTerm("."), ast.ArrayTerm(ast.InternedStringTerm("foobar"))},
+			expected: ast.InternedStringTerm("foobar"),
+		},
+		{
+			name:     "100 elements ',' sep",
+			operands: []*ast.Term{ast.InternedStringTerm(","), repeatTerm(ast.InternedStringTerm("foobar"), 100)},
+			expected: ast.StringTerm(strings.Repeat("foobar,", 99) + "foobar"),
+		},
+		{
+			name:     "100 elements ', ' sep",
+			operands: []*ast.Term{ast.InternedStringTerm(", "), repeatTerm(ast.InternedStringTerm("foobar"), 100)},
+			expected: ast.StringTerm(strings.Repeat("foobar, ", 99) + "foobar"),
+		},
+		{
+			name:     "100 elements blank sep",
+			operands: []*ast.Term{ast.InternedEmptyString, repeatTerm(ast.InternedStringTerm("foobar"), 100)},
+			expected: ast.StringTerm(strings.Repeat("foobar", 100)),
+		},
+	}
+
+	for _, test := range tests {
+		b.Run(test.name, func(b *testing.B) {
+			for range b.N {
+				if err := builtinConcat(bctx, test.operands, eqIter(test.expected)); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkConcatVsSprintfSimple(b *testing.B) {
+	bctx := BuiltinContext{}
+
+	foo := ast.InternedStringTerm("foo")
+	bar := ast.InternedStringTerm("bar")
+	expected := ast.InternedStringTerm("foobar")
+
+	b.Run("concat foobar", func(b *testing.B) {
+		operands := []*ast.Term{ast.InternedEmptyString, ast.ArrayTerm(foo, bar)}
+
+		for range b.N {
+			if err := builtinConcat(bctx, operands, eqIter(expected)); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.ResetTimer()
+
+	b.Run("sprintf foobar", func(b *testing.B) {
+		operands := []*ast.Term{ast.InternedStringTerm("%s%s"), ast.ArrayTerm(foo, bar)}
+
+		for range b.N {
+			if err := builtinSprintf(bctx, operands, eqIter(expected)); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+func repeatTerm(t *ast.Term, n int) *ast.Term {
+	terms := make([]*ast.Term, 0, n)
+	for range n {
+		terms = append(terms, t)
+	}
+	return ast.ArrayTerm(terms...)
+}
+
+func BenchmarkSplitLenVsStringsCount(b *testing.B) {
+	str := "a.b.c.d.e"
+
+	b.Run("split len", func(b *testing.B) {
+		for range b.N {
+			if len(strings.Split(str, ".")) != 5 {
+				b.Fatal("expected 5 elements")
+			}
+		}
+	})
+
+	b.Run("strings count", func(b *testing.B) {
+		for range b.N {
+			if strings.Count(str, ".")+1 != 5 {
+				b.Fatal("expected 5 elements")
+			}
+		}
+	})
 }


### PR DESCRIPTION
Looks like there was a previous attempt made to optimize this built-in function which wasn't wrapped up properly. The previous code correctly counted the total string length but then used that to allocate a string *slice* of that length, which meant that we allocated much more space than we ever used. Fixing that meant about a 3/4 reduction of B/op and cutting ns/op in half. Using Go's `strings.Join` however means we first have to allocate a `[]string` to pass to that function. So the next step was to instead extract the `strings.Join` implementation and use that directly in `concat`, but building the result from `ast.String` values without using an intermediate `[]string`. This along with some other tweaks meant another significant reduction of both ns/op and B/op, and one less allocation performed.

The example below shows the performance difference of main, vs with the overallocation issue fixed, vs with that fixed and the `[]string` allocation gone.

```
BenchmarkConcat/100_elements_blank_sep-12    738444    1564 ns/op    10408 B/op    4 allocs/op
BenchmarkConcat/100_elements_blank_sep-12   1547155     769 ns/op     2472 B/op    4 allocs/op
BenchmarkConcat/100_elements_blank_sep-12   3526724     343 ns/op      680 B/op    3 allocs/op
```

While the implementation requires more code, I think it's still pretty straightforward, and the extra lines warranted for such a common function to perform well.