### PR TITLE
docs: Add note on using LLMs in PR discussions

### DIFF
--- a/docs/docs/contrib-code.md
+++ b/docs/docs/contrib-code.md
@@ -145,6 +145,18 @@ the review process. Use your judgement about what constitutes a small Pull
 Request. If you aren't sure, send a message to the OPA slack or post a comment
 on the Pull Request.
 
+:::note
+**Do not** use LLMs to generate responses to maintainer review comments. Reviewers
+are interested in knowing **your** reasoning about the code you submitted for review.
+Even if an LLM helped you write that code, it's yours to own and explain. Engaging an
+AI in discussions with people who took the time to review your code and provide you
+with personal feedback is considered disrespectful and will have your PR rejected.
+
+Don't be afraid to ask for help or clarification during the review process. Don't be
+afraid to get something wrong, or to let us know when you think we are wrong. That's
+how we all learn and grow.
+:::
+
 ### Vulnerability scanning
 
 On each Pull Request, a series of tests will be run to ensure that the code

--- a/docs/docs/contributing.md
+++ b/docs/docs/contributing.md
@@ -35,10 +35,15 @@ If you have an idea for a new feature, we also **request that you file an
 issue** to discuss it first. This again allows you to get feedback from
 the maintainer team and the community before you start working on it.
 
+If you'd like to work on an existing issue that's been stale for quite some time,
+it's a good idea to comment on the issue first to check if it's still relevant, and
+if there are additional details that might have emerged since it was last updated.
+
 If you want to chat to the maintainers before opening an issue or about anything
 else, head over to
 [#contributors](https://openpolicyagent.slack.com/archives/C02L1TLPN59) in
-Slack.
+Slack. This is also a great place to ask for ideas if you want to contribute, but
+aren't sure what to work on!
 
 If you are ready to start contributing code, please see our
 [Contributing Code](./contrib-code/) guide for pointers on how to get


### PR DESCRIPTION
We've seen an increase in AI generated contributions lately, and often where issues have been picked seemingly at random. This change updates the docs on contributing to OPA to address some of the issues we've seen around that.