### PR TITLE
perf: 10% faster compilation

### DIFF
--- a/v1/ast/compile.go
+++ b/v1/ast/compile.go
@@ -959,17 +959,22 @@ func (c *Compiler) buildRuleIndices() {
 }
 
 func (c *Compiler) buildComprehensionIndices() {
+	vis := varVisitorPool.Get()
+
 	for _, name := range c.sorted {
 		WalkRules(c.Modules[name], func(r *Rule) bool {
-			candidates := ReservedVars.Copy()
+			vis = vis.Clear()
+			vis.vars.Update(ReservedVars)
 			if len(r.Head.Args) > 0 {
-				candidates.Update(r.Head.Args.Vars())
+				vis.WalkArgs(r.Head.Args)
 			}
-			n := buildComprehensionIndices(c.debug, c.GetArity, candidates, c.RewrittenVars, r.Body, c.comprehensionIndices)
+			n := buildComprehensionIndices(c.debug, c.GetArity, vis.vars, c.RewrittenVars, r.Body, c.comprehensionIndices)
 			c.counterAdd(compileStageComprehensionIndexBuild, n)
 			return false
 		})
 	}
+
+	varVisitorPool.Put(vis)
 }
 
 var futureKeywordsPrefix = Ref{FutureRootDocument, InternedTerm("keywords")}
@@ -988,16 +993,15 @@ func (c *Compiler) buildRequiredCapabilities() {
 
 	for _, name := range c.sorted {
 		for _, imp := range c.imports[name] {
-			mod := c.Modules[name]
 			path := imp.Path.Value.(Ref)
 			switch {
 			case path.Equal(RegoV1CompatibleRef):
-				if !c.moduleIsRegoV1(mod) {
+				if !c.moduleIsRegoV1(c.Modules[name]) {
 					features[FeatureRegoV1Import] = struct{}{}
 				}
 			case path.HasPrefix(futureKeywordsPrefix):
 				if len(path) == 2 {
-					if c.moduleIsRegoV1(mod) {
+					if c.moduleIsRegoV1(c.Modules[name]) {
 						for kw := range futureKeywords {
 							keywords[kw] = struct{}{}
 						}
@@ -1008,7 +1012,7 @@ func (c *Compiler) buildRequiredCapabilities() {
 					}
 				} else {
 					kw := string(path[2].Value.(String))
-					if c.moduleIsRegoV1(mod) {
+					if c.moduleIsRegoV1(c.Modules[name]) {
 						for allowedKw := range futureKeywords {
 							if kw == allowedKw {
 								keywords[kw] = struct{}{}
@@ -1285,17 +1289,23 @@ func arityMismatchError(env *TypeEnv, f Ref, expr *Expr, exp, act int) *Error {
 // positions of built-in expressions will be bound when evaluating the rule from left
 // to right, re-ordering as necessary.
 func (c *Compiler) checkSafetyRuleBodies() {
+	vis := varVisitorPool.Get()
+
 	for _, name := range c.sorted {
 		m := c.Modules[name]
 		WalkRules(m, func(r *Rule) bool {
-			safe := ReservedVars.Copy()
+			vis = vis.Clear()
+			// vis.vars == safe
+			vis.vars.Update(ReservedVars)
 			if len(r.Head.Args) > 0 {
-				safe.Update(r.Head.Args.Vars())
+				vis.WalkArgs(r.Head.Args)
 			}
-			r.Body = c.checkBodySafety(safe, r.Body)
+			r.Body = c.checkBodySafety(vis.vars, r.Body)
 			return false
 		})
 	}
+
+	varVisitorPool.Put(vis)
 }
 
 func (c *Compiler) checkBodySafety(safe VarSet, b Body) Body {
@@ -1320,16 +1330,22 @@ var SafetyCheckVisitorParams = VarVisitorParams{
 // checkSafetyRuleHeads ensures that variables appearing in the head of a
 // rule also appear in the body.
 func (c *Compiler) checkSafetyRuleHeads() {
+	vis := varVisitorPool.Get()
+
 	for _, name := range c.sorted {
 		WalkRules(c.Modules[name], func(r *Rule) bool {
-			safe := r.Body.Vars(SafetyCheckVisitorParams)
-			if len(r.Head.Args) > 0 {
-				safe.Update(r.Head.Args.Vars())
-			}
 			if headMayHaveVars(r.Head) {
+				vis = vis.Clear().WithParams(SafetyCheckVisitorParams)
+				vis.WalkBody(r.Body)
+
+				vis = vis.WithParams(VarVisitorParams{})
+				if len(r.Head.Args) > 0 {
+					vis.WalkArgs(r.Head.Args)
+				}
+
 				vars := r.Head.Vars()
-				if vars.DiffCount(safe) > 0 {
-					unsafe := vars.Diff(safe)
+				if vars.DiffCount(vis.vars) > 0 {
+					unsafe := vars.Diff(vis.vars)
 					for v := range unsafe {
 						if w, ok := c.RewrittenVars[v]; ok {
 							v = w
@@ -1343,6 +1359,8 @@ func (c *Compiler) checkSafetyRuleHeads() {
 			return false
 		})
 	}
+
+	varVisitorPool.Put(vis)
 }
 
 func compileSchema(goSchema any, allowNet []string) (*gojsonschema.Schema, error) {
@@ -1631,9 +1649,8 @@ func (c *Compiler) checkDeprecatedBuiltins() {
 	}
 
 	for _, name := range c.sorted {
-		mod := c.Modules[name]
-		if c.strict || mod.regoV1Compatible() {
-			errs := checkDeprecatedBuiltins(c.deprecatedBuiltinsMap, mod)
+		if c.strict || c.Modules[name].regoV1Compatible() {
+			errs := checkDeprecatedBuiltins(c.deprecatedBuiltinsMap, c.Modules[name])
 			for _, err := range errs {
 				c.err(err)
 			}
@@ -1765,14 +1782,11 @@ func (c *Compiler) err(err *Error) {
 }
 
 func (c *Compiler) getExports() *util.HasherMap[Ref, []Ref] {
-
 	rules := util.NewHasherMap[Ref, []Ref](RefEqual)
 
 	for _, name := range c.sorted {
-		mod := c.Modules[name]
-
-		for _, rule := range mod.Rules {
-			hashMapAdd(rules, mod.Package.Path, rule.Head.Ref().GroundPrefix())
+		for _, rule := range c.Modules[name].Rules {
+			hashMapAdd(rules, c.Modules[name].Package.Path, rule.Head.Ref().GroundPrefix())
 		}
 	}
 
@@ -1816,30 +1830,26 @@ func (c *Compiler) checkImports() {
 		c.capabilities.ContainsFeature(FeatureRegoV1)
 
 	for _, name := range c.sorted {
-		mod := c.Modules[name]
-
-		for _, imp := range mod.Imports {
+		for _, imp := range c.Modules[name].Imports {
 			if !supportsRegoV1Import && RegoV1CompatibleRef.Equal(imp.Path.Value) {
 				c.err(NewError(CompileErr, imp.Loc(), "rego.v1 import is not supported"))
 			}
 		}
 
-		if c.strict || c.moduleIsRegoV1Compatible(mod) {
-			modules = append(modules, mod)
+		if c.strict || c.moduleIsRegoV1Compatible(c.Modules[name]) {
+			modules = append(modules, c.Modules[name])
 		}
 	}
 
-	errs := checkDuplicateImports(modules)
-	for _, err := range errs {
+	for _, err := range checkDuplicateImports(modules) {
 		c.err(err)
 	}
 }
 
 func (c *Compiler) checkKeywordOverrides() {
 	for _, name := range c.sorted {
-		mod := c.Modules[name]
-		if c.strict || c.moduleIsRegoV1Compatible(mod) {
-			errs := checkRootDocumentOverrides(mod)
+		if c.strict || c.moduleIsRegoV1Compatible(c.Modules[name]) {
+			errs := checkRootDocumentOverrides(c.Modules[name])
 			for _, err := range errs {
 				c.err(err)
 			}
@@ -1893,12 +1903,10 @@ func (c *Compiler) moduleIsRegoV1Compatible(mod *Module) bool {
 //
 // The reference "c.d.e" would be resolved to "data.a.b.c.d.e".
 func (c *Compiler) resolveAllRefs() {
-
 	rules := c.getExports()
 
 	for _, name := range c.sorted {
 		mod := c.Modules[name]
-
 		var ruleExports []Ref
 		if x, ok := rules.Get(mod.Package.Path); ok {
 			ruleExports = x
@@ -1970,15 +1978,13 @@ func (c *Compiler) initLocalVarGen() {
 func (c *Compiler) rewriteComprehensionTerms() {
 	f := newEqualityFactory(c.localvargen)
 	for _, name := range c.sorted {
-		mod := c.Modules[name]
-		_, _ = rewriteComprehensionTerms(f, mod) // ignore error
+		_, _ = rewriteComprehensionTerms(f, c.Modules[name]) // ignore error
 	}
 }
 
 func (c *Compiler) rewriteExprTerms() {
 	for _, name := range c.sorted {
-		mod := c.Modules[name]
-		WalkRules(mod, func(rule *Rule) bool {
+		WalkRules(c.Modules[name], func(rule *Rule) bool {
 			rewriteExprTermsInHead(c.localvargen, rule)
 			rule.Body = rewriteExprTermsInBody(c.localvargen, rule.Body)
 			return false
@@ -2047,8 +2053,7 @@ func (c *Compiler) rewriteRuleHeadRefs() {
 
 func (c *Compiler) checkVoidCalls() {
 	for _, name := range c.sorted {
-		mod := c.Modules[name]
-		for _, err := range checkVoidCalls(c.TypeEnv, mod) {
+		for _, err := range checkVoidCalls(c.TypeEnv, c.Modules[name]) {
 			c.err(err)
 		}
 	}
@@ -2063,13 +2068,18 @@ func (c *Compiler) rewritePrintCalls() {
 			}
 		}
 	} else {
+		vis := varVisitorPool.Get()
+
 		for _, name := range c.sorted {
-			mod := c.Modules[name]
-			WalkRules(mod, func(r *Rule) bool {
-				safe := r.Head.Args.Vars()
-				safe.Update(ReservedVars)
-				vis := func(b Body) bool {
-					modrec, errs := rewritePrintCalls(c.localvargen, c.GetArity, safe, b)
+			WalkRules(c.Modules[name], func(r *Rule) bool {
+				vis = vis.Clear()
+				vis.vars.Update(ReservedVars)
+				if len(r.Head.Args) > 0 {
+					vis.WalkArgs(r.Head.Args)
+				}
+
+				bodyVis := func(b Body) bool {
+					modrec, errs := rewritePrintCalls(c.localvargen, c.GetArity, vis.vars, b)
 					if modrec {
 						modified = true
 					}
@@ -2078,11 +2088,13 @@ func (c *Compiler) rewritePrintCalls() {
 					}
 					return false
 				}
-				WalkBodies(r.Head, vis)
-				WalkBodies(r.Body, vis)
+				WalkBodies(r.Head, bodyVis)
+				WalkBodies(r.Body, bodyVis)
 				return false
 			})
 		}
+
+		varVisitorPool.Put(vis)
 	}
 	if modified {
 		c.Required.addBuiltinSorted(Print)
@@ -2126,7 +2138,7 @@ func rewritePrintCalls(gen *localVarGenerator, getArity func(Ref) int, globals V
 	// those bodies only close over variables that are safe.
 	for i := range body {
 		if ContainsClosures(body[i]) {
-			safe := outputVarsForBody(body[:i], getArity, globals)
+			safe := outputVarsForBody(body[:i], getArity, globals, nil)
 			safe.Update(globals)
 			WalkClosures(body[i], func(x any) bool {
 				var modrec bool
@@ -2163,7 +2175,7 @@ func rewritePrintCalls(gen *localVarGenerator, getArity func(Ref) int, globals V
 		modified = true
 
 		var errs Errors
-		safe := outputVarsForBody(body[:i], getArity, globals)
+		safe := outputVarsForBody(body[:i], getArity, globals, nil)
 		safe.Update(globals)
 
 		// Fixes Issue #7647 by adding generated variables to the safe set
@@ -2177,8 +2189,13 @@ func rewritePrintCalls(gen *localVarGenerator, getArity func(Ref) int, globals V
 		args := body[i].Operands()
 
 		var vis *VarVisitor
+		if len(args) > 0 {
+			vis = varVisitorPool.Get()
+			defer varVisitorPool.Put(vis)
+		}
+
 		for j := range args {
-			vis = vis.ClearOrNew().WithParams(SafetyCheckVisitorParams)
+			vis = vis.Clear().WithParams(SafetyCheckVisitorParams)
 			vis.Walk(args[j])
 			vars := vis.Vars()
 			if vars.DiffCount(safe) > 0 {
@@ -2296,8 +2313,7 @@ func isPrintCall(x *Expr) bool {
 func (c *Compiler) rewriteRefsInHead() {
 	f := newEqualityFactory(c.localvargen)
 	for _, name := range c.sorted {
-		mod := c.Modules[name]
-		WalkRules(mod, func(rule *Rule) bool {
+		WalkRules(c.Modules[name], func(rule *Rule) bool {
 			if requiresEval(rule.Head.Key) {
 				expr := f.Generate(rule.Head.Key)
 				rule.Head.Key = expr.Operand(0)
@@ -2367,8 +2383,7 @@ func (c *Compiler) rewriteTestRuleEqualities() {
 
 	f := newEqualityFactory(c.localvargen)
 	for _, name := range c.sorted {
-		mod := c.Modules[name]
-		WalkRules(mod, func(rule *Rule) bool {
+		WalkRules(c.Modules[name], func(rule *Rule) bool {
 			if strings.HasPrefix(string(rule.Head.Name), "test_") {
 				rule.Body = rewriteTestEqualities(f, rule.Body)
 			}
@@ -2381,8 +2396,7 @@ func (c *Compiler) parseMetadataBlocks() {
 	// Only parse annotations if rego.metadata built-ins are called
 	regoMetadataCalled := false
 	for _, name := range c.sorted {
-		mod := c.Modules[name]
-		WalkExprs(mod, func(expr *Expr) bool {
+		WalkExprs(c.Modules[name], func(expr *Expr) bool {
 			if isRegoMetadataChainCall(expr) || isRegoMetadataRuleCall(expr) {
 				regoMetadataCalled = true
 			}
@@ -2398,7 +2412,6 @@ func (c *Compiler) parseMetadataBlocks() {
 		// NOTE: Possible optimization: only parse annotations for modules on the path of rego.metadata-calling module
 		for _, name := range c.sorted {
 			mod := c.Modules[name]
-
 			if len(mod.Annotations) == 0 {
 				var errs Errors
 				mod.Annotations, errs = parseAnnotations(mod.Comments)
@@ -2420,11 +2433,8 @@ func (c *Compiler) rewriteRegoMetadataCalls() {
 	_, ruleFuncAllowed := c.builtins[RegoMetadataRule.Name]
 
 	for _, name := range c.sorted {
-		mod := c.Modules[name]
-
-		WalkRules(mod, func(rule *Rule) bool {
-			var firstChainCall *Expr
-			var firstRuleCall *Expr
+		WalkRules(c.Modules[name], func(rule *Rule) bool {
+			var firstChainCall, firstRuleCall *Expr
 
 			WalkExprs(rule, func(expr *Expr) bool {
 				if chainFuncAllowed && firstChainCall == nil && isRegoMetadataChainCall(expr) {
@@ -2684,25 +2694,29 @@ func (c *Compiler) rewriteLocalVarsInRule(rule *Rule, unusedArgs VarSet, argsSta
 		}
 
 		// Rewrite assignments in body.
-		used = NewVarSet()
+		vis := NewVarVisitor()
 
 		for _, t := range rule.Head.Ref()[1:] {
-			used.Update(t.Vars())
+			if !IsScalar(t.Value) {
+				vis.Walk(t)
+			}
 		}
 
-		if rule.Head.Key != nil {
-			used.Update(rule.Head.Key.Vars())
+		if rule.Head.Key != nil && !IsScalar(rule.Head.Key.Value) {
+			vis.Walk(rule.Head.Key)
 		}
 
-		if rule.Head.Value != nil {
+		if rule.Head.Value != nil && !IsScalar(rule.Head.Value.Value) {
 			valueVars := rule.Head.Value.Vars()
-			used.Update(valueVars)
+			vis.vars.Update(valueVars)
 			for arg := range unusedArgs {
 				if valueVars.Contains(arg) {
 					delete(unusedArgs, arg)
 				}
 			}
 		}
+
+		used = vis.Vars()
 	}
 
 	stack := argsStack.Copy()
@@ -2777,19 +2791,21 @@ func (xform *rewriteNestedHeadVarLocalTransform) Visit(x any) bool {
 
 		switch x := term.Value.(type) {
 		case *object:
+			vis := NewGenericVisitor(xform.Visit)
 			cpy, _ := x.Map(func(k, v *Term) (*Term, *Term, error) {
 				kcpy := k.Copy()
-				NewGenericVisitor(xform.Visit).Walk(kcpy)
+				vis.Walk(kcpy)
 				vcpy := v.Copy()
-				NewGenericVisitor(xform.Visit).Walk(vcpy)
+				vis.Walk(vcpy)
 				return kcpy, vcpy, nil
 			})
 			term.Value = cpy
 			stop = true
 		case *set:
+			vis := NewGenericVisitor(xform.Visit)
 			cpy, _ := x.Map(func(v *Term) (*Term, error) {
 				vcpy := v.Copy()
-				NewGenericVisitor(xform.Visit).Walk(vcpy)
+				vis.Walk(vcpy)
 				return vcpy, nil
 			})
 			term.Value = cpy
@@ -2827,7 +2843,6 @@ func (xform rewriteHeadVarLocalTransform) Transform(x any) (any, error) {
 }
 
 func (c *Compiler) rewriteLocalArgVars(gen *localVarGenerator, stack *localDeclaredVars, rule *Rule) {
-
 	vis := &ruleArgLocalRewriter{
 		stack: stack,
 		gen:   gen,
@@ -3251,6 +3266,10 @@ func (ci *ComprehensionIndex) String() string {
 func buildComprehensionIndices(dbg debug.Debug, arity func(Ref) int, candidates VarSet, rwVars map[Var]Var, node Body, result map[*Term]*ComprehensionIndex) uint64 {
 	var n uint64
 	cpy := candidates.Copy()
+	vis := varVisitorPool.Get()
+
+	defer varVisitorPool.Put(vis)
+
 	WalkBodies(node, func(b Body) bool {
 		for _, expr := range b {
 			index := getComprehensionIndex(dbg, arity, cpy, rwVars, expr)
@@ -3260,7 +3279,9 @@ func buildComprehensionIndices(dbg debug.Debug, arity func(Ref) int, candidates 
 			}
 			// Any variables appearing in the expressions leading up to the comprehension
 			// are fair-game to be used as index keys.
-			cpy.Update(expr.Vars(VarVisitorParams{SkipClosures: true, SkipRefCallHead: true}))
+			vis = vis.Clear().WithParams(VarVisitorParams{SkipClosures: true, SkipRefCallHead: true})
+			vis.Walk(expr)
+			cpy.Update(vis.Vars())
 		}
 		return false
 	})
@@ -3268,7 +3289,6 @@ func buildComprehensionIndices(dbg debug.Debug, arity func(Ref) int, candidates 
 }
 
 func getComprehensionIndex(dbg debug.Debug, arity func(Ref) int, candidates VarSet, rwVars map[Var]Var, expr *Expr) *ComprehensionIndex {
-
 	// Ignore everything except <var> = <comprehension> expressions. Extract
 	// the comprehension term from the expression.
 	if !expr.IsEquality() || expr.Negated || len(expr.With) > 0 {
@@ -3321,7 +3341,7 @@ func getComprehensionIndex(dbg debug.Debug, arity func(Ref) int, candidates VarS
 		body = x.Body
 	}
 
-	outputs := outputVarsForBody(body, arity, ReservedVars)
+	outputs := outputVarsForBody(body, arity, ReservedVars, nil)
 	unsafe := body.Vars(SafetyCheckVisitorParams).Diff(outputs).Diff(ReservedVars)
 
 	if len(unsafe) > 0 {
@@ -3455,9 +3475,11 @@ func (vis *comprehensionIndexNestedCandidateVisitor) visit(x any) bool {
 	}
 
 	if v, ok := x.(Value); ok && IsComprehension(v) {
-		varVis := NewVarVisitor().WithParams(VarVisitorParams{SkipRefHead: true})
+		varVis := varVisitorPool.Get().WithParams(VarVisitorParams{SkipRefHead: true})
 		varVis.Walk(v)
 		vis.found = len(varVis.Vars().Intersect(vis.candidates)) > 0
+		varVisitorPool.Put(varVis)
+
 		return true
 	}
 
@@ -3998,7 +4020,8 @@ func reorderBodyForSafety(builtins map[string]*Builtin, arity func(Ref) int, glo
 	unsafe := make(unsafeVars, len(bodyVars)-len(safe))
 
 	for _, e := range body {
-		vis.Clear().WithParams(SafetyCheckVisitorParams).Walk(e)
+		vis = vis.Clear().WithParams(SafetyCheckVisitorParams)
+		vis.Walk(e)
 		for v := range vis.Vars() {
 			if _, ok := safe[v]; !ok {
 				unsafe.Add(e, v)
@@ -4007,7 +4030,8 @@ func reorderBodyForSafety(builtins map[string]*Builtin, arity func(Ref) int, glo
 	}
 
 	reordered := make(Body, 0, len(body))
-	output := VarSet{}
+	output := NewVarSet()
+	unsVis := varVisitorPool.Get()
 
 	for {
 		n := len(reordered)
@@ -4017,13 +4041,15 @@ func reorderBodyForSafety(builtins map[string]*Builtin, arity func(Ref) int, glo
 				continue
 			}
 
-			ovs := outputVarsForExpr(e, arity, safe, output)
+			ovs := outputVarsForExpr(e, arity, safe, output, vis)
 
 			// check closures: is this expression closing over variables that
 			// haven't been made safe by what's already included in `reordered`?
-			vs := unsafeVarsInClosures(e)
-			cv := vs.Intersect(bodyVars).Diff(globals)
-			ob := outputVarsForBody(reordered, arity, safe)
+			unsafeVarsInClosures(e, unsVis)
+			cv := unsVis.Vars().Intersect(bodyVars).Diff(globals)
+			unsVis.Clear()
+
+			ob := outputVarsForBody(reordered, arity, safe, vis)
 
 			if cv.DiffCount(ob) > 0 {
 				uv := cv.Diff(ob)
@@ -4051,26 +4077,25 @@ func reorderBodyForSafety(builtins map[string]*Builtin, arity func(Ref) int, glo
 		}
 	}
 
+	varVisitorPool.Put(unsVis)
+
 	// Recursively visit closures and perform the safety checks on them.
 	// Update the globals at each expression to include the variables that could
 	// be closed over.
 	g := globals.Copy()
-	xform := &bodySafetyTransformer{
-		builtins: builtins,
-		arity:    arity,
-	}
-	gvis := &GenericVisitor{}
+	xform := newBodySafetyTransformer(builtins, arity)
+	xform.gv = NewGenericVisitor(xform.Visit)
+
 	for i, e := range reordered {
 		if i > 0 {
+			vis = vis.Clear().WithParams(SafetyCheckVisitorParams)
 			vis.Walk(reordered[i-1])
 			g.Update(vis.Vars())
-			vis.Clear().WithParams(SafetyCheckVisitorParams)
 		}
 		xform.current = e
 		xform.globals = g
 		xform.unsafe = unsafe
-		gvis.f = xform.Visit
-		gvis.Walk(e)
+		xform.gv.Walk(e)
 	}
 
 	return reordered, unsafe
@@ -4082,18 +4107,29 @@ type bodySafetyTransformer struct {
 	current  *Expr
 	globals  VarSet
 	unsafe   unsafeVars
+	gv       *GenericVisitor
+}
+
+func newBodySafetyTransformer(builtins map[string]*Builtin, arity func(Ref) int) *bodySafetyTransformer {
+	return &bodySafetyTransformer{
+		builtins: builtins,
+		arity:    arity,
+	}
 }
 
 func (xform *bodySafetyTransformer) Visit(x any) bool {
+	if xform.gv == nil {
+		xform.gv = NewGenericVisitor(xform.Visit)
+	}
 	switch term := x.(type) {
 	case *Term:
 		switch x := term.Value.(type) {
 		case *object:
 			cpy, _ := x.Map(func(k, v *Term) (*Term, *Term, error) {
 				kcpy := k.Copy()
-				NewGenericVisitor(xform.Visit).Walk(kcpy)
+				xform.gv.Walk(kcpy)
 				vcpy := v.Copy()
-				NewGenericVisitor(xform.Visit).Walk(vcpy)
+				xform.gv.Walk(vcpy)
 				return kcpy, vcpy, nil
 			})
 			term.Value = cpy
@@ -4101,7 +4137,7 @@ func (xform *bodySafetyTransformer) Visit(x any) bool {
 		case *set:
 			cpy, _ := x.Map(func(v *Term) (*Term, error) {
 				vcpy := v.Copy()
-				NewGenericVisitor(xform.Visit).Walk(vcpy)
+				xform.gv.Walk(vcpy)
 				return vcpy, nil
 			})
 			term.Value = cpy
@@ -4162,10 +4198,8 @@ func (xform *bodySafetyTransformer) reorderSetComprehensionSafety(sc *SetCompreh
 
 // unsafeVarsInClosures collects vars that are contained in closures within
 // this expression.
-func unsafeVarsInClosures(e *Expr) VarSet {
-	vs := VarSet{}
+func unsafeVarsInClosures(e *Expr, vis *VarVisitor) {
 	WalkClosures(e, func(x any) bool {
-		vis := &VarVisitor{vars: vs}
 		if ev, ok := x.(*Every); ok {
 			vis.WalkBody(ev.Body)
 			return true
@@ -4173,21 +4207,23 @@ func unsafeVarsInClosures(e *Expr) VarSet {
 		vis.Walk(x)
 		return true
 	})
-	return vs
 }
 
 // OutputVarsFromBody returns all variables which are the "output" for
 // the given body. For safety checks this means that they would be
 // made safe by the body.
 func OutputVarsFromBody(c *Compiler, body Body, safe VarSet) VarSet {
-	return outputVarsForBody(body, c.GetArity, safe)
+	return outputVarsForBody(body, c.GetArity, safe, nil)
 }
 
-func outputVarsForBody(body Body, arity func(Ref) int, safe VarSet) VarSet {
+func outputVarsForBody(body Body, arity func(Ref) int, safe VarSet, vis *VarVisitor) VarSet {
 	o := safe.Copy()
 	output := VarSet{}
+
+	vis = ClearOrNewVarVisitor(vis)
+
 	for _, e := range body {
-		o.Update(outputVarsForExpr(e, arity, o, output))
+		o.Update(outputVarsForExpr(e, arity, o, output, vis))
 	}
 	return o.Diff(safe)
 }
@@ -4196,20 +4232,22 @@ func outputVarsForBody(body Body, arity func(Ref) int, safe VarSet) VarSet {
 // the given expression. For safety checks this means that they would be
 // made safe by the expr.
 func OutputVarsFromExpr(c *Compiler, expr *Expr, safe VarSet) VarSet {
-	return outputVarsForExpr(expr, c.GetArity, safe, VarSet{})
+	return outputVarsForExpr(expr, c.GetArity, safe, VarSet{}, nil)
 }
 
-func outputVarsForExpr(expr *Expr, arity func(Ref) int, safe VarSet, output VarSet) VarSet {
+func outputVarsForExpr(expr *Expr, arity func(Ref) int, safe VarSet, output VarSet, vis *VarVisitor) VarSet {
 	// Negated expressions must be safe.
 	if expr.Negated {
 		return VarSet{}
 	}
 
-	var vis *VarVisitor
+	if len(expr.With) > 0 {
+		vis = ClearOrNewVarVisitor(vis).WithParams(SafetyCheckVisitorParams)
+	}
 
 	// With modifier inputs must be safe.
 	for _, with := range expr.With {
-		vis = vis.ClearOrNew().WithParams(SafetyCheckVisitorParams)
+		vis = vis.Clear().WithParams(SafetyCheckVisitorParams)
 		vis.Walk(with)
 		if vis.Vars().DiffCount(safe) > 0 {
 			return VarSet{}
@@ -4218,7 +4256,7 @@ func outputVarsForExpr(expr *Expr, arity func(Ref) int, safe VarSet, output VarS
 
 	switch terms := expr.Terms.(type) {
 	case *Term:
-		return outputVarsForTerms(expr, safe)
+		return outputVarsForTerms(expr, safe, nil)
 	case []*Term:
 		if expr.IsEquality() {
 			return outputVarsForExprEq(expr, safe, output)
@@ -4236,7 +4274,7 @@ func outputVarsForExpr(expr *Expr, arity func(Ref) int, safe VarSet, output VarS
 
 		return outputVarsForExprCall(expr, ar, safe, terms, vis, output)
 	case *Every:
-		return outputVarsForTerms(terms.Domain, safe)
+		return outputVarsForTerms(terms.Domain, safe, output)
 	default:
 		panic("illegal expression")
 	}
@@ -4247,7 +4285,7 @@ func outputVarsForExprEq(expr *Expr, safe VarSet, output VarSet) VarSet {
 		return safe
 	}
 
-	output.Update(outputVarsForTerms(expr, safe))
+	output = outputVarsForTerms(expr, safe, output)
 	output.Update(safe)
 	output.Update(Unify(output, expr.Operand(0), expr.Operand(1)))
 
@@ -4261,7 +4299,7 @@ func outputVarsForExprEq(expr *Expr, safe VarSet, output VarSet) VarSet {
 func outputVarsForExprCall(expr *Expr, arity int, safe VarSet, terms []*Term, vis *VarVisitor, output VarSet) VarSet {
 	clear(output)
 
-	output.Update(outputVarsForTerms(expr, safe))
+	output = outputVarsForTerms(expr, safe, output)
 
 	numInputTerms := arity + 1
 	if numInputTerms >= len(terms) {
@@ -4274,7 +4312,8 @@ func outputVarsForExprCall(expr *Expr, arity int, safe VarSet, terms []*Term, vi
 		SkipObjectKeys: true,
 		SkipRefHead:    true,
 	}
-	vis = vis.ClearOrNew().WithParams(params)
+
+	vis = ClearOrNewVarVisitor(vis).WithParams(params)
 	vis.WalkArgs(Args(terms[:numInputTerms]))
 
 	unsafe := vis.Vars().Diff(output).DiffCount(safe)
@@ -4288,8 +4327,10 @@ func outputVarsForExprCall(expr *Expr, arity int, safe VarSet, terms []*Term, vi
 	return output
 }
 
-func outputVarsForTerms(expr any, safe VarSet) VarSet {
-	output := VarSet{}
+func outputVarsForTerms(expr any, safe, output VarSet) VarSet {
+	if output == nil {
+		output = VarSet{}
+	}
 	WalkTerms(expr, func(x *Term) bool {
 		switch r := x.Value.(type) {
 		case *SetComprehension, *ArrayComprehension, *ObjectComprehension:
@@ -4341,22 +4382,29 @@ func newLocalVarGeneratorForModuleSet(sorted []string, modules map[string]*Modul
 	for _, key := range sorted {
 		vis.Walk(modules[key])
 	}
-	return &localVarGenerator{exclude: vis.vars, next: 0}
+	return &localVarGenerator{exclude: vis.vars, suffix: LocalVarPrefix}
 }
 
 func newLocalVarGenerator(suffix string, node any) *localVarGenerator {
 	vis := NewVarVisitor()
 	vis.Walk(node)
-	return &localVarGenerator{exclude: vis.vars, suffix: suffix, next: 0}
+	return &localVarGenerator{exclude: vis.vars, suffix: LocalVarPrefix + suffix}
 }
 
 func (l *localVarGenerator) Generate() Var {
+	buf := make([]byte, 0, len(l.suffix)+util.NumDigitsInt(l.next)+2)
 	for {
-		result := Var(LocalVarPrefix + l.suffix + strconv.Itoa(l.next) + "__")
+		buf = append(buf, l.suffix...)
+		buf = strconv.AppendInt(buf, int64(l.next), 10)
+		buf = append(buf, "__"...)
+
+		result := Var(string(buf))
 		l.next++
 		if !l.exclude.Contains(result) {
 			return result
 		}
+
+		buf = buf[:0]
 	}
 }
 
@@ -5565,7 +5613,7 @@ func rewriteSomeDeclStatement(g *localVarGenerator, stack *localDeclaredVars, ex
 				RefTerm(VarTerm(Equality.Name)), val, rhs,
 			}
 
-			output := VarSet{}
+			output := NewVarSet()
 
 			for _, v0 := range outputVarsForExprEq(e, container.Vars(), output).Sorted() {
 				if _, err := rewriteDeclaredVar(g, stack, v0, declaredVar); err != nil {
@@ -5762,8 +5810,7 @@ func rewriteDeclaredVarsInArrayComprehension(g *localVarGenerator, stack *localD
 }
 
 func rewriteDeclaredVarsInSetComprehension(g *localVarGenerator, stack *localDeclaredVars, v *SetComprehension, errs Errors, strict bool) Errors {
-	used := NewVarSet()
-	used.Update(v.Term.Vars())
+	used := v.Term.Vars()
 
 	stack.Push()
 	v.Body, errs = rewriteDeclaredVarsInBody(g, stack, used, v.Body, errs, strict)

--- a/v1/ast/compile_bench_test.go
+++ b/v1/ast/compile_bench_test.go
@@ -6,7 +6,6 @@ import (
 )
 
 func BenchmarkRewriteDynamics(b *testing.B) {
-
 	// The choice of query to use is somewhat arbitrary. This query is
 	// representative of the ones that result from partial evaluation on IAM
 	// data models (e.g., a triple glob match on subject/action/resource.)
@@ -29,11 +28,19 @@ func BenchmarkRewriteDynamics(b *testing.B) {
 			}
 		})
 	}
+}
 
+// 32.38 ns/op	      31 B/op	       1 allocs/op // String concatenation
+// 18.77 ns/op	      23 B/op	       1 allocs/op // []byte appends
+func BenchmarkGenerateLocalVar(b *testing.B) {
+	g := newLocalVarGenerator("q", nil)
+
+	for b.Loop() {
+		g.Generate()
+	}
 }
 
 func makeQueriesForRewriteDynamicsBenchmark(sizes []int, body Body) [][]Body {
-
 	queries := make([][]Body, len(sizes))
 
 	for i := range queries {

--- a/v1/ast/compile_test.go
+++ b/v1/ast/compile_test.go
@@ -23,7 +23,6 @@ import (
 )
 
 func TestOutputVarsForNode(t *testing.T) {
-
 	tests := []struct {
 		note      string
 		query     string
@@ -250,7 +249,7 @@ func TestOutputVarsForNode(t *testing.T) {
 
 			vs := NewSet()
 
-			for v := range outputVarsForBody(body, arity, safe) {
+			for v := range outputVarsForBody(body, arity, safe, nil) {
 				vs.Add(NewTerm(v))
 			}
 

--- a/v1/ast/oracle/oracle.go
+++ b/v1/ast/oracle/oracle.go
@@ -303,22 +303,10 @@ func halted(c *ast.Compiler) error {
 }
 
 func walkToFirstOccurrence(node ast.Node, needle ast.Var) (match *ast.Term) {
-	ast.WalkNodes(node, func(x ast.Node) bool {
+	ast.WalkTerms(node, func(x *ast.Term) bool {
 		if match == nil {
-			switch x := x.(type) {
-			case *ast.SomeDecl:
-				// NOTE(tsandall): The visitor doesn't traverse into some decl terms
-				// so special case here.
-				for i := range x.Symbols {
-					if x.Symbols[i].Value.Compare(needle) == 0 {
-						match = x.Symbols[i]
-						break
-					}
-				}
-			case *ast.Term:
-				if x.Value.Compare(needle) == 0 {
-					match = x
-				}
+			if x.Value.Compare(needle) == 0 {
+				match = x
 			}
 		}
 		return match != nil
@@ -331,7 +319,6 @@ func findContainingNodeStack(module *ast.Module, pos int) []ast.Node {
 
 	ast.WalkNodes(module, func(x ast.Node) bool {
 		minLoc, maxLoc := getLocMinMax(x)
-
 		if pos < minLoc || pos >= maxLoc {
 			return true
 		}

--- a/v1/ast/parser.go
+++ b/v1/ast/parser.go
@@ -2532,12 +2532,10 @@ func (p *Parser) restore(s *state) {
 }
 
 func setLocRecursive(x any, loc *location.Location) {
-	NewGenericVisitor(func(x any) bool {
-		if node, ok := x.(Node); ok {
-			node.SetLoc(loc)
-		}
+	WalkNodes(x, func(n Node) bool {
+		n.SetLoc(loc)
 		return false
-	}).Walk(x)
+	})
 }
 
 func (p *Parser) setLoc(term *Term, loc *location.Location, offset, end int) *Term {

--- a/v1/ast/parser_ext.go
+++ b/v1/ast/parser_ext.go
@@ -11,7 +11,6 @@
 package ast
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"slices"
@@ -625,10 +624,9 @@ func ParseStatements(filename, input string) ([]Statement, []*Comment, error) {
 // ParseStatementsWithOpts returns a slice of parsed statements. This is the
 // default return value from the parser.
 func ParseStatementsWithOpts(filename, input string, popts ParserOptions) ([]Statement, []*Comment, error) {
-
 	parser := NewParser().
 		WithFilename(filename).
-		WithReader(bytes.NewBufferString(input)).
+		WithReader(strings.NewReader(input)).
 		WithProcessAnnotation(popts.ProcessAnnotation).
 		WithFutureKeywords(popts.FutureKeywords...).
 		WithAllFutureKeywords(popts.AllFutureKeywords).
@@ -638,7 +636,6 @@ func ParseStatementsWithOpts(filename, input string, popts ParserOptions) ([]Sta
 		withUnreleasedKeywords(popts.unreleasedKeywords)
 
 	stmts, comments, errs := parser.Parse()
-
 	if len(errs) > 0 {
 		return nil, nil, errs
 	}
@@ -647,7 +644,6 @@ func ParseStatementsWithOpts(filename, input string, popts ParserOptions) ([]Sta
 }
 
 func parseModule(filename string, stmts []Statement, comments []*Comment, regoCompatibilityMode RegoVersion) (*Module, error) {
-
 	if len(stmts) == 0 {
 		return nil, NewError(ParseErr, &Location{File: filename}, "empty module")
 	}
@@ -662,23 +658,21 @@ func parseModule(filename string, stmts []Statement, comments []*Comment, regoCo
 
 	mod := &Module{
 		Package: pkg,
-		stmts:   stmts,
+		// The comments slice only holds comments that were not their own statements.
+		Comments: comments,
+		stmts:    stmts,
 	}
 
-	// The comments slice only holds comments that were not their own statements.
-	mod.Comments = append(mod.Comments, comments...)
-
+	mod.regoVersion = regoCompatibilityMode
 	if regoCompatibilityMode == RegoUndefined {
 		mod.regoVersion = DefaultRegoVersion
-	} else {
-		mod.regoVersion = regoCompatibilityMode
 	}
 
 	for i, stmt := range stmts[1:] {
 		switch stmt := stmt.(type) {
 		case *Import:
 			mod.Imports = append(mod.Imports, stmt)
-			if mod.regoVersion == RegoV0 && Compare(stmt.Path.Value, RegoV1CompatibleRef) == 0 {
+			if mod.regoVersion == RegoV0 && RegoV1CompatibleRef.Equal(stmt.Path.Value) {
 				mod.regoVersion = RegoV0CompatV1
 			}
 		case *Rule:

--- a/v1/ast/rego_v1.go
+++ b/v1/ast/rego_v1.go
@@ -65,7 +65,7 @@ func checkRootDocumentOverrides(node any) Errors {
 }
 
 func walkCalls(node any, f func(any) bool) {
-	vis := &GenericVisitor{func(x any) bool {
+	vis := NewGenericVisitor(func(x any) bool {
 		switch x := x.(type) {
 		case Call:
 			return f(x)
@@ -78,13 +78,11 @@ func walkCalls(node any, f func(any) bool) {
 			walkCalls(x.Reference, f)
 		}
 		return false
-	}}
+	})
 	vis.Walk(node)
 }
 
-func checkDeprecatedBuiltins(deprecatedBuiltinsMap map[string]struct{}, node any) Errors {
-	errs := make(Errors, 0)
-
+func checkDeprecatedBuiltins(deprecatedBuiltinsMap map[string]struct{}, node any) (errs Errors) {
 	walkCalls(node, func(x any) bool {
 		var operator string
 		var loc *Location

--- a/v1/ast/transform.go
+++ b/v1/ast/transform.go
@@ -19,7 +19,6 @@ type Transformer interface {
 // Transform iterates the AST and calls the Transform function on the
 // Transformer t for x before recursing.
 func Transform(t Transformer, x any) (any, error) {
-
 	if term, ok := x.(*Term); ok {
 		return Transform(t, term.Value)
 	}
@@ -387,11 +386,7 @@ func transformTerm(t Transformer, term *Term) (*Term, error) {
 	if err != nil {
 		return nil, err
 	}
-	r := &Term{
-		Value:    v,
-		Location: term.Location,
-	}
-	return r, nil
+	return &Term{Value: v, Location: term.Location}, nil
 }
 
 func transformValue(t Transformer, v Value) (Value, error) {
@@ -407,13 +402,18 @@ func transformValue(t Transformer, v Value) (Value, error) {
 }
 
 func transformVar(t Transformer, v Var) (Var, error) {
-	v1, err := Transform(t, v)
+	tv, err := t.Transform(v)
 	if err != nil {
 		return "", err
 	}
-	r, ok := v1.(Var)
+
+	if tv == nil {
+		return "", nil
+	}
+
+	r, ok := tv.(Var)
 	if !ok {
-		return "", fmt.Errorf("illegal transform: %T != %T", v, v1)
+		return "", fmt.Errorf("illegal transform: %T != %T", v, tv)
 	}
 	return r, nil
 }

--- a/v1/ast/visit.go
+++ b/v1/ast/visit.go
@@ -4,44 +4,108 @@
 
 package ast
 
-// Visitor defines the interface for iterating AST elements. The Visit function
-// can return a Visitor w which will be used to visit the children of the AST
-// element v. If the Visit function returns nil, the children will not be
-// visited.
-//
-// Deprecated: use GenericVisitor or another visitor implementation
-type Visitor interface {
-	Visit(v any) (w Visitor)
-}
+var (
+	termTypeVisitor = newTypeVisitor[*Term]()
+	varTypeVisitor  = newTypeVisitor[Var]()
+	exprTypeVisitor = newTypeVisitor[*Expr]()
+	ruleTypeVisitor = newTypeVisitor[*Rule]()
+	refTypeVisitor  = newTypeVisitor[Ref]()
+	bodyTypeVisitor = newTypeVisitor[Body]()
+	withTypeVisitor = newTypeVisitor[*With]()
+)
 
-// BeforeAndAfterVisitor wraps Visitor to provide hooks for being called before
-// and after the AST has been visited.
-//
-// Deprecated: use GenericVisitor or another visitor implementation
-type BeforeAndAfterVisitor interface {
-	Visitor
-	Before(x any)
-	After(x any)
-}
+type (
+	// GenericVisitor provides a utility to walk over AST nodes using a
+	// closure. If the closure returns true, the visitor will not walk
+	// over AST nodes under x.
+	GenericVisitor struct {
+		f func(x any) bool
+	}
 
-// Walk iterates the AST by calling the Visit function on the Visitor
+	// BeforeAfterVisitor provides a utility to walk over AST nodes using
+	// closures. If the before closure returns true, the visitor will not
+	// walk over AST nodes under x. The after closure is invoked always
+	// after visiting a node.
+	BeforeAfterVisitor struct {
+		before func(x any) bool
+		after  func(x any)
+	}
+
+	// VarVisitor walks AST nodes under a given node and collects all encountered
+	// variables. The collected variables can be controlled by specifying
+	// VarVisitorParams when creating the visitor.
+	VarVisitor struct {
+		params VarVisitorParams
+		vars   VarSet
+	}
+
+	// VarVisitorParams contains settings for a VarVisitor.
+	VarVisitorParams struct {
+		SkipRefHead     bool
+		SkipRefCallHead bool
+		SkipObjectKeys  bool
+		SkipClosures    bool
+		SkipWithTarget  bool
+		SkipSets        bool
+	}
+
+	// Visitor defines the interface for iterating AST elements. The Visit function
+	// can return a Visitor w which will be used to visit the children of the AST
+	// element v. If the Visit function returns nil, the children will not be
+	// visited.
+	//
+	// Deprecated: use [GenericVisitor] or another visitor implementation
+	Visitor interface {
+		Visit(v any) (w Visitor)
+	}
+
+	// BeforeAndAfterVisitor wraps Visitor to provide hooks for being called before
+	// and after the AST has been visited.
+	//
+	// Deprecated: use [GenericVisitor] or another visitor implementation
+	BeforeAndAfterVisitor interface {
+		Visitor
+		Before(x any)
+		After(x any)
+	}
+
+	// typeVisitor is a generic visitor for a specific type T (the "generic" name was
+	// however taken). Contrary to the [GenericVisitor], the typeVisitor only invokes
+	// the visit function for nodes of type T, saving both CPU cycles and type assertions.
+	// typeVisitor implementations carry no state, and can be shared freely across
+	// goroutines. Access is private for the time being, as there is already inflation
+	// in visitor types exposed in the AST package. The various WalkXXX functions however
+	// now leverage typeVisitor under the hood.
+	//
+	// While a typeVisitor is generally a more performant option over a GenericVisitor,
+	// it is not as flexible: a type visitor can only visit nodes of a single type T,
+	// whereas a GenericVisitor visits all nodes. Adding to that, a typeVisitor can only
+	// be instantiated for **concrete types** — not interfaces (e.g., [*Expr], not [Node]),
+	// as reflection would be required to determine the concrete type at runtime, thus
+	// nullifying the performance benefits of the typeVisitor in the first place.
+	typeVisitor[T any] struct {
+		typ any
+	}
+)
+
+// Walk iterates the AST by calling the Visit function on the [Visitor]
 // v for x before recursing.
 //
-// Deprecated: use GenericVisitor.Walk
+// Deprecated: use [GenericVisitor.Walk]
 func Walk(v Visitor, x any) {
 	if bav, ok := v.(BeforeAndAfterVisitor); !ok {
 		walk(v, x)
 	} else {
 		bav.Before(x)
-		defer bav.After(x)
 		walk(bav, x)
+		bav.After(x)
 	}
 }
 
 // WalkBeforeAndAfter iterates the AST by calling the Visit function on the
 // Visitor v for x before recursing.
 //
-// Deprecated: use GenericVisitor.Walk
+// Deprecated: use [GenericVisitor.Walk]
 func WalkBeforeAndAfter(v BeforeAndAfterVisitor, x any) {
 	Walk(v, x)
 }
@@ -159,126 +223,244 @@ func walk(v Visitor, x any) {
 // WalkVars calls the function f on all vars under x. If the function f
 // returns true, AST nodes under the last node will not be visited.
 func WalkVars(x any, f func(Var) bool) {
-	vis := &GenericVisitor{func(x any) bool {
-		if v, ok := x.(Var); ok {
-			return f(v)
-		}
-		return false
-	}}
-	vis.Walk(x)
+	varTypeVisitor.walk(x, f)
 }
 
 // WalkClosures calls the function f on all closures under x. If the function f
 // returns true, AST nodes under the last node will not be visited.
 func WalkClosures(x any, f func(any) bool) {
-	vis := &GenericVisitor{func(x any) bool {
+	vis := NewGenericVisitor(func(x any) bool {
 		switch x := x.(type) {
 		case *ArrayComprehension, *ObjectComprehension, *SetComprehension, *Every:
 			return f(x)
 		}
 		return false
-	}}
+	})
 	vis.Walk(x)
 }
 
 // WalkRefs calls the function f on all references under x. If the function f
 // returns true, AST nodes under the last node will not be visited.
 func WalkRefs(x any, f func(Ref) bool) {
-	vis := &GenericVisitor{func(x any) bool {
-		if r, ok := x.(Ref); ok {
-			return f(r)
-		}
-		return false
-	}}
-	vis.Walk(x)
+	refTypeVisitor.walk(x, f)
 }
 
 // WalkTerms calls the function f on all terms under x. If the function f
 // returns true, AST nodes under the last node will not be visited.
 func WalkTerms(x any, f func(*Term) bool) {
-	vis := &GenericVisitor{func(x any) bool {
-		if term, ok := x.(*Term); ok {
-			return f(term)
-		}
-		return false
-	}}
-	vis.Walk(x)
+	termTypeVisitor.walk(x, f)
 }
 
 // WalkWiths calls the function f on all with modifiers under x. If the function f
 // returns true, AST nodes under the last node will not be visited.
 func WalkWiths(x any, f func(*With) bool) {
-	vis := &GenericVisitor{func(x any) bool {
-		if w, ok := x.(*With); ok {
-			return f(w)
-		}
-		return false
-	}}
-	vis.Walk(x)
+	withTypeVisitor.walk(x, f)
 }
 
 // WalkExprs calls the function f on all expressions under x. If the function f
 // returns true, AST nodes under the last node will not be visited.
 func WalkExprs(x any, f func(*Expr) bool) {
-	vis := &GenericVisitor{func(x any) bool {
-		if r, ok := x.(*Expr); ok {
-			return f(r)
-		}
-		return false
-	}}
-	vis.Walk(x)
+	exprTypeVisitor.walk(x, f)
 }
 
 // WalkBodies calls the function f on all bodies under x. If the function f
 // returns true, AST nodes under the last node will not be visited.
 func WalkBodies(x any, f func(Body) bool) {
-	vis := &GenericVisitor{func(x any) bool {
-		if b, ok := x.(Body); ok {
-			return f(b)
-		}
-		return false
-	}}
-	vis.Walk(x)
+	bodyTypeVisitor.walk(x, f)
 }
 
 // WalkRules calls the function f on all rules under x. If the function f
 // returns true, AST nodes under the last node will not be visited.
 func WalkRules(x any, f func(*Rule) bool) {
-	vis := &GenericVisitor{func(x any) bool {
-		if r, ok := x.(*Rule); ok {
-			stop := f(r)
-			// NOTE(tsandall): since rules cannot be embedded inside of queries
-			// we can stop early if there is no else block.
-			if stop || r.Else == nil {
-				return true
+	switch x := x.(type) {
+	case *Module:
+		for i := range x.Rules {
+			if !f(x.Rules[i]) && x.Rules[i].Else != nil {
+				WalkRules(x.Rules[i].Else, f)
 			}
 		}
-		return false
-	}}
-	vis.Walk(x)
+	case *Rule:
+		if !f(x) && x.Else != nil {
+			WalkRules(x.Else, f)
+		}
+	default:
+		ruleTypeVisitor.walk(x, f)
+	}
 }
 
 // WalkNodes calls the function f on all nodes under x. If the function f
 // returns true, AST nodes under the last node will not be visited.
 func WalkNodes(x any, f func(Node) bool) {
-	vis := &GenericVisitor{func(x any) bool {
+	vis := NewGenericVisitor(func(x any) bool {
 		if n, ok := x.(Node); ok {
 			return f(n)
 		}
 		return false
-	}}
+	})
 	vis.Walk(x)
 }
 
-// GenericVisitor provides a utility to walk over AST nodes using a
-// closure. If the closure returns true, the visitor will not walk
-// over AST nodes under x.
-type GenericVisitor struct {
-	f func(x any) bool
+func newTypeVisitor[T any]() *typeVisitor[T] {
+	var t T
+
+	return &typeVisitor[T]{typ: any(t)}
+}
+
+func (tv *typeVisitor[T]) walkArgs(args Args, visit func(x T) bool) {
+	// If T is not Args, avoid allocation by inlining the walk.
+	if _, ok := tv.typ.(Args); !ok {
+		for i := range args {
+			tv.walk(args[i], visit)
+		}
+	} else {
+		tv.walk(args, visit) // allocates
+	}
+}
+
+func (tv *typeVisitor[T]) walkBody(body Body, visit func(x T) bool) {
+	if _, ok := tv.typ.(Body); !ok {
+		for i := range body {
+			tv.walk(body[i], visit)
+		}
+	} else {
+		tv.walk(body, visit) // allocates
+	}
+}
+
+func (tv *typeVisitor[T]) walkRef(ref Ref, visit func(x T) bool) {
+	if _, ok := tv.typ.(Ref); !ok {
+		for i := range ref {
+			tv.walk(ref[i], visit)
+		}
+	} else {
+		tv.walk(ref, visit) // allocates
+	}
+}
+
+func (tv *typeVisitor[T]) walk(x any, visit func(x T) bool) {
+	if v, ok := x.(T); ok && visit(v) {
+		return
+	}
+
+	switch x := x.(type) {
+	case *Module:
+		tv.walk(x.Package, visit)
+		for i := range x.Imports {
+			tv.walk(x.Imports[i], visit)
+		}
+		for i := range x.Rules {
+			tv.walk(x.Rules[i], visit)
+		}
+		for i := range x.Annotations {
+			tv.walk(x.Annotations[i], visit)
+		}
+		for i := range x.Comments {
+			tv.walk(x.Comments[i], visit)
+		}
+	case *Package:
+		tv.walkRef(x.Path, visit)
+	case *Import:
+		tv.walk(x.Path, visit)
+		if _, ok := tv.typ.(Var); ok {
+			tv.walk(x.Alias, visit)
+		}
+	case *Rule:
+		tv.walk(x.Head, visit)
+		tv.walkBody(x.Body, visit)
+		if x.Else != nil {
+			tv.walk(x.Else, visit)
+		}
+	case *Head:
+		if _, ok := tv.typ.(Var); ok {
+			tv.walk(x.Name, visit)
+		}
+		tv.walkArgs(x.Args, visit)
+		if x.Key != nil {
+			tv.walk(x.Key, visit)
+		}
+		if x.Value != nil {
+			tv.walk(x.Value, visit)
+		}
+	case Body:
+		for i := range x {
+			tv.walk(x[i], visit)
+		}
+	case Args:
+		for i := range x {
+			tv.walk(x[i], visit)
+		}
+	case *Expr:
+		switch ts := x.Terms.(type) {
+		case *Term, *SomeDecl, *Every:
+			tv.walk(ts, visit)
+		case []*Term:
+			for i := range ts {
+				tv.walk(ts[i], visit)
+			}
+		}
+		for i := range x.With {
+			tv.walk(x.With[i], visit)
+		}
+	case *With:
+		tv.walk(x.Target, visit)
+		tv.walk(x.Value, visit)
+	case *Term:
+		tv.walk(x.Value, visit)
+	case Ref:
+		for i := range x {
+			tv.walk(x[i], visit)
+		}
+	case *object:
+		x.Foreach(func(k, v *Term) {
+			tv.walk(k, visit)
+			tv.walk(v, visit)
+		})
+	case Object:
+		for _, k := range x.Keys() {
+			tv.walk(k, visit)
+			tv.walk(x.Get(k), visit)
+		}
+	case *Array:
+		for i := range x.Len() {
+			tv.walk(x.Elem(i), visit)
+		}
+	case Set:
+		xSlice := x.Slice()
+		for i := range xSlice {
+			tv.walk(xSlice[i], visit)
+		}
+	case *ArrayComprehension:
+		tv.walk(x.Term, visit)
+		tv.walkBody(x.Body, visit)
+	case *ObjectComprehension:
+		tv.walk(x.Key, visit)
+		tv.walk(x.Value, visit)
+		tv.walkBody(x.Body, visit)
+	case *SetComprehension:
+		tv.walk(x.Term, visit)
+		tv.walkBody(x.Body, visit)
+	case Call:
+		for i := range x {
+			tv.walk(x[i], visit)
+		}
+	case *Every:
+		if x.Key != nil {
+			tv.walk(x.Key, visit)
+		}
+		tv.walk(x.Value, visit)
+		tv.walk(x.Domain, visit)
+		tv.walkBody(x.Body, visit)
+	case *SomeDecl:
+		for i := range x.Symbols {
+			tv.walk(x.Symbols[i], visit)
+		}
+	}
 }
 
 // NewGenericVisitor returns a new GenericVisitor that will invoke the function
-// f on AST nodes.
+// f on AST nodes. Note that while it returns a pointer, the creating a GenericVisitor
+// doesn't commonly allocate it on the heap, as long as it doesn't escape the function
+// in which it is created and used (as it's trivially inlined).
 func NewGenericVisitor(f func(x any) bool) *GenericVisitor {
 	return &GenericVisitor{f}
 }
@@ -310,7 +492,9 @@ func (vis *GenericVisitor) Walk(x any) {
 		vis.Walk(x.Path)
 	case *Import:
 		vis.Walk(x.Path)
-		vis.Walk(x.Alias)
+		if x.Alias != "" {
+			vis.f(x.Alias)
+		}
 	case *Rule:
 		vis.Walk(x.Head)
 		vis.Walk(x.Body)
@@ -318,8 +502,12 @@ func (vis *GenericVisitor) Walk(x any) {
 			vis.Walk(x.Else)
 		}
 	case *Head:
-		vis.Walk(x.Name)
-		vis.Walk(x.Args)
+		if x.Name != "" {
+			vis.f(x.Name)
+		}
+		if x.Args != nil {
+			vis.Walk(x.Args)
+		}
 		if x.Key != nil {
 			vis.Walk(x.Key)
 		}
@@ -400,15 +588,6 @@ func (vis *GenericVisitor) Walk(x any) {
 			vis.Walk(x.Symbols[i])
 		}
 	}
-}
-
-// BeforeAfterVisitor provides a utility to walk over AST nodes using
-// closures. If the before closure returns true, the visitor will not
-// walk over AST nodes under x. The after closure is invoked always
-// after visiting a node.
-type BeforeAfterVisitor struct {
-	before func(x any) bool
-	after  func(x any)
 }
 
 // NewBeforeAfterVisitor returns a new BeforeAndAfterVisitor that
@@ -542,29 +721,27 @@ func (vis *BeforeAfterVisitor) Walk(x any) {
 	}
 }
 
-// VarVisitor walks AST nodes under a given node and collects all encountered
-// variables. The collected variables can be controlled by specifying
-// VarVisitorParams when creating the visitor.
-type VarVisitor struct {
-	params VarVisitorParams
-	vars   VarSet
-}
-
-// VarVisitorParams contains settings for a VarVisitor.
-type VarVisitorParams struct {
-	SkipRefHead     bool
-	SkipRefCallHead bool
-	SkipObjectKeys  bool
-	SkipClosures    bool
-	SkipWithTarget  bool
-	SkipSets        bool
-}
-
-// NewVarVisitor returns a new VarVisitor object.
+// NewVarVisitor returns a new [VarVisitor] object.
 func NewVarVisitor() *VarVisitor {
 	return &VarVisitor{
 		vars: NewVarSet(),
 	}
+}
+
+// ClearOrNewVarVisitor clears a non-nil [VarVisitor] or returns a new one.
+func ClearOrNewVarVisitor(vis *VarVisitor) *VarVisitor {
+	if vis == nil {
+		return NewVarVisitor()
+	}
+
+	return vis.Clear()
+}
+
+// ClearOrNew resets the visitor to its initial state, or returns a new one if nil.
+//
+// Deprecated: use [ClearOrNewVarVisitor] instead.
+func (vis *VarVisitor) ClearOrNew() *VarVisitor {
+	return ClearOrNewVarVisitor(vis)
 }
 
 // Clear resets the visitor to its initial state, and returns it for chaining.
@@ -573,14 +750,6 @@ func (vis *VarVisitor) Clear() *VarVisitor {
 	clear(vis.vars)
 
 	return vis
-}
-
-// ClearOrNew returns a new VarVisitor if vis is nil, or else a cleared VarVisitor.
-func (vis *VarVisitor) ClearOrNew() *VarVisitor {
-	if vis == nil {
-		return NewVarVisitor()
-	}
-	return vis.Clear()
 }
 
 // WithParams sets the parameters in params on vis.
@@ -598,7 +767,7 @@ func (vis *VarVisitor) Add(v Var) {
 	}
 }
 
-// Vars returns a VarSet that contains collected vars.
+// Vars returns a [VarSet] that contains collected vars.
 func (vis *VarVisitor) Vars() VarSet {
 	return vis.vars
 }
@@ -695,9 +864,8 @@ func (vis *VarVisitor) visit(v any) bool {
 	return false
 }
 
-// Walk iterates the AST by calling the function f on the
-// GenericVisitor before recursing. Contrary to the generic Walk, this
-// does not require allocating the visitor from heap.
+// Walk iterates the AST by calling the function f on the [VarVisitor] before recursing.
+// Contrary to the deprecated [Walk] function, this does not require allocating the visitor from heap.
 func (vis *VarVisitor) Walk(x any) {
 	if vis.visit(x) {
 		return
@@ -705,15 +873,8 @@ func (vis *VarVisitor) Walk(x any) {
 
 	switch x := x.(type) {
 	case *Module:
-		vis.Walk(x.Package)
-		for i := range x.Imports {
-			vis.Walk(x.Imports[i])
-		}
 		for i := range x.Rules {
 			vis.Walk(x.Rules[i])
-		}
-		for i := range x.Comments {
-			vis.Walk(x.Comments[i])
 		}
 	case *Package:
 		vis.WalkRef(x.Path)
@@ -767,9 +928,9 @@ func (vis *VarVisitor) Walk(x any) {
 			vis.Walk(x[i].Value)
 		}
 	case *object:
-		x.Foreach(func(k, _ *Term) {
+		x.Foreach(func(k, v *Term) {
 			vis.Walk(k)
-			vis.Walk(x.Get(k))
+			vis.Walk(v)
 		})
 	case *Array:
 		x.Foreach(func(t *Term) {

--- a/v1/ast/visit_bench_test.go
+++ b/v1/ast/visit_bench_test.go
@@ -49,3 +49,58 @@ func BenchmarkVarSetUpdateEmpty(b *testing.B) {
 		}
 	}
 }
+
+// This benchmark demonstratesthe cost of walking "blindly", i.e. across
+// all nodes even when most of them can't contain what we're looking for.
+// While the TypeVisitor is much more efficient even in a default walk, the
+// difference becomes massive when walking nodes selectively. The downside
+// is there'll be a lot more code needed for type-specific visitors.
+//
+// GenericVisitor-16              879.1 ns/op     624 B/op     30 allocs/op
+// TypeVisitor_term-16            475.5 ns/op       0 B/op      0 allocs/op
+// TypeVisitor_via_WalkRules-16   16.11 ns/op       0 B/op      0 allocs/op
+func BenchmarkGenericVisitorWalkVsTypeVisitor(b *testing.B) {
+	mod := module(`package ex.this
+
+import input.foo
+import data.bar.this as qux
+import future.keywords.every
+
+p = true if { "this" = "that" }
+p = "this" if { false }
+p contains "this" if { false }
+p[y] = {"this": ["this"]} if { false }
+p = true if { ["this" | "this"] }
+p = n if { count({"this", "that"}, n) with input.foo.this as {"this": true} }
+p if { false } else = "this" if { "this" } else = ["this"] if { true }
+foo(x) = y if { split(x, "this", y) }
+p if { every x in ["this"] { x == "this" } }
+a.b.c.this["this"] = d if { d := "this" }
+`)
+
+	b.Run("GenericVisitor", func(b *testing.B) {
+		vis := NewGenericVisitor(func(x any) bool {
+			return false
+		})
+
+		for b.Loop() {
+			vis.Walk(mod)
+		}
+	})
+
+	b.Run("TypeVisitor term", func(b *testing.B) {
+		for b.Loop() {
+			termTypeVisitor.walk(mod, func(x *Term) bool {
+				return false
+			})
+		}
+	})
+
+	b.Run("TypeVisitor via WalkRules", func(b *testing.B) {
+		for b.Loop() {
+			WalkRules(mod, func(r *Rule) bool {
+				return false
+			})
+		}
+	})
+}

--- a/v1/ast/visit_test.go
+++ b/v1/ast/visit_test.go
@@ -40,7 +40,7 @@ fn([x, y]) = z if { json.unmarshal(x, z); z > y }
 	vis := &testVis{}
 	NewGenericVisitor(vis.Visit).Walk(rule)
 
-	if exp, act := 254, len(vis.elems); exp != act {
+	if exp, act := 252, len(vis.elems); exp != act {
 		t.Errorf("Expected exactly %d elements in AST but got %d: %v", exp, act, vis.elems)
 	}
 }
@@ -60,7 +60,7 @@ p := 7`, ParserOptions{ProcessAnnotation: true})
 
 	NewGenericVisitor(vis.Visit).Walk(module)
 
-	exp := 20
+	exp := 19
 
 	if len(vis.elems) != exp {
 		t.Fatalf("expected %d elements but got %v: %v", exp, len(vis.elems), vis.elems)
@@ -107,7 +107,7 @@ fn([x, y]) = z if { json.unmarshal(x, z); z > y }
 	})
 	vis.Walk(rule)
 
-	if len(elems) != 254 {
+	if len(elems) != 252 {
 		t.Errorf("Expected exactly 254 elements in AST but got %d: %v", len(elems), elems)
 	}
 }

--- a/v1/topdown/bindings.go
+++ b/v1/topdown/bindings.go
@@ -216,16 +216,25 @@ func (vis namespacingVisitor) Visit(x any) bool {
 	switch x := x.(type) {
 	case *ast.ArrayComprehension:
 		x.Term = vis.namespaceTerm(x.Term)
-		ast.NewGenericVisitor(vis.Visit).Walk(x.Body)
+		vis := ast.NewGenericVisitor(vis.Visit)
+		for _, expr := range x.Body {
+			vis.Walk(expr)
+		}
 		return true
 	case *ast.SetComprehension:
 		x.Term = vis.namespaceTerm(x.Term)
-		ast.NewGenericVisitor(vis.Visit).Walk(x.Body)
+		vis := ast.NewGenericVisitor(vis.Visit)
+		for _, expr := range x.Body {
+			vis.Walk(expr)
+		}
 		return true
 	case *ast.ObjectComprehension:
 		x.Key = vis.namespaceTerm(x.Key)
 		x.Value = vis.namespaceTerm(x.Value)
-		ast.NewGenericVisitor(vis.Visit).Walk(x.Body)
+		vis := ast.NewGenericVisitor(vis.Visit)
+		for _, expr := range x.Body {
+			vis.Walk(expr)
+		}
 		return true
 	case *ast.Expr:
 		switch terms := x.Terms.(type) {


### PR DESCRIPTION
Or something in that ballpark. This is accomplished by tweaking existing walk/visitor implementations where appropriate, and by introducing a new visitor type that while more limited, is able to perform much better where it can be used. Most impressive of the improvements here is the new `WalkRules` implementation, as the benchmark included in this change shows. The most impactful change is however the improved use of the various `VarVisitor`s used during the compilation process.

Compiling the Regal bundle:

**OPA v1.11.0 (main)**
```
67207511 ns/op  42652069 B/op    1032387 allocs/op
```

**Now**
```
62502125 ns/op  35918354 B/op     929634 allocs/op
```