### PR TITLE
Fix logBuffer eviction loop only dropping one element

### DIFF
--- a/v1/plugins/logs/buffer.go
+++ b/v1/plugins/logs/buffer.go
@@ -33,7 +33,15 @@ func (lb *logBuffer) Push(bs []byte) (dropped int) {
 	size := int64(len(bs))
 
 	if lb.limit > 0 {
-		for elem := lb.l.Front(); elem != nil && (lb.usage+size > lb.limit); elem = elem.Next() {
+		if size > lb.limit {
+			return 1
+		}
+
+		for lb.usage+size > lb.limit {
+			elem := lb.l.Front()
+			if elem == nil {
+				break
+			}
 			drop := elem.Value.(logBufferElem).bs
 			lb.l.Remove(elem)
 			lb.usage -= int64(len(drop))

--- a/v1/plugins/logs/buffer_test.go
+++ b/v1/plugins/logs/buffer_test.go
@@ -54,3 +54,57 @@ func TestLogBuffer(t *testing.T) {
 	}
 
 }
+
+func TestLogBufferDropsMultipleItems(t *testing.T) {
+	buffer := newLogBuffer(int64(20))
+
+	buffer.Push(bytes.Repeat([]byte(`a`), 5))
+	buffer.Push(bytes.Repeat([]byte(`b`), 5))
+	buffer.Push(bytes.Repeat([]byte(`c`), 5))
+	buffer.Push(bytes.Repeat([]byte(`d`), 5))
+
+	// Push a 15-byte item into a full 20-byte buffer.
+	// Must evict 3 items (a, b, c) to make room, not just 1.
+	dropped := buffer.Push(bytes.Repeat([]byte(`e`), 15))
+	if dropped != 3 {
+		t.Fatalf("Expected dropped to be 3 but got %v", dropped)
+	}
+
+	if buffer.Len() != 2 {
+		t.Fatalf("Expected buffer length to be 2 but got %v", buffer.Len())
+	}
+
+	if buffer.usage != 20 {
+		t.Fatalf("Expected buffer usage to be 20 but got %v", buffer.usage)
+	}
+
+	bs := buffer.Pop()
+	if exp := bytes.Repeat([]byte(`d`), 5); !bytes.Equal(bs, exp) {
+		t.Fatalf("Expected %v but got %v", exp, bs)
+	}
+
+	bs = buffer.Pop()
+	if exp := bytes.Repeat([]byte(`e`), 15); !bytes.Equal(bs, exp) {
+		t.Fatalf("Expected %v but got %v", exp, bs)
+	}
+}
+
+func TestLogBufferOversizedItem(t *testing.T) {
+	buffer := newLogBuffer(int64(20))
+
+	buffer.Push(bytes.Repeat([]byte(`a`), 10))
+	buffer.Push(bytes.Repeat([]byte(`b`), 10))
+
+	dropped := buffer.Push(bytes.Repeat([]byte(`c`), 21))
+	if dropped != 1 {
+		t.Fatalf("Expected dropped to be 1 but got %v", dropped)
+	}
+
+	if buffer.Len() != 2 {
+		t.Fatalf("Expected buffer length to be 2 but got %v", buffer.Len())
+	}
+
+	if buffer.usage != 20 {
+		t.Fatalf("Expected buffer usage to be 20 but got %v", buffer.usage)
+	}
+}


### PR DESCRIPTION
The logBuffer.Push eviction loop used a for loop that called elem.Next() after list.Remove(elem). List clears the element's pointers on removal, so Next() always returned nil after the first eviction — meaning only one element was ever dropped per push, regardless of how much space was needed.

The fix replaces the iterator with a while-loop that re-reads Front() each iteration. It also rejects items that individually exceed the buffer limit, preventing them from evicting all existing entries only to leave the buffer over capacity.