### PR TITLE
Ref String() and greatly improved builtin lookup cost

### DIFF
--- a/v1/ast/builtins.go
+++ b/v1/ast/builtins.go
@@ -347,7 +347,7 @@ var Equality = &Builtin{
 		types.Args(types.A, types.A),
 		types.B,
 	),
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 /**
@@ -362,7 +362,7 @@ var Assign = &Builtin{
 		types.Args(types.A, types.A),
 		types.B,
 	),
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 // Member represents the `in` (infix) operator.
@@ -376,7 +376,7 @@ var Member = &Builtin{
 		),
 		types.B,
 	),
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 // MemberWithKey represents the `in` (infix) operator when used
@@ -392,7 +392,7 @@ var MemberWithKey = &Builtin{
 		),
 		types.B,
 	),
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 /**
@@ -411,7 +411,7 @@ var GreaterThan = &Builtin{
 		),
 		types.Named("result", types.B).Description("true if `x` is greater than `y`; false otherwise"),
 	),
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var GreaterThanEq = &Builtin{
@@ -425,7 +425,7 @@ var GreaterThanEq = &Builtin{
 		),
 		types.Named("result", types.B).Description("true if `x` is greater or equal to `y`; false otherwise"),
 	),
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 // LessThan represents the "<" comparison operator.
@@ -440,7 +440,7 @@ var LessThan = &Builtin{
 		),
 		types.Named("result", types.B).Description("true if `x` is less than `y`; false otherwise"),
 	),
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var LessThanEq = &Builtin{
@@ -454,7 +454,7 @@ var LessThanEq = &Builtin{
 		),
 		types.Named("result", types.B).Description("true if `x` is less than or equal to `y`; false otherwise"),
 	),
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var NotEqual = &Builtin{
@@ -468,7 +468,7 @@ var NotEqual = &Builtin{
 		),
 		types.Named("result", types.B).Description("true if `x` is not equal to `y`; false otherwise"),
 	),
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 // Equal represents the "==" comparison operator.
@@ -483,7 +483,7 @@ var Equal = &Builtin{
 		),
 		types.Named("result", types.B).Description("true if `x` is equal to `y`; false otherwise"),
 	),
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 /**
@@ -503,7 +503,7 @@ var Plus = &Builtin{
 		types.Named("z", types.N).Description("the sum of `x` and `y`"),
 	),
 	Categories:  number,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var Minus = &Builtin{
@@ -518,7 +518,7 @@ var Minus = &Builtin{
 		types.Named("z", types.NewAny(types.N, types.SetOfAny)).Description("the difference of `x` and `y`"),
 	),
 	Categories:  category("sets", "numbers"),
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var Multiply = &Builtin{
@@ -533,7 +533,7 @@ var Multiply = &Builtin{
 		types.Named("z", types.N).Description("the product of `x` and `y`"),
 	),
 	Categories:  number,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var Divide = &Builtin{
@@ -548,7 +548,7 @@ var Divide = &Builtin{
 		types.Named("z", types.N).Description("the result of `x` divided by `y`"),
 	),
 	Categories:  number,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var Round = &Builtin{
@@ -561,7 +561,7 @@ var Round = &Builtin{
 		types.Named("y", types.N).Description("the result of rounding `x`"),
 	),
 	Categories:  number,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var Ceil = &Builtin{
@@ -574,7 +574,7 @@ var Ceil = &Builtin{
 		types.Named("y", types.N).Description("the result of rounding `x` _up_"),
 	),
 	Categories:  number,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var Floor = &Builtin{
@@ -587,7 +587,7 @@ var Floor = &Builtin{
 		types.Named("y", types.N).Description("the result of rounding `x` _down_"),
 	),
 	Categories:  number,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var Abs = &Builtin{
@@ -600,7 +600,7 @@ var Abs = &Builtin{
 		types.Named("y", types.N).Description("the absolute value of `x`"),
 	),
 	Categories:  number,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var Rem = &Builtin{
@@ -615,7 +615,7 @@ var Rem = &Builtin{
 		types.Named("z", types.N).Description("the remainder"),
 	),
 	Categories:  number,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 /**
@@ -632,7 +632,7 @@ var BitsOr = &Builtin{
 		),
 		types.Named("z", types.N).Description("the bitwise OR of `x` and `y`"),
 	),
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var BitsAnd = &Builtin{
@@ -645,7 +645,7 @@ var BitsAnd = &Builtin{
 		),
 		types.Named("z", types.N).Description("the bitwise AND of `x` and `y`"),
 	),
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var BitsNegate = &Builtin{
@@ -657,7 +657,7 @@ var BitsNegate = &Builtin{
 		),
 		types.Named("z", types.N).Description("the bitwise negation of `x`"),
 	),
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var BitsXOr = &Builtin{
@@ -670,7 +670,7 @@ var BitsXOr = &Builtin{
 		),
 		types.Named("z", types.N).Description("the bitwise XOR of `x` and `y`"),
 	),
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var BitsShiftLeft = &Builtin{
@@ -683,7 +683,7 @@ var BitsShiftLeft = &Builtin{
 		),
 		types.Named("z", types.N).Description("the result of shifting `x` `s` bits to the left"),
 	),
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var BitsShiftRight = &Builtin{
@@ -696,7 +696,7 @@ var BitsShiftRight = &Builtin{
 		),
 		types.Named("z", types.N).Description("the result of shifting `x` `s` bits to the right"),
 	),
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 /**
@@ -717,7 +717,7 @@ var And = &Builtin{
 		types.Named("z", types.SetOfAny).Description("the intersection of `x` and `y`"),
 	),
 	Categories:  sets,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 // Or performs a union operation on sets.
@@ -733,7 +733,7 @@ var Or = &Builtin{
 		types.Named("z", types.SetOfAny).Description("the union of `x` and `y`"),
 	),
 	Categories:  sets,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var Intersection = &Builtin{
@@ -746,7 +746,7 @@ var Intersection = &Builtin{
 		types.Named("y", types.SetOfAny).Description("the intersection of all `xs` sets"),
 	),
 	Categories:  sets,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var Union = &Builtin{
@@ -759,7 +759,7 @@ var Union = &Builtin{
 		types.Named("y", types.SetOfAny).Description("the union of all `xs` sets"),
 	),
 	Categories:  sets,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 /**
@@ -783,7 +783,7 @@ var Count = &Builtin{
 		types.Named("n", types.N).Description("the count of elements, key/val pairs, or characters, respectively."),
 	),
 	Categories:  aggregates,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var Sum = &Builtin{
@@ -799,7 +799,7 @@ var Sum = &Builtin{
 		types.Named("n", types.N).Description("the sum of all elements"),
 	),
 	Categories:  aggregates,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var Product = &Builtin{
@@ -815,7 +815,7 @@ var Product = &Builtin{
 		types.Named("n", types.N).Description("the product of all elements"),
 	),
 	Categories:  aggregates,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var Max = &Builtin{
@@ -831,7 +831,7 @@ var Max = &Builtin{
 		types.Named("n", types.A).Description("the maximum of all elements"),
 	),
 	Categories:  aggregates,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var Min = &Builtin{
@@ -847,7 +847,7 @@ var Min = &Builtin{
 		types.Named("n", types.A).Description("the minimum of all elements"),
 	),
 	Categories:  aggregates,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 /**
@@ -867,7 +867,7 @@ var Sort = &Builtin{
 		types.Named("n", types.NewArray(nil, types.A)).Description("the sorted array"),
 	),
 	Categories:  aggregates,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 /**
@@ -884,7 +884,7 @@ var ArrayConcat = &Builtin{
 		),
 		types.Named("z", types.NewArray(nil, types.A)).Description("the concatenation of `x` and `y`"),
 	),
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var ArraySlice = &Builtin{
@@ -898,7 +898,7 @@ var ArraySlice = &Builtin{
 		),
 		types.Named("slice", types.NewArray(nil, types.A)).Description("the subslice of `array`, from `start` to `end`, including `arr[start]`, but excluding `arr[end]`"),
 	),
-	canSkipBctx: true,
+	CanSkipBctx: true,
 } // NOTE(sr): this function really needs examples
 
 var ArrayReverse = &Builtin{
@@ -910,7 +910,7 @@ var ArrayReverse = &Builtin{
 		),
 		types.Named("rev", types.NewArray(nil, types.A)).Description("an array containing the elements of `arr` in reverse order"),
 	),
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 /**
@@ -933,7 +933,7 @@ var ToNumber = &Builtin{
 		types.Named("num", types.N).Description("the numeric representation of `x`"),
 	),
 	Categories:  conversions,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 /**
@@ -961,7 +961,7 @@ var RegexIsValid = &Builtin{
 		),
 		types.Named("result", types.B).Description("true if `pattern` is a valid regular expression"),
 	),
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var RegexFindAllStringSubmatch = &Builtin{
@@ -975,7 +975,7 @@ var RegexFindAllStringSubmatch = &Builtin{
 		),
 		types.Named("output", types.NewArray(nil, types.NewArray(nil, types.S))).Description("array of all matches"),
 	),
-	canSkipBctx: false,
+	CanSkipBctx: false,
 }
 
 var RegexTemplateMatch = &Builtin{
@@ -990,7 +990,7 @@ var RegexTemplateMatch = &Builtin{
 		),
 		types.Named("result", types.B).Description("true if `value` matches the `template`"),
 	),
-	canSkipBctx: true,
+	CanSkipBctx: true,
 } // TODO(sr): example:`regex.template_match("urn:foo:{.*}", "urn:foo:bar:baz", "{", "}")`` returns ``true``.
 
 var RegexSplit = &Builtin{
@@ -1003,7 +1003,7 @@ var RegexSplit = &Builtin{
 		),
 		types.Named("output", types.NewArray(nil, types.S)).Description("the parts obtained by splitting `value`"),
 	),
-	canSkipBctx: false,
+	CanSkipBctx: false,
 }
 
 // RegexFind takes two strings and a number, the pattern, the value and number of match values to
@@ -1019,7 +1019,7 @@ var RegexFind = &Builtin{
 		),
 		types.Named("output", types.NewArray(nil, types.S)).Description("collected matches"),
 	),
-	canSkipBctx: false,
+	CanSkipBctx: false,
 }
 
 // GlobsMatch takes two strings regexp-style strings and evaluates to true if their
@@ -1038,7 +1038,7 @@ The set of regex symbols is limited for this builtin: only ` + "`.`, `*`, `+`, `
 		),
 		types.Named("result", types.B).Description("true if the intersection of `glob1` and `glob2` matches a non-empty set of non-empty strings"),
 	),
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 /**
@@ -1065,7 +1065,7 @@ var AnyPrefixMatch = &Builtin{
 		types.Named("result", types.B).Description("result of the prefix check"),
 	),
 	Categories:  stringsCat,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var AnySuffixMatch = &Builtin{
@@ -1087,7 +1087,7 @@ var AnySuffixMatch = &Builtin{
 		types.Named("result", types.B).Description("result of the suffix check"),
 	),
 	Categories:  stringsCat,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var Concat = &Builtin{
@@ -1104,7 +1104,7 @@ var Concat = &Builtin{
 		types.Named("output", types.S).Description("the joined string"),
 	),
 	Categories:  stringsCat,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var FormatInt = &Builtin{
@@ -1118,7 +1118,7 @@ var FormatInt = &Builtin{
 		types.Named("output", types.S).Description("formatted number"),
 	),
 	Categories:  stringsCat,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var IndexOf = &Builtin{
@@ -1132,7 +1132,7 @@ var IndexOf = &Builtin{
 		types.Named("output", types.N).Description("index of first occurrence, `-1` if not found"),
 	),
 	Categories:  stringsCat,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var IndexOfN = &Builtin{
@@ -1146,7 +1146,7 @@ var IndexOfN = &Builtin{
 		types.Named("output", types.NewArray(nil, types.N)).Description("all indices at which `needle` occurs in `haystack`, may be empty"),
 	),
 	Categories:  stringsCat,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var Substring = &Builtin{
@@ -1161,7 +1161,7 @@ var Substring = &Builtin{
 		types.Named("output", types.S).Description("substring of `value` from `offset`, of length `length`"),
 	),
 	Categories:  stringsCat,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var Contains = &Builtin{
@@ -1175,7 +1175,7 @@ var Contains = &Builtin{
 		types.Named("result", types.B).Description("result of the containment check"),
 	),
 	Categories:  stringsCat,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var StringCount = &Builtin{
@@ -1189,7 +1189,7 @@ var StringCount = &Builtin{
 		types.Named("output", types.N).Description("count of occurrences, `0` if not found"),
 	),
 	Categories:  stringsCat,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var StartsWith = &Builtin{
@@ -1203,7 +1203,7 @@ var StartsWith = &Builtin{
 		types.Named("result", types.B).Description("result of the prefix check"),
 	),
 	Categories:  stringsCat,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var EndsWith = &Builtin{
@@ -1217,7 +1217,7 @@ var EndsWith = &Builtin{
 		types.Named("result", types.B).Description("result of the suffix check"),
 	),
 	Categories:  stringsCat,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var Lower = &Builtin{
@@ -1230,7 +1230,7 @@ var Lower = &Builtin{
 		types.Named("y", types.S).Description("lower-case of x"),
 	),
 	Categories:  stringsCat,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var Upper = &Builtin{
@@ -1243,7 +1243,7 @@ var Upper = &Builtin{
 		types.Named("y", types.S).Description("upper-case of x"),
 	),
 	Categories:  stringsCat,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var Split = &Builtin{
@@ -1257,7 +1257,7 @@ var Split = &Builtin{
 		types.Named("ys", types.NewArray(nil, types.S)).Description("split parts"),
 	),
 	Categories:  stringsCat,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var Replace = &Builtin{
@@ -1272,7 +1272,7 @@ var Replace = &Builtin{
 		types.Named("y", types.S).Description("string with replaced substrings"),
 	),
 	Categories:  stringsCat,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var ReplaceN = &Builtin{
@@ -1292,7 +1292,7 @@ The old string comparisons are done in argument order.`,
 		),
 		types.Named("output", types.S).Description("string with replaced substrings"),
 	),
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var RegexReplace = &Builtin{
@@ -1306,7 +1306,7 @@ var RegexReplace = &Builtin{
 		),
 		types.Named("output", types.S).Description("string with replaced substrings"),
 	),
-	canSkipBctx: false,
+	CanSkipBctx: false,
 }
 
 var Trim = &Builtin{
@@ -1320,7 +1320,7 @@ var Trim = &Builtin{
 		types.Named("output", types.S).Description("string trimmed of `cutset` characters"),
 	),
 	Categories:  stringsCat,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var TrimLeft = &Builtin{
@@ -1334,7 +1334,7 @@ var TrimLeft = &Builtin{
 		types.Named("output", types.S).Description("string left-trimmed of `cutset` characters"),
 	),
 	Categories:  stringsCat,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var TrimPrefix = &Builtin{
@@ -1348,7 +1348,7 @@ var TrimPrefix = &Builtin{
 		types.Named("output", types.S).Description("string with `prefix` cut off"),
 	),
 	Categories:  stringsCat,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var TrimRight = &Builtin{
@@ -1362,7 +1362,7 @@ var TrimRight = &Builtin{
 		types.Named("output", types.S).Description("string right-trimmed of `cutset` characters"),
 	),
 	Categories:  stringsCat,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var TrimSuffix = &Builtin{
@@ -1376,7 +1376,7 @@ var TrimSuffix = &Builtin{
 		types.Named("output", types.S).Description("string with `suffix` cut off"),
 	),
 	Categories:  stringsCat,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var TrimSpace = &Builtin{
@@ -1389,7 +1389,7 @@ var TrimSpace = &Builtin{
 		types.Named("output", types.S).Description("string leading and trailing white space cut off"),
 	),
 	Categories:  stringsCat,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var Sprintf = &Builtin{
@@ -1403,7 +1403,7 @@ var Sprintf = &Builtin{
 		types.Named("output", types.S).Description("`format` formatted by the values in `values`"),
 	),
 	Categories:  stringsCat,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var StringReverse = &Builtin{
@@ -1416,7 +1416,7 @@ var StringReverse = &Builtin{
 		types.Named("y", types.S).Description("reversed string"),
 	),
 	Categories:  stringsCat,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var RenderTemplate = &Builtin{
@@ -1431,7 +1431,7 @@ var RenderTemplate = &Builtin{
 		types.Named("result", types.S).Description("rendered template with template variables injected"),
 	),
 	Categories:  stringsCat,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 /**
@@ -1452,7 +1452,7 @@ var RandIntn = &Builtin{
 	),
 	Categories:       number,
 	Nondeterministic: true,
-	canSkipBctx:      false,
+	CanSkipBctx:      false,
 }
 
 var NumbersRange = &Builtin{
@@ -1465,7 +1465,7 @@ var NumbersRange = &Builtin{
 		),
 		types.Named("range", types.NewArray(nil, types.N)).Description("the range between `a` and `b`"),
 	),
-	canSkipBctx: false, // needed for context timeout check
+	CanSkipBctx: false, // needed for context timeout check
 }
 
 var NumbersRangeStep = &Builtin{
@@ -1483,7 +1483,7 @@ var NumbersRangeStep = &Builtin{
 		),
 		types.Named("range", types.NewArray(nil, types.N)).Description("the range between `a` and `b` in `step` increments"),
 	),
-	canSkipBctx: false, // needed for context timeout check
+	CanSkipBctx: false, // needed for context timeout check
 }
 
 /**
@@ -1508,7 +1508,7 @@ respectively. Other units are case-insensitive.`,
 		),
 		types.Named("y", types.N).Description("the parsed number"),
 	),
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var UnitsParseBytes = &Builtin{
@@ -1527,7 +1527,7 @@ and "MiB" are equivalent).`,
 		),
 		types.Named("y", types.N).Description("the parsed number"),
 	),
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 //
@@ -1547,7 +1547,7 @@ var UUIDRFC4122 = &Builtin{
 		types.Named("output", types.S).Description("a version 4 UUID; for any given `k`, the output will be consistent throughout a query evaluation"),
 	),
 	Nondeterministic: true,
-	canSkipBctx:      false,
+	CanSkipBctx:      false,
 }
 
 var UUIDParse = &Builtin{
@@ -1561,7 +1561,7 @@ var UUIDParse = &Builtin{
 		types.Named("result", types.NewObject(nil, types.NewDynamicProperty(types.S, types.A))).Description("Properties of UUID if valid (version, variant, etc). Undefined otherwise."),
 	),
 	Relation:    false,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 /**
@@ -1606,7 +1606,7 @@ var JSONFilter = &Builtin{
 		types.Named("filtered", types.A).Description("remaining data from `object` with only keys specified in `paths`"),
 	),
 	Categories:  objectCat,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var JSONRemove = &Builtin{
@@ -1645,7 +1645,7 @@ var JSONRemove = &Builtin{
 		types.Named("output", types.A).Description("result of removing all keys specified in `paths`"),
 	),
 	Categories:  objectCat,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var JSONPatch = &Builtin{
@@ -1671,7 +1671,7 @@ var JSONPatch = &Builtin{
 		types.Named("output", types.A).Description("result obtained after consecutively applying all patch operations in `patches`"),
 	),
 	Categories:  objectCat,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var ObjectSubset = &Builtin{
@@ -1705,7 +1705,7 @@ var ObjectSubset = &Builtin{
 		),
 		types.Named("result", types.A).Description("`true` if `sub` is a subset of `super`"),
 	),
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var ObjectUnion = &Builtin{
@@ -1725,7 +1725,7 @@ var ObjectUnion = &Builtin{
 		),
 		types.Named("output", types.A).Description("a new object which is the result of an asymmetric recursive union of two objects where conflicts are resolved by choosing the key from the right-hand object `b`"),
 	), // TODO(sr): types.A?  ^^^^^^^ (also below)
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var ObjectUnionN = &Builtin{
@@ -1741,7 +1741,7 @@ var ObjectUnionN = &Builtin{
 		),
 		types.Named("output", types.A).Description("asymmetric recursive union of all objects in `objects`, merged from left to right, where conflicts are resolved by choosing the key from the right-hand object"),
 	),
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var ObjectRemove = &Builtin{
@@ -1761,7 +1761,7 @@ var ObjectRemove = &Builtin{
 		),
 		types.Named("output", types.A).Description("result of removing the specified `keys` from `object`"),
 	),
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var ObjectFilter = &Builtin{
@@ -1782,7 +1782,7 @@ var ObjectFilter = &Builtin{
 		),
 		types.Named("filtered", types.A).Description("remaining data from `object` with only keys specified in `keys`"),
 	),
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var ObjectGet = &Builtin{
@@ -1798,7 +1798,7 @@ var ObjectGet = &Builtin{
 		),
 		types.Named("value", types.A).Description("`object[key]` if present, otherwise `default`"),
 	),
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var ObjectKeys = &Builtin{
@@ -1811,7 +1811,7 @@ var ObjectKeys = &Builtin{
 		),
 		types.Named("value", types.SetOfAny).Description("set of `object`'s keys"),
 	),
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 /*
@@ -1829,7 +1829,7 @@ var JSONMarshal = &Builtin{
 		types.Named("y", types.S).Description("the JSON string representation of `x`"),
 	),
 	Categories:  encoding,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var JSONMarshalWithOptions = &Builtin{
@@ -1851,7 +1851,7 @@ var JSONMarshalWithOptions = &Builtin{
 		types.Named("y", types.S).Description("the JSON string representation of `x`, with configured prefix/indent string(s) as appropriate"),
 	),
 	Categories:  encoding,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var JSONUnmarshal = &Builtin{
@@ -1864,7 +1864,7 @@ var JSONUnmarshal = &Builtin{
 		types.Named("y", types.A).Description("the term deserialized from `x`"),
 	),
 	Categories:  encoding,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var JSONIsValid = &Builtin{
@@ -1877,7 +1877,7 @@ var JSONIsValid = &Builtin{
 		types.Named("result", types.B).Description("`true` if `x` is valid JSON, `false` otherwise"),
 	),
 	Categories:  encoding,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var Base64Encode = &Builtin{
@@ -1890,7 +1890,7 @@ var Base64Encode = &Builtin{
 		types.Named("y", types.S).Description("base64 serialization of `x`"),
 	),
 	Categories:  encoding,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var Base64Decode = &Builtin{
@@ -1903,7 +1903,7 @@ var Base64Decode = &Builtin{
 		types.Named("y", types.S).Description("base64 deserialization of `x`"),
 	),
 	Categories:  encoding,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var Base64IsValid = &Builtin{
@@ -1916,7 +1916,7 @@ var Base64IsValid = &Builtin{
 		types.Named("result", types.B).Description("`true` if `x` is valid base64 encoded value, `false` otherwise"),
 	),
 	Categories:  encoding,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var Base64UrlEncode = &Builtin{
@@ -1929,7 +1929,7 @@ var Base64UrlEncode = &Builtin{
 		types.Named("y", types.S).Description("base64url serialization of `x`"),
 	),
 	Categories:  encoding,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var Base64UrlEncodeNoPad = &Builtin{
@@ -1942,7 +1942,7 @@ var Base64UrlEncodeNoPad = &Builtin{
 		types.Named("y", types.S).Description("base64url serialization of `x`"),
 	),
 	Categories:  encoding,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var Base64UrlDecode = &Builtin{
@@ -1955,7 +1955,7 @@ var Base64UrlDecode = &Builtin{
 		types.Named("y", types.S).Description("base64url deserialization of `x`"),
 	),
 	Categories:  encoding,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var URLQueryDecode = &Builtin{
@@ -1968,7 +1968,7 @@ var URLQueryDecode = &Builtin{
 		types.Named("y", types.S).Description("URL-encoding deserialization of `x`"),
 	),
 	Categories:  encoding,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var URLQueryEncode = &Builtin{
@@ -1981,7 +1981,7 @@ var URLQueryEncode = &Builtin{
 		types.Named("y", types.S).Description("URL-encoding serialization of `x`"),
 	),
 	Categories:  encoding,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var URLQueryEncodeObject = &Builtin{
@@ -2005,7 +2005,7 @@ var URLQueryEncodeObject = &Builtin{
 		types.Named("y", types.S).Description("the URL-encoded serialization of `object`"),
 	),
 	Categories:  encoding,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var URLQueryDecodeObject = &Builtin{
@@ -2020,7 +2020,7 @@ var URLQueryDecodeObject = &Builtin{
 			types.NewArray(nil, types.S)))).Description("the resulting object"),
 	),
 	Categories:  encoding,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var YAMLMarshal = &Builtin{
@@ -2033,7 +2033,7 @@ var YAMLMarshal = &Builtin{
 		types.Named("y", types.S).Description("the YAML string representation of `x`"),
 	),
 	Categories:  encoding,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var YAMLUnmarshal = &Builtin{
@@ -2046,7 +2046,7 @@ var YAMLUnmarshal = &Builtin{
 		types.Named("y", types.A).Description("the term deserialized from `x`"),
 	),
 	Categories:  encoding,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 // YAMLIsValid verifies the input string is a valid YAML document.
@@ -2060,7 +2060,7 @@ var YAMLIsValid = &Builtin{
 		types.Named("result", types.B).Description("`true` if `x` is valid YAML, `false` otherwise"),
 	),
 	Categories:  encoding,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var HexEncode = &Builtin{
@@ -2073,7 +2073,7 @@ var HexEncode = &Builtin{
 		types.Named("y", types.S).Description("serialization of `x` using hex-encoding"),
 	),
 	Categories:  encoding,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var HexDecode = &Builtin{
@@ -2086,7 +2086,7 @@ var HexDecode = &Builtin{
 		types.Named("y", types.S).Description("deserialized from `x`"),
 	),
 	Categories:  encoding,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 /**
@@ -2108,7 +2108,7 @@ var JWTDecode = &Builtin{
 		}, nil)).Description("`[header, payload, sig]`, where `header` and `payload` are objects; `sig` is the hexadecimal representation of the signature on the token."),
 	),
 	Categories:  tokensCat,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var JWTVerifyRS256 = &Builtin{
@@ -2122,7 +2122,7 @@ var JWTVerifyRS256 = &Builtin{
 		types.Named("result", types.B).Description("`true` if the signature is valid, `false` otherwise"),
 	),
 	Categories:  tokensCat,
-	canSkipBctx: false,
+	CanSkipBctx: false,
 }
 
 var JWTVerifyRS384 = &Builtin{
@@ -2136,7 +2136,7 @@ var JWTVerifyRS384 = &Builtin{
 		types.Named("result", types.B).Description("`true` if the signature is valid, `false` otherwise"),
 	),
 	Categories:  tokensCat,
-	canSkipBctx: false,
+	CanSkipBctx: false,
 }
 
 var JWTVerifyRS512 = &Builtin{
@@ -2150,7 +2150,7 @@ var JWTVerifyRS512 = &Builtin{
 		types.Named("result", types.B).Description("`true` if the signature is valid, `false` otherwise"),
 	),
 	Categories:  tokensCat,
-	canSkipBctx: false,
+	CanSkipBctx: false,
 }
 
 var JWTVerifyPS256 = &Builtin{
@@ -2164,7 +2164,7 @@ var JWTVerifyPS256 = &Builtin{
 		types.Named("result", types.B).Description("`true` if the signature is valid, `false` otherwise"),
 	),
 	Categories:  tokensCat,
-	canSkipBctx: false,
+	CanSkipBctx: false,
 }
 
 var JWTVerifyPS384 = &Builtin{
@@ -2178,7 +2178,7 @@ var JWTVerifyPS384 = &Builtin{
 		types.Named("result", types.B).Description("`true` if the signature is valid, `false` otherwise"),
 	),
 	Categories:  tokensCat,
-	canSkipBctx: false,
+	CanSkipBctx: false,
 }
 
 var JWTVerifyPS512 = &Builtin{
@@ -2192,7 +2192,7 @@ var JWTVerifyPS512 = &Builtin{
 		types.Named("result", types.B).Description("`true` if the signature is valid, `false` otherwise"),
 	),
 	Categories:  tokensCat,
-	canSkipBctx: false,
+	CanSkipBctx: false,
 }
 
 var JWTVerifyES256 = &Builtin{
@@ -2206,7 +2206,7 @@ var JWTVerifyES256 = &Builtin{
 		types.Named("result", types.B).Description("`true` if the signature is valid, `false` otherwise"),
 	),
 	Categories:  tokensCat,
-	canSkipBctx: false,
+	CanSkipBctx: false,
 }
 
 var JWTVerifyES384 = &Builtin{
@@ -2220,7 +2220,7 @@ var JWTVerifyES384 = &Builtin{
 		types.Named("result", types.B).Description("`true` if the signature is valid, `false` otherwise"),
 	),
 	Categories:  tokensCat,
-	canSkipBctx: false,
+	CanSkipBctx: false,
 }
 
 var JWTVerifyES512 = &Builtin{
@@ -2234,7 +2234,7 @@ var JWTVerifyES512 = &Builtin{
 		types.Named("result", types.B).Description("`true` if the signature is valid, `false` otherwise"),
 	),
 	Categories:  tokensCat,
-	canSkipBctx: false,
+	CanSkipBctx: false,
 }
 
 var JWTVerifyEdDSA = &Builtin{
@@ -2248,7 +2248,7 @@ var JWTVerifyEdDSA = &Builtin{
 		types.Named("result", types.B).Description("`true` if the signature is valid, `false` otherwise"),
 	),
 	Categories:  tokensCat,
-	canSkipBctx: false,
+	CanSkipBctx: false,
 }
 
 var JWTVerifyHS256 = &Builtin{
@@ -2262,7 +2262,7 @@ var JWTVerifyHS256 = &Builtin{
 		types.Named("result", types.B).Description("`true` if the signature is valid, `false` otherwise"),
 	),
 	Categories:  tokensCat,
-	canSkipBctx: false,
+	CanSkipBctx: false,
 }
 
 var JWTVerifyHS384 = &Builtin{
@@ -2276,7 +2276,7 @@ var JWTVerifyHS384 = &Builtin{
 		types.Named("result", types.B).Description("`true` if the signature is valid, `false` otherwise"),
 	),
 	Categories:  tokensCat,
-	canSkipBctx: false,
+	CanSkipBctx: false,
 }
 
 var JWTVerifyHS512 = &Builtin{
@@ -2290,7 +2290,7 @@ var JWTVerifyHS512 = &Builtin{
 		types.Named("result", types.B).Description("`true` if the signature is valid, `false` otherwise"),
 	),
 	Categories:  tokensCat,
-	canSkipBctx: false,
+	CanSkipBctx: false,
 }
 
 // Marked non-deterministic because it relies on time internally.
@@ -2311,7 +2311,7 @@ Supports the following algorithms: HS256, HS384, HS512, RS256, RS384, RS512, ES2
 	),
 	Categories:       tokensCat,
 	Nondeterministic: true,
-	canSkipBctx:      false,
+	CanSkipBctx:      false,
 }
 
 var tokenSign = category("tokensign")
@@ -2330,7 +2330,7 @@ var JWTEncodeSignRaw = &Builtin{
 	),
 	Categories:       tokenSign,
 	Nondeterministic: true,
-	canSkipBctx:      false,
+	CanSkipBctx:      false,
 }
 
 // Marked non-deterministic because it relies on RNG internally.
@@ -2347,7 +2347,7 @@ var JWTEncodeSign = &Builtin{
 	),
 	Categories:       tokenSign,
 	Nondeterministic: true,
-	canSkipBctx:      false,
+	CanSkipBctx:      false,
 }
 
 /**
@@ -2363,7 +2363,7 @@ var NowNanos = &Builtin{
 		types.Named("now", types.N).Description("nanoseconds since epoch"),
 	),
 	Nondeterministic: true,
-	canSkipBctx:      false,
+	CanSkipBctx:      false,
 }
 
 var ParseNanos = &Builtin{
@@ -2376,7 +2376,7 @@ var ParseNanos = &Builtin{
 		),
 		types.Named("ns", types.N).Description("`value` in nanoseconds since epoch"),
 	),
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var ParseRFC3339Nanos = &Builtin{
@@ -2388,7 +2388,7 @@ var ParseRFC3339Nanos = &Builtin{
 		),
 		types.Named("ns", types.N).Description("`value` in nanoseconds since epoch"),
 	),
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var ParseDurationNanos = &Builtin{
@@ -2400,7 +2400,7 @@ var ParseDurationNanos = &Builtin{
 		),
 		types.Named("ns", types.N).Description("the `duration` in nanoseconds"),
 	),
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var Format = &Builtin{
@@ -2416,7 +2416,7 @@ var Format = &Builtin{
 		),
 		types.Named("formatted timestamp", types.S).Description("the formatted timestamp represented for the nanoseconds since the epoch in the supplied timezone (or UTC)"),
 	),
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var Date = &Builtin{
@@ -2431,7 +2431,7 @@ var Date = &Builtin{
 		),
 		types.Named("date", types.NewArray([]types.Type{types.N, types.N, types.N}, nil)).Description("an array of `year`, `month` (1-12), and `day` (1-31)"),
 	),
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var Clock = &Builtin{
@@ -2447,7 +2447,7 @@ var Clock = &Builtin{
 		types.Named("output", types.NewArray([]types.Type{types.N, types.N, types.N}, nil)).
 			Description("the `hour`, `minute` (0-59), and `second` (0-59) representing the time of day for the nanoseconds since epoch in the supplied timezone (or UTC)"),
 	),
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var Weekday = &Builtin{
@@ -2462,7 +2462,7 @@ var Weekday = &Builtin{
 		),
 		types.Named("day", types.S).Description("the weekday represented by `ns` nanoseconds since the epoch in the supplied timezone (or UTC)"),
 	),
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var AddDate = &Builtin{
@@ -2477,7 +2477,7 @@ var AddDate = &Builtin{
 		),
 		types.Named("output", types.N).Description("nanoseconds since the epoch representing the input time, with years, months and days added"),
 	),
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var Diff = &Builtin{
@@ -2496,7 +2496,7 @@ var Diff = &Builtin{
 		),
 		types.Named("output", types.NewArray([]types.Type{types.N, types.N, types.N, types.N, types.N, types.N}, nil)).Description("difference between `ns1` and `ns2` (in their supplied timezones, if supplied, or UTC) as array of numbers: `[years, months, days, hours, minutes, seconds]`"),
 	),
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 /**
@@ -2516,7 +2516,7 @@ concatenated PEM blocks. The whole input of concatenated PEM blocks can optional
 		),
 		types.Named("output", types.NewArray(nil, types.NewObject(nil, types.NewDynamicProperty(types.S, types.A)))).Description("parsed X.509 certificates represented as objects"),
 	),
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var CryptoX509ParseAndVerifyCertificates = &Builtin{
@@ -2536,7 +2536,7 @@ with all others being treated as intermediates.`,
 			types.NewArray(nil, types.NewObject(nil, types.NewDynamicProperty(types.S, types.A))),
 		}, nil)).Description("array of `[valid, certs]`: if the input certificate chain could be verified then `valid` is `true` and `certs` is an array of X.509 certificates represented as objects; if the input certificate chain could not be verified then `valid` is `false` and `certs` is `[]`"),
 	),
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var CryptoX509ParseAndVerifyCertificatesWithOptions = &Builtin{
@@ -2561,7 +2561,7 @@ with all others being treated as intermediates.`,
 			types.NewArray(nil, types.NewObject(nil, types.NewDynamicProperty(types.S, types.A))),
 		}, nil)).Description("array of `[valid, certs]`: if the input certificate chain could be verified then `valid` is `true` and `certs` is an array of X.509 certificates represented as objects; if the input certificate chain could not be verified then `valid` is `false` and `certs` is `[]`"),
 	),
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var CryptoX509ParseCertificateRequest = &Builtin{
@@ -2573,7 +2573,7 @@ var CryptoX509ParseCertificateRequest = &Builtin{
 		),
 		types.Named("output", types.NewObject(nil, types.NewDynamicProperty(types.S, types.A))).Description("X.509 CSR represented as an object"),
 	),
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var CryptoX509ParseKeyPair = &Builtin{
@@ -2586,7 +2586,7 @@ var CryptoX509ParseKeyPair = &Builtin{
 		),
 		types.Named("output", types.NewObject(nil, types.NewDynamicProperty(types.S, types.A))).Description("if key pair is valid, returns the tls.certificate(https://pkg.go.dev/crypto/tls#Certificate) as an object. If the key pair is invalid, nil and an error are returned."),
 	),
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var CryptoX509ParseRSAPrivateKey = &Builtin{
@@ -2598,7 +2598,7 @@ var CryptoX509ParseRSAPrivateKey = &Builtin{
 		),
 		types.Named("output", types.NewObject(nil, types.NewDynamicProperty(types.S, types.A))).Description("JWK as an object"),
 	),
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var CryptoParsePrivateKeys = &Builtin{
@@ -2612,7 +2612,7 @@ If the input is empty, the function will return null. The input string should be
 		),
 		types.Named("output", types.NewArray(nil, types.NewObject(nil, types.NewDynamicProperty(types.S, types.A)))).Description("parsed private keys represented as objects"),
 	),
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var CryptoMd5 = &Builtin{
@@ -2624,7 +2624,7 @@ var CryptoMd5 = &Builtin{
 		),
 		types.Named("y", types.S).Description("MD5-hash of `x`"),
 	),
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var CryptoSha1 = &Builtin{
@@ -2636,7 +2636,7 @@ var CryptoSha1 = &Builtin{
 		),
 		types.Named("y", types.S).Description("SHA1-hash of `x`"),
 	),
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var CryptoSha256 = &Builtin{
@@ -2648,7 +2648,7 @@ var CryptoSha256 = &Builtin{
 		),
 		types.Named("y", types.S).Description("SHA256-hash of `x`"),
 	),
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var CryptoHmacMd5 = &Builtin{
@@ -2661,7 +2661,7 @@ var CryptoHmacMd5 = &Builtin{
 		),
 		types.Named("y", types.S).Description("MD5-HMAC of `x`"),
 	),
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var CryptoHmacSha1 = &Builtin{
@@ -2674,7 +2674,7 @@ var CryptoHmacSha1 = &Builtin{
 		),
 		types.Named("y", types.S).Description("SHA1-HMAC of `x`"),
 	),
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var CryptoHmacSha256 = &Builtin{
@@ -2687,7 +2687,7 @@ var CryptoHmacSha256 = &Builtin{
 		),
 		types.Named("y", types.S).Description("SHA256-HMAC of `x`"),
 	),
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var CryptoHmacSha512 = &Builtin{
@@ -2700,7 +2700,7 @@ var CryptoHmacSha512 = &Builtin{
 		),
 		types.Named("y", types.S).Description("SHA512-HMAC of `x`"),
 	),
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var CryptoHmacEqual = &Builtin{
@@ -2713,7 +2713,7 @@ var CryptoHmacEqual = &Builtin{
 		),
 		types.Named("result", types.B).Description("`true` if the MACs are equals, `false` otherwise"),
 	),
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 /**
@@ -2738,7 +2738,7 @@ var WalkBuiltin = &Builtin{
 		)).Description("pairs of `path` and `value`: `path` is an array representing the pointer to `value` in `x`. If `path` is assigned a wildcard (`_`), the `walk` function will skip path creation entirely for faster evaluation."),
 	),
 	Categories:  graphs,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var ReachableBuiltin = &Builtin{
@@ -2759,7 +2759,7 @@ var ReachableBuiltin = &Builtin{
 		),
 		types.Named("output", types.SetOfAny).Description("set of vertices reachable from the `initial` vertices in the directed `graph`"),
 	),
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var ReachablePathsBuiltin = &Builtin{
@@ -2780,7 +2780,7 @@ var ReachablePathsBuiltin = &Builtin{
 		),
 		types.Named("output", types.NewSet(types.NewArray(nil, types.A))).Description("paths reachable from the `initial` vertices in the directed `graph`"),
 	),
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 /**
@@ -2798,7 +2798,7 @@ var IsNumber = &Builtin{
 		types.Named("result", types.B).Description("`true` if `x` is a number, `false` otherwise."),
 	),
 	Categories:  typesCat,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var IsString = &Builtin{
@@ -2811,7 +2811,7 @@ var IsString = &Builtin{
 		types.Named("result", types.B).Description("`true` if `x` is a string, `false` otherwise."),
 	),
 	Categories:  typesCat,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var IsBoolean = &Builtin{
@@ -2824,7 +2824,7 @@ var IsBoolean = &Builtin{
 		types.Named("result", types.B).Description("`true` if `x` is an boolean, `false` otherwise."),
 	),
 	Categories:  typesCat,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var IsArray = &Builtin{
@@ -2837,7 +2837,7 @@ var IsArray = &Builtin{
 		types.Named("result", types.B).Description("`true` if `x` is an array, `false` otherwise."),
 	),
 	Categories:  typesCat,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var IsSet = &Builtin{
@@ -2850,7 +2850,7 @@ var IsSet = &Builtin{
 		types.Named("result", types.B).Description("`true` if `x` is a set, `false` otherwise."),
 	),
 	Categories:  typesCat,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var IsObject = &Builtin{
@@ -2863,7 +2863,7 @@ var IsObject = &Builtin{
 		types.Named("result", types.B).Description("`true` if `x` is an object, `false` otherwise."),
 	),
 	Categories:  typesCat,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var IsNull = &Builtin{
@@ -2876,7 +2876,7 @@ var IsNull = &Builtin{
 		types.Named("result", types.B).Description("`true` if `x` is null, `false` otherwise."),
 	),
 	Categories:  typesCat,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 /**
@@ -2894,7 +2894,7 @@ var TypeNameBuiltin = &Builtin{
 		types.Named("type", types.S).Description(`one of "null", "boolean", "number", "string", "array", "object", "set"`),
 	),
 	Categories:  typesCat,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 /**
@@ -2914,7 +2914,7 @@ var HTTPSend = &Builtin{
 			Description("the HTTP response object"),
 	),
 	Nondeterministic: true,
-	canSkipBctx:      false,
+	CanSkipBctx:      false,
 }
 
 /**
@@ -2937,7 +2937,7 @@ var GraphQLParse = &Builtin{
 			types.NewObject(nil, types.NewDynamicProperty(types.A, types.A)),
 		}, nil)).Description("`output` is of the form `[query_ast, schema_ast]`. If the GraphQL query is valid given the provided schema, then `query_ast` and `schema_ast` are objects describing the ASTs for the query and schema."),
 	),
-	canSkipBctx: false,
+	CanSkipBctx: false,
 }
 
 // GraphQLParseAndVerify returns a boolean and a pair of AST object from parsing/validation.
@@ -2957,7 +2957,7 @@ var GraphQLParseAndVerify = &Builtin{
 			types.NewObject(nil, types.NewDynamicProperty(types.A, types.A)),
 		}, nil)).Description(" `output` is of the form `[valid, query_ast, schema_ast]`. If the query is valid given the provided schema, then `valid` is `true`, and `query_ast` and `schema_ast` are objects describing the ASTs for the GraphQL query and schema. Otherwise, `valid` is `false` and `query_ast` and `schema_ast` are `{}`."),
 	),
-	canSkipBctx: false,
+	CanSkipBctx: false,
 }
 
 // GraphQLParseQuery parses the input GraphQL query and returns a JSON
@@ -2971,7 +2971,7 @@ var GraphQLParseQuery = &Builtin{
 		),
 		types.Named("output", types.NewObject(nil, types.NewDynamicProperty(types.A, types.A))).Description("AST object for the GraphQL query."),
 	),
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 // GraphQLParseSchema parses the input GraphQL schema and returns a JSON
@@ -2985,7 +2985,7 @@ var GraphQLParseSchema = &Builtin{
 		),
 		types.Named("output", types.NewObject(nil, types.NewDynamicProperty(types.A, types.A))).Description("AST object for the GraphQL schema."),
 	),
-	canSkipBctx: false,
+	CanSkipBctx: false,
 }
 
 // GraphQLIsValid returns true if a GraphQL query is valid with a given
@@ -3002,7 +3002,7 @@ var GraphQLIsValid = &Builtin{
 		),
 		types.Named("output", types.B).Description("`true` if the query is valid under the given schema. `false` otherwise."),
 	),
-	canSkipBctx: false,
+	CanSkipBctx: false,
 }
 
 // GraphQLSchemaIsValid returns true if the input is valid GraphQL schema,
@@ -3017,7 +3017,7 @@ var GraphQLSchemaIsValid = &Builtin{
 		),
 		types.Named("output", types.B).Description("`true` if the schema is a valid GraphQL schema. `false` otherwise."),
 	),
-	canSkipBctx: false,
+	CanSkipBctx: false,
 }
 
 /**
@@ -3041,7 +3041,7 @@ var JSONSchemaVerify = &Builtin{
 			Description("`output` is of the form `[valid, error]`. If the schema is valid, then `valid` is `true`, and `error` is `null`. Otherwise, `valid` is `false` and `error` is a string describing the error."),
 	),
 	Categories:  objectCat,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 // JSONMatchSchema returns empty array if the document matches the JSON schema,
@@ -3073,7 +3073,7 @@ var JSONMatchSchema = &Builtin{
 			Description("`output` is of the form `[match, errors]`. If the document is valid given the schema, then `match` is `true`, and `errors` is an empty array. Otherwise, `match` is `false` and `errors` is an array of objects describing the error(s)."),
 	),
 	Categories:  objectCat,
-	canSkipBctx: false,
+	CanSkipBctx: false,
 }
 
 /**
@@ -3096,7 +3096,7 @@ var ProvidersAWSSignReqObj = &Builtin{
 			Description("HTTP request object with `Authorization` header"),
 	),
 	Categories:  providersAWSCat,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 /**
@@ -3114,7 +3114,7 @@ var RegoParseModule = &Builtin{
 		types.Named("output", types.NewObject(nil, types.NewDynamicProperty(types.S, types.A))).
 			Description("AST object for the Rego module"),
 	),
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var RegoMetadataChain = &Builtin{
@@ -3127,7 +3127,7 @@ The first entry in the chain always points to the active rule, even if it has no
 		types.Args(),
 		types.Named("chain", types.NewArray(nil, types.A)).Description("each array entry represents a node in the path ancestry (chain) of the active rule that also has declared annotations"),
 	),
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 // RegoMetadataRule returns the metadata for the active rule
@@ -3138,7 +3138,7 @@ var RegoMetadataRule = &Builtin{
 		types.Args(),
 		types.Named("output", types.A).Description("\"rule\" scope annotations for this rule; empty object if no annotations exist"),
 	),
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 /**
@@ -3155,7 +3155,7 @@ var OPARuntime = &Builtin{
 			Description("includes a `config` key if OPA was started with a configuration file; an `env` key containing the environment variables that the OPA process was started with; includes `version` and `commit` keys containing the version and build commit of OPA."),
 	),
 	Nondeterministic: true,
-	canSkipBctx:      false,
+	CanSkipBctx:      false,
 }
 
 /**
@@ -3173,7 +3173,7 @@ var Trace = &Builtin{
 		types.Named("result", types.B).Description("always `true`"),
 	),
 	Categories:  tracing,
-	canSkipBctx: false,
+	CanSkipBctx: false,
 }
 
 /**
@@ -3194,7 +3194,7 @@ var GlobMatch = &Builtin{
 		),
 		types.Named("result", types.B).Description("true if `match` can be found in `pattern` which is separated by `delimiters`"),
 	),
-	canSkipBctx: false,
+	CanSkipBctx: false,
 }
 
 var GlobQuoteMeta = &Builtin{
@@ -3206,7 +3206,7 @@ var GlobQuoteMeta = &Builtin{
 		),
 		types.Named("output", types.S).Description("the escaped string of `pattern`"),
 	),
-	canSkipBctx: true,
+	CanSkipBctx: true,
 	// TODO(sr): example for this was: Calling ``glob.quote_meta("*.github.com", output)`` returns ``\\*.github.com`` as ``output``.
 }
 
@@ -3224,7 +3224,7 @@ var NetCIDRIntersects = &Builtin{
 		),
 		types.Named("result", types.B).Description("`true` if `cidr1` intersects with `cidr2`"),
 	),
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var NetCIDRExpand = &Builtin{
@@ -3236,7 +3236,7 @@ var NetCIDRExpand = &Builtin{
 		),
 		types.Named("hosts", types.SetOfStr).Description("set of IP addresses the CIDR `cidr` expands to"),
 	),
-	canSkipBctx: false,
+	CanSkipBctx: false,
 }
 
 var NetCIDRContains = &Builtin{
@@ -3249,7 +3249,7 @@ var NetCIDRContains = &Builtin{
 		),
 		types.Named("result", types.B).Description("`true` if `cidr_or_ip` is contained within `cidr`"),
 	),
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var NetCIDRContainsMatches = &Builtin{
@@ -3263,7 +3263,7 @@ var NetCIDRContainsMatches = &Builtin{
 		),
 		types.Named("output", types.NewSet(types.NewArray([]types.Type{types.A, types.A}, nil))).Description("tuples identifying matches where `cidrs_or_ips` are contained within `cidrs`"),
 	),
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var NetCIDRMerge = &Builtin{
@@ -3280,7 +3280,7 @@ Supports both IPv4 and IPv6 notations. IPv6 inputs need a prefix length (e.g. "/
 		),
 		types.Named("output", types.SetOfStr).Description("smallest possible set of CIDRs obtained after merging the provided list of IP addresses and subnets in `addrs`"),
 	),
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var NetCIDRIsValid = &Builtin{
@@ -3292,7 +3292,7 @@ var NetCIDRIsValid = &Builtin{
 		),
 		types.Named("result", types.B).Description("`true` if `cidr` is a valid CIDR"),
 	),
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var netCidrContainsMatchesOperandType = types.NewAny(
@@ -3325,7 +3325,7 @@ var NetLookupIPAddr = &Builtin{
 		types.Named("addrs", types.SetOfStr).Description("IP addresses (v4 and v6) that `name` resolves to"),
 	),
 	Nondeterministic: true,
-	canSkipBctx:      false,
+	CanSkipBctx:      false,
 }
 
 /**
@@ -3341,7 +3341,7 @@ var SemVerIsValid = &Builtin{
 		),
 		types.Named("result", types.B).Description("`true` if `vsn` is a valid SemVer; `false` otherwise"),
 	),
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 var SemVerCompare = &Builtin{
@@ -3354,7 +3354,7 @@ var SemVerCompare = &Builtin{
 		),
 		types.Named("result", types.N).Description("`-1` if `a < b`; `1` if `a > b`; `0` if `a == b`"),
 	),
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 /**
@@ -3398,7 +3398,7 @@ var SetDiff = &Builtin{
 		types.SetOfAny,
 	),
 	deprecated:  true,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 // NetCIDROverlap has been replaced by the `net.cidr_contains` built-in.
@@ -3412,7 +3412,7 @@ var NetCIDROverlap = &Builtin{
 		types.B,
 	),
 	deprecated:  true,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 // CastArray checks the underlying type of the input. If it is array or set, an array
@@ -3424,7 +3424,7 @@ var CastArray = &Builtin{
 		types.NewArray(nil, types.A),
 	),
 	deprecated:  true,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 // CastSet checks the underlying type of the input.
@@ -3438,7 +3438,7 @@ var CastSet = &Builtin{
 		types.SetOfAny,
 	),
 	deprecated:  true,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 // CastString returns input if it is a string; if not returns error.
@@ -3450,7 +3450,7 @@ var CastString = &Builtin{
 		types.S,
 	),
 	deprecated:  true,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 // CastBoolean returns input if it is a boolean; if not returns error.
@@ -3461,7 +3461,7 @@ var CastBoolean = &Builtin{
 		types.B,
 	),
 	deprecated:  true,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 // CastNull returns null if input is null; if not returns error.
@@ -3472,7 +3472,7 @@ var CastNull = &Builtin{
 		types.Nl,
 	),
 	deprecated:  true,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 // CastObject returns the given object if it is null; throws an error otherwise
@@ -3483,7 +3483,7 @@ var CastObject = &Builtin{
 		types.NewObject(nil, types.NewDynamicProperty(types.A, types.A)),
 	),
 	deprecated:  true,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 // RegexMatchDeprecated declares `re_match` which has been deprecated. Use `regex.match` instead.
@@ -3497,7 +3497,7 @@ var RegexMatchDeprecated = &Builtin{
 		types.B,
 	),
 	deprecated:  true,
-	canSkipBctx: false,
+	CanSkipBctx: false,
 }
 
 // All takes a list and returns true if all of the items
@@ -3514,7 +3514,7 @@ var All = &Builtin{
 		types.B,
 	),
 	deprecated:  true,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 // Any takes a collection and returns true if any of the items
@@ -3531,7 +3531,7 @@ var Any = &Builtin{
 		types.B,
 	),
 	deprecated:  true,
-	canSkipBctx: true,
+	CanSkipBctx: true,
 }
 
 // Builtin represents a built-in function supported by OPA. Every built-in
@@ -3545,11 +3545,11 @@ type Builtin struct {
 	// "minus" for example, is part of two categories: numbers and sets. (NOTE(sr): aspirational)
 	Categories []string `json:"categories,omitempty"`
 
-	Decl             *types.Function `json:"decl"`               // Built-in function type declaration.
-	Infix            string          `json:"infix,omitempty"`    // Unique name of infix operator. Default should be unset.
-	Relation         bool            `json:"relation,omitempty"` // Indicates if the built-in acts as a relation.
-	deprecated       bool            // Indicates if the built-in has been deprecated.
-	canSkipBctx      bool            // Built-in needs no data from the built-in context.
+	Decl             *types.Function `json:"decl"`                       // Built-in function type declaration.
+	Infix            string          `json:"infix,omitempty"`            // Unique name of infix operator. Default should be unset.
+	Relation         bool            `json:"relation,omitempty"`         // Indicates if the built-in acts as a relation.
+	deprecated       bool            `json:"-"`                          // Indicates if the built-in has been deprecated.
+	CanSkipBctx      bool            `json:"-"`                          // Built-in needs no data from the built-in context.
 	Nondeterministic bool            `json:"nondeterministic,omitempty"` // Indicates if the built-in returns non-deterministic results.
 }
 
@@ -3626,7 +3626,7 @@ func (b *Builtin) IsTargetPos(i int) bool {
 func (b *Builtin) NeedsBuiltInContext() bool {
 	// Negated, so built-ins we don't know about (and who don't know about this option)
 	// will get a built-in context provided to them.
-	return !b.canSkipBctx
+	return !b.CanSkipBctx
 }
 
 func init() {

--- a/v1/ast/performance.go
+++ b/v1/ast/performance.go
@@ -1,0 +1,85 @@
+// Copyright 2025 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+package ast
+
+import (
+	"strings"
+	"sync"
+)
+
+var builtinNamesByNumParts = sync.OnceValue(func() map[int][]string {
+	m := map[int][]string{}
+	for name := range BuiltinMap {
+		parts := strings.Count(name, ".") + 1
+		if parts > 1 {
+			m[parts] = append(m[parts], name)
+		}
+	}
+	return m
+})
+
+// BuiltinNameFromRef attempts to extract a known built-in function name from a ref,
+// in the most efficient way possible. I.e. without allocating memory for a new string.
+// If no built-in function name can be extracted, the second return value is false.
+func BuiltinNameFromRef(ref Ref) (string, bool) {
+	reflen := len(ref)
+	if reflen == 0 {
+		return "", false
+	}
+
+	_var, ok := ref[0].Value.(Var)
+	if !ok {
+		return "", false
+	}
+
+	varName := string(_var)
+	if reflen == 1 {
+		if _, ok := BuiltinMap[varName]; ok {
+			return varName, true
+		}
+		return "", false
+	}
+
+	totalLen := len(varName)
+	for _, term := range ref[1:] {
+		if _, ok = term.Value.(String); !ok {
+			return "", false
+		}
+		totalLen += 1 + len(term.Value.(String)) // account for dot
+	}
+
+	matched, ok := builtinNamesByNumParts()[reflen]
+	if !ok {
+		return "", false
+	}
+
+	for _, name := range matched {
+		// This check saves us a huge amount of work, as only very few built-in
+		// names will have the exact same length as the ref we are checking.
+		if len(name) != totalLen {
+			continue
+		}
+		// Example: `name` is "io.jwt.decode" (and so is ref)
+		// The first part is varName, which have already been established to be 'io':
+		// io,   jwt.decode                              io   == io
+		if curr, remaining, _ := strings.Cut(name, "."); curr == varName {
+			// Loop over the remaining (now known to be string) terms in the ref, e.g. "jwt" and "decode"
+			for _, term := range ref[1:] {
+				ts := string(term.Value.(String))
+				// First iteration: jwt.decode != jwt, so we continue cutting
+				// Second iteration: remaining is "decode", and so is term
+				if remaining == ts {
+					return name, true
+				}
+				// Cutting remaining (e.g. jwt.decode), and we now get:
+				// jwt,  decode,                                              false  || jwt  != jwt
+				if curr, remaining, _ = strings.Cut(remaining, "."); remaining == "" || curr != ts {
+					break
+				}
+			}
+		}
+	}
+
+	return "", false
+}

--- a/v1/ast/performance_test.go
+++ b/v1/ast/performance_test.go
@@ -1,0 +1,61 @@
+package ast_test
+
+import (
+	"testing"
+
+	"github.com/open-policy-agent/opa/v1/ast"
+)
+
+func TestFromBuiltinNames(t *testing.T) {
+	for _, name := range []string{"io.jwt.decode", "http.send", "net.cidr_contains"} {
+		if s, ok := ast.BuiltinNameFromRef(ast.MustParseRef(name)); !ok {
+			t.Fatalf("Expected to find match for %v", name)
+		} else if s != name {
+			t.Fatalf("Expected %v but got: %v", name, s)
+		}
+	}
+}
+
+func BenchmarkFromBuiltinNames(b *testing.B) {
+	tests := []struct {
+		name string
+		ref  ast.Ref
+		ok   bool
+	}{
+		{
+			name: "single part",
+			ref:  ast.Ref{ast.VarTerm("count")},
+			ok:   true,
+		},
+		{
+			name: "two parts",
+			ref:  ast.MustParseRef("http.send"),
+			ok:   true,
+		},
+		{
+			name: "three parts",
+			ref:  ast.MustParseRef("io.jwt.decode"),
+			ok:   true,
+		},
+		{
+			name: "no match",
+			ref:  ast.MustParseRef("foo.bar.baz"),
+			ok:   false,
+		},
+		{
+			name: "no match long",
+			ref:  ast.MustParseRef("a.b.c.d.e.f.g.h.i.j.k.l.m.n.o.p.q.r.s.t.u.v.w.x.y.z"),
+			ok:   false,
+		},
+	}
+
+	for _, tc := range tests {
+		b.Run(tc.name, func(b *testing.B) {
+			for b.Loop() {
+				if _, ok := ast.BuiltinNameFromRef(tc.ref); ok != tc.ok {
+					b.Fatalf("Expected ok=%v but got: %v", tc.ok, ok)
+				}
+			}
+		})
+	}
+}

--- a/v1/rego/plugins_test.go
+++ b/v1/rego/plugins_test.go
@@ -142,6 +142,7 @@ func TestPluginPrepareOptions(t *testing.T) {
 		cpy := ast.BuiltinMap["count"]
 		cpy.Description = ""
 		cpy.Categories = nil
+		cpy.CanSkipBctx = false
 		bi := map[string]*topdown.Builtin{
 			"count": {
 				Decl: cpy,

--- a/v1/topdown/eval.go
+++ b/v1/topdown/eval.go
@@ -171,16 +171,17 @@ func (e *eval) string(s *strings.Builder) {
 func (e *eval) builtinFunc(name string) (*ast.Builtin, BuiltinFunc, bool) {
 	decl, ok := ast.BuiltinMap[name]
 	if ok {
-		f, ok := builtinFunctions[name]
-		if ok {
+		if f, ok := builtinFunctions[name]; ok {
 			return decl, f, true
 		}
-	} else {
-		bi, ok := e.builtins[name]
-		if ok {
-			return bi.Decl, bi.Func, true
+		if bi, ok := e.builtins[name]; ok {
+			return decl, bi.Func, true
 		}
 	}
+	if bi, ok := e.builtins[name]; ok {
+		return bi.Decl, bi.Func, true
+	}
+
 	return nil, nil, false
 }
 
@@ -951,7 +952,7 @@ func (e *eval) evalCall(terms []*ast.Term, iter unifyIterator) error {
 	var bctx *BuiltinContext
 
 	// Creating a BuiltinContext is expensive, so only do it if the builtin depends on it.
-	if bi.NeedsBuiltInContext() {
+	if !bi.CanSkipBctx {
 		var parentID uint64
 		if e.parent != nil {
 			parentID = e.parent.queryID


### PR DESCRIPTION
I was meant to do slides for a talk, but here we are. Fun exercise in "writing" a string without actually writing one, but rather by trying to exclude all other possible built-in function names to compare against ref as early as possible in order to make the operation inexpensive. And it worked! Down from a few allocations (worst case) and at least 3 digit ns/op, to no allocations and lower end of the 2 digit ns/op scale.

For reference, this PR accounts for 700K allocations gone in `regal lint bunde`, as we do millions of builtin function calls as part of that benchmark.

Another 300K+ allocs gone by revisiting the `canSkipBctx` field on the AST builtin struct, and making it public sp that client like Regal may benefit. And we did :)
