### PR TITLE
chore: typo `nonexistant` -> `nonexistent` in compile_test note

### DIFF
--- a/v1/ast/compile_test.go
+++ b/v1/ast/compile_test.go
@@ -8774,7 +8774,7 @@ func TestCompilerMockFunction(t *testing.T) {
 			`,
 		},
 		{
-			note: "invalid ref: nonexistant",
+			note: "invalid ref: nonexistent",
 			module: `package test
 				p if { true with time.now_ns as now }
 			`,


### PR DESCRIPTION
One-character typo fix inside `v1/ast/compile_test.go:8777` (test case note). No functional change.

Signed-off-by: SAY-5 <SAY-5@users.noreply.github.com>