### PR TITLE
Fix benchmarks check files changed

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -50,11 +50,13 @@ jobs:
           echo "Changed files:"
           jq -r '.[].filename' changed_files.json
 
-          go_result=$(opa eval \
-            --data build/policy/pr-check/pr_check.rego \
-            --input changed_files.json \
-            --format pretty \
-            'data.policy["pr-check"].changes.go' | jq -r '. // false')
+          opa eval \
+          --data build/policy/pr-check/pr_check.rego \
+          --input changed_files.json \
+          --format pretty \
+          'data.policy["pr-check"]' > opa_result.json
+          
+          go_result=$(jq -r '.changes.go // false' opa_result.json)
 
           echo "go=${go_result}" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
broke the check files changed: https://github.com/open-policy-agent/opa/actions/runs/24564573730/job/71829397409
if no Go files are changed `data.policy["pr-check"].changes.go` returns undefined breaking jq. Updated benchmarks.yaml to do the same thing pull-request.yaml does.