### PR TITLE
Fix benchmark test which was introduced with PR 7970

### DIFF
--- a/v1/ast/parser_bench_test.go
+++ b/v1/ast/parser_bench_test.go
@@ -28,7 +28,7 @@ func BenchmarkParseModuleRulesBase(b *testing.B) {
 // BenchmarkParseStatementBasic gives a baseline for parsing a simple
 // statement with a single call and two variables
 func BenchmarkParseStatementBasicCall(b *testing.B) {
-	runParseStatementBenchmark(b, `a+b`)
+	runParseStatementBenchmark(b, `a + b`)
 }
 
 func BenchmarkParseStatementMixedJSON(b *testing.B) {


### PR DESCRIPTION
Related to issue: #7433

### Why the changes in this PR are needed?

With PR #7970 this test (and the pipeline) broke (sorry, I didn't catch that upfront).

The reason is that this test calls the `ParseStatement` function which will try to parse the input as a rule first, resulting in `nil`, then continue parsing it as query. With the newly introduced error message when infix operators are used within rule names, this will no longer work and result in an error.

### What are the changes in this PR?

This PR fixes the test by adding whitespaces around the infix operator, thus not being interpreted as an invalid rule name.

### Further comments:

- An alternative fix for this test would be to pass the `skipRules` flag in the `ParserOptions` to avoid trying to parse this statement as a rule.
- Do you think there could be other use cases of OPA similar as in this test which would fail with the change of PR #7970 that could be problematic?
