### PR TITLE
v1/ast: Fix Call parsing Text attibute including an extra character

### DIFF
--- a/v1/ast/parser.go
+++ b/v1/ast/parser.go
@@ -1978,7 +1978,7 @@ func (p *Parser) parseRef(head *Term, offset int) (term *Term) {
 					term = p.parseRef(term, offset)
 				}
 			}
-			end = p.s.tokEnd
+			end = p.s.lastEnd
 			return term
 		case tokens.LBrack:
 			p.scan()

--- a/v1/ast/parser_test.go
+++ b/v1/ast/parser_test.go
@@ -6468,6 +6468,50 @@ else = {
 	`), curElse.Head.Value.Location)
 }
 
+func TestNestedCallText(t *testing.T) {
+	cases := []struct {
+		note     string
+		input    string
+		expected *Location
+	}{
+		{
+			note:  "Nested call",
+			input: "foo(bar(1))",
+			expected: &Location{
+				Row:    1,
+				Col:    5,
+				Offset: 4,
+				Text:   []byte("bar(1)"),
+			},
+		},
+		{
+			note:  "Inner set term",
+			input: "foo(set())",
+			expected: &Location{
+				Row:    1,
+				Col:    5,
+				Offset: 4,
+				Text:   []byte("set()"),
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.note, func(t *testing.T) {
+			parsed, err := ParseExpr(tc.input)
+			if err != nil {
+				t.Errorf("Unexpected error on %s: %s", tc.input, err)
+				return
+			}
+
+			innerCall := parsed.Operand(0)
+			if !innerCall.Location.Equal(tc.expected) {
+				t.Errorf("Expected location %+v for '%v' but got %+v ", *(tc.expected), innerCall.String(), *innerCall.Location)
+			}
+		})
+	}
+}
+
 func TestAnnotations(t *testing.T) {
 
 	dataServers := MustParseRef("data.servers")


### PR DESCRIPTION
Alters parseRef's LParen case to use lastEnd instead of tokEnd. This is necessary because parseCall advances a token beyond the call's closing paren to check for a SetTerm.

Fixes: open-policy-agent#7989

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

* You have read the project's
  [guidelines on AI tool use](https://www.openpolicyagent.org/docs/contrib-code#ai-guidelines).

For more information on contributing to OPA see our
[Contributing Guide](https://www.openpolicyagent.org/docs/contributing/)
for high-level contributing guidelines and development setup.
(See the [Developer Certificate of Origin](https://www.openpolicyagent.org/docs/contrib-code/#developer-certificate-of-origin)
section for specifics on signing off a commit.)

-->

### Why the changes in this PR are needed?

In parseCall, this logic scans past the closing paren:

```go
if p.s.tok == tokens.RParen { // no args, i.e. set() or any.func()
	end = p.s.tokEnd
	p.scanWS()
	if operator.Equal(setConstructor) {
		return SetTerm()
	}
	return CallTerm(operator)
}

if r := p.parseTermList(tokens.RParen, []*Term{operator}); r != nil {
	end = p.s.tokEnd
	p.scanWS()
	return CallTerm(r...)
}
```
Where an additional scan advances the last token.
This causes p.s.tokEnd to contain the additional unwanted character. 

### What are the changes in this PR?
Line 1981's p.s.tokEnd becomes p.s.lastTok
The original intent seems to have been to omit whitespace, not to capture this token.


### Notes to assist PR review:
The only regression in regal was TestSerializedModuleSize
