### PR TITLE
Don't post netlify preview on non-doc changes

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -11,6 +11,7 @@ SECRETS_SCAN_OMIT_PATHS = "v1/test/cases,v1/topdown/crypto_test.go"
 
 [context.deploy-preview]
 command = "make netlify-edge"
+ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- docs/ netlify.toml"
 
 [[edge_functions]]
 # this path should not be changed as various external sites depend on it for OPA


### PR DESCRIPTION
The preview is useful, but not when there hasn't been any changes to the docs. This change should prevent comments like this: https://github.com/open-policy-agent/opa/pull/8526#issuecomment-4262867821

Of course prints on this PR because it also includes changes to the toml config 😄 