### PR TITLE
Template string performance improvements and more

### DIFF
--- a/v1/ast/annotations.go
+++ b/v1/ast/annotations.go
@@ -433,18 +433,7 @@ func (a *Annotations) toObject() (*Object, *Error) {
 	}
 
 	if len(a.Scope) > 0 {
-		switch a.Scope {
-		case annotationScopeDocument:
-			obj.Insert(InternedTerm("scope"), InternedTerm("document"))
-		case annotationScopePackage:
-			obj.Insert(InternedTerm("scope"), InternedTerm("package"))
-		case annotationScopeRule:
-			obj.Insert(InternedTerm("scope"), InternedTerm("rule"))
-		case annotationScopeSubpackages:
-			obj.Insert(InternedTerm("scope"), InternedTerm("subpackages"))
-		default:
-			obj.Insert(InternedTerm("scope"), StringTerm(a.Scope))
-		}
+		obj.Insert(InternedTerm("scope"), InternedTerm(a.Scope))
 	}
 
 	if len(a.Title) > 0 {

--- a/v1/ast/env.go
+++ b/v1/ast/env.go
@@ -61,8 +61,7 @@ func (env *TypeEnv) GetByValue(v Value) types.Type {
 	case *Array:
 		static := make([]types.Type, x.Len())
 		for i := range static {
-			tpe := env.GetByValue(x.Elem(i).Value)
-			static[i] = tpe
+			static[i] = env.GetByValue(x.Elem(i).Value)
 		}
 
 		var dynamic types.Type
@@ -80,17 +79,13 @@ func (env *TypeEnv) GetByValue(v Value) types.Type {
 
 		x.Foreach(func(k, v *Term) {
 			if IsConstant(k.Value) {
-				kjson, err := JSON(k.Value)
-				if err == nil {
-					tpe := env.GetByValue(v.Value)
-					static = append(static, types.NewStaticProperty(kjson, tpe))
+				if kjson, err := JSON(k.Value); err == nil {
+					static = append(static, types.NewStaticProperty(kjson, env.GetByValue(v.Value)))
 					return
 				}
 			}
 			// Can't handle it as a static property, fallback to dynamic
-			typeK := env.GetByValue(k.Value)
-			typeV := env.GetByValue(v.Value)
-			dynamic = types.NewDynamicProperty(typeK, typeV)
+			dynamic = types.NewDynamicProperty(env.GetByValue(k.Value), env.GetByValue(v.Value))
 		})
 
 		if len(static) == 0 && dynamic == nil {
@@ -99,7 +94,7 @@ func (env *TypeEnv) GetByValue(v Value) types.Type {
 
 		return types.NewObject(static, dynamic)
 
-	case Set:
+	case *set:
 		var tpe types.Type
 		x.Foreach(func(elem *Term) {
 			tpe = types.Or(tpe, env.GetByValue(elem.Value))
@@ -162,7 +157,6 @@ func (env *TypeEnv) GetByRef(ref Ref) types.Type {
 }
 
 func (env *TypeEnv) getRefFallback(ref Ref) types.Type {
-
 	if env.next != nil {
 		return env.next.GetByRef(ref)
 	}
@@ -299,15 +293,11 @@ func (n *typeTreeNode) PutOne(key Value, tpe types.Type) {
 func (n *typeTreeNode) Put(path Ref, tpe types.Type) {
 	curr := n
 	for _, term := range path {
-		c, ok := curr.children.Get(term.Value)
-
-		var child *typeTreeNode
+		child, ok := curr.children.Get(term.Value)
 		if !ok {
 			child = newTypeTree()
 			child.key = term.Value
 			curr.children.Put(child.key, child)
-		} else {
-			child = c
 		}
 
 		curr = child
@@ -321,23 +311,18 @@ func (n *typeTreeNode) Put(path Ref, tpe types.Type) {
 func (n *typeTreeNode) Insert(path Ref, tpe types.Type, env *TypeEnv) {
 	curr := n
 	for i, term := range path {
-		c, ok := curr.children.Get(term.Value)
-
-		var child *typeTreeNode
+		child, ok := curr.children.Get(term.Value)
 		if !ok {
 			child = newTypeTree()
 			child.key = term.Value
 			curr.children.Put(child.key, child)
-		} else {
-			child = c
-			if child.value != nil && i+1 < len(path) {
-				// If child has an object value, merge the new value into it.
-				if o, ok := child.value.(*types.Object); ok {
-					var err error
-					child.value, err = insertIntoObject(o, path[i+1:], tpe, env)
-					if err != nil {
-						panic(fmt.Errorf("unreachable, insertIntoObject: %w", err))
-					}
+		} else if child.value != nil && i+1 < len(path) {
+			// If child has an object value, merge the new value into it.
+			if o, ok := child.value.(*types.Object); ok {
+				var err error
+				child.value, err = insertIntoObject(o, path[i+1:], tpe, env)
+				if err != nil {
+					panic(fmt.Errorf("unreachable, insertIntoObject: %w", err))
 				}
 			}
 		}
@@ -349,8 +334,7 @@ func (n *typeTreeNode) Insert(path Ref, tpe types.Type, env *TypeEnv) {
 
 	if _, ok := tpe.(*types.Object); ok && curr.children.Len() > 0 {
 		// merge all leafs into the inserted object
-		leafs := curr.Leafs()
-		for p, t := range leafs {
+		for p, t := range curr.Leafs() {
 			var err error
 			curr.value, err = insertIntoObject(curr.value.(*types.Object), *p, t, env)
 			if err != nil {
@@ -388,7 +372,8 @@ func mergeTypes(a, b types.Type) types.Type {
 			bDynProps := bObj.DynamicProperties()
 			dynProps := types.NewDynamicProperty(
 				types.Or(aDynProps.Key, bDynProps.Key),
-				mergeTypes(aDynProps.Value, bDynProps.Value))
+				mergeTypes(aDynProps.Value, bDynProps.Value),
+			)
 			return types.NewObject(nil, dynProps)
 		} else if bAny, ok := b.(types.Any); ok && len(a.StaticProperties()) == 0 {
 			// If a is an object type with no static components ...
@@ -417,14 +402,14 @@ func mergeTypes(a, b types.Type) types.Type {
 }
 
 func (n *typeTreeNode) String() string {
-	b := strings.Builder{}
+	b := &strings.Builder{}
 
+	key := "-"
 	if k := n.key; k != nil {
-		b.WriteString(k.String())
-	} else {
-		b.WriteString("-")
+		key = k.String()
 	}
 
+	b.WriteString(key)
 	if v := n.value; v != nil {
 		b.WriteString(": ")
 		b.WriteString(v.String())
@@ -432,9 +417,7 @@ func (n *typeTreeNode) String() string {
 
 	n.children.Iter(func(_ Value, child *typeTreeNode) bool {
 		b.WriteString("\n\t+ ")
-		s := child.String()
-		s = strings.ReplaceAll(s, "\n", "\n\t")
-		b.WriteString(s)
+		b.WriteString(strings.ReplaceAll(child.String(), "\n", "\n\t"))
 
 		return false
 	})
@@ -485,7 +468,8 @@ func (n *typeTreeNode) Leafs() map[*Ref]types.Type {
 func collectLeafs(n *typeTreeNode, path Ref, leafs map[*Ref]types.Type) {
 	nPath := append(path, NewTerm(n.key))
 	if n.Leaf() {
-		leafs[&nPath] = n.Value()
+		npc := nPath // copy of else nPath escapes to heap even if !n.Leaf()
+		leafs[&npc] = n.Value()
 		return
 	}
 	n.children.Iter(func(_ Value, v *typeTreeNode) bool {
@@ -513,7 +497,6 @@ func selectConstant(tpe types.Type, term *Term) types.Type {
 // contains vars or refs, then the returned type will be a union of the
 // possible types.
 func selectRef(tpe types.Type, ref Ref) types.Type {
-
 	if tpe == nil || len(ref) == 0 {
 		return tpe
 	}

--- a/v1/ast/interning.go
+++ b/v1/ast/interning.go
@@ -42,10 +42,17 @@ var (
 	}
 
 	internedVarValues = map[string]Value{
-		"input": Var("input"),
-		"data":  Var("data"),
-		"key":   Var("key"),
-		"value": Var("value"),
+		"input":    Var("input"),
+		"data":     Var("data"),
+		"args":     Var("args"),
+		"schema":   Var("schema"),
+		"key":      Var("key"),
+		"value":    Var("value"),
+		"future":   Var("future"),
+		"rego":     Var("rego"),
+		"set":      Var("set"),
+		"internal": Var("internal"),
+		"else":     Var("else"),
 
 		"i": Var("i"), "j": Var("j"), "k": Var("k"), "v": Var("v"), "x": Var("x"), "y": Var("y"), "z": Var("z"),
 	}

--- a/v1/ast/policy.go
+++ b/v1/ast/policy.go
@@ -621,7 +621,7 @@ func (imp *Import) SetLoc(loc *Location) {
 // document. This is the alias if defined otherwise the last element in the
 // path.
 func (imp *Import) Name() Var {
-	if len(imp.Alias) != 0 {
+	if imp.Alias != "" {
 		return imp.Alias
 	}
 	switch v := imp.Path.Value.(type) {

--- a/v1/ast/strings.go
+++ b/v1/ast/strings.go
@@ -48,6 +48,8 @@ func ValueName(x Value) string {
 		return "objectcomprehension"
 	case *SetComprehension:
 		return "setcomprehension"
+	case *TemplateString:
+		return "templatestring"
 	}
 
 	return TypeName(x)

--- a/v1/ast/transform.go
+++ b/v1/ast/transform.go
@@ -303,29 +303,29 @@ func Transform(t Transformer, x any) (any, error) {
 
 // TransformRefs calls the function f on all references under x.
 func TransformRefs(x any, f func(Ref) (Value, error)) (any, error) {
-	t := &GenericTransformer{func(x any) (any, error) {
+	t := NewGenericTransformer(func(x any) (any, error) {
 		if r, ok := x.(Ref); ok {
 			return f(r)
 		}
 		return x, nil
-	}}
+	})
 	return Transform(t, x)
 }
 
 // TransformVars calls the function f on all vars under x.
 func TransformVars(x any, f func(Var) (Value, error)) (any, error) {
-	t := &GenericTransformer{func(x any) (any, error) {
+	t := NewGenericTransformer(func(x any) (any, error) {
 		if v, ok := x.(Var); ok {
 			return f(v)
 		}
 		return x, nil
-	}}
+	})
 	return Transform(t, x)
 }
 
-// TransformComprehensions calls the functio nf on all comprehensions under x.
+// TransformComprehensions calls the function f on all comprehensions under x.
 func TransformComprehensions(x any, f func(any) (Value, error)) (any, error) {
-	t := &GenericTransformer{func(x any) (any, error) {
+	t := NewGenericTransformer(func(x any) (any, error) {
 		switch x := x.(type) {
 		case *ArrayComprehension:
 			return f(x)
@@ -335,7 +335,7 @@ func TransformComprehensions(x any, f func(any) (Value, error)) (any, error) {
 			return f(x)
 		}
 		return x, nil
-	}}
+	})
 	return Transform(t, x)
 }
 

--- a/v1/bundle/store.go
+++ b/v1/bundle/store.go
@@ -970,7 +970,7 @@ func compileModules(compiler *ast.Compiler, m metrics.Metrics, bundles map[strin
 	m.Timer(metrics.RegoModuleCompile).Start()
 	defer m.Timer(metrics.RegoModuleCompile).Stop()
 
-	modules := map[string]*ast.Module{}
+	modules := make(map[string]*ast.Module, len(compiler.Modules)+len(extraModules)+len(bundles))
 
 	// preserve any modules already on the compiler
 	maps.Copy(modules, compiler.Modules)

--- a/v1/format/format.go
+++ b/v1/format/format.go
@@ -27,8 +27,6 @@ import (
 const defaultLocationFile = "__format_default__"
 
 var (
-	elseVar ast.Value = ast.Var("else")
-
 	expandedConst     = ast.NewBody(ast.NewExpr(ast.InternedTerm(true)))
 	commentsSlicePool = util.NewSlicePool[*ast.Comment](50)
 	varRegexp         = regexp.MustCompile("^[[:alpha:]_][[:alpha:][:digit:]_]*$")
@@ -732,7 +730,7 @@ func (w *writer) writeElse(rule *ast.Rule, comments []*ast.Comment) ([]*ast.Comm
 
 	rule.Else.Head.Name = "else" // NOTE(sr): whaaat
 
-	elseHeadReference := ast.NewTerm(elseVar)            // construct a reference for the term
+	elseHeadReference := ast.VarTerm("else")             // construct a reference for the term
 	elseHeadReference.Location = rule.Else.Head.Location // and set the location to match the rule location
 
 	rule.Else.Head.Reference = ast.Ref{elseHeadReference}

--- a/v1/repl/repl.go
+++ b/v1/repl/repl.go
@@ -1293,9 +1293,8 @@ func (r *REPL) loadModules(ctx context.Context, txn storage.Transaction) (map[st
 }
 
 func (r *REPL) printTypes(_ context.Context, typeEnv *ast.TypeEnv, body ast.Body) {
-
 	ast.WalkRefs(body, func(ref ast.Ref) bool {
-		fmt.Fprintf(r.output, "# %v: %v\n", ref, typeEnv.Get(ref))
+		fmt.Fprintf(r.output, "# %v: %v\n", ref, typeEnv.GetByRef(ref))
 		return false
 	})
 

--- a/v1/topdown/print.go
+++ b/v1/topdown/print.go
@@ -28,7 +28,6 @@ func (h printHook) Print(_ print.Context, msg string) error {
 }
 
 func builtinPrint(bctx BuiltinContext, operands []*ast.Term, iter func(*ast.Term) error) error {
-
 	if bctx.PrintHook == nil {
 		return iter(nil)
 	}
@@ -40,7 +39,7 @@ func builtinPrint(bctx BuiltinContext, operands []*ast.Term, iter func(*ast.Term
 
 	buf := make([]string, arr.Len())
 
-	err = builtinPrintCrossProductOperands(bctx, buf, arr, 0, func(buf []string) error {
+	err = builtinPrintCrossProductOperands(bctx.Location, buf, arr, 0, func(buf []string) error {
 		pctx := print.Context{
 			Context:  bctx.Context,
 			Location: bctx.Location,
@@ -54,31 +53,32 @@ func builtinPrint(bctx BuiltinContext, operands []*ast.Term, iter func(*ast.Term
 	return iter(nil)
 }
 
-func builtinPrintCrossProductOperands(bctx BuiltinContext, buf []string, operands *ast.Array, i int, f func([]string) error) error {
-
+func builtinPrintCrossProductOperands(loc *ast.Location, buf []string, operands *ast.Array, i int, f func([]string) error) error {
 	if i >= operands.Len() {
 		return f(buf)
 	}
 
+	operand := operands.Elem(i)
+
 	// We allow primitives ...
-	switch x := operands.Elem(i).Value.(type) {
+	switch x := operand.Value.(type) {
 	case ast.String:
 		buf[i] = string(x)
-		return builtinPrintCrossProductOperands(bctx, buf, operands, i+1, f)
+		return builtinPrintCrossProductOperands(loc, buf, operands, i+1, f)
 	case ast.Number, ast.Boolean, ast.Null:
 		buf[i] = x.String()
-		return builtinPrintCrossProductOperands(bctx, buf, operands, i+1, f)
+		return builtinPrintCrossProductOperands(loc, buf, operands, i+1, f)
 	}
 
 	// ... but all other operand types must be sets.
-	xs, ok := operands.Elem(i).Value.(ast.Set)
+	xs, ok := operand.Value.(ast.Set)
 	if !ok {
-		return Halt{Err: internalErr(bctx.Location, fmt.Sprintf("illegal argument type: %v", ast.ValueName(operands.Elem(i).Value)))}
+		return Halt{Err: internalErr(loc, "illegal argument type: "+ast.ValueName(operand.Value))}
 	}
 
 	if xs.Len() == 0 {
 		buf[i] = "<undefined>"
-		return builtinPrintCrossProductOperands(bctx, buf, operands, i+1, f)
+		return builtinPrintCrossProductOperands(loc, buf, operands, i+1, f)
 	}
 
 	return xs.Iter(func(x *ast.Term) error {
@@ -88,7 +88,7 @@ func builtinPrintCrossProductOperands(bctx BuiltinContext, buf []string, operand
 		default:
 			buf[i] = v.String()
 		}
-		return builtinPrintCrossProductOperands(bctx, buf, operands, i+1, f)
+		return builtinPrintCrossProductOperands(loc, buf, operands, i+1, f)
 	})
 }
 

--- a/v1/topdown/query.go
+++ b/v1/topdown/query.go
@@ -134,7 +134,7 @@ func (q *Query) WithTracer(tracer Tracer) *Query {
 // WithQueryTracer adds a query tracer to use during evaluation. This is optional.
 // Disabled QueryTracers will be ignored.
 func (q *Query) WithQueryTracer(tracer QueryTracer) *Query {
-	if !tracer.Enabled() {
+	if tracer == nil || !tracer.Enabled() {
 		return q
 	}
 

--- a/v1/topdown/template_string.go
+++ b/v1/topdown/template_string.go
@@ -20,7 +20,7 @@ func builtinTemplateString(bctx BuiltinContext, operands []*ast.Term, iter func(
 	buf := make([]string, arr.Len())
 
 	var count int
-	err = builtinPrintCrossProductOperands(bctx, buf, arr, 0, func(buf []string) error {
+	err = builtinPrintCrossProductOperands(bctx.Location, buf, arr, 0, func(buf []string) error {
 		count += 1
 		// Precautionary run-time assertion that template-strings can't produce multiple outputs; e.g. for custom relation type built-ins not known at compile-time.
 		if count > 1 {
@@ -37,8 +37,7 @@ func builtinTemplateString(bctx BuiltinContext, operands []*ast.Term, iter func(
 		return err
 	}
 
-	str := ast.StringTerm(strings.Join(buf, ""))
-	return iter(str)
+	return iter(ast.StringTerm(strings.Join(buf, "")))
 }
 
 func init() {

--- a/v1/topdown/template_string_test.go
+++ b/v1/topdown/template_string_test.go
@@ -7,52 +7,52 @@ import (
 	"github.com/open-policy-agent/opa/v1/ast"
 )
 
-func TestBuiltinTemplateString(t *testing.T) {
-	tests := []struct {
-		note   string
-		parts  *ast.Array
-		expRes *ast.Term
-		expErr string
-	}{
-		{
-			note:   "no parts",
-			parts:  ast.NewArray(),
-			expRes: ast.StringTerm(""),
-		},
-		{
-			note:   "single string part",
-			parts:  ast.NewArray(ast.StringTerm("foo")),
-			expRes: ast.StringTerm("foo"),
-		},
-		{
-			note:   "single undefined part",
-			parts:  ast.NewArray(ast.SetTerm()),
-			expRes: ast.StringTerm("<undefined>"),
-		},
-		{
-			note:   "primitives",
-			parts:  ast.NewArray(ast.StringTerm("foo"), ast.NumberTerm("42"), ast.BooleanTerm(false), ast.NullTerm()),
-			expRes: ast.StringTerm("foo42falsenull"),
-		},
-		{
-			note: "collections",
-			parts: ast.NewArray(
-				ast.SetTerm(ast.ArrayTerm()), ast.StringTerm(" "),
-				ast.SetTerm(ast.ArrayTerm(ast.StringTerm("a"), ast.StringTerm("b"))), ast.StringTerm(" "),
-				ast.SetTerm(ast.SetTerm()), ast.StringTerm(" "),
-				ast.SetTerm(ast.SetTerm(ast.StringTerm("c"))), ast.StringTerm(" "),
-				ast.SetTerm(ast.ObjectTerm()), ast.StringTerm(" "),
-				ast.SetTerm(ast.ObjectTerm(ast.Item(ast.StringTerm("d"), ast.StringTerm("e")))),
-			),
-			expRes: ast.StringTerm(`[] ["a", "b"] set() {"c"} {} {"d": "e"}`),
-		},
-		{
-			note:   "multiple outputs",
-			parts:  ast.NewArray(ast.SetTerm(ast.BooleanTerm(true), ast.BooleanTerm(false))),
-			expErr: "eval_conflict_error: template-strings must not produce multiple outputs",
-		},
-	}
+var tests = []struct {
+	note   string
+	parts  *ast.Array
+	expRes *ast.Term
+	expErr string
+}{
+	{
+		note:   "no parts",
+		parts:  ast.NewArray(),
+		expRes: ast.StringTerm(""),
+	},
+	{
+		note:   "single string part",
+		parts:  ast.NewArray(ast.StringTerm("foo")),
+		expRes: ast.StringTerm("foo"),
+	},
+	{
+		note:   "single undefined part",
+		parts:  ast.NewArray(ast.SetTerm()),
+		expRes: ast.StringTerm("<undefined>"),
+	},
+	{
+		note:   "primitives",
+		parts:  ast.NewArray(ast.StringTerm("foo"), ast.NumberTerm("42"), ast.BooleanTerm(false), ast.NullTerm()),
+		expRes: ast.StringTerm("foo42falsenull"),
+	},
+	{
+		note: "collections",
+		parts: ast.NewArray(
+			ast.SetTerm(ast.ArrayTerm()), ast.StringTerm(" "),
+			ast.SetTerm(ast.ArrayTerm(ast.StringTerm("a"), ast.StringTerm("b"))), ast.StringTerm(" "),
+			ast.SetTerm(ast.SetTerm()), ast.StringTerm(" "),
+			ast.SetTerm(ast.SetTerm(ast.StringTerm("c"))), ast.StringTerm(" "),
+			ast.SetTerm(ast.ObjectTerm()), ast.StringTerm(" "),
+			ast.SetTerm(ast.ObjectTerm(ast.Item(ast.StringTerm("d"), ast.StringTerm("e")))),
+		),
+		expRes: ast.StringTerm(`[] ["a", "b"] set() {"c"} {} {"d": "e"}`),
+	},
+	{
+		note:   "multiple outputs",
+		parts:  ast.NewArray(ast.SetTerm(ast.BooleanTerm(true), ast.BooleanTerm(false))),
+		expErr: "eval_conflict_error: template-strings must not produce multiple outputs",
+	},
+}
 
+func TestBuiltinTemplateString(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.note, func(t *testing.T) {
 			var result *ast.Term
@@ -78,6 +78,26 @@ func TestBuiltinTemplateString(t *testing.T) {
 				if act := err.Error(); !strings.Contains(act, tc.expErr) {
 					t.Fatalf("Expected error to contain:\n\n%s\n\ngot:\n\n%s", tc.expErr, act)
 				}
+			}
+		})
+	}
+}
+
+// BenchmarkBuiltinTemplateString/no_parts-16         				13434396	        82.17 ns/op	     344 B/op	       4 allocs/op
+// BenchmarkBuiltinTemplateString/single_string_part-16         	11506334	       106.0 ns/op	     376 B/op	       6 allocs/op
+// BenchmarkBuiltinTemplateString/single_undefined_part-16      	11367075	       106.0 ns/op	     376 B/op	       6 allocs/op
+// BenchmarkBuiltinTemplateString/primitives-16                 	 8217890	       144.9 ns/op	     440 B/op	       7 allocs/op
+// BenchmarkBuiltinTemplateString/collections-16                	 2056494	       583.7 ns/op	    1144 B/op	      28 allocs/op
+// BenchmarkBuiltinTemplateString/multiple_outputs-16           	 9424003	       128.8 ns/op	     480 B/op	       7 allocs/op
+func BenchmarkBuiltinTemplateString(b *testing.B) {
+	for _, tc := range tests {
+		b.Run(tc.note, func(b *testing.B) {
+			bctx := BuiltinContext{}
+			oper := []*ast.Term{ast.NewTerm(tc.parts)}
+			iter := eqIter(tc.expRes)
+
+			for b.Loop() {
+				_ = builtinTemplateString(bctx, oper, iter)
 			}
 		})
 	}


### PR DESCRIPTION
A mixed bag of improvements I have had around for a while, and would like to see included in v1.12.0 if possible. I have about twice the amount of changes **not** included here as they could use some more testing. These changes should be low risk, I believe.. but obviously do let me know if you see any potential risks that I don't!

- Add template string benchmarks
- Faster template strings / print eval by not passing bctx in recursion
- Allow passing nil value to `Query.WithQueryTracer` (no-op)
- Reduce allocations in rego v1 compiler stages
- Intern a few more common var name `Value`s
- Remove redundant switch on `scope` in annotations code
- Add a few more benchmarks in the `ast` package
- Performance improvements in type checker, most notably removing a function literal for checking expression, which only ever had one implementation. We can extend this later if needed.
- Prefer `NewGenericTransformer` over `&GenericTransformer` for easier tracking in pprof
