### PR TITLE
format: Don't unwrap one-line rule body braces from single set term

### DIFF
--- a/v1/format/format.go
+++ b/v1/format/format.go
@@ -644,8 +644,12 @@ func (w *writer) writeRule(rule *ast.Rule, isElse bool, comments []*ast.Comment)
 			// same line as the end of the head. Comparing against the head's
 			// start row would wrongly expand the condition into a block whenever
 			// the head value spans multiple lines (e.g. a multi-line call).
+			//
+			// Additionally, a single set term must not be stripped of the outer body
+			// braces, as that would semantically change the inner set to a body:
+			// `p if { { x } }` -> p if { x }
 			headEndRow := rule.Head.Location.Row + strings.Count(string(rule.Head.Location.Text), "\n")
-			if rule.Body[0].Location.Row == headEndRow {
+			if rule.Body[0].Location.Row == headEndRow && !isSetTerm(rule.Body[0]) {
 				w.write(" ")
 				var err error
 				comments, err = w.writeExpr(rule.Body[0], comments)
@@ -1027,6 +1031,21 @@ func exprTermsEndRow(expr *ast.Expr) int {
 	}
 	text = bytes.TrimRight(text, " \t\r\n")
 	return loc.Row + bytes.Count(text, []byte{'\n'})
+}
+
+// isSetTerm reports whether expr is a non-negated set term.
+func isSetTerm(expr *ast.Expr) bool {
+	if expr.IsNegated() {
+		return false
+	}
+
+	term, ok := expr.Terms.(*ast.Term)
+	if !ok {
+		return false
+	}
+
+	_, ok = term.Value.(ast.Set)
+	return ok
 }
 
 func (w *writer) writeSomeDecl(decl *ast.SomeDecl, comments []*ast.Comment) ([]*ast.Comment, error) {

--- a/v1/format/testfiles/v1/test_lone_set_term_body.rego
+++ b/v1/format/testfiles/v1/test_lone_set_term_body.rego
@@ -1,0 +1,35 @@
+package test
+
+multiple_elements if { {1, 2} }
+
+ref_element if { {input.x} }
+
+scalar_element if { {false} }
+
+set_element if { {{1}} }
+
+array_element if { {[1]} }
+
+parenthesized_scalar_element if { ({false}) }
+
+parenthesized_parenthesized if { ({1, 2}) }
+
+fn(x) if { {x, 2} }
+
+collection contains 1 if { {1, 2} }
+
+a.b.c if { {1, 2} }
+
+with_else := 1 if { {1, 2} } else := 2 if { true }
+
+already_multiline if {
+	{1, 2}
+}
+
+ref_term if { input.x }
+
+object_term if { {"a": 1} }
+
+set_comprehension if { {y | y := input.x} }
+
+set_comparison if { {1, 2} == {1, 2} }

--- a/v1/format/testfiles/v1/test_lone_set_term_body.rego.formatted
+++ b/v1/format/testfiles/v1/test_lone_set_term_body.rego.formatted
@@ -1,0 +1,59 @@
+package test
+
+multiple_elements if {
+	{1, 2}
+}
+
+ref_element if {
+	{input.x}
+}
+
+scalar_element if {
+	{false}
+}
+
+set_element if {
+	{{1}}
+}
+
+array_element if {
+	{[1]}
+}
+
+parenthesized_scalar_element if {
+	{false}
+}
+
+parenthesized_parenthesized if {
+	{1, 2}
+}
+
+fn(x) if {
+	{x, 2}
+}
+
+collection contains 1 if {
+	{1, 2}
+}
+
+a.b.c if {
+	{1, 2}
+}
+
+with_else := 1 if {
+	{1, 2}
+}
+
+else := 2
+
+already_multiline if {
+	{1, 2}
+}
+
+ref_term if input.x
+
+object_term if {"a": 1}
+
+set_comprehension if {y | y := input.x}
+
+set_comparison if {1, 2} == {1, 2}

--- a/v1/format/testfiles/v1/test_not_future_import.rego
+++ b/v1/format/testfiles/v1/test_not_future_import.rego
@@ -37,3 +37,5 @@ b if {
 		with input.y3 as 7
 	with input.y4 as 8
 }
+
+c if { not {input.x} }

--- a/v1/format/testfiles/v1/test_not_future_import.rego.formatted
+++ b/v1/format/testfiles/v1/test_not_future_import.rego.formatted
@@ -37,3 +37,5 @@ b if {
 		with input.y3 as 7
 		with input.y4 as 8
 }
+
+c if not { input.x }


### PR DESCRIPTION
Before this fix, e.g., the rule:

```rego
p if { {false} }
```

would be formated to:

```rego
p if {false}
```

which changes the semantics from a rule body containing a single set (`{false}`) to a rule body containing a single scalar value (`false`).