### PR TITLE
cmd: allow branding

### DIFF
--- a/build/generate-cli-docs/generate.go
+++ b/build/generate-cli-docs/generate.go
@@ -13,7 +13,7 @@ import (
 )
 
 func main() {
-	command := cmd.RootCommand
+	command := cmd.Command(nil, "opa")
 	command.Use = "opa [command]"
 	command.DisableAutoGenTag = true
 

--- a/build/generate-man/generate.go
+++ b/build/generate-man/generate.go
@@ -23,7 +23,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	cmd := cmd.RootCommand
+	cmd := cmd.Command(nil, "OPA")
 	cmd.Use = "opa [command]"
 	cmd.DisableAutoGenTag = true
 

--- a/cmd/bench.go
+++ b/cmd/bench.go
@@ -63,7 +63,9 @@ func newBenchmarkEvalParams() benchmarkCommandParams {
 	}
 }
 
-func init() {
+func initBench(root *cobra.Command, brand string) {
+	executable := root.Name()
+
 	params := newBenchmarkEvalParams()
 
 	benchCommand := &cobra.Command{
@@ -76,9 +78,10 @@ evaluation will be repeated a number of times and performance results will be re
 
 Example with bundle and input data:
 
-	opa bench -b ./policy-bundle -i input.json 'data.authz.allow'
+	` + executable + ` bench -b ./policy-bundle -i input.json 'data.authz.allow'
 
-To run benchmarks against a running OPA server to evaluate server overhead use the --e2e flag.
+To run benchmarks against a running ` + brand + ` server to evaluate server overhead use the --e2e flag.
+To enable more detailed analysis use the --metrics and --benchmem flags.
 
 The optional "gobench" output format conforms to the Go Benchmark Data Format.
 `,
@@ -130,13 +133,13 @@ The optional "gobench" output format conforms to the Go Benchmark Data Format.
 	addCountFlag(benchCommand.Flags(), &params.count, "benchmark")
 	addBenchmemFlag(benchCommand.Flags(), &params.benchMem, true)
 
-	addE2EFlag(benchCommand.Flags(), &params.e2e, false)
+	addE2EFlag(benchCommand.Flags(), &params.e2e, false, brand)
 	addConfigFileFlag(benchCommand.Flags(), &params.configFile)
 
 	benchCommand.Flags().IntVar(&params.gracefulShutdownPeriod, "shutdown-grace-period", 10, "set the time (in seconds) that the server will wait to gracefully shut down. This flag is valid in 'e2e' mode only.")
 	benchCommand.Flags().IntVar(&params.shutdownWaitPeriod, "shutdown-wait-period", 0, "set the time (in seconds) that the server will wait before initiating shutdown. This flag is valid in 'e2e' mode only.")
 
-	RootCommand.AddCommand(benchCommand)
+	root.AddCommand(benchCommand)
 }
 
 type benchRunner interface {

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -69,34 +69,35 @@ func (p *buildParams) regoVersion() ast.RegoVersion {
 	return ast.DefaultRegoVersion
 }
 
-func init() {
+func initBuild(root *cobra.Command, brand string) {
+	executable := root.Name()
 
 	buildParams := newBuildParams()
 
 	var buildCommand = &cobra.Command{
 		Use:   "build <path> [<path> [...]]",
-		Short: "Build an OPA bundle",
-		Long: `Build an OPA bundle.
+		Short: `Build an ` + brand + ` bundle`,
+		Long: `Build an ` + brand + ` bundle.
 
-The 'build' command packages OPA policy and data files into bundles. Bundles are
+The 'build' command packages ` + brand + ` policy and data files into bundles. Bundles are
 gzipped tarballs containing policies and data. Paths referring to directories are
 loaded recursively.
 
     $ ls
     example.rego
 
-    $ opa build -b .
+    $ ` + executable + ` build -b .
 
-You can load bundles into OPA on the command-line:
+You can load bundles into ` + brand + ` on the command-line:
 
     $ ls
     bundle.tar.gz example.rego
 
-    $ opa run bundle.tar.gz
+    $ ` + executable + ` run bundle.tar.gz
 
-You can also configure OPA to download bundles from remote HTTP endpoints:
+You can also configure ` + brand + ` to download bundles from remote HTTP endpoints:
 
-    $ opa run --server \
+    $ ` + executable + ` run --server \
         --set bundles.example.resource=bundle.tar.gz \
         --set services.example.url=http://localhost:8080
 
@@ -136,9 +137,9 @@ The 'build' command supports targets (specified by -t):
             original policy or data files.
 
     plan    The plan target emits a bundle containing a plan, i.e., an intermediate
-            representation compiled from the input files for each specified entrypoint.
-            This is for further processing, OPA cannot evaluate a "plan bundle" like it
-            can evaluate a wasm or rego bundle.
+			representation compiled from the input files for each specified entrypoint.
+			This is for further processing, ` + brand + ` cannot evaluate a "plan bundle" like it
+			can evaluate a wasm or rego bundle.
 
 The -e flag tells the 'build' command which documents (entrypoints) will be queried by 
 the software asking for policy decisions, so that it can focus optimization efforts and 
@@ -161,7 +162,7 @@ https://www.openpolicyagent.org/docs/latest/management-bundles/#signing.
 
 Example:
 
-    $ opa build --verification-key /path/to/public_key.pem --signing-key /path/to/private_key.pem --bundle foo
+    $ ` + executable + ` build --verification-key /path/to/public_key.pem --signing-key /path/to/private_key.pem --bundle foo
 
 Where foo has the following structure:
 
@@ -196,7 +197,7 @@ see https://www.openpolicyagent.org/docs/latest/management-bundles/#signature-fo
 Capabilities
 ------------
 
-The 'build' command can validate policies against a configurable set of OPA capabilities.
+The 'build' command can validate policies against a configurable set of ` + brand + ` capabilities.
 The capabilities define the built-in functions and other language features that policies
 may depend on. For example, the following capabilities file only permits the policy to
 depend on the "plus" built-in function ('+'):
@@ -224,12 +225,12 @@ depend on the "plus" built-in function ('+'):
         ]
     }
 
-Capabilities can be used to validate policies against a specific version of OPA.
-The OPA repository contains a set of capabilities files for each OPA release. For example,
+Capabilities can be used to validate policies against a specific version of ` + brand + `.
+The ` + brand + ` repository contains a set of capabilities files for each ` + brand + ` release. For example,
 the following command builds a directory of policies ('./policies') and validates them
-against OPA v0.22.0:
+against ` + brand + ` v0.22.0:
 
-    opa build ./policies --capabilities v0.22.0
+    ` + executable + ` build ./policies --capabilities v0.22.0
 `,
 		PreRunE: func(Cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
@@ -279,7 +280,7 @@ against OPA v0.22.0:
 	addV0CompatibleFlag(buildCommand.Flags(), &buildParams.v0Compatible, false)
 	addV1CompatibleFlag(buildCommand.Flags(), &buildParams.v1Compatible, false)
 
-	RootCommand.AddCommand(buildCommand)
+	root.AddCommand(buildCommand)
 }
 
 func dobuild(params buildParams, args []string) error {

--- a/cmd/capabilities.go
+++ b/cmd/capabilities.go
@@ -28,20 +28,21 @@ func (p *capabilitiesParams) regoVersion() ast.RegoVersion {
 	return ast.DefaultRegoVersion
 }
 
-func init() {
+func initCapabilities(root *cobra.Command, brand string) {
+	executable := root.Name()
 
 	capabilitiesParams := capabilitiesParams{}
 
 	var capabilitiesCommand = &cobra.Command{
 		Use:   "capabilities",
-		Short: "Print the capabilities of OPA",
-		Long: `Show capabilities for OPA.
+		Short: "Print the capabilities of " + brand,
+		Long: `Show capabilities for ` + brand + `.
 
-The 'capabilities' command prints the OPA capabilities, prior to and including the version of OPA used.
+The 'capabilities' command prints the ` + brand + ` capabilities, prior to and including the version of ` + brand + ` used.
 
 Print a list of all existing capabilities version names
 
-    $ opa capabilities
+    $ ` + executable + ` capabilities
     v0.17.0
     v0.17.1
     ...
@@ -52,7 +53,7 @@ Print a list of all existing capabilities version names
 
 Print the capabilities of the current version
 
-    $ opa capabilities --current
+    $ ` + executable + ` capabilities --current
     {
         "builtins": [...],
         "future_keywords": [...],
@@ -61,7 +62,7 @@ Print the capabilities of the current version
 
 Print the capabilities of a specific version
 
-    $ opa capabilities --version v0.32.1
+    $ ` + executable + ` capabilities --version v0.32.1
     {
         "builtins": [...],
         "future_keywords": null,
@@ -70,7 +71,7 @@ Print the capabilities of a specific version
 
 Print the capabilities of a capabilities file
 
-    $ opa capabilities --file ./capabilities/v0.32.1.json
+    $ ` + executable + ` capabilities --file ./capabilities/v0.32.1.json
     {
         "builtins": [...],
         "future_keywords": null,
@@ -98,7 +99,7 @@ Print the capabilities of a capabilities file
 	capabilitiesCommand.Flags().StringVar(&capabilitiesParams.file, "file", "", "print capabilities defined by a file")
 	addV0CompatibleFlag(capabilitiesCommand.Flags(), &capabilitiesParams.v0Compatible, false)
 
-	RootCommand.AddCommand(capabilitiesCommand)
+	root.AddCommand(capabilitiesCommand)
 }
 
 func doCapabilities(params capabilitiesParams) (string, error) {

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -173,7 +173,7 @@ func outputErrors(format string, err error) {
 	}
 }
 
-func init() {
+func initCheck(root *cobra.Command, _ string) {
 	checkParams := newCheckParams()
 
 	checkCommand := &cobra.Command{
@@ -215,5 +215,6 @@ and exit with a non-zero exit code.`,
 		"check for Rego v0 and v1 compatibility (policies must be compatible with both Rego versions)")
 	addV0CompatibleFlag(checkCommand.Flags(), &checkParams.v0Compatible, false)
 	addV1CompatibleFlag(checkCommand.Flags(), &checkParams.v1Compatible, false)
-	RootCommand.AddCommand(checkCommand)
+
+	root.AddCommand(checkCommand)
 }

--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -5,15 +5,45 @@
 package cmd
 
 import (
-	"os"
-	"path"
-
 	"github.com/spf13/cobra"
+
+	iversion "github.com/open-policy-agent/opa/internal/version"
 )
 
-// RootCommand is the base CLI command that all subcommands are added to.
-var RootCommand = &cobra.Command{
-	Use:   path.Base(os.Args[0]),
-	Short: "Open Policy Agent (OPA)",
-	Long:  "An open source project to policy-enable your service.",
+// UserAgent lets you override the OPA UA sent with all the HTTP requests.
+// It's another vanity thing -- if you build your own version of OPA, you
+// may want to adjust this.
+// NOTE(sr): Caution: Please consider this experimental, I have the hunch
+// that we'll find a better way to make this adjustment in the future.
+func UserAgent(agent string) {
+	iversion.UserAgent = agent
+}
+
+func Command(rootCommand *cobra.Command, brand string) *cobra.Command {
+	// rootCommand is the base CLI command that all subcommands are added to.
+	if rootCommand == nil {
+		rootCommand = &cobra.Command{
+			Use:   "opa",
+			Short: "Open Policy Agent (OPA)",
+			Long:  "An open source project to policy-enable your service.",
+		}
+	}
+
+	initBench(rootCommand, brand)
+	initBuild(rootCommand, brand)
+	initCapabilities(rootCommand, brand)
+	initCheck(rootCommand, brand)
+	initDeps(rootCommand, brand)
+	initEval(rootCommand, brand)
+	initExec(rootCommand, brand)
+	initFmt(rootCommand, brand)
+	initInspect(rootCommand, brand)
+	initOracle(rootCommand, brand)
+	initParse(rootCommand, brand)
+	initRefactor(rootCommand, brand)
+	initRun(rootCommand, brand)
+	initSign(rootCommand, brand)
+	initTest(rootCommand, brand)
+	initVersion(rootCommand, brand)
+	return rootCommand
 }

--- a/cmd/deps.go
+++ b/cmd/deps.go
@@ -50,7 +50,9 @@ func newDepsCommandParams() depsCommandParams {
 	}
 }
 
-func init() {
+func initDeps(root *cobra.Command, _ string) {
+	executable := root.Name()
+
 	params := newDepsCommandParams()
 
 	depsCommand := &cobra.Command{
@@ -72,9 +74,9 @@ Given a policy like this:
 	is_admin if "admin" in input.user.roles
 
 To evaluate the dependencies of a simple query (e.g. data.policy.allow),
-we'd run opa deps like demonstrated below:
+we'd run ` + executable + ` deps like demonstrated below:
 
-	$ opa deps --data policy.rego data.policy.allow
+	$ ` + executable + ` deps --data policy.rego data.policy.allow
 	+------------------+----------------------+
 	|  BASE DOCUMENTS  |  VIRTUAL DOCUMENTS   |
 	+------------------+----------------------+
@@ -109,7 +111,7 @@ data.policy.is_admin.
 	addOutputFormat(depsCommand.Flags(), params.outputFormat)
 	addV1CompatibleFlag(depsCommand.Flags(), &params.v1Compatible, false)
 
-	RootCommand.AddCommand(depsCommand)
+	root.AddCommand(depsCommand)
 }
 
 func deps(args []string, params depsCommandParams, w io.Writer) error {

--- a/cmd/eval.go
+++ b/cmd/eval.go
@@ -187,7 +187,9 @@ func (r regoError) Unwrap() error {
 	return r.wrapped
 }
 
-func init() {
+func initEval(root *cobra.Command, _ string) {
+	executable := root.Name()
+
 	params := newEvalCommandParams()
 
 	evalCommand := &cobra.Command{
@@ -198,15 +200,15 @@ func init() {
 
 To evaluate a simple query:
 
-    $ opa eval 'x := 1; y := 2; x < y'
+    $ ` + executable + ` eval 'x := 1; y := 2; x < y'
 
 To evaluate a query against JSON data:
 
-    $ opa eval --data data.json 'name := data.names[_]'
+    $ ` + executable + ` eval --data data.json 'name := data.names[_]'
 
 To evaluate a query against JSON data supplied with a file:// URL:
 
-    $ opa eval --data file:///path/to/file.json 'data'
+    $ ` + executable + ` eval --data file:///path/to/file.json 'data'
 
 
 File & Bundle Loading
@@ -216,7 +218,7 @@ The --bundle flag will load data files and Rego files contained
 in the bundle specified by the path. It can be either a
 compressed tar archive bundle file or a directory tree.
 
-    $ opa eval --bundle /some/path 'data'
+    $ ` + executable + ` eval --bundle /some/path 'data'
 
 Where /some/path contains:
 
@@ -269,8 +271,8 @@ Schema
 The -s/--schema flag provides one or more JSON Schemas used to validate references to the input or data documents.
 Loads a single JSON file, applying it to the input document; or all the schema files under the specified directory.
 
-    $ opa eval --data policy.rego --input input.json --schema schema.json
-    $ opa eval --data policy.rego --input input.json --schema schemas/
+    $ ` + executable + ` eval --data policy.rego --input input.json --schema schema.json
+    $ ` + executable + ` eval --data policy.rego --input input.json --schema schemas/
 
 Capabilities
 ------------
@@ -364,7 +366,7 @@ access.
 	addV1CompatibleFlag(evalCommand.Flags(), &params.v1Compatible, false)
 	addReadAstValuesFromStoreFlag(evalCommand.Flags(), &params.ReadAstValuesFromStore, false)
 
-	RootCommand.AddCommand(evalCommand)
+	root.AddCommand(evalCommand)
 }
 
 func eval(args []string, params evalCommandParams, w io.Writer) (bool, error) {

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -25,39 +25,40 @@ import (
 	"github.com/open-policy-agent/opa/v1/util"
 )
 
-func init() {
+func initExec(root *cobra.Command, brand string) {
+	executable := root.Name()
 
 	var bundlePaths repeatedStringFlag
 
 	params := exec.NewParams(os.Stdout)
 
-	var cmd = &cobra.Command{
+	execCommand := &cobra.Command{
 		Use:   `exec <path> [<path> [...]]`,
 		Short: "Execute against input files",
 		Long: `Execute against input files.
 
-The 'exec' command executes OPA against one or more input files. If the paths
-refer to directories, OPA will execute against files contained inside those
+The 'exec' command executes ` + brand + ` against one or more input files. If the paths
+refer to directories, ` + brand + ` will execute against files contained inside those
 directories, recursively.
 
 The 'exec' command accepts a --config-file/-c or series of --set options as
-arguments. These options behave the same as way as 'opa run'. Since the 'exec'
-command is intended to execute OPA in one-shot, the 'exec' command will
+arguments. These options behave the same as way as '` + executable + ` run'. Since the 'exec'
+command is intended to execute ` + brand + ` in one-shot, the 'exec' command will
 manually trigger plugins before and after policy execution:
 
 Before: Discovery -> Bundle -> Status
 After: Decision Logs
 
 By default, the 'exec' command executes the "default decision" (specified in
-the OPA configuration) against each input file. This can be overridden by
+the ` + brand + ` configuration) against each input file. This can be overridden by
 specifying the --decision argument and pointing at a specific policy decision,
-e.g., opa exec --decision /foo/bar/baz ...
+
+e.g., ` + executable + ` exec --decision /foo/bar/baz ...
 `,
 
 		Example: fmt.Sprintf(`  Loading input from stdin:
     %s exec [<path> [...]] --stdin-input [flags]
-`, RootCommand.Use),
-
+`, root.Use),
 		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return env.CmdFlags.CheckEnvironmentVariables(cmd)
 		},
@@ -74,25 +75,22 @@ e.g., opa exec --decision /foo/bar/baz ...
 			return nil
 		},
 	}
+	addBundleFlag(execCommand.Flags(), &bundlePaths)
+	addOutputFormat(execCommand.Flags(), params.OutputFormat)
+	addConfigFileFlag(execCommand.Flags(), &params.ConfigFile)
+	addConfigOverrides(execCommand.Flags(), &params.ConfigOverrides)
+	addConfigOverrideFiles(execCommand.Flags(), &params.ConfigOverrideFiles)
+	execCommand.Flags().StringVarP(&params.Decision, "decision", "", "", "set decision to evaluate")
+	execCommand.Flags().BoolVarP(&params.FailDefined, "fail-defined", "", false, "exits with non-zero exit code on defined/non-empty result and errors")
+	execCommand.Flags().BoolVarP(&params.Fail, "fail", "", false, "exits with non-zero exit code on undefined/empty result and errors")
+	execCommand.Flags().VarP(params.LogLevel, "log-level", "l", "set log level")
+	execCommand.Flags().Var(params.LogFormat, "log-format", "set log format")
+	execCommand.Flags().StringVar(&params.LogTimestampFormat, "log-timestamp-format", "", "set log timestamp format (OPA_LOG_TIMESTAMP_FORMAT environment variable)")
+	execCommand.Flags().DurationVar(&params.Timeout, "timeout", 0, "set exec timeout with a Go-style duration, such as '5m 30s'. (default unlimited)")
+	addV0CompatibleFlag(execCommand.Flags(), &params.V0Compatible, false)
+	addV1CompatibleFlag(execCommand.Flags(), &params.V1Compatible, false)
 
-	addBundleFlag(cmd.Flags(), &bundlePaths)
-	addOutputFormat(cmd.Flags(), params.OutputFormat)
-	addConfigFileFlag(cmd.Flags(), &params.ConfigFile)
-	addConfigOverrides(cmd.Flags(), &params.ConfigOverrides)
-	addConfigOverrideFiles(cmd.Flags(), &params.ConfigOverrideFiles)
-	cmd.Flags().StringVarP(&params.Decision, "decision", "", "", "set decision to evaluate")
-	cmd.Flags().BoolVarP(&params.FailDefined, "fail-defined", "", false, "exits with non-zero exit code on defined result and errors")
-	cmd.Flags().BoolVarP(&params.Fail, "fail", "", false, "exits with non-zero exit code on undefined result and errors")
-	cmd.Flags().BoolVarP(&params.FailNonEmpty, "fail-non-empty", "", false, "exits with non-zero exit code on non-empty result and errors")
-	cmd.Flags().VarP(params.LogLevel, "log-level", "l", "set log level")
-	cmd.Flags().Var(params.LogFormat, "log-format", "set log format")
-	cmd.Flags().StringVar(&params.LogTimestampFormat, "log-timestamp-format", "", "set log timestamp format (OPA_LOG_TIMESTAMP_FORMAT environment variable)")
-	cmd.Flags().BoolVarP(&params.StdIn, "stdin-input", "I", false, "read input document from stdin rather than a static file")
-	cmd.Flags().DurationVar(&params.Timeout, "timeout", 0, "set exec timeout with a Go-style duration, such as '5m 30s'. (default unlimited)")
-	addV0CompatibleFlag(cmd.Flags(), &params.V0Compatible, false)
-	addV1CompatibleFlag(cmd.Flags(), &params.V1Compatible, false)
-
-	RootCommand.AddCommand(cmd)
+	root.AddCommand(execCommand)
 }
 
 func runExec(params *exec.Params) error {
@@ -179,7 +177,6 @@ func triggerPlugins(ctx context.Context, opa *sdk.OPA, names []string) error {
 }
 
 func setupLogging(level, format, timestampFormat string) (logging.Logger, logging.Logger, error) {
-
 	lvl, err := internal_logging.GetLevel(level)
 	if err != nil {
 		return nil, nil, err
@@ -203,7 +200,6 @@ func setupLogging(level, format, timestampFormat string) (logging.Logger, loggin
 }
 
 func setupConfig(file string, overrides []string, overrideFiles []string, bundlePaths []string) ([]byte, error) {
-
 	bs, err := config.Load(file, overrides, overrideFiles)
 	if err != nil {
 		return nil, err

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -184,8 +184,8 @@ func addReadAstValuesFromStoreFlag(fs *pflag.FlagSet, readAstValuesFromStore *bo
 	fs.BoolVar(readAstValuesFromStore, "optimize-store-for-read-speed", value, "optimize default in-memory store for read speed. Has possible negative impact on memory footprint and write speed. See https://www.openpolicyagent.org/docs/latest/policy-performance/#storage-optimization for more details.")
 }
 
-func addE2EFlag(fs *pflag.FlagSet, e2e *bool, value bool) {
-	fs.BoolVar(e2e, "e2e", value, "run benchmarks against a running OPA server")
+func addE2EFlag(fs *pflag.FlagSet, e2e *bool, value bool, brand string) {
+	fs.BoolVar(e2e, "e2e", value, "run benchmarks against a running "+brand+" server")
 }
 
 func newExplainFlag(modes []string) *util.EnumFlag {

--- a/cmd/fmt.go
+++ b/cmd/fmt.go
@@ -246,10 +246,10 @@ func newError(msg string, a ...any) fmtError {
 	}
 }
 
-func init() {
+func initFmt(root *cobra.Command, _ string) {
+	cmd := root.Name()
 	fmtParams := newFmtCommandParams()
-
-	var formatCommand = &cobra.Command{
+	formatCommand := &cobra.Command{
 		Use:   "fmt [path [...]]",
 		Short: "Format Rego source files",
 		Long: `Format Rego source files.
@@ -275,18 +275,18 @@ code if a file would be reformatted.
 The 'fmt' command can be run in several compatibility modes for consuming and outputting
 different Rego versions:
 
-* ` + "`" + `opa fmt` + "`" + `:
+* ` + "`" + cmd + ` fmt` + "`" + `:
   * v1 Rego is formatted to v1
   * ` + "`" + `rego.v1` + "`" + `/` + "`" + `future.keywords` + "`" + ` imports are NOT removed
   * ` + "`" + `rego.v1` + "`" + `/` + "`" + `future.keywords` + "`" + ` imports are NOT added if missing
   * v0 rego is rejected
-* ` + "`" + `opa fmt --v0-compatible` + "`" + `:
+* ` + "`" + cmd + ` fmt --v0-compatible` + "`" + `:
   * v0 Rego is formatted to v0
   * v1 Rego is rejected
-* ` + "`" + `opa fmt --v0-v1` + "`" + `:
+* ` + "`" + cmd + ` fmt --v0-v1` + "`" + `:
   * v0 Rego is formatted to be compatible with v0 AND v1
   * v1 Rego is rejected
-* ` + "`" + `opa fmt --v0-v1 --v1-compatible` + "`" + `:
+* ` + "`" + cmd + ` fmt --v0-v1 --v1-compatible` + "`" + `:
   * v1 Rego is formatted to be compatible with v0 AND v1
   * v0 Rego is rejected
 `,
@@ -301,7 +301,6 @@ different Rego versions:
 				return newExitError(exit)
 			}
 			return nil
-
 		},
 	}
 
@@ -316,5 +315,5 @@ different Rego versions:
 	formatCommand.Flags().BoolVar(&fmtParams.dropV0Imports, "drop-v0-imports", false, "drop v0 imports from the formatted code, such as 'rego.v1' and 'future.keywords'")
 	addCapabilitiesFlag(formatCommand.Flags(), fmtParams.capabilitiesFlag)
 
-	RootCommand.AddCommand(formatCommand)
+	root.AddCommand(formatCommand)
 }

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -57,17 +57,18 @@ func newInspectCommandParams() inspectCommandParams {
 	}
 }
 
-func init() {
+func initInspect(root *cobra.Command, brand string) {
+	executable := root.Name()
 
 	params := newInspectCommandParams()
 
-	var inspectCommand = &cobra.Command{
+	inspectCommand := &cobra.Command{
 		Use:   "inspect <path> [<path> [...]]",
-		Short: "Inspect OPA bundle(s) or Rego files.",
-		Long: `Inspect OPA bundle(s) or Rego files.
+		Short: `Inspect ` + brand + ` bundle(s)`,
+		Long: `Inspect ` + brand + ` bundle(s).
 
-The 'inspect' command provides a summary of the contents in OPA bundle(s) or a single Rego file. Bundles are
-gzipped tarballs containing policies and data. The 'inspect' command reads bundle(s) and lists
+The 'inspect' command provides a summary of the contents in ` + brand + ` bundle(s) or a single Rego file.
+Bundles are gzipped tarballs containing policies and data. The 'inspect' command reads bundle(s) and lists
 the following:
 
 * packages that are contributed by .rego files
@@ -81,12 +82,12 @@ Example:
 
     $ ls
     bundle.tar.gz
-    $ opa inspect bundle.tar.gz
+    $ ` + executable + ` inspect bundle.tar.gz
 
-You can provide exactly one OPA bundle, path to a bundle directory, or direct path to a Rego file to the 'inspect' command
-on the command-line. If you provide a path referring to a directory, the 'inspect' command will load that path as a bundle
-and summarize its structure and contents. If you provide a path referring to a Rego file, the 'inspect' command will load
-that file and summarize its structure and contents.
+You can provide exactly one ` + brand + ` bundle, to a bundle directory, or direct path to a Rego file to the 'inspect'
+command on the command-line. If you provide a path referring to a directory, the 'inspect' command will load that path as
+a bundle and summarize its structure and contents.  If you provide a path referring to a Rego file, the 'inspect' command
+will load that file and summarize its structure and contents.
 `,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if err := validateInspectParams(&params, args); err != nil {
@@ -110,7 +111,7 @@ that file and summarize its structure and contents.
 	addListAnnotations(inspectCommand.Flags(), &params.listAnnotations)
 	addV0CompatibleFlag(inspectCommand.Flags(), &params.v0Compatible, false)
 	addV1CompatibleFlag(inspectCommand.Flags(), &params.v1Compatible, false)
-	RootCommand.AddCommand(inspectCommand)
+	root.AddCommand(inspectCommand)
 }
 
 func doInspect(params inspectCommandParams, path string, out io.Writer) error {

--- a/cmd/oracle.go
+++ b/cmd/oracle.go
@@ -40,7 +40,7 @@ func (p *findDefinitionParams) regoVersion() ast.RegoVersion {
 	return ast.DefaultRegoVersion
 }
 
-func init() {
+func initOracle(root *cobra.Command, brand string) {
 
 	var findDefinitionParams findDefinitionParams
 
@@ -112,7 +112,7 @@ by the input location.`,
 	oracleCommand.AddCommand(findDefinitionCommand)
 	addV0CompatibleFlag(oracleCommand.Flags(), &findDefinitionParams.v0Compatible, false)
 	addV1CompatibleFlag(oracleCommand.Flags(), &findDefinitionParams.v1Compatible, false)
-	RootCommand.AddCommand(oracleCommand)
+	root.AddCommand(oracleCommand)
 }
 
 func dofindDefinition(params findDefinitionParams, stdin io.Reader, stdout io.Writer, args []string) error {

--- a/cmd/parse.go
+++ b/cmd/parse.go
@@ -139,11 +139,11 @@ func parse(args []string, params *parseParams, stdout io.Writer, stderr io.Write
 	return 0
 }
 
-func init() {
+func initParse(root *cobra.Command, _ string) {
 	addOutputFormat(parseCommand.Flags(), configuredParseParams.format)
 	parseCommand.Flags().StringVarP(&configuredParseParams.jsonInclude, "json-include", "", "", "include or exclude optional elements. By default comments are included. Current options: locations, comments. E.g. --json-include locations,-comments will include locations and exclude comments.")
 	addV1CompatibleFlag(parseCommand.Flags(), &configuredParseParams.v1Compatible, false)
 	addV0CompatibleFlag(parseCommand.Flags(), &configuredParseParams.v0Compatible, false)
 
-	RootCommand.AddCommand(parseCommand)
+	root.AddCommand(parseCommand)
 }

--- a/cmd/refactor.go
+++ b/cmd/refactor.go
@@ -40,7 +40,8 @@ func (m *moveCommandParams) regoVersion() ast.RegoVersion {
 	return ast.DefaultRegoVersion
 }
 
-func init() {
+func initRefactor(root *cobra.Command, brand string) {
+	executable := root.Name()
 
 	var moveCommandParams moveCommandParams
 
@@ -73,7 +74,7 @@ Example:
 | default allow = false   |
 | _ _ _ _ _ _ _ _ _ _ _ _ |     
 	
-	$ opa refactor move -p data.lib.foo:data.baz.bar policy.rego
+	$ ` + executable + ` refactor move -p data.lib.foo:data.baz.bar policy.rego
 
 The 'move' command outputs the below policy to stdout with the package name rewritten as per the mapping:
 
@@ -107,7 +108,7 @@ The 'move' command outputs the below policy to stdout with the package name rewr
 	refactorCommand.AddCommand(moveCommand)
 	addV0CompatibleFlag(moveCommand.Flags(), &moveCommandParams.v0Compatible, false)
 	addV1CompatibleFlag(moveCommand.Flags(), &moveCommandParams.v1Compatible, false)
-	RootCommand.AddCommand(refactorCommand)
+	root.AddCommand(refactorCommand)
 }
 
 func doMove(params moveCommandParams, args []string, out io.Writer) error {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -67,27 +68,28 @@ func newRunParams() runCmdParams {
 	}
 }
 
-func init() {
+func initRun(root *cobra.Command, brand string) {
+	executable := root.Name()
 	cmdParams := newRunParams()
 
 	runCommand := &cobra.Command{
 		Use:   "run",
-		Short: "Start OPA in interactive or server mode",
-		Long: `Start an instance of the Open Policy Agent (OPA).
+		Short: `Start ` + brand + ` in interactive or server mode`,
+		Long: `Start an instance of ` + brand + `.
 
 To run the interactive shell:
 
-    $ opa run
+    $ ` + executable + ` run
 
 To run the server:
 
-    $ opa run -s
+    $ ` + executable + ` run -s
 
-The 'run' command starts an instance of the OPA runtime. The OPA runtime can be
+The 'run' command starts an instance of the ` + brand + ` runtime. The ` + brand + ` runtime can be
 started as an interactive shell or a server.
 
 When the runtime is started as a shell, users can define rules and evaluate
-expressions interactively. When the runtime is started as a server, OPA exposes
+expressions interactively. When the runtime is started as a server, ` + brand + ` exposes
 an HTTP API for managing policies, reading and writing data, and executing
 queries.
 
@@ -95,11 +97,11 @@ The runtime can be initialized with one or more files that contain policies or
 data. If the '--bundle' option is specified the paths will be treated as policy
 bundles and loaded following standard bundle conventions. The path can be a
 compressed archive file or a directory which will be treated as a bundle.
-Without the '--bundle' flag OPA will recursively load ALL rego, JSON, and YAML
+Without the '--bundle' flag ` + brand + ` will recursively load ALL rego, JSON, and YAML
 files.
 
 When loading from directories, only files with known extensions are considered.
-The current set of file extensions that OPA will consider are:
+The current set of file extensions that ` + brand + ` will consider are:
 
     .json          # JSON data
     .yaml or .yml  # YAML data
@@ -117,7 +119,7 @@ To set a data file as the input document in the interactive shell use the
 
 Example:
 
-    $ opa run repl.input:input.json
+    $ ` + executable + ` run repl.input:input.json
 
 Which will load the "input.json" file at path "data.repl.input".
 
@@ -126,22 +128,22 @@ Use the "help input" command in the interactive shell to see more options.
 
 File paths can be specified as URLs to resolve ambiguity in paths containing colons:
 
-    $ opa run file:///c:/path/to/data.json
+    $ ` + executable + ` run file:///c:/path/to/data.json
 
 URL paths to remote public bundles (http or https) will be parsed as shorthand
 configuration equivalent of using repeated --set flags to accomplish the same:
 
-	$ opa run -s https://example.com/bundles/bundle.tar.gz
+	$ ` + executable + ` run -s https://example.com/bundles/bundle.tar.gz
 
 The above shorthand command is identical to:
 
-    $ opa run -s --set "services.cli1.url=https://example.com" \
+    $ ` + executable + ` run -s --set "services.cli1.url=https://example.com" \
                  --set "bundles.cli1.service=cli1" \
                  --set "bundles.cli1.resource=/bundles/bundle.tar.gz" \
                  --set "bundles.cli1.persist=true"
 
 The 'run' command can also verify the signature of a signed bundle.
-A signed bundle is a normal OPA bundle that includes a file
+A signed bundle is a normal ` + brand + ` bundle that includes a file
 named ".signatures.json". For more information on signed bundles
 see https://www.openpolicyagent.org/docs/latest/management-bundles/#signing.
 
@@ -162,7 +164,7 @@ bundle signature verification.
 
 Example:
 
-    $ opa run --verification-key secret --signing-alg HS256 --bundle bundle.tar.gz
+    $ ` + executable + ` run --verification-key secret --signing-alg HS256 --bundle bundle.tar.gz
 
 The 'run' command will read the bundle "bundle.tar.gz", check the
 ".signatures.json" file and perform verification using the provided key.
@@ -220,7 +222,7 @@ See https://godoc.org/crypto/tls#pkg-constants for more information.
 	addConfigFileFlag(runCommand.Flags(), &cmdParams.rt.ConfigFile)
 	runCommand.Flags().BoolVarP(&cmdParams.serverMode, "server", "s", false, "start the runtime in server mode")
 	runCommand.Flags().IntVar(&cmdParams.rt.ReadyTimeout, "ready-timeout", 0, "wait (in seconds) for configured plugins before starting server (value <= 0 disables ready check)")
-	runCommand.Flags().StringVarP(&cmdParams.rt.HistoryPath, "history", "H", historyPath(), "set path of history file")
+	runCommand.Flags().StringVarP(&cmdParams.rt.HistoryPath, "history", "H", historyPath(brand), "set path of history file")
 	cmdParams.rt.Addrs = runCommand.Flags().StringSliceP("addr", "a", []string{defaultLocalAddr}, "set listening address of the server (e.g., [ip]:<port> for TCP, unix://<path> for UNIX domain socket)")
 	cmdParams.rt.DiagnosticAddrs = runCommand.Flags().StringSlice("diagnostic-addr", []string{}, "set read-only diagnostic listening address of the server for /health and /metric APIs (e.g., [ip]:<port> for TCP, unix://<path> for UNIX domain socket)")
 	cmdParams.rt.UnixSocketPerm = runCommand.Flags().String("unix-socket-perm", "755", "specify the permissions for the Unix domain socket if used to listen for incoming connections")
@@ -237,7 +239,7 @@ See https://godoc.org/crypto/tls#pkg-constants for more information.
 	runCommand.Flags().DurationVar(&cmdParams.tlsCertRefresh, "tls-cert-refresh-period", 0, "set certificate refresh period")
 	runCommand.Flags().Var(cmdParams.authentication, "authentication", "set authentication scheme")
 	runCommand.Flags().Var(cmdParams.authorization, "authorization", "set authorization scheme")
-	runCommand.Flags().Var(cmdParams.minTLSVersion, "min-tls-version", "set minimum TLS version to be used by OPA's server")
+	runCommand.Flags().Var(cmdParams.minTLSVersion, "min-tls-version", "set minimum TLS version to be used by "+brand+"'s server")
 	runCommand.Flags().VarP(cmdParams.logLevel, "log-level", "l", "set log level")
 	runCommand.Flags().Var(cmdParams.logFormat, "log-format", "set log format")
 	runCommand.Flags().StringVar(&cmdParams.logTimestampFormat, "log-timestamp-format", "", "set log timestamp format (OPA_LOG_TIMESTAMP_FORMAT environment variable)")
@@ -277,7 +279,7 @@ Flags:
 
 	runCommand.SetUsageTemplate(usageTemplate)
 
-	RootCommand.AddCommand(runCommand)
+	root.AddCommand(runCommand)
 }
 
 func initRuntime(ctx context.Context, params runCmdParams, args []string, addrSetByUser bool) (*runtime.Runtime, error) {
@@ -427,12 +429,15 @@ func verifyCipherSuites(cipherSuites []string) (*[]uint16, error) {
 	return &cipherSuitesIDs, nil
 }
 
-func historyPath() string {
+func historyPath(brand string) string {
+	b := strings.ToLower(brand)
+	historyFile := strings.Replace(defaultHistoryFile, "opa", b, 1)
+
 	home := os.Getenv("HOME")
 	if len(home) == 0 {
-		return defaultHistoryFile
+		return historyFile
 	}
-	return path.Join(home, defaultHistoryFile)
+	return path.Join(home, historyFile)
 }
 
 func loadCertificate(tlsCertFile, tlsPrivateKeyFile string) (*tls.Certificate, error) {

--- a/cmd/sign.go
+++ b/cmd/sign.go
@@ -44,13 +44,14 @@ func newSignCmdParams() signCmdParams {
 	return signCmdParams{}
 }
 
-func init() {
+func initSign(root *cobra.Command, brand string) {
+	executable := root.Name()
 	cmdParams := newSignCmdParams()
 
 	var signCommand = &cobra.Command{
 		Use:   "sign <path> [<path> [...]]",
-		Short: "Generate an OPA bundle signature",
-		Long: `Generate an OPA bundle signature.
+		Short: `Generate an ` + brand + ` bundle signature`,
+		Long: `Generate an ` + brand + ` bundle signature.
 
 The 'sign' command generates a digital signature for policy bundles. It generates a
 ".signatures.json" file that dictates which files should be included in the bundle,
@@ -70,10 +71,10 @@ the private key.
 For HMAC family of algorithms (eg. HS256), the secret can be provided using
 the --signing-key flag.
 
-OPA 'sign' can ONLY be used with the --bundle flag to load paths that refer to
+` + brand + ` 'sign' can ONLY be used with the --bundle flag to load paths that refer to
 existing bundle files or directories following the bundle structure.
 
-	$ opa sign --signing-key /path/to/private_key.pem --bundle foo
+	$ ` + executable + ` sign --signing-key /path/to/private_key.pem --bundle foo
 
 Where foo has the following structure:
 
@@ -122,7 +123,7 @@ And the decoded JWT payload has the following form:
 	}
 
 The "files" field is generated from the files under the directory path(s)
-provided to the 'sign' command. During bundle signature verification, OPA will check
+provided to the 'sign' command. During bundle signature verification, ` + brand + ` will check
 each file name (ex. "foo/bar/data.json") in the "files" field
 exists in the actual bundle. The file content is hashed using SHA256.
 
@@ -161,7 +162,7 @@ https://www.openpolicyagent.org/docs/latest/management-bundles/#signature-format
 
 	signCommand.Flags().StringVarP(&cmdParams.outputFilePath, "output-file-path", "o", ".", "set the location for the .signatures.json file")
 
-	RootCommand.AddCommand(signCommand)
+	root.AddCommand(signCommand)
 }
 
 func doSign(args []string, params signCmdParams) error {

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -454,7 +454,9 @@ func compileAndSetupTests(ctx context.Context, testParams testCommandParams, sto
 	return runner, reporter, nil
 }
 
-func init() {
+func initTest(root *cobra.Command, brand string) {
+	executable := root.Name()
+
 	var testParams = newTestCommandParams()
 
 	var testCommand = &cobra.Command{
@@ -515,17 +517,17 @@ Example test (example/authz_test.rego):
 
 Example test run:
 
-	$ opa test ./example/
+	$ ` + executable + ` test ./example/
 
 If used with the '--bench' option then tests will be benchmarked.
 
 Example benchmark run:
 
-	$ opa test --bench ./example/
+	$  ` + executable + ` test --bench ./example/
 
 The optional "gobench" output format conforms to the Go Benchmark Data Format.
 
-The --watch flag can be used to monitor policy and data file-system changes. When a change is detected, OPA reloads
+The --watch flag can be used to monitor policy and data file-system changes. When a change is detected, ` + brand + ` reloads
 the policy and data and then re-runs the tests. Watching individual files (rather than directories) is generally not
 recommended as some updates might cause them to be dropped by OPA.
 `,
@@ -580,5 +582,5 @@ recommended as some updates might cause them to be dropped by OPA.
 	addV0CompatibleFlag(testCommand.Flags(), &testParams.v0Compatible, false)
 	addV1CompatibleFlag(testCommand.Flags(), &testParams.v1Compatible, false)
 
-	RootCommand.AddCommand(testCommand)
+	root.AddCommand(testCommand)
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -18,14 +18,13 @@ import (
 	"github.com/open-policy-agent/opa/internal/report"
 )
 
-func init() {
-
+func initVersion(root *cobra.Command, brand string) {
 	var check bool
 	var versionCommand = &cobra.Command{
 		Use:   "version",
-		Short: "Print the version of OPA",
-		Long:  "Show version and build information for OPA.",
-		PreRunE: func(cmd *cobra.Command, _ []string) error {
+		Short: `Print the version of ` + brand,
+		Long:  `Show version and build information for ` + brand + `.`,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return env.CmdFlags.CheckEnvironmentVariables(cmd)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -37,8 +36,8 @@ func init() {
 
 	// The version command can also be used to check for the latest released OPA version.
 	// Some tools could use this for feature flagging purposes and hence this option is OFF by-default.
-	versionCommand.Flags().BoolVarP(&check, "check", "c", false, "check for latest OPA release")
-	RootCommand.AddCommand(versionCommand)
+	versionCommand.Flags().BoolVarP(&check, "check", "c", false, "check for latest "+brand+" release")
+	root.AddCommand(versionCommand)
 }
 
 func generateCmdOutput(out io.Writer, check bool) error {

--- a/main.go
+++ b/main.go
@@ -19,7 +19,8 @@ func main() {
 		}
 	}() // orderly shutdown, run all defer routines
 
-	if err := cmd.RootCommand.Execute(); err != nil {
+	root := cmd.Command(nil, "OPA")
+	if err := root.Execute(); err != nil {
 		var e *cmd.ExitError
 		if errors.As(err, &e) {
 			exit = e.Exit


### PR DESCRIPTION
This change allows users that build their own executable or "spin" of OPA to give it a name, and have it reference itself properly in help texts.

It's a vanity thing, but I think some people would appreciate it, hat tip to the international association of pedants.
