### PR TITLE
benchmarks: clean up plots

### DIFF
--- a/clay/src/opa_bench/charts.clj
+++ b/clay/src/opa_bench/charts.clj
@@ -49,8 +49,11 @@
                                        :url     (str "https://github.com/open-policy-agent/opa/commit/"
                                                      (:commit r))}])))
                           bench-rows)
+        all-x      (mapv #(or (:tag %) (subs (:commit %) 0 7)) bench-rows)
+        tick-vals  (filterv some? (mapv :tag bench-rows))
         layout     {:yaxis    {:type "log" :title (str "Relative to " data/latest-tag)}
-                    :xaxis    {:title "" :tickangle -45}
+                    :xaxis    {:title "" :tickangle -45
+                               :tickvals tick-vals :ticktext tick-vals}
                     :hovermode "x unified"
                     :height   500
                     :margin   {:b 120}

--- a/clay/src/opa_bench/charts.clj
+++ b/clay/src/opa_bench/charts.clj
@@ -11,7 +11,8 @@
                         (sort-by :date))
         by-measure (group-by :measure bench-rows)
         tag-xs     (into #{} (keep :tag) bench-rows)
-        traces     (for [[measure rows] by-measure]
+        traces     (for [[measure rows] by-measure
+                         :when (some #(pos? (:value %)) rows)]
                      (let [basis-val (get data/basis [pkg bench-name measure] 1)
                            basis-val (if (zero? basis-val) 1 basis-val)]
                        {:x    (mapv #(or (:tag %) (subs (:commit %) 0 7)) rows)


### PR DESCRIPTION
Slightly cleaner display: Before,

<img width="1321" height="599" alt="image" src="https://github.com/user-attachments/assets/c5465f0d-91d6-4cac-bb40-35855bdf0e94" />


After:

<img width="1289" height="625" alt="image" src="https://github.com/user-attachments/assets/e54dbb4e-bc93-4149-9f80-16a355a75605" />