### PR TITLE
ast: add DefaultModuleLoader

### DIFF
--- a/v1/ast/default_module_loader.go
+++ b/v1/ast/default_module_loader.go
@@ -1,0 +1,14 @@
+// Copyright 2025 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package ast
+
+var defaultModuleLoader ModuleLoader
+
+// DefaultModuleLoader lets you inject an `ast.ModuleLoader` that will
+// always be used. If another one is provided with the ast package,
+// they will both be consulted to enrich the set of modules dynamically.
+func DefaultModuleLoader(ml ModuleLoader) {
+	defaultModuleLoader = ml
+}


### PR DESCRIPTION
This provides the means to inject modules _for all invocations of the ast package in an executable_. It's handy if you want to include your own set of base modules, with helper functions.

Since the module loader can be provided via other means, we need to check both possibilities:

1. If there hasn't been a module loader set up before, just use the default module loader.

2. If there had been one set up before, run that first, then run the default one, and merge the results. This can be iterated, of course, if need be -- and should reach a fix point given that the individual loaders do.
