### PR TITLE
topdown: fix negation inlining limit overflowing

### DIFF
--- a/v1/topdown/eval.go
+++ b/v1/topdown/eval.go
@@ -4710,6 +4710,14 @@ func canInlineNegation(safe ast.VarSet, queries []ast.Body) bool {
 
 	for _, query := range queries {
 		size *= len(query)
+
+		// NOTE(tsandall): this limit is arbitrary–it's only in place to prevent the
+		// partial evaluation result from blowing up. In the future, we could make this
+		// configurable or do something more clever.
+		if size > maxInlineNegationSize {
+			return false
+		}
+
 		for _, expr := range query {
 			if containsNestedRefOrCall(vis, expr) {
 				// Expressions containing nested refs or calls cannot be trivially negated
@@ -4737,11 +4745,12 @@ func canInlineNegation(safe ast.VarSet, queries []ast.Body) bool {
 		}
 	}
 
-	// NOTE(tsandall): this limit is arbitrary–it's only in place to prevent the
-	// partial evaluation result from blowing up. In the future, we could make this
-	// configurable or do something more clever.
-	return size <= 16
+	return true
 }
+
+// maxInlineNegationSize is the largest cross product of negated queries that
+// evalNotPartial will inline instead of generating support rules for.
+const maxInlineNegationSize = 16
 
 type nestedCheckVisitor struct {
 	vis   *ast.GenericVisitor

--- a/v1/topdown/eval_test.go
+++ b/v1/topdown/eval_test.go
@@ -1844,3 +1844,47 @@ func BenchmarkFormatVarTerm(b *testing.B) {
 		_ = e.fmtVar()
 	}
 }
+
+func TestCanInlineNegation(t *testing.T) {
+	t.Parallel()
+
+	// A query of three negated expressions over the unknown, as partial
+	// evaluation of a policy with an unknown-dependent rule produces.
+	query := ast.MustParseBody(`not "1" = input.type; not "1" = input.subtype; not input.attribute = "0"`)
+
+	queries := func(n int) []ast.Body {
+		result := make([]ast.Body, n)
+		for i := range result {
+			result[i] = query
+		}
+		return result
+	}
+
+	tests := []struct {
+		note     string
+		queries  []ast.Body
+		expected bool
+	}{
+		{"single query", queries(1), true},
+		{"cross product within limit", queries(2), true},
+		{"cross product above limit", queries(3), false},
+		// The cross product of 100 queries of length three is 3^100, which does
+		// not fit in an int. It must still be rejected: before the size check
+		// moved into the loop, the product wrapped around to a negative value
+		// and partial evaluation went on to enumerate the cross product.
+		{"cross product overflows int", queries(100), false},
+		{"cross product overflows int, larger", queries(2500), false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.note, func(t *testing.T) {
+			t.Parallel()
+
+			safe := ast.NewVarSet()
+
+			if actual := canInlineNegation(safe, tc.queries); actual != tc.expected {
+				t.Errorf("Expected canInlineNegation to return %v but got %v", tc.expected, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The limit deciding whether partial evaluation inlines a negation or generates support rules for it multiplies the lengths of all saved queries, this can overflow for large results. Fix is to check the size in the loop before it can overflow. 

A reproduction of the problem, given 63 items in data.items this policy hangs partial evaluation and allocates until the process is killed:

`policy.rego`:

```rego
package example

deny if {
	data.items[_] == input.a
	input.b == "x"
}

allow if not deny
```

`data.json`:

```json
{"items":[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62]}
```

```sh
opa eval --partial --data policy.rego --data data.json --unknowns input 'data.example.allow'
```

To restate not deny in terms of the unknowns, partial evaluation either inlines the negation, Which needs the cross product of the ways deny can hold.  So 63 items make the product 2^63, which does not fit in an int.
