### PR TITLE
website: Use Regal in regal page titles

### DIFF
--- a/docs/projects/regal/adopters.md
+++ b/docs/projects/regal/adopters.md
@@ -2,6 +2,9 @@
 sidebar_position: 13
 ---
 
+<head>
+  <title>Adopters | Regal</title>
+</head>
 
 # Adopters
 

--- a/docs/projects/regal/architecture.md
+++ b/docs/projects/regal/architecture.md
@@ -2,6 +2,9 @@
 sidebar_position: 4
 ---
 
+<head>
+  <title>Architecture | Regal</title>
+</head>
 
 # Architecture
 

--- a/docs/projects/regal/cicd.md
+++ b/docs/projects/regal/cicd.md
@@ -3,6 +3,9 @@ sidebar_label: CI/CD
 sidebar_position: 8
 ---
 
+<head>
+  <title>CI/CD | Regal</title>
+</head>
 
 # Using Regal in your build pipeline
 

--- a/docs/projects/regal/cli.md
+++ b/docs/projects/regal/cli.md
@@ -3,6 +3,9 @@ sidebar_position: 4
 sidebar_label: CLI
 ---
 
+<head>
+  <title>CLI | Regal</title>
+</head>
 
 # CLI
 

--- a/docs/projects/regal/configuration/capabilities.md
+++ b/docs/projects/regal/configuration/capabilities.md
@@ -2,6 +2,9 @@
 sidebar_position: 5
 ---
 
+<head>
+  <title>Capabilities | Regal</title>
+</head>
 
 # Capabilities
 

--- a/docs/projects/regal/configuration/ignore-rules.md
+++ b/docs/projects/regal/configuration/ignore-rules.md
@@ -2,6 +2,9 @@
 sidebar_position: 6
 ---
 
+<head>
+  <title>Ignoring Rules | Regal</title>
+</head>
 
 # Ignoring Rules
 

--- a/docs/projects/regal/configuration/index.md
+++ b/docs/projects/regal/configuration/index.md
@@ -2,6 +2,9 @@
 sidebar_position: 4
 ---
 
+<head>
+  <title>Configuration | Regal</title>
+</head>
 
 # Configuration
 

--- a/docs/projects/regal/configuration/project-roots.md
+++ b/docs/projects/regal/configuration/project-roots.md
@@ -2,6 +2,9 @@
 sidebar_position: 7
 ---
 
+<head>
+  <title>Project Roots | Regal</title>
+</head>
 
 # Project Roots
 

--- a/docs/projects/regal/configuration/rego-version.md
+++ b/docs/projects/regal/configuration/rego-version.md
@@ -3,6 +3,9 @@ sidebar_position: 8
 sidebar_label: Rego Version
 ---
 
+<head>
+  <title>Rego Version | Regal</title>
+</head>
 
 # Configuring Rego Version
 

--- a/docs/projects/regal/custom-rules/index.md
+++ b/docs/projects/regal/custom-rules/index.md
@@ -2,6 +2,9 @@
 sidebar_position: 5
 ---
 
+<head>
+  <title>Custom Rules | Regal</title>
+</head>
 
 # Custom Rules
 

--- a/docs/projects/regal/custom-rules/roast.md
+++ b/docs/projects/regal/custom-rules/roast.md
@@ -2,6 +2,9 @@
 sidebar_position: 2
 ---
 
+<head>
+  <title>Roast (Regal's Optimized AST) | Regal</title>
+</head>
 
 # Roast (Regal's Optimized AST)
 

--- a/docs/projects/regal/debug-adapter.md
+++ b/docs/projects/regal/debug-adapter.md
@@ -2,6 +2,9 @@
 sidebar_position: 10
 ---
 
+<head>
+  <title>Debugging Rego | Regal</title>
+</head>
 
 # Debugging Rego
 

--- a/docs/projects/regal/editor-support.md
+++ b/docs/projects/regal/editor-support.md
@@ -2,6 +2,9 @@
 sidebar_position: 7
 ---
 
+<head>
+  <title>Editor Support | Regal</title>
+</head>
 
 # Editor Support
 

--- a/docs/projects/regal/fixing.md
+++ b/docs/projects/regal/fixing.md
@@ -2,6 +2,9 @@
 sidebar_position: 3
 ---
 
+<head>
+  <title>Fixing Violations | Regal</title>
+</head>
 
 # Fixing Violations
 

--- a/docs/projects/regal/index.md
+++ b/docs/projects/regal/index.md
@@ -4,6 +4,12 @@ sidebar_position: 1
 title: Introduction
 ---
 
+<!-- markdownlint-disable MD033 -->
+<head>
+<!-- markdownlint-disable MD033 -->
+  <title>Introduction | Regal</title>
+</head>
+
 <!-- markdownlint-disable MD041 -->
 
 import Intro from '@site/src/components/projects/regal/Intro';
@@ -24,7 +30,6 @@ experienced Rego developer or just starting out.
 
 <Intro image={require('./assets/regal-banner.png').default}/>
 
-
 <!-- markdownlint-disable MD041 -->
 
 ## Goals
@@ -33,7 +38,6 @@ experienced Rego developer or just starting out.
 - Identify common mistakes, bugs and inefficiencies in Rego policies, and suggest better approaches
 - Provide advice on [best practices](https://www.openpolicyagent.org/docs/style-guide), coding style, and tooling
 - Allow users, teams and organizations to enforce custom rules on their policy code
-
 
 <!-- markdownlint-disable MD041 -->
 
@@ -57,7 +61,6 @@ experienced Rego developer or just starting out.
 — Jimmy Ray, [Boeing](https://www.boeing.com/)
 
 See the [adopters](https://www.openpolicyagent.org/projects/regal/adopters) file for more Regal users.
-
 
 <!-- markdownlint-disable MD041 -->
 
@@ -200,7 +203,6 @@ we've made it easy to run Regal as part of your builds.
 See the docs on [Using Regal in your build pipeline](https://www.openpolicyagent.org/projects/regal/cicd) to learn more
 about how to set up Regal to lint your policies on every commit or pull request.
 
-
 <!-- markdownlint-disable MD041 -->
 
 ## Next Steps
@@ -226,7 +228,6 @@ Regal.
 - [CI/CD](https://www.openpolicyagent.org/projects/regal/cicd): Run Regal as part of your automated checks.
 - [Custom Rules](https://www.openpolicyagent.org/projects/regal/custom-rules): Learn how to write your own rules for Regal.
 - [Adopters](https://www.openpolicyagent.org/projects/regal/adopters): See who else is using Regal.
-
 
 <!-- If updating, please check resources.md too -->
 
@@ -255,14 +256,12 @@ contains information about how to hack on Regal itself.
 - [Regal を使って Rego を Lint する](https://tech.dentsusoken.com/entry/2024/12/05/Regal_%E3%82%92%E4%BD%BF%E3%81%A3%E3%81%A6_Rego_%E3%82%92_Lint_%E3%81%99%E3%82%8B)
   by Shibata Takao ([@shibata.takao](https://shodo.ink/@shibata.takao/))
 
-
 <!-- markdownlint-disable MD041 -->
 
 ## Status
 
 Regal is currently in beta. End-users should not expect any drastic changes, but any API may change without notice.
 If you want to embed Regal in another project or product, please reach out!
-
 
 <!-- markdownlint-disable MD041 -->
 
@@ -280,5 +279,3 @@ The current Roadmap items are all related to the preparation for
 - [lsp: Support a JetBrains LSP client (#1560)](https://github.com/open-policy-agent/regal/issues/1560)
 
 If there's something you'd like to have added to the roadmap, either open an issue, or reach out in the community Slack!
-
-

--- a/docs/projects/regal/integration.md
+++ b/docs/projects/regal/integration.md
@@ -3,6 +3,9 @@ sidebar_position: 12
 sidebar_label: Go Integration
 ---
 
+<head>
+  <title>Go Integration | Regal</title>
+</head>
 
 # Go Integration
 

--- a/docs/projects/regal/language-server.md
+++ b/docs/projects/regal/language-server.md
@@ -2,6 +2,9 @@
 sidebar_position: 9
 ---
 
+<head>
+  <title>Language Server | Regal</title>
+</head>
 
 # Language Server
 

--- a/docs/projects/regal/opa-one-dot-zero.md
+++ b/docs/projects/regal/opa-one-dot-zero.md
@@ -3,6 +3,9 @@ sidebar_label: OPA 1.0
 sidebar_position: 14
 ---
 
+<head>
+  <title>OPA 1.0 | Regal</title>
+</head>
 
 # OPA 1.0 and Regal
 

--- a/docs/projects/regal/pre-commit-hooks.md
+++ b/docs/projects/regal/pre-commit-hooks.md
@@ -2,6 +2,9 @@
 sidebar_position: 6
 ---
 
+<head>
+  <title>Pre-Commit Hooks | Regal</title>
+</head>
 
 # Pre-Commit Hooks
 

--- a/docs/projects/regal/remote-features.md
+++ b/docs/projects/regal/remote-features.md
@@ -2,6 +2,9 @@
 sidebar_position: 11
 ---
 
+<head>
+  <title>Remote Features | Regal</title>
+</head>
 
 # Remote Features
 

--- a/docs/projects/regal/rules/bugs/index.md
+++ b/docs/projects/regal/rules/bugs/index.md
@@ -3,6 +3,9 @@ title: Bugs
 sidebar_position: 1
 ---
 
+<head>
+  <title>Bugs | Regal</title>
+</head>
 
 # Bugs
 

--- a/docs/projects/regal/rules/custom/index.md
+++ b/docs/projects/regal/rules/custom/index.md
@@ -3,6 +3,9 @@ title: Custom
 sidebar_position: 7
 ---
 
+<head>
+  <title>Custom | Regal</title>
+</head>
 
 # Custom
 

--- a/docs/projects/regal/rules/idiomatic/index.md
+++ b/docs/projects/regal/rules/idiomatic/index.md
@@ -3,6 +3,9 @@ title: Idiomatic
 sidebar_position: 2
 ---
 
+<head>
+  <title>Idiomatic | Regal</title>
+</head>
 
 # Idiomatic
 

--- a/docs/projects/regal/rules/imports/index.md
+++ b/docs/projects/regal/rules/imports/index.md
@@ -3,6 +3,9 @@ title: Imports
 sidebar_position: 3
 ---
 
+<head>
+  <title>Imports | Regal</title>
+</head>
 
 # Imports
 

--- a/docs/projects/regal/rules/index.md
+++ b/docs/projects/regal/rules/index.md
@@ -3,6 +3,9 @@ title: Rules
 sidebar_position: 2
 ---
 
+<head>
+  <title>Rules | Regal</title>
+</head>
 
 # Rules
 

--- a/docs/projects/regal/rules/performance/index.md
+++ b/docs/projects/regal/rules/performance/index.md
@@ -3,6 +3,9 @@ title: Performance
 sidebar_position: 4
 ---
 
+<head>
+  <title>Performance | Regal</title>
+</head>
 
 # Performance
 

--- a/docs/projects/regal/rules/style/index.md
+++ b/docs/projects/regal/rules/style/index.md
@@ -3,6 +3,9 @@ title: Style
 sidebar_position: 5
 ---
 
+<head>
+  <title>Style | Regal</title>
+</head>
 
 # Style
 

--- a/docs/projects/regal/rules/testing/index.md
+++ b/docs/projects/regal/rules/testing/index.md
@@ -3,6 +3,9 @@ title: Testing
 sidebar_position: 6
 ---
 
+<head>
+  <title>Testing | Regal</title>
+</head>
 
 # Testing
 


### PR DESCRIPTION
Rather than Open Policy Agent, which was confusing

before 
<img width="214" height="105" alt="Screenshot 2025-11-10 at 12 27 30" src="https://github.com/user-attachments/assets/6e495325-4583-4407-90f9-47f7053407b2" />

after
<img width="149" height="99" alt="Screenshot 2025-11-10 at 12 27 17" src="https://github.com/user-attachments/assets/68853414-7bbc-4328-a37b-3e79bf01cf80" />
