### PR TITLE
perf(topdown): skip set copy in getObjectKeysParam

### DIFF
--- a/v1/topdown/object.go
+++ b/v1/topdown/object.go
@@ -158,7 +158,9 @@ func builtinObjectKeys(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Te
 }
 
 // getObjectKeysParam returns a set of key values
-// from a supplied ast array, object, set value
+// from a supplied ast array, object, set value.
+// The returned set must not be mutated. For Set
+// inputs, it may be the original.
 func getObjectKeysParam(arrayOrSet ast.Value) (ast.Set, error) {
 	switch v := arrayOrSet.(type) {
 	case *ast.Array:
@@ -166,7 +168,9 @@ func getObjectKeysParam(arrayOrSet ast.Value) (ast.Set, error) {
 		v.Foreach(keys.Add)
 		return keys, nil
 	case ast.Set:
-		return ast.NewSet(v.Slice()...), nil
+		// Return directly. Callers only use this for Contains() checks
+		// without mutating the set.
+		return v, nil
 	case ast.Object:
 		return ast.NewSet(v.Keys()...), nil
 	}


### PR DESCRIPTION
### Why the changes in this PR are needed?

When `object.remove` or `object.filter` receives a Set as the keys parameter, `getObjectKeysParam` was unnecessarily copying the entire set before using it for containment checks. This performed O(N) allocations and O(N) hash insertions only to then read from the set without ever mutating it.

<!--
Include a short description of WHY the changes were made.
-->

### What are the changes in this PR?

Return the original Set directly in `getObjectKeysParam` instead of copying it. Currently the returned set is only used for read-only `.Contains()` lookups. Added a comment documenting that the returned set must not be mutated.

<!--
Include a short description of WHAT changes were made.
-->

### Notes to assist PR review:

<!--
Here you can add information you think will help the reviewer(s).
-->

Additional notes:

- The function is internal and only called by `builtinObjectRemove` and `builtinObjectFilter`.
- Both callers only use the returned set for checks like:

```go
	keysToRemove, err := getObjectKeysParam(operands[1].Value)
	...
	obj.Foreach(...) {
		if !keysToRemove.Contains(key) {
			...
		}
	})
```
- For Array and Object, we must still create a Set due to type conversion

### Further comments:

I couldn't find any existing benchmarks that would hit this path. I could add a benchmark here, but I thought the change is maybe straightforward enough. Happy to hear thoughts on this!

<!--
Here you can include links to additional resources related to the changes, discuss your solution, other approaches you considered etc.
-->
