### PR TITLE
Intern common var values + some parser improvements

### DIFF
--- a/v1/ast/annotations.go
+++ b/v1/ast/annotations.go
@@ -752,10 +752,7 @@ func (c *CompileAnnotation) Compare(other *CompileAnnotation) int {
 		return -1
 	}
 
-	if cmp := slices.CompareFunc(c.Unknowns, other.Unknowns,
-		func(x, y Ref) int {
-			return x.Compare(y)
-		}); cmp != 0 {
+	if cmp := slices.CompareFunc(c.Unknowns, other.Unknowns, RefCompare); cmp != 0 {
 		return cmp
 	}
 	return c.MaskRule.Compare(other.MaskRule)

--- a/v1/ast/builtins.go
+++ b/v1/ast/builtins.go
@@ -26,11 +26,16 @@ func RegisterBuiltin(b *Builtin) {
 		BuiltinMap[b.Infix] = b
 
 		InternStringTerm(b.Infix)
+		InternVarValue(b.Infix)
 	}
 
-	InternStringTerm(b.Name)
 	if strings.Contains(b.Name, ".") {
-		InternStringTerm(strings.Split(b.Name, ".")...)
+		parts := strings.Split(b.Name, ".")
+		InternStringTerm(parts...)
+		InternVarValue(parts[0])
+	} else {
+		InternStringTerm(b.Name)
+		InternVarValue(b.Name)
 	}
 }
 

--- a/v1/ast/check.go
+++ b/v1/ast/check.go
@@ -383,10 +383,6 @@ func (tc *typeChecker) checkExpr(env *TypeEnv, expr *Expr) *Error {
 }
 
 func (tc *typeChecker) checkExprBuiltin(env *TypeEnv, expr *Expr) *Error {
-
-	args := expr.Operands()
-	pre := getArgTypes(env, args)
-
 	// NOTE(tsandall): undefined functions will have been caught earlier in the
 	// compiler. We check for undefined functions before the safety check so
 	// that references to non-existent functions result in undefined function
@@ -424,12 +420,14 @@ func (tc *typeChecker) checkExprBuiltin(env *TypeEnv, expr *Expr) *Error {
 		namedFargs.Args = append(namedFargs.Args, ftpe.NamedResult())
 	}
 
+	args := expr.Operands()
+
 	if len(args) > len(fargs.Args) && fargs.Variadic == nil {
-		return newArgError(expr.Location, name, "too many arguments", pre, namedFargs)
+		return newArgError(expr.Location, name, "too many arguments", getArgTypes(env, args), namedFargs)
 	}
 
 	if len(args) < len(ftpe.FuncArgs().Args) {
-		return newArgError(expr.Location, name, "too few arguments", pre, namedFargs)
+		return newArgError(expr.Location, name, "too few arguments", getArgTypes(env, args), namedFargs)
 	}
 
 	for i := range args {

--- a/v1/ast/interning.go
+++ b/v1/ast/interning.go
@@ -28,7 +28,7 @@ var (
 
 	InternedEmptyString = StringTerm("")
 	InternedEmptyObject = ObjectTerm()
-	InternedEmptyArray  = ArrayTerm()
+	InternedEmptyArray  = NewTerm(InternedEmptyArrayValue)
 	InternedEmptySet    = SetTerm()
 
 	InternedEmptyArrayValue = NewArray()
@@ -39,6 +39,15 @@ var (
 
 	internedStringTerms = map[string]*Term{
 		"": InternedEmptyString,
+	}
+
+	internedVarValues = map[string]Value{
+		"input": Var("input"),
+		"data":  Var("data"),
+		"key":   Var("key"),
+		"value": Var("value"),
+
+		"i": Var("i"), "j": Var("j"), "k": Var("k"), "v": Var("v"), "x": Var("x"), "y": Var("y"), "z": Var("z"),
 	}
 )
 
@@ -53,6 +62,20 @@ func InternStringTerm(str ...string) {
 		}
 
 		internedStringTerms[s] = StringTerm(s)
+	}
+}
+
+// InternVarValue interns the given variable names as Var Values. Note that Interning is
+// considered experimental and should not be relied upon by external code.
+// WARNING: This must **only** be called at initialization time, as the
+// interned terms are shared globally, and the underlying map is not thread-safe.
+func InternVarValue(names ...string) {
+	for _, name := range names {
+		if _, ok := internedVarValues[name]; ok {
+			continue
+		}
+
+		internedVarValues[name] = Var(name)
 	}
 }
 
@@ -92,6 +115,16 @@ func HasInternedValue[T internable](v T) bool {
 // interned. If the value is not interned, a new Value is returned.
 func InternedValue[T internable](v T) Value {
 	return InternedValueOr(v, internedTermValue)
+}
+
+// InternedVarValue returns an interned Var Value for the given name. If the
+// name is not interned, a new Var Value is returned.
+func InternedVarValue(name string) Value {
+	if v, ok := internedVarValues[name]; ok {
+		return v
+	}
+
+	return Var(name)
 }
 
 // InternedValueOr returns an interned Value for scalar v. Calls supplier

--- a/v1/ast/parser_bench_test.go
+++ b/v1/ast/parser_bench_test.go
@@ -123,6 +123,15 @@ func BenchmarkParseStatementNestedObjectsOrSets(b *testing.B) {
 	}
 }
 
+// 7471 ns/op	    8024 B/op	      56 allocs/op
+func BenchmarkParseVars(b *testing.B) {
+	for b.Loop() {
+		if _, err := ParseExpr(`data[i][_][j]`); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func BenchmarkParseBasicABACModule(b *testing.B) {
 	mod := `
 	package app.abac

--- a/v1/ast/policy.go
+++ b/v1/ast/policy.go
@@ -86,7 +86,11 @@ var ReservedVars = NewVarSet(
 )
 
 // Wildcard represents the wildcard variable as defined in the language.
-var Wildcard = &Term{Value: Var("_")}
+var (
+	WildcardString       = "_"
+	WildcardValue  Value = Var(WildcardString)
+	Wildcard             = &Term{Value: WildcardValue}
+)
 
 // WildcardPrefix is the special character that all wildcard variables are
 // prefixed with when the statement they are contained in is parsed.

--- a/v1/ast/term.go
+++ b/v1/ast/term.go
@@ -824,7 +824,7 @@ type Var string
 
 // VarTerm creates a new Term with a Variable value.
 func VarTerm(v string) *Term {
-	return &Term{Value: Var(v)}
+	return &Term{Value: InternedVarValue(v)}
 }
 
 // Equal returns true if the other Value is a Variable and has the same value
@@ -881,7 +881,7 @@ func (v Var) String() string {
 	// illegal variable name character (WildcardPrefix) to avoid conflicts. When
 	// we serialize the variable here, we need to make sure it's parseable.
 	if v.IsWildcard() {
-		return Wildcard.String()
+		return WildcardString
 	}
 	return string(v)
 }


### PR DESCRIPTION
While we can't use interned `Term`s in the parser (mutable), we can use interned `Value`s (immutable) and put in those terms. Seeing how often we would allocate a new `Value` for e.g. "input" or "data" made me want to try interning for vars. Just like all things interning, this is slightly experimental and clearly marked as such. Worth highlighting here is that the majority of vars allocated in at least Regal is however those generated in eval.go.. and their names don't lend themselves well to interning beforehand. Perhaps we can find a way to change that later, as those account for a million+ allocations in `regal lint bundle`. Oh well.

Also some general improvements in the parser code, reducing allocations often simply by moving things around in order to not evaluate (potentially allocating) code before it's needed.