### PR TITLE
docs: add examples for units.parse and units.parse_bytes

### DIFF
--- a/docs/docs/policy-reference/_examples/units/parse/basic/config.json
+++ b/docs/docs/policy-reference/_examples/units/parse/basic/config.json
@@ -1,0 +1,4 @@
+{
+  "showInput": false,
+  "titleSize": 4
+}

--- a/docs/docs/policy-reference/_examples/units/parse/basic/intro.md
+++ b/docs/docs/policy-reference/_examples/units/parse/basic/intro.md
@@ -1,0 +1,16 @@
+<!-- markdownlint-disable MD041 -->
+The `units.parse` function converts string representations of units into their numeric values.
+
+**Decimal (SI) units** (base 1000):
+- K/k = 1000, M = 1000000, G/g = 1000000000
+
+**Binary units** (base 1024):
+- Ki = 1024, Mi = 1048576, Gi = 1073741824
+
+**Milli-units**:
+- m = 0.001 (e.g., "100m" = 0.1)
+
+Common use cases:
+- Parsing Kubernetes resource requests/limits
+- Converting rate limits  
+- Standardizing unit representations

--- a/docs/docs/policy-reference/_examples/units/parse/basic/policy.rego
+++ b/docs/docs/policy-reference/_examples/units/parse/basic/policy.rego
@@ -1,0 +1,20 @@
+package play
+
+import rego.v1
+
+# Parse decimal SI units (base 1000)
+kilobytes := units.parse("10K") # Result: 10000
+
+megabytes := units.parse("200M") # Result: 200000000
+
+gigabytes := units.parse("100G") # Result: 100000000000
+
+# Parse milli-units (base 0.001)
+milliunits := units.parse("100m") # Result: 0.1
+
+# Parse binary units (base 1024)
+kibibytes := units.parse("10Ki") # Result: 10240
+
+mebibytes := units.parse("100Mi") # Result: 104857600
+
+gibibytes := units.parse("5Gi") # Result: 5368709120

--- a/docs/docs/policy-reference/_examples/units/parse/basic/title.txt
+++ b/docs/docs/policy-reference/_examples/units/parse/basic/title.txt
@@ -1,0 +1,1 @@
+Basic Unit Parsing

--- a/docs/docs/policy-reference/_examples/units/parse/memory_limits/config.json
+++ b/docs/docs/policy-reference/_examples/units/parse/memory_limits/config.json
@@ -1,0 +1,4 @@
+{
+  "showInput": true,
+  "titleSize": 4
+}

--- a/docs/docs/policy-reference/_examples/units/parse/memory_limits/input.json
+++ b/docs/docs/policy-reference/_examples/units/parse/memory_limits/input.json
@@ -1,0 +1,13 @@
+{
+  "container": {
+    "name": "app",
+    "resources": {
+      "requests": {
+        "memory": "512Mi"
+      },
+      "limits": {
+        "memory": "2Gi"
+      }
+    }
+  }
+}

--- a/docs/docs/policy-reference/_examples/units/parse/memory_limits/intro.md
+++ b/docs/docs/policy-reference/_examples/units/parse/memory_limits/intro.md
@@ -1,0 +1,16 @@
+<!-- markdownlint-disable MD041 -->
+This example shows how to validate Kubernetes container memory requests and limits using `units.parse`.
+
+The policy ensures:
+1. Memory request is less than memory limit
+2. Memory limit doesn't exceed 8Gi
+
+**Note:** Kubernetes uses binary units (Mi, Gi) which are base-1024:
+- `"512Mi"` = 536870912 (512 × 1024²)
+- `"2Gi"` = 2147483648 (2 × 1024³)
+- `"8Gi"` = 8589934592 (8 × 1024³)
+
+This is useful for:
+- Preventing resource over-allocation
+- Enforcing organizational policies
+- Validating infrastructure-as-code

--- a/docs/docs/policy-reference/_examples/units/parse/memory_limits/policy.rego
+++ b/docs/docs/policy-reference/_examples/units/parse/memory_limits/policy.rego
@@ -1,0 +1,19 @@
+package play
+
+import rego.v1
+
+# Validate Kubernetes container memory request is reasonable
+allow if {
+	mem_request := input.container.resources.requests.memory
+	mem_limit := input.container.resources.limits.memory
+
+	# Parse memory strings to numeric values
+	request_value := units.parse(mem_request)
+	limit_value := units.parse(mem_limit)
+
+	# Ensure request is less than limit
+	request_value < limit_value
+
+	# Ensure limit is not excessive (less than 8Gi)
+	limit_value < units.parse("8Gi")
+}

--- a/docs/docs/policy-reference/_examples/units/parse/memory_limits/title.txt
+++ b/docs/docs/policy-reference/_examples/units/parse/memory_limits/title.txt
@@ -1,0 +1,1 @@
+Validating Kubernetes Memory Limits

--- a/docs/docs/policy-reference/_examples/units/parse_bytes/storage_quota/config.json
+++ b/docs/docs/policy-reference/_examples/units/parse_bytes/storage_quota/config.json
@@ -1,0 +1,4 @@
+{
+  "showInput": true,
+  "titleSize": 4
+}

--- a/docs/docs/policy-reference/_examples/units/parse_bytes/storage_quota/input.json
+++ b/docs/docs/policy-reference/_examples/units/parse_bytes/storage_quota/input.json
@@ -1,0 +1,4 @@
+{
+  "storage_request": "50GB",
+  "storage_used": "75GB"
+}

--- a/docs/docs/policy-reference/_examples/units/parse_bytes/storage_quota/intro.md
+++ b/docs/docs/policy-reference/_examples/units/parse_bytes/storage_quota/intro.md
@@ -1,0 +1,16 @@
+<!-- markdownlint-disable MD041 -->
+The `units.parse_bytes` function converts storage size strings into byte values as **integers**.
+
+Examples:
+- `"100KB"` = 100000 bytes
+- `"100KiB"` = 102400 bytes (binary)
+- `"50GB"` = 50000000000 bytes
+- `"2GiB"` = 2147483648 bytes (binary)
+
+This example demonstrates:
+1. Validating storage requests against quotas
+2. Calculating remaining storage
+
+Unlike `units.parse`, this function:
+- Returns **integers** (no floating point)
+- Specifically handles byte units (KB, MB, GB, etc.)

--- a/docs/docs/policy-reference/_examples/units/parse_bytes/storage_quota/policy.rego
+++ b/docs/docs/policy-reference/_examples/units/parse_bytes/storage_quota/policy.rego
@@ -1,0 +1,17 @@
+package play
+
+import rego.v1
+
+# Check if storage request is within quota
+within_quota if {
+	requested := units.parse_bytes(input.storage_request)
+	max_quota := units.parse_bytes("100GB")
+
+	requested <= max_quota
+}
+
+# Calculate remaining quota
+remaining_bytes := quota - used if {
+	quota := units.parse_bytes("100GB") # 100GB = 100000000000 bytes
+	used := units.parse_bytes(input.storage_used)
+}

--- a/docs/docs/policy-reference/_examples/units/parse_bytes/storage_quota/title.txt
+++ b/docs/docs/policy-reference/_examples/units/parse_bytes/storage_quota/title.txt
@@ -1,0 +1,1 @@
+Storage Quota Validation

--- a/docs/docs/policy-reference/builtins/units.mdx
+++ b/docs/docs/policy-reference/builtins/units.mdx
@@ -2,3 +2,19 @@
 title: Units
 ---
 <BuiltinTable category={"units"}/>
+
+## Examples
+
+### units.parse
+
+The `units.parse` function converts string representations of units into numeric values. It supports SI prefixes (K, M, G) and milli-units (m).
+
+<PlaygroundExample dir={require.context('../_examples/units/parse/basic')} />
+
+<PlaygroundExample dir={require.context('../_examples/units/parse/memory_limits')} />
+
+### units.parse_bytes
+
+The `units.parse_bytes` function converts byte size strings into integer byte values.
+
+<PlaygroundExample dir={require.context('../_examples/units/parse_bytes/storage_quota')} />


### PR DESCRIPTION
Adds three practical examples demonstrating the usage of units.parse and units.parse_bytes built-in functions:

1. Basic unit parsing showing SI prefixes (K, M, G) and milli-units
2. Kubernetes memory limit validation example
3. Storage quota validation using parse_bytes

Fixes #3786

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

* You have read the project's
  [guidelines on AI tool use](https://www.openpolicyagent.org/docs/contrib-code#ai-guidelines).

For more information on contributing to OPA see our
[Contributing Guide](https://www.openpolicyagent.org/docs/contributing/)
for high-level contributing guidelines and development setup.
(See the [Developer Certificate of Origin](https://www.openpolicyagent.org/docs/contrib-code/#developer-certificate-of-origin)
section for specifics on signing off a commit.)

-->

### Why the changes in this PR are needed?

The units built-in functions (units.parse and units.parse_bytes) currently have no examples in the documentation, making it difficult for users to understand how to use them. Issue #3786 requested adding practical examples to help users get started with these functions.

### What are the changes in this PR?

Added 3 new examples in `docs/docs/policy-reference/_examples/units/`:

 4. `parse/basic/` - Shows basic usage of decimal units (K, M, G), binary units (Ki, Mi, Gi), and milli-units (m)
 5. `parse/memory_limits/` - Real-world Kubernetes example validating container memory requests and limits
 6. `parse_bytes/storage_quota/` - Demonstrates storage quota validation using units.parse_bytes

Updated `docs/docs/policy-reference/builtins/units.mdx`:
• Added examples section
• Referenced all 3 examples using <PlaygroundExample> component

Each example includes:
• config.json - Playground configuration
• policy.rego - Rego code with comments
• intro.md - Explanation of the example
• title.txt - Example title
• input.json (where applicable) - Sample input data

Total changes:
• 15 files created (14 new + 1 updated)
• 152 lines added
• All numeric values verified against OPA's test suite in v1/test/cases/testdata/v1/units/

### Notes to assist PR review:

• Following maintainer guidance: This PR follows the structure suggested by @charlieegan3 in this comment (https://github.com/open-policy-agent/opa/issues/3786#issuecomment-2584738363)
• Values verified: All numeric values in examples are taken directly from OPA's test files (test-parse-units.yaml and test-parse-bytes.yaml) to ensure accuracy
• Binary vs Decimal units: Examples clearly distinguish between decimal (K=1000) and binary (Ki=1024) units, which is important for Kubernetes use cases
• No code changes: This PR only adds documentation/examples, no changes to OPA's functionality

### Further comments:

The examples demonstrate common use cases:
• Basic example: Decimal SI units (K, M, G), binary units (Ki, Mi, Gi), and milli-units
• Kubernetes example: Practical policy validation for container resource limits
• Storage example: Using units.parse_bytes for byte-based quota calculations

Development note: Initial examples were generated with AI assistance, then reviewed and verified against OPA's test suite (v1/test/cases/testdata/v1/units/) to ensure accuracy. Open to any feedback or improvements!