### PR TITLE
format: Wrap set union `|` infix in parens when output would be re-interpreted as comprehension

### DIFF
--- a/v1/format/format.go
+++ b/v1/format/format.go
@@ -820,7 +820,7 @@ func (w *writer) writeHead(head *ast.Head, isDefault bool, isExpandedConst bool,
 			args = append(args, arg)
 		}
 		var err error
-		comments, err = w.writeIterable(args, head.Location, closingLoc(0, 0, '(', ')', head.Location), comments, w.listWriter())
+		comments, err = w.writeIterable(args, head.Location, closingLoc(0, 0, '(', ')', head.Location), comments, w.listWriter(false))
 		w.write(")")
 		if err != nil {
 			return comments, err
@@ -1239,7 +1239,7 @@ func (w *writer) writeFunctionCallPlain(terms []*ast.Term, comments []*ast.Comme
 	}
 	loc := terms[0].Location
 	var err error
-	comments, err = w.writeIterable(args, loc, closingLoc(0, 0, '(', ')', loc), comments, w.listWriter())
+	comments, err = w.writeIterable(args, loc, closingLoc(0, 0, '(', ')', loc), comments, w.listWriter(false))
 	if err != nil {
 		return nil, err
 	}
@@ -1721,7 +1721,7 @@ func (w *writer) writeArray(arr *ast.Array, loc *ast.Location, comments []*ast.C
 		s = append(s, t)
 	})
 	var err error
-	comments, err = w.writeIterable(s, loc, closingLoc(0, 0, '[', ']', loc), comments, w.listWriter())
+	comments, err = w.writeIterable(s, loc, closingLoc(0, 0, '[', ']', loc), comments, w.listWriter(true))
 	if err != nil {
 		return nil, err
 	}
@@ -1748,7 +1748,7 @@ func (w *writer) writeSet(set ast.Set, loc *ast.Location, comments []*ast.Commen
 		s = append(s, t)
 	})
 	var err error
-	comments, err = w.writeIterable(s, loc, closingLoc(0, 0, '{', '}', loc), comments, w.listWriter())
+	comments, err = w.writeIterable(s, loc, closingLoc(0, 0, '{', '}', loc), comments, w.listWriter(true))
 	if err != nil {
 		return nil, err
 	}
@@ -1779,11 +1779,20 @@ func (w *writer) writeObjectComprehension(object *ast.ObjectComprehension, loc *
 		w.startLine()
 	}
 
+	paren := isUnionCall(object.Key)
+	if paren {
+		w.write("(")
+	}
+
 	var err error
 	comments, err = w.writeTerm(object.Key, comments)
 	if err != nil {
 		return nil, err
 	}
+	if paren {
+		w.write(")")
+	}
+
 	w.write(": ")
 	return w.writeComprehension('{', '}', object.Value, object.Body, loc, comments)
 }
@@ -1795,9 +1804,8 @@ func (w *writer) writeComprehension(openChar, closeChar byte, term *ast.Term, bo
 	}
 
 	parens := false
-	_, ok := term.Value.(ast.Call)
-	if ok {
-		parens = term.Location.Text[0] == 40 // Starts with "("
+	if _, ok := term.Value.(ast.Call); ok {
+		parens = isUnionCall(term) || term.Location.Text[0] == 40 // Starts with "("
 	}
 	var err error
 	comments, err = w.writeTermParens(parens, term, comments)
@@ -2011,15 +2019,20 @@ func (w *writer) writeIterableLine(elements []any, comments []*ast.Comment, fn e
 	return fn(elements[i], comments)
 }
 
+// isUnionCall returns true if the term is a call to the union built-in, whose
+// infix form (`|`) is comprehension syntax when used inside a collection
+// literal or as a comprehension term, and must be parenthesized there.
+func isUnionCall(t *ast.Term) bool {
+	call, ok := t.Value.(ast.Call)
+	return ok && ast.Or.Ref().Equal(call[0].Value)
+}
+
 func (w *writer) objectWriter() entryWriter {
 	return func(x any, comments []*ast.Comment) ([]*ast.Comment, error) {
 		entry := x.([2]*ast.Term)
 
-		call, isCall := entry[0].Value.(ast.Call)
-
-		paren := false
-		if isCall && ast.Or.Ref().Equal(call[0].Value) && entry[0].Location.Text[0] == 40 { // Starts with "("
-			paren = true
+		paren := isUnionCall(entry[0])
+		if paren {
 			w.write("(")
 		}
 
@@ -2034,8 +2047,7 @@ func (w *writer) objectWriter() entryWriter {
 
 		w.write(": ")
 
-		call, isCall = entry[1].Value.(ast.Call)
-		if isCall && ast.Or.Ref().Equal(call[0].Value) && entry[1].Location.Text[0] == 40 { // Starts with "("
+		if isUnionCall(entry[1]) {
 			w.write("(")
 			defer w.write(")")
 		}
@@ -2044,12 +2056,11 @@ func (w *writer) objectWriter() entryWriter {
 	}
 }
 
-func (w *writer) listWriter() entryWriter {
+func (w *writer) listWriter(parenUnionCalls bool) entryWriter {
 	return func(x any, comments []*ast.Comment) ([]*ast.Comment, error) {
 		t, ok := x.(*ast.Term)
-		if ok {
-			call, isCall := t.Value.(ast.Call)
-			if isCall && ast.Or.Ref().Equal(call[0].Value) && t.Location.Text[0] == 40 { // Starts with "("
+		if ok && isUnionCall(t) {
+			if parenUnionCalls || t.Location.Text[0] == 40 { // Starts with "("
 				w.write("(")
 				defer w.write(")")
 			}

--- a/v1/format/format_test.go
+++ b/v1/format/format_test.go
@@ -135,8 +135,16 @@ func TestFormatV0Source(t *testing.T) {
 				t.Fatalf("Expected formatted bytes to equal expected bytes but differed near line %d / byte %d (got: %q, expected: %q):\n%s", ln, at, formatted[at], expected[at], prefixWithLineNumbers(formatted))
 			}
 
-			if _, err := ast.ParseModuleWithOpts(rego+".tmp", string(formatted), popts); err != nil {
+			formattedModule, err := ast.ParseModuleWithOpts(rego+".tmp", string(formatted), popts)
+			if err != nil {
 				t.Fatalf("Failed to parse formatted bytes: %v", err)
+			}
+
+			if expASTPreserved(rego) {
+				module := ast.MustParseModuleWithOpts(string(contents), popts)
+				if !module.Equal(formattedModule) {
+					t.Fatalf("Expected formatting to preserve the AST, but got:\n\n%v\n\nexpected:\n\n%v", formattedModule, module)
+				}
 			}
 
 			formatted, err = SourceWithOpts(rego, formatted, opts)
@@ -187,8 +195,16 @@ func TestFormatV1Source(t *testing.T) {
 				t.Fatalf("Expected formatted bytes to equal expected bytes but differed near line %d / byte %d (got: %q, expected: %q):\n%s", ln, at, formatted[at], expected[at], prefixWithLineNumbers(formatted))
 			}
 
-			if _, err := ast.ParseModuleWithOpts(rego+".tmp", string(formatted), popts); err != nil {
+			formattedModule, err := ast.ParseModuleWithOpts(rego+".tmp", string(formatted), popts)
+			if err != nil {
 				t.Fatalf("Failed to parse formatted bytes: %v", err)
+			}
+
+			if expASTPreserved(rego) {
+				module := ast.MustParseModuleWithOpts(string(contents), popts)
+				if !module.Equal(formattedModule) {
+					t.Fatalf("Expected formatting to preserve the AST, but got:\n\n%v\n\nexpected:\n\n%v", formattedModule, module)
+				}
 			}
 
 			formatted, err = SourceWithOpts(rego, formatted, opts)
@@ -202,6 +218,59 @@ func TestFormatV1Source(t *testing.T) {
 
 		})
 	}
+}
+
+// astAlteringTestFiles are the test files where formatting is expected to
+// change the AST. For all other test files, formatting must preserve it.
+var astAlteringTestFiles = map[string]bool{
+	// Imports are sorted.
+	"testfiles/v0/test.rego": true,
+	"testfiles/v0/test_in_operator_with_all_keywords_import.rego": true,
+	"testfiles/v0/test_keywords_in_refs.rego":                     true,
+	"testfiles/v0/test_keywords_in_refs_keep_brackets.rego":       true,
+
+	// The `future.keywords.in` import is added.
+	"testfiles/v0/test_in_operator_without_import.rego": true,
+
+	// `if` is dropped from the rule head, making `q[1] = y` parse as a partial
+	// object rule rather than a ref head rule.
+	"testfiles/v0/test_ref_heads.rego": true,
+
+	// Rule head `=` is rewritten to `:=`.
+	"testfiles/v1/test_contains.rego":                          true,
+	"testfiles/v1/test_contains_if.rego":                       true,
+	"testfiles/v1/test_every.rego":                             true,
+	"testfiles/v1/test_functions.rego":                         true,
+	"testfiles/v1/test_future_kw_import.rego":                  true,
+	"testfiles/v1/test_if.rego":                                true,
+	"testfiles/v1/test_in_operator_with_parenthesis.rego":      true,
+	"testfiles/v1/test_issue_2299.rego":                        true,
+	"testfiles/v1/test_issue_3836.rego":                        true,
+	"testfiles/v1/test_issue_5449.rego":                        true,
+	"testfiles/v1/test_issue_5449_with_contains_ref_rule.rego": true,
+	"testfiles/v1/test_issue_5449_with_ref_rule.rego":          true,
+	"testfiles/v1/test_issue_5798.rego":                        true,
+	"testfiles/v1/test_ref_heads.rego":                         true,
+	"testfiles/v1/test_unicode.rego":                           true,
+	"testfiles/v1/test_with.rego":                              true,
+
+	// Imports are sorted.
+	"testfiles/v1/test_keywords_in_refs.rego":               true,
+	"testfiles/v1/test_keywords_in_refs_keep_brackets.rego": true,
+
+	// The `rego.v1` import is dropped.
+	"testfiles/v1/test_rego_v1.rego": true,
+
+	// Constant template string expressions are folded into string parts.
+	"testfiles/v1/test_template_strings.rego": true,
+
+	// Rule head `=` is rewritten to `:=`, imports are sorted, and calls in
+	// expression position are rewritten to infix comparisons.
+	"testfiles/v1/test.rego": true,
+}
+
+func expASTPreserved(rego string) bool {
+	return !astAlteringTestFiles[filepath.ToSlash(rego)]
 }
 
 func TestFormatV0SourceToRegoV1(t *testing.T) {

--- a/v1/format/testfiles/v0/test_union_call_parens.rego
+++ b/v1/format/testfiles/v0/test_union_call_parens.rego
@@ -1,0 +1,95 @@
+package test
+
+# The union built-in's infix form (`|`) is comprehension syntax in collection
+# literals and comprehension terms, so it must be parenthesized there.
+
+set_element := {or(x, y)}
+
+array_element := [or(x, y)]
+
+object_value := {"k": or(x, y)}
+
+object_key := {or(x, y): "v"}
+
+nested_set_element := {{or(x, y)}}
+
+nested_array_element := [[or(x, y)]]
+
+array_element_in_object_value := {"k": [or(x, y)]}
+
+union_of_unions := {or(or(x, y), z)}
+
+lone_set_term_body { {or(x, y)} }
+
+partial_set_element[{or(x, y)}] { true }
+
+multiple_set_elements := {or(x, y), z}
+
+multiple_array_elements := [or(x, y), z]
+
+multiple_object_entries := {"k": or(x, y), "j": z}
+
+multiline_set_element := {
+	or(x, y),
+}
+
+array_comprehension_term := [or(a, b) | c]
+
+set_comprehension_term := {or(a, b) | c}
+
+object_comprehension_value := {k: or(a, b) | c}
+
+object_comprehension_key := {or(a, b): v | c}
+
+object_comprehension_key_and_value := {or(a, b): or(c, d) | e}
+
+# Parens in the source are preserved in every position where they're required.
+
+parens_set_element := {(x | y)}
+
+parens_array_element := [(x | y)]
+
+parens_object_value := {"k": (x | y)}
+
+parens_object_key := {(x | y): "v"}
+
+parens_nested_set_element := {{(x | y)}}
+
+parens_nested_array_element := [[(x | y)]]
+
+parens_union_of_unions := {((x | y) | z)}
+
+parens_redundant := {((x | y))}
+
+parens_lone_set_term_body { {(x | y)} }
+
+parens_partial_set_element[{(x | y)}] { true }
+
+parens_multiple_set_elements := {(x | y), z}
+
+parens_multiline_set_element := {(
+	x | y
+)}
+
+parens_array_comprehension_term := [(a | b) | c]
+
+parens_set_comprehension_term := {(a | b) | c}
+
+parens_object_comprehension_value := {k: (a | b) | c}
+
+parens_object_comprehension_key := {(a | b): v | c}
+
+parens_object_comprehension_key_and_value := {(a | b): (c | d) | e}
+
+# Unaffected: `|` is unambiguous outside of collection literals and
+# comprehension terms, and `&` is never comprehension syntax.
+
+union_outside_collection := or(x, y)
+
+intersection_in_set := {and(x, y)}
+
+union_as_call_argument := f(or(a, b))
+
+union_as_ref_operand := q[or(a, b)]
+
+union_in_comprehension_body := [x | y := or(a, b)]

--- a/v1/format/testfiles/v0/test_union_call_parens.rego.formatted
+++ b/v1/format/testfiles/v0/test_union_call_parens.rego.formatted
@@ -1,0 +1,97 @@
+package test
+
+# The union built-in's infix form (`|`) is comprehension syntax in collection
+# literals and comprehension terms, so it must be parenthesized there.
+
+set_element := {(x | y)}
+
+array_element := [(x | y)]
+
+object_value := {"k": (x | y)}
+
+object_key := {(x | y): "v"}
+
+nested_set_element := {{(x | y)}}
+
+nested_array_element := [[(x | y)]]
+
+array_element_in_object_value := {"k": [(x | y)]}
+
+union_of_unions := {((x | y) | z)}
+
+lone_set_term_body {
+	{(x | y)}
+}
+
+partial_set_element[{(x | y)}]
+
+multiple_set_elements := {(x | y), z}
+
+multiple_array_elements := [(x | y), z]
+
+multiple_object_entries := {"k": (x | y), "j": z}
+
+multiline_set_element := {
+	(x | y),
+}
+
+array_comprehension_term := [(a | b) | c]
+
+set_comprehension_term := {(a | b) | c}
+
+object_comprehension_value := {k: (a | b) | c}
+
+object_comprehension_key := {(a | b): v | c}
+
+object_comprehension_key_and_value := {(a | b): (c | d) | e}
+
+# Parens in the source are preserved in every position where they're required.
+
+parens_set_element := {(x | y)}
+
+parens_array_element := [(x | y)]
+
+parens_object_value := {"k": (x | y)}
+
+parens_object_key := {(x | y): "v"}
+
+parens_nested_set_element := {{(x | y)}}
+
+parens_nested_array_element := [[(x | y)]]
+
+parens_union_of_unions := {((x | y) | z)}
+
+parens_redundant := {(x | y)}
+
+parens_lone_set_term_body {
+	{(x | y)}
+}
+
+parens_partial_set_element[{(x | y)}]
+
+parens_multiple_set_elements := {(x | y), z}
+
+parens_multiline_set_element := {(x | y)}
+
+parens_array_comprehension_term := [(a | b) | c]
+
+parens_set_comprehension_term := {(a | b) | c}
+
+parens_object_comprehension_value := {k: (a | b) | c}
+
+parens_object_comprehension_key := {(a | b): v | c}
+
+parens_object_comprehension_key_and_value := {(a | b): (c | d) | e}
+
+# Unaffected: `|` is unambiguous outside of collection literals and
+# comprehension terms, and `&` is never comprehension syntax.
+
+union_outside_collection := x | y
+
+intersection_in_set := {x & y}
+
+union_as_call_argument := f(a | b)
+
+union_as_ref_operand := q[a | b]
+
+union_in_comprehension_body := [x | y := a | b]

--- a/v1/format/testfiles/v1/test_union_call_parens.rego
+++ b/v1/format/testfiles/v1/test_union_call_parens.rego
@@ -1,0 +1,103 @@
+package test
+
+# The union built-in's infix form (`|`) is comprehension syntax in collection
+# literals and comprehension terms, so it must be parenthesized there.
+
+set_element := {or(x, y)}
+
+array_element := [or(x, y)]
+
+object_value := {"k": or(x, y)}
+
+object_key := {or(x, y): "v"}
+
+nested_set_element := {{or(x, y)}}
+
+nested_array_element := [[or(x, y)]]
+
+array_element_in_object_value := {"k": [or(x, y)]}
+
+union_of_unions := {or(or(x, y), z)}
+
+lone_set_term_body if { {or(x, y)} }
+
+set_element_in_rule_value contains {or(x, y)}
+
+set_element_in_in_operator if x in {or(a, b)}
+
+set_element_in_every_domain if every x in {or(a, b)} { x }
+
+multiple_set_elements := {or(x, y), z}
+
+multiple_array_elements := [or(x, y), z]
+
+multiple_object_entries := {"k": or(x, y), "j": z}
+
+multiline_set_element := {
+	or(x, y),
+}
+
+array_comprehension_term := [or(a, b) | c]
+
+set_comprehension_term := {or(a, b) | c}
+
+object_comprehension_value := {k: or(a, b) | c}
+
+object_comprehension_key := {or(a, b): v | c}
+
+object_comprehension_key_and_value := {or(a, b): or(c, d) | e}
+
+parens_kept := {(x | y)}
+
+redundant_parens := {((x | y))}
+
+# Parens in the source are preserved in every position where they're required.
+
+parens_set_element := {(x | y)}
+
+parens_array_element := [(x | y)]
+
+parens_object_value := {"k": (x | y)}
+
+parens_object_key := {(x | y): "v"}
+
+parens_nested_set_element := {{(x | y)}}
+
+parens_nested_array_element := [[(x | y)]]
+
+parens_union_of_unions := {((x | y) | z)}
+
+parens_lone_set_term_body if { {(x | y)} }
+
+parens_set_element_in_rule_value contains {(x | y)}
+
+parens_set_element_in_in_operator if x in {(a | b)}
+
+parens_multiple_set_elements := {(x | y), z}
+
+parens_multiline_set_element := {(
+	x | y
+)}
+
+parens_array_comprehension_term := [(a | b) | c]
+
+parens_set_comprehension_term := {(a | b) | c}
+
+parens_object_comprehension_value := {k: (a | b) | c}
+
+parens_object_comprehension_key := {(a | b): v | c}
+
+parens_object_comprehension_key_and_value := {(a | b): (c | d) | e}
+
+# Unaffected: `|` is unambiguous outside of collection literals and
+# comprehension terms, and `&` is never comprehension syntax.
+
+union_outside_collection := or(x, y)
+
+intersection_in_set := {and(x, y)}
+
+union_as_call_argument := f(or(a, b))
+
+union_as_ref_operand := q[or(a, b)]
+
+union_in_comprehension_body := [x | y := or(a, b)]

--- a/v1/format/testfiles/v1/test_union_call_parens.rego.formatted
+++ b/v1/format/testfiles/v1/test_union_call_parens.rego.formatted
@@ -1,0 +1,105 @@
+package test
+
+# The union built-in's infix form (`|`) is comprehension syntax in collection
+# literals and comprehension terms, so it must be parenthesized there.
+
+set_element := {(x | y)}
+
+array_element := [(x | y)]
+
+object_value := {"k": (x | y)}
+
+object_key := {(x | y): "v"}
+
+nested_set_element := {{(x | y)}}
+
+nested_array_element := [[(x | y)]]
+
+array_element_in_object_value := {"k": [(x | y)]}
+
+union_of_unions := {((x | y) | z)}
+
+lone_set_term_body if {
+	{(x | y)}
+}
+
+set_element_in_rule_value contains {(x | y)}
+
+set_element_in_in_operator if x in {(a | b)}
+
+set_element_in_every_domain if every x in {(a | b)} { x }
+
+multiple_set_elements := {(x | y), z}
+
+multiple_array_elements := [(x | y), z]
+
+multiple_object_entries := {"k": (x | y), "j": z}
+
+multiline_set_element := {
+	(x | y),
+}
+
+array_comprehension_term := [(a | b) | c]
+
+set_comprehension_term := {(a | b) | c}
+
+object_comprehension_value := {k: (a | b) | c}
+
+object_comprehension_key := {(a | b): v | c}
+
+object_comprehension_key_and_value := {(a | b): (c | d) | e}
+
+parens_kept := {(x | y)}
+
+redundant_parens := {(x | y)}
+
+# Parens in the source are preserved in every position where they're required.
+
+parens_set_element := {(x | y)}
+
+parens_array_element := [(x | y)]
+
+parens_object_value := {"k": (x | y)}
+
+parens_object_key := {(x | y): "v"}
+
+parens_nested_set_element := {{(x | y)}}
+
+parens_nested_array_element := [[(x | y)]]
+
+parens_union_of_unions := {((x | y) | z)}
+
+parens_lone_set_term_body if {
+	{(x | y)}
+}
+
+parens_set_element_in_rule_value contains {(x | y)}
+
+parens_set_element_in_in_operator if x in {(a | b)}
+
+parens_multiple_set_elements := {(x | y), z}
+
+parens_multiline_set_element := {(x | y)}
+
+parens_array_comprehension_term := [(a | b) | c]
+
+parens_set_comprehension_term := {(a | b) | c}
+
+parens_object_comprehension_value := {k: (a | b) | c}
+
+parens_object_comprehension_key := {(a | b): v | c}
+
+parens_object_comprehension_key_and_value := {(a | b): (c | d) | e}
+
+# Unaffected: `|` is unambiguous outside of collection literals and
+# comprehension terms, and `&` is never comprehension syntax.
+
+union_outside_collection := x | y
+
+intersection_in_set := {x & y}
+
+union_as_call_argument := f(a | b)
+
+union_as_ref_operand := q[a | b]
+
+union_in_comprehension_body := [x | y := a | b]


### PR DESCRIPTION
The set union infix operator shares the `|` symbol with comprehensions, creating edge-cases where the formatter would change the semantics of a set union into a comprehension.

E.g. When formatted, `{or(a, b)}` becomes `{a | b}`; where the former is a set containing the union of two sets, and the latter is a set comprehension.

Note: the `or()` built-in backing the `|` set union infix operator isn't advertised through documentation, and it's very unlikely that anyone is affected by this issue. Nevertheless, formatting shouldn't change the semantics of a policy.
