### PR TITLE
post-merge: use and override `dev` tag

### DIFF
--- a/.github/workflows/post-merge.yaml
+++ b/.github/workflows/post-merge.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    tags-ignore:
+      - dev
 
 permissions:
   contents: read
@@ -172,8 +174,8 @@ jobs:
           name: binaries-darwin
           path: _release
 
-  deploy-edge:
-    name: Deploy Edge Prerelease
+  deploy-dev:
+    name: Deploy Dev Prerelease
     runs-on: ubuntu-24.04
     needs: [ release-build, release-build-darwin ]
     permissions:
@@ -182,7 +184,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          persist-credentials: false
+          persist-credentials: true
 
       - name: Download release binaries
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -191,12 +193,12 @@ jobs:
           merge-multiple: true
           path: _release
 
-      - name: Create or update edge prerelease
+      - name: Create or update dev prerelease
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          # Delete the previous edge release if it exists
-          gh release delete edge --yes --cleanup-tag || true
+          git tag -f dev
+          git push origin dev -f
 
           # Collect all OPA binaries from the release directory
           ASSETS=()
@@ -204,12 +206,16 @@ jobs:
             ASSETS+=("$asset")
           done
 
-          gh release create edge \
+          gh release create dev \
             --prerelease \
-            --target ${{ github.sha }} \
-            --title "Edge (latest main)" \
+            --title "Dev (latest main)" \
             --notes "Automated prerelease from the latest main branch commit ($(git rev-parse --short HEAD))." \
-            "${ASSETS[@]}"
+            "${ASSETS[@]}" || {
+            gh release edit dev \
+              --title "Dev (latest main)" \
+              --notes "Automated prerelease from the latest main branch commit ($(git rev-parse --short HEAD))."
+            gh release upload dev --clobber "${ASSETS[@]}"
+          }
 
   deploy-wasm-builder:
     name: Deploy WASM Builder


### PR DESCRIPTION
This is exactly what wasmtime does, maybe it works with immutable github releases.

This would work if pre-releases are not immutable. Let's hope they aren't 🤞 