### PR TITLE
server: Decouple decision logging from request context cancellation

### DIFF
--- a/v1/server/server.go
+++ b/v1/server/server.go
@@ -3191,7 +3191,9 @@ func (l decisionLogger) Log(
 	}
 
 	if l.logger != nil {
-		if err := l.logger(ctx, info); err != nil {
+		// Decouple from request cancellation/deadline so a client disconnect can't
+		// race a mask/drop policy eval in the logger and drop the decision event.
+		if err := l.logger(context.WithoutCancel(ctx), info); err != nil {
 			return fmt.Errorf("decision_logs: %w", err)
 		}
 	}

--- a/v1/server/server_test.go
+++ b/v1/server/server_test.go
@@ -4375,6 +4375,42 @@ func TestDecisionLoggingWithHTTPRequestContext(t *testing.T) {
 	}
 }
 
+// TestDecisionLoggingWithCancelledRequestContext ensures a cancelled/expired request
+// context doesn't reach the decision logger, since that can race a mask/drop policy
+// eval inside the logger and cause the decision event to be dropped.
+func TestDecisionLoggingWithCancelledRequestContext(t *testing.T) {
+	t.Parallel()
+
+	f := newFixture(t)
+
+	var loggedCtxErr error
+	var loggedCalls int
+
+	f.server = f.server.WithDecisionLoggerWithErr(func(ctx context.Context, _ *Info) error {
+		loggedCalls++
+		loggedCtxErr = ctx.Err()
+		return nil
+	})
+
+	req := newReqV1("GET", "/data/undefined", "")
+
+	ctx, cancel := context.WithCancel(req.Context())
+	cancel() // simulate a client disconnect / request timeout before the decision is logged
+	req = req.WithContext(ctx)
+
+	if err := f.executeRequest(req, 200, `{}`); err != nil {
+		t.Fatal(err)
+	}
+
+	if loggedCalls != 1 {
+		t.Fatalf("Expected exactly 1 decision log call but got: %d", loggedCalls)
+	}
+
+	if loggedCtxErr != nil {
+		t.Fatalf("Expected the decision logger's context to not be cancelled, got: %v", loggedCtxErr)
+	}
+}
+
 func TestDecisionLogging(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
logger.Log used the request context as-is, so a cancelled/expired request context (client disconnect, timeout) could race a mask/drop policy eval inside the decision logger and silently drop the decision event. Use context.WithoutCancel before invoking the logger.

Same issue and fix as open-policy-agent/opa-envoy-plugin#876.
