### PR TITLE
perf(ast): optimize Set.Union

### DIFF
--- a/v1/ast/term.go
+++ b/v1/ast/term.go
@@ -1858,9 +1858,16 @@ func (s *set) Intersect(other Set) Set {
 
 // Union returns the set containing all elements of s and other.
 func (s *set) Union(other Set) Set {
-	r := NewSet()
-	s.Foreach(r.Add)
-	other.Foreach(r.Add)
+	o := other.(*set)
+	// Pre-allocate with max size - avoids over-allocation for overlapping sets
+	// while only requiring one potential grow for disjoint sets.
+	r := newset(max(len(s.keys), len(o.keys)))
+	for _, term := range s.keys {
+		r.insert(term, false)
+	}
+	for _, term := range o.keys {
+		r.insert(term, false)
+	}
 	return r
 }
 

--- a/v1/ast/term_bench_test.go
+++ b/v1/ast/term_bench_test.go
@@ -418,6 +418,48 @@ func BenchmarkSetIntersectionDifferentSize(b *testing.B) {
 	}
 }
 
+func BenchmarkSetUnion(b *testing.B) {
+	sizes := []int{5, 50, 500, 5000}
+	for _, n := range sizes {
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			setA := NewSet()
+			setB := NewSet()
+			for i := range n {
+				setA.Add(IntNumberTerm(i))
+				setB.Add(IntNumberTerm(i + n)) // disjoint sets
+			}
+			b.ResetTimer()
+			for b.Loop() {
+				setC := setA.Union(setB)
+				if setC.Len() != 2*n {
+					b.Fatal("expected combined size")
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkSetUnionOverlapping(b *testing.B) {
+	sizes := []int{5, 50, 500, 5000}
+	for _, n := range sizes {
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			setA := NewSet()
+			setB := NewSet()
+			for i := range n {
+				setA.Add(IntNumberTerm(i))
+				setB.Add(IntNumberTerm(i)) // identical sets
+			}
+			b.ResetTimer()
+			for b.Loop() {
+				setC := setA.Union(setB)
+				if setC.Len() != n {
+					b.Fatal("expected same size")
+				}
+			}
+		})
+	}
+}
+
 func BenchmarkSetMembership(b *testing.B) {
 	sizes := []int{5, 50, 500, 5000}
 	for _, n := range sizes {


### PR DESCRIPTION
<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

* You have read the project's
  [guidelines on AI tool use](https://www.openpolicyagent.org/docs/contrib-code#ai-guidelines).

For more information on contributing to OPA see our
[Contributing Guide](https://www.openpolicyagent.org/docs/contributing/)
for high-level contributing guidelines and development setup.
(See the [Developer Certificate of Origin](https://www.openpolicyagent.org/docs/contrib-code/#developer-certificate-of-origin)
section for specifics on signing off a commit.)

-->

### Why the changes in this PR are needed?

<!--
Include a short description of WHY the changes were made.
-->

The `Set.Union` method has inefficiencies similar to those fixed for `Set.Intersect` and `Set.Diff` in #8167:

- Uses `Foreach()` which calls `sortedKeys()`, causing unnecessary sorting overhead.
- Uses `Add()` which resets `sortGuard` on every insertion.
- No pre-allocation, so starting with empty set and growing dynamically.

### What are the changes in this PR?

<!--
Include a short description of WHAT changes were made.
-->

Use direct iteration and pre-allocation instead of `Foreach()` + `Add()`. Pre-allocate with `max(|A|, |B|)`. This strikes a balance between disjoint and overlapping set scenarios.

This eliminates:
- Unnecessary sorting via `sortedKeys()` as `Foreach` always calls `sortedKeys()`.
- Repeated sortGuard resets.
- Over-allocation for overlapping sets, as in naively always allocating `len(A) + len(B)`.

Add two new benchmarks: `BenchmarkSetUnion` and `BenchmarkSetUnionOverlapping`, following other similar benchmarks in the package.

### Notes to assist PR review:

<!--
Here you can add information you think will help the reviewer(s).
-->

Result sets have a fresh `sortGuard` (behind a `sync.Once`). When users access the result via `Iter()`, `String()`, `Foreach()`, etc., these methods call `sortedKeys()` which sorts in-place on first access.

Benchmarked with:

```bash
go test -bench="BenchmarkSetUnion" -benchmem '-run=^$' -count=10 ./v1/ast/...
```

Benchstat results:

```
cpu: Apple M1 Pro
                           │ ast_master.out │             ast_fix.out              │
                           │     sec/op     │    sec/op     vs base                │
SetUnion/5-8                   771.1n ± 11%   579.1n ± 10%  -24.89% (p=0.000 n=10)
SetUnion/50-8                  5.823µ ±  9%   4.062µ ± 11%  -30.24% (p=0.000 n=10)
SetUnion/500-8                 68.10µ ±  8%   52.13µ ± 34%  -23.45% (p=0.015 n=10)
SetUnion/5000-8               1022.4µ ±  3%   734.3µ ±  2%  -28.18% (p=0.000 n=10)
SetUnionOverlapping/5-8        448.0n ±  2%   318.6n ±  9%  -28.87% (p=0.000 n=10)
SetUnionOverlapping/50-8       4.428µ ± 22%   2.672µ ±  3%  -39.67% (p=0.000 n=10)
SetUnionOverlapping/500-8      48.28µ ± 15%   26.55µ ±  2%  -45.00% (p=0.000 n=10)
SetUnionOverlapping/5000-8     698.2µ ±  5%   444.4µ ±  7%  -36.34% (p=0.000 n=10)
geomean                        19.50µ         13.17µ        -32.46%

                           │ ast_master.out │             ast_fix.out              │
                           │      B/op      │     B/op      vs base                │
SetUnion/5-8                     856.0 ± 0%     712.0 ± 0%  -16.82% (p=0.000 n=10)
SetUnion/50-8                  6.742Ki ± 0%   4.836Ki ± 0%  -28.27% (p=0.000 n=10)
SetUnion/500-8                 89.92Ki ± 0%   74.85Ki ± 0%  -16.75% (p=0.000 n=10)
SetUnion/5000-8                881.0Ki ± 0%   697.1Ki ± 0%  -20.88% (p=0.000 n=10)
SetUnionOverlapping/5-8          400.0 ± 0%     304.0 ± 0%  -24.00% (p=0.000 n=10)
SetUnionOverlapping/50-8       3.336Ki ± 0%   1.680Ki ± 0%  -49.65% (p=0.000 n=10)
SetUnionOverlapping/500-8      45.84Ki ± 0%   22.15Ki ± 0%  -51.68% (p=0.000 n=10)
SetUnionOverlapping/5000-8     440.4Ki ± 0%   184.4Ki ± 0%  -58.12% (p=0.000 n=10)
geomean                        18.14Ki        11.73Ki       -35.37%

                           │ ast_master.out │            ast_fix.out             │
                           │   allocs/op    │ allocs/op   vs base                │
SetUnion/5-8                    12.000 ± 0%   8.000 ± 0%  -33.33% (p=0.000 n=10)
SetUnion/50-8                   21.000 ± 0%   9.000 ± 0%  -57.14% (p=0.000 n=10)
SetUnion/500-8                   35.00 ± 0%   13.00 ± 0%  -62.86% (p=0.000 n=10)
SetUnion/5000-8                 101.00 ± 0%   56.00 ± 0%  -44.55% (p=0.000 n=10)
SetUnionOverlapping/5-8          8.000 ± 0%   4.000 ± 0%  -50.00% (p=0.000 n=10)
SetUnionOverlapping/50-8        18.000 ± 0%   6.000 ± 0%  -66.67% (p=0.000 n=10)
SetUnionOverlapping/500-8       29.000 ± 0%   6.000 ± 0%  -79.31% (p=0.000 n=10)
SetUnionOverlapping/5000-8       66.00 ± 0%   20.00 ± 0%  -69.70% (p=0.000 n=10)
geomean                          26.53        10.53       -60.32%
```



### Further comments:

<!--
Here you can include links to additional resources related to the changes, discuss your solution, other approaches you considered etc.
-->

As for the `max(|A|, |B|)` pre-allocation strategy:

- Disjoint sets: OPA allocates for larger set, then grows once to full size. The trade-off is one reallocation vs. zero with sum-based pre-allocation.

- Overlapping sets: Allocates (probably) closer to actual result size. Identical sets need exactly `max(|A|, |B|)` with zero growth.

So it's optimised for a common case, while accepting growth if needed.