### PR TITLE
Fix type checker match error for objects with set keys

### DIFF
--- a/v1/ast/check.go
+++ b/v1/ast/check.go
@@ -979,7 +979,7 @@ func unifiesObjectsStatic(a, b *types.Object) bool {
 	for _, k := range a.Keys() {
 		tpeB := b.Select(k)
 		if tpeB == nil {
-			if a.DynamicValue() != nil {
+			if a.DynamicValue() != nil || b.DynamicValue() != nil {
 				continue
 			}
 			return false

--- a/v1/ast/check_test.go
+++ b/v1/ast/check_test.go
@@ -2727,6 +2727,30 @@ allow := s if {
     s := sum([1, input.a])
 }`,
 		},
+		// this policy verifies the issue: https://github.com/open-policy-agent/opa/issues/6260
+		{
+			name: "object literal with set keys",
+			policy: `package bin
+
+a := {1, 2, 3, 4}
+
+b := {3, 4, 5}
+
+c := {4, 5, 6}
+
+d := {
+	a: b,
+	[1, 2]: c,
+}
+
+# this results in a compile error due to type mismatch
+output if {
+	d == {
+		[1, 2]: {4, 5, 6},
+		{1, 2, 3, 4}: {3, 4, 5}
+	}
+}`,
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
resolve: https://github.com/open-policy-agent/opa/issues/6260

Check if the target  object (b) has dynamic properties when a static key lookup fails, not just the source object (a). This allows the dynamic value unification in unifiesObjects to handle the compatibility check instead.