### PR TITLE
loader+internal: Add bundle lazy loading mode across the runtime.

### DIFF
--- a/cmd/test.go
+++ b/cmd/test.go
@@ -290,7 +290,7 @@ func processWatcherUpdate(ctx context.Context, testParams testCommandParams, pat
 
 	var loadResult *initload.LoadPathsResult
 
-	err := pathwatcher.ProcessWatcherUpdateForRegoVersion(ctx, testParams.RegoVersion(), paths, removed, store, filter, testParams.bundleMode,
+	err := pathwatcher.ProcessWatcherUpdateForRegoVersion(ctx, testParams.RegoVersion(), paths, removed, store, filter, testParams.bundleMode, false,
 		func(ctx context.Context, txn storage.Transaction, loaded *initload.LoadPathsResult) error {
 			if len(loaded.Files.Documents) > 0 || removed != "" {
 				if err := store.Write(ctx, txn, storage.AddOp, storage.Path{}, loaded.Files.Documents); err != nil {

--- a/internal/bundle/inspect/inspect.go
+++ b/internal/bundle/inspect/inspect.go
@@ -46,7 +46,8 @@ func bundleOrDirInfoForRegoVersion(regoVersion ast.RegoVersion, path string, inc
 	b, err := loader.NewFileLoader().
 		WithRegoVersion(regoVersion).
 		WithSkipBundleVerification(true).
-		WithProcessAnnotation(true). // Always process annotations, for enriching namespace listing
+		WithBundleLazyLoadingMode(true). // Bundle lazy loading mode skips parsing data files
+		WithProcessAnnotation(true).     // Always process annotations, for enriching namespace listing
 		AsBundle(path)
 	if err != nil {
 		return nil, err

--- a/internal/pathwatcher/utils.go
+++ b/internal/pathwatcher/utils.go
@@ -40,14 +40,14 @@ func CreatePathWatcher(rootPaths []string) (*fsnotify.Watcher, error) {
 }
 
 // ProcessWatcherUpdate handles an occurrence of a watcher event
-func ProcessWatcherUpdate(ctx context.Context, paths []string, removed string, store storage.Store, filter loader.Filter, asBundle bool,
+func ProcessWatcherUpdate(ctx context.Context, paths []string, removed string, store storage.Store, filter loader.Filter, asBundle bool, bundleLazyLoadingMode bool,
 	f func(context.Context, storage.Transaction, *initload.LoadPathsResult) error) error {
-	return ProcessWatcherUpdateForRegoVersion(ctx, ast.DefaultRegoVersion, paths, removed, store, filter, asBundle, f)
+	return ProcessWatcherUpdateForRegoVersion(ctx, ast.DefaultRegoVersion, paths, removed, store, filter, asBundle, bundleLazyLoadingMode, f)
 }
 
-func ProcessWatcherUpdateForRegoVersion(ctx context.Context, regoVersion ast.RegoVersion, paths []string, removed string, store storage.Store, filter loader.Filter, asBundle bool,
+func ProcessWatcherUpdateForRegoVersion(ctx context.Context, regoVersion ast.RegoVersion, paths []string, removed string, store storage.Store, filter loader.Filter, asBundle bool, bundleLazyLoadingMode bool,
 	f func(context.Context, storage.Transaction, *initload.LoadPathsResult) error) error {
-	loaded, err := initload.LoadPathsForRegoVersion(regoVersion, paths, filter, asBundle, nil, true, false, false, nil, nil)
+	loaded, err := initload.LoadPathsForRegoVersion(regoVersion, paths, filter, asBundle, nil, true, bundleLazyLoadingMode, false, false, nil, nil)
 	if err != nil {
 		return err
 	}

--- a/internal/runtime/init/init.go
+++ b/internal/runtime/init/init.go
@@ -122,10 +122,11 @@ func LoadPaths(paths []string,
 	asBundle bool,
 	bvc *bundle.VerificationConfig,
 	skipVerify bool,
+	bundleLazyLoading bool,
 	processAnnotations bool,
 	caps *ast.Capabilities,
 	fsys fs.FS) (*LoadPathsResult, error) {
-	return LoadPathsForRegoVersion(ast.RegoV0, paths, filter, asBundle, bvc, skipVerify, processAnnotations, false, caps, fsys)
+	return LoadPathsForRegoVersion(ast.RegoV0, paths, filter, asBundle, bvc, skipVerify, bundleLazyLoading, processAnnotations, false, caps, fsys)
 }
 
 func LoadPathsForRegoVersion(regoVersion ast.RegoVersion,
@@ -134,6 +135,7 @@ func LoadPathsForRegoVersion(regoVersion ast.RegoVersion,
 	asBundle bool,
 	bvc *bundle.VerificationConfig,
 	skipVerify bool,
+	bundleLazyLoading bool,
 	processAnnotations bool,
 	followSymlinks bool,
 	caps *ast.Capabilities,
@@ -159,6 +161,7 @@ func LoadPathsForRegoVersion(regoVersion ast.RegoVersion,
 				WithFS(fsys).
 				WithBundleVerificationConfig(bvc).
 				WithSkipBundleVerification(skipVerify).
+				WithBundleLazyLoadingMode(bundleLazyLoading).
 				WithFilter(filter).
 				WithProcessAnnotation(processAnnotations).
 				WithCapabilities(caps).
@@ -177,6 +180,7 @@ func LoadPathsForRegoVersion(regoVersion ast.RegoVersion,
 
 	files, err := loader.NewFileLoader().
 		WithFS(fsys).
+		WithBundleLazyLoadingMode(bundleLazyLoading).
 		WithProcessAnnotation(processAnnotations).
 		WithCapabilities(caps).
 		WithRegoVersion(regoVersion).

--- a/internal/runtime/init/init_test.go
+++ b/internal/runtime/init/init_test.go
@@ -124,7 +124,7 @@ p = true { 1 = 2 }`
 					store := inmem.New()
 
 					err := storage.Txn(ctx, store, storage.WriteParams, func(txn storage.Transaction) error {
-						loaded, err := LoadPaths(paths, nil, tc.asBundle, nil, true, false, nil, fsys)
+						loaded, err := LoadPaths(paths, nil, tc.asBundle, nil, false, true, false, nil, fsys)
 						if err != nil {
 							return err
 						}
@@ -378,7 +378,7 @@ func TestLoadTarGzsInBundleAndNonBundleMode(t *testing.T) {
 					paths = append(paths, filepath.Join(rootDir, bdlInfo.fileName))
 				}
 
-				loaded, err := LoadPaths(paths, nil, tc.asBundle, nil, true, false, nil, nil)
+				loaded, err := LoadPaths(paths, nil, tc.asBundle, nil, true, false, false, nil, nil)
 				if err != nil {
 					t.Fatal("Failed LoadPaths ", err)
 				}
@@ -506,7 +506,7 @@ func TestLoadPathsBundleModeWithFilter(t *testing.T) {
 		// bundle mode
 		loaded, err := LoadPaths(paths, func(abspath string, info os.FileInfo, depth int) bool {
 			return loader.GlobExcludeName("*_test.rego", 1)(abspath, info, depth)
-		}, true, nil, true, false, nil, nil)
+		}, true, nil, true, false, false, nil, nil)
 		if err != nil {
 			t.Fatalf("Unexpected error: %s", err)
 		}

--- a/v1/compile/compile.go
+++ b/v1/compile/compile.go
@@ -81,6 +81,7 @@ type Compiler struct {
 	bvc                          *bundle.VerificationConfig // represents the key configuration used to verify a signed bundle
 	bsc                          *bundle.SigningConfig      // represents the key configuration used to generate a signed bundle
 	keyID                        string                     // represents the name of the default key used to verify a signed bundle
+	enableBundleLazyLoadingMode  bool                       // bundle lazy loading mode
 	metadata                     *map[string]any            // represents additional data included in .manifest file
 	fsys                         fs.FS                      // file system to use when loading paths
 	ns                           string
@@ -213,6 +214,12 @@ func (c *Compiler) WithBundleSigningConfig(config *bundle.SigningConfig) *Compil
 // If provided, the "keyid" claim in the bundle signature, will be set to this value
 func (c *Compiler) WithBundleVerificationKeyID(keyID string) *Compiler {
 	c.keyID = keyID
+	return c
+}
+
+// WithBundleLazyLoadingMode sets the additional data to be included in .manifest
+func (c *Compiler) WithBundleLazyLoadingMode(mode bool) *Compiler {
+	c.enableBundleLazyLoadingMode = mode
 	return c
 }
 
@@ -486,6 +493,7 @@ func (c *Compiler) initBundle(usePath bool) error {
 		c.asBundle,
 		c.bvc,
 		false,
+		c.enableBundleLazyLoadingMode,
 		c.useRegoAnnotationEntrypoints,
 		c.followSymlinks,
 		c.capabilities,

--- a/v1/rego/rego.go
+++ b/v1/rego/rego.go
@@ -647,6 +647,7 @@ type Rego struct {
 	bundlePaths                 []string
 	bundles                     map[string]*bundle.Bundle
 	skipBundleVerification      bool
+	enableBundleLazyLoadingMode bool
 	interQueryBuiltinCache      cache.InterQueryCache
 	interQueryBuiltinValueCache cache.InterQueryValueCache
 	ndBuiltinCache              builtins.NDBCache
@@ -1186,6 +1187,16 @@ func UnsafeBuiltins(unsafeBuiltins map[string]struct{}) func(r *Rego) {
 func SkipBundleVerification(yes bool) func(r *Rego) {
 	return func(r *Rego) {
 		r.skipBundleVerification = yes
+	}
+}
+
+// BundleLazyLoadingMode sets the bundle loading mode. If true, bundles will be
+// read in lazy mode. In this mode, data files in the bundle will not be
+// deserialized and the check to validate that the bundle data does not contain
+// paths outside the bundle's roots will not be performed while reading the bundle.
+func BundleLazyLoadingMode(yes bool) func(r *Rego) {
+	return func(r *Rego) {
+		r.enableBundleLazyLoadingMode = yes
 	}
 }
 


### PR DESCRIPTION
## What Changed?

This PR comprehensively plumbs in the bundle lazy loading mode option in the `compile`, `runtime`, `rego`, and `bundle` packages. It also includes the bare minimum plumbing to allow the path watcher utilities to also toggle the option on.

In nearly all places where a default is expected, the lazy loading mode is set to `false` (disabled) to avoid behavior changes.