### PR TITLE
ci: Fix `check-changes` job skipping over YAML changes.

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -71,7 +71,7 @@ jobs:
         wasm_result=$(jq -r '.changes.wasm // false' opa_result.json)
         docs_result=$(jq -r '.changes.docs // false' opa_result.json)
         rego_result=$(jq -r '.changes.rego // false' opa_result.json)
-        yaml_result=$(jq -r '.changes.rego // false' opa_result.json)
+        yaml_result=$(jq -r '.changes.yaml // false' opa_result.json)
 
         echo "go=${go_result}" >> $GITHUB_OUTPUT
         echo "wasm=${wasm_result}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## What changed?

This PR fixes a copy/paste bug from #8356 that resulted in the YAML detection logic of the `check-changes` job setting the wrong result for the job step's `yaml` changes output.

This bug caused downstream jobs to not see that YAML files were altered at all in a PR, and YAML-specific jobs like the linter and zizmor passes would not be run.

An example of the wrong change-detection logic can be seen in the [Actions run](https://github.com/open-policy-agent/opa/actions/runs/22353116835) for @srenatus's recent PR #8368, which altered a YAML file for the Benchmarks job. The YAML linter and zizmor runs were skipped over entirely!

The bug's presence was masked in the original PR because there were also Rego file changes in that PR, which resulted the the final `yaml` output being set to `true`, despite the source for that value being the wrong one.

Thanks @srenatus for calling that weirdness to my attention yesterday!

## Definition of done

 - [x] Does this PR run the YAML linter + zizmor jobs on this PR? (The only change is to YAML files, so it should be detected now.)

## How to test?

 - Observe the GH Actions that run for this YAML-only PR.