### PR TITLE
e2e/authz,topdown: fix benchmarks

### DIFF
--- a/v1/test/e2e/authz/authz_bench_integration_test.go
+++ b/v1/test/e2e/authz/authz_bench_integration_test.go
@@ -97,12 +97,11 @@ func runAuthzBenchmark(b *testing.B, mode testAuthz.InputMode, numPaths int) {
 		// receive a response, and do any normal client error checking on
 		// the response. The benchmark is for the OPA server, not how
 		// long it takes the golang client to unpack the response body.
-		b.StartTimer()
 		resp, err := testRuntime.GetDataWithRawInput(url, inputReader)
 		if err != nil {
 			b.Fatal(err)
 		}
-		b.StopTimer()
+		b.StopTimer() // don't measure time for the checks below
 
 		body, err := io.ReadAll(resp)
 		if err != nil {
@@ -123,5 +122,8 @@ func runAuthzBenchmark(b *testing.B, mode testAuthz.InputMode, numPaths int) {
 		}
 
 		inputReader.Reset(inputPayload)
+
+		// start timing again, b.Loop() requires that
+		b.StartTimer()
 	}
 }

--- a/v1/topdown/graphql_bench_test.go
+++ b/v1/topdown/graphql_bench_test.go
@@ -350,7 +350,6 @@ func BenchmarkGraphQLParseAndVerify(b *testing.B) {
 		b.Run(bench.desc, func(b *testing.B) {
 			for b.Loop() {
 				var result *ast.Term
-				b.StartTimer()
 				err := builtinGraphQLParseAndVerify(
 					BuiltinContext{
 						InterQueryBuiltinValueCache: bench.cache,
@@ -378,6 +377,8 @@ func BenchmarkGraphQLParseAndVerify(b *testing.B) {
 						return
 					}
 				}
+
+				b.StartTimer() // b.Loop() requires a running timer
 			}
 		})
 	}


### PR DESCRIPTION
Before, we'd see these benchmarks die (in our nightly tests) with

    benchmark.go:412: B.Loop called with timer stopped

Now, we can run them again:

```
% go test -bench=. -v -run=XXX ./v1/test/e2e/authz
{
  "level": "info",
  "msg": "Test server ready and listening on: http://127.0.0.1:64200",
  "time": "2025-10-15T11:44:06+02:00"
}
goos: darwin
goarch: arm64
pkg: github.com/open-policy-agent/opa/v1/test/e2e/authz
cpu: Apple M4 Max
BenchmarkRESTAuthzForbidAuthn
BenchmarkRESTAuthzForbidAuthn-16           22623             52375 ns/op
BenchmarkRESTAuthzForbidPath
BenchmarkRESTAuthzForbidPath-16            16729             71916 ns/op
BenchmarkRESTAuthzForbidMethod
BenchmarkRESTAuthzForbidMethod-16          16434             72963 ns/op
BenchmarkRESTAuthzAllow10Paths
BenchmarkRESTAuthzAllow10Paths-16          15883             74936 ns/op
BenchmarkRESTAuthzAllow100Paths
BenchmarkRESTAuthzAllow100Paths-16         10000            109283 ns/op
BenchmarkRESTAuthzAllow1000Paths
BenchmarkRESTAuthzAllow1000Paths-16         2731            462167 ns/op
PASS
ok      github.com/open-policy-agent/opa/v1/test/e2e/authz      13.349s
```
