### PR TITLE
cmd+repl: only plumb through target if it was set

### DIFF
--- a/cmd/eval.go
+++ b/cmd/eval.go
@@ -558,6 +558,7 @@ func setupEval(args []string, params evalCommandParams) (*evalContext, error) {
 		rego.Runtime(info),
 		rego.SetRegoVersion(params.regoVersion()),
 		rego.StoreReadAST(params.ReadAstValuesFromStore),
+		rego.SkipBundleVerification(true),
 	}
 
 	evalArgs := []rego.EvalOption{
@@ -602,7 +603,9 @@ func setupEval(args []string, params evalCommandParams) (*evalContext, error) {
 		}
 	}
 
-	regoArgs = append(regoArgs, rego.SkipBundleVerification(true), rego.Target(params.target.String()))
+	if params.target.IsSet() {
+		regoArgs = append(regoArgs, rego.Target(params.target.String()))
+	}
 
 	inputBytes, err := readInputBytes(params)
 	if err != nil {

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -402,8 +402,11 @@ func compileAndSetupTests(ctx context.Context, testParams testCommandParams, sto
 		SetBundles(bundles).
 		SetTimeout(timeout).
 		Filter(testParams.runRegex).
-		Target(testParams.target.String()).
 		SetParallel(testParams.parallel)
+
+	if testParams.target.IsSet() {
+		runner = runner.Target(testParams.target.String())
+	}
 
 	var reporter tester.Reporter
 

--- a/v1/rego/plugins_test.go
+++ b/v1/rego/plugins_test.go
@@ -22,16 +22,6 @@ type testPlugin struct {
 	state        string
 }
 
-func (*testPlugin) Start(context.Context) error {
-	return nil
-}
-
-func (*testPlugin) Stop(context.Context) {
-}
-
-func (*testPlugin) Reconfigure(context.Context, any) {
-}
-
 func (*testPlugin) IsTarget(t string) bool {
 	return t == "foo"
 }

--- a/v1/repl/repl.go
+++ b/v1/repl/repl.go
@@ -125,7 +125,7 @@ func New(store storage.Store, historyPath string, output io.Writer, outputFormat
 		banner:       banner,
 		errLimit:     errLimit,
 		prettyLimit:  defaultPrettyLimit,
-		target:       compile.TargetRego,
+		target:       "",
 		regoVersion:  ast.DefaultRegoVersion,
 	}
 }

--- a/v1/repl/repl_test.go
+++ b/v1/repl/repl_test.go
@@ -3370,8 +3370,7 @@ func expectOutput(t *testing.T, output string, expected string) {
 }
 
 func newRepl(store storage.Store, buffer *bytes.Buffer) *REPL {
-	repl := New(store, "", buffer, "", 0, "")
-	return repl
+	return New(store, "", buffer, "", 0, "")
 }
 
 func newTestStore() storage.Store {


### PR DESCRIPTION
This is allowing the _default_ target plugin to be changed.

The use case is this: An application wrapping OPA, using a different rego target plugin, wants to have that target plugin be used "by default", i.e. for `opa eval` and `opa test` without a specified `-t` argument.

With this change, that can be achieved by having the target plugin _claim ""_.

Testing this is tricky, because a replaced _default_ might affect other tests. I have thus tried to centralize the tests using a different default plugin to one test case in the cmd package. 