### PR TITLE
workflows: replace setup-zig with mise-action

### DIFF
--- a/.github/workflows/post-merge.yaml
+++ b/.github/workflows/post-merge.yaml
@@ -101,9 +101,13 @@ jobs:
       - name: Git Describe
         run: git describe --tags
 
-      - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
-          version: '0.15.2'
+          install: true
+          cache: true
+          mise_toml: |
+            [tools]
+            zig = "0.16.0"
 
       - id: go_version
         name: Read go version

--- a/.github/workflows/post-tag.yaml
+++ b/.github/workflows/post-tag.yaml
@@ -44,10 +44,13 @@ jobs:
         with:
           go-version: ${{ steps.go_version.outputs.go_version }}
           cache: false
-      - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
-          version: '0.15.2'
-          use-cache: false
+          install: true
+          cache: false
+          mise_toml: |
+            [tools]
+            zig = "0.16.0"
 
       - name: Git Describe
         run: git describe --tags

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -167,9 +167,13 @@ jobs:
       with:
         go-version: ${{ steps.go_version.outputs.go_version }}
       if: matrix.os != 'linux'
-    - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
+    - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
       with:
-        version: '0.15.2'
+        install: true
+        cache: true
+        mise_toml: |
+          [tools]
+          zig = "0.16.0"
       if: matrix.os == 'windows'
 
     - name: Download generated artifacts


### PR DESCRIPTION
The former seems dormant, and we need to deal with the node20 deprecation on github.
