### PR TITLE
Deploy edge prelease

### DIFF
--- a/.github/workflows/post-merge.yaml
+++ b/.github/workflows/post-merge.yaml
@@ -172,6 +172,45 @@ jobs:
           name: binaries-darwin
           path: _release
 
+  deploy-edge:
+    name: Deploy Edge Prerelease
+    runs-on: ubuntu-24.04
+    needs: [ release-build, release-build-darwin ]
+    permissions:
+      contents: write
+    steps:
+      - name: Check out code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Download release binaries
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: binaries-*
+          merge-multiple: true
+          path: _release
+
+      - name: Create or update edge prerelease
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Delete the previous edge release if it exists
+          gh release delete edge --yes --cleanup-tag || true
+
+          # Collect all OPA binaries from the release directory
+          ASSETS=()
+          for asset in _release/*/opa_*_*; do
+            ASSETS+=("$asset")
+          done
+
+          gh release create edge \
+            --prerelease \
+            --target ${{ github.sha }} \
+            --title "Edge (latest main)" \
+            --notes "Automated prerelease from the latest main branch commit ($(git rev-parse --short HEAD))." \
+            "${ASSETS[@]}"
+
   deploy-wasm-builder:
     name: Deploy WASM Builder
     runs-on: ubuntu-24.04

--- a/docs/static/_redirects
+++ b/docs/static/_redirects
@@ -80,6 +80,6 @@
 # Redirects relating to github asset downloads
 # -----------------------------------------------------------------------------
 
-/downloads/edge/*       https://opa-releases.s3.amazonaws.com/edge/:splat 200
+/downloads/edge/*       https://github.com/open-policy-agent/opa/releases/download/edge/:splat 200
 /downloads/latest/*     https://github.com/open-policy-agent/opa/releases/latest/download/:splat 200
 /downloads/*            https://github.com/open-policy-agent/opa/releases/download/:splat 200

--- a/docs/static/_redirects
+++ b/docs/static/_redirects
@@ -80,6 +80,6 @@
 # Redirects relating to github asset downloads
 # -----------------------------------------------------------------------------
 
-/downloads/edge/*       https://github.com/open-policy-agent/opa/releases/download/edge/:splat 200
+/downloads/edge/*       https://opa-releases.s3.amazonaws.com/edge/:splat 200
 /downloads/latest/*     https://github.com/open-policy-agent/opa/releases/latest/download/:splat 200
 /downloads/*            https://github.com/open-policy-agent/opa/releases/download/:splat 200


### PR DESCRIPTION
follow up to: https://github.com/open-policy-agent/opa/pull/8615

The S3 bucket containing the edge release binaries is no longer available. setup-opa relies on these binaries. This new `Deploy Edge Prelease` re-introduces edge release by publishing them as a Github pre-release instead. 

On every push to main, after the linux/windows/darwin release builds complete, a new deploy-edge job deletes any existing edge release and creates a fresh GitHub prerelease tagged edge with all OPA binaries attached.