### PR TITLE
Support arrays as input for json.match_schema

### DIFF
--- a/v1/topdown/jsonschema.go
+++ b/v1/topdown/jsonschema.go
@@ -27,7 +27,7 @@ func astValueToJSONSchemaLoader(value ast.Value) (gojsonschema.JSONLoader, error
 			return nil, errors.New("invalid JSON string")
 		}
 		loader = gojsonschema.NewStringLoader(string(x))
-	case ast.Object:
+	case ast.Object, *ast.Array:
 		// In case of object serialize it to JSON representation.
 		var data any
 		data, err = ast.JSON(value)

--- a/v1/topdown/jsonschema_test.go
+++ b/v1/topdown/jsonschema_test.go
@@ -69,6 +69,14 @@ func TestAstValueToJSONSchemaLoader(t *testing.T) {
 			),
 			valid: true,
 		},
+		{
+			note: "array simple input",
+			schema: ast.NewArray(
+				ast.StringTerm("foo"),
+				ast.StringTerm("bar"),
+			),
+			valid: true,
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
resolve: https://github.com/open-policy-agent/opa/issues/6615

Running the provided examples with the `--show-builtin-errors` flag I got the error: `1 error occurred: array_input/array_input.rego:10: eval_builtin_error: json.match_schema: wrong type, expected string or object`

Seems like a simple fix to process arrays the same way as objects, testing with this change led to the expected output:

```
❯ ./opa_darwin_arm64 eval -b . -f pretty data.array_input.policy --input array_input/input/valid/data.json
{
  "errors": [],
  "matches": true
}
❯ ./opa_darwin_arm64 eval -b . -f pretty data.array_input.policy --input array_input/input/invalid_type/data.json
{
  "errors": [
    {
      "desc": "foo is required",
      "error": "0: foo is required",
      "field": "0",
      "type": "required"
    }
  ],
  "matches": false
}
```