### PR TITLE
Use `sync.Pool` for eval func objects

### DIFF
--- a/v1/topdown/eval.go
+++ b/v1/topdown/eval.go
@@ -119,9 +119,17 @@ type eval struct {
 	defined                     bool
 }
 
-type evp struct {
-	pool sync.Pool
-}
+type (
+	evp struct {
+		pool sync.Pool
+	}
+	evfp struct {
+		pool sync.Pool
+	}
+	evbp struct {
+		pool sync.Pool
+	}
+)
 
 func (ep *evp) Put(e *eval) {
 	ep.pool.Put(e)
@@ -131,13 +139,51 @@ func (ep *evp) Get() *eval {
 	return ep.pool.Get().(*eval)
 }
 
-var evalPool = evp{
-	pool: sync.Pool{
-		New: func() any {
-			return &eval{}
-		},
-	},
+func (ep *evfp) Put(e *evalFunc) {
+	if e != nil {
+		e.e, e.terms, e.ir = nil, nil, nil
+		ep.pool.Put(e)
+	}
 }
+
+func (ep *evfp) Get() *evalFunc {
+	return ep.pool.Get().(*evalFunc)
+}
+
+func (ep *evbp) Put(e *evalBuiltin) {
+	if e != nil {
+		e.e, e.bi, e.bctx, e.f, e.terms = nil, nil, nil, nil, nil
+		ep.pool.Put(e)
+	}
+}
+
+func (ep *evbp) Get() *evalBuiltin {
+	return ep.pool.Get().(*evalBuiltin)
+}
+
+var (
+	evalPool = &evp{
+		pool: sync.Pool{
+			New: func() any {
+				return &eval{}
+			},
+		},
+	}
+	evalFuncPool = &evfp{
+		pool: sync.Pool{
+			New: func() any {
+				return &evalFunc{}
+			},
+		},
+	}
+	evalBuiltinPool = &evbp{
+		pool: sync.Pool{
+			New: func() any {
+				return &evalBuiltin{}
+			},
+		},
+	}
+)
 
 func (e *eval) Run(iter evalIterator) error {
 	if !e.traceEnabled {
@@ -401,9 +447,11 @@ func (e *eval) evalExpr(iter evalIterator) error {
 		}
 		return nil
 	}
-	expr := e.query[e.index]
 
-	e.traceEval(expr)
+	expr := e.query[e.index]
+	if e.traceEnabled {
+		e.traceEval(expr)
+	}
 
 	if len(expr.With) > 0 {
 		return e.evalWith(iter)
@@ -521,7 +569,7 @@ func (e *eval) evalStep(iter evalIterator) error {
 		// generateVar inlined here to avoid extra allocations in hot path
 		rterm := ast.VarTerm(e.fmtVarTerm())
 		err = e.unify(terms, rterm, func() error {
-			if e.saveSet.Contains(rterm, e.bindings) {
+			if e.saveSet != nil && e.saveSet.Contains(rterm, e.bindings) {
 				return e.saveExpr(ast.NewExpr(rterm), e.bindings, func() error {
 					return iter(e)
 				})
@@ -888,7 +936,6 @@ func (e *eval) evalNotPartialSupport(negationID uint64, expr *ast.Expr, unknowns
 }
 
 func (e *eval) evalCall(terms []*ast.Term, iter unifyIterator) error {
-
 	ref := terms[0].Value.(ast.Ref)
 
 	mock, mocked := e.functionMocks.Get(ref)
@@ -912,8 +959,8 @@ func (e *eval) evalCall(terms []*ast.Term, iter unifyIterator) error {
 
 	if ref[0].Equal(ast.DefaultRootDocument) {
 		if mocked {
-			f := e.compiler.TypeEnv.Get(ref).(*types.Function)
-			return e.evalCallValue(f.Arity(), terms, mock, iter)
+			arity := e.compiler.TypeEnv.GetByRef(ref).(*types.Function).Arity()
+			return e.evalCallValue(arity, terms, mock, iter)
 		}
 
 		var ir *ast.IndexResult
@@ -928,11 +975,13 @@ func (e *eval) evalCall(terms []*ast.Term, iter unifyIterator) error {
 			return err
 		}
 
-		eval := evalFunc{
-			e:     e,
-			terms: terms,
-			ir:    ir,
-		}
+		eval := evalFuncPool.Get()
+		defer evalFuncPool.Put(eval)
+
+		eval.e = e
+		eval.terms = terms
+		eval.ir = ir
+
 		return eval.eval(iter)
 	}
 
@@ -991,13 +1040,14 @@ func (e *eval) evalCall(terms []*ast.Term, iter unifyIterator) error {
 		}
 	}
 
-	eval := evalBuiltin{
-		e:     e,
-		bi:    bi,
-		bctx:  bctx,
-		f:     f,
-		terms: terms[1:],
-	}
+	eval := evalBuiltinPool.Get()
+	defer evalBuiltinPool.Put(eval)
+
+	eval.e = e
+	eval.bi = bi
+	eval.bctx = bctx
+	eval.f = f
+	eval.terms = terms[1:]
 
 	return eval.eval(iter)
 }
@@ -1054,7 +1104,9 @@ func (e *eval) biunify(a, b *ast.Term, b1, b2 *bindings, iter unifyIterator) err
 		case ast.Var, ast.Ref, *ast.ArrayComprehension:
 			return e.biunifyValues(a, b, b1, b2, iter)
 		case *ast.Array:
-			return e.biunifyArrays(vA, vB, b1, b2, iter)
+			if vA.Len() == vB.Len() {
+				return e.biunifyArraysRec(vA, vB, b1, b2, iter, 0)
+			}
 		}
 	case ast.Object:
 		switch vB := b.Value.(type) {
@@ -1067,13 +1119,6 @@ func (e *eval) biunify(a, b *ast.Term, b1, b2 *bindings, iter unifyIterator) err
 		return e.biunifyValues(a, b, b1, b2, iter)
 	}
 	return nil
-}
-
-func (e *eval) biunifyArrays(a, b *ast.Array, b1, b2 *bindings, iter unifyIterator) error {
-	if a.Len() != b.Len() {
-		return nil
-	}
-	return e.biunifyArraysRec(a, b, b1, b2, iter, 0)
 }
 
 func (e *eval) biunifyArraysRec(a, b *ast.Array, b1, b2 *bindings, iter unifyIterator, idx int) error {
@@ -2052,8 +2097,7 @@ type evalFunc struct {
 	terms []*ast.Term
 }
 
-func (e evalFunc) eval(iter unifyIterator) error {
-
+func (e *evalFunc) eval(iter unifyIterator) error {
 	if e.ir.Empty() {
 		return nil
 	}
@@ -2065,13 +2109,13 @@ func (e evalFunc) eval(iter unifyIterator) error {
 		argCount = len(e.ir.Default.Head.Args)
 	}
 
-	if len(e.ir.Else) > 0 && e.e.unknown(e.e.query[e.e.index], e.e.bindings) {
-		// Partial evaluation of ordered rules is not supported currently. Save the
-		// expression and continue. This could be revisited in the future.
-		return e.e.saveCall(argCount, e.terms, iter)
-	}
-
 	if e.e.partial() {
+		if len(e.ir.Else) > 0 && e.e.unknown(e.e.query[e.e.index], e.e.bindings) {
+			// Partial evaluation of ordered rules is not supported currently. Save the
+			// expression and continue. This could be revisited in the future.
+			return e.e.saveCall(argCount, e.terms, iter)
+		}
+
 		var mustGenerateSupport bool
 
 		if defRule := e.ir.Default; defRule != nil {
@@ -2109,7 +2153,7 @@ func (e evalFunc) eval(iter unifyIterator) error {
 	return e.evalValue(iter, argCount, e.ir.EarlyExit)
 }
 
-func (e evalFunc) evalValue(iter unifyIterator, argCount int, findOne bool) error {
+func (e *evalFunc) evalValue(iter unifyIterator, argCount int, findOne bool) error {
 	var cacheKey ast.Ref
 	if !e.e.partial() {
 		var hit bool
@@ -2194,7 +2238,7 @@ func (e evalFunc) evalValue(iter unifyIterator, argCount int, findOne bool) erro
 	})
 }
 
-func (e evalFunc) evalCache(argCount int, iter unifyIterator) (ast.Ref, bool, error) {
+func (e *evalFunc) evalCache(argCount int, iter unifyIterator) (ast.Ref, bool, error) {
 	plen := len(e.terms)
 	if plen == argCount+2 { // func name + output = 2
 		plen -= 1
@@ -2226,7 +2270,7 @@ func (e evalFunc) evalCache(argCount int, iter unifyIterator) (ast.Ref, bool, er
 	return cacheKey, false, nil
 }
 
-func (e evalFunc) evalOneRule(iter unifyIterator, rule *ast.Rule, args []*ast.Term, cacheKey ast.Ref, prev *ast.Term, findOne bool) (*ast.Term, error) {
+func (e *evalFunc) evalOneRule(iter unifyIterator, rule *ast.Rule, args []*ast.Term, cacheKey ast.Ref, prev *ast.Term, findOne bool) (*ast.Term, error) {
 	child := evalPool.Get()
 	defer evalPool.Put(child)
 
@@ -2288,7 +2332,7 @@ func (e evalFunc) evalOneRule(iter unifyIterator, rule *ast.Rule, args []*ast.Te
 	return result, err
 }
 
-func (e evalFunc) partialEvalSupport(declArgsLen int, iter unifyIterator) error {
+func (e *evalFunc) partialEvalSupport(declArgsLen int, iter unifyIterator) error {
 	path := e.e.namespaceRef(e.terms[0].Value.(ast.Ref))
 
 	if !e.e.saveSupport.Exists(path) {
@@ -2316,7 +2360,7 @@ func (e evalFunc) partialEvalSupport(declArgsLen int, iter unifyIterator) error 
 	return e.e.saveCall(declArgsLen, append([]*ast.Term{term}, e.terms[1:]...), iter)
 }
 
-func (e evalFunc) partialEvalSupportRule(rule *ast.Rule, path ast.Ref) error {
+func (e *evalFunc) partialEvalSupportRule(rule *ast.Rule, path ast.Ref) error {
 	child := evalPool.Get()
 	defer evalPool.Put(child)
 


### PR DESCRIPTION
These did not show up in escape analysis as they weren't pointers. I guess you could say they... escaped the analysis. But some pprof exploration revealed these were heavy allocation sources, and just like that, we have almost 2 million allocations less running the `regal lint bundle` benchmark. And a nice reduction in `B/op` too!

Also in this PR a simple change to the regexp built-in functions, where a `RWMutex` is now used to reduce blocking, which also showed up in the pprof data (although with marginal impact).

**Before**
```
756176916 ns/op	2614292780 B/op	53440051 allocs/op
```
**After**
```
737606792 ns/op	2469976856 B/op	51680605 allocs/op
```

