### PR TITLE
server/failtracer: don't assume only being fed two-elem calls

### DIFF
--- a/v1/server/failtracer/failtracer.go
+++ b/v1/server/failtracer/failtracer.go
@@ -69,8 +69,7 @@ func (b *failTracer) Hints(unknowns []ast.Ref) []Hint {
 		var ref ast.Ref // when this is processed, only one input.X.Y ref is in the expression (SSA)
 		switch {
 		case expr.IsCall():
-			for i := range 2 {
-				op := expr.Operand(i)
+			for _, op := range expr.Operands() {
 				if r, ok := op.Value.(ast.Ref); ok && r.HasPrefix(ast.InputRootRef) {
 					ref = r
 				}

--- a/v1/server/failtracer/hints_test.go
+++ b/v1/server/failtracer/hints_test.go
@@ -39,6 +39,14 @@ func TestHints(t *testing.T) {
 			},
 		},
 		{
+			note: "failing function call",
+			evts: []topdown.Event{
+				evtFromExpr(`data.policy.udf(__local1__)`),
+			},
+			unknowns: []string{"input.fruits"},
+			exp:      nil,
+		},
+		{
 			note: "all of input unknown, ignored",
 			evts: []topdown.Event{
 				evtFromExpr(`__local1__ = input.fruit.price`),


### PR DESCRIPTION
This was overly specific before, and quickly failed when fail events had not been on of the right sort. Now, we're more lenient.

These would happen, as in https://github.com/orgs/open-policy-agent/discussions/722#discussioncomment-14812737, when a fail event happened that's unrelated to unknowns lookup, but a valid failure nonetheless. So this will not lead to a hint. Only fail events of the previously-expected form could yield hints.

Reported by @huntkalio