### PR TITLE
ast: Fix parsing of unary `-` in front of a ref

### DIFF
--- a/v1/ast/parser.go
+++ b/v1/ast/parser.go
@@ -1758,6 +1758,7 @@ func (p *Parser) parseTerm() *Term {
 	s0 := p.save()
 
 	var term *Term
+	var unaryMinusLoc *Location
 	switch p.s.tok {
 	case tokens.Null:
 		term = NullTerm().SetLocation(p.s.Loc())
@@ -1765,7 +1766,21 @@ func (p *Parser) parseTerm() *Term {
 		term = BooleanTerm(true).SetLocation(p.s.Loc())
 	case tokens.False:
 		term = BooleanTerm(false).SetLocation(p.s.Loc())
-	case tokens.Sub, tokens.Dot, tokens.Number:
+	case tokens.Sub:
+		loc := p.s.Loc()
+		s := p.save()
+		p.scan()
+		if p.s.tok == tokens.Ident || p.s.tok == tokens.Contains {
+			// Unary minus on a reference: -ref → minus(0, ref).
+			// parseTermFinish below will resolve the full ref (e.g. input.number),
+			// after which we wrap the result in a minus call.
+			unaryMinusLoc = loc
+			term = p.parseVar()
+		} else {
+			p.restore(s)
+			term = p.parseNumber()
+		}
+	case tokens.Dot, tokens.Number:
 		term = p.parseNumber()
 	case tokens.String:
 		term = p.parseString()
@@ -1795,6 +1810,10 @@ func (p *Parser) parseTerm() *Term {
 	}
 
 	term = p.parseTermFinish(term, false)
+	if unaryMinusLoc != nil && term != nil {
+		zero := IntNumberTerm(0).SetLocation(unaryMinusLoc)
+		term = p.setLoc(Minus.Call(zero, term), unaryMinusLoc, unaryMinusLoc.Offset, p.s.lastEnd)
+	}
 	p.parsedTermCachePush(term, s0)
 	return term
 }

--- a/v1/ast/parser_test.go
+++ b/v1/ast/parser_test.go
@@ -3814,6 +3814,16 @@ func TestRule(t *testing.T) {
 		Body: NewBody(NewExpr(BooleanTerm(true))),
 	})
 
+	assertParseRule(t, "assignment with unary minus on reference", `x := -input.number { true }`, &Rule{
+		Head: &Head{
+			Name:      Var("x"),
+			Reference: Ref{VarTerm("x")},
+			Value:     Minus.Call(IntNumberTerm(0), RefTerm(InputRootDocument, StringTerm("number"))),
+			Assign:    true,
+		},
+		Body: NewBody(NewExpr(BooleanTerm(true))),
+	})
+
 	assertParseRule(t, "else assignment", `x := 1 { false } else := 2`, &Rule{
 		Head: &Head{
 			Name:      "x", // ha! clever!


### PR DESCRIPTION
### Why the changes in this PR are needed?

The PR fixes the open bug described in issue #5014.

The bug is caused in the parser, where a unary `-` always expects a number or dot as next token. In cases where the `-` is followed by another token, e.g. a ref like `-input.number`, the two following parser errors are thrown:
- _rego_parse_error: unexpected identifier token: expected number_ 
- _rego_parse_error: unexpected identifier token: expected rule value term (e.g., output := <VALUE> { ... })_

This behavior can be reproduced with the following command:
`echo '{"number": 5}' | opa eval 'output := -input.number' -I `
or by testing this scenario in the [Rego Playground](https://play.openpolicyagent.org/).

### What are the changes in this PR?

* add a test to reproduce the issue and demonstrate that it is resolved
* adapt `parseTerm` to support parsing a `-` in front of a ref correctly

The fix is implemented by peaking ahead to see what the next token after the `-` is. If it is a number, `parseNumber` is called (as the original behavior was). If it is a reference, `-ref` is transformed into `minus(0, ref)`.

### Further comments:

Thank you in advance for taking the time to review this PR. I am curious to hear what you think and address your feedback.