### PR TITLE
ast: don't leak generated locals in ref type errors

### DIFF
--- a/v1/ast/compile.go
+++ b/v1/ast/compile.go
@@ -468,7 +468,7 @@ func NewCompiler() *Compiler {
 		{StageCheckSafetyRuleHeads, "compile_stage_check_safety_rule_heads", c.checkSafetyRuleHeads},
 		{StageCheckSafetyRuleBodies, "compile_stage_check_safety_rule_bodies", c.checkSafetyRuleBodies},
 		{StageRewriteEquals, "compile_stage_rewrite_equals", c.rewriteEquals},
-		{StageRewriteDynamicTerms, "compile_stage_rewrite_dynamic_terms", c.rewriteDynamicTerms},
+		{StageRewriteDynamicTerms, "compile_stage_rewrite_dynamic_terms", c.rewriteDynamicTerms},                       // stages before CheckTypes must not rewrite hoisted terms, see recordSubjectNoCopy
 		{StageRewriteTestRulesForTracing, "compile_stage_rewrite_test_rules_for_tracing", c.rewriteTestRuleEqualities}, // must run after RewriteDynamicTerms
 		{StageCheckRecursion, "compile_stage_check_recursion", c.checkRecursion},
 		{StageCheckTypes, "compile_stage_check_types", c.checkTypes}, // must be run after CheckRecursion
@@ -3725,7 +3725,7 @@ func (qc *queryCompiler) Compile(query Body) (Body, error) {
 		{StageRewriteWithValues, "query_compile_stage_rewrite_with_values", qc.rewriteWithModifiers},
 		{StageCheckUndefinedFuncs, "query_compile_stage_check_undefined_funcs", qc.checkUndefinedFuncs},
 		{StageCheckSafety, "query_compile_stage_check_safety", qc.checkSafety},
-		{StageRewriteDynamicTerms, "query_compile_stage_rewrite_dynamic_terms", qc.rewriteDynamicTerms},
+		{StageRewriteDynamicTerms, "query_compile_stage_rewrite_dynamic_terms", qc.rewriteDynamicTerms}, // see recordSubjectNoCopy
 		{StageCheckTypes, "query_compile_stage_check_types", qc.checkTypes},
 		{StageCheckUnsafeBuiltins, "query_compile_stage_check_unsafe_builtins", qc.checkUnsafeBuiltins},
 		{StageCheckDeprecatedBuiltins, "query_compile_stage_check_deprecated_builtins", qc.checkDeprecatedBuiltins},
@@ -5516,13 +5516,31 @@ type localVarGenerator struct {
 	subjects map[Var]Value
 }
 
-// recordSubject records that local stands in for value. The value is copied so
-// later rewrites can't mutate the compiled AST.
+// recordSubject records that local stands in for value. The value is copied, as
+// stages running between the caller and CheckTypes may rewrite it in place: a
+// composite subject recorded in RewriteExprTerms, say [x, input.y][i], has its
+// dynamic elements hoisted by the later RewriteDynamicTerms stage, which would
+// otherwise turn the recorded value into [__local5__, __local6__].
 func (l *localVarGenerator) recordSubject(local Var, value *Term) {
+	l.putSubject(local, CopyValue(value.Value))
+}
+
+// recordSubjectNoCopy records that local stands in for value, aliasing value
+// rather than copying it. Only callers in the RewriteDynamicTerms stage may use
+// this: only RewriteTestRulesForTracing and CheckRecursion run between that
+// stage and CheckTypes, and neither rewrites hoisted terms, so nothing can
+// mutate value before the mapping is read. Copying here instead would allocate
+// on every hoisted ref of every compile, for a map only read when a type error
+// is rendered.
+func (l *localVarGenerator) recordSubjectNoCopy(local Var, value *Term) {
+	l.putSubject(local, value.Value)
+}
+
+func (l *localVarGenerator) putSubject(local Var, value Value) {
 	if l.subjects == nil {
 		l.subjects = map[Var]Value{}
 	}
-	l.subjects[local] = CopyValue(value.Value)
+	l.subjects[local] = value
 }
 
 func newLocalVarGeneratorForModuleSet(sorted []string, modules map[string]*Module) *localVarGenerator {
@@ -6146,7 +6164,7 @@ func rewriteDynamicsOne(original *Expr, f *equalityFactory, term *Term, result B
 		generated.With = original.With
 		result.Append(generated)
 		connectGeneratedExprs(original, generated)
-		f.gen.recordSubject(generated.Operand(0).Value.(Var), term)
+		f.gen.recordSubjectNoCopy(generated.Operand(0).Value.(Var), term)
 		return result, result[len(result)-1].Operand(0)
 	case *Array:
 		for i := range v.Len() {
@@ -6176,21 +6194,21 @@ func rewriteDynamicsOne(original *Expr, f *equalityFactory, term *Term, result B
 		v.Body, extra = rewriteDynamicsComprehensionBody(original, f, v.Body, term)
 		result.Append(extra)
 		connectGeneratedExprs(original, extra)
-		f.gen.recordSubject(extra.Operand(0).Value.(Var), term)
+		f.gen.recordSubjectNoCopy(extra.Operand(0).Value.(Var), term)
 		return result, result[len(result)-1].Operand(0)
 	case *SetComprehension:
 		var extra *Expr
 		v.Body, extra = rewriteDynamicsComprehensionBody(original, f, v.Body, term)
 		result.Append(extra)
 		connectGeneratedExprs(original, extra)
-		f.gen.recordSubject(extra.Operand(0).Value.(Var), term)
+		f.gen.recordSubjectNoCopy(extra.Operand(0).Value.(Var), term)
 		return result, result[len(result)-1].Operand(0)
 	case *ObjectComprehension:
 		var extra *Expr
 		v.Body, extra = rewriteDynamicsComprehensionBody(original, f, v.Body, term)
 		result.Append(extra)
 		connectGeneratedExprs(original, extra)
-		f.gen.recordSubject(extra.Operand(0).Value.(Var), term)
+		f.gen.recordSubjectNoCopy(extra.Operand(0).Value.(Var), term)
 		return result, result[len(result)-1].Operand(0)
 	}
 	return result, term

--- a/v1/ast/compile.go
+++ b/v1/ast/compile.go
@@ -5522,7 +5522,7 @@ func (l *localVarGenerator) recordSubject(local Var, value *Term) {
 	if l.subjects == nil {
 		l.subjects = map[Var]Value{}
 	}
-	l.subjects[local] = value.Copy().Value
+	l.subjects[local] = CopyValue(value.Value)
 }
 
 func newLocalVarGeneratorForModuleSet(sorted []string, modules map[string]*Module) *localVarGenerator {
@@ -7445,7 +7445,7 @@ func rewriteRefErrVars(subjects map[Var]Value, vars ...map[Var]Var) varRewriter 
 	return func(node Ref) Ref {
 		i, _ := TransformVars(node.Copy(), func(v Var) (Value, error) {
 			if val, ok := subjects[v]; ok {
-				return NewTerm(val).Copy().Value, nil
+				return CopyValue(val), nil
 			}
 			for _, m := range vars {
 				if u, ok := m[v]; ok {

--- a/v1/ast/compile_bench_test.go
+++ b/v1/ast/compile_bench_test.go
@@ -1,9 +1,60 @@
 package ast
 
 import (
+	"fmt"
 	"strconv"
 	"testing"
 )
+
+func BenchmarkCompileModules(b *testing.B) {
+	// The choice of module set is somewhat arbitrary. These rules are
+	// representative of the ones that exercise the term-rewriting stages:
+	// composite ref subjects, dynamic ref operands and comprehensions all get
+	// hoisted into generated locals, so per-hoist work in those stages shows up
+	// here. BenchmarkRewriteDynamics covers one of them in isolation, but reuses
+	// the same bodies across iterations, so they are already rewritten after the
+	// first pass.
+	sizes := []int{1, 10, 100}
+
+	for _, size := range sizes {
+		b.Run(strconv.Itoa(size), func(b *testing.B) {
+			base := make(map[string]*Module, size)
+			for i := range size {
+				base[fmt.Sprintf("mod%d.rego", i)] = MustParseModule(fmt.Sprintf(`package bench.p%d
+
+allow if {
+	some x
+	input.users[x].roles[_] == "admin"
+	data.perms[input.tenant][x]
+	count([y | y := input.items[_]; y.n > 0]) > 2
+	input.a.b.c[input.i].d == data.z.w[input.j]
+}
+
+deny contains msg if {
+	msg := input.msgs[input.i].text
+	[1, 2][input.k]
+}
+`, i))
+			}
+
+			for b.Loop() {
+				// Compile rewrites modules in place, so every iteration needs
+				// its own copies. Copying is not what we're measuring.
+				b.StopTimer()
+				modules := make(map[string]*Module, len(base))
+				for name, module := range base {
+					modules[name] = module.Copy()
+				}
+				b.StartTimer()
+
+				c := NewCompiler()
+				if c.Compile(modules); c.Failed() {
+					b.Fatal(c.Errors)
+				}
+			}
+		})
+	}
+}
 
 func BenchmarkRewriteDynamics(b *testing.B) {
 	// The choice of query to use is somewhat arbitrary. This query is

--- a/v1/ast/compile_bench_test.go
+++ b/v1/ast/compile_bench_test.go
@@ -6,6 +6,10 @@ import (
 	"testing"
 )
 
+// Cost of recording generated locals for ref type errors, at 100 modules:
+// 9452905 ns/op   6487160 B/op   162824 allocs/op // not recorded
+// 9944902 ns/op   6751259 B/op   168040 allocs/op // every subject copied
+// 9578020 ns/op   6580108 B/op   163241 allocs/op // copied only where a later stage can rewrite it
 func BenchmarkCompileModules(b *testing.B) {
 	// The choice of module set is somewhat arbitrary. These rules are
 	// representative of the ones that exercise the term-rewriting stages:

--- a/v1/ast/compile_test.go
+++ b/v1/ast/compile_test.go
@@ -11538,6 +11538,14 @@ func TestQueryCompiler(t *testing.T) {
 			expected: errors.New("1 error occurred: 1:1: rego_type_error: undefined ref: [1, 2][input.x][j]"),
 		},
 		{
+			// A dynamic index term is rewritten before the local standing in for
+			// it is recorded, so a nested one must be rendered through both
+			// mappings rather than leaking the inner local.
+			note:     "nested dynamic index locals not leaked in type error",
+			q:        `[1, 2][input.a[input.b]][j]`,
+			expected: errors.New("1 error occurred: 1:1: rego_type_error: undefined ref: [1, 2][input.a[input.b]][j]"),
+		},
+		{
 			note:     "imports resolved without package",
 			q:        "abc",
 			pkg:      "",

--- a/v1/ast/term.go
+++ b/v1/ast/term.go
@@ -350,31 +350,40 @@ func (term *Term) Copy() *Term {
 	}
 
 	cpy := *term
-
-	switch v := term.Value.(type) {
-	case Null, Boolean, Number, String, Var:
-		cpy.Value = v
-	case Ref:
-		cpy.Value = v.Copy()
-	case *Array:
-		cpy.Value = v.Copy()
-	case Set:
-		cpy.Value = v.Copy()
-	case *object:
-		cpy.Value = v.Copy()
-	case *ArrayComprehension:
-		cpy.Value = v.Copy()
-	case *ObjectComprehension:
-		cpy.Value = v.Copy()
-	case *SetComprehension:
-		cpy.Value = v.Copy()
-	case *TemplateString:
-		cpy.Value = v.Copy()
-	case Call:
-		cpy.Value = v.Copy()
-	}
+	cpy.Value = CopyValue(term.Value)
 
 	return &cpy
+}
+
+// CopyValue returns a deep copy of v. The Value interface doesn't require a
+// Copy method, so this dispatches on the known value types. Values of any other
+// type are returned as-is.
+func CopyValue(v Value) Value {
+	switch v := v.(type) {
+	case Null, Boolean, Number, String, Var:
+		// Scalars are immutable, no copy needed.
+		return v
+	case Ref:
+		return v.Copy()
+	case *Array:
+		return v.Copy()
+	case Set:
+		return v.Copy()
+	case *object:
+		return v.Copy()
+	case *ArrayComprehension:
+		return v.Copy()
+	case *ObjectComprehension:
+		return v.Copy()
+	case *SetComprehension:
+		return v.Copy()
+	case *TemplateString:
+		return v.Copy()
+	case Call:
+		return v.Copy()
+	}
+
+	return v
 }
 
 // Equal returns true if this term equals the other term. Equality is


### PR DESCRIPTION
Fixes #8897

When a reference has a composite subject (e.g. [1, 2][i]) or a dynamic index term (e.g. [1, 2][input.x]), the compiler hoists that part of the ref into a generated local. Previously these locals leaked verbatim into type errors, e.g.:

    undefined ref: __localq0__[i][j]

The type checker's var rewriter only knew how to map user variables back (via RewrittenVars), so anonymous generated locals were rendered as-is.

Record a mapping from each generated ref-subject/dynamic-operand local back to the original term value (in localVarGenerator.subjects) and use it when rendering refs in type errors, so the original expression is shown instead:

    undefined ref: [1, 2][i][j]

