### PR TITLE
website: Ensure no hscroll on built-in tables

### DIFF
--- a/docs/src/components/BuiltinTable/index.js
+++ b/docs/src/components/BuiltinTable/index.js
@@ -1,6 +1,9 @@
-import builtins from "@generated/builtin-data/default/builtins.json";
 import React from "react";
 import ReactMarkdown from "react-markdown";
+
+import styles from "./styles.module.css";
+
+import builtins from "@generated/builtin-data/default/builtins.json";
 
 function capitalize(str) {
   return str.charAt(0).toUpperCase() + str.slice(1);
@@ -89,9 +92,22 @@ export default function BuiltinTable({
 
             return (
               <tr key={anchor} id={anchor}>
-                <td>
+                <td className={styles.functionCell}>
                   <a href={`#${anchor}`}>
-                    <code>{isInfix ? signature : name}</code>
+                    <code className={styles.functionName}>
+                      {(isInfix ? signature : name)
+                        .split(/(\.|_)/)
+                        .map((part, index) =>
+                          part === "." || part === "_"
+                            ? (
+                              <React.Fragment key={index}>
+                                {part}
+                                <wbr />
+                              </React.Fragment>
+                            )
+                            : part
+                        )}
+                    </code>
                   </a>
                 </td>
                 <td>

--- a/docs/src/components/BuiltinTable/styles.module.css
+++ b/docs/src/components/BuiltinTable/styles.module.css
@@ -1,0 +1,7 @@
+.functionCell {
+	width: 20%;
+}
+
+.functionName {
+	font-size: 0.8rem;
+}


### PR DESCRIPTION
This makes a number of changes to how the built in functions are displayed to ensure that there is no horizontal scrolling when viewing builtin in tables with longer function names.

https://github.com/user-attachments/assets/5e368415-b966-4a88-88b1-504aa549ae2d

