### PR TITLE
Some small improvements to inmem storage

### DIFF
--- a/cmd/test.go
+++ b/cmd/test.go
@@ -302,7 +302,7 @@ func processWatcherUpdate(ctx context.Context, testParams testCommandParams, pat
 	err := pathwatcher.ProcessWatcherUpdateForRegoVersion(ctx, testParams.RegoVersion(), paths, removed, store, filter, testParams.bundleMode, false,
 		func(ctx context.Context, txn storage.Transaction, loaded *initload.LoadPathsResult) error {
 			if len(loaded.Files.Documents) > 0 || removed != "" {
-				if err := store.Write(ctx, txn, storage.AddOp, storage.Path{}, loaded.Files.Documents); err != nil {
+				if err := store.Write(ctx, txn, storage.AddOp, storage.RootPath, loaded.Files.Documents); err != nil {
 					return fmt.Errorf("storage error: %w", err)
 				}
 			}

--- a/internal/bundle/utils.go
+++ b/internal/bundle/utils.go
@@ -72,7 +72,7 @@ func LoadWasmResolversFromStore(ctx context.Context, store storage.Store, txn st
 	var resolvers []*wasm.Resolver
 	if len(resolversToLoad) > 0 {
 		// Get a full snapshot of the current data (including any from "outside" the bundles)
-		data, err := store.Read(ctx, txn, storage.Path{})
+		data, err := store.Read(ctx, txn, storage.RootPath)
 		if err != nil {
 			return nil, fmt.Errorf("failed to initialize wasm runtime: %s", err)
 		}

--- a/internal/presentation/presentation_test.go
+++ b/internal/presentation/presentation_test.go
@@ -126,7 +126,7 @@ func TestOutputJSONErrorStructuredASTErr(t *testing.T) {
 func TestOutputJSONErrorStructuredStorageErr(t *testing.T) {
 	store := inmem.New()
 	txn := storage.NewTransactionOrDie(t.Context(), store)
-	err := store.Write(t.Context(), txn, storage.AddOp, storage.Path{}, map[string]any{"foo": 1})
+	err := store.Write(t.Context(), txn, storage.AddOp, storage.RootPath, map[string]any{"foo": 1})
 	expected := `{
   "errors": [
     {

--- a/internal/runtime/init/init.go
+++ b/internal/runtime/init/init.go
@@ -42,7 +42,7 @@ type InsertAndCompileResult struct {
 // store contents.
 func InsertAndCompile(ctx context.Context, opts InsertAndCompileOptions) (*InsertAndCompileResult, error) {
 	if len(opts.Files.Documents) > 0 {
-		if err := opts.Store.Write(ctx, opts.Txn, storage.AddOp, storage.Path{}, opts.Files.Documents); err != nil {
+		if err := opts.Store.Write(ctx, opts.Txn, storage.AddOp, storage.RootPath, opts.Files.Documents); err != nil {
 			return nil, fmt.Errorf("storage error: %w", err)
 		}
 	}

--- a/v1/debug/thread.go
+++ b/v1/debug/thread.go
@@ -471,7 +471,7 @@ func (t *thread) inputVars(e *topdown.Event) VarRef {
 func (t *thread) dataVars() VarRef {
 	return t.varManager.addVars(func() []namedVar {
 		ctx := context.Background()
-		d, err := storage.ReadOne(ctx, t.store, storage.Path{})
+		d, err := storage.ReadOne(ctx, t.store, storage.RootPath)
 		if err != nil {
 			return nil
 		}

--- a/v1/plugins/bundle/plugin_test.go
+++ b/v1/plugins/bundle/plugin_test.go
@@ -109,7 +109,7 @@ func TestPluginOneShot(t *testing.T) {
 		t.Fatalf("Bad policy content. Exp:\n%v\n\nGot:\n\n%v", string(exp), string(bs))
 	}
 
-	data, err := manager.Store.Read(ctx, txn, storage.Path{})
+	data, err := manager.Store.Read(ctx, txn, storage.RootPath)
 	expData := util.MustUnmarshalJSON([]byte(`{
 		"foo": {"bar": 1, "baz": "qux"},
 		"system": {
@@ -163,7 +163,7 @@ func TestPluginOneShotWithAstStore(t *testing.T) {
 	txn := storage.NewTransactionOrDie(ctx, manager.Store)
 	defer manager.Store.Abort(ctx, txn)
 
-	data, err := manager.Store.Read(ctx, txn, storage.Path{})
+	data, err := manager.Store.Read(ctx, txn, storage.RootPath)
 	expData := ast.MustParseTerm(`{"foo": {"bar": 1, "baz": "qux"}, "system": {"bundles": {"test-bundle": {"etag": "foo", "manifest": {"revision": "quickbrownfaux", "roots": [""]}}}}}`)
 	if err != nil {
 		t.Fatal(err)
@@ -993,7 +993,7 @@ func TestPluginStartLazyLoadInMem(t *testing.T) {
 				t.Fatalf("Bad policy content. Exp:\n%v\n\nGot:\n\n%v", string(exp), string(bs))
 			}
 
-			data, err := manager.Store.Read(ctx, txn, storage.Path{})
+			data, err := manager.Store.Read(ctx, txn, storage.RootPath)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1118,7 +1118,7 @@ func TestPluginOneShotDiskStorageMetrics(t *testing.T) {
 			t.Fatalf("Bad policy content. Exp:\n%v\n\nGot:\n\n%v", string(exp), string(bs))
 		}
 
-		data, err := manager.Store.Read(ctx, txn, storage.Path{})
+		data, err := manager.Store.Read(ctx, txn, storage.RootPath)
 		expData := util.MustUnmarshalJSON([]byte(`{
 			"foo": {"bar": 1, "baz": "qux"},
 			"system": {
@@ -1227,7 +1227,7 @@ func TestPluginOneShotDeltaBundle(t *testing.T) {
 		t.Fatalf("Bad policy content. Exp:\n%v\n\nGot:\n\n%v", string(exp), string(bs))
 	}
 
-	data, err := manager.Store.Read(ctx, txn, storage.Path{})
+	data, err := manager.Store.Read(ctx, txn, storage.RootPath)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1338,7 +1338,7 @@ func TestPluginOneShotDeltaBundleWithAstStore(t *testing.T) {
 		t.Fatalf("Bad policy content. Exp:\n%v\n\nGot:\n\n%v", string(exp), string(bs))
 	}
 
-	data, err := manager.Store.Read(ctx, txn, storage.Path{})
+	data, err := manager.Store.Read(ctx, txn, storage.RootPath)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1535,7 +1535,7 @@ func TestPluginOneShotBundlePersistence(t *testing.T) {
 		t.Fatalf("Bad policy content. Exp:\n%v\n\nGot:\n\n%v", string(exp), string(bs))
 	}
 
-	data, err := manager.Store.Read(ctx, txn, storage.Path{})
+	data, err := manager.Store.Read(ctx, txn, storage.RootPath)
 	expData := util.MustUnmarshalJSON([]byte(`{
 		"foo": {"bar": 1, "baz": "qux"},
 		"system": {
@@ -1731,7 +1731,7 @@ corge contains 1 if {
 					}
 				}`))
 
-				data, err := manager.Store.Read(ctx, txn, storage.Path{})
+				data, err := manager.Store.Read(ctx, txn, storage.RootPath)
 				if err != nil {
 					t.Fatal(err)
 				} else if !reflect.DeepEqual(data, expData) {
@@ -2017,7 +2017,7 @@ corge contains 1 if {
 					t.Fatalf("Bad policy content. Exp:\n%v\n\nGot:\n\n%v", string(exp), string(bs))
 				}
 
-				data, err := manager.Store.Read(ctx, txn, storage.Path{})
+				data, err := manager.Store.Read(ctx, txn, storage.RootPath)
 
 				var manifestRegoVersion string
 				var moduleRegoVersion string
@@ -2143,7 +2143,7 @@ func TestPluginOneShotSignedBundlePersistence(t *testing.T) {
 		t.Fatal("Expected no policy")
 	}
 
-	data, err := manager.Store.Read(ctx, txn, storage.Path{})
+	data, err := manager.Store.Read(ctx, txn, storage.RootPath)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2228,7 +2228,7 @@ func TestLoadAndActivateBundlesFromDisk(t *testing.T) {
 		t.Fatalf("Bad policy content. Exp:\n%v\n\nGot:\n\n%v", string(exp), string(bs))
 	}
 
-	data, err := manager.Store.Read(ctx, txn, storage.Path{})
+	data, err := manager.Store.Read(ctx, txn, storage.RootPath)
 	expData := util.MustUnmarshalJSON([]byte(`{
 		"foo": {"bar": 1, "baz": "qux"},
 		"system": {
@@ -2314,7 +2314,7 @@ func TestLoadAndActivateBundlesFromDiskReservedChars(t *testing.T) {
 		t.Fatalf("Bad policy content. Exp:\n%v\n\nGot:\n\n%v", string(exp), string(bs))
 	}
 
-	data, err := manager.Store.Read(ctx, txn, storage.Path{})
+	data, err := manager.Store.Read(ctx, txn, storage.RootPath)
 	expData := util.MustUnmarshalJSON([]byte(`{
 		"foo": {"bar": 1, "baz": "qux"},
 		"system": {
@@ -2570,7 +2570,7 @@ corge contains 2 if {
 						}
 					}`))
 
-					data, err := manager.Store.Read(ctx, txn, storage.Path{})
+					data, err := manager.Store.Read(ctx, txn, storage.RootPath)
 					if err != nil {
 						fatal(err)
 					} else if !reflect.DeepEqual(data, expData) {
@@ -2781,7 +2781,7 @@ corge contains 1 if {
 					t.Fatalf("Bad policy content. Exp:\n%v\n\nGot:\n\n%v", string(exp), string(bs))
 				}
 
-				data, err := manager.Store.Read(ctx, txn, storage.Path{})
+				data, err := manager.Store.Read(ctx, txn, storage.RootPath)
 
 				manifestRegoVersionStr := ""
 				if tc.bundleRegoVersion != nil {
@@ -3231,7 +3231,7 @@ func TestPluginOneShotActivationRemovesOld(t *testing.T) {
 		} else if !slices.Equal([]string{filepath.Join(bundleName, "example2.rego")}, ids) {
 			return errors.New("expected updated policy ids")
 		}
-		data, err := manager.Store.Read(ctx, txn, storage.Path{})
+		data, err := manager.Store.Read(ctx, txn, storage.RootPath)
 		// remove system key to make comparison simpler
 		delete(data.(map[string]any), "system")
 		if err != nil {
@@ -3884,7 +3884,7 @@ func TestPluginActivateScopedBundle(t *testing.T) {
 			if err := storage.Txn(ctx, manager.Store, storage.WriteParams, func(txn storage.Transaction) error {
 				externalData := map[string]any{"a": map[string]any{"a1": "x1", "a3": "x2", "a5": "x3"}}
 
-				if err := manager.Store.Write(ctx, txn, storage.AddOp, storage.Path{}, externalData); err != nil {
+				if err := manager.Store.Write(ctx, txn, storage.AddOp, storage.RootPath, externalData); err != nil {
 					return err
 				}
 				if err := manager.Store.UpsertPolicy(ctx, txn, "some/id1", []byte(`package a.a2`)); err != nil {
@@ -7137,7 +7137,7 @@ func TestPluginManualTriggerMultipleDiskStorage(t *testing.T) {
 			t.Fatalf("Bad policy content. Exp:\n%v\n\nGot:\n\n%v", string(exp), string(bs))
 		}
 
-		data, err := manager.Store.Read(ctx, txn, storage.Path{})
+		data, err := manager.Store.Read(ctx, txn, storage.RootPath)
 		expData := util.MustUnmarshalJSON([]byte(`{
 			"p": "x1", "q": "x2",
 			"system": {

--- a/v1/rego/example_test.go
+++ b/v1/rego/example_test.go
@@ -372,7 +372,7 @@ func ExampleRego_Eval_persistent_storage() {
 		// Handle error.
 	}
 
-	err = storage.WriteOne(ctx, store, storage.AddOp, storage.Path{}, json)
+	err = storage.WriteOne(ctx, store, storage.AddOp, storage.RootPath, json)
 	if err != nil {
 		// Handle error
 	}

--- a/v1/rego/rego.go
+++ b/v1/rego/rego.go
@@ -1798,7 +1798,7 @@ func (r *Rego) PrepareForEval(ctx context.Context, opts ...PrepareOption) (Prepa
 		}
 
 		// nolint: staticcheck // SA4006 false positive
-		data, err := r.store.Read(ctx, r.txn, storage.Path{})
+		data, err := r.store.Read(ctx, r.txn, storage.RootPath)
 		if err != nil {
 			_ = txnClose(ctx, err) // Ignore error
 			return PreparedEvalQuery{}, err
@@ -2020,7 +2020,7 @@ func (r *Rego) loadFiles(ctx context.Context, txn storage.Transaction, m metrics
 	}
 
 	if len(result.Documents) > 0 {
-		err = r.store.Write(ctx, txn, storage.AddOp, storage.Path{}, result.Documents)
+		err = r.store.Write(ctx, txn, storage.AddOp, storage.RootPath, result.Documents)
 		if err != nil {
 			return err
 		}

--- a/v1/repl/repl.go
+++ b/v1/repl/repl.go
@@ -1410,7 +1410,7 @@ func newCommand(line string) *command {
 }
 
 func dumpStorage(ctx context.Context, store storage.Store, txn storage.Transaction, w io.Writer) error {
-	data, err := store.Read(ctx, txn, storage.Path{})
+	data, err := store.Read(ctx, txn, storage.RootPath)
 	if err != nil {
 		return err
 	}

--- a/v1/storage/inmem/inmem_bench_test.go
+++ b/v1/storage/inmem/inmem_bench_test.go
@@ -1,0 +1,130 @@
+package inmem_test
+
+import (
+	"testing"
+
+	"github.com/open-policy-agent/opa/v1/storage"
+	"github.com/open-policy-agent/opa/v1/storage/inmem"
+)
+
+type (
+	txnType bool
+	target  struct {
+		name  string
+		store storage.Store
+	}
+	targets []target
+
+	withTxnFn func(b *testing.B, target storage.Store, txn storage.Transaction)
+	noTxnFn   func(b *testing.B, target storage.Store)
+)
+
+const (
+	readTxn  txnType = false
+	writeTxn txnType = true
+)
+
+func BenchmarkNewTransaction(b *testing.B) {
+	store := inmem.NewFromObject(map[string]any{})
+
+	for name, typ := range map[string]txnType{"Read": readTxn, "Write": writeTxn} {
+		b.Run(name, func(b *testing.B) {
+			for b.Loop() {
+				txn, err := store.NewTransaction(b.Context(), transactionParams(typ)...)
+				if err != nil {
+					b.Fatal(err)
+				}
+				store.Abort(b.Context(), txn)
+			}
+		})
+	}
+}
+
+func BenchmarkReadOne(b *testing.B) {
+	data := map[string]any{"foo": "bar"}
+	path := storage.Path{"foo"}
+
+	AllStores(data).Bench(b, func(b *testing.B, store storage.Store) {
+		if _, err := storage.ReadOne(b.Context(), store, path); err != nil {
+			b.Fatal(err)
+		}
+	})
+}
+
+func BenchmarkRead(b *testing.B) {
+	data := map[string]any{"foo": "bar"}
+	path := storage.Path{"foo"}
+
+	AllStores(data).BenchWithTxn(b, readTxn, func(b *testing.B, s storage.Store, txn storage.Transaction) {
+		if _, err := s.Read(b.Context(), txn, path); err != nil {
+			b.Fatal(err)
+		}
+	})
+}
+
+func BenchmarkWriteOne(b *testing.B) {
+	data := map[string]any{}
+	path := storage.Path{"foo"}
+
+	AllStores(data).Bench(b, func(b *testing.B, store storage.Store) {
+		if err := storage.WriteOne(b.Context(), store, storage.AddOp, path, "bar"); err != nil {
+			b.Fatal(err)
+		}
+	})
+}
+
+func transactionParams(mode txnType) (params []storage.TransactionParams) {
+	if mode == writeTxn {
+		params = append(params, storage.WriteParams)
+	}
+	return params
+}
+
+func AllStores(data map[string]any) targets {
+	return []target{
+		{
+			"Go store (roundtrip)",
+			inmem.NewFromObjectWithOpts(data, inmem.OptRoundTripOnWrite(true)),
+		},
+		{
+			"Go store (no roundtrip)",
+			inmem.NewFromObjectWithOpts(data, inmem.OptRoundTripOnWrite(false)),
+		},
+		{
+			"AST store (roundtrip)",
+			inmem.NewFromObjectWithOpts(data, inmem.OptReturnASTValuesOnRead(true), inmem.OptRoundTripOnWrite(true)),
+		},
+		{
+			"AST store (no roundtrip)",
+			inmem.NewFromObjectWithOpts(data, inmem.OptReturnASTValuesOnRead(true), inmem.OptRoundTripOnWrite(false)),
+		},
+	}
+}
+
+func (t targets) Bench(b *testing.B, fn noTxnFn) {
+	b.Helper()
+
+	for _, target := range t {
+		b.Run(target.name, func(b *testing.B) {
+			for b.Loop() {
+				fn(b, target.store)
+			}
+		})
+	}
+}
+
+func (t targets) BenchWithTxn(b *testing.B, mode txnType, fn withTxnFn) {
+	b.Helper()
+
+	for _, target := range t {
+		b.Run(target.name, func(b *testing.B) {
+			txn := storage.NewTransactionOrDie(b.Context(), target.store, transactionParams(mode)...)
+
+			for b.Loop() {
+				fn(b, target.store, txn)
+			}
+
+			target.store.Abort(b.Context(), txn)
+		})
+	}
+}

--- a/v1/storage/inmem/inmem_test.go
+++ b/v1/storage/inmem/inmem_test.go
@@ -195,7 +195,7 @@ func TestInMemoryWrite(t *testing.T) {
 				store := NewFromObjectWithOpts(data, OptReturnASTValuesOnRead(rvt.ast))
 
 				// Perform patch and check result
-				value := loadExpectedSortedResult(tc.value)
+				value := loadExpectedResult(tc.value)
 
 				var op storage.PatchOp
 				switch tc.op {
@@ -304,7 +304,7 @@ func TestInMemoryWriteOfStruct(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			expected := loadExpectedSortedResult(tc.expected)
+			expected := loadExpectedResult(tc.expected)
 			if !reflect.DeepEqual(expected, actual) {
 				t.Errorf("expected %v, got %v", tc.expected, actual)
 			}
@@ -1235,21 +1235,8 @@ func loadExpectedResult(input string) any {
 	if len(input) == 0 {
 		return nil
 	}
-	var data any
-	if err := util.UnmarshalJSON([]byte(input), &data); err != nil {
-		panic(err)
-	}
-	return data
-}
 
-func loadExpectedSortedResult(input string) any {
-	data := loadExpectedResult(input)
-	switch data := data.(type) {
-	case []any:
-		return data
-	default:
-		return data
-	}
+	return util.MustUnmarshalJSON([]byte(input))
 }
 
 func loadSmallTestData() map[string]any {

--- a/v1/storage/path_test.go
+++ b/v1/storage/path_test.go
@@ -23,7 +23,7 @@ func TestNewPathForString(t *testing.T) {
 	}{
 		{"", nil, false},
 		{"foo", nil, false},
-		{"/", Path{}, true},
+		{"/", RootPath, true},
 		{"/", nil, true},
 		{"/foo", Path{"foo"}, true},
 		{"/foo/bar", Path{"foo", "bar"}, true},
@@ -53,7 +53,7 @@ func TestNewPathForRef(t *testing.T) {
 		{ast.MustParseRef("data.foo[{1, 2}]"), nil, fmt.Errorf("composites cannot be base document keys: %v", ast.MustParseRef("data.foo[{1, 2}]"))},
 		{ast.MustParseRef(`data.foo[{"foo": 2}]`), nil, fmt.Errorf("composites cannot be base document keys: %v", ast.MustParseRef(`data.foo[{"foo": 2}]`))},
 
-		{ast.MustParseRef("data"), Path{}, nil},
+		{ast.MustParseRef("data"), RootPath, nil},
 		{ast.MustParseRef("data.foo"), Path{"foo"}, nil},
 		{ast.MustParseRef("data.foo[1]"), Path{"foo", "1"}, nil},
 		{ast.MustParseRef("data.foo.bar"), Path{"foo", "bar"}, nil},
@@ -70,12 +70,15 @@ func TestNewPathForRef(t *testing.T) {
 }
 
 func TestNewPathForStringEscaped(t *testing.T) {
-
 	tests := []struct {
 		input  string
 		result Path
 		ok     bool
 	}{
+		{
+			input: "",
+			ok:    false,
+		},
 		{
 			input:  "/foo/bar", // no escaping
 			result: Path{"foo", "bar"},
@@ -90,6 +93,11 @@ func TestNewPathForStringEscaped(t *testing.T) {
 			input:  "/foo%2F%2Fbar/baz", // double escape
 			result: Path{"foo//bar", "baz"},
 			ok:     true,
+		},
+		{
+			input:  "/foo%%%%bar",
+			result: nil, // invalid escaping
+			ok:     false,
 		},
 	}
 
@@ -107,9 +115,9 @@ func TestPathCompare(t *testing.T) {
 		b      Path
 		result int
 	}{
-		{Path{}, Path{}, 0},
-		{Path{}, Path{"x"}, -1},
-		{Path{"x"}, Path{}, 1},
+		{RootPath, RootPath, 0},
+		{RootPath, Path{"x"}, -1},
+		{Path{"x"}, RootPath, 1},
 		{Path{"x"}, Path{"x"}, 0},
 		{Path{"x"}, Path{"y"}, -1},
 		{Path{"x"}, Path{"w"}, 1},
@@ -133,9 +141,9 @@ func TestPathEqual(t *testing.T) {
 		b      Path
 		result bool
 	}{
-		{Path{}, Path{}, true},
-		{Path{}, Path{"foo"}, false},
-		{Path{"foo"}, Path{}, false},
+		{RootPath, RootPath, true},
+		{RootPath, Path{"foo"}, false},
+		{Path{"foo"}, RootPath, false},
 		{Path{"foo", "bar"}, Path{"foo"}, false},
 		{Path{"foo", "bar"}, Path{"foo", "bar"}, true},
 	}
@@ -153,15 +161,15 @@ func TestPathHasPrefix(t *testing.T) {
 		b      Path
 		result bool
 	}{
-		{Path{}, Path{}, true},
-		{Path{}, Path{"foo"}, false},
-		{Path{"foo"}, Path{}, true},
+		{RootPath, RootPath, true},
+		{RootPath, Path{"foo"}, false},
+		{Path{"foo"}, RootPath, true},
 		{Path{"foo"}, Path{"bar"}, false},
 		{Path{"bar"}, Path{"foo"}, false},
 		{Path{"foo", "bar"}, Path{"foo"}, true},
 		{Path{"foo", "bar"}, Path{"foo", "bar"}, true},
 		{Path{"foo", "bar"}, Path{"foo", "bar", "baz"}, false},
-		{Path{"foo", "bar", "baz"}, Path{}, true},
+		{Path{"foo", "bar", "baz"}, RootPath, true},
 	}
 	for _, tc := range tests {
 		result := tc.a.HasPrefix(tc.b)

--- a/v1/test/authz/authz_bench_test.go
+++ b/v1/test/authz/authz_bench_test.go
@@ -61,7 +61,7 @@ func runAuthzBenchmark(b *testing.B, mode InputMode, numPaths int, extras ...boo
 			b.Fatal(err)
 		}
 
-		if err = storage.WriteOne(ctx, store, storage.AddOp, storage.Path{}, data); err != nil {
+		if err = storage.WriteOne(ctx, store, storage.AddOp, storage.RootPath, data); err != nil {
 			b.Fatal(err)
 		}
 	} else {

--- a/v1/tester/runner.go
+++ b/v1/tester/runner.go
@@ -1172,10 +1172,12 @@ func LoadWithRegoVersion(args []string, filter loader.Filter, regoVersion ast.Re
 	}
 
 	var store storage.Store
+	ctx := context.Background()
+
 	if bundle.BundleExtStore != nil {
 		store = bundle.BundleExtStore()
 		// inline'd NewFromObject
-		if err := storage.WriteOne(context.Background(), store, storage.AddOp, storage.Path{}, loaded.Documents); err != nil {
+		if err := storage.WriteOne(ctx, store, storage.AddOp, storage.RootPath, loaded.Documents); err != nil {
 			return nil, nil, err
 		}
 	} else {
@@ -1183,7 +1185,7 @@ func LoadWithRegoVersion(args []string, filter loader.Filter, regoVersion ast.Re
 	}
 
 	modules := make(map[string]*ast.Module, len(loaded.Modules))
-	ctx := context.Background()
+
 	err = storage.Txn(ctx, store, storage.WriteParams, func(txn storage.Transaction) error {
 		for _, loadedModule := range loaded.Modules {
 			modules[loadedModule.Name] = loadedModule.Parsed
@@ -1213,12 +1215,15 @@ func LoadWithParserOptions(args []string, filter loader.Filter, popts ast.Parser
 	if err != nil {
 		return nil, nil, err
 	}
+
 	var store storage.Store
+	ctx := context.Background()
+
 	// Plumb in storage for external bundle activation plugin, if registered with bundle.RegisterStore.
 	if bundle.BundleExtStore != nil {
 		store = bundle.BundleExtStore()
 		// inline'd NewFromObject
-		if err := storage.WriteOne(context.Background(), store, storage.AddOp, storage.Path{}, loaded.Documents); err != nil {
+		if err := storage.WriteOne(ctx, store, storage.AddOp, storage.RootPath, loaded.Documents); err != nil {
 			return nil, nil, err
 		}
 	} else {
@@ -1226,7 +1231,6 @@ func LoadWithParserOptions(args []string, filter loader.Filter, popts ast.Parser
 	}
 
 	modules := make(map[string]*ast.Module, len(loaded.Modules))
-	ctx := context.Background()
 	err = storage.Txn(ctx, store, storage.WriteParams, func(txn storage.Transaction) error {
 		for _, loadedModule := range loaded.Modules {
 			modules[loadedModule.Name] = loadedModule.Parsed
@@ -1234,8 +1238,7 @@ func LoadWithParserOptions(args []string, filter loader.Filter, popts ast.Parser
 			// Add the policies to the store to ensure that any future bundle
 			// activations will preserve them and re-compile the module with
 			// the bundle modules.
-			err := store.UpsertPolicy(ctx, txn, loadedModule.Name, loadedModule.Raw)
-			if err != nil {
+			if err := store.UpsertPolicy(ctx, txn, loadedModule.Name, loadedModule.Raw); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
Mainly making transactions cheaper to create, and read transactions much cheaper.

- Add exported RootPath shorthand var
- Don't return path on ParsePathEscaped failure
- Allocate nothing for read transactions, other than the transaction itself
- Lazy init of write update collections to avoid needless allocations
- Add benchmarks

**Before**
```
BenchmarkNewTransaction/Read-16                     26707234            44.78 ns/op      144 B/op          3 allocs/op
BenchmarkNewTransaction/Write-16                    20344212            59.44 ns/op      192 B/op          4 allocs/op
BenchmarkReadOne/Go_store_(roundtrip)-16            21963003            54.41 ns/op      144 B/op          3 allocs/op
BenchmarkReadOne/Go_store_(no_roundtrip)-16         22217593            54.18 ns/op      144 B/op          3 allocs/op
BenchmarkReadOne/AST_store_(roundtrip)-16           15626653            76.52 ns/op      160 B/op          4 allocs/op
BenchmarkReadOne/AST_store_(no_roundtrip)-16        15820837            76.15 ns/op      160 B/op          4 allocs/op
```

**After**
```
BenchmarkNewTransaction/Read-16                     68091271            17.37 ns/op       48 B/op          1 allocs/op
BenchmarkNewTransaction/Write-16                    24928028            47.68 ns/op      144 B/op          3 allocs/op
BenchmarkReadOne/Go_store_(roundtrip)-16            42967630            28.10 ns/op       48 B/op          1 allocs/op
BenchmarkReadOne/Go_store_(no_roundtrip)-16         43825009            27.63 ns/op       48 B/op          1 allocs/op
BenchmarkReadOne/AST_store_(roundtrip)-16           24885938            48.06 ns/op       64 B/op          2 allocs/op
BenchmarkReadOne/AST_store_(no_roundtrip)-16        25012396            47.96 ns/op       64 B/op          2 allocs/op
```