### PR TITLE
Respect the user provided timeout when calling units.parse_bytes 

### DIFF
--- a/v1/ast/builtins.go
+++ b/v1/ast/builtins.go
@@ -1546,7 +1546,7 @@ and "MiB" are equivalent).`,
 		),
 		types.Named("y", types.N).Description("the parsed number"),
 	),
-	CanSkipBctx: true,
+	CanSkipBctx: false,
 }
 
 //

--- a/v1/topdown/parse_bytes_test.go
+++ b/v1/topdown/parse_bytes_test.go
@@ -1,0 +1,60 @@
+package topdown
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/open-policy-agent/opa/v1/ast"
+)
+
+func TestBuiltinNumBytesTimeout(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		timeout     time.Duration
+		expectedErr string
+	}{
+		{
+			name:        "timeout due to large number",
+			input:       "10000000000e100000000EiB",
+			timeout:     time.Second,
+			expectedErr: "context deadline exceeded",
+		},
+		{
+			name:    "no timeout",
+			input:   "10000000000e10000EiB",
+			timeout: time.Second,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+
+			iter := func(*ast.Term) error { return nil }
+			ctx := BuiltinContext{
+				Context: t.Context(),
+			}
+
+			if tc.timeout != 0 {
+				var cancel func()
+				ctx.Context, cancel = context.WithTimeout(ctx.Context, tc.timeout)
+				defer cancel()
+			}
+
+			operands := []*ast.Term{
+				ast.StringTerm(tc.input),
+			}
+
+			err := builtinNumBytes(ctx, operands, iter)
+			if tc.expectedErr != "" && err == nil {
+				t.Fatalf("expected error %s, got nil", tc.expectedErr)
+			}
+			if err != nil && !strings.Contains(err.Error(), tc.expectedErr) {
+				t.Fatalf("expected error %s, got %s", tc.expectedErr, err)
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
resolve: https://github.com/open-policy-agent/opa/issues/8326

```
❯ time ./opa_darwin_arm64 eval --format pretty --timeout 1s --show-builtin-errors 'units.parse_bytes("10000000000e100000000EiB")'
1 error occurred: units.parse_bytes("10000000000e100000000EiB"): eval_builtin_error: units.parse_bytes: context deadline exceeded
./opa_darwin_arm64 eval --format pretty --timeout 1s --show-builtin-errors   1.00s user 0.03s system 66% cpu 1.540 total
```