### PR TITLE
docs: Address pages with similar titles

### DIFF
--- a/docs/docs/envoy/index.md
+++ b/docs/docs/envoy/index.md
@@ -1,5 +1,6 @@
 ---
-title: Overview & Architecture
+title: OPA-Envoy Plugin
+sidebar_label: Overview
 sidebar_position: 1
 ---
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -1,5 +1,6 @@
 ---
-title: "Introduction"
+title: "Open Policy Agent (OPA)"
+sidebar_label: "Introduction"
 ---
 
 The Open Policy Agent (OPA, pronounced "oh-pa") is an open source,

--- a/docs/docs/kubernetes/index.md
+++ b/docs/docs/kubernetes/index.md
@@ -1,5 +1,6 @@
 ---
-title: "Overview & Architecture"
+title: "OPA for Kubernetes Admission Control"
+sidebar_label: "Overview"
 sidebar_position: 1
 ---
 

--- a/docs/docs/management-introduction/index.md
+++ b/docs/docs/management-introduction/index.md
@@ -1,5 +1,6 @@
 ---
-title: "Overview & Architecture"
+title: "OPA Management APIs and Architecture"
+sidebar_label: "Overview"
 ---
 
 OPA exposes a set of APIs that enable unified, logically centralized policy

--- a/docs/src/EcosystemFeature.js
+++ b/docs/src/EcosystemFeature.js
@@ -43,7 +43,7 @@ const EcosystemFeature = (props) => {
     <Layout title={title}>
       <div className="container margin-vert--lg">
         <Heading as="h1" style={{ margin: 0 }}>
-          {title}
+          {title} OPA Ecosystem Projects
         </Heading>
         {content && (
           <div style={{ marginTop: "1rem" }}>

--- a/docs/src/EcosystemLanguage.js
+++ b/docs/src/EcosystemLanguage.js
@@ -40,7 +40,7 @@ const EcosystemFeature = (props) => {
     <Layout title={title}>
       <div className="container margin-vert--lg">
         <Heading as="h1" style={{ margin: 0 }}>
-          {title}
+          {title} OPA Ecosystem Projects
         </Heading>
         {content && (
           <div style={{ marginTop: "1rem" }}>


### PR DESCRIPTION
Fixes https://github.com/open-policy-agent/opa/issues/2244

These new titles should make for more clear search engine results too, as well as local search.


<img width="271" height="191" alt="Screenshot 2025-11-12 at 11 34 01" src="https://github.com/user-attachments/assets/b33b4e94-319b-4e3d-9d05-94e62e614467" />
