### PR TITLE
Add Equal implementation for *object

### DIFF
--- a/v1/ast/annotations.go
+++ b/v1/ast/annotations.go
@@ -379,11 +379,7 @@ func (a *Annotations) toObject() (*Object, *Error) {
 	}
 
 	if len(a.Organizations) > 0 {
-		orgs := make([]*Term, 0, len(a.Organizations))
-		for _, org := range a.Organizations {
-			orgs = append(orgs, StringTerm(org))
-		}
-		obj.Insert(InternedTerm("organizations"), ArrayTerm(orgs...))
+		obj.Insert(InternedTerm("organizations"), ArrayTerm(util.Map(a.Organizations, StringTerm)...))
 	}
 
 	if len(a.RelatedResources) > 0 {

--- a/v1/ast/compare.go
+++ b/v1/ast/compare.go
@@ -10,6 +10,8 @@ import (
 	"math/big"
 	"slices"
 	"strings"
+
+	"github.com/open-policy-agent/opa/v1/util"
 )
 
 // Compare returns an integer indicating whether two AST values are less than,
@@ -315,6 +317,8 @@ func ValueEqual(a, b Value) bool {
 		return v.Equal(b)
 	case *Array:
 		return v.Equal(b)
+	case *object:
+		return v.Equal(b)
 	case *Not:
 		return v.Equal(b)
 	case *TemplateString:
@@ -334,34 +338,34 @@ func RefEqual(a, b Ref) bool {
 
 func NumberCompare(x, y Number) int {
 	xs, ys := string(x), string(y)
-
-	var xIsF, yIsF bool
-
-	// Treat "1" and "1.0", "1.00", etc as "1"
-	if strings.Contains(xs, ".") {
-		if tx := strings.TrimRight(xs, ".0"); tx != xs {
-			// Still a float after trimming?
-			xIsF = strings.Contains(tx, ".")
-			xs = tx
-		}
-	}
-	if strings.Contains(ys, ".") {
-		if ty := strings.TrimRight(ys, ".0"); ty != ys {
-			yIsF = strings.Contains(ty, ".")
-			ys = ty
-		}
-	}
 	if xs == ys {
 		return 0
 	}
 
 	var xi, yi int64
-	var xf, yf float64
 	var xiOK, yiOK, xfOK, yfOK bool
 
-	if xi, xiOK = x.Int64(); xiOK {
-		if yi, yiOK = y.Int64(); yiOK {
+	if xi, xiOK = util.Atoi64(xs); xiOK {
+		if yi, yiOK = util.Atoi64(ys); yiOK {
 			return cmp.Compare(xi, yi)
+		}
+	}
+
+	var xf, yf float64
+	var xIsF, yIsF bool
+
+	// Treat "1" and "1.0", "1.00", etc as "1"
+	if strings.IndexByte(xs, '.') != -1 {
+		if tx := strings.TrimRight(xs, ".0"); tx != xs {
+			// Still a float after trimming?
+			xIsF = strings.IndexByte(tx, '.') != -1
+			xs = tx
+		}
+	}
+	if strings.IndexByte(ys, '.') != -1 {
+		if ty := strings.TrimRight(ys, ".0"); ty != ys {
+			yIsF = strings.IndexByte(ty, '.') != -1
+			ys = ty
 		}
 	}
 
@@ -377,7 +381,7 @@ func NumberCompare(x, y Number) int {
 	}
 
 	var a *big.Rat
-	fa, ok := new(big.Float).SetString(string(x))
+	fa, ok := new(big.Float).SetString(xs)
 	if !ok {
 		panic("illegal value")
 	}
@@ -387,14 +391,14 @@ func NumberCompare(x, y Number) int {
 		}
 	}
 	if a == nil {
-		a, ok = new(big.Rat).SetString(string(x))
+		a, ok = new(big.Rat).SetString(xs)
 		if !ok {
 			panic("illegal value")
 		}
 	}
 
 	var b *big.Rat
-	fb, ok := new(big.Float).SetString(string(y))
+	fb, ok := new(big.Float).SetString(ys)
 	if !ok {
 		panic("illegal value")
 	}
@@ -404,7 +408,7 @@ func NumberCompare(x, y Number) int {
 		}
 	}
 	if b == nil {
-		b, ok = new(big.Rat).SetString(string(y))
+		b, ok = new(big.Rat).SetString(ys)
 		if !ok {
 			panic("illegal value")
 		}

--- a/v1/ast/compile.go
+++ b/v1/ast/compile.go
@@ -28,9 +28,7 @@ const CompileErrorLimitDefault = 10
 
 var (
 	errLimitReached = newErrorString(CompileErr, nil, "error limit reached")
-
-	doubleEq     = Equal.Ref()
-	emptyPackage = &Package{Path: Ref{VarTerm("")}}
+	emptyPackage    = &Package{Path: Ref{VarTerm("")}}
 )
 
 // Compiler contains the state of a compilation process.
@@ -6018,7 +6016,7 @@ func rewriteEquals(x any) (modified bool) {
 	t := NewGenericTransformer(func(x any) (any, error) {
 		if x, ok := x.(*Expr); ok && x.IsCall() {
 			operator := x.Operator()
-			if operator.Equal(doubleEq) && len(x.Operands()) == 2 {
+			if operator.Equal(equalRef) && len(x.Operands()) == 2 {
 				modified = true
 				x.SetOperator(NewTerm(unifyOp))
 			}

--- a/v1/ast/term.go
+++ b/v1/ast/term.go
@@ -389,14 +389,7 @@ func CopyValue(v Value) Value {
 // Equal returns true if this term equals the other term. Equality is
 // defined for each kind of term, and does not compare the Location.
 func (term *Term) Equal(other *Term) bool {
-	if term == other {
-		return true
-	}
-	if term == nil || other == nil {
-		return false
-	}
-
-	return ValueEqual(term.Value, other.Value)
+	return term == other || (term != nil && other != nil && ValueEqual(term.Value, other.Value))
 }
 
 // Get returns a value referred to by name from the term.
@@ -2294,6 +2287,38 @@ func (obj *object) Compare(other Value) int {
 	return len(akeys) - len(bkeys)
 }
 
+func (obj *object) Equal(other Value) bool {
+	var ob2 *object
+	switch v := other.(type) {
+	case *object:
+		ob2 = v
+	case *lazyObj:
+		return obj.Equal(v.force())
+	}
+
+	if obj == ob2 {
+		return true
+	}
+	if obj == nil || ob2 == nil || len(obj.keys) != len(ob2.keys) {
+		return false
+	}
+	elems1, elems2 := obj.sortedKeys(), ob2.sortedKeys()
+	// Note(anderseknert):
+	// Go can't (easily) know that the above calls don't modify the length
+	// checked before. Doing it once more here is cheap and ensures that the
+	// loop is evaluated without additional nil and bounds checks
+	if len(elems1) != len(elems2) {
+		return false
+	}
+
+	for i, elem := range elems1 {
+		if !elem.key.Equal(elems2[i].key) || !elem.value.Equal(elems2[i].value) {
+			return false
+		}
+	}
+	return true
+}
+
 // Find returns the value at the key or undefined.
 func (obj *object) Find(path Ref) (Value, error) {
 	if len(path) == 0 {
@@ -2373,11 +2398,13 @@ func (obj *object) Copy() Object {
 		return cpy
 	}
 
-	// Batch-allocate all objectElems, keys, and values in contiguous blocks
-	// (3 allocations instead of 3N).
+	// Batch-allocate all objectElems and keys/value pairs in contiguous blocks
+	// (2 allocations instead of 3N).
 	elems := make([]objectElem, n)
-	keys := make([]Term, n)
-	vals := make([]Term, n)
+	pairs := make([]Term, n*2)
+	keys := pairs[:n]
+	vals := pairs[n:]
+
 	cpy.keys = make([]*objectElem, n)
 
 	for i, srcElem := range obj.keys {

--- a/v1/ast/term_bench_test.go
+++ b/v1/ast/term_bench_test.go
@@ -489,6 +489,8 @@ func BenchmarkSetCopy(b *testing.B) {
 }
 
 // 396.9 ns/op	     664 B/op	      19 allocs/op
+// 198.7 ns/op	     688 B/op	       7 allocs/op
+// 199.2 ns/op	     672 B/op	       6 allocs/op
 func BenchmarkObjectCopy(b *testing.B) {
 	o := NewObject(
 		Item(InternedTerm("a"), InternedTerm(1)),
@@ -758,6 +760,60 @@ func BenchmarkArrayEquality(b *testing.B) {
 			}
 		})
 	}
+}
+
+// Before and after [*object.Equal]:
+// ----------------------------------------------
+// pointer_equality-16         711834544       1.6 ns/op       0 B/op       0 allocs/op (no change)
+//
+// shallow_copy_equality-16        59499      7230 ns/op       0 B/op       0 allocs/op
+// shallow_copy_equality-16     49511161        24 ns/op       0 B/op       0 allocs/op (huge ns/op reduction)
+//
+// deep_copy_equality-16          161464      7217 ns/op       0 B/op       0 allocs/op
+// deep_copy_equality-16          236464	  4954 ns/op       0 B/op       0 allocs/op (decent ns/op reduction)
+func BenchmarkObjectEquality(b *testing.B) {
+	keys := []string{
+		"a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m",
+		"n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z",
+	}
+	itms := make([][2]*Term, len(keys))
+	for i, k := range keys {
+		itms[i][0] = InternedTerm(k)
+		itms[i][1] = IntNumberTerm(i)
+	}
+
+	base := ObjectTerm(itms...)
+	for i := range itms {
+		itms[i][1] = base
+	}
+
+	objA := ObjectTerm(itms...)
+	objB := ObjectTerm(itms...)
+	objC := objB.Copy()
+
+	b.Run("pointer equality", func(b *testing.B) {
+		for b.Loop() {
+			if !objA.Equal(objA) { //nolint:gocritic // "suspicious method call with the same argument and receiver"
+				b.Fatal("expected equal")
+			}
+		}
+	})
+
+	b.Run("shallow copy equality", func(b *testing.B) {
+		for b.Loop() {
+			if !objA.Equal(objB) {
+				b.Fatal("expected equal")
+			}
+		}
+	})
+
+	b.Run("deep copy equality", func(b *testing.B) {
+		for b.Loop() {
+			if !objA.Equal(objC) {
+				b.Fatal("expected equal")
+			}
+		}
+	})
 }
 
 func BenchmarkSetString(b *testing.B) {

--- a/v1/util/performance.go
+++ b/v1/util/performance.go
@@ -194,6 +194,8 @@ func Atoi(s string) (int, bool) {
 // codebase — most notably ast.Number's Int() and Int64() methods — have no interest in the
 // details of the failure, and keeping this allocation free means both methods can be used
 // not only for conversion, but as a most efficient "IsInt64" check.
+// Additionally this function accepts trailing decimal zeroes ("10.00", not "10.01") as that
+// makes sense in the context of us using JSON numbers.
 func Atoi64(s string) (int64, bool) {
 	sLen := len(s)
 	if sLen > 0 {
@@ -206,9 +208,23 @@ func Atoi64(s string) (int64, bool) {
 			return 0, false
 		}
 
+		var pastDecimal bool
 		var n int64
 		for _, ch := range []byte(s) {
+			if ch == '.' {
+				if !pastDecimal {
+					pastDecimal = true
+					continue
+				}
+				return 0, false
+			}
 			ch -= '0'
+			if pastDecimal {
+				if ch == 0 {
+					continue
+				}
+				return 0, false
+			}
 			if ch > 9 {
 				return 0, false
 			}

--- a/v1/util/performance_test.go
+++ b/v1/util/performance_test.go
@@ -104,6 +104,7 @@ func TestAtoi64(t *testing.T) {
 		{"no", false, 0},
 		{"02", true, 2},
 		{"0", true, 0},
+		{"+0.0", true, 0},
 		{"-0", true, 0},
 		{"123", true, 123},
 		{"-123", true, -123},
@@ -114,12 +115,22 @@ func TestAtoi64(t *testing.T) {
 		{"9223372036854775808", false, 0},                    // max int64 + 1
 		{"-9223372036854775808", true, -9223372036854775808}, // min int64
 		{"-9223372036854775809", false, 0},                   // min int64 - 1
+		{"1.0", true, 1},
+		{"-123.00000000", true, -123},
+		{"1.001", false, 0},
+		{"1.1.1", false, 0},
 	}
 
 	for _, test := range tests {
 		res, ok := Atoi64(test.input)
 		if ok != test.expOK || res != test.expInt {
 			t.Errorf("Atoi64(%q) = (%d, %v); expected (%d, %v)", test.input, res, ok, test.expInt, test.expOK)
+		}
+		if strings.Contains(test.input, ".") {
+			if res != test.expInt {
+				t.Fatalf("Atoi64(%q) = (%d, %v); expected (%d, %v)", test.input, res, ok, test.expInt, test.expOK)
+			}
+			continue
 		}
 
 		strconvRes, err := strconv.Atoi(test.input)


### PR DESCRIPTION
Mostly improving performance of comparing "objects with object values", but since that's most objects.. well, that's pretty good.

Also:
- Found a way to shave off an alloc from *object.Copy()!
- Make Atoi64 parse trailing decimal zeros (`1.000`) as integer values (`1`)
- Reuse interned ref values in the compiler's `rewriteEquals`
- A few style fixes