### PR TITLE
website: Make latest release versioning docs content only

### DIFF
--- a/docs/bin/build-latest.sh
+++ b/docs/bin/build-latest.sh
@@ -10,8 +10,6 @@ fi
 
 git fetch --tags origin
 
-CURRENT_REF=$(git rev-parse HEAD)
-
 LATEST_TAG=$(git tag --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
 
 if [ -z "$LATEST_TAG" ]; then
@@ -19,11 +17,7 @@ if [ -z "$LATEST_TAG" ]; then
     exit 1
 fi
 
-git checkout "$LATEST_TAG"
-
-# update the sections of the site that are versioned elsewhere to use main.
-git checkout "$CURRENT_REF" -- projects/
+# for docs content we use the latest release
+git checkout "$LATEST_TAG" -- docs
 
 BUILD_VERSION="$LATEST_TAG" npx docusaurus build
-
-git checkout "$CURRENT_REF"

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -19,8 +19,10 @@ const baseUrl = "/";
     url: "https://openpolicyagent.org",
     baseUrl: baseUrl,
     trailingSlash: false,
-    onBrokenLinks: 'throw',
-    onBrokenAnchors: 'throw',
+    // when BUILD_VERSION is set (release builds), warn on broken links/anchors so we don't break main
+    // when not set (PR checks), throw to flag issues for developers
+    onBrokenLinks: process.env.BUILD_VERSION ? 'warn' : 'throw',
+    onBrokenAnchors: process.env.BUILD_VERSION ? 'warn' : 'throw',
     presets: [
       [
         "@docusaurus/preset-classic",


### PR DESCRIPTION
Only revert the docs content to the latest release. Retain all other parts of the site the same.

Makes #8035 actually show.