### PR TITLE
Allow setting OPA_VERSION_CHECK_SERVICE_URL=false

### DIFF
--- a/docs/docs/privacy.md
+++ b/docs/docs/privacy.md
@@ -19,7 +19,7 @@ For the `opa version` command, this feature can be enabled by specifying the
 OPA checks the latest release version by querying the GitHub
 API at `https://api.github.com`. The environment variable
 `OPA_VERSION_CHECK_SERVICE_URL` can be used to configure an alternative service
-URL.
+URL. It can be set to `false` to disable version checking entirely.
 
 Sample HTTP request from OPA to the GitHub API:
 

--- a/internal/versioncheck/versioncheck.go
+++ b/internal/versioncheck/versioncheck.go
@@ -83,6 +83,9 @@ func New(opts Options) (Checker, error) {
 	if url == "" {
 		url = ExternalServiceURL
 	}
+	if url == "false" {
+		return nil, errors.New("version check is disabled with OPA_VERSION_CHECK_SERVICE_URL=false")
+	}
 
 	// Set a generic User-Agent to avoid sending version/platform information about the user's OPA instance.
 	// This ensures we only retrieve version information without transmitting any identifying data.


### PR DESCRIPTION
### Why the changes in this PR are needed?

This PR provides a simple way to disable version check entirely. It's useful for downstream distribution of the `opa` binary (e.g. Linux distros). We don't want users to go download the newer version on GitHub into their system PATH like `/usr/bin` when being noticed of an update.

### Notes to assist PR review:

With this commit, `opa version -c` command errors out, and `opa run` fails the check silently in the background. I don't know whether the approach is appropriate, but it produces the simplest patch.
