### PR TITLE
test: add --strict-builtin-errors to opa test

### DIFF
--- a/cmd/test.go
+++ b/cmd/test.go
@@ -39,33 +39,34 @@ import (
 )
 
 type testCommandParams struct {
-	verbose      bool
-	explain      *util.EnumFlag
-	errLimit     int
-	outputFormat *util.EnumFlag
-	coverage     bool
-	threshold    float64
-	timeout      time.Duration
-	ignore       []string
-	bundleMode   bool
-	benchmark    bool
-	benchMem     bool
-	runRegex     string
-	sortTests    *util.EnumFlag
-	count        int
-	target       *util.EnumFlag
-	skipExitZero bool
-	capabilities *capabilitiesFlag
-	schema       *schemaFlags
-	watch        bool
-	stopChan     chan os.Signal
-	output       io.Writer
-	errOutput    io.Writer
-	v0Compatible bool
-	v1Compatible bool
-	varValues    bool
-	parallel     int
-	failOnEmpty  bool
+	verbose             bool
+	explain             *util.EnumFlag
+	errLimit            int
+	outputFormat        *util.EnumFlag
+	coverage            bool
+	threshold           float64
+	timeout             time.Duration
+	ignore              []string
+	bundleMode          bool
+	benchmark           bool
+	benchMem            bool
+	runRegex            string
+	sortTests           *util.EnumFlag
+	count               int
+	target              *util.EnumFlag
+	skipExitZero        bool
+	capabilities        *capabilitiesFlag
+	schema              *schemaFlags
+	watch               bool
+	stopChan            chan os.Signal
+	output              io.Writer
+	errOutput           io.Writer
+	v0Compatible        bool
+	v1Compatible        bool
+	varValues           bool
+	parallel            int
+	failOnEmpty         bool
+	strictBuiltinErrors bool
 }
 
 func newTestCommandParams() testCommandParams {
@@ -429,7 +430,8 @@ func compileAndSetupTests(ctx context.Context, testParams testCommandParams, sto
 		SetBundles(bundles).
 		SetTimeout(timeout).
 		Filter(testParams.runRegex).
-		SetParallel(testParams.parallel)
+		SetParallel(testParams.parallel).
+		StrictBuiltinErrors(testParams.strictBuiltinErrors)
 
 	if testParams.target.IsSet() {
 		runner = runner.Target(testParams.target.String())
@@ -592,6 +594,7 @@ recommended as some updates might cause them to be dropped by OPA.
 	testCommand.Flags().IntVarP(&testParams.parallel, "parallel", "p", goRuntime.NumCPU(), "the number of tests that can run in parallel, defaulting to the number of CPUs (explicitly set with 0). Benchmarks are always run sequentially.")
 	testCommand.Flags().BoolVar(&testParams.failOnEmpty, "fail-on-empty", false, "Whether to fail the test when no test was run")
 	testCommand.Flags().Var(testParams.sortTests, "sort", "sort the JSON formatted test output")
+	testCommand.Flags().BoolVar(&testParams.strictBuiltinErrors, "strict-builtin-errors", false, "treat the first built-in function error encountered in a test as fatal, reporting it as ERROR instead of FAIL")
 
 	// Shared flags
 	addOutputFormat(testCommand.Flags(), testParams.outputFormat)

--- a/docs/docs/policy-testing.md
+++ b/docs/docs/policy-testing.md
@@ -197,10 +197,14 @@ This is also useful in CI/CD pipelines to ensure that tests are actually being e
 ## Test Results
 
 If the test rule is undefined or generates a non-`true` value the test result
-is reported as `FAIL`. If the test encounters a runtime error (e.g., a divide
-by zero condition) the test result is marked as an `ERROR`. Tests prefixed with
-`todo_` will be reported as `SKIPPED`. Otherwise, the test result is marked as
-`PASS`.
+is reported as `FAIL`. Tests prefixed with `todo_` will be reported as
+`SKIPPED`. Otherwise, the test result is marked as `PASS`.
+
+Errors raised by built-in functions (e.g., a divide by zero condition) make the
+expression undefined rather than aborting evaluation, so by default such a test
+is also reported as `FAIL`. Run `opa test` with `--strict-builtin-errors` to
+treat the first built-in function error in a test as fatal and report it as an
+`ERROR` instead, along with the location and message of the error.
 
 ```rego title="pass_fail_error_test.rego"
 package example_test
@@ -223,17 +227,30 @@ todo_test_missing_implementation if {
 ```
 
 By default, `opa test` reports the number of tests executed and displays all
-of the tests that failed or errored.
+of the tests that failed, errored or were skipped.
 
 ```console
 $ opa test pass_fail_error_test.rego
-data.example_test.test_failure: FAIL (253ns)
-data.example_test.test_error: ERROR (289ns)
-  pass_fail_error_test.rego:15: eval_builtin_error: div: divide by zero
+data.example_test.todo_test_missing_implementation: SKIPPED
+data.example_test.test_failure: FAIL (588.413µs)
+data.example_test.test_error: FAIL (732.268µs)
 --------------------------------------------------------------------------------
-PASS: 1/3
-FAIL: 1/3
-ERROR: 1/3
+PASS: 1/4
+FAIL: 2/4
+SKIPPED: 1/4
+```
+
+With `--strict-builtin-errors`, the divide by zero is reported as an `ERROR`
+instead:
+
+```console
+data.example_test.test_error: ERROR (550.67µs)
+  pass_fail_error_test.rego:12: eval_builtin_error: div: divide by zero
+--------------------------------------------------------------------------------
+PASS: 1/4
+FAIL: 1/4
+SKIPPED: 1/4
+ERROR: 1/4
 ```
 
 By default, OPA prints the test results in a human-readable format. If you

--- a/docs/src/data/cli.json
+++ b/docs/src/data/cli.json
@@ -1547,6 +1547,13 @@
         "type": "{none,duration}"
       },
       {
+        "default": "false",
+        "description": "treat the first built-in function error encountered in a test as fatal, reporting it as ERROR instead of FAIL",
+        "name": "--strict-builtin-errors",
+        "shorthand": "",
+        "type": "bool"
+      },
+      {
         "default": "rego",
         "description": "set the runtime to exercise",
         "name": "--target",

--- a/v1/tester/runner.go
+++ b/v1/tester/runner.go
@@ -324,6 +324,7 @@ type Runner struct {
 	trace                 bool
 	enablePrintStatements bool
 	raiseBuiltinErrors    bool
+	strictBuiltinErrors   bool
 	runtime               *ast.Term
 	timeout               time.Duration
 	modules               map[string]*ast.Module
@@ -370,9 +371,16 @@ func (r *Runner) SetCompiler(compiler *ast.Compiler) *Runner {
 }
 
 // RaiseBuiltinErrors sets the runner to raise errors encountered by builtins
-// such as parsing input.
+// such as parsing input. [StrictBuiltinErrors] takes precedence over this.
 func (r *Runner) RaiseBuiltinErrors(enabled bool) *Runner {
 	r.raiseBuiltinErrors = enabled
+	return r
+}
+
+// StrictBuiltinErrors reports the first builtin error in a test as ERROR
+// instead of FAIL. Takes precedence over [RaiseBuiltinErrors].
+func (r *Runner) StrictBuiltinErrors(enabled bool) *Runner {
+	r.strictBuiltinErrors = enabled
 	return r
 }
 
@@ -1001,6 +1009,7 @@ func (r *Runner) runTest(ctx context.Context, txn storage.Transaction, mod *ast.
 		rego.Target(r.target),
 		rego.PrintHook(topdown.NewPrintHook(printbuf)),
 		rego.BuiltinErrorList(&builtinErrors),
+		rego.StrictBuiltinErrors(r.strictBuiltinErrors),
 	}
 
 	for _, t := range tracers {

--- a/v1/tester/runner_test.go
+++ b/v1/tester/runner_test.go
@@ -869,7 +869,9 @@ func TestRunnerWithBuiltinErrors(t *testing.T) {
 		desc          string
 		json          string
 		builtinErrors bool
+		strict        bool
 		wantErr       bool
+		wantFail      bool
 	}{
 		{
 			desc:          "Valid JSON with flag enabled does not raise an error",
@@ -881,10 +883,23 @@ func TestRunnerWithBuiltinErrors(t *testing.T) {
 			json:          `test: 123`,
 			builtinErrors: true,
 			wantErr:       true,
+			wantFail:      true,
 		},
 		{
-			desc: "Invalid JSON with flag disabled does not raise an error",
-			json: `test: 123`,
+			desc:     "Invalid JSON with flag disabled does not raise an error",
+			json:     `test: 123`,
+			wantFail: true,
+		},
+		{
+			desc:   "Valid JSON with strict flag enabled does not raise an error",
+			json:   `{\"test\": 123}`,
+			strict: true,
+		},
+		{
+			desc:    "Invalid JSON with strict flag enabled raises an error",
+			json:    `test: 123`,
+			strict:  true,
+			wantErr: true,
 		},
 	}
 
@@ -907,7 +922,8 @@ func TestRunnerWithBuiltinErrors(t *testing.T) {
 					NewRunner().
 					SetStore(store).
 					SetModules(modules).
-					RaiseBuiltinErrors(tc.builtinErrors)
+					RaiseBuiltinErrors(tc.builtinErrors).
+					StrictBuiltinErrors(tc.strict)
 
 				ch, err := runner.RunTests(ctx, txn)
 				if err != nil {
@@ -916,6 +932,9 @@ func TestRunnerWithBuiltinErrors(t *testing.T) {
 				for result := range ch {
 					if gotErr := result.Error != nil; gotErr != tc.wantErr {
 						t.Errorf("wantErr = %v, gotErr = %v", tc.wantErr, gotErr)
+					}
+					if result.Fail != tc.wantFail {
+						t.Errorf("wantFail = %v, gotFail = %v", tc.wantFail, result.Fail)
 					}
 				}
 			})


### PR DESCRIPTION
### Why the changes in this PR are needed?

`opa test` reports a builtin error (ex. divide by zero) as `FAIL`, even though the docs  describe it as `ERROR`. `opa eval` already has `--strict-builtin-errors` for this, so added in opa test as well

Fixes #6816.

### What are the changes in this PR?

- Add `tester.Runner.StrictBuiltinErrors()`. When enabled, the first  builtin error in a test is reported as `Result.Error` instead of  `Result.Fail`, matching `opa eval --strict-builtin-errors`.
- `RaiseBuiltinErrors` is unchanged. `StrictBuiltinErrors` takes precedence when both are set
- Updates `docs/docs/policy-testing.md`
