### PR TITLE
plugins/rest: add disable_keep_alives config option to reduce idle connections

### DIFF
--- a/v1/plugins/rest/rest.go
+++ b/v1/plugins/rest/rest.go
@@ -52,7 +52,14 @@ type Config struct {
 	Headers                      map[string]string `json:"headers"`
 	AllowInsecureTLS             bool              `json:"allow_insecure_tls,omitempty"`
 	ResponseHeaderTimeoutSeconds *int64            `json:"response_header_timeout_seconds,omitempty"`
-	TLS                          *serverTLSConfig  `json:"tls,omitempty"`
+	// DisableKeepAlives disables HTTP keep-alive connections for this client.
+	// When set to true, every request will open a new TCP connection and
+	// the connection will be closed after the response is received.
+	// This can be useful when OPA is used in environments where the number of
+	// idle connections needs to be minimized, e.g. when frequently polling
+	// bundle servers causes a large number of idle connections to accumulate.
+	DisableKeepAlives bool             `json:"disable_keep_alives,omitempty"`
+	TLS               *serverTLSConfig `json:"tls,omitempty"`
 	Credentials                  struct {
 		Bearer               *bearerAuthPlugin                  `json:"bearer,omitempty"`
 		OAuth2               *oauth2ClientCredentialsAuthPlugin `json:"oauth2,omitempty"`


### PR DESCRIPTION
Fixes #4884

## Problem

When OPA frequently polls bundle servers, each request leaves idle HTTP
keep-alive connections open. In high-frequency polling environments this
can accumulate hundreds of idle connections.

## Solution

Add a `disable_keep_alives` boolean field to the REST service `Config`
struct. When `true`, `net/http.Transport.DisableKeepAlives` is set on
the transport so each request uses a fresh TCP connection that is closed
when the response is received.

## Implementation

- **`Config.DisableKeepAlives`** – new optional JSON field (`disable_keep_alives`)
- **`DefaultRoundTripperClientWithOpts()`** – new function accepting the option
- **`DefaultRoundTripperClient()`** – unchanged signature; delegates to the new function with `false` for full backward compatibility
- All five `NewClient()` implementations (bearer, OAuth2, clientTLS, AWS SigV4, GCP, Azure, etc.) pass `c.DisableKeepAlives` through

## Example Configuration

```yaml
services:
  bundle-server:
    url: https://bundle.example.com
    disable_keep_alives: true   # close connection after each response
```

## Backward Compatibility

Default is `false` — zero-value preserves existing behaviour.

Made with [Cursor](https://cursor.com)