### PR TITLE
server: Skip chmod for abstract Unix domain sockets

### DIFF
--- a/v1/server/server.go
+++ b/v1/server/server.go
@@ -735,7 +735,9 @@ func (s *Server) getListenerForUNIXSocket(u *url.URL, h http.Handler, t httpList
 		return nil, nil, err
 	}
 
-	if s.unixSocketPerm != nil {
+	// Skip chmod for abstract Unix sockets — they exist only in the
+	// kernel's socket namespace and have no filesystem path to chmod.
+	if s.unixSocketPerm != nil && !strings.HasPrefix(socketPath, "@") {
 		modeVal, err := strconv.ParseUint(*s.unixSocketPerm, 8, 32)
 		if err != nil {
 			return nil, nil, err

--- a/v1/server/server_test.go
+++ b/v1/server/server_test.go
@@ -7022,3 +7022,20 @@ data.baz.qux`,
 		})
 	}
 }
+
+func TestAbstractUnixSocketWithPermFlag(t *testing.T) {
+	t.Parallel()
+
+	perm := "755"
+	s := New().
+		WithAddresses([]string{"unix://@opa-test-abstract.sock"}).
+		WithUnixSocketPermission(&perm)
+
+	loops, err := s.Listeners()
+	if err != nil {
+		t.Fatalf("expected no error creating listener on abstract socket with --unix-socket-perm, got: %v", err)
+	}
+	if len(loops) == 0 {
+		t.Fatal("expected at least one loop")
+	}
+}


### PR DESCRIPTION
### Why the changes in this PR are needed?

When OPA listens on an abstract Unix domain socket (e.g., `--addr unix://@authz.sock`), it crashes on startup with:

```
{"err":"chmod @authz.sock: no such file or directory","level":"error","msg":"Unable to create listeners."}
```

This happens because the `--unix-socket-perm` flag (introduced in v0.53.0 via #5888) defaults to `"755"` and unconditionally calls `os.Chmod()` on the socket path after the listener is created. Abstract sockets (prefixed with `@`) exist only in the kernel's socket namespace — they have no filesystem path, so `chmod` fails.

This bug affects **every OPA version from v0.53.0 onward** (including the latest v1.14.0) when using abstract Unix sockets.

Our use case: we run OPA as a Kubernetes sidecar listening on `unix://@authz.sock`. The application container in the same pod connects to OPA over this abstract socket for authorization decisions. Abstract sockets are ideal for pod-internal communication because they require no shared volume mounts. This setup worked on OPA v0.38.1 but breaks on any version >= v0.53.0.

### What are the changes in this PR?

Added a guard to skip `os.Chmod()` when the socket path is an abstract socket (starts with `@`). This matches the existing guard a few lines above that already skips `os.Remove()` for abstract sockets:

```go
// Before (line 720-726): already handles abstract sockets for Remove
if strings.HasPrefix(u.String(), u.Scheme+"://@") {
    socketPath = "@" + socketPath
} else {
    os.Remove(socketPath)  // only for filesystem sockets
}

// After (line 738): now also handles abstract sockets for Chmod
if s.unixSocketPerm != nil && !strings.HasPrefix(socketPath, "@") {
```

Also added a test that verifies OPA can create a listener on an abstract Unix socket when `--unix-socket-perm` is set.

### Notes to assist PR review:

- The fix is a single condition added to line 738: `&& !strings.HasPrefix(socketPath, "@")`
- No existing tests covered abstract Unix sockets with the `--unix-socket-perm` flag
- The original PR #5888 author noted "I am not sure how to unit test this" — the test added here creates a real abstract socket listener and verifies no error occurs
- Abstract Unix sockets are a Linux-specific feature; the test uses `t.Parallel()` and should be skipped on non-Linux CI if needed

### Further comments:

- The `--unix-socket-perm` flag was introduced in v0.53.0 (#5888) to allow configuring file permissions on filesystem Unix sockets for cross-container access via shared volumes
- Abstract sockets don't need file permissions — any process in the same network namespace can connect to them
- This bug has existed since v0.53.0 (May 2023) but was likely never reported because abstract socket usage is uncommon
