### PR TITLE
perf: Improved UUID implementation

### DIFF
--- a/internal/uuid/uuid.go
+++ b/internal/uuid/uuid.go
@@ -5,27 +5,36 @@
 package uuid
 
 import (
+	"encoding/hex"
 	"fmt"
 	"io"
 	"strings"
 
 	"github.com/google/uuid"
+	"github.com/open-policy-agent/opa/v1/util"
 )
 
-const (
-	BILLION = 1000000000
-)
+const BILLION = 1000000000
 
 // New Create a version 4 random UUID
 func New(r io.Reader) (string, error) {
-	bs := make([]byte, 16)
-	n, err := io.ReadFull(r, bs)
-	if n != len(bs) || err != nil {
+	var arr [52]byte     // arr, same buffer for both src (16) and dst (36)
+	src := arr[:16]      // src, bytes to encode
+	dst := arr[16:16:52] // dst, to encode, len 0, cap 36 (for appending)
+
+	n, err := io.ReadFull(r, src)
+	if n != 16 || err != nil {
 		return "", err
 	}
-	bs[8] = bs[8]&^0xc0 | 0x80
-	bs[6] = bs[6]&^0xf0 | 0x40
-	return fmt.Sprintf("%x-%x-%x-%x-%x", bs[0:4], bs[4:6], bs[6:8], bs[8:10], bs[10:]), nil
+	src[8] = src[8]&^0xc0 | 0x80
+	src[6] = src[6]&^0xf0 | 0x40
+
+	dst = append(hex.AppendEncode(dst, src[:4]), '-')
+	dst = append(hex.AppendEncode(dst, src[4:6]), '-')
+	dst = append(hex.AppendEncode(dst, src[6:8]), '-')
+	dst = append(hex.AppendEncode(dst, src[8:10]), '-')
+
+	return util.ByteSliceToString(hex.AppendEncode(dst, src[10:])), nil
 }
 
 // Parse will use the google/uuid library to parse the string into a uuid

--- a/internal/uuid/uuid_test.go
+++ b/internal/uuid/uuid_test.go
@@ -5,6 +5,7 @@ package uuid
 
 import (
 	"bytes"
+	"crypto/rand"
 	"fmt"
 	"reflect"
 	"testing"
@@ -145,5 +146,26 @@ func TestMACVars(t *testing.T) {
 				t.Errorf("got %s, expected %s", got, expected[i])
 			}
 		})
+	}
+}
+
+// 328.2 ns/op	     184 B/op	       7 allocs/op // Using fmt.Sprintf
+// 195.6 ns/op	      64 B/op	       1 allocs/op // Using hex.AppendEncode
+func BenchmarkNew(b *testing.B) {
+	for b.Loop() {
+		if _, err := New(rand.Reader); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// 391.6 ns/op	     480 B/op	      11 allocs/op
+func BenchmarkParse(b *testing.B) {
+	for b.Loop() {
+		if res, err := Parse("{000003e8-48b9-21ee-b200-325096b39f47}"); err != nil {
+			b.Fatal(err)
+		} else {
+			_ = res
+		}
 	}
 }

--- a/v1/topdown/uuid.go
+++ b/v1/topdown/uuid.go
@@ -10,12 +10,10 @@ import (
 	"github.com/open-policy-agent/opa/v1/topdown/builtins"
 )
 
-type uuidCachingKey string
+type uuidCachingKey int
 
 func builtinUUIDRFC4122(bctx BuiltinContext, operands []*ast.Term, iter func(*ast.Term) error) error {
-
-	var key = uuidCachingKey(operands[0].Value.String())
-
+	key := uuidCachingKey(operands[0].Value.Hash())
 	val, ok := bctx.Cache.Get(key)
 	if ok {
 		return iter(val.(*ast.Term))
@@ -51,6 +49,11 @@ func builtinUUIDParse(_ BuiltinContext, operands []*ast.Term, iter func(term *as
 }
 
 func init() {
+	ast.InternStringTerm(
+		"version", "variant", "nodeid", "macvariables", "time", "clocksequence", "domain", "id",
+		"local:multicast", "global:multicast", "local:unicast", "global:unicast", "RFC4122",
+		"Person", "Group", "Org",
+	)
 	RegisterBuiltinFunc(ast.UUIDRFC4122.Name, builtinUUIDRFC4122)
 	RegisterBuiltinFunc(ast.UUIDParse.Name, builtinUUIDParse)
 }

--- a/v1/topdown/uuid_test.go
+++ b/v1/topdown/uuid_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/open-policy-agent/opa/v1/ast"
+	"github.com/open-policy-agent/opa/v1/topdown/builtins"
 )
 
 func TestUUIDRFC4122SeedingAndCaching(t *testing.T) {
@@ -19,9 +20,7 @@ func TestUUIDRFC4122SeedingAndCaching(t *testing.T) {
 
 	q := NewQuery(ast.MustParseBody(query)).WithSeed(rand.New(rand.NewSource(0))).WithCompiler(ast.NewCompiler())
 
-	ctx := t.Context()
-
-	qrs, err := q.Run(ctx)
+	qrs, err := q.Run(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	} else if len(qrs) != 1 {
@@ -100,4 +99,83 @@ func queryResultSetToTerm(qrs QueryResultSet) *ast.Term {
 		s.Add(ast.NewTerm(bindings))
 	}
 	return ast.NewTerm(s)
+}
+
+// BenchmarkUUIDRFC4122/uncached-16         	 1581787	       748.1 ns/op	    1953 B/op	      32 allocs/op
+// BenchmarkUUIDRFC4122/cached-16           	 1271378	       942.0 ns/op	    2354 B/op	      37 allocs/op
+// BenchmarkUUIDRFC4122/different-16        	 1000000	      1046 ns/op	    2466 B/op	      41 allocs/op
+func BenchmarkUUIDRFC4122Query(b *testing.B) {
+	names := []string{"uncached", "cached", "different"}
+	queries := []ast.Body{
+		ast.MustParseBody(`uuid.rfc4122("x")`),
+		ast.MustParseBody(`uuid.rfc4122("x"); uuid.rfc4122("x")`),
+		ast.MustParseBody(`uuid.rfc4122("x"); uuid.rfc4122("y")`),
+	}
+
+	for i, name := range names {
+		b.Run(name, func(b *testing.B) {
+			q := NewQuery(queries[i]).WithSeed(rand.New(rand.NewSource(12345)))
+			for b.Loop() {
+				if _, err := q.Run(b.Context()); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// uncached-16         	 7452488       155.2 ns/op     136 B/op       6 allocs/op // Using String() as key
+// uncached-16         	10524730       120.1 ns/op     112 B/op       4 allocs/op // Using Hash() as key
+// cached-16           	77896573        15.4 ns/op       0 B/op       0 allocs/op
+func BenchmarkUUIDRFC4122(b *testing.B) {
+	// 101.0 ns/op    112 B/op    4 allocs/op (1 UUID string + 1 Value boxing + 1 *Term + 1 cache.Put)
+	b.Run("uncached", func(b *testing.B) {
+		bcx := BuiltinContext{Cache: make(builtins.Cache), Seed: rand.New(rand.NewSource(12345))}
+		ops := []*ast.Term{ast.InternedTerm("x")}
+		key := uuidCachingKey(ops[0].Value.Hash())
+
+		for b.Loop() {
+			if err := builtinUUIDRFC4122(bcx, ops, noOpIter); err != nil {
+				b.Fatal(err)
+			}
+			delete(bcx.Cache, key)
+		}
+	})
+
+	// 15.04 ns/op	       0 B/op	       0 allocs/op
+	b.Run("cached", func(b *testing.B) {
+		bcx := BuiltinContext{Cache: make(builtins.Cache), Seed: rand.New(rand.NewSource(12345))}
+		ops := []*ast.Term{ast.InternedTerm("x")}
+		for b.Loop() {
+			if err := builtinUUIDRFC4122(bcx, ops, noOpIter); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+// BenchmarkParseUUIDRFC4122/version=1-16         	 1159633	      1032 ns/op	    1489 B/op	      28 allocs/op
+// BenchmarkParseUUIDRFC4122/version=2-16         	 1000000	      1199 ns/op	    1761 B/op	      34 allocs/op
+func BenchmarkParseUUIDRFC4122(b *testing.B) {
+	b.Run("version=1", func(b *testing.B) {
+		operands := []*ast.Term{ast.StringTerm("c2fc67c2-47f2-11ee-b67a-9f3619c7493f")}
+		for b.Loop() {
+			if err := builtinUUIDParse(BuiltinContext{}, operands, noOpIter); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("version=2", func(b *testing.B) {
+		operands := []*ast.Term{ast.StringTerm("000003e8-48b9-21ee-b200-325096b39f47")}
+		for b.Loop() {
+			if err := builtinUUIDParse(BuiltinContext{}, operands, noOpIter); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+func noOpIter(term *ast.Term) error {
+	return nil
 }


### PR DESCRIPTION
Just stumbled upon this and it was too easy not to improve a little :) Not particularly important, but since each request to the server generates a decision ID, paying 1 allocation for that is better than paying 7.

Also somewhat cheaper UUID built-in call by using `Value.Hash()` as cache key rather than `Value.String()`.
