### PR TITLE
docs: Document metrics for http.send, regex, and glob builtins

### DIFF
--- a/docs/docs/policy-reference/builtins/glob.mdx
+++ b/docs/docs/policy-reference/builtins/glob.mdx
@@ -77,3 +77,11 @@ The following table shows examples of how `glob.match` works:
 | `output := glob.match("{cat,bat,[fr]at}", [], "bat")`            | `true`   | A glob with pattern-alternatives matchers.    |
 | `output := glob.match("{cat,bat,[fr]at}", [], "rat")`            | `true`   | A glob with pattern-alternatives matchers.    |
 | `output := glob.match("{cat,bat,[fr]at}", [], "at")`             | `false`  | A glob with pattern-alternatives matchers.    |
+
+## Performance Metrics
+
+When `?metrics=true` is specified in API requests, `glob.match` operations expose the following per-query metrics:
+
+| Metric | Description |
+| ------ | ----------- |
+| `counter_rego_builtin_glob_interquery_value_cache_hits` | Number of compiled glob patterns served from the inter-query value cache. Only present when [inter-query value caching](/docs/configuration/#caching) is enabled and a previously compiled pattern is reused |

--- a/docs/docs/policy-reference/builtins/http.mdx
+++ b/docs/docs/policy-reference/builtins/http.mdx
@@ -113,3 +113,13 @@ The table below shows examples of calling `http.send`:
 | Files containing TLS material                 | `http.send({"method": "get", "url": "https://127.0.0.1:65331", "tls_ca_cert_file": "testdata/ca.pem", "tls_client_cert_file": "testdata/client-cert.pem", "tls_client_key_file": "testdata/client-key.pem"})`     |
 | Environment variables containing TLS material | `http.send({"method": "get", "url": "https://127.0.0.1:65360", "tls_ca_cert_env_variable": "CLIENT_CA_ENV", "tls_client_cert_env_variable": "CLIENT_CERT_ENV", "tls_client_key_env_variable": "CLIENT_KEY_ENV"})` |
 | Unix Socket URL Format                        | `http.send({"method": "get", "url": "unix://localhost/?socket=%F2path%F2file.socket"})`                                                                                                                           |
+
+## Performance Metrics
+
+When `?metrics=true` is specified in API requests, `http.send` operations expose the following per-query metrics:
+
+| Metric | Description |
+| ------ | ----------- |
+| `timer_rego_builtin_http_send_ns` | Total time spent in `http.send` calls during query evaluation |
+| `counter_rego_builtin_http_send_interquery_cache_hits` | Number of inter-query cache hits for `http.send` requests. Only appears when [inter-query caching is enabled](/docs/configuration/#caching) in OPA's configuration and the `http.send` request configuration has `cache` or `force_cache` set to `true` |
+| `counter_rego_builtin_http_send_network_requests` | Number of actual network requests made, excluding cached responses |

--- a/docs/docs/policy-reference/builtins/regex.mdx
+++ b/docs/docs/policy-reference/builtins/regex.mdx
@@ -110,3 +110,11 @@ overlap. This can be useful when using patterns to define permissions or access 
 rules. The function returns `true` if the two patterns overlap and `false` otherwise.
 
 <PlaygroundExample dir={require.context('../_examples/regex/globs_match/role_patterns')} />
+
+## Performance Metrics
+
+When `?metrics=true` is specified in API requests, regex operations expose the following per-query metrics:
+
+| Metric | Description |
+| ------ | ----------- |
+| `counter_rego_builtin_regex_interquery_value_cache_hits` | Number of compiled regex patterns served from the inter-query value cache. Only present when [inter-query value caching](/docs/configuration/#caching) is enabled and a previously compiled pattern is reused |


### PR DESCRIPTION
This PR addresses issue #6730 and the feedback from the closed PR #7929.

The original PR attempted to create a comprehensive metrics registry documenting all OPA metrics. After review, that approach was too broad - it created maintenance overhead and put documentation in places where users wouldn't naturally look for it.

This PR takes a simpler approach: document metrics right where users need them - on the builtin reference pages themselves. When someone is reading about `http.send`, they can scroll down and see exactly what metrics it exposes. Same for `regex` and `glob`.

Added Performance Metrics sections to three builtin pages:

- **http.send** - Timer for execution time, counter for cache hits, counter for actual network requests (helps distinguish cached vs real requests)
- **regex** - Cache hit counter that tracks when compiled patterns are reused  
- **glob.match** - Cache hit counter for compiled glob patterns

These are the most commonly used builtins that expose their own metrics. Also clarified the REST API docs to explain what additional metrics you get when you enable `instrument=true`.

Following reviewer feedback, this PR intentionally does NOT create a comprehensive registry, add a generator tool, or update monitoring.md/policy-performance.md. Those can be addressed separately if needed.

Fixes #6730