### PR TITLE
docs: Update link checker config

### DIFF
--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -20,6 +20,8 @@ jobs:
     - name: Link Checker
       id: lychee
       uses: lycheeverse/lychee-action@885c65f3dc543b57c898c8099f4e08c8afd178a2 # v2.6.1
+      # ignored domains are a source of false positives in
+      # https://github.com/open-policy-agent/opa/issues/7888 for example
       with:
         args: >
           --max-concurrency 1
@@ -29,6 +31,9 @@ jobs:
           --exclude-path CHANGELOG.md
           --scheme https
           --scheme http
+          --exclude medium.com
+          --exclude blog.openpolicyagent.org
+          --exclude itnext.io
           --accept 200..=206,403,429
           --retry-wait-time 5
           --max-retries 1

--- a/docs/src/data/ecosystem/entries/kong-authorization.md
+++ b/docs/src/data/ecosystem/entries/kong-authorization.md
@@ -6,10 +6,10 @@ labels:
 software:
 - kong
 code:
-- https://github.com/TravelNest/kong-authorization-opa
 - https://github.com/open-policy-agent/contrib/tree/master/kong_api_authz
 inventors:
-- travelnest
 - wada-ama
 ---
-Kong is a microservice API Gateway.  OPA provides fine-grained, context-aware control over the requests that Kong receives.
+
+Kong is a microservice API Gateway. OPA provides fine-grained, context-aware
+control over the requests that Kong receives.


### PR DESCRIPTION
We have a lot of false positives in
https://github.com/open-policy-agent/opa/issues/7888, this ignores some domains that appear to block the scanning tool as `ERROR`.

Fixes https://github.com/open-policy-agent/opa/issues/7888

https://github.com/open-policy-agent/regal/pull/1704 fixes a number of others found in the Regal docs.
