### PR TITLE
perf(ast): reduce allocations in Expr.MarshalJSON

### DIFF
--- a/v1/ast/policy.go
+++ b/v1/ast/policy.go
@@ -1442,28 +1442,37 @@ func (expr *Expr) String() string {
 	return util.ByteSliceToString(buf)
 }
 
+// exprJSON is used for JSON serialization of Expr to avoid map allocation overhead.
+// Field order is alphabetical to match previous map-based output.
+type exprJSON struct {
+	Generated bool      `json:"generated,omitempty"`
+	Index     int       `json:"index"`
+	Location  *Location `json:"location,omitempty"`
+	Negated   bool      `json:"negated,omitempty"`
+	Terms     any       `json:"terms"`
+	With      []*With   `json:"with,omitempty"`
+}
+
 func (expr *Expr) MarshalJSON() ([]byte, error) {
-	data := map[string]any{
-		"terms": expr.Terms,
-		"index": expr.Index,
+	data := exprJSON{
+		Index: expr.Index,
+		Terms: expr.Terms,
 	}
 
 	if len(expr.With) > 0 {
-		data["with"] = expr.With
+		data.With = expr.With
 	}
 
 	if expr.Generated {
-		data["generated"] = true
+		data.Generated = true
 	}
 
 	if expr.Negated {
-		data["negated"] = true
+		data.Negated = true
 	}
 
 	if astJSON.GetOptions().MarshalOptions.IncludeLocation.Expr {
-		if expr.Location != nil {
-			data["location"] = expr.Location
-		}
+		data.Location = expr.Location
 	}
 
 	return json.Marshal(data)

--- a/v1/ast/policy_bench_test.go
+++ b/v1/ast/policy_bench_test.go
@@ -1,6 +1,7 @@
 package ast
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/open-policy-agent/opa/v1/ast/location"
@@ -80,6 +81,34 @@ func BenchmarkExprAppendText(b *testing.B) {
 			for b.Loop() {
 				buf, _ = tc.expr.AppendText(buf)
 				buf = buf[:0]
+			}
+		})
+	}
+}
+
+func BenchmarkExprMarshalJSON(b *testing.B) {
+	tests := []struct {
+		note string
+		expr *Expr
+	}{
+		{
+			note: "simple expr",
+			expr: MustParseExpr(`input.x == 10`),
+		},
+		{
+			note: "negated expr with with modifier",
+			expr: MustParseExpr(`not input.y != "hello" with input.z as 5`),
+		},
+		{
+			note: "complex expr",
+			expr: MustParseExpr(`count({x | x := input.arr[_]; x > 10}) == 3 with input.arr as [5, 15, 25, 8, 30]`),
+		},
+	}
+
+	for _, tc := range tests {
+		b.Run(tc.note, func(b *testing.B) {
+			for b.Loop() {
+				_, _ = json.Marshal(tc.expr)
 			}
 		})
 	}


### PR DESCRIPTION
### Why the changes in this PR are needed?

<!--
Include a short description of WHY the changes were made.
-->

Similarly as in #8200, `Expr.MarshalJSON` creates a `map[string]any` on every call, incurring map allocation overhead and reflection costs during `encoding/json` marshaling. This affects at least partial evaluation responses and `opa parse --json` output.

### What are the changes in this PR?

<!--
Include a short description of WHAT changes were made.
-->

Replace map[string]any with a typed `exprJSON` struct in `Expr.MarshalJSON`. Fields are ordered alphabetically to preserve JSON output compatibility.

Also adds `BenchmarkExprMarshalJSON` with a few different queries to measure performance.

Benchmark run:

```bash
go test ./v1/ast -run='^$' -bench='BenchmarkExprMarshalJSON' -benchmem -count=10
```

Benchstat result:

```
cpu: Apple M1 Pro
                                                  │   old.txt    │              new.txt               │
                                                  │    sec/op    │   sec/op     vs base               │
ExprMarshalJSON/simple_expr-8                       6.526µ ±  1%   6.296µ ± 3%  -3.53% (p=0.001 n=10)
ExprMarshalJSON/negated_expr_with_with_modifier-8   12.73µ ±  4%   11.76µ ± 3%  -7.66% (p=0.001 n=10)
ExprMarshalJSON/complex_expr-8                      42.95µ ± 10%   41.83µ ± 1%  -2.61% (p=0.000 n=10)
geomean                                             15.28µ         14.57µ       -4.63%

                                                  │   old.txt    │               new.txt               │
                                                  │     B/op     │     B/op      vs base               │
ExprMarshalJSON/simple_expr-8                       4.059Ki ± 0%   3.668Ki ± 0%  -9.62% (p=0.000 n=10)
ExprMarshalJSON/negated_expr_with_with_modifier-8   7.290Ki ± 0%   6.734Ki ± 0%  -7.62% (p=0.000 n=10)
ExprMarshalJSON/complex_expr-8                      21.18Ki ± 0%   19.90Ki ± 0%  -6.02% (p=0.000 n=10)
geomean                                             8.557Ki        7.892Ki       -7.77%

                                                  │  old.txt   │              new.txt              │
                                                  │ allocs/op  │ allocs/op   vs base               │
ExprMarshalJSON/simple_expr-8                       65.00 ± 0%   59.00 ± 0%  -9.23% (p=0.000 n=10)
ExprMarshalJSON/negated_expr_with_with_modifier-8   114.0 ± 0%   103.0 ± 0%  -9.65% (p=0.000 n=10)
ExprMarshalJSON/complex_expr-8                      306.0 ± 0%   285.0 ± 0%  -6.86% (p=0.000 n=10)
geomean                                             131.4        120.1       -8.59%
```

### Notes to assist PR review:

<!--
Here you can add information you think will help the reviewer(s).
-->

Same notes as in #8200.



### Further comments:

<!--
Here you can include links to additional resources related to the changes, discuss your solution, other approaches you considered etc.
-->

Improvement is smaller than `Term.MarshalJSON` because `Expr` contains nested terms. The bulk of marshaling work is in the nested `Terms` field, which is expensive even after this change.