### PR TITLE
docs: Add EvergreenCodeBlock for code with version

### DIFF
--- a/docs/docs/deployments.md
+++ b/docs/docs/deployments.md
@@ -174,9 +174,8 @@ Next, create a Deployment to run OPA. The ConfigMap containing the policy is
 volume mounted into the container. This allows OPA to load the policy from
 the file system.
 
-**deployment-opa.yaml**:
-
-```yaml
+<EvergreenCodeBlock>
+```yaml title="deployment-opa.yaml"
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -196,7 +195,7 @@ spec:
     spec:
       containers:
       - name: opa
-        image: openpolicyagent/opa:{{< current_docker_version >}}
+        image: openpolicyagent/opa:{{ current_version_docker }}
         ports:
         - name: http
           containerPort: 8181
@@ -214,6 +213,7 @@ spec:
         configMap:
           name: example-policy
 ```
+</EvergreenCodeBlock>
 
 ```bash
 kubectl create -f deployment-opa.yaml
@@ -276,10 +276,11 @@ OPA exposes a `/health` API endpoint that you can configure Kubernetes
 [Readiness and Liveness Probes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/)
 to call. For example:
 
+<EvergreenCodeBlock>
 ```yaml
 containers:
 - name: opa
-  image: openpolicyagent/opa:{{< current_docker_version >}}
+  image: openpolicyagent/opa:{{ current_version_docker }}
   ports:
   - name: http
     containerPort: 8181
@@ -307,6 +308,7 @@ containers:
     initialDelaySeconds: 5
     periodSeconds: 5
 ```
+</EvergreenCodeBlock>
 
 See the [Health API](./rest-api#health-api) documentation for more detail on the `/health` API endpoint.
 

--- a/docs/docs/envoy/performance.md
+++ b/docs/docs/envoy/performance.md
@@ -110,9 +110,10 @@ layered_runtime:
 
 Now let's deploy OPA as an External Authorization server. Below is a sample configuration for the OPA-Envoy container:
 
+<EvergreenCodeBlock>
 ```yaml
 containers:
-- image: openpolicyagent/opa:{{< current_opa_envoy_docker_version >}}
+- image: openpolicyagent/opa:{{ current_version_docker_envoy }}
   imagePullPolicy: IfNotPresent
   name: opa
   resources:
@@ -140,6 +141,7 @@ containers:
       path: /health?plugins
       port: 8282
 ```
+</EvergreenCodeBlock>
 
 > 💡 Consider specifying CPU and memory resource requests and limits for the OPA and other containers to prevent
 > deployments from resource starvation.

--- a/docs/docs/envoy/tutorial-gloo-edge.md
+++ b/docs/docs/envoy/tutorial-gloo-edge.md
@@ -178,9 +178,10 @@ docker run --rm --name bundle-server -d -p 8888:80 -v ${PWD}:/usr/share/nginx/ht
 
 ### 6. Setup OPA-Envoy
 
-Create a deployment as shown below and save it in **deployments.yaml**
+Create a deployment as shown below:
 
-```yaml
+<EvergreenCodeBlock>
+```yaml title="deployments.yaml"
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -199,7 +200,7 @@ spec:
     spec:
       containers:
       - name: opa
-        image: openpolicyagent/opa:{{< current_opa_envoy_docker_version >}}
+        image: openpolicyagent/opa:{{ current_version_docker_envoy }}
         volumeMounts:
         - readOnly: true
           mountPath: /policy
@@ -218,6 +219,7 @@ spec:
       volumes:
       - name: opa-policy
 ```
+</EvergreenCodeBlock>
 
 ```bash
 kubectl apply -f deployments.yaml

--- a/docs/docs/graphql-api-authorization.md
+++ b/docs/docs/graphql-api-authorization.md
@@ -158,10 +158,11 @@ You should now see a policy bundle (`bundle.tar.gz`) in your working directory.
 
 Next, create a `docker-compose.yaml` file that runs OPA, a bundle server and the demo GraphQL server.
 
+<EvergreenCodeBlock>
 ```yaml title="docker-compose.yaml"
 services:
   opa:
-    image: openpolicyagent/opa:{{< current_docker_version >}}
+    image: openpolicyagent/opa:{{ current_version_docker }}
     ports:
     - "8181:8181"
     command:
@@ -192,6 +193,7 @@ services:
     volumes:
     - ./bundles/:/usr/share/nginx/html/
 ```
+</EvergreenCodeBlock>
 
 Then run `docker-compose` to pull and run the containers.
 

--- a/docs/docs/http-api-authorization.md
+++ b/docs/docs/http-api-authorization.md
@@ -71,11 +71,12 @@ You should now see a policy bundle (`bundle.tar.gz`) in your working directory (
 
 Next, create a `docker-compose.yaml` file that runs OPA, a bundle server and the demo web server.
 
+<EvergreenCodeBlock>
 ```yaml title="docker-compose.yaml"
 version: "2"
 services:
   opa:
-    image: openpolicyagent/opa:{{< current_docker_version >}}
+    image: openpolicyagent/opa:{{ current_version_docker }}
     ports:
     - 8181:8181
     # WARNING: OPA is NOT running with an authorization policy configured. This
@@ -110,6 +111,7 @@ services:
     volumes:
     - ./bundles:/usr/share/nginx/html/bundles
 ```
+</EvergreenCodeBlock>
 
 Then run `docker-compose` to pull and run the containers.
 

--- a/docs/docs/kafka-authorization.md
+++ b/docs/docs/kafka-authorization.md
@@ -70,9 +70,9 @@ For more information on how to configure the OPA plugin for Kafka, see the plugi
 
 Next, create a `docker-compose.yaml` file that runs OPA, Nginx, ZooKeeper, and Kafka.
 
-**docker-compose.yaml**:
+<EvergreenCodeBlock>
 
-```yaml
+```yaml title="docker-compose.yaml"
 services:
   nginx:
     image: nginx:1.21.4
@@ -81,7 +81,7 @@ services:
     ports:
     - "80:80"
   opa:
-    image: openpolicyagent/opa:{{< current_docker_version >}}
+    image: openpolicyagent/opa:{{ current_version_docker }}
     ports:
     - "8181:8181"
     command:
@@ -132,6 +132,8 @@ services:
     - opa
     - zookeeper
 ```
+
+</EvergreenCodeBlock>
 
 #### Authentication
 

--- a/docs/docs/kubernetes/tutorial.md
+++ b/docs/docs/kubernetes/tutorial.md
@@ -247,7 +247,8 @@ docker run --rm --name bundle-server -d -p 8888:80 -v ${PWD}:/usr/share/nginx/ht
 
 Next, use the file below to deploy OPA as an admission controller.
 
-```yaml title="admission-controller.yaml"
+<EvergreenCodeBlock>
+```
 # Grant OPA/kube-mgmt read-only access to resources. This lets kube-mgmt
 # replicate resources into OPA so they can be used in policies.
 kind: ClusterRoleBinding
@@ -328,7 +329,7 @@ spec:
       # authentication and authorization on the daemon. See the Security page for
       # details: https://www.openpolicyagent.org/docs/security.html.
       - name: opa
-        image: openpolicyagent/opa:{{< current_docker_version >}}
+        image: openpolicyagent/opa:{{ current_version_docker }}
         args:
         - "run"
         - "--server"
@@ -360,7 +361,7 @@ spec:
           initialDelaySeconds: 3
           periodSeconds: 5
       - name: kube-mgmt
-        image: openpolicyagent/kube-mgmt:2.0.1
+        image: openpolicyagent/kube-mgmt:{{ current_version_kube_mgmt }}
         args:
         - "--replicate-cluster=v1/namespaces"
         - "--replicate=networking.k8s.io/v1/ingresses"
@@ -369,6 +370,7 @@ spec:
         secret:
           secretName: opa-server
 ```
+</EvergreenCodeBlock>
 
 > ⚠️ If using `kind` to run a local Kubernetes cluster, the bundle service URL should be `http://host.docker.internal:8888`.
 

--- a/docs/docs/management-decision-logs.md
+++ b/docs/docs/management-decision-logs.md
@@ -30,13 +30,14 @@ updates will be sent to `/logs`.
 The message body contains a gzip compressed JSON array. Each array element (event)
 represents a policy decision returned by OPA.
 
+<EvergreenCodeBlock>
 ```json
 [
   {
     "labels": {
       "app": "my-example-app",
       "id": "1780d507-aea2-45cc-ae50-fa153c8e4a5a",
-      "version": "{{< current_version >}}"
+      "version": "{{ current_version }}"
     },
     "decision_id": "4ca636c1-55e4-417a-b1d8-4aceb67960d1",
     "bundles": {
@@ -55,6 +56,7 @@ represents a policy decision returned by OPA.
   }
 ]
 ```
+</EvergreenCodeBlock>
 
 Decision log updates contain the following fields:
 

--- a/docs/docs/management-status.md
+++ b/docs/docs/management-status.md
@@ -34,12 +34,13 @@ The partition name is an optional path segment that can be used to route
 status updates to different backends. If the partition name is not configured
 on the agent, updates will be sent to `/status`.
 
+<EvergreenCodeBlock>
 ```json
 {
   "labels": {
     "app": "my-example-app",
     "id": "1780d507-aea2-45cc-ae50-fa153c8e4a5a",
-    "version": "{{< current_version >}}"
+    "version": "{{ current_version }}"
   },
   "bundles": {
     "http/example/authz": {
@@ -225,6 +226,7 @@ on the agent, updates will be sent to `/status`.
   }
 }
 ```
+</EvergreenCodeBlock>
 
 Status updates contain the following fields:
 

--- a/docs/docs/ssh-and-sudo-authorization.md
+++ b/docs/docs/ssh-and-sudo-authorization.md
@@ -46,13 +46,12 @@ with OPA. The dummy SSH hosts are just containers running sshd inside.
 First, create a `tutorial-docker-compose.yaml` file that runs OPA and the containers that
 represent our backend and frontend hosts.
 
-**tutorial-docker-compose.yaml**:
-
-```yaml
+<EvergreenCodeBlock>
+```yaml title="tutorial-docker-compose.yaml"
 version: "2"
 services:
   opa:
-    image: openpolicyagent/opa:{{< current_docker_version >}}
+    image: openpolicyagent/opa:{{ current_version_docker }}
     ports:
     - "8181:8181"
     # WARNING: OPA is NOT running with an authorization policy configured. This
@@ -88,6 +87,7 @@ services:
     volumes:
     - ./bundles:/usr/share/nginx/html/bundles
 ```
+</EvergreenCodeBlock>
 
 The `tutorial-docker-compose.yaml` file requires two other local files:
 `frontend_host_id.json` and `backend_host_id.json`. These files are mounted

--- a/docs/src/components/EvergreenCodeBlock/index.js
+++ b/docs/src/components/EvergreenCodeBlock/index.js
@@ -1,0 +1,52 @@
+import React from "react";
+import semver from "semver";
+
+import versions from "@generated/versions-data/default/versions.json";
+
+// EvergreenCodeBlock is a component that can perform some templating of code blocks
+// based on data available in docusaurus but not in mdx files.
+function EvergreenCodeBlock({ children }) {
+  const currentVersion = versions.filter(semver.valid).sort(semver.rcompare)[0];
+
+  const replacements = {
+    "current_version": currentVersion,
+    "current_version_docker": currentVersion.replace("v", ""),
+    "current_version_docker_envoy": currentVersion.replace("v", "") + "-envoy-4",
+    // TODO: Automate the updates of this value
+    "current_version_kube_mgmt": "9.0.1",
+  };
+
+  // Function to recursively process React children and replace template variables
+  const processChildren = (children) => {
+    return React.Children.map(children, child => {
+      if (typeof child === "string") {
+        let processedText = child;
+
+        Object.entries(replacements).forEach(([key, value]) => {
+          const pattern = new RegExp(`\\{\\{\\s*${key}\\s*\\}\\}`, "g");
+          processedText = processedText.replace(pattern, value);
+        });
+
+        return processedText;
+      }
+
+      if (React.isValidElement(child) && child.props.children) {
+        return React.cloneElement(child, {
+          ...child.props,
+          children: processChildren(child.props.children),
+        });
+      }
+
+      return child;
+    });
+  };
+
+  return (
+    <div>
+      {processChildren(children)}
+    </div>
+  );
+}
+
+export default EvergreenCodeBlock;
+

--- a/docs/src/theme/MDXComponents.js
+++ b/docs/src/theme/MDXComponents.js
@@ -10,6 +10,7 @@ import PlaygroundExample from "@site/src/components/PlaygroundExample";
 import RunSnippet from "@site/src/components/RunSnippet";
 import SideBySideColumn from "@site/src/components/SideBySide/Column";
 import SideBySideContainer from "@site/src/components/SideBySide/Container";
+import EvergreenCodeBlock from "@site/src/components/EvergreenCodeBlock";
 
 export default {
   ...MDXComponents,
@@ -23,4 +24,5 @@ export default {
   SideBySideContainer,
   TabItem,
   Tabs,
+  EvergreenCodeBlock,
 };


### PR DESCRIPTION
This adds a new EvergreenCodeBlock component to the documentation site that allows code blocks to contain template for the current versions of opa components. This means we can show the current version in docs, but don't need update the version in every code block when we release a new version.

Fixes https://github.com/open-policy-agent/opa/issues/7705

In the future, it would be nice to pull the latest release for this on build since the envoy release sometimes lags behind the opa release a small amount, but for now this is a step in the right direction. The kube-mgmt version is also manually set, but at least this component owns all versioned code blocks in the documentation now.
