### PR TITLE
home page example fix

### DIFF
--- a/docs/src/pages/_examples/ai/policy.rego
+++ b/docs/src/pages/_examples/ai/policy.rego
@@ -20,6 +20,6 @@ model_access := {
 }
 
 all_accessible_models contains m if {
-	some group in input.groups
+	some group in input.user.groups
 	some m in model_access[group]
 }

--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -167,6 +167,10 @@ const Index = (props) => {
             high-level declarative language that lets you specify policy for a wide range of use cases. You can use OPA
             to enforce policies in applications, proxies, Kubernetes, CI/CD pipelines, API gateways, and more.
           </p>
+          <p>
+            The examples below are interactive! Use the <b>Evaluate</b> button to see output for the given rego and input.
+            Then edit the rego or the input (or both) to see how the output changes.
+          </p>
 
           <Tabs
             defaultValue="app"


### PR DESCRIPTION
### Why the changes in this PR are needed?

Example on the OPA home page in the AI category was broken.

Previously output of default rego was this, i.e. the available models list was empty:
```
[
  "Model 'model-2' is not in your accessible models: "
]
```

Output of default rego is now this:
```
[
  "Model 'model-2' is not in your accessible models: ^model-\\d+-stage$, model-1"
]
```

### What are the changes in this PR?

* Corrected path to the input element. 
* PR bonus: added explanatory text to aid new users.

### Notes to assist PR review:

NA

### Further comments:

NA
