### PR TITLE
ast: add feature registration from the outside

### DIFF
--- a/v1/ast/capabilities.go
+++ b/v1/ast/capabilities.go
@@ -57,6 +57,24 @@ const FeatureRegoV1 = "rego_v1"
 const FeatureRegoV1Import = "rego_v1_import"
 const FeatureKeywordsInRefs = "keywords_in_refs"
 
+// Features carries the default features supported by this version of OPA.
+// Use RegisterFeatures to add to them.
+var Features = []string{
+	FeatureRegoV1,
+	FeatureKeywordsInRefs,
+}
+
+// RegisterFeatures lets applications wrapping OPA register features, to be
+// included in `ast.CapabilitiesForThisVersion()`.
+func RegisterFeatures(fs ...string) {
+	for i := range fs {
+		if slices.Contains(Features, fs[i]) {
+			continue
+		}
+		Features = append(Features, fs[i])
+	}
+}
+
 // Capabilities defines a structure containing data that describes the capabilities
 // or features supported by a particular version of OPA.
 type Capabilities struct {
@@ -141,10 +159,8 @@ func CapabilitiesForThisVersion(opts ...CapabilitiesOption) *Capabilities {
 			f.FutureKeywords = append(f.FutureKeywords, kw)
 		}
 
-		f.Features = []string{
-			FeatureRegoV1,
-			FeatureKeywordsInRefs,
-		}
+		f.Features = make([]string, len(Features))
+		copy(f.Features, Features)
 	}
 
 	sort.Strings(f.FutureKeywords)


### PR DESCRIPTION
If I add this to `main.go` (imagine another executable including OPA),

```diff
diff --git a/main.go b/main.go
index 9d5aea6c7c..5126479107 100644
--- a/main.go
+++ b/main.go
@@ -8,9 +8,11 @@
 	"os"
 
 	"github.com/open-policy-agent/opa/cmd"
+	"github.com/open-policy-agent/opa/v1/ast"
 )
 
 func main() {
+	ast.RegisterFeatures("foo", "bar", "baz")
 	if err := cmd.RootCommand.Execute(); err != nil {
 		os.Exit(1)
 	}
```

and I subsequently run `opa capabilities --current`, we'll find (other stuff omitted):

```json
{
  "features": [
    "bar",
    "baz",
    "foo",
    "keywords_in_refs",
    "rego_v1"
  ]
}
```

This complements _builtins_, which can already be registered from the outside.