### PR TITLE
perf: `String()` implementations using appenders

### DIFF
--- a/internal/edittree/edittree.go
+++ b/internal/edittree/edittree.go
@@ -602,7 +602,7 @@ func (e *EditTree) Unfold(path ast.Ref) (*EditTree, error) {
 			}
 			return child.Unfold(path[1:])
 		}
-		return nil, fmt.Errorf("path %v does not exist in object term %v", ast.Ref{path[0]}, e.value.Value)
+		return nil, fmt.Errorf("path %v does not exist in object term %v", path[0], e.value.Value)
 	case ast.Set:
 		// Sets' keys *are* their values, so in order to allow accurate
 		// traversal, we have to collapse the tree beneath this node,
@@ -662,10 +662,10 @@ func (e *EditTree) Unfold(path ast.Ref) (*EditTree, error) {
 			}
 			return child.Unfold(path[1:])
 		}
-		return nil, fmt.Errorf("path %v does not exist in array term %v", ast.Ref{ast.IntNumberTerm(idx)}, e.value.Value)
+		return nil, fmt.Errorf("path %v does not exist in array term %v", ast.IntNumberTerm(idx), e.value.Value)
 	default:
 		// Catch all primitive types.
-		return nil, fmt.Errorf("expected composite type for path %v, found value: %v (type: %T)", ast.Ref{path[0]}, x, x)
+		return nil, fmt.Errorf("expected composite type for path %v, found value: %v (type: %T)", path[0], x, x)
 	}
 }
 

--- a/internal/edittree/edittree_test.go
+++ b/internal/edittree/edittree_test.go
@@ -561,7 +561,7 @@ func TestEditTreeApplyPatches(t *testing.T) {
 		{
 			note: "nested remove on nested primitive number",
 			patches: []string{
-				`{"op": "test", "path": "/a/2/b", "value": 3}`,
+				`{"op": "remove", "path": "/a/2/b", "value": 3}`,
 			},
 			source:   `{"a": 2}`,
 			expError: errors.New(`expected composite type for path "2", found value: 2 (type: ast.Number)`),
@@ -844,7 +844,7 @@ func TestEditTreeApplyPatches(t *testing.T) {
 			if err != nil {
 				if tc.expError != nil {
 					if tc.expError.Error() != err.Error() {
-						t.Fatalf("wrong error: %s", err)
+						t.Fatalf("wrong error\ngot: %q\nexp: %q\n", err.Error(), tc.expError.Error())
 					}
 				} else {
 					t.Fatalf("unexpected error building EditTree: %s", err)

--- a/v1/ast/builtins.go
+++ b/v1/ast/builtins.go
@@ -1823,7 +1823,8 @@ var ObjectKeys = &Builtin{
 /*
  *  Encoding
  */
-var encoding = category("encoding")
+// Not using 'encoding' to avoid having to alias stdlib "encoding" imports
+var catEncoding = category("encoding")
 
 var JSONMarshal = &Builtin{
 	Name:        "json.marshal",
@@ -1834,7 +1835,7 @@ var JSONMarshal = &Builtin{
 		),
 		types.Named("y", types.S).Description("the JSON string representation of `x`"),
 	),
-	Categories:  encoding,
+	Categories:  catEncoding,
 	CanSkipBctx: true,
 }
 
@@ -1856,7 +1857,7 @@ var JSONMarshalWithOptions = &Builtin{
 		),
 		types.Named("y", types.S).Description("the JSON string representation of `x`, with configured prefix/indent string(s) as appropriate"),
 	),
-	Categories:  encoding,
+	Categories:  catEncoding,
 	CanSkipBctx: true,
 }
 
@@ -1869,7 +1870,7 @@ var JSONUnmarshal = &Builtin{
 		),
 		types.Named("y", types.A).Description("the term deserialized from `x`"),
 	),
-	Categories:  encoding,
+	Categories:  catEncoding,
 	CanSkipBctx: true,
 }
 
@@ -1882,7 +1883,7 @@ var JSONIsValid = &Builtin{
 		),
 		types.Named("result", types.B).Description("`true` if `x` is valid JSON, `false` otherwise"),
 	),
-	Categories:  encoding,
+	Categories:  catEncoding,
 	CanSkipBctx: true,
 }
 
@@ -1895,7 +1896,7 @@ var Base64Encode = &Builtin{
 		),
 		types.Named("y", types.S).Description("base64 serialization of `x`"),
 	),
-	Categories:  encoding,
+	Categories:  catEncoding,
 	CanSkipBctx: true,
 }
 
@@ -1908,7 +1909,7 @@ var Base64Decode = &Builtin{
 		),
 		types.Named("y", types.S).Description("base64 deserialization of `x`"),
 	),
-	Categories:  encoding,
+	Categories:  catEncoding,
 	CanSkipBctx: true,
 }
 
@@ -1921,7 +1922,7 @@ var Base64IsValid = &Builtin{
 		),
 		types.Named("result", types.B).Description("`true` if `x` is valid base64 encoded value, `false` otherwise"),
 	),
-	Categories:  encoding,
+	Categories:  catEncoding,
 	CanSkipBctx: true,
 }
 
@@ -1934,7 +1935,7 @@ var Base64UrlEncode = &Builtin{
 		),
 		types.Named("y", types.S).Description("base64url serialization of `x`"),
 	),
-	Categories:  encoding,
+	Categories:  catEncoding,
 	CanSkipBctx: true,
 }
 
@@ -1947,7 +1948,7 @@ var Base64UrlEncodeNoPad = &Builtin{
 		),
 		types.Named("y", types.S).Description("base64url serialization of `x`"),
 	),
-	Categories:  encoding,
+	Categories:  catEncoding,
 	CanSkipBctx: true,
 }
 
@@ -1960,7 +1961,7 @@ var Base64UrlDecode = &Builtin{
 		),
 		types.Named("y", types.S).Description("base64url deserialization of `x`"),
 	),
-	Categories:  encoding,
+	Categories:  catEncoding,
 	CanSkipBctx: true,
 }
 
@@ -1973,7 +1974,7 @@ var URLQueryDecode = &Builtin{
 		),
 		types.Named("y", types.S).Description("URL-encoding deserialization of `x`"),
 	),
-	Categories:  encoding,
+	Categories:  catEncoding,
 	CanSkipBctx: true,
 }
 
@@ -1986,7 +1987,7 @@ var URLQueryEncode = &Builtin{
 		),
 		types.Named("y", types.S).Description("URL-encoding serialization of `x`"),
 	),
-	Categories:  encoding,
+	Categories:  catEncoding,
 	CanSkipBctx: true,
 }
 
@@ -2010,7 +2011,7 @@ var URLQueryEncodeObject = &Builtin{
 		),
 		types.Named("y", types.S).Description("the URL-encoded serialization of `object`"),
 	),
-	Categories:  encoding,
+	Categories:  catEncoding,
 	CanSkipBctx: true,
 }
 
@@ -2025,7 +2026,7 @@ var URLQueryDecodeObject = &Builtin{
 			types.S,
 			types.NewArray(nil, types.S)))).Description("the resulting object"),
 	),
-	Categories:  encoding,
+	Categories:  catEncoding,
 	CanSkipBctx: true,
 }
 
@@ -2038,7 +2039,7 @@ var YAMLMarshal = &Builtin{
 		),
 		types.Named("y", types.S).Description("the YAML string representation of `x`"),
 	),
-	Categories:  encoding,
+	Categories:  catEncoding,
 	CanSkipBctx: true,
 }
 
@@ -2051,7 +2052,7 @@ var YAMLUnmarshal = &Builtin{
 		),
 		types.Named("y", types.A).Description("the term deserialized from `x`"),
 	),
-	Categories:  encoding,
+	Categories:  catEncoding,
 	CanSkipBctx: true,
 }
 
@@ -2065,7 +2066,7 @@ var YAMLIsValid = &Builtin{
 		),
 		types.Named("result", types.B).Description("`true` if `x` is valid YAML, `false` otherwise"),
 	),
-	Categories:  encoding,
+	Categories:  catEncoding,
 	CanSkipBctx: true,
 }
 
@@ -2078,7 +2079,7 @@ var HexEncode = &Builtin{
 		),
 		types.Named("y", types.S).Description("serialization of `x` using hex-encoding"),
 	),
-	Categories:  encoding,
+	Categories:  catEncoding,
 	CanSkipBctx: true,
 }
 
@@ -2091,7 +2092,7 @@ var HexDecode = &Builtin{
 		),
 		types.Named("y", types.S).Description("deserialized from `x`"),
 	),
-	Categories:  encoding,
+	Categories:  catEncoding,
 	CanSkipBctx: true,
 }
 

--- a/v1/ast/performance.go
+++ b/v1/ast/performance.go
@@ -4,6 +4,7 @@
 package ast
 
 import (
+	"encoding"
 	"strings"
 	"sync"
 )
@@ -82,4 +83,17 @@ func BuiltinNameFromRef(ref Ref) (string, bool) {
 	}
 
 	return "", false
+}
+
+func AppendDelimeted[T encoding.TextAppender](buf []byte, appenders []T, delim string) ([]byte, error) {
+	for i, item := range appenders {
+		if i > 0 {
+			buf = append(buf, delim...)
+		}
+		var err error
+		if buf, err = item.AppendText(buf); err != nil {
+			return nil, err
+		}
+	}
+	return buf, nil
 }

--- a/v1/ast/policy.go
+++ b/v1/ast/policy.go
@@ -371,42 +371,8 @@ func (mod *Module) Equal(other *Module) bool {
 }
 
 func (mod *Module) String() string {
-	byNode := map[Node][]*Annotations{}
-	for _, a := range mod.Annotations {
-		byNode[a.node] = append(byNode[a.node], a)
-	}
-
-	appendAnnotationStrings := func(buf []string, node Node) []string {
-		if as, ok := byNode[node]; ok {
-			for i := range as {
-				buf = append(buf,
-					"# METADATA",
-					"# "+as[i].String(),
-				)
-			}
-		}
-		return buf
-	}
-
-	buf := []string{}
-	buf = appendAnnotationStrings(buf, mod.Package)
-	buf = append(buf, mod.Package.String())
-
-	if len(mod.Imports) > 0 {
-		buf = append(buf, "")
-		for _, imp := range mod.Imports {
-			buf = appendAnnotationStrings(buf, imp)
-			buf = append(buf, imp.String())
-		}
-	}
-	if len(mod.Rules) > 0 {
-		buf = append(buf, "")
-		for _, rule := range mod.Rules {
-			buf = appendAnnotationStrings(buf, rule)
-			buf = append(buf, rule.stringWithOpts(toStringOpts{regoVersion: mod.regoVersion}))
-		}
-	}
-	return strings.Join(buf, "\n")
+	buf, _ := mod.AppendText(make([]byte, 0, mod.StringLength()))
+	return util.ByteSliceToString(buf)
 }
 
 // RuleSet returns a RuleSet containing named rules in the mod.
@@ -475,7 +441,8 @@ func (c *Comment) SetLoc(loc *Location) {
 }
 
 func (c *Comment) String() string {
-	return "#" + string(c.Text)
+	buf, _ := c.AppendText(make([]byte, 0, c.StringLength()))
+	return util.ByteSliceToString(buf)
 }
 
 // Copy returns a deep copy of c.
@@ -525,16 +492,8 @@ func (pkg *Package) SetLoc(loc *Location) {
 }
 
 func (pkg *Package) String() string {
-	if pkg == nil {
-		return "<illegal nil package>"
-	} else if len(pkg.Path) <= 1 {
-		return fmt.Sprintf("package <illegal path %q>", pkg.Path)
-	}
-	// Omit head as all packages have the DefaultRootDocument prepended at parse time.
-	path := make(Ref, len(pkg.Path)-1)
-	path[0] = VarTerm(string(pkg.Path[1].Value.(String)))
-	copy(path[1:], pkg.Path[2:])
-	return fmt.Sprintf("package %v", path)
+	buf, _ := pkg.AppendText(make([]byte, 0, pkg.StringLength()))
+	return util.ByteSliceToString(buf)
 }
 
 func (pkg *Package) MarshalJSON() ([]byte, error) {
@@ -637,11 +596,8 @@ func (imp *Import) Name() Var {
 }
 
 func (imp *Import) String() string {
-	buf := []string{"import", imp.Path.String()}
-	if len(imp.Alias) > 0 {
-		buf = append(buf, "as", imp.Alias.String())
-	}
-	return strings.Join(buf, " ")
+	buf, _ := imp.AppendText(make([]byte, 0, imp.StringLength()))
+	return util.ByteSliceToString(buf)
 }
 
 func (imp *Import) MarshalJSON() ([]byte, error) {
@@ -752,11 +708,12 @@ func (rule *Rule) Ref() Ref {
 }
 
 func (rule *Rule) String() string {
-	regoVersion := DefaultRegoVersion
+	opts := toStringOpts{}
 	if rule.Module != nil {
-		regoVersion = rule.Module.RegoVersion()
+		opts.regoVersion = rule.Module.RegoVersion()
 	}
-	return rule.stringWithOpts(toStringOpts{regoVersion: regoVersion})
+	buf, _ := rule.appendWithOpts(opts, make([]byte, 0, rule.stringLengthWithOpts(opts)))
+	return util.ByteSliceToString(buf)
 }
 
 type toStringOpts struct {
@@ -768,25 +725,6 @@ func (o toStringOpts) RegoVersion() RegoVersion {
 		return DefaultRegoVersion
 	}
 	return o.regoVersion
-}
-
-func (rule *Rule) stringWithOpts(opts toStringOpts) string {
-	buf := []string{}
-	if rule.Default {
-		buf = append(buf, "default")
-	}
-	buf = append(buf, rule.Head.stringWithOpts(opts))
-	if !rule.Default {
-		switch opts.RegoVersion() {
-		case RegoV1, RegoV0CompatV1:
-			buf = append(buf, "if")
-		}
-		buf = append(buf, "{", rule.Body.String(), "}")
-	}
-	if rule.Else != nil {
-		buf = append(buf, rule.Else.elseString(opts))
-	}
-	return strings.Join(buf, " ")
 }
 
 func (rule *Rule) isFunction() bool {
@@ -818,30 +756,6 @@ func (rule *Rule) MarshalJSON() ([]byte, error) {
 	}
 
 	return json.Marshal(data)
-}
-
-func (rule *Rule) elseString(opts toStringOpts) string {
-	var buf []string
-
-	buf = append(buf, "else")
-
-	value := rule.Head.Value
-	if value != nil {
-		buf = append(buf, "=", value.String())
-	}
-
-	switch opts.RegoVersion() {
-	case RegoV1, RegoV0CompatV1:
-		buf = append(buf, "if")
-	}
-
-	buf = append(buf, "{", rule.Body.String(), "}")
-
-	if rule.Else != nil {
-		buf = append(buf, rule.Else.elseString(opts))
-	}
-
-	return strings.Join(buf, " ")
 }
 
 // NewHead returns a new Head object. If args are provided, the first will be
@@ -1002,37 +916,8 @@ func (head *Head) String() string {
 }
 
 func (head *Head) stringWithOpts(opts toStringOpts) string {
-	buf := strings.Builder{}
-	buf.WriteString(head.Ref().String())
-	containsAdded := false
-
-	switch {
-	case len(head.Args) != 0:
-		buf.WriteString(head.Args.String())
-	case len(head.Reference) == 1 && head.Key != nil:
-		switch opts.RegoVersion() {
-		case RegoV0:
-			buf.WriteRune('[')
-			buf.WriteString(head.Key.String())
-			buf.WriteRune(']')
-		default:
-			containsAdded = true
-			buf.WriteString(" contains ")
-			buf.WriteString(head.Key.String())
-		}
-	}
-	if head.Value != nil {
-		if head.Assign {
-			buf.WriteString(" := ")
-		} else {
-			buf.WriteString(" = ")
-		}
-		buf.WriteString(head.Value.String())
-	} else if !containsAdded && head.Name == "" && head.Key != nil {
-		buf.WriteString(" contains ")
-		buf.WriteString(head.Key.String())
-	}
-	return buf.String()
+	buf, _ := head.appendWithOpts(opts, make([]byte, 0, head.stringLengthWithOpts(opts)))
+	return util.ByteSliceToString(buf)
 }
 
 func (head *Head) MarshalJSON() ([]byte, error) {
@@ -1103,11 +988,8 @@ func (a Args) Copy() Args {
 }
 
 func (a Args) String() string {
-	buf := make([]string, 0, len(a))
-	for _, t := range a {
-		buf = append(buf, t.String())
-	}
-	return "(" + strings.Join(buf, ", ") + ")"
+	buf, _ := a.AppendText(make([]byte, 0, a.StringLength()))
+	return util.ByteSliceToString(buf)
 }
 
 // Loc returns the Location of a.
@@ -1240,11 +1122,12 @@ func (body Body) SetLoc(loc *Location) {
 }
 
 func (body Body) String() string {
-	buf := make([]string, 0, len(body))
-	for _, v := range body {
-		buf = append(buf, v.String())
-	}
-	return strings.Join(buf, "; ")
+	buf, _ := body.AppendText(make([]byte, 0, body.StringLength()))
+	return util.ByteSliceToString(buf)
+}
+
+func (body Body) AppendText(buf []byte) ([]byte, error) {
+	return AppendDelimeted(buf, body, "; ")
 }
 
 // Vars returns a VarSet containing variables in body. The params can be set to
@@ -1555,26 +1438,8 @@ func (expr *Expr) SetLoc(loc *Location) {
 }
 
 func (expr *Expr) String() string {
-	buf := make([]string, 0, 2+len(expr.With))
-	if expr.Negated {
-		buf = append(buf, "not")
-	}
-	switch t := expr.Terms.(type) {
-	case []*Term:
-		if expr.IsEquality() && validEqAssignArgCount(expr) {
-			buf = append(buf, fmt.Sprintf("%v %v %v", t[1], Equality.Infix, t[2]))
-		} else {
-			buf = append(buf, Call(t).String())
-		}
-	case fmt.Stringer:
-		buf = append(buf, t.String())
-	}
-
-	for i := range expr.With {
-		buf = append(buf, expr.With[i].String())
-	}
-
-	return strings.Join(buf, " ")
+	buf, _ := expr.AppendText(make([]byte, 0, expr.StringLength()))
+	return util.ByteSliceToString(buf)
 }
 
 func (expr *Expr) MarshalJSON() ([]byte, error) {
@@ -1668,17 +1533,8 @@ func visitCogeneratedExprs(expr *Expr, f func(*Expr) bool) {
 }
 
 func (d *SomeDecl) String() string {
-	if call, ok := d.Symbols[0].Value.(Call); ok {
-		if len(call) == 4 {
-			return "some " + call[1].String() + ", " + call[2].String() + " in " + call[3].String()
-		}
-		return "some " + call[1].String() + " in " + call[2].String()
-	}
-	buf := make([]string, len(d.Symbols))
-	for i := range buf {
-		buf[i] = d.Symbols[i].String()
-	}
-	return "some " + strings.Join(buf, ", ")
+	buf, _ := d.AppendText(make([]byte, 0, d.StringLength()))
+	return util.ByteSliceToString(buf)
 }
 
 // SetLoc sets the Location on d.
@@ -1797,7 +1653,8 @@ func (q *Every) MarshalJSON() ([]byte, error) {
 }
 
 func (w *With) String() string {
-	return "with " + w.Target.String() + " as " + w.Value.String()
+	buf, _ := w.AppendText(make([]byte, 0, w.StringLength()))
+	return util.ByteSliceToString(buf)
 }
 
 // Equal returns true if this With is equals the other With.

--- a/v1/ast/policy_appenders.go
+++ b/v1/ast/policy_appenders.go
@@ -1,0 +1,333 @@
+package ast
+
+import (
+	"encoding"
+	"fmt"
+)
+
+func (m *Module) AppendText(buf []byte) ([]byte, error) {
+	if m == nil {
+		return append(buf, "<nil module>"...), nil
+	}
+
+	var err error
+
+	// NOTE(anderseknert): this DOES allocate still, and while that's unfortunate,
+	// we'll be better off dealing with that when we have v2 JSON in the stdlib than
+	// doing manual JSON marshalling (and string length calculations) here.
+	for _, annotations := range m.Annotations {
+		// rule annotations are attached to rules, so only check for package scoped ones here
+		if annotations.Scope == "package" || annotations.Scope == "subpackages" {
+			buf = append(buf, "# METADATA\n# "...)
+			buf = append(buf, annotations.String()...)
+			buf = append(buf, '\n')
+		}
+	}
+
+	if buf, err = m.Package.AppendText(buf); err != nil {
+		return nil, err
+	}
+	buf = append(buf, '\n')
+
+	if len(m.Imports) > 0 {
+		for _, imp := range m.Imports {
+			buf = append(buf, '\n')
+			if buf, err = imp.AppendText(buf); err != nil {
+				return nil, err
+			}
+		}
+		buf = append(buf, '\n')
+	}
+
+	if len(m.Rules) > 0 {
+		for _, rule := range m.Rules {
+			buf = append(buf, '\n')
+			if buf, err = rule.appendWithOpts(toStringOpts{regoVersion: m.regoVersion}, buf); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return buf, nil
+}
+
+func (pkg *Package) AppendText(buf []byte) ([]byte, error) {
+	var err error
+	if pkg == nil {
+		return append(buf, "<illegal nil package>"...), nil
+	}
+	if len(pkg.Path) <= 1 {
+		buf = append(buf, "package <illegal path \""...)
+		if buf, err = pkg.Path.AppendText(buf); err != nil {
+			return nil, err
+		}
+		return append(buf, "\">"...), nil
+	}
+
+	buf = append(buf, "package "...)
+
+	path := pkg.Path[1:] // omit "data"
+
+	if s, ok := path[0].Value.(String); ok {
+		buf = append(buf, s...) // first term should never be quoted
+		if len(path) == 1 {
+			return buf, nil
+		}
+		buf = append(buf, '.')
+		path = path[1:]
+	}
+
+	return path.AppendText(buf)
+}
+
+func (imp *Import) AppendText(buf []byte) ([]byte, error) {
+	buf = append(buf, "import "...)
+	var err error
+	if buf, err = imp.Path.AppendText(buf); err != nil {
+		return nil, err
+	}
+	if imp.Alias != "" {
+		buf = append(buf, ' ', 'a', 's', ' ')
+		buf = append(buf, imp.Alias...)
+	}
+	return buf, nil
+}
+
+func (r *Rule) AppendText(buf []byte) ([]byte, error) {
+	regoVersion := DefaultRegoVersion
+	if r.Module != nil {
+		regoVersion = r.Module.RegoVersion()
+	}
+	return r.appendWithOpts(toStringOpts{regoVersion: regoVersion}, buf)
+}
+
+func (r *Rule) appendWithOpts(opts toStringOpts, buf []byte) ([]byte, error) {
+	// See note in [Module.AppendText] regarding annotations.
+	for _, annotations := range r.Annotations {
+		buf = append(buf, "# METADATA\n# "...)
+		buf = append(buf, annotations.String()...)
+		buf = append(buf, '\n')
+	}
+
+	if r.Default {
+		buf = append(buf, "default "...)
+	}
+
+	var err error
+	if buf, err = r.Head.appendWithOpts(opts, buf); err != nil {
+		return nil, err
+	}
+
+	if !r.Default {
+		switch opts.RegoVersion() {
+		case RegoV1, RegoV0CompatV1:
+			buf = append(buf, " if { "...)
+		default:
+			buf = append(buf, " { "...)
+		}
+		if buf, err = r.Body.AppendText(buf); err != nil {
+			return nil, err
+		}
+		buf = append(buf, " }"...)
+	}
+	if r.Else != nil {
+		if buf, err = r.Else.appendElse(opts, buf); err != nil {
+			return nil, err
+		}
+	}
+
+	return buf, nil
+}
+
+func (r *Rule) appendElse(opts toStringOpts, buf []byte) ([]byte, error) {
+	buf = append(buf, " else "...)
+
+	var err error
+	if r.Head.Value != nil {
+		buf = append(buf, "= "...)
+		if buf, err = r.Head.Value.AppendText(buf); err != nil {
+			return nil, err
+		}
+	}
+
+	if v := opts.RegoVersion(); v == RegoV1 || v == RegoV0CompatV1 {
+		buf = append(buf, " if { "...)
+	} else {
+		buf = append(buf, " { "...)
+	}
+	if buf, err = r.Body.AppendText(buf); err != nil {
+		return nil, err
+	}
+	buf = append(buf, " }"...)
+
+	if r.Else != nil {
+		if buf, err = r.Else.appendElse(opts, buf); err != nil {
+			return nil, err
+		}
+	}
+
+	return buf, nil
+}
+
+func (h *Head) AppendText(buf []byte) ([]byte, error) {
+	return h.appendWithOpts(toStringOpts{}, buf)
+}
+
+func (h *Head) appendWithOpts(opts toStringOpts, buf []byte) ([]byte, error) {
+	var err error
+	if h.Reference == nil {
+		buf = append(buf, h.Name...)
+	} else {
+		if buf, err = h.Reference.AppendText(buf); err != nil {
+			return nil, err
+		}
+	}
+
+	containsAdded := false
+	switch {
+	case len(h.Args) != 0:
+		if buf, err = h.Args.AppendText(buf); err != nil {
+			return nil, err
+		}
+	case len(h.Reference) == 1 && h.Key != nil:
+		switch opts.RegoVersion() {
+		case RegoV0:
+			buf = append(buf, '[')
+			if buf, err = h.Key.AppendText(buf); err != nil {
+				return nil, err
+			}
+			buf = append(buf, ']')
+		default:
+			if buf, err = h.Key.AppendText(append(buf, " contains "...)); err != nil {
+				return nil, err
+			}
+			containsAdded = true
+		}
+	}
+	if h.Value != nil {
+		if h.Assign {
+			buf = append(buf, " := "...)
+		} else {
+			buf = append(buf, " = "...)
+		}
+		if buf, err = h.Value.AppendText(buf); err != nil {
+			return nil, err
+		}
+	} else if !containsAdded && h.Name == "" && h.Key != nil {
+		if buf, err = h.Key.AppendText(append(buf, " contains "...)); err != nil {
+			return nil, err
+		}
+	}
+	return buf, nil
+}
+
+func (a Args) AppendText(buf []byte) ([]byte, error) {
+	var err error
+	buf = append(buf, '(')
+	if buf, err = AppendDelimeted(buf, a, ", "); err != nil {
+		return nil, err
+	}
+	return append(buf, ')'), nil
+}
+
+func (expr *Expr) AppendText(buf []byte) ([]byte, error) {
+	if expr.Negated {
+		buf = append(buf, "not "...)
+	}
+
+	var err error
+
+	switch t := expr.Terms.(type) {
+	case []*Term:
+		if expr.IsEquality() && validEqAssignArgCount(expr) {
+			if buf, err = t[1].AppendText(buf); err != nil {
+				return nil, err
+			}
+			buf = append(append(append(buf, ' '), Equality.Infix...), ' ')
+			if buf, err = t[2].AppendText(buf); err != nil {
+				return nil, err
+			}
+		} else if buf, err = Call(t).AppendText(buf); err != nil {
+			return nil, err
+		}
+	case encoding.TextAppender:
+		if buf, err = t.AppendText(buf); err != nil {
+			return nil, err
+		}
+	default:
+		return nil, fmt.Errorf("unsupported expr terms type: %T", expr.Terms)
+	}
+
+	if len(expr.With) > 0 {
+		buf = append(buf, ' ')
+	}
+
+	return AppendDelimeted(buf, expr.With, " ")
+}
+
+func (w *With) AppendText(buf []byte) ([]byte, error) {
+	buf = append(buf, "with "...)
+	var err error
+	if buf, err = w.Target.AppendText(buf); err != nil {
+		return nil, err
+	}
+	buf = append(buf, " as "...)
+	if buf, err = w.Value.AppendText(buf); err != nil {
+		return nil, err
+	}
+	return buf, nil
+}
+
+func (w *Every) AppendText(buf []byte) ([]byte, error) {
+	buf = append(buf, "every "...)
+	var err error
+	if w.Key != nil {
+		if buf, err = w.Key.AppendText(buf); err != nil {
+			return nil, err
+		}
+		buf = append(buf, ", "...)
+	}
+	if buf, err = w.Value.AppendText(buf); err == nil {
+		buf = append(buf, " in "...)
+		if buf, err = w.Domain.AppendText(buf); err == nil {
+			buf = append(buf, " { "...)
+			if buf, err = w.Body.AppendText(buf); err == nil {
+				buf = append(buf, " }"...)
+			}
+		}
+	}
+	return buf, err
+}
+
+func (d *SomeDecl) AppendText(buf []byte) ([]byte, error) {
+	var err error
+	buf = append(buf, "some "...)
+	if call, ok := d.Symbols[0].Value.(Call); ok {
+		if buf, err = call[1].AppendText(buf); err != nil {
+			return nil, err
+		}
+		if len(call) == 3 {
+			buf = append(buf, " in "...)
+		} else {
+			buf = append(buf, ", "...)
+		}
+		if buf, err = call[2].AppendText(buf); err != nil {
+			return nil, err
+		}
+		if len(call) == 4 {
+			buf = append(buf, " in "...)
+			if buf, err = call[3].AppendText(buf); err != nil {
+				return nil, err
+			}
+		}
+		return buf, nil
+	}
+
+	buf, err = AppendDelimeted(buf, d.Symbols, ", ")
+
+	return buf, err
+}
+
+func (c *Comment) AppendText(buf []byte) ([]byte, error) {
+	return append(append(buf, '#'), c.Text...), nil
+}

--- a/v1/ast/policy_appenders_test.go
+++ b/v1/ast/policy_appenders_test.go
@@ -1,0 +1,179 @@
+package ast_test
+
+import (
+	"encoding"
+	"testing"
+
+	"github.com/open-policy-agent/opa/v1/ast"
+)
+
+var policyAppenderTests = []struct {
+	name  string
+	node  ast.StringLengther
+	want  string
+	nolen bool
+}{
+	{
+		name: "module",
+		node: &ast.Module{
+			Package: &ast.Package{
+				Path: ast.Ref{ast.DefaultRootDocument, ast.InternedTerm("a"), ast.InternedTerm("b")},
+			},
+			Imports: ast.MustParseImports(`
+				import data.foo.bar as baz
+				import input.a.b.c
+			`),
+		},
+		want: `package a.b
+
+import data.foo.bar as baz
+import input.a.b.c
+`,
+	},
+	{
+		name: "module annotated",
+		node: ast.MustParseModuleWithOpts(`# METADATA
+# title: p
+package p
+
+# METADATA
+# title: r
+r = true`,
+			ast.ParserOptions{ProcessAnnotation: true}),
+		want: "# METADATA\n# {\"scope\":\"package\",\"title\":\"p\"}\npackage p\n\n# METADATA\n# {\"scope\":\"rule\",\"title\":\"r\"}\nr = true if { true }",
+		// We don't count this correctly for annoations currently.
+		nolen: true,
+	},
+	{
+		name: "package",
+		node: &ast.Package{
+			Path: ast.MustParseRef("data.example.foo"),
+		},
+		want: `package example.foo`,
+	},
+	{
+		name: "import",
+		node: &ast.Import{
+			Path:  ast.NewTerm(ast.MustParseRef("data.example.foo")),
+			Alias: ast.Var("bar"),
+		},
+		want: `import data.example.foo as bar`,
+	},
+	{
+		name: "head",
+		node: &ast.Head{
+			Reference: ast.Ref{ast.VarTerm("allow")},
+			Value:     ast.InternedTerm(true),
+		},
+		want: `allow = true`,
+	},
+	{
+		name: "head assign",
+		node: &ast.Head{
+			Reference: ast.Ref{ast.VarTerm("allow")},
+			Value:     ast.InternedTerm(false),
+			Assign:    true,
+		},
+		want: `allow := false`,
+	},
+	{
+		name: "head with key",
+		node: &ast.Head{
+			Reference: ast.Ref{ast.VarTerm("deny")},
+			Key:       ast.InternedTerm("reason"),
+		},
+		want: `deny contains "reason"`,
+	},
+	{
+		name: "ref head with value",
+		node: &ast.Head{
+			Reference: ast.Ref{ast.VarTerm("authz"), ast.StringTerm("deny"), ast.VarTerm("user")},
+			Value:     ast.InternedTerm("violation"),
+			Assign:    true,
+		},
+		want: `authz.deny[user] := "violation"`,
+	},
+	{
+		name: "body",
+		node: ast.Body{
+			ast.MustParseExpr("input.foo == 1"),
+			ast.MustParseExpr("input.bar != 2"),
+		},
+		want: `equal(input.foo, 1); neq(input.bar, 2)`,
+	},
+	{
+		name: "expr",
+		node: ast.MustParseExpr(`input.foo[_][1][baz] == "bar"`),
+		want: `equal(input.foo[_][1][baz], "bar")`,
+	},
+	{
+		name: "with",
+		node: &ast.With{
+			Target: ast.MustParseTerm("input.foo"),
+			Value:  ast.MustParseTerm(`"bar"`),
+		},
+		want: `with input.foo as "bar"`,
+	},
+	{
+		name: "every",
+		node: &ast.Every{
+			Key:    ast.MustParseTerm("k"),
+			Value:  ast.MustParseTerm("v"),
+			Domain: ast.MustParseTerm("input.map"),
+			Body: ast.Body{
+				ast.MustParseExpr("v > 0"),
+			},
+		},
+		want: `every k, v in input.map { gt(v, 0) }`,
+	},
+	{
+		name: "some decl",
+		node: &ast.SomeDecl{
+			Symbols: []*ast.Term{
+				ast.MustParseTerm("x"),
+				ast.MustParseTerm("y"),
+			},
+		},
+		want: `some x, y`,
+	},
+	{
+		name: "some in decl",
+		node: ast.MustParseExpr("some x, y in input.map"),
+		want: `some x, y in input.map`,
+	},
+}
+
+func TestASTNodeTextAppendersAndLengthAllocation(t *testing.T) {
+	for _, tc := range policyAppenderTests {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf []byte
+			res, err := tc.node.(encoding.TextAppender).AppendText(buf)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := string(res)
+			if got != tc.want {
+				t.Errorf("%s:\nexp: %q\ngot: %q", tc.name, tc.want, got)
+			}
+
+			if expLen := tc.node.StringLength(); !tc.nolen && expLen != len(got) {
+				t.Errorf("%s: string length = %d, expected %d", tc.name, len(got), expLen)
+				t.Logf("%q", got)
+			}
+		})
+	}
+}
+
+func BenchmarkNoNodeTypeAllocatesOnAppend(b *testing.B) {
+	for _, tc := range policyAppenderTests {
+		b.Run(tc.name, func(b *testing.B) {
+			buf := make([]byte, 0, tc.node.StringLength())
+			for b.Loop() {
+				_, err := tc.node.(encoding.TextAppender).AppendText(buf)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/v1/ast/policy_bench_test.go
+++ b/v1/ast/policy_bench_test.go
@@ -1,0 +1,86 @@
+package ast
+
+import (
+	"testing"
+
+	"github.com/open-policy-agent/opa/v1/ast/location"
+)
+
+// 12.03 ns/op	      48 B/op	       1 allocs/op
+func BenchmarkCommentString(b *testing.B) {
+	comment := &Comment{
+		Text:     []byte("This is a sample comment for benchmarking."),
+		Location: &location.Location{},
+	}
+
+	for b.Loop() {
+		_ = comment.String()
+	}
+}
+
+// Before using TextAppenders and pre-allocating buffers:
+// simple_expr-16                              6196365       181.1 ns/op      64 B/op       4 allocs/op
+// negated_expr_with_with_modifier-16          3400506       353.3 ns/op     200 B/op       9 allocs/op
+// complex_expr-16                             1584336       760.4 ns/op     673 B/op      20 allocs/op
+// Now:
+// simple_expr-16                              8809898       120.9 ns/op      24 B/op       1 allocs/op
+// negated_expr_with_with_modifier-16          5300791       227.3 ns/op      48 B/op       1 allocs/op
+// complex_expr-16                             3071887       382.8 ns/op      96 B/op       1 allocs/op
+func BenchmarkExprString(b *testing.B) {
+	tests := []struct {
+		note string
+		expr *Expr
+	}{
+		{
+			note: "simple expr",
+			expr: MustParseExpr(`input.x == 10`),
+		},
+		{
+			note: "negated expr with with modifier",
+			expr: MustParseExpr(`not input.y != "hello" with input.z as 5`),
+		},
+		{
+			note: "complex expr",
+			expr: MustParseExpr(`count({x | x := input.arr[_]; x > 10}) == 3 with input.arr as [5, 15, 25, 8, 30]`),
+		},
+	}
+
+	for _, tc := range tests {
+		b.Run(tc.note, func(b *testing.B) {
+			for b.Loop() {
+				_ = tc.expr.String()
+			}
+		})
+	}
+}
+
+// All zero allocs
+func BenchmarkExprAppendText(b *testing.B) {
+	tests := []struct {
+		note string
+		expr *Expr
+	}{
+		{
+			note: "simple expr",
+			expr: MustParseExpr(`input.x == 10`),
+		},
+		{
+			note: "negated expr with with modifier",
+			expr: MustParseExpr(`not input.y != "hello" with input.z as 5`),
+		},
+		{
+			note: "complex expr",
+			expr: MustParseExpr(`count({x | x := input.arr[_]; x > 10}) == 3 with input.arr as [5, 15, 25, 8, 30]`),
+		},
+	}
+
+	for _, tc := range tests {
+		b.Run(tc.note, func(b *testing.B) {
+			buf := make([]byte, 0, 256)
+			for b.Loop() {
+				buf, _ = tc.expr.AppendText(buf)
+				buf = buf[:0]
+			}
+		})
+	}
+}

--- a/v1/ast/string_length.go
+++ b/v1/ast/string_length.go
@@ -1,0 +1,347 @@
+package ast
+
+import (
+	"fmt"
+	"unicode/utf8"
+
+	"github.com/open-policy-agent/opa/v1/util"
+)
+
+// StringLengther is an interface for types that can report their string length without
+// actually constructing the string. This is useful for pre-allocating buffers, like those
+// used in AppendText, strings.Builder, bytes.Buffer, etc.
+type StringLengther interface {
+	StringLength() int
+}
+
+// TermSliceStringLength returns the total string length of the given terms, as reported
+// by the [StringLengther.StringLength] method implementation of each term's [Value]. The
+// delimLen value will be added between each term's length to account for a delimiter, or
+// no delimiter if delimLen is 0.
+// Implementation note: this function is optimized for inlining, and just meets the threshold
+// for that. Don't change without making sure that's still the case.
+func TermSliceStringLength(terms []*Term, delimLen int) (n int) {
+	for i := range terms {
+		n += terms[i].StringLength() + delimLen
+	}
+	return max(n-delimLen, 0)
+}
+
+func (t *Term) StringLength() int {
+	if sl, ok := t.Value.(StringLengther); ok {
+		return sl.StringLength()
+	}
+
+	panic("expected all ast.Value types to implement StringLenghter interface, got: " + ValueName(t.Value))
+}
+
+func (s String) StringLength() int {
+	n := 2 // surrounding quotes
+	bs := util.StringToByteSlice(s)
+	for i := 0; i < len(bs); {
+		r, size := utf8.DecodeRune(bs[i:])
+		switch r {
+		case '\\', '"':
+			n += 2 // escaped backslash or quote
+		case '\b', '\f', '\n', '\r', '\t':
+			n += 2 // escaped control characters
+		default:
+			if r < 0x20 {
+				n += 6 // unicode escape for other control characters
+			} else {
+				n += size // normal rune
+			}
+		}
+		i += size
+	}
+	return n
+}
+
+func (n Number) StringLength() int {
+	return len(n)
+}
+
+func (b Boolean) StringLength() int {
+	if b {
+		return 4
+	}
+	return 5
+}
+
+func (Null) StringLength() int {
+	return 4
+}
+
+func (s *set) StringLength() int {
+	if s.Len() == 0 {
+		return 5 // set()
+	}
+	// surrounding {} + ", " for every element - 1
+	return TermSliceStringLength(s.Slice(), 2) + 2
+}
+
+func (a *Array) StringLength() int {
+	if a.Len() == 0 {
+		return 2 // []
+	}
+	// surrounding brackets + ", " for every element - 1
+	return TermSliceStringLength(a.elems, 2) + 2
+}
+
+func (o *object) StringLength() (n int) {
+	if o.Len() == 0 {
+		return 2 // {}
+	}
+	// ": " for every item + ", " for every item - 1
+	o.Foreach(func(key, value *Term) {
+		n += key.StringLength() + 4 + value.StringLength() // ": " and ", "
+	})
+	return n // surrounding {} but also minus last ", "
+}
+
+func (ts *TemplateString) StringLength() (n int) {
+	for _, p := range ts.Parts {
+		switch x := p.(type) {
+		case *Expr:
+			n += 2 + x.StringLength() // for {}
+		case *Term:
+			if s, ok := x.Value.(String); ok {
+				n += len(s) + countUnescapedLeftCurly(string(s))
+			} else {
+				n += x.StringLength()
+			}
+		default:
+			n += 9 // <invalid>
+		}
+	}
+	return n + 3 // $"" or $``
+}
+
+func (c Call) StringLength() int {
+	return c[0].StringLength() + 2 + TermSliceStringLength(c[1:], 2)
+}
+
+func (r Ref) StringLength() (n int) {
+	rlen := len(r)
+	if rlen == 0 {
+		return 0
+	}
+
+	if s, ok := r[0].Value.(String); ok {
+		n = len(s) // first term should never be quoted
+	} else {
+		n = r[0].StringLength()
+	}
+
+	if rlen == 1 {
+		return n
+	}
+
+	for _, p := range r[1:] {
+		switch v := p.Value.(type) {
+		case String:
+			str := string(v)
+			if IsVarCompatibleString(str) && !IsKeyword(str) {
+				n += 1 + len(str) // dot + name
+			} else {
+				n += 2 + p.StringLength() // brackets
+			}
+		default:
+			n += 2 + p.StringLength() // brackets
+		}
+	}
+	return n
+}
+
+func (v Var) StringLength() int {
+	if v.IsWildcard() {
+		return 1
+	}
+	return len(v)
+}
+
+func (s *SetComprehension) StringLength() int {
+	return s.Term.StringLength() + s.Body.StringLength() + 5 // {} and " | "
+}
+
+func (a *ArrayComprehension) StringLength() int {
+	return a.Term.StringLength() + a.Body.StringLength() + 5 // [] and " | "
+}
+
+func (o *ObjectComprehension) StringLength() (n int) {
+	n += o.Key.StringLength()
+	n += o.Value.StringLength()
+	n += o.Body.StringLength()
+	return n + 7 // "{}"", " | ", and ": "
+}
+
+func (m *Module) StringLength() (n int) {
+	if m.Package != nil {
+		n += m.Package.StringLength() + 2 // newlines
+	}
+
+	if len(m.Imports) > 0 {
+		for _, imp := range m.Imports {
+			n += imp.StringLength() + 1 // newline
+		}
+	}
+
+	if len(m.Rules) > 0 {
+		for _, rule := range m.Rules {
+			n += rule.stringLengthWithOpts(toStringOpts{regoVersion: m.regoVersion}) + 1 // newline
+		}
+	}
+
+	return n
+}
+
+func (p *Package) StringLength() int {
+	if p == nil {
+		return 21 // <illegal nil package>
+	}
+	if len(p.Path) <= 1 {
+		return 25 + p.Path.StringLength() // // package <illegal path " ... ">
+	}
+
+	return 8 + p.Path[1:].StringLength() // "package ..."
+}
+
+func (i *Import) StringLength() (n int) {
+	n = 7 + i.Path.StringLength() // "import " and path
+	if i.Alias != "" {
+		n += 4 + i.Alias.StringLength() // " as " and alias
+	}
+	return n
+}
+
+func (r *Rule) StringLength() int {
+	return r.stringLengthWithOpts(toStringOpts{})
+}
+
+func (r *Rule) stringLengthWithOpts(opts toStringOpts) int {
+	n := 0
+	if r.Default {
+		n += 8 // "default "
+	}
+	n += r.Head.stringLengthWithOpts(opts)
+	if !r.Default {
+		switch opts.RegoVersion() {
+		case RegoV1, RegoV0CompatV1:
+			n += 6 // " if { "
+		default:
+			n += 3 // " { "
+		}
+		n += r.Body.StringLength() + 2 // body and closing " }"
+	}
+	if r.Else != nil {
+		n += r.Else.stringLengthWithOpts(opts)
+	}
+	return n
+}
+
+func (h *Head) StringLength() int {
+	return h.stringLengthWithOpts(toStringOpts{})
+}
+
+func (h *Head) stringLengthWithOpts(opts toStringOpts) int {
+	n := h.Reference.StringLength()
+	containsAdded := false
+	switch {
+	case len(h.Args) != 0:
+		n += h.Args.StringLength()
+	case len(h.Reference) == 1 && h.Key != nil:
+		switch opts.RegoVersion() {
+		case RegoV0:
+			n += 2 + h.Key.StringLength() // for []
+		default:
+			n += 10 + h.Key.StringLength() // " contains "
+			containsAdded = true
+		}
+	}
+	if h.Value != nil {
+		if h.Assign {
+			n += 4 // " := "
+		} else {
+			n += 3 // " = "
+		}
+		n += h.Value.StringLength()
+	} else if !containsAdded && h.Name == "" && h.Key != nil {
+		n += 10 + h.Key.StringLength() // " contains "
+	}
+	return n
+}
+
+func (a Args) StringLength() (n int) {
+	n = 2 // ()
+	for _, t := range a {
+		n += t.StringLength() + 2 // ", "
+	}
+	return n - 2 // minus last ", "
+}
+
+func (b Body) StringLength() (n int) {
+	for _, expr := range b {
+		n += expr.StringLength() + 2 // "; "
+	}
+	return n - 2 // minus last "; "
+}
+
+func (e *Expr) StringLength() (n int) {
+	if e.Negated {
+		n += 4 // "not "
+	}
+	switch terms := e.Terms.(type) {
+	case []*Term:
+		if e.IsEquality() && validEqAssignArgCount(e) {
+			n += terms[1].StringLength() + len(Equality.Infix) + terms[2].StringLength() + 2 // spaces around =
+		} else {
+			n += Call(terms).StringLength()
+		}
+	case StringLengther:
+		n += terms.StringLength()
+	default:
+		panic(fmt.Sprintf("string length estimation not implemented for type: %T", e.Terms))
+	}
+
+	for _, w := range e.With {
+		n += w.StringLength() + 1 // space before with
+	}
+
+	return n
+}
+
+func (w *With) StringLength() int {
+	return w.Target.StringLength() + w.Value.StringLength() + 9 // "with " and " as "
+}
+
+func (e *Every) StringLength() int {
+	n := 6 // "every "
+	if e.Key != nil {
+		n += e.Key.StringLength() + 2 // ", "
+	}
+	n += e.Value.StringLength() + 4  // " in "
+	n += e.Domain.StringLength() + 3 // " { "
+	n += e.Body.StringLength() + 2   // " }"
+	return n
+}
+
+func (s *SomeDecl) StringLength() int {
+	n := 5 // "some "
+	if call, ok := s.Symbols[0].Value.(Call); ok {
+		n += 4 // " in "
+		n += call[1].StringLength()
+		if len(call) == 4 {
+			n += 2 // ", "
+		}
+		n += call[2].StringLength()
+		if len(call) == 4 {
+			n += call[3].StringLength()
+		}
+		return n
+	}
+	return n + TermSliceStringLength(s.Symbols, 2)
+}
+
+func (c *Comment) StringLength() int {
+	return 1 + len(c.Text) // '#' + text
+}

--- a/v1/ast/syncpools.go
+++ b/v1/ast/syncpools.go
@@ -2,7 +2,6 @@ package ast
 
 import (
 	"bytes"
-	"strings"
 	"sync"
 
 	"github.com/open-policy-agent/opa/v1/util"
@@ -12,15 +11,7 @@ var (
 	TermPtrPool     = util.NewSyncPool[Term]()
 	BytesReaderPool = util.NewSyncPool[bytes.Reader]()
 	IndexResultPool = util.NewSyncPool[IndexResult]()
-	bbPool          = util.NewSyncPool[bytes.Buffer]()
-	// Needs custom pool because of custom Put logic.
-	sbPool = &stringBuilderPool{
-		pool: sync.Pool{
-			New: func() any {
-				return &strings.Builder{}
-			},
-		},
-	}
+
 	// Needs custom pool because of custom Put logic.
 	varVisitorPool = &vvPool{
 		pool: sync.Pool{
@@ -31,18 +22,8 @@ var (
 	}
 )
 
-type (
-	stringBuilderPool struct{ pool sync.Pool }
-	vvPool            struct{ pool sync.Pool }
-)
-
-func (p *stringBuilderPool) Get() *strings.Builder {
-	return p.pool.Get().(*strings.Builder)
-}
-
-func (p *stringBuilderPool) Put(sb *strings.Builder) {
-	sb.Reset()
-	p.pool.Put(sb)
+type vvPool struct {
+	pool sync.Pool
 }
 
 func (p *vvPool) Get() *VarVisitor {

--- a/v1/ast/term_appenders.go
+++ b/v1/ast/term_appenders.go
@@ -1,0 +1,266 @@
+package ast
+
+import (
+	"encoding"
+	"strconv"
+	"strings"
+
+	"github.com/open-policy-agent/opa/v1/util"
+)
+
+// AppendText appends the text representation of term (i.e. as printed in policy) to
+// buf and returns the extended buffer.
+func (term *Term) AppendText(buf []byte) ([]byte, error) {
+	if app, ok := term.Value.(encoding.TextAppender); ok {
+		return app.AppendText(buf)
+	}
+
+	return append(buf, term.Value.String()...), nil
+}
+
+func (v Var) AppendText(buf []byte) ([]byte, error) {
+	if v.IsWildcard() {
+		return append(buf, WildcardString...), nil
+	}
+	return append(buf, v...), nil
+}
+
+func (b Boolean) AppendText(buf []byte) ([]byte, error) {
+	if b {
+		return append(buf, "true"...), nil
+	}
+	return append(buf, "false"...), nil
+}
+
+func (Null) AppendText(buf []byte) ([]byte, error) {
+	return append(buf, "null"...), nil
+}
+
+func (str String) AppendText(buf []byte) ([]byte, error) {
+	return strconv.AppendQuote(buf, string(str)), nil
+}
+
+func (str String) appendNoQuote(buf []byte) []byte {
+	// Append using strconv.AppendQuote for proper escaping, but trim off
+	// the leading and trailing quotes afterwards.
+	oldLen := len(buf)
+	buf = strconv.AppendQuote(buf, string(str))
+	newLen := len(buf)
+	quoted := buf[oldLen:newLen]
+
+	return append(buf[:oldLen], quoted[1:len(quoted)-1]...)
+}
+
+func (num Number) AppendText(buf []byte) ([]byte, error) {
+	return append(buf, num...), nil
+}
+
+func (arr *Array) AppendText(buf []byte) ([]byte, error) {
+	buf, err := AppendDelimeted(append(buf, '['), arr.elems, ", ")
+	if err != nil {
+		return nil, err
+	}
+	return append(buf, ']'), nil
+}
+
+func (obj *object) AppendText(buf []byte) ([]byte, error) {
+	olen := obj.Len()
+	if olen == 0 {
+		return append(buf, "{}"...), nil
+	}
+
+	buf = append(buf, '{')
+
+	var err error
+
+	// first key-value pair
+	keys := obj.sortedKeys()
+	for i := range keys {
+		if buf, err = keys[i].key.AppendText(buf); err != nil {
+			return nil, err
+		}
+		buf = append(buf, ": "...)
+		if buf, err = keys[i].value.AppendText(buf); err != nil {
+			return nil, err
+		}
+		if i < olen-1 {
+			buf = append(buf, ", "...)
+		}
+	}
+
+	return append(buf, '}'), nil
+}
+
+func (obj *lazyObj) AppendText(buf []byte) ([]byte, error) {
+	return append(buf, obj.force().String()...), nil
+}
+
+func (s *set) AppendText(buf []byte) ([]byte, error) {
+	slen := s.Len()
+	if slen == 0 {
+		return append(buf, "set()"...), nil
+	}
+
+	var err error
+
+	buf = append(buf, '{')
+	if buf, err = AppendDelimeted(buf, s.sortedKeys(), ", "); err != nil {
+		return nil, err
+	}
+
+	return append(buf, '}'), nil
+}
+
+func (c Call) AppendText(buf []byte) ([]byte, error) {
+	if len(c) == 0 {
+		return buf, nil
+	}
+
+	var err error
+
+	if buf, err = c[0].AppendText(buf); err != nil {
+		return nil, err
+	}
+
+	if buf, err = AppendDelimeted(append(buf, '('), c[1:], ", "); err != nil {
+		return nil, err
+	}
+	return append(buf, ')'), nil
+}
+
+func (ts *TemplateString) AppendText(buf []byte) ([]byte, error) {
+	buf = append(buf, "$\""...)
+	for _, p := range ts.Parts {
+		switch x := p.(type) {
+		case *Expr:
+			buf = append(buf, '{')
+			var err error
+			if buf, err = x.AppendText(buf); err != nil {
+				return nil, err
+			}
+			buf = append(buf, '}')
+		case *Term:
+			if str, ok := x.Value.(String); ok {
+				// TODO(anders): this is a bit of a mess, but as explained by the comment on
+				// [EscapeTemplateStringStringPart], required as long as we rely on strconv for escaping, which adds
+				// quotes around the string that we don't want here, and trying to "unappend" them is not nice at all..
+				s := string(str)
+				ulc := countUnescapedLeftCurly(s)
+				sl := str.StringLength() + ulc - 2 // no surrounding quotes
+
+				if sl == len(s) { // no escaping needed
+					buf = append(buf, s...)
+				} else { // some escaping needed
+					if sl == len(s)+ulc { // only unescaped {
+						buf = AppendEscapedTemplateStringStringPart(buf, string(str))
+					} else { // full escaping needed. this is expensive but luckily rare
+						tmp := str.appendNoQuote(make([]byte, 0, sl))
+						ets := EscapeTemplateStringStringPart(util.ByteSliceToString(tmp))
+						buf = append(buf, ets...)
+					}
+				}
+			} else {
+				var err error
+				if buf, err = x.AppendText(buf); err != nil {
+					return nil, err
+				}
+			}
+		default:
+			buf = append(buf, "<invalid>"...)
+		}
+	}
+	return append(buf, '"'), nil
+}
+
+func (r Ref) AppendText(buf []byte) ([]byte, error) {
+	reflen := len(r)
+	if reflen == 0 {
+		return buf, nil
+	}
+	if reflen == 1 {
+		if s, ok := r[0].Value.(String); ok {
+			// While a ref head is typically a Var, a lone String term should not be quoted
+			return append(buf, s...), nil
+		}
+		return r[0].AppendText(buf)
+	}
+	if name, ok := BuiltinNameFromRef(r); ok {
+		return append(buf, name...), nil
+	}
+
+	var err error
+	if s, ok := r[0].Value.(String); ok {
+		buf = append(buf, s...)
+	} else if buf, err = r[0].AppendText(buf); err != nil {
+		return nil, err
+	}
+
+	for _, p := range r[1:] {
+		switch v := p.Value.(type) {
+		case String:
+			str := string(v)
+			if IsVarCompatibleString(str) && !IsKeyword(str) {
+				buf = append(append(buf, '.'), str...)
+			} else {
+				buf = append(buf, '[')
+				// Determine whether we need the full JSON-escaped form
+				if strings.ContainsFunc(str, isControlOrBackslash) {
+					if buf, err = v.AppendText(buf); err != nil {
+						return nil, err
+					}
+				} else {
+					buf = append(append(append(buf, '"'), str...), '"')
+				}
+				buf = append(buf, ']')
+			}
+		default:
+			buf = append(buf, '[')
+			if buf, err = p.AppendText(buf); err != nil {
+				return nil, err
+			}
+			buf = append(buf, ']')
+		}
+	}
+
+	return buf, nil
+}
+
+func (sc *SetComprehension) AppendText(buf []byte) ([]byte, error) {
+	buf = append(buf, '{')
+	var err error
+	if buf, err = sc.Term.AppendText(buf); err != nil {
+		return nil, err
+	}
+	if buf, err = sc.Body.AppendText(append(buf, " | "...)); err != nil {
+		return nil, err
+	}
+	return append(buf, '}'), nil
+}
+
+func (ac *ArrayComprehension) AppendText(buf []byte) ([]byte, error) {
+	buf = append(buf, '[')
+	var err error
+	if buf, err = ac.Term.AppendText(buf); err != nil {
+		return nil, err
+	}
+	if buf, err = ac.Body.AppendText(append(buf, " | "...)); err != nil {
+		return nil, err
+	}
+	return append(buf, ']'), nil
+}
+
+func (oc *ObjectComprehension) AppendText(buf []byte) ([]byte, error) {
+	buf = append(buf, '{')
+	var err error
+	if buf, err = oc.Key.AppendText(buf); err != nil {
+		return nil, err
+	}
+	buf = append(buf, ": "...)
+	if buf, err = oc.Value.AppendText(buf); err != nil {
+		return nil, err
+	}
+	if buf, err = oc.Body.AppendText(append(buf, " | "...)); err != nil {
+		return nil, err
+	}
+	return append(buf, '}'), nil
+}

--- a/v1/ast/term_appenders_test.go
+++ b/v1/ast/term_appenders_test.go
@@ -1,0 +1,137 @@
+package ast_test
+
+import (
+	"encoding"
+	"testing"
+
+	"github.com/open-policy-agent/opa/v1/ast"
+)
+
+var value_appender_tests = []struct {
+	name string
+	term ast.StringLengther
+	want string
+}{
+	{
+		name: "var",
+		term: ast.MustParseTerm("input.foo.bar"),
+		want: "input.foo.bar",
+	},
+	{
+		name: "string",
+		term: ast.StringTerm(`foo bar baz`),
+		want: `"foo bar baz"`,
+	},
+	{
+		name: "string with escapes",
+		term: ast.StringTerm(`"foo" "bar" "qux"`),
+		want: `"\"foo\" \"bar\" \"qux\""`,
+	},
+	{
+		name: "string with newlines",
+		term: ast.StringTerm("line1\nline2\nline3"),
+		want: `"line1\nline2\nline3"`,
+	},
+	{
+		name: "number",
+		term: ast.MustParseTerm("3.14"),
+		want: "3.14",
+	},
+	{
+		name: "boolean",
+		term: ast.MustParseTerm("true"),
+		want: "true",
+	},
+	{
+		name: "null",
+		term: ast.MustParseTerm("null"),
+		want: "null",
+	},
+	{
+		name: "array",
+		term: ast.MustParseTerm(`[1, "two", false]`),
+		want: `[1, "two", false]`,
+	},
+	{
+		name: "set",
+		term: ast.MustParseTerm(`{1, 2, 3}`),
+		want: `{1, 2, 3}`,
+	},
+	{
+		name: "object",
+		term: ast.MustParseTerm(`{"a": 1, "b": "two"}`),
+		want: `{"a": 1, "b": "two"}`,
+	},
+	{
+		name: "call",
+		term: ast.MustParseExpr(`foo(input.bar, "baz")`),
+		want: `foo(input.bar, "baz")`,
+	},
+	{
+		name: "template string",
+		term: ast.MustParseTerm(`$"Hello, {input.name}!"`),
+		want: `$"Hello, {input.name}!"`,
+	},
+	{
+		name: "ref",
+		term: ast.MustParseTerm(`data.foo["b a r"].allow`),
+		want: `data.foo["b a r"].allow`,
+	},
+	{
+		name: "object comprehension",
+		term: ast.MustParseTerm(`{k: v |
+				some k, v
+				data.items[k] == v
+				v > 10
+			}`),
+		want: `{k: v | some k, v; equal(data.items[k], v); gt(v, 10)}`,
+	},
+	{
+		name: "array comprehension",
+		term: ast.MustParseTerm(`[(x * 2) | x := data.numbers[_]; x > 5]`),
+		want: `[mul(x, 2) | assign(x, data.numbers[_]); gt(x, 5)]`,
+	},
+	{
+		name: "set comprehension",
+		term: ast.MustParseTerm(`{x | x := data.values[_]; x < 100}`),
+		want: `{x | assign(x, data.values[_]); lt(x, 100)}`,
+	},
+}
+
+func TestASTValueTextAppendersAndStringLength(t *testing.T) {
+	for _, tc := range value_appender_tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf []byte
+			var err error
+
+			buf, err = tc.term.(encoding.TextAppender).AppendText(buf)
+			if err != nil {
+				t.Fatalf("AppendText error: %v", err)
+			}
+			got := string(buf)
+			if got != tc.want {
+				t.Errorf("AppendText got %s, want %s", got, tc.want)
+			}
+
+			if expLen, gotLen := len(tc.want), tc.term.StringLength(); expLen != gotLen {
+				t.Errorf("StringLength = %d; want %d", gotLen, expLen)
+				t.Log(got)
+			}
+		})
+	}
+}
+
+// Ensure no appender allocates when appending to a pre-sized buffer.
+func BenchmarkNoASTTypeAllocatesOnAppendToBufferOfStringLength(b *testing.B) {
+	for _, tc := range value_appender_tests {
+		b.Run(tc.name, func(b *testing.B) {
+			buf := make([]byte, 0, tc.term.StringLength())
+			for b.Loop() {
+				_, err := tc.term.(encoding.TextAppender).AppendText(buf)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/v1/bundle/hash.go
+++ b/v1/bundle/hash.go
@@ -14,7 +14,6 @@ import (
 	"fmt"
 	"hash"
 	"io"
-	"strings"
 
 	"github.com/open-policy-agent/opa/v1/util"
 )
@@ -132,5 +131,5 @@ func encodePrimitive(v any) []byte {
 	encoder := json.NewEncoder(&buf)
 	encoder.SetEscapeHTML(false)
 	_ = encoder.Encode(v)
-	return []byte(strings.Trim(buf.String(), "\n"))
+	return bytes.Trim(buf.Bytes(), "\n")
 }

--- a/v1/server/compile_handler_bench_test.go
+++ b/v1/server/compile_handler_bench_test.go
@@ -60,9 +60,6 @@ func BenchmarkCompileHandler(b *testing.B) {
 
 			for b.Loop() {
 				req := httptest.NewRequest("POST", "/v1/compile/"+path, bytes.NewBuffer(jsonData))
-				if err != nil {
-					b.Fatalf("Failed to create request: %v", err)
-				}
 				req.Header.Set("Content-Type", "application/json")
 				req.Header.Set("Accept", target)
 

--- a/v1/topdown/errors_test.go
+++ b/v1/topdown/errors_test.go
@@ -115,3 +115,22 @@ func TestErrorWrapping(t *testing.T) {
 		})
 	}
 }
+
+// 101.7 ns/op	     144 B/op	       5 allocs/op // using fmt.Sprintf
+// 18.78 ns/op	      48 B/op	       1 allocs/op // using []byte + Location.AppendText
+func BenchmarkErrorError(b *testing.B) {
+	loc := &location.Location{
+		File: "b.rego",
+		Col:  10,
+		Row:  12,
+	}
+	err := &topdown.Error{
+		Code:     topdown.BuiltinErr,
+		Message:  "builtin error",
+		Location: loc,
+	}
+
+	for b.Loop() {
+		_ = err.Error()
+	}
+}

--- a/v1/util/performance.go
+++ b/v1/util/performance.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"unsafe"
@@ -106,6 +107,11 @@ func NumDigitsUint(n uint64) int {
 		count++
 	}
 	return count
+}
+
+// AppendInt is a less messy version of strconv.AppendInt for base 10 ints.
+func AppendInt(buf []byte, n int) []byte {
+	return strconv.AppendInt(buf, int64(n), 10)
 }
 
 // SplitMap calls fn for each delim-separated part of text and returns a slice of the results.


### PR DESCRIPTION
Some work I did during the holidays as part of improving the performance of interpolated strings. This change is however not isolated to those, but updates the `String()` implementation of all AST node types (term values and policy components). This change also lays the groundwork for migrating OPA to the `json/v2` package once that's stable. The `json/v2` package provides low-level functions for zero alloc marshalling via appenders — and well, here they are. The appenders here should be usable for that purpose with only a few tweaks needed for the few cases where our `String()` implementations aren't also valid JSON.

Creating perfectly sized buffers requires knowing the expected length beforehand. In order to do this, each component now implements not only `encoding.AppendText` but a new custom `StringLengther` interface, which allows asking any AST node about its `StringLength()` before `make`ing a buffer of that length.

We could definitely consider adding these to e.g. the `Value` or `Node` interfaces, but I've left that out of this PR as it's an easy thing to do later should we want to, and I guess there's always some concerns about changing public interfaces even when they're not meant to be implemented by external code.

While no `Value` appenders allocate and almost none of the policy appenders do either, one notable exception is `Module` when there are annotations present, as they are a bit of a (YAML) special case. It's doable, but as serializing full modules isn't on a hot path anywhere, I have chosen to defer that work to the future.