### PR TITLE
workflow: integrate benchmarks notebook

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -65,10 +65,9 @@ jobs:
       contents: write # we'll push to the `benchmarks` branch
     name: Benchmarks
     needs: check-changes
-    if: ${{ needs.check-changes.outputs.go == 'true' }} && ${{ github.actor != 'dependabot[bot]' }}
+    if: ${{ needs.check-changes.outputs.go == 'true' }}
     runs-on: ubuntu-24.04
     steps:
-      - uses: open-policy-agent/setup-opa@950f159a49aa91f9323f36f1de81c7f6b5de9576 # v2.3.0
       - name: Check out code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
@@ -91,3 +90,41 @@ jobs:
           INPUT_PUBLISH_BRANCH: benchmarks
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         timeout-minutes: 120
+
+  notebook:
+    permissions:
+      contents: write # we'll push to the `benchmarks` branch
+    name: update notebook
+    runs-on: ubuntu-24.04
+    needs: [check-changes, benchmarks] # force sequential commits for notebook and benchmark results
+    if: ${{ needs.check-changes.outputs.go == 'true' }}
+    steps:
+      - uses: open-policy-agent/setup-opa@950f159a49aa91f9323f36f1de81c7f6b5de9576 # v2.3.0
+      - name: Check out code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          ref: benchmarks
+      - name: Install Node
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+      - name: update notebook
+        run: |
+          npm ci
+          cp ../benchmarks.json . # nodejs data loader can't access ../
+          npm run docs:build
+          rm benchmarks.json
+        working-directory: src/
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: commit if changed
+        working-directory: benchmarks/ # output dir of the docs:build command
+        run: |
+          if ! git diff-index --quiet HEAD -- .; then
+            git config --local user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+            git config --local user.name "${GITHUB_ACTOR}"
+            git add -f .
+            git diff --staged
+            git commit -m "benchmarks: update notebook for ${GITHUB_SHA}"
+            git push origin benchmarks
+          else
+            echo "no changes, no commit"
+          fi


### PR DESCRIPTION
This will bring an extra commit to the benchmarks branch, as that's the way to do gh-pages deployments.
