### PR TITLE
bundle: Add support for bundle store and activation plugins.

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -314,6 +314,7 @@ func dobuild(params buildParams, args []string) error {
 		WithRegoAnnotationEntrypoints(true).
 		WithPaths(args...).
 		WithFilter(buildCommandLoaderFilter(params.bundleMode, params.ignore)).
+		WithBundleLazyLoadingMode(bundle.HasExtension()).
 		WithBundleVerificationConfig(bvc).
 		WithBundleSigningConfig(bsc).
 		WithPartialNamespace(params.ns).

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -68,6 +68,7 @@ func checkModules(params checkParams, args []string) error {
 	l := loader.NewFileLoader().
 		WithRegoVersion(params.regoVersion()).
 		WithProcessAnnotation(true).
+		WithBundleLazyLoadingMode(bundle.HasExtension()).
 		WithCapabilities(capabilities)
 
 	ss, err := loader.Schemas(params.schema.path)

--- a/cmd/deps.go
+++ b/cmd/deps.go
@@ -19,6 +19,7 @@ import (
 	"github.com/open-policy-agent/opa/cmd/formats"
 	"github.com/open-policy-agent/opa/cmd/internal/env"
 	"github.com/open-policy-agent/opa/v1/ast"
+	"github.com/open-policy-agent/opa/v1/bundle"
 	"github.com/open-policy-agent/opa/v1/loader"
 	"github.com/open-policy-agent/opa/v1/util"
 )
@@ -118,6 +119,7 @@ func deps(args []string, params depsCommandParams, w io.Writer) error {
 
 	if len(params.dataPaths.v) > 0 {
 		result, err := loader.NewFileLoader().
+			WithBundleLazyLoadingMode(bundle.HasExtension()).
 			WithRegoVersion(params.regoVersion()).
 			Filtered(params.dataPaths.v, ignored(params.ignore).Apply)
 		if err != nil {
@@ -130,7 +132,7 @@ func deps(args []string, params depsCommandParams, w io.Writer) error {
 	if len(params.bundlePaths.v) > 0 {
 		modules = make(map[string]*ast.Module, len(params.bundlePaths.v))
 		for _, path := range params.bundlePaths.v {
-			b, err := loader.NewFileLoader().WithSkipBundleVerification(true).AsBundle(path)
+			b, err := loader.NewFileLoader().WithBundleLazyLoadingMode(bundle.HasExtension()).WithSkipBundleVerification(true).AsBundle(path)
 			if err != nil {
 				return err
 			}

--- a/cmd/eval.go
+++ b/cmd/eval.go
@@ -862,6 +862,7 @@ func generateOptimizedBundle(params evalCommandParams, asBundle bool, filter loa
 		WithCapabilities(capabilities).
 		WithTarget(params.target.String()).
 		WithAsBundle(asBundle).
+		WithBundleLazyLoadingMode(bundle.HasExtension()).
 		WithOptimizationLevel(params.optimizationLevel).
 		WithOutput(bytes.NewBuffer(nil)).
 		WithEntrypoints(params.entrypoints.v...).

--- a/cmd/oracle.go
+++ b/cmd/oracle.go
@@ -125,6 +125,7 @@ func dofindDefinition(params findDefinitionParams, stdin io.Reader, stdout io.Wr
 			return errors.New("not implemented: multiple bundle paths")
 		}
 		b, err = loader.NewFileLoader().
+			WithBundleLazyLoadingMode(bundle.HasExtension()).
 			WithSkipBundleVerification(true).
 			WithFilter(func(_ string, info os.FileInfo, _ int) bool {
 				// While directories may contain other things of interest for OPA (json, yaml..),

--- a/cmd/refactor.go
+++ b/cmd/refactor.go
@@ -15,6 +15,7 @@ import (
 	"github.com/open-policy-agent/opa/cmd/internal/env"
 	fileurl "github.com/open-policy-agent/opa/internal/file/url"
 	"github.com/open-policy-agent/opa/v1/ast"
+	"github.com/open-policy-agent/opa/v1/bundle"
 	"github.com/open-policy-agent/opa/v1/format"
 	"github.com/open-policy-agent/opa/v1/loader"
 	"github.com/open-policy-agent/opa/v1/refactor"
@@ -116,6 +117,7 @@ func doMove(params moveCommandParams, args []string, out io.Writer) error {
 	}
 
 	result, err := loader.NewFileLoader().
+		WithBundleLazyLoadingMode(bundle.HasExtension()).
 		WithRegoVersion(params.regoVersion()).
 		Filtered(args, ignored(params.ignore).Apply)
 	if err != nil {

--- a/internal/runtime/init/init.go
+++ b/internal/runtime/init/init.go
@@ -29,6 +29,7 @@ type InsertAndCompileOptions struct {
 	MaxErrors             int
 	EnablePrintStatements bool
 	ParserOptions         ast.ParserOptions
+	BundleActivatorPlugin string
 }
 
 // InsertAndCompileResult contains the output of the operation.
@@ -68,6 +69,7 @@ func InsertAndCompile(ctx context.Context, opts InsertAndCompileOptions) (*Inser
 		Bundles:       opts.Bundles,
 		ExtraModules:  policies,
 		ParserOptions: opts.ParserOptions,
+		Plugin:        opts.BundleActivatorPlugin,
 	}
 
 	err := bundle.Activate(activation)

--- a/v1/bundle/bundle.go
+++ b/v1/bundle/bundle.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
+	"sync"
 
 	"github.com/gobwas/glob"
 	"github.com/open-policy-agent/opa/internal/file/archive"
@@ -29,6 +30,7 @@ import (
 	astJSON "github.com/open-policy-agent/opa/v1/ast/json"
 	"github.com/open-policy-agent/opa/v1/format"
 	"github.com/open-policy-agent/opa/v1/metrics"
+	"github.com/open-policy-agent/opa/v1/storage"
 	"github.com/open-policy-agent/opa/v1/util"
 )
 
@@ -435,6 +437,45 @@ type PlanModuleFile struct {
 	Raw  []byte
 }
 
+var (
+	pluginMtx sync.Mutex
+
+	// The bundle activator to use by default.
+	bundleExtActivator string
+
+	// The function to use for creating a storage.Store for bundles.
+	BundleExtStore func() storage.Store
+)
+
+// RegisterDefaultBundleActivator sets the default bundle activator for OPA to use for bundle activation.
+// The id must already have been registered with RegisterActivator.
+func RegisterDefaultBundleActivator(id string) {
+	pluginMtx.Lock()
+	defer pluginMtx.Unlock()
+
+	bundleExtActivator = id
+}
+
+// RegisterStoreFunc sets the function to use for creating storage for bundles
+// in OPA. If no function is registered, OPA will use situational defaults to
+// decide on what sort of storage.Store to create when bundle storage is
+// needed. Typically the default is inmem.Store.
+func RegisterStoreFunc(s func() storage.Store) {
+	pluginMtx.Lock()
+	defer pluginMtx.Unlock()
+
+	BundleExtStore = s
+}
+
+// HasExtension returns true if a default bundle activator has been set
+// with RegisterDefaultBundleActivator.
+func HasExtension() bool {
+	pluginMtx.Lock()
+	defer pluginMtx.Unlock()
+
+	return bundleExtActivator != ""
+}
+
 // Reader contains the reader to load the bundle from.
 type Reader struct {
 	loader                DirectoryLoader
@@ -464,10 +505,11 @@ func NewReader(r io.Reader) *Reader {
 // specified DirectoryLoader.
 func NewCustomReader(loader DirectoryLoader) *Reader {
 	nr := Reader{
-		loader:         loader,
-		metrics:        metrics.New(),
-		files:          make(map[string]FileInfo),
-		sizeLimitBytes: DefaultSizeLimitBytes + 1,
+		loader:          loader,
+		metrics:         metrics.New(),
+		files:           make(map[string]FileInfo),
+		sizeLimitBytes:  DefaultSizeLimitBytes + 1,
+		lazyLoadingMode: HasExtension(),
 	}
 	return &nr
 }

--- a/v1/bundle/bundle_ext_test.go
+++ b/v1/bundle/bundle_ext_test.go
@@ -1,0 +1,181 @@
+// Copyright 2025 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+package bundle_test
+
+import (
+	"context"
+	"maps"
+	"slices"
+	"testing"
+
+	"github.com/open-policy-agent/opa/internal/file/archive"
+	"github.com/open-policy-agent/opa/v1/ast"
+	"github.com/open-policy-agent/opa/v1/bundle"
+	"github.com/open-policy-agent/opa/v1/logging"
+	"github.com/open-policy-agent/opa/v1/metrics"
+	"github.com/open-policy-agent/opa/v1/storage"
+	"github.com/open-policy-agent/opa/v1/storage/disk"
+	"github.com/open-policy-agent/opa/v1/storage/inmem"
+	"github.com/open-policy-agent/opa/v1/util/test"
+)
+
+type customBundleActivator struct {
+	activator   *bundle.DefaultActivator
+	BundleNames []string
+	Files       map[string]map[string][]byte
+}
+
+func (cba *customBundleActivator) Activate(opts *bundle.ActivateOpts) error {
+	cba.activator = &bundle.DefaultActivator{}
+	cba.BundleNames = slices.Collect(maps.Keys(opts.Bundles))
+	if cba.Files == nil {
+		cba.Files = make(map[string]map[string][]byte, len(cba.BundleNames))
+	}
+	for k, v := range opts.Bundles {
+		cba.Files[k] = make(map[string][]byte, len(v.Raw))
+		for _, r := range v.Raw {
+			cba.Files[k][r.Path] = r.Value
+		}
+	}
+	return cba.activator.Activate(opts)
+}
+
+// Warning: This test modifies package variables, and as
+// a result, cannot be run in parallel with other tests.
+func TestRegisterBundleActivatorWithStore(t *testing.T) {
+	getInmemStore := func() storage.Store {
+		return inmem.NewFromObject(map[string]any{})
+	}
+
+	// Top-level variables, shared between tests.
+	// These are only needed to make disk storage tests use an external dir name and context value.
+	var dir string
+	var ctx context.Context
+	getDiskStore := func() storage.Store {
+		s, err := disk.New(ctx, logging.NewNoOpLogger(), nil, disk.Options{Dir: dir})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return s
+	}
+
+	buf := archive.MustWriteTarGz([][2]string{
+		{"/.manifest", `{"revision": "abcd"}`},
+		{"/data.json", `{"a": 1}`},
+		{"/x.rego", `package foo`},
+	})
+	b, err := bundle.NewReader(buf).IncludeManifestInData(true).Read()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		note      string
+		activator bundle.Activator
+		storeFunc func() storage.Store
+		disk      bool
+	}{
+		{
+			note: "package init default activator, default store",
+		},
+		{
+			note:      "default activator, default store",
+			activator: &bundle.DefaultActivator{},
+		},
+		{
+			note:      "default activator, inmem store",
+			activator: &bundle.DefaultActivator{},
+			storeFunc: getInmemStore,
+		},
+		{
+			note:      "custom activator, inmem store",
+			activator: &customBundleActivator{},
+			storeFunc: getInmemStore,
+		},
+		{
+			note:      "package init default activator, disk store",
+			storeFunc: getDiskStore,
+			disk:      true,
+		},
+		{
+			note:      "default activator, disk store",
+			activator: &bundle.DefaultActivator{},
+			storeFunc: getDiskStore,
+			disk:      true,
+		},
+		{
+			note:      "custom activator, disk store",
+			activator: &customBundleActivator{},
+			storeFunc: getDiskStore,
+			disk:      true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.note, func(t *testing.T) {
+			var store storage.Store
+			ctx = context.Background()
+
+			// Plumb in the bundle store if func provided.
+			if tc.storeFunc != nil {
+				bundle.RegisterStoreFunc(tc.storeFunc)
+				// Create temp folder when using disk storage.
+				if tc.disk {
+					rootDir, cleanup, err := test.MakeTempFS("", "opa_test", make(map[string]string))
+					dir = rootDir // Set top-level var for the storage function to pick up.
+					if err != nil {
+						panic(err)
+					}
+					defer cleanup()
+				}
+				store = bundle.BundleExtStore()
+			} else {
+				store = getInmemStore() // The default store.
+			}
+
+			// Register our custom bundle activator if provided.
+			if tc.activator != nil {
+				bundle.RegisterActivator("example-activator", tc.activator)
+				bundle.RegisterDefaultBundleActivator("example-activator")
+			}
+
+			txn := storage.NewTransactionOrDie(ctx, store, storage.WriteParams)
+			bundles := map[string]*bundle.Bundle{"example": &b}
+			opts := &bundle.ActivateOpts{
+				Ctx:      ctx,
+				Store:    store,
+				Txn:      txn,
+				Compiler: ast.NewCompiler(),
+				Metrics:  metrics.New(),
+				Bundles:  bundles,
+			}
+			if tc.activator != nil {
+				opts.Plugin = "example-activator"
+			}
+
+			if err := bundle.Activate(opts); err != nil {
+				t.Fatal(err)
+			}
+
+			// If using the custom bundle activator, inspect contents.
+			if cba, ok := tc.activator.(*customBundleActivator); ok {
+				expNames := []string{"example"}
+				actNames := cba.BundleNames
+				if slices.Compare(expNames, actNames) != 0 {
+					t.Fatalf("wrong bundle names. expected: %v, got: %v", expNames, actNames)
+				}
+				for k, v := range bundles {
+					actFilenames := slices.Collect(maps.Keys(cba.Files[k]))
+					expFilenames := make([]string, len(v.Raw))
+					for _, r := range v.Raw {
+						expFilenames = append(expFilenames, r.Path)
+					}
+					if slices.Compare(expFilenames, actFilenames) != 0 {
+						t.Fatalf("wrong bundle file names. expected: %v, got: %v", expFilenames, actFilenames)
+					}
+				}
+			}
+		})
+	}
+}

--- a/v1/plugins/bundle/plugin.go
+++ b/v1/plugins/bundle/plugin.go
@@ -863,6 +863,7 @@ func (fl *fileLoader) oneShot(ctx context.Context) {
 	b, err := reader.
 		WithMetrics(u.Metrics).
 		WithBundleVerificationConfig(fl.bvc).
+		WithLazyLoadingMode(bundle.HasExtension()).
 		WithSizeLimitBytes(fl.sizeLimitBytes).
 		WithRegoVersion(fl.bundleParserOpts.RegoVersion).
 		Read()

--- a/v1/plugins/plugins.go
+++ b/v1/plugins/plugins.go
@@ -220,6 +220,7 @@ type Manager struct {
 	stop                         chan chan struct{}
 	parserOptions                ast.ParserOptions
 	extraRoutes                  map[string]ExtraRoute
+	bundleActivatorPlugin        string
 }
 
 type managerContextKey string
@@ -426,6 +427,13 @@ func WithTelemetryGatherers(gs map[string]report.Gatherer) func(*Manager) {
 	}
 }
 
+// WithBundleActivatorPlugin sets the name of the activator plugin to load bundles into the store
+func WithBundleActivatorPlugin(bundleActivatorPlugin string) func(*Manager) {
+	return func(m *Manager) {
+		m.bundleActivatorPlugin = bundleActivatorPlugin
+	}
+}
+
 // New creates a new Manager using config.
 func New(raw []byte, id string, store storage.Store, opts ...func(*Manager)) (*Manager, error) {
 
@@ -547,6 +555,7 @@ func (m *Manager) Init(ctx context.Context) error {
 			MaxErrors:             m.maxErrors,
 			EnablePrintStatements: m.enablePrintStatements,
 			ParserOptions:         m.parserOptions,
+			BundleActivatorPlugin: m.bundleActivatorPlugin,
 		})
 
 		if err != nil {

--- a/v1/runtime/runtime.go
+++ b/v1/runtime/runtime.go
@@ -207,6 +207,9 @@ type Params struct {
 	// SkipBundleVerification flag controls whether OPA will verify a signed bundle
 	SkipBundleVerification bool
 
+	// BundleActivatorPlugin controls the name of the activator plugin used to load bundles into the store.
+	BundleActivatorPlugin string
+
 	// BundleLazyLoadingMode flag controls whether OPA will load bundle contents in lazy mode.
 	BundleLazyLoadingMode bool
 
@@ -482,6 +485,7 @@ func NewRuntime(ctx context.Context, params Params) (*Runtime, error) {
 		plugins.WithEnableTelemetry(params.EnableVersionCheck),
 		plugins.WithParserOptions(params.parserOptions()),
 		plugins.WithDistributedTracingOpts(params.DistributedTracingOpts),
+		plugins.WithBundleActivatorPlugin(params.BundleActivatorPlugin),
 		plugins.WithHooks(params.Hooks),
 	)
 	if err != nil {

--- a/v1/sdk/opa.go
+++ b/v1/sdk/opa.go
@@ -177,12 +177,19 @@ func (opa *OPA) configure(ctx context.Context, bs []byte, ready chan struct{}, b
 		plugins.PrintHook(loggingPrintHook{logger: opa.logger}),
 		plugins.WithHooks(opa.hooks),
 	}
-
 	opts = append(opts, opa.managerOpts...)
+
+	// Plumb in storage for external bundle activation plugin, if registered with bundle.RegisterStore.
+	var store storage.Store
+	if bundle.BundleExtStore != nil {
+		store = bundle.BundleExtStore()
+	} else {
+		store = opa.store
+	}
 	manager, err := plugins.New(
 		bs,
 		opa.id,
-		opa.store,
+		store,
 		opts...,
 	)
 	if err != nil {


### PR DESCRIPTION
## What changed?

This PR introduces support for a singleton plugin to control bundle storage and activation. This will allow experimentation with new bundle and data formats.

Note: There are a few hacks required to make this feature work in the library and SDK usecases (see `bundle.RegisterStore`).

Bundle lazy loading (#7768) is also enabled by default when a bundle activation plugin is registered. The thinking there is that a bundle activation plugin may accept data formats that the default `bundle` plugin would not, so we want to *defer* the validation work to whatever plugin is doing the work of putting things into OPA's storage layer during activation.

## TODO's

 - [x] Add the shims needed for `cmd/test.go` to support bundle lazy loading.
 - [x] A proper test of a dummy bundle activation plugin.

## Additional resources

 - #7768