### PR TITLE
ast: fix parenthesis in String() of {obj,arr,set} comprehensions

### DIFF
--- a/v1/ast/string_length.go
+++ b/v1/ast/string_length.go
@@ -125,6 +125,19 @@ func (c Call) StringLength() int {
 	return c[0].StringLength() + 2 + TermSliceStringLength(c[1:], 2)
 }
 
+// comprehensionTermStringLength returns the string length of a term when
+// rendered inside a comprehension head, where infix operators are rendered
+// in infix notation wrapped in parens.
+func comprehensionTermStringLength(t *Term) int {
+	if call, ok := t.Value.(Call); ok && len(call) == 3 {
+		if bi, found := BuiltinMap[call[0].String()]; found && bi.Infix != "" && bi.Infix != "in" {
+			// "(left op right)" = left + " " + op + " " + right + "()"
+			return comprehensionTermStringLength(call[1]) + len(bi.Infix) + comprehensionTermStringLength(call[2]) + 4
+		}
+	}
+	return t.StringLength()
+}
+
 func (r Ref) StringLength() (n int) {
 	rlen := len(r)
 	if rlen == 0 {
@@ -165,16 +178,16 @@ func (v Var) StringLength() int {
 }
 
 func (s *SetComprehension) StringLength() int {
-	return s.Term.StringLength() + s.Body.StringLength() + 5 // {} and " | "
+	return comprehensionTermStringLength(s.Term) + s.Body.StringLength() + 5 // {} and " | "
 }
 
 func (a *ArrayComprehension) StringLength() int {
-	return a.Term.StringLength() + a.Body.StringLength() + 5 // [] and " | "
+	return comprehensionTermStringLength(a.Term) + a.Body.StringLength() + 5 // [] and " | "
 }
 
 func (o *ObjectComprehension) StringLength() (n int) {
-	n += o.Key.StringLength()
-	n += o.Value.StringLength()
+	n += comprehensionTermStringLength(o.Key)
+	n += comprehensionTermStringLength(o.Value)
 	n += o.Body.StringLength()
 	return n + 7 // "{}"", " | ", and ": "
 }

--- a/v1/ast/term_appenders.go
+++ b/v1/ast/term_appenders.go
@@ -2,6 +2,7 @@ package ast
 
 import (
 	"encoding"
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -228,7 +229,7 @@ func (r Ref) AppendText(buf []byte) ([]byte, error) {
 func (sc *SetComprehension) AppendText(buf []byte) ([]byte, error) {
 	buf = append(buf, '{')
 	var err error
-	if buf, err = sc.Term.AppendText(buf); err != nil {
+	if buf, err = appendComprehensionTerm(buf, sc.Term); err != nil {
 		return nil, err
 	}
 	if buf, err = sc.Body.AppendText(append(buf, " | "...)); err != nil {
@@ -240,7 +241,7 @@ func (sc *SetComprehension) AppendText(buf []byte) ([]byte, error) {
 func (ac *ArrayComprehension) AppendText(buf []byte) ([]byte, error) {
 	buf = append(buf, '[')
 	var err error
-	if buf, err = ac.Term.AppendText(buf); err != nil {
+	if buf, err = appendComprehensionTerm(buf, ac.Term); err != nil {
 		return nil, err
 	}
 	if buf, err = ac.Body.AppendText(append(buf, " | "...)); err != nil {
@@ -252,17 +253,38 @@ func (ac *ArrayComprehension) AppendText(buf []byte) ([]byte, error) {
 func (oc *ObjectComprehension) AppendText(buf []byte) ([]byte, error) {
 	buf = append(buf, '{')
 	var err error
-	if buf, err = oc.Key.AppendText(buf); err != nil {
+	if buf, err = appendComprehensionTerm(buf, oc.Key); err != nil {
 		return nil, err
 	}
 	buf = append(buf, ": "...)
-	if buf, err = oc.Value.AppendText(buf); err != nil {
+	if buf, err = appendComprehensionTerm(buf, oc.Value); err != nil {
 		return nil, err
 	}
 	if buf, err = oc.Body.AppendText(append(buf, " | "...)); err != nil {
 		return nil, err
 	}
 	return append(buf, '}'), nil
+}
+
+// appendComprehensionTerm writes a term, rendering infix operator calls
+// in infix notation wrapped in parens. This prevents ambiguity with the
+// comprehension "|" separator and produces more readable output.
+func appendComprehensionTerm(buf []byte, term *Term) ([]byte, error) {
+	if call, ok := term.Value.(Call); ok && len(call) == 3 {
+		if bi, found := BuiltinMap[call[0].String()]; found && bi.Infix != "" && bi.Infix != "in" {
+			buf = append(buf, '(')
+			var err error
+			if buf, err = appendComprehensionTerm(buf, call[1]); err != nil {
+				return nil, err
+			}
+			buf = fmt.Appendf(buf, " %s ", bi.Infix)
+			if buf, err = appendComprehensionTerm(buf, call[2]); err != nil {
+				return nil, err
+			}
+			return append(buf, ')'), nil
+		}
+	}
+	return term.AppendText(buf)
 }
 
 func (not *Not) AppendText(buf []byte) ([]byte, error) {

--- a/v1/ast/term_appenders_test.go
+++ b/v1/ast/term_appenders_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/open-policy-agent/opa/v1/ast"
 )
 
-var value_appender_tests = []struct {
+var valueAppenderTests = []struct {
 	name string
 	term ast.StringLengther
 	want string
@@ -87,9 +87,34 @@ var value_appender_tests = []struct {
 		want: `{k: v | some k, v; equal(data.items[k], v); gt(v, 10)}`,
 	},
 	{
+		name: "object comprehension infix value",
+		term: ast.MustParseTerm(`{k: (v * 100) | some k, v; v > 0}`),
+		want: `{k: (v * 100) | some k, v; gt(v, 0)}`,
+	},
+	{
+		name: "object comprehension infix key",
+		term: ast.MustParseTerm(`{(k + 1): v | some k, v; v > 0}`),
+		want: `{(k + 1): v | some k, v; gt(v, 0)}`,
+	},
+	{
 		name: "array comprehension",
 		term: ast.MustParseTerm(`[(x * 2) | x := data.numbers[_]; x > 5]`),
-		want: `[mul(x, 2) | assign(x, data.numbers[_]); gt(x, 5)]`,
+		want: `[(x * 2) | assign(x, data.numbers[_]); gt(x, 5)]`,
+	},
+	{
+		name: "array comprehension nested infix operators",
+		term: ast.MustParseTerm(`[((x + 1) * 2) | x := data.numbers[_]]`),
+		want: `[((x + 1) * 2) | assign(x, data.numbers[_])]`,
+	},
+	{
+		name: "array comprehension non-infix head",
+		term: ast.MustParseTerm(`[count(x) | x := data.lists[_]]`),
+		want: `[count(x) | assign(x, data.lists[_])]`,
+	},
+	{
+		name: "array comprehension nested infix with function call",
+		term: ast.MustParseTerm(`[(to_number(cpu_str[i])/1000) | cpu_str[i]]`),
+		want: `[(to_number(cpu_str[i]) / 1000) | cpu_str[i]]`,
 	},
 	{
 		name: "set comprehension",
@@ -99,7 +124,7 @@ var value_appender_tests = []struct {
 }
 
 func TestASTValueTextAppendersAndStringLength(t *testing.T) {
-	for _, tc := range value_appender_tests {
+	for _, tc := range valueAppenderTests {
 		t.Run(tc.name, func(t *testing.T) {
 			var buf []byte
 			var err error
@@ -123,7 +148,7 @@ func TestASTValueTextAppendersAndStringLength(t *testing.T) {
 
 // Ensure no appender allocates when appending to a pre-sized buffer.
 func BenchmarkNoASTTypeAllocatesOnAppendToBufferOfStringLength(b *testing.B) {
-	for _, tc := range value_appender_tests {
+	for _, tc := range valueAppenderTests {
 		b.Run(tc.name, func(b *testing.B) {
 			buf := make([]byte, 0, tc.term.StringLength())
 			for b.Loop() {


### PR DESCRIPTION
This should fix the issue underlying

https://github.com/open-policy-agent/opa-control-plane/issues/321
