### PR TITLE
Enable Memory64 support for large policies

### DIFF
--- a/internal/wasm/sdk/internal/wasm/pool.go
+++ b/internal/wasm/sdk/internal/wasm/pool.go
@@ -7,6 +7,7 @@ package wasm
 import (
 	"bytes"
 	"context"
+	"os"
 	"sync"
 
 	wasmtime "github.com/bytecodealliance/wasmtime-go/v3"
@@ -42,6 +43,11 @@ func NewPool(poolSize, memoryMinPages, memoryMaxPages uint32) *Pool {
 
 	cfg := wasmtime.NewConfig()
 	cfg.SetEpochInterruption(true)
+
+	// Enable WASM Memory64 for large policies when requested
+	if os.Getenv("OPA_WASM_MEMORY64") == "true" {
+		cfg.SetWasmMemory64(true)
+	}
 
 	available := make(chan struct{}, poolSize)
 	for range poolSize {


### PR DESCRIPTION
Adds environment variable `OPA_WASM_MEMORY64=true` to enable WebAssembly Memory64 support for policies requiring >4GB memory.

This leverages existing wasmtime-go v3 capabilities without changing default behavior. When enabled, VMs automatically use 64-bit memory addressing for large policy workloads.

Addresses issue #7971.