### PR TITLE
internal/gojsonschema: reject empty enum

### DIFF
--- a/internal/gojsonschema/schema.go
+++ b/internal/gojsonschema/schema.go
@@ -676,6 +676,9 @@ func (d *Schema) parseSchema(documentNode any, currentSchema *SubSchema) error {
 	if err != nil {
 		return err
 	}
+	if _, found := m[KeyEnum]; found {
+		currentSchema.enum = make([]string, 0, len(enum))
+	}
 	for _, v := range enum {
 		is, err := marshalWithoutNumber(v)
 		if err != nil {

--- a/internal/gojsonschema/schemaLoader_test.go
+++ b/internal/gojsonschema/schemaLoader_test.go
@@ -259,6 +259,38 @@ func TestSchemaLoaderValidatePatterns(t *testing.T) {
 	})
 }
 
+func TestSchemaLoaderEmptyEnumRejectsEveryValue(t *testing.T) {
+	schema, err := NewSchemaLoader().Compile(NewStringLoader(`{"enum": []}`))
+	if err != nil {
+		t.Fatalf("unexpected schema compile error: %v", err)
+	}
+
+	for _, document := range []string{`"allow"`, `null`} {
+		result, err := schema.Validate(NewStringLoader(document))
+		if err != nil {
+			t.Fatalf("unexpected validation error for %s: %v", document, err)
+		}
+		if result.Valid() {
+			t.Errorf("expected %s to be invalid for an empty enum", document)
+		}
+	}
+}
+
+func TestSchemaLoaderWithoutEnumAcceptsValue(t *testing.T) {
+	schema, err := NewSchemaLoader().Compile(NewStringLoader(`{}`))
+	if err != nil {
+		t.Fatalf("unexpected schema compile error: %v", err)
+	}
+
+	result, err := schema.Validate(NewStringLoader(`"allow"`))
+	if err != nil {
+		t.Fatalf("unexpected validation error: %v", err)
+	}
+	if !result.Valid() {
+		t.Fatalf("expected a schema without enum to accept the document, got errors: %v", result.Errors())
+	}
+}
+
 const notMapInterface = "not map interface"
 
 func TestParseSchemaURL_NotMap(t *testing.T) {

--- a/internal/gojsonschema/validation.go
+++ b/internal/gojsonschema/validation.go
@@ -420,7 +420,7 @@ func (v *SubSchema) validateCommon(currentSubSchema *SubSchema, value any, resul
 	}
 
 	// enum:
-	if len(currentSubSchema.enum) > 0 {
+	if currentSubSchema.enum != nil {
 		vString, err := marshalWithoutNumber(value)
 		if err != nil {
 			result.addInternalError(new(InternalError), context, value, ErrorDetails{"error": err})

--- a/v1/test/cases/testdata/v1/jsonschema/test-json-match_schema.yaml
+++ b/v1/test/cases/testdata/v1/jsonschema/test-json-match_schema.yaml
@@ -79,6 +79,18 @@ cases:
               error: "id: Invalid type. Expected: integer, given: string"
               field: id
               type: invalid_type
+  - note: json_match_schema/empty enum rejects document
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p if {
+          result := json.match_schema({"value": "allow"}, {"enum": []})
+          result[0] == false
+        }
+    want_result:
+      - x: true
   - note: json_match_schema/invalid schema
     query: data.test.p = x
     modules:


### PR DESCRIPTION
## Summary

- preserve an explicitly empty `enum` while parsing a schema
- validate explicit empty enums, while preserving the behavior when `enum` is absent
- cover the validator and the `json.match_schema` builtin regression

Fixes #8910

## Testing

- `go test ./internal/gojsonschema -count=1`
- `go test ./v1/topdown -run 'TestRego/v1/json_match_schema/empty_enum_rejects_document' -count=1`
- `go vet ./internal/gojsonschema ./v1/topdown`