### PR TITLE
fix "Post Merge": add generate step for windows build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -310,7 +310,7 @@ ci-build-darwin-arm64-static: ensure-release-dir
 	cd $(RELEASE_DIR)/ && shasum -a 256 opa_darwin_arm64_static > opa_darwin_arm64_static.sha256
 
 .PHONY: ci-build-windows
-ci-build-windows: ensure-release-dir
+ci-build-windows: generate ensure-release-dir
 	@$(MAKE) build GOOS=windows CC="zig cc -target x86_64-windows-gnu -lunwind"
 	mv opa_windows_$(GOARCH) $(RELEASE_DIR)/opa_windows_$(GOARCH).exe
 	cd $(RELEASE_DIR)/ && shasum -a 256 opa_windows_$(GOARCH).exe > opa_windows_$(GOARCH).exe.sha256


### PR DESCRIPTION
follow up to: https://github.com/open-policy-agent/opa/pull/7984, still failing on main: https://github.com/open-policy-agent/opa/actions/runs/18571336585/job/52945822531

`ci-build-windows` needs a generate step before to install `goversioninfo`

this was missed in the previous PR because I had added a `generate` step to the temporary workflow I was using to test it, you can see that here: https://github.com/open-policy-agent/opa/actions/runs/18599742832/job/53035067061 and https://github.com/srenatus/opa/blob/08036db9edf150ddca8d749cba65088f7f1d1fb2/.github/workflows/temp-workflow.yml

Instead of adding it as a separate step in the Github workflow I added it as a dependency in the makefile command so it won't be forgotten.