### PR TITLE
build: add s390x support for wasm-enabled builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,12 +19,33 @@ GOVERSION ?= $(shell cat ./.go-version)
 GOARCH := $(shell go env GOARCH)
 GOOS := $(shell go env GOOS)
 
+GO_S390X = CGO_CFLAGS="-I$(WASMTIME_DIR)/include" CGO_LDFLAGS="-L$(WASMTIME_DIR)/lib -lwasmtime -Wl,-rpath,$(WASMTIME_DIR)/lib" CGO_ENABLED=$(CGO_ENABLED) GOFLAGS="$(GOFLAGS)" go
+ifeq ($(GOARCH),s390x)
+GO = $(GO_S390X)
+endif
+
 GO_TAGS ?=
 CONDITIONAL_WASM_TAG :=
 ifeq ($(WASM_ENABLED),1)
 CONDITIONAL_WASM_TAG := -tags=opa_wasm
 endif
 override GO_TAGS := $(GO_TAGS) $(CONDITIONAL_WASM_TAG)
+
+WASMTIME_VERSION ?= 39.0.1
+WASMTIME_DIR := $(shell pwd)/.wasmtime
+
+.PHONY: ensure-wasmtime-s390x
+ensure-wasmtime-s390x:
+ifeq ($(GOARCH),s390x)
+ifeq ($(WASM_ENABLED),1)
+	@echo "Ensuring Wasmtime C-API for s390x"
+	@if [ ! -f "$(WASMTIME_DIR)/lib/libwasmtime.a" ]; then \
+		mkdir -p $(WASMTIME_DIR); \
+		curl -L https://github.com/bytecodealliance/wasmtime/releases/download/v$(WASMTIME_VERSION)/wasmtime-v$(WASMTIME_VERSION)-s390x-linux-c-api.tar.xz \
+		| tar -xJ --strip-components=1 -C $(WASMTIME_DIR); \
+	fi
+endif
+endif
 
 GOLANGCI_LINT_VERSION := v2.9.0
 YAML_LINT_VERSION := 0.29.0
@@ -93,7 +114,7 @@ release-dir:
 	@echo $(RELEASE_DIR)
 
 .PHONY: generate
-generate: wasm-lib-build
+generate: ensure-wasmtime-s390x wasm-lib-build
 ifeq ($(GOOS),windows)
 	GOOS=linux go install github.com/josephspurrier/goversioninfo/cmd/goversioninfo@v1.5.0
 endif
@@ -126,15 +147,15 @@ e2e-prep:
 test-short: go-test-short
 
 .PHONY: go-build
-go-build: generate
+go-build: generate ensure-wasmtime-s390x
 	$(GO) build $(GO_TAGS) -o $(BIN) -ldflags $(LDFLAGS)
 
 .PHONY: go-test
-go-test: generate
+go-test: generate ensure-wasmtime-s390x
 	$(GO) test $(GO_TAGS),slow ./...
 
 .PHONY: go-test-short
-go-test-short: generate
+go-test-short: generate ensure-wasmtime-s390x
 	$(GO) test $(GO_TAGS) -short ./...
 
 .PHONY: race-detector
@@ -154,13 +175,24 @@ perf-noisy: generate
 	$(GO) test $(GO_TAGS),slow,noisy $(GO_TEST_TIMEOUT) -run=- -bench=. -benchmem ./...
 
 .PHONY: wasm-sdk-e2e-test
-wasm-sdk-e2e-test: generate
+wasm-sdk-e2e-test: generate ensure-wasmtime-s390x
 	$(GO) test $(GO_TAGS),slow,wasm_sdk_e2e $(GO_TEST_TIMEOUT) ./internal/wasm/sdk/test/e2e
 
 .PHONY: check
 check:
 ifeq ($(DOCKER_RUNNING), 1)
-	$(DOCKER) run --rm -v $(shell pwd):/app:ro,Z -w /app golangci/golangci-lint:${GOLANGCI_LINT_VERSION} golangci-lint run -v
+    ifeq ($(GOARCH),s390x)
+		@# ON S390X: Check if linter exists, install if missing, then run natively
+		@if ! command -v golangci-lint >/dev/null; then \
+			echo "s390x detected: Installing golangci-lint binary..."; \
+			curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b `go env GOPATH`/bin ${GOLANGCI_LINT_VERSION}; \
+		fi
+		@# Use the binary we just confirmed/installed
+		golangci-lint run
+    else
+		@# ON INTEL/ARM: Keep the original Docker-based linting
+		docker run --rm -v $(shell pwd):/app:ro,Z -w /app golangci/golangci-lint:${GOLANGCI_LINT_VERSION} golangci-lint run -v
+    endif
 else
 	@echo "Docker not installed or running. Skipping golangci run."
 endif
@@ -168,7 +200,17 @@ endif
 .PHONY: fmt
 fmt:
 ifeq ($(DOCKER_RUNNING), 1)
-	$(DOCKER) run --rm -v $(shell pwd):/app:Z -w /app golangci/golangci-lint:${GOLANGCI_LINT_VERSION} golangci-lint run -v --fix
+    ifeq ($(GOARCH),s390x)
+		@# ON S390X: Install if missing, then run with --fix to actually format
+		@if ! command -v golangci-lint >/dev/null; then \
+			echo "s390x detected: Installing golangci-lint binary..."; \
+			curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b `go env GOPATH`/bin ${GOLANGCI_LINT_VERSION}; \
+		fi
+		golangci-lint run --fix
+    else
+		@# ON INTEL/ARM: Original Docker behavior with fix enabled
+		docker run --rm -v $(shell pwd):/app:Z -w /app golangci/golangci-lint:${GOLANGCI_LINT_VERSION} golangci-lint run -v --fix
+    endif
 else
 	@echo "Docker not installed or running. Skipping golangci run."
 endif
@@ -214,12 +256,16 @@ deb:
 ######################################################
 
 .PHONY: wasm-test
-wasm-test: wasm-lib-test wasm-rego-test
+wasm-test: ensure-wasmtime-s390x wasm-lib-test wasm-rego-test
 
 .PHONY: wasm-lib-build
 wasm-lib-build:
 ifeq ($(DOCKER_RUNNING), 1)
+ifeq ($(GOARCH),s390x)
+	@$(MAKE) -C wasm builder build
+else
 	@$(MAKE) -C wasm ensure-builder build
+endif
 	cp wasm/_obj/opa.wasm internal/compiler/wasm/opa/opa.wasm
 	cp wasm/_obj/callgraph.csv internal/compiler/wasm/opa/callgraph.csv
 else
@@ -340,6 +386,24 @@ build-all-platforms: ci-build-linux ci-build-linux-static ci-build-darwin ci-bui
 
 .PHONY: image-quick
 image-quick: image-quick-$(GOARCH)
+
+.PHONY: image-s390x
+image-s390x: build
+	$(DOCKER) build \
+               -t $(DOCKER_IMAGE):$(VERSION) \
+               --build-arg BASE=gcr.io/distroless/cc \
+               --platform linux/s390x \
+               .
+
+.PHONY: image-s390x-static
+image-s390x-static:
+	@$(MAKE) build GOOS=linux WASM_ENABLED=0 CGO_ENABLED=0 BIN=opa_linux_s390x_static
+	$(DOCKER) build \
+               -t $(DOCKER_IMAGE):$(VERSION) \
+               --build-arg BASE=gcr.io/distroless/cc \
+               --build-arg BIN_SUFFIX=_static \
+               --platform linux/s390x \
+               .
 
 # % = arch
 .PHONY: image-quick-%

--- a/build/run-wasm-rego-tests.sh
+++ b/build/run-wasm-rego-tests.sh
@@ -69,13 +69,19 @@ function run_testcases {
     # NOTE(tsandall): background the container because the interrupt trap does
     # not run otherwise.
     purge_testrun_container
+
+    NODE_IMAGE="node:14"
+    if [[ "$(uname -m)" == "s390x" ]]; then
+        NODE_IMAGE="node:14-bullseye"
+    fi
+
     docker run \
         --rm \
         --name $TESTRUN_CONTAINER_NAME \
         --volumes-from $TESTGEN_CONTAINER_NAME:z \
         -e VERBOSE=$VERBOSE \
         -w /scratch \
-        node:14 \
+        ${NODE_IMAGE} \
         sh -c 'tar xzf \
             /src/.go/cache/testcases.tar.gz \
             && node test.js opa.wasm' &

--- a/wasm/Dockerfile
+++ b/wasm/Dockerfile
@@ -19,7 +19,11 @@ RUN apt-get update && \
       libc++-21-dev \
       libc++abi-21-dev \
       lld-21 && \
-    update-alternatives --install /usr/bin/ld ld /usr/bin/lld-21 90 && \
+    if [ "$(uname -m)" = "s390x" ]; then \
+        update-alternatives --install /usr/bin/ld ld /usr/bin/ld.bfd 90; \
+    else \
+        update-alternatives --install /usr/bin/ld ld /usr/bin/lld-21 90; \
+    fi && \
     update-alternatives --install /usr/bin/cc cc /usr/bin/clang-21 90 && \
     update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-21 90
 

--- a/wasm/Makefile
+++ b/wasm/Makefile
@@ -106,7 +106,11 @@ endif
 test:
 ifeq ($(USE_DOCKER), 1)
 	@$(DOCKER) run $(DOCKER_FLAGS) -v $(CURDIR):/src:Z $(WASM_BUILDER_IMAGE) make $(WASM_OBJ_DIR)/opa-test.wasm
-	@$(DOCKER) run $(DOCKER_FLAGS) -e VERBOSE -v $(CURDIR):/src:Z -w /src node:$(WASM_TEST_NODE_VERSION) node test.js $(WASM_OBJ_DIR)/opa-test.wasm
+	@NODE_IMAGE="node:$(WASM_TEST_NODE_VERSION)"; \
+	if [ "$$(uname -m)" = "s390x" ]; then \
+		NODE_IMAGE="node:$(WASM_TEST_NODE_VERSION)-bullseye"; \
+	fi; \
+	$(DOCKER) run $(DOCKER_FLAGS) -e VERBOSE -v $(CURDIR):/src:Z -w /src $$NODE_IMAGE node test.js $(WASM_OBJ_DIR)/opa-test.wasm
 else
 	@$(MAKE) $(WASM_OBJ_DIR)/opa-test.wasm
 	@node test.js $(WASM_OBJ_DIR)/opa-test.wasm


### PR DESCRIPTION
Add s390x-specific handling to the build and test flow so wasm-enabled targets work on linux s390x systems.

On s390x, the usual toolchain and container assumptions used by OPA do not all hold. The standard golangci-lint container image is not available for s390x, so lint-related targets install and run the binary natively instead. Wasm-enabled builds require the Wasmtime C API, so the build logic ensures the correct s390x release artifact is downloaded and used when needed.

The wasm build and test flow also needs platform-specific runtime adjustments. Node.js-based wasm tests use node:14-bullseye because the default node:14 image is not published for s390x. The wasm builder uses ld.bfd on s390x because lld does not yet provide the linker support required by this build flow.

These changes make OPA's local build and wasm test workflow behave correctly on s390x while preserving existing behavior on other architectures.

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

* You have read the project's
  [guidelines on AI tool use](https://www.openpolicyagent.org/docs/contrib-code#ai-guidelines).

For more information on contributing to OPA see our
[Contributing Guide](https://www.openpolicyagent.org/docs/contributing/)
for high-level contributing guidelines and development setup.
(See the [Developer Certificate of Origin](https://www.openpolicyagent.org/docs/contrib-code/#developer-certificate-of-origin)
section for specifics on signing off a commit.)

-->

### Why the changes in this PR are needed?

<!--
Include a short description of WHY the changes were made.
-->

### What are the changes in this PR?

<!--
Include a short description of WHAT changes were made.
-->

### Notes to assist PR review:

<!--
Here you can add information you think will help the reviewer(s).
-->

### Further comments:

<!--
Here you can include links to additional resources related to the changes, discuss your solution, other approaches you considered etc.
-->
