### PR TITLE
docs: Add header for crypto example to make

### DIFF
--- a/docs/docs/policy-reference/builtins/crypto.mdx
+++ b/docs/docs/policy-reference/builtins/crypto.mdx
@@ -6,4 +6,6 @@ title: Cryptography
 
 ## Examples
 
+### `crypto.md5`
+
 <PlaygroundExample dir={require.context("../_examples/crypto/digest_verification")} />


### PR DESCRIPTION
This makes it consistent with how other examples are presented.

Now
<img width="219" height="140" alt="Screenshot 2026-01-28 at 16 00 06" src="https://github.com/user-attachments/assets/ccc16326-4e60-4f17-a125-5740b6cfac3f" />

Other builtins
<img width="279" height="135" alt="Screenshot 2026-01-28 at 15 58 43" src="https://github.com/user-attachments/assets/8951343a-ba0b-49ff-8eb8-2e5a851a2cf7" />

Before (note missing header for example function)
<img width="259" height="162" alt="Screenshot 2026-01-28 at 15 58 39" src="https://github.com/user-attachments/assets/e4fc1d76-8d8f-4674-a609-077ec8b22243" />
