### PR TITLE
ast/compile: deal with error limit without  panic/defer

### DIFF
--- a/v1/ast/errors.go
+++ b/v1/ast/errors.go
@@ -121,9 +121,13 @@ func (e *Error) Error() string {
 
 // NewError returns a new Error object.
 func NewError(code string, loc *Location, f string, a ...any) *Error {
+	return newErrorString(code, loc, fmt.Sprintf(f, a...))
+}
+
+func newErrorString(code string, loc *Location, m string) *Error {
 	return &Error{
 		Code:     code,
 		Location: loc,
-		Message:  fmt.Sprintf(f, a...),
+		Message:  m,
 	}
 }


### PR DESCRIPTION
```
goos: darwin
goarch: arm64
pkg: github.com/open-policy-agent/regal/pkg/linter cpu: Apple M4 Max
               │ ../scratch/main.bench │        ../scratch/pr.bench         │
               │        sec/op         │   sec/op     vs base               │
OnlyPrepare-16             63.22m ± 1%   59.72m ± 0%  -5.54% (p=0.000 n=10)

               │ ../scratch/main.bench │         ../scratch/pr.bench          │
               │         B/op          │     B/op      vs base                │
OnlyPrepare-16            41.82Mi ± 0%   35.36Mi ± 0%  -15.45% (p=0.000 n=10)

               │ ../scratch/main.bench │         ../scratch/pr.bench         │
               │       allocs/op       │  allocs/op   vs base                │
OnlyPrepare-16            1025.3k ± 0%   920.6k ± 0%  -10.21% (p=0.000 n=10)
```

I don't know which of our benchmarks would best prove this.... but that's looks pretty decent ☝️ 

Why? Prep work for getting some concurrency in the compiler. Waitgroup and friends don't like panics.