### PR TITLE
benchmarks: install node v24

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -106,6 +106,8 @@ jobs:
           ref: benchmarks
       - name: Install Node
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+        with:
+          node-version: 24
       - name: update notebook
         run: |
           npm ci


### PR DESCRIPTION
Because that's what notebook-kit expects.