### PR TITLE
topdown: Apply allow_net to remote schema $refs

### DIFF
--- a/docs/docs/operations.md
+++ b/docs/docs/operations.md
@@ -148,6 +148,8 @@ Not providing a capabilities file, or providing a file without an `allow_net` ke
 
 Note that the metaschemas [https://json-schema.org/draft-04/schema](https://json-schema.org/draft-04/schema), [https://json-schema.org/draft-06/schema](https://json-schema.org/draft-06/schema), and [https://json-schema.org/draft-07/schema](https://json-schema.org/draft-07/schema), are always available, even without network access.
 
+This applies both to schemas resolved while type checking a policy, and to schemas compiled at evaluation time by the `json.match_schema` and `json.verify_schema` built-in functions. A schema passed to either built-in may contain a remote `$ref`, and if the host is not permitted, the reference is not fetched and the built-in reports an error instead.
+
 Similarly, the `allow_net` capability restricts what hosts the `http.send` built-in function may send requests to, and what hosts the `net.lookup_ip_addr` built-in function may resolve IP addresses for.
 
 ### Features

--- a/internal/gojsonschema/jsonLoader.go
+++ b/internal/gojsonschema/jsonLoader.go
@@ -28,6 +28,7 @@ package gojsonschema
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -38,39 +39,40 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
-	"sync"
 
 	"github.com/xeipuuv/gojsonreference"
 )
 
-// NOTE(sr): We need to control from which hosts remote references are
-// allowed to be resolved via HTTP requests. It's quite cumbersome to
-// add extra parameters to all calls and interfaces involved, so we're
-// using a global variable instead:
-var allowNet map[string]struct{}
-var netMut sync.RWMutex
+// maxRemoteRefRedirects bounds the redirect chain a single remote reference
+// fetch may follow. net/http applies its own limit only when CheckRedirect is
+// nil, so policing the allowlist there means reimposing it here; the value
+// matches the stdlib default.
+const maxRemoteRefRedirects = 10
 
-func SetAllowNet(hosts []string) {
-	netMut.Lock()
-	defer netMut.Unlock()
+// remoteRefLimits bounds the outbound requests a loader may make while
+// resolving remote references. The zero value is unrestricted.
+type remoteRefLimits struct {
+	// A nil set permits any host; an empty set permits none.
+	allowNet map[string]struct{}
+
+	// LoadJSON takes no arguments, so the context rides on the loader instead.
+	// Loaders are built per Compile call, so its scope is that one compilation.
+	// A nil ctx means context.Background().
+	ctx context.Context
+}
+
+// newAllowNetSet turns a list of permitted hosts into a set. A nil list
+// yields a nil set, which permits every host; a non-nil empty list yields
+// an empty set, which permits none.
+func newAllowNetSet(hosts []string) map[string]struct{} {
 	if hosts == nil {
-		allowNet = nil // resetting the global
-		return
+		return nil
 	}
-	allowNet = make(map[string]struct{}, len(hosts))
+	allowNet := make(map[string]struct{}, len(hosts))
 	for _, host := range hosts {
 		allowNet[host] = struct{}{}
 	}
-}
-
-func isAllowed(ref *url.URL) bool {
-	netMut.RLock()
-	defer netMut.RUnlock()
-	if allowNet == nil {
-		return true
-	}
-	_, ok := allowNet[ref.Hostname()]
-	return ok
+	return allowNet
 }
 
 var osFS = osFileSystem(os.Open)
@@ -87,15 +89,20 @@ type JSONLoader interface {
 type JSONLoaderFactory interface {
 	// New creates a new JSON loader for the given source
 	New(source string) JSONLoader
+	// withRemoteRefLimits returns a copy of the factory whose loaders resolve
+	// remote references subject to the given limits.
+	withRemoteRefLimits(limits remoteRefLimits) JSONLoaderFactory
 }
 
 // DefaultJSONLoaderFactory is the default JSON loader factory
 type DefaultJSONLoaderFactory struct {
+	limits remoteRefLimits
 }
 
 // FileSystemJSONLoaderFactory is a JSON loader factory that uses http.FileSystem
 type FileSystemJSONLoaderFactory struct {
-	fs http.FileSystem
+	fs     http.FileSystem
+	limits remoteRefLimits
 }
 
 // New creates a new JSON loader for the given source
@@ -103,6 +110,7 @@ func (d DefaultJSONLoaderFactory) New(source string) JSONLoader {
 	return &jsonReferenceLoader{
 		fs:     osFS,
 		source: source,
+		limits: d.limits,
 	}
 }
 
@@ -111,7 +119,18 @@ func (f FileSystemJSONLoaderFactory) New(source string) JSONLoader {
 	return &jsonReferenceLoader{
 		fs:     f.fs,
 		source: source,
+		limits: f.limits,
 	}
+}
+
+func (d DefaultJSONLoaderFactory) withRemoteRefLimits(limits remoteRefLimits) JSONLoaderFactory {
+	d.limits = limits
+	return d
+}
+
+func (f FileSystemJSONLoaderFactory) withRemoteRefLimits(limits remoteRefLimits) JSONLoaderFactory {
+	f.limits = limits
+	return f
 }
 
 // osFileSystem is a functional wrapper for os.Open that implements http.FileSystem.
@@ -128,6 +147,22 @@ func (o osFileSystem) Open(name string) (http.File, error) {
 type jsonReferenceLoader struct {
 	fs     http.FileSystem
 	source string
+	limits remoteRefLimits
+}
+
+func (l *jsonReferenceLoader) isAllowed(ref *url.URL) bool {
+	if l.limits.allowNet == nil {
+		return true
+	}
+	_, ok := l.limits.allowNet[ref.Hostname()]
+	return ok
+}
+
+func (l *jsonReferenceLoader) context() context.Context {
+	if l.limits.ctx == nil {
+		return context.Background()
+	}
+	return l.limits.ctx
 }
 
 func (l *jsonReferenceLoader) JSONSource() any {
@@ -140,7 +175,8 @@ func (l *jsonReferenceLoader) JSONReference() (gojsonreference.JsonReference, er
 
 func (l *jsonReferenceLoader) LoaderFactory() JSONLoaderFactory {
 	return &FileSystemJSONLoaderFactory{
-		fs: l.fs,
+		fs:     l.fs,
+		limits: l.limits,
 	}
 }
 
@@ -200,7 +236,7 @@ func (l *jsonReferenceLoader) LoadJSON() (any, error) {
 		return decodeJSONUsingNumber(strings.NewReader(metaSchema))
 	}
 
-	if isAllowed(refToURL.GetUrl()) {
+	if l.isAllowed(refToURL.GetUrl()) {
 		return l.loadFromHTTP(refToURL.String())
 	}
 
@@ -209,10 +245,30 @@ func (l *jsonReferenceLoader) LoadJSON() (any, error) {
 
 func (l *jsonReferenceLoader) loadFromHTTP(address string) (any, error) {
 
-	resp, err := http.Get(address)
+	client := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= maxRemoteRefRedirects {
+				return fmt.Errorf("stopped after %d redirects", maxRemoteRefRedirects)
+			}
+			// Checking every hop, not just the first, stops a permitted host
+			// from bouncing the request onward to one that isn't allowed.
+			if !l.isAllowed(req.URL) {
+				return fmt.Errorf("remote reference loading disabled: %s", req.URL.String())
+			}
+			return nil
+		},
+	}
+
+	req, err := http.NewRequestWithContext(l.context(), http.MethodGet, address, nil)
 	if err != nil {
 		return nil, err
 	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
 
 	// must return HTTP Status 200 OK
 	if resp.StatusCode != http.StatusOK {

--- a/internal/gojsonschema/jsonLoader.go
+++ b/internal/gojsonschema/jsonLoader.go
@@ -38,39 +38,22 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
-	"sync"
 
 	"github.com/xeipuuv/gojsonreference"
 )
 
-// NOTE(sr): We need to control from which hosts remote references are
-// allowed to be resolved via HTTP requests. It's quite cumbersome to
-// add extra parameters to all calls and interfaces involved, so we're
-// using a global variable instead:
-var allowNet map[string]struct{}
-var netMut sync.RWMutex
-
-func SetAllowNet(hosts []string) {
-	netMut.Lock()
-	defer netMut.Unlock()
+// newAllowNetSet turns a list of permitted hosts into a set. A nil list
+// yields a nil set, which permits every host; a non-nil empty list yields
+// an empty set, which permits none.
+func newAllowNetSet(hosts []string) map[string]struct{} {
 	if hosts == nil {
-		allowNet = nil // resetting the global
-		return
+		return nil
 	}
-	allowNet = make(map[string]struct{}, len(hosts))
+	allowNet := make(map[string]struct{}, len(hosts))
 	for _, host := range hosts {
 		allowNet[host] = struct{}{}
 	}
-}
-
-func isAllowed(ref *url.URL) bool {
-	netMut.RLock()
-	defer netMut.RUnlock()
-	if allowNet == nil {
-		return true
-	}
-	_, ok := allowNet[ref.Hostname()]
-	return ok
+	return allowNet
 }
 
 var osFS = osFileSystem(os.Open)
@@ -87,31 +70,49 @@ type JSONLoader interface {
 type JSONLoaderFactory interface {
 	// New creates a new JSON loader for the given source
 	New(source string) JSONLoader
+	// withAllowNet returns a copy of the factory whose loaders may only
+	// fetch remote references from the given set of hosts. A nil set
+	// permits any host; an empty set permits none.
+	withAllowNet(allowNet map[string]struct{}) JSONLoaderFactory
 }
 
 // DefaultJSONLoaderFactory is the default JSON loader factory
 type DefaultJSONLoaderFactory struct {
+	allowNet map[string]struct{}
 }
 
 // FileSystemJSONLoaderFactory is a JSON loader factory that uses http.FileSystem
 type FileSystemJSONLoaderFactory struct {
-	fs http.FileSystem
+	fs       http.FileSystem
+	allowNet map[string]struct{}
 }
 
 // New creates a new JSON loader for the given source
 func (d DefaultJSONLoaderFactory) New(source string) JSONLoader {
 	return &jsonReferenceLoader{
-		fs:     osFS,
-		source: source,
+		fs:       osFS,
+		source:   source,
+		allowNet: d.allowNet,
 	}
 }
 
 // New creates a new JSON loader for the given source
 func (f FileSystemJSONLoaderFactory) New(source string) JSONLoader {
 	return &jsonReferenceLoader{
-		fs:     f.fs,
-		source: source,
+		fs:       f.fs,
+		source:   source,
+		allowNet: f.allowNet,
 	}
+}
+
+func (d DefaultJSONLoaderFactory) withAllowNet(allowNet map[string]struct{}) JSONLoaderFactory {
+	d.allowNet = allowNet
+	return d
+}
+
+func (f FileSystemJSONLoaderFactory) withAllowNet(allowNet map[string]struct{}) JSONLoaderFactory {
+	f.allowNet = allowNet
+	return f
 }
 
 // osFileSystem is a functional wrapper for os.Open that implements http.FileSystem.
@@ -128,6 +129,17 @@ func (o osFileSystem) Open(name string) (http.File, error) {
 type jsonReferenceLoader struct {
 	fs     http.FileSystem
 	source string
+	// allowNet is the set of hosts remote references may be fetched from.
+	// A nil set permits any host; an empty set permits none.
+	allowNet map[string]struct{}
+}
+
+func (l *jsonReferenceLoader) isAllowed(ref *url.URL) bool {
+	if l.allowNet == nil {
+		return true
+	}
+	_, ok := l.allowNet[ref.Hostname()]
+	return ok
 }
 
 func (l *jsonReferenceLoader) JSONSource() any {
@@ -140,7 +152,8 @@ func (l *jsonReferenceLoader) JSONReference() (gojsonreference.JsonReference, er
 
 func (l *jsonReferenceLoader) LoaderFactory() JSONLoaderFactory {
 	return &FileSystemJSONLoaderFactory{
-		fs: l.fs,
+		fs:       l.fs,
+		allowNet: l.allowNet,
 	}
 }
 
@@ -200,7 +213,7 @@ func (l *jsonReferenceLoader) LoadJSON() (any, error) {
 		return decodeJSONUsingNumber(strings.NewReader(metaSchema))
 	}
 
-	if isAllowed(refToURL.GetUrl()) {
+	if l.isAllowed(refToURL.GetUrl()) {
 		return l.loadFromHTTP(refToURL.String())
 	}
 
@@ -209,7 +222,20 @@ func (l *jsonReferenceLoader) LoadJSON() (any, error) {
 
 func (l *jsonReferenceLoader) loadFromHTTP(address string) (any, error) {
 
-	resp, err := http.Get(address)
+	// Redirects are followed, so each hop has to be checked against the
+	// allowlist as well -- otherwise a permitted host could bounce the
+	// request onward to one that isn't. This mirrors what the http.send
+	// built-in does for its own redirect handling.
+	client := &http.Client{
+		CheckRedirect: func(req *http.Request, _ []*http.Request) error {
+			if !l.isAllowed(req.URL) {
+				return fmt.Errorf("remote reference loading disabled: %s", req.URL.String())
+			}
+			return nil
+		},
+	}
+
+	resp, err := client.Get(address)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/gojsonschema/jsonschema_test.go
+++ b/internal/gojsonschema/jsonschema_test.go
@@ -15,14 +15,20 @@
 package gojsonschema
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 )
 
 type jsonSchemaTest struct {
@@ -133,8 +139,6 @@ func TestSuite(t *testing.T) {
 		}
 	}()
 
-	SetAllowNet(nil)
-
 	err = filepath.Walk(wd, func(path string, fileInfo os.FileInfo, _ error) error {
 		if fileInfo.IsDir() && path != wd && !testDirectories.MatchString(fileInfo.Name()) {
 			return filepath.SkipDir
@@ -190,9 +194,219 @@ func TestFormats(t *testing.T) {
 	}
 }
 
-func Test_ConcurrentNetAccessModification(_ *testing.T) {
+func TestAllowNetIsPerSchemaLoader(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"type": "string"}`)
+	}))
+	defer srv.Close()
+
+	srvURL, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	schema := fmt.Sprintf(`{"$ref": %q}`, srv.URL+"/schema.json")
+
+	compile := func(allowNet []string) error {
+		sl := NewSchemaLoader()
+		sl.AllowNet = allowNet
+		_, err := sl.Compile(NewStringLoader(schema))
+		return err
+	}
+
+	tests := []struct {
+		note       string
+		allowNet   []string
+		wantDenied bool
+	}{
+		{note: "nil list permits any host", allowNet: nil},
+		{note: "empty list permits no host", allowNet: []string{}, wantDenied: true},
+		{note: "listed host is permitted", allowNet: []string{srvURL.Hostname()}},
+		{note: "unlisted host is denied", allowNet: []string{"example.com"}, wantDenied: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.note, func(t *testing.T) {
+			err := compile(tc.allowNet)
+			if tc.wantDenied {
+				if err == nil {
+					t.Fatal("expected remote reference to be denied, but compilation succeeded")
+				}
+				if !strings.Contains(err.Error(), "remote reference loading disabled") {
+					t.Fatalf("expected remote reference loading to be disabled, got %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected remote reference to be permitted, got %v", err)
+			}
+		})
+	}
+
+	// Loaders with conflicting allowlists, used concurrently, must each honour
+	// their own -- the permissive one must not open up the restrictive one.
+	t.Run("conflicting allowlists used concurrently", func(t *testing.T) {
+		var wg sync.WaitGroup
+		for range 20 {
+			wg.Add(2)
+			go func() {
+				defer wg.Done()
+				if err := compile(nil); err != nil {
+					t.Errorf("permissive loader: expected success, got %v", err)
+				}
+			}()
+			go func() {
+				defer wg.Done()
+				if err := compile([]string{}); err == nil {
+					t.Error("restrictive loader: expected remote reference to be denied")
+				}
+			}()
+		}
+		wg.Wait()
+	})
+}
+
+func TestAllowNetIsCheckedOnRedirects(t *testing.T) {
+	var srv *httptest.Server
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/schema.json", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"type": "string"}`)
+	})
+	mux.HandleFunc("/leave", func(w http.ResponseWriter, r *http.Request) {
+		// The same address under a different host name, which is what the
+		// allowlist matches on.
+		viaLocalhost := strings.Replace(srv.URL, "127.0.0.1", "localhost", 1)
+		http.Redirect(w, r, viaLocalhost+"/schema.json", http.StatusFound)
+	})
+	mux.HandleFunc("/hop-then-leave", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, srv.URL+"/leave", http.StatusFound)
+	})
+	mux.HandleFunc("/hop-then-stay", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, srv.URL+"/schema.json", http.StatusFound)
+	})
+	srv = httptest.NewServer(mux)
+	defer srv.Close()
+
+	srvURL, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		note       string
+		entry      string
+		wantDenied bool
+	}{
+		{note: "first hop leaves the allowlist", entry: "/leave", wantDenied: true},
+		{note: "later hop leaves the allowlist", entry: "/hop-then-leave", wantDenied: true},
+		{note: "chain stays within the allowlist", entry: "/hop-then-stay"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.note, func(t *testing.T) {
+			sl := NewSchemaLoader()
+			sl.AllowNet = []string{srvURL.Hostname()} // permits 127.0.0.1, not localhost
+			_, err := sl.Compile(NewStringLoader(fmt.Sprintf(`{"$ref": %q}`, srv.URL+tc.entry)))
+
+			if tc.wantDenied {
+				if err == nil {
+					t.Fatal("expected the redirect to a non-allowlisted host to be denied")
+				}
+				if !strings.Contains(err.Error(), "remote reference loading disabled") {
+					t.Fatalf("expected remote reference loading to be disabled, got %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected the redirect chain to be permitted, got %v", err)
+			}
+		})
+	}
+}
+
+// Setting CheckRedirect opts out of net/http's own hop limit, so the limit has
+// to be enforced by the loader instead. Nothing else bounds the exchange -- the
+// client applies no timeout -- so without the limit a host that redirects to
+// itself keeps a fetch going indefinitely.
+func TestRemoteRefRedirectsAreBounded(t *testing.T) {
+	var hops int
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hops++
+		http.Redirect(w, r, "/again", http.StatusFound)
+	}))
+	defer srv.Close()
+
+	// The hop limit fires in milliseconds against a local server; the deadline
+	// is only here so a regression fails the test instead of hanging it.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	sl := NewSchemaLoader()
+	sl.Context = ctx
+
+	_, err := sl.Compile(NewStringLoader(fmt.Sprintf(`{"$ref": %q}`, srv.URL+"/schema.json")))
+	if err == nil {
+		t.Fatal("expected the redirect loop to be stopped")
+	}
+	if !strings.Contains(err.Error(), fmt.Sprintf("stopped after %d redirects", maxRemoteRefRedirects)) {
+		t.Fatalf("expected the redirect loop to be stopped after %d redirects, got %v", maxRemoteRefRedirects, err)
+	}
+	if hops > maxRemoteRefRedirects+1 {
+		t.Fatalf("expected at most %d requests, got %d", maxRemoteRefRedirects+1, hops)
+	}
+}
+
+// A cancelled caller -- an aborted or timed-out query, say -- should not leave
+// a remote reference fetch running behind it.
+func TestRemoteRefFetchHonoursContext(t *testing.T) {
+	release := make(chan struct{})
+	defer close(release)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-release:
+		case <-r.Context().Done():
+		}
+		fmt.Fprint(w, `{"type": "string"}`)
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	sl := NewSchemaLoader()
+	sl.Context = ctx
+
+	done := make(chan error, 1)
 	go func() {
-		SetAllowNet([]string{"something"})
+		_, err := sl.Compile(NewStringLoader(fmt.Sprintf(`{"$ref": %q}`, srv.URL+"/schema.json")))
+		done <- err
 	}()
-	SetAllowNet(nil)
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected the cancelled fetch to fail")
+		}
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected a context cancellation error, got %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("fetch did not observe the cancelled context")
+	}
+}
+
+// The loaders reached by the compile-time type-checking path are built without
+// a context; they must still work rather than panicking on a nil one.
+func TestRemoteRefFetchWithoutContext(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"type": "string"}`)
+	}))
+	defer srv.Close()
+
+	sl := NewSchemaLoader() // Context left unset
+	if _, err := sl.Compile(NewStringLoader(fmt.Sprintf(`{"$ref": %q}`, srv.URL+"/schema.json"))); err != nil {
+		t.Fatalf("expected the fetch to succeed, got %v", err)
+	}
 }

--- a/internal/gojsonschema/jsonschema_test.go
+++ b/internal/gojsonschema/jsonschema_test.go
@@ -18,10 +18,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -133,8 +136,6 @@ func TestSuite(t *testing.T) {
 		}
 	}()
 
-	SetAllowNet(nil)
-
 	err = filepath.Walk(wd, func(path string, fileInfo os.FileInfo, _ error) error {
 		if fileInfo.IsDir() && path != wd && !testDirectories.MatchString(fileInfo.Name()) {
 			return filepath.SkipDir
@@ -190,9 +191,132 @@ func TestFormats(t *testing.T) {
 	}
 }
 
-func Test_ConcurrentNetAccessModification(_ *testing.T) {
-	go func() {
-		SetAllowNet([]string{"something"})
-	}()
-	SetAllowNet(nil)
+func TestAllowNetIsPerSchemaLoader(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"type": "string"}`)
+	}))
+	defer srv.Close()
+
+	srvURL, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	schema := fmt.Sprintf(`{"$ref": %q}`, srv.URL+"/schema.json")
+
+	compile := func(allowNet []string) error {
+		sl := NewSchemaLoader()
+		sl.AllowNet = allowNet
+		_, err := sl.Compile(NewStringLoader(schema))
+		return err
+	}
+
+	tests := []struct {
+		note       string
+		allowNet   []string
+		wantDenied bool
+	}{
+		{note: "nil list permits any host", allowNet: nil},
+		{note: "empty list permits no host", allowNet: []string{}, wantDenied: true},
+		{note: "listed host is permitted", allowNet: []string{srvURL.Hostname()}},
+		{note: "unlisted host is denied", allowNet: []string{"example.com"}, wantDenied: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.note, func(t *testing.T) {
+			err := compile(tc.allowNet)
+			if tc.wantDenied {
+				if err == nil {
+					t.Fatal("expected remote reference to be denied, but compilation succeeded")
+				}
+				if !strings.Contains(err.Error(), "remote reference loading disabled") {
+					t.Fatalf("expected remote reference loading to be disabled, got %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected remote reference to be permitted, got %v", err)
+			}
+		})
+	}
+
+	// Loaders with conflicting allowlists, used concurrently, must each honour
+	// their own -- the permissive one must not open up the restrictive one.
+	t.Run("conflicting allowlists used concurrently", func(t *testing.T) {
+		var wg sync.WaitGroup
+		for range 20 {
+			wg.Add(2)
+			go func() {
+				defer wg.Done()
+				if err := compile(nil); err != nil {
+					t.Errorf("permissive loader: expected success, got %v", err)
+				}
+			}()
+			go func() {
+				defer wg.Done()
+				if err := compile([]string{}); err == nil {
+					t.Error("restrictive loader: expected remote reference to be denied")
+				}
+			}()
+		}
+		wg.Wait()
+	})
+}
+
+func TestAllowNetIsCheckedOnRedirects(t *testing.T) {
+	var srv *httptest.Server
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/schema.json", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"type": "string"}`)
+	})
+	mux.HandleFunc("/leave", func(w http.ResponseWriter, r *http.Request) {
+		// The same address under a different host name, which is what the
+		// allowlist matches on.
+		viaLocalhost := strings.Replace(srv.URL, "127.0.0.1", "localhost", 1)
+		http.Redirect(w, r, viaLocalhost+"/schema.json", http.StatusFound)
+	})
+	mux.HandleFunc("/hop-then-leave", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, srv.URL+"/leave", http.StatusFound)
+	})
+	mux.HandleFunc("/hop-then-stay", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, srv.URL+"/schema.json", http.StatusFound)
+	})
+	srv = httptest.NewServer(mux)
+	defer srv.Close()
+
+	srvURL, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		note       string
+		entry      string
+		wantDenied bool
+	}{
+		{note: "first hop leaves the allowlist", entry: "/leave", wantDenied: true},
+		{note: "later hop leaves the allowlist", entry: "/hop-then-leave", wantDenied: true},
+		{note: "chain stays within the allowlist", entry: "/hop-then-stay"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.note, func(t *testing.T) {
+			sl := NewSchemaLoader()
+			sl.AllowNet = []string{srvURL.Hostname()} // permits 127.0.0.1, not localhost
+			_, err := sl.Compile(NewStringLoader(fmt.Sprintf(`{"$ref": %q}`, srv.URL+tc.entry)))
+
+			if tc.wantDenied {
+				if err == nil {
+					t.Fatal("expected the redirect to a non-allowlisted host to be denied")
+				}
+				if !strings.Contains(err.Error(), "remote reference loading disabled") {
+					t.Fatalf("expected remote reference loading to be disabled, got %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected the redirect chain to be permitted, got %v", err)
+			}
+		})
+	}
 }

--- a/internal/gojsonschema/schemaLoader.go
+++ b/internal/gojsonschema/schemaLoader.go
@@ -16,6 +16,7 @@ package gojsonschema
 
 import (
 	"bytes"
+	"context"
 	"errors"
 
 	"github.com/xeipuuv/gojsonreference"
@@ -28,6 +29,14 @@ type SchemaLoader struct {
 	Validate         bool
 	Draft            Draft
 	ValidatePatterns bool
+	// AllowNet is the list of hosts that remote references may be fetched
+	// from. A nil list permits any host; a non-nil empty list permits none.
+	AllowNet []string
+	// Context, when set, aborts in-flight remote reference fetches. Callers
+	// that have one -- evaluation, which holds the query's context -- should
+	// pass it so a cancelled or timed-out query doesn't leave requests
+	// running behind it.
+	Context context.Context
 }
 
 // NewSchemaLoader creates a new NewSchemaLoader
@@ -140,7 +149,13 @@ func (sl *SchemaLoader) Compile(rootSchema JSONLoader) (*Schema, error) {
 
 	d := Schema{}
 	d.Pool = sl.pool
-	d.Pool.jsonLoaderFactory = rootSchema.LoaderFactory()
+	// NewStringLoader and NewGoLoader hand back unrestricted factories, so the
+	// limits come from the compilation, not the root loader. The pool resolves
+	// every $ref through this factory, however deeply nested.
+	d.Pool.jsonLoaderFactory = rootSchema.LoaderFactory().withRemoteRefLimits(remoteRefLimits{
+		allowNet: newAllowNetSet(sl.AllowNet),
+		ctx:      sl.Context,
+	})
 	d.DocumentReference = ref
 	d.ReferencePool = newSchemaReferencePool()
 	d.validatePatterns = sl.ValidatePatterns

--- a/internal/gojsonschema/schemaLoader.go
+++ b/internal/gojsonschema/schemaLoader.go
@@ -28,6 +28,9 @@ type SchemaLoader struct {
 	Validate         bool
 	Draft            Draft
 	ValidatePatterns bool
+	// AllowNet is the list of hosts that remote references may be fetched
+	// from. A nil list permits any host; a non-nil empty list permits none.
+	AllowNet []string
 }
 
 // NewSchemaLoader creates a new NewSchemaLoader
@@ -155,7 +158,11 @@ func (sl *SchemaLoader) Compile(rootSchema JSONLoader) (*Schema, error) {
 
 	d := Schema{}
 	d.Pool = sl.pool
-	d.Pool.jsonLoaderFactory = rootSchema.LoaderFactory()
+	// The allowlist is applied to the factory rather than taken from the root
+	// loader, so that every remote reference resolved while compiling this
+	// schema -- however deeply nested -- is checked against the capabilities
+	// of the caller that asked for the compilation.
+	d.Pool.jsonLoaderFactory = rootSchema.LoaderFactory().withAllowNet(newAllowNetSet(sl.AllowNet))
 	d.DocumentReference = ref
 	d.ReferencePool = newSchemaReferencePool()
 	d.validatePatterns = sl.ValidatePatterns

--- a/v1/ast/builtins.go
+++ b/v1/ast/builtins.go
@@ -3125,8 +3125,10 @@ var JSONSchemaVerify = &Builtin{
 		}, nil)).
 			Description("`output` is of the form `[valid, error]`. If the schema is valid, then `valid` is `true`, and `error` is `null`. Otherwise, `valid` is `false` and `error` is a string describing the error."),
 	),
-	Categories:  objectCat,
-	CanSkipBctx: true,
+	Categories: objectCat,
+	// Needs the BuiltinContext to read the allow_net capability, which
+	// restricts the hosts that remote `$ref`s may be fetched from.
+	CanSkipBctx: false,
 }
 
 // JSONMatchSchema returns empty array if the document matches the JSON schema,

--- a/v1/ast/builtins.go
+++ b/v1/ast/builtins.go
@@ -3123,8 +3123,10 @@ var JSONSchemaVerify = &Builtin{
 		}, nil)).
 			Description("`output` is of the form `[valid, error]`. If the schema is valid, then `valid` is `true`, and `error` is `null`. Otherwise, `valid` is `false` and `error` is a string describing the error."),
 	),
-	Categories:  objectCat,
-	CanSkipBctx: true,
+	Categories: objectCat,
+	// Needs the BuiltinContext to read the allow_net capability, which
+	// restricts the hosts that remote `$ref`s may be fetched from.
+	CanSkipBctx: false,
 }
 
 // JSONMatchSchema returns empty array if the document matches the JSON schema,

--- a/v1/ast/compile.go
+++ b/v1/ast/compile.go
@@ -1631,10 +1631,9 @@ func (c *Compiler) checkSafetyRuleHeads() {
 }
 
 func compileSchema(goSchema any, allowNet []string) (*gojsonschema.Schema, error) {
-	gojsonschema.SetAllowNet(allowNet)
-
 	var refLoader gojsonschema.JSONLoader
 	sl := gojsonschema.NewSchemaLoader()
+	sl.AllowNet = allowNet
 
 	if goSchema != nil {
 		refLoader = gojsonschema.NewGoLoader(goSchema)

--- a/v1/topdown/jsonschema.go
+++ b/v1/topdown/jsonschema.go
@@ -54,15 +54,26 @@ func newResultTerm(valid bool, data *ast.Term) *ast.Term {
 // type-checking path, where pattern validation is disabled to tolerate
 // schemas containing ECMA-262 regex features that Go's RE2 dialect can't
 // compile.
-func newPatternValidatingSchemaLoader() *gojsonschema.SchemaLoader {
+//
+// Remote reference fetching is restricted to the hosts in the caller's
+// allow_net capability. Schemas reaching these built-ins come from the policy
+// or, worse, from input, so an unrestricted loader would let a `$ref` drive
+// outbound requests from wherever OPA happens to be deployed. The query's
+// context comes along so that those fetches are abandoned when evaluation is
+// cancelled.
+func newPatternValidatingSchemaLoader(bctx BuiltinContext) *gojsonschema.SchemaLoader {
 	sl := gojsonschema.NewSchemaLoader()
 	sl.ValidatePatterns = true
+	sl.Context = bctx.Context
+	if bctx.Capabilities != nil {
+		sl.AllowNet = bctx.Capabilities.AllowNet
+	}
 	return sl
 }
 
 // builtinJSONSchemaVerify accepts 1 argument which can be string or object and checks if it is valid JSON schema.
 // Returns array [false, <string>] with error string at index 1, or [true, ""] with empty string at index 1 otherwise.
-func builtinJSONSchemaVerify(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term) error) error {
+func builtinJSONSchemaVerify(bctx BuiltinContext, operands []*ast.Term, iter func(*ast.Term) error) error {
 	// Take first argument and make JSON Loader from it.
 	loader, err := astValueToJSONSchemaLoader(operands[0].Value)
 	if err != nil {
@@ -70,7 +81,7 @@ func builtinJSONSchemaVerify(_ BuiltinContext, operands []*ast.Term, iter func(*
 	}
 
 	// Check that schema is correct and parses without errors.
-	if _, err = newPatternValidatingSchemaLoader().Compile(loader); err != nil {
+	if _, err = newPatternValidatingSchemaLoader(bctx).Compile(loader); err != nil {
 		return iter(newResultTerm(false, ast.StringTerm("jsonschema: "+err.Error())))
 	}
 
@@ -80,6 +91,11 @@ func builtinJSONSchemaVerify(_ BuiltinContext, operands []*ast.Term, iter func(*
 // builtinJSONMatchSchema accepts 2 arguments both can be string or object and verifies if the document matches the JSON schema.
 // Returns an array where first element is a boolean indicating a successful match, and the second is an array of errors that is empty on success and populated on failure.
 // In case of internal error returns empty array.
+//
+// Cached schemas are keyed on the schema value alone. A compiled schema has
+// already resolved its remote references, so a cache shared between callers
+// with differing allow_net would leak across them. That needs a deliberately
+// shared cache, an assumption http.send makes as well.
 func builtinJSONMatchSchema(bctx BuiltinContext, operands []*ast.Term, iter func(*ast.Term) error) error {
 	var schema *gojsonschema.Schema
 
@@ -106,7 +122,7 @@ func builtinJSONMatchSchema(bctx BuiltinContext, operands []*ast.Term, iter func
 			return err
 		}
 
-		schema, err = newPatternValidatingSchemaLoader().Compile(schemaLoader)
+		schema, err = newPatternValidatingSchemaLoader(bctx).Compile(schemaLoader)
 		if err != nil {
 			return err
 		}

--- a/v1/topdown/jsonschema.go
+++ b/v1/topdown/jsonschema.go
@@ -54,15 +54,23 @@ func newResultTerm(valid bool, data *ast.Term) *ast.Term {
 // type-checking path, where pattern validation is disabled to tolerate
 // schemas containing ECMA-262 regex features that Go's RE2 dialect can't
 // compile.
-func newPatternValidatingSchemaLoader() *gojsonschema.SchemaLoader {
+//
+// Remote reference fetching is restricted to the hosts in the caller's
+// allow_net capability. Schemas reaching these built-ins come from the policy
+// or, worse, from input, so an unrestricted loader would let a `$ref` drive
+// outbound requests from wherever OPA happens to be deployed.
+func newPatternValidatingSchemaLoader(bctx BuiltinContext) *gojsonschema.SchemaLoader {
 	sl := gojsonschema.NewSchemaLoader()
 	sl.ValidatePatterns = true
+	if bctx.Capabilities != nil {
+		sl.AllowNet = bctx.Capabilities.AllowNet
+	}
 	return sl
 }
 
 // builtinJSONSchemaVerify accepts 1 argument which can be string or object and checks if it is valid JSON schema.
 // Returns array [false, <string>] with error string at index 1, or [true, ""] with empty string at index 1 otherwise.
-func builtinJSONSchemaVerify(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term) error) error {
+func builtinJSONSchemaVerify(bctx BuiltinContext, operands []*ast.Term, iter func(*ast.Term) error) error {
 	// Take first argument and make JSON Loader from it.
 	loader, err := astValueToJSONSchemaLoader(operands[0].Value)
 	if err != nil {
@@ -70,11 +78,30 @@ func builtinJSONSchemaVerify(_ BuiltinContext, operands []*ast.Term, iter func(*
 	}
 
 	// Check that schema is correct and parses without errors.
-	if _, err = newPatternValidatingSchemaLoader().Compile(loader); err != nil {
+	if _, err = newPatternValidatingSchemaLoader(bctx).Compile(loader); err != nil {
 		return iter(newResultTerm(false, ast.StringTerm("jsonschema: "+err.Error())))
 	}
 
 	return iter(newResultTerm(true, ast.InternedNullTerm))
+}
+
+// schemaCacheKey returns the inter-query value cache key for a compiled
+// schema. A compiled schema has already resolved its remote references, so it
+// must not be shared between callers with different allow_net capabilities --
+// otherwise a permissive caller could populate the cache for a restrictive
+// one. When allow_net is unset the schema value is used as-is, keeping the
+// common case allocation-free.
+func schemaCacheKey(bctx BuiltinContext, schema ast.Value) ast.Value {
+	if bctx.Capabilities == nil || bctx.Capabilities.AllowNet == nil {
+		return schema
+	}
+
+	hosts := make([]*ast.Term, len(bctx.Capabilities.AllowNet))
+	for i, host := range bctx.Capabilities.AllowNet {
+		hosts[i] = ast.StringTerm(host)
+	}
+
+	return ast.NewArray(ast.NewTerm(schema), ast.ArrayTerm(hosts...))
 }
 
 // builtinJSONMatchSchema accepts 2 arguments both can be string or object and verifies if the document matches the JSON schema.
@@ -83,8 +110,10 @@ func builtinJSONSchemaVerify(_ BuiltinContext, operands []*ast.Term, iter func(*
 func builtinJSONMatchSchema(bctx BuiltinContext, operands []*ast.Term, iter func(*ast.Term) error) error {
 	var schema *gojsonschema.Schema
 
+	cacheKey := schemaCacheKey(bctx, operands[1].Value)
+
 	if bctx.InterQueryBuiltinValueCache != nil {
-		if val, ok := bctx.InterQueryBuiltinValueCache.Get(operands[1].Value); ok {
+		if val, ok := bctx.InterQueryBuiltinValueCache.Get(cacheKey); ok {
 			if s, isSchema := val.(*gojsonschema.Schema); isSchema {
 				schema = s
 			}
@@ -106,13 +135,13 @@ func builtinJSONMatchSchema(bctx BuiltinContext, operands []*ast.Term, iter func
 			return err
 		}
 
-		schema, err = newPatternValidatingSchemaLoader().Compile(schemaLoader)
+		schema, err = newPatternValidatingSchemaLoader(bctx).Compile(schemaLoader)
 		if err != nil {
 			return err
 		}
 
 		if bctx.InterQueryBuiltinValueCache != nil {
-			bctx.InterQueryBuiltinValueCache.Insert(operands[1].Value, schema)
+			bctx.InterQueryBuiltinValueCache.Insert(cacheKey, schema)
 		}
 	}
 

--- a/v1/topdown/jsonschema_test.go
+++ b/v1/topdown/jsonschema_test.go
@@ -5,6 +5,12 @@
 package topdown
 
 import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/open-policy-agent/opa/v1/topdown/cache"
@@ -507,5 +513,124 @@ func TestBuiltinJSONMatchSchemaCache(t *testing.T) {
 
 	if _, found := valueCache.Get(schema); !found {
 		t.Fatalf("Expected document to be cached")
+	}
+}
+
+func TestBuiltinJSONSchemaAllowNet(t *testing.T) {
+	t.Parallel()
+
+	var requests atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		fmt.Fprint(w, `{"required": ["pwned"]}`)
+	}))
+	defer srv.Close()
+
+	srvURL, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	remoteSchema := ast.String(fmt.Sprintf(`{"$ref": %q}`, srv.URL+"/schema.json"))
+
+	cases := []struct {
+		note         string
+		capabilities *ast.Capabilities
+		wantDenied   bool
+	}{
+		{
+			note:         "no capabilities permits any host",
+			capabilities: nil,
+		},
+		{
+			note:         "unset allow_net permits any host",
+			capabilities: &ast.Capabilities{},
+		},
+		{
+			note:         "empty allow_net permits no host",
+			capabilities: &ast.Capabilities{AllowNet: []string{}},
+			wantDenied:   true,
+		},
+		{
+			note:         "listed host is permitted",
+			capabilities: &ast.Capabilities{AllowNet: []string{srvURL.Hostname()}},
+		},
+		{
+			note:         "unlisted host is denied",
+			capabilities: &ast.Capabilities{AllowNet: []string{"example.com"}},
+			wantDenied:   true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run("json.match_schema/"+tc.note, func(t *testing.T) {
+			before := requests.Load()
+			err := builtinJSONMatchSchema(
+				BuiltinContext{Capabilities: tc.capabilities},
+				[]*ast.Term{ast.NewTerm(ast.String(`{"id": 5}`)), ast.NewTerm(remoteSchema)},
+				func(*ast.Term) error { return nil },
+			)
+
+			fetched := requests.Load() > before
+			if tc.wantDenied {
+				if err == nil {
+					t.Fatal("expected remote reference to be denied, got no error")
+				}
+				if !strings.Contains(err.Error(), "remote reference loading disabled") {
+					t.Fatalf("expected remote reference loading to be disabled, got %v", err)
+				}
+				if fetched {
+					t.Fatal("expected no request to reach the server")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected remote reference to be permitted, got %v", err)
+			}
+			if !fetched {
+				t.Fatal("expected a request to reach the server")
+			}
+		})
+
+		t.Run("json.verify_schema/"+tc.note, func(t *testing.T) {
+			before := requests.Load()
+			var result ast.Value
+			err := builtinJSONSchemaVerify(
+				BuiltinContext{Capabilities: tc.capabilities},
+				[]*ast.Term{ast.NewTerm(remoteSchema)},
+				func(term *ast.Term) error {
+					result = term.Value
+					return nil
+				},
+			)
+			if err != nil {
+				t.Fatalf("Unexpected error: %s", err)
+			}
+
+			arr, ok := result.(*ast.Array)
+			if !ok {
+				t.Fatalf("Unexpected result type, expected array, got %T", result)
+			}
+			valid := arr.Elem(0).Value.Compare(ast.Boolean(true)) == 0
+
+			fetched := requests.Load() > before
+			if tc.wantDenied {
+				if valid {
+					t.Fatalf("expected schema verification to fail, got %s", arr)
+				}
+				if !strings.Contains(arr.Elem(1).String(), "remote reference loading disabled") {
+					t.Fatalf("expected remote reference loading to be disabled, got %s", arr)
+				}
+				if fetched {
+					t.Fatal("expected no request to reach the server")
+				}
+				return
+			}
+			if !valid {
+				t.Fatalf("expected schema verification to succeed, got %s", arr)
+			}
+			if !fetched {
+				t.Fatal("expected a request to reach the server")
+			}
+		})
 	}
 }

--- a/v1/topdown/jsonschema_test.go
+++ b/v1/topdown/jsonschema_test.go
@@ -5,6 +5,12 @@
 package topdown
 
 import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/open-policy-agent/opa/v1/topdown/cache"
@@ -425,5 +431,161 @@ func TestBuiltinJSONMatchSchemaCache(t *testing.T) {
 
 	if _, found := valueCache.Get(schema); !found {
 		t.Fatalf("Expected document to be cached")
+	}
+}
+
+func TestBuiltinJSONSchemaAllowNet(t *testing.T) {
+	t.Parallel()
+
+	var requests atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		fmt.Fprint(w, `{"required": ["pwned"]}`)
+	}))
+	defer srv.Close()
+
+	srvURL, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	remoteSchema := ast.String(fmt.Sprintf(`{"$ref": %q}`, srv.URL+"/schema.json"))
+
+	cases := []struct {
+		note         string
+		capabilities *ast.Capabilities
+		wantDenied   bool
+	}{
+		{
+			note:         "no capabilities permits any host",
+			capabilities: nil,
+		},
+		{
+			note:         "unset allow_net permits any host",
+			capabilities: &ast.Capabilities{},
+		},
+		{
+			note:         "empty allow_net permits no host",
+			capabilities: &ast.Capabilities{AllowNet: []string{}},
+			wantDenied:   true,
+		},
+		{
+			note:         "listed host is permitted",
+			capabilities: &ast.Capabilities{AllowNet: []string{srvURL.Hostname()}},
+		},
+		{
+			note:         "unlisted host is denied",
+			capabilities: &ast.Capabilities{AllowNet: []string{"example.com"}},
+			wantDenied:   true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run("json.match_schema/"+tc.note, func(t *testing.T) {
+			before := requests.Load()
+			err := builtinJSONMatchSchema(
+				BuiltinContext{Capabilities: tc.capabilities},
+				[]*ast.Term{ast.NewTerm(ast.String(`{"id": 5}`)), ast.NewTerm(remoteSchema)},
+				func(*ast.Term) error { return nil },
+			)
+
+			fetched := requests.Load() > before
+			if tc.wantDenied {
+				if err == nil {
+					t.Fatal("expected remote reference to be denied, got no error")
+				}
+				if !strings.Contains(err.Error(), "remote reference loading disabled") {
+					t.Fatalf("expected remote reference loading to be disabled, got %v", err)
+				}
+				if fetched {
+					t.Fatal("expected no request to reach the server")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected remote reference to be permitted, got %v", err)
+			}
+			if !fetched {
+				t.Fatal("expected a request to reach the server")
+			}
+		})
+
+		t.Run("json.verify_schema/"+tc.note, func(t *testing.T) {
+			before := requests.Load()
+			var result ast.Value
+			err := builtinJSONSchemaVerify(
+				BuiltinContext{Capabilities: tc.capabilities},
+				[]*ast.Term{ast.NewTerm(remoteSchema)},
+				func(term *ast.Term) error {
+					result = term.Value
+					return nil
+				},
+			)
+			if err != nil {
+				t.Fatalf("Unexpected error: %s", err)
+			}
+
+			arr, ok := result.(*ast.Array)
+			if !ok {
+				t.Fatalf("Unexpected result type, expected array, got %T", result)
+			}
+			valid := arr.Elem(0).Value.Compare(ast.Boolean(true)) == 0
+
+			fetched := requests.Load() > before
+			if tc.wantDenied {
+				if valid {
+					t.Fatalf("expected schema verification to fail, got %s", arr)
+				}
+				if !strings.Contains(arr.Elem(1).String(), "remote reference loading disabled") {
+					t.Fatalf("expected remote reference loading to be disabled, got %s", arr)
+				}
+				if fetched {
+					t.Fatal("expected no request to reach the server")
+				}
+				return
+			}
+			if !valid {
+				t.Fatalf("expected schema verification to succeed, got %s", arr)
+			}
+			if !fetched {
+				t.Fatal("expected a request to reach the server")
+			}
+		})
+	}
+}
+
+func TestBuiltinJSONMatchSchemaCacheIsScopedToAllowNet(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"required": ["id"]}`)
+	}))
+	defer srv.Close()
+
+	srvURL, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	remoteSchema := ast.String(fmt.Sprintf(`{"$ref": %q}`, srv.URL+"/schema.json"))
+	valueCache := cache.NewInterQueryValueCache(t.Context(), nil)
+
+	call := func(capabilities *ast.Capabilities) error {
+		return builtinJSONMatchSchema(
+			BuiltinContext{
+				Capabilities:                capabilities,
+				InterQueryBuiltinValueCache: valueCache,
+			},
+			[]*ast.Term{ast.NewTerm(ast.String(`{"id": 5}`)), ast.NewTerm(remoteSchema)},
+			func(*ast.Term) error { return nil },
+		)
+	}
+
+	// Populate the cache as a caller that is allowed to reach the host.
+	if err := call(&ast.Capabilities{AllowNet: []string{srvURL.Hostname()}}); err != nil {
+		t.Fatalf("Unexpected error for permitted host: %s", err)
+	}
+
+	// A caller that may not reach the host must not pick up the cached schema.
+	if err := call(&ast.Capabilities{AllowNet: []string{}}); err == nil {
+		t.Fatal("expected cached schema not to be reused by a caller denied network access")
 	}
 }


### PR DESCRIPTION
The allow_net capability restricts which hosts remote JSON schema references may be fetched from. The allowlist was held in a package-level variable in internal/gojsonschema, set from a single place: the compile-time schema type-checking path. Policies that use neither `-s` schemas nor `# METADATA schemas:` annotations never reach that path, so the variable stayed nil, and nil means "permit every host".

The `json.match_schema` and `json.verify_schema` built-ins compile schemas at evaluation time through the same loader, so with allow_net configured but no annotation schemas in play, a `$ref` in a schema was still fetched from any host. Whether the restriction applied at all depended on unrelated policy content having run first. Since the schema argument to those built-ins can come from input, the host was not necessarily under the policy author's control either.

The allowlist is now carried on the SchemaLoader and threaded down to the loaders that perform the fetching, so each caller is checked against its own capabilities. Applying it to the loader factory rather than reading it off the root loader means nested references are covered at any depth. A process can host several compilers and evaluators with different capabilities, and they no longer influence each other.

Redirects were followed unchecked, so a permitted host could bounce a fetch onward to one that is not on the allowlist. Every hop is now checked, matching what http.send already does.

Compiled schemas cached in the inter-query value cache have already resolved their remote references, so the cache key includes the allowlist to keep a permissive caller from populating the cache for a restrictive one.

Credit to @charlesdaniels for bringing the issues around allow_net and `json.match_schema` and `json.verify_schema` to our attention! Thank you!