### PR TITLE
Fix performance regression in InterfaceToValue

### DIFF
--- a/v1/ast/term.go
+++ b/v1/ast/term.go
@@ -75,7 +75,7 @@ func InterfaceToValue(x any) (Value, error) {
 	case nil:
 		return NullValue, nil
 	case bool:
-		return InternedValue(x), nil
+		return internedBooleanValue(x), nil
 	case json.Number:
 		if interned := InternedIntNumberTermFromString(string(x)); interned != nil {
 			return interned.Value, nil
@@ -90,14 +90,40 @@ func InterfaceToValue(x any) (Value, error) {
 	case float64:
 		return floatNumber(x), nil
 	case string:
-		return InternedValue(x), nil
+		return internedStringValue(x), nil
 	case []any:
-		r, err := util.TryMap(x, InterfaceToTermMapper)
-		return NewArray(r...), err
+		r := util.NewPtrSlice[Term](len(x))
+		for i, e := range x {
+			e, err := InterfaceToValue(e)
+			if err != nil {
+				return nil, err
+			}
+			r[i].Value = e
+		}
+		return NewArray(r...), nil
 	case []string:
-		return NewArray(util.Map(x, InternedTerm)...), nil
+		r := util.NewPtrSlice[Term](len(x))
+		for i, e := range x {
+			r[i].Value = internedStringValue(e)
+		}
+		return NewArray(r...), nil
 	case map[string]any:
-		return TryMapToObject(x, nil, InterfaceToTermMapper)
+		kvs := util.NewPtrSlice[Term](len(x) * 2)
+		idx := 0
+		for k, v := range x {
+			kvs[idx].Value = internedStringValue(k)
+			v, err := InterfaceToValue(v)
+			if err != nil {
+				return nil, err
+			}
+			kvs[idx+1].Value = v
+			idx += 2
+		}
+		tuples := make([][2]*Term, len(kvs)/2)
+		for i := 0; i < len(kvs); i += 2 {
+			tuples[i/2] = *(*[2]*Term)(kvs[i : i+2])
+		}
+		return NewObject(tuples...), nil
 	case map[string]string:
 		return MapToObject(x, nil, InternedTerm), nil
 	default:

--- a/v1/topdown/topdown_bench_test.go
+++ b/v1/topdown/topdown_bench_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/open-policy-agent/opa/v1/ast"
 	"github.com/open-policy-agent/opa/v1/metrics"
 	"github.com/open-policy-agent/opa/v1/storage"
-	inmem "github.com/open-policy-agent/opa/v1/storage/inmem/test"
+	"github.com/open-policy-agent/opa/v1/storage/inmem"
 	"github.com/open-policy-agent/opa/v1/util/test"
 )
 
@@ -31,48 +31,41 @@ func BenchmarkArrayIteration(b *testing.B) {
 }
 
 func BenchmarkArrayPlugging(b *testing.B) {
-	ctx := b.Context()
+	type store struct {
+		name  string
+		store storage.Store
+	}
 
-	sizes := []int{10, 100, 1000, 10000}
+	data := make([]any, 1000)
+	for i := range data {
+		data[i] = fmt.Sprintf("whatever%d", i)
+	}
+	src := map[string]any{"fixture": data}
 
-	for _, n := range sizes {
-		b.Run(strconv.Itoa(n), func(b *testing.B) {
-			data := make([]any, n)
-			for i := range n {
-				data[i] = fmt.Sprintf("whatever%d", i)
-			}
-			store := inmem.NewFromObject(map[string]any{"fixture": data})
-			module := `package test
-			fixture := data.fixture
-			main if { x := fixture }`
+	stores := []store{
+		{"mapStore", inmem.NewFromObject(src)},
+		{"astStore", inmem.NewFromASTObject(ast.MustInterfaceToValue(src).(ast.Object))},
+	}
+	mods := map[string]string{"test.rego": "package test\nfixture := data.fixture\nmain if { x := fixture }"}
 
-			query := ast.MustParseBody("data.test.main")
-			compiler := ast.MustCompileModules(map[string]string{
-				"test.rego": module,
-			})
+	for _, tc := range stores {
+		b.Run(tc.name, func(b *testing.B) {
+			ctx := b.Context()
+			err := storage.Txn(ctx, tc.store, storage.TransactionParams{}, func(txn storage.Transaction) error {
+				q := NewQuery(ast.MustParseBody("data.test.main")).
+					WithCompiler(ast.MustCompileModules(mods)).
+					WithStore(tc.store).
+					WithTransaction(txn)
 
-			b.ResetTimer()
-
-			for b.Loop() {
-
-				err := storage.Txn(ctx, store, storage.TransactionParams{}, func(txn storage.Transaction) error {
-
-					q := NewQuery(query).
-						WithCompiler(compiler).
-						WithStore(store).
-						WithTransaction(txn)
-
-					_, err := q.Run(ctx)
-					if err != nil {
+				for b.Loop() {
+					if _, err := q.Run(ctx); err != nil {
 						return err
 					}
-
-					return nil
-				})
-
-				if err != nil {
-					b.Fatal(err)
 				}
+				return nil
+			})
+			if err != nil {
+				b.Fatal(err)
 			}
 		})
 	}
@@ -97,17 +90,12 @@ func BenchmarkObjectIteration(b *testing.B) {
 }
 
 func benchmarkIteration(b *testing.B, module string) {
-	ctx := b.Context()
-	query := ast.MustParseBody("data.test.main")
-	compiler := ast.MustCompileModules(map[string]string{
-		"test.rego": module,
-	})
+	p := ast.MustParseBody("data.test.main")
+	c := ast.MustCompileModules(map[string]string{"test.rego": module})
+	q := NewQuery(p).WithCompiler(c)
 
 	for b.Loop() {
-
-		q := NewQuery(query).WithCompiler(compiler)
-		_, err := q.Run(ctx)
-		if err != nil {
+		if _, err := q.Run(b.Context()); err != nil {
 			b.Fatal(err)
 		}
 	}


### PR DESCRIPTION
I was hoping we could get rid of my old `util.NewPtrSlice` hack, but as @srenatus kindly pointed out, that proved to be much to costly, and I should have checked existing benchmarks better. This reverts the changes that got in on the "http.send" improvements PR regarding ast.InterfaceToValue, and only those.

Also cleaned up the relevant benchmark and had it run with both Go and AST storage backends, which was really what was benchmarked here.

Since this fixes a recent addition, it should not be included in the next release notes.
