### PR TITLE
fix(status): race in TestStatusUpdateBuffer

### DIFF
--- a/v1/plugins/status/plugin_test.go
+++ b/v1/plugins/status/plugin_test.go
@@ -63,13 +63,6 @@ func TestStatusUpdateBuffer(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			fixture := newTestFixture(t, nil)
-			ctx := t.Context()
-
-			err := fixture.plugin.Start(ctx)
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer fixture.plugin.Stop(ctx)
 
 			for i := range tc.numberOfStatusUpdates {
 				s := bundle.Status{


### PR DESCRIPTION
### Why the changes in this PR are needed?

`TestStatusUpdateBuffer` was flaky on CI (see example [here](https://github.com/open-policy-agent/opa/actions/runs/20280143946/job/58239726266)). Starting the plugin spawns a goroutine that consumes from `bulkBundleCh`, racing with the test's channel length assertion.

```
--- FAIL: TestStatusUpdateBuffer (0.00s)
    --- FAIL: TestStatusUpdateBuffer/don't_drop_anything (0.00s)
        plugin_test.go:84: expected 1 updates, got 0
```

### What are the changes in this PR?

Remove unnecessary `fixture.plugin.Start` calls from the test since it only verifies `PushFIFO` buffer semantics, not the plugin lifecycle.

### Notes to assist PR review:

I ran the test locally and tried to reproduce it before and after the fix. Couldn't trigger it. The test passes though.

### Further comments:

N/A