### PR TITLE
fix(ast): skip template string vars in ref safety

### DIFF
--- a/v1/ast/compile_test.go
+++ b/v1/ast/compile_test.go
@@ -8319,6 +8319,22 @@ func TestCompilerRewriteTemplateStrings(t *testing.T) {
 					"user_1" = __local4__[__local1__]
 				}`,
 		},
+		{
+			note: "template string in head referencing var from some with template string in domain (issue #8162)",
+			module: `package test
+				r contains $"{val}" if {
+					some val in [1, $"{1 + 1}"]
+				}`,
+			exp: `package test
+				r contains __local5__ if {
+					__local9__ = {__local3__ | plus(1, 1, __local6__); __local3__ = __local6__}
+					internal.template_string([__local9__], __local7__)
+					__local8__ = [1, __local7__]
+					__local2__ = __local8__[__local1__]
+					__local10__ = {__local4__ | __local4__ = __local2__}
+					internal.template_string([__local10__], __local5__)
+				}`,
+		},
 
 		// else
 		{

--- a/v1/ast/unify.go
+++ b/v1/ast/unify.go
@@ -11,12 +11,11 @@ func isRefSafe(ref Ref, safe VarSet) bool {
 	case Call:
 		return isCallSafe(head, safe)
 	default:
-		for v := range ref[0].Vars() {
-			if !safe.Contains(v) {
-				return false
-			}
-		}
-		return true
+		vis := varVisitorPool.Get().WithParams(SafetyCheckVisitorParams)
+		vis.Walk(ref[0])
+		isSafe := vis.Vars().DiffCount(safe) == 0
+		varVisitorPool.Put(vis)
+		return isSafe
 	}
 }
 

--- a/v1/ast/visit.go
+++ b/v1/ast/visit.go
@@ -806,7 +806,7 @@ func (vis *VarVisitor) visit(v any) bool {
 	}
 	if vis.params.SkipClosures {
 		switch v := v.(type) {
-		case *ArrayComprehension, *ObjectComprehension, *SetComprehension:
+		case *ArrayComprehension, *ObjectComprehension, *SetComprehension, *TemplateString:
 			return true
 		case *Expr:
 			if ev, ok := v.Terms.(*Every); ok {


### PR DESCRIPTION
### Why the changes in this PR are needed?

Template strings inside a ref head (like [1, $"{1+1}"][x]) caused variables to be incorrectly reported as undeclared when referenced from another template string. This affected at least some expressions and assignments.

The root cause was that when checking if a ref is safe, the compiler walked into the template string and found the builtin name `plus`, which isn't in the safe vars set. This incorrectly marked the ref as unsafe.

Fixes #8162.

<!--
Include a short description of WHY the changes were made.
-->

### What are the changes in this PR?

<!--
Include a short description of WHAT changes were made.
-->

The fix skips template strings when collecting vars for safety checks. Template strings evaluate to values and don't contribute free variables.

- `visit.go`: Added `*TemplateString` to the `SkipClosures` case, treating template strings like comprehensions.
- `unify.go`: Use `SafetyCheckVisitorParams` (which has `SkipClosures: true`) instead of a default visitor when evaluating in `isRefSafe()`.

Added a test.

### Notes to assist PR review:

Original implementation:

```go
for v := range ref[0].Vars() {
    if !safe.Contains(v) {
        return false
    }
}
return true
```

The `ref[0].Vars()` creates a default visitor and walks the term, with all skip options set to `false`. When it encounters  `$"{1 + 1}"`, it finds the var `plus`, which is the builtin function name from the call `plus(1, 1)`). Since `plus` isn't in the safe set then:

- the loop returns `false`
- it becomes an unsafe reference
- the LHS var (`val`) isn't recognised as an output variable
- error

With this proposed fix we now use `SafetyCheckVisitorParams`. It skips closures (and now template strings), so we don't incorrectly flag builtin names inside template strings as "unsafe vars".

The regression test fails against `main` branch with:

```
--- FAIL: TestCompilerRewriteTemplateStrings (0.02s)
    --- FAIL: TestCompilerRewriteTemplateStrings/template_string_in_head_referencing_var_from_some_with_template_string_in_domain_(issue_#8162) (0.00s)
        /git/opa/v1/ast/compile_test.go:8551: 1 error occurred: 2:19: rego_compile_error: var __local2__ is undeclared
```

<!--
Here you can add information you think will help the reviewer(s).
-->

### Further comments:

IMO this is consistent with how comprehensions are already handled. `SkipClosures` already skips `*ArrayComprehension`, `*ObjectComprehension`, and `*SetComprehension`. Adding `*TemplateString` to this list follows the same principle.


