### PR TITLE
security: make allow_net restrict file:// refs in JSON schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,6 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
-### Fixes
-
-- Security: Make `allow_net` restrict `file://` references in JSON schemas used by
-  `json.match_schema` and `json.verify_schema`, closing a sandbox bypass that allowed local file
-  reads. ([#9000](https://github.com/open-policy-agent/opa/issues/9000))
-
 ## 1.19.1
 
 This release uses the latest version of Go (1.26.6) to build OPA, fixing stdlib vulnerabilities in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Fixes
+
+- Security: Make `allow_net` restrict `file://` references in JSON schemas used by
+  `json.match_schema` and `json.verify_schema`, closing a sandbox bypass that allowed local file
+  reads. ([#9000](https://github.com/open-policy-agent/opa/issues/9000))
+
 ## 1.19.1
 
 This release uses the latest version of Go (1.26.6) to build OPA, fixing stdlib vulnerabilities in

--- a/internal/gojsonschema/jsonLoader.go
+++ b/internal/gojsonschema/jsonLoader.go
@@ -49,15 +49,16 @@ import (
 // matches the stdlib default.
 const maxRemoteRefRedirects = 10
 
-// remoteRefLimits bounds the outbound requests a loader may make while
-// resolving remote references. The zero value is unrestricted.
-type remoteRefLimits struct {
+// loaderLimits controls the external resources a loader may access while
+// resolving references. Its zero value permits any network host and denies
+// filesystem access.
+type loaderLimits struct {
 	// A nil set permits any host; an empty set permits none.
 	allowNet map[string]struct{}
 
-	// A file:// $ref is denied whenever DenyFileScheme is set, independent
+	// Local file access is allowed only when allowFilesystem is set, independent
 	// of allowNet. allowNet governs only remote HTTP fetches.
-	denyFileScheme bool
+	allowFilesystem bool
 
 	// LoadJSON takes no arguments, so the context rides on the loader instead.
 	// Loaders are built per Compile call, so its scope is that one compilation.
@@ -93,20 +94,20 @@ type JSONLoader interface {
 type JSONLoaderFactory interface {
 	// New creates a new JSON loader for the given source
 	New(source string) JSONLoader
-	// withRemoteRefLimits returns a copy of the factory whose loaders resolve
-	// remote references subject to the given limits.
-	withRemoteRefLimits(limits remoteRefLimits) JSONLoaderFactory
+	// withLoaderLimits returns a copy of the factory whose loaders resolve
+	// references subject to the given limits.
+	withLoaderLimits(limits loaderLimits) JSONLoaderFactory
 }
 
 // DefaultJSONLoaderFactory is the default JSON loader factory
 type DefaultJSONLoaderFactory struct {
-	limits remoteRefLimits
+	limits loaderLimits
 }
 
 // FileSystemJSONLoaderFactory is a JSON loader factory that uses http.FileSystem
 type FileSystemJSONLoaderFactory struct {
 	fs     http.FileSystem
-	limits remoteRefLimits
+	limits loaderLimits
 }
 
 // New creates a new JSON loader for the given source
@@ -127,12 +128,12 @@ func (f FileSystemJSONLoaderFactory) New(source string) JSONLoader {
 	}
 }
 
-func (d DefaultJSONLoaderFactory) withRemoteRefLimits(limits remoteRefLimits) JSONLoaderFactory {
+func (d DefaultJSONLoaderFactory) withLoaderLimits(limits loaderLimits) JSONLoaderFactory {
 	d.limits = limits
 	return d
 }
 
-func (f FileSystemJSONLoaderFactory) withRemoteRefLimits(limits remoteRefLimits) JSONLoaderFactory {
+func (f FileSystemJSONLoaderFactory) withLoaderLimits(limits loaderLimits) JSONLoaderFactory {
 	f.limits = limits
 	return f
 }
@@ -151,7 +152,7 @@ func (o osFileSystem) Open(name string) (http.File, error) {
 type jsonReferenceLoader struct {
 	fs     http.FileSystem
 	source string
-	limits remoteRefLimits
+	limits loaderLimits
 }
 
 func (l *jsonReferenceLoader) isAllowed(ref *url.URL) bool {
@@ -189,6 +190,7 @@ func NewReferenceLoader(source string) JSONLoader {
 	return &jsonReferenceLoader{
 		fs:     osFS,
 		source: source,
+		limits: loaderLimits{allowFilesystem: true},
 	}
 }
 
@@ -197,6 +199,7 @@ func NewReferenceLoaderFileSystem(source string, fs http.FileSystem) JSONLoader 
 	return &jsonReferenceLoader{
 		fs:     fs,
 		source: source,
+		limits: loaderLimits{allowFilesystem: true},
 	}
 }
 
@@ -213,7 +216,7 @@ func (l *jsonReferenceLoader) LoadJSON() (any, error) {
 	refToURL.GetUrl().Fragment = ""
 
 	if reference.HasFileScheme {
-		if l.limits.denyFileScheme {
+		if !l.limits.allowFilesystem {
 			return nil, fmt.Errorf("file reference loading disabled: %s", reference.String())
 		}
 

--- a/internal/gojsonschema/jsonLoader.go
+++ b/internal/gojsonschema/jsonLoader.go
@@ -209,6 +209,9 @@ func (l *jsonReferenceLoader) LoadJSON() (any, error) {
 	refToURL.GetUrl().Fragment = ""
 
 	if reference.HasFileScheme {
+		if l.limits.allowNet != nil {
+			return nil, fmt.Errorf("remote reference loading disabled: %s", reference.String())
+		}
 
 		filename := strings.TrimPrefix(refToURL.String(), "file://")
 		filename, err = url.QueryUnescape(filename)

--- a/internal/gojsonschema/jsonLoader.go
+++ b/internal/gojsonschema/jsonLoader.go
@@ -55,6 +55,10 @@ type remoteRefLimits struct {
 	// A nil set permits any host; an empty set permits none.
 	allowNet map[string]struct{}
 
+	// A file:// $ref is denied whenever DenyFileScheme is set, independent
+	// of allowNet. allowNet governs only remote HTTP fetches.
+	denyFileScheme bool
+
 	// LoadJSON takes no arguments, so the context rides on the loader instead.
 	// Loaders are built per Compile call, so its scope is that one compilation.
 	// A nil ctx means context.Background().
@@ -209,8 +213,8 @@ func (l *jsonReferenceLoader) LoadJSON() (any, error) {
 	refToURL.GetUrl().Fragment = ""
 
 	if reference.HasFileScheme {
-		if l.limits.allowNet != nil {
-			return nil, fmt.Errorf("remote reference loading disabled: %s", reference.String())
+		if l.limits.denyFileScheme {
+			return nil, fmt.Errorf("file reference loading disabled: %s", reference.String())
 		}
 
 		filename := strings.TrimPrefix(refToURL.String(), "file://")

--- a/internal/gojsonschema/jsonschema_test.go
+++ b/internal/gojsonschema/jsonschema_test.go
@@ -267,18 +267,17 @@ func TestAllowNetIsPerSchemaLoader(t *testing.T) {
 	})
 }
 
-func TestAllowNetRestrictsFileReferences(t *testing.T) {
+func TestFileReferencesIgnoreAllowNet(t *testing.T) {
 	root := test.TempDirOf(t, "schema.json", `{"type": "string"}`)
 	filename := filepath.Join(root, "schema.json")
 	schema := fmt.Sprintf(`{"$ref": %q}`, "file://"+filepath.ToSlash(filename))
 
 	tests := []struct {
-		note       string
-		allowNet   []string
-		wantDenied bool
+		note     string
+		allowNet []string
 	}{
-		{note: "nil list permits file references", allowNet: nil},
-		{note: "empty list denies file references", allowNet: []string{}, wantDenied: true},
+		{note: "nil list", allowNet: nil},
+		{note: "empty list", allowNet: []string{}},
 	}
 
 	for _, tc := range tests {
@@ -286,17 +285,38 @@ func TestAllowNetRestrictsFileReferences(t *testing.T) {
 			sl := NewSchemaLoader()
 			sl.AllowNet = tc.allowNet
 			_, err := sl.Compile(NewStringLoader(schema))
-			if tc.wantDenied {
-				if err == nil {
-					t.Fatal("expected file reference to be denied, but compilation succeeded")
-				}
-				if !strings.Contains(err.Error(), "remote reference loading disabled") {
-					t.Fatalf("expected remote reference loading to be disabled, got %v", err)
-				}
-				return
-			}
 			if err != nil {
 				t.Fatalf("expected file reference to be permitted, got %v", err)
+			}
+		})
+	}
+}
+
+func TestDenyFileSchemeRestrictsFileReferences(t *testing.T) {
+	root := test.TempDirOf(t, "schema.json", `{"type": "string"}`)
+	filename := filepath.Join(root, "schema.json")
+	schema := fmt.Sprintf(`{"$ref": %q}`, "file://"+filepath.ToSlash(filename))
+
+	tests := []struct {
+		note     string
+		allowNet []string
+	}{
+		{note: "nil list", allowNet: nil},
+		{note: "empty list", allowNet: []string{}},
+		{note: "populated list", allowNet: []string{"example.com"}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.note, func(t *testing.T) {
+			sl := NewSchemaLoader()
+			sl.AllowNet = tc.allowNet
+			sl.DenyFileScheme = true
+			_, err := sl.Compile(NewStringLoader(schema))
+			if err == nil {
+				t.Fatal("expected file reference to be denied, but compilation succeeded")
+			}
+			if !strings.Contains(err.Error(), "file reference loading disabled") {
+				t.Fatalf("expected file reference loading to be disabled, got %v", err)
 			}
 		})
 	}

--- a/internal/gojsonschema/jsonschema_test.go
+++ b/internal/gojsonschema/jsonschema_test.go
@@ -284,6 +284,7 @@ func TestFileReferencesIgnoreAllowNet(t *testing.T) {
 		t.Run(tc.note, func(t *testing.T) {
 			sl := NewSchemaLoader()
 			sl.AllowNet = tc.allowNet
+			sl.AllowFilesystem = true
 			_, err := sl.Compile(NewStringLoader(schema))
 			if err != nil {
 				t.Fatalf("expected file reference to be permitted, got %v", err)
@@ -292,7 +293,7 @@ func TestFileReferencesIgnoreAllowNet(t *testing.T) {
 	}
 }
 
-func TestDenyFileSchemeRestrictsFileReferences(t *testing.T) {
+func TestAllowFilesystemDefaultsToDenyFileReferences(t *testing.T) {
 	root := test.TempDirOf(t, "schema.json", `{"type": "string"}`)
 	filename := filepath.Join(root, "schema.json")
 	schema := fmt.Sprintf(`{"$ref": %q}`, "file://"+filepath.ToSlash(filename))
@@ -310,7 +311,6 @@ func TestDenyFileSchemeRestrictsFileReferences(t *testing.T) {
 		t.Run(tc.note, func(t *testing.T) {
 			sl := NewSchemaLoader()
 			sl.AllowNet = tc.allowNet
-			sl.DenyFileScheme = true
 			_, err := sl.Compile(NewStringLoader(schema))
 			if err == nil {
 				t.Fatal("expected file reference to be denied, but compilation succeeded")

--- a/internal/gojsonschema/jsonschema_test.go
+++ b/internal/gojsonschema/jsonschema_test.go
@@ -28,6 +28,8 @@ import (
 	"strings"
 	"sync"
 	"testing"
+
+	"github.com/open-policy-agent/opa/v1/util/test"
 	"time"
 )
 
@@ -266,10 +268,8 @@ func TestAllowNetIsPerSchemaLoader(t *testing.T) {
 }
 
 func TestAllowNetRestrictsFileReferences(t *testing.T) {
-	filename := filepath.Join(t.TempDir(), "schema.json")
-	if err := os.WriteFile(filename, []byte(`{"type": "string"}`), 0o600); err != nil {
-		t.Fatal(err)
-	}
+	root := test.TempDirOf(t, "schema.json", `{"type": "string"}`)
+	filename := filepath.Join(root, "schema.json")
 	schema := fmt.Sprintf(`{"$ref": %q}`, "file://"+filepath.ToSlash(filename))
 
 	tests := []struct {

--- a/internal/gojsonschema/jsonschema_test.go
+++ b/internal/gojsonschema/jsonschema_test.go
@@ -265,6 +265,43 @@ func TestAllowNetIsPerSchemaLoader(t *testing.T) {
 	})
 }
 
+func TestAllowNetRestrictsFileReferences(t *testing.T) {
+	filename := filepath.Join(t.TempDir(), "schema.json")
+	if err := os.WriteFile(filename, []byte(`{"type": "string"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	schema := fmt.Sprintf(`{"$ref": %q}`, "file://"+filepath.ToSlash(filename))
+
+	tests := []struct {
+		note       string
+		allowNet   []string
+		wantDenied bool
+	}{
+		{note: "nil list permits file references", allowNet: nil},
+		{note: "empty list denies file references", allowNet: []string{}, wantDenied: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.note, func(t *testing.T) {
+			sl := NewSchemaLoader()
+			sl.AllowNet = tc.allowNet
+			_, err := sl.Compile(NewStringLoader(schema))
+			if tc.wantDenied {
+				if err == nil {
+					t.Fatal("expected file reference to be denied, but compilation succeeded")
+				}
+				if !strings.Contains(err.Error(), "remote reference loading disabled") {
+					t.Fatalf("expected remote reference loading to be disabled, got %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected file reference to be permitted, got %v", err)
+			}
+		})
+	}
+}
+
 func TestAllowNetIsCheckedOnRedirects(t *testing.T) {
 	var srv *httptest.Server
 

--- a/internal/gojsonschema/schema.go
+++ b/internal/gojsonschema/schema.go
@@ -50,7 +50,9 @@ var (
 
 // NewSchema instances a schema using the given JSONLoader
 func NewSchema(l JSONLoader) (*Schema, error) {
-	return NewSchemaLoader().Compile(l)
+	sl := NewSchemaLoader()
+	sl.AllowFilesystem = true
+	return sl.Compile(l)
 }
 
 // Schema holds a schema

--- a/internal/gojsonschema/schemaLoader.go
+++ b/internal/gojsonschema/schemaLoader.go
@@ -32,6 +32,11 @@ type SchemaLoader struct {
 	// AllowNet is the list of hosts that remote references may be fetched
 	// from. A nil list permits any host; a non-nil empty list permits none.
 	AllowNet []string
+	// DenyFileScheme, when true, makes file:// $ref loading fail
+	// unconditionally. It is independent of AllowNet, which governs only
+	// remote HTTP fetches. The zero value (false) preserves the historical
+	// behavior of allowing local file references.
+	DenyFileScheme bool
 	// Context, when set, aborts in-flight remote reference fetches. Callers
 	// that have one -- evaluation, which holds the query's context -- should
 	// pass it so a cancelled or timed-out query doesn't leave requests
@@ -153,8 +158,9 @@ func (sl *SchemaLoader) Compile(rootSchema JSONLoader) (*Schema, error) {
 	// limits come from the compilation, not the root loader. The pool resolves
 	// every $ref through this factory, however deeply nested.
 	d.Pool.jsonLoaderFactory = rootSchema.LoaderFactory().withRemoteRefLimits(remoteRefLimits{
-		allowNet: newAllowNetSet(sl.AllowNet),
-		ctx:      sl.Context,
+		allowNet:       newAllowNetSet(sl.AllowNet),
+		denyFileScheme: sl.DenyFileScheme,
+		ctx:            sl.Context,
 	})
 	d.DocumentReference = ref
 	d.ReferencePool = newSchemaReferencePool()

--- a/internal/gojsonschema/schemaLoader.go
+++ b/internal/gojsonschema/schemaLoader.go
@@ -32,11 +32,10 @@ type SchemaLoader struct {
 	// AllowNet is the list of hosts that remote references may be fetched
 	// from. A nil list permits any host; a non-nil empty list permits none.
 	AllowNet []string
-	// DenyFileScheme, when true, makes file:// $ref loading fail
-	// unconditionally. It is independent of AllowNet, which governs only
-	// remote HTTP fetches. The zero value (false) preserves the historical
-	// behavior of allowing local file references.
-	DenyFileScheme bool
+	// AllowFilesystem permits file:// $ref loading. It is independent of
+	// AllowNet, which governs only remote HTTP fetches. The zero value (false)
+	// denies local file references.
+	AllowFilesystem bool
 	// Context, when set, aborts in-flight remote reference fetches. Callers
 	// that have one -- evaluation, which holds the query's context -- should
 	// pass it so a cancelled or timed-out query doesn't leave requests
@@ -154,13 +153,12 @@ func (sl *SchemaLoader) Compile(rootSchema JSONLoader) (*Schema, error) {
 
 	d := Schema{}
 	d.Pool = sl.pool
-	// NewStringLoader and NewGoLoader hand back unrestricted factories, so the
-	// limits come from the compilation, not the root loader. The pool resolves
-	// every $ref through this factory, however deeply nested.
-	d.Pool.jsonLoaderFactory = rootSchema.LoaderFactory().withRemoteRefLimits(remoteRefLimits{
-		allowNet:       newAllowNetSet(sl.AllowNet),
-		denyFileScheme: sl.DenyFileScheme,
-		ctx:            sl.Context,
+	// Reference access policy comes from the compilation, not the root loader.
+	// The pool resolves every $ref through this factory, however deeply nested.
+	d.Pool.jsonLoaderFactory = rootSchema.LoaderFactory().withLoaderLimits(loaderLimits{
+		allowNet:        newAllowNetSet(sl.AllowNet),
+		allowFilesystem: sl.AllowFilesystem,
+		ctx:             sl.Context,
 	})
 	d.DocumentReference = ref
 	d.ReferencePool = newSchemaReferencePool()

--- a/v1/ast/compile.go
+++ b/v1/ast/compile.go
@@ -1636,6 +1636,7 @@ func compileSchema(goSchema any, allowNet []string) (*gojsonschema.Schema, error
 	var refLoader gojsonschema.JSONLoader
 	sl := gojsonschema.NewSchemaLoader()
 	sl.AllowNet = allowNet
+	sl.AllowFilesystem = true
 
 	if goSchema != nil {
 		refLoader = gojsonschema.NewGoLoader(goSchema)

--- a/v1/topdown/jsonschema.go
+++ b/v1/topdown/jsonschema.go
@@ -61,9 +61,13 @@ func newResultTerm(valid bool, data *ast.Term) *ast.Term {
 // outbound requests from wherever OPA happens to be deployed. The query's
 // context comes along so that those fetches are abandoned when evaluation is
 // cancelled.
+//
+// File references are always denied, independent of allow_net, because schemas
+// reaching these built-ins may be attacker-controlled.
 func newPatternValidatingSchemaLoader(bctx BuiltinContext) *gojsonschema.SchemaLoader {
 	sl := gojsonschema.NewSchemaLoader()
 	sl.ValidatePatterns = true
+	sl.DenyFileScheme = true
 	sl.Context = bctx.Context
 	if bctx.Capabilities != nil {
 		sl.AllowNet = bctx.Capabilities.AllowNet

--- a/v1/topdown/jsonschema.go
+++ b/v1/topdown/jsonschema.go
@@ -67,7 +67,6 @@ func newResultTerm(valid bool, data *ast.Term) *ast.Term {
 func newPatternValidatingSchemaLoader(bctx BuiltinContext) *gojsonschema.SchemaLoader {
 	sl := gojsonschema.NewSchemaLoader()
 	sl.ValidatePatterns = true
-	sl.DenyFileScheme = true
 	sl.Context = bctx.Context
 	if bctx.Capabilities != nil {
 		sl.AllowNet = bctx.Capabilities.AllowNet

--- a/v1/topdown/jsonschema_test.go
+++ b/v1/topdown/jsonschema_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"path/filepath"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -16,6 +17,7 @@ import (
 	"github.com/open-policy-agent/opa/v1/topdown/cache"
 
 	"github.com/open-policy-agent/opa/v1/ast"
+	"github.com/open-policy-agent/opa/v1/util/test"
 )
 
 func TestAstValueToJSONSchemaLoader(t *testing.T) {
@@ -630,6 +632,77 @@ func TestBuiltinJSONSchemaAllowNet(t *testing.T) {
 			}
 			if !fetched {
 				t.Fatal("expected a request to reach the server")
+			}
+		})
+	}
+}
+
+func TestBuiltinJSONSchemaDeniesFileReferences(t *testing.T) {
+	root := test.TempDirOf(t, "schema.json", `{"required": ["pwned"]}`)
+	filename := filepath.Join(root, "schema.json")
+	fileSchema := ast.String(fmt.Sprintf(`{"$ref": %q}`, "file://"+filepath.ToSlash(filename)))
+
+	cases := []struct {
+		note         string
+		capabilities *ast.Capabilities
+	}{
+		{
+			note:         "no capabilities",
+			capabilities: nil,
+		},
+		{
+			note:         "unset allow_net",
+			capabilities: &ast.Capabilities{},
+		},
+		{
+			note:         "empty allow_net",
+			capabilities: &ast.Capabilities{AllowNet: []string{}},
+		},
+		{
+			note:         "populated allow_net",
+			capabilities: &ast.Capabilities{AllowNet: []string{"example.com"}},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run("json.match_schema/"+tc.note, func(t *testing.T) {
+			err := builtinJSONMatchSchema(
+				BuiltinContext{Capabilities: tc.capabilities},
+				[]*ast.Term{ast.NewTerm(ast.String(`{"id": 5}`)), ast.NewTerm(fileSchema)},
+				func(*ast.Term) error { return nil },
+			)
+			if err == nil {
+				t.Fatal("expected file reference to be denied, got no error")
+			}
+			if !strings.Contains(err.Error(), "file reference loading disabled") {
+				t.Fatalf("expected file reference loading to be disabled, got %v", err)
+			}
+		})
+
+		t.Run("json.verify_schema/"+tc.note, func(t *testing.T) {
+			var result ast.Value
+			err := builtinJSONSchemaVerify(
+				BuiltinContext{Capabilities: tc.capabilities},
+				[]*ast.Term{ast.NewTerm(fileSchema)},
+				func(term *ast.Term) error {
+					result = term.Value
+					return nil
+				},
+			)
+			if err != nil {
+				t.Fatalf("Unexpected error: %s", err)
+			}
+
+			arr, ok := result.(*ast.Array)
+			if !ok {
+				t.Fatalf("Unexpected result type, expected array, got %T", result)
+			}
+			valid := arr.Elem(0).Value.Compare(ast.Boolean(true)) == 0
+			if valid {
+				t.Fatalf("expected schema verification to fail, got %s", arr)
+			}
+			if !strings.Contains(arr.Elem(1).String(), "file reference loading disabled") {
+				t.Fatalf("expected file reference loading to be disabled, got %s", arr)
 			}
 		})
 	}


### PR DESCRIPTION
Fixes #9000

## Root cause

`jsonReferenceLoader.LoadJSON()` in `internal/gojsonschema/jsonLoader.go` resolved `file://` `$ref`s by calling `loadFromFile()` unconditionally whenever `reference.HasFileScheme` is true — before the `isAllowed()` allow-list check is ever consulted:

```go
if reference.HasFileScheme {
    filename := strings.TrimPrefix(refToURL.String(), "file://")
    ...
    return l.loadFromFile(filename)
}
...
if l.isAllowed(refToURL.GetUrl()) {
    return l.loadFromHTTP(refToURL.String())
}
```

`isAllowed()` checks `ref.Hostname()` against `limits.allowNet`, which is only meaningful for the HTTP branch. `allow_net` (wired in for `json.match_schema`/`json.verify_schema` via `newPatternValidatingSchemaLoader` in `v1/topdown/jsonschema.go`) therefore never restricted `file://` refs at all — `allow_net: []` blocked every remote host but left local file reads on the machine running OPA completely open. Since the schema operand to these builtins can come from `input`, this allowed input-driven arbitrary local file reads, defeating the sandboxing `allow_net` is meant to provide.

## Fix

Deny `file://` refs whenever `allow_net` is set (including the empty-list case, `allow_net: []`), consistent with how `allow_net` already treats every other remote resource: deny by default unless explicitly permitted. When `allow_net` is unset (nil / unrestricted), file refs keep loading exactly as before — no behavior change for callers who don't configure `allow_net`.

I considered instead extending the allow-list mechanism to permit specific local paths, but a hostname allow-list doesn't map cleanly onto filesystem paths, so I went with the more conservative deny-outright approach. Flagged this tradeoff on the issue before starting — happy to adjust if maintainers prefer a different shape (e.g. a dedicated capability for local file refs).

## Testing

- `go build ./...` passes
- `go test ./internal/gojsonschema/... ./v1/topdown/...` passes (2 pre-existing, unrelated `TestCertSelectionLogic` failures reproduce identically on unmodified `main` on this machine — Windows system-cert environment issue, not touched by this change)
- Added `TestAllowNetRestrictsFileReferences` covering: `file://` ref denied when `allow_net: []`, `file://` ref still loads when `allow_net` unset
- Existing HTTP `allow_net` enforcement tests unmodified and still pass

## Changelog

Added an entry under `Unreleased` / `Fixes` in `CHANGELOG.md`.