### PR TITLE
Fix intermittent plugins manager  deadlock on opa.configure

### DIFF
--- a/v1/sdk/opa.go
+++ b/v1/sdk/opa.go
@@ -243,20 +243,7 @@ func (opa *OPA) configure(ctx context.Context, bs []byte, ready chan struct{}, b
 
 	manager.Register(discovery.Name, d)
 
-	if err := manager.Start(ctx); err != nil {
-		return err
-	}
-
-	if block {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-ready:
-		}
-	}
-
 	opa.mtx.Lock()
-	defer opa.mtx.Unlock()
 
 	// NOTE(tsandall): there is no return value from Stop() and it could block
 	// on async operations (e.g., decision log uploading) so defer the call to
@@ -276,6 +263,20 @@ func (opa *OPA) configure(ctx context.Context, bs []byte, ready chan struct{}, b
 	opa.state.interQueryBuiltinCache = cache.NewInterQueryCacheWithContext(ctx, manager.InterQueryBuiltinCacheConfig())
 	opa.state.interQueryBuiltinValueCache = cache.NewInterQueryValueCache(ctx, manager.InterQueryBuiltinCacheConfig())
 	opa.config = bs
+
+	opa.mtx.Unlock()
+
+	if err := manager.Start(ctx); err != nil {
+		return err
+	}
+
+	if block {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ready:
+		}
+	}
 
 	return nil
 }


### PR DESCRIPTION
After this race condition fix: https://github.com/open-policy-agent/opa/pull/8365 there have been intermittent tests timing out on main, for example: https://github.com/open-policy-agent/opa/actions/runs/22347854238/job/64667233912

The fix added a lock before triggering the `m.registeredTriggers` within the  `manager.onCommit` method, this inadvertently causes a deadlock within `opa.configure`. 

There are two mutxes at play here within `opa.configure` the manager mtx and the opa mtx. If `manager.onCommit` gets triggered just when the configure method is calling `opa.state.interQueryBuiltinCache = cache.NewInterQueryCacheWithContext(ctx, manager.InterQueryBuiltinCacheConfig())` then the deadlock occurs. 

What is happening is that a call to `manager.Start(ctx)` registers the `onCommit` method: https://github.com/open-policy-agent/opa/blob/7cafd621d342798e30237e8833d156fa4facba5b/v1/plugins/plugins.go#L582

And the `onCommit` method calls a registered function that will use the opa mtx, but after the race condition fix it will also control the manager mutex at the same time:
https://github.com/open-policy-agent/opa/blob/b155a3750990eb6db5bf2a5cae876930856259c1/v1/sdk/opa.go#L201-L205 

but at the end of the `opa.configure` method, opa gets the opa mutex and then tries to get the manager mutex when calling `manager.InterQueryBuiltinCacheConfig()`:
https://github.com/open-policy-agent/opa/blob/b155a3750990eb6db5bf2a5cae876930856259c1/v1/sdk/opa.go#L261-L265 

So the opa mutex won't be unlocked until the manager mutex is unlocked but the manager mutex won't unlock until the opa mutex is unlocked.

A messy situation unfortunately. The easiest solution seems to call `manager.Start(ctx)` AFTER setting up the `opa.state`. Then it won't be possible to call `onCommit` quite yet. This failure has happened quite a few times in main, mainly affecting two tests: `TestExecWithBundleRegoVersion` (different test case each time) and `TestFailFlagCases`: https://github.com/open-policy-agent/opa/commits/main/