### PR TITLE
website: Process feedback form on netlify

### DIFF
--- a/docs/functions/feedback.ts
+++ b/docs/functions/feedback.ts
@@ -1,0 +1,91 @@
+import { Context } from "netlify:edge";
+
+const headers = { "Content-Type": "application/json" };
+
+export default async (req: Request, context: Context) => {
+  if (req.method !== "POST") {
+    return new Response(JSON.stringify({ error: "Method not allowed" }), {
+      status: 405,
+      headers,
+    });
+  }
+
+  try {
+    const requestBody = await req.json();
+    const feedbackData = requestBody.data;
+    const formName = requestBody.form_name;
+
+    // Verify this is from the correct form
+    if (formName !== "page-feedback") {
+      return new Response(JSON.stringify({ error: "Invalid form" }), {
+        status: 400,
+        headers,
+      });
+    }
+
+    const slackUrl = Deno.env.get("SLACK_DOCUMENTATION_FEEDBACK_URL");
+    if (!slackUrl) {
+      console.error("SLACK_DOCUMENTATION_FEEDBACK_URL environment variable not set");
+      return new Response(JSON.stringify({ error: "Configuration error" }), {
+        status: 500,
+        headers,
+      });
+    }
+
+    const feedbackType = feedbackData["feedback-type"];
+    const comment = feedbackData.comment || "No comment provided";
+    const url = feedbackData.url;
+
+    const emoji = feedbackType === "positive" ? "👍" : "👎";
+    const slackMessage = {
+      text: `📨 New feedback received`,
+      attachments: [
+        {
+          fields: [
+            {
+              title: "Feedback Type",
+              value: feedbackType === "positive" ? "Positive" : "Negative",
+              short: true,
+            },
+            {
+              title: "Page URL",
+              value: url,
+              short: false,
+            },
+            {
+              title: "Comment",
+              value: comment,
+              short: false,
+            },
+          ],
+          footer: "OPA Documentation Feedback",
+          ts: Math.floor(Date.now() / 1000),
+        },
+      ],
+    };
+
+    const response = await fetch(slackUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(slackMessage),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Slack webhook failed: ${response.status}`);
+    }
+
+    return new Response(JSON.stringify({ success: true }), {
+      status: 200,
+      headers,
+    });
+  } catch (error) {
+    console.error("Error processing feedback:", error);
+    return new Response(JSON.stringify({ error: "Internal server error" }), {
+      status: 500,
+      headers,
+    });
+  }
+};
+

--- a/docs/src/components/FeedbackForm/index.js
+++ b/docs/src/components/FeedbackForm/index.js
@@ -10,7 +10,7 @@ import styles from "./styles.module.css";
  * A feedback form component that is automatically added to the end of documentation pages.
  * It can also be manually included in other pages by setting enablePopup to true.
  * The form allows users to provide positive or negative feedback with optional comments
- * and email for follow-up. Feedback is submitted to Netlify Forms via AJAX.
+. Feedback is submitted to Netlify Forms via AJAX.
  *
  * Note: When adding new fields to this form, remember to update the static/netlify-forms.html
  * file so that Netlify knows which fields to permit. If this is not updated, new fields
@@ -207,6 +207,17 @@ export default function FeedbackForm({ enablePopup = false }) {
  * hidden when the feedback form comes into view.
  */
 const FloatingPopup = ({ onClose, onFeedbackSelect }) => {
+  const [showAnimation, setShowAnimation] = useState(false);
+
+  useEffect(() => {
+    // Trigger fade-in animation after component mounts
+    const timer = setTimeout(() => {
+      setShowAnimation(true);
+    }, 50); // Small delay to ensure smooth animation
+
+    return () => clearTimeout(timer);
+  }, []);
+
   const handleClose = () => {
     // Set global flag to never show popup again
     localStorage.setItem("documentation-feedback-popup-dismissed", "true");
@@ -221,7 +232,7 @@ const FloatingPopup = ({ onClose, onFeedbackSelect }) => {
   };
 
   return (
-    <div className={styles.popup}>
+    <div className={`${styles.popup} ${showAnimation ? styles.show : ''}`}>
       <button
         className={styles.closeButton}
         onClick={handleClose}
@@ -302,12 +313,6 @@ const Form = ({
             required={feedbackType === "negative"}
           />
         </div>
-        <div className={styles.email}>
-          <div>
-            <input type="email" name="email" placeholder="Email (optional)" />
-          </div>
-        </div>
-        <p className={styles.note}>Email will only be used for comment follow-up.</p>
       </div>
     )}
 

--- a/docs/src/components/FeedbackForm/styles.module.css
+++ b/docs/src/components/FeedbackForm/styles.module.css
@@ -44,28 +44,6 @@
 	color: var(--ifm-font-color-base);
 }
 
-.email div {
-	width: 100%;
-	display: inline-block;
-	max-width: 25rem;
-}
-
-.email div:first-child {
-	/* Removing padding-right to match widths */
-}
-
-.email input {
-	padding: 0.5rem 0.5rem;
-	font-size: 1rem;
-	width: 100%;
-	max-width: 25rem;
-	border-radius: 0.2rem;
-	border: 1px solid var(--ifm-color-emphasis-300);
-	box-sizing: border-box;
-	background-color: var(--ifm-background-color);
-	color: var(--ifm-font-color-base);
-}
-
 .note {
 	font-size: 0.8rem;
 }
@@ -74,13 +52,22 @@
 	position: fixed;
 	bottom: 1.25rem;
 	right: 1.25rem;
-	background: var(--ifm-background-color);
+	background-color: var(--ifm-card-background-color);
+	color: var(--ifm-font-color-base);
 	border-radius: 0.5rem;
 	box-shadow: 0 0.125rem 0.625rem rgba(0, 0, 0, 0.1);
 	padding: 1rem;
 	z-index: 1000;
 	max-width: 18.75rem;
 	border: 1px solid var(--ifm-color-emphasis-300);
+	opacity: 0;
+	transform: translateY(20px);
+	transition: opacity 0.6s ease-out, transform 0.6s ease-out;
+}
+
+.popup.show {
+	opacity: 1;
+	transform: translateY(0);
 }
 
 .closeButton {

--- a/docs/static/netlify-forms.html
+++ b/docs/static/netlify-forms.html
@@ -9,7 +9,6 @@
 		<form name="page-feedback" netlify netlify-honeypot="bot-field" hidden>
 			<input type="hidden" name="url" />
 			<input type="hidden" name="feedback-type" />
-			<input type="email" name="email" />
 			<textarea name="comment"></textarea>
 		</form>
 	</div>

--- a/netlify.toml
+++ b/netlify.toml
@@ -24,6 +24,11 @@ function = "badge"
 path = "/docs/*"
 function = "version-redirect"
 
+# function to process form notifications from netlify forms and send them to slack
+[[edge_functions]]
+path = "/api/feedback"
+function = "feedback"
+
 # /data/versions.json is used by versioned OPA deployments to determine
 # if what the latest release is, how outdated they are.
 [[headers]]


### PR DESCRIPTION
This new function allows netlify to process the form's notification hook itself and post to slack without zapier.

I have also removed email from the form since it's PII.