### PR TITLE
deps: bump wasmtime-go v37 -> v39

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24.6
 
 require (
 	github.com/agnivade/levenshtein v1.2.1
-	github.com/bytecodealliance/wasmtime-go/v37 v37.0.0
+	github.com/bytecodealliance/wasmtime-go/v39 v39.0.1
 	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/containerd/containerd/v2 v2.2.0
 	github.com/containerd/errdefs v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0 h1:jfIu9sQUG6Ig
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0/go.mod h1:t2tdKJDJF9BV14lnkjHmOQgcvEKgtqs5a1N3LNdJhGE=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/bytecodealliance/wasmtime-go/v37 v37.0.0 h1:DPjdn2V3JhXHMoZ2ymRqGK+y1bDyr9wgpyYCvhjMky8=
-github.com/bytecodealliance/wasmtime-go/v37 v37.0.0/go.mod h1:Pf1l2JCTUFMnOqDIwkjzx1qfVJ09xbaXETKgRVE4jZ0=
+github.com/bytecodealliance/wasmtime-go/v39 v39.0.1 h1:RibaT47yiyCRxMOj/l2cvL8cWiWBSqDXHyqsa9sGcCE=
+github.com/bytecodealliance/wasmtime-go/v39 v39.0.1/go.mod h1:miR4NYIEBXeDNamZIzpskhJ0z/p8al+lwMWylQ/ZJb4=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/internal/wasm/sdk/internal/wasm/bindings.go
+++ b/internal/wasm/sdk/internal/wasm/bindings.go
@@ -16,7 +16,7 @@ import (
 	"strconv"
 	"time"
 
-	wasmtime "github.com/bytecodealliance/wasmtime-go/v37"
+	wasmtime "github.com/bytecodealliance/wasmtime-go/v39"
 
 	"github.com/open-policy-agent/opa/v1/ast"
 	"github.com/open-policy-agent/opa/v1/metrics"

--- a/internal/wasm/sdk/internal/wasm/pool.go
+++ b/internal/wasm/sdk/internal/wasm/pool.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"sync"
 
-	wasmtime "github.com/bytecodealliance/wasmtime-go/v37"
+	wasmtime "github.com/bytecodealliance/wasmtime-go/v39"
 
 	"github.com/open-policy-agent/opa/internal/wasm/sdk/opa/errors"
 	"github.com/open-policy-agent/opa/internal/wasm/util"

--- a/internal/wasm/sdk/internal/wasm/vm.go
+++ b/internal/wasm/sdk/internal/wasm/vm.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 	"time"
 
-	wasmtime "github.com/bytecodealliance/wasmtime-go/v37"
+	wasmtime "github.com/bytecodealliance/wasmtime-go/v39"
 
 	sdk_errors "github.com/open-policy-agent/opa/internal/wasm/sdk/opa/errors"
 	"github.com/open-policy-agent/opa/internal/wasm/util"
@@ -79,12 +79,15 @@ func newVM(opts vmOpts, engine *wasmtime.Engine) (*VM, error) {
 	v := &VM{engine: engine}
 	store := wasmtime.NewStore(engine)
 	store.SetEpochDeadline(1)
-	memorytype := wasmtime.NewMemoryType(
+	memorytype, err := wasmtime.NewMemoryType(
 		opts.memoryMin,
 		true,
 		opts.memoryMax,
 		false,
 	)
+	if err != nil {
+		return nil, err
+	}
 	memory, err := wasmtime.NewMemory(store, memorytype)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
38.0.x went a bit up and down, I believe this might have to do with switching to immutable releases? 🤔 

Anyways, lots of things in v39:
* https://github.com/bytecodealliance/wasmtime/releases/tag/v39.0.0