### PR TITLE
docs/rest-api: add basic Compile API docs

### DIFF
--- a/docs/docs/rest-api.md
+++ b/docs/docs/rest-api.md
@@ -1684,7 +1684,6 @@ Accept: application/vnd.opa.sql.postgresql+json
 {
   "input": {
     "favorite": "pineapple"
-    }
   }
 }
 ```


### PR DESCRIPTION
We have more extensive docs to port over, but this isn't the right place for those. So let's get these in first.

Follow-up for #7887.