### PR TITLE
server+topdown+logs: feed arbitrary extra info from Data API to topdown and back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,11 @@ Wrapping projects can now attach custom metadata to Data API requests and have e
 
 Two distinct metadata paths are introduced:
 
-- **Incoming metadata**: parsed from extra top-level keys in the request body, made available to builtins via `BuiltinContext.IncomingMetadata`. Logged in the decision log under `Custom["incoming_metadata"]`.
+- **Request metadata**: parsed from extra top-level keys in the request body, made available to builtins via `BuiltinContext.RequestMetadata`. Logged in the decision log under `Custom["request_metadata"]`.
 
-- **Outgoing metadata**: a separate map (`BuiltinContext.OutgoingMetadata`) that builtins can populate during evaluation. Only included in the API response and decision log if non-empty.
+- **Response metadata**: a separate map (`BuiltinContext.ResponseMetadata`) that builtins can populate during evaluation. Only included in the API response and decision log if non-empty.
 
-In vanilla OPA, no builtins write outgoing metadata, so responses are unchanged. The incoming metadata map is only allocated when the request carries extra fields; the outgoing map is one empty map per request.
+In vanilla OPA, no builtins write response metadata, so responses are unchanged. The request metadata map is only allocated when the request carries extra fields; the response map is one empty map per request.
 
 To avoid conflicts with future OPA top-level keys, callers should use a namespaced key: `{"input": {...}, "com.example.opa/md": {...}}`.
 
@@ -27,7 +27,7 @@ curl -H 'Content-Type: application/json' \
   http://localhost:8181/v1/data/example/allow
 ```
 
-**Response** (outgoing metadata included if, for example, set by a custom builtin):
+**Response** (response metadata included if, for example, set by a custom builtin):
 
 ```json
 {
@@ -44,12 +44,12 @@ curl -H 'Content-Type: application/json' \
 ```json
 {
   "custom": {
-    "incoming_metadata": {
+    "request_metadata": {
       "com.example.opa/metadata": {
         "corp-id": "acme-42"
       }
     },
-    "outgoing_metadata": {
+    "response_metadata": {
       "com.example.opa/response": {
         "snapshot_version": "v3"
       }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,65 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
-1.15.1
+### Data API Request/Response Metadata
+
+Wrapping projects can now attach custom metadata to Data API requests and have evaluation produce response metadata.
+
+Two distinct metadata paths are introduced:
+
+- **Incoming metadata**: parsed from extra top-level keys in the request body, made available to builtins via `BuiltinContext.IncomingMetadata`. Logged in the decision log under `Custom["incoming_metadata"]`.
+
+- **Outgoing metadata**: a separate map (`BuiltinContext.OutgoingMetadata`) that builtins can populate during evaluation. Only included in the API response and decision log if non-empty.
+
+In vanilla OPA, no builtins write outgoing metadata, so responses are unchanged. The incoming metadata map is only allocated when the request carries extra fields; the outgoing map is one empty map per request.
+
+To avoid conflicts with future OPA top-level keys, callers should use a namespaced key: `{"input": {...}, "com.example.opa/md": {...}}`.
+
+**Request with metadata:**
+
+```bash
+curl -H 'Content-Type: application/json' \
+  -d '{"input": {"user": "alice"}, "com.example.opa/metadata": {"corp-id": "acme-42"}}' \
+  http://localhost:8181/v1/data/example/allow
+```
+
+**Response** (outgoing metadata included if, for example, set by a custom builtin):
+
+```json
+{
+  "decision_id": "04789f85-de5a-477b-8aa5-6d59d7742135",
+  "result": true,
+  "com.example.opa/response": {
+    "snapshot_version": "v3"
+  }
+}
+```
+
+**Decision log entry:**
+
+```json
+{
+  "custom": {
+    "incoming_metadata": {
+      "com.example.opa/metadata": {
+        "corp-id": "acme-42"
+      }
+    },
+    "outgoing_metadata": {
+      "com.example.opa/response": {
+        "snapshot_version": "v3"
+      }
+    }
+  },
+  "decision_id": "04789f85-de5a-477b-8aa5-6d59d7742135",
+  "input": { "user": "alice" },
+  "msg": "Decision Log",
+  "path": "example/allow",
+  "result": true
+}
+```
+
+## 1.15.1
 
 This patch release fixes a backwards-incompatible change in the v1/logging.Logger interface that inadvertently made it
 into Release v1.15.0. When using OPA as Go module, and when providing custom Logger implementations, this change would

--- a/docs/docs/rest-api.md
+++ b/docs/docs/rest-api.md
@@ -876,6 +876,10 @@ The path separator is used to access values inside object and array documents. T
 
 The request body contains an object that specifies a value for [The input Document](./philosophy/#the-opa-document-model).
 
+Any additional top-level keys in the request body beyond `input` are treated as
+request metadata. See [Request/Response Metadata](#requestresponse-metadata)
+below.
+
 #### Request Headers
 
 - **[Content-Type](#content-type)**: `application/json` or `application/yaml`
@@ -979,6 +983,75 @@ HTTP/1.1 200 OK
 
 ```json
 {}
+```
+
+#### Request/Response Metadata
+
+The Data API POST request body may contain additional top-level keys beyond
+`input`. These are captured as **incoming metadata** and made available to
+custom builtins via `BuiltinContext.IncomingMetadata` during evaluation. Incoming
+metadata is included in [decision log](./management-decision-logs) events under
+the `custom.incoming_metadata` field.
+
+Custom builtins registered by wrapping projects can also produce **outgoing
+metadata** by writing to `BuiltinContext.OutgoingMetadata` during evaluation.
+If any outgoing metadata is produced, it appears as additional top-level fields
+in the API response and is included in decision log events under
+`custom.outgoing_metadata`.
+
+In vanilla OPA, no builtins write outgoing metadata, so responses are unchanged.
+
+:::caution
+Future OPA versions may introduce new top-level keys in the request and response
+bodies. To avoid conflicts, use a unique namespaced key for metadata, e.g.
+`"com.example.opa/metadata"`.
+:::
+
+##### Example Request
+
+```http
+POST /v1/data/example/allow HTTP/1.1
+Content-Type: application/json
+```
+
+```json
+{
+  "input": {
+    "user": "alice"
+  },
+  "com.example.opa/metadata": {
+    "corp-id": "acme-42"
+  }
+}
+```
+
+##### Example Response
+
+If a custom builtin writes outgoing metadata during evaluation, the response
+includes those fields alongside the standard ones:
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+```
+
+```json
+{
+  "decision_id": "04789f85-de5a-477b-8aa5-6d59d7742135",
+  "result": true,
+  "com.example.opa/response": {
+    "version": "v3"
+  }
+}
+```
+
+Without any outgoing metadata, the response contains only the standard fields:
+
+```json
+{
+  "decision_id": "04789f85-de5a-477b-8aa5-6d59d7742135",
+  "result": true
+}
 ```
 
 ### Get a Document (Webhook)

--- a/docs/docs/rest-api.md
+++ b/docs/docs/rest-api.md
@@ -988,18 +988,18 @@ HTTP/1.1 200 OK
 #### Request/Response Metadata
 
 The Data API POST request body may contain additional top-level keys beyond
-`input`. These are captured as **incoming metadata** and made available to
-custom builtins via `BuiltinContext.IncomingMetadata` during evaluation. Incoming
+`input`. These are captured as **request metadata** and made available to
+custom builtins via `BuiltinContext.RequestMetadata` during evaluation. Request
 metadata is included in [decision log](./management-decision-logs) events under
-the `custom.incoming_metadata` field.
+the `custom.request_metadata` field.
 
-Custom builtins registered by wrapping projects can also produce **outgoing
-metadata** by writing to `BuiltinContext.OutgoingMetadata` during evaluation.
-If any outgoing metadata is produced, it appears as additional top-level fields
+Custom builtins registered by wrapping projects can also produce **response
+metadata** by writing to `BuiltinContext.ResponseMetadata` during evaluation.
+If any response metadata is produced, it appears as additional top-level fields
 in the API response and is included in decision log events under
-`custom.outgoing_metadata`.
+`custom.response_metadata`.
 
-In vanilla OPA, no builtins write outgoing metadata, so responses are unchanged.
+In vanilla OPA, no builtins write response metadata, so responses are unchanged.
 
 :::caution
 Future OPA versions may introduce new top-level keys in the request and response
@@ -1027,7 +1027,7 @@ Content-Type: application/json
 
 ##### Example Response
 
-If a custom builtin writes outgoing metadata during evaluation, the response
+If a custom builtin writes response metadata during evaluation, the response
 includes those fields alongside the standard ones:
 
 ```http
@@ -1045,7 +1045,7 @@ Content-Type: application/json
 }
 ```
 
-Without any outgoing metadata, the response contains only the standard fields:
+Without any response metadata, the response contains only the standard fields:
 
 ```json
 {

--- a/e2e/cli/metadata.txtar
+++ b/e2e/cli/metadata.txtar
@@ -1,0 +1,34 @@
+# Verify that request metadata flows into decision logs and does NOT leak
+# into the API response. In vanilla OPA (no custom builtins that write to
+# OutgoingMetadata), the response must contain only the standard fields.
+
+exec $OPA run --server --addr unix://opa.sock --log-format json --log-level info --set decision_logs.console=true ./policy/example.rego &opa&
+retry curl -sf --unix-socket opa.sock 'http://localhost/health'
+
+# POST with namespaced metadata alongside input (recommended pattern).
+exec curl -sf --unix-socket opa.sock -H 'Content-Type: application/json' -d '{"input": {"user": "alice"}, "com.example.opa/metadata": {"trace_id": "req-42"}}' http://localhost/v1/data/example/allow
+jq stdout '.result == true'
+! jq stdout '.["com.example.opa/metadata"]'
+
+# POST without any metadata — baseline.
+exec curl -sf --unix-socket opa.sock -H 'Content-Type: application/json' -d '{"input": {"user": "bob"}}' http://localhost/v1/data/example/allow
+jq stdout '.result == true'
+
+kill -INT opa
+wait opa
+
+# Decision log for the first request must contain incoming_metadata.
+jq -s stderr '[.[] | select(.msg == "Decision Log" and .custom.incoming_metadata["com.example.opa/metadata"].trace_id == "req-42")] | length == 1'
+
+# Decision log for the first request must NOT have outgoing_metadata (vanilla OPA).
+! jq -s stderr '[.[] | select(.msg == "Decision Log" and .custom.outgoing_metadata)] | length > 0'
+
+# Decision log for the second request (no metadata) must not have a custom field.
+jq -s stderr '[.[] | select(.msg == "Decision Log" and .path == "example/allow" and (.custom | not))] | length == 1'
+
+-- policy/example.rego --
+package example
+
+default allow := false
+
+allow if input.user != ""

--- a/e2e/cli/metadata.txtar
+++ b/e2e/cli/metadata.txtar
@@ -1,6 +1,6 @@
 # Verify that request metadata flows into decision logs and does NOT leak
 # into the API response. In vanilla OPA (no custom builtins that write to
-# OutgoingMetadata), the response must contain only the standard fields.
+# ResponseMetadata), the response must contain only the standard fields.
 
 exec $OPA run --server --addr unix://opa.sock --log-format json --log-level info --set decision_logs.console=true ./policy/example.rego &opa&
 retry curl -sf --unix-socket opa.sock 'http://localhost/health'
@@ -17,11 +17,11 @@ jq stdout '.result == true'
 kill -INT opa
 wait opa
 
-# Decision log for the first request must contain incoming_metadata.
-jq -s stderr '[.[] | select(.msg == "Decision Log" and .custom.incoming_metadata["com.example.opa/metadata"].trace_id == "req-42")] | length == 1'
+# Decision log for the first request must contain request_metadata.
+jq -s stderr '[.[] | select(.msg == "Decision Log" and .custom.request_metadata["com.example.opa/metadata"].trace_id == "req-42")] | length == 1'
 
-# Decision log for the first request must NOT have outgoing_metadata (vanilla OPA).
-! jq -s stderr '[.[] | select(.msg == "Decision Log" and .custom.outgoing_metadata)] | length > 0'
+# Decision log for the first request must NOT have response_metadata (vanilla OPA).
+! jq -s stderr '[.[] | select(.msg == "Decision Log" and .custom.response_metadata)] | length > 0'
 
 # Decision log for the second request (no metadata) must not have a custom field.
 jq -s stderr '[.[] | select(.msg == "Decision Log" and .path == "example/allow" and (.custom | not))] | length == 1'

--- a/v1/rego/rego.go
+++ b/v1/rego/rego.go
@@ -125,6 +125,8 @@ type EvalContext struct {
 	baseCache                   topdown.BaseCache
 	tracing                     tracing.Options
 	externalCancel              topdown.Cancel // Note(philip): If non-nil, the cancellation is handled outside of this package.
+	incomingMetadata            map[string]any
+	outgoingMetadata            map[string]any
 }
 
 func (e *EvalContext) RawInput() *any {
@@ -405,6 +407,23 @@ func EvalNondeterministicBuiltins(yes bool) EvalOption {
 func EvalExternalCancel(ec topdown.Cancel) EvalOption {
 	return func(e *EvalContext) {
 		e.externalCancel = ec
+	}
+}
+
+// EvalIncomingMetadata sets arbitrary metadata from the caller that can be
+// passed through to the evaluation. This allows wrapping projects to attach
+// custom metadata to queries.
+func EvalIncomingMetadata(m map[string]any) EvalOption {
+	return func(e *EvalContext) {
+		e.incomingMetadata = m
+	}
+}
+
+// EvalOutgoingMetadata sets a map that wrapping projects can populate during
+// evaluation to include additional fields in the API response.
+func EvalOutgoingMetadata(m map[string]any) EvalOption {
+	return func(e *EvalContext) {
+		e.outgoingMetadata = m
 	}
 }
 
@@ -2271,7 +2290,9 @@ func (r *Rego) eval(ctx context.Context, ectx *EvalContext) (ResultSet, error) {
 		WithPrintHook(ectx.printHook).
 		WithDistributedTracingOpts(r.distributedTracingOpts).
 		WithVirtualCache(ectx.virtualCache).
-		WithBaseCache(ectx.baseCache)
+		WithBaseCache(ectx.baseCache).
+		WithIncomingMetadata(ectx.incomingMetadata).
+		WithOutgoingMetadata(ectx.outgoingMetadata)
 
 	if !ectx.time.IsZero() {
 		q = q.WithTime(ectx.time)
@@ -2565,7 +2586,9 @@ func (r *Rego) partial(ctx context.Context, ectx *EvalContext) (*PartialQueries,
 		WithInterQueryBuiltinValueCache(ectx.interQueryBuiltinValueCache).
 		WithStrictBuiltinErrors(ectx.strictBuiltinErrors).
 		WithSeed(ectx.seed).
-		WithPrintHook(ectx.printHook)
+		WithPrintHook(ectx.printHook).
+		WithIncomingMetadata(ectx.incomingMetadata).
+		WithOutgoingMetadata(ectx.outgoingMetadata)
 
 	if !ectx.time.IsZero() {
 		q = q.WithTime(ectx.time)

--- a/v1/rego/rego.go
+++ b/v1/rego/rego.go
@@ -125,8 +125,8 @@ type EvalContext struct {
 	baseCache                   topdown.BaseCache
 	tracing                     tracing.Options
 	externalCancel              topdown.Cancel // Note(philip): If non-nil, the cancellation is handled outside of this package.
-	incomingMetadata            map[string]any
-	outgoingMetadata            map[string]any
+	requestMetadata             map[string]any
+	responseMetadata            map[string]any
 }
 
 func (e *EvalContext) RawInput() *any {
@@ -410,20 +410,20 @@ func EvalExternalCancel(ec topdown.Cancel) EvalOption {
 	}
 }
 
-// EvalIncomingMetadata sets arbitrary metadata from the caller that can be
+// EvalRequestMetadata sets arbitrary metadata from the caller that can be
 // passed through to the evaluation. This allows wrapping projects to attach
 // custom metadata to queries.
-func EvalIncomingMetadata(m map[string]any) EvalOption {
+func EvalRequestMetadata(m map[string]any) EvalOption {
 	return func(e *EvalContext) {
-		e.incomingMetadata = m
+		e.requestMetadata = m
 	}
 }
 
-// EvalOutgoingMetadata sets a map that wrapping projects can populate during
+// EvalResponseMetadata sets a map that wrapping projects can populate during
 // evaluation to include additional fields in the API response.
-func EvalOutgoingMetadata(m map[string]any) EvalOption {
+func EvalResponseMetadata(m map[string]any) EvalOption {
 	return func(e *EvalContext) {
-		e.outgoingMetadata = m
+		e.responseMetadata = m
 	}
 }
 
@@ -2291,8 +2291,8 @@ func (r *Rego) eval(ctx context.Context, ectx *EvalContext) (ResultSet, error) {
 		WithDistributedTracingOpts(r.distributedTracingOpts).
 		WithVirtualCache(ectx.virtualCache).
 		WithBaseCache(ectx.baseCache).
-		WithIncomingMetadata(ectx.incomingMetadata).
-		WithOutgoingMetadata(ectx.outgoingMetadata)
+		WithRequestMetadata(ectx.requestMetadata).
+		WithResponseMetadata(ectx.responseMetadata)
 
 	if !ectx.time.IsZero() {
 		q = q.WithTime(ectx.time)
@@ -2587,8 +2587,8 @@ func (r *Rego) partial(ctx context.Context, ectx *EvalContext) (*PartialQueries,
 		WithStrictBuiltinErrors(ectx.strictBuiltinErrors).
 		WithSeed(ectx.seed).
 		WithPrintHook(ectx.printHook).
-		WithIncomingMetadata(ectx.incomingMetadata).
-		WithOutgoingMetadata(ectx.outgoingMetadata)
+		WithRequestMetadata(ectx.requestMetadata).
+		WithResponseMetadata(ectx.responseMetadata)
 
 	if !ectx.time.IsZero() {
 		q = q.WithTime(ectx.time)

--- a/v1/rego/rego_metadata_test.go
+++ b/v1/rego/rego_metadata_test.go
@@ -1,0 +1,70 @@
+// Copyright 2026 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package rego
+
+import (
+	"testing"
+
+	"github.com/open-policy-agent/opa/v1/ast"
+	"github.com/open-policy-agent/opa/v1/topdown"
+	"github.com/open-policy-agent/opa/v1/types"
+)
+
+func init() {
+	ast.RegisterBuiltin(&ast.Builtin{
+		Name: "test.transform_metadata",
+		Decl: types.NewFunction(nil, types.B),
+	})
+
+	topdown.RegisterBuiltinFunc(
+		"test.transform_metadata",
+		func(bctx topdown.BuiltinContext, _ []*ast.Term, iter func(*ast.Term) error) error {
+			if bctx.OutgoingMetadata != nil {
+				if v, ok := bctx.IncomingMetadata["correlation_id"]; ok {
+					bctx.OutgoingMetadata["correlation_id"] = v
+					bctx.OutgoingMetadata["processed"] = true
+				}
+			}
+			return iter(ast.BooleanTerm(true))
+		},
+	)
+}
+
+func TestEvalMetadataTransformViaBuiltin(t *testing.T) {
+	module := `package test
+		p if { test.transform_metadata() }
+	`
+
+	r := New(
+		Query("data.test.p"),
+		Module("test.rego", module),
+	)
+
+	pq, err := r.PrepareForEval(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	incoming := map[string]any{
+		"correlation_id": "req-42",
+	}
+	outgoing := map[string]any{}
+
+	rs, err := pq.Eval(t.Context(), EvalIncomingMetadata(incoming), EvalOutgoingMetadata(outgoing))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(rs) != 1 {
+		t.Fatalf("Expected 1 result, got %d", len(rs))
+	}
+
+	if outgoing["correlation_id"] != "req-42" {
+		t.Fatalf("Expected outgoing correlation_id='req-42', got %v", outgoing["correlation_id"])
+	}
+	if outgoing["processed"] != true {
+		t.Fatalf("Expected outgoing processed=true, got %v", outgoing["processed"])
+	}
+}

--- a/v1/rego/rego_metadata_test.go
+++ b/v1/rego/rego_metadata_test.go
@@ -21,10 +21,10 @@ func init() {
 	topdown.RegisterBuiltinFunc(
 		"test.transform_metadata",
 		func(bctx topdown.BuiltinContext, _ []*ast.Term, iter func(*ast.Term) error) error {
-			if bctx.OutgoingMetadata != nil {
-				if v, ok := bctx.IncomingMetadata["correlation_id"]; ok {
-					bctx.OutgoingMetadata["correlation_id"] = v
-					bctx.OutgoingMetadata["processed"] = true
+			if bctx.ResponseMetadata != nil {
+				if v, ok := bctx.RequestMetadata["correlation_id"]; ok {
+					bctx.ResponseMetadata["correlation_id"] = v
+					bctx.ResponseMetadata["processed"] = true
 				}
 			}
 			return iter(ast.BooleanTerm(true))
@@ -52,7 +52,7 @@ func TestEvalMetadataTransformViaBuiltin(t *testing.T) {
 	}
 	outgoing := map[string]any{}
 
-	rs, err := pq.Eval(t.Context(), EvalIncomingMetadata(incoming), EvalOutgoingMetadata(outgoing))
+	rs, err := pq.Eval(t.Context(), EvalRequestMetadata(incoming), EvalResponseMetadata(outgoing))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/v1/server/server.go
+++ b/v1/server/server.go
@@ -1732,11 +1732,15 @@ func (s *Server) v1DataPost(w http.ResponseWriter, r *http.Request) {
 
 	m.Timer(metrics.RegoInputParse).Start()
 
-	input, goInput, reqMetadata, err := readInputPostV1(r)
+	parsed, err := readInputPostV1(r)
 	if err != nil {
 		writer.ErrorString(w, http.StatusBadRequest, types.CodeInvalidParameter, err)
 		return
 	}
+
+	input := parsed.Value
+	goInput := parsed.GoInput
+	reqMetadata := parsed.Metadata
 
 	respMetadata := map[string]any{}
 	customLog := func() map[string]any {
@@ -2939,16 +2943,22 @@ func readInputGetV1(str string) (ast.Value, *any, error) {
 	return v, &input, err
 }
 
-func readInputPostV1(r *http.Request) (ast.Value, *any, map[string]any, error) {
+type parsedInput struct {
+	Value    ast.Value
+	GoInput  *any
+	Metadata map[string]any
+}
+
+func readInputPostV1(r *http.Request) (*parsedInput, error) {
 	parsed, ok := authorizer.GetBodyOnContext(r.Context())
 	if ok {
 		if obj, ok := parsed.(map[string]any); ok {
 			if input, ok := obj["input"]; ok {
 				v, err := ast.InterfaceToValue(input)
-				return v, &input, nil, err
+				return &parsedInput{Value: v, GoInput: &input}, err
 			}
 		}
-		return nil, nil, nil, nil
+		return &parsedInput{}, nil
 	}
 
 	var request types.DataRequestV1
@@ -2956,7 +2966,7 @@ func readInputPostV1(r *http.Request) (ast.Value, *any, map[string]any, error) {
 	// decompress the input if sent as zip
 	bodyBytes, err := util.ReadMaybeCompressedBody(r)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("could not decompress the body: %w", err)
+		return nil, fmt.Errorf("could not decompress the body: %w", err)
 	}
 
 	ct := r.Header.Get("Content-Type")
@@ -2965,22 +2975,22 @@ func readInputPostV1(r *http.Request) (ast.Value, *any, map[string]any, error) {
 	if strings.Contains(ct, "yaml") {
 		if len(bodyBytes) > 0 {
 			if err = util.Unmarshal(bodyBytes, &request); err != nil {
-				return nil, nil, nil, fmt.Errorf("body contains malformed input document: %w", err)
+				return nil, fmt.Errorf("body contains malformed input document: %w", err)
 			}
 		}
 	} else {
 		dec := util.NewJSONDecoder(bytes.NewBuffer(bodyBytes))
 		if err := dec.Decode(&request); err != nil && err != io.EOF {
-			return nil, nil, nil, fmt.Errorf("body contains malformed input document: %w", err)
+			return nil, fmt.Errorf("body contains malformed input document: %w", err)
 		}
 	}
 
 	if request.Input == nil {
-		return nil, nil, request.Metadata, nil
+		return &parsedInput{Metadata: request.Metadata}, nil
 	}
 
 	v, err := ast.InterfaceToValue(*request.Input)
-	return v, request.Input, request.Metadata, err
+	return &parsedInput{Value: v, GoInput: request.Input, Metadata: request.Metadata}, err
 }
 
 type compileRequest struct {

--- a/v1/server/server.go
+++ b/v1/server/server.go
@@ -1749,10 +1749,10 @@ func (s *Server) v1DataPost(w http.ResponseWriter, r *http.Request) {
 		}
 		c := make(map[string]any, 2)
 		if len(reqMetadata) > 0 {
-			c["incoming_metadata"] = reqMetadata
+			c["request_metadata"] = reqMetadata
 		}
 		if len(respMetadata) > 0 {
-			c["outgoing_metadata"] = respMetadata
+			c["response_metadata"] = respMetadata
 		}
 		return c
 	}
@@ -1846,11 +1846,11 @@ func (s *Server) v1DataPost(w http.ResponseWriter, r *http.Request) {
 		rego.EvalInterQueryBuiltinValueCache(s.interQueryBuiltinValueCache),
 		rego.EvalInstrument(includeInstrumentation),
 		rego.EvalNDBuiltinCache(ndbCache),
-		rego.EvalOutgoingMetadata(respMetadata),
+		rego.EvalResponseMetadata(respMetadata),
 	}
 
 	if reqMetadata != nil {
-		evalOpts = append(evalOpts, rego.EvalIncomingMetadata(reqMetadata))
+		evalOpts = append(evalOpts, rego.EvalRequestMetadata(reqMetadata))
 	}
 
 	rs, err := preparedQuery.Eval(ctx, evalOpts...)

--- a/v1/server/server.go
+++ b/v1/server/server.go
@@ -1732,10 +1732,25 @@ func (s *Server) v1DataPost(w http.ResponseWriter, r *http.Request) {
 
 	m.Timer(metrics.RegoInputParse).Start()
 
-	input, goInput, err := readInputPostV1(r)
+	input, goInput, reqMetadata, err := readInputPostV1(r)
 	if err != nil {
 		writer.ErrorString(w, http.StatusBadRequest, types.CodeInvalidParameter, err)
 		return
+	}
+
+	respMetadata := map[string]any{}
+	customLog := func() map[string]any {
+		if len(reqMetadata) == 0 && len(respMetadata) == 0 {
+			return nil
+		}
+		c := make(map[string]any, 2)
+		if len(reqMetadata) > 0 {
+			c["incoming_metadata"] = reqMetadata
+		}
+		if len(respMetadata) > 0 {
+			c["outgoing_metadata"] = respMetadata
+		}
+		return c
 	}
 
 	m.Timer(metrics.RegoInputParse).Stop()
@@ -1803,14 +1818,14 @@ func (s *Server) v1DataPost(w http.ResponseWriter, r *http.Request) {
 
 		rego, err := s.makeRego(ctx, strictBuiltinErrors, txn, input, urlPath, m, includeInstrumentation, buf, opts)
 		if err != nil {
-			_ = logger.Log(ctx, txn, urlPath, "", goInput, input, nil, ndbCache, err, m, nil)
+			_ = logger.Log(ctx, txn, urlPath, "", goInput, input, nil, ndbCache, err, m, customLog())
 			writer.ErrorAuto(w, err)
 			return
 		}
 
 		pq, err := rego.PrepareForEval(ctx)
 		if err != nil {
-			_ = logger.Log(ctx, txn, urlPath, "", goInput, input, nil, ndbCache, err, m, nil)
+			_ = logger.Log(ctx, txn, urlPath, "", goInput, input, nil, ndbCache, err, m, customLog())
 			writer.ErrorAuto(w, err)
 			return
 		}
@@ -1818,7 +1833,7 @@ func (s *Server) v1DataPost(w http.ResponseWriter, r *http.Request) {
 		s.preparedEvalQueries.Insert(pqID, preparedQuery)
 	}
 
-	rs, err := preparedQuery.Eval(ctx,
+	evalOpts := []rego.EvalOption{
 		rego.EvalTransaction(txn),
 		rego.EvalParsedInput(input),
 		rego.EvalMetrics(m),
@@ -1827,19 +1842,30 @@ func (s *Server) v1DataPost(w http.ResponseWriter, r *http.Request) {
 		rego.EvalInterQueryBuiltinValueCache(s.interQueryBuiltinValueCache),
 		rego.EvalInstrument(includeInstrumentation),
 		rego.EvalNDBuiltinCache(ndbCache),
-	)
+		rego.EvalOutgoingMetadata(respMetadata),
+	}
+
+	if reqMetadata != nil {
+		evalOpts = append(evalOpts, rego.EvalIncomingMetadata(reqMetadata))
+	}
+
+	rs, err := preparedQuery.Eval(ctx, evalOpts...)
 
 	m.Timer(metrics.ServerHandler).Stop()
 
 	// Handle results.
 	if err != nil {
-		_ = logger.Log(ctx, txn, urlPath, "", goInput, input, nil, ndbCache, err, m, nil)
+		_ = logger.Log(ctx, txn, urlPath, "", goInput, input, nil, ndbCache, err, m, customLog())
 		writer.ErrorAuto(w, err)
 		return
 	}
 
 	result := types.DataResponseV1{
 		DecisionID: decisionID,
+	}
+
+	if len(respMetadata) > 0 {
+		result.Metadata = respMetadata
 	}
 
 	if input == nil {
@@ -1862,7 +1888,7 @@ func (s *Server) v1DataPost(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 		}
-		if err = logger.Log(ctx, txn, urlPath, "", goInput, input, nil, ndbCache, nil, m, nil); err != nil {
+		if err = logger.Log(ctx, txn, urlPath, "", goInput, input, nil, ndbCache, nil, m, customLog()); err != nil {
 			writer.ErrorAuto(w, err)
 			return
 		}
@@ -1876,7 +1902,7 @@ func (s *Server) v1DataPost(w http.ResponseWriter, r *http.Request) {
 		result.Explanation = s.getExplainResponse(explainMode, *buf, pretty(r))
 	}
 
-	if err := logger.Log(ctx, txn, urlPath, "", goInput, input, result.Result, ndbCache, nil, m, nil); err != nil {
+	if err := logger.Log(ctx, txn, urlPath, "", goInput, input, result.Result, ndbCache, nil, m, customLog()); err != nil {
 		writer.ErrorAuto(w, err)
 		return
 	}
@@ -2913,16 +2939,16 @@ func readInputGetV1(str string) (ast.Value, *any, error) {
 	return v, &input, err
 }
 
-func readInputPostV1(r *http.Request) (ast.Value, *any, error) {
+func readInputPostV1(r *http.Request) (ast.Value, *any, map[string]any, error) {
 	parsed, ok := authorizer.GetBodyOnContext(r.Context())
 	if ok {
 		if obj, ok := parsed.(map[string]any); ok {
 			if input, ok := obj["input"]; ok {
 				v, err := ast.InterfaceToValue(input)
-				return v, &input, err
+				return v, &input, nil, err
 			}
 		}
-		return nil, nil, nil
+		return nil, nil, nil, nil
 	}
 
 	var request types.DataRequestV1
@@ -2930,7 +2956,7 @@ func readInputPostV1(r *http.Request) (ast.Value, *any, error) {
 	// decompress the input if sent as zip
 	bodyBytes, err := util.ReadMaybeCompressedBody(r)
 	if err != nil {
-		return nil, nil, fmt.Errorf("could not decompress the body: %w", err)
+		return nil, nil, nil, fmt.Errorf("could not decompress the body: %w", err)
 	}
 
 	ct := r.Header.Get("Content-Type")
@@ -2939,22 +2965,22 @@ func readInputPostV1(r *http.Request) (ast.Value, *any, error) {
 	if strings.Contains(ct, "yaml") {
 		if len(bodyBytes) > 0 {
 			if err = util.Unmarshal(bodyBytes, &request); err != nil {
-				return nil, nil, fmt.Errorf("body contains malformed input document: %w", err)
+				return nil, nil, nil, fmt.Errorf("body contains malformed input document: %w", err)
 			}
 		}
 	} else {
 		dec := util.NewJSONDecoder(bytes.NewBuffer(bodyBytes))
 		if err := dec.Decode(&request); err != nil && err != io.EOF {
-			return nil, nil, fmt.Errorf("body contains malformed input document: %w", err)
+			return nil, nil, nil, fmt.Errorf("body contains malformed input document: %w", err)
 		}
 	}
 
 	if request.Input == nil {
-		return nil, nil, nil
+		return nil, nil, request.Metadata, nil
 	}
 
 	v, err := ast.InterfaceToValue(*request.Input)
-	return v, request.Input, err
+	return v, request.Input, request.Metadata, err
 }
 
 type compileRequest struct {

--- a/v1/server/server_test.go
+++ b/v1/server/server_test.go
@@ -5216,10 +5216,11 @@ func TestServerUsesAuthorizerParsedBody(t *testing.T) {
 	})
 
 	// Check that v1 reader function behaves correctly.
-	inp, goInp, _, err := readInputPostV1(req.WithContext(ctx))
+	parsed, err := readInputPostV1(req.WithContext(ctx))
 	if err != nil {
 		t.Fatal(err)
 	}
+	inp, goInp := parsed.Value, parsed.GoInput
 
 	exp := ast.MustParseTerm(`{"foo": "good"}`)
 
@@ -5259,23 +5260,23 @@ func TestReadInputPostV1Metadata(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	inp, goInp, metadata, err := readInputPostV1(req)
+	parsed, err := readInputPostV1(req)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if inp == nil {
+	if parsed.Value == nil {
 		t.Fatal("expected parsed input")
 	}
-	if goInp == nil {
+	if parsed.GoInput == nil {
 		t.Fatal("expected go input")
 	}
 
-	if metadata == nil {
+	if parsed.Metadata == nil {
 		t.Fatal("expected metadata fields")
 	}
 
-	md, ok := metadata["com.example.opa/metadata"].(map[string]any)
+	md, ok := parsed.Metadata["com.example.opa/metadata"].(map[string]any)
 	if !ok {
 		t.Fatal("expected com.example.opa/metadata in metadata")
 	}
@@ -5284,7 +5285,7 @@ func TestReadInputPostV1Metadata(t *testing.T) {
 		t.Fatalf("expected trace_id='abc-123', got %v", md["trace_id"])
 	}
 
-	if _, ok := metadata["input"]; ok {
+	if _, ok := parsed.Metadata["input"]; ok {
 		t.Fatal("'input' should not appear in metadata")
 	}
 }

--- a/v1/server/server_test.go
+++ b/v1/server/server_test.go
@@ -60,11 +60,30 @@ import (
 	"github.com/open-policy-agent/opa/v1/storage"
 	"github.com/open-policy-agent/opa/v1/storage/disk"
 	"github.com/open-policy-agent/opa/v1/storage/inmem"
+	"github.com/open-policy-agent/opa/v1/topdown"
+	astTypes "github.com/open-policy-agent/opa/v1/types"
 	"github.com/open-policy-agent/opa/v1/util"
 	"github.com/open-policy-agent/opa/v1/util/test"
 	"github.com/open-policy-agent/opa/v1/version"
 	prom "github.com/prometheus/client_golang/prometheus"
 )
+
+func init() {
+	ast.RegisterBuiltin(&ast.Builtin{
+		Name: "test.set_outgoing",
+		Decl: astTypes.NewFunction(nil, astTypes.B),
+	})
+
+	topdown.RegisterBuiltinFunc(
+		"test.set_outgoing",
+		func(bctx topdown.BuiltinContext, _ []*ast.Term, iter func(*ast.Term) error) error {
+			if bctx.OutgoingMetadata != nil {
+				bctx.OutgoingMetadata["version"] = "1.0"
+			}
+			return iter(ast.BooleanTerm(true))
+		},
+	)
+}
 
 type tr struct {
 	method string
@@ -4553,6 +4572,102 @@ func TestDecisionLogging(t *testing.T) {
 	}
 }
 
+func TestDecisionLogRequestMetadata(t *testing.T) {
+	t.Parallel()
+
+	f := newFixture(t)
+
+	var logged *Info
+
+	f.server = f.server.WithDecisionIDFactory(func() string {
+		return "test-id"
+	}).WithDecisionLoggerWithErr(func(_ context.Context, info *Info) error {
+		logged = info
+		return nil
+	})
+
+	if err := f.v1("PUT", "/policies/test", "package test\np = true", http.StatusOK, "{}"); err != nil {
+		t.Fatal(err)
+	}
+
+	body := `{"input": {"user": "alice"}, "com.example.opa/metadata": {"trace_id": "abc-123"}}`
+	if err := f.v1("POST", "/data/test/p", body, http.StatusOK, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	if logged == nil {
+		t.Fatal("expected decision log entry")
+	}
+
+	if logged.Custom == nil {
+		t.Fatal("expected Custom in decision log")
+	}
+
+	incoming, ok := logged.Custom["incoming_metadata"].(map[string]any)
+	if !ok {
+		t.Fatal("expected incoming_metadata in Custom")
+	}
+
+	md, ok := incoming["com.example.opa/metadata"].(map[string]any)
+	if !ok {
+		t.Fatal("expected com.example.opa/metadata in incoming_metadata")
+	}
+
+	if md["trace_id"] != "abc-123" {
+		t.Fatalf("expected trace_id='abc-123', got %v", md["trace_id"])
+	}
+
+	if _, ok := incoming["input"]; ok {
+		t.Fatal("'input' should not appear in incoming_metadata")
+	}
+
+	if _, ok := logged.Custom["outgoing_metadata"]; ok {
+		t.Fatal("outgoing_metadata should be absent when nothing populates it")
+	}
+}
+
+func TestDecisionLogOutgoingMetadata(t *testing.T) {
+	t.Parallel()
+
+	f := newFixture(t)
+
+	var logged *Info
+
+	f.server = f.server.WithDecisionIDFactory(func() string {
+		return "test-id"
+	}).WithDecisionLoggerWithErr(func(_ context.Context, info *Info) error {
+		logged = info
+		return nil
+	})
+
+	policy := "package test\nimport rego.v1\np if { test.set_outgoing() }"
+	if err := f.v1("PUT", "/policies/test", policy, http.StatusOK, "{}"); err != nil {
+		t.Fatal(err)
+	}
+
+	body := `{"input": {"user": "alice"}, "com.example.opa/metadata": {"trace_id": "abc-123"}}`
+	if err := f.v1("POST", "/data/test/p", body, http.StatusOK, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	if logged == nil {
+		t.Fatal("expected decision log entry")
+	}
+
+	if logged.Custom == nil {
+		t.Fatal("expected Custom in decision log")
+	}
+
+	outgoing, ok := logged.Custom["outgoing_metadata"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected outgoing_metadata in Custom, got %v", logged.Custom)
+	}
+
+	if outgoing["version"] != "1.0" {
+		t.Fatalf("expected version='1.0' in outgoing_metadata, got %v", outgoing["version"])
+	}
+}
+
 func TestDecisionLogErrorMessage(t *testing.T) {
 	t.Parallel()
 
@@ -5101,7 +5216,7 @@ func TestServerUsesAuthorizerParsedBody(t *testing.T) {
 	})
 
 	// Check that v1 reader function behaves correctly.
-	inp, goInp, err := readInputPostV1(req.WithContext(ctx))
+	inp, goInp, _, err := readInputPostV1(req.WithContext(ctx))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -5132,6 +5247,45 @@ func TestServerUsesAuthorizerParsedBody(t *testing.T) {
 
 	if exp.Value.Compare(ast.MustInterfaceToValue(*goInp)) != 0 {
 		t.Fatalf("expected %v but got %v", exp, *goInp)
+	}
+}
+
+func TestReadInputPostV1Metadata(t *testing.T) {
+	t.Parallel()
+
+	body := `{"input": {"user": "alice"}, "com.example.opa/metadata": {"trace_id": "abc-123"}}`
+	req, err := http.NewRequest(http.MethodPost, "http://localhost:8182/v1/data/test", bytes.NewBufferString(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	inp, goInp, metadata, err := readInputPostV1(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if inp == nil {
+		t.Fatal("expected parsed input")
+	}
+	if goInp == nil {
+		t.Fatal("expected go input")
+	}
+
+	if metadata == nil {
+		t.Fatal("expected metadata fields")
+	}
+
+	md, ok := metadata["com.example.opa/metadata"].(map[string]any)
+	if !ok {
+		t.Fatal("expected com.example.opa/metadata in metadata")
+	}
+
+	if md["trace_id"] != "abc-123" {
+		t.Fatalf("expected trace_id='abc-123', got %v", md["trace_id"])
+	}
+
+	if _, ok := metadata["input"]; ok {
+		t.Fatal("'input' should not appear in metadata")
 	}
 }
 

--- a/v1/server/server_test.go
+++ b/v1/server/server_test.go
@@ -77,8 +77,8 @@ func init() {
 	topdown.RegisterBuiltinFunc(
 		"test.set_outgoing",
 		func(bctx topdown.BuiltinContext, _ []*ast.Term, iter func(*ast.Term) error) error {
-			if bctx.OutgoingMetadata != nil {
-				bctx.OutgoingMetadata["version"] = "1.0"
+			if bctx.ResponseMetadata != nil {
+				bctx.ResponseMetadata["version"] = "1.0"
 			}
 			return iter(ast.BooleanTerm(true))
 		},
@@ -4603,14 +4603,14 @@ func TestDecisionLogRequestMetadata(t *testing.T) {
 		t.Fatal("expected Custom in decision log")
 	}
 
-	incoming, ok := logged.Custom["incoming_metadata"].(map[string]any)
+	incoming, ok := logged.Custom["request_metadata"].(map[string]any)
 	if !ok {
-		t.Fatal("expected incoming_metadata in Custom")
+		t.Fatal("expected request_metadata in Custom")
 	}
 
 	md, ok := incoming["com.example.opa/metadata"].(map[string]any)
 	if !ok {
-		t.Fatal("expected com.example.opa/metadata in incoming_metadata")
+		t.Fatal("expected com.example.opa/metadata in request_metadata")
 	}
 
 	if md["trace_id"] != "abc-123" {
@@ -4618,15 +4618,15 @@ func TestDecisionLogRequestMetadata(t *testing.T) {
 	}
 
 	if _, ok := incoming["input"]; ok {
-		t.Fatal("'input' should not appear in incoming_metadata")
+		t.Fatal("'input' should not appear in request_metadata")
 	}
 
-	if _, ok := logged.Custom["outgoing_metadata"]; ok {
-		t.Fatal("outgoing_metadata should be absent when nothing populates it")
+	if _, ok := logged.Custom["response_metadata"]; ok {
+		t.Fatal("response_metadata should be absent when nothing populates it")
 	}
 }
 
-func TestDecisionLogOutgoingMetadata(t *testing.T) {
+func TestDecisionLogResponseMetadata(t *testing.T) {
 	t.Parallel()
 
 	f := newFixture(t)
@@ -4658,13 +4658,13 @@ func TestDecisionLogOutgoingMetadata(t *testing.T) {
 		t.Fatal("expected Custom in decision log")
 	}
 
-	outgoing, ok := logged.Custom["outgoing_metadata"].(map[string]any)
+	outgoing, ok := logged.Custom["response_metadata"].(map[string]any)
 	if !ok {
-		t.Fatalf("expected outgoing_metadata in Custom, got %v", logged.Custom)
+		t.Fatalf("expected response_metadata in Custom, got %v", logged.Custom)
 	}
 
 	if outgoing["version"] != "1.0" {
-		t.Fatalf("expected version='1.0' in outgoing_metadata, got %v", outgoing["version"])
+		t.Fatalf("expected version='1.0' in response_metadata, got %v", outgoing["version"])
 	}
 }
 

--- a/v1/server/types/types.go
+++ b/v1/server/types/types.go
@@ -142,6 +142,78 @@ type ProvenanceBundleV1 struct {
 // DataRequestV1 models the request message for Data API POST operations.
 type DataRequestV1 struct {
 	Input *any `json:"input"`
+
+	// Metadata holds any additional top-level fields not defined in this struct.
+	// These fields are preserved during JSON unmarshaling, allowing wrapping
+	// projects to pass through custom key/value pairs.
+	//
+	// Future OPA versions may introduce new top-level keys. To avoid conflicts,
+	// use a unique namespaced key, e.g. "com.example.opa/metadata": { ... }.
+	Metadata map[string]any `json:"-"`
+}
+
+func (r *DataRequestV1) UnmarshalJSON(data []byte) error {
+	type Alias DataRequestV1
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(r),
+	}
+
+	var raw map[string]json.RawMessage
+	if err := util.UnmarshalJSON(data, &raw); err != nil {
+		return err
+	}
+
+	if err := util.UnmarshalJSON(data, aux); err != nil {
+		return err
+	}
+
+	r.Metadata = make(map[string]any)
+	for key, val := range raw {
+		if key != "input" {
+			var v any
+			if err := util.UnmarshalJSON(val, &v); err != nil {
+				return err
+			}
+			r.Metadata[key] = v
+		}
+	}
+
+	if len(r.Metadata) == 0 {
+		r.Metadata = nil
+	}
+
+	return nil
+}
+
+func (r DataRequestV1) MarshalJSON() ([]byte, error) {
+	type Alias DataRequestV1
+	aux := struct {
+		*Alias
+	}{
+		Alias: (*Alias)(&r),
+	}
+
+	data, err := json.Marshal(aux)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(r.Metadata) == 0 {
+		return data, nil
+	}
+
+	var base map[string]any
+	if err := json.Unmarshal(data, &base); err != nil {
+		return nil, err
+	}
+
+	for key, val := range r.Metadata {
+		base[key] = val
+	}
+
+	return json.Marshal(base)
 }
 
 // DataResponseV1 models the response message for Data API read operations.
@@ -152,6 +224,99 @@ type DataResponseV1 struct {
 	Metrics     MetricsV1     `json:"metrics,omitempty"`
 	Result      *any          `json:"result,omitempty"`
 	Warning     *Warning      `json:"warning,omitempty"`
+
+	// Metadata holds any additional top-level fields not defined in this struct.
+	// These fields are preserved during JSON marshaling/unmarshaling, allowing
+	// wrapping projects to pass through custom key/value pairs.
+	//
+	// Future OPA versions may introduce new top-level keys. To avoid conflicts,
+	// use a unique namespaced key, e.g. "com.example.opa/metadata": { ... }.
+	Metadata map[string]any `json:"-"`
+}
+
+func (r *DataResponseV1) UnmarshalJSON(data []byte) error {
+	type Alias DataResponseV1
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(r),
+	}
+
+	var raw map[string]json.RawMessage
+	if err := util.UnmarshalJSON(data, &raw); err != nil {
+		return err
+	}
+
+	if err := util.UnmarshalJSON(data, aux); err != nil {
+		return err
+	}
+
+	knownFields := map[string]bool{
+		"decision_id": true,
+		"provenance":  true,
+		"explanation": true,
+		"metrics":     true,
+		"result":      true,
+		"warning":     true,
+	}
+
+	r.Metadata = make(map[string]any)
+	for key, val := range raw {
+		if !knownFields[key] {
+			var v any
+			if err := util.UnmarshalJSON(val, &v); err != nil {
+				return err
+			}
+			r.Metadata[key] = v
+		}
+	}
+
+	if len(r.Metadata) == 0 {
+		r.Metadata = nil
+	}
+
+	return nil
+}
+
+func (r DataResponseV1) MarshalJSON() ([]byte, error) {
+	type Alias DataResponseV1
+	aux := struct {
+		*Alias
+	}{
+		Alias: (*Alias)(&r),
+	}
+
+	data, err := json.Marshal(aux)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(r.Metadata) == 0 {
+		return data, nil
+	}
+
+	// Reserved field names that must not be overridden by metadata.
+	reservedFields := map[string]bool{
+		"decision_id": true,
+		"provenance":  true,
+		"explanation": true,
+		"metrics":     true,
+		"result":      true,
+		"warning":     true,
+	}
+
+	var base map[string]any
+	if err := json.Unmarshal(data, &base); err != nil {
+		return nil, err
+	}
+
+	for key, val := range r.Metadata {
+		if !reservedFields[key] {
+			base[key] = val
+		}
+	}
+
+	return json.Marshal(base)
 }
 
 // Warning models DataResponse warnings

--- a/v1/server/types/types_extensible_test.go
+++ b/v1/server/types/types_extensible_test.go
@@ -1,0 +1,202 @@
+// Copyright 2026 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package types
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestDataRequestV1_ExtraFields(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantErr  bool
+		validate func(*testing.T, *DataRequestV1)
+	}{
+		{
+			name:  "basic request with extra fields",
+			input: `{"input": {"user": "alice"}, "request_id": "123", "metadata": {"source": "test"}}`,
+			validate: func(t *testing.T, req *DataRequestV1) {
+				if req.Input == nil {
+					t.Error("Input should not be nil")
+				}
+				if len(req.Metadata) != 2 {
+					t.Errorf("Expected 2 extra fields, got %d", len(req.Metadata))
+				}
+				if req.Metadata["request_id"] != "123" {
+					t.Errorf("Expected request_id='123', got %v", req.Metadata["request_id"])
+				}
+				metadata, ok := req.Metadata["metadata"].(map[string]any)
+				if !ok {
+					t.Error("metadata should be a map")
+				} else if metadata["source"] != "test" {
+					t.Errorf("Expected metadata.source='test', got %v", metadata["source"])
+				}
+			},
+		},
+		{
+			name:  "request with no extra fields",
+			input: `{"input": {"user": "bob"}}`,
+			validate: func(t *testing.T, req *DataRequestV1) {
+				if req.Input == nil {
+					t.Error("Input should not be nil")
+				}
+				if req.Metadata != nil {
+					t.Errorf("Extra should be nil when no extra fields, got %v", req.Metadata)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var req DataRequestV1
+			err := json.Unmarshal([]byte(tt.input), &req)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Unmarshal() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && tt.validate != nil {
+				tt.validate(t, &req)
+			}
+		})
+	}
+}
+
+func TestDataResponseV1_ExtraFields(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantErr  bool
+		validate func(*testing.T, *DataResponseV1)
+	}{
+		{
+			name:  "response with extra fields",
+			input: `{"result": true, "decision_id": "abc123", "custom_field": "value", "trace_id": "xyz"}`,
+			validate: func(t *testing.T, resp *DataResponseV1) {
+				if resp.DecisionID != "abc123" {
+					t.Errorf("Expected decision_id='abc123', got %s", resp.DecisionID)
+				}
+				if len(resp.Metadata) != 2 {
+					t.Errorf("Expected 2 extra fields, got %d", len(resp.Metadata))
+				}
+				if resp.Metadata["custom_field"] != "value" {
+					t.Errorf("Expected custom_field='value', got %v", resp.Metadata["custom_field"])
+				}
+				if resp.Metadata["trace_id"] != "xyz" {
+					t.Errorf("Expected trace_id='xyz', got %v", resp.Metadata["trace_id"])
+				}
+			},
+		},
+		{
+			name:  "response with no extra fields",
+			input: `{"result": {"allowed": true}, "decision_id": "def456"}`,
+			validate: func(t *testing.T, resp *DataResponseV1) {
+				if resp.DecisionID != "def456" {
+					t.Errorf("Expected decision_id='def456', got %s", resp.DecisionID)
+				}
+				if resp.Metadata != nil {
+					t.Errorf("Extra should be nil when no extra fields, got %v", resp.Metadata)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var resp DataResponseV1
+			err := json.Unmarshal([]byte(tt.input), &resp)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Unmarshal() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && tt.validate != nil {
+				tt.validate(t, &resp)
+			}
+		})
+	}
+}
+
+func TestDataResponseV1_RoundTrip(t *testing.T) {
+	input := `{"result": {"allowed": true}, "decision_id": "xyz", "custom": "data", "metrics": {"timer_rego_query_eval_ns": 1000}}`
+
+	var resp DataResponseV1
+	if err := json.Unmarshal([]byte(input), &resp); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+
+	output, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	var resp2 DataResponseV1
+	if err := json.Unmarshal(output, &resp2); err != nil {
+		t.Fatalf("Second unmarshal failed: %v", err)
+	}
+
+	if resp.DecisionID != resp2.DecisionID {
+		t.Errorf("decision_id not preserved: %s != %s", resp.DecisionID, resp2.DecisionID)
+	}
+
+	if resp.Metadata["custom"] != resp2.Metadata["custom"] {
+		t.Errorf("custom field not preserved: %v != %v", resp.Metadata["custom"], resp2.Metadata["custom"])
+	}
+
+	if resp.Metrics["timer_rego_query_eval_ns"] != resp2.Metrics["timer_rego_query_eval_ns"] {
+		t.Error("metrics not preserved")
+	}
+}
+
+func TestDataResponseV1_ReservedFieldsNotOverridden(t *testing.T) {
+	reservedFields := []string{
+		"decision_id",
+		"provenance",
+		"explanation",
+		"metrics",
+		"result",
+		"warning",
+	}
+
+	for _, field := range reservedFields {
+		t.Run(field, func(t *testing.T) {
+			resp := DataResponseV1{
+				DecisionID: "real_decision_id",
+				Metadata: map[string]any{
+					field: "should_be_ignored",
+				},
+			}
+
+			if field == "result" {
+				result := any("real_result")
+				resp.Result = &result
+			}
+
+			output, err := json.Marshal(resp)
+			if err != nil {
+				t.Fatalf("Marshal failed: %v", err)
+			}
+
+			var raw map[string]any
+			if err := json.Unmarshal(output, &raw); err != nil {
+				t.Fatalf("Unmarshal to map failed: %v", err)
+			}
+
+			if field == "decision_id" && raw["decision_id"] != "real_decision_id" {
+				t.Errorf("Reserved field '%s' was overridden by extra field", field)
+			}
+			if field == "result" && raw["result"] != "real_result" {
+				t.Errorf("Reserved field 'result' was overridden by extra field, got: %v", raw["result"])
+			}
+
+			if field != "decision_id" && field != "result" {
+				if _, exists := raw[field]; exists && raw[field] == "should_be_ignored" {
+					t.Errorf("Reserved field '%s' from extra should have been ignored but appeared in output", field)
+				}
+			}
+		})
+	}
+}

--- a/v1/topdown/builtins.go
+++ b/v1/topdown/builtins.go
@@ -54,8 +54,8 @@ type (
 		PrintHook                   print.Hook                 // provides callback function to use for printing
 		RoundTripper                CustomizeRoundTripper      // customize transport to use for HTTP requests
 		DistributedTracingOpts      tracing.Options            // options to be used by distributed tracing.
-		IncomingMetadata            map[string]any             // metadata from the caller, for use by wrapping projects
-		OutgoingMetadata            map[string]any             // metadata for the response, populated by wrapping projects
+		RequestMetadata             map[string]any             // metadata from the caller, for use by wrapping projects
+		ResponseMetadata            map[string]any             // metadata for the response, populated by wrapping projects
 		rand                        *rand.Rand                 // randomization source for non-security-sensitive operations
 		Capabilities                *ast.Capabilities
 	}

--- a/v1/topdown/builtins.go
+++ b/v1/topdown/builtins.go
@@ -54,6 +54,8 @@ type (
 		PrintHook                   print.Hook                 // provides callback function to use for printing
 		RoundTripper                CustomizeRoundTripper      // customize transport to use for HTTP requests
 		DistributedTracingOpts      tracing.Options            // options to be used by distributed tracing.
+		IncomingMetadata            map[string]any             // metadata from the caller, for use by wrapping projects
+		OutgoingMetadata            map[string]any             // metadata for the response, populated by wrapping projects
 		rand                        *rand.Rand                 // randomization source for non-security-sensitive operations
 		Capabilities                *ast.Capabilities
 	}

--- a/v1/topdown/eval.go
+++ b/v1/topdown/eval.go
@@ -124,8 +124,8 @@ type eval struct {
 	findOne                     bool
 	strictObjects               bool
 	defined                     bool
-	incomingMetadata            map[string]any
-	outgoingMetadata            map[string]any
+	requestMetadata             map[string]any
+	responseMetadata            map[string]any
 }
 
 type (
@@ -1052,8 +1052,8 @@ func (e *eval) evalCall(terms []*ast.Term, iter unifyIterator) error {
 			DistributedTracingOpts:      e.tracingOpts,
 			Capabilities:                capabilities,
 			RoundTripper:                e.roundTripper,
-			IncomingMetadata:            e.incomingMetadata,
-			OutgoingMetadata:            e.outgoingMetadata,
+			RequestMetadata:             e.requestMetadata,
+			ResponseMetadata:            e.responseMetadata,
 		}
 	}
 

--- a/v1/topdown/eval.go
+++ b/v1/topdown/eval.go
@@ -124,6 +124,8 @@ type eval struct {
 	findOne                     bool
 	strictObjects               bool
 	defined                     bool
+	incomingMetadata            map[string]any
+	outgoingMetadata            map[string]any
 }
 
 type (
@@ -1050,6 +1052,8 @@ func (e *eval) evalCall(terms []*ast.Term, iter unifyIterator) error {
 			DistributedTracingOpts:      e.tracingOpts,
 			Capabilities:                capabilities,
 			RoundTripper:                e.roundTripper,
+			IncomingMetadata:            e.incomingMetadata,
+			OutgoingMetadata:            e.outgoingMetadata,
 		}
 	}
 

--- a/v1/topdown/query.go
+++ b/v1/topdown/query.go
@@ -63,8 +63,8 @@ type Query struct {
 	tracingOpts                 tracing.Options
 	virtualCache                VirtualCache
 	baseCache                   BaseCache
-	incomingMetadata            map[string]any
-	outgoingMetadata            map[string]any
+	requestMetadata             map[string]any
+	responseMetadata            map[string]any
 }
 
 // Builtin represents a built-in function that queries can call.
@@ -335,18 +335,18 @@ func (q *Query) WithNondeterministicBuiltins(yes bool) *Query {
 	return q
 }
 
-// WithIncomingMetadata sets arbitrary metadata from the caller that can be
+// WithRequestMetadata sets arbitrary metadata from the caller that can be
 // used by wrapping projects. The data is stored but not directly used by
 // OPA's evaluation engine.
-func (q *Query) WithIncomingMetadata(m map[string]any) *Query {
-	q.incomingMetadata = m
+func (q *Query) WithRequestMetadata(m map[string]any) *Query {
+	q.requestMetadata = m
 	return q
 }
 
-// WithOutgoingMetadata sets a map that wrapping projects can populate during
+// WithResponseMetadata sets a map that wrapping projects can populate during
 // evaluation to include additional fields in the API response.
-func (q *Query) WithOutgoingMetadata(m map[string]any) *Query {
-	q.outgoingMetadata = m
+func (q *Query) WithResponseMetadata(m map[string]any) *Query {
+	q.responseMetadata = m
 	return q
 }
 
@@ -431,8 +431,8 @@ func (q *Query) PartialRun(ctx context.Context) (partials []ast.Body, support []
 		builtinErrors:    &builtinErrors{},
 		printHook:        q.printHook,
 		strictObjects:    q.strictObjects,
-		incomingMetadata: q.incomingMetadata,
-		outgoingMetadata: q.outgoingMetadata,
+		requestMetadata:  q.requestMetadata,
+		responseMetadata: q.responseMetadata,
 	}
 
 	if len(q.disableInlining) > 0 {
@@ -621,11 +621,11 @@ func (q *Query) Iter(ctx context.Context, iter func(QueryResult) error) error {
 		tracingOpts:                 q.tracingOpts,
 		strictObjects:               q.strictObjects,
 		roundTripper:                q.roundTripper,
-		incomingMetadata:            q.incomingMetadata,
-		outgoingMetadata:            q.outgoingMetadata,
+		requestMetadata:             q.requestMetadata,
+		responseMetadata:            q.responseMetadata,
 	}
-	if e.incomingMetadata == nil {
-		e.incomingMetadata = map[string]any{}
+	if e.requestMetadata == nil {
+		e.requestMetadata = map[string]any{}
 	}
 	e.caller = e
 	q.metrics.Timer(metrics.RegoQueryEval).Start()

--- a/v1/topdown/query.go
+++ b/v1/topdown/query.go
@@ -63,6 +63,8 @@ type Query struct {
 	tracingOpts                 tracing.Options
 	virtualCache                VirtualCache
 	baseCache                   BaseCache
+	incomingMetadata            map[string]any
+	outgoingMetadata            map[string]any
 }
 
 // Builtin represents a built-in function that queries can call.
@@ -333,6 +335,21 @@ func (q *Query) WithNondeterministicBuiltins(yes bool) *Query {
 	return q
 }
 
+// WithIncomingMetadata sets arbitrary metadata from the caller that can be
+// used by wrapping projects. The data is stored but not directly used by
+// OPA's evaluation engine.
+func (q *Query) WithIncomingMetadata(m map[string]any) *Query {
+	q.incomingMetadata = m
+	return q
+}
+
+// WithOutgoingMetadata sets a map that wrapping projects can populate during
+// evaluation to include additional fields in the API response.
+func (q *Query) WithOutgoingMetadata(m map[string]any) *Query {
+	q.outgoingMetadata = m
+	return q
+}
+
 // PartialRun executes partial evaluation on the query with respect to unknown
 // values. Partial evaluation attempts to evaluate as much of the query as
 // possible without requiring values for the unknowns set on the query. The
@@ -407,13 +424,15 @@ func (q *Query) PartialRun(ctx context.Context) (partials []ast.Body, support []
 			shallow:                  q.shallowInlining,
 			nondeterministicBuiltins: q.nondeterministicBuiltins,
 		},
-		genvarprefix:  q.genvarprefix,
-		runtime:       q.runtime,
-		indexing:      q.indexing,
-		earlyExit:     q.earlyExit,
-		builtinErrors: &builtinErrors{},
-		printHook:     q.printHook,
-		strictObjects: q.strictObjects,
+		genvarprefix:     q.genvarprefix,
+		runtime:          q.runtime,
+		indexing:         q.indexing,
+		earlyExit:        q.earlyExit,
+		builtinErrors:    &builtinErrors{},
+		printHook:        q.printHook,
+		strictObjects:    q.strictObjects,
+		incomingMetadata: q.incomingMetadata,
+		outgoingMetadata: q.outgoingMetadata,
 	}
 
 	if len(q.disableInlining) > 0 {
@@ -602,6 +621,11 @@ func (q *Query) Iter(ctx context.Context, iter func(QueryResult) error) error {
 		tracingOpts:                 q.tracingOpts,
 		strictObjects:               q.strictObjects,
 		roundTripper:                q.roundTripper,
+		incomingMetadata:            q.incomingMetadata,
+		outgoingMetadata:            q.outgoingMetadata,
+	}
+	if e.incomingMetadata == nil {
+		e.incomingMetadata = map[string]any{}
 	}
 	e.caller = e
 	q.metrics.Timer(metrics.RegoQueryEval).Start()


### PR DESCRIPTION
Wrapping projects can now attach custom metadata to Data API requests and have evaluation produce response metadata.

Introduce two distinct metadata paths:

  - Incoming metadata: parsed from extra top-level keys in the request
    body, made available to builtins via `BuiltinContext.IncomingMetadata`.
    Logged in the decision log under `Custom["incoming_metadata"]`.

  - Outgoing metadata: a separate map (`BuiltinContext.OutgoingMetadata`)
    that builtins can populate during evaluation. Only included in the
    API response and decision log if non-empty.

In vanilla OPA, no builtins write outgoing metadata, so responses are unchanged. The incoming metadata map is only allocated when the request carries extra fields; the outgoing map is one empty map per request.

To avoid conflicts with future OPA top-level keys, callers should use a namespaced key: `{"input": {...}, "com.example.opa/md": {...}}`.

```mermaid
flowchart LR
    req["POST /v1/data\n{input, com.example.opa/md}"]
    parse["readInputPostV1"]
    eval["topdown eval"]
    resp["API response"]
    dl["decision log"]

    req --> parse
    parse -- "reqMetadata" --> eval
    parse -- "reqMetadata" --> dl
    eval -- "respMetadata\n(if non-empty)" --> resp
    eval -- "respMetadata\n(if non-empty)" --> dl
    eval -. "BuiltinContext\n.IncomingMetadata\n.OutgoingMetadata" .-> eval
```
