### PR TITLE
ast: support naked refs in rule indexer

### DIFF
--- a/v1/ast/index_test.go
+++ b/v1/ast/index_test.go
@@ -149,6 +149,12 @@ func TestBaseDocEqIndexing(t *testing.T) {
 		input.y == 3
 	}
 
+	naked if {
+		input.x
+	} {
+		input.y
+	}
+
 	# filtering ruleset contains rules that cannot be indexed (for different reasons).
 	filtering if {
 		count([], x)
@@ -379,6 +385,29 @@ func TestBaseDocEqIndexing(t *testing.T) {
 			note:       "miss ==",
 			ruleset:    "equal",
 			input:      `{"x": 1000, "y": 1000}`,
+			expectedRS: []string{},
+		},
+		{
+			note:    "hit both",
+			ruleset: "naked",
+			input:   `{"x": 1000, "y": 1000}`,
+			expectedRS: []string{
+				"naked if { input.y }",
+				"naked if { input.x }",
+			},
+		},
+		{
+			note:    "hit one",
+			ruleset: "naked",
+			input:   `{"x": false}`,
+			expectedRS: []string{
+				"naked if { input.x }",
+			},
+		},
+		{
+			note:       "miss",
+			ruleset:    "naked",
+			input:      `{"z": "onk"}`,
 			expectedRS: []string{},
 		},
 		{

--- a/v1/rego/example_test.go
+++ b/v1/rego/example_test.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 
 	"github.com/open-policy-agent/opa/v1/logging"
@@ -804,6 +805,21 @@ func ExampleRego_PrepareForPartial() {
 
 	ctx := context.Background()
 
+	// This is typically not needed, but we do it here to ensure that our
+	// example output is stable. We sort the result bodies, and rename the
+	// variable that's `userX` for some number X to `user`.
+	makeStable := func(bodies []ast.Body) {
+		for i := range bodies {
+			ast.WalkTerms(bodies[i], func(t *ast.Term) bool {
+				if v, ok := t.Value.(ast.Var); ok && strings.HasPrefix(string(v), "user") {
+					t.Value = ast.Var("user")
+				}
+				return false // go on
+			})
+		}
+		sort.Slice(bodies, func(i, j int) bool { return bodies[i].Compare(bodies[j]) < 0 })
+	}
+
 	// Define a simple policy for example purposes.
 	module := `package test
 
@@ -825,7 +841,7 @@ func ExampleRego_PrepareForPartial() {
 	`
 
 	r := rego.New(
-		rego.Query("data.test.allow == true"),
+		rego.Query("data.test.allow"),
 		rego.Module("example.rego", module),
 	)
 
@@ -838,6 +854,7 @@ func ExampleRego_PrepareForPartial() {
 	if err != nil {
 		// Handle error.
 	}
+	makeStable(pqs.Queries)
 
 	// Inspect result
 	fmt.Println("First evaluation")
@@ -858,6 +875,7 @@ func ExampleRego_PrepareForPartial() {
 	if err != nil {
 		// Handle error.
 	}
+	makeStable(pqs.Queries)
 
 	// Inspect result
 	fmt.Println("Second evaluation")
@@ -869,10 +887,10 @@ func ExampleRego_PrepareForPartial() {
 	//
 	// First evaluation
 	// Query #1: "GET" = input.method; input.path = ["reviews", _]; input.is_admin
-	// Query #2: "GET" = input.method; input.path = ["reviews", user3]; user3 = input.user
+	// Query #2: "GET" = input.method; input.path = ["reviews", user]; user = input.user
 	// Second evaluation
 	// Query #1: input.path = ["reviews", _]; input.is_admin
-	// Query #2: input.path = ["reviews", user3]; user3 = input.user
+	// Query #2: input.path = ["reviews", user]; user = input.user
 }
 
 func ExampleRego_custom_functional_builtin() {

--- a/v1/topdown/eval.go
+++ b/v1/topdown/eval.go
@@ -1646,12 +1646,11 @@ func (e *eval) getRules(ref ast.Ref, args []*ast.Term) (*ast.IndexResult, error)
 
 	var result *ast.IndexResult
 	var err error
+	resolver.e = e
 	if e.indexing {
-		resolver.e = e
 		resolver.args = args
 		result, err = index.Lookup(resolver)
 	} else {
-		resolver.e = e
 		result, err = index.AllRules(resolver)
 	}
 	if err != nil {

--- a/v1/topdown/topdown_partial_test.go
+++ b/v1/topdown/topdown_partial_test.go
@@ -1429,19 +1429,10 @@ func TestTopDownPartialEval(t *testing.T) {
 			`},
 			wantSupport: []string{`package partial.test
 
-			q if {
-				__local6__2 = input
-				data.partial.test.mock_concat(["foo"], __local6__2, __local5__2)
-				__local4__2 = __local5__2
-			}
-			mock_concat(__local0__3, __local1__3) = ["foo", "bar"] if {
-				input.foo = x_term_3_03
-				x_term_3_03
-			}
-			mock_concat(__local2__4, __local3__4) = ["bar", "baz"] if {
-				input.bar = x_term_4_04
-				x_term_4_04
-			}`},
+			q if { __local6__2 = input; data.partial.test.mock_concat(["foo"], __local6__2, __local5__2); __local4__2 = __local5__2 }
+			mock_concat(__local0__4, __local1__4) = ["foo", "bar"] if { input.foo = x_term_4_04; x_term_4_04 }
+			mock_concat(__local2__3, __local3__3) = ["bar", "baz"] if { input.bar = x_term_3_03; x_term_3_03 }`,
+			},
 		},
 		{
 			note:  "with+function: unknowns in replacement function's bodies",
@@ -1461,19 +1452,10 @@ func TestTopDownPartialEval(t *testing.T) {
 			`},
 			wantSupport: []string{`package partial.test
 
-			q if {
-				__local9__2 = input
-				data.partial.test.mock_concat(",", __local9__2, __local8__2)
-				__local6__2 = __local8__2
-			}
-			mock_concat(__local2__3, __local3__3) = "foo,bar" if {
-				input.foo = x_term_3_03
-				x_term_3_03
-			}
-			mock_concat(__local4__4, __local5__4) = "bar,baz" if {
-				input.bar = x_term_4_04
-				x_term_4_04
-			}`},
+			q if { __local9__2 = input; data.partial.test.mock_concat(",", __local9__2, __local8__2); __local6__2 = __local8__2 }
+			mock_concat(__local2__4, __local3__4) = "foo,bar" if { input.foo = x_term_4_04; x_term_4_04 }
+			mock_concat(__local4__3, __local5__3) = "bar,baz" if { input.bar = x_term_3_03; x_term_3_03 }`,
+			},
 		},
 		{
 			note:  "with+builtin+negation: when replacement has no unknowns (args, defs), save negated expr without replacement",
@@ -1586,8 +1568,8 @@ func TestTopDownPartialEval(t *testing.T) {
 				package partial.test
 
 				q if { data.partial.test.mock_count([1], __local2__3); __local2__3 = input.x }
-				mock_count(__local0__4) = 100 if { input.y = x_term_4_04; x_term_4_04 }
-				mock_count(__local1__5) = 101 if { input.z = x_term_5_05; x_term_5_05 }
+				mock_count(__local0__5) = 100 if { input.y = x_term_5_05; x_term_5_05 }
+				mock_count(__local1__4) = 101 if { input.z = x_term_4_04; x_term_4_04 }
 			`},
 		},
 		{
@@ -1611,8 +1593,8 @@ func TestTopDownPartialEval(t *testing.T) {
 				package partial.test
 
 				q if { data.partial.test.mock_count([1], __local4__3); __local4__3 = input.x }
-				mock_count(__local1__4) = 100 if { input.y = x_term_4_04; x_term_4_04 }
-				mock_count(__local2__5) = 101 if { input.z = x_term_5_05; x_term_5_05 }
+				mock_count(__local1__5) = 100 if { input.y = x_term_5_05; x_term_5_05 }
+				mock_count(__local2__4) = 101 if { input.z = x_term_4_04; x_term_4_04 }
 			`},
 		},
 		{


### PR DESCRIPTION
This turned out to be a low-hanging fruit. With this change, these two expression behave the same as far as the rule indexer is concerned:

    input.foo != false # this worked before
    input.foo          # now works, too!

Under the hood, expressions like `input.foo` are handled as if it was written as `x = input.foo` for a synthetic variable. That way, it's handled the same -- 100% the same, so we're not looking at the actual value of `input.foo` in the rule index lookup, we're just selecting the rules that use it (and omit the ones that don't). The actual FAIL that may happen in evaluation if `input.foo` is `false` will just happen as it always has, and give up on that subtree for evaluation.

Also similar to `input.foo != false`, there is no support with `not` or `with` in the rule index.

Note that we don't handle function arguments in the same way:

If you have a function (with some more rule bodies so that RI matters),

```rego
foo(a, b) if {
  a > 1
  b == 200
}
```

and the evaluator does a lookup of `foo(2, 100)`, it will not evaluate that body -- because `b` is used in the indexer with value `100`.

Now, if that was a naked expression,

```rego
foo(a, b) if {
  a > 1
  b
}
```

it will not be handled any different with this change: It's a function argument, so it cannot be undefined. There's no point in using the rule index to reference this function body for "b is defined" -- it always is if we're calling the function.


Previously mentioned in https://github.com/open-policy-agent/opa/issues/642#issuecomment-1186982100.
