### PR TITLE
docs/ocp: mention source prefix/path options

### DIFF
--- a/docs/docs/ocp/api-reference.md
+++ b/docs/docs/ocp/api-reference.md
@@ -86,7 +86,9 @@ Bundles are collections of policies and data that can be distributed to OPA inst
           "source": "my-app-policies"
         },
         {
-          "source": "shared-policies"
+          "source": "shared-policies",
+          "path": "library",
+          "prefix": "shared.lib"
         }
       ],
       "excluded_files": [
@@ -174,7 +176,9 @@ Bundles are collections of policies and data that can be distributed to OPA inst
       "source": "auth-policies"
     },
     {
-      "source": "common-utils"
+      "source": "common-utils",
+      "path": "utils",
+      "prefix": "shared.utils"
     }
   ],
   "excluded_files": [
@@ -548,7 +552,9 @@ Stacks define how bundles are distributed to different environments or services 
       "source": "dev-policies"
     },
     {
-      "source": "testing-utils"
+      "source": "testing-utils",
+      "path": "utils.testing",
+      "prefix": "test.utils"
     }
   ]
 }

--- a/docs/docs/ocp/guide-deploy-as-a-service.md
+++ b/docs/docs/ocp/guide-deploy-as-a-service.md
@@ -142,6 +142,7 @@ bundles:
     requirements:
     - source: my-alpha-app
     - source: my-shared-datasource
+      prefix: shared.external
 ```
 
 Note: the name `my-alpha-app` in the requirements is specifically referencing the name under sources (from the previous step). You will oftentimes name the bundle with the same name to “link” them logically together, these will normally (but not required to) be configured together in their own configuration file.


### PR DESCRIPTION
These went in before the first OCP release in https://github.com/open-policy-agent/opa-control-plane/pull/135, but we've never updated the docs.