### PR TITLE
v1/plugins: Address race in config access

### DIFF
--- a/v1/plugins/bundle/plugin.go
+++ b/v1/plugins/bundle/plugin.go
@@ -451,8 +451,8 @@ func (p *Plugin) newDownloader(name string, source *Source, bundles map[string]*
 	}
 	if strings.ToLower(client.Config().Type) == "oci" {
 		ociStorePath := filepath.Join(os.TempDir(), "opa", "oci") // use temporary folder /tmp/opa/oci
-		if p.manager.Config.PersistenceDirectory != nil {
-			ociStorePath = filepath.Join(*p.manager.Config.PersistenceDirectory, "oci")
+		if p.manager.GetConfig().PersistenceDirectory != nil {
+			ociStorePath = filepath.Join(*p.manager.GetConfig().PersistenceDirectory, "oci")
 		}
 		return download.NewOCI(conf, client, path, ociStorePath).
 			WithCallback(callback).
@@ -646,7 +646,7 @@ func (p *Plugin) activate(ctx context.Context, name string, b *bundle.Bundle, is
 			isAuthzEnabled := p.manager.Info.Get(ast.StringTerm("authorization_enabled"))
 
 			if ast.BooleanTerm(true).Equal(isAuthzEnabled) && ast.BooleanTerm(false).Equal(skipKnownSchemaCheck) {
-				authorizationDecisionRef, err := ref.ParseDataPath(*p.manager.Config.DefaultAuthorizationDecision)
+				authorizationDecisionRef, err := ref.ParseDataPath(*p.manager.GetConfig().DefaultAuthorizationDecision)
 				if err != nil {
 					return err
 				}
@@ -756,7 +756,7 @@ func (p *Plugin) log(name string) logging.Logger {
 }
 
 func (p *Plugin) getBundlePersistPath() (string, error) {
-	persistDir, err := p.manager.Config.GetPersistenceDirectory()
+	persistDir, err := p.manager.GetConfig().GetPersistenceDirectory()
 	if err != nil {
 		return "", err
 	}

--- a/v1/plugins/bundle/plugin_test.go
+++ b/v1/plugins/bundle/plugin_test.go
@@ -706,7 +706,7 @@ func TestPluginOneShotWithAuthzSchemaVerificationNonDefaultAuthzPath(t *testing.
 	manager := getTestManager()
 
 	s := "/foo/authz/allow"
-	manager.Config.DefaultAuthorizationDecision = &s
+	manager.GetConfig().DefaultAuthorizationDecision = &s
 
 	info, err := runtime.Term(runtime.Params{Config: nil, IsAuthorizationEnabled: true})
 	if err != nil {
@@ -4900,7 +4900,7 @@ func TestSaveBundleToDiskNewConfiguredPersistDir(t *testing.T) {
 	dir := t.TempDir()
 
 	manager := getTestManager()
-	manager.Config.PersistenceDirectory = &dir
+	manager.GetConfig().PersistenceDirectory = &dir
 	bundles := map[string]*Source{}
 	plugin := New(&Config{Bundles: bundles}, manager)
 
@@ -5166,7 +5166,7 @@ func TestConfiguredBundlePersistPath(t *testing.T) {
 
 	persistPath := "/var/opa"
 	manager := getTestManager()
-	manager.Config.PersistenceDirectory = &persistPath
+	manager.GetConfig().PersistenceDirectory = &persistPath
 	plugin := New(&Config{}, manager)
 
 	path, err := plugin.getBundlePersistPath()

--- a/v1/plugins/discovery/discovery_test.go
+++ b/v1/plugins/discovery/discovery_test.go
@@ -230,7 +230,7 @@ func TestEnvVarSubstitution(t *testing.T) {
 		t.Fatalf("Expected exactly three start events but got %v", ps)
 	}
 
-	actualConfig, err := manager.Config.ActiveConfig()
+	actualConfig, err := manager.GetConfig().ActiveConfig()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -290,7 +290,7 @@ decision_logs := {} if { 3 == 3 }
 		t.Fatalf("Expected exactly three start events but got %v", ps)
 	}
 
-	actualConfig, err := manager.Config.ActiveConfig()
+	actualConfig, err := manager.GetConfig().ActiveConfig()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -329,7 +329,7 @@ decision_logs.partition_name := "bar" if { 3 == 3 }
 		t.Fatalf("Expected exactly three start events but got %v", ps)
 	}
 
-	actualConfig, err = manager.Config.ActiveConfig()
+	actualConfig, err = manager.GetConfig().ActiveConfig()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -431,7 +431,7 @@ func TestProcessBundleWithActiveConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	actual, err := manager.Config.ActiveConfig()
+	actual, err := manager.GetConfig().ActiveConfig()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -496,7 +496,7 @@ func TestProcessBundleWithActiveConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	actual, err = manager.Config.ActiveConfig()
+	actual, err = manager.GetConfig().ActiveConfig()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -619,7 +619,7 @@ func TestStartWithBundlePersistence(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	manager.Config.PersistenceDirectory = &dir
+	manager.GetConfig().PersistenceDirectory = &dir
 
 	testPlugin := &reconfigureTestPlugin{counts: map[string]int{}}
 	testFactory := testFactory{p: testPlugin}
@@ -1370,7 +1370,7 @@ func TestSaveBundleToDiskNewConfiguredPersistDir(t *testing.T) {
 	}
 
 	// configure persistence dir instead of using the default. Discover plugin should pick this up
-	manager.Config.PersistenceDirectory = &dir
+	manager.GetConfig().PersistenceDirectory = &dir
 
 	testPlugin := &reconfigureTestPlugin{counts: map[string]int{}}
 	testFactory := testFactory{p: testPlugin}
@@ -1474,11 +1474,11 @@ func TestReconfigure(t *testing.T) {
 	// Verify decision ids set
 	expDecision := ast.MustParseTerm("data.bar.baz")
 	expAuthzDecision := ast.MustParseTerm("data.baz.qux")
-	if !manager.Config.DefaultDecisionRef().Equal(expDecision.Value) {
-		t.Errorf("Expected default decision to be %v but got %v", expDecision, manager.Config.DefaultDecisionRef())
+	if !manager.GetConfig().DefaultDecisionRef().Equal(expDecision.Value) {
+		t.Errorf("Expected default decision to be %v but got %v", expDecision, manager.GetConfig().DefaultDecisionRef())
 	}
-	if !manager.Config.DefaultAuthorizationDecisionRef().Equal(expAuthzDecision.Value) {
-		t.Errorf("Expected default authz decision to be %v but got %v", expAuthzDecision, manager.Config.DefaultAuthorizationDecisionRef())
+	if !manager.GetConfig().DefaultAuthorizationDecisionRef().Equal(expAuthzDecision.Value) {
+		t.Errorf("Expected default authz decision to be %v but got %v", expAuthzDecision, manager.GetConfig().DefaultAuthorizationDecisionRef())
 	}
 
 	// Verify plugins started
@@ -1576,11 +1576,11 @@ plugins.test_plugin := v if {
 	// Verify decision ids set
 	expDecision := ast.MustParseTerm("data.bar.baz")
 	expAuthzDecision := ast.MustParseTerm("data.baz.qux")
-	if !manager.Config.DefaultDecisionRef().Equal(expDecision.Value) {
-		t.Errorf("Expected default decision to be %v but got %v", expDecision, manager.Config.DefaultDecisionRef())
+	if !manager.GetConfig().DefaultDecisionRef().Equal(expDecision.Value) {
+		t.Errorf("Expected default decision to be %v but got %v", expDecision, manager.GetConfig().DefaultDecisionRef())
 	}
-	if !manager.Config.DefaultAuthorizationDecisionRef().Equal(expAuthzDecision.Value) {
-		t.Errorf("Expected default authz decision to be %v but got %v", expAuthzDecision, manager.Config.DefaultAuthorizationDecisionRef())
+	if !manager.GetConfig().DefaultAuthorizationDecisionRef().Equal(expAuthzDecision.Value) {
+		t.Errorf("Expected default authz decision to be %v but got %v", expAuthzDecision, manager.GetConfig().DefaultAuthorizationDecisionRef())
 	}
 
 	// Verify plugins started
@@ -1717,11 +1717,11 @@ plugins.test_plugin := v if {
 	// Verify decision ids set
 	expDecision := ast.MustParseTerm("data.bar.baz")
 	expAuthzDecision := ast.MustParseTerm("data.baz.qux")
-	if !manager.Config.DefaultDecisionRef().Equal(expDecision.Value) {
-		t.Errorf("Expected default decision to be %v but got %v", expDecision, manager.Config.DefaultDecisionRef())
+	if !manager.GetConfig().DefaultDecisionRef().Equal(expDecision.Value) {
+		t.Errorf("Expected default decision to be %v but got %v", expDecision, manager.GetConfig().DefaultDecisionRef())
 	}
-	if !manager.Config.DefaultAuthorizationDecisionRef().Equal(expAuthzDecision.Value) {
-		t.Errorf("Expected default authz decision to be %v but got %v", expAuthzDecision, manager.Config.DefaultAuthorizationDecisionRef())
+	if !manager.GetConfig().DefaultAuthorizationDecisionRef().Equal(expAuthzDecision.Value) {
+		t.Errorf("Expected default authz decision to be %v but got %v", expAuthzDecision, manager.GetConfig().DefaultAuthorizationDecisionRef())
 	}
 
 	// Verify plugins started
@@ -1842,8 +1842,8 @@ func TestReconfigureWithLocalOverride(t *testing.T) {
 	disco.oneShot(ctx, download.Update{Bundle: serviceBundle})
 
 	expAuthzRule := "/http/example/system/allow"
-	if *manager.Config.DefaultAuthorizationDecision != expAuthzRule {
-		t.Errorf("Expected default authorization decision %v but got %v", expAuthzRule, *manager.Config.DefaultAuthorizationDecision)
+	if *manager.GetConfig().DefaultAuthorizationDecision != expAuthzRule {
+		t.Errorf("Expected default authorization decision %v but got %v", expAuthzRule, *manager.GetConfig().DefaultAuthorizationDecision)
 	}
 
 	// `default_decision` is specified in both boot and service config. The former should take precedence.
@@ -1864,8 +1864,8 @@ func TestReconfigureWithLocalOverride(t *testing.T) {
 	}
 
 	expAuthzRule = "/http/example/authz/allow"
-	if *manager.Config.DefaultDecision != expAuthzRule {
-		t.Fatalf("Expected default decision %v but got %v", expAuthzRule, *manager.Config.DefaultDecision)
+	if *manager.GetConfig().DefaultDecision != expAuthzRule {
+		t.Fatalf("Expected default decision %v but got %v", expAuthzRule, *manager.GetConfig().DefaultDecision)
 	}
 
 	// `nd_builtin_cache` is specified in both boot and service config. The former should take precedence.
@@ -1885,7 +1885,7 @@ func TestReconfigureWithLocalOverride(t *testing.T) {
 		t.Fatal("expected key \"nd_builtin_cache\" to be overridden")
 	}
 
-	if manager.Config.NDBuiltinCache {
+	if manager.GetConfig().NDBuiltinCache {
 		t.Fatal("Expected nd_builtin_cache value to be false")
 	}
 
@@ -1900,7 +1900,7 @@ func TestReconfigureWithLocalOverride(t *testing.T) {
 
 	disco.oneShot(ctx, download.Update{Bundle: serviceBundle})
 
-	if manager.Config.PersistenceDirectory == nil || *manager.Config.PersistenceDirectory != "test" {
+	if manager.GetConfig().PersistenceDirectory == nil || *manager.GetConfig().PersistenceDirectory != "test" {
 		t.Fatal("Unexpected update to persistence directory")
 	}
 
@@ -1979,7 +1979,7 @@ func TestReconfigureWithLocalOverride(t *testing.T) {
 		}
 	}
 
-	cacheConf, err := cache.ParseCachingConfig(manager.Config.Caching)
+	cacheConf, err := cache.ParseCachingConfig(manager.GetConfig().Caching)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2030,7 +2030,7 @@ func TestReconfigureWithLocalOverride(t *testing.T) {
 	disco.oneShot(ctx, download.Update{Bundle: serviceBundle})
 
 	var dtConfig map[string]any
-	err = util.Unmarshal(manager.Config.DistributedTracing, &dtConfig)
+	err = util.Unmarshal(manager.GetConfig().DistributedTracing, &dtConfig)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2644,10 +2644,10 @@ func TestReconfigureWithUpdates(t *testing.T) {
 		t.Fatalf("Unexpected error %v", err)
 	}
 
-	if manager.Config.PersistenceDirectory == nil {
+	if manager.GetConfig().PersistenceDirectory == nil {
 		t.Fatal("Erased persistence directory configuration")
 	}
-	if manager.Config.Discovery == nil {
+	if manager.GetConfig().Discovery == nil {
 		t.Fatal("Erased discovery plugin configuration")
 	}
 
@@ -2665,7 +2665,7 @@ func TestReconfigureWithUpdates(t *testing.T) {
 		t.Fatalf("Unexpected error %v", err)
 	}
 
-	if manager.Config.PersistenceDirectory == nil || *manager.Config.PersistenceDirectory == "my_bundles" {
+	if manager.GetConfig().PersistenceDirectory == nil || *manager.GetConfig().PersistenceDirectory == "my_bundles" {
 		t.Fatal("Unexpected update to persistence directory")
 	}
 }
@@ -3317,7 +3317,7 @@ bundle:
 `
 	manager := getTestManager(t, conf)
 	trigger := plugins.TriggerManual
-	_, err := getPluginSet(nil, manager, manager.Config, nil, nil, &trigger)
+	_, err := getPluginSet(nil, manager, manager.GetConfig(), nil, nil, &trigger)
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}
@@ -3354,7 +3354,7 @@ bundles:
 `
 	manager := getTestManager(t, conf)
 	trigger := plugins.TriggerManual
-	_, err := getPluginSet(nil, manager, manager.Config, nil, nil, &trigger)
+	_, err := getPluginSet(nil, manager, manager.GetConfig(), nil, nil, &trigger)
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}
@@ -3414,7 +3414,7 @@ bundles:
 
 			manager := getTestManager(t, tc.conf)
 			trigger := plugins.TriggerManual
-			_, err := getPluginSet(nil, manager, manager.Config, nil, nil, &trigger)
+			_, err := getPluginSet(nil, manager, manager.GetConfig(), nil, nil, &trigger)
 
 			if tc.wantErr {
 				if err == nil {
@@ -3479,7 +3479,7 @@ decision_logs:
 
 			manager := getTestManager(t, tc.conf)
 			trigger := plugins.TriggerManual
-			_, err := getPluginSet(nil, manager, manager.Config, nil, nil, &trigger)
+			_, err := getPluginSet(nil, manager, manager.GetConfig(), nil, nil, &trigger)
 
 			if tc.wantErr {
 				if err == nil {
@@ -3550,7 +3550,7 @@ status:
 
 			manager := getTestManager(t, tc.conf)
 			trigger := plugins.TriggerManual
-			_, err := getPluginSet(nil, manager, manager.Config, nil, nil, &trigger)
+			_, err := getPluginSet(nil, manager, manager.GetConfig(), nil, nil, &trigger)
 
 			if tc.wantErr {
 				if err == nil {

--- a/v1/plugins/plugins_test.go
+++ b/v1/plugins/plugins_test.go
@@ -49,7 +49,7 @@ func TestManagerCacheTriggers(t *testing.T) {
 		t.Fatal("Listeners should not be called yet")
 	}
 
-	err = m.Reconfigure(m.Config)
+	err = m.Reconfigure(m.GetConfig())
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}
@@ -87,7 +87,7 @@ func TestManagerNDCacheTriggers(t *testing.T) {
 		t.Fatal("Listeners should not be called yet")
 	}
 
-	err = m.Reconfigure(m.Config)
+	err = m.Reconfigure(m.GetConfig())
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}
@@ -310,8 +310,8 @@ func TestManagerWithNDCachingConfig(t *testing.T) {
 	}
 
 	expected := true
-	if !m.Config.NDBuiltinCache == expected {
-		t.Fatalf("want %+v got %+v", expected, m.Config.NDBuiltinCache)
+	if !m.GetConfig().NDBuiltinCache == expected {
+		t.Fatalf("want %+v got %+v", expected, m.GetConfig().NDBuiltinCache)
 	}
 
 	// config error

--- a/v1/runtime/runtime.go
+++ b/v1/runtime/runtime.go
@@ -661,7 +661,7 @@ func (rt *Runtime) Serve(ctx context.Context) error {
 
 	// If decision_logging plugin enabled, check to see if we opted in to the ND builtins cache.
 	if lp := logs.Lookup(rt.Manager); lp != nil {
-		rt.server = rt.server.WithNDBCacheEnabled(rt.Params.NDBCacheEnabled || rt.Manager.Config.NDBuiltinCacheEnabled())
+		rt.server = rt.server.WithNDBCacheEnabled(rt.Params.NDBCacheEnabled || rt.Manager.GetConfig().NDBuiltinCacheEnabled())
 	}
 
 	if rt.Params.DiagnosticAddrs != nil {
@@ -1065,7 +1065,7 @@ func generateDecisionID() string {
 }
 
 func verifyAuthorizationPolicySchema(m *plugins.Manager) error {
-	authorizationDecisionRef, err := ref.ParseDataPath(*m.Config.DefaultAuthorizationDecision)
+	authorizationDecisionRef, err := ref.ParseDataPath(*m.GetConfig().DefaultAuthorizationDecision)
 	if err != nil {
 		return err
 	}

--- a/v1/runtime/runtime_test.go
+++ b/v1/runtime/runtime_test.go
@@ -1481,7 +1481,7 @@ func TestUrlPathToConfigOverride(t *testing.T) {
 	}
 
 	var serviceConf map[string]any
-	if err = json.Unmarshal(rt.Manager.Config.Services, &serviceConf); err != nil {
+	if err = json.Unmarshal(rt.Manager.GetConfig().Services, &serviceConf); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1495,7 +1495,7 @@ func TestUrlPathToConfigOverride(t *testing.T) {
 	}
 
 	var bundleConf map[string]any
-	if err = json.Unmarshal(rt.Manager.Config.Bundles, &bundleConf); err != nil {
+	if err = json.Unmarshal(rt.Manager.GetConfig().Bundles, &bundleConf); err != nil {
 		t.Fatal(err)
 	}
 

--- a/v1/sdk/opa.go
+++ b/v1/sdk/opa.go
@@ -394,7 +394,7 @@ func (opa *OPA) executeTransaction(ctx context.Context, record *server.Info, wor
 	}
 
 	if record.Path == "" {
-		record.Path = *s.manager.Config.DefaultDecision
+		record.Path = *s.manager.GetConfig().DefaultDecision
 	}
 
 	record.Txn, record.Error = s.manager.Store.NewTransaction(ctx, storage.TransactionParams{})

--- a/v1/server/server.go
+++ b/v1/server/server.go
@@ -764,7 +764,7 @@ func (s *Server) initHandlerAuthz(handler http.Handler) http.Handler {
 			s.getCompiler,
 			s.store,
 			authorizer.Runtime(s.runtime),
-			authorizer.Decision(s.manager.Config.DefaultAuthorizationDecisionRef),
+			authorizer.Decision(s.manager.GetConfig().DefaultAuthorizationDecisionRef),
 			authorizer.PrintHook(s.manager.PrintHook()),
 			authorizer.EnablePrintStatements(s.manager.EnablePrintStatements()),
 			authorizer.InterQueryCache(s.interQueryBuiltinCache),
@@ -784,7 +784,7 @@ func (s *Server) initHandlerAuthz(handler http.Handler) http.Handler {
 // context.
 func (s *Server) initHandlerDecodingLimits(handler http.Handler) (http.Handler, error) {
 	var decodingRawConfig json.RawMessage
-	serverConfig := s.manager.Config.Server
+	serverConfig := s.manager.GetConfig().Server
 	if serverConfig != nil {
 		decodingRawConfig = serverConfig.Decoding
 	}
@@ -799,7 +799,7 @@ func (s *Server) initHandlerDecodingLimits(handler http.Handler) (http.Handler, 
 
 func (s *Server) initHandlerCompression(handler http.Handler) (http.Handler, error) {
 	var encodingRawConfig json.RawMessage
-	serverConfig := s.manager.Config.Server
+	serverConfig := s.manager.GetConfig().Server
 	if serverConfig != nil {
 		encodingRawConfig = serverConfig.Encoding
 	}
@@ -2387,7 +2387,7 @@ func (s *Server) v1QueryPost(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) v1ConfigGet(w http.ResponseWriter, r *http.Request) {
-	result, err := s.manager.Config.ActiveConfig()
+	result, err := s.manager.GetConfig().ActiveConfig()
 	if err != nil {
 		writer.ErrorAuto(w, err)
 		return
@@ -2730,7 +2730,7 @@ func (s *Server) hasLegacyBundle(br bundleRevisions) bool {
 
 func (s *Server) generateDefaultDecisionPath() string {
 	// Assume the path is safe to transition back to a url
-	p, _ := s.manager.Config.DefaultDecisionRef().Ptr()
+	p, _ := s.manager.GetConfig().DefaultDecisionRef().Ptr()
 	return p
 }
 


### PR DESCRIPTION
I ran into this race condition on another PR:

https://github.com/open-policy-agent/opa/actions/runs/16655603110/job/47139789057

I _think_ we don't need to worry about the config being read after it's accessed from GetConfig since it'll be a pointer to the old config if it's updated on the manager in the meantime.
