### PR TITLE
ast: add compile annotation key

### DIFF
--- a/docs/docs/rest-api.md
+++ b/docs/docs/rest-api.md
@@ -1664,7 +1664,7 @@ package filters
 
 # METADATA
 # scope: document
-# custom:
+# compile:
 #   unknowns: [input.fruits]
 include if input.fruits.name == input.favorite
 

--- a/e2e/api/compile/e2e_test.go
+++ b/e2e/api/compile/e2e_test.go
@@ -566,7 +566,7 @@ func TestPrometheusMetrics(t *testing.T) {
 	policy := `package filters
 # METADATA
 # scope: document
-# custom:
+# compile:
 #   unknowns: [input.fruits]
 include if input.fruits.name == "banana"
 `

--- a/e2e/api/compile/logs_test.go
+++ b/e2e/api/compile/logs_test.go
@@ -37,7 +37,7 @@ func TestDecisionLogsCompileAPIResult(t *testing.T) {
 package filters
 
 # METADATA
-# custom:
+# compile:
 #   unknowns: [input.fruits]
 #   mask_rule: data.filters.mask
 include if input.fruits.name in input.favorites

--- a/v1/ast/parser_test.go
+++ b/v1/ast/parser_test.go
@@ -7008,6 +7008,78 @@ p if { input = "str" }`,
 				},
 			},
 		},
+		{
+			note: "compile annotation, short mask_rule",
+			module: `
+package opa.examples
+
+# METADATA
+# scope: document
+# compile:
+#   unknowns:
+#   - input.fruits
+#   mask_rule: mask
+include if input.fruits.name == "banana"
+mask.fruits.owner.replace.value := "___"
+`,
+			expNumComments: 6,
+			expAnnotations: []*Annotations{
+				{
+					Scope: annotationScopeDocument,
+					Compile: &CompileAnnotation{
+						Unknowns: []Ref{MustParseRef("input.fruits")},
+						MaskRule: EmptyRef().Append(VarTerm("mask")),
+					},
+				},
+			},
+		},
+		{
+			note: "compile annotation, full mask_rule",
+			module: `
+package opa.examples
+
+# METADATA
+# scope: document
+# compile:
+#   unknowns:
+#   - input.fruits
+#   mask_rule: data.filtering.mask
+include if input.fruits.name == "banana"
+mask.fruits.owner.replace.value := "___"
+`,
+			expNumComments: 6,
+			expAnnotations: []*Annotations{
+				{
+					Scope: annotationScopeDocument,
+					Compile: &CompileAnnotation{
+						Unknowns: []Ref{MustParseRef("input.fruits")},
+						MaskRule: MustParseRef("data.filtering.mask"),
+					},
+				},
+			},
+		},
+		{
+			note: "compile annotation, no mask_rule",
+			module: `
+package opa.examples
+
+# METADATA
+# scope: document
+# compile:
+#   unknowns:
+#   - input.fruits
+include if input.fruits.name == "banana"
+`,
+			expNumComments: 5,
+			expAnnotations: []*Annotations{
+				{
+					Scope: annotationScopeDocument,
+					Compile: &CompileAnnotation{
+						Unknowns: []Ref{MustParseRef("input.fruits")},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range tests {

--- a/v1/rego/compile/compile.go
+++ b/v1/rego/compile/compile.go
@@ -26,7 +26,7 @@ type Compile struct {
 	targets  []string
 	dialects []string
 	maskRule ast.Ref
-	unknowns []*ast.Term
+	unknowns []*ast.Term // ast.Ref would be slightly more on-the-spot, but we follow what is done in v1/rego to minimise surprises.
 	query    ast.Body
 	mappings map[string]any
 	metrics  metrics.Metrics

--- a/v1/server/compile_handler_checks_test.go
+++ b/v1/server/compile_handler_checks_test.go
@@ -80,7 +80,7 @@ func TestPostPartialChecks(t *testing.T) {
 			rego: `
 # METADATA
 # scope: document
-# custom:
+# compile:
 #  unknowns:
 #   - input.fruits
 include if input.fruits.colour == input.colour
@@ -95,7 +95,7 @@ _use_metadata := rego.metadata.chain()`,
 			rego: `
 # METADATA
 # scope: package
-# custom:
+# compile:
 #  unknowns:
 #   - input.fruits
 package filters
@@ -112,7 +112,7 @@ _use_metadata := rego.metadata.chain()`,
 			rego: `
 # METADATA
 # scope: package
-# custom:
+# compile:
 #  unknowns:
 #   - input.fruits
 package filters
@@ -129,14 +129,14 @@ _use_metadata := rego.metadata.chain()`,
 			rego: `
 # METADATA
 # scope: package
-# custom:
+# compile:
 #  unknowns:
 #   - input.fruits
 package filters
 
 # METADATA
 # scope: document
-# custom:
+# compile:
 #  unknowns:
 #   - input.baskets
 include if {
@@ -147,7 +147,7 @@ include if {
 # METADATA
 # scope: document
 # description: if this metadata were picked up, the checks would fail
-# custom:
+# compile:
 #  unknowns:
 #   - input.colour
 red_herring if true
@@ -169,14 +169,14 @@ _use_metadata := rego.metadata.chain()`,
 			rego: `
 # METADATA
 # scope: package
-# custom:
+# compile:
 #  unknowns:
 #   - input.fruits
 package filters
 
 # METADATA
 # scope: document
-# custom:
+# compile:
 #  unknowns:
 #   - input.baskets
 include if {
@@ -187,7 +187,7 @@ include if {
 # METADATA
 # scope: document
 # description: if this metadata were picked up, the checks would fail
-# custom:
+# compile:
 #  unknowns:
 #   - input.colour
 red_herring if true
@@ -281,7 +281,7 @@ red_herring if true
 			note: "happy path, mapped short unknown",
 			rego: `package filters
 # METADATA
-# custom:
+# compile:
 #  unknowns:
 #   - input.name
 include if input.name != "apple"`,
@@ -296,7 +296,7 @@ include if input.name != "apple"`,
 			note: "happy path, double-mapped short unknown",
 			rego: `package filters
 # METADATA
-# custom:
+# compile:
 #  unknowns:
 #   - input.name
 include if input.name != "apple"`,
@@ -701,7 +701,7 @@ other if input.fruits.price > 100
 			omitUnknowns: true,
 			rego: `
 # METADATA
-# custom:
+# compile:
 #  unknowns:
 #   - inpu.fruits
 #   - data.whatever
@@ -727,7 +727,7 @@ _use_metadata := rego.metadata.chain()`,
 			omitUnknowns: true,
 			rego: `
 # METADATA
-# custom:
+# compile:
 #  unknowns:
 #   - inpu.fruits
 #   - data.whatever

--- a/v1/server/compile_handler_test.go
+++ b/v1/server/compile_handler_test.go
@@ -241,7 +241,7 @@ func TestCompileHandlerHints(t *testing.T) {
 	typoRego := `package filters
 # METADATA
 # scope: document
-# custom:
+# compile:
 #   unknowns: [input.fruits]
 include if input.fruits.name == "apple"
 include if input.fruit.cost < input.max

--- a/v1/server/failtracer/failtracer.go
+++ b/v1/server/failtracer/failtracer.go
@@ -28,7 +28,7 @@ type FailTracer interface {
 	Enabled() bool
 	TraceEvent(topdown.Event)
 	Config() topdown.TraceConfig
-	Hints([]*ast.Term) []Hint
+	Hints([]ast.Ref) []Hint
 }
 
 func New() FailTracer {
@@ -54,16 +54,15 @@ func (*failTracer) Config() topdown.TraceConfig {
 	return topdown.TraceConfig{PlugLocalVars: true}
 }
 
-func (b *failTracer) Hints(unknowns []*ast.Term) []Hint {
+func (b *failTracer) Hints(unknowns []ast.Ref) []Hint {
 	var hints []Hint //nolint:prealloc
 	seenRefs := map[string]struct{}{}
 	candidates := make([]string, 0, len(unknowns))
-	for i := range unknowns {
-		ref, ok := unknowns[i].Value.(ast.Ref)
-		if !ok || len(ref) < 2 {
+	for _, ref := range unknowns {
+		if len(ref) < 2 {
 			continue
 		}
-		candidates = append(candidates, string(unknowns[i].Value.(ast.Ref)[1].Value.(ast.String)))
+		candidates = append(candidates, string(ref[1].Value.(ast.String)))
 	}
 
 	for _, expr := range b.exprs {

--- a/v1/server/failtracer/hints_test.go
+++ b/v1/server/failtracer/hints_test.go
@@ -95,9 +95,9 @@ func TestHints(t *testing.T) {
 			for i := range tc.evts {
 				ft.TraceEvent(tc.evts[i])
 			}
-			unk := make([]*ast.Term, len(tc.unknowns))
+			unk := make([]ast.Ref, len(tc.unknowns))
 			for i := range tc.unknowns {
-				unk[i] = ast.MustParseTerm(tc.unknowns[i])
+				unk[i] = ast.MustParseRef(tc.unknowns[i])
 			}
 
 			hints := ft.Hints(unk)

--- a/v1/server/server.go
+++ b/v1/server/server.go
@@ -153,7 +153,7 @@ type Server struct {
 	cipherSuites                *[]uint16
 	hooks                       hooks.Hooks
 
-	compileUnknownsCache     *lru.Cache[string, []*ast.Term]
+	compileUnknownsCache     *lru.Cache[string, []ast.Ref]
 	compileMaskingRulesCache *lru.Cache[string, ast.Ref]
 }
 
@@ -187,7 +187,7 @@ type Loop func() error
 // New returns a new Server.
 func New() *Server {
 	s := Server{}
-	s.compileUnknownsCache, _ = lru.New[string, []*ast.Term](unknownsCacheSize)
+	s.compileUnknownsCache, _ = lru.New[string, []ast.Ref](unknownsCacheSize)
 	s.compileMaskingRulesCache, _ = lru.New[string, ast.Ref](maskingRuleCacheSize)
 	return &s
 }

--- a/v1/server/testdata/bench_filters.rego
+++ b/v1/server/testdata/bench_filters.rego
@@ -1,6 +1,6 @@
 # METADATA
 # scope: package
-# custom:
+# compile:
 #   unknowns:
 #     - input.tickets
 #     - input.users


### PR DESCRIPTION
This used to be

```
  custom:
    unknowns: [ ... ]
    mask_rule: ...
```

and now becomes
```
  compile:
    unknowns: [ ... ]
    mask_rule: ...
```

TODO:
- [x] adapt annotations types
- [x] handling of these annotations in the compile handler's helpers
- [x] docs