### PR TITLE
topdown: Treat an empty enum as unsatisfiable in json.match_schema (#8910)

### DIFF
--- a/internal/gojsonschema/README.md
+++ b/internal/gojsonschema/README.md
@@ -13,6 +13,8 @@ The modifications done are as below:
 
 3. Modernize usage of Go in `gojsonschema`, using conventions like type switching and language-built-in map accessing rather than helper methods. 
 
+4. A spec-conformance fix to `enum`. Upstream gates enum validation on `len(subSchema.enum) > 0`, which cannot tell an absent `enum` keyword from `"enum": []` — both leave the slice empty. Per the [validation spec](https://json-schema.org/draft/2020-12/json-schema-validation#section-6.1.2) an instance must deep-equal one of the listed values, so an empty list rejects everything, while an absent keyword constrains nothing. `subSchema` now carries an `enumPresent` flag and validation gates on it. The same defect is present in upstream `xeipuuv/gojsonschema`, which has had no commits since 2024-06-28; it is worth offering there too, but this fork is where OPA's `json.match_schema` reads from.
+
 [![GoDoc](https://godoc.org/github.com/xeipuuv/gojsonschema?status.svg)](https://godoc.org/github.com/xeipuuv/gojsonschema)
 [![Build Status](https://travis-ci.org/xeipuuv/gojsonschema.svg)](https://travis-ci.org/xeipuuv/gojsonschema)
 [![Go Report Card](https://goreportcard.com/badge/github.com/xeipuuv/gojsonschema)](https://goreportcard.com/report/github.com/xeipuuv/gojsonschema)

--- a/internal/gojsonschema/schema.go
+++ b/internal/gojsonschema/schema.go
@@ -676,6 +676,9 @@ func (d *Schema) parseSchema(documentNode any, currentSchema *SubSchema) error {
 	if err != nil {
 		return err
 	}
+	// Record presence separately: getSlice returns an empty slice both for an absent
+	// keyword and for `"enum": []`, and those mean opposite things at validation time.
+	_, currentSchema.enumPresent = m[KeyEnum]
 	for _, v := range enum {
 		is, err := marshalWithoutNumber(v)
 		if err != nil {

--- a/internal/gojsonschema/subSchema.go
+++ b/internal/gojsonschema/subSchema.go
@@ -139,6 +139,11 @@ type SubSchema struct {
 	// validation : all
 	_const *string //const is a golang keyword
 	enum   []string
+	// enumPresent records that the schema carried an "enum" keyword, which `enum` alone
+	// cannot express: an absent keyword and `"enum": []` both leave the slice empty. Per
+	// the spec an empty enum has no value to deep-equal, so it must reject everything,
+	// while an absent enum must constrain nothing.
+	enumPresent bool
 
 	// validation : SubSchema
 	oneOf []*SubSchema

--- a/internal/gojsonschema/validation.go
+++ b/internal/gojsonschema/validation.go
@@ -420,18 +420,28 @@ func (v *SubSchema) validateCommon(currentSubSchema *SubSchema, value any, resul
 	}
 
 	// enum:
-	if len(currentSubSchema.enum) > 0 {
+	// Gate on presence, not length. An absent "enum" constrains nothing; `"enum": []` has
+	// no value for the instance to deep-equal, so it rejects every instance. Both leave the
+	// slice empty, so a length check silently turns the second one into the first — which
+	// makes a schema meant to allow nothing allow everything.
+	if currentSubSchema.enumPresent {
 		vString, err := marshalWithoutNumber(value)
 		if err != nil {
 			result.addInternalError(new(InternalError), context, value, ErrorDetails{"error": err})
 		}
 		if !isStringInSlice(currentSubSchema.enum, *vString) {
+			allowed := strings.Join(currentSubSchema.enum, ", ")
+			if len(currentSubSchema.enum) == 0 {
+				// "must be one of the following: " with nothing after it reads as a bug in
+				// the message rather than a property of the schema.
+				allowed = "(none)"
+			}
 			result.addInternalError(
 				new(EnumError),
 				context,
 				value,
 				ErrorDetails{
-					"allowed": strings.Join(currentSubSchema.enum, ", "),
+					"allowed": allowed,
 				},
 			)
 		}

--- a/v1/topdown/jsonschema_test.go
+++ b/v1/topdown/jsonschema_test.go
@@ -295,6 +295,63 @@ func TestBuiltinJSONMatchSchema(t *testing.T) {
 			err: false,
 		},
 		{
+			// https://json-schema.org/draft/2020-12/json-schema-validation#section-6.1.2:
+			// enum passes only if the instance deep-equals one of the listed values. An
+			// empty list has nothing to deep-equal, so it rejects every instance. Treating
+			// it as an absent keyword makes a schema meant to allow nothing allow
+			// everything, which fails open for any schema generator whose allow-list
+			// resolved to zero entries.
+			note:     "empty enum rejects a string",
+			document: ast.String(`{ "id": "anything" }`),
+			schema:   ast.String(`{ "properties": { "id": { "enum": [] } } }`),
+			result: ast.NewArray(ast.BooleanTerm(false),
+				ast.ArrayTerm(ast.NewTerm(ast.NewObject(
+					[...]*ast.Term{ast.StringTerm("error"), ast.StringTerm("id: id must be one of the following: (none)")},
+					[...]*ast.Term{ast.StringTerm("type"), ast.StringTerm("enum")},
+					[...]*ast.Term{ast.StringTerm("field"), ast.StringTerm("id")},
+					[...]*ast.Term{ast.StringTerm("desc"), ast.StringTerm("id must be one of the following: (none)")},
+				)))),
+			err: false,
+		},
+		{
+			// null is the case most likely to slip through a length-based guard, since a
+			// missing value and a null value look alike in a lot of validators.
+			note:     "empty enum rejects null",
+			document: ast.String(`{ "id": null }`),
+			schema:   ast.String(`{ "properties": { "id": { "enum": [] } } }`),
+			result: ast.NewArray(ast.BooleanTerm(false),
+				ast.ArrayTerm(ast.NewTerm(ast.NewObject(
+					[...]*ast.Term{ast.StringTerm("error"), ast.StringTerm("id: id must be one of the following: (none)")},
+					[...]*ast.Term{ast.StringTerm("type"), ast.StringTerm("enum")},
+					[...]*ast.Term{ast.StringTerm("field"), ast.StringTerm("id")},
+					[...]*ast.Term{ast.StringTerm("desc"), ast.StringTerm("id must be one of the following: (none)")},
+				)))),
+			err: false,
+		},
+		{
+			// The other half of the contract, and the one a presence flag could break: an
+			// absent enum must still constrain nothing.
+			note:     "absent enum constrains nothing",
+			document: ast.String(`{ "id": "anything" }`),
+			schema:   ast.String(`{ "properties": { "id": { "type": "string" } } }`),
+			result:   ast.NewArray(ast.BooleanTerm(true), ast.ArrayTerm()),
+			err:      false,
+		},
+		{
+			// A non-empty enum keeps working, so the presence gate did not widen it.
+			note:     "non-empty enum still rejects a value outside it",
+			document: ast.String(`{ "id": "z" }`),
+			schema:   ast.String(`{ "properties": { "id": { "enum": ["a", "b"] } } }`),
+			result: ast.NewArray(ast.BooleanTerm(false),
+				ast.ArrayTerm(ast.NewTerm(ast.NewObject(
+					[...]*ast.Term{ast.StringTerm("error"), ast.StringTerm(`id: id must be one of the following: "a", "b"`)},
+					[...]*ast.Term{ast.StringTerm("type"), ast.StringTerm("enum")},
+					[...]*ast.Term{ast.StringTerm("field"), ast.StringTerm("id")},
+					[...]*ast.Term{ast.StringTerm("desc"), ast.StringTerm(`id must be one of the following: "a", "b"`)},
+				)))),
+			err: false,
+		},
+		{
 			note:     "string document with matching pattern",
 			document: ast.String(`{ "name": "alice" }`),
 			schema: ast.String(`


### PR DESCRIPTION
Fixes #8910.

## Cause

`validateCommon` gates enum validation on the slice length:

```go
// enum:
if len(currentSubSchema.enum) > 0 {
```

That cannot tell an **absent** `enum` keyword from `"enum": []`. `getSlice` returns an empty slice for both, so the loop that populates `subSchema.enum` never runs either way, and validation is skipped entirely — which is why every value type in the report passed with no errors.

The two cases mean opposite things. Per [§6.1.2](https://json-schema.org/draft/2020-12/json-schema-validation#section-6.1.2) an instance passes `enum` only if it deep-equals one of the listed values; an empty list has nothing to deep-equal, so it rejects everything, while an absent keyword constrains nothing. Collapsing them makes a schema written to allow nothing allow everything.

The reporter's framing of the consequence is the part worth keeping: a schema generator whose allow-list resolves to zero entries **fails open rather than closed**.

## Fix

`subSchema` gains `enumPresent`, set from the raw schema map where presence is still observable, and `validateCommon` gates on that instead of on length. Three lines of behaviour change; the rest is the flag and its comment.

The empty case renders its allowed list as `(none)`:

```
id must be one of the following: (none)
```

rather than `must be one of the following: ` with nothing after it, which reads as a broken message rather than as an unsatisfiable schema. I kept the existing `EnumError` type deliberately — a new error type would change `type` in the result from `"enum"` to something else, and anything matching on that field would break for a case that is still, semantically, an enum failure.

## Tests

Four cases in `TestBuiltinJSONMatchSchema`:

| case | expectation |
| --- | --- |
| empty enum rejects a string | `[false, [enum error]]` |
| empty enum rejects `null` | `[false, [enum error]]` |
| absent enum constrains nothing | `[true, []]` |
| non-empty enum still rejects a value outside it | `[false, [enum error]]` |

`null` is in there because a missing value and a null value look alike to a lot of validators, and it is the case most likely to slip past a length-based guard.

**Reverting only the `validation.go` change**, with all four tests in place:

```
--- FAIL: TestBuiltinJSONMatchSchema/empty_enum_rejects_a_string
--- FAIL: TestBuiltinJSONMatchSchema/empty_enum_rejects_null
```

Exactly those two, and the two controls still pass — so the new tests are pinned to this behaviour rather than to the file having been touched.

## Verification

- `go test ./internal/gojsonschema/... ./v1/topdown/... ./v1/ast/...` — all `ok`
- `go vet` clean, `gofmt -l` clean

`v1/ast` matters here because it's the other importer of this fork — it uses `Compile` for compile-time schema type checking, which reads the parsed schema rather than running validation, so the flag doesn't reach it. Its suite passes either way; I ran it to confirm rather than to assume.

## Two notes

**Documented the divergence.** `internal/gojsonschema/README.md` keeps a numbered list of this fork's modifications from upstream, so this is item 4 rather than an undocumented behaviour change.

**Same defect upstream.** `xeipuuv/gojsonschema` has the identical length gate. It is not archived, but it has had no commits since 2024-06-28 — I checked rather than assumed, having first written "archived" into the README and had to correct it. Happy to open the equivalent PR there if you'd rather the fork not drift further, though this fork has already diverged intentionally in three other ways.

## What this does not do

It doesn't touch the doubled field name in the rendered message (`"error": "id: id must be one of the following: ..."`), which is pre-existing for non-empty enums too — I verified that against unmodified `main` before writing this, so it isn't introduced here. Out of scope for this fix; say the word if you want it in a separate PR.
