### PR TITLE
storage/inmem: avoid allocations from Read() in MakeDir()

### DIFF
--- a/v1/storage/inmem/inmem.go
+++ b/v1/storage/inmem/inmem.go
@@ -304,6 +304,14 @@ func (db *store) Register(_ context.Context, txn storage.Transaction, config sto
 	return h, nil
 }
 
+func (db *store) MakeDir(_ context.Context, txn storage.Transaction, path storage.Path) error {
+	underlying, err := db.underlying(txn)
+	if err != nil {
+		return err
+	}
+	return underlying.makeDir(path)
+}
+
 func (db *store) Read(_ context.Context, txn storage.Transaction, path storage.Path) (any, error) {
 	underlying, err := db.underlying(txn)
 	if err != nil {

--- a/v1/storage/inmem/inmem_bench_test.go
+++ b/v1/storage/inmem/inmem_bench_test.go
@@ -295,6 +295,42 @@ func BenchmarkWriteAndCommitWithTriggersSkipConversion(b *testing.B) {
 	}
 }
 
+func BenchmarkMakeDirSiblings(b *testing.B) {
+	for _, n := range []int{10, 100, 1000} {
+		b.Run(strconv.Itoa(n)+"_existing", func(b *testing.B) {
+			existing := make(map[string]any, n)
+			for i := range n {
+				existing[strconv.Itoa(i)] = map[string]any{"v": i}
+			}
+			data := map[string]any{"parent": existing}
+
+			paths := make([]storage.Path, 100)
+			for i := range paths {
+				paths[i] = storage.Path{"parent", "new-" + strconv.Itoa(i)}
+			}
+
+			// Abort after each iteration so the store stays unmodified
+			// and subsequent iterations exercise the full MakeDir path.
+			operation := func(ctx context.Context, target *target) error {
+				txn, err := target.store.NewTransaction(ctx, storage.WriteParams)
+				if err != nil {
+					return err
+				}
+				for _, p := range paths {
+					if err := storage.MakeDir(ctx, target.store, txn, p); err != nil {
+						target.store.Abort(ctx, txn)
+						return err
+					}
+				}
+				target.store.Abort(ctx, txn)
+				return nil
+			}
+
+			AllStores(data).Bench(b, operation)
+		})
+	}
+}
+
 func (t targets) VerifyRead(b *testing.B, path storage.Path, expected any) targets {
 	b.Helper()
 	for _, target := range t {

--- a/v1/storage/inmem/inmem_test.go
+++ b/v1/storage/inmem/inmem_test.go
@@ -1324,6 +1324,18 @@ func TestInMemoryMakeDir(t *testing.T) {
 			expErr: storage.WriteConflictErr,
 		},
 		{
+			note:   "conflict on array",
+			data:   map[string]any{"a": []any{1, 2, 3}},
+			path:   "/a",
+			expErr: storage.WriteConflictErr,
+		},
+		{
+			note:   "conflict on non-object intermediate",
+			data:   map[string]any{"a": []any{1, 2}},
+			path:   "/a/b",
+			expErr: storage.WriteConflictErr,
+		},
+		{
 			note:    "empty path is a no-op",
 			data:    map[string]any{"x": "y"},
 			path:    "/",
@@ -1417,6 +1429,117 @@ func TestInMemoryMakeDirMultipleSiblings(t *testing.T) {
 		if _, ok := obj[key]; !ok {
 			t.Errorf("missing key %q", key)
 		}
+	}
+}
+
+func TestInMemoryMakeDirAfterRemove(t *testing.T) {
+	ctx := t.Context()
+	store := NewFromObject(map[string]any{
+		"a": map[string]any{
+			"b": map[string]any{"old": "data"},
+		},
+	})
+
+	txn, err := store.NewTransaction(ctx, storage.WriteParams)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Remove a/b, then MakeDir a/b/c — should recreate the path.
+	if err := store.Write(ctx, txn, storage.RemoveOp, storage.MustParsePath("/a/b"), nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := storage.MakeDir(ctx, store, txn, storage.MustParsePath("/a/b/c")); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Commit(ctx, txn); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := storage.ReadOne(ctx, store, storage.MustParsePath("/a/b"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := map[string]any{"c": map[string]any{}}
+	if !reflect.DeepEqual(result, expected) {
+		t.Fatalf("expected %v but got %v", expected, result)
+	}
+}
+
+func TestInMemoryMakeDirAfterWrite(t *testing.T) {
+	ctx := t.Context()
+	store := NewFromObject(map[string]any{})
+
+	txn, err := store.NewTransaction(ctx, storage.WriteParams)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Write data, then MakeDir a child — isObject must fall through
+	// past unrelated updates to check the store data.
+	if err := store.Write(ctx, txn, storage.AddOp, storage.MustParsePath("/x"), map[string]any{"y": "z"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := storage.MakeDir(ctx, store, txn, storage.MustParsePath("/x/w")); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Commit(ctx, txn); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := storage.ReadOne(ctx, store, storage.MustParsePath("/x"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := map[string]any{"y": "z", "w": map[string]any{}}
+	if !reflect.DeepEqual(result, expected) {
+		t.Fatalf("expected %v but got %v", expected, result)
+	}
+}
+
+func TestInMemoryMakeDirAST(t *testing.T) {
+	ctx := t.Context()
+	store := NewFromObjectWithOpts(map[string]any{
+		"a": map[string]any{"existing": "value"},
+	}, OptReturnASTValuesOnRead(true))
+
+	txn, err := store.NewTransaction(ctx, storage.WriteParams)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create sibling next to existing data.
+	if err := storage.MakeDir(ctx, store, txn, storage.MustParsePath("/a/b/c")); err != nil {
+		t.Fatal(err)
+	}
+
+	// Existing path should be a no-op.
+	if err := storage.MakeDir(ctx, store, txn, storage.MustParsePath("/a")); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := store.Commit(ctx, txn); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify existing data is preserved.
+	result, err := storage.ReadOne(ctx, store, storage.MustParsePath("/a/existing"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v, ok := result.(ast.Value); !ok || ast.Compare(v, ast.String("value")) != 0 {
+		t.Fatalf("expected ast.String(\"value\") but got %T: %v", result, result)
+	}
+
+	// Verify new path was created.
+	result, err = storage.ReadOne(ctx, store, storage.MustParsePath("/a/b/c"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v, ok := result.(ast.Value); !ok {
+		t.Fatalf("expected ast.Value but got %T", result)
+	} else if _, ok := v.(ast.Object); !ok {
+		t.Fatalf("expected ast.Object but got %T", v)
 	}
 }
 

--- a/v1/storage/inmem/inmem_test.go
+++ b/v1/storage/inmem/inmem_test.go
@@ -1291,6 +1291,135 @@ func TestInMemoryContext(t *testing.T) {
 
 }
 
+func TestInMemoryMakeDir(t *testing.T) {
+	tests := []struct {
+		note    string
+		data    map[string]any
+		path    string
+		expErr  string
+		expData string
+	}{
+		{
+			note:    "create nested path from scratch",
+			data:    map[string]any{},
+			path:    "/a/b/c",
+			expData: `{"a": {"b": {"c": {}}}}`,
+		},
+		{
+			note:    "existing intermediate object is a no-op",
+			data:    map[string]any{"a": map[string]any{"b": map[string]any{"x": "y"}}},
+			path:    "/a/b",
+			expData: `{"a": {"b": {"x": "y"}}}`,
+		},
+		{
+			note:    "create sibling under existing parent",
+			data:    map[string]any{"a": map[string]any{"b": map[string]any{}}},
+			path:    "/a/c",
+			expData: `{"a": {"b": {}, "c": {}}}`,
+		},
+		{
+			note:   "conflict on non-object leaf",
+			data:   map[string]any{"a": "string-value"},
+			path:   "/a",
+			expErr: storage.WriteConflictErr,
+		},
+		{
+			note:    "empty path is a no-op",
+			data:    map[string]any{"x": "y"},
+			path:    "/",
+			expData: `{"x": "y"}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.note, func(t *testing.T) {
+			ctx := t.Context()
+			store := NewFromObject(tc.data)
+
+			txn, err := store.NewTransaction(ctx, storage.WriteParams)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			path := storage.MustParsePath(tc.path)
+			err = storage.MakeDir(ctx, store, txn, path)
+
+			if tc.expErr != "" {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				serr, ok := err.(*storage.Error)
+				if !ok || serr.Code != tc.expErr {
+					t.Fatalf("expected %v error but got: %v", tc.expErr, err)
+				}
+				store.Abort(ctx, txn)
+				return
+			}
+
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := store.Commit(ctx, txn); err != nil {
+				t.Fatal(err)
+			}
+
+			result, err := storage.ReadOne(ctx, store, storage.RootPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			var expected any
+			if err := util.UnmarshalJSON([]byte(tc.expData), &expected); err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(result, expected) {
+				t.Fatalf("expected %v but got %v", expected, result)
+			}
+		})
+	}
+}
+
+func TestInMemoryMakeDirMultipleSiblings(t *testing.T) {
+	ctx := t.Context()
+	store := NewFromObject(map[string]any{
+		"parent": map[string]any{
+			"existing": map[string]any{"data": "value"},
+		},
+	})
+
+	txn, err := store.NewTransaction(ctx, storage.WriteParams)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, id := range []string{"aaa", "bbb", "ccc"} {
+		path := storage.MustParsePath("/parent/" + id)
+		if err := storage.MakeDir(ctx, store, txn, path); err != nil {
+			t.Fatalf("MakeDir(%s): %v", id, err)
+		}
+	}
+
+	if err := store.Commit(ctx, txn); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := storage.ReadOne(ctx, store, storage.MustParsePath("/parent"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	obj, ok := result.(map[string]any)
+	if !ok {
+		t.Fatal("expected object")
+	}
+
+	for _, key := range []string{"existing", "aaa", "bbb", "ccc"} {
+		if _, ok := obj[key]; !ok {
+			t.Errorf("missing key %q", key)
+		}
+	}
+}
+
 func loadExpectedResult(input string) any {
 	if len(input) == 0 {
 		return nil

--- a/v1/storage/inmem/txn.go
+++ b/v1/storage/inmem/txn.go
@@ -297,6 +297,75 @@ func (txn *transaction) Read(path storage.Path) (any, error) {
 	return cpy, nil
 }
 
+func (txn *transaction) makeDir(path storage.Path) error {
+	if len(path) == 0 {
+		return nil
+	}
+
+	exists, isObj, err := txn.isObject(path)
+	if err != nil {
+		return err
+	}
+
+	if exists {
+		if isObj {
+			return nil
+		}
+		return &storage.Error{
+			Code:    storage.WriteConflictErr,
+			Message: path.String(),
+		}
+	}
+
+	if err := txn.makeDir(path[:len(path)-1]); err != nil {
+		return err
+	}
+
+	return txn.Write(storage.AddOp, path, map[string]any{})
+}
+
+// isObject checks whether the given path exists and points to an object,
+// without deep-copying the subtree the way transaction.Read would.
+func (txn *transaction) isObject(path storage.Path) (exists bool, isObj bool, err error) {
+	if !txn.write || txn.updates == nil {
+		return isObjectNode(pointer(txn.db.data, path))
+	}
+
+	for curr := txn.updates.Front(); curr != nil; curr = curr.Next() {
+		upd := curr.Value.(dataUpdate)
+
+		if path.HasPrefix(upd.Path()) {
+			if upd.Remove() {
+				return false, false, nil
+			}
+			return isObjectNode(pointer(upd.Value(), path[len(upd.Path()):]))
+		}
+
+		// A child of this path has been written, so this path is an object.
+		if upd.Path().HasPrefix(path) {
+			return true, true, nil
+		}
+	}
+
+	return isObjectNode(pointer(txn.db.data, path))
+}
+
+func isObjectNode(node any, err error) (bool, bool, error) {
+	if err != nil {
+		if storage.IsNotFound(err) {
+			return false, false, nil
+		}
+		return false, false, err
+	}
+
+	switch node.(type) {
+	case map[string]any, ast.Object:
+		return true, true, nil
+	default:
+		return true, false, nil
+	}
+}
+
 func (txn *transaction) ListPolicies() (ids []string) {
 	for id := range txn.db.policies {
 		if _, ok := txn.policies[id]; !ok {


### PR DESCRIPTION
...by special-casing MakeDir for our inmem store's transactions. The infrastructure was there from #4381.

Benchstat is a bit ridiculous on this one,

```
goos: darwin
goarch: arm64
pkg: github.com/open-policy-agent/opa/v1/storage/inmem
cpu: Apple M4 Max
                                                │ ../makedir_main.bench │         ../makedir_pr.bench         │
                                                │        sec/op         │   sec/op     vs base                │
MakeDirSiblings/10_children/Go-16                           592.1µ ± 0%   128.7µ ± 3%  -78.27% (p=0.000 n=10)
MakeDirSiblings/10_children/Go_(roundtrip)-16               635.4µ ± 4%   133.6µ ± 2%  -78.98% (p=0.000 n=10)
MakeDirSiblings/10_children/AST-16                         1065.9µ ± 1%   153.1µ ± 1%  -85.64% (p=0.000 n=10)
MakeDirSiblings/100_children/Go-16                         1864.7µ ± 0%   132.0µ ± 2%  -92.92% (p=0.000 n=10)
MakeDirSiblings/100_children/Go_(roundtrip)-16             1907.1µ ± 0%   134.6µ ± 1%  -92.94% (p=0.000 n=10)
MakeDirSiblings/100_children/AST-16                        2949.8µ ± 1%   155.9µ ± 1%  -94.72% (p=0.000 n=10)
MakeDirSiblings/1000_children/Go-16                       15412.5µ ± 1%   130.7µ ± 1%  -99.15% (p=0.000 n=10)
MakeDirSiblings/1000_children/Go_(roundtrip)-16           15954.6µ ± 2%   132.2µ ± 1%  -99.17% (p=0.000 n=10)
MakeDirSiblings/1000_children/AST-16                      23283.6µ ± 2%   156.5µ ± 1%  -99.33% (p=0.000 n=10)
geomean                                                     3.068m        139.3µ       -95.46%

                                                │ ../makedir_main.bench │         ../makedir_pr.bench          │
                                                │         B/op          │     B/op      vs base                │
MakeDirSiblings/10_children/Go-16                        1407.00Ki ± 0%   14.20Ki ± 0%  -98.99% (p=0.000 n=10)
MakeDirSiblings/10_children/Go_(roundtrip)-16            1501.26Ki ± 0%   14.20Ki ± 0%  -99.05% (p=0.000 n=10)
MakeDirSiblings/10_children/AST-16                       1760.71Ki ± 0%   41.61Ki ± 0%  -97.64% (p=0.000 n=10)
MakeDirSiblings/100_children/Go-16                       5004.60Ki ± 0%   14.20Ki ± 0%  -99.72% (p=0.000 n=10)
MakeDirSiblings/100_children/Go_(roundtrip)-16           5102.42Ki ± 0%   14.20Ki ± 0%  -99.72% (p=0.000 n=10)
MakeDirSiblings/100_children/AST-16                      5785.23Ki ± 0%   41.61Ki ± 0%  -99.28% (p=0.000 n=10)
MakeDirSiblings/1000_children/Go-16                     40886.97Ki ± 0%   14.20Ki ± 0%  -99.97% (p=0.000 n=10)
MakeDirSiblings/1000_children/Go_(roundtrip)-16         41020.92Ki ± 0%   14.20Ki ± 0%  -99.97% (p=0.000 n=10)
MakeDirSiblings/1000_children/AST-16                    45975.37Ki ± 0%   41.62Ki ± 0%  -99.91% (p=0.000 n=10)
geomean                                                    6.873Mi        20.32Ki       -99.71%

                                                │ ../makedir_main.bench │         ../makedir_pr.bench         │
                                                │       allocs/op       │  allocs/op   vs base                │
MakeDirSiblings/10_children/Go-16                           8748.0 ± 0%    303.0 ± 0%  -96.54% (p=0.000 n=10)
MakeDirSiblings/10_children/Go_(roundtrip)-16               9451.0 ± 0%    303.0 ± 0%  -96.79% (p=0.000 n=10)
MakeDirSiblings/10_children/AST-16                         38.047k ± 0%   1.405k ± 0%  -96.31% (p=0.000 n=10)
MakeDirSiblings/100_children/Go-16                         26284.0 ± 0%    303.0 ± 0%  -98.85% (p=0.000 n=10)
MakeDirSiblings/100_children/Go_(roundtrip)-16             26995.0 ± 0%    303.0 ± 0%  -98.88% (p=0.000 n=10)
MakeDirSiblings/100_children/AST-16                       126.688k ± 0%   1.405k ± 0%  -98.89% (p=0.000 n=10)
MakeDirSiblings/1000_children/Go-16                       204510.0 ± 0%    303.0 ± 0%  -99.85% (p=0.000 n=10)
MakeDirSiblings/1000_children/Go_(roundtrip)-16           205297.0 ± 0%    303.0 ± 0%  -99.85% (p=0.000 n=10)
MakeDirSiblings/1000_children/AST-16                     1017.768k ± 0%   1.405k ± 0%  -99.86% (p=0.000 n=10)
geomean                                                     61.22k         505.3       -99.17%
```

Let's see if something weird happens when running the complete test suite (which I have not just now). 🤞 