### PR TITLE
v1/tester: support uint64 and float64 metrics in runBenchmark

### DIFF
--- a/v1/tester/runner.go
+++ b/v1/tester/runner.go
@@ -1141,7 +1141,18 @@ func (r *Runner) runBenchmark(ctx context.Context, txn storage.Transaction, mod 
 		}
 
 		for k, v := range m.All() {
-			fv := float64(v.(int64)) / float64(b.N)
+			var val float64
+			switch v := v.(type) {
+			case int64:
+				val = float64(v)
+			case uint64:
+				val = float64(v)
+			case float64:
+				val = v
+			default:
+				continue // skip this metric
+			}
+			fv := val / float64(b.N)
 			b.ReportMetric(fv, k+"/op")
 		}
 	})


### PR DESCRIPTION
This is quite hard to test, but if you're using a rego plugin that emits metrics that are not int64 (such as counters), this would give a panic at run time.
