### PR TITLE
Clean up irrelevant nolint directives

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -13,6 +13,7 @@ linters:
     - mirror
     - misspell
     - modernize
+    - nolintlint
     - perfsprint
     - prealloc
     - revive # replacement for golint
@@ -108,16 +109,18 @@ linters:
     rules:
       - linters:
           - staticcheck
-        text: This package is intended for older projects transitioning from OPA v0.x
-        path-except: v1/
-      - linters:
-          - staticcheck
         text: SA1019 # Using a deprecated function, variable, constant or field
         path: _test\.go
+      - linters:
+          - prealloc
+          - errcheck
+        path: _test\.go # Using a deprecated function, variable, constant or field
     paths:
-      - internal/gojsonschema
-      - internal/methodlesstemplate
-      - node_modules
+      # v0 - ^ needed to avoid matching name in any path
+      - ^ast|^bundle|^cover|^compile|^debug|^dependencies|^download|^format|^loader|^server
+      - ^topdown|^plugins|^rego|^repl|^resolver|^runtime|^sdk|^storage|^test|^util
+      # various exclusions
+      - ^internal/gojsonschema|^internal/methodlesstemplate|node_modules|example_test
 issues:
   # don't hide issues in CI runs because they are the same type
   max-same-issues: 0

--- a/ast/builtins.go
+++ b/ast/builtins.go
@@ -29,7 +29,7 @@ var BuiltinMap = v1.BuiltinMap
 // Deprecated: Builtins can now be directly annotated with the
 // Nondeterministic property, and when set to true, will be ignored
 // for partial evaluation.
-var IgnoreDuringPartialEval = v1.IgnoreDuringPartialEval //nolint:staticcheck
+var IgnoreDuringPartialEval = v1.IgnoreDuringPartialEval
 
 /**
  * Unification

--- a/ast/visit.go
+++ b/ast/visit.go
@@ -12,13 +12,13 @@ import v1 "github.com/open-policy-agent/opa/v1/ast"
 // visited.
 //
 // Deprecated: use GenericVisitor or another visitor implementation
-type Visitor = v1.Visitor //nolint:staticcheck
+type Visitor = v1.Visitor
 
 // BeforeAndAfterVisitor wraps Visitor to provide hooks for being called before
 // and after the AST has been visited.
 //
 // Deprecated: use GenericVisitor or another visitor implementation
-type BeforeAndAfterVisitor = v1.BeforeAndAfterVisitor //nolint:staticcheck
+type BeforeAndAfterVisitor = v1.BeforeAndAfterVisitor
 
 // Walk iterates the AST by calling the Visit function on the Visitor
 // v for x before recursing.

--- a/cmd/build_jsonv2_test.go
+++ b/cmd/build_jsonv2_test.go
@@ -80,7 +80,6 @@ func TestBuildProducesBundle(t *testing.T) {
 }
 
 func TestBuildRespectsCapabilities(t *testing.T) {
-	//nolint:prealloc // test slice is extended dynamically, initial values are clearer as slice literal
 	tests := []struct {
 		note       string
 		caps       string

--- a/cmd/build_test.go
+++ b/cmd/build_test.go
@@ -80,7 +80,6 @@ func TestBuildProducesBundle(t *testing.T) {
 }
 
 func TestBuildRespectsCapabilities(t *testing.T) {
-	//nolint:prealloc // test slice is extended dynamically, initial values are clearer as slice literal
 	tests := []struct {
 		note       string
 		caps       string

--- a/cmd/check_jsonv2_test.go
+++ b/cmd/check_jsonv2_test.go
@@ -26,7 +26,6 @@ import (
 )
 
 func TestCheckRespectsCapabilities(t *testing.T) {
-	//nolint:prealloc // test slice is extended dynamically, initial values are clearer as slice literal
 	tests := []struct {
 		note       string
 		caps       string

--- a/cmd/check_test.go
+++ b/cmd/check_test.go
@@ -26,7 +26,6 @@ import (
 )
 
 func TestCheckRespectsCapabilities(t *testing.T) {
-	//nolint:prealloc // test slice is extended dynamically, initial values are clearer as slice literal
 	tests := []struct {
 		note       string
 		caps       string

--- a/cmd/eval_jsonv2_test.go
+++ b/cmd/eval_jsonv2_test.go
@@ -4,7 +4,6 @@
 // Use of this source code is governed by an Apache2
 // license that can be found in the LICENSE file.
 
-// nolint: goconst // string duplication is for test readability.
 package cmd
 
 import (

--- a/cmd/eval_test.go
+++ b/cmd/eval_test.go
@@ -4,7 +4,6 @@
 // Use of this source code is governed by an Apache2
 // license that can be found in the LICENSE file.
 
-// nolint: goconst // string duplication is for test readability.
 package cmd
 
 import (

--- a/cover/cover.go
+++ b/cover/cover.go
@@ -24,7 +24,7 @@ type Position = v1.Position
 //
 // Deprecated: PositionSlice is unused inside OPA and will be removed in a
 // future release.
-type PositionSlice = v1.PositionSlice //nolint:staticcheck
+type PositionSlice = v1.PositionSlice
 
 // Range represents a range of positions in a file.
 type Range = v1.Range

--- a/internal/compile/checks.go
+++ b/internal/compile/checks.go
@@ -207,7 +207,7 @@ func checkBuiltins(c *checker, e *ast.Expr, _ []*ast.Module) *ast.Error {
 			}
 			return nil
 		}
-		if !twoRefsOK || unknownRefs != 2 { // nolint:staticcheck
+		if !twoRefsOK || unknownRefs != 2 {
 			return err(loc, "both rhs and lhs non-scalar/non-ground")
 		}
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2,7 +2,6 @@
 // Use of this source code is governed by an Apache2
 // license that can be found in the LICENSE file.
 
-// nolint: goconst // string duplication is for test readability.
 package config
 
 import (

--- a/internal/gojsonschema/errors.go
+++ b/internal/gojsonschema/errors.go
@@ -1,4 +1,3 @@
-// nolint: goconst // String duplication will be handled later by using errors.Is.
 package gojsonschema
 
 import (

--- a/internal/gojsonschema/utils.go
+++ b/internal/gojsonschema/utils.go
@@ -23,7 +23,6 @@
 //
 // created          26-02-2013
 
-// nolint:unused // Package in development (2021).
 package gojsonschema
 
 import (

--- a/internal/wasm/sdk/opa/loader/http/util.go
+++ b/internal/wasm/sdk/opa/loader/http/util.go
@@ -22,7 +22,6 @@ func backoff(base, max, jitter, factor float64, retries int) time.Duration {
 		return 0
 	}
 
-	//nolint:unconvert
 	backoff, max := float64(base), float64(max)
 	for backoff < max && retries > 0 {
 		backoff *= factor

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -5,7 +5,6 @@
 // Package repl implements a Read-Eval-Print-Loop (REPL) for interacting with the policy engine.
 //
 // The REPL is typically used from the command line, however, it can also be used as a library.
-// nolint: goconst // String reuse here doesn't make sense to deduplicate.
 package repl
 
 import (

--- a/server/types/types.go
+++ b/server/types/types.go
@@ -203,7 +203,7 @@ const (
 	// of the health API.
 	//
 	// Deprecated: Use ParamBundlesActivationV1 instead.
-	ParamBundleActivationV1 = v1.ParamBundleActivationV1 //nolint:staticcheck
+	ParamBundleActivationV1 = v1.ParamBundleActivationV1
 
 	// ParamBundlesActivationV1 defines the name of the HTTP URL parameter that
 	// indicates the client wants to include bundle activation in the results

--- a/topdown/builtins.go
+++ b/topdown/builtins.go
@@ -10,16 +10,16 @@ import (
 
 type (
 	// Deprecated: Functional-style builtins are deprecated. Use BuiltinFunc instead.
-	FunctionalBuiltin1 = v1.FunctionalBuiltin1 //nolint:staticcheck // SA1019: Intentional use of deprecated type.
+	FunctionalBuiltin1 = v1.FunctionalBuiltin1
 
 	// Deprecated: Functional-style builtins are deprecated. Use BuiltinFunc instead.
-	FunctionalBuiltin2 = v1.FunctionalBuiltin2 //nolint:staticcheck // SA1019: Intentional use of deprecated type.
+	FunctionalBuiltin2 = v1.FunctionalBuiltin2
 
 	// Deprecated: Functional-style builtins are deprecated. Use BuiltinFunc instead.
-	FunctionalBuiltin3 = v1.FunctionalBuiltin3 //nolint:staticcheck // SA1019: Intentional use of deprecated type.
+	FunctionalBuiltin3 = v1.FunctionalBuiltin3
 
 	// Deprecated: Functional-style builtins are deprecated. Use BuiltinFunc instead.
-	FunctionalBuiltin4 = v1.FunctionalBuiltin4 //nolint:staticcheck // SA1019: Intentional use of deprecated type.
+	FunctionalBuiltin4 = v1.FunctionalBuiltin4
 
 	// BuiltinContext contains context from the evaluator that may be used by
 	// built-in functions.

--- a/topdown/trace.go
+++ b/topdown/trace.go
@@ -65,7 +65,7 @@ type Event = v1.Event
 // Tracer defines the interface for tracing in the top-down evaluation engine.
 //
 // Deprecated: Use QueryTracer instead.
-type Tracer = v1.Tracer //nolint:staticcheck
+type Tracer = v1.Tracer
 
 // QueryTracer defines the interface for tracing in the top-down evaluation engine.
 // The implementation can provide additional configuration to modify the tracing

--- a/util/test/tempfs.go
+++ b/util/test/tempfs.go
@@ -13,7 +13,7 @@ import (
 // WithTempFS creates a temporary directory structure and invokes f with the
 // root directory path.
 func WithTempFS(files map[string]string, f func(string)) {
-	v1.WithTempFS(files, f) //nolint // ignore deprecation warning
+	v1.WithTempFS(files, f)
 }
 
 // MakeTempFS creates a temporary directory structure for test purposes rooted at root.

--- a/v1/ast/fuzz_test.go
+++ b/v1/ast/fuzz_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by an Apache2
 // license that can be found in the LICENSE file.
 
-// nolint
+//nolint
 package ast
 
 import (

--- a/v1/bundle/bundle_test.go
+++ b/v1/bundle/bundle_test.go
@@ -2,7 +2,6 @@
 // Use of this source code is governed by an Apache2
 // license that can be found in the LICENSE file.
 
-// nolint: goconst // string duplication is for test readability.
 package bundle
 
 import (

--- a/v1/plugins/bundle/plugin_test.go
+++ b/v1/plugins/bundle/plugin_test.go
@@ -2,7 +2,6 @@
 // Use of this source code is governed by an Apache2
 // license that can be found in the LICENSE file.
 
-// nolint: goconst // string duplication is for test readability.
 package bundle
 
 import (

--- a/v1/plugins/discovery/discovery_test.go
+++ b/v1/plugins/discovery/discovery_test.go
@@ -2,7 +2,6 @@
 // Use of this source code is governed by an Apache2
 // license that can be found in the LICENSE file.
 
-// nolint: goconst // string duplication is for test readability.
 package discovery
 
 import (

--- a/v1/plugins/rest/auth.go
+++ b/v1/plugins/rest/auth.go
@@ -156,8 +156,8 @@ func convertSignatureToBase64(alg string, der []byte) (string, error) {
 	return signatureData, nil
 }
 
-func pointsFromDER(der []byte) (R, S *big.Int, err error) { //nolint:gocritic
-	R, S = &big.Int{}, &big.Int{}
+func pointsFromDER(der []byte) (bigR, bigS *big.Int, err error) {
+	bigR, bigS = &big.Int{}, &big.Int{}
 	data := asn1.RawValue{}
 	if _, err := asn1.Unmarshal(der, &data); err != nil {
 		return nil, nil, fmt.Errorf("failed to unmarshall the signature from DER format %v", err)
@@ -170,8 +170,8 @@ func pointsFromDER(der []byte) (R, S *big.Int, err error) { //nolint:gocritic
 	r := data.Bytes[2 : rLen+2]
 	// Ignore the next 0x02 and slen bytes and just take the start of S to the end of the byte array
 	s := data.Bytes[rLen+4:]
-	R.SetBytes(r)
-	S.SetBytes(s)
+	bigR.SetBytes(r)
+	bigS.SetBytes(s)
 	return
 }
 

--- a/v1/plugins/rest/auth_tls.go
+++ b/v1/plugins/rest/auth_tls.go
@@ -147,12 +147,12 @@ func (ap *clientTLSAuthPlugin) loadCertificate() (*tls.Certificate, error) {
 		return nil, errors.New("PEM data could not be found")
 	}
 
-	// nolint: staticcheck // We don't want to forbid users from using this encryption.
+	//nolint: staticcheck // We don't want to forbid users from using this encryption.
 	if x509.IsEncryptedPEMBlock(block) {
 		if ap.PrivateKeyPassphrase == "" {
 			return nil, errors.New("client private key passphrase is needed, because the certificate is password encrypted")
 		}
-		// nolint: staticcheck // We don't want to forbid users from using this encryption.
+		//nolint: staticcheck // We don't want to forbid users from using this encryption.
 		decryptedBlock, err := x509.DecryptPEMBlock(block, []byte(ap.PrivateKeyPassphrase))
 		if err != nil {
 			return nil, err

--- a/v1/plugins/rest/rest_test.go
+++ b/v1/plugins/rest/rest_test.go
@@ -2370,7 +2370,6 @@ func (t *testServer) generateClientKeys() {
 
 	var pemBlock *pem.Block
 	if t.clientCertPassword != "" {
-		// nolint: staticcheck // We don't want to forbid users from using this encryption.
 		pemBlock, err = x509.EncryptPEMBlock(rand.Reader, "RSA PRIVATE KEY", x509.MarshalPKCS1PrivateKey(clientKey),
 			[]byte(t.clientCertPassword), x509.PEMCipherAES128)
 		if err != nil {

--- a/v1/profiler/profiler_test.go
+++ b/v1/profiler/profiler_test.go
@@ -2,7 +2,6 @@
 // Use of this source code is governed by an Apache2
 // license that can be found in the LICENSE file.
 
-// nolint: goconst // string duplication is for test readability.
 package profiler
 
 import (

--- a/v1/rego/example_test.go
+++ b/v1/rego/example_test.go
@@ -2,7 +2,6 @@
 // Use of this source code is governed by an Apache2
 // license that can be found in the LICENSE file.
 
-// nolint // example code
 package rego_test
 
 import (

--- a/v1/rego/rego.go
+++ b/v1/rego/rego.go
@@ -1872,14 +1872,12 @@ func (r *Rego) PrepareForEval(ctx context.Context, opts ...PrepareOption) (Prepa
 			return PreparedEvalQuery{}, err
 		}
 
-		// nolint: staticcheck // SA4006 false positive
 		cr, err := r.compileWasm(modules, queries, evalQueryType)
 		if err != nil {
 			_ = txnClose(ctx, err) // Ignore error
 			return PreparedEvalQuery{}, err
 		}
 
-		// nolint: staticcheck // SA4006 false positive
 		data, err := r.store.Read(ctx, r.txn, storage.RootPath)
 		if err != nil {
 			_ = txnClose(ctx, err) // Ignore error

--- a/v1/rego/rego_test.go
+++ b/v1/rego/rego_test.go
@@ -2,7 +2,6 @@
 // Use of this source code is governed by an Apache2
 // license that can be found in the LICENSE file.
 
-// nolint: goconst // string duplication is for test readability.
 package rego
 
 import (

--- a/v1/repl/example_test.go
+++ b/v1/repl/example_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/open-policy-agent/opa/v1/storage/inmem"
 )
 
-// nolint // example code
 func ExampleREPL_OneShot() {
 	// Initialize context for the example. Normally the caller would obtain the
 	// context from an input parameter or instantiate their own.

--- a/v1/repl/repl.go
+++ b/v1/repl/repl.go
@@ -5,7 +5,6 @@
 // Package repl implements a Read-Eval-Print-Loop (REPL) for interacting with the policy engine.
 //
 // The REPL is typically used from the command line, however, it can also be used as a library.
-// nolint: goconst // String reuse here doesn't make sense to deduplicate.
 package repl
 
 import (

--- a/v1/repl/repl_test.go
+++ b/v1/repl/repl_test.go
@@ -2,7 +2,6 @@
 // Use of this source code is governed by an Apache2
 // license that can be found in the LICENSE file.
 
-// nolint: goconst // string duplication is for test readability.
 package repl
 
 import (

--- a/v1/runtime/logging_test.go
+++ b/v1/runtime/logging_test.go
@@ -2,7 +2,6 @@
 // Use of this source code is governed by an Apache2
 // license that can be found in the LICENSE file.
 
-// nolint: goconst // string duplication is for test readability.
 package runtime
 
 import (

--- a/v1/runtime/runtime.go
+++ b/v1/runtime/runtime.go
@@ -807,7 +807,7 @@ func (rt *Runtime) Serve(ctx context.Context) (err error) {
 			return rt.gracefulServerShutdown(rt.server)
 		case err := <-errc:
 			rt.logger.WithFields(map[string]any{"err": err}).Error("Listener failed.")
-			os.Exit(1) //nolint:gocritic
+			os.Exit(1)
 		}
 	}
 }

--- a/v1/sdk/opa.go
+++ b/v1/sdk/opa.go
@@ -171,8 +171,7 @@ func (opa *OPA) configure(ctx context.Context, bs []byte, ready chan struct{}, b
 		return err
 	}
 
-	//nolint:prealloc // option list has known initial values, extended with opa.managerOpts
-	opts := []func(*plugins.Manager){
+	opts := append([]func(*plugins.Manager){
 		plugins.Info(runtimeInfo),
 		plugins.Logger(opa.logger),
 		plugins.ConsoleLogger(opa.console),
@@ -180,8 +179,7 @@ func (opa *OPA) configure(ctx context.Context, bs []byte, ready chan struct{}, b
 		plugins.EnablePrintStatements(opa.logger.GetLevel() >= logging.Info),
 		plugins.PrintHook(loggingPrintHook{logger: opa.logger}),
 		plugins.WithHooks(opa.hooks),
-	}
-	opts = append(opts, opa.managerOpts...)
+	}, opa.managerOpts...)
 
 	// Plumb in storage for external bundle activation plugin, if registered with bundle.RegisterStore,
 	// unless the user has passed their own store already.

--- a/v1/server/cache_test.go
+++ b/v1/server/cache_test.go
@@ -18,7 +18,6 @@ func TestCacheLimit(t *testing.T) {
 
 	// Fill the cache with values
 	var i int
-	//nolint:intrange
 	for i = 0; i < max; i++ {
 		c.Insert(strconv.Itoa(i), i)
 	}

--- a/v1/server/failtracer/failtracer.go
+++ b/v1/server/failtracer/failtracer.go
@@ -55,7 +55,7 @@ func (*failTracer) Config() topdown.TraceConfig {
 }
 
 func (b *failTracer) Hints(unknowns []ast.Ref) []Hint {
-	var hints []Hint //nolint:prealloc
+	var hints []Hint
 	seenRefs := map[string]struct{}{}
 	candidates := make([]string, 0, len(unknowns))
 	for _, ref := range unknowns {

--- a/v1/server/server_test.go
+++ b/v1/server/server_test.go
@@ -2,7 +2,6 @@
 // Use of this source code is governed by an Apache2
 // license that can be found in the LICENSE file.
 
-// nolint: goconst // string duplication is for test readability.
 package server
 
 import (

--- a/v1/test/cases/internal/fmtcases/main.go
+++ b/v1/test/cases/internal/fmtcases/main.go
@@ -89,9 +89,9 @@ func copyEntry(sourceRoot string, sourceRegoVersion ast.RegoVersion, e os.DirEnt
 		}
 
 		// Format test modules
-		for _, testCase := range testCases.Cases { //nolint:gocritic
-			for i, module := range testCase.Modules {
-				bs, err := format.SourceWithOpts(fmt.Sprintf("mod%d.rego", i), []byte(module),
+		for i := range testCases.Cases {
+			for j, module := range testCases.Cases[i].Modules {
+				bs, err := format.SourceWithOpts(fmt.Sprintf("mod%d.rego", j), []byte(module),
 					format.Opts{
 						ParserOptions: &ast.ParserOptions{
 							RegoVersion: sourceRegoVersion,
@@ -99,9 +99,9 @@ func copyEntry(sourceRoot string, sourceRegoVersion ast.RegoVersion, e os.DirEnt
 						RegoVersion: targetRegoVersion,
 					})
 				if err != nil {
-					fmt.Printf("Error formatting module %s %s:%d: %v\n", path, testCase.Note, i, err)
+					fmt.Printf("Error formatting module %s %s:%d: %v\n", path, testCases.Cases[i].Note, j, err)
 				} else {
-					testCase.Modules[i] = string(bs)
+					testCases.Cases[i].Modules[j] = string(bs)
 				}
 			}
 		}

--- a/v1/test/e2e/authz/disk.go
+++ b/v1/test/e2e/authz/disk.go
@@ -5,7 +5,6 @@
 //go:build bench_disk
 // +build bench_disk
 
-// nolint: unused // build tags confuse these linters
 package authz
 
 import (

--- a/v1/test/e2e/authz/nodisk.go
+++ b/v1/test/e2e/authz/nodisk.go
@@ -4,7 +4,6 @@
 
 //go:build !bench_disk
 
-// nolint: unused // build tags confuse these linters
 package authz
 
 import "github.com/open-policy-agent/opa/v1/storage/disk"

--- a/v1/test/e2e/wasm/authz/disk.go
+++ b/v1/test/e2e/wasm/authz/disk.go
@@ -5,7 +5,6 @@
 //go:build bench_disk
 // +build bench_disk
 
-// nolint: unused // build tags confuse these linters
 package authz
 
 import (

--- a/v1/test/e2e/wasm/authz/nodisk.go
+++ b/v1/test/e2e/wasm/authz/nodisk.go
@@ -4,11 +4,11 @@
 
 //go:build !bench_disk
 
-// nolint: unused // build tags confuse these linters
 package authz
 
 import "github.com/open-policy-agent/opa/v1/storage/disk"
 
+//nolint:unused
 func diskStorage() (*disk.Options, func() error) {
 	return nil, nil
 }

--- a/v1/test/wasm/cmd/wasm-rego-testgen/main.go
+++ b/v1/test/wasm/cmd/wasm-rego-testgen/main.go
@@ -41,10 +41,10 @@ type compiledTestCase struct {
 
 func compileTestCases(ctx context.Context, tests cases.Set) (*compiledTestCaseSet, error) {
 	result := make([]compiledTestCase, 0, len(tests.Cases))
-	for _, tc := range tests.Cases { //nolint:gocritic
-
+	for i := range tests.Cases {
 		var numExpects int
 
+		tc := tests.Cases[i]
 		if tc.WantDefined != nil {
 			numExpects++
 		}

--- a/v1/tester/runner_test.go
+++ b/v1/tester/runner_test.go
@@ -56,7 +56,6 @@ func TestRunWithCoverage(t *testing.T) {
 type expectedTestResult struct {
 	wantErr  bool
 	wantFail bool
-	// nolint: structcheck // The test doesn't check this value, but should.
 	wantSkip bool
 	cases    map[string]expectedTestResult
 }

--- a/v1/topdown/http_test.go
+++ b/v1/topdown/http_test.go
@@ -2,7 +2,6 @@
 // Use of this source code is governed by an Apache2
 // license that can be found in the LICENSE file.
 
-// nolint: goconst // string duplication is for test readability.
 package topdown
 
 import (
@@ -3046,7 +3045,7 @@ func TestCertSelectionLogic(t *testing.T) {
 		{
 			note:     "tls_use_system_certs set to true",
 			input:    map[*ast.Term]*ast.Term{ast.StringTerm("tls_use_system_certs"): ast.BooleanTerm(true)},
-			expected: systemCertsPool.Subjects(), // nolint:staticcheck // ignoring the deprecated (*CertPool).Subjects() call here because it's in a test.
+			expected: systemCertsPool.Subjects(), // ignoring the deprecated (*CertPool).Subjects() call here because it's in a test.
 			msg:      "Expected TLS config to use system certs",
 		},
 		{
@@ -3064,19 +3063,19 @@ func TestCertSelectionLogic(t *testing.T) {
 		{
 			note:     "CA cert provided directly",
 			input:    map[*ast.Term]*ast.Term{ast.StringTerm("tls_ca_cert"): ast.StringTerm(string(ca))},
-			expected: caPool.Subjects(), // nolint:staticcheck // ignoring the deprecated (*CertPool).Subjects() call here because it's in a test.
+			expected: caPool.Subjects(),
 			msg:      "Expected TLS config to use provided CA certs",
 		},
 		{
 			note:     "CA cert file path provided",
 			input:    map[*ast.Term]*ast.Term{ast.StringTerm("tls_ca_cert_file"): ast.StringTerm(localCaFile)},
-			expected: caPool.Subjects(), // nolint:staticcheck // ignoring the deprecated (*CertPool).Subjects() call here because it's in a test.
+			expected: caPool.Subjects(),
 			msg:      "Expected TLS config to use provided CA certs in file",
 		},
 		{
 			note:     "CA cert provided in env variable",
 			input:    map[*ast.Term]*ast.Term{ast.StringTerm("tls_ca_cert_env_variable"): ast.StringTerm("CLIENT_CA_ENV")},
-			expected: caPool.Subjects(), // nolint:staticcheck // ignoring the deprecated (*CertPool).Subjects() call here because it's in a test.
+			expected: caPool.Subjects(),
 			msg:      "Expected TLS config to use provided CA certs in env variable",
 		},
 		{
@@ -3085,7 +3084,7 @@ func TestCertSelectionLogic(t *testing.T) {
 				ast.StringTerm("tls_ca_cert"):          ast.StringTerm(string(ca)),
 				ast.StringTerm("tls_use_system_certs"): ast.BooleanTerm(false),
 			},
-			expected: caPool.Subjects(), // nolint:staticcheck // ignoring the deprecated (*CertPool).Subjects() call here because it's in a test.
+			expected: caPool.Subjects(),
 			msg:      "Expected TLS config to use provided CA certs only",
 		},
 		{
@@ -3094,7 +3093,7 @@ func TestCertSelectionLogic(t *testing.T) {
 				ast.StringTerm("tls_ca_cert"):          ast.StringTerm(string(ca)),
 				ast.StringTerm("tls_use_system_certs"): ast.BooleanTerm(true),
 			},
-			expected: systemCertsAndCaPool.Subjects(), // nolint:staticcheck // ignoring the deprecated (*CertPool).Subjects() call here because it's in a test.
+			expected: systemCertsAndCaPool.Subjects(),
 			msg:      "Expected TLS config to use provided CA certs and system certs",
 		},
 	}
@@ -3111,7 +3110,6 @@ func TestCertSelectionLogic(t *testing.T) {
 					t.Fatal(tc.msg)
 				}
 			} else {
-				// nolint:staticcheck // ignoring the deprecated (*CertPool).Subjects() call here because it's in a test.
 				if !reflect.DeepEqual(tlsConfig.RootCAs.Subjects(), tc.expected) {
 					t.Fatal(tc.msg)
 				}

--- a/v1/topdown/strings.go
+++ b/v1/topdown/strings.go
@@ -316,8 +316,8 @@ func builtinIndexOf(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term)
 	}
 
 	if isASCII(string(base)) && isASCII(string(search)) {
-		// this is a false positive in the indexAlloc rule that thinks
-		// we're converting byte arrays to strings
+		// this is a false positive in the indexAlloc rule that thinks we're converting
+		// byte arrays to strings. still a false positive as of 2026-08-19.
 		//nolint:gocritic
 		return iter(ast.InternedTerm(strings.Index(string(base), string(search))))
 	}

--- a/v1/util/hashmap_test.go
+++ b/v1/util/hashmap_test.go
@@ -2,7 +2,6 @@
 // Use of this source code is governed by an Apache2
 // license that can be found in the LICENSE file.
 
-// nolint: goconst // string duplication is for test readability.
 package util
 
 import (

--- a/v1/util/test/benchmark.go
+++ b/v1/util/test/benchmark.go
@@ -45,7 +45,6 @@ func PartialObjectBenchmarkCrossModule(n int) []string {
 	ruleBuilder := ""
 
 	for idx := 1; idx <= n; idx++ {
-		//nolint:perfsprint
 		barMod += fmt.Sprintf(`
 		bench_test_%[1]d := result if {
             input.bench_test_collector_mambo_number_%[3]d


### PR DESCRIPTION
And update linter conf to ignore v0 directories entirely

Finally, added the `nolintlint` linter which will help enforce better nolint hygiene in the project going forward.