### PR TITLE
ast: don't report type errors for documents replaced by with

### DIFF
--- a/v1/ast/check.go
+++ b/v1/ast/check.go
@@ -16,6 +16,10 @@ import (
 
 type varRewriter func(Ref) Ref
 
+// dependentsResolver returns the refs of the rules that (transitively) depend on
+// the document(s) at ref.
+type dependentsResolver func(Ref) []Ref
+
 // typeChecker implements type checking on queries and rules. Errors are
 // accumulated on the typeChecker so that a single run can report multiple
 // issues.
@@ -29,6 +33,8 @@ type typeChecker struct {
 	input               types.Type
 	allowUndefinedFuncs bool
 	schemaTypes         map[string]types.Type
+	dependentsResolver  dependentsResolver
+	withTrees           map[string]*typeTreeNode
 }
 
 // newTypeChecker returns a new typeChecker object that has no errors.
@@ -56,6 +62,7 @@ func (tc *typeChecker) copy() *typeChecker {
 		WithInputType(tc.input).
 		WithAllowUndefinedFunctionCalls(tc.allowUndefinedFuncs).
 		WithBuiltins(tc.builtins).
+		WithDependentsResolver(tc.dependentsResolver).
 		WithRequiredCapabilities(tc.required)
 }
 
@@ -86,6 +93,13 @@ func (tc *typeChecker) WithAllowNet(hosts []string) *typeChecker {
 
 func (tc *typeChecker) WithVarRewriter(f varRewriter) *typeChecker {
 	tc.varRewriter = f
+	return tc
+}
+
+// WithDependentsResolver sets the function used to look up the rules that depend
+// on the document(s) replaced by a with modifier.
+func (tc *typeChecker) WithDependentsResolver(f dependentsResolver) *typeChecker {
+	tc.dependentsResolver = f
 	return tc
 }
 
@@ -124,17 +138,27 @@ func (tc *typeChecker) CheckBody(env *TypeEnv, body Body) (*TypeEnv, Errors) {
 
 	for _, bexpr := range body {
 		WalkExprs(bexpr, func(expr *Expr) bool {
-			closureErrs := tc.checkClosures(env, expr)
+			exprEnv, exprVis, exprGV := env, vis, gv
+
+			if len(expr.With) > 0 {
+				if withEnv := tc.withEnv(env, expr); withEnv != env {
+					exprEnv = withEnv
+					exprVis = newRefChecker(withEnv, tc.varRewriter)
+					exprGV = NewGenericVisitor(exprVis.Visit)
+				}
+			}
+
+			closureErrs := tc.checkClosures(exprEnv, expr)
 			errors = append(errors, closureErrs...)
 
 			// reset errors from previous iteration
-			vis.errs = nil
-			gv.Walk(expr)
-			errors = append(errors, vis.errs...)
+			exprVis.errs = nil
+			exprGV.Walk(expr)
+			errors = append(errors, exprVis.errs...)
 
-			if err := tc.checkExpr(env, expr); err != nil {
+			if err := tc.checkExpr(exprEnv, expr); err != nil {
 				hasClosureErrors := len(closureErrs) > 0
-				hasRefErrors := len(vis.errs) > 0
+				hasRefErrors := len(exprVis.errs) > 0
 				// Suppress this error if a more actionable one has occurred. In
 				// this case, if an error occurred in a ref or closure contained in
 				// this expression, and the error is due to a nil type, then it's
@@ -271,7 +295,7 @@ func (tc *typeChecker) checkRule(env *TypeEnv, as *AnnotationSet, rule *Rule) {
 			// If args are not referred to in body, infer as any.
 			WalkTerms(arg, func(t *Term) bool {
 				if _, ok := t.Value.(Var); ok && cpy.GetByValue(t.Value) == nil {
-					cpy.tree.PutOne(t.Value, types.A)
+					cpy.vars.PutOne(t.Value, types.A)
 				}
 				return false
 			})
@@ -479,6 +503,99 @@ func checkExprEq(env *TypeEnv, expr *Expr) *Error {
 	return nil
 }
 
+// withEnv returns the TypeEnv to check expr against, where the documents its
+// with modifiers replace can also have the type of their replacement value, and
+// the rules depending on those documents are widened to any.
+func (tc *typeChecker) withEnv(env *TypeEnv, expr *Expr) *TypeEnv {
+	cpy := env
+	targets := make([]Ref, 0, len(expr.With))
+	targetTypes := make([]types.Type, 0, len(expr.With))
+
+	for _, w := range expr.With {
+		target, ok := w.Target.Value.(Ref)
+		if !ok {
+			continue
+		}
+
+		targetType := env.GetByRef(target)
+
+		// Keeping the declaration of a replaced function allows its arity to be
+		// checked against the replacement.
+		_, isFunc := targetType.(*types.Function)
+
+		if tree := tc.relaxedDependents(target, isFunc); tree != nil {
+			layer := cpy.wrapWith()
+			// Shared with every other expression replacing this target.
+			layer.tree = tree
+			cpy = layer
+		}
+
+		if !isFunc {
+			// A non-ground target replaces an unknown part of the document, so
+			// nothing more specific than any can be said about its prefix.
+			tpe := types.A
+			if target.IsGround() && targetType != nil {
+				// Or returns nil if only one of the two is a function.
+				if valueType := env.GetByValue(w.Value.Value); valueType != nil {
+					if or := types.Or(targetType, valueType); or != nil {
+						tpe = or
+					}
+				}
+			}
+			targets = append(targets, target.GroundPrefix())
+			targetTypes = append(targetTypes, tpe)
+		}
+	}
+
+	if len(targets) == 0 {
+		return cpy
+	}
+
+	// Wrapped last, so that a replaced document keeps the type of its
+	// replacement value even if another modifier replaces one of its dependencies.
+	cpy = cpy.wrapWith()
+	for i := range targets {
+		cpy.tree.Put(targets[i], targetTypes[i])
+	}
+
+	return cpy
+}
+
+// relaxedDependents returns a cached type tree where the rules affected by
+// replacing the document(s) at target are typed as any, or nil if there are none.
+func (tc *typeChecker) relaxedDependents(target Ref, isFunc bool) *typeTreeNode {
+	if tc.dependentsResolver == nil {
+		return nil
+	}
+
+	key := target.String()
+	if isFunc {
+		key = "f:" + key
+	}
+
+	if tree, ok := tc.withTrees[key]; ok {
+		return tree
+	}
+
+	var tree *typeTreeNode
+	for _, ref := range tc.dependentsResolver(target) {
+		if isFunc && ref.Equal(target) {
+			continue
+		}
+		if tree == nil {
+			tree = newTypeTree()
+		}
+		tree.Put(ref, types.A)
+	}
+
+	if tc.withTrees == nil {
+		tc.withTrees = map[string]*typeTreeNode{}
+	}
+	tc.withTrees[key] = tree
+
+	return tree
+}
+
 func (tc *typeChecker) checkExprWith(env *TypeEnv, expr *Expr, i int) *Error {
 	if i == len(expr.With) {
 		return nil
@@ -656,9 +773,9 @@ func unify1(env *TypeEnv, term *Term, tpe types.Type, union bool) bool {
 			if exist := env.GetByValue(term.Value); exist != nil {
 				return unifies(exist, tpe)
 			}
-			env.tree.PutOne(term.Value, tpe)
+			env.vars.PutOne(term.Value, tpe)
 		} else {
-			env.tree.PutOne(term.Value, types.Or(env.GetByValue(term.Value), tpe))
+			env.vars.PutOne(term.Value, types.Or(env.GetByValue(term.Value), tpe))
 		}
 		return true
 	default:
@@ -805,7 +922,7 @@ func (rc *refChecker) checkRef(curr *TypeEnv, node *typeTreeNode, ref Ref, idx i
 				return newRefErrInvalid(ref[0].Location, rc.varRewriter(ref), idx, exist, tpe, getOneOfForNode(node))
 			}
 		} else {
-			rc.env.tree.PutOne(head.Value, tpe)
+			rc.env.vars.PutOne(head.Value, tpe)
 		}
 	}
 
@@ -859,7 +976,7 @@ func (rc *refChecker) checkRefLeaf(tpe types.Type, ref Ref, idx int) *Error {
 				return newRefErrInvalid(ref[0].Location, rc.varRewriter(ref), idx, exist, keys, getOneOfForType(tpe))
 			}
 		} else {
-			rc.env.tree.PutOne(head.Value, types.Keys(tpe))
+			rc.env.vars.PutOne(head.Value, types.Keys(tpe))
 		}
 
 	case Ref:

--- a/v1/ast/check_test.go
+++ b/v1/ast/check_test.go
@@ -2973,3 +2973,143 @@ func TestCheckObjectCategoryReturnType(t *testing.T) {
 		})
 	}
 }
+
+func TestCheckWithModifiers(t *testing.T) {
+	tests := []struct {
+		note    string
+		modules []string
+		err     string
+	}{
+		{
+			note: "rule depending on replaced package",
+			modules: []string{
+				`package root.a
+				import data.root
+				rule_a := x if { x = {"b": root.b} }`,
+				`package root.b
+				rule_b if { true }`,
+				`package root.a
+				test_rule_a if { rule_a == {"b": "1"} with data.root.b as "1" }`,
+			},
+		},
+		{
+			note: "replaced document referred to directly",
+			modules: []string{
+				`package p
+				b := true
+				q if { data.p.b == "foo" with data.p.b as "foo" }`,
+			},
+		},
+		{
+			note: "rule depending on replaced document passed to built-in function",
+			modules: []string{
+				`package p
+				b := true
+				a := x if { x = data.p.b }
+				q if { lower(data.p.a) == "foo" with data.p.b as "foo" }`,
+			},
+		},
+		{
+			note: "rule depending transitively on replaced document",
+			modules: []string{
+				`package p
+				b := true
+				a := data.p.b
+				c := data.p.a
+				q if { lower(data.p.c) == "foo" with data.p.b as "foo" }`,
+			},
+		},
+		{
+			note: "rule depending on replaced document inside comprehension",
+			modules: []string{
+				`package p
+				b := true
+				a := x if { x = data.p.b }
+				q if { [y | y := lower(data.p.a)] == ["foo"] with data.p.b as "foo" }`,
+			},
+		},
+		{
+			note: "rule depending on replaced function",
+			modules: []string{
+				`package p
+				f(_) := true
+				a := f(1)
+				q if { lower(data.p.a) == "foo" with data.p.f as "foo" }`,
+			},
+		},
+		{
+			note: "function replacement arity is still checked",
+			modules: []string{
+				`package p
+				f(_) := true
+				mock(_, _) := "foo"
+				q if { f(1) with data.p.f as mock }`,
+			},
+			err: "rego_type_error: data.p.f: arity mismatch",
+		},
+		{
+			note: "variable assigned the replacement value",
+			modules: []string{
+				`package p
+				b := true
+				q if { x := data.p.b with data.p.b as "foo"; lower(x) == "foo" }`,
+			},
+		},
+		{
+			note: "variable assigned neither the replaced nor the replacement type",
+			modules: []string{
+				`package p
+				b := true
+				q if { x := data.p.b with data.p.b as 1; lower(x) == "foo" }`,
+			},
+			err: "rego_type_error: lower: invalid argument(s)",
+		},
+		{
+			note: "rule not depending on replaced document is still checked",
+			modules: []string{
+				`package p
+				b := true
+				a := x if { x = data.p.b }
+				other := 1
+				q if { lower(data.p.a) == "foo" with data.p.other as "foo" }`,
+			},
+			err: "rego_type_error: lower: invalid argument(s)",
+		},
+		{
+			note: "expression unrelated to replaced document is still checked",
+			modules: []string{
+				`package p
+				b := true
+				q if { x := "foo"; sum([1, x]) == 1 with data.p.b as "foo" }`,
+			},
+			err: "rego_type_error: sum: invalid argument(s)",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.note, func(t *testing.T) {
+			modules := map[string]*Module{}
+			for i, module := range tc.modules {
+				name := fmt.Sprintf("mod%d.rego", i)
+				modules[name] = MustParseModule(module)
+			}
+
+			c := NewCompiler()
+			c.Compile(modules)
+
+			if tc.err == "" {
+				if c.Failed() {
+					t.Fatalf("expected no error, got %v", c.Errors)
+				}
+				return
+			}
+
+			if !c.Failed() {
+				t.Fatal("expected error, got none")
+			}
+			if !strings.Contains(c.Errors.Error(), tc.err) {
+				t.Fatalf("expected error:\n\n%s\n\ngot:\n\n%s", tc.err, c.Errors.Error())
+			}
+		})
+	}
+}

--- a/v1/ast/compile.go
+++ b/v1/ast/compile.go
@@ -1908,6 +1908,7 @@ func (c *Compiler) checkTypes() {
 		WithBuiltins(c.builtins).
 		WithRequiredCapabilities(c.Required).
 		WithVarRewriter(rewriteRefErrVars(c.localvargen.subjects, c.RewrittenVars)).
+		WithDependentsResolver(c.dependentRuleRefs).
 		WithAllowUndefinedFunctionCalls(c.allowUndefinedFuncCalls)
 	var as *AnnotationSet
 	if c.useTypeCheckAnnotations {
@@ -1918,6 +1919,40 @@ func (c *Compiler) checkTypes() {
 		c.err(err)
 	}
 	c.TypeEnv = env
+}
+
+// dependentRuleRefs returns the refs of the rules that ref could refer to,
+// together with the refs of the rules that transitively depend on them.
+func (c *Compiler) dependentRuleRefs(ref Ref) []Ref {
+	if c.Graph == nil {
+		return nil
+	}
+
+	rules := c.GetRulesDynamicWithOpts(ref, RulesOptions{IncludeHiddenModules: true})
+	if len(rules) == 0 {
+		return nil
+	}
+
+	refs := make([]Ref, 0, len(rules))
+	visited := make(map[*Rule]struct{}, len(rules))
+
+	var visit func(*Rule)
+	visit = func(rule *Rule) {
+		if _, ok := visited[rule]; ok {
+			return
+		}
+		visited[rule] = struct{}{}
+		refs = append(refs, rule.Ref().GroundPrefix())
+		for dependent := range c.Graph.Dependents(rule) {
+			visit(dependent.(*Rule))
+		}
+	}
+
+	for _, rule := range rules {
+		visit(rule)
+	}
+
+	return refs
 }
 
 func (c *Compiler) checkUnsafeBuiltins() {
@@ -3909,6 +3944,7 @@ func (qc *queryCompiler) checkTypes(_ *QueryContext, body Body) (Body, error) {
 	checker := newTypeChecker().
 		WithSchemaSet(qc.compiler.schemaSet).
 		WithInputType(qc.compiler.inputType).
+		WithDependentsResolver(qc.compiler.dependentRuleRefs).
 		WithVarRewriter(rewriteRefErrVars(qc.refSubjects, qc.rewritten, qc.compiler.RewrittenVars))
 	qc.typeEnv, errs = checker.CheckBody(qc.compiler.TypeEnv, body)
 	if len(errs) > 0 {

--- a/v1/ast/env.go
+++ b/v1/ast/env.go
@@ -14,7 +14,10 @@ import (
 
 // TypeEnv contains type info for static analysis such as type checking.
 type TypeEnv struct {
-	tree       *typeTreeNode
+	tree *typeTreeNode
+	// vars is the tree the types inferred for variables are stored in, which is
+	// tree except in the environments created for with modifiers.
+	vars       *typeTreeNode
 	next       *TypeEnv
 	newChecker func() *typeChecker
 }
@@ -22,8 +25,10 @@ type TypeEnv struct {
 // newTypeEnv returns an empty TypeEnv. The constructor is not exported because
 // type environments should only be created by the type checker.
 func newTypeEnv(f func() *typeChecker) *TypeEnv {
+	tree := newTypeTree()
 	return &TypeEnv{
-		tree:       newTypeTree(),
+		tree:       tree,
+		vars:       tree,
 		newChecker: f,
 	}
 }
@@ -231,7 +236,17 @@ func (env *TypeEnv) wrap() *TypeEnv {
 	cpy := *env
 	cpy.next = env
 	cpy.tree = newTypeTree()
+	cpy.vars = cpy.tree
 	return &cpy
+}
+
+// wrapWith returns a TypeEnv for checking a single expression carrying with
+// modifiers: unlike wrap, the types it infers for variables are kept in the
+// enclosing environment, as those variables outlive the expression.
+func (env *TypeEnv) wrapWith() *TypeEnv {
+	cpy := env.wrap()
+	cpy.vars = env.vars
+	return cpy
 }
 
 // typeTreeNode is used to store type information in a tree.


### PR DESCRIPTION
When a `with` modifier replaced a document, the type checker kept using the types it had inferred for the rules reading that document, and reported errors for tests that would pass. Those rules, and the replaced document itself, can now be of any type in the expression carrying the modifier.

Fixes: #2903