### PR TITLE
perf: avoid extra allocation in sink if no cancel

### DIFF
--- a/v1/rego/rego.go
+++ b/v1/rego/rego.go
@@ -2212,7 +2212,7 @@ func (r *Rego) compileQuery(query ast.Body, imports []*ast.Import, _ metrics.Met
 
 	if r.pkg != "" {
 		var err error
-		pkg, err = ast.ParsePackage(fmt.Sprintf("package %v", r.pkg))
+		pkg, err = ast.ParsePackage("package " + r.pkg)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/v1/topdown/sink.go
+++ b/v1/topdown/sink.go
@@ -26,6 +26,11 @@ func newSink(name string, hint int, c Cancel) sinkWriter {
 	if hint > 0 {
 		b.Grow(hint)
 	}
+
+	if c == nil {
+		return b
+	}
+
 	return &sinkW{
 		cancel: c,
 		buf:    b,
@@ -43,21 +48,21 @@ func (sw *sinkW) Grow(n int) {
 }
 
 func (sw *sinkW) Write(bs []byte) (int, error) {
-	if sw.cancel != nil && sw.cancel.Cancelled() {
+	if sw.cancel.Cancelled() {
 		return 0, sw.err
 	}
 	return sw.buf.Write(bs)
 }
 
 func (sw *sinkW) WriteByte(b byte) error {
-	if sw.cancel != nil && sw.cancel.Cancelled() {
+	if sw.cancel.Cancelled() {
 		return sw.err
 	}
 	return sw.buf.WriteByte(b)
 }
 
 func (sw *sinkW) WriteString(s string) (int, error) {
-	if sw.cancel != nil && sw.cancel.Cancelled() {
+	if sw.cancel.Cancelled() {
 		return 0, sw.err
 	}
 	return sw.buf.WriteString(s)


### PR DESCRIPTION
Which also allows skipping the nil checks in the various write functions.
