### PR TITLE
plugin/decision: return event same size as limit immediately

### DIFF
--- a/v1/plugins/logs/encoder.go
+++ b/v1/plugins/logs/encoder.go
@@ -135,7 +135,7 @@ func (enc *chunkEncoder) Encode(event EventV1, eventBytes []byte) ([][]byte, err
 		}
 	}
 
-	if int64(len(eventBytes)+enc.bytesWritten+1) <= enc.uncompressedLimit {
+	if int64(len(eventBytes)+enc.bytesWritten+1) < enc.uncompressedLimit {
 		return nil, enc.appendEvent(eventBytes)
 	}
 
@@ -167,16 +167,12 @@ func (enc *chunkEncoder) Encode(event EventV1, eventBytes []byte) ([][]byte, err
 		}
 
 		currentSize := len(result)
-		if currentSize < int(enc.limit) {
+		if currentSize <= int(enc.limit) {
 			// success! the incoming chunk doesn't have to lose the ND cache and can go into a chunk by itself
 			// scale up the uncompressed limit using the uncompressed event size as a base
-			err = enc.appendEvent(eventBytes)
-			if err != nil {
-				return nil, err
-			}
 			enc.uncompressedLimit = int64(len(eventBytes))
 			enc.scaleUp()
-			return nil, nil
+			return [][]byte{result}, nil
 		}
 
 		// The ND cache has to be dropped, record this size as a known maximum event size

--- a/v1/plugins/logs/encoder_test.go
+++ b/v1/plugins/logs/encoder_test.go
@@ -281,7 +281,7 @@ func TestChunkEncoderSizeLimit(t *testing.T) {
 		t.Fatal(err)
 	}
 	if len(chunks) != 1 {
-		t.Errorf("Unexpected result: %v", result)
+		t.Errorf("Unexpected chunk: %v", chunks)
 	}
 	// the incoming event doesn't fit, but the previous small event size is between 90-100% capacity so chunk is returned
 	// the incoming event is too large and will be dropped
@@ -324,6 +324,15 @@ func TestChunkEncoderSizeLimit(t *testing.T) {
 	if enc.metrics.Counter(logEncodingFailureCounterName).Value().(uint64) != 1 {
 		t.Errorf("Expected one encoding failure but got: %v", enc.metrics.Counter(logEncodingFailureCounterName).Value().(uint64))
 	}
+
+	enc = newChunkEncoder(179).WithMetrics(metrics.New())
+	chunks, err = enc.Encode(event, eventBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(chunks) != 1 {
+		t.Errorf("Unexpected chunk: %v", chunks)
+	}
 }
 
 func TestChunkEncoderAdaptive(t *testing.T) {
@@ -348,7 +357,7 @@ func TestChunkEncoderAdaptive(t *testing.T) {
 			expectedMaxEventsInChunk:  1,
 			expectedScaleUpEvents:     1,
 			expectedScaleDownEvents:   0,
-			expectedEquiEvents:        999,
+			expectedEquiEvents:        998,
 		},
 		{
 			// 61 events can fit, but takes some guessing before it gets to the uncompressed limit 7200

--- a/v1/plugins/logs/eventBuffer.go
+++ b/v1/plugins/logs/eventBuffer.go
@@ -136,7 +136,7 @@ func (b *eventBuffer) Upload(ctx context.Context, client rest.Client, uploadPath
 		if event.chunk != nil {
 			result = [][]byte{event.chunk}
 		} else {
-			eventBytes, err := json.Marshal(&event)
+			eventBytes, err := json.Marshal(&event.EventV1)
 			if err != nil {
 				return err
 			}

--- a/v1/plugins/logs/eventBuffer_test.go
+++ b/v1/plugins/logs/eventBuffer_test.go
@@ -143,8 +143,8 @@ func TestEventBuffer_Upload(t *testing.T) {
 			uploadSizeLimitBytes: 196, // Each test event is 195 bytes
 			handleFunc: func(w http.ResponseWriter, r *http.Request) {
 				events := decodeLogEvent(t, r.Body)
-				if len(events) != 2 {
-					t.Errorf("expected 2 events, got %d", len(events))
+				if len(events) != 1 {
+					t.Errorf("expected 1 events, got %d", len(events))
 				}
 				w.WriteHeader(http.StatusOK)
 			},


### PR DESCRIPTION
In the encoder, if the event size equals the limit it was added to the buffer. Instead return it to avoid unnecessary downsize step that could lead to an infinite loop.