### PR TITLE
docs/ocp: fix wrong example on concepts page

### DIFF
--- a/docs/docs/ocp/concepts.md
+++ b/docs/docs/ocp/concepts.md
@@ -122,8 +122,8 @@ sources:
       - .*/*
       credentials: github-token
   global-data:
-    files:
-      data/common.json
+    paths:
+      - global/common.json
 ```
 
 ## Stacks


### PR DESCRIPTION
Fixes https://github.com/open-policy-agent/opa-control-plane/issues/73.
