### PR TITLE
build: add top-level token permissions for workflows

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -16,14 +16,15 @@ on:
     branches: [ main, release-* ]
 
 permissions:
-  actions: read
   contents: read
-  security-events: write
 
 jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      security-events: write
 
     strategy:
       fail-fast: false

--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -6,6 +6,9 @@ on:
   schedule:
   - cron: "0 0 1 * *" # At 00:00 on day-of-month 1
 
+permissions:
+  contents: read
+
 jobs:
   linkChecker:
     runs-on: ubuntu-latest

--- a/.github/workflows/post-tag.yaml
+++ b/.github/workflows/post-tag.yaml
@@ -5,6 +5,9 @@ on:
     tags:
       - "*"
 
+permissions:
+  contents: read
+
 jobs:
   generate:
     name: Generate Code
@@ -94,6 +97,8 @@ jobs:
     name: Push Latest Release
     needs: [release-build, release-build-darwin]
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
     steps:
       - name: Check out code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -8,6 +8,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   # Check what types of changes this PR contains
   check-changes:


### PR DESCRIPTION
### Why the changes in this PR are needed?

This continues the effort in #6938 to improve the OpenSSF Scorecard score by adding top-level token permissions to all workflows. The guideline for token permissions is [here](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions), but essentially consists of:

> Set top-level permissions as read-all or contents: read as described in GitHub's [documentation](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#permissions).
Set any required write permissions at the job-level. Only set the permissions required for that job; do not set permissions: write-all at the job level.

The most impact would be from ensure all workflows have top level permissions, as the scoring metric assigns a 0 even if one workflow is lacking a top-level permission.

### What are the changes in this PR?

Add top level permissions where missing and include write permissions at the job level where needed.

Part of #6938 

### Notes to assist PR review:

None

### Further comments:

None
