### PR TITLE
docs(policy-language.md): Use array instead of set in the code example

### DIFF
--- a/docs/docs/policy-language.md
+++ b/docs/docs/policy-language.md
@@ -525,7 +525,7 @@ package references
 
 import data.example.sites
 
-result := {h| h := sites[i].servers[j].hostname }
+result := [h| h := sites[i].servers[j].hostname]
 ```
 
 <RunSnippet files="#example_data.rego" command="data.references.result"/>


### PR DESCRIPTION
<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/contributing/)
  for high-level contributing guidelines and development setup.
  (See the [Developer Certificate of Origin](https://www.openpolicyagent.org/docs/contrib-code/#developer-certificate-of-origin)
  section for specifics on signing off a commit.)

-->

### Why the changes in this PR are needed?
Mistake in the [Policy Language documentation](https://www.openpolicyagent.org/docs/policy-language#variable-keys).

### What are the changes in this PR?

Creates and array instead of set, because the example mentions "all" instead of "all unique" and the imperative Python code block, that follows, also uses an array.

### Notes to assist PR review:

None.

### Further comments:

None.
