### PR TITLE
website: Copy button improvements

### DIFF
--- a/docs/src/components/CopyPageMarkdown/index.jsx
+++ b/docs/src/components/CopyPageMarkdown/index.jsx
@@ -2,6 +2,9 @@ import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from
 import { createPortal } from "react-dom";
 
 import BrowserOnly from "@docusaurus/BrowserOnly";
+import IconCopy from "@theme/Icon/Copy";
+import IconSuccess from "@theme/Icon/Success";
+
 import styles from "./styles.module.css";
 
 export default function CopyPageMarkdown() {
@@ -136,6 +139,9 @@ function CopyButton() {
         title={label}
         aria-label={label}
       >
+        <span className={styles.icons} aria-hidden="true">
+          {copied ? <IconSuccess /> : <IconCopy />}
+        </span>
         {label}
       </button>
     </div>

--- a/docs/src/components/CopyPageMarkdown/styles.module.css
+++ b/docs/src/components/CopyPageMarkdown/styles.module.css
@@ -1,7 +1,21 @@
 .wrapper {
   margin: 0.75rem 0 1rem;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.wrapper button {
+  padding-left: 0.5rem;
 }
 
 .icons {
-  display: flex;
+  display: inline-flex;
+  align-items: center;
+  margin-right: 0.35rem;
+  vertical-align: middle;
+}
+
+.icons svg {
+  width: 1rem;
+  height: 1rem;
 }

--- a/docs/src/components/CopyPageMarkdown/styles.module.css
+++ b/docs/src/components/CopyPageMarkdown/styles.module.css
@@ -2,6 +2,6 @@
   margin: 0.75rem 0 1rem;
 }
 
-.wrapper button {
-    font-size: 0.75rem;
+.icons {
+  display: flex;
 }


### PR DESCRIPTION
Reverts https://github.com/open-policy-agent/opa/pull/8568 and addresses the issue with the button.

FF left, safari right:

https://github.com/user-attachments/assets/2163b8a1-9368-4f90-9fe8-af7f6303483c

