### PR TITLE
Add test cases for consistent cache behavior

### DIFF
--- a/v1/test/cases/testdata/v1/time/test-time-0972.yaml
+++ b/v1/test/cases/testdata/v1/time/test-time-0972.yaml
@@ -1,0 +1,13 @@
+---
+cases:
+  - note: time.now_ns/consistent value for same evaluation
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p := count(times) if {
+        	times := {time.now_ns() | numbers.range(1, 100)[_]}
+        }
+    want_result:
+      - x: 1

--- a/v1/test/cases/testdata/v1/uuid/test-uuid-rfc4122.yaml
+++ b/v1/test/cases/testdata/v1/uuid/test-uuid-rfc4122.yaml
@@ -1,0 +1,13 @@
+---
+cases:
+  - note: uuid.rfc4122/consistent values for same arguments
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p := count(uuids) if {
+        	uuids := {uuid.rfc4122("key") | numbers.range(1, 100)[_]}
+        }
+    want_result:
+      - x: 1


### PR DESCRIPTION
### Why the changes in this PR are needed?

Using `rand.intn` test cases as template, we create similar tests that verify consistent values returned by `uuid.rfc4122` and `time.now_ns` builtins when invoked during the same evaluation/query. This is done for _coverage and consistency._
As an added bonus, these tests can also aid compliance regression testing for other OPA implementations, such as Swift.

### What are the changes in this PR?
This change adds two test cases that expect 100 calls to `time.now_ns` and `uuid.rfc4122` to return _one unique value_ since both builtins are supposed to behave consistently during a given evaluation.