### PR TITLE
Move global builtin.Ref() vars to single location

### DIFF
--- a/v1/ast/compile.go
+++ b/v1/ast/compile.go
@@ -2932,10 +2932,8 @@ func containsPrintCall(x any) bool {
 	return found
 }
 
-var printRef = Print.Ref()
-
 func isPrintCall(x *Expr) bool {
-	return x.IsCall() && x.Operator().Equal(printRef)
+	return x.IsCall() && x.Operator().Equal(Interned.Refs.Print)
 }
 
 // rewriteRefsInHead will rewrite rules so that the head does not contain any
@@ -3216,19 +3214,15 @@ func rewriteRegoMetadataCalls(metadataChainVar *Var, metadataRuleVar *Var, body 
 	return errs
 }
 
-var regoMetadataChainRef = RegoMetadataChain.Ref()
-var regoMetadataRuleRef = RegoMetadataRule.Ref()
-
 func isRegoMetadataChainCall(x *Expr) bool {
-	return x.IsCall() && x.Operator().Equal(regoMetadataChainRef)
+	return x.IsCall() && Interned.Refs.RegoMetadataChain.Equal(x.Operator())
 }
 
 func isRegoMetadataRuleCall(x *Expr) bool {
-	return x.IsCall() && x.Operator().Equal(regoMetadataRuleRef)
+	return x.IsCall() && Interned.Refs.RegoMetadataRule.Equal(x.Operator())
 }
 
 func createMetadataChain(chain []*AnnotationsRef) (*Term, *Error) {
-
 	metaArray := NewArray()
 	for _, link := range chain {
 		// Dropping leading 'data' element of path
@@ -6012,11 +6006,12 @@ func rewriteComprehensionTerms(f *equalityFactory, node any) (any, error) {
 // partial evaluation cases we do want to rewrite == to = to simplify the
 // result.
 func rewriteEquals(x any) (modified bool) {
+	// Note: can't use Interned.Refs.Equality here as this may be mutated
 	unifyOp := Equality.Ref()
 	t := NewGenericTransformer(func(x any) (any, error) {
 		if x, ok := x.(*Expr); ok && x.IsCall() {
 			operator := x.Operator()
-			if operator.Equal(equalRef) && len(x.Operands()) == 2 {
+			if operator.Equal(Interned.Refs.Equal) && len(x.Operands()) == 2 {
 				modified = true
 				x.SetOperator(NewTerm(unifyOp))
 			}

--- a/v1/ast/index.go
+++ b/v1/ast/index.go
@@ -13,15 +13,8 @@ import (
 )
 
 var (
-	equalityRef         = Equality.Ref()
-	equalRef            = Equal.Ref()
-	globMatchRef        = GlobMatch.Ref()
-	internalPrintRef    = InternalPrint.Ref()
-	internalTestCaseRef = InternalTestCase.Ref()
-	internalMemberRef   = Member.Ref()
-
 	globwildcard = VarTerm("$globwildcard")
-	skipIndexing = NewSet(NewTerm(internalPrintRef), NewTerm(internalTestCaseRef))
+	skipIndexing = NewSet(NewTerm(Interned.Refs.InternalPrint), NewTerm(Interned.Refs.InternalTestCase))
 
 	// anyValue is a fake variable we used to put "naked ref" expressions
 	// into the rule index
@@ -353,12 +346,12 @@ func (i *refindices) Update(rule *Rule, expr *Expr, values map[Var]Value) {
 		}
 	}
 
-	equalish := op.Equal(equalityRef) || // unification, no 3-operands version exists
+	equalish := op.Equal(Interned.Refs.Equality) || // unification, no 3-operands version exists
 		// NOTE(tsandall): if equal() is called with more than two arguments the
 		// output value is being captured in which case the indexer cannot
 		// exclude the rule if the equal() call would return false (because the
 		// false value must still be produced.)
-		(op.Equal(equalRef) && len(expr.Operands()) == 2)
+		(op.Equal(Interned.Refs.Equal) && len(expr.Operands()) == 2)
 
 	a, b := expr.Operand(0), expr.Operand(1)
 	switch {
@@ -367,12 +360,12 @@ func (i *refindices) Update(rule *Rule, expr *Expr, values map[Var]Value) {
 			i.updateEq(rule, a.Value, b.Value, values)
 		}
 
-	case op.Equal(globMatchRef) && len(expr.Operands()) == 3:
+	case op.Equal(Interned.Refs.GlobMatch) && len(expr.Operands()) == 3:
 		// NOTE(sr): Same as with equal() above -- 4 operands means the output
 		// of `glob.match` is captured and the rule can thus not be excluded.
 		i.updateGlobMatch(rule, expr)
 
-	case op.Equal(internalMemberRef) && len(expr.Operands()) == 2:
+	case op.Equal(Interned.Refs.Member) && len(expr.Operands()) == 2:
 		// NOTE(sr): Again, 3 operands means captured output (like above).
 		i.updateMember(rule, expr, values)
 	}

--- a/v1/ast/interning.go
+++ b/v1/ast/interning.go
@@ -13,12 +13,46 @@ type internable interface {
 	bool | string | int | int8 | int16 | int32 | int64 | uint | uint8 | uint16 | uint32 | uint64
 }
 
+type interned struct {
+	Refs *internedRefs
+}
+
+type internedRefs struct {
+	Equal             Ref
+	Equality          Ref
+	GlobMatch         Ref
+	InternalPrint     Ref
+	InternalTestCase  Ref
+	Member            Ref
+	MemberWithKey     Ref
+	Or                Ref
+	Print             Ref
+	RegoMetadataChain Ref
+	RegoMetadataRule  Ref
+}
+
 // NOTE! Great care must be taken **not** to modify the terms returned
 // from these functions, as they are shared across all callers.
 // This package is currently considered experimental, and may change
 // at any time without notice.
 
 var (
+	Interned = &interned{
+		Refs: &internedRefs{
+			Equal:             Equal.Ref(),
+			Equality:          Equality.Ref(),
+			GlobMatch:         GlobMatch.Ref(),
+			InternalPrint:     InternalPrint.Ref(),
+			InternalTestCase:  InternalTestCase.Ref(),
+			Member:            Member.Ref(),
+			MemberWithKey:     MemberWithKey.Ref(),
+			Or:                Or.Ref(),
+			Print:             Print.Ref(),
+			RegoMetadataChain: RegoMetadataChain.Ref(),
+			RegoMetadataRule:  RegoMetadataRule.Ref(),
+		},
+	}
+
 	InternedNullValue Value = Null{}
 	InternedNullTerm        = NewTerm(InternedNullValue)
 

--- a/v1/ast/parser.go
+++ b/v1/ast/parser.go
@@ -71,12 +71,6 @@ var (
 		Var("$0"), Var("$1"), Var("$2"), Var("$3"), Var("$4"), Var("$5"),
 		Var("$6"), Var("$7"), Var("$8"), Var("$9"), Var("$10"),
 	}
-
-	// use static references to avoid allocations, and
-	// copy them to  the call term only when needed
-	memberWithKeyRef = MemberWithKey.Ref()
-	memberRef        = Member.Ref()
-
 	metadataBytes      = []byte("METADATA")
 	metadataParserPool = util.NewSyncPool[metadataParser]()
 )
@@ -1868,7 +1862,7 @@ func isAmbiguousUnionBody(b Body) bool {
 	// The first expression decides: `{A | B; C}` also reads as a comprehension with
 	// head A and body `B; C`, so trailing expressions don't disambiguate anything.
 	terms, ok := b[0].Terms.([]*Term)
-	if !ok || !Or.Ref().Equal(b[0].Operator()) {
+	if !ok || !Interned.Refs.Or.Equal(b[0].Operator()) {
 		return false
 	}
 
@@ -2235,7 +2229,7 @@ func (p *Parser) parseTermIn(lhs *Term, keyVal bool, offset int) *Term {
 			p.scan()
 			if mhs := p.parseTermRelation(nil, offset); mhs != nil {
 
-				if op := p.parseTermOpName(memberWithKeyRef, tokens.In); op != nil {
+				if op := p.parseTermOpName(Interned.Refs.MemberWithKey, tokens.In); op != nil {
 					if rhs := p.parseTermRelation(nil, p.s.loc.Offset); rhs != nil {
 						call := p.setLoc(CallTerm(op, lhs, mhs, rhs), lhs.Location, offset, p.s.lastEnd)
 						switch p.s.tok {
@@ -2252,7 +2246,7 @@ func (p *Parser) parseTermIn(lhs *Term, keyVal bool, offset int) *Term {
 
 		_ = scanAheadRef(p)
 
-		if op := p.parseTermOpName(memberRef, tokens.In); op != nil {
+		if op := p.parseTermOpName(Interned.Refs.Member, tokens.In); op != nil {
 			if rhs := p.parseTermRelation(nil, p.s.loc.Offset); rhs != nil {
 				call := p.setLoc(CallTerm(op, lhs, rhs), lhs.Location, offset, p.s.lastEnd)
 				switch p.s.tok {

--- a/v1/ast/parser_test.go
+++ b/v1/ast/parser_test.go
@@ -9225,8 +9225,8 @@ func TestNotImport(t *testing.T) {
 						Body: NewBody(
 							&Expr{
 								Terms: []*Term{
-									NewTerm(Equal.Ref()),
-									CallTerm(NewTerm(Plus.Ref()), NumberTerm("1"), NumberTerm("1")),
+									NewTerm(Interned.Refs.Equal),
+									Plus.Call(NumberTerm("1"), NumberTerm("1")),
 									NumberTerm("3"),
 								},
 								Negated: true,
@@ -9285,8 +9285,8 @@ func TestNotImport(t *testing.T) {
 							NewExpr(
 								&Not{
 									Body: NewBody(Equal.Expr(
-										CallTerm(NewTerm(Plus.Ref()), NumberTerm("1"), NumberTerm("1")),
-										NumberTerm("3"),
+										Plus.Call(InternedTerm(1), InternedTerm(1)),
+										InternedTerm(3),
 									)),
 								},
 							),
@@ -9317,7 +9317,7 @@ func TestNotImport(t *testing.T) {
 							&Expr{
 								Terms: &Not{
 									Body: NewBody(Equal.Expr(
-										CallTerm(NewTerm(Plus.Ref()), NumberTerm("1"), NumberTerm("1")),
+										Plus.Call(InternedTerm(1), InternedTerm(1)),
 										RefTerm(VarTerm("input"), StringTerm("x")),
 									)),
 								},
@@ -9895,7 +9895,7 @@ func TestAmbiguousUnionBodyIsRejected(t *testing.T) {
 			// The parens make the braces a set literal, holding the call.
 			expBody: NewBody(NewExpr(&Not{
 				Body: NewBody(NewExpr(SetTerm(
-					CallTerm(NewTerm(Or.Ref()), VarTerm("a"), VarTerm("b")),
+					CallTerm(NewTerm(Interned.Refs.Or), VarTerm("a"), VarTerm("b")),
 				))),
 			})),
 		},

--- a/v1/ast/policy.go
+++ b/v1/ast/policy.go
@@ -55,10 +55,14 @@ var RootDocumentNames = NewSet(
 // All refs to data in the policy engine's storage layer are prefixed with this ref.
 var DefaultRootRef = Ref{DefaultRootDocument}
 
+var DefaultRootRefTerm = NewTerm(DefaultRootRef)
+
 // InputRootRef is a reference to the root of the input document.
 //
 // All refs to query arguments are prefixed with this ref.
 var InputRootRef = Ref{InputRootDocument}
+
+var InputRootRefTerm = NewTerm(InputRootRef)
 
 // SchemaRootRef is a reference to the root of the schema document.
 //
@@ -69,10 +73,7 @@ var SchemaRootRef = Ref{SchemaRootDocument}
 
 // RootDocumentRefs contains the prefixes of top-level documents that all
 // non-local references start with.
-var RootDocumentRefs = NewSet(
-	NewTerm(DefaultRootRef),
-	NewTerm(InputRootRef),
-)
+var RootDocumentRefs = NewSet(DefaultRootRefTerm, InputRootRefTerm)
 
 // SystemDocumentKey is the name of the top-level key that identifies the system
 // document.

--- a/v1/format/format.go
+++ b/v1/format/format.go
@@ -206,9 +206,6 @@ func AstWithOpts(x any, opts Opts) ([]byte, error) {
 	}
 	o.allowKeywordsInRefs = capabilities.ContainsFeature(ast.FeatureKeywordsInRefs)
 
-	memberRef := ast.Member.Ref()
-	memberWithKeyRef := ast.MemberWithKey.Ref()
-
 	// Preprocess the AST. Set any required defaults and calculate
 	// values required for printing the formatted output.
 	ast.WalkNodes(x, func(x ast.Node) bool {
@@ -222,7 +219,8 @@ func AstWithOpts(x any, opts Opts) ([]byte, error) {
 
 		case *ast.Expr:
 			switch {
-			case n.IsCall() && memberRef.Equal(n.Operator()) || memberWithKeyRef.Equal(n.Operator()):
+			case n.IsCall() && ast.Interned.Refs.Member.Equal(n.Operator()) ||
+				ast.Interned.Refs.MemberWithKey.Equal(n.Operator()):
 				extraFutureKeywordImports["in"] = struct{}{}
 			case n.IsEvery():
 				extraFutureKeywordImports["every"] = struct{}{}
@@ -2355,7 +2353,7 @@ func (w *writer) writeIterableLine(elements []any, comments []*ast.Comment, fn e
 // `x | y`, which is comprehension syntax at an operand brace.
 func isUnionExpr(expr *ast.Expr) bool {
 	terms, ok := expr.Terms.([]*ast.Term)
-	return ok && len(terms) == 3 && ast.Or.Ref().Equal(terms[0].Value)
+	return ok && len(terms) == 3 && ast.Interned.Refs.Or.Equal(terms[0].Value)
 }
 
 // markUnionLead parenthesizes the set union leading the rendering of expr, if
@@ -2453,7 +2451,7 @@ func termRendersBraceLead(t *ast.Term) bool {
 // literal or as a comprehension term, and must be parenthesized there.
 func isUnionCall(t *ast.Term) bool {
 	call, ok := t.Value.(ast.Call)
-	return ok && ast.Or.Ref().Equal(call[0].Value)
+	return ok && ast.Interned.Refs.Or.Equal(call[0].Value)
 }
 
 func (w *writer) objectWriter() entryWriter {

--- a/v1/rego/rego.go
+++ b/v1/rego/rego.go
@@ -2834,12 +2834,11 @@ func (*Rego) rewriteQueryForPartialEval(_ ast.QueryCompiler, query ast.Body) (as
 // where rewriting them can substantially simplify the result, and it is unlikely
 // that the caller would need expression values.
 func (*Rego) rewriteEqualsForPartialQueryCompile(_ ast.QueryCompiler, query ast.Body) (ast.Body, error) {
-	doubleEq := ast.Equal.Ref()
 	unifyOp := ast.Equality.Ref()
 	ast.WalkExprs(query, func(x *ast.Expr) bool {
 		if x.IsCall() {
 			operator := x.Operator()
-			if operator.Equal(doubleEq) && len(x.Operands()) == 2 {
+			if operator.Equal(ast.Interned.Refs.Equal) && len(x.Operands()) == 2 {
 				x.SetOperator(ast.NewTerm(unifyOp))
 			}
 		}

--- a/v1/sdk/opa.go
+++ b/v1/sdk/opa.go
@@ -390,9 +390,7 @@ type DecisionResult struct {
 }
 
 func (opa *OPA) executeTransaction(ctx context.Context, record *server.Info, work func(state, *DecisionResult)) (*DecisionResult, error) {
-	if record.Metrics == nil {
-		record.Metrics = metrics.New()
-	}
+	record.Metrics = util.Or(record.Metrics, metrics.New)
 	record.Metrics.Timer(metrics.SDKDecisionEval).Start()
 
 	if record.DecisionID == "" {

--- a/v1/tester/runner.go
+++ b/v1/tester/runner.go
@@ -761,8 +761,6 @@ func rewriteDuplicateTestNames(compiler *ast.Compiler) *ast.Error {
 	return nil
 }
 
-var testCaseFuncRef = ast.InternalTestCase.Ref()
-
 // injectTestCaseFunc will inject a call to the 'internal.test_case' function into partial-object test rules.
 // We attempt to find the earliest point in the rule body where we can inject the call, to ensure that the test-case
 // function is called as early as possible so that we capture as many failed test cases as possible.
@@ -812,7 +810,7 @@ func injectTestCaseFunc(compiler *ast.Compiler) *ast.Error {
 			// Only apply to rules that doesn't have manual use of the test-case function
 			manualCall := false
 			ast.WalkExprs(rule.Body, func(expr *ast.Expr) bool {
-				if expr.IsCall() && expr.Operator().Equal(testCaseFuncRef) {
+				if expr.IsCall() && expr.Operator().Equal(ast.Interned.Refs.InternalTestCase) {
 					manualCall = true
 					return true
 				}
@@ -933,7 +931,7 @@ func injectTestCaseFunc(compiler *ast.Compiler) *ast.Error {
 			})
 
 			testCaseFuncExpr := ast.NewExpr([]*ast.Term{
-				ast.NewTerm(ast.InternalTestCase.Ref()),
+				ast.NewTerm(ast.Interned.Refs.InternalTestCase),
 				ast.NewTerm(args),
 			})
 

--- a/v1/topdown/bindings_alloc_bench_test.go
+++ b/v1/topdown/bindings_alloc_bench_test.go
@@ -18,6 +18,8 @@ import (
 // BenchmarkBindingsAllocation benchmarks memory allocation for bindings with different sizes.
 // This directly tests the optimization from issue #7266.
 func BenchmarkBindingsAllocation(b *testing.B) {
+	const maxBindings int = 50
+
 	tests := []struct {
 		name     string
 		bindings int
@@ -29,32 +31,32 @@ func BenchmarkBindingsAllocation(b *testing.B) {
 		{"10_bindings", 10},
 		{"16_bindings", 16},
 		{"20_bindings", 20},
-		{"50_bindings", 50},
+		{"50_bindings", maxBindings},
 	}
+
+	var keys, vals [maxBindings]*ast.Term
+	for j := range maxBindings {
+		keys[j] = ast.VarTerm(fmt.Sprintf("x%d", j))
+		vals[j] = ast.InternedTerm(j)
+	}
+
+	u := &undo{}
 
 	for _, tt := range tests {
 		b.Run(tt.name+"_without_hint", func(b *testing.B) {
-			b.ReportAllocs()
-			b.ResetTimer()
 			for b.Loop() {
 				bi := newBindings(0, nil)
 				for j := range tt.bindings {
-					key := ast.VarTerm(fmt.Sprintf("x%d", j))
-					val := ast.IntNumberTerm(j)
-					bi.bind(key, val, nil, &undo{})
+					bi.bind(keys[j], vals[j], nil, u)
 				}
 			}
 		})
 
 		b.Run(tt.name+"_with_hint", func(b *testing.B) {
-			b.ReportAllocs()
-			b.ResetTimer()
 			for b.Loop() {
 				bi := newBindingsWithSize(0, nil, tt.bindings)
 				for j := range tt.bindings {
-					key := ast.VarTerm(fmt.Sprintf("x%d", j))
-					val := ast.IntNumberTerm(j)
-					bi.bind(key, val, nil, &undo{})
+					bi.bind(keys[j], vals[j], nil, u)
 				}
 			}
 		})
@@ -75,7 +77,7 @@ func BenchmarkFunctionArgumentCounts(b *testing.B) {
 			checks := make([]string, argCount)
 			for i := range argCount {
 				args[i] = fmt.Sprintf("x%d", i)
-				checks[i] = fmt.Sprintf("%s == %d", args[i], i)
+				checks[i] = fmt.Sprintf("x%[1]d == %[1]d", i)
 			}
 
 			module := fmt.Sprintf(`package test
@@ -85,10 +87,7 @@ func BenchmarkFunctionArgumentCounts(b *testing.B) {
 			}
 			`, strings.Join(args, ", "), strings.Join(checks, "\n\t\t\t\t"))
 
-			compiler := ast.MustCompileModules(map[string]string{
-				"test.rego": module,
-			})
-
+			compiler := ast.MustCompileModules(map[string]string{"test.rego": module})
 			store := inmem.NewFromObject(map[string]any{})
 
 			// Create call with matching arguments
@@ -98,23 +97,23 @@ func BenchmarkFunctionArgumentCounts(b *testing.B) {
 			}
 			query := ast.MustParseBody(fmt.Sprintf(`data.test.f(%s)`, strings.Join(callArgs, ", ")))
 
-			b.ReportAllocs()
-			b.ResetTimer()
+			err := storage.Txn(ctx, store, storage.TransactionParams{}, func(txn storage.Transaction) error {
+				q := NewQuery(query).
+					WithCompiler(compiler).
+					WithStore(store).
+					WithTransaction(txn)
 
-			for b.Loop() {
-				err := storage.Txn(ctx, store, storage.TransactionParams{}, func(txn storage.Transaction) error {
-					q := NewQuery(query).
-						WithCompiler(compiler).
-						WithStore(store).
-						WithTransaction(txn)
-
-					_, err := q.Run(ctx)
-					return err
-				})
-
-				if err != nil {
-					b.Fatal(err)
+				for b.Loop() {
+					if _, err := q.Run(ctx); err != nil {
+						return err
+					}
 				}
+
+				return nil
+			})
+
+			if err != nil {
+				b.Fatal(err)
 			}
 		})
 	}
@@ -122,30 +121,30 @@ func BenchmarkFunctionArgumentCounts(b *testing.B) {
 
 // BenchmarkBindingsArrayHashmapTransition benchmarks the transition from array to map mode.
 func BenchmarkBindingsArrayHashmapTransition(b *testing.B) {
+	var keys [17]*ast.Term
+	var vals [17]value
+
+	for j := range 17 {
+		keys[j] = ast.VarTerm(fmt.Sprintf("x%d", j))
+		vals[j] = value{v: ast.InternedTerm(j)}
+	}
+
 	b.Run("without_hint_transition_at_17", func(b *testing.B) {
-		b.ReportAllocs()
-		b.ResetTimer()
 		for b.Loop() {
 			bh := newBindingsArrayHashmap()
 			// Add 17 bindings to force transition to map
 			for j := range 17 {
-				key := ast.VarTerm(fmt.Sprintf("x%d", j))
-				val := value{v: ast.IntNumberTerm(j)}
-				bh.Put(key, val)
+				bh.Put(keys[j], vals[j])
 			}
 		}
 	})
 
 	b.Run("with_hint_starts_with_map", func(b *testing.B) {
-		b.ReportAllocs()
-		b.ResetTimer()
 		for b.Loop() {
 			bh := newBindingsArrayHashmapWithSize(17)
 			// Add 17 bindings directly to map (no transition)
 			for j := range 17 {
-				key := ast.VarTerm(fmt.Sprintf("x%d", j))
-				val := value{v: ast.IntNumberTerm(j)}
-				bh.Put(key, val)
+				bh.Put(keys[j], vals[j])
 			}
 		}
 	})

--- a/v1/topdown/copypropagation/copypropagation.go
+++ b/v1/topdown/copypropagation/copypropagation.go
@@ -525,11 +525,10 @@ func makeDisjointSets(livevars ast.VarSet, query ast.Body) (*unionFind, bool) {
 }
 
 func isNoop(expr *ast.Expr) bool {
-
 	switch t := expr.Terms.(type) {
 	case []*ast.Term:
 		// A==A can be ignored
-		if expr.Operator().Equal(ast.Equal.Ref()) {
+		if expr.Operator().Equal(ast.Interned.Refs.Equal) {
 			return expr.Operand(0).Equal(expr.Operand(1))
 		}
 		return false

--- a/v1/topdown/test.go
+++ b/v1/topdown/test.go
@@ -13,7 +13,7 @@ func builtinTestCase(bctx BuiltinContext, operands []*ast.Term, iter func(*ast.T
 		Op:      TestCaseOp,
 		QueryID: bctx.QueryID,
 		Node: ast.NewExpr([]*ast.Term{
-			ast.NewTerm(ast.InternalTestCase.Ref()),
+			ast.NewTerm(ast.Interned.Refs.InternalTestCase),
 			ast.NewTerm(operands[0].Value),
 		}),
 	}

--- a/v1/topdown/tokens_test.go
+++ b/v1/topdown/tokens_test.go
@@ -271,10 +271,8 @@ func TestTopDownJWTEncodeSignES256(t *testing.T) {
 
 	defer store.Abort(ctx, txn)
 
-	var lhs *ast.Term
-	if len(path) == 0 {
-		lhs = ast.NewTerm(ast.DefaultRootRef)
-	} else {
+	lhs := ast.DefaultRootRefTerm
+	if len(path) != 0 {
 		lhs = ast.MustParseTerm("data." + strings.Join(path, "."))
 	}
 
@@ -409,10 +407,8 @@ func TestTopDownJWTEncodeSignES512(t *testing.T) {
 
 	defer store.Abort(ctx, txn)
 
-	var lhs *ast.Term
-	if len(path) == 0 {
-		lhs = ast.NewTerm(ast.DefaultRootRef)
-	} else {
+	lhs := ast.DefaultRootRefTerm
+	if len(path) != 0 {
 		lhs = ast.MustParseTerm("data." + strings.Join(path, "."))
 	}
 

--- a/v1/topdown/topdown_partial_test.go
+++ b/v1/topdown/topdown_partial_test.go
@@ -2103,11 +2103,7 @@ func TestTopDownPartialEval(t *testing.T) {
 			wantQueryASTs: []ast.Body{
 				ast.NewBody(
 					ast.NewExpr(
-						ast.CallTerm(
-							ast.NewTerm(ast.Equal.Ref()),
-							ast.NewTerm(ast.InputRootRef),
-							ast.InternedTerm(1),
-						),
+						ast.Equal.Call(ast.InputRootRefTerm, ast.InternedTerm(1)),
 					),
 				),
 			},
@@ -2257,11 +2253,7 @@ func TestTopDownPartialEval(t *testing.T) {
 			wantQueryASTs: []ast.Body{
 				ast.NewBody(
 					ast.NewExpr(
-						ast.CallTerm(
-							ast.NewTerm(ast.Equal.Ref()),
-							ast.NewTerm(ast.InputRootRef),
-							ast.IntNumberTerm(1),
-						),
+						ast.Equal.Call(ast.InputRootRefTerm, ast.InternedTerm(1)),
 					),
 				),
 			},
@@ -6486,9 +6478,9 @@ func TestTopDownPartialEvalNegation(t *testing.T) {
 						&ast.Expr{ // legacy negation (equivalent to implicit not-body when serialized to Rego).
 							Negated: true,
 							Terms: []*ast.Term{
-								{Value: ast.Equality.Ref()},
-								ast.RefTerm(ast.VarTerm("input"), ast.StringTerm("x")),
-								ast.NumberTerm("1"),
+								{Value: ast.Interned.Refs.Equality},
+								ast.NewTerm(ast.InputRootRef.Append(ast.InternedTerm("x"))),
+								ast.InternedTerm(1),
 							},
 						},
 					),
@@ -6541,15 +6533,15 @@ func TestTopDownPartialEvalNegation(t *testing.T) {
 				ast.NewBody(
 					ast.NotExpr(
 						ast.Equality.Expr(
-							ast.RefTerm(ast.VarTerm("input"), ast.StringTerm("x")),
-							ast.NumberTerm("1"),
+							ast.RefTerm(ast.InputRootDocument, ast.InternedTerm("x")),
+							ast.InternedTerm(1),
 						),
 						&ast.Expr{ // legacy negation (equivalent to implicit not-body when serialized to Rego).
 							Negated: true,
 							Terms: []*ast.Term{
 								{Value: ast.Equality.Ref()},
-								ast.RefTerm(ast.VarTerm("input"), ast.StringTerm("y")),
-								ast.NumberTerm("2"),
+								ast.RefTerm(ast.InputRootDocument, ast.InternedTerm("y")),
+								ast.InternedTerm(2),
 							},
 						},
 					),

--- a/v1/topdown/topdown_test.go
+++ b/v1/topdown/topdown_test.go
@@ -2147,10 +2147,8 @@ func assertTopDownWithPathAndContext(ctx context.Context, t *testing.T, compiler
 
 	defer store.Abort(ctx, txn)
 
-	var lhs *ast.Term
-	if len(path) == 0 {
-		lhs = ast.NewTerm(ast.DefaultRootRef)
-	} else {
+	lhs := ast.DefaultRootRefTerm
+	if len(path) != 0 {
 		lhs = ast.MustParseTerm("data." + strings.Join(path, "."))
 	}
 


### PR DESCRIPTION
These have previously been scattered throughout the project, and a few of them have been stored several times under different names. This change moves them all in under the interning code where it feels like they belong.