### PR TITLE
build/generate-extended-cases: Fix testcase loader to use json.Number.

### DIFF
--- a/build/generate-extended-cases/extended_cases.go
+++ b/build/generate-extended-cases/extended_cases.go
@@ -2,6 +2,7 @@ package cases
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -135,7 +136,11 @@ func LoadIrExtendedTestCasesFiltered(filters ...Filters) ([]ExtendedSet, error) 
 		}
 
 		var x ExtendedSet
-		if err := yaml.Unmarshal(f, &x); err != nil {
+		useNumber := yaml.JSONOpt(func(d *json.Decoder) *json.Decoder {
+			d.UseNumber()
+			return d
+		})
+		if err := yaml.Unmarshal(f, &x, useNumber); err != nil {
 			return fmt.Errorf("%s: %w", path, err)
 		}
 


### PR DESCRIPTION
## What changed, and why?

The testcase generator had a bug where very large numbers would be parsed incorrectly, truncating the less-significant digits off their values.

I discovered this was caused by the [YAML library defaulting to parsing all numeric values into floating point numbers](https://pkg.go.dev/sigs.k8s.io/yaml#Unmarshal), which lose precision at larger sizes.

The fix was to provide the YAML unmarshaling function with the appropriate equivalent of [`(*json.Decoder).UseNumber()`](https://pkg.go.dev/encoding/json#Decoder.UseNumber) at the callsite. This causes the YAML library to use [`json.Number`](https://pkg.go.dev/encoding/json#Number) types by default, just as we expect almost everywhere else in Rego.

## How to test?

I couldn't come up with a clean Golang test, but if you run the [testcase generator from Swift OPA](https://github.com/open-policy-agent/swift-opa/blob/main/tools/generate-compliance-tests/main.go), the testcase for `v1/test/cases/testdata/v1/time/test-time-0948.yaml` is particularly instructive.

The source YAML:
```yaml
---
cases:
  - note: time/parse_nanos
    query: data.generated.p = x
    modules: # ...
    input:
      cases: # ...
    want_result:
      - x:
          "1": 1496455200000000000
          "2": -9223372036854775808 # <-- The values we care about.
          "3": 9223372036854775807  # <--
          "4": 1496455200000000000
          "5": 1496455200000000000
          "6": 1496455200000000000
```

The incorrect JSON we see downstream in the [equivalent generated testcase](https://github.com/open-policy-agent/swift-opa/blob/main/ComplianceSuite/Tests/RegoComplianceTests/TestData/v1/time/test-time-0948.json#L37-L48) in Swift OPA's `ComplianceSuite`:
```json
"want_result": [
    {
        "x": {
            "1": 1496455200000000000,
            "2": -9223372036854776000, # <-- Truncation visible.
            "3": 9223372036854776000,  # <--
            "4": 1496455200000000000,
            "5": 1496455200000000000,
            "6": 1496455200000000000
        }
    }
],
```

And after applying this patch (and using a `replace` directive in the appropriate downstream `go.mod`), this is the new JSON:
```json
"want_result": [
    {
        "x": {
            "1": 1496455200000000000,
            "2": -9223372036854775808, # <-- No truncation!
            "3": 9223372036854775807,  # <--
            "4": 1496455200000000000,
            "5": 1496455200000000000,
            "6": 1496455200000000000
        }
    }
],
```