### PR TITLE
fmt: don't indent until first with on new line

### DIFF
--- a/v1/format/format.go
+++ b/v1/format/format.go
@@ -959,20 +959,24 @@ func (w *writer) writeExpr(expr *ast.Expr, comments []*ast.Comment) ([]*ast.Comm
 	}
 
 	if len(withs) > 0 {
-		w.up()
+		var indented bool
+
 		for _, with := range withs {
 			indent := with.Location.Row > lastRow
 			if indent {
+				if !indented {
+					w.up()
+					defer w.down() //nolint:errcheck
+					indented = true
+				}
 				w.endLine()
 				w.startLine()
 				lastRow = with.Location.Row
 			}
 			if comments, err = w.writeWith(with, comments, indent); err != nil {
-				return nil, err
+				return comments, err
 			}
 		}
-
-		return comments, w.down()
 	}
 
 	return comments, nil

--- a/v1/format/testfiles/v1/test_with_indentation.rego
+++ b/v1/format/testfiles/v1/test_with_indentation.rego
@@ -1,0 +1,26 @@
+package p
+
+test_with_and_indentation if {
+	# with should not increase indentation level here
+	dep == 6 with input.x as 2 with input.y.z as {
+			"x": 3,
+			"z": 4,
+		}
+
+	# but here it should
+	dep == 6 with input.x as 2
+		with input.y.z as {
+			"x": 3,
+			"z": 4,
+		}
+
+	# and here
+	dep == 6
+		with input.x as 2
+		with input.y.z as {
+			"x": 3,
+			"z": 4,
+		}
+}
+
+dep := input.x + input.y.z

--- a/v1/format/testfiles/v1/test_with_indentation.rego.formatted
+++ b/v1/format/testfiles/v1/test_with_indentation.rego.formatted
@@ -1,0 +1,26 @@
+package p
+
+test_with_and_indentation if {
+	# with should not increase indentation level here
+	dep == 6 with input.x as 2 with input.y.z as {
+		"x": 3,
+		"z": 4,
+	}
+
+	# but here it should
+	dep == 6 with input.x as 2
+		with input.y.z as {
+			"x": 3,
+			"z": 4,
+		}
+
+	# and here
+	dep == 6
+		with input.x as 2
+		with input.y.z as {
+			"x": 3,
+			"z": 4,
+		}
+}
+
+dep := input.x + input.y.z


### PR DESCRIPTION
This worked before but got lost in my `with` indentation change. Now it works again!