### PR TITLE
Benchmark fixes

### DIFF
--- a/v1/ast/strings_bench_test.go
+++ b/v1/ast/strings_bench_test.go
@@ -5,7 +5,6 @@ import "testing"
 // BenchmarkTypeName-10    32207775	   38.93 ns/op    8 B/op    1 allocs/op
 func BenchmarkTypeName(b *testing.B) {
 	term := StringTerm("foo")
-	b.ResetTimer()
 
 	for range b.N {
 		name := TypeName(term.Value)
@@ -18,7 +17,6 @@ func BenchmarkTypeName(b *testing.B) {
 // BenchmarkValueName-10    508312227    2.374 ns/op    0 B/op    0 allocs/op
 func BenchmarkValueName(b *testing.B) {
 	term := StringTerm("foo")
-	b.ResetTimer()
 
 	for range b.N {
 		name := ValueName(term.Value)

--- a/v1/bundle/file_bench_test.go
+++ b/v1/bundle/file_bench_test.go
@@ -52,31 +52,31 @@ func BenchmarkTarballLoader(b *testing.B) {
 			defer f.Close()
 
 			b.Run(strconv.Itoa(n), func(b *testing.B) {
-				// Reset the file reader.
-				if _, err := f.Seek(0, 0); err != nil {
-					b.Fatalf("Unexpected error: %s", err)
+				for range b.N {
+					// Reset the file reader.
+					if _, err := f.Seek(0, 0); err != nil {
+						b.Fatalf("Unexpected error: %s", err)
+					}
+					loader := NewTarballLoaderWithBaseURL(f, tarballFile)
+					benchTestLoader(b, loader)
 				}
-				loader := NewTarballLoaderWithBaseURL(f, tarballFile)
-				benchTestLoader(b, loader)
 			})
 		})
 	}
 }
 
 func BenchmarkDirectoryLoader(b *testing.B) {
-	sizes := []int{10000, 100000, 250000, 500000}
-
-	for _, n := range sizes {
+	for _, n := range []int{10000, 100000, 250000, 500000} {
 		expectedFiles := make(map[string]string, len(benchTestArchiveFiles)+1)
 		maps.Copy(expectedFiles, benchTestArchiveFiles)
 		expectedFiles["/x/data.json"] = benchTestGetFlatDataJSON(n)
 
 		test.WithTempFS(expectedFiles, func(rootDir string) {
 			b.ResetTimer()
-
 			b.Run(strconv.Itoa(n), func(b *testing.B) {
-				loader := NewDirectoryLoader(rootDir)
-				benchTestLoader(b, loader)
+				for range b.N {
+					benchTestLoader(b, NewDirectoryLoader(rootDir))
+				}
 			})
 		})
 	}

--- a/v1/compile/compile_bench_test.go
+++ b/v1/compile/compile_bench_test.go
@@ -19,7 +19,6 @@ import (
 func BenchmarkCompileDynamicPolicy(b *testing.B) {
 	// This benchmarks the compiler against increasingly large numbers of dynamically-selected policies.
 	// See: https://github.com/open-policy-agent/opa/issues/5216
-
 	numPolicies := []int{1000, 2500, 5000, 7500, 10000}
 
 	for _, n := range numPolicies {
@@ -27,13 +26,12 @@ func BenchmarkCompileDynamicPolicy(b *testing.B) {
 		test.WithTestFS(testcase, true, func(root string, fileSys fs.FS) {
 			b.ResetTimer()
 			b.Run(strconv.Itoa(n), func(b *testing.B) {
-				compiler := New().
-					WithFS(fileSys).
-					WithPaths(root)
+				for range b.N {
+					compiler := New().WithFS(fileSys).WithPaths(root)
 
-				err := compiler.Build(context.Background())
-				if err != nil {
-					b.Fatal("unexpected error", err)
+					if err := compiler.Build(context.Background()); err != nil {
+						b.Fatal("unexpected error", err)
+					}
 				}
 			})
 		})
@@ -83,12 +81,12 @@ func BenchmarkLargePartialRulePolicy(b *testing.B) {
 			test.WithTempFS(testcase, func(root string) {
 				b.ResetTimer()
 
-				compiler := New().
-					WithPaths(root)
+				for range b.N {
+					compiler := New().WithPaths(root)
 
-				err := compiler.Build(context.Background())
-				if err != nil {
-					b.Fatal("unexpected error", err)
+					if err := compiler.Build(context.Background()); err != nil {
+						b.Fatal("unexpected error", err)
+					}
 				}
 			})
 		})

--- a/v1/cover/cover_bench_test.go
+++ b/v1/cover/cover_bench_test.go
@@ -22,11 +22,9 @@ func BenchmarkCoverBigLocalVar(b *testing.B) {
 		for _, varCount := range vars {
 			name := fmt.Sprintf("%dVars%dIterations", varCount, iterationCount)
 			b.Run(name, func(b *testing.B) {
-				cover := New()
 				module := generateModule(varCount, iterationCount)
 
-				_, err := ast.ParseModule("test.rego", module)
-				if err != nil {
+				if _, err := ast.ParseModule("test.rego", module); err != nil {
 					b.Fatal(err)
 				}
 
@@ -41,14 +39,12 @@ func BenchmarkCoverBigLocalVar(b *testing.B) {
 					b.Fatal(err)
 				}
 
+				cover := New()
+
 				b.ResetTimer()
 
 				for range b.N {
-					b.StartTimer()
-					_, err = pq.Eval(ctx, rego.EvalQueryTracer(cover))
-					b.StopTimer()
-
-					if err != nil {
+					if _, err = pq.Eval(ctx, rego.EvalQueryTracer(cover)); err != nil {
 						b.Fatal(err)
 					}
 				}

--- a/v1/dependencies/deps_bench_test.go
+++ b/v1/dependencies/deps_bench_test.go
@@ -24,9 +24,10 @@ func BenchmarkBase(b *testing.B) {
 
 			b.ResetTimer()
 
-			_, err := Base(compiler, ref)
-			if err != nil {
-				b.Fatalf("Failed to compute base doc deps: %v", err)
+			for range b.N {
+				if _, err := Base(compiler, ref); err != nil {
+					b.Fatalf("Failed to compute base doc deps: %v", err)
+				}
 			}
 		})
 	}
@@ -36,8 +37,7 @@ func BenchmarkVirtual(b *testing.B) {
 	ruleCounts := []int{10, 20, 50}
 	for _, ruleCount := range ruleCounts {
 		b.Run(strconv.Itoa(ruleCount), func(b *testing.B) {
-			policy := makePolicy(ruleCount)
-			module := ast.MustParseModule(policy)
+			module := ast.MustParseModule(makePolicy(ruleCount))
 			compiler := ast.NewCompiler()
 			if compiler.Compile(map[string]*ast.Module{"test": module}); compiler.Failed() {
 				b.Fatalf("Failed to compile policy: %v", compiler.Errors)
@@ -47,9 +47,10 @@ func BenchmarkVirtual(b *testing.B) {
 
 			b.ResetTimer()
 
-			_, err := Virtual(compiler, ref)
-			if err != nil {
-				b.Fatalf("Failed to compute virtual doc deps: %v", err)
+			for range b.N {
+				if _, err := Virtual(compiler, ref); err != nil {
+					b.Fatalf("Failed to compute virtual doc deps: %v", err)
+				}
 			}
 		})
 	}

--- a/v1/metrics/metrics_bench_test.go
+++ b/v1/metrics/metrics_bench_test.go
@@ -46,14 +46,10 @@ func BenchmarkMetricsMarshaling(b *testing.B) {
 			b.Fatalf("No output")
 		}
 	}
-
-	b.StopTimer()
 }
 
 func BenchmarkMetricsTimerStartStopRestart(b *testing.B) {
 	m := metrics.New()
-
-	b.ResetTimer()
 
 	for range b.N {
 		m.Timer("foo").Start()
@@ -62,6 +58,4 @@ func BenchmarkMetricsTimerStartStopRestart(b *testing.B) {
 		m.Timer("foo").Start()
 		_ = m.Timer("foo").Stop()
 	}
-
-	b.StopTimer()
 }

--- a/v1/profiler/profiler_bench_test.go
+++ b/v1/profiler/profiler_bench_test.go
@@ -25,8 +25,7 @@ func BenchmarkProfilerBigLocalVar(b *testing.B) {
 				profiler := New()
 				module := generateModule(varCount, iterationCount)
 
-				_, err := ast.ParseModule("test.rego", module)
-				if err != nil {
+				if _, err := ast.ParseModule("test.rego", module); err != nil {
 					b.Fatal(err)
 				}
 
@@ -44,11 +43,7 @@ func BenchmarkProfilerBigLocalVar(b *testing.B) {
 				b.ResetTimer()
 
 				for range b.N {
-					b.StartTimer()
-					_, err = pq.Eval(ctx, rego.EvalQueryTracer(profiler))
-					b.StopTimer()
-
-					if err != nil {
+					if _, err = pq.Eval(ctx, rego.EvalQueryTracer(profiler)); err != nil {
 						b.Fatal(err)
 					}
 				}

--- a/v1/rego/rego_bench_test.go
+++ b/v1/rego/rego_bench_test.go
@@ -344,7 +344,6 @@ r contains true if {
 			}
 
 			b.ResetTimer()
-			b.ReportAllocs()
 
 			for range b.N {
 				res, err := pq.Eval(ctx)
@@ -416,8 +415,7 @@ func BenchmarkTrivialPolicy(b *testing.B) {
 	}
 
 	for range b.N {
-		_, err := pq.Eval(ctx)
-		if err != nil {
+		if _, err := pq.Eval(ctx); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -439,8 +437,7 @@ func BenchmarkTrivialQuery(b *testing.B) {
 	}
 
 	for range b.N {
-		_, err := pq.Eval(ctx, EvalMetrics(m))
-		if err != nil {
+		if _, err := pq.Eval(ctx, EvalMetrics(m)); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -502,8 +499,7 @@ local_var if {
 	for i, pq := range []PreparedEvalQuery{pq1, pq2} {
 		b.Run(names[i], func(b *testing.B) {
 			for range b.N {
-				_, err := pq.Eval(ctx)
-				if err != nil {
+				if _, err := pq.Eval(ctx); err != nil {
 					b.Fatal(err)
 				}
 			}

--- a/v1/test/authz/testing.go
+++ b/v1/test/authz/testing.go
@@ -17,16 +17,15 @@ import (
 // Policy is a test rego policy for a token based authz system
 const Policy = `package policy.restauthz
 
-import rego.v1
 import data.restauthz.tokens
 
-default allow = false
+default allow := false
 
 allow if {
-	tokens[input.token_id] = token
-	token.authz_profiles[_] = authz
+	token := tokens[input.token_id]
+	some authz in token.authz_profiles
 	regex.match(authz.path, input.path)
-	authz.methods[_] = input.method
+	input.method in authz.methods
 }`
 
 // AllowQuery is the test query that goes with the Policy
@@ -52,7 +51,6 @@ const (
 
 // GenerateInput will use a dataset profile and desired InputMode to generate inputs for testing
 func GenerateInput(profile DataSetProfile, mode InputMode) (any, any) {
-
 	var input string
 	var allow bool
 
@@ -132,11 +130,10 @@ func generateTokens(profile DataSetProfile) map[string]token {
 }
 
 func generateToken(profile DataSetProfile, i int) token {
-	token := token{
+	return token{
 		ID:            generateTokenID(i),
 		AuthzProfiles: generateAuthzProfiles(profile),
 	}
-	return token
 }
 
 func generateAuthzProfiles(profile DataSetProfile) []authzProfile {

--- a/v1/test/e2e/logs/remote/remote_decision_logger_benchmark_test.go
+++ b/v1/test/e2e/logs/remote/remote_decision_logger_benchmark_test.go
@@ -104,8 +104,7 @@ func runAuthzBenchmark(b *testing.B, mode testAuthz.InputMode, numPaths int) {
 
 	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
-
+	for range b.N {
 		// The benchmark will include the time it takes to make the request,
 		// receive a response, and do any normal client error checking on
 		// the response. The benchmark is for the OPA server, not how
@@ -142,11 +141,11 @@ func BenchmarkRESTRemoteDecisionLogger(b *testing.B) {
 
 func BenchmarkRESTRemoteDecisionLoggerMaskApplied(b *testing.B) {
 	maskPolicy := `package system.log
-	
+
 mask["/input/password"] {
 	true
 }
-	
+
 mask[{"op": "upsert", "path": "/input/ssn", "value": x}] {
 	last4 := split(input.input.ssn, "-")[2]
 	x := sprintf("***-**-%s", [last4])

--- a/v1/test/e2e/wasm/authz/authz_bench_integration_test.go
+++ b/v1/test/e2e/wasm/authz/authz_bench_integration_test.go
@@ -151,8 +151,7 @@ func runAuthzBenchmark(b *testing.B, mode testAuthz.InputMode, numPaths int) {
 
 	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
-
+	for range b.N {
 		// The benchmark will include the time it takes to make the request,
 		// receive a response, and do any normal client error checking on
 		// the response. The benchmark is for the OPA server, not how

--- a/v1/tester/runner.go
+++ b/v1/tester/runner.go
@@ -1097,14 +1097,8 @@ func (r *Runner) runBenchmark(ctx context.Context, txn storage.Transaction, mod 
 			b.ReportAllocs()
 		}
 
-		// Don't count setup in the benchmark time, only evaluation time
-		b.ResetTimer()
-
 		for range b.N {
-			opts := []rego.EvalOption{
-				rego.EvalTransaction(txn),
-				rego.EvalMetrics(m),
-			}
+			opts := []rego.EvalOption{rego.EvalTransaction(txn), rego.EvalMetrics(m)}
 
 			var tracer *TestQueryTracer
 			if rule.Head.DocKind() == ast.PartialObjectDoc {
@@ -1112,16 +1106,7 @@ func (r *Runner) runBenchmark(ctx context.Context, txn storage.Transaction, mod 
 				opts = append(opts, rego.EvalQueryTracer(tracer))
 			}
 
-			// Start the timer (might already be started, but that's ok)
-			b.StartTimer()
-
-			rs, err := pq.Eval(
-				ctx,
-				opts...,
-			)
-
-			// Stop the timer so we don't count any of the error handling time
-			b.StopTimer()
+			rs, err := pq.Eval(ctx, opts...)
 
 			if err != nil {
 				tr.Error = err

--- a/v1/topdown/eval_test.go
+++ b/v1/topdown/eval_test.go
@@ -1692,9 +1692,6 @@ func TestFmtVarTerm(t *testing.T) {
 // fmt.sprintf        8093799   159.41 ns/op      56 B/op       4 allocs/op
 // formatVarTerm     20424126    50.95 ns/op      24 B/op       1 allocs/op
 func BenchmarkFormatVarTerm(b *testing.B) {
-	b.ResetTimer()
-	b.ReportAllocs()
-
 	e := &eval{
 		genvarprefix: "foobar",
 		queryID:      12345,

--- a/v1/topdown/graphql_bench_test.go
+++ b/v1/topdown/graphql_bench_test.go
@@ -29,39 +29,39 @@ func BenchmarkGraphQLSchemaIsValid(b *testing.B) {
 	}{
 		{
 			desc:   "Trivial Schema - string",
-			schema: ast.NewTerm(ast.String(employeeGQLSchema)),
+			schema: ast.StringTerm(employeeGQLSchema),
 			cache:  nil,
-			result: ast.BooleanTerm(true),
+			result: ast.InternedTerm(true),
 		},
 		{
 			desc:   "Trivial Schema with cache - string",
-			schema: ast.NewTerm(ast.String(employeeGQLSchema)),
+			schema: ast.StringTerm(employeeGQLSchema),
 			cache:  valueCacheFactory(gqlCacheName, defaultCacheEntries),
-			result: ast.BooleanTerm(true),
+			result: ast.InternedTerm(true),
 		},
 		{
 			desc:   fmt.Sprintf("Schema w/ %d types - string", extraTypes+1),
-			schema: ast.NewTerm(ast.String(schemaWithExtraEmployeeTypes(extraTypes))),
+			schema: ast.StringTerm(schemaWithExtraEmployeeTypes(extraTypes)),
 			cache:  nil,
-			result: ast.BooleanTerm(true),
+			result: ast.InternedTerm(true),
 		},
 		{
 			desc:   fmt.Sprintf("Schema w/ %d types with cache - string", extraTypes+1),
-			schema: ast.NewTerm(ast.String(schemaWithExtraEmployeeTypes(extraTypes))),
+			schema: ast.StringTerm(schemaWithExtraEmployeeTypes(extraTypes)),
 			cache:  valueCacheFactory(gqlCacheName, defaultCacheEntries),
-			result: ast.BooleanTerm(true),
+			result: ast.InternedTerm(true),
 		},
 		{
 			desc:   "Trivial Schema - AST object",
 			schema: ast.NewTerm(ast.MustParseTerm(employeeGQLSchemaAST).Value.(ast.Object)),
 			cache:  nil,
-			result: ast.BooleanTerm(true),
+			result: ast.InternedTerm(true),
 		},
 		{
 			desc:   "Trivial Schema with cache - AST object",
 			schema: ast.NewTerm(ast.MustParseTerm(employeeGQLSchemaAST).Value.(ast.Object)),
 			cache:  valueCacheFactory(gqlCacheName, defaultCacheEntries),
-			result: ast.BooleanTerm(true),
+			result: ast.InternedTerm(true),
 		},
 	}
 
@@ -69,7 +69,6 @@ func BenchmarkGraphQLSchemaIsValid(b *testing.B) {
 		b.Run(bench.desc, func(b *testing.B) {
 			for range b.N {
 				var result *ast.Term
-				b.StartTimer()
 				err := builtinGraphQLSchemaIsValid(
 					BuiltinContext{
 						InterQueryBuiltinValueCache: bench.cache,
@@ -80,7 +79,6 @@ func BenchmarkGraphQLSchemaIsValid(b *testing.B) {
 						return nil
 					},
 				)
-				b.StopTimer()
 				if err != nil {
 					b.Fatalf("unexpected error: %s", err)
 				}
@@ -101,13 +99,13 @@ func BenchmarkGraphQLParseSchema(b *testing.B) {
 	}{
 		{
 			desc:   "Trivial Schema - string",
-			schema: ast.NewTerm(ast.String(employeeGQLSchema)),
+			schema: ast.StringTerm(employeeGQLSchema),
 			cache:  nil,
 			result: ast.NewTerm(employeeGQLSchemaASTObj),
 		},
 		{
 			desc:   "Trivial Schema with cache - string",
-			schema: ast.NewTerm(ast.String(employeeGQLSchema)),
+			schema: ast.StringTerm(employeeGQLSchema),
 			cache:  valueCacheFactory(gqlCacheName, defaultCacheEntries),
 			result: ast.NewTerm(employeeGQLSchemaASTObj),
 		},
@@ -116,7 +114,6 @@ func BenchmarkGraphQLParseSchema(b *testing.B) {
 		b.Run(bench.desc, func(b *testing.B) {
 			for range b.N {
 				var result *ast.Term
-				b.StartTimer()
 				err := builtinGraphQLParseSchema(
 					BuiltinContext{
 						InterQueryBuiltinValueCache: bench.cache,
@@ -127,7 +124,6 @@ func BenchmarkGraphQLParseSchema(b *testing.B) {
 						return nil
 					},
 				)
-				b.StopTimer()
 				if err != nil {
 					b.Fatalf("unexpected error: %s", err)
 				}
@@ -149,13 +145,13 @@ func BenchmarkGraphQLParseQuery(b *testing.B) {
 	}{
 		{
 			desc:   "Trivial Query - string",
-			query:  ast.NewTerm(ast.String(`{ employeeByID(id: "alice") { salary } }`)),
+			query:  ast.StringTerm(`{ employeeByID(id: "alice") { salary } }`),
 			cache:  nil,
 			result: ast.NewTerm(employeeGQLQueryASTObj),
 		},
 		{
 			desc:   "Trivial Query with cache - string",
-			query:  ast.NewTerm(ast.String(`{ employeeByID(id: "alice") { salary } }`)),
+			query:  ast.StringTerm(`{ employeeByID(id: "alice") { salary } }`),
 			cache:  valueCacheFactory(gqlCacheName, defaultCacheEntries),
 			result: ast.NewTerm(employeeGQLQueryASTObj),
 		},
@@ -164,7 +160,6 @@ func BenchmarkGraphQLParseQuery(b *testing.B) {
 		b.Run(bench.desc, func(b *testing.B) {
 			for range b.N {
 				var result *ast.Term
-				b.StartTimer()
 				err := builtinGraphQLParseQuery(
 					BuiltinContext{
 						InterQueryBuiltinValueCache: bench.cache,
@@ -175,7 +170,6 @@ func BenchmarkGraphQLParseQuery(b *testing.B) {
 						return nil
 					},
 				)
-				b.StopTimer()
 				if err != nil {
 					b.Fatalf("unexpected error: %s", err)
 				}
@@ -199,37 +193,36 @@ func BenchmarkGraphQLIsValid(b *testing.B) {
 		{
 			desc:   "Trivial Schema - string",
 			cache:  nil,
-			query:  ast.NewTerm(ast.String(`{ employeeByID(id: "alice") { salary } }`)),
-			schema: ast.NewTerm(ast.String(employeeGQLSchema)),
-			result: ast.BooleanTerm(true),
+			query:  ast.StringTerm(`{ employeeByID(id: "alice") { salary } }`),
+			schema: ast.StringTerm(employeeGQLSchema),
+			result: ast.InternedTerm(true),
 		},
 		{
 			desc:   "Trivial Schema with cache - string",
 			cache:  valueCacheFactory(gqlCacheName, defaultCacheEntries),
-			query:  ast.NewTerm(ast.String(`{ employeeByID(id: "alice") { salary } }`)),
-			schema: ast.NewTerm(ast.String(employeeGQLSchema)),
-			result: ast.BooleanTerm(true),
+			query:  ast.StringTerm(`{ employeeByID(id: "alice") { salary } }`),
+			schema: ast.StringTerm(employeeGQLSchema),
+			result: ast.InternedTerm(true),
 		},
 		{
 			desc:   fmt.Sprintf("Schema w/ %d types - string", extraTypes+1),
 			cache:  nil,
-			query:  ast.NewTerm(ast.String(`{ employeeByID(id: "alice") { salary } }`)),
-			schema: ast.NewTerm(ast.String(schemaWithExtraEmployeeTypes(extraTypes))),
-			result: ast.BooleanTerm(true),
+			query:  ast.StringTerm(`{ employeeByID(id: "alice") { salary } }`),
+			schema: ast.StringTerm(schemaWithExtraEmployeeTypes(extraTypes)),
+			result: ast.InternedTerm(true),
 		},
 		{
 			desc:   fmt.Sprintf("Schema w/ %d types with cache - string", extraTypes+1),
 			cache:  valueCacheFactory(gqlCacheName, defaultCacheEntries),
-			query:  ast.NewTerm(ast.String(`{ employeeByID(id: "alice") { salary } }`)),
-			schema: ast.NewTerm(ast.String(schemaWithExtraEmployeeTypes(extraTypes))),
-			result: ast.BooleanTerm(true),
+			query:  ast.StringTerm(`{ employeeByID(id: "alice") { salary } }`),
+			schema: ast.StringTerm(schemaWithExtraEmployeeTypes(extraTypes)),
+			result: ast.InternedTerm(true),
 		},
 	}
 	for _, bench := range benches {
 		b.Run(bench.desc, func(b *testing.B) {
 			for range b.N {
 				var result *ast.Term
-				b.StartTimer()
 				err := builtinGraphQLIsValid(
 					BuiltinContext{
 						InterQueryBuiltinValueCache: bench.cache,
@@ -240,7 +233,6 @@ func BenchmarkGraphQLIsValid(b *testing.B) {
 						return nil
 					},
 				)
-				b.StopTimer()
 				if err != nil {
 					b.Fatalf("unexpected error: %s", err)
 				}
@@ -267,8 +259,8 @@ func BenchmarkGraphQLParse(b *testing.B) {
 		{
 			desc:   "Trivial Schema - string",
 			cache:  nil,
-			query:  ast.NewTerm(ast.String(`{ employeeByID(id: "alice") { salary } }`)),
-			schema: ast.NewTerm(ast.String(employeeGQLSchema)),
+			query:  ast.StringTerm(`{ employeeByID(id: "alice") { salary } }`),
+			schema: ast.StringTerm(employeeGQLSchema),
 			result: ast.ArrayTerm(
 				ast.NewTerm(employeeGQLQueryASTObj),
 				ast.NewTerm(employeeGQLSchemaASTObj),
@@ -277,8 +269,8 @@ func BenchmarkGraphQLParse(b *testing.B) {
 		{
 			desc:   "Trivial Schema with cache - string",
 			cache:  valueCacheFactory(gqlCacheName, defaultCacheEntries),
-			query:  ast.NewTerm(ast.String(`{ employeeByID(id: "alice") { salary } }`)),
-			schema: ast.NewTerm(ast.String(employeeGQLSchema)),
+			query:  ast.StringTerm(`{ employeeByID(id: "alice") { salary } }`),
+			schema: ast.StringTerm(employeeGQLSchema),
 			result: ast.ArrayTerm(
 				ast.NewTerm(employeeGQLQueryASTObj),
 				ast.NewTerm(employeeGQLSchemaASTObj),
@@ -289,7 +281,6 @@ func BenchmarkGraphQLParse(b *testing.B) {
 		b.Run(bench.desc, func(b *testing.B) {
 			for range b.N {
 				var result *ast.Term
-				b.StartTimer()
 				err := builtinGraphQLParse(
 					BuiltinContext{
 						InterQueryBuiltinValueCache: bench.cache,
@@ -300,7 +291,6 @@ func BenchmarkGraphQLParse(b *testing.B) {
 						return nil
 					},
 				)
-				b.StopTimer()
 				if err != nil {
 					b.Fatalf("unexpected error: %s", err)
 				}
@@ -336,10 +326,10 @@ func BenchmarkGraphQLParseAndVerify(b *testing.B) {
 		{
 			desc:   "Trivial Schema - string",
 			cache:  nil,
-			query:  ast.NewTerm(ast.String(`{ employeeByID(id: "alice") { salary } }`)),
-			schema: ast.NewTerm(ast.String(employeeGQLSchema)),
+			query:  ast.StringTerm(`{ employeeByID(id: "alice") { salary } }`),
+			schema: ast.StringTerm(employeeGQLSchema),
 			result: ast.ArrayTerm(
-				ast.BooleanTerm(true),
+				ast.InternedTerm(true),
 				ast.NewTerm(employeeGQLQueryASTObj),
 				ast.NewTerm(employeeGQLSchemaASTObj),
 			),
@@ -347,10 +337,10 @@ func BenchmarkGraphQLParseAndVerify(b *testing.B) {
 		{
 			desc:   "Trivial Schema with cache - string",
 			cache:  valueCacheFactory(gqlCacheName, defaultCacheEntries),
-			query:  ast.NewTerm(ast.String(`{ employeeByID(id: "alice") { salary } }`)),
-			schema: ast.NewTerm(ast.String(employeeGQLSchema)),
+			query:  ast.StringTerm(`{ employeeByID(id: "alice") { salary } }`),
+			schema: ast.StringTerm(employeeGQLSchema),
 			result: ast.ArrayTerm(
-				ast.BooleanTerm(true),
+				ast.InternedTerm(true),
 				ast.NewTerm(employeeGQLQueryASTObj),
 				ast.NewTerm(employeeGQLSchemaASTObj),
 			),

--- a/v1/topdown/object_bench_test.go
+++ b/v1/topdown/object_bench_test.go
@@ -47,20 +47,14 @@ func BenchmarkObjectUnionN(b *testing.B) {
 				b.ResetTimer()
 
 				for range b.N {
-
 					err := storage.Txn(ctx, store, storage.TransactionParams{}, func(txn storage.Transaction) error {
-
-						q := NewQuery(query).
+						_, err := NewQuery(query).
 							WithCompiler(compiler).
 							WithStore(store).
-							WithTransaction(txn)
+							WithTransaction(txn).
+							Run(ctx)
 
-						_, err := q.Run(ctx)
-						if err != nil {
-							return err
-						}
-
-						return nil
+						return err
 					})
 
 					if err != nil {
@@ -96,20 +90,14 @@ func BenchmarkObjectUnionNSlow(b *testing.B) {
 				b.ResetTimer()
 
 				for range b.N {
-
 					err := storage.Txn(ctx, store, storage.TransactionParams{}, func(txn storage.Transaction) error {
-
-						q := NewQuery(query).
+						_, err := NewQuery(query).
 							WithCompiler(compiler).
 							WithStore(store).
-							WithTransaction(txn)
+							WithTransaction(txn).
+							Run(ctx)
 
-						_, err := q.Run(ctx)
-						if err != nil {
-							return err
-						}
-
-						return nil
+						return err
 					})
 
 					if err != nil {

--- a/v1/topdown/regex_bench_test.go
+++ b/v1/topdown/regex_bench_test.go
@@ -13,6 +13,11 @@ import (
 	"github.com/open-policy-agent/opa/v1/ast"
 )
 
+var reuseOperands = []*ast.Term{
+	ast.NewTerm(ast.String("foo.*")),
+	ast.NewTerm(ast.String("foobar")),
+}
+
 func BenchmarkBuiltinRegexMatch(b *testing.B) {
 	iter := func(*ast.Term) error { return nil }
 	ctx := BuiltinContext{}
@@ -28,10 +33,7 @@ func BenchmarkBuiltinRegexMatch(b *testing.B) {
 					for i := range patternCount {
 						var operands []*ast.Term
 						if reusePattern {
-							operands = []*ast.Term{
-								ast.NewTerm(ast.String("foo.*")),
-								ast.NewTerm(ast.String("foobar")),
-							}
+							operands = reuseOperands
 						} else {
 							operands = []*ast.Term{
 								ast.NewTerm(ast.String(fmt.Sprintf("foo%d.*", i))),
@@ -69,10 +71,7 @@ func BenchmarkBuiltinRegexMatchAsync(b *testing.B) {
 								for j := range patternCount {
 									var operands []*ast.Term
 									if reusePattern {
-										operands = []*ast.Term{
-											ast.NewTerm(ast.String("foo.*")),
-											ast.NewTerm(ast.String("foobar")),
-										}
+										operands = reuseOperands
 									} else {
 										operands = []*ast.Term{
 											ast.NewTerm(ast.String(fmt.Sprintf("foo%d_%d.*", clientID, j))),

--- a/v1/topdown/sets_bench_test.go
+++ b/v1/topdown/sets_bench_test.go
@@ -48,20 +48,14 @@ func BenchmarkSetIntersection(b *testing.B) {
 				b.ResetTimer()
 
 				for range b.N {
-
 					err := storage.Txn(ctx, store, storage.TransactionParams{}, func(txn storage.Transaction) error {
-
-						q := NewQuery(query).
+						_, err := NewQuery(query).
 							WithCompiler(compiler).
 							WithStore(store).
-							WithTransaction(txn)
+							WithTransaction(txn).
+							Run(ctx)
 
-						_, err := q.Run(ctx)
-						if err != nil {
-							return err
-						}
-
-						return nil
+						return err
 					})
 
 					if err != nil {
@@ -100,20 +94,14 @@ func BenchmarkSetIntersectionSlow(b *testing.B) {
 				b.ResetTimer()
 
 				for range b.N {
-
 					err := storage.Txn(ctx, store, storage.TransactionParams{}, func(txn storage.Transaction) error {
-
-						q := NewQuery(query).
+						_, err := NewQuery(query).
 							WithCompiler(compiler).
 							WithStore(store).
-							WithTransaction(txn)
+							WithTransaction(txn).
+							Run(ctx)
 
-						_, err := q.Run(ctx)
-						if err != nil {
-							return err
-						}
-
-						return nil
+						return err
 					})
 
 					if err != nil {
@@ -150,20 +138,14 @@ func BenchmarkSetUnion(b *testing.B) {
 				b.ResetTimer()
 
 				for range b.N {
-
 					err := storage.Txn(ctx, store, storage.TransactionParams{}, func(txn storage.Transaction) error {
-
-						q := NewQuery(query).
+						_, err := NewQuery(query).
 							WithCompiler(compiler).
 							WithStore(store).
-							WithTransaction(txn)
+							WithTransaction(txn).
+							Run(ctx)
 
-						_, err := q.Run(ctx)
-						if err != nil {
-							return err
-						}
-
-						return nil
+						return err
 					})
 
 					if err != nil {
@@ -203,20 +185,14 @@ func BenchmarkSetUnionSlow(b *testing.B) {
 				b.ResetTimer()
 
 				for range b.N {
-
 					err := storage.Txn(ctx, store, storage.TransactionParams{}, func(txn storage.Transaction) error {
-
-						q := NewQuery(query).
+						_, err := NewQuery(query).
 							WithCompiler(compiler).
 							WithStore(store).
-							WithTransaction(txn)
+							WithTransaction(txn).
+							Run(ctx)
 
-						_, err := q.Run(ctx)
-						if err != nil {
-							return err
-						}
-
-						return nil
+						return err
 					})
 
 					if err != nil {

--- a/v1/topdown/strings_bench_test.go
+++ b/v1/topdown/strings_bench_test.go
@@ -34,20 +34,14 @@ result if {
 	b.ResetTimer()
 
 	for range b.N {
-
 		err := storage.Txn(ctx, store, storage.TransactionParams{}, func(txn storage.Transaction) error {
-
-			q := NewQuery(query).
+			_, err := NewQuery(query).
 				WithCompiler(compiler).
 				WithStore(store).
-				WithTransaction(txn)
+				WithTransaction(txn).
+				Run(ctx)
 
-			_, err := q.Run(ctx)
-			if err != nil {
-				return err
-			}
-
-			return nil
+			return err
 		})
 
 		if err != nil {
@@ -79,20 +73,14 @@ result if {
 	b.ResetTimer()
 
 	for range b.N {
-
 		err := storage.Txn(ctx, store, storage.TransactionParams{}, func(txn storage.Transaction) error {
-
-			q := NewQuery(query).
+			_, err := NewQuery(query).
 				WithCompiler(compiler).
 				WithStore(store).
-				WithTransaction(txn)
+				WithTransaction(txn).
+				Run(ctx)
 
-			_, err := q.Run(ctx)
-			if err != nil {
-				return err
-			}
-
-			return nil
+			return err
 		})
 
 		if err != nil {


### PR DESCRIPTION
A number of benchmarks did not have a `for range b.N` (or equivalent) loop in them, leading to nothing being measured. This PR fixes that, along with some cleanups in benchmarks found along the way.

Also remove `b.StopTimer` where not absolutely necessary, as that is [notoriously buggy](https://github.com/golang/go/issues/27217), and had some benchmarks hang for a very long time.