### PR TITLE
Concurrent Rego parsing in bundle loader

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -45,6 +45,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.38.0
 	go.uber.org/automaxprocs v1.6.0
 	golang.org/x/net v0.47.0
+	golang.org/x/sync v0.18.0
 	golang.org/x/text v0.31.0
 	golang.org/x/time v0.14.0
 	google.golang.org/grpc v1.76.0
@@ -118,7 +119,6 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.45.0 // indirect
 	golang.org/x/mod v0.29.0 // indirect
-	golang.org/x/sync v0.18.0 // indirect
 	golang.org/x/sys v0.38.0 // indirect
 	golang.org/x/tools v0.38.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250825161204-c5933d9347a5 // indirect

--- a/internal/ref/ref.go
+++ b/internal/ref/ref.go
@@ -7,16 +7,16 @@ package ref
 
 import (
 	"errors"
-	"strings"
 
 	"github.com/open-policy-agent/opa/v1/ast"
 	"github.com/open-policy-agent/opa/v1/storage"
+	"github.com/open-policy-agent/opa/v1/util"
 )
 
 // ParseDataPath returns a ref from the slash separated path s rooted at data.
 // All path segments are treated as identifier strings.
 func ParseDataPath(s string) (ast.Ref, error) {
-	path, ok := storage.ParsePath("/" + strings.TrimPrefix(s, "/"))
+	path, ok := storage.ParsePath(util.WithPrefix(s, "/"))
 	if !ok {
 		return nil, errors.New("invalid path")
 	}

--- a/internal/runtime/init/init.go
+++ b/internal/runtime/init/init.go
@@ -18,6 +18,7 @@ import (
 	"github.com/open-policy-agent/opa/v1/loader"
 	"github.com/open-policy-agent/opa/v1/metrics"
 	"github.com/open-policy-agent/opa/v1/storage"
+	"github.com/open-policy-agent/opa/v1/util"
 )
 
 // InsertAndCompileOptions contains the input for the operation.
@@ -246,13 +247,9 @@ func WalkPaths(paths []string, filter loader.Filter, asBundle bool) (*WalkPathsR
 				cleanedPath = fp
 			}
 
-			if !strings.HasPrefix(cleanedPath, "/") {
-				cleanedPath = "/" + cleanedPath
-			}
-
 			result.FileDescriptors = append(result.FileDescriptors, &Descriptor{
 				Root: path,
-				Path: cleanedPath,
+				Path: util.WithPrefix(cleanedPath, "/"),
 			})
 		}
 	}

--- a/internal/wasm/sdk/opa/loader/http/loader.go
+++ b/internal/wasm/sdk/opa/loader/http/loader.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"math/rand"
 	"net/http"
 	"sync"
@@ -229,7 +228,7 @@ func (l *Loader) get(ctx context.Context, tag string) (*bundle.Bundle, error) {
 		return nil, err
 	}
 
-	defer l.close(resp)
+	defer util.Close(resp)
 
 	switch resp.StatusCode {
 	case http.StatusOK:
@@ -254,11 +253,4 @@ func (l *Loader) get(ctx context.Context, tag string) (*bundle.Bundle, error) {
 	default:
 		return nil, fmt.Errorf("unknown HTTP status %v", resp.StatusCode)
 	}
-}
-
-// close closes the HTTP response gracefully, first draining it, to
-// avoid resource leaks.
-func (*Loader) close(resp *http.Response) {
-	_, _ = io.Copy(io.Discard, resp.Body) // Ignore errors.
-	_ = resp.Body.Close()
 }

--- a/v1/ast/parser.go
+++ b/v1/ast/parser.go
@@ -26,6 +26,7 @@ import (
 	"github.com/open-policy-agent/opa/v1/ast/internal/tokens"
 	astJSON "github.com/open-policy-agent/opa/v1/ast/json"
 	"github.com/open-policy-agent/opa/v1/ast/location"
+	"github.com/open-policy-agent/opa/v1/util"
 )
 
 // DefaultMaxParsingRecursionDepth is the default maximum recursion
@@ -3017,10 +3018,7 @@ func (p *Parser) futureImport(imp *Import, allowedFutureKeywords map[string]toke
 		return
 	}
 
-	kwds := make([]string, 0, len(allowedFutureKeywords))
-	for k := range allowedFutureKeywords {
-		kwds = append(kwds, k)
-	}
+	kwds := util.Keys(allowedFutureKeywords)
 
 	switch len(path) {
 	case 2: // all keywords imported, nothing to do
@@ -3070,10 +3068,7 @@ func (p *Parser) regoV1Import(imp *Import) {
 	}
 
 	// import all future keywords with the rego.v1 import
-	kwds := make([]string, 0, len(futureKeywordsV0))
-	for k := range futureKeywordsV0 {
-		kwds = append(kwds, k)
-	}
+	kwds := util.Keys(futureKeywordsV0)
 
 	p.s.s.SetRegoV1Compatible()
 	for _, kw := range kwds {

--- a/v1/bundle/bundle_ext_test.go
+++ b/v1/bundle/bundle_ext_test.go
@@ -5,7 +5,6 @@ package bundle_test
 
 import (
 	"context"
-	"maps"
 	"slices"
 	"testing"
 
@@ -17,6 +16,7 @@ import (
 	"github.com/open-policy-agent/opa/v1/storage"
 	"github.com/open-policy-agent/opa/v1/storage/disk"
 	"github.com/open-policy-agent/opa/v1/storage/inmem"
+	"github.com/open-policy-agent/opa/v1/util"
 	"github.com/open-policy-agent/opa/v1/util/test"
 )
 
@@ -28,7 +28,7 @@ type customBundleActivator struct {
 
 func (cba *customBundleActivator) Activate(opts *bundle.ActivateOpts) error {
 	cba.activator = &bundle.DefaultActivator{}
-	cba.BundleNames = slices.Collect(maps.Keys(opts.Bundles))
+	cba.BundleNames = util.Keys(opts.Bundles)
 	if cba.Files == nil {
 		cba.Files = make(map[string]map[string][]byte, len(cba.BundleNames))
 	}
@@ -166,7 +166,7 @@ func TestRegisterBundleActivatorWithStore(t *testing.T) {
 					t.Fatalf("wrong bundle names. expected: %v, got: %v", expNames, actNames)
 				}
 				for k, v := range bundles {
-					actFilenames := slices.Collect(maps.Keys(cba.Files[k]))
+					actFilenames := util.Keys(cba.Files[k])
 					expFilenames := make([]string, len(v.Raw))
 					for _, r := range v.Raw {
 						expFilenames = append(expFilenames, r.Path)

--- a/v1/bundle/file.go
+++ b/v1/bundle/file.go
@@ -352,12 +352,10 @@ func (t *tarballLoader) NextFile() (*Descriptor, error) {
 
 		for {
 			header, err := t.tr.Next()
-
-			if err == io.EOF {
-				break
-			}
-
 			if err != nil {
+				if err == io.EOF {
+					break
+				}
 				return nil, err
 			}
 
@@ -365,7 +363,6 @@ func (t *tarballLoader) NextFile() (*Descriptor, error) {
 			if header.Typeflag == tar.TypeReg {
 
 				if t.filter != nil {
-
 					if t.filter(filepath.ToSlash(header.Name), header.FileInfo(), getdepth(header.Name, false)) {
 						continue
 					}
@@ -504,9 +501,9 @@ func getdepth(path string, isDir bool) int {
 }
 
 func getFileStoragePath(path string) (storage.Path, error) {
-	fpath := strings.TrimLeft(normalizePath(filepath.Dir(path)), "/.")
+	fpath := strings.TrimLeft(filepath.ToSlash(filepath.Dir(path)), "/.")
 	if strings.HasSuffix(path, RegoExt) {
-		fpath = strings.Trim(normalizePath(path), "/")
+		fpath = strings.Trim(filepath.ToSlash(path), "/")
 	}
 
 	p, ok := storage.ParsePathEscaped("/" + fpath)

--- a/v1/bundle/store.go
+++ b/v1/bundle/store.go
@@ -571,12 +571,11 @@ func doDFS(obj map[string]json.RawMessage, path string, roots []string) error {
 	}
 
 	for key := range obj {
-
 		newPath := filepath.Join(strings.Trim(path, "/"), key)
 
 		// Note: filepath.Join can return paths with '\' separators, always use
 		// filepath.ToSlash to keep them normalized.
-		newPath = strings.TrimLeft(normalizePath(newPath), "/.")
+		newPath = strings.TrimLeft(filepath.ToSlash(newPath), "/.")
 
 		contains := false
 		prefix := false

--- a/v1/bundle/store_test.go
+++ b/v1/bundle/store_test.go
@@ -270,7 +270,7 @@ func TestBundleLazyModeNoPolicyOrData(t *testing.T) {
 		}
 	}
 
-	actual, err := mockStore.Read(ctx, txn, storage.MustParsePath("/"))
+	actual, err := mockStore.Read(ctx, txn, storage.RootPath)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -1883,7 +1883,7 @@ func TestBundleLifecycle_ModuleRegoVersions(t *testing.T) {
 					// Start read transaction
 					txn = storage.NewTransactionOrDie(ctx, mockStore)
 
-					actual, err := mockStore.Read(ctx, txn, storage.MustParsePath("/"))
+					actual, err := mockStore.Read(ctx, txn, storage.RootPath)
 					if err != nil {
 						t.Fatalf("unexpected error: %s", err)
 					}
@@ -1918,7 +1918,7 @@ func TestBundleLifecycle_ModuleRegoVersions(t *testing.T) {
 					// Start read transaction
 					txn = storage.NewTransactionOrDie(ctx, mockStore)
 
-					actual, err := mockStore.Read(ctx, txn, storage.MustParsePath("/"))
+					actual, err := mockStore.Read(ctx, txn, storage.RootPath)
 					if err != nil {
 						t.Fatalf("unexpected error: %s", err)
 					}
@@ -2026,7 +2026,7 @@ func TestBundleLazyModeLifecycleRaw(t *testing.T) {
 		}
 	}
 
-	actual, err := mockStore.Read(ctx, txn, storage.MustParsePath("/"))
+	actual, err := mockStore.Read(ctx, txn, storage.RootPath)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -2120,7 +2120,7 @@ func TestBundleLazyModeLifecycleRaw(t *testing.T) {
 		t.Fatalf("expected 0 bundles in store, found %d", len(names))
 	}
 
-	actual, err = mockStore.Read(ctx, txn, storage.MustParsePath("/"))
+	actual, err = mockStore.Read(ctx, txn, storage.RootPath)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -2285,7 +2285,7 @@ func TestBundleLazyModeLifecycle(t *testing.T) {
 		}
 	}
 
-	actual, err := mockStore.Read(ctx, txn, storage.MustParsePath("/"))
+	actual, err := mockStore.Read(ctx, txn, storage.RootPath)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -2365,7 +2365,7 @@ func TestBundleLazyModeLifecycle(t *testing.T) {
 		t.Fatalf("expected 0 bundles in store, found %d", len(names))
 	}
 
-	actual, err = mockStore.Read(ctx, txn, storage.MustParsePath("/"))
+	actual, err = mockStore.Read(ctx, txn, storage.RootPath)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -2450,7 +2450,7 @@ func TestBundleLazyModeLifecycleRawNoBundleRoots(t *testing.T) {
 		}
 	}
 
-	actual, err := mockStore.Read(ctx, txn, storage.MustParsePath("/"))
+	actual, err := mockStore.Read(ctx, txn, storage.RootPath)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -2530,7 +2530,7 @@ func TestBundleLazyModeLifecycleRawNoBundleRoots(t *testing.T) {
 
 	txn = storage.NewTransactionOrDie(ctx, mockStore)
 
-	actual, err = mockStore.Read(ctx, txn, storage.MustParsePath("/"))
+	actual, err = mockStore.Read(ctx, txn, storage.RootPath)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -2642,7 +2642,7 @@ func TestBundleLazyModeLifecycleRawNoBundleRootsDiskStorage(t *testing.T) {
 			}
 		}
 
-		actual, err := store.Read(ctx, txn, storage.MustParsePath("/"))
+		actual, err := store.Read(ctx, txn, storage.RootPath)
 		if err != nil {
 			t.Fatalf("unexpected error: %s", err)
 		}
@@ -2722,7 +2722,7 @@ func TestBundleLazyModeLifecycleRawNoBundleRootsDiskStorage(t *testing.T) {
 
 		txn = storage.NewTransactionOrDie(ctx, store)
 
-		actual, err = store.Read(ctx, txn, storage.MustParsePath("/"))
+		actual, err = store.Read(ctx, txn, storage.RootPath)
 		if err != nil {
 			t.Fatalf("unexpected error: %s", err)
 		}
@@ -2820,7 +2820,7 @@ func TestBundleLazyModeLifecycleNoBundleRoots(t *testing.T) {
 	// Ensure the patches were applied
 	txn = storage.NewTransactionOrDie(ctx, mockStore)
 
-	actual, err := mockStore.Read(ctx, txn, storage.MustParsePath("/"))
+	actual, err := mockStore.Read(ctx, txn, storage.RootPath)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -2903,7 +2903,7 @@ func TestBundleLazyModeLifecycleNoBundleRoots(t *testing.T) {
 	// Ensure the patches were applied
 	txn = storage.NewTransactionOrDie(ctx, mockStore)
 
-	actual, err = mockStore.Read(ctx, txn, storage.MustParsePath("/"))
+	actual, err = mockStore.Read(ctx, txn, storage.RootPath)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -3030,7 +3030,7 @@ func TestBundleLazyModeLifecycleNoBundleRootsDiskStorage(t *testing.T) {
 			}
 		}
 
-		actual, err := store.Read(ctx, txn, storage.MustParsePath("/"))
+		actual, err := store.Read(ctx, txn, storage.RootPath)
 		if err != nil {
 			t.Fatalf("unexpected error: %s", err)
 		}
@@ -3113,7 +3113,7 @@ func TestBundleLazyModeLifecycleNoBundleRootsDiskStorage(t *testing.T) {
 		// Ensure the snapshot bundle was activated
 		txn = storage.NewTransactionOrDie(ctx, store)
 
-		actual, err = store.Read(ctx, txn, storage.MustParsePath("/"))
+		actual, err = store.Read(ctx, txn, storage.RootPath)
 		if err != nil {
 			t.Fatalf("unexpected error: %s", err)
 		}
@@ -3253,7 +3253,7 @@ func TestBundleLazyModeLifecycleMixBundleTypeActivationDiskStorage(t *testing.T)
 		// Ensure the patches were applied
 		txn = storage.NewTransactionOrDie(ctx, store)
 
-		actual, err := store.Read(ctx, txn, storage.MustParsePath("/"))
+		actual, err := store.Read(ctx, txn, storage.RootPath)
 		if err != nil {
 			t.Fatalf("unexpected error: %s", err)
 		}
@@ -3395,7 +3395,7 @@ func TestBundleLazyModeLifecycleOldBundleEraseDiskStorage(t *testing.T) {
 			}
 		}
 
-		actual, err := store.Read(ctx, txn, storage.MustParsePath("/"))
+		actual, err := store.Read(ctx, txn, storage.RootPath)
 		if err != nil {
 			t.Fatalf("unexpected error: %s", err)
 		}
@@ -3478,7 +3478,7 @@ func TestBundleLazyModeLifecycleOldBundleEraseDiskStorage(t *testing.T) {
 		// Ensure the snapshot bundle was activated
 		txn = storage.NewTransactionOrDie(ctx, store)
 
-		actual, err = store.Read(ctx, txn, storage.MustParsePath("/"))
+		actual, err = store.Read(ctx, txn, storage.RootPath)
 		if err != nil {
 			t.Fatalf("unexpected error: %s", err)
 		}
@@ -3607,7 +3607,7 @@ func TestBundleLazyModeLifecycleRestoreBackupDB(t *testing.T) {
 			}
 		}
 
-		actual, err := store.Read(ctx, txn, storage.MustParsePath("/"))
+		actual, err := store.Read(ctx, txn, storage.RootPath)
 		if err != nil {
 			t.Fatalf("unexpected error: %s", err)
 		}
@@ -3686,7 +3686,7 @@ func TestBundleLazyModeLifecycleRestoreBackupDB(t *testing.T) {
 
 		txn = storage.NewTransactionOrDie(ctx, store)
 
-		actual, err = store.Read(ctx, txn, storage.MustParsePath("/"))
+		actual, err = store.Read(ctx, txn, storage.RootPath)
 		if err != nil {
 			t.Fatalf("unexpected error: %s", err)
 		}
@@ -3953,7 +3953,7 @@ func TestDeltaBundleLazyModeLifecycleDiskStorage(t *testing.T) {
 		// Ensure the patches were applied
 		txn = storage.NewTransactionOrDie(ctx, store)
 
-		actual, err := store.Read(ctx, txn, storage.MustParsePath("/"))
+		actual, err := store.Read(ctx, txn, storage.RootPath)
 		if err != nil {
 			t.Fatalf("unexpected error: %s", err)
 		}
@@ -4112,7 +4112,7 @@ func TestBundleLazyModeLifecycleOverlappingBundleRoots(t *testing.T) {
 	// Ensure the patches were applied
 	txn = storage.NewTransactionOrDie(ctx, mockStore)
 
-	actual, err := mockStore.Read(ctx, txn, storage.MustParsePath("/"))
+	actual, err := mockStore.Read(ctx, txn, storage.RootPath)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -4270,7 +4270,7 @@ func TestBundleLazyModeLifecycleOverlappingBundleRootsDiskStorage(t *testing.T) 
 		// Ensure the patches were applied
 		txn = storage.NewTransactionOrDie(ctx, store)
 
-		actual, err := store.Read(ctx, txn, storage.MustParsePath("/"))
+		actual, err := store.Read(ctx, txn, storage.RootPath)
 		if err != nil {
 			t.Fatalf("unexpected error: %s", err)
 		}
@@ -4396,7 +4396,7 @@ func TestBundleLazyModeLifecycleRawOverlappingBundleRoots(t *testing.T) {
 	// Ensure the patches were applied
 	txn = storage.NewTransactionOrDie(ctx, mockStore)
 
-	actual, err := mockStore.Read(ctx, txn, storage.MustParsePath("/"))
+	actual, err := mockStore.Read(ctx, txn, storage.RootPath)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -4536,7 +4536,7 @@ func TestBundleLazyModeLifecycleRawOverlappingBundleRootsDiskStorage(t *testing.
 		// Ensure the patches were applied
 		txn = storage.NewTransactionOrDie(ctx, store)
 
-		actual, err := store.Read(ctx, txn, storage.MustParsePath("/"))
+		actual, err := store.Read(ctx, txn, storage.RootPath)
 		if err != nil {
 			t.Fatalf("unexpected error: %s", err)
 		}
@@ -4816,7 +4816,7 @@ func TestDeltaBundleLazyModeLifecycle(t *testing.T) {
 	// Ensure the patches were applied
 	txn = storage.NewTransactionOrDie(ctx, mockStore)
 
-	actual, err := mockStore.Read(ctx, txn, storage.MustParsePath("/"))
+	actual, err := mockStore.Read(ctx, txn, storage.RootPath)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -5106,7 +5106,7 @@ func TestDeltaBundleLazyModeWithDefaultRules(t *testing.T) {
 	// Ensure the patches were applied
 	txn = storage.NewTransactionOrDie(ctx, mockStore)
 
-	actual, err := mockStore.Read(ctx, txn, storage.MustParsePath("/"))
+	actual, err := mockStore.Read(ctx, txn, storage.RootPath)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -5268,7 +5268,7 @@ func TestBundleLifecycle(t *testing.T) {
 				}
 			}
 
-			actual, err := mockStore.Read(ctx, txn, storage.MustParsePath("/"))
+			actual, err := mockStore.Read(ctx, txn, storage.RootPath)
 			if err != nil {
 				t.Fatalf("unexpected error: %s", err)
 			}
@@ -5343,7 +5343,7 @@ func TestBundleLifecycle(t *testing.T) {
 				t.Fatalf("expected 0 bundles in store, found %d", len(names))
 			}
 
-			actual, err = mockStore.Read(ctx, txn, storage.MustParsePath("/"))
+			actual, err = mockStore.Read(ctx, txn, storage.RootPath)
 			if err != nil {
 				t.Fatalf("unexpected error: %s", err)
 			}
@@ -5575,7 +5575,7 @@ func TestDeltaBundleLifecycle(t *testing.T) {
 			// Ensure the patches were applied
 			txn = storage.NewTransactionOrDie(ctx, mockStore)
 
-			actual, err := mockStore.Read(ctx, txn, storage.MustParsePath("/"))
+			actual, err := mockStore.Read(ctx, txn, storage.RootPath)
 			if err != nil {
 				t.Fatalf("unexpected error: %s", err)
 			}
@@ -5720,7 +5720,7 @@ func TestDeltaBundleActivate(t *testing.T) {
 			// Ensure the patches were applied
 			txn = storage.NewTransactionOrDie(ctx, mockStore)
 
-			actual, err := mockStore.Read(ctx, txn, storage.MustParsePath("/"))
+			actual, err := mockStore.Read(ctx, txn, storage.RootPath)
 			if err != nil {
 				t.Fatalf("unexpected error: %s", err)
 			}
@@ -5974,7 +5974,7 @@ func TestEraseData(t *testing.T) {
 					mockStore.AssertValid(t)
 
 					txn = storage.NewTransactionOrDie(ctx, mockStore)
-					actual, err := mockStore.Read(ctx, txn, storage.MustParsePath("/"))
+					actual, err := mockStore.Read(ctx, txn, storage.RootPath)
 					if err != nil {
 						t.Fatalf("unexpected error: %s", err)
 					}
@@ -6224,7 +6224,7 @@ func TestWriteData(t *testing.T) {
 					mockStore.AssertValid(t)
 
 					txn = storage.NewTransactionOrDie(ctx, mockStore)
-					actual, err := mockStore.Read(ctx, txn, storage.MustParsePath("/"))
+					actual, err := mockStore.Read(ctx, txn, storage.RootPath)
 					if err != nil {
 						t.Fatalf("unexpected error: %s", err)
 					}

--- a/v1/compile/compile.go
+++ b/v1/compile/compile.go
@@ -32,6 +32,7 @@ import (
 	"github.com/open-policy-agent/opa/v1/rego"
 	"github.com/open-policy-agent/opa/v1/storage"
 	"github.com/open-policy-agent/opa/v1/storage/inmem"
+	"github.com/open-policy-agent/opa/v1/util"
 )
 
 const (
@@ -749,7 +750,7 @@ func (c *Compiler) compileWasm(ctx context.Context) error {
 		}
 
 		c.bundle.Manifest.WasmResolvers = append(c.bundle.Manifest.WasmResolvers, bundle.WasmResolver{
-			Module:      "/" + strings.TrimLeft(modulePath, "/"),
+			Module:      util.WithPrefix(modulePath, "/"),
 			Entrypoint:  entrypointPath,
 			Annotations: annotations,
 		})

--- a/v1/storage/disk/disk.go
+++ b/v1/storage/disk/disk.go
@@ -279,12 +279,7 @@ func (db *Store) Truncate(ctx context.Context, txn storage.Transaction, params s
 
 	// For backwards compatibility, check if `RootOverwrite` was configured.
 	if params.RootOverwrite || overwriteRoot(params.BasePaths) {
-		newPath, ok := storage.ParsePathEscaped("/")
-		if !ok {
-			return fmt.Errorf("storage path invalid: %v", newPath)
-		}
-
-		sTxn, err := db.doTruncateData(ctx, underlyingTxn, db.db, params, newPath, map[string]any{})
+		sTxn, err := db.doTruncateData(ctx, underlyingTxn, db.db, params, storage.RootPath, map[string]any{})
 		if err != nil {
 			return wrapError(err)
 		}
@@ -835,7 +830,7 @@ func (db *Store) diagnostics(ctx context.Context, partitions pathSet, logger log
 	}
 	if len(partitions) == 1 { // '/system/*' is always present
 		logger.Warn("no partitions configured")
-		if err := db.logPrefixStatistics(ctx, storage.MustParsePath("/"), logger); err != nil {
+		if err := db.logPrefixStatistics(ctx, storage.RootPath, logger); err != nil {
 			return err
 		}
 	}

--- a/v1/storage/disk/disk_test.go
+++ b/v1/storage/disk/disk_test.go
@@ -236,7 +236,7 @@ func runTruncateTest(t *testing.T, dir string) {
 
 	txn = storage.NewTransactionOrDie(ctx, s)
 
-	actual, err := s.Read(ctx, txn, storage.MustParsePath("/"))
+	actual, err := s.Read(ctx, txn, storage.RootPath)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1524,7 +1524,7 @@ func TestDataPartitioningWriteInvalidPatchError(t *testing.T) {
 					t.Fatal("expected invalid patch error but got:", err)
 				}
 
-				err = storage.WriteOne(ctx, s, storage.AddOp, storage.MustParsePath("/"), util.MustUnmarshalJSON([]byte(`{"foo": [1,2,3]}`)))
+				err = storage.WriteOne(ctx, s, storage.AddOp, storage.RootPath, util.MustUnmarshalJSON([]byte(`{"foo": [1,2,3]}`)))
 				if err == nil {
 					t.Fatal("expected error")
 				} else if sErr, ok := err.(*storage.Error); !ok {
@@ -1533,7 +1533,7 @@ func TestDataPartitioningWriteInvalidPatchError(t *testing.T) {
 					t.Fatal("expected invalid patch error but got:", err)
 				}
 
-				err = storage.WriteOne(ctx, s, storage.AddOp, storage.MustParsePath("/"), util.MustUnmarshalJSON([]byte(`[1,2,3]`)))
+				err = storage.WriteOne(ctx, s, storage.AddOp, storage.RootPath, util.MustUnmarshalJSON([]byte(`[1,2,3]`)))
 				if err == nil {
 					t.Fatal("expected error")
 				} else if sErr, ok := err.(*storage.Error); !ok {

--- a/v1/storage/disk/example_test.go
+++ b/v1/storage/disk/example_test.go
@@ -44,7 +44,7 @@ func Example_store() {
 	// Insert data into the store. The `storage.WriteOne` function automatically
 	// opens a write transaction, applies the operation, and commits the
 	// transaction in one-shot.
-	err = storage.WriteOne(ctx, store, storage.AddOp, storage.MustParsePath("/"), util.MustUnmarshalJSON([]byte(`{
+	err = storage.WriteOne(ctx, store, storage.AddOp, storage.RootPath, util.MustUnmarshalJSON([]byte(`{
 		"authz": {
 			"tenants": {
 				"acmecorp.openpolicyagent.org": {

--- a/v1/storage/disk/txn_test.go
+++ b/v1/storage/disk/txn_test.go
@@ -49,7 +49,7 @@ func TestSetTxnIsTooBigToFitIntoOneRequestWhenUseDiskStoreReturnsError(t *testin
 		nbKeys := 140_000 // 135_000 is ok, but 140_000 not
 		jsonFixture := fixture(nbKeys)
 		err = storage.Txn(ctx, s, storage.WriteParams, func(txn storage.Transaction) error {
-			err := s.Write(ctx, txn, storage.AddOp, storage.MustParsePath("/"), jsonFixture)
+			err := s.Write(ctx, txn, storage.AddOp, storage.RootPath, jsonFixture)
 			if !errors.Is(err, badger.ErrTxnTooBig) {
 				t.Errorf("expected %v, got %v", badger.ErrTxnTooBig, err)
 			}

--- a/v1/storage/inmem/inmem_test.go
+++ b/v1/storage/inmem/inmem_test.go
@@ -569,7 +569,7 @@ func TestTruncateNoExistingPath(t *testing.T) {
 
 			txn = storage.NewTransactionOrDie(ctx, store)
 
-			actual, err := store.Read(ctx, txn, storage.MustParsePath("/"))
+			actual, err := store.Read(ctx, txn, storage.RootPath)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -641,7 +641,7 @@ func TestTruncate(t *testing.T) {
 
 	txn = storage.NewTransactionOrDie(ctx, store)
 
-	actual, err := store.Read(ctx, txn, storage.MustParsePath("/"))
+	actual, err := store.Read(ctx, txn, storage.RootPath)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -739,7 +739,7 @@ func TestTruncateAst(t *testing.T) {
 
 	txn = storage.NewTransactionOrDie(ctx, store)
 
-	actual, err := store.Read(ctx, txn, storage.MustParsePath("/"))
+	actual, err := store.Read(ctx, txn, storage.RootPath)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/v1/topdown/topdown_test.go
+++ b/v1/topdown/topdown_test.go
@@ -2139,8 +2139,7 @@ func assertTopDownWithPathAndContext(ctx context.Context, t *testing.T, compiler
 	}
 
 	if os.Getenv("OPA_DUMP_TEST") != "" {
-
-		data, err := store.Read(ctx, txn, storage.MustParsePath("/"))
+		data, err := store.Read(ctx, txn, storage.RootPath)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/v1/util/strings.go
+++ b/v1/util/strings.go
@@ -1,0 +1,13 @@
+package util
+
+import "strings"
+
+// WithPrefix ensures that the string s starts with the given prefix.
+// If s already starts with prefix, it is returned unchanged.
+func WithPrefix(s, prefix string) string {
+	if strings.HasPrefix(s, prefix) {
+		return s
+	}
+
+	return prefix + s
+}


### PR DESCRIPTION
Parsing is generally fast, so this mainly improves performance of creating big bundles with many Rego files in them. For Regal's embedded bundle, loading it from memory would previously take 16 ms on my laptop, and now it takes 9 ms. There are other things in this process that could be concurrent too, like JSON unmarshalling of multiple data files. But starting with parsing modules.

This PR adds `errgroup` as a direct dependency (previously indirect) as it is a nicer way to work with wait groups, and one that can be useful elsewhere in the codebase (like in the compiler).

Also, and as usual, went off on a bit of a tangent refactoring code related to the bundle build process, and made sure to use some common helpers in code where available.
