### PR TITLE
[template] removes hard-coded missing key error

### DIFF
--- a/v1/test/cases/testdata/v0/rendertemplate/rendertemplate.yaml
+++ b/v1/test/cases/testdata/v0/rendertemplate/rendertemplate.yaml
@@ -45,5 +45,20 @@ cases:
         template_string = `{{.testvarnotprovided}}`
         template_vars = {`test`: `hello world`}
         p = strings.render_template(template_string, template_vars)
-    want_error_code: eval_builtin_error
+    want_result:
+      - x: <undefined>
+    strict_error: true
+  - note: rendertemplate/missingmultiplekeys
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        template_string := `test {{.foo}} {{.bar}} {{.baz}}`
+
+        template_vars := {`baz`: 1}
+
+        p := strings.render_template(template_string, template_vars)
+    want_result:
+      - x: test <undefined> <undefined> 1
     strict_error: true

--- a/v1/test/cases/testdata/v1/rendertemplate/rendertemplate.yaml
+++ b/v1/test/cases/testdata/v1/rendertemplate/rendertemplate.yaml
@@ -50,5 +50,20 @@ cases:
         template_vars := {`test`: `hello world`}
 
         p := strings.render_template(template_string, template_vars)
-    want_error_code: eval_builtin_error
+    want_result:
+      - x: <undefined>
+    strict_error: true
+  - note: rendertemplate/missingmultiplekeys
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        template_string := `test {{.foo}} {{.bar}} {{.baz}}`
+
+        template_vars := {`baz`: 1}
+
+        p := strings.render_template(template_string, template_vars)
+    want_result:
+      - x: test <undefined> <undefined> 1
     strict_error: true

--- a/v1/topdown/template.go
+++ b/v1/topdown/template.go
@@ -2,6 +2,7 @@ package topdown
 
 import (
 	"bytes"
+	"strings"
 	"text/template"
 
 	"github.com/open-policy-agent/opa/v1/ast"
@@ -30,14 +31,13 @@ func renderTemplate(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term)
 		return err
 	}
 
-	// Do not attempt to render if template variable keys are missing
-	tmpl.Option("missingkey=error")
 	var buf bytes.Buffer
 	if err := tmpl.Execute(&buf, templateVariables); err != nil {
 		return err
 	}
 
-	return iter(ast.StringTerm(buf.String()))
+	res := strings.ReplaceAll(buf.String(), "<no value>", "<undefined>")
+	return iter(ast.StringTerm(res))
 }
 
 func init() {


### PR DESCRIPTION
### Why the changes in this PR are needed?

Current implementation of `render_template` passes in an explicit `missingkey=error` option when rendering a Golang template. That's not the default behavior for Golang, so it's an unexpected result. See #7931 for more detail.

### What are the changes in this PR?

This PR removes the hard-coded `missingkey=error` option, giving way to the default template parsing behavior built into Golang.

### Notes to assist PR review:

See updated tests for example output.

### Further comments:

This is admittedly a breaking change. I'm not sure how widely used the `render_template` function is, and what the risk is of impacting existing implementations. If the risk is seen as problematic, I'd be happy to close this PR or modify the implementation.
