### PR TITLE
Add API method to match tests by ref prefixes

### DIFF
--- a/v1/tester/runner.go
+++ b/v1/tester/runner.go
@@ -115,6 +115,20 @@ func (unknownResolver) Resolve(_ ast.Ref) (any, error) {
 	return "UNKNOWN", nil
 }
 
+type prefixMatchers []ast.Ref
+
+// Match returns true if any of it's prefixes matches ref, or it contains no prefixes.
+func (pm prefixMatchers) Match(ref ast.Ref) bool {
+	return len(pm) == 0 || slices.ContainsFunc(pm, ref.HasPrefix)
+}
+
+// AnyPrefixMatcher returns true if prefix is a prefix of any of the matchers, or it contains no prefixes.
+func (pm prefixMatchers) AnyPrefixMatcher(prefix ast.Ref) bool {
+	return len(pm) == 0 || slices.ContainsFunc(pm, func(matcher ast.Ref) bool {
+		return matcher.HasPrefix(prefix)
+	})
+}
+
 func termToString(t *ast.Term) string {
 	ti, err := ast.ValueToInterface(t.Value, unknownResolver{})
 	if err != nil {
@@ -270,6 +284,7 @@ type Runner struct {
 	timeout               time.Duration
 	modules               map[string]*ast.Module
 	bundles               map[string]*bundle.Bundle
+	prefixMatchers        prefixMatchers
 	filter                string
 	target                string // target type (wasm, rego, etc.)
 	customBuiltins        []*Builtin
@@ -397,6 +412,19 @@ func (r *Runner) SetModules(modules map[string]*ast.Module) *Runner {
 // for discovering and evaluating tests.
 func (r *Runner) SetBundles(bundles map[string]*bundle.Bundle) *Runner {
 	r.bundles = bundles
+	return r
+}
+
+// SetPrefixMatchers will have the test runner use the provided ref prefixes as a
+// filter for which test cases to run- This could either be a shorther path to e.g.
+// run all tests in one or more packages, or a full refs pointing to to individual
+// tests. Potential matches are evaluated in ascending order based on ref length.
+//
+// Experimental: This function is used to allow editor integrations more
+// flexibility in selecting which tests to run, and the implementation may
+// change depending on what we learn from that.
+func (r *Runner) SetPrefixMatchers(prefixes ...ast.Ref) *Runner {
+	r.prefixMatchers = slices.SortedFunc(slices.Values(prefixes), util.SliceLenCompare)
 	return r
 }
 
@@ -536,11 +564,17 @@ func (r *Runner) runTests(ctx context.Context, txn storage.Transaction, enablePr
 		defer cancelTests()
 
 		for _, module := range r.compiler.Modules {
-			for _, rule := range module.Rules {
-				wg.Add(1)
-				go func() {
-					defer wg.Done()
+			// If:
+			// 1. prefix matchers have been provided, and
+			// 2. no provided prefix matches the package path, and
+			// 3. the package path is not a prefix of any provided matcher
+			// We can skip this the module entirely
+			if !r.prefixMatchers.Match(module.Package.Path) && !r.prefixMatchers.AnyPrefixMatcher(module.Package.Path) {
+				continue
+			}
 
+			for _, rule := range module.Rules {
+				wg.Go(func() {
 					select {
 					case <-stopCtx.Done():
 						return
@@ -567,7 +601,7 @@ func (r *Runner) runTests(ctx context.Context, txn storage.Transaction, enablePr
 					if stop {
 						cancelTests()
 					}
-				}()
+				})
 			}
 		}
 		wg.Wait()
@@ -576,10 +610,17 @@ func (r *Runner) runTests(ctx context.Context, txn storage.Transaction, enablePr
 	return ch, nil
 }
 
-func (*Runner) shouldRun(rule *ast.Rule, testRegex *regexp.Regexp) bool {
+func (r *Runner) shouldRun(rule *ast.Rule, testRegex *regexp.Regexp) bool {
+	ruleRef := rule.Head.Ref().GroundPrefix()
+	// len check even though the Match function does this already, as we'll
+	// want to avoid the Extend allocations in the common case of no prefixes configured
+	if len(r.prefixMatchers) > 0 && !r.prefixMatchers.Match(rule.Module.Package.Path.Extend(ruleRef)) {
+		return false
+	}
+
 	var ref ast.Ref
 
-	for _, term := range rule.Head.Ref().GroundPrefix() {
+	for _, term := range ruleRef {
 		ref = ref.Append(term)
 
 		var n string
@@ -588,8 +629,6 @@ func (*Runner) shouldRun(rule *ast.Rule, testRegex *regexp.Regexp) bool {
 			n = string(v)
 		case ast.String:
 			n = string(v)
-		default:
-			n = ""
 		}
 
 		if strings.HasPrefix(n, TestPrefix) || strings.HasPrefix(n, SkipTestPrefix) {
@@ -740,15 +779,15 @@ func injectTestCaseFunc(compiler *ast.Compiler) *ast.Error {
 							// Find the lowest (highest up the body) individual index of each var referenced in the rhs,
 							// and select the highest (lowest down the body) of those
 
-							// TODO: Use TypedValueMap once synced with main
-							lowest := ast.NewValueMap()
+							lowest := util.NewHasherMap[ast.Var, int](cmpEqual)
 
 							for j := i - 1; j >= 0; j-- {
 								expr := rule.Body[j]
 								ast.WalkVars(expr, func(v ast.Var) bool {
 									if vars.Contains(v) {
-										// We override the value for each var, so we get the lowest index (line highest up the body) for each
-										lowest.Put(v, ast.Number(strconv.Itoa(j)))
+										// We override the value for each var, so we get the lowest index
+										// (line highest up the body) for each
+										lowest.Put(v, j)
 										return true
 									}
 									return false
@@ -756,20 +795,18 @@ func injectTestCaseFunc(compiler *ast.Compiler) *ast.Error {
 							}
 
 							highest := 0
-							lowest.Iter(func(k, v ast.Value) bool {
-								if n, err := strconv.Atoi(string(v.(ast.Number))); err == nil {
-									if n > highest {
-										highest = n
-									}
+							lowest.Iter(func(k ast.Var, v int) bool {
+								if v > highest {
+									highest = v
 								}
+
 								return false
 							})
 
 							if highest < i {
-								// The expression is lower in the body than the lowes line of any expression that might contribute to its assignment
-								// Move the expression to just after the lowest line
-								moveTo := highest + 1
-								rule.Body, moved = moveExpr(rule.Body, i, moveTo)
+								// The expression is lower in the body than the lowest line of any expression that might
+								// contribute to its assignment. Move the expression to just after the lowest line.
+								rule.Body, moved = moveExpr(rule.Body, i, highest+1)
 							}
 						}
 					}
@@ -787,9 +824,7 @@ func injectTestCaseFunc(compiler *ast.Compiler) *ast.Error {
 
 			injectBelowMap := ast.NewValueMap()
 			for _, term := range argsRef {
-				for i := len(rule.Body) - 1; i >= 0; i-- {
-					expr := rule.Body[i]
-
+				for i, expr := range slices.Backward(rule.Body) {
 					ast.WalkVars(expr, func(v ast.Var) bool {
 						if v.Equal(term.Value) {
 							injectBelowMap.Put(v, ast.Number(strconv.Itoa(i)))
@@ -819,6 +854,10 @@ func injectTestCaseFunc(compiler *ast.Compiler) *ast.Error {
 		}
 	}
 	return nil
+}
+
+func cmpEqual[T comparable](a, b T) bool {
+	return a == b
 }
 
 func isLocalVar(v ast.Value) bool {

--- a/v1/tester/runner_test.go
+++ b/v1/tester/runner_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/open-policy-agent/opa/v1/tester"
 	"github.com/open-policy-agent/opa/v1/topdown"
 	"github.com/open-policy-agent/opa/v1/types"
+	"github.com/open-policy-agent/opa/v1/util"
 	"github.com/open-policy-agent/opa/v1/util/test"
 )
 
@@ -60,9 +61,10 @@ type expectedTestResult struct {
 }
 
 type testRunConfig struct {
-	bench       bool
-	filter      string
-	coverTracer topdown.QueryTracer
+	bench          bool
+	filter         string
+	coverTracer    topdown.QueryTracer
+	prefixMatchers []string
 }
 
 type expectedTestResults map[[2]string]expectedTestResult
@@ -184,7 +186,8 @@ func doTestRunWithTmpDir(t *testing.T, dir string, conf testRunConfig) ([]*teste
 		SetModules(modules).
 		Filter(conf.filter).
 		SetTimeout(60 * time.Second).
-		SetCoverageQueryTracer(conf.coverTracer)
+		SetCoverageQueryTracer(conf.coverTracer).
+		SetPrefixMatchers(util.Map(conf.prefixMatchers, ast.MustParseRef)...)
 
 	var ch chan *tester.Result
 	if conf.bench {
@@ -259,6 +262,115 @@ func validateSubTestResults(t *testing.T, tests map[string]expectedTestResult, s
 			validateSubTestResults(t, tests[k].cases, v.SubResults)
 		}
 	}
+}
+
+func TestRunWithPrefixMatchers(t *testing.T) {
+	files := map[string]string{
+		"/a_b_c_test.rego": `package a.b.c_test
+
+		test_input_1 if true
+		test_input_2 if true
+
+		nested.test_input_3 if true`,
+	}
+
+	cases := []struct {
+		note     string
+		prefixes []string
+		tests    expectedTestResults
+	}{
+		{
+			note:     "empty prefixes matches all tests",
+			prefixes: nil,
+			tests: expectedTestResults{
+				{"data.a.b.c_test", "test_input_1"}:        {false, false, false, nil},
+				{"data.a.b.c_test", "test_input_2"}:        {false, false, false, nil},
+				{"data.a.b.c_test", "nested.test_input_3"}: {false, false, false, nil},
+			},
+		},
+		{
+			note:     "data document ref",
+			prefixes: []string{"data"},
+			tests: expectedTestResults{
+				{"data.a.b.c_test", "test_input_1"}:        {false, false, false, nil},
+				{"data.a.b.c_test", "test_input_2"}:        {false, false, false, nil},
+				{"data.a.b.c_test", "nested.test_input_3"}: {false, false, false, nil},
+			},
+		},
+		{
+			note:     "package name",
+			prefixes: []string{"data.a.b.c_test"},
+			tests: expectedTestResults{
+				{"data.a.b.c_test", "test_input_1"}:        {false, false, false, nil},
+				{"data.a.b.c_test", "test_input_2"}:        {false, false, false, nil},
+				{"data.a.b.c_test", "nested.test_input_3"}: {false, false, false, nil},
+			},
+		},
+		{
+			note:     "package prefix",
+			prefixes: []string{"data.a.b"},
+			tests: expectedTestResults{
+				{"data.a.b.c_test", "test_input_1"}:        {false, false, false, nil},
+				{"data.a.b.c_test", "test_input_2"}:        {false, false, false, nil},
+				{"data.a.b.c_test", "nested.test_input_3"}: {false, false, false, nil},
+			},
+		},
+		{
+			note:     "exact ref match",
+			prefixes: []string{"data.a.b.c_test.test_input_1"},
+			tests: expectedTestResults{
+				{"data.a.b.c_test", "test_input_1"}: {false, false, false, nil},
+			},
+		},
+		{
+			note:     "nested test",
+			prefixes: []string{"data.a.b.c_test.nested.test_input_3"},
+			tests: expectedTestResults{
+				{"data.a.b.c_test", "nested.test_input_3"}: {false, false, false, nil},
+			},
+		},
+		{
+			note:     "no tests match",
+			prefixes: []string{"data.x.y.z"},
+			tests:    nil,
+		},
+		{
+			note:     "prefix longer than refs",
+			prefixes: []string{"data.a.b.c_test.test_input_1.extra"},
+			tests:    nil,
+		},
+		{
+			note:     "multiple prefixes matches",
+			prefixes: []string{"data.a.b.c_test.test_input_1", "data.a.b.c_test.nested"},
+			tests: expectedTestResults{
+				{"data.a.b.c_test", "test_input_1"}:        {false, false, false, nil},
+				{"data.a.b.c_test", "nested.test_input_3"}: {false, false, false, nil},
+			},
+		},
+		{
+			note:     "multiple prefixes one match",
+			prefixes: []string{"data.a.b.c_test.test_input_1", "data.x.y.z"},
+			tests: expectedTestResults{
+				{"data.a.b.c_test", "test_input_1"}: {false, false, false, nil},
+			},
+		},
+		{
+			note:     "multiple prefixes no match",
+			prefixes: []string{"data.a.b.c_test.test_input_1.extra", "data.x.y.z"},
+			tests:    nil,
+		},
+	}
+
+	test.WithTempFS(files, func(d string) {
+		for _, tc := range cases {
+			t.Run(tc.note, func(t *testing.T) {
+
+				conf := testRunConfig{prefixMatchers: tc.prefixes}
+				rs, _ := doTestRunWithTmpDir(t, d, conf)
+				validateTestResults(t, tc.tests, rs, conf)
+			})
+		}
+	})
 }
 
 func TestRunWithFilterRegex(t *testing.T) {
@@ -430,7 +542,6 @@ func TestRunWithFilterRegex(t *testing.T) {
 	}
 
 	test.WithTempFS(files, func(d string) {
-
 		for _, tc := range cases {
 			t.Run(tc.note, func(t *testing.T) {
 				conf := testRunConfig{filter: tc.regex}

--- a/v1/util/compare.go
+++ b/v1/util/compare.go
@@ -10,6 +10,28 @@ import (
 	"math/big"
 )
 
+const (
+	nilSort = iota
+	boolSort
+	numberSort
+	stringSort
+	arraySort
+	objectSort
+)
+
+// SliceLenCompare is a convenience function for comparing / sorting
+// slices by their length using the various slices.SortX functions.
+func SliceLenCompare[T any, S ~[]T](a, b S) int {
+	aLen, bLen := len(a), len(b)
+	if aLen == bLen {
+		return 0
+	} else if aLen < bLen {
+		return -1
+	}
+
+	return 1
+}
+
 // Compare returns 0 if a equals b, -1 if a is less than b, and 1 if b is than a.
 //
 // For comparison between values of different types, the following ordering is used:
@@ -124,15 +146,6 @@ func Compare(a, b any) int {
 
 	panic(fmt.Sprintf("illegal arguments of type %T and type %T", a, b))
 }
-
-const (
-	nilSort    = iota
-	boolSort   = iota
-	numberSort = iota
-	stringSort = iota
-	arraySort  = iota
-	objectSort = iota
-)
 
 func compareJSONNumber(a, b json.Number) int {
 	bigA, ok := new(big.Float).SetString(string(a))

--- a/v1/util/slices.go
+++ b/v1/util/slices.go
@@ -1,0 +1,16 @@
+// Copyright 2026 The OPA Authors. All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package util
+
+func Map[T any, U any](s []T, f func(T) U) []U {
+	if s == nil {
+		return nil
+	}
+	r := make([]U, len(s))
+	for i, v := range s {
+		r[i] = f(v)
+	}
+	return r
+}


### PR DESCRIPTION
Labeled as experimental as we'll want some time to adjust this based on real editor integrations. Initial testing looks very good though, and dramatically reduces the time taken to test e.g. a package compared to the whole workspace and filtering the result afterwards.

Once we know this is the form and shape we want for the method, we can consider adding this to the CLI test command too.

Fixes #6696