### PR TITLE
ir: Add list of unplanned rules to plan data

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -51,6 +51,7 @@ type (
 		v1Compatible       bool
 		followSymlinks     bool
 		wasmIncludePrint   bool
+		planAddons         []string
 		stderr             io.Writer
 	}
 	// deferredFileWriter is a wrapper around [*os.File] that defers the creation of the file until
@@ -283,6 +284,7 @@ against ` + brand + ` v0.22.0:
 	buildCommand.Flags().StringVar(&buildParams.ns, "partial-namespace", "partial", "set the namespace to use for partially evaluated files in an optimized bundle")
 	buildCommand.Flags().BoolVar(&buildParams.followSymlinks, "follow-symlinks", false, "follow symlinks in the input set of paths when building the bundle")
 	buildCommand.Flags().BoolVar(&buildParams.wasmIncludePrint, "wasm-include-print", false, "enable print statements inside of WebAssembly modules compiled by the compiler")
+	buildCommand.Flags().StringArrayVar(&buildParams.planAddons, "plan-addons", []string{}, "include optional extra data in the plan; supported value: unplanned_rules (requires --target=plan)")
 
 	addBundleModeFlag(buildCommand.Flags(), &buildParams.bundleMode, false)
 	addIgnoreFlag(buildCommand.Flags(), &buildParams.ignore)
@@ -361,7 +363,8 @@ func dobuild(params buildParams, args []string) error {
 		WithBundleVerificationConfig(bvc).
 		WithBundleSigningConfig(bsc).
 		WithPartialNamespace(params.ns).
-		WithFollowSymlinks(params.followSymlinks)
+		WithFollowSymlinks(params.followSymlinks).
+		WithPlanAddons(params.planAddons)
 
 	compiler = compiler.WithRegoVersion(params.regoVersion())
 

--- a/e2e/proto/plan_test.go
+++ b/e2e/proto/plan_test.go
@@ -113,6 +113,8 @@ func TestPlanProtoConsistency(t *testing.T) {
 		{Name: "Block", GoType: reflect.TypeOf(ir.Block{})},
 		{Name: "StringConst", GoType: reflect.TypeOf(ir.StringConst{})},
 		{Name: "Operand", GoType: reflect.TypeOf(ir.Operand{})},
+		{Name: "UnplannedRule", GoType: reflect.TypeOf(ir.UnplannedRule{})},
+		{Name: "Location", GoType: locationT},
 		// Stmt envelope: file/col/row come from ir.Location; oneof
 		// validated via the OneofSpec below.
 		{Name: "Stmt", GoType: locationT},

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -49,6 +49,9 @@ type Planner struct {
 	lnext   ir.Local                // next variable to use
 	loc     *location.Location      // location currently "being planned"
 	debug   debug.Debug             // debug information produced during planning
+
+	allRules     map[*ast.Rule]bool // all rules parsed from input modules, used to track unplanned rules for additional reporting (e.g. coverage)
+	plannedRules map[*ast.Rule]bool
 }
 
 // debugf prepends the planner location. We're passing callstack depth 2 because
@@ -83,6 +86,9 @@ func New() *Planner {
 		funcs: newFuncstack(),
 		mocks: newFunctionMocksStack(),
 		debug: debug.Discard(),
+
+		allRules:     map[*ast.Rule]bool{},
+		plannedRules: map[*ast.Rule]bool{},
 	}
 }
 
@@ -130,7 +136,28 @@ func (p *Planner) Plan() (*ir.Policy, error) {
 		return nil, err
 	}
 
+	p.buildUnplannedRules()
+
 	return p.policy, nil
+}
+
+// buildUnplannedRules populates policy.UnplannedRules with the rules that
+// were parsed but never planned (i.e. not reachable from any entrypoint),
+// for coverage reporting purposes.
+func (p *Planner) buildUnplannedRules() {
+	for rule := range p.allRules {
+		if p.plannedRules[rule] {
+			continue
+		}
+		p.policy.UnplannedRules = append(p.policy.UnplannedRules, &ir.UnplannedRule{
+			Path:     rule.Ref().String(),
+			Location: p.newLocation(rule.Loc()),
+		})
+	}
+
+	slices.SortFunc(p.policy.UnplannedRules, func(a, b *ir.UnplannedRule) int {
+		return strings.Compare(a.Path, b.Path)
+	})
 }
 
 func (p *Planner) buildFunctrie() error {
@@ -151,6 +178,8 @@ func (p *Planner) buildFunctrie() error {
 		}
 
 		for _, rule := range module.Rules {
+			p.allRules[rule] = true
+
 			r := rule.Ref().StringPrefix()
 			val := p.rules.LookupOrInsert(r)
 
@@ -163,6 +192,10 @@ func (p *Planner) buildFunctrie() error {
 }
 
 func (p *Planner) planRules(rules []*ast.Rule) (string, error) {
+	for _, rule := range rules {
+		p.plannedRules[rule] = true
+	}
+
 	// We sort rules, first by ref length, and then using the
 	// Ref.Compare method to break ties. This yields a stable
 	// sorting order for the slice of rules to be planned.
@@ -2478,6 +2511,18 @@ func (p *Planner) getFileConst(s string) int {
 		p.files[s] = index
 	}
 	return index
+}
+
+// newLocation builds a fresh *ir.Location from an ast.Location. It lives on
+// Planner because it needs p.getFileConst to resolve the file constant index.
+func (p *Planner) newLocation(loc *location.Location) *ir.Location {
+	str := loc.File
+	if str == "" {
+		str = `<query>`
+	}
+	l := &ir.Location{}
+	l.SetLocation(p.getFileConst(str), loc.Row, loc.Col, str, loc.Text)
+	return l
 }
 
 func (p *Planner) appendStmt(s ir.Stmt) {

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -52,6 +52,8 @@ type Planner struct {
 
 	allRules     map[*ast.Rule]bool // all rules parsed from input modules, used to track unplanned rules for additional reporting (e.g. coverage)
 	plannedRules map[*ast.Rule]bool
+
+	unplannedRules bool // whether to populate policy.UnplannedRules
 }
 
 // debugf prepends the planner location. We're passing callstack depth 2 because
@@ -121,6 +123,14 @@ func (p *Planner) WithDebug(sink io.Writer) *Planner {
 	return p
 }
 
+// WithUnplannedRules controls whether the resulting policy includes the
+// list of rules that were parsed but never planned (i.e. not reachable
+// from any entrypoint). Disabled by default.
+func (p *Planner) WithUnplannedRules(yes bool) *Planner {
+	p.unplannedRules = yes
+	return p
+}
+
 // Plan returns a IR plan for the policy query.
 func (p *Planner) Plan() (*ir.Policy, error) {
 
@@ -136,7 +146,9 @@ func (p *Planner) Plan() (*ir.Policy, error) {
 		return nil, err
 	}
 
-	p.buildUnplannedRules()
+	if p.unplannedRules {
+		p.buildUnplannedRules()
+	}
 
 	return p.policy, nil
 }

--- a/internal/planner/planner_test.go
+++ b/internal/planner/planner_test.go
@@ -35,7 +35,7 @@ unused if { true }
 
 	policy, err := New().WithQueries([]QuerySet{
 		{Name: "test", Queries: queries},
-	}).WithModules([]*ast.Module{m}).WithBuiltinDecls(ast.BuiltinMap).Plan()
+	}).WithModules([]*ast.Module{m}).WithBuiltinDecls(ast.BuiltinMap).WithUnplannedRules(true).Plan()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/planner/planner_test.go
+++ b/internal/planner/planner_test.go
@@ -19,6 +19,40 @@ import (
 	"github.com/open-policy-agent/opa/v1/ir"
 )
 
+func TestPlannerUnplannedRules(t *testing.T) {
+	module := `
+package example
+
+allow if { true }
+unused if { true }
+`
+	m, err := ast.ParseModuleWithOpts("example.rego", module, ast.ParserOptions{AllFutureKeywords: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	queries := []ast.Body{ast.MustParseBody("data.example.allow")}
+
+	policy, err := New().WithQueries([]QuerySet{
+		{Name: "test", Queries: queries},
+	}).WithModules([]*ast.Module{m}).WithBuiltinDecls(ast.BuiltinMap).Plan()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(policy.UnplannedRules) != 1 {
+		t.Fatalf("expected 1 unplanned rule, got %d: %v", len(policy.UnplannedRules), policy.UnplannedRules)
+	}
+
+	if policy.UnplannedRules[0].Path != "data.example.unused" {
+		t.Errorf("expected unplanned rule path %q, got %q", "data.example.unused", policy.UnplannedRules[0].Path)
+	}
+
+	if policy.UnplannedRules[0].Location == nil || policy.UnplannedRules[0].Location.Row != 5 {
+		t.Errorf("expected unplanned rule location on row 5, got %v", policy.UnplannedRules[0].Location)
+	}
+}
+
 func TestPlannerHelloWorld(t *testing.T) {
 	// NOTE(tsandall): These tests are not meant to give comprehensive coverage
 	// of the planner. Currently we have a suite of end-to-end tests in the

--- a/v1/compile/compile.go
+++ b/v1/compile/compile.go
@@ -100,6 +100,7 @@ type Compiler struct {
 	regoVersion                  ast.RegoVersion
 	followSymlinks               bool      // optionally follow symlinks in the bundle directory when building the bundle
 	externalRefs                 []ast.Ref // external entrypoints provided dynamically
+	planAddons                   []string  // optional extra contents to include in the plan (e.g. unplanned_rules)
 }
 
 // New returns a new compiler instance that can be invoked.
@@ -287,6 +288,13 @@ func (c *Compiler) WithPartialNamespace(ns string) *Compiler {
 
 func (c *Compiler) WithRegoVersion(v ast.RegoVersion) *Compiler {
 	c.regoVersion = v
+	return c
+}
+
+// WithPlanAddons sets optional extra data to include in the generated plan.
+// The only supported value is "unplanned_rules".
+func (c *Compiler) WithPlanAddons(contents []string) *Compiler {
+	c.planAddons = contents
 	return c
 }
 
@@ -711,7 +719,8 @@ func (c *Compiler) compilePlan(context.Context) error {
 		WithQueries(queries).
 		WithModules(modules).
 		WithBuiltinDecls(builtins).
-		WithDebug(c.debug.Writer())
+		WithDebug(c.debug.Writer()).
+		WithUnplannedRules(slices.Contains(c.planAddons, "unplanned_rules"))
 	policy, err := p.Plan()
 	if err != nil {
 		return err

--- a/v1/ir/ir.go
+++ b/v1/ir/ir.go
@@ -22,9 +22,10 @@ import (
 type (
 	// Policy represents a planned policy query.
 	Policy struct {
-		Static *Static `json:"static,omitempty"`
-		Plans  *Plans  `json:"plans,omitempty"`
-		Funcs  *Funcs  `json:"funcs,omitempty"`
+		Static         *Static          `json:"static,omitempty"`
+		Plans          *Plans           `json:"plans,omitempty"`
+		Funcs          *Funcs           `json:"funcs,omitempty"`
+		UnplannedRules []*UnplannedRule `json:"unplanned_rules,omitempty"`
 	}
 
 	// Static represents a static data segment that is indexed into by the policy.
@@ -97,6 +98,15 @@ type (
 	// StringConst represents a string value.
 	StringConst struct {
 		Value string `json:"value"`
+	}
+
+	// UnplannedRule represents a rule that was parsed but not included in the
+	// plan because it is not reachable from the entrypoint.
+	// This is used for coverage reporting, to distinguish rules that were never
+	// planned from rules that were planned but never executed.
+	UnplannedRule struct {
+		Path     string    `json:"path"`
+		Location *Location `json:"location"`
 	}
 )
 

--- a/v1/ir/plan.proto
+++ b/v1/ir/plan.proto
@@ -14,6 +14,26 @@ message Policy {
   Static static = 1;
   Plans plans = 2;
   Funcs funcs = 3;
+  repeated UnplannedRule unplanned_rules = 4;
+}
+
+// UnplannedRule mirrors `ir.UnplannedRule` in v1/ir/ir.go.
+message UnplannedRule {
+  string path = 1;
+  Location location = 2;
+}
+
+// Location mirrors `ir.Location` in v1/ir/ir.go. Note: Stmt inlines these
+// same fields directly on its envelope (see the `Stmt` message below)
+// rather than nesting a Location message, since every Stmt body embeds
+// ir.Location anonymously; UnplannedRule references it as a named field
+// instead, so it gets its own message here.
+message Location {
+  int32 file = 1;
+  int32 col = 2;
+  int32 row = 3;
+  int32 end_col = 4;
+  int32 end_row = 5;
 }
 
 // Static mirrors `ir.Static` in v1/ir/ir.go.

--- a/v1/ir/plan.schema.json
+++ b/v1/ir/plan.schema.json
@@ -684,6 +684,34 @@
       ],
       "additionalProperties": false
     },
+    "Location": {
+      "type": "object",
+      "properties": {
+        "col": {
+          "type": "integer"
+        },
+        "end_col": {
+          "type": "integer"
+        },
+        "end_row": {
+          "type": "integer"
+        },
+        "file": {
+          "type": "integer"
+        },
+        "row": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "col",
+        "end_col",
+        "end_row",
+        "file",
+        "row"
+      ],
+      "additionalProperties": false
+    },
     "MakeArrayStmt": {
       "type": "object",
       "properties": {
@@ -1170,6 +1198,12 @@
         },
         "static": {
           "$ref": "#/$defs/Static"
+        },
+        "unplanned_rules": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/UnplannedRule"
+          }
         }
       },
       "additionalProperties": false
@@ -1938,6 +1972,29 @@
       },
       "required": [
         "value"
+      ],
+      "additionalProperties": false
+    },
+    "UnplannedRule": {
+      "type": "object",
+      "properties": {
+        "location": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/Location"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "path": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "location",
+        "path"
       ],
       "additionalProperties": false
     },


### PR DESCRIPTION
This adds a list of rules that were not reachable from the planner's entrypoint as supplementary data for coverage reporting in evaluators.

First pass impl, we might also consider:
- having another .json file in the bundle for this data
- nesting this under a cover-all top level key like Provenance or similar to group data that is about the build, and not the bundle.
