### PR TITLE
docs: fix input value type in not undefined example

### DIFF
--- a/docs/docs/policy-reference/keywords/_examples/not/undefined/input.json
+++ b/docs/docs/policy-reference/keywords/_examples/not/undefined/input.json
@@ -1,4 +1,4 @@
 {
   "e_mail": "oops@example.com",
-  "age": "20"
+  "age": 20
 }


### PR DESCRIPTION
### Why the changes in this PR are needed?

When looking at the docs for the `not` keyword example, I was confused why the `deny` rule wasn't including the "under 18" error if I changed the age in the input. Turns out it was a string so that was never getting triggered.

### What are the changes in this PR?

Changes the value of `age` in the input for the `not` example for an undefined value in the docs.