### PR TITLE
fix(util): enforce gzip decompression limits

### DIFF
--- a/v1/server/server_test.go
+++ b/v1/server/server_test.go
@@ -2108,7 +2108,7 @@ func TestDataPostV1CompressedDecodingLimits(t *testing.T) {
 			payload:               mustGZIPPayload([]byte(`{"input": {"user": "alice"}}`)),
 			expRespHTTPStatus:     400,
 			forcePayloadSizeField: 134217728, // 128 MB
-			expErrorMsg:           "gzip payload too large",
+			expErrorMsg:           "gzip: invalid checksum",
 			gzipMaxLen:            1024,
 		},
 		{
@@ -2118,7 +2118,7 @@ func TestDataPostV1CompressedDecodingLimits(t *testing.T) {
 			payload:               mustGZIPPayload([]byte(`{"input": {"user": "alice"}}`)),
 			expRespHTTPStatus:     400,
 			forcePayloadSizeField: 134217728, // 128 MB
-			expErrorMsg:           "gzip payload too large",
+			expErrorMsg:           "gzip: invalid checksum",
 			gzipMaxLen:            1024,
 		},
 		{

--- a/v1/util/read_gzip_body_test.go
+++ b/v1/util/read_gzip_body_test.go
@@ -3,6 +3,7 @@ package util_test
 import (
 	"bytes"
 	"compress/gzip"
+	"encoding/binary"
 	"net/http/httptest"
 	"testing"
 
@@ -13,31 +14,72 @@ import (
 func TestReadMaybeCompressedBody(t *testing.T) {
 	t.Parallel()
 
-	exp := []byte(`{"input": {"foo": "bar"}}`)
-
-	bb := new(bytes.Buffer)
-	gz := gzip.NewWriter(bb)
-	if _, err := gz.Write(exp); err != nil {
-		t.Fatal(err)
+	tests := []struct {
+		name          string
+		payload       []byte
+		forgedSize    uint32 // If > 0, overwrite trailer with this size
+		limit         int64
+		expectedError string
+	}{
+		{
+			name:          "valid payload",
+			payload:       []byte(`{"input": {"foo": "bar"}}`),
+			limit:         200,
+			expectedError: "",
+		},
+		{
+			name:          "forged small trailer, actual content larger",
+			payload:       bytes.Repeat([]byte("a"), 100),
+			forgedSize:    50,
+			limit:         200,
+			expectedError: "gzip: invalid checksum",
+		},
+		{
+			name:          "content exceeds limit",
+			payload:       bytes.Repeat([]byte("a"), 300),
+			limit:         200,
+			expectedError: "gzip payload too large",
+		},
 	}
-	if err := gz.Close(); err != nil {
-		t.Fatal(err)
-	}
-	compressed := bb.Bytes()
 
-	ctx := decoding.AddServerDecodingGzipMaxLen(decoding.AddServerDecodingMaxLen(t.Context(), 200), 200)
-	req := httptest.NewRequestWithContext(ctx, "POST", "/v1/data/test", bytes.NewReader(compressed))
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			bb := new(bytes.Buffer)
+			gz := gzip.NewWriter(bb)
+			if _, err := gz.Write(tc.payload); err != nil {
+				t.Fatal(err)
+			}
+			if err := gz.Close(); err != nil {
+				t.Fatal(err)
+			}
+			compressed := bb.Bytes()
 
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Content-Encoding", "gzip")
+			if tc.forgedSize > 0 {
+				binary.LittleEndian.PutUint32(compressed[len(compressed)-4:], tc.forgedSize)
+			}
 
-	got, err := util.ReadMaybeCompressedBody(req)
-	if err != nil {
-		t.Fatal(err)
-	}
+			ctx := decoding.AddServerDecodingGzipMaxLen(decoding.AddServerDecodingMaxLen(t.Context(), tc.limit), tc.limit)
+			req := httptest.NewRequestWithContext(ctx, "POST", "/v1/data/test", bytes.NewReader(compressed))
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Content-Encoding", "gzip")
 
-	if !bytes.Equal(got, exp) {
-		t.Fatalf("Expected %q, got: %q", exp, got)
+			got, err := util.ReadMaybeCompressedBody(req)
+			if tc.expectedError != "" {
+				if err == nil {
+					t.Fatal("Expected error, got nil")
+				}
+				if err.Error() != tc.expectedError {
+					t.Fatalf("Expected error %q, got: %v", tc.expectedError, err)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("Expected no error, got: %v", err)
+				}
+				if !bytes.Equal(got, tc.payload) {
+					t.Fatalf("Expected %q, got: %q", tc.payload, got)
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
### Why the changes in this PR are needed?

This PR fixes a potential denial-of-service vector caused by memory exhaustion when handling gzip-compressed request bodies in the OPA server. The previous implementation trusted the gzip trailer size (`ISIZE`) as-is to pre-allocate memory for decompression. A forged small payload with a large trailer size would cause the server to allocate excessive memory and potentially crash (OOM).

### What are the changes in this PR?

`ReadMaybeCompressedBody` no longer pre-allocates memory based on the gzip trailer. The maximum gzip size limit is enforced through `io.LimitReader` during the decompression stream. The limit is still based on `server-decoding-plugin-context-gzip-max-length` context key as previously. Initial memory allocation for the decompression buffer is based on the compressed content length, with dynamic growth as needed.

### Notes to assist PR review:

The `io.LimitReader` is initialized with `gzipMaxLength + 1` to allow distinguishing between "exactly the limit" (success) and "exceeds the limit" (error) in cases where `Read` might return `EOF` exactly at the limit.

The failure mode for forged trailers changes from a potential OOM to a `gzip: invalid checksum` error, as the `gzip.Reader` will eventually validate the footer against the actual decompressed stream and find the mismatch.

The error message for requests with forged gzip trailers has changed from `gzip payload too large` to `gzip: invalid checksum`. This is because we no longer trust the trailer size for pre-allocation. Instead, we stream the decompression and only fail if the actual content limit is exceeded (which triggers the size error) or if the trailer checksum/size does not match the content (which triggers the checksum error, as seen here).

### Further comments:

This change is backwards compatible.