### PR TITLE
format: Preserve location of trailing comments inside `every` body

### DIFF
--- a/v1/format/format.go
+++ b/v1/format/format.go
@@ -927,7 +927,7 @@ func (w *writer) writeExpr(expr *ast.Expr, comments []*ast.Comment) ([]*ast.Comm
 			return nil, err
 		}
 	case *ast.Every:
-		comments, err = w.writeEvery(t, comments)
+		comments, err = w.writeEvery(t, expr.Loc(), comments)
 		if err != nil {
 			return nil, err
 		}
@@ -1023,9 +1023,13 @@ func (w *writer) writeSomeDecl(decl *ast.SomeDecl, comments []*ast.Comment) ([]*
 	return comments, nil
 }
 
-func (w *writer) writeEvery(every *ast.Every, comments []*ast.Comment) ([]*ast.Comment, error) {
+func (w *writer) writeEvery(every *ast.Every, loc *ast.Location, comments []*ast.Comment) ([]*ast.Comment, error) {
+	if loc == nil {
+		loc = every.Loc()
+	}
+
 	var err error
-	comments, err = w.insertComments(comments, every.Location)
+	comments, err = w.insertComments(comments, loc)
 	if err != nil {
 		return nil, err
 	}
@@ -1047,7 +1051,7 @@ func (w *writer) writeEvery(every *ast.Every, comments []*ast.Comment) ([]*ast.C
 		return nil, err
 	}
 	w.write(" {")
-	comments, err = w.writeComprehensionBody('{', '}', every.Body, every.Loc(), every.Loc(), comments)
+	comments, err = w.writeComprehensionBody('{', '}', every.Body, loc, loc, comments)
 	if err != nil {
 		// the unexpected comment error is passed up to be handled by writeHead
 		if !errors.As(err, &unexpectedCommentError{}) {

--- a/v1/format/testfiles/v1/test_every.rego
+++ b/v1/format/testfiles/v1/test_every.rego
@@ -15,3 +15,14 @@ r if {
 }
 
 is_odd(x) = x % 2 == 0
+
+s if {
+	# comment 1
+	every x, y in input.x { # comment 2
+		# comment 3
+		input.a == x
+		input.b == y # comment 4
+		# comment 5
+	} # comment 6
+	# comment 7
+}

--- a/v1/format/testfiles/v1/test_every.rego.formatted
+++ b/v1/format/testfiles/v1/test_every.rego.formatted
@@ -15,3 +15,14 @@ r if {
 }
 
 is_odd(x) := (x % 2) == 0
+
+s if {
+	# comment 1
+	every x, y in input.x { # comment 2
+		# comment 3
+		input.a == x
+		input.b == y # comment 4
+		# comment 5
+	} # comment 6
+	# comment 7
+}

--- a/v1/format/testfiles/v1/test_issue_6330.rego
+++ b/v1/format/testfiles/v1/test_issue_6330.rego
@@ -133,3 +133,34 @@ p[x].r := y if {
 
     y := 1
 }
+
+set_compr if {
+	# comment 1
+	{x | # comment 2
+		# comment 3
+		x = input.x # comment 4
+		# comment 5
+	} # comment 6
+	# comment 7
+}
+
+array_compr if {
+	# comment 1
+	[x | # comment 2
+		# comment 3
+		x = input.x # comment 4
+		# comment 5
+	] # comment 6
+	# comment 7
+}
+
+map_compr if {
+	# comment 1
+	{x: y | # comment 2
+		# comment 3
+		x = input.x # comment 4
+		y = input.y # comment 5
+		# comment 6
+	} # comment 7
+	# comment 8
+}

--- a/v1/format/testfiles/v1/test_issue_6330.rego.formatted
+++ b/v1/format/testfiles/v1/test_issue_6330.rego.formatted
@@ -114,3 +114,34 @@ p[x].r := y if {
 
 	y := 1
 }
+
+set_compr if {
+	# comment 1
+	{x | # comment 2
+		# comment 3
+		x = input.x # comment 4
+		# comment 5
+	} # comment 6
+	# comment 7
+}
+
+array_compr if {
+	# comment 1
+	[x | # comment 2
+		# comment 3
+		x = input.x # comment 4
+		# comment 5
+	] # comment 6
+	# comment 7
+}
+
+map_compr if {
+	# comment 1
+	{x: y | # comment 2
+		# comment 3
+		x = input.x # comment 4
+		y = input.y # comment 5
+		# comment 6
+	} # comment 7
+	# comment 8
+}


### PR DESCRIPTION
Use location text of outer expression to calculate closing location of `every` body (the term itself doesn't capture the full text).

Fixes: #8558