### PR TITLE
Support recursive JSON Schemas

### DIFF
--- a/cmd/eval_test.go
+++ b/cmd/eval_test.go
@@ -640,13 +640,19 @@ func testReadParamWithSchemaDir(input string, inputSchema string) error {
 }
 
 func TestEvalWithRecursiveJSONSchema(t *testing.T) {
-	input := `{"foo": {"foo": {}}}`
-
-	policy := `package p
-
-allow if input.foo`
-
-	schema := `{
+	tests := []struct {
+		note       string
+		input      string
+		query      string
+		schema     string
+		policy     string
+		expTypeErr bool
+	}{
+		{
+			note:  "recursive object ref - valid usage",
+			input: `{"foo": {"foo": {}}}`,
+			query: "data.p.allow",
+			schema: `{
     "$ref": "#/$defs/foo",
     "$defs": {
         "foo": {
@@ -658,15 +664,29 @@ allow if input.foo`
             }
         }
     }
-}`
+}`,
+			policy: `package p
 
-	err := testEvalWithSchemaFile(t, input, "data.p.allow", schema, policy, false)
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
-	}
-
-	// Type mismatch: input.foo is an object per the recursive schema, not a number
-	policyWithSchemasAnnotation := `
+allow if input.foo`,
+		},
+		{
+			note:  "recursive object ref - type mismatch at top level",
+			input: `{"foo": {"foo": {}}}`,
+			query: "data.test.p",
+			schema: `{
+    "$ref": "#/$defs/foo",
+    "$defs": {
+        "foo": {
+            "type": "object",
+            "properties": {
+                "foo": {
+                    "$ref": "#/$defs/foo"
+                }
+            }
+        }
+    }
+}`,
+			policy: `
 package test
 
 # METADATA
@@ -674,14 +694,27 @@ package test
 #   - input: schema
 p if {
 	input.foo == 42
-}`
-	err = testEvalWithSchemaFile(t, input, "data.test.p", schema, policyWithSchemasAnnotation, true)
-	if err != nil {
-		t.Fatalf("unexpected error for schema annotation type check: %s", err)
-	}
-
-	// Type mismatch on nested recursive property
-	policyNestedMismatch := `
+}`,
+			expTypeErr: true,
+		},
+		{
+			note:  "recursive object ref - nested type mismatch",
+			input: `{"foo": {"foo": {}}}`,
+			query: "data.test.p",
+			schema: `{
+    "$ref": "#/$defs/foo",
+    "$defs": {
+        "foo": {
+            "type": "object",
+            "properties": {
+                "foo": {
+                    "$ref": "#/$defs/foo"
+                }
+            }
+        }
+    }
+}`,
+			policy: `
 package test
 
 # METADATA
@@ -689,14 +722,27 @@ package test
 #   - input: schema
 p if {
 	input.foo.foo == "hello"
-}`
-	err = testEvalWithSchemaFile(t, input, "data.test.p", schema, policyNestedMismatch, true)
-	if err != nil {
-		t.Fatalf("unexpected error for nested recursive type check: %s", err)
-	}
-
-	// Type mismatch with inlined recursive schema
-	policyWithInlinedSchema := `
+}`,
+			expTypeErr: true,
+		},
+		{
+			note:  "recursive object ref - inlined schema type mismatch",
+			input: `{"foo": {"foo": {}}}`,
+			query: "data.test.p",
+			schema: `{
+    "$ref": "#/$defs/foo",
+    "$defs": {
+        "foo": {
+            "type": "object",
+            "properties": {
+                "foo": {
+                    "$ref": "#/$defs/foo"
+                }
+            }
+        }
+    }
+}`,
+			policy: `
 package test
 
 # METADATA
@@ -704,14 +750,27 @@ package test
 #   - input.foo: {"type": "boolean"}
 p if {
 	input.foo == 42
-}`
-	err = testEvalWithSchemaFile(t, input, "data.test.p", schema, policyWithInlinedSchema, true)
-	if err != nil {
-		t.Fatalf("unexpected error for inlined schema type check: %s", err)
-	}
-
-	// Valid usage: no type error when comparing object property correctly
-	policyValid := `
+}`,
+			expTypeErr: true,
+		},
+		{
+			note:  "recursive object ref - valid with schema annotation",
+			input: `{"foo": {"foo": {}}}`,
+			query: "data.test.p",
+			schema: `{
+    "$ref": "#/$defs/foo",
+    "$defs": {
+        "foo": {
+            "type": "object",
+            "properties": {
+                "foo": {
+                    "$ref": "#/$defs/foo"
+                }
+            }
+        }
+    }
+}`,
+			policy: `
 package test
 
 # METADATA
@@ -719,17 +778,13 @@ package test
 #   - input: schema
 p if {
 	input.foo
-}`
-	err = testEvalWithSchemaFile(t, input, "data.test.p", schema, policyValid, false)
-	if err != nil {
-		t.Fatalf("unexpected error for valid recursive schema usage: %s", err)
-	}
-}
-
-func TestEvalWithRecursiveArrayJSONSchema(t *testing.T) {
-	input := `{"tree": [[[]]]}`
-
-	schema := `{
+}`,
+		},
+		{
+			note:  "recursive array ref - valid usage",
+			input: `{"tree": [[[]]]}`,
+			query: "data.p.allow",
+			schema: `{
     "type": "object",
     "properties": {
         "tree": {
@@ -744,19 +799,32 @@ func TestEvalWithRecursiveArrayJSONSchema(t *testing.T) {
             }
         }
     }
-}`
+}`,
+			policy: `package p
 
-	policy := `package p
-
-allow if input.tree`
-
-	err := testEvalWithSchemaFile(t, input, "data.p.allow", schema, policy, false)
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
-	}
-
-	// Type mismatch: input.tree[0] is an array per the recursive schema, not a string
-	policyMismatch := `
+allow if input.tree`,
+		},
+		{
+			note:  "recursive array ref - type mismatch on element",
+			input: `{"tree": [[[]]]}`,
+			query: "data.test.p",
+			schema: `{
+    "type": "object",
+    "properties": {
+        "tree": {
+            "$ref": "#/$defs/tree"
+        }
+    },
+    "$defs": {
+        "tree": {
+            "type": "array",
+            "items": {
+                "$ref": "#/$defs/tree"
+            }
+        }
+    }
+}`,
+			policy: `
 package test
 
 # METADATA
@@ -764,17 +832,14 @@ package test
 #   - input: schema
 p if {
 	input.tree[0] == "hello"
-}`
-	err = testEvalWithSchemaFile(t, input, "data.test.p", schema, policyMismatch, true)
-	if err != nil {
-		t.Fatalf("unexpected error for recursive array type check: %s", err)
-	}
-}
-
-func TestEvalWithRecursiveAnyOfJSONSchema(t *testing.T) {
-	input := `{"node": ["hello", ["world"]]}`
-
-	schema := `{
+}`,
+			expTypeErr: true,
+		},
+		{
+			note:  "recursive anyOf ref - valid usage",
+			input: `{"node": ["hello", ["world"]]}`,
+			query: "data.p.allow",
+			schema: `{
     "type": "object",
     "properties": {
         "node": {
@@ -792,22 +857,16 @@ func TestEvalWithRecursiveAnyOfJSONSchema(t *testing.T) {
             ]
         }
     }
-}`
+}`,
+			policy: `package p
 
-	policy := `package p
-
-allow if input.node`
-
-	err := testEvalWithSchemaFile(t, input, "data.p.allow", schema, policy, false)
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
-	}
-}
-
-func TestEvalWithNonRecursiveRefJSONSchema(t *testing.T) {
-	input := `{"addr": {"street": "Main St", "city": "Springfield"}}`
-
-	schema := `{
+allow if input.node`,
+		},
+		{
+			note:  "non-recursive ref - valid usage",
+			input: `{"addr": {"street": "Main St", "city": "Springfield"}}`,
+			query: "data.p.allow",
+			schema: `{
     "type": "object",
     "properties": {
         "addr": {
@@ -823,19 +882,33 @@ func TestEvalWithNonRecursiveRefJSONSchema(t *testing.T) {
             }
         }
     }
-}`
+}`,
+			policy: `package p
 
-	policy := `package p
-
-allow if input.addr.street`
-
-	err := testEvalWithSchemaFile(t, input, "data.p.allow", schema, policy, false)
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
-	}
-
-	// Type mismatch: input.addr.street is a string, not a number
-	policyMismatch := `
+allow if input.addr.street`,
+		},
+		{
+			note:  "non-recursive ref - type mismatch",
+			input: `{"addr": {"street": "Main St", "city": "Springfield"}}`,
+			query: "data.test.p",
+			schema: `{
+    "type": "object",
+    "properties": {
+        "addr": {
+            "$ref": "#/$defs/address"
+        }
+    },
+    "$defs": {
+        "address": {
+            "type": "object",
+            "properties": {
+                "street": { "type": "string" },
+                "city": { "type": "string" }
+            }
+        }
+    }
+}`,
+			policy: `
 package test
 
 # METADATA
@@ -843,10 +916,18 @@ package test
 #   - input: schema
 p if {
 	input.addr.street == 42
-}`
-	err = testEvalWithSchemaFile(t, input, "data.test.p", schema, policyMismatch, true)
-	if err != nil {
-		t.Fatalf("unexpected error for non-recursive ref type check: %s", err)
+}`,
+			expTypeErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.note, func(t *testing.T) {
+			err := testEvalWithSchemaFile(t, tc.input, tc.query, tc.schema, tc.policy, tc.expTypeErr)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+		})
 	}
 }
 

--- a/cmd/eval_test.go
+++ b/cmd/eval_test.go
@@ -639,6 +639,217 @@ func testReadParamWithSchemaDir(input string, inputSchema string) error {
 	return err
 }
 
+func TestEvalWithRecursiveJSONSchema(t *testing.T) {
+	input := `{"foo": {"foo": {}}}`
+
+	policy := `package p
+
+allow if input.foo`
+
+	schema := `{
+    "$ref": "#/$defs/foo",
+    "$defs": {
+        "foo": {
+            "type": "object",
+            "properties": {
+                "foo": {
+                    "$ref": "#/$defs/foo"
+                }
+            }
+        }
+    }
+}`
+
+	err := testEvalWithSchemaFile(t, input, "data.p.allow", schema, policy, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	// Type mismatch: input.foo is an object per the recursive schema, not a number
+	policyWithSchemasAnnotation := `
+package test
+
+# METADATA
+# schemas:
+#   - input: schema
+p if {
+	input.foo == 42
+}`
+	err = testEvalWithSchemaFile(t, input, "data.test.p", schema, policyWithSchemasAnnotation, true)
+	if err != nil {
+		t.Fatalf("unexpected error for schema annotation type check: %s", err)
+	}
+
+	// Type mismatch on nested recursive property
+	policyNestedMismatch := `
+package test
+
+# METADATA
+# schemas:
+#   - input: schema
+p if {
+	input.foo.foo == "hello"
+}`
+	err = testEvalWithSchemaFile(t, input, "data.test.p", schema, policyNestedMismatch, true)
+	if err != nil {
+		t.Fatalf("unexpected error for nested recursive type check: %s", err)
+	}
+
+	// Type mismatch with inlined recursive schema
+	policyWithInlinedSchema := `
+package test
+
+# METADATA
+# schemas:
+#   - input.foo: {"type": "boolean"}
+p if {
+	input.foo == 42
+}`
+	err = testEvalWithSchemaFile(t, input, "data.test.p", schema, policyWithInlinedSchema, true)
+	if err != nil {
+		t.Fatalf("unexpected error for inlined schema type check: %s", err)
+	}
+
+	// Valid usage: no type error when comparing object property correctly
+	policyValid := `
+package test
+
+# METADATA
+# schemas:
+#   - input: schema
+p if {
+	input.foo
+}`
+	err = testEvalWithSchemaFile(t, input, "data.test.p", schema, policyValid, false)
+	if err != nil {
+		t.Fatalf("unexpected error for valid recursive schema usage: %s", err)
+	}
+}
+
+func TestEvalWithRecursiveArrayJSONSchema(t *testing.T) {
+	input := `{"tree": [[[]]]}`
+
+	schema := `{
+    "type": "object",
+    "properties": {
+        "tree": {
+            "$ref": "#/$defs/tree"
+        }
+    },
+    "$defs": {
+        "tree": {
+            "type": "array",
+            "items": {
+                "$ref": "#/$defs/tree"
+            }
+        }
+    }
+}`
+
+	policy := `package p
+
+allow if input.tree`
+
+	err := testEvalWithSchemaFile(t, input, "data.p.allow", schema, policy, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	// Type mismatch: input.tree[0] is an array per the recursive schema, not a string
+	policyMismatch := `
+package test
+
+# METADATA
+# schemas:
+#   - input: schema
+p if {
+	input.tree[0] == "hello"
+}`
+	err = testEvalWithSchemaFile(t, input, "data.test.p", schema, policyMismatch, true)
+	if err != nil {
+		t.Fatalf("unexpected error for recursive array type check: %s", err)
+	}
+}
+
+func TestEvalWithRecursiveAnyOfJSONSchema(t *testing.T) {
+	input := `{"node": ["hello", ["world"]]}`
+
+	schema := `{
+    "type": "object",
+    "properties": {
+        "node": {
+            "$ref": "#/$defs/node"
+        }
+    },
+    "$defs": {
+        "node": {
+            "anyOf": [
+                { "type": "string" },
+                {
+                    "type": "array",
+                    "items": { "$ref": "#/$defs/node" }
+                }
+            ]
+        }
+    }
+}`
+
+	policy := `package p
+
+allow if input.node`
+
+	err := testEvalWithSchemaFile(t, input, "data.p.allow", schema, policy, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+}
+
+func TestEvalWithNonRecursiveRefJSONSchema(t *testing.T) {
+	input := `{"addr": {"street": "Main St", "city": "Springfield"}}`
+
+	schema := `{
+    "type": "object",
+    "properties": {
+        "addr": {
+            "$ref": "#/$defs/address"
+        }
+    },
+    "$defs": {
+        "address": {
+            "type": "object",
+            "properties": {
+                "street": { "type": "string" },
+                "city": { "type": "string" }
+            }
+        }
+    }
+}`
+
+	policy := `package p
+
+allow if input.addr.street`
+
+	err := testEvalWithSchemaFile(t, input, "data.p.allow", schema, policy, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	// Type mismatch: input.addr.street is a string, not a number
+	policyMismatch := `
+package test
+
+# METADATA
+# schemas:
+#   - input: schema
+p if {
+	input.addr.street == 42
+}`
+	err = testEvalWithSchemaFile(t, input, "data.test.p", schema, policyMismatch, true)
+	if err != nil {
+		t.Fatalf("unexpected error for non-recursive ref type check: %s", err)
+	}
+}
+
 func TestEvalWithJSONSchema(t *testing.T) {
 
 	input := `{

--- a/v1/ast/check.go
+++ b/v1/ast/check.go
@@ -580,6 +580,11 @@ func unify1(env *TypeEnv, term *Term, tpe types.Type, union bool) bool {
 		switch tpe := tpe.(type) {
 		case *types.Array:
 			return unify1Array(env, v, tpe, union)
+		case *types.Recursive:
+			if arr, ok := tpe.Unwrap().(*types.Array); ok {
+				return unify1Array(env, v, arr, union)
+			}
+			return false
 		case types.Any:
 			if types.Compare(tpe, types.A) == 0 {
 				for i := range v.Len() {
@@ -598,6 +603,11 @@ func unify1(env *TypeEnv, term *Term, tpe types.Type, union bool) bool {
 		switch tpe := tpe.(type) {
 		case *types.Object:
 			return unify1Object(env, v, tpe, union)
+		case *types.Recursive:
+			if obj, ok := tpe.Unwrap().(*types.Object); ok {
+				return unify1Object(env, v, obj, union)
+			}
+			return false
 		case types.Any:
 			if types.Compare(tpe, types.A) == 0 {
 				v.Foreach(func(key, value *Term) {
@@ -869,6 +879,14 @@ func unifies(a, b types.Type) bool {
 
 	if a == nil || b == nil {
 		return false
+	}
+
+	// Unwrap recursive types so they compare as their underlying type.
+	if r, ok := a.(*types.Recursive); ok {
+		a = r.Unwrap()
+	}
+	if r, ok := b.(*types.Recursive); ok {
+		b = r.Unwrap()
 	}
 
 	anyA, ok1 := a.(types.Any)
@@ -1180,6 +1198,9 @@ func getOneOfForType(tpe types.Type) (result []Value) {
 			result = append(result, v)
 		}
 
+	case *types.Recursive:
+		return getOneOfForType(tpe.Unwrap())
+
 	case types.Any:
 		for _, object := range tpe {
 			objRes := getOneOfForType(object)
@@ -1234,6 +1255,9 @@ var dynamicAnyAny = types.NewDynamicProperty(types.A, types.A)
 // override takes a type t and returns a type obtained from t where the path represented by ref within it has type o (overriding the original type of that path)
 func override(ref Ref, t types.Type, o types.Type, rule *Rule) (types.Type, *Error) {
 	var newStaticProps []*types.StaticProperty
+	if r, ok := t.(*types.Recursive); ok {
+		t = r.Unwrap()
+	}
 	obj, ok := t.(*types.Object)
 	if !ok {
 		newType, err := getObjectType(ref, o, rule, dynamicAnyAny)

--- a/v1/ast/check_test.go
+++ b/v1/ast/check_test.go
@@ -315,6 +315,75 @@ func TestCheckInference(t *testing.T) {
 	}
 }
 
+func TestCheckInferenceRecursiveTypes(t *testing.T) {
+	// Build a recursive object type: object{foo: Recursive -> self, bar: number}
+	recObj := types.NewObject([]*types.StaticProperty{
+		types.NewStaticProperty("foo", nil),
+		types.NewStaticProperty("bar", types.N),
+	}, nil)
+	recObjType := types.NewRecursive("#/$defs/obj", recObj)
+	// NewObject sorts by key: index 0 = "bar", index 1 = "foo"
+	recObj.StaticProperties()[1].Value = recObjType
+
+	// Build a recursive array type: array[Recursive -> self]
+	recArrType := types.NewRecursive("#/$defs/arr", nil)
+	recArr := types.NewArray(nil, recArrType)
+	recArrType.SetType(recArr)
+
+	tests := []struct {
+		note     string
+		query    string
+		expected map[Var]types.Type
+	}{
+		{
+			note:  "object unify against recursive object",
+			query: `{"foo": x, "bar": y} = data.rec_obj`,
+			expected: map[Var]types.Type{
+				Var("x"): recObjType,
+				Var("y"): types.N,
+			},
+		},
+		{
+			note:  "array unify against recursive array",
+			query: `[x] = data.rec_arr`,
+			expected: map[Var]types.Type{
+				Var("x"): recArrType,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.note, func(t *testing.T) {
+			body := MustParseBody(tc.query)
+			checker := newTypeChecker()
+			env := checker.Env(BuiltinMap)
+
+			// Inject recursive types into the environment for data.rec_obj and data.rec_arr
+			env.tree.Put(MustParseRef("data.rec_obj"), recObjType)
+			env.tree.Put(MustParseRef("data.rec_arr"), recArrType)
+
+			env, err := checker.CheckBody(env, body)
+			if len(err) != 0 {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			for k, tpe := range tc.expected {
+				result := env.GetByValue(k)
+				if tpe == nil {
+					if result != nil {
+						t.Errorf("Expected %v type to be unset but got: %v", k, result)
+					}
+				} else {
+					if result == nil {
+						t.Errorf("Expected to infer %v => %v but got nil", k, tpe)
+					} else if types.Compare(tpe, result) != 0 {
+						t.Errorf("Expected to infer %v => %v but got %v", k, tpe, result)
+					}
+				}
+			}
+		})
+	}
+}
+
 func TestCheckInferenceRules(t *testing.T) {
 
 	// Rules must have refs resolved, safe ordering, etc. Each pair is a

--- a/v1/ast/compile.go
+++ b/v1/ast/compile.go
@@ -1639,7 +1639,9 @@ type schemaParser struct {
 }
 
 type cachedDef struct {
-	properties []*types.StaticProperty
+	typ        types.Type
+	rec        *types.Recursive
+	processing bool
 }
 
 func newSchemaParser() *schemaParser {
@@ -1652,7 +1654,7 @@ func (parser *schemaParser) parseSchema(schema any) (types.Type, error) {
 	return parser.parseSchemaWithPropertyKey(schema, "")
 }
 
-func (parser *schemaParser) parseSchemaWithPropertyKey(schema any, propertyKey string) (types.Type, error) {
+func (parser *schemaParser) parseSchemaWithPropertyKey(schema any, propertyKey string) (result types.Type, err error) {
 	subSchema, ok := schema.(*gojsonschema.SubSchema)
 	if !ok {
 		return nil, fmt.Errorf("unexpected schema type %v", subSchema)
@@ -1661,9 +1663,33 @@ func (parser *schemaParser) parseSchemaWithPropertyKey(schema any, propertyKey s
 	// Handle referenced schemas, returns directly when a $ref is found
 	if subSchema.RefSchema != nil {
 		if existing, ok := parser.definitionCache[subSchema.Ref.String()]; ok {
-			return types.NewObject(existing.properties, nil), nil
+			if existing.processing {
+				if existing.rec == nil {
+					existing.rec = types.NewRecursive(subSchema.Ref.String(), nil)
+				}
+				return existing.rec, nil
+			}
+			return existing.typ, nil
 		}
 		return parser.parseSchemaWithPropertyKey(subSchema.RefSchema, subSchema.Ref.String())
+	}
+
+	// Cache this $ref definition and finalize it via defer when parsing
+	// completes. This allows recursive $refs to be detected: if a nested
+	// $ref hits a definition that is still processing, we know it's a cycle.
+	var def *cachedDef
+	if propertyKey != "" {
+		def = &cachedDef{processing: true}
+		parser.definitionCache[propertyKey] = def
+		defer func() {
+			def.processing = false
+			if result != nil && err == nil {
+				def.typ = result
+				if def.rec != nil {
+					def.rec.SetType(result)
+				}
+			}
+		}()
 	}
 
 	// Handle anyOf
@@ -1733,28 +1759,15 @@ func (parser *schemaParser) parseSchemaWithPropertyKey(schema any, propertyKey s
 
 		} else if subSchema.Types.Contains("object") {
 			if len(subSchema.PropertiesChildren) > 0 {
-				def := &cachedDef{
-					properties: make([]*types.StaticProperty, 0, len(subSchema.PropertiesChildren)),
-				}
-				for _, pSchema := range subSchema.PropertiesChildren {
-					def.properties = append(def.properties, types.NewStaticProperty(pSchema.Property, nil))
-				}
-				if propertyKey != "" {
-					parser.definitionCache[propertyKey] = def
-				}
+				properties := make([]*types.StaticProperty, 0, len(subSchema.PropertiesChildren))
 				for _, pSchema := range subSchema.PropertiesChildren {
 					newtype, err := parser.parseSchema(pSchema)
 					if err != nil {
 						return nil, fmt.Errorf("unexpected schema type %v: %w", pSchema, err)
 					}
-					for i, prop := range def.properties {
-						if prop.Key == pSchema.Property {
-							def.properties[i].Value = newtype
-							break
-						}
-					}
+					properties = append(properties, types.NewStaticProperty(pSchema.Property, newtype))
 				}
-				return types.NewObject(def.properties, nil), nil
+				return types.NewObject(properties, nil), nil
 			}
 			return types.NewObject(nil, types.NewDynamicProperty(types.A, types.A)), nil
 

--- a/v1/ast/env.go
+++ b/v1/ast/env.go
@@ -320,7 +320,11 @@ func (n *typeTreeNode) Insert(path Ref, tpe types.Type, env *TypeEnv) {
 			curr.children.Put(child.key, child)
 		} else if child.value != nil && i+1 < len(path) {
 			// If child has an object value, merge the new value into it.
-			if o, ok := child.value.(*types.Object); ok {
+			cv := child.value
+			if r, ok := cv.(*types.Recursive); ok {
+				cv = r.Unwrap()
+			}
+			if o, ok := cv.(*types.Object); ok {
 				var err error
 				child.value, err = insertIntoObject(o, path[i+1:], tpe, env)
 				if err != nil {
@@ -334,15 +338,26 @@ func (n *typeTreeNode) Insert(path Ref, tpe types.Type, env *TypeEnv) {
 
 	curr.value = mergeTypes(curr.value, tpe)
 
-	if _, ok := tpe.(*types.Object); ok && curr.children.Len() > 0 {
+	_, isObj := tpe.(*types.Object)
+	if !isObj {
+		if r, ok := tpe.(*types.Recursive); ok {
+			_, isObj = r.Unwrap().(*types.Object)
+		}
+	}
+	if isObj && curr.children.Len() > 0 {
 		// merge all leafs into the inserted object
+		cv := curr.value
+		if r, ok := cv.(*types.Recursive); ok {
+			cv = r.Unwrap()
+		}
 		for p, t := range curr.Leafs() {
 			var err error
-			curr.value, err = insertIntoObject(curr.value.(*types.Object), *p, t, env)
+			cv, err = insertIntoObject(cv.(*types.Object), *p, t, env)
 			if err != nil {
 				panic(fmt.Errorf("unreachable, insertIntoObject: %w", err))
 			}
 		}
+		curr.value = cv
 	}
 }
 
@@ -361,6 +376,14 @@ func mergeTypes(a, b types.Type) types.Type {
 
 	if b == nil {
 		return a
+	}
+
+	// Unwrap recursive types so they merge as their underlying type.
+	if r, ok := a.(*types.Recursive); ok {
+		a = r.Unwrap()
+	}
+	if r, ok := b.(*types.Recursive); ok {
+		b = r.Unwrap()
 	}
 
 	switch a := a.(type) {

--- a/v1/types/decode.go
+++ b/v1/types/decode.go
@@ -12,15 +12,16 @@ import (
 )
 
 const (
-	typeNull     = "null"
-	typeBoolean  = "boolean"
-	typeNumber   = "number"
-	typeString   = "string"
-	typeArray    = "array"
-	typeSet      = "set"
-	typeObject   = "object"
-	typeAny      = "any"
-	typeFunction = "function"
+	typeNull      = "null"
+	typeBoolean   = "boolean"
+	typeNumber    = "number"
+	typeString    = "string"
+	typeArray     = "array"
+	typeSet       = "set"
+	typeObject    = "object"
+	typeAny       = "any"
+	typeFunction  = "function"
+	typeRecursive = "recursive"
 )
 
 // Unmarshal deserializes bs and returns the resulting type.

--- a/v1/types/types.go
+++ b/v1/types/types.go
@@ -48,15 +48,16 @@ type Type interface {
 	json.Marshaler
 }
 
-func (Null) typeMarker() string     { return typeNull }
-func (Boolean) typeMarker() string  { return typeBoolean }
-func (Number) typeMarker() string   { return typeNumber }
-func (String) typeMarker() string   { return typeString }
-func (*Array) typeMarker() string   { return typeArray }
-func (*Object) typeMarker() string  { return typeObject }
-func (*Set) typeMarker() string     { return typeSet }
-func (Any) typeMarker() string      { return typeAny }
-func (Function) typeMarker() string { return typeFunction }
+func (Null) typeMarker() string       { return typeNull }
+func (Boolean) typeMarker() string    { return typeBoolean }
+func (Number) typeMarker() string     { return typeNumber }
+func (String) typeMarker() string     { return typeString }
+func (*Array) typeMarker() string     { return typeArray }
+func (*Object) typeMarker() string    { return typeObject }
+func (*Set) typeMarker() string       { return typeSet }
+func (Any) typeMarker() string        { return typeAny }
+func (Function) typeMarker() string   { return typeFunction }
+func (*Recursive) typeMarker() string { return typeRecursive }
 
 // Null represents the null type.
 type Null struct{}
@@ -121,6 +122,13 @@ func unwrap(t Type) Type {
 	default:
 		return t
 	}
+}
+
+func unwrapRecursive(t Type) Type {
+	if r, ok := t.(*Recursive); ok {
+		return r.typ
+	}
+	return t
 }
 
 func (Null) String() string {
@@ -508,6 +516,36 @@ func mergeObjects(a, b *Object) *Object {
 	return NewObject(staticProps, dynamicProps)
 }
 
+// Recursive is a Type that contains a pointer back to itself.
+// This is for representing recursive JSON Schema definitions.
+type Recursive struct {
+	name string // the $ref key (e.g. "#/$defs/foo")
+	typ  Type   // the referenced type (can be *Object, *Array, or Any)
+}
+
+// NewRecursive returns a new Recursive type that wraps typ under the given name.
+func NewRecursive(name string, typ Type) *Recursive {
+	return &Recursive{name: name, typ: typ}
+}
+
+func (t *Recursive) String() string {
+	return "recursive(" + t.name + ")"
+}
+
+func (t *Recursive) Unwrap() Type {
+	return t.typ
+}
+
+func (t *Recursive) SetType(typ Type) {
+	t.typ = typ
+}
+
+func (t *Recursive) MarshalJSON() ([]byte, error) {
+	return json.Marshal(map[string]any{
+		"name": t.name,
+	})
+}
+
 // Any represents a dynamic type.
 type Any []Type
 
@@ -845,7 +883,7 @@ func (a FuncArgs) Arg(x int) Type {
 
 // Compare returns -1, 0, 1 based on comparison between a and b.
 func Compare(a, b Type) int {
-	a, b = unwrap(a), unwrap(b)
+	a, b = unwrapRecursive(unwrap(a)), unwrapRecursive(unwrap(b))
 	x := typeOrder(a)
 	y := typeOrder(b)
 	if x > y {
@@ -859,6 +897,9 @@ func Compare(a, b Type) int {
 	case *Array:
 		arrA := a.(*Array)
 		arrB := b.(*Array)
+		if arrA == arrB {
+			return 0
+		}
 		if arrA.dynamic != nil && arrB.dynamic == nil {
 			return 1
 		} else if arrB.dynamic != nil && arrA.dynamic == nil {
@@ -873,6 +914,9 @@ func Compare(a, b Type) int {
 	case *Object:
 		objA := a.(*Object)
 		objB := b.(*Object)
+		if objA == objB {
+			return 0
+		}
 		if objA.dynamic != nil && objB.dynamic == nil {
 			return 1
 		} else if objB.dynamic != nil && objA.dynamic == nil {
@@ -985,7 +1029,7 @@ func Or(a, b Type) Type {
 
 // Select returns a property or item of a.
 func Select(a Type, x any) Type {
-	switch a := unwrap(a).(type) {
+	switch a := unwrapRecursive(unwrap(a)).(type) {
 	case *Array:
 		n, ok := x.(json.Number)
 		if !ok {
@@ -1028,7 +1072,7 @@ func Select(a Type, x any) Type {
 // keys are always number types, for objects the keys are always string types,
 // and for sets the keys are always the type of the set element.
 func Keys(a Type) Type {
-	switch a := unwrap(a).(type) {
+	switch a := unwrapRecursive(unwrap(a)).(type) {
 	case *Array:
 		return N
 	case *Object:
@@ -1058,7 +1102,7 @@ func Keys(a Type) Type {
 
 // Values returns the type of values that can be enumerated for a.
 func Values(a Type) Type {
-	switch a := unwrap(a).(type) {
+	switch a := unwrapRecursive(unwrap(a)).(type) {
 	case *Array:
 		var tpe Type
 		for i := range a.static {
@@ -1091,32 +1135,52 @@ func Values(a Type) Type {
 
 // Nil returns true if a's type is unknown.
 func Nil(a Type) bool {
-	switch a := unwrap(a).(type) {
-	case nil:
+	return nilRec(a, nil)
+}
+
+func nilRec(a Type, seen map[Type]struct{}) bool {
+	a = unwrapRecursive(unwrap(a))
+	if a == nil {
 		return true
+	}
+	switch a := a.(type) {
 	case *Function:
-		if slices.ContainsFunc(a.args, Nil) {
+		if slices.ContainsFunc(a.args, func(t Type) bool { return nilRec(t, seen) }) {
 			return true
 		}
-		return Nil(a.result)
+		return nilRec(a.result, seen)
 	case *Array:
-		if slices.ContainsFunc(a.static, Nil) {
+		if _, ok := seen[a]; ok {
+			return false
+		}
+		if seen == nil {
+			seen = make(map[Type]struct{})
+		}
+		seen[a] = struct{}{}
+		if slices.ContainsFunc(a.static, func(t Type) bool { return nilRec(t, seen) }) {
 			return true
 		}
 		if a.dynamic != nil {
-			return Nil(a.dynamic)
+			return nilRec(a.dynamic, seen)
 		}
 	case *Object:
+		if _, ok := seen[a]; ok {
+			return false
+		}
+		if seen == nil {
+			seen = make(map[Type]struct{})
+		}
+		seen[a] = struct{}{}
 		for i := range a.static {
-			if Nil(a.static[i].Value) {
+			if nilRec(a.static[i].Value, seen) {
 				return true
 			}
 		}
 		if a.dynamic != nil {
-			return Nil(a.dynamic.Key) || Nil(a.dynamic.Value)
+			return nilRec(a.dynamic.Key, seen) || nilRec(a.dynamic.Value, seen)
 		}
 	case *Set:
-		return Nil(a.of)
+		return nilRec(a.of, seen)
 	}
 	return false
 }
@@ -1179,7 +1243,7 @@ func typeSliceCompare(a, b []Type) int {
 }
 
 func typeOrder(x Type) int {
-	switch unwrap(x).(type) {
+	switch unwrapRecursive(unwrap(x)).(type) {
 	case Null:
 		return 0
 	case Boolean:

--- a/v1/types/types_test.go
+++ b/v1/types/types_test.go
@@ -7,6 +7,7 @@ package types
 import (
 	"encoding/json"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/open-policy-agent/opa/v1/util"
@@ -371,6 +372,145 @@ func TestNil(t *testing.T) {
 		t.Fatalf("Expected %v type to be unknown", tpe)
 	}
 
+}
+
+func TestNilCircularObject(t *testing.T) {
+	// Construct a circular type using Recursive: an Object whose property
+	// is a Recursive type pointing back to itself.
+	// Nil() must terminate and return false (the type is known, just recursive).
+	obj := NewObject([]*StaticProperty{
+		NewStaticProperty("self", nil),
+	}, nil)
+	obj.StaticProperties()[0].Value = NewRecursive("test", obj)
+
+	if Nil(obj) {
+		t.Fatal("Expected Nil to return false for circular object type")
+	}
+}
+
+func TestNilCircularArray(t *testing.T) {
+	rec := NewRecursive("tree", nil)
+	arr := NewArray(nil, rec)
+	rec.SetType(arr)
+
+	if Nil(arr) {
+		t.Fatal("Expected Nil to return false for circular array type")
+	}
+}
+
+func TestRecursiveType(t *testing.T) {
+	// Build a recursive type: object<"foo": recursive(#/$defs/foo), "bar": number>
+	obj := NewObject([]*StaticProperty{
+		NewStaticProperty("foo", nil),
+		NewStaticProperty("bar", N),
+	}, nil)
+	rec := NewRecursive("#/$defs/foo", obj)
+	// NewObject sorts by key, so "bar" is at index 0 and "foo" is at index 1.
+	obj.StaticProperties()[1].Value = rec
+
+	t.Run("String", func(t *testing.T) {
+		s := rec.String()
+		if s != "recursive(#/$defs/foo)" {
+			t.Fatalf("expected recursive(#/$defs/foo), got %s", s)
+		}
+		// Verify the containing object can be stringified without infinite loop.
+		s = obj.String()
+		if !strings.Contains(s, "recursive(#/$defs/foo)") {
+			t.Fatalf("expected object string to contain recursive reference, got %s", s)
+		}
+	})
+
+	t.Run("Unwrap", func(t *testing.T) {
+		if rec.Unwrap() != obj {
+			t.Fatal("Unwrap should return the wrapped object")
+		}
+	})
+
+	t.Run("Compare", func(t *testing.T) {
+		// Recursive should compare equal to its underlying object
+		if Compare(rec, obj) != 0 {
+			t.Fatal("Recursive should compare equal to its underlying object")
+		}
+	})
+
+	t.Run("Select", func(t *testing.T) {
+		// Selecting "bar" through the recursive type should return Number
+		result := Select(rec, "bar")
+		if Compare(result, N) != 0 {
+			t.Fatalf("expected number, got %v", result)
+		}
+		// Selecting "foo" should return the Recursive type itself
+		result = Select(rec, "foo")
+		if result == nil {
+			t.Fatal("expected non-nil selecting 'foo' from recursive type")
+		}
+	})
+
+	t.Run("Keys", func(t *testing.T) {
+		k := Keys(rec)
+		if k == nil {
+			t.Fatal("expected non-nil keys")
+		}
+	})
+
+	t.Run("Values", func(t *testing.T) {
+		v := Values(rec)
+		if v == nil {
+			t.Fatal("expected non-nil values")
+		}
+	})
+
+	t.Run("Contains", func(t *testing.T) {
+		if !Contains(rec, obj) {
+			t.Fatal("Recursive should contain its underlying object")
+		}
+	})
+}
+
+func TestRecursiveArray(t *testing.T) {
+	rec := NewRecursive("#/$defs/tree", nil)
+	arr := NewArray(nil, rec)
+	rec.SetType(arr)
+
+	t.Run("String", func(t *testing.T) {
+		s := rec.String()
+		if s != "recursive(#/$defs/tree)" {
+			t.Fatalf("expected recursive(#/$defs/tree), got %s", s)
+		}
+	})
+
+	t.Run("Unwrap", func(t *testing.T) {
+		if rec.Unwrap() != arr {
+			t.Fatal("Unwrap should return the wrapped array")
+		}
+	})
+
+	t.Run("Compare", func(t *testing.T) {
+		if Compare(rec, arr) != 0 {
+			t.Fatal("Recursive should compare equal to its underlying array")
+		}
+	})
+
+	t.Run("Select", func(t *testing.T) {
+		result := Select(rec, json.Number("0"))
+		if result == nil {
+			t.Fatal("expected non-nil selecting from recursive array type")
+		}
+	})
+
+	t.Run("Keys", func(t *testing.T) {
+		k := Keys(rec)
+		if Compare(k, N) != 0 {
+			t.Fatalf("expected number keys for array, got %v", k)
+		}
+	})
+
+	t.Run("Values", func(t *testing.T) {
+		v := Values(rec)
+		if v == nil {
+			t.Fatal("expected non-nil values")
+		}
+	})
 }
 
 func TestMarshalJSON(t *testing.T) {


### PR DESCRIPTION
resolve: https://github.com/open-policy-agent/opa/issues/6099

Prevent stack overflows by detecting recursion when parsing JSON Schemas. Using a new `Recursive` type that contains a pointer to the self-reference.

