### PR TITLE
loader: pass bundle name in AsBundle()

### DIFF
--- a/v1/loader/loader.go
+++ b/v1/loader/loader.go
@@ -284,7 +284,9 @@ func (fl fileLoader) AsBundle(path string) (*bundle.Bundle, error) {
 		WithProcessAnnotations(fl.opts.ProcessAnnotation).
 		WithCapabilities(fl.opts.Capabilities).
 		WithFollowSymlinks(fl.followSymlinks).
-		WithRegoVersion(fl.opts.RegoVersion)
+		WithRegoVersion(fl.opts.RegoVersion).
+		WithLazyLoadingMode(fl.bundleLazyLoading).
+		WithBundleName(path)
 
 	// For bundle directories add the full path in front of module file names
 	// to simplify debugging.


### PR DESCRIPTION
It seems correct to give the bundle a name, after all. It's just metadata.
