### PR TITLE
perf: replace regex implementation in IsVarCompatibleString

### DIFF
--- a/v1/format/format.go
+++ b/v1/format/format.go
@@ -9,7 +9,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"regexp"
 	"slices"
 	"sort"
 	"strings"
@@ -29,7 +28,6 @@ const defaultLocationFile = "__format_default__"
 var (
 	expandedConst     = ast.NewBody(ast.NewExpr(ast.InternedTerm(true)))
 	commentsSlicePool = util.NewSlicePool[*ast.Comment](50)
-	varRegexp         = regexp.MustCompile("^[[:alpha:]_][[:alpha:][:digit:]_]*$")
 )
 
 // Opts lets you control the code formatting via `AstWithOpts()`.
@@ -1441,7 +1439,7 @@ func (w *writer) writeRefStringPath(s ast.String, l *ast.Location) {
 }
 
 func (w *writer) shouldBracketRefTerm(s string, l *ast.Location) bool {
-	if !varRegexp.MatchString(s) {
+	if !ast.IsVarCompatibleString(s) {
 		return true
 	}
 


### PR DESCRIPTION
The allowed pattern is simple enough to check byte-for-byte, and doing so is much faster, as the benchmarks clearly demonstrate. While it isn't a bottleneck by any means, this function is called often enough (once for every term in any ref serialized) that optimizing its implementation is warranted, IMO.