### PR TITLE
Fixing failing benchmarks

### DIFF
--- a/internal/wasm/sdk/opa/opa_bench_test.go
+++ b/internal/wasm/sdk/opa/opa_bench_test.go
@@ -113,7 +113,7 @@ func benchmarkIteration(b *testing.B, module string) {
 		if err != nil {
 			b.Fatalf("Unexpected query error: %v", err)
 		}
-		if string(r.Result) != `{{"x":true}}` {
+		if string(r.Result) != `{{"x": true}}` {
 			b.Errorf("unexpected result: %s", string(r.Result))
 		}
 	}


### PR DESCRIPTION
caused by string-interpolation changes.

https://github.com/open-policy-agent/opa/actions/runs/20265242799/job/58187653450#step:3:770
