### PR TITLE
docs: add Windows development notes to dev reference guide

### DIFF
--- a/docs/docs/contrib-development.md
+++ b/docs/docs/contrib-development.md
@@ -19,7 +19,20 @@ Requirements:
 - GitHub account (if you are contributing)
 - Go (please see the project's [go.mod](https://github.com/open-policy-agent/opa/blob/main/go.mod) file for the current version in use)
 - GNU Make
+- A POSIX-compatible shell (`bash`)
+- A C compiler (e.g., `gcc`) for CGO
 - Python3, pip, `yamllint` (if linting YAML files manually)
+
+## Windows
+
+The build system relies on `bash` shell scripts and GNU Make, which are not available out of the box on Windows. The recommended approach is to use [WSL (Windows Subsystem for Linux)](https://learn.microsoft.com/en-us/windows/wsl/install), which provides a full Linux environment where the standard requirements above apply.
+
+If you prefer to develop without WSL, you can use [MSYS2](https://www.msys2.org/) with the MinGW64 toolchain, which provides `bash`, `make`, and `gcc`. Note the following when using MSYS2/MinGW64:
+
+- Install the MinGW64 variants of GCC, Go, and Make (e.g., `pacman -S mingw-w64-x86_64-gcc mingw-w64-x86_64-go make`).
+- Configure Git to check out files with Unix-style line endings (`git config --global core.autocrlf input`) to avoid test failures caused by `CRLF` vs `LF` differences.
+- A small number of tests may still fail due to Windows path separator differences (`\\` vs `/`). This is expected and should not block development.
+- Some build scripts (e.g., `go:generate` directives in `main.go`) invoke `.sh` files directly. These require `bash` to be in your `PATH`, which MSYS2 provides.
 
 ## Getting Started
 


### PR DESCRIPTION
## Summary

- Add `bash` and `gcc` (for CGO) as explicit requirements in the development reference guide
- Add a Windows section documenting WSL as the recommended approach and MSYS2/MinGW64 as an alternative
- Document known limitations: CRLF line ending issues, path separator test failures, and `go:generate` shell script requirements

Fixes #6635

## Test plan

- [ ] Verify the docs page renders correctly on the OPA documentation site
- [ ] Confirm the MSYS2 package names are accurate for current MinGW64 repos