### PR TITLE
perf: fix issue in Object.Insert on existing key

### DIFF
--- a/v1/ast/fuzz_test.go
+++ b/v1/ast/fuzz_test.go
@@ -6,15 +6,18 @@
 package ast
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/open-policy-agent/opa/v1/test/cases"
 )
 
-var testcases = cases.MustLoad("../test/cases/testdata").Sorted().Cases
+var testcases = sync.OnceValue(func() []cases.TestCase {
+	return cases.MustLoad("../test/cases/testdata").Sorted().Cases
+})
 
 func FuzzCompileModules(f *testing.F) {
-	for _, tc := range testcases {
+	for _, tc := range testcases() {
 		for _, mod := range tc.Modules {
 			f.Add(mod)
 		}
@@ -26,7 +29,7 @@ func FuzzCompileModules(f *testing.F) {
 }
 
 func FuzzCompileModulesWithPrintAndAllFutureKWs(f *testing.F) {
-	for _, tc := range testcases {
+	for _, tc := range testcases() {
 		for _, mod := range tc.Modules {
 			f.Add(mod)
 		}


### PR DESCRIPTION
Experimenting with using an ast.Object for a cache in Regal led me to find this, and to rule out that idea until this is released :)

The `.rehash()` method would consistently allocate a new slice for hashes, making it more expensive to add a new value to an existing key than inserting a new key-value pair! Added benchmarks to verify.

Before:
```
BenchmarkObjectInsert
existing_key_and_value-12   126126	      8923 ns/op	   19200 B/op	     200 allocs/op
existing_key,_new_value-12  129670	      9024 ns/op	   19200 B/op	     200 allocs/op
new_key-12                  244428	      5016 ns/op	    2400 B/op	     100 allocs/op
new_key,_new_value-12       220352	      5172 ns/op	    2400 B/op	     100 allocs/op
```

After:
```
existing_key_and_value-12   261966	      4610 ns/op	       0 B/op	       0 allocs/op
existing_key,_new_value-12  263820	      4608 ns/op	       0 B/op	       0 allocs/op
new_key-12                  320822	      3692 ns/op	    2400 B/op	     100 allocs/op
new_key,_new_value-12       319423	      3696 ns/op	    2400 B/op	     100 allocs/op
```
