### PR TITLE
Remove intrange linter as it's covered by  modernize

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -9,7 +9,6 @@ linters:
     - gocritic
     - govet
     - ineffassign
-    - intrange
     - mirror
     - misspell
     - modernize


### PR DESCRIPTION
https://pkg.go.dev/golang.org/x/tools/go/analysis/passes/modernize#hdr-Analyzer_rangeint