### PR TITLE
inspect: Fixing missing annotations location in `opa inspect` with JSON format

### DIFF
--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -20,6 +20,7 @@ import (
 	pr "github.com/open-policy-agent/opa/internal/presentation"
 	iStrs "github.com/open-policy-agent/opa/internal/strings"
 	"github.com/open-policy-agent/opa/v1/ast"
+	astJson "github.com/open-policy-agent/opa/v1/ast/json"
 	"github.com/open-policy-agent/opa/v1/bundle"
 	"github.com/open-policy-agent/opa/v1/util"
 
@@ -116,6 +117,16 @@ func doInspect(params inspectCommandParams, path string, out io.Writer) error {
 
 	switch params.outputFormat.String() {
 	case formats.JSON:
+		astJson.SetOptions(astJson.Options{
+			MarshalOptions: astJson.MarshalOptions{
+				IncludeLocation: astJson.NodeToggle{
+					// Annotation location data is only included if includeAnnotations is set
+					AnnotationsRef: params.listAnnotations,
+				},
+			},
+		})
+		defer astJson.SetOptions(astJson.Defaults())
+
 		return pr.JSON(out, info)
 
 	default:

--- a/internal/bundle/inspect/inspect.go
+++ b/internal/bundle/inspect/inspect.go
@@ -15,7 +15,6 @@ import (
 
 	initload "github.com/open-policy-agent/opa/internal/runtime/init"
 	"github.com/open-policy-agent/opa/v1/ast"
-	"github.com/open-policy-agent/opa/v1/ast/json"
 	"github.com/open-policy-agent/opa/v1/bundle"
 	"github.com/open-policy-agent/opa/v1/loader"
 	"github.com/open-policy-agent/opa/v1/util"
@@ -44,16 +43,6 @@ func FileForRegoVersion(regoVersion ast.RegoVersion, path string, includeAnnotat
 }
 
 func bundleOrDirInfoForRegoVersion(regoVersion ast.RegoVersion, path string, includeAnnotations bool) (*Info, error) {
-	json.SetOptions(json.Options{
-		MarshalOptions: json.MarshalOptions{
-			IncludeLocation: json.NodeToggle{
-				// Annotation location data is only included if includeAnnotations is set
-				AnnotationsRef: includeAnnotations,
-			},
-		},
-	})
-	defer json.SetOptions(json.Defaults())
-
 	b, err := loader.NewFileLoader().
 		WithRegoVersion(regoVersion).
 		WithSkipBundleVerification(true).


### PR DESCRIPTION
Fixing: #7459