### PR TITLE
rego: disable rule indexing for benchmark

### DIFF
--- a/v1/rego/rego_wasm_bench_test.go
+++ b/v1/rego/rego_wasm_bench_test.go
@@ -299,7 +299,7 @@ func BenchmarkPolicyComplexityTargets(b *testing.B) {
 
 				b.ResetTimer()
 				for range b.N {
-					rs, err := pq.Eval(ctx)
+					rs, err := pq.Eval(ctx, EvalRuleIndexing(false))
 					if err != nil {
 						b.Fatal(err)
 					}


### PR DESCRIPTION
It's not fair to compare Wasm vs Rego with Rego having indexing on the rules in question.
