### PR TITLE
Avoid port exhaustion in concurrent tests

### DIFF
--- a/v1/test/e2e/testing.go
+++ b/v1/test/e2e/testing.go
@@ -82,9 +82,11 @@ func NewTestRuntime(params runtime.Params) (*TestRuntime, error) {
 
 // NewTestRuntimeWithOpts returns a new TestRuntime.
 func NewTestRuntimeWithOpts(opts TestRuntimeOpts, params runtime.Params) (*TestRuntime, error) {
-
 	ctx := context.Background()
 	ctx, cancel := context.WithCancel(ctx)
+
+	// Avoid port exhaustion in concurrent tests: https://github.com/golang/go/issues/16012
+	http.DefaultTransport.(*http.Transport).MaxIdleConnsPerHost = 100
 
 	rt, err := runtime.NewRuntime(ctx, params)
 	if err != nil {
@@ -105,6 +107,9 @@ func NewTestRuntimeWithOpts(opts TestRuntimeOpts, params runtime.Params) (*TestR
 
 // WrapRuntime creates a new TestRuntime by wrapping an existing runtime
 func WrapRuntime(ctx context.Context, cancel context.CancelFunc, rt *runtime.Runtime) *TestRuntime {
+	// Avoid port exhaustion in concurrent tests: https://github.com/golang/go/issues/16012
+	http.DefaultTransport.(*http.Transport).MaxIdleConnsPerHost = 100
+
 	return &TestRuntime{
 		Params:  rt.Params,
 		Runtime: rt,


### PR DESCRIPTION
Running `make test` on a new Macbook Pro could previously fail with errors like "connect: can't assign requested address". This can be alleviated by increasing the range of ports to open, but setting a limit for idle connections in the tests seems like the better solution.

More details in https://github.com/golang/go/issues/16012
