### PR TITLE
run: support `--h2c` with unix domain socket (UDS)

### DIFF
--- a/v1/server/server.go
+++ b/v1/server/server.go
@@ -726,6 +726,10 @@ func (s *Server) getListenerForUNIXSocket(u *url.URL, h http.Handler, t httpList
 		os.Remove(socketPath)
 	}
 
+	if s.h2cEnabled {
+		h2s := &http2.Server{}
+		h = h2c.NewHandler(h, h2s)
+	}
 	domainSocketServer := http.Server{Handler: h}
 	unixListener, err := net.Listen("unix", socketPath)
 	if err != nil {


### PR DESCRIPTION
When `--h2c` is passed, HTTP2 will also be used on the unix domain socket. Previously, it had no effect on UDS, only on TCP connections.

Fixes #8282.
