### PR TITLE
Update netlify ignore using previous commit instead of cached commit

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -11,7 +11,7 @@ SECRETS_SCAN_OMIT_PATHS = "v1/test/cases,v1/topdown/crypto_test.go"
 
 [context.deploy-preview]
 command = "make netlify-edge"
-ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- docs/ netlify.toml"
+ignore = "git diff --quiet HEAD~1 -- docs/ netlify.toml"
 
 [[edge_functions]]
 # this path should not be changed as various external sites depend on it for OPA


### PR DESCRIPTION
Netlify was posting the doc preview seemingly randomly, evidently using the cached commit reference is the likely culprit. If there was a recent doc changed this reference could be stale. Check the previous commit in the current PR instead.