### PR TITLE
docs: Add authz-spring-boot-starter to Spring Security API ecosystem

### DIFF
--- a/docs/src/data/ecosystem/entries/springsecurity-api.md
+++ b/docs/src/data/ecosystem/entries/springsecurity-api.md
@@ -12,6 +12,7 @@ code:
 - https://github.com/Bisnode/opa-spring-security
 - https://github.com/massenz/jwt-opa
 - https://github.com/eugenp/tutorials/tree/master/spring-security-modules/spring-security-opa
+- https://github.com/big-acl/authz-spring-boot-starter
 tutorials:
 - https://github.com/open-policy-agent/contrib/blob/main/spring_authz/README.md
 - https://github.com/massenz/jwt-opa#web-server-demo-app
@@ -21,6 +22,7 @@ inventors:
 - build-security
 - bisnode
 - alertavert
+- big-acl
 docs_features:
   rest-api-integration:
     note: |


### PR DESCRIPTION
Add Big ACL's authz-spring-boot-starter project to the existing Spring Security API integration entry.

A Policy Enforcement Point library for Spring Boot applications that provides fine-grained access control through Spring Security's method security (@PreAuthorize, @PostAuthorize).
