### PR TITLE
perf(topdown): optimize union builtin

### DIFF
--- a/v1/ast/term.go
+++ b/v1/ast/term.go
@@ -1728,6 +1728,11 @@ func NewSet(t ...*Term) Set {
 	return s
 }
 
+// NewSetWithCapacity returns a new empty Set with the given capacity pre-allocated.
+func NewSetWithCapacity(capacity int) Set {
+	return newset(capacity)
+}
+
 func newset(n int) *set {
 	var keys []*Term
 	if n > 0 {

--- a/v1/topdown/sets.go
+++ b/v1/topdown/sets.go
@@ -61,22 +61,34 @@ func builtinSetIntersection(_ BuiltinContext, operands []*ast.Term, iter func(*a
 
 // builtinSetUnion returns the union of the given input sets
 func builtinSetUnion(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term) error) error {
-	// The set union logic here is duplicated and manually inlined on
-	// purpose. By lifting this logic up a level, and not doing pairwise
-	// set unions, we avoid a number of heap allocations. This improves
-	// performance dramatically over the naive approach.
-	result := ast.NewSet()
-
+	// The set union logic here is manually inlined on purpose. By lifting
+	// this logic up a level and not doing pairwise set unions, we avoid
+	// many heap allocations. We also pre-allocate the result set by first
+	// counting total elements across all input sets.
 	inputSet, err := builtins.SetOperand(operands[0].Value, 1)
 	if err != nil {
 		return err
 	}
 
+	// First pass: count total elements for pre-allocation
+	totalSize := 0
 	err = inputSet.Iter(func(x *ast.Term) error {
 		item, err := builtins.SetOperand(x.Value, 1)
 		if err != nil {
 			return err
 		}
+		totalSize += item.Len()
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	// Pre-allocate result set with estimated capacity
+	result := ast.NewSetWithCapacity(totalSize)
+
+	err = inputSet.Iter(func(x *ast.Term) error {
+		item, _ := builtins.SetOperand(x.Value, 1) // error checked above
 		item.Foreach(result.Add)
 		return nil
 	})


### PR DESCRIPTION
<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

* You have read the project's
  [guidelines on AI tool use](https://www.openpolicyagent.org/docs/contrib-code#ai-guidelines).

For more information on contributing to OPA see our
[Contributing Guide](https://www.openpolicyagent.org/docs/contributing/)
for high-level contributing guidelines and development setup.
(See the [Developer Certificate of Origin](https://www.openpolicyagent.org/docs/contrib-code/#developer-certificate-of-origin)
section for specifics on signing off a commit.)

-->

### Why the changes in this PR are needed?

The `union()` builtin creates a result set with zero initial capacity, then grows it incrementally as elements are added from each input set. This causes repeated map and slice reallocations for large inputs.

<!--
Include a short description of WHY the changes were made.
-->

### What are the changes in this PR?

Add `NewSetWithCapacity()` to `ast` package, exposing this same functionality to other packages.

Use it in `builtinSetUnion` to pre-allocate the result set by first counting total elements across all input sets, avoiding incremental reallocations as the result grows.

<!--
Include a short description of WHAT changes were made.
-->

### Notes to assist PR review:

<!--
Here you can add information you think will help the reviewer(s).
-->

The optimization adds a first pass over the input sets to count elements, then pre-allocates accordingly. Worth mentioning that `.Len()` is O(1). The overhead of the extra iteration is minimal compared to avoiding multiple map/slice reallocations.

There is an existing benchmark for the built-in union at `BenchmarkSetUnion` and `BenchmarkSetUnionSlow`.

Run:

```bash
go test -bench="BenchmarkSetUnion" -benchmem '-run=^$' -count=10 ./v1/topdown/...
```

Benchstat results:

```
cpu: Apple M1 Pro
                       │     main      │                 fix                  │
                       │    sec/op     │    sec/op     vs base                │
SetUnion/10x10-8          17.05µ ±  4%   13.43µ ±  1%  -21.19% (p=0.000 n=10)
SetUnion/10x100-8         96.12µ ±  3%   50.35µ ± 24%  -47.61% (p=0.000 n=10)
SetUnion/10x250-8         218.2µ ±  4%   110.2µ ± 27%  -49.51% (p=0.000 n=10)
SetUnion/100x10-8        131.75µ ±  1%   87.19µ ±  8%  -33.82% (p=0.000 n=10)
SetUnion/100x100-8       1082.2µ ±  5%   518.4µ ±  2%  -52.10% (p=0.000 n=10)
SetUnion/100x250-8        2.407m ± 31%   1.279m ±  9%  -46.87% (p=0.000 n=10)
SetUnion/250x10-8         323.6µ ±  2%   218.2µ ± 12%  -32.56% (p=0.000 n=10)
SetUnion/250x100-8        2.503m ±  2%   1.274m ±  4%  -49.09% (p=0.000 n=10)
SetUnion/250x250-8        7.119m ±  4%   3.209m ±  5%  -54.92% (p=0.000 n=10)
SetUnionSlow/10x10-8      36.71µ ±  1%   36.85µ ± 11%        ~ (p=0.315 n=10)
SetUnionSlow/10x100-8     282.1µ ±  9%   280.8µ ±  1%        ~ (p=0.436 n=10)
SetUnionSlow/10x250-8     676.0µ ± 13%   801.0µ ± 30%        ~ (p=0.075 n=10)
SetUnionSlow/100x10-8     374.6µ ± 34%   343.7µ ± 11%        ~ (p=0.165 n=10)
SetUnionSlow/100x100-8    3.048m ±  3%   3.129m ±  5%        ~ (p=0.063 n=10)
SetUnionSlow/100x250-8    7.395m ± 39%   8.490m ± 61%        ~ (p=0.190 n=10)
SetUnionSlow/250x10-8     930.3µ ± 17%   843.6µ ±  9%   -9.32% (p=0.005 n=10)
SetUnionSlow/250x100-8    8.103m ± 15%   7.672m ±  6%   -5.32% (p=0.015 n=10)
SetUnionSlow/250x250-8    23.53m ± 19%   21.59m ± 12%        ~ (p=0.063 n=10)
geomean                   761.5µ         570.2µ        -25.12%

                       │     main      │                 fix                  │
                       │     B/op      │     B/op      vs base                │
SetUnion/10x10-8          14.18Ki ± 0%   10.74Ki ± 0%  -24.21% (p=0.000 n=10)
SetUnion/10x100-8         97.61Ki ± 0%   51.79Ki ± 0%  -46.94% (p=0.000 n=10)
SetUnion/10x250-8         224.2Ki ± 0%   100.0Ki ± 0%  -55.38% (p=0.000 n=10)
SetUnion/100x10-8        119.05Ki ± 0%   73.23Ki ± 0%  -38.49% (p=0.000 n=10)
SetUnion/100x100-8        913.5Ki ± 0%   399.1Ki ± 0%  -56.31% (p=0.000 n=10)
SetUnion/100x250-8       2163.8Ki ± 0%   807.9Ki ± 0%  -62.66% (p=0.000 n=10)
SetUnion/250x10-8         287.9Ki ± 0%   163.7Ki ± 0%  -43.13% (p=0.000 n=10)
SetUnion/250x100-8       2206.3Ki ± 0%   850.1Ki ± 0%  -61.47% (p=0.000 n=10)
SetUnion/250x250-8        7.221Mi ± 0%   2.811Mi ± 0%  -61.07% (p=0.000 n=10)
SetUnionSlow/10x10-8      17.89Ki ± 0%   17.89Ki ± 0%        ~ (p=0.720 n=10)
SetUnionSlow/10x100-8     129.4Ki ± 0%   129.4Ki ± 0%        ~ (p=0.590 n=10)
SetUnionSlow/10x250-8     302.9Ki ± 0%   302.9Ki ± 0%        ~ (p=0.618 n=10)
SetUnionSlow/100x10-8     159.1Ki ± 0%   159.1Ki ± 0%        ~ (p=0.588 n=10)
SetUnionSlow/100x100-8    1.206Mi ± 0%   1.206Mi ± 0%        ~ (p=0.579 n=10)
SetUnionSlow/100x250-8    2.885Mi ± 0%   2.885Mi ± 0%        ~ (p=0.987 n=10)
SetUnionSlow/250x10-8     381.9Ki ± 0%   381.9Ki ± 0%        ~ (p=0.209 n=10)
SetUnionSlow/250x100-8    2.933Mi ± 0%   2.933Mi ± 0%        ~ (p=0.896 n=10)
SetUnionSlow/250x250-8    9.148Mi ± 0%   9.146Mi ± 0%        ~ (p=0.315 n=10)
geomean                   474.7Ki        331.2Ki       -30.23%

                       │    main     │                  fix                  │
                       │  allocs/op  │  allocs/op   vs base                  │
SetUnion/10x10-8          145.0 ± 0%    133.0 ± 0%   -8.28% (p=0.000 n=10)
SetUnion/10x100-8         159.0 ± 0%    135.0 ± 0%  -15.09% (p=0.000 n=10)
SetUnion/10x250-8         172.0 ± 0%    139.0 ± 0%  -19.19% (p=0.000 n=10)
SetUnion/100x10-8         438.0 ± 0%    414.0 ± 0%   -5.48% (p=0.000 n=10)
SetUnion/100x100-8        512.0 ± 0%    445.0 ± 0%  -13.09% (p=0.000 n=10)
SetUnion/100x250-8        583.0 ± 0%    477.0 ± 0%  -18.18% (p=0.000 n=10)
SetUnion/250x10-8         907.0 ± 0%    874.0 ± 0%   -3.64% (p=0.000 n=10)
SetUnion/250x100-8       1039.0 ± 0%    932.0 ± 0%  -10.30% (p=0.000 n=10)
SetUnion/250x250-8       1.430k ± 0%   1.125k ± 0%  -21.29% (p=0.000 n=10)
SetUnionSlow/10x10-8      278.0 ± 0%    278.0 ± 0%        ~ (p=1.000 n=10) ¹
SetUnionSlow/10x100-8    1.192k ± 0%   1.192k ± 0%        ~ (p=1.000 n=10) ¹
SetUnionSlow/10x250-8    2.705k ± 0%   2.705k ± 0%        ~ (p=1.000 n=10) ¹
SetUnionSlow/100x10-8    1.912k ± 0%   1.912k ± 0%        ~ (p=1.000 n=10)
SetUnionSlow/100x100-8   10.99k ± 0%   10.99k ± 0%        ~ (p=1.000 n=10) ¹
SetUnionSlow/100x250-8   26.06k ± 0%   26.06k ± 0%        ~ (p=1.000 n=10)
SetUnionSlow/250x10-8    4.626k ± 0%   4.626k ± 0%        ~ (p=1.000 n=10) ¹
SetUnionSlow/250x100-8   27.26k ± 0%   27.26k ± 0%        ~ (p=1.000 n=10)
SetUnionSlow/250x250-8   65.15k ± 0%   65.15k ± 0%        ~ (p=1.000 n=10)
geomean                  1.555k        1.451k        -6.69%
¹ all samples are equal
```

### Further comments:

<!--
Here you can include links to additional resources related to the changes, discuss your solution, other approaches you considered etc.
-->

As the built-in union is N-ary, we cannot use the same approach of `max(|A|, |B|)` as in #8172. With many overlapping sets this approach will overallocate - but it's probably cheaper than repeated reallocations with many disjoint sets.