### PR TITLE
config: accept env vars set to "", discern from unset

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -138,7 +138,8 @@ func subEnvVars(s string) string {
 		// Lookup the variable in the environment. We do not
 		// play by bash rules: if its undefined we'll keep it
 		// as-is, it could be replaced somewhere down the line.
-		if lu := os.Getenv(varName); lu != "" {
+		// If it's set to "", we'll return that.
+		if lu, ok := os.LookupEnv(varName); ok {
 			return lu
 		}
 		return s

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -96,7 +96,7 @@ func TestSubEnvVarsVarsSubMissingEnvVar(t *testing.T) {
 	envKey := setTestEnvVar(t, "var1", "foo")
 	configYaml := fmt.Sprintf("field1: '${%s}'", envKey)
 
-	// Remove the env var and expect the system to sub in ""
+	// Remove the env var and expect the system to keep the key as-is
 	os.Unsetenv(envKey)
 	expected := configYaml // untouched
 
@@ -109,6 +109,20 @@ func TestSubEnvVarsVarsSubMissingEnvVar(t *testing.T) {
 
 func TestSubEnvVarsVarsSubEmptyVarName(t *testing.T) {
 	configYaml := "field1: '${}'"
+	expected := "field1: ''"
+
+	actual := subEnvVars(configYaml)
+
+	if actual != expected {
+		t.Errorf("Expected: '%s'\nActual: '%s'", expected, actual)
+	}
+}
+
+func TestSubEnvVarsVarsSubEmptyEnvVar(t *testing.T) {
+	envKey := setTestEnvVar(t, "var1", "foo")
+	configYaml := fmt.Sprintf("field1: '${%s}'", envKey)
+
+	t.Setenv(envKey, "")
 	expected := "field1: ''"
 
 	actual := subEnvVars(configYaml)


### PR DESCRIPTION
This means that explicitly-set-to-empty string env vars will behave like they did before.

Fixes #7831 to a certain extent.
