### PR TITLE
docs/website: Refresh Apache APISIX ecosystem resources

### DIFF
--- a/docs/src/data/ecosystem/entries/apache-apisix.md
+++ b/docs/src/data/ecosystem/entries/apache-apisix.md
@@ -7,16 +7,21 @@ labels:
   layer: network
 code:
 - https://github.com/apache/apisix
+tutorials:
+- https://apisix.apache.org/docs/apisix/plugins/opa/
+videos:
+- https://www.youtube.com/watch?v=DWl0QEYIXaA
 blogs:
 - https://apisix.apache.org/blog/2021/12/24/open-policy-agent/
-- https://medium.com/@ApacheAPISIX/apache-apisix-integrates-with-open-policy-agent-to-enrich-its-ecosystem-15569fe3ab9c
+- https://apisix.apache.org/blog/2023/03/02/security-policy-auditable/
 docs_features:
   rest-api-integration:
     note: |
-      Apache APISIX routes can be configured to call an OPA instance over
-      the REST API.
-      [This blog post](https://apisix.apache.org/blog/2021/12/24/open-policy-agent//)
-      explains how such a configuration can be achieved.
+      Apache APISIX routes can delegate authorization decisions to OPA through
+      the REST API. The
+      [Apache APISIX OPA plugin documentation](https://apisix.apache.org/docs/apisix/plugins/opa/)
+      describes the request and decision contract, plugin configuration, and
+      example authorization policies.
 ---
 
 Apache APISIX provides a plugin for delegating fine-grained authorization decisions to OPA.


### PR DESCRIPTION
The Apache APISIX ecosystem entry does not currently point readers to the maintained `opa` plugin documentation and includes a duplicate Medium cross-post.

This update makes the official plugin documentation the primary integration reference, adds a related ASF talk and an authorization-focused APISIX article, and removes the duplicate link. Keeping these resources current will help OPA users find the request and decision contract, configuration, and runnable examples from the ecosystem page.

Validation completed:

- `make fmt-check`
- `make markdownlint-check`
- `make lint-check`
- `make build`