### PR TITLE
gha: bump trivy-action

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -113,7 +113,7 @@ jobs:
       # Equivalent to:
       # $ trivy image openpolicyagent/opa:edge-static
       - name: Run Trivy scan on image
-        uses: aquasecurity/trivy-action@e368e328979b113139d6f9068e03accaed98a518 # 0.34.1
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
         with:
           image-ref: 'openpolicyagent/opa:edge-static'
           format: table
@@ -149,7 +149,7 @@ jobs:
       # Equivalent to:
       # $ trivy fs .
       - name: Run Trivy scan on repo
-        uses: aquasecurity/trivy-action@e368e328979b113139d6f9068e03accaed98a518 # 0.34.1
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
         with:
           scan-type: fs
           format: table

--- a/.github/workflows/release-vulnerability-check.yaml
+++ b/.github/workflows/release-vulnerability-check.yaml
@@ -73,7 +73,7 @@ jobs:
     needs: fetch-release-info
     steps:
       - name: Run Trivy scan on static image
-        uses: aquasecurity/trivy-action@e368e328979b113139d6f9068e03accaed98a518 # 0.34.1
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
         with:
           image-ref: 'openpolicyagent/opa:${{ needs.fetch-release-info.outputs.docker_tag }}-static'
           format: table
@@ -85,7 +85,7 @@ jobs:
           TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
 
       - name: Run Trivy scan on envoy image
-        uses: aquasecurity/trivy-action@e368e328979b113139d6f9068e03accaed98a518 # 0.34.1
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
         with:
           image-ref: 'openpolicyagent/opa:${{ needs.fetch-release-info.outputs.docker_tag }}-envoy'
           format: table
@@ -121,7 +121,7 @@ jobs:
           persist-credentials: false
 
       - name: Run Trivy scan on repo
-        uses: aquasecurity/trivy-action@e368e328979b113139d6f9068e03accaed98a518 # 0.34.1
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
         with:
           scan-type: fs
           format: table


### PR DESCRIPTION
dependabot didn't do it because of our configured 7 day cooldown. But hopefully this fixes the workflows that use it.
