### PR TITLE
ast: fix double-fix for refs["with-a"].dash as package

### DIFF
--- a/v1/ast/policy_appenders.go
+++ b/v1/ast/policy_appenders.go
@@ -68,15 +68,6 @@ func (pkg *Package) AppendText(buf []byte) ([]byte, error) {
 
 	path := pkg.Path[1:] // omit "data"
 
-	if s, ok := path[0].Value.(String); ok {
-		buf = append(buf, s...) // first term should never be quoted
-		if len(path) == 1 {
-			return buf, nil
-		}
-		buf = append(buf, '.')
-		path = path[1:]
-	}
-
 	return path.AppendText(buf)
 }
 

--- a/v1/ast/policy_appenders_test.go
+++ b/v1/ast/policy_appenders_test.go
@@ -52,6 +52,18 @@ r = true`,
 		want: `package example.foo`,
 	},
 	{
+		name: "package with special chars",
+		node: &ast.Package{
+			Path: ast.Ref{
+				ast.DefaultRootDocument,
+				ast.StringTerm("pkg"),
+				ast.StringTerm("with-a"),
+				ast.StringTerm("dash"),
+			},
+		},
+		want: `package pkg["with-a"].dash`,
+	},
+	{
 		name: "import",
 		node: &ast.Import{
 			Path:  ast.NewTerm(ast.MustParseRef("data.example.foo")),


### PR DESCRIPTION
I think (Package).AppendText accounts for the first (non-data) ref part not needing any escaping, and (Ref).AppendText did, too. Removing the special handling from the former resolves the test case that's added.

Fixes the [E2E OCP failures here](https://github.com/open-policy-agent/opa-control-plane/actions/runs/21597868242/job/62235269881#step:10:1599) 