### PR TITLE
perf: `json.patch` + interning improvements

### DIFF
--- a/internal/edittree/bitvector/bitvector.go
+++ b/internal/edittree/bitvector/bitvector.go
@@ -2,10 +2,12 @@
 // which supports lookups, sets, appends, insertions, and deletions.
 package bitvector
 
+import "slices"
+
 // A BitVector is a variable sized vector of bits. It supports
 // lookups, sets, appends, insertions, and deletions.
 //
-// This class is not thread safe.
+// Operations are not thread safe.
 type BitVector struct {
 	data   []byte
 	length int
@@ -14,10 +16,25 @@ type BitVector struct {
 // NewBitVector creates and initializes a new bit vector with length
 // elements, using data as its initial contents.
 func NewBitVector(data []byte, length int) *BitVector {
-	return &BitVector{
-		data:   data,
-		length: length,
+	return &BitVector{data: data, length: length}
+}
+
+func (vector *BitVector) Clear() *BitVector {
+	if vector == nil {
+		return nil
 	}
+	clear(vector.data)
+	vector.length = 0
+
+	return vector
+}
+
+func (vector *BitVector) Reset(size, length int) *BitVector {
+	clear(vector.data)
+	vector.data = slices.Grow(vector.data, size)[:size]
+	vector.length = length
+
+	return vector
 }
 
 // Bytes returns a slice of the contents of the bit vector. If the caller changes the returned slice,

--- a/internal/edittree/edittree_test.go
+++ b/internal/edittree/edittree_test.go
@@ -765,7 +765,10 @@ func TestEditTreeApplyPatches(t *testing.T) {
 				patches = patches.Append(ast.MustParseTerm(tc.patches[i]))
 			}
 
-			et := NewEditTree(ast.MustParseTerm(tc.source))
+			et := EditTreeFromPool(ast.MustParseTerm(tc.source))
+			t.Cleanup(func() {
+				Dispose(et)
+			})
 			err := patches.Iter(func(term *ast.Term) error {
 				object, ok := term.Value.(ast.Object)
 				if !ok {

--- a/topdown/graphql.go
+++ b/topdown/graphql.go
@@ -20,6 +20,8 @@ import (
 	"github.com/open-policy-agent/opa/v1/topdown/builtins"
 )
 
+var unverified = ast.ArrayTerm(ast.InternedTerm(false), ast.InternedEmptyObject, ast.InternedEmptyObject)
+
 // Parses a GraphQL schema, and returns the GraphQL AST for the schema.
 func parseSchema(schema string) (*gqlast.SchemaDocument, error) {
 	// NOTE(philipc): We don't include the "built-in schema defs" from the
@@ -293,12 +295,6 @@ func builtinGraphQLParseAndVerify(_ BuiltinContext, operands []*ast.Term, iter f
 	var queryDoc *gqlast.QueryDocument
 	var schemaDoc *gqlast.SchemaDocument
 	var err error
-
-	unverified := ast.ArrayTerm(
-		ast.InternedTerm(false),
-		ast.NewTerm(ast.NewObject()),
-		ast.NewTerm(ast.NewObject()),
-	)
 
 	// Parse/translate query if it's a string/object.
 	switch x := operands[0].Value.(type) {

--- a/v1/ast/compile.go
+++ b/v1/ast/compile.go
@@ -2478,7 +2478,7 @@ func rewriteTemplateString(tsr *templateStringRewriter, safe VarSet, loc *Locati
 	terms := make([]*Term, 0, len(ts.Parts))
 
 	if len(ts.Parts) == 0 {
-		terms = append(terms, NewTerm(InternedEmptyString.Value).SetLocation(loc))
+		terms = append(terms, NewTerm(InternedEmptyStringValue).SetLocation(loc))
 	} else {
 		vis := ClearOrNewVarVisitor(nil).WithParams(SafetyCheckVisitorParams)
 		for _, p := range ts.Parts {

--- a/v1/ast/interning.go
+++ b/v1/ast/interning.go
@@ -5,6 +5,7 @@
 package ast
 
 import (
+	"iter"
 	"strconv"
 )
 
@@ -19,23 +20,26 @@ type internable interface {
 
 var (
 	InternedNullValue Value = Null{}
-	InternedNullTerm        = &Term{Value: InternedNullValue}
+	InternedNullTerm        = NewTerm(InternedNullValue)
 
 	InternedBooleanTrueValue  Value = Boolean(true)
 	InternedBooleanFalseValue Value = Boolean(false)
-	InternedBooleanTrueTerm         = &Term{Value: InternedBooleanTrueValue}
-	InternedBooleanFalseTerm        = &Term{Value: InternedBooleanFalseValue}
+	InternedEmptyStringValue  Value = String("")
+	InternedEmptyArrayValue   Value = NewArray()
+	InternedEmptyRefValue     Value = Ref{}
+	InternedEmptyObjectValue  Value = NewObject()
+	InternedEmptySetValue     Value = NewSet()
 
-	InternedEmptyString = StringTerm("")
-	InternedEmptyObject = ObjectTerm()
-	InternedEmptyArray  = NewTerm(InternedEmptyArrayValue)
-	InternedEmptySet    = SetTerm()
-
-	InternedEmptyArrayValue = NewArray()
+	InternedBooleanTrue  = NewTerm(InternedBooleanTrueValue)
+	InternedBooleanFalse = NewTerm(InternedBooleanFalseValue)
+	InternedEmptyString  = NewTerm(InternedEmptyStringValue)
+	InternedEmptyObject  = NewTerm(InternedEmptyObjectValue)
+	InternedEmptyArray   = NewTerm(InternedEmptyArrayValue)
+	InternedEmptySet     = NewTerm(InternedEmptySetValue)
 
 	// since this is by far the most common negative number
 	minusOneValue Value = Number("-1")
-	minusOneTerm        = &Term{Value: minusOneValue}
+	minusOneTerm        = NewTerm(minusOneValue)
 
 	internedStringTerms = map[string]*Term{
 		"": InternedEmptyString,
@@ -68,7 +72,7 @@ func InternStringTerm(str ...string) {
 			continue
 		}
 
-		internedStringTerms[s] = StringTerm(s)
+		internedStringTerms[s] = &Term{Value: String(s)}
 	}
 }
 
@@ -215,6 +219,19 @@ func InternedIntNumberTermFromString(s string) *Term {
 	return nil
 }
 
+// InternedIntRange returns a sequence of interned integer number terms
+// from start (inclusive) to end (exclusive). For values outside of the
+// interned range, non-interned IntNumberTerms are returned.
+func InternedIntRange(start, end int) iter.Seq[*Term] {
+	return func(yield func(*Term) bool) {
+		for i := start; i < end; i++ {
+			if !yield(internedIntNumberTerm(i)) {
+				return
+			}
+		}
+	}
+}
+
 // HasInternedIntNumberTerm returns true if the given integer value maps to an interned
 // term, otherwise false.
 func HasInternedIntNumberTerm(i int) bool {
@@ -253,10 +270,10 @@ func internedBooleanValue(b bool) Value {
 // InternedBooleanTerm returns an interned term with the given boolean value.
 func internedBooleanTerm(b bool) *Term {
 	if b {
-		return InternedBooleanTrueTerm
+		return InternedBooleanTrue
 	}
 
-	return InternedBooleanFalseTerm
+	return InternedBooleanFalse
 }
 
 func internedIntNumberValue(i int) Value {
@@ -323,7 +340,7 @@ func init() {
 		// Various
 		"data", "input", "result", "keywords", "path", "v1", "error", "partial",
 		// HTTP
-		"code", "message", "status_code", "method", "url", "uri",
+		"code", "message", "status_code", "method", "url", "uri", "body", "raw_body", "headers", "query_params",
 		// JWT
 		"enc", "cty", "iss", "exp", "nbf", "aud", "secret", "cert",
 		// Decisions

--- a/v1/ast/oracle/target_test.go
+++ b/v1/ast/oracle/target_test.go
@@ -77,10 +77,8 @@ func TestFindTarget(t *testing.T) {
 			wantNil: true,
 		},
 		{
-			name: "term with non-var non-ref value",
-			stack: []ast.Node{
-				ast.IntNumberTerm(42),
-			},
+			name:    "term with non-var non-ref value",
+			stack:   []ast.Node{ast.InternedTerm(42)},
 			wantNil: true,
 		},
 	}

--- a/v1/ast/parser.go
+++ b/v1/ast/parser.go
@@ -1893,7 +1893,7 @@ func (p *Parser) parseNumber() *Term {
 func (p *Parser) parseString() *Term {
 	if p.s.lit[0] == '"' {
 		if p.s.lit == "\"\"" {
-			return NewTerm(InternedEmptyString.Value).SetLocation(p.s.Loc())
+			return NewTerm(InternedEmptyStringValue).SetLocation(p.s.Loc())
 		}
 
 		inner := p.s.lit[1 : len(p.s.lit)-1]

--- a/v1/server/server.go
+++ b/v1/server/server.go
@@ -2792,7 +2792,7 @@ func stringPathToRef(s string) (ast.Ref, error) {
 		if err != nil {
 			r = append(r, ast.StringTerm(x))
 		} else {
-			r = append(r, ast.IntNumberTerm(i))
+			r = append(r, ast.InternedTerm(i))
 		}
 	}
 	return r, nil

--- a/v1/topdown/array.go
+++ b/v1/topdown/array.go
@@ -95,12 +95,14 @@ func builtinArraySlice(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Te
 		return err
 	}
 
+	l := arr.Len()
+
 	// Clamp stopIndex to avoid out-of-range errors. If negative, clamp to zero.
 	// Otherwise, clamp to length of array.
 	if stopIndex < 0 {
 		stopIndex = 0
-	} else if stopIndex > arr.Len() {
-		stopIndex = arr.Len()
+	} else if stopIndex > l {
+		stopIndex = l
 	}
 
 	// Clamp startIndex to avoid out-of-range errors. If negative, clamp to zero.
@@ -111,7 +113,7 @@ func builtinArraySlice(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Te
 		startIndex = stopIndex
 	}
 
-	if startIndex == 0 && stopIndex >= arr.Len() {
+	if startIndex == 0 && stopIndex >= l {
 		return iter(operands[0])
 	}
 

--- a/v1/topdown/json_bench_test.go
+++ b/v1/topdown/json_bench_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -23,15 +24,12 @@ func BenchmarkJSONRemoveArray(b *testing.B) {
 	for _, n := range sizes {
 		b.Run(fmt.Sprintf("size=%d", n), func(b *testing.B) {
 			// Create an object wrapping the array: {"a": [0, 1, ...]}
-			terms := make([]*ast.Term, n)
-			for i := range n {
-				terms[i] = ast.IntNumberTerm(i)
-			}
+			terms := slices.Collect(ast.InternedIntRange(0, n))
 			arr := ast.NewArray(terms...)
-			obj := ast.NewObject([2]*ast.Term{ast.StringTerm("a"), ast.NewTerm(arr)})
+			obj := ast.NewObject([2]*ast.Term{ast.InternedTerm("a"), ast.NewTerm(arr)})
 
 			// Remove something inside the array to force traversal
-			paths := ast.NewSet(ast.StringTerm("a/nonexistent"))
+			paths := ast.NewSet(ast.InternedTerm("a/nonexistent"))
 
 			operands := []*ast.Term{
 				ast.NewTerm(obj),
@@ -61,11 +59,11 @@ func BenchmarkJSONFilterArray(b *testing.B) {
 	for _, n := range sizes {
 		b.Run(fmt.Sprintf("size=%d", n), func(b *testing.B) {
 			// Create an object with n keys
-			obj := ast.NewObject()
+			obj := ast.NewObjectWithCapacity(n)
 			pathSlice := make([]*ast.Term, n)
 			for i := range n {
 				k := ast.StringTerm(fmt.Sprintf("k%d", i))
-				obj.Insert(k, ast.IntNumberTerm(i))
+				obj.Insert(k, ast.InternedTerm(i))
 				pathSlice[i] = k
 			}
 			// Filter all keys: json.filter(obj, ["k0", "k1", ...])
@@ -100,10 +98,7 @@ func BenchmarkJSONFilterArrayIndices(b *testing.B) {
 	for _, n := range sizes {
 		b.Run(fmt.Sprintf("size=%d", n), func(b *testing.B) {
 			// Create an object wrapping an array: {"a": [0, 1, ...]}
-			terms := make([]*ast.Term, n)
-			for i := range n {
-				terms[i] = ast.IntNumberTerm(i)
-			}
+			terms := slices.Collect(ast.InternedIntRange(0, n))
 			arr := ast.NewArray(terms...)
 			obj := ast.NewObject([2]*ast.Term{ast.StringTerm("a"), ast.NewTerm(arr)})
 
@@ -142,73 +137,43 @@ func BenchmarkJSONFilterArrayIndices(b *testing.B) {
 }
 
 func BenchmarkJSONPatchAddShallowScalar(b *testing.B) {
-	ctx := b.Context()
-
 	sizes := []int{10, 100, 1000, 10000}
 
-	// Object case
-	for _, n := range sizes {
-		source := genTestObject(n)
-		for _, m := range sizes {
-			testName := fmt.Sprintf("object-%d-%d", n, m)
-			// Build dataset right before use:
-			plArrayObj := make([]*ast.Term, 0, m*2)
-			// add ops
-			for i := range m {
-				plArrayObj = append(plArrayObj, genTestJSONPatchObject("add", ast.StringTerm("/"+strconv.FormatInt(int64(i+n), 10)), nil, ast.IntNumberTerm(i+n)))
-			}
-			patchList := ast.NewArray(plArrayObj...)
+	m := slices.Max(sizes)
+	objArrPatches, setPatches := make([]*ast.Term, 0, m), make([]*ast.Term, 0, m)
 
-			b.ResetTimer()
-			b.Run(testName, func(b *testing.B) {
-				runJSONPatchBenchmarkTest(ctx, b, source, patchList)
-			})
-		}
+	for i := range m {
+		path := ast.StringTerm(fmt.Sprintf("/%d", i))
+		value := ast.InternedTerm(i)
+
+		objArrPatches = append(objArrPatches, createPatch("add", path, nil, value))
+		setPatches = append(setPatches, createPatch("add", ast.ArrayTerm(value), nil, value))
 	}
 
-	// Array case
 	for _, n := range sizes {
-		source := genTestArray(n)
-		for _, m := range sizes {
-			testName := fmt.Sprintf("array-%d-%d", n, m)
-			// Build dataset right before use:
-			plArrayObj := make([]*ast.Term, 0, m*2)
-			// add ops
-			for i := range m {
-				plArrayObj = append(plArrayObj, genTestJSONPatchObject("add", ast.StringTerm("/"+strconv.FormatInt(int64(i+n), 10)), nil, ast.IntNumberTerm(i+n)))
-			}
-			patchList := ast.NewArray(plArrayObj...)
-
-			b.ResetTimer()
-			b.Run(testName, func(b *testing.B) {
-				runJSONPatchBenchmarkTest(ctx, b, source, patchList)
-			})
-		}
+		b.Run(fmt.Sprintf("object-%d", n), func(b *testing.B) {
+			runJSONPatchBenchmarkTest(b, genTestObject(n), ast.NewArray(objArrPatches[:n]...))
+		})
 	}
-	// Set case
-	for _, n := range sizes {
-		source := genTestSet(n)
-		for _, m := range sizes {
-			testName := fmt.Sprintf("set-%d-%d", n, m)
-			// Build dataset right before use:
-			plSet := make([]*ast.Term, 0, m*2)
-			// add ops
-			for i := range m {
-				plSet = append(plSet, genTestJSONPatchObject("add", ast.ArrayTerm(ast.IntNumberTerm(i+n)), nil, ast.IntNumberTerm(i+n)))
-			}
-			patchList := ast.NewArray(plSet...)
 
-			b.ResetTimer()
-			b.Run(testName, func(b *testing.B) {
-				runJSONPatchBenchmarkTest(ctx, b, source, patchList)
-			})
-		}
+	for _, n := range sizes {
+		b.Run(fmt.Sprintf("array-%d", n), func(b *testing.B) {
+			runJSONPatchBenchmarkTest(b,
+				ast.NewArray(slices.Collect(ast.InternedIntRange(0, n))...),
+				ast.NewArray(objArrPatches[:n]...))
+		})
+	}
+
+	for _, n := range sizes {
+		b.Run(fmt.Sprintf("set-%d", n), func(b *testing.B) {
+			runJSONPatchBenchmarkTest(b,
+				ast.NewSet(slices.Collect(ast.InternedIntRange(0, n))...),
+				ast.NewArray(setPatches[:n]...))
+		})
 	}
 }
 
 func BenchmarkJSONPatchAddShallowComposite(b *testing.B) {
-	ctx := b.Context()
-
 	sizes := []int{10, 100, 1000, 10000}
 
 	// Object case
@@ -220,60 +185,58 @@ func BenchmarkJSONPatchAddShallowComposite(b *testing.B) {
 			plArrayObj := make([]*ast.Term, 0, m*2)
 			// add ops
 			for i := range m {
-				plArrayObj = append(plArrayObj, genTestJSONPatchObject("add", ast.StringTerm("/"+strconv.FormatInt(int64(i+n), 10)), nil, ast.ArrayTerm(ast.IntNumberTerm(i+n))))
+				plArrayObj = append(plArrayObj, createPatch("add", ast.StringTerm("/"+strconv.FormatInt(int64(i+n), 10)), nil, ast.ArrayTerm(ast.IntNumberTerm(i+n))))
 			}
 			patchList := ast.NewArray(plArrayObj...)
 
 			b.ResetTimer()
 			b.Run(testName, func(b *testing.B) {
-				runJSONPatchBenchmarkTest(ctx, b, source, patchList)
+				runJSONPatchBenchmarkTest(b, source, patchList)
 			})
 		}
 	}
 
 	// Array case
 	for _, n := range sizes {
-		source := genTestArray(n)
+		source := ast.NewArray(slices.Collect(ast.InternedIntRange(0, n))...)
 		for _, m := range sizes {
 			testName := fmt.Sprintf("array-%d-%d", n, m)
 			// Build dataset right before use:
 			plArrayObj := make([]*ast.Term, 0, m*2)
 			// add ops
 			for i := range m {
-				plArrayObj = append(plArrayObj, genTestJSONPatchObject("add", ast.StringTerm("/"+strconv.FormatInt(int64(i+n), 10)), nil, ast.ArrayTerm(ast.IntNumberTerm(i+n))))
+				plArrayObj = append(plArrayObj, createPatch("add", ast.StringTerm("/"+strconv.FormatInt(int64(i+n), 10)), nil, ast.ArrayTerm(ast.IntNumberTerm(i+n))))
 			}
 			patchList := ast.NewArray(plArrayObj...)
 
 			b.ResetTimer()
 			b.Run(testName, func(b *testing.B) {
-				runJSONPatchBenchmarkTest(ctx, b, source, patchList)
+				runJSONPatchBenchmarkTest(b, source, patchList)
 			})
 		}
 	}
 	// Set case
 	for _, n := range sizes {
-		source := genTestSet(n)
+		source := ast.NewSet(slices.Collect(ast.InternedIntRange(0, n))...)
 		for _, m := range sizes {
 			testName := fmt.Sprintf("set-%d-%d", n, m)
 			// Build dataset right before use:
 			plSet := make([]*ast.Term, 0, m*2)
 			// add ops
 			for i := range m {
-				plSet = append(plSet, genTestJSONPatchObject("add", ast.ArrayTerm(ast.ArrayTerm(ast.IntNumberTerm(i+n))), nil, ast.ArrayTerm(ast.IntNumberTerm(i+n))))
+				plSet = append(plSet, createPatch("add", ast.ArrayTerm(ast.ArrayTerm(ast.IntNumberTerm(i+n))), nil, ast.ArrayTerm(ast.IntNumberTerm(i+n))))
 			}
 			patchList := ast.NewArray(plSet...)
 
 			b.ResetTimer()
 			b.Run(testName, func(b *testing.B) {
-				runJSONPatchBenchmarkTest(ctx, b, source, patchList)
+				runJSONPatchBenchmarkTest(b, source, patchList)
 			})
 		}
 	}
 }
 
 func BenchmarkJSONPatchAddRemove(b *testing.B) {
-	ctx := b.Context()
-
 	sizes := []int{10, 100, 1000, 10000}
 
 	// Object case
@@ -285,104 +248,88 @@ func BenchmarkJSONPatchAddRemove(b *testing.B) {
 			plArrayObj := make([]*ast.Term, 0, m*2)
 			// add ops
 			for i := range m {
-				plArrayObj = append(plArrayObj, genTestJSONPatchObject("add", ast.StringTerm("/"+strconv.FormatInt(int64(i+n), 10)), nil, ast.IntNumberTerm(i+n)))
+				plArrayObj = append(plArrayObj, createPatch("add", ast.StringTerm("/"+strconv.FormatInt(int64(i+n), 10)), nil, ast.IntNumberTerm(i+n)))
 			}
 			// remove ops
 			for i := m - 1; i >= 0; i-- {
-				plArrayObj = append(plArrayObj, genTestJSONPatchObject("remove", ast.StringTerm("/"+strconv.FormatInt(int64(i+n), 10)), nil, nil))
+				plArrayObj = append(plArrayObj, createPatch("remove", ast.StringTerm("/"+strconv.FormatInt(int64(i+n), 10)), nil, nil))
 			}
 			patchList := ast.NewArray(plArrayObj...)
 
 			b.ResetTimer()
 			b.Run(testName, func(b *testing.B) {
-				runJSONPatchBenchmarkTest(ctx, b, source, patchList)
+				runJSONPatchBenchmarkTest(b, source, patchList)
 			})
 		}
 	}
 
 	// Array case
 	for _, n := range sizes {
-		source := genTestArray(n)
+		source := ast.NewArray(slices.Collect(ast.InternedIntRange(0, n))...)
 		for _, m := range sizes {
 			testName := fmt.Sprintf("array-%d-%d", n, m)
 			// Build dataset right before use:
 			plArrayObj := make([]*ast.Term, 0, m*2)
 			// add ops
 			for i := range m {
-				plArrayObj = append(plArrayObj, genTestJSONPatchObject("add", ast.StringTerm("/"+strconv.FormatInt(int64(i+n), 10)), nil, ast.IntNumberTerm(i+n)))
+				plArrayObj = append(plArrayObj, createPatch("add", ast.StringTerm("/"+strconv.FormatInt(int64(i+n), 10)), nil, ast.IntNumberTerm(i+n)))
 			}
 			// remove ops
 			for i := m - 1; i >= 0; i-- {
-				plArrayObj = append(plArrayObj, genTestJSONPatchObject("remove", ast.StringTerm("/"+strconv.FormatInt(int64(i+n), 10)), nil, nil))
+				plArrayObj = append(plArrayObj, createPatch("remove", ast.StringTerm("/"+strconv.FormatInt(int64(i+n), 10)), nil, nil))
 			}
 			patchList := ast.NewArray(plArrayObj...)
 
 			b.ResetTimer()
 			b.Run(testName, func(b *testing.B) {
-				runJSONPatchBenchmarkTest(ctx, b, source, patchList)
+				runJSONPatchBenchmarkTest(b, source, patchList)
 			})
 		}
 	}
 
 	// Set case
 	for _, n := range sizes {
-		source := genTestSet(n)
+		source := ast.NewSet(slices.Collect(ast.InternedIntRange(0, n))...)
 		for _, m := range sizes {
 			testName := fmt.Sprintf("set-%d-%d", n, m)
 			// Build dataset right before use:
 			plSet := make([]*ast.Term, 0, m*2)
 			// add ops
 			for i := range m {
-				plSet = append(plSet, genTestJSONPatchObject("add", ast.ArrayTerm(ast.IntNumberTerm(i+n)), nil, ast.IntNumberTerm(i+n)))
+				plSet = append(plSet, createPatch("add", ast.ArrayTerm(ast.IntNumberTerm(i+n)), nil, ast.IntNumberTerm(i+n)))
 			}
 			// remove ops
 			for i := m - 1; i >= 0; i-- {
-				plSet = append(plSet, genTestJSONPatchObject("remove", ast.ArrayTerm(ast.IntNumberTerm(i+n)), nil, nil))
+				plSet = append(plSet, createPatch("remove", ast.ArrayTerm(ast.IntNumberTerm(i+n)), nil, nil))
 			}
 			patchList := ast.NewArray(plSet...)
 
 			b.ResetTimer()
 			b.Run(testName, func(b *testing.B) {
-				runJSONPatchBenchmarkTest(ctx, b, source, patchList)
+				runJSONPatchBenchmarkTest(b, source, patchList)
 			})
 		}
 	}
 }
 
-func genTestJSONPatchObject(op string, path, from, value *ast.Term) *ast.Term {
+func createPatch(op string, path, from, value *ast.Term) *ast.Term {
 	patchObj := ast.NewObject(
-		[2]*ast.Term{ast.StringTerm("op"), ast.StringTerm(op)},
-		[2]*ast.Term{ast.StringTerm("path"), path},
+		[2]*ast.Term{ast.InternedTerm("op"), ast.InternedTerm(op)},
+		[2]*ast.Term{ast.InternedTerm("path"), path},
 	)
 	if from != nil {
-		patchObj.Insert(ast.StringTerm("from"), from)
+		patchObj.Insert(ast.InternedTerm("from"), from)
 	}
 	if value != nil {
-		patchObj.Insert(ast.StringTerm("value"), value)
+		patchObj.Insert(ast.InternedTerm("value"), value)
 	}
 	return ast.NewTerm(patchObj)
 }
 
 func genTestObject(width int) ast.Value {
-	out := ast.NewObject()
+	out := ast.NewObjectWithCapacity(width)
 	for i := range width {
-		out.Insert(ast.IntNumberTerm(i), ast.IntNumberTerm(i))
-	}
-	return out
-}
-
-func genTestArray(width int) ast.Value {
-	out := ast.NewArray()
-	for i := range width {
-		out = out.Append(ast.IntNumberTerm(i))
-	}
-	return out
-}
-
-func genTestSet(width int) ast.Value {
-	out := ast.NewSet()
-	for i := range width {
-		out.Add(ast.IntNumberTerm(i))
+		out.Insert(ast.InternedTerm(i), ast.InternedTerm(i))
 	}
 	return out
 }
@@ -396,11 +343,11 @@ func gen3LayerObject(l1Keys, l2Keys, l3Keys int) ast.Value {
 		for j := range l2Keys {
 			l3Obj := ast.NewObject()
 			for k := range l3Keys {
-				l3Obj.Insert(ast.StringTerm(strconv.Itoa(k)), ast.InternedTerm(true))
+				l3Obj.Insert(ast.InternedTerm(strconv.Itoa(k)), ast.InternedTerm(true))
 			}
-			l2Obj.Insert(ast.StringTerm(strconv.Itoa(j)), ast.NewTerm(l3Obj))
+			l2Obj.Insert(ast.InternedTerm(strconv.Itoa(j)), ast.NewTerm(l3Obj))
 		}
-		obj.Insert(ast.StringTerm(strconv.Itoa(i)), ast.NewTerm(l2Obj))
+		obj.Insert(ast.InternedTerm(strconv.Itoa(i)), ast.NewTerm(l2Obj))
 	}
 	return obj
 }
@@ -412,8 +359,8 @@ func genRandom3LayerObjectJSONPatchListData(l1Keys, l2Keys, l3Keys, p int) ast.V
 	numKeys := []int{l1Keys, l2Keys, l3Keys}
 	for i := range p {
 		patchObj := ast.NewObject(
-			[2]*ast.Term{ast.StringTerm("op"), ast.StringTerm("replace")},
-			[2]*ast.Term{ast.StringTerm("value"), ast.IntNumberTerm(2)},
+			[2]*ast.Term{ast.InternedTerm("op"), ast.InternedTerm("replace")},
+			[2]*ast.Term{ast.InternedTerm("value"), ast.InternedTerm(2)},
 		)
 		// Random path depth.
 		depth := rand.Intn(3) + 1 // (max - min) + min method of getting a random range.
@@ -425,7 +372,7 @@ func genRandom3LayerObjectJSONPatchListData(l1Keys, l2Keys, l3Keys, p int) ast.V
 			segments = append(segments, "/", pathSegment)
 		}
 		path := strings.Join(segments, "")
-		patchObj.Insert(ast.StringTerm("path"), ast.StringTerm(path))
+		patchObj.Insert(ast.InternedTerm("path"), ast.InternedTerm(path))
 		patchList[i] = ast.NewTerm(patchObj)
 	}
 	return ast.NewArray(patchList...)
@@ -496,8 +443,6 @@ func BenchmarkJSONPatchReplace(b *testing.B) {
 }
 
 func BenchmarkJSONPatchPathologicalNestedAddChainObject(b *testing.B) {
-	ctx := b.Context()
-
 	sizes := []int{10, 100, 500, 1000, 5000, 10000}
 	// Pre-generate the test datasets/patches.
 	testdata := map[string]ast.Value{}
@@ -521,14 +466,12 @@ func BenchmarkJSONPatchPathologicalNestedAddChainObject(b *testing.B) {
 	for _, n := range sizes {
 		testName := strconv.Itoa(n)
 		b.Run(testName, func(b *testing.B) {
-			runJSONPatchBenchmarkTest(ctx, b, ast.NewObject(), testdata[testName])
+			runJSONPatchBenchmarkTest(b, ast.NewObject(), testdata[testName])
 		})
 	}
 }
 
 func BenchmarkJSONPatchPathologicalNestedAddChainArray(b *testing.B) {
-	ctx := b.Context()
-
 	sizes := []int{10, 100, 500, 1000, 5000, 10000}
 	// Pre-generate the test datasets/patches.
 	testdata := map[string]ast.Value{}
@@ -552,7 +495,7 @@ func BenchmarkJSONPatchPathologicalNestedAddChainArray(b *testing.B) {
 	for _, n := range sizes {
 		testName := strconv.Itoa(n)
 		b.Run(testName, func(b *testing.B) {
-			runJSONPatchBenchmarkTest(ctx, b, ast.NewArray(), testdata[testName])
+			runJSONPatchBenchmarkTest(b, ast.NewArray(), testdata[testName])
 		})
 	}
 }
@@ -560,7 +503,6 @@ func BenchmarkJSONPatchPathologicalNestedAddChainArray(b *testing.B) {
 // This one is tricky, because sets used content-based addressing.
 // That means our sets for the path have to be recursively constructed!
 func BenchmarkJSONPatchPathologicalNestedAddChainSet(b *testing.B) {
-	ctx := b.Context()
 	sizes := []int{10, 100, 500, 1000}
 
 	// Pre-generate the test datasets/patches.
@@ -595,40 +537,31 @@ func BenchmarkJSONPatchPathologicalNestedAddChainSet(b *testing.B) {
 	for _, n := range sizes {
 		testName := strconv.Itoa(n)
 		b.Run(testName, func(b *testing.B) {
-			runJSONPatchBenchmarkTest(ctx, b, ast.NewSet(ast.StringTerm("a")), testdata[testName])
+			runJSONPatchBenchmarkTest(b, ast.NewSet(ast.StringTerm("a")), testdata[testName])
 		})
 	}
 }
 
-func runJSONPatchBenchmarkTest(ctx context.Context, b *testing.B, source ast.Value, patches ast.Value) {
-	store := inmem.NewFromObject(map[string]any{
-		"source":  source,
-		"patches": patches,
-	})
+func runJSONPatchBenchmarkTest(b *testing.B, source ast.Value, patches ast.Value) {
+	store := inmem.NewFromObject(map[string]any{"source": source, "patches": patches})
 
-	module := `package test
-
-			result := json.patch(data.source, data.patches)`
-
+	module := "package test\n\nresult := json.patch(data.source, data.patches)"
 	query := ast.MustParseBody("data.test.result")
-	compiler := ast.MustCompileModules(map[string]string{
-		"test.rego": module,
+	compiler := ast.MustCompileModules(map[string]string{"test.rego": module})
+
+	err := storage.Txn(b.Context(), store, storage.TransactionParams{}, func(txn storage.Transaction) error {
+		q := NewQuery(query).WithCompiler(compiler).WithStore(store).WithTransaction(txn)
+
+		for b.Loop() {
+			if _, err := q.Run(b.Context()); err != nil {
+				return err
+			}
+		}
+
+		return nil
 	})
 
-	for b.Loop() {
-		err := storage.Txn(ctx, store, storage.TransactionParams{}, func(txn storage.Transaction) error {
-			_, err := NewQuery(query).
-				WithCompiler(compiler).
-				WithStore(store).
-				WithTransaction(txn).
-				Run(ctx)
-
-			return err
-		})
-
-		if err != nil {
-			b.Fatal(err)
-		}
+	if err != nil {
+		b.Fatal(err)
 	}
-
 }

--- a/v1/topdown/topdown_partial_test.go
+++ b/v1/topdown/topdown_partial_test.go
@@ -2355,7 +2355,7 @@ func TestTopDownPartialEval(t *testing.T) {
 						ast.CallTerm(
 							ast.NewTerm(ast.Equal.Ref()),
 							ast.NewTerm(ast.InputRootRef),
-							ast.IntNumberTerm(1),
+							ast.InternedTerm(1),
 						),
 					),
 				),

--- a/v1/topdown/walk.go
+++ b/v1/topdown/walk.go
@@ -25,21 +25,22 @@ func evalWalk(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term) error
 
 func walk(filter, path *ast.Array, input *ast.Term, iter func(*ast.Term) error) error {
 	if filter == nil || filter.Len() == 0 {
-		var pathCopy *ast.Array
 		if path == nil {
-			pathCopy = ast.InternedEmptyArrayValue
+			if err := iter(ast.ArrayTerm(ast.NewTerm(ast.InternedEmptyArrayValue), input)); err != nil {
+				return err
+			}
 		} else {
 			// Shallow copy, as while the array is modified, the elements are not
-			pathCopy = copyShallow(path)
-		}
+			pathCopy := copyShallow(path)
 
-		// TODO(ae): I'd *really* like these terms to be retrieved from a sync.Pool, and
-		// returned after iter is called. However, all my atttempts to do this have failed
-		// as there seems to be something holding on to these references after the call,
-		// leading to modifications that entirely alter the results. Perhaps this is not
-		// possible to do, but if it is,it would be a huge performance win.
-		if err := iter(ast.ArrayTerm(ast.NewTerm(pathCopy), input)); err != nil {
-			return err
+			// TODO(ae): I'd *really* like these terms to be retrieved from a sync.Pool, and
+			// returned after iter is called. However, all my atttempts to do this have failed
+			// as there seems to be something holding on to these references after the call,
+			// leading to modifications that entirely alter the results. Perhaps this is not
+			// possible to do, but if it is,it would be a huge performance win.
+			if err := iter(ast.ArrayTerm(ast.NewTerm(pathCopy), input)); err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
The `json.patch` built-in is quite versatile, and compared to patching via e.g. `object.union` et. al. often communicates intent better, IMO. But while it uses some fairly advanced logic for complex patch operations, it doesn't perform all that great on simple ones. This is a first and pretty basic attempt to improve that somewhat by picking the most low-hangig performance fruits, like avoiding repeated allocations of temporary term pointers.

The main allocation source is the creation of EditTree's, and this remains a problem. I have created a sync pool but only managed to get the outermost edit tree to recycle, as I found it really hard to track where it's safe to release those created in the deeply nested calls. Additionally, I managed to trigger stack overflows trying to recycle child trees, so there seems to be some circular refs? Or I just did something wrong.

If someone wants to look into this and pick up where I left, that'd be great!

- Add InternedIntRange for testing, primarily
- Intern keys used in json.patch patches
- Clean up json.X built-in benchmarks
- Reduce allocations in edit tree function
- Avoid using intermediate data structures for JSON patches
- Some unrelated interning fixes to reduce noise in tests and benchmarks (e.g. do less stuff in var inits)

Selected benchmark that I used while working on this:

**Before**
```
BenchmarkJSONPatchAddShallowScalar/object-10-16    147853      8008 ns/op    9667 B/op    206 allocs/op
BenchmarkJSONPatchAddShallowScalar/array-10-16     201704      5889 ns/op    7256 B/op    173 allocs/op
BenchmarkJSONPatchAddShallowScalar/set-10-16       182566      6733 ns/op    8103 B/op    156 allocs/op
```

**After**
```
BenchmarkJSONPatchAddShallowScalar/object-10-16    197414      6066 ns/op    7256 B/op    133 allocs/op
BenchmarkJSONPatchAddShallowScalar/array-10-16     278121      4427 ns/op    5285 B/op    100 allocs/op
BenchmarkJSONPatchAddShallowScalar/set-10-16       233884      4839 ns/op    6243 B/op    113 allocs/op
```