### PR TITLE
runtime: Update server init check in runtime tests

### DIFF
--- a/v1/runtime/runtime_test.go
+++ b/v1/runtime/runtime_test.go
@@ -618,11 +618,7 @@ p contains 1 if {
 				go rt.StartServer(ctx)
 
 				if !test.Eventually(t, 5*time.Second, func() bool {
-					found := false
-					for _, e := range testLogger.Entries() {
-						found = strings.Contains(e.Message, "Server initialized.") || found
-					}
-					return found
+					return rt.ServerStatus() == ServerInitialized && len(rt.Addrs()) > 0
 				}) {
 					t.Fatal("Timed out waiting for server to start")
 				}
@@ -1816,11 +1812,7 @@ func TestCustomHandlerFlusher(t *testing.T) {
 			}
 			go rt.StartServer(ctx)
 			if !test.Eventually(t, 5*time.Second, func() bool {
-				found := false
-				for _, e := range testLogger.Entries() {
-					found = strings.Contains(e.Message, "Server initialized.") || found
-				}
-				return found
+				return rt.ServerStatus() == ServerInitialized && len(rt.Addrs()) > 0
 			}) {
 				t.Fatal("Timed out waiting for server to start")
 			}
@@ -2024,11 +2016,7 @@ func TestCustomStoreBuilder(t *testing.T) {
 	}
 	go rt.StartServer(ctx)
 	if !test.Eventually(t, 5*time.Second, func() bool {
-		found := false
-		for _, e := range testLogger.Entries() {
-			found = strings.Contains(e.Message, "Server initialized.") || found
-		}
-		return found
+		return rt.ServerStatus() == ServerInitialized && len(rt.Addrs()) > 0
 	}) {
 		t.Fatal("Timed out waiting for server to start")
 	}
@@ -2079,11 +2067,7 @@ func TestExtraMiddleware(t *testing.T) {
 	}))
 	go rt.StartServer(ctx)
 	if !test.Eventually(t, 5*time.Second, func() bool {
-		found := false
-		for _, e := range testLogger.Entries() {
-			found = strings.Contains(e.Message, "Server initialized.") || found
-		}
-		return found
+		return rt.ServerStatus() == ServerInitialized && len(rt.Addrs()) > 0
 	}) {
 		t.Fatal("Timed out waiting for server to start")
 	}
@@ -2158,11 +2142,7 @@ allow if {
 	})
 	go rt.StartServer(ctx)
 	if !test.Eventually(t, 5*time.Second, func() bool {
-		found := false
-		for _, e := range testLogger.Entries() {
-			found = strings.Contains(e.Message, "Server initialized.") || found
-		}
-		return found
+		return rt.ServerStatus() == ServerInitialized && len(rt.Addrs()) > 0
 	}) {
 		t.Fatal("Timed out waiting for server to start")
 	}


### PR DESCRIPTION
I saw a panic here: https://github.com/open-policy-agent/opa/actions/runs/16652495113/job/47128828522 and think it's related to the server init check returning before the addrs are set.

I update all cases where a similar check on logs is done.

I am unsure how the log could come before the server is initialized, but sometimes funny things happen in race detector ordering and this looks more correct to me.