### PR TITLE
handlers: add thread-safe initialization for gzipPool

### DIFF
--- a/v1/server/handlers/compress.go
+++ b/v1/server/handlers/compress.go
@@ -141,10 +141,16 @@ func (w *compressResponseWriter) Close() error {
 	}
 
 	err := w.gzipWriter.Close()
+	if err != nil {
+		return err
+	}
+
 	gzipPoolMutex.RLock()
-	defer gzipPool.Put(w.gzipWriter)
+	gzipPool.Put(w.gzipWriter)
 	gzipPoolMutex.RUnlock()
+
 	w.gzipWriter = nil
+
 	return err
 }
 


### PR DESCRIPTION
Fixes race condition in initGzipPool() that was causing go race test failures when multiple tests run concurrently. The package-level gzipPool variable was being unsafely reassigned across without synchronization.

RWMutex ensures that the gzipPool is only initialized once.
