### PR TITLE
build: Exclude domains that cause false positives

### DIFF
--- a/build/lychee/repo.toml
+++ b/build/lychee/repo.toml
@@ -7,6 +7,16 @@ retry_wait_time = 5
 accept = ["200..=206", "403", "429"]
 scheme = ["https", "http"]
 
+exclude = [
+    # These domains frequently timeout, causing false positives
+    # e.g. https://github.com/open-policy-agent/opa/issues/8495
+    'opa-docs\.netlify\.app',
+    'kind\.sigs\.k8s\.io',
+    'openpolicycontainers\.com',
+    'permit\.io',
+    'aserto\.com',
+]
+
 exclude_path = [
     # docs is tested with the website.toml config instead
     'docs',

--- a/build/lychee/website.toml
+++ b/build/lychee/website.toml
@@ -19,6 +19,13 @@ exclude = [
     'blog\.openpolicyagent\.org',
     'itnext\.io',
     'stacklok\.com',
+    # These domains frequently timeout, causing false positives
+    # e.g. https://github.com/open-policy-agent/opa/issues/8495
+    'opa-docs\.netlify\.app',
+    'kind\.sigs\.k8s\.io',
+    'openpolicycontainers\.com',
+    'permit\.io',
+    'aserto\.com',
 ]
 
 exclude_path = [


### PR DESCRIPTION
Several external domains frequently timeout during link checking.

Fixes #8495 (that is, I am not going to do more than this, this time around and have done loads of work on these before)
