### PR TITLE
logging: keep forwarding from BufferedLogger after Flush()

### DIFF
--- a/v1/logging/buffered_logger.go
+++ b/v1/logging/buffered_logger.go
@@ -16,12 +16,15 @@ type logEntry struct {
 
 // BufferedLogger captures log entries in memory until Flush is called,
 // at which point it replays all buffered entries to the target logger.
-// After Flush() is called, the BufferedLogger should not be used anymore.
+// After Flush, subsequent log calls are forwarded to the flush target.
+// This ensures that code holding a cached reference to the BufferedLogger
+// (or a WithFields derivative) continues to work correctly.
 type BufferedLogger struct {
 	mu           sync.Mutex
 	buffer       []logEntry
 	maxEntries   int
 	currentLevel Level
+	target       Logger
 }
 
 // NewBufferedLogger creates a new buffered logger that will buffer up to maxEntries.
@@ -42,20 +45,38 @@ func (b *BufferedLogger) addToBuffer(level Level, format string, args []any, fie
 		message = fmt.Sprintf(format, args...)
 	}
 
-	entry := logEntry{
-		level:   level,
-		message: message,
-		fields:  fields,
-		time:    time.Now(),
-	}
-
 	b.mu.Lock()
-	defer b.mu.Unlock()
+	if b.target != nil {
+		target := b.target
+		b.mu.Unlock()
+
+		logger := target
+		if len(fields) > 0 {
+			logger = target.WithFields(fields)
+		}
+		switch level {
+		case Debug:
+			logger.Debug("%s", message)
+		case Info:
+			logger.Info("%s", message)
+		case Warn:
+			logger.Warn("%s", message)
+		case Error:
+			logger.Error("%s", message)
+		}
+		return
+	}
 
 	if len(b.buffer) >= b.maxEntries {
 		b.buffer = b.buffer[1:]
 	}
-	b.buffer = append(b.buffer, entry)
+	b.buffer = append(b.buffer, logEntry{
+		level:   level,
+		message: message,
+		fields:  fields,
+		time:    time.Now(),
+	})
+	b.mu.Unlock()
 }
 
 func (*BufferedLogger) logToTarget(target Logger, entry logEntry) {
@@ -105,6 +126,9 @@ func (b *BufferedLogger) WithFields(fields map[string]any) Logger {
 func (b *BufferedLogger) GetLevel() Level {
 	b.mu.Lock()
 	defer b.mu.Unlock()
+	if b.target != nil {
+		return b.target.GetLevel()
+	}
 	return b.currentLevel
 }
 
@@ -113,6 +137,9 @@ func (b *BufferedLogger) SetLevel(level Level) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.currentLevel = level
+	if b.target != nil {
+		b.target.SetLevel(level)
+	}
 }
 
 // Close discards all buffered entries without flushing them.
@@ -124,14 +151,15 @@ func (b *BufferedLogger) Close() {
 }
 
 // Flush replays all buffered entries to the target logger.
-// After calling Flush, the BufferedLogger should not be used anymore.
-// The caller should switch to using the target logger directly.
+// After Flush, subsequent log calls on this BufferedLogger (and any
+// previously obtained WithFields loggers) are forwarded to the target.
 func (b *BufferedLogger) Flush(targetLogger Logger) {
 	if targetLogger == nil {
 		return
 	}
 
 	b.mu.Lock()
+	b.target = targetLogger
 	targetLogger.SetLevel(b.currentLevel)
 	entries := b.buffer
 	b.buffer = nil

--- a/v1/logging/buffered_logger_test.go
+++ b/v1/logging/buffered_logger_test.go
@@ -2,6 +2,7 @@ package logging
 
 import (
 	"fmt"
+	"sync"
 	"testing"
 )
 
@@ -82,9 +83,12 @@ func TestBufferedLoggerBufferOverflow(t *testing.T) {
 func TestBufferedLoggerFlush(t *testing.T) {
 	buffered := NewBufferedLogger(100)
 
+	// Cache a WithFields reference before flush (simulates what plugins do)
+	cached := buffered.WithFields(map[string]any{"plugin": "bundle"})
+
 	buffered.Info("buffered 1")
 	buffered.Warn("buffered 2")
-	buffered.Error("buffered 3")
+	cached.Error("buffered 3")
 
 	testLog := &captureLogger{entries: make([]string, 0)}
 	buffered.Flush(testLog)
@@ -100,11 +104,27 @@ func TestBufferedLoggerFlush(t *testing.T) {
 		}
 	}
 
-	// After flush, use the target logger directly (not the buffered logger)
-	testLog.Info("direct message")
+	// After flush, log via cached reference — should forward to target
+	cached.Info("forwarded via cached ref")
+	buffered.Info("forwarded directly")
 
-	if len(testLog.entries) != 4 {
-		t.Errorf("Expected 4 entries after direct log, got %d", len(testLog.entries))
+	if len(testLog.entries) != 5 {
+		t.Fatalf("Expected 5 entries after forwarding, got %d", len(testLog.entries))
+	}
+	if testLog.entries[3] != "forwarded via cached ref" {
+		t.Errorf("Entry 3: expected 'forwarded via cached ref', got %q", testLog.entries[3])
+	}
+	if testLog.entries[4] != "forwarded directly" {
+		t.Errorf("Entry 4: expected 'forwarded directly', got %q", testLog.entries[4])
+	}
+
+	// SetLevel/GetLevel should forward to target after flush
+	buffered.SetLevel(Error)
+	if got := testLog.GetLevel(); got != Error {
+		t.Errorf("Expected target level Error after SetLevel, got %v", got)
+	}
+	if got := buffered.GetLevel(); got != Error {
+		t.Errorf("Expected buffered GetLevel to return Error, got %v", got)
 	}
 }
 
@@ -132,9 +152,36 @@ func TestBufferedLoggerConcurrentWrites(t *testing.T) {
 	if count != 1000 {
 		t.Errorf("Expected 1000 buffered messages, got %d", count)
 	}
+
+	// Flush and verify concurrent forwarding works
+	testLog := &captureLogger{entries: make([]string, 0)}
+	buffered.Flush(testLog)
+
+	cachedLoggers := make([]Logger, 10)
+	for i := range cachedLoggers {
+		cachedLoggers[i] = buffered.WithFields(map[string]any{"goroutine": i})
+	}
+
+	var wg sync.WaitGroup
+	for i, logger := range cachedLoggers {
+		wg.Add(1)
+		go func(id int, l Logger) {
+			defer wg.Done()
+			for j := range 100 {
+				l.Info("fwd %d-%d", id, j)
+			}
+		}(i, logger)
+	}
+	wg.Wait()
+
+	// 1000 flushed + 1000 forwarded
+	if len(testLog.entries) != 2000 {
+		t.Errorf("Expected 2000 total entries, got %d", len(testLog.entries))
+	}
 }
 
 type captureLogger struct {
+	mu      sync.Mutex
 	entries []string
 	level   Level
 }
@@ -144,7 +191,9 @@ func (c *captureLogger) Debug(format string, args ...any) {
 	if len(args) > 0 {
 		msg = fmt.Sprintf(format, args...)
 	}
+	c.mu.Lock()
 	c.entries = append(c.entries, msg)
+	c.mu.Unlock()
 }
 
 func (c *captureLogger) Info(format string, args ...any) {
@@ -152,7 +201,9 @@ func (c *captureLogger) Info(format string, args ...any) {
 	if len(args) > 0 {
 		msg = fmt.Sprintf(format, args...)
 	}
+	c.mu.Lock()
 	c.entries = append(c.entries, msg)
+	c.mu.Unlock()
 }
 
 func (c *captureLogger) Warn(format string, args ...any) {
@@ -160,7 +211,9 @@ func (c *captureLogger) Warn(format string, args ...any) {
 	if len(args) > 0 {
 		msg = fmt.Sprintf(format, args...)
 	}
+	c.mu.Lock()
 	c.entries = append(c.entries, msg)
+	c.mu.Unlock()
 }
 
 func (c *captureLogger) Error(format string, args ...any) {
@@ -168,7 +221,9 @@ func (c *captureLogger) Error(format string, args ...any) {
 	if len(args) > 0 {
 		msg = fmt.Sprintf(format, args...)
 	}
+	c.mu.Lock()
 	c.entries = append(c.entries, msg)
+	c.mu.Unlock()
 }
 
 func (c *captureLogger) WithFields(fields map[string]any) Logger {

--- a/v1/plugins/logger_integration_test.go
+++ b/v1/plugins/logger_integration_test.go
@@ -153,20 +153,33 @@ func TestBufferedLoggerWithFields(t *testing.T) {
 
 	bufferedLogger.Flush(testLog)
 
-	// After flush, use the target logger directly
+	// After flush, log via the SAME cached WithFields reference.
+	// This is the scenario where plugins hold a stale reference to the
+	// BufferedLogger: the forwarding behavior ensures these logs reach
+	// the resolved target.
+	logger1.Info("forwarded message")
+
+	// Also log directly on the target for comparison.
 	logger2 := testLog.WithFields(map[string]any{"component": "server"})
 	logger2.Info("direct message")
 
 	entries := testLog.Entries()
-	if len(entries) != 2 {
-		t.Fatalf("Expected 2 entries, got %d", len(entries))
+	if len(entries) != 3 {
+		t.Fatalf("Expected 3 entries, got %d", len(entries))
 	}
 
 	if entries[0].Fields["component"] != "runtime" {
 		t.Errorf("First entry: expected component=runtime, got %v", entries[0].Fields)
 	}
 
-	if entries[1].Fields["component"] != "server" {
-		t.Errorf("Second entry: expected component=server, got %v", entries[1].Fields)
+	if entries[1].Message != "forwarded message" {
+		t.Errorf("Second entry: expected 'forwarded message', got %q", entries[1].Message)
+	}
+	if entries[1].Fields["component"] != "runtime" {
+		t.Errorf("Second entry: expected component=runtime, got %v", entries[1].Fields)
+	}
+
+	if entries[2].Fields["component"] != "server" {
+		t.Errorf("Third entry: expected component=server, got %v", entries[2].Fields)
 	}
 }


### PR DESCRIPTION
The BufferedLogger introduced for logger plugins is created at startup and passed to the `*plugins.Manager`. Plugins (bundle, discovery, status, logs) cache `manager.Logger()` in a field at construction time. After `Manager.Start()`, `ResolveBufferedLogger` flushes the buffer and swaps the `Manager'`s logger to a `StandardLogger` — but the plugins still hold the old `BufferedLogger`. Since bundle loading is async, the "Bundle loaded and activated successfully" message (and similar) gets written to the already-flushed buffer where nobody reads it.

----------

I had thought about doing it like this from the start, but then I thought not doing it was simpler. Turns out there's a reason to do it ✨ 