### PR TITLE
docs: fix broken url in s3 datasource example

### DIFF
--- a/docs/docs/ocp/concepts.md
+++ b/docs/docs/ocp/concepts.md
@@ -168,7 +168,7 @@ sources:
         type: http
         path: data/from/s3
         config:
-          url: https://my-bucket.my-region.s3.amazonaws.com/s3-data.json
+          url: https://my-bucket.s3.my-region.amazonaws.com/s3-data.json
           credentials: aws_auth
 ```
 


### PR DESCRIPTION
Current url to s3 datasorce is broken. 

Correct form is: https://bucket-name.s3.region-code.amazonaws.com where the s3 comes before the region. 

Source official Amazon docs:
https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html

