### PR TITLE
Only pass built-in context to calls depending on it

### DIFF
--- a/v1/ast/builtins.go
+++ b/v1/ast/builtins.go
@@ -346,6 +346,7 @@ var Equality = &Builtin{
 		types.Args(types.A, types.A),
 		types.B,
 	),
+	canSkipBctx: true,
 }
 
 /**
@@ -360,6 +361,7 @@ var Assign = &Builtin{
 		types.Args(types.A, types.A),
 		types.B,
 	),
+	canSkipBctx: true,
 }
 
 // Member represents the `in` (infix) operator.
@@ -373,6 +375,7 @@ var Member = &Builtin{
 		),
 		types.B,
 	),
+	canSkipBctx: true,
 }
 
 // MemberWithKey represents the `in` (infix) operator when used
@@ -388,6 +391,7 @@ var MemberWithKey = &Builtin{
 		),
 		types.B,
 	),
+	canSkipBctx: true,
 }
 
 /**
@@ -406,6 +410,7 @@ var GreaterThan = &Builtin{
 		),
 		types.Named("result", types.B).Description("true if `x` is greater than `y`; false otherwise"),
 	),
+	canSkipBctx: true,
 }
 
 var GreaterThanEq = &Builtin{
@@ -419,6 +424,7 @@ var GreaterThanEq = &Builtin{
 		),
 		types.Named("result", types.B).Description("true if `x` is greater or equal to `y`; false otherwise"),
 	),
+	canSkipBctx: true,
 }
 
 // LessThan represents the "<" comparison operator.
@@ -433,6 +439,7 @@ var LessThan = &Builtin{
 		),
 		types.Named("result", types.B).Description("true if `x` is less than `y`; false otherwise"),
 	),
+	canSkipBctx: true,
 }
 
 var LessThanEq = &Builtin{
@@ -446,6 +453,7 @@ var LessThanEq = &Builtin{
 		),
 		types.Named("result", types.B).Description("true if `x` is less than or equal to `y`; false otherwise"),
 	),
+	canSkipBctx: true,
 }
 
 var NotEqual = &Builtin{
@@ -459,6 +467,7 @@ var NotEqual = &Builtin{
 		),
 		types.Named("result", types.B).Description("true if `x` is not equal to `y`; false otherwise"),
 	),
+	canSkipBctx: true,
 }
 
 // Equal represents the "==" comparison operator.
@@ -473,6 +482,7 @@ var Equal = &Builtin{
 		),
 		types.Named("result", types.B).Description("true if `x` is equal to `y`; false otherwise"),
 	),
+	canSkipBctx: true,
 }
 
 /**
@@ -491,7 +501,8 @@ var Plus = &Builtin{
 		),
 		types.Named("z", types.N).Description("the sum of `x` and `y`"),
 	),
-	Categories: number,
+	Categories:  number,
+	canSkipBctx: true,
 }
 
 var Minus = &Builtin{
@@ -505,7 +516,8 @@ var Minus = &Builtin{
 		),
 		types.Named("z", types.NewAny(types.N, types.SetOfAny)).Description("the difference of `x` and `y`"),
 	),
-	Categories: category("sets", "numbers"),
+	Categories:  category("sets", "numbers"),
+	canSkipBctx: true,
 }
 
 var Multiply = &Builtin{
@@ -519,7 +531,8 @@ var Multiply = &Builtin{
 		),
 		types.Named("z", types.N).Description("the product of `x` and `y`"),
 	),
-	Categories: number,
+	Categories:  number,
+	canSkipBctx: true,
 }
 
 var Divide = &Builtin{
@@ -533,7 +546,8 @@ var Divide = &Builtin{
 		),
 		types.Named("z", types.N).Description("the result of `x` divided by `y`"),
 	),
-	Categories: number,
+	Categories:  number,
+	canSkipBctx: true,
 }
 
 var Round = &Builtin{
@@ -545,7 +559,8 @@ var Round = &Builtin{
 		),
 		types.Named("y", types.N).Description("the result of rounding `x`"),
 	),
-	Categories: number,
+	Categories:  number,
+	canSkipBctx: true,
 }
 
 var Ceil = &Builtin{
@@ -557,7 +572,8 @@ var Ceil = &Builtin{
 		),
 		types.Named("y", types.N).Description("the result of rounding `x` _up_"),
 	),
-	Categories: number,
+	Categories:  number,
+	canSkipBctx: true,
 }
 
 var Floor = &Builtin{
@@ -569,7 +585,8 @@ var Floor = &Builtin{
 		),
 		types.Named("y", types.N).Description("the result of rounding `x` _down_"),
 	),
-	Categories: number,
+	Categories:  number,
+	canSkipBctx: true,
 }
 
 var Abs = &Builtin{
@@ -581,7 +598,8 @@ var Abs = &Builtin{
 		),
 		types.Named("y", types.N).Description("the absolute value of `x`"),
 	),
-	Categories: number,
+	Categories:  number,
+	canSkipBctx: true,
 }
 
 var Rem = &Builtin{
@@ -595,7 +613,8 @@ var Rem = &Builtin{
 		),
 		types.Named("z", types.N).Description("the remainder"),
 	),
-	Categories: number,
+	Categories:  number,
+	canSkipBctx: true,
 }
 
 /**
@@ -612,6 +631,7 @@ var BitsOr = &Builtin{
 		),
 		types.Named("z", types.N).Description("the bitwise OR of `x` and `y`"),
 	),
+	canSkipBctx: true,
 }
 
 var BitsAnd = &Builtin{
@@ -624,6 +644,7 @@ var BitsAnd = &Builtin{
 		),
 		types.Named("z", types.N).Description("the bitwise AND of `x` and `y`"),
 	),
+	canSkipBctx: true,
 }
 
 var BitsNegate = &Builtin{
@@ -635,6 +656,7 @@ var BitsNegate = &Builtin{
 		),
 		types.Named("z", types.N).Description("the bitwise negation of `x`"),
 	),
+	canSkipBctx: true,
 }
 
 var BitsXOr = &Builtin{
@@ -647,6 +669,7 @@ var BitsXOr = &Builtin{
 		),
 		types.Named("z", types.N).Description("the bitwise XOR of `x` and `y`"),
 	),
+	canSkipBctx: true,
 }
 
 var BitsShiftLeft = &Builtin{
@@ -659,6 +682,7 @@ var BitsShiftLeft = &Builtin{
 		),
 		types.Named("z", types.N).Description("the result of shifting `x` `s` bits to the left"),
 	),
+	canSkipBctx: true,
 }
 
 var BitsShiftRight = &Builtin{
@@ -671,6 +695,7 @@ var BitsShiftRight = &Builtin{
 		),
 		types.Named("z", types.N).Description("the result of shifting `x` `s` bits to the right"),
 	),
+	canSkipBctx: true,
 }
 
 /**
@@ -690,7 +715,8 @@ var And = &Builtin{
 		),
 		types.Named("z", types.SetOfAny).Description("the intersection of `x` and `y`"),
 	),
-	Categories: sets,
+	Categories:  sets,
+	canSkipBctx: true,
 }
 
 // Or performs a union operation on sets.
@@ -705,7 +731,8 @@ var Or = &Builtin{
 		),
 		types.Named("z", types.SetOfAny).Description("the union of `x` and `y`"),
 	),
-	Categories: sets,
+	Categories:  sets,
+	canSkipBctx: true,
 }
 
 var Intersection = &Builtin{
@@ -717,7 +744,8 @@ var Intersection = &Builtin{
 		),
 		types.Named("y", types.SetOfAny).Description("the intersection of all `xs` sets"),
 	),
-	Categories: sets,
+	Categories:  sets,
+	canSkipBctx: true,
 }
 
 var Union = &Builtin{
@@ -729,7 +757,8 @@ var Union = &Builtin{
 		),
 		types.Named("y", types.SetOfAny).Description("the union of all `xs` sets"),
 	),
-	Categories: sets,
+	Categories:  sets,
+	canSkipBctx: true,
 }
 
 /**
@@ -752,7 +781,8 @@ var Count = &Builtin{
 		),
 		types.Named("n", types.N).Description("the count of elements, key/val pairs, or characters, respectively."),
 	),
-	Categories: aggregates,
+	Categories:  aggregates,
+	canSkipBctx: true,
 }
 
 var Sum = &Builtin{
@@ -767,7 +797,8 @@ var Sum = &Builtin{
 		),
 		types.Named("n", types.N).Description("the sum of all elements"),
 	),
-	Categories: aggregates,
+	Categories:  aggregates,
+	canSkipBctx: true,
 }
 
 var Product = &Builtin{
@@ -782,7 +813,8 @@ var Product = &Builtin{
 		),
 		types.Named("n", types.N).Description("the product of all elements"),
 	),
-	Categories: aggregates,
+	Categories:  aggregates,
+	canSkipBctx: true,
 }
 
 var Max = &Builtin{
@@ -797,7 +829,8 @@ var Max = &Builtin{
 		),
 		types.Named("n", types.A).Description("the maximum of all elements"),
 	),
-	Categories: aggregates,
+	Categories:  aggregates,
+	canSkipBctx: true,
 }
 
 var Min = &Builtin{
@@ -812,7 +845,8 @@ var Min = &Builtin{
 		),
 		types.Named("n", types.A).Description("the minimum of all elements"),
 	),
-	Categories: aggregates,
+	Categories:  aggregates,
+	canSkipBctx: true,
 }
 
 /**
@@ -831,7 +865,8 @@ var Sort = &Builtin{
 		),
 		types.Named("n", types.NewArray(nil, types.A)).Description("the sorted array"),
 	),
-	Categories: aggregates,
+	Categories:  aggregates,
+	canSkipBctx: true,
 }
 
 /**
@@ -848,6 +883,7 @@ var ArrayConcat = &Builtin{
 		),
 		types.Named("z", types.NewArray(nil, types.A)).Description("the concatenation of `x` and `y`"),
 	),
+	canSkipBctx: true,
 }
 
 var ArraySlice = &Builtin{
@@ -861,6 +897,7 @@ var ArraySlice = &Builtin{
 		),
 		types.Named("slice", types.NewArray(nil, types.A)).Description("the subslice of `array`, from `start` to `end`, including `arr[start]`, but excluding `arr[end]`"),
 	),
+	canSkipBctx: true,
 } // NOTE(sr): this function really needs examples
 
 var ArrayReverse = &Builtin{
@@ -872,6 +909,7 @@ var ArrayReverse = &Builtin{
 		),
 		types.Named("rev", types.NewArray(nil, types.A)).Description("an array containing the elements of `arr` in reverse order"),
 	),
+	canSkipBctx: true,
 }
 
 /**
@@ -893,7 +931,8 @@ var ToNumber = &Builtin{
 		),
 		types.Named("num", types.N).Description("the numeric representation of `x`"),
 	),
-	Categories: conversions,
+	Categories:  conversions,
+	canSkipBctx: true,
 }
 
 /**
@@ -921,6 +960,7 @@ var RegexIsValid = &Builtin{
 		),
 		types.Named("result", types.B).Description("true if `pattern` is a valid regular expression"),
 	),
+	canSkipBctx: true,
 }
 
 var RegexFindAllStringSubmatch = &Builtin{
@@ -934,6 +974,7 @@ var RegexFindAllStringSubmatch = &Builtin{
 		),
 		types.Named("output", types.NewArray(nil, types.NewArray(nil, types.S))).Description("array of all matches"),
 	),
+	canSkipBctx: false,
 }
 
 var RegexTemplateMatch = &Builtin{
@@ -948,6 +989,7 @@ var RegexTemplateMatch = &Builtin{
 		),
 		types.Named("result", types.B).Description("true if `value` matches the `template`"),
 	),
+	canSkipBctx: true,
 } // TODO(sr): example:`regex.template_match("urn:foo:{.*}", "urn:foo:bar:baz", "{", "}")`` returns ``true``.
 
 var RegexSplit = &Builtin{
@@ -960,6 +1002,7 @@ var RegexSplit = &Builtin{
 		),
 		types.Named("output", types.NewArray(nil, types.S)).Description("the parts obtained by splitting `value`"),
 	),
+	canSkipBctx: false,
 }
 
 // RegexFind takes two strings and a number, the pattern, the value and number of match values to
@@ -975,6 +1018,7 @@ var RegexFind = &Builtin{
 		),
 		types.Named("output", types.NewArray(nil, types.S)).Description("collected matches"),
 	),
+	canSkipBctx: false,
 }
 
 // GlobsMatch takes two strings regexp-style strings and evaluates to true if their
@@ -993,6 +1037,7 @@ The set of regex symbols is limited for this builtin: only ` + "`.`, `*`, `+`, `
 		),
 		types.Named("result", types.B).Description("true if the intersection of `glob1` and `glob2` matches a non-empty set of non-empty strings"),
 	),
+	canSkipBctx: true,
 }
 
 /**
@@ -1018,7 +1063,8 @@ var AnyPrefixMatch = &Builtin{
 		),
 		types.Named("result", types.B).Description("result of the prefix check"),
 	),
-	Categories: stringsCat,
+	Categories:  stringsCat,
+	canSkipBctx: true,
 }
 
 var AnySuffixMatch = &Builtin{
@@ -1039,7 +1085,8 @@ var AnySuffixMatch = &Builtin{
 		),
 		types.Named("result", types.B).Description("result of the suffix check"),
 	),
-	Categories: stringsCat,
+	Categories:  stringsCat,
+	canSkipBctx: true,
 }
 
 var Concat = &Builtin{
@@ -1055,7 +1102,8 @@ var Concat = &Builtin{
 		),
 		types.Named("output", types.S).Description("the joined string"),
 	),
-	Categories: stringsCat,
+	Categories:  stringsCat,
+	canSkipBctx: true,
 }
 
 var FormatInt = &Builtin{
@@ -1068,7 +1116,8 @@ var FormatInt = &Builtin{
 		),
 		types.Named("output", types.S).Description("formatted number"),
 	),
-	Categories: stringsCat,
+	Categories:  stringsCat,
+	canSkipBctx: true,
 }
 
 var IndexOf = &Builtin{
@@ -1081,7 +1130,8 @@ var IndexOf = &Builtin{
 		),
 		types.Named("output", types.N).Description("index of first occurrence, `-1` if not found"),
 	),
-	Categories: stringsCat,
+	Categories:  stringsCat,
+	canSkipBctx: true,
 }
 
 var IndexOfN = &Builtin{
@@ -1094,7 +1144,8 @@ var IndexOfN = &Builtin{
 		),
 		types.Named("output", types.NewArray(nil, types.N)).Description("all indices at which `needle` occurs in `haystack`, may be empty"),
 	),
-	Categories: stringsCat,
+	Categories:  stringsCat,
+	canSkipBctx: true,
 }
 
 var Substring = &Builtin{
@@ -1108,7 +1159,8 @@ var Substring = &Builtin{
 		),
 		types.Named("output", types.S).Description("substring of `value` from `offset`, of length `length`"),
 	),
-	Categories: stringsCat,
+	Categories:  stringsCat,
+	canSkipBctx: true,
 }
 
 var Contains = &Builtin{
@@ -1121,7 +1173,8 @@ var Contains = &Builtin{
 		),
 		types.Named("result", types.B).Description("result of the containment check"),
 	),
-	Categories: stringsCat,
+	Categories:  stringsCat,
+	canSkipBctx: true,
 }
 
 var StringCount = &Builtin{
@@ -1134,7 +1187,8 @@ var StringCount = &Builtin{
 		),
 		types.Named("output", types.N).Description("count of occurrences, `0` if not found"),
 	),
-	Categories: stringsCat,
+	Categories:  stringsCat,
+	canSkipBctx: true,
 }
 
 var StartsWith = &Builtin{
@@ -1147,7 +1201,8 @@ var StartsWith = &Builtin{
 		),
 		types.Named("result", types.B).Description("result of the prefix check"),
 	),
-	Categories: stringsCat,
+	Categories:  stringsCat,
+	canSkipBctx: true,
 }
 
 var EndsWith = &Builtin{
@@ -1160,7 +1215,8 @@ var EndsWith = &Builtin{
 		),
 		types.Named("result", types.B).Description("result of the suffix check"),
 	),
-	Categories: stringsCat,
+	Categories:  stringsCat,
+	canSkipBctx: true,
 }
 
 var Lower = &Builtin{
@@ -1172,7 +1228,8 @@ var Lower = &Builtin{
 		),
 		types.Named("y", types.S).Description("lower-case of x"),
 	),
-	Categories: stringsCat,
+	Categories:  stringsCat,
+	canSkipBctx: true,
 }
 
 var Upper = &Builtin{
@@ -1184,7 +1241,8 @@ var Upper = &Builtin{
 		),
 		types.Named("y", types.S).Description("upper-case of x"),
 	),
-	Categories: stringsCat,
+	Categories:  stringsCat,
+	canSkipBctx: true,
 }
 
 var Split = &Builtin{
@@ -1197,7 +1255,8 @@ var Split = &Builtin{
 		),
 		types.Named("ys", types.NewArray(nil, types.S)).Description("split parts"),
 	),
-	Categories: stringsCat,
+	Categories:  stringsCat,
+	canSkipBctx: true,
 }
 
 var Replace = &Builtin{
@@ -1211,7 +1270,8 @@ var Replace = &Builtin{
 		),
 		types.Named("y", types.S).Description("string with replaced substrings"),
 	),
-	Categories: stringsCat,
+	Categories:  stringsCat,
+	canSkipBctx: true,
 }
 
 var ReplaceN = &Builtin{
@@ -1231,6 +1291,7 @@ The old string comparisons are done in argument order.`,
 		),
 		types.Named("output", types.S).Description("string with replaced substrings"),
 	),
+	canSkipBctx: true,
 }
 
 var RegexReplace = &Builtin{
@@ -1244,6 +1305,7 @@ var RegexReplace = &Builtin{
 		),
 		types.Named("output", types.S).Description("string with replaced substrings"),
 	),
+	canSkipBctx: false,
 }
 
 var Trim = &Builtin{
@@ -1256,7 +1318,8 @@ var Trim = &Builtin{
 		),
 		types.Named("output", types.S).Description("string trimmed of `cutset` characters"),
 	),
-	Categories: stringsCat,
+	Categories:  stringsCat,
+	canSkipBctx: true,
 }
 
 var TrimLeft = &Builtin{
@@ -1269,7 +1332,8 @@ var TrimLeft = &Builtin{
 		),
 		types.Named("output", types.S).Description("string left-trimmed of `cutset` characters"),
 	),
-	Categories: stringsCat,
+	Categories:  stringsCat,
+	canSkipBctx: true,
 }
 
 var TrimPrefix = &Builtin{
@@ -1282,7 +1346,8 @@ var TrimPrefix = &Builtin{
 		),
 		types.Named("output", types.S).Description("string with `prefix` cut off"),
 	),
-	Categories: stringsCat,
+	Categories:  stringsCat,
+	canSkipBctx: true,
 }
 
 var TrimRight = &Builtin{
@@ -1295,7 +1360,8 @@ var TrimRight = &Builtin{
 		),
 		types.Named("output", types.S).Description("string right-trimmed of `cutset` characters"),
 	),
-	Categories: stringsCat,
+	Categories:  stringsCat,
+	canSkipBctx: true,
 }
 
 var TrimSuffix = &Builtin{
@@ -1308,7 +1374,8 @@ var TrimSuffix = &Builtin{
 		),
 		types.Named("output", types.S).Description("string with `suffix` cut off"),
 	),
-	Categories: stringsCat,
+	Categories:  stringsCat,
+	canSkipBctx: true,
 }
 
 var TrimSpace = &Builtin{
@@ -1320,7 +1387,8 @@ var TrimSpace = &Builtin{
 		),
 		types.Named("output", types.S).Description("string leading and trailing white space cut off"),
 	),
-	Categories: stringsCat,
+	Categories:  stringsCat,
+	canSkipBctx: true,
 }
 
 var Sprintf = &Builtin{
@@ -1333,7 +1401,8 @@ var Sprintf = &Builtin{
 		),
 		types.Named("output", types.S).Description("`format` formatted by the values in `values`"),
 	),
-	Categories: stringsCat,
+	Categories:  stringsCat,
+	canSkipBctx: true,
 }
 
 var StringReverse = &Builtin{
@@ -1345,7 +1414,8 @@ var StringReverse = &Builtin{
 		),
 		types.Named("y", types.S).Description("reversed string"),
 	),
-	Categories: stringsCat,
+	Categories:  stringsCat,
+	canSkipBctx: true,
 }
 
 var RenderTemplate = &Builtin{
@@ -1359,7 +1429,8 @@ var RenderTemplate = &Builtin{
 		),
 		types.Named("result", types.S).Description("rendered template with template variables injected"),
 	),
-	Categories: stringsCat,
+	Categories:  stringsCat,
+	canSkipBctx: true,
 }
 
 /**
@@ -1380,6 +1451,7 @@ var RandIntn = &Builtin{
 	),
 	Categories:       number,
 	Nondeterministic: true,
+	canSkipBctx:      false,
 }
 
 var NumbersRange = &Builtin{
@@ -1392,6 +1464,7 @@ var NumbersRange = &Builtin{
 		),
 		types.Named("range", types.NewArray(nil, types.N)).Description("the range between `a` and `b`"),
 	),
+	canSkipBctx: false, // needed for context timeout check
 }
 
 var NumbersRangeStep = &Builtin{
@@ -1409,6 +1482,7 @@ var NumbersRangeStep = &Builtin{
 		),
 		types.Named("range", types.NewArray(nil, types.N)).Description("the range between `a` and `b` in `step` increments"),
 	),
+	canSkipBctx: false, // needed for context timeout check
 }
 
 /**
@@ -1433,6 +1507,7 @@ respectively. Other units are case-insensitive.`,
 		),
 		types.Named("y", types.N).Description("the parsed number"),
 	),
+	canSkipBctx: true,
 }
 
 var UnitsParseBytes = &Builtin{
@@ -1451,6 +1526,7 @@ and "MiB" are equivalent).`,
 		),
 		types.Named("y", types.N).Description("the parsed number"),
 	),
+	canSkipBctx: true,
 }
 
 //
@@ -1470,6 +1546,7 @@ var UUIDRFC4122 = &Builtin{
 		types.Named("output", types.S).Description("a version 4 UUID; for any given `k`, the output will be consistent throughout a query evaluation"),
 	),
 	Nondeterministic: true,
+	canSkipBctx:      false,
 }
 
 var UUIDParse = &Builtin{
@@ -1482,7 +1559,8 @@ var UUIDParse = &Builtin{
 		),
 		types.Named("result", types.NewObject(nil, types.NewDynamicProperty(types.S, types.A))).Description("Properties of UUID if valid (version, variant, etc). Undefined otherwise."),
 	),
-	Relation: false,
+	Relation:    false,
+	canSkipBctx: true,
 }
 
 /**
@@ -1526,7 +1604,8 @@ var JSONFilter = &Builtin{
 		),
 		types.Named("filtered", types.A).Description("remaining data from `object` with only keys specified in `paths`"),
 	),
-	Categories: objectCat,
+	Categories:  objectCat,
+	canSkipBctx: true,
 }
 
 var JSONRemove = &Builtin{
@@ -1564,7 +1643,8 @@ var JSONRemove = &Builtin{
 		),
 		types.Named("output", types.A).Description("result of removing all keys specified in `paths`"),
 	),
-	Categories: objectCat,
+	Categories:  objectCat,
+	canSkipBctx: true,
 }
 
 var JSONPatch = &Builtin{
@@ -1589,7 +1669,8 @@ var JSONPatch = &Builtin{
 		),
 		types.Named("output", types.A).Description("result obtained after consecutively applying all patch operations in `patches`"),
 	),
-	Categories: objectCat,
+	Categories:  objectCat,
+	canSkipBctx: true,
 }
 
 var ObjectSubset = &Builtin{
@@ -1623,6 +1704,7 @@ var ObjectSubset = &Builtin{
 		),
 		types.Named("result", types.A).Description("`true` if `sub` is a subset of `super`"),
 	),
+	canSkipBctx: true,
 }
 
 var ObjectUnion = &Builtin{
@@ -1642,6 +1724,7 @@ var ObjectUnion = &Builtin{
 		),
 		types.Named("output", types.A).Description("a new object which is the result of an asymmetric recursive union of two objects where conflicts are resolved by choosing the key from the right-hand object `b`"),
 	), // TODO(sr): types.A?  ^^^^^^^ (also below)
+	canSkipBctx: true,
 }
 
 var ObjectUnionN = &Builtin{
@@ -1657,6 +1740,7 @@ var ObjectUnionN = &Builtin{
 		),
 		types.Named("output", types.A).Description("asymmetric recursive union of all objects in `objects`, merged from left to right, where conflicts are resolved by choosing the key from the right-hand object"),
 	),
+	canSkipBctx: true,
 }
 
 var ObjectRemove = &Builtin{
@@ -1676,6 +1760,7 @@ var ObjectRemove = &Builtin{
 		),
 		types.Named("output", types.A).Description("result of removing the specified `keys` from `object`"),
 	),
+	canSkipBctx: true,
 }
 
 var ObjectFilter = &Builtin{
@@ -1696,6 +1781,7 @@ var ObjectFilter = &Builtin{
 		),
 		types.Named("filtered", types.A).Description("remaining data from `object` with only keys specified in `keys`"),
 	),
+	canSkipBctx: true,
 }
 
 var ObjectGet = &Builtin{
@@ -1711,6 +1797,7 @@ var ObjectGet = &Builtin{
 		),
 		types.Named("value", types.A).Description("`object[key]` if present, otherwise `default`"),
 	),
+	canSkipBctx: true,
 }
 
 var ObjectKeys = &Builtin{
@@ -1723,6 +1810,7 @@ var ObjectKeys = &Builtin{
 		),
 		types.Named("value", types.SetOfAny).Description("set of `object`'s keys"),
 	),
+	canSkipBctx: true,
 }
 
 /*
@@ -1739,7 +1827,8 @@ var JSONMarshal = &Builtin{
 		),
 		types.Named("y", types.S).Description("the JSON string representation of `x`"),
 	),
-	Categories: encoding,
+	Categories:  encoding,
+	canSkipBctx: true,
 }
 
 var JSONMarshalWithOptions = &Builtin{
@@ -1760,7 +1849,8 @@ var JSONMarshalWithOptions = &Builtin{
 		),
 		types.Named("y", types.S).Description("the JSON string representation of `x`, with configured prefix/indent string(s) as appropriate"),
 	),
-	Categories: encoding,
+	Categories:  encoding,
+	canSkipBctx: true,
 }
 
 var JSONUnmarshal = &Builtin{
@@ -1772,7 +1862,8 @@ var JSONUnmarshal = &Builtin{
 		),
 		types.Named("y", types.A).Description("the term deserialized from `x`"),
 	),
-	Categories: encoding,
+	Categories:  encoding,
+	canSkipBctx: true,
 }
 
 var JSONIsValid = &Builtin{
@@ -1784,7 +1875,8 @@ var JSONIsValid = &Builtin{
 		),
 		types.Named("result", types.B).Description("`true` if `x` is valid JSON, `false` otherwise"),
 	),
-	Categories: encoding,
+	Categories:  encoding,
+	canSkipBctx: true,
 }
 
 var Base64Encode = &Builtin{
@@ -1796,7 +1888,8 @@ var Base64Encode = &Builtin{
 		),
 		types.Named("y", types.S).Description("base64 serialization of `x`"),
 	),
-	Categories: encoding,
+	Categories:  encoding,
+	canSkipBctx: true,
 }
 
 var Base64Decode = &Builtin{
@@ -1808,7 +1901,8 @@ var Base64Decode = &Builtin{
 		),
 		types.Named("y", types.S).Description("base64 deserialization of `x`"),
 	),
-	Categories: encoding,
+	Categories:  encoding,
+	canSkipBctx: true,
 }
 
 var Base64IsValid = &Builtin{
@@ -1820,7 +1914,8 @@ var Base64IsValid = &Builtin{
 		),
 		types.Named("result", types.B).Description("`true` if `x` is valid base64 encoded value, `false` otherwise"),
 	),
-	Categories: encoding,
+	Categories:  encoding,
+	canSkipBctx: true,
 }
 
 var Base64UrlEncode = &Builtin{
@@ -1832,7 +1927,8 @@ var Base64UrlEncode = &Builtin{
 		),
 		types.Named("y", types.S).Description("base64url serialization of `x`"),
 	),
-	Categories: encoding,
+	Categories:  encoding,
+	canSkipBctx: true,
 }
 
 var Base64UrlEncodeNoPad = &Builtin{
@@ -1844,7 +1940,8 @@ var Base64UrlEncodeNoPad = &Builtin{
 		),
 		types.Named("y", types.S).Description("base64url serialization of `x`"),
 	),
-	Categories: encoding,
+	Categories:  encoding,
+	canSkipBctx: true,
 }
 
 var Base64UrlDecode = &Builtin{
@@ -1856,7 +1953,8 @@ var Base64UrlDecode = &Builtin{
 		),
 		types.Named("y", types.S).Description("base64url deserialization of `x`"),
 	),
-	Categories: encoding,
+	Categories:  encoding,
+	canSkipBctx: true,
 }
 
 var URLQueryDecode = &Builtin{
@@ -1868,7 +1966,8 @@ var URLQueryDecode = &Builtin{
 		),
 		types.Named("y", types.S).Description("URL-encoding deserialization of `x`"),
 	),
-	Categories: encoding,
+	Categories:  encoding,
+	canSkipBctx: true,
 }
 
 var URLQueryEncode = &Builtin{
@@ -1880,7 +1979,8 @@ var URLQueryEncode = &Builtin{
 		),
 		types.Named("y", types.S).Description("URL-encoding serialization of `x`"),
 	),
-	Categories: encoding,
+	Categories:  encoding,
+	canSkipBctx: true,
 }
 
 var URLQueryEncodeObject = &Builtin{
@@ -1903,7 +2003,8 @@ var URLQueryEncodeObject = &Builtin{
 		),
 		types.Named("y", types.S).Description("the URL-encoded serialization of `object`"),
 	),
-	Categories: encoding,
+	Categories:  encoding,
+	canSkipBctx: true,
 }
 
 var URLQueryDecodeObject = &Builtin{
@@ -1917,7 +2018,8 @@ var URLQueryDecodeObject = &Builtin{
 			types.S,
 			types.NewArray(nil, types.S)))).Description("the resulting object"),
 	),
-	Categories: encoding,
+	Categories:  encoding,
+	canSkipBctx: true,
 }
 
 var YAMLMarshal = &Builtin{
@@ -1929,7 +2031,8 @@ var YAMLMarshal = &Builtin{
 		),
 		types.Named("y", types.S).Description("the YAML string representation of `x`"),
 	),
-	Categories: encoding,
+	Categories:  encoding,
+	canSkipBctx: true,
 }
 
 var YAMLUnmarshal = &Builtin{
@@ -1941,7 +2044,8 @@ var YAMLUnmarshal = &Builtin{
 		),
 		types.Named("y", types.A).Description("the term deserialized from `x`"),
 	),
-	Categories: encoding,
+	Categories:  encoding,
+	canSkipBctx: true,
 }
 
 // YAMLIsValid verifies the input string is a valid YAML document.
@@ -1954,7 +2058,8 @@ var YAMLIsValid = &Builtin{
 		),
 		types.Named("result", types.B).Description("`true` if `x` is valid YAML, `false` otherwise"),
 	),
-	Categories: encoding,
+	Categories:  encoding,
+	canSkipBctx: true,
 }
 
 var HexEncode = &Builtin{
@@ -1966,7 +2071,8 @@ var HexEncode = &Builtin{
 		),
 		types.Named("y", types.S).Description("serialization of `x` using hex-encoding"),
 	),
-	Categories: encoding,
+	Categories:  encoding,
+	canSkipBctx: true,
 }
 
 var HexDecode = &Builtin{
@@ -1978,7 +2084,8 @@ var HexDecode = &Builtin{
 		),
 		types.Named("y", types.S).Description("deserialized from `x`"),
 	),
-	Categories: encoding,
+	Categories:  encoding,
+	canSkipBctx: true,
 }
 
 /**
@@ -1999,7 +2106,8 @@ var JWTDecode = &Builtin{
 			types.S,
 		}, nil)).Description("`[header, payload, sig]`, where `header` and `payload` are objects; `sig` is the hexadecimal representation of the signature on the token."),
 	),
-	Categories: tokensCat,
+	Categories:  tokensCat,
+	canSkipBctx: true,
 }
 
 var JWTVerifyRS256 = &Builtin{
@@ -2012,7 +2120,8 @@ var JWTVerifyRS256 = &Builtin{
 		),
 		types.Named("result", types.B).Description("`true` if the signature is valid, `false` otherwise"),
 	),
-	Categories: tokensCat,
+	Categories:  tokensCat,
+	canSkipBctx: false,
 }
 
 var JWTVerifyRS384 = &Builtin{
@@ -2025,7 +2134,8 @@ var JWTVerifyRS384 = &Builtin{
 		),
 		types.Named("result", types.B).Description("`true` if the signature is valid, `false` otherwise"),
 	),
-	Categories: tokensCat,
+	Categories:  tokensCat,
+	canSkipBctx: false,
 }
 
 var JWTVerifyRS512 = &Builtin{
@@ -2038,7 +2148,8 @@ var JWTVerifyRS512 = &Builtin{
 		),
 		types.Named("result", types.B).Description("`true` if the signature is valid, `false` otherwise"),
 	),
-	Categories: tokensCat,
+	Categories:  tokensCat,
+	canSkipBctx: false,
 }
 
 var JWTVerifyPS256 = &Builtin{
@@ -2051,7 +2162,8 @@ var JWTVerifyPS256 = &Builtin{
 		),
 		types.Named("result", types.B).Description("`true` if the signature is valid, `false` otherwise"),
 	),
-	Categories: tokensCat,
+	Categories:  tokensCat,
+	canSkipBctx: false,
 }
 
 var JWTVerifyPS384 = &Builtin{
@@ -2064,7 +2176,8 @@ var JWTVerifyPS384 = &Builtin{
 		),
 		types.Named("result", types.B).Description("`true` if the signature is valid, `false` otherwise"),
 	),
-	Categories: tokensCat,
+	Categories:  tokensCat,
+	canSkipBctx: false,
 }
 
 var JWTVerifyPS512 = &Builtin{
@@ -2077,7 +2190,8 @@ var JWTVerifyPS512 = &Builtin{
 		),
 		types.Named("result", types.B).Description("`true` if the signature is valid, `false` otherwise"),
 	),
-	Categories: tokensCat,
+	Categories:  tokensCat,
+	canSkipBctx: false,
 }
 
 var JWTVerifyES256 = &Builtin{
@@ -2090,7 +2204,8 @@ var JWTVerifyES256 = &Builtin{
 		),
 		types.Named("result", types.B).Description("`true` if the signature is valid, `false` otherwise"),
 	),
-	Categories: tokensCat,
+	Categories:  tokensCat,
+	canSkipBctx: false,
 }
 
 var JWTVerifyES384 = &Builtin{
@@ -2103,7 +2218,8 @@ var JWTVerifyES384 = &Builtin{
 		),
 		types.Named("result", types.B).Description("`true` if the signature is valid, `false` otherwise"),
 	),
-	Categories: tokensCat,
+	Categories:  tokensCat,
+	canSkipBctx: false,
 }
 
 var JWTVerifyES512 = &Builtin{
@@ -2116,7 +2232,8 @@ var JWTVerifyES512 = &Builtin{
 		),
 		types.Named("result", types.B).Description("`true` if the signature is valid, `false` otherwise"),
 	),
-	Categories: tokensCat,
+	Categories:  tokensCat,
+	canSkipBctx: false,
 }
 
 var JWTVerifyHS256 = &Builtin{
@@ -2129,7 +2246,8 @@ var JWTVerifyHS256 = &Builtin{
 		),
 		types.Named("result", types.B).Description("`true` if the signature is valid, `false` otherwise"),
 	),
-	Categories: tokensCat,
+	Categories:  tokensCat,
+	canSkipBctx: false,
 }
 
 var JWTVerifyHS384 = &Builtin{
@@ -2142,7 +2260,8 @@ var JWTVerifyHS384 = &Builtin{
 		),
 		types.Named("result", types.B).Description("`true` if the signature is valid, `false` otherwise"),
 	),
-	Categories: tokensCat,
+	Categories:  tokensCat,
+	canSkipBctx: false,
 }
 
 var JWTVerifyHS512 = &Builtin{
@@ -2155,7 +2274,8 @@ var JWTVerifyHS512 = &Builtin{
 		),
 		types.Named("result", types.B).Description("`true` if the signature is valid, `false` otherwise"),
 	),
-	Categories: tokensCat,
+	Categories:  tokensCat,
+	canSkipBctx: false,
 }
 
 // Marked non-deterministic because it relies on time internally.
@@ -2176,6 +2296,7 @@ Supports the following algorithms: HS256, HS384, HS512, RS256, RS384, RS512, ES2
 	),
 	Categories:       tokensCat,
 	Nondeterministic: true,
+	canSkipBctx:      false,
 }
 
 var tokenSign = category("tokensign")
@@ -2194,6 +2315,7 @@ var JWTEncodeSignRaw = &Builtin{
 	),
 	Categories:       tokenSign,
 	Nondeterministic: true,
+	canSkipBctx:      false,
 }
 
 // Marked non-deterministic because it relies on RNG internally.
@@ -2210,6 +2332,7 @@ var JWTEncodeSign = &Builtin{
 	),
 	Categories:       tokenSign,
 	Nondeterministic: true,
+	canSkipBctx:      false,
 }
 
 /**
@@ -2225,6 +2348,7 @@ var NowNanos = &Builtin{
 		types.Named("now", types.N).Description("nanoseconds since epoch"),
 	),
 	Nondeterministic: true,
+	canSkipBctx:      false,
 }
 
 var ParseNanos = &Builtin{
@@ -2237,6 +2361,7 @@ var ParseNanos = &Builtin{
 		),
 		types.Named("ns", types.N).Description("`value` in nanoseconds since epoch"),
 	),
+	canSkipBctx: true,
 }
 
 var ParseRFC3339Nanos = &Builtin{
@@ -2248,6 +2373,7 @@ var ParseRFC3339Nanos = &Builtin{
 		),
 		types.Named("ns", types.N).Description("`value` in nanoseconds since epoch"),
 	),
+	canSkipBctx: true,
 }
 
 var ParseDurationNanos = &Builtin{
@@ -2259,6 +2385,7 @@ var ParseDurationNanos = &Builtin{
 		),
 		types.Named("ns", types.N).Description("the `duration` in nanoseconds"),
 	),
+	canSkipBctx: true,
 }
 
 var Format = &Builtin{
@@ -2274,6 +2401,7 @@ var Format = &Builtin{
 		),
 		types.Named("formatted timestamp", types.S).Description("the formatted timestamp represented for the nanoseconds since the epoch in the supplied timezone (or UTC)"),
 	),
+	canSkipBctx: true,
 }
 
 var Date = &Builtin{
@@ -2288,6 +2416,7 @@ var Date = &Builtin{
 		),
 		types.Named("date", types.NewArray([]types.Type{types.N, types.N, types.N}, nil)).Description("an array of `year`, `month` (1-12), and `day` (1-31)"),
 	),
+	canSkipBctx: true,
 }
 
 var Clock = &Builtin{
@@ -2303,6 +2432,7 @@ var Clock = &Builtin{
 		types.Named("output", types.NewArray([]types.Type{types.N, types.N, types.N}, nil)).
 			Description("the `hour`, `minute` (0-59), and `second` (0-59) representing the time of day for the nanoseconds since epoch in the supplied timezone (or UTC)"),
 	),
+	canSkipBctx: true,
 }
 
 var Weekday = &Builtin{
@@ -2317,6 +2447,7 @@ var Weekday = &Builtin{
 		),
 		types.Named("day", types.S).Description("the weekday represented by `ns` nanoseconds since the epoch in the supplied timezone (or UTC)"),
 	),
+	canSkipBctx: true,
 }
 
 var AddDate = &Builtin{
@@ -2331,6 +2462,7 @@ var AddDate = &Builtin{
 		),
 		types.Named("output", types.N).Description("nanoseconds since the epoch representing the input time, with years, months and days added"),
 	),
+	canSkipBctx: true,
 }
 
 var Diff = &Builtin{
@@ -2349,6 +2481,7 @@ var Diff = &Builtin{
 		),
 		types.Named("output", types.NewArray([]types.Type{types.N, types.N, types.N, types.N, types.N, types.N}, nil)).Description("difference between `ns1` and `ns2` (in their supplied timezones, if supplied, or UTC) as array of numbers: `[years, months, days, hours, minutes, seconds]`"),
 	),
+	canSkipBctx: true,
 }
 
 /**
@@ -2368,6 +2501,7 @@ concatenated PEM blocks. The whole input of concatenated PEM blocks can optional
 		),
 		types.Named("output", types.NewArray(nil, types.NewObject(nil, types.NewDynamicProperty(types.S, types.A)))).Description("parsed X.509 certificates represented as objects"),
 	),
+	canSkipBctx: true,
 }
 
 var CryptoX509ParseAndVerifyCertificates = &Builtin{
@@ -2387,6 +2521,7 @@ with all others being treated as intermediates.`,
 			types.NewArray(nil, types.NewObject(nil, types.NewDynamicProperty(types.S, types.A))),
 		}, nil)).Description("array of `[valid, certs]`: if the input certificate chain could be verified then `valid` is `true` and `certs` is an array of X.509 certificates represented as objects; if the input certificate chain could not be verified then `valid` is `false` and `certs` is `[]`"),
 	),
+	canSkipBctx: true,
 }
 
 var CryptoX509ParseAndVerifyCertificatesWithOptions = &Builtin{
@@ -2398,7 +2533,6 @@ be used to configure the validation options used.
 
 The first certificate is treated as the root and the last is treated as the leaf,
 with all others being treated as intermediates.`,
-
 	Decl: types.NewFunction(
 		types.Args(
 			types.Named("certs", types.S).Description("base64 encoded DER or PEM data containing two or more certificates where the first is a root CA, the last is a leaf certificate, and all others are intermediate CAs"),
@@ -2412,6 +2546,7 @@ with all others being treated as intermediates.`,
 			types.NewArray(nil, types.NewObject(nil, types.NewDynamicProperty(types.S, types.A))),
 		}, nil)).Description("array of `[valid, certs]`: if the input certificate chain could be verified then `valid` is `true` and `certs` is an array of X.509 certificates represented as objects; if the input certificate chain could not be verified then `valid` is `false` and `certs` is `[]`"),
 	),
+	canSkipBctx: true,
 }
 
 var CryptoX509ParseCertificateRequest = &Builtin{
@@ -2423,6 +2558,7 @@ var CryptoX509ParseCertificateRequest = &Builtin{
 		),
 		types.Named("output", types.NewObject(nil, types.NewDynamicProperty(types.S, types.A))).Description("X.509 CSR represented as an object"),
 	),
+	canSkipBctx: true,
 }
 
 var CryptoX509ParseKeyPair = &Builtin{
@@ -2435,6 +2571,7 @@ var CryptoX509ParseKeyPair = &Builtin{
 		),
 		types.Named("output", types.NewObject(nil, types.NewDynamicProperty(types.S, types.A))).Description("if key pair is valid, returns the tls.certificate(https://pkg.go.dev/crypto/tls#Certificate) as an object. If the key pair is invalid, nil and an error are returned."),
 	),
+	canSkipBctx: true,
 }
 var CryptoX509ParseRSAPrivateKey = &Builtin{
 	Name:        "crypto.x509.parse_rsa_private_key",
@@ -2445,6 +2582,7 @@ var CryptoX509ParseRSAPrivateKey = &Builtin{
 		),
 		types.Named("output", types.NewObject(nil, types.NewDynamicProperty(types.S, types.A))).Description("JWK as an object"),
 	),
+	canSkipBctx: true,
 }
 
 var CryptoParsePrivateKeys = &Builtin{
@@ -2458,6 +2596,7 @@ If the input is empty, the function will return null. The input string should be
 		),
 		types.Named("output", types.NewArray(nil, types.NewObject(nil, types.NewDynamicProperty(types.S, types.A)))).Description("parsed private keys represented as objects"),
 	),
+	canSkipBctx: true,
 }
 
 var CryptoMd5 = &Builtin{
@@ -2469,6 +2608,7 @@ var CryptoMd5 = &Builtin{
 		),
 		types.Named("y", types.S).Description("MD5-hash of `x`"),
 	),
+	canSkipBctx: true,
 }
 
 var CryptoSha1 = &Builtin{
@@ -2480,6 +2620,7 @@ var CryptoSha1 = &Builtin{
 		),
 		types.Named("y", types.S).Description("SHA1-hash of `x`"),
 	),
+	canSkipBctx: true,
 }
 
 var CryptoSha256 = &Builtin{
@@ -2491,6 +2632,7 @@ var CryptoSha256 = &Builtin{
 		),
 		types.Named("y", types.S).Description("SHA256-hash of `x`"),
 	),
+	canSkipBctx: true,
 }
 
 var CryptoHmacMd5 = &Builtin{
@@ -2503,6 +2645,7 @@ var CryptoHmacMd5 = &Builtin{
 		),
 		types.Named("y", types.S).Description("MD5-HMAC of `x`"),
 	),
+	canSkipBctx: true,
 }
 
 var CryptoHmacSha1 = &Builtin{
@@ -2515,6 +2658,7 @@ var CryptoHmacSha1 = &Builtin{
 		),
 		types.Named("y", types.S).Description("SHA1-HMAC of `x`"),
 	),
+	canSkipBctx: true,
 }
 
 var CryptoHmacSha256 = &Builtin{
@@ -2527,6 +2671,7 @@ var CryptoHmacSha256 = &Builtin{
 		),
 		types.Named("y", types.S).Description("SHA256-HMAC of `x`"),
 	),
+	canSkipBctx: true,
 }
 
 var CryptoHmacSha512 = &Builtin{
@@ -2539,6 +2684,7 @@ var CryptoHmacSha512 = &Builtin{
 		),
 		types.Named("y", types.S).Description("SHA512-HMAC of `x`"),
 	),
+	canSkipBctx: true,
 }
 
 var CryptoHmacEqual = &Builtin{
@@ -2551,6 +2697,7 @@ var CryptoHmacEqual = &Builtin{
 		),
 		types.Named("result", types.B).Description("`true` if the MACs are equals, `false` otherwise"),
 	),
+	canSkipBctx: true,
 }
 
 /**
@@ -2574,7 +2721,8 @@ var WalkBuiltin = &Builtin{
 			nil,
 		)).Description("pairs of `path` and `value`: `path` is an array representing the pointer to `value` in `x`. If `path` is assigned a wildcard (`_`), the `walk` function will skip path creation entirely for faster evaluation."),
 	),
-	Categories: graphs,
+	Categories:  graphs,
+	canSkipBctx: true,
 }
 
 var ReachableBuiltin = &Builtin{
@@ -2595,6 +2743,7 @@ var ReachableBuiltin = &Builtin{
 		),
 		types.Named("output", types.SetOfAny).Description("set of vertices reachable from the `initial` vertices in the directed `graph`"),
 	),
+	canSkipBctx: true,
 }
 
 var ReachablePathsBuiltin = &Builtin{
@@ -2615,6 +2764,7 @@ var ReachablePathsBuiltin = &Builtin{
 		),
 		types.Named("output", types.NewSet(types.NewArray(nil, types.A))).Description("paths reachable from the `initial` vertices in the directed `graph`"),
 	),
+	canSkipBctx: true,
 }
 
 /**
@@ -2631,7 +2781,8 @@ var IsNumber = &Builtin{
 		),
 		types.Named("result", types.B).Description("`true` if `x` is a number, `false` otherwise."),
 	),
-	Categories: typesCat,
+	Categories:  typesCat,
+	canSkipBctx: true,
 }
 
 var IsString = &Builtin{
@@ -2643,7 +2794,8 @@ var IsString = &Builtin{
 		),
 		types.Named("result", types.B).Description("`true` if `x` is a string, `false` otherwise."),
 	),
-	Categories: typesCat,
+	Categories:  typesCat,
+	canSkipBctx: true,
 }
 
 var IsBoolean = &Builtin{
@@ -2655,7 +2807,8 @@ var IsBoolean = &Builtin{
 		),
 		types.Named("result", types.B).Description("`true` if `x` is an boolean, `false` otherwise."),
 	),
-	Categories: typesCat,
+	Categories:  typesCat,
+	canSkipBctx: true,
 }
 
 var IsArray = &Builtin{
@@ -2667,7 +2820,8 @@ var IsArray = &Builtin{
 		),
 		types.Named("result", types.B).Description("`true` if `x` is an array, `false` otherwise."),
 	),
-	Categories: typesCat,
+	Categories:  typesCat,
+	canSkipBctx: true,
 }
 
 var IsSet = &Builtin{
@@ -2679,7 +2833,8 @@ var IsSet = &Builtin{
 		),
 		types.Named("result", types.B).Description("`true` if `x` is a set, `false` otherwise."),
 	),
-	Categories: typesCat,
+	Categories:  typesCat,
+	canSkipBctx: true,
 }
 
 var IsObject = &Builtin{
@@ -2691,7 +2846,8 @@ var IsObject = &Builtin{
 		),
 		types.Named("result", types.B).Description("`true` if `x` is an object, `false` otherwise."),
 	),
-	Categories: typesCat,
+	Categories:  typesCat,
+	canSkipBctx: true,
 }
 
 var IsNull = &Builtin{
@@ -2703,7 +2859,8 @@ var IsNull = &Builtin{
 		),
 		types.Named("result", types.B).Description("`true` if `x` is null, `false` otherwise."),
 	),
-	Categories: typesCat,
+	Categories:  typesCat,
+	canSkipBctx: true,
 }
 
 /**
@@ -2720,7 +2877,8 @@ var TypeNameBuiltin = &Builtin{
 		),
 		types.Named("type", types.S).Description(`one of "null", "boolean", "number", "string", "array", "object", "set"`),
 	),
-	Categories: typesCat,
+	Categories:  typesCat,
+	canSkipBctx: true,
 }
 
 /**
@@ -2740,6 +2898,7 @@ var HTTPSend = &Builtin{
 			Description("the HTTP response object"),
 	),
 	Nondeterministic: true,
+	canSkipBctx:      false,
 }
 
 /**
@@ -2762,6 +2921,7 @@ var GraphQLParse = &Builtin{
 			types.NewObject(nil, types.NewDynamicProperty(types.A, types.A)),
 		}, nil)).Description("`output` is of the form `[query_ast, schema_ast]`. If the GraphQL query is valid given the provided schema, then `query_ast` and `schema_ast` are objects describing the ASTs for the query and schema."),
 	),
+	canSkipBctx: false,
 }
 
 // GraphQLParseAndVerify returns a boolean and a pair of AST object from parsing/validation.
@@ -2781,6 +2941,7 @@ var GraphQLParseAndVerify = &Builtin{
 			types.NewObject(nil, types.NewDynamicProperty(types.A, types.A)),
 		}, nil)).Description(" `output` is of the form `[valid, query_ast, schema_ast]`. If the query is valid given the provided schema, then `valid` is `true`, and `query_ast` and `schema_ast` are objects describing the ASTs for the GraphQL query and schema. Otherwise, `valid` is `false` and `query_ast` and `schema_ast` are `{}`."),
 	),
+	canSkipBctx: false,
 }
 
 // GraphQLParseQuery parses the input GraphQL query and returns a JSON
@@ -2794,6 +2955,7 @@ var GraphQLParseQuery = &Builtin{
 		),
 		types.Named("output", types.NewObject(nil, types.NewDynamicProperty(types.A, types.A))).Description("AST object for the GraphQL query."),
 	),
+	canSkipBctx: true,
 }
 
 // GraphQLParseSchema parses the input GraphQL schema and returns a JSON
@@ -2807,6 +2969,7 @@ var GraphQLParseSchema = &Builtin{
 		),
 		types.Named("output", types.NewObject(nil, types.NewDynamicProperty(types.A, types.A))).Description("AST object for the GraphQL schema."),
 	),
+	canSkipBctx: false,
 }
 
 // GraphQLIsValid returns true if a GraphQL query is valid with a given
@@ -2823,6 +2986,7 @@ var GraphQLIsValid = &Builtin{
 		),
 		types.Named("output", types.B).Description("`true` if the query is valid under the given schema. `false` otherwise."),
 	),
+	canSkipBctx: false,
 }
 
 // GraphQLSchemaIsValid returns true if the input is valid GraphQL schema,
@@ -2837,6 +3001,7 @@ var GraphQLSchemaIsValid = &Builtin{
 		),
 		types.Named("output", types.B).Description("`true` if the schema is a valid GraphQL schema. `false` otherwise."),
 	),
+	canSkipBctx: false,
 }
 
 /**
@@ -2859,7 +3024,8 @@ var JSONSchemaVerify = &Builtin{
 		}, nil)).
 			Description("`output` is of the form `[valid, error]`. If the schema is valid, then `valid` is `true`, and `error` is `null`. Otherwise, `valid` is `false` and `error` is a string describing the error."),
 	),
-	Categories: objectCat,
+	Categories:  objectCat,
+	canSkipBctx: true,
 }
 
 // JSONMatchSchema returns empty array if the document matches the JSON schema,
@@ -2890,7 +3056,8 @@ var JSONMatchSchema = &Builtin{
 		}, nil)).
 			Description("`output` is of the form `[match, errors]`. If the document is valid given the schema, then `match` is `true`, and `errors` is an empty array. Otherwise, `match` is `false` and `errors` is an array of objects describing the error(s)."),
 	),
-	Categories: objectCat,
+	Categories:  objectCat,
+	canSkipBctx: false,
 }
 
 /**
@@ -2912,7 +3079,8 @@ var ProvidersAWSSignReqObj = &Builtin{
 		types.Named("signed_request", types.NewObject(nil, types.NewDynamicProperty(types.A, types.A))).
 			Description("HTTP request object with `Authorization` header"),
 	),
-	Categories: providersAWSCat,
+	Categories:  providersAWSCat,
+	canSkipBctx: true,
 }
 
 /**
@@ -2930,6 +3098,7 @@ var RegoParseModule = &Builtin{
 		types.Named("output", types.NewObject(nil, types.NewDynamicProperty(types.S, types.A))).
 			Description("AST object for the Rego module"),
 	),
+	canSkipBctx: true,
 }
 
 var RegoMetadataChain = &Builtin{
@@ -2942,6 +3111,7 @@ The first entry in the chain always points to the active rule, even if it has no
 		types.Args(),
 		types.Named("chain", types.NewArray(nil, types.A)).Description("each array entry represents a node in the path ancestry (chain) of the active rule that also has declared annotations"),
 	),
+	canSkipBctx: true,
 }
 
 // RegoMetadataRule returns the metadata for the active rule
@@ -2952,6 +3122,7 @@ var RegoMetadataRule = &Builtin{
 		types.Args(),
 		types.Named("output", types.A).Description("\"rule\" scope annotations for this rule; empty object if no annotations exist"),
 	),
+	canSkipBctx: true,
 }
 
 /**
@@ -2968,6 +3139,7 @@ var OPARuntime = &Builtin{
 			Description("includes a `config` key if OPA was started with a configuration file; an `env` key containing the environment variables that the OPA process was started with; includes `version` and `commit` keys containing the version and build commit of OPA."),
 	),
 	Nondeterministic: true,
+	canSkipBctx:      false,
 }
 
 /**
@@ -2984,7 +3156,8 @@ var Trace = &Builtin{
 		),
 		types.Named("result", types.B).Description("always `true`"),
 	),
-	Categories: tracing,
+	Categories:  tracing,
+	canSkipBctx: false,
 }
 
 /**
@@ -3005,6 +3178,7 @@ var GlobMatch = &Builtin{
 		),
 		types.Named("result", types.B).Description("true if `match` can be found in `pattern` which is separated by `delimiters`"),
 	),
+	canSkipBctx: false,
 }
 
 var GlobQuoteMeta = &Builtin{
@@ -3016,6 +3190,7 @@ var GlobQuoteMeta = &Builtin{
 		),
 		types.Named("output", types.S).Description("the escaped string of `pattern`"),
 	),
+	canSkipBctx: true,
 	// TODO(sr): example for this was: Calling ``glob.quote_meta("*.github.com", output)`` returns ``\\*.github.com`` as ``output``.
 }
 
@@ -3033,6 +3208,7 @@ var NetCIDRIntersects = &Builtin{
 		),
 		types.Named("result", types.B).Description("`true` if `cidr1` intersects with `cidr2`"),
 	),
+	canSkipBctx: true,
 }
 
 var NetCIDRExpand = &Builtin{
@@ -3044,6 +3220,7 @@ var NetCIDRExpand = &Builtin{
 		),
 		types.Named("hosts", types.SetOfStr).Description("set of IP addresses the CIDR `cidr` expands to"),
 	),
+	canSkipBctx: false,
 }
 
 var NetCIDRContains = &Builtin{
@@ -3056,6 +3233,7 @@ var NetCIDRContains = &Builtin{
 		),
 		types.Named("result", types.B).Description("`true` if `cidr_or_ip` is contained within `cidr`"),
 	),
+	canSkipBctx: true,
 }
 
 var NetCIDRContainsMatches = &Builtin{
@@ -3069,6 +3247,7 @@ var NetCIDRContainsMatches = &Builtin{
 		),
 		types.Named("output", types.NewSet(types.NewArray([]types.Type{types.A, types.A}, nil))).Description("tuples identifying matches where `cidrs_or_ips` are contained within `cidrs`"),
 	),
+	canSkipBctx: true,
 }
 
 var NetCIDRMerge = &Builtin{
@@ -3085,6 +3264,7 @@ Supports both IPv4 and IPv6 notations. IPv6 inputs need a prefix length (e.g. "/
 		),
 		types.Named("output", types.SetOfStr).Description("smallest possible set of CIDRs obtained after merging the provided list of IP addresses and subnets in `addrs`"),
 	),
+	canSkipBctx: true,
 }
 
 var NetCIDRIsValid = &Builtin{
@@ -3096,6 +3276,7 @@ var NetCIDRIsValid = &Builtin{
 		),
 		types.Named("result", types.B).Description("`true` if `cidr` is a valid CIDR"),
 	),
+	canSkipBctx: true,
 }
 
 var netCidrContainsMatchesOperandType = types.NewAny(
@@ -3128,6 +3309,7 @@ var NetLookupIPAddr = &Builtin{
 		types.Named("addrs", types.SetOfStr).Description("IP addresses (v4 and v6) that `name` resolves to"),
 	),
 	Nondeterministic: true,
+	canSkipBctx:      false,
 }
 
 /**
@@ -3143,6 +3325,7 @@ var SemVerIsValid = &Builtin{
 		),
 		types.Named("result", types.B).Description("`true` if `vsn` is a valid SemVer; `false` otherwise"),
 	),
+	canSkipBctx: true,
 }
 
 var SemVerCompare = &Builtin{
@@ -3155,6 +3338,7 @@ var SemVerCompare = &Builtin{
 		),
 		types.Named("result", types.N).Description("`-1` if `a < b`; `1` if `a > b`; `0` if `a == b`"),
 	),
+	canSkipBctx: true,
 }
 
 /**
@@ -3197,7 +3381,8 @@ var SetDiff = &Builtin{
 		),
 		types.SetOfAny,
 	),
-	deprecated: true,
+	deprecated:  true,
+	canSkipBctx: true,
 }
 
 // NetCIDROverlap has been replaced by the `net.cidr_contains` built-in.
@@ -3210,7 +3395,8 @@ var NetCIDROverlap = &Builtin{
 		),
 		types.B,
 	),
-	deprecated: true,
+	deprecated:  true,
+	canSkipBctx: true,
 }
 
 // CastArray checks the underlying type of the input. If it is array or set, an array
@@ -3221,7 +3407,8 @@ var CastArray = &Builtin{
 		types.Args(types.A),
 		types.NewArray(nil, types.A),
 	),
-	deprecated: true,
+	deprecated:  true,
+	canSkipBctx: true,
 }
 
 // CastSet checks the underlying type of the input.
@@ -3234,7 +3421,8 @@ var CastSet = &Builtin{
 		types.Args(types.A),
 		types.SetOfAny,
 	),
-	deprecated: true,
+	deprecated:  true,
+	canSkipBctx: true,
 }
 
 // CastString returns input if it is a string; if not returns error.
@@ -3245,7 +3433,8 @@ var CastString = &Builtin{
 		types.Args(types.A),
 		types.S,
 	),
-	deprecated: true,
+	deprecated:  true,
+	canSkipBctx: true,
 }
 
 // CastBoolean returns input if it is a boolean; if not returns error.
@@ -3255,7 +3444,8 @@ var CastBoolean = &Builtin{
 		types.Args(types.A),
 		types.B,
 	),
-	deprecated: true,
+	deprecated:  true,
+	canSkipBctx: true,
 }
 
 // CastNull returns null if input is null; if not returns error.
@@ -3265,7 +3455,8 @@ var CastNull = &Builtin{
 		types.Args(types.A),
 		types.NewNull(),
 	),
-	deprecated: true,
+	deprecated:  true,
+	canSkipBctx: true,
 }
 
 // CastObject returns the given object if it is null; throws an error otherwise
@@ -3275,7 +3466,8 @@ var CastObject = &Builtin{
 		types.Args(types.A),
 		types.NewObject(nil, types.NewDynamicProperty(types.A, types.A)),
 	),
-	deprecated: true,
+	deprecated:  true,
+	canSkipBctx: true,
 }
 
 // RegexMatchDeprecated declares `re_match` which has been deprecated. Use `regex.match` instead.
@@ -3288,7 +3480,8 @@ var RegexMatchDeprecated = &Builtin{
 		),
 		types.B,
 	),
-	deprecated: true,
+	deprecated:  true,
+	canSkipBctx: false,
 }
 
 // All takes a list and returns true if all of the items
@@ -3304,7 +3497,8 @@ var All = &Builtin{
 		),
 		types.B,
 	),
-	deprecated: true,
+	deprecated:  true,
+	canSkipBctx: true,
 }
 
 // Any takes a collection and returns true if any of the items
@@ -3320,7 +3514,8 @@ var Any = &Builtin{
 		),
 		types.B,
 	),
-	deprecated: true,
+	deprecated:  true,
+	canSkipBctx: true,
 }
 
 // Builtin represents a built-in function supported by OPA. Every built-in
@@ -3338,6 +3533,7 @@ type Builtin struct {
 	Infix            string          `json:"infix,omitempty"`    // Unique name of infix operator. Default should be unset.
 	Relation         bool            `json:"relation,omitempty"` // Indicates if the built-in acts as a relation.
 	deprecated       bool            // Indicates if the built-in has been deprecated.
+	canSkipBctx      bool            // Built-in needs no data from the built-in context.
 	Nondeterministic bool            `json:"nondeterministic,omitempty"` // Indicates if the built-in returns non-deterministic results.
 }
 
@@ -3408,6 +3604,13 @@ func (b *Builtin) Ref() Ref {
 // evaluating the call expression.
 func (b *Builtin) IsTargetPos(i int) bool {
 	return b.Decl.Arity() == i
+}
+
+// NeedsBuiltInContext returns true if the built-in depends on the built-in context.
+func (b *Builtin) NeedsBuiltInContext() bool {
+	// Negated, so built-ins we don't know about (and who don't know about this option)
+	// will get a built-in context provided to them.
+	return !b.canSkipBctx
 }
 
 func init() {

--- a/v1/topdown/strings.go
+++ b/v1/topdown/strings.go
@@ -151,7 +151,7 @@ func builtinFormatInt(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Ter
 	return iter(ast.InternedTerm(fmt.Sprintf(format, i)))
 }
 
-func builtinConcat(b BuiltinContext, operands []*ast.Term, iter func(*ast.Term) error) error {
+func builtinConcat(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term) error) error {
 	join, err := builtins.StringOperand(operands[0].Value, 1)
 	if err != nil {
 		return err


### PR DESCRIPTION
This commit updates the ast.Builtin struct adding a private field that'll store information about whether the built-in needs a builtin context, and a public method to read this.

This information is then read in eval, where the construction of the BuiltinContext is skipped unless a built-in depends on that.
