### PR TITLE
wasm: Address regression causing memory corruption

### DIFF
--- a/internal/wasm/sdk/internal/wasm/bindings.go
+++ b/internal/wasm/sdk/internal/wasm/bindings.go
@@ -139,7 +139,13 @@ func (d *builtinDispatcher) opaPrintln(_ context.Context, addr int32) {
 	if uaddr < size {
 		if data, ok := d.mem.Read(uaddr, size-uaddr); ok {
 			if before, _, ok := bytes.Cut(data, []byte{0}); ok {
-				os.Stderr.Write(append(before, '\n'))
+				// before is a sub-slice of data, whose capacity extends past
+				// the NUL byte to the end of the region mem.Read returned,
+				// not just to len(before). append(before, '\n') would write
+				// in place into that capacity, i.e. into the wasm module's
+				// own linear memory, so write the newline separately instead.
+				os.Stderr.Write(before)
+				os.Stderr.WriteString("\n")
 			}
 		}
 	}


### PR DESCRIPTION
The edits here call append and modify the underlying data

https://github.com/open-policy-agent/opa/pull/8993/changes#diff-f7b1543028161be3bac5d911fa4d334b596f6b384d3498810dd32daac3ee9a78

This causes corruption between two print calls.
