### PR TITLE
server+logging: Add BatchDecisionID field to Decision Logs.

### DIFF
--- a/v1/logging/logging.go
+++ b/v1/logging/logging.go
@@ -261,3 +261,14 @@ func DecisionIDFromContext(ctx context.Context) (string, bool) {
 	s, ok := ctx.Value(decisionCtxKey).(string)
 	return s, ok
 }
+
+const batchDecisionCtxKey = requestContextKey("batch_decision_id")
+
+func WithBatchDecisionID(parent context.Context, id string) context.Context {
+	return context.WithValue(parent, batchDecisionCtxKey, id)
+}
+
+func BatchDecisionIDFromContext(ctx context.Context) (string, bool) {
+	s, ok := ctx.Value(batchDecisionCtxKey).(string)
+	return s, ok
+}

--- a/v1/plugins/logs/plugin.go
+++ b/v1/plugins/logs/plugin.go
@@ -47,26 +47,27 @@ type Logger interface {
 // the struct. Any changes here MUST be reflected in the AST()
 // implementation below.
 type EventV1 struct {
-	Labels         map[string]string       `json:"labels"`
-	DecisionID     string                  `json:"decision_id"`
-	TraceID        string                  `json:"trace_id,omitempty"`
-	SpanID         string                  `json:"span_id,omitempty"`
-	Revision       string                  `json:"revision,omitempty"` // Deprecated: Use Bundles instead
-	Bundles        map[string]BundleInfoV1 `json:"bundles,omitempty"`
-	Path           string                  `json:"path,omitempty"`
-	Query          string                  `json:"query,omitempty"`
-	Input          *any                    `json:"input,omitempty"`
-	Result         *any                    `json:"result,omitempty"`
-	MappedResult   *any                    `json:"mapped_result,omitempty"`
-	NDBuiltinCache *any                    `json:"nd_builtin_cache,omitempty"`
-	Erased         []string                `json:"erased,omitempty"`
-	Masked         []string                `json:"masked,omitempty"`
-	Error          error                   `json:"error,omitempty"`
-	RequestedBy    string                  `json:"requested_by,omitempty"`
-	Timestamp      time.Time               `json:"timestamp"`
-	Metrics        map[string]any          `json:"metrics,omitempty"`
-	RequestID      uint64                  `json:"req_id,omitempty"`
-	RequestContext *RequestContext         `json:"request_context,omitempty"`
+	Labels          map[string]string       `json:"labels"`
+	DecisionID      string                  `json:"decision_id"`
+	BatchDecisionID string                  `json:"batch_decision_id,omitempty"`
+	TraceID         string                  `json:"trace_id,omitempty"`
+	SpanID          string                  `json:"span_id,omitempty"`
+	Revision        string                  `json:"revision,omitempty"` // Deprecated: Use Bundles instead
+	Bundles         map[string]BundleInfoV1 `json:"bundles,omitempty"`
+	Path            string                  `json:"path,omitempty"`
+	Query           string                  `json:"query,omitempty"`
+	Input           *any                    `json:"input,omitempty"`
+	Result          *any                    `json:"result,omitempty"`
+	MappedResult    *any                    `json:"mapped_result,omitempty"`
+	NDBuiltinCache  *any                    `json:"nd_builtin_cache,omitempty"`
+	Erased          []string                `json:"erased,omitempty"`
+	Masked          []string                `json:"masked,omitempty"`
+	Error           error                   `json:"error,omitempty"`
+	RequestedBy     string                  `json:"requested_by,omitempty"`
+	Timestamp       time.Time               `json:"timestamp"`
+	Metrics         map[string]any          `json:"metrics,omitempty"`
+	RequestID       uint64                  `json:"req_id,omitempty"`
+	RequestContext  *RequestContext         `json:"request_context,omitempty"`
 
 	inputAST ast.Value
 }
@@ -101,6 +102,10 @@ func (e *EventV1) AST() (ast.Value, error) {
 	event := ast.NewObject(
 		ast.Item(ast.InternedTerm("decision_id"), ast.StringTerm(e.DecisionID)),
 	)
+
+	if e.BatchDecisionID != "" {
+		event.Insert(ast.InternedTerm("batch_decision_id"), ast.StringTerm(e.BatchDecisionID))
+	}
 
 	if e.Labels != nil {
 		labelsObj := ast.NewObject()
@@ -686,22 +691,23 @@ func (p *Plugin) Log(ctx context.Context, decision *server.Info) error {
 	}
 
 	event := EventV1{
-		Labels:         p.manager.Labels(),
-		DecisionID:     decision.DecisionID,
-		TraceID:        decision.TraceID,
-		SpanID:         decision.SpanID,
-		Revision:       decision.Revision,
-		Bundles:        bundles,
-		Path:           decision.Path,
-		Query:          decision.Query,
-		Input:          decision.Input,
-		Result:         decision.Results,
-		MappedResult:   decision.MappedResults,
-		NDBuiltinCache: decision.NDBuiltinCache,
-		RequestedBy:    decision.RemoteAddr,
-		Timestamp:      decision.Timestamp,
-		RequestID:      decision.RequestID,
-		inputAST:       decision.InputAST,
+		Labels:          p.manager.Labels(),
+		DecisionID:      decision.DecisionID,
+		BatchDecisionID: decision.BatchDecisionID,
+		TraceID:         decision.TraceID,
+		SpanID:          decision.SpanID,
+		Revision:        decision.Revision,
+		Bundles:         bundles,
+		Path:            decision.Path,
+		Query:           decision.Query,
+		Input:           decision.Input,
+		Result:          decision.Results,
+		MappedResult:    decision.MappedResults,
+		NDBuiltinCache:  decision.NDBuiltinCache,
+		RequestedBy:     decision.RemoteAddr,
+		Timestamp:       decision.Timestamp,
+		RequestID:       decision.RequestID,
+		inputAST:        decision.InputAST,
 	}
 
 	headers := map[string][]string{}

--- a/v1/plugins/logs/plugin_test.go
+++ b/v1/plugins/logs/plugin_test.go
@@ -3320,6 +3320,26 @@ func TestEventV1ToAST(t *testing.T) {
 				inputAST:    astInput,
 			},
 		},
+		{
+			note: "event with batch decision id",
+			event: EventV1{
+				Labels:          map[string]string{"foo": "1", "bar": "2"},
+				DecisionID:      "1234567890",
+				BatchDecisionID: "abcdefghij",
+				Bundles: map[string]BundleInfoV1{
+					"b1": {"revision7"},
+					"b2": {"0"},
+					"b3": {},
+				},
+				Input:       &goInput,
+				Path:        "/http/authz/allow",
+				RequestedBy: "[::1]:59943",
+				Result:      &result,
+				Timestamp:   time.Now(),
+				RequestID:   1,
+				inputAST:    astInput,
+			},
+		},
 	}
 
 	for _, tc := range cases {

--- a/v1/server/buffer.go
+++ b/v1/server/buffer.go
@@ -20,6 +20,7 @@ type Info struct {
 	Revision           string // Deprecated: Use `Bundles` instead
 	Bundles            map[string]BundleInfo
 	DecisionID         string
+	BatchDecisionID    string
 	TraceID            string
 	SpanID             string
 	RemoteAddr         string


### PR DESCRIPTION
## What changed?

This commit adds a new `batch_decision_id` field to Decision Log entries, allowing batches of decisions to be correlated together later. This has a different intent and purpose than the preexisting `request_id` field-- you might have several decisions that are logically part of the same batch, but are initiated from multiple individual requests.

The point of this PR is to provide the minimal scaffolding to allow eventual batching of requests/decisions/queries.
