### PR TITLE
util/performance: remove math.Log10, remove unused KeysCount

### DIFF
--- a/v1/util/performance.go
+++ b/v1/util/performance.go
@@ -1,7 +1,6 @@
 package util
 
 import (
-	"math"
 	"slices"
 	"strings"
 	"sync"
@@ -58,7 +57,12 @@ func NumDigitsInt64(n int64) int {
 		n = -n
 	}
 
-	return int(math.Log10(float64(n))) + 1
+	count := 0
+	for n > 0 {
+		n /= 10
+		count++
+	}
+	return count
 }
 
 // NumDigitsUint returns the number of digits in n.
@@ -68,16 +72,10 @@ func NumDigitsUint(n uint64) int {
 		return 1
 	}
 
-	return int(math.Log10(float64(n))) + 1
-}
-
-// KeysCount returns the number of keys in m that satisfy predicate p.
-func KeysCount[K comparable, V any](m map[K]V, p func(K) bool) int {
 	count := 0
-	for k := range m {
-		if p(k) {
-			count++
-		}
+	for n > 0 {
+		n /= 10
+		count++
 	}
 	return count
 }


### PR DESCRIPTION
@anderseknert I thought that integer devision _must_ be faster than anything float-y... but I might be wrong :sweat_smile:

Also removing `KeysCount()` because we're no longer using it. Let's hope nobody external uses it either.