### PR TITLE
fix: reject some-in bindings that also appear in the domain

### DIFF
--- a/v1/ast/compile.go
+++ b/v1/ast/compile.go
@@ -6921,6 +6921,27 @@ func rewriteSomeDeclStatement(g *localVarGenerator, stack *localDeclaredVars, ex
 				container = v[2]
 			}
 
+			// Vars bound by this `some .. in` must not also appear in the domain.
+			bound := NewVarSet()
+			if key != nil {
+				bound.Update(key.Vars())
+			}
+			if val != nil {
+				bound.Update(val.Vars())
+			}
+			domainVis := NewVarVisitor().WithParams(VarVisitorParams{SkipClosures: true})
+			domainVis.Walk(container)
+			nerrs := len(errs)
+			for _, v0 := range bound.Intersect(domainVis.Vars()).Sorted() {
+				if v0.IsWildcard() {
+					continue
+				}
+				errs = append(errs, NewError(CompileErr, decl.Loc(), "var %v used in some domain", v0))
+			}
+			if len(errs) > nerrs {
+				return nil, errs
+			}
+
 			var rhs *Term
 			switch c := container.Value.(type) {
 			case Ref:

--- a/v1/ast/compile.go
+++ b/v1/ast/compile.go
@@ -6929,15 +6929,16 @@ func rewriteSomeDeclStatement(g *localVarGenerator, stack *localDeclaredVars, ex
 			if val != nil {
 				bound.Update(val.Vars())
 			}
-			domainVis := NewVarVisitor().WithParams(VarVisitorParams{SkipClosures: true})
+			domainVis := varVisitorPool.Get().WithParams(VarVisitorParams{SkipClosures: true})
 			domainVis.Walk(container)
 			nerrs := len(errs)
 			for _, v0 := range bound.Intersect(domainVis.Vars()).Sorted() {
 				if v0.IsWildcard() {
 					continue
 				}
-				errs = append(errs, NewError(CompileErr, decl.Loc(), "var %v used in some domain", v0))
+				errs = append(errs, NewError(CompileErr, decl.Loc(), "var %v assigned before", v0))
 			}
+			varVisitorPool.Put(domainVis)
 			if len(errs) > nerrs {
 				return nil, errs
 			}

--- a/v1/ast/compile_test.go
+++ b/v1/ast/compile_test.go
@@ -6876,6 +6876,48 @@ func TestRewriteDeclaredVars(t *testing.T) {
 			wantErr: errors.New("test.rego:5: rego_compile_error: var x referenced above"),
 		},
 		{
+			note: "some/in key used in domain",
+			module: `
+				package test
+				p if {
+					some i, x in [[0]][i]
+				}
+			`,
+			wantErr: errors.New("test.rego:4: rego_compile_error: var i used in some domain"),
+		},
+		{
+			note: "some/in key used in domain after some",
+			module: `
+				package test
+				p if {
+					some i
+					some i, x in [[0]][i]
+				}
+			`,
+			wantErr: errors.New("test.rego:5: rego_compile_error: var i used in some domain"),
+		},
+		{
+			note: "some/in key used in domain after assignment",
+			module: `
+				package test
+				p if {
+					i := 0
+					some i, x in [[0]][i]
+				}
+			`,
+			wantErr: errors.New("test.rego:5: rego_compile_error: var i used in some domain"),
+		},
+		{
+			note: "some/in value used in domain",
+			module: `
+				package test
+				p if {
+					some x in [[0]][x]
+				}
+			`,
+			wantErr: errors.New("test.rego:4: rego_compile_error: var x used in some domain"),
+		},
+		{
 			note: "declare unused err",
 			module: `
 				package test

--- a/v1/ast/compile_test.go
+++ b/v1/ast/compile_test.go
@@ -6883,7 +6883,7 @@ func TestRewriteDeclaredVars(t *testing.T) {
 					some i, x in [[0]][i]
 				}
 			`,
-			wantErr: errors.New("test.rego:4: rego_compile_error: var i used in some domain"),
+			wantErr: errors.New("test.rego:4: rego_compile_error: var i assigned before"),
 		},
 		{
 			note: "some/in key used in domain after some",
@@ -6894,7 +6894,7 @@ func TestRewriteDeclaredVars(t *testing.T) {
 					some i, x in [[0]][i]
 				}
 			`,
-			wantErr: errors.New("test.rego:5: rego_compile_error: var i used in some domain"),
+			wantErr: errors.New("test.rego:5: rego_compile_error: var i assigned before"),
 		},
 		{
 			note: "some/in key used in domain after assignment",
@@ -6905,7 +6905,7 @@ func TestRewriteDeclaredVars(t *testing.T) {
 					some i, x in [[0]][i]
 				}
 			`,
-			wantErr: errors.New("test.rego:5: rego_compile_error: var i used in some domain"),
+			wantErr: errors.New("test.rego:5: rego_compile_error: var i assigned before"),
 		},
 		{
 			note: "some/in value used in domain",
@@ -6915,7 +6915,7 @@ func TestRewriteDeclaredVars(t *testing.T) {
 					some x in [[0]][x]
 				}
 			`,
-			wantErr: errors.New("test.rego:4: rego_compile_error: var x used in some domain"),
+			wantErr: errors.New("test.rego:4: rego_compile_error: var x assigned before"),
 		},
 		{
 			note: "declare unused err",


### PR DESCRIPTION
some i, x in xs[i] compiled because the domain was rewritten after the binding. Treat that overlap as a compile error. Fixes #9052.