### PR TITLE
ast: don't leak generated locals for calls in ref type errors

### DIFF
--- a/v1/ast/compile.go
+++ b/v1/ast/compile.go
@@ -6436,7 +6436,25 @@ func expandExprTerm(gen *localVarGenerator, term *Term) (support []*Expr, output
 
 func expandExprRef(gen *localVarGenerator, v []*Term) (support []*Expr) {
 	// Start by calling a normal expandExprTerm on all terms.
-	support = expandExprTermSlice(gen, v)
+	for i := range v {
+		// A call in a ref, e.g. the opa.runtime() in opa.runtime()[0].foo, is
+		// hoisted into a generated local by expandExprTerm below. Record the
+		// call that local stands in for, so type errors on this ref render the
+		// call rather than the local. The call has to be copied first:
+		// expandExprTerm hoists nested calls out of its arguments in place.
+		var subject Value
+		if call, ok := v[i].Value.(Call); ok {
+			subject = call.Copy()
+		}
+
+		var extras []*Expr
+		extras, v[i] = expandExprTerm(gen, v[i])
+		support = append(support, extras...)
+
+		if local, ok := v[i].Value.(Var); ok && subject != nil {
+			gen.putSubject(local, subject)
+		}
+	}
 
 	// Rewrite references in order to support indirect references.  We rewrite
 	// e.g.
@@ -6466,15 +6484,6 @@ func expandExprTermArray(gen *localVarGenerator, arr *Array) (support []*Expr) {
 	for i := range arr.Len() {
 		extras, v := expandExprTerm(gen, arr.Elem(i))
 		arr.set(i, v)
-		support = append(support, extras...)
-	}
-	return
-}
-
-func expandExprTermSlice(gen *localVarGenerator, v []*Term) (support []*Expr) {
-	for i := range v {
-		var extras []*Expr
-		extras, v[i] = expandExprTerm(gen, v[i])
 		support = append(support, extras...)
 	}
 	return

--- a/v1/ast/compile_test.go
+++ b/v1/ast/compile_test.go
@@ -2118,6 +2118,68 @@ x if {
 	assertNotFailed(t, c)
 }
 
+// Regression test for GH issue #4577
+func TestCompilerCheckTypesCallsInRefsNotLeaked(t *testing.T) {
+	tests := []struct {
+		note   string
+		module string
+		// The expected error, up to and including the caret line of the detail:
+		// the caret is positioned by rendering the ref, so it moves along with
+		// the substituted call.
+		expErr string
+	}{
+		{
+			note: "builtin call as ref subject",
+			module: `package test
+
+q := opa.runtime()[0].foo`,
+			expErr: "undefined ref: opa.runtime()[0].foo\n" +
+				"\topa.runtime()[0].foo\n" +
+				"\t              ^",
+		},
+		{
+			// rego.metadata.chain() is rewritten into a var of its own after the
+			// call has been hoisted out of the ref.
+			note: "rego.metadata.chain() call as ref subject",
+			module: `package test
+
+p := rego.metadata.chain()[0].annotations`,
+			expErr: "undefined ref: rego.metadata.chain()[0].annotations\n" +
+				"\trego.metadata.chain()[0].annotations\n" +
+				"\t                         ^",
+		},
+		{
+			note: "function call as ref subject",
+			module: `package test
+
+f(x) := {"a": x}
+
+p := f(1)[0]`,
+			expErr: "undefined ref: data.test.f(1)[0]\n" +
+				"\tdata.test.f(1)[0]\n" +
+				"\t               ^",
+		},
+		{
+			note: "call in ref index position",
+			module: `package test
+
+p := {"a": 1}[count([1, 2])]`,
+			expErr: "undefined ref: {\"a\": 1}[count([1, 2])]\n" +
+				"\t{\"a\": 1}[count([1, 2])]\n" +
+				"\t         ^",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.note, func(t *testing.T) {
+			c := NewCompiler()
+			c.Modules = map[string]*Module{"test": MustParseModule(tc.module)}
+			compileStages(c, StageCheckTypes)
+			assertCompilerErrorStrings(t, c, []string{"rego_type_error: " + tc.expErr})
+		})
+	}
+}
+
 func TestCompilerCheckRuleConflicts(t *testing.T) {
 
 	c := getCompilerWithParsedModules(map[string]string{
@@ -11683,6 +11745,26 @@ func TestQueryCompiler(t *testing.T) {
 			note:     "nested dynamic index locals not leaked in type error",
 			q:        `[1, 2][input.a[input.b]][j]`,
 			expected: errors.New("1 error occurred: 1:1: rego_type_error: undefined ref: [1, 2][input.a[input.b]][j]"),
+		},
+		{
+			// Regression test for https://github.com/open-policy-agent/opa/issues/4577:
+			// the generated local for a call in a ref subject must not leak.
+			note:     "call ref subject not leaked in type error",
+			q:        `opa.runtime()[0].foo`,
+			expected: errors.New("1 error occurred: 1:1: rego_type_error: undefined ref: opa.runtime()[0].foo"),
+		},
+		{
+			// A call in an index position is hoisted into a local too.
+			note:     "call index local not leaked in type error",
+			q:        `{"a": 1}[count([1, 2])]`,
+			expected: errors.New("1 error occurred: 1:1: rego_type_error: undefined ref: {\"a\": 1}[count([1, 2])]"),
+		},
+		{
+			// The arguments of a hoisted call are themselves hoisted into
+			// locals, so the call must be recorded before that happens.
+			note:     "nested call arguments not leaked in type error",
+			q:        `count(input.a[input.b])[0]`,
+			expected: errors.New("1 error occurred: 1:1: rego_type_error: undefined ref: count(input.a[input.b])[0]"),
 		},
 		{
 			note:     "imports resolved without package",


### PR DESCRIPTION
fix: #4577

A call in a reference, e.g. the opa.runtime() in opa.runtime()[0].foo, is hoisted into a generated local before type checking. That local leaked into type errors on the reference, so a typo in a policy was reported against a name that appears nowhere in the source:

    rego_type_error: undefined ref: __local0__[0].foo
        __local0__[0].foo
                   ^

Refs with a composite subject or a dynamic operand already record the term their generated local stands in for, so type errors can render the original expression. Do the same for calls in a ref, giving:

    rego_type_error: undefined ref: opa.runtime()[0].foo
        opa.runtime()[0].foo
                      ^

The call is recorded before its own arguments are expanded, as they are hoisted out of it in place; otherwise a nested call would leak instead. Only calls in refs are recorded, as that is the only place the type checker renders a var it did not get from the policy source.