### PR TITLE
perf: AST compiler optimizations

### DIFF
--- a/cmd/eval.go
+++ b/cmd/eval.go
@@ -138,6 +138,9 @@ func validateEvalParams(p *evalCommandParams, cmdArgs []string) error {
 
 	// check if illegal arguments is passed with unknowns flag
 	for _, unknwn := range p.unknowns {
+		if unknwn == "input" {
+			continue
+		}
 		term, err := ast.ParseTerm(unknwn)
 		if err != nil {
 			return err

--- a/v1/ast/capabilities_test.go
+++ b/v1/ast/capabilities_test.go
@@ -291,6 +291,16 @@ func TestCapabilitiesMinimumCompatibleVersion(t *testing.T) {
 	}
 }
 
+func BenchmarkCapabilitiesCurrentVersion(b *testing.B) {
+	var caps *Capabilities
+	for range b.N {
+		caps = CapabilitiesForThisVersion()
+	}
+	if caps == nil {
+		b.Fatal("expected capabilities to be non-nil")
+	}
+}
+
 func findBuiltinIndex(c *Capabilities, name string) int {
 	for i, bi := range c.Builtins {
 		if bi.Name == name {

--- a/v1/ast/compile.go
+++ b/v1/ast/compile.go
@@ -26,7 +26,11 @@ import (
 // exiting.
 const CompileErrorLimitDefault = 10
 
-var errLimitReached = NewError(CompileErr, nil, "error limit reached")
+var (
+	errLimitReached = NewError(CompileErr, nil, "error limit reached")
+
+	doubleEq = Equal.Ref()
+)
 
 // Compiler contains the state of a compilation process.
 type Compiler struct {
@@ -955,8 +959,10 @@ func (c *Compiler) buildRuleIndices() {
 func (c *Compiler) buildComprehensionIndices() {
 	for _, name := range c.sorted {
 		WalkRules(c.Modules[name], func(r *Rule) bool {
-			candidates := r.Head.Args.Vars()
-			candidates.Update(ReservedVars)
+			candidates := ReservedVars.Copy()
+			if len(r.Head.Args) > 0 {
+				candidates.Update(r.Head.Args.Vars())
+			}
 			n := buildComprehensionIndices(c.debug, c.GetArity, candidates, c.RewrittenVars, r.Body, c.comprehensionIndices)
 			c.counterAdd(compileStageComprehensionIndexBuild, n)
 			return false
@@ -1281,7 +1287,9 @@ func (c *Compiler) checkSafetyRuleBodies() {
 		m := c.Modules[name]
 		WalkRules(m, func(r *Rule) bool {
 			safe := ReservedVars.Copy()
-			safe.Update(r.Head.Args.Vars())
+			if len(r.Head.Args) > 0 {
+				safe.Update(r.Head.Args.Vars())
+			}
 			r.Body = c.checkBodySafety(safe, r.Body)
 			return false
 		})
@@ -1310,19 +1318,24 @@ var SafetyCheckVisitorParams = VarVisitorParams{
 // checkSafetyRuleHeads ensures that variables appearing in the head of a
 // rule also appear in the body.
 func (c *Compiler) checkSafetyRuleHeads() {
-
 	for _, name := range c.sorted {
-		m := c.Modules[name]
-		WalkRules(m, func(r *Rule) bool {
+		WalkRules(c.Modules[name], func(r *Rule) bool {
 			safe := r.Body.Vars(SafetyCheckVisitorParams)
-			safe.Update(r.Head.Args.Vars())
-			unsafe := r.Head.Vars().Diff(safe)
-			for v := range unsafe {
-				if w, ok := c.RewrittenVars[v]; ok {
-					v = w
-				}
-				if !v.IsGenerated() {
-					c.err(NewError(UnsafeVarErr, r.Loc(), "var %v is unsafe", v))
+			if len(r.Head.Args) > 0 {
+				safe.Update(r.Head.Args.Vars())
+			}
+			if headMayHaveVars(r.Head) {
+				vars := r.Head.Vars()
+				if vars.DiffCount(safe) > 0 {
+					unsafe := vars.Diff(safe)
+					for v := range unsafe {
+						if w, ok := c.RewrittenVars[v]; ok {
+							v = w
+						}
+						if !v.IsGenerated() {
+							c.err(NewError(UnsafeVarErr, r.Loc(), "var %v is unsafe", v))
+						}
+					}
 				}
 			}
 			return false
@@ -2127,12 +2140,16 @@ func rewritePrintCalls(gen *localVarGenerator, getArity func(Ref) int, globals V
 		safe.Update(globals)
 		args := body[i].Operands()
 
+		var vis *VarVisitor
 		for j := range args {
-			vis := NewVarVisitor().WithParams(SafetyCheckVisitorParams)
+			vis = vis.ClearOrNew().WithParams(SafetyCheckVisitorParams)
 			vis.Walk(args[j])
-			unsafe := vis.Vars().Diff(safe)
-			for _, v := range unsafe.Sorted() {
-				errs = append(errs, NewError(CompileErr, args[j].Loc(), "var %v is undeclared", v))
+			vars := vis.Vars()
+			if vars.DiffCount(safe) > 0 {
+				unsafe := vars.Diff(safe)
+				for _, v := range unsafe.Sorted() {
+					errs = append(errs, NewError(CompileErr, args[j].Loc(), "var %v is undeclared", v))
+				}
 			}
 		}
 
@@ -2140,17 +2157,17 @@ func rewritePrintCalls(gen *localVarGenerator, getArity func(Ref) int, globals V
 			return false, errs
 		}
 
-		arr := NewArray()
+		terms := make([]*Term, 0, len(args))
 
 		for j := range args {
 			x := NewTerm(gen.Generate()).SetLocation(args[j].Loc())
 			capture := Equality.Expr(x, args[j]).SetLocation(args[j].Loc())
-			arr = arr.Append(SetComprehensionTerm(x, NewBody(capture)).SetLocation(args[j].Loc()))
+			terms = append(terms, SetComprehensionTerm(x, NewBody(capture)).SetLocation(args[j].Loc()))
 		}
 
 		body.Set(NewExpr([]*Term{
 			NewTerm(InternalPrint.Ref()).SetLocation(body[i].Loc()),
-			NewTerm(arr).SetLocation(body[i].Loc()),
+			ArrayTerm(terms...).SetLocation(body[i].Loc()),
 		}).SetLocation(body[i].Loc()), i)
 	}
 
@@ -2270,8 +2287,7 @@ func (c *Compiler) rewriteRefsInHead() {
 func (c *Compiler) rewriteEquals() {
 	modified := false
 	for _, name := range c.sorted {
-		mod := c.Modules[name]
-		modified = rewriteEquals(mod) || modified
+		modified = rewriteEquals(c.Modules[name]) || modified
 	}
 	if modified {
 		c.Required.addBuiltinSorted(Equal)
@@ -2281,8 +2297,7 @@ func (c *Compiler) rewriteEquals() {
 func (c *Compiler) rewriteDynamicTerms() {
 	f := newEqualityFactory(c.localvargen)
 	for _, name := range c.sorted {
-		mod := c.Modules[name]
-		WalkRules(mod, func(rule *Rule) bool {
+		WalkRules(c.Modules[name], func(rule *Rule) bool {
 			rule.Body = rewriteDynamics(f, rule.Body)
 			return false
 		})
@@ -2546,19 +2561,21 @@ func createMetadataChain(chain []*AnnotationsRef) (*Term, *Error) {
 }
 
 func (c *Compiler) rewriteLocalVars() {
-
 	var assignment bool
+
+	args := NewVarVisitor()
+	argsStack := newLocalDeclaredVars()
 
 	for _, name := range c.sorted {
 		mod := c.Modules[name]
 		gen := c.localvargen
 
 		WalkRules(mod, func(rule *Rule) bool {
-			argsStack := newLocalDeclaredVars()
+			args.Clear()
+			argsStack.Clear()
 
-			args := NewVarVisitor()
-			if c.strict {
-				args.Walk(rule.Head.Args)
+			if c.strict && len(rule.Head.Args) > 0 {
+				args.WalkArgs(rule.Head.Args)
 			}
 			unusedArgs := args.Vars()
 
@@ -2603,45 +2620,51 @@ func (c *Compiler) rewriteLocalVars() {
 }
 
 func (c *Compiler) rewriteLocalVarsInRule(rule *Rule, unusedArgs VarSet, argsStack *localDeclaredVars, gen *localVarGenerator) (*localDeclaredVars, Errors) {
-	// Rewrite assignments contained in head of rule. Assignments can
-	// occur in rule head if they're inside a comprehension. Note,
-	// assigned vars in comprehensions in the head will be rewritten
-	// first to preserve scoping rules. For example:
-	//
-	// p = [x | x := 1] { x := 2 } becomes p = [__local0__ | __local0__ = 1] { __local1__ = 2 }
-	//
-	// This behaviour is consistent scoping inside the body. For example:
-	//
-	// p = xs { x := 2; xs = [x | x := 1] } becomes p = xs { __local0__ = 2; xs = [__local1__ | __local1__ = 1] }
-	nestedXform := &rewriteNestedHeadVarLocalTransform{
-		gen:           gen,
-		RewrittenVars: c.RewrittenVars,
-		strict:        c.strict,
-	}
+	onlyScalars := !headMayHaveVars(rule.Head)
 
-	NewGenericVisitor(nestedXform.Visit).Walk(rule.Head)
+	var used VarSet
 
-	for _, err := range nestedXform.errs {
-		c.err(err)
-	}
+	if !onlyScalars {
+		// Rewrite assignments contained in head of rule. Assignments can
+		// occur in rule head if they're inside a comprehension. Note,
+		// assigned vars in comprehensions in the head will be rewritten
+		// first to preserve scoping rules. For example:
+		//
+		// p = [x | x := 1] { x := 2 } becomes p = [__local0__ | __local0__ = 1] { __local1__ = 2 }
+		//
+		// This behaviour is consistent scoping inside the body. For example:
+		//
+		// p = xs { x := 2; xs = [x | x := 1] } becomes p = xs { __local0__ = 2; xs = [__local1__ | __local1__ = 1] }
+		nestedXform := &rewriteNestedHeadVarLocalTransform{
+			gen:           gen,
+			RewrittenVars: c.RewrittenVars,
+			strict:        c.strict,
+		}
 
-	// Rewrite assignments in body.
-	used := NewVarSet()
+		NewGenericVisitor(nestedXform.Visit).Walk(rule.Head)
 
-	for _, t := range rule.Head.Ref()[1:] {
-		used.Update(t.Vars())
-	}
+		for _, err := range nestedXform.errs {
+			c.err(err)
+		}
 
-	if rule.Head.Key != nil {
-		used.Update(rule.Head.Key.Vars())
-	}
+		// Rewrite assignments in body.
+		used = NewVarSet()
 
-	if rule.Head.Value != nil {
-		valueVars := rule.Head.Value.Vars()
-		used.Update(valueVars)
-		for arg := range unusedArgs {
-			if valueVars.Contains(arg) {
-				delete(unusedArgs, arg)
+		for _, t := range rule.Head.Ref()[1:] {
+			used.Update(t.Vars())
+		}
+
+		if rule.Head.Key != nil {
+			used.Update(rule.Head.Key.Vars())
+		}
+
+		if rule.Head.Value != nil {
+			valueVars := rule.Head.Value.Vars()
+			used.Update(valueVars)
+			for arg := range unusedArgs {
+				if valueVars.Contains(arg) {
+					delete(unusedArgs, arg)
+				}
 			}
 		}
 	}
@@ -2655,6 +2678,10 @@ func (c *Compiler) rewriteLocalVarsInRule(rule *Rule, unusedArgs VarSet, argsSta
 	maps.Copy(c.RewrittenVars, stack.rewritten)
 
 	rule.Body = body
+
+	if onlyScalars {
+		return stack, errs
+	}
 
 	// Rewrite vars in head that refer to locally declared vars in the body.
 	localXform := rewriteHeadVarLocalTransform{declared: declared}
@@ -2676,6 +2703,30 @@ func (c *Compiler) rewriteLocalVarsInRule(rule *Rule, unusedArgs VarSet, argsSta
 	return stack, errs
 }
 
+func headMayHaveVars(head *Head) bool {
+	if head == nil {
+		return false
+	}
+	for i := range head.Args {
+		if !IsScalar(head.Args[i].Value) {
+			return true
+		}
+	}
+	if head.Key != nil && !IsScalar(head.Key.Value) {
+		return true
+	}
+	if head.Value != nil && !IsScalar(head.Value.Value) {
+		return true
+	}
+	ref := head.Ref()[1:]
+	for i := range ref {
+		if !IsScalar(ref[i].Value) {
+			return true
+		}
+	}
+	return false
+}
+
 type rewriteNestedHeadVarLocalTransform struct {
 	gen           *localVarGenerator
 	errs          Errors
@@ -2684,9 +2735,7 @@ type rewriteNestedHeadVarLocalTransform struct {
 }
 
 func (xform *rewriteNestedHeadVarLocalTransform) Visit(x any) bool {
-
 	if term, ok := x.(*Term); ok {
-
 		stop := false
 		stack := newLocalDeclaredVars()
 
@@ -3163,7 +3212,7 @@ func (ci *ComprehensionIndex) String() string {
 	return fmt.Sprintf("<keys: %v>", NewArray(ci.Keys...))
 }
 
-func buildComprehensionIndices(dbg debug.Debug, arity func(Ref) int, candidates VarSet, rwVars map[Var]Var, node any, result map[*Term]*ComprehensionIndex) uint64 {
+func buildComprehensionIndices(dbg debug.Debug, arity func(Ref) int, candidates VarSet, rwVars map[Var]Var, node Body, result map[*Term]*ComprehensionIndex) uint64 {
 	var n uint64
 	cpy := candidates.Copy()
 	WalkBodies(node, func(b Body) bool {
@@ -3365,7 +3414,6 @@ func (vis *comprehensionIndexNestedCandidateVisitor) Walk(x any) {
 }
 
 func (vis *comprehensionIndexNestedCandidateVisitor) visit(x any) bool {
-
 	if vis.found {
 		return true
 	}
@@ -3904,21 +3952,26 @@ func (vs unsafeVars) Slice() (result []unsafePair) {
 // If the body cannot be reordered to ensure safety, the second return value
 // contains a mapping of expressions to unsafe variables in those expressions.
 func reorderBodyForSafety(builtins map[string]*Builtin, arity func(Ref) int, globals VarSet, body Body) (Body, unsafeVars) {
+	vis := varVisitorPool.Get().WithParams(SafetyCheckVisitorParams)
+	vis.WalkBody(body)
 
-	bodyVars := body.Vars(SafetyCheckVisitorParams)
-	reordered := make(Body, 0, len(body))
-	safe := VarSet{}
-	unsafe := unsafeVars{}
+	defer varVisitorPool.Put(vis)
+
+	bodyVars := vis.Vars().Copy()
+	safe := bodyVars.Intersect(globals)
+	unsafe := make(unsafeVars, len(bodyVars)-len(safe))
 
 	for _, e := range body {
-		for v := range e.Vars(SafetyCheckVisitorParams) {
-			if globals.Contains(v) {
-				safe.Add(v)
-			} else {
+		vis.Clear().WithParams(SafetyCheckVisitorParams).Walk(e)
+		for v := range vis.Vars() {
+			if _, ok := safe[v]; !ok {
 				unsafe.Add(e, v)
 			}
 		}
 	}
+
+	reordered := make(Body, 0, len(body))
+	output := VarSet{}
 
 	for {
 		n := len(reordered)
@@ -3928,15 +3981,16 @@ func reorderBodyForSafety(builtins map[string]*Builtin, arity func(Ref) int, glo
 				continue
 			}
 
-			ovs := outputVarsForExpr(e, arity, safe)
+			ovs := outputVarsForExpr(e, arity, safe, output)
 
 			// check closures: is this expression closing over variables that
 			// haven't been made safe by what's already included in `reordered`?
 			vs := unsafeVarsInClosures(e)
 			cv := vs.Intersect(bodyVars).Diff(globals)
-			uv := cv.Diff(outputVarsForBody(reordered, arity, safe))
+			ob := outputVarsForBody(reordered, arity, safe)
 
-			if len(uv) > 0 {
+			if cv.DiffCount(ob) > 0 {
+				uv := cv.Diff(ob)
 				if uv.Equal(ovs) { // special case "closure-self"
 					continue
 				}
@@ -3965,18 +4019,22 @@ func reorderBodyForSafety(builtins map[string]*Builtin, arity func(Ref) int, glo
 	// Update the globals at each expression to include the variables that could
 	// be closed over.
 	g := globals.Copy()
+	xform := &bodySafetyTransformer{
+		builtins: builtins,
+		arity:    arity,
+	}
+	gvis := &GenericVisitor{}
 	for i, e := range reordered {
 		if i > 0 {
-			g.Update(reordered[i-1].Vars(SafetyCheckVisitorParams))
+			vis.Walk(reordered[i-1])
+			g.Update(vis.Vars())
+			vis.Clear().WithParams(SafetyCheckVisitorParams)
 		}
-		xform := &bodySafetyTransformer{
-			builtins: builtins,
-			arity:    arity,
-			current:  e,
-			globals:  g,
-			unsafe:   unsafe,
-		}
-		NewGenericVisitor(xform.Visit).Walk(e)
+		xform.current = e
+		xform.globals = g
+		xform.unsafe = unsafe
+		gvis.f = xform.Visit
+		gvis.Walk(e)
 	}
 
 	return reordered, unsafe
@@ -4035,9 +4093,12 @@ func (xform *bodySafetyTransformer) Visit(x any) bool {
 func (xform *bodySafetyTransformer) reorderComprehensionSafety(tv VarSet, body Body) Body {
 	bv := body.Vars(SafetyCheckVisitorParams)
 	bv.Update(xform.globals)
-	uv := tv.Diff(bv)
-	for v := range uv {
-		xform.unsafe.Add(xform.current, v)
+
+	if tv.DiffCount(bv) > 0 {
+		uv := tv.Diff(bv)
+		for v := range uv {
+			xform.unsafe.Add(xform.current, v)
+		}
 	}
 
 	r, u := reorderBodyForSafety(xform.builtins, xform.arity, xform.globals, body)
@@ -4070,7 +4131,7 @@ func unsafeVarsInClosures(e *Expr) VarSet {
 	WalkClosures(e, func(x any) bool {
 		vis := &VarVisitor{vars: vs}
 		if ev, ok := x.(*Every); ok {
-			vis.Walk(ev.Body)
+			vis.WalkBody(ev.Body)
 			return true
 		}
 		vis.Walk(x)
@@ -4088,8 +4149,9 @@ func OutputVarsFromBody(c *Compiler, body Body, safe VarSet) VarSet {
 
 func outputVarsForBody(body Body, arity func(Ref) int, safe VarSet) VarSet {
 	o := safe.Copy()
+	output := VarSet{}
 	for _, e := range body {
-		o.Update(outputVarsForExpr(e, arity, o))
+		o.Update(outputVarsForExpr(e, arity, o, output))
 	}
 	return o.Diff(safe)
 }
@@ -4098,23 +4160,22 @@ func outputVarsForBody(body Body, arity func(Ref) int, safe VarSet) VarSet {
 // the given expression. For safety checks this means that they would be
 // made safe by the expr.
 func OutputVarsFromExpr(c *Compiler, expr *Expr, safe VarSet) VarSet {
-	return outputVarsForExpr(expr, c.GetArity, safe)
+	return outputVarsForExpr(expr, c.GetArity, safe, VarSet{})
 }
 
-func outputVarsForExpr(expr *Expr, arity func(Ref) int, safe VarSet) VarSet {
-
+func outputVarsForExpr(expr *Expr, arity func(Ref) int, safe VarSet, output VarSet) VarSet {
 	// Negated expressions must be safe.
 	if expr.Negated {
 		return VarSet{}
 	}
 
+	var vis *VarVisitor
+
 	// With modifier inputs must be safe.
 	for _, with := range expr.With {
-		vis := NewVarVisitor().WithParams(SafetyCheckVisitorParams)
+		vis = vis.ClearOrNew().WithParams(SafetyCheckVisitorParams)
 		vis.Walk(with)
-		vars := vis.Vars()
-		unsafe := vars.Diff(safe)
-		if len(unsafe) > 0 {
+		if vis.Vars().DiffCount(safe) > 0 {
 			return VarSet{}
 		}
 	}
@@ -4124,7 +4185,7 @@ func outputVarsForExpr(expr *Expr, arity func(Ref) int, safe VarSet) VarSet {
 		return outputVarsForTerms(expr, safe)
 	case []*Term:
 		if expr.IsEquality() {
-			return outputVarsForExprEq(expr, safe)
+			return outputVarsForExprEq(expr, safe, output)
 		}
 
 		operator, ok := terms[0].Value.(Ref)
@@ -4137,7 +4198,7 @@ func outputVarsForExpr(expr *Expr, arity func(Ref) int, safe VarSet) VarSet {
 			return VarSet{}
 		}
 
-		return outputVarsForExprCall(expr, ar, safe, terms)
+		return outputVarsForExprCall(expr, ar, safe, terms, vis, output)
 	case *Every:
 		return outputVarsForTerms(terms.Domain, safe)
 	default:
@@ -4145,22 +4206,26 @@ func outputVarsForExpr(expr *Expr, arity func(Ref) int, safe VarSet) VarSet {
 	}
 }
 
-func outputVarsForExprEq(expr *Expr, safe VarSet) VarSet {
-
+func outputVarsForExprEq(expr *Expr, safe VarSet, output VarSet) VarSet {
 	if !validEqAssignArgCount(expr) {
 		return safe
 	}
 
-	output := outputVarsForTerms(expr, safe)
+	output.Update(outputVarsForTerms(expr, safe))
 	output.Update(safe)
 	output.Update(Unify(output, expr.Operand(0), expr.Operand(1)))
 
-	return output.Diff(safe)
+	diff := output.Diff(safe)
+
+	clear(output)
+
+	return diff
 }
 
-func outputVarsForExprCall(expr *Expr, arity int, safe VarSet, terms []*Term) VarSet {
+func outputVarsForExprCall(expr *Expr, arity int, safe VarSet, terms []*Term, vis *VarVisitor, output VarSet) VarSet {
+	clear(output)
 
-	output := outputVarsForTerms(expr, safe)
+	output.Update(outputVarsForTerms(expr, safe))
 
 	numInputTerms := arity + 1
 	if numInputTerms >= len(terms) {
@@ -4173,16 +4238,16 @@ func outputVarsForExprCall(expr *Expr, arity int, safe VarSet, terms []*Term) Va
 		SkipObjectKeys: true,
 		SkipRefHead:    true,
 	}
-	vis := NewVarVisitor().WithParams(params)
-	vis.Walk(Args(terms[:numInputTerms]))
-	unsafe := vis.Vars().Diff(output).Diff(safe)
+	vis = vis.ClearOrNew().WithParams(params)
+	vis.WalkArgs(Args(terms[:numInputTerms]))
 
-	if len(unsafe) > 0 {
+	unsafe := vis.Vars().Diff(output).DiffCount(safe)
+	if unsafe > 0 {
 		return VarSet{}
 	}
 
-	vis = NewVarVisitor().WithParams(params)
-	vis.Walk(Args(terms[numInputTerms:]))
+	vis = vis.Clear().WithParams(params)
+	vis.WalkArgs(Args(terms[numInputTerms:]))
 	output.Update(vis.vars)
 	return output
 }
@@ -4197,8 +4262,13 @@ func outputVarsForTerms(expr any, safe VarSet) VarSet {
 			if !isRefSafe(r, safe) {
 				return true
 			}
-			output.Update(r.OutputVars())
-			return false
+			if !r.IsGround() {
+				// Avoiding r.OutputVars() here as it won't allow reusing the visitor.
+				vis := varVisitorPool.Get().WithParams(VarVisitorParams{SkipRefHead: true})
+				vis.WalkRef(r)
+				output.Update(vis.Vars())
+				varVisitorPool.Put(vis)
+			}
 		}
 		return false
 	})
@@ -4231,19 +4301,17 @@ type localVarGenerator struct {
 }
 
 func newLocalVarGeneratorForModuleSet(sorted []string, modules map[string]*Module) *localVarGenerator {
-	exclude := NewVarSet()
-	vis := &VarVisitor{vars: exclude}
+	vis := NewVarVisitor()
 	for _, key := range sorted {
 		vis.Walk(modules[key])
 	}
-	return &localVarGenerator{exclude: exclude, next: 0}
+	return &localVarGenerator{exclude: vis.vars, next: 0}
 }
 
 func newLocalVarGenerator(suffix string, node any) *localVarGenerator {
-	exclude := NewVarSet()
-	vis := &VarVisitor{vars: exclude}
+	vis := NewVarVisitor()
 	vis.Walk(node)
-	return &localVarGenerator{exclude: exclude, suffix: suffix, next: 0}
+	return &localVarGenerator{exclude: vis.vars, suffix: suffix, next: 0}
 }
 
 func (l *localVarGenerator) Generate() Var {
@@ -4257,20 +4325,17 @@ func (l *localVarGenerator) Generate() Var {
 }
 
 func getGlobals(pkg *Package, rules []Ref, imports []*Import) map[Var]*usedRef {
+	globals := make(map[Var]*usedRef, len(rules)+len(imports))
 
-	globals := make(map[Var]*usedRef, len(rules)) // NB: might grow bigger with imports
-
-	// Populate globals with exports within the package.
 	for _, ref := range rules {
 		v := ref[0].Value.(Var)
 		globals[v] = &usedRef{ref: pkg.Path.Append(StringTerm(string(v)))}
 	}
 
-	// Populate globals with imports.
 	for _, imp := range imports {
 		path := imp.Path.Value.(Ref)
 		if FutureRootDocument.Equal(path[0]) || RegoRootDocument.Equal(path[0]) {
-			continue // ignore future and rego imports
+			continue
 		}
 		globals[imp.Name()] = &usedRef{ref: path}
 	}
@@ -4634,8 +4699,6 @@ func rewriteComprehensionTerms(f *equalityFactory, node any) (any, error) {
 		panic("illegal type")
 	})
 }
-
-var doubleEq = Equal.Ref()
 
 // rewriteEquals will rewrite exprs under x as unification calls instead of ==
 // calls. For example:
@@ -5055,7 +5118,7 @@ type localDeclaredVars struct {
 	assignment bool
 }
 
-type varOccurrence int
+type varOccurrence uint8
 
 const (
 	newVar varOccurrence = iota
@@ -5067,7 +5130,6 @@ const (
 
 type declaredVarSet struct {
 	vs         map[Var]Var
-	reverse    map[Var]Var
 	occurrence map[Var]varOccurrence
 	count      map[Var]int
 }
@@ -5075,10 +5137,17 @@ type declaredVarSet struct {
 func newDeclaredVarSet() *declaredVarSet {
 	return &declaredVarSet{
 		vs:         map[Var]Var{},
-		reverse:    map[Var]Var{},
 		occurrence: map[Var]varOccurrence{},
 		count:      map[Var]int{},
 	}
+}
+
+func (s *declaredVarSet) clear() *declaredVarSet {
+	clear(s.vs)
+	clear(s.occurrence)
+	clear(s.count)
+
+	return s
 }
 
 func newLocalDeclaredVars() *localDeclaredVars {
@@ -5088,21 +5157,39 @@ func newLocalDeclaredVars() *localDeclaredVars {
 	}
 }
 
+func (s *localDeclaredVars) Clear() {
+	var vs *declaredVarSet
+	if len(s.vars) > 0 {
+		vs = s.vars[0]
+	}
+
+	clear(s.vars)
+	clear(s.rewritten)
+
+	s.vars = s.vars[:0]
+
+	if vs != nil {
+		s.vars = append(s.vars, vs.clear())
+	}
+	if s.vars[0] == nil {
+		s.vars[0] = newDeclaredVarSet()
+	}
+	s.assignment = false
+}
+
 func (s *localDeclaredVars) Copy() *localDeclaredVars {
 	stack := &localDeclaredVars{
-		vars:      []*declaredVarSet{},
-		rewritten: map[Var]Var{},
+		vars: make([]*declaredVarSet, 0, len(s.vars)),
 	}
 
 	for i := range s.vars {
 		stack.vars = append(stack.vars, newDeclaredVarSet())
 		maps.Copy(stack.vars[0].vs, s.vars[i].vs)
-		maps.Copy(stack.vars[0].reverse, s.vars[i].reverse)
 		maps.Copy(stack.vars[0].occurrence, s.vars[i].occurrence)
 		maps.Copy(stack.vars[0].count, s.vars[i].count)
 	}
 
-	maps.Copy(stack.rewritten, s.rewritten)
+	stack.rewritten = maps.Clone(s.rewritten)
 
 	return stack
 }
@@ -5125,7 +5212,6 @@ func (s localDeclaredVars) Peek() *declaredVarSet {
 func (s localDeclaredVars) Insert(x, y Var, occurrence varOccurrence) {
 	elem := s.vars[len(s.vars)-1]
 	elem.vs[x] = y
-	elem.reverse[y] = x
 	elem.occurrence[x] = occurrence
 
 	elem.count[x] = 1
@@ -5205,7 +5291,6 @@ func rewriteLocalVars(g *localVarGenerator, stack *localDeclaredVars, used VarSe
 }
 
 func rewriteDeclaredVarsInBody(g *localVarGenerator, stack *localDeclaredVars, used VarSet, body Body, errs Errors, strict bool) (Body, Errors) {
-
 	var cpy Body
 
 	for i := range body {
@@ -5238,12 +5323,22 @@ func rewriteDeclaredVarsInBody(g *localVarGenerator, stack *localDeclaredVars, u
 }
 
 func checkUnusedAssignedVars(body Body, stack *localDeclaredVars, used VarSet, errs Errors, strict bool) Errors {
-
 	if !strict || len(errs) > 0 {
 		return errs
 	}
 
 	dvs := stack.Peek()
+
+	hasAssignedVars := false
+	for _, occ := range dvs.occurrence {
+		if occ == assignedVar {
+			hasAssignedVars = true
+		}
+	}
+	if !hasAssignedVars {
+		return errs
+	}
+
 	unused := NewVarSet()
 
 	for v, occ := range dvs.occurrence {
@@ -5264,18 +5359,26 @@ func checkUnusedAssignedVars(body Body, stack *localDeclaredVars, used VarSet, e
 	}
 
 	unused = unused.Diff(rewrittenUsed)
+	if len(unused) == 0 {
+		return errs
+	}
+
+	reversed := make(map[Var]Var, len(dvs.vs))
+	for k, v := range dvs.vs {
+		reversed[v] = k
+	}
 
 	for _, gv := range unused.Sorted() {
 		found := false
 		for i := range body {
 			if body[i].Vars(VarVisitorParams{}).Contains(gv) {
-				errs = append(errs, NewError(CompileErr, body[i].Loc(), "assigned var %v unused", dvs.reverse[gv]))
+				errs = append(errs, NewError(CompileErr, body[i].Loc(), "assigned var %v unused", reversed[gv]))
 				found = true
 				break
 			}
 		}
 		if !found {
-			errs = append(errs, NewError(CompileErr, body[0].Loc(), "assigned var %v unused", dvs.reverse[gv]))
+			errs = append(errs, NewError(CompileErr, body[0].Loc(), "assigned var %v unused", reversed[gv]))
 		}
 	}
 
@@ -5291,6 +5394,17 @@ func checkUnusedDeclaredVars(body Body, stack *localDeclaredVars, used VarSet, c
 	}
 
 	dvs := stack.Peek()
+
+	hasDeclaredVars := false
+	for _, occ := range dvs.occurrence {
+		if occ == declaredVar {
+			hasDeclaredVars = true
+		}
+	}
+	if !hasDeclaredVars {
+		return errs
+	}
+
 	declared := NewVarSet()
 
 	for v, occ := range dvs.occurrence {
@@ -5309,27 +5423,37 @@ func checkUnusedDeclaredVars(body Body, stack *localDeclaredVars, used VarSet, c
 		}
 	}
 
-	unused := declared.Diff(bodyvars).Diff(used)
+	dbv := declared.Diff(bodyvars)
+	if dbv.DiffCount(used) == 0 {
+		return errs
+	}
+
+	unused := dbv.Diff(used)
+
+	reversed := make(map[Var]Var, len(dvs.vs))
+	for k, v := range dvs.vs {
+		reversed[v] = k
+	}
 
 	for _, gv := range unused.Sorted() {
-		rv := dvs.reverse[gv]
+		rv := reversed[gv]
 		if !rv.IsGenerated() {
 			// Scan through body exprs, looking for a match between the
 			// bad var's original name, and each expr's declared vars.
 			foundUnusedVarByName := false
 			for i := range body {
 				varsDeclaredInExpr := declaredVars(body[i])
-				if varsDeclaredInExpr.Contains(dvs.reverse[gv]) {
+				if varsDeclaredInExpr.Contains(rv) {
 					// TODO(philipc): Clean up the offset logic here when the parser
 					// reports more accurate locations.
-					errs = append(errs, NewError(CompileErr, body[i].Loc(), "declared var %v unused", dvs.reverse[gv]))
+					errs = append(errs, NewError(CompileErr, body[i].Loc(), "declared var %v unused", rv))
 					foundUnusedVarByName = true
 					break
 				}
 			}
 			// Default error location returned.
 			if !foundUnusedVarByName {
-				errs = append(errs, NewError(CompileErr, body[0].Loc(), "declared var %v unused", dvs.reverse[gv]))
+				errs = append(errs, NewError(CompileErr, body[0].Loc(), "declared var %v unused", rv))
 			}
 		}
 	}
@@ -5407,7 +5531,9 @@ func rewriteSomeDeclStatement(g *localVarGenerator, stack *localDeclaredVars, ex
 				RefTerm(VarTerm(Equality.Name)), val, rhs,
 			}
 
-			for _, v0 := range outputVarsForExprEq(e, container.Vars()).Sorted() {
+			output := VarSet{}
+
+			for _, v0 := range outputVarsForExprEq(e, container.Vars(), output).Sorted() {
 				if _, err := rewriteDeclaredVar(g, stack, v0, declaredVar); err != nil {
 					return nil, append(errs, NewError(CompileErr, decl.Loc(), err.Error())) //nolint:govet
 				}
@@ -5845,7 +5971,6 @@ func isVirtual(node *TreeNode, ref Ref) bool {
 }
 
 func safetyErrorSlice(unsafe unsafeVars, rewritten map[Var]Var) (result Errors) {
-
 	if len(unsafe) == 0 {
 		return
 	}
@@ -5897,7 +6022,7 @@ func safetyErrorSlice(unsafe unsafeVars, rewritten map[Var]Var) (result Errors) 
 }
 
 func checkUnsafeBuiltins(unsafeBuiltinsMap map[string]struct{}, node any) Errors {
-	errs := make(Errors, 0)
+	var errs Errors
 	WalkExprs(node, func(x *Expr) bool {
 		if x.IsCall() {
 			operator := x.Operator().String()

--- a/v1/ast/policy.go
+++ b/v1/ast/policy.go
@@ -1050,10 +1050,10 @@ func (head *Head) MarshalJSON() ([]byte, error) {
 
 // Vars returns a set of vars found in the head.
 func (head *Head) Vars() VarSet {
-	vis := &VarVisitor{vars: VarSet{}}
+	vis := NewVarVisitor()
 	// TODO: improve test coverage for this.
 	if head.Args != nil {
-		vis.Walk(head.Args)
+		vis.WalkArgs(head.Args)
 	}
 	if head.Key != nil {
 		vis.Walk(head.Key)
@@ -1062,7 +1062,7 @@ func (head *Head) Vars() VarSet {
 		vis.Walk(head.Value)
 	}
 	if len(head.Reference) > 0 {
-		vis.Walk(head.Reference[1:])
+		vis.WalkRef(head.Reference[1:])
 	}
 	return vis.vars
 }
@@ -1119,8 +1119,8 @@ func (a Args) SetLoc(loc *Location) {
 
 // Vars returns a set of vars that appear in a.
 func (a Args) Vars() VarSet {
-	vis := &VarVisitor{vars: VarSet{}}
-	vis.Walk(a)
+	vis := NewVarVisitor()
+	vis.WalkArgs(a)
 	return vis.vars
 }
 
@@ -1243,7 +1243,7 @@ func (body Body) String() string {
 // control which vars are included.
 func (body Body) Vars(params VarVisitorParams) VarSet {
 	vis := NewVarVisitor().WithParams(params)
-	vis.Walk(body)
+	vis.WalkBody(body)
 	return vis.Vars()
 }
 
@@ -1763,7 +1763,7 @@ func (q *Every) Compare(other *Every) int {
 // KeyValueVars returns the key and val arguments of an `every`
 // expression, if they are non-nil and not wildcards.
 func (q *Every) KeyValueVars() VarSet {
-	vis := &VarVisitor{vars: VarSet{}}
+	vis := NewVarVisitor()
 	if q.Key != nil {
 		vis.Walk(q.Key)
 	}

--- a/v1/ast/syncpools.go
+++ b/v1/ast/syncpools.go
@@ -17,6 +17,10 @@ type indexResultPool struct {
 	pool sync.Pool
 }
 
+type vvPool struct {
+	pool sync.Pool
+}
+
 func (p *termPtrPool) Get() *Term {
 	return p.pool.Get().(*Term)
 }
@@ -44,6 +48,17 @@ func (p *indexResultPool) Put(x *IndexResult) {
 	}
 }
 
+func (p *vvPool) Get() *VarVisitor {
+	return p.pool.Get().(*VarVisitor)
+}
+
+func (p *vvPool) Put(vv *VarVisitor) {
+	if vv != nil {
+		vv.Clear()
+		p.pool.Put(vv)
+	}
+}
+
 var TermPtrPool = &termPtrPool{
 	pool: sync.Pool{
 		New: func() any {
@@ -56,6 +71,14 @@ var sbPool = &stringBuilderPool{
 	pool: sync.Pool{
 		New: func() any {
 			return &strings.Builder{}
+		},
+	},
+}
+
+var varVisitorPool = &vvPool{
+	pool: sync.Pool{
+		New: func() any {
+			return NewVarVisitor()
 		},
 	},
 }

--- a/v1/ast/term.go
+++ b/v1/ast/term.go
@@ -452,7 +452,7 @@ func (term *Term) UnmarshalJSON(bs []byte) error {
 
 // Vars returns a VarSet with variables contained in this term.
 func (term *Term) Vars() VarSet {
-	vis := &VarVisitor{vars: VarSet{}}
+	vis := NewVarVisitor()
 	vis.Walk(term)
 	return vis.vars
 }
@@ -1227,7 +1227,7 @@ func (ref Ref) String() string {
 // this expression in isolation.
 func (ref Ref) OutputVars() VarSet {
 	vis := NewVarVisitor().WithParams(VarVisitorParams{SkipRefHead: true})
-	vis.Walk(ref)
+	vis.WalkRef(ref)
 	return vis.Vars()
 }
 

--- a/v1/ast/varset.go
+++ b/v1/ast/varset.go
@@ -50,19 +50,23 @@ func (s VarSet) Copy() VarSet {
 
 // Diff returns a VarSet containing variables in s that are not in vs.
 func (s VarSet) Diff(vs VarSet) VarSet {
-	i := 0
-	for v := range s {
-		if !vs.Contains(v) {
-			i++
-		}
-	}
-	r := NewVarSetOfSize(i)
+	r := NewVarSetOfSize(s.DiffCount(vs))
 	for v := range s {
 		if !vs.Contains(v) {
 			r.Add(v)
 		}
 	}
 	return r
+}
+
+// DiffCount returns the number of variables in s that are not in vs.
+func (s VarSet) DiffCount(vs VarSet) (i int) {
+	for v := range s {
+		if !vs.Contains(v) {
+			i++
+		}
+	}
+	return
 }
 
 // Equal returns true if s contains exactly the same elements as vs.

--- a/v1/ast/visit.go
+++ b/v1/ast/visit.go
@@ -563,10 +563,35 @@ func NewVarVisitor() *VarVisitor {
 	}
 }
 
+// Clear resets the visitor to its initial state, and returns it for chaining.
+func (vis *VarVisitor) Clear() *VarVisitor {
+	vis.params = VarVisitorParams{}
+	clear(vis.vars)
+
+	return vis
+}
+
+// ClearOrNew returns a new VarVisitor if vis is nil, or else a cleared VarVisitor.
+func (vis *VarVisitor) ClearOrNew() *VarVisitor {
+	if vis == nil {
+		return NewVarVisitor()
+	}
+	return vis.Clear()
+}
+
 // WithParams sets the parameters in params on vis.
 func (vis *VarVisitor) WithParams(params VarVisitorParams) *VarVisitor {
 	vis.params = params
 	return vis
+}
+
+// Add adds a variable v to the visitor's set of variables.
+func (vis *VarVisitor) Add(v Var) {
+	if vis.vars == nil {
+		vis.vars = NewVarSet(v)
+	} else {
+		vis.vars.Add(v)
+	}
 }
 
 // Vars returns a VarSet that contains collected vars.
@@ -661,7 +686,7 @@ func (vis *VarVisitor) visit(v any) bool {
 		}
 	}
 	if v, ok := v.(Var); ok {
-		vis.vars.Add(v)
+		vis.Add(v)
 	}
 	return false
 }
@@ -687,58 +712,55 @@ func (vis *VarVisitor) Walk(x any) {
 			vis.Walk(x.Comments[i])
 		}
 	case *Package:
-		vis.Walk(x.Path)
+		vis.WalkRef(x.Path)
 	case *Import:
 		vis.Walk(x.Path)
-		vis.Walk(x.Alias)
+		if x.Alias != "" {
+			vis.Add(x.Alias)
+		}
 	case *Rule:
 		vis.Walk(x.Head)
-		vis.Walk(x.Body)
+		vis.WalkBody(x.Body)
 		if x.Else != nil {
 			vis.Walk(x.Else)
 		}
 	case *Head:
 		if len(x.Reference) > 0 {
-			vis.Walk(x.Reference)
+			vis.WalkRef(x.Reference)
 		} else {
-			vis.Walk(x.Name)
+			vis.Add(x.Name)
 			if x.Key != nil {
 				vis.Walk(x.Key)
 			}
 		}
-		vis.Walk(x.Args)
-
+		vis.WalkArgs(x.Args)
 		if x.Value != nil {
 			vis.Walk(x.Value)
 		}
 	case Body:
-		for i := range x {
-			vis.Walk(x[i])
-		}
+		vis.WalkBody(x)
 	case Args:
-		for i := range x {
-			vis.Walk(x[i])
-		}
+		vis.WalkArgs(x)
 	case *Expr:
 		switch ts := x.Terms.(type) {
 		case *Term, *SomeDecl, *Every:
 			vis.Walk(ts)
 		case []*Term:
 			for i := range ts {
-				vis.Walk(ts[i])
+				vis.Walk(ts[i].Value)
 			}
 		}
 		for i := range x.With {
 			vis.Walk(x.With[i])
 		}
 	case *With:
-		vis.Walk(x.Target)
-		vis.Walk(x.Value)
+		vis.Walk(x.Target.Value)
+		vis.Walk(x.Value.Value)
 	case *Term:
 		vis.Walk(x.Value)
 	case Ref:
 		for i := range x {
-			vis.Walk(x[i])
+			vis.Walk(x[i].Value)
 		}
 	case *object:
 		x.Foreach(func(k, _ *Term) {
@@ -755,29 +777,56 @@ func (vis *VarVisitor) Walk(x any) {
 			vis.Walk(xSlice[i])
 		}
 	case *ArrayComprehension:
-		vis.Walk(x.Term)
-		vis.Walk(x.Body)
+		vis.Walk(x.Term.Value)
+		vis.WalkBody(x.Body)
 	case *ObjectComprehension:
-		vis.Walk(x.Key)
-		vis.Walk(x.Value)
-		vis.Walk(x.Body)
+		vis.Walk(x.Key.Value)
+		vis.Walk(x.Value.Value)
+		vis.WalkBody(x.Body)
 	case *SetComprehension:
-		vis.Walk(x.Term)
-		vis.Walk(x.Body)
+		vis.Walk(x.Term.Value)
+		vis.WalkBody(x.Body)
 	case Call:
 		for i := range x {
-			vis.Walk(x[i])
+			vis.Walk(x[i].Value)
 		}
 	case *Every:
 		if x.Key != nil {
-			vis.Walk(x.Key)
+			vis.Walk(x.Key.Value)
 		}
 		vis.Walk(x.Value)
 		vis.Walk(x.Domain)
-		vis.Walk(x.Body)
+		vis.WalkBody(x.Body)
 	case *SomeDecl:
 		for i := range x.Symbols {
 			vis.Walk(x.Symbols[i])
 		}
+	}
+}
+
+// WalkArgs exists only to avoid the allocation cost of boxing Args to `any` in the VarVisitor.
+// Use it when you know beforehand that the type to walk is Args.
+func (vis *VarVisitor) WalkArgs(x Args) {
+	for i := range x {
+		vis.Walk(x[i].Value)
+	}
+}
+
+// WalkRef exists only to avoid the allocation cost of boxing Ref to `any` in the VarVisitor.
+// Use it when you know beforehand that the type to walk is a Ref.
+func (vis *VarVisitor) WalkRef(ref Ref) {
+	if vis.params.SkipRefHead {
+		ref = ref[1:]
+	}
+	for _, term := range ref {
+		vis.Walk(term.Value)
+	}
+}
+
+// WalkBody exists only to avoid the allocation cost of boxing Body to `any` in the VarVisitor.
+// Use it when you know beforehand that the type to walk is a Body.
+func (vis *VarVisitor) WalkBody(body Body) {
+	for _, expr := range body {
+		vis.Walk(expr)
 	}
 }

--- a/v1/ast/visit_bench_test.go
+++ b/v1/ast/visit_bench_test.go
@@ -1,0 +1,51 @@
+package ast
+
+import "testing"
+
+// Simple benchmark to demonstrate the cost of boxing to `any`, and why it's
+// good not to when it's possible to avoid it.
+//
+// BenchmarkVarVisitorWalkAnyVsSpecific/Walk-12         33266721        36.70 ns/op      24 B/op       1 allocs/op
+// BenchmarkVarVisitorWalkAnyVsSpecific/WalkBody-12     70195105        17.41 ns/op       0 B/op       0 allocs/op
+func BenchmarkVarVisitorWalkAnyVsSpecific(b *testing.B) {
+	bod := MustParseBody("foo")
+	vis := NewVarVisitor()
+
+	b.Run("Walk", func(b *testing.B) {
+		for range b.N {
+			vis.Walk(bod)
+		}
+	})
+
+	if len(vis.vars) != 1 {
+		b.Fatalf("Expected exactly one variable in AST but got %d: %v", len(vis.vars), vis.vars)
+	}
+
+	vis.Clear()
+	b.ResetTimer()
+
+	b.Run("WalkBody", func(b *testing.B) {
+		for range b.N {
+			vis.WalkBody(bod)
+		}
+	})
+
+	if len(vis.vars) != 1 {
+		b.Fatalf("Expected exactly one variable in AST but got %d: %v", len(vis.vars), vis.vars)
+	}
+}
+
+// Example benchmark of us over-allocating in place like [outputVarsForExprEq]
+//
+// BenchmarkVarSetUpdateEmpty-12    	15169982	        79.69 ns/op	     128 B/op	       4 allocs/op
+func BenchmarkVarSetUpdateEmpty(b *testing.B) {
+	ref := MustParseRef("foo.bar.baz")
+	used := NewVarSet()
+
+	for range b.N {
+		for _, t := range ref[1:] {
+			vars := t.Vars()
+			used.Update(vars)
+		}
+	}
+}

--- a/v1/bundle/bundle.go
+++ b/v1/bundle/bundle.go
@@ -721,7 +721,7 @@ func (r *Reader) Read() (Bundle, error) {
 			modulePopts.RegoVersion = regoVersion
 		}
 		r.metrics.Timer(metrics.RegoModuleParse).Start()
-		mf.Parsed, err = ast.ParseModuleWithOpts(mf.Path, string(mf.Raw), modulePopts)
+		mf.Parsed, err = ast.ParseModuleWithOpts(mf.Path, util.ByteSliceToString(mf.Raw), modulePopts)
 		r.metrics.Timer(metrics.RegoModuleParse).Stop()
 		if err != nil {
 			return bundle, err

--- a/v1/rego/rego.go
+++ b/v1/rego/rego.go
@@ -1876,6 +1876,11 @@ func (r *Rego) parseModules(ctx context.Context, txn storage.Transaction, m metr
 	defer m.Timer(metrics.RegoModuleParse).Stop()
 	var errs Errors
 
+	popts := ast.ParserOptions{
+		RegoVersion:  r.regoVersion,
+		Capabilities: r.capabilities,
+	}
+
 	// Parse any modules that are saved to the store, but only if
 	// another compile step is going to occur (ie. we have parsed modules
 	// that need to be compiled).
@@ -1891,7 +1896,7 @@ func (r *Rego) parseModules(ctx context.Context, txn storage.Transaction, m metr
 			return err
 		}
 
-		parsed, err := ast.ParseModuleWithOpts(id, string(bs), ast.ParserOptions{RegoVersion: r.regoVersion})
+		parsed, err := ast.ParseModuleWithOpts(id, string(bs), popts)
 		if err != nil {
 			errs = append(errs, err)
 		}
@@ -1901,7 +1906,7 @@ func (r *Rego) parseModules(ctx context.Context, txn storage.Transaction, m metr
 
 	// Parse any passed in as arguments to the Rego object
 	for _, module := range r.modules {
-		p, err := module.ParseWithOpts(ast.ParserOptions{RegoVersion: r.regoVersion})
+		p, err := module.ParseWithOpts(popts)
 		if err != nil {
 			switch errorWithType := err.(type) {
 			case ast.Errors:
@@ -2022,6 +2027,8 @@ func (r *Rego) parseQuery(queryImports []*ast.Import, m metrics.Metrics) (ast.Bo
 		return nil, err
 	}
 	popts.SkipRules = true
+	popts.Capabilities = r.capabilities
+
 	return ast.ParseBodyWithOpts(r.query, popts)
 }
 

--- a/v1/storage/disk/disk_test.go
+++ b/v1/storage/disk/disk_test.go
@@ -181,13 +181,7 @@ func TestTruncateAbsoluteStoragePath(t *testing.T) {
 func TestTruncateRelativeStoragePath(t *testing.T) {
 	t.Parallel()
 
-	dir := "foobar"
-	err := os.Mkdir(dir, 0700)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-	runTruncateTest(t, dir)
+	runTruncateTest(t, t.TempDir())
 }
 
 func runTruncateTest(t *testing.T, dir string) {

--- a/v1/topdown/eval.go
+++ b/v1/topdown/eval.go
@@ -561,7 +561,6 @@ func (e *eval) fmtVarTerm() string {
 }
 
 func (e *eval) evalNot(iter evalIterator) error {
-
 	expr := e.query[e.index]
 
 	if e.unknown(expr, e.bindings) {
@@ -578,12 +577,12 @@ func (e *eval) evalNot(iter evalIterator) error {
 		child.traceEnter(negation)
 	}
 
-	if err := child.eval(func(*eval) error {
-		if e.traceEnabled {
-			child.traceExit(negation)
-			child.traceRedo(negation)
+	if err := child.eval(func(c *eval) error {
+		if c.traceEnabled {
+			c.traceExit(negation)
+			c.traceRedo(negation)
 		}
-		child.defined = true
+		c.defined = true
 
 		return nil
 	}); err != nil {
@@ -4106,8 +4105,7 @@ func canInlineNegation(safe ast.VarSet, queries []ast.Body) bool {
 					SkipClosures:    true,
 				})
 				vis.Walk(expr)
-				unsafe := vis.Vars().Diff(safe).Diff(ast.ReservedVars)
-				if len(unsafe) > 0 {
+				if vis.Vars().Diff(safe).DiffCount(ast.ReservedVars) > 0 {
 					return false
 				}
 			}

--- a/v1/util/performance.go
+++ b/v1/util/performance.go
@@ -62,3 +62,14 @@ func NumDigitsUint(n uint64) int {
 
 	return int(math.Log10(float64(n))) + 1
 }
+
+// KeysCount returns the number of keys in m that satisfy predicate p.
+func KeysCount[K comparable, V any](m map[K]V, p func(K) bool) int {
+	count := 0
+	for k := range m {
+		if p(k) {
+			count++
+		}
+	}
+	return count
+}


### PR DESCRIPTION
Funnily, this started out as an attempt to look into issues reported with compiling large policy sets... before I realized that it isn't likely *this* compiler that has perf issues, but the one that "compiles" bundles as part of activation. So while these fixes likely does little to address that, there are still some rather nice improvements here, where the big ones as ususal are mostly just wins from avoiding work where it's possible.

For benchmarking I've used Regal's embedded bundle, which isn't great to use over time, as it's a moving target. But since it's a pretty extensive bundle and one that covers most features of OPA, it's at least good for 1:1 comparisons when testing perf improvements.

```
// 66555594 ns/op	50239492 B/op	 1083664 allocs/op - main
// 62569440 ns/op	38723015 B/op	  944277 allocs/op - compiler-optimizations pr
```
The B/op / alloc_space improvement is particularly nice here. What's noteworthy is how relatively little impact that has on performance in this case. That may be surprising but aligns pretty well with my previous experience of Go code where a lot of time is spend in recursive walks — that simply takes time, no matter how much you optimize. Oh well, less memory allocated for this is more memory to spend elsewhere.

(I'm adding the benchmark used below to Regal in a parallel PR)

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/contributing/)
  for high-level contributing guidelines and development setup.
  (See the [Developer Certificate of Origin](https://www.openpolicyagent.org/docs/contrib-code/#developer-certificate-of-origin)
  section for specifics on signing off a commit.)

-->

### Why the changes in this PR are needed?

<!--
Include a short description of WHY the changes were made.
-->

### What are the changes in this PR?

<!--
Include a short description of WHAT changes were made.
-->

### Notes to assist PR review:

<!--
Here you can add information you think will help the reviewer(s).
-->

### Further comments:

<!--
Here you can include links to additional resources related to the changes, discuss your solution, other approaches you considered etc.
-->
