### PR TITLE
runtime: allow registering hooks, and pass them to discovery

### DIFF
--- a/v1/runtime/runtime.go
+++ b/v1/runtime/runtime.go
@@ -70,6 +70,9 @@ var (
 
 	registeredStorageBackend    StorageBackendBuilder
 	registeredStorageBackendMux sync.Mutex
+
+	registeredHooks    []hooks.Hook
+	registeredHooksMux sync.Mutex
 )
 
 const (
@@ -102,6 +105,20 @@ func RegisterStorageBackend(builder StorageBackendBuilder) {
 	registeredStorageBackendMux.Lock()
 	defer registeredStorageBackendMux.Unlock()
 	registeredStorageBackend = builder
+}
+
+// RegisterHook registers a hook with the runtime package. When the runtime is
+// created, registered hooks are appended to those passed via Params.Hooks.
+//
+// This exists for embedders that build their own OPA binary on top of this
+// package's CLI commands, and so never construct Params themselves: registering
+// from an init function, or from main before the runtime is created, is the only
+// opportunity they get. Hooks registered after NewRuntime has been called are
+// not picked up by that runtime.
+func RegisterHook(h hooks.Hook) {
+	registeredHooksMux.Lock()
+	defer registeredHooksMux.Unlock()
+	registeredHooks = append(registeredHooks, h)
 }
 
 // Params stores the configuration for an OPA instance.
@@ -400,6 +417,15 @@ func NewRuntime(ctx context.Context, params Params) (*Runtime, error) {
 		logger = bufferedLogger
 	}
 
+	// Hooks registered with this package apply on top of whatever the caller
+	// passed in, so that embedders building on the CLI commands -- who never get
+	// to construct Params -- can contribute hooks too.
+	registeredHooksMux.Lock()
+	for _, h := range registeredHooks {
+		params.Hooks.Append(h)
+	}
+	registeredHooksMux.Unlock()
+
 	if err := params.Hooks.Validate(); err != nil {
 		return nil, err
 	}
@@ -556,11 +582,12 @@ func NewRuntime(ctx context.Context, params Params) (*Runtime, error) {
 		return nil, fmt.Errorf("config error: %w", err)
 	}
 
-	opts := make([]func(*discovery.Discovery), 0, len(params.ExtraDiscoveryOpts)+3)
+	opts := make([]func(*discovery.Discovery), 0, len(params.ExtraDiscoveryOpts)+4)
 	opts = append(opts,
 		discovery.Factories(registeredPlugins),
 		discovery.Metrics(metrics),
 		discovery.BootConfig(bootConfig),
+		discovery.Hooks(params.Hooks),
 	)
 	opts = append(opts, params.ExtraDiscoveryOpts...)
 	disco, err := discovery.New(manager, opts...)

--- a/v1/runtime/runtime_test.go
+++ b/v1/runtime/runtime_test.go
@@ -2195,3 +2195,145 @@ allow if {
 		t.Errorf("got %s, want %s", act, exp)
 	}
 }
+
+// registryConfigHook records the configs it is handed and stamps a label, so
+// tests can tell which of the two hook points fired.
+type registryConfigHook struct {
+	label      string
+	onConfig   *config.Config
+	onDiscover *config.Config
+}
+
+func (h *registryConfigHook) OnConfig(_ context.Context, c *config.Config) (*config.Config, error) {
+	c.Labels[h.label] = "on-config"
+	h.onConfig = c
+	return c, nil
+}
+
+func (h *registryConfigHook) OnConfigDiscovery(_ context.Context, c *config.Config) (*config.Config, error) {
+	c.Labels[h.label] = "on-config-discovery"
+	h.onDiscover = c
+	return c, nil
+}
+
+func TestRegisterHook(t *testing.T) {
+	// Not parallel, and not t.Cleanup-restorable in a way that would survive
+	// concurrent tests: RegisterHook mutates package-level state.
+	h := &registryConfigHook{label: "test-register-hook"}
+	RegisterHook(h)
+	t.Cleanup(func() {
+		registeredHooksMux.Lock()
+		defer registeredHooksMux.Unlock()
+		registeredHooks = slices.DeleteFunc(registeredHooks, func(x hooks.Hook) bool { return x == hooks.Hook(h) })
+	})
+
+	params := NewParams()
+	if _, err := NewRuntime(t.Context(), params); err != nil {
+		t.Fatal(err)
+	}
+
+	// A hook registered with the package must be honoured even though nothing
+	// was passed via Params.Hooks.
+	if h.onConfig == nil {
+		t.Fatal("expected OnConfig to have been called")
+	}
+	if exp, act := "on-config", h.onConfig.Labels[h.label]; exp != act {
+		t.Errorf("expected label %q, got %q", exp, act)
+	}
+}
+
+func TestRegisterHookDoesNotDropParamsHooks(t *testing.T) {
+	registered := &registryConfigHook{label: "test-registered"}
+	viaParams := &registryConfigHook{label: "test-via-params"}
+
+	RegisterHook(registered)
+	t.Cleanup(func() {
+		registeredHooksMux.Lock()
+		defer registeredHooksMux.Unlock()
+		registeredHooks = slices.DeleteFunc(registeredHooks, func(x hooks.Hook) bool { return x == hooks.Hook(registered) })
+	})
+
+	params := NewParams()
+	params.Hooks = hooks.New(viaParams)
+
+	if _, err := NewRuntime(t.Context(), params); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, h := range []*registryConfigHook{registered, viaParams} {
+		if h.onConfig == nil {
+			t.Errorf("expected OnConfig to have been called for %q", h.label)
+		}
+	}
+}
+
+func TestRegisterHookConfigDiscovery(t *testing.T) {
+	ctx := t.Context()
+	server := sdktest.MustNewServer(
+		sdktest.MockBundle("/bundles/discovery.tar.gz", map[string]string{
+			"main.rego": `
+package config
+
+decision_logs.console := true
+`,
+		}),
+	)
+	defer server.Stop()
+
+	cfgContent := fmt.Sprintf(`{
+		"services": {
+			"test": {
+				"url": %q
+			}
+		},
+		"discovery": {
+			"decision": "config",
+			"resource": "/bundles/discovery.tar.gz"
+		}
+	}`, server.URL())
+	cfg := filepath.Join(t.TempDir(), "opa.json")
+	if err := os.WriteFile(cfg, []byte(cfgContent), 0o644); err != nil {
+		t.Fatalf("write config %s: %v", cfg, err)
+	}
+
+	h := &registryConfigHook{label: "test-register-hook-discovery"}
+	RegisterHook(h)
+	t.Cleanup(func() {
+		registeredHooksMux.Lock()
+		defer registeredHooksMux.Unlock()
+		registeredHooks = slices.DeleteFunc(registeredHooks, func(x hooks.Hook) bool { return x == hooks.Hook(h) })
+	})
+
+	params := NewParams()
+	params.ConfigFile = cfg
+	params.Output = io.Discard
+	params.Addrs = &[]string{"localhost:0"}
+	params.GracefulShutdownPeriod = 1
+	testLogger := testLog.New()
+	params.Logger = testLogger
+
+	// Note that Params.Hooks is deliberately left unset: the hook reaches
+	// discovery purely by virtue of having been registered with the package.
+	rt, err := NewRuntime(ctx, params)
+	if err != nil {
+		t.Fatalf("Unexpected error %v", err)
+	}
+
+	disco := discovery.Lookup(rt.Manager)
+	if err := disco.Trigger(ctx); err != nil {
+		t.Errorf("trigger discovery: %v", err)
+	}
+
+	if !test.Eventually(t, 5*time.Second, func() bool {
+		return h.onDiscover != nil
+	}) {
+		t.Fatal("expected OnConfigDiscovery to have been called")
+	}
+
+	// The hook sees the merged, post-discovery config, so decision_logs from the
+	// discovery bundle is visible to it -- that is what makes it a usable place to
+	// amend discovered plugin config.
+	if h.onDiscover.DecisionLogs == nil {
+		t.Error("expected discovered decision_logs config to be visible to the hook")
+	}
+}


### PR DESCRIPTION
Two related gaps for embedders that build their own OPA binary on top of this package's CLI commands: they hand their cobra root to cmd.Command and so never construct Params themselves, which leaves them no way to supply hooks.Hooks at all. Plugins have **RegisterPlugin** for exactly this reason, so add **RegisterHook** alongside it. Registered hooks are appended to whatever came in via Params.Hooks, rather than replacing it.

The second gap is arguably a bug in its own right: on this path, discovery was never handed any hooks, so **ConfigDiscoveryHook** silently never fired, even though the SDK has always passed them along (see sdk.New). Anyone relying on it under `opa run` would have seen **OnConfig** called and **OnConfigDiscovery** not, with nothing to explain the difference.

That distinction matters, because the two hook points see different things: **OnConfig** sees the boot config, while **OnConfigDiscovery** sees the result of merging the discovered config with it. Only the latter can observe -- or amend -- plugin configuration that arrives via a discovery bundle.
 