### PR TITLE
benchmarks: reign in volatile benchmarks

### DIFF
--- a/build/bench-comment/main.go
+++ b/build/bench-comment/main.go
@@ -117,12 +117,20 @@ func requireEnv(name string) string {
 
 // runBenchlab runs a single benchlab comparison for pkg, writing its
 // bench/benchstat output under .benchlab/ for parseBenchstatFile to pick up.
+//
+// One benchmark run per rep, rather than benchlab's default of five: benchstat
+// treats every sample as independent, but samples from one process share a map
+// hash seed, a heap layout and a set of interned globals, so a cluster of five
+// tells us far less than its size suggests. Sampling from fifteen processes
+// instead of three keeps the total sample count while letting per-process
+// effects land in the within-group variance, where they belong.
 func runBenchlab(before, after, pkg string) error {
 	cmd := exec.Command("benchlab",
 		"-commit", before+","+after,
 		"-pkg", pkg,
 		"-host", "local:tags=opa_wasm",
-		"-reps", "3",
+		"-reps", "15",
+		"-count", "1",
 		"-benchtime", "300ms",
 		"-run", "^$",
 	)

--- a/v1/ast/interning_test.go
+++ b/v1/ast/interning_test.go
@@ -1,3 +1,5 @@
+//go:build noisy
+
 package ast_test
 
 import (
@@ -32,6 +34,10 @@ func getNewValue() ast.Value {
 }
 
 // Benchmark experiment to compare the performance of accessing values in different ways.
+// Behind the `noisy` build tag, and so excluded from the tracked benchmark suite: these
+// are single-digit-nanosecond loops whose numbers move with the layout of whatever
+// binary they happen to be compiled into, and are only meaningful when the four are
+// compared against each other within one run. Use `make perf-noisy` to run them.
 //
 // BenchmarkInterningAccessValue/package_var_value-12         100000000      10.95 ns/op     16 B/op    1 allocs/op
 // BenchmarkInterningAccessValue/interned_value-12            175498335       6.81 ns/op      0 B/op    0 allocs/op

--- a/v1/ast/performance.go
+++ b/v1/ast/performance.go
@@ -5,17 +5,35 @@ package ast
 
 import (
 	"encoding"
+	"slices"
 	"strings"
 	"sync"
 )
 
-var builtinNamesByNumParts = sync.OnceValue(func() map[int][]string {
-	m := map[int][]string{}
+// builtinNameShape packs the two properties of a dotted built-in name that are cheap
+// to derive from a ref without allocating — its number of parts and its total length —
+// into a single key, which keeps map lookups on the runtime's fast path for 64-bit
+// keys. uint64 rather than int so that the shift is well defined on 32-bit platforms.
+func builtinNameShape(parts, totalLen int) uint64 {
+	return uint64(parts)<<32 | uint64(totalLen)
+}
+
+// builtinNamesByShape groups multi-part built-in names by shape, so that
+// BuiltinNameFromRef only has to compare against names that could possibly match.
+// Bucketing on length as well as part count narrows the candidates from ~100 names
+// to a handful, and sorting keeps the scan order deterministic: ranging over
+// BuiltinMap yields a fresh random order in every process, which would otherwise
+// make the cost of a lookup vary several-fold from one run to the next.
+var builtinNamesByShape = sync.OnceValue(func() map[uint64][]string {
+	m := map[uint64][]string{}
 	for name := range BuiltinMap {
-		parts := strings.Count(name, ".") + 1
-		if parts > 1 {
-			m[parts] = append(m[parts], name)
+		if parts := strings.Count(name, ".") + 1; parts > 1 {
+			shape := builtinNameShape(parts, len(name))
+			m[shape] = append(m[shape], name)
 		}
+	}
+	for _, names := range m {
+		slices.Sort(names)
 	}
 	return m
 })
@@ -50,17 +68,12 @@ func BuiltinNameFromRef(ref Ref) (string, bool) {
 		totalLen += 1 + len(term.Value.(String)) // account for dot
 	}
 
-	matched, ok := builtinNamesByNumParts()[reflen]
+	matched, ok := builtinNamesByShape()[builtinNameShape(reflen, totalLen)]
 	if !ok {
 		return "", false
 	}
 
 	for _, name := range matched {
-		// This check saves us a huge amount of work, as only very few built-in
-		// names will have the exact same length as the ref we are checking.
-		if len(name) != totalLen {
-			continue
-		}
 		// Example: `name` is "io.jwt.decode" (and so is ref)
 		// The first part is varName, which have already been established to be 'io':
 		// io,   jwt.decode                              io   == io

--- a/v1/ast/performance_test.go
+++ b/v1/ast/performance_test.go
@@ -16,6 +16,50 @@ func TestFromBuiltinNames(t *testing.T) {
 	}
 }
 
+// TestFromBuiltinNamesAll checks every built-in name that can be written as a ref
+// against the candidate bucketing in BuiltinNameFromRef, so that a name landing in
+// the wrong bucket can't go unnoticed.
+func TestFromBuiltinNamesAll(t *testing.T) {
+	for name := range ast.BuiltinMap {
+		// BuiltinMap also holds infix operators ("+", "/", ...), which aren't refs.
+		ref, err := ast.ParseRef(name)
+		if err != nil {
+			continue
+		}
+		if s, ok := ast.BuiltinNameFromRef(ref); !ok {
+			t.Errorf("Expected to find match for %v", name)
+		} else if s != name {
+			t.Errorf("Expected %v but got: %v", name, s)
+		}
+	}
+}
+
+// TestFromBuiltinNamesNearMisses checks that names sharing a bucket with a real
+// built-in — same number of parts and same total length — are still rejected.
+func TestFromBuiltinNamesNearMisses(t *testing.T) {
+	for name := range ast.BuiltinMap {
+		// Bump the last character, preserving length and part count.
+		bs := []byte(name)
+		if bs[len(bs)-1] == 'z' {
+			bs[len(bs)-1] = 'y'
+		} else {
+			bs[len(bs)-1]++
+		}
+
+		mutated := string(bs)
+		if _, ok := ast.BuiltinMap[mutated]; ok {
+			continue // bumping produced another real built-in name
+		}
+		ref, err := ast.ParseRef(mutated)
+		if err != nil {
+			continue
+		}
+		if s, ok := ast.BuiltinNameFromRef(ref); ok {
+			t.Errorf("Expected no match for %v but got: %v", mutated, s)
+		}
+	}
+}
+
 func BenchmarkFromBuiltinNames(b *testing.B) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
Fixing this, I hope: https://github.com/open-policy-agent/opa/pull/9012#issuecomment-5321168856. A unrelated change should not cause an 80% diff _on the same host_ at all.