### PR TITLE
plugin/decision: refactor size buffer into its own type

### DIFF
--- a/v1/plugins/logs/eventBuffer_test.go
+++ b/v1/plugins/logs/eventBuffer_test.go
@@ -55,7 +55,7 @@ func TestEventBuffer_Push(t *testing.T) {
 
 	// Increase the limit, forcing the buffer to change
 	limit = int64(3)
-	b.Reconfigure(limit, rest.Client{}, "", 0)
+	b.Reconfigure(limit, rest.Client{}, "", 0, nil)
 	checkBufferState(t, limit, b, expectedDropped, expectedIds)
 
 	id = "id4"
@@ -72,7 +72,7 @@ func TestEventBuffer_Push(t *testing.T) {
 	checkBufferState(t, limit, b, expectedDropped, expectedIds)
 
 	limit = int64(1)
-	b.Reconfigure(limit, rest.Client{}, "", 0)
+	b.Reconfigure(limit, rest.Client{}, "", 0, nil)
 	// Limit reconfigured from 3->1, dropping 2 more events.
 	expectedDropped = 4
 	delete(expectedIds, "id3")
@@ -80,7 +80,7 @@ func TestEventBuffer_Push(t *testing.T) {
 	checkBufferState(t, limit, b, expectedDropped, expectedIds)
 
 	// Nothing changed
-	b.Reconfigure(limit, rest.Client{}, "", 0)
+	b.Reconfigure(limit, rest.Client{}, "", 0, nil)
 	checkBufferState(t, limit, b, expectedDropped, expectedIds)
 }
 

--- a/v1/plugins/logs/sizeBuffer.go
+++ b/v1/plugins/logs/sizeBuffer.go
@@ -1,0 +1,167 @@
+package logs
+
+import (
+	"context"
+	"encoding/json"
+	"math"
+	"sync"
+
+	"github.com/open-policy-agent/opa/v1/logging"
+	"github.com/open-policy-agent/opa/v1/metrics"
+	"github.com/open-policy-agent/opa/v1/plugins/rest"
+	"golang.org/x/time/rate"
+)
+
+type sizeBuffer struct {
+	mtx                  sync.Mutex
+	buffer               *logBuffer
+	BufferSizeLimitBytes int64
+	UploadSizeLimitBytes int64
+	uploadPath           string        // uploadPath is the configured HTTP resource path for upload
+	client               rest.Client   // client is used to upload the data to the configured service
+	enc                  *chunkEncoder // encoder appends events into the gzip compressed JSON array
+	limiter              *rate.Limiter
+	metrics              metrics.Metrics
+	logger               logging.Logger
+}
+
+func newSizeBuffer(bufferSizeLimitBytes int64, client rest.Client, uploadPath string, uploadSizeLimitBytes int64) *sizeBuffer {
+	return &sizeBuffer{
+		enc:                  newChunkEncoder(uploadSizeLimitBytes),
+		buffer:               newLogBuffer(bufferSizeLimitBytes),
+		BufferSizeLimitBytes: uploadSizeLimitBytes,
+		UploadSizeLimitBytes: uploadSizeLimitBytes,
+		client:               client,
+		uploadPath:           uploadPath,
+	}
+}
+
+func (b *sizeBuffer) WithLimiter(maxDecisionsPerSecond *float64) *sizeBuffer {
+	if maxDecisionsPerSecond != nil {
+		b.limiter = rate.NewLimiter(rate.Limit(*maxDecisionsPerSecond), int(math.Max(1, *maxDecisionsPerSecond)))
+	}
+	return b
+}
+
+func (b *sizeBuffer) WithMetrics(m metrics.Metrics) *sizeBuffer {
+	b.metrics = m
+	b.enc.metrics = m
+	return b
+}
+
+func (b *sizeBuffer) WithLogger(l logging.Logger) *sizeBuffer {
+	b.logger = l
+	b.enc.logger = l
+	return b
+}
+
+func (b *sizeBuffer) incrMetric(name string) {
+	if b.metrics != nil {
+		b.metrics.Counter(name).Incr()
+	}
+}
+
+func (b *sizeBuffer) Reconfigure(bufferSizeLimitBytes int64, client rest.Client, uploadPath string, uploadSizeLimitBytes int64, maxDecisionsPerSecond *float64) {
+	b.mtx.Lock()
+	defer b.mtx.Unlock()
+
+	b.client = client
+	b.uploadPath = uploadPath
+	if maxDecisionsPerSecond != nil {
+		b.limiter = rate.NewLimiter(rate.Limit(*maxDecisionsPerSecond), int(math.Max(1, *maxDecisionsPerSecond)))
+	} else if b.limiter != nil {
+		b.limiter = nil
+	}
+
+	// The encoder and buffer will use these new values after upload
+	b.UploadSizeLimitBytes = uploadSizeLimitBytes
+	b.BufferSizeLimitBytes = bufferSizeLimitBytes
+}
+
+func (b *sizeBuffer) Push(event *EventV1) {
+	if b.limiter != nil && !b.limiter.Allow() {
+		b.incrMetric(logRateLimitExDropCounterName)
+		b.logger.Error("Decision log dropped as rate limit exceeded. Reduce reporting interval or increase rate limit.")
+		return
+	}
+
+	eventBytes, err := json.Marshal(&event)
+	if err != nil {
+		b.logger.Error("Decision log dropped due to error serializing event to JSON: %v", err)
+		return
+	}
+
+	b.mtx.Lock()
+	defer b.mtx.Unlock()
+	result, err := b.enc.Encode(*event, eventBytes)
+	if err != nil {
+		return
+	}
+	for _, chunk := range result {
+		b.bufferChunk(b.buffer, chunk)
+	}
+}
+
+func (b *sizeBuffer) Upload(ctx context.Context) error {
+	// Make a local copy of the plugin's encoder and buffer and create
+	// a new encoder and buffer. This is needed as locking the buffer for
+	// the upload duration will block policy evaluation and result in
+	// increased latency for OPA clients
+	b.mtx.Lock()
+	oldChunkEnc := b.enc
+	oldBuffer := b.buffer
+	b.buffer = newLogBuffer(b.BufferSizeLimitBytes)
+	b.enc = newChunkEncoder(b.UploadSizeLimitBytes).WithMetrics(b.metrics).WithLogger(b.logger).
+		WithUncompressedLimit(oldChunkEnc.uncompressedLimit, oldChunkEnc.uncompressedLimitScaleDownExponent, oldChunkEnc.uncompressedLimitScaleUpExponent)
+	b.mtx.Unlock()
+
+	// Along with uploading the compressed events in the buffer
+	// to the remote server, flush any pending compressed data to the
+	// underlying writer and add to the buffer.
+	chunk, err := oldChunkEnc.Flush()
+	if err != nil {
+		return err
+	}
+
+	for _, ch := range chunk {
+		b.bufferChunk(oldBuffer, ch)
+	}
+
+	if oldBuffer.Len() == 0 {
+		return &bufferEmpty{}
+	}
+
+	for bs := oldBuffer.Pop(); bs != nil; bs = oldBuffer.Pop() {
+		if err == nil {
+			err = uploadChunk(ctx, b.client, b.uploadPath, bs)
+		}
+		if err != nil {
+			if b.limiter != nil {
+				events, decErr := newChunkDecoder(bs).decode()
+				if decErr != nil {
+					continue
+				}
+
+				for i := range events {
+					b.Push(&events[i])
+				}
+			} else {
+				// requeue the chunk
+				b.mtx.Lock()
+				b.bufferChunk(b.buffer, bs)
+				b.mtx.Unlock()
+			}
+		}
+	}
+
+	return err
+}
+
+func (b *sizeBuffer) bufferChunk(buffer *logBuffer, bs []byte) {
+	dropped := buffer.Push(bs)
+	if dropped > 0 {
+		b.incrMetric(logBufferEventDropCounterName)
+		b.incrMetric(logBufferSizeLimitExDropCounterName)
+		b.logger.Error("Dropped %v chunks from buffer. Reduce reporting interval or increase buffer size.", dropped)
+	}
+}


### PR DESCRIPTION
https://github.com/open-policy-agent/opa/pull/7446 introduced a new buffer type for the decision log plugin designated as "event" type and labelling the original implementation as "size". This PR refactors the original implementation to follow the same pattern as the new "event" type instead of being baked into the `Plugin` type. This helps create a clearer distinction between the two buffer types and make `Plugin` easier to understand.

The "limiter" has also been moved into buffer type structs so that on failure to upload it can be used. The event buffer was missing this and has been updated to also check the limiter before adding events back into the buffer.

`WithMetrics` for the buffer types has also been moved into the `Plugin.WithMetrics` method call, before it was called during creation when the `Plugin` metric would have been nil.