### PR TITLE
go1.26 modernizations

### DIFF
--- a/build/bench-comment/main.go
+++ b/build/bench-comment/main.go
@@ -273,9 +273,9 @@ func parseBenchstatFile(path string) ([]change, error) {
 // its "# benchstat -flags... <file>" comment header.
 func sourceFileFromHeader(header string) (string, error) {
 	fields := strings.Fields(header)
-	for i := len(fields) - 1; i >= 0; i-- {
-		if strings.HasSuffix(fields[i], ".txt") {
-			return fields[i], nil
+	for _, field := range slices.Backward(fields) {
+		if strings.HasSuffix(field, ".txt") {
+			return field, nil
 		}
 	}
 	return "", fmt.Errorf("no source file found in header %q", header)

--- a/cmd/exec_jsonv2_test.go
+++ b/cmd/exec_jsonv2_test.go
@@ -49,11 +49,6 @@ func (r execResultItemError) isEmpty() bool {
 	return r.Code == "" && r.Message == ""
 }
 
-//go:fix inline
-func toAnyPtr(a any) *any {
-	return new(a)
-}
-
 func toStringSlice(a *any) []string {
 	switch a := (*a).(type) {
 	case []string:
@@ -151,15 +146,15 @@ func TestExecBasic(t *testing.T) {
 		resultSliceEquals(t, []execResultItem{
 			{
 				Path:   "/test.json",
-				Result: toAnyPtr([]string{"hello"}),
+				Result: new(any([]string{"hello"})),
 			},
 			{
 				Path:   "/test2.yaml",
-				Result: toAnyPtr([]string{"hello"}),
+				Result: new(any([]string{"hello"})),
 			},
 			{
 				Path:   "/test3.yml",
-				Result: toAnyPtr([]string{"hello"}),
+				Result: new(any([]string{"hello"})),
 			},
 		}, output.Result)
 	})
@@ -204,7 +199,7 @@ func TestExecDecisionOption(t *testing.T) {
 		resultSliceEquals(t, []execResultItem{
 			{
 				Path:   "/test.json",
-				Result: toAnyPtr([]string{"hello"}),
+				Result: new(any([]string{"hello"})),
 			},
 		}, output.Result)
 	})
@@ -238,7 +233,7 @@ func TestExecBundleFlag(t *testing.T) {
 		resultSliceEquals(t, []execResultItem{
 			{
 				Path:   "/files/test.json",
-				Result: toAnyPtr([]string{"hello"}),
+				Result: new(any([]string{"hello"})),
 			},
 		}, output.Result)
 	})
@@ -337,7 +332,7 @@ main contains "hello" if {
 					resultSliceEquals(t, []execResultItem{
 						{
 							Path:   "/test.json",
-							Result: toAnyPtr([]string{"hello"}),
+							Result: new(any([]string{"hello"})),
 						},
 					}, output.Result)
 				}
@@ -546,7 +541,7 @@ main contains "hello" if {
 					resultSliceEquals(t, []execResultItem{
 						{
 							Path:   "/test.json",
-							Result: toAnyPtr([]string{"hello"}),
+							Result: new(any([]string{"hello"})),
 						},
 					}, output.Result)
 				}
@@ -903,7 +898,7 @@ main contains "hello" if {
 							resultSliceEquals(t, []execResultItem{
 								{
 									Path:   "/files/test.json",
-									Result: toAnyPtr([]string{"hello"}),
+									Result: new(any([]string{"hello"})),
 								},
 							}, output.Result)
 						}

--- a/cmd/exec_jsonv2_test.go
+++ b/cmd/exec_jsonv2_test.go
@@ -49,8 +49,9 @@ func (r execResultItemError) isEmpty() bool {
 	return r.Code == "" && r.Message == ""
 }
 
+//go:fix inline
 func toAnyPtr(a any) *any {
-	return &a
+	return new(a)
 }
 
 func toStringSlice(a *any) []string {

--- a/cmd/exec_jsonv2_test.go
+++ b/cmd/exec_jsonv2_test.go
@@ -848,9 +848,7 @@ main contains "hello" if {
 							// runExec to hang indefinitely. WithContext allows us to cancel the context
 							// when we have the required errors logged.
 							var wg sync.WaitGroup
-							wg.Add(1)
-							go func() {
-								defer wg.Done()
+							wg.Go(func() {
 								err := runExecWithContext(ctx, params)
 								// we cancelled the context, so we expect that error
 								if err != nil && err.Error() != "context canceled" {
@@ -864,7 +862,7 @@ main contains "hello" if {
 									t.Error(err)
 									return
 								}
-							}()
+							})
 
 							test.EventuallyOrFatal(t, 5*time.Second, func() bool {
 								for _, expErr := range tc.expErrs {

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -236,8 +236,7 @@ func runTests(ctx context.Context, txn storage.Transaction, runner *tester.Runne
 	if err := reporter.Report(dup); err != nil {
 		_, _ = fmt.Fprintln(testParams.errOutput, err)
 		if !testParams.benchmark {
-			var coverageThresholdError *cover.CoverageThresholdError
-			if errors.As(err, &coverageThresholdError) {
+			if _, ok := errors.AsType[*cover.CoverageThresholdError](err); ok {
 				return 2, err
 			}
 		}

--- a/internal/edittree/edittree.go
+++ b/internal/edittree/edittree.go
@@ -168,6 +168,7 @@ package edittree
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/open-policy-agent/opa/internal/edittree/bitvector"
@@ -435,16 +436,16 @@ func (e *EditTree) unsafeInsertArray(idx int, value *ast.Term) *EditTree {
 		}
 	}
 	// Do rewrites in reverse order to make room for the newly-inserted element.
-	for i := len(rewritesScalars) - 1; i >= 0; i-- {
-		originalIdx := rewritesScalars[i]
-		rewriteIdx := rewritesScalars[i] + 1
+	for _, originalIdx := range slices.Backward(rewritesScalars) {
+
+		rewriteIdx := originalIdx + 1
 		v := e.childScalarValues[originalIdx]
 		e.deleteChildValue(originalIdx)
 		e.setChildScalarValue(rewriteIdx, v)
 	}
-	for i := len(rewritesComposites) - 1; i >= 0; i-- {
-		originalIdx := rewritesComposites[i]
-		rewriteIdx := rewritesComposites[i] + 1
+	for _, originalIdx := range slices.Backward(rewritesComposites) {
+
+		rewriteIdx := originalIdx + 1
 		v := e.childCompositeValues[originalIdx]
 		e.deleteChildValue(originalIdx)
 		e.setChildCompositeValue(rewriteIdx, v)

--- a/internal/genjsonschema/genjsonschema.go
+++ b/internal/genjsonschema/genjsonschema.go
@@ -181,8 +181,7 @@ func (b *Builder) collectFields(t reflect.Type, properties *OrderedMap, required
 	}
 	var fields []pendingField
 
-	for i := range t.NumField() {
-		f := t.Field(i)
+	for f := range t.Fields() {
 		if !f.IsExported() {
 			continue
 		}

--- a/internal/lcss/qsufsort.go
+++ b/internal/lcss/qsufsort.go
@@ -24,7 +24,10 @@
 
 package lcss
 
-import "sort"
+import (
+	"slices"
+	"sort"
+)
 
 // qsufsort constructs the suffix array for a given string.
 func qsufsort(data []byte) []int {
@@ -98,15 +101,15 @@ func initGroups(sa []int, data []byte) []int {
 	inv := make([]int, len(data))
 	prevGroup := len(sa) - 1
 	groupByte := data[sa[prevGroup]]
-	for i := len(sa) - 1; i >= 0; i-- {
-		if b := data[sa[i]]; b < groupByte {
+	for i, s := range slices.Backward(sa) {
+		if b := data[s]; b < groupByte {
 			if prevGroup == i+1 {
 				sa[i+1] = -1
 			}
 			groupByte = b
 			prevGroup = i
 		}
-		inv[sa[i]] = prevGroup
+		inv[s] = prevGroup
 		if prevGroup == 0 {
 			sa[0] = -1
 		}

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -945,8 +945,8 @@ func (p *Planner) planWith(e *ast.Expr, iter planiter) error {
 			p.mocks.PopFrame()
 			if shadowing {
 				p.funcs.Pop()
-				for i := len(dataRefs) - 1; i >= 0; i-- {
-					p.rules.Pop(dataRefs[i])
+				for _, dataRef := range slices.Backward(dataRefs) {
+					p.rules.Pop(dataRef)
 				}
 			}
 
@@ -970,8 +970,8 @@ func (p *Planner) planWith(e *ast.Expr, iter planiter) error {
 		p.mocks.PopFrame()
 		if shadowing {
 			p.funcs.Pop()
-			for i := len(dataRefs) - 1; i >= 0; i-- {
-				p.rules.Pop(dataRefs[i])
+			for _, dataRef := range slices.Backward(dataRefs) {
+				p.rules.Pop(dataRef)
 			}
 		}
 		return err

--- a/internal/planner/rules.go
+++ b/internal/planner/rules.go
@@ -2,6 +2,7 @@ package planner
 
 import (
 	"fmt"
+	"slices"
 
 	"github.com/open-policy-agent/opa/v1/ast"
 	"github.com/open-policy-agent/opa/v1/util"
@@ -322,8 +323,8 @@ func (s *functionMocksStack) PopFrame() {
 
 func (s *functionMocksStack) Lookup(f string) *ast.Term {
 	current := s.stack.PeekGroup()
-	for i := len(current) - 1; i >= 0; i-- {
-		if t, ok := current[i][f]; ok {
+	for _, c := range slices.Backward(current) {
+		if t, ok := c[f]; ok {
 			return t
 		}
 	}

--- a/internal/planner/varstack.go
+++ b/internal/planner/varstack.go
@@ -5,6 +5,8 @@
 package planner
 
 import (
+	"slices"
+
 	"github.com/open-policy-agent/opa/v1/ast"
 	"github.com/open-policy-agent/opa/v1/ir"
 )
@@ -34,8 +36,8 @@ func (vs varstack) GetOrEmpty(k ast.Var) ir.Local {
 }
 
 func (vs varstack) Get(k ast.Var) (ir.Local, bool) {
-	for i := len(vs) - 1; i >= 0; i-- {
-		if l, ok := vs[i][k]; ok {
+	for _, v := range slices.Backward(vs) {
+		if l, ok := v[k]; ok {
 			return l, true
 		}
 	}

--- a/internal/wasm/sdk/internal/wasm/vm.go
+++ b/internal/wasm/sdk/internal/wasm/vm.go
@@ -697,22 +697,18 @@ func callOrCancel(ctx context.Context, vm *VM, name string, args ...int32) (any,
 
 	res, err := f.Call(ctx, ul...)
 	if err != nil {
-		var abort abortError
-		if errors.As(err, &abort) {
+		if abort, ok := errors.AsType[abortError](err); ok {
 			return 0, sdk_errors.New(sdk_errors.InternalErr, abort.message)
 		}
-		var cancelled cancelledError
-		if errors.As(err, &cancelled) {
+		if cancelled, ok := errors.AsType[cancelledError](err); ok {
 			return 0, sdk_errors.New(sdk_errors.CancelledErr, cancelled.message)
 		}
-		var be builtinError
-		if errors.As(err, &be) {
+		if be, ok := errors.AsType[builtinError](err); ok {
 			return 0, sdk_errors.New(sdk_errors.InternalErr, be.err.Error())
 		}
 		// WithCloseOnContextDone: wazero closes the module and returns sys.ExitError
 		// when ctx is cancelled or times out mid-execution (tight wasm loops included).
-		var exitErr *sys.ExitError
-		if errors.As(err, &exitErr) {
+		if exitErr, ok := errors.AsType[*sys.ExitError](err); ok {
 			c := exitErr.ExitCode()
 			if c == sys.ExitCodeContextCanceled || c == sys.ExitCodeDeadlineExceeded {
 				vm.dead = true

--- a/internal/wasm/sdk/opa/errors/errors.go
+++ b/internal/wasm/sdk/opa/errors/errors.go
@@ -61,8 +61,7 @@ func IsCancel(err error) bool {
 
 // Is allows matching error types using errors.Is (see IsCancel).
 func (e *Error) Is(target error) bool {
-	var t *Error
-	if errors.As(target, &t) {
+	if t, ok := errors.AsType[*Error](target); ok {
 		return (t.Code == "" || e.Code == t.Code) &&
 			(t.Message == "" || e.Message == t.Message)
 	}

--- a/main.go
+++ b/main.go
@@ -20,8 +20,7 @@ func main() {
 	}() // orderly shutdown, run all defer routines
 
 	if err := cmd.RootCommand.Execute(); err != nil {
-		var e *cmd.ExitError
-		if errors.As(err, &e) {
+		if e, ok := errors.AsType[*cmd.ExitError](err); ok {
 			exit = e.Exit
 		} else {
 			exit = 1

--- a/v1/ast/annotations.go
+++ b/v1/ast/annotations.go
@@ -741,8 +741,8 @@ func (as *AnnotationSet) Chain(rule *Rule) AnnotationsRefSet {
 	subPkgAnnots := as.GetSubpackagesScope(rule.Module.Package.Path)
 	// We need to reverse the order, as subPkgAnnots ordering will start at the root,
 	// whereas we want to end at the root.
-	for i := len(subPkgAnnots) - 1; i >= 0; i-- {
-		refs = append(refs, NewAnnotationsRef(subPkgAnnots[i]))
+	for _, subPkgAnnot := range slices.Backward(subPkgAnnots) {
+		refs = append(refs, NewAnnotationsRef(subPkgAnnot))
 	}
 
 	return refs
@@ -768,8 +768,8 @@ func (as *AnnotationSet) MergedLabels(rule *Rule) (labels map[string]any, key st
 // we iterate in reverse to fold outer-to-inner.
 func mergeChainLabels(chain AnnotationsRefSet) map[string]any {
 	var merged map[string]any
-	for i := len(chain) - 1; i >= 0; i-- {
-		a := chain[i].Annotations
+	for _, c := range slices.Backward(chain) {
+		a := c.Annotations
 		if a == nil || len(a.Labels) == 0 {
 			continue
 		}

--- a/v1/ast/compile.go
+++ b/v1/ast/compile.go
@@ -5911,8 +5911,8 @@ func resolveRefsInTermSlice(globals map[Var]*usedRef, ignore *declaredVarStack, 
 type declaredVarStack []VarSet
 
 func (s declaredVarStack) Contains(v Var) bool {
-	for i := len(s) - 1; i >= 0; i-- {
-		if _, ok := s[i][v]; ok {
+	for _, v0 := range slices.Backward(s) {
+		if _, ok := v0[v]; ok {
 			return ok
 		}
 	}
@@ -6625,8 +6625,8 @@ func (s localDeclaredVars) Insert(x, y Var, occurrence varOccurrence) {
 }
 
 func (s localDeclaredVars) Declared(x Var) (y Var, ok bool) {
-	for i := len(s.vars) - 1; i >= 0; i-- {
-		if y, ok = s.vars[i].vs[x]; ok {
+	for _, v := range slices.Backward(s.vars) {
+		if y, ok = v.vs[x]; ok {
 			return
 		}
 	}
@@ -6642,8 +6642,8 @@ func (s localDeclaredVars) Occurrence(x Var) varOccurrence {
 // GlobalOccurrence returns a flag that indicates whether x has occurred in the
 // global scope.
 func (s localDeclaredVars) GlobalOccurrence(x Var) (varOccurrence, bool) {
-	for i := len(s.vars) - 1; i >= 0; i-- {
-		if occ, ok := s.vars[i].occurrence[x]; ok {
+	for _, v := range slices.Backward(s.vars) {
+		if occ, ok := v.occurrence[x]; ok {
 			return occ, true
 		}
 	}
@@ -6652,8 +6652,8 @@ func (s localDeclaredVars) GlobalOccurrence(x Var) (varOccurrence, bool) {
 
 // Seen marks x as seen by incrementing its counter
 func (s localDeclaredVars) Seen(x Var) {
-	for i := len(s.vars) - 1; i >= 0; i-- {
-		dvs := s.vars[i]
+	for _, dvs := range slices.Backward(s.vars) {
+
 		if c, ok := dvs.count[x]; ok {
 			dvs.count[x] = c + 1
 			return
@@ -6665,8 +6665,8 @@ func (s localDeclaredVars) Seen(x Var) {
 
 // Count returns how many times x has been seen
 func (s localDeclaredVars) Count(x Var) int {
-	for i := len(s.vars) - 1; i >= 0; i-- {
-		if c, ok := s.vars[i].count[x]; ok {
+	for _, v := range slices.Backward(s.vars) {
+		if c, ok := v.count[x]; ok {
 			return c
 		}
 	}

--- a/v1/ast/compile.go
+++ b/v1/ast/compile.go
@@ -3793,8 +3793,7 @@ func (qc *queryCompiler) TypeEnv() *TypeEnv {
 }
 
 func (qc *queryCompiler) applyErrorLimit(err error) error {
-	var errs Errors
-	if errors.As(err, &errs) {
+	if errs, ok := errors.AsType[Errors](err); ok {
 		if qc.compiler.maxErrs > 0 && len(errs) > qc.compiler.maxErrs {
 			err = append(errs[:qc.compiler.maxErrs], errLimitReached)
 		}

--- a/v1/ast/compile_test.go
+++ b/v1/ast/compile_test.go
@@ -12700,8 +12700,7 @@ func TestCustomBuiltinWithCompileModulesWithOpt(t *testing.T) {
 				if err == nil {
 					t.Fatalf("expected error code %s but got success", tc.expectedErrorCode)
 				}
-				var astError Errors
-				if errors.As(err, &astError) {
+				if astError, ok := errors.AsType[Errors](err); ok {
 					if astError[0].Code != tc.expectedErrorCode {
 						t.Fatalf("expected error code %s but got %s", tc.expectedErrorCode, astError[0].Code)
 					}

--- a/v1/ast/oracle/definition.go
+++ b/v1/ast/oracle/definition.go
@@ -4,6 +4,8 @@
 package oracle
 
 import (
+	"slices"
+
 	"github.com/open-policy-agent/opa/v1/ast"
 )
 
@@ -27,8 +29,8 @@ func findDefinition(
 	// Walk down the stack from innermost to outermost, collecting matches.
 	// The matchResult tracks the best match found (ref or variable).
 	result := &matchResult{}
-	for i := len(stack) - 1; i >= 0; i-- {
-		matchFn(stack[i], compiler, parsed, result)
+	for _, s := range slices.Backward(stack) {
+		matchFn(s, compiler, parsed, result)
 		// exit if we found a ref (refs always win)
 		if !result.isVar && result.loc != nil {
 			break

--- a/v1/ast/oracle/stack.go
+++ b/v1/ast/oracle/stack.go
@@ -4,6 +4,8 @@
 package oracle
 
 import (
+	"slices"
+
 	"github.com/open-policy-agent/opa/v1/ast"
 )
 
@@ -103,9 +105,9 @@ func getLocMinMax(x ast.Node) (int, int) {
 // has rewritten the rule bodies slightly. By ignoring appended generated body expressions,
 // we can still use the "circling in on the variable" logic based on node locations.
 func findLastExpr(body ast.Body) *ast.Expr {
-	for i := len(body) - 1; i >= 0; i-- {
-		if !body[i].Generated {
-			return body[i]
+	for _, b := range slices.Backward(body) {
+		if !b.Generated {
+			return b
 		}
 	}
 	// NOTE(sr): I believe this shouldn't happen -- we only ever start circling in on a node

--- a/v1/ast/oracle/target.go
+++ b/v1/ast/oracle/target.go
@@ -4,6 +4,8 @@
 package oracle
 
 import (
+	"slices"
+
 	"github.com/open-policy-agent/opa/v1/ast"
 )
 
@@ -37,8 +39,8 @@ func findTarget(stack []ast.Node) *target {
 
 	// If top wasn't a var, walk up the stack looking for a Ref.
 	if targetTerm == nil {
-		for i := len(stack) - 1; i >= 0; i-- {
-			if term, ok := stack[i].(*ast.Term); ok {
+		for _, s := range slices.Backward(stack) {
+			if term, ok := s.(*ast.Term); ok {
 				switch term.Value.(type) {
 				case ast.Ref:
 					// Found a ref - this is our target

--- a/v1/bundle/bundle_test.go
+++ b/v1/bundle/bundle_test.go
@@ -2428,8 +2428,3 @@ func TestMerge(t *testing.T) {
 		})
 	}
 }
-
-//go:fix inline
-func pointTo[T any](x T) *T {
-	return new(x)
-}

--- a/v1/bundle/bundle_test.go
+++ b/v1/bundle/bundle_test.go
@@ -84,13 +84,13 @@ func TestManifestEqual(t *testing.T) {
 
 	// rego-version
 
-	n.RegoVersion = pointTo(1)
+	n.RegoVersion = new(1)
 	assertNotEqual()
 
-	m.RegoVersion = pointTo(0)
+	m.RegoVersion = new(0)
 	assertNotEqual()
 
-	m.RegoVersion = pointTo(1)
+	m.RegoVersion = new(1)
 	assertEqual()
 
 	n.FileRegoVersions = map[string]int{
@@ -2429,6 +2429,7 @@ func TestMerge(t *testing.T) {
 	}
 }
 
+//go:fix inline
 func pointTo[T any](x T) *T {
-	return &x
+	return new(x)
 }

--- a/v1/bundle/proto.go
+++ b/v1/bundle/proto.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"net/url"
 
-	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/open-policy-agent/opa/v1/ast"
@@ -26,11 +25,11 @@ func ManifestToProto(m *Manifest) (*pb.Manifest, error) {
 		return nil, nil
 	}
 	out := &pb.Manifest{
-		Revision: proto.String(m.Revision),
+		Revision: new(m.Revision),
 	}
 	if m.Roots != nil {
 		out.Roots = append([]string(nil), (*m.Roots)...)
-		out.RootsSet = proto.Bool(true)
+		out.RootsSet = new(true)
 	}
 	if len(m.WasmResolvers) > 0 {
 		out.Wasm = make([]*pb.WasmResolver, len(m.WasmResolvers))
@@ -43,7 +42,7 @@ func ManifestToProto(m *Manifest) (*pb.Manifest, error) {
 		}
 	}
 	if m.RegoVersion != nil {
-		out.RegoVersion = proto.Int32(int32(*m.RegoVersion))
+		out.RegoVersion = new(int32(*m.RegoVersion))
 	}
 	if len(m.FileRegoVersions) > 0 {
 		out.FileRegoVersions = make(map[string]int32, len(m.FileRegoVersions))
@@ -66,8 +65,8 @@ func wasmResolverToProto(w *WasmResolver) (*pb.WasmResolver, error) {
 		return nil, nil
 	}
 	out := &pb.WasmResolver{
-		Entrypoint: proto.String(w.Entrypoint),
-		Module:     proto.String(w.Module),
+		Entrypoint: new(w.Entrypoint),
+		Module:     new(w.Module),
 	}
 	if len(w.Annotations) > 0 {
 		out.Annotations = make([]*pb.Annotations, len(w.Annotations))
@@ -87,10 +86,10 @@ func annotationsToProto(a *ast.Annotations) (*pb.Annotations, error) {
 		return nil, nil
 	}
 	out := &pb.Annotations{
-		Scope:         proto.String(a.Scope),
-		Title:         proto.String(a.Title),
-		Entrypoint:    proto.Bool(a.Entrypoint),
-		Description:   proto.String(a.Description),
+		Scope:         new(a.Scope),
+		Title:         new(a.Title),
+		Entrypoint:    new(a.Entrypoint),
+		Description:   new(a.Description),
 		Organizations: append([]string(nil), a.Organizations...),
 	}
 	if len(a.RelatedResources) > 0 {
@@ -143,8 +142,8 @@ func relatedResourceToProto(r *ast.RelatedResourceAnnotation) *pb.RelatedResourc
 		return nil
 	}
 	return &pb.RelatedResourceAnnotation{
-		Ref:         proto.String(r.Ref.String()),
-		Description: proto.String(r.Description),
+		Ref:         new(r.Ref.String()),
+		Description: new(r.Description),
 	}
 }
 
@@ -153,8 +152,8 @@ func authorToProto(a *ast.AuthorAnnotation) *pb.AuthorAnnotation {
 		return nil
 	}
 	return &pb.AuthorAnnotation{
-		Name:  proto.String(a.Name),
-		Email: proto.String(a.Email),
+		Name:  new(a.Name),
+		Email: new(a.Email),
 	}
 }
 
@@ -163,8 +162,8 @@ func schemaToProto(s *ast.SchemaAnnotation) (*pb.SchemaAnnotation, error) {
 		return nil, nil
 	}
 	out := &pb.SchemaAnnotation{
-		Path:   proto.String(s.Path.String()),
-		Schema: proto.String(s.Schema.String()),
+		Path:   new(s.Path.String()),
+		Schema: new(s.Schema.String()),
 	}
 	if s.Definition != nil {
 		v, err := jsonNormalizeValue(*s.Definition)
@@ -181,7 +180,7 @@ func compileToProto(c *ast.CompileAnnotation) *pb.CompileAnnotation {
 		return nil
 	}
 	out := &pb.CompileAnnotation{
-		MaskRule: proto.String(c.MaskRule.String()),
+		MaskRule: new(c.MaskRule.String()),
 	}
 	if len(c.Unknowns) > 0 {
 		out.Unknowns = make([]string, len(c.Unknowns))
@@ -197,9 +196,9 @@ func locationToProto(l *location.Location) *pb.Location {
 		return nil
 	}
 	return &pb.Location{
-		File: proto.String(l.File),
-		Row:  proto.Int32(int32(l.Row)),
-		Col:  proto.Int32(int32(l.Col)),
+		File: new(l.File),
+		Row:  new(int32(l.Row)),
+		Col:  new(int32(l.Col)),
 	}
 }
 

--- a/v1/bundle/proto_test.go
+++ b/v1/bundle/proto_test.go
@@ -151,7 +151,7 @@ func TestManifestFromProtoMalformedRef(t *testing.T) {
 	pm := &pb.Manifest{
 		Wasm: []*pb.WasmResolver{{
 			Annotations: []*pb.Annotations{{
-				Compile: &pb.CompileAnnotation{MaskRule: proto.String("not a ref!!!")},
+				Compile: &pb.CompileAnnotation{MaskRule: new("not a ref!!!")},
 			}},
 		}},
 	}

--- a/v1/config/spec.go
+++ b/v1/config/spec.go
@@ -58,9 +58,7 @@ func collectStructSpec(specs *[]ConfigSpec, pattern []string, t reflect.Type) {
 // flattening anonymous embedded structs.
 func structKeys(specs *[]ConfigSpec, pattern []string, t reflect.Type) []string {
 	var keys []string
-	for i := range t.NumField() {
-		field := t.Field(i)
-
+	for field := range t.Fields() {
 		name, _, _ := strings.Cut(field.Tag.Get("json"), ",")
 		if name == "-" {
 			continue

--- a/v1/config/validate_test.go
+++ b/v1/config/validate_test.go
@@ -90,8 +90,8 @@ func TestParseConfigNonStringDecisionErrors(t *testing.T) {
 func TestCoreValidationRootSpecMatchesConfigStruct(t *testing.T) {
 	structKeys := map[string]struct{}{}
 	objType := reflect.TypeFor[Config]()
-	for i := range objType.NumField() {
-		name, _, _ := strings.Cut(objType.Field(i).Tag.Get("json"), ",")
+	for field := range objType.Fields() {
+		name, _, _ := strings.Cut(field.Tag.Get("json"), ",")
 		if name == "" || name == "-" {
 			continue
 		}

--- a/v1/ir/proto.go
+++ b/v1/ir/proto.go
@@ -8,8 +8,6 @@ import (
 	"fmt"
 	"math"
 
-	"google.golang.org/protobuf/proto"
-
 	pb "github.com/open-policy-agent/opa/v1/ir/v1pb"
 )
 
@@ -58,14 +56,14 @@ func stringConstToProto(s *StringConst) *pb.StringConst {
 	if s == nil {
 		return nil
 	}
-	return &pb.StringConst{Value: proto.String(s.Value)}
+	return &pb.StringConst{Value: new(s.Value)}
 }
 
 func builtinFuncToProto(b *BuiltinFunc) *pb.BuiltinFunc {
 	if b == nil {
 		return nil
 	}
-	return &pb.BuiltinFunc{Name: proto.String(b.Name)}
+	return &pb.BuiltinFunc{Name: new(b.Name)}
 }
 
 func plansToProto(p *Plans) *pb.Plans {
@@ -83,7 +81,7 @@ func planToProto(p *Plan) *pb.Plan {
 	if p == nil {
 		return nil
 	}
-	out := &pb.Plan{Name: proto.String(p.Name), Blocks: make([]*pb.Block, len(p.Blocks))}
+	out := &pb.Plan{Name: new(p.Name), Blocks: make([]*pb.Block, len(p.Blocks))}
 	for i, b := range p.Blocks {
 		out.Blocks[i] = blockToProto(b)
 	}
@@ -106,9 +104,9 @@ func funcToProto(f *Func) *pb.Func {
 		return nil
 	}
 	out := &pb.Func{
-		Name:   proto.String(f.Name),
+		Name:   new(f.Name),
 		Params: localsToInt32s(f.Params),
-		Result: proto.Int32(toInt32(f.Return)),
+		Result: new(toInt32(f.Return)),
 		Blocks: make([]*pb.Block, len(f.Blocks)),
 		Path:   f.Path,
 	}
@@ -189,32 +187,32 @@ func stmtToProto(s Stmt) *pb.Stmt {
 	}
 	loc := s.GetLocation()
 	out := &pb.Stmt{
-		File:   proto.Int32(toInt32(loc.File)),
-		Col:    proto.Int32(toInt32(loc.Col)),
-		Row:    proto.Int32(toInt32(loc.Row)),
-		EndCol: proto.Int32(toInt32(loc.EndCol)),
-		EndRow: proto.Int32(toInt32(loc.EndRow)),
+		File:   new(toInt32(loc.File)),
+		Col:    new(toInt32(loc.Col)),
+		Row:    new(toInt32(loc.Row)),
+		EndCol: new(toInt32(loc.EndCol)),
+		EndRow: new(toInt32(loc.EndRow)),
 	}
 	switch x := s.(type) {
 	case *ArrayAppendStmt:
 		out.Kind = &pb.Stmt_ArrayAppendStmt{ArrayAppendStmt: &pb.ArrayAppendStmt{
 			Value: operandToProto(x.Value),
-			Array: proto.Int32(toInt32(x.Array)),
+			Array: new(toInt32(x.Array)),
 		}}
 	case *AssignIntStmt:
 		out.Kind = &pb.Stmt_AssignIntStmt{AssignIntStmt: &pb.AssignIntStmt{
-			Value:  proto.Int64(x.Value),
-			Target: proto.Int32(toInt32(x.Target)),
+			Value:  new(x.Value),
+			Target: new(toInt32(x.Target)),
 		}}
 	case *AssignVarOnceStmt:
 		out.Kind = &pb.Stmt_AssignVarOnceStmt{AssignVarOnceStmt: &pb.AssignVarOnceStmt{
 			Source: operandToProto(x.Source),
-			Target: proto.Int32(toInt32(x.Target)),
+			Target: new(toInt32(x.Target)),
 		}}
 	case *AssignVarStmt:
 		out.Kind = &pb.Stmt_AssignVarStmt{AssignVarStmt: &pb.AssignVarStmt{
 			Source: operandToProto(x.Source),
-			Target: proto.Int32(toInt32(x.Target)),
+			Target: new(toInt32(x.Target)),
 		}}
 	case *BlockStmt:
 		body := &pb.BlockStmt{Blocks: make([]*pb.Block, len(x.Blocks))}
@@ -223,24 +221,24 @@ func stmtToProto(s Stmt) *pb.Stmt {
 		}
 		out.Kind = &pb.Stmt_BlockStmt{BlockStmt: body}
 	case *BreakStmt:
-		out.Kind = &pb.Stmt_BreakStmt{BreakStmt: &pb.BreakStmt{Index: proto.Uint32(x.Index)}}
+		out.Kind = &pb.Stmt_BreakStmt{BreakStmt: &pb.BreakStmt{Index: new(x.Index)}}
 	case *CallDynamicStmt:
 		out.Kind = &pb.Stmt_CallDynamicStmt{CallDynamicStmt: &pb.CallDynamicStmt{
 			Args:   localsToInt32s(x.Args),
-			Result: proto.Int32(toInt32(x.Result)),
+			Result: new(toInt32(x.Result)),
 			Path:   operandsToProto(x.Path),
 		}}
 	case *CallStmt:
 		out.Kind = &pb.Stmt_CallStmt{CallStmt: &pb.CallStmt{
-			Function: proto.String(x.Func),
+			Function: new(x.Func),
 			Args:     operandsToProto(x.Args),
-			Result:   proto.Int32(toInt32(x.Result)),
+			Result:   new(toInt32(x.Result)),
 		}}
 	case *DotStmt:
 		out.Kind = &pb.Stmt_DotStmt{DotStmt: &pb.DotStmt{
 			Source: operandToProto(x.Source),
 			Key:    operandToProto(x.Key),
-			Target: proto.Int32(toInt32(x.Target)),
+			Target: new(toInt32(x.Target)),
 		}}
 	case *EqualStmt:
 		out.Kind = &pb.Stmt_EqualStmt{EqualStmt: &pb.EqualStmt{
@@ -250,39 +248,39 @@ func stmtToProto(s Stmt) *pb.Stmt {
 	case *IsArrayStmt:
 		out.Kind = &pb.Stmt_IsArrayStmt{IsArrayStmt: &pb.IsArrayStmt{Source: operandToProto(x.Source)}}
 	case *IsDefinedStmt:
-		out.Kind = &pb.Stmt_IsDefinedStmt{IsDefinedStmt: &pb.IsDefinedStmt{Source: proto.Int32(toInt32(x.Source))}}
+		out.Kind = &pb.Stmt_IsDefinedStmt{IsDefinedStmt: &pb.IsDefinedStmt{Source: new(toInt32(x.Source))}}
 	case *IsObjectStmt:
 		out.Kind = &pb.Stmt_IsObjectStmt{IsObjectStmt: &pb.IsObjectStmt{Source: operandToProto(x.Source)}}
 	case *IsSetStmt:
 		out.Kind = &pb.Stmt_IsSetStmt{IsSetStmt: &pb.IsSetStmt{Source: operandToProto(x.Source)}}
 	case *IsUndefinedStmt:
-		out.Kind = &pb.Stmt_IsUndefinedStmt{IsUndefinedStmt: &pb.IsUndefinedStmt{Source: proto.Int32(toInt32(x.Source))}}
+		out.Kind = &pb.Stmt_IsUndefinedStmt{IsUndefinedStmt: &pb.IsUndefinedStmt{Source: new(toInt32(x.Source))}}
 	case *LenStmt:
 		out.Kind = &pb.Stmt_LenStmt{LenStmt: &pb.LenStmt{
 			Source: operandToProto(x.Source),
-			Target: proto.Int32(toInt32(x.Target)),
+			Target: new(toInt32(x.Target)),
 		}}
 	case *MakeArrayStmt:
 		out.Kind = &pb.Stmt_MakeArrayStmt{MakeArrayStmt: &pb.MakeArrayStmt{
-			Capacity: proto.Int32(x.Capacity),
-			Target:   proto.Int32(toInt32(x.Target)),
+			Capacity: new(x.Capacity),
+			Target:   new(toInt32(x.Target)),
 		}}
 	case *MakeNullStmt:
-		out.Kind = &pb.Stmt_MakeNullStmt{MakeNullStmt: &pb.MakeNullStmt{Target: proto.Int32(toInt32(x.Target))}}
+		out.Kind = &pb.Stmt_MakeNullStmt{MakeNullStmt: &pb.MakeNullStmt{Target: new(toInt32(x.Target))}}
 	case *MakeNumberIntStmt:
 		out.Kind = &pb.Stmt_MakeNumberIntStmt{MakeNumberIntStmt: &pb.MakeNumberIntStmt{
-			Value:  proto.Int64(x.Value),
-			Target: proto.Int32(toInt32(x.Target)),
+			Value:  new(x.Value),
+			Target: new(toInt32(x.Target)),
 		}}
 	case *MakeNumberRefStmt:
 		out.Kind = &pb.Stmt_MakeNumberRefStmt{MakeNumberRefStmt: &pb.MakeNumberRefStmt{
-			Index:  proto.Int32(toInt32(x.Index)),
-			Target: proto.Int32(toInt32(x.Target)),
+			Index:  new(toInt32(x.Index)),
+			Target: new(toInt32(x.Target)),
 		}}
 	case *MakeObjectStmt:
-		out.Kind = &pb.Stmt_MakeObjectStmt{MakeObjectStmt: &pb.MakeObjectStmt{Target: proto.Int32(toInt32(x.Target))}}
+		out.Kind = &pb.Stmt_MakeObjectStmt{MakeObjectStmt: &pb.MakeObjectStmt{Target: new(toInt32(x.Target))}}
 	case *MakeSetStmt:
-		out.Kind = &pb.Stmt_MakeSetStmt{MakeSetStmt: &pb.MakeSetStmt{Target: proto.Int32(toInt32(x.Target))}}
+		out.Kind = &pb.Stmt_MakeSetStmt{MakeSetStmt: &pb.MakeSetStmt{Target: new(toInt32(x.Target))}}
 	case *NopStmt:
 		out.Kind = &pb.Stmt_NopStmt{NopStmt: &pb.NopStmt{}}
 	case *NotEqualStmt:
@@ -296,41 +294,41 @@ func stmtToProto(s Stmt) *pb.Stmt {
 		out.Kind = &pb.Stmt_ObjectInsertOnceStmt{ObjectInsertOnceStmt: &pb.ObjectInsertOnceStmt{
 			Key:    operandToProto(x.Key),
 			Value:  operandToProto(x.Value),
-			Object: proto.Int32(toInt32(x.Object)),
+			Object: new(toInt32(x.Object)),
 		}}
 	case *ObjectInsertStmt:
 		out.Kind = &pb.Stmt_ObjectInsertStmt{ObjectInsertStmt: &pb.ObjectInsertStmt{
 			Key:    operandToProto(x.Key),
 			Value:  operandToProto(x.Value),
-			Object: proto.Int32(toInt32(x.Object)),
+			Object: new(toInt32(x.Object)),
 		}}
 	case *ObjectMergeStmt:
 		out.Kind = &pb.Stmt_ObjectMergeStmt{ObjectMergeStmt: &pb.ObjectMergeStmt{
-			A:      proto.Int32(toInt32(x.A)),
-			B:      proto.Int32(toInt32(x.B)),
-			Target: proto.Int32(toInt32(x.Target)),
+			A:      new(toInt32(x.A)),
+			B:      new(toInt32(x.B)),
+			Target: new(toInt32(x.Target)),
 		}}
 	case *ResetLocalStmt:
-		out.Kind = &pb.Stmt_ResetLocalStmt{ResetLocalStmt: &pb.ResetLocalStmt{Target: proto.Int32(toInt32(x.Target))}}
+		out.Kind = &pb.Stmt_ResetLocalStmt{ResetLocalStmt: &pb.ResetLocalStmt{Target: new(toInt32(x.Target))}}
 	case *ResultSetAddStmt:
-		out.Kind = &pb.Stmt_ResultSetAddStmt{ResultSetAddStmt: &pb.ResultSetAddStmt{Value: proto.Int32(toInt32(x.Value))}}
+		out.Kind = &pb.Stmt_ResultSetAddStmt{ResultSetAddStmt: &pb.ResultSetAddStmt{Value: new(toInt32(x.Value))}}
 	case *ReturnLocalStmt:
-		out.Kind = &pb.Stmt_ReturnLocalStmt{ReturnLocalStmt: &pb.ReturnLocalStmt{Source: proto.Int32(toInt32(x.Source))}}
+		out.Kind = &pb.Stmt_ReturnLocalStmt{ReturnLocalStmt: &pb.ReturnLocalStmt{Source: new(toInt32(x.Source))}}
 	case *ScanStmt:
 		out.Kind = &pb.Stmt_ScanStmt{ScanStmt: &pb.ScanStmt{
-			Source: proto.Int32(toInt32(x.Source)),
-			Key:    proto.Int32(toInt32(x.Key)),
-			Value:  proto.Int32(toInt32(x.Value)),
+			Source: new(toInt32(x.Source)),
+			Key:    new(toInt32(x.Key)),
+			Value:  new(toInt32(x.Value)),
 			Block:  blockToProto(x.Block),
 		}}
 	case *SetAddStmt:
 		out.Kind = &pb.Stmt_SetAddStmt{SetAddStmt: &pb.SetAddStmt{
 			Value: operandToProto(x.Value),
-			Set:   proto.Int32(toInt32(x.Set)),
+			Set:   new(toInt32(x.Set)),
 		}}
 	case *WithStmt:
 		out.Kind = &pb.Stmt_WithStmt{WithStmt: &pb.WithStmt{
-			Local: proto.Int32(toInt32(x.Local)),
+			Local: new(toInt32(x.Local)),
 			Path:  intsToInt32s(x.Path),
 			Value: operandToProto(x.Value),
 			Block: blockToProto(x.Block),

--- a/v1/plugins/bundle/plugin_test.go
+++ b/v1/plugins/bundle/plugin_test.go
@@ -2822,8 +2822,9 @@ corge contains 1 if {
 	}
 }
 
+//go:fix inline
 func pointTo[T any](v T) *T {
-	return &v
+	return new(v)
 }
 
 func bundleRegoVersion(v ast.RegoVersion) int {
@@ -4441,7 +4442,7 @@ func TestReconfigurePlugin_OneShot_BundleDeactivation(t *testing.T) {
 			}
 
 			if tc.bundleRegoVersion != ast.RegoUndefined {
-				b.Manifest.RegoVersion = pointTo(tc.bundleRegoVersion.Int())
+				b.Manifest.RegoVersion = new(tc.bundleRegoVersion.Int())
 			}
 
 			b.Manifest.Init()
@@ -4578,7 +4579,7 @@ func TestReconfigurePlugin_ManagerInit_BundleDeactivation(t *testing.T) {
 			}
 
 			if tc.bundleRegoVersion != ast.RegoUndefined {
-				b.Manifest.RegoVersion = pointTo(tc.bundleRegoVersion.Int())
+				b.Manifest.RegoVersion = new(tc.bundleRegoVersion.Int())
 			}
 
 			b.Manifest.Init()

--- a/v1/plugins/bundle/plugin_test.go
+++ b/v1/plugins/bundle/plugin_test.go
@@ -7358,8 +7358,7 @@ func TestPluginManualTriggerWithServerError(t *testing.T) {
 
 	plugin.Stop(ctx)
 
-	var bundleErrors Errors
-	if errors.As(err, &bundleErrors) {
+	if bundleErrors, ok := errors.AsType[Errors](err); ok {
 		if len(bundleErrors) != 1 {
 			t.Fatalf("expected exactly one error, got %d", len(bundleErrors))
 		}

--- a/v1/plugins/rest/rest.go
+++ b/v1/plugins/rest/rest.go
@@ -102,8 +102,8 @@ func (c *Config) AuthPlugin(lookup AuthPluginLookupFunc) (HTTPAuthPlugin, error)
 	}
 	// reflection avoids need for this code to change as auth plugins are added
 	s := reflect.ValueOf(c.Credentials)
-	for i := range s.NumField() {
-		if s.Field(i).IsNil() {
+	for _, field := range s.Fields() {
+		if field.IsNil() {
 			continue
 		}
 
@@ -111,7 +111,7 @@ func (c *Config) AuthPlugin(lookup AuthPluginLookupFunc) (HTTPAuthPlugin, error)
 			return nil, errors.New("a maximum one credential method must be specified")
 		}
 
-		candidate = s.Field(i).Interface().(HTTPAuthPlugin)
+		candidate = field.Interface().(HTTPAuthPlugin)
 	}
 
 	if candidate == nil {

--- a/v1/rego/rego.go
+++ b/v1/rego/rego.go
@@ -3033,9 +3033,8 @@ func parseStringsToRefs(s []string) ([]ast.Ref, error) {
 // was defined.
 func finishFunction(name string, bctx topdown.BuiltinContext, result *ast.Term, err error, iter func(*ast.Term) error) error {
 	if err != nil {
-		var e *HaltError
 		sb := strings.Builder{}
-		if errors.As(err, &e) {
+		if e, ok := errors.AsType[*HaltError](err); ok {
 			sb.Grow(len(name) + len(e.Error()) + 2)
 			sb.WriteString(name)
 			sb.WriteString(": ")

--- a/v1/server/server.go
+++ b/v1/server/server.go
@@ -944,8 +944,8 @@ func (s *Server) initRouters(ctx context.Context) {
 func createMiddleware(mw ...func(http.Handler) http.Handler) func(http.Handler) http.Handler {
 	return func(hnd http.Handler) http.Handler {
 		next := hnd
-		for k := len(mw) - 1; k >= 0; k-- {
-			next = mw[k](next)
+		for _, m := range slices.Backward(mw) {
+			next = m(next)
 		}
 		return next
 	}

--- a/v1/server/types/types.go
+++ b/v1/server/types/types.go
@@ -31,8 +31,7 @@ func RegisterJSONFields[T any]() {
 		panic(fmt.Sprintf("types: RegisterJSONFields[%s]: not a struct", t))
 	}
 	f := make(map[string]bool, t.NumField())
-	for i := range t.NumField() {
-		sf := t.Field(i)
+	for sf := range t.Fields() {
 		tag := sf.Tag.Get("json")
 		if tag == "-" {
 			continue

--- a/v1/test/e2e/tls/tls_test.go
+++ b/v1/test/e2e/tls/tls_test.go
@@ -172,8 +172,7 @@ func TestNotDefaultTLSVersion(t *testing.T) {
 		if err == nil {
 			t.Error("expected err - protocol version not supported, got nil")
 		}
-		var exp *url.Error
-		if !errors.As(err, &exp) {
+		if exp, ok := errors.AsType[*url.Error](err); !ok {
 			t.Errorf("expected err type %[1]T, got %[2]T: %[2]v", exp, err)
 		}
 	})

--- a/v1/tester/reporter.go
+++ b/v1/tester/reporter.go
@@ -206,8 +206,8 @@ func printFailure(w io.Writer, trace []*topdown.Event, verbose bool, failureLine
 
 	if failureLine {
 		_, _ = fmt.Fprintln(w)
-		for i := len(trace) - 1; i >= 0; i-- {
-			e := trace[i]
+		for _, e := range slices.Backward(trace) {
+
 			if e.Op == topdown.FailOp && e.Location != nil && e.QueryID != 0 {
 				if expr, isExpr := e.Node.(*ast.Expr); isExpr {
 					if _, isEvery := expr.Terms.(*ast.Every); isEvery {

--- a/v1/topdown/cache.go
+++ b/v1/topdown/cache.go
@@ -229,8 +229,8 @@ func (s *refStack) Pop() {
 func (s *refStack) Prefixed(ref ast.Ref) bool {
 	if s != nil {
 		sl := s.sl.Slice()
-		for i := len(sl) - 1; i >= 0; i-- {
-			if slices.ContainsFunc(sl[i].refs, ref.HasPrefix) {
+		for _, s := range slices.Backward(sl) {
+			if slices.ContainsFunc(s.refs, ref.HasPrefix) {
 				return true
 			}
 		}
@@ -347,8 +347,8 @@ func (s *functionMocksStack) Get(f ast.Ref) (*ast.Term, bool) {
 	}
 
 	current := s.stack.PeekGroup()
-	for i := len(current) - 1; i >= 0; i-- {
-		if r, ok := current[i][f.String()]; ok {
+	for _, c := range slices.Backward(current) {
+		if r, ok := c[f.String()]; ok {
 			return r, true
 		}
 	}

--- a/v1/topdown/errors.go
+++ b/v1/topdown/errors.go
@@ -73,8 +73,7 @@ func IsCancel(err error) bool {
 
 // Is allows matching topdown errors using errors.Is (see IsCancel).
 func (e *Error) Is(target error) bool {
-	var t *Error
-	if errors.As(target, &t) {
+	if t, ok := errors.AsType[*Error](target); ok {
 		return (t.Code == "" || e.Code == t.Code) &&
 			(t.Message == "" || e.Message == t.Message) &&
 			(t.Location == nil || t.Location.Compare(e.Location) == 0)

--- a/v1/topdown/eval.go
+++ b/v1/topdown/eval.go
@@ -4068,8 +4068,7 @@ func (e evalTerm) next(iter unifyIterator, plugged *ast.Term) error {
 func (e evalTerm) enumerate(iter unifyIterator) error {
 	var deferredEe *deferredEarlyExitError
 	handleErr := func(err error) error {
-		var dee *deferredEarlyExitError
-		if errors.As(err, &dee) {
+		if dee, ok := errors.AsType[*deferredEarlyExitError](err); ok {
 			if deferredEe == nil {
 				deferredEe = dee
 			}

--- a/v1/topdown/eval.go
+++ b/v1/topdown/eval.go
@@ -3613,8 +3613,8 @@ func (q vcKeyScope) AppendText(buf []byte) ([]byte, error) {
 func (q vcKeyScope) reduce() vcKeyScope {
 	ref := q.Ref.CopyNonGround()
 	var i int
-	for i = len(q.Ref) - 1; i >= 0; i-- {
-		if _, ok := q.Ref[i].Value.(ast.Var); !ok {
+	for _, v := range slices.Backward(q.Ref) {
+		if _, ok := v.Value.(ast.Var); !ok {
 			break
 		}
 	}
@@ -4978,9 +4978,9 @@ func (e *eval) updateSavedMocks(withs []*ast.With) []*ast.With {
 // tree levels. keys are the ground parameter terms in reference order.
 func wrapExternalParams(keys []*ast.Term, tree *ast.TreeNode) *ast.TreeNode {
 	node := tree
-	for i := len(keys) - 1; i >= 0; i-- {
+	for _, key := range slices.Backward(keys) {
 		node = &ast.TreeNode{
-			Children: map[ast.Value]*ast.TreeNode{keys[i].Value: node},
+			Children: map[ast.Value]*ast.TreeNode{key.Value: node},
 		}
 	}
 	return node

--- a/v1/topdown/lineage/lineage.go
+++ b/v1/topdown/lineage/lineage.go
@@ -5,6 +5,8 @@
 package lineage
 
 import (
+	"slices"
+
 	"github.com/open-policy-agent/opa/v1/topdown"
 )
 
@@ -66,8 +68,8 @@ func Filter(trace []*topdown.Event, filter func(*topdown.Event) bool) (result []
 			}
 
 			// Add the path to the result, reversing it in the process.
-			for i := len(path) - 1; i >= 0; i-- {
-				result = append(result, path[i])
+			for _, p := range slices.Backward(path) {
+				result = append(result, p)
 			}
 
 			qids = map[uint64]*topdown.Event{}

--- a/v1/topdown/trace.go
+++ b/v1/topdown/trace.go
@@ -894,7 +894,7 @@ func printPrettyVars(w *bytes.Buffer, exprVars map[string]varInfo) {
 
 	w.WriteByte('\n')
 	printArrows(w, byCol, -1)
-	for i := len(byCol) - 1; i >= 0; i-- {
+	for i := range slices.Backward(byCol) {
 		w.WriteByte('\n')
 		printArrows(w, byCol, i)
 	}


### PR DESCRIPTION
See individual commits. To be squashed.

🔍 [8cfc65f](https://github.com/open-policy-agent/opa/pull/9058/commits/8cfc65fbf3e76ab342186d2bc5426a05d1c7bacc) might be the only controversial thing here. I suspect it to behave worse performance-wise, but I could be wrong.