### PR TITLE
ci: Harden and update all GH Actions workflows.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,8 @@ updates:
           - "*"
         exclude-patterns:
           - "go.opentelemetry.io/*"
+    cooldown:
+      default-days: 7
   - package-ecosystem: npm
     directory: /e2e/api/compile/prisma
     schedule:
@@ -23,6 +25,8 @@ updates:
       e2e/prisma:
         patterns:
           - "*"
+    cooldown:
+      default-days: 7
   - package-ecosystem: github-actions
     directory: /
     schedule:
@@ -31,3 +35,5 @@ updates:
       gha-dependencies:
         patterns:
           - "*"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
     # Check what types of changes this PR contains
   check-changes:
@@ -17,6 +20,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Check for file changes
         id: changes
         run: |
@@ -72,6 +76,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: opa
+          persist-credentials: false
       - id: go_version
         name: Read go version
         run: echo "go_version=$(cat .go-version)" >> $GITHUB_OUTPUT
@@ -104,6 +109,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: benchmarks
+          persist-credentials: false
       - name: Install Node
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,6 +13,7 @@ name: "CodeQL"
 
 on:
   push:
+    # zizmor: ignore[cache-poisoning] This workflow publishes no artifacts.
     branches: [ main, release-* ]
 
 permissions:
@@ -37,6 +38,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     - id: go_version
       name: Read go version

--- a/.github/workflows/docs-update.yaml
+++ b/.github/workflows/docs-update.yaml
@@ -16,6 +16,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           token: ${{ secrets.GH_PUSH_TOKEN }}
+          persist-credentials: false
 
       - name: Get latest Regal release
         id: latest
@@ -36,35 +37,44 @@ jobs:
       - name: Check if update needed
         id: check
         run: |
-          if [ "${{ steps.latest.outputs.version }}" = "${{ steps.current.outputs.version }}" ]; then
+          if [ "${STEPS_LATEST_OUTPUTS_VERSION}" = "${STEPS_CURRENT_OUTPUTS_VERSION}" ]; then
             echo "Already at latest version, no update needed"
             echo "needed=false" >> $GITHUB_OUTPUT
           else
-            echo "Update needed: ${{ steps.current.outputs.version }} -> ${{ steps.latest.outputs.version }}"
+            echo "Update needed: ${STEPS_CURRENT_OUTPUTS_VERSION} -> ${STEPS_LATEST_OUTPUTS_VERSION}"
             echo "needed=true" >> $GITHUB_OUTPUT
           fi
+        env:
+          STEPS_LATEST_OUTPUTS_VERSION: ${{ steps.latest.outputs.version }}
+          STEPS_CURRENT_OUTPUTS_VERSION: ${{ steps.current.outputs.version }}
 
       - name: Check if branch already exists
         if: steps.check.outputs.needed == 'true'
         run: |
-          BRANCH_NAME="update-regal-${{ steps.latest.outputs.version }}"
+          BRANCH_NAME="update-regal-${STEPS_LATEST_OUTPUTS_VERSION}"
           if git ls-remote --exit-code --heads origin "$BRANCH_NAME" >/dev/null 2>&1; then
             echo "::error::Branch '$BRANCH_NAME' already exists. A PR for this version may already be open."
             exit 1
           fi
           echo "Branch '$BRANCH_NAME' does not exist, proceeding with update"
+        env:
+          STEPS_LATEST_OUTPUTS_VERSION: ${{ steps.latest.outputs.version }}
 
       - name: Update imported.json
         if: steps.check.outputs.needed == 'true'
         run: |
-          jq --arg version "${{ steps.latest.outputs.version }}" '.regal = $version' docs/imported.json > docs/imported.json.tmp
+          jq --arg version "${STEPS_LATEST_OUTPUTS_VERSION}" '.regal = $version' docs/imported.json > docs/imported.json.tmp
           mv docs/imported.json.tmp docs/imported.json
+        env:
+          STEPS_LATEST_OUTPUTS_VERSION: ${{ steps.latest.outputs.version }}
 
       - name: Run import script
         if: steps.check.outputs.needed == 'true'
         run: |
           cd docs
-          VERSION=${{ steps.latest.outputs.version }} ./bin/import-regal-docs.sh
+          VERSION=${STEPS_LATEST_OUTPUTS_VERSION} ./bin/import-regal-docs.sh
+        env:
+          STEPS_LATEST_OUTPUTS_VERSION: ${{ steps.latest.outputs.version }}
 
       - name: Check for changes
         if: steps.check.outputs.needed == 'true'
@@ -87,23 +97,28 @@ jobs:
       - name: Create branch and commit
         if: steps.check.outputs.needed == 'true' && steps.changes.outputs.has_changes == 'true'
         run: |
-          BRANCH_NAME="update-regal-${{ steps.latest.outputs.version }}"
+          BRANCH_NAME="update-regal-${STEPS_LATEST_OUTPUTS_VERSION}"
           git checkout -b "$BRANCH_NAME"
           git add -A
-          git commit -s -m "docs: Update Regal docs to ${{ steps.latest.outputs.version }}"
+          git commit -s -m "docs: Update Regal docs to ${STEPS_LATEST_OUTPUTS_VERSION}"
+        env:
+          STEPS_LATEST_OUTPUTS_VERSION: ${{ steps.latest.outputs.version }}
 
       - name: Push branch
         if: steps.check.outputs.needed == 'true' && steps.changes.outputs.has_changes == 'true'
         run: |
-          BRANCH_NAME="update-regal-${{ steps.latest.outputs.version }}"
+          BRANCH_NAME="update-regal-${STEPS_LATEST_OUTPUTS_VERSION}"
           git push origin "$BRANCH_NAME"
+        env:
+          STEPS_LATEST_OUTPUTS_VERSION: ${{ steps.latest.outputs.version }}
 
       - name: Create pull request
         if: steps.check.outputs.needed == 'true' && steps.changes.outputs.has_changes == 'true'
         env:
           GH_TOKEN: ${{ secrets.GH_PUSH_TOKEN }}
+          STEPS_LATEST_OUTPUTS_VERSION: ${{ steps.latest.outputs.version }}
         run: |
-          VERSION="${{ steps.latest.outputs.version }}"
+          VERSION="${STEPS_LATEST_OUTPUTS_VERSION}"
           gh pr create \
             --title "docs: Update Regal docs to $VERSION" \
             --body "$(cat <<EOF

--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -16,6 +16,8 @@ jobs:
       issues: write # required for peter-evans/create-issue-from-file
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     - name: Link Checker
       id: lychee

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -14,18 +14,22 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Test with Race Detector
         run: CGO_ENABLED=1 make ci-go-race-detector
 
       - name: Slack Notification
-        uses: 8398a7/action-slack@77eaa4f1c608a7d68b38af4e3f739dcd8cba273e # v3.19.0
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_NOTIFICATION_WEBHOOK }}
-        if: ${{ failure() && env.SLACK_WEBHOOK_URL }}
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        if: ${{ failure() && secrets.SLACK_NOTIFICATION_WEBHOOK != '' }}
         with:
-          status: ${{ job.status }}
-          fields: repo,workflow
+          webhook: ${{ secrets.SLACK_NOTIFICATION_WEBHOOK }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "Workflow `${{ github.workflow }}` in `${{ github.repository }}` failed with status: ${{ job.status }}"
+            }
 
   native-fuzzer:
     name: Go Fuzzer (native)
@@ -33,6 +37,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - id: go_version
         name: Read go version
@@ -51,13 +57,15 @@ jobs:
         run: find ast/testdata/fuzz ! -name '*.stmt' ! -type d -print -exec cat {} \;
 
       - name: Slack Notification
-        uses: 8398a7/action-slack@77eaa4f1c608a7d68b38af4e3f739dcd8cba273e # v3.19.0
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_NOTIFICATION_WEBHOOK }}
-        if: ${{ failure() && env.SLACK_WEBHOOK_URL }}
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        if: ${{ failure() && secrets.SLACK_NOTIFICATION_WEBHOOK != '' }}
         with:
-          status: ${{ job.status }}
-          fields: repo,workflow
+          webhook: ${{ secrets.SLACK_NOTIFICATION_WEBHOOK }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "Workflow `${{ github.workflow }}` in `${{ github.repository }}` failed with status: ${{ job.status }}"
+            }
 
   go-perf:
     name: Go Perf
@@ -65,6 +73,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Benchmark Test Golang
         run: make ci-go-perf
@@ -73,13 +83,15 @@ jobs:
           DOCKER_RUNNING: 0
 
       - name: Slack Notification
-        uses: 8398a7/action-slack@77eaa4f1c608a7d68b38af4e3f739dcd8cba273e # v3.19.0
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_NOTIFICATION_WEBHOOK }}
-        if: ${{ failure() && env.SLACK_WEBHOOK_URL }}
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        if: ${{ failure() && secrets.SLACK_NOTIFICATION_WEBHOOK != '' }}
         with:
-          status: ${{ job.status }}
-          fields: repo,workflow
+          webhook: ${{ secrets.SLACK_NOTIFICATION_WEBHOOK }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "Workflow `${{ github.workflow }}` in `${{ github.repository }}` failed with status: ${{ job.status }}"
+            }
 
   trivy-scan-image:
     name: Trivy security scan image
@@ -87,6 +99,8 @@ jobs:
     steps:
       - name: Checkout code # needed for .trivyignore file
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - run: "docker pull openpolicyagent/opa:edge-static"
 
@@ -105,13 +119,15 @@ jobs:
           TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
 
       - name: Slack Notification
-        uses: 8398a7/action-slack@77eaa4f1c608a7d68b38af4e3f739dcd8cba273e # v3.19.0
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_NOTIFICATION_WEBHOOK }}
-        if: ${{ failure() && env.SLACK_WEBHOOK_URL }}
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        if: ${{ failure() && secrets.SLACK_NOTIFICATION_WEBHOOK != '' }}
         with:
-          status: ${{ job.status }}
-          fields: repo,workflow
+          webhook: ${{ secrets.SLACK_NOTIFICATION_WEBHOOK }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "Workflow `${{ github.workflow }}` in `${{ github.repository }}` failed with status: ${{ job.status }}"
+            }
 
   trivy-scan-repo:
     name: Trivy security scan repo
@@ -119,6 +135,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       # Equivalent to:
       # $ trivy fs .
@@ -135,19 +153,23 @@ jobs:
           TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
 
       - name: Slack Notification
-        uses: 8398a7/action-slack@77eaa4f1c608a7d68b38af4e3f739dcd8cba273e # v3.19.0
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_NOTIFICATION_WEBHOOK }}
-        if: ${{ failure() && env.SLACK_WEBHOOK_URL }}
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        if: ${{ failure() && secrets.SLACK_NOTIFICATION_WEBHOOK != '' }}
         with:
-          status: ${{ job.status }}
-          fields: repo,workflow
+          webhook: ${{ secrets.SLACK_NOTIFICATION_WEBHOOK }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "Workflow `${{ github.workflow }}` in `${{ github.repository }}` failed with status: ${{ job.status }}"
+            }
 
   govulncheck:
     name: Go vulnerability check
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - id: go_version
         name: Read go version
         run: echo "go_version=$(cat .go-version)" >> $GITHUB_OUTPUT
@@ -161,13 +183,15 @@ jobs:
       - run: govulncheck ./...
 
       - name: Slack Notification
-        uses: 8398a7/action-slack@77eaa4f1c608a7d68b38af4e3f739dcd8cba273e # v3.19.0
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_NOTIFICATION_WEBHOOK }}
-        if: ${{ failure() && env.SLACK_WEBHOOK_URL }}
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        if: ${{ failure() && secrets.SLACK_NOTIFICATION_WEBHOOK != '' }}
         with:
-          status: ${{ job.status }}
-          fields: repo,workflow
+          webhook: ${{ secrets.SLACK_NOTIFICATION_WEBHOOK }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "Workflow `${{ github.workflow }}` in `${{ github.repository }}` failed with status: ${{ job.status }}"
+            }
 
   go-get-test:
     name: Go Get Smoke Test
@@ -175,6 +199,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - id: go_version
         name: Read go version
@@ -206,10 +232,12 @@ jobs:
         timeout-minutes: 10
 
       - name: Slack Notification
-        uses: 8398a7/action-slack@77eaa4f1c608a7d68b38af4e3f739dcd8cba273e # v3.19.0
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_NOTIFICATION_WEBHOOK }}
-        if: ${{ failure() && env.SLACK_WEBHOOK_URL }}
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        if: ${{ failure() && secrets.SLACK_NOTIFICATION_WEBHOOK != '' }}
         with:
-          status: ${{ job.status }}
-          fields: repo,workflow
+          webhook: ${{ secrets.SLACK_NOTIFICATION_WEBHOOK }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "Workflow `${{ github.workflow }}` in `${{ github.repository }}` failed with status: ${{ job.status }}"
+            }

--- a/.github/workflows/post-merge.yaml
+++ b/.github/workflows/post-merge.yaml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           token: ${{ secrets.GH_PUSH_TOKEN }} # required to push to protected branch below
+          persist-credentials: true
 
       - name: Generate
         run: make clean generate docs-generate-cli-docs
@@ -78,6 +79,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Unit Test Golang
         run: make ci-go-test-coverage
@@ -93,6 +96,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+          persist-credentials: false
 
       - name: Git Describe
         run: git describe --tags
@@ -137,6 +141,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+          persist-credentials: false
 
       - name: Git Describe
         run: git describe --tags
@@ -170,6 +175,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Test
         run: make ci-release-test
@@ -204,6 +211,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Build and Push opa-wasm-builder
         env:
@@ -220,5 +229,7 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Run Smoke Test
         run: make -C docs smoke-test

--- a/.github/workflows/post-tag.yaml
+++ b/.github/workflows/post-tag.yaml
@@ -1,4 +1,7 @@
 name: Post Tag
+# Note: Because this workflow builds and publishes release
+# artifacts, we intentionally disable caching to prevent
+# cache poisoning attacks during the builds.
 
 on:
   push:
@@ -16,7 +19,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          token: ${{ secrets.GH_PUSH_TOKEN }}
+          persist-credentials: false
 
       - name: Generate
         run: make clean generate
@@ -31,6 +34,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+          persist-credentials: false
 
       - id: go_version
         name: Read go version
@@ -39,9 +43,11 @@ jobs:
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:
           go-version: ${{ steps.go_version.outputs.go_version }}
+          cache: false
       - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
         with:
           version: '0.15.2'
+          use-cache: false
 
       - name: Git Describe
         run: git describe --tags
@@ -73,6 +79,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+          persist-credentials: false
 
       - name: Git Describe
         run: git describe --tags
@@ -85,6 +92,7 @@ jobs:
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:
           go-version: ${{ steps.go_version.outputs.go_version }}
+          cache: false
 
       - name: Build Darwin
         run: |
@@ -99,7 +107,7 @@ jobs:
           name: binaries-darwin
           path: _release
 
-  build:
+  publish-release:
     name: Push Latest Release
     needs: [release-build, release-build-darwin]
     runs-on: ubuntu-24.04
@@ -108,6 +116,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set TAG_NAME in Environment
         # Subsequent jobs will be have the computed tag name

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -21,12 +21,15 @@ jobs:
       wasm: ${{ steps.changes.outputs.wasm }}
       docs: ${{ steps.changes.outputs.docs }}
       rego: ${{ steps.changes.outputs.rego }}
+      yaml: ${{ steps.changes.outputs.yaml }}
     steps:
     - name: Check out repository code
-      uses: actions/checkout@v6.0.2
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     - name: Download OPA
-      uses: open-policy-agent/setup-opa@87c881550699b0257d7b7aeb8c33019d70bae4a2 # v2.3.0
+      uses: open-policy-agent/setup-opa@950f159a49aa91f9323f36f1de81c7f6b5de9576 # v2.3.0
       with:
         version: latest
 
@@ -40,17 +43,18 @@ jobs:
         echo "wasm=true" >> $GITHUB_OUTPUT
         echo "docs=true" >> $GITHUB_OUTPUT
         echo "rego=true" >> $GITHUB_OUTPUT
+        echo "yaml=true" >> $GITHUB_OUTPUT
 
         if ! curl -s -o changed_files.json -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
           "https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files"; then
           echo "Error: Failed to fetch changed files from GitHub API"
-          echo "Defaulting to running all checks (go=true, wasm=true, docs=true, rego=true)"
+          echo "Defaulting to running all checks (go=true, wasm=true, docs=true, rego=true, yaml=true)"
           exit 0
         fi
 
         if [ ! -s changed_files.json ]; then
           echo "Warning: No changed files found"
-          echo "Defaulting to running all checks (go=true, wasm=true, docs=true, rego=true)"
+          echo "Defaulting to running all checks (go=true, wasm=true, docs=true, rego=true, yaml=true)"
           exit 0
         fi
 
@@ -67,17 +71,20 @@ jobs:
         wasm_result=$(jq -r '.changes.wasm // false' opa_result.json)
         docs_result=$(jq -r '.changes.docs // false' opa_result.json)
         rego_result=$(jq -r '.changes.rego // false' opa_result.json)
+        yaml_result=$(jq -r '.changes.rego // false' opa_result.json)
 
         echo "go=${go_result}" >> $GITHUB_OUTPUT
         echo "wasm=${wasm_result}" >> $GITHUB_OUTPUT
         echo "docs=${docs_result}" >> $GITHUB_OUTPUT
         echo "rego=${rego_result}" >> $GITHUB_OUTPUT
+        echo "yaml=${yaml_result}" >> $GITHUB_OUTPUT
 
         echo "Final outputs:"
         echo "  go=${go_result}"
         echo "  wasm=${wasm_result}"
         echo "  docs=${docs_result}"
         echo "  rego=${rego_result}"
+        echo "  yaml=${yaml_result}"
 
   # All jobs essentially re-create the `ci-release-test` make target, but are split
   # up for parallel runners for faster PR feedback and a nicer UX.
@@ -89,6 +96,8 @@ jobs:
     steps:
     - name: Check out code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     - name: Generate
       run: make clean generate
@@ -140,6 +149,8 @@ jobs:
     steps:
     - name: Check out code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     - id: go_version
       name: Read go version
@@ -189,6 +200,8 @@ jobs:
     steps:
     - name: Check out code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     - id: go_version
       name: Read go version
@@ -222,6 +235,8 @@ jobs:
     steps:
     - name: Check out code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     - name: Golang Style and Lint Check
       run: make check
@@ -231,16 +246,32 @@ jobs:
     name: YAML Lint
     runs-on: ubuntu-24.04
     needs: check-changes
-    if: ${{ needs.check-changes.outputs.go == 'true' }}
+    if: ${{ needs.check-changes.outputs.yaml == 'true' }}
     steps:
     - name: Check out code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     - name: YAML Style and Lint Check
       run: make check-yaml-tests
       timeout-minutes: 30
       env:
         YAML_LINT_FORMAT: github
+
+  gh-actions-lint:
+    name: Github Actions Lint
+    runs-on: ubuntu-24.04
+    needs: check-changes
+    if: ${{ needs.check-changes.outputs.yaml == 'true' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@0dce2577a4760a2749d8cfb7a84b7d5585ebcb7d # v0.5.0
 
   wasm:
     name: WASM
@@ -250,6 +281,8 @@ jobs:
     steps:
     - name: Check out code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     - name: Download generated artifacts
       uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
@@ -274,6 +307,8 @@ jobs:
     steps:
     - name: Check out code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     - name: Download generated artifacts
       uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
@@ -294,6 +329,8 @@ jobs:
     steps:
     - name: Check out code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     - name: Download generated artifacts
       uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
@@ -313,6 +350,8 @@ jobs:
     steps:
     - name: Check out code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     - name: Set up QEMU
       uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
@@ -368,6 +407,8 @@ jobs:
     steps:
     - name: Check out code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     - name: Install Go
       uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
@@ -411,6 +452,8 @@ jobs:
         version: ["1.25.7"]
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
     - name: Download generated artifacts
       uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
       with:
@@ -434,6 +477,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     - name: Download OPA
       uses: open-policy-agent/setup-opa@950f159a49aa91f9323f36f1de81c7f6b5de9576 # v2.3.0
@@ -470,6 +515,8 @@ jobs:
     steps:
     - name: Check out code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     - name: Build docs
       run: make docs-install docs-build
@@ -482,6 +529,8 @@ jobs:
     steps:
     - name: Check out code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     - name: Check docs formatting
       run: make docs-install docs-fmt-check
@@ -494,6 +543,8 @@ jobs:
     steps:
     - name: Check out code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     - name: Lint docs
       run: make docs-install docs-lint-check
@@ -506,6 +557,8 @@ jobs:
     steps:
     - name: Check out code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     - name: Check markdown linting
       run: make docs-install docs-markdownlint-check
@@ -518,6 +571,8 @@ jobs:
     steps:
     - name: Check out code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     - name: Install Vale
       run: |
@@ -543,6 +598,7 @@ jobs:
       go-test,
       go-lint,
       yaml-lint,
+      gh-actions-lint,
       wasm,
       check-generated,
       race-detector,
@@ -560,12 +616,14 @@ jobs:
     steps:
     - name: Check out code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
     - name: Download OPA
       uses: open-policy-agent/setup-opa@950f159a49aa91f9323f36f1de81c7f6b5de9576 # v2.3.0
       with:
         version: edge
     - name: Check job results
-      run: |
+      run: | # zizmor: ignore[template-injection] The 'needs' var is controlled by us.
         # Create the input file with all job results
         echo '${{ toJSON(needs) }}' > input.json
 

--- a/.github/workflows/release-vulnerability-check.yaml
+++ b/.github/workflows/release-vulnerability-check.yaml
@@ -40,6 +40,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ needs.fetch-release-info.outputs.release_tag }}
+          persist-credentials: false
 
       - id: go_version
         name: Read go version
@@ -54,14 +55,15 @@ jobs:
       - run: govulncheck ./...
 
       - name: Slack Notification
-        uses: 8398a7/action-slack@77eaa4f1c608a7d68b38af4e3f739dcd8cba273e # v3.19.0
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_NOTIFICATION_WEBHOOK }}
-        if: ${{ failure() && env.SLACK_WEBHOOK_URL }}
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        if: ${{ failure() && secrets.SLACK_NOTIFICATION_WEBHOOK != '' }}
         with:
-          status: ${{ job.status }}
-          fields: repo,workflow
-          text: 'Vulnerabilities found in latest release: ${{ needs.fetch-release-info.outputs.release_tag }}'
+          webhook: ${{ secrets.SLACK_NOTIFICATION_WEBHOOK }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "Vulnerabilities found in latest release: ${{ needs.fetch-release-info.outputs.release_tag }}\nWorkflow `${{ github.workflow }}` in `${{ github.repository }}` failed with status: ${{ job.status }}"
+            }
 
   trivy-scan-release-images:
     name: Trivy security scan (release images)
@@ -93,14 +95,15 @@ jobs:
           TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
 
       - name: Slack Notification
-        uses: 8398a7/action-slack@77eaa4f1c608a7d68b38af4e3f739dcd8cba273e # v3.19.0
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_NOTIFICATION_WEBHOOK }}
-        if: ${{ failure() && env.SLACK_WEBHOOK_URL }}
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        if: ${{ failure() && secrets.SLACK_NOTIFICATION_WEBHOOK != '' }}
         with:
-          status: ${{ job.status }}
-          fields: repo,workflow
-          text: 'Image vulnerabilities found in latest release: ${{ needs.fetch-release-info.outputs.release_tag }}'
+          webhook: ${{ secrets.SLACK_NOTIFICATION_WEBHOOK }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "Image vulnerabilities found in latest release: ${{ needs.fetch-release-info.outputs.release_tag }}\nWorkflow `${{ github.workflow }}` in `${{ github.repository }}` failed with status: ${{ job.status }}"
+            }
 
   trivy-scan-release-repo:
     name: Trivy security scan (latest release repo)
@@ -111,6 +114,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ needs.fetch-release-info.outputs.release_tag }}
+          persist-credentials: false
 
       - name: Run Trivy scan on repo
         uses: aquasecurity/trivy-action@c1824fd6edce30d7ab345a9989de00bbd46ef284 # 0.34.0
@@ -125,11 +129,12 @@ jobs:
           TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
 
       - name: Slack Notification
-        uses: 8398a7/action-slack@77eaa4f1c608a7d68b38af4e3f739dcd8cba273e # v3.19.0
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_NOTIFICATION_WEBHOOK }}
-        if: ${{ failure() && env.SLACK_WEBHOOK_URL }}
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        if: ${{ failure() && secrets.SLACK_NOTIFICATION_WEBHOOK != '' }}
         with:
-          status: ${{ job.status }}
-          fields: repo,workflow
-          text: 'Repository vulnerabilities found in latest release: ${{ needs.fetch-release-info.outputs.release_tag }}'
+          webhook: ${{ secrets.SLACK_NOTIFICATION_WEBHOOK }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "Repository vulnerabilities found in latest release: ${{ needs.fetch-release-info.outputs.release_tag }}\nWorkflow `${{ github.workflow }}` in `${{ github.repository }}` failed with status: ${{ job.status }}"
+            }

--- a/build/policy/pr-check/pr_check.rego
+++ b/build/policy/pr-check/pr_check.rego
@@ -34,6 +34,11 @@ wasm_change_prefixes := [
 	"v1/ir",
 ]
 
+yaml_change_suffixes := [
+	".yaml",
+	".yml",
+]
+
 rego_and_wasm_change_root_files := ["Makefile"]
 
 docs_root_files := [
@@ -91,4 +96,9 @@ changes["rego"] if {
 } else if {
 	some changed_file in input
 	changed_file.filename in rego_and_wasm_change_root_files
+}
+
+changes["yaml"] if {
+	some changed_file in input
+	strings.any_suffix_match(changed_file.filename, yaml_change_suffixes)
 }

--- a/build/policy/pr-check/pr_check_test.rego
+++ b/build/policy/pr-check/pr_check_test.rego
@@ -41,6 +41,12 @@ example_docs_and_go_root_changelist := [
 	{"filename": "capabilities.json"},
 ]
 
+example_gh_actions_changelist := [
+	{"filename": "wasm/Makefile"},
+	{"filename": "v1/rego/testdata/ast.json"},
+	{"filename": ".github/workflows/pull-request.yaml"},
+]
+
 test_run_docs_check_expect if {
 	pr_check.changes.docs with input as example_docs_changelist
 }
@@ -61,6 +67,10 @@ test_run_rego_tests_expect if {
 	pr_check.changes.rego with input as example_rego_changelist
 }
 
+test_run_yaml_tests_expect if {
+	pr_check.changes.yaml with input as example_gh_actions_changelist
+}
+
 test_run_docs_not_go_tests_expect if {
 	pr_check.changes.docs with input as example_docs_exception_changelist
 	not pr_check.changes.go with input as example_docs_exception_changelist
@@ -75,10 +85,12 @@ test_run_some_not_others_expect if {
 	not pr_check.changes.docs with input as mixed_bag_changelist
 	pr_check.changes.go with input as mixed_bag_changelist
 	pr_check.changes.wasm with input as mixed_bag_changelist
+	not pr_check.changes.yaml with input as mixed_bag_changelist
 }
 
 test_run_all_tests_expect if {
 	pr_check.changes.docs with input as example_all_checks_root_changelist
 	pr_check.changes.go with input as example_all_checks_root_changelist
 	pr_check.changes.wasm with input as example_all_checks_root_changelist
+	not pr_check.changes.yaml with input as example_all_checks_root_changelist
 }


### PR DESCRIPTION
## What changed?

This PR contains fixes for all findings I saw from the static analysis tool [zizmor](https://docs.zizmor.sh/), and reduces the attack surface available in our GH Actions workflows. Most workflows already were in a good place, but a few of the bigger ones had issues or vectors we could mitigate. I added some tactical linter ignores in places where it made sense to do so.

The biggest changes:
 - **All `checkout` actions now have `persist-credentials: false` where possible**. No sense leaving tokens lying around for ne'er-do-wells to use later.
 - **To protect release builds, the `post-tag` workflow will no longer use the [actions cache](https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching)**. This change is specifically to prevent cache poisoning attacks. This will drive up release publishing times (probably by 3-5+ minutes), but eliminates an attack vector on release builds.
- **Slack alerting steps now use the official [slackapi/slack-github-action](https://github.com/slackapi/slack-github-action) project**. The Slack alert action we were using previously is [archived now](https://github.com/8398a7/action-slack/blob/master/README.md), so it's probably best to shift to the official one.

In the second commit in the patch stack, I've added a new conditionally-triggered CI job for PRs that will run the [zizmor GH Action](https://github.com/zizmorcore/zizmor-action) on the project if YAML changes are detected. I believe in [applying ratchets](https://qntm.org/ratchet) when making patch sets like this one, and this is the ratchet for GH Actions linting.

Note: ~~I will try to get a self-review pass up this afternoon with callouts for the more interesting and finicky bits. I'll want a second pair of eyes on one of the checkout steps in the `post-tag.yml` workflow in particular!~~ 😅 
 - [Self-review comment](https://github.com/open-policy-agent/opa/pull/8356#pullrequestreview-3835891472) 

## How to test?

 - Does this PR go green? (CI still works)
 - Do Nightly and Benchmarks still post Slack updates properly?
   - We can test this with a one-off commit that adds a job that will fail and trigger the Slack automation during normal PR checks.
 - Monitor CI during next release for any issues.

## Related resources

 - [2024/2025 survey of OSS supply chain compromises](https://words.filippo.io/compromise-survey) by Filippo Valsorda (maintainer of Go cryptographic libraries).
   - [Blog post describing Github Actions cache poisoning attacks](https://adnanthekhan.com/2024/05/06/the-monsters-in-your-build-cache-github-actions-cache-poisoning/) by Adnahn Kahn (security researcher).
 - https://github.com/open-policy-agent/opa/pull/8183: The PR where the Rego policy driving conditional job execution checks landed.
 - [Living Off The Pipeline](https://boostsecurityio.github.io/lotp/), a list of [RCE](https://en.wikipedia.org/wiki/Arbitrary_code_execution)-by-design tools that can be used as attack vectors when run on untrusted code.
   - There's some surprising ones here, but I think there's low-hanging fruit for mitigating most of them. Our `pull-request` workflow shouldn't need any radical modifications-- but we may want to flag some of the easier-to-miss things in the future, like altered `//go:generate ...` comments.