### PR TITLE
perf(topdown): pre-alloc in various builtins

### DIFF
--- a/v1/ast/term.go
+++ b/v1/ast/term.go
@@ -1399,6 +1399,15 @@ func NewArray(a ...*Term) *Array {
 	return arr
 }
 
+// NewArrayWithCapacity returns a new empty Array with the given capacity pre-allocated.
+func NewArrayWithCapacity(capacity int) *Array {
+	return &Array{
+		elems:  make([]*Term, 0, capacity),
+		hashs:  make([]int, 0, capacity),
+		ground: true,
+	}
+}
+
 // Array represents an array as defined by the language. Arrays are similar to the
 // same types as defined by JSON with the exception that they can contain Vars
 // and References.

--- a/v1/topdown/cidr.go
+++ b/v1/topdown/cidr.go
@@ -300,7 +300,7 @@ func builtinNetCIDRMerge(_ BuiltinContext, operands []*ast.Term, iter func(*ast.
 
 	merged := evalNetCIDRMerge(networks)
 
-	result := ast.NewSet()
+	result := ast.NewSetWithCapacity(len(merged))
 	for _, network := range merged {
 		result.Add(ast.StringTerm(network.String()))
 	}

--- a/v1/topdown/encoding.go
+++ b/v1/topdown/encoding.go
@@ -287,7 +287,7 @@ func builtinURLQueryDecodeObject(_ BuiltinContext, operands []*ast.Term, iter fu
 		return err
 	}
 
-	queryObject := ast.NewObject()
+	queryObject := ast.NewObjectWithCapacity(len(queryParams))
 	for k, v := range queryParams {
 		paramsArray := make([]*ast.Term, len(v))
 		for i, param := range v {

--- a/v1/topdown/eval.go
+++ b/v1/topdown/eval.go
@@ -1492,20 +1492,20 @@ func (e *eval) amendComprehension(a *ast.Term, b1 *bindings) (*ast.Term, error) 
 }
 
 func (e *eval) biunifyComprehensionArray(x *ast.ArrayComprehension, b *ast.Term, b1, b2 *bindings, iter unifyIterator) error {
-	result := ast.NewArray()
+	var elements []*ast.Term
 	child := evalPool.Get()
 
 	e.closure(x.Body, child)
 	defer evalPool.Put(child)
 
 	err := child.Run(func(child *eval) error {
-		result = result.Append(child.bindings.Plug(x.Term))
+		elements = append(elements, child.bindings.Plug(x.Term))
 		return nil
 	})
 	if err != nil {
 		return err
 	}
-	return e.biunify(ast.NewTerm(result), b, b1, b2, iter)
+	return e.biunify(ast.NewTerm(ast.NewArray(elements...)), b, b1, b2, iter)
 }
 
 func (e *eval) biunifyComprehensionSet(x *ast.SetComprehension, b *ast.Term, b1, b2 *bindings, iter unifyIterator) error {

--- a/v1/topdown/graphql.go
+++ b/v1/topdown/graphql.go
@@ -146,7 +146,7 @@ func pruneIrrelevantGraphQLASTNodes(value ast.Value) ast.Value {
 	// extant ast type!
 	switch x := value.(type) {
 	case *ast.Array:
-		result := ast.NewArray()
+		result := ast.NewArrayWithCapacity(x.Len())
 		// Iterate over the array's elements, and do the following:
 		// - Drop any Nulls
 		// - Drop any any empty object/array value (after running the pruner)
@@ -173,7 +173,7 @@ func pruneIrrelevantGraphQLASTNodes(value ast.Value) ast.Value {
 		}
 		return result
 	case ast.Object:
-		result := ast.NewObject()
+		result := ast.NewObjectWithCapacity(x.Len())
 		// Iterate over our object's keys, and do the following:
 		// - Drop "Position".
 		// - Drop any key with a Null value.

--- a/v1/topdown/jsonschema.go
+++ b/v1/topdown/jsonschema.go
@@ -110,7 +110,7 @@ func builtinJSONMatchSchema(bctx BuiltinContext, operands []*ast.Term, iter func
 	}
 
 	// In case of validation errors produce Rego array of objects to describe the errors.
-	arr := ast.NewArray()
+	arr := ast.NewArrayWithCapacity(len(result.Errors()))
 	for _, re := range result.Errors() {
 		o := ast.NewObject(
 			[...]*ast.Term{ast.StringTerm("error"), ast.StringTerm(re.String())},

--- a/v1/topdown/net.go
+++ b/v1/topdown/net.go
@@ -49,7 +49,7 @@ func builtinLookupIPAddr(bctx BuiltinContext, operands []*ast.Term, iter func(*a
 		return err
 	}
 
-	ret := ast.NewSet()
+	ret := ast.NewSetWithCapacity(len(addrs))
 	for _, a := range addrs {
 		ret.Add(ast.StringTerm(a.String()))
 

--- a/v1/topdown/object.go
+++ b/v1/topdown/object.go
@@ -175,7 +175,7 @@ func builtinObjectKeys(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Te
 func getObjectKeysParam(arrayOrSet ast.Value) (ast.Set, error) {
 	switch v := arrayOrSet.(type) {
 	case *ast.Array:
-		keys := ast.NewSet()
+		keys := ast.NewSetWithCapacity(v.Len())
 		v.Foreach(keys.Add)
 		return keys, nil
 	case ast.Set:

--- a/v1/topdown/resolver.go
+++ b/v1/topdown/resolver.go
@@ -99,7 +99,7 @@ func (t *resolverTrie) mktree(e *eval, in resolver.Input) (ast.Value, error) {
 		}
 		return result.Value, nil
 	}
-	obj := ast.NewObject()
+	obj := ast.NewObjectWithCapacity(len(t.children))
 	for k, child := range t.children {
 		v, err := child.mktree(e, resolver.Input{Ref: append(in.Ref, ast.NewTerm(k)), Input: in.Input, Metrics: in.Metrics})
 		if err != nil {


### PR DESCRIPTION
### Why the changes in this PR are needed?

<!--
Include a short description of WHY the changes were made.
-->

Several built-in functions construct new sets, objects, or arrays where the final size is known beforehand (e.g., based on the length of an input slice or map). Pre-allocating these structures avoids repeated resizing and re-hashing operations during population, reducing memory allocations and CPU usage.

Some of this work has already been done in #8172, #8173 and #8175. This PR is a mixed bag of straightforward changes to utilise up-front allocation.

### What are the changes in this PR?

<!--
Include a short description of WHAT changes were made.
-->

Add a new initialiser `NewArrayWithCapacity(capacity int)` alongside of `NewSetWithCapacity` and `NewObjectWithCapacity`. Use these three in various places.

### Notes to assist PR review:

<!--
Here you can add information you think will help the reviewer(s).
-->

The changes are mechanical replacements of `NewSet()`, `NewObject()` and `NewArray()` with their `WithCapacity()` counterparts using known lengths.

`biunifyComprehensionArray` in `eval.go` was also optimized to use a Go slice for accumulation before creating the AST Array, similar to optimizations done in other files not included in this PR.

### Further comments:

<!--
Here you can include links to additional resources related to the changes, discuss your solution, other approaches you considered etc.
-->

There are numerous other occurences of NewSet/NewArray/NewObject in the codebase. Some of these cannot be optimised, often because the size is unknown or it's unbounded.
