### PR TITLE
Fix type checker to recognize numeric index in generated map

### DIFF
--- a/v1/ast/check.go
+++ b/v1/ast/check.go
@@ -308,6 +308,17 @@ func (tc *typeChecker) checkRule(env *TypeEnv, as *AnnotationSet, rule *Rule) {
 			typeK := cpy.GetByValue(rule.Head.Key.Value)
 			if typeK != nil {
 				tpe = types.NewSet(typeK)
+				if !path.IsGround() {
+					objPath := path.DynamicSuffix()
+					path = path.GroundPrefix()
+
+					var err error
+					tpe, err = nestedObject(cpy, objPath, tpe)
+					if err != nil {
+						tc.err(NewError(TypeErr, rule.Head.Location, "%s", err.Error()))
+						tpe = nil
+					}
+				}
 			}
 		}
 	}

--- a/v1/ast/check_test.go
+++ b/v1/ast/check_test.go
@@ -2751,6 +2751,36 @@ output if {
 	}
 }`,
 		},
+		// this policy verifies the issue: https://github.com/open-policy-agent/opa/issues/6736
+		{
+			name: "check referencing generated map with numeric keys",
+			policy: `package p
+
+import rego.v1
+
+nums[x] contains x if some x in [1, 2, 3]
+
+bug if {
+    nums[x]
+    x == 1
+}`,
+		},
+		// this policy verifies the issue: https://github.com/open-policy-agent/opa/issues/6736
+		{
+			name: "check referencing generated map with numeric keys with some...in",
+			policy: `package p
+
+import rego.v1
+
+ns := [1, 2, 3]
+
+nums[x] contains ns if some x in ns
+
+bug if {
+	some n1 in ns
+	some n2 in nums[n1]
+}`,
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
resolve: https://github.com/open-policy-agent/opa/issues/6736

Add the same check used in the `SingleValue` case to the `MultiValue` case so that the resulting type for x in inferred correctly.