### PR TITLE
docs/ocp: fix inline-transform example

### DIFF
--- a/docs/docs/ocp/api-reference.md
+++ b/docs/docs/ocp/api-reference.md
@@ -322,7 +322,7 @@ Sources define where policies and data come from (Git repositories, local files,
         }
       },
       "credentials": "api-credentials",
-      "transform_query": "users[user.id] = user { user := input.users[_] }"
+      "transform_query": "{user.id: user | user := input.users[_]}"
     }
   ]
 }
@@ -699,7 +699,7 @@ Unauthorized
         }
       },
       "credentials": "api-credentials",
-      "transform_query": "users[user.id] = user { user := input.users[_] }"
+      "transform_query": "{user.id: user | user := input.users[_]}"
     }
   ]
 }


### PR DESCRIPTION
The previous rego policy snippet wasn't valid. It's got to be a query, either referencing a rule defined in one of the sources, or an inline query like in the updated example.