### PR TITLE
docs/ocp: update "concepts" for v0.2.0

### DIFF
--- a/docs/docs/ocp/concepts.md
+++ b/docs/docs/ocp/concepts.md
@@ -289,7 +289,7 @@ import rego.v1
 
 main if {
   data.service.allow
-  not data.globalsecurity.deny
+  not data.mandatory.globalsecurity.deny
 }
 ```
 
@@ -302,22 +302,19 @@ bundles:
       environment: prod
     requirements:
     - source: petshop-svc
-    options:
-      no_default_stack_mount: true
   notifications-svc:
     labels:
       environment: prod
     requirements:
     - source: notifications-svc
-    options:
-      no_default_stack_mount: true
 
 stacks:
-  globalsecurity:
+  mandatory:
     selector:
       environment: [prod]
     requirements:
     - source: main
+      automount: false
     - source: globalsecurity
 
 sources:


### PR DESCRIPTION
The stack automounting [introduced in OCP v0.2.0](https://github.com/open-policy-agent/opa-control-plane/releases/tag/v0.2.0) made the example break. Since it's only been a sketch in the first place, this made it harder for people to follow.

How, a more complete version of this is a test case in OCP: https://github.com/open-policy-agent/opa-control-plane/pull/215 and https://github.com/open-policy-agent/opa-control-plane/pull/216/changes#diff-fc3d30eded2083b2e46e942b801fe5a7545b3fba09bdcf3e8f47bb29a7d0e2fd.

In a follow-up, we'll most likely update the docs to use stack auto- mounting, and document that.
