### PR TITLE
perf: Don't invoke future parser for Rego v1

### DIFF
--- a/v1/ast/parser_bench_test.go
+++ b/v1/ast/parser_bench_test.go
@@ -76,6 +76,22 @@ func BenchmarkParseStatementNestedObjects(b *testing.B) {
 	}
 }
 
+func BenchmarkParseSome(b *testing.B) {
+	b.Run("parse some", func(b *testing.B) {
+		for range b.N {
+			_ = MustParseStatement("some foo")
+		}
+	})
+}
+
+func BenchmarkParseEvery(b *testing.B) {
+	b.Run("parse every", func(b *testing.B) {
+		for range b.N {
+			_ = MustParseStatement("every x, y in input { x == y}")
+		}
+	})
+}
+
 // BenchmarkParseDeepNesting tests the impact of recursion depth tracking
 // on parsing performance with deeply nested structures (arrays and objects).
 // Different depths are used to measure the overhead at various nesting levels.


### PR DESCRIPTION
Just a little something that came up when testing `json/v2`. Not a big issue, but also makes no sense to instantiate a new parser when it won't be needed.

**Before/after**
```
BenchmarkParseSome/parse_some-16    162577  7317 ns/op   8088 B/op   53 allocs/op
BenchmarkParseSome/parse_some-16    135363  8754 ns/op	 10536 B/op  69 allocs/op
```