### PR TITLE
website/docs: Fix remaining broken links

### DIFF
--- a/docs/docs/debugging/index.md
+++ b/docs/docs/debugging/index.md
@@ -73,7 +73,7 @@ OPA logs are a great place to start when debugging issues. The logs can be used 
 at any given time. Common issues such as failing to load in policy or data bundles will be shown here.
 
 You can also enable debug logging to get more detailed information about what OPA is doing with `--log-level debug`.
-This is documented in the [CLI documentation](./cli/#options-10) for `opa run`.
+This is documented in the [CLI documentation](./cli/#run) for `opa run`.
 
 ### Decision Logging
 

--- a/docs/docs/deploy/aws/ecs.mdx
+++ b/docs/docs/deploy/aws/ecs.mdx
@@ -4,6 +4,9 @@ sidebar_position: 3
 title: Deploying OPA on AWS ECS
 ---
 
+<!-- Manual Heading imports are needed because the ParamProvider plugin provider hides anchors from the broken link checker -->
+import Heading from '@theme/Heading';
+
 Amazon ECS (Elastic Container Service) is a managed platform for running
 containerized applications. Software already packaged as containers, like OPA,
 is easy to run on ECS. ECS takes care of scaling, networking, and
@@ -84,7 +87,7 @@ graph
 >
 
 
-## Creating a Secret and IAM Role for your OPA Task
+<Heading as="h2" id="creating-a-secret-and-iam-role-for-your-opa-task">Creating a Secret and IAM Role for your OPA Task</Heading>
 
 OPA needs to download policy at startup. Often credentials are needed to
 download new policy and data bundles. These might be an API token, or
@@ -128,7 +131,7 @@ the task's ARN here to populate the later steps:
 <InlineEditable paramKey="taskRoleArn"/>.
 
 
-## Creating an OPA Task Definition
+<Heading as="h2" id="creating-an-opa-task-definition">Creating an OPA Task Definition</Heading>
 
 An ECS task definition is a blueprint that describes how containers
 should run in AWS ECS, specifying details like container images, commands and
@@ -236,7 +239,7 @@ the health `localhost` port too.
 :::
 
 
-## Deploying OPA on the Cluster
+<Heading as="h2" id="deploying-opa-on-the-cluster">Deploying OPA on the Cluster</Heading>
 
 Once you have a task definition in place, you can deploy it to your ECS cluster.
 

--- a/docs/docs/deploy/azure/container-apps.mdx
+++ b/docs/docs/deploy/azure/container-apps.mdx
@@ -4,6 +4,9 @@ sidebar_position: 3
 title: Deploying OPA on Azure Container Apps
 ---
 
+<!-- Manual Heading imports are needed because the ParamProvider plugin provider hides anchors from the broken link checker -->
+import Heading from '@theme/Heading';
+
 Azure Container Apps provides a fully managed platform for deploying and scaling
 containerized applications. It is well-suited for running off-the-shelf
 software, such as OPA, handling scaling, networking, and infrastructure,
@@ -104,7 +107,7 @@ Once created, the app will be deployed with the specified image. In the next
 step we'll create an link the OPA configuration file as a secret mount.
 
 
-## Loading OPA Configuration
+<Heading as="h2" id="loading-opa-configuration">Loading OPA Configuration</Heading>
 
 OPA requires a configuration file specifying policy bundle locations. For secure
 management, store the OPA configuration file as a secret in Azure Container

--- a/docs/docs/deploy/docker/index.md
+++ b/docs/docs/deploy/docker/index.md
@@ -44,7 +44,7 @@ accessible from outside the container. This is not necessary when running OPA
 in other environments.
 
 More information can be found in the
-[security documentation](../../security#interface-binding).
+[security documentation](../../../docs/security#interface-binding).
 :::
 
 Test that OPA is available:

--- a/docs/docs/docker-authorization.md
+++ b/docs/docs/docker-authorization.md
@@ -172,7 +172,7 @@ The output should be:
 Error response from daemon: authorization denied by plugin opa-docker-authz: request rejected by administrative policy
 ```
 
-To learn more about how rules define the content of documents, see: [How Does OPA Work?](../#overview)
+To learn more about how rules define the content of documents, see: [How Does OPA Work?](./philosophy)
 
 With this policy in place, users will not be able to run any Docker commands. Go
 ahead and try other commands such as `docker run` or `docker pull`. They will

--- a/docs/docs/envoy/debugging.md
+++ b/docs/docs/envoy/debugging.md
@@ -23,7 +23,7 @@ To enable local console logging of decisions see [this](https://www.openpolicyag
 ### Envoy External Authorization Filter Configuration
 
 Envoy's External authorization gRPC service configuration uses either Envoy’s in-built gRPC client, or the Google C++ gRPC client.
-From the [benchmarking](./performance#opa-benchmarks) results, lower latency numbers are seen while using Envoy’s gRPC client versus Google's. Experimenting
+From the [benchmarking](./performance#benchmark-scenarios) results, lower latency numbers are seen while using Envoy's gRPC client versus Google's. Experimenting
 with the gRPC service configuration may help in improving performance.
 
 The filter configuration also has a `status_on_error` field that can be used to indicate a network error between the filter

--- a/docs/docs/envoy/performance.md
+++ b/docs/docs/envoy/performance.md
@@ -232,7 +232,7 @@ role_perms := {
 - **App, Envoy and OPA (Header Injection policy)**
 
 This scenario is similar to the previous one expect the policy decision is an object which contains optional
-response headers. An example of such a policy can be found [here](../envoy/primer#example-policy-with-object-response).
+response headers. An example of such a policy can be found [here](../envoy/primer#example-policy-with-additional-controls).
 
 ### Measurements
 

--- a/docs/docs/envoy/primer.md
+++ b/docs/docs/envoy/primer.md
@@ -57,7 +57,7 @@ token := {"valid": valid, "payload": payload} if {
 <RunSnippet id="authz.rego"/>
 
 The first line `package envoy.authz` declaration gives the (hierarchical) name `envoy.authz` to the rules in the
-remainder of the policy. If the OPA-Envoy [configuration](../#configuration) does not specify the `path`
+remainder of the policy. If the OPA-Envoy [configuration](../configuration) does not specify the `path`
 field, `envoy/authz/allow` will be considered as the default policy decision path. `data.envoy.authz.allow` will be the
 name of the policy decision to query in the default case.
 
@@ -486,7 +486,7 @@ allow if {
 The `truncated_body` field in the input represents if the HTTP request body is truncated. The body is considered to be
 truncated, if the value of the `Content-Length` header exceeds the size of the request body.
 
-If `skip-request-body-parse: true` is specified in the OPA-Envoy [configuration](../#configuration), then
+If `skip-request-body-parse: true` is specified in the OPA-Envoy [configuration](../configuration), then
 the `parsed_body` and `truncated_body` fields will be omitted from the input.
 
 ## Example with JWT payload passed from Envoy

--- a/docs/docs/policy-language.md
+++ b/docs/docs/policy-language.md
@@ -2759,7 +2759,7 @@ This value is false by default, and can only be used at `document` or `package` 
 explicit `scope` set, the presence of an `entrypoint` annotation will automatically set the scope to `document`.
 
 The `build` and `eval` CLI commands will automatically pick up annotated entrypoints; you do not have to specify them with
-[`--entrypoint`](./cli/#options-1).
+[`--entrypoint`](./cli/#eval).
 
 :::info
 Unless the `--prune-unused` flag is used, any rule transitively referring to a
@@ -2829,7 +2829,7 @@ output := decision if {
 
 <RunSnippet files="#input.metadata.json" command="data.example.output"/>
 
-If you'd like more examples and information on this, you can see more here under the [Rego](./policy-reference/#rego) policy reference.
+If you'd like more examples and information on this, you can see more here under the [Rego](./policy-reference/builtins/rego) policy reference.
 
 #### From the `inspect` command
 

--- a/docs/docs/policy-reference/builtins/regex.mdx
+++ b/docs/docs/policy-reference/builtins/regex.mdx
@@ -77,7 +77,7 @@ specific parts of the string separately.
 Before continuing, make sure your use case is not solved by the simpler
 [`regex.match()`](#match)
 or
-[`glob.match`](/docs/policy-reference/#builtin-glob-globmatch)
+[`glob.match`](/docs/policy-reference/builtins/glob#builtin-glob-globmatch)
 functions.
 
 This functions are easier to use and thus less error prone for simpler use cases.

--- a/docs/docs/ssh-and-sudo-authorization.md
+++ b/docs/docs/ssh-and-sudo-authorization.md
@@ -419,7 +419,7 @@ You will find that running `sudo ls /` as the `frontend-dev` user is disallowed 
 It is possible to configure the _display_ policy to only make the PAM module prompt for the
 elevation ticket when our mock API has a non-empty `tickets` object. So when there are no
 elevated users, there will be no prompt for a ticket. This can be done using the Rego
-[`count` aggregate](./policy-reference/#aggregates).
+[`count` aggregate](./policy-reference/builtins/aggregates).
 
 ## Wrap Up
 

--- a/docs/docs/v0-upgrade/index.md
+++ b/docs/docs/v0-upgrade/index.md
@@ -57,8 +57,8 @@ matches your setup to find the recommended upgrade path.
 If you are in doubt, [Scenario 1](#scenario-1-v0x-producer-v0x-consumer) is the most common starting
 point and we recommended you start there.
 
-|                   | v0.x Consumer                        | Mix Consumer              | v1.0 Consumer                        |
-| ----------------- | ------------------------------------ | ------------------------- | ------------------------------------ |
+|                   | v0.x Consumer                                                  | Mix Consumer                                        | v1.0 Consumer                                                  |
+| ----------------- | -------------------------------------------------------------- | --------------------------------------------------- | -------------------------------------------------------------- |
 | **v0.x Producer** | [Scenario 1](#scenario-1-v0x-producer-v0x-consumer) (All v0.x) | [Scenario 4](#scenario-4-v0x-producer-mix-consumer) | [Scenario 7](#scenario-7-v0x-producer-v10-consumer)            |
 | **Mix Producer**  | [Scenario 2](#scenario-2-mix-producer-v0x-consumer)            | [Scenario 5](#scenario-5-mix-producer-mix-consumer) | [Scenario 8](#scenario-8-mix-producer-v10-consumer)            |
 | **v1.0 Producer** | [Scenario 3](#scenario-3-v10-producer-v0x-consumer)            | [Scenario 6](#scenario-6-v10-producer-mix-consumer) | [Scenario 9](#scenario-9-v10-producer-v10-consumer) (All v1.0) |
@@ -512,7 +512,7 @@ when the instance needs to be accessed by the host or another container.
 :::
 
 More information can be found in the
-[security documentation](../security#interface-binding).
+[security documentation](./security#interface-binding).
 
 ## Upgrading for Go Integrations
 

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -19,6 +19,8 @@ const baseUrl = "/";
     url: "https://openpolicyagent.org",
     baseUrl: baseUrl,
     trailingSlash: false,
+    onBrokenLinks: 'throw',
+    onBrokenAnchors: 'throw',
     presets: [
       [
         "@docusaurus/preset-classic",
@@ -33,10 +35,6 @@ const baseUrl = "/";
           blog: false,
           theme: {
             customCss: require.resolve("./src/css/custom.css"),
-          },
-          gtag: {
-            trackingID: "G-JNBNV64PDX",
-            anonymizeIP: true,
           },
         },
       ],
@@ -281,6 +279,13 @@ The Linux Foundation has registered trademarks and uses trademarks. For a list o
     },
 
     plugins: [
+      [
+        "@docusaurus/plugin-google-gtag",
+        {
+          trackingID: "G-JNBNV64PDX",
+          anonymizeIP: true,
+        },
+      ],
       [
         "@docusaurus/plugin-content-docs",
         {

--- a/docs/projects/regal/configuration/ignore-rules.md
+++ b/docs/projects/regal/configuration/ignore-rules.md
@@ -132,7 +132,7 @@ The format of an ignore directive is `regal ignore:<rule-name>,<rule-name>...`, 
 rule to ignore. Multiple rules may be added to the same ignore directive, separated by commas.
 
 Note that at this point in time, Regal only considers the same line or the line following the ignore directive, i.e. it
-does not apply to entire blocks of code (like rules, functions or even packages). See [configuration](#configuration)
+does not apply to entire blocks of code (like rules, functions or even packages). See [configuration](./)
 if you want to ignore certain rules altogether.
 
 ## Ignoring Rules via CLI Flags

--- a/docs/src/components/BuiltinTable/index.js
+++ b/docs/src/components/BuiltinTable/index.js
@@ -1,3 +1,4 @@
+import Heading from "@theme/Heading";
 import React from "react";
 import ReactMarkdown from "react-markdown";
 
@@ -91,9 +92,9 @@ export default function BuiltinTable({
               : `${result.name || "result"} := ${name}(${args.map((a) => a.name).join(", ")})`;
 
             return (
-              <tr key={anchor} id={anchor}>
+              <tr key={anchor}>
                 <td className={styles.functionCell}>
-                  <a href={`#${anchor}`}>
+                  <Heading as="h6" id={anchor}>
                     <code className={styles.functionName}>
                       {(isInfix ? signature : name)
                         .split(/(\.|_)/)
@@ -108,7 +109,7 @@ export default function BuiltinTable({
                             : part
                         )}
                     </code>
-                  </a>
+                  </Heading>
                 </td>
                 <td>
                   <p>

--- a/docs/src/components/CommandDoc/index.js
+++ b/docs/src/components/CommandDoc/index.js
@@ -2,6 +2,7 @@ import { React, useEffect } from "react";
 import { useLocation } from "react-router-dom";
 
 import { useThemeConfig } from "@docusaurus/theme-common";
+import Heading from "@theme/Heading";
 import ReactMarkdown from "react-markdown";
 import styles from "./styles.module.css";
 
@@ -57,12 +58,7 @@ const CommandDoc = ({ command }) => {
   return (
     <div>
       <div className={styles.commandHeader}>
-        <h2 id={id} className={styles.commandTitle}>
-          {id}
-          <a href={`#${id}`} className={styles.directLink} title={`Direct link to ${id}`}>
-            <span className={styles.directLinkSymbol}>#</span>
-          </a>
-        </h2>
+        <Heading id={id} as="h2">{id}</Heading>
       </div>
 
       {useline && (


### PR DESCRIPTION
- some were false positives where the react components I had made were not working with the checker. (CLI and Builtins refs)
- Others related to pages moved around etc, pages that used to be headings and so on.
- also address gtag loading issue by correctly configure via plugin.

From now, a broken anchor is fatal at build time.