### PR TITLE
compiler: replace `true` expr when appending to empty body

### DIFF
--- a/v1/ast/compile.go
+++ b/v1/ast/compile.go
@@ -11,7 +11,6 @@ import (
 	"maps"
 	"slices"
 	"sort"
-	"strconv"
 	"strings"
 	"sync"
 
@@ -2069,7 +2068,7 @@ func (c *Compiler) rewriteRuleHeadRefs() {
 						rule.Head.Key = expr.Operand(0)
 					}
 					rule.Head.Reference[i] = expr.Operand(0)
-					rule.Body.Append(expr)
+					rule.Body = appendToBody(rule.Body, expr)
 				}
 			}
 
@@ -2538,18 +2537,18 @@ func (c *Compiler) rewriteRefsInHead() {
 			if requiresEval(rule.Head.Key) {
 				expr := f.Generate(rule.Head.Key)
 				rule.Head.Key = expr.Operand(0)
-				rule.Body.Append(expr)
+				rule.Body = appendToBody(rule.Body, expr)
 			}
 			if requiresEval(rule.Head.Value) {
 				expr := f.Generate(rule.Head.Value)
 				rule.Head.Value = expr.Operand(0)
-				rule.Body.Append(expr)
+				rule.Body = appendToBody(rule.Body, expr)
 			}
 			for i := 0; i < len(rule.Head.Args); i++ {
 				if requiresEval(rule.Head.Args[i]) {
 					expr := f.Generate(rule.Head.Args[i])
 					rule.Head.Args[i] = expr.Operand(0)
-					rule.Body.Append(expr)
+					rule.Body = appendToBody(rule.Body, expr)
 				}
 			}
 			return false
@@ -2683,7 +2682,7 @@ func (c *Compiler) rewriteRegoMetadataCalls() {
 					chain.Location = firstChainCall.Location
 					eq := eqFactory.Generate(chain)
 					metadataChainVar = eq.Operands()[0].Value.(Var)
-					body.Append(eq)
+					body = appendToBody(body, eq)
 				}
 
 				var metadataRuleVar Var
@@ -2707,12 +2706,10 @@ func (c *Compiler) rewriteRegoMetadataCalls() {
 					metadataRuleTerm.Location = firstRuleCall.Location
 					eq := eqFactory.Generate(metadataRuleTerm)
 					metadataRuleVar = eq.Operands()[0].Value.(Var)
-					body.Append(eq)
+					body = appendToBody(body, eq)
 				}
 
-				for _, expr := range rule.Body {
-					body.Append(expr)
-				}
+				body = appendToBody(body, rule.Body...)
 				rule.Body = body
 
 				vis := func(b Body) bool {
@@ -3603,11 +3600,9 @@ func getComprehensionIndex(dbg debug.Debug, arity func(Ref) int, candidates VarS
 	}
 
 	result := make([]*Term, 0, len(indexVars))
-
 	for v := range indexVars {
 		result = append(result, NewTerm(v))
 	}
-
 	slices.SortFunc(result, TermValueCompare)
 
 	debugRes := make([]*Term, len(result))
@@ -3848,7 +3843,7 @@ func NewRuleTree(mtree *ModuleTreeNode) *TreeNode {
 	}
 
 	root.DepthFirst(func(x *TreeNode) bool {
-		x.sort()
+		slices.SortFunc(x.Sorted, Value.Compare)
 		return false
 	})
 
@@ -3929,10 +3924,6 @@ func (n *TreeNode) DepthFirst(f func(*TreeNode) bool) {
 	}
 }
 
-func (n *TreeNode) sort() {
-	slices.SortFunc(n.Sorted, Value.Compare)
-}
-
 func treeNodeFromRef(ref Ref, rule *Rule) *TreeNode {
 	depth := len(ref) - 1
 	key := ref[depth].Value
@@ -3968,8 +3959,7 @@ func (n *TreeNode) flattenChildren() []Ref {
 		})
 	}
 
-	slices.SortFunc(ret.s, RefCompare)
-	return ret.s
+	return util.SortedFunc(ret.s, RefCompare)
 }
 
 // Graph represents the graph of dependencies between rules.
@@ -4139,11 +4129,7 @@ func NewGraphTraversal(graph *Graph) *GraphTraversal {
 
 // Edges lists all dependency connections for a given node
 func (g *GraphTraversal) Edges(x util.T) []util.T {
-	r := []util.T{}
-	for v := range g.graph.Dependencies(x) {
-		r = append(r, v)
-	}
-	return r
+	return util.Keys(g.graph.Dependencies(x))
 }
 
 // Visited returns whether a node has been visited, setting a node to visited if not
@@ -4187,7 +4173,6 @@ func (vs unsafeVars) Update(o unsafeVars) {
 }
 
 func (vs unsafeVars) Vars() (result []unsafeVarLoc) {
-
 	locs := map[Var]*Location{}
 
 	// If var appears in multiple sets then pick first by location.
@@ -4200,17 +4185,12 @@ func (vs unsafeVars) Vars() (result []unsafeVarLoc) {
 	}
 
 	for v, loc := range locs {
-		result = append(result, unsafeVarLoc{
-			Var: v,
-			Loc: loc,
-		})
+		result = append(result, unsafeVarLoc{Var: v, Loc: loc})
 	}
 
-	slices.SortFunc(result, func(a, b unsafeVarLoc) int {
+	return util.SortedFunc(result, func(a, b unsafeVarLoc) int {
 		return a.Loc.Compare(b.Loc)
 	})
-
-	return result
 }
 
 func (vs unsafeVars) Slice() (result []unsafePair) {
@@ -4622,7 +4602,7 @@ func (l *localVarGenerator) Generate() Var {
 	buf := make([]byte, 0, len(l.suffix)+util.NumDigitsInt(l.next)+2)
 	for {
 		buf = append(buf, l.suffix...)
-		buf = strconv.AppendInt(buf, int64(l.next), 10)
+		buf = util.AppendInt(buf, l.next)
 		buf = append(buf, "__"...)
 
 		result := Var(string(buf))
@@ -4662,8 +4642,7 @@ func requiresEval(x *Term) bool {
 }
 
 func resolveRef(globals map[Var]*usedRef, ignore *declaredVarStack, ref Ref) Ref {
-
-	r := Ref{}
+	r := make(Ref, 0, len(ref))
 	for i, x := range ref {
 		switch v := x.Value.(type) {
 		case Var:
@@ -4883,6 +4862,9 @@ func resolveRefsInTerm(globals map[Var]*usedRef, ignore *declaredVarStack, term 
 		return &cpy
 	case *TemplateString:
 		ts := &TemplateString{}
+		if len(v.Parts) > 0 {
+			ts.Parts = make([]Node, 0, len(v.Parts))
+		}
 		for _, p := range v.Parts {
 			if expr, ok := p.(*Expr); ok {
 				ts.Parts = append(ts.Parts, resolveRefsInExpr(globals, ignore, expr))
@@ -4996,26 +4978,26 @@ func rewriteComprehensionTerms(f *equalityFactory, node any) (any, error) {
 			if requiresEval(x.Term) {
 				expr := f.Generate(x.Term)
 				x.Term = expr.Operand(0)
-				x.Body.Append(expr)
+				x.Body = appendToBody(x.Body, expr)
 			}
 			return x, nil
 		case *SetComprehension:
 			if requiresEval(x.Term) {
 				expr := f.Generate(x.Term)
 				x.Term = expr.Operand(0)
-				x.Body.Append(expr)
+				x.Body = appendToBody(x.Body, expr)
 			}
 			return x, nil
 		case *ObjectComprehension:
 			if requiresEval(x.Key) {
 				expr := f.Generate(x.Key)
 				x.Key = expr.Operand(0)
-				x.Body.Append(expr)
+				x.Body = appendToBody(x.Body, expr)
 			}
 			if requiresEval(x.Value) {
 				expr := f.Generate(x.Value)
 				x.Value = expr.Operand(0)
-				x.Body.Append(expr)
+				x.Body = appendToBody(x.Body, expr)
 			}
 			return x, nil
 		}
@@ -5070,7 +5052,7 @@ func rewriteTestEqualities(f *equalityFactory, body Body) Body {
 				every.Body = rewriteTestEqualities(f, every.Body)
 			}
 		}
-		result = appendExpr(result, expr)
+		result = appendToBody(result, expr)
 	}
 	return result
 }
@@ -5115,19 +5097,15 @@ func rewriteDynamics(f *equalityFactory, body Body) Body {
 	return result
 }
 
-func appendExpr(body Body, expr *Expr) Body {
-	body.Append(expr)
-	return body
-}
-
 func rewriteDynamicsEqExpr(f *equalityFactory, expr *Expr, result Body) Body {
 	if !validEqAssignArgCount(expr) {
-		return appendExpr(result, expr)
+		return appendToBody(result, expr)
 	}
 	terms := expr.Terms.([]*Term)
 	result, terms[1] = rewriteDynamicsInTerm(expr, f, terms[1], result)
 	result, terms[2] = rewriteDynamicsInTerm(expr, f, terms[2], result)
-	return appendExpr(result, expr)
+	result.Append(expr)
+	return result
 }
 
 func rewriteDynamicsCallExpr(f *equalityFactory, expr *Expr, result Body) Body {
@@ -5135,20 +5113,23 @@ func rewriteDynamicsCallExpr(f *equalityFactory, expr *Expr, result Body) Body {
 	for i := 1; i < len(terms); i++ {
 		result, terms[i] = rewriteDynamicsOne(expr, f, terms[i], result)
 	}
-	return appendExpr(result, expr)
+	result.Append(expr)
+	return result
 }
 
 func rewriteDynamicsEveryExpr(f *equalityFactory, expr *Expr, result Body) Body {
 	ev := expr.Terms.(*Every)
 	result, ev.Domain = rewriteDynamicsOne(expr, f, ev.Domain, result)
 	ev.Body = rewriteDynamics(f, ev.Body)
-	return appendExpr(result, expr)
+	result.Append(expr)
+	return result
 }
 
 func rewriteDynamicsTermExpr(f *equalityFactory, expr *Expr, result Body) Body {
 	term := expr.Terms.(*Term)
 	result, expr.Terms = rewriteDynamicsInTerm(expr, f, term, result)
-	return appendExpr(result, expr)
+	result.Append(expr)
+	return result
 }
 
 func rewriteDynamicsInTerm(original *Expr, f *equalityFactory, term *Term, result Body) (Body, *Term) {
@@ -5235,25 +5216,46 @@ func rewriteDynamicsComprehensionBody(original *Expr, f *equalityFactory, body B
 func rewriteExprTermsInHead(gen *localVarGenerator, rule *Rule) {
 	for i := range rule.Head.Args {
 		support, output := expandExprTerm(gen, rule.Head.Args[i])
-		for j := range support {
-			rule.Body.Append(support[j])
-		}
+		rule.Body = appendToBody(rule.Body, support...)
 		rule.Head.Args[i] = output
 	}
 	if rule.Head.Key != nil {
 		support, output := expandExprTerm(gen, rule.Head.Key)
-		for i := range support {
-			rule.Body.Append(support[i])
-		}
+		rule.Body = appendToBody(rule.Body, support...)
 		rule.Head.Key = output
 	}
 	if rule.Head.Value != nil {
 		support, output := expandExprTerm(gen, rule.Head.Value)
-		for i := range support {
-			rule.Body.Append(support[i])
-		}
+		rule.Body = appendToBody(rule.Body, support...)
 		rule.Head.Value = output
 	}
+}
+
+// appendToBody inlines Body.Append and adds additional logic for
+// replacing a single 'true' expression (i.e an empty body) with
+// the first expression to be appended, while appending the rest
+// of the expressions as normal. Additionally accepts multiple
+// expressions to append, which potentially reduces allocations
+// in larger appends.
+func appendToBody(body Body, exprs ...*Expr) Body {
+	if len(exprs) == 0 {
+		return body
+	}
+
+	blen := len(body)
+	if blen == 1 {
+		if term, ok := body[0].Terms.(*Term); ok && Boolean(true).Equal(term.Value) {
+			// body will no longer be empty, so instead of appending,
+			// replace the 'true' expression with the new expression.
+			exprs[0].Index = 0
+			body[0], exprs = exprs[0], exprs[1:]
+		}
+	}
+	for i, expr := range exprs {
+		expr.Index = blen + i
+	}
+
+	return append(body, exprs...)
 }
 
 func rewriteExprTermsInBody(gen *localVarGenerator, body Body) Body {
@@ -5280,9 +5282,8 @@ func expandExpr(gen *localVarGenerator, expr *Expr) (result []*Expr) {
 				extras[i].With = expr.With
 			}
 		}
-		result = append(result, extras...)
 		expr.Terms = term
-		result = append(result, expr)
+		result = append(append(result, extras...), expr)
 	case []*Term:
 		for i := 1; i < len(terms); i++ {
 			var extras []*Expr
@@ -5356,30 +5357,19 @@ func expandExprTerm(gen *localVarGenerator, term *Term) (support []*Expr, output
 		output = NewTerm(cpy).SetLocation(term.Location)
 	case *ArrayComprehension:
 		support, term := expandExprTerm(gen, v.Term)
-		for i := range support {
-			v.Body.Append(support[i])
-		}
 		v.Term = term
-		v.Body = rewriteExprTermsInBody(gen, v.Body)
+		v.Body = rewriteExprTermsInBody(gen, appendToBody(v.Body, support...))
 	case *SetComprehension:
 		support, term := expandExprTerm(gen, v.Term)
-		for i := range support {
-			v.Body.Append(support[i])
-		}
 		v.Term = term
-		v.Body = rewriteExprTermsInBody(gen, v.Body)
+		v.Body = rewriteExprTermsInBody(gen, appendToBody(v.Body, support...))
 	case *ObjectComprehension:
 		support, key := expandExprTerm(gen, v.Key)
-		for i := range support {
-			v.Body.Append(support[i])
-		}
+		v.Body = appendToBody(v.Body, support...)
 		v.Key = key
 		support, value := expandExprTerm(gen, v.Value)
-		for i := range support {
-			v.Body.Append(support[i])
-		}
 		v.Value = value
-		v.Body = rewriteExprTermsInBody(gen, v.Body)
+		v.Body = rewriteExprTermsInBody(gen, appendToBody(v.Body, support...))
 	}
 	return
 }
@@ -6051,8 +6041,7 @@ func rewriteDeclaredVarsInTemplateString(g *localVarGenerator, stack *localDecla
 }
 
 func rewriteDeclaredVarsInArrayComprehension(g *localVarGenerator, stack *localDeclaredVars, v *ArrayComprehension, errs Errors, strict bool) Errors {
-	used := NewVarSet()
-	used.Update(v.Term.Vars())
+	used := v.Term.Vars()
 
 	stack.Push()
 	v.Body, errs = rewriteDeclaredVarsInBody(g, stack, used, v.Body, errs, strict)
@@ -6205,7 +6194,6 @@ func validateWith(c *Compiler, unsafeBuiltinsMap map[string]struct{}, expr *Expr
 		}
 	case isInputRef(target): // ok, valid
 	case isBuiltinRefOrVar:
-
 		// NOTE(sr): first we ensure that parsed Var builtins (`count`, `concat`, etc)
 		// are rewritten to their proper Ref convention
 		if v, ok := target.Value.(Var); ok {
@@ -6261,30 +6249,23 @@ func validateWithFunctionValue(bs map[string]*Builtin, unsafeMap map[string]stru
 }
 
 func isInputRef(term *Term) bool {
-	if ref, ok := term.Value.(Ref); ok {
-		if ref.HasPrefix(InputRootRef) {
-			return true
-		}
-	}
-	return false
+	ref, ok := term.Value.(Ref)
+	return ok && ref.HasPrefix(InputRootRef)
 }
 
 func isDataRef(term *Term) bool {
-	if ref, ok := term.Value.(Ref); ok {
-		if ref.HasPrefix(DefaultRootRef) {
-			return true
-		}
-	}
-	return false
+	ref, ok := term.Value.(Ref)
+	return ok && ref.HasPrefix(DefaultRootRef)
 }
 
 func isBuiltinRefOrVar(bs map[string]*Builtin, unsafeBuiltinsMap map[string]struct{}, term *Term) (bool, *Error) {
 	switch v := term.Value.(type) {
 	case Ref, Var:
-		if _, ok := unsafeBuiltinsMap[v.String()]; ok {
+		vs := v.String()
+		if _, ok := unsafeBuiltinsMap[vs]; ok {
 			return false, NewError(CompileErr, term.Location, "with keyword replacing built-in function: target must not be unsafe: %q", v)
 		}
-		_, ok := bs[v.String()]
+		_, ok := bs[vs]
 		return ok, nil
 	}
 	return false, nil
@@ -6330,9 +6311,7 @@ func safetyErrorSlice(unsafe unsafeVars, rewritten map[Var]Var) (result Errors) 
 	// If the expression contains unsafe generated variables, report which
 	// expressions are unsafe instead of the variables that are unsafe (since
 	// the latter are not meaningful to the user.)
-	pairs := unsafe.Slice()
-
-	slices.SortFunc(pairs, func(a, b unsafePair) int {
+	pairs := util.SortedFunc(unsafe.Slice(), func(a, b unsafePair) int {
 		return a.Expr.Location.Compare(b.Expr.Location)
 	})
 
@@ -6425,6 +6404,5 @@ func (rs *refSet) Sorted() []*Term {
 	for i := range rs.s {
 		terms[i] = NewTerm(rs.s[i])
 	}
-	slices.SortFunc(terms, TermValueCompare)
-	return terms
+	return util.SortedFunc(terms, TermValueCompare)
 }

--- a/v1/ast/compile_test.go
+++ b/v1/ast/compile_test.go
@@ -2674,9 +2674,9 @@ func TestCompilerRewriteExprTerms(t *testing.T) {
 
 				r = [__local4__] { x = 1; data.test.f(x, __local4__) }
 
-				f(__local0__) = __local5__ { true; data.test.g(__local0__, __local5__) }
+				f(__local0__) = __local5__ { data.test.g(__local0__, __local5__) }
 
-				pi = __local6__ { true; plus(3, 0.14, __local6__) }
+				pi = __local6__ { plus(3, 0.14, __local6__) }
 
 				with_value { data.test.f(1, __local7__); 1 with input as __local7__ }
 			`,
@@ -2708,7 +2708,7 @@ func TestCompilerRewriteExprTerms(t *testing.T) {
 			expected: `
 				package test
 
-				f(__local0__[0]) { true; __local0__ = [1] }`,
+				f(__local0__[0]) { __local0__ = [1] }`,
 		},
 		{
 			note: "every: domain (array)",
@@ -4109,7 +4109,7 @@ p := count([x | q[x]])
 q[1] = 1
 `,
 			exp: `package test
-p := __local0__ if { true; __local1__ = [x | data.test.q[x]]; count(__local1__, __local0__) }
+p := __local0__ if { __local1__ = [x | data.test.q[x]]; count(__local1__, __local0__) }
 q[1] = 1
 `,
 		},
@@ -4458,14 +4458,14 @@ import input.qux as baz
 
 p[foo[bar[i]]] = {"baz": baz, "corge": corge} if { true }
 `),
-			exp: MustParseRule(`p[__local0__] = __local1__ { true; __local0__ = input.x.y.foo[data.doc1[i]]; __local1__ = {"baz": input.qux, "corge": data.doc2} }`),
+			exp: MustParseRule(`p[__local0__] = __local1__ { __local0__ = input.x.y.foo[data.doc1[i]]; __local1__ = {"baz": input.qux, "corge": data.doc2} }`),
 		},
 		{
 			note: "array comprehension value",
 			mod: module(`package head
 q = [true | true] if { true }
 `),
-			exp: MustParseRule(`q = __local0__ { true; __local0__ = [true | true] }`),
+			exp: MustParseRule(`q = __local0__ { __local0__ = [true | true] }`),
 		},
 		{
 			note: "array comprehension value in else head",
@@ -4476,7 +4476,7 @@ q if {
 	true
 }
 `),
-			exp: MustParseRule(`q = true { false } else = __local0__ { true; __local0__ = [true | true] }`),
+			exp: MustParseRule(`q = true { false } else = __local0__ { __local0__ = [true | true] }`),
 		},
 		{
 			note: "array comprehension value in head (comprehension-local var)",
@@ -4487,7 +4487,7 @@ q = [a | a := true] if {
 	true
 }
 `),
-			exp: MustParseRule(`q = __local2__ { false; __local2__ = [__local0__ | __local0__ = true] } else = __local3__ { true; __local3__ = [__local1__ | __local1__ = true] }`),
+			exp: MustParseRule(`q = __local2__ { false; __local2__ = [__local0__ | __local0__ = true] } else = __local3__ { __local3__ = [__local1__ | __local1__ = true] }`),
 		},
 		{
 			note: "array comprehension value in function head (comprehension-local var)",
@@ -4498,7 +4498,7 @@ f(x) = [a | a := true] if {
 	true
 }
 `),
-			exp: MustParseRule(`f(__local0__) = __local3__ { false; __local3__ = [__local1__ | __local1__ = true] } else = __local4__ { true; __local4__ = [__local2__ | __local2__ = true] }`),
+			exp: MustParseRule(`f(__local0__) = __local3__ { false; __local3__ = [__local1__ | __local1__ = true] } else = __local4__ { __local4__ = [__local2__ | __local2__ = true] }`),
 		},
 		{
 			note: "array comprehension value in else-func head (reused arg rewrite)",
@@ -4509,14 +4509,14 @@ f(x, y) = [x | y] if {
 	true
 }
 `),
-			exp: MustParseRule(`f(__local0__, __local1__) = __local2__ { false; __local2__ = [__local0__ | __local1__] } else = __local3__ { true; __local3__ = [__local0__ | __local1__] }`),
+			exp: MustParseRule(`f(__local0__, __local1__) = __local2__ { false; __local2__ = [__local0__ | __local1__] } else = __local3__ { __local3__ = [__local0__ | __local1__] }`),
 		},
 		{
 			note: "object comprehension value",
 			mod: module(`package head
 r = {"true": true | true} if { true }
 `),
-			exp: MustParseRule(`r = __local0__ { true; __local0__ = {"true": true | true} }`),
+			exp: MustParseRule(`r = __local0__ { __local0__ = {"true": true | true} }`),
 		},
 		{
 			note: "object comprehension value in else head",
@@ -4527,7 +4527,7 @@ q if {
 	true
 }
 `),
-			exp: MustParseRule(`q = true { false } else = __local0__ { true; __local0__ = {"true": true | true} }`),
+			exp: MustParseRule(`q = true { false } else = __local0__ { __local0__ = {"true": true | true} }`),
 		},
 		{
 			note: "object comprehension value in head (comprehension-local var)",
@@ -4538,7 +4538,7 @@ q = {"a": a | a := true} if {
 	true
 }
 `),
-			exp: MustParseRule(`q = __local2__ { false; __local2__ = {"a": __local0__ | __local0__ = true} } else = __local3__ { true; __local3__ = {"a": __local1__ | __local1__ = true} }`),
+			exp: MustParseRule(`q = __local2__ { false; __local2__ = {"a": __local0__ | __local0__ = true} } else = __local3__ { __local3__ = {"a": __local1__ | __local1__ = true} }`),
 		},
 		{
 			note: "object comprehension value in function head (comprehension-local var)",
@@ -4549,7 +4549,7 @@ f(x) = {"a": a | a := true} if {
 	true
 }
 `),
-			exp: MustParseRule(`f(__local0__) = __local3__ { false; __local3__ = {"a": __local1__ | __local1__ = true} } else = __local4__ { true; __local4__ = {"a": __local2__ | __local2__ = true} }`),
+			exp: MustParseRule(`f(__local0__) = __local3__ { false; __local3__ = {"a": __local1__ | __local1__ = true} } else = __local4__ { __local4__ = {"a": __local2__ | __local2__ = true} }`),
 		},
 		{
 			note: "object comprehension value in else-func head (reused arg rewrite)",
@@ -4560,14 +4560,14 @@ f(x, y) = {x: y | true} if {
 	true
 }
 `),
-			exp: MustParseRule(`f(__local0__, __local1__) = __local2__ { false; __local2__ = {__local0__: __local1__ | true} } else = __local3__ { true; __local3__ = {__local0__: __local1__ | true} }`),
+			exp: MustParseRule(`f(__local0__, __local1__) = __local2__ { false; __local2__ = {__local0__: __local1__ | true} } else = __local3__ { __local3__ = {__local0__: __local1__ | true} }`),
 		},
 		{
 			note: "set comprehension value",
 			mod: module(`package head
 s = {true | true} if { true }
 `),
-			exp: MustParseRule(`s = __local0__ { true; __local0__ = {true | true} }`),
+			exp: MustParseRule(`s = __local0__ { __local0__ = {true | true} }`),
 		},
 		{
 			note: "set comprehension value in else head",
@@ -4578,7 +4578,7 @@ q = {false | false} if {
 	true
 }
 `),
-			exp: MustParseRule(`q = __local0__ { false; __local0__ = {false | false} } else = __local1__ { true; __local1__ = {true | true} }`),
+			exp: MustParseRule(`q = __local0__ { false; __local0__ = {false | false} } else = __local1__ { __local1__ = {true | true} }`),
 		},
 		{
 			note: "set comprehension value in head (comprehension-local var)",
@@ -4589,7 +4589,7 @@ q = {a | a := true} if {
 	true
 }
 `),
-			exp: MustParseRule(`q = __local2__ { false; __local2__ = {__local0__ | __local0__ = true} } else = __local3__ { true; __local3__ = {__local1__ | __local1__ = true} }`),
+			exp: MustParseRule(`q = __local2__ { false; __local2__ = {__local0__ | __local0__ = true} } else = __local3__ { __local3__ = {__local1__ | __local1__ = true} }`),
 		},
 		{
 			note: "set comprehension value in function head (comprehension-local var)",
@@ -4600,7 +4600,7 @@ f(x) = {a | a := true} if {
 	true
 }
 `),
-			exp: MustParseRule(`f(__local0__) = __local3__ { false; __local3__ = {__local1__ | __local1__ = true} } else = __local4__ { true; __local4__ = {__local2__ | __local2__ = true} }`),
+			exp: MustParseRule(`f(__local0__) = __local3__ { false; __local3__ = {__local1__ | __local1__ = true} } else = __local4__ { __local4__ = {__local2__ | __local2__ = true} }`),
 		},
 		{
 			note: "set comprehension value in else-func head (reused arg rewrite)",
@@ -4611,7 +4611,7 @@ f(x, y) = {x | y} if {
 	true
 }
 `),
-			exp: MustParseRule(`f(__local0__, __local1__) = __local2__ { false; __local2__ = {__local0__ | __local1__} } else = __local3__ { true; __local3__ = {__local0__ | __local1__} }`),
+			exp: MustParseRule(`f(__local0__, __local1__) = __local2__ { false; __local2__ = {__local0__ | __local1__} } else = __local3__ { __local3__ = {__local0__ | __local1__} }`),
 		},
 		{
 			note: "import in else value",
@@ -4623,7 +4623,7 @@ elsekw if {
 	true
 }
 `),
-			exp: MustParseRule(`elsekw { false } else = __local0__ { true; __local0__ = input.qux }`),
+			exp: MustParseRule(`elsekw { false } else = __local0__ { __local0__ = input.qux }`),
 		},
 		{
 			note: "import ref in last ref head term",
@@ -4631,7 +4631,7 @@ elsekw if {
 import data.doc1 as bar
 x.y.z[bar[i]] = true
 `),
-			exp: MustParseRule(`x.y.z[__local0__] = true { true; __local0__ = data.doc1[i] }`),
+			exp: MustParseRule(`x.y.z[__local0__] = true { __local0__ = data.doc1[i] }`),
 		},
 		{
 			note: "import ref in multi-value ref rule",
@@ -4640,7 +4640,7 @@ import data.doc1 as bar
 x.y.w contains bar[i] if true
 `),
 			exp: func() *Rule {
-				exp, _ := ParseRuleWithOpts(`x.y.w contains __local0__ if {true; __local0__ = data.doc1[i] }`, popts)
+				exp, _ := ParseRuleWithOpts(`x.y.w contains __local0__ if { __local0__ = data.doc1[i] }`, popts)
 				return exp
 			}(),
 		},
@@ -4860,7 +4860,6 @@ p := rego.metadata.chain()`,
 
 p := __local0__ if {
 	__local1__ = [{"path": ["test", "p"]}]
-	true
 	__local0__ = __local1__
 }`,
 		},
@@ -5791,7 +5790,7 @@ func TestRewriteDeclaredVars(t *testing.T) {
 				package test
 				p if {
 					__local0__ = "bar"
-					{__local1__ | true; __local1__ = { 2 | true with input[__local0__] as 1 }}
+					{__local1__ | __local1__ = { 2 | true with input[__local0__] as 1 }}
 				}
 			`,
 		},
@@ -7213,7 +7212,6 @@ func TestCompilerRewriteWithValue(t *testing.T) {
 }
 
 func TestCompilerRewritePrintCallsErasure(t *testing.T) {
-
 	cases := []struct {
 		note   string
 		module string
@@ -7293,7 +7291,7 @@ func TestCompilerRewritePrintCallsErasure(t *testing.T) {
 			p = {1 | print("x")}`,
 			exp: `package test
 
-			p = __local0__ if { true; __local0__ = {1 | true} }`,
+			p = __local0__ if { __local0__ = {1 | true} }`,
 		},
 	}
 
@@ -7490,7 +7488,6 @@ func TestCompilerRewritePrintCalls(t *testing.T) {
 			exp: `package test
 
 			p = __local1__ if {
-				true
 				__local1__ = {1 | __local2__ = { __local0__ | __local0__ = "x"}; internal.print([__local2__])}
 			}`,
 		},
@@ -7501,7 +7498,7 @@ func TestCompilerRewritePrintCalls(t *testing.T) {
 			f(a) = {1 | a[x]; print(x)}`,
 			exp: `package test
 
-			f(__local0__) = __local2__ if { true; __local2__ = {1 | __local0__[x]; __local3__ = {__local1__ | __local1__ = x}; internal.print([__local3__])} }
+			f(__local0__) = __local2__ if { __local2__ = {1 | __local0__[x]; __local3__ = {__local1__ | __local1__ = x}; internal.print([__local3__])} }
 			`,
 		},
 		{
@@ -7543,7 +7540,7 @@ func TestCompilerRewritePrintCalls(t *testing.T) {
 				print(x)
 			}`,
 			exp: `package test
-			q = __local3__ if { true; __local3__ = input }
+			q = __local3__ if { __local3__ = input }
 			p = true if {
 				json.unmarshal("{}", __local2__)
 				__local0__ = data.test.q with input as __local2__
@@ -7583,7 +7580,6 @@ func TestCompilerRewriteTemplateStrings(t *testing.T) {
 				p := $""`,
 			exp: `package test
 				p := __local0__ if { 
-					true
 					internal.template_string([""], __local0__) 
 				}`,
 		},
@@ -7593,7 +7589,6 @@ func TestCompilerRewriteTemplateStrings(t *testing.T) {
 				p contains $""`,
 			exp: `package test
 				p contains __local0__ if { 
-					true
 					internal.template_string([""], __local0__) 
 				}`,
 		},
@@ -7602,8 +7597,7 @@ func TestCompilerRewriteTemplateStrings(t *testing.T) {
 			module: `package test
 				p[$""] := true`,
 			exp: `package test
-				p[__local0__] := true if { 
-					true
+				p[__local0__] := true if {
 					internal.template_string([""], __local1__)
 					__local0__ = __local1__
 				}`,
@@ -7640,7 +7634,6 @@ func TestCompilerRewriteTemplateStrings(t *testing.T) {
 				p := $"foo bar"`,
 			exp: `package test
 				p := __local0__ if { 
-					true
 					internal.template_string(["foo bar"], __local0__) 
 				}`,
 		},
@@ -7650,7 +7643,6 @@ func TestCompilerRewriteTemplateStrings(t *testing.T) {
 				p contains $"foo bar"`,
 			exp: `package test
 				p contains __local0__ if { 
-					true
 					internal.template_string(["foo bar"], __local0__) 
 				}`,
 		},
@@ -7660,7 +7652,6 @@ func TestCompilerRewriteTemplateStrings(t *testing.T) {
 				p[$"foo bar"] := true`,
 			exp: `package test
 				p[__local0__] := true if { 
-					true
 					internal.template_string(["foo bar"], __local1__)
 					__local0__ = __local1__
 				}`,
@@ -7697,7 +7688,6 @@ func TestCompilerRewriteTemplateStrings(t *testing.T) {
 				p := $"{input.x}"`,
 			exp: `package test
 				p := __local1__ if { 
-					true 
 					__local2__ = {__local0__ | __local0__ = input.x}; internal.template_string([__local2__], __local1__)
 				}`,
 		},
@@ -7707,7 +7697,6 @@ func TestCompilerRewriteTemplateStrings(t *testing.T) {
 				p contains $"{input.x}"`,
 			exp: `package test
 				p contains __local1__ if { 
-					true
 					__local2__ = {__local0__ | __local0__ = input.x}
 					internal.template_string([__local2__], __local1__)
 				}`,
@@ -7718,7 +7707,6 @@ func TestCompilerRewriteTemplateStrings(t *testing.T) {
 				p[$"{input.x}"] := true`,
 			exp: `package test
 				p[__local0__] := true if { 
-					true
 					__local3__ = {__local1__ | __local1__ = input.x}
 					internal.template_string([__local3__], __local2__)
 					__local0__ = __local2__
@@ -7758,7 +7746,6 @@ func TestCompilerRewriteTemplateStrings(t *testing.T) {
 				f($"{input.x}") := 42`,
 			exp: `package test
 				f(__local1__) := 42 if { 
-					true
 					__local2__ = {__local0__ | __local0__ = input.x}
 					internal.template_string([__local2__], __local1__)
 				}`,
@@ -7869,7 +7856,6 @@ func TestCompilerRewriteTemplateStrings(t *testing.T) {
 				f(x) := $"{x}"`,
 			exp: `package test
 				f(__local0__) := __local2__ if { 
-					true
 					__local3__ = {__local1__ | __local1__ = __local0__}
 					internal.template_string([__local3__], __local2__)
 				}`,
@@ -7896,7 +7882,6 @@ func TestCompilerRewriteTemplateStrings(t *testing.T) {
 				p := $"{false}, {42}, {13.37}, {"foo"}, {` + "`bar`" + `}, {null}"`,
 			exp: `package test
 				p := __local0__ if { 
-					true
 					internal.template_string([false, ", ", 42, ", ", 13.37, ", ", "foo", ", ", "bar", ", ", null], __local0__) 
 				}`,
 		},
@@ -7908,7 +7893,6 @@ func TestCompilerRewriteTemplateStrings(t *testing.T) {
 				p := $"{[1, 2, 3]}, {{false, true}}, {{"a": "b"}}"`,
 			exp: `package test
 				p := __local3__ if { 
-					true
 					__local4__ = {__local0__ | __local0__ = [1, 2, 3]}
 					__local5__ = {__local1__ | __local1__ = {false, true}}
 					__local6__ = {__local2__ | __local2__ = {"a": "b"}}
@@ -7925,7 +7909,6 @@ func TestCompilerRewriteTemplateStrings(t *testing.T) {
 			exp: `package test
 				f(__local0__) := __local0__ if { true }
 				p := __local3__ if { 
-					true
 					__local5__ = {__local1__ | 
 						__local4__ = input.x
 						data.test.f(__local4__, __local2__)
@@ -7942,7 +7925,6 @@ func TestCompilerRewriteTemplateStrings(t *testing.T) {
 			exp: `package test
 				f(__local0__) := __local0__ if { true }
 				p contains __local3__ if { 
-					true
 					__local5__ = {__local1__ | 
 						__local4__ = input.x
 						data.test.f(__local4__, __local2__)
@@ -7959,7 +7941,6 @@ func TestCompilerRewriteTemplateStrings(t *testing.T) {
 			exp: `package test
 				f(__local1__) := __local1__ if { true }
 				p[__local0__] := true if { 
-					true
 					__local6__ = {__local2__ | 
 						__local5__ = input.x
 						data.test.f(__local5__, __local3__)
@@ -7996,7 +7977,6 @@ func TestCompilerRewriteTemplateStrings(t *testing.T) {
 				p := $"{input.x + 2}"`,
 			exp: `package test
 				p := __local2__ if { 
-					true
 					__local4__ = {__local0__ | 
 						__local3__ = input.x
 						plus(__local3__, 2, __local1__)
@@ -8011,7 +7991,6 @@ func TestCompilerRewriteTemplateStrings(t *testing.T) {
 				p contains $"{input.x + 2}"`,
 			exp: `package test
 				p contains __local2__ if { 
-					true
 					__local4__ = {__local0__ | 
 						__local3__ = input.x
 						plus(__local3__, 2, __local1__)
@@ -8026,7 +8005,6 @@ func TestCompilerRewriteTemplateStrings(t *testing.T) {
 				p[$"{input.x + 2}"] := true`,
 			exp: `package test
 				p[__local0__] := true if {
-					true
 					__local5__ = {__local1__ | 
 						__local4__ = input.x
 						plus(__local4__, 2, __local2__)
@@ -8235,7 +8213,7 @@ func TestCompilerRewriteTemplateStrings(t *testing.T) {
 			module: `package test
 				f($"{[x | y := input.ys[_]; x := y]}") := 42`,
 			exp: `package test
-				f(__local3__) := 42 if { true
+				f(__local3__) := 42 if {
 					__local4__ = {__local2__ | 
 						__local2__ = [__local1__ | __local0__ = input.ys[_]
 						__local1__ = __local0__]
@@ -8366,7 +8344,6 @@ func TestCompilerRewriteTemplateStrings(t *testing.T) {
 				p = true if { 
 					false 
 				} else := __local1__ if { 
-					true
 					__local2__ = {__local0__ | 
 						__local0__ = input.y
 					}
@@ -8400,7 +8377,6 @@ func TestCompilerRewriteTemplateStrings(t *testing.T) {
 				p := $"foo {$"bar {data.a}"}"`,
 			exp: `package test
 				p := __local3__ if { 
-					true
 					__local5__ = {__local0__ |
 						__local4__ = {__local1__ | 
 							__local1__ = data.a
@@ -8417,7 +8393,6 @@ func TestCompilerRewriteTemplateStrings(t *testing.T) {
 				p contains $"foo {$"bar {data.a}"}"`,
 			exp: `package test
 				p contains __local3__ if { 
-					true
 					__local5__ = {__local0__ |
 						__local4__ = {__local1__ | 
 							__local1__ = data.a
@@ -8434,7 +8409,6 @@ func TestCompilerRewriteTemplateStrings(t *testing.T) {
 				p[$"foo {$"bar {data.a}"}"] := true`,
 			exp: `package test
 				p[__local0__] := true if { 
-					true
 					__local6__ = {__local1__ | 
 						__local5__ = {__local2__ | 
 							__local2__ = data.a
@@ -8478,9 +8452,8 @@ func TestCompilerRewriteTemplateStrings(t *testing.T) {
 				a := input
 				p := $"{a with input as 42} {a with input as {"x": true}}"`,
 			exp: `package test
-				a := __local3__ if { true; __local3__ = input }
+				a := __local3__ if { __local3__ = input }
 				p := __local2__ if { 
-					true
 					__local4__ = {__local0__ | __local0__ = data.test.a with input as 42}
 					__local5__ = {__local1__ | __local1__ = data.test.a with input as {"x": true}}
 					internal.template_string([__local4__, " ", __local5__], __local2__)
@@ -8495,8 +8468,8 @@ func TestCompilerRewriteTemplateStrings(t *testing.T) {
 					$"{a} {b}" with input as 42
 				}`,
 			exp: `package test
-				a := __local3__ if { true; __local3__ = input }
-				b := __local4__ if { true; __local4__ = input }
+				a := __local3__ if { __local3__ = input }
+				b := __local4__ if { __local4__ = input }
 				p = true if { 
 					__local5__ = {__local0__ | __local0__ = data.test.a} with input as 42
 					__local6__ = {__local1__ | __local1__ = data.test.b} with input as 42
@@ -8512,7 +8485,7 @@ func TestCompilerRewriteTemplateStrings(t *testing.T) {
 					x := $"{a with input.x as 1}" with input.y as 2
 				}`,
 			exp: `package test
-				a := __local2__ if { true
+				a := __local2__ if {
 					__local4__ = input.x
 					__local5__ = input.y
 					plus(__local4__, __local5__, __local2__)

--- a/v1/rego/rego_test.go
+++ b/v1/rego/rego_test.go
@@ -3426,7 +3426,7 @@ result := test.module("policy.rego")
 			t.Fatalf("No results")
 		}
 		got := rs[0].Expressions[0].Value
-		want := "package test\n\nresult := __local0__ if { true; test.module(\"policy.rego\", __local0__) }"
+		want := "package test\n\nresult := __local0__ if { test.module(\"policy.rego\", __local0__) }"
 		if got != want {
 			t.Errorf("Expected %q, got %q", want, got)
 		}

--- a/v1/topdown/copypropagation/copypropagation.go
+++ b/v1/topdown/copypropagation/copypropagation.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 
 	"github.com/open-policy-agent/opa/v1/ast"
+	"github.com/open-policy-agent/opa/v1/util"
 )
 
 // CopyPropagator implements a simple copy propagation optimization to remove
@@ -49,17 +50,7 @@ func (l *localVarGenerator) Generate() ast.Var {
 // New returns a new CopyPropagator that optimizes queries while preserving vars
 // in the livevars set.
 func New(livevars ast.VarSet) *CopyPropagator {
-
-	sorted := make([]ast.Var, 0, len(livevars))
-	for v := range livevars {
-		sorted = append(sorted, v)
-	}
-
-	sort.Slice(sorted, func(i, j int) bool {
-		return sorted[i].Compare(sorted[j]) < 0
-	})
-
-	return &CopyPropagator{livevars: livevars, sorted: sorted, localvargen: &localVarGenerator{}}
+	return &CopyPropagator{livevars: livevars, sorted: util.KeysSorted(livevars), localvargen: &localVarGenerator{}}
 }
 
 // WithEnsureNonEmptyBody configures p to ensure that results are always non-empty.

--- a/v1/topdown/topdown_bench_test.go
+++ b/v1/topdown/topdown_bench_test.go
@@ -970,11 +970,9 @@ func BenchmarkObjectGetFromBaseDoc(b *testing.B) {
 	}
 }
 
-// templatestring           216386      5524 ns/op   10074 B/op	     158 allocs/op
-// templatestring                       5219 ns/op    8337 B/op      152 allocs/op don't pass bctx
-// --
-// concat                   272054      4500 ns/op    6728 B/op	     123 allocs/op
-// sprintf                  280381      4421 ns/op    6365 B/op	     121 allocs/op
+// templatestring-16         	  234561	      5096 ns/op	    8257 B/op	     150 allocs/op
+// concat-16                 	  286130	      4265 ns/op	    6624 B/op	     118 allocs/op
+// sprintf-16                	  286662	      4206 ns/op	    6260 B/op	     116 allocs/op
 func BenchmarkTemplateStringVsConcatVsSprintf(b *testing.B) {
 	ctx := b.Context()
 	store := inmem.NewFromObject(map[string]any{})

--- a/v1/topdown/trace_test.go
+++ b/v1/topdown/trace_test.go
@@ -1233,12 +1233,10 @@ query:1      | Eval data.test = _
 query:1      | Index data.test.chain_no_output_var (matched 1 rule)
 query:9      | Enter data.test.chain_no_output_var
 query:9      | | Eval __local8__ = [{"path": ["test", "chain_no_output_var"]}]
-query:9      | | Eval true
 query:9      | | Eval __local4__ = __local8__
 query:9      | | Exit data.test.chain_no_output_var
 query:9      | Redo data.test.chain_no_output_var
 query:9      | | Redo __local4__ = __local8__
-query:9      | | Redo true
 query:9      | | Redo __local8__ = [{"path": ["test", "chain_no_output_var"]}]
 query:1      | Index data.test.chain_with_output_var (matched 1 rule, early exit)
 query:11     | Enter data.test.chain_with_output_var
@@ -1253,12 +1251,10 @@ query:12     | | Redo __local9__ = [{"path": ["test", "chain_with_output_var"]}]
 query:1      | Index data.test.rule_no_output_var (matched 1 rule)
 query:2      | Enter data.test.rule_no_output_var
 query:2      | | Eval __local6__ = {}
-query:2      | | Eval true
 query:2      | | Eval __local2__ = __local6__
 query:2      | | Exit data.test.rule_no_output_var
 query:2      | Redo data.test.rule_no_output_var
 query:2      | | Redo __local2__ = __local6__
-query:2      | | Redo true
 query:2      | | Redo __local6__ = {}
 query:1      | Index data.test.rule_with_output_var (matched 1 rule, early exit)
 query:4      | Enter data.test.rule_with_output_var

--- a/v1/util/performance.go
+++ b/v1/util/performance.go
@@ -161,7 +161,6 @@ func (sp *SlicePool[T]) Get(length int) *[]T {
 	clear(d)
 
 	*s = d
-
 	return s
 }
 
@@ -170,4 +169,10 @@ func (sp *SlicePool[T]) Put(s *[]T) {
 	if s != nil {
 		sp.pool.Put(s)
 	}
+}
+
+// SortedFunc is simply a shorthand for [slices.SortFunc] which also returns the sorted slice.
+func SortedFunc[T any, S ~[]T](s S, cmp func(a, b T) int) S {
+	slices.SortFunc(s, cmp)
+	return s
 }


### PR DESCRIPTION
The OPA parser places a single boolean true term inside an expression to populate empty rule bodies, so that e.g. `x := input.x` parses as:

```rego
x := input.x if {
    true
}
```

When the compiler rewrites rules in its various stages, it would previously ignore such "true expressions" and simply append what it rewrote as the next expression:

```
x := __local1__ if {
    true
    __local1__ = input.x
}
```

This is of course redundant, as the only purpose of the `true` expr was to mark the body as empty — which it no longer is! While fairly harmless, this contributes noise to the compiler's output, which is then passed onwards to topdown evaluation. Not a huge deal, but measurable!

**BenchmarkRegalLintingItselfPrepareOnce**
```
502062750 ns/op    1900946509 B/op    45426050 allocs/op
496509250 ns/op    1893094357 B/op    45112660 allocs/op
```

With this change, the compiler now replaces an empty true expression with a new one whenever we append to a body. Meaning `true` remains to mark empty bodies, but not in non-empty ones.

This is more about elegance than performance though :)