### PR TITLE
website: Disable cancel script

### DIFF
--- a/build/docs-build-needed.sh
+++ b/build/docs-build-needed.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-set -exo pipefail
-
-# NOTE(sr): we include version because that's what drives releases
-# Makefile and netlify.toml capture when the build infrastructure changes
-# ast/builtins.go and capabilities.json are driving the builtins_metadata.
-git diff --name-only --exit-code $CACHED_COMMIT_REF $COMMIT_REF docs/ Makefile build/ netlify.toml ast/builtins.go capabilities.json version/ CHANGELOG.md

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,6 @@
 [build]
 publish = "docs/build"
 command = "make netlify"
-ignore = "./build/docs-build-needed.sh"
 edge_functions = "docs/functions"
 
 [build.environment]


### PR DESCRIPTION
This script is functioning correctly, but netlify can't stop sending emails for cancelled build:

https://answers.netlify.com/t/deploy-notifications-cancel-vs-failure/37300 https://answers.netlify.com/t/differentiate-betweeen-cancel-and-failure-for-deployment-notifications/67054 https://answers.netlify.com/t/deploy-notification-cancel-vs-failure/88316

In order to avoid red-blindness, we are disabling the script so we get emails only for failed builds.

cc @tsandall 
