### PR TITLE
website: Add wildcard CORS for data/versions.json

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -26,6 +26,6 @@ function = "version-redirect"
 [[headers]]
 for = "/data/versions.json"
 [headers.values]
-Access-Control-Allow-Origin = "https://*.netlify.app"
+Access-Control-Allow-Origin = "*"
 Access-Control-Allow-Methods = "GET, OPTIONS"
 Access-Control-Allow-Headers = "Content-Type"


### PR DESCRIPTION
Turns out that CORS is either any host, or a specific host. We need to match any opa versioned deployment host, so we need a *.
