### PR TITLE
perf(topdown): optimize object builtins

### DIFF
--- a/v1/ast/term.go
+++ b/v1/ast/term.go
@@ -2060,6 +2060,11 @@ func NewObject(t ...[2]*Term) Object {
 	return obj
 }
 
+// NewObjectWithCapacity returns a new empty Object with the given capacity pre-allocated.
+func NewObjectWithCapacity(capacity int) Object {
+	return newobject(capacity)
+}
+
 // ObjectTerm creates a new Term with an Object value.
 func ObjectTerm(o ...[2]*Term) *Term {
 	return &Term{Value: NewObject(o...)}

--- a/v1/topdown/object.go
+++ b/v1/topdown/object.go
@@ -52,13 +52,21 @@ func builtinObjectUnionN(_ BuiltinContext, operands []*ast.Term, iter func(*ast.
 	// Example:
 	//   Input: [{"a": {"b": 2}}, {"a": 4}, {"a": {"c": 3}}]
 	//   Want Output: {"a": {"c": 3}}
-	result := ast.NewObject()
-	frozenKeys := map[*ast.Term]struct{}{}
-	for i := arr.Len() - 1; i >= 0; i-- {
+
+	// First pass: count total keys for pre-allocation
+	totalSize := 0
+	for i := range arr.Len() {
 		o, ok := arr.Elem(i).Value.(ast.Object)
 		if !ok {
 			return builtins.NewOperandElementErr(1, arr, arr.Elem(i).Value, "object")
 		}
+		totalSize += o.Len()
+	}
+
+	result := ast.NewObjectWithCapacity(totalSize)
+	frozenKeys := make(map[*ast.Term]struct{}, totalSize)
+	for i := arr.Len() - 1; i >= 0; i-- {
+		o := arr.Elem(i).Value.(ast.Object) // Already validated above
 		mergewithOverwriteInPlace(result, o, frozenKeys)
 	}
 
@@ -77,7 +85,9 @@ func builtinObjectRemove(_ BuiltinContext, operands []*ast.Term, iter func(*ast.
 	if err != nil {
 		return err
 	}
-	r := ast.NewObject()
+
+	// Pre-allocate with obj size (upper bound for result)
+	r := ast.NewObjectWithCapacity(obj.Len())
 	obj.Foreach(func(key *ast.Term, value *ast.Term) {
 		if !keysToRemove.Contains(key) {
 			r.Insert(key, value)
@@ -100,7 +110,8 @@ func builtinObjectFilter(_ BuiltinContext, operands []*ast.Term, iter func(*ast.
 		return err
 	}
 
-	filterObj := ast.NewObject()
+	// Pre-allocate with keys size (upper bound for filter object)
+	filterObj := ast.NewObjectWithCapacity(keys.Len())
 	keys.Foreach(func(key *ast.Term) {
 		filterObj.Insert(key, ast.InternedNullTerm)
 	})


### PR DESCRIPTION
### Why the changes in this PR are needed?

Builtin object methods rely on incremental memory allocations.

Similar as #8172 and #8173.

<!--
Include a short description of WHY the changes were made.
-->

### What are the changes in this PR?

Optimize methods as follows:

- `builtinObjectUnionN`: first count total keys across all input objects, then pre-allocate.
- `builtinObjectRemove`: pre-allocate with source object size.
- `builtinObjectFilter`: pre-allocate filter object with keys size.

<!--
Include a short description of WHAT changes were made.
-->

### Notes to assist PR review:

<!--
Here you can add information you think will help the reviewer(s).
-->

Benchmark run with:

```bash
go test -bench="BenchmarkObjectUnionN" -benchmem '-run=^$' -count=10 ./v1/topdown/...
```

Results:

```
cpu: Apple M1 Pro
                           │  master.out   │               fix.out                │
                           │    sec/op     │    sec/op     vs base                │
ObjectUnionN/10x10-8          17.10µ ± 32%   14.41µ ± 15%  -15.70% (p=0.000 n=10)
ObjectUnionN/10x100-8        139.70µ ±  5%   99.38µ ±  5%  -28.86% (p=0.002 n=10)
ObjectUnionN/10x250-8         352.9µ ±  1%   266.4µ ± 15%  -24.51% (p=0.002 n=10)
ObjectUnionN/100x10-8         145.7µ ±  6%   104.7µ ±  7%  -28.16% (p=0.000 n=10)
ObjectUnionN/100x100-8        1.617m ± 11%   1.046m ±  2%  -35.33% (p=0.000 n=10)
ObjectUnionN/100x250-8        3.825m ±  8%   2.624m ±  2%  -31.41% (p=0.000 n=10)
ObjectUnionN/250x10-8         364.6µ ±  7%   263.3µ ±  6%  -27.80% (p=0.000 n=10)
ObjectUnionN/250x100-8        3.849m ± 15%   2.763m ± 15%  -28.20% (p=0.000 n=10)
ObjectUnionN/250x250-8       10.871m ± 26%   7.780m ± 29%  -28.44% (p=0.001 n=10)
ObjectUnionNSlow/10x10-8      43.43µ ± 12%   42.71µ ± 14%        ~ (p=0.143 n=10)
ObjectUnionNSlow/10x100-8     345.6µ ±  2%   353.0µ ±  3%        ~ (p=0.105 n=10)
ObjectUnionNSlow/10x250-8     844.8µ ±  4%   858.7µ ±  6%        ~ (p=0.123 n=10)
ObjectUnionNSlow/100x10-8     399.9µ ±  4%   394.4µ ±  4%        ~ (p=0.796 n=10)
ObjectUnionNSlow/100x100-8    3.826m ±  7%   3.710m ± 10%        ~ (p=0.052 n=10)
ObjectUnionNSlow/100x250-8    9.023m ± 31%   9.070m ±  4%        ~ (p=0.684 n=10)
ObjectUnionNSlow/250x10-8     977.0µ ±  1%   994.6µ ±  1%   +1.80% (p=0.003 n=10)
ObjectUnionNSlow/250x100-8   10.109m ± 21%   9.257m ±  5%        ~ (p=0.063 n=10)
ObjectUnionNSlow/250x250-8    26.54m ± 11%   24.76m ±  3%   -6.71% (p=0.009 n=10)
geomean                       965.5µ         813.4µ        -15.76%

                           │  master.out   │               fix.out                │
                           │     B/op      │     B/op      vs base                │
ObjectUnionN/10x10-8          14.09Ki ± 0%   12.93Ki ± 0%   -8.23% (p=0.000 n=10)
ObjectUnionN/10x100-8         118.6Ki ± 0%   109.0Ki ± 0%   -8.15% (p=0.000 n=10)
ObjectUnionN/10x250-8         280.4Ki ± 0%   228.6Ki ± 0%  -18.46% (p=0.000 n=10)
ObjectUnionN/100x10-8         121.5Ki ± 0%   111.8Ki ± 0%   -7.96% (p=0.000 n=10)
ObjectUnionN/100x100-8       1126.2Ki ± 0%   901.5Ki ± 0%  -19.95% (p=0.000 n=10)
ObjectUnionN/100x250-8        2.664Mi ± 0%   1.905Mi ± 0%  -28.49% (p=0.000 n=10)
ObjectUnionN/250x10-8         287.9Ki ± 0%   236.2Ki ± 0%  -17.98% (p=0.000 n=10)
ObjectUnionN/250x100-8        2.668Mi ± 0%   1.910Mi ± 0%  -28.44% (p=0.000 n=10)
ObjectUnionN/250x250-8        8.597Mi ± 0%   6.440Mi ± 0%  -25.09% (p=0.000 n=10)
ObjectUnionNSlow/10x10-8      20.90Ki ± 0%   20.90Ki ± 0%        ~ (p=0.157 n=10)
ObjectUnionNSlow/10x100-8     161.6Ki ± 0%   161.6Ki ± 0%        ~ (p=0.492 n=10)
ObjectUnionNSlow/10x250-8     381.7Ki ± 0%   381.7Ki ± 0%        ~ (p=0.119 n=10)
ObjectUnionNSlow/100x10-8     190.3Ki ± 0%   190.3Ki ± 0%   -0.00% (p=0.006 n=10)
ObjectUnionNSlow/100x100-8    1.521Mi ± 0%   1.521Mi ± 0%        ~ (p=0.218 n=10)
ObjectUnionNSlow/100x250-8    3.653Mi ± 0%   3.653Mi ± 0%        ~ (p=0.912 n=10)
ObjectUnionNSlow/250x10-8     460.2Ki ± 0%   460.2Ki ± 0%        ~ (p=0.541 n=10)
ObjectUnionNSlow/250x100-8    3.719Mi ± 0%   3.719Mi ± 0%        ~ (p=0.684 n=10)
ObjectUnionNSlow/250x250-8    11.06Mi ± 0%   11.06Mi ± 0%        ~ (p=0.123 n=10)
geomean                       564.9Ki        510.1Ki        -9.70%

                           │ master.out  │               fix.out                │
                           │  allocs/op  │  allocs/op   vs base                 │
ObjectUnionN/10x10-8          209.0 ± 0%    198.0 ± 0%  -5.26% (p=0.000 n=10)
ObjectUnionN/10x100-8        1.123k ± 0%   1.102k ± 0%  -1.87% (p=0.000 n=10)
ObjectUnionN/10x250-8        2.636k ± 0%   2.611k ± 0%  -0.95% (p=0.000 n=10)
ObjectUnionN/100x10-8        1.213k ± 0%   1.192k ± 0%  -1.73% (p=0.000 n=10)
ObjectUnionN/100x100-8       10.29k ± 0%   10.25k ± 0%  -0.33% (p=0.000 n=10)
ObjectUnionN/100x250-8       25.36k ± 0%   25.32k ± 0%  -0.15% (p=0.000 n=10)
ObjectUnionN/250x10-8        2.876k ± 0%   2.851k ± 0%  -0.87% (p=0.000 n=10)
ObjectUnionN/250x100-8       25.50k ± 0%   25.47k ± 0%  -0.15% (p=0.000 n=10)
ObjectUnionN/250x250-8       63.40k ± 0%   63.35k ± 0%  -0.07% (p=0.000 n=10)
ObjectUnionNSlow/10x10-8      387.0 ± 0%    387.0 ± 0%       ~ (p=1.000 n=10) ¹
ObjectUnionNSlow/10x100-8    2.201k ± 0%   2.201k ± 0%       ~ (p=0.474 n=10)
ObjectUnionNSlow/10x250-8    5.215k ± 0%   5.215k ± 0%       ~ (p=1.000 n=10) ¹
ObjectUnionNSlow/100x10-8    3.012k ± 0%   3.012k ± 0%       ~ (p=1.000 n=10) ¹
ObjectUnionNSlow/100x100-8   21.09k ± 0%   21.09k ± 0%       ~ (p=0.170 n=10)
ObjectUnionNSlow/100x250-8   51.16k ± 0%   51.16k ± 0%       ~ (p=1.000 n=10)
ObjectUnionNSlow/250x10-8    7.375k ± 0%   7.375k ± 0%       ~ (p=1.000 n=10)
ObjectUnionNSlow/250x100-8   52.51k ± 0%   52.51k ± 0%       ~ (p=1.000 n=10)
ObjectUnionNSlow/250x250-8   127.9k ± 0%   127.9k ± 0%  +0.00% (p=0.042 n=10)
geomean                      6.652k        6.609k       -0.64%
¹ all samples are equal
```

### Further comments:

<!--
Here you can include links to additional resources related to the changes, discuss your solution, other approaches you considered etc.
-->


Similar to the `union()` set optimization, `builtinObjectUnionN` uses sum-of-sizes for pre-allocation since it's N-ary. For `object.remove` and `object.filter`, we use the input object/keys size as an upper bound. Might cause over-allocation, but better than realloc IMO.