### PR TITLE
e2e/prisma: override hono version (trivy repo scan fix)

### DIFF
--- a/e2e/api/compile/prisma/package-lock.json
+++ b/e2e/api/compile/prisma/package-lock.json
@@ -614,9 +614,9 @@
       "license": "MIT"
     },
     "node_modules/hono": {
-      "version": "4.10.6",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.10.6.tgz",
-      "integrity": "sha512-BIdolzGpDO9MQ4nu3AUuDwHZZ+KViNm+EZ75Ae55eMXMqLVhDFqEMXxtUe9Qh8hjL+pIna/frs2j6Y2yD5Ua/g==",
+      "version": "4.11.4",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.4.tgz",
+      "integrity": "sha512-U7tt8JsyrxSRKspfhtLET79pU8K+tInj5QZXs1jSugO1Vq5dFj3kmZsRldo29mTBfcjDRVRXrEZ6LS63Cog9ZA==",
       "devOptional": true,
       "license": "MIT",
       "engines": {

--- a/e2e/api/compile/prisma/package.json
+++ b/e2e/api/compile/prisma/package.json
@@ -17,5 +17,8 @@
   },
   "devDependencies": {
     "prisma": "^7.2.0"
+  },
+  "overrides": {
+    "hono": "^4.11.4"
   }
 }


### PR DESCRIPTION
That'll fix our nightly tests:

```
e2e/api/compile/prisma/package-lock.json (npm)
==============================================
Total: 2 (HIGH: 2, CRITICAL: 0)

┌─────────┬────────────────┬──────────┬────────┬───────────────────┬───────────────┬───────────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │ Fixed Version │                           Title                           │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼───────────────┼───────────────────────────────────────────────────────────┤
│ hono    │ CVE-2026-22817 │ HIGH     │ fixed  │ 4.10.6            │ 4.11.4        │ Hono JWT Middleware's JWT Algorithm Confusion via Unsafe  │
│         │                │          │        │                   │               │ Default (HS256) Allows Token...                           │
│         │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2026-22817                │
│         ├────────────────┤          │        │                   │               ├───────────────────────────────────────────────────────────┤
│         │ CVE-2026-22818 │          │        │                   │               │ Hono JWK Auth Middleware has JWT algorithm confusion when │
│         │                │          │        │                   │               │ JWK lacks "alg"...                                        │
│         │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2026-22818                │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴───────────────┴───────────────────────────────────────────────────────────┘
```

Not code a user runs, but it's always nicer to have green nightlies