### PR TITLE
compile: Add StringLength to lazy object

### DIFF
--- a/v1/ast/string_length.go
+++ b/v1/ast/string_length.go
@@ -99,6 +99,10 @@ func (o *object) StringLength() (n int) {
 	return n // surrounding {} but also minus last ", "
 }
 
+func (l *lazyObj) StringLength() int {
+	return l.force().(*object).StringLength()
+}
+
 func (ts *TemplateString) StringLength() (n int) {
 	for _, p := range ts.Parts {
 		switch x := p.(type) {

--- a/v1/compile/compile_test.go
+++ b/v1/compile/compile_test.go
@@ -3667,6 +3667,27 @@ func getOptimizer(modules map[string]string, data string, entries []string, root
 	return o
 }
 
+// https://github.com/open-policy-agent/opa/issues/8369
+func TestCompilerOptimizationWithLazyObject(t *testing.T) {
+	files := map[string]string{
+		"data.json": `{ "foo": { "bar": { } } }`,
+	}
+
+	test.WithTestFS(files, true, func(root string, fsys fs.FS) {
+		compiler := New().
+			WithRegoVersion(ast.RegoV1).
+			WithFS(fsys).
+			WithPaths(root).
+			WithOptimizationLevel(1).
+			WithEntrypoints("foo/bar")
+
+		err := compiler.Build(t.Context())
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
 func getModuleFiles(src map[string]string, includeRaw bool, popts ast.ParserOptions) []bundle.ModuleFile {
 
 	keys := util.KeysSorted(src)


### PR DESCRIPTION
This is needed in build -O 1 as I think the optimizer is evaluating the path and making a rule for it, which is then formatted, which is where StringLength is needed.

Fixes https://github.com/open-policy-agent/opa/issues/8369
