### PR TITLE
fix: nil *Profiler should not report Enabled()

### DIFF
--- a/v1/profiler/profiler.go
+++ b/v1/profiler/profiler.go
@@ -38,8 +38,8 @@ func New() *Profiler {
 }
 
 // Enabled returns true if profiler is enabled.
-func (*Profiler) Enabled() bool {
-	return true
+func (p *Profiler) Enabled() bool {
+	return p != nil
 }
 
 // Config returns the standard Tracer configuration for the profiler

--- a/v1/profiler/profiler_test.go
+++ b/v1/profiler/profiler_test.go
@@ -516,3 +516,17 @@ func TestProfilerTraceConfig(t *testing.T) {
 		t.Fatalf("Expected config: %+v, got %+v", expected, conf)
 	}
 }
+
+func TestProfilerEnabled(t *testing.T) {
+	t.Parallel()
+
+	var profiler *Profiler
+
+	if profiler.Enabled() {
+		t.Fatal("Expected non-initialized profiler to be disabled")
+	}
+
+	if profiler = New(); !profiler.Enabled() {
+		t.Fatal("Expected initialized profiler to be enabled")
+	}
+}


### PR DESCRIPTION
Not likely to be an issue for anyone but me, but since I stumbled upon and accidental nil dereference due to this, I might as well fix it. An uninitialized/nil *Profiler now returns `false` when asked if it's `Enabled()`, which seems more intuitive to me.