### PR TITLE
docs: Add a search function for the builtins section of policy-reference

### DIFF
--- a/docs/docs/policy-reference/index.md
+++ b/docs/docs/policy-reference/index.md
@@ -330,6 +330,10 @@ The built-in functions for the language provide basic operations to manipulate
 scalar values (e.g. numbers and strings), and aggregate functions that summarize
 complex types.
 
+import BuiltinSearch from "@site/src/components/BuiltinSearch";
+
+<BuiltinSearch entryLimit={10} />
+
 ### Comparison
 
 <BuiltinTable category="comparison" />

--- a/docs/src/components/BuiltinSearch/index.js
+++ b/docs/src/components/BuiltinSearch/index.js
@@ -1,0 +1,151 @@
+import React, { useMemo, useState } from "react";
+import ReactMarkdown from "react-markdown";
+
+import builtins from "@generated/builtin-data/default/builtins.json";
+
+import styles from "./styles.module.css";
+
+export default function BuiltinSearch({ entryLimit }) {
+  const [searchTerm, setSearchTerm] = useState("");
+  const [selectedCategory, setSelectedCategory] = useState("");
+  const [isWasm, setIsWasm] = useState(false);
+  const isFiltered = isWasm || searchTerm || selectedCategory;
+  const displayLimit = entryLimit;
+  const allRows = useMemo(() => {
+    return (Object.keys(builtins._categories).filter((a) => (a != "internal"))
+      .map((category) => {
+        return builtins._categories[category]
+          .filter((builtin) => ((!builtins[builtin].deprecated ?? false) && (builtins[builtin])))
+          .map((builtin) => {
+            const fn = builtins[builtin];
+
+            const anchor = `builtin-${category}-${builtin.replaceAll(".", "")}`;
+
+            const isInfix = !!fn.infix;
+            const isRelation = !!fn.relation;
+            const args = fn.args || [];
+            const result = fn.result || {};
+
+            const signature = isInfix
+              ? `${args[0]?.name || "x"} ${fn.infix} ${args[1]?.name || "y"}`
+              : isRelation
+              ? `${builtin}(${args.map((a) => a.name).join(", ")}, ${result.name})`
+              : `${result.name || "result"} := ${builtin}(${args.map((a) => a.name).join(", ")})`;
+            return {
+              name: builtin,
+              category: category,
+              wasm: fn.wasm,
+              introduced: fn.introduced,
+              infix: isInfix,
+              signature: signature,
+              anchor: anchor,
+              versions: fn.available,
+            };
+          });
+      })).reduce((a, b) => a.concat(b), []); // builds and flattens the function list
+  });
+  const filteredRows = allRows.filter((row) => (
+    (row.name.includes(searchTerm) || row.signature.includes(searchTerm) && row.infix) // filter name
+    && (!selectedCategory || row.category == selectedCategory) // filter category
+    && (!isWasm || row.wasm) // filter wasm
+    && isFiltered // ensures that at least one criteria is being filtered on
+  ));
+  return (
+    <>
+      <div className={styles.searchBar}>
+        <select
+          title="Filter Catgeory"
+          value={selectedCategory}
+          onChange={(e) => setSelectedCategory(e.target.value)}
+        >
+          <option value="" key="0">All Categories</option>
+          {Array.from(Object.keys(builtins._categories).entries()).map((
+            mod,
+          ) => (mod[1] != "internal" && <option key={mod[0] + 1} value={mod[1]}>{mod[1]}</option>))}
+        </select>
+        <input
+          type="text"
+          title="Function Name"
+          placeholder="Search built-ins..."
+          value={searchTerm}
+          onChange={(e) => setSearchTerm(e.target.value)}
+        />
+        <span className={isWasm ? styles.wasm_1 : styles.wasm_0} onClick={(e) => setIsWasm(!isWasm)}>
+          {isWasm ? "✓" : "✗"} Wasm Only
+        </span>
+      </div>
+      {isFiltered && renderResults(filteredRows, entryLimit)}
+    </>
+  );
+}
+
+function renderResults(filteredRows, entryLimit) {
+  if (filteredRows.length == 0) return <p>No matches</p>;
+  if (!entryLimit || filteredRows.length <= entryLimit) return (renderTable(filteredRows));
+  return <p>Currently {filteredRows.length} matches, keep typing to narrow it down</p>;
+}
+
+function renderTable(filteredRows) {
+  return (
+    <table style={{ width: "100%", tableLayout: "fixed" }}>
+      <colgroup>
+        <col />
+        <col style={{ width: "100%" }} />
+        <col />
+      </colgroup>
+      <thead>
+        <tr>
+          <th>Category</th>
+          <th>Name</th>
+          <th>Meta</th>
+        </tr>
+      </thead>
+      <tbody>
+        {filteredRows.map((row) => (renderRow(row)))}
+      </tbody>
+    </table>
+  );
+}
+
+function renderRow(row) {
+  return (
+    <tr key={row.anchor}>
+      <td>
+        <span className={styles.categoryTag}>
+          {row.category}
+        </span>
+      </td>
+      <td>
+        <a href={`#${row.anchor}`}>{row.name}</a>
+        <br />
+        <code>{row.signature}</code>
+      </td>
+      <td>
+        <div className={styles.metaCell}>
+          {row.introduced && row.introduced !== "edge" && row.introduced !== "v0.17.0" && (
+            <span className={styles.versionTag}>
+              <a
+                href={`https://github.com/open-policy-agent/opa/releases/${row.introduced}`}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <span>{row.introduced}</span>
+              </a>
+            </span>
+          )}
+          {row.introduced === "edge" && <span>edge</span>} {row.wasm
+            ? (
+              <span className={styles.wasmTag}>
+                Wasm
+              </span>
+            )
+            : (
+              <span className={styles.sdkTag}>
+                SDK-dependent
+              </span>
+            )}
+        </div>
+      </td>
+    </tr>
+  );
+}

--- a/docs/src/components/BuiltinSearch/styles.module.css
+++ b/docs/src/components/BuiltinSearch/styles.module.css
@@ -1,0 +1,111 @@
+.versionTag a:link {
+  color: inherit;
+}
+
+.versionTag {
+  background-color: slategrey;
+  color: white;
+  font-weight: bold;
+  font-size: 0.8rem;
+  padding: 0.1rem 0.2rem;
+  border-radius: 0.2rem;
+  margin-bottom: 0.5rem;
+}
+
+.versionTag a:visited {
+  color: inherit;
+}
+
+.wasmTag {
+  background-color: seagreen;
+  color: white;
+  font-weight: bold;
+  font-size: 0.8rem;
+  padding: 0.1rem 0.2rem;
+  border-radius: 0.2rem;
+}
+
+.sdkTag {
+  background-color: darkgoldenrod;
+  color: white;
+  font-weight: bold;
+  font-size: 0.8rem;
+  padding: 0.1rem 0.2rem;
+  border-radius: 0.2rem;
+  white-space: nowrap;
+}
+
+.categoryTag {
+  font-weight: bold;
+  font-size: 0.8rem;
+  padding: 0.1rem 0.2rem;
+  border-radius: 0.2rem;
+  white-space: nowrap;
+}
+
+.categoryTag a:link {
+  color: inherit;
+}
+.categoryTag a:visited {
+  color: inherit;
+}
+.searchBar {
+  display: flex;
+  font-weight: bold;
+  font-size: 0.8rem;
+  padding: 0.1rem 0.2rem;
+  border-radius: 0.2rem;
+  margin-bottom: 0.4rem;
+  white-space: nowrap;
+}
+.searchBar input {
+  display: flex;
+  background-color: var(--ifm-background-color);
+  color: inherit;
+  font-weight: bold;
+  font-size: 0.8rem;
+  padding: 0.1rem 0.2rem;
+  border: none;
+  border-bottom: 0.1rem solid var(--ifm-table-border-color);
+}
+.searchBar select {
+  display: flex;
+  background-color: var(--ifm-background-color);
+  color: inherit;
+  font-weight: bold;
+  font-size: 0.8rem;
+  padding: 0.1rem 0.2rem;
+  border: none;
+  border-bottom: 0.1rem solid var(--ifm-table-border-color);
+}
+
+.wasm_0 {
+  cursor: pointer;
+  user-select: none;
+  background-color: slategrey;
+  color: white;
+  font-weight: bold;
+  font-size: 0.8rem;
+  padding: 0.1rem 0.2rem;
+  margin-left: 0.4rem;
+  border-radius: 0.2rem;
+}
+.wasm_1 {
+  cursor: pointer;
+  user-select: none;
+  background-color: seagreen;
+  color: white;
+  font-weight: bold;
+  font-size: 0.8rem;
+  padding: 0.1rem 0.2rem;
+  margin-left: 0.4rem;
+  border-radius: 0.2rem;
+}
+
+.metaCell {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+}


### PR DESCRIPTION
<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

*Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/contributing/)
  for high-level contributing guidelines and development setup.
  (See the [Developer Certificate of Origin](https://www.openpolicyagent.org/docs/contrib-code/#developer-certificate-of-origin)
  section for specifics on signing off a commit.)

-->

### Why the changes in this PR are needed?

The builtins section of the policy reference is cluttered and tedious to parse, this will make it easier to find the builtin you want

### What are the changes in this PR?

Adds a BuiltinSearch component that is used to search and filter the builtin functions on name, wasm availability, and category.

### Notes to assist PR review:
The component can be found directly below [the built-ins section of the policy reference page](https://deploy-preview-7704--openpolicyagent.netlify.app/docs/policy-reference#built-in-functions) in the docs

An example of the component in use:
Empty filter
![bild](https://github.com/user-attachments/assets/8b9a6546-557e-468d-951b-357b3f008d80)

Too many matches
![bild](https://github.com/user-attachments/assets/546856bc-1530-4754-b33a-0944c611fb5d)

Narrowed down
![bild](https://github.com/user-attachments/assets/48f1872a-a236-4515-8bdf-24704cc94ea7)



### Further comments:

<!--
Here you can include links to additional resources related to the changes, discuss your solution, other approaches you considered etc.
-->


Related to https://github.com/open-policy-agent/opa/issues/7684