### PR TITLE
Type Checker: recognize when a variable has multiple assignments but is an undefined function

### DIFF
--- a/v1/ast/check.go
+++ b/v1/ast/check.go
@@ -387,10 +387,12 @@ func (tc *typeChecker) checkExprBuiltin(env *TypeEnv, expr *Expr) *Error {
 		return NewError(TypeErr, expr.Location, "undefined function %v", name)
 	}
 
-	// check if the expression refers to a function that contains an error
-	_, ok := tpe.(types.Any)
-	if ok {
-		return nil
+	if t, ok := tpe.(types.Any); ok {
+		// A type.Any with a len(0) is created by using types.A , this represents a potential non-local reference
+		// This is the exception when checking if the type represents a function
+		if len(t) == 0 {
+			return nil
+		}
 	}
 
 	ftpe, ok := tpe.(*types.Function)

--- a/v1/ast/env.go
+++ b/v1/ast/env.go
@@ -162,6 +162,8 @@ func (env *TypeEnv) getRefFallback(ref Ref) types.Type {
 	}
 
 	if RootDocumentNames.Contains(ref[0]) {
+		// types.A is an empty types.Any
+		// this is used to represent a potential non-local reference
 		return types.A
 	}
 


### PR DESCRIPTION
resolve: https://github.com/open-policy-agent/opa/issues/7463

```rego
package p
default f := ""
f := 1
r := f()
```

The root cause is within a exception in the `checkExprBuiltin` method so that functions with errors inside of them would still be registered to avoid false `undefined function` errors ([context](https://github.com/open-policy-agent/opa/commit/c43b61b0892da20c45483b031362f7a9d9acb5f3)). When there is an error the function is registered as `types.A` so that the function won't be recognized as undefined: https://github.com/open-policy-agent/opa/blob/c2b897d27f329d488ec96569c60751dc9a61b6e0/v1/ast/check.go#L258-L264

So what is happening in the above policy from the issue, is that `f` has two assignments and is then recognized as a `types.Any` although it is not a function and wasn't registered as an empty `types.A`. The solution is to add another check to make sure it isn't `types.A` and checking the len==0 seemed the best way to do so.