### PR TITLE
ast,format,planner: Add `not` block syntax

### DIFF
--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -637,11 +637,11 @@ func (p *Planner) planQuery(q ast.Body, index int, iter planiter) error {
 func (p *Planner) planExpr(e *ast.Expr, iter planiter) error {
 
 	switch {
-	case e.IsNegated():
-		return p.planNot(e, iter)
-
 	case len(e.With) > 0:
 		return p.planWith(e, iter)
+
+	case e.IsNegated():
+		return p.planNot(e, iter)
 
 	case e.IsCall():
 		return p.planExprCall(e, iter)
@@ -662,11 +662,22 @@ func (p *Planner) planNot(e *ast.Expr, iter planiter) error {
 	p.curr = not.Block
 
 	if n, ok := e.Terms.(*ast.Not); ok {
-		for _, be := range n.Body {
-			if err := p.planExpr(be, func() error { return nil }); err != nil {
-				return err
-			}
+		cond := p.newLocal() // success condition
+
+		err := p.planQuery(n.Body, 0, func() error {
+			p.appendStmt(&ir.AssignVarStmt{
+				Source: op(ir.Bool(true)),
+				Target: cond,
+			})
+			return nil
+		})
+		if err != nil {
+			return err
 		}
+
+		p.appendStmt(&ir.IsDefinedStmt{
+			Source: cond,
+		})
 	} else {
 		if err := p.planExpr(e.Complement(), func() error { return nil }); err != nil {
 			return err

--- a/v1/ast/check.go
+++ b/v1/ast/check.go
@@ -745,6 +745,9 @@ func (rc *refChecker) Visit(x any) bool {
 		case *Term:
 			NewGenericVisitor(rc.Visit).Walk(terms)
 			return true
+		case *Not:
+			NewGenericVisitor(rc.Visit).Walk(terms.Body)
+			return true
 		}
 	case Ref:
 		if err := rc.checkApply(rc.env, x); err != nil {

--- a/v1/ast/compile.go
+++ b/v1/ast/compile.go
@@ -4661,6 +4661,10 @@ func unsafeNotVars(arity func(Ref) int, vis *VarVisitor, v any) bool {
 		return false
 	}
 
+	if n.ExplicitBody {
+		return true
+	}
+
 	internalVis := varVisitorPool.Get()
 	defer varVisitorPool.Put(internalVis)
 
@@ -5227,7 +5231,8 @@ func resolveRefsInExpr(globals map[Var]*usedRef, ignore *declaredVarStack, expr 
 		ignore.Pop()
 	case *Not:
 		cpy.Terms = &Not{
-			Body: resolveRefsInBody(globals, ignore, ts.Body),
+			Body:         resolveRefsInBody(globals, ignore, ts.Body),
+			ExplicitBody: ts.ExplicitBody,
 		}
 	}
 	for _, w := range cpy.With {
@@ -6100,6 +6105,9 @@ func rewriteDeclaredVarsInBody(g *localVarGenerator, stack *localDeclaredVars, u
 			expr, errs = rewriteSomeDeclStatement(g, stack, body[i], errs, strict)
 		case body[i].IsEvery():
 			expr, errs = rewriteEveryStatement(g, stack, body[i], errs, strict)
+		case body[i].IsNot() && body[i].Terms.(*Not).ExplicitBody:
+			// Only explicit not bodies are allowed to declare vars
+			expr, errs = rewriteNotStatement(g, stack, body[i], errs, strict)
 		default:
 			expr, errs = rewriteDeclaredVarsInExpr(g, stack, body[i], errs, strict)
 		}
@@ -6337,6 +6345,19 @@ func rewriteSomeDeclStatement(g *localVarGenerator, stack *localDeclaredVars, ex
 		}
 	}
 	return nil, errs
+}
+
+func rewriteNotStatement(g *localVarGenerator, stack *localDeclaredVars, expr *Expr, errs Errors, strict bool) (*Expr, Errors) {
+	e := expr.Copy()
+	not := e.Terms.(*Not)
+
+	stack.Push()
+	defer stack.Pop()
+
+	used := NewVarSet()
+	not.Body, errs = rewriteDeclaredVarsInBody(g, stack, used, not.Body, errs, strict)
+
+	return rewriteDeclaredVarsInExpr(g, stack, e, errs, strict)
 }
 
 func rewriteDeclaredVarsInExpr(g *localVarGenerator, stack *localDeclaredVars, expr *Expr, errs Errors, strict bool) (*Expr, Errors) {

--- a/v1/ast/compile_test.go
+++ b/v1/ast/compile_test.go
@@ -12991,6 +12991,12 @@ func TestCompilerCopiesTemplateStrings(t *testing.T) {
 
 // TODO: For readability, update AST assertions to use parsed expected module (parser update required)
 func TestCompilerNotImport(t *testing.T) {
+	// TODO: drop once future.keywords.not is enabled by default
+	popts := ParserOptions{
+		Capabilities:   CapabilitiesForThisVersion().withFutureKeyword("not"),
+		FutureKeywords: []string{"not"},
+	}
+
 	tests := []struct {
 		note    string
 		module  string
@@ -13004,31 +13010,14 @@ func TestCompilerNotImport(t *testing.T) {
 					not input.x + input.y == input.z
 				}
 			`,
-			expMod: &Module{
-				Package: MustParsePackage("package negation"),
-				Rules: RuleSet{
-					&Rule{
-						Head: &Head{
-							Name:      Var("p"),
-							Reference: Ref{VarTerm("p")},
-							Value:     BooleanTerm(true),
-						},
-						Body: NewBody(
-							Equality.Expr(VarTerm("__local1__"), RefTerm(VarTerm("input"), StringTerm("x"))), // broken out of not expr
-							Equality.Expr(VarTerm("__local2__"), RefTerm(VarTerm("input"), StringTerm("y"))), // broken out of not expr
-							Plus.Expr(VarTerm("__local1__"), VarTerm("__local2__"), VarTerm("__local0__")),   // broken out of not expr
-							&Expr{
-								Terms: []*Term{
-									NewTerm(Equality.Ref()),
-									VarTerm("__local0__"),
-									RefTerm(VarTerm("input"), StringTerm("z")),
-								},
-								Negated: true,
-							},
-						),
-					},
-				},
-			},
+			expMod: MustParseModule(`package negation
+				p = true if {
+					__local1__ = input.x
+					__local2__ = input.y
+					plus(__local1__, __local2__, __local0__)
+					not __local0__ = input.z
+				}
+			`),
 		},
 		{
 			note: "negated call, equal",
@@ -13038,28 +13027,14 @@ func TestCompilerNotImport(t *testing.T) {
 					not 1 + 2 == 3
 				}
 			`,
-			expMod: &Module{
-				Package: MustParsePackage("package negation"),
-				Rules: RuleSet{
-					&Rule{
-						Head: &Head{
-							Name:      Var("p"),
-							Reference: Ref{VarTerm("p")},
-							Value:     BooleanTerm(true),
-						},
-						Body: NewBody(
-							NewExpr(
-								&Not{
-									Body: NewBody(
-										Plus.Expr(NumberTerm("1"), NumberTerm("2"), VarTerm("__local0__")),
-										Equal.Expr(VarTerm("__local0__"), NumberTerm("3")),
-									),
-								},
-							),
-						),
-					},
-				},
-			},
+			expMod: MustParseModuleWithOpts(`package negation
+				p = true if { 
+					not {
+						plus(1, 2, __local0__)
+						__local0__ = 3
+					}
+				}
+			`, popts),
 		},
 		{
 			note: "negated call, unification",
@@ -13069,28 +13044,31 @@ func TestCompilerNotImport(t *testing.T) {
 					not 1 + 2 = 3
 				}
 			`,
-			expMod: &Module{
-				Package: MustParsePackage("package negation"),
-				Rules: RuleSet{
-					&Rule{
-						Head: &Head{
-							Name:      Var("p"),
-							Reference: Ref{VarTerm("p")},
-							Value:     BooleanTerm(true),
-						},
-						Body: NewBody(
-							NewExpr(
-								&Not{
-									Body: NewBody(
-										Plus.Expr(NumberTerm("1"), NumberTerm("2"), VarTerm("__local0__")),
-										Equality.Expr(VarTerm("__local0__"), NumberTerm("3")),
-									),
-								},
-							),
-						),
-					},
-				},
-			},
+			expMod: MustParseModuleWithOpts(`package negation
+				p = true if { 
+					not {
+						plus(1, 2, __local0__)
+						__local0__ = 3
+					}
+				}
+			`, popts),
+		},
+		{
+			note: "negated call, unification, explicit not-body",
+			module: `package negation
+				import future.keywords.not
+				p if {
+					not { 1 + 2 = 3 }
+				}
+			`,
+			expMod: MustParseModuleWithOpts(`package negation
+				p = true if { 
+					not {
+						plus(1, 2, __local0__)
+						__local0__ = 3
+					}
+				}
+			`, popts),
 		},
 		{
 			note: "negated call with refs (local var expansion)",
@@ -13100,31 +13078,16 @@ func TestCompilerNotImport(t *testing.T) {
 					not input.x + input.y == input.z
 				}
 			`,
-			expMod: &Module{
-				Package: MustParsePackage("package negation"),
-				Rules: RuleSet{
-					&Rule{
-						Head: &Head{
-							Name:      Var("p"),
-							Reference: Ref{VarTerm("p")},
-							Value:     BooleanTerm(true),
-						},
-						Body: NewBody(
-							NewExpr(
-								&Not{
-									Body: NewBody(
-										Equality.Expr(VarTerm("__local1__"), RefTerm(VarTerm("input"), StringTerm("x"))),
-										Equality.Expr(VarTerm("__local2__"), RefTerm(VarTerm("input"), StringTerm("y"))),
-										Plus.Expr(VarTerm("__local1__"), VarTerm("__local2__"), VarTerm("__local0__")),
-										Equality.Expr(VarTerm("__local3__"), RefTerm(VarTerm("input"), StringTerm("z"))),
-										Equal.Expr(VarTerm("__local0__"), VarTerm("__local3__")),
-									),
-								},
-							),
-						),
-					},
-				},
-			},
+			expMod: MustParseModuleWithOpts(`package negation
+				p = true if { 
+					not {
+						__local1__ = input.x
+						__local2__ = input.y
+						plus(__local1__, __local2__, __local0__)
+						__local0__ = input.z
+					}
+				}
+			`, popts),
 		},
 		{
 			note: "negated call with vars, inside comprehension",
@@ -13135,47 +13098,18 @@ func TestCompilerNotImport(t *testing.T) {
 				
 				f(_) := true
 			`,
-			expMod: &Module{
-				Package: MustParsePackage("package negation"),
-				Rules: RuleSet{
-					&Rule{
-						Head: &Head{
-							Name:      Var("p"),
-							Reference: Ref{VarTerm("p")},
-							Value:     VarTerm("__local2__"),
-							Assign:    true,
-						},
-						Body: NewBody(
-							Equality.Expr(
-								VarTerm("__local2__"),
-								ArrayComprehensionTerm(
-									VarTerm("__local0__"),
-									NewBody(
-										Equality.Expr(VarTerm("__local0__"), StringTerm("foo")),
-										NotExpr(
-											Equality.Expr(VarTerm("__local3__"), RefTerm(VarTerm("input"), StringTerm("x"))),
-											NewExpr([]*Term{
-												RefTerm(VarTerm("data"), StringTerm("negation"), StringTerm("f")),
-												VarTerm("__local3__"),
-											}),
-										),
-									),
-								),
-							),
-						),
-					},
-					&Rule{
-						Head: &Head{
-							Name:      Var("f"),
-							Reference: Ref{VarTerm("f")},
-							Args:      Args{VarTerm("__local1__")},
-							Value:     BooleanTerm(true),
-							Assign:    true,
-						},
-						Body: NewBody(NewExpr(BooleanTerm(true))),
-					},
-				},
-			},
+			expMod: MustParseModuleWithOpts(`package negation
+				p := __local2__ if {
+					__local2__ = [__local0__ | __local0__ = "foo"
+						not {
+							__local3__ = input.x
+							data.negation.f(__local3__)
+						}
+					]
+				}
+				
+				f(__local1__) := true if { true }
+			`, popts),
 		},
 		{
 			note: "negated call with vars, inside comprehension, unsafe assignment",
@@ -13206,49 +13140,19 @@ func TestCompilerNotImport(t *testing.T) {
 				
 				f(_, _) := true
 			`,
-			expMod: &Module{
-				Package: MustParsePackage("package negation"),
-				Rules: RuleSet{
-					&Rule{
-						Head: &Head{
-							Name:      Var("p"),
-							Reference: Ref{VarTerm("p")},
-							Value:     BooleanTerm(true),
-						},
-						Body: NewBody(
-							Equality.Expr(
-								VarTerm("__local4__"),
-								RefTerm(VarTerm("input"), StringTerm("x")),
-							),
-							NewExpr(&Every{
-								Key:    VarTerm("__local0__"),
-								Value:  VarTerm("__local1__"),
-								Domain: VarTerm("__local4__"),
-								Body: NewBody(
-									NotExpr(
-										Equality.Expr(VarTerm("__local5__"), RefTerm(VarTerm("input"), StringTerm("y"))),
-										NewExpr([]*Term{
-											RefTerm(VarTerm("data"), StringTerm("negation"), StringTerm("f")),
-											VarTerm("__local1__"),
-											VarTerm("__local5__"),
-										}),
-									),
-								),
-							}),
-						),
-					},
-					&Rule{
-						Head: &Head{
-							Name:      Var("f"),
-							Reference: Ref{VarTerm("f")},
-							Args:      Args{VarTerm("__local2__"), VarTerm("__local3__")},
-							Value:     BooleanTerm(true),
-							Assign:    true,
-						},
-						Body: NewBody(NewExpr(BooleanTerm(true))),
-					},
-				},
-			},
+			expMod: MustParseModuleWithOpts(`package negation
+				p = true if {
+					__local4__ = input.x
+					every __local0__, __local1__ in __local4__ {
+						not {
+							__local5__ = input.y
+							data.negation.f(__local1__, __local5__)
+						}
+					}
+				}
+				
+				f(__local2__, __local3__) := true if { true }
+			`, popts),
 		},
 		{
 			note: "negated assignment",
@@ -13267,6 +13171,21 @@ func TestCompilerNotImport(t *testing.T) {
 			},
 		},
 		{
+			note: "negated assignment, explicit not-body",
+			module: `package negation
+				import future.keywords.not
+				
+				p if {
+					not { a := 1 }
+				}
+			`,
+			expMod: MustParseModuleWithOpts(`package negation
+				p = true if {
+					not { __local0__ = 1 }
+				}
+			`, popts),
+		},
+		{
 			note: "negated assignment, call",
 			module: `package negation
 				import future.keywords.not
@@ -13281,6 +13200,24 @@ func TestCompilerNotImport(t *testing.T) {
 					Message: "var a is unsafe",
 				},
 			},
+		},
+		{
+			note: "negated assignment, call, explicit not-body",
+			module: `package negation
+				import future.keywords.not
+				
+				p if {
+					not { a := 1 + 2 }
+				}
+			`,
+			expMod: MustParseModuleWithOpts(`package negation
+				p = true if { 
+					not {
+						plus(1, 2, __local1__)
+						__local0__ = __local1__
+					}
+				}
+			`, popts),
 		},
 		{
 			note: "negated assignment, call, output var",
@@ -13299,12 +13236,45 @@ func TestCompilerNotImport(t *testing.T) {
 			},
 		},
 		{
+			note: "negated assignment, call, output var, explicit not-body",
+			module: `package negation
+				import future.keywords.not
+				
+				p if {
+					not { plus(1, 2, a) }
+				}
+			`,
+			expMod: MustParseModuleWithOpts(`package negation
+				p = true if { 
+					not {
+						plus(1, 2, a)
+					}
+				}
+			`, popts),
+		},
+		{
 			note: "negated equality, unsafe var",
 			module: `package negation
 				import future.keywords.not
 				
 				p if {
 					not a == 1
+				}
+			`,
+			expErrs: Errors{
+				&Error{
+					Code:    CompileErr,
+					Message: "var a is unsafe",
+				},
+			},
+		},
+		{
+			note: "negated equality, unsafe var, explicit not-body",
+			module: `package negation
+				import future.keywords.not
+				
+				p if {
+					not { a == 1 }
 				}
 			`,
 			expErrs: Errors{
@@ -13331,6 +13301,21 @@ func TestCompilerNotImport(t *testing.T) {
 			},
 		},
 		{
+			note: "negated unification, unsafe var, explicit not-body",
+			module: `package negation
+				import future.keywords.not
+				
+				p if {
+					not { a = 1 }
+				}
+			`,
+			expMod: MustParseModuleWithOpts(`package negation
+				p = true if { 
+					not {a = 1}
+				}
+			`, popts),
+		},
+		{
 			note: "negated unification, unsafe var, call",
 			module: `package negation
 				import future.keywords.not
@@ -13345,6 +13330,24 @@ func TestCompilerNotImport(t *testing.T) {
 					Message: "var a is unsafe",
 				},
 			},
+		},
+		{
+			note: "negated unification, call, explicit not-body",
+			module: `package negation
+				import future.keywords.not
+				
+				p if {
+					not { a = 1 + 2 }
+				}
+			`,
+			expMod: MustParseModuleWithOpts(`package negation
+				p = true if { 
+					not {
+						plus(1, 2, __local0__)
+						a = __local0__
+					}
+				}
+			`, popts),
 		},
 		{
 			note: "negated enumeration, unsafe var (wildcard)",
@@ -13363,6 +13366,21 @@ func TestCompilerNotImport(t *testing.T) {
 			},
 		},
 		{
+			note: "negated enumeration, wildcard, explicit not-body",
+			module: `package negation
+				import future.keywords.not
+				
+				p if {
+					not { input.a[_] }
+				}
+			`,
+			expMod: MustParseModuleWithOpts(`package negation
+				p = true if { 
+					not { input.a[_] }
+				}
+			`, popts),
+		},
+		{
 			note: "negated safe var",
 			module: `package negation
 				import future.keywords.not
@@ -13372,25 +13390,35 @@ func TestCompilerNotImport(t *testing.T) {
 					not a + 2 = 3
 				}
 			`,
-			expMod: &Module{
-				Package: MustParsePackage("package negation"),
-				Rules: RuleSet{
-					&Rule{
-						Head: &Head{
-							Name:      Var("p"),
-							Reference: Ref{VarTerm("p")},
-							Value:     BooleanTerm(true),
-						},
-						Body: NewBody(
-							Equality.Expr(VarTerm("a"), NumberTerm("1")),
-							NotExpr(
-								Plus.Expr(VarTerm("a"), NumberTerm("2"), VarTerm("__local0__")),
-								Equality.Expr(VarTerm("__local0__"), NumberTerm("3")),
-							),
-						),
-					},
-				},
-			},
+			expMod: MustParseModuleWithOpts(`package negation
+				p = true if {
+					a = 1
+					not {
+						plus(a, 2, __local0__)
+						__local0__ = 3
+					}
+			}
+			`, popts),
+		},
+		{
+			note: "negated safe var, explicit not-body",
+			module: `package negation
+				import future.keywords.not
+				
+				p if {
+					a = 1
+					not { a + 2 = 3 }
+				}
+			`,
+			expMod: MustParseModuleWithOpts(`package negation
+				p = true if {
+					a = 1
+					not {
+						plus(a, 2, __local0__)
+						__local0__ = 3
+					}
+				}
+			`, popts),
 		},
 		{
 			note: "negated safe var, rearranged",
@@ -13402,25 +13430,35 @@ func TestCompilerNotImport(t *testing.T) {
 					a = 1
 				}
 			`,
-			expMod: &Module{
-				Package: MustParsePackage("package negation"),
-				Rules: RuleSet{
-					&Rule{
-						Head: &Head{
-							Name:      Var("p"),
-							Reference: Ref{VarTerm("p")},
-							Value:     BooleanTerm(true),
-						},
-						Body: NewBody(
-							Equality.Expr(VarTerm("a"), NumberTerm("1")), // reordered
-							NotExpr(
-								Plus.Expr(VarTerm("a"), NumberTerm("2"), VarTerm("__local0__")),
-								Equality.Expr(VarTerm("__local0__"), NumberTerm("3")),
-							),
-						),
-					},
-				},
-			},
+			expMod: MustParseModuleWithOpts(`package negation
+				p = true if { 
+					a = 1
+					not {
+						plus(a, 2, __local0__)
+						__local0__ = 3
+					}
+				}
+			`, popts),
+		},
+		{
+			note: "negated safe var, explicit not-body, rearranged",
+			module: `package negation
+				import future.keywords.not
+				
+				p if {
+					not { a + 2 = 3 }
+					a = 1
+				}
+			`,
+			expMod: MustParseModuleWithOpts(`package negation
+				p = true if { 
+					a = 1
+					not {
+						plus(a, 2, __local0__)
+						__local0__ = 3
+					}
+				}
+			`, popts),
 		},
 		{
 			note: "negated unsafe var",
@@ -13429,6 +13467,22 @@ func TestCompilerNotImport(t *testing.T) {
 				
 				p if {
 					not a + 2 = 3
+				}
+			`,
+			expErrs: Errors{
+				&Error{
+					Code:    CompileErr,
+					Message: "var a is unsafe",
+				},
+			},
+		},
+		{
+			note: "negated unsafe var, explicit not-body",
+			module: `package negation
+				import future.keywords.not
+				
+				p if {
+					not { a + 2 = 3 }
 				}
 			`,
 			expErrs: Errors{
@@ -13449,24 +13503,54 @@ func TestCompilerNotImport(t *testing.T) {
 					not a = 1
 				}
 			`,
-			expMod: &Module{
-				Package: MustParsePackage("package negation"),
-				Rules: RuleSet{
-					&Rule{
-						Head: &Head{
-							Name:      Var("p"),
-							Reference: Ref{VarTerm("p")},
-							Value:     BooleanTerm(true),
-						},
-						Body: NewBody(
-							Equality.Expr(VarTerm("a"), NumberTerm("2")),
-							NotExpr(
-								Equality.Expr(VarTerm("a"), NumberTerm("1")),
-							),
-						),
-					},
-				},
-			},
+			expMod: MustParseModuleWithOpts(`package negation
+				p = true if {
+					a = 2
+					not { a = 1 }
+				}
+			`, popts),
+		},
+		{
+			note: "negated and non-negated unification on same var, explicit not-body",
+			module: `package negation
+				import future.keywords.not
+				
+				p if {
+					a = 2
+					not { a = 1 }
+				}
+			`,
+			expMod: MustParseModuleWithOpts(`package negation
+				p = true if {
+					a = 2
+					not { a = 1 }
+				}
+			`, popts),
+		},
+		{
+			note: "negated assignment override, explicit not-body",
+			module: `package negation
+				import future.keywords.not
+				
+				p if {
+					a = 2
+					not { 
+						a := 1
+						a == 3
+					}
+					a == 2
+				}
+			`,
+			expMod: MustParseModuleWithOpts(`package negation
+				p = true if { 
+					a = 2
+					not {
+						__local0__ = 1
+						__local0__ = 3
+					}
+					a = 2
+				}
+			`, popts),
 		},
 		{
 			note: "negated and non-negated unification on same var, rearranged",
@@ -13478,24 +13562,29 @@ func TestCompilerNotImport(t *testing.T) {
 					a = 2
 				}
 			`,
-			expMod: &Module{
-				Package: MustParsePackage("package negation"),
-				Rules: RuleSet{
-					&Rule{
-						Head: &Head{
-							Name:      Var("p"),
-							Reference: Ref{VarTerm("p")},
-							Value:     BooleanTerm(true),
-						},
-						Body: NewBody(
-							Equality.Expr(VarTerm("a"), NumberTerm("2")), // reordered
-							NotExpr(
-								Equality.Expr(VarTerm("a"), NumberTerm("1")),
-							),
-						),
-					},
-				},
-			},
+			expMod: MustParseModuleWithOpts(`package negation
+				p = true if {
+					a = 2
+					not { a = 1 }
+				}
+			`, popts),
+		},
+		{
+			note: "negated and non-negated unification on same var, explicit not-body, rearranged",
+			module: `package negation
+				import future.keywords.not
+				
+				p if {
+					not { a = 1 }
+					a = 2
+				}
+			`,
+			expMod: MustParseModuleWithOpts(`package negation
+				p = true if {
+					a = 2
+					not { a = 1 }
+				}
+			`, popts),
 		},
 		{
 			note: "negated and non-negated unification on same var, calls, rearranged",
@@ -13503,50 +13592,49 @@ func TestCompilerNotImport(t *testing.T) {
 				import future.keywords.not
 				
 				p if {
-					a = f(2)
 					not a = f(1)
+					a = f(2)
 				}
 				
 				f(x) := x
 			`,
-			expMod: &Module{
-				Package: MustParsePackage("package negation"),
-				Rules: RuleSet{
-					&Rule{
-						Head: &Head{
-							Name:      Var("p"),
-							Reference: Ref{VarTerm("p")},
-							Value:     BooleanTerm(true),
-						},
-						Body: NewBody(
-							NewExpr([]*Term{
-								RefTerm(VarTerm("data"), StringTerm("negation"), StringTerm("f")),
-								NumberTerm("2"),
-								VarTerm("__local1__"),
-							}),
-							Equality.Expr(VarTerm("a"), VarTerm("__local1__")), // reordered
-							NotExpr(
-								NewExpr([]*Term{
-									RefTerm(VarTerm("data"), StringTerm("negation"), StringTerm("f")),
-									NumberTerm("1"),
-									VarTerm("__local2__"),
-								}),
-								Equality.Expr(VarTerm("a"), VarTerm("__local2__")),
-							),
-						),
-					},
-					&Rule{
-						Head: &Head{
-							Name:      Var("f"),
-							Reference: Ref{VarTerm("f")},
-							Args:      Args{VarTerm("__local0__")},
-							Value:     VarTerm("__local0__"),
-							Assign:    true,
-						},
-						Body: NewBody(NewExpr(BooleanTerm(true))),
-					},
-				},
-			},
+			expMod: MustParseModuleWithOpts(`package negation
+				p = true if {
+					data.negation.f(2, __local2__)
+					a = __local2__
+					not {
+						data.negation.f(1, __local1__)
+						a = __local1__
+					}
+				}
+				
+				f(__local0__) := __local0__ if { true }
+			`, popts),
+		},
+		{
+			note: "negated and non-negated unification on same var, calls, explicit not-body, rearranged",
+			module: `package negation
+				import future.keywords.not
+				
+				p if {
+					not { a = f(1) }
+					a = f(2)
+				}
+				
+				f(x) := x
+			`,
+			expMod: MustParseModuleWithOpts(`package negation
+				p = true if {
+					data.negation.f(2, __local2__)
+					a = __local2__
+					not {
+						data.negation.f(1, __local1__)
+						a = __local1__
+					}
+				}
+				
+				f(__local0__) := __local0__ if { true }
+			`, popts),
 		},
 
 		{
@@ -13560,33 +13648,40 @@ func TestCompilerNotImport(t *testing.T) {
 						not v = 2
 					]
 				}`,
-			expMod: &Module{
-				Package: MustParsePackage("package negation"),
-				Rules: RuleSet{
-					&Rule{
-						Head: &Head{
-							Name:      Var("p"),
-							Reference: Ref{VarTerm("p")},
-							Value:     BooleanTerm(true),
-						},
-						Body: NewBody(
-							NotExpr(
-								&Expr{
-									Terms: ArrayComprehensionTerm(
-										VarTerm("__local0__"),
-										NewBody(
-											Equality.Expr(VarTerm("__local0__"), NumberTerm("1")),
-											NotExpr(
-												Equality.Expr(VarTerm("__local0__"), NumberTerm("2")),
-											),
-										),
-									),
-								},
-							),
-						),
-					},
-				},
-			},
+			expMod: MustParseModuleWithOpts(`package negation
+				p = true if {
+					not {
+						[__local0__ | 
+							__local0__ = 1
+							not { __local0__ = 2 }
+						]
+					}
+				}
+			`, popts),
+		},
+		{
+			note: "nested negation (comprehension), explicit not-bodies",
+			module: `package negation
+				import future.keywords.not
+				
+				p if {
+					not {
+						[v |
+							v := 1
+							not { v = 2 }
+						]
+					}
+				}`,
+			expMod: MustParseModuleWithOpts(`package negation
+				p = true if {
+					not {
+						[__local0__ | 
+							__local0__ = 1
+							not { __local0__ = 2 }
+						]
+					}
+				}
+			`, popts),
 		},
 		{
 			note: "nested negation (comprehension), outer closure var reference",
@@ -13599,33 +13694,62 @@ func TestCompilerNotImport(t *testing.T) {
 						not v = 2
 					]
 				}`,
-			expMod: &Module{
-				Package: MustParsePackage("package negation"),
-				Rules: RuleSet{
-					&Rule{
-						Head: &Head{
-							Name:      Var("p"),
-							Reference: Ref{VarTerm("p")},
-							Value:     BooleanTerm(true),
-						},
-						Body: NewBody(
-							Equality.Expr(VarTerm("__local0__"), NumberTerm("1")),
-							NotExpr(
-								&Expr{
-									Terms: ArrayComprehensionTerm(
-										NumberTerm("42"),
-										NewBody(
-											NotExpr(
-												Equality.Expr(VarTerm("__local0__"), NumberTerm("2")),
-											),
-										),
-									),
-								},
-							),
-						),
-					},
-				},
-			},
+			expMod: MustParseModuleWithOpts(`package negation
+				p = true if { 
+					__local0__ = 1
+					not {
+						[42 | 
+							not { __local0__ = 2 }
+						]
+					}
+				}
+			`, popts),
+		},
+		{
+			note: "nested negation (comprehension), outer closure var reference, rearranged",
+			module: `package negation
+				import future.keywords.not
+				
+				p if {
+					not [42 |
+						not v = 2
+					]
+					v = 1
+				}`,
+			expMod: MustParseModuleWithOpts(`package negation
+				p = true if { 
+					v = 1
+					not {
+						[42 | 
+							not { v = 2 }
+						]
+					}
+				}
+			`, popts),
+		},
+		{
+			note: "nested negation (comprehension), outer closure var reference, explicit not-bodies, rearranged",
+			module: `package negation
+				import future.keywords.not
+				
+				p if {
+					not {
+						[42 |
+							not { v = 2 }
+						]
+					}
+					v = 1
+				}`,
+			expMod: MustParseModuleWithOpts(`package negation
+				p = true if { 
+					v = 1
+					not {
+						[42 | 
+							not { v = 2 }
+						]
+					}
+				}
+			`, popts),
 		},
 		{
 			note: "nested negation (comprehension), unsafe var reference",
@@ -13656,86 +13780,322 @@ func TestCompilerNotImport(t *testing.T) {
 						not v = 1
 					]
 				}`,
-			expMod: &Module{
-				Package: MustParsePackage("package negation"),
-				Rules: RuleSet{
-					&Rule{
-						Head: &Head{
-							Name:      Var("p"),
-							Reference: Ref{VarTerm("p")},
-							Value:     BooleanTerm(true),
-						},
-						Body: NewBody(
-							Equality.Expr(VarTerm("__local0__"), NumberTerm("1")),
-							NotExpr(
-								&Expr{
-									Terms: ArrayComprehensionTerm(
-										NumberTerm("42"),
-										NewBody(
-											Equality.Expr(VarTerm("__local1__"), NumberTerm("2")),
-											NotExpr(
-												Equality.Expr(VarTerm("__local1__"), NumberTerm("1")),
-											),
-										),
-									),
-								},
-							),
-						),
-					},
+			expMod: MustParseModuleWithOpts(`package negation
+				p = true if {
+					__local0__ = 1
+					not {
+						[42 | 
+							__local1__ = 2
+							not { __local1__ = 1 }
+						]
+					}
+				}
+			`, popts),
+		},
+
+		// Explicit not-bodies required
+
+		{
+			note: "explicit not-body, enumeration",
+			module: `package negation
+				import future.keywords.not
+				
+				p if {
+					not {
+						x = [1, 2][_]
+						x > 2
+					}
+				}`,
+			expMod: MustParseModuleWithOpts(`package negation
+				p if {
+					not {
+						__local0__ = [1, 2]
+						x = __local0__[_]
+						gt(x, 2)
+					}
+				}
+			`, popts),
+		},
+		{
+			note: "explicit not-body, enumeration, reordering",
+			module: `package negation
+				import future.keywords.not
+				
+				p if {
+					not {
+						x = [1, 2][_]
+						x > y
+					}
+					y = 2
+				}`,
+			expMod: MustParseModuleWithOpts(`package negation
+				p if {
+					y = 2
+					not {
+						__local0__ = [1, 2]
+						x = __local0__[_]
+						gt(x, y)
+					}
+				}
+			`, popts),
+		},
+
+		{
+			note: "explicit not-body, enumeration, some in",
+			module: `package negation
+				import future.keywords.not
+				
+				p if {
+					not {
+						some x in [1, 2]
+						x > 3
+					}
+				}`,
+			expMod: MustParseModuleWithOpts(`package negation
+				p = true if { 
+					not {
+						__local3__ = [1, 2]
+						__local2__ = __local3__[__local1__]
+						gt(__local2__, 3)
+					}
+				}
+			`, popts),
+		},
+		{
+			note: "explicit not-body, enumeration, some in, reordering",
+			module: `package negation
+				import future.keywords.not
+				
+				p if {
+					not {
+						some x in [1, 2]
+						x < y
+					}
+					y = 3
+				}`,
+			expMod: MustParseModuleWithOpts(`package negation
+				p = true if {
+					y = 3
+					not {
+						__local3__ = [1, 2]
+						__local2__ = __local3__[__local1__]
+						lt(__local2__, y)
+					}
+				}
+			`, popts),
+		},
+
+		{
+			note: "explicit not-body, var indirection",
+			module: `package negation
+				import future.keywords.not
+				
+				p if {
+					not {
+						a = 1
+						b = a
+						a + 1 = 2
+					}
+				}
+			`,
+			expMod: MustParseModuleWithOpts(`package negation
+				p = true if { 
+					not {
+						a = 1
+						b = a
+						plus(a, 1, __local0__)
+						__local0__ = 2
+					}
+				}
+			`, popts),
+		},
+		{
+			note: "explicit not-body, var indirection, safe var (unification)",
+			module: `package negation
+				import future.keywords.not
+				
+				p if {
+					x = 1
+					not {
+						a = x
+						b = a
+						a + 1 = 2
+					}
+				}
+			`,
+			expMod: MustParseModuleWithOpts(`package negation
+				p = true if { 
+					x = 1
+					not {
+						a = x
+						b = a
+						plus(a, 1, __local0__)
+						__local0__ = 2
+					}
+				}
+			`, popts),
+		},
+		{
+			note: "explicit not-body, var indirection, safe var (assignment)",
+			module: `package negation
+				import future.keywords.not
+				
+				p if {
+					x := 1
+					not {
+						a = x
+						b = a
+						a + 1 = 2
+					}
+				}
+			`,
+			expMod: MustParseModuleWithOpts(`package negation
+				p = true if {
+					__local0__ = 1
+					not {
+						a = __local0__
+						b = a
+						plus(a, 1, __local1__)
+						__local1__ = 2
+					}
+				}
+			`, popts),
+		},
+		{
+			note: "explicit not-body, var indirection, unsafe var",
+			module: `package negation
+				import future.keywords.not
+		
+				p if {
+					not {
+						a = x
+						b = a
+						a + 1 = 2
+					}
+				}
+			`,
+			expErrs: Errors{
+				&Error{
+					Code:    CompileErr,
+					Message: "var a is unsafe",
+				},
+				&Error{
+					Code:    CompileErr,
+					Message: "var x is unsafe",
+				},
+				&Error{
+					Code:    CompileErr,
+					Message: "var b is unsafe",
 				},
 			},
 		},
-		// TODO: Add purely nested negations (requires body parsing)
 
-		// TODO: not-body parsing required
-		// {
-		// 	note: "negated indirection",
-		// 	module: `package negation
-		// 		import future.keywords.not
-		//
-		// 		p if {
-		// 			not {
-		// 				a = 1
-		// 				b = a
-		// 				a + 1 = 2
-		// 			}
-		// 		}
-		// 	`,
-		// },
-		// 	note: "negated indirection, safe var",
-		// 	module: `package negation
-		// 		import future.keywords.not
-		//
-		// 		p if {
-		// 			x := 1
-		// 			not {
-		// 				a = x
-		// 				b = a
-		// 				a + 1 = 2
-		// 			}
-		// 		}
-		// 	`,
-		// },
-		// {
-		// 	note: "negated indirection, unsafe var",
-		// 	module: `package negation
-		// 		import future.keywords.not
-		//
-		// 		p if {
-		// 			not {
-		// 				a = x
-		// 				b = a
-		// 				a + 1 = 2
-		// 			}
-		// 		}
-		// 	`,
-		// 	expErrs: Errors{
-		// 		&Error{
-		// 			Code:    CompileErr,
-		// 			Message: "var a is unsafe",
-		// 		},
-		// 	},
-		// },
+		{
+			note: "explicit not-body, nested negations",
+			module: `package negation
+				import future.keywords.not
+				
+				p if not {
+					not {
+						not false
+					}
+				}
+			`,
+			expMod: MustParseModuleWithOpts(`package negation
+				p if not {
+					not {
+						not false
+					}
+				}
+			`, popts),
+		},
+		{
+			note: "explicit not-body, nested negations, ref to outer var",
+			module: `package negation
+				import future.keywords.not
+				
+				p if {
+					a = 1
+					not {
+						a = 2
+						not {
+							a = 3
+							not a = 4
+						}
+					}
+				}
+			`,
+			expMod: MustParseModuleWithOpts(`package negation
+				p if {
+					a = 1
+					not {
+						a = 2
+						not {
+							a = 3
+							not a = 4
+						}
+					}
+				}
+			`, popts),
+		},
+		{
+			note: "explicit not-body, nested negations, ref to outer var, inner override",
+			module: `package negation
+				import future.keywords.not
+				
+				p if {
+					a = 1
+					not {
+						a := 2
+						not {
+							a = 3
+							not a = 4
+						}
+					}
+				}
+			`,
+			expMod: MustParseModuleWithOpts(`package negation
+				p = true if {
+					a = 1
+					not {
+						__local0__ = 2
+						not {
+							__local0__ = 3
+							not { __local0__ = 4 }
+						}
+					}
+				}
+			`, popts),
+		},
+		{
+			note: "explicit not-body, nested negations, ref to outer var, multiple inner overrides",
+			module: `package negation
+				import future.keywords.not
+				
+				p if {
+					a = 1
+					not {
+						a := 2
+						not {
+							a := 3
+							not a = 4
+						}
+					}
+				}
+			`,
+			expMod: MustParseModuleWithOpts(`package negation
+				p = true if {
+					a = 1
+					not {
+						__local0__ = 2
+						not {
+							__local1__ = 3
+							not { __local1__ = 4 }
+						}
+					}
+				}
+			`, popts),
+		},
 	}
 
 	for _, tc := range tests {

--- a/v1/ast/parser.go
+++ b/v1/ast/parser.go
@@ -1260,6 +1260,10 @@ func (p *Parser) parseLiteral() (expr *Expr) {
 		}
 	}
 
+	if negated && p.notBodies && p.s.tok == tokens.LBrace {
+		return p.parseNotBody()
+	}
+
 	switch p.s.tok {
 	case tokens.Some:
 		if negated {
@@ -1318,7 +1322,11 @@ func (p *Parser) parseLiteralExpr(negated bool) *Expr {
 		}
 
 		if negated && p.notBodies {
+			// Move 'with' statement to outer not expr
+			w := expr.With
+			expr.With = nil
 			expr = NewExpr(&Not{Body: NewBody(expr), Location: p.s.Loc()})
+			expr.With = w
 		} else {
 			expr.Negated = negated
 		}
@@ -1452,6 +1460,28 @@ func (p *Parser) parseSome() *Expr {
 	}
 
 	return NewExpr(decl).SetLocation(decl.Location)
+}
+
+func (p *Parser) parseNotBody() *Expr {
+	loc := p.s.Loc()
+	p.scan()
+
+	body := p.parseBody(tokens.RBrace)
+	if body == nil {
+		return nil
+	}
+	p.scan()
+
+	not := &Not{Body: body, ExplicitBody: true, Location: loc}
+	expr := NewExpr(not).SetLocation(loc)
+
+	if p.s.tok == tokens.With {
+		if expr.With = p.parseWith(); expr.With == nil {
+			return nil
+		}
+	}
+
+	return expr
 }
 
 func (p *Parser) parseEvery() *Expr {

--- a/v1/ast/parser_test.go
+++ b/v1/ast/parser_test.go
@@ -9045,9 +9045,10 @@ func TestNotImport(t *testing.T) {
 		note   string
 		module string
 		exp    *Module
+		expErr string
 	}{
 		{
-			note: "no import",
+			note: "no import, implicit body (legacy negation)",
 			module: `package test
 				p if {
 					not 1 + 1 == 3
@@ -9077,7 +9078,34 @@ func TestNotImport(t *testing.T) {
 			},
 		},
 		{
-			note: "import",
+			// Syntactically similar to empty explicit not-body, but not an error state
+			note: "no import, implicit body, empty object",
+			module: `package test
+				p if {
+					not {}
+				}
+			`,
+			exp: &Module{
+				Package: MustParsePackage("package test"),
+				Rules: RuleSet{
+					&Rule{
+						Head: &Head{
+							Name:      Var("p"),
+							Reference: Ref{VarTerm("p")},
+							Value:     BooleanTerm(true),
+						},
+						Body: NewBody(
+							&Expr{
+								Terms:   ObjectTerm(),
+								Negated: true,
+							},
+						),
+					},
+				},
+			},
+		},
+		{
+			note: "implicit body",
 			module: `package test
 				import future.keywords.not
 				p if {
@@ -9108,18 +9136,272 @@ func TestNotImport(t *testing.T) {
 				},
 			},
 		},
+		{
+			note: "explicit body, no expression",
+			module: `package test
+				import future.keywords.not
+				p if {
+					not {}
+				}
+			`,
+			expErr: "rego_parse_error: found empty body",
+		},
+		{
+			note: "explicit body, single expression",
+			module: `package test
+				import future.keywords.not
+				p if {
+					not { x == 1 }
+				}
+			`,
+			exp: &Module{
+				Package: MustParsePackage("package test"),
+				Imports: []*Import{{Path: RefTerm(VarTerm("future"), StringTerm("keywords"), StringTerm("not"))}},
+				Rules: RuleSet{
+					&Rule{
+						Head: &Head{
+							Name:      Var("p"),
+							Reference: Ref{VarTerm("p")},
+							Value:     BooleanTerm(true),
+						},
+						Body: NewBody(
+							NewExpr(
+								&Not{
+									Body: NewBody(
+										Equal.Expr(VarTerm("x"), NumberTerm("1")),
+									),
+									ExplicitBody: true,
+								},
+							),
+						),
+					},
+				},
+			},
+		},
+		{
+			note: "explicit body, multiple expressions",
+			module: `package test
+				import future.keywords.not
+				p if {
+					not {
+						x == 1
+						y == 2
+					}
+				}
+			`,
+			exp: &Module{
+				Package: MustParsePackage("package test"),
+				Imports: []*Import{{Path: RefTerm(VarTerm("future"), StringTerm("keywords"), StringTerm("not"))}},
+				Rules: RuleSet{
+					&Rule{
+						Head: &Head{
+							Name:      Var("p"),
+							Reference: Ref{VarTerm("p")},
+							Value:     BooleanTerm(true),
+						},
+						Body: NewBody(
+							NewExpr(
+								&Not{
+									Body: NewBody(
+										Equal.Expr(VarTerm("x"), NumberTerm("1")),
+										Equal.Expr(VarTerm("y"), NumberTerm("2")),
+									),
+									ExplicitBody: true,
+								},
+							),
+						),
+					},
+				},
+			},
+		},
+		{
+			note: "explicit body, multiple expressions, one-line",
+			module: `package test
+				import future.keywords.not
+				p if {
+					not { x == 1;y == 2 }
+				}
+			`,
+			exp: &Module{
+				Package: MustParsePackage("package test"),
+				Imports: []*Import{{Path: RefTerm(VarTerm("future"), StringTerm("keywords"), StringTerm("not"))}},
+				Rules: RuleSet{
+					&Rule{
+						Head: &Head{
+							Name:      Var("p"),
+							Reference: Ref{VarTerm("p")},
+							Value:     BooleanTerm(true),
+						},
+						Body: NewBody(
+							NewExpr(
+								&Not{
+									Body: NewBody(
+										Equal.Expr(VarTerm("x"), NumberTerm("1")),
+										Equal.Expr(VarTerm("y"), NumberTerm("2")),
+									),
+									ExplicitBody: true,
+								},
+							),
+						),
+					},
+				},
+			},
+		},
+		{
+			note: "explicit body, 'with' modifier, outer",
+			module: `package test
+				import future.keywords.not
+				p if {
+					not { x == 1 } with input as {"x": 2}
+				}
+			`,
+			exp: &Module{
+				Package: MustParsePackage("package test"),
+				Imports: []*Import{{Path: RefTerm(VarTerm("future"), StringTerm("keywords"), StringTerm("not"))}},
+				Rules: RuleSet{
+					&Rule{
+						Head: &Head{
+							Name:      Var("p"),
+							Reference: Ref{VarTerm("p")},
+							Value:     BooleanTerm(true),
+						},
+						Body: NewBody(
+							func() *Expr {
+								e := NewExpr(
+									&Not{
+										Body: NewBody(
+											Equal.Expr(VarTerm("x"), NumberTerm("1")),
+										),
+										ExplicitBody: true,
+									},
+								)
+								e.With = []*With{
+									{
+										Target: RefTerm(VarTerm("input")),
+										Value:  ObjectTerm([2]*Term{StringTerm("x"), NumberTerm("2")}),
+									},
+								}
+								return e
+							}(),
+						),
+					},
+				},
+			},
+		},
+		{
+			note: "explicit body, 'with' modifier, inner",
+			module: `package test
+				import future.keywords.not
+				p if {
+					not { x == 1 with input as {"x": 2} } 
+				}
+			`,
+			exp: &Module{
+				Package: MustParsePackage("package test"),
+				Imports: []*Import{{Path: RefTerm(VarTerm("future"), StringTerm("keywords"), StringTerm("not"))}},
+				Rules: RuleSet{
+					&Rule{
+						Head: &Head{
+							Name:      Var("p"),
+							Reference: Ref{VarTerm("p")},
+							Value:     BooleanTerm(true),
+						},
+						Body: NewBody(
+							NewExpr(
+								&Not{
+									Body: NewBody(
+										func() *Expr {
+											e := Equal.Expr(VarTerm("x"), NumberTerm("1"))
+											e.With = []*With{
+												{
+													Target: RefTerm(VarTerm("input")),
+													Value:  ObjectTerm([2]*Term{StringTerm("x"), NumberTerm("2")}),
+												},
+											}
+											return e
+										}(),
+									),
+									ExplicitBody: true,
+								},
+							),
+						),
+					},
+				},
+			},
+		},
+		{
+			note: "explicit body, 'with' modifier, inner+outer",
+			module: `package test
+				import future.keywords.not
+				p if {
+					not { x == 1 with input as {"x": 2} } with input as {"y": 3}
+				}
+			`,
+			exp: &Module{
+				Package: MustParsePackage("package test"),
+				Imports: []*Import{{Path: RefTerm(VarTerm("future"), StringTerm("keywords"), StringTerm("not"))}},
+				Rules: RuleSet{
+					&Rule{
+						Head: &Head{
+							Name:      Var("p"),
+							Reference: Ref{VarTerm("p")},
+							Value:     BooleanTerm(true),
+						},
+						Body: NewBody(
+							func() *Expr {
+								e := NewExpr(
+									&Not{
+										Body: NewBody(
+											func() *Expr {
+												e := Equal.Expr(VarTerm("x"), NumberTerm("1"))
+												e.With = []*With{
+													{
+														Target: RefTerm(VarTerm("input")),
+														Value:  ObjectTerm([2]*Term{StringTerm("x"), NumberTerm("2")}),
+													},
+												}
+												return e
+											}(),
+										),
+										ExplicitBody: true,
+									},
+								)
+								e.With = []*With{
+									{
+										Target: RefTerm(VarTerm("input")),
+										Value:  ObjectTerm([2]*Term{StringTerm("y"), NumberTerm("3")}),
+									},
+								}
+								return e
+							}(),
+						),
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.note, func(t *testing.T) {
 			mod, err := ParseModuleWithOpts("", tc.module,
 				ParserOptions{Capabilities: CapabilitiesForThisVersion().withFutureKeyword("not")}) // TODO: drop once future.keywords.not is enabled by default
-			if err != nil {
-				t.Fatalf("Unexpected error: %s", err)
-			}
 
-			if diff := cmp.Diff(tc.exp, mod); diff != "" {
-				t.Errorf("Unexpected result (-want, +got):\n%s", diff)
+			if tc.expErr != "" {
+				if err == nil {
+					t.Fatalf("Expected error, got nil")
+				}
+
+				if !strings.Contains(err.Error(), tc.expErr) {
+					t.Fatalf("Expected error to contain %q, but got: %v", tc.expErr, err)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("Unexpected error: %s", err)
+				}
+
+				if diff := cmp.Diff(tc.exp, mod); diff != "" {
+					t.Errorf("Unexpected result (-want, +got):\n%s", diff)
+				}
 			}
 		})
 	}

--- a/v1/ast/string_length.go
+++ b/v1/ast/string_length.go
@@ -364,6 +364,10 @@ func (c *Comment) StringLength() int {
 }
 
 func (not *Not) StringLength() int {
-	l := 6 // "not {}"
-	return l + not.Body.StringLength()
+	if !not.ExplicitBody && len(not.Body) == 1 {
+		// "not ..."
+		return 4 + not.Body.StringLength()
+	}
+	// "not {...}"
+	return 6 + not.Body.StringLength()
 }

--- a/v1/ast/term.go
+++ b/v1/ast/term.go
@@ -564,8 +564,9 @@ func IsScalar(v Value) bool {
 
 // Not is both a Term and a Node
 type Not struct {
-	Body     Body      `json:"body"`
-	Location *Location `json:"location,omitempty"`
+	Body         Body      `json:"body"`
+	ExplicitBody bool      `json:"explicit_body,omitempty"`
+	Location     *Location `json:"location,omitempty"`
 }
 
 func NotTerm(exprs ...*Expr) *Term {
@@ -602,6 +603,7 @@ func (n *Not) Equal(other Value) bool {
 func (n *Not) Compare(other Value) int {
 	switch o := other.(type) {
 	case *Not:
+		// We don't consider the ExplicitBody field, as it has no effect on expression negation
 		return n.Body.Compare(o.Body)
 	default:
 		return -1
@@ -624,7 +626,10 @@ func (n *Not) IsGround() bool {
 }
 
 func (n *Not) String() string {
-	// TODO: Do best-effort unroll/interpolation of not-body to create one-liner expression if possible
+	if !n.ExplicitBody && len(n.Body) == 1 {
+		return "not " + n.Body.String()
+	}
+
 	return "not {" + n.Body.String() + "}"
 }
 

--- a/v1/ast/term_appenders.go
+++ b/v1/ast/term_appenders.go
@@ -288,6 +288,11 @@ func appendComprehensionTerm(buf []byte, term *Term) ([]byte, error) {
 }
 
 func (not *Not) AppendText(buf []byte) ([]byte, error) {
+	if !not.ExplicitBody && len(not.Body) == 1 {
+		buf = append(buf, "not "...)
+		return not.Body.AppendText(buf)
+	}
+
 	buf = append(buf, "not {"...)
 	var err error
 	if buf, err = not.Body.AppendText(buf); err != nil {

--- a/v1/ast/term_appenders_test.go
+++ b/v1/ast/term_appenders_test.go
@@ -121,6 +121,42 @@ var valueAppenderTests = []struct {
 		term: ast.MustParseTerm(`{x | x := data.values[_]; x < 100}`),
 		want: `{x | assign(x, data.values[_]); lt(x, 100)}`,
 	},
+	{
+		name: "not",
+		term: &ast.Not{
+			Body: ast.NewBody(ast.NewExpr(ast.LessThan.Call(ast.NumberTerm("100"), ast.NumberTerm("1")))),
+		},
+		want: `not lt(100, 1)`,
+	},
+	{
+		name: "not, explicit body, one-line",
+		term: &ast.Not{
+			ExplicitBody: true,
+			Body:         ast.NewBody(ast.NewExpr(ast.LessThan.Call(ast.NumberTerm("100"), ast.NumberTerm("1")))),
+		},
+		want: `not {lt(100, 1)}`,
+	},
+	{
+		name: "not, implicit body, multi-line",
+		term: &ast.Not{
+			Body: ast.NewBody(
+				ast.NewExpr(ast.LessThan.Call(ast.NumberTerm("100"), ast.NumberTerm("1"))),
+				ast.NewExpr(ast.LessThan.Call(ast.NumberTerm("99"), ast.NumberTerm("1"))),
+			),
+		},
+		want: `not {lt(100, 1); lt(99, 1)}`,
+	},
+	{
+		name: "not, explicit body, multi-line",
+		term: &ast.Not{
+			ExplicitBody: true,
+			Body: ast.NewBody(
+				ast.NewExpr(ast.LessThan.Call(ast.NumberTerm("100"), ast.NumberTerm("1"))),
+				ast.NewExpr(ast.LessThan.Call(ast.NumberTerm("99"), ast.NumberTerm("1"))),
+			),
+		},
+		want: `not {lt(100, 1); lt(99, 1)}`,
+	},
 }
 
 func TestASTValueTextAppendersAndStringLength(t *testing.T) {

--- a/v1/ast/transform.go
+++ b/v1/ast/transform.go
@@ -194,6 +194,11 @@ func Transform(t Transformer, x any) (any, error) {
 				return nil, err
 			}
 			y.Terms = ts
+		case *Not:
+			ts.Body, err = transformBody(t, ts.Body)
+			if err != nil {
+				return nil, err
+			}
 		}
 		for i, w := range y.With {
 			w, err := Transform(t, w)

--- a/v1/bundle/bundle.go
+++ b/v1/bundle/bundle.go
@@ -1115,6 +1115,10 @@ func (b *Bundle) FormatModulesWithOptions(opts BundleFormatOptions) error {
 			Capabilities: opts.Capabilities,
 		}
 
+		if fmtOpts.Capabilities == nil {
+			fmtOpts.Capabilities = ast.CapabilitiesForThisVersion(ast.CapabilitiesRegoVersion(fmtOpts.RegoVersion))
+		}
+
 		if module.Parsed != nil {
 			fmtOpts.ParserOptions = &ast.ParserOptions{
 				RegoVersion: module.Parsed.RegoVersion(),
@@ -1122,10 +1126,9 @@ func (b *Bundle) FormatModulesWithOptions(opts BundleFormatOptions) error {
 			if opts.PreserveModuleRegoVersion {
 				fmtOpts.RegoVersion = module.Parsed.RegoVersion()
 			}
-		}
-
-		if fmtOpts.Capabilities == nil {
-			fmtOpts.Capabilities = ast.CapabilitiesForThisVersion(ast.CapabilitiesRegoVersion(fmtOpts.RegoVersion))
+			if fmtOpts.ParserOptions.RegoVersion == fmtOpts.RegoVersion {
+				fmtOpts.ParserOptions.Capabilities = fmtOpts.Capabilities
+			}
 		}
 
 		if module.Raw == nil {

--- a/v1/format/format.go
+++ b/v1/format/format.go
@@ -226,6 +226,8 @@ func AstWithOpts(x any, opts Opts) ([]byte, error) {
 				extraFutureKeywordImports["in"] = struct{}{}
 			case n.IsEvery():
 				extraFutureKeywordImports["every"] = struct{}{}
+			case n.IsNot():
+				extraFutureKeywordImports["not"] = struct{}{}
 			}
 
 		case *ast.Import:
@@ -278,6 +280,7 @@ func AstWithOpts(x any, opts Opts) ([]byte, error) {
 		}
 
 		regoV1Imported := slices.ContainsFunc(x.Imports, isRegoV1Compatible)
+
 		if regoVersion == ast.RegoV0CompatV1 || regoVersion == ast.RegoV1 || regoV1Imported {
 			if !opts.DropV0Imports && !regoV1Imported {
 				for _, kw := range o.futureKeywords {
@@ -286,11 +289,18 @@ func AstWithOpts(x any, opts Opts) ([]byte, error) {
 			} else {
 				x.Imports = future.FilterFutureImports(x.Imports)
 			}
+
+			for kw := range extraFutureKeywordImports {
+				if ast.IsFutureKeywordForRegoVersion(kw, ast.RegoV1) {
+					x.Imports = ensureFutureKeywordImport(x.Imports, kw)
+				}
+			}
 		} else {
 			for kw := range extraFutureKeywordImports {
 				x.Imports = ensureFutureKeywordImport(x.Imports, kw)
 			}
 		}
+
 		err := w.writeModule(x)
 		if err != nil {
 			w.errs = append(w.errs, ast.NewError(ast.FormatErr, &ast.Location{}, "%s", err.Error()))
@@ -931,6 +941,11 @@ func (w *writer) writeExpr(expr *ast.Expr, comments []*ast.Comment) ([]*ast.Comm
 		if err != nil {
 			return nil, err
 		}
+	case *ast.Not:
+		comments, err = w.writeNot(t, expr.Loc(), comments)
+		if err != nil {
+			return nil, err
+		}
 	case []*ast.Term:
 		comments, err = w.writeFunctionCall(expr, comments)
 		if err != nil {
@@ -1064,6 +1079,45 @@ func (w *writer) writeEvery(every *ast.Every, loc *ast.Location, comments []*ast
 		w.write(" ")
 	}
 	w.write("}")
+	return comments, nil
+}
+
+func (w *writer) writeNot(not *ast.Not, loc *ast.Location, comments []*ast.Comment) ([]*ast.Comment, error) {
+	if loc == nil {
+		loc = not.Loc()
+	}
+
+	var err error
+	comments, err = w.insertComments(comments, loc)
+	if err != nil {
+		return nil, err
+	}
+
+	w.write("not ")
+
+	if not.ExplicitBody || len(not.Body) > 1 {
+		w.write("{")
+		comments, err = w.writeComprehensionBody('{', '}', not.Body, loc, loc, comments)
+		if err != nil {
+			if !errors.As(err, &unexpectedCommentError{}) {
+				return nil, err
+			}
+		}
+
+		if len(not.Body) == 1 &&
+			not.Body[0].Location.Row == loc.Row {
+			w.write(" ")
+		}
+		w.write("}")
+	} else {
+		comments, err = w.writeExpr(not.Body[0], comments)
+		if err != nil {
+			if !errors.As(err, &unexpectedCommentError{}) {
+				return nil, err
+			}
+		}
+	}
+
 	return comments, nil
 }
 
@@ -1784,6 +1838,9 @@ func (w *writer) writeImport(imp *ast.Import) error {
 		// We don't want to wrap future.keywords imports in parens, so we create a new writer that doesn't
 		w2 := writer{
 			buf: bytes.Buffer{},
+			fmtOpts: fmtOpts{
+				allowKeywordsInRefs: true,
+			},
 		}
 		_, err := w2.writeRef(path, nil)
 		if err != nil {
@@ -2343,15 +2400,33 @@ func ensureFutureKeywordImport(imps []*ast.Import, kw string) []*ast.Import {
 		}
 	}
 	imp := &ast.Import{
-		// NOTE: This is a hack to not error on the ref containing a keyword already present in v1.
-		// A cleaner solution would be to instead allow refs to contain keyword terms.
-		// E.g. in v1, `import future.keywords["in"]` is valid, but `import future.keywords.in` is not
-		// as it contains a reserved keyword.
-		Path: ast.MustParseTerm("future.keywords[\"" + kw + "\"]"),
-		//Path: ast.MustParseTerm("future.keywords." + kw),
+		Path: ast.MustParseTerm("future.keywords." + kw),
 	}
-	imp.Location = defaultLocation(imp)
+	imp.Location = nextImportLoc(imps, imp)
 	return append(imps, imp)
+}
+
+func nextImportLoc(imps []*ast.Import, node ast.Node) *ast.Location {
+	maxRow := 0
+	for _, imp := range imps {
+		if imp.Loc() == nil {
+			continue
+		}
+		if isFutureKeywordsImport(imp) || isRegoV1Compatible(imp) {
+			if imp.Loc().Row > maxRow {
+				maxRow = imp.Loc().Row
+			}
+		}
+	}
+	if maxRow == 0 {
+		return defaultLocation(node)
+	}
+	return ast.NewLocation([]byte(node.String()), defaultLocationFile, maxRow+1, 1)
+}
+
+func isFutureKeywordsImport(imp *ast.Import) bool {
+	path := imp.Path.Value.(ast.Ref)
+	return len(path) >= 2 && ast.FutureRootDocument.Equal(path[0])
 }
 
 func ensureRegoV1Import(imps []*ast.Import) []*ast.Import {
@@ -2379,7 +2454,7 @@ func ensureImport(imps []*ast.Import, path ast.Ref) []*ast.Import {
 	imp := &ast.Import{
 		Path: ast.NewTerm(path),
 	}
-	imp.Location = defaultLocation(imp)
+	imp.Location = nextImportLoc(imps, imp)
 	return append(imps, imp)
 }
 

--- a/v1/format/format_test.go
+++ b/v1/format/format_test.go
@@ -118,8 +118,13 @@ func TestFormatV0Source(t *testing.T) {
 				t.Fatalf("Failed to read expected rego source: %v", err)
 			}
 
+			// TODO: drop once future.keywords.not is enabled by default
+			caps := ast.CapabilitiesForThisVersion(ast.CapabilitiesRegoVersion(ast.RegoV0))
+			caps.FutureKeywords = append(caps.FutureKeywords, "not")
+
 			popts := ast.ParserOptions{
-				RegoVersion: ast.RegoV0,
+				RegoVersion:  ast.RegoV0,
+				Capabilities: caps,
 			}
 			opts := Opts{
 				RegoVersion:   ast.RegoV0,
@@ -170,8 +175,13 @@ func TestFormatV1Source(t *testing.T) {
 				t.Fatalf("Failed to read expected rego source: %v", err)
 			}
 
+			// TODO: drop once future.keywords.not is enabled by default
+			caps := ast.CapabilitiesForThisVersion(ast.CapabilitiesRegoVersion(ast.RegoV1))
+			caps.FutureKeywords = append(caps.FutureKeywords, "not")
+
 			popts := ast.ParserOptions{
-				RegoVersion: ast.RegoV1,
+				RegoVersion:  ast.RegoV1,
+				Capabilities: caps,
 			}
 			opts := Opts{
 				RegoVersion:   ast.RegoV1,
@@ -232,14 +242,23 @@ func TestFormatV0SourceToRegoV1(t *testing.T) {
 				}
 			}
 
+			// TODO: drop once future.keywords.not is enabled by default
+			caps := ast.CapabilitiesForThisVersion(ast.CapabilitiesRegoVersion(ast.RegoV1))
+			caps.FutureKeywords = append(caps.FutureKeywords, "not")
+
 			sourceOpts := Opts{
 				RegoVersion: ast.RegoV0CompatV1, // Target syntax is v0 compat v1
 				ParserOptions: &ast.ParserOptions{
-					RegoVersion: ast.RegoV0, // Original syntax is v0
+					RegoVersion:  ast.RegoV0, // Original syntax is v0
+					Capabilities: caps,
 				},
 			}
 			targetOpts := Opts{
 				RegoVersion: ast.RegoV0CompatV1, // Target syntax is v0 compat v1
+				ParserOptions: &ast.ParserOptions{
+					RegoVersion:  ast.RegoV0CompatV1,
+					Capabilities: caps,
+				},
 			}
 
 			if errorExpected {
@@ -262,13 +281,13 @@ func TestFormatV0SourceToRegoV1(t *testing.T) {
 					t.Fatalf("Expected formatted bytes to equal expected bytes but differed near line %d / byte %d (got: %q, expected: %q):\n%s", ln, at, formatted[at], expected[at], prefixWithLineNumbers(formatted))
 				}
 
-				if _, err := ast.ParseModule(rego+".tmp", string(formatted)); err != nil {
+				if _, err := ast.ParseModuleWithOpts(rego+".tmp", string(formatted), ast.ParserOptions{RegoVersion: ast.RegoV0CompatV1, Capabilities: caps}); err != nil {
 					t.Fatalf("Failed to parse formatted bytes: %v", err)
 				}
 
 				formatted, err = SourceWithOpts(rego, formatted, targetOpts)
 				if err != nil {
-					t.Fatalf("Failed to double format file")
+					t.Fatalf("Failed to double format file: %s", err)
 				}
 
 				if ln, at := differsAt(formatted, expected); ln != 0 {
@@ -278,7 +297,7 @@ func TestFormatV0SourceToRegoV1(t *testing.T) {
 				// rego-v1 formatted code is still compliant with v0, and should not be changed if formatted as such
 				formatted, err = SourceWithOpts(rego, formatted, targetOpts)
 				if err != nil {
-					t.Fatalf("Failed to double format file as v0")
+					t.Fatalf("Failed to double format file as v0: %s", err)
 				}
 
 				if ln, at := differsAt(formatted, expected); ln != 0 {
@@ -744,6 +763,132 @@ a[_x[y][[z, w]]]`,
 				ast.StringTerm("\n}"),
 			),
 			expected: "$`allow if \\{\n\t{x}\n}`",
+		},
+		{
+			note:        "v0, not-body adds import if missing",
+			regoVersion: ast.RegoV0,
+			toFmt: ast.MustParseModuleWithOpts(`package test
+				p if {
+					not 1 + input.x == 2
+				}`,
+				ast.ParserOptions{
+					FutureKeywords: []string{"not"},
+					Capabilities: func() *ast.Capabilities {
+						// TODO: drop once future.keywords.not is enabled by default
+						caps := ast.CapabilitiesForThisVersion()
+						caps.FutureKeywords = append(caps.FutureKeywords, "not")
+						return caps
+					}(),
+				}),
+			expected: `package test
+
+import future.keywords.not
+
+p {
+	not 1 + input.x == 2
+}`,
+		},
+		{
+			note:        "v1, not-body adds import if missing",
+			regoVersion: ast.RegoV1,
+			toFmt: ast.MustParseModuleWithOpts(`package test
+				p if {
+					not 1 + input.x == 2
+				}`,
+				ast.ParserOptions{
+					FutureKeywords: []string{"not"},
+					Capabilities: func() *ast.Capabilities {
+						// TODO: drop once future.keywords.not is enabled by default
+						caps := ast.CapabilitiesForThisVersion()
+						caps.FutureKeywords = append(caps.FutureKeywords, "not")
+						return caps
+					}(),
+				}),
+			expected: `package test
+
+import future.keywords.not
+
+p if {
+	not 1 + input.x == 2
+}`,
+		},
+		{
+			note:        "v1, not-body explicit single expression round-trips",
+			regoVersion: ast.RegoV1,
+			toFmt: ast.MustParseModuleWithOpts(`package test
+				import future.keywords.not
+				p if {
+					not {input.x == 1}
+				}`,
+				ast.ParserOptions{
+					FutureKeywords: []string{"not"},
+					Capabilities: func() *ast.Capabilities {
+						caps := ast.CapabilitiesForThisVersion()
+						caps.FutureKeywords = append(caps.FutureKeywords, "not")
+						return caps
+					}(),
+				}),
+			expected: `package test
+
+import future.keywords.not
+
+p if {
+	not { input.x == 1 }
+}`,
+		},
+		{
+			note:        "v1, not-body multi expression",
+			regoVersion: ast.RegoV1,
+			toFmt: ast.MustParseModuleWithOpts(`package test
+				import future.keywords.not
+				p if {
+					not {
+						input.x == 1
+						input.y == 2
+					}
+				}`,
+				ast.ParserOptions{
+					FutureKeywords: []string{"not"},
+					Capabilities: func() *ast.Capabilities {
+						caps := ast.CapabilitiesForThisVersion()
+						caps.FutureKeywords = append(caps.FutureKeywords, "not")
+						return caps
+					}(),
+				}),
+			expected: `package test
+
+import future.keywords.not
+
+p if {
+	not {
+		input.x == 1
+		input.y == 2
+	}
+}`,
+		},
+		{
+			note:        "v1, not-body implicit single expression stays inline",
+			regoVersion: ast.RegoV1,
+			toFmt: ast.MustParseModuleWithOpts(`package test
+				import future.keywords.not
+				p if {
+					not input.x == 1
+				}`,
+				ast.ParserOptions{
+					FutureKeywords: []string{"not"},
+					Capabilities: func() *ast.Capabilities {
+						caps := ast.CapabilitiesForThisVersion()
+						caps.FutureKeywords = append(caps.FutureKeywords, "not")
+						return caps
+					}(),
+				}),
+			expected: `package test
+
+import future.keywords.not
+
+p if {
+	not input.x == 1
+}`,
 		},
 	}
 

--- a/v1/format/testfiles/v0/test_not_future_import.rego
+++ b/v1/format/testfiles/v0/test_not_future_import.rego
@@ -1,0 +1,7 @@
+package test
+
+import future.keywords.not
+
+a {
+	not input.x + input.y == 2
+}

--- a/v1/format/testfiles/v0/test_not_future_import.rego.formatted
+++ b/v1/format/testfiles/v0/test_not_future_import.rego.formatted
@@ -1,0 +1,7 @@
+package test
+
+import future.keywords.not
+
+a {
+	not input.x + input.y == 2
+}

--- a/v1/format/testfiles/v0_to_v1/test_not_future_import.rego
+++ b/v1/format/testfiles/v0_to_v1/test_not_future_import.rego
@@ -1,0 +1,8 @@
+package test
+
+import future.keywords.not
+
+a if {
+	not input.x + input.y == 2
+}
+

--- a/v1/format/testfiles/v0_to_v1/test_not_future_import.rego.formatted
+++ b/v1/format/testfiles/v0_to_v1/test_not_future_import.rego.formatted
@@ -1,0 +1,8 @@
+package test
+
+import future.keywords.not
+import rego.v1
+
+a if {
+	not input.x + input.y == 2
+}

--- a/v1/format/testfiles/v1/test_not_future_import.rego
+++ b/v1/format/testfiles/v1/test_not_future_import.rego
@@ -1,0 +1,39 @@
+package test
+
+import future.keywords.not
+
+a if {
+	not input.x + input.y == 1
+	not {input.x + input.y == 2}
+	not { input.x + input.y == 3 }
+	not {
+		input.x + input.y == 4
+	}
+
+	not {input.a == 1;input.b == 2}
+	not {
+		input.a == 1
+		input.b == 2
+	}
+
+	# comment 1
+	not { # comment 2
+		# comment 3
+		input.a == 1
+		input.b == 2 # comment 4
+		# comment 5
+	} # comment 6
+	# comment 7
+}
+
+b if {
+	not { f(42) with input.x as 1 } with input.y as 2
+
+	not {
+		f(42) with input.x as 1 with input.x2 as 2
+			with input.x3 as 3
+	with input.x4 as 4
+	} with input.y as 5 with input.y2 as 6
+		with input.y3 as 7
+	with input.y4 as 8
+}

--- a/v1/format/testfiles/v1/test_not_future_import.rego.formatted
+++ b/v1/format/testfiles/v1/test_not_future_import.rego.formatted
@@ -1,0 +1,40 @@
+package test
+
+import future.keywords.not
+
+a if {
+	not input.x + input.y == 1
+	not { input.x + input.y == 2 }
+	not { input.x + input.y == 3 }
+	not {
+		input.x + input.y == 4
+	}
+
+	not { input.a == 1; input.b == 2}
+	not {
+		input.a == 1
+		input.b == 2
+	}
+
+	# comment 1
+	not { # comment 2
+		# comment 3
+		input.a == 1
+		input.b == 2 # comment 4
+		# comment 5
+	} # comment 6
+	# comment 7
+}
+
+b if {
+	not { f(42) with input.x as 1 } with input.y as 2
+
+	not {
+		f(42) with input.x as 1 with input.x2 as 2
+			with input.x3 as 3
+			with input.x4 as 4
+	}
+		with input.y as 5 with input.y2 as 6
+		with input.y3 as 7
+		with input.y4 as 8
+}

--- a/v1/rego/rego.go
+++ b/v1/rego/rego.go
@@ -2616,31 +2616,31 @@ func (r *Rego) partial(ctx context.Context, ectx *EvalContext) (*PartialQueries,
 		for i, mod := range support {
 			// We can't apply the RegoV0CompatV1 version to the support module if it contains rules or vars that
 			// conflict with future keywords.
-			applyRegoVersion := true
+			applyCompatRegoVersion := true
 
 			ast.WalkRules(mod, func(r *ast.Rule) bool {
 				name := r.Head.Name
 				if name == "" && len(r.Head.Reference) > 0 {
 					name = r.Head.Reference[0].Value.(ast.Var)
 				}
-				if ast.IsFutureKeywordForRegoVersion(name.String(), ast.RegoV0) {
-					applyRegoVersion = false
+				if ast.IsFutureKeywordForRegoVersion(name.String(), ast.RegoV0) && !ast.IsFutureKeywordForRegoVersion(name.String(), ast.RegoV1) {
+					applyCompatRegoVersion = false
 					return true
 				}
 				return false
 			})
 
-			if applyRegoVersion {
+			if applyCompatRegoVersion {
 				ast.WalkVars(mod, func(v ast.Var) bool {
-					if ast.IsFutureKeywordForRegoVersion(v.String(), ast.RegoV0) {
-						applyRegoVersion = false
+					if ast.IsFutureKeywordForRegoVersion(v.String(), ast.RegoV0) && !ast.IsFutureKeywordForRegoVersion(v.String(), ast.RegoV1) {
+						applyCompatRegoVersion = false
 						return true
 					}
 					return false
 				})
 			}
 
-			if applyRegoVersion {
+			if applyCompatRegoVersion {
 				support[i].SetRegoVersion(ast.RegoV0CompatV1)
 			} else {
 				support[i].SetRegoVersion(r.regoVersion)

--- a/v1/test/cases/testdata/v1/negation/test-not-body.yaml
+++ b/v1/test/cases/testdata/v1/negation/test-not-body.yaml
@@ -138,6 +138,182 @@ cases:
         }
 
         f(x) := x
-
     want_result:
       - x: 2
+  - note: "negation/not-body: with statement, ref replaced"
+    query: data.negation.p = x
+    modules:
+      - |
+        package negation
+
+        import future.keywords.not
+
+        p if {
+          not q with input.x as 1
+        }
+
+        q if {
+          count([1,2,3]) = input.x
+        }
+    input:
+      x: 3
+    want_result:
+      - x: true
+  - note: "negation/not-body: with statement, built-in call replaced"
+    query: data.negation.p = x
+    modules:
+      - |
+        package negation
+
+        import future.keywords.not
+
+        p if {
+          not q with count as mock_count
+        }
+
+        q if {
+          count([1,2,3]) == 3
+        }
+
+        mock_count(_) = 100
+    want_result:
+      - x: true
+  - note: "negation/not-body: with statement, rego-function call replaced"
+    query: data.negation.p = x
+    modules:
+      - |
+        package negation
+
+        import future.keywords.not
+
+        p if {
+          not q with foo as mock_foo
+        }
+
+        q if {
+          foo([1,2,3]) == 3
+        }
+
+        foo(x) := count(x)
+
+        mock_foo(_) := 100
+    want_result:
+      - x: true
+  - note: "negation/not-body: explicit body"
+    query: data.negation.p = x
+    modules:
+      - |
+        package negation
+
+        import future.keywords.not
+
+        p if not {
+          false
+        }
+    want_result:
+      - x: true
+  - note: "negation/not-body: explicit body, local var assignment override"
+    query: data.negation.p = x
+    modules:
+      - |
+        package negation
+
+        import future.keywords.not
+
+        p if {
+          a = 2
+          not {
+            a := 1
+            a == 3
+          }
+          a == 2
+        }
+    want_result:
+      - x: true
+  - note: "negation/not-body: explicit body, nested negation"
+    query: data.negation = x
+    modules:
+      - |
+        package negation
+
+        import future.keywords.not
+
+        a if {
+          not { # 2 so this succeeds
+            not { # 1. this fails
+              true
+            }
+          }
+        }
+
+        b if {
+          not { # 2. so this fails
+            not { # 1. this succeeds
+              false
+            }
+          }
+        }
+
+        c if {
+          not { # 3. therefore this succeeds
+            not { # 2. so this fails
+              not { # 1. this succeeds
+                false
+              }
+            }
+          }
+        }
+    want_result:
+      - x:
+          a: true
+          c: true
+  - note: "negation/not-body: explicit body, enumeration"
+    query: data.negation = x
+    modules:
+      - |
+        package negation
+
+        import future.keywords.not
+
+        p if {
+          not {
+            l = ["a", "b", "c"]
+            x = l[_]
+            x == "b"
+          }
+        }
+
+        q if {
+          not {
+            l = ["a", "b", "c"]
+            x = l[_]
+            x == "d"
+          }
+        }
+    want_result:
+      - x:
+          q: true
+  - note: "negation/not-body: explicit body, enumeration (some .. in)"
+    query: data.negation = x
+    modules:
+      - |
+        package negation
+
+        import future.keywords.not
+
+        p if {
+          not {
+            some x in ["a", "b", "c"]
+            x == "b"
+          }
+        }
+
+        q if {
+          not {
+            some x in ["a", "b", "c"]
+            x == "d"
+          }
+        }
+    want_result:
+      - x:
+          q: true


### PR DESCRIPTION
Expanding the Rego syntax to support not-bodies (not blocks?): `not {...}`

For a not block to successfully evaluate, its body _must not_ successfully evaluate. If evaluation causes iteration, all evaluation paths must fail.

```rego
package example

import future.keywords.not

a if f([1, 2, 3])

b if f([1, 0, 3])

c if not {
    true
    false
}

f(lst) if not {
    some x in lst
    x == 0
}
```

```bash
$ opa eval -d policy.rego -fpretty 'data'
{
  "example": {
    "a": true,
    "c": true
  }
}
```

Fixes: #8402