### PR TITLE
topdown,tester: don't put shared interned refs into mutable ASTs

### DIFF
--- a/v1/tester/runner.go
+++ b/v1/tester/runner.go
@@ -931,7 +931,8 @@ func injectTestCaseFunc(compiler *ast.Compiler) *ast.Error {
 			})
 
 			testCaseFuncExpr := ast.NewExpr([]*ast.Term{
-				ast.NewTerm(ast.Interned.Refs.InternalTestCase),
+				// Copied, as later compiler stages rewrite this body in place.
+				ast.NewTerm(ast.Interned.Refs.InternalTestCase.Copy()),
 				ast.NewTerm(args),
 			})
 

--- a/v1/tester/runner_test.go
+++ b/v1/tester/runner_test.go
@@ -1324,3 +1324,32 @@ func TestResultUnmarshalJSONEvalError(t *testing.T) {
 		t.Errorf("Expected message %q, got %q", exp, tdErr.Message)
 	}
 }
+
+func TestRunTestsDoesNotMutateInternedTestCaseRef(t *testing.T) {
+	ctx := t.Context()
+
+	before := ast.Interned.Refs.InternalTestCase[0]
+
+	modules := map[string]*ast.Module{
+		"test.rego": ast.MustParseModule(`package test
+			test_cases[x] if { some x in ["foo", "bar"] }`),
+	}
+
+	store := inmem.New()
+	txn := storage.NewTransactionOrDie(ctx, store)
+	defer store.Abort(ctx, txn)
+
+	ch, err := tester.NewRunner().SetStore(store).SetModules(modules).RunTests(ctx, txn)
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
+	for r := range ch {
+		if !r.Pass() {
+			t.Fatalf("Expected test to pass, got %v", r)
+		}
+	}
+
+	if act := ast.Interned.Refs.InternalTestCase[0]; act != before {
+		t.Errorf("ast.Interned.Refs.InternalTestCase was mutated: %p -> %p", before, act)
+	}
+}

--- a/v1/topdown/test.go
+++ b/v1/topdown/test.go
@@ -13,7 +13,8 @@ func builtinTestCase(bctx BuiltinContext, operands []*ast.Term, iter func(*ast.T
 		Op:      TestCaseOp,
 		QueryID: bctx.QueryID,
 		Node: ast.NewExpr([]*ast.Term{
-			ast.NewTerm(ast.Interned.Refs.InternalTestCase),
+			// Copied, as tracers may transform the node.
+			ast.NewTerm(ast.Interned.Refs.InternalTestCase.Copy()),
 			ast.NewTerm(operands[0].Value),
 		}),
 	}

--- a/v1/topdown/topdown_partial_test.go
+++ b/v1/topdown/topdown_partial_test.go
@@ -2125,7 +2125,7 @@ func TestTopDownPartialEval(t *testing.T) {
 			wantQueryASTs: []ast.Body{
 				ast.NewBody(
 					ast.NewExpr(
-						ast.Equal.Call(ast.InputRootRefTerm, ast.InternedTerm(1)),
+						ast.Equal.Call(ast.NewTerm(ast.InputRootRef.Copy()), ast.InternedTerm(1)),
 					),
 				),
 			},
@@ -2275,7 +2275,7 @@ func TestTopDownPartialEval(t *testing.T) {
 			wantQueryASTs: []ast.Body{
 				ast.NewBody(
 					ast.NewExpr(
-						ast.Equal.Call(ast.InputRootRefTerm, ast.InternedTerm(1)),
+						ast.Equal.Call(ast.NewTerm(ast.InputRootRef.Copy()), ast.InternedTerm(1)),
 					),
 				),
 			},
@@ -6500,7 +6500,7 @@ func TestTopDownPartialEvalNegation(t *testing.T) {
 						&ast.Expr{ // legacy negation (equivalent to implicit not-body when serialized to Rego).
 							Negated: true,
 							Terms: []*ast.Term{
-								{Value: ast.Interned.Refs.Equality},
+								{Value: ast.Equality.Ref()},
 								ast.NewTerm(ast.InputRootRef.Append(ast.InternedTerm("x"))),
 								ast.InternedTerm(1),
 							},
@@ -7073,9 +7073,11 @@ func pIsDefined(t *testing.T, ctx context.Context, module, pkg, inputJSON string
 	return len(rs) > 0
 }
 
+// Transformed on copies, as ast.Transform rewrites refs in place.
+
 func replaceWildcardsInBodySet(s bodySet) {
 	for i := range s {
-		x, _ := ast.TransformVars(s[i], func(v ast.Var) (ast.Value, error) {
+		x, _ := ast.TransformVars(s[i].Copy(), func(v ast.Var) (ast.Value, error) {
 			if v.IsWildcard() {
 				return ast.WildcardValue, nil
 			}
@@ -7087,7 +7089,7 @@ func replaceWildcardsInBodySet(s bodySet) {
 
 func replaceWildcardsInModuleSet(s moduleSet) {
 	for i := range s {
-		x, _ := ast.TransformVars(s[i], func(v ast.Var) (ast.Value, error) {
+		x, _ := ast.TransformVars(s[i].Copy(), func(v ast.Var) (ast.Value, error) {
 			if v.IsWildcard() {
 				return ast.WildcardValue, nil
 			}


### PR DESCRIPTION
fix for this intermittent race condition: https://github.com/open-policy-agent/opa/actions/runs/32267010718/job/96114749964?pr=9043

ast.Transform rewrites refs in place, so embedding a shared ast.Interned ref in an AST that gets transformed rewrites the global and races with anything reading it, which is what made the race detector job flaky.

