### PR TITLE
website: Use latest release rather than edge

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -462,8 +462,11 @@ else
 release-ci: push-image push-manifest-list-latest
 endif
 
-.PHONY: netlify
-netlify: docs-clean docs-ci docs-build
+.PHONY: netlify-latest
+netlify-latest: docs-clean docs-ci docs-build-latest
+
+.PHONY: netlify-edge
+netlify-edge: docs-clean docs-ci docs-build
 
 # Kept for compatibility. Use `make fuzz` instead.
 .PHONY: check-fuzz

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -14,6 +14,10 @@ dev:
 build:
 	npx docusaurus build
 
+.PHONY: build-latest
+build-latest:
+	./bin/build-latest.sh
+
 .PHONY: clean
 clean:
 	rm -rf build .docusaurus

--- a/docs/bin/build-latest.sh
+++ b/docs/bin/build-latest.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if ! git diff --quiet HEAD -- || ! git diff --cached --quiet; then
+    echo "Latest release build must be done without working changes"
+    git status
+    exit 1
+fi
+
+git fetch --tags origin
+
+CURRENT_REF=$(git rev-parse HEAD)
+
+LATEST_TAG=$(git tag --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
+
+if [ -z "$LATEST_TAG" ]; then
+    echo "No valid release tag found (expected format: v1.2.3)"
+    exit 1
+fi
+
+git checkout "$LATEST_TAG"
+
+BUILD_VERSION="$LATEST_TAG" npx docusaurus build
+
+git checkout "$CURRENT_REF"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
 publish = "docs/build"
-command = "make netlify"
+command = "make netlify-latest"
 edge_functions = "docs/functions"
 
 [build.environment]
@@ -8,6 +8,9 @@ NODE_VERSION = "22.15.0"
 # some examples in v1/test/cases/testdata/v0/cryptox509* flag the netlify
 # secret scan
 SECRETS_SCAN_OMIT_PATHS = "v1/test/cases,v1/topdown/crypto_test.go"
+
+[context.deploy-preview]
+command = "make netlify-edge"
 
 [[edge_functions]]
 # this path should not be changed as various external sites depend on it for OPA


### PR DESCRIPTION
⚠️ This should be merged *after* v1.7.0 is released as the v1.6.0 website is not going to have: https://github.com/open-policy-agent/opa/pull/7783, which is needed by the versioned deployments to toggle their out of date state.

This is intended to make the default view of the OPA site and docs from the latest release, rather than from edge.

Deploy preview command will need to show edge, but using that to test the prod command atm.

When `make netlify-latest` was used on the preview, we see that the site was built from the latest release:

<img width="607" height="114" alt="Screenshot 2025-07-17 at 11 16 43" src="https://github.com/user-attachments/assets/93b72c9a-a6bd-4f65-aa19-3d90021a7637" />
