### PR TITLE
Run benchmarks in the merge queue

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -4,7 +4,6 @@ on:
   workflow_dispatch: {}
   push:
     branches: [main]
-  merge_group: # needed for checks in merge queue
 
 permissions:
   contents: read

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -591,6 +591,35 @@ jobs:
       run: vale --config=.vale.ini .
       working-directory: docs
 
+  benchmarks:
+    name: Benchmarks
+    runs-on: ubuntu-24.04
+    needs: check-changes
+    if: github.event_name == 'merge_group' && needs.check-changes.outputs.go == 'true'
+    steps:
+      - name: Check out code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          path: opa
+          persist-credentials: false
+      - id: go_version
+        name: Read go version
+        run: echo "go_version=$(cat .go-version)" >> $GITHUB_OUTPUT
+        working-directory: opa
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: ${{ steps.go_version.outputs.go_version }}
+          cache-dependency-path: opa/go.sum
+      - name: Run benchmarks
+        run: go run go.bobheadxi.dev/gobenchdata@v1 action
+        env:
+          INPUT_GO_TEST_FLAGS: "-tags=opa_wasm -timeout=120m -run=^#"
+          INPUT_GO_TEST_PKGS: ./...
+          INPUT_SUBDIRECTORY: opa
+          INPUT_PUBLISH: false
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        timeout-minutes: 120
+
   # This job is required to complete before merging, and is set as a branch
   # protection rule:
   # https://github.com/open-policy-agent/opa/settings/branch_protection_rules
@@ -617,6 +646,7 @@ jobs:
       docs-lint-check,
       docs-markdownlint-check,
       docs-spell-check,
+      benchmarks,
     ]
     if: always()
     steps:


### PR DESCRIPTION
Previous attempt to get merge queue working didn't work entirely: https://github.com/open-policy-agent/opa/pull/8523

`PR Check Summary` is a required job, but benchmarks isn't. So what happened was the moment `PR Check Summary` succeeded the PR merged before the benchmark job could finish. benchmark can't be required or it will block the PR from even getting into the merge queue. The idea here is to move running just the benchmarks when in a merge queue event as a requirement for the `PR Check Summary`.

The publishing of benchmarks stays the same and only happens on main.