### PR TITLE
benchmarks: update plot to omit commits in x-axis ticks

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -305,7 +305,7 @@
       x: {
         type: "band",
         domain: data.map((d) => tags[d.commit] || d.commit),
-        tickFormat: (d) => d.substring(0, 7),
+        ticks: tagsInData,
         tickRotate: -45,
         tickAnchor: "start",
         clip: false,
@@ -368,7 +368,8 @@
   </script>
   <script type="text/markdown">
     ```
-    ${commit ? `Author: ${commit?.github_username}
+    ${commit ? `Commit: ${x?.commit}
+Author: ${commit?.github_username}
 Date: ${commit?.author_date}
 
 ${commit?.message}` : ""}


### PR DESCRIPTION
this became unreadable

Before:

<img width="1042" height="403" alt="image" src="https://github.com/user-attachments/assets/ce9ab755-6767-4eae-8479-0151d3c03756" />


After:

<img width="1042" height="398" alt="image" src="https://github.com/user-attachments/assets/f3bc5997-024d-4ec9-acfa-91fb2cd6c3e5" />
