### PR TITLE
docs: fix json.patch target description

### DIFF
--- a/builtin_metadata.json
+++ b/builtin_metadata.json
@@ -13818,8 +13818,8 @@
   "json.patch": {
     "args": [
       {
-        "description": "the object to patch",
-        "name": "object",
+        "description": "the object, array or set to patch",
+        "name": "target",
         "type": "any"
       },
       {

--- a/v1/ast/builtins.go
+++ b/v1/ast/builtins.go
@@ -1675,7 +1675,7 @@ var JSONPatch = &Builtin{
 		"Additionally works on sets, where a value contained in the set is considered to be its path.",
 	Decl: types.NewFunction(
 		types.Args(
-			types.Named("object", types.A).Description("the object to patch"), // TODO(sr): types.A?
+			types.Named("target", types.A).Description("the object, array or set to patch"),
 			types.Named("patches", types.NewArray(
 				nil,
 				types.NewObject(


### PR DESCRIPTION
This built-in can patch any composite type, which the documentation for the first argument didn't mention.