### PR TITLE
workflow/post-tag: build arm64 binaries for linux/darwin, too

### DIFF
--- a/.github/workflows/post-tag.yaml
+++ b/.github/workflows/post-tag.yaml
@@ -42,7 +42,7 @@ jobs:
           TELEMETRY_URL: ${{ secrets.TELEMETRY_URL }}
 
       - name: Build Linux arm64
-        run: make ci-go-ci-build-linux-static
+        run: make ci-go-ci-build-linux ci-go-ci-build-linux-static
         timeout-minutes: 30
         env:
           GOARCH: arm64
@@ -81,7 +81,7 @@ jobs:
       - name: Build Darwin
         run: |
           make ci-build-darwin GOARCH=amd64
-          make ci-build-darwin-arm64-static
+          make ci-build-darwin ci-build-darwin-arm64-static GOARCH=arm64
         timeout-minutes: 30
         env:
           TELEMETRY_URL: ${{ secrets.TELEMETRY_URL }}


### PR DESCRIPTION
This was an oversight in #7977. With this change, we should be publishing non-static binaries for linux and darwin on arm64 🤞 

It's hairy to test this without having a release. Let's be hopeful 😉 