### PR TITLE
internal/config: keep unknown env replacements

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -131,10 +131,13 @@ func subEnvVars(s string) string {
 		}
 		varName := s[2 : len(s)-1]
 
-		// Lookup the variable in the environment. We play by
-		// bash rules.. if its undefined we'll treat it as an
-		// empty string instead of raising an error.
-		return os.Getenv(varName)
+		// Lookup the variable in the environment. We do not
+		// play by bash rules: if its undefined we'll keep it
+		// as-is, it could be replaced somewhere down the line.
+		if lu := os.Getenv(varName); lu != "" {
+			return lu
+		}
+		return s
 	})
 
 	return updatedConfig

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -98,7 +98,7 @@ func TestSubEnvVarsVarsSubMissingEnvVar(t *testing.T) {
 
 	// Remove the env var and expect the system to sub in ""
 	os.Unsetenv(envKey)
-	expected := "field1: ''"
+	expected := configYaml // untouched
 
 	actual := subEnvVars(configYaml)
 


### PR DESCRIPTION
Not replacing env vars when they cannot be replaced allows for some nice extensions like
```yaml
config:
  some_value: ${extra("foo")}
```
that you then replace with some custom magic in a hook. ✨ 