### PR TITLE
perf: Allocate less in `ast.NewObject`

### DIFF
--- a/v1/ast/term.go
+++ b/v1/ast/term.go
@@ -2023,10 +2023,44 @@ type Object interface {
 
 // NewObject creates a new Object with t.
 func NewObject(t ...[2]*Term) Object {
-	obj := newobject(len(t))
-	for i := range t {
-		obj.insert(t[i][0], t[i][1], false)
+	var keys []*objectElem
+	n := len(t)
+	if n > 0 {
+		keys = make([]*objectElem, n)
 	}
+	obj := &object{
+		elems:     make(map[int]*objectElem, n),
+		keys:      keys,
+		sortGuard: sync.Once{},
+	}
+
+	// NOTE(anders): The code below is convoluted, but necessary
+	// since creating objects is something we do a lot and often
+	// on hot paths, this avoids allocating one objectElem per
+	// key-value pair, in favor of a single contiguous block of
+	// memory. The same technique is used in (*object).Copy(),
+	// for the same reasons.
+	elems := make([]objectElem, n)
+	for i, kv := range t {
+		key, val := kv[0], kv[1]
+		elems[i] = objectElem{key: key, value: val}
+		obj.keys[i] = &elems[i]
+
+		keyHash := key.Hash()
+		if head, ok := obj.elems[keyHash]; ok {
+			elems[i].next = head
+		}
+		obj.hash += keyHash + val.Hash()
+
+		if key.IsGround() {
+			obj.ground++
+		}
+		if val.IsGround() {
+			obj.ground++
+		}
+		obj.elems[keyHash] = &elems[i]
+	}
+
 	return obj
 }
 

--- a/v1/ast/term_bench_test.go
+++ b/v1/ast/term_bench_test.go
@@ -479,6 +479,27 @@ func BenchmarkSetMembership(b *testing.B) {
 	}
 }
 
+// 418.1 ns/op	     760 B/op	      16 allocs/op // was
+// 337.4 ns/op	     760 B/op	       7 allocs/op // now
+func BenchmarkNewObject(b *testing.B) {
+	kvs := [][2]*Term{
+		{InternedTerm(1), InternedTerm(1)},
+		{InternedTerm(2), InternedTerm(2)},
+		{InternedTerm(3), InternedTerm(3)},
+		{InternedTerm(4), InternedTerm(4)},
+		{InternedTerm(5), InternedTerm(5)},
+		{InternedTerm(6), InternedTerm(6)},
+		{InternedTerm(7), InternedTerm(7)},
+		{InternedTerm(8), InternedTerm(8)},
+		{InternedTerm(9), InternedTerm(9)},
+		{InternedTerm(10), InternedTerm(10)},
+	}
+
+	for b.Loop() {
+		_ = NewObject(kvs...)
+	}
+}
+
 // 241.9 ns/op	     472 B/op	      10 allocs/op
 // 207.7 ns/op	     424 B/op	       9 allocs/op
 func BenchmarkSetCopy(b *testing.B) {


### PR DESCRIPTION
Benchmarks in PR to show the difference. This meant about 260K less allocations in Regal, so no record by any means, but quite a nice improvement nonetheless.

Note that as always with this "trick", the _amount_ of memory allocated (B/op) remains the same, the only change is that we make a single allocation for a group of items.