### PR TITLE
plugins: allow registering handlerfuncs with name+path

### DIFF
--- a/v1/server/server.go
+++ b/v1/server/server.go
@@ -822,6 +822,10 @@ func (s *Server) initRouters(ctx context.Context) {
 		router.Handle("GET /health/{path...}", s.instrumentHandler(s.unversionedGetHealthWithPolicy, PromHandlerHealth))
 	}
 
+	for p, r := range s.manager.ExtraRoutes() {
+		mainRouter.Handle(p, s.instrumentHandler(r.HandlerFunc, r.PromName))
+	}
+
 	if s.pprofEnabled {
 		mainRouter.HandleFunc("GET /debug/pprof/", pprof.Index)
 		mainRouter.Handle("GET /debug/pprof/allocs", pprof.Handler("allocs"))


### PR DESCRIPTION
This way, the extra handler functions are still covered by prometheus metrics and opentelemetry spans.

The previous method of directly registering routes with the router bypassed the server's handler wrapping.

<