### PR TITLE
fmt: restore indention level when handling unexpected comments

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -484,6 +484,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
+        fetch-depth: 0
         persist-credentials: false
 
     - name: Download OPA
@@ -496,8 +497,13 @@ jobs:
 
     - name: Run file policy checks on changed files
       run: |
-        curl --silent --fail --header 'Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' -o files.json \
-          https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files
+        if [ -n "${{ github.event.merge_group.base_sha }}" ]; then
+          git diff --name-only "${{ github.event.merge_group.base_sha }}" "${{ github.event.merge_group.head_sha }}" \
+            | jq -R '{filename: .}' | jq -s '.' > files.json
+        else
+          curl --silent --fail --header 'Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' -o files.json \
+            https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files
+        fi
 
         opa eval --bundle build/policy --format values --input files.json  --fail-defined 'data.files.deny[message]'
       env:

--- a/v1/format/format.go
+++ b/v1/format/format.go
@@ -1173,6 +1173,7 @@ func (w *writer) writeTerm(term *ast.Term, comments []*ast.Comment) ([]*ast.Comm
 	}
 
 	currentLen := w.buf.Len()
+	currentLevel := w.level
 	currentComments := saveComments(comments)
 	defer commentsSlicePool.Put(currentComments)
 
@@ -1180,6 +1181,7 @@ func (w *writer) writeTerm(term *ast.Term, comments []*ast.Comment) ([]*ast.Comm
 	if err != nil {
 		if errors.As(err, &unexpectedCommentError{}) {
 			w.buf.Truncate(currentLen)
+			w.level = currentLevel
 
 			// If beforeEnd refers to a comment within the source text range, clear it
 			// This prevents the comment from being written twice

--- a/v1/format/testfiles/v1/test_issue_nested_comment.rego
+++ b/v1/format/testfiles/v1/test_issue_nested_comment.rego
@@ -1,0 +1,14 @@
+package p
+
+fmt_bug := {
+	"a": [{
+		"b": 1,
+		# this comment seems to trigger the issue
+		"c": 2,
+	}],
+	"d": 3,
+}
+
+default this_should_not_get_indented := {}
+
+this_should_not_get_indented := input.x

--- a/v1/format/testfiles/v1/test_issue_nested_comment.rego
+++ b/v1/format/testfiles/v1/test_issue_nested_comment.rego
@@ -12,3 +12,21 @@ fmt_bug := {
 default this_should_not_get_indented := {}
 
 this_should_not_get_indented := input.x
+
+fmt_bug := {
+	"a": [{
+		"a": [{
+    		"b": 1,
+    		# this comment seems to trigger the issue
+    		"c": 2,
+    	}],
+		"b": 1,
+		# this comment seems to trigger the issue
+		"c": 2,
+	}],
+	"d": 3,
+}
+
+default this_should_not_get_indented := {}
+
+this_should_not_get_indented := input.x

--- a/v1/format/testfiles/v1/test_issue_nested_comment.rego.formatted
+++ b/v1/format/testfiles/v1/test_issue_nested_comment.rego.formatted
@@ -1,0 +1,14 @@
+package p
+
+fmt_bug := {
+	"a": [{
+		"b": 1,
+		# this comment seems to trigger the issue
+		"c": 2,
+	}],
+	"d": 3,
+}
+
+default this_should_not_get_indented := {}
+
+this_should_not_get_indented := input.x

--- a/v1/format/testfiles/v1/test_issue_nested_comment.rego.formatted
+++ b/v1/format/testfiles/v1/test_issue_nested_comment.rego.formatted
@@ -12,3 +12,21 @@ fmt_bug := {
 default this_should_not_get_indented := {}
 
 this_should_not_get_indented := input.x
+
+fmt_bug := {
+	"a": [{
+		"a": [{
+    		"b": 1,
+    		# this comment seems to trigger the issue
+    		"c": 2,
+    	}],
+		"b": 1,
+		# this comment seems to trigger the issue
+		"c": 2,
+	}],
+	"d": 3,
+}
+
+default this_should_not_get_indented := {}
+
+this_should_not_get_indented := input.x


### PR DESCRIPTION
resolve an issue introduced in: https://github.com/open-policy-agent/opa/pull/8519

The indention level needed to be reset after an unexpected comment that writes the pre-formatted text.