### PR TITLE
server_test: adjust test to avoid flakey decision log test outcome

### DIFF
--- a/v1/server/server_test.go
+++ b/v1/server/server_test.go
@@ -4398,9 +4398,13 @@ func TestDecisionLoggingWithCancelledRequestContext(t *testing.T) {
 	cancel() // simulate a client disconnect / request timeout before the decision is logged
 	req = req.WithContext(ctx)
 
-	if err := f.executeRequest(req, 200, `{}`); err != nil {
-		t.Fatal(err)
-	}
+	// The request context is already cancelled before the handler even runs, so the
+	// eval itself may race the cancellation and return either a successful result or
+	// an eval_cancel_error; that outcome isn't what's under test here. What matters is
+	// that the decision logger still runs exactly once, with a context that isn't
+	// cancelled.
+	f.recorder = httptest.NewRecorder()
+	f.server.Handler.ServeHTTP(f.recorder, req)
 
 	if loggedCalls != 1 {
 		t.Fatalf("Expected exactly 1 decision log call but got: %d", loggedCalls)


### PR DESCRIPTION
Should fix this:

```
--- FAIL: TestDecisionLoggingWithCancelledRequestContext (0.01s)
    server_test.go:4402: Expected code 200 from GET /v1/data/undefined but got: &{Code:500 HeaderMap:map[Content-Type:[application/json] Vary:[Accept-Encoding]] Body:{
          "code": "internal_error",
          "message": "error(s) occurred while evaluating query",
          "errors": [
            {
              "code": "eval_cancel_error",
              "message": "context canceled"
            }
          ]
        }
         Flushed:false result:<nil> snapHeader:map[Content-Type:[application/json] Vary:[Accept-Encoding]] wroteHeader:true}
```
