### PR TITLE
docs: Add scripts to import docs from source

### DIFF
--- a/docs/bin/import-rego-cheat-sheet.sh
+++ b/docs/bin/import-rego-cheat-sheet.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if ! command -v curl >/dev/null 2>&1
+then
+  echo "curl could not be found"
+  exit 1
+fi
+
+if ! command -v unzip >/dev/null 2>&1
+then
+  echo "unzip could not be found"
+  exit 1
+fi
+
+download_cheatsheet() {
+  # Always download from main branch
+  ref="heads/main"
+
+  # https://github.com/open-policy-agent/rego-cheat-sheet/archive/refs/heads/main.zip
+  url="https://github.com/open-policy-agent/rego-cheat-sheet/archive/refs/$ref.zip"
+
+  curl --silent -L -o rego-cheat-sheet.zip "$url"
+}
+
+if [[ ! -e rego-cheat-sheet.zip ]]; then
+  download_cheatsheet
+else
+  echo "Using existing rego-cheat-sheet.zip"
+fi
+
+tempdir=$(mktemp -d)
+
+unzip rego-cheat-sheet.zip -d "$tempdir" 2>&1 > /dev/null
+
+mv $tempdir/*/* $tempdir
+
+cheatsheet_src="$tempdir/build"
+
+# Destination paths relative to docs directory
+cheatsheet_md_dest="docs/cheatsheet.md"
+cheatsheet_pdf_dest="static/cheatsheet.pdf"
+
+# Copy the markdown file
+if [[ -f "$cheatsheet_src/cheatsheet.md" ]]; then
+  cp "$cheatsheet_src/cheatsheet.md" "$cheatsheet_md_dest"
+  echo "Copied cheatsheet.md to $cheatsheet_md_dest"
+else
+  echo "Error: cheatsheet.md not found in $cheatsheet_src"
+  exit 1
+fi
+
+# Copy the PDF file
+if [[ -f "$cheatsheet_src/cheatsheet.pdf" ]]; then
+  cp "$cheatsheet_src/cheatsheet.pdf" "$cheatsheet_pdf_dest"
+  echo "Copied cheatsheet.pdf to $cheatsheet_pdf_dest"
+else
+  echo "Error: cheatsheet.pdf not found in $cheatsheet_src"
+  exit 1
+fi
+
+# Clean up
+rm -rf "$tempdir"
+
+echo "Cheat sheet import complete!"

--- a/docs/bin/import-rego-style-guide.sh
+++ b/docs/bin/import-rego-style-guide.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if ! command -v curl >/dev/null 2>&1
+then
+  echo "curl could not be found"
+  exit 1
+fi
+
+if ! command -v unzip >/dev/null 2>&1
+then
+  echo "unzip could not be found"
+  exit 1
+fi
+
+download_style_guide() {
+  # Always download from main branch
+  ref="heads/main"
+
+  # https://github.com/open-policy-agent/rego-style-guide/archive/refs/heads/main.zip
+  url="https://github.com/open-policy-agent/rego-style-guide/archive/refs/$ref.zip"
+
+  curl --silent -L -o rego-style-guide.zip "$url"
+}
+
+if [[ ! -e rego-style-guide.zip ]]; then
+  download_style_guide
+else
+  echo "Using existing rego-style-guide.zip"
+fi
+
+tempdir=$(mktemp -d)
+
+unzip rego-style-guide.zip -d "$tempdir" 2>&1 > /dev/null
+
+mv $tempdir/*/* $tempdir
+
+style_guide_src="$tempdir/style-guide.md"
+
+# Destination path relative to docs directory
+style_guide_dest="docs/style-guide.md"
+
+# Copy the markdown file
+if [[ -f "$style_guide_src" ]]; then
+  cp "$style_guide_src" "$style_guide_dest"
+  echo "Copied style-guide.md to $style_guide_dest"
+else
+  echo "Error: style-guide.md not found in $tempdir"
+  exit 1
+fi
+
+# Clean up
+rm -rf "$tempdir"
+
+echo "Style guide import complete!"

--- a/docs/docs/cheatsheet.md
+++ b/docs/docs/cheatsheet.md
@@ -34,7 +34,6 @@ In older documentation, these are sometimes referred to as "complete rules". ([T
 
 
 
-
 ```json title="input.json"
 {
   "user": {
@@ -73,7 +72,6 @@ In older documentation these are sometimes referred to as "partial set rules". (
 
 
 
-
 ```json title="input.json"
 {
   "user": {
@@ -83,7 +81,6 @@ In older documentation these are sometimes referred to as "partial set rules". (
     ]
   }
 }
-
 ```
 
 <RunSnippet id="input.Multi-Value+Set+Rules.json"/>
@@ -112,7 +109,6 @@ In older documentation these are sometimes referred to as "partial object rules"
 
 
 
-
 ```json title="input.json"
 {
   "paths": [
@@ -123,7 +119,6 @@ In older documentation these are sometimes referred to as "partial object rules"
     "c/x.txt"
   ]
 }
-
 ```
 
 <RunSnippet id="input.Multi-Value+Object+Rules.json"/>
@@ -184,7 +179,6 @@ Check conditions on many elements. ([Try It](https://play.openpolicyagent.org/?s
 
 
 
-
 ```json title="input.json"
 {
   "userID": "u123",
@@ -224,7 +218,6 @@ Statements in rules are joined with logical AND. ([Try It](https://play.openpoli
 
 
 
-
 ```json title="input.json"
 {
   "email": "joe@example.com"
@@ -250,7 +243,6 @@ valid_staff_email if {
 
 
 Express OR with multiple rules, functions or the in keyword. ([Try It](https://play.openpolicyagent.org/?state=eyJpIjoie1xuICBcImVtYWlsXCI6IFwib3BhQGV4YW1wbGUuY29tXCIsXG4gIFwibmFtZVwiOiBcImFubmFcIixcbiAgXCJtZXRob2RcIjogXCJHRVRcIlxufSIsInAiOiJwYWNrYWdlIGNoZWF0XG5cbmltcG9ydCByZWdvLnYxXG5cbiMgdXNpbmcgbXVsdGlwbGUgcnVsZXNcbnZhbGlkX2VtYWlsIGlmIGVuZHN3aXRoKGlucHV0LmVtYWlsLCBcIkBleGFtcGxlLmNvbVwiKVxudmFsaWRfZW1haWwgaWYgZW5kc3dpdGgoaW5wdXQuZW1haWwsIFwiQGV4YW1wbGUub3JnXCIpXG52YWxpZF9lbWFpbCBpZiBlbmRzd2l0aChpbnB1dC5lbWFpbCwgXCJAZXhhbXBsZS5uZXRcIilcblxuIyB1c2luZyBmdW5jdGlvbnNcbmFsbG93ZWRfZmlyc3RuYW1lKG5hbWUpIGlmIHtcblx0c3RhcnRzd2l0aChuYW1lLCBcImFcIilcblx0Y291bnQobmFtZSkgXHUwMDNlIDJcbn1cblxuYWxsb3dlZF9maXJzdG5hbWUoXCJqb2VcIikgIyBpZiBuYW1lID09ICdqb2UnXG5cbnZhbGlkX25hbWUgaWYgYWxsb3dlZF9maXJzdG5hbWUoaW5wdXQubmFtZSlcblxudmFsaWRfcmVxdWVzdCBpZiB7XG5cdGlucHV0Lm1ldGhvZCBpbiB7XCJHRVRcIiwgXCJQT1NUXCJ9ICMgdXNpbmcgYGluYFxufVxuIn0%3D))
-
 
 
 


### PR DESCRIPTION
Regal, cheat sheet, and style guide all get docs from other repos but are vendored here to build the site.

These scripts are currently run manually, but at least codify the process. Eventually this will be automated too.

`docs/bin/import-rego-cheat-sheet.sh` and `docs/bin/import-rego-style-guide.sh` are just copied from the regal one really, to keep it consistent and to keep track of these three special cases.

Related:
- https://github.com/open-policy-agent/rego-style-guide/pull/42
- https://github.com/open-policy-agent/regal/pull/1800
