### PR TITLE
docs: align Rego grammar with parser for calls and ref indexes

### DIFF
--- a/docs/docs/policy-reference/index.md
+++ b/docs/docs/policy-reference/index.md
@@ -398,7 +398,7 @@ literal         = ( some-decl | expr | "not" ( expr | "{" query "}" ) ) { with-m
 with-modifier   = "with" term "as" term
 some-decl       = "some" term { "," term } { "in" expr }
 expr            = term | expr-call | expr-infix | expr-every | expr-parens | unary-expr
-expr-call       = var [ "." var ] "(" [ expr { "," expr } ] ")"
+expr-call       = term "(" [ expr { "," expr } ] ")"
 expr-infix      = expr infix-operator expr
 expr-every      = "every" var { "," var } "in" ( term | expr-call | expr-infix ) "{" query "}"
 expr-parens     = "(" expr ")"
@@ -415,7 +415,7 @@ bin-operator    = "&" | "|"
 assign-operator = ":=" | "="
 ref             = ( var | array | object | set | array-compr | object-compr | set-compr | expr-call ) { ref-arg }
 ref-arg         = ref-arg-dot | ref-arg-brack
-ref-arg-brack   = "[" ( scalar | var | array | object | set | "_" ) "]"
+ref-arg-brack   = "[" ( expr | "_" ) "]"
 ref-arg-dot     = "." var
 var             = ( ALPHA | "_" ) { ALPHA | DIGIT | "_" }
 scalar          = string | NUMBER | TRUE | FALSE | NULL


### PR DESCRIPTION
The published grammar still treated function callees as `var[.var]` only, and `ref-arg-brack` didn't allow expressions in the brackets. Parser already accepts more than that (e.g. `x[i + 1]`, calls on refs).

Updated those two productions. `%` was already listed under `arith-operator`.

Fixes #6261