### PR TITLE
fix: format pr_check.rego with opa fmt

### DIFF
--- a/build/policy/pr-check/pr_check.rego
+++ b/build/policy/pr-check/pr_check.rego
@@ -65,9 +65,9 @@ changes["docs"] if {
 	changed_file.filename in docs_root_files
 }
 
-changes["go"] if{
-    some changed_file in input
-    endswith(changed_file.filename, ".go")
+changes["go"] if {
+	some changed_file in input
+	endswith(changed_file.filename, ".go")
 } else if {
 	some changed_file in input
 	strings.any_prefix_match(changed_file.filename, go_change_prefixes)


### PR DESCRIPTION

### Why the changes in this PR are needed?

<!--
Include a short description of WHY the changes were made.
-->

File was not properly formatted, causing CI to fail. See [this](https://github.com/open-policy-agent/opa/actions/runs/20863755895/job/59949631018?pr=8200) for an example from #8200.

### What are the changes in this PR?

<!--
Include a short description of WHAT changes were made.
-->

Fixed with `opa fmt -w build/policy/pr-check/pr_check.rego`.

### Notes to assist PR review:

<!--
Here you can add information you think will help the reviewer(s).
-->

Relates to #8183.

### Further comments:

<!--
Here you can include links to additional resources related to the changes, discuss your solution, other approaches you considered etc.
-->

N/A
