### PR TITLE
docs/devel: Adding note to rebase and not squash when merging patch release PR

### DIFF
--- a/docs/devel/RELEASE.md
+++ b/docs/devel/RELEASE.md
@@ -217,7 +217,10 @@ git push origin release-0.14
 
 Open a Pull Request against the upstream release branch. Be careful to open the
 Pull Request against the correct upstream release branch. **DO NOT** open/merge
-the Pull Request into main or other release branches:
+the Pull Request into main or other release branches.
+
+> Note: Make sure to do a "Rebase and merge" and NOT a squash when merging the PR, to preserve the cherry-picked commits. 
+> Alternatively, the cherry-picks can be pushed to `upstream` before submitting the PR.
 
 Once the Pull Request has merged fetch the latest changes and tag the commit to
 prepare for publishing. Use the same instructions as defined above in normal


### PR DESCRIPTION
to preserve cherry-picked commits.
