### PR TITLE
plugins/discovery: Replace environment variables after evaluation.

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -120,8 +120,12 @@ func Load(configFile string, overrides []string, overrideFiles []string) ([]byte
 // regex looking for ${...} notation strings
 var envRegex = regexp.MustCompile(`(?U:\${.*})`)
 
-// subEnvVars will look for any environment variables in the passed in string
+// SubEnvVars will look for any environment variables in the passed in string
 // with the syntax of ${VAR_NAME} and replace that string with ENV[VAR_NAME]
+func SubEnvVars(s string) string {
+	return subEnvVars(s)
+}
+
 func subEnvVars(s string) string {
 	updatedConfig := envRegex.ReplaceAllStringFunc(s, func(s string) string {
 		// Trim off the '${' and '}'

--- a/v1/plugins/discovery/discovery.go
+++ b/v1/plugins/discovery/discovery.go
@@ -573,7 +573,8 @@ func evaluateBundle(ctx context.Context, id string, info *ast.Term, b *bundleApi
 		return nil, err
 	}
 
-	return config.ParseConfig(bs, id)
+	processedConf := cfg.SubEnvVars(string(bs))
+	return config.ParseConfig([]byte(processedConf), id)
 }
 
 type pluginSet struct {


### PR DESCRIPTION
This allows simple setups -- those feeding the OPA discovery plugin with a static JSON file -- to still do env variable replacements.

This should be possible already, by using a policy to construct the disco config, but it becomes easier now.
