### PR TITLE
fix(ast): use original var names in template error

### DIFF
--- a/v1/ast/compile.go
+++ b/v1/ast/compile.go
@@ -2112,7 +2112,7 @@ func (c *Compiler) rewriteTemplateStrings() {
 			safe := r.Head.Args.Vars()
 			safe.Update(ReservedVars)
 
-			modrec, safe, errs := rewriteTemplateStrings(c.capabilities, c.localvargen, c.GetArity, safe, c.builtinLoc, r.Body)
+			modrec, safe, errs := rewriteTemplateStrings(c.capabilities, c.localvargen, c.GetArity, safe, c.builtinLoc, c.RewrittenVars, r.Body)
 			if modrec {
 				modified = true
 			}
@@ -2120,7 +2120,7 @@ func (c *Compiler) rewriteTemplateStrings() {
 				c.err(err)
 			}
 
-			modrec, _, errs = rewriteTemplateStrings(c.capabilities, c.localvargen, c.GetArity, safe, c.builtinLoc, r.Head)
+			modrec, _, errs = rewriteTemplateStrings(c.capabilities, c.localvargen, c.GetArity, safe, c.builtinLoc, c.RewrittenVars, r.Head)
 			if modrec {
 				modified = true
 			}
@@ -2136,7 +2136,7 @@ func (c *Compiler) rewriteTemplateStrings() {
 	}
 }
 
-func rewriteTemplateStrings(caps *Capabilities, gen *localVarGenerator, getArity func(Ref) int, globals VarSet, builtins builtinLocator, x any) (bool, VarSet, Errors) {
+func rewriteTemplateStrings(caps *Capabilities, gen *localVarGenerator, getArity func(Ref) int, globals VarSet, builtins builtinLocator, rewritten map[Var]Var, x any) (bool, VarSet, Errors) {
 	var errs Errors
 	var modified bool
 
@@ -2155,43 +2155,43 @@ func rewriteTemplateStrings(caps *Capabilities, gen *localVarGenerator, getArity
 		switch x := x.(type) {
 		case *Term:
 			if _, ok := x.Value.(*TemplateString); ok {
-				modrec, errsrec = rewriteTemplateStringTerm(caps, gen, safe, builtins, x)
+				modrec, errsrec = rewriteTemplateStringTerm(caps, gen, safe, builtins, rewritten, x)
 			}
 		case *SetComprehension:
 			var s VarSet
-			modrec, s, errsrec = rewriteTemplateStrings(caps, gen, getArity, safe, builtins, x.Body)
+			modrec, s, errsrec = rewriteTemplateStrings(caps, gen, getArity, safe, builtins, rewritten, x.Body)
 			if modrec {
 				modified = true
 			}
 			errs = append(errs, errsrec...)
 
-			modrec, errsrec = rewriteTemplateStringTerm(caps, gen, s, builtins, x.Term)
+			modrec, errsrec = rewriteTemplateStringTerm(caps, gen, s, builtins, rewritten, x.Term)
 		case *ArrayComprehension:
 			var s VarSet
-			modrec, s, errsrec = rewriteTemplateStrings(caps, gen, getArity, safe, builtins, x.Body)
+			modrec, s, errsrec = rewriteTemplateStrings(caps, gen, getArity, safe, builtins, rewritten, x.Body)
 			if modrec {
 				modified = true
 			}
 			errs = append(errs, errsrec...)
 
-			modrec, errsrec = rewriteTemplateStringTerm(caps, gen, s, builtins, x.Term)
+			modrec, errsrec = rewriteTemplateStringTerm(caps, gen, s, builtins, rewritten, x.Term)
 		case *ObjectComprehension:
 			var s VarSet
-			modrec, s, errsrec = rewriteTemplateStrings(caps, gen, getArity, safe, builtins, x.Body)
+			modrec, s, errsrec = rewriteTemplateStrings(caps, gen, getArity, safe, builtins, rewritten, x.Body)
 			if modrec {
 				modified = true
 			}
 			errs = append(errs, errsrec...)
 
-			modrec, errsrec = rewriteTemplateStringTerm(caps, gen, s, builtins, x.Key)
+			modrec, errsrec = rewriteTemplateStringTerm(caps, gen, s, builtins, rewritten, x.Key)
 			if modrec {
 				modified = true
 			}
 			errs = append(errs, errsrec...)
 
-			modrec, errsrec = rewriteTemplateStringTerm(caps, gen, s, builtins, x.Value)
+			modrec, errsrec = rewriteTemplateStringTerm(caps, gen, s, builtins, rewritten, x.Value)
 		case *Every:
-			modrec, errsrec = rewriteTemplateStringTerm(caps, gen, safe, builtins, x.Domain)
+			modrec, errsrec = rewriteTemplateStringTerm(caps, gen, safe, builtins, rewritten, x.Domain)
 			if modrec {
 				modified = true
 			}
@@ -2199,7 +2199,7 @@ func rewriteTemplateStrings(caps *Capabilities, gen *localVarGenerator, getArity
 
 			s := safe.Copy()
 			s.Update(x.KeyValueVars())
-			modrec, _, errsrec = rewriteTemplateStrings(caps, gen, getArity, s, builtins, x.Body)
+			modrec, _, errsrec = rewriteTemplateStrings(caps, gen, getArity, s, builtins, rewritten, x.Body)
 		}
 		if modrec {
 			modified = true
@@ -2212,9 +2212,9 @@ func rewriteTemplateStrings(caps *Capabilities, gen *localVarGenerator, getArity
 	return modified, safe, errs
 }
 
-func rewriteTemplateStringTerm(caps *Capabilities, gen *localVarGenerator, globals VarSet, builtins builtinLocator, t *Term) (bool, Errors) {
+func rewriteTemplateStringTerm(caps *Capabilities, gen *localVarGenerator, globals VarSet, builtins builtinLocator, rewritten map[Var]Var, t *Term) (bool, Errors) {
 	if ts, ok := t.Value.(*TemplateString); ok {
-		call, errs := rewriteTemplateString(caps, gen, globals, builtins, t.Loc(), ts)
+		call, errs := rewriteTemplateString(caps, gen, globals, builtins, rewritten, t.Loc(), ts)
 		if len(errs) != 0 {
 			return false, errs
 		}
@@ -2226,7 +2226,7 @@ func rewriteTemplateStringTerm(caps *Capabilities, gen *localVarGenerator, globa
 
 type builtinLocator func(Ref) *Builtin
 
-func rewriteTemplateString(caps *Capabilities, gen *localVarGenerator, safe VarSet, builtins builtinLocator, loc *Location, ts *TemplateString) (Call, Errors) {
+func rewriteTemplateString(caps *Capabilities, gen *localVarGenerator, safe VarSet, builtins builtinLocator, rewritten map[Var]Var, loc *Location, ts *TemplateString) (Call, Errors) {
 	if !caps.ContainsFeature(FeatureTemplateStrings) || !caps.ContainsBuiltin(InternalTemplateString.Name) {
 		return nil, Errors{NewError(CompileErr, loc, "template-strings are not supported")}
 	}
@@ -2263,6 +2263,9 @@ func rewriteTemplateString(caps *Capabilities, gen *localVarGenerator, safe VarS
 				if vars.DiffCount(safe) > 0 {
 					unsafe := vars.Diff(safe)
 					for _, v := range unsafe.Sorted() {
+						if w, ok := rewritten[v]; ok {
+							v = w
+						}
 						errs = append(errs, NewError(CompileErr, t.Loc(), "var %v is undeclared", v))
 					}
 				}
@@ -3378,7 +3381,7 @@ func (qc *queryCompiler) rewriteLocalVars(_ *QueryContext, body Body) (Body, err
 
 func (qc *queryCompiler) rewriteTemplateStrings(_ *QueryContext, body Body) (Body, error) {
 	gen := newLocalVarGenerator("q", body)
-	if _, _, errs := rewriteTemplateStrings(qc.compiler.capabilities, gen, qc.compiler.GetArity, ReservedVars, qc.compiler.builtinLoc, body); len(errs) > 0 {
+	if _, _, errs := rewriteTemplateStrings(qc.compiler.capabilities, gen, qc.compiler.GetArity, ReservedVars, qc.compiler.builtinLoc, qc.rewritten, body); len(errs) > 0 {
 		return nil, errs
 	}
 	return body, nil

--- a/v1/ast/compile_test.go
+++ b/v1/ast/compile_test.go
@@ -8660,7 +8660,7 @@ func TestCompilerRewriteTemplateStringsErrors(t *testing.T) {
 						x != "b"
 					}
 				}`,
-			exp: "var __local1__ is undeclared", // FIXME
+			exp: "var x is undeclared",
 		},
 		{
 			note: "undeclared var, inside every body",
@@ -8677,6 +8677,15 @@ func TestCompilerRewriteTemplateStringsErrors(t *testing.T) {
 			module: `package test
 p := $"{walk(["a", "b"])}"`,
 			exp: "illegal call to relation built-in 'walk' that may cause multiple outputs",
+		},
+		{
+			note: "undeclared var, some-in with undeclared collection (issue #8157)",
+			module: `package test
+				items contains item if {
+					some label in labels
+					item := $"{label}"
+				}`,
+			exp: "var label is undeclared",
 		},
 	}
 


### PR DESCRIPTION
### Why the changes in this PR are needed?

<!--
Include a short description of WHY the changes were made.
-->

When a template string expression contains an undeclared variable, the compiler was reporting the internal rewritten variable name (e.g., `__local2__`) instead of the original variable name. This is described in issue #8157.

### What are the changes in this PR?

<!--
Include a short description of WHAT changes were made.
-->

The rewrite map `RewrittenVars` is now passed through template string rewriting functions. The rewritten variable names are translated back to original names when errors are being generated.

There actually was a test case already for this marked with `FIXME`. The test is now fixed and I also added a regression test from #8157.

### Notes to assist PR review:

<!--
Here you can add information you think will help the reviewer(s).
-->

The `RewriteLocalVars` compiler stage runs before `RewriteTemplateStrings`, so variables have already been renamed to internal names by the time template string safety checks run. The fix follows the same pattern used elsewhere like in `safetyErrorSlice` and `checkSafetyRuleHeads`.

### Further comments:

<!--
Here you can include links to additional resources related to the changes, discuss your solution, other approaches you considered etc.
-->

Fixes #8157.
