### PR TITLE
ucast: Quote SQL filter field identifiers

### DIFF
--- a/internal/ucast/ucast.go
+++ b/internal/ucast/ucast.go
@@ -82,6 +82,7 @@ func (u *UCASTNode) asSQL(cond *sqlbuilder.Cond, dialect string) (string, error)
 
 	switch {
 	case slices.Contains(fieldOps, operator) || uType == "field":
+		field = quoteField(cond.Args.Flavor, field)
 		switch value {
 		case nil:
 			return "", nil
@@ -96,7 +97,7 @@ func (u *UCASTNode) asSQL(cond *sqlbuilder.Cond, dialect string) (string, error)
 			}
 		default:
 			if fr, ok := value.(FieldRef); ok {
-				value = sqlbuilder.Raw(fr.Field)
+				value = sqlbuilder.Raw(quoteField(cond.Args.Flavor, fr.Field))
 			}
 		}
 		switch operator {
@@ -212,6 +213,46 @@ func (u *UCASTNode) asSQL(cond *sqlbuilder.Cond, dialect string) (string, error)
 	default:
 		return "", fmt.Errorf("unrecognized operator: %s", operator)
 	}
+}
+
+// quoteField quotes the segments of a dot-separated field reference that cannot
+// be emitted as bare SQL identifiers. Fields are built from partially evaluated
+// refs, so a dynamic key such as input.fruits[input.column] can put arbitrary
+// text in an identifier position. Segments that are already bare identifiers are
+// left alone: quoting them would make them case-sensitive on Postgres and would
+// change the output of every existing filter.
+func quoteField(flavor sqlbuilder.Flavor, field string) string {
+	// The quote character has to match what sqlbuilder.Flavor.Quote emits for
+	// the flavors dialectToFlavor returns.
+	quote := `"`
+	if flavor == sqlbuilder.MySQL {
+		quote = "`"
+	}
+	segments := strings.Split(field, ".")
+	for i, seg := range segments {
+		if !isBareIdent(seg) {
+			segments[i] = flavor.Quote(strings.ReplaceAll(seg, quote, quote+quote))
+		}
+	}
+	return strings.Join(segments, ".")
+}
+
+// isBareIdent reports whether s needs no quoting: a letter or underscore
+// followed by letters, digits or underscores. Deliberately narrower than any
+// dialect's identifier rules -- anything else is quoted.
+func isBareIdent(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := range len(s) {
+		switch c := s[i]; {
+		case c >= 'a' && c <= 'z', c >= 'A' && c <= 'Z', c == '_':
+		case i > 0 && c >= '0' && c <= '9':
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 func prefix(p any) (string, error) {

--- a/internal/ucast/ucast_test.go
+++ b/internal/ucast/ucast_test.go
@@ -91,6 +91,38 @@ func TestUCASTNodeAsSQL(t *testing.T) {
 			Dialect: "postgres",
 			Result:  "WHERE NOT name = E'bob'",
 		},
+		{
+			// Guards the no-op path: quoting ordinary column names would change
+			// the SQL generated for every existing filter.
+			Note:    "plain identifier stays unquoted",
+			Source:  UCASTNode{Type: "field", Field: "public.fruit.display_name_2", Op: "eq", Value: "apple"},
+			Dialect: "postgres",
+			Result:  `WHERE public.fruit.display_name_2 = E'apple'`,
+		},
+		{
+			Note:    "SQL syntax in field is quoted",
+			Source:  UCASTNode{Type: "field", Field: "fruit.name = 'allowed' OR 1=1 --", Op: "eq", Value: "allowed"},
+			Dialect: "postgres",
+			Result:  `WHERE fruit."name = 'allowed' OR 1=1 --" = E'allowed'`,
+		},
+		{
+			Note:    "SQL syntax in field reference value is quoted",
+			Source:  UCASTNode{Type: "field", Field: "fruit.name", Op: "eq", Value: FieldRef{Field: "other.name OR 1=1"}},
+			Dialect: "postgres",
+			Result:  `WHERE fruit.name = other."name OR 1=1"`,
+		},
+		{
+			Note:    "embedded identifier quote is escaped",
+			Source:  UCASTNode{Type: "field", Field: `fruit.na"me`, Op: "eq", Value: "allowed"},
+			Dialect: "postgres",
+			Result:  `WHERE fruit."na""me" = E'allowed'`,
+		},
+		{
+			Note:    "embedded MySQL identifier quote is escaped",
+			Source:  UCASTNode{Type: "field", Field: "fruit.na`me", Op: "eq", Value: "allowed"},
+			Dialect: "mysql",
+			Result:  "WHERE fruit.`na``me` = 'allowed'",
+		},
 	}
 
 	for _, tc := range tests {

--- a/v1/server/compile_handler_checks_test.go
+++ b/v1/server/compile_handler_checks_test.go
@@ -576,6 +576,13 @@ include if user == input.fruits.user`,
 			result: "WHERE fruits.colour IS NOT NULL",
 		},
 		{
+			note:   "dynamic field key with SQL syntax is quoted",
+			rego:   `include if input.fruits[input.column] == "allowed"`,
+			input:  map[string]any{"column": `name = 'allowed' OR 1=1 --`},
+			target: "application/vnd.opa.sql.sqlite+json",
+			result: `WHERE fruits."name = 'allowed' OR 1=1 --" = 'allowed'`,
+		},
+		{
 			note:   "equality with var (prisma)",
 			rego:   `include if input.fruits.colour = _`,
 			target: "application/vnd.opa.ucast.prisma+json",


### PR DESCRIPTION
<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

* You have read the project's
  [guidelines on AI tool use](https://www.openpolicyagent.org/docs/contrib-code#ai-guidelines).

For more information on contributing to OPA see our
[Contributing Guide](https://www.openpolicyagent.org/docs/contributing/)
for high-level contributing guidelines and development setup.
(See the [Developer Certificate of Origin](https://www.openpolicyagent.org/docs/contrib-code/#developer-certificate-of-origin)
section for specifics on signing off a commit.)

-->

### Why the changes in this PR are needed?

<!--
Include a short description of WHY the changes were made.
-->

Field names in the SQL emitted by the Compile API come from partially evaluated refs, so a policy selecting a dynamic key such as `input.fruits[input.column]` puts caller-controlled text in an identifier position. That text was emitted verbatim, which turns this:

```sql
WHERE fruits.name = 'allowed'
```

into this:

```sql
WHERE fruits.name = 'allowed' OR 1=1 -- = 'allowed'
```

An application appending the filter to its query returns rows the policy denies.

A policy that lets an external party pick the column already hands unsafe control over the generated SQL to that party, injection aside. This was reported privately to the OPA maintainers, who confirmed it doesn't warrant a security advisory, so it's being fixed in the open.

### What are the changes in this PR?

<!--
Include a short description of WHAT changes were made.
-->

Quote field segments that are not bare identifiers at the UCAST-to-SQL boundary, escaping any embedded quote character. Ordinary column names stay unquoted. Existing filters keep their current shape and remain case-insensitive on Postgres.

Only the SQL targets change. Quoting happens inside `asSQL` on a local copy of the field, and the `ucast` target never calls `asSQL`.

### Notes to assist PR review:

<!--
Here you can add information you think will help the reviewer(s).
-->

The fix sits in `internal/ucast` rather than `internal/compile` on purpose. `UCASTNode.Field` is also serialized as the dialect-agnostic UCAST response consumed by the Prisma and LINQ targets, so quoting any earlier would leak SQL syntax into that output.

### Further comments:

<!--
Here you can include links to additional resources related to the changes, discuss your solution, other approaches you considered etc.
-->

Two alternatives I considered and rejected:

- Quoting every segment unconditionally is simpler. But it changes the SQL generated for every existing filter. And because Postgres folds unquoted identifiers to lowercase it would break any policy whose ref case differs from the column's.

- Returning a compile error instead of quoting would give a clearer failure than the downstream `no such column`. But quoting is the standard mitigation and has a functional upside: column names containing spaces, dashes, or reserved words are currently emitted bare, i.e. as broken SQL, and now work.

AI tooling was used to prepare this change.