### PR TITLE
Update Envoy tutorial for new versions and images

### DIFF
--- a/docs/docs/envoy/tutorial-standalone-envoy.md
+++ b/docs/docs/envoy/tutorial-standalone-envoy.md
@@ -35,9 +35,9 @@ in the [project documentation](https://kind.sigs.k8s.io/#installation-and-usage)
 Create a cluster with the following command:
 
 ```shell
-$ kind create cluster --name opa-envoy --image kindest/node:v1.27.3
+$ kind create cluster --name opa-envoy --image kindest/node:v1.33.1
 Creating cluster "opa-envoy" ...
- ✓ Ensuring node image (kindest/node:v1.27.3) 🖼
+ ✓ Ensuring node image (kindest/node:v1.33.1) 🖼
  ✓ Preparing nodes 📦
  ✓ Writing configuration 📜
  ✓ Starting control-plane 🕹️
@@ -61,7 +61,7 @@ Listing the cluster nodes, should show something like this:
 ```shell
 $ kubectl get nodes
 NAME                       STATUS   ROLES           AGE     VERSION
-opa-envoy-control-plane   Ready    control-plane   2m35s   v1.27.3
+opa-envoy-control-plane   Ready    control-plane   2m35s   v1.33.1
 ```
 
 ## Creating & Serving our Policy Bundle
@@ -369,7 +369,7 @@ spec:
         - name: ENVOY_UID
           value: "1111"
       - name: opa
-        image: openpolicyagent/opa:latest-envoy
+        image: openpolicyagent/opa:latest-envoy-static
         args:
         - "run"
         - "--server"


### PR DESCRIPTION
<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/contributing/)
  for high-level contributing guidelines and development setup.
  (See the [Developer Certificate of Origin](https://www.openpolicyagent.org/docs/contrib-code/#developer-certificate-of-origin)
  section for specifics on signing off a commit.)

-->

### Why the changes in this PR are needed?

I wasn't able to find an arm64 variant of docker.io/openpolicyagent/opa:latest-envoy, but I was able to find it for docker.io/openpolicyagent/opa:latest-envoy-static.

I was able to go through this tutorial with a newer version of kind, so I thought I'd update that version, too.

### What are the changes in this PR?

Updates to KIND version used and opa image tag used that includes the linux/arm64 variant in addition to linux/amd64.

### Notes to assist PR review:

Using skopeo, we can find which image tag supports arm64.

```sh
# docker.io/openpolicyagent/opa:latest-envoy doesn't include the linux/arm64 variant
$ skopeo inspect --override-os=linux --override-arch=arm64 docker://docker.io/openpolicyagent/opa:latest-envoy 
FATA[0000] Error parsing manifest for image: choosing image instance: no image found in image index for architecture "arm64", variant "", OS "linux" 
```

```sh
# docker.io/openpolicyagent/opa:latest-envoy-static DOES include the linux/arm64 variant
$ skopeo inspect --override-os=linux --override-arch=amd64 docker://docker.io/openpolicyagent/opa:latest-envoy-static
 "Created": "2025-09-11T15:07:03.186697081Z",
    "DockerVersion": "",
    "Labels": {
        "dev.chainguard.package.main": "",
        "org.opencontainers.image.authors": "Ashutosh Narkar \u003canrkar4387@gmail.com\u003e",
        "org.opencontainers.image.created": "2025-09-08T13:41:17Z",
        "org.opencontainers.image.source": "https://github.com/chainguard-images/images/tree/main/images/glibc-dynamic",
        "org.opencontainers.image.url": "https://images.chainguard.dev/directory/image/glibc-dynamic/overview",
        "org.opencontainers.image.vendor": "Chainguard"
    },
    "Architecture": "amd64",
    "Os": "linux",
```

### Further comments:

I didn't look into why there wasn't an arm64 variant of the docker.io/openpolicyagent/opa:latest-envoy image since I'm not familiar with how this image is built.