### PR TITLE
perf(ast): reduce allocations in With.MarshalJSON

### DIFF
--- a/v1/ast/policy.go
+++ b/v1/ast/policy.go
@@ -1729,16 +1729,22 @@ func (w *With) SetLoc(loc *Location) {
 	w.Location = loc
 }
 
+// withJSON is used for JSON serialization of With to avoid map allocation overhead.
+// Field order is alphabetical to match previous map-based output.
+type withJSON struct {
+	Location *Location `json:"location,omitempty"`
+	Target   *Term     `json:"target"`
+	Value    *Term     `json:"value"`
+}
+
 func (w *With) MarshalJSON() ([]byte, error) {
-	data := map[string]any{
-		"target": w.Target,
-		"value":  w.Value,
+	data := withJSON{
+		Target: w.Target,
+		Value:  w.Value,
 	}
 
 	if astJSON.GetOptions().MarshalOptions.IncludeLocation.With {
-		if w.Location != nil {
-			data["location"] = w.Location
-		}
+		data.Location = w.Location
 	}
 
 	return json.Marshal(data)

--- a/v1/ast/policy_bench_test.go
+++ b/v1/ast/policy_bench_test.go
@@ -157,3 +157,16 @@ func BenchmarkRuleMarshalJSON(b *testing.B) {
 		})
 	}
 }
+
+func BenchmarkWithMarshalJSON(b *testing.B) {
+	module := MustParseModule(`
+		package test
+		allow if { input.x with input as {"x": true} }
+	`)
+
+	with := module.Rules[0].Body[0].With[0]
+
+	for b.Loop() {
+		_, _ = json.Marshal(with)
+	}
+}


### PR DESCRIPTION
### Why the changes in this PR are needed?

<!--
Include a short description of WHY the changes were made.
-->

Similarly as with #8200, #8204 and #8205, `With.MarshalJSON` creates a `map[string]any` on every call, incurring map allocation overhead. `With` modifiers are used in expressions and are marshaled as part of `Expr` serialization.

### What are the changes in this PR?

<!--
Include a short description of WHAT changes were made.
-->

Replace `map[string]any` with a typed `withJSON` struct. Fields are ordered alphabetically to preserve JSON output compatibility.

Also adds `BenchmarkWithMarshalJSON` to measure performance.

Benchmark run:

```bash
go test ./v1/ast -run='^$' -bench='BenchmarkWithMarshalJSON' -benchmem -count=10
```

Benchstat results:

```
cpu: Apple M1 Pro
                  │   old.txt   │              new.txt               │
                  │   sec/op    │   sec/op     vs base               │
WithMarshalJSON-8   6.080µ ± 3%   5.744µ ± 6%  -5.53% (p=0.005 n=10)

                  │   old.txt    │               new.txt                │
                  │     B/op     │     B/op      vs base                │
WithMarshalJSON-8   3.605Ki ± 0%   3.159Ki ± 0%  -12.38% (p=0.000 n=10)

                  │  old.txt   │              new.txt               │
                  │ allocs/op  │ allocs/op   vs base                │
WithMarshalJSON-8   57.00 ± 0%   51.00 ± 0%  -10.53% (p=0.000 n=10)
```

### Notes to assist PR review:

<!--
Here you can add information you think will help the reviewer(s).
-->

Same notes as in #8200.

### Further comments:

<!--
Here you can include links to additional resources related to the changes, discuss your solution, other approaches you considered etc.
-->

Compared to #8205, the map allocation overhead is a larger proportion of total cost in this case.