### PR TITLE
github_actions: add working directory in arguments for Link Checker

### DIFF
--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -19,18 +19,20 @@ jobs:
 
     - name: Link Checker
       id: lychee
-      uses: lycheeverse/lychee-action@v2
+      uses: lycheeverse/lychee-action@885c65f3dc543b57c898c8099f4e08c8afd178a2 # v2.6.1
       with:
-        workingDirectory: .
-        args: |
-          --max-concurrency 1 \
-          --no-progress \
-          --exclude-path vendor \
-          --exclude-path internal \
-          --exclude-path CHANGELOG.md \
-          --scheme https \
-          --scheme http \
+        args: >
+          --max-concurrency 1
+          --no-progress
+          --exclude-path vendor
+          --exclude-path internal
+          --exclude-path CHANGELOG.md
+          --scheme https
+          --scheme http
           --accept 200..=206,403,429
+          --retry-wait-time 5
+          --max-retries 1
+          .
         fail: false
 
     - name: Show Report


### PR DESCRIPTION
resolve: https://github.com/open-policy-agent/opa/issues/7815

Test run on my fork: https://github.com/sspaink/opa/actions/runs/17468456584/job/49610340442
Example issue: https://github.com/sspaink/opa/issues/29

Looks like the working directory is required in the `args` now causing the failure. Also:
*  pinning the version as [recommended](https://github.com/lycheeverse/lychee-action?tab=readme-ov-file#security-and-updates)
* limiting the max retries and wait-time to reduce network errors