### PR TITLE
workflows: add nightly vuln checks for released versions/images

### DIFF
--- a/.github/workflows/release-vulnerability-check.yaml
+++ b/.github/workflows/release-vulnerability-check.yaml
@@ -1,0 +1,135 @@
+name: Release Vulnerability Check
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron:  '0 8 * * 0-4' # Sun-Thu, at 8:00 UTC
+
+permissions:
+  contents: read
+
+jobs:
+  fetch-release-info:
+    name: Fetch release information
+    runs-on: ubuntu-24.04
+    outputs:
+      release_tag: ${{ steps.release.outputs.release_tag }}
+      docker_tag: ${{ steps.release.outputs.docker_tag }}
+    steps:
+      - name: Fetch latest release tag
+        id: release
+        run: |
+          LATEST_RELEASE=$(curl -s https://api.github.com/repos/open-policy-agent/opa/releases/latest | jq -r .tag_name)
+          # Remove 'v' prefix for Docker tag
+          DOCKER_TAG=${LATEST_RELEASE#v}
+          echo "release_tag=${LATEST_RELEASE}" >> $GITHUB_OUTPUT
+          echo "docker_tag=${DOCKER_TAG}" >> $GITHUB_OUTPUT
+          echo "### 🔍 Release Vulnerability Checks" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Checking vulnerabilities for:" >> $GITHUB_STEP_SUMMARY
+          echo "- **Release**: [${LATEST_RELEASE}](https://github.com/open-policy-agent/opa/releases/tag/${LATEST_RELEASE})" >> $GITHUB_STEP_SUMMARY
+          echo "- **Docker Images**:" >> $GITHUB_STEP_SUMMARY
+          echo "  - [\`openpolicyagent/opa:${DOCKER_TAG}-static\`](https://hub.docker.com/r/openpolicyagent/opa/tags?name=${DOCKER_TAG}-static)" >> $GITHUB_STEP_SUMMARY
+          echo "  - [\`openpolicyagent/opa:${DOCKER_TAG}-envoy\`](https://hub.docker.com/r/openpolicyagent/opa/tags?name=${DOCKER_TAG}-envoy)" >> $GITHUB_STEP_SUMMARY
+
+  govulncheck-latest-release:
+    name: Go vulnerability check (latest release)
+    runs-on: ubuntu-24.04
+    needs: fetch-release-info
+    steps:
+      - name: Check out latest release
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.fetch-release-info.outputs.release_tag }}
+
+      - id: go_version
+        name: Read go version
+        run: echo "go_version=$(cat .go-version)" >> $GITHUB_OUTPUT
+
+      - name: Install Go (${{ steps.go_version.outputs.go_version }})
+        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+        with:
+          go-version: ${{ steps.go_version.outputs.go_version }}
+
+      - run: go install golang.org/x/vuln/cmd/govulncheck@latest
+      - run: govulncheck ./...
+
+      - name: Slack Notification
+        uses: 8398a7/action-slack@77eaa4f1c608a7d68b38af4e3f739dcd8cba273e # v3.19.0
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_NOTIFICATION_WEBHOOK }}
+        if: ${{ failure() && env.SLACK_WEBHOOK_URL }}
+        with:
+          status: ${{ job.status }}
+          fields: repo,workflow
+          text: 'Vulnerabilities found in latest release: ${{ needs.fetch-release-info.outputs.release_tag }}'
+
+  trivy-scan-release-images:
+    name: Trivy security scan (release images)
+    runs-on: ubuntu-24.04
+    needs: fetch-release-info
+    steps:
+      - name: Run Trivy scan on static image
+        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
+        with:
+          image-ref: 'openpolicyagent/opa:${{ needs.fetch-release-info.outputs.docker_tag }}-static'
+          format: table
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: os,library
+          severity: CRITICAL,HIGH
+        env:
+          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
+
+      - name: Run Trivy scan on envoy image
+        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
+        with:
+          image-ref: 'openpolicyagent/opa:${{ needs.fetch-release-info.outputs.docker_tag }}-envoy'
+          format: table
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: os,library
+          severity: CRITICAL,HIGH
+        env:
+          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
+
+      - name: Slack Notification
+        uses: 8398a7/action-slack@77eaa4f1c608a7d68b38af4e3f739dcd8cba273e # v3.19.0
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_NOTIFICATION_WEBHOOK }}
+        if: ${{ failure() && env.SLACK_WEBHOOK_URL }}
+        with:
+          status: ${{ job.status }}
+          fields: repo,workflow
+          text: 'Image vulnerabilities found in latest release: ${{ needs.fetch-release-info.outputs.release_tag }}'
+
+  trivy-scan-release-repo:
+    name: Trivy security scan (latest release repo)
+    runs-on: ubuntu-24.04
+    needs: fetch-release-info
+    steps:
+      - name: Checkout latest release
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.fetch-release-info.outputs.release_tag }}
+
+      - name: Run Trivy scan on repo
+        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
+        with:
+          scan-type: fs
+          format: table
+          exit-code: '1'
+          ignore-unfixed: true
+          skip-dirs: vendor/
+          severity: CRITICAL,HIGH
+        env:
+          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
+
+      - name: Slack Notification
+        uses: 8398a7/action-slack@77eaa4f1c608a7d68b38af4e3f739dcd8cba273e # v3.19.0
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_NOTIFICATION_WEBHOOK }}
+        if: ${{ failure() && env.SLACK_WEBHOOK_URL }}
+        with:
+          status: ${{ job.status }}
+          fields: repo,workflow
+          text: 'Repository vulnerabilities found in latest release: ${{ needs.fetch-release-info.outputs.release_tag }}'


### PR DESCRIPTION
This is almost what do in nightlies, but:

1. Not pulling docker images, trivy can do that -- we don't deal with changing tags here (latest, edge), but concrete ones that don't get overwritten in dockerhub ever.
2. It's also checking the envoy-plugin image, because it felt like an OK thing to include here.
3. It's a different, since we don't want nightly to turn red when there is a vulnerability in the latest release, it's two separate concerns.
