### PR TITLE
Use pointer comparison in Equal methods

### DIFF
--- a/internal/compile/constraints.go
+++ b/internal/compile/constraints.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"maps"
 	"strings"
+
+	"github.com/open-policy-agent/opa/v1/util"
 )
 
 type Set[T comparable] map[T]struct{}
@@ -148,12 +150,9 @@ func NewConstraintSet(cs ...*Constraint) *ConstraintSet {
 
 // Builtin returns true if all the constraints in the set support the builtin.
 func (cs *ConstraintSet) Builtin(x string) bool {
-	for i := range cs.Constraints {
-		if !cs.Constraints[i].Builtin(x) {
-			return false
-		}
-	}
-	return true
+	return util.Every(cs.Constraints, func(c *Constraint) bool {
+		return c.Builtin(x)
+	})
 }
 
 func (cs *ConstraintSet) AssertBuiltin(x string) error {

--- a/v1/ast/check.go
+++ b/v1/ast/check.go
@@ -270,10 +270,8 @@ func (tc *typeChecker) checkRule(env *TypeEnv, as *AnnotationSet, rule *Rule) {
 		for _, arg := range rule.Head.Args {
 			// If args are not referred to in body, infer as any.
 			WalkTerms(arg, func(t *Term) bool {
-				if _, ok := t.Value.(Var); ok {
-					if cpy.GetByValue(t.Value) == nil {
-						cpy.tree.PutOne(t.Value, types.A)
-					}
+				if _, ok := t.Value.(Var); ok && cpy.GetByValue(t.Value) == nil {
+					cpy.tree.PutOne(t.Value, types.A)
 				}
 				return false
 			})

--- a/v1/ast/compare.go
+++ b/v1/ast/compare.go
@@ -8,6 +8,7 @@ import (
 	"cmp"
 	"fmt"
 	"math/big"
+	"slices"
 	"strings"
 )
 
@@ -360,7 +361,7 @@ func RefCompare(a, b Ref) int {
 }
 
 func RefEqual(a, b Ref) bool {
-	return termSliceEqual(a, b)
+	return slices.EqualFunc(a, b, (*Term).Equal)
 }
 
 func NumberCompare(x, y Number) int {

--- a/v1/ast/policy.go
+++ b/v1/ast/policy.go
@@ -389,7 +389,7 @@ func (mod *Module) Copy() *Module {
 
 // Equal returns true if mod equals other.
 func (mod *Module) Equal(other *Module) bool {
-	return mod.Compare(other) == 0
+	return mod == other || mod.Compare(other) == 0
 }
 
 func (mod *Module) String() string {
@@ -459,7 +459,7 @@ func (c *Comment) Copy() *Comment {
 // Unlike other equality checks on AST nodes, comment equality
 // depends on location.
 func (c *Comment) Equal(other *Comment) bool {
-	return c.Location.Equal(other.Location) && bytes.Equal(c.Text, other.Text)
+	return c == other || (c.Location.Equal(other.Location) && bytes.Equal(c.Text, other.Text))
 }
 
 // Compare returns an integer indicating whether pkg is less than, equal to,
@@ -477,7 +477,7 @@ func (pkg *Package) Copy() *Package {
 
 // Equal returns true if pkg is equal to other.
 func (pkg *Package) Equal(other *Package) bool {
-	return pkg.Compare(other) == 0
+	return pkg == other || pkg.Compare(other) == 0
 }
 
 // Loc returns the location of the Package in the definition.
@@ -548,7 +548,7 @@ func (imp *Import) Copy() *Import {
 
 // Equal returns true if imp is equal to other.
 func (imp *Import) Equal(other *Import) bool {
-	return imp.Compare(other) == 0
+	return imp == other || imp.Compare(other) == 0
 }
 
 // Loc returns the location of the Import in the definition.
@@ -640,7 +640,7 @@ func (rule *Rule) Copy() *Rule {
 
 // Equal returns true if rule is equal to other.
 func (rule *Rule) Equal(other *Rule) bool {
-	return rule.Compare(other) == 0
+	return rule == other || rule.Compare(other) == 0
 }
 
 // Loc returns the location of the Rule in the definition.
@@ -851,7 +851,7 @@ func (head *Head) Copy() *Head {
 
 // Equal returns true if this head equals other.
 func (head *Head) Equal(other *Head) bool {
-	return head.Compare(other) == 0
+	return head == other || head.Compare(other) == 0
 }
 
 func (head *Head) String() string {
@@ -965,11 +965,7 @@ func (body Body) Compare(other Body) int {
 
 // Copy returns a deep copy of body.
 func (body Body) Copy() Body {
-	cpy := make(Body, len(body))
-	for i := range body {
-		cpy[i] = body[i].Copy()
-	}
-	return cpy
+	return util.Map(body, (*Expr).Copy)
 }
 
 // Contains returns true if this body contains the given expression.
@@ -979,7 +975,7 @@ func (body Body) Contains(x *Expr) bool {
 
 // Equal returns true if this Body is equal to the other Body.
 func (body Body) Equal(other Body) bool {
-	return body.Compare(other) == 0
+	return slices.EqualFunc(body, other, (*Expr).Equal)
 }
 
 // Hash returns the hash code for the Body.
@@ -993,12 +989,7 @@ func (body Body) Hash() int {
 
 // IsGround returns true if all of the expressions in the Body are ground.
 func (body Body) IsGround() bool {
-	for _, e := range body {
-		if !e.IsGround() {
-			return false
-		}
-	}
-	return true
+	return util.Every(body, (*Expr).IsGround)
 }
 
 // Loc returns the location of the Body in the definition.
@@ -1070,7 +1061,7 @@ func (expr *Expr) ComplementNoWith() *Expr {
 
 // Equal returns true if this Expr equals the other Expr.
 func (expr *Expr) Equal(other *Expr) bool {
-	return expr.Compare(other) == 0
+	return expr == other || expr.Compare(other) == 0
 }
 
 // Compare returns an integer indicating whether expr is less than, equal to,
@@ -1086,12 +1077,12 @@ func (expr *Expr) Equal(other *Expr) bool {
 // Otherwise, the expression terms are compared normally. If both expressions
 // have the same terms, the modifiers are compared.
 func (expr *Expr) Compare(other *Expr) int {
-	if expr == nil {
-		if other == nil {
-			return 0
-		}
+	switch {
+	case expr == other:
+		return 0
+	case expr == nil:
 		return -1
-	} else if other == nil {
+	case other == nil:
 		return 1
 	}
 
@@ -1187,7 +1178,6 @@ func (expr *Expr) CopyWithoutTerms() *Expr {
 
 // Copy returns a deep copy of expr.
 func (expr *Expr) Copy() *Expr {
-
 	cpy := expr.CopyWithoutTerms()
 
 	switch ts := expr.Terms.(type) {
@@ -1694,7 +1684,7 @@ func (w *With) String() string {
 
 // Equal returns true if this With is equals the other With.
 func (w *With) Equal(other *With) bool {
-	return Compare(w, other) == 0
+	return w == other || w.Compare(other) == 0
 }
 
 // Compare returns an integer indicating whether w is less than, equal to, or
@@ -1812,11 +1802,10 @@ func NewRuleSet(rules ...*Rule) RuleSet {
 // Add inserts the rule into rs.
 func (rs *RuleSet) Add(rule *Rule) {
 	for _, exist := range *rs {
-		if exist.Equal(rule) {
-			return
+		if !exist.Equal(rule) {
+			*rs = append(*rs, rule)
 		}
 	}
-	*rs = append(*rs, rule)
 }
 
 // Contains returns true if rs contains rule.

--- a/v1/ast/term.go
+++ b/v1/ast/term.go
@@ -611,12 +611,8 @@ func NullTerm() *Term {
 
 // Equal returns true if the other term Value is also Null.
 func (Null) Equal(other Value) bool {
-	switch other.(type) {
-	case Null:
-		return true
-	default:
-		return false
-	}
+	_, ok := other.(Null)
+	return ok
 }
 
 // Compare compares null to other, return <0, 0, or >0 if it is less than, equal to,
@@ -660,12 +656,8 @@ func BooleanTerm(b bool) *Term {
 
 // Equal returns true if the other Value is a Boolean and is equal.
 func (bol Boolean) Equal(other Value) bool {
-	switch other := other.(type) {
-	case Boolean:
-		return bol == other
-	default:
-		return false
-	}
+	_, ok := other.(Boolean)
+	return ok && bol == other
 }
 
 // Compare compares bol to other, return <0, 0, or >0 if it is less than, equal to,
@@ -1319,20 +1311,12 @@ func (ref Ref) DynamicSuffix() Ref {
 
 // IsGround returns true if all of the parts of the Ref are ground.
 func (ref Ref) IsGround() bool {
-	if len(ref) < 2 {
-		return true
-	}
-	return termSliceIsGround(ref[1:])
+	return len(ref) < 2 || util.Every(ref[1:], (*Term).IsGround)
 }
 
 // IsNested returns true if this ref contains other Refs.
 func (ref Ref) IsNested() bool {
-	for _, x := range ref {
-		if _, ok := x.Value.(Ref); ok {
-			return true
-		}
-	}
-	return false
+	return slices.ContainsFunc(ref, TermValueIs[Ref])
 }
 
 // Ptr returns a slash-separated path string for this ref. If the ref
@@ -1454,7 +1438,7 @@ func NewArray(a ...*Term) *Array {
 	for i, e := range a {
 		hs[i] = e.Value.Hash()
 	}
-	arr := &Array{elems: a, hashs: hs, ground: termSliceIsGround(a)}
+	arr := &Array{elems: a, hashs: hs, ground: util.Every(a, (*Term).IsGround)}
 	arr.rehash()
 	return arr
 }
@@ -1630,7 +1614,7 @@ func (arr *Array) Slice(i, j int) *Array {
 	}
 	// If arr is ground, the slice is, too.
 	// If it's not, the slice could still be.
-	gr := arr.ground || termSliceIsGround(elems)
+	gr := arr.ground || util.Every(elems, (*Term).IsGround)
 
 	s := &Array{elems: elems, hashs: hashs, ground: gr}
 	s.rehash()
@@ -2929,7 +2913,7 @@ func (c Call) Hash() int {
 
 // IsGround returns true if the Value is ground.
 func (c Call) IsGround() bool {
-	return termSliceIsGround(c)
+	return util.Every(c, (*Term).IsGround)
 }
 
 // MakeExpr returns a new Expr from this call.
@@ -3020,15 +3004,6 @@ func termSliceHash(a []*Term) int {
 		hash += v.Value.Hash()
 	}
 	return hash
-}
-
-func termSliceIsGround(a []*Term) bool {
-	for _, v := range a {
-		if !v.IsGround() {
-			return false
-		}
-	}
-	return true
 }
 
 // Detect when String() need to use expensive JSON‐escaped form

--- a/v1/util/constraints.go
+++ b/v1/util/constraints.go
@@ -1,0 +1,19 @@
+package util
+
+type (
+	Number interface {
+		Integer | Float
+	}
+	Integer interface {
+		SignedInteger | UnsignedInteger
+	}
+	SignedInteger interface {
+		~int | ~int8 | ~int16 | ~int32 | ~int64
+	}
+	UnsignedInteger interface {
+		~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr
+	}
+	Float interface {
+		~float32 | ~float64
+	}
+)

--- a/v1/util/performance.go
+++ b/v1/util/performance.go
@@ -12,18 +12,6 @@ import (
 	"unsafe"
 )
 
-type (
-	Signed interface {
-		~int | ~int8 | ~int16 | ~int32 | ~int64
-	}
-	Unsigned interface {
-		~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr
-	}
-	Integer interface {
-		Signed | Unsigned
-	}
-)
-
 // SyncPool is a generic sync.Pool for type T, providing some convenience
 // over sync.Pool directly: [SyncPool.Put] ensures that nil values are not
 // put into the pool, and [SyncPool.Get] returns a pointer to T without having

--- a/v1/util/slices.go
+++ b/v1/util/slices.go
@@ -4,7 +4,7 @@
 
 package util
 
-// Map returns a new slice of type U by applying the function f to each element of the input slice s.
+// Map applies f to each element of s and returns a new slice containing the results.
 func Map[T any, U any](s []T, f func(T) U) []U {
 	if s == nil {
 		return nil
@@ -14,6 +14,17 @@ func Map[T any, U any](s []T, f func(T) U) []U {
 		r[i] = f(v)
 	}
 	return r
+}
+
+// Every returns true if pred is true for every element of a, otherwise false.
+// Returns true for empty / nil slices.
+func Every[T any, S ~[]T](a S, pred func(T) bool) bool {
+	for _, v := range a {
+		if !pred(v) {
+			return false
+		}
+	}
+	return true
 }
 
 // TryMap returns a new slice of type U by applying the function f to each element of the input slice s.


### PR DESCRIPTION
That'll be infintely faster when equal (and cost almost nothing extra when not equal). Also add a nifty `util.Every` function to replace some common patterns currently spread out in custom functions.