### PR TITLE
sdk: options store takes precedence over ext store

### DIFF
--- a/v1/sdk/opa.go
+++ b/v1/sdk/opa.go
@@ -179,12 +179,14 @@ func (opa *OPA) configure(ctx context.Context, bs []byte, ready chan struct{}, b
 	}
 	opts = append(opts, opa.managerOpts...)
 
-	// Plumb in storage for external bundle activation plugin, if registered with bundle.RegisterStore.
+	// Plumb in storage for external bundle activation plugin, if registered with bundle.RegisterStore,
+	// unless the user has passed their own store already.
 	var store storage.Store
-	if bundle.BundleExtStore != nil {
-		store = bundle.BundleExtStore()
-	} else {
+	switch {
+	case opa.store != nil:
 		store = opa.store
+	case bundle.BundleExtStore != nil:
+		store = bundle.BundleExtStore()
 	}
 	manager, err := plugins.New(
 		bs,

--- a/v1/sdk/opa_test.go
+++ b/v1/sdk/opa_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/open-policy-agent/opa/internal/file/archive"
 	"github.com/open-policy-agent/opa/v1/ast"
+	"github.com/open-policy-agent/opa/v1/bundle"
 	"github.com/open-policy-agent/opa/v1/config"
 	"github.com/open-policy-agent/opa/v1/hooks"
 	"github.com/open-policy-agent/opa/v1/logging"
@@ -38,6 +39,8 @@ import (
 	"github.com/open-policy-agent/opa/v1/sdk"
 	sdktest "github.com/open-policy-agent/opa/v1/sdk/test"
 	"github.com/open-policy-agent/opa/v1/server/types"
+	"github.com/open-policy-agent/opa/v1/storage"
+	"github.com/open-policy-agent/opa/v1/storage/inmem"
 	"github.com/open-policy-agent/opa/v1/topdown"
 	"github.com/open-policy-agent/opa/v1/topdown/builtins"
 	"github.com/open-policy-agent/opa/v1/topdown/lineage"
@@ -2979,4 +2982,41 @@ func TestActivateV1Bundles(t *testing.T) {
 	if d.Result != true {
 		t.Errorf("expected result to be true, got %v", d.Result)
 	}
+}
+
+// TestWithOwnStoreVSExtStore asserts that in the SDK setup, a provided
+// store always takes precedence over the extensions store.
+func TestWithOwnStoreVSExtStore(t *testing.T) {
+	bundle.RegisterStoreFunc(inmem.New)
+	t.Cleanup(func() { bundle.RegisterStoreFunc(nil) })
+	ctx := context.Background()
+	opts := sdk.Options{
+		Store: inmem.New(),
+	}
+	store := opts.Store
+	if err := storage.Txn(ctx, store, storage.WriteParams, func(txn storage.Transaction) error {
+		return store.UpsertPolicy(ctx, txn, "pkg", []byte(`package pkg
+p := true
+`))
+	}); err != nil {
+		panic(err)
+	}
+
+	o, err := sdk.New(ctx, opts)
+	if err != nil {
+		panic(err)
+	}
+
+	res, err := o.Decision(ctx, sdk.DecisionOptions{
+		Path: "pkg/p",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	exp := true
+	act := res.Result
+	if diff := cmp.Diff(exp, act); diff != "" {
+		t.Errorf("unexpected result (-want, +got):\n%s", diff)
+	}
+
 }


### PR DESCRIPTION
Rationale is that if the user has passed a store into the SDK, it probably has something in it already, like data and policies.

----

Excellent rationale from @philipaconrad, copied here to make it stand out a bit more:



> Thanks for putting this PR together! The changes here solve a potential "footgun" around using the SDK: if you registered a bundle store func elsewhere, you can wind up with 2x stores (one the user passed in, and one created by the store func for bundle storage)! 😨

> That behavior is obviously surprising when you're using the SDK and populating the store yourself, so this change brings management of stores more into line with what users might expect: if they pass in a storage.Store instance, that's what gets used, and if they don't provide a choice, they get whatever default is available. (The bundle storage func gets invoked, or OPA makes them a new inmem store behind the scenes.)
