### PR TITLE
perf(ast): reduce allocations in Term.MarshalJSON

### DIFF
--- a/v1/ast/term.go
+++ b/v1/ast/term.go
@@ -410,19 +410,24 @@ func (term *Term) IsGround() bool {
 	return term.Value.IsGround()
 }
 
+// termJSON is used to serialize Term to JSON without map allocation.
+type termJSON struct {
+	Location *Location `json:"location,omitempty"`
+	Type     string    `json:"type"`
+	Value    Value     `json:"value"`
+}
+
 // MarshalJSON returns the JSON encoding of the term.
 //
 // Specialized marshalling logic is required to include a type hint for Value.
 func (term *Term) MarshalJSON() ([]byte, error) {
-	d := map[string]any{
-		"type":  ValueName(term.Value),
-		"value": term.Value,
+	d := termJSON{
+		Type:  ValueName(term.Value),
+		Value: term.Value,
 	}
 	jsonOptions := astJSON.GetOptions().MarshalOptions
 	if jsonOptions.IncludeLocation.Term {
-		if term.Location != nil {
-			d["location"] = term.Location
-		}
+		d.Location = term.Location
 	}
 	return json.Marshal(d)
 }


### PR DESCRIPTION
### Why the changes in this PR are needed?

<!--
Include a short description of WHY the changes were made.
-->

Profiling `BenchmarkSetMarshalJSON` revealed that `reflect.copyVal` accounted for >40% of allocations, triggered by `encoding/json` iterating over maps using reflection. The `Term.MarshalJSON` method was creating a `map[string]any` for every term, which is expensive. Each map requires a header struct plus bucket storage.

### What are the changes in this PR?

<!--
Include a short description of WHAT changes were made.
-->

Replace dynamic `map[string]any` with a static struct:

```go
// Before
d := map[string]any{
    "type":  ValueName(term.Value),
    "value": term.Value,
}

// After
type termJSON struct {
    Location *Location `json:"location,omitempty"`
    Type     string    `json:"type"`
    Value    Value     `json:"value"`
}
d := termJSON{
    Type: ValueName(term.Value),
    Value: term.Value
}
```

The struct field order is guaranteed.

Benchmark run:

```bash
go test ./v1/ast -run='^$' -bench='BenchmarkSetMarshalJSON' -benchmem -count=10
```

Benchstat results:

```
cpu: AMD EPYC 9655 96-Core Processor
                                     │  main.out   │               fix.out               │
                                     │   sec/op    │   sec/op     vs base                │
SetMarshalJSON/5/json.Marshal-16       3.956µ ± 2%   2.187µ ± 1%  -44.72% (p=0.000 n=10)
SetMarshalJSON/50/json.Marshal-16      37.04µ ± 1%   19.66µ ± 1%  -46.92% (p=0.000 n=10)
SetMarshalJSON/500/json.Marshal-16     368.6µ ± 0%   187.9µ ± 1%  -49.03% (p=0.000 n=10)
SetMarshalJSON/5000/json.Marshal-16    4.393m ± 1%   2.027m ± 1%  -53.86% (p=0.000 n=10)
SetMarshalJSON/50000/json.Marshal-16   40.58m ± 1%   20.16m ± 2%  -50.32% (p=0.000 n=10)
geomean                                395.1µ        201.3µ       -49.06%

                                     │   main.out    │               fix.out                │
                                     │     B/op      │     B/op      vs base                │
SetMarshalJSON/5/json.Marshal-16         2989.0 ± 0%     745.0 ± 0%  -75.08% (p=0.000 n=10)
SetMarshalJSON/50/json.Marshal-16      29.362Ki ± 0%   7.444Ki ± 0%  -74.65% (p=0.000 n=10)
SetMarshalJSON/500/json.Marshal-16     291.11Ki ± 0%   71.47Ki ± 0%  -75.45% (p=0.000 n=10)
SetMarshalJSON/5000/json.Marshal-16    3049.7Ki ± 0%   759.2Ki ± 1%  -75.11% (p=0.000 n=10)
SetMarshalJSON/50000/json.Marshal-16   30.998Mi ± 2%   8.613Mi ± 4%  -72.21% (p=0.000 n=10)
geomean                                 299.6Ki        76.33Ki       -74.52%

                                     │  main.out   │               fix.out               │
                                     │  allocs/op  │  allocs/op   vs base                │
SetMarshalJSON/5/json.Marshal-16        48.00 ± 0%    13.00 ± 0%  -72.92% (p=0.000 n=10)
SetMarshalJSON/50/json.Marshal-16       453.0 ± 0%    103.0 ± 0%  -77.26% (p=0.000 n=10)
SetMarshalJSON/500/json.Marshal-16     4.504k ± 0%   1.003k ± 0%  -77.73% (p=0.000 n=10)
SetMarshalJSON/5000/json.Marshal-16    45.02k ± 0%   10.01k ± 0%  -77.77% (p=0.000 n=10)
SetMarshalJSON/50000/json.Marshal-16   450.1k ± 0%   100.0k ± 0%  -77.78% (p=0.000 n=10)
geomean                                4.566k        1.061k       -76.76%
```

### Notes to assist PR review:

<!--
Here you can add information you think will help the reviewer(s).
-->

Just some of the benefits from using struct here instead of a map:

- `struct` field access is direct memory, no hash lookups
- No `reflect.MapRange()` iteration or `reflect.copyVal` allocations
- `omitempty` tag handles optional fields cleanly without conditional map insertion

Profile capture:

```bash
go test ./v1/ast -run='^$' -bench='BenchmarkSetMarshalJSON/500/json.Marshal' -benchmem -memprofile=json_opt_mem.prof -count=1
```

Analysis:

```bash
go tool pprof -text -alloc_objects json_opt_mem.prof
```

Before:

<details>
<code>
File: ast.test
Type: alloc_objects
Time: 2026-01-09 21:48:23 EET
Showing nodes accounting for 37077458, 99.41% of 37297394 total
Dropped 68 nodes (cum <= 186486)
      flat  flat%   sum%        cum   cum%
  16122102 43.23% 43.23%   16122102 43.23%  reflect.copyVal
  12476872 33.45% 76.68%   37070429 99.39%  github.com/open-policy-agent/opa/v1/ast.(*Term).MarshalJSON
   4358476 11.69% 88.36%   20480578 54.91%  encoding/json.mapEncoder.encode
   4120008 11.05% 99.41%   37112737 99.50%  encoding/json.Marshal
         0     0% 99.41%   37109034 99.49%  encoding/json.(*encodeState).marshal
         0     0% 99.41%   37109034 99.49%  encoding/json.(*encodeState).reflectValue
         0     0% 99.41%   37072323 99.40%  encoding/json.arrayEncoder.encode
         0     0% 99.41%   37109034 99.49%  encoding/json.marshalerEncoder
         0     0% 99.41%   37072323 99.40%  encoding/json.sliceEncoder.encode
         0     0% 99.41%   37076104 99.41%  github.com/open-policy-agent/opa/v1/ast.(*set).MarshalJSON
         0     0% 99.41%   37112737 99.50%  github.com/open-policy-agent/opa/v1/ast.BenchmarkSetMarshalJSON.func1.1
         0     0% 99.41%    8126588 21.79%  reflect.(*MapIter).Key
         0     0% 99.41%    7995514 21.44%  reflect.(*MapIter).Value
         0     0% 99.41%   37276738 99.94%  testing.(*B).run1.func1
         0     0% 99.41%   37276738 99.94%  testing.(*B).runN
</code>
</details>

After:

<details>
<code>
File: ast.test
Type: alloc_objects
Time: 2026-01-09 21:45:22 EET
Showing nodes accounting for 13905103, 99.85% of 13925943 total
Dropped 48 nodes (cum <= 69629)
      flat  flat%   sum%        cum   cum%
   6914286 49.65% 49.65%   13680651 98.24%  encoding/json.Marshal
   6739593 48.40% 98.05%   13642956 97.97%  github.com/open-policy-agent/opa/v1/ast.(*Term).MarshalJSON
    229379  1.65% 99.69%     229379  1.65%  github.com/open-policy-agent/opa/v1/ast.StringTerm (inline)
     21845  0.16% 99.85%   13674395 98.19%  github.com/open-policy-agent/opa/v1/ast.(*set).MarshalJSON
         0     0% 99.85%   13675024 98.20%  encoding/json.(*encodeState).marshal
         0     0% 99.85%   13675024 98.20%  encoding/json.(*encodeState).reflectValue
         0     0% 99.85%   13643158 97.97%  encoding/json.arrayEncoder.encode
         0     0% 99.85%   13675024 98.20%  encoding/json.marshalerEncoder
         0     0% 99.85%   13643158 97.97%  encoding/json.sliceEncoder.encode
         0     0% 99.85%     207671  1.49%  github.com/open-policy-agent/opa/v1/ast.BenchmarkSetMarshalJSON.func1
         0     0% 99.85%   13680651 98.24%  github.com/open-policy-agent/opa/v1/ast.BenchmarkSetMarshalJSON.func1.1
         0     0% 99.85%   13888322 99.73%  testing.(*B).run1.func1
         0     0% 99.85%   13888322 99.73%  testing.(*B).runN
</code>
</details>


### Further comments:

<!--
Here you can include links to additional resources related to the changes, discuss your solution, other approaches you considered etc.
-->


The same `map[string]any` pattern exists in other `MarshalJSON` methods  (like `Expr`). Didn't look too much yet if those could be optimised, however probably with less impact than this AST change.
