### PR TITLE
builtins: Add `StringOperandByteSlice` helper

### DIFF
--- a/v1/ast/syncpools.go
+++ b/v1/ast/syncpools.go
@@ -1,32 +1,63 @@
 package ast
 
 import (
+	"bytes"
 	"strings"
 	"sync"
 )
 
-type termPtrPool struct {
-	pool sync.Pool
+var (
+	TermPtrPool     = NewSyncPool[Term]()
+	BytesReaderPool = NewSyncPool[bytes.Reader]()
+	IndexResultPool = NewSyncPool[IndexResult]()
+	// Needs custom pool because of custom Put logic.
+	sbPool = &stringBuilderPool{
+		pool: sync.Pool{
+			New: func() any {
+				return &strings.Builder{}
+			},
+		},
+	}
+	// Needs custom pool because of custom Put logic.
+	varVisitorPool = &vvPool{
+		pool: sync.Pool{
+			New: func() any {
+				return NewVarVisitor()
+			},
+		},
+	}
+)
+
+type (
+	syncPool[T any] struct {
+		pool sync.Pool
+	}
+	stringBuilderPool struct {
+		pool sync.Pool
+	}
+	vvPool struct {
+		pool sync.Pool
+	}
+)
+
+func NewSyncPool[T any]() *syncPool[T] {
+	return &syncPool[T]{
+		pool: sync.Pool{
+			New: func() any {
+				return new(T)
+			},
+		},
+	}
 }
 
-type stringBuilderPool struct {
-	pool sync.Pool
+func (p *syncPool[T]) Get() *T {
+	return p.pool.Get().(*T)
 }
 
-type indexResultPool struct {
-	pool sync.Pool
-}
-
-type vvPool struct {
-	pool sync.Pool
-}
-
-func (p *termPtrPool) Get() *Term {
-	return p.pool.Get().(*Term)
-}
-
-func (p *termPtrPool) Put(t *Term) {
-	p.pool.Put(t)
+func (p *syncPool[T]) Put(x *T) {
+	if x != nil {
+		p.pool.Put(x)
+	}
 }
 
 func (p *stringBuilderPool) Get() *strings.Builder {
@@ -38,16 +69,6 @@ func (p *stringBuilderPool) Put(sb *strings.Builder) {
 	p.pool.Put(sb)
 }
 
-func (p *indexResultPool) Get() *IndexResult {
-	return p.pool.Get().(*IndexResult)
-}
-
-func (p *indexResultPool) Put(x *IndexResult) {
-	if x != nil {
-		p.pool.Put(x)
-	}
-}
-
 func (p *vvPool) Get() *VarVisitor {
 	return p.pool.Get().(*VarVisitor)
 }
@@ -57,36 +78,4 @@ func (p *vvPool) Put(vv *VarVisitor) {
 		vv.Clear()
 		p.pool.Put(vv)
 	}
-}
-
-var TermPtrPool = &termPtrPool{
-	pool: sync.Pool{
-		New: func() any {
-			return &Term{}
-		},
-	},
-}
-
-var sbPool = &stringBuilderPool{
-	pool: sync.Pool{
-		New: func() any {
-			return &strings.Builder{}
-		},
-	},
-}
-
-var varVisitorPool = &vvPool{
-	pool: sync.Pool{
-		New: func() any {
-			return NewVarVisitor()
-		},
-	},
-}
-
-var IndexResultPool = &indexResultPool{
-	pool: sync.Pool{
-		New: func() any {
-			return &IndexResult{}
-		},
-	},
 }

--- a/v1/topdown/builtins/builtins.go
+++ b/v1/topdown/builtins/builtins.go
@@ -209,14 +209,24 @@ func SetOperand(x ast.Value, pos int) (ast.Set, error) {
 	return s, nil
 }
 
-// StringOperand converts x to a string. If the cast fails, a descriptive error is
-// returned.
+// StringOperand returns x as [ast.String], or a descriptive error if the conversion fails.
 func StringOperand(x ast.Value, pos int) (ast.String, error) {
 	s, ok := x.(ast.String)
 	if !ok {
 		return ast.String(""), NewOperandTypeErr(pos, x, "string")
 	}
 	return s, nil
+}
+
+// StringOperandByteSlice returns x a []byte, assuming x is [ast.String], or a descriptive error
+// if that is not the case. The returned byte slice points directly at the underlying array backing
+// the string, and should not be modified.
+func StringOperandByteSlice(x ast.Value, pos int) ([]byte, error) {
+	s, err := StringOperand(x, pos)
+	if err != nil {
+		return nil, err
+	}
+	return util.StringToByteSlice(string(s)), nil
 }
 
 // ObjectOperand converts x to an object. If the cast fails, a descriptive

--- a/v1/topdown/crypto.go
+++ b/v1/topdown/crypto.go
@@ -255,17 +255,17 @@ func extractVerifyOpts(options ast.Object) (verifyOpt x509.VerifyOptions, err er
 }
 
 func builtinCryptoX509ParseKeyPair(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term) error) error {
-	certificate, err := builtins.StringOperand(operands[0].Value, 1)
+	certificate, err := builtins.StringOperandByteSlice(operands[0].Value, 1)
 	if err != nil {
 		return err
 	}
 
-	key, err := builtins.StringOperand(operands[1].Value, 1)
+	key, err := builtins.StringOperandByteSlice(operands[1].Value, 1)
 	if err != nil {
 		return err
 	}
 
-	certs, err := getTLSx509KeyPairFromString([]byte(certificate), []byte(key))
+	certs, err := getTLSx509KeyPairFromString(certificate, key)
 	if err != nil {
 		return err
 	}
@@ -326,10 +326,7 @@ func builtinCryptoX509ParseCertificateRequest(_ BuiltinContext, operands []*ast.
 }
 
 func builtinCryptoJWKFromPrivateKey(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term) error) error {
-	var x any
-
-	a := operands[0].Value
-	input, err := builtins.StringOperand(a, 1)
+	input, err := builtins.StringOperand(operands[0].Value, 1)
 	if err != nil {
 		return err
 	}
@@ -371,6 +368,7 @@ func builtinCryptoJWKFromPrivateKey(_ BuiltinContext, operands []*ast.Term, iter
 		return err
 	}
 
+	var x any
 	if err := util.UnmarshalJSON(jsonKey, &x); err != nil {
 		return err
 	}
@@ -430,53 +428,51 @@ func toHexEncodedString(src []byte) string {
 }
 
 func builtinCryptoMd5(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term) error) error {
-	s, err := builtins.StringOperand(operands[0].Value, 1)
+	bs, err := builtins.StringOperandByteSlice(operands[0].Value, 1)
 	if err != nil {
 		return err
 	}
 
-	md5sum := md5.Sum([]byte(s))
+	md5sum := md5.Sum(bs)
 
 	return iter(ast.StringTerm(toHexEncodedString(md5sum[:])))
 }
 
 func builtinCryptoSha1(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term) error) error {
-	s, err := builtins.StringOperand(operands[0].Value, 1)
+	bs, err := builtins.StringOperandByteSlice(operands[0].Value, 1)
 	if err != nil {
 		return err
 	}
 
-	sha1sum := sha1.Sum([]byte(s))
+	sha1sum := sha1.Sum(bs)
 
 	return iter(ast.StringTerm(toHexEncodedString(sha1sum[:])))
 }
 
 func builtinCryptoSha256(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term) error) error {
-	s, err := builtins.StringOperand(operands[0].Value, 1)
+	bs, err := builtins.StringOperandByteSlice(operands[0].Value, 1)
 	if err != nil {
 		return err
 	}
 
-	sha256sum := sha256.Sum256([]byte(s))
+	sha256sum := sha256.Sum256(bs)
 
 	return iter(ast.StringTerm(toHexEncodedString(sha256sum[:])))
 }
 
 func hmacHelper(operands []*ast.Term, iter func(*ast.Term) error, h func() hash.Hash) error {
-	a1 := operands[0].Value
-	message, err := builtins.StringOperand(a1, 1)
+	message, err := builtins.StringOperandByteSlice(operands[0].Value, 1)
 	if err != nil {
 		return err
 	}
 
-	a2 := operands[1].Value
-	key, err := builtins.StringOperand(a2, 2)
+	key, err := builtins.StringOperandByteSlice(operands[1].Value, 2)
 	if err != nil {
 		return err
 	}
 
-	mac := hmac.New(h, []byte(key))
-	mac.Write([]byte(message))
+	mac := hmac.New(h, key)
+	mac.Write(message)
 	messageDigest := mac.Sum(nil)
 
 	return iter(ast.StringTerm(hex.EncodeToString(messageDigest)))
@@ -499,21 +495,17 @@ func builtinCryptoHmacSha512(_ BuiltinContext, operands []*ast.Term, iter func(*
 }
 
 func builtinCryptoHmacEqual(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term) error) error {
-	a1 := operands[0].Value
-	mac1, err := builtins.StringOperand(a1, 1)
+	mac1, err := builtins.StringOperandByteSlice(operands[0].Value, 1)
 	if err != nil {
 		return err
 	}
 
-	a2 := operands[1].Value
-	mac2, err := builtins.StringOperand(a2, 2)
+	mac2, err := builtins.StringOperandByteSlice(operands[1].Value, 2)
 	if err != nil {
 		return err
 	}
 
-	res := hmac.Equal([]byte(mac1), []byte(mac2))
-
-	return iter(ast.InternedTerm(res))
+	return iter(ast.InternedTerm(hmac.Equal(mac1, mac2)))
 }
 
 func init() {
@@ -668,7 +660,7 @@ func addCACertsFromFile(pool *x509.CertPool, filePath string) (*x509.CertPool, e
 		pool = x509.NewCertPool()
 	}
 
-	caCert, err := readCertFromFile(filePath)
+	caCert, err := os.ReadFile(filePath)
 	if err != nil {
 		return nil, err
 	}
@@ -703,17 +695,7 @@ func addCACertsFromEnv(pool *x509.CertPool, envName string) (*x509.CertPool, err
 		return nil, fmt.Errorf("could not add CA certificates from envvar %q: %w", envName, err)
 	}
 
-	return pool, err
-}
-
-// ReadCertFromFile reads a cert from file
-func readCertFromFile(localCertFile string) ([]byte, error) {
-	// Read in the cert file
-	certPEM, err := os.ReadFile(localCertFile)
-	if err != nil {
-		return nil, err
-	}
-	return certPEM, nil
+	return pool, nil
 }
 
 var beginPrefix = []byte("-----BEGIN ")
@@ -770,14 +752,4 @@ func getTLSx509KeyPairFromString(certPemBlock []byte, keyPemBlock []byte) (*tls.
 	}
 
 	return &cert, nil
-}
-
-// ReadKeyFromFile reads a key from file
-func readKeyFromFile(localKeyFile string) ([]byte, error) {
-	// Read in the cert file
-	key, err := os.ReadFile(localKeyFile)
-	if err != nil {
-		return nil, err
-	}
-	return key, nil
 }

--- a/v1/topdown/encoding_bench_test.go
+++ b/v1/topdown/encoding_bench_test.go
@@ -1,0 +1,49 @@
+package topdown
+
+import (
+	"testing"
+
+	"github.com/open-policy-agent/opa/v1/ast"
+)
+
+var (
+	unmarshalled = ast.ObjectTerm(
+		ast.Item(ast.InternedTerm("foo"), ast.ObjectTerm(
+			ast.Item(ast.InternedTerm("bar"), ast.ArrayTerm(ast.InternedTerm("baz"), ast.InternedTerm("qux"))),
+			ast.Item(ast.InternedTerm("num"), ast.InternedTerm(42)),
+		)),
+	)
+	marshalled = `foo:
+  bar:
+  - baz
+  - qux
+  num: 42
+`
+)
+
+// 7447 ns/op	   22984 B/op	     142 allocs/op
+// 7343 ns/op	   22872 B/op	     140 allocs/op
+func BenchmarkYAMLMarshal(b *testing.B) {
+	expect := ast.InternedTerm(marshalled)
+	operands := []*ast.Term{unmarshalled}
+	iter := eqIter(expect)
+
+	for b.Loop() {
+		if err := builtinYAMLMarshal(BuiltinContext{}, operands, iter); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// 5393 ns/op	   11066 B/op	     146 allocs/op
+// 5210 ns/op	   10980 B/op	     144 allocs/op
+func BenchmarkYAMLUnmarshal(b *testing.B) {
+	operands := []*ast.Term{ast.InternedTerm(marshalled)}
+	iter := eqIter(unmarshalled)
+
+	for b.Loop() {
+		if err := builtinYAMLUnmarshal(BuiltinContext{}, operands, iter); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/v1/topdown/http_test.go
+++ b/v1/topdown/http_test.go
@@ -2440,13 +2440,13 @@ func TestHTTPSClient(t *testing.T) {
 	}
 
 	// Set up Environment
-	clientCert, err := readCertFromFile(localClientCertFile)
+	clientCert, err := os.ReadFile(localClientCertFile)
 	if err != nil {
 		t.Fatal(err)
 	}
 	t.Setenv("CLIENT_CERT_ENV", string(clientCert))
 
-	clientKey, err := readKeyFromFile(localClientKeyFile)
+	clientKey, err := os.ReadFile(localClientKeyFile)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Many built-in functions immediatley convert an `ast.String` into `[]byte` which comes with some cost. This change introduces a `StringOperandByteSlice` function, which IMHO better helps communicate purpose, as well as it makes these operations a little cheaper. Nothing major here, but a small improvement.

Also:
- Cleaner `sync.Pool` helper module
- Add benchmarks for YAML marshalling/unmarshalling
