### PR TITLE
fix: reachable_paths does not return all reachable paths

### DIFF
--- a/v1/test/cases/testdata/v0/reachable/test-reachable-paths-0422.yaml
+++ b/v1/test/cases/testdata/v0/reachable/test-reachable-paths-0422.yaml
@@ -170,6 +170,37 @@ cases:
   - data: {}
     input_term: '{
         "graph": {
+          "1": [],
+          "2": ["1"],
+          "3": ["2"],
+          "4": ["3", "2"],
+          "5": ["4"]
+        },
+        "initial": ["5"]
+      }'
+    modules:
+      - |
+        package reachable
+
+        p = result {
+          graph.reachable_paths(input.graph, input.initial, result)
+        }
+    note: reachable_paths/shared_ancestor
+    query: data.reachable.p = x
+    want_result:
+      - x:
+          - - "5"
+            - "4"
+            - "2"
+            - "1"
+          - - "5"
+            - "4"
+            - "3"
+            - "2"
+            - "1"
+  - data: {}
+    input_term: '{
+        "graph": {
           "a": ["b"],
           "b": ["nonexistent"],
         },

--- a/v1/test/cases/testdata/v0/reachable/test-reachable-paths-1022.yaml
+++ b/v1/test/cases/testdata/v0/reachable/test-reachable-paths-1022.yaml
@@ -117,11 +117,14 @@ cases:
           - - one
             - five
             - six
+            - nine
 
           - - one
             - five
             - six
-            - nine
+            - seven
+            - eight
+            - three
 
           - - one
             - two

--- a/v1/test/cases/testdata/v1/reachable/test-reachable-paths-0422.yaml
+++ b/v1/test/cases/testdata/v1/reachable/test-reachable-paths-0422.yaml
@@ -119,6 +119,28 @@ cases:
             - c
           - - a
             - c
+  - note: reachable_paths/shared_ancestor
+    query: data.reachable.p = x
+    modules:
+      - |
+        package reachable
+
+        p := result if {
+        	graph.reachable_paths(input.graph, input.initial, result)
+        }
+    data: {}
+    input_term: '{ "graph": { "1": [], "2": ["1"], "3": ["2"], "4": ["3", "2"], "5": ["4"] }, "initial": ["5"] }'
+    want_result:
+      - x:
+          - - "5"
+            - "4"
+            - "2"
+            - "1"
+          - - "5"
+            - "4"
+            - "3"
+            - "2"
+            - "1"
   - note: reachable_paths/invalid_end
     query: data.reachable.p = x
     modules:

--- a/v1/test/cases/testdata/v1/reachable/test-reachable-paths-1022.yaml
+++ b/v1/test/cases/testdata/v1/reachable/test-reachable-paths-1022.yaml
@@ -71,10 +71,13 @@ cases:
           - - one
             - five
             - six
+            - nine
           - - one
             - five
             - six
-            - nine
+            - seven
+            - eight
+            - three
           - - one
             - two
             - four

--- a/v1/topdown/reachable.go
+++ b/v1/topdown/reachable.go
@@ -74,39 +74,31 @@ func builtinReachable(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Ter
 
 // pathBuilder is called recursively to build a Set of paths that are reachable from the root
 func pathBuilder(graph ast.Object, root *ast.Term, path []*ast.Term, edgeRslt ast.Set, reached ast.Set) {
-	paths := []*ast.Term{}
-
-	if edges := graph.Get(root); edges != nil {
-		path = append(path, root)
-
-		if numberOfEdges(edges) >= 1 {
-
-			foreachVertex(edges, func(neighbor *ast.Term) {
-
-				if reached.Contains(neighbor) {
-					// If we've already reached this node, return current path (avoid infinite recursion)
-					paths = append(paths, path...)
-					edgeRslt.Add(ast.ArrayTerm(paths...))
-				} else {
-					reached.Add(root)
-					pathBuilder(graph, neighbor, path, edgeRslt, reached)
-
-				}
-
-			})
-
-		} else {
-			paths = append(paths, path...)
-			edgeRslt.Add(ast.ArrayTerm(paths...))
-
-		}
-	} else {
-		// Node is nonexistent (not in graph). Commit the current path (without adding this root)
-		paths = append(paths, path...)
-		edgeRslt.Add(ast.ArrayTerm(paths...))
-
+	edges := graph.Get(root)
+	if edges == nil {
+		// Node not in graph — commit path without this node.
+		edgeRslt.Add(ast.ArrayTerm(path...))
+		return
 	}
 
+	path = append(path, root)
+
+	if numberOfEdges(edges) == 0 {
+		edgeRslt.Add(ast.ArrayTerm(path...))
+		return
+	}
+
+	reached = reached.Copy()
+	reached.Add(root)
+
+	foreachVertex(edges, func(neighbor *ast.Term) {
+		if reached.Contains(neighbor) {
+			// Cycle detected — commit current path.
+			edgeRslt.Add(ast.ArrayTerm(path...))
+		} else {
+			pathBuilder(graph, neighbor, append([]*ast.Term(nil), path...), edgeRslt, reached)
+		}
+	})
 }
 
 func builtinReachablePaths(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term) error) error {


### PR DESCRIPTION
Fixes  [#5871](https://github.com/open-policy-agent/opa/issues/5871)

`graph.reachable_paths` silently drops paths when a node is reachable via  multiple routes. Given this graph:

  "1": [],
  "2": ["1"],
  "3": ["2"],
  "4": ["3", "2"],
  "5": ["4"]

  Calling graph.reachable_paths from 5 returns:

  ["5", "4", "3", "2", "1"]   ✓
  ["5", "4"]                  ✗ truncated — should be ["5", "4", "2", "1"]

  The path 4 → 2 → 1 is dropped because node 2 is also reachable via 4 → 3 → 2.

  There were bugs in pathBuilder:

  1. Shared reached set across sibling branches. The visited set was mutated and shared between siblings inside the foreachVertex loop. After the 3 branch  recursed and added 2 to reached, the 2 branch found it already marked visited and emitted a truncated path instead of continuing.

  2. Slice aliasing via ast.NewArray. ast.NewArray stores the slice it receives directly as elems without copying. When sibling calls appended to a path slice  with spare capacity, one sibling's in-place write corrupted the already-committed path term of the previous sibling.

The fix copies reached once per pathBuilder invocation and passes append([]*ast.Term(nil), path...) to each recursive call, giving each branch its own independent visited set and path backing array.

  ---
  The existing cycle_1022_3 test was asserting the wrong output — its expected results were written to match what the buggy implementation produced rather than correct behavior. With this graph:
  
```mermaid
  graph LR
      one --> two & five
      two --> four
      four --> three
      five --> seven & six
      six --> nine & seven
      seven --> eight
      eight --> three
      three --> T1([end])
      nine --> T2([end])

      style seven fill:#f96
```

  Node seven is reachable from five both directly and via six. The bug caused the five → six → seven path to be dropped. The four correct paths are:

```mermaid
  graph LR
      one --> two --> four --> three
```

```mermaid
  graph LR
      one --> five --> seven --> eight --> three
```

```mermaid
  graph LR
      one --> five --> six --> nine
```

```mermaid
  graph LR
      one --> five --> six --> seven --> eight --> three
```

  The first commit updates cycle_1022_3 to the correct expectation (which fails against the unfixed code) and adds a new shared_ancestor test reproducing the pattern from https://github.com/open-policy-agent/opa/issues/5871. The second commit contains only the fix.
  
  