### PR TITLE
plugins/logs: Add experimental intermediate results field.

### DIFF
--- a/v1/plugins/logs/plugin.go
+++ b/v1/plugins/logs/plugin.go
@@ -47,28 +47,29 @@ type Logger interface {
 // the struct. Any changes here MUST be reflected in the AST()
 // implementation below.
 type EventV1 struct {
-	Labels          map[string]string       `json:"labels"`
-	DecisionID      string                  `json:"decision_id"`
-	BatchDecisionID string                  `json:"batch_decision_id,omitempty"`
-	TraceID         string                  `json:"trace_id,omitempty"`
-	SpanID          string                  `json:"span_id,omitempty"`
-	Revision        string                  `json:"revision,omitempty"` // Deprecated: Use Bundles instead
-	Bundles         map[string]BundleInfoV1 `json:"bundles,omitempty"`
-	Path            string                  `json:"path,omitempty"`
-	Query           string                  `json:"query,omitempty"`
-	Input           *any                    `json:"input,omitempty"`
-	Result          *any                    `json:"result,omitempty"`
-	MappedResult    *any                    `json:"mapped_result,omitempty"`
-	NDBuiltinCache  *any                    `json:"nd_builtin_cache,omitempty"`
-	Erased          []string                `json:"erased,omitempty"`
-	Masked          []string                `json:"masked,omitempty"`
-	Error           error                   `json:"error,omitempty"`
-	RequestedBy     string                  `json:"requested_by,omitempty"`
-	Timestamp       time.Time               `json:"timestamp"`
-	Metrics         map[string]any          `json:"metrics,omitempty"`
-	RequestID       uint64                  `json:"req_id,omitempty"`
-	RequestContext  *RequestContext         `json:"request_context,omitempty"`
-	Custom          map[string]any          `json:"custom,omitempty"`
+	Labels              map[string]string       `json:"labels"`
+	DecisionID          string                  `json:"decision_id"`
+	BatchDecisionID     string                  `json:"batch_decision_id,omitempty"`
+	TraceID             string                  `json:"trace_id,omitempty"`
+	SpanID              string                  `json:"span_id,omitempty"`
+	Revision            string                  `json:"revision,omitempty"` // Deprecated: Use Bundles instead
+	Bundles             map[string]BundleInfoV1 `json:"bundles,omitempty"`
+	Path                string                  `json:"path,omitempty"`
+	Query               string                  `json:"query,omitempty"`
+	Input               *any                    `json:"input,omitempty"`
+	Result              *any                    `json:"result,omitempty"`
+	IntermediateResults map[string]any          `json:"intermediate_results,omitempty"`
+	MappedResult        *any                    `json:"mapped_result,omitempty"`
+	NDBuiltinCache      *any                    `json:"nd_builtin_cache,omitempty"`
+	Erased              []string                `json:"erased,omitempty"`
+	Masked              []string                `json:"masked,omitempty"`
+	Error               error                   `json:"error,omitempty"`
+	RequestedBy         string                  `json:"requested_by,omitempty"`
+	Timestamp           time.Time               `json:"timestamp"`
+	Metrics             map[string]any          `json:"metrics,omitempty"`
+	RequestID           uint64                  `json:"req_id,omitempty"`
+	RequestContext      *RequestContext         `json:"request_context,omitempty"`
+	Custom              map[string]any          `json:"custom,omitempty"`
 
 	inputAST ast.Value
 }
@@ -154,6 +155,14 @@ func (e *EventV1) AST() (ast.Value, error) {
 			return nil, err
 		}
 		event.Insert(ast.InternedTerm("result"), ast.NewTerm(results))
+	}
+
+	if len(e.IntermediateResults) > 0 {
+		iresults, err := roundtripJSONToAST(e.IntermediateResults)
+		if err != nil {
+			return nil, err
+		}
+		event.Insert(ast.InternedTerm("intermediate_results"), ast.NewTerm(iresults))
 	}
 
 	if e.MappedResult != nil {
@@ -700,24 +709,25 @@ func (p *Plugin) Log(ctx context.Context, decision *server.Info) error {
 	}
 
 	event := EventV1{
-		Labels:          p.manager.Labels(),
-		DecisionID:      decision.DecisionID,
-		BatchDecisionID: decision.BatchDecisionID,
-		TraceID:         decision.TraceID,
-		SpanID:          decision.SpanID,
-		Revision:        decision.Revision,
-		Bundles:         bundles,
-		Path:            decision.Path,
-		Query:           decision.Query,
-		Input:           decision.Input,
-		Result:          decision.Results,
-		MappedResult:    decision.MappedResults,
-		NDBuiltinCache:  decision.NDBuiltinCache,
-		RequestedBy:     decision.RemoteAddr,
-		Timestamp:       decision.Timestamp,
-		RequestID:       decision.RequestID,
-		inputAST:        decision.InputAST,
-		Custom:          decision.Custom,
+		Labels:              p.manager.Labels(),
+		DecisionID:          decision.DecisionID,
+		BatchDecisionID:     decision.BatchDecisionID,
+		TraceID:             decision.TraceID,
+		SpanID:              decision.SpanID,
+		Revision:            decision.Revision,
+		Bundles:             bundles,
+		Path:                decision.Path,
+		Query:               decision.Query,
+		Input:               decision.Input,
+		Result:              decision.Results,
+		IntermediateResults: decision.IntermediateResults,
+		MappedResult:        decision.MappedResults,
+		NDBuiltinCache:      decision.NDBuiltinCache,
+		RequestedBy:         decision.RemoteAddr,
+		Timestamp:           decision.Timestamp,
+		RequestID:           decision.RequestID,
+		inputAST:            decision.InputAST,
+		Custom:              decision.Custom,
 	}
 
 	headers := map[string][]string{}

--- a/v1/plugins/logs/plugin_test.go
+++ b/v1/plugins/logs/plugin_test.go
@@ -3376,6 +3376,26 @@ func TestEventV1ToAST(t *testing.T) {
 				inputAST:    astInput,
 			},
 		},
+		{
+			note: "event with intermediate results",
+			event: EventV1{
+				Labels:     map[string]string{"foo": "1", "bar": "2"},
+				DecisionID: "1234567890",
+				Bundles: map[string]BundleInfoV1{
+					"b1": {"revision7"},
+					"b2": {"0"},
+					"b3": {},
+				},
+				Input:               &goInput,
+				Path:                "/http/authz/allow",
+				RequestedBy:         "[::1]:59943",
+				Result:              &result,
+				IntermediateResults: map[string]any{"foo": "bar"},
+				Timestamp:           time.Now(),
+				RequestID:           1,
+				inputAST:            astInput,
+			},
+		},
 	}
 
 	for _, tc := range cases {

--- a/v1/server/buffer.go
+++ b/v1/server/buffer.go
@@ -16,28 +16,29 @@ import (
 
 // Info contains information describing a policy decision.
 type Info struct {
-	Txn                storage.Transaction
-	Revision           string // Deprecated: Use `Bundles` instead
-	Bundles            map[string]BundleInfo
-	DecisionID         string
-	BatchDecisionID    string
-	TraceID            string
-	SpanID             string
-	RemoteAddr         string
-	HTTPRequestContext logging.HTTPRequestContext
-	Query              string
-	Path               string
-	Timestamp          time.Time
-	Input              *any
-	InputAST           ast.Value
-	Results            *any
-	MappedResults      *any
-	NDBuiltinCache     *any
-	Error              error
-	Metrics            metrics.Metrics
-	Trace              []*topdown.Event
-	RequestID          uint64
-	Custom             map[string]any
+	Txn                 storage.Transaction
+	Revision            string // Deprecated: Use `Bundles` instead
+	Bundles             map[string]BundleInfo
+	DecisionID          string
+	BatchDecisionID     string
+	TraceID             string
+	SpanID              string
+	RemoteAddr          string
+	HTTPRequestContext  logging.HTTPRequestContext
+	Query               string
+	Path                string
+	Timestamp           time.Time
+	Input               *any
+	InputAST            ast.Value
+	Results             *any
+	IntermediateResults map[string]any
+	MappedResults       *any
+	NDBuiltinCache      *any
+	Error               error
+	Metrics             metrics.Metrics
+	Trace               []*topdown.Event
+	RequestID           uint64
+	Custom              map[string]any
 }
 
 // BundleInfo contains information describing a bundle.

--- a/v1/server/server.go
+++ b/v1/server/server.go
@@ -103,9 +103,12 @@ const (
 )
 
 var (
-	supportedTLSVersions = []uint16{tls.VersionTLS10, tls.VersionTLS11, tls.VersionTLS12, tls.VersionTLS13}
-	unsafeBuiltinsMap    = map[string]struct{}{ast.HTTPSend.Name: {}}
+	supportedTLSVersions       = []uint16{tls.VersionTLS10, tls.VersionTLS11, tls.VersionTLS12, tls.VersionTLS13}
+	unsafeBuiltinsMap          = map[string]struct{}{ast.HTTPSend.Name: {}}
+	intermediateResultsEnabled = os.Getenv("OPA_DECISIONS_INTERMEDIATE_RESULTS") != ""
 )
+
+type IntermediateResultsContextKey struct{}
 
 // Server represents an instance of OPA running in server mode.
 type Server struct {
@@ -931,7 +934,7 @@ func (s *Server) methodNotAllowedHandler() http.Handler {
 
 func (s *Server) execQuery(ctx context.Context, br bundleRevisions, txn storage.Transaction, parsedQuery ast.Body, input ast.Value, rawInput *any, m metrics.Metrics, explainMode types.ExplainModeV1, includeMetrics, includeInstrumentation, pretty bool) (*types.QueryResponseV1, error) {
 	results := types.QueryResponseV1{}
-	logger := s.getDecisionLogger(br)
+	ctx, logger := s.getDecisionLogger(ctx, br)
 
 	var buf *topdown.BufferTracer
 	if explainMode != types.ExplainOffV1 {
@@ -1099,7 +1102,7 @@ func (s *Server) v0QueryPath(w http.ResponseWriter, r *http.Request, urlPath str
 		urlPath = s.generateDefaultDecisionPath()
 	}
 
-	logger := s.getDecisionLogger(br)
+	ctx, logger := s.getDecisionLogger(ctx, br)
 
 	var ndbCache builtins.NDBCache
 	if s.ndbCacheEnabled {
@@ -1519,7 +1522,7 @@ func (s *Server) v1DataGet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	logger := s.getDecisionLogger(br)
+	ctx, logger := s.getDecisionLogger(ctx, br)
 
 	var ndbCache builtins.NDBCache
 	if s.ndbCacheEnabled {
@@ -1736,7 +1739,7 @@ func (s *Server) v1DataPost(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if s.logger != nil {
-			logger = s.getDecisionLogger(br)
+			ctx, logger = s.getDecisionLogger(ctx, br)
 		}
 	}
 
@@ -2488,7 +2491,12 @@ func (s *Server) checkPathScope(ctx context.Context, txn storage.Transaction, pa
 	return nil
 }
 
-func (s *Server) getDecisionLogger(br bundleRevisions) (logger decisionLogger) {
+func (s *Server) getDecisionLogger(ctx context.Context, br bundleRevisions) (context.Context, decisionLogger) {
+	var logger decisionLogger
+	if intermediateResultsEnabled {
+		ctx = context.WithValue(ctx, IntermediateResultsContextKey{}, make(map[string]any))
+	}
+
 	// For backwards compatibility use `revision` as needed.
 	if s.hasLegacyBundle(br) {
 		logger.revision = br.LegacyRevision
@@ -2496,7 +2504,7 @@ func (s *Server) getDecisionLogger(br bundleRevisions) (logger decisionLogger) {
 		logger.revisions = br.Revisions
 	}
 	logger.logger = s.logger
-	return logger
+	return ctx, logger
 }
 
 func (*Server) getExplainResponse(explainMode types.ExplainModeV1, trace []*topdown.Event, pretty bool) (explanation types.TraceV1) {
@@ -3129,8 +3137,16 @@ func (l decisionLogger) Log(
 		info.SpanID = sctx.SpanID().String()
 	}
 
-	if err := l.logger(ctx, info); err != nil {
-		return fmt.Errorf("decision_logs: %w", err)
+	if intermediateResultsEnabled {
+		if iresults, ok := ctx.Value(IntermediateResultsContextKey{}).(map[string]any); ok {
+			info.IntermediateResults = iresults
+		}
+	}
+
+	if l.logger != nil {
+		if err := l.logger(ctx, info); err != nil {
+			return fmt.Errorf("decision_logs: %w", err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
## What changed?
This PR adds an experimental "intermediate results" field to decision logs, and provides some basic plumbing in the server package for eventually attaching the intermediate results of an eval to the request context.

The feature can be enabled with the environment variable `OPA_DECISIONS_INTERMEDIATE_RESULTS`, like so:

    export OPA_DECISIONS_INTERMEDIATE_RESULTS=1 ./opa run -s mypolicy.rego --set

The intermediate results are not populated with anything exciting yet, so it should have no effect on decision logs.