### PR TITLE
add opa test --fail-on-empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Optionally fail when `opa test` did not run any tests
+
+With the new `--fail-on-empty` flag, accidentally running `opa test` in a directory without any tests or 
+with a `-r` that did not match any test names, can be caught by making the test fail instead.
+
 ## 1.9.0
 
 This release contains a mix of new features, performance improvements, and bugfixes. Notably:

--- a/docs/docs/policy-testing.md
+++ b/docs/docs/policy-testing.md
@@ -196,6 +196,11 @@ The `opa test` subcommand supports a `--run`/`-r` regex option to further
 specify which of the discovered tests should be evaluated. The option supports
 [re2 syntax](https://github.com/google/re2/wiki/Syntax)
 
+### Failing on No Tests Run
+
+When misspelling a test name or running no test by accident, `opa test` will still succeed, use `--fail-on-empty` to make it fail instead.
+This is also useful in CI/CD pipelines to ensure that tests are actually being executed.
+
 ## Test Results
 
 If the test rule is undefined or generates a non-`true` value the test result


### PR DESCRIPTION
### Why the changes in this PR are needed?

Setting a invalid `-r` for `opa test` makes it silently pass and that is unnoticeable when also using `--coverage` to read the generated output.

fixes https://github.com/open-policy-agent/opa/issues/7943#issuecomment-3362698960

### What are the changes in this PR?

Add new flag and test/document it.

### Manual testing
```
opa test --verbose --v0-compatible --run 'test_blocks_non_az_node_affinity' policies/k8sstatefulsetdonotschedule/src.rego --fail-on-empty
policies/k8sstatefulsetdonotschedule/test.rego:
data.k8sstatefulsetdonotschedule.test_blocks_non_az_node_affinity: PASS (555.5µs)
--------------------------------------------------------------------------------
PASS: 1/1
opa test --verbose --v0-compatible --run 'xtest_blocks_non_az_node_affinity' policies/k8sstatefulsetdonotschedule/src.rego --fail-on-empty
no tests were run
```