### PR TITLE
website: checkout relative to docs dir

### DIFF
--- a/docs/bin/build-latest.sh
+++ b/docs/bin/build-latest.sh
@@ -22,7 +22,7 @@ fi
 git checkout "$LATEST_TAG"
 
 # update the sections of the site that are versioned elsewhere to use main.
-git checkout "$CURRENT_REF" -- docs/projects/
+git checkout "$CURRENT_REF" -- projects/
 
 BUILD_VERSION="$LATEST_TAG" npx docusaurus build
 


### PR DESCRIPTION
Missed in https://github.com/open-policy-agent/opa/pull/8023

This script is run in the docs directory, so path needs to be relative to that.