### PR TITLE
Allowing keywords in Rego references

### DIFF
--- a/capabilities.json
+++ b/capabilities.json
@@ -4844,6 +4844,7 @@
     }
   ],
   "features": [
+    "keywords_in_refs",
     "rego_v1"
   ]
 }

--- a/cmd/bench.go
+++ b/cmd/bench.go
@@ -64,7 +64,7 @@ func newBenchmarkEvalParams() benchmarkCommandParams {
 			}),
 			target:       util.NewEnumFlag(compile.TargetRego, []string{compile.TargetRego, compile.TargetWasm}),
 			schema:       &schemaFlags{},
-			capabilities: newcapabilitiesFlag(),
+			capabilities: newCapabilitiesFlag(),
 		},
 		gracefulShutdownPeriod: 10,
 	}

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -53,7 +53,7 @@ type buildParams struct {
 
 func newBuildParams() buildParams {
 	return buildParams{
-		capabilities: newcapabilitiesFlag(),
+		capabilities: newCapabilitiesFlag(),
 		target:       util.NewEnumFlag(compile.TargetRego, compile.Targets),
 	}
 }

--- a/cmd/build_test.go
+++ b/cmd/build_test.go
@@ -203,7 +203,7 @@ import rego.v1`,
 			}
 
 			test.WithTempFS(files, func(root string) {
-				caps := newcapabilitiesFlag()
+				caps := newCapabilitiesFlag()
 				if err := caps.Set(path.Join(root, "capabilities.json")); err != nil {
 					t.Fatal(err)
 				}
@@ -1324,7 +1324,7 @@ p[4] {
 				params.v1Compatible = tc.v1Compatible
 
 				if tc.capabilities != nil {
-					params.capabilities = newcapabilitiesFlag()
+					params.capabilities = newCapabilitiesFlag()
 					params.capabilities.C = tc.capabilities
 				}
 
@@ -2842,7 +2842,7 @@ foo contains __local1__1 if {
 				params.optimizationLevel = 1
 
 				if !tc.regoV1ImportCapable {
-					caps := newcapabilitiesFlag()
+					caps := newCapabilitiesFlag()
 					caps.C = ast.CapabilitiesForThisVersion()
 					caps.C.Features = []string{
 						ast.FeatureRefHeadStringPrefixes,

--- a/cmd/capabilities_test.go
+++ b/cmd/capabilities_test.go
@@ -90,6 +90,7 @@ func TestCapabilitiesCurrent(t *testing.T) {
 			note: "current",
 			expFeatures: []string{
 				ast.FeatureRegoV1,
+				ast.FeatureKeywordsInRefs,
 			},
 		},
 		{
@@ -100,6 +101,7 @@ func TestCapabilitiesCurrent(t *testing.T) {
 				ast.FeatureRefHeads,
 				ast.FeatureRegoV1Import,
 				ast.FeatureRegoV1,
+				ast.FeatureKeywordsInRefs,
 			},
 			expFutureKeywords: []string{
 				"in",

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -39,7 +39,7 @@ func newCheckParams() checkParams {
 		format: util.NewEnumFlag(checkFormatPretty, []string{
 			checkFormatPretty, checkFormatJSON,
 		}),
-		capabilities: newcapabilitiesFlag(),
+		capabilities: newCapabilitiesFlag(),
 		schema:       &schemaFlags{},
 	}
 }

--- a/cmd/check_test.go
+++ b/cmd/check_test.go
@@ -162,7 +162,7 @@ import rego.v1`,
 			}
 
 			test.WithTempFS(files, func(root string) {
-				caps := newcapabilitiesFlag()
+				caps := newCapabilitiesFlag()
 				if err := caps.Set(path.Join(root, "capabilities.json")); err != nil {
 					t.Fatal(err)
 				}

--- a/cmd/eval.go
+++ b/cmd/eval.go
@@ -91,7 +91,7 @@ func (p *evalCommandParams) regoVersion() ast.RegoVersion {
 
 func newEvalCommandParams() evalCommandParams {
 	return evalCommandParams{
-		capabilities: newcapabilitiesFlag(),
+		capabilities: newCapabilitiesFlag(),
 		outputFormat: util.NewEnumFlag(evalJSONOutput, []string{
 			evalJSONOutput,
 			evalValuesOutput,

--- a/cmd/eval_test.go
+++ b/cmd/eval_test.go
@@ -2066,7 +2066,7 @@ p contains __local0__1 if __local0__1 = input.v
 						_ = params.outputFormat.Set(format)
 
 						if !tc.regoV1ImportCapable {
-							caps := newcapabilitiesFlag()
+							caps := newCapabilitiesFlag()
 							caps.C = ast.CapabilitiesForThisVersion()
 							caps.C.Features = []string{
 								ast.FeatureRefHeadStringPrefixes,

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -199,7 +199,7 @@ type capabilitiesFlag struct {
 	pathOrVersion string
 }
 
-func newcapabilitiesFlag() *capabilitiesFlag {
+func newCapabilitiesFlag() *capabilitiesFlag {
 	return &capabilitiesFlag{
 		// cannot call ast.CapabilitiesForThisVersion here because
 		// custom builtins cannot be registered by this point in execution

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -73,7 +73,7 @@ func newTestCommandParams() testCommandParams {
 		outputFormat: util.NewEnumFlag(testPrettyOutput, []string{testPrettyOutput, testJSONOutput, benchmarkGoBenchOutput}),
 		explain:      newExplainFlag([]string{explainModeFails, explainModeFull, explainModeNotes, explainModeDebug}),
 		target:       util.NewEnumFlag(compile.TargetRego, []string{compile.TargetRego, compile.TargetWasm}),
-		capabilities: newcapabilitiesFlag(),
+		capabilities: newCapabilitiesFlag(),
 		schema:       &schemaFlags{},
 		output:       os.Stdout,
 		errOutput:    os.Stderr,

--- a/v1/ast/capabilities.go
+++ b/v1/ast/capabilities.go
@@ -55,6 +55,7 @@ const FeatureRefHeadStringPrefixes = "rule_head_ref_string_prefixes"
 const FeatureRefHeads = "rule_head_refs"
 const FeatureRegoV1 = "rego_v1"
 const FeatureRegoV1Import = "rego_v1_import"
+const FeatureKeywordsInRefs = "keywords_in_refs"
 
 // Capabilities defines a structure containing data that describes the capabilities
 // or features supported by a particular version of OPA.
@@ -133,6 +134,7 @@ func CapabilitiesForThisVersion(opts ...CapabilitiesOption) *Capabilities {
 			FeatureRefHeads,
 			FeatureRegoV1Import,
 			FeatureRegoV1, // Included in v0 capabilities to allow v1 bundles in --v0-compatible mode
+			FeatureKeywordsInRefs,
 		}
 	default:
 		for kw := range futureKeywords {
@@ -141,6 +143,7 @@ func CapabilitiesForThisVersion(opts ...CapabilitiesOption) *Capabilities {
 
 		f.Features = []string{
 			FeatureRegoV1,
+			FeatureKeywordsInRefs,
 		}
 	}
 

--- a/v1/ast/internal/scanner/scanner.go
+++ b/v1/ast/internal/scanner/scanner.go
@@ -116,6 +116,15 @@ func (s *Scanner) HasKeyword(keywords map[string]tokens.Token) bool {
 	return false
 }
 
+func (s *Scanner) IsKeyword(str string) bool {
+	for kw := range s.keywords {
+		if kw == str {
+			return true
+		}
+	}
+	return false
+}
+
 func (s *Scanner) SetRegoV1Compatible() {
 	s.regoV1Compatible = true
 }

--- a/v1/ast/parser.go
+++ b/v1/ast/parser.go
@@ -556,16 +556,17 @@ func (p *Parser) parsePackage() *Package {
 	}
 
 	// This allows keywords in the first var term of the ref; should we support this, or only on subsequent terms?
-	p.scanWS()
-
-	if p.s.tok == tokens.Dot || p.s.tok == tokens.LBrack {
-		// This is a ref
-		return nil
-	}
-
-	if p.s.tok == tokens.Whitespace {
-		p.scan()
-	}
+	//p.scanWS()
+	//
+	//if p.s.tok == tokens.Dot || p.s.tok == tokens.LBrack {
+	//	// This is a ref
+	//	return nil
+	//}
+	//
+	//if p.s.tok == tokens.Whitespace {
+	//	p.scan()
+	//}
+	p.scan()
 
 	if p.s.tok != tokens.Ident {
 		p.illegalToken()
@@ -625,16 +626,17 @@ func (p *Parser) parseImport() *Import {
 	}
 
 	// This allows keywords in the first var term of the ref; should we support this, or only on subsequent terms?
-	p.scanWS()
-
-	if p.s.tok == tokens.Dot || p.s.tok == tokens.LBrack {
-		// This is a ref
-		return nil
-	}
-
-	if p.s.tok == tokens.Whitespace {
-		p.scan()
-	}
+	//p.scanWS()
+	//
+	//if p.s.tok == tokens.Dot || p.s.tok == tokens.LBrack {
+	//	// This is a ref
+	//	return nil
+	//}
+	//
+	//if p.s.tok == tokens.Whitespace {
+	//	p.scan()
+	//}
+	p.scan()
 
 	if p.s.tok != tokens.Ident {
 		p.error(p.s.Loc(), "expected ident")
@@ -696,6 +698,21 @@ func (p *Parser) parseImport() *Import {
 		}
 		p.illegal("expected var")
 		return nil
+	}
+
+	if imp.Alias != "" {
+		// Unreachable: parsing the alias var should already have generated an error.
+		name := imp.Alias.String()
+		if IsKeywordInRegoVersion(name, p.po.EffectiveRegoVersion()) {
+			p.errorf(imp.Location, "invalid import: alias cannot be a keyword: %s", name)
+		}
+	} else {
+		r := imp.Path.Value.(Ref)
+		t := r[len(r)-1]
+		name := string(t.Value.(String))
+		if IsKeywordInRegoVersion(name, p.po.EffectiveRegoVersion()) {
+			p.errorf(t.Location, "invalid import: path cannot end with a keyword: %s", name)
+		}
 	}
 
 	return &imp
@@ -1104,18 +1121,18 @@ func (p *Parser) parseLiteral() (expr *Expr) {
 	}()
 
 	// This allows keywords in the first var term of the ref; should we support this, or only on subsequent terms?
-	if IsKeywordInRegoVersion(p.s.tok.String(), p.po.EffectiveRegoVersion()) {
-		// scan ahead to check if we're parsing a ref
-		s := p.save()
-		p.scanWS()
-		tok := p.s.tok
-		p.restore(s)
-
-		if tok == tokens.Dot || tok == tokens.LBrack {
-			p.s.tok = tokens.Ident
-			return p.parseLiteralExpr(false)
-		}
-	}
+	//if IsKeywordInRegoVersion(p.s.tok.String(), p.po.EffectiveRegoVersion()) {
+	//	// scan ahead to check if we're parsing a ref
+	//	s := p.save()
+	//	p.scanWS()
+	//	tok := p.s.tok
+	//	p.restore(s)
+	//
+	//	if tok == tokens.Dot || tok == tokens.LBrack {
+	//		p.s.tok = tokens.Ident
+	//		return p.parseLiteralExpr(false)
+	//	}
+	//}
 
 	var negated bool
 	if p.s.tok == tokens.Not {

--- a/v1/ast/parser.go
+++ b/v1/ast/parser.go
@@ -711,7 +711,15 @@ func (p *Parser) parseImport() *Import {
 	} else {
 		r := imp.Path.Value.(Ref)
 		t := r[len(r)-1]
-		name := string(t.Value.(String))
+
+		var name string
+		switch v := t.Value.(type) {
+		case Var:
+			name = string(v)
+		case String:
+			name = string(v)
+		}
+
 		if IsKeywordInRegoVersion(name, p.po.EffectiveRegoVersion()) {
 			p.errorf(t.Location, "unexpected import path, must not end with a keyword, got: %s", name)
 			p.hint("import a different path or use an alias")

--- a/v1/ast/parser.go
+++ b/v1/ast/parser.go
@@ -1514,6 +1514,9 @@ func (p *Parser) parseTermIn(lhs *Term, keyVal bool, offset int) *Term {
 			}
 			p.restore(s)
 		}
+
+		_ = scanAheadRef(p)
+
 		if op := p.parseTermOpName(memberRef, tokens.In); op != nil {
 			if rhs := p.parseTermRelation(nil, p.s.loc.Offset); rhs != nil {
 				call := p.setLoc(CallTerm(op, lhs, rhs), lhs.Location, offset, p.s.lastEnd)

--- a/v1/ast/parser.go
+++ b/v1/ast/parser.go
@@ -712,6 +712,7 @@ func (p *Parser) parseImport() *Import {
 		name := string(t.Value.(String))
 		if IsKeywordInRegoVersion(name, p.po.EffectiveRegoVersion()) {
 			p.errorf(t.Location, "invalid import: path cannot end with a keyword: %s", name)
+			p.hint("import a different path or use an alias")
 		}
 	}
 

--- a/v1/ast/parser_test.go
+++ b/v1/ast/parser_test.go
@@ -910,6 +910,34 @@ func TestRuleHeadsContainingKeywords_RegoV0(t *testing.T) {
 	}
 }
 
+func TestRefKeywordsEdgeCases(t *testing.T) {
+	t.Run("'in' kw first term in ref head rule following 'contains'", func(t *testing.T) {
+		input := `package test
+			foo contains "a"
+
+			in.bar contains "b" if {
+			  false
+			}`
+
+		exp := &Module{
+			Package: MustParsePackage("package test"),
+			Rules: []*Rule{
+				MustParseRule(`foo contains "a"`),
+				MustParseRule(`in.bar contains "b" if { false }`),
+			},
+		}
+
+		m, err := ParseModule("", input)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if !m.Equal(exp) {
+			t.Fatalf("expected module:\n\n%v\n\ngot:\n\n%v", exp, m)
+		}
+	})
+}
+
 func TestRuleBodyContainingRefKeywords(t *testing.T) {
 	for _, kw := range KeywordsForRegoVersion(RegoV1) {
 		t.Run(kw, func(t *testing.T) {

--- a/v1/ast/rego_v1.go
+++ b/v1/ast/rego_v1.go
@@ -191,7 +191,7 @@ func checkRegoV1Rule(rule *Rule, opts RegoCheckOptions) Errors {
 
 	var errs Errors
 
-	if opts.NoKeywordsAsRuleNames && IsKeywordInRegoVersion(rule.Head.Name.String(), RegoV1) {
+	if opts.NoKeywordsAsRuleNames && len(rule.Head.Reference) < 2 && IsKeywordInRegoVersion(rule.Head.Name.String(), RegoV1) {
 		errs = append(errs, NewError(ParseErr, rule.Location, "%s keyword cannot be used for rule name", rule.Head.Name.String()))
 	}
 	if opts.RequireRuleBodyOrValue && rule.generatedBody && rule.Head.generatedValue {

--- a/v1/compile/compile.go
+++ b/v1/compile/compile.go
@@ -381,14 +381,12 @@ func (c *Compiler) Build(ctx context.Context) error {
 		c.bundle.Manifest.Metadata = *c.metadata
 	}
 
-	if c.regoVersion == ast.RegoV1 {
-		if err := c.bundle.FormatModulesForRegoVersion(c.regoVersion, true, false); err != nil {
-			return err
-		}
-	} else {
-		if err := c.bundle.FormatModules(false); err != nil {
-			return err
-		}
+	if err := c.bundle.FormatModulesWithOptions(bundle.BundleFormatOptions{
+		RegoVersion:               c.regoVersion,
+		Capabilities:              c.capabilities,
+		PreserveModuleRegoVersion: true,
+	}); err != nil {
+		return err
 	}
 
 	if c.bsc != nil {

--- a/v1/format/format.go
+++ b/v1/format/format.go
@@ -20,6 +20,9 @@ import (
 	"github.com/open-policy-agent/opa/v1/types"
 )
 
+// TODO: Don't format v0 refs, to maximize compatibility
+// TODO: Add capabilities to Opts and add 'keywords_in_refs' capability; format refs depending on capability presence. (?)
+
 // Opts lets you control the code formatting via `AstWithOpts()`.
 type Opts struct {
 	// IgnoreLocations instructs the formatter not to use the AST nodes' locations

--- a/v1/format/format.go
+++ b/v1/format/format.go
@@ -40,6 +40,8 @@ type Opts struct {
 	// DropV0Imports instructs the formatter to drop all v0 imports from the module; i.e. 'rego.v1' and 'future.keywords' imports.
 	// Imports are only removed if [Opts.RegoVersion] makes them redundant.
 	DropV0Imports bool
+
+	Capabilities *ast.Capabilities
 }
 
 func (o Opts) effectiveRegoVersion() ast.RegoVersion {
@@ -149,6 +151,10 @@ type fmtOpts struct {
 	regoV1         bool
 	regoV1Imported bool
 	futureKeywords []string
+
+	// If true, the formatter will retain keywords in refs, e.g. `p.not ` instead of `p["not"]`.
+	// The format of the original ref is preserved, so `p["not"]` will still be formatted as `p["not"]`.
+	allowKeywordsInRefs bool
 }
 
 func (o fmtOpts) keywords() []string {
@@ -181,6 +187,12 @@ func AstWithOpts(x any, opts Opts) ([]byte, error) {
 		o.ifs = true
 		o.contains = true
 	}
+
+	capabilities := opts.Capabilities
+	if capabilities == nil {
+		capabilities = ast.CapabilitiesForThisVersion(ast.CapabilitiesRegoVersion(opts.effectiveRegoVersion()))
+	}
+	o.allowKeywordsInRefs = capabilities.ContainsFeature(ast.FeatureKeywordsInRefs)
 
 	memberRef := ast.Member.Ref()
 	memberWithKeyRef := ast.MemberWithKey.Ref()
@@ -1073,8 +1085,14 @@ func (w *writer) writeFunctionCall(expr *ast.Expr, comments []*ast.Comment) ([]*
 }
 
 func (w *writer) writeFunctionCallPlain(terms []*ast.Term, comments []*ast.Comment) ([]*ast.Comment, error) {
-	w.write(terms[0].String() + "(")
+	if r, ok := terms[0].Value.(ast.Ref); ok {
+		w.writeRef(r, comments)
+	} else {
+		w.write(terms[0].String())
+	}
+	w.write("(")
 	defer w.write(")")
+
 	args := make([]any, len(terms)-1)
 	for i, t := range terms[1:] {
 		args[i] = t
@@ -1267,7 +1285,7 @@ func (w *writer) writeRef(x ast.Ref, comments []*ast.Comment) ([]*ast.Comment, e
 		for _, t := range path {
 			switch p := t.Value.(type) {
 			case ast.String:
-				w.writeRefStringPath(p)
+				w.writeRefStringPath(p, t.Location)
 			case ast.Var:
 				w.writeBracketed(w.formatVar(p))
 			default:
@@ -1295,13 +1313,31 @@ func (w *writer) writeBracketed(str string) {
 
 var varRegexp = regexp.MustCompile("^[[:alpha:]_][[:alpha:][:digit:]_]*$")
 
-func (w *writer) writeRefStringPath(s ast.String) {
+func (w *writer) writeRefStringPath(s ast.String, l *ast.Location) {
 	str := string(s)
-	if varRegexp.MatchString(str) && !ast.IsInKeywords(str, w.fmtOpts.keywords()) {
-		w.write("." + str)
-	} else {
+	if w.shouldBracketRefTerm(str, l) {
 		w.writeBracketed(s.String())
+	} else {
+		w.write("." + str)
 	}
+}
+
+func (w *writer) shouldBracketRefTerm(s string, l *ast.Location) bool {
+	if !varRegexp.MatchString(s) {
+		return true
+	}
+
+	if ast.IsInKeywords(s, w.fmtOpts.keywords()) {
+		if !w.fmtOpts.allowKeywordsInRefs {
+			return true
+		}
+
+		if l != nil && l.Text[0] == 34 { // If the original term text starts with '"', we preserve the brackets and quotes
+			return true
+		}
+	}
+
+	return false
 }
 
 func (*writer) formatVar(v ast.Var) string {

--- a/v1/format/testfiles/v0/test_contains.rego.formatted_no_keywords_in_refs
+++ b/v1/format/testfiles/v0/test_contains.rego.formatted_no_keywords_in_refs
@@ -1,4 +1,4 @@
-package test.contains
+package test["contains"]
 
 import future.keywords.contains
 

--- a/v1/format/testfiles/v0/test_if.rego.formatted_no_keywords_in_refs
+++ b/v1/format/testfiles/v0/test_if.rego.formatted_no_keywords_in_refs
@@ -1,4 +1,4 @@
-package test.if
+package test["if"]
 
 import future.keywords.if
 

--- a/v1/format/testfiles/v0/test_if_else.rego.formatted_no_keywords_in_refs
+++ b/v1/format/testfiles/v0/test_if_else.rego.formatted_no_keywords_in_refs
@@ -1,4 +1,4 @@
-package test.if
+package test["if"]
 
 import future.keywords.if
 

--- a/v1/format/testfiles/v0/test_in.rego.formatted_no_keywords_in_refs
+++ b/v1/format/testfiles/v0/test_in.rego.formatted_no_keywords_in_refs
@@ -1,4 +1,4 @@
-package test.in
+package test["in"]
 
 import future.keywords.in
 

--- a/v1/format/testfiles/v0/test_keywords_in_refs.rego
+++ b/v1/format/testfiles/v0/test_keywords_in_refs.rego
@@ -1,0 +1,147 @@
+package test.not.package.import.as.default.else.with.null.true.false.some
+
+p {
+	a.not == 1
+	a.package == 1
+	a.import == 1
+	a.as == 1
+	a.default == 1
+	a.else == 1
+	a.with == 1
+	a.null == 1
+	a.true == 1
+	a.false == 1
+	a.some == 1
+
+	b.c.not == 1
+	b.c.package == 1
+	b.c.import == 1
+	b.c.as == 1
+	b.c.default == 1
+	b.c.else == 1
+	b.c.with == 1
+	b.c.null == 1
+	b.c.true == 1
+	b.c.false == 1
+	b.c.some == 1
+
+	d.not.e == 1
+	d.package.e == 1
+	d.import.e == 1
+	d.as.e == 1
+	d.default.e == 1
+	d.else.e == 1
+	d.with.e == 1
+	d.null.e == 1
+	d.true.e == 1
+	d.false.e == 1
+	d.some.e == 1
+
+	f.not(2)
+	f.package(2)
+	f.import(2)
+	f.as(2)
+	f.default(2)
+	f.else(2)
+	f.with(2)
+	f.null(2)
+	f.true(2)
+	f.false(2)
+	f.some(2)
+
+	g.h.not(2)
+	g.h.package(2)
+	g.h.import(2)
+	g.h.as(2)
+	g.h.default(2)
+	g.h.else(2)
+	g.h.with(2)
+	g.h.null(2)
+	g.h.true(2)
+	g.h.false(2)
+	g.h.some(2)
+
+	i.not.j(2)
+	i.package.j(2)
+	i.import.j(2)
+	i.as.j(2)
+	i.default.j(2)
+	i.else.j(2)
+	i.with.j(2)
+	i.null.j(2)
+	i.true.j(2)
+	i.false.j(2)
+	i.some.j(2)
+}
+
+a.not := 1
+a.package := 1
+a.import := 1
+a.as := 1
+a.default := 1
+a.else := 1
+a.with := 1
+a.null := 1
+a.true := 1
+a.false := 1
+a.some := 1
+
+b.c.not := 1
+b.c.package := 1
+b.c.import := 1
+b.c.as := 1
+b.c.default := 1
+b.c.else := 1
+b.c.with := 1
+b.c.null := 1
+b.c.true := 1
+b.c.false := 1
+b.c.some := 1
+
+d.not.e := 1
+d.package.e := 1
+d.import.e := 1
+d.as.e := 1
+d.default.e := 1
+d.else.e := 1
+d.with.e := 1
+d.null.e := 1
+d.true.e := 1
+d.false.e := 1
+d.some.e := 1
+
+f.not(x) := x
+f.package(x) := x
+f.import(x) := x
+f.as(x) := x
+f.default(x) := x
+f.else(x) := x
+f.with(x) := x
+f.null(x) := x
+f.true(x) := x
+f.false(x) := x
+f.some(x) := x
+
+g.h.not(x) := x
+g.h.package(x) := x
+g.h.import(x) := x
+g.h.as(x) := x
+g.h.default(x) := x
+g.h.else(x) := x
+g.h.with(x) := x
+g.h.null(x) := x
+g.h.true(x) := x
+g.h.false(x) := x
+g.h.some(x) := x
+
+i.not.j(x) := x
+i.package.j(x) := x
+i.import.j(x) := x
+i.as.j(x) := x
+i.default.j(x) := x
+i.else.j(x) := x
+i.with.j(x) := x
+i.null.j(x) := x
+i.true.j(x) := x
+i.false.j(x) := x
+i.some.j(x) := x

--- a/v1/format/testfiles/v0/test_keywords_in_refs.rego.formatted
+++ b/v1/format/testfiles/v0/test_keywords_in_refs.rego.formatted
@@ -1,0 +1,207 @@
+package test.not.package.import.as.default.else.with.null.true.false.some
+
+p {
+	a.not == 1
+	a.package == 1
+	a.import == 1
+	a.as == 1
+	a.default == 1
+	a.else == 1
+	a.with == 1
+	a.null == 1
+	a.true == 1
+	a.false == 1
+	a.some == 1
+
+	b.c.not == 1
+	b.c.package == 1
+	b.c.import == 1
+	b.c.as == 1
+	b.c.default == 1
+	b.c.else == 1
+	b.c.with == 1
+	b.c.null == 1
+	b.c.true == 1
+	b.c.false == 1
+	b.c.some == 1
+
+	d.not.e == 1
+	d.package.e == 1
+	d.import.e == 1
+	d.as.e == 1
+	d.default.e == 1
+	d.else.e == 1
+	d.with.e == 1
+	d.null.e == 1
+	d.true.e == 1
+	d.false.e == 1
+	d.some.e == 1
+
+	f.not(2)
+	f.package(2)
+	f.import(2)
+	f.as(2)
+	f.default(2)
+	f.else(2)
+	f.with(2)
+	f.null(2)
+	f.true(2)
+	f.false(2)
+	f.some(2)
+
+	g.h.not(2)
+	g.h.package(2)
+	g.h.import(2)
+	g.h.as(2)
+	g.h.default(2)
+	g.h.else(2)
+	g.h.with(2)
+	g.h.null(2)
+	g.h.true(2)
+	g.h.false(2)
+	g.h.some(2)
+
+	i.not.j(2)
+	i.package.j(2)
+	i.import.j(2)
+	i.as.j(2)
+	i.default.j(2)
+	i.else.j(2)
+	i.with.j(2)
+	i.null.j(2)
+	i.true.j(2)
+	i.false.j(2)
+	i.some.j(2)
+}
+
+a.not := 1
+
+a.package := 1
+
+a.import := 1
+
+a.as := 1
+
+a.default := 1
+
+a.else := 1
+
+a.with := 1
+
+a.null := 1
+
+a.true := 1
+
+a.false := 1
+
+a.some := 1
+
+b.c.not := 1
+
+b.c.package := 1
+
+b.c.import := 1
+
+b.c.as := 1
+
+b.c.default := 1
+
+b.c.else := 1
+
+b.c.with := 1
+
+b.c.null := 1
+
+b.c.true := 1
+
+b.c.false := 1
+
+b.c.some := 1
+
+d.not.e := 1
+
+d.package.e := 1
+
+d.import.e := 1
+
+d.as.e := 1
+
+d.default.e := 1
+
+d.else.e := 1
+
+d.with.e := 1
+
+d.null.e := 1
+
+d.true.e := 1
+
+d.false.e := 1
+
+d.some.e := 1
+
+f.not(x) := x
+
+f.package(x) := x
+
+f.import(x) := x
+
+f.as(x) := x
+
+f.default(x) := x
+
+f.else(x) := x
+
+f.with(x) := x
+
+f.null(x) := x
+
+f.true(x) := x
+
+f.false(x) := x
+
+f.some(x) := x
+
+g.h.not(x) := x
+
+g.h.package(x) := x
+
+g.h.import(x) := x
+
+g.h.as(x) := x
+
+g.h.default(x) := x
+
+g.h.else(x) := x
+
+g.h.with(x) := x
+
+g.h.null(x) := x
+
+g.h.true(x) := x
+
+g.h.false(x) := x
+
+g.h.some(x) := x
+
+i.not.j(x) := x
+
+i.package.j(x) := x
+
+i.import.j(x) := x
+
+i.as.j(x) := x
+
+i.default.j(x) := x
+
+i.else.j(x) := x
+
+i.with.j(x) := x
+
+i.null.j(x) := x
+
+i.true.j(x) := x
+
+i.false.j(x) := x
+
+i.some.j(x) := x

--- a/v1/format/testfiles/v0/test_keywords_in_refs.rego.formatted_no_keywords_in_refs
+++ b/v1/format/testfiles/v0/test_keywords_in_refs.rego.formatted_no_keywords_in_refs
@@ -1,0 +1,207 @@
+package test["not"]["package"]["import"]["as"]["default"]["else"]["with"]["null"]["true"]["false"]["some"]
+
+p {
+	a["not"] == 1
+	a["package"] == 1
+	a["import"] == 1
+	a["as"] == 1
+	a["default"] == 1
+	a["else"] == 1
+	a["with"] == 1
+	a["null"] == 1
+	a["true"] == 1
+	a["false"] == 1
+	a["some"] == 1
+
+	b.c["not"] == 1
+	b.c["package"] == 1
+	b.c["import"] == 1
+	b.c["as"] == 1
+	b.c["default"] == 1
+	b.c["else"] == 1
+	b.c["with"] == 1
+	b.c["null"] == 1
+	b.c["true"] == 1
+	b.c["false"] == 1
+	b.c["some"] == 1
+
+	d["not"].e == 1
+	d["package"].e == 1
+	d["import"].e == 1
+	d["as"].e == 1
+	d["default"].e == 1
+	d["else"].e == 1
+	d["with"].e == 1
+	d["null"].e == 1
+	d["true"].e == 1
+	d["false"].e == 1
+	d["some"].e == 1
+
+	f["not"](2)
+	f["package"](2)
+	f["import"](2)
+	f["as"](2)
+	f["default"](2)
+	f["else"](2)
+	f["with"](2)
+	f["null"](2)
+	f["true"](2)
+	f["false"](2)
+	f["some"](2)
+
+	g.h["not"](2)
+	g.h["package"](2)
+	g.h["import"](2)
+	g.h["as"](2)
+	g.h["default"](2)
+	g.h["else"](2)
+	g.h["with"](2)
+	g.h["null"](2)
+	g.h["true"](2)
+	g.h["false"](2)
+	g.h["some"](2)
+
+	i["not"].j(2)
+	i["package"].j(2)
+	i["import"].j(2)
+	i["as"].j(2)
+	i["default"].j(2)
+	i["else"].j(2)
+	i["with"].j(2)
+	i["null"].j(2)
+	i["true"].j(2)
+	i["false"].j(2)
+	i["some"].j(2)
+}
+
+a["not"] := 1
+
+a["package"] := 1
+
+a["import"] := 1
+
+a["as"] := 1
+
+a["default"] := 1
+
+a["else"] := 1
+
+a["with"] := 1
+
+a["null"] := 1
+
+a["true"] := 1
+
+a["false"] := 1
+
+a["some"] := 1
+
+b.c["not"] := 1
+
+b.c["package"] := 1
+
+b.c["import"] := 1
+
+b.c["as"] := 1
+
+b.c["default"] := 1
+
+b.c["else"] := 1
+
+b.c["with"] := 1
+
+b.c["null"] := 1
+
+b.c["true"] := 1
+
+b.c["false"] := 1
+
+b.c["some"] := 1
+
+d["not"].e := 1
+
+d["package"].e := 1
+
+d["import"].e := 1
+
+d["as"].e := 1
+
+d["default"].e := 1
+
+d["else"].e := 1
+
+d["with"].e := 1
+
+d["null"].e := 1
+
+d["true"].e := 1
+
+d["false"].e := 1
+
+d["some"].e := 1
+
+f["not"](x) := x
+
+f["package"](x) := x
+
+f["import"](x) := x
+
+f["as"](x) := x
+
+f["default"](x) := x
+
+f["else"](x) := x
+
+f["with"](x) := x
+
+f["null"](x) := x
+
+f["true"](x) := x
+
+f["false"](x) := x
+
+f["some"](x) := x
+
+g.h["not"](x) := x
+
+g.h["package"](x) := x
+
+g.h["import"](x) := x
+
+g.h["as"](x) := x
+
+g.h["default"](x) := x
+
+g.h["else"](x) := x
+
+g.h["with"](x) := x
+
+g.h["null"](x) := x
+
+g.h["true"](x) := x
+
+g.h["false"](x) := x
+
+g.h["some"](x) := x
+
+i["not"].j(x) := x
+
+i["package"].j(x) := x
+
+i["import"].j(x) := x
+
+i["as"].j(x) := x
+
+i["default"].j(x) := x
+
+i["else"].j(x) := x
+
+i["with"].j(x) := x
+
+i["null"].j(x) := x
+
+i["true"].j(x) := x
+
+i["false"].j(x) := x
+
+i["some"].j(x) := x

--- a/v1/format/testfiles/v0/test_keywords_in_refs_keep_brackets.rego
+++ b/v1/format/testfiles/v0/test_keywords_in_refs_keep_brackets.rego
@@ -1,0 +1,147 @@
+package test["not"]["package"]["import"]["as"]["default"]["else"]["with"]["null"]["true"]["false"]["some"]
+
+p {
+	a["not"] == 1
+	a["package"] == 1
+	a["import"] == 1
+	a["as"] == 1
+	a["default"] == 1
+	a["else"] == 1
+	a["with"] == 1
+	a["null"] == 1
+	a["true"] == 1
+	a["false"] == 1
+	a["some"] == 1
+
+	b.c["not"] == 1
+	b.c["package"] == 1
+	b.c["import"] == 1
+	b.c["as"] == 1
+	b.c["default"] == 1
+	b.c["else"] == 1
+	b.c["with"] == 1
+	b.c["null"] == 1
+	b.c["true"] == 1
+	b.c["false"] == 1
+	b.c["some"] == 1
+
+	d["not"].e == 1
+	d["package"].e == 1
+	d["import"].e == 1
+	d["as"].e == 1
+	d["default"].e == 1
+	d["else"].e == 1
+	d["with"].e == 1
+	d["null"].e == 1
+	d["true"].e == 1
+	d["false"].e == 1
+	d["some"].e == 1
+
+	f["not"](2)
+	f["package"](2)
+	f["import"](2)
+	f["as"](2)
+	f["default"](2)
+	f["else"](2)
+	f["with"](2)
+	f["null"](2)
+	f["true"](2)
+	f["false"](2)
+	f["some"](2)
+
+	g.h["not"](2)
+	g.h["package"](2)
+	g.h["import"](2)
+	g.h["as"](2)
+	g.h["default"](2)
+	g.h["else"](2)
+	g.h["with"](2)
+	g.h["null"](2)
+	g.h["true"](2)
+	g.h["false"](2)
+	g.h["some"](2)
+
+	i["not"].j(2)
+	i["package"].j(2)
+	i["import"].j(2)
+	i["as"].j(2)
+	i["default"].j(2)
+	i["else"].j(2)
+	i["with"].j(2)
+	i["null"].j(2)
+	i["true"].j(2)
+	i["false"].j(2)
+	i["some"].j(2)
+}
+
+a["not"] := 1
+a["package"] := 1
+a["import"] := 1
+a["as"] := 1
+a["default"] := 1
+a["else"] := 1
+a["with"] := 1
+a["null"] := 1
+a["true"] := 1
+a["false"] := 1
+a["some"] := 1
+
+b.c["not"] := 1
+b.c["package"] := 1
+b.c["import"] := 1
+b.c["as"] := 1
+b.c["default"] := 1
+b.c["else"] := 1
+b.c["with"] := 1
+b.c["null"] := 1
+b.c["true"] := 1
+b.c["false"] := 1
+b.c["some"] := 1
+
+d["not"].e := 1
+d["package"].e := 1
+d["import"].e := 1
+d["as"].e := 1
+d["default"].e := 1
+d["else"].e := 1
+d["with"].e := 1
+d["null"].e := 1
+d["true"].e := 1
+d["false"].e := 1
+d["some"].e := 1
+
+f["not"](x) := x
+f["package"](x) := x
+f["import"](x) := x
+f["as"](x) := x
+f["default"](x) := x
+f["else"](x) := x
+f["with"](x) := x
+f["null"](x) := x
+f["true"](x) := x
+f["false"](x) := x
+f["some"](x) := x
+
+g.h["not"](x) := x
+g.h["package"](x) := x
+g.h["import"](x) := x
+g.h["as"](x) := x
+g.h["default"](x) := x
+g.h["else"](x) := x
+g.h["with"](x) := x
+g.h["null"](x) := x
+g.h["true"](x) := x
+g.h["false"](x) := x
+g.h["some"](x) := x
+
+i["not"].j(x) := x
+i["package"].j(x) := x
+i["import"].j(x) := x
+i["as"].j(x) := x
+i["default"].j(x) := x
+i["else"].j(x) := x
+i["with"].j(x) := x
+i["null"].j(x) := x
+i["true"].j(x) := x
+i["false"].j(x) := x
+i["some"].j(x) := x

--- a/v1/format/testfiles/v0/test_keywords_in_refs_keep_brackets.rego.formatted
+++ b/v1/format/testfiles/v0/test_keywords_in_refs_keep_brackets.rego.formatted
@@ -1,0 +1,207 @@
+package test["not"]["package"]["import"]["as"]["default"]["else"]["with"]["null"]["true"]["false"]["some"]
+
+p {
+	a["not"] == 1
+	a["package"] == 1
+	a["import"] == 1
+	a["as"] == 1
+	a["default"] == 1
+	a["else"] == 1
+	a["with"] == 1
+	a["null"] == 1
+	a["true"] == 1
+	a["false"] == 1
+	a["some"] == 1
+
+	b.c["not"] == 1
+	b.c["package"] == 1
+	b.c["import"] == 1
+	b.c["as"] == 1
+	b.c["default"] == 1
+	b.c["else"] == 1
+	b.c["with"] == 1
+	b.c["null"] == 1
+	b.c["true"] == 1
+	b.c["false"] == 1
+	b.c["some"] == 1
+
+	d["not"].e == 1
+	d["package"].e == 1
+	d["import"].e == 1
+	d["as"].e == 1
+	d["default"].e == 1
+	d["else"].e == 1
+	d["with"].e == 1
+	d["null"].e == 1
+	d["true"].e == 1
+	d["false"].e == 1
+	d["some"].e == 1
+
+	f["not"](2)
+	f["package"](2)
+	f["import"](2)
+	f["as"](2)
+	f["default"](2)
+	f["else"](2)
+	f["with"](2)
+	f["null"](2)
+	f["true"](2)
+	f["false"](2)
+	f["some"](2)
+
+	g.h["not"](2)
+	g.h["package"](2)
+	g.h["import"](2)
+	g.h["as"](2)
+	g.h["default"](2)
+	g.h["else"](2)
+	g.h["with"](2)
+	g.h["null"](2)
+	g.h["true"](2)
+	g.h["false"](2)
+	g.h["some"](2)
+
+	i["not"].j(2)
+	i["package"].j(2)
+	i["import"].j(2)
+	i["as"].j(2)
+	i["default"].j(2)
+	i["else"].j(2)
+	i["with"].j(2)
+	i["null"].j(2)
+	i["true"].j(2)
+	i["false"].j(2)
+	i["some"].j(2)
+}
+
+a["not"] := 1
+
+a["package"] := 1
+
+a["import"] := 1
+
+a["as"] := 1
+
+a["default"] := 1
+
+a["else"] := 1
+
+a["with"] := 1
+
+a["null"] := 1
+
+a["true"] := 1
+
+a["false"] := 1
+
+a["some"] := 1
+
+b.c["not"] := 1
+
+b.c["package"] := 1
+
+b.c["import"] := 1
+
+b.c["as"] := 1
+
+b.c["default"] := 1
+
+b.c["else"] := 1
+
+b.c["with"] := 1
+
+b.c["null"] := 1
+
+b.c["true"] := 1
+
+b.c["false"] := 1
+
+b.c["some"] := 1
+
+d["not"].e := 1
+
+d["package"].e := 1
+
+d["import"].e := 1
+
+d["as"].e := 1
+
+d["default"].e := 1
+
+d["else"].e := 1
+
+d["with"].e := 1
+
+d["null"].e := 1
+
+d["true"].e := 1
+
+d["false"].e := 1
+
+d["some"].e := 1
+
+f["not"](x) := x
+
+f["package"](x) := x
+
+f["import"](x) := x
+
+f["as"](x) := x
+
+f["default"](x) := x
+
+f["else"](x) := x
+
+f["with"](x) := x
+
+f["null"](x) := x
+
+f["true"](x) := x
+
+f["false"](x) := x
+
+f["some"](x) := x
+
+g.h["not"](x) := x
+
+g.h["package"](x) := x
+
+g.h["import"](x) := x
+
+g.h["as"](x) := x
+
+g.h["default"](x) := x
+
+g.h["else"](x) := x
+
+g.h["with"](x) := x
+
+g.h["null"](x) := x
+
+g.h["true"](x) := x
+
+g.h["false"](x) := x
+
+g.h["some"](x) := x
+
+i["not"].j(x) := x
+
+i["package"].j(x) := x
+
+i["import"].j(x) := x
+
+i["as"].j(x) := x
+
+i["default"].j(x) := x
+
+i["else"].j(x) := x
+
+i["with"].j(x) := x
+
+i["null"].j(x) := x
+
+i["true"].j(x) := x
+
+i["false"].j(x) := x
+
+i["some"].j(x) := x

--- a/v1/format/testfiles/v0_to_v1/keywords.rego
+++ b/v1/format/testfiles/v0_to_v1/keywords.rego
@@ -1,5 +1,6 @@
 package test.if.contains.in.every
 
 p {
-	data.if.contains.in.every == 42
+	data.if.contains.in.every == 1
+	data["if"]["contains"]["in"]["every"] == 2
 }

--- a/v1/format/testfiles/v0_to_v1/keywords.rego.formatted
+++ b/v1/format/testfiles/v0_to_v1/keywords.rego.formatted
@@ -1,7 +1,8 @@
-package test["if"]["contains"]["in"]["every"]
+package test.if.contains.in.every
 
 import rego.v1
 
 p if {
-	data["if"]["contains"]["in"]["every"] == 42
+	data.if.contains.in.every == 1
+	data["if"]["contains"]["in"]["every"] == 2
 }

--- a/v1/format/testfiles/v1/test_keywords_in_refs.rego
+++ b/v1/format/testfiles/v1/test_keywords_in_refs.rego
@@ -1,0 +1,195 @@
+package test.not.package.import.as.default.else.with.null.true.false.some.if.contains.in.every
+
+p if {
+	a.not == 1
+	a.package == 1
+	a.import == 1
+	a.as == 1
+	a.default == 1
+	a.else == 1
+	a.with == 1
+	a.null == 1
+	a.true == 1
+	a.false == 1
+	a.some == 1
+	a.if == 1
+	a.contains == 1
+	a.in == 1
+	a.every == 1
+
+	b.c.not == 1
+	b.c.package == 1
+	b.c.import == 1
+	b.c.as == 1
+	b.c.default == 1
+	b.c.else == 1
+	b.c.with == 1
+	b.c.null == 1
+	b.c.true == 1
+	b.c.false == 1
+	b.c.some == 1
+	b.c.if == 1
+	b.c.contains == 1
+	b.c.in == 1
+	b.c.every == 1
+
+	d.not.e == 1
+	d.package.e == 1
+	d.import.e == 1
+	d.as.e == 1
+	d.default.e == 1
+	d.else.e == 1
+	d.with.e == 1
+	d.null.e == 1
+	d.true.e == 1
+	d.false.e == 1
+	d.some.e == 1
+	d.if.e == 1
+	d.contains.e == 1
+	d.in.e == 1
+	d.every.e == 1
+
+	f.not(2)
+	f.package(2)
+	f.import(2)
+	f.as(2)
+	f.default(2)
+	f.else(2)
+	f.with(2)
+	f.null(2)
+	f.true(2)
+	f.false(2)
+	f.some(2)
+	f.if(2)
+	f.contains(2)
+	f.in(2)
+	f.every(2)
+
+	g.h.not(2)
+	g.h.package(2)
+	g.h.import(2)
+	g.h.as(2)
+	g.h.default(2)
+	g.h.else(2)
+	g.h.with(2)
+	g.h.null(2)
+	g.h.true(2)
+	g.h.false(2)
+	g.h.some(2)
+	g.h.if(2)
+	g.h.contains(2)
+	g.h.in(2)
+	g.h.every(2)
+
+	i.not.j(2)
+	i.package.j(2)
+	i.import.j(2)
+	i.as.j(2)
+	i.default.j(2)
+	i.else.j(2)
+	i.with.j(2)
+	i.null.j(2)
+	i.true.j(2)
+	i.false.j(2)
+	i.some.j(2)
+	i.if.j(2)
+	i.contains.j(2)
+	i.in.j(2)
+	i.every.j(2)
+}
+
+a.not := 1
+a.package := 1
+a.import := 1
+a.as := 1
+a.default := 1
+a.else := 1
+a.with := 1
+a.null := 1
+a.true := 1
+a.false := 1
+a.some := 1
+a.if := 1
+a.contains := 1
+a.in := 1
+a.every := 1
+
+b.c.not := 1
+b.c.package := 1
+b.c.import := 1
+b.c.as := 1
+b.c.default := 1
+b.c.else := 1
+b.c.with := 1
+b.c.null := 1
+b.c.true := 1
+b.c.false := 1
+b.c.some := 1
+b.c.if := 1
+b.c.contains := 1
+b.c.in := 1
+b.c.every := 1
+
+d.not.e := 1
+d.package.e := 1
+d.import.e := 1
+d.as.e := 1
+d.default.e := 1
+d.else.e := 1
+d.with.e := 1
+d.null.e := 1
+d.true.e := 1
+d.false.e := 1
+d.some.e := 1
+d.if.e := 1
+d.contains.e := 1
+d.in.e := 1
+d.every.e := 1
+
+f.not(x) := x
+f.package(x) := x
+f.import(x) := x
+f.as(x) := x
+f.default(x) := x
+f.else(x) := x
+f.with(x) := x
+f.null(x) := x
+f.true(x) := x
+f.false(x) := x
+f.some(x) := x
+f.if(x) := x
+f.contains(x) := x
+f.in(x) := x
+f.every(x) := x
+
+g.h.not(x) := x
+g.h.package(x) := x
+g.h.import(x) := x
+g.h.as(x) := x
+g.h.default(x) := x
+g.h.else(x) := x
+g.h.with(x) := x
+g.h.null(x) := x
+g.h.true(x) := x
+g.h.false(x) := x
+g.h.some(x) := x
+g.h.if(x) := x
+g.h.contains(x) := x
+g.h.in(x) := x
+g.h.every(x) := x
+
+i.not.j(x) := x
+i.package.j(x) := x
+i.import.j(x) := x
+i.as.j(x) := x
+i.default.j(x) := x
+i.else.j(x) := x
+i.with.j(x) := x
+i.null.j(x) := x
+i.true.j(x) := x
+i.false.j(x) := x
+i.some.j(x) := x
+i.if.j(x) := x
+i.contains.j(x) := x
+i.in.j(x) := x
+i.every.j(x) := x

--- a/v1/format/testfiles/v1/test_keywords_in_refs.rego.formatted
+++ b/v1/format/testfiles/v1/test_keywords_in_refs.rego.formatted
@@ -1,0 +1,195 @@
+package test.not.package.import.as.default.else.with.null.true.false.some.if.contains.in.every
+
+p if {
+	a.not == 1
+	a.package == 1
+	a.import == 1
+	a.as == 1
+	a.default == 1
+	a.else == 1
+	a.with == 1
+	a.null == 1
+	a.true == 1
+	a.false == 1
+	a.some == 1
+	a.if == 1
+	a.contains == 1
+	a.in == 1
+	a.every == 1
+
+	b.c.not == 1
+	b.c.package == 1
+	b.c.import == 1
+	b.c.as == 1
+	b.c.default == 1
+	b.c.else == 1
+	b.c.with == 1
+	b.c.null == 1
+	b.c.true == 1
+	b.c.false == 1
+	b.c.some == 1
+	b.c.if == 1
+	b.c.contains == 1
+	b.c.in == 1
+	b.c.every == 1
+
+	d.not.e == 1
+	d.package.e == 1
+	d.import.e == 1
+	d.as.e == 1
+	d.default.e == 1
+	d.else.e == 1
+	d.with.e == 1
+	d.null.e == 1
+	d.true.e == 1
+	d.false.e == 1
+	d.some.e == 1
+	d.if.e == 1
+	d.contains.e == 1
+	d.in.e == 1
+	d.every.e == 1
+
+	f.not(2)
+	f.package(2)
+	f.import(2)
+	f.as(2)
+	f.default(2)
+	f.else(2)
+	f.with(2)
+	f.null(2)
+	f.true(2)
+	f.false(2)
+	f.some(2)
+	f.if(2)
+	f.contains(2)
+	f.in(2)
+	f.every(2)
+
+	g.h.not(2)
+	g.h.package(2)
+	g.h.import(2)
+	g.h.as(2)
+	g.h.default(2)
+	g.h.else(2)
+	g.h.with(2)
+	g.h.null(2)
+	g.h.true(2)
+	g.h.false(2)
+	g.h.some(2)
+	g.h.if(2)
+	g.h.contains(2)
+	g.h.in(2)
+	g.h.every(2)
+
+	i.not.j(2)
+	i.package.j(2)
+	i.import.j(2)
+	i.as.j(2)
+	i.default.j(2)
+	i.else.j(2)
+	i.with.j(2)
+	i.null.j(2)
+	i.true.j(2)
+	i.false.j(2)
+	i.some.j(2)
+	i.if.j(2)
+	i.contains.j(2)
+	i.in.j(2)
+	i.every.j(2)
+}
+
+a.not := 1
+a.package := 1
+a.import := 1
+a.as := 1
+a.default := 1
+a.else := 1
+a.with := 1
+a.null := 1
+a.true := 1
+a.false := 1
+a.some := 1
+a.if := 1
+a.contains := 1
+a.in := 1
+a.every := 1
+
+b.c.not := 1
+b.c.package := 1
+b.c.import := 1
+b.c.as := 1
+b.c.default := 1
+b.c.else := 1
+b.c.with := 1
+b.c.null := 1
+b.c.true := 1
+b.c.false := 1
+b.c.some := 1
+b.c.if := 1
+b.c.contains := 1
+b.c.in := 1
+b.c.every := 1
+
+d.not.e := 1
+d.package.e := 1
+d.import.e := 1
+d.as.e := 1
+d.default.e := 1
+d.else.e := 1
+d.with.e := 1
+d.null.e := 1
+d.true.e := 1
+d.false.e := 1
+d.some.e := 1
+d.if.e := 1
+d.contains.e := 1
+d.in.e := 1
+d.every.e := 1
+
+f.not(x) := x
+f.package(x) := x
+f.import(x) := x
+f.as(x) := x
+f.default(x) := x
+f.else(x) := x
+f.with(x) := x
+f.null(x) := x
+f.true(x) := x
+f.false(x) := x
+f.some(x) := x
+f.if(x) := x
+f.contains(x) := x
+f.in(x) := x
+f.every(x) := x
+
+g.h.not(x) := x
+g.h.package(x) := x
+g.h.import(x) := x
+g.h.as(x) := x
+g.h.default(x) := x
+g.h.else(x) := x
+g.h.with(x) := x
+g.h.null(x) := x
+g.h.true(x) := x
+g.h.false(x) := x
+g.h.some(x) := x
+g.h.if(x) := x
+g.h.contains(x) := x
+g.h.in(x) := x
+g.h.every(x) := x
+
+i.not.j(x) := x
+i.package.j(x) := x
+i.import.j(x) := x
+i.as.j(x) := x
+i.default.j(x) := x
+i.else.j(x) := x
+i.with.j(x) := x
+i.null.j(x) := x
+i.true.j(x) := x
+i.false.j(x) := x
+i.some.j(x) := x
+i.if.j(x) := x
+i.contains.j(x) := x
+i.in.j(x) := x
+i.every.j(x) := x

--- a/v1/format/testfiles/v1/test_keywords_in_refs.rego.formatted_no_keywords_in_refs
+++ b/v1/format/testfiles/v1/test_keywords_in_refs.rego.formatted_no_keywords_in_refs
@@ -1,0 +1,195 @@
+package test["not"]["package"]["import"]["as"]["default"]["else"]["with"]["null"]["true"]["false"]["some"]["if"]["contains"]["in"]["every"]
+
+p if {
+	a["not"] == 1
+	a["package"] == 1
+	a["import"] == 1
+	a["as"] == 1
+	a["default"] == 1
+	a["else"] == 1
+	a["with"] == 1
+	a["null"] == 1
+	a["true"] == 1
+	a["false"] == 1
+	a["some"] == 1
+	a["if"] == 1
+	a["contains"] == 1
+	a["in"] == 1
+	a["every"] == 1
+
+	b.c["not"] == 1
+	b.c["package"] == 1
+	b.c["import"] == 1
+	b.c["as"] == 1
+	b.c["default"] == 1
+	b.c["else"] == 1
+	b.c["with"] == 1
+	b.c["null"] == 1
+	b.c["true"] == 1
+	b.c["false"] == 1
+	b.c["some"] == 1
+	b.c["if"] == 1
+	b.c["contains"] == 1
+	b.c["in"] == 1
+	b.c["every"] == 1
+
+	d["not"].e == 1
+	d["package"].e == 1
+	d["import"].e == 1
+	d["as"].e == 1
+	d["default"].e == 1
+	d["else"].e == 1
+	d["with"].e == 1
+	d["null"].e == 1
+	d["true"].e == 1
+	d["false"].e == 1
+	d["some"].e == 1
+	d["if"].e == 1
+	d["contains"].e == 1
+	d["in"].e == 1
+	d["every"].e == 1
+
+	f["not"](2)
+	f["package"](2)
+	f["import"](2)
+	f["as"](2)
+	f["default"](2)
+	f["else"](2)
+	f["with"](2)
+	f["null"](2)
+	f["true"](2)
+	f["false"](2)
+	f["some"](2)
+	f["if"](2)
+	f["contains"](2)
+	f["in"](2)
+	f["every"](2)
+
+	g.h["not"](2)
+	g.h["package"](2)
+	g.h["import"](2)
+	g.h["as"](2)
+	g.h["default"](2)
+	g.h["else"](2)
+	g.h["with"](2)
+	g.h["null"](2)
+	g.h["true"](2)
+	g.h["false"](2)
+	g.h["some"](2)
+	g.h["if"](2)
+	g.h["contains"](2)
+	g.h["in"](2)
+	g.h["every"](2)
+
+	i["not"].j(2)
+	i["package"].j(2)
+	i["import"].j(2)
+	i["as"].j(2)
+	i["default"].j(2)
+	i["else"].j(2)
+	i["with"].j(2)
+	i["null"].j(2)
+	i["true"].j(2)
+	i["false"].j(2)
+	i["some"].j(2)
+	i["if"].j(2)
+	i["contains"].j(2)
+	i["in"].j(2)
+	i["every"].j(2)
+}
+
+a["not"] := 1
+a["package"] := 1
+a["import"] := 1
+a["as"] := 1
+a["default"] := 1
+a["else"] := 1
+a["with"] := 1
+a["null"] := 1
+a["true"] := 1
+a["false"] := 1
+a["some"] := 1
+a["if"] := 1
+a["contains"] := 1
+a["in"] := 1
+a["every"] := 1
+
+b.c["not"] := 1
+b.c["package"] := 1
+b.c["import"] := 1
+b.c["as"] := 1
+b.c["default"] := 1
+b.c["else"] := 1
+b.c["with"] := 1
+b.c["null"] := 1
+b.c["true"] := 1
+b.c["false"] := 1
+b.c["some"] := 1
+b.c["if"] := 1
+b.c["contains"] := 1
+b.c["in"] := 1
+b.c["every"] := 1
+
+d["not"].e := 1
+d["package"].e := 1
+d["import"].e := 1
+d["as"].e := 1
+d["default"].e := 1
+d["else"].e := 1
+d["with"].e := 1
+d["null"].e := 1
+d["true"].e := 1
+d["false"].e := 1
+d["some"].e := 1
+d["if"].e := 1
+d["contains"].e := 1
+d["in"].e := 1
+d["every"].e := 1
+
+f["not"](x) := x
+f["package"](x) := x
+f["import"](x) := x
+f["as"](x) := x
+f["default"](x) := x
+f["else"](x) := x
+f["with"](x) := x
+f["null"](x) := x
+f["true"](x) := x
+f["false"](x) := x
+f["some"](x) := x
+f["if"](x) := x
+f["contains"](x) := x
+f["in"](x) := x
+f["every"](x) := x
+
+g.h["not"](x) := x
+g.h["package"](x) := x
+g.h["import"](x) := x
+g.h["as"](x) := x
+g.h["default"](x) := x
+g.h["else"](x) := x
+g.h["with"](x) := x
+g.h["null"](x) := x
+g.h["true"](x) := x
+g.h["false"](x) := x
+g.h["some"](x) := x
+g.h["if"](x) := x
+g.h["contains"](x) := x
+g.h["in"](x) := x
+g.h["every"](x) := x
+
+i["not"].j(x) := x
+i["package"].j(x) := x
+i["import"].j(x) := x
+i["as"].j(x) := x
+i["default"].j(x) := x
+i["else"].j(x) := x
+i["with"].j(x) := x
+i["null"].j(x) := x
+i["true"].j(x) := x
+i["false"].j(x) := x
+i["some"].j(x) := x
+i["if"].j(x) := x
+i["contains"].j(x) := x
+i["in"].j(x) := x
+i["every"].j(x) := x

--- a/v1/format/testfiles/v1/test_keywords_in_refs_keep_brackets.rego
+++ b/v1/format/testfiles/v1/test_keywords_in_refs_keep_brackets.rego
@@ -1,0 +1,195 @@
+package test["not"]["package"]["import"]["as"]["default"]["else"]["with"]["null"]["true"]["false"]["some"]["if"]["contains"]["in"]["every"]
+
+p if {
+	a["not"] == 1
+	a["package"] == 1
+	a["import"] == 1
+	a["as"] == 1
+	a["default"] == 1
+	a["else"] == 1
+	a["with"] == 1
+	a["null"] == 1
+	a["true"] == 1
+	a["false"] == 1
+	a["some"] == 1
+	a["if"] == 1
+	a["contains"] == 1
+	a["in"] == 1
+	a["every"] == 1
+
+	b.c["not"] == 1
+	b.c["package"] == 1
+	b.c["import"] == 1
+	b.c["as"] == 1
+	b.c["default"] == 1
+	b.c["else"] == 1
+	b.c["with"] == 1
+	b.c["null"] == 1
+	b.c["true"] == 1
+	b.c["false"] == 1
+	b.c["some"] == 1
+	b.c["if"] == 1
+	b.c["contains"] == 1
+	b.c["in"] == 1
+	b.c["every"] == 1
+
+	d["not"].e == 1
+	d["package"].e == 1
+	d["import"].e == 1
+	d["as"].e == 1
+	d["default"].e == 1
+	d["else"].e == 1
+	d["with"].e == 1
+	d["null"].e == 1
+	d["true"].e == 1
+	d["false"].e == 1
+	d["some"].e == 1
+	d["if"].e == 1
+	d["contains"].e == 1
+	d["in"].e == 1
+	d["every"].e == 1
+
+	f["not"](2)
+	f["package"](2)
+	f["import"](2)
+	f["as"](2)
+	f["default"](2)
+	f["else"](2)
+	f["with"](2)
+	f["null"](2)
+	f["true"](2)
+	f["false"](2)
+	f["some"](2)
+	f["if"](2)
+	f["contains"](2)
+	f["in"](2)
+	f["every"](2)
+
+	g.h["not"](2)
+	g.h["package"](2)
+	g.h["import"](2)
+	g.h["as"](2)
+	g.h["default"](2)
+	g.h["else"](2)
+	g.h["with"](2)
+	g.h["null"](2)
+	g.h["true"](2)
+	g.h["false"](2)
+	g.h["some"](2)
+	g.h["if"](2)
+	g.h["contains"](2)
+	g.h["in"](2)
+	g.h["every"](2)
+
+	i["not"].j(2)
+	i["package"].j(2)
+	i["import"].j(2)
+	i["as"].j(2)
+	i["default"].j(2)
+	i["else"].j(2)
+	i["with"].j(2)
+	i["null"].j(2)
+	i["true"].j(2)
+	i["false"].j(2)
+	i["some"].j(2)
+	i["if"].j(2)
+	i["contains"].j(2)
+	i["in"].j(2)
+	i["every"].j(2)
+}
+
+a["not"] := 1
+a["package"] := 1
+a["import"] := 1
+a["as"] := 1
+a["default"] := 1
+a["else"] := 1
+a["with"] := 1
+a["null"] := 1
+a["true"] := 1
+a["false"] := 1
+a["some"] := 1
+a["if"] := 1
+a["contains"] := 1
+a["in"] := 1
+a["every"] := 1
+
+b.c["not"] := 1
+b.c["package"] := 1
+b.c["import"] := 1
+b.c["as"] := 1
+b.c["default"] := 1
+b.c["else"] := 1
+b.c["with"] := 1
+b.c["null"] := 1
+b.c["true"] := 1
+b.c["false"] := 1
+b.c["some"] := 1
+b.c["if"] := 1
+b.c["contains"] := 1
+b.c["in"] := 1
+b.c["every"] := 1
+
+d["not"].e := 1
+d["package"].e := 1
+d["import"].e := 1
+d["as"].e := 1
+d["default"].e := 1
+d["else"].e := 1
+d["with"].e := 1
+d["null"].e := 1
+d["true"].e := 1
+d["false"].e := 1
+d["some"].e := 1
+d["if"].e := 1
+d["contains"].e := 1
+d["in"].e := 1
+d["every"].e := 1
+
+f["not"](x) := x
+f["package"](x) := x
+f["import"](x) := x
+f["as"](x) := x
+f["default"](x) := x
+f["else"](x) := x
+f["with"](x) := x
+f["null"](x) := x
+f["true"](x) := x
+f["false"](x) := x
+f["some"](x) := x
+f["if"](x) := x
+f["contains"](x) := x
+f["in"](x) := x
+f["every"](x) := x
+
+g.h["not"](x) := x
+g.h["package"](x) := x
+g.h["import"](x) := x
+g.h["as"](x) := x
+g.h["default"](x) := x
+g.h["else"](x) := x
+g.h["with"](x) := x
+g.h["null"](x) := x
+g.h["true"](x) := x
+g.h["false"](x) := x
+g.h["some"](x) := x
+g.h["if"](x) := x
+g.h["contains"](x) := x
+g.h["in"](x) := x
+g.h["every"](x) := x
+
+i["not"].j(x) := x
+i["package"].j(x) := x
+i["import"].j(x) := x
+i["as"].j(x) := x
+i["default"].j(x) := x
+i["else"].j(x) := x
+i["with"].j(x) := x
+i["null"].j(x) := x
+i["true"].j(x) := x
+i["false"].j(x) := x
+i["some"].j(x) := x
+i["if"].j(x) := x
+i["contains"].j(x) := x
+i["in"].j(x) := x
+i["every"].j(x) := x

--- a/v1/format/testfiles/v1/test_keywords_in_refs_keep_brackets.rego.formatted
+++ b/v1/format/testfiles/v1/test_keywords_in_refs_keep_brackets.rego.formatted
@@ -1,0 +1,195 @@
+package test["not"]["package"]["import"]["as"]["default"]["else"]["with"]["null"]["true"]["false"]["some"]["if"]["contains"]["in"]["every"]
+
+p if {
+	a["not"] == 1
+	a["package"] == 1
+	a["import"] == 1
+	a["as"] == 1
+	a["default"] == 1
+	a["else"] == 1
+	a["with"] == 1
+	a["null"] == 1
+	a["true"] == 1
+	a["false"] == 1
+	a["some"] == 1
+	a["if"] == 1
+	a["contains"] == 1
+	a["in"] == 1
+	a["every"] == 1
+
+	b.c["not"] == 1
+	b.c["package"] == 1
+	b.c["import"] == 1
+	b.c["as"] == 1
+	b.c["default"] == 1
+	b.c["else"] == 1
+	b.c["with"] == 1
+	b.c["null"] == 1
+	b.c["true"] == 1
+	b.c["false"] == 1
+	b.c["some"] == 1
+	b.c["if"] == 1
+	b.c["contains"] == 1
+	b.c["in"] == 1
+	b.c["every"] == 1
+
+	d["not"].e == 1
+	d["package"].e == 1
+	d["import"].e == 1
+	d["as"].e == 1
+	d["default"].e == 1
+	d["else"].e == 1
+	d["with"].e == 1
+	d["null"].e == 1
+	d["true"].e == 1
+	d["false"].e == 1
+	d["some"].e == 1
+	d["if"].e == 1
+	d["contains"].e == 1
+	d["in"].e == 1
+	d["every"].e == 1
+
+	f["not"](2)
+	f["package"](2)
+	f["import"](2)
+	f["as"](2)
+	f["default"](2)
+	f["else"](2)
+	f["with"](2)
+	f["null"](2)
+	f["true"](2)
+	f["false"](2)
+	f["some"](2)
+	f["if"](2)
+	f["contains"](2)
+	f["in"](2)
+	f["every"](2)
+
+	g.h["not"](2)
+	g.h["package"](2)
+	g.h["import"](2)
+	g.h["as"](2)
+	g.h["default"](2)
+	g.h["else"](2)
+	g.h["with"](2)
+	g.h["null"](2)
+	g.h["true"](2)
+	g.h["false"](2)
+	g.h["some"](2)
+	g.h["if"](2)
+	g.h["contains"](2)
+	g.h["in"](2)
+	g.h["every"](2)
+
+	i["not"].j(2)
+	i["package"].j(2)
+	i["import"].j(2)
+	i["as"].j(2)
+	i["default"].j(2)
+	i["else"].j(2)
+	i["with"].j(2)
+	i["null"].j(2)
+	i["true"].j(2)
+	i["false"].j(2)
+	i["some"].j(2)
+	i["if"].j(2)
+	i["contains"].j(2)
+	i["in"].j(2)
+	i["every"].j(2)
+}
+
+a["not"] := 1
+a["package"] := 1
+a["import"] := 1
+a["as"] := 1
+a["default"] := 1
+a["else"] := 1
+a["with"] := 1
+a["null"] := 1
+a["true"] := 1
+a["false"] := 1
+a["some"] := 1
+a["if"] := 1
+a["contains"] := 1
+a["in"] := 1
+a["every"] := 1
+
+b.c["not"] := 1
+b.c["package"] := 1
+b.c["import"] := 1
+b.c["as"] := 1
+b.c["default"] := 1
+b.c["else"] := 1
+b.c["with"] := 1
+b.c["null"] := 1
+b.c["true"] := 1
+b.c["false"] := 1
+b.c["some"] := 1
+b.c["if"] := 1
+b.c["contains"] := 1
+b.c["in"] := 1
+b.c["every"] := 1
+
+d["not"].e := 1
+d["package"].e := 1
+d["import"].e := 1
+d["as"].e := 1
+d["default"].e := 1
+d["else"].e := 1
+d["with"].e := 1
+d["null"].e := 1
+d["true"].e := 1
+d["false"].e := 1
+d["some"].e := 1
+d["if"].e := 1
+d["contains"].e := 1
+d["in"].e := 1
+d["every"].e := 1
+
+f["not"](x) := x
+f["package"](x) := x
+f["import"](x) := x
+f["as"](x) := x
+f["default"](x) := x
+f["else"](x) := x
+f["with"](x) := x
+f["null"](x) := x
+f["true"](x) := x
+f["false"](x) := x
+f["some"](x) := x
+f["if"](x) := x
+f["contains"](x) := x
+f["in"](x) := x
+f["every"](x) := x
+
+g.h["not"](x) := x
+g.h["package"](x) := x
+g.h["import"](x) := x
+g.h["as"](x) := x
+g.h["default"](x) := x
+g.h["else"](x) := x
+g.h["with"](x) := x
+g.h["null"](x) := x
+g.h["true"](x) := x
+g.h["false"](x) := x
+g.h["some"](x) := x
+g.h["if"](x) := x
+g.h["contains"](x) := x
+g.h["in"](x) := x
+g.h["every"](x) := x
+
+i["not"].j(x) := x
+i["package"].j(x) := x
+i["import"].j(x) := x
+i["as"].j(x) := x
+i["default"].j(x) := x
+i["else"].j(x) := x
+i["with"].j(x) := x
+i["null"].j(x) := x
+i["true"].j(x) := x
+i["false"].j(x) := x
+i["some"].j(x) := x
+i["if"].j(x) := x
+i["contains"].j(x) := x
+i["in"].j(x) := x
+i["every"].j(x) := x

--- a/v1/test/cases/internal/keywordrefs/main.go
+++ b/v1/test/cases/internal/keywordrefs/main.go
@@ -1,0 +1,65 @@
+// Copyright 2025 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/open-policy-agent/opa/v1/ast"
+)
+
+//go:generate go run main.go
+
+func main() {
+	templateFile := "test-keywords-in-ref_v0.yaml.template"
+	templateContent, err := os.ReadFile(templateFile)
+	if err != nil {
+		fmt.Printf("Error reading v0 template file: %v\n", err)
+		os.Exit(1)
+	}
+
+	err = generate(ast.KeywordsV0[:], "../../testdata/v0/keywordrefs", string(templateContent))
+	if err != nil {
+		fmt.Printf("Error:%v\n", err)
+		os.Exit(1)
+	}
+
+	templateFile = "test-keywords-in-ref_v1.yaml.template"
+	templateContent, err = os.ReadFile(templateFile)
+	if err != nil {
+		fmt.Printf("Error reading v1 template file: %v\n", err)
+		os.Exit(1)
+	}
+
+	err = generate(ast.KeywordsV1[:], "../../testdata/v1/keywordrefs", string(templateContent))
+	if err != nil {
+		fmt.Printf("Error:%v\n", err)
+		os.Exit(1)
+	}
+}
+
+func generate(keywords []string, root string, template string) error {
+	err := os.MkdirAll(root, os.ModePerm)
+	if err != nil {
+		return fmt.Errorf("error creating directory %s: %v\n", root, err)
+	}
+
+	// Generate a YAML file for each keyword
+	for _, keyword := range keywords {
+		file := fmt.Sprintf("%s/test-keyword-%s.yaml", root, keyword)
+
+		outputContent := strings.ReplaceAll(template, "%{KW}", keyword)
+
+		err := os.WriteFile(file, []byte(outputContent), 0644)
+		if err != nil {
+			return fmt.Errorf("error writing file %s: %v\n", file, err)
+		}
+		fmt.Printf("Generated file: %s\n", file)
+	}
+
+	return nil
+}

--- a/v1/test/cases/internal/keywordrefs/test-keywords-in-ref_v0.yaml.template
+++ b/v1/test/cases/internal/keywordrefs/test-keywords-in-ref_v0.yaml.template
@@ -164,3 +164,37 @@ cases:
         }
     want_result:
       - x: true
+  - note: keywordrefs/%{KW} keyword function refhead
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p {
+          %{KW}.foo(1) == 1
+          %{KW}.foo(11) == 42
+          foo.%{KW}(1) == 1
+          foo.%{KW}(11) == 42
+          bar.%{KW}.baz(1) == 1
+          bar.%{KW}.baz(11) == 42
+        }
+
+        default %{KW}.foo(_) := 42
+
+        %{KW}.foo(x) := x {
+          x < 10
+        }
+
+        default foo.%{KW}(_) := 42
+
+        foo.%{KW}(x) := x {
+          x < 10
+        }
+
+        default bar.%{KW}.baz(_) := 42
+
+        bar.%{KW}.baz(x) := x {
+          x < 10
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/internal/keywordrefs/test-keywords-in-ref_v0.yaml.template
+++ b/v1/test/cases/internal/keywordrefs/test-keywords-in-ref_v0.yaml.template
@@ -109,3 +109,58 @@ cases:
         }
     want_result:
       - x: true
+  - note: keywordrefs/%{KW} keyword rule refhead, partial object
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p {
+          %{KW}.foo == "a"
+          %{KW}.bar.one == "a"
+          %{KW}.bar.three == "c"
+          foo.%{KW} == "a"
+          bar.baz.%{KW} == "a"
+        }
+
+        %{KW}.foo := "a"
+
+        %{KW}.foo := "b" {
+          false
+        }
+
+        %{KW}.foo := "c" {
+          false
+        }
+
+        %{KW}.bar.one := "a"
+
+        %{KW}.bar.two := "b" {
+          false
+        }
+
+        %{KW}.bar.three := "c" {
+          true
+        }
+
+        foo.%{KW} := "a"
+
+        foo.%{KW} := "b" {
+          false
+        }
+
+        foo.%{KW} := "c" {
+          false
+        }
+
+        bar.baz.%{KW} := "a"
+
+        bar.baz.%{KW} := "b" {
+          false
+        }
+
+        bar.baz.%{KW} := "c" {
+          false
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/internal/keywordrefs/test-keywords-in-ref_v0.yaml.template
+++ b/v1/test/cases/internal/keywordrefs/test-keywords-in-ref_v0.yaml.template
@@ -1,0 +1,52 @@
+---
+cases:
+  - note: keywordrefs/%{KW} keyword in package
+    query: data.foo.p = x
+    modules:
+      - |
+        package foo.%{KW}.bar
+
+        baz := 42
+      - |
+        package foo
+        import data.foo.%{KW}.bar
+        
+        p {
+          bar.baz == 42
+          data.foo.%{KW}.bar.baz == 42
+        }
+    want_result:
+      - x: true
+  - note: keywordrefs/%{KW} keyword in package, import alias
+    query: data.foo.p = x
+    modules:
+      - |
+        package foo.%{KW}
+
+        bar := 42
+      - |
+        package foo
+        import data.foo.%{KW} as my_if
+        
+        p {
+          my_if.bar == 42
+          data.foo.%{KW}.bar == 42
+        }
+    want_result:
+      - x: true
+  - note: keywordrefs/%{KW} keyword rule refhead
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+        
+        p {
+          %{KW}.foo == 1
+          foo.%{KW} == 2
+        }
+        
+        %{KW}.foo := 1
+        
+        foo.%{KW} := 2
+    want_result:
+      - x: true

--- a/v1/test/cases/internal/keywordrefs/test-keywords-in-ref_v0.yaml.template
+++ b/v1/test/cases/internal/keywordrefs/test-keywords-in-ref_v0.yaml.template
@@ -50,3 +50,62 @@ cases:
         foo.%{KW} := 2
     want_result:
       - x: true
+  - note: keywordrefs/%{KW} keyword rule refhead, else bodies
+    query: data.test.p = x
+    input:
+      x: 3
+    modules:
+      - |
+        package test
+
+        p {
+          %{KW}.foo.bar == 3
+          foo.bar.%{KW} == 6
+        }
+
+        %{KW}.foo.bar := 1 {
+          input.x == 1
+        } else := 2 {
+          input.x == 2
+        } else := 3
+
+        foo.bar.%{KW} := 4 {
+          input.x == 1
+        } else := 5 {
+          input.x == 2
+        } else := 6
+    want_result:
+      - x: true
+  - note: keywordrefs/%{KW} keyword rule refhead, partial set
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+        import future.keywords.contains
+
+        p {
+          %{KW}.foo.bar == {"a", "c"}
+          foo.bar.%{KW} == {"a", "c"}
+        }
+
+        %{KW}.foo.bar contains "a"
+
+        %{KW}.foo.bar contains "b" {
+          false
+        }
+
+        %{KW}.foo.bar contains "c" {
+          true
+        }
+
+        foo.bar.%{KW} contains "a"
+
+        foo.bar.%{KW} contains "b" {
+          false
+        }
+
+        foo.bar.%{KW} contains "c" {
+          true
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/internal/keywordrefs/test-keywords-in-ref_v1.yaml.template
+++ b/v1/test/cases/internal/keywordrefs/test-keywords-in-ref_v1.yaml.template
@@ -108,3 +108,58 @@ cases:
         }
     want_result:
       - x: true
+  - note: keywordrefs/%{KW} keyword rule refhead, partial object
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p if {
+          %{KW}.foo == "a"
+          %{KW}.bar.one == "a"
+          %{KW}.bar.three == "c"
+          foo.%{KW} == "a"
+          bar.baz.%{KW} == "a"
+        }
+
+        %{KW}.foo := "a"
+
+        %{KW}.foo := "b" if {
+          false
+        }
+
+        %{KW}.foo := "c" if {
+          false
+        }
+
+        %{KW}.bar.one := "a"
+
+        %{KW}.bar.two := "b" if {
+          false
+        }
+
+        %{KW}.bar.three := "c" if {
+          true
+        }
+
+        foo.%{KW} := "a"
+
+        foo.%{KW} := "b" if {
+          false
+        }
+
+        foo.%{KW} := "c" if {
+          false
+        }
+
+        bar.baz.%{KW} := "a"
+
+        bar.baz.%{KW} := "b" if {
+          false
+        }
+
+        bar.baz.%{KW} := "c" if {
+          false
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/internal/keywordrefs/test-keywords-in-ref_v1.yaml.template
+++ b/v1/test/cases/internal/keywordrefs/test-keywords-in-ref_v1.yaml.template
@@ -1,0 +1,52 @@
+---
+cases:
+  - note: keywordrefs/%{KW} keyword in package
+    query: data.foo.p = x
+    modules:
+      - |
+        package foo.%{KW}.bar
+
+        baz := 42
+      - |
+        package foo
+        import data.foo.%{KW}.bar
+        
+        p if {
+          bar.baz == 42
+          data.foo.%{KW}.bar.baz == 42
+        }
+    want_result:
+      - x: true
+  - note: keywordrefs/%{KW} keyword in package, import alias
+    query: data.foo.p = x
+    modules:
+      - |
+        package foo.%{KW}
+
+        bar := 42
+      - |
+        package foo
+        import data.foo.%{KW} as my_if
+        
+        p if {
+          my_if.bar == 42
+          data.foo.%{KW}.bar == 42
+        }
+    want_result:
+      - x: true
+  - note: keywordrefs/%{KW} keyword rule refhead
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+        
+        p if {
+          %{KW}.foo == 1
+          foo.%{KW} == 2
+        }
+        
+        %{KW}.foo := 1
+        
+        foo.%{KW} := 2
+    want_result:
+      - x: true

--- a/v1/test/cases/internal/keywordrefs/test-keywords-in-ref_v1.yaml.template
+++ b/v1/test/cases/internal/keywordrefs/test-keywords-in-ref_v1.yaml.template
@@ -50,3 +50,61 @@ cases:
         foo.%{KW} := 2
     want_result:
       - x: true
+  - note: keywordrefs/%{KW} keyword rule refhead, else bodies
+    query: data.test.p = x
+    input:
+      x: 3
+    modules:
+      - |
+        package test
+
+        p if {
+          %{KW}.foo == 3
+          foo.%{KW} == 6
+        }
+
+        %{KW}.foo := 1 if {
+          input.x == 1
+        } else := 2 if {
+          input.x == 2
+        } else := 3
+
+        foo.%{KW} := 4 if {
+          input.x == 1
+        } else := 5 if {
+          input.x == 2
+        } else := 6
+    want_result:
+      - x: true
+  - note: keywordrefs/%{KW} keyword rule refhead, partial set
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p if {
+          %{KW}.foo == {"a", "c"}
+          foo.%{KW} == {"a", "c"}
+        }
+
+        %{KW}.foo contains "a"
+
+        %{KW}.foo contains "b" if {
+          false
+        }
+
+        %{KW}.foo contains "c" if {
+          true
+        }
+
+        foo.%{KW} contains "a"
+
+        foo.%{KW} contains "b" if {
+          false
+        }
+
+        foo.%{KW} contains "c" if {
+          true
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/internal/keywordrefs/test-keywords-in-ref_v1.yaml.template
+++ b/v1/test/cases/internal/keywordrefs/test-keywords-in-ref_v1.yaml.template
@@ -163,3 +163,37 @@ cases:
         }
     want_result:
       - x: true
+  - note: keywordrefs/%{KW} keyword function refhead
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p if {
+          %{KW}.foo(1) == 1
+          %{KW}.foo(11) == 42
+          foo.%{KW}(1) == 1
+          foo.%{KW}(11) == 42
+          bar.%{KW}.baz(1) == 1
+          bar.%{KW}.baz(11) == 42
+        }
+
+        default %{KW}.foo(_) := 42
+
+        %{KW}.foo(x) := x if {
+          x < 10
+        }
+
+        default foo.%{KW}(_) := 42
+
+        foo.%{KW}(x) := x if {
+          x < 10
+        }
+
+        default bar.%{KW}.baz(_) := 42
+
+        bar.%{KW}.baz(x) := x if {
+          x < 10
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v0/keywordrefs/test-keyword-as.yaml
+++ b/v1/test/cases/testdata/v0/keywordrefs/test-keyword-as.yaml
@@ -1,0 +1,52 @@
+---
+cases:
+  - note: keywordrefs/as keyword in package
+    query: data.foo.p = x
+    modules:
+      - |
+        package foo.as.bar
+
+        baz := 42
+      - |
+        package foo
+        import data.foo.as.bar
+        
+        p {
+          bar.baz == 42
+          data.foo.as.bar.baz == 42
+        }
+    want_result:
+      - x: true
+  - note: keywordrefs/as keyword in package, import alias
+    query: data.foo.p = x
+    modules:
+      - |
+        package foo.as
+
+        bar := 42
+      - |
+        package foo
+        import data.foo.as as my_if
+        
+        p {
+          my_if.bar == 42
+          data.foo.as.bar == 42
+        }
+    want_result:
+      - x: true
+  - note: keywordrefs/as keyword rule refhead
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+        
+        p {
+          as.foo == 1
+          foo.as == 2
+        }
+        
+        as.foo := 1
+        
+        foo.as := 2
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v0/keywordrefs/test-keyword-as.yaml
+++ b/v1/test/cases/testdata/v0/keywordrefs/test-keyword-as.yaml
@@ -164,3 +164,37 @@ cases:
         }
     want_result:
       - x: true
+  - note: keywordrefs/as keyword function refhead
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p {
+          as.foo(1) == 1
+          as.foo(11) == 42
+          foo.as(1) == 1
+          foo.as(11) == 42
+          bar.as.baz(1) == 1
+          bar.as.baz(11) == 42
+        }
+
+        default as.foo(_) := 42
+
+        as.foo(x) := x {
+          x < 10
+        }
+
+        default foo.as(_) := 42
+
+        foo.as(x) := x {
+          x < 10
+        }
+
+        default bar.as.baz(_) := 42
+
+        bar.as.baz(x) := x {
+          x < 10
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v0/keywordrefs/test-keyword-as.yaml
+++ b/v1/test/cases/testdata/v0/keywordrefs/test-keyword-as.yaml
@@ -50,3 +50,62 @@ cases:
         foo.as := 2
     want_result:
       - x: true
+  - note: keywordrefs/as keyword rule refhead, else bodies
+    query: data.test.p = x
+    input:
+      x: 3
+    modules:
+      - |
+        package test
+
+        p {
+          as.foo.bar == 3
+          foo.bar.as == 6
+        }
+
+        as.foo.bar := 1 {
+          input.x == 1
+        } else := 2 {
+          input.x == 2
+        } else := 3
+
+        foo.bar.as := 4 {
+          input.x == 1
+        } else := 5 {
+          input.x == 2
+        } else := 6
+    want_result:
+      - x: true
+  - note: keywordrefs/as keyword rule refhead, partial set
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+        import future.keywords.contains
+
+        p {
+          as.foo.bar == {"a", "c"}
+          foo.bar.as == {"a", "c"}
+        }
+
+        as.foo.bar contains "a"
+
+        as.foo.bar contains "b" {
+          false
+        }
+
+        as.foo.bar contains "c" {
+          true
+        }
+
+        foo.bar.as contains "a"
+
+        foo.bar.as contains "b" {
+          false
+        }
+
+        foo.bar.as contains "c" {
+          true
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v0/keywordrefs/test-keyword-as.yaml
+++ b/v1/test/cases/testdata/v0/keywordrefs/test-keyword-as.yaml
@@ -109,3 +109,58 @@ cases:
         }
     want_result:
       - x: true
+  - note: keywordrefs/as keyword rule refhead, partial object
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p {
+          as.foo == "a"
+          as.bar.one == "a"
+          as.bar.three == "c"
+          foo.as == "a"
+          bar.baz.as == "a"
+        }
+
+        as.foo := "a"
+
+        as.foo := "b" {
+          false
+        }
+
+        as.foo := "c" {
+          false
+        }
+
+        as.bar.one := "a"
+
+        as.bar.two := "b" {
+          false
+        }
+
+        as.bar.three := "c" {
+          true
+        }
+
+        foo.as := "a"
+
+        foo.as := "b" {
+          false
+        }
+
+        foo.as := "c" {
+          false
+        }
+
+        bar.baz.as := "a"
+
+        bar.baz.as := "b" {
+          false
+        }
+
+        bar.baz.as := "c" {
+          false
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v0/keywordrefs/test-keyword-default.yaml
+++ b/v1/test/cases/testdata/v0/keywordrefs/test-keyword-default.yaml
@@ -109,3 +109,58 @@ cases:
         }
     want_result:
       - x: true
+  - note: keywordrefs/default keyword rule refhead, partial object
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p {
+          default.foo == "a"
+          default.bar.one == "a"
+          default.bar.three == "c"
+          foo.default == "a"
+          bar.baz.default == "a"
+        }
+
+        default.foo := "a"
+
+        default.foo := "b" {
+          false
+        }
+
+        default.foo := "c" {
+          false
+        }
+
+        default.bar.one := "a"
+
+        default.bar.two := "b" {
+          false
+        }
+
+        default.bar.three := "c" {
+          true
+        }
+
+        foo.default := "a"
+
+        foo.default := "b" {
+          false
+        }
+
+        foo.default := "c" {
+          false
+        }
+
+        bar.baz.default := "a"
+
+        bar.baz.default := "b" {
+          false
+        }
+
+        bar.baz.default := "c" {
+          false
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v0/keywordrefs/test-keyword-default.yaml
+++ b/v1/test/cases/testdata/v0/keywordrefs/test-keyword-default.yaml
@@ -50,3 +50,62 @@ cases:
         foo.default := 2
     want_result:
       - x: true
+  - note: keywordrefs/default keyword rule refhead, else bodies
+    query: data.test.p = x
+    input:
+      x: 3
+    modules:
+      - |
+        package test
+
+        p {
+          default.foo.bar == 3
+          foo.bar.default == 6
+        }
+
+        default.foo.bar := 1 {
+          input.x == 1
+        } else := 2 {
+          input.x == 2
+        } else := 3
+
+        foo.bar.default := 4 {
+          input.x == 1
+        } else := 5 {
+          input.x == 2
+        } else := 6
+    want_result:
+      - x: true
+  - note: keywordrefs/default keyword rule refhead, partial set
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+        import future.keywords.contains
+
+        p {
+          default.foo.bar == {"a", "c"}
+          foo.bar.default == {"a", "c"}
+        }
+
+        default.foo.bar contains "a"
+
+        default.foo.bar contains "b" {
+          false
+        }
+
+        default.foo.bar contains "c" {
+          true
+        }
+
+        foo.bar.default contains "a"
+
+        foo.bar.default contains "b" {
+          false
+        }
+
+        foo.bar.default contains "c" {
+          true
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v0/keywordrefs/test-keyword-default.yaml
+++ b/v1/test/cases/testdata/v0/keywordrefs/test-keyword-default.yaml
@@ -164,3 +164,37 @@ cases:
         }
     want_result:
       - x: true
+  - note: keywordrefs/default keyword function refhead
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p {
+          default.foo(1) == 1
+          default.foo(11) == 42
+          foo.default(1) == 1
+          foo.default(11) == 42
+          bar.default.baz(1) == 1
+          bar.default.baz(11) == 42
+        }
+
+        default default.foo(_) := 42
+
+        default.foo(x) := x {
+          x < 10
+        }
+
+        default foo.default(_) := 42
+
+        foo.default(x) := x {
+          x < 10
+        }
+
+        default bar.default.baz(_) := 42
+
+        bar.default.baz(x) := x {
+          x < 10
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v0/keywordrefs/test-keyword-default.yaml
+++ b/v1/test/cases/testdata/v0/keywordrefs/test-keyword-default.yaml
@@ -1,0 +1,52 @@
+---
+cases:
+  - note: keywordrefs/default keyword in package
+    query: data.foo.p = x
+    modules:
+      - |
+        package foo.default.bar
+
+        baz := 42
+      - |
+        package foo
+        import data.foo.default.bar
+        
+        p {
+          bar.baz == 42
+          data.foo.default.bar.baz == 42
+        }
+    want_result:
+      - x: true
+  - note: keywordrefs/default keyword in package, import alias
+    query: data.foo.p = x
+    modules:
+      - |
+        package foo.default
+
+        bar := 42
+      - |
+        package foo
+        import data.foo.default as my_if
+        
+        p {
+          my_if.bar == 42
+          data.foo.default.bar == 42
+        }
+    want_result:
+      - x: true
+  - note: keywordrefs/default keyword rule refhead
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+        
+        p {
+          default.foo == 1
+          foo.default == 2
+        }
+        
+        default.foo := 1
+        
+        foo.default := 2
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v0/keywordrefs/test-keyword-else.yaml
+++ b/v1/test/cases/testdata/v0/keywordrefs/test-keyword-else.yaml
@@ -164,3 +164,37 @@ cases:
         }
     want_result:
       - x: true
+  - note: keywordrefs/else keyword function refhead
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p {
+          else.foo(1) == 1
+          else.foo(11) == 42
+          foo.else(1) == 1
+          foo.else(11) == 42
+          bar.else.baz(1) == 1
+          bar.else.baz(11) == 42
+        }
+
+        default else.foo(_) := 42
+
+        else.foo(x) := x {
+          x < 10
+        }
+
+        default foo.else(_) := 42
+
+        foo.else(x) := x {
+          x < 10
+        }
+
+        default bar.else.baz(_) := 42
+
+        bar.else.baz(x) := x {
+          x < 10
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v0/keywordrefs/test-keyword-else.yaml
+++ b/v1/test/cases/testdata/v0/keywordrefs/test-keyword-else.yaml
@@ -1,0 +1,52 @@
+---
+cases:
+  - note: keywordrefs/else keyword in package
+    query: data.foo.p = x
+    modules:
+      - |
+        package foo.else.bar
+
+        baz := 42
+      - |
+        package foo
+        import data.foo.else.bar
+        
+        p {
+          bar.baz == 42
+          data.foo.else.bar.baz == 42
+        }
+    want_result:
+      - x: true
+  - note: keywordrefs/else keyword in package, import alias
+    query: data.foo.p = x
+    modules:
+      - |
+        package foo.else
+
+        bar := 42
+      - |
+        package foo
+        import data.foo.else as my_if
+        
+        p {
+          my_if.bar == 42
+          data.foo.else.bar == 42
+        }
+    want_result:
+      - x: true
+  - note: keywordrefs/else keyword rule refhead
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+        
+        p {
+          else.foo == 1
+          foo.else == 2
+        }
+        
+        else.foo := 1
+        
+        foo.else := 2
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v0/keywordrefs/test-keyword-else.yaml
+++ b/v1/test/cases/testdata/v0/keywordrefs/test-keyword-else.yaml
@@ -109,3 +109,58 @@ cases:
         }
     want_result:
       - x: true
+  - note: keywordrefs/else keyword rule refhead, partial object
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p {
+          else.foo == "a"
+          else.bar.one == "a"
+          else.bar.three == "c"
+          foo.else == "a"
+          bar.baz.else == "a"
+        }
+
+        else.foo := "a"
+
+        else.foo := "b" {
+          false
+        }
+
+        else.foo := "c" {
+          false
+        }
+
+        else.bar.one := "a"
+
+        else.bar.two := "b" {
+          false
+        }
+
+        else.bar.three := "c" {
+          true
+        }
+
+        foo.else := "a"
+
+        foo.else := "b" {
+          false
+        }
+
+        foo.else := "c" {
+          false
+        }
+
+        bar.baz.else := "a"
+
+        bar.baz.else := "b" {
+          false
+        }
+
+        bar.baz.else := "c" {
+          false
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v0/keywordrefs/test-keyword-else.yaml
+++ b/v1/test/cases/testdata/v0/keywordrefs/test-keyword-else.yaml
@@ -50,3 +50,62 @@ cases:
         foo.else := 2
     want_result:
       - x: true
+  - note: keywordrefs/else keyword rule refhead, else bodies
+    query: data.test.p = x
+    input:
+      x: 3
+    modules:
+      - |
+        package test
+
+        p {
+          else.foo.bar == 3
+          foo.bar.else == 6
+        }
+
+        else.foo.bar := 1 {
+          input.x == 1
+        } else := 2 {
+          input.x == 2
+        } else := 3
+
+        foo.bar.else := 4 {
+          input.x == 1
+        } else := 5 {
+          input.x == 2
+        } else := 6
+    want_result:
+      - x: true
+  - note: keywordrefs/else keyword rule refhead, partial set
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+        import future.keywords.contains
+
+        p {
+          else.foo.bar == {"a", "c"}
+          foo.bar.else == {"a", "c"}
+        }
+
+        else.foo.bar contains "a"
+
+        else.foo.bar contains "b" {
+          false
+        }
+
+        else.foo.bar contains "c" {
+          true
+        }
+
+        foo.bar.else contains "a"
+
+        foo.bar.else contains "b" {
+          false
+        }
+
+        foo.bar.else contains "c" {
+          true
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v0/keywordrefs/test-keyword-false.yaml
+++ b/v1/test/cases/testdata/v0/keywordrefs/test-keyword-false.yaml
@@ -1,0 +1,52 @@
+---
+cases:
+  - note: keywordrefs/false keyword in package
+    query: data.foo.p = x
+    modules:
+      - |
+        package foo.false.bar
+
+        baz := 42
+      - |
+        package foo
+        import data.foo.false.bar
+        
+        p {
+          bar.baz == 42
+          data.foo.false.bar.baz == 42
+        }
+    want_result:
+      - x: true
+  - note: keywordrefs/false keyword in package, import alias
+    query: data.foo.p = x
+    modules:
+      - |
+        package foo.false
+
+        bar := 42
+      - |
+        package foo
+        import data.foo.false as my_if
+        
+        p {
+          my_if.bar == 42
+          data.foo.false.bar == 42
+        }
+    want_result:
+      - x: true
+  - note: keywordrefs/false keyword rule refhead
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+        
+        p {
+          false.foo == 1
+          foo.false == 2
+        }
+        
+        false.foo := 1
+        
+        foo.false := 2
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v0/keywordrefs/test-keyword-false.yaml
+++ b/v1/test/cases/testdata/v0/keywordrefs/test-keyword-false.yaml
@@ -50,3 +50,62 @@ cases:
         foo.false := 2
     want_result:
       - x: true
+  - note: keywordrefs/false keyword rule refhead, else bodies
+    query: data.test.p = x
+    input:
+      x: 3
+    modules:
+      - |
+        package test
+
+        p {
+          false.foo.bar == 3
+          foo.bar.false == 6
+        }
+
+        false.foo.bar := 1 {
+          input.x == 1
+        } else := 2 {
+          input.x == 2
+        } else := 3
+
+        foo.bar.false := 4 {
+          input.x == 1
+        } else := 5 {
+          input.x == 2
+        } else := 6
+    want_result:
+      - x: true
+  - note: keywordrefs/false keyword rule refhead, partial set
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+        import future.keywords.contains
+
+        p {
+          false.foo.bar == {"a", "c"}
+          foo.bar.false == {"a", "c"}
+        }
+
+        false.foo.bar contains "a"
+
+        false.foo.bar contains "b" {
+          false
+        }
+
+        false.foo.bar contains "c" {
+          true
+        }
+
+        foo.bar.false contains "a"
+
+        foo.bar.false contains "b" {
+          false
+        }
+
+        foo.bar.false contains "c" {
+          true
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v0/keywordrefs/test-keyword-false.yaml
+++ b/v1/test/cases/testdata/v0/keywordrefs/test-keyword-false.yaml
@@ -164,3 +164,37 @@ cases:
         }
     want_result:
       - x: true
+  - note: keywordrefs/false keyword function refhead
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p {
+          false.foo(1) == 1
+          false.foo(11) == 42
+          foo.false(1) == 1
+          foo.false(11) == 42
+          bar.false.baz(1) == 1
+          bar.false.baz(11) == 42
+        }
+
+        default false.foo(_) := 42
+
+        false.foo(x) := x {
+          x < 10
+        }
+
+        default foo.false(_) := 42
+
+        foo.false(x) := x {
+          x < 10
+        }
+
+        default bar.false.baz(_) := 42
+
+        bar.false.baz(x) := x {
+          x < 10
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v0/keywordrefs/test-keyword-false.yaml
+++ b/v1/test/cases/testdata/v0/keywordrefs/test-keyword-false.yaml
@@ -109,3 +109,58 @@ cases:
         }
     want_result:
       - x: true
+  - note: keywordrefs/false keyword rule refhead, partial object
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p {
+          false.foo == "a"
+          false.bar.one == "a"
+          false.bar.three == "c"
+          foo.false == "a"
+          bar.baz.false == "a"
+        }
+
+        false.foo := "a"
+
+        false.foo := "b" {
+          false
+        }
+
+        false.foo := "c" {
+          false
+        }
+
+        false.bar.one := "a"
+
+        false.bar.two := "b" {
+          false
+        }
+
+        false.bar.three := "c" {
+          true
+        }
+
+        foo.false := "a"
+
+        foo.false := "b" {
+          false
+        }
+
+        foo.false := "c" {
+          false
+        }
+
+        bar.baz.false := "a"
+
+        bar.baz.false := "b" {
+          false
+        }
+
+        bar.baz.false := "c" {
+          false
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v0/keywordrefs/test-keyword-import.yaml
+++ b/v1/test/cases/testdata/v0/keywordrefs/test-keyword-import.yaml
@@ -1,0 +1,52 @@
+---
+cases:
+  - note: keywordrefs/import keyword in package
+    query: data.foo.p = x
+    modules:
+      - |
+        package foo.import.bar
+
+        baz := 42
+      - |
+        package foo
+        import data.foo.import.bar
+        
+        p {
+          bar.baz == 42
+          data.foo.import.bar.baz == 42
+        }
+    want_result:
+      - x: true
+  - note: keywordrefs/import keyword in package, import alias
+    query: data.foo.p = x
+    modules:
+      - |
+        package foo.import
+
+        bar := 42
+      - |
+        package foo
+        import data.foo.import as my_if
+        
+        p {
+          my_if.bar == 42
+          data.foo.import.bar == 42
+        }
+    want_result:
+      - x: true
+  - note: keywordrefs/import keyword rule refhead
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+        
+        p {
+          import.foo == 1
+          foo.import == 2
+        }
+        
+        import.foo := 1
+        
+        foo.import := 2
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v0/keywordrefs/test-keyword-import.yaml
+++ b/v1/test/cases/testdata/v0/keywordrefs/test-keyword-import.yaml
@@ -109,3 +109,58 @@ cases:
         }
     want_result:
       - x: true
+  - note: keywordrefs/import keyword rule refhead, partial object
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p {
+          import.foo == "a"
+          import.bar.one == "a"
+          import.bar.three == "c"
+          foo.import == "a"
+          bar.baz.import == "a"
+        }
+
+        import.foo := "a"
+
+        import.foo := "b" {
+          false
+        }
+
+        import.foo := "c" {
+          false
+        }
+
+        import.bar.one := "a"
+
+        import.bar.two := "b" {
+          false
+        }
+
+        import.bar.three := "c" {
+          true
+        }
+
+        foo.import := "a"
+
+        foo.import := "b" {
+          false
+        }
+
+        foo.import := "c" {
+          false
+        }
+
+        bar.baz.import := "a"
+
+        bar.baz.import := "b" {
+          false
+        }
+
+        bar.baz.import := "c" {
+          false
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v0/keywordrefs/test-keyword-import.yaml
+++ b/v1/test/cases/testdata/v0/keywordrefs/test-keyword-import.yaml
@@ -164,3 +164,37 @@ cases:
         }
     want_result:
       - x: true
+  - note: keywordrefs/import keyword function refhead
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p {
+          import.foo(1) == 1
+          import.foo(11) == 42
+          foo.import(1) == 1
+          foo.import(11) == 42
+          bar.import.baz(1) == 1
+          bar.import.baz(11) == 42
+        }
+
+        default import.foo(_) := 42
+
+        import.foo(x) := x {
+          x < 10
+        }
+
+        default foo.import(_) := 42
+
+        foo.import(x) := x {
+          x < 10
+        }
+
+        default bar.import.baz(_) := 42
+
+        bar.import.baz(x) := x {
+          x < 10
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v0/keywordrefs/test-keyword-import.yaml
+++ b/v1/test/cases/testdata/v0/keywordrefs/test-keyword-import.yaml
@@ -50,3 +50,62 @@ cases:
         foo.import := 2
     want_result:
       - x: true
+  - note: keywordrefs/import keyword rule refhead, else bodies
+    query: data.test.p = x
+    input:
+      x: 3
+    modules:
+      - |
+        package test
+
+        p {
+          import.foo.bar == 3
+          foo.bar.import == 6
+        }
+
+        import.foo.bar := 1 {
+          input.x == 1
+        } else := 2 {
+          input.x == 2
+        } else := 3
+
+        foo.bar.import := 4 {
+          input.x == 1
+        } else := 5 {
+          input.x == 2
+        } else := 6
+    want_result:
+      - x: true
+  - note: keywordrefs/import keyword rule refhead, partial set
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+        import future.keywords.contains
+
+        p {
+          import.foo.bar == {"a", "c"}
+          foo.bar.import == {"a", "c"}
+        }
+
+        import.foo.bar contains "a"
+
+        import.foo.bar contains "b" {
+          false
+        }
+
+        import.foo.bar contains "c" {
+          true
+        }
+
+        foo.bar.import contains "a"
+
+        foo.bar.import contains "b" {
+          false
+        }
+
+        foo.bar.import contains "c" {
+          true
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v0/keywordrefs/test-keyword-not.yaml
+++ b/v1/test/cases/testdata/v0/keywordrefs/test-keyword-not.yaml
@@ -164,3 +164,37 @@ cases:
         }
     want_result:
       - x: true
+  - note: keywordrefs/not keyword function refhead
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p {
+          not.foo(1) == 1
+          not.foo(11) == 42
+          foo.not(1) == 1
+          foo.not(11) == 42
+          bar.not.baz(1) == 1
+          bar.not.baz(11) == 42
+        }
+
+        default not.foo(_) := 42
+
+        not.foo(x) := x {
+          x < 10
+        }
+
+        default foo.not(_) := 42
+
+        foo.not(x) := x {
+          x < 10
+        }
+
+        default bar.not.baz(_) := 42
+
+        bar.not.baz(x) := x {
+          x < 10
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v0/keywordrefs/test-keyword-not.yaml
+++ b/v1/test/cases/testdata/v0/keywordrefs/test-keyword-not.yaml
@@ -1,0 +1,52 @@
+---
+cases:
+  - note: keywordrefs/not keyword in package
+    query: data.foo.p = x
+    modules:
+      - |
+        package foo.not.bar
+
+        baz := 42
+      - |
+        package foo
+        import data.foo.not.bar
+        
+        p {
+          bar.baz == 42
+          data.foo.not.bar.baz == 42
+        }
+    want_result:
+      - x: true
+  - note: keywordrefs/not keyword in package, import alias
+    query: data.foo.p = x
+    modules:
+      - |
+        package foo.not
+
+        bar := 42
+      - |
+        package foo
+        import data.foo.not as my_if
+        
+        p {
+          my_if.bar == 42
+          data.foo.not.bar == 42
+        }
+    want_result:
+      - x: true
+  - note: keywordrefs/not keyword rule refhead
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+        
+        p {
+          not.foo == 1
+          foo.not == 2
+        }
+        
+        not.foo := 1
+        
+        foo.not := 2
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v0/keywordrefs/test-keyword-not.yaml
+++ b/v1/test/cases/testdata/v0/keywordrefs/test-keyword-not.yaml
@@ -109,3 +109,58 @@ cases:
         }
     want_result:
       - x: true
+  - note: keywordrefs/not keyword rule refhead, partial object
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p {
+          not.foo == "a"
+          not.bar.one == "a"
+          not.bar.three == "c"
+          foo.not == "a"
+          bar.baz.not == "a"
+        }
+
+        not.foo := "a"
+
+        not.foo := "b" {
+          false
+        }
+
+        not.foo := "c" {
+          false
+        }
+
+        not.bar.one := "a"
+
+        not.bar.two := "b" {
+          false
+        }
+
+        not.bar.three := "c" {
+          true
+        }
+
+        foo.not := "a"
+
+        foo.not := "b" {
+          false
+        }
+
+        foo.not := "c" {
+          false
+        }
+
+        bar.baz.not := "a"
+
+        bar.baz.not := "b" {
+          false
+        }
+
+        bar.baz.not := "c" {
+          false
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v0/keywordrefs/test-keyword-not.yaml
+++ b/v1/test/cases/testdata/v0/keywordrefs/test-keyword-not.yaml
@@ -50,3 +50,62 @@ cases:
         foo.not := 2
     want_result:
       - x: true
+  - note: keywordrefs/not keyword rule refhead, else bodies
+    query: data.test.p = x
+    input:
+      x: 3
+    modules:
+      - |
+        package test
+
+        p {
+          not.foo.bar == 3
+          foo.bar.not == 6
+        }
+
+        not.foo.bar := 1 {
+          input.x == 1
+        } else := 2 {
+          input.x == 2
+        } else := 3
+
+        foo.bar.not := 4 {
+          input.x == 1
+        } else := 5 {
+          input.x == 2
+        } else := 6
+    want_result:
+      - x: true
+  - note: keywordrefs/not keyword rule refhead, partial set
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+        import future.keywords.contains
+
+        p {
+          not.foo.bar == {"a", "c"}
+          foo.bar.not == {"a", "c"}
+        }
+
+        not.foo.bar contains "a"
+
+        not.foo.bar contains "b" {
+          false
+        }
+
+        not.foo.bar contains "c" {
+          true
+        }
+
+        foo.bar.not contains "a"
+
+        foo.bar.not contains "b" {
+          false
+        }
+
+        foo.bar.not contains "c" {
+          true
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v0/keywordrefs/test-keyword-null.yaml
+++ b/v1/test/cases/testdata/v0/keywordrefs/test-keyword-null.yaml
@@ -164,3 +164,37 @@ cases:
         }
     want_result:
       - x: true
+  - note: keywordrefs/null keyword function refhead
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p {
+          null.foo(1) == 1
+          null.foo(11) == 42
+          foo.null(1) == 1
+          foo.null(11) == 42
+          bar.null.baz(1) == 1
+          bar.null.baz(11) == 42
+        }
+
+        default null.foo(_) := 42
+
+        null.foo(x) := x {
+          x < 10
+        }
+
+        default foo.null(_) := 42
+
+        foo.null(x) := x {
+          x < 10
+        }
+
+        default bar.null.baz(_) := 42
+
+        bar.null.baz(x) := x {
+          x < 10
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v0/keywordrefs/test-keyword-null.yaml
+++ b/v1/test/cases/testdata/v0/keywordrefs/test-keyword-null.yaml
@@ -1,0 +1,52 @@
+---
+cases:
+  - note: keywordrefs/null keyword in package
+    query: data.foo.p = x
+    modules:
+      - |
+        package foo.null.bar
+
+        baz := 42
+      - |
+        package foo
+        import data.foo.null.bar
+        
+        p {
+          bar.baz == 42
+          data.foo.null.bar.baz == 42
+        }
+    want_result:
+      - x: true
+  - note: keywordrefs/null keyword in package, import alias
+    query: data.foo.p = x
+    modules:
+      - |
+        package foo.null
+
+        bar := 42
+      - |
+        package foo
+        import data.foo.null as my_if
+        
+        p {
+          my_if.bar == 42
+          data.foo.null.bar == 42
+        }
+    want_result:
+      - x: true
+  - note: keywordrefs/null keyword rule refhead
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+        
+        p {
+          null.foo == 1
+          foo.null == 2
+        }
+        
+        null.foo := 1
+        
+        foo.null := 2
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v0/keywordrefs/test-keyword-null.yaml
+++ b/v1/test/cases/testdata/v0/keywordrefs/test-keyword-null.yaml
@@ -109,3 +109,58 @@ cases:
         }
     want_result:
       - x: true
+  - note: keywordrefs/null keyword rule refhead, partial object
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p {
+          null.foo == "a"
+          null.bar.one == "a"
+          null.bar.three == "c"
+          foo.null == "a"
+          bar.baz.null == "a"
+        }
+
+        null.foo := "a"
+
+        null.foo := "b" {
+          false
+        }
+
+        null.foo := "c" {
+          false
+        }
+
+        null.bar.one := "a"
+
+        null.bar.two := "b" {
+          false
+        }
+
+        null.bar.three := "c" {
+          true
+        }
+
+        foo.null := "a"
+
+        foo.null := "b" {
+          false
+        }
+
+        foo.null := "c" {
+          false
+        }
+
+        bar.baz.null := "a"
+
+        bar.baz.null := "b" {
+          false
+        }
+
+        bar.baz.null := "c" {
+          false
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v0/keywordrefs/test-keyword-null.yaml
+++ b/v1/test/cases/testdata/v0/keywordrefs/test-keyword-null.yaml
@@ -50,3 +50,62 @@ cases:
         foo.null := 2
     want_result:
       - x: true
+  - note: keywordrefs/null keyword rule refhead, else bodies
+    query: data.test.p = x
+    input:
+      x: 3
+    modules:
+      - |
+        package test
+
+        p {
+          null.foo.bar == 3
+          foo.bar.null == 6
+        }
+
+        null.foo.bar := 1 {
+          input.x == 1
+        } else := 2 {
+          input.x == 2
+        } else := 3
+
+        foo.bar.null := 4 {
+          input.x == 1
+        } else := 5 {
+          input.x == 2
+        } else := 6
+    want_result:
+      - x: true
+  - note: keywordrefs/null keyword rule refhead, partial set
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+        import future.keywords.contains
+
+        p {
+          null.foo.bar == {"a", "c"}
+          foo.bar.null == {"a", "c"}
+        }
+
+        null.foo.bar contains "a"
+
+        null.foo.bar contains "b" {
+          false
+        }
+
+        null.foo.bar contains "c" {
+          true
+        }
+
+        foo.bar.null contains "a"
+
+        foo.bar.null contains "b" {
+          false
+        }
+
+        foo.bar.null contains "c" {
+          true
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v0/keywordrefs/test-keyword-package.yaml
+++ b/v1/test/cases/testdata/v0/keywordrefs/test-keyword-package.yaml
@@ -109,3 +109,58 @@ cases:
         }
     want_result:
       - x: true
+  - note: keywordrefs/package keyword rule refhead, partial object
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p {
+          package.foo == "a"
+          package.bar.one == "a"
+          package.bar.three == "c"
+          foo.package == "a"
+          bar.baz.package == "a"
+        }
+
+        package.foo := "a"
+
+        package.foo := "b" {
+          false
+        }
+
+        package.foo := "c" {
+          false
+        }
+
+        package.bar.one := "a"
+
+        package.bar.two := "b" {
+          false
+        }
+
+        package.bar.three := "c" {
+          true
+        }
+
+        foo.package := "a"
+
+        foo.package := "b" {
+          false
+        }
+
+        foo.package := "c" {
+          false
+        }
+
+        bar.baz.package := "a"
+
+        bar.baz.package := "b" {
+          false
+        }
+
+        bar.baz.package := "c" {
+          false
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v0/keywordrefs/test-keyword-package.yaml
+++ b/v1/test/cases/testdata/v0/keywordrefs/test-keyword-package.yaml
@@ -164,3 +164,37 @@ cases:
         }
     want_result:
       - x: true
+  - note: keywordrefs/package keyword function refhead
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p {
+          package.foo(1) == 1
+          package.foo(11) == 42
+          foo.package(1) == 1
+          foo.package(11) == 42
+          bar.package.baz(1) == 1
+          bar.package.baz(11) == 42
+        }
+
+        default package.foo(_) := 42
+
+        package.foo(x) := x {
+          x < 10
+        }
+
+        default foo.package(_) := 42
+
+        foo.package(x) := x {
+          x < 10
+        }
+
+        default bar.package.baz(_) := 42
+
+        bar.package.baz(x) := x {
+          x < 10
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v0/keywordrefs/test-keyword-package.yaml
+++ b/v1/test/cases/testdata/v0/keywordrefs/test-keyword-package.yaml
@@ -1,0 +1,52 @@
+---
+cases:
+  - note: keywordrefs/package keyword in package
+    query: data.foo.p = x
+    modules:
+      - |
+        package foo.package.bar
+
+        baz := 42
+      - |
+        package foo
+        import data.foo.package.bar
+        
+        p {
+          bar.baz == 42
+          data.foo.package.bar.baz == 42
+        }
+    want_result:
+      - x: true
+  - note: keywordrefs/package keyword in package, import alias
+    query: data.foo.p = x
+    modules:
+      - |
+        package foo.package
+
+        bar := 42
+      - |
+        package foo
+        import data.foo.package as my_if
+        
+        p {
+          my_if.bar == 42
+          data.foo.package.bar == 42
+        }
+    want_result:
+      - x: true
+  - note: keywordrefs/package keyword rule refhead
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+        
+        p {
+          package.foo == 1
+          foo.package == 2
+        }
+        
+        package.foo := 1
+        
+        foo.package := 2
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v0/keywordrefs/test-keyword-package.yaml
+++ b/v1/test/cases/testdata/v0/keywordrefs/test-keyword-package.yaml
@@ -50,3 +50,62 @@ cases:
         foo.package := 2
     want_result:
       - x: true
+  - note: keywordrefs/package keyword rule refhead, else bodies
+    query: data.test.p = x
+    input:
+      x: 3
+    modules:
+      - |
+        package test
+
+        p {
+          package.foo.bar == 3
+          foo.bar.package == 6
+        }
+
+        package.foo.bar := 1 {
+          input.x == 1
+        } else := 2 {
+          input.x == 2
+        } else := 3
+
+        foo.bar.package := 4 {
+          input.x == 1
+        } else := 5 {
+          input.x == 2
+        } else := 6
+    want_result:
+      - x: true
+  - note: keywordrefs/package keyword rule refhead, partial set
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+        import future.keywords.contains
+
+        p {
+          package.foo.bar == {"a", "c"}
+          foo.bar.package == {"a", "c"}
+        }
+
+        package.foo.bar contains "a"
+
+        package.foo.bar contains "b" {
+          false
+        }
+
+        package.foo.bar contains "c" {
+          true
+        }
+
+        foo.bar.package contains "a"
+
+        foo.bar.package contains "b" {
+          false
+        }
+
+        foo.bar.package contains "c" {
+          true
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v0/keywordrefs/test-keyword-some.yaml
+++ b/v1/test/cases/testdata/v0/keywordrefs/test-keyword-some.yaml
@@ -164,3 +164,37 @@ cases:
         }
     want_result:
       - x: true
+  - note: keywordrefs/some keyword function refhead
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p {
+          some.foo(1) == 1
+          some.foo(11) == 42
+          foo.some(1) == 1
+          foo.some(11) == 42
+          bar.some.baz(1) == 1
+          bar.some.baz(11) == 42
+        }
+
+        default some.foo(_) := 42
+
+        some.foo(x) := x {
+          x < 10
+        }
+
+        default foo.some(_) := 42
+
+        foo.some(x) := x {
+          x < 10
+        }
+
+        default bar.some.baz(_) := 42
+
+        bar.some.baz(x) := x {
+          x < 10
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v0/keywordrefs/test-keyword-some.yaml
+++ b/v1/test/cases/testdata/v0/keywordrefs/test-keyword-some.yaml
@@ -109,3 +109,58 @@ cases:
         }
     want_result:
       - x: true
+  - note: keywordrefs/some keyword rule refhead, partial object
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p {
+          some.foo == "a"
+          some.bar.one == "a"
+          some.bar.three == "c"
+          foo.some == "a"
+          bar.baz.some == "a"
+        }
+
+        some.foo := "a"
+
+        some.foo := "b" {
+          false
+        }
+
+        some.foo := "c" {
+          false
+        }
+
+        some.bar.one := "a"
+
+        some.bar.two := "b" {
+          false
+        }
+
+        some.bar.three := "c" {
+          true
+        }
+
+        foo.some := "a"
+
+        foo.some := "b" {
+          false
+        }
+
+        foo.some := "c" {
+          false
+        }
+
+        bar.baz.some := "a"
+
+        bar.baz.some := "b" {
+          false
+        }
+
+        bar.baz.some := "c" {
+          false
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v0/keywordrefs/test-keyword-some.yaml
+++ b/v1/test/cases/testdata/v0/keywordrefs/test-keyword-some.yaml
@@ -1,0 +1,52 @@
+---
+cases:
+  - note: keywordrefs/some keyword in package
+    query: data.foo.p = x
+    modules:
+      - |
+        package foo.some.bar
+
+        baz := 42
+      - |
+        package foo
+        import data.foo.some.bar
+        
+        p {
+          bar.baz == 42
+          data.foo.some.bar.baz == 42
+        }
+    want_result:
+      - x: true
+  - note: keywordrefs/some keyword in package, import alias
+    query: data.foo.p = x
+    modules:
+      - |
+        package foo.some
+
+        bar := 42
+      - |
+        package foo
+        import data.foo.some as my_if
+        
+        p {
+          my_if.bar == 42
+          data.foo.some.bar == 42
+        }
+    want_result:
+      - x: true
+  - note: keywordrefs/some keyword rule refhead
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+        
+        p {
+          some.foo == 1
+          foo.some == 2
+        }
+        
+        some.foo := 1
+        
+        foo.some := 2
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v0/keywordrefs/test-keyword-some.yaml
+++ b/v1/test/cases/testdata/v0/keywordrefs/test-keyword-some.yaml
@@ -50,3 +50,62 @@ cases:
         foo.some := 2
     want_result:
       - x: true
+  - note: keywordrefs/some keyword rule refhead, else bodies
+    query: data.test.p = x
+    input:
+      x: 3
+    modules:
+      - |
+        package test
+
+        p {
+          some.foo.bar == 3
+          foo.bar.some == 6
+        }
+
+        some.foo.bar := 1 {
+          input.x == 1
+        } else := 2 {
+          input.x == 2
+        } else := 3
+
+        foo.bar.some := 4 {
+          input.x == 1
+        } else := 5 {
+          input.x == 2
+        } else := 6
+    want_result:
+      - x: true
+  - note: keywordrefs/some keyword rule refhead, partial set
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+        import future.keywords.contains
+
+        p {
+          some.foo.bar == {"a", "c"}
+          foo.bar.some == {"a", "c"}
+        }
+
+        some.foo.bar contains "a"
+
+        some.foo.bar contains "b" {
+          false
+        }
+
+        some.foo.bar contains "c" {
+          true
+        }
+
+        foo.bar.some contains "a"
+
+        foo.bar.some contains "b" {
+          false
+        }
+
+        foo.bar.some contains "c" {
+          true
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v0/keywordrefs/test-keyword-true.yaml
+++ b/v1/test/cases/testdata/v0/keywordrefs/test-keyword-true.yaml
@@ -109,3 +109,58 @@ cases:
         }
     want_result:
       - x: true
+  - note: keywordrefs/true keyword rule refhead, partial object
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p {
+          true.foo == "a"
+          true.bar.one == "a"
+          true.bar.three == "c"
+          foo.true == "a"
+          bar.baz.true == "a"
+        }
+
+        true.foo := "a"
+
+        true.foo := "b" {
+          false
+        }
+
+        true.foo := "c" {
+          false
+        }
+
+        true.bar.one := "a"
+
+        true.bar.two := "b" {
+          false
+        }
+
+        true.bar.three := "c" {
+          true
+        }
+
+        foo.true := "a"
+
+        foo.true := "b" {
+          false
+        }
+
+        foo.true := "c" {
+          false
+        }
+
+        bar.baz.true := "a"
+
+        bar.baz.true := "b" {
+          false
+        }
+
+        bar.baz.true := "c" {
+          false
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v0/keywordrefs/test-keyword-true.yaml
+++ b/v1/test/cases/testdata/v0/keywordrefs/test-keyword-true.yaml
@@ -1,0 +1,52 @@
+---
+cases:
+  - note: keywordrefs/true keyword in package
+    query: data.foo.p = x
+    modules:
+      - |
+        package foo.true.bar
+
+        baz := 42
+      - |
+        package foo
+        import data.foo.true.bar
+        
+        p {
+          bar.baz == 42
+          data.foo.true.bar.baz == 42
+        }
+    want_result:
+      - x: true
+  - note: keywordrefs/true keyword in package, import alias
+    query: data.foo.p = x
+    modules:
+      - |
+        package foo.true
+
+        bar := 42
+      - |
+        package foo
+        import data.foo.true as my_if
+        
+        p {
+          my_if.bar == 42
+          data.foo.true.bar == 42
+        }
+    want_result:
+      - x: true
+  - note: keywordrefs/true keyword rule refhead
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+        
+        p {
+          true.foo == 1
+          foo.true == 2
+        }
+        
+        true.foo := 1
+        
+        foo.true := 2
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v0/keywordrefs/test-keyword-true.yaml
+++ b/v1/test/cases/testdata/v0/keywordrefs/test-keyword-true.yaml
@@ -164,3 +164,37 @@ cases:
         }
     want_result:
       - x: true
+  - note: keywordrefs/true keyword function refhead
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p {
+          true.foo(1) == 1
+          true.foo(11) == 42
+          foo.true(1) == 1
+          foo.true(11) == 42
+          bar.true.baz(1) == 1
+          bar.true.baz(11) == 42
+        }
+
+        default true.foo(_) := 42
+
+        true.foo(x) := x {
+          x < 10
+        }
+
+        default foo.true(_) := 42
+
+        foo.true(x) := x {
+          x < 10
+        }
+
+        default bar.true.baz(_) := 42
+
+        bar.true.baz(x) := x {
+          x < 10
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v0/keywordrefs/test-keyword-true.yaml
+++ b/v1/test/cases/testdata/v0/keywordrefs/test-keyword-true.yaml
@@ -50,3 +50,62 @@ cases:
         foo.true := 2
     want_result:
       - x: true
+  - note: keywordrefs/true keyword rule refhead, else bodies
+    query: data.test.p = x
+    input:
+      x: 3
+    modules:
+      - |
+        package test
+
+        p {
+          true.foo.bar == 3
+          foo.bar.true == 6
+        }
+
+        true.foo.bar := 1 {
+          input.x == 1
+        } else := 2 {
+          input.x == 2
+        } else := 3
+
+        foo.bar.true := 4 {
+          input.x == 1
+        } else := 5 {
+          input.x == 2
+        } else := 6
+    want_result:
+      - x: true
+  - note: keywordrefs/true keyword rule refhead, partial set
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+        import future.keywords.contains
+
+        p {
+          true.foo.bar == {"a", "c"}
+          foo.bar.true == {"a", "c"}
+        }
+
+        true.foo.bar contains "a"
+
+        true.foo.bar contains "b" {
+          false
+        }
+
+        true.foo.bar contains "c" {
+          true
+        }
+
+        foo.bar.true contains "a"
+
+        foo.bar.true contains "b" {
+          false
+        }
+
+        foo.bar.true contains "c" {
+          true
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v0/keywordrefs/test-keyword-with.yaml
+++ b/v1/test/cases/testdata/v0/keywordrefs/test-keyword-with.yaml
@@ -1,0 +1,52 @@
+---
+cases:
+  - note: keywordrefs/with keyword in package
+    query: data.foo.p = x
+    modules:
+      - |
+        package foo.with.bar
+
+        baz := 42
+      - |
+        package foo
+        import data.foo.with.bar
+        
+        p {
+          bar.baz == 42
+          data.foo.with.bar.baz == 42
+        }
+    want_result:
+      - x: true
+  - note: keywordrefs/with keyword in package, import alias
+    query: data.foo.p = x
+    modules:
+      - |
+        package foo.with
+
+        bar := 42
+      - |
+        package foo
+        import data.foo.with as my_if
+        
+        p {
+          my_if.bar == 42
+          data.foo.with.bar == 42
+        }
+    want_result:
+      - x: true
+  - note: keywordrefs/with keyword rule refhead
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+        
+        p {
+          with.foo == 1
+          foo.with == 2
+        }
+        
+        with.foo := 1
+        
+        foo.with := 2
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v0/keywordrefs/test-keyword-with.yaml
+++ b/v1/test/cases/testdata/v0/keywordrefs/test-keyword-with.yaml
@@ -109,3 +109,58 @@ cases:
         }
     want_result:
       - x: true
+  - note: keywordrefs/with keyword rule refhead, partial object
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p {
+          with.foo == "a"
+          with.bar.one == "a"
+          with.bar.three == "c"
+          foo.with == "a"
+          bar.baz.with == "a"
+        }
+
+        with.foo := "a"
+
+        with.foo := "b" {
+          false
+        }
+
+        with.foo := "c" {
+          false
+        }
+
+        with.bar.one := "a"
+
+        with.bar.two := "b" {
+          false
+        }
+
+        with.bar.three := "c" {
+          true
+        }
+
+        foo.with := "a"
+
+        foo.with := "b" {
+          false
+        }
+
+        foo.with := "c" {
+          false
+        }
+
+        bar.baz.with := "a"
+
+        bar.baz.with := "b" {
+          false
+        }
+
+        bar.baz.with := "c" {
+          false
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v0/keywordrefs/test-keyword-with.yaml
+++ b/v1/test/cases/testdata/v0/keywordrefs/test-keyword-with.yaml
@@ -164,3 +164,37 @@ cases:
         }
     want_result:
       - x: true
+  - note: keywordrefs/with keyword function refhead
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p {
+          with.foo(1) == 1
+          with.foo(11) == 42
+          foo.with(1) == 1
+          foo.with(11) == 42
+          bar.with.baz(1) == 1
+          bar.with.baz(11) == 42
+        }
+
+        default with.foo(_) := 42
+
+        with.foo(x) := x {
+          x < 10
+        }
+
+        default foo.with(_) := 42
+
+        foo.with(x) := x {
+          x < 10
+        }
+
+        default bar.with.baz(_) := 42
+
+        bar.with.baz(x) := x {
+          x < 10
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v0/keywordrefs/test-keyword-with.yaml
+++ b/v1/test/cases/testdata/v0/keywordrefs/test-keyword-with.yaml
@@ -50,3 +50,62 @@ cases:
         foo.with := 2
     want_result:
       - x: true
+  - note: keywordrefs/with keyword rule refhead, else bodies
+    query: data.test.p = x
+    input:
+      x: 3
+    modules:
+      - |
+        package test
+
+        p {
+          with.foo.bar == 3
+          foo.bar.with == 6
+        }
+
+        with.foo.bar := 1 {
+          input.x == 1
+        } else := 2 {
+          input.x == 2
+        } else := 3
+
+        foo.bar.with := 4 {
+          input.x == 1
+        } else := 5 {
+          input.x == 2
+        } else := 6
+    want_result:
+      - x: true
+  - note: keywordrefs/with keyword rule refhead, partial set
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+        import future.keywords.contains
+
+        p {
+          with.foo.bar == {"a", "c"}
+          foo.bar.with == {"a", "c"}
+        }
+
+        with.foo.bar contains "a"
+
+        with.foo.bar contains "b" {
+          false
+        }
+
+        with.foo.bar contains "c" {
+          true
+        }
+
+        foo.bar.with contains "a"
+
+        foo.bar.with contains "b" {
+          false
+        }
+
+        foo.bar.with contains "c" {
+          true
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v1/keywordrefs/test-keyword-as.yaml
+++ b/v1/test/cases/testdata/v1/keywordrefs/test-keyword-as.yaml
@@ -163,3 +163,37 @@ cases:
         }
     want_result:
       - x: true
+  - note: keywordrefs/as keyword function refhead
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p if {
+          as.foo(1) == 1
+          as.foo(11) == 42
+          foo.as(1) == 1
+          foo.as(11) == 42
+          bar.as.baz(1) == 1
+          bar.as.baz(11) == 42
+        }
+
+        default as.foo(_) := 42
+
+        as.foo(x) := x if {
+          x < 10
+        }
+
+        default foo.as(_) := 42
+
+        foo.as(x) := x if {
+          x < 10
+        }
+
+        default bar.as.baz(_) := 42
+
+        bar.as.baz(x) := x if {
+          x < 10
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v1/keywordrefs/test-keyword-as.yaml
+++ b/v1/test/cases/testdata/v1/keywordrefs/test-keyword-as.yaml
@@ -50,3 +50,61 @@ cases:
         foo.as := 2
     want_result:
       - x: true
+  - note: keywordrefs/as keyword rule refhead, else bodies
+    query: data.test.p = x
+    input:
+      x: 3
+    modules:
+      - |
+        package test
+
+        p if {
+          as.foo == 3
+          foo.as == 6
+        }
+
+        as.foo := 1 if {
+          input.x == 1
+        } else := 2 if {
+          input.x == 2
+        } else := 3
+
+        foo.as := 4 if {
+          input.x == 1
+        } else := 5 if {
+          input.x == 2
+        } else := 6
+    want_result:
+      - x: true
+  - note: keywordrefs/as keyword rule refhead, partial set
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p if {
+          as.foo == {"a", "c"}
+          foo.as == {"a", "c"}
+        }
+
+        as.foo contains "a"
+
+        as.foo contains "b" if {
+          false
+        }
+
+        as.foo contains "c" if {
+          true
+        }
+
+        foo.as contains "a"
+
+        foo.as contains "b" if {
+          false
+        }
+
+        foo.as contains "c" if {
+          true
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v1/keywordrefs/test-keyword-as.yaml
+++ b/v1/test/cases/testdata/v1/keywordrefs/test-keyword-as.yaml
@@ -108,3 +108,58 @@ cases:
         }
     want_result:
       - x: true
+  - note: keywordrefs/as keyword rule refhead, partial object
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p if {
+          as.foo == "a"
+          as.bar.one == "a"
+          as.bar.three == "c"
+          foo.as == "a"
+          bar.baz.as == "a"
+        }
+
+        as.foo := "a"
+
+        as.foo := "b" if {
+          false
+        }
+
+        as.foo := "c" if {
+          false
+        }
+
+        as.bar.one := "a"
+
+        as.bar.two := "b" if {
+          false
+        }
+
+        as.bar.three := "c" if {
+          true
+        }
+
+        foo.as := "a"
+
+        foo.as := "b" if {
+          false
+        }
+
+        foo.as := "c" if {
+          false
+        }
+
+        bar.baz.as := "a"
+
+        bar.baz.as := "b" if {
+          false
+        }
+
+        bar.baz.as := "c" if {
+          false
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v1/keywordrefs/test-keyword-as.yaml
+++ b/v1/test/cases/testdata/v1/keywordrefs/test-keyword-as.yaml
@@ -1,0 +1,52 @@
+---
+cases:
+  - note: keywordrefs/as keyword in package
+    query: data.foo.p = x
+    modules:
+      - |
+        package foo.as.bar
+
+        baz := 42
+      - |
+        package foo
+        import data.foo.as.bar
+        
+        p if {
+          bar.baz == 42
+          data.foo.as.bar.baz == 42
+        }
+    want_result:
+      - x: true
+  - note: keywordrefs/as keyword in package, import alias
+    query: data.foo.p = x
+    modules:
+      - |
+        package foo.as
+
+        bar := 42
+      - |
+        package foo
+        import data.foo.as as my_if
+        
+        p if {
+          my_if.bar == 42
+          data.foo.as.bar == 42
+        }
+    want_result:
+      - x: true
+  - note: keywordrefs/as keyword rule refhead
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+        
+        p if {
+          as.foo == 1
+          foo.as == 2
+        }
+        
+        as.foo := 1
+        
+        foo.as := 2
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v1/keywordrefs/test-keyword-contains.yaml
+++ b/v1/test/cases/testdata/v1/keywordrefs/test-keyword-contains.yaml
@@ -50,3 +50,61 @@ cases:
         foo.contains := 2
     want_result:
       - x: true
+  - note: keywordrefs/contains keyword rule refhead, else bodies
+    query: data.test.p = x
+    input:
+      x: 3
+    modules:
+      - |
+        package test
+
+        p if {
+          contains.foo == 3
+          foo.contains == 6
+        }
+
+        contains.foo := 1 if {
+          input.x == 1
+        } else := 2 if {
+          input.x == 2
+        } else := 3
+
+        foo.contains := 4 if {
+          input.x == 1
+        } else := 5 if {
+          input.x == 2
+        } else := 6
+    want_result:
+      - x: true
+  - note: keywordrefs/contains keyword rule refhead, partial set
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p if {
+          contains.foo == {"a", "c"}
+          foo.contains == {"a", "c"}
+        }
+
+        contains.foo contains "a"
+
+        contains.foo contains "b" if {
+          false
+        }
+
+        contains.foo contains "c" if {
+          true
+        }
+
+        foo.contains contains "a"
+
+        foo.contains contains "b" if {
+          false
+        }
+
+        foo.contains contains "c" if {
+          true
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v1/keywordrefs/test-keyword-contains.yaml
+++ b/v1/test/cases/testdata/v1/keywordrefs/test-keyword-contains.yaml
@@ -1,0 +1,52 @@
+---
+cases:
+  - note: keywordrefs/contains keyword in package
+    query: data.foo.p = x
+    modules:
+      - |
+        package foo.contains.bar
+
+        baz := 42
+      - |
+        package foo
+        import data.foo.contains.bar
+        
+        p if {
+          bar.baz == 42
+          data.foo.contains.bar.baz == 42
+        }
+    want_result:
+      - x: true
+  - note: keywordrefs/contains keyword in package, import alias
+    query: data.foo.p = x
+    modules:
+      - |
+        package foo.contains
+
+        bar := 42
+      - |
+        package foo
+        import data.foo.contains as my_if
+        
+        p if {
+          my_if.bar == 42
+          data.foo.contains.bar == 42
+        }
+    want_result:
+      - x: true
+  - note: keywordrefs/contains keyword rule refhead
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+        
+        p if {
+          contains.foo == 1
+          foo.contains == 2
+        }
+        
+        contains.foo := 1
+        
+        foo.contains := 2
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v1/keywordrefs/test-keyword-contains.yaml
+++ b/v1/test/cases/testdata/v1/keywordrefs/test-keyword-contains.yaml
@@ -163,3 +163,37 @@ cases:
         }
     want_result:
       - x: true
+  - note: keywordrefs/contains keyword function refhead
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p if {
+          contains.foo(1) == 1
+          contains.foo(11) == 42
+          foo.contains(1) == 1
+          foo.contains(11) == 42
+          bar.contains.baz(1) == 1
+          bar.contains.baz(11) == 42
+        }
+
+        default contains.foo(_) := 42
+
+        contains.foo(x) := x if {
+          x < 10
+        }
+
+        default foo.contains(_) := 42
+
+        foo.contains(x) := x if {
+          x < 10
+        }
+
+        default bar.contains.baz(_) := 42
+
+        bar.contains.baz(x) := x if {
+          x < 10
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v1/keywordrefs/test-keyword-contains.yaml
+++ b/v1/test/cases/testdata/v1/keywordrefs/test-keyword-contains.yaml
@@ -108,3 +108,58 @@ cases:
         }
     want_result:
       - x: true
+  - note: keywordrefs/contains keyword rule refhead, partial object
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p if {
+          contains.foo == "a"
+          contains.bar.one == "a"
+          contains.bar.three == "c"
+          foo.contains == "a"
+          bar.baz.contains == "a"
+        }
+
+        contains.foo := "a"
+
+        contains.foo := "b" if {
+          false
+        }
+
+        contains.foo := "c" if {
+          false
+        }
+
+        contains.bar.one := "a"
+
+        contains.bar.two := "b" if {
+          false
+        }
+
+        contains.bar.three := "c" if {
+          true
+        }
+
+        foo.contains := "a"
+
+        foo.contains := "b" if {
+          false
+        }
+
+        foo.contains := "c" if {
+          false
+        }
+
+        bar.baz.contains := "a"
+
+        bar.baz.contains := "b" if {
+          false
+        }
+
+        bar.baz.contains := "c" if {
+          false
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v1/keywordrefs/test-keyword-default.yaml
+++ b/v1/test/cases/testdata/v1/keywordrefs/test-keyword-default.yaml
@@ -50,3 +50,61 @@ cases:
         foo.default := 2
     want_result:
       - x: true
+  - note: keywordrefs/default keyword rule refhead, else bodies
+    query: data.test.p = x
+    input:
+      x: 3
+    modules:
+      - |
+        package test
+
+        p if {
+          default.foo == 3
+          foo.default == 6
+        }
+
+        default.foo := 1 if {
+          input.x == 1
+        } else := 2 if {
+          input.x == 2
+        } else := 3
+
+        foo.default := 4 if {
+          input.x == 1
+        } else := 5 if {
+          input.x == 2
+        } else := 6
+    want_result:
+      - x: true
+  - note: keywordrefs/default keyword rule refhead, partial set
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p if {
+          default.foo == {"a", "c"}
+          foo.default == {"a", "c"}
+        }
+
+        default.foo contains "a"
+
+        default.foo contains "b" if {
+          false
+        }
+
+        default.foo contains "c" if {
+          true
+        }
+
+        foo.default contains "a"
+
+        foo.default contains "b" if {
+          false
+        }
+
+        foo.default contains "c" if {
+          true
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v1/keywordrefs/test-keyword-default.yaml
+++ b/v1/test/cases/testdata/v1/keywordrefs/test-keyword-default.yaml
@@ -1,0 +1,52 @@
+---
+cases:
+  - note: keywordrefs/default keyword in package
+    query: data.foo.p = x
+    modules:
+      - |
+        package foo.default.bar
+
+        baz := 42
+      - |
+        package foo
+        import data.foo.default.bar
+        
+        p if {
+          bar.baz == 42
+          data.foo.default.bar.baz == 42
+        }
+    want_result:
+      - x: true
+  - note: keywordrefs/default keyword in package, import alias
+    query: data.foo.p = x
+    modules:
+      - |
+        package foo.default
+
+        bar := 42
+      - |
+        package foo
+        import data.foo.default as my_if
+        
+        p if {
+          my_if.bar == 42
+          data.foo.default.bar == 42
+        }
+    want_result:
+      - x: true
+  - note: keywordrefs/default keyword rule refhead
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+        
+        p if {
+          default.foo == 1
+          foo.default == 2
+        }
+        
+        default.foo := 1
+        
+        foo.default := 2
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v1/keywordrefs/test-keyword-default.yaml
+++ b/v1/test/cases/testdata/v1/keywordrefs/test-keyword-default.yaml
@@ -108,3 +108,58 @@ cases:
         }
     want_result:
       - x: true
+  - note: keywordrefs/default keyword rule refhead, partial object
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p if {
+          default.foo == "a"
+          default.bar.one == "a"
+          default.bar.three == "c"
+          foo.default == "a"
+          bar.baz.default == "a"
+        }
+
+        default.foo := "a"
+
+        default.foo := "b" if {
+          false
+        }
+
+        default.foo := "c" if {
+          false
+        }
+
+        default.bar.one := "a"
+
+        default.bar.two := "b" if {
+          false
+        }
+
+        default.bar.three := "c" if {
+          true
+        }
+
+        foo.default := "a"
+
+        foo.default := "b" if {
+          false
+        }
+
+        foo.default := "c" if {
+          false
+        }
+
+        bar.baz.default := "a"
+
+        bar.baz.default := "b" if {
+          false
+        }
+
+        bar.baz.default := "c" if {
+          false
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v1/keywordrefs/test-keyword-default.yaml
+++ b/v1/test/cases/testdata/v1/keywordrefs/test-keyword-default.yaml
@@ -163,3 +163,37 @@ cases:
         }
     want_result:
       - x: true
+  - note: keywordrefs/default keyword function refhead
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p if {
+          default.foo(1) == 1
+          default.foo(11) == 42
+          foo.default(1) == 1
+          foo.default(11) == 42
+          bar.default.baz(1) == 1
+          bar.default.baz(11) == 42
+        }
+
+        default default.foo(_) := 42
+
+        default.foo(x) := x if {
+          x < 10
+        }
+
+        default foo.default(_) := 42
+
+        foo.default(x) := x if {
+          x < 10
+        }
+
+        default bar.default.baz(_) := 42
+
+        bar.default.baz(x) := x if {
+          x < 10
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v1/keywordrefs/test-keyword-else.yaml
+++ b/v1/test/cases/testdata/v1/keywordrefs/test-keyword-else.yaml
@@ -50,3 +50,61 @@ cases:
         foo.else := 2
     want_result:
       - x: true
+  - note: keywordrefs/else keyword rule refhead, else bodies
+    query: data.test.p = x
+    input:
+      x: 3
+    modules:
+      - |
+        package test
+
+        p if {
+          else.foo == 3
+          foo.else == 6
+        }
+
+        else.foo := 1 if {
+          input.x == 1
+        } else := 2 if {
+          input.x == 2
+        } else := 3
+
+        foo.else := 4 if {
+          input.x == 1
+        } else := 5 if {
+          input.x == 2
+        } else := 6
+    want_result:
+      - x: true
+  - note: keywordrefs/else keyword rule refhead, partial set
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p if {
+          else.foo == {"a", "c"}
+          foo.else == {"a", "c"}
+        }
+
+        else.foo contains "a"
+
+        else.foo contains "b" if {
+          false
+        }
+
+        else.foo contains "c" if {
+          true
+        }
+
+        foo.else contains "a"
+
+        foo.else contains "b" if {
+          false
+        }
+
+        foo.else contains "c" if {
+          true
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v1/keywordrefs/test-keyword-else.yaml
+++ b/v1/test/cases/testdata/v1/keywordrefs/test-keyword-else.yaml
@@ -1,0 +1,52 @@
+---
+cases:
+  - note: keywordrefs/else keyword in package
+    query: data.foo.p = x
+    modules:
+      - |
+        package foo.else.bar
+
+        baz := 42
+      - |
+        package foo
+        import data.foo.else.bar
+        
+        p if {
+          bar.baz == 42
+          data.foo.else.bar.baz == 42
+        }
+    want_result:
+      - x: true
+  - note: keywordrefs/else keyword in package, import alias
+    query: data.foo.p = x
+    modules:
+      - |
+        package foo.else
+
+        bar := 42
+      - |
+        package foo
+        import data.foo.else as my_if
+        
+        p if {
+          my_if.bar == 42
+          data.foo.else.bar == 42
+        }
+    want_result:
+      - x: true
+  - note: keywordrefs/else keyword rule refhead
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+        
+        p if {
+          else.foo == 1
+          foo.else == 2
+        }
+        
+        else.foo := 1
+        
+        foo.else := 2
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v1/keywordrefs/test-keyword-else.yaml
+++ b/v1/test/cases/testdata/v1/keywordrefs/test-keyword-else.yaml
@@ -108,3 +108,58 @@ cases:
         }
     want_result:
       - x: true
+  - note: keywordrefs/else keyword rule refhead, partial object
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p if {
+          else.foo == "a"
+          else.bar.one == "a"
+          else.bar.three == "c"
+          foo.else == "a"
+          bar.baz.else == "a"
+        }
+
+        else.foo := "a"
+
+        else.foo := "b" if {
+          false
+        }
+
+        else.foo := "c" if {
+          false
+        }
+
+        else.bar.one := "a"
+
+        else.bar.two := "b" if {
+          false
+        }
+
+        else.bar.three := "c" if {
+          true
+        }
+
+        foo.else := "a"
+
+        foo.else := "b" if {
+          false
+        }
+
+        foo.else := "c" if {
+          false
+        }
+
+        bar.baz.else := "a"
+
+        bar.baz.else := "b" if {
+          false
+        }
+
+        bar.baz.else := "c" if {
+          false
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v1/keywordrefs/test-keyword-else.yaml
+++ b/v1/test/cases/testdata/v1/keywordrefs/test-keyword-else.yaml
@@ -163,3 +163,37 @@ cases:
         }
     want_result:
       - x: true
+  - note: keywordrefs/else keyword function refhead
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p if {
+          else.foo(1) == 1
+          else.foo(11) == 42
+          foo.else(1) == 1
+          foo.else(11) == 42
+          bar.else.baz(1) == 1
+          bar.else.baz(11) == 42
+        }
+
+        default else.foo(_) := 42
+
+        else.foo(x) := x if {
+          x < 10
+        }
+
+        default foo.else(_) := 42
+
+        foo.else(x) := x if {
+          x < 10
+        }
+
+        default bar.else.baz(_) := 42
+
+        bar.else.baz(x) := x if {
+          x < 10
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v1/keywordrefs/test-keyword-every.yaml
+++ b/v1/test/cases/testdata/v1/keywordrefs/test-keyword-every.yaml
@@ -50,3 +50,61 @@ cases:
         foo.every := 2
     want_result:
       - x: true
+  - note: keywordrefs/every keyword rule refhead, else bodies
+    query: data.test.p = x
+    input:
+      x: 3
+    modules:
+      - |
+        package test
+
+        p if {
+          every.foo == 3
+          foo.every == 6
+        }
+
+        every.foo := 1 if {
+          input.x == 1
+        } else := 2 if {
+          input.x == 2
+        } else := 3
+
+        foo.every := 4 if {
+          input.x == 1
+        } else := 5 if {
+          input.x == 2
+        } else := 6
+    want_result:
+      - x: true
+  - note: keywordrefs/every keyword rule refhead, partial set
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p if {
+          every.foo == {"a", "c"}
+          foo.every == {"a", "c"}
+        }
+
+        every.foo contains "a"
+
+        every.foo contains "b" if {
+          false
+        }
+
+        every.foo contains "c" if {
+          true
+        }
+
+        foo.every contains "a"
+
+        foo.every contains "b" if {
+          false
+        }
+
+        foo.every contains "c" if {
+          true
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v1/keywordrefs/test-keyword-every.yaml
+++ b/v1/test/cases/testdata/v1/keywordrefs/test-keyword-every.yaml
@@ -108,3 +108,58 @@ cases:
         }
     want_result:
       - x: true
+  - note: keywordrefs/every keyword rule refhead, partial object
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p if {
+          every.foo == "a"
+          every.bar.one == "a"
+          every.bar.three == "c"
+          foo.every == "a"
+          bar.baz.every == "a"
+        }
+
+        every.foo := "a"
+
+        every.foo := "b" if {
+          false
+        }
+
+        every.foo := "c" if {
+          false
+        }
+
+        every.bar.one := "a"
+
+        every.bar.two := "b" if {
+          false
+        }
+
+        every.bar.three := "c" if {
+          true
+        }
+
+        foo.every := "a"
+
+        foo.every := "b" if {
+          false
+        }
+
+        foo.every := "c" if {
+          false
+        }
+
+        bar.baz.every := "a"
+
+        bar.baz.every := "b" if {
+          false
+        }
+
+        bar.baz.every := "c" if {
+          false
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v1/keywordrefs/test-keyword-every.yaml
+++ b/v1/test/cases/testdata/v1/keywordrefs/test-keyword-every.yaml
@@ -1,0 +1,52 @@
+---
+cases:
+  - note: keywordrefs/every keyword in package
+    query: data.foo.p = x
+    modules:
+      - |
+        package foo.every.bar
+
+        baz := 42
+      - |
+        package foo
+        import data.foo.every.bar
+        
+        p if {
+          bar.baz == 42
+          data.foo.every.bar.baz == 42
+        }
+    want_result:
+      - x: true
+  - note: keywordrefs/every keyword in package, import alias
+    query: data.foo.p = x
+    modules:
+      - |
+        package foo.every
+
+        bar := 42
+      - |
+        package foo
+        import data.foo.every as my_if
+        
+        p if {
+          my_if.bar == 42
+          data.foo.every.bar == 42
+        }
+    want_result:
+      - x: true
+  - note: keywordrefs/every keyword rule refhead
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+        
+        p if {
+          every.foo == 1
+          foo.every == 2
+        }
+        
+        every.foo := 1
+        
+        foo.every := 2
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v1/keywordrefs/test-keyword-every.yaml
+++ b/v1/test/cases/testdata/v1/keywordrefs/test-keyword-every.yaml
@@ -163,3 +163,37 @@ cases:
         }
     want_result:
       - x: true
+  - note: keywordrefs/every keyword function refhead
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p if {
+          every.foo(1) == 1
+          every.foo(11) == 42
+          foo.every(1) == 1
+          foo.every(11) == 42
+          bar.every.baz(1) == 1
+          bar.every.baz(11) == 42
+        }
+
+        default every.foo(_) := 42
+
+        every.foo(x) := x if {
+          x < 10
+        }
+
+        default foo.every(_) := 42
+
+        foo.every(x) := x if {
+          x < 10
+        }
+
+        default bar.every.baz(_) := 42
+
+        bar.every.baz(x) := x if {
+          x < 10
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v1/keywordrefs/test-keyword-false.yaml
+++ b/v1/test/cases/testdata/v1/keywordrefs/test-keyword-false.yaml
@@ -108,3 +108,58 @@ cases:
         }
     want_result:
       - x: true
+  - note: keywordrefs/false keyword rule refhead, partial object
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p if {
+          false.foo == "a"
+          false.bar.one == "a"
+          false.bar.three == "c"
+          foo.false == "a"
+          bar.baz.false == "a"
+        }
+
+        false.foo := "a"
+
+        false.foo := "b" if {
+          false
+        }
+
+        false.foo := "c" if {
+          false
+        }
+
+        false.bar.one := "a"
+
+        false.bar.two := "b" if {
+          false
+        }
+
+        false.bar.three := "c" if {
+          true
+        }
+
+        foo.false := "a"
+
+        foo.false := "b" if {
+          false
+        }
+
+        foo.false := "c" if {
+          false
+        }
+
+        bar.baz.false := "a"
+
+        bar.baz.false := "b" if {
+          false
+        }
+
+        bar.baz.false := "c" if {
+          false
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v1/keywordrefs/test-keyword-false.yaml
+++ b/v1/test/cases/testdata/v1/keywordrefs/test-keyword-false.yaml
@@ -163,3 +163,37 @@ cases:
         }
     want_result:
       - x: true
+  - note: keywordrefs/false keyword function refhead
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p if {
+          false.foo(1) == 1
+          false.foo(11) == 42
+          foo.false(1) == 1
+          foo.false(11) == 42
+          bar.false.baz(1) == 1
+          bar.false.baz(11) == 42
+        }
+
+        default false.foo(_) := 42
+
+        false.foo(x) := x if {
+          x < 10
+        }
+
+        default foo.false(_) := 42
+
+        foo.false(x) := x if {
+          x < 10
+        }
+
+        default bar.false.baz(_) := 42
+
+        bar.false.baz(x) := x if {
+          x < 10
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v1/keywordrefs/test-keyword-false.yaml
+++ b/v1/test/cases/testdata/v1/keywordrefs/test-keyword-false.yaml
@@ -1,0 +1,52 @@
+---
+cases:
+  - note: keywordrefs/false keyword in package
+    query: data.foo.p = x
+    modules:
+      - |
+        package foo.false.bar
+
+        baz := 42
+      - |
+        package foo
+        import data.foo.false.bar
+        
+        p if {
+          bar.baz == 42
+          data.foo.false.bar.baz == 42
+        }
+    want_result:
+      - x: true
+  - note: keywordrefs/false keyword in package, import alias
+    query: data.foo.p = x
+    modules:
+      - |
+        package foo.false
+
+        bar := 42
+      - |
+        package foo
+        import data.foo.false as my_if
+        
+        p if {
+          my_if.bar == 42
+          data.foo.false.bar == 42
+        }
+    want_result:
+      - x: true
+  - note: keywordrefs/false keyword rule refhead
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+        
+        p if {
+          false.foo == 1
+          foo.false == 2
+        }
+        
+        false.foo := 1
+        
+        foo.false := 2
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v1/keywordrefs/test-keyword-false.yaml
+++ b/v1/test/cases/testdata/v1/keywordrefs/test-keyword-false.yaml
@@ -50,3 +50,61 @@ cases:
         foo.false := 2
     want_result:
       - x: true
+  - note: keywordrefs/false keyword rule refhead, else bodies
+    query: data.test.p = x
+    input:
+      x: 3
+    modules:
+      - |
+        package test
+
+        p if {
+          false.foo == 3
+          foo.false == 6
+        }
+
+        false.foo := 1 if {
+          input.x == 1
+        } else := 2 if {
+          input.x == 2
+        } else := 3
+
+        foo.false := 4 if {
+          input.x == 1
+        } else := 5 if {
+          input.x == 2
+        } else := 6
+    want_result:
+      - x: true
+  - note: keywordrefs/false keyword rule refhead, partial set
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p if {
+          false.foo == {"a", "c"}
+          foo.false == {"a", "c"}
+        }
+
+        false.foo contains "a"
+
+        false.foo contains "b" if {
+          false
+        }
+
+        false.foo contains "c" if {
+          true
+        }
+
+        foo.false contains "a"
+
+        foo.false contains "b" if {
+          false
+        }
+
+        foo.false contains "c" if {
+          true
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v1/keywordrefs/test-keyword-if.yaml
+++ b/v1/test/cases/testdata/v1/keywordrefs/test-keyword-if.yaml
@@ -163,3 +163,37 @@ cases:
         }
     want_result:
       - x: true
+  - note: keywordrefs/if keyword function refhead
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p if {
+          if.foo(1) == 1
+          if.foo(11) == 42
+          foo.if(1) == 1
+          foo.if(11) == 42
+          bar.if.baz(1) == 1
+          bar.if.baz(11) == 42
+        }
+
+        default if.foo(_) := 42
+
+        if.foo(x) := x if {
+          x < 10
+        }
+
+        default foo.if(_) := 42
+
+        foo.if(x) := x if {
+          x < 10
+        }
+
+        default bar.if.baz(_) := 42
+
+        bar.if.baz(x) := x if {
+          x < 10
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v1/keywordrefs/test-keyword-if.yaml
+++ b/v1/test/cases/testdata/v1/keywordrefs/test-keyword-if.yaml
@@ -1,0 +1,52 @@
+---
+cases:
+  - note: keywordrefs/if keyword in package
+    query: data.foo.p = x
+    modules:
+      - |
+        package foo.if.bar
+
+        baz := 42
+      - |
+        package foo
+        import data.foo.if.bar
+        
+        p if {
+          bar.baz == 42
+          data.foo.if.bar.baz == 42
+        }
+    want_result:
+      - x: true
+  - note: keywordrefs/if keyword in package, import alias
+    query: data.foo.p = x
+    modules:
+      - |
+        package foo.if
+
+        bar := 42
+      - |
+        package foo
+        import data.foo.if as my_if
+        
+        p if {
+          my_if.bar == 42
+          data.foo.if.bar == 42
+        }
+    want_result:
+      - x: true
+  - note: keywordrefs/if keyword rule refhead
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+        
+        p if {
+          if.foo == 1
+          foo.if == 2
+        }
+        
+        if.foo := 1
+        
+        foo.if := 2
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v1/keywordrefs/test-keyword-if.yaml
+++ b/v1/test/cases/testdata/v1/keywordrefs/test-keyword-if.yaml
@@ -108,3 +108,58 @@ cases:
         }
     want_result:
       - x: true
+  - note: keywordrefs/if keyword rule refhead, partial object
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p if {
+          if.foo == "a"
+          if.bar.one == "a"
+          if.bar.three == "c"
+          foo.if == "a"
+          bar.baz.if == "a"
+        }
+
+        if.foo := "a"
+
+        if.foo := "b" if {
+          false
+        }
+
+        if.foo := "c" if {
+          false
+        }
+
+        if.bar.one := "a"
+
+        if.bar.two := "b" if {
+          false
+        }
+
+        if.bar.three := "c" if {
+          true
+        }
+
+        foo.if := "a"
+
+        foo.if := "b" if {
+          false
+        }
+
+        foo.if := "c" if {
+          false
+        }
+
+        bar.baz.if := "a"
+
+        bar.baz.if := "b" if {
+          false
+        }
+
+        bar.baz.if := "c" if {
+          false
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v1/keywordrefs/test-keyword-if.yaml
+++ b/v1/test/cases/testdata/v1/keywordrefs/test-keyword-if.yaml
@@ -50,3 +50,61 @@ cases:
         foo.if := 2
     want_result:
       - x: true
+  - note: keywordrefs/if keyword rule refhead, else bodies
+    query: data.test.p = x
+    input:
+      x: 3
+    modules:
+      - |
+        package test
+
+        p if {
+          if.foo == 3
+          foo.if == 6
+        }
+
+        if.foo := 1 if {
+          input.x == 1
+        } else := 2 if {
+          input.x == 2
+        } else := 3
+
+        foo.if := 4 if {
+          input.x == 1
+        } else := 5 if {
+          input.x == 2
+        } else := 6
+    want_result:
+      - x: true
+  - note: keywordrefs/if keyword rule refhead, partial set
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p if {
+          if.foo == {"a", "c"}
+          foo.if == {"a", "c"}
+        }
+
+        if.foo contains "a"
+
+        if.foo contains "b" if {
+          false
+        }
+
+        if.foo contains "c" if {
+          true
+        }
+
+        foo.if contains "a"
+
+        foo.if contains "b" if {
+          false
+        }
+
+        foo.if contains "c" if {
+          true
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v1/keywordrefs/test-keyword-import.yaml
+++ b/v1/test/cases/testdata/v1/keywordrefs/test-keyword-import.yaml
@@ -1,0 +1,52 @@
+---
+cases:
+  - note: keywordrefs/import keyword in package
+    query: data.foo.p = x
+    modules:
+      - |
+        package foo.import.bar
+
+        baz := 42
+      - |
+        package foo
+        import data.foo.import.bar
+        
+        p if {
+          bar.baz == 42
+          data.foo.import.bar.baz == 42
+        }
+    want_result:
+      - x: true
+  - note: keywordrefs/import keyword in package, import alias
+    query: data.foo.p = x
+    modules:
+      - |
+        package foo.import
+
+        bar := 42
+      - |
+        package foo
+        import data.foo.import as my_if
+        
+        p if {
+          my_if.bar == 42
+          data.foo.import.bar == 42
+        }
+    want_result:
+      - x: true
+  - note: keywordrefs/import keyword rule refhead
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+        
+        p if {
+          import.foo == 1
+          foo.import == 2
+        }
+        
+        import.foo := 1
+        
+        foo.import := 2
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v1/keywordrefs/test-keyword-import.yaml
+++ b/v1/test/cases/testdata/v1/keywordrefs/test-keyword-import.yaml
@@ -163,3 +163,37 @@ cases:
         }
     want_result:
       - x: true
+  - note: keywordrefs/import keyword function refhead
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p if {
+          import.foo(1) == 1
+          import.foo(11) == 42
+          foo.import(1) == 1
+          foo.import(11) == 42
+          bar.import.baz(1) == 1
+          bar.import.baz(11) == 42
+        }
+
+        default import.foo(_) := 42
+
+        import.foo(x) := x if {
+          x < 10
+        }
+
+        default foo.import(_) := 42
+
+        foo.import(x) := x if {
+          x < 10
+        }
+
+        default bar.import.baz(_) := 42
+
+        bar.import.baz(x) := x if {
+          x < 10
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v1/keywordrefs/test-keyword-import.yaml
+++ b/v1/test/cases/testdata/v1/keywordrefs/test-keyword-import.yaml
@@ -50,3 +50,61 @@ cases:
         foo.import := 2
     want_result:
       - x: true
+  - note: keywordrefs/import keyword rule refhead, else bodies
+    query: data.test.p = x
+    input:
+      x: 3
+    modules:
+      - |
+        package test
+
+        p if {
+          import.foo == 3
+          foo.import == 6
+        }
+
+        import.foo := 1 if {
+          input.x == 1
+        } else := 2 if {
+          input.x == 2
+        } else := 3
+
+        foo.import := 4 if {
+          input.x == 1
+        } else := 5 if {
+          input.x == 2
+        } else := 6
+    want_result:
+      - x: true
+  - note: keywordrefs/import keyword rule refhead, partial set
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p if {
+          import.foo == {"a", "c"}
+          foo.import == {"a", "c"}
+        }
+
+        import.foo contains "a"
+
+        import.foo contains "b" if {
+          false
+        }
+
+        import.foo contains "c" if {
+          true
+        }
+
+        foo.import contains "a"
+
+        foo.import contains "b" if {
+          false
+        }
+
+        foo.import contains "c" if {
+          true
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v1/keywordrefs/test-keyword-import.yaml
+++ b/v1/test/cases/testdata/v1/keywordrefs/test-keyword-import.yaml
@@ -108,3 +108,58 @@ cases:
         }
     want_result:
       - x: true
+  - note: keywordrefs/import keyword rule refhead, partial object
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p if {
+          import.foo == "a"
+          import.bar.one == "a"
+          import.bar.three == "c"
+          foo.import == "a"
+          bar.baz.import == "a"
+        }
+
+        import.foo := "a"
+
+        import.foo := "b" if {
+          false
+        }
+
+        import.foo := "c" if {
+          false
+        }
+
+        import.bar.one := "a"
+
+        import.bar.two := "b" if {
+          false
+        }
+
+        import.bar.three := "c" if {
+          true
+        }
+
+        foo.import := "a"
+
+        foo.import := "b" if {
+          false
+        }
+
+        foo.import := "c" if {
+          false
+        }
+
+        bar.baz.import := "a"
+
+        bar.baz.import := "b" if {
+          false
+        }
+
+        bar.baz.import := "c" if {
+          false
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v1/keywordrefs/test-keyword-in.yaml
+++ b/v1/test/cases/testdata/v1/keywordrefs/test-keyword-in.yaml
@@ -50,3 +50,61 @@ cases:
         foo.in := 2
     want_result:
       - x: true
+  - note: keywordrefs/in keyword rule refhead, else bodies
+    query: data.test.p = x
+    input:
+      x: 3
+    modules:
+      - |
+        package test
+
+        p if {
+          in.foo == 3
+          foo.in == 6
+        }
+
+        in.foo := 1 if {
+          input.x == 1
+        } else := 2 if {
+          input.x == 2
+        } else := 3
+
+        foo.in := 4 if {
+          input.x == 1
+        } else := 5 if {
+          input.x == 2
+        } else := 6
+    want_result:
+      - x: true
+  - note: keywordrefs/in keyword rule refhead, partial set
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p if {
+          in.foo == {"a", "c"}
+          foo.in == {"a", "c"}
+        }
+
+        in.foo contains "a"
+
+        in.foo contains "b" if {
+          false
+        }
+
+        in.foo contains "c" if {
+          true
+        }
+
+        foo.in contains "a"
+
+        foo.in contains "b" if {
+          false
+        }
+
+        foo.in contains "c" if {
+          true
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v1/keywordrefs/test-keyword-in.yaml
+++ b/v1/test/cases/testdata/v1/keywordrefs/test-keyword-in.yaml
@@ -1,0 +1,52 @@
+---
+cases:
+  - note: keywordrefs/in keyword in package
+    query: data.foo.p = x
+    modules:
+      - |
+        package foo.in.bar
+
+        baz := 42
+      - |
+        package foo
+        import data.foo.in.bar
+        
+        p if {
+          bar.baz == 42
+          data.foo.in.bar.baz == 42
+        }
+    want_result:
+      - x: true
+  - note: keywordrefs/in keyword in package, import alias
+    query: data.foo.p = x
+    modules:
+      - |
+        package foo.in
+
+        bar := 42
+      - |
+        package foo
+        import data.foo.in as my_if
+        
+        p if {
+          my_if.bar == 42
+          data.foo.in.bar == 42
+        }
+    want_result:
+      - x: true
+  - note: keywordrefs/in keyword rule refhead
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+        
+        p if {
+          in.foo == 1
+          foo.in == 2
+        }
+        
+        in.foo := 1
+        
+        foo.in := 2
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v1/keywordrefs/test-keyword-in.yaml
+++ b/v1/test/cases/testdata/v1/keywordrefs/test-keyword-in.yaml
@@ -108,3 +108,58 @@ cases:
         }
     want_result:
       - x: true
+  - note: keywordrefs/in keyword rule refhead, partial object
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p if {
+          in.foo == "a"
+          in.bar.one == "a"
+          in.bar.three == "c"
+          foo.in == "a"
+          bar.baz.in == "a"
+        }
+
+        in.foo := "a"
+
+        in.foo := "b" if {
+          false
+        }
+
+        in.foo := "c" if {
+          false
+        }
+
+        in.bar.one := "a"
+
+        in.bar.two := "b" if {
+          false
+        }
+
+        in.bar.three := "c" if {
+          true
+        }
+
+        foo.in := "a"
+
+        foo.in := "b" if {
+          false
+        }
+
+        foo.in := "c" if {
+          false
+        }
+
+        bar.baz.in := "a"
+
+        bar.baz.in := "b" if {
+          false
+        }
+
+        bar.baz.in := "c" if {
+          false
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v1/keywordrefs/test-keyword-in.yaml
+++ b/v1/test/cases/testdata/v1/keywordrefs/test-keyword-in.yaml
@@ -163,3 +163,37 @@ cases:
         }
     want_result:
       - x: true
+  - note: keywordrefs/in keyword function refhead
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p if {
+          in.foo(1) == 1
+          in.foo(11) == 42
+          foo.in(1) == 1
+          foo.in(11) == 42
+          bar.in.baz(1) == 1
+          bar.in.baz(11) == 42
+        }
+
+        default in.foo(_) := 42
+
+        in.foo(x) := x if {
+          x < 10
+        }
+
+        default foo.in(_) := 42
+
+        foo.in(x) := x if {
+          x < 10
+        }
+
+        default bar.in.baz(_) := 42
+
+        bar.in.baz(x) := x if {
+          x < 10
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v1/keywordrefs/test-keyword-not.yaml
+++ b/v1/test/cases/testdata/v1/keywordrefs/test-keyword-not.yaml
@@ -108,3 +108,58 @@ cases:
         }
     want_result:
       - x: true
+  - note: keywordrefs/not keyword rule refhead, partial object
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p if {
+          not.foo == "a"
+          not.bar.one == "a"
+          not.bar.three == "c"
+          foo.not == "a"
+          bar.baz.not == "a"
+        }
+
+        not.foo := "a"
+
+        not.foo := "b" if {
+          false
+        }
+
+        not.foo := "c" if {
+          false
+        }
+
+        not.bar.one := "a"
+
+        not.bar.two := "b" if {
+          false
+        }
+
+        not.bar.three := "c" if {
+          true
+        }
+
+        foo.not := "a"
+
+        foo.not := "b" if {
+          false
+        }
+
+        foo.not := "c" if {
+          false
+        }
+
+        bar.baz.not := "a"
+
+        bar.baz.not := "b" if {
+          false
+        }
+
+        bar.baz.not := "c" if {
+          false
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v1/keywordrefs/test-keyword-not.yaml
+++ b/v1/test/cases/testdata/v1/keywordrefs/test-keyword-not.yaml
@@ -1,0 +1,52 @@
+---
+cases:
+  - note: keywordrefs/not keyword in package
+    query: data.foo.p = x
+    modules:
+      - |
+        package foo.not.bar
+
+        baz := 42
+      - |
+        package foo
+        import data.foo.not.bar
+        
+        p if {
+          bar.baz == 42
+          data.foo.not.bar.baz == 42
+        }
+    want_result:
+      - x: true
+  - note: keywordrefs/not keyword in package, import alias
+    query: data.foo.p = x
+    modules:
+      - |
+        package foo.not
+
+        bar := 42
+      - |
+        package foo
+        import data.foo.not as my_if
+        
+        p if {
+          my_if.bar == 42
+          data.foo.not.bar == 42
+        }
+    want_result:
+      - x: true
+  - note: keywordrefs/not keyword rule refhead
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+        
+        p if {
+          not.foo == 1
+          foo.not == 2
+        }
+        
+        not.foo := 1
+        
+        foo.not := 2
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v1/keywordrefs/test-keyword-not.yaml
+++ b/v1/test/cases/testdata/v1/keywordrefs/test-keyword-not.yaml
@@ -50,3 +50,61 @@ cases:
         foo.not := 2
     want_result:
       - x: true
+  - note: keywordrefs/not keyword rule refhead, else bodies
+    query: data.test.p = x
+    input:
+      x: 3
+    modules:
+      - |
+        package test
+
+        p if {
+          not.foo == 3
+          foo.not == 6
+        }
+
+        not.foo := 1 if {
+          input.x == 1
+        } else := 2 if {
+          input.x == 2
+        } else := 3
+
+        foo.not := 4 if {
+          input.x == 1
+        } else := 5 if {
+          input.x == 2
+        } else := 6
+    want_result:
+      - x: true
+  - note: keywordrefs/not keyword rule refhead, partial set
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p if {
+          not.foo == {"a", "c"}
+          foo.not == {"a", "c"}
+        }
+
+        not.foo contains "a"
+
+        not.foo contains "b" if {
+          false
+        }
+
+        not.foo contains "c" if {
+          true
+        }
+
+        foo.not contains "a"
+
+        foo.not contains "b" if {
+          false
+        }
+
+        foo.not contains "c" if {
+          true
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v1/keywordrefs/test-keyword-not.yaml
+++ b/v1/test/cases/testdata/v1/keywordrefs/test-keyword-not.yaml
@@ -163,3 +163,37 @@ cases:
         }
     want_result:
       - x: true
+  - note: keywordrefs/not keyword function refhead
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p if {
+          not.foo(1) == 1
+          not.foo(11) == 42
+          foo.not(1) == 1
+          foo.not(11) == 42
+          bar.not.baz(1) == 1
+          bar.not.baz(11) == 42
+        }
+
+        default not.foo(_) := 42
+
+        not.foo(x) := x if {
+          x < 10
+        }
+
+        default foo.not(_) := 42
+
+        foo.not(x) := x if {
+          x < 10
+        }
+
+        default bar.not.baz(_) := 42
+
+        bar.not.baz(x) := x if {
+          x < 10
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v1/keywordrefs/test-keyword-null.yaml
+++ b/v1/test/cases/testdata/v1/keywordrefs/test-keyword-null.yaml
@@ -108,3 +108,58 @@ cases:
         }
     want_result:
       - x: true
+  - note: keywordrefs/null keyword rule refhead, partial object
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p if {
+          null.foo == "a"
+          null.bar.one == "a"
+          null.bar.three == "c"
+          foo.null == "a"
+          bar.baz.null == "a"
+        }
+
+        null.foo := "a"
+
+        null.foo := "b" if {
+          false
+        }
+
+        null.foo := "c" if {
+          false
+        }
+
+        null.bar.one := "a"
+
+        null.bar.two := "b" if {
+          false
+        }
+
+        null.bar.three := "c" if {
+          true
+        }
+
+        foo.null := "a"
+
+        foo.null := "b" if {
+          false
+        }
+
+        foo.null := "c" if {
+          false
+        }
+
+        bar.baz.null := "a"
+
+        bar.baz.null := "b" if {
+          false
+        }
+
+        bar.baz.null := "c" if {
+          false
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v1/keywordrefs/test-keyword-null.yaml
+++ b/v1/test/cases/testdata/v1/keywordrefs/test-keyword-null.yaml
@@ -163,3 +163,37 @@ cases:
         }
     want_result:
       - x: true
+  - note: keywordrefs/null keyword function refhead
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p if {
+          null.foo(1) == 1
+          null.foo(11) == 42
+          foo.null(1) == 1
+          foo.null(11) == 42
+          bar.null.baz(1) == 1
+          bar.null.baz(11) == 42
+        }
+
+        default null.foo(_) := 42
+
+        null.foo(x) := x if {
+          x < 10
+        }
+
+        default foo.null(_) := 42
+
+        foo.null(x) := x if {
+          x < 10
+        }
+
+        default bar.null.baz(_) := 42
+
+        bar.null.baz(x) := x if {
+          x < 10
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v1/keywordrefs/test-keyword-null.yaml
+++ b/v1/test/cases/testdata/v1/keywordrefs/test-keyword-null.yaml
@@ -50,3 +50,61 @@ cases:
         foo.null := 2
     want_result:
       - x: true
+  - note: keywordrefs/null keyword rule refhead, else bodies
+    query: data.test.p = x
+    input:
+      x: 3
+    modules:
+      - |
+        package test
+
+        p if {
+          null.foo == 3
+          foo.null == 6
+        }
+
+        null.foo := 1 if {
+          input.x == 1
+        } else := 2 if {
+          input.x == 2
+        } else := 3
+
+        foo.null := 4 if {
+          input.x == 1
+        } else := 5 if {
+          input.x == 2
+        } else := 6
+    want_result:
+      - x: true
+  - note: keywordrefs/null keyword rule refhead, partial set
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p if {
+          null.foo == {"a", "c"}
+          foo.null == {"a", "c"}
+        }
+
+        null.foo contains "a"
+
+        null.foo contains "b" if {
+          false
+        }
+
+        null.foo contains "c" if {
+          true
+        }
+
+        foo.null contains "a"
+
+        foo.null contains "b" if {
+          false
+        }
+
+        foo.null contains "c" if {
+          true
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v1/keywordrefs/test-keyword-null.yaml
+++ b/v1/test/cases/testdata/v1/keywordrefs/test-keyword-null.yaml
@@ -1,0 +1,52 @@
+---
+cases:
+  - note: keywordrefs/null keyword in package
+    query: data.foo.p = x
+    modules:
+      - |
+        package foo.null.bar
+
+        baz := 42
+      - |
+        package foo
+        import data.foo.null.bar
+        
+        p if {
+          bar.baz == 42
+          data.foo.null.bar.baz == 42
+        }
+    want_result:
+      - x: true
+  - note: keywordrefs/null keyword in package, import alias
+    query: data.foo.p = x
+    modules:
+      - |
+        package foo.null
+
+        bar := 42
+      - |
+        package foo
+        import data.foo.null as my_if
+        
+        p if {
+          my_if.bar == 42
+          data.foo.null.bar == 42
+        }
+    want_result:
+      - x: true
+  - note: keywordrefs/null keyword rule refhead
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+        
+        p if {
+          null.foo == 1
+          foo.null == 2
+        }
+        
+        null.foo := 1
+        
+        foo.null := 2
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v1/keywordrefs/test-keyword-package.yaml
+++ b/v1/test/cases/testdata/v1/keywordrefs/test-keyword-package.yaml
@@ -1,0 +1,52 @@
+---
+cases:
+  - note: keywordrefs/package keyword in package
+    query: data.foo.p = x
+    modules:
+      - |
+        package foo.package.bar
+
+        baz := 42
+      - |
+        package foo
+        import data.foo.package.bar
+        
+        p if {
+          bar.baz == 42
+          data.foo.package.bar.baz == 42
+        }
+    want_result:
+      - x: true
+  - note: keywordrefs/package keyword in package, import alias
+    query: data.foo.p = x
+    modules:
+      - |
+        package foo.package
+
+        bar := 42
+      - |
+        package foo
+        import data.foo.package as my_if
+        
+        p if {
+          my_if.bar == 42
+          data.foo.package.bar == 42
+        }
+    want_result:
+      - x: true
+  - note: keywordrefs/package keyword rule refhead
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+        
+        p if {
+          package.foo == 1
+          foo.package == 2
+        }
+        
+        package.foo := 1
+        
+        foo.package := 2
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v1/keywordrefs/test-keyword-package.yaml
+++ b/v1/test/cases/testdata/v1/keywordrefs/test-keyword-package.yaml
@@ -108,3 +108,58 @@ cases:
         }
     want_result:
       - x: true
+  - note: keywordrefs/package keyword rule refhead, partial object
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p if {
+          package.foo == "a"
+          package.bar.one == "a"
+          package.bar.three == "c"
+          foo.package == "a"
+          bar.baz.package == "a"
+        }
+
+        package.foo := "a"
+
+        package.foo := "b" if {
+          false
+        }
+
+        package.foo := "c" if {
+          false
+        }
+
+        package.bar.one := "a"
+
+        package.bar.two := "b" if {
+          false
+        }
+
+        package.bar.three := "c" if {
+          true
+        }
+
+        foo.package := "a"
+
+        foo.package := "b" if {
+          false
+        }
+
+        foo.package := "c" if {
+          false
+        }
+
+        bar.baz.package := "a"
+
+        bar.baz.package := "b" if {
+          false
+        }
+
+        bar.baz.package := "c" if {
+          false
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v1/keywordrefs/test-keyword-package.yaml
+++ b/v1/test/cases/testdata/v1/keywordrefs/test-keyword-package.yaml
@@ -163,3 +163,37 @@ cases:
         }
     want_result:
       - x: true
+  - note: keywordrefs/package keyword function refhead
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p if {
+          package.foo(1) == 1
+          package.foo(11) == 42
+          foo.package(1) == 1
+          foo.package(11) == 42
+          bar.package.baz(1) == 1
+          bar.package.baz(11) == 42
+        }
+
+        default package.foo(_) := 42
+
+        package.foo(x) := x if {
+          x < 10
+        }
+
+        default foo.package(_) := 42
+
+        foo.package(x) := x if {
+          x < 10
+        }
+
+        default bar.package.baz(_) := 42
+
+        bar.package.baz(x) := x if {
+          x < 10
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v1/keywordrefs/test-keyword-package.yaml
+++ b/v1/test/cases/testdata/v1/keywordrefs/test-keyword-package.yaml
@@ -50,3 +50,61 @@ cases:
         foo.package := 2
     want_result:
       - x: true
+  - note: keywordrefs/package keyword rule refhead, else bodies
+    query: data.test.p = x
+    input:
+      x: 3
+    modules:
+      - |
+        package test
+
+        p if {
+          package.foo == 3
+          foo.package == 6
+        }
+
+        package.foo := 1 if {
+          input.x == 1
+        } else := 2 if {
+          input.x == 2
+        } else := 3
+
+        foo.package := 4 if {
+          input.x == 1
+        } else := 5 if {
+          input.x == 2
+        } else := 6
+    want_result:
+      - x: true
+  - note: keywordrefs/package keyword rule refhead, partial set
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p if {
+          package.foo == {"a", "c"}
+          foo.package == {"a", "c"}
+        }
+
+        package.foo contains "a"
+
+        package.foo contains "b" if {
+          false
+        }
+
+        package.foo contains "c" if {
+          true
+        }
+
+        foo.package contains "a"
+
+        foo.package contains "b" if {
+          false
+        }
+
+        foo.package contains "c" if {
+          true
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v1/keywordrefs/test-keyword-some.yaml
+++ b/v1/test/cases/testdata/v1/keywordrefs/test-keyword-some.yaml
@@ -50,3 +50,61 @@ cases:
         foo.some := 2
     want_result:
       - x: true
+  - note: keywordrefs/some keyword rule refhead, else bodies
+    query: data.test.p = x
+    input:
+      x: 3
+    modules:
+      - |
+        package test
+
+        p if {
+          some.foo == 3
+          foo.some == 6
+        }
+
+        some.foo := 1 if {
+          input.x == 1
+        } else := 2 if {
+          input.x == 2
+        } else := 3
+
+        foo.some := 4 if {
+          input.x == 1
+        } else := 5 if {
+          input.x == 2
+        } else := 6
+    want_result:
+      - x: true
+  - note: keywordrefs/some keyword rule refhead, partial set
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p if {
+          some.foo == {"a", "c"}
+          foo.some == {"a", "c"}
+        }
+
+        some.foo contains "a"
+
+        some.foo contains "b" if {
+          false
+        }
+
+        some.foo contains "c" if {
+          true
+        }
+
+        foo.some contains "a"
+
+        foo.some contains "b" if {
+          false
+        }
+
+        foo.some contains "c" if {
+          true
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v1/keywordrefs/test-keyword-some.yaml
+++ b/v1/test/cases/testdata/v1/keywordrefs/test-keyword-some.yaml
@@ -1,0 +1,52 @@
+---
+cases:
+  - note: keywordrefs/some keyword in package
+    query: data.foo.p = x
+    modules:
+      - |
+        package foo.some.bar
+
+        baz := 42
+      - |
+        package foo
+        import data.foo.some.bar
+        
+        p if {
+          bar.baz == 42
+          data.foo.some.bar.baz == 42
+        }
+    want_result:
+      - x: true
+  - note: keywordrefs/some keyword in package, import alias
+    query: data.foo.p = x
+    modules:
+      - |
+        package foo.some
+
+        bar := 42
+      - |
+        package foo
+        import data.foo.some as my_if
+        
+        p if {
+          my_if.bar == 42
+          data.foo.some.bar == 42
+        }
+    want_result:
+      - x: true
+  - note: keywordrefs/some keyword rule refhead
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+        
+        p if {
+          some.foo == 1
+          foo.some == 2
+        }
+        
+        some.foo := 1
+        
+        foo.some := 2
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v1/keywordrefs/test-keyword-some.yaml
+++ b/v1/test/cases/testdata/v1/keywordrefs/test-keyword-some.yaml
@@ -163,3 +163,37 @@ cases:
         }
     want_result:
       - x: true
+  - note: keywordrefs/some keyword function refhead
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p if {
+          some.foo(1) == 1
+          some.foo(11) == 42
+          foo.some(1) == 1
+          foo.some(11) == 42
+          bar.some.baz(1) == 1
+          bar.some.baz(11) == 42
+        }
+
+        default some.foo(_) := 42
+
+        some.foo(x) := x if {
+          x < 10
+        }
+
+        default foo.some(_) := 42
+
+        foo.some(x) := x if {
+          x < 10
+        }
+
+        default bar.some.baz(_) := 42
+
+        bar.some.baz(x) := x if {
+          x < 10
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v1/keywordrefs/test-keyword-some.yaml
+++ b/v1/test/cases/testdata/v1/keywordrefs/test-keyword-some.yaml
@@ -108,3 +108,58 @@ cases:
         }
     want_result:
       - x: true
+  - note: keywordrefs/some keyword rule refhead, partial object
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p if {
+          some.foo == "a"
+          some.bar.one == "a"
+          some.bar.three == "c"
+          foo.some == "a"
+          bar.baz.some == "a"
+        }
+
+        some.foo := "a"
+
+        some.foo := "b" if {
+          false
+        }
+
+        some.foo := "c" if {
+          false
+        }
+
+        some.bar.one := "a"
+
+        some.bar.two := "b" if {
+          false
+        }
+
+        some.bar.three := "c" if {
+          true
+        }
+
+        foo.some := "a"
+
+        foo.some := "b" if {
+          false
+        }
+
+        foo.some := "c" if {
+          false
+        }
+
+        bar.baz.some := "a"
+
+        bar.baz.some := "b" if {
+          false
+        }
+
+        bar.baz.some := "c" if {
+          false
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v1/keywordrefs/test-keyword-true.yaml
+++ b/v1/test/cases/testdata/v1/keywordrefs/test-keyword-true.yaml
@@ -1,0 +1,52 @@
+---
+cases:
+  - note: keywordrefs/true keyword in package
+    query: data.foo.p = x
+    modules:
+      - |
+        package foo.true.bar
+
+        baz := 42
+      - |
+        package foo
+        import data.foo.true.bar
+        
+        p if {
+          bar.baz == 42
+          data.foo.true.bar.baz == 42
+        }
+    want_result:
+      - x: true
+  - note: keywordrefs/true keyword in package, import alias
+    query: data.foo.p = x
+    modules:
+      - |
+        package foo.true
+
+        bar := 42
+      - |
+        package foo
+        import data.foo.true as my_if
+        
+        p if {
+          my_if.bar == 42
+          data.foo.true.bar == 42
+        }
+    want_result:
+      - x: true
+  - note: keywordrefs/true keyword rule refhead
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+        
+        p if {
+          true.foo == 1
+          foo.true == 2
+        }
+        
+        true.foo := 1
+        
+        foo.true := 2
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v1/keywordrefs/test-keyword-true.yaml
+++ b/v1/test/cases/testdata/v1/keywordrefs/test-keyword-true.yaml
@@ -108,3 +108,58 @@ cases:
         }
     want_result:
       - x: true
+  - note: keywordrefs/true keyword rule refhead, partial object
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p if {
+          true.foo == "a"
+          true.bar.one == "a"
+          true.bar.three == "c"
+          foo.true == "a"
+          bar.baz.true == "a"
+        }
+
+        true.foo := "a"
+
+        true.foo := "b" if {
+          false
+        }
+
+        true.foo := "c" if {
+          false
+        }
+
+        true.bar.one := "a"
+
+        true.bar.two := "b" if {
+          false
+        }
+
+        true.bar.three := "c" if {
+          true
+        }
+
+        foo.true := "a"
+
+        foo.true := "b" if {
+          false
+        }
+
+        foo.true := "c" if {
+          false
+        }
+
+        bar.baz.true := "a"
+
+        bar.baz.true := "b" if {
+          false
+        }
+
+        bar.baz.true := "c" if {
+          false
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v1/keywordrefs/test-keyword-true.yaml
+++ b/v1/test/cases/testdata/v1/keywordrefs/test-keyword-true.yaml
@@ -50,3 +50,61 @@ cases:
         foo.true := 2
     want_result:
       - x: true
+  - note: keywordrefs/true keyword rule refhead, else bodies
+    query: data.test.p = x
+    input:
+      x: 3
+    modules:
+      - |
+        package test
+
+        p if {
+          true.foo == 3
+          foo.true == 6
+        }
+
+        true.foo := 1 if {
+          input.x == 1
+        } else := 2 if {
+          input.x == 2
+        } else := 3
+
+        foo.true := 4 if {
+          input.x == 1
+        } else := 5 if {
+          input.x == 2
+        } else := 6
+    want_result:
+      - x: true
+  - note: keywordrefs/true keyword rule refhead, partial set
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p if {
+          true.foo == {"a", "c"}
+          foo.true == {"a", "c"}
+        }
+
+        true.foo contains "a"
+
+        true.foo contains "b" if {
+          false
+        }
+
+        true.foo contains "c" if {
+          true
+        }
+
+        foo.true contains "a"
+
+        foo.true contains "b" if {
+          false
+        }
+
+        foo.true contains "c" if {
+          true
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v1/keywordrefs/test-keyword-true.yaml
+++ b/v1/test/cases/testdata/v1/keywordrefs/test-keyword-true.yaml
@@ -163,3 +163,37 @@ cases:
         }
     want_result:
       - x: true
+  - note: keywordrefs/true keyword function refhead
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p if {
+          true.foo(1) == 1
+          true.foo(11) == 42
+          foo.true(1) == 1
+          foo.true(11) == 42
+          bar.true.baz(1) == 1
+          bar.true.baz(11) == 42
+        }
+
+        default true.foo(_) := 42
+
+        true.foo(x) := x if {
+          x < 10
+        }
+
+        default foo.true(_) := 42
+
+        foo.true(x) := x if {
+          x < 10
+        }
+
+        default bar.true.baz(_) := 42
+
+        bar.true.baz(x) := x if {
+          x < 10
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v1/keywordrefs/test-keyword-with.yaml
+++ b/v1/test/cases/testdata/v1/keywordrefs/test-keyword-with.yaml
@@ -1,0 +1,52 @@
+---
+cases:
+  - note: keywordrefs/with keyword in package
+    query: data.foo.p = x
+    modules:
+      - |
+        package foo.with.bar
+
+        baz := 42
+      - |
+        package foo
+        import data.foo.with.bar
+        
+        p if {
+          bar.baz == 42
+          data.foo.with.bar.baz == 42
+        }
+    want_result:
+      - x: true
+  - note: keywordrefs/with keyword in package, import alias
+    query: data.foo.p = x
+    modules:
+      - |
+        package foo.with
+
+        bar := 42
+      - |
+        package foo
+        import data.foo.with as my_if
+        
+        p if {
+          my_if.bar == 42
+          data.foo.with.bar == 42
+        }
+    want_result:
+      - x: true
+  - note: keywordrefs/with keyword rule refhead
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+        
+        p if {
+          with.foo == 1
+          foo.with == 2
+        }
+        
+        with.foo := 1
+        
+        foo.with := 2
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v1/keywordrefs/test-keyword-with.yaml
+++ b/v1/test/cases/testdata/v1/keywordrefs/test-keyword-with.yaml
@@ -50,3 +50,61 @@ cases:
         foo.with := 2
     want_result:
       - x: true
+  - note: keywordrefs/with keyword rule refhead, else bodies
+    query: data.test.p = x
+    input:
+      x: 3
+    modules:
+      - |
+        package test
+
+        p if {
+          with.foo == 3
+          foo.with == 6
+        }
+
+        with.foo := 1 if {
+          input.x == 1
+        } else := 2 if {
+          input.x == 2
+        } else := 3
+
+        foo.with := 4 if {
+          input.x == 1
+        } else := 5 if {
+          input.x == 2
+        } else := 6
+    want_result:
+      - x: true
+  - note: keywordrefs/with keyword rule refhead, partial set
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p if {
+          with.foo == {"a", "c"}
+          foo.with == {"a", "c"}
+        }
+
+        with.foo contains "a"
+
+        with.foo contains "b" if {
+          false
+        }
+
+        with.foo contains "c" if {
+          true
+        }
+
+        foo.with contains "a"
+
+        foo.with contains "b" if {
+          false
+        }
+
+        foo.with contains "c" if {
+          true
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v1/keywordrefs/test-keyword-with.yaml
+++ b/v1/test/cases/testdata/v1/keywordrefs/test-keyword-with.yaml
@@ -163,3 +163,37 @@ cases:
         }
     want_result:
       - x: true
+  - note: keywordrefs/with keyword function refhead
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p if {
+          with.foo(1) == 1
+          with.foo(11) == 42
+          foo.with(1) == 1
+          foo.with(11) == 42
+          bar.with.baz(1) == 1
+          bar.with.baz(11) == 42
+        }
+
+        default with.foo(_) := 42
+
+        with.foo(x) := x if {
+          x < 10
+        }
+
+        default foo.with(_) := 42
+
+        foo.with(x) := x if {
+          x < 10
+        }
+
+        default bar.with.baz(_) := 42
+
+        bar.with.baz(x) := x if {
+          x < 10
+        }
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v1/keywordrefs/test-keyword-with.yaml
+++ b/v1/test/cases/testdata/v1/keywordrefs/test-keyword-with.yaml
@@ -108,3 +108,58 @@ cases:
         }
     want_result:
       - x: true
+  - note: keywordrefs/with keyword rule refhead, partial object
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p if {
+          with.foo == "a"
+          with.bar.one == "a"
+          with.bar.three == "c"
+          foo.with == "a"
+          bar.baz.with == "a"
+        }
+
+        with.foo := "a"
+
+        with.foo := "b" if {
+          false
+        }
+
+        with.foo := "c" if {
+          false
+        }
+
+        with.bar.one := "a"
+
+        with.bar.two := "b" if {
+          false
+        }
+
+        with.bar.three := "c" if {
+          true
+        }
+
+        foo.with := "a"
+
+        foo.with := "b" if {
+          false
+        }
+
+        foo.with := "c" if {
+          false
+        }
+
+        bar.baz.with := "a"
+
+        bar.baz.with := "b" if {
+          false
+        }
+
+        bar.baz.with := "c" if {
+          false
+        }
+    want_result:
+      - x: true


### PR DESCRIPTION
Updating the parser and formatter to allow keywords in refs. 

Before this change references containing keywords were invalid:

```rego
package example

allow if {
  # Invalid: 'import' and 'package' are keywords, and may not be used in a ref
  input.import.package.origin == "Italy"
}
```

and keywords had to be expressed as bracketed string terms:

```rego
package example

allow if {
  input["import"]["package"].origin == "Italy"
}
```

There is however no ambiguity when keywords are used as Rego reference terms, and the parser has been updated to accept this scenario. Likewise, the formatter will not enclose keywords in bracketed strings when they occur in references. 

To maximize compatibility with older OPA versions, Rego containing refs with bracketed string keywords will be retained when formatted or built (e.g. `input["import"]["package"].origin` will remain as `input["import"]["package"].origin` in the output Rego). Additionally, the new `keywords_in_refs` capability feature is required to accept Rego references containing keywords (e.g. when using the `--capabilities` flag with `opa eval`, `opa build`, `opa check`, etc.) and to output Rego references containing keywords when using the `--capabilities` flag with `opa fmt`.