### PR TITLE
fix(topdown): correct operand in cheap range step

### DIFF
--- a/v1/test/cases/testdata/v1/numbersrangestep/test-numbersrangestep.yaml
+++ b/v1/test/cases/testdata/v1/numbersrangestep/test-numbersrangestep.yaml
@@ -101,3 +101,15 @@ cases:
       - x:
           - 2
           - 4
+  - note: numbersrangestep/big int step
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p := num if {
+          num := numbers.range_step(0, 10, 99999999999999999999)
+        }
+    want_result:
+      - x:
+          - 0

--- a/v1/topdown/numbers.go
+++ b/v1/topdown/numbers.go
@@ -96,7 +96,7 @@ func canGenerateCheapRange(operands []*ast.Term) bool {
 
 func canGenerateCheapRangeStep(operands []*ast.Term) bool {
 	if canGenerateCheapRange(operands) {
-		step, err := builtins.IntOperand(operands[1].Value, 3)
+		step, err := builtins.IntOperand(operands[2].Value, 3)
 		if err == nil && ast.HasInternedIntNumberTerm(step) {
 			return true
 		}


### PR DESCRIPTION
### Why the changes in this PR are needed?

<!--
Include a short description of WHY the changes were made.
-->

`canGenerateCheapRangeStep` was checking the wrong operand when deciding whether to use the fast path for `numbers.range_step`. The `operands[1]` (y) instead of `operands[2]` (step).

The bug caused `numbers.range_step` to return undefined (empty result) when:
- x and y are small interned integers (e.g., 0-512)
- step is a big integer that doesn't fit in int

Consider `numbers.range_step(0, 10, 99999999999999999999)`. Current implementation returns `{}` (empty/undefined), and this fixed version returns `[0]`. It should be correct, as in start value only since step > range.

### What are the changes in this PR?

<!--
Include a short description of WHAT changes were made.
-->

Fix operand index from 1 to 2 in `canGenerateCheapRangeStep`. Added a regression test.

### Notes to assist PR review:

<!--
Here you can add information you think will help the reviewer(s).
-->

The function signature is `numbers.range_step(a, b, step)`, so operands are `[a, b, step]` at indices `[0, 1, 2]`. See [v1/ast/builtins.go](https://github.com/open-policy-agent/opa/blob/main/v1/ast/builtins.go#L1477-L1493) for definition.

### Further comments:

<!--
Here you can include links to additional resources related to the changes, discuss your solution, other approaches you considered etc.
-->

Found while investigating `numbers.range` performance optimizations.
