### PR TITLE
Fix #7647 nested comprehension rego_compile_error when print()-ing value

### DIFF
--- a/v1/ast/compile.go
+++ b/v1/ast/compile.go
@@ -2163,6 +2163,15 @@ func rewritePrintCalls(gen *localVarGenerator, getArity func(Ref) int, globals V
 		var errs Errors
 		safe := outputVarsForBody(body[:i], getArity, globals)
 		safe.Update(globals)
+
+		// Fixes Issue #7647 by adding generated variables to the safe set
+		WalkVars(body[:i], func(v Var) bool {
+			if v.IsGenerated() {
+				safe.Add(v)
+			}
+			return false
+		})
+
 		args := body[i].Operands()
 
 		var vis *VarVisitor

--- a/v1/ast/compile_test.go
+++ b/v1/ast/compile_test.go
@@ -7360,6 +7360,39 @@ func TestCompilerRewritePrintCallsErrors(t *testing.T) {
 	}
 }
 
+// Regression test for bug #7647
+// head values in nested comprehensions should not lead to undeclared error.
+func TestCompilterRewritePrintCallsNestedComprehensionLocalsSafe(t *testing.T) {
+	cases := []struct {
+		note   string
+		module string
+	}{
+		{
+			note: "print variable from nested comprehension without error",
+			module: `package test
+		    f(_) := {"a": [1, 2, 3], "b": [4, 5, 6], "c": [7, 8, 9]}
+
+		    p := [v |
+			m := {l | l := f(true)[k]}[_]
+			v := m[_]
+			print(v)
+			]`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.note, func(t *testing.T) {
+			c := NewCompiler().WithEnablePrintStatements(true)
+			c.Compile(map[string]*Module{
+				"test.rego": module(tc.module),
+			})
+			if c.Failed() {
+				t.Fatal("unexpected error:", c.Errors)
+			}
+		})
+	}
+}
+
 func TestCompilerRewritePrintCalls(t *testing.T) {
 	cases := []struct {
 		note   string


### PR DESCRIPTION
### Why the changes in this PR are needed?
#7647 Valid Rego statements were failing due to incomplete safety analysis. Namely wildcards within comprehensions are never added to global safe withing set because comprehension terms are not rewritten until later compiler stages.

### What are the changes in this PR?
Sufficient compiler context is not available without making changes to the function signature of `rewritePrintCalls`.
Instead I opted to mark generated variables safe for  the purposes of print safety checking.
```go
// --nothing changes about the first loop here--
for i := range body {

		if !isPrintCall(body[i]) {
			continue
		}

		modified = true

		var errs Errors
		safe := outputVarsForBody(body[:i], getArity, globals)
		safe.Update(globals)
		
		// Fixes Issue #7647 by adding generated variables to the safe set
		for k := range body[:i] {
			vis := NewVarVisitor().WithParams(SafetyCheckVisitorParams)
			vis.Walk(body[k])
			for v := range vis.Vars() {
				if v.IsGenerated() {
					safe.Add(v)
				}
			}
		}
	        // --Error and rewrite logic stays the same below-- 
```
This is a safe assumption because generated variables at this stage correspond to declarations and definitions of variables. The variable scope is managed by the already implemented logic in `rewritePrintCalls`

### Notes to assist PR review:
New tests were not included, I attempted to write a new test based on a previously failing case:
```rego
package test

f(_) := {"a": [1, 2, 3], "b": [4, 5, 6], "c": [7, 8, 9]}

p := [v |
	m := {l | l := f(true)[k]}[_]
	v := m[_]
	print(v)
]
```
However despite expected and actual strings matching, there is a minute difference in the AST (perhaps the head of the function?)
```
Expected:

    package test
    
    f(__local0__) = {"a": [1, 2, 3], "b": [4, 5, 6], "c": [7, 8, 9]} if { true }
    p := __local7__ if { true; __local7__ = [__local3__ | __local6__ = {__local1__ | data.test.f(true, __local5__); __local1__ = __local5__[k]}; __local2__ = __local6__[_]; __local3__ = __local2__[_]; __local8__ = {__local4__ | __local4__ = __local3__}; internal.print([__local8__])] }
            
Got:
            
    package test
    
    f(__local0__) = {"a": [1, 2, 3], "b": [4, 5, 6], "c": [7, 8, 9]} if { true }
    p := __local7__ if { true; __local7__ = [__local3__ | __local6__ = {__local1__ | data.test.f(true, __local5__); __local1__ = __local5__[k]}; __local2__ = __local6__[_]; __local3__ = __local2__[_]; __local8__ = {__local4__ | __local4__ = __local3__}; internal.print([__local8__])] }
```
There were no regressions in the existing tests. In the interest of reviewing the actual change instead of figuring out how to patching the Expected's AST for this test, I am submitting the PR without this new test. 

### Further comments:

I am not 100% happy with this approach, as it couples us to an subtle assumption about generated variables that could easily change in the future. However this change also avoids redoubling the work that takes place and keeps changes localized to this compiler stage.
