### PR TITLE
fix runtime tests: close watcher & set default `GracefulShutdownPeriod`

### DIFF
--- a/v1/runtime/runtime.go
+++ b/v1/runtime/runtime.go
@@ -298,10 +298,11 @@ type LoggingConfig struct {
 // NewParams returns a new Params object.
 func NewParams() Params {
 	return Params{
-		Output:             os.Stdout,
-		BundleMode:         false,
-		EnableVersionCheck: false,
-		Brand:              "OPA", // default
+		Output:                 os.Stdout,
+		BundleMode:             false,
+		EnableVersionCheck:     false,
+		GracefulShutdownPeriod: 1,
+		Brand:                  "OPA", // default
 	}
 }
 


### PR DESCRIPTION
<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

* You have read the project's
  [guidelines on AI tool use](https://www.openpolicyagent.org/docs/contrib-code#ai-guidelines).

For more information on contributing to OPA see our
[Contributing Guide](https://www.openpolicyagent.org/docs/contributing/)
for high-level contributing guidelines and development setup.
(See the [Developer Certificate of Origin](https://www.openpolicyagent.org/docs/contrib-code/#developer-certificate-of-origin)
section for specifics on signing off a commit.)

-->

### Why the changes in this PR are needed?

<!--
Include a short description of WHY the changes were made.
-->

When I stress test `runtime` unit tests, there are two errors surface:
- `too many opened files` on `startWatcher()`
- `context deadline exceed` on server shutdown

Checking [`fsnotify`](https://github.com/fsnotify/fsnotify) examples, a `watcher.Close()` is used to close the file which I failed to find in the current codebase. If we don't set `GracefulShutdownPeriod`, the default value would be 0, and the server must shutdown in 0s.

### What are the changes in this PR?

<!--
Include a short description of WHAT changes were made.
-->

- Close watcher when the context is closed, similar as https://github.com/open-policy-agent/opa/blob/e048c1984d8b866cd24407c90b1c645a2b0f5c98/cmd/test.go#L287-L300
- Update `NewParam()` to have a default 1s `GracefulShutdownPeriod` to avoid immediate context expiry

### Notes to assist PR review:

<!--
Here you can add information you think will help the reviewer(s).
-->

fix #7956

### Further comments:

<!--
Here you can include links to additional resources related to the changes, discuss your solution, other approaches you considered etc.
-->

The original PR focused on closing watchers. However, seeing the broken CI leads me to the `GracefulShutdownPeriod` change, which is independent to watchers. The new fix is only a one-line update, and I amended the fix here. If it's better to keep them separate, I can create another PR for `GracefulShutdownPeriod` change as well.