### PR TITLE
Avoid unnecessary use of custom http.Transport by http.send

### DIFF
--- a/v1/topdown/http.go
+++ b/v1/topdown/http.go
@@ -314,7 +314,6 @@ func validateHTTPRequestOperand(term *ast.Term, pos int) (ast.Object, error) {
 	}
 
 	return obj, nil
-
 }
 
 // canonicalizeHeaders returns a copy of the headers where the keys are in
@@ -580,13 +579,6 @@ func createHTTPRequest(bctx BuiltinContext, obj ast.Object) (*http.Request, *htt
 
 		isTLS = true
 		tlsConfig.Certificates = append(tlsConfig.Certificates, cert)
-	}
-
-	// Use system certs if no CA cert is provided
-	// or system certs flag is not set
-	if len(tlsCaCert) == 0 && tlsCaCertFile == "" && tlsCaCertEnvVar == "" && tlsUseSystemCerts == nil {
-		trueValue := true
-		tlsUseSystemCerts = &trueValue
 	}
 
 	// Check the system certificates config first so that we
@@ -1385,7 +1377,6 @@ func parseMaxAgeCacheDirective(cc map[string]string) (deltaSeconds, error) {
 }
 
 func formatHTTPResponseToAST(resp *http.Response, forceJSONDecode, forceYAMLDecode bool) (ast.Value, []byte, error) {
-
 	resultRawBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, nil, err

--- a/v1/topdown/http_test.go
+++ b/v1/topdown/http_test.go
@@ -3034,7 +3034,7 @@ func TestCertSelectionLogic(t *testing.T) {
 			msg:      "Expected TLS config to use system certs",
 		},
 		{
-			note:     "tls_use_system_certs set to nil",
+			note:     "tls_use_system_certs set to false",
 			input:    map[*ast.Term]*ast.Term{ast.StringTerm("tls_use_system_certs"): ast.BooleanTerm(false)},
 			expected: nil,
 			msg:      "Expected no TLS config",
@@ -3042,7 +3042,7 @@ func TestCertSelectionLogic(t *testing.T) {
 		{
 			note:     "no CAs specified",
 			input:    nil,
-			expected: systemCertsPool.Subjects(), // nolint:staticcheck // ignoring the deprecated (*CertPool).Subjects() call here because it's in a test.
+			expected: nil,
 			msg:      "Expected TLS config to use system certs",
 		},
 		{
@@ -3165,7 +3165,6 @@ func TestHTTPSendCacheDefaultStatusCodesInterQueryCache(t *testing.T) {
 	defer ts.Close()
 
 	t.Run("non-cacheable status code: inter-query cache", func(t *testing.T) {
-
 		// add an inter-query cache
 		config, _ := iCache.ParseCachingConfig([]byte(`{"inter_query_builtin_cache": {"max_size_bytes": 500, "stale_entry_eviction_period_seconds": 1, "forced_eviction_threshold_percentage": 80},}`))
 		interQueryCache := iCache.NewInterQueryCacheWithContext(t.Context(), config)
@@ -3639,49 +3638,51 @@ func (*tracemock) NewHandler(http.Handler, string, tracing.Options) http.Handler
 
 // Warning(philipc): This test modifies package variables in tracing, which
 // means it cannot be run in parallel with other tests.
-func TestDistributedTracingEnableDisable(t *testing.T) {
-	t.Run("TestDistributedTracingEnabled", func(t *testing.T) {
-		mock := tracemock{}
-		tracing.RegisterHTTPTracing(&mock)
+func TestDistributedTracing(t *testing.T) {
+	tests := []struct {
+		name            string
+		opts            tracing.Options
+		obj             ast.Object
+		expectedCalls   int
+		expectTransport bool
+	}{
+		{name: "Disabled", opts: nil, expectedCalls: 0},
+		{name: "Enabled", opts: tracing.NewOptions(true), expectedCalls: 1},
+		{
+			name: "EnabledWithConfigured", opts: tracing.NewOptions(true), expectedCalls: 1,
+			obj: ast.NewObject( // Force TLS configuration for SNI
+				[2]*ast.Term{ast.StringTerm("tls_server_name"), ast.StringTerm("test-server")},
+			),
+			expectTransport: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Cleanup(func() { tracing.RegisterHTTPTracing(nil) })
+			mock := tracemock{}
+			tracing.RegisterHTTPTracing(&mock)
 
-		builtinContext := BuiltinContext{
-			Context:                t.Context(),
-			DistributedTracingOpts: tracing.NewOptions(true), // any option means it's enabled
-		}
+			if tt.obj == nil {
+				tt.obj = ast.NewObject()
+			}
 
-		_, client, err := createHTTPRequest(builtinContext, ast.NewObject())
-		if err != nil {
-			t.Fatalf("Unexpected error creating HTTP request %v", err)
-		}
-		if client.Transport == nil {
-			t.Fatal("No Transport defined")
-		}
+			builtinContext := BuiltinContext{
+				Context:                t.Context(),
+				DistributedTracingOpts: tt.opts,
+			}
 
-		if exp, act := 1, mock.called; exp != act {
-			t.Errorf("calls to NewTransport: expected %d, got %d", exp, act)
-		}
-	})
-
-	t.Run("TestDistributedTracingDisabled", func(t *testing.T) {
-		mock := tracemock{}
-		tracing.RegisterHTTPTracing(&mock)
-
-		builtinContext := BuiltinContext{
-			Context: t.Context(),
-		}
-
-		_, client, err := createHTTPRequest(builtinContext, ast.NewObject())
-		if err != nil {
-			t.Fatalf("Unexpected error creating HTTP request %v", err)
-		}
-		if client.Transport == nil {
-			t.Fatal("No Transport defined")
-		}
-
-		if exp, act := 0, mock.called; exp != act {
-			t.Errorf("calls to NewTransported: expected %d, got %d", exp, act)
-		}
-	})
+			_, client, err := createHTTPRequest(builtinContext, tt.obj)
+			if err != nil {
+				t.Fatalf("Unexpected error creating HTTP request %v", err)
+			}
+			if exp, act := tt.expectedCalls, mock.called; exp != act {
+				t.Errorf("calls to NewTransport: expected %d, got %d", exp, act)
+			}
+			if exp, act := tt.expectTransport, client.Transport != nil; exp != act {
+				t.Errorf("client transport present: expected %t, got %t", exp, act)
+			}
+		})
+	}
 }
 
 func TestHTTPGetRequestAllowNet(t *testing.T) {
@@ -3780,6 +3781,10 @@ func (st *secretTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 }
 
 func (st *secretTransport) Transform(t *http.Transport) http.RoundTripper {
+	// Transport may be nil when the http.DefaultTransport is used
+	if t == nil {
+		t = http.DefaultTransport.(*http.Transport)
+	}
 	st.Transport = t.Clone()
 	return st
 }


### PR DESCRIPTION
### Why the changes in this PR are needed?

Under load, we observed inconsistent throughput and high error rates when evaluating policies that use `http.send`. While troubleshooting, we noted a high number of sockets in the TIME_WAIT state. This implied client connections were not getting reused across queries. We attempted to resolve this by increasing MaxIdleConns and MaxIdleConnsPerHost on the default transport. Unfortunately, this did not help.

When we looked through the implementation of `http.send`, we discovered that nearly every path creates a new http.Transport that gets abandoned at the end of the query. This effectively disables connection pooling. We also observed that these new transports were setup to disable keep-alive. Either one of these behaviors effectively forces new client connections and TLS handshakes for each request. This was the source of the TIME_WAIT sockets.

We found one existing path through the code that constructs an http.Client without a transport: explicitly setting `tls_use_system_certs` to false. When we made this change to our policies, the default transport was used and we no longer encountered errors. We also observed higher throughput that was stable under load.

### What are the changes in this PR?

The primary change is to remove the block that causes a new transport to be constructed by default. A transport is only created when options are specified that require non-default TLS client configuration.

While making the primary change, two additional updates were made.

When UNIX domain sockets are used, the scheme is explicitly set to "http", effectively disabling TLS and removing the need for the custom configuration. The code was refactored slightly to stop passing the *tls.Config to useSocket.
When a Host header is set and tls_use_system_certs is false, the SNI server name was not setup and the client hello message did not use the correct name. Tests were added to exercise this path and setup the configuration when a Host header is configured.

### Notes to assist PR review:

When tls.Config#RootCAs is nil, the system certificate pool is used by default. A new pool is only required when the configuration needs to deviate from this default because CA certificate options were provided. The documentation for http.send remains accurate – the system certificate pool is used by default when tls_ca_cert, tls_ca_cert_file, and tls_ca_cert_env_variable are unset.