### PR TITLE
fmt: No overwrite to unchanged files in fmt

### DIFF
--- a/cmd/fmt.go
+++ b/cmd/fmt.go
@@ -177,6 +177,11 @@ func formatFile(params *fmtCommandParams, out io.Writer, filename string, info o
 	}
 
 	if params.overwrite {
+		if !changed {
+			// no output is expected in this case
+			return nil
+		}
+
 		outfile, err := os.OpenFile(filename, os.O_WRONLY|os.O_TRUNC, info.Mode().Perm())
 		if err != nil {
 			return newError("failed to open file for writing: %v", err)


### PR DESCRIPTION
Fixes https://github.com/open-policy-agent/opa/issues/8222

```bash 
# std out is the same
…/opa no-change-no-overwrite ➜ opa fmt foobar.rego
package example

foo := 1
…/opa no-change-no-overwrite ➜ go run main.go fmt foobar.rego
package example

foo := 1

# file is modified by 1.12.2 opa
…/opa no-change-no-overwrite ➜ /bin/ls -alT  foobar.rego
-rw-r--r--@ 1 charlieegan3  staff  26 19 Jan 13:55:55 2026 foobar.rego
…/opa no-change-no-overwrite ➜ opa fmt -w foobar.rego
…/opa no-change-no-overwrite ➜ /bin/ls -alT  foobar.rego
-rw-r--r--@ 1 charlieegan3  staff  26 19 Jan 14:00:17 2026 foobar.rego

# but not by this change
…/opa no-change-no-overwrite ➜ go run main.go fmt -w foobar.rego

# time is the same since the file has not been formatted
…/opa no-change-no-overwrite ➜ /bin/ls -alT  foobar.rego
-rw-r--r--@ 1 charlieegan3  staff  26 19 Jan 14:00:17 2026 foobar.rego
```