### PR TITLE
perf(topdown): optimize json.remove and .filter

### DIFF
--- a/v1/ast/term.go
+++ b/v1/ast/term.go
@@ -2570,7 +2570,7 @@ func filterObject(o Value, filter Value) (Value, error) {
 	case String, Number, Boolean, Null:
 		return o, nil
 	case *Array:
-		values := NewArray()
+		values := make([]*Term, 0, v.Len())
 		for i := range v.Len() {
 			subFilter := filteredObj.Get(InternedIntegerString(i))
 			if subFilter != nil {
@@ -2578,10 +2578,10 @@ func filterObject(o Value, filter Value) (Value, error) {
 				if err != nil {
 					return nil, err
 				}
-				values = values.Append(NewTerm(filteredValue))
+				values = append(values, NewTerm(filteredValue))
 			}
 		}
-		return values, nil
+		return NewArray(values...), nil
 	case Set:
 		terms := make([]*Term, 0, v.Len())
 		for _, t := range v.Slice() {


### PR DESCRIPTION
### Why the changes in this PR are needed?

<!--
Include a short description of WHY the changes were made.
-->

The `json.remove` and `json.filter` built-in functions were constructing result collections (Objects, Sets, and Arrays) incrementally. For Arrays specifically, `ast.Array.Append` allocates a new `*Array` struct per element, causing unnecessary intermediate allocations.

### What are the changes in this PR?

<!--
Include a short description of WHAT changes were made.
-->

The implementation utilises the new `ast.NewObjectWithCapacity` method for pre-allocating collections from #8175.

Changes:

- Optimized `jsonRemove` to pre-allocate collections with the size of the source collection as an upper bound.
- Refactored array handling in `jsonRemove` to accumulate elements in a Go slice first (with pre-allocated capacity) and construct the final array with `ast.NewArray`.
- Refactored array handling similarly for `ast.Object.Filter`.
- Optimized `pathsToObject` (used by `json.remove` and `json.filter`) to pre-allocate the root object based on the number of paths.

Added:

- Three new benchmarks: `BenchmarkJSONRemoveArray`, `BenchmarkJSONFilterArray` and `BenchmarkJSONFilterArrayIndices`

Benchmarked with:

```bash
go test -bench="BenchmarkJSONRemoveArray|BenchmarkJSONFilterArray" -run=^$ -count=10 -benchmem ./v1/topdown/..
```

Benchstat results:

```
cpu: Apple M1 Pro
                                   │  master.out  │               fix.out               │
                                   │    sec/op    │   sec/op     vs base                │
JSONRemoveArray/size=10-8             2.108µ ± 7%   1.494µ ± 1%  -29.13% (p=0.000 n=10)
JSONRemoveArray/size=100-8           10.693µ ± 7%   7.180µ ± 4%  -32.86% (p=0.000 n=10)
JSONRemoveArray/size=1000-8           159.1µ ± 5%   115.2µ ± 6%  -27.62% (p=0.000 n=10)
JSONRemoveArray/size=5000-8           891.9µ ± 0%   560.6µ ± 3%  -37.14% (p=0.000 n=10)
JSONFilterArray/size=10-8             4.458µ ± 4%   4.037µ ± 5%   -9.44% (p=0.001 n=10)
JSONFilterArray/size=100-8            42.82µ ± 4%   38.45µ ± 6%  -10.20% (p=0.000 n=10)
JSONFilterArray/size=1000-8           432.2µ ± 1%   395.7µ ± 3%   -8.46% (p=0.002 n=10)
JSONFilterArray/size=5000-8           2.560m ± 2%   2.336m ± 2%   -8.75% (p=0.001 n=10)
JSONFilterArrayIndices/size=10-8      3.142µ ± 1%   3.062µ ± 3%   -2.56% (p=0.002 n=10)
JSONFilterArrayIndices/size=100-8     28.43µ ± 5%   27.39µ ± 4%        ~ (p=0.063 n=10)
JSONFilterArrayIndices/size=1000-8    324.8µ ± 8%   310.8µ ± 2%   -4.29% (p=0.001 n=10)
JSONFilterArrayIndices/size=5000-8    1.893m ± 2%   1.688m ± 2%  -10.82% (p=0.000 n=10)
geomean                               75.99µ        63.59µ       -16.32%

                                   │  master.out   │               fix.out                │
                                   │     B/op      │     B/op      vs base                │
JSONRemoveArray/size=10-8             2.484Ki ± 0%   1.531Ki ± 0%  -38.36% (p=0.000 n=10)
JSONRemoveArray/size=100-8           13.141Ki ± 0%   4.531Ki ± 0%  -65.52% (p=0.000 n=10)
JSONRemoveArray/size=1000-8          152.69Ki ± 0%   64.45Ki ± 0%  -57.79% (p=0.000 n=10)
JSONRemoveArray/size=5000-8           809.2Ki ± 0%   300.3Ki ± 0%  -62.89% (p=0.000 n=10)
JSONFilterArray/size=10-8             3.742Ki ± 0%   3.438Ki ± 0%   -8.14% (p=0.000 n=10)
JSONFilterArray/size=100-8            34.13Ki ± 0%   30.69Ki ± 0%  -10.09% (p=0.000 n=10)
JSONFilterArray/size=1000-8           370.6Ki ± 0%   324.9Ki ± 0%  -12.33% (p=0.000 n=10)
JSONFilterArray/size=5000-8           1.995Mi ± 0%   1.745Mi ± 0%  -12.53% (p=0.000 n=10)
JSONFilterArrayIndices/size=10-8      3.055Ki ± 0%   2.672Ki ± 0%  -12.53% (p=0.000 n=10)
JSONFilterArrayIndices/size=100-8     23.05Ki ± 0%   20.65Ki ± 0%  -10.44% (p=0.000 n=10)
JSONFilterArrayIndices/size=1000-8    263.3Ki ± 0%   248.9Ki ± 0%   -5.49% (p=0.000 n=10)
JSONFilterArrayIndices/size=5000-8    1.372Mi ± 0%   1.241Mi ± 0%   -9.54% (p=0.000 n=10)
geomean                               68.22Ki        47.84Ki       -29.88%

                                   │ master.out  │               fix.out               │
                                   │  allocs/op  │  allocs/op   vs base                │
JSONRemoveArray/size=10-8             60.00 ± 0%    42.00 ± 0%  -30.00% (p=0.000 n=10)
JSONRemoveArray/size=100-8            246.0 ± 0%    132.0 ± 0%  -46.34% (p=0.000 n=10)
JSONRemoveArray/size=1000-8          4.676k ± 0%   3.655k ± 0%  -21.83% (p=0.000 n=10)
JSONRemoveArray/size=5000-8          20.68k ± 0%   15.65k ± 0%  -24.32% (p=0.000 n=10)
JSONFilterArray/size=10-8            100.00 ± 0%    95.00 ± 0%   -5.00% (p=0.000 n=10)
JSONFilterArray/size=100-8            751.0 ± 0%    737.0 ± 0%   -1.86% (p=0.000 n=10)
JSONFilterArray/size=1000-8          7.082k ± 0%   7.056k ± 0%   -0.37% (p=0.000 n=10)
JSONFilterArray/size=5000-8          35.15k ± 0%   35.10k ± 0%   -0.13% (p=0.000 n=10)
JSONFilterArrayIndices/size=10-8      95.00 ± 0%    84.00 ± 0%  -11.58% (p=0.000 n=10)
JSONFilterArrayIndices/size=100-8     654.0 ± 0%    594.0 ± 0%   -9.17% (p=0.000 n=10)
JSONFilterArrayIndices/size=1000-8   8.697k ± 0%   8.181k ± 0%   -5.93% (p=0.000 n=10)
JSONFilterArrayIndices/size=5000-8   40.73k ± 0%   38.21k ± 0%   -6.18% (p=0.000 n=10)
geomean                              1.701k        1.449k       -14.81%
```

### Notes to assist PR review:

<!--
Here you can add information you think will help the reviewer(s).
-->

The internal logic remains the same. Only the construction method of the result terms has been optimized.

### Further comments:

<!--
Here you can include links to additional resources related to the changes, discuss your solution, other approaches you considered etc.
-->

Follows patterns from other similar performance improvements like #8172 and #8173. 
