### PR TITLE
Add zig to post-merge github action

### DIFF
--- a/.github/workflows/post-merge.yaml
+++ b/.github/workflows/post-merge.yaml
@@ -97,6 +97,10 @@ jobs:
       - name: Git Describe
         run: git describe --tags
 
+      - uses: mlugg/setup-zig@8d6198c65fb0feaa111df26e6b467fea8345e46f # v2.0.5
+        with:
+          version: '0.15.2'
+
       - name: Build Linux and Windows
         run: make ci-go-ci-build-linux ci-go-ci-build-linux-static ci-go-ci-build-windows
         timeout-minutes: 30


### PR DESCRIPTION
follow up for: https://github.com/open-policy-agent/opa/pull/7981

Add Zig in the post merge GitHub action as well.

Currently failing: https://github.com/open-policy-agent/opa/actions/runs/18569296341/job/52938896343