### PR TITLE
topdown: use sink for concat()

### DIFF
--- a/v1/ast/builtins.go
+++ b/v1/ast/builtins.go
@@ -1109,7 +1109,7 @@ var Concat = &Builtin{
 		types.Named("output", types.S).Description("the joined string"),
 	),
 	Categories:  stringsCat,
-	CanSkipBctx: true,
+	CanSkipBctx: false,
 }
 
 var FormatInt = &Builtin{

--- a/v1/topdown/sink.go
+++ b/v1/topdown/sink.go
@@ -10,6 +10,9 @@ var _ io.Writer = (*sinkW)(nil)
 type sinkWriter interface {
 	io.Writer
 	String() string
+	Grow(int)
+	WriteByte(byte) error
+	WriteString(string) (int, error)
 }
 
 type sinkW struct {
@@ -35,11 +38,29 @@ func newSink(name string, hint int, c Cancel) sinkWriter {
 	}
 }
 
+func (sw *sinkW) Grow(n int) {
+	sw.buf.Grow(n)
+}
+
 func (sw *sinkW) Write(bs []byte) (int, error) {
 	if sw.cancel != nil && sw.cancel.Cancelled() {
 		return 0, sw.err
 	}
 	return sw.buf.Write(bs)
+}
+
+func (sw *sinkW) WriteByte(b byte) error {
+	if sw.cancel != nil && sw.cancel.Cancelled() {
+		return sw.err
+	}
+	return sw.buf.WriteByte(b)
+}
+
+func (sw *sinkW) WriteString(s string) (int, error) {
+	if sw.cancel != nil && sw.cancel.Cancelled() {
+		return 0, sw.err
+	}
+	return sw.buf.WriteString(s)
 }
 
 func (sw *sinkW) String() string {


### PR DESCRIPTION
The builtin should be cancellable even when used with really large inputs now.