### PR TITLE
plugins: Ensure plugin status functions don't hang after manager is stopped

### DIFF
--- a/v1/plugins/plugins.go
+++ b/v1/plugins/plugins.go
@@ -206,6 +206,8 @@ type Manager struct {
 	mtx                          sync.Mutex
 	pluginStatusCh               chan pluginStatusMsg
 	stopPluginStatusCh           chan chan struct{}
+	pluginStatusDoneCh           chan struct{}
+	finalPluginStatus            map[string]*Status
 	initBundles                  map[string]*bundle.Bundle
 	initFiles                    loader.Result
 	maxErrors                    int
@@ -535,6 +537,7 @@ func New(raw []byte, id string, store storage.Store, opts ...func(*Manager)) (*M
 		extraRoutes:           map[string]ExtraRoute{},
 		pluginStatusCh:        make(chan pluginStatusMsg),
 		stopPluginStatusCh:    make(chan chan struct{}),
+		pluginStatusDoneCh:    make(chan struct{}),
 	}
 
 	for _, f := range opts {
@@ -689,7 +692,11 @@ func (m *Manager) Register(name string, plugin Plugin) {
 		plugin: plugin,
 	})
 	m.mtx.Unlock()
-	m.pluginStatusCh <- statusInitPlugin{name: name}
+
+	select {
+	case m.pluginStatusCh <- statusInitPlugin{name: name}:
+	case <-m.pluginStatusDoneCh:
+	}
 }
 
 // Plugins returns the list of plugins registered with the manager.
@@ -970,20 +977,30 @@ func (m *Manager) Reconfigure(newCfg *config.Config) error {
 // PluginStatus returns the current statuses of any plugins registered.
 func (m *Manager) PluginStatus() map[string]*Status {
 	reply := make(chan map[string]*Status, 1)
-	m.pluginStatusCh <- statusQuery{reply: reply}
-	return <-reply
+	select {
+	case m.pluginStatusCh <- statusQuery{reply: reply}:
+		return <-reply
+	case <-m.pluginStatusDoneCh:
+		return m.finalPluginStatus
+	}
 }
 
 // RegisterPluginStatusListener registers a StatusListener to be
 // called when plugin status updates occur.
 func (m *Manager) RegisterPluginStatusListener(name string, listener StatusListener) {
-	m.pluginStatusCh <- statusRegisterListener{name: name, listener: listener}
+	select {
+	case m.pluginStatusCh <- statusRegisterListener{name: name, listener: listener}:
+	case <-m.pluginStatusDoneCh:
+	}
 }
 
 // UnregisterPluginStatusListener removes a StatusListener registered with the
 // same name.
 func (m *Manager) UnregisterPluginStatusListener(name string) {
-	m.pluginStatusCh <- statusUnregisterListener{name: name}
+	select {
+	case m.pluginStatusCh <- statusUnregisterListener{name: name}:
+	case <-m.pluginStatusDoneCh:
+	}
 }
 
 // UpdatePluginStatus updates a named plugins status. Any registered
@@ -991,8 +1008,11 @@ func (m *Manager) UnregisterPluginStatusListener(name string) {
 // plugins.
 func (m *Manager) UpdatePluginStatus(pluginName string, status *Status) {
 	done := make(chan struct{})
-	m.pluginStatusCh <- statusUpdate{name: pluginName, status: status, done: done}
-	<-done
+	select {
+	case m.pluginStatusCh <- statusUpdate{name: pluginName, status: status, done: done}:
+		<-done
+	case <-m.pluginStatusDoneCh:
+	}
 }
 
 func copyPluginStatus(src map[string]*Status) map[string]*Status {
@@ -1299,6 +1319,11 @@ func (m *Manager) sendOPAUpdateLoop(ctx context.Context) {
 func (m *Manager) pluginStatusLoop() {
 	status := map[string]*Status{}
 	listeners := map[string]StatusListener{}
+
+	defer func() {
+		m.finalPluginStatus = copyPluginStatus(status)
+		close(m.pluginStatusDoneCh)
+	}()
 
 	for {
 		select {

--- a/v1/plugins/plugins_test.go
+++ b/v1/plugins/plugins_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"reflect"
 	"testing"
+	"time"
 
 	internal_tracing "github.com/open-policy-agent/opa/internal/distributedtracing"
 	"github.com/open-policy-agent/opa/internal/storage/mock"
@@ -456,6 +457,114 @@ func TestPluginManagerServerInitialized(t *testing.T) {
 		t.Fatal("expected ServerInitializedChannel to be open and have no messages")
 	default:
 		break
+	}
+}
+
+func TestUpdatePluginStatusAfterStop(t *testing.T) {
+	m, err := New([]byte{}, "test", inmem.New())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	m.Register("p1", &testPlugin{m})
+
+	if err := m.Start(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	m.Stop(t.Context())
+
+	// Must not hang.
+	done := make(chan struct{})
+	go func() {
+		m.UpdatePluginStatus("p1", &Status{State: StateNotReady})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(1 * time.Second):
+		t.Fatal("UpdatePluginStatus hung after Stop")
+	}
+}
+
+func TestPluginStatusAfterStop(t *testing.T) {
+	m, err := New([]byte{}, "test", inmem.New())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	m.Register("p1", &testPlugin{m})
+
+	if err := m.Start(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	m.Stop(t.Context())
+
+	done := make(chan struct{})
+	var status map[string]*Status
+	go func() {
+		status = m.PluginStatus()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(1 * time.Second):
+		t.Fatal("PluginStatus hung after Stop")
+	}
+
+	// testPlugin.Stop() reports StateNotReady
+	if s, ok := status["p1"]; !ok {
+		t.Fatal("expected status for p1")
+	} else if s.State != StateNotReady {
+		t.Fatalf("expected StateNotReady, got %v", s.State)
+	}
+}
+
+func TestRegisterAfterStop(t *testing.T) {
+	m, err := New([]byte{}, "test", inmem.New())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := m.Start(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	m.Stop(t.Context())
+
+	done := make(chan struct{})
+	go func() {
+		m.Register("late", &testPlugin{m})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(1 * time.Second):
+		t.Fatal("Register hung after Stop")
+	}
+}
+
+func TestRegisterListenerAfterStop(t *testing.T) {
+	m, err := New([]byte{}, "test", inmem.New())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := m.Start(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	m.Stop(t.Context())
+
+	done := make(chan struct{})
+	go func() {
+		m.RegisterPluginStatusListener("l1", func(map[string]*Status) {})
+		m.UnregisterPluginStatusListener("l1")
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(1 * time.Second):
+		t.Fatal("RegisterPluginStatusListener hung after Stop")
 	}
 }
 


### PR DESCRIPTION
As [noticed in opa-envoy-plugin](https://github.com/open-policy-agent/opa-envoy-plugin/actions/runs/25171518551/job/73791953836?pr=835#step:3:574) when bumping OPA dep to v1.16.0.