### PR TITLE
website: Add support for rego string interpolation

### DIFF
--- a/docs/src/theme/prism-include-languages.js
+++ b/docs/src/theme/prism-include-languages.js
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * This file was swizzled to provide custom Rego language highlighting.
+ *
+ * To recreate this swizzle:
+ * npx docusaurus swizzle @docusaurus/theme-classic prism-include-languages --eject
+ *
+ * Modifications:
+ * - Add custom formatting for Rego language with string interpolation
+ */
+
+import siteConfig from "@generated/docusaurus.config";
+import regoLanguage from "./prism-rego";
+
+export default function prismIncludeLanguages(PrismObject) {
+  const {
+    themeConfig: { prism },
+  } = siteConfig;
+  const { additionalLanguages } = prism;
+
+  globalThis.Prism = PrismObject;
+
+  additionalLanguages.forEach((lang) => {
+    // skip rego since we're using our custom implementation
+    if (lang === "rego") {
+      return;
+    }
+
+    try {
+      require(`prismjs/components/prism-${lang}`);
+    } catch (error) {
+      console.warn(`Prism language '${lang}' not found.`);
+    }
+  });
+
+  regoLanguage(PrismObject);
+
+  delete globalThis.Prism;
+}

--- a/docs/src/theme/prism-rego.js
+++ b/docs/src/theme/prism-rego.js
@@ -1,0 +1,115 @@
+// Custom Rego language definition for Prism.js
+// Based on rego.tmLanguage from the OPA repository
+//
+// Note: As of December 2025, https://github.com/PrismJS/prism is not accepting
+// language updates until they cut v2, so we maintain our own custom definition here.
+
+export default function(Prism) {
+  Prism.languages.rego = {
+    "comment": {
+      pattern: /#.*/,
+      greedy: true,
+    },
+
+    // Keywords from tmLanguage: default, not, package, import, as, with, else, some, in, every, if, contains
+    "keyword": {
+      pattern: /\b(?:default|not|package|import|as|with|else|some|in|every|if|contains)\b/,
+      greedy: true,
+    },
+
+    // Boolean and null constants
+    "boolean": /\b(?:true|false)\b/,
+    "null": /\bnull\b/,
+
+    // Template/interpolated strings
+    "template-string": {
+      pattern: /\$`(?:[^`\\]|\\[\s\S])*`/,
+      greedy: true,
+      inside: {
+        "interpolation": {
+          pattern: /\{[^}]+\}/,
+          inside: {
+            "interpolation-punctuation": {
+              pattern: /^\{|\}$/,
+              alias: "punctuation",
+            },
+            rest: null, // Will be populated later
+          },
+        },
+        "string": /[\s\S]/,
+      },
+    },
+
+    // Interpolated double quoted strings
+    "interpolated-string": {
+      pattern: /\$"(?:[^"\\]|\\[\s\S])*"/,
+      greedy: true,
+      inside: {
+        "interpolation": {
+          pattern: /\{[^}]+\}/,
+          inside: {
+            "interpolation-punctuation": {
+              pattern: /^\{|\}$/,
+              alias: "punctuation",
+            },
+            rest: null, // Will be populated later
+          },
+        },
+        "escape": /\\(?:["\\\/bfnrt]|u[0-9a-fA-F]{4})/,
+        "string": /[\s\S]/,
+      },
+    },
+
+    // Regular strings
+    "string": [
+      {
+        pattern: /"(?:[^"\\]|\\[\s\S])*"/,
+        greedy: true,
+        inside: {
+          "escape": /\\(?:["\\\/bfnrt]|u[0-9a-fA-F]{4})/,
+        },
+      },
+      {
+        pattern: /`[^`]*`/,
+        greedy: true,
+      },
+    ],
+
+    // Function calls
+    "function": {
+      pattern: /\b[a-zA-Z_][a-zA-Z0-9_]*(?:\s*\.\s*[a-zA-Z_][a-zA-Z0-9_]*)*(?=\s*\()/,
+      inside: {
+        "namespace": {
+          pattern: /\b\w+\b(?=\s*\.)/,
+          alias: "punctuation",
+        },
+        "punctuation": /\./,
+      },
+    },
+
+    // Numbers (including scientific notation)
+    "number": {
+      pattern: /-?\b\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\b/,
+      greedy: true,
+    },
+
+    // Variables and identifiers
+    "variable": {
+      pattern: /\b[a-zA-Z_][a-zA-Z0-9_]*\b/,
+      greedy: true,
+    },
+
+    // Comparison and arithmetic operators
+    "operator": /==|!=|<=|>=|[<>+\-*/%|&]|:=|=/,
+
+    // Assignment operators
+    "assignment": /:=|=/,
+
+    // Punctuation
+    "punctuation": /[;,.\[\]{}()]/,
+  };
+
+  // Copy the main language definition to interpolation rest for recursive parsing
+  Prism.languages.rego["template-string"].inside["interpolation"].inside.rest = Prism.languages.rego;
+  Prism.languages.rego["interpolated-string"].inside["interpolation"].inside.rest = Prism.languages.rego;
+}


### PR DESCRIPTION
This adds a custom rego theme for prism since they are not accepting mainline updates right now.

Example in light and dark

<img width="626" height="369" alt="Screenshot 2025-12-01 at 11 52 37" src="https://github.com/user-attachments/assets/ea540937-1dee-4386-9b04-e577b2892a9d" />



<img width="503" height="348" alt="Screenshot 2025-12-01 at 11 52 45" src="https://github.com/user-attachments/assets/fdf8b0e5-26ed-416a-87b6-d5f98638329e" />
