### PR TITLE
Add `(*TemplateString).Copy()` method

### DIFF
--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -1768,7 +1768,7 @@ func (p *Planner) planRef(ref ast.Ref, iter planiter) error {
 		return errors.New("illegal ref: non-var head")
 	}
 
-	if head.Compare(ast.DefaultRootDocument.Value) == 0 {
+	if head.Equal(ast.DefaultRootDocument.Value) {
 		virtual := p.rules.Get(ref[0].Value)
 		base := &baseptr{local: p.vars.GetOrEmpty(ast.DefaultRootDocument.Value.(ast.Var))}
 		return p.planRefData(virtual, base, ref, 1, iter)

--- a/v1/ast/compare.go
+++ b/v1/ast/compare.go
@@ -327,14 +327,6 @@ func TermValueEqual(a, b *Term) bool {
 }
 
 func ValueEqual(a, b Value) bool {
-	// TODO(ae): why doesn't this work the same?
-	//
-	// case interface{ Equal(Value) bool }:
-	// 	   return v.Equal(b)
-	//
-	// When put on top, golangci-lint even flags the other cases as unreachable..
-	// but TestTopdownVirtualCache will have failing test cases when we replace
-	// the other cases with the above one.. 🤔
 	switch v := a.(type) {
 	case Null:
 		return v.Equal(b)
@@ -349,6 +341,8 @@ func ValueEqual(a, b Value) bool {
 	case Ref:
 		return v.Equal(b)
 	case *Array:
+		return v.Equal(b)
+	case *TemplateString:
 		return v.Equal(b)
 	}
 

--- a/v1/ast/compile.go
+++ b/v1/ast/compile.go
@@ -3746,7 +3746,7 @@ func NewModuleTree(mods map[string]*Module) *ModuleTreeNode {
 			c, ok := node.Children[x.Value]
 			if !ok {
 				var hide bool
-				if i == 1 && x.Value.Compare(SystemDocumentKey) == 0 {
+				if i == 1 && SystemDocumentKey.Equal(x.Value) {
 					hide = true
 				}
 				c = &ModuleTreeNode{

--- a/v1/ast/index.go
+++ b/v1/ast/index.go
@@ -412,7 +412,7 @@ func (i *refindices) updateGlobMatch(rule *Rule, expr *Expr) {
 		if _, ok := match.Value.(Var); ok {
 			var ref Ref
 			for _, other := range i.rules[rule] {
-				if _, ok := other.Value.(Var); ok && other.Value.Compare(match.Value) == 0 {
+				if ov, ok := other.Value.(Var); ok && ov.Equal(match.Value) {
 					ref = other.Ref
 				}
 			}

--- a/v1/ast/oracle/matcher.go
+++ b/v1/ast/oracle/matcher.go
@@ -190,7 +190,7 @@ func termMatchesVar(t *ast.Term, name ast.Var) bool {
 
 	v, ok := t.Value.(ast.Var)
 
-	return ok && v.Compare(name) == 0
+	return ok && v.Equal(name)
 }
 
 // findRulesDefinition looks up rules for a given ref. Rules appear in various

--- a/v1/ast/term_test.go
+++ b/v1/ast/term_test.go
@@ -1689,6 +1689,20 @@ func TestLazyObjectCompare(t *testing.T) {
 	assertForced(t, x, true)
 }
 
+func TestTemplateStringEqual(t *testing.T) {
+	a := MustParseTerm(`$"hello {world}!"`).Value.(*TemplateString)
+	b := MustParseTerm(`$"hello {world}!"`).Value.(*TemplateString)
+	c := MustParseTerm(`$"goodbye {world}!"`).Value.(*TemplateString)
+
+	if !a.Equal(b) {
+		t.Errorf("Expected %v to equal %v", a, b)
+	}
+
+	if a.Equal(c) {
+		t.Errorf("Expected %v to not equal %v", a, c)
+	}
+}
+
 func assertForced(t *testing.T, x Object, forced bool) {
 	t.Helper()
 	l, ok := x.(*lazyObj)

--- a/v1/ast/transform_test.go
+++ b/v1/ast/transform_test.go
@@ -121,7 +121,7 @@ func TestTransformRefsAndRuleHeads(t *testing.T) {
 p.q.this.fo[x] = y if { x := "x"; y := "y" }`)
 
 	result, err := TransformRefs(module, func(r Ref) (Value, error) {
-		if r[0].Value.Compare(Var("p")) == 0 {
+		if Var("p").Equal(r[0].Value) {
 			r[2] = StringTerm("that")
 		}
 		return r, nil

--- a/v1/repl/repl.go
+++ b/v1/repl/repl.go
@@ -930,7 +930,7 @@ func (r *REPL) parserOptions() (ast.ParserOptions, error) {
 		opts, err := future.ParserOptionsFromFutureImports(r.modules[r.currentModuleID].Imports)
 		if err == nil {
 			for _, i := range r.modules[r.currentModuleID].Imports {
-				if ast.Compare(i.Path.Value, ast.RegoV1CompatibleRef) == 0 {
+				if ast.RegoV1CompatibleRef.Equal(i.Path.Value) {
 					opts.RegoVersion = ast.RegoV1
 				}
 			}

--- a/v1/tester/runner.go
+++ b/v1/tester/runner.go
@@ -799,7 +799,7 @@ func injectTestCaseFunc(compiler *ast.Compiler) *ast.Error {
 					expr := rule.Body[i]
 
 					ast.WalkVars(expr, func(v ast.Var) bool {
-						if term.Value.Compare(v) == 0 {
+						if v.Equal(term.Value) {
 							injectBelowMap.Put(v, ast.Number(strconv.Itoa(i)))
 						}
 						return false

--- a/v1/topdown/copypropagation/copypropagation.go
+++ b/v1/topdown/copypropagation/copypropagation.go
@@ -344,7 +344,7 @@ func (p *CopyPropagator) livevarRef(a *ast.Term) bool {
 	}
 
 	for _, v := range p.sorted {
-		if ref[0].Value.Compare(v) == 0 {
+		if v.Equal(ref[0].Value) {
 			return true
 		}
 	}
@@ -403,7 +403,7 @@ func containedIn(value ast.Value, x any) bool {
 			if v, ok := value.(ast.Ref); ok {
 				match = x.HasPrefix(v)
 			} else {
-				match = x.Compare(value) == 0
+				match = x.Equal(value)
 			}
 			if stop || match {
 				stop = true

--- a/v1/topdown/tokens.go
+++ b/v1/topdown/tokens.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"hash"
 	"math/big"
+	"strconv"
 	"strings"
 
 	"github.com/lestrrat-go/jwx/v3/jwk"
@@ -1131,8 +1132,8 @@ func builtinJWTDecodeVerify(bctx BuiltinContext, operands []*ast.Term, iter func
 		switch v := nbf.Value.(type) {
 		case ast.Number:
 			// constraints.time is in nanoseconds but nbf Value is in seconds
-			compareTime := ast.FloatNumberTerm(constraints.time / 1000000000)
-			if ast.Compare(compareTime, v) == -1 {
+			compareTime := ast.Number(strconv.FormatFloat(constraints.time/1000000000, 'g', -1, 64))
+			if compareTime.Compare(v) == -1 {
 				return iter(unverified)
 			}
 		default:


### PR DESCRIPTION
Also:
- Add `(*TemplateString).Equal()` because why not.
- Update `x.Compare(y) == 0` to instead use `x.Equal(y)` where possible

Fixes #8158