### PR TITLE
Use shorthand form for types

### DIFF
--- a/v1/ast/builtins.go
+++ b/v1/ast/builtins.go
@@ -926,7 +926,7 @@ var ToNumber = &Builtin{
 				types.N,
 				types.S,
 				types.B,
-				types.NewNull(),
+				types.Nl,
 			)).Description("value to convert"),
 		),
 		types.Named("num", types.N).Description("the numeric representation of `x`"),
@@ -3172,7 +3172,7 @@ var GlobMatch = &Builtin{
 			types.Named("pattern", types.S).Description("glob pattern"),
 			types.Named("delimiters", types.NewAny(
 				types.NewArray(nil, types.S),
-				types.NewNull(),
+				types.Nl,
 			)).Description("glob pattern delimiters, e.g. `[\".\", \":\"]`, defaults to `[\".\"]` if unset. If `delimiters` is `null`, glob match without delimiter."),
 			types.Named("match", types.S).Description("string to match against `pattern`"),
 		),
@@ -3453,7 +3453,7 @@ var CastNull = &Builtin{
 	Name: "cast_null",
 	Decl: types.NewFunction(
 		types.Args(types.A),
-		types.NewNull(),
+		types.Nl,
 	),
 	deprecated:  true,
 	canSkipBctx: true,

--- a/v1/ast/check_test.go
+++ b/v1/ast/check_test.go
@@ -182,7 +182,7 @@ func TestCheckInference(t *testing.T) {
 				3];
 
 			x = a[1].foo[_].bar`, map[Var]types.Type{
-			Var("x"): types.NewAny(types.NewNull(), types.B),
+			Var("x"): types.NewAny(types.Nl, types.B),
 		}},
 		{"local-reference-var", `
 
@@ -390,7 +390,7 @@ func TestCheckInferenceRules(t *testing.T) {
 
 		{"complete-doc-suffix", ruleset1, `data.a.complete[0].foo`, types.N},
 
-		{"else-kw", ruleset1, "data.c.else_kw", types.NewAny(types.NewNull(), types.N, types.S)},
+		{"else-kw", ruleset1, "data.c.else_kw", types.NewAny(types.Nl, types.N, types.S)},
 
 		{"partial-set-doc", ruleset1, `data.a.partialset`, types.NewSet(
 			types.NewObject(

--- a/v1/ast/schema_test.go
+++ b/v1/ast/schema_test.go
@@ -213,11 +213,7 @@ func TestAllOfSchemas(t *testing.T) {
 	outerType = append(outerType, &types.StaticProperty{Key: "AddressLine", Value: types.S})
 	coreSchemaExpectedType := types.NewObject(outerType, nil)
 
-	// Tests 14-17: other types besides array and object
-	expectedStringType := types.NewString()
-	expectedIntegerType := types.NewNumber()
-	expectedBooleanType := types.NewBoolean()
-
+	// Test 14-17: other types besides array and object
 	// Test 18: array with uneven numbers of items children to merge
 	expectedUnevenArrayType := types.NewArray([]types.Type{types.N, types.N, types.S}, nil)
 
@@ -308,19 +304,19 @@ func TestAllOfSchemas(t *testing.T) {
 		{
 			note:          "allOf with mergeable String types in schema",
 			schema:        allOfStringSchema,
-			expectedType:  expectedStringType,
+			expectedType:  types.S,
 			expectedError: nil,
 		},
 		{
 			note:          "allOf with mergeable Integer types in schema",
 			schema:        allOfIntegerSchema,
-			expectedType:  expectedIntegerType,
+			expectedType:  types.N,
 			expectedError: nil,
 		},
 		{
 			note:          "allOf with mergeable Boolean types in schema",
 			schema:        allOfBooleanSchema,
-			expectedType:  expectedBooleanType,
+			expectedType:  types.B,
 			expectedError: nil,
 		},
 		{

--- a/v1/profiler/profiler_test.go
+++ b/v1/profiler/profiler_test.go
@@ -116,7 +116,7 @@ func TestProfileCheckExprDuration(t *testing.T) {
 		Name: "test.sleep",
 		Decl: types.NewFunction(
 			types.Args(types.S),
-			types.NewNull(),
+			types.Nl,
 		),
 	})
 

--- a/v1/rego/rego_test.go
+++ b/v1/rego/rego_test.go
@@ -598,7 +598,7 @@ func TestRegoCancellation(t *testing.T) {
 		Name: "test.sleep",
 		Decl: types.NewFunction(
 			types.Args(types.S),
-			types.NewNull(),
+			types.Nl,
 		),
 	})
 
@@ -629,7 +629,7 @@ func TestRegoCustomBuiltinHalt(t *testing.T) {
 			Name: "halt_func",
 			Decl: types.NewFunction(
 				types.Args(types.S),
-				types.NewNull(),
+				types.Nl,
 			),
 		},
 		func(BuiltinContext, *ast.Term) (*ast.Term, error) {

--- a/v1/tester/runner_test.go
+++ b/v1/tester/runner_test.go
@@ -71,12 +71,12 @@ func testRun(t *testing.T, conf testRunConfig) map[string]*ast.Module {
 	files := map[string]string{
 		"/a.rego": `package foo
 			import rego.v1
-		
+
 			allow if { true }
 			`,
 		"/a_test.rego": `package foo
 			import rego.v1
-		
+
 			test_pass if { allow }
 			non_test if { true }
 			test_fail if { not allow }
@@ -91,18 +91,18 @@ func testRun(t *testing.T, conf testRunConfig) map[string]*ast.Module {
 			`,
 		"/b_test.rego": `package bar
 			import rego.v1
-		
+
 			test_duplicate if { true }`,
 		"/c_test.rego": `package baz
 			import rego.v1
-		
+
 			a.b.test_duplicate if { false }
 			a.b.test_duplicate if { true }
 			a.b.test_duplicate if { true }`,
 		// Regression test for issue #5496.
 		"/d_test.rego": `package test
 			import rego.v1
-		
+
 			a[0] := 1
 			test_pass if { true }`,
 		"/e_test.rego": `package qux
@@ -658,7 +658,7 @@ func registerSleepBuiltin() {
 		Name: "test.sleep",
 		Decl: types.NewFunction(
 			types.Args(types.S),
-			types.NewNull(),
+			types.Nl,
 		),
 	})
 

--- a/v1/topdown/topdown_test.go
+++ b/v1/topdown/topdown_test.go
@@ -2341,7 +2341,7 @@ func init() {
 		Name: "test.sleep",
 		Decl: types.NewFunction(
 			types.Args(types.S),
-			types.NewNull(),
+			types.Nl,
 		),
 	})
 

--- a/v1/types/types.go
+++ b/v1/types/types.go
@@ -17,6 +17,22 @@ import (
 	"github.com/open-policy-agent/opa/v1/util"
 )
 
+var (
+	// Nl represents an instance of the null type.
+	Nl Type = NewNull()
+	// B represents an instance of the boolean type.
+	B Type = NewBoolean()
+	// S represents an instance of the string type.
+	S Type = NewString()
+	// N represents an instance of the number type.
+	N Type = NewNumber()
+	// A represents the superset of all types.
+	A Type = NewAny()
+
+	// Boxed set types.
+	SetOfAny, SetOfStr, SetOfNum Type = NewSet(A), NewSet(S), NewSet(N)
+)
+
 // Sprint returns the string representation of the type.
 func Sprint(x Type) string {
 	if x == nil {
@@ -49,8 +65,6 @@ type Null struct{}
 func NewNull() Null {
 	return Null{}
 }
-
-var Nl Type = NewNull()
 
 // NamedType represents a type alias with an arbitrary name and description.
 // This is useful for generating documentation for built-in functions.
@@ -116,9 +130,6 @@ func (Null) String() string {
 // Boolean represents the boolean type.
 type Boolean struct{}
 
-// B represents an instance of the boolean type.
-var B Type = NewBoolean()
-
 // NewBoolean returns a new Boolean type.
 func NewBoolean() Boolean {
 	return Boolean{}
@@ -139,9 +150,6 @@ func (t Boolean) String() string {
 // String represents the string type.
 type String struct{}
 
-// S represents an instance of the string type.
-var S Type = NewString()
-
 // NewString returns a new String type.
 func NewString() String {
 	return String{}
@@ -160,9 +168,6 @@ func (String) String() string {
 
 // Number represents the number type.
 type Number struct{}
-
-// N represents an instance of the number type.
-var N Type = NewNumber()
 
 // NewNumber returns a new Number type.
 func NewNumber() Number {
@@ -255,13 +260,6 @@ func (t *Array) Select(pos int) Type {
 type Set struct {
 	of Type
 }
-
-// Boxed set types.
-var (
-	SetOfAny Type = NewSet(A)
-	SetOfStr Type = NewSet(S)
-	SetOfNum Type = NewSet(N)
-)
 
 // NewSet returns a new Set type.
 func NewSet(of Type) *Set {
@@ -512,9 +510,6 @@ func mergeObjects(a, b *Object) *Object {
 
 // Any represents a dynamic type.
 type Any []Type
-
-// A represents the superset of all types.
-var A Type = NewAny()
 
 // NewAny returns a new Any type.
 func NewAny(of ...Type) Any {

--- a/v1/types/types_test.go
+++ b/v1/types/types_test.go
@@ -15,8 +15,7 @@ import (
 var dynamicPropertyAnyAny = NewDynamicProperty(A, A)
 
 func TestAnySorted(t *testing.T) {
-	a := NewAny(S, N)
-	if Compare(a[0], N) != 0 {
+	if Compare(NewAny(S, N)[0], N) != 0 {
 		t.Fatal("expected any type to be sorted")
 	}
 }
@@ -28,7 +27,7 @@ func TestAnyMerge(t *testing.T) {
 		t.Fatal("expected number to be inserted into middle")
 	}
 
-	if Compare(x.Merge(NewNull())[0], NewNull()) != 0 {
+	if Compare(x.Merge(Nl)[0], Nl) != 0 {
 		t.Fatal("expected null to be inserted at front")
 	}
 
@@ -38,10 +37,10 @@ func TestAnyMerge(t *testing.T) {
 }
 
 func TestAnyUnion(t *testing.T) {
-	x := NewAny(NewNull(), N)
+	x := NewAny(Nl, N)
 	y := NewAny(S, B)
 	z := x.Union(y)
-	exp := []Type{NewNull(), B, N, S}
+	exp := []Type{Nl, B, N, S}
 	if len(z) != len(exp) {
 		t.Fatalf("expected %v elements in result of union", len(exp))
 	}
@@ -53,18 +52,17 @@ func TestAnyUnion(t *testing.T) {
 }
 
 func TestStrings(t *testing.T) {
-
 	tpe := NewObject([]*StaticProperty{
-		{"foo", NewNull()},
-		{"bar", NewBoolean()},
-		{"baz", NewNumber()},
-		{"qux", NewString()},
+		{"foo", Nl},
+		{"bar", B},
+		{"baz", N},
+		{"qux", S},
 		{"corge", NewArray(
 			[]Type{
-				NewAny(),
-				NewAny(NewNull(), NewString()),
-				NewSet(NewString()),
-			}, NewString(),
+				A,
+				NewAny(Nl, S),
+				NewSet(S),
+			}, S,
 		)},
 		{"nil", nil},
 	}, NewDynamicProperty(S, N))
@@ -91,77 +89,76 @@ func TestStrings(t *testing.T) {
 }
 
 func TestCompare(t *testing.T) {
-
 	tests := []struct {
 		a   Type
 		b   Type
 		cmp int
 	}{
-		{NewNull(), NewNull(), 0},
-		{NewNull(), NewBoolean(), -1},
-		{NewBoolean(), NewNull(), 1},
-		{NewBoolean(), NewBoolean(), 0},
-		{NewBoolean(), NewNumber(), -1},
-		{NewNumber(), NewNumber(), 0},
-		{NewNumber(), NewString(), -1},
-		{NewString(), NewString(), 0},
-		{NewString(), NewArray(NewAny(), nil), -1},
-		{NewArray(NewAny(), nil), NewArray(NewAny(), NewAny()), -1},
-		{NewArray(NewAny(), NewAny()), NewArray(NewAny(), NewAny()), 0},
-		{NewArray(NewAny(), NewAny()), NewArray(NewAny(), NewString()), 1},
-		{NewArray(NewAny(), NewAny()), NewArray(NewAny(), nil), 1},
-		{NewArray([]Type{NewString()}, nil), NewArray([]Type{NewNumber()}, nil), 1},
+		{Nl, Nl, 0},
+		{Nl, B, -1},
+		{B, Nl, 1},
+		{B, B, 0},
+		{B, N, -1},
+		{N, N, 0},
+		{N, S, -1},
+		{S, S, 0},
+		{S, NewArray(NewAny(), nil), -1},
+		{NewArray(NewAny(), nil), NewArray(NewAny(), A), -1},
+		{NewArray(NewAny(), A), NewArray(NewAny(), A), 0},
+		{NewArray(NewAny(), A), NewArray(NewAny(), S), 1},
+		{NewArray(NewAny(), A), NewArray(NewAny(), nil), 1},
+		{NewArray([]Type{S}, nil), NewArray([]Type{N}, nil), 1},
 		{NewObject(nil, nil), NewObject(nil, dynamicPropertyAnyAny), -1},
 		{NewObject(nil, dynamicPropertyAnyAny), NewObject(nil, nil), 1},
 		{NewObject(nil, dynamicPropertyAnyAny), NewObject(nil, dynamicPropertyAnyAny), 0},
-		{NewObject(nil, NewDynamicProperty(S, NewAny(NewString(), NewNull()))), NewObject(nil, dynamicPropertyAnyAny), -1},
-		{NewSet(NewNull()), NewSet(NewAny()), -1},
+		{NewObject(nil, NewDynamicProperty(S, NewAny(S, Nl))), NewObject(nil, dynamicPropertyAnyAny), -1},
+		{NewSet(Nl), NewSet(NewAny()), -1},
 		{
 			NewObject(
-				[]*StaticProperty{{"foo", NewString()}},
+				[]*StaticProperty{{"foo", S}},
 				nil),
 			NewObject(
-				[]*StaticProperty{{"foo", NewString()}, {"bar", NewNumber()}},
+				[]*StaticProperty{{"foo", S}, {"bar", N}},
 				nil),
 			1,
 		},
 		{
 			NewObject(
-				[]*StaticProperty{{"foo", NewString()}, {"bar", NewNumber()}},
+				[]*StaticProperty{{"foo", S}, {"bar", N}},
 				nil),
 			NewObject(
-				[]*StaticProperty{{"foo", NewString()}},
+				[]*StaticProperty{{"foo", S}},
 				nil),
 			-1,
 		},
 		{
 			NewObject(
-				[]*StaticProperty{{"foo", NewString()}},
+				[]*StaticProperty{{"foo", S}},
 				nil),
 			NewObject(
-				[]*StaticProperty{{"foo", NewNull()}},
+				[]*StaticProperty{{"foo", Nl}},
 				nil),
 			1,
 		},
 		{
 			NewObject(
-				[]*StaticProperty{{"foo", NewString()}},
+				[]*StaticProperty{{"foo", S}},
 				nil),
 			NewObject(
-				[]*StaticProperty{{"foo", NewString()}, {"foo-2", NewNumber()}},
+				[]*StaticProperty{{"foo", S}, {"foo-2", N}},
 				nil),
 			-1,
 		},
 		{
 			NewObject(
-				[]*StaticProperty{{"foo", NewString()}, {"foo-2", NewNumber()}},
+				[]*StaticProperty{{"foo", S}, {"foo-2", N}},
 				nil),
 			NewObject(
-				[]*StaticProperty{{"foo", NewString()}},
+				[]*StaticProperty{{"foo", S}},
 				nil),
 			1,
 		},
-		{NewFunction(nil, nil), NewAny(), 1},
+		{NewFunction(nil, nil), A, 1},
 		{NewFunction([]Type{B}, N), NewFunction([]Type{S}, N), -1},
 		{NewFunction(nil, S), NewFunction(nil, N), 1},
 		{NewFunction(nil, S), NewFunction([]Type{N}, S), -1},
@@ -202,17 +199,17 @@ func TestOr(t *testing.T) {
 		b        Type
 		expected Type
 	}{
-		{nil, NewString(), NewString()},
-		{NewString(), nil, NewString()},
-		{NewNull(), NewNull(), NewNull()},
-		{NewString(), NewNumber(), NewAny(NewNumber(), NewString())},
-		{NewAny(), NewNull(), NewAny()},
-		{NewNull(), NewAny(), NewAny()},
-		{NewNull(), NewAny(NewString(), NewNumber()), NewAny(NewString(), NewNumber(), NewNull())},
-		{NewAny(), NewAny(), NewAny()},
-		{NewAny(NewNull(), NewNumber()), NewAny(), NewAny()},
-		{NewAny(NewNumber(), NewString()), NewAny(NewNull(), NewBoolean()), NewAny(NewNull(), NewBoolean(), NewString(), NewNumber())},
-		{NewAny(NewNull(), NewNumber()), NewNull(), NewAny(NewNull(), NewNumber())},
+		{nil, S, S},
+		{S, nil, S},
+		{Nl, Nl, Nl},
+		{S, N, NewAny(N, S)},
+		{A, Nl, A},
+		{Nl, A, A},
+		{Nl, NewAny(S, N), NewAny(S, N, Nl)},
+		{A, A, A},
+		{NewAny(Nl, N), A, A},
+		{NewAny(N, S), NewAny(Nl, B), NewAny(Nl, B, S, N)},
+		{NewAny(Nl, N), Nl, NewAny(Nl, N)},
 		{NewFunction([]Type{S}, B), NewFunction([]Type{N}, B), NewFunction([]Type{NewAny(S, N)}, B)},
 	}
 
@@ -254,7 +251,7 @@ func TestSelect(t *testing.T) {
 		{"scalar", N, "1", nil},
 		{"scalar-2", S, "1", nil},
 		{"scalar-3", B, "1", nil},
-		{"scalar-4", NewNull(), "1", nil},
+		{"scalar-4", Nl, "1", nil},
 	}
 
 	for _, tc := range tests {
@@ -282,7 +279,7 @@ func TestKeys(t *testing.T) {
 		{"scalar-1", N, nil},
 		{"scalar-2", S, nil},
 		{"scalar-3", B, nil},
-		{"scalar-4", NewNull(), nil},
+		{"scalar-4", Nl, nil},
 	}
 
 	for _, tc := range tests {
@@ -311,7 +308,7 @@ func TestValues(t *testing.T) {
 		{"scalar-1", N, nil},
 		{"scalar-2", S, nil},
 		{"scalar-3", B, nil},
-		{"scalar-4", NewNull(), nil},
+		{"scalar-4", Nl, nil},
 	}
 
 	for _, tc := range tests {
@@ -334,7 +331,7 @@ func TestTypeOf(t *testing.T) {
 	exp := NewObject([]*StaticProperty{
 		NewStaticProperty("foo", NewArray(
 			[]Type{
-				N, B, NewNull(), S,
+				N, B, Nl, S,
 			}, nil,
 		)),
 	}, nil)
@@ -365,7 +362,7 @@ func TestNil(t *testing.T) {
 	tpe := NewObject([]*StaticProperty{
 		NewStaticProperty("foo", NewArray(
 			[]Type{
-				N, B, NewNull(), S, NewSet(nil),
+				N, B, Nl, S, NewSet(nil),
 			}, nil,
 		)),
 	}, nil)
@@ -447,7 +444,7 @@ func TestMarshalJSON(t *testing.T) {
 
 func TestRoundtripJSON(t *testing.T) {
 	tpe := NewFunction([]Type{
-		NewArray([]Type{S, NewNull()}, N),
+		NewArray([]Type{S, Nl}, N),
 		NewObject(
 			[]*StaticProperty{
 				NewStaticProperty("foo", B),


### PR DESCRIPTION
Not so much an optimiziation (although a tiny one) as it is fixing something that annoyed me :) Don't create new types when we have interned alternatives available.

Note that `NewAny` can't always be replaced with `A`, like when provided as arg expecting `[]Type` — as `A` is boxed to `Type`.