### PR TITLE
benchmarks: tweak tooltip background colour

### DIFF
--- a/clay/src/opa_bench/charts.clj
+++ b/clay/src/opa_bench/charts.clj
@@ -54,6 +54,8 @@
         layout     {:yaxis    {:type "log" :title (str "Relative to " data/latest-tag)}
                     :xaxis    {:title "" :tickangle -45
                                :tickvals tick-vals :ticktext tick-vals}
+                    :hoverlabel {:bgcolor "#eaffff" :bordercolor "#888"
+                                 :font {:family "Go Mono, monospace" :size 11 :color "#000"}}
                     :hovermode "x unified"
                     :height   500
                     :margin   {:b 120}


### PR DESCRIPTION
<img width="354" height="327" alt="image" src="https://github.com/user-attachments/assets/3e9d709d-6ed3-46cb-a632-5ab147639ae9" />