### PR TITLE
Redirect to edge prelease

### DIFF
--- a/docs/static/_redirects
+++ b/docs/static/_redirects
@@ -80,6 +80,6 @@
 # Redirects relating to github asset downloads
 # -----------------------------------------------------------------------------
 
-/downloads/edge/*       https://opa-releases.s3.amazonaws.com/edge/:splat 200
+/downloads/edge/*        https://github.com/open-policy-agent/opa/releases/download/edge/:splat 200
 /downloads/latest/*     https://github.com/open-policy-agent/opa/releases/latest/download/:splat 200
 /downloads/*            https://github.com/open-policy-agent/opa/releases/download/:splat 200


### PR DESCRIPTION
follow up to: https://github.com/open-policy-agent/opa/pull/8626

🥳 https://github.com/open-policy-agent/opa/releases/tag/edge

```
gh release view edge --repo open-policy-agent/opa --json assets
```