### PR TITLE
ci: serialize benchmarks workflow to avoid racing writes to benchmarks branch

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -5,6 +5,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: benchmarks
+  cancel-in-progress: false
+
 permissions:
   contents: read
 


### PR DESCRIPTION
Quick successive merges to main were spinning up overlapping Benchmarks workflow runs. Each run publishes results by cloning the benchmarks branch, running the (long) benchmark suite, and force-pushing merged results back. Overlapping runs race: gobenchdata's force-push means the run that finishes last silently clobbers data another run already published, and the notebook job's plain push fails outright when two runs finish close together.

Add a concurrency group so runs queue instead of overlapping, so every push to main gets a data point instead of some being silently dropped or failing to push.
