### PR TITLE
builtins: Add uri.parse and uri.is_valid built in functions

### DIFF
--- a/builtin_metadata.json
+++ b/builtin_metadata.json
@@ -244,6 +244,10 @@
       "units.parse",
       "units.parse_bytes"
     ],
+    "uri": [
+      "uri.is_valid",
+      "uri.parse"
+    ],
     "uuid": [
       "uuid.parse",
       "uuid.rfc4122"
@@ -27072,6 +27076,46 @@
       "type": "string"
     },
     "wasm": true
+  },
+  "uri.is_valid": {
+    "args": [
+      {
+        "description": "the URI string to validate",
+        "name": "uri",
+        "type": "string"
+      }
+    ],
+    "available": [
+      "edge"
+    ],
+    "description": "Returns true if the input can be parsed as a URI.",
+    "introduced": "edge",
+    "result": {
+      "description": "true if `uri` is a valid URI",
+      "name": "result",
+      "type": "boolean"
+    },
+    "wasm": false
+  },
+  "uri.parse": {
+    "args": [
+      {
+        "description": "the URI string to parse",
+        "name": "uri",
+        "type": "string"
+      }
+    ],
+    "available": [
+      "edge"
+    ],
+    "description": "Parses a URI and returns an object containing its components according to RFC 3986. Empty components are omitted. In addition to the standard components, `raw_query` is returned for use with `urlquery` builtins, and `raw_path` is returned to allow detection of path-based exploits using percent-encoded characters.",
+    "introduced": "edge",
+    "result": {
+      "description": "object containing URI components",
+      "name": "output",
+      "type": "object[string: string]"
+    },
+    "wasm": false
   },
   "urlquery.decode": {
     "args": [

--- a/builtin_metadata.json
+++ b/builtin_metadata.json
@@ -27091,7 +27091,7 @@
     "description": "Returns true if the input can be parsed as a URI.",
     "introduced": "edge",
     "result": {
-      "description": "true if `uri` is a valid URI",
+      "description": "true if `uri` is a valid URI, false otherwise",
       "name": "result",
       "type": "boolean"
     },

--- a/capabilities.json
+++ b/capabilities.json
@@ -4701,6 +4701,42 @@
       }
     },
     {
+      "name": "uri.is_valid",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "boolean"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "uri.parse",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "dynamic": {
+            "key": {
+              "type": "string"
+            },
+            "value": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "type": "function"
+      }
+    },
+    {
       "name": "urlquery.decode",
       "decl": {
         "args": [

--- a/v1/ast/builtins.go
+++ b/v1/ast/builtins.go
@@ -2067,7 +2067,7 @@ var URIIsValid = &Builtin{
 		types.Args(
 			types.Named("uri", types.S).Description("the URI string to validate"),
 		),
-		types.Named("result", types.B).Description("true if `uri` is a valid URI"),
+		types.Named("result", types.B).Description("true if `uri` is a valid URI, false otherwise"),
 	),
 	CanSkipBctx: true,
 }

--- a/v1/ast/builtins.go
+++ b/v1/ast/builtins.go
@@ -174,6 +174,8 @@ var DefaultBuiltins = [...]*Builtin{
 	URLQueryEncode,
 	URLQueryEncodeObject,
 	URLQueryDecodeObject,
+	URIParse,
+	URIIsValid,
 	YAMLMarshal,
 	YAMLUnmarshal,
 	YAMLIsValid,
@@ -2040,6 +2042,33 @@ var URLQueryDecodeObject = &Builtin{
 			types.NewArray(nil, types.S)))).Description("the resulting object"),
 	),
 	Categories:  catEncoding,
+	CanSkipBctx: true,
+}
+
+var URIParse = &Builtin{
+	Name: "uri.parse",
+	Description: "Parses a URI and returns an object containing its components according to RFC 3986. " +
+		"Empty components are omitted. " +
+		"In addition to the standard components, `raw_query` is returned for use with `urlquery` builtins, " +
+		"and `raw_path` is returned to allow detection of path-based exploits using percent-encoded characters.",
+	Decl: types.NewFunction(
+		types.Args(
+			types.Named("uri", types.S).Description("the URI string to parse"),
+		),
+		types.Named("output", types.NewObject(nil, types.NewDynamicProperty(types.S, types.S))).Description("object containing URI components"),
+	),
+	CanSkipBctx: true,
+}
+
+var URIIsValid = &Builtin{
+	Name:        "uri.is_valid",
+	Description: "Returns true if the input can be parsed as a URI.",
+	Decl: types.NewFunction(
+		types.Args(
+			types.Named("uri", types.S).Description("the URI string to validate"),
+		),
+		types.Named("result", types.B).Description("true if `uri` is a valid URI"),
+	),
 	CanSkipBctx: true,
 }
 

--- a/v1/ast/interning.go
+++ b/v1/ast/interning.go
@@ -341,6 +341,8 @@ func init() {
 		"data", "input", "result", "keywords", "path", "v1", "error", "partial",
 		// HTTP
 		"code", "message", "status_code", "method", "url", "uri", "body", "raw_body", "headers", "query_params",
+		// URI
+		"scheme", "hostname", "port", "raw_path", "raw_query", "fragment",
 		// JWT
 		"enc", "cty", "iss", "exp", "nbf", "aud", "secret", "cert",
 		// Decisions

--- a/v1/test/cases/testdata/v1/uribuiltins/test-uribuiltins-0001.yaml
+++ b/v1/test/cases/testdata/v1/uribuiltins/test-uribuiltins-0001.yaml
@@ -1,0 +1,126 @@
+---
+cases:
+  - note: uribuiltins/parse full url
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p := uri.parse("https://example.com:8080/api?q=1#top")
+    data: {}
+    want_result:
+      - x:
+          scheme: https
+          hostname: example.com
+          port: "8080"
+          path: /api
+          raw_path: /api
+          raw_query: q=1
+          fragment: top
+  - note: uribuiltins/parse without port
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p := uri.parse("https://example.com/path")
+    data: {}
+    want_result:
+      - x:
+          scheme: https
+          hostname: example.com
+          path: /path
+          raw_path: /path
+  - note: uribuiltins/parse without query or fragment
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p := uri.parse("https://example.com:443/path")
+    data: {}
+    want_result:
+      - x:
+          scheme: https
+          hostname: example.com
+          port: "443"
+          path: /path
+          raw_path: /path
+  - note: uribuiltins/parse without path
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p := uri.parse("https://example.com?q=1#frag")
+    data: {}
+    want_result:
+      - x:
+          scheme: https
+          hostname: example.com
+          raw_query: q=1
+          fragment: frag
+  - note: uribuiltins/parse ipv6 hostname
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p := uri.parse("http://[::1]:8080/path")
+    data: {}
+    want_result:
+      - x:
+          scheme: http
+          hostname: "::1"
+          port: "8080"
+          path: /path
+          raw_path: /path
+  - note: uribuiltins/parse percent-encoded path
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p := uri.parse("https://example.com/path%2Fwith%2Fslashes")
+    data: {}
+    want_result:
+      - x:
+          scheme: https
+          hostname: example.com
+          path: /path/with/slashes
+          raw_path: /path%2Fwith%2Fslashes
+  - note: uribuiltins/parse plain path raw_path matches path
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p := uri.parse("https://example.com/plain/path")
+    data: {}
+    want_result:
+      - x:
+          scheme: https
+          hostname: example.com
+          path: /plain/path
+          raw_path: /plain/path
+  - note: uribuiltins/parse empty string
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p := uri.parse("")
+    data: {}
+    want_result:
+      - x: {}
+  - note: uribuiltins/parse mailto uri
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p := uri.parse("mailto:user@example.com")
+    data: {}
+    want_result:
+      - x:
+          scheme: mailto

--- a/v1/test/cases/testdata/v1/uribuiltins/test-uribuiltins-0002.yaml
+++ b/v1/test/cases/testdata/v1/uribuiltins/test-uribuiltins-0002.yaml
@@ -1,0 +1,32 @@
+---
+cases:
+  - note: uribuiltins/is_valid true
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p := uri.is_valid("https://example.com/path?q=1")
+    data: {}
+    want_result:
+      - x: true
+  - note: uribuiltins/is_valid empty string
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p := uri.is_valid("")
+    data: {}
+    want_result:
+      - x: false
+  - note: uribuiltins/is_valid invalid
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p := uri.is_valid("http://[invalid")
+    data: {}
+    want_result:
+      - x: false

--- a/v1/topdown/uri.go
+++ b/v1/topdown/uri.go
@@ -1,0 +1,74 @@
+// Copyright 2026 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package topdown
+
+import (
+	"cmp"
+	"net/url"
+
+	"github.com/open-policy-agent/opa/v1/ast"
+	"github.com/open-policy-agent/opa/v1/topdown/builtins"
+)
+
+func builtinURIParse(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term) error) error {
+	str, err := builtins.StringOperand(operands[0].Value, 1)
+	if err != nil {
+		return err
+	}
+
+	parsed, err := url.Parse(string(str))
+	if err != nil {
+		return err
+	}
+
+	obj := ast.NewObject()
+
+	if parsed.Scheme != "" {
+		obj.Insert(ast.StringTerm("scheme"), ast.StringTerm(parsed.Scheme))
+	}
+	if hostname := parsed.Hostname(); hostname != "" {
+		obj.Insert(ast.StringTerm("hostname"), ast.StringTerm(hostname))
+	}
+	if port := parsed.Port(); port != "" {
+		obj.Insert(ast.StringTerm("port"), ast.StringTerm(port))
+	}
+	if parsed.Path != "" {
+		obj.Insert(ast.StringTerm("path"), ast.StringTerm(parsed.Path))
+		// raw_path is always set when path is present, so that users can
+		// rely on it being available for custom path normalization.
+		obj.Insert(ast.StringTerm("raw_path"), ast.StringTerm(cmp.Or(parsed.RawPath, parsed.Path)))
+	}
+	if parsed.RawQuery != "" {
+		// raw_query can be piped into urlquery.decode_object() for structured access
+		obj.Insert(ast.StringTerm("raw_query"), ast.StringTerm(parsed.RawQuery))
+	}
+	if parsed.Fragment != "" {
+		obj.Insert(ast.StringTerm("fragment"), ast.StringTerm(parsed.Fragment))
+	}
+
+	return iter(ast.NewTerm(obj))
+}
+
+func builtinURIIsValid(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term) error) error {
+	str, err := builtins.StringOperand(operands[0].Value, 1)
+	if err != nil {
+		return iter(ast.InternedTerm(false))
+	}
+
+	// Empty strings are technically valid relative references per RFC 3986,
+	// but are rejected here to avoid unexpected results for policy use cases.
+	if len(str) == 0 {
+		return iter(ast.InternedTerm(false))
+	}
+
+	_, err = url.Parse(string(str))
+
+	return iter(ast.InternedTerm(err == nil))
+}
+
+func init() {
+	RegisterBuiltinFunc(ast.URIParse.Name, builtinURIParse)
+	RegisterBuiltinFunc(ast.URIIsValid.Name, builtinURIIsValid)
+}

--- a/v1/topdown/uri.go
+++ b/v1/topdown/uri.go
@@ -26,26 +26,26 @@ func builtinURIParse(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term
 	obj := ast.NewObject()
 
 	if parsed.Scheme != "" {
-		obj.Insert(ast.StringTerm("scheme"), ast.StringTerm(parsed.Scheme))
+		obj.Insert(ast.InternedTerm("scheme"), ast.StringTerm(parsed.Scheme))
 	}
 	if hostname := parsed.Hostname(); hostname != "" {
-		obj.Insert(ast.StringTerm("hostname"), ast.StringTerm(hostname))
+		obj.Insert(ast.InternedTerm("hostname"), ast.StringTerm(hostname))
 	}
 	if port := parsed.Port(); port != "" {
-		obj.Insert(ast.StringTerm("port"), ast.StringTerm(port))
+		obj.Insert(ast.InternedTerm("port"), ast.StringTerm(port))
 	}
 	if parsed.Path != "" {
-		obj.Insert(ast.StringTerm("path"), ast.StringTerm(parsed.Path))
+		obj.Insert(ast.InternedTerm("path"), ast.StringTerm(parsed.Path))
 		// raw_path is always set when path is present, so that users can
 		// rely on it being available for custom path normalization.
-		obj.Insert(ast.StringTerm("raw_path"), ast.StringTerm(cmp.Or(parsed.RawPath, parsed.Path)))
+		obj.Insert(ast.InternedTerm("raw_path"), ast.StringTerm(cmp.Or(parsed.RawPath, parsed.Path)))
 	}
 	if parsed.RawQuery != "" {
 		// raw_query can be piped into urlquery.decode_object() for structured access
-		obj.Insert(ast.StringTerm("raw_query"), ast.StringTerm(parsed.RawQuery))
+		obj.Insert(ast.InternedTerm("raw_query"), ast.StringTerm(parsed.RawQuery))
 	}
 	if parsed.Fragment != "" {
-		obj.Insert(ast.StringTerm("fragment"), ast.StringTerm(parsed.Fragment))
+		obj.Insert(ast.InternedTerm("fragment"), ast.StringTerm(parsed.Fragment))
 	}
 
 	return iter(ast.NewTerm(obj))


### PR DESCRIPTION
Examples of things this is useful for:
- Implementing policy around AI coding tool calls (permitted domains etc)
- Validating SPIFFE IDs

Fixes https://github.com/open-policy-agent/opa/issues/8263
