### PR TITLE
oracle: Support `and`/`or` logical keywords

### DIFF
--- a/cmd/oracle.go
+++ b/cmd/oracle.go
@@ -25,8 +25,15 @@ import (
 type findDefinitionParams struct {
 	stdinBuffer  bool
 	bundlePaths  repeatedStringFlag
+	capabilities *capabilitiesFlag
 	v0Compatible bool
 	v1Compatible bool
+}
+
+func newFindDefinitionParams() findDefinitionParams {
+	return findDefinitionParams{
+		capabilities: newCapabilitiesFlag(),
+	}
 }
 
 func (p *findDefinitionParams) regoVersion() ast.RegoVersion {
@@ -40,9 +47,17 @@ func (p *findDefinitionParams) regoVersion() ast.RegoVersion {
 	return ast.DefaultRegoVersion
 }
 
+func (p *findDefinitionParams) parserOptions() ast.ParserOptions {
+	popts := ast.ParserOptions{Capabilities: p.capabilities.C}
+	if p.v0Compatible || p.v1Compatible {
+		popts.RegoVersion = p.regoVersion()
+	}
+	return popts
+}
+
 func initOracle(root *cobra.Command, brand string) {
 
-	var findDefinitionParams findDefinitionParams
+	var findDefinitionParams = newFindDefinitionParams()
 
 	var oracleCommand = &cobra.Command{
 		Use:    "oracle",
@@ -109,9 +124,10 @@ by the input location.`,
 
 	findDefinitionCommand.Flags().BoolVarP(&findDefinitionParams.stdinBuffer, "stdin-buffer", "", false, "read buffer from stdin")
 	addBundleFlag(findDefinitionCommand.Flags(), &findDefinitionParams.bundlePaths)
+	addCapabilitiesFlag(findDefinitionCommand.Flags(), findDefinitionParams.capabilities)
+	addV0CompatibleFlag(findDefinitionCommand.Flags(), &findDefinitionParams.v0Compatible, false)
+	addV1CompatibleFlag(findDefinitionCommand.Flags(), &findDefinitionParams.v1Compatible, false)
 	oracleCommand.AddCommand(findDefinitionCommand)
-	addV0CompatibleFlag(oracleCommand.Flags(), &findDefinitionParams.v0Compatible, false)
-	addV1CompatibleFlag(oracleCommand.Flags(), &findDefinitionParams.v1Compatible, false)
 	root.AddCommand(oracleCommand)
 }
 
@@ -136,6 +152,7 @@ func dofindDefinition(params findDefinitionParams, stdin io.Reader, stdout io.Wr
 				// only .rego will work reliably for the purpose of finding definitions
 				return strings.HasPrefix(info.Name(), ".rego")
 			}).
+			WithCapabilities(params.capabilities.C).
 			WithRegoVersion(params.regoVersion()).
 			AsBundle(params.bundlePaths.v[0])
 		if err != nil {
@@ -170,10 +187,11 @@ func dofindDefinition(params findDefinitionParams, stdin io.Reader, stdout io.Wr
 	// FindDefinition() will instantiate a new compiler, but we don't need to set the
 	// default rego-version because the passed modules already have the rego-version from parsing.
 	result, err := oracle.New().FindDefinition(oracle.DefinitionQuery{
-		Buffer:   bs,
-		Filename: filename,
-		Pos:      offset,
-		Modules:  modules,
+		Buffer:        bs,
+		Filename:      filename,
+		Pos:           offset,
+		Modules:       modules,
+		ParserOptions: params.parserOptions(),
 	})
 
 	if err != nil {

--- a/cmd/oracle_jsonv2_test.go
+++ b/cmd/oracle_jsonv2_test.go
@@ -4,6 +4,7 @@ package cmd
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"path"
@@ -12,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/open-policy-agent/opa/v1/ast"
 	"github.com/open-policy-agent/opa/v1/util"
 	"github.com/open-policy-agent/opa/v1/util/test"
 )
@@ -75,14 +77,13 @@ q = true`,
 
 			test.WithTempFS(files, func(rootDir string) {
 
-				params := findDefinitionParams{
-					bundlePaths: repeatedStringFlag{
-						v:     []string{rootDir},
-						isSet: true,
-					},
-					stdinBuffer:  true,
-					v0Compatible: tc.v0Compatible,
+				params := newFindDefinitionParams()
+				params.bundlePaths = repeatedStringFlag{
+					v:     []string{rootDir},
+					isSet: true,
 				}
+				params.stdinBuffer = true
+				params.v0Compatible = tc.v0Compatible
 
 				stdout := bytes.NewBuffer(nil)
 
@@ -123,13 +124,12 @@ q = true`)
 	}
 
 	test.WithTempFS(files, func(rootDir string) {
-		params := findDefinitionParams{
-			bundlePaths: repeatedStringFlag{
-				v:     []string{rootDir},
-				isSet: true,
-			},
-			stdinBuffer: true,
+		params := newFindDefinitionParams()
+		params.bundlePaths = repeatedStringFlag{
+			v:     []string{rootDir},
+			isSet: true,
 		}
+		params.stdinBuffer = true
 
 		stdout := bytes.NewBuffer(nil)
 
@@ -148,6 +148,94 @@ q = true`)
 			t.Errorf("unexpected result (-want, +got):\n%s", diff)
 		}
 	})
+}
+
+// The oracle parses the stdin buffer itself, so keywords that are gated behind
+// capabilities must reach it through the --capabilities flag.
+func TestOracleFindDefinitionExperimentalKeywords(t *testing.T) {
+	module := `package test
+
+import future.keywords.or
+
+p if {
+	q or r
+}
+
+q := 1
+
+r := 2`
+
+	capabilities, err := json.Marshal(ast.CapabilitiesForThisVersion(ast.CapabilitiesExperimentalKeywords(true)))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	files := map[string]string{
+		"test.rego":         module,
+		"capabilities.json": string(capabilities),
+	}
+
+	// offset of 'q' in the 'q or r' expression
+	pos := strings.Index(module, "q or r")
+
+	rootDir := test.TempDir(t, files)
+
+	params := newFindDefinitionParams()
+	params.bundlePaths = repeatedStringFlag{
+		v:     []string{rootDir},
+		isSet: true,
+	}
+	params.stdinBuffer = true
+
+	arg := fmt.Sprintf("%s:%d", path.Join(rootDir, "test.rego"), pos)
+	stdout := bytes.NewBuffer(nil)
+
+	err = dofindDefinition(params, bytes.NewBufferString(module), stdout, []string{arg})
+	if err == nil || !strings.Contains(err.Error(), "rego_parse_error") {
+		t.Fatal("expected parse error without capabilities but got:", err, "result:", stdout.String())
+	}
+
+	if err := params.capabilities.Set(path.Join(rootDir, "capabilities.json")); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout.Reset()
+
+	err = dofindDefinition(params, bytes.NewBufferString(module), stdout, []string{arg})
+	expectJSON(t, err, stdout, fmt.Sprintf(`{"result": {
+		"file": %q,
+		"row": 9,
+		"col": 1
+	}}`, path.Join(rootDir, "test.rego")))
+}
+
+// The rego-version must be left undefined unless explicitly asked for, so that the
+// buffer inherits it from the file it shadows, e.g. one parsed as v0 because of a
+// bundle manifest.
+func TestFindDefinitionParamsParserOptions(t *testing.T) {
+	tests := []struct {
+		note         string
+		v0Compatible bool
+		v1Compatible bool
+		exp          ast.RegoVersion
+	}{
+		{note: "no flags", exp: ast.RegoUndefined},
+		{note: "v0", v0Compatible: true, exp: ast.RegoV0},
+		{note: "v1", v1Compatible: true, exp: ast.RegoV1},
+		{note: "v0 takes precedence over v1", v0Compatible: true, v1Compatible: true, exp: ast.RegoV0},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.note, func(t *testing.T) {
+			params := newFindDefinitionParams()
+			params.v0Compatible = tc.v0Compatible
+			params.v1Compatible = tc.v1Compatible
+
+			if act := params.parserOptions().RegoVersion; act != tc.exp {
+				t.Fatalf("expected rego-version %v but got %v", tc.exp, act)
+			}
+		})
+	}
 }
 
 func expectJSON(t *testing.T, err error, buffer *bytes.Buffer, exp string) {

--- a/cmd/oracle_test.go
+++ b/cmd/oracle_test.go
@@ -4,6 +4,7 @@ package cmd
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"path"
@@ -12,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/open-policy-agent/opa/v1/ast"
 	"github.com/open-policy-agent/opa/v1/util"
 	"github.com/open-policy-agent/opa/v1/util/test"
 )
@@ -75,14 +77,13 @@ q = true`,
 
 			test.WithTempFS(files, func(rootDir string) {
 
-				params := findDefinitionParams{
-					bundlePaths: repeatedStringFlag{
-						v:     []string{rootDir},
-						isSet: true,
-					},
-					stdinBuffer:  true,
-					v0Compatible: tc.v0Compatible,
+				params := newFindDefinitionParams()
+				params.bundlePaths = repeatedStringFlag{
+					v:     []string{rootDir},
+					isSet: true,
 				}
+				params.stdinBuffer = true
+				params.v0Compatible = tc.v0Compatible
 
 				stdout := bytes.NewBuffer(nil)
 
@@ -123,13 +124,12 @@ q = true`)
 	}
 
 	test.WithTempFS(files, func(rootDir string) {
-		params := findDefinitionParams{
-			bundlePaths: repeatedStringFlag{
-				v:     []string{rootDir},
-				isSet: true,
-			},
-			stdinBuffer: true,
+		params := newFindDefinitionParams()
+		params.bundlePaths = repeatedStringFlag{
+			v:     []string{rootDir},
+			isSet: true,
 		}
+		params.stdinBuffer = true
 
 		stdout := bytes.NewBuffer(nil)
 
@@ -148,6 +148,94 @@ q = true`)
 			t.Errorf("unexpected result (-want, +got):\n%s", diff)
 		}
 	})
+}
+
+// The oracle parses the stdin buffer itself, so keywords that are gated behind
+// capabilities must reach it through the --capabilities flag.
+func TestOracleFindDefinitionExperimentalKeywords(t *testing.T) {
+	module := `package test
+
+import future.keywords.or
+
+p if {
+	q or r
+}
+
+q := 1
+
+r := 2`
+
+	capabilities, err := json.Marshal(ast.CapabilitiesForThisVersion(ast.CapabilitiesExperimentalKeywords(true)))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	files := map[string]string{
+		"test.rego":         module,
+		"capabilities.json": string(capabilities),
+	}
+
+	// offset of 'q' in the 'q or r' expression
+	pos := strings.Index(module, "q or r")
+
+	rootDir := test.TempDir(t, files)
+
+	params := newFindDefinitionParams()
+	params.bundlePaths = repeatedStringFlag{
+		v:     []string{rootDir},
+		isSet: true,
+	}
+	params.stdinBuffer = true
+
+	arg := fmt.Sprintf("%s:%d", path.Join(rootDir, "test.rego"), pos)
+	stdout := bytes.NewBuffer(nil)
+
+	err = dofindDefinition(params, bytes.NewBufferString(module), stdout, []string{arg})
+	if err == nil || !strings.Contains(err.Error(), "rego_parse_error") {
+		t.Fatal("expected parse error without capabilities but got:", err, "result:", stdout.String())
+	}
+
+	if err := params.capabilities.Set(path.Join(rootDir, "capabilities.json")); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout.Reset()
+
+	err = dofindDefinition(params, bytes.NewBufferString(module), stdout, []string{arg})
+	expectJSON(t, err, stdout, fmt.Sprintf(`{"result": {
+		"file": %q,
+		"row": 9,
+		"col": 1
+	}}`, path.Join(rootDir, "test.rego")))
+}
+
+// The rego-version must be left undefined unless explicitly asked for, so that the
+// buffer inherits it from the file it shadows, e.g. one parsed as v0 because of a
+// bundle manifest.
+func TestFindDefinitionParamsParserOptions(t *testing.T) {
+	tests := []struct {
+		note         string
+		v0Compatible bool
+		v1Compatible bool
+		exp          ast.RegoVersion
+	}{
+		{note: "no flags", exp: ast.RegoUndefined},
+		{note: "v0", v0Compatible: true, exp: ast.RegoV0},
+		{note: "v1", v1Compatible: true, exp: ast.RegoV1},
+		{note: "v0 takes precedence over v1", v0Compatible: true, v1Compatible: true, exp: ast.RegoV0},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.note, func(t *testing.T) {
+			params := newFindDefinitionParams()
+			params.v0Compatible = tc.v0Compatible
+			params.v1Compatible = tc.v1Compatible
+
+			if act := params.parserOptions().RegoVersion; act != tc.exp {
+				t.Fatalf("expected rego-version %v but got %v", tc.exp, act)
+			}
+		})
+	}
 }
 
 func expectJSON(t *testing.T, err error, buffer *bytes.Buffer, exp string) {

--- a/v1/ast/oracle/oracle.go
+++ b/v1/ast/oracle/oracle.go
@@ -29,10 +29,11 @@ func New() *Oracle {
 
 // DefinitionQuery defines a Rego definition query.
 type DefinitionQuery struct {
-	Modules  map[string]*ast.Module // workspace modules; buffer may shadow a file inside the workspace
-	Filename string                 // name of file to search for position inside of
-	Buffer   []byte                 // buffer that overrides module with filename
-	Pos      int                    // position to search for
+	Modules       map[string]*ast.Module // workspace modules; buffer may shadow a file inside the workspace
+	Filename      string                 // name of file to search for position inside of
+	Buffer        []byte                 // buffer that overrides module with filename
+	Pos           int                    // position to search for
+	ParserOptions ast.ParserOptions      // options for parsing Buffer
 }
 
 var (
@@ -64,7 +65,7 @@ func (o *Oracle) FindDefinition(q DefinitionQuery) (*DefinitionQueryResult, erro
 	// Ditto for caching across runs. Avoid repeating the same work.
 
 	// NOTE(sr): "SetRuleTree" because it's needed for compiler.GetRulesExact() below
-	compiler, parsed, err := o.compileUpto("SetRuleTree", q.Modules, q.Buffer, q.Filename)
+	compiler, parsed, err := o.compileUpto("SetRuleTree", q)
 	if err != nil {
 		return nil, err
 	}
@@ -92,7 +93,7 @@ func (o *Oracle) FindDefinition(q DefinitionQuery) (*DefinitionQueryResult, erro
 	return &DefinitionQueryResult{Result: location}, nil
 }
 
-func (o *Oracle) compileUpto(stage ast.StageID, modules map[string]*ast.Module, bs []byte, filename string) (*ast.Compiler, *ast.Module, error) {
+func (o *Oracle) compileUpto(stage ast.StageID, q DefinitionQuery) (*ast.Compiler, *ast.Module, error) {
 	var compiler *ast.Compiler
 	if o.compiler != nil {
 		compiler = o.compiler
@@ -104,6 +105,7 @@ func (o *Oracle) compileUpto(stage ast.StageID, modules map[string]*ast.Module, 
 		compiler = compiler.WithOnlyStagesUpTo(stage)
 	}
 
+	modules := q.Modules
 	if modules == nil {
 		modules = map[string]*ast.Module{}
 	}
@@ -111,14 +113,16 @@ func (o *Oracle) compileUpto(stage ast.StageID, modules map[string]*ast.Module, 
 	var module *ast.Module
 	var err error
 
-	if len(bs) > 0 {
-		module, err = ast.ParseModule(filename, util.ByteSliceToString(bs))
+	if len(q.Buffer) > 0 {
+		popts := parserOptions(q.ParserOptions, compiler, modules[q.Filename])
+
+		module, err = ast.ParseModuleWithOpts(q.Filename, util.ByteSliceToString(q.Buffer), popts)
 		if err != nil {
 			return nil, nil, err
 		}
-		modules[filename] = module
+		modules[q.Filename] = module
 	} else {
-		module = modules[filename]
+		module = modules[q.Filename]
 	}
 
 	compiler.Compile(modules)
@@ -127,4 +131,16 @@ func (o *Oracle) compileUpto(stage ast.StageID, modules map[string]*ast.Module, 
 	}
 
 	return compiler, module, nil
+}
+
+func parserOptions(popts ast.ParserOptions, compiler *ast.Compiler, shadowed *ast.Module) ast.ParserOptions {
+	if popts.Capabilities == nil {
+		popts.Capabilities = compiler.Capabilities()
+	}
+
+	if popts.RegoVersion == ast.RegoUndefined && shadowed != nil {
+		popts.RegoVersion = shadowed.RegoVersion()
+	}
+
+	return popts
 }

--- a/v1/ast/oracle/oracle_logical_test.go
+++ b/v1/ast/oracle/oracle_logical_test.go
@@ -1,0 +1,552 @@
+// Copyright 2026 The OPA Authors. All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+package oracle
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/open-policy-agent/opa/v1/ast"
+)
+
+// cursorMarker marks the position to query for in a test module. It is removed
+// from the module before parsing, and its byte offset becomes the query position.
+const cursorMarker = "‸"
+
+func experimentalCapabilities() *ast.Capabilities {
+	return ast.CapabilitiesForThisVersion(ast.CapabilitiesExperimentalKeywords(true))
+}
+
+func logicalParserOpts() ast.ParserOptions {
+	return ast.ParserOptions{
+		Capabilities:   experimentalCapabilities(),
+		FutureKeywords: []string{"and", "or", "not"},
+	}
+}
+
+func cursorOffset(t *testing.T, module string) (string, int) {
+	t.Helper()
+
+	pos := strings.Index(module, cursorMarker)
+	if pos < 0 {
+		t.Fatalf("module is missing the %q cursor marker", cursorMarker)
+	}
+
+	return strings.Replace(module, cursorMarker, "", 1), pos
+}
+
+func TestOracleFindDefinitionLogical(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		note    string
+		opts    *ast.ParserOptions // defaults to logicalParserOpts()
+		modules map[string]string  // buffer.rego holds the cursor marker
+		exp     *ast.Location
+	}{
+		{
+			note: "rule ref in implicit lhs operand",
+			modules: map[string]string{
+				"buffer.rego": `package test
+
+p if {
+	‸q or r
+}
+
+q := 1
+
+r := 2`,
+			},
+			exp: &ast.Location{File: "buffer.rego", Row: 7, Col: 1, Text: []byte("q := 1")},
+		},
+		{
+			note: "rule ref in implicit rhs operand",
+			modules: map[string]string{
+				"buffer.rego": `package test
+
+p if {
+	q or ‸r
+}
+
+q := 1
+
+r := 2`,
+			},
+			exp: &ast.Location{File: "buffer.rego", Row: 9, Col: 1, Text: []byte("r := 2")},
+		},
+		{
+			note: "rule ref in explicit operand body",
+			modules: map[string]string{
+				"buffer.rego": `package test
+
+p if {
+	{‸q} and {r}
+}
+
+q := 1
+
+r := 2`,
+			},
+			exp: &ast.Location{File: "buffer.rego", Row: 7, Col: 1, Text: []byte("q := 1")},
+		},
+		{
+			note: "outer var referenced from operand body",
+			modules: map[string]string{
+				"buffer.rego": `package test
+
+p if {
+	x := 1
+	{‸x > 0} and {x < 5}
+}`,
+			},
+			exp: &ast.Location{File: "buffer.rego", Row: 4, Col: 2, Text: []byte("x")},
+		},
+		{
+			note: "operand-local assignment",
+			modules: map[string]string{
+				"buffer.rego": `package test
+
+p if {
+	{y := 1; ‸y > 0} and q
+}
+
+q := 2`,
+			},
+			exp: &ast.Location{File: "buffer.rego", Row: 4, Col: 3, Text: []byte("y")},
+		},
+		{
+			note: "assignment in enclosing operand body",
+			modules: map[string]string{
+				"buffer.rego": `package test
+
+p if {
+	{y := 1; {‸y > 0} and true} or false
+}`,
+			},
+			exp: &ast.Location{File: "buffer.rego", Row: 4, Col: 3, Text: []byte("y")},
+		},
+		{
+			note: "assignment in sibling operand body is not visible",
+			modules: map[string]string{
+				"buffer.rego": `package test
+
+p if {
+	{x := 1; x > 0} or {x := 2; ‸x > 1}
+}`,
+			},
+			exp: &ast.Location{File: "buffer.rego", Row: 4, Col: 22, Text: []byte("x")},
+		},
+		{
+			note: "some declaration in operand body",
+			modules: map[string]string{
+				"buffer.rego": `package test
+
+p if {
+	{some x in [1]; ‸x > 0} and true
+}`,
+			},
+			exp: &ast.Location{File: "buffer.rego", Row: 4, Col: 8, Text: []byte("x")},
+		},
+		{
+			note: "some domain in operand body",
+			modules: map[string]string{
+				"buffer.rego": `package test
+
+p if {
+	{some x in ‸d; x > 0} and true
+}
+
+d := [1]`,
+			},
+			exp: &ast.Location{File: "buffer.rego", Row: 7, Col: 1, Text: []byte("d := [1]")},
+		},
+		{
+			note: "function argument referenced from operand body",
+			modules: map[string]string{
+				"buffer.rego": `package test
+
+f(a) if {
+	{‸a > 1} or {a < 0}
+}`,
+			},
+			exp: &ast.Location{File: "buffer.rego", Row: 3, Col: 3, Text: []byte("a")},
+		},
+		{
+			note: "imported ref in operand resolves in other module",
+			modules: map[string]string{
+				"buffer.rego": `package test
+
+import data.lib
+
+p if {
+	‸lib.q or lib.r
+}`,
+				"lib.rego": `package lib
+
+q := 1
+
+r := 2`,
+			},
+			exp: &ast.Location{File: "lib.rego", Row: 3, Col: 1, Text: []byte("q := 1")},
+		},
+		{
+			note: "ref in nested parenthesized groups",
+			modules: map[string]string{
+				"buffer.rego": `package test
+
+p if {
+	((‸q or r) and s) or t
+}
+
+q := 1
+
+r := 2
+
+s := 3
+
+t := 4`,
+			},
+			exp: &ast.Location{File: "buffer.rego", Row: 7, Col: 1, Text: []byte("q := 1")},
+		},
+		{
+			note: "ref in negated group",
+			modules: map[string]string{
+				"buffer.rego": `package test
+
+p if {
+	not (q or ‸r)
+}
+
+q := 1
+
+r := 2`,
+			},
+			exp: &ast.Location{File: "buffer.rego", Row: 9, Col: 1, Text: []byte("r := 2")},
+		},
+		{
+			note: "ref in or inside every body",
+			modules: map[string]string{
+				"buffer.rego": `package test
+
+p if {
+	every v in [1] {
+		‸q or v
+	}
+}
+
+q := 1`,
+			},
+			exp: &ast.Location{File: "buffer.rego", Row: 9, Col: 1, Text: []byte("q := 1")},
+		},
+		{
+			note: "ref in or inside comprehension body",
+			modules: map[string]string{
+				"buffer.rego": `package test
+
+p := [x |
+	x := 1
+	‸q or r
+]
+
+q := 1
+
+r := 2`,
+			},
+			exp: &ast.Location{File: "buffer.rego", Row: 8, Col: 1, Text: []byte("q := 1")},
+		},
+		{
+			note: "ref in operand body with with-modifier",
+			modules: map[string]string{
+				"buffer.rego": `package test
+
+p if {
+	{q with input as 1} and ‸r
+}
+
+q := input
+
+r := 2`,
+			},
+			exp: &ast.Location{File: "buffer.rego", Row: 9, Col: 1, Text: []byte("r := 2")},
+		},
+		{
+			note: "ref in group with with-modifier",
+			modules: map[string]string{
+				"buffer.rego": `package test
+
+p if {
+	(‸q and r) with input as 1
+}
+
+q := input
+
+r := 2`,
+			},
+			exp: &ast.Location{File: "buffer.rego", Row: 7, Col: 1, Text: []byte("q := input")},
+		},
+		{
+			note: "keywords activated by future import",
+			opts: &ast.ParserOptions{Capabilities: experimentalCapabilities()},
+			modules: map[string]string{
+				"buffer.rego": `package test
+
+import future.keywords.and
+
+p if {
+	‸q and r
+}
+
+q := 1
+
+r := 2`,
+			},
+			exp: &ast.Location{File: "buffer.rego", Row: 9, Col: 1, Text: []byte("q := 1")},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.note, func(t *testing.T) {
+			t.Parallel()
+
+			opts := logicalParserOpts()
+			if tc.opts != nil {
+				opts = *tc.opts
+			}
+
+			buffer, pos := cursorOffset(t, tc.modules["buffer.rego"])
+
+			modules := map[string]*ast.Module{}
+			for k, v := range tc.modules {
+				if k == "buffer.rego" {
+					v = buffer
+				}
+
+				var err error
+				modules[k], err = ast.ParseModuleWithOpts(k, v, opts)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			result, err := New().FindDefinition(DefinitionQuery{
+				Modules:       modules,
+				Buffer:        []byte(buffer),
+				Filename:      "buffer.rego",
+				Pos:           pos,
+				ParserOptions: opts,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !tc.exp.Equal(result.Result) {
+				t.Fatalf("expected %v %q but got %v %q", tc.exp, tc.exp.Text, result.Result, result.Result.Text)
+			}
+		})
+	}
+}
+
+func TestOracleFindDefinitionLogicalErrors(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		note   string
+		opts   *ast.ParserOptions // defaults to logicalParserOpts()
+		buffer string
+		exp    error
+	}{
+		{
+			note: "no good match - and keyword",
+			buffer: `package test
+
+p if {
+	q ‸and r
+}
+
+q := 1
+
+r := 2`,
+			exp: ErrNoDefinitionFound,
+		},
+		{
+			note: "no good match - whitespace between operands",
+			buffer: `package test
+
+p if {
+	q and‸ r
+}
+
+q := 1
+
+r := 2`,
+			exp: ErrNoDefinitionFound,
+		},
+		{
+			note: "buffer parse error - keywords not in capabilities",
+			opts: &ast.ParserOptions{},
+			buffer: `package test
+
+p if {
+	‸q and r
+}
+
+q := 1
+
+r := 2`,
+			exp: errors.New("rego_parse_error"),
+		},
+		{
+			note: "buffer parse error - future import not in capabilities",
+			opts: &ast.ParserOptions{},
+			buffer: `package test
+
+import future.keywords.and
+
+p if {
+	‸q and r
+}
+
+q := 1
+
+r := 2`,
+			exp: errors.New("unexpected keyword, must be one of"),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.note, func(t *testing.T) {
+			t.Parallel()
+
+			opts := logicalParserOpts()
+			if tc.opts != nil {
+				opts = *tc.opts
+			}
+
+			buffer, pos := cursorOffset(t, tc.buffer)
+
+			result, err := New().FindDefinition(DefinitionQuery{
+				Buffer:        []byte(buffer),
+				Filename:      "buffer.rego",
+				Pos:           pos,
+				ParserOptions: opts,
+			})
+			if err == nil || result != nil {
+				t.Fatal("expected error but got:", err, "result:", result)
+			}
+
+			if !strings.Contains(err.Error(), tc.exp.Error()) {
+				t.Fatalf("expected %v but got %v", tc.exp, err)
+			}
+		})
+	}
+}
+
+func TestFindContainingNodeStackLogical(t *testing.T) {
+	t.Parallel()
+
+	module, pos := cursorOffset(t, `package test
+
+p if {
+	x := 1
+	{‸x > 0} and {x < 5}
+}`)
+
+	parsed := ast.MustParseModuleWithOpts(module, logicalParserOpts())
+
+	and, ok := parsed.Rules[0].Body[1].Terms.(*ast.LogicalAnd)
+	if !ok {
+		t.Fatalf("expected *ast.LogicalAnd but got %T", parsed.Rules[0].Body[1].Terms)
+	}
+
+	exp := []*ast.Location{
+		parsed.Rules[0].Loc(),
+		parsed.Rules[0].Body.Loc(),
+		parsed.Rules[0].Body[1].Loc(),
+		and.Loc(),
+		and.Lhs.Loc(),
+		and.Lhs[0].Loc(),
+		and.Lhs[0].Terms.([]*ast.Term)[1].Loc(),
+	}
+
+	assertNodeStack(t, findContainingNodeStack(parsed, pos), exp)
+}
+
+// Nodes carrying bodies must be traversed even when they have no location, so
+// that programmatically constructed ASTs can still be searched.
+func TestFindContainingNodeStackMissingLocation(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		note   string
+		module string
+		unset  func(*ast.Expr)
+	}{
+		{
+			note: "and",
+			module: `package test
+
+p if {
+	{‸q} and {r}
+}`,
+			unset: func(expr *ast.Expr) { expr.Terms.(*ast.LogicalAnd).Location = nil },
+		},
+		{
+			note: "or",
+			module: `package test
+
+p if {
+	{‸q} or {r}
+}`,
+			unset: func(expr *ast.Expr) { expr.Terms.(*ast.LogicalOr).Location = nil },
+		},
+		{
+			note: "not",
+			module: `package test
+
+p if {
+	not {‸q}
+}`,
+			unset: func(expr *ast.Expr) { expr.Terms.(*ast.Not).Location = nil },
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.note, func(t *testing.T) {
+			t.Parallel()
+
+			module, pos := cursorOffset(t, tc.module)
+			parsed := ast.MustParseModuleWithOpts(module, logicalParserOpts())
+			tc.unset(parsed.Rules[0].Body[0])
+
+			stack := findContainingNodeStack(parsed, pos)
+			if len(stack) == 0 {
+				t.Fatal("expected non-empty node stack")
+			}
+
+			top, ok := stack[len(stack)-1].(*ast.Term)
+			if !ok {
+				t.Fatalf("expected *ast.Term at top of stack but got %T: %v", stack[len(stack)-1], stack)
+			}
+
+			if !ast.Var("q").Equal(top.Value) {
+				t.Fatalf("expected var q at top of stack but got %v", top)
+			}
+		})
+	}
+}
+
+func assertNodeStack(t *testing.T, result []ast.Node, exp []*ast.Location) {
+	t.Helper()
+
+	if len(result) != len(exp) {
+		t.Fatalf("expected %d nodes on the stack but got %d: %v", len(exp), len(result), result)
+	}
+
+	for i := range result {
+		if result[i].Loc() != exp[i] {
+			t.Fatalf("expected exact location pointers but found difference on i = %d (%T): %v", i, result[i], result[i].Loc())
+		}
+	}
+}

--- a/v1/ast/oracle/oracle_test.go
+++ b/v1/ast/oracle/oracle_test.go
@@ -1096,7 +1096,10 @@ q = true`
 
 func TestCompileUptoNoModules(t *testing.T) {
 	t.Parallel()
-	compiler, module, err := New().compileUpto("SetRuleTree", nil, []byte("package test\np=1"), "test.rego")
+	compiler, module, err := New().compileUpto("SetRuleTree", DefinitionQuery{
+		Buffer:   []byte("package test\np=1"),
+		Filename: "test.rego",
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1113,9 +1116,12 @@ func TestCompileUptoNoModules(t *testing.T) {
 
 func TestCompileUptoNoBuffer(t *testing.T) {
 	t.Parallel()
-	compiler, module, err := New().compileUpto("SetRuleTree", map[string]*ast.Module{
-		"test.rego": ast.MustParseModule("package test\np=1"),
-	}, nil, "test.rego")
+	compiler, module, err := New().compileUpto("SetRuleTree", DefinitionQuery{
+		Modules: map[string]*ast.Module{
+			"test.rego": ast.MustParseModule("package test\np=1"),
+		},
+		Filename: "test.rego",
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1128,6 +1134,76 @@ func TestCompileUptoNoBuffer(t *testing.T) {
 	if module == nil {
 		t.Fatal("expected parsed module")
 	}
+}
+
+func TestCompileUptoBufferParserOptions(t *testing.T) {
+	t.Parallel()
+
+	const v0Module = `package test
+
+p[x] {
+	x = 1
+}`
+
+	const logicalModule = `package test
+
+import future.keywords.and
+
+p if {
+	q and r
+}
+
+q := 1
+r := 2`
+
+	t.Run("rego version from query", func(t *testing.T) {
+		t.Parallel()
+		_, module, err := New().compileUpto("SetRuleTree", DefinitionQuery{
+			Buffer:        []byte(v0Module),
+			Filename:      "test.rego",
+			ParserOptions: ast.ParserOptions{RegoVersion: ast.RegoV0},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if module == nil {
+			t.Fatal("expected parsed module")
+		}
+	})
+
+	t.Run("rego version from shadowed module", func(t *testing.T) {
+		t.Parallel()
+		shadowed := ast.MustParseModuleWithOpts(v0Module, ast.ParserOptions{RegoVersion: ast.RegoV0})
+
+		_, module, err := New().compileUpto("SetRuleTree", DefinitionQuery{
+			Modules:  map[string]*ast.Module{"test.rego": shadowed},
+			Buffer:   []byte(v0Module),
+			Filename: "test.rego",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if module == nil {
+			t.Fatal("expected parsed module")
+		}
+	})
+
+	t.Run("capabilities from compiler", func(t *testing.T) {
+		t.Parallel()
+		capabilities := ast.CapabilitiesForThisVersion(ast.CapabilitiesExperimentalKeywords(true))
+		o := New().WithCompiler(ast.NewCompiler().WithCapabilities(capabilities))
+
+		_, module, err := o.compileUpto("SetRuleTree", DefinitionQuery{
+			Buffer:   []byte(logicalModule),
+			Filename: "test.rego",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !module.Rules[0].Body[0].IsAnd() {
+			t.Fatal("expected logical and expression but got:", module.Rules[0].Body[0])
+		}
+	})
 }
 
 func TestUsingCustomCompiler(t *testing.T) {

--- a/v1/ast/oracle/stack.go
+++ b/v1/ast/oracle/stack.go
@@ -13,10 +13,11 @@ func findContainingNodeStack(module *ast.Module, pos int) []ast.Node {
 	ast.WalkNodes(module, func(x ast.Node) bool {
 		minLoc, maxLoc := getLocMinMax(x)
 
-		// ast.Every nodes have no location but should still be traversed
-		// to reach children
+		// Nodes carrying bodies may have no location but should still be
+		// traversed to reach children
 		if minLoc == -1 && maxLoc == -1 {
-			if _, ok := x.(*ast.Every); ok {
+			switch x.(type) {
+			case *ast.Every, *ast.Not, *ast.LogicalAnd, *ast.LogicalOr:
 				return false
 			}
 


### PR DESCRIPTION
Traversal into `and`/`or` operands was already supported. What was missing was testing and to wire up the `--capabilities` flag for `opa oracle` so a user can opt-in to experimental features.

Fixes: #8819
