### PR TITLE
perf(topdown): reduce allocs in float sum/product

### DIFF
--- a/v1/topdown/aggregates.go
+++ b/v1/topdown/aggregates.go
@@ -45,12 +45,13 @@ func builtinSum(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term) err
 
 		// Non-integer values found, so we need to sum as floats.
 		sum := big.NewFloat(0)
+		tmp := new(big.Float)
 		err := a.Iter(func(x *ast.Term) error {
 			n, ok := x.Value.(ast.Number)
 			if !ok {
 				return builtins.NewOperandElementErr(1, a, x.Value, "number")
 			}
-			sum = new(big.Float).Add(sum, builtins.NumberToFloat(n))
+			sum = new(big.Float).Add(sum, builtins.NumberToFloatInto(tmp, n))
 			return nil
 		})
 		if err != nil {
@@ -74,12 +75,13 @@ func builtinSum(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term) err
 		}
 
 		sum := big.NewFloat(0)
+		tmp := new(big.Float)
 		err := a.Iter(func(x *ast.Term) error {
 			n, ok := x.Value.(ast.Number)
 			if !ok {
 				return builtins.NewOperandElementErr(1, a, x.Value, "number")
 			}
-			sum = new(big.Float).Add(sum, builtins.NumberToFloat(n))
+			sum = new(big.Float).Add(sum, builtins.NumberToFloatInto(tmp, n))
 			return nil
 		})
 		if err != nil {
@@ -94,12 +96,13 @@ func builtinProduct(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term)
 	switch a := operands[0].Value.(type) {
 	case *ast.Array:
 		product := big.NewFloat(1)
+		tmp := new(big.Float)
 		err := a.Iter(func(x *ast.Term) error {
 			n, ok := x.Value.(ast.Number)
 			if !ok {
 				return builtins.NewOperandElementErr(1, a, x.Value, "number")
 			}
-			product = new(big.Float).Mul(product, builtins.NumberToFloat(n))
+			product = new(big.Float).Mul(product, builtins.NumberToFloatInto(tmp, n))
 			return nil
 		})
 		if err != nil {
@@ -108,12 +111,13 @@ func builtinProduct(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term)
 		return iter(ast.NewTerm(builtins.FloatToNumber(product)))
 	case ast.Set:
 		product := big.NewFloat(1)
+		tmp := new(big.Float)
 		err := a.Iter(func(x *ast.Term) error {
 			n, ok := x.Value.(ast.Number)
 			if !ok {
 				return builtins.NewOperandElementErr(1, a, x.Value, "number")
 			}
-			product = new(big.Float).Mul(product, builtins.NumberToFloat(n))
+			product = new(big.Float).Mul(product, builtins.NumberToFloatInto(tmp, n))
 			return nil
 		})
 		if err != nil {

--- a/v1/topdown/builtins/builtins.go
+++ b/v1/topdown/builtins/builtins.go
@@ -251,11 +251,18 @@ func ArrayOperand(x ast.Value, pos int) (*ast.Array, error) {
 
 // NumberToFloat converts n to a big float.
 func NumberToFloat(n ast.Number) *big.Float {
-	r, ok := new(big.Float).SetString(string(n))
-	if !ok {
+	return NumberToFloatInto(nil, n)
+}
+
+// NumberToFloatInto converts n to a big float, storing it in dst when provided.
+func NumberToFloatInto(dst *big.Float, n ast.Number) *big.Float {
+	if dst == nil {
+		dst = new(big.Float)
+	}
+	if _, ok := dst.SetString(string(n)); !ok {
 		panic("illegal value")
 	}
-	return r
+	return dst
 }
 
 // FloatToNumber converts f to a number.

--- a/v1/topdown/builtins_test.go
+++ b/v1/topdown/builtins_test.go
@@ -1,9 +1,11 @@
 package topdown
 
 import (
+	"math/big"
 	"testing"
 
 	"github.com/open-policy-agent/opa/v1/ast"
+	"github.com/open-policy-agent/opa/v1/topdown/builtins"
 	"github.com/open-policy-agent/opa/v1/types"
 )
 
@@ -40,5 +42,26 @@ func TestCustomBuiltinIterator(t *testing.T) {
 		t.Fatal("Expected one result but got:", rs)
 	} else if !rs[0][ast.Var("x")].Equal(ast.IntNumberTerm(2)) {
 		t.Fatal("Expected x to be 2 but got:", rs[0])
+	}
+}
+
+func TestNumberToFloatInto(t *testing.T) {
+	t.Parallel()
+
+	first := builtins.NumberToFloatInto(nil, ast.Number("1.5"))
+	if first == nil {
+		t.Fatal("expected non-nil float")
+	}
+	if first.Cmp(big.NewFloat(1.5)) != 0 {
+		t.Fatalf("expected 1.5, got %v", first)
+	}
+
+	reuse := big.NewFloat(0)
+	second := builtins.NumberToFloatInto(reuse, ast.Number("2.75"))
+	if second != reuse {
+		t.Fatal("expected reuse of provided float")
+	}
+	if reuse.Cmp(big.NewFloat(2.75)) != 0 {
+		t.Fatalf("expected 2.75, got %v", reuse)
 	}
 }


### PR DESCRIPTION
### Why the changes in this PR are needed?

<!--
Include a short description of WHY the changes were made.
-->

The `sum` and `product` builtins allocate a new `big.Float` for every element when processing arrays/sets containing non-integer numbers. For large collections this creates GC pressure and slows down evaluation.

### What are the changes in this PR?

<!--
Include a short description of WHAT changes were made.
-->

- Add `NumberToFloatInto(dst *big.Float, n ast.Number)` helper in `v1/topdown/builtins` that reuses a caller-provided `big.Float`
- Update `builtinSum` and `builtinProduct` float paths to reuse a single temp `big.Float` per loop
- Add unit test for the new helper

Benchmark run:

```bash
go test ./v1/topdown -run=^$ -bench 'BenchmarkSumFloat' -benchmem -count=10
```

Benchstat results:

```
cpu: Apple M1 Pro
                │   old.txt   │               new.txt               │
                │   sec/op    │   sec/op     vs base                │
SumFloatArray-8   3.047µ ± 0%   2.705µ ± 2%  -11.22% (p=0.000 n=10)
SumFloatSet-8     3.096µ ± 0%   2.861µ ± 1%   -7.61% (p=0.000 n=10)
geomean           3.071µ        2.782µ        -9.43%

                │   old.txt    │               new.txt                │
                │     B/op     │     B/op      vs base                │
SumFloatArray-8   2.517Ki ± 0%   1.883Ki ± 0%  -25.18% (p=0.000 n=10)
SumFloatSet-8     2.626Ki ± 0%   2.055Ki ± 0%  -21.76% (p=0.000 n=10)
geomean           2.571Ki        1.967Ki       -23.49%

                │  old.txt   │              new.txt               │
                │ allocs/op  │ allocs/op   vs base                │
SumFloatArray-8   73.00 ± 0%   57.00 ± 0%  -21.92% (p=0.000 n=10)
SumFloatSet-8     78.00 ± 0%   63.00 ± 0%  -19.23% (p=0.000 n=10)
geomean           75.46        59.92       -20.59%
```

### Notes to assist PR review:

<!--
Here you can add information you think will help the reviewer(s).
-->

The result `big.Float` allocation in Add/Mul is preserved to maintain identical floating-point precision semantics. I originally had an implementation that used in-place `sum.Add(sum, tmp)` which eliminated more allocations. But the problem was that it produced slightly different precision accumulation (e.g., `5.0138888888888893335` vs `5.0138888888888888886`) due to how `big.Float` precision propagates differently when reusing vs allocating fresh results. This was caught by `TestScheduler` which compares exact string representations. So, in this PR only the operand parsing allocation is now eliminated.

Integer paths remain unaffected (fast path unchanged).

### Further comments:

<!--
Here you can include links to additional resources related to the changes, discuss your solution, other approaches you considered etc.
-->

Other `NumberToFloat` call sites (arithmetic, time, etc.) were analysed but showed minimal impact since they don't operate in per-element loops.

