### PR TITLE
website: Show breadcrumbs in search results

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -301,6 +301,7 @@ The Linux Foundation has registered trademarks and uses trademarks. For a list o
         require.resolve("@easyops-cn/docusaurus-search-local"),
         {
           indexPages: true,
+          explicitSearchResultPath: true,
         },
       ],
       () => ({


### PR DESCRIPTION
This PR makes a minor improvement to the display of search results. I have not yet worked out how to show the breadcrumbs correctly for regal root level pages, so this issue remains.


before
<img width="549" height="375" alt="Screenshot 2026-01-12 at 13 14 06" src="https://github.com/user-attachments/assets/14912571-dca7-4638-853a-4a791d330b08" />

after
<img width="575" height="326" alt="Screenshot 2026-01-12 at 11 56 43" src="https://github.com/user-attachments/assets/af84fa39-2b2c-4ef1-b2bb-e6708b100506" />
