### PR TITLE
perf: Allocate less in array unification

### DIFF
--- a/v1/topdown/eval_bench_test.go
+++ b/v1/topdown/eval_bench_test.go
@@ -1,0 +1,20 @@
+package topdown_test
+
+import (
+	"testing"
+
+	"github.com/open-policy-agent/opa/v1/ast"
+	"github.com/open-policy-agent/opa/v1/topdown"
+)
+
+func BenchmarkBiunifyArrays(b *testing.B) {
+	q := topdown.NewQuery(ast.MustParseBody("[1,x,3] = [y,5,6]"))
+
+	ctx := b.Context()
+
+	for b.Loop() {
+		if _, err := q.Run(ctx); err != nil {
+			b.Fatalf("Query failed: %v", err)
+		}
+	}
+}


### PR DESCRIPTION
Surprisingly, this sailed up as the major source of B/op in the Regal linting itself benchmark. I guess we never paid attention to it in the past as there were many worse culprits.

With help from @tsandall we tracked this down to Regal's frequent use of walk, and how that'd unify the path-value array. Not sure if there are any other noteworthy scenarios that lead on to this path, but at least us `walk` enthusiasts get to start the weekend in the best possible way.

No surprises wrt the fix here. Just cram everything into a single struct that can be reused across requests via a sync pool. Not particularly elegant, but fairly limited, so I hope to get this in even if the impact should be minimal outside of `walk` heavy integrations.

RegalLintingItself benchmark, main vs change. Ns/op and # allocs largely unchanged, while the difference in B/op is rather massive for a simple change!
```
348015056 ns/op	1260364874 B/op	31868705 allocs/op
343963417 ns/op	1122163613 B/op	31874931 allocs/op
```