### PR TITLE
topdown: speed up partial evaluation of dynamically composed policies

### DIFF
--- a/v1/topdown/save.go
+++ b/v1/topdown/save.go
@@ -383,13 +383,10 @@ func saveRequired(compilerTree *ast.TreeNode, extStack *externalTreeStack, ic *i
 				} else if ic.Disabled(v.ConstantPrefix(), icIgnoreInternal) {
 					found = true
 				} else {
-					rules := getRulesDynamic(compilerTree, extStack, v, ast.RulesOptions{IncludeHiddenModules: false})
-					for _, rule := range rules {
-						if saveRequired(compilerTree, extStack, ic, icIgnoreInternal, ss, b, rule, true) {
-							found = true
-							break
-						}
-					}
+					found = anyRuleDynamic(compilerTree, extStack, v, ast.RulesOptions{IncludeHiddenModules: false},
+						func(rule *ast.Rule) bool {
+							return saveRequired(compilerTree, extStack, ic, icIgnoreInternal, ss, b, rule, true)
+						})
 				}
 			}
 		}
@@ -401,10 +398,12 @@ func saveRequired(compilerTree *ast.TreeNode, extStack *externalTreeStack, ic *i
 	return found
 }
 
-// getRulesDynamic looks up rules in both the compiler tree and external sources.
-func getRulesDynamic(compilerTree *ast.TreeNode, extStack *externalTreeStack, ref ast.Ref, opts ast.RulesOptions) []*ast.Rule {
-	var rules []*ast.Rule
-
+// anyRuleDynamic invokes f for the rules matching ref in the external trees and
+// the compiler tree, stopping as soon as f returns true. Rules are streamed to f
+// rather than collected so that callers only interested in whether *some* rule
+// satisfies a predicate don't pay for walking the whole matching sub-tree, which
+// for refs with non-constant elements can mean every rule loaded.
+func anyRuleDynamic(compilerTree *ast.TreeNode, extStack *externalTreeStack, ref ast.Ref, opts ast.RulesOptions, f func(*ast.Rule) bool) bool {
 	// Check external trees
 	if extStack != nil {
 		for i := range extStack.entries {
@@ -412,63 +411,75 @@ func getRulesDynamic(compilerTree *ast.TreeNode, extStack *externalTreeStack, re
 			if entry.tree != nil && ref.HasPrefix(entry.ref) {
 				// Navigate into the external tree using the remaining path
 				remaining := ref[len(entry.ref):]
-				rules = append(rules, getRulesFromTree(entry.tree, remaining, opts)...)
+				if anyRuleFromTree(entry.tree, remaining, opts, f) {
+					return true
+				}
 			}
 		}
 	}
 
 	// Then check compiler tree
-	rules = append(rules, getRulesFromTree(compilerTree, ref, opts)...)
-
-	return rules
+	return anyRuleFromTree(compilerTree, ref, opts, f)
 }
 
-// getRulesFromTree walks a tree to find all rules matching the given ref.
-func getRulesFromTree(node *ast.TreeNode, ref ast.Ref, opts ast.RulesOptions) []*ast.Rule {
-	set := map[*ast.Rule]struct{}{}
-	var walk func(*ast.TreeNode, int)
-	walk = func(nav *ast.TreeNode, i int) {
+// anyRuleFromTree walks a tree to find rules matching the given ref, invoking f
+// for each and stopping early if f returns true.
+func anyRuleFromTree(node *ast.TreeNode, ref ast.Ref, opts ast.RulesOptions, f func(*ast.Rule) bool) bool {
+	var walk func(*ast.TreeNode, int) bool
+	walk = func(nav *ast.TreeNode, i int) bool {
 		switch {
 		case i >= len(ref):
-			nav.DepthFirst(func(descendant *ast.TreeNode) bool {
-				for _, rule := range descendant.Values {
-					set[rule] = struct{}{}
-				}
-				if opts.IncludeHiddenModules {
-					return false
-				}
-				return descendant.Hide
-			})
+			// The rules on nav itself have already been passed to f by the caller,
+			// unless nav is where the walk started.
+			return anyRuleDescendant(nav, opts, f, i == 0)
 
 		case i == 0 || ast.IsConstant(ref[i].Value):
-			if child := nav.Child(ref[i].Value); child != nil {
-				for _, rule := range child.Values {
-					set[rule] = struct{}{}
-				}
-				walk(child, i+1)
-			} else {
-				return
+			child := nav.Child(ref[i].Value)
+			if child == nil {
+				return false
 			}
+			return anyRule(child.Values, f) || walk(child, i+1)
 
 		default:
 			for _, child := range nav.Children {
 				if child.Hide && !opts.IncludeHiddenModules {
 					continue
 				}
-				for _, rule := range child.Values {
-					set[rule] = struct{}{}
+				if anyRule(child.Values, f) || walk(child, i+1) {
+					return true
 				}
-				walk(child, i+1)
 			}
+			return false
 		}
 	}
 
-	walk(node, 0)
-	rules := make([]*ast.Rule, 0, len(set))
-	for rule := range set {
-		rules = append(rules, rule)
+	return walk(node, 0)
+}
+
+// anyRuleDescendant invokes f for every rule in node's sub-tree, stopping early
+// if f returns true. The rules on node itself are only visited if visitSelf is
+// set. Hidden nodes are not descended into unless opts.IncludeHiddenModules is
+// set.
+func anyRuleDescendant(node *ast.TreeNode, opts ast.RulesOptions, f func(*ast.Rule) bool, visitSelf bool) bool {
+	if visitSelf && anyRule(node.Values, f) {
+		return true
 	}
-	return rules
+
+	if node.Hide && !opts.IncludeHiddenModules {
+		return false
+	}
+
+	for _, child := range node.Children {
+		if anyRuleDescendant(child, opts, f, true) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func anyRule(rules []*ast.Rule, f func(*ast.Rule) bool) bool {
+	return slices.ContainsFunc(rules, f)
 }
 
 func ignoreExprDuringPartial(expr *ast.Expr) bool {

--- a/v1/topdown/save.go
+++ b/v1/topdown/save.go
@@ -383,7 +383,14 @@ func saveRequired(compilerTree *ast.TreeNode, extStack *externalTreeStack, ic *i
 				} else if ic.Disabled(v.ConstantPrefix(), icIgnoreInternal) {
 					found = true
 				} else {
-					found = anyRuleDynamic(compilerTree, extStack, v, ast.RulesOptions{IncludeHiddenModules: false},
+					// Only terms from the call site can be plugged: once traversal
+					// recurses into a rule, that rule's variables belong to another
+					// binding list and could resolve to unrelated values in b.
+					lookup := v
+					if !rec {
+						lookup = plugRefForRuleLookup(v, b)
+					}
+					found = anyRuleDynamic(compilerTree, extStack, lookup, ast.RulesOptions{IncludeHiddenModules: false},
 						func(rule *ast.Rule) bool {
 							return saveRequired(compilerTree, extStack, ic, icIgnoreInternal, ss, b, rule, true)
 						})
@@ -396,6 +403,35 @@ func saveRequired(compilerTree *ast.TreeNode, extStack *externalTreeStack, ic *i
 	vis.Walk(x)
 
 	return found
+}
+
+// plugRefForRuleLookup replaces variables in ref that are bound to a scalar with
+// that value, narrowing rule lookup to the sub-tree that will actually be
+// evaluated. Positions left as-is, because they are unbound or bound to a
+// composite, fan out over all children as before.
+func plugRefForRuleLookup(ref ast.Ref, b *bindings) ast.Ref {
+	if b == nil {
+		return ref
+	}
+
+	cpy := ref
+
+	for i := 1; i < len(ref); i++ {
+		if _, ok := ref[i].Value.(ast.Var); !ok {
+			continue
+		}
+		plugged := b.Plug(ref[i])
+		if !ast.IsScalar(plugged.Value) {
+			continue
+		}
+		if len(cpy) == len(ref) && &cpy[0] == &ref[0] {
+			cpy = make(ast.Ref, len(ref))
+			copy(cpy, ref)
+		}
+		cpy[i] = plugged
+	}
+
+	return cpy
 }
 
 // anyRuleDynamic invokes f for the rules matching ref in the external trees and

--- a/v1/topdown/topdown_partial_bench_test.go
+++ b/v1/topdown/topdown_partial_bench_test.go
@@ -78,6 +78,17 @@ func generateInlineFullScanBenchmarkData(n int) map[string]any {
 	}
 }
 
+// Was
+// BenchmarkPartialEvalDynamicComposition/10-16           	   40417	     28230 ns/op	   19373 B/op	     439 allocs/op
+// BenchmarkPartialEvalDynamicComposition/100-16          	    9672	    126033 ns/op	   60020 B/op	     481 allocs/op
+// BenchmarkPartialEvalDynamicComposition/1000-16         	     898	   1297354 ns/op	  651551 B/op	     560 allocs/op
+// BenchmarkPartialEvalDynamicComposition/5000-16         	     180	   6603512 ns/op	 2661954 B/op	     742 allocs/op
+//
+// Now
+// BenchmarkPartialEvalDynamicComposition/10-16           	   63439	     18205 ns/op	   15795 B/op	     386 allocs/op
+// BenchmarkPartialEvalDynamicComposition/100-16          	   58730	     21472 ns/op	   15851 B/op	     386 allocs/op
+// BenchmarkPartialEvalDynamicComposition/1000-16         	   41414	     24438 ns/op	   15743 B/op	     386 allocs/op
+// BenchmarkPartialEvalDynamicComposition/5000-16         	   44376	     24398 ns/op	   15713 B/op	     386 allocs/op
 // BenchmarkPartialEvalDynamicComposition partially evaluates an entrypoint that
 // composes policies dynamically, i.e. the packages to evaluate are selected by
 // (known) input values. Only a single policy applies to any given input, so the

--- a/v1/topdown/topdown_partial_bench_test.go
+++ b/v1/topdown/topdown_partial_bench_test.go
@@ -106,6 +106,17 @@ func BenchmarkPartialEvalDynamicComposition(b *testing.B) {
 	}
 }
 
+// Was
+// BenchmarkPartialEvalDynamicCompositionKnownRules/10-16 	   39566	     30391 ns/op	   13041 B/op	     408 allocs/op
+// BenchmarkPartialEvalDynamicCompositionKnownRules/100-16         	    5332	    224829 ns/op	   47862 B/op	    2028 allocs/op
+// BenchmarkPartialEvalDynamicCompositionKnownRules/1000-16        	     271	   4378521 ns/op	  975648 B/op	   45430 allocs/op
+// BenchmarkPartialEvalDynamicCompositionKnownRules/5000-16        	      13	  82562061 ns/op	17643343 B/op	  826324 allocs/op
+//
+// Now
+// BenchmarkPartialEvalDynamicCompositionKnownRules/10-16 	   44154	     27070 ns/op	   12510 B/op	     382 allocs/op
+// BenchmarkPartialEvalDynamicCompositionKnownRules/100-16         	    6354	    189338 ns/op	   41534 B/op	    1732 allocs/op
+// BenchmarkPartialEvalDynamicCompositionKnownRules/1000-16        	     804	   1515485 ns/op	  335291 B/op	   15467 allocs/op
+// BenchmarkPartialEvalDynamicCompositionKnownRules/5000-16        	     142	   8450281 ns/op	 1639188 B/op	   76507 allocs/op
 // BenchmarkPartialEvalDynamicCompositionKnownRules is the counterpart of
 // BenchmarkPartialEvalDynamicComposition for policies that don't depend on the
 // unknown: partial evaluation has to consider every rule that could apply before

--- a/v1/topdown/topdown_partial_bench_test.go
+++ b/v1/topdown/topdown_partial_bench_test.go
@@ -77,3 +77,107 @@ func generateInlineFullScanBenchmarkData(n int) map[string]any {
 		"a": sl,
 	}
 }
+
+// BenchmarkPartialEvalDynamicComposition partially evaluates an entrypoint that
+// composes policies dynamically, i.e. the packages to evaluate are selected by
+// (known) input values. Only a single policy applies to any given input, so the
+// cost of partial evaluation should be mostly independent of how many policies
+// are loaded.
+func BenchmarkPartialEvalDynamicComposition(b *testing.B) {
+	sizes := []int{10, 100, 1000, 5000}
+
+	for _, n := range sizes {
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			// One policy per type/subtype pair, and every policy conditioned on
+			// the unknown, so the applicable rule requires saving.
+			runDynamicCompositionBenchmark(b, generateDynamicCompositionPolicies(n, n, `input.attribute == "yes"`))
+		})
+	}
+}
+
+// BenchmarkPartialEvalDynamicCompositionKnownRules is the counterpart of
+// BenchmarkPartialEvalDynamicComposition for policies that don't depend on the
+// unknown: partial evaluation has to consider every rule that could apply before
+// concluding that none of them needs to be saved, so the applicable packages
+// being few is all that keeps the cost down.
+func BenchmarkPartialEvalDynamicCompositionKnownRules(b *testing.B) {
+	sizes := []int{10, 100, 1000, 5000}
+
+	for _, n := range sizes {
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			// Spread over 100 type/subtype pairs, so a hundredth of the policies
+			// apply to the input and the entrypoint's rule is evaluated for each.
+			runDynamicCompositionBenchmark(b, generateDynamicCompositionPolicies(n, 100, `input.type == "no-match"`))
+		})
+	}
+}
+
+func runDynamicCompositionBenchmark(b *testing.B, modules map[string]string) {
+
+	ctx := b.Context()
+	body := ast.MustParseBody("data.main.allow = true")
+	unknowns := []*ast.Term{ast.MustParseTerm("input.attribute")}
+	input := ast.MustParseTerm(`{"type": "1", "subtype": "1"}`)
+
+	compiler := ast.MustCompileModules(modules)
+	store := inmem.New()
+
+	b.ResetTimer()
+
+	for b.Loop() {
+
+		err := storage.Txn(ctx, store, storage.TransactionParams{}, func(txn storage.Transaction) error {
+
+			q := NewQuery(body).
+				WithCompiler(compiler).
+				WithStore(store).
+				WithTransaction(txn).
+				WithInput(input).
+				WithUnknowns(unknowns)
+
+			queries, support, err := q.PartialRun(ctx)
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			if len(queries) != 1 {
+				b.Fatal("Expected exactly one query but got:", queries)
+			} else if len(support) != 0 {
+				b.Fatal("Unexpected support:", support)
+			}
+
+			return nil
+		})
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// generateDynamicCompositionPolicies spreads n policies over the given number of
+// type/subtype pairs, giving each policy a rule conditioned on ruleBody.
+func generateDynamicCompositionPolicies(n, pairs int, ruleBody string) map[string]string {
+
+	modules := map[string]string{
+		"main.rego": `package main
+
+		denies contains x if {
+			x := data.policies[input.type][input.subtype][_].denies[_]
+		}
+
+		allow if not any_denies
+
+		any_denies if denies[_]
+		`,
+	}
+
+	for i := range n {
+		key := strconv.Itoa(i % pairs)
+		modules[strconv.Itoa(i)+".rego"] = `package policies["` + key + `"]["` + key + `"].policy` + strconv.Itoa(i) + `
+
+		denies contains "denied" if ` + ruleBody + `
+		`
+	}
+
+	return modules
+}


### PR DESCRIPTION
fix: https://github.com/open-policy-agent/opa/issues/5216

With dynamic policy composition, the Compile API cost grows quadratically in the
number of loaded policies. The check for whether a term must be saved collects
every rule its ref could reach before testing any of them, and ignores dispatch keys that
are already bound. This streams rules to that check so it stops at the first one that
requires saving, and substitutes bound scalars into the ref so the lookup narrows to the
package that will actually be evaluated.

Policies whose rules depend on the unknown input(the shape from the issue):

| policies | before | after | change | allocated before → after |
|---|---|---|---|---|
| 10 | 28.2 µs | 18.2 µs | −35.5% | 19 KB → 15 KB |
| 100 | 126.0 µs | 21.5 µs | −83.0% | 59 KB → 15 KB |
| 1,000 | 1,297.4 µs | 24.4 µs | −98.1% | 636 KB → 15 KB |
| 5,000 | 6,603.5 µs | 24.4 µs | −99.6% | 2,600 KB → 15 KB |

Policies whose rules only test known input, where there is no early exit to take and the
narrowing does the work (baselined against the preceding commit, so this reflects only
that change):

| policies | before | after | change | allocated before → after |
|---|---|---|---|---|
| 10 | 30.4 µs | 27.1 µs | −10.9% | 13 KB → 12 KB |
| 100 | 224.8 µs | 189.3 µs | −15.8% | 47 KB → 41 KB |
| 1,000 | 4,378.5 µs | 1,515.5 µs | −65.4% | 953 KB → 327 KB |
| 5,000 | 82,562.1 µs | 8,450.3 µs | −89.8% | 17,230 KB → 1,601 KB |
