### PR TITLE
Test OCP and Regal during merge queue

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -76,31 +76,10 @@ jobs:
     name: Benchmarks
     needs: check-changes
     if: ${{ needs.check-changes.outputs.go == 'true' }}
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Check out code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          path: opa
-          persist-credentials: true
-      - id: go_version
-        name: Read go version
-        run: echo "go_version=$(cat .go-version)" >> $GITHUB_OUTPUT
-        working-directory: opa
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version: ${{ steps.go_version.outputs.go_version }}
-          cache-dependency-path: opa/go.sum
-      - name: gobenchdata publish
-        run: go run go.bobheadxi.dev/gobenchdata@v1 action
-        env:
-          INPUT_GO_TEST_FLAGS: "-tags=opa_wasm -timeout=120m -run=^#"
-          INPUT_GO_TEST_PKGS: ./...
-          INPUT_SUBDIRECTORY: opa
-          INPUT_PUBLISH: true
-          INPUT_PUBLISH_BRANCH: benchmarks
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        timeout-minutes: 120
+    uses: ./.github/workflows/run-benchmarks.yaml
+    with:
+      publish: true
+      publish_branch: benchmarks
 
   notebook:
     permissions:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -127,136 +127,15 @@ jobs:
 
   test-ocp-with-opa-main:
     name: Test OCP with OPA main
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Check out OPA code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-          path: opa
-
-      - id: go_version
-        name: Read go version
-        run: echo "go_version=$(cat opa/.go-version)" >> $GITHUB_OUTPUT
-
-      - name: Install Go (${{ steps.go_version.outputs.go_version }})
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version: ${{ steps.go_version.outputs.go_version }}
-
-      - name: Get latest OCP release tag
-        id: ocp_release
-        run: |
-          tag=$(gh api repos/open-policy-agent/opa-control-plane/releases/latest --jq '.tag_name')
-          echo "tag=$tag" >> $GITHUB_OUTPUT
-        env:
-          GH_TOKEN: ${{ github.token }}
-
-      - name: Check out OCP ${{ steps.ocp_release.outputs.tag }}
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          repository: open-policy-agent/opa-control-plane
-          ref: "61213c778cd937822cfdfed0f8914649a8381954" # ${{ steps.ocp_release.outputs.tag }}
-          persist-credentials: false
-          path: ocp
-
-      - name: Update OPA to main
-        working-directory: ocp
-        run: |
-          go mod edit -replace github.com/open-policy-agent/opa=../opa
-          go mod tidy
-
-      - name: Build
-        working-directory: ocp
-        run: make build
-
-      - name: Test
-        working-directory: ocp
-        run: make test
-
-      - name: e2e tests
-        working-directory: ocp
-        run: |
-          set -euo pipefail
-          matches=(opactl_*)
-          export OPACTL="$(pwd)/${matches[0]}"
-          $OPACTL version
-          go test -tags=e2e ./e2e/... -v
-
-      - name: Slack Notification
-        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
-        if: failure() && env.SLACK_WEBHOOK_URL != ''
-        with:
-          webhook: ${{ secrets.SLACK_NOTIFICATION_WEBHOOK }} # zizmor: ignore[secrets-outside-env]
-          webhook-type: incoming-webhook
-          payload: |
-            {
-              "text": "Nightly check failed: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }} - ${{ github.job }}>"
-            }
+    uses: ./.github/workflows/test-ocp-with-opa.yaml
+    secrets:
+      slack_webhook_url: ${{ secrets.SLACK_NOTIFICATION_WEBHOOK }}
 
   test-regal-with-opa-main:
     name: Test Regal with OPA main
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Check out OPA code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-          path: opa
-
-      - id: go_version
-        name: Read go version
-        run: echo "go_version=$(cat opa/.go-version)" >> $GITHUB_OUTPUT
-
-      - name: Install Go (${{ steps.go_version.outputs.go_version }})
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version: ${{ steps.go_version.outputs.go_version }}
-
-      - name: Get latest Regal release tag
-        id: regal_release
-        run: |
-          tag=$(gh api repos/open-policy-agent/regal/releases/latest --jq '.tag_name')
-          echo "tag=$tag" >> $GITHUB_OUTPUT
-        env:
-          GH_TOKEN: ${{ github.token }}
-
-      - name: Check out Regal ${{ steps.regal_release.outputs.tag }}
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          repository: open-policy-agent/regal
-          ref: ${{ steps.regal_release.outputs.tag }}
-          persist-credentials: false
-          path: regal
-
-      - name: Update OPA to main
-        working-directory: regal
-        run: |
-          go mod edit -replace github.com/open-policy-agent/opa=../opa
-          go mod tidy
-
-      - name: Build
-        working-directory: regal
-        run: go build -tags=regal_standalone
-
-      - name: Test
-        working-directory: regal
-        run: go test ./...
-
-      - name: e2e tests
-        working-directory: regal
-        run: go test -tags e2e ./e2e -count=1
-
-      - name: Slack Notification
-        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
-        if: failure() && env.SLACK_WEBHOOK_URL != ''
-        with:
-          webhook: ${{ secrets.SLACK_NOTIFICATION_WEBHOOK }} # zizmor: ignore[secrets-outside-env]
-          webhook-type: incoming-webhook
-          payload: |
-            {
-              "text": "Nightly check failed: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }} - ${{ github.job }}>"
-            }
+    uses: ./.github/workflows/test-regal-with-opa.yaml
+    secrets:
+      slack_webhook_url: ${{ secrets.SLACK_NOTIFICATION_WEBHOOK }}
 
   go-get-test:
     name: Go Get Smoke Test

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -593,32 +593,23 @@ jobs:
 
   benchmarks:
     name: Benchmarks
-    runs-on: ubuntu-24.04
     needs: check-changes
     if: github.event_name == 'merge_group' && needs.check-changes.outputs.go == 'true'
-    steps:
-      - name: Check out code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          path: opa
-          persist-credentials: false
-      - id: go_version
-        name: Read go version
-        run: echo "go_version=$(cat .go-version)" >> $GITHUB_OUTPUT
-        working-directory: opa
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version: ${{ steps.go_version.outputs.go_version }}
-          cache-dependency-path: opa/go.sum
-      - name: Run benchmarks
-        run: go run go.bobheadxi.dev/gobenchdata@v1 action
-        env:
-          INPUT_GO_TEST_FLAGS: "-tags=opa_wasm -timeout=120m -run=^#"
-          INPUT_GO_TEST_PKGS: ./...
-          INPUT_SUBDIRECTORY: opa
-          INPUT_PUBLISH: false
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        timeout-minutes: 120
+    uses: ./.github/workflows/run-benchmarks.yaml
+    with:
+      publish: false
+
+  test-ocp-with-opa:
+    name: Test OCP with OPA
+    needs: check-changes
+    if: github.event_name == 'merge_group' && needs.check-changes.outputs.go == 'true'
+    uses: ./.github/workflows/test-ocp-with-opa.yaml
+
+  test-regal-with-opa:
+    name: Test Regal with OPA
+    needs: check-changes
+    if: github.event_name == 'merge_group' && needs.check-changes.outputs.go == 'true'
+    uses: ./.github/workflows/test-regal-with-opa.yaml
 
   # This job is required to complete before merging, and is set as a branch
   # protection rule:
@@ -647,6 +638,8 @@ jobs:
       docs-markdownlint-check,
       docs-spell-check,
       benchmarks,
+      test-ocp-with-opa,
+      test-regal-with-opa,
     ]
     if: always()
     steps:

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -600,13 +600,11 @@ jobs:
       publish: false
 
   test-ocp-with-opa:
-    name: Test OCP with OPA
     needs: check-changes
     if: github.event_name == 'merge_group' && needs.check-changes.outputs.go == 'true'
     uses: ./.github/workflows/test-ocp-with-opa.yaml
 
   test-regal-with-opa:
-    name: Test Regal with OPA
     needs: check-changes
     if: github.event_name == 'merge_group' && needs.check-changes.outputs.go == 'true'
     uses: ./.github/workflows/test-regal-with-opa.yaml

--- a/.github/workflows/run-benchmarks.yaml
+++ b/.github/workflows/run-benchmarks.yaml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: opa
-          persist-credentials: ${{ inputs.publish }}
+          persist-credentials: false
       - id: go_version
         name: Read go version
         run: echo "go_version=$(cat .go-version)" >> $GITHUB_OUTPUT

--- a/.github/workflows/run-benchmarks.yaml
+++ b/.github/workflows/run-benchmarks.yaml
@@ -14,7 +14,7 @@ on:
         default: ''
 
 permissions:
-  contents: write
+  contents: write # Required when publish=true; capped by caller's token otherwise
 
 jobs:
   benchmarks:

--- a/.github/workflows/run-benchmarks.yaml
+++ b/.github/workflows/run-benchmarks.yaml
@@ -1,0 +1,46 @@
+name: Run Benchmarks
+
+on:
+  workflow_call:
+    inputs:
+      publish:
+        description: Whether to publish benchmark results
+        required: true
+        type: boolean
+      publish_branch:
+        description: Branch to publish results to
+        required: false
+        type: string
+        default: ''
+
+permissions:
+  contents: write
+
+jobs:
+  benchmarks:
+    name: Benchmarks
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          path: opa
+          persist-credentials: ${{ inputs.publish }}
+      - id: go_version
+        name: Read go version
+        run: echo "go_version=$(cat .go-version)" >> $GITHUB_OUTPUT
+        working-directory: opa
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: ${{ steps.go_version.outputs.go_version }}
+          cache-dependency-path: opa/go.sum
+      - name: Run benchmarks
+        run: go run go.bobheadxi.dev/gobenchdata@v1 action
+        env:
+          INPUT_GO_TEST_FLAGS: "-tags=opa_wasm -timeout=120m -run=^#"
+          INPUT_GO_TEST_PKGS: ./...
+          INPUT_SUBDIRECTORY: opa
+          INPUT_PUBLISH: ${{ inputs.publish }}
+          INPUT_PUBLISH_BRANCH: ${{ inputs.publish_branch }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        timeout-minutes: 120

--- a/.github/workflows/run-benchmarks.yaml
+++ b/.github/workflows/run-benchmarks.yaml
@@ -13,9 +13,6 @@ on:
         type: string
         default: ''
 
-permissions:
-  contents: write # Required when publish=true; capped by caller's token otherwise
-
 jobs:
   benchmarks:
     name: Benchmarks

--- a/.github/workflows/test-ocp-with-opa.yaml
+++ b/.github/workflows/test-ocp-with-opa.yaml
@@ -13,6 +13,8 @@ jobs:
   test-ocp-with-opa:
     name: Test OCP with OPA
     runs-on: ubuntu-24.04
+    env:
+      SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_url }}
     steps:
       - name: Check out OPA code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -70,9 +72,9 @@ jobs:
 
       - name: Slack Notification
         uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
-        if: failure() && secrets.slack_webhook_url != ''
+        if: failure() && env.SLACK_WEBHOOK_URL != ''
         with:
-          webhook: ${{ secrets.slack_webhook_url }} # zizmor: ignore[secrets-outside-env]
+          webhook: ${{ env.SLACK_WEBHOOK_URL }} # zizmor: ignore[secrets-outside-env]
           webhook-type: incoming-webhook
           payload: |
             {

--- a/.github/workflows/test-ocp-with-opa.yaml
+++ b/.github/workflows/test-ocp-with-opa.yaml
@@ -1,0 +1,80 @@
+name: Test OCP with OPA
+
+on:
+  workflow_call:
+    secrets:
+      slack_webhook_url:
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  test-ocp-with-opa:
+    name: Test OCP with OPA
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out OPA code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          path: opa
+
+      - id: go_version
+        name: Read go version
+        run: echo "go_version=$(cat opa/.go-version)" >> $GITHUB_OUTPUT
+
+      - name: Install Go (${{ steps.go_version.outputs.go_version }})
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: ${{ steps.go_version.outputs.go_version }}
+
+      - name: Get latest OCP release tag
+        id: ocp_release
+        run: |
+          tag=$(gh api repos/open-policy-agent/opa-control-plane/releases/latest --jq '.tag_name')
+          echo "tag=$tag" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Check out OCP ${{ steps.ocp_release.outputs.tag }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: open-policy-agent/opa-control-plane
+          ref: "61213c778cd937822cfdfed0f8914649a8381954" # ${{ steps.ocp_release.outputs.tag }}
+          persist-credentials: false
+          path: ocp
+
+      - name: Update OPA dependency
+        working-directory: ocp
+        run: |
+          go mod edit -replace github.com/open-policy-agent/opa=../opa
+          go mod tidy
+
+      - name: Build
+        working-directory: ocp
+        run: make build
+
+      - name: Test
+        working-directory: ocp
+        run: make test
+
+      - name: e2e tests
+        working-directory: ocp
+        run: |
+          set -euo pipefail
+          matches=(opactl_*)
+          export OPACTL="$(pwd)/${matches[0]}"
+          $OPACTL version
+          go test -tags=e2e ./e2e/... -v
+
+      - name: Slack Notification
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
+        if: failure() && secrets.slack_webhook_url != ''
+        with:
+          webhook: ${{ secrets.slack_webhook_url }} # zizmor: ignore[secrets-outside-env]
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "OCP compatibility check failed: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }} - ${{ github.job }}>"
+            }

--- a/.github/workflows/test-ocp-with-opa.yaml
+++ b/.github/workflows/test-ocp-with-opa.yaml
@@ -14,7 +14,7 @@ jobs:
     name: Test OCP with OPA
     runs-on: ubuntu-24.04
     env:
-      SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_url }}
+      SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_url }} # zizmor: ignore[secrets-outside-env]
     steps:
       - name: Check out OPA code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/test-regal-with-opa.yaml
+++ b/.github/workflows/test-regal-with-opa.yaml
@@ -13,6 +13,8 @@ jobs:
   test-regal-with-opa:
     name: Test Regal with OPA
     runs-on: ubuntu-24.04
+    env:
+      SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_url }}
     steps:
       - name: Check out OPA code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -65,9 +67,9 @@ jobs:
 
       - name: Slack Notification
         uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
-        if: failure() && secrets.slack_webhook_url != ''
+        if: failure() && env.SLACK_WEBHOOK_URL != ''
         with:
-          webhook: ${{ secrets.slack_webhook_url }} # zizmor: ignore[secrets-outside-env]
+          webhook: ${{ env.SLACK_WEBHOOK_URL }} # zizmor: ignore[secrets-outside-env]
           webhook-type: incoming-webhook
           payload: |
             {

--- a/.github/workflows/test-regal-with-opa.yaml
+++ b/.github/workflows/test-regal-with-opa.yaml
@@ -14,7 +14,7 @@ jobs:
     name: Test Regal with OPA
     runs-on: ubuntu-24.04
     env:
-      SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_url }}
+      SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_url }} # zizmor: ignore[secrets-outside-env]
     steps:
       - name: Check out OPA code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/test-regal-with-opa.yaml
+++ b/.github/workflows/test-regal-with-opa.yaml
@@ -1,0 +1,75 @@
+name: Test Regal with OPA
+
+on:
+  workflow_call:
+    secrets:
+      slack_webhook_url:
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  test-regal-with-opa:
+    name: Test Regal with OPA
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out OPA code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          path: opa
+
+      - id: go_version
+        name: Read go version
+        run: echo "go_version=$(cat opa/.go-version)" >> $GITHUB_OUTPUT
+
+      - name: Install Go (${{ steps.go_version.outputs.go_version }})
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: ${{ steps.go_version.outputs.go_version }}
+
+      - name: Get latest Regal release tag
+        id: regal_release
+        run: |
+          tag=$(gh api repos/open-policy-agent/regal/releases/latest --jq '.tag_name')
+          echo "tag=$tag" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Check out Regal ${{ steps.regal_release.outputs.tag }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: open-policy-agent/regal
+          ref: ${{ steps.regal_release.outputs.tag }}
+          persist-credentials: false
+          path: regal
+
+      - name: Update OPA dependency
+        working-directory: regal
+        run: |
+          go mod edit -replace github.com/open-policy-agent/opa=../opa
+          go mod tidy
+
+      - name: Build
+        working-directory: regal
+        run: go build -tags=regal_standalone
+
+      - name: Test
+        working-directory: regal
+        run: go test ./...
+
+      - name: e2e tests
+        working-directory: regal
+        run: go test -tags e2e ./e2e -count=1
+
+      - name: Slack Notification
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
+        if: failure() && secrets.slack_webhook_url != ''
+        with:
+          webhook: ${{ secrets.slack_webhook_url }} # zizmor: ignore[secrets-outside-env]
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "Regal compatibility check failed: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }} - ${{ github.job }}>"
+            }


### PR DESCRIPTION
Could add all of the nightly checks, the OCP and Regal checks have caught things recently so that made the most sense for now. Happy to hear opinions on this.

Updated the recently added benchmark steps into a separate workflow following the same pattern as the now duplicate OCP and Regal checks.