### PR TITLE
runtime: Extract runtime info functions to public interface

### DIFF
--- a/cmd/eval.go
+++ b/cmd/eval.go
@@ -21,7 +21,6 @@ import (
 	"github.com/open-policy-agent/opa/cmd/internal/env"
 	fileurl "github.com/open-policy-agent/opa/internal/file/url"
 	pr "github.com/open-policy-agent/opa/internal/presentation"
-	"github.com/open-policy-agent/opa/internal/runtime"
 	"github.com/open-policy-agent/opa/v1/ast"
 	"github.com/open-policy-agent/opa/v1/ast/location"
 	"github.com/open-policy-agent/opa/v1/bundle"
@@ -31,6 +30,7 @@ import (
 	"github.com/open-policy-agent/opa/v1/metrics"
 	"github.com/open-policy-agent/opa/v1/profiler"
 	"github.com/open-policy-agent/opa/v1/rego"
+	"github.com/open-policy-agent/opa/v1/runtime/info"
 	"github.com/open-policy-agent/opa/v1/topdown"
 	"github.com/open-policy-agent/opa/v1/topdown/lineage"
 	"github.com/open-policy-agent/opa/v1/util"
@@ -565,14 +565,14 @@ func setupEval(args []string, params evalCommandParams) (*evalContext, error) {
 		query = args[0]
 	}
 
-	info, err := runtime.Term(runtime.Params{})
+	runtimeInfo, err := info.New()
 	if err != nil {
 		return nil, err
 	}
 
 	regoArgs := []func(*rego.Rego){
 		rego.Query(query),
-		rego.Runtime(info),
+		rego.Runtime(runtimeInfo),
 		rego.SetRegoVersion(params.regoVersion()),
 		rego.StoreReadAST(params.ReadAstValuesFromStore),
 		rego.SkipBundleVerification(true),

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -24,12 +24,12 @@ import (
 
 	"github.com/open-policy-agent/opa/cmd/formats"
 	"github.com/open-policy-agent/opa/cmd/internal/env"
-	"github.com/open-policy-agent/opa/internal/runtime"
 	"github.com/open-policy-agent/opa/v1/ast"
 	"github.com/open-policy-agent/opa/v1/bundle"
 	"github.com/open-policy-agent/opa/v1/compile"
 	"github.com/open-policy-agent/opa/v1/cover"
 	"github.com/open-policy-agent/opa/v1/loader"
+	"github.com/open-policy-agent/opa/v1/runtime/info"
 	"github.com/open-policy-agent/opa/v1/storage"
 	"github.com/open-policy-agent/opa/v1/storage/inmem"
 	"github.com/open-policy-agent/opa/v1/tester"
@@ -380,7 +380,7 @@ func compileAndSetupTests(ctx context.Context, testParams testCommandParams, sto
 		WithUseTypeCheckAnnotations(true).
 		WithRewriteTestRules(testParams.varValues)
 
-	info, err := runtime.Term(runtime.Params{})
+	runtimeInfo, err := info.New()
 	if err != nil {
 		return nil, nil, err
 	}
@@ -416,7 +416,7 @@ func compileAndSetupTests(ctx context.Context, testParams testCommandParams, sto
 		CapturePrintOutput(true).
 		EnableTracing(testParams.verbose || testParams.varValues).
 		SetCoverageQueryTracer(coverTracer).
-		SetRuntime(info).
+		SetRuntime(runtimeInfo).
 		SetModules(modules).
 		SetBundles(bundles).
 		SetTimeout(timeout).

--- a/v1/plugins/bundle/plugin_test.go
+++ b/v1/plugins/bundle/plugin_test.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	"github.com/open-policy-agent/opa/internal/file/archive"
-	"github.com/open-policy-agent/opa/internal/runtime"
 	"github.com/open-policy-agent/opa/v1/ast"
 	"github.com/open-policy-agent/opa/v1/bundle"
 	"github.com/open-policy-agent/opa/v1/config"
@@ -33,6 +32,7 @@ import (
 	"github.com/open-policy-agent/opa/v1/logging"
 	"github.com/open-policy-agent/opa/v1/metrics"
 	"github.com/open-policy-agent/opa/v1/plugins"
+	"github.com/open-policy-agent/opa/v1/runtime/info"
 	"github.com/open-policy-agent/opa/v1/storage"
 	"github.com/open-policy-agent/opa/v1/storage/disk"
 	"github.com/open-policy-agent/opa/v1/storage/inmem"
@@ -570,11 +570,11 @@ func TestPluginOneShotWithAuthzSchemaVerification(t *testing.T) {
 	manager := getTestManager()
 	defer manager.Stop(ctx)
 
-	info, err := runtime.Term(runtime.Params{Config: nil, IsAuthorizationEnabled: true})
+	runtimeInfo, err := info.NewWithOptions(info.Options{Config: nil, IsAuthorizationEnabled: true})
 	if err != nil {
 		t.Fatal(err)
 	}
-	manager.Info = info
+	manager.Info = runtimeInfo
 
 	plugin := New(&Config{}, manager)
 
@@ -684,11 +684,11 @@ func TestPluginOneShotWithAuthzSchemaVerification(t *testing.T) {
 	}
 
 	// disable authorization to ensure bundle activates with bad authz policy
-	info, err = runtime.Term(runtime.Params{Config: nil, IsAuthorizationEnabled: false})
+	runtimeInfo, err = info.NewWithOptions(info.Options{Config: nil, IsAuthorizationEnabled: false})
 	if err != nil {
 		t.Fatal(err)
 	}
-	plugin.manager.Info = info
+	plugin.manager.Info = runtimeInfo
 
 	err = plugin.oneShot(ctx, bundleName, download.Update{Bundle: &b, Metrics: metrics.New()})
 	if err != nil {
@@ -702,11 +702,11 @@ func TestPluginOneShotWithAuthzSchemaVerification(t *testing.T) {
 	}
 
 	// enable authorization but skip type checking of known input schemas
-	info, err = runtime.Term(runtime.Params{Config: nil, IsAuthorizationEnabled: true, SkipKnownSchemaCheck: true})
+	runtimeInfo, err = info.NewWithOptions(info.Options{Config: nil, IsAuthorizationEnabled: true, SkipKnownSchemaCheck: true})
 	if err != nil {
 		t.Fatal(err)
 	}
-	plugin.manager.Info = info
+	plugin.manager.Info = runtimeInfo
 
 	err = plugin.oneShot(ctx, bundleName, download.Update{Bundle: &b, Metrics: metrics.New()})
 	if err != nil {
@@ -736,11 +736,11 @@ func TestPluginOneShotWithAuthzSchemaVerificationNonDefaultAuthzPath(t *testing.
 		t.Fatal(err)
 	}
 
-	info, err := runtime.Term(runtime.Params{Config: nil, IsAuthorizationEnabled: true})
+	runtimeInfo, err := info.NewWithOptions(info.Options{Config: nil, IsAuthorizationEnabled: true})
 	if err != nil {
 		t.Fatal(err)
 	}
-	manager.Info = info
+	manager.Info = runtimeInfo
 
 	plugin := New(&Config{}, manager)
 

--- a/v1/rego/rego_bench_test.go
+++ b/v1/rego/rego_bench_test.go
@@ -6,10 +6,10 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/open-policy-agent/opa/internal/runtime"
 	"github.com/open-policy-agent/opa/v1/ast"
 	"github.com/open-policy-agent/opa/v1/loader"
 	"github.com/open-policy-agent/opa/v1/metrics"
+	"github.com/open-policy-agent/opa/v1/runtime/info"
 	"github.com/open-policy-agent/opa/v1/storage"
 	inmem "github.com/open-policy-agent/opa/v1/storage/inmem/test"
 	"github.com/open-policy-agent/opa/v1/util/test"
@@ -39,7 +39,8 @@ func BenchmarkPartialObjectRuleCrossModule(b *testing.B) {
 				"test/bar.rego": mods[1],
 				"test/baz.rego": mods[2],
 			})
-			info, err := runtime.Term(runtime.Params{})
+
+			runtimeInfo, err := info.New()
 			if err != nil {
 				b.Fatal(err)
 			}
@@ -48,7 +49,7 @@ func BenchmarkPartialObjectRuleCrossModule(b *testing.B) {
 				Query(query),
 				Compiler(compiler),
 				Store(store),
-				Runtime(info),
+				Runtime(runtimeInfo),
 			).PrepareForEval(ctx)
 
 			if err != nil {

--- a/v1/runtime/info/info.go
+++ b/v1/runtime/info/info.go
@@ -2,8 +2,9 @@
 // Use of this source code is governed by an Apache2
 // license that can be found in the LICENSE file.
 
-// Package runtime contains utilities to return runtime information on the OPA instance.
-package runtime
+// Package params provides utilities to create runtime context information for
+// OPA instances.
+package info
 
 import (
 	"os"
@@ -14,22 +15,24 @@ import (
 	"github.com/open-policy-agent/opa/v1/version"
 )
 
-// Params controls the types of runtime information to return.
-type Params struct {
+// Options controls the types of runtime context information to return.
+type Options struct {
 	Config                 []byte
 	IsAuthorizationEnabled bool
 	SkipKnownSchemaCheck   bool
 }
 
-// Term returns the runtime information as an ast.Term object.
-func Term(params Params) (*ast.Term, error) {
+func New() (*ast.Term, error) {
+	return NewWithOptions(Options{})
+}
 
+// NewWithOptions returns the runtime context information as an ast.Term object.
+func NewWithOptions(opts Options) (*ast.Term, error) {
 	obj := ast.NewObject()
 
-	if params.Config != nil {
-
+	if opts.Config != nil {
 		var x any
-		if err := util.Unmarshal(params.Config, &x); err != nil {
+		if err := util.Unmarshal(opts.Config, &x); err != nil {
 			return nil, err
 		}
 
@@ -55,8 +58,8 @@ func Term(params Params) (*ast.Term, error) {
 	obj.Insert(ast.InternedTerm("env"), ast.NewTerm(env))
 	obj.Insert(ast.InternedTerm("version"), ast.StringTerm(version.Version))
 	obj.Insert(ast.InternedTerm("commit"), ast.StringTerm(version.Vcs))
-	obj.Insert(ast.InternedTerm("authorization_enabled"), ast.InternedTerm(params.IsAuthorizationEnabled))
-	obj.Insert(ast.InternedTerm("skip_known_schema_check"), ast.InternedTerm(params.SkipKnownSchemaCheck))
+	obj.Insert(ast.InternedTerm("authorization_enabled"), ast.InternedTerm(opts.IsAuthorizationEnabled))
+	obj.Insert(ast.InternedTerm("skip_known_schema_check"), ast.InternedTerm(opts.SkipKnownSchemaCheck))
 
 	return ast.NewTerm(obj), nil
 }

--- a/v1/runtime/runtime.go
+++ b/v1/runtime/runtime.go
@@ -37,7 +37,6 @@ import (
 	"github.com/open-policy-agent/opa/internal/pathwatcher"
 	"github.com/open-policy-agent/opa/internal/prometheus"
 	"github.com/open-policy-agent/opa/internal/ref"
-	"github.com/open-policy-agent/opa/internal/runtime"
 	initload "github.com/open-policy-agent/opa/internal/runtime/init"
 	"github.com/open-policy-agent/opa/internal/uuid"
 	"github.com/open-policy-agent/opa/internal/versioncheck"
@@ -53,6 +52,7 @@ import (
 	"github.com/open-policy-agent/opa/v1/plugins/logs"
 	metrics_config "github.com/open-policy-agent/opa/v1/plugins/server/metrics"
 	"github.com/open-policy-agent/opa/v1/repl"
+	"github.com/open-policy-agent/opa/v1/runtime/info"
 	"github.com/open-policy-agent/opa/v1/server"
 	"github.com/open-policy-agent/opa/v1/storage"
 	"github.com/open-policy-agent/opa/v1/storage/disk"
@@ -432,7 +432,7 @@ func NewRuntime(ctx context.Context, params Params) (*Runtime, error) {
 
 	isAuthorizationEnabled := params.Authorization != server.AuthorizationOff
 
-	info, err := runtime.Term(runtime.Params{Config: config, IsAuthorizationEnabled: isAuthorizationEnabled, SkipKnownSchemaCheck: params.SkipKnownSchemaCheck})
+	runtimeInfo, err := info.NewWithOptions(info.Options{Config: config, IsAuthorizationEnabled: isAuthorizationEnabled, SkipKnownSchemaCheck: params.SkipKnownSchemaCheck})
 	if err != nil {
 		return nil, err
 	}
@@ -499,7 +499,7 @@ func NewRuntime(ctx context.Context, params Params) (*Runtime, error) {
 	manager, err := plugins.New(config,
 		params.ID,
 		store,
-		plugins.Info(info),
+		plugins.Info(runtimeInfo),
 		plugins.InitBundles(loaded.Bundles),
 		plugins.InitFiles(loaded.Files),
 		plugins.MaxErrors(params.ErrorLimit),

--- a/v1/sdk/opa.go
+++ b/v1/sdk/opa.go
@@ -16,7 +16,6 @@ import (
 	"time"
 
 	"github.com/open-policy-agent/opa/internal/ref"
-	"github.com/open-policy-agent/opa/internal/runtime"
 	"github.com/open-policy-agent/opa/internal/uuid"
 	"github.com/open-policy-agent/opa/v1/ast"
 	"github.com/open-policy-agent/opa/v1/bundle"
@@ -27,6 +26,7 @@ import (
 	"github.com/open-policy-agent/opa/v1/plugins/discovery"
 	"github.com/open-policy-agent/opa/v1/plugins/logs"
 	"github.com/open-policy-agent/opa/v1/rego"
+	"github.com/open-policy-agent/opa/v1/runtime/info"
 	"github.com/open-policy-agent/opa/v1/server"
 	"github.com/open-policy-agent/opa/v1/server/types"
 	"github.com/open-policy-agent/opa/v1/storage"
@@ -162,14 +162,14 @@ func (opa *OPA) Configure(ctx context.Context, opts ConfigOptions) error {
 }
 
 func (opa *OPA) configure(ctx context.Context, bs []byte, ready chan struct{}, block bool) error {
-	info, err := runtime.Term(runtime.Params{Config: opa.config})
+	runtimeInfo, err := info.NewWithOptions(info.Options{Config: opa.config})
 	if err != nil {
 		return err
 	}
 
 	//nolint:prealloc // option list has known initial values, extended with opa.managerOpts
 	opts := []func(*plugins.Manager){
-		plugins.Info(info),
+		plugins.Info(runtimeInfo),
 		plugins.Logger(opa.logger),
 		plugins.ConsoleLogger(opa.console),
 		plugins.WithParserOptions(ast.ParserOptions{RegoVersion: opa.regoVersion}),


### PR DESCRIPTION
This allows me to replicate the OPA test runner in the Regal LS more closely.

https://github.com/open-policy-agent/regal/pull/1888/changes#diff-6a862d98ef36b31df772aeddd4a535899610634ef1f56d36f8ce11a77cc0d729R33-R36 is where this is used in the related Regal PR.

Fixes https://github.com/open-policy-agent/opa/issues/7427