### PR TITLE
Fix out-of-order plugin status notifications

### DIFF
--- a/v1/plugins/logs/logger_plugin_integration_test.go
+++ b/v1/plugins/logs/logger_plugin_integration_test.go
@@ -164,8 +164,7 @@ func TestDecisionLogsWithLoggerPlugin(t *testing.T) {
 			t.Errorf("expected type field in log output, got: %s", logged)
 		}
 
-		decisionLogsPlugin.Stop(ctx)
-		testLoggerPlug.Stop(ctx)
+		manager.Stop(ctx)
 	})
 }
 
@@ -277,8 +276,7 @@ func TestDecisionLogsWithBothConsoleAndLoggerPlugin(t *testing.T) {
 			t.Errorf("expected decision_id in console logger output")
 		}
 
-		decisionLogsPlugin.Stop(ctx)
-		testLoggerPlug.Stop(ctx)
+		manager.Stop(ctx)
 	})
 }
 

--- a/v1/plugins/plugins.go
+++ b/v1/plugins/plugins.go
@@ -204,8 +204,8 @@ type Manager struct {
 	plugins                      []namedplugin
 	registeredTriggers           []func(storage.Transaction)
 	mtx                          sync.Mutex
-	pluginStatus                 map[string]*Status
-	pluginStatusListeners        map[string]StatusListener
+	pluginStatusCh               chan pluginStatusMsg
+	stopPluginStatusCh           chan chan struct{}
 	initBundles                  map[string]*bundle.Bundle
 	initFiles                    loader.Result
 	maxErrors                    int
@@ -238,6 +238,37 @@ type Manager struct {
 	extraAuthorizerRoutes        []func(string, []any) bool
 	bundleActivatorPlugin        string
 }
+
+type pluginStatusMsg interface{ pluginStatusMsg() }
+
+type statusUpdate struct {
+	name   string
+	status *Status
+	done   chan struct{}
+}
+
+type statusInitPlugin struct {
+	name string
+}
+
+type statusRegisterListener struct {
+	name     string
+	listener StatusListener
+}
+
+type statusUnregisterListener struct {
+	name string
+}
+
+type statusQuery struct {
+	reply chan map[string]*Status
+}
+
+func (statusUpdate) pluginStatusMsg()             {}
+func (statusInitPlugin) pluginStatusMsg()         {}
+func (statusRegisterListener) pluginStatusMsg()   {}
+func (statusUnregisterListener) pluginStatusMsg() {}
+func (statusQuery) pluginStatusMsg()              {}
 
 type (
 	managerContextKey      string
@@ -496,12 +527,12 @@ func New(raw []byte, id string, store storage.Store, opts ...func(*Manager)) (*M
 		Store:                 store,
 		Config:                parsedConfig,
 		ID:                    id,
-		pluginStatus:          map[string]*Status{},
-		pluginStatusListeners: map[string]StatusListener{},
 		maxErrors:             -1,
 		serverInitialized:     make(chan struct{}),
 		bootstrapConfigLabels: parsedConfig.Labels,
 		extraRoutes:           map[string]ExtraRoute{},
+		pluginStatusCh:        make(chan pluginStatusMsg),
+		stopPluginStatusCh:    make(chan chan struct{}),
 	}
 
 	for _, f := range opts {
@@ -559,6 +590,8 @@ func New(raw []byte, id string, store storage.Store, opts ...func(*Manager)) (*M
 		}
 		m.versionChecker = versionChecker
 	}
+
+	go m.pluginStatusLoop()
 
 	return m, nil
 }
@@ -649,14 +682,12 @@ func (m *Manager) GetConfig() *config.Config {
 // the plugins will be started.
 func (m *Manager) Register(name string, plugin Plugin) {
 	m.mtx.Lock()
-	defer m.mtx.Unlock()
 	m.plugins = append(m.plugins, namedplugin{
 		name:   name,
 		plugin: plugin,
 	})
-	if _, ok := m.pluginStatus[name]; !ok {
-		m.pluginStatus[name] = &Status{State: StateNotReady}
-	}
+	m.mtx.Unlock()
+	m.pluginStatusCh <- statusInitPlugin{name: name}
 }
 
 // Plugins returns the list of plugins registered with the manager.
@@ -853,6 +884,12 @@ func (m *Manager) Stop(ctx context.Context) {
 		}
 	}
 
+	{
+		done := make(chan struct{})
+		m.stopPluginStatusCh <- done
+		<-done
+	}
+
 	if m.stop != nil {
 		done := make(chan struct{})
 		m.stop <- done
@@ -929,54 +966,35 @@ func (m *Manager) Reconfigure(newCfg *config.Config) error {
 
 // PluginStatus returns the current statuses of any plugins registered.
 func (m *Manager) PluginStatus() map[string]*Status {
-	m.mtx.Lock()
-	defer m.mtx.Unlock()
-
-	return m.copyPluginStatus()
+	reply := make(chan map[string]*Status, 1)
+	m.pluginStatusCh <- statusQuery{reply: reply}
+	return <-reply
 }
 
 // RegisterPluginStatusListener registers a StatusListener to be
 // called when plugin status updates occur.
 func (m *Manager) RegisterPluginStatusListener(name string, listener StatusListener) {
-	m.mtx.Lock()
-	defer m.mtx.Unlock()
-
-	m.pluginStatusListeners[name] = listener
+	m.pluginStatusCh <- statusRegisterListener{name: name, listener: listener}
 }
 
 // UnregisterPluginStatusListener removes a StatusListener registered with the
 // same name.
 func (m *Manager) UnregisterPluginStatusListener(name string) {
-	m.mtx.Lock()
-	defer m.mtx.Unlock()
-
-	delete(m.pluginStatusListeners, name)
+	m.pluginStatusCh <- statusUnregisterListener{name: name}
 }
 
 // UpdatePluginStatus updates a named plugins status. Any registered
 // listeners will be called with a copy of the new state of all
 // plugins.
 func (m *Manager) UpdatePluginStatus(pluginName string, status *Status) {
-	var toNotify map[string]StatusListener
-	var statuses map[string]*Status
-
-	func() {
-		m.mtx.Lock()
-		defer m.mtx.Unlock()
-		m.pluginStatus[pluginName] = status
-		toNotify = make(map[string]StatusListener, len(m.pluginStatusListeners))
-		maps.Copy(toNotify, m.pluginStatusListeners)
-		statuses = m.copyPluginStatus()
-	}()
-
-	for _, l := range toNotify {
-		l(statuses)
-	}
+	done := make(chan struct{})
+	m.pluginStatusCh <- statusUpdate{name: pluginName, status: status, done: done}
+	<-done
 }
 
-func (m *Manager) copyPluginStatus() map[string]*Status {
+func copyPluginStatus(src map[string]*Status) map[string]*Status {
 	statusCpy := map[string]*Status{}
-	for k, v := range m.pluginStatus {
+	for k, v := range src {
 		var cpy *Status
 		if v != nil {
 			cpy = &Status{
@@ -1269,6 +1287,39 @@ func (m *Manager) sendOPAUpdateLoop(ctx context.Context) {
 		case done := <-m.stop:
 			cancel()
 			ticker.Stop()
+			done <- struct{}{}
+			return
+		}
+	}
+}
+
+func (m *Manager) pluginStatusLoop() {
+	status := map[string]*Status{}
+	listeners := map[string]StatusListener{}
+
+	for {
+		select {
+		case msg := <-m.pluginStatusCh:
+			switch msg := msg.(type) {
+			case statusUpdate:
+				status[msg.name] = msg.status
+				statuses := copyPluginStatus(status)
+				for _, l := range listeners {
+					l(statuses)
+				}
+				close(msg.done)
+			case statusInitPlugin:
+				if _, ok := status[msg.name]; !ok {
+					status[msg.name] = &Status{State: StateNotReady}
+				}
+			case statusRegisterListener:
+				listeners[msg.name] = msg.listener
+			case statusUnregisterListener:
+				delete(listeners, msg.name)
+			case statusQuery:
+				msg.reply <- copyPluginStatus(status)
+			}
+		case done := <-m.stopPluginStatusCh:
 			done <- struct{}{}
 			return
 		}

--- a/v1/plugins/plugins.go
+++ b/v1/plugins/plugins.go
@@ -239,7 +239,9 @@ type Manager struct {
 	bundleActivatorPlugin        string
 }
 
-type pluginStatusMsg interface{ pluginStatusMsg() }
+type pluginStatusMsg interface {
+	pluginStatusMsg()
+}
 
 type statusUpdate struct {
 	name   string
@@ -856,6 +858,7 @@ func (m *Manager) Start(ctx context.Context) error {
 // of the graceful shutdown period passed with the context as a timeout.
 // Note that a graceful shutdown period configured with the Manager instance
 // will override the timeout of the passed in context (if applicable).
+// NOTE: You cannot call this twice, or it will hang.
 func (m *Manager) Stop(ctx context.Context) {
 	var toStop []Plugin
 
@@ -1303,9 +1306,11 @@ func (m *Manager) pluginStatusLoop() {
 			switch msg := msg.(type) {
 			case statusUpdate:
 				status[msg.name] = msg.status
-				statuses := copyPluginStatus(status)
-				for _, l := range listeners {
-					l(statuses)
+				if len(listeners) > 0 {
+					statuses := copyPluginStatus(status)
+					for _, l := range listeners {
+						l(statuses)
+					}
 				}
 				close(msg.done)
 			case statusInitPlugin:

--- a/v1/plugins/plugins_test.go
+++ b/v1/plugins/plugins_test.go
@@ -102,24 +102,18 @@ func TestManagerPluginStatusListener(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}
+	defer m.Stop(context.Background())
 
-	// Start by registering a single listener and validate that it was registered correctly
+	// Register two listeners
 	var l1Status map[string]*Status
 	m.RegisterPluginStatusListener("l1", func(status map[string]*Status) {
 		l1Status = status
 	})
-	if len(m.pluginStatusListeners) != 1 || m.pluginStatusListeners["l1"] == nil {
-		t.Fatalf("Expected a single listener named 'l1' got: %+v", m.pluginStatusListeners)
-	}
 
-	// Register a second one, validate both are there
 	var l2Status map[string]*Status
 	m.RegisterPluginStatusListener("l2", func(status map[string]*Status) {
 		l2Status = status
 	})
-	if len(m.pluginStatusListeners) != 2 || m.pluginStatusListeners["l2"] == nil {
-		t.Fatalf("Expected a two listeners named 'l1' and 'l2' got: %+v", m.pluginStatusListeners)
-	}
 
 	// Ensure starting statuses are empty by default
 	currentStatus := m.PluginStatus()
@@ -138,11 +132,8 @@ func TestManagerPluginStatusListener(t *testing.T) {
 		t.Fatalf("Unexpected status in updates:\n\n\texpecting: %+v\n\n\tgot: l1: %+v  l2: %+v\n", currentStatus, l1Status, l2Status)
 	}
 
-	// Unregister the first listener, ensure it is removed
+	// Unregister the first listener
 	m.UnregisterPluginStatusListener("l1")
-	if len(m.pluginStatusListeners) != 1 || m.pluginStatusListeners["l2"] == nil {
-		t.Fatalf("Expected a single listeners named 'l2' got: %+v", m.pluginStatusListeners)
-	}
 
 	// Send another update, ensure the status is ok and the remaining listener is still called
 	m.UpdatePluginStatus("p2", &Status{State: StateErr})
@@ -156,9 +147,6 @@ func TestManagerPluginStatusListener(t *testing.T) {
 
 	// Unregister the last listener
 	m.UnregisterPluginStatusListener("l2")
-	if len(m.pluginStatusListeners) != 0 {
-		t.Fatalf("Expected zero listeners got: %+v", m.pluginStatusListeners)
-	}
 
 	// Ensure updates can still be sent with no listeners
 	m.UpdatePluginStatus("p2", &Status{State: StateOK})

--- a/v1/plugins/plugins_test.go
+++ b/v1/plugins/plugins_test.go
@@ -134,6 +134,7 @@ func TestManagerPluginStatusListener(t *testing.T) {
 
 	// Unregister the first listener
 	m.UnregisterPluginStatusListener("l1")
+	l1Status = nil
 
 	// Send another update, ensure the status is ok and the remaining listener is still called
 	m.UpdatePluginStatus("p2", &Status{State: StateErr})
@@ -144,15 +145,22 @@ func TestManagerPluginStatusListener(t *testing.T) {
 	if !reflect.DeepEqual(currentStatus, l2Status) {
 		t.Fatalf("Unexpected status in updates:\n\n\texpecting: %+v\n\n\tgot: %+v\n", currentStatus, l2Status)
 	}
+	if l1Status != nil {
+		t.Fatalf("Expected unregistered listener l1 to not be called, got: %+v", l1Status)
+	}
 
 	// Unregister the last listener
 	m.UnregisterPluginStatusListener("l2")
+	l2Status = nil
 
 	// Ensure updates can still be sent with no listeners
 	m.UpdatePluginStatus("p2", &Status{State: StateOK})
 	currentStatus = m.PluginStatus()
 	if len(currentStatus) != 2 || currentStatus["p1"].State != StateOK || currentStatus["p1"].Message != message || currentStatus["p2"].State != StateOK {
 		t.Fatalf("Unexpected current plugin status, got: %+v", currentStatus)
+	}
+	if l2Status != nil {
+		t.Fatalf("Expected unregistered listener l2 to not be called, got: %+v", l2Status)
 	}
 }
 


### PR DESCRIPTION
resolve: https://github.com/open-policy-agent/opa/issues/8009

Replace the mutex protected status maps with a single goroutine that owns all plugin status state. 