### PR TITLE
docs: explain how to use the SDK without a initialising a server

### DIFF
--- a/docs/docs/integration.md
+++ b/docs/docs/integration.md
@@ -269,6 +269,34 @@ Setting an `ID` in `sdk.Options` is optional, but recommended. If you do not set
 for the system. While this is fine for testing, it makes it difficult to monitor the system over time, as a new ID will
 be created each time the SDK is initialized, such as when the process is restarted.
 
+#### Using the SDK client without a server
+
+You might want to use the high-level SDK to load policy from the filesystem instead of a bundle server.
+This can be useful if you do not have a bundle server, or you ship policy with the application using the SDK.
+In that case, you can use the SDK as normal, but modify the configuration to use a file scheme and path, instead of a HTTP server resource path.
+You will also not need to include any services in the configuration:
+
+```go
+bundleFilePath, err := filepath.Abs("./policy")
+if err != nil {
+	// handle error
+}
+
+// provide an absolute path to the location of the policy files
+config := []byte(fmt.Sprintf(`{
+	"bundles": {
+		"test": {
+			"resource": "file://%s"
+		}
+	},
+	"decision_logs": {
+		"console": true
+	}
+}`, bundleFilePath))
+
+// create an instance of the OPA object and use it to get policy decisions as normal.
+```
+
 #### Manually Triggering Bundle Reloads
 
 Users of the SDK can


### PR DESCRIPTION
### Why the changes in this PR are needed?

<!--
Include a short description of WHY the changes were made.
-->

My team wanted to use the SDK client in a very simple use case without using a bundle server to distribute policy. The documents did not cover this use case and I spent a lot of time figuring out how to do it. Adding this to the documentation will help other users who may later find themselves in this same situation.

### What are the changes in this PR?

<!--
Include a short description of WHAT changes were made.
-->

A short description on the kind of configuration that is needed to instantiate the SDK client without a real or mock bundle server.

### Further comments:

<!--
Here you can include links to additional resources related to the changes, discuss your solution, other approaches you considered etc.
-->

Discussion on the community slack: https://openpolicyagent.slack.com/archives/C02L1TLPN59/p1768513465312369
