### PR TITLE
ast: reject `print` calls as `and`/`or` operands

### DIFF
--- a/v1/ast/parser.go
+++ b/v1/ast/parser.go
@@ -1672,6 +1672,8 @@ func (p *Parser) parseLogicalOrChain(lhsBody Body, lhsExplicit bool, lhsLoc *Loc
 			rhsExplicit = false
 		}
 
+		p.checkVoidCallOperands(lhsBody, rhsBody, "or")
+
 		exprLoc := p.extendLoc(lhsLoc)
 		node := &LogicalOr{
 			Lhs:         lhsBody,
@@ -1708,6 +1710,8 @@ func (p *Parser) parseLogicalAndChain(lhsBody Body, lhsExplicit bool, lhsLoc *Lo
 		if rhsBody == nil {
 			return nil
 		}
+
+		p.checkVoidCallOperands(lhsBody, rhsBody, "and")
 
 		exprLoc := p.extendLoc(lhsLoc)
 		node := &LogicalAnd{
@@ -1925,6 +1929,45 @@ func isEmptyObjectTerm(expr *Expr) bool {
 func (p *Parser) errorBraceLedOperand(loc *Location, operand []byte, op string) {
 	p.hint(fmt.Sprintf("wrap the operand to keep the value: `(%s) %s ...`", operand, op))
 	p.errorf(loc, "operand of `%s` cannot begin with `{` unless the braces hold a body", op)
+}
+
+func (p *Parser) checkVoidCallOperands(lhs, rhs Body, op string) {
+	if name, loc := voidCallOperand(lhs); name != "" {
+		p.errorVoidCallOperand(loc, name, op)
+	}
+
+	if name, loc := voidCallOperand(rhs); name != "" {
+		p.errorVoidCallOperand(loc, name, op)
+	}
+}
+
+func (p *Parser) errorVoidCallOperand(loc *Location, name, op string) {
+	p.hint(fmt.Sprintf("`%s` produces no value and always succeeds, so the operand can never fail; move it out of the operand, or add an expression that can fail", name))
+	p.errorf(loc, "operand of `%s` cannot consist only of calls to `%s`", op, name)
+}
+
+// voidCallOperand returns the name and location of the first void builtin called by
+// an operand whose body does nothing else; negated operands are left alone.
+func voidCallOperand(body Body) (string, *Location) {
+	var name string
+	var loc *Location
+
+	for _, expr := range body {
+		if expr.Negated || !expr.IsCall() {
+			return "", nil
+		}
+
+		bi, ok := BuiltinMap[expr.Operator().String()]
+		if !ok || bi.Decl == nil || bi.Decl.Result() != nil {
+			return "", nil
+		}
+
+		if name == "" {
+			name, loc = bi.Name, expr.Location
+		}
+	}
+
+	return name, loc
 }
 
 // errorParensCannotWrapBody reports `(...)` holding expressions rather than a value.

--- a/v1/ast/parser_logical_test.go
+++ b/v1/ast/parser_logical_test.go
@@ -2312,6 +2312,76 @@ func TestParseLogical_BraceLedOperandHintExtent(t *testing.T) {
 	}
 }
 
+func TestParseLogical_VoidCallOperandIsRejected(t *testing.T) {
+	opts := logicalParserOpts("not")
+
+	// Every builtin declared without a result type.
+	operands := []struct {
+		name string
+		call string
+	}{
+		{"print", `print("x")`},
+		{"internal.print", `internal.print([{"x"}])`},
+		{"internal.test_case", `internal.test_case(["x"])`},
+	}
+
+	positions := []struct {
+		note string
+		expr string
+		op   string
+	}{
+		{note: "lhs of and", expr: "%s and z", op: "and"},
+		{note: "rhs of and", expr: "z and %s", op: "and"},
+		{note: "lhs of or", expr: "%s or z", op: "or"},
+		{note: "rhs of or", expr: "z or %s", op: "or"},
+		{note: "both operands of and", expr: "%s and %s", op: "and"},
+		{note: "both operands of or", expr: "%s or %s", op: "or"},
+		{note: "middle of an and chain", expr: "y and %s and z", op: "and"},
+		{note: "middle of an or chain", expr: "y or %s or z", op: "or"},
+		// `and` binds tighter, so the operand belongs to it, not to the `or`.
+		{note: "and operand inside an or chain", expr: "y or z and %s", op: "and"},
+		// Parens group rather than delimit, so the operand is still the bare call.
+		{note: "parenthesized lhs of and", expr: "(%s) and z", op: "and"},
+		// Braces don't change the semantics: the operand still cannot fail.
+		{note: "explicit body operand, lhs of and", expr: "{%s} and z", op: "and"},
+		{note: "explicit body operand, rhs of or", expr: "z or {%s}", op: "or"},
+		{note: "explicit body of only void calls", expr: "{%s; %s} and z", op: "and"},
+	}
+
+	for _, tc := range operands {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, ptc := range positions {
+				t.Run(ptc.note, func(t *testing.T) {
+					input := strings.ReplaceAll(ptc.expr, "%s", tc.call)
+					expErr := fmt.Sprintf("operand of `%s` cannot consist only of calls to `%s` "+
+						"(hint: `%s` produces no value and always succeeds, so the operand can never "+
+						"fail; move it out of the operand, or add an expression that can fail)",
+						ptc.op, tc.name, tc.name)
+
+					assertParseErrorContains(t, ptc.note, input, expErr, opts)
+				})
+			}
+		})
+	}
+
+	allowed := []string{
+		`{print("x"); true} and z`,
+		`{some v in [1]; print(v)} and z`,
+		`not print("x") and z`,
+		`not {print("x")} and z`,
+		`x := [1 | print("x")] and z`,
+		`print(f(x)) ; z`,
+	}
+
+	for _, input := range allowed {
+		t.Run(input, func(t *testing.T) {
+			if _, err := ParseBodyWithOpts(input, opts); err != nil {
+				t.Fatalf("unexpected error for %q: %v", input, err)
+			}
+		})
+	}
+}
+
 // TestParseLogical_NotBodyLeadingOperand covers a not-body leading an and/or chain.
 func TestParseLogical_NotBodyLeadingOperand(t *testing.T) {
 	opts := logicalParserOpts("not")

--- a/v1/topdown/topdown_logical_test.go
+++ b/v1/topdown/topdown_logical_test.go
@@ -87,19 +87,10 @@ func TestTopDownLogicalAnd(t *testing.T) {
 			fail: true,
 		},
 		{
-			note: "lhs fails: rhs not evaluated (short-circuit)",
+			note: "print inside both explicit body operands",
 			module: `package test
 				p if {
-					false and print("rhs")
-				}`,
-			notes: n(),
-			fail:  true,
-		},
-		{
-			note: "lhs succeeds: rhs evaluated",
-			module: `package test
-				p if {
-					print("lhs") and print("rhs")
+					{print("lhs"); true} and {print("rhs"); true}
 				}`,
 			notes: n("lhs", "rhs"),
 		},
@@ -168,20 +159,12 @@ func TestTopDownLogicalOr(t *testing.T) {
 			fail: true,
 		},
 		{
-			note: "lhs succeeds: rhs not evaluated (short-circuit)",
+			note: "print inside both explicit body operands, rhs skipped",
 			module: `package test
 				p if {
-					print("lhs") or print("rhs")
+					{print("lhs"); true} or {print("rhs"); true}
 				}`,
 			notes: n("lhs"),
-		},
-		{
-			note: "lhs fails: rhs evaluated",
-			module: `package test
-				p if {
-					false or print("rhs")
-				}`,
-			notes: n("rhs"),
 		},
 		{
 			note: "explicit body operands",


### PR DESCRIPTION
Disallow `print`, `internal.print` and `internal.test_case` as operands of `and`/`or`. They produce no value and always succeed, so the operand is either dead weight (`and`) or makes the expression unconditionally true (`or`).