### PR TITLE
docs: Show edge rather than latest release

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -44,6 +44,10 @@ const baseUrl = "/";
       ],
     ],
 
+    customFields: {
+      buildVersion: process.env.BUILD_VERSION,
+    },
+
     markdown: {
       mermaid: true,
     },

--- a/docs/src/components/NavbarItems/CurrentVersionNavbarItem.js
+++ b/docs/src/components/NavbarItems/CurrentVersionNavbarItem.js
@@ -5,6 +5,7 @@ import React from "react";
 
 import BrowserOnly from "@docusaurus/BrowserOnly";
 import useBaseUrl from "@docusaurus/useBaseUrl";
+import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 import semver from "semver";
 
 import DefaultNavbarItem from "@theme/NavbarItem/DefaultNavbarItem";
@@ -17,6 +18,9 @@ export default function CurrentVersionNavbarItem({ ...props }) {
   const baseUrl = useBaseUrl("/");
   const normalizedBaseUrl = baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`;
   const href = useBaseUrl("/docs/archive");
+
+  const { siteConfig: { customFields } } = useDocusaurusContext();
+  const version = customFields.buildVersion || "edge";
 
   // on the mobile menu, show nothing. Note, the 'Desktop' item has 'display'
   // set, so it'll appear on mobile too.
@@ -34,7 +38,7 @@ export default function CurrentVersionNavbarItem({ ...props }) {
           <div className={styles.versionWrapper}>
             <DefaultNavbarItem
               {...props}
-              label={"edge"}
+              label={`${version}`}
               href={href}
             />
           </div>

--- a/docs/src/components/NavbarItems/CurrentVersionNavbarItem.js
+++ b/docs/src/components/NavbarItems/CurrentVersionNavbarItem.js
@@ -11,15 +11,12 @@ import DefaultNavbarItem from "@theme/NavbarItem/DefaultNavbarItem";
 
 import styles from "./styles.module.css";
 
-import versions from "@generated/versions-data/default/versions.json";
-
 // display: inline-block overrides the default and ensures the item shows on
 // mobile at the top of the page.
 export default function CurrentVersionNavbarItem({ ...props }) {
   const baseUrl = useBaseUrl("/");
   const normalizedBaseUrl = baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`;
   const href = useBaseUrl("/docs/archive");
-  const latestVersion = versions.filter(semver.valid).sort(semver.rcompare)[0];
 
   // on the mobile menu, show nothing. Note, the 'Desktop' item has 'display'
   // set, so it'll appear on mobile too.
@@ -37,7 +34,7 @@ export default function CurrentVersionNavbarItem({ ...props }) {
           <div className={styles.versionWrapper}>
             <DefaultNavbarItem
               {...props}
-              label={`${latestVersion}`}
+              label={"edge"}
               href={href}
             />
           </div>


### PR DESCRIPTION
Docs are updated as we push to main, this means the version is not the latest, but rather the edge version. This is to avoid confusion while still showing fixes to the docs site as we make them, since it's still an active area of development after we released the new version.

![Screenshot 2025-06-23 at 16 10 45](https://github.com/user-attachments/assets/1d04dc30-eec9-4a22-a1d7-34ae052e2e60)

I have left in the component as we will want to make it so that this shows the latest tag when building an archived deployment and will use this component for that, but for now, it's just always shows edge.
