### PR TITLE
Delete copy content icon

### DIFF
--- a/docs/src/components/CopyPageMarkdown/index.jsx
+++ b/docs/src/components/CopyPageMarkdown/index.jsx
@@ -2,9 +2,6 @@ import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from
 import { createPortal } from "react-dom";
 
 import BrowserOnly from "@docusaurus/BrowserOnly";
-import IconCopy from "@theme/Icon/Copy";
-import IconSuccess from "@theme/Icon/Success";
-
 import styles from "./styles.module.css";
 
 export default function CopyPageMarkdown() {
@@ -139,9 +136,6 @@ function CopyButton() {
         title={label}
         aria-label={label}
       >
-        <span className={styles.icons} aria-hidden="true">
-          {copied ? <IconSuccess /> : <IconCopy />}
-        </span>
         {label}
       </button>
     </div>

--- a/docs/src/components/CopyPageMarkdown/styles.module.css
+++ b/docs/src/components/CopyPageMarkdown/styles.module.css
@@ -7,14 +7,5 @@
 }
 
 .icons {
-  display: flex;
-    width: 1em;
-    height: 1em;
-}
-
-/* Hide icon in Firefox to match Safari's rendering */
-@supports (-moz-appearance: none) {
-    .icons {
-        display: none;
-    }
+    display: none;
 }

--- a/docs/src/components/CopyPageMarkdown/styles.module.css
+++ b/docs/src/components/CopyPageMarkdown/styles.module.css
@@ -5,7 +5,3 @@
 .wrapper button {
     font-size: 0.75rem;
 }
-
-.icons {
-    display: none;
-}

--- a/docs/src/components/CopyPageMarkdown/styles.module.css
+++ b/docs/src/components/CopyPageMarkdown/styles.module.css
@@ -2,6 +2,19 @@
   margin: 0.75rem 0 1rem;
 }
 
+.wrapper button {
+    font-size: 0.75rem;
+}
+
 .icons {
   display: flex;
+    width: 1em;
+    height: 1em;
+}
+
+/* Hide icon in Firefox to match Safari's rendering */
+@supports (-moz-appearance: none) {
+    .icons {
+        display: none;
+    }
 }


### PR DESCRIPTION
Currently the button looks like this in Firefox: 
<img width="969" height="539" alt="image" src="https://github.com/user-attachments/assets/342e353b-5e2a-4b1b-9745-d748c34149b6" />

With this change it looks the same as Safari:
<img width="969" height="199" alt="image" src="https://github.com/user-attachments/assets/88601a8d-13f8-42f9-85ce-5f89cce87ef4" />
