### PR TITLE
plugin/decision: correctly reconfigure limit based on buffer type

### DIFF
--- a/v1/plugins/logs/eventBuffer.go
+++ b/v1/plugins/logs/eventBuffer.go
@@ -70,7 +70,7 @@ func (b *eventBuffer) incrMetric(name string) {
 // Reconfigure updates the user configurable values
 // This cannot be called concurrently, this could change the underlying channel.
 // Plugin manages a lock to control this so that changes to both buffer types can be managed sequentially.
-func (b *eventBuffer) Reconfigure(bufferSizeLimitEvents int64, client rest.Client, uploadPath string, uploadSizeLimitBytes int64, maxDecisionsPerSecond *float64) {
+func (b *eventBuffer) Reconfigure(bufferSizeLimitEvents int64, uploadSizeLimitBytes int64, maxDecisionsPerSecond *float64) {
 	// prevent an upload from pushing events that failed to upload back into a closed buffer
 	b.upload.Lock()
 	defer b.upload.Unlock()

--- a/v1/plugins/logs/eventBuffer_test.go
+++ b/v1/plugins/logs/eventBuffer_test.go
@@ -56,7 +56,7 @@ func TestEventBuffer_Push(t *testing.T) {
 
 	// Increase the limit, forcing the buffer to change
 	limit = int64(3)
-	b.Reconfigure(limit, rest.Client{}, "", 0, nil)
+	b.Reconfigure(limit, 0, nil)
 	checkBufferState(t, limit, b, expectedDropped, expectedIds)
 
 	id = "id4"
@@ -73,7 +73,7 @@ func TestEventBuffer_Push(t *testing.T) {
 	checkBufferState(t, limit, b, expectedDropped, expectedIds)
 
 	limit = int64(1)
-	b.Reconfigure(limit, rest.Client{}, "", 0, nil)
+	b.Reconfigure(limit, 0, nil)
 	// Limit reconfigured from 3->1, dropping 2 more events.
 	expectedDropped = 4
 	delete(expectedIds, "id3")
@@ -81,7 +81,7 @@ func TestEventBuffer_Push(t *testing.T) {
 	checkBufferState(t, limit, b, expectedDropped, expectedIds)
 
 	// Nothing changed
-	b.Reconfigure(limit, rest.Client{}, "", 0, nil)
+	b.Reconfigure(limit, 0, nil)
 	checkBufferState(t, limit, b, expectedDropped, expectedIds)
 }
 

--- a/v1/plugins/logs/plugin.go
+++ b/v1/plugins/logs/plugin.go
@@ -456,7 +456,7 @@ type buffer interface {
 	Name() string
 	Push(*EventV1)
 	Upload(context.Context, rest.Client, string) error
-	Reconfigure(int64, rest.Client, string, int64, *float64)
+	Reconfigure(int64, int64, *float64)
 	WithMetrics(metrics.Metrics)
 }
 
@@ -945,10 +945,16 @@ func (p *Plugin) reconfigure(ctx context.Context, config any) {
 		return
 	}
 
+	var limit int64
+
+	switch p.config.Reporting.BufferType {
+	case eventBufferType:
+		limit = *p.config.Reporting.BufferSizeLimitEvents
+	case sizeBufferType:
+		limit = *p.config.Reporting.UploadSizeLimitBytes
+	}
 	p.b.Reconfigure(
-		*p.config.Reporting.BufferSizeLimitEvents,
-		p.manager.Client(p.config.Service),
-		*p.config.Resource,
+		limit,
 		*p.config.Reporting.UploadSizeLimitBytes,
 		p.config.Reporting.MaxDecisionsPerSecond,
 	)

--- a/v1/plugins/logs/sizeBuffer.go
+++ b/v1/plugins/logs/sizeBuffer.go
@@ -60,7 +60,7 @@ func (b *sizeBuffer) incrMetric(name string) {
 	}
 }
 
-func (b *sizeBuffer) Reconfigure(bufferSizeLimitBytes int64, client rest.Client, uploadPath string, uploadSizeLimitBytes int64, maxDecisionsPerSecond *float64) {
+func (b *sizeBuffer) Reconfigure(bufferSizeLimitBytes int64, uploadSizeLimitBytes int64, maxDecisionsPerSecond *float64) {
 	b.mtx.Lock()
 	defer b.mtx.Unlock()
 


### PR DESCRIPTION
When reconfiguring without changing the buffer type the event limit was always sent, now it chooses byte or event limit correctly. This bug hasn't been released yet and was introduced in: https://github.com/open-policy-agent/opa/pull/7884 (also forgot to delete some unused parameters that are now cleaned up)

Updated the `TestPluginReconfigure` test to catch this as well.