### PR TITLE
docs: Correctly spell NetBSD

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -869,7 +869,7 @@ For example:
 - [nixpkgs](https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/op/open-policy-agent/package.nix)
 - [Wolfi](https://github.com/wolfi-dev/os/blob/main/opa.yaml)
 - [FreeBSD](https://cgit.freebsd.org/ports/tree/sysutils/opa)
-- [NetBSB](https://pkgsrc.se/devel/opa)
+- [NetBSD](https://pkgsrc.se/devel/opa)
 
 In order to manually install the OPA binary from the GitHub release assets,
 please run the following:


### PR DESCRIPTION
This PR fixes a typo in the installation section in order to properly spell NetBSD.

### Why the changes in this PR are needed?

NetBSD was accidentally spelled as NetBSB.

### What are the changes in this PR?

Just a mechanical s/NetBSB/NetBSD/ in the docs.

### Notes to assist PR review:

N/A

### Further comments:

Thanks for mentioning the pkgsrc package!
