### PR TITLE
ast/capabilities: remove stale comment

### DIFF
--- a/v1/ast/capabilities.go
+++ b/v1/ast/capabilities.go
@@ -95,7 +95,6 @@ type Capabilities struct {
 	// As of now, this only controls fetching remote refs for using JSON Schemas in
 	// the type checker.
 	// TODO(sr): support ports to further restrict connection peers
-	// TODO(sr): support restricting `http.send` using the same mechanism (see https://github.com/open-policy-agent/opa/issues/3665)
 	AllowNet []string `json:"allow_net,omitempty"`
 }
 


### PR DESCRIPTION
This has been dealt with since, it seems. The linked issue is closed.
