### PR TITLE
Wrap agent startup hook commands with bash -c

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,11 +6,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "if [ -f \"$CLAUDE_PROJECT_DIR/AGENTS.md\" ]; then cat \"$CLAUDE_PROJECT_DIR/AGENTS.md\"; fi"
+            "command": "bash -c 'if [ -f \"$CLAUDE_PROJECT_DIR/AGENTS.md\" ]; then cat \"$CLAUDE_PROJECT_DIR/AGENTS.md\"; fi'"
           },
           {
             "type": "command",
-            "command": "if [ -f \"$CLAUDE_PROJECT_DIR/docs/docs/contrib-code.md\" ]; then cat \"$CLAUDE_PROJECT_DIR/docs/docs/contrib-code.md\"; fi"
+            "command": "bash -c 'if [ -f \"$CLAUDE_PROJECT_DIR/docs/docs/contrib-code.md\" ]; then cat \"$CLAUDE_PROJECT_DIR/docs/docs/contrib-code.md\"; fi'"
           }
         ]
       }


### PR DESCRIPTION
Updated sessionStart hook commands to explicitly use bash -c wrapper. This improves compatibility across different environments where default shell may vary.

See https://github.com/open-policy-agent/opa/pull/8147 for more context.