### PR TITLE
experiment: per-module fan-out in compiler stages

### DIFF
--- a/v1/ast/compile_test.go
+++ b/v1/ast/compile_test.go
@@ -736,7 +736,6 @@ func TestRuleTreeWithDotsInHeads(t *testing.T) {
 			c := NewCompiler()
 			for i, m := range tc.modules {
 				c.Modules[strconv.Itoa(i)] = m
-				c.sorted = append(c.sorted, strconv.Itoa(i))
 			}
 			compileStages(c, c.setRuleTree)
 			if len(c.Errors) > 0 {
@@ -815,7 +814,6 @@ func TestRuleIndices(t *testing.T) {
 			c := NewCompiler()
 			for i, m := range tc.modules {
 				c.Modules[strconv.Itoa(i)] = m
-				c.sorted = append(c.sorted, strconv.Itoa(i))
 			}
 			compileStages(c, c.buildRuleIndices)
 

--- a/v1/topdown/topdown_test.go
+++ b/v1/topdown/topdown_test.go
@@ -277,7 +277,7 @@ func TestTopDownQueryCancellationEvery(t *testing.T) {
 			t.Parallel()
 
 			compiler := ast.NewCompiler().WithEnablePrintStatements(true)
-			compiler.Compile(map[string]*ast.Module{"test.rego": tc.module})
+			compiler.Compile(map[string]*ast.Module{"test.rego": tc.module.Copy()})
 			if compiler.Failed() {
 				t.Fatalf("compiler: %v", compiler.Errors)
 			}


### PR DESCRIPTION
Adapted to what we've merged since my previous experiment. Notable changes:

1. If there's only one module, don't bother with goroutines.
2. Less sloppy handling of booleans set in the stages -- they're all (🤞) atomic.Bools now.
3. None of the grouping bits I had experimented with in #8063. It's working, but it's so much more cumbersome for little effect.
4. It's using errgroup -- not because it would return an error, but because it's almost like waitgroup.Go() but without having to bump the lower bound golang version.

Supersedes #8063.