### PR TITLE
gitattributes: fix language name

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-*.rego.formatted linguist-language="Open Policy Agent"
+*.rego.formatted linguist-language=Open-Policy-Agent


### PR DESCRIPTION
Spaces need to become dashes.
