### PR TITLE
add merge_group build trigger to benchmarks

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch: {}
   push:
     branches: [main]
+  merge_group: # needed for checks in merge queue
 
 permissions:
   contents: read


### PR DESCRIPTION
The benchmarks have occasionally caught issues but are only run after the PR is merged in main, with merge queues we can have the benchmarks run before the PR is merged but not with every commit to a PR because they do take a while.

relevant docs: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions

similar to regal: https://github.com/open-policy-agent/regal/blob/main/.github/workflows/build.yaml#L13-L14

