### PR TITLE
docs(ecosystem): add Kopa Kubernetes webhook integration

### DIFF
--- a/docs/src/data/ecosystem/entries/kopa.md
+++ b/docs/src/data/ecosystem/entries/kopa.md
@@ -1,0 +1,16 @@
+---
+title: Kopa
+labels:
+  category: containers
+  layer: orchestration
+software:
+- kubernetes
+code:
+- https://github.com/sfreet/kopa
+docs_features:
+  kubernetes:
+    note: Kopa integrates OPA with Kubernetes validating admission webhooks.
+---
+
+Kopa is a Kubernetes validating admission webhook that delegates policy
+decisions to OPA.

--- a/docs/static/img/ecosystem-entry-logos/kopa.svg
+++ b/docs/static/img/ecosystem-entry-logos/kopa.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512">
+  <rect width="512" height="512" rx="96" fill="#0f172a"/>
+  <rect x="56" y="56" width="400" height="400" rx="72" fill="#111827" stroke="#22c55e" stroke-width="12"/>
+  <path d="M160 176h56l40 64 40-64h56l-68 104 72 112h-56l-44-70-44 70h-56l72-112z" fill="#e5e7eb"/>
+  <text x="256" y="444" text-anchor="middle" font-family="Arial, sans-serif" font-size="42" fill="#22c55e">KOPA</text>
+</svg>


### PR DESCRIPTION
## Summary
Add Kopa to the OPA ecosystem directory (Kubernetes integrations).

Kopa is a Python-based Kubernetes validating admission webhook that delegates policy decisions to OPA via REST API.

- Repo: https://github.com/sfreet/kopa
- Docs: https://github.com/sfreet/kopa/blob/main/README.md