### PR TITLE
Tidy up and unify sync pool handling

### DIFF
--- a/v1/ast/syncpools.go
+++ b/v1/ast/syncpools.go
@@ -4,12 +4,15 @@ import (
 	"bytes"
 	"strings"
 	"sync"
+
+	"github.com/open-policy-agent/opa/v1/util"
 )
 
 var (
-	TermPtrPool     = NewSyncPool[Term]()
-	BytesReaderPool = NewSyncPool[bytes.Reader]()
-	IndexResultPool = NewSyncPool[IndexResult]()
+	TermPtrPool     = util.NewSyncPool[Term]()
+	BytesReaderPool = util.NewSyncPool[bytes.Reader]()
+	IndexResultPool = util.NewSyncPool[IndexResult]()
+	bbPool          = util.NewSyncPool[bytes.Buffer]()
 	// Needs custom pool because of custom Put logic.
 	sbPool = &stringBuilderPool{
 		pool: sync.Pool{
@@ -29,36 +32,9 @@ var (
 )
 
 type (
-	syncPool[T any] struct {
-		pool sync.Pool
-	}
-	stringBuilderPool struct {
-		pool sync.Pool
-	}
-	vvPool struct {
-		pool sync.Pool
-	}
+	stringBuilderPool struct{ pool sync.Pool }
+	vvPool            struct{ pool sync.Pool }
 )
-
-func NewSyncPool[T any]() *syncPool[T] {
-	return &syncPool[T]{
-		pool: sync.Pool{
-			New: func() any {
-				return new(T)
-			},
-		},
-	}
-}
-
-func (p *syncPool[T]) Get() *T {
-	return p.pool.Get().(*T)
-}
-
-func (p *syncPool[T]) Put(x *T) {
-	if x != nil {
-		p.pool.Put(x)
-	}
-}
 
 func (p *stringBuilderPool) Get() *strings.Builder {
 	return p.pool.Get().(*strings.Builder)

--- a/v1/ast/term.go
+++ b/v1/ast/term.go
@@ -1153,12 +1153,6 @@ func IsVarCompatibleString(s string) bool {
 	return varRegexp.MatchString(s)
 }
 
-var bbPool = &sync.Pool{
-	New: func() any {
-		return new(bytes.Buffer)
-	},
-}
-
 func (ref Ref) String() string {
 	// Note(anderseknert):
 	// Options tried in the order of cheapness, where after some effort,
@@ -1180,7 +1174,7 @@ func (ref Ref) String() string {
 
 	_var := ref[0].Value.String()
 
-	bb := bbPool.Get().(*bytes.Buffer)
+	bb := bbPool.Get()
 	bb.Reset()
 
 	defer bbPool.Put(bb)

--- a/v1/util/performance.go
+++ b/v1/util/performance.go
@@ -7,6 +7,34 @@ import (
 	"unsafe"
 )
 
+// SyncPool is a generic sync.Pool for type T, providing some convenience
+// over sync.Pool directly: [SyncPool.Put] ensures that nil values are not
+// put into the pool, and [SyncPool.Get] returns a pointer to T without having
+// to do a type assertion at the call site.
+type SyncPool[T any] struct {
+	pool sync.Pool
+}
+
+func NewSyncPool[T any]() *SyncPool[T] {
+	return &SyncPool[T]{
+		pool: sync.Pool{
+			New: func() any {
+				return new(T)
+			},
+		},
+	}
+}
+
+func (p *SyncPool[T]) Get() *T {
+	return p.pool.Get().(*T)
+}
+
+func (p *SyncPool[T]) Put(x *T) {
+	if x != nil {
+		p.pool.Put(x)
+	}
+}
+
 // NewPtrSlice returns a slice of pointers to T with length n,
 // with only 2 allocations performed no matter the size of n.
 // See:
@@ -133,5 +161,7 @@ func (sp *SlicePool[T]) Get(length int) *[]T {
 
 // Put returns a pointer to a slice of type T to the pool.
 func (sp *SlicePool[T]) Put(s *[]T) {
-	sp.pool.Put(s)
+	if s != nil {
+		sp.pool.Put(s)
+	}
 }

--- a/v1/util/read_gzip_body.go
+++ b/v1/util/read_gzip_body.go
@@ -8,17 +8,11 @@ import (
 	"io"
 	"net/http"
 	"strings"
-	"sync"
 
 	"github.com/open-policy-agent/opa/v1/util/decoding"
 )
 
-var gzipReaderPool = sync.Pool{
-	New: func() any {
-		reader := new(gzip.Reader)
-		return reader
-	},
-}
+var gzipReaderPool = NewSyncPool[gzip.Reader]()
 
 // Note(philipc): Originally taken from server/server.go
 // The DecodingLimitHandler handles validating that the gzip payload is within the
@@ -49,7 +43,7 @@ func ReadMaybeCompressedBody(r *http.Request) ([]byte, error) {
 			return nil, errors.New("gzip payload too large")
 		}
 
-		gzReader := gzipReaderPool.Get().(*gzip.Reader)
+		gzReader := gzipReaderPool.Get()
 		defer func() {
 			gzReader.Close()
 			gzipReaderPool.Put(gzReader)


### PR DESCRIPTION
As @srenatus pointed out in a previous review, these were a little messy in some places. This moves the generic SyncPool type to the util package for reuse across the codebase. Also some various related improvements.