### PR TITLE
topdown: Save enumerated refs over unknown data

### DIFF
--- a/v1/topdown/eval.go
+++ b/v1/topdown/eval.go
@@ -2781,6 +2781,13 @@ func (e evalTree) enumerate(iter unifyIterator) error {
 
 	doc, err := e.e.Resolve(e.plugged[:e.pos])
 	if err != nil {
+		// The save set check in biunifyValues compares refs as written, so a ref
+		// that only becomes unknown once bindings are plugged (e.g.
+		// data[input.type].x with data.project.x unknown) reaches here, where the
+		// document can't be enumerated and must be saved as evalTree.finish does.
+		if ast.IsUnknownValueErr(err) {
+			return e.e.saveUnify(ast.NewTerm(e.plugged), e.rterm, e.bindings, e.rbindings, iter)
+		}
 		return err
 	}
 

--- a/v1/topdown/topdown_partial_test.go
+++ b/v1/topdown/topdown_partial_test.go
@@ -1487,6 +1487,28 @@ func TestTopDownPartialEval(t *testing.T) {
 			},
 		},
 		{
+			note: "save: enumerate unknown base doc via dynamic ref operand (#5471)",
+			// The ref operand plugs to an unknown base document, so the save set
+			// cannot match it as written. Enumeration must still save the ref
+			// instead of failing with "unknown value".
+			query: "data.test.p",
+			input: `{"type": "project", "name": "jared"}`,
+			modules: []string{
+				`package test
+				p if {
+					some i
+					role := data[input.type].user_roles[i]
+					role.user_name == input.name
+				}`,
+			},
+			wantQueries: []string{
+				`"jared" = data.project.user_roles[__local0__1].user_name`,
+			},
+			unknowns: []string{
+				"data.project.user_roles",
+			},
+		},
+		{
 			note:  "automatic shallow inlining: full extent: partial set",
 			query: "data.test.p = x",
 			modules: []string{


### PR DESCRIPTION
fix: #5471

The save set matches refs as written, so a ref whose operand only resolves to an unknown path once bindings are plugged (e.g. data[input.type].user_roles[_] with data.project.user_roles unknown) reached evalTree.enumerate, which propagated the resulting UnknownValueErr to the caller as "unknown value" and failed the whole query, rather than leaving the ref in the partial result. Handle it by saving the ref, as evalTree.finish already does for the non-enumerating case.

