### PR TITLE
cmd: Add --data flag to opa inspect command

### DIFF
--- a/cmd/inspect_data_flag_test.go
+++ b/cmd/inspect_data_flag_test.go
@@ -1,0 +1,154 @@
+// Copyright 2024 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestInspectDataFlag(t *testing.T) {
+	tests := []struct {
+		name        string
+		files       map[string]string
+		dataPaths   []string
+		wantErr     bool
+		errContains string
+		wantOutput  []string
+	}{
+		{
+			name: "inspect single json data file",
+			files: map[string]string{
+				"data.json": `{"users": {"alice": {"role": "admin"}}}`,
+			},
+			dataPaths: []string{"data.json"},
+			wantOutput: []string{
+				"NAMESPACES:",
+				"data",
+				"data.json",
+			},
+		},
+		{
+			name: "inspect single yaml data file",
+			files: map[string]string{
+				"config.yaml": `
+users:
+  alice:
+    role: admin
+`,
+			},
+			dataPaths: []string{"config.yaml"},
+			wantOutput: []string{
+				"NAMESPACES:",
+				"data",
+				"config.yaml",
+			},
+		},
+		{
+			name: "inspect multiple data files",
+			files: map[string]string{
+				"data1.json": `{"key1": "value1"}`,
+				"data2.json": `{"key2": "value2"}`,
+			},
+			dataPaths: []string{"data1.json", "data2.json"},
+			wantOutput: []string{
+				"NAMESPACES:",
+				"data",
+				"data1.json",
+				"data2.json",
+			},
+		},
+		{
+			name: "error on non-data file",
+			files: map[string]string{
+				"policy.rego": `package test`,
+			},
+			dataPaths:   []string{"policy.rego"},
+			wantErr:     true,
+			errContains: "is not a JSON or YAML data file",
+		},
+		{
+			name:        "error on non-existent file",
+			files:       map[string]string{},
+			dataPaths:   []string{"missing.json"},
+			wantErr:     true,
+			errContains: "error accessing path",
+		},
+		{
+			name: "inspect directory with --data flag",
+			files: map[string]string{
+				"bundle/data.json": `{"foo": "bar"}`,
+				"bundle/.manifest": `{"revision": "test"}`,
+			},
+			dataPaths: []string{"bundle"},
+			wantOutput: []string{
+				"MANIFEST:",
+				"Revision",
+				"test",
+				"NAMESPACES:",
+				"data",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create temporary directory
+			tempDir := t.TempDir()
+
+			// Create test files
+			for path, content := range tt.files {
+				fullPath := filepath.Join(tempDir, path)
+				dir := filepath.Dir(fullPath)
+				if err := os.MkdirAll(dir, 0755); err != nil {
+					t.Fatalf("failed to create directory: %v", err)
+				}
+				if err := os.WriteFile(fullPath, []byte(content), 0644); err != nil {
+					t.Fatalf("failed to write file: %v", err)
+				}
+			}
+
+			// Change to temp directory
+			oldWd, _ := os.Getwd()
+			os.Chdir(tempDir)
+			defer os.Chdir(oldWd)
+
+			// Create params with data paths
+			params := newInspectCommandParams()
+			for _, p := range tt.dataPaths {
+				params.dataPaths.Set(p)
+			}
+
+			var out bytes.Buffer
+			err := doInspect(params, "", &out)
+
+			// Check error
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error but got none")
+				} else if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("expected error containing %q, got %q", tt.errContains, err.Error())
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			// Check output
+			output := out.String()
+			for _, want := range tt.wantOutput {
+				if !strings.Contains(output, want) {
+					t.Errorf("expected output to contain %q, got:\n%s", want, output)
+				}
+			}
+		})
+	}
+}

--- a/cmd/inspect_validation_test.go
+++ b/cmd/inspect_validation_test.go
@@ -1,0 +1,76 @@
+// Copyright 2024 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateInspectParams(t *testing.T) {
+	tests := []struct {
+		name        string
+		params      inspectCommandParams
+		args        []string
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:   "valid single path",
+			params: newInspectCommandParams(),
+			args:   []string{"bundle.tar.gz"},
+		},
+		{
+			name:   "error on no arguments and no data flag",
+			params: newInspectCommandParams(),
+			args:   []string{},
+			wantErr: true,
+			errContains: "specify exactly one OPA bundle or path",
+		},
+		{
+			name:   "error on multiple path arguments",
+			params: newInspectCommandParams(),
+			args:   []string{"path1", "path2"},
+			wantErr: true,
+			errContains: "specify exactly one OPA bundle or path",
+		},
+		{
+			name: "valid data flag with no args",
+			params: func() inspectCommandParams {
+				p := newInspectCommandParams()
+				p.dataPaths.Set("data.json")
+				return p
+			}(),
+			args: []string{},
+		},
+		{
+			name: "error on mixing data flag with path arg",
+			params: func() inspectCommandParams {
+				p := newInspectCommandParams()
+				p.dataPaths.Set("data.json")
+				return p
+			}(),
+			args: []string{"bundle.tar.gz"},
+			wantErr: true,
+			errContains: "specify either a bundle/path argument or --data flag, not both",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateInspectParams(&tt.params, tt.args)
+			
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error but got none")
+				} else if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("expected error containing %q, got %q", tt.errContains, err.Error())
+				}
+			} else if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
This PR addresses issue #6879 by adding a `--data` flag to the `opa inspect` command, allowing users to inspect individual data files (JSON/YAML) directly without needing to bundle them first.

## What changed?
- Added `--data` flag to the `opa inspect` command that accepts one or more data files
- Users can now inspect JSON/YAML data files directly: `opa inspect --data data.json`
- Multiple files can be inspected: `opa inspect --data file1.json --data file2.yaml`
- For directories, the existing bundle inspection logic is used
- The flag is mutually exclusive with path arguments to avoid confusion

## Implementation details
- Reused the existing `repeatedStringFlag` type from `eval.go` for consistency
- Added `inspectDataFiles()` function to handle data file inspection
- Updated command usage and help text to document the new functionality
- Added comprehensive test coverage for both functionality and validation

## Testing
- Added `TestInspectDataFlag` with tests for:
  - Single JSON file inspection
  - Single YAML file inspection  
  - Multiple data files with repeated --data flags
  - Error handling for non-data files
  - Error handling for non-existent files
  - Directory inspection with --data flag
- Added `TestValidateInspectParams` to test parameter validation
- All existing inspect tests continue to pass

## Fixes
Fixes #6879

🤖 Generated with [Claude Code](https://claude.ai/code)