### PR TITLE
docs: highlight and/or keywords in Rego syntax

### DIFF
--- a/docs/src/theme/prism-rego.js
+++ b/docs/src/theme/prism-rego.js
@@ -12,8 +12,9 @@ export default function(Prism) {
     },
 
     // Keywords from tmLanguage: default, not, package, import, as, with, else, some, in, every, if, contains
+    // plus the logical operator keywords: and, or
     "keyword": {
-      pattern: /\b(?:default|not|package|import|as|with|else|some|in|every|if|contains)\b/,
+      pattern: /\b(?:default|not|package|import|as|with|else|some|in|every|if|contains|and|or)\b/,
       greedy: true,
     },
 


### PR DESCRIPTION
Adds highlighting for the new and and or keywords in the docs.

Part of https://github.com/open-policy-agent/opa/issues/8999